### PR TITLE
Fixes tensorflow/skflow#148 - off by one error

### DIFF
--- a/tensorflow/examples/skflow/neural_translation_word.py
+++ b/tensorflow/examples/skflow/neural_translation_word.py
@@ -153,7 +153,7 @@ while True:
 
     xpred, ygold = [], []
     for _ in range(10):
-        idx = random.randint(0, len(X_test))
+        idx = random.randint(0, len(X_test) - 1)
         xpred.append(X_test[idx])
         ygold.append(y_test[idx])
     xpred = np.array(xpred)


### PR DESCRIPTION
Fixes tensorflow/skflow#148 - error in neural translation example for sampling validation examples.
