### PR TITLE
TensorBoard Graph: Put edge label in the middle of edge only if it is thick enough

### DIFF
--- a/tensorflow/tensorboard/components/tf-graph-common/lib/scene/edge.ts
+++ b/tensorflow/tensorboard/components/tf-graph-common/lib/scene/edge.ts
@@ -17,6 +17,9 @@ module tf.graph.scene.edge {
 /** Delimiter between dimensions when showing sizes of tensors. */
 const TENSOR_SHAPE_DELIM = "×";
 
+/** Minimum stroke width to put edge labels in the middle of edges */
+const CENTER_EDGE_LABEL_MIN_STROKE_WIDTH = 2.5;
+
 export type EdgeData = {v: string, w: string, label: render.RenderMetaedgeInfo};
 
 export function getEdgeKey(edgeObj: EdgeData) {
@@ -181,11 +184,16 @@ export function appendEdge(edgeGroup, d: EdgeData,
     // We have no information to show on this edge.
     return;
   }
+  
+  // Put edge label in the middle of edge only if the edge is thick enough.
+  let baseline = strokeWidth > CENTER_EDGE_LABEL_MIN_STROKE_WIDTH ?
+    "central" : "text-after-edge";
+    
   edgeGroup.append("text").append("textPath").attr({
       "xlink:href": "#" + pathId,
       "startOffset": "50%",
       "text-anchor": "middle",
-      "dominant-baseline": "central"
+      "dominant-baseline": baseline
   }).text(labelForEdge);
 };
 


### PR DESCRIPTION
Put edge label in the middle of edge only if it is thick enough.

`2.5` looks like the correct stroke width threshold.  

See example from CIFAR

<img width="551" alt="tf-graph_demo" src="https://cloud.githubusercontent.com/assets/111269/14037174/1160d4a0-f1fe-11e5-8378-c8fba63d4306.png">
