### PR TITLE
fixes #1423 - add check for tests to see if tensorflow was built with gpu

### DIFF
--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -222,7 +222,7 @@ class TensorFlowTestCase(googletest.TestCase):
       config: An optional config_pb2.ConfigProto to use to configure the
         session.
       use_gpu: If True, attempt to run as many ops as possible on GPU.
-      force_gpu: If True, pin all ops to `/gpu:0`.
+      force_gpu: If True and built with GPU, pin all ops to `/gpu:0`.
 
     Returns:
       A Session object that should be used as a context manager to surround
@@ -246,7 +246,7 @@ class TensorFlowTestCase(googletest.TestCase):
                                                config=prepare_config(config))
       sess = self._cached_session
       with sess.graph.as_default(), sess.as_default():
-        if force_gpu:
+        if force_gpu and test.is_built_with_gpu():
           with sess.graph.device("/gpu:0"):
             yield sess
         elif use_gpu:
@@ -256,7 +256,7 @@ class TensorFlowTestCase(googletest.TestCase):
             yield sess
     else:
       with session.Session(graph=graph, config=prepare_config(config)) as sess:
-        if force_gpu:
+        if force_gpu and test.is_built_with_gpu():
           with sess.graph.device("/gpu:0"):
             yield sess
         elif use_gpu:

--- a/tensorflow/python/framework/test_util_test.py
+++ b/tensorflow/python/framework/test_util_test.py
@@ -23,6 +23,7 @@ import threading
 import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
+import warnings
 
 from google.protobuf import text_format
 
@@ -167,14 +168,17 @@ class TestUtilTest(test_util.TensorFlowTestCase):
       self.assertAllClose(7, 8)
 
   def testForceGPU(self):
-    with self.assertRaisesRegexp(errors.InvalidArgumentError,
-                                 "Cannot assign a device to node"):
-      with self.test_session(force_gpu=True):
-        # this relies on us not having a GPU implementation for assert, which
-        # seems sensible
-        x = [True]
-        y = [15]
-        logging_ops.Assert(x, y).run()
+    if tf.test.is_built_with_gpu():
+      with self.assertRaisesRegexp(errors.InvalidArgumentError,
+                                   "Cannot assign a device to node"):
+        with self.test_session(force_gpu=True):
+          # this relies on us not having a GPU implementation for assert, which
+          # seems sensible
+          x = [True]
+          y = [15]
+          logging_ops.Assert(x, y).run()
+    else:
+      warnings.warn("GPU is not configured to be used on this system.")
 
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/python/platform/test.py
+++ b/tensorflow/python/platform/test.py
@@ -44,6 +44,7 @@ methods.  We will document these methods soon.
 @@assert_equal_graph_def
 @@get_temp_dir
 @@is_built_with_cuda
+@@is_built_with_gpu
 
 ## Gradient checking
 
@@ -87,6 +88,12 @@ def get_temp_dir():
   """
   return googletest.GetTempDir()
 
+def is_built_with_gpu():
+  """
+  Returns whether TensorFlow was built with GPU support.  Currently
+  only supports CUDA.
+  """
+  return is_built_with_cuda()
 
 def is_built_with_cuda():
   """Returns whether TensorFlow was built with CUDA (GPU) support."""


### PR DESCRIPTION
EDIT:
The changes worked on CPU, but I would like to test GPU just to make sure.  I opened an issue for GPU test failure #1501
