### PR TITLE
Fixing mac-pip builds

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip.sh
+++ b/tensorflow/tools/ci_build/builds/pip.sh
@@ -163,10 +163,10 @@ source "${VENV_DIR}/bin/activate" || \
     die "FAILED: Unable to activate virtualenv"
 
 
-# Install the pip file in virtual env
-pip install -v --force-reinstall ${WHL_PATH} \
-&& echo "Successfully installed pip package ${WHL_PATH}" \
-|| die "pip install (without --upgrade) FAILED"
+# Install the pip file in virtualenv
+pip install -v --upgrade --force-reinstall ${WHL_PATH} || \
+    die "pip install FAILED"
+echo "Successfully installed pip package ${WHL_PATH}"
 
 # Install extra pip packages required by the test-on-install
 for PACKAGE in ${INSTALL_EXTRA_PIP_PACKAGES}; do


### PR DESCRIPTION
The --system-site-package option flag in PR 1472 broke Mac pip builds due to existing packages on the system. For example, see: http://ci.tensorflow.org/view/Experimental/job/experimental-cais-tensorflow-mac-python2-copt_both/17/console

Generally speaking, the --system-site-package option makes the virtualenv environment depend on the packages on the Mac host. Removing the option gets rid of this dependency and the need to maintain the host packages, which will save work (especially if there are multiple Mac slaves). 

The cost of installing the packages in the virtualenv should be minimal for both Mac and Linux, now that we cache the virtualenv folder by default. 

The PR has been tested manually for both python2 and python3 on Mac. See:
http://ci.tensorflow.org/view/Experimental/job/experimental-cais-tensorflow-mac-python2-copt_both/18/console
http://ci.tensorflow.org/view/Experimental/job/experimental-cais-tensorflow-mac-python3-copt_both/4/console
