### PR TITLE
558: Markdown to html, titles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+###
+title: Contributing Guidelines for Tensor
+###
+
 # Contributing guidelines
 
 ## How to become a contributor and submit your own code
@@ -18,7 +22,7 @@ Follow either of the two links above to access the appropriate CLA and instructi
 ### Contributing code
 
 If you have improvements to TensorFlow, send us your pull requests! For those
-just getting started, Github has a [howto](https://help.github.com/articles/using-pull-requests/).
+just getting started, Github has a [howto](https://help.github.com/articles/using-pull-requests/ "How To Contribute Using Github").
 
 If you want to contribute but you're not sure where to start, take a look at the
 [issues with the "contributions welcome" label](https://github.com/tensorflow/tensorflow/labels/contributions%20welcome).


### PR DESCRIPTION
Hi,
Most of projects I have worked on were based on Jekyll, pigments of markdown to webpages and used title/layout based on .yml/css/layouts file.In other python projects, providing title on the link itself works.Both variants done as example on Contributing.md to seek inputs.thanks.

```

---
title: Contributing to Spark

---
```

```
just getting started, Github has a [howto](https://help.github.com/articles/using-pull-requests/ "How To Contribute Using Github”)
```

However as this largely depends on project .js/.css files, from my quick look on this codebase, seems the tensorflow/python/framework/docs.py the .md content just gets transformed to body content, and likely library.title reflects the title of page.thanks.
