### PR TITLE
add default decay value for RMSPropOptimizer

### DIFF
--- a/tensorflow/g3doc/api_docs/python/train.md
+++ b/tensorflow/g3doc/api_docs/python/train.md
@@ -463,7 +463,7 @@ Optimizer that implements the RMSProp algorithm.
 
 - - -
 
-#### `tf.train.RMSPropOptimizer.__init__(learning_rate, decay, momentum=0.0, epsilon=1e-10, use_locking=False, name='RMSProp')` {#RMSPropOptimizer.__init__}
+#### `tf.train.RMSPropOptimizer.__init__(learning_rate, decay=0.9, momentum=0.0, epsilon=1e-10, use_locking=False, name='RMSProp')` {#RMSPropOptimizer.__init__}
 
 Construct a new RMSProp optimizer.
 

--- a/tensorflow/python/training/rmsprop.py
+++ b/tensorflow/python/training/rmsprop.py
@@ -44,7 +44,7 @@ class RMSPropOptimizer(optimizer.Optimizer):
   @@__init__
   """
 
-  def __init__(self, learning_rate, decay, momentum=0.0, epsilon=1e-10,
+  def __init__(self, learning_rate, decay=0.9, momentum=0.0, epsilon=1e-10,
                use_locking=False, name="RMSProp"):
     """Construct a new RMSProp optimizer.
 


### PR DESCRIPTION
Set RMSPropOptimizer decay parameter default value to 0.9, for simplicity.
