### PR TITLE
Print the correct host information instead of `localhost` alias.

### DIFF
--- a/tensorflow/tensorboard/tensorboard.py
+++ b/tensorflow/tensorboard/tensorboard.py
@@ -155,7 +155,7 @@ def main(unused_argv=None):
 
   status_bar.SetupStatusBarInsideGoogle('TensorBoard %s' % tag, FLAGS.port)
   print('Starting TensorBoard %s on port %d' % (tag, FLAGS.port))
-  print('(You can navigate to http://localhost:%d)' % FLAGS.port)
+  print('(You can navigate to http://%s:%d)' % (FLAGS.host, FLAGS.port))
   server.serve_forever()
 
 


### PR DESCRIPTION
If a user specify a host ip by using `--host` option,
any connections to `http://localhost:6006` are refused.
