### PR TITLE
MNIST example using TFRecordWriter context manager.

### DIFF
--- a/tensorflow/examples/how_tos/reading_data/convert_to_records.py
+++ b/tensorflow/examples/how_tos/reading_data/convert_to_records.py
@@ -68,6 +68,7 @@ def convert_to(images, labels, name):
         'label': _int64_feature(int(labels[index])),
         'image_raw': _bytes_feature(image_raw)}))
     writer.write(example.SerializeToString())
+  writer.close()
 
 
 def main(argv):


### PR DESCRIPTION
The `TFRecordWriter` wasn't being explicitly closed. Updated the example to use the context while writing the examples.

**NOTE**: This code will throw an error on any install of TensorFlow before [this commit](https://github.com/tensorflow/tensorflow/commit/67b2abcd673f466d32c4017ad8bab0d0b9ac86c5). The exception will likely be `AttributeError: 'NoneType' object has no attribute 'write'`.

Would it be better to call `TFRecordWriter#close()` explicitly on this example code since that would work with older version of TF as well?
