### PR TITLE
Make python_check relocatable

### DIFF
--- a/util/python/BUILD
+++ b/util/python/BUILD
@@ -19,6 +19,6 @@ genrule(
     outs = [
         "python_checked",
     ],
-    cmd = "OUTPUTDIR=\"$(@D)/\"; ./util/python/python_config.sh --check && touch $$OUTPUTDIR/python_checked",
+    cmd = "OUTPUTDIR=\"$(@D)/\"; $(location :python_config.sh) --check && touch $$OUTPUTDIR/python_checked",
     local = 1,
 )

--- a/util/python/python_config.sh
+++ b/util/python/python_config.sh
@@ -16,7 +16,14 @@
 
 set -e -o errexit
 
-EXPECTED_PATHS="util/python/python_include util/python/python_lib third_party/py/numpy/numpy_include"
+# Prefix expected paths with ./ locally and external/reponame/ for remote repos.
+# TODO(kchodorow): remove once runfiles paths are fixed, see
+# https://github.com/bazelbuild/bazel/issues/848.
+script_path=$(dirname $(dirname $(dirname "$0")))
+script_path=${script_path:-.}
+EXPECTED_PATHS="$script_path/util/python/python_include"\
+" $script_path/util/python/python_lib"\
+" $script_path/third_party/py/numpy/numpy_include"
 
 function main {
   argument="$1"


### PR DESCRIPTION
Uses $location in the genrule and a path that's relative to the
script to find expected files so that this works both as a local
rule and if tensorflow is used as a remote repository.
