### PR TITLE
Fix for issue #117: allow relative paths for tensorboard logdir

### DIFF
--- a/tensorflow/tensorboard/tensorboard.py
+++ b/tensorflow/tensorboard/tensorboard.py
@@ -103,6 +103,11 @@ def ParseEventFilesFlag(flag_value):
     else:
       run_name = None
       path = specification
+      
+    if not os.path.isabs(path):
+      # Create absolute path out of relative one.
+      path = os.path.join(os.path.realpath('.'), path)
+
     files[path] = run_name
   return files
 


### PR DESCRIPTION
This fixes issues [#117](https://github.com/tensorflow/tensorflow/issues/117) and [#321](https://github.com/tensorflow/tensorflow/issues/321).

It checks if paths passed to `tensorboard --logdir=logs/events` are relative or absolute, and properly resolves relative paths to the current directory instead of assuming they're relative to $HOME.
