### PR TITLE
Fix types image ops tests

### DIFF
--- a/tensorflow/core/kernels/resize_nearest_neighbor_op.cc
+++ b/tensorflow/core/kernels/resize_nearest_neighbor_op.cc
@@ -281,9 +281,7 @@ class ResizeNearestNeighborGPUOp : public OpKernel {
                               .HostMemory("size"),                \
                           ResizeNearestNeighborGPUOp<T>);
 
-REGISTER_KERNEL(float);
-// TODO(panmari): Fix kernel for double.
-//REGISTER_KERNEL(double);
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_KERNEL);
 
 #undef REGISTER_KERNEL
 

--- a/tensorflow/core/kernels/resize_nearest_neighbor_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/resize_nearest_neighbor_op_gpu.cu.cc
@@ -31,9 +31,9 @@ namespace {
 template <typename T>
 __global__ void ResizeNearestNeighborNHWC(const int nthreads, const T* bottom_data,
                                           const int in_height, const int in_width,
-                                          const int channels, const float height_scale,
-                                          const float width_scale, const int out_height,
-                                          const int out_width, T* top_data) {
+                                          const int channels, const int out_height,
+                                          const int out_width, const float height_scale,
+                                          const float width_scale, T* top_data) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     int n = index;
     int c = n % channels;
@@ -46,8 +46,8 @@ __global__ void ResizeNearestNeighborNHWC(const int nthreads, const T* bottom_da
     const T* bottom_data_n = bottom_data + n * channels * in_height * in_width;
     const int in_x = min(static_cast<int>(floorf(out_x * width_scale)), in_width - 1);
     const int in_y = min(static_cast<int>(floorf(out_y * height_scale)), in_height - 1);
-    const int idx = (in_y * in_height + in_x) * channels + c;
-    top_data[index] = bottom_data_n[idx];
+    const int idx = (in_y * in_width + in_x) * channels + c;
+    top_data[index] = ldg(bottom_data_n + idx);
   }
 }
 

--- a/tensorflow/core/kernels/resize_nearest_neighbor_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/resize_nearest_neighbor_op_gpu.cu.cc
@@ -78,7 +78,7 @@ bool ResizeNearestNeighbor(const T* bottom_data, const int batch,
                                const float width_scale, T* top_data,               \
                                const Eigen::GpuDevice& d);
 
-DECLARE_GPU_SPEC(float);
+TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPEC);
 
 #undef DECLARE_GPU_SPEC
 }  // end namespace tensorflow

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -741,10 +741,11 @@ class ResizeImagesTest(test_util.TensorFlowTestCase):
              image_ops.ResizeMethod.AREA]
 
   TYPES = [np.uint8, np.int8, np.int16, np.int32, np.int64,
-           np.float, np.double]
+           np.float32, np.float64]
 
-  def availableGPUModes(self, opt):
-    if opt == image_ops.ResizeMethod.NEAREST_NEIGHBOR:
+  def availableGPUModes(self, opt, nptype):
+    if opt == image_ops.ResizeMethod.NEAREST_NEIGHBOR \
+            and nptype == np.float32:
       return [True, False]
     else:
       return [False]
@@ -767,7 +768,7 @@ class ResizeImagesTest(test_util.TensorFlowTestCase):
       img_np = np.array(data, dtype=nptype).reshape(img_shape)
 
       for opt in self.OPTIONS:
-        for use_gpu in self.availableGPUModes(opt):
+        for use_gpu in self.availableGPUModes(opt, nptype):
           with self.test_session(use_gpu=use_gpu) as sess:
             image = constant_op.constant(img_np, shape=img_shape)
             y = image_ops.resize_images(image, target_height, target_width, opt)
@@ -864,7 +865,7 @@ class ResizeImagesTest(test_util.TensorFlowTestCase):
         img_np = np.array(data, dtype=nptype).reshape(img_shape)
 
         for opt in self.OPTIONS:
-          for use_gpu in self.availableGPUModes(opt):
+          for use_gpu in self.availableGPUModes(opt, nptype):
             with self.test_session(use_gpu=use_gpu):
               image = constant_op.constant(img_np, shape=img_shape)
               y = image_ops.resize_images(image, target_height, target_width, opt)
@@ -907,7 +908,7 @@ class ResizeImagesTest(test_util.TensorFlowTestCase):
           image_ops.ResizeMethod.BILINEAR,
           image_ops.ResizeMethod.NEAREST_NEIGHBOR,
           image_ops.ResizeMethod.AREA]:
-        for use_gpu in self.availableGPUModes(opt):
+        for use_gpu in self.availableGPUModes(opt, nptype):
           with self.test_session(use_gpu=use_gpu):
             img_np = np.array(data, dtype=nptype).reshape(img_shape)
             image = constant_op.constant(img_np, shape=img_shape)
@@ -974,9 +975,10 @@ class ResizeImagesTest(test_util.TensorFlowTestCase):
 
 
   def testCompareNearestNeighbor(self):
-    input_shape = [1, 5, 5, 3]
-    target_height = target_width = 10
-    for nptype in [np.float]:
+    input_shape = [1, 5, 6, 3]
+    target_height = 8
+    target_width = 12
+    for nptype in [np.float32]:
       for align_corners in [True, False]:
         img_np = np.arange(0, np.prod(input_shape), dtype=nptype).reshape(input_shape)
         with self.test_session(use_gpu=True):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -745,7 +745,7 @@ class ResizeImagesTest(test_util.TensorFlowTestCase):
 
   def availableGPUModes(self, opt, nptype):
     if opt == image_ops.ResizeMethod.NEAREST_NEIGHBOR \
-            and nptype == np.float32:
+            and nptype in [np.float32, np.float64]:
       return [True, False]
     else:
       return [False]
@@ -978,7 +978,7 @@ class ResizeImagesTest(test_util.TensorFlowTestCase):
     input_shape = [1, 5, 6, 3]
     target_height = 8
     target_width = 12
-    for nptype in [np.float32]:
+    for nptype in [np.float32, np.float64]:
       for align_corners in [True, False]:
         img_np = np.arange(0, np.prod(input_shape), dtype=nptype).reshape(input_shape)
         with self.test_session(use_gpu=True):


### PR DESCRIPTION
Thanks to a recent comment by @martinwicke I realized that there's something wrong with the tests of `test_image_ops.py`. Combined with the use of `use_gpu` instead of `force_gpu`, the tests that were supposed to test the GPU implementation actually ran the CPU implementation. 

After rectifying this, two bugs were found in the GPU implementation and corrected. 
