### PR TITLE
Fix PCRE link in get started docs

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -464,7 +464,7 @@ We recommend using [homebrew](http://brew.sh) to install the bazel and SWIG
 dependencies, and installing python dependencies using easy_install or pip.
 
 Of course you can also install Swig from source without using homebrew. In that
-case, be sure to install its dependency [PCRE](from www.pcre.org) and not PCRE2.
+case, be sure to install its dependency [PCRE](http://www.pcre.org) and not PCRE2.
 
 #### Dependencies
 


### PR DESCRIPTION
This is just a simple typo correction. Does this still require the [Contributor License Agreements](https://github.com/tensorflow/tensorflow/blob/master/CONTRIBUTING.md#contributor-license-agreements) mentioned in the contributing guidelines?
