### PR TITLE
Fix broken android example README link 

### DIFF
--- a/tensorflow/examples/android/README.md
+++ b/tensorflow/examples/android/README.md
@@ -19,7 +19,7 @@ installed on your system.
 3. The Android SDK and build tools may be obtained from:
         https://developer.android.com/tools/revisions/build-tools.html
 
-The Android entries in [`<workspace_root>/WORKSPACE`](../../WORKSPACE) must be
+The Android entries in [`<workspace_root>/WORKSPACE`](../../../WORKSPACE#L2-L13) must be
 uncommented with the paths filled in appropriately depending on where you
 installed the NDK and SDK. Otherwise an error such as:
 "The external label '//external:android/sdk' is not bound to anything" will
@@ -45,10 +45,8 @@ your workspace root:
 $ bazel build //tensorflow/examples/android:tensorflow_demo
 ```
 
-If you get build errors about protocol buffers then you may have left out the
-`--recurse-submodules` argument to `git clone`. Review the instructions
-here and then build again:
-https://www.tensorflow.org/versions/master/get_started/os_setup.html#clone-the-tensorflow-repository
+If you get build errors about protocol buffers, run
+`git submodule update --init` and build again.
 
 If adb debugging is enabled on your Android 5.0 or later device, you may then
 use the following command from your workspace root to install the APK once


### PR DESCRIPTION
This PR fixes the link to the WORKSPACE file, highlights the relevant sections of that file, and recommends a faster command to initialize the protobuf submodule. I'm looking forward to getting this running on my phone! (I'm working through some ndk issues. I think bazel/protobuf depends on 32-bit r10e).
