### PR TITLE
Fix Skflow imports (esp in examples)

### DIFF
--- a/tensorflow/contrib/skflow/python/__init__.py
+++ b/tensorflow/contrib/skflow/python/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 # ==============================================================================
 
-from skflow import * 
+from skflow.python.skflow import * 

--- a/tensorflow/examples/skflow/boston.py
+++ b/tensorflow/examples/skflow/boston.py
@@ -15,7 +15,7 @@
 from sklearn import datasets, cross_validation, metrics
 from sklearn import preprocessing
 
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 # Load dataset
 boston = datasets.load_boston()

--- a/tensorflow/examples/skflow/digits.py
+++ b/tensorflow/examples/skflow/digits.py
@@ -15,8 +15,8 @@
 from sklearn import datasets, cross_validation, metrics
 import tensorflow as tf
 
-from tensorflow.contrib import skflow
-from tensorflow.contrib.skflow import monitors
+from tensorflow.contrib.skflow.python import skflow
+from tensorflow.contrib.skflow.python.skflow import monitors as monitors
 
 # Load dataset
 

--- a/tensorflow/examples/skflow/iris.py
+++ b/tensorflow/examples/skflow/iris.py
@@ -14,7 +14,7 @@
 
 from sklearn import datasets, metrics, cross_validation
 
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 # Load dataset.
 iris = datasets.load_iris()
@@ -29,4 +29,3 @@ classifier = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
 classifier.fit(X_train, y_train)
 score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))
-

--- a/tensorflow/examples/skflow/iris_config_addon.py
+++ b/tensorflow/examples/skflow/iris_config_addon.py
@@ -14,7 +14,7 @@
 
 from sklearn import datasets, metrics, cross_validation
 
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 
 # Load dataset.
@@ -34,4 +34,3 @@ classifier = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
 classifier.fit(X_train, y_train)
 score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))
-

--- a/tensorflow/examples/skflow/iris_custom_decay_dnn.py
+++ b/tensorflow/examples/skflow/iris_custom_decay_dnn.py
@@ -16,7 +16,7 @@ from sklearn import datasets, metrics
 from sklearn.cross_validation import train_test_split
 
 import tensorflow as tf
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 iris = datasets.load_iris()
 X_train, X_test, y_train, y_test = train_test_split(iris.data,

--- a/tensorflow/examples/skflow/iris_custom_model.py
+++ b/tensorflow/examples/skflow/iris_custom_model.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 from sklearn import datasets, metrics, cross_validation
 
 iris = datasets.load_iris()
@@ -29,4 +29,3 @@ classifier = skflow.TensorFlowEstimator(model_fn=my_model, n_classes=3,
 classifier.fit(X_train, y_train)
 score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))
-

--- a/tensorflow/examples/skflow/iris_save_restore.py
+++ b/tensorflow/examples/skflow/iris_save_restore.py
@@ -15,7 +15,7 @@
 import shutil
 
 from sklearn import datasets, metrics, cross_validation
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 iris = datasets.load_iris()
 X_train, X_test, y_train, y_test = cross_validation.train_test_split(iris.data, iris.target,

--- a/tensorflow/examples/skflow/iris_val_based_early_stopping.py
+++ b/tensorflow/examples/skflow/iris_val_based_early_stopping.py
@@ -15,7 +15,7 @@
 from sklearn import datasets, metrics
 from sklearn.cross_validation import train_test_split
 
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 
 iris = datasets.load_iris()

--- a/tensorflow/examples/skflow/iris_with_pipeline.py
+++ b/tensorflow/examples/skflow/iris_with_pipeline.py
@@ -17,7 +17,7 @@ from sklearn.datasets import load_iris
 from sklearn import cross_validation
 from sklearn.preprocessing import StandardScaler
 from sklearn.metrics import accuracy_score
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 iris = load_iris()
 X_train, X_test, y_train, y_test = cross_validation.train_test_split(iris.data, iris.target,
@@ -29,7 +29,7 @@ scaler = StandardScaler()
 # DNN classifier
 DNNclassifier = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10], n_classes=3, steps=200)
 
