### PR TITLE
Enable building with GPU support under OS X.

### DIFF
--- a/configure
+++ b/configure
@@ -43,20 +43,33 @@ if [ "$TF_NEED_CUDA" == "0" ]; then
 fi
 
 # Find out where the CUDA toolkit is installed
+osname=`uname -s`
+CUDA_VERSION='7.0'
+CUDNN_VERSION='6.5'
+if [ "$osname" == "Linux" ]; then
+  CUDA_RT_LIB_PATH="lib64/libcudart.so.${CUDA_VERSION}"
+  CUDA_DNN_LIB_PATH="lib64/libcudnn.so.${CUDNN_VERSION}"
+  CUDA_DNN_LIB_ALT_PATH="libcudnn.so.${CUDNN_VERSION}"
+elif [ "$osname" == "Darwin" ]; then
+  CUDA_RT_LIB_PATH="lib/libcudart.${CUDA_VERSION}.dylib"
+  CUDA_DNN_LIB_PATH="lib/libcudnn.${CUDNN_VERSION}.dylib"
+  CUDA_DNN_LIB_ALT_PATH="libcudnn.${CUDNN_VERSION}.dylib"
+fi
+
 while true; do
   fromuser=""
   if [ -z "$CUDA_TOOLKIT_PATH" ]; then
     default_cuda_path=/usr/local/cuda
-    read -p "Please specify the location where CUDA 7.0 toolkit is installed. Refer to README.md for more details. [Default is $default_cuda_path]: " CUDA_TOOLKIT_PATH
+    read -p "Please specify the location where CUDA ${CUDA_VERSION} toolkit is installed. Refer to README.md for more details. [Default is $default_cuda_path]: " CUDA_TOOLKIT_PATH
     fromuser="1"
     if [ -z "$CUDA_TOOLKIT_PATH" ]; then
       CUDA_TOOLKIT_PATH=$default_cuda_path
     fi
   fi
-  if [ -e "$CUDA_TOOLKIT_PATH/lib64/libcudart.so.7.0" ]; then
+  if [ -e "${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH}" ]; then
     break
   fi
-  echo "Invalid path to CUDA 7.0 toolkit. ${CUDA_TOOLKIT_PATH}/lib64/libcudart.so.7.0 cannot be found"
+  echo "Invalid path to CUDA toolkit. ${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH} cannot be found"
   if [ -z "$fromuser" ]; then
     exit 1
   fi
@@ -69,21 +82,21 @@ while true; do
   fromuser=""
   if [ -z "$CUDNN_INSTALL_PATH" ]; then
     default_cudnn_path=${CUDA_TOOLKIT_PATH}
-    read -p "Please specify the location where CUDNN 6.5 V2 library is installed. Refer to README.md for more details. [Default is $default_cudnn_path]: " CUDNN_INSTALL_PATH
+    read -p "Please specify the location where CUDNN ${CUDNN_VERSION} library is installed. Refer to README.md for more details. [Default is $default_cudnn_path]: " CUDNN_INSTALL_PATH
     fromuser="1"
     if [ -z "$CUDNN_INSTALL_PATH" ]; then
       CUDNN_INSTALL_PATH=$default_cudnn_path
     fi
     # Result returned from "read" will be used unexpanded. That make "~" unuseable.
     # Going through one more level of expansion to handle that.
-    CUDNN_INSTALL_PATH=$(bash -c "readlink -f $CUDNN_INSTALL_PATH")
+    CUDNN_INSTALL_PATH=`${PYTHON_BIN_PATH} -c "import os; print(os.path.realpath(os.path.expanduser('${CUDNN_INSTALL_PATH}')))"`
   fi
-  if [ -e "$CUDNN_INSTALL_PATH/libcudnn.so.6.5" -o -e "$CUDNN_INSTALL_PATH/lib64/libcudnn.so.6.5" ]; then
+  if [ -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_ALT_PATH}" -o -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_PATH}" ]; then
     break
   fi
-  echo "Invalid path to CUDNN 6.5 V2 toolkit. Neither of the following two files can be found:"
-  echo "$CUDNN_INSTALL_PATH/lib64/libcudnn.so.6.5"
-  echo "$CUDNN_INSTALL_PATH/libcudnn.so.6.5"
+  echo "Invalid path to CUDNN ${CUDNN_VERSION} toolkit. Neither of the following two files can be found:"
+  echo "${CUDNN_INSTALL_PATH}/${CUDA_DNN_LIB_PATH}"
+  echo "${CUDNN_INSTALL_PATH}/${CUDA_DNN_LIB_ALT_PATH}"
   if [ -z "$fromuser" ]; then
     exit 1
   fi


### PR DESCRIPTION
These changes add GPU/CUDA support when building under OS X. Cuda and CuDNN library directories and file extensions are set based on the current build platform and library versions are stored in easily modifiable variables.
