### PR TITLE
Add _python_build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules
 /util/python/python_include
 /util/python/python_lib
 /pip_test
+/_python_build


### PR DESCRIPTION
The directions for a development build say to make it, so .gitignore
should ignore it.
