### PR TITLE
AlexNet with FC layers: backward is very slow?

### DIFF
--- a/tensorflow/models/image/alexnet/alexnet_benchmark.py
+++ b/tensorflow/models/image/alexnet/alexnet_benchmark.py
@@ -265,8 +265,9 @@ def run_benchmark():
           logits, labels))
     # Compute the gradient with respect to all the parameters.
     grad = tf.gradients(objective, parameters)
+    sink = tf.group(*grad)
     # Run the backward benchmark.
-    time_tensorflow_run(sess, grad, "Forward-backward")
+    time_tensorflow_run(sess, sink, "Forward-backward")
 
 
 def main(_):

--- a/tensorflow/models/image/alexnet/alexnet_benchmark.py
+++ b/tensorflow/models/image/alexnet/alexnet_benchmark.py
@@ -13,10 +13,14 @@ Run on Titan X:     70 +/- 0.1 ms / batch
 Forward-backward pass:
 Run on Tesla K40c: 480 +/- 48 ms / batch
 Run on Titan X:    244 +/- 30 ms / batch
+
+Note that this benchmark does not include the local response normalization
+(LRN) layers of AlexNet.
 """
 from __future__ import print_function
 from datetime import datetime
 import math
+import numpy as np
 import time
 
 import tensorflow.python.platform
@@ -29,13 +33,16 @@ tf.app.flags.DEFINE_integer('batch_size', 128,
                             """Batch size.""")
 tf.app.flags.DEFINE_integer('num_batches', 100,
                             """Number of batches to run.""")
+tf.app.flags.DEFINE_boolean('l2_loss', False,
+                            """Use L2 loss, rather than softmax.""")
 
+NUM_LABELS = 1000
 
 def print_activations(t):
   print(t.op.name, ' ', t.get_shape().as_list())
 
 
-def inference(images):
+def inference(images, train=True):
   """Build the AlexNet model.
 
   Args:
@@ -137,7 +144,53 @@ def inference(images):
                          name='pool5')
   print_activations(pool5)
 
-  return pool5, parameters
+  pool5_shape = pool5.get_shape().as_list()
+  pool5_dim = np.prod(pool5_shape[1:])
+  reshape = tf.reshape(pool5, [pool5_shape[0], pool5_dim])
+
+  # fc6
+  with tf.name_scope('fc6') as scope:
+    weights = tf.Variable(tf.truncated_normal([pool5_dim, 4096],
+                                              dtype=tf.float32,
+                                              stddev=1e-1), name='weights')
+    acts = tf.matmul(reshape, weights)
+    biases = tf.Variable(tf.constant(0.0, shape=[4096], dtype=tf.float32),
+                         trainable=True, name='biases')
+    bias = tf.nn.bias_add(acts, biases)
+    fc6 = tf.nn.relu(bias, name=scope)
+    if train:
+      fc6 = tf.nn.dropout(fc6, 0.5, name=scope)
+    parameters += [weights, biases]
+    print_activations(fc6)
+
+  # fc7
+  with tf.name_scope('fc7') as scope:
+    weights = tf.Variable(tf.truncated_normal([4096, 4096],
+                                              dtype=tf.float32,
+                                              stddev=1e-1), name='weights')
+    acts = tf.matmul(fc6, weights)
+    biases = tf.Variable(tf.constant(0.0, shape=[4096], dtype=tf.float32),
+                         trainable=True, name='biases')
+    bias = tf.nn.bias_add(acts, biases)
+    fc7 = tf.nn.relu(bias, name=scope)
+    if train:
+      fc7 = tf.nn.dropout(fc7, 0.5, name=scope)
+    parameters += [weights, biases]
+    print_activations(fc7)
+
+  # fc8
+  with tf.name_scope('fc8') as scope:
+    weights = tf.Variable(tf.truncated_normal([4096, NUM_LABELS],
+                                              dtype=tf.float32,
+                                              stddev=1e-1), name='weights')
+    acts = tf.matmul(fc7, weights)
+    biases = tf.Variable(tf.constant(0.0, shape=[NUM_LABELS], dtype=tf.float32),
+                         trainable=True, name='biases')
+    fc8 = tf.nn.bias_add(acts, biases, name=scope)
+    parameters += [weights, biases]
+    print_activations(fc8)
+
+  return fc8, parameters
 
 
 def time_tensorflow_run(session, target, info_string):
@@ -185,10 +238,14 @@ def run_benchmark():
                                            image_size + 3, 3],
                                           dtype=tf.float32,
                                           stddev=1e-1))
+    label_indices = np.random.randint(0, NUM_LABELS, FLAGS.batch_size)
+    one_hot_labels = np.zeros((FLAGS.batch_size, NUM_LABELS), dtype=np.float32)
+    one_hot_labels[np.arange(FLAGS.batch_size), label_indices] = 1
+    labels = tf.Variable(one_hot_labels)
 
     # Build a Graph that computes the logits predictions from the
     # inference model.
-    pool5, parameters = inference(images)
+    logits, parameters = inference(images)
 
     # Build an initialization operation.
     init = tf.initialize_all_variables()
