### PR TITLE
replaced an unused parameter with `_`

### DIFF
--- a/tensorflow/models/rnn/ptb/ptb_word_lm.py
+++ b/tensorflow/models/rnn/ptb/ptb_word_lm.py
@@ -276,7 +276,7 @@ def get_config():
     raise ValueError("Invalid model: %s", FLAGS.model)
 
 
-def main(unused_args):
+def main(_):
   if not FLAGS.data_path:
     raise ValueError("Must set --data_path to PTB data directory")
 


### PR DESCRIPTION
replaced an unused parameter with `_` as the Python convention to stop a linter warning
