### PR TITLE
Change types of constant numeric literals.

### DIFF
--- a/tensorflow/cc/tutorials/example_trainer.cc
+++ b/tensorflow/cc/tutorials/example_trainer.cc
@@ -114,7 +114,7 @@ void ConcurrentSteps(const Options* opts, int session_index) {
         outputs.clear();
         TF_CHECK_OK(
             session->Run({{"x", x}}, {"y:0", "y_normalized:0"}, {}, &outputs));
-        CHECK_EQ(2, outputs.size());
+        CHECK_EQ(size_t{2}, outputs.size());
 
         const Tensor& y = outputs[0];
         const Tensor& y_norm = outputs[1];

--- a/tensorflow/core/common_runtime/constant_folding.cc
+++ b/tensorflow/core/common_runtime/constant_folding.cc
@@ -115,9 +115,9 @@ Graph* GetConstantGraph(const Graph* orig_graph,
     already_added.insert(added);
     for (const Edge* in_edge : n->in_edges()) {
       Node* in = in_edge->src();
-      CHECK_GT(node_map.count(in), 0) << n->DebugString() << " <-"
+      CHECK_GT(node_map.count(in), size_t{0}) << n->DebugString() << " <-"
                                       << in->DebugString();
-      CHECK_GT(already_added.count(node_map[in]), 0) << in->DebugString();
+      CHECK_GT(already_added.count(node_map[in]), size_t{0}) << in->DebugString();
       constant_graph->AddEdge(node_map[in], in_edge->src_output(), added,
                               in_edge->dst_input());
     }

--- a/tensorflow/core/common_runtime/device_factory.cc
+++ b/tensorflow/core/common_runtime/device_factory.cc
@@ -116,7 +116,7 @@ Device* DeviceFactory::NewDevice(const string& type,
   (*opt.config.mutable_device_count())[type] = 1;
   std::vector<Device*> devices;
   device_factory->CreateDevices(opt, name_prefix, &devices);
-  CHECK_EQ(devices.size(), 1);
+  CHECK_EQ(devices.size(), size_t{1});
   return devices[0];
 }
 

--- a/tensorflow/core/common_runtime/function.cc
+++ b/tensorflow/core/common_runtime/function.cc
@@ -416,7 +416,7 @@ REGISTER_KERNEL_BUILDER(Name(kGradientOp).Device(DEVICE_GPU),
 
 const FunctionBody* FunctionLibraryRuntimeImpl::GetFunctionBody(Handle h) {
   mutex_lock l(mu_);
-  CHECK_LE(0, h);
+  CHECK_LE(static_cast<Handle>(0), h);
   CHECK_LT(h, func_graphs_.size());
   return func_graphs_[h];
 }

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
@@ -153,7 +153,7 @@ void* GPUBFCAllocator::AllocateRawInternal(size_t unused_alignment,
   // allocate multiples of 256 bytes so all memory addresses are
   // nicely byte aligned.
   size_t rounded_bytes = (256 * ((num_bytes + 255) / 256));
-  DCHECK_EQ(0, rounded_bytes % 256);
+  DCHECK_EQ(size_t{0}, rounded_bytes % 256);
 
   // The BFC allocator tries to find the best fit first.
   //

--- a/tensorflow/core/common_runtime/gpu/gpu_region_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_region_allocator.cc
@@ -171,7 +171,7 @@ bool GPURegionAllocator::ExpandPool(Pool* pool, size_t chunk_size,
                                     bool dump_log_on_failure) {
   VLOG(1) << "ExpandPool of " << chunk_size << " from " << pool->num_chunks
           << " current members";
-  DCHECK_NE(0, chunk_size);
+  DCHECK_NE(size_t{0}, chunk_size);
   // If chunk_size is < 4096, double the pool size.  Otherwise
   // just increase by one.
   int num_chunks = pool->num_chunks;

--- a/tensorflow/core/common_runtime/gpu/pool_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/pool_allocator.cc
@@ -39,7 +39,7 @@ PoolAllocator::PoolAllocator(size_t pool_size_limit, bool auto_resize,
       size_rounder_(size_rounder),
       allocation_begun_(false) {
   if (auto_resize) {
-    CHECK_LT(0, pool_size_limit)
+    CHECK_LT(size_t{0}, pool_size_limit)
         << "size limit must be > 0 if auto_resize is true.";
   }
 }

--- a/tensorflow/core/framework/function.cc
+++ b/tensorflow/core/framework/function.cc
@@ -157,7 +157,7 @@ Status BuildInputArgIndex(const OpDef::ArgDef& arg_def,
   bool is_type_list;
   DataTypeVector dtypes;
   TF_RETURN_IF_ERROR(ArgNumType(attr_values, arg_def, &is_type_list, &dtypes));
-  CHECK_GE(dtypes.size(), 1);
+  CHECK_GE(dtypes.size(), size_t{1});
   GraphDef* gdef = &result->gdef;
   int arg_index = gdef->node_size();
   TF_RETURN_IF_ERROR(AddArgName(name_info, arg_def.name(),
@@ -312,7 +312,7 @@ Status AddReturnNode(const OpDef::ArgDef& ret_def,
   bool is_type_list;
   DataTypeVector dtypes;
   TF_RETURN_IF_ERROR(ArgNumType(attrs, ret_def, &is_type_list, &dtypes));
-  CHECK_GE(dtypes.size(), 1);
+  CHECK_GE(dtypes.size(), size_t{1});
   const NameInfoItem* item = gtl::FindOrNull(name_info, ret_def.name());
   if (item == nullptr) {
     return errors::InvalidArgument("ret is not found.");

--- a/tensorflow/core/framework/tensor_util.cc
+++ b/tensorflow/core/framework/tensor_util.cc
@@ -41,7 +41,7 @@ Tensor DeepCopy(const Tensor& other) {
 }
 
 Tensor Concat(const gtl::ArraySlice<Tensor>& tensors) {
-  CHECK_GT(tensors.size(), 0);
+  CHECK_GT(tensors.size(), size_t{0});
   int64 total_dim0_size = 0;
   for (const Tensor& tensor : tensors) {
     CHECK_GT(tensor.dims(), 0);

--- a/tensorflow/core/graph/graph.cc
+++ b/tensorflow/core/graph/graph.cc
@@ -253,11 +253,11 @@ const Edge* Graph::AddEdge(Node* source, int x, Node* dest, int y) {
 void Graph::RemoveEdge(const Edge* e) {
   DCHECK(IsValidNode(e->src_)) << e->src_->DebugString();
   DCHECK(IsValidNode(e->dst_)) << e->dst_->DebugString();
-  CHECK_EQ(e->src_->out_edges_.erase(e), 1);
-  CHECK_EQ(e->dst_->in_edges_.erase(e), 1);
+  CHECK_EQ(e->src_->out_edges_.erase(e), size_t{1});
+  CHECK_EQ(e->dst_->in_edges_.erase(e), size_t{1});
   CHECK_EQ(e, edges_[e->id_]);
 
-  CHECK_EQ(edge_set_.erase(e), 1);
+  CHECK_EQ(edge_set_.erase(e), size_t{1});
   edges_[e->id_] = nullptr;
 
   Edge* del = const_cast<Edge*>(e);

--- a/tensorflow/core/kernels/fifo_queue.cc
+++ b/tensorflow/core/kernels/fifo_queue.cc
@@ -36,7 +36,7 @@ FIFOQueue::FIFOQueue(int capacity, const DataTypeVector& component_dtypes,
     : TypedQueue(capacity, component_dtypes, component_shapes, name) {}
 
 void FIFOQueue::DequeueLocked(OpKernelContext* ctx, Tuple* tuple) {
-  DCHECK_GT(queues_[0].size(), 0);
+  DCHECK_GT(queues_[0].size(), size_t{0});
   (*tuple).reserve(num_components());
   for (int i = 0; i < num_components(); ++i) {
     (*tuple).push_back(*queues_[i][0].AccessTensor(ctx));

--- a/tensorflow/core/kernels/random_shuffle_queue_op.cc
+++ b/tensorflow/core/kernels/random_shuffle_queue_op.cc
@@ -107,7 +107,7 @@ Status RandomShuffleQueue::Initialize() {
 }
 
 void RandomShuffleQueue::DequeueLocked(OpKernelContext* ctx, Tuple* tuple) {
-  DCHECK_GT(queues_[0].size(), 0);
+  DCHECK_GT(queues_[0].size(), size_t{0});
   int64 index = generator_() % queues_[0].size();
   (*tuple).reserve(num_components());
   for (int i = 0; i < num_components(); ++i) {

--- a/tensorflow/core/kernels/range_sampler.cc
+++ b/tensorflow/core/kernels/range_sampler.cc
@@ -97,7 +97,7 @@ void RangeSampler::SampleBatchGetExpectedCountAvoid(
       }
     }
   } else {
-    CHECK_EQ(avoided_values.size(), 0)
+    CHECK_EQ(avoided_values.size(), size_t{0})
         << "avoided_values only supported with unique=true";
     for (int i = 0; i < batch_size; i++) {
       batch[i] = Sample(rnd);
@@ -138,7 +138,7 @@ void AllSampler::SampleBatchGetExpectedCountAvoid(
       batch_expected_count[i] = 1;
     }
   }
-  CHECK_EQ(0, avoided_values.size());
+  CHECK_EQ(size_t{0}, avoided_values.size());
   CHECK_EQ(extras.size(), extras_expected_count.size());
   for (size_t i = 0; i < extras.size(); i++) {
     extras_expected_count[i] = 1;

--- a/tensorflow/core/kernels/sparse_matmul_op.cc
+++ b/tensorflow/core/kernels/sparse_matmul_op.cc
@@ -803,7 +803,7 @@ inline void SparseMatMulOp::ComputeBlockSizes(const ConstMatrixMap& left,
 
   *JB = std::max(1, static_cast<int>(sqrt(num_threads) / 2.0));
   *IB = 8 * *JB;
-  DCHECK_EQ(N * sizeof(float) % 64, 0);
+  DCHECK_EQ(N * sizeof(float) % 64, size_t{0});
 }
 
 // Here is a an overview of the SparseMatMul code. Note that we assume that the

--- a/tensorflow/core/lib/core/arena.cc
+++ b/tensorflow/core/lib/core/arena.cc
@@ -77,7 +77,7 @@ bool Arena::SatisfyAlignment(size_t alignment) {
     freestart_ += waste;
     remaining_ -= waste;
   }
-  DCHECK_EQ(0, reinterpret_cast<size_t>(freestart_) & (alignment - 1));
+  DCHECK_EQ(size_t{0}, reinterpret_cast<size_t>(freestart_) & (alignment - 1));
   return true;
 }
 
@@ -168,7 +168,7 @@ Arena::AllocatedBlock* Arena::AllocNewBlock(const size_t block_size,
   const uint32 adjusted_alignment =
       (alignment > 1 ? LeastCommonMultiple(alignment, kDefaultAlignment) : 1);
 
-  CHECK_LE(adjusted_alignment, 1 << 20)
+  CHECK_LE(adjusted_alignment, static_cast<uint32>(1 << 20))
       << "Alignment on boundaries greater than 1MB not supported.";
 
   // If block_size > alignment we force block_size to be a multiple

--- a/tensorflow/core/lib/histogram/histogram.cc
+++ b/tensorflow/core/lib/histogram/histogram.cc
@@ -59,7 +59,7 @@ Histogram::Histogram(gtl::ArraySlice<double> custom_bucket_limits)
                             custom_bucket_limits.end()),
       bucket_limits_(custom_bucket_limits_) {
 #ifndef NDEBUG
-  DCHECK_GT(bucket_limits_.size(), 0);
+  DCHECK_GT(bucket_limits_.size(), size_t{0});
   // Verify that the bucket boundaries are strictly increasing
   for (size_t i = 1; i < bucket_limits_.size(); i++) {
     DCHECK_GT(bucket_limits_[i], bucket_limits_[i - 1]);

--- a/tensorflow/core/lib/jpeg/jpeg_mem.cc
+++ b/tensorflow/core/lib/jpeg/jpeg_mem.cc
@@ -540,7 +540,7 @@ bool CompressInternal(const uint8* srcdata, int width, int height,
         row_pointer[0] = reinterpret_cast<JSAMPLE*>(const_cast<JSAMPLE*>(r));
       }
     }
-    CHECK_EQ(jpeg_write_scanlines(&cinfo, row_pointer, 1), 1);
+    CHECK_EQ(jpeg_write_scanlines(&cinfo, row_pointer, 1), 1u);
   }
   jpeg_finish_compress(&cinfo);
 

--- a/tensorflow/core/util/sparse/dim_comparator.h
+++ b/tensorflow/core/util/sparse/dim_comparator.h
@@ -48,7 +48,7 @@ class DimComparator {
   inline DimComparator(const TTypes<int64>::Matrix& ix,
                        const VarDimArray& order, int dims)
       : ix_(ix), order_(order), dims_(dims) {
-    CHECK_GT(order.size(), 0) << "Must order using at least one index";
+    CHECK_GT(order.size(), size_t{0}) << "Must order using at least one index";
     CHECK_LE(order.size(), dims_) << "Can only sort up to dims";
     for (size_t d = 0; d < order.size(); ++d) {
       CHECK_GE(order[d], 0);

--- a/tensorflow/core/util/sparse/sparse_tensor.h
+++ b/tensorflow/core/util/sparse/sparse_tensor.h
@@ -340,7 +340,7 @@ bool SparseTensor::ToDense(Tensor* out, bool initialize) {
 template <typename T>
 SparseTensor SparseTensor::Concat(
     const gtl::ArraySlice<SparseTensor>& tensors) {
-  CHECK_GE(tensors.size(), 1) << "Cannot concat 0 SparseTensors";
+  CHECK_GE(tensors.size(), size_t{1}) << "Cannot concat 0 SparseTensors";
   const int dims = tensors[0].dims_;
   CHECK_GE(dims, 1) << "Cannot concat 0-dimensional SparseTensors";
   auto order_0 = tensors[0].order();

--- a/tensorflow/core/util/tensor_slice_reader_cache.cc
+++ b/tensorflow/core/util/tensor_slice_reader_cache.cc
@@ -92,7 +92,7 @@ const TensorSliceReader* TensorSliceReaderCache::GetReader(
     } else {
       delete tmp_reader;
     }
-    CHECK_EQ(1, still_opening_.erase(filepattern));
+    CHECK_EQ(size_t{1}, still_opening_.erase(filepattern));
     VLOG(1) << "Cached TensorSliceReader for " << filepattern << ": " << reader;
   } else {
     auto cached_val = readers_[filepattern];


### PR DESCRIPTION
This PR fixes mismatched types in numeric literals usages.
For examples, use 'size_t{0}' and '1u' instead of '0' and '1' respectively.
This removes 26 simple compiler warnings in 20 files
on 'signed' and 'unsigned' comparisons on CHECK_\* and DCHECK_\* macros.
