### PR TITLE
Change needed in index

### DIFF
--- a/tensorflow/g3doc/tutorials/mnist/tf/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/tf/index.md
@@ -18,7 +18,7 @@ This tutorial references the following files:
 
 File | Purpose
 --- | ---
-[`mnist.py`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/examples/tutorials/mnist/mnist.py) | The code to build a fully-connected MNIST model.
+[`mnist.py`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/examples/tutorials/mnist/mnist.py)  | The code to build a fully-connected MNIST model.
 [`fully_connected_feed.py`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/examples/tutorials/mnist/fully_connected_feed.py) | The main code to train the built MNIST model against the downloaded dataset using a feed dictionary.
 
 Simply run the `fully_connected_feed.py` file directly to start training:


### PR DESCRIPTION
The url to mnist.py here is https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/examples/tutorials/mnist/mnist.py which works. 

However, at https://www.tensorflow.org/versions/master/tutorials/mnist/tf/index.html which I believe is the compiled version of this file, the url reads 
https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/g3doc/tutorials/mnist/mnist.py which leads nowhere. I'm not sure exactly where this mistake is, but it should definitely be fixed because otherwise people can't follow along with the tensorflow mechanics tutorial.
