### PR TITLE
Move spawn_strategy args from install docs to bazelrc.

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -408,7 +408,7 @@ you invoke the bazel build command.
 From the root of your source tree, run:
 
 ```bash
-$ bazel build -c opt --config=cuda --spawn_strategy=standalone //tensorflow/cc:tutorials_example_trainer
+$ bazel build -c opt --config=cuda //tensorflow/cc:tutorials_example_trainer
 
 $ bazel-bin/tensorflow/cc/tutorials_example_trainer --use_gpu
 # Lots of output. This tutorial iteratively calculates the major eigenvalue of
@@ -510,10 +510,10 @@ Do you wish to build TensorFlow with GPU support? [y/N]
 When building from source, you will still build a pip package and install that.
 
 ```bash
-$ bazel build -c opt --spawn_strategy=standalone //tensorflow/tools/pip_package:build_pip_package
+$ bazel build -c opt //tensorflow/tools/pip_package:build_pip_package
 
 # To build with GPU support:
-$ bazel build -c opt --config=cuda --spawn_strategy=standalone //tensorflow/tools/pip_package:build_pip_package
+$ bazel build -c opt --config=cuda //tensorflow/tools/pip_package:build_pip_package
 
 $ bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
 
@@ -531,7 +531,7 @@ system directories, run the following commands inside the TensorFlow root
 directory:
 
 ```bash
-bazel build -c opt --spawn_strategy=standalone //tensorflow/tools/pip_package:build_pip_package
+bazel build -c opt //tensorflow/tools/pip_package:build_pip_package
 mkdir _python_build
 cd _python_build
 ln -s ../bazel-bin/tensorflow/tools/pip_package/build_pip_package.runfiles/* .

--- a/tensorflow/tools/ci_build/install/.bazelrc
+++ b/tensorflow/tools/ci_build/install/.bazelrc
@@ -6,6 +6,7 @@ startup --batch
 # Similarly, we need to workaround sandboxing issues:
 #   https://github.com/bazelbuild/bazel/issues/418
 build --spawn_strategy=standalone --genrule_strategy=standalone
+test --spawn_strategy=standalone
 
 build --color=yes --verbose_failures
 test --color=yes --verbose_failures --test_timeout=3600 --test_output=errors --test_verbose_timeout_warnings

--- a/tools/bazel.rc.template
+++ b/tools/bazel.rc.template
@@ -3,3 +3,7 @@ build:cuda --crosstool_top=//third_party/gpus/crosstool
 build --force_python=py$PYTHON_MAJOR_VERSION
 build --python$PYTHON_MAJOR_VERSION_path=$PYTHON_BINARY
 build --define=use_fast_cpp_protos=true
+
+build --spawn_strategy=standalone
+test --spawn_strategy=standalone
+run --spawn_strategy=standalone


### PR DESCRIPTION
`--spawn_strategy=standalone` is pretty much always required to avoid problems with hermetic builds excluding system files, so we make it the default in the bazelrc file. This simplifies the installation instructions.
