### PR TITLE
make xrange python 2 and 3 compatible in sdca_ops.py

### DIFF
--- a/tensorflow/contrib/linear_optimizer/python/ops/sdca_ops.py
+++ b/tensorflow/contrib/linear_optimizer/python/ops/sdca_ops.py
@@ -21,6 +21,8 @@ import os.path
 import threading
 import uuid
 
+from six.moves import range
+
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework.load_library import load_op_library
@@ -223,7 +225,7 @@ class SdcaModel(object):
       dense_features = self._convert_n_to_tensor(examples['dense_features'])
       dense_variables = self._convert_n_to_tensor(self._variables[
           'dense_features_weights'])
-      for i in xrange(len(dense_variables)):
+      for i in range(len(dense_variables)):
         predictions += dense_features[i] * dense_variables[i]
     return predictions
 


### PR DESCRIPTION
use six.moves.range instead of xrange for python2/3 compatibility.

By the way, are there ways to use jenkins remotely to test on personal forks?  It takes a long time to run the entire test suite and renders my computer almost unusable for other tasks.
