### PR TITLE
Set visibility of all targets to //visibilty:public

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -2,7 +2,7 @@
 # TensorFlow is a computational framework, primarily for use in machine
 # learning applications.
 
-package(default_visibility = [":internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -17,11 +17,6 @@ config_setting(
     name = "darwin",
     values = {"cpu": "darwin"},
     visibility = ["//visibility:public"],
-)
-
-package_group(
-    name = "internal",
-    packages = ["//tensorflow/..."],
 )
 
 sh_binary(
@@ -40,7 +35,7 @@ filegroup(
             "g3doc/sitemap.md",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(

--- a/tensorflow/cc/BUILD
+++ b/tensorflow/cc/BUILD
@@ -84,5 +84,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/contrib/BUILD
+++ b/tensorflow/contrib/BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-package(default_visibility = ["//tensorflow:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "contrib_py",
@@ -25,5 +25,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/contrib/layers/BUILD
+++ b/tensorflow/contrib/layers/BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-package(default_visibility = ["//tensorflow:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "layers_py",
@@ -25,5 +25,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/contrib/layers/python/framework/BUILD
+++ b/tensorflow/contrib/layers/python/framework/BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-package(default_visibility = ["//tensorflow:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "all_files",
@@ -16,7 +16,7 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -43,7 +43,7 @@
 # cc_library ":android_tensorflow_lib" - Native library
 # portable_proto_library ":android_proto_lib" (Google-internal)
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -1183,5 +1183,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/core/platform/default/build_config/BUILD
+++ b/tensorflow/core/platform/default/build_config/BUILD
@@ -1,7 +1,7 @@
 # Description:
 # Platform-specific build configurations.
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorflow/examples/android/BUILD
+++ b/tensorflow/examples/android/BUILD
@@ -93,5 +93,5 @@ filegroup(
             "gen/**",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/examples/how_tos/reading_data/BUILD
+++ b/tensorflow/examples/how_tos/reading_data/BUILD
@@ -1,7 +1,7 @@
 # Description:
 # Example MNIST TensorFlow models for demonstrating data reading.
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -64,5 +64,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/examples/label_image/BUILD
+++ b/tensorflow/examples/label_image/BUILD
@@ -1,7 +1,7 @@
 # Description:
 #   Tensorflow C++ inference example for labeling images.
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -55,5 +55,5 @@ filegroup(
             "gen/**",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/examples/tutorials/mnist/BUILD
+++ b/tensorflow/examples/tutorials/mnist/BUILD
@@ -11,7 +11,7 @@ py_library(
         "__init__.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":input_data",
         ":mnist",
@@ -22,7 +22,7 @@ py_library(
     name = "input_data",
     srcs = ["input_data.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:internal"],
+    visibility = ["//visibility:public"],
     deps = ["//tensorflow:tensorflow_py"],
 )
 
@@ -32,7 +32,7 @@ py_library(
         "mnist.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorflow:tensorflow_py",
     ],
@@ -111,5 +111,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/examples/tutorials/word2vec/BUILD
+++ b/tensorflow/examples/tutorials/word2vec/BUILD
@@ -1,7 +1,7 @@
 # Description:
 # TensorFlow model for word2vec
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorflow/g3doc/tutorials/BUILD
+++ b/tensorflow/g3doc/tutorials/BUILD
@@ -1,7 +1,7 @@
 # Description:
 # Top-level tutorials files
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorflow/models/embedding/BUILD
+++ b/tensorflow/models/embedding/BUILD
@@ -1,7 +1,7 @@
 # Description:
 # TensorFlow model for word2vec
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -15,7 +15,7 @@ py_library(
         "__init__.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":gen_word2vec",
         ":word2vec",
@@ -82,7 +82,7 @@ cc_library(
     srcs = [
         "word2vec_ops.cc",
     ],
-    visibility = ["//tensorflow:internal"],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",
     ],
@@ -94,7 +94,7 @@ cc_library(
     srcs = [
         "word2vec_kernels.cc",
     ],
-    visibility = ["//tensorflow:internal"],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core",
     ],
@@ -116,5 +116,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/models/image/alexnet/BUILD
+++ b/tensorflow/models/image/alexnet/BUILD
@@ -25,5 +25,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/models/image/cifar10/BUILD
+++ b/tensorflow/models/image/cifar10/BUILD
@@ -9,7 +9,7 @@ py_library(
     name = "cifar10_input",
     srcs = ["cifar10_input.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:internal"],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorflow:tensorflow_py",
     ],
@@ -43,7 +43,7 @@ py_binary(
         "cifar10_eval.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":cifar10",
     ],
@@ -55,7 +55,7 @@ py_binary(
         "cifar10_train.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":cifar10",
     ],
@@ -67,7 +67,7 @@ py_binary(
         "cifar10_multi_gpu_train.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":cifar10",
     ],
@@ -82,5 +82,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/models/image/imagenet/BUILD
+++ b/tensorflow/models/image/imagenet/BUILD
@@ -11,7 +11,7 @@ py_binary(
         "classify_image.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorflow:tensorflow_py",
     ],
@@ -26,5 +26,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/models/image/mnist/BUILD
+++ b/tensorflow/models/image/mnist/BUILD
@@ -11,7 +11,7 @@ py_binary(
         "convolutional.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = ["//tensorflow:tensorflow_py"],
 )
 
@@ -38,5 +38,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/models/rnn/BUILD
+++ b/tensorflow/models/rnn/BUILD
@@ -76,5 +76,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/models/rnn/ptb/BUILD
+++ b/tensorflow/models/rnn/ptb/BUILD
@@ -1,7 +1,7 @@
 # Description:
 # Python support for TensorFlow.
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -59,5 +59,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/models/rnn/translate/BUILD
+++ b/tensorflow/models/rnn/translate/BUILD
@@ -81,5 +81,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1,7 +1,7 @@
 # Description:
 # Python support for TensorFlow.
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -22,7 +22,7 @@ py_library(
         "unsupported.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorflow:__pkg__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":client",
         ":client_testlib",
@@ -1152,5 +1152,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/python/tools/BUILD
+++ b/tensorflow/python/tools/BUILD
@@ -74,5 +74,5 @@ filegroup(
             "gen/**",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/tensorboard/BUILD
+++ b/tensorflow/tensorboard/BUILD
@@ -1,7 +1,7 @@
 # Description:
 # TensorBoard, a dashboard for investigating TensorFlow
 
-package(default_visibility = ["//tensorflow:internal"])
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "tensorboard_frontend",

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -138,7 +138,7 @@ def tf_gen_op_wrapper_py(name, out=None, hidden=[], visibility=None, deps=[],
       linkstatic = 1,   # Faster to link this one-time-use binary dynamically
       deps = (["//tensorflow/core:framework",
                "//tensorflow/python:python_op_gen_main"] + deps),
-      visibility = ["//tensorflow:internal"],
+      visibility = ["//visibility:public"],
   )
 
   # Invoke the previous cc_binary to generate a python file.
@@ -359,7 +359,7 @@ def py_tests(name,
                    srcs=[src],
                    main=src,
                    tags=tags,
-                   visibility=["//tensorflow:internal"],
+                   visibility=["//visibility:public"],
                    shard_count=shard_count,
                    data=data,
                    deps=[

--- a/tensorflow/tools/docker/BUILD
+++ b/tensorflow/tools/docker/BUILD
@@ -23,5 +23,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorflow/tools/docs/BUILD
+++ b/tensorflow/tools/docs/BUILD
@@ -6,7 +6,7 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 package(
-    default_visibility = ["//tensorflow:__subpackages__"],
+    default_visibility = ["//visibility:public"],
 )
 
 py_binary(

--- a/tensorflow/user_ops/BUILD
+++ b/tensorflow/user_ops/BUILD
@@ -2,15 +2,7 @@
 # An example for custom op and kernel defined as a TensorFlow plugin.
 
 package(
-    default_visibility = ["//tensorflow:internal"],
-)
-
-package_group(
-    name = "friends",
-    packages = [
-        "//learning/serving/...",
-        "//platforms/techila/...",
-    ],
+    default_visibility = ["//visibility:public"],
 )
 
 licenses(["notice"])  # Apache 2.0
@@ -58,5 +50,5 @@ filegroup(
             "**/OWNERS",
         ],
     ),
-    visibility = ["//tensorflow:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/third_party/gpus/cuda/BUILD
+++ b/third_party/gpus/cuda/BUILD
@@ -144,19 +144,8 @@ genrule(
         "OUTPUTDIR=`readlink -f $(@D)/../../..`; cd third_party/gpus/cuda; OUTPUTDIR=$$OUTPUTDIR ./cuda_config.sh --check;",
 
         # Under non-cuda config, create all dummy files to make the build go through
-        ";".join([
-          "mkdir -p $(@D)/include",
-          "mkdir -p $(@D)/lib64",
-          "touch $(@D)/include/cuda.h",
-          "touch $(@D)/include/cublas.h",
-          "touch $(@D)/include/cudnn.h",
-          "touch $(@D)/lib64/libcudart_static.a",
-          "touch $(@D)/lib64/libcublas.so." + tf_get_cuda_version(),
-          "touch $(@D)/lib64/libcudnn.so." + tf_get_cudnn_version(),
-          "touch $(@D)/lib64/libcudart.so." + tf_get_cuda_version(),
-          "touch $(@D)/lib64/libcufft.so." + tf_get_cuda_version(),
-            ]),
-    ),
+        "touch $(OUTS)"
+        ),
     local = 1,
 )
 


### PR DESCRIPTION
Bazel has a bug that prevent correct resolution of visibility labels
and this change is using //visiblity:\* targets to be able to
load tensorflow as a remote repository.
