### PR TITLE
Add a missing `import` statement to show correct error messages.

### DIFF
--- a/tensorflow/python/platform/default/_googletest.py
+++ b/tensorflow/python/platform/default/_googletest.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import inspect
 import itertools
 import os
+import sys
 import tempfile
 
 # pylint: disable=wildcard-import


### PR DESCRIPTION
`_googletest.py` uses `sys.stderr.write` and `sys.exit` without importing `sys`.
