### PR TITLE
Remove compiler warnings on CHECK_* and DCHECK_* macros.

### DIFF
--- a/tensorflow/cc/tutorials/example_trainer.cc
+++ b/tensorflow/cc/tutorials/example_trainer.cc
@@ -114,7 +114,7 @@ void ConcurrentSteps(const Options* opts, int session_index) {
         outputs.clear();
         TF_CHECK_OK(
             session->Run({{"x", x}}, {"y:0", "y_normalized:0"}, {}, &outputs));
-        CHECK_EQ(2, outputs.size());
+        CHECK_EQ(size_t{2}, outputs.size());
 
         const Tensor& y = outputs[0];
         const Tensor& y_norm = outputs[1];

--- a/tensorflow/core/common_runtime/constant_folding.cc
+++ b/tensorflow/core/common_runtime/constant_folding.cc
@@ -115,9 +115,9 @@ Graph* GetConstantGraph(const Graph* orig_graph,
     already_added.insert(added);
     for (const Edge* in_edge : n->in_edges()) {
       Node* in = in_edge->src();
-      CHECK_GT(node_map.count(in), 0) << n->DebugString() << " <-"
+      CHECK_GT(node_map.count(in), size_t{0}) << n->DebugString() << " <-"
                                       << in->DebugString();
-      CHECK_GT(already_added.count(node_map[in]), 0) << in->DebugString();
+      CHECK_GT(already_added.count(node_map[in]), size_t{0}) << in->DebugString();
       constant_graph->AddEdge(node_map[in], in_edge->src_output(), added,
                               in_edge->dst_input());
     }

--- a/tensorflow/core/common_runtime/device_factory.cc
+++ b/tensorflow/core/common_runtime/device_factory.cc
@@ -116,7 +116,7 @@ Device* DeviceFactory::NewDevice(const string& type,
   (*opt.config.mutable_device_count())[type] = 1;
   std::vector<Device*> devices;
   device_factory->CreateDevices(opt, name_prefix, &devices);
-  CHECK_EQ(devices.size(), 1);
+  CHECK_EQ(devices.size(), size_t{1});
   return devices[0];
 }
 

--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -310,7 +310,7 @@ Status ExecutorImpl::SetAllocAttrs() {
       }
     }
 
-    for (int out = 0; out < n->num_outputs(); out++) {
+    for (size_t out = 0; out < n->num_outputs(); out++) {
       OpKernel* op_kernel = item->kernel;
       DCHECK_LT(out, op_kernel->output_memory_types().size());
       bool on_host = op_kernel->output_memory_types()[out] == HOST_MEMORY;
@@ -1033,7 +1033,7 @@ Status ExecutorState::PrepareInputs(const NodeItem& item, Entry* first_input,
   *is_input_dead = false;
 
   bool is_merge = IsMerge(node);
-  for (int i = 0; i < node->num_inputs(); ++i) {
+  for (size_t i = 0; i < node->num_inputs(); ++i) {
     const bool expect_ref = IsRefType(node->input_type(i));
     Entry* entry = first_input + i;
     (*input_device_contexts)[i] = entry->device_context;
@@ -1104,7 +1104,7 @@ Status ExecutorState::ProcessOutputs(const NodeItem& item, OpKernelContext* ctx,
     device_context = dc_it->second;
   }
 
-  for (int i = 0; i < node->num_outputs(); ++i) {
+  for (size_t i = 0; i < node->num_outputs(); ++i) {
     TensorValue val = ctx->release_output(i);
     if (*ctx->is_output_dead() || val.tensor == nullptr) {
       // Unless it's a Switch or a Recv, the node must produce a
@@ -1216,7 +1216,7 @@ void ExecutorState::ActivateNode(const Node* node, const bool is_dead,
       if (e->IsControlEdge()) {
         (*pending)[dst_id] -= 2;
         int count = (*pending)[dst_id];
-        dst_dead = ((*dead_count)[dst_id] == dst_node->num_inputs());
+        dst_dead = (static_cast<size_t>((*dead_count)[dst_id]) == dst_node->num_inputs());
         dst_ready = (count == 1) || ((count == 0) && dst_dead);
       } else {
         if (outputs[src_slot].has_value) {
@@ -1228,7 +1228,7 @@ void ExecutorState::ActivateNode(const Node* node, const bool is_dead,
         } else {
           // This is a dead data input.
           ++(*dead_count)[dst_id];
-          dst_dead = ((*dead_count)[dst_id] == dst_node->num_inputs());
+          dst_dead = (static_cast<size_t>((*dead_count)[dst_id]) == dst_node->num_inputs());
           dst_ready = ((*pending)[dst_id] == 0) && dst_dead;
           dst_need_input = false;
         }
@@ -1603,11 +1603,11 @@ void ExecutorState::CleanupFramesIterations(FrameState* frame, int64 iter,
           if (e->IsControlEdge()) {
             (*pending)[dst_id] -= 2;
             int count = (*pending)[dst_id];
-            dst_dead = ((*dead_count)[dst_id] == dst_node->num_inputs());
+            dst_dead = (static_cast<size_t>((*dead_count)[dst_id]) == dst_node->num_inputs());
             dst_ready = (count == 1) || ((count == 0) && dst_dead);
           } else {
             ++(*dead_count)[dst_id];
-            dst_dead = ((*dead_count)[dst_id] == dst_node->num_inputs());
+            dst_dead = (static_cast<size_t>((*dead_count)[dst_id]) == dst_node->num_inputs());
             dst_ready = ((*pending)[dst_id] == 0) && dst_dead;
           }
         } else {

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
@@ -153,7 +153,7 @@ void* GPUBFCAllocator::AllocateRawInternal(size_t unused_alignment,
   // allocate multiples of 256 bytes so all memory addresses are
   // nicely byte aligned.
   size_t rounded_bytes = (256 * ((num_bytes + 255) / 256));
-  DCHECK_EQ(0, rounded_bytes % 256);
+  DCHECK_EQ(size_t{0}, rounded_bytes % 256);
 
   // The BFC allocator tries to find the best fit first.
   //

--- a/tensorflow/core/common_runtime/gpu/gpu_region_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_region_allocator.cc
@@ -171,7 +171,7 @@ bool GPURegionAllocator::ExpandPool(Pool* pool, size_t chunk_size,
                                     bool dump_log_on_failure) {
   VLOG(1) << "ExpandPool of " << chunk_size << " from " << pool->num_chunks
           << " current members";
-  DCHECK_NE(0, chunk_size);
+  DCHECK_NE(size_t{0}, chunk_size);
   // If chunk_size is < 4096, double the pool size.  Otherwise
   // just increase by one.
   int num_chunks = pool->num_chunks;

--- a/tensorflow/core/common_runtime/gpu/pool_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/pool_allocator.cc
@@ -39,7 +39,7 @@ PoolAllocator::PoolAllocator(size_t pool_size_limit, bool auto_resize,
       size_rounder_(size_rounder),
       allocation_begun_(false) {
   if (auto_resize) {
-    CHECK_LT(0, pool_size_limit)
+    CHECK_LT(size_t{0}, pool_size_limit)
         << "size limit must be > 0 if auto_resize is true.";
   }
 }

--- a/tensorflow/core/framework/function.cc
+++ b/tensorflow/core/framework/function.cc
@@ -157,7 +157,7 @@ Status BuildInputArgIndex(const OpDef::ArgDef& arg_def,
   bool is_type_list;
   DataTypeVector dtypes;
   TF_RETURN_IF_ERROR(ArgNumType(attr_values, arg_def, &is_type_list, &dtypes));
-  CHECK_GE(dtypes.size(), 1);
+  CHECK_GE(dtypes.size(), size_t{1});
   GraphDef* gdef = &result->gdef;
   int arg_index = gdef->node_size();
   TF_RETURN_IF_ERROR(AddArgName(name_info, arg_def.name(),
@@ -312,7 +312,7 @@ Status AddReturnNode(const OpDef::ArgDef& ret_def,
   bool is_type_list;
   DataTypeVector dtypes;
   TF_RETURN_IF_ERROR(ArgNumType(attrs, ret_def, &is_type_list, &dtypes));
-  CHECK_GE(dtypes.size(), 1);
+  CHECK_GE(dtypes.size(), size_t{1});
   const NameInfoItem* item = gtl::FindOrNull(name_info, ret_def.name());
   if (item == nullptr) {
     return errors::InvalidArgument("ret is not found.");

--- a/tensorflow/core/framework/op_kernel.h
+++ b/tensorflow/core/framework/op_kernel.h
@@ -798,7 +798,7 @@ class OpKernelContext {
 
   AllocatorAttributes input_alloc_attr(int index) const {
     DCHECK_GE(index, 0);
-    DCHECK_LT(index, params_->input_alloc_attrs->size());
+    DCHECK_LT(static_cast<size_t>(index), params_->input_alloc_attrs->size());
     return (*params_->input_alloc_attrs)[index];
   }
 
@@ -1065,7 +1065,7 @@ class OpKernelRegistrar {
 
 inline DataType OpKernelContext::input_dtype(int index) const {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->inputs->size());
+  DCHECK_LT(static_cast<size_t>(index), params_->inputs->size());
   const TensorValue& value((*params_->inputs)[index]);
   if (value.is_ref()) {
     return MakeRefType(value->dtype());
@@ -1076,7 +1076,7 @@ inline DataType OpKernelContext::input_dtype(int index) const {
 
 inline DataType OpKernelContext::expected_output_dtype(int index) const {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->op_kernel->output_types().size());
+  DCHECK_LT(static_cast<size_t>(index), params_->op_kernel->output_types().size());
   return params_->op_kernel->output_type(index);
 }
 
@@ -1096,7 +1096,7 @@ inline void OpKernelContext::retrieve_accessed_tensors(
 
 inline const Tensor& OpKernelContext::input(int index) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->inputs->size());
+  DCHECK_LT(static_cast<size_t>(index), params_->inputs->size());
   DCHECK(!(*params_->inputs)[index].is_ref());
   const Tensor& tensor = *((*params_->inputs)[index].tensor);
   record_tensor_reference(tensor);
@@ -1105,7 +1105,7 @@ inline const Tensor& OpKernelContext::input(int index) {
 
 inline Tensor OpKernelContext::mutable_input(int index, bool lock_held) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->inputs->size());
+  DCHECK_LT(static_cast<size_t>(index), params_->inputs->size());
   DCHECK((*params_->inputs)[index].is_ref());
   // return a copy of the Ref acquired while holding the mutex
   if (lock_held) {
@@ -1123,7 +1123,7 @@ inline Tensor OpKernelContext::mutable_input(int index, bool lock_held) {
 inline void OpKernelContext::replace_ref_input(int index, const Tensor& tensor,
                                                bool lock_held) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->inputs->size());
+  DCHECK_LT(static_cast<size_t>(index), params_->inputs->size());
   DCHECK((*params_->inputs)[index].is_ref());
   // should only modify the tensor while holding the mutex
   if (lock_held) {
@@ -1138,7 +1138,7 @@ inline void OpKernelContext::replace_ref_input(int index, const Tensor& tensor,
 inline void OpKernelContext::forward_ref_input_to_ref_output(int input_index,
                                                              int output_index) {
   DCHECK_GE(input_index, 0);
-  DCHECK_LT(input_index, params_->inputs->size());
+  DCHECK_LT(static_cast<size_t>(input_index), params_->inputs->size());
   DCHECK((*params_->inputs)[input_index].is_ref());
   set_output_ref(output_index, (*params_->inputs)[input_index].mutex_if_ref,
                  (*params_->inputs)[input_index].tensor);
@@ -1146,7 +1146,7 @@ inline void OpKernelContext::forward_ref_input_to_ref_output(int input_index,
 
 inline void OpKernelContext::delete_ref_input(int index, bool lock_held) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->inputs->size());
+  DCHECK_LT(static_cast<size_t>(index), params_->inputs->size());
   DCHECK((*params_->inputs)[index].is_ref());
   // should only modify the tensor while holding the mutex
   if (lock_held) {
@@ -1160,13 +1160,13 @@ inline void OpKernelContext::delete_ref_input(int index, bool lock_held) {
 // no input if tensor == nullptr.
 inline bool OpKernelContext::has_input(int index) const {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->inputs->size());
+  DCHECK_LT(static_cast<size_t>(index), params_->inputs->size());
   return (*params_->inputs)[index].tensor != nullptr;
 }
 
 inline mutex* OpKernelContext::input_ref_mutex(int index) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->inputs->size());
+  DCHECK_LT(static_cast<size_t>(index), params_->inputs->size());
   DCHECK((*params_->inputs)[index].is_ref());
   return (*params_->inputs)[index].mutex_if_ref;
 }
@@ -1200,7 +1200,7 @@ inline Status OpKernelContext::allocate_output(int index,
                                                Tensor** output,
                                                AllocatorAttributes attr) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, outputs_.size());
+  DCHECK_LT(static_cast<size_t>(index), outputs_.size());
   const DataType type = params_->op_kernel->output_type(index);
   DCHECK(!IsRefType(type));
   DCHECK(mutable_output(index) == nullptr);
@@ -1245,7 +1245,7 @@ inline void OpKernelContext::NotifyUseOfPersistentTensor(const Tensor& t) {
 
 inline void OpKernelContext::set_output(int index, const Tensor& tensor) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, outputs_.size());
+  DCHECK_LT(static_cast<size_t>(index), outputs_.size());
   DCHECK(!IsRefType(params_->op_kernel->output_type(index)));
   DCHECK_EQ(mutable_output(index), nullptr);
   record_tensor_reference(tensor);
@@ -1255,7 +1255,7 @@ inline void OpKernelContext::set_output(int index, const Tensor& tensor) {
 inline void OpKernelContext::set_output_ref(int index, mutex* mu,
                                             Tensor* tensor_for_ref) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, outputs_.size());
+  DCHECK_LT(static_cast<size_t>(index), outputs_.size());
   DCHECK(IsRefType(params_->op_kernel->output_type(index)));
   record_tensor_reference(*tensor_for_ref);
   outputs_[index] = TensorValue(mu, tensor_for_ref);
@@ -1263,7 +1263,7 @@ inline void OpKernelContext::set_output_ref(int index, mutex* mu,
 
 inline Tensor* OpKernelContext::mutable_output(int index) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, outputs_.size());
+  DCHECK_LT(static_cast<size_t>(index), outputs_.size());
   // No need to record_tensor_reference since the output must already
   // have been set by a call that did so.
   return outputs_[index].tensor;
@@ -1271,7 +1271,7 @@ inline Tensor* OpKernelContext::mutable_output(int index) {
 
 inline TensorValue OpKernelContext::release_output(int index) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, outputs_.size());
+  DCHECK_LT(static_cast<size_t>(index), outputs_.size());
   TensorValue value = outputs_[index];
   outputs_[index] = TensorValue();
   return value;
@@ -1287,7 +1287,7 @@ T* OpKernelContext::op_device_context() {
 template <typename T>
 T* OpKernelContext::input_device_context(int index) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->input_device_contexts->size());
+  DCHECK_LT(static_cast<size_t>(index), params_->input_device_contexts->size());
   static_assert(std::is_base_of<DeviceContext, T>::value,
                 "T is not a subclass of DeviceContext");
   return static_cast<T*>((*params_->input_device_contexts)[index]);
@@ -1295,7 +1295,7 @@ T* OpKernelContext::input_device_context(int index) {
 
 inline DeviceContext* OpKernelContext::input_device_context(int index) {
   DCHECK_GE(index, 0);
-  DCHECK_LT(index, params_->input_device_contexts->size());
+  DCHECK_LT(static_cast<size_t>(index), params_->input_device_contexts->size());
   return (*params_->input_device_contexts)[index];
 }
 

--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -152,7 +152,7 @@ struct Helper<string> {
   // stored in buffer "in".
   static int64 TotalBytes(TensorBuffer* in, int n) {
     int64 tot = in->size();
-    DCHECK_EQ(tot, sizeof(string) * n);
+    DCHECK_EQ(static_cast<size_t>(tot), sizeof(string) * n);
     const string* p = in->base<const string>();
     for (int i = 0; i < n; ++i, ++p) tot += p->size();
     return tot;

--- a/tensorflow/core/framework/tensor_util.cc
+++ b/tensorflow/core/framework/tensor_util.cc
@@ -41,7 +41,7 @@ Tensor DeepCopy(const Tensor& other) {
 }
 
 Tensor Concat(const gtl::ArraySlice<Tensor>& tensors) {
-  CHECK_GT(tensors.size(), 0);
+  CHECK_GT(tensors.size(), size_t{0});
   int64 total_dim0_size = 0;
   for (const Tensor& tensor : tensors) {
     CHECK_GT(tensor.dims(), 0);

--- a/tensorflow/core/framework/unique_tensor_references.h
+++ b/tensorflow/core/framework/unique_tensor_references.h
@@ -78,7 +78,7 @@ class UniqueTensorReferences {
           referenced_tensors_set_->reserve(kInVector);
           referenced_tensors_set_->insert(referenced_tensors_vector_.begin(),
                                           referenced_tensors_vector_.end());
-          DCHECK_EQ(kInVector, referenced_tensors_set_->size());
+          DCHECK_EQ(static_cast<size_t>(kInVector), referenced_tensors_set_->size());
           referenced_tensors_vector_.clear();
         }
       }

--- a/tensorflow/core/graph/costmodel.cc
+++ b/tensorflow/core/graph/costmodel.cc
@@ -62,7 +62,7 @@ void CostModel::MergeFromLocal(const Graph& g, const CostModel& cm) {
       if (slot_bytes_[global_id].size() == 0) {
         slot_bytes_[global_id].resize(num_slots);
       } else {
-        CHECK_EQ(num_slots, slot_bytes_[global_id].size());
+        CHECK_EQ(static_cast<size_t>(num_slots), slot_bytes_[global_id].size());
       }
       for (int s = 0; s < num_slots; ++s) {
         slot_bytes_[global_id][s] += cm.slot_bytes_[local_id][s];
@@ -84,7 +84,7 @@ void CostModel::MergeFromGlobal(const CostModel& cm) {
       if (slot_bytes_[i].size() == 0) {
         slot_bytes_[i].resize(num_slots);
       } else {
-        CHECK_EQ(num_slots, slot_bytes_[i].size());
+        CHECK_EQ(static_cast<size_t>(num_slots), slot_bytes_[i].size());
       }
       for (int s = 0; s < num_slots; ++s) {
         slot_bytes_[i][s] += cm.slot_bytes_[i][s];
@@ -133,7 +133,7 @@ void CostModel::SetNumOutputs(const Node* node, int num_outputs) {
   Ensure(id);
   auto perslot = &slot_bytes_[id];
   if (perslot->size() > 0) {
-    CHECK_EQ(num_outputs, perslot->size()) << "Cannot resize slot_bytes, node="
+    CHECK_EQ(static_cast<size_t>(num_outputs), perslot->size()) << "Cannot resize slot_bytes, node="
                                            << node->name();
   } else {
     perslot->resize(num_outputs, Bytes(-1));
@@ -143,7 +143,7 @@ void CostModel::SetNumOutputs(const Node* node, int num_outputs) {
 void CostModel::RecordCount(const Node* node, int count) {
   const int id = Id(node);
   if (id < 0) return;
-  CHECK_LT(id, slot_bytes_.size());
+  CHECK_LT(static_cast<size_t>(id), slot_bytes_.size());
   count_[id] += count;
 }
 
@@ -156,9 +156,9 @@ int32 CostModel::TotalCount(const Node* node) const {
 void CostModel::RecordSize(const Node* node, int slot, Bytes bytes) {
   const int id = Id(node);
   if (id < 0) return;
-  CHECK_LT(id, slot_bytes_.size());
+  CHECK_LT(static_cast<size_t>(id), slot_bytes_.size());
   auto perslot = &slot_bytes_[id];
-  CHECK_LT(slot, perslot->size());
+  CHECK_LT(static_cast<size_t>(slot), perslot->size());
   auto v = &(*perslot)[slot];
   if (*v >= 0) {
     *v += bytes;

--- a/tensorflow/core/graph/graph.cc
+++ b/tensorflow/core/graph/graph.cc
@@ -253,11 +253,11 @@ const Edge* Graph::AddEdge(Node* source, int x, Node* dest, int y) {
 void Graph::RemoveEdge(const Edge* e) {
   DCHECK(IsValidNode(e->src_)) << e->src_->DebugString();
   DCHECK(IsValidNode(e->dst_)) << e->dst_->DebugString();
-  CHECK_EQ(e->src_->out_edges_.erase(e), 1);
-  CHECK_EQ(e->dst_->in_edges_.erase(e), 1);
+  CHECK_EQ(e->src_->out_edges_.erase(e), size_t{1});
+  CHECK_EQ(e->dst_->in_edges_.erase(e), size_t{1});
   CHECK_EQ(e, edges_[e->id_]);
 
-  CHECK_EQ(edge_set_.erase(e), 1);
+  CHECK_EQ(edge_set_.erase(e), size_t{1});
   edges_[e->id_] = nullptr;
 
   Edge* del = const_cast<Edge*>(e);

--- a/tensorflow/core/graph/graph.h
+++ b/tensorflow/core/graph/graph.h
@@ -74,11 +74,11 @@ class Node {
   const OpDef& op_def() const { return *props_->op_def_; }
 
   // input and output types
-  int num_inputs() const { return props_->input_types_.size(); }
+  size_t num_inputs() const { return props_->input_types_.size(); }
   DataType input_type(int i) const { return props_->input_types_[i]; }
   const DataTypeVector& input_types() const { return props_->input_types_; }
 
-  int num_outputs() const { return props_->output_types_.size(); }
+  size_t num_outputs() const { return props_->output_types_.size(); }
   DataType output_type(int o) const { return props_->output_types_[o]; }
   const DataTypeVector& output_types() const { return props_->output_types_; }
 

--- a/tensorflow/core/graph/graph_constructor.cc
+++ b/tensorflow/core/graph/graph_constructor.cc
@@ -283,7 +283,7 @@ void GraphConstructor::Convert() {
           has_data_back_edge = true;
           inputs.push_back(InputInfo(id.first, src_node, id.second));
         } else {
-          if (id.second >= src_node->num_outputs()) {
+          if (static_cast<size_t>(id.second) >= src_node->num_outputs()) {
             SetNodeError(
                 node_def,
                 strings::StrCat("Connecting to invalid output ", id.second,

--- a/tensorflow/core/graph/node_builder.h
+++ b/tensorflow/core/graph/node_builder.h
@@ -119,7 +119,7 @@ class NodeBuilder {
 
  private:
   static DataType SafeGetOutput(Node* node, int i, bool* error) {
-    if (node != nullptr && i >= 0 && i < node->num_outputs()) {
+    if (node != nullptr && i >= 0 && static_cast<size_t>(i) < node->num_outputs()) {
       *error = false;
       return node->output_type(i);
     } else {

--- a/tensorflow/core/graph/subgraph.cc
+++ b/tensorflow/core/graph/subgraph.cc
@@ -65,7 +65,7 @@ static Status FeedInputs(Graph* g, const DeviceAttributes& device_info,
     }
     const Node* n = iter->second;
     DCHECK_EQ(n->name(), id.first);
-    if (id.second >= n->num_outputs()) {
+    if (static_cast<size_t>(id.second) >= n->num_outputs()) {
       return errors::InvalidArgument(
           "FeedInputs: ", t, " should have output index < ", n->num_outputs());
     }
@@ -190,7 +190,7 @@ Status FetchOutputs(Graph* g, const DeviceAttributes& device_info,
           t,
           "' as an argument to the 'target_node_names' argument of the "
           "Session::Run API.");
-    } else if (id.second >= n->num_outputs()) {
+    } else if (static_cast<size_t>(id.second) >= n->num_outputs()) {
       return errors::InvalidArgument("FetchOutputs ", t,
                                      ": output index too large, must be < ",
                                      n->num_outputs());

--- a/tensorflow/core/kernels/cwise_ops_common.h
+++ b/tensorflow/core/kernels/cwise_ops_common.h
@@ -52,7 +52,7 @@ class BinaryOpShared : public OpKernel {
   template <int NDIMS>
   static Eigen::array<Eigen::DenseIndex, NDIMS> ToIndexArray(
       const BCast::Vec& vec) {
-    CHECK_EQ(vec.size(), NDIMS);
+    CHECK_EQ(vec.size(), static_cast<size_t>(NDIMS));
     Eigen::array<Eigen::DenseIndex, NDIMS> ret;
     for (int i = 0; i < NDIMS; ++i) ret[i] = vec[i];
     return ret;

--- a/tensorflow/core/kernels/decode_raw_op.cc
+++ b/tensorflow/core/kernels/decode_raw_op.cc
@@ -42,7 +42,7 @@ class DecodeRawOp : public OpKernel {
       if (str_size == -1) {
         str_size = in_str.size();
       } else {
-        OP_REQUIRES(context, str_size == in_str.size(),
+        OP_REQUIRES(context, str_size == static_cast<int>(in_str.size()),
                     errors::InvalidArgument(
                         "DecodeRaw requires input strings to all be the same "
                         "size, but element ",

--- a/tensorflow/core/kernels/diag_op.cc
+++ b/tensorflow/core/kernels/diag_op.cc
@@ -28,7 +28,7 @@ class DiagonalGenerator {
   explicit DiagonalGenerator(const Tensor& diagonal) : diagonal_(diagonal) {
     static_assert(DoubleNumDims == 2 * NumDims,
                   "The second size must be the double of the first size.");
-    CHECK_EQ(diagonal.dims(), NumDims);
+    CHECK_EQ(static_cast<size_t>(diagonal.dims()), NumDims);
   }
   T operator()(
       const Eigen::array<Eigen::DenseIndex, DoubleNumDims>& coordinates) const {

--- a/tensorflow/core/kernels/fifo_queue.cc
+++ b/tensorflow/core/kernels/fifo_queue.cc
@@ -36,7 +36,7 @@ FIFOQueue::FIFOQueue(int capacity, const DataTypeVector& component_dtypes,
     : TypedQueue(capacity, component_dtypes, component_shapes, name) {}
 
 void FIFOQueue::DequeueLocked(OpKernelContext* ctx, Tuple* tuple) {
-  DCHECK_GT(queues_[0].size(), 0);
+  DCHECK_GT(queues_[0].size(), size_t{0});
   (*tuple).reserve(num_components());
   for (int i = 0; i < num_components(); ++i) {
     (*tuple).push_back(*queues_[i][0].AccessTensor(ctx));

--- a/tensorflow/core/kernels/random_shuffle_queue_op.cc
+++ b/tensorflow/core/kernels/random_shuffle_queue_op.cc
@@ -107,7 +107,7 @@ Status RandomShuffleQueue::Initialize() {
 }
 
 void RandomShuffleQueue::DequeueLocked(OpKernelContext* ctx, Tuple* tuple) {
-  DCHECK_GT(queues_[0].size(), 0);
+  DCHECK_GT(queues_[0].size(), size_t{0});
   int64 index = generator_() % queues_[0].size();
   (*tuple).reserve(num_components());
   for (int i = 0; i < num_components(); ++i) {

--- a/tensorflow/core/kernels/range_sampler.cc
+++ b/tensorflow/core/kernels/range_sampler.cc
@@ -83,7 +83,7 @@ void RangeSampler::SampleBatchGetExpectedCountAvoid(
   int num_tries;
 
   if (unique) {
-    CHECK_LE(batch_size + avoided_values.size(), range_);
+    CHECK_LE(static_cast<int64>(batch_size + avoided_values.size()), range_);
     std::unordered_set<int64> used(batch_size);
     used.insert(avoided_values.begin(), avoided_values.end());
     int num_picked = 0;
@@ -97,7 +97,7 @@ void RangeSampler::SampleBatchGetExpectedCountAvoid(
       }
     }
   } else {
-    CHECK_EQ(avoided_values.size(), 0)
+    CHECK_EQ(avoided_values.size(), size_t{0})
         << "avoided_values only supported with unique=true";
     for (int i = 0; i < batch_size; i++) {
       batch[i] = Sample(rnd);
@@ -106,7 +106,7 @@ void RangeSampler::SampleBatchGetExpectedCountAvoid(
   }
   // Compute the expected counts of the batch and the extra values
   if (batch_expected_count.size() > 0) {
-    CHECK_EQ(batch_size, batch_expected_count.size());
+    CHECK_EQ(static_cast<size_t>(batch_size), batch_expected_count.size());
     for (int i = 0; i < batch_size; i++) {
       batch_expected_count[i] =
           ExpectedCountHelper(Probability(batch[i]), batch_size, num_tries);
@@ -133,12 +133,12 @@ void AllSampler::SampleBatchGetExpectedCountAvoid(
     batch[i] = i;
   }
   if (batch_expected_count.size() > 0) {
-    CHECK_EQ(batch_size, batch_expected_count.size());
+    CHECK_EQ(static_cast<size_t>(batch_size), batch_expected_count.size());
     for (int i = 0; i < batch_size; i++) {
       batch_expected_count[i] = 1;
     }
   }
-  CHECK_EQ(0, avoided_values.size());
+  CHECK_EQ(size_t{0}, avoided_values.size());
   CHECK_EQ(extras.size(), extras_expected_count.size());
   for (size_t i = 0; i < extras.size(); i++) {
     extras_expected_count[i] = 1;
@@ -242,7 +242,7 @@ FixedUnigramSampler::FixedUnigramSampler(Env* env, int64 range,
   FillReservedIds(num_reserved_ids);
   // TODO(vanhoucke): make this non-crashing.
   TF_CHECK_OK(LoadFromFile(env, vocab_file, distortion));
-  CHECK_EQ(range, weights_.size());
+  CHECK_EQ(static_cast<size_t>(range), weights_.size());
   dist_sampler_.reset(new random::DistributionSampler(weights_));
 }
 
@@ -258,7 +258,7 @@ FixedUnigramSampler::FixedUnigramSampler(int64 range,
   FillReservedIds(num_reserved_ids);
   LoadFromUnigrams(unigrams, distortion);
   // TODO(vanhoucke): make this non-crashing.
-  CHECK_EQ(range, weights_.size());
+  CHECK_EQ(static_cast<size_t>(range), weights_.size());
   dist_sampler_.reset(new random::DistributionSampler(weights_));
 }
 

--- a/tensorflow/core/kernels/sparse_matmul_op.cc
+++ b/tensorflow/core/kernels/sparse_matmul_op.cc
@@ -203,8 +203,8 @@ void SparseSlice::Initialize(const ConstMatrixMap& mat, int col_offset) {
     index3_offset.push_back(index3.size());
     index_offset.push_back(index.size());
   }
-  DCHECK_EQ(index3_offset.size(), num_blocks);
-  DCHECK_EQ(index_offset.size(), num_blocks);
+  DCHECK_EQ(index3_offset.size(), static_cast<size_t>(num_blocks));
+  DCHECK_EQ(index_offset.size(), static_cast<size_t>(num_blocks));
   DCHECK_EQ(3 * index3.size(), data3.size());
   DCHECK_EQ(index.size(), data.size());
 }
@@ -803,7 +803,7 @@ inline void SparseMatMulOp::ComputeBlockSizes(const ConstMatrixMap& left,
 
   *JB = std::max(1, static_cast<int>(sqrt(num_threads) / 2.0));
   *IB = 8 * *JB;
-  DCHECK_EQ(N * sizeof(float) % 64, 0);
+  DCHECK_EQ(N * sizeof(float) % 64, size_t{0});
 }
 
 // Here is a an overview of the SparseMatMul code. Note that we assume that the

--- a/tensorflow/core/kernels/transpose_op.cc
+++ b/tensorflow/core/kernels/transpose_op.cc
@@ -142,7 +142,7 @@ void TransposeTensor(const Device& device, const Tensor& input,
                      const gtl::ArraySlice<int64> input_shape,
                      gtl::ArraySlice<int32> permutation, Tensor* output) {
   const int dims = input_shape.size();
-  CHECK(permutation.size() == dims);
+  CHECK(permutation.size() == static_cast<size_t>(dims));
   if (input.NumElements() == 0) {
     return;
   }

--- a/tensorflow/core/lib/core/arena.cc
+++ b/tensorflow/core/lib/core/arena.cc
@@ -77,7 +77,7 @@ bool Arena::SatisfyAlignment(size_t alignment) {
     freestart_ += waste;
     remaining_ -= waste;
   }
-  DCHECK_EQ(0, reinterpret_cast<size_t>(freestart_) & (alignment - 1));
+  DCHECK_EQ(size_t{0}, reinterpret_cast<size_t>(freestart_) & (alignment - 1));
   return true;
 }
 
@@ -168,7 +168,7 @@ Arena::AllocatedBlock* Arena::AllocNewBlock(const size_t block_size,
   const uint32 adjusted_alignment =
       (alignment > 1 ? LeastCommonMultiple(alignment, kDefaultAlignment) : 1);
 
-  CHECK_LE(adjusted_alignment, 1 << 20)
+  CHECK_LE(adjusted_alignment, static_cast<uint32>(1 << 20))
       << "Alignment on boundaries greater than 1MB not supported.";
 
   // If block_size > alignment we force block_size to be a multiple

--- a/tensorflow/core/lib/gtl/inlined_vector.h
+++ b/tensorflow/core/lib/gtl/inlined_vector.h
@@ -374,7 +374,7 @@ class InlinedVector {
 
   // Moves srcs[0,n-1] contents to dst[0,n-1].
   static void Move(const T* src, size_t n, T* dst) {
-    for (int i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
       new (dst + i) T(std::move(*(src + i)));
     }
   }

--- a/tensorflow/core/lib/histogram/histogram.cc
+++ b/tensorflow/core/lib/histogram/histogram.cc
@@ -59,7 +59,7 @@ Histogram::Histogram(gtl::ArraySlice<double> custom_bucket_limits)
                             custom_bucket_limits.end()),
       bucket_limits_(custom_bucket_limits_) {
 #ifndef NDEBUG
-  DCHECK_GT(bucket_limits_.size(), 0);
+  DCHECK_GT(bucket_limits_.size(), size_t{0});
   // Verify that the bucket boundaries are strictly increasing
   for (size_t i = 1; i < bucket_limits_.size(); i++) {
     DCHECK_GT(bucket_limits_[i], bucket_limits_[i - 1]);

--- a/tensorflow/core/lib/jpeg/jpeg_mem.cc
+++ b/tensorflow/core/lib/jpeg/jpeg_mem.cc
@@ -540,7 +540,7 @@ bool CompressInternal(const uint8* srcdata, int width, int height,
         row_pointer[0] = reinterpret_cast<JSAMPLE*>(const_cast<JSAMPLE*>(r));
       }
     }
-    CHECK_EQ(jpeg_write_scanlines(&cinfo, row_pointer, 1), 1);
+    CHECK_EQ(jpeg_write_scanlines(&cinfo, row_pointer, 1), 1u);
   }
   jpeg_finish_compress(&cinfo);
 

--- a/tensorflow/core/util/sparse/dim_comparator.h
+++ b/tensorflow/core/util/sparse/dim_comparator.h
@@ -48,8 +48,8 @@ class DimComparator {
   inline DimComparator(const TTypes<int64>::Matrix& ix,
                        const VarDimArray& order, int dims)
       : ix_(ix), order_(order), dims_(dims) {
-    CHECK_GT(order.size(), 0) << "Must order using at least one index";
-    CHECK_LE(order.size(), dims_) << "Can only sort up to dims";
+    CHECK_GT(order.size(), size_t{0}) << "Must order using at least one index";
+    CHECK_LE(order.size(), static_cast<size_t>(dims_)) << "Can only sort up to dims";
     for (size_t d = 0; d < order.size(); ++d) {
       CHECK_GE(order[d], 0);
       CHECK_LT(order[d], dims);

--- a/tensorflow/core/util/sparse/sparse_tensor.h
+++ b/tensorflow/core/util/sparse/sparse_tensor.h
@@ -99,7 +99,7 @@ class SparseTensor {
   //
   // See the README.md in this directory for more usage information.
   GroupIterable group(const VarDimArray& group_ix) {
-    CHECK_LE(group_ix.size(), dims_);
+    CHECK_LE(group_ix.size(), static_cast<size_t>(dims_));
     for (std::size_t di = 0; di < group_ix.size(); ++di) {
       CHECK_GE(group_ix[di], 0) << "Group dimension out of range";
       CHECK_LT(group_ix[di], dims_) << "Group dimension out of range";
@@ -239,7 +239,7 @@ template <typename T>
 void SparseTensor::Reorder(const VarDimArray& order) {
   CHECK_EQ(DataTypeToEnum<T>::v(), dtype())
       << "Reorder requested with the wrong datatype";
-  CHECK_EQ(order.size(), dims_) << "Order length must be SparseTensor rank";
+  CHECK_EQ(order.size(), static_cast<size_t>(dims_)) << "Order length must be SparseTensor rank";
   auto ix_t = ix_.matrix<int64>();
   auto vals_t = vals_.vec<T>();
 
@@ -267,7 +267,7 @@ void SparseTensor::Reorder(const VarDimArray& order) {
   //   https://en.wikipedia.org/wiki/Cyclic_permutation
   // This is N swaps, 2*N comparisons.
   for (std::size_t n = 0; n + 1 < permutation.size(); ++n) {
-    while (n != permutation[n]) {
+    while (n != static_cast<size_t>(permutation[n])) {
       std::size_t r = permutation[n];
       std::swap_ranges(&(ix_t(n, 0)), &(ix_t(n + 1, 0)), &(ix_t(r, 0)));
       std::swap(vals_t(n), vals_t(r));
@@ -340,7 +340,7 @@ bool SparseTensor::ToDense(Tensor* out, bool initialize) {
 template <typename T>
 SparseTensor SparseTensor::Concat(
     const gtl::ArraySlice<SparseTensor>& tensors) {
-  CHECK_GE(tensors.size(), 1) << "Cannot concat 0 SparseTensors";
+  CHECK_GE(tensors.size(), size_t{1}) << "Cannot concat 0 SparseTensors";
   const int dims = tensors[0].dims_;
   CHECK_GE(dims, 1) << "Cannot concat 0-dimensional SparseTensors";
   auto order_0 = tensors[0].order();

--- a/tensorflow/core/util/tensor_slice_reader.cc
+++ b/tensorflow/core/util/tensor_slice_reader.cc
@@ -131,7 +131,7 @@ TensorSliceReader::TensorSliceReader(const string& filepattern,
 }
 
 void TensorSliceReader::LoadShard(int shard) const {
-  CHECK_LT(shard, sss_.size());
+  CHECK_LT(static_cast<size_t>(shard), sss_.size());
   if (sss_[shard] || !status_.ok()) {
     return;  // Already loaded, or invalid.
   }

--- a/tensorflow/core/util/tensor_slice_reader_cache.cc
+++ b/tensorflow/core/util/tensor_slice_reader_cache.cc
@@ -92,7 +92,7 @@ const TensorSliceReader* TensorSliceReaderCache::GetReader(
     } else {
       delete tmp_reader;
     }
-    CHECK_EQ(1, still_opening_.erase(filepattern));
+    CHECK_EQ(size_t{1}, still_opening_.erase(filepattern));
     VLOG(1) << "Cached TensorSliceReader for " << filepattern << ": " << reader;
   } else {
     auto cached_val = readers_[filepattern];


### PR DESCRIPTION
This removes lots of simple compiler warnings on 'signed' and 'unsigned'
comparisons on CHECK_\* and DCHECK_\* macros (reported in #128).
In most cases, `static_cast<>` is used to remove the warnings.

This does not fix 3rd-party(stream_executor/eigen/protobuf)-related warnings and
also does not change any function signatures.
