### PR TITLE
Fix some compilation issues found with Visual Studio 2015.

### DIFF
--- a/tensorflow/core/framework/allocator.h
+++ b/tensorflow/core/framework/allocator.h
@@ -125,6 +125,7 @@ class Allocator {
   // allocated by this allocator.
   virtual size_t RequestedSize(void* ptr) {
     CHECK(false) << "allocator doesn't track sizes";
+    return 0;
   }
 
   // Returns the allocated size of the buffer at 'ptr' if known,

--- a/tensorflow/core/framework/device_base.h
+++ b/tensorflow/core/framework/device_base.h
@@ -146,6 +146,7 @@ class DeviceBase {
   // attributes requested.  See allocator.h for more details.
   virtual Allocator* GetAllocator(AllocatorAttributes /*attr*/) {
     LOG(FATAL) << "GetAllocator() is not implemented.";
+    return nullptr;
   }
 
   // Return the Allocator implementation to use based on the allocator
@@ -174,9 +175,7 @@ class DeviceBase {
                                      DeviceContext* /*dc*/,
                                      Allocator* /*allocator*/) {}
 
-  virtual const DeviceAttributes& attributes() const {
-    LOG(FATAL) << "Device does not implement attributes()";
-  }
+  virtual const DeviceAttributes& attributes() const = 0;
 
   // Materializes the given TensorProto into 'tensor' stored in Device
   // memory.  Most devices will want to override this.

--- a/tensorflow/core/framework/node_def_builder.h
+++ b/tensorflow/core/framework/node_def_builder.h
@@ -91,6 +91,11 @@ class NodeDefBuilder {
     if (arg != nullptr) ListInput(arg, src_list);
     return *this;
   }
+  NodeDefBuilder& Input(std::vector<NodeDefBuilder::NodeOut> srcs)
+  {
+    gtl::ArraySlice<NodeOut> src_list(srcs);
+    return Input(src_list);
+  }
 
   // To create inputs in tests, see fake_input.h.
   NodeDefBuilder& Input(FakeInputFunctor fake_input);

--- a/tensorflow/core/kernels/range_sampler.h
+++ b/tensorflow/core/kernels/range_sampler.h
@@ -115,10 +115,12 @@ class AllSampler : public RangeSampler {
 
   int64 Sample(random::SimplePhilox* rnd) const override {
     LOG(FATAL) << "Should not be called";
+    return 0;
   }
 
   float Probability(int64 value) const override {
     LOG(FATAL) << "Should not be called";
+    return 0;
   }
 
   void SampleBatchGetExpectedCountAvoid(

--- a/tensorflow/core/lib/gtl/inlined_vector.h
+++ b/tensorflow/core/lib/gtl/inlined_vector.h
@@ -60,7 +60,7 @@ class InlinedVector {
   typedef T& reference;
   typedef const T& const_reference;
   typedef size_t size_type;
-  typedef ssize_t difference_type;
+  typedef ptrdiff_t difference_type;
   typedef pointer iterator;
   typedef const_pointer const_iterator;
 

--- a/tensorflow/core/lib/png/png_io.cc
+++ b/tensorflow/core/lib/png/png_io.cc
@@ -58,7 +58,7 @@ static void Convert8to16(const uint8* p8, int num_comps, int p8_row_bytes,
   for (; height-- != 0;
        CPTR_INC(uint8, p8, bump8), PTR_INC(uint16, p16, bump16)) {
     for (int w = width; w-- != 0; --p8, --p16) {
-      uint pix = *p8;
+      uint32 pix = *p8;
       pix |= pix << 8;
       *p16 = static_cast<uint16>(pix);
     }


### PR DESCRIPTION
- Use standard types in allocator.h, inlined_vector.h and png_io.cc
- Fix missing return in allocator.h, device_base.h and range_sampler.h
- Add function NodeDefBuilder& Input(std::vectorNodeDefBuilder::NodeOut srcs)
  so type std::vectorNodeDefBuilder::NodeOut can be solved unambiguously
