### PR TITLE
added //tensorflow/cc:cc_ops to //tensorflow:libtensorflow.so

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -61,3 +61,12 @@ cc_binary(
         "//tensorflow/core:tensorflow",
     ],
 )
+
+cc_binary(
+    name = "libtensorflow_cc.so",
+    linkshared = 1,
+    deps = [
+        "//tensorflow/core:tensorflow",
+        "//tensorflow/cc:cc_ops"
+    ],
+)


### PR DESCRIPTION
Hey, I've wrapped tensorflow into openframeworks (http://openframeworks.cc/ ) was a massive PITA but more on that later :)

I needed the c++ ops so I added that to the libtensorflow.so target. I believe this is the right way to do it?
(I can confirm that it does work, I can create graphs in openframeworks. I'll make it all public once i've ironed out a few other things)
