### PR TITLE
Print `tags` instead of `tag` since `tag` doesn't exist in funtion `Run`.

### DIFF
--- a/tensorflow/tensorboard/scripts/demo_from_server.py
+++ b/tensorflow/tensorboard/scripts/demo_from_server.py
@@ -120,12 +120,12 @@ class TensorBoardStaticSerializer(object):
             for t in tags:
               self._RetrieveAndSave(tag_type, run, t)
         except requests.exceptions.ConnectionError as e:
-          print('Retrieval failed for %s/%s/%s' % (tag_type, run, tag))
+          print('Retrieval failed for %s/%s/%s' % (tag_type, run, tags))
           print('Got error: ', e)
           print('continuing...')
           continue
         except IOError as e:
-          print('Retrieval failed for %s/%s/%s' % (tag_type, run, tag))
+          print('Retrieval failed for %s/%s/%s' % (tag_type, run, tags))
           print('Got error: ', e)
           print('continuing...')
           continue


### PR DESCRIPTION
Otherwise, in order to print exception info for each tag,
we also are able to declare local variable `tag`, and
set it with the value of `t` in for statement.
