### PR TITLE
Complete the loop before returning the words

### DIFF
--- a/tensorflow/g3doc/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/g3doc/tutorials/word2vec/word2vec_basic.py
@@ -29,12 +29,14 @@ def maybe_download(filename, expected_bytes):
 filename = maybe_download('text8.zip', 31344016)
 
 
-# Read the data into a string.
+# Read the data into a list of words.
 def read_data(filename):
-  f = zipfile.ZipFile(filename)
-  for name in f.namelist():
-    return f.read(name).split()
-  f.close()
+  words = []
+  with zipfile.ZipFile(filename) as f: 
+     for name in f.namelist():
+        words += f.read(name).split()
+  return words
+  
 
 words = read_data(filename)
 print('Data size', len(words))


### PR DESCRIPTION
The loop now completes before returning the words, 'with' is used to make sure the file closes and the description of the function now describes that it returns a list of words, not a string.
