### PR TITLE
Fixed random_contrast link in the Deep CNN tutorial

### DIFF
--- a/tensorflow/g3doc/tutorials/deep_cnn/index.md
+++ b/tensorflow/g3doc/tutorials/deep_cnn/index.md
@@ -126,7 +126,7 @@ artificially increase the data set size:
 
 * [Randomly flip](../../api_docs/python/image.md#random_flip_left_right) the image from left to right.
 * Randomly distort the [image brightness](../../api_docs/python/image.md#random_brightness).
-* Randomly distort the [image contrast](../../api_docs/python/image.md#tf_image_random_contrast).
+* Randomly distort the [image contrast](../../api_docs/python/image.md#random_contrast).
 
 Please see the [Images](../../api_docs/python/image.md) page for the list of
 available distortions. We also attach an


### PR DESCRIPTION
The `random_contrast` link was pointing to an older location that seems to no longer exist. Fixed it to point to the right location.

I believe the tech report should also really point to http://www.cs.toronto.edu/~kriz/conv-cifar10-aug2010.pdf, which is actually a short 9 page report about using convolutional neural networks on CIFAR-10. The previously linked document is Krizhevsky's master thesis at 60 pages and is mostly about RBMs instead of convolutional neural networks and doesn't really fit the tutorial.
