### PR TITLE
Avoid copying invalid large constant data.

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -1038,7 +1038,7 @@ class Operation(object):
       raise TypeError("node_def needs to be a NodeDef: %s" % node_def)
     if node_def.ByteSize() >= (1 << 31) or node_def.ByteSize() < 0:
       raise ValueError(
-          "Cannot create an Operation with a NodeDef larger than 2GB.")
+          "Cannot create a tensor proto whose content is larger than 2GB.")
     if not _VALID_OP_NAME_REGEX.match(node_def.name):
       raise ValueError("'%s' is not a valid node name" % node_def.name)
     if not isinstance(g, Graph):

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -361,6 +361,9 @@ def make_tensor_proto(values, dtype=None, shape=None):
       tensor_shape=tensor_shape.as_shape(shape).as_proto())
 
   if is_same_size and numpy_dtype in _TENSOR_CONTENT_TYPES and shape_size > 1:
+    if nparray.size * nparray.itemsize >= (1 << 31):
+      raise ValueError(
+          "Cannot create a tensor proto whose content is larger than 2GB.")
     tensor_proto.tensor_content = nparray.tostring()
     return tensor_proto
 

--- a/tensorflow/python/kernel_tests/constant_op_test.py
+++ b/tensorflow/python/kernel_tests/constant_op_test.py
@@ -155,7 +155,7 @@ class ConstantTest(tf.test.TestCase):
       large_array = np.zeros((512, 1024, 1024), dtype=np.float32)
       with self.assertRaisesRegexp(
           ValueError,
-          "Cannot create an Operation with a NodeDef larger than 2GB."):
+          "Cannot create a tensor proto whose content is larger than 2GB."):
         c = tf.constant(large_array)
 
   def testTooLargeGraph(self):


### PR DESCRIPTION
Tensorflow cannot create an operation with a NodeDef larger than 2GB.
(Python Unit Test Case: ConstantTest.testTooLargeConstant)
However, before throwing a meaningful exception, it consumes lots of memory
to copy the invalid input data. This causes `std::bad_alloc` errors sometimes.

This PR prevents those invalid copying. The allocated memory for the following
testcase decreases from over 4GB into less than 1GB.

bazel-bin/tensorflow/python/constant_op_test ConstantTest.testTooLargeConstant
