### PR TITLE
Fix a bug for an unavailable argument

### DIFF
--- a/tensorflow/examples/tutorials/mnist/input_data.py
+++ b/tensorflow/examples/tutorials/mnist/input_data.py
@@ -67,7 +67,7 @@ def extract_images(filename):
     return data
 
 
-def dense_to_one_hot(labels_dense, num_classes=10):
+def dense_to_one_hot(labels_dense, num_classes):
   """Convert class labels from scalars to one-hot vectors."""
   num_labels = labels_dense.shape[0]
   index_offset = numpy.arange(num_labels) * num_classes
@@ -76,7 +76,7 @@ def dense_to_one_hot(labels_dense, num_classes=10):
   return labels_one_hot
 
 
-def extract_labels(filename, one_hot=False):
+def extract_labels(filename, one_hot=False, num_classes=10):
   """Extract the labels into a 1D uint8 numpy array [index]."""
   print('Extracting', filename)
   with gzip.open(filename) as bytestream:
@@ -89,7 +89,7 @@ def extract_labels(filename, one_hot=False):
     buf = bytestream.read(num_items)
     labels = numpy.frombuffer(buf, dtype=numpy.uint8)
     if one_hot:
-      return dense_to_one_hot(labels)
+      return dense_to_one_hot(labels, num_classes)
     return labels
 
 


### PR DESCRIPTION
The _num_classes_ argument of the _dense_to_one_hot_ function is never called by the other function.

IHMO, we should set the number of classes in _extract_labels_.
Since, the _extract_labels_ is a task-specific-function but the _dense_to_one_hot_ is not.
