### PR TITLE
virtualenv tests should inherit system site-packages

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip.sh
+++ b/tensorflow/tools/ci_build/builds/pip.sh
@@ -135,7 +135,7 @@ if [[ -z $(which virtualenv) ]]; then
   die "FAILED: virtualenv not available on path"
 fi
 
-virtualenv -p "${PYTHON_BIN_PATH}" "${VENV_DIR}" ||
+virtualenv --system-site-packages -p "${PYTHON_BIN_PATH}" "${VENV_DIR}" ||
 die "FAILED: Unable to create virtualenv"
 
 source "${VENV_DIR}/bin/activate" ||


### PR DESCRIPTION
This way we do not need compile and install anything. We will test with the same version of packages we have compiled with (and the same as bazel test is running). Also we do not need install gcc and compile pip packages.
