### PR TITLE
Example image code using image module.

### DIFF
--- a/tensorflow/g3doc/how_tos/documentation/index.md
+++ b/tensorflow/g3doc/how_tos/documentation/index.md
@@ -320,9 +320,9 @@ Here's an example from the module docsting in `image_ops.py`:
 
     ```python
     # Decode an image and convert it to HSV.
-    rgb_image = tf.decode_png(...,  channels=3)
-    rgb_image_float = tf.convert_image_dtype(rgb_image, tf.float32)
-    hsv_image = tf.rgb_to_hsv(rgb_image)
+    rgb_image = tf.image.decode_png(...,  channels=3)
+    rgb_image_float = tf.image.convert_image_dtype(rgb_image, tf.float32)
+    hsv_image = tf.image.rgb_to_hsv(rgb_image)
     ```
 
 ### Requirements, caveats, important notes.

--- a/tensorflow/g3doc/how_tos/new_data_formats/index.md
+++ b/tensorflow/g3doc/how_tos/new_data_formats/index.md
@@ -211,8 +211,8 @@ format.  For example, you may have an image saved as a string in
 Depending on the format of that image, you might take the corresponding output
 from a
 [`tf.parse_single_example`](../../api_docs/python/io_ops.md#parse_single_example)
-op and call [`tf.decode_jpeg`](../../api_docs/python/image.md#decode_jpeg),
-[`tf.decode_png`](../../api_docs/python/image.md#decode_png), or
+op and call [`tf.image.decode_jpeg`](../../api_docs/python/image.md#decode_jpeg),
+[`tf.image.decode_png`](../../api_docs/python/image.md#decode_png), or
 [`tf.decode_raw`](../../api_docs/python/io_ops.md#decode_raw).  It is common to
 take the output of `tf.decode_raw` and use
 [`tf.slice`](../../api_docs/python/array_ops.md#slice) and

--- a/tensorflow/python/ops/image_ops.py
+++ b/tensorflow/python/ops/image_ops.py
@@ -109,9 +109,9 @@ Example:
 
 ```python
 # Decode an image and convert it to HSV.
-rgb_image = tf.decode_png(...,  channels=3)
-rgb_image_float = tf.convert_image_dtype(rgb_image, tf.float32)
-hsv_image = tf.rgb_to_hsv(rgb_image)
+rgb_image = tf.image.decode_png(...,  channels=3)
+rgb_image_float = tf.image.convert_image_dtype(rgb_image, tf.float32)
+hsv_image = tf.image.rgb_to_hsv(rgb_image)
 ```
 
 @@rgb_to_grayscale
@@ -776,7 +776,7 @@ def adjust_contrast(images, contrast_factor):
     contrast_factor: A float multiplier for adjusting contrast.
 
   Returns:
-    The constrast-adjusted image or images.
+    The contrast-adjusted image or images.
   """
   with ops.op_scope([images, contrast_factor], None, 'adjust_contrast') as name:
     # Remember original dtype to so we can convert back if needed


### PR DESCRIPTION
I couldn't find `decode_png`, `convert_image_dtype` or `rgb_to_hsv` added to the `tf` module.

Updated examples to use the functions on the `tf.image` module instead. Unfortunately, the example code was used on the how to document page as well.

A minor spelling adjustment is included as well.
