### PR TITLE
Fix wrong variable name (pickle_name) in 1_notmnist.ipynb

### DIFF
--- a/tensorflow/examples/udacity/1_notmnist.ipynb
+++ b/tensorflow/examples/udacity/1_notmnist.ipynb
@@ -325,7 +325,7 @@
         "            pickle.dump(dataset, f, pickle.HIGHEST_PROTOCOL)\n",
         "        dataset_names.append(set_filename)\n",
         "    except Exception as e:\n",
-        "        print('Unable to save data to', pickle_file, ':', e)\n",
+        "        print('Unable to save data to', set_filename, ':', e)\n",
         "  \n",
         "  return dataset_names\n",
         "\n",


### PR DESCRIPTION
When raise Exception at line 327, 'pickle_file' at line 328 is not predefined and raise error.

NameError: global name 'pickle_file' is not defined
