### PR TITLE
Remove all {#anchor} tags in non-API Markdown docs

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -9,18 +9,18 @@ The TensorFlow Python API currently supports Python 2.7 and Python 3.3+ from
 source.
 
 The GPU version (Linux only) currently requires the Cuda Toolkit 7.0 and CUDNN
-6.5 V2.  Please see [Cuda installation](#install_cuda).
+6.5 V2.  Please see [Cuda installation](#optional-install-cuda-gpus-on-linux).
 
 ## Overview
 
 We support different ways to install TensorFlow:
 
-*  [Pip install](#pip_install): Install TensorFlow on your machine, possibly
+*  [Pip install](#pip-installation): Install TensorFlow on your machine, possibly
    upgrading previously installed Python packages.  May impact existing
    Python programs on your machine.
-*  [Virtualenv install](#virtualenv_install): Install TensorFlow in its own
+*  [Virtualenv install](#virtualenv-installation): Install TensorFlow in its own
    directory, not impacting any existing Python programs on your machine.
-*  [Docker install](#docker_install): Run TensorFlow in a Docker container
+*  [Docker install](#docker-installation): Run TensorFlow in a Docker container
    isolated from all other programs on your machine.
 
 If you are familiar with Pip, Virtualenv, or Docker, please feel free to adapt
@@ -28,9 +28,9 @@ the instructions to your particular needs.  The names of the pip and Docker
 images are listed in the corresponding installation sections.
 
 If you encounter installation errors, see
-[common problems](#common_install_problems) for some solutions.
+[common problems](#common-problems) for some solutions.
 
-## Pip Installation {#pip_install}
+## Pip Installation 
 
 [Pip](https://en.wikipedia.org/wiki/Pip_(package_manager)) is a package
 management system used to install and manage software packages written in
@@ -78,9 +78,9 @@ $ sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/mac/tens
 ```
 
 
-You can now [test your installation](#test_install).
+You can now [test your installation](#test-the-tensorflow-installation).
 
-## Virtualenv installation {#virtualenv_install}
+## Virtualenv installation 
 
 [Virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) is a tool
 to keep the dependencies required by different Python projects in separate
@@ -148,7 +148,7 @@ $ source ~/tensorflow/bin/activate.csh  # If using csh
 ```
 
 With the Virtualenv environment activated, you can now
-[test your installation](#test_install).
+[test your installation](#test-the-tensorflow-installation).
 
 When you are done using TensorFlow, deactivate the environment.
 
@@ -170,7 +170,7 @@ $ source ~/tensorflow/bin/activate.csh  # If using csh.
 (tensorflow)$ deactivate
 ```
 
-## Docker installation {#docker_install}
+## Docker installation 
 
 [Docker](http://docker.com/) is a system to build self contained versions of a
 Linux operating system running on your machine.  When you install and run
@@ -217,14 +217,14 @@ in the repo with these flags, so the command-line would look like
 $ path/to/repo/tensorflow/tools/docker/docker_run_gpu.sh b.gcr.io/tensorflow/tensorflow:gpu
 ```
 
-You can now [test your installation](#test_install) within the Docker container.
+You can now [test your installation](#test-the-tensorflow-installation) within the Docker container.
 
-## Test the TensorFlow installation {#test_install}
+## Test the TensorFlow installation 
 
 ### (Optional, Linux) Enable GPU Support
 
 If you installed the GPU version of TensorFlow, you must also install the Cuda
-Toolkit 7.0 and CUDNN 6.5 V2.  Please see [Cuda installation](#install_cuda).
+Toolkit 7.0 and CUDNN 6.5 V2.  Please see [Cuda installation](#optional-install-cuda-gpus-on-linux).
 
 You also need to set the `LD_LIBRARY_PATH` and `CUDA_HOME` environment
 variables.  Consider adding the commands below to your `~/.bash_profile`.  These
@@ -237,7 +237,7 @@ export CUDA_HOME=/usr/local/cuda
 
 ### Run TensorFlow from the Command Line
 
-See [common problems](#common_install_problems) if an error happens.
+See [common problems](#common-problems) if an error happens.
 
 Open a terminal and type the following:
 
@@ -290,11 +290,11 @@ $ python /usr/local/lib/python2.7/dist-packages/tensorflow/models/image/mnist/co
 ...
 ```
 
-## Installing from sources {#source}
+## Installing from sources 
 
 When installing from source you will build a pip wheel that you then install
 using pip. You'll need pip for that, so install it as described
-[above](#pip_install).
+[above](#pip-installation).
 
 ### Clone the TensorFlow repository
 
@@ -331,11 +331,11 @@ binary path.
 $ sudo apt-get install python-numpy swig python-dev
 ```
 
-#### Configure the installation {#configure}
+#### Configure the installation 
 
 Run the `configure` script at the root of the tree.  The configure script
 asks you for the path to your python interpreter and allows (optional)
-configuration of the CUDA libraries (see [below](#configure_cuda)).
+configuration of the CUDA libraries (see [below](#configure-tensorflows-canonical-view-of-cuda-libraries)).
 
 This step is used to locate the python and numpy header files.
 
@@ -344,7 +344,7 @@ $ ./configure
 Please specify the location of python. [Default is /usr/bin/python]:
 ```
 
-#### Optional: Install CUDA (GPUs on Linux) {#install_cuda}
+#### Optional: Install CUDA (GPUs on Linux) 
 
 In order to build or run TensorFlow with GPU support, both Cuda Toolkit 7.0 and
 CUDNN 6.5 V2 from NVIDIA need to be installed.
@@ -376,7 +376,7 @@ sudo cp cudnn-6.5-linux-x64-v2/cudnn.h /usr/local/cuda/include
 sudo cp cudnn-6.5-linux-x64-v2/libcudnn* /usr/local/cuda/lib64
 ```
 
-##### Configure TensorFlow's canonical view of Cuda libraries {#configure_cuda}
+##### Configure TensorFlow's canonical view of Cuda libraries 
 When running the `configure` script from the root of your source tree, select
 the option `Y` when asked to build TensorFlow with GPU support.
 
@@ -491,7 +491,7 @@ best install that too:
 $ sudo easy_install ipython
 ```
 
-#### Configure the installation {#configure_osx}
+#### Configure the installation 
 
 Run the `configure` script at the root of the tree.  The configure script
 asks you for the path to your python interpreter.
@@ -504,7 +504,7 @@ Please specify the location of python. [Default is /usr/bin/python]:
 Do you wish to build TensorFlow with GPU support? [y/N]
 ```
 
-### Create the pip package and install {#create-pip}
+### Create the pip package and install 
 
 ```bash
 $ bazel build -c opt //tensorflow/tools/pip_package:build_pip_package
@@ -546,7 +546,7 @@ Validation error: 7.0%
 ...
 ```
 
-## Common Problems {#common_install_problems}
+## Common Problems 
 
 ### GPU-related issues
 
@@ -556,7 +556,7 @@ If you encounter the following when trying to run a TensorFlow program:
 ImportError: libcudart.so.7.0: cannot open shared object file: No such file or directory
 ```
 
-Make sure you followed the the GPU installation [instructions](#install_cuda).
+Make sure you followed the the GPU installation [instructions](#optional-install-cuda-gpus-on-linux).
 
 ### Pip installation issues
 
@@ -624,8 +624,8 @@ $ sudo easy_install -U six
 
 * Install TensorFlow with a separate Python library:
 
-    *  Using [Virtualenv](#virtualenv_install).
-    *  Using [Docker](#docker_install).
+    *  Using [Virtualenv](#virtualenv-installation).
+    *  Using [Docker](#docker-installation).
 
 * Install a separate copy of Python via [Homebrew](http://brew.sh/) or
 [MacPorts](https://www.macports.org/) and re-install TensorFlow in that

--- a/tensorflow/g3doc/how_tos/adding_an_op/index.md
+++ b/tensorflow/g3doc/how_tos/adding_an_op/index.md
@@ -26,12 +26,12 @@ to:
 
 [TOC]
 
-## Define the Op's interface {#define_interface}
+## Define the Op's interface 
 
 You define the interface of an Op by registering it with the TensorFlow system.
 In the registration, you specify the name of your Op, its inputs (types and
 names) and outputs (types and names), as well as docstrings and
-any [attrs](#Attrs) the Op might require.
+any [attrs](#attrs) the Op might require.
 
 To see how this works, suppose you'd like to create an Op that takes a tensor of
 `int32`s and outputs a copy of the tensor, with all but the first element set to
@@ -107,7 +107,7 @@ REGISTER_KERNEL_BUILDER(Name("ZeroOut").Device(DEVICE_CPU), ZeroOutOp);
 ```
 
 Once you
-[build and reinstall TensorFlow](../../get_started/os_setup.md#create-pip), the
+[build and reinstall TensorFlow](../../get_started/os_setup.md#pip-installation), the
 Tensorflow system can reference and use the Op when requested.
 
 ## Generate the client wrapper
@@ -193,7 +193,7 @@ Then run your test:
 $ bazel test tensorflow/python:zero_out_op_test
 ```
 
-## Validation {#Validation}
+## Validation 
 
 The example above assumed that the Op applied to a tensor of any shape.  What
 if it only applied to vectors?  That means adding a check to the above OpKernel
@@ -234,7 +234,7 @@ function on error.
 
 ## Op registration
 
-### Attrs {#Attrs}
+### Attrs 
 
 Ops can have attrs, whose values are set when the Op is added to a graph. These
 are used to configure the Op, and their values can be accessed both within the
@@ -435,8 +435,8 @@ REGISTER_OP("AttrDefaultExampleForAllTypes")
 Note in particular that the values of type `type` use [the `DT_*` names
 for the types](../../resources/dims_types.md#data-types).
 
-### Polymorphism {#Polymorphism}
-#### Type Polymorphism {#type-polymorphism}
+### Polymorphism 
+#### Type Polymorphism 
 
 For ops that can take different types as input or produce different output
 types, you can specify [an attr](#attrs) in
@@ -664,7 +664,7 @@ TF_CALL_REAL_NUMBER_TYPES(REGISTER_KERNEL);
 #undef REGISTER_KERNEL
 ```
 
-#### List Inputs and Outputs {#list-input-output}
+#### List Inputs and Outputs 
 
 In addition to being able to accept or produce different types, ops can consume
 or produce a variable number of tensors.
@@ -775,7 +775,7 @@ expressions:
 
 * `<attr-type>`, where `<attr-type>` is the name of an [Attr](#attrs) with type
   `type` or `list(type)` (with a possible type restriction). This syntax allows
-  for [polymorphic ops](#Polymorphism).
+  for [polymorphic ops](#polymorphism).
 
   ```c++
   REGISTER_OP("PolymorphicSingleInput")
@@ -899,10 +899,10 @@ hand-written Python wrapper, by keeping the old signature except possibly adding
 new optional arguments to the end.  Generally incompatible changes may only be
 made when TensorFlow's changes major versions.
 
-## GPU Support {#mult-archs}
+## GPU Support 
 
 You can implement different OpKernels and register one for CPU and another for
-GPU, just like you can [register kernels for different types](#Polymorphism).
+GPU, just like you can [register kernels for different types](#polymorphism).
 There are several examples of kernels with GPU support in
 [`tensorflow/core/kernels/`](https://tensorflow.googlesource.com/tensorflow/+/master/tensorflow/core/kernels/).
 Notice some kernels have a CPU version in a `.cc` file, a GPU version in a file
@@ -1018,7 +1018,7 @@ returns a list of
 output of the op). To register a shape function, apply the
 [`tf.RegisterShape` decorator](../../api_docs/python/framework.md#RegisterShape)
 to a shape function. For example, the
-[`ZeroOut` op defined above](#define_interface) would have a shape function like
+[`ZeroOut` op defined above](#define-the-ops-interface) would have a shape function like
 the following:
 
 ```python
@@ -1033,7 +1033,7 @@ def _zero_out_shape(op):
 ```
 
 A shape function can also constrain the shape of an input. For the version of
-[`ZeroOut` with a vector shape constraint](#Validation), the shape function
+[`ZeroOut` with a vector shape constraint](#validation), the shape function
 would be as follows:
 
 ```python
@@ -1048,7 +1048,7 @@ def _zero_out_shape(op):
   return [input_shape]
 ```
 
-If your op is [polymorphic with multiple inputs](#Polymorphism), use the
+If your op is [polymorphic with multiple inputs](#polymorphism), use the
 properties of the operation to determine the number of shapes to check:
 
 ```

--- a/tensorflow/g3doc/how_tos/new_data_formats/index.md
+++ b/tensorflow/g3doc/how_tos/new_data_formats/index.md
@@ -4,7 +4,7 @@ PREREQUISITES:
 
 *   Some familiarity with C++.
 *   Must have
-    [downloaded TensorFlow source](../../get_started/os_setup.md#source), and be
+    [downloaded TensorFlow source](../../get_started/os_setup.md#installing-from-sources), and be
     able to build it.
 
 We divide the task of supporting a file format into two pieces:

--- a/tensorflow/g3doc/how_tos/reading_data/index.md
+++ b/tensorflow/g3doc/how_tos/reading_data/index.md
@@ -10,7 +10,7 @@ There are three main methods of getting data into a TensorFlow program:
 
 [TOC]
 
-## Feeding {#Feeding}
+## Feeding 
 
 TensorFlow's feed mechanism lets you inject data into any Tensor in a
 computation graph. A python computation can thus feed data directly into the
@@ -253,7 +253,7 @@ summary to the graph that indicates how full the example queue is. If you have
 enough reading threads, that summary will stay above zero.  You can
 [view your summaries as training progresses using TensorBoard](../../how_tos/summaries_and_tensorboard/index.md).
 
-### Creating threads to prefetch using `QueueRunner` objects {#QueueRunner}
+### Creating threads to prefetch using `QueueRunner` objects 
 
 The short version: many of the `tf.train` functions listed above add
 [`QueueRunner`](../../api_docs/python/train.md#QueueRunner) objects to your

--- a/tensorflow/g3doc/resources/faq.md
+++ b/tensorflow/g3doc/resources/faq.md
@@ -170,7 +170,7 @@ available. These operations allow you to build sophisticated
 [input pipelines](../how_tos/reading_data/index.md), at the cost of making the
 TensorFlow computation somewhat more complicated. See the how-to documentation
 for
-[using `QueueRunner` objects to drive queues and readers](../how_tos/reading_data/index.md#QueueRunners)
+[using `QueueRunner` objects to drive queues and readers](../how_tos/reading_data/index.md#creating-threads-to-prefetch-using-queuerunner-objects)
 for more information on how to use them.
 
 ## Variables
@@ -241,7 +241,7 @@ to encode the batch size as a Python constant, but instead to use a symbolic
   of `tf.reduce_sum(...) / batch_size`.
 
 * If you use
-  [placeholders for feeding input](../how_tos/reading_data/index.md#Feeding),
+  [placeholders for feeding input](../how_tos/reading_data/index.md#feeding),
   you can specify a variable batch dimension by creating the placeholder with
   [`tf.placeholder(..., shape=[None, ...])`](../api_docs/python/io_ops.md#placeholder). The
   `None` element of the shape corresponds to a variable-sized dimension.
@@ -281,7 +281,7 @@ The easier option is to write parsing code in Python that transforms the data
 into a numpy array, then feed a [`tf.placeholder()`]
 (../api_docs/python/io_ops.md#placeholder) a tensor with that data. See the
 documentation on
-[using placeholders for input](../how_tos/reading_data/index.md#Feeding) for
+[using placeholders for input](../how_tos/reading_data/index.md#feeding) for
 more details. This approach is easy to get up and running, but the parsing can
 be a performance bottleneck.
 
@@ -298,7 +298,7 @@ single tensor, a list of tensors with the same type (for example when adding
 together a variable-length list of tensors), or a list of tensors with different
 types (for example when enqueuing a tuple of tensors to a queue).  See the
 how-to documentation for
-[adding an op with a list of inputs or outputs](../how_tos/adding_an_op/index.md#list-input-output)
+[adding an op with a list of inputs or outputs](../how_tos/adding_an_op/index.md#list-inputs-and-outputs)
 for more details of how to define these different input types.
 
 ## Miscellaneous

--- a/tensorflow/g3doc/tutorials/deep_cnn/index.md
+++ b/tensorflow/g3doc/tutorials/deep_cnn/index.md
@@ -105,7 +105,7 @@ adds operations that perform inference, i.e. classification, on supplied images.
 add operations that compute the loss,
 gradients, variable updates and visualization summaries.
 
-### Model Inputs {#model-inputs}
+### Model Inputs 
 
 The input part of the model is built by the functions `inputs()` and
 `distorted_inputs()` which read images from the CIFAR-10 binary data files.
@@ -143,7 +143,7 @@ processing time. To prevent these operations from slowing down training, we run
 them inside 16 separate threads which continuously fill a TensorFlow
 [queue](../../api_docs/python/io_ops.md#shuffle_batch).
 
-### Model Prediction {#model-prediction}
+### Model Prediction 
 
 The prediction part of the model is constructed by the `inference()` function
 which adds operations to compute the *logits* of the predictions. That part of
@@ -182,7 +182,7 @@ layers of Alex's original model are locally connected and not fully connected.
 Try editing the architecture to exactly reproduce the locally connected
 architecture in the top layer.
 
-### Model Training {#model-training}
+### Model Training 
 
 The usual method for training a network to perform N-way classification is
 [multinomial logistic regression](https://en.wikipedia.org/wiki/Multinomial_logistic_regression),
@@ -301,7 +301,7 @@ values.  See how the scripts use
 [`ExponentialMovingAverage`](../../api_docs/python/train.md#ExponentialMovingAverage)
 for this purpose.
 
-## Evaluating a Model {#evaluating-a-model}
+## Evaluating a Model 
 
 Let us now evaluate how well the trained model performs on a hold-out data set.
 The model is evaluated by the script `cifar10_eval.py`.  It constructs the model

--- a/tensorflow/g3doc/tutorials/seq2seq/index.md
+++ b/tensorflow/g3doc/tutorials/seq2seq/index.md
@@ -22,7 +22,7 @@ python translate.py --data_dir [your_data_directory]
 It will download English-to-French translation data from the
 [WMT'15 Website](http://www.statmt.org/wmt15/translation-task.html)
 prepare it for training and train. It takes about 20GB of disk space,
-and a while to download and prepare (see [later](#run_it) for details),
+and a while to download and prepare (see [later](#lets-run-it) for details),
 so you can start and leave it running while reading this tutorial.
 
 This tutorial references the following files from `models/rnn`.
@@ -233,7 +233,7 @@ with encoder inputs representing `[PAD PAD "." "go" "I"]` and decoder
 inputs `[GO "Je" "vais" "." EOS PAD PAD PAD PAD PAD]`.
 
 
-## Let's Run It {#run_it}
+## Let's Run It 
 
 To train the model described above, we need to a large English-French corpus.
 We will use the *10^9-French-English corpus* from the


### PR DESCRIPTION
This commit does two things:
1. Removes all '{#anchor}' syntax from Markdown header lines in the codebase
2. Replaces all links that used those #anchors with links conforming to
   Github/Tensorflow website auto-generated anchors

The work is a continuation on #648.

This commit does not change the API docs, as those Markdown files are
auto-generated.

Generated using Python script available here:
https://github.com/samjabrahams/tensorflow_util/blob/master/py/change_header_anchor_links.py

Cross-page links changed by hand using this script to find non-api
anchor links:
https://github.com/samjabrahams/tensorflow_util/blob/master/py/get_anchor_references.py
