### PR TITLE
Cherry-pick into r0.7: Add community projects to the resources page

### DIFF
--- a/tensorflow/g3doc/resources/index.md
+++ b/tensorflow/g3doc/resources/index.md
@@ -31,6 +31,11 @@ something amazing with TensorFlow, we'd like to hear about it!
 
 ## Community
 
+The TensorFlow community has created many great projects around TensorFlow, including:
+
+* [TensorFlow tutorials](https://github.com/pkmital/tensorflow_tutorials)
+* [Scikit Flow - Simplified Interface for TensorFlow](https://github.com/tensorflow/skflow)
+
 ### Development
 
 The source code for TensorFlow is hosted on GitHub:


### PR DESCRIPTION
This supercedes some pull requests requesting to put these on the from page. We will only include what's included in the repo itself in the top-level readme, and add a pointer here instead.

Closes #995, closes #1223.
