### PR TITLE
Update os_setup.md

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -531,6 +531,10 @@ directory:
 
 ```bash
 bazel build -c opt //tensorflow/tools/pip_package:build_pip_package
+
+# To build with GPU support:
+bazel build -c opt --config=cuda //tensorflow/tools/pip_package:build_pip_package
+
 mkdir _python_build
 cd _python_build
 ln -s ../bazel-bin/tensorflow/tools/pip_package/build_pip_package.runfiles/* .


### PR DESCRIPTION
add "build with GPU support" in "Setting up TensorFlow for Development", otherwise it is quite easy to wrongly build a CPU-only version.
I didn't noticed that there's a "build with GPU support" option at first, so I wrongly built a CPU-only version.
