### PR TITLE
Add list of community created projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Hello, TensorFlow!
 ```
 
 ##For more information
+
 * [TensorFlow website](http://tensorflow.org)
 * [TensorFlow whitepaper](http://download.tensorflow.org/paper/whitepaper2015.pdf)
-* [Tensorflow MOOC on Udacity] (https://www.udacity.com/course/deep-learning--ud730)
+* [TensorFlow MOOC on Udacity] (https://www.udacity.com/course/deep-learning--ud730)
+
+The TensorFlow community has created amazing things with TensorFlow, please see the [resources section of tensorflow.org](https://www.tensorflow.org/versions/master/resources#community) for an incomplete list.

--- a/tensorflow/g3doc/resources/index.md
+++ b/tensorflow/g3doc/resources/index.md
@@ -31,6 +31,11 @@ something amazing with TensorFlow, we'd like to hear about it!
 
 ## Community
 
+The TensorFlow community has created many great projects around TensorFlow, including:
+
+* [TensorFlow tutorials](https://github.com/pkmital/tensorflow_tutorials)
+* [Scikit Flow - Simplified Interface for TensorFlow](https://github.com/tensorflow/skflow)
+
 ### Development
 
 The source code for TensorFlow is hosted on GitHub:


### PR DESCRIPTION
... and point to it from the README. This addresses #995, #1223. We'd like to link only to things in this repo from the README, but it's a good idea to add a place for projects using or enhancing TensorFlow.
