### PR TITLE
Update InitGPU() to return if VisibleDeviceCount() <=0.

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_init.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_init.cc
@@ -77,7 +77,7 @@ static void InitGPU() {
 
   int dev_count = platform->VisibleDeviceCount();
 
-  if (dev_count == 0) {
+  if (dev_count <= 0) {
     LOG(INFO) << "No GPU devices available on machine.";
     return;
   }


### PR DESCRIPTION
When CUDA_VISIBLE_DEVICES is empty, VisibleDeviceCount() returns -1, so we should check for <= 0.
