### PR TITLE
Test the TensorFlow installation location using inspect

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -269,7 +269,7 @@ The exact location of the Python library depends on your system, but is usually 
 You can find out the directory with the following command:
 
 ```bash
-$ python -c 'import site; print("\n".join(site.getsitepackages()))'
+$ python -c 'import os; import inspect; import tensorflow; print(os.path.dirname(inspect.getfile(tensorflow)))'
 ```
 
 The simple demo model for classifying handwritten digits from the MNIST dataset


### PR DESCRIPTION
While testing an installation I executed `python -c 'import site; print("\n".join(site.getsitepackages()))'` from within a virtualenv environment. This raised the same error mentioned in #392.

According to pypa/virtualenv#355 this is an issue with their custom site implementation and may not be updated soon.

I updated the command in the documentation to output the directory where TensorFlow is installed using [inspect](https://docs.python.org/2/library/inspect.html).

``` python
import os
import inspect
import tensorflow

print(os.path.dirname(inspect.getfile(tensorflow)))
```

I hope this is useful.
