### PR TITLE
Remove mutable default value.

### DIFF
--- a/tensorflow/python/ops/candidate_sampling_ops.py
+++ b/tensorflow/python/ops/candidate_sampling_ops.py
@@ -195,7 +195,7 @@ def learned_unigram_candidate_sampler(true_classes, num_true, num_sampled,
 def fixed_unigram_candidate_sampler(true_classes, num_true, num_sampled, unique,
                                     range_max, vocab_file='', distortion=1.0,
                                     num_reserved_ids=0, num_shards=1, shard=0,
-                                    unigrams=[], seed=None, name=None):
+                                    unigrams=(), seed=None, name=None):
   """Samples a set of classes using the provided (fixed) base distribution.
 
   This operation randomly samples a tensor of sampled classes


### PR DESCRIPTION
Up to now, it's not a problem since `unigrams` is always given.
However, it might cause a problem in the future because
a mutable default parameter value is created once and shared.
