### PR TITLE
Fix directory_watcher_test on mac.  Fixes #964

### DIFF
--- a/tensorflow/python/summary/impl/directory_watcher_test.py
+++ b/tensorflow/python/summary/impl/directory_watcher_test.py
@@ -32,10 +32,13 @@ class _ByteLoader(object):
 
   def __init__(self, path):
     self._f = open(path)
+    self.bytes_read = 0
 
   def Load(self):
+    self._f.seek(self.bytes_read)
     while True:
       byte = self._f.read(1)
+      self.bytes_read += 1
       if byte:
         yield byte
       else:


### PR DESCRIPTION
Keeps track of seek position and seeks to current byte offset prior to reading
from the file.  Apparently this is necessary on Mac, because once you've read EOF,
you need to seek to your current position to read new data that has since been
appended to the file.
