### PR TITLE
use string::append to catenate strings

### DIFF
--- a/tensorflow/core/lib/strings/strcat.cc
+++ b/tensorflow/core/lib/strings/strcat.cc
@@ -56,50 +56,42 @@ AlphaNum::AlphaNum(Hex hex) {
 // Append is merely a version of memcpy that returns the address of the byte
 // after the area just overwritten.  It comes in multiple flavors to minimize
 // call overhead.
-static char *Append1(char *out, const AlphaNum &x) {
-  memcpy(out, x.data(), x.size());
-  return out + x.size();
+static void Append1(string *out, const AlphaNum &x) {
+  out->append(x.data(), x.size());
 }
 
-static char *Append2(char *out, const AlphaNum &x1, const AlphaNum &x2) {
-  memcpy(out, x1.data(), x1.size());
-  out += x1.size();
-
-  memcpy(out, x2.data(), x2.size());
-  return out + x2.size();
+static void Append2(string *out, const AlphaNum &x1, const AlphaNum &x2) {
+  out->append(x1.data(), x1.size());
+  out->append(x2.data(), x2.size());
 }
 
-static char *Append4(char *out, const AlphaNum &x1, const AlphaNum &x2,
-                     const AlphaNum &x3, const AlphaNum &x4) {
-  memcpy(out, x1.data(), x1.size());
-  out += x1.size();
+static void Append3(string *out, const AlphaNum &x1, const AlphaNum &x2,
+                     const AlphaNum &x3) {
+  out->append(x1.data(), x1.size());
+  out->append(x2.data(), x2.size());
+  out->append(x3.data(), x3.size());
+}
 
-  memcpy(out, x2.data(), x2.size());
-  out += x2.size();
-
-  memcpy(out, x3.data(), x3.size());
-  out += x3.size();
-
-  memcpy(out, x4.data(), x4.size());
-  return out + x4.size();
+static void Append4(string *out, const AlphaNum &x1, const AlphaNum &x2,
+    const AlphaNum &x3, const AlphaNum &x4)
+{
+  out->append(x1.data(), x1.size());
+  out->append(x2.data(), x2.size());
+  out->append(x3.data(), x3.size());
+  out->append(x4.data(), x4.size());
 }
 
 string StrCat(const AlphaNum &a, const AlphaNum &b) {
   string result;
   gtl::STLStringResizeUninitialized(&result, a.size() + b.size());
-  char *const begin = &*result.begin();
-  char *out = Append2(begin, a, b);
-  DCHECK_EQ(out, begin + result.size());
+  Append2(&result, a, b);
   return result;
 }
 
 string StrCat(const AlphaNum &a, const AlphaNum &b, const AlphaNum &c) {
   string result;
   gtl::STLStringResizeUninitialized(&result, a.size() + b.size() + c.size());
-  char *const begin = &*result.begin();
-  char *out = Append2(begin, a, b);
-  out = Append1(out, c);
-  DCHECK_EQ(out, begin + result.size());
+  Append3(&result, a, b, c);
   return result;
 }
 
@@ -108,9 +100,7 @@ string StrCat(const AlphaNum &a, const AlphaNum &b, const AlphaNum &c,
   string result;
   gtl::STLStringResizeUninitialized(&result,
                                     a.size() + b.size() + c.size() + d.size());
-  char *const begin = &*result.begin();
-  char *out = Append4(begin, a, b, c, d);
-  DCHECK_EQ(out, begin + result.size());
+  Append4(&result, a, b, c, d);
   return result;
 }
 
@@ -123,14 +113,9 @@ string CatPieces(std::initializer_list<StringPiece> pieces) {
   for (const StringPiece piece : pieces) total_size += piece.size();
   gtl::STLStringResizeUninitialized(&result, total_size);
 
-  char *const begin = &*result.begin();
-  char *out = begin;
   for (const StringPiece piece : pieces) {
-    const size_t this_size = piece.size();
-    memcpy(out, piece.data(), this_size);
-    out += this_size;
+    result.append(piece.data(), piece.size());
   }
-  DCHECK_EQ(out, begin + result.size());
   return result;
 }
 
@@ -150,14 +135,9 @@ void AppendPieces(string *result, std::initializer_list<StringPiece> pieces) {
   }
   gtl::STLStringResizeUninitialized(result, total_size);
 
-  char *const begin = &*result->begin();
-  char *out = begin + old_size;
   for (const StringPiece piece : pieces) {
-    const size_t this_size = piece.size();
-    memcpy(out, piece.data(), this_size);
-    out += this_size;
+    result->append(piece.data(), piece.size());
   }
-  DCHECK_EQ(out, begin + result->size());
 }
 
 }  // namespace internal
@@ -172,9 +152,7 @@ void StrAppend(string *result, const AlphaNum &a, const AlphaNum &b) {
   DCHECK_NO_OVERLAP(*result, b);
   string::size_type old_size = result->size();
   gtl::STLStringResizeUninitialized(result, old_size + a.size() + b.size());
-  char *const begin = &*result->begin();
-  char *out = Append2(begin + old_size, a, b);
-  DCHECK_EQ(out, begin + result->size());
+  Append2(result, a, b);
 }
 
 void StrAppend(string *result, const AlphaNum &a, const AlphaNum &b,
@@ -185,10 +163,7 @@ void StrAppend(string *result, const AlphaNum &a, const AlphaNum &b,
   string::size_type old_size = result->size();
   gtl::STLStringResizeUninitialized(result,
                                     old_size + a.size() + b.size() + c.size());
-  char *const begin = &*result->begin();
-  char *out = Append2(begin + old_size, a, b);
-  out = Append1(out, c);
-  DCHECK_EQ(out, begin + result->size());
+  Append3(result, a, b, c);
 }
 
 void StrAppend(string *result, const AlphaNum &a, const AlphaNum &b,
@@ -200,9 +175,7 @@ void StrAppend(string *result, const AlphaNum &a, const AlphaNum &b,
   string::size_type old_size = result->size();
   gtl::STLStringResizeUninitialized(
       result, old_size + a.size() + b.size() + c.size() + d.size());
-  char *const begin = &*result->begin();
-  char *out = Append4(begin + old_size, a, b, c, d);
-  DCHECK_EQ(out, begin + result->size());
+  Append4(result, a, b, c, d);
 }
 
 }  // namespace strings


### PR DESCRIPTION
With VC++, when std::string is empty, there will be an error -- "string iterator not dereferencable" -- to use string::begin.

And using raw pointer to manipulate std::string doesn't look like a good idea.
