### PR TITLE
update tensorflow mechanics 101 index.md

### DIFF
--- a/tensorflow/g3doc/tutorials/mnist/tf/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/tf/index.md
@@ -385,8 +385,7 @@ may be instantiated to write the events files, which
 contain both the graph itself and the values of the summaries.
 
 ```python
-summary_writer = tf.train.SummaryWriter(FLAGS.train_dir,
-                                        graph_def=sess.graph_def)
+summary_writer = tf.train.SummaryWriter(FLAGS.train_dir, sess.graph)
 ```
 
 Lastly, the events file will be updated with new summary values every time the


### PR DESCRIPTION
Update `tensorflow mechanics 101 index.md` according to the `fully_connected_feed.py`.
Now we don't need `sess.graph_def` but only need `sess.graph`.
