### PR TITLE
Revert "Fix tensorboard import path"

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -51,7 +51,7 @@ else:
 
 # pylint: disable=line-too-long
 CONSOLE_SCRIPTS = [
-    'tensorboard = tensorflow.tensorboard.tensorboard:main',
+    'tensorboard = tensorflow.tensorboard.backend.tensorboard:main',
 ]
 # pylint: enable=line-too-long
 


### PR DESCRIPTION
This reverts commit 4b3069401fde5ba8a6a01d1aab95cc31e2169626.

This cherry-pick was not necessary -- the change to tensorboard
paths was done after 0.7.0.
