### PR TITLE
Add binary flag to gunzip_file in tensorflow/models/rnn/translate/data_utils.py.

### DIFF
--- a/tensorflow/models/rnn/translate/data_utils.py
+++ b/tensorflow/models/rnn/translate/data_utils.py
@@ -66,7 +66,7 @@ def gunzip_file(gz_path, new_path):
   """Unzips from gz_path into new_path."""
   print("Unpacking %s to %s" % (gz_path, new_path))
   with gzip.open(gz_path, "rb") as gz_file:
-    with open(new_path, "w") as new_file:
+    with open(new_path, "wb") as new_file:
       for line in gz_file:
         new_file.write(line)
 


### PR DESCRIPTION
Python 3.4 does "TypeError: must be str, not bytes" unless the binary flag is present on line 69.
