### PR TITLE
Add targets to build libtensorflow.so and libtensorflow.dylib

### DIFF
--- a/tensorflow/cc/BUILD
+++ b/tensorflow/cc/BUILD
@@ -26,6 +26,25 @@ cc_library(
     ],
 )
 
+cc_binary(
+    name = "libtensorflow.so",
+    copts = tf_copts(),
+    linkshared = 1,
+    deps = [
+        ":cc_ops",
+        "//tensorflow/core:kernels",
+        "//tensorflow/core:tensorflow",
+    ],
+)
+
+genrule(
+    name = "libtensorflow_dylib",
+    srcs = ["libtensorflow.so"],
+    outs = ["libtensorflow.dylib"],
+    cmd = "cp $< $@",
+)
+
+
 # Generates a library that contains C++ wrappers for ops.
 tf_gen_op_wrappers_cc(
     name = "cc_ops",


### PR DESCRIPTION
Using these build targets to build libtensorflow for use with node.js.

Hoping these don't have to live in my fork, and can be merged.

Thanks, Nikhil
