### PR TITLE
Embed __version__ into package

### DIFF
--- a/tensorflow/__init__.py
+++ b/tensorflow/__init__.py
@@ -21,3 +21,5 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python import *
+
+__version__ = '0.8.0dev'


### PR DESCRIPTION
Hi,
it would be nice to embed a version into the tensorflow package for reproducibility. The common Python convention is to do this via `__version__` attribute in the `__init__.py` file so that one can import the package and verify its version. 

```
import tensorflow as tf
print(tf.__version__)
```

This is very helpful for reproducibility and managing different virtual environments. 
