### PR TITLE
Improve LSTMCell's appearance in TensorBoard

### DIFF
--- a/tensorflow/python/ops/rnn_cell.py
+++ b/tensorflow/python/ops/rnn_cell.py
@@ -208,7 +208,7 @@ class BasicLSTMCell(RNNCell):
       new_c = c * sigmoid(f + self._forget_bias) + sigmoid(i) * tanh(j)
       new_h = tanh(new_c) * sigmoid(o)
 
-    return new_h, array_ops.concat(1, [new_c, new_h])
+      return new_h, array_ops.concat(1, [new_c, new_h])
 
 
 def _get_concat_variable(name, shape, dtype, num_shards):


### PR DESCRIPTION
This is a very small cosmetic change, right now the 'concat' operation
isn't carried out in the scope created by calling LSTMCell so
this makes it appear weirdly inside tensorboard.
