### PR TITLE
Adding Python 3 support to Tensorboard

### DIFF
--- a/tensorflow/tensorboard/tensorboard.py
+++ b/tensorflow/tensorboard/tensorboard.py
@@ -22,11 +22,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import BaseHTTPServer
+from six.moves import BaseHTTPServer
 import functools
 import os
 import socket
-import SocketServer
+from six.moves import socketserver
 
 import tensorflow.python.platform
 
@@ -112,7 +112,7 @@ def ParseEventFilesFlag(flag_value):
   return files
 
 
-class ThreadedHTTPServer(SocketServer.ThreadingMixIn,
+class ThreadedHTTPServer(socketserver.ThreadingMixIn,
                          BaseHTTPServer.HTTPServer):
   """A threaded HTTP server."""
   daemon = True


### PR DESCRIPTION
This PR implements Python 3 support into Tensorboard in a portable way, by importing packages from six when possible and converting strings into the correct encoding whenever necessary.
