### PR TITLE
Fix small missing [by]

### DIFF
--- a/tensorflow/examples/udacity/4_convolutions.ipynb
+++ b/tensorflow/examples/udacity/4_convolutions.ipynb
@@ -218,7 +218,7 @@
             "colab_type": "text"
           },
           "cell_type": "markdown",
-          "source": "---\nProblem 1\n---------\n\nThe convolutional model above uses convolutions with stride 2 to reduce the dimensionality. Replace the strides a max pooling operation (`nn.max_pool()`) of stride 2 and kernel size 2.\n\n---"
+          "source": "---\nProblem 1\n---------\n\nThe convolutional model above uses convolutions with stride 2 to reduce the dimensionality. Replace the strides by a max pooling operation (`nn.max_pool()`) of stride 2 and kernel size 2.\n\n---"
         },
         {
           "metadata": {


### PR DESCRIPTION
I think there is the word `by` missing:

> Replace the strides [by] a max pooling operation [...]
