### PR TITLE
Force embedding_lookup onto CPU in basic word2vec example - #514

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -141,16 +141,18 @@ with graph.as_default():
   train_labels = tf.placeholder(tf.int32, shape=[batch_size, 1])
   valid_dataset = tf.constant(valid_examples, dtype=tf.int32)
 
-  # Construct the variables.
-  embeddings = tf.Variable(
-      tf.random_uniform([vocabulary_size, embedding_size], -1.0, 1.0))
-  nce_weights = tf.Variable(
-      tf.truncated_normal([vocabulary_size, embedding_size],
-                          stddev=1.0 / math.sqrt(embedding_size)))
-  nce_biases = tf.Variable(tf.zeros([vocabulary_size]))
+  # Ops and variables pinned to the CPU because of missing GPU implementation
+  with tf.device("/cpu:0"):
+    # Look up embeddings for inputs.
+    embeddings = tf.Variable(
+        tf.random_uniform([vocabulary_size, embedding_size], -1.0, 1.0))
+    embed = tf.nn.embedding_lookup(embeddings, train_inputs)
 
-  # Look up embeddings for inputs.
-  embed = tf.nn.embedding_lookup(embeddings, train_inputs)
+    # Construct the variables for the NCE loss
+    nce_weights = tf.Variable(
+        tf.truncated_normal([vocabulary_size, embedding_size],
+                            stddev=1.0 / math.sqrt(embedding_size)))
+    nce_biases = tf.Variable(tf.zeros([vocabulary_size]))
 
   # Compute the average NCE loss for the batch.
   # tf.nce_loss automatically draws a new sample of the negative labels each


### PR DESCRIPTION
Should fix https://github.com/tensorflow/tensorflow/issues/514. Of course the ideal solution would be to implement `ScatterSub` on the GPU, but I think this is a reasonable short-term fix so that help don't run into errors when running the script on a machine with GPU.
