### PR TITLE
Keeps optional question format consisten

### DIFF
--- a/tensorflow/examples/udacity/1_notmnist.ipynb
+++ b/tensorflow/examples/udacity/1_notmnist.ipynb
@@ -622,6 +622,7 @@
         "\n",
         "By construction, this dataset might contain a lot of overlapping samples, including training data that's also contained in the validation and test set! Overlap between training and test can skew the results if you expect to use your model in an environment where there is never an overlap, but are actually ok if you expect to see training samples recur when you use it.\n",
         "Measure how much overlap there is between training, validation and test samples.\n",
+        "\n",
         "Optional questions:\n",
         "- What about near duplicates between datasets? (images that are almost identical)\n",
         "- Create a sanitized validation and test set, and compare your accuracy on those in subsequent assignments.\n",


### PR DESCRIPTION
Added a newline to keep separation of optional questions from required tasks consistent and easier to read.
