### PR TITLE
Fixing more tests in Python3

### DIFF
--- a/tensorflow/python/framework/function.py
+++ b/tensorflow/python/framework/function.py
@@ -21,6 +21,8 @@ from __future__ import print_function
 import inspect
 import re
 
+from six.moves import xrange
+
 from tensorflow.core.framework import attr_value_pb2
 from tensorflow.core.framework import function_pb2
 from tensorflow.core.framework import op_def_pb2
@@ -159,7 +161,7 @@ def _add_op_node(graph, op, func):
       inp_index += 1
   node.dep.extend([_make_argname_from_tensor_name(x.name)
                    for x in op.control_inputs])
-  for k, v in _get_node_def_attr(op).iteritems():
+  for k, v in _get_node_def_attr(op).items():
     node.attr[k].CopyFrom(v)
   func.node.extend([node])
 
@@ -322,7 +324,7 @@ def define_function(func, input_types):
   if inspect.isfunction(func):
     func_name = func.__name__
   elif inspect.ismethod(func):
-    func_name = func.im_self.__name__ + "." + func.__name__
+    func_name = func.__self__.__name__ + "." + func.__name__
   else:
     raise ValueError("Argument must be a function")
   argspec = inspect.getargspec(func)

--- a/tensorflow/python/framework/function_test.py
+++ b/tensorflow/python/framework/function_test.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import tensorflow.python.platform
 # pylint: enable=unused-import,g-bad-import-order
 
+from six.moves import xrange
 import time
 import numpy as np
 import tensorflow as tf

--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -107,7 +107,7 @@ class UnaryOpTest(tf.test.TestCase):
       try:
         return fn(x)
       except ValueError as e:
-        if "domain error" in e.message:
+        if "domain error" in str(e):
           return np.inf * np.ones_like(x)
         else:
           raise e

--- a/tensorflow/python/kernel_tests/learn_test.py
+++ b/tensorflow/python/kernel_tests/learn_test.py
@@ -32,7 +32,14 @@ def assert_summary_scope(regexp):
   for summary in tf.get_collection(tf.GraphKeys.SUMMARIES):
     tag = tf.unsupported.constant_value(summary.op.inputs[0])
     assert tag is not None, 'All summaries must have constant tags'
+
     tag = str(tag)
+    # Tags in Python 3 erroneously acquire the 'b\'' perfix and '\'' suffix
+    # This is a temporary measure meant to expediently overcome test failure.
+    # TODO: Get rid of the extraneous prefix and suffix.
+    if tag.startswith('b\'') and tag.endswith('\''):
+        tag = tag[2:-1]
+
     assert isinstance(tag[0], six.string_types), tag[0]
     assert re.match(regexp, tag), "tag doesn't match %s: %s" % (regexp, tag)
 
@@ -167,8 +174,8 @@ class FullyConnectedTest(tf.test.TestCase):
                              weight_collections=['unbiased'],
                              bias_collections=['biased'])
 
-    self.assertEquals(1, len(tf.get_collection('unbiased')))
-    self.assertEquals(1, len(tf.get_collection('biased')))
+    self.assertEqual(1, len(tf.get_collection('unbiased')))
+    self.assertEqual(1, len(tf.get_collection('biased')))
 
   def test_all_custom_collections(self):
     tf.learn.fully_connected(self.input,
@@ -177,10 +184,10 @@ class FullyConnectedTest(tf.test.TestCase):
                              weight_collections=['unbiased', 'all'],
                              bias_collections=['biased', 'all'])
 
-    self.assertEquals(1, len(tf.get_collection('unbiased')))
-    self.assertEquals(1, len(tf.get_collection('biased')))
-    self.assertEquals(2, len(tf.get_collection('all')))
-    self.assertEquals(tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES),
+    self.assertEqual(1, len(tf.get_collection('unbiased')))
+    self.assertEqual(1, len(tf.get_collection('biased')))
+    self.assertEqual(2, len(tf.get_collection('all')))
+    self.assertEqual(tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES),
                       tf.get_collection('all'))
 
   def test_no_summaries(self):
@@ -188,7 +195,7 @@ class FullyConnectedTest(tf.test.TestCase):
                              2,
                              activation_fn=tf.nn.relu,
                              create_summaries=False)
-    self.assertEquals([], tf.get_collection(tf.GraphKeys.SUMMARIES))
+    self.assertEqual([], tf.get_collection(tf.GraphKeys.SUMMARIES))
 
   # Verify fix of a bug where no_summaries + activation_fn=None led to a
   # NoneType exception.
