### PR TITLE
Update os_setup.md

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -551,7 +551,7 @@ rules.
 
 Starting from the root of your source tree, run:
 
-```python
+```bash
 $ cd tensorflow/models/image/mnist
 $ python convolutional.py
 Successfully downloaded train-images-idx3-ubyte.gz 9912422 bytes.


### PR DESCRIPTION
Actually these two lines are still `bash` commands,
although it has `python convolutional.py`, but `python setup.py develop` at before is also defined as `bash`
besides, using `python` make the `$` becomes red which is not consistent with other commands
