### PR TITLE
Adding build info print-out for Jenkins Description Setter

### DIFF
--- a/tensorflow/tools/ci_build/builds/configured
+++ b/tensorflow/tools/ci_build/builds/configured
@@ -35,6 +35,6 @@ fi
 
 # Gather and print build information
 SCRIPT_DIR=$( cd ${0%/*} && pwd -P )
-${SCRIPT_DIR}/print_build_info.sh
+${SCRIPT_DIR}/print_build_info.sh ${CONTAINER_TYPE} ${COMMAND[@]}
 
 ${COMMAND[@]}

--- a/tensorflow/tools/ci_build/builds/configured
+++ b/tensorflow/tools/ci_build/builds/configured
@@ -33,4 +33,8 @@ fi
 
 ./configure
 
+# Gather and print build information
+SCRIPT_DIR=$( cd ${0%/*} && pwd -P )
+${SCRIPT_DIR}/print_build_info.sh
+
 ${COMMAND[@]}

--- a/tensorflow/tools/ci_build/builds/print_build_info.sh
+++ b/tensorflow/tools/ci_build/builds/print_build_info.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+# Print build info, including info related to the machine, OS, build tools
+# and TensorFlow source code. This can be used by build tools such as Jenkins.
+# All info is printed on a single line, in JSON format, to workaround the
+# limitation of Jenkins Description Setter Plugin'sthat multi-line regex is
+# not supported.
+
+# Information about machine and OS
+OS=`uname`
+KERNEL=`uname -r`
+
+ARCH=`uname -p`
+PROCESSOR=`grep "model name" /proc/cpuinfo | head -1 | awk '{print substr($0, index($0, $4))}'`
+
+MEM_TOTAL=`grep MemTotal /proc/meminfo | awk '{print $2, $3}'`
+SWAP_TOTAL=`grep SwapTotal /proc/meminfo | awk '{print $2, $3}'`
+
+# Information about build tools
+BAZEL_VER=`bazel version | head -1`
+JAVA_VER=`javac -version 2>&1 | awk '{print $2}'`
+PYTHON_VER=`python -V 2>&1 | awk '{print $2}'`
+GPP_VER=`g++ --version | head -1`
+SWIG_VER=`swig -version | grep -m 1 . | awk '{print $3}'`
+
+# Information about TensorFlow source
+TF_FETCH_URL=`git remote show origin | grep "Fetch URL:" | awk '{print $3}'`
+TF_HEAD=`git rev-parse HEAD`
+
+# NVIDIA & CUDA info
+NVIDIA_DRIVER_VER=""
+if [[ -f /proc/driver/nvidia/version ]]; then
+  NVIDIA_DRIVER_VER=`head -1 /proc/driver/nvidia/version | awk '{print $(NF-6)}'`
+fi
+
+CUDA_DEVICE_COUNT="0"
+CUDA_DEVICE_NAMES=""
+if [[ ! -z `which nvidia-debugdump` ]]; then
+  CUDA_DEVICE_COUNT=`nvidia-debugdump -l | grep "^Found [0-9]*.*device.*" | awk '{print $2}'`
+  CUDA_DEVICE_NAMES=`nvidia-debugdump -l | grep "Device name:.*" | awk '{print substr($0, index($0, $3)) ","}'`
+fi
+
+CUDA_TOOLKIT_VER=""
+if [[ ! -z 'which nvcc' ]]; then
+  CUDA_TOOLKIT_VER=`nvcc -V | grep release | awk '{print $(NF)}'`
+fi
+
+# Print info
+echo "TF_BUILD_INFO = {"\
+"Source_HEAD: \"${TF_HEAD}\", "\
+"Source_remote_origin: \"${TF_FETCH_URL}\", "\
+"OS: \"${OS}\", "\
+"Kernel: \"${KERNEL}\", "\
+"Architecture: \"${ARCH}\", "\
+"Processor: \"${PROCESSOR}\", "\
+"Memory_total: \"${MEM_TOTAL}\", "\
+"Swap_total: \"${SWAP_TOTAL}\", "\
+"Bazel_version: \"${BAZEL_VER}\", "\
+"Java_version: \"${JAVA_VER}\", "\
+"Python_version: \"${PYTHON_VER}\", "\
+"gpp_version: \"${GPP_VER}\", "\
+"NVIDIA_driver_version: \"${NVIDIA_DRIVER_VER}\", "\
+"CUDA_device_count: \"${CUDA_DEVICE_COUNT}\", "\
+"CUDA_device_names: \"${CUDA_DEVICE_NAMES}\", "\
+"CUDA_toolkit_version: \"${CUDA_TOOLKIT_VER}\""\
+"}"

--- a/tensorflow/tools/ci_build/builds/print_build_info.sh
+++ b/tensorflow/tools/ci_build/builds/print_build_info.sh
@@ -17,8 +17,18 @@
 # Print build info, including info related to the machine, OS, build tools
 # and TensorFlow source code. This can be used by build tools such as Jenkins.
 # All info is printed on a single line, in JSON format, to workaround the
-# limitation of Jenkins Description Setter Plugin'sthat multi-line regex is
+# limitation of Jenkins Description Setter Plugin that multi-line regex is
 # not supported.
+#
+# Usage:
+#   print_build_info.sh (CONTAINER_TYPE) (COMMAND)
+#     e.g.,
+#       print_build_info.sh GPU bazel test -c opt --config=cuda //tensorflow/...
+
+# Information about the command
+CONTAINER_TYPE=$1
+shift 1
+COMMAND=("$@")
 
 # Information about machine and OS
 OS=`uname`
@@ -26,6 +36,7 @@ KERNEL=`uname -r`
 
 ARCH=`uname -p`
 PROCESSOR=`grep "model name" /proc/cpuinfo | head -1 | awk '{print substr($0, index($0, $4))}'`
+PROCESSOR_COUNT=`grep "model name" /proc/cpuinfo | wc -l`
 
 MEM_TOTAL=`grep MemTotal /proc/meminfo | awk '{print $2, $3}'`
 SWAP_TOTAL=`grep SwapTotal /proc/meminfo | awk '{print $2, $3}'`
@@ -61,14 +72,17 @@ fi
 
 # Print info
 echo "TF_BUILD_INFO = {"\
-"Source_HEAD: \"${TF_HEAD}\", "\
-"Source_remote_origin: \"${TF_FETCH_URL}\", "\
+"container_type: \"${CONTAINER_TYPE}\", "\
+"command: \"${COMMAND[@]}\", "\
+"source_HEAD: \"${TF_HEAD}\", "\
+"source_remote_origin: \"${TF_FETCH_URL}\", "\
 "OS: \"${OS}\", "\
-"Kernel: \"${KERNEL}\", "\
-"Architecture: \"${ARCH}\", "\
-"Processor: \"${PROCESSOR}\", "\
-"Memory_total: \"${MEM_TOTAL}\", "\
-"Swap_total: \"${SWAP_TOTAL}\", "\
+"kernel: \"${KERNEL}\", "\
+"architecture: \"${ARCH}\", "\
+"processor: \"${PROCESSOR}\", "\
+"processor_count: \"${PROCESSOR_COUNT}\", "\
+"memory_total: \"${MEM_TOTAL}\", "\
+"swap_total: \"${SWAP_TOTAL}\", "\
 "Bazel_version: \"${BAZEL_VER}\", "\
 "Java_version: \"${JAVA_VER}\", "\
 "Python_version: \"${PYTHON_VER}\", "\

--- a/tensorflow/tools/ci_build/builds/print_build_info.sh
+++ b/tensorflow/tools/ci_build/builds/print_build_info.sh
@@ -17,7 +17,7 @@
 # Print build info, including info related to the machine, OS, build tools
 # and TensorFlow source code. This can be used by build tools such as Jenkins.
 # All info is printed on a single line, in JSON format, to workaround the
-# limitation of Jenkins Description Setter Plugin that multi-line regex is
+# limitation of Jenkins Description Setter Plugin'sthat multi-line regex is
 # not supported.
 
 # Information about machine and OS

--- a/tensorflow/tools/ci_build/builds/print_build_info.sh
+++ b/tensorflow/tools/ci_build/builds/print_build_info.sh
@@ -17,7 +17,7 @@
 # Print build info, including info related to the machine, OS, build tools
 # and TensorFlow source code. This can be used by build tools such as Jenkins.
 # All info is printed on a single line, in JSON format, to workaround the
-# limitation of Jenkins Description Setter Plugin'sthat multi-line regex is
+# limitation of Jenkins Description Setter Plugin that multi-line regex is
 # not supported.
 
 # Information about machine and OS


### PR DESCRIPTION
This is addressing issue https://github.com/tensorflow/tensorflow/issues/736

The print-out JSON object line can be used by Jenkins Description Setter to extract and display information about the build, including source version, platform and build tools. See example at: 

http://ci.tensorflow.org/view/Experimental/job/experimental-cais-tensorflow-cpu-python27-copt_pip_install-test/29/
