### PR TITLE
Fix bitcast_op_test.py on Python 3

### DIFF
--- a/tensorflow/python/kernel_tests/bitcast_op_test.py
+++ b/tensorflow/python/kernel_tests/bitcast_op_test.py
@@ -28,8 +28,8 @@ class BitcastTest(tf.test.TestCase):
     with self.test_session():
       tf_ans = tf.bitcast(x, datatype)
       out = tf_ans.eval()
-      buff_after = np.getbuffer(out)
-      buff_before = np.getbuffer(x)
+      buff_after = memoryview(out).tobytes()
+      buff_before = memoryview(x).tobytes()
       self.assertEqual(buff_before, buff_after)
       self.assertEqual(tf_ans.get_shape(), shape)
 


### PR DESCRIPTION
This test is failing for me on Python 3 because the `getbuffer` interface only exists in Python 2.
Replacing it with `.data` should work for both versions.

Here is the log output of the failing test:

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
-----------------------------------------------------------------------------
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "DrawBoundingBoxes" device_type: "CPU"') for unknown op: DrawBoundingBoxes
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SparseTensorDenseMatMul" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_COMPLEX64 } } } host_memory_arg: "a_shape"') for unknown op: SparseTensorDenseMatMul
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SparseTensorDenseMatMul" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_INT32 } } } host_memory_arg: "a_shape"') for unknown op: SparseTensorDenseMatMul
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SparseTensorDenseMatMul" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_DOUBLE } } } host_memory_arg: "a_shape"') for unknown op: SparseTensorDenseMatMul
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SparseTensorDenseMatMul" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_FLOAT } } } host_memory_arg: "a_shape"') for unknown op: SparseTensorDenseMatMul
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SampleDistortedBoundingBox" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_INT8 } } }') for unknown op: SampleDistortedBoundingBox
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SampleDistortedBoundingBox" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_INT16 } } }') for unknown op: SampleDistortedBoundingBox
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SampleDistortedBoundingBox" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_UINT8 } } }') for unknown op: SampleDistortedBoundingBox
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SampleDistortedBoundingBox" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_INT32 } } }') for unknown op: SampleDistortedBoundingBox
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SampleDistortedBoundingBox" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_INT64 } } }') for unknown op: SampleDistortedBoundingBox
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SampleDistortedBoundingBox" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_DOUBLE } } }') for unknown op: SampleDistortedBoundingBox
E tensorflow/core/framework/op_kernel.cc:662] OpKernel ('op: "SampleDistortedBoundingBox" device_type: "CPU" constraint { name: "T" allowed_values { list { type: DT_FLOAT } } }') for unknown op: SampleDistortedBoundingBox
E.EEEE.
======================================================================
ERROR: testEmpty (__main__.BitcastTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 68, in testEmpty
    self._testBitcast(x, datatype, shape)
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 31, in _testBitcast
    buff_after = np.getbuffer(out)
AttributeError: 'module' object has no attribute 'getbuffer'

======================================================================
ERROR: testLarger (__main__.BitcastTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 46, in testLarger
    self._testBitcast(x, datatype, shape)
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 31, in _testBitcast
    buff_after = np.getbuffer(out)
AttributeError: 'module' object has no attribute 'getbuffer'

======================================================================
ERROR: testSameDtype (__main__.BitcastTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 51, in testSameDtype
    self._testBitcast(x, x.dtype, shape)
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 31, in _testBitcast
    buff_after = np.getbuffer(out)
AttributeError: 'module' object has no attribute 'getbuffer'

======================================================================
ERROR: testSameSize (__main__.BitcastTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 56, in testSameSize
    self._testBitcast(x, tf.double, shape)
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 31, in _testBitcast
    buff_after = np.getbuffer(out)
AttributeError: 'module' object has no attribute 'getbuffer'

======================================================================
ERROR: testSmaller (__main__.BitcastTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 40, in testSmaller
    self._testBitcast(x, datatype, shape)
  File "/hepgpu1-data3/ibabusch/.cache/bazel/_bazel_ibabusch/f5ec547a72254d5c5a13ec3d76a853de/tensorflow/bazel-out/local_linux-py3-opt/bin/tensorflow/python/bitcast_op_test.runfiles/tensorflow/python/kernel_tests/bitcast_op_test.py", line 31, in _testBitcast
    buff_after = np.getbuffer(out)
AttributeError: 'module' object has no attribute 'getbuffer'

----------------------------------------------------------------------
Ran 7 tests in 0.026s

FAILED (errors=5)
```
