### PR TITLE
keep numpy version in pip.sh

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip.sh
+++ b/tensorflow/tools/ci_build/builds/pip.sh
@@ -132,7 +132,7 @@ echo "Installing pip whl file: ${WHL_PATH}"
 
 # Call pip install twice, first time with --upgrade and second time without it
 # This addresses the sporadic test failures related to protobuf version
-${PYTHON_BIN_PATH} -m pip install -v --user --upgrade ${WHL_PATH} &&
+${PYTHON_BIN_PATH} -m pip install -v --user --upgrade ${WHL_PATH} numpy==1.8.2 &&
 ${PYTHON_BIN_PATH} -m pip install -v --user ${WHL_PATH} &&
 
 # If NO_TEST_ON_INSTALL is set to any non-empty value, skip all Python


### PR DESCRIPTION
We should keep building against numpy 1.8.2 - the version in ubuntu 14.04.
