### PR TITLE
CSV file loading example using pack

### DIFF
--- a/tensorflow/g3doc/how_tos/reading_data/index.md
+++ b/tensorflow/g3doc/how_tos/reading_data/index.md
@@ -99,7 +99,7 @@ key, value = reader.read(filename_queue)
 record_defaults = [[1], [1], [1], [1], [1]]
 col1, col2, col3, col4, col5 = tf.decode_csv(
     value, record_defaults=record_defaults)
-features = tf.concat(0, [col1, col2, col3, col4])
+features = tf.pack([col1, col2, col3, col4])
 
 with tf.Session() as sess:
   # Start populating the filename queue.


### PR DESCRIPTION
[The example code to read CSV files](https://www.tensorflow.org/versions/master/how_tos/reading_data/index.html#csv-files) raised the exception:

> tensorflow.python.framework.errors.InvalidArgumentError: ConcatOp : Expected concatenating dimensions in the range [0, 0), but got 0

The CSV files contents were:

``` csv
5,4,3,2,1
```

Updated the documentation to use [tf.pack](https://www.tensorflow.org/versions/master/api_docs/python/array_ops.html#pack) for the same reasons mentioned in [this stack overflow answer](http://stackoverflow.com/a/33686790/1589147).

This change might be irrelevant due to any updates on #278.
