### PR TITLE
remove dropout in MNIST tutorial

### DIFF
--- a/tensorflow/g3doc/tutorials/mnist/pros/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/pros/index.md
@@ -333,20 +333,6 @@ h_pool2_flat = tf.reshape(h_pool2, [-1, 7*7*64])
 h_fc1 = tf.nn.relu(tf.matmul(h_pool2_flat, W_fc1) + b_fc1)
 ```
 
-#### Dropout
-
-To reduce overfitting, we will apply dropout before the readout layer.
-We create a `placeholder` for the probability that a neuron's output is kept
-during dropout. This allows us to turn dropout on during training, and turn it
-off during testing.
-TensorFlow's `tf.nn.dropout` op automatically handles scaling neuron outputs in
-addition to masking them, so dropout just works without any additional scaling.
-
-```python
-keep_prob = tf.placeholder(tf.float32)
-h_fc1_drop = tf.nn.dropout(h_fc1, keep_prob)
-```
-
 ### Readout Layer
 
 Finally, we add a softmax layer, just like for the one layer softmax regression
@@ -356,7 +342,7 @@ above.
 W_fc2 = weight_variable([1024, 10])
 b_fc2 = bias_variable([10])
 
-y_conv=tf.nn.softmax(tf.matmul(h_fc1_drop, W_fc2) + b_fc2)
+y_conv=tf.nn.softmax(tf.matmul(h_fc1, W_fc2) + b_fc2)
 ```
 
 ### Train and Evaluate the Model
@@ -365,9 +351,8 @@ How well does this model do?
 To train and evaluate it we will use code that is nearly identical to that for
 the simple one layer SoftMax network above.
 The differences are that: we will replace the steepest gradient descent
-optimizer with the more sophisticated ADAM optimizer; we will include the
-additional parameter `keep_prob` in `feed_dict` to control the dropout rate;
-and we will add logging to every 100th iteration in the training process.
+optimizer with the more sophisticated ADAM optimizer; and we will add logging to
+every 100th iteration in the training process.
 
 ```python
 cross_entropy = -tf.reduce_sum(y_*tf.log(y_conv))
@@ -379,12 +364,12 @@ for i in range(20000):
   batch = mnist.train.next_batch(50)
   if i%100 == 0:
     train_accuracy = accuracy.eval(feed_dict={
-        x:batch[0], y_: batch[1], keep_prob: 1.0})
+        x:batch[0], y_: batch[1]})
     print("step %d, training accuracy %g"%(i, train_accuracy))
-  train_step.run(feed_dict={x: batch[0], y_: batch[1], keep_prob: 0.5})
+  train_step.run(feed_dict={x: batch[0], y_: batch[1]})
 
 print("test accuracy %g"%accuracy.eval(feed_dict={
-    x: mnist.test.images, y_: mnist.test.labels, keep_prob: 1.0}))
+    x: mnist.test.images, y_: mnist.test.labels}))
 ```
 
 The final test set accuracy after running this code should be approximately 99.2%.


### PR DESCRIPTION
remove dropout in MNIST tutorial since it didn't improve the accuracy but make training slower,
what's more, it make the tutorial long and tedious. A simpler demo which can show same results will be cool.
After removing dropout, the accuracy remains around 99.2% and sometimes even higher (test 3 times, 0.9919, 0.9922, 0.9929).
