### PR TITLE
Changed non-public ops to public ones in tutorials

### DIFF
--- a/tensorflow/models/image/cifar10/cifar10.py
+++ b/tensorflow/models/image/cifar10/cifar10.py
@@ -230,7 +230,7 @@ def inference(images):
     weights = _variable_with_weight_decay('weights', shape=[dim, 384],
                                           stddev=0.04, wd=0.004)
     biases = _variable_on_cpu('biases', [384], tf.constant_initializer(0.1))
-    local3 = tf.nn.relu_layer(reshape, weights, biases, name=scope.name)
+    local3 = tf.nn.relu(tf.matmul(reshape, weights) + biases, name=scope.name)
     _activation_summary(local3)
 
   # local4
@@ -238,7 +238,7 @@ def inference(images):
     weights = _variable_with_weight_decay('weights', shape=[384, 192],
                                           stddev=0.04, wd=0.004)
     biases = _variable_on_cpu('biases', [192], tf.constant_initializer(0.1))
-    local4 = tf.nn.relu_layer(local3, weights, biases, name=scope.name)
+    local4 = tf.nn.relu(tf.matmul(local3, weights) + biases, name=scope.name)
     _activation_summary(local4)
 
   # softmax, i.e. softmax(WX + b)
@@ -247,7 +247,7 @@ def inference(images):
                                           stddev=1/192.0, wd=0.0)
     biases = _variable_on_cpu('biases', [NUM_CLASSES],
                               tf.constant_initializer(0.0))
-    softmax_linear = tf.nn.xw_plus_b(local4, weights, biases, name=scope.name)
+    softmax_linear = tf.add(tf.matmul(local4, weights), biases, name=scope.name)
     _activation_summary(softmax_linear)
 
   return softmax_linear

--- a/tensorflow/models/rnn/ptb/ptb_word_lm.py
+++ b/tensorflow/models/rnn/ptb/ptb_word_lm.py
@@ -129,9 +129,9 @@ class PTBModel(object):
         states.append(state)
 
     output = tf.reshape(tf.concat(1, outputs), [-1, size])
-    logits = tf.nn.xw_plus_b(output,
-                             tf.get_variable("softmax_w", [size, vocab_size]),
-                             tf.get_variable("softmax_b", [vocab_size]))
+    softmax_w = tf.get_variable("softmax_w", [size, vocab_size])
+    softmax_b = tf.get_variable("softmax_b", [vocab_size])
+    logits = tf.matmul(output, softmax_w) + softmax_b
     loss = seq2seq.sequence_loss_by_example([logits],
                                             [tf.reshape(self._targets, [-1])],
                                             [tf.ones([batch_size * num_steps])],

--- a/tensorflow/models/rnn/translate/seq2seq_model.py
+++ b/tensorflow/models/rnn/translate/seq2seq_model.py
@@ -141,8 +141,8 @@ class Seq2SeqModel(object):
       # If we use output projection, we need to project outputs for decoding.
       if output_projection is not None:
         for b in xrange(len(buckets)):
-          self.outputs[b] = [tf.nn.xw_plus_b(output, output_projection[0],
-                                             output_projection[1])
+          self.outputs[b] = [tf.matmul(output, output_projection[0]) +
+                             output_projection[1]
                              for output in self.outputs[b]]
     else:
       self.outputs, self.losses = seq2seq.model_with_buckets(


### PR DESCRIPTION
Replace non-public `tf.nn.relu_layer` and `tf.nn.xw_plus_b` by a combination of `tf.nn.relu`, `tf.matmul` and `tf.add`.

This PR fixes #811.
