### PR TITLE
#1293 Implement Matrix Trace

### DIFF
--- a/tensorflow/python/kernel_tests/trace_op_test.py
+++ b/tensorflow/python/kernel_tests/trace_op_test.py
@@ -1,0 +1,70 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy
+import tensorflow as tf
+
+
+class GenerateIdentityTensorTest(tf.test.TestCase):
+
+  def setUp(self):
+    x = numpy.random.seed(0)
+
+  def traceOp(self, x, dtype, expected_ans, use_gpu=False):
+    with self.test_session(use_gpu=use_gpu):
+      tf_ans = tf.trace(x.astype(dtype))
+      out = tf_ans.eval()
+    self.assertAllClose(out, expected_ans)
+
+  def testEmptyTensor(self):
+    x = numpy.array([])
+    self.assertRaises(ValueError, self.traceOp, x, numpy.float32, 0)
+
+  def testRankOneTensor(self):
+    x = numpy.array([1,2,3])
+    self.assertRaises(ValueError, self.traceOp, x, numpy.float32, 0)
+
+  def testRankTwoIntTensor(self):
+    x = numpy.array(
+        [[1, 0, 0],
+         [0, 2, 0],
+         [0, 0, 3]])
+    expected_ans = 6
+    self.traceOp(x, numpy.int32, expected_ans)
+    self.traceOp(x, numpy.int64, expected_ans)
+
+  def testRankTwoFloatTensor(self):
+    x = numpy.array(
+        [[1.1, 0, 0],
+         [0, 2.2, 0],
+         [0, 0, 3.3]])
+    expected_ans = 6.6
+    self.traceOp(x, numpy.float32, expected_ans)
+    self.traceOp(x, numpy.float64, expected_ans)
+
+  def testRankThreeFloatTensor(self):
+    x = numpy.random.rand(2, 2, 2)
+    self.assertRaises(ValueError, self.traceOp, x, numpy.float32, 0)
+
+  def testRankFourFloatTensor(self):
+    x = numpy.random.rand(2, 2, 2, 2)
+    self.assertRaises(ValueError, self.traceOp, x, numpy.float32, 0)
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorflow/python/kernel_tests/trace_op_test.py
+++ b/tensorflow/python/kernel_tests/trace_op_test.py
@@ -21,7 +21,7 @@ import numpy
 import tensorflow as tf
 
 
-class GenerateIdentityTensorTest(tf.test.TestCase):
+class TraceTest(tf.test.TestCase):
 
   def setUp(self):
     x = numpy.random.seed(0)

--- a/tensorflow/python/kernel_tests/trace_op_test.py
+++ b/tensorflow/python/kernel_tests/trace_op_test.py
@@ -66,5 +66,6 @@ class TraceTest(tf.test.TestCase):
     x = numpy.random.rand(2, 2, 2, 2)
     self.assertRaises(ValueError, self.traceOp, x, numpy.float32, 0)
 
+
 if __name__ == "__main__":
   tf.test.main()

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -922,7 +922,7 @@ def reduce_any(input_tensor, reduction_indices=None, keep_dims=False,
                            keep_dims, name=name)
 
 def trace(x, name=None):
-  """ Compte the trace of a tensor `x`.
+  """ Compute the trace of a tensor `x`.
 
   `trace(x)` returns the sum of along the diagonal.
   
@@ -940,7 +940,7 @@ def trace(x, name=None):
   ```
 
   Args:
-    input_tensor: Rank 2 tensor.
+    input_tensor: 2-D tensor.
     name: A name for the operation (optional).
 
   Returns:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -921,6 +921,7 @@ def reduce_any(input_tensor, reduction_indices=None, keep_dims=False,
                                                         reduction_indices),
                            keep_dims, name=name)
 
+
 def trace(x, name=None):
   """ Compute the trace of a tensor `x`.
 
@@ -946,14 +947,13 @@ def trace(x, name=None):
   Returns:
     The trace of input tensor.
   """
-  #if not isinstance(x, (ops.Tensor, ops.IndexedSlices)):
-  #  raise TypeError("Not a Tensor or IndexedSlices: %s" % type(x))
   with ops.op_scope([x], name, "Trace") as name: 
     x = ops.convert_to_tensor(x, name="x")
     if len(x.get_shape()) != 2:
       raise ValueError("Expected a tensor with rank 2, rank %d tensor received"
                        % len(x.get_shape()))
     return reduce_sum(array_ops.diag_part(x), name=name)
+
 
 def matmul(a, b,
            transpose_a=False, transpose_b=False,

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -63,6 +63,7 @@ mathematical functions for matrices to your graph.
 
 @@diag
 @@diag_part
+@@trace
 @@transpose
 
 @@matmul
@@ -920,6 +921,39 @@ def reduce_any(input_tensor, reduction_indices=None, keep_dims=False,
                                                         reduction_indices),
                            keep_dims, name=name)
 
+def trace(x, name=None):
+  """ Compte the trace of a tensor `x`.
+
+  `trace(x)` returns the sum of along the diagonal.
+  
+  For example:
+
+  ```python
+  # 'x' is [[1, 1],
+  #         [1, 1]]
+  tf.trace(x) ==> 2
+  
+  # 'x' is [[1,2,3],
+  #         [4,5,6],
+  #         [7,8,9]]
+  tf.trace(x) ==> 15
+  ```
+
+  Args:
+    input_tensor: Rank 2 tensor.
+    name: A name for the operation (optional).
+
+  Returns:
+    The trace of input tensor.
+  """
+  #if not isinstance(x, (ops.Tensor, ops.IndexedSlices)):
+  #  raise TypeError("Not a Tensor or IndexedSlices: %s" % type(x))
+  with ops.op_scope([x], name, "Trace") as name: 
+    x = ops.convert_to_tensor(x, name="x")
+    if len(x.get_shape()) != 2:
+      raise ValueError("Expected a tensor with rank 2, rank %d tensor received"
+                       % len(x.get_shape()))
+    return reduce_sum(array_ops.diag_part(x), name=name)
 
 def matmul(a, b,
            transpose_a=False, transpose_b=False,


### PR DESCRIPTION
As discussed in #1293, this is an attempt to implement matrix trace operator for rank 2 tensors. It only takes tensors with rank 2 (similar to the trace design in Theano). Trace for higher rank tensors requires more discussion on how we want to implement it. One approach is to calculate trace for all rank 2 sub-tensors as numpy. Another is to implement [tensor contraction](https://en.wikipedia.org/wiki/Tensor_contraction) (generalization of trace).
