### PR TITLE
ConcatOp error text change

### DIFF
--- a/tensorflow/core/kernels/concat_op.cc
+++ b/tensorflow/core/kernels/concat_op.cc
@@ -60,7 +60,7 @@ class ConcatOp : public OpKernel {
                (kAllowLegacyScalars && concat_dim == 0),
         errors::InvalidArgument(
             "ConcatOp : Expected concatenating dimensions in the range [", 0,
-            ", ", input_dims, "), but got ", concat_dim));
+            ", ", input_dims, "], but got ", concat_dim));
 
     // Note that we reduce the concat of n-dimensional tensors into a two
     // dimensional concat. Assuming the dimensions of any input/output


### PR DESCRIPTION
I think this message was meant to be ended with a `]` but I am uncertain if that notation is clear.

Before this change, the script:

``` python
import tensorflow as tf

with tf.Session() as sess:
    sess.run(tf.concat(0, [1, 2, 3]))
```

Throws the following exception:

> InvalidArgumentError: ConcatOp : Expected concatenating dimensions in the range [0, 0**)**, but got 0

After this change the output is:

> InvalidArgumentError: ConcatOp : Expected concatenating dimensions in the range [0, 0**]***, but got 0
