### PR TITLE
Clean up unused variables in a example

### DIFF
--- a/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
@@ -59,16 +59,16 @@ def main(_):
     y = tf.nn.softmax(tf.matmul(x, W) + b)
 
   # Add summary ops to collect data
-  _ = tf.histogram_summary('weights', W)
-  _ = tf.histogram_summary('biases', b)
-  _ = tf.histogram_summary('y', y)
+  tf.histogram_summary('weights', W)
+  tf.histogram_summary('biases', b)
+  tf.histogram_summary('y', y)
 
   # Define loss and optimizer
   y_ = tf.placeholder(tf.float32, [None, 10], name='y-input')
   # More name scopes will clean up the graph representation
   with tf.name_scope('xent'):
     cross_entropy = -tf.reduce_sum(y_ * tf.log(y))
-    _ = tf.scalar_summary('cross entropy', cross_entropy)
+    tf.scalar_summary('cross entropy', cross_entropy)
   with tf.name_scope('train'):
     train_step = tf.train.GradientDescentOptimizer(
         FLAGS.learning_rate).minimize(cross_entropy)
@@ -76,7 +76,7 @@ def main(_):
   with tf.name_scope('test'):
     correct_prediction = tf.equal(tf.argmax(y, 1), tf.argmax(y_, 1))
     accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
-    _ = tf.scalar_summary('accuracy', accuracy)
+    tf.scalar_summary('accuracy', accuracy)
 
   # Merge all the summaries and write them out to /tmp/mnist_logs
   merged = tf.merge_all_summaries()

--- a/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
+++ b/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
@@ -82,23 +82,23 @@ with tf.name_scope("Wx_b") as scope:
   y = tf.nn.softmax(tf.matmul(x,W) + b)
 
 # Add summary ops to collect data
-w_hist = tf.histogram_summary("weights", W)
-b_hist = tf.histogram_summary("biases", b)
-y_hist = tf.histogram_summary("y", y)
+tf.histogram_summary("weights", W)
+tf.histogram_summary("biases", b)
+tf.histogram_summary("y", y)
 
 # Define loss and optimizer
 y_ = tf.placeholder(tf.float32, [None,10], name="y-input")
 # More name scopes will clean up the graph representation
 with tf.name_scope("xent") as scope:
   cross_entropy = -tf.reduce_sum(y_*tf.log(y))
-  ce_summ = tf.scalar_summary("cross entropy", cross_entropy)
+  tf.scalar_summary("cross entropy", cross_entropy)
 with tf.name_scope("train") as scope:
   train_step = tf.train.GradientDescentOptimizer(0.01).minimize(cross_entropy)
 
 with tf.name_scope("test") as scope:
   correct_prediction = tf.equal(tf.argmax(y,1), tf.argmax(y_,1))
   accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
-  accuracy_summary = tf.scalar_summary("accuracy", accuracy)
+  tf.scalar_summary("accuracy", accuracy)
 
 # Merge all the summaries and write them out to /tmp/mnist_logs
 merged = tf.merge_all_summaries()


### PR DESCRIPTION
This PR removes unused variables in `mnist_with_summaries.py` and makes its document align with it.
