### PR TITLE
Clarify that skip-gram and CBOW are both Word2Vec models

### DIFF
--- a/tensorflow/examples/udacity/5_word2vec.ipynb
+++ b/tensorflow/examples/udacity/5_word2vec.ipynb
@@ -283,7 +283,7 @@
       ],
       "execution_count": 0
     },
-    { skip-gram mod
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "lFwoyygOmWsL",

--- a/tensorflow/examples/udacity/5_word2vec.ipynb
+++ b/tensorflow/examples/udacity/5_word2vec.ipynb
@@ -24,7 +24,7 @@
         "Assignment 5\n",
         "------------\n",
         "\n",
-        "The goal of this assignment is to train a skip-gram model over [Text8](http://mattmahoney.net/dc/textdata) data."
+        "The goal of this assignment is to train a Word2Vec skip-gram model over [Text8](http://mattmahoney.net/dc/textdata) data."
       ]
     },
     {
@@ -283,7 +283,7 @@
       ],
       "execution_count": 0
     },
-    {
+    { skip-gram mod
       "cell_type": "markdown",
       "metadata": {
         "id": "lFwoyygOmWsL",
@@ -881,7 +881,7 @@
         "Problem\n",
         "-------\n",
         "\n",
-        "An alternative to Word2Vec is called [CBOW](http://arxiv.org/abs/1301.3781) (Continuous Bag of Words). In the CBOW model, instead of predicting a context word from a word vector, you predict a word from the sum of all the word vectors in its context. Implement and evaluate a CBOW model trained on the text8 dataset.\n",
+        "An alternative to skip-gram is another Word2Vec model called [CBOW](http://arxiv.org/abs/1301.3781) (Continuous Bag of Words). In the CBOW model, instead of predicting a context word from a word vector, you predict a word from the sum of all the word vectors in its context. Implement and evaluate a CBOW model trained on the text8 dataset.\n",
         "\n",
         "---"
       ]


### PR DESCRIPTION
Text changes made in the Udacity Deep Learning Assignment 5 to clarify that skip-gram and CBOW are both Word2Vec models
