### PR TITLE
Update README.md to remove stale install instructions, instead pointing to os_setup.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,35 +26,7 @@ and discussion.**
 
 # Download and Setup
 
-To install the CPU version of TensorFlow using a binary package, see the
-instructions below.  For more detailed installation instructions, including
-installing from source, GPU-enabled support, etc., see
-[here](tensorflow/g3doc/get_started/os_setup.md).
-
-## Binary Installation
-
-The TensorFlow Python API supports Python 2.7 and Python 3.3+.
-
-The simplest way to install TensorFlow is using
-[pip](https://pypi.python.org/pypi/pip) for both Linux and Mac.
-
-For the GPU-enabled version, or if you encounter installation errors, or for
-more detailed installation instructions, see
-[here](tensorflow/g3doc/get_started/os_setup.md#detailed_install).
-
-### Ubuntu/Linux 64-bit
-
-```bash
-# For CPU-only version
-$ pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.5.0-cp27-none-linux_x86_64.whl
-```
-
-### Mac OS X
-
-```bash
-# Only CPU-version is available at the moment.
-$ pip install https://storage.googleapis.com/tensorflow/mac/tensorflow-0.5.0-py2-none-any.whl
-```
+See [install instructions](tensorflow/g3doc/get_started/os_setup.md).
 
 ### Try your first TensorFlow program
 


### PR DESCRIPTION
Change README.md to point to install instructions, since the install instructions were stale (mentioned 0.5.0), and are likely to continue to be stale with respect to os_setup.md.
