### PR TITLE
ADB Install Instructions for Android Example (tiny fix)

### DIFF
--- a/tensorflow/examples/android/README.md
+++ b/tensorflow/examples/android/README.md
@@ -55,7 +55,7 @@ use the following command from your workspace root to install the APK once
 built:
 
 ```bash
-$ adb install -r -g bazel-bin/tensorflow/examples/android/tensorflow_demo.apk
+$ adb install -rg bazel-bin/tensorflow/examples/android/tensorflow_demo.apk
 ```
 
 Alternatively, a streamlined means of building, installing and running in one

--- a/tensorflow/examples/android/README.md
+++ b/tensorflow/examples/android/README.md
@@ -57,11 +57,11 @@ built:
 ```bash
 $ adb install -r -g bazel-bin/tensorflow/examples/android/tensorflow_demo.apk
 ```
+
 Some older versions of adb might complain about the -g option (returning: "Error: Unknown option: -g").
 In this case, if your device runs Android 6.0 or later, then make sure you update to
 the latest adb version before trying the install command again. If your device runs earlier
 versions of Android, however, you can issue the install command without the -g option.
-
 
 Alternatively, a streamlined means of building, installing and running in one
 command is:

--- a/tensorflow/examples/android/README.md
+++ b/tensorflow/examples/android/README.md
@@ -55,8 +55,13 @@ use the following command from your workspace root to install the APK once
 built:
 
 ```bash
-$ adb install -rg bazel-bin/tensorflow/examples/android/tensorflow_demo.apk
+$ adb install -r -g bazel-bin/tensorflow/examples/android/tensorflow_demo.apk
 ```
+Some older versions of adb might complain about the -g option (returning: "Error: Unknown option: -g").
+In this case, if your device runs Android 6.0 or later, then make sure you update to
+the latest adb version before trying the install command again. If your device runs earlier
+versions of Android, however, you can issue the install command without the -g option.
+
 
 Alternatively, a streamlined means of building, installing and running in one
 command is:


### PR DESCRIPTION
The ADB installation command in the documentation for the Android app threw this error when I tried it:

``` bash
$ adb install -r -g bazel-bin/tensorflow/examples/android/tensorflow_demo.apk
2918 KB/s (58599654 bytes in 19.605s)
Error: Unknown option: -g
```

The option flags have to be supplied together for it to work:

``` bash
$ adb install -rg bazel-bin/tensorflow/examples/android/tensorflow_demo.apk
```

Which resulted in successfully installing the app:

``` bash
$ adb install -rg bazel-bin/tensorflow/examples/android/tensorflow_demo.apk
2683 KB/s (58599654 bytes in 21.322s)
    pkg: /data/local/tmp/tensorflow_demo.apk
Success
```
