### PR TITLE
Python API docs fix array syntax

### DIFF
--- a/tensorflow/g3doc/api_docs/python/math_ops.md
+++ b/tensorflow/g3doc/api_docs/python/math_ops.md
@@ -395,7 +395,7 @@ Given a tensor `x` and a tensor `y`, this operation computes \\(x^y\\) for
 corresponding elements in `x` and `y`. For example:
 
 ```
-# tensor 'x' is [[2, 2]], [3, 3]]
+# tensor 'x' is [[2, 2], [3, 3]]
 # tensor 'y' is [[8, 16], [2, 3]]
 tf.pow(x, y) ==> [[256, 65536], [9, 27]]
 ```
@@ -1670,7 +1670,7 @@ otherwise, these are inferred.
 For example:
 
 ```python
-# tensor 'a' is [[1, 2], [3, 4]
+# tensor 'a' is [[1, 2], [3, 4]]
 # tensor `b` is [[5, 0], [0, 6]]
 tf.accumulate_n([a, b, a]) ==> [[7, 4], [6, 14]]
 

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -254,7 +254,7 @@ def pow(x, y, name=None):
   corresponding elements in `x` and `y`. For example:
 
   ```
-  # tensor 'x' is [[2, 2]], [3, 3]]
+  # tensor 'x' is [[2, 2], [3, 3]]
   # tensor 'y' is [[8, 16], [2, 3]]
   tf.pow(x, y) ==> [[256, 65536], [9, 27]]
   ```
@@ -1080,7 +1080,7 @@ def accumulate_n(inputs, shape=None, tensor_dtype=None, name=None):
   For example:
 
   ```python
-  # tensor 'a' is [[1, 2], [3, 4]
+  # tensor 'a' is [[1, 2], [3, 4]]
   # tensor `b` is [[5, 0], [0, 6]]
   tf.accumulate_n([a, b, a]) ==> [[7, 4], [6, 14]]
 


### PR DESCRIPTION
Fix array syntax in comments for examples `tf.pow` and `tf.accumulate_n`
