### PR TITLE
Fix typos in a testcase name and comments of core/common_runtime module.

### DIFF
--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -94,7 +94,7 @@ string GetRendezvousKey(const string& tensor_name,
 //
 // 2) Recv nodes always complete immediately: The inputs are sent into
 //    the local rendezvous before we start the executor, so the
-//    corresonding recvs will not block.
+//    corresponding recvs will not block.
 //
 // Based on these assumptions, we can use the same thread pool for
 // both "non-blocking" and "blocking" OpKernels on Android.

--- a/tensorflow/core/common_runtime/direct_session_test.cc
+++ b/tensorflow/core/common_runtime/direct_session_test.cc
@@ -94,7 +94,7 @@ TEST_F(DirectSessionMinusAXTest, RunSimpleNetwork) {
   ASSERT_OK(s);
 
   ASSERT_EQ(1, outputs.size());
-  // The first output should be initiailzed and have the correct
+  // The first output should be initialized and have the correct
   // output.
   auto mat = outputs[0].matrix<float>();
   ASSERT_TRUE(outputs[0].IsInitialized());

--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -374,7 +374,7 @@ Status ExecutorImpl::InferAllocAttr(
   return s;
 }
 
-// The state associated with one invokation of ExecutorImpl::Run.
+// The state associated with one invocation of ExecutorImpl::Run.
 // ExecutorState dispatches nodes when they become ready and keeps
 // track of how many predecessors of a node have not done (pending_).
 class ExecutorState {

--- a/tensorflow/core/common_runtime/function.cc
+++ b/tensorflow/core/common_runtime/function.cc
@@ -430,7 +430,7 @@ Status FunctionLibraryRuntimeImpl::InstantiateSymbolicGradient(
   const auto& func = f->func();
   const FunctionDef* fdef = lib_def_->Find(func.name());
   if (fdef == nullptr) {
-    // f is a primitve op.
+    // f is a primitive op.
     gradient::Creator creator;
     TF_RETURN_IF_ERROR(gradient::GetOpGradientCreator(func.name(), &creator));
     if (creator == nullptr) {
@@ -1100,7 +1100,7 @@ class SymbolicGradientHelper {
 
   // 'ready' keeps track of nodes that have been completely
   // backpropped. Initially, for every output y of the function f, we
-  // add dy as an input of the the gradient function.
+  // add dy as an input of the gradient function.
   std::deque<Node*> ready_;
 
   // Makes a copy of fbody_ in gbody_.

--- a/tensorflow/core/common_runtime/function.h
+++ b/tensorflow/core/common_runtime/function.h
@@ -90,7 +90,7 @@ bool RemoveListArrayConverter(Graph* g);
 // multiple times by calling ExpandInlineFunctions a few times.
 bool ExpandInlineFunctions(FunctionLibraryRuntime* lib, Graph* graph);
 
-// Applies graph rewrite optimzation such as inlining, dead code
+// Applies graph rewrite optimization such as inlining, dead code
 // removal, etc.
 //
 // **g is a graph constructed based on the runtime library 'lib'.

--- a/tensorflow/core/common_runtime/gpu/gpu_allocator_retry.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_allocator_retry.h
@@ -32,7 +32,7 @@ class GPUAllocatorRetry {
   // then wait up to 'max_millis_to_wait' milliseconds, retrying each
   // time a call to DeallocateRaw() is detected, until either a good
   // pointer is returned or the deadline is exhausted.  If the
-  // deadline is exahusted, try one more time with 'verbose_failure'
+  // deadline is exhausted, try one more time with 'verbose_failure'
   // set to true.  The value returned is either the first good pointer
   // obtained from 'alloc_func' or nullptr.
   void* AllocateRaw(std::function<void*(size_t alignment, size_t num_bytes,

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
@@ -420,7 +420,7 @@ void GPUBFCAllocator::DumpMemoryLog(size_t num_bytes) {
     }
   }
 
-  // Next show the the chunks that are in use, and also summarize their
+  // Next show the chunks that are in use, and also summarize their
   // number by size.
   std::map<size_t, int> in_use_by_size;
   for (auto& it : ptr_to_chunk_map_) {

--- a/tensorflow/core/common_runtime/gpu/gpu_event_mgr_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_event_mgr_test.cc
@@ -199,7 +199,7 @@ TEST(EventMgr, StreamSwitchingFlushesImmediately) {
   EXPECT_GT(initial_live_bytes, live_tensor_bytes);
 }
 
-TEST(EventMgr, ManySmallTensorsSeperateCallsFlushed) {
+TEST(EventMgr, ManySmallTensorsSeparateCallsFlushed) {
   auto stream_exec = GPUMachineManager()->ExecutorForDevice(0).ValueOrDie();
   EventMgr em(stream_exec, GPUOptions());
   TEST_EventMgrHelper th(&em);

--- a/tensorflow/core/common_runtime/gpu/gpu_region_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_region_allocator.cc
@@ -279,7 +279,7 @@ void GPURegionAllocator::CheckForMemoryLeaks() {
 }
 
 // Since there's no merging of chunks once allocated, we want to
-// maximize their reusablity (which argues for fewer, larger sizes),
+// maximize their reusability (which argues for fewer, larger sizes),
 // while minimizing waste (which argues for tight-fitting sizes).
 //
 // The smallest unit of allocation is 256 bytes.

--- a/tensorflow/core/common_runtime/gpu/gpu_stream_util.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_stream_util.cc
@@ -61,7 +61,7 @@ Status AssignStreams(const Graph* graph, const AssignStreamsOpts& opts,
       }
     }
   }
-  // We perform stream assigmnent assuming a large number of
+  // We perform stream assignment assuming a large number of
   // stream IDs and then map these down to the required number of streams
   // using simple round-robin.
   // Stream Assignment strategy:

--- a/tensorflow/core/common_runtime/gpu/gpu_util.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_util.h
@@ -36,7 +36,7 @@ class GPUUtil {
   // "tensor" is GPU-local.  "dev" is the hosting GPU.
   // "device_context" should be the context of the GPU "_Send" op
   // which provides the Tensor.
-  // Sets all necessasry fields of "proto" by transferring value
+  // Sets all necessary fields of "proto" by transferring value
   // bytes from GPU to CPU RAM. "is_dead" indicates that the
   // tensor is dead with an uninit value.
   static void SetProtoFromGPU(const Tensor& tensor, Device* dev,

--- a/tensorflow/core/common_runtime/gpu/pool_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/pool_allocator.cc
@@ -47,7 +47,7 @@ PoolAllocator::PoolAllocator(size_t pool_size_limit, bool auto_resize,
 PoolAllocator::~PoolAllocator() { Clear(); }
 
 namespace {
-// Pools contain Chunks allocatated from the underlying Allocator.
+// Pools contain Chunks allocated from the underlying Allocator.
 // Chunk alignment is always on kPoolAlignment boundaries.  Each Chunk
 // begins with a descriptor (ChunkPrefix) that gives its size and a
 // pointer to itself.  The pointer returned to the user is just past
@@ -56,7 +56,7 @@ namespace {
 // pointer and also re-write the ChunkPrefix.chunk_ptr value
 // immediately before it.  This way the Chunk address and size can be
 // recovered from the returned user pointer, regardless of alignment.
-// Note that this deferencing of the pointers means that we cannot
+// Note that this dereferencing of the pointers means that we cannot
 // handle GPU memory, only CPU memory.
 struct ChunkPrefix {
   size_t num_bytes;

--- a/tensorflow/core/common_runtime/gpu/process_state.cc
+++ b/tensorflow/core/common_runtime/gpu/process_state.cc
@@ -46,7 +46,7 @@ const bool FLAGS_brain_gpu_region_allocator_reset_to_nan = false;
 const bool FLAGS_brain_gpu_use_bfc_allocator = true;
 
 // If true, record attributes of memory allocations and
-// dyanmically check for appropriate use of registered memory.
+// dynamically check for appropriate use of registered memory.
 // Should only be true for debugging or diagnosis of
 // performance issues.
 bool FLAGS_brain_gpu_record_mem_types = false;

--- a/tensorflow/core/common_runtime/gpu/process_state.h
+++ b/tensorflow/core/common_runtime/gpu/process_state.h
@@ -67,7 +67,7 @@ class ProcessState {
   MemDesc PtrType(const void* ptr);
 
   // Returns the one CPUAllocator used for the given numa_node.
-  // TEMPORY: ignores numa_node.
+  // TEMPORARY: ignores numa_node.
   Allocator* GetCPUAllocator(int numa_node);
 
   // Returns the one GPU allocator used for the indexed GPU.
@@ -80,7 +80,7 @@ class ProcessState {
   // used on that first call is used.
   //
   // "Allocator type" describes the type of algorithm to use for the
-  // underlying allocator.  REQURES: Must be a valid type (see
+  // underlying allocator.  REQUIRES: Must be a valid type (see
   // config.proto for the list of supported strings.).
   //
   // REQUIRES: gpu_id must be a valid ordinal for a GPU available in the
@@ -98,7 +98,7 @@ class ProcessState {
   // interface to be used for network device memory registration.
   // "bus_id" is platform-specific.  On many platforms it
   // should be 0.  On machines with multiple PCIe buses, it should be
-  // the index of one of the PCIe buses.  If the the bus_id is invalid,
+  // the index of one of the PCIe buses.  If the bus_id is invalid,
   // results are undefined.
   typedef std::function<void(void*, size_t)> AllocVisitor;
   void AddGPUAllocVisitor(int bus_id, AllocVisitor visitor);

--- a/tensorflow/core/common_runtime/simple_placer.cc
+++ b/tensorflow/core/common_runtime/simple_placer.cc
@@ -37,7 +37,7 @@ namespace {
 // types in 'supported_device_types' and returns the *first* subset of devices
 // that match.
 //
-// For example, if suported_device_types contains {GPU, CPU} and
+// For example, if supported_device_types contains {GPU, CPU} and
 // 'devices' contains CPU and GPU devices, the returned vector will
 // include *only* GPU devices, since that is higher in the priority
 // order in 'supported_device_types'.


### PR DESCRIPTION
Please note that this PR renames the following test case.

```
-TEST(EventMgr, ManySmallTensorsSeperateCallsFlushed) {
+TEST(EventMgr, ManySmallTensorsSeparateCallsFlushed) {
```
