### PR TITLE
ci_build: improve user handling inside the container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 /bazel-bin
+/bazel-ci_build-cache
 /bazel-genfiles
 /bazel-out
 /bazel-tensorflow

--- a/tensorflow/tools/ci_build/Dockerfile.android
+++ b/tensorflow/tools/ci_build/Dockerfile.android
@@ -12,7 +12,6 @@ RUN /install/install_bazel.sh
 
 # Set up bazelrc.
 COPY install/.bazelrc /root/.bazelrc
-RUN chmod 0644 /root/.bazelrc
 ENV BAZELRC /root/.bazelrc
 
 # Install extra libraries for android sdk.

--- a/tensorflow/tools/ci_build/Dockerfile.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu
@@ -12,5 +12,4 @@ RUN /install/install_bazel.sh
 
 # Set up bazelrc.
 COPY install/.bazelrc /root/.bazelrc
-RUN chmod 0644 /root/.bazelrc
 ENV BAZELRC /root/.bazelrc

--- a/tensorflow/tools/ci_build/Dockerfile.gpu
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu
@@ -12,7 +12,6 @@ RUN /install/install_bazel.sh
 
 # Set up bazelrc.
 COPY install/.bazelrc /root/.bazelrc
-RUN chmod 0644 /root/.bazelrc
 ENV BAZELRC /root/.bazelrc
 
 # Set up CUDA variables

--- a/tensorflow/tools/ci_build/builds/with_the_same_user
+++ b/tensorflow/tools/ci_build/builds/with_the_same_user
@@ -25,8 +25,11 @@ set -e
 
 COMMAND=("$@")
 
-addgroup --gid $CI_BUILD_GID $CI_BUILD_GROUP
-adduser --gid $CI_BUILD_GID --uid $CI_BUILD_UID --disabled-password \
-    --home $CI_BUILD_HOME --quiet $CI_BUILD_USER
+getent group "${CI_BUILD_GID}" || addgroup --gid "${CI_BUILD_GID}" "${CI_BUILD_GROUP}"
+getent passwd "${CI_BUILD_UID}" || adduser --gid "${CI_BUILD_GID}" --uid "${CI_BUILD_UID}" \
+    --disabled-password --home "${CI_BUILD_HOME}" --quiet "${CI_BUILD_USER}"
 
-sudo -u $CI_BUILD_USER --preserve-env -H ${COMMAND[@]}
+cp /root/.bazelrc "${CI_BUILD_HOME}/.bazelrc"
+chown "${CI_BUILD_UID}:${CI_BUILD_GID}" "${CI_BUILD_HOME}/.bazelrc"
+
+sudo -u "#${CI_BUILD_UID}" --preserve-env -H "${COMMAND[@]}"

--- a/tensorflow/tools/ci_build/ci_build.sh
+++ b/tensorflow/tools/ci_build/ci_build.sh
@@ -76,7 +76,9 @@ docker run \
     -e "CI_BUILD_GID=$(id -g $USER)" \
     -v ${WORKSPACE}:/tensorflow \
     -w /tensorflow \
-    ${BUILD_TAG}.${CONTAINER_TYPE} \
+    "${CI_BUILD_DOCKER_RUN_EXTRA_PARAMETERS[@]}" \
+    "${BUILD_TAG}.${CONTAINER_TYPE}" \
+    "${CI_BUILD_DOCKER_RUN_COMMAND_PREFIX[@]}" \
     "tensorflow/tools/ci_build/builds/with_the_same_user" \
         "tensorflow/tools/ci_build/builds/configured" \
         "${CONTAINER_TYPE}" "${COMMAND[@]}"


### PR DESCRIPTION
- create user home with .bazelrc (this is needed for slaves)
- create and use user based on uid instead of user name
- add bazel-ci_build-cache to .gitignore
- add optional extra ci build parameters (this is good for hacky jobs like git bisect for bazel)