@@ -198,10 +255,14 @@ def run_benchmark():
     sess.run(init)
 
     # Run the forward benchmark.
-    time_tensorflow_run(sess, pool5, "Forward")
+    time_tensorflow_run(sess, logits, "Forward")
 
-    # Add a simple objective so we can calculate the backward pass.
-    objective = tf.nn.l2_loss(pool5)
+    # Add the objective so we can calculate the backward pass.
+    if FLAGS.l2_loss:
+      objective = tf.nn.l2_loss(logits)
+    else:
+      objective = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
+          logits, labels))
     # Compute the gradient with respect to all the parameters.
     grad = tf.gradients(objective, parameters)
     # Run the backward benchmark.


### PR DESCRIPTION
(I know PRs are not the way to contribute to TensorFlow -- I'm just posting this for discussion, though I'm happy to submit this patch via the official means if desired.)

I modified `alexnet_benchmark.py` to compute activations for the fully-connected layers (fc6-fc8) where the original only computes through `pool5`.  Using a Titan X with the original code that only goes through `pool5`, I see roughly the expected result:

```
2015-11-10 16:29:54.760793: step 10, duration = 0.098
2015-11-10 16:29:55.746638: step 20, duration = 0.099
2015-11-10 16:29:56.734163: step 30, duration = 0.099
2015-11-10 16:29:57.720769: step 40, duration = 0.098
2015-11-10 16:29:58.708402: step 50, duration = 0.099
2015-11-10 16:29:59.697522: step 60, duration = 0.100
2015-11-10 16:30:00.687530: step 70, duration = 0.099
2015-11-10 16:30:01.677052: step 80, duration = 0.099
2015-11-10 16:30:02.669677: step 90, duration = 0.099
2015-11-10 16:30:03.563315: Forward across 100 steps, 0.098 +/- 0.010 sec / batch
2015-11-10 16:30:10.385117: step 10, duration = 0.321
2015-11-10 16:30:13.613230: step 20, duration = 0.322
2015-11-10 16:30:16.840772: step 30, duration = 0.322
2015-11-10 16:30:20.068794: step 40, duration = 0.322
2015-11-10 16:30:23.308556: step 50, duration = 0.326
2015-11-10 16:30:26.558616: step 60, duration = 0.323
2015-11-10 16:30:30.260454: step 70, duration = 0.325
2015-11-10 16:30:33.939707: step 80, duration = 0.324
2015-11-10 16:30:37.797578: step 90, duration = 0.326
2015-11-10 16:30:41.159575: Forward-backward across 100 steps, 0.340 +/- 0.052 sec / batch
```

With this modified version, I get expected computation speed for the forward-only version (only epsilon longer than the pool5 version), but very slow speeds doing forward-backward (stopped after 60 iterations due to slowness):

```
2015-11-10 15:54:39.231156: step 10, duration = 0.101
2015-11-10 15:54:40.235104: step 20, duration = 0.100
2015-11-10 15:54:41.238807: step 30, duration = 0.100
2015-11-10 15:54:42.241662: step 40, duration = 0.100
2015-11-10 15:54:43.245950: step 50, duration = 0.100
2015-11-10 15:54:44.251555: step 60, duration = 0.100
2015-11-10 15:54:45.255560: step 70, duration = 0.100
2015-11-10 15:54:46.260286: step 80, duration = 0.101
2015-11-10 15:54:47.268687: step 90, duration = 0.101
2015-11-10 15:54:48.172288: Forward across 100 steps, 0.099 +/- 0.010 sec / batch
2015-11-10 15:55:30.047371: step 10, duration = 13.337
2015-11-10 15:58:34.855597: step 20, duration = 11.968
2015-11-10 16:01:40.070674: step 30, duration = 19.707
2015-11-10 16:04:30.698742: step 40, duration = 13.459
2015-11-10 16:07:15.900770: step 50, duration = 20.028
2015-11-10 16:10:11.997452: step 60, duration = 12.357
^C^C^CTraceback (most recent call last):
```

During the forward-backward part of the benchmark, looking at GPU utilization using `nvidia-smi` while running this shows 0% utilization most of the time.

For reference, I ran more or less the equivalent timing on the same GPU using out-of-the-box Caffe (_no_ CuDNN) using [this prototxt](https://gist.github.com/jeffdonahue/9193b3c88e4262128fe8), and see Forward-Backward times of ~413 ms.  (And for the record the comparison is still a little unfair to Caffe as `caffe time`, unlike `caffe train`, computes all gradients, including w.r.t. the input image.)

```
$ caffe time -model alexnet_dummydata_nolrn.prototxt -gpu 0
[...]
I1110 16:37:19.770344  6275 caffe.cpp:366] Average Forward pass: 176.546 ms.
I1110 16:37:19.770350  6275 caffe.cpp:368] Average Backward pass: 237.147 ms.
I1110 16:37:19.770356  6275 caffe.cpp:370] Average Forward-Backward: 413.773 ms.
```

Please let me know if anyone has any idea what might be going on, or if something is wrong with my implementation (which I wouldn't doubt!).  Thanks!
