### PR TITLE
Fix when installation on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ $ pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.5
 ```bash
 # Only CPU-version is available at the moment.
 $ pip install https://storage.googleapis.com/tensorflow/mac/tensorflow-0.5.0-py2-none-any.whl
+
+# For El Capital
+$ pip install --ignore-installed six  https://storage.googleapis.com/tensorflow/mac/tensorflow-0.5.0-py2-none-any.whl
 ```
 
 ### Try your first TensorFlow program


### PR DESCRIPTION
Update the instruction to fix installation on OSX for exception like below

OSError: [Errno 1] Operation not permitted: '/tmp/pip-LA3gmg-uninstall/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/six-1.4.1-py2.7.egg-info' 
