### PR TITLE
Adds GPU CUDA kernel for scatter ops

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,6 +33,8 @@
   maintained for short-term compatibility but will be removed.
 * The non-public `nn.rnn` and the various `nn.seq2seq` methods now return
   just the final state instead of the list of all states.
+* `tf.scatter_update` now no longer guarantees that lexicographically largest
+  index be used for update when duplicate entires exist.
 
 
 ## Bug fixes

--- a/tensorflow/core/kernels/scatter_op.cc
+++ b/tensorflow/core/kernels/scatter_op.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 // See docs in ../ops/state_ops.cc.
 
+#include "tensorflow/core/kernels/scatter_op.h"
+
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -23,33 +25,38 @@ limitations under the License.
 
 namespace tensorflow {
 
-enum class UpdateOp { ASSIGN, ADD, SUB };
+typedef Eigen::ThreadPoolDevice CPUDevice;
+typedef Eigen::GpuDevice GPUDevice;
 
-template <UpdateOp Op>
+namespace {
+
+template <scatter_op::UpdateOp Op>
 struct Assign {};
 template <>
-struct Assign<UpdateOp::ASSIGN> {
+struct Assign<scatter_op::UpdateOp::ASSIGN> {
   template <typename Params, typename Update>
   static void Run(Params p, Update u) {
     p = u;
   }
 };
 template <>
-struct Assign<UpdateOp::ADD> {
+struct Assign<scatter_op::UpdateOp::ADD> {
   template <typename Params, typename Update>
   static void Run(Params p, Update u) {
     p += u;
   }
 };
 template <>
-struct Assign<UpdateOp::SUB> {
+struct Assign<scatter_op::UpdateOp::SUB> {
   template <typename Params, typename Update>
   static void Run(Params p, Update u) {
     p -= u;
   }
 };
 
-template <class T, typename Index, UpdateOp op>
+}  // namespace
+
+template <typename Device, typename T, typename Index, scatter_op::UpdateOp op>
 class ScatterUpdateOp : public OpKernel {
  public:
   //   QUESTION: It'd be nice to support DT_INT16, DT_UINT8,
@@ -108,85 +115,136 @@ class ScatterUpdateOp : public OpKernel {
             "updates.shape ", Tupdates.shape().DebugString(),
             ", indices.shape ", Tindices.shape().DebugString(),
             ", params.shape ", Tparams.shape().DebugString()));
-    const Index N = Tindices.NumElements();
 
     // We always return the input ref.
     c->forward_ref_input_to_ref_output(0, 0);
 
+    const Index N = Tindices.NumElements();
     if (N > 0) {
-      const Index first_dim_size = Tparams.dim_size(0);
-      // Validate all the indices are in range
-      auto Tindices_vec = Tindices.flat<Index>();
-      for (Index i = 0; i < N; i++) {
-        const Index index = Tindices_vec(i);
-        OP_REQUIRES(c, index >= 0 && index < first_dim_size,
-                    errors::InvalidArgument(
-                        strings::StrCat("Index ", index, " at offset ", i,
-                                        " in indices is out of range")));
-      }
+      auto Tindices_flat = Tindices.flat<Index>();
       auto Tparams_flat = Tparams.flat_outer_dims<T>();
       auto Tupdates_flat =
           Tupdates.shaped<T, 2>({N, Tupdates.NumElements() / N});
-      for (Index i = 0; i < N; i++) {
-        // Copy last Ndim-1 dimensions of Tupdates[i] to
-        // Tparams[Tindices[i]]
-        Assign<op>::Run(Tparams_flat.template chip<0>(Tindices_vec(i)),
-                        Tupdates_flat.template chip<0>(i));
-      }
+
+      functor::ScatterFunctor<Device, T, Index, op> functor;
+      functor(c, c->template eigen_device<Device>(),
+              Tparams_flat, Tupdates_flat, Tindices_flat);
     }
   }
 };
 
-#define REGISTER_SCATTER_UPDATE(type, index_type)  \
-  REGISTER_KERNEL_BUILDER(                         \
-      Name("ScatterUpdate")                        \
-          .Device(DEVICE_CPU)                      \
-          .TypeConstraint<type>("T")               \
-          .TypeConstraint<index_type>("Tindices"), \
-      ScatterUpdateOp<type, index_type, UpdateOp::ASSIGN>);
+namespace functor {
+// Implementation of update functor for CPU.
+template <typename T, typename Index, scatter_op::UpdateOp op>
+struct ScatterFunctor<CPUDevice, T, Index, op> {
+  void operator()(OpKernelContext* c, const CPUDevice& d,
+                  typename TTypes<T>::Matrix params,
+                  typename TTypes<T>::ConstMatrix updates,
+                  typename TTypes<Index>::ConstFlat indices) {
+    Index N = indices.size();
+    // Validate all the indices are in range
+    Index first_dim_size = params.dimension(0);
+    for (Index i = 0; i < N; i++) {
+      const Index index = indices(i);
+      OP_REQUIRES(c, index >= 0 && index < first_dim_size,
+                  errors::InvalidArgument(
+                      strings::StrCat("Index ", index, " at offset ", i,
+                                      " in indices is out of range")));
+    }
+    for (Index i = 0; i < N; i++) {
+      // Copy last Ndim-1 dimensions of Tupdates[i] to
+      // Tparams[Tindices[i]]
+      Assign<op>::Run(params.template chip<0>(indices(i)),
+                      updates.template chip<0>(i));
+    }
+  }
+};
+}  // namespace functor
 
-#define REGISTER_SCATTER_UPDATE_INT32(type) REGISTER_SCATTER_UPDATE(type, int32)
-#define REGISTER_SCATTER_UPDATE_INT64(type) REGISTER_SCATTER_UPDATE(type, int64)
+#define REGISTER_SCATTER_KERNEL_INDEX(type, index_type, dev, name, op)  \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name(name)                                                        \
+      .Device(DEVICE_##dev)                                             \
+      .TypeConstraint<type>("T")                                        \
+      .TypeConstraint<index_type>("Tindices"),                          \
+      ScatterUpdateOp<dev##Device, type, index_type, op>)
 
-TF_CALL_ALL_TYPES(REGISTER_SCATTER_UPDATE_INT32);
-TF_CALL_ALL_TYPES(REGISTER_SCATTER_UPDATE_INT64);
+#define REGISTER_SCATTER_KERNEL(type, dev, name, op)            \
+  REGISTER_SCATTER_KERNEL_INDEX(type, int32, dev, name, op);    \
+  REGISTER_SCATTER_KERNEL_INDEX(type, int64, dev, name, op);
 
-#undef REGISTER_SCATTER_UPDATE_INT64
-#undef REGISTER_SCATTER_UPDATE_INT32
-#undef REGISTER_SCATTER_UPDATE
+#define REGISTER_SCATTER_ADD_SUB(type, dev)                 \
+  REGISTER_SCATTER_KERNEL(                                  \
+      type, dev, "ScatterAdd", scatter_op::UpdateOp::ADD);  \
+  REGISTER_SCATTER_KERNEL(                                  \
+      type, dev, "ScatterSub", scatter_op::UpdateOp::SUB);
 
-#define REGISTER_SCATTER_ADD(type, index_type)                         \
-  REGISTER_KERNEL_BUILDER(Name("ScatterAdd")                           \
-                              .Device(DEVICE_CPU)                      \
-                              .TypeConstraint<type>("T")               \
-                              .TypeConstraint<index_type>("Tindices"), \
-                          ScatterUpdateOp<type, index_type, UpdateOp::ADD>);
+#define REGISTER_SCATTER_UPDATE(type, dev)                  \
+  REGISTER_SCATTER_KERNEL(                                  \
+      type, dev, "ScatterUpdate", scatter_op::UpdateOp::ASSIGN);
 
-#define REGISTER_SCATTER_ADD_INT32(type) REGISTER_SCATTER_ADD(type, int32)
-#define REGISTER_SCATTER_ADD_INT64(type) REGISTER_SCATTER_ADD(type, int64)
+// Registers CPU kernels.
+#define REGISTER_SCATTER_ADD_SUB_CPU(type)      \
+  REGISTER_SCATTER_ADD_SUB(type, CPU);
 
-TF_CALL_NUMBER_TYPES(REGISTER_SCATTER_ADD_INT32);
-TF_CALL_NUMBER_TYPES(REGISTER_SCATTER_ADD_INT64);
+#define REGISTER_SCATTER_UPDATE_CPU(type)       \
+  REGISTER_SCATTER_UPDATE(type, CPU);
 
-#undef REGISTER_SCATTER_ADD_INT32
-#undef REGISTER_SCATTER_ADD_INT64
+TF_CALL_NUMBER_TYPES(REGISTER_SCATTER_ADD_SUB_CPU);
+TF_CALL_ALL_TYPES(REGISTER_SCATTER_UPDATE_CPU);
+
+// Registers GPU kernels.
+#if GOOGLE_CUDA
+#define REGISTER_SCATTER_ADD_SUB_GPU(type)      \
+  REGISTER_SCATTER_ADD_SUB(type, GPU);
+
+#define REGISTER_SCATTER_UPDATE_GPU(type)       \
+  REGISTER_SCATTER_UPDATE(type, GPU);
+
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_SCATTER_ADD_SUB_GPU);
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_SCATTER_UPDATE_GPU);
+
+#endif  // GOOGLE_CUDA
+
 #undef REGISTER_SCATTER_ADD
+#undef REGISTER_SCATTER_ADD_SUB
+#undef REGISTER_SCATTER_ADD_SUB_CPU
+#undef REGISTER_SCATTER_ADD_SUB_GPU
+#undef REGISTER_SCATTER_UPDATE
+#undef REGISTER_SCATTER_UPDATE_CPU
+#undef REGISTER_SCATTER_UPDATE_GPU
+#undef REGISTER_SCATTER_KERNEL
+#undef REGISTER_SCATTER_KERNEL_INDEX
 
-#define REGISTER_SCATTER_SUB(type, index_type)                         \
-  REGISTER_KERNEL_BUILDER(Name("ScatterSub")                           \
-                              .Device(DEVICE_CPU)                      \
-                              .TypeConstraint<type>("T")               \
-                              .TypeConstraint<index_type>("Tindices"), \
-                          ScatterUpdateOp<type, index_type, UpdateOp::SUB>);
+#if GOOGLE_CUDA
+// Forward declarations of the functor specializations for GPU.
+namespace functor {
 
-#define REGISTER_SCATTER_SUB_INT32(type) REGISTER_SCATTER_SUB(type, int32)
-#define REGISTER_SCATTER_SUB_INT64(type) REGISTER_SCATTER_SUB(type, int64)
+#define DECLARE_GPU_SPECS_OP(T, Index, op)                              \
+  template <>                                                           \
+  void ScatterFunctor<GPUDevice, T, Index, op>::operator()(             \
+      OpKernelContext* c, const GPUDevice& d,                           \
+      typename TTypes<T>::Matrix params,                                \
+      typename TTypes<T>::ConstMatrix updates,                          \
+      typename TTypes<Index>::ConstFlat indices);                       \
+  extern template struct ScatterFunctor<GPUDevice, T, Index, op>;
 
-TF_CALL_NUMBER_TYPES(REGISTER_SCATTER_SUB_INT32);
-TF_CALL_NUMBER_TYPES(REGISTER_SCATTER_SUB_INT64);
+#define DECLARE_GPU_SPECS_INDEX(T, Index)                       \
+  DECLARE_GPU_SPECS_OP(T, Index, scatter_op::UpdateOp::ASSIGN); \
+  DECLARE_GPU_SPECS_OP(T, Index, scatter_op::UpdateOp::ADD);    \
+  DECLARE_GPU_SPECS_OP(T, Index, scatter_op::UpdateOp::SUB);
 
-#undef REGISTER_SCATTER_SUB_INT64
-#undef REGISTER_SCATTER_SUB_INT32
-#undef REGISTER_SCATTER_SUB
+#define DECLARE_GPU_SPECS(T)                    \
+  DECLARE_GPU_SPECS_INDEX(T, int32);            \
+  DECLARE_GPU_SPECS_INDEX(T, int64);
+
+TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPECS);
+
+#undef DECLARE_GPU_SPECS
+#undef DECLARE_GPU_SPECS_INDEX
+#undef DECLARE_GPU_SPECS_OP
+
+}  // namespace functor
+#endif  // GOOGLE_CUDA
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/scatter_op.h
+++ b/tensorflow/core/kernels/scatter_op.h
@@ -1,0 +1,48 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_KERNELS_SCATTER_OP_H_
+#define TENSORFLOW_KERNELS_SCATTER_OP_H_
+
+// Functor definitions for Scatter ops, must be compilable by nvcc.
+
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "tensorflow/core/framework/tensor_types.h"
+
+namespace tensorflow {
+
+class OpKernelContext;
+
+namespace scatter_op {
+
+enum class UpdateOp { ASSIGN, ADD, SUB };
+
+}  // namespace scatter_op
+
+namespace functor {
+
+// Functor used by ScatterOp to do the computations.
+template <typename Device, typename T, typename Index, scatter_op::UpdateOp op>
+struct ScatterFunctor {
+  void operator()(OpKernelContext* c, const Device& d,
+                  typename TTypes<T>::Matrix params,
+                  typename TTypes<T>::ConstMatrix updates,
+                  typename TTypes<Index>::ConstFlat indices);
+};
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_KERNELS_SCATTER_OP_H_

--- a/tensorflow/core/kernels/scatter_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/scatter_op_gpu.cu.cc
@@ -1,0 +1,108 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA
+
+#define EIGEN_USE_GPU
+
+#include "tensorflow/core/kernels/scatter_op.h"
+
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/cuda_kernel_helper.h"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+template <typename T, typename Index, scatter_op::UpdateOp op>
+__global__ void ScatterOpCustomKernel(
+    T* params, const T* updates, const Index* indices,
+    Index first_dim_size, Index updates_size, Index indices_size) {
+  Index update_block = updates_size / indices_size;
+  CUDA_1D_KERNEL_LOOP(i, updates_size) {
+    int indices_i = i / update_block;
+    int updates_i = i;
+    int param_first_index = indices[indices_i];
+    if (!(param_first_index >= 0 && param_first_index < first_dim_size)) {
+      // Ignore indices that are out of range.
+      continue;
+    }
+    int params_i = param_first_index * update_block + (i % update_block);
+    switch (op) {
+      case scatter_op::UpdateOp::ASSIGN: {
+        params[params_i] = ldg(updates + updates_i);
+        break;
+      }
+      case scatter_op::UpdateOp::ADD: {
+        CudaAtomicAdd(params + params_i, ldg(updates + updates_i));
+        break;
+      }
+      case scatter_op::UpdateOp::SUB: {
+        CudaAtomicSub(params + params_i, ldg(updates + updates_i));
+        break;
+      }
+    }
+  }
+}
+
+namespace functor {
+// Specialization for a GPU device.
+template <typename T, typename Index, scatter_op::UpdateOp op>
+struct ScatterFunctor<GPUDevice, T, Index, op> {
+  void operator()(OpKernelContext* c, const GPUDevice& d,
+                  typename TTypes<T>::Matrix params,
+                  typename TTypes<T>::ConstMatrix updates,
+                  typename TTypes<Index>::ConstFlat indices) {
+    // TODO: Implement indices range check.  The hardest part is with returning
+    // a value after the range check, as we do not want to do device to host
+    // memcpy during a stream.
+    const Index first_dim_size = params.dimension(0);
+    const Index indices_size = indices.size();
+    const Index updates_size = updates.size();
+    CudaLaunchConfig config = GetCudaLaunchConfig(updates_size, d);
+    ScatterOpCustomKernel<T,Index,op>
+        <<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
+            params.data(), updates.data(), indices.data(),
+            first_dim_size, updates_size, indices_size);
+  }
+};
+
+}  // namespace functor
+
+#define DEFINE_GPU_SPECS_OP(T, Index, op)                               \
+  template struct functor::ScatterFunctor<GPUDevice, T, Index, op>;
+
+#define DEFINE_GPU_SPECS_INDEX(T, Index)                        \
+  DEFINE_GPU_SPECS_OP(T, Index, scatter_op::UpdateOp::ASSIGN);  \
+  DEFINE_GPU_SPECS_OP(T, Index, scatter_op::UpdateOp::ADD);     \
+  DEFINE_GPU_SPECS_OP(T, Index, scatter_op::UpdateOp::SUB);
+
+#define DEFINE_GPU_SPECS(T)                     \
+  DEFINE_GPU_SPECS_INDEX(T, int32);             \
+  DEFINE_GPU_SPECS_INDEX(T, int64);
+
+DEFINE_GPU_SPECS(float);
+DEFINE_GPU_SPECS(double);
+// TODO: The following fails to compile.
+// TF_CALL_GPU_NUMBER_TYPES(DEFINE_GPU_SPECS);
+
+#undef DEFINE_GPU_SPECS
+#undef DEFINE_GPU_SPECS_INDEX
+#undef DEFINE_GPU_SPECS_OP
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA

--- a/tensorflow/core/kernels/scatter_op_test.cc
+++ b/tensorflow/core/kernels/scatter_op_test.cc
@@ -243,6 +243,7 @@ static void BM_ScatterHelper(int iters, int embedding_size, const char* op) {
   testing::StopTiming();
   const int kRows = 10000000 / embedding_size;
   std::vector<float> values;
+  values.reserve(kRows);
   for (int i = 0; i < kRows * embedding_size; i++) {
     values.push_back(i);
   }
@@ -270,6 +271,7 @@ static void BM_ScatterHelper(int iters, int embedding_size, const char* op) {
   while (iters-- > 0) {
     Status s = bm.RunOpKernel();
   }
+  testing::StopTiming();
 }
 
 static void BM_ScatterUpdateInt32(int iters, int embedding_size) {

--- a/tensorflow/core/ops/state_ops.cc
+++ b/tensorflow/core/ops/state_ops.cc
@@ -182,8 +182,9 @@ This operation computes
 This operation outputs `ref` after the update is done.
 This makes it easier to chain operations that need to use the reset value.
 
-If `indices` contains duplicate entries, lexicographically later entries
-override earlier entries.
+If values in `ref` is to be updated more than once, because there are
+duplicate entires in `indices`, the order at which the updates happen
+for each value is undefined.
 
 Requires `updates.shape = indices.shape + ref.shape[1:]`.
 

--- a/tensorflow/core/util/cuda_kernel_helper.h
+++ b/tensorflow/core/util/cuda_kernel_helper.h
@@ -20,6 +20,8 @@ limitations under the License.
 
 #include <algorithm>
 
+#include "tensorflow/core/platform/types.h"
+
 #define CUDA_1D_KERNEL_LOOP(i, n)                            \
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < n; \
        i += blockDim.x * gridDim.x)
@@ -68,6 +70,58 @@ __device__ __host__ inline T ldg(const T* address) {
   return *address;
 #endif
 }
+
+// CUDA provides atomic ops, but not for all types.  We provide wrappers
+// for some ops and provide implementation for all reasonable types.
+#define CUDA_ATOMIC_WRAPPER(op, T)                                      \
+  __device__ __forceinline__ T CudaAtomic##op(T* address, T val)
+
+#define USE_CUDA_ATOMIC(op, T)       \
+  CUDA_ATOMIC_WRAPPER(op, T) {       \
+    return atomic##op(address, val); \
+  }
+
+// For atomicAdd.
+USE_CUDA_ATOMIC(Add, int32);
+USE_CUDA_ATOMIC(Add, uint32);
+USE_CUDA_ATOMIC(Add, uint64);
+USE_CUDA_ATOMIC(Add, float);
+
+// Custom implementation of atomicAdd for double.
+// This implementation is copied from CUDA manual.
+CUDA_ATOMIC_WRAPPER(Add, double) {
+  uint64* address_as_ull = (uint64*)address;
+  uint64 old = *address_as_ull, assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    __double_as_longlong(val + __longlong_as_double(assumed)));
+
+    // Note: uses integer comparison to avoid hang in case of NaN
+  } while (assumed != old);
+
+  return __longlong_as_double(old);
+}
+
+// For atomicSub.
+USE_CUDA_ATOMIC(Sub, int32);
+USE_CUDA_ATOMIC(Sub, uint32);
+
+// Custom implementation of the rest by just negating the value.
+#define WRAPPED_ATOMIC_SUB(T)                       \
+  CUDA_ATOMIC_WRAPPER(Sub, T) {                     \
+    return CudaAtomicAdd(address, -val);            \
+  }
+
+WRAPPED_ATOMIC_SUB(uint64);
+WRAPPED_ATOMIC_SUB(float);
+WRAPPED_ATOMIC_SUB(double);
+
+#undef WRAPPED_ATOMIC_SUB
+
+#undef USE_CUDA_ATOMIC
+#undef CUDA_ATOMIC_WRAPPER
 
 }  // namespace tensorflow
 

