### PR TITLE
Fixing broken link in "Using the Op in Python"

### DIFF
--- a/tensorflow/g3doc/how_tos/adding_an_op/index.md
+++ b/tensorflow/g3doc/how_tos/adding_an_op/index.md
@@ -176,7 +176,7 @@ $ bazel build -c opt //tensorflow/core/user_ops:zero_out.so
 ## Using the Op in Python
 
 TensorFlow Python API provides the
-[load_op_library](../../api_docs/python/framework#load_op_library) function to
+[load_op_library](https://www.tensorflow.org/versions/r0.7/api_docs/python/framework.html#load_op_library) function to
 load the dynamic library and register the Op with the TensorFlow
 framework. `load_op_library` returns a Python module, that contains the Python
 wrappers for the Op. Thus, once you have built the op, you can do the following


### PR DESCRIPTION
In "Using the Op in Python" section: the load_op_library link is broken.  Changed from ../../api_docs/python/framework#load_op_library to https://www.tensorflow.org/versions/r0.7/api_docs/python/framework.html#load_op_library
