### PR TITLE
Mount notebooks into a mounted fs volume to avoid data loss

### DIFF
--- a/tensorflow/examples/udacity/README.md
+++ b/tensorflow/examples/udacity/README.md
@@ -26,7 +26,17 @@ Building a local Docker container
 Running the local container
 ---------------------------
 
+To run a disposable container:  
+
     docker run -p 8888:8888 -it --rm $USER/assignments
+
+Note the above command will create an ephemeral container and all data stored in the container will be lost when the container stops.
+
+To avoid losing work between sessions in the container, it is recommended that you mount the `tensorflow/examples/udacity` directory into the container:
+
+    docker run -p 8888:8888 -v </path/to/tensorflow/examples/udacity>:/notebooks -it --rm $USER/assignments
+
+This will allow you to save work and have access to generated files on the host filesystem.
 
 Pushing a Google Cloud release
 ------------------------------


### PR DESCRIPTION
The current way this is done:

```
docker run -p 8888:8888 -it --rm $USER/assignments
```

creates an ephemeral container due to the `--rm` flag. In the first notebook you are doing very expensive operations (gunziping) several GBs. All of this data will be lost when the container shuts down. Using the filesystem as a mounted volume, allows subsequent sessions to have access to the files created (eg pickled data). This is especially important because this is course material so want to avoid time consuming gotchas for the students.
