### PR TITLE
Fix TensorBoard not displaying any images

### DIFF
--- a/tensorflow/tensorboard/components/tf-image-dashboard/tf-image-grid.html
+++ b/tensorflow/tensorboard/components/tf-image-dashboard/tf-image-grid.html
@@ -153,7 +153,7 @@ is high)
       _getTags: function(runToImages) {
         return _.chain(runToImages.base).values().flatten().union().value();
       },
-      _getRuns(runToImages) {
+      _getRuns: function(runToImages) {
         var r2i = runToImages.base;
         return _.keys(r2i).filter(function(x) {return r2i[x].length > 0;});
       },

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -7939,7 +7939,7 @@ var TF;
       _getTags: function(runToImages) {
         return _.chain(runToImages.base).values().flatten().union().value();
       },
-      _getRuns(runToImages) {
+      _getRuns: function(runToImages) {
         var r2i = runToImages.base;
         return _.keys(r2i).filter(function(x) {return r2i[x].length > 0;});
       },


### PR DESCRIPTION
The Convolutional Neural Networks/CIFAR-10 tutorial describes how TensorBoard is able to display preprocessed images that have been output through tf.image_summary. However, when viewing the resulting TensorBoard site, the 'Images' tab displays no images at all, and Chrome reports invalid javascript.

Making _getRuns a proper function definition as in this commit fixes the syntax error, and results in TensorBoard actually displaying some images in that tutorial.
