### PR TITLE
Adding instructions for wheel on python3.5

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -66,11 +66,21 @@ $ sudo pip install --upgrade https://storage.googleapis.com/tensorflow/mac/tenso
 For python3:
 
 ```bash
-# Ubuntu/Linux 64-bit, CPU only:
+# Ubuntu/Linux 64-bit, CPU only, python3.4.x:
 $ sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.6.0-cp34-none-linux_x86_64.whl
 
-# Ubuntu/Linux 64-bit, GPU enabled:
+# Ubuntu/Linux 64-bit, CPU only, python3.5.x:
+$ sudo wget https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.6.0-cp34-none-linux_x86_64.whl
+$ sudo mv tensorflow-0.6.0-cp34-none-linux_x86_64.whl tensorflow-0.6.0-cp35-none-linux_x86_64.whl
+$ sudo pip3 install --upgrade tensorflow-0.6.0-cp35-none-linux_x86_64.whl
+
+# Ubuntu/Linux 64-bit, GPU enabled, python3.4.x:
 $ sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.6.0-cp34-none-linux_x86_64.whl
+
+# Ubuntu/Linux 64-bit, GPU only, python3.5.x:
+$ sudo wget https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.6.0-cp34-none-linux_x86_64.whl
+$ sudo mv tensorflow-0.6.0-cp34-none-linux_x86_64.whl tensorflow-0.6.0-cp35-none-linux_x86_64.whl
+$ sudo pip3 install --upgrade tensorflow-0.6.0-cp35-none-linux_x86_64.whl
 
 # Mac OS X, CPU only:
 $ sudo easy_install --upgrade six


### PR DESCRIPTION
The current python3 wheel installation instructions doesn't work for python3.5, since the pip3 (python3.5) is unable to recognize the wheel file "tensorflow-0.6.0-cp34-none-linux_x86_64.whl" due to the version information contained in the file name "cp34-none". See issue #468