@@ -197,7 +204,7 @@ class FullyConnectedTest(tf.test.TestCase):
                              2,
                              activation_fn=None,
                              create_summaries=False)
-    self.assertEquals([], tf.get_collection(tf.GraphKeys.SUMMARIES))
+    self.assertEqual([], tf.get_collection(tf.GraphKeys.SUMMARIES))
 
   def test_regularizer(self):
     cnt = [0]
@@ -330,8 +337,8 @@ class Convolution2dTest(tf.test.TestCase):
                            weight_collections=['unbiased'],
                            bias_collections=['biased'])
 
-    self.assertEquals(1, len(tf.get_collection('unbiased')))
-    self.assertEquals(1, len(tf.get_collection('biased')))
+    self.assertEqual(1, len(tf.get_collection('unbiased')))
+    self.assertEqual(1, len(tf.get_collection('biased')))
 
   def test_all_custom_collections(self):
     tf.learn.convolution2d(self.input,
@@ -340,10 +347,10 @@ class Convolution2dTest(tf.test.TestCase):
                            weight_collections=['unbiased', 'all'],
                            bias_collections=['biased', 'all'])
 
-    self.assertEquals(1, len(tf.get_collection('unbiased')))
-    self.assertEquals(1, len(tf.get_collection('biased')))
-    self.assertEquals(2, len(tf.get_collection('all')))
-    self.assertEquals(tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES),
+    self.assertEqual(1, len(tf.get_collection('unbiased')))
+    self.assertEqual(1, len(tf.get_collection('biased')))
+    self.assertEqual(2, len(tf.get_collection('all')))
+    self.assertEqual(tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES),
                       tf.get_collection('all'))
 
   def test_no_summaries(self):
@@ -351,7 +358,7 @@ class Convolution2dTest(tf.test.TestCase):
                            2, (3, 3),
                            activation_fn=tf.nn.relu,
                            create_summaries=False)
-    self.assertEquals([], tf.get_collection(tf.GraphKeys.SUMMARIES))
+    self.assertEqual([], tf.get_collection(tf.GraphKeys.SUMMARIES))
 
   def test_regularizer(self):
     cnt = [0]

--- a/tensorflow/python/kernel_tests/parsing_ops_test.py
+++ b/tensorflow/python/kernel_tests/parsing_ops_test.py
@@ -98,7 +98,7 @@ class ParseExampleTest(tf.test.TestCase):
       batch_size = (
           serialized.eval().size if isinstance(serialized, tf.Tensor)
           else np.asarray(serialized).size)
-      for k, f in kwargs["features"].iteritems():
+      for k, f in kwargs["features"].items():
         if isinstance(f, tf.FixedLenFeature) and f.shape is not None:
           self.assertEqual(
               tuple(out[k].get_shape().as_list()), (batch_size,) + f.shape)
@@ -367,7 +367,7 @@ class ParseSingleExampleTest(tf.test.TestCase):
         _compare_output_to_expected(self, out, expected_values, tf_result)
 
       # Check shapes.
-      for k, f in kwargs["features"].iteritems():
+      for k, f in kwargs["features"].items():
         if isinstance(f, tf.FixedLenFeature) and f.shape is not None:
           self.assertEqual(tuple(out[k].get_shape()), f.shape)
         elif isinstance(f, tf.VarLenFeature):
@@ -455,7 +455,7 @@ class ParseSequenceExampleTest(tf.test.TestCase):
       # Check shapes; if serialized is a Tensor we need its size to
       # properly check.
       if "context_features" in kwargs:
-        for k, f in kwargs["context_features"].iteritems():
+        for k, f in kwargs["context_features"].items():
           if isinstance(f, tf.FixedLenFeature) and f.shape is not None:
             self.assertEqual(
                 tuple(context_out[k].get_shape().as_list()), f.shape)

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -359,7 +359,7 @@ def _TopKShape(op):
   else:
     k = op.get_attr("k")
   last = input_shape[-1].value
-  if last is not None and last < k:
+  if last is not None and k is not None and last < k:
     raise ValueError("input.shape %s must have last dimension >= k = %d" %
                      (input_shape, k))
   output_shape = input_shape[:-1].concatenate([k])


### PR DESCRIPTION
Fixing more tests in Python3

```
This CL fixes a number of (but not all) remaining Python3 test errors,
including:
//tensorflow/python:cwise_ops_test
//tensorflow/python:gradients_test
//tensorflow/python:topk_op_test
//tensorflow/python:parsing_ops_test
//tensorflow/python:learn_test

It also fixes a subset of the failing tests in:
//tensorflow/python:function_test
```
