### PR TITLE
Added missing PY2AND3 build annotation

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -263,6 +263,7 @@ tf_gen_op_wrapper_py(
 py_library(
     name = "functional_ops_lib",
     srcs = ["ops/functional_ops.py"],
+    srcs_version = "PY2AND3",
     deps = [
         ":functional_ops",
     ],


### PR DESCRIPTION
As @martinwicke [commented](https://github.com/tensorflow/tensorflow/issues/791#issuecomment-173009071), building for python 3 was failing due to missing `srcs_version="PY2AND3"` annotations. This single addition of the annotation allowed the build to complete successfully for me using python 3.5.1 on OS X 10.11.2.

Fixes #791 
