### PR TITLE
Minor comment spelling fix.

### DIFF
--- a/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
@@ -21,7 +21,7 @@ http://tensorflow.org/tutorials/mnist/beginners/index.md
 See documentation on the TensorBoard specific pieces at
 http://tensorflow.org/how_tos/summaries_and_tensorboard/index.md
 
-If you modify this file, please update the exerpt in
+If you modify this file, please update the excerpt in
 how_tos/summaries_and_tensorboard/index.md.
 
 """


### PR DESCRIPTION
Changing excerpt spelling in the `mnist_with_summaries.py` file.
