### PR TITLE
ci_build updates

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.android
+++ b/tensorflow/tools/ci_build/Dockerfile.android
@@ -24,31 +24,36 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Android SDK and NDK root direcotry workaround. For details see
+# https://github.com/bazelbuild/bazel/issues/714#issuecomment-166735874
+ENV ANDROID_DEV_HOME /android
+RUN mkdir -p ${ANDROID_DEV_HOME}
+
 # Install Android SDK.
 ENV ANDROID_SDK_FILENAME android-sdk_r24.4.1-linux.tgz
 ENV ANDROID_SDK_URL http://dl.google.com/android/${ANDROID_SDK_FILENAME}
 ENV ANDROID_API_LEVEL 23
 ENV ANDROID_BUILD_TOOLS_VERSION 23.0.2
-ENV ANDROID_SDK_HOME /opt/android-sdk
+ENV ANDROID_SDK_HOME ${ANDROID_DEV_HOME}/sdk
 ENV PATH ${PATH}:${ANDROID_SDK_HOME}/tools:${ANDROID_SDK_HOME}/platform-tools
-RUN cd /opt && \
+RUN cd ${ANDROID_DEV_HOME} && \
     wget -q ${ANDROID_SDK_URL} && \
     tar -xzf ${ANDROID_SDK_FILENAME} && \
     rm ${ANDROID_SDK_FILENAME} && \
-    echo y | android update sdk --no-ui -a --filter tools,platform-tools,android-${ANDROID_API_LEVEL},build-tools-${ANDROID_BUILD_TOOLS_VERSION} && \
-    bash -c 'ln -s /opt/android-sdk-* /opt/android-sdk'
+    bash -c "ln -s ${ANDROID_DEV_HOME}/android-sdk-* ${ANDROID_SDK_HOME}" && \
+    echo y | android update sdk --no-ui -a --filter tools,platform-tools,android-${ANDROID_API_LEVEL},build-tools-${ANDROID_BUILD_TOOLS_VERSION}
 
 # Install Android NDK.
 ENV ANDROID_NDK_FILENAME android-ndk-r10e-linux-x86_64.bin
 ENV ANDROID_NDK_URL http://dl.google.com/android/ndk/${ANDROID_NDK_FILENAME}
-ENV ANDROID_NDK_HOME /opt/android-ndk
+ENV ANDROID_NDK_HOME ${ANDROID_DEV_HOME}/ndk
 ENV PATH ${PATH}:${ANDROID_NDK_HOME}
-RUN cd /opt && \
+RUN cd ${ANDROID_DEV_HOME} && \
     wget -q ${ANDROID_NDK_URL} && \
     chmod +x ${ANDROID_NDK_FILENAME} && \
-    ./${ANDROID_NDK_FILENAME} -o/opt && \
+    ./${ANDROID_NDK_FILENAME} -o${ANDROID_DEV_HOME} && \
     rm ${ANDROID_NDK_FILENAME} && \
-    bash -c 'ln -s /opt/android-ndk-* /opt/android-ndk'
+    bash -c "ln -s ${ANDROID_DEV_HOME}/android-ndk-* ${ANDROID_NDK_HOME}"
 
 # Make android ndk executable to all users.
-RUN chmod -R a+rx /opt
+RUN chmod -R go=u ${ANDROID_DEV_HOME}

--- a/tensorflow/tools/ci_build/Dockerfile.android
+++ b/tensorflow/tools/ci_build/Dockerfile.android
@@ -12,6 +12,7 @@ RUN /install/install_bazel.sh
 
 # Set up bazelrc.
 COPY install/.bazelrc /root/.bazelrc
+RUN chmod 0644 /root/.bazelrc
 ENV BAZELRC /root/.bazelrc
 
 # Install extra libraries for android sdk.

--- a/tensorflow/tools/ci_build/Dockerfile.android
+++ b/tensorflow/tools/ci_build/Dockerfile.android
@@ -28,13 +28,14 @@ ENV ANDROID_SDK_FILENAME android-sdk_r24.4.1-linux.tgz
 ENV ANDROID_SDK_URL http://dl.google.com/android/${ANDROID_SDK_FILENAME}
 ENV ANDROID_API_LEVEL 23
 ENV ANDROID_BUILD_TOOLS_VERSION 23.0.2
-ENV ANDROID_HOME /opt/android-sdk-linux
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+ENV ANDROID_SDK_HOME /opt/android-sdk
+ENV PATH ${PATH}:${ANDROID_SDK_HOME}/tools:${ANDROID_SDK_HOME}/platform-tools
 RUN cd /opt && \
     wget -q ${ANDROID_SDK_URL} && \
     tar -xzf ${ANDROID_SDK_FILENAME} && \
     rm ${ANDROID_SDK_FILENAME} && \
