### PR TITLE
Fix for python3 syntax incompatibility.

### DIFF
--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -1074,7 +1074,7 @@ def _add_collection_def(meta_graph_def, key):
         getattr(col_def, kind).value.extend([x.name for x in collection_list])
       else:
         getattr(col_def, kind).value.extend([x for x in collection_list])
-  except Exception, e:  # pylint: disable=broad-except
+  except Exception as e:  # pylint: disable=broad-except
     logging.warning("Type is unsupported, or the types of the items don't "
                     "match field type in CollectionDef.\n%s" % str(e))
     if key in meta_graph_def.collection_def:


### PR DESCRIPTION
Encountered a syntax error while following "Getting started" tutorial with python3:

$ python convolutional.py 
Traceback (most recent call last):
  File "convolutional.py", line 31, in <module>
    import tensorflow.python.platform
  File "/Users/povi/Library/Developer/virtual_envs/py3/lib/python3.5/site-packages/tensorflow/**init**.py", line 23, in <module>
    from tensorflow.python import *
  File "/Users/povi/Library/Developer/virtual_envs/py3/lib/python3.5/site-packages/tensorflow/python/**init**.py", line 73, in <module>
    from tensorflow.python.training import training as train
  File "/Users/povi/Library/Developer/virtual_envs/py3/lib/python3.5/site-packages/tensorflow/python/training/training.py", line 149, in <module>
    from tensorflow.python.training.saver import generate_checkpoint_state_proto
  File "/Users/povi/Library/Developer/virtual_envs/py3/lib/python3.5/site-packages/tensorflow/python/training/saver.py", line 1077
    except Exception, e:  # pylint: disable=broad-except
                    ^
SyntaxError: invalid syntax

Fixed it, so it would be python 2 & 3 compatible.
