### PR TITLE
TENSOR-566: Fix for verbose messaging

### DIFF
--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -55,8 +55,8 @@ thread::ThreadPool* NewThreadPool(const SessionOptions& options) {
     // Default to using the number of cores available in the process.
     inter_op_parallelism_threads = port::NumSchedulableCPUs();
   }
-  LOG(INFO) << "Direct session inter op parallelism threads: "
-            << inter_op_parallelism_threads;
+  VLOG(1) << "Direct session inter op parallelism threads: "
+          << inter_op_parallelism_threads;
   return new thread::ThreadPool(options.env, "Compute",
                                 inter_op_parallelism_threads);
 }

--- a/tensorflow/core/common_runtime/local_device.cc
+++ b/tensorflow/core/common_runtime/local_device.cc
@@ -37,8 +37,8 @@ static bool InitModule(const SessionOptions& options) {
   if (intra_op_parallelism_threads == 0) {
     intra_op_parallelism_threads = port::NumSchedulableCPUs();
   }
-  LOG(INFO) << "Local device intra op parallelism threads: "
-            << intra_op_parallelism_threads;
+  VLOG(1) << "Local device intra op parallelism threads: "
+          << intra_op_parallelism_threads;
   eigen_worker_threads.num_threads = intra_op_parallelism_threads;
   eigen_worker_threads.workers = new thread::ThreadPool(
       options.env, "Eigen", intra_op_parallelism_threads);


### PR DESCRIPTION
After doing a bit of digging on various logging.h used in tensorflow, while some provide facility of silencing logs via LogSilencer and some use re2 package with flags like FLAGS_minlogLevel, the flow for local_device.cc and direct_session.cc only hit the core platform default logging (tensorflow/core/platform/default/logging.h) which neither has facility to silence log nor is capable of interpreting command line flag setting. One way is to make it verbose logging at level 1 for these messages are truly not messages a user needs to know  every time, but only if interested.Please review and let me know if this is ok.Also long term if there is log suppressing on this flow.thanks.
