### PR TITLE
Add missing arguments.

### DIFF
--- a/tensorflow/python/framework/docs.py
+++ b/tensorflow/python/framework/docs.py
@@ -121,7 +121,7 @@ def collect_members(module_to_name):
           if len(fullname) == len(other_fullname):
             raise RuntimeError("Can't decide whether to use %s or %s for %s: "
                                "both full names have length %d" %
-                               (fullname, other_fullname, len(fullname)))
+                               (fullname, other_fullname, name, len(fullname)))
           if len(fullname) > len(other_fullname):
             continue  # Use the shorter full name
         members[name] = fullname, member

--- a/tensorflow/python/kernel_tests/rnn_test.py
+++ b/tensorflow/python/kernel_tests/rnn_test.py
@@ -37,7 +37,7 @@ class Plus1RNNCell(tf.nn.rnn_cell.RNNCell):
   def state_size(self):
     return 5
 
-  def __call__(self, input_, state):
+  def __call__(self, input_, state, scope=None):
     return (input_ + 1, state + 1)
 
 

--- a/tensorflow/python/ops/rnn_cell.py
+++ b/tensorflow/python/ops/rnn_cell.py
@@ -501,7 +501,7 @@ class DropoutWrapper(RNNCell):
   def state_size(self):
     return self._cell.state_size
 
-  def __call__(self, inputs, state):
+  def __call__(self, inputs, state, scope=None):
     """Run the cell with the declared dropouts."""
     if (not isinstance(self._input_keep_prob, float) or
         self._input_keep_prob < 1):


### PR DESCRIPTION
- For `docs.py`, add `name` for exception message generation.
- For `rnn_cell.py` and `rnn_test.py`, add `scope=None` for inheritance.
