### PR TITLE
improved array_ops.md

### DIFF
--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -581,6 +581,7 @@ output[3, 2:, :, ...] = input[3, 2:, :, ...]
 ```
 
 In contrast, if:
+
 ```prettyprint
 # Given this:
 batch_dim = 2


### PR DESCRIPTION
In my environment, the documentation of [reverse_sequence](https://www.tensorflow.org/versions/master/api_docs/python/array_ops.html#reverse_sequence) looks like this:

---

<img width="854" alt="2015-12-23 23 47 57" src="https://cloud.githubusercontent.com/assets/1457682/11978610/41dd6e20-a9d0-11e5-8f39-9aaba1c3aba2.png">
## 

It seems like this is affected by no newline.
