### PR TITLE
solve a serious bug which cause you fail to build

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc
@@ -43,15 +43,15 @@ import re
 import sys
 import pipes
 
-CURRENT_DIR = os.path.dirname(sys.argv[0])
-NVCC_PATH = CURRENT_DIR + '/../../../cuda/bin/nvcc'
-LLVM_HOST_COMPILER_PATH = ('/usr/bin/gcc')
-PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH)
-
 # "configure" uses the specific format to substitute the following string.
 # If you change it, make sure you modify "configure" as well.
 CPU_COMPILER = ('/usr/bin/gcc')
 GCC_HOST_COMPILER_PATH = ('/usr/bin/gcc')
+
+CURRENT_DIR = os.path.dirname(sys.argv[0])
+NVCC_PATH = CURRENT_DIR + '/../../../cuda/bin/nvcc'
+LLVM_HOST_COMPILER_PATH = ('/usr/bin/gcc')
+PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH)
 
 def Log(s):
   print 'gpus/crosstool: {0}'.format(s)


### PR DESCRIPTION
last day's update on `third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc` made me failed to build tensorflow.
The error is as follow: 

```
ERROR: /home/wenjian/pkgs/tensorflow/tensorflow/core/BUILD:985:1: C++ compilation of rule '//tensorflow/core:gpu_runtime' failed: crosstool_wrapper_driver_is_not_gcc failed: error executing command third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -U_FORTIFY_SOURCE '-D_FORTIFY_SOURCE=1' -fstack-protector -fPIE -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object ... (remaining 85 argument(s) skipped): com.google.devtools.build.lib.shell.BadExitStatusException: Process exited with status 1.
Traceback (most recent call last):
  File "third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc", line 49, in <module>
    PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH)
NameError: name 'GCC_HOST_COMPILER_PATH' is not defined
Target //tensorflow/tools/pip_package:build_pip_package failed to build
Use --verbose_failures to see the command lines of failed build steps.
```

I found the `GCC_HOST_COMPILER_PATH` is defined behind where it is used. This is the reason why it can't work.
I moved it before the usage and configure again, the problem solved.
