### PR TITLE
Fixes anchor links in installation instructions

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -15,12 +15,12 @@ The GPU version (Linux only) currently requires the Cuda Toolkit 7.0 and CUDNN
 
 We support different ways to install TensorFlow:
 
-*  [Pip install](#pip_install): Install TensorFlow on your machine, possibly
+*  [Pip install](#pip-installation): Install TensorFlow on your machine, possibly
    upgrading previously installed Python packages.  May impact existing
    Python programs on your machine.
-*  [Virtualenv install](#virtualenv_install): Install TensorFlow in its own
+*  [Virtualenv install](#virtualenv-installation): Install TensorFlow in its own
    directory, not impacting any existing Python programs on your machine.
-*  [Docker install](#docker_install): Run TensorFlow in a Docker container
+*  [Docker install](#docker-installation): Run TensorFlow in a Docker container
    isolated from all other programs on your machine.
 
 If you are familiar with Pip, Virtualenv, or Docker, please feel free to adapt
@@ -30,7 +30,7 @@ images are listed in the corresponding installation sections.
 If you encounter installation errors, see
 [common problems](#common_install_problems) for some solutions.
 
-## Pip Installation {#pip_install}
+## Pip Installation
 
 [Pip](https://en.wikipedia.org/wiki/Pip_(package_manager)) is a package
 management system used to install and manage software packages written in
@@ -78,9 +78,9 @@ $ sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/mac/tens
 ```
 
 
-You can now [test your installation](#test_install).
+You can now [test your installation](#test-the-tensorflow-installation).
 
-## Virtualenv installation {#virtualenv_install}
+## Virtualenv installation
 
 [Virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) is a tool
 to keep the dependencies required by different Python projects in separate
@@ -121,13 +121,13 @@ $ source ~/tensorflow/bin/activate.csh  # If using csh
 (tensorflow)$  # Your prompt should change
 
 # Ubuntu/Linux 64-bit, CPU only:
-(tensorflow)$ pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.6.0-cp27-none-linux_x86_64.whl
+(tensorflow)$ pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.5.0-cp27-none-linux_x86_64.whl
 
 # Ubuntu/Linux 64-bit, GPU enabled:
-(tensorflow)$ pip install --upgrade https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.6.0-cp27-none-linux_x86_64.whl
+(tensorflow)$ pip install --upgrade https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.5.0-cp27-none-linux_x86_64.whl
 
 # Mac OS X, CPU only:
-(tensorflow)$ pip install --upgrade https://storage.googleapis.com/tensorflow/mac/tensorflow-0.6.0-py2-none-any.whl
+(tensorflow)$ pip install --upgrade https://storage.googleapis.com/tensorflow/mac/tensorflow-0.5.0-py2-none-any.whl
 ```
 
 and again for python3:
@@ -148,7 +148,7 @@ $ source ~/tensorflow/bin/activate.csh  # If using csh
 ```
 
 With the Virtualenv environment activated, you can now
-[test your installation](#test_install).
+[test your installation](#test-the-tensorflow-installation).
 
 When you are done using TensorFlow, deactivate the environment.
 
@@ -170,7 +170,7 @@ $ source ~/tensorflow/bin/activate.csh  # If using csh.
 (tensorflow)$ deactivate
 ```
 
-## Docker installation {#docker_install}
+## Docker installation
 
 [Docker](http://docker.com/) is a system to build self contained versions of a
 Linux operating system running on your machine.  When you install and run
@@ -217,9 +217,9 @@ in the repo with these flags, so the command-line would look like
 $ path/to/repo/tensorflow/tools/docker/docker_run_gpu.sh b.gcr.io/tensorflow/tensorflow:gpu
 ```
 
-You can now [test your installation](#test_install) within the Docker container.
+You can now [test your installation](#test-the-tensorflow-installation) within the Docker container.
 
-## Test the TensorFlow installation {#test_install}
+## Test the TensorFlow installation
 
 ### (Optional, Linux) Enable GPU Support
 
@@ -290,11 +290,11 @@ $ python /usr/local/lib/python2.7/dist-packages/tensorflow/models/image/mnist/co
 ...
 ```
 
-## Installing from sources {#source}
+## Installing from sources
 
 When installing from source you will build a pip wheel that you then install
 using pip. You'll need pip for that, so install it as described
-[above](#pip_install).
+[above](#pip-installation).
 
 ### Clone the TensorFlow repository
 
@@ -515,7 +515,7 @@ $ bazel build -c opt --config=cuda //tensorflow/tools/pip_package:build_pip_pack
 $ bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
 
 # The name of the .whl file will depend on your platform.
-$ pip install /tmp/tensorflow_pkg/tensorflow-0.6.0-cp27-none-linux_x86_64.whl
+$ pip install /tmp/tensorflow_pkg/tensorflow-0.5.0-cp27-none-linux_x86_64.whl
 ```
 
 ## Train your first TensorFlow neural net model
@@ -624,8 +624,8 @@ $ sudo easy_install -U six
 
 * Install TensorFlow with a separate Python library:
 
-    *  Using [Virtualenv](#virtualenv_install).
-    *  Using [Docker](#docker_install).
+    *  Using [Virtualenv](#virtualenv-installation).
+    *  Using [Docker](#docker-installation).
 
 * Install a separate copy of Python via [Homebrew](http://brew.sh/) or
 [MacPorts](https://www.macports.org/) and re-install TensorFlow in that
@@ -649,9 +649,9 @@ On Mac OS X, you may encounter the following when importing tensorflow.
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
   File "/usr/local/lib/python2.7/site-packages/tensorflow/__init__.py", line 4, in <module>
-    from tensorflow.python import *
+    from google3.third_party.tensorflow.python import *
   File "/usr/local/lib/python2.7/site-packages/tensorflow/python/__init__.py", line 13, in <module>
-    from tensorflow.core.framework.graph_pb2 import *
+    from google3.third_party.tensorflow.core.framework.graph_pb2 import *
 ...
   File "/usr/local/lib/python2.7/site-packages/tensorflow/core/framework/tensor_shape_pb2.py", line 22, in <module>
     serialized_pb=_b('\n,tensorflow/core/framework/tensor_shape.proto\x12\ntensorflow\"d\n\x10TensorShapeProto\x12-\n\x03\x64im\x18\x02 \x03(\x0b\x32 .tensorflow.TensorShapeProto.Dim\x1a!\n\x03\x44im\x12\x0c\n\x04size\x18\x01 \x01(\x03\x12\x0c\n\x04name\x18\x02 \x01(\tb\x06proto3')

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -9,7 +9,7 @@ The TensorFlow Python API currently supports Python 2.7 and Python 3.3+ from
 source.
 
 The GPU version (Linux only) currently requires the Cuda Toolkit 7.0 and CUDNN
-6.5 V2.  Please see [Cuda installation](#install_cuda).
+6.5 V2.  Please see [Cuda installation](#optional-install-cuda-gpus-on-linux).
 
 ## Overview
 
@@ -28,7 +28,7 @@ the instructions to your particular needs.  The names of the pip and Docker
 images are listed in the corresponding installation sections.
 
 If you encounter installation errors, see
-[common problems](#common_install_problems) for some solutions.
+[common problems](#common-installation-problems) for some solutions.
 
 ## Pip Installation
 
@@ -224,7 +224,7 @@ You can now [test your installation](#test-the-tensorflow-installation) within t
 ### (Optional, Linux) Enable GPU Support
 
 If you installed the GPU version of TensorFlow, you must also install the Cuda
-Toolkit 7.0 and CUDNN 6.5 V2.  Please see [Cuda installation](#install_cuda).
+Toolkit 7.0 and CUDNN 6.5 V2.  Please see [Cuda installation](#optional-install-cuda-gpus-on-linux).
 
 You also need to set the `LD_LIBRARY_PATH` and `CUDA_HOME` environment
 variables.  Consider adding the commands below to your `~/.bash_profile`.  These
@@ -237,7 +237,7 @@ export CUDA_HOME=/usr/local/cuda
 
 ### Run TensorFlow from the Command Line
 
-See [common problems](#common_install_problems) if an error happens.
+See [common problems](#common-installation-problems) if an error happens.
 
 Open a terminal and type the following:
 
@@ -331,11 +331,11 @@ binary path.
 $ sudo apt-get install python-numpy swig python-dev
 ```
 
-#### Configure the installation {#configure}
+#### Configure the installation
 
 Run the `configure` script at the root of the tree.  The configure script
 asks you for the path to your python interpreter and allows (optional)
-configuration of the CUDA libraries (see [below](#configure_cuda)).
+configuration of the CUDA libraries (see [below](#configure-tensorflows-canonical-view-of-cuda-libraries)).
 
 This step is used to locate the python and numpy header files.
 
@@ -344,7 +344,7 @@ $ ./configure
 Please specify the location of python. [Default is /usr/bin/python]:
 ```
 
-#### Optional: Install CUDA (GPUs on Linux) {#install_cuda}
+#### Optional: Install CUDA (GPUs on Linux)
 
 In order to build or run TensorFlow with GPU support, both Cuda Toolkit 7.0 and
 CUDNN 6.5 V2 from NVIDIA need to be installed.
@@ -376,7 +376,7 @@ sudo cp cudnn-6.5-linux-x64-v2/cudnn.h /usr/local/cuda/include
 sudo cp cudnn-6.5-linux-x64-v2/libcudnn* /usr/local/cuda/lib64
 ```
 
-##### Configure TensorFlow's canonical view of Cuda libraries {#configure_cuda}
+##### Configure TensorFlow's canonical view of Cuda libraries
 When running the `configure` script from the root of your source tree, select
 the option `Y` when asked to build TensorFlow with GPU support.
 
@@ -491,7 +491,7 @@ best install that too:
 $ sudo easy_install ipython
 ```
 
-#### Configure the installation {#configure_osx}
+#### Configure the installation for Mac OS X
 
 Run the `configure` script at the root of the tree.  The configure script
 asks you for the path to your python interpreter.
@@ -504,7 +504,7 @@ Please specify the location of python. [Default is /usr/bin/python]:
 Do you wish to build TensorFlow with GPU support? [y/N]
 ```
 
-### Create the pip package and install {#create-pip}
+### Create the pip package and install
 
 ```bash
 $ bazel build -c opt //tensorflow/tools/pip_package:build_pip_package
@@ -546,7 +546,7 @@ Validation error: 7.0%
 ...
 ```
 
-## Common Problems {#common_install_problems}
+## Common Installation Problems
 
 ### GPU-related issues
 
@@ -556,7 +556,7 @@ If you encounter the following when trying to run a TensorFlow program:
 ImportError: libcudart.so.7.0: cannot open shared object file: No such file or directory
 ```
 
-Make sure you followed the the GPU installation [instructions](#install_cuda).
+Make sure you followed the the GPU installation [instructions](#optional-install-cuda-gpus-on-linux).
 
 ### Pip installation issues
 

--- a/tensorflow/g3doc/how_tos/adding_an_op/index.md
+++ b/tensorflow/g3doc/how_tos/adding_an_op/index.md
@@ -3,7 +3,7 @@
 PREREQUISITES:
 
 * Some familiarity with C++.
-* Must have [downloaded TensorFlow source](../../get_started/index.md#source),
+* Must have [downloaded TensorFlow source](../../get_started/os_setup.md#installing-from-sources),
   and be able to build it.
 
 If you'd like to incorporate an operation that isn't covered by the existing
@@ -22,7 +22,7 @@ to:
 * Optionally, write a function to compute gradients for the Op.
 * Optionally, write a function that describes the input and output shapes
   for the Op.  This allows shape inference to work with your Op.
-* Test the Op, typically in Python. If you define gradients, you can verify them   with the Python [`GradientChecker`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/kernel_tests/gradient_checker.py).
+* Test the Op, typically in Python. If you define gradients, you can verify them   with the Python [`GradientChecker`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/kernel_tests/gradient_checker.py).
 
 [TOC]
 
@@ -39,7 +39,7 @@ zero. Create file [`tensorflow/core/user_ops`][user_ops]`/zero_out.cc` and
 add a call to the `REGISTER_OP` macro that defines the interface for such an Op:
 
 ```c++
-#include "tensorflow/core/framework/op.h"
+#include "third_party/tensorflow/core/framework/op.h"
 
 REGISTER_OP("ZeroOut")
     .Input("to_zero: int32")
@@ -64,7 +64,7 @@ Add your kernel to the file you created above. The kernel might look something
 like this:
 
 ```c++
-#include "tensorflow/core/framework/op_kernel.h"
+#include "third_party/tensorflow/core/framework/op_kernel.h"
 
 using namespace tensorflow;
 
@@ -114,7 +114,7 @@ Tensorflow system can reference and use the Op when requested.
 ### The Python Op wrapper
 
 Python op wrappers are created automatically in
-`bazel-genfiles/tensorflow/python/ops/gen_user_ops.py` for all ops placed in the
+`blaze-genfiles/third_party/tensorflow/python/ops/gen_user_ops.py` for all ops placed in the
 [`tensorflow/core/user_ops`][user_ops] directory when you build Tensorflow.
 
 > Note: The generated function will be given a snake\_case name (to comply with
@@ -125,13 +125,13 @@ Those ops are imported into
 [`tensorflow/python/user_ops/user_ops.py`][python-user_ops] with the statement:
 
 ```python
-from tensorflow.python.ops.gen_user_ops import *
+from google3.third_party.tensorflow.python.ops.gen_user_ops import *
 ```
 
 You may optionally use your own function instead.  To do this, you first hide
 the generated code for that op by adding its name to the `hidden` list in the
 `"user_ops"` rule in
-[`tensorflow/python/BUILD`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/BUILD):
+[`tensorflow/python/BUILD`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/BUILD):
 
 ```python
 tf_gen_op_wrapper_py(
@@ -144,7 +144,7 @@ tf_gen_op_wrapper_py(
 ```
 
 List your op next to `"Fact"`.  Next you add your replacement function to
-[`tensorflow/python/user_ops/user_ops.py`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/user_ops/user_ops.py).
+[`tensorflow/python/user_ops/user_ops.py`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/user_ops/user_ops.py).
 Typically your function will call the generated function to actually add the op
 to the graph.  The hidden version of the generated function will be in the
 `gen_user_ops` package and start with an underscore ("`_`").  For example:
@@ -160,14 +160,14 @@ def my_fact():
 C++ op wrappers are created automatically for all ops placed in the
 [`tensorflow/core/user_ops`][user_ops] directory, when you build Tensorflow. For
 example, ops in `tensorflow/core/user_ops/zero_out.cc` will generate wrappers in
-`bazel-genfiles/tensorflow/cc/ops/user_ops.{h,cc}`.
+`blaze-genfiles/third_party/tensorflow/cc/ops/user_ops.{h,cc}`.
 
 All generated wrappers for user ops are automatically
 imported into [`tensorflow/cc/ops/standard_ops.h`][standard_ops-cc] with the
 statement
 
 ```c++
-#include "tensorflow/cc/ops/user_ops.h"
+#include "third_party/tensorflow/cc/ops/user_ops.h"
 ```
 
 ## Verify it works
@@ -216,13 +216,13 @@ This asserts that the input is a vector, and returns having set the
 
 *   The `context`, which can either be an `OpKernelContext` or
     `OpKernelConstruction` pointer (see
-    [`tensorflow/core/framework/op_kernel.h`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/op_kernel.h)),
+    [`tensorflow/core/framework/op_kernel.h`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/op_kernel.h)),
     for its `SetStatus()` method.
 *   The condition.  For example, there are functions for validating the shape
     of a tensor in
-    [`tensorflow/core/public/tensor_shape.h`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/public/tensor_shape.h)
+    [`tensorflow/core/public/tensor_shape.h`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/public/tensor_shape.h)
 *   The error itself, which is represented by a `Status` object, see
-    [`tensorflow/core/public/status.h`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/public/status.h). A
+    [`tensorflow/core/public/status.h`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/public/status.h). A
     `Status` has both a type (frequently `InvalidArgument`, but see the list of
     types) and a message.  Functions for constructing an error may be found in
     [`tensorflow/core/lib/core/errors.h`][validation-macros].
@@ -368,7 +368,7 @@ define an attr with constraints, you can use the following `<attr-type-expr>`s:
 
     The specific lists of types allowed by these are defined by the functions
     (like `NumberTypes()`) in
-    [`tensorflow/core/framework/types.h`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/types.h).
+    [`tensorflow/core/framework/types.h`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/types.h).
     In this example the attr `t` must be one of the numeric types:
 
     ```c++
@@ -512,7 +512,7 @@ Your Op registration now specifies that the input's type must be `float`, or
 > ```
 
 <code class="lang-c++"><pre>
-\#include "tensorflow/core/framework/op_kernel.h"<br/>
+\#include "third_party/tensorflow/core/framework/op_kernel.h"<br/>
 class ZeroOut<b>Int32</b>Op : public OpKernel {
   // as before
 };<br/>
@@ -624,7 +624,7 @@ If you have more than a couple overloads, you can put the registration in a
 macro.
 
 ```c++
-#include "tensorflow/core/framework/op_kernel.h"
+#include "third_party/tensorflow/core/framework/op_kernel.h"
 
 #define REGISTER_KERNEL(type)                                       \
   REGISTER_KERNEL_BUILDER(                                          \
@@ -643,8 +643,8 @@ able to use a macro provided by
 [`tensorflow/core/framework/register_types.h`][register_types]:
 
 ```c++
-#include "tensorflow/core/framework/op_kernel.h"
-#include "tensorflow/core/framework/register_types.h"
+#include "third_party/tensorflow/core/framework/op_kernel.h"
+#include "third_party/tensorflow/core/framework/register_types.h"
 
 REGISTER_OP("ZeroOut")
     .Attr("T: realnumbertype")
@@ -844,7 +844,8 @@ For more details, see
 
 In general, changes to specifications must be backwards-compatible: changing the
 specification of an Op must not break prior serialized `GraphDef` protocol
-buffers constructed from older specfications.
+buffers constructed from older specfications.  The details of `GraphDef`
+compatibility are [described here](../../resources/versions.md#graphs).
 
 There are several ways to preserve backwards-compatibility.
 
@@ -888,7 +889,7 @@ There are several ways to preserve backwards-compatibility.
    type into a list of varying types).
 
 The full list of safe and unsafe changes can be found in
-[`tensorflow/core/framework/op_compatibility_test.cc`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/op_compatibility_test.cc).
+[`tensorflow/core/framework/op_compatibility_test.cc`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/op_compatibility_test.cc).
 If you cannot make your change to an operation backwards compatible, then create
 a new operation with a new name with the new semantics.
 
@@ -897,23 +898,24 @@ generated Python code may change in a way that isn't compatible with old
 callers.  The Python API may be kept compatible by careful changes in a
 hand-written Python wrapper, by keeping the old signature except possibly adding
 new optional arguments to the end.  Generally incompatible changes may only be
-made when TensorFlow's changes major versions.
+made when TensorFlow's changes major versions, and must conform to the
+[`GraphDef` version semantics](../../resources/versions.md#graphs).
 
 ## GPU Support {#mult-archs}
 
 You can implement different OpKernels and register one for CPU and another for
 GPU, just like you can [register kernels for different types](#Polymorphism).
 There are several examples of kernels with GPU support in
-[`tensorflow/core/kernels/`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/).
+[`tensorflow/core/kernels/`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/).
 Notice some kernels have a CPU version in a `.cc` file, a GPU version in a file
 ending in `_gpu.cu.cc`, and some code shared in common in a `.h` file.
 
 For example, the [`pad` op](../../api_docs/python/array_ops.md#pad) has
 everything but the GPU kernel in [`tensorflow/core/kernels/pad_op.cc`][pad_op].
 The GPU kernel is in
-[`tensorflow/core/kernels/pad_op_gpu.cu.cc`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/pad_op_gpu.cu.cc),
+[`tensorflow/core/kernels/pad_op_gpu.cu.cc`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/pad_op_gpu.cu.cc),
 and the shared code is a templated class defined in
-[`tensorflow/core/kernels/pad_op.h`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/pad_op.h).
+[`tensorflow/core/kernels/pad_op.h`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/pad_op.h).
 One thing to note, even when the GPU kernel version of `pad` is used, it still
 needs its `"paddings"` input in CPU memory.  To mark that inputs or outputs are
 kept on the CPU, add a `HostMemory()` call to the kernel registration, e.g.:
@@ -951,9 +953,9 @@ gradient with respect to the input is a sparse "one hot" tensor.  This is
 expressed as follows:
 
 ```python
-from tensorflow.python.framework import ops
-from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import sparse_ops
+from google3.third_party.tensorflow.python.framework import ops
+from google3.third_party.tensorflow.python.ops import array_ops
+from google3.third_party.tensorflow.python.ops import sparse_ops
 
 @ops.RegisterGradient("ZeroOut")
 def _zero_out_grad(op, grad):
@@ -1070,23 +1072,23 @@ any of the inputs. The [`merge_with`](../../api_docs/python/framework.md)
 method allows the caller to assert that two shapes are the same, even if either
 or both of them do not have complete information. Shape functions are defined
 for all of the
-[standard Python ops](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/ops/),
+[standard Python ops](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/ops/),
 and provide many different usage examples.
 
-[core-array_ops]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/ops/array_ops.cc
-[python-user_ops]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/user_ops/user_ops.py
-[tf-kernels]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/
-[user_ops]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/user_ops/
-[pad_op]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/pad_op.cc
-[standard_ops-py]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/ops/standard_ops.py
-[standard_ops-cc]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/cc/ops/standard_ops.h
-[python-BUILD]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/BUILD
-[validation-macros]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/lib/core/errors.h
-[op_def_builder]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/op_def_builder.h
-[register_types]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/register_types.h
-[FinalizeAttr]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/op_def_builder.cc#FinalizeAttr
-[DataTypeString]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/types.cc#DataTypeString
-[python-BUILD]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/BUILD
-[types-proto]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/types.proto
-[TensorShapeProto]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/tensor_shape.proto
-[TensorProto]:https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/tensor.proto
+[core-array_ops]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/ops/array_ops.cc
+[python-user_ops]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/user_ops/user_ops.py
+[tf-kernels]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/
+[user_ops]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/user_ops/
+[pad_op]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/pad_op.cc
+[standard_ops-py]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/ops/standard_ops.py
+[standard_ops-cc]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/cc/ops/standard_ops.h
+[python-BUILD]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/BUILD
+[validation-macros]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/lib/core/errors.h
+[op_def_builder]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/op_def_builder.h
+[register_types]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/register_types.h
+[FinalizeAttr]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/op_def_builder.cc#FinalizeAttr
+[DataTypeString]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/types.cc#DataTypeString
+[python-BUILD]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/BUILD
+[types-proto]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/types.proto
+[TensorShapeProto]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/tensor_shape.proto
+[TensorProto]:https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/tensor.proto

--- a/tensorflow/g3doc/how_tos/adding_an_op/index.md
+++ b/tensorflow/g3doc/how_tos/adding_an_op/index.md
@@ -107,7 +107,7 @@ REGISTER_KERNEL_BUILDER(Name("ZeroOut").Device(DEVICE_CPU), ZeroOutOp);
 ```
 
 Once you
-[build and reinstall TensorFlow](../../get_started/os_setup.md#create-pip), the
+[build and reinstall TensorFlow](../../get_started/os_setup.md#create-the-pip-package-and-install-create-pip), the
 Tensorflow system can reference and use the Op when requested.
 
 ## Generate the client wrapper

--- a/tensorflow/g3doc/how_tos/new_data_formats/index.md
+++ b/tensorflow/g3doc/how_tos/new_data_formats/index.md
@@ -4,7 +4,7 @@ PREREQUISITES:
 
 *   Some familiarity with C++.
 *   Must have
-    [downloaded TensorFlow source](../../get_started/os_setup.md#source), and be
+    [downloaded TensorFlow source](../../get_started/os_setup.md#installing-from-sources), and be
     able to build it.
 
 We divide the task of supporting a file format into two pieces:
@@ -28,11 +28,11 @@ A `Reader` is something that reads records from a file.  There are some examples
 of Reader Ops already built into TensorFlow:
 
 *   [`tf.TFRecordReader`](../../api_docs/python/io_ops.md#TFRecordReader)
-    ([source in `kernels/tf_record_reader_op.cc`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/tf_record_reader_op.cc))
+    ([source in `kernels/tf_record_reader_op.cc`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/tf_record_reader_op.cc))
 *   [`tf.FixedLengthRecordReader`](../../api_docs/python/io_ops.md#FixedLengthRecordReader)
-    ([source in `kernels/fixed_length_record_reader_op.cc`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/fixed_length_record_reader_op.cc))
+    ([source in `kernels/fixed_length_record_reader_op.cc`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/fixed_length_record_reader_op.cc))
 *   [`tf.TextLineReader`](../../api_docs/python/io_ops.md#TextLineReader)
-    ([source in `kernels/text_line_reader_op.cc`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/text_line_reader_op.cc))
+    ([source in `kernels/text_line_reader_op.cc`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/text_line_reader_op.cc))
 
 You can see these all expose the same interface, the only differences
 are in their constructors.  The most important method is `read`.
@@ -44,15 +44,15 @@ two scalar tensors: a string key and and a string value.
 To create a new reader called `SomeReader`, you will need to:
 
 1.  In C++, define a subclass of
-    [`tensorflow::ReaderBase`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/reader_base.h)
+    [`tensorflow::ReaderBase`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/reader_base.h)
     called `SomeReader`.
 2.  In C++, register a new reader op and kernel with the name `"SomeReader"`.
-3.  In Python, define a subclass of [`tf.ReaderBase`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/ops/io_ops.py) called `SomeReader`.
+3.  In Python, define a subclass of [`tf.ReaderBase`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/ops/io_ops.py) called `SomeReader`.
 
 You can put all the C++ code in a file in
 `tensorflow/core/user_ops/some_reader_op.cc`.  The code to read a file will live
 in a descendant of the C++ `ReaderBase` class, which is defined in
-[`tensorflow/core/kernels/reader_base.h`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/reader_base.h).
+[`tensorflow/core/kernels/reader_base.h`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/kernels/reader_base.h).
 You will need to implement the following methods:
 
 *   `OnWorkStartedLocked`: open the next file
@@ -83,7 +83,7 @@ If `ReadLocked` successfully reads a record from the file, it should fill in:
 If you hit the end of a file (EOF), set `*at_end` to `true`.  In either case,
 return `Status::OK()`.  If there is an error, simply return it using one of the
 helper functions from
-[`tensorflow/core/lib/core/errors.h`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/lib/core/errors.h)
+[`tensorflow/core/lib/core/errors.h`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/lib/core/errors.h)
 without modifying any arguments.
 
 Next you will create the actual Reader op.  It will help if you are familiar
@@ -94,16 +94,16 @@ are:
 *   Define and register an `OpKernel`.
 
 To register the op, you will use a `REGISTER_OP` call defined in
-[`tensorflow/core/framework/op.h`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/op.h).
+[`tensorflow/core/framework/op.h`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/op.h).
 Reader ops never take any input and always have a single output with type
 `Ref(string)`.  They should always call `SetIsStateful()`, and have a string
 `container` and `shared_name` attrs.  You may optionally define additional attrs
 for configuration or include documentation in a `Doc`.  For examples, see
-[`tensorflow/core/ops/io_ops.cc`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/ops/io_ops.cc),
+[`tensorflow/core/ops/io_ops.cc`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/ops/io_ops.cc),
 e.g.:
 
 ```c++
-#include "tensorflow/core/framework/op.h"
+#include "third_party/tensorflow/core/framework/op.h"
 
 REGISTER_OP("TextLineReader")
     .Output("reader_handle: Ref(string)")
@@ -118,13 +118,13 @@ A Reader that outputs the lines of a file delimited by '\n'.
 
 To define an `OpKernel`, Readers can use the shortcut of descending from
 `ReaderOpKernel`, defined in
-[`tensorflow/core/framework/reader_op_kernel.h`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/framework/reader_op_kernel.h),
+[`tensorflow/core/framework/reader_op_kernel.h`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/framework/reader_op_kernel.h),
 and implement a constructor that calls `SetReaderFactory`.  After defining
 your class, you will need to register it using `REGISTER_KERNEL_BUILDER(...)`.
 An example with no attrs:
 
 ```c++
-#include "tensorflow/core/framework/reader_op_kernel.h"
+#include "third_party/tensorflow/core/framework/reader_op_kernel.h"
 
 class TFRecordReaderOp : public ReaderOpKernel {
  public:
@@ -142,7 +142,7 @@ REGISTER_KERNEL_BUILDER(Name("TFRecordReader").Device(DEVICE_CPU),
 An example with attrs:
 
 ```c++
-#include "tensorflow/core/framework/reader_op_kernel.h"
+#include "third_party/tensorflow/core/framework/reader_op_kernel.h"
 
 class TextLineReaderOp : public ReaderOpKernel {
  public:
@@ -167,13 +167,13 @@ REGISTER_KERNEL_BUILDER(Name("TextLineReader").Device(DEVICE_CPU),
 
 The last step is to add the Python wrapper.  You will import
 `tensorflow.python.ops.io_ops` in
-[`tensorflow/python/user_ops/user_ops.py`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/user_ops/user_ops.py)
-and add a descendant of [`io_ops.ReaderBase`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/ops/io_ops.py).
+[`tensorflow/python/user_ops/user_ops.py`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/user_ops/user_ops.py)
+and add a descendant of [`io_ops.ReaderBase`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/ops/io_ops.py).
 
 ```python
-from tensorflow.python.framework import ops
-from tensorflow.python.ops import common_shapes
-from tensorflow.python.ops import io_ops
+from google3.third_party.tensorflow.python.framework import ops
+from google3.third_party.tensorflow.python.ops import common_shapes
+from google3.third_party.tensorflow.python.ops import io_ops
 
 class SomeReader(io_ops.ReaderBase):
 
@@ -187,7 +187,7 @@ ops.RegisterShape("SomeReader")(common_shapes.scalar_shape)
 ```
 
 You can see some examples in
-[`tensorflow/python/ops/io_ops.py`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/python/ops/io_ops.py).
+[`tensorflow/python/ops/io_ops.py`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/python/ops/io_ops.py).
 
 ## Writing an Op for a record format
 
@@ -207,7 +207,7 @@ Examples of Ops useful for decoding records:
 
 Note that it can be useful to use multiple Ops to decode a particular record
 format.  For example, you may have an image saved as a string in
-[a `tf.train.Example` protocol buffer](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/example/example.proto).
+[a `tf.train.Example` protocol buffer](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/core/example/example.proto).
 Depending on the format of that image, you might take the corresponding output
 from a
 [`tf.parse_single_example`](../../api_docs/python/io_ops.md#parse_single_example)

--- a/tensorflow/g3doc/tutorials/image_recognition/index.md
+++ b/tensorflow/g3doc/tutorials/image_recognition/index.md
@@ -108,7 +108,7 @@ unzip tensorflow/examples/label_image/data/inception_dec_2015.zip -d tensorflow/
 
 Next, we need to compile the C++ binary that includes the code to load and run the graph.
 If you've followed [the instructions to download the source installation of
-TensorFlow](http://www.tensorflow.org/versions/master/get_started/os_setup.html#source)
+TensorFlow](../../get_started/os_setup.md#installing-from-sources)
 for your platform, you should be able to build the example by
 running this command from your shell terminal:
 


### PR DESCRIPTION
The header anchor links in the docs (inside the directory g3doc) is using a {#anchor} format that github's Markdown does not understand.  This PR primarily fixes the anchor text in the installation instructions, which I assume is fairly popular.