-    echo y | android update sdk --no-ui -a --filter tools,platform-tools,android-${ANDROID_API_LEVEL},build-tools-${ANDROID_BUILD_TOOLS_VERSION}
+    echo y | android update sdk --no-ui -a --filter tools,platform-tools,android-${ANDROID_API_LEVEL},build-tools-${ANDROID_BUILD_TOOLS_VERSION} && \
+    bash -c 'ln -s /opt/android-sdk-* /opt/android-sdk'
 
 # Install Android NDK.
 ENV ANDROID_NDK_FILENAME android-ndk-r10e-linux-x86_64.bin

--- a/tensorflow/tools/ci_build/Dockerfile.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu
@@ -12,4 +12,5 @@ RUN /install/install_bazel.sh
 
 # Set up bazelrc.
 COPY install/.bazelrc /root/.bazelrc
+RUN chmod 0644 /root/.bazelrc
 ENV BAZELRC /root/.bazelrc

--- a/tensorflow/tools/ci_build/Dockerfile.gpu
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu
@@ -12,6 +12,7 @@ RUN /install/install_bazel.sh
 
 # Set up bazelrc.
 COPY install/.bazelrc /root/.bazelrc
+RUN chmod 0644 /root/.bazelrc
 ENV BAZELRC /root/.bazelrc
 
 # Set up CUDA variables

--- a/tensorflow/tools/ci_build/builds/android.sh
+++ b/tensorflow/tools/ci_build/builds/android.sh
@@ -30,7 +30,7 @@ if grep -q '^android_sdk_repository' WORKSPACE && grep -q '^android_ndk_reposito
   echo "You probably have your WORKSPACE file setup for Android."
 else
   if [ -z "${ANDROID_API_LEVEL}" -o -z "${ANDROID_BUILD_TOOLS_VERSION}" ] || \
-      [ -z "${ANDROID_HOME}" -o -z "${ANDROID_NDK_HOME}" ]; then
+      [ -z "${ANDROID_SDK_HOME}" -o -z "${ANDROID_NDK_HOME}" ]; then
     echo "ERROR: Your WORKSPACE file does not seems to have proper android"
     echo "       configuration and not all the environment variables expected"
     echo "       inside ci_build android docker container are set."
@@ -41,7 +41,7 @@ android_sdk_repository(
     name = "androidsdk",
     api_level = ${ANDROID_API_LEVEL},
     build_tools_version = "${ANDROID_BUILD_TOOLS_VERSION}",
-    path = "${ANDROID_HOME}",
+    path = "${ANDROID_SDK_HOME}",
 )
 
 android_ndk_repository(

--- a/tensorflow/tools/ci_build/builds/with_the_same_user
+++ b/tensorflow/tools/ci_build/builds/with_the_same_user
@@ -29,7 +29,4 @@ addgroup --gid $CI_BUILD_GID $CI_BUILD_GROUP
 adduser --gid $CI_BUILD_GID --uid $CI_BUILD_UID --disabled-password \
     --home $CI_BUILD_HOME --quiet $CI_BUILD_USER
 
-cp /root/.bazelrc $CI_BUILD_HOME/.bazelrc
-chown $CI_BUILD_USER:$CI_BUILD_GROUP $CI_BUILD_HOME/.bazelrc
-
 sudo -u $CI_BUILD_USER --preserve-env -H ${COMMAND[@]}

--- a/tensorflow/tools/ci_build/ci_build.sh
+++ b/tensorflow/tools/ci_build/ci_build.sh
@@ -67,6 +67,7 @@ docker build -t ${BUILD_TAG}.${CONTAINER_TYPE} \
 echo "Running '${COMMAND[@]}' inside ${BUILD_TAG}.${CONTAINER_TYPE}..."
 mkdir -p ${WORKSPACE}/bazel-ci_build-cache
 docker run \
+    --rm \
     -v ${WORKSPACE}/bazel-ci_build-cache:${WORKSPACE}/bazel-ci_build-cache \
     -e "CI_BUILD_HOME=${WORKSPACE}/bazel-ci_build-cache" \
     -e "CI_BUILD_USER=${USER}" \

--- a/tensorflow/tools/ci_build/install/install_bazel.sh
+++ b/tensorflow/tools/ci_build/install/install_bazel.sh
@@ -23,7 +23,6 @@ BAZEL_VERSION="0.1.1"
 mkdir /bazel
 cd /bazel
 curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
-curl -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE.txt
 chmod +x /bazel/bazel-*.sh
 /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
 rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh


### PR DESCRIPTION
A few ci_build changes:
- add the `--rm` for `docker run` to decrease the number of docker images on a machine and avoid problems we have run into
- workaround problem newer bazel have with android ndk
- cleanups
