### PR TITLE
fix mem leaks for dynamic rnn

### DIFF
--- a/tensorflow/core/kernels/stack_ops.cc
+++ b/tensorflow/core/kernels/stack_ops.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/lib/core/refcount.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/gtl/map_util.h"
 #include "tensorflow/core/platform/logging.h"
@@ -174,6 +175,7 @@ class StackPushOp : public AsyncOpKernel {
     // Get the stack from the handle.
     Stack* stack = nullptr;
     OP_REQUIRES_OK(ctx, GetStack(ctx, &stack));
+    core::ScopedUnref unref(stack);
     OP_REQUIRES(ctx, ctx->input_dtype(1) == stack->ElemType(),
                 errors::InvalidArgument("Must have type ", stack->ElemType(),
                                         " but got ", ctx->input_dtype(1)));
@@ -273,6 +275,7 @@ class StackPopOp : public AsyncOpKernel {
     // Get the stack from the handle.
     Stack* stack = nullptr;
     OP_REQUIRES_OK(ctx, GetStack(ctx, &stack));
+    core::ScopedUnref unref(stack);
 
     // Pop the tensor. Transfer the tensor back to device if it was
     // swapped out to CPU.
@@ -341,6 +344,7 @@ class StackCloseOp : public OpKernel {
   void Compute(OpKernelContext* ctx) override {
     Stack* stack = nullptr;
     OP_REQUIRES_OK(ctx, GetStack(ctx, &stack));
+    core::ScopedUnref unref(stack);
     stack->Close();
   }
 

--- a/tensorflow/core/kernels/tensor_array_ops.cc
+++ b/tensorflow/core/kernels/tensor_array_ops.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/concat_lib.h"
 #include "tensorflow/core/kernels/split_lib.h"
 #include "tensorflow/core/kernels/tensor_array.h"
+#include "tensorflow/core/lib/core/refcount.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/logging.h"
@@ -105,7 +106,6 @@ class TensorArrayCreationOp : public OpKernel {
     TensorArray* output_tensor_array;
     OP_REQUIRES_OK(ctx, CreateTensorArray(ctx, rm, &tensor_array_output_handle,
                                           &output_tensor_array));
-
     ctx->set_output_ref(0, output_tensor_array->mu(),
                         output_tensor_array->handle());
   }
@@ -213,6 +213,7 @@ class TensorArrayGradOp : public TensorArrayCreationOp {
     TensorArray* tensor_array;
     int32 array_size;
     TF_RETURN_IF_ERROR(rm->Lookup(container, tensor_array_name, &tensor_array));
+    core::ScopedUnref unref(tensor_array);
 
     // Once gradients are being calculated, the forward TensorArray
     // may no longer be resized by new Writes.
@@ -229,6 +230,7 @@ class TensorArrayGradOp : public TensorArrayCreationOp {
 
     Status s = rm->LookupOrCreate<TensorArray>(
         output_handle(0), output_handle(1), output_tensor_array, creator);
+    (*output_tensor_array)->Unref();
 
     return s;
   }
@@ -274,6 +276,7 @@ class TensorArrayWriteOp : public OpKernel {
 
     TensorArray* tensor_array = nullptr;
     OP_REQUIRES_OK(ctx, GetTensorArray("handle", ctx, &tensor_array));
+    core::ScopedUnref unref(tensor_array);
     const int32 index = tensor_index->scalar<int32>()();
     OP_REQUIRES(
         ctx, tensor_value->dtype() == tensor_array->ElemType(),
@@ -335,6 +338,7 @@ class TensorArrayReadOp : public OpKernel {
 
     TensorArray* tensor_array = nullptr;
     OP_REQUIRES_OK(ctx, GetTensorArray("handle", ctx, &tensor_array));
+    core::ScopedUnref unref(tensor_array);
 
     const int32 index = tensor_index->scalar<int32>()();
     OP_REQUIRES(
@@ -392,6 +396,8 @@ class TensorArrayPackOp : public OpKernel {
 
     TensorArray* tensor_array = nullptr;
     OP_REQUIRES_OK(ctx, GetTensorArray("handle", ctx, &tensor_array));
+
+    core::ScopedUnref unref(tensor_array);
     int32 array_size;
     OP_REQUIRES_OK(ctx, tensor_array->Size(&array_size));
     OP_REQUIRES(
@@ -509,6 +515,7 @@ class TensorArrayConcatOp : public OpKernel {
 
     TensorArray* tensor_array = nullptr;
     OP_REQUIRES_OK(ctx, GetTensorArray("handle", ctx, &tensor_array));
+    core::ScopedUnref unref(tensor_array);
     OP_REQUIRES(
         ctx, dtype_ == tensor_array->ElemType(),
         errors::InvalidArgument(
@@ -655,6 +662,7 @@ class TensorArrayUnpackOp : public OpKernel {
 
     TensorArray* tensor_array = nullptr;
     OP_REQUIRES_OK(ctx, GetTensorArray("handle", ctx, &tensor_array));
+    core::ScopedUnref unref(tensor_array);
     const Tensor* tensor_value;
     OP_REQUIRES_OK(ctx, ctx->input("value", &tensor_value));
 
@@ -751,6 +759,7 @@ class TensorArraySplitOp : public OpKernel {
 
     TensorArray* tensor_array = nullptr;
     OP_REQUIRES_OK(ctx, GetTensorArray("handle", ctx, &tensor_array));
+    core::ScopedUnref unref(tensor_array);
     const Tensor* tensor_value;
     OP_REQUIRES_OK(ctx, ctx->input("value", &tensor_value));
     const Tensor* tensor_lengths;
@@ -883,6 +892,7 @@ class TensorArraySizeOp : public OpKernel {
   void Compute(OpKernelContext* ctx) override {
     TensorArray* tensor_array;
     OP_REQUIRES_OK(ctx, GetTensorArray("handle", ctx, &tensor_array));
+    core::ScopedUnref unref(tensor_array);
     Tensor* output = nullptr;
     OP_REQUIRES_OK(ctx, ctx->allocate_output(0, TensorShape({}), &output));
     OP_REQUIRES_OK(ctx, tensor_array->Size(&(output->scalar<int32>()())));
@@ -913,6 +923,7 @@ class TensorArrayCloseOp : public OpKernel {
   void Compute(OpKernelContext* ctx) override {
     TensorArray* tensor_array;
     OP_REQUIRES_OK(ctx, GetTensorArray("handle", ctx, &tensor_array));
+    core::ScopedUnref unref(tensor_array);
     // Instead of deleting this TA from the ResourceManager, we just
     // clear it away and mark it as closed.  The remaining memory
     // consumed store its mutex and handle Tensor.  This will be


### PR DESCRIPTION
Fix mem leaks in tensor array and stack.

Tests `tensorflow/python/kernel_tests/rnn_*.py` pass.
