### PR TITLE
Changes to pip.sh; adding docker_test.sh

### DIFF
--- a/tensorflow/tools/ci_build/builds/docker_test.sh
+++ b/tensorflow/tools/ci_build/builds/docker_test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Build and test TensorFlow docker images.
+# The tests include Python unit tests-on-install and tutorial tests.
+#
+# Usage: docker_test.sh <IMAGE_TYPE> <TAG> <WHL_PATH>
+# Arguments:
+#   IMAGE_TYPE : Type of the image: (CPU|GPU)
+#   TAG        : Docker image tag
+#   WHL_PATH   : Path to the whl file to be installed inside the docker image
+#
+#   e.g.: docker_test.sh CPU someone/tensorflow:0.8.0 pip_test/whl/tensorflow-0.8.0-cp27-none-linux_x86_64.whl
+#
+
+# Helper functions
+# Exit after a failure
+die() {
+  echo $@
+  exit 1
+}
+
+# Convert to lower case
+to_lower () {
+  echo "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+
+# Helper function to traverse directories up until given file is found.
+function upsearch () {
+  test / == "$PWD" && return || \
+      test -e "$1" && echo "$PWD" && return || \
+      cd .. && upsearch "$1"
+}
+
+
+# Verify command line argument
+if [[ $# != "3" ]]; then
+  die "Usage: $(basename $0) <IMAGE_TYPE> <TAG> <WHL_PATH>"
+fi
+IMAGE_TYPE=$(to_lower "$1")
+DOCKER_IMG_TAG=$2
+WHL_PATH=$3
+
+# Verify image type
+if [[ "${IMAGE_TYPE}" == "cpu" ]]; then
+  DOCKERFILE="tensorflow/tools/docker/Dockerfile"
+elif [[ "${IMAGE_TYPE}" == "gpu" ]]; then
+  DOCKERFILE="tensorflow/tools/docker/Dockerfile.gpu"
+else
+  die "Unrecognized image type: $1"
+fi
+
+# Verify docker binary existence
+if [[ -z $(which docker) ]]; then
+  die "FAILED: docker binary unavailable"
+fi
+
+# Locate the base directory
+BASE_DIR=$(upsearch "${DOCKERFILE}")
+if [[ -z "${BASE_DIR}" ]]; then
+  die "FAILED: Unable to find the base directory where the dockerfile "\
+"${DOCKERFFILE} resides"
+fi
+echo "Base directory: ${BASE_DIR}"
+
+pushd ${BASE_DIR} > /dev/null
+
+# Build docker image
+DOCKERFILE_PATH="${BASE_DIR}/${DOCKERFILE}"
+DOCKERFILE_DIR="$(dirname ${DOCKERFILE_PATH})"
+
+# Check to make sure that the whl file exists
+test -f ${WHL_PATH} || \
+    die "whl file does not exist: ${WHL_PATH}"
+
+TMP_WHL_DIR="${DOCKERFILE_DIR}/whl"
+mkdir -p "${TMP_WHL_DIR}"
+cp "${WHL_PATH}" "${TMP_WHL_DIR}/" || \
+    die "FAILED to copy whl file from ${WHL_PATH} to ${TMP_WHL_DIR}/"
+
+docker build -t "${DOCKER_IMG_TAG}" -f "${DOCKERFILE_PATH}" \
+"${DOCKERFILE_DIR}" || \
+    die "FAILED to build docker image from Dockerfile ${DOCKERFILE_PATH}"
+
+# Clean up
+rm -rf "${TMP_WHL_DIR}" || \
+    die "Failed to remove temporary directory ${TMP_WHL_DIR}"
+
+
+# Add extra params for cuda devices and libraries for GPU container.
+if [ "${IMAGE_TYPE}" == "gpu" ]; then
+  devices=$(\ls /dev/nvidia* | xargs -I{} echo '--device {}:{}')
+  libs=$(\ls /usr/lib/x86_64-linux-gnu/libcuda.* | xargs -I{} echo '-v {}:{}')
+  GPU_EXTRA_PARAMS="${devices} ${libs}"
+else
+  GPU_EXTRA_PARAMS=""
+fi
+
+# Run docker image with source directory mapped
+docker run -v ${BASE_DIR}:/tensorflow-src -w /tensorflow-src \
+${GPU_EXTRA_PARAMS} \
+"${DOCKER_IMG_TAG}" \
+/bin/bash -c "tensorflow/tools/ci_build/builds/test_installation.sh && "\
+"tensorflow/tools/ci_build/builds/test_tutorials.sh"
+
+RESULT=$?
+
+popd > /dev/null
+if [[ ${RESULT} == 0 ]]; then
+  echo "SUCCESS: Built and tested docker image: ${DOCKER_IMG_TAG}"
+else
+  die "FAILED to build and test docker image: ${DOCKER_IMG_TAG}"
+fi

--- a/tensorflow/tools/ci_build/builds/pip.sh
+++ b/tensorflow/tools/ci_build/builds/pip.sh
@@ -13,58 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-# Build the Python PIP installation package for TensorFlow
-# and run the Python unit tests from the source code on the installation
+#
+# Build the Python PIP installation package for TensorFlow and install
+# the package.
+# The PIP installation is done using the --user flag.
 #
 # Usage:
-#   pip.sh CONTAINER_TYPE
+#   pip.sh CONTAINER_TYPE [--test_tutorials]
 #
 # When executing the Python unit tests, the script obeys the shell
-# variables: PY_TEST_WHITELIST, PY_TEST_BLACKLIST, PY_TEST_GPU_BLACKLIST,
-# TF_BUILD_BAZEL_CLEAN, NO_TEST_ON_INSTALL
-#
-# To select only a subset of the Python tests to run, set the environment
-# variable PY_TEST_WHITELIST, e.g.,
-#   PY_TEST_WHITELIST="tensorflow/python/kernel_tests/shape_ops_test.py"
-# Separate the tests with a colon (:). Leave this environment variable empty
-# to disable the whitelist.
-#
-# You can also ignore a set of the tests by using the environment variable
-# PY_TEST_BLACKLIST. For example, you can include in PY_TEST_BLACKLIST the
-# tests that depend on Python modules in TensorFlow source that are not
-# exported publicly.
-#
-# In addition, you can put blacklist for only GPU build inthe environment
-# variable PY_TEST_GPU_BLACKLIST.
+# variables: TF_BUILD_BAZEL_CLEAN, NO_TEST_ON_INSTALL
 #
 # TF_BUILD_BAZEL_CLEAN, if set to any non-empty and non-0 value, directs the
 # script to perform bazel clean prior to main build and test steps.
 #
-# If the environmental variable NO_TEST_ON_INSTALL is set to any non-empty
-# value, the script will exit after the pip install step.
-
-# =============================================================================
-# Test blacklist: General
+# If NO_TEST_ON_INSTALL has any non-empty and non-0 value, the test-on-install
+# part will be skipped.
 #
-# tensorflow/python/framework/ops_test.py
-#   depends on depends on "test_ops", which is defined in a C++ file wrapped as
-#   a .py file through the Bazel rule “tf_gen_ops_wrapper_py”.
-# tensorflow/util/protobuf/compare_test.py:
-#   depends on compare_test_pb2 defined outside Python
-# tensorflow/python/framework/device_test.py:
-#   depends on CheckValid() and ToString(), both defined externally
+# I the --test_tutorials flag is set, it will cause the script to run the
+# tutorial tests (see test_tutorials.sh) after the PIP
+# installation and the Python unit tests-on-install step.
 #
-PY_TEST_BLACKLIST="${PY_TEST_BLACKLIST}:"\
-"tensorflow/python/framework/ops_test.py:"\
-"tensorflow/python/util/protobuf/compare_test.py:"\
-"tensorflow/python/framework/device_test.py"
-
-# Test blacklist: GPU-only
-PY_TEST_GPU_BLACKLIST="${PY_TEST_GPU_BLACKLIST}:"\
-"tensorflow/python/framework/function_test.py"
-
-# =============================================================================
 
 # Helper functions
 # Get the absolute path from a path
@@ -72,11 +41,13 @@ abs_path() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
+
 # Exit after a failure
 die() {
     echo $@
     exit 1
 }
+
 
 # Get the command line arguments
 CONTAINER_TYPE=$( echo "$1" | tr '[:upper:]' '[:lower:]' )
@@ -86,6 +57,13 @@ if [[ ! -z "${TF_BUILD_BAZEL_CLEAN}" ]] && \
   echo "TF_BUILD_BAZEL_CLEAN=${TF_BUILD_BAZEL_CLEAN}: Performing 'bazel clean'"
   bazel clean
 fi
+
+DO_TEST_TUTORIALS=0
+for ARG in $@; do
+  if [[ "${ARG}" == "--test_tutorials" ]]; then
+    DO_TEST_TUTORIALS=1
+  fi
+done
 
 PIP_BUILD_TARGET="//tensorflow/tools/pip_package:build_pip_package"
 if [[ ${CONTAINER_TYPE} == "cpu" ]]; then
@@ -105,6 +83,12 @@ if [[ ${CONTAINER_TYPE} == "gpu" ]]; then
   PY_TEST_BLACKLIST="${PY_TEST_BLACKLIST}:${PY_TEST_GPU_BLACKLIST}"
 fi
 
+# If still in a virtualenv, deactivate it first
+if [[ ! -z "$(which deactivate)" ]]; then
+  echo "It appears that we are already in a virtualenv. Deactivating..."
+  deactivate || die "FAILED: Unable to deactivate from existing virtualenv"
+fi
+
 # Obtain the path to Python binary
 source tools/python_bin_path.sh
 
@@ -118,11 +102,12 @@ fi
 # installation of Python
 PY_MAJOR_MINOR_VER=$(${PYTHON_BIN_PATH} -V 2>&1 | awk '{print $NF}' | cut -d. -f-2)
 
-echo "Python binary path to be used in PIP install-test: ${PYTHON_BIN_PATH} "\
+echo "Python binary path to be used in PIP install: ${PYTHON_BIN_PATH} "\
 "(Major.Minor version: ${PY_MAJOR_MINOR_VER})"
 
 # Build PIP Wheel file
-PIP_WHL_DIR="pip_test/whl"
+PIP_TEST_ROOT="pip_test"
+PIP_WHL_DIR="${PIP_TEST_ROOT}/whl"
 PIP_WHL_DIR=$(abs_path ${PIP_WHL_DIR})  # Get absolute path
 rm -rf ${PIP_WHL_DIR} && mkdir -p ${PIP_WHL_DIR}
 bazel-bin/tensorflow/tools/pip_package/build_pip_package ${PIP_WHL_DIR} || \
@@ -140,189 +125,47 @@ echo "whl file path = ${WHL_PATH}"
 # Install, in user's local home folder
 echo "Installing pip whl file: ${WHL_PATH}"
 
-# Call pip install on the whl file. We are doing it without the --upgrade
-# option. So dependency updates will need to be performed separately in
-# the environment.
-${PYTHON_BIN_PATH} -m pip install -v --user ${WHL_PATH} \
+# Create temporary directory for install test
+VENV_DIR="${PIP_TEST_ROOT}/venv"
+rm -rf "${VENV_DIR}" && mkdir -p "${VENV_DIR}"
+echo "Create directory for virtualenv: ${VENV_DIR}"
+
+# Verify that virtualenv exists
+if [[ -z $(which virtualenv) ]]; then
+  die "FAILED: virtualenv not available on path"
+fi
+
+virtualenv -p "${PYTHON_BIN_PATH}" "${VENV_DIR}" ||
+die "FAILED: Unable to create virtualenv"
+
+source "${VENV_DIR}/bin/activate" ||
+die "FAILED: Unable to activate virtualenv"
+
+# Install the pip file in virtual env
+pip install -v ${WHL_PATH} \
+&& echo "Successfully installed pip package ${WHL_PATH}" \
 || die "pip install (without --upgrade) FAILED"
 
 # If NO_TEST_ON_INSTALL is set to any non-empty value, skip all Python
 # tests-on-install and exit right away
-if [[ ! -z ${NO_TEST_ON_INSTALL} ]]; then
+if [[ ! -z "${NO_TEST_ON_INSTALL}" ]] &&
+   [[ "${NO_TEST_ON_INSTALL}" != "0" ]]; then
   echo "NO_TEST_ON_INSTALL=${NO_TEST_ON_INSTALL}:"
   echo "  Skipping ALL Python unit tests on install"
   exit 0
 fi
 
-# Directory from which the unit-test files will be run
-PY_TEST_DIR_REL="pip_test/tests"
-PY_TEST_DIR=$(abs_path ${PY_TEST_DIR_REL})  # Get absolute path
-rm -rf ${PY_TEST_DIR} && mkdir -p ${PY_TEST_DIR}
+# Call test_installation.sh to perform test-on-install
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Create test log directory
-PY_TEST_LOG_DIR_REL=${PY_TEST_DIR_REL}/logs
-PY_TEST_LOG_DIR=$(abs_path ${PY_TEST_LOG_DIR_REL})  # Absolute path
+"${DIR}/test_installation.sh" --virtualenv ||
+die "PIP tests-on-install FAILED"
 
-mkdir ${PY_TEST_LOG_DIR}
-
-# Copy source files that are required by the tests but are not included in the
-# PIP package
-
-# Look for local Python library directory
-LIB_PYTHON_DIR=""
-
-# Candidate locations of the local Python library directory
-LIB_PYTHON_DIR_CANDS="${HOME}/.local/lib/python${PY_MAJOR_MINOR_VER}* "\
-"${HOME}/Library/Python/${PY_MAJOR_MINOR_VER}*/lib/python"
-
-for CAND in ${LIB_PYTHON_DIR_CANDS}; do
-  if [[ -d "${CAND}" ]]; then
-    LIB_PYTHON_DIR="${CAND}"
-    break
-  fi
-done
-
-if [[ -z ${LIB_PYTHON_DIR} ]]; then
-  die "Failed to find local Python library directory"
-else
-  echo "Found local Python library directory at: ${LIB_PYTHON_DIR}"
+# Optional: Run the tutorial tests
+if [[ "${DO_TEST_TUTORIALS}" == "1" ]]; then
+  "${DIR}/test_tutorials.sh" --virtualenv ||
+die "PIP tutorial tests-on-install FAILED"
 fi
 
-PACKAGES_DIR=$(ls -d ${LIB_PYTHON_DIR}/*-packages | head -1)
-
-echo "Copying some source directories that are required by tests but are "\
-"not included in install to Python packages directory: ${PACKAGES_DIR}"
-
-# Files for tensorflow.python.tools
-rm -rf ${PACKAGES_DIR}/tensorflow/python/tools
-cp -r tensorflow/python/tools \
-      ${PACKAGES_DIR}/tensorflow/python/tools
-touch ${PACKAGES_DIR}/tensorflow/python/tools/__init__.py  # Make module visible
-
-# Files for tensorflow.examples
-rm -rf ${PACKAGES_DIR}/tensorflow/examples
-mkdir -p ${PACKAGES_DIR}/tensorflow/examples/image_retraining
-cp -r tensorflow/examples/image_retraining/retrain.py \
-      ${PACKAGES_DIR}/tensorflow/examples/image_retraining/retrain.py
-touch ${PACKAGES_DIR}/tensorflow/examples/__init__.py
-touch ${PACKAGES_DIR}/tensorflow/examples/image_retraining/__init__.py
-
-echo "Copying additional files required by tests to working directory "\
-"for test: ${PY_TEST_DIR}"
-
-# Image files required by some tests, e.g., images_ops_test.py
-mkdir -p ${PY_TEST_DIR}/tensorflow/core/lib
-rm -rf ${PY_TEST_DIR}/tensorflow/core/lib/jpeg
-cp -r tensorflow/core/lib/jpeg ${PY_TEST_DIR}/tensorflow/core/lib
-rm -rf ${PY_TEST_DIR}/tensorflow/core/lib/png
-cp -r tensorflow/core/lib/png ${PY_TEST_DIR}/tensorflow/core/lib
-
-# Run tests
-DIR0=$(pwd)
-ALL_PY_TESTS=$(find tensorflow/{contrib,examples,models,python,tensorboard} -name "*_test.py" | sort)
-# TODO(cais): Add tests in tensorflow/contrib
-
-PY_TEST_COUNT=$(echo ${ALL_PY_TESTS} | wc -w)
-
-if [[ ${PY_TEST_COUNT} -eq 0 ]]; then
-  die "ERROR: Cannot find any tensorflow Python unit tests to run on install"
-fi
-
-# Iterate through all the Python unit test files using the installation
-COUNTER=0
-PASS_COUNTER=0
-FAIL_COUNTER=0
-SKIP_COUNTER=0
-FAILED_TESTS=""
-FAILED_TEST_LOGS=""
-
-for TEST_FILE_PATH in ${ALL_PY_TESTS}; do
-  ((COUNTER++))
-
-  PROG_STR="(${COUNTER} / ${PY_TEST_COUNT})"
-
-  # If PY_TEST_WHITELIST is not empty, only the white-listed tests will be run
-  if [[ ! -z ${PY_TEST_WHITELIST} ]] && \
-     [[ ! ${PY_TEST_WHITELIST} == *"${TEST_FILE_PATH}"* ]]; then
-    ((SKIP_COUNTER++))
-    echo "${PROG_STR} Non-whitelisted test SKIPPED: ${TEST_FILE_PATH}"
-    continue
-  fi
-
-  # If the test is in the black list, skip it
-  if [[ ${PY_TEST_BLACKLIST} == *"${TEST_FILE_PATH}"* ]]; then
-    ((SKIP_COUNTER++))
-    echo "${PROG_STR} Blacklisted test SKIPPED: ${TEST_FILE_PATH}"
-    continue
-  fi
-
-  # Copy to a separate directory to guard against the possibility of picking up
-  # modules in the source directory
-  cp ${TEST_FILE_PATH} ${PY_TEST_DIR}/
-
-  TEST_BASENAME=$(basename "${TEST_FILE_PATH}")
-
-  # Relative path of the test log. Use long path in case there are duplicate
-  # file names in the Python tests
-  TEST_LOG_REL="${PY_TEST_LOG_DIR_REL}/${TEST_FILE_PATH}.log"
-  mkdir -p $(dirname ${TEST_LOG_REL})  # Create directory for log
-
-  TEST_LOG=$(abs_path ${TEST_LOG_REL})  # Absolute path
-
-  # Before running the test, cd away from the Tensorflow source to
-  # avoid the possibility of picking up dependencies from the
-  # source directory
-  cd ${PY_TEST_DIR}
-  ${PYTHON_BIN_PATH} ${PY_TEST_DIR}/${TEST_BASENAME} >${TEST_LOG} 2>&1
-
-  # Check for pass or failure status of the test outtput and exit
-  if [[ $? -eq 0 ]]; then
-    ((PASS_COUNTER++))
-
-    echo "${PROG_STR} Python test-on-install PASSED: ${TEST_FILE_PATH}"
-  else
-    ((FAIL_COUNTER++))
-
-    FAILED_TESTS="${FAILED_TESTS} ${TEST_FILE_PATH}"
-
-    FAILED_TEST_LOGS="${FAILED_TEST_LOGS} ${TEST_LOG_REL}"
-
-    echo "${PROG_STR} Python test-on-install FAILED: ${TEST_FILE_PATH}"
-    echo "  Log @: ${TEST_LOG_REL}"
-    echo "============== BEGINS failure log content =============="
-    cat ${TEST_LOG}
-    echo "============== ENDS failure log content =============="
-    echo ""
-  fi
-  cd ${DIR0}
-
-  # Clean up files for this test
-  rm -f ${PY_TEST_DIR}/${TEST_BASENAME}
-
-done
-
-echo ""
-echo "${PY_TEST_COUNT} Python test(s):" \
-     "${PASS_COUNTER} passed;" \
-     "${FAIL_COUNTER} failed; " \
-     "${SKIP_COUNTER} skipped"
-echo "Test logs directory: ${PY_TEST_LOG_DIR_REL}"
-
-if [[ ${FAIL_COUNTER} -eq 0  ]]; then
-  echo ""
-  echo "Python test-on-install SUCCEEDED"
-
-  exit 0
-else
-  echo "FAILED test(s):"
-  FAILED_TEST_LOGS=($FAILED_TEST_LOGS)
-  FAIL_COUNTER=0
-  for TEST_NAME in ${FAILED_TESTS}; do
-    echo "  ${TEST_NAME} (Log @: ${FAILED_TEST_LOGS[${FAIL_COUNTER}]})"
-    ((FAIL_COUNTER++))
-  done
-
-  echo ""
-  echo "Python test-on-install FAILED"
-  exit 1
-fi
+deactivate ||
+die "FAILED: Unable to deactivate virtualenv"

--- a/tensorflow/tools/ci_build/builds/test_installation.sh
+++ b/tensorflow/tools/ci_build/builds/test_installation.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Build the Python PIP installation package for TensorFlow
+# and run the Python unit tests from the source code on the installation
+#
+# Usage:
+#   test_installation.sh [--virtualenv]
+#
+# If the flag --virtualenv is set, the script will use "python" as the Python
+# binary path. Otherwise, it will use tools/python_bin_path.sh to determine
+# the Python binary path.
+#
+# When executing the Python unit tests, the script obeys the shell
+# variables: PY_TEST_WHITELIST, PY_TEST_BLACKLIST, PY_TEST_GPU_BLACKLIST,
+#
+# To select only a subset of the Python tests to run, set the environment
+# variable PY_TEST_WHITELIST, e.g.,
+#   PY_TEST_WHITELIST="tensorflow/python/kernel_tests/shape_ops_test.py"
+# Separate the tests with a colon (:). Leave this environment variable empty
+# to disable the whitelist.
+#
+# You can also ignore a set of the tests by using the environment variable
+# PY_TEST_BLACKLIST. For example, you can include in PY_TEST_BLACKLIST the
+# tests that depend on Python modules in TensorFlow source that are not
+# exported publicly.
+#
+# In addition, you can put blacklist for only GPU build inthe environment
+# variable PY_TEST_GPU_BLACKLIST.
+#
+# TF_BUILD_BAZEL_CLEAN, if set to any non-empty and non-0 value, directs the
+# script to perform bazel clean prior to main build and test steps.
+#
+# If the environmental variable NO_TEST_ON_INSTALL is set to any non-empty
+# value, the script will exit after the pip install step.
+
+# =============================================================================
+# Test blacklist: General
+#
+# tensorflow/python/framework/ops_test.py
+#   depends on depends on "test_ops", which is defined in a C++ file wrapped as
+#   a .py file through the Bazel rule “tf_gen_ops_wrapper_py”.
+# tensorflow/util/protobuf/compare_test.py:
+#   depends on compare_test_pb2 defined outside Python
+# tensorflow/python/framework/device_test.py:
+#   depends on CheckValid() and ToString(), both defined externally
+#
+PY_TEST_BLACKLIST="${PY_TEST_BLACKLIST}:"\
+"tensorflow/python/framework/ops_test.py:"\
+"tensorflow/python/util/protobuf/compare_test.py:"\
+"tensorflow/python/framework/device_test.py"
+
+# Test blacklist: GPU-only
+PY_TEST_GPU_BLACKLIST="${PY_TEST_GPU_BLACKLIST}:"\
+"tensorflow/python/framework/function_test.py"
+
+# =============================================================================
+
+
+# Helper functions
+# Get the absolute path from a path
+abs_path() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+
+die() {
+  echo $@
+  exit 1
+}
+
+
+# Obtain the path to Python binary
+# source tools/python_bin_path.sh
+if [[ "$1" == "--virtualenv" ]]; then
+  PYTHON_BIN_PATH="$(which python)"
+else
+  source tools/python_bin_path.sh
+  # Assume: PYTHON_BIN_PATH is exported by the script above
+fi
+
+if [[ -z "${PYTHON_BIN_PATH}" ]]; then
+  die "PYTHON_BIN_PATH was not provided. If this is not virtualenv, "\
+"did you run configure?"
+fi
+
+# Determine the major and minor versions of Python being used (e.g., 2.7)
+# This info will be useful for determining the directory of the local pip
+# installation of Python
+PY_MAJOR_MINOR_VER=$(${PYTHON_BIN_PATH} -V 2>&1 | awk '{print $NF}' | cut -d. -f-2)
+
+echo "Python binary path to be used in PIP install-test: ${PYTHON_BIN_PATH} "\
+"(Major.Minor version: ${PY_MAJOR_MINOR_VER})"
+
+# Avoid permission issues outside container
+umask 000
+
+# Directory from which the unit-test files will be run
+PY_TEST_DIR_REL="pip_test/tests"
+PY_TEST_DIR=$(abs_path ${PY_TEST_DIR_REL})  # Get absolute path
+rm -rf ${PY_TEST_DIR} && mkdir -p ${PY_TEST_DIR}
+
+# Create test log directory
+PY_TEST_LOG_DIR_REL=${PY_TEST_DIR_REL}/logs
+PY_TEST_LOG_DIR=$(abs_path ${PY_TEST_LOG_DIR_REL})  # Absolute path
+
+mkdir ${PY_TEST_LOG_DIR}
+
+
+# Copy source files that are required by the tests but are not included in the
+# PIP package
+
+# Look for local Python library directory
+# pushd/popd avoids importing TensorFlow from the source directory.
+pushd /tmp > /dev/null
+TF_INSTALL_PATH=$(dirname \
+    $("${PYTHON_BIN_PATH}" -c "import tensorflow as tf; print(tf.__file__)"))
+popd > /dev/null
+
+if [[ -z ${TF_INSTALL_PATH} ]]; then
+  die "Failed to find path where TensorFlow is installed."
+else
+  echo "Found TensorFlow install path: ${TF_INSTALL_PATH}"
+fi
+
+echo "Copying some source directories required by Python unit tests but "\
+"not included in install to TensorFlow install path: ${TF_INSTALL_PATH}"
+
+# Files for tensorflow.python.tools
+rm -rf ${TF_INSTALL_PATH}/python/tools
+cp -r tensorflow/python/tools \
+      ${TF_INSTALL_PATH}/python/tools
+touch ${TF_INSTALL_PATH}/python/tools/__init__.py  # Make module visible
+
+# Files for tensorflow.examples
+rm -rf ${TF_INSTALL_PATH}/examples/image_retraining
+mkdir -p ${TF_INSTALL_PATH}/examples/image_retraining
+cp -r tensorflow/examples/image_retraining/retrain.py \
+      ${TF_INSTALL_PATH}/examples/image_retraining/retrain.py
+touch ${TF_INSTALL_PATH}/examples/__init__.py
+touch ${TF_INSTALL_PATH}/examples/image_retraining/__init__.py
+
+echo "Copying additional files required by tests to working directory "\
+"for test: ${PY_TEST_DIR}"
+
+# Image files required by some tests, e.g., images_ops_test.py
+
+mkdir -p ${PY_TEST_DIR}/tensorflow/core/lib
+rm -rf ${PY_TEST_DIR}/tensorflow/core/lib/jpeg
+cp -r tensorflow/core/lib/jpeg ${PY_TEST_DIR}/tensorflow/core/lib
+rm -rf ${PY_TEST_DIR}/tensorflow/core/lib/png
+cp -r tensorflow/core/lib/png ${PY_TEST_DIR}/tensorflow/core/lib
+
+# Run tests
+DIR0=$(pwd)
+ALL_PY_TESTS=$(find tensorflow/{contrib,examples,models,python,tensorboard} -name "*_test.py" | sort)
+# TODO(cais): Add tests in tensorflow/contrib
+
+PY_TEST_COUNT=$(echo ${ALL_PY_TESTS} | wc -w)
+
+if [[ ${PY_TEST_COUNT} -eq 0 ]]; then
+  die "ERROR: Cannot find any tensorflow Python unit tests to run on install"
+fi
+
+# Iterate through all the Python unit test files using the installation
+COUNTER=0
+PASS_COUNTER=0
+FAIL_COUNTER=0
+SKIP_COUNTER=0
+FAILED_TESTS=""
+FAILED_TEST_LOGS=""
+
+for TEST_FILE_PATH in ${ALL_PY_TESTS}; do
+  ((COUNTER++))
+
+  PROG_STR="(${COUNTER} / ${PY_TEST_COUNT})"
+
+  # If PY_TEST_WHITELIST is not empty, only the white-listed tests will be run
+  if [[ ! -z ${PY_TEST_WHITELIST} ]] && \
+     [[ ! ${PY_TEST_WHITELIST} == *"${TEST_FILE_PATH}"* ]]; then
+    ((SKIP_COUNTER++))
+    echo "${PROG_STR} Non-whitelisted test SKIPPED: ${TEST_FILE_PATH}"
+    continue
+  fi
+
+  # If the test is in the black list, skip it
+  if [[ ${PY_TEST_BLACKLIST} == *"${TEST_FILE_PATH}"* ]]; then
+    ((SKIP_COUNTER++))
+    echo "${PROG_STR} Blacklisted test SKIPPED: ${TEST_FILE_PATH}"
+    continue
+  fi
+
+  # Copy to a separate directory to guard against the possibility of picking up
+  # modules in the source directory
+  cp ${TEST_FILE_PATH} ${PY_TEST_DIR}/
+
+  TEST_BASENAME=$(basename "${TEST_FILE_PATH}")
+
+  # Relative path of the test log. Use long path in case there are duplicate
+  # file names in the Python tests
+  TEST_LOG_REL="${PY_TEST_LOG_DIR_REL}/${TEST_FILE_PATH}.log"
+  mkdir -p $(dirname ${TEST_LOG_REL})  # Create directory for log
+
+  TEST_LOG=$(abs_path ${TEST_LOG_REL})  # Absolute path
+
+  # Start the stopwatch for this test
+  START_TIME=$(date +'%s')
+
+  # Before running the test, cd away from the Tensorflow source to
+  # avoid the possibility of picking up dependencies from the
+  # source directory
+  cd ${PY_TEST_DIR}
+  ${PYTHON_BIN_PATH} ${PY_TEST_DIR}/${TEST_BASENAME} >${TEST_LOG} 2>&1
+
+  TEST_RESULT=$?
+
+  END_TIME=$(date +'%s')
+  ELAPSED_TIME="$((${END_TIME} - ${START_TIME})) s"
+
+  # Check for pass or failure status of the test outtput and exit
+  if [[ ${TEST_RESULT} -eq 0 ]]; then
+    ((PASS_COUNTER++))
+
+    echo "${PROG_STR} Python test-on-install PASSED (${ELAPSED_TIME}): "\
+"${TEST_FILE_PATH}"
+  else
+    ((FAIL_COUNTER++))
+
+    FAILED_TESTS="${FAILED_TESTS} ${TEST_FILE_PATH}"
+
+    FAILED_TEST_LOGS="${FAILED_TEST_LOGS} ${TEST_LOG_REL}"
+
+    echo "${PROG_STR} Python test-on-install FAILED (${ELPASED_TIME}): "\
+"${TEST_FILE_PATH}"
+
+    echo "  Log @: ${TEST_LOG_REL}"
+    echo "============== BEGINS failure log content =============="
+    cat ${TEST_LOG}
+    echo "============== ENDS failure log content =============="
+    echo ""
+  fi
+  cd ${DIR0}
+
+  # Clean up files for this test
+  rm -f ${PY_TEST_DIR}/${TEST_BASENAME}
+
+done
+
+# Clean up files copied for Python unit tests:
+rm -rf ${TF_INSTALL_PATH}/python/tools
+rm -rf ${TF_INSTALL_PATH}/examples/image_retraining
+rm -rf ${PY_TEST_DIR}/tensorflow/core/lib/jpeg
+rm -rf ${PY_TEST_DIR}/tensorflow/core/lib/png
+
+echo ""
+echo "${PY_TEST_COUNT} Python test(s):" \
+     "${PASS_COUNTER} passed;" \
+     "${FAIL_COUNTER} failed; " \
+     "${SKIP_COUNTER} skipped"
+echo "Test logs directory: ${PY_TEST_LOG_DIR_REL}"
+
+if [[ ${FAIL_COUNTER} -eq 0  ]]; then
+  echo ""
+  echo "Python test-on-install SUCCEEDED"
+
+  exit 0
+else
+  echo "FAILED test(s):"
+  FAILED_TEST_LOGS=($FAILED_TEST_LOGS)
+  FAIL_COUNTER=0
+  for TEST_NAME in ${FAILED_TESTS}; do
+    echo "  ${TEST_NAME} (Log @: ${FAILED_TEST_LOGS[${FAIL_COUNTER}]})"
+    ((FAIL_COUNTER++))
+  done
+
+  echo ""
+  echo "Python test-on-install FAILED"
+  exit 1
+fi

--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -27,6 +27,7 @@ apt-get install -y \
     python-dev \
     python-numpy \
     python-pip \
+    python-virtualenv \
     python3-dev \
     python3-numpy \
     python3-pip \

--- a/tensorflow/tools/docker/Dockerfile
+++ b/tensorflow/tools/docker/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Craig Citro <craigcitro@google.com>
 
 # Pick up some TF dependencies
 RUN apt-get update && apt-get install -y \
+        bc \
         curl \
         libfreetype6-dev \
         libpng12-dev \

--- a/tensorflow/tools/docker/Dockerfile.gpu
+++ b/tensorflow/tools/docker/Dockerfile.gpu
@@ -4,6 +4,7 @@ MAINTAINER Craig Citro <craigcitro@google.com>
 
 # Pick up some TF dependencies
 RUN apt-get update && apt-get install -y \
+        bc \
         curl \
         libfreetype6-dev \
         libpng12-dev \


### PR DESCRIPTION
1) Breaking pip.sh into the install step (pip.sh) and the test step
(newly added test_installation.sh)

pip.sh now performs only the building and install of the pip package,
with the install happening inside virtualenv. (vritualenv address the
reinstallation issue on Mac pip tests). Then it calls
test_installation.sh and test_tutorials.sh to test the virtualenv pip
install of TensorFlow.

2) Adding a new file, docker_test.sh, as a first step toward automation
of TensorFlow docker image build and test process.

This script builds and tests docker images with TensorFlow pip whl
installed. The tests include the Python unit tests and tutorial tests
against the (non-virtualenv) install. This is not fully functional yet, because
we need to further automate the pip package uploading process, so the
Dockerfiles in tensorflow/tools/docker can point to the latest pip
files.
