### PR TITLE
Remove external/<repositoryName>/ prefix from C includes statements

### DIFF
--- a/tensorflow/core/platform/jpeg.h
+++ b/tensorflow/core/platform/jpeg.h
@@ -23,10 +23,10 @@ limitations under the License.
 #elif defined(PLATFORM_POSIX) || defined(PLATFORM_POSIX_ANDROID) || \
     defined(PLATFORM_GOOGLE_ANDROID)
 extern "C" {
-#include "external/jpeg_archive/jpeg-9a/jerror.h"
-#include "external/jpeg_archive/jpeg-9a/jinclude.h"
-#include "external/jpeg_archive/jpeg-9a/jpeglib.h"
-#include "external/jpeg_archive/jpeg-9a/transupp.h"  // for rotations
+#include "jpeg-9a/jerror.h"
+#include "jpeg-9a/jinclude.h"
+#include "jpeg-9a/jpeglib.h"
+#include "jpeg-9a/transupp.h"  // for rotations
 }
 #else
 #error Define the appropriate PLATFORM_<foo> macro for this platform

--- a/tensorflow/core/platform/png.h
+++ b/tensorflow/core/platform/png.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include "tensorflow/core/platform/google/build_config/png.h"
 #elif defined(PLATFORM_POSIX) || defined(PLATFORM_POSIX_ANDROID) || \
     defined(PLATFORM_GOOGLE_ANDROID)
-#include "external/png_archive/libpng-1.2.53/png.h"
+#include "libpng-1.2.53/png.h"
 #else
 #error Define the appropriate PLATFORM_<foo> macro for this platform
 #endif

--- a/tensorflow/core/platform/regexp.h
+++ b/tensorflow/core/platform/regexp.h
@@ -27,7 +27,7 @@ typedef ::StringPiece RegexpStringPiece;
 
 #else
 
-#include "external/re2/re2/re2.h"
+#include "re2/re2.h"
 namespace tensorflow {
 typedef re2::StringPiece RegexpStringPiece;
 }  // namespace tensorflow

--- a/third_party/eigen3/Eigen/Cholesky
+++ b/third_party/eigen3/Eigen/Cholesky
@@ -1,1 +1,1 @@
-#include "external/eigen_archive/eigen-eigen-b45554449873/Eigen/Cholesky"
+#include "eigen-eigen-b45554449873/Eigen/Cholesky"

--- a/third_party/eigen3/Eigen/Core
+++ b/third_party/eigen3/Eigen/Core
@@ -1,1 +1,1 @@
-#include "external/eigen_archive/eigen-eigen-b45554449873/Eigen/Core"
+#include "eigen-eigen-b45554449873/Eigen/Core"

--- a/third_party/eigen3/Eigen/Eigenvalues
+++ b/third_party/eigen3/Eigen/Eigenvalues
@@ -1,1 +1,1 @@
-#include "external/eigen_archive/eigen-eigen-b45554449873/Eigen/Eigenvalues"
+#include "eigen-eigen-b45554449873/Eigen/Eigenvalues"

--- a/third_party/eigen3/Eigen/LU
+++ b/third_party/eigen3/Eigen/LU
@@ -1,1 +1,1 @@
-#include "external/eigen_archive/eigen-eigen-b45554449873/Eigen/LU"
+#include "eigen-eigen-b45554449873/Eigen/LU"

--- a/third_party/eigen3/Eigen/QR
+++ b/third_party/eigen3/Eigen/QR
@@ -1,1 +1,1 @@
-#include "external/eigen_archive/eigen-eigen-b45554449873/Eigen/QR"
+#include "eigen-eigen-b45554449873/Eigen/QR"

--- a/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
+++ b/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
@@ -1,1 +1,1 @@
-#include "external/eigen_archive/eigen-eigen-b45554449873/unsupported/Eigen/CXX11/Tensor"
+#include "eigen-eigen-b45554449873/unsupported/Eigen/CXX11/Tensor"


### PR DESCRIPTION
This prefix is invalid when using TensorFlow as a remote repository.