--- a/tensorflow/python/kernel_tests/scatter_ops_test.py
+++ b/tensorflow/python/kernel_tests/scatter_ops_test.py
@@ -24,47 +24,89 @@ import numpy as np
 import tensorflow as tf
 
 
+def _AsType(v, vtype):
+  return v.astype(vtype) if isinstance(v, np.ndarray) else vtype(v)
+
+
+def _NumpyAdd(ref, indices, updates):
+  # Since numpy advanced assignment does not support repeated indices,
+  # we run a simple loop to perform scatter_add.
+  for i, indx in np.ndenumerate(indices):
+    ref[indx] += updates[i]
+
+
+def _NumpySub(ref, indices, updates):
+  for i, indx in np.ndenumerate(indices):
+    ref[indx] -= updates[i]
+
+
 class ScatterTest(tf.test.TestCase):
 
-  def _VariableRankTest(self, np_scatter, tf_scatter):
+  def _VariableRankTest(self, np_scatter, tf_scatter, vtype, itype, use_gpu,
+                        repeat_indices=False):
     np.random.seed(8)
-    with self.test_session():
-      for indices_shape in (), (2,), (2, 3), (2, 3, 4):
-        for extra_shape in (), (5,), (5, 6):
+    with self.test_session(use_gpu=use_gpu):
+      for indices_shape in (), (2,), (3, 7), (3, 4, 7):
+        for extra_shape in (), (5,), (5, 9):
           # Generate random indices with no duplicates for easy numpy comparison
