### PR TITLE
Check if logdir already exists before trying to create it

### DIFF
--- a/tensorflow/python/training/training_util.py
+++ b/tensorflow/python/training/training_util.py
@@ -66,8 +66,9 @@ def write_graph(graph_def, logdir, name, as_text=True):
     name: Filename for the graph.
     as_text: If `True`, writes the graph as an ASCII proto.
   """
+  if not gfile.IsDirectory(logdir):
+    gfile.MakeDirs(logdir)
   path = os.path.join(logdir, name)
-  gfile.MakeDirs(os.path.dirname(path))
   f = gfile.FastGFile(path, "w")
   if as_text:
     f.write(str(graph_def))


### PR DESCRIPTION
Currently, running something like this:

`tf.train.write_graph(sess.graph_def, 'models/', 'model.pbtxt', as_text=True)`

Will fail the second time its run because it tries to create a folder that now already exists. This patch fixes that behaviour by checking if the directory exists before attempting to create it.
