### PR TITLE
SessionOptions should be declared as defined. <numeric> should be included to use itoa.

### DIFF
--- a/tensorflow/core/common_runtime/kernel_benchmark_testlib.h
+++ b/tensorflow/core/common_runtime/kernel_benchmark_testlib.h
@@ -29,7 +29,7 @@ limitations under the License.
 namespace tensorflow {
 
 class Device;
-class SessionOptions;
+struct SessionOptions;
 
 namespace test {
 

--- a/tensorflow/core/common_runtime/local_device.h
+++ b/tensorflow/core/common_runtime/local_device.h
@@ -22,7 +22,7 @@ limitations under the License.
 
 namespace tensorflow {
 
-class SessionOptions;
+struct SessionOptions;
 
 // This class is shared by ThreadPoolDevice and GPUDevice and
 // initializes a shared Eigen compute device used by both.  This

--- a/tensorflow/core/common_runtime/session_factory.h
+++ b/tensorflow/core/common_runtime/session_factory.h
@@ -25,7 +25,7 @@ limitations under the License.
 namespace tensorflow {
 
 class Session;
-class SessionOptions;
+struct SessionOptions;
 
 class SessionFactory {
  public:

--- a/tensorflow/core/kernels/check_numerics_op.cc
+++ b/tensorflow/core/kernels/check_numerics_op.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <math.h>
 #include <algorithm>
+#include <numeric>
 
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/types.h"

--- a/tensorflow/core/kernels/serialize_sparse_op.cc
+++ b/tensorflow/core/kernels/serialize_sparse_op.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <numeric>
 
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"

--- a/tensorflow/core/kernels/sparse_concat_op.cc
+++ b/tensorflow/core/kernels/sparse_concat_op.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <numeric>
 
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"

--- a/tensorflow/core/kernels/sparse_reorder_op.cc
+++ b/tensorflow/core/kernels/sparse_reorder_op.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <unordered_map>
 #include <utility>
+#include <numeric>
 
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"

--- a/tensorflow/core/kernels/sparse_to_dense_op.cc
+++ b/tensorflow/core/kernels/sparse_to_dense_op.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <numeric>
 
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"


### PR DESCRIPTION
Some minor issues found while porting the code to Windows.
