### PR TITLE
Clean out assets left over from a prior run

### DIFF
--- a/tensorflow/tools/ci_build/builds/android.sh
+++ b/tensorflow/tools/ci_build/builds/android.sh
@@ -22,6 +22,8 @@ model_file_name="inception5h.zip"
 tmp_model_file_name="${HOME}/.cache/tensorflow_models/${model_file_name}"
 mkdir -p $(dirname ${tmp_model_file_name})
 [ -e "${tmp_model_file_name}" ] || wget -c "https://storage.googleapis.com/download.tensorflow.org/models/${model_file_name}" -O "${tmp_model_file_name}"
+# We clean up after ourselves, but not if we exit with an error, so make sure we start clean
+rm -rf tensorflow/examples/android/assets/
 unzip -o "${tmp_model_file_name}" -d tensorflow/examples/android/assets/
 
 # Modify the WORKSPACE file.


### PR DESCRIPTION
Before, assets were not cleaned out if the build failed. Since some of them are created with mode 400, the next run will fail because unzip won't overwrite them. This makes sure we always remove the directory before we try unzipping.
