### PR TITLE
Udacity example 1: import urllib for download

### DIFF
--- a/tensorflow/examples/udacity/1_notmnist.ipynb
+++ b/tensorflow/examples/udacity/1_notmnist.ipynb
@@ -110,7 +110,7 @@
         "def maybe_download(filename, expected_bytes):\n",
         "  \"\"\"Download a file if not present, and make sure it's the right size.\"\"\"\n",
         "  if not os.path.exists(filename):\n",
-        "    filename, _ = urllib.urlretrieve(url + filename, filename)\n",
+        "    filename, _ = urlretrieve(url + filename, filename)\n",
         "  statinfo = os.stat(filename)\n",
         "  if statinfo.st_size == expected_bytes:\n",
         "    print 'Found and verified', filename\n",


### PR DESCRIPTION
Really minor, import urllib so the dataset download below just works the first time.
