### PR TITLE
Python PIP test-on-install

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu
@@ -13,3 +13,11 @@ RUN /install/install_bazel.sh
 # Set up bazelrc.
 COPY install/.bazelrc /root/.bazelrc
 ENV BAZELRC /root/.bazelrc
+
+# Script for (optional) test on install
+COPY builds/test_on_install.sh /builds/test_on_install.sh
+RUN chmod a+rx /builds/test_on_install.sh
+
+# Grant users installation permission on Python package directory
+RUN chmod -R a+rw /usr/local/lib/python2.7/dist-packages
+RUN chmod -R a+rw /usr/local/bin

--- a/tensorflow/tools/ci_build/Dockerfile.gpu
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu
@@ -22,3 +22,12 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
 ENV CUDA_TOOLKIT_PATH /usr/local/cuda
 ENV CUDNN_INSTALL_PATH /usr/local/cuda
 ENV TF_NEED_CUDA 1
+
+# Script for (optional) test on install
+COPY builds/test_on_install.sh /builds/test_on_install.sh
+RUN chmod a+rx /builds/test_on_install.sh
+
+# Grant users installation permission on Python package directory
+RUN chmod -R a+rw /usr/local/lib/python2.7/dist-packages
+RUN chmod -R a+rw /usr/local/bin
+

--- a/tensorflow/tools/ci_build/builds/test_on_install.sh
+++ b/tensorflow/tools/ci_build/builds/test_on_install.sh
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#q
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software

