### PR TITLE
Fix building android_tensorflow_lib.

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -666,6 +666,7 @@ cc_library(
         ":android_op_registrations_and_gradients",
         "//tensorflow/core/kernels:android_core_ops",
         "//tensorflow/core/kernels:android_extended_ops",
+        "//tensorflow/core/util/ctc:android_srcs",
     ],
     copts = select({
         ":android": ANDROID_TF_COPTS,
@@ -679,7 +680,10 @@ cc_library(
     deps = [
         "@re2//:re2",
         ":android_tensorflow_lib_lite",
+        ":core_cpu",
+        ":framework",
         ":protos_cc",
+        "//tensorflow/core/kernels:pooling_ops",
         "//third_party/eigen3",
     ],
 )


### PR DESCRIPTION
This commit fixes a build time failure of the Android TF library that is
missing some dependencies since they have been made more fine-grained.
For reference, the relevant errors (one per required dep) look something
like:

```
ERROR: tensorflow/tensorflow/core/BUILD:663:1: Couldn't build file tensorflow/core/_objs/android_tensorflow_lib/tensorflow/core/kernels/softsign_op.o: undeclared inclusion(s) in rule '//tensorflow/core:android_tensorflow_lib':
this rule is missing dependency declarations for the following files included by 'tensorflow/core/kernels/softsign_op.cc':

ERROR: tensorflow/tensorflow/core/BUILD:663:1: undeclared inclusion(s) in rule '//tensorflow/core:android_tensorflow_lib':
this rule is missing dependency declarations for the following files included by 'tensorflow/core/kernels/maxpooling_op.cc':

ERROR: tensorflow/tensorflow/core/BUILD:663:1: undeclared inclusion(s) in rule '//tensorflow/core:android_tensorflow_lib':
this rule is missing dependency declarations for the following files included by 'tensorflow/core/kernels/ctc_decoder_ops.cc':

ERROR: tensorflow/tensorflow/core/BUILD:663:1: undeclared inclusion(s) in rule '//tensorflow/core:android_tensorflow_lib':
this rule is missing dependency declarations for the following files included by 'tensorflow/core/kernels/avgpooling_op.cc':
```
