### PR TITLE
Example code for SummaryIterator using `tf.train.summary_iterator`.

### DIFF
--- a/tensorflow/python/training/summary_io.py
+++ b/tensorflow/python/training/summary_io.py
@@ -234,7 +234,7 @@ def summary_iterator(path):
   Example: Print the contents of an events file.
 
   ```python
-  for e in tf.summary_iterator(path to events file):
+  for e in tf.train.summary_iterator(path to events file):
       print(e)
   ```
 
@@ -245,7 +245,7 @@ def summary_iterator(path):
   # summary value tag 'loss'.  These could have been added by calling
   # `add_summary()`, passing the output of a scalar summary op created with
   # with: `tf.scalar_summary(['loss'], loss_tensor)`.
-  for e in tf.summary_iterator(path to events file):
+  for e in tf.train.summary_iterator(path to events file):
       for v in e.summary.value:
           if v.tag == 'loss':
               print(v.simple_value)


### PR DESCRIPTION
I couldn't find [`tensorflow.summary_iterator`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/__init__.py#L92) but found it under [`tensorflow.train`](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/python/training). I've updated the documentation to match [this test](https://github.com/tensorflow/tensorflow/blob/3b3b06278cc7971bb273563bc917a89d49d19e7d/tensorflow/python/training/summary_writer_test.py#L49) which also calls it by `tf.train.summary_iterator`.
