### PR TITLE
Fix compatibility with CUDA Compute Capability <3.2 (issue #320).

### DIFF
--- a/tensorflow/core/kernels/bias_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bias_op_gpu.cu.cc
@@ -37,7 +37,12 @@ __global__ void BiasOpCustomKernel(int nthreads, const T* input, const T* bias,
                                    T* output) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     int bias_offset = index % bias_size;
-    output[index] = __ldg(input + index) + __ldg(bias + bias_offset);
+    
+    #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 320)
+      output[index] = __ldg(input + index) + __ldg(bias + bias_offset);
+    #else 
+      output[index] = input[index] + bias[bias_offset];
+    #endif
   }
 }
 

--- a/tensorflow/core/kernels/conv_ops_gpu_3.cu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu_3.cu.cc
@@ -94,7 +94,11 @@ __global__ void SwapDimension0And2InTensor3(int nthreads, const T* input,
 
     int input_index = TensorIndexToFlat(input_tensor_index, input_dims);
 
-    output[output_index] = __ldg(input + input_index);
+    #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 320)
+      output[output_index] = __ldg(input + input_index);
+    #else
+      output[output_index] = input[input_index];
+    #endif  
   }
 }
 
@@ -118,8 +122,13 @@ __global__ void SwapDimension1And2InTensor3(int nthreads, const T* input,
     input_tensor_index[2] = output_tensor_index[1];
 
     int input_index = TensorIndexToFlat(input_tensor_index, input_dims);
+    
+    #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 320)
+      output[output_index] = __ldg(input + input_index);
+    #else
+      output[output_index] = input[input_index];
+    #endif  
 
-    output[output_index] = __ldg(input + input_index);
   }
 }
 


### PR DESCRIPTION
The current code is not compatible with CUDA devices withe CC <3.2 due to the use of __ldg intrinsic. A  preprocessor check for CC>=3.2, such as the one proposed here resolves the issue.
