### PR TITLE
Assign graph to cpu in example/udacity/5_word2vec.

### DIFF
--- a/tensorflow/examples/udacity/5_word2vec.ipynb
+++ b/tensorflow/examples/udacity/5_word2vec.ipynb
@@ -421,7 +421,7 @@
         "\n",
         "graph = tf.Graph()\n",
         "\n",
-        "with graph.as_default():\n",
+        "with graph.as_default(), tf.device('/cpu:0'):\n",
         "\n",
         "  # Input data.\n",
         "  train_dataset = tf.placeholder(tf.int32, shape=[batch_size])\n",


### PR DESCRIPTION
Here's what I think is a fix for [1297](https://github.com/tensorflow/tensorflow/issues/1297). Please see the issue for discussion.

If there's a way to do this without all the whitespace changes please let me know. I'm new to Python. The only real change is addition of the `with tf.device():` statement.
