### PR TITLE
Fix syntax error when executing setup.py using python 3.4

### DIFF
--- a/tensorflow/models/rnn/ptb/reader.py
+++ b/tensorflow/models/rnn/ptb/reader.py
@@ -44,7 +44,7 @@ def _build_vocab(filename):
 
   counter = collections.Counter(data)
   count_pairs = sorted(counter.items(),
-                       key=lambda (word, count): (-count, word))
+                       key=lambda x : (-x[1], x[0]))
 
   words, _ = list(zip(*count_pairs))
   word_to_id = dict(zip(words, range(len(words))))

--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -106,7 +106,7 @@ class UnaryOpTest(tf.test.TestCase):
     def func(x):
       try:
         return fn(x)
-      except ValueError, e:
+      except ValueError as e:
         if "domain error" in e.message:
           return np.inf * np.ones_like(x)
         else:


### PR DESCRIPTION
When I execute `python3 ./tensorflow/tools/pip_package/setup.py install` on raspberry pi 2, I encountered syntax error message at these two code snippets. This commit is for fixing such error.