-          size = np.prod(indices_shape, dtype=np.int32)
-          indices = np.arange(2 * size)
+          size = np.prod(indices_shape, dtype=itype)
+          first_dim = 3 * size
+          indices = np.arange(first_dim)
           np.random.shuffle(indices)
-          indices = indices[:size].reshape(indices_shape)
-          updates = np.random.randn(*(indices_shape + extra_shape))
-          old = np.random.randn(*((2 * size,) + extra_shape))
-        # Scatter via numpy
-        new = old.copy()
-        np_scatter(new, indices, updates)
-        # Scatter via tensorflow
-        ref = tf.Variable(old)
-        ref.initializer.run()
-        tf_scatter(ref, indices, updates).eval()
-        # Compare
-        self.assertAllClose(ref.eval(), new)
+          indices = indices[:size]
+          if size > 1 and repeat_indices:
+            # Add some random repeats.
+            indices = indices[:size//2]
+            for _ in xrange(size-size//2):
+              # Randomly append some repeats.
+              indices = np.append(indices, indices[np.random.randint(size//2)])
+            np.random.shuffle(indices)
+          indices = indices.reshape(indices_shape)
+          updates = _AsType(np.random.randn(*(indices_shape + extra_shape)),
+                            vtype)
+          old = _AsType(np.random.randn(*((first_dim,) + extra_shape)), vtype)
+
+          # Scatter via numpy
+          new = old.copy()
+          np_scatter(new, indices, updates)
+          # Scatter via tensorflow
+          ref = tf.Variable(old)
+          ref.initializer.run()
+          tf_scatter(ref, indices, updates).eval()
+          # Compare
+          self.assertAllClose(ref.eval(), new)
+
+  def _VariableRankTests(self, np_scatter, tf_scatter):
+    for vtype in (np.float32, np.float64):
+      for itype in (np.int32, np.int64):
+        for use_gpu in (False, True):
+          self._VariableRankTest(np_scatter, tf_scatter, vtype, itype, use_gpu)
 
   def testVariableRankUpdate(self):
     def update(ref, indices, updates):
       ref[indices] = updates
-    self._VariableRankTest(update, tf.scatter_update)
+    self._VariableRankTests(update, tf.scatter_update)
 
   def testVariableRankAdd(self):
-    def add(ref, indices, updates):
-      ref[indices] += updates
-    self._VariableRankTest(add, tf.scatter_add)
+    self._VariableRankTests(_NumpyAdd, tf.scatter_add)
 
   def testVariableRankSub(self):
-    def sub(ref, indices, updates):
-      ref[indices] -= updates
-    self._VariableRankTest(sub, tf.scatter_sub)
+    self._VariableRankTests(_NumpySub, tf.scatter_sub)
+
+  def _ScatterRepeatIndicesTest(self, np_scatter, tf_scatter):
+    for vtype in (np.float32, np.float64):
+      for itype in (np.int32, np.int64):
+        for use_gpu in (False, True):
+          self._VariableRankTest(np_scatter, tf_scatter, vtype, itype, use_gpu,
+                                 repeat_indices=True)
+
+  def testScatterRepeatIndices(self):
+    """This tests scatter_add using indices that repeat."""
+    self._ScatterRepeatIndicesTest(_NumpyAdd, tf.scatter_add)
+    self._ScatterRepeatIndicesTest(_NumpySub, tf.scatter_sub)
 
   def testBooleanScatterUpdate(self):
-    with self.test_session() as session:
+    with self.test_session(use_gpu=False) as session:
       var = tf.Variable([True, False])
       update0 = tf.scatter_update(var, 1, True)
       update1 = tf.scatter_update(var, tf.constant(0, dtype=tf.int64), False)
@@ -73,6 +115,50 @@ class ScatterTest(tf.test.TestCase):
       session.run([update0, update1])
 
       self.assertAllEqual([False, True], var.eval())
+
+  def testScatterOutOfRangeCpu(self):
+    for op in (tf.scatter_add, tf.scatter_sub, tf.scatter_update):
+      params = np.array([1, 2, 3, 4, 5, 6]).astype(np.float32)
+      updates = np.array([-3, -4, -5]).astype(np.float32)
+      with self.test_session(use_gpu=False):
+        ref = tf.Variable(params)
+        ref.initializer.run()
+
+        # Indices all in range, no problem.
+        indices = np.array([2, 0, 5])
+        op(ref, indices, updates).eval()
+
+        # Test some out of range errors.
+        indices = np.array([-1, 0, 5])
+        with self.assertRaisesOpError('indices is out of range'):
+          op(ref, indices, updates).eval()
+
+        indices = np.array([2, 0, 6])
+        with self.assertRaisesOpError('indices is out of range'):
+          op(ref, indices, updates).eval()
+
+  # TODO(fpmc): Re-enable this test when gpu_pip test actually runs on a GPU.
+  def _disabledTestScatterOutOfRangeGpu(self):
+    if not tf.test.IsBuiltWithCuda():
+      return
+    for op in (tf.scatter_add, tf.scatter_sub, tf.scatter_update):
+      params = np.array([1, 2, 3, 4, 5, 6]).astype(np.float32)
+      updates = np.array([-3, -4, -5]).astype(np.float32)
+      # With GPU, the code ignores indices that are out of range.
+      # We don't test the implementation; just test there's no failures.
+      with self.test_session(force_gpu=True):
+        ref = tf.Variable(params)
+        ref.initializer.run()
+
+        # Indices all in range, no problem.
+        indices = np.array([2, 0, 5])
+        op(ref, indices, updates).eval()
+
+        # Indicies out of range should not fail.
+        indices = np.array([-1, 0, 5])
+        op(ref, indices, updates).eval()
+        indices = np.array([2, 0, 6])
+        op(ref, indices, updates).eval()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds GPU CUDA kernels for scatter_add, scatter_sub, and scatter_update.

Testing on a local machine with a weak graphics card already shows good improvement.  For about 20M floats, split as a 2Mx10 matrix, 1M size for idx, the op on a weak 3-core GPU is about twice as fast as on a 12-core CPU.  On very small data sets (1000 floats) the GPU code seems a bit slower (20%).

Some notes:
1. range checking in CUDA kernel currently not implemented.  It's not possible to include `OpKernelContext` since it includes protos hence nvcc fails to compile.  I can do it as a method in the .h/.cc files.  However, it seems rather inefficient as for low-dimensional input it is basically as slow as doing the entire scatter op sequentially on CPU.  Would it make sense to run the entire kernel, ignore bad indices, and report after?  This does mean the parameters may be updated when the code does fail because the modifications are happening in place.  Advice?<br>
2. There's a weird bug in `scatter_op_gpu.cu.cc` where I cannot use `TF_CALL_GPU_NUMBER_TYPES`.  I suspect it has to do with the `defined(__ANDROID__)` magic in `register_types.h` interacting badly with nvcc, but cannot confirm.
