### PR TITLE
typos fix and ign temp files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+.ipynb_checkpoints
 node_modules
 /bazel-bin
 /bazel-ci_build-cache

--- a/tensorflow/g3doc/get_started/basic_usage.md
+++ b/tensorflow/g3doc/get_started/basic_usage.md
@@ -96,7 +96,7 @@ sess = tf.Session()
 # All inputs needed by the op are run automatically by the session.  They
 # typically are run in parallel.
 #
-# The call 'run(product)' thus causes the execution of threes ops in the
+# The call 'run(product)' thus causes the execution of three ops in the
 # graph: the two constants and matmul.
 #
 # The output of the op is returned in 'result' as a numpy `ndarray` object.


### PR DESCRIPTION
Just wanted to fix a simple typo in the documentation and noticed that some temporary files (e.g. .ipynb checkpoints and Mac DS_Store files for indexing) were not listed in the gitignore, yet, so that I just added them as well.