--- a/tensorflow/tools/ci_build/builds/test_on_install.sh
+++ b/tensorflow/tools/ci_build/builds/test_on_install.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Build the Python PIP installation package for TensorFlow
+# and run the Python unit tests from the source code on the installation
+
+cd /tensorflow &&
+
+# Build the pip package
+bazel build -c opt //tensorflow/tools/pip_package:build_pip_package &&
+
+# Install
+rm -rf _python_build &&
+mkdir _python_build &&
+cd _python_build &&
+ln -s ../bazel-bin/tensorflow/tools/pip_package/build_pip_package.runfiles/* \
+  . &&
+ln -s ../tensorflow/tools/pip_package/* . &&
+python setup.py develop &&
+
+# Run tests
+cd .. &&
+ALL_PY_TESTS=`find tensorflow/python -name "*_test.py" | xargs` &&
+PY_TEST_COUNT=`echo ${ALL_PY_TESTS} | wc -w`
+
+PY_TEST_DIR=${HOME}/tf_py_tests
+
+rm -rf ${PY_TEST_DIR} &&
+mkdir ${PY_TEST_DIR} &&
+
+# Iterate through all the Python unit test files using the installation
+for TEST_FILE_PATH in ${ALL_PY_TESTS}; do
+  # Copy to a separate directory to guard against the possibility of picking up 
+  # modules in the source directory 
+  cp ${TEST_FILE_PATH} ${PY_TEST_DIR}/ &&
+
+  echo "Running Python test on install: ${TEST_FILE_PATH}"
+  TEST_FILE_BASENAME=`basename "${TEST_FILE_PATH}"`
+
+  TEST_OUTPUT=${PY_TEST_DIR}/${TEST_FILE_BASENAME}.out
+
+  python ${PY_TEST_DIR}/${TEST_FILE_BASENAME} | \
+    tee ${TEST_OUTPUT}  &&
+
+  # Examine the OK status of the test output
+  LASTLINE=`awk '/./{line=$0} END{print line}' ${TEST_OUTPUT}`
+  test "${LASTLINE}" = OK &&
+
+  # Clean up files for this test
+  rm -f ${PY_TEST_DIR}/${TEST_FILE_BASENAME} &&
+  rm -f ${PY_TEST_DIR}/${TEST_FILE_BASENAME}.out
+
+done
+
+echo ""
+echo "All ${PY_TEST_COUNT} Python tests on install PASSED"

--- a/tensorflow/tools/ci_build/builds/test_on_install.sh
+++ b/tensorflow/tools/ci_build/builds/test_on_install.sh
@@ -17,21 +17,26 @@
 # Build the Python PIP installation package for TensorFlow
 # and run the Python unit tests from the source code on the installation
 #
+# When executing the Python unit tests, the script obeys three environment
+# variables: PY_TEST_WHITELIST, PY_TEST_BLACKLIST and PY_TEST_GPU_BLACKLIST
+#
 # To select only a subset of the Python tests to run, set the environment
 # variable PY_TEST_WHITELIST, e.g.,
 #   PY_TEST_WHITELIST="tensorflow/python/kernel_tests/shape_ops_test.py"
-#
-# Seprate the tests with a space. Leave this environment variable empty to
+# Separate the tests with a space. Leave this environment variable empty to
 # disable the whitelist.
+#
+# You can also ignore a set of the tests by using the environment variable
+# PY_TEST_BLACKLIST. For example, you can include in PY_TEST_BLACKLIST the
+# tests that depend on Python modules in TensorFlow source that are not
+# exported publicly.
+#
+# In addition, you can put blacklist for only GPU build inthe environment
+# variable PY_TEST_GPU_BLACKLIST.
+#
 
-# You can also ignore a set of the tests by using the variable PY_TEST_BLACKLIST
-# These are the test that depend on Python modules in the source that are not
-# exported publicly. In addition, you can put blacklist for only GPU build in
-# the environment variable PY_TEST_GPU_BLACKLIST
-PY_TEST_BLACKLIST="tensorflow/python/tools/freeze_graph_test.py "\
-"tensorflow/python/util/protobuf/compare_test.py "\
-"tensorflow/python/framework/ops_test.py "\
-"tensorflow/python/framework/device_test.py "
+echo "PY_TEST_BLACKLIST: ${PY_TEST_BLACKLIST}"
+echo "PY_TEST_GPU_BLACKLIST: ${PY_TEST_GPU_BLACKLIST}"
 
 # Get the command line arguments
 CONTAINER_TYPE=$( echo "$1" | tr '[:upper:]' '[:lower:]' )

--- a/tensorflow/tools/ci_build/builds/test_on_install.sh
+++ b/tensorflow/tools/ci_build/builds/test_on_install.sh
@@ -32,10 +32,21 @@ PY_TEST_BLACKLIST="tensorflow/python/tools/freeze_graph_test.py "\
 "tensorflow/python/framework/ops_test.py "\
 "tensorflow/python/framework/device_test.py "
 
+# Get the command line arguments.
+CONTAINER_TYPE=$( echo "$1" | tr '[:upper:]' '[:lower:]' )
+
 cd /tensorflow &&
 
 # Build the pip package
-bazel build -c opt //tensorflow/tools/pip_package:build_pip_package &&
+PIP_BUILD_TARGET="//tensorflow/tools/pip_package:build_pip_package"
+if [[ ${CONTAINER_TYPE} == "cpu" ]]; then
+  bazel build -c opt ${PIP_BUILD_TARGET}
+elif [[ ${CONTAINER_TYPE} == "gpu" ]]; then
+  bazel build -c opt --config=cuda ${PIP_BUILD_TARGET}
+else
+  echo "Unrecognized container type: ${CONTAINER_TYPE}"
+  exit 1
+fi
 
 # Install
 rm -rf _python_build &&

--- a/tensorflow/tools/ci_build/builds/test_on_install.sh
+++ b/tensorflow/tools/ci_build/builds/test_on_install.sh
@@ -26,14 +26,20 @@
 
 # You can also ignore a set of the tests by using the variable PY_TEST_BLACKLIST
 # These are the test that depend on Python modules in the source that are not
-# exported publicly:
+# exported publicly. In addition, you can put blacklist for only GPU build in
+# the environment variable PY_TEST_GPU_BLACKLIST
 PY_TEST_BLACKLIST="tensorflow/python/tools/freeze_graph_test.py "\
 "tensorflow/python/util/protobuf/compare_test.py "\
 "tensorflow/python/framework/ops_test.py "\
 "tensorflow/python/framework/device_test.py "
 
-# Get the command line arguments.
+# Get the command line arguments
 CONTAINER_TYPE=$( echo "$1" | tr '[:upper:]' '[:lower:]' )
+
+# Append GPU-only test blacklist
+if [[ ${CONTAINER_TYPE} == "gpu" ]]; then
+  PY_TEST_BLACKLIST="${PY_TEST_BLACKLIST} ${PY_TEST_GPU_BLACKLIST}"
+fi
 
 cd /tensorflow &&
 

--- a/tensorflow/tools/ci_build/builds/test_on_install.sh
+++ b/tensorflow/tools/ci_build/builds/test_on_install.sh
@@ -23,8 +23,8 @@
 # To select only a subset of the Python tests to run, set the environment
 # variable PY_TEST_WHITELIST, e.g.,
 #   PY_TEST_WHITELIST="tensorflow/python/kernel_tests/shape_ops_test.py"
-# Separate the tests with a space. Leave this environment variable empty to
-# disable the whitelist.
+# Separate the tests with a colon (:). Leave this environment variable empty
+# to disable the whitelist.
 #
 # You can also ignore a set of the tests by using the environment variable
 # PY_TEST_BLACKLIST. For example, you can include in PY_TEST_BLACKLIST the
@@ -43,7 +43,7 @@ CONTAINER_TYPE=$( echo "$1" | tr '[:upper:]' '[:lower:]' )
 
 # Append GPU-only test blacklist
 if [[ ${CONTAINER_TYPE} == "gpu" ]]; then
-  PY_TEST_BLACKLIST="${PY_TEST_BLACKLIST} ${PY_TEST_GPU_BLACKLIST}"
+  PY_TEST_BLACKLIST="${PY_TEST_BLACKLIST}:${PY_TEST_GPU_BLACKLIST}"
 fi
 
 cd /tensorflow &&

--- a/tensorflow/tools/ci_build/ci_test_on_install.sh
+++ b/tensorflow/tools/ci_build/ci_test_on_install.sh
@@ -17,8 +17,6 @@
 # Get the command line arguments.
 CONTAINER_TYPE=$( echo "$1" | tr '[:upper:]' '[:lower:]' )
 
-COMMAND=/builds/test_on_install.sh
-
 # Validate command line arguments.
 if [ "$#" -gt 1 ] || [[ ! "${CONTAINER_TYPE}" =~ ^(cpu|gpu|android)$ ]]; then
   >&2 echo "Usage: $(basename $0) CONTAINER_TYPE"
@@ -29,6 +27,8 @@ if [ "$#" -gt 1 ] || [[ ! "${CONTAINER_TYPE}" =~ ^(cpu|gpu|android)$ ]]; then
   exit 1
 fi
 
+
+COMMAND="/builds/test_on_install.sh ${CONTAINER_TYPE}"
 
 # Figure out the directory where this script is.
 SCRIPT_DIR=$( cd ${0%/*} && pwd -P )
@@ -78,4 +78,4 @@ docker run \
     ${CI_BUILD_DOCKER_RUN_COMMAND_PREFIX[@]} \
    "tensorflow/tools/ci_build/builds/with_the_same_user" \
    "tensorflow/tools/ci_build/builds/configured" \
-   "${CONTAINER_TYPE}" ${COMMAND}
+   "${CONTAINER_TYPE}" ${COMMAND[@]}

--- a/tensorflow/tools/ci_build/ci_test_on_install.sh
+++ b/tensorflow/tools/ci_build/ci_test_on_install.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Get the command line arguments.
+CONTAINER_TYPE=$( echo "$1" | tr '[:upper:]' '[:lower:]' )
+
+COMMAND=/builds/test_on_install.sh
+
+# Validate command line arguments.
+if [ "$#" -gt 1 ] || [[ ! "${CONTAINER_TYPE}" =~ ^(cpu|gpu|android)$ ]]; then
+  >&2 echo "Usage: $(basename $0) CONTAINER_TYPE"
+  >&2 echo "       CONTAINER_TYPE can be 'CPU' or 'GPU'"
+  >&2 echo ""
+  >&2 echo "Example (run test-on-install on CPU):"
+  >&2 echo "$0 CPU"
+  exit 1
+fi
+
+
+# Figure out the directory where this script is.
+SCRIPT_DIR=$( cd ${0%/*} && pwd -P )
+
+# Helper function to traverse directories up until given file is found.
+function upsearch () {
+  test / == "$PWD" && return || \
+      test -e "$1" && echo "$PWD" && return || \
+      cd .. && upsearch "$1"
+}
+
+# Set up WORKSPACE and BUILD_TAG. Jenkins will set them for you or we pick
+# reasonable defaults if you run it outside of Jenkins.
+WORKSPACE="${WORKSPACE:-$(upsearch WORKSPACE)}"
+BUILD_TAG="${BUILD_TAG:-tf_ci}"
+
+
+# Print arguments.
+echo "CONTAINER_TYPE: ${CONTAINER_TYPE}"
+echo "COMMAND: ${COMMAND[@]}"
+echo "WORKSAPCE: ${WORKSPACE}"
+echo "BUILD_TAG: ${BUILD_TAG}"
+echo "  (docker container name will be ${BUILD_TAG}.${CONTAINER_TYPE})"
+echo ""
+
+
+# Build the docker container.
+echo "Building container (${BUILD_TAG}.${CONTAINER_TYPE})..."
+docker build -t ${BUILD_TAG}.${CONTAINER_TYPE} \
+    -f ${SCRIPT_DIR}/Dockerfile.${CONTAINER_TYPE} ${SCRIPT_DIR}
+
+# Run the command inside the container.
+echo "Running '${COMMAND[@]}' inside ${BUILD_TAG}.${CONTAINER_TYPE}..."
+mkdir -p ${WORKSPACE}/bazel-ci_build-cache
+docker run \
+    --rm \
+    -v ${WORKSPACE}/bazel-ci_build-cache:${WORKSPACE}/bazel-ci_build-cache \
+    -e "CI_BUILD_HOME=${WORKSPACE}/bazel-ci_build-cache" \
+    -e "CI_BUILD_USER=${USER}" \
+    -e "CI_BUILD_UID=$(id -u $USER)" \
+    -e "CI_BUILD_GROUP=$(id -g --name $USER)" \
+    -e "CI_BUILD_GID=$(id -g $USER)" \
+    -v ${WORKSPACE}:/tensorflow \
+    -w /tensorflow \
+    ${CI_BUILD_DOCKER_RUN_EXTRA_PARAMETERS[@]} \
+    "${BUILD_TAG}.${CONTAINER_TYPE}" \
+    ${CI_BUILD_DOCKER_RUN_COMMAND_PREFIX[@]} \
+   "tensorflow/tools/ci_build/builds/with_the_same_user" \
+   "tensorflow/tools/ci_build/builds/configured" \
+   "${CONTAINER_TYPE}" ${COMMAND}


### PR DESCRIPTION
PIP package is built and installed in a Docker container. Then the Python unit tests in the TF source are moved to a separate folder and ran with the plain Python environment without Blaze.

Four out of 151 tests were skipped for now due to dependency on modules in TF source that are not publicly exported.

Tests performed: Jenkins experimental builds for CPU and GPU Python test-on-install, see passing results at: 
http://ci.tensorflow.org/view/Experimental/job/experimental-cais-tensorflow-cpu-python27-copt_pip_install-test/1/consoleFull
http://ci.tensorflow.org/view/Experimental/job/experimental-cais-tensorflow-gpu-python27-copt_pip_install-test/1/consoleFull
