### PR TITLE
Python3 tests: getting easy ones out of the way

### DIFF
--- a/tensorflow/contrib/layers/python/framework/BUILD
+++ b/tensorflow/contrib/layers/python/framework/BUILD
@@ -32,6 +32,7 @@ py_test(
     name = "tensor_util_test",
     size = "small",
     srcs = ["tensor_util_test.py"],
+    srcs_version = "PY2AND3",
     deps = [
         ":tensor_util",
         "//tensorflow:tensorflow_py",

--- a/tensorflow/python/kernel_tests/learn_test.py
+++ b/tensorflow/python/kernel_tests/learn_test.py
@@ -59,7 +59,7 @@ class FullyConnectedTest(tf.test.TestCase):
     self.assertTrue(np.all(out_value >= 0),
                     'Relu should have all values >= 0.')
 
-    self.assertGreater(tf.get_collection(tf.GraphKeys.SUMMARIES), 0,
+    self.assertGreater(len(tf.get_collection(tf.GraphKeys.SUMMARIES)), 0,
                        'Some summaries should have been added.')
     self.assertEqual(2,
                      len(tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)))
@@ -81,7 +81,7 @@ class FullyConnectedTest(tf.test.TestCase):
     self.assertTrue(np.all(out_value >= 0),
                     'Relu should have all values >= 0.')
 
-    self.assertGreater(tf.get_collection(tf.GraphKeys.SUMMARIES), 0,
+    self.assertGreater(len(tf.get_collection(tf.GraphKeys.SUMMARIES)), 0,
                        'Some summaries should have been added.')
     self.assertEqual(2,
                      len(tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)))
@@ -105,7 +105,7 @@ class FullyConnectedTest(tf.test.TestCase):
     self.assertTrue(np.all(out_value <= 6),
                     'Relu6 should have all values <= 6.')
 
-    self.assertGreater(tf.get_collection(tf.GraphKeys.SUMMARIES), 0,
+    self.assertGreater(len(tf.get_collection(tf.GraphKeys.SUMMARIES)), 0,
                        'Some summaries should have been added.')
     self.assertEqual(2,
                      len(tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)))
@@ -264,7 +264,7 @@ class Convolution2dTest(tf.test.TestCase):
     self.assertTrue(np.all(out_value >= 0),
                     'Relu should have capped all values.')
 
-    self.assertGreater(tf.get_collection(tf.GraphKeys.SUMMARIES), 0,
+    self.assertGreater(len(tf.get_collection(tf.GraphKeys.SUMMARIES)), 0,
                        'Some summaries should have been added.')
     self.assertEqual(2,
                      len(tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)))

--- a/tensorflow/python/kernel_tests/padding_fifo_queue_test.py
+++ b/tensorflow/python/kernel_tests/padding_fifo_queue_test.py
@@ -429,11 +429,11 @@ class PaddingFIFOQueueTest(tf.test.TestCase):
       string_val, int_val = sess.run(dequeued_t)
 
       self.assertAllEqual(
-          [["a", "", ""],
-           ["ab", "", ""],
-           ["abc", "", ""],
-           ["abc", "d", ""],
-           ["abc", "d", "e"]],
+          [[b"a", b"", b""],
+           [b"ab", b"", b""],
+           [b"abc", b"", b""],
+           [b"abc", b"d", b""],
+           [b"abc", b"d", b"e"]],
           string_val)
       self.assertAllEqual(
           [[[1, 0, 0]],
@@ -450,7 +450,7 @@ class PaddingFIFOQueueTest(tf.test.TestCase):
               dequeued_t[1].get_shape()))
 
       string_val, int_val = sess.run(dequeued_single_t)
-      self.assertAllEqual(["abc", "d", "e", "f"], string_val)
+      self.assertAllEqual([b"abc", b"d", b"e", b"f"], string_val)
       self.assertAllEqual([[1, 2, 3, 4]], int_val)
       self.assertTrue(
           tf.TensorShape(string_val.shape).is_compatible_with(

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -24,6 +24,7 @@ import tensorflow as tf
 
 from tensorflow.python.framework import errors
 from tensorflow.python.ops import script_ops
+from six.moves import xrange
 
 
 class PyOpTest(tf.test.TestCase):
@@ -100,7 +101,7 @@ class PyOpTest(tf.test.TestCase):
       self.assertAllClose(x.eval(), 42.0)
 
   def testCleanup(self):
-    for _ in range(1000):
+    for _ in xrange(1000):
       g = tf.Graph()
       with g.as_default():
         c = tf.constant([1.], tf.float32)

--- a/tensorflow/python/kernel_tests/rnn_test.py
+++ b/tensorflow/python/kernel_tests/rnn_test.py
@@ -25,6 +25,7 @@ import tensorflow.python.platform
 import numpy as np
 import tensorflow as tf
 
+from six.moves import xrange
 
 class Plus1RNNCell(tf.nn.rnn_cell.RNNCell):
   """RNN Cell generating (output, new_state) = (input + 1, state + 1)."""


### PR DESCRIPTION
Adding PY2AND3 label for a Python test file. Getting rid some obvious Python 2-3 compatibility issues that cause test errors, including comparing lists with integers, string-byte array difference, and use of xrange. After this CL, there are still 11 tests that fail in Python3. Those are more involved issues and will be addressed separately. 
