### PR TITLE
Use the same types in `for` statements.

### DIFF
--- a/tensorflow/core/framework/function.h
+++ b/tensorflow/core/framework/function.h
@@ -127,7 +127,7 @@ class FunctionDefHelper {
     n.attr.push_back({"dtype", dtype});
     int64 num = vals.size();
     Tensor t(dtype, TensorShape({num}));
-    for (int i = 0; i < vals.size(); ++i) {
+    for (size_t i = 0; i < vals.size(); ++i) {
       t.flat<T>()(i) = vals[i];
     }
     n.attr.push_back({"value", t});

--- a/tensorflow/core/framework/tensor.h
+++ b/tensorflow/core/framework/tensor.h
@@ -440,7 +440,7 @@ typename TTypes<T, NDIMS>::Tensor Tensor::shaped(
   CHECK_EQ(NDIMS, new_sizes.size());
   int64 new_num_elements = 1;
   Eigen::array<Eigen::DenseIndex, NDIMS> dims;
-  for (int d = 0; d < NDIMS; d++) {
+  for (size_t d = 0; d < NDIMS; d++) {
     new_num_elements *= new_sizes[d];
     dims[d] = new_sizes[d];
   }
@@ -455,7 +455,7 @@ typename TTypes<T, NDIMS>::UnalignedTensor Tensor::unaligned_shaped(
   CHECK_EQ(NDIMS, new_sizes.size());
   int64 new_num_elements = 1;
   Eigen::array<Eigen::DenseIndex, NDIMS> dims;
-  for (int d = 0; d < NDIMS; d++) {
+  for (size_t d = 0; d < NDIMS; d++) {
     new_num_elements *= new_sizes[d];
     dims[d] = new_sizes[d];
   }
@@ -471,7 +471,7 @@ typename TTypes<T, NDIMS>::ConstTensor Tensor::shaped(
   CHECK_EQ(NDIMS, new_sizes.size());
   int64 new_num_elements = 1;
   Eigen::array<Eigen::DenseIndex, NDIMS> dims;
-  for (int d = 0; d < NDIMS; d++) {
+  for (size_t d = 0; d < NDIMS; d++) {
     new_num_elements *= new_sizes[d];
     dims[d] = new_sizes[d];
   }
@@ -486,7 +486,7 @@ typename TTypes<T, NDIMS>::UnalignedConstTensor Tensor::unaligned_shaped(
   CHECK_EQ(NDIMS, new_sizes.size());
   int64 new_num_elements = 1;
   Eigen::array<Eigen::DenseIndex, NDIMS> dims;
-  for (int d = 0; d < NDIMS; d++) {
+  for (size_t d = 0; d < NDIMS; d++) {
     new_num_elements *= new_sizes[d];
     dims[d] = new_sizes[d];
   }

--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -614,7 +614,7 @@ struct BinaryFunctor {
 
 template <int NDIMS>
 bool AllOne(const typename Eigen::array<Eigen::DenseIndex, NDIMS>& a) {
-  for (int i = 0; i < a.size(); ++i) {
+  for (size_t i = 0; i < a.size(); ++i) {
     if (a[i] != 1) return false;
   }
   return true;

--- a/tensorflow/core/kernels/diag_op.cc
+++ b/tensorflow/core/kernels/diag_op.cc
@@ -33,7 +33,7 @@ class DiagonalGenerator {
   T operator()(
       const Eigen::array<Eigen::DenseIndex, DoubleNumDims>& coordinates) const {
     Eigen::array<Eigen::DenseIndex, NumDims> index;
-    for (int i = 0; i < NumDims; ++i) {
+    for (size_t i = 0; i < NumDims; ++i) {
       if (coordinates[i] != coordinates[NumDims + i]) {
         return T(0);
       }

--- a/tensorflow/core/kernels/edit_distance_op.cc
+++ b/tensorflow/core/kernels/edit_distance_op.cc
@@ -144,7 +144,7 @@ class EditDistanceOp : public OpKernel {
     std::iota(group_dims.begin(), group_dims.end(), 0);
 
     TensorShape output_shape;
-    for (int d = 0; d < group_dims.size(); ++d) {
+    for (size_t d = 0; d < group_dims.size(); ++d) {
       output_shape.AddDim(std::max(hypothesis_st_shape.dim_size(d),
                                    truth_st_shape.dim_size(d)));
     }

--- a/tensorflow/core/kernels/lookup_table_op.cc
+++ b/tensorflow/core/kernels/lookup_table_op.cc
@@ -76,7 +76,7 @@ class HashTable : public InitializableLookupTable {
 
     const auto key_values = keys.flat<K>();
     const auto value_values = values.flat<V>();
-    for (size_t i = 0; i < key_values.size(); ++i) {
+    for (int i = 0; i < key_values.size(); ++i) {
       const K& key = key_values(i);
       const V& value = value_values(i);
       const V& previous_value = gtl::LookupOrInsert(table_.get(), key, value);
@@ -95,7 +95,7 @@ class HashTable : public InitializableLookupTable {
     const auto key_values = key.flat<K>();
     auto value_values = value->flat<V>();
 
-    for (size_t i = 0; i < key_values.size(); ++i) {
+    for (int i = 0; i < key_values.size(); ++i) {
       value_values(i) =
           gtl::FindWithDefault(*table_, key_values(i), default_val);
     }

--- a/tensorflow/core/kernels/padding_fifo_queue.cc
+++ b/tensorflow/core/kernels/padding_fifo_queue.cc
@@ -285,7 +285,7 @@ Status HandleElementToLargerSlice(const Tensor& element, Tensor* parent,
   slice_indices[0] = index;
   Eigen::DSizes<Eigen::DenseIndex, NDIMS + 1> slice_size;
   slice_size[0] = 1;
-  for (int i = 1; i < slice_size.size(); ++i) {
+  for (size_t i = 1; i < slice_size.size(); ++i) {
     slice_size[i] = element_t.dimension(i - 1);
   }
   parent_t.slice(slice_indices, slice_size) = element_t.reshape(slice_size);

--- a/tensorflow/core/kernels/reverse_sequence_op.cc
+++ b/tensorflow/core/kernels/reverse_sequence_op.cc
@@ -67,7 +67,7 @@ void CheckErrors(OpKernelContext* context, int batch_dim, int seq_dim) {
                                       "), ", "(", seq_lens.NumElements(),
                                       " vs. ", input.dim_size(batch_dim)));
 
-  for (int d = 0; d < seq_lens_vec.size(); ++d) {
+  for (size_t d = 0; d < seq_lens_vec.size(); ++d) {
     OP_REQUIRES(context, seq_lens_vec[d] >= 0,
                 errors::InvalidArgument("seq_lens(", d, ") < 0"));
     OP_REQUIRES(context, seq_lens_vec[d] <= input.dim_size(seq_dim),

--- a/tensorflow/core/kernels/segment_reduction_ops.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops.cc
@@ -466,7 +466,7 @@ class SparseSegmentGradOpBase : public OpKernel {
     for (int64 i = 0; i < N; ++i) {
       scaling[segment_vec(i)] += 1;
     }
-    for (int i = 0; i < scaling.size(); ++i) {
+    for (size_t i = 0; i < scaling.size(); ++i) {
       if (is_sqrtn_) {
         scaling[i] = 1.0 / sqrt(std::max(scaling[i], 1.0));
       } else {

--- a/tensorflow/core/kernels/string_to_number_op.cc
+++ b/tensorflow/core/kernels/string_to_number_op.cc
@@ -48,7 +48,7 @@ class StringToNumberOp : public OpKernel {
                                             &output_tensor));
     auto output_flat = output_tensor->flat<OutputType>();
 
-    for (std::size_t i = 0; i < input_flat.size(); ++i) {
+    for (int i = 0; i < input_flat.size(); ++i) {
       const char* s = input_flat(i).data();
       Convert(s, &output_flat(i), context);
     }

--- a/tensorflow/core/lib/strings/str_util.h
+++ b/tensorflow/core/lib/strings/str_util.h
@@ -134,7 +134,7 @@ std::vector<string> Split(StringPiece text, char delim, Predicate p) {
   std::vector<string> result;
   int token_start = 0;
   if (!text.empty()) {
-    for (int i = 0; i < text.size() + 1; i++) {
+    for (size_t i = 0; i < text.size() + 1; i++) {
       if ((i == text.size()) || (text[i] == delim)) {
         StringPiece token(text.data() + token_start, i - token_start);
         if (p(token)) {

--- a/tensorflow/core/util/sparse/sparse_tensor.h
+++ b/tensorflow/core/util/sparse/sparse_tensor.h
@@ -321,7 +321,7 @@ bool SparseTensor::ToDense(Tensor* out, bool initialize) {
     strides[d] = strides[d + 1] * out_shape.dim_size(d + 1);
   }
 
-  for (std::size_t n = 0; n < vals_t.dimension(0); ++n) {
+  for (int n = 0; n < vals_t.dimension(0); ++n) {
     bool invalid_dims = false;
     int64 ix = 0;
     for (int d = 0; d < dims_; ++d) {


### PR DESCRIPTION
This removes lots of simple compiler warnings on 'signed' and 'unsigned'
comparisons (reported in #128). Please note that there are two types of
changes. It is because this does not change any function signatures.
- In most cases: `int` --> `size_t`.
- In `lookup_table_op.cc`, `string_to_number_op.cc`, and
  `sparse_tensor.h`: `size_t` --> int.
