### PR TITLE
Fixing exit code in ci_parameterized_build.sh

### DIFF
--- a/tensorflow/tools/ci_build/ci_parameterized_build.sh
+++ b/tensorflow/tools/ci_build/ci_parameterized_build.sh
@@ -285,11 +285,14 @@ else
   else
     ${TMP_SCRIPT}
   fi
-fi &&
+fi && FAILURE=0 || FAILURE=1
+[[ ${FAILURE} == "0" ]] && RESULT="SUCCESS" || RESULT="FAILURE"
 
 rm -f ${TMP_SCRIPT}
 
 END_TIME=$(date +'%s')
 echo ""
-echo "Parameterized build ends at: $(date) "\
+echo "Parameterized build ends with ${RESULT} at: $(date) "\
 "(Elapsed time: $((${END_TIME} - ${START_TIME})) s)"
+
+exit ${FAILURE}


### PR DESCRIPTION
Commit
https://github.com/tensorflow/tensorflow/commit/00b5ea730ddf63e0cb49a9200f3b610cdbbdc13c#diff-6ea208942bad0a8c2194f5540b5dd618

broke the exit code. This changeset fixes it.