-pipeline = Pipeline([('scaler', scaler, ('DNNclassifier', DNNclassifier)])
+pipeline = Pipeline([('scaler', scaler), ('DNNclassifier', DNNclassifier)])
 
 pipeline.fit(X_train, y_train)
 

--- a/tensorflow/examples/skflow/language_model.py
+++ b/tensorflow/examples/skflow/language_model.py
@@ -22,7 +22,7 @@ import os
 import numpy as np
 
 import tensorflow as tf
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 ### Training data
 
@@ -86,16 +86,15 @@ def get_language_model(hidden_size):
         encoder_cell = tf.nn.rnn_cell.OutputProjectionWrapper(tf.nn.rnn_cell.GRUCell(hidden_size),256)
         output, _ = tf.nn.rnn(encoder_cell, inputs, dtype=tf.float32)
         return skflow.ops.sequence_classifier(output, target)
-  
+
     return language_model
 
 
 ### Training model.
 
-estimator = skflow.TensorFlowEstimator(model_fn=get_language_model(HIDDEN_SIZE), 
-                                       n_classes=256, 
-                                       optimizer='Adam', learning_rate=0.01, 
+estimator = skflow.TensorFlowEstimator(model_fn=get_language_model(HIDDEN_SIZE),
+                                       n_classes=256,
+                                       optimizer='Adam', learning_rate=0.01,
                                        steps=1000, batch_size=64, continue_training=True)
 
 estimator.fit(X, y)
-

--- a/tensorflow/examples/skflow/mnist.py
+++ b/tensorflow/examples/skflow/mnist.py
@@ -22,7 +22,7 @@ from sklearn import metrics
 
 import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 ### Download and load MNIST data.
 
@@ -48,12 +48,12 @@ def conv_model(X, y):
     X = tf.reshape(X, [-1, 28, 28, 1])
     # first conv layer will compute 32 features for each 5x5 patch
     with tf.variable_scope('conv_layer1'):
-        h_conv1 = skflow.ops.conv2d(X, n_filters=32, filter_shape=[5, 5], 
+        h_conv1 = skflow.ops.conv2d(X, n_filters=32, filter_shape=[5, 5],
                                     bias=True, activation=tf.nn.relu)
         h_pool1 = max_pool_2x2(h_conv1)
     # second conv layer will compute 64 features for each 5x5 patch
     with tf.variable_scope('conv_layer2'):
-        h_conv2 = skflow.ops.conv2d(h_pool1, n_filters=64, filter_shape=[5, 5], 
+        h_conv2 = skflow.ops.conv2d(h_pool1, n_filters=64, filter_shape=[5, 5],
                                     bias=True, activation=tf.nn.relu)
         h_pool2 = max_pool_2x2(h_conv2)
         # reshape tensor into a batch of vectors

--- a/tensorflow/examples/skflow/mnist_weights.py
+++ b/tensorflow/examples/skflow/mnist_weights.py
@@ -21,7 +21,7 @@ from sklearn import metrics
 
 import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 ### Download and load MNIST data.
 
@@ -47,12 +47,12 @@ def conv_model(X, y):
     X = tf.reshape(X, [-1, 28, 28, 1])
     # first conv layer will compute 32 features for each 5x5 patch
     with tf.variable_scope('conv_layer1'):
-        h_conv1 = skflow.ops.conv2d(X, n_filters=32, filter_shape=[5, 5], 
+        h_conv1 = skflow.ops.conv2d(X, n_filters=32, filter_shape=[5, 5],
                                     bias=True, activation=tf.nn.relu)
         h_pool1 = max_pool_2x2(h_conv1)
     # second conv layer will compute 64 features for each 5x5 patch
     with tf.variable_scope('conv_layer2'):
-        h_conv2 = skflow.ops.conv2d(h_pool1, n_filters=64, filter_shape=[5, 5], 
+        h_conv2 = skflow.ops.conv2d(h_pool1, n_filters=64, filter_shape=[5, 5],
                                     bias=True, activation=tf.nn.relu)
         h_pool2 = max_pool_2x2(h_conv2)
         # reshape tensor into a batch of vectors
@@ -73,7 +73,7 @@ print('Accuracy: {0:f}'.format(score))
 
 ## General usage is classifier.get_tensor_value('foo')
 ## 'foo' must be the variable scope of the desired tensor followed by the
-## graph path. 
+## graph path.
 
 ## To understand the mechanism and figure out the right scope and path, you can do logging.
 ## Then use TensorBoard or a text editor on the log file to look at available strings.

--- a/tensorflow/examples/skflow/multioutput_regression.py
+++ b/tensorflow/examples/skflow/multioutput_regression.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 from sklearn import datasets
 from sklearn.metrics import mean_squared_error
 
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 # Create random dataset.
 rng = np.random.RandomState(1)

--- a/tensorflow/examples/skflow/multiple_gpu.py
+++ b/tensorflow/examples/skflow/multiple_gpu.py
@@ -14,7 +14,7 @@
 
 from sklearn import datasets, metrics, cross_validation
 import tensorflow as tf
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 iris = datasets.load_iris()
 X_train, X_test, y_train, y_test = cross_validation.train_test_split(iris.data, iris.target,
@@ -24,8 +24,8 @@ def my_model(X, y):
     """
     This is DNN with 10, 20, 10 hidden layers, and dropout of 0.5 probability.
 
-    Note: If you want to run this example with multiple GPUs, Cuda Toolkit 7.0 and 
-    CUDNN 6.5 V2 from NVIDIA need to be installed beforehand. 
+    Note: If you want to run this example with multiple GPUs, Cuda Toolkit 7.0 and
+    CUDNN 6.5 V2 from NVIDIA need to be installed beforehand.
     """
     with tf.device('/gpu:1'):
     	layers = skflow.ops.dnn(X, [10, 20, 10], keep_prob=0.5)

--- a/tensorflow/examples/skflow/neural_translation.py
+++ b/tensorflow/examples/skflow/neural_translation.py
@@ -21,7 +21,7 @@ import os
 import numpy as np
 
 import tensorflow as tf
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 # Get training data
 
@@ -125,4 +125,3 @@ while True:
         print('English: %s. French (pred): %s, French (gold): %s' %
             (input_text, output_text, gold.decode('utf-8')))
         print(inp_data, pred)
-

--- a/tensorflow/examples/skflow/neural_translation_word.py
+++ b/tensorflow/examples/skflow/neural_translation_word.py
@@ -24,7 +24,7 @@ import random
 import numpy as np
 import tensorflow as tf
 
-import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 # Get training data
 
@@ -165,4 +165,3 @@ while True:
         print('English: %s. French (pred): %s, French (gold): %s' %
             (input_text, output_text, gold))
         print(inp_data, pred)
-

--- a/tensorflow/examples/skflow/out_of_core_data_classification.py
+++ b/tensorflow/examples/skflow/out_of_core_data_classification.py
@@ -17,11 +17,11 @@ from sklearn import datasets, metrics, cross_validation
 import pandas as pd
 import dask.dataframe as dd
 
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 # Sometimes when your dataset is too large to hold in the memory
 # you may want to load it into a out-of-core dataframe as provided by dask library
-# to firstly draw sample batches and then load into memory for training. 
+# to firstly draw sample batches and then load into memory for training.
 
 # Load dataset.
 iris = datasets.load_iris()

--- a/tensorflow/examples/skflow/resnet.py
+++ b/tensorflow/examples/skflow/resnet.py
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 """
-This example builds deep residual network for mnist data. 
+This example builds deep residual network for mnist data.
 Reference Paper: http://arxiv.org/pdf/1512.03385.pdf
 
 Note that this is still a work-in-progress. Feel free to submit a PR
-to make this better. 
+to make this better.
 """
 
 import os
@@ -28,12 +28,12 @@ from sklearn import metrics
 
 import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 
 def res_net(x, y, activation=tf.nn.relu):
     """Builds a residual network. Note that if the input tensor is 2D, it must be
-    square in order to be converted to a 4D tensor. 
+    square in order to be converted to a 4D tensor.
 
     Borrowed structure from here: https://github.com/pkmital/tensorflow_tutorials/blob/master/10_residual_network.py
 
@@ -154,4 +154,3 @@ while True:
 
     # Save model graph and checkpoints.
     classifier.save("models/resnet/")
-

--- a/tensorflow/examples/skflow/text_classification.py
+++ b/tensorflow/examples/skflow/text_classification.py
@@ -18,7 +18,7 @@ import pandas
 
 import tensorflow as tf
 from tensorflow.models.rnn import rnn, rnn_cell
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 ### Training data
 
@@ -82,4 +82,3 @@ while True:
     classifier.fit(X_train, y_train, logdir='/tmp/tf_examples/word_rnn')
     score = metrics.accuracy_score(y_test, classifier.predict(X_test))
     print('Accuracy: {0:f}'.format(score))
-

--- a/tensorflow/examples/skflow/text_classification_builtin_rnn_model.py
+++ b/tensorflow/examples/skflow/text_classification_builtin_rnn_model.py
@@ -17,7 +17,7 @@ from sklearn import metrics
 import pandas
 
 import tensorflow as tf
-from tensorflow.contrib import skflow
+from tensorflow.contrib.skflow.python import skflow
 
 ### Training data
 
@@ -59,7 +59,7 @@ def input_op_fn(X):
     return word_list
 
 # Single direction GRU with a single layer
-classifier = skflow.TensorFlowRNNClassifier(rnn_size=EMBEDDING_SIZE, 
+classifier = skflow.TensorFlowRNNClassifier(rnn_size=EMBEDDING_SIZE,
     n_classes=15, cell_type='gru', input_op_fn=input_op_fn,
     num_layers=1, bidirectional=False, sequence_length=None,
     steps=1000, optimizer='Adam', learning_rate=0.01, continue_training=True)
@@ -69,4 +69,3 @@ while True:
     classifier.fit(X_train, y_train, logdir='/tmp/tf_examples/word_rnn')
     score = metrics.accuracy_score(y_test, classifier.predict(X_test))
     print('Accuracy: {0:f}'.format(score))
-

--- a/tensorflow/examples/skflow/text_classification_character_rnn.py
+++ b/tensorflow/examples/skflow/text_classification_character_rnn.py
@@ -30,7 +30,7 @@ import pandas
 
 import tensorflow as tf
 from tensorflow.models.rnn import rnn, rnn_cell
-from tensorflow.contrib import skflow
+from tensorflow.contrib.sklow.python import skflow
 
 ### Training data
 
@@ -70,4 +70,3 @@ while True:
     classifier.fit(X_train, y_train)
     score = metrics.accuracy_score(y_test, classifier.predict(X_test))
     print("Accuracy: %f" % score)
-


### PR DESCRIPTION
Prior to this, the imports in the examples were broken. 

It does not appear to me that this could be resolved with changes only to `/contrib/skflow/__init__.py`

I mentioned this in gitter to @ilblackdragon though he hasn't seen it before now.
