### PR TITLE
Make data_folders have only folders

### DIFF
--- a/tensorflow/examples/udacity/1_notmnist.ipynb
+++ b/tensorflow/examples/udacity/1_notmnist.ipynb
@@ -123,7 +123,7 @@
             "outputId": "ef6c790c-2513-4b09-962e-27c79390c762"
           },
           "cell_type": "code",
-          "input": "num_classes = 10\n\ndef extract(filename):\n  tar = tarfile.open(filename)\n  tar.extractall()\n  tar.close()\n  root = os.path.splitext(os.path.splitext(filename)[0])[0]  # remove .tar.gz\n  data_folders = [os.path.join(root, d) for d in sorted(os.listdir(root))]\n  if len(data_folders) != num_classes:\n    raise Exception(\n      'Expected %d folders, one per class. Found %d instead.' % (\n        num_classes, len(data_folders)))\n  print data_folders\n  return data_folders\n  \ntrain_folders = extract(train_filename)\ntest_folders = extract(test_filename)",
+          "input": "num_classes = 10\n\ndef extract(filename):\n  tar = tarfile.open(filename)\n  tar.extractall()\n  tar.close()\n  root = os.path.splitext(os.path.splitext(filename)[0])[0]  # remove .tar.gz\n  data_folders = [os.path.join(root, d) for d in sorted(os.listdir(root)) if os.path.isdir(os.path.join(root, d))]\n  if len(data_folders) != num_classes:\n    raise Exception(\n      'Expected %d folders, one per class. Found %d instead.' % (\n        num_classes, len(data_folders)))\n  print data_folders\n  return data_folders\n  \ntrain_folders = extract(train_filename)\ntest_folders = extract(test_filename)",
           "language": "python",
           "outputs": [
             {


### PR DESCRIPTION
On OS X the system created .DS_Store files in every folder. As a result running the same notebook twice
leads to the exception being thrown.
Really, |data_folders| should be gated behind  a check for folder type.
