### PR TITLE
ci_build: fixes

### DIFF
--- a/tensorflow/tools/ci_build/builds/print_build_info.sh
+++ b/tensorflow/tools/ci_build/builds/print_build_info.sh
@@ -63,7 +63,7 @@ if [[ ! -z $(which swig) ]]; then
 fi
 
 # Information about TensorFlow source
-TF_FETCH_URL=$(git remote show origin | grep "Fetch URL:" | awk '{print $3}')
+TF_FETCH_URL=$(git config --get remote.origin.url)
 TF_HEAD=$(git rev-parse HEAD)
 
 # NVIDIA & CUDA info

--- a/tensorflow/tools/ci_build/ci_build.sh
+++ b/tensorflow/tools/ci_build/ci_build.sh
@@ -101,10 +101,10 @@ mkdir -p ${WORKSPACE}/bazel-ci_build-cache
 docker run \
     -v ${WORKSPACE}/bazel-ci_build-cache:${WORKSPACE}/bazel-ci_build-cache \
     -e "CI_BUILD_HOME=${WORKSPACE}/bazel-ci_build-cache" \
-    -e "CI_BUILD_USER=${USER}" \
-    -e "CI_BUILD_UID=$(id -u $USER)" \
-    -e "CI_BUILD_GROUP=$(id -g --name $USER)" \
-    -e "CI_BUILD_GID=$(id -g $USER)" \
+    -e "CI_BUILD_USER=$(id -u --name)" \
+    -e "CI_BUILD_UID=$(id -u)" \
+    -e "CI_BUILD_GROUP=$(id -g --name)" \
+    -e "CI_BUILD_GID=$(id -g)" \
     -e "CI_TENSORFLOW_SUBMODULE_PATH=${CI_TENSORFLOW_SUBMODULE_PATH}" \
     -v ${WORKSPACE}:/workspace \
     -w /workspace \


### PR DESCRIPTION
- do not require $USER variable
- do not contact github in print_build_info.sh
  - there is a easier and faster way to get the clone url
