### PR TITLE
Adding --recurse-submodules flag to git clone in ci_bulid README

### DIFF
--- a/tensorflow/tools/ci_build/README.md
+++ b/tensorflow/tools/ci_build/README.md
@@ -42,7 +42,7 @@ to docker caching. Individual builds are fast thanks to bazel caching.
 2. Clone tensorflow repository.
 
    ```bash
-git clone https://github.com/tensorflow/tensorflow.git
+git clone --recurse-submodules https://github.com/tensorflow/tensorflow.git
 ```
 
 3. Go to tensorflow directory


### PR DESCRIPTION
This simple doc fix is related to issue: https://github.com/tensorflow/tensorflow/issues/896
