### PR TITLE
move dropout to later chapters where it can truly work

### DIFF
--- a/tensorflow/examples/tutorials/mnist/fully_connected_feed.py
+++ b/tensorflow/examples/tutorials/mnist/fully_connected_feed.py
@@ -34,7 +34,7 @@ from tensorflow.examples.tutorials.mnist import mnist
 flags = tf.app.flags
 FLAGS = flags.FLAGS
 flags.DEFINE_float('learning_rate', 0.1, 'Initial learning rate.')
-flags.DEFINE_float('keep_prob', 0.5, 'Dropout keep rate.')
+flags.DEFINE_float('keep_prob', 0.5, 'Dropout keep probability.')
 flags.DEFINE_integer('max_steps', 20000, 'Number of steps to run trainer.')
 flags.DEFINE_integer('hidden1', 1024, 'Number of units in hidden layer 1.')
 flags.DEFINE_integer('hidden2', 1024, 'Number of units in hidden layer 2.')
@@ -178,17 +178,11 @@ def run_training():
 
       # Fill a feed dictionary with the actual set of images and labels
       # for this particular training step.
-      feed_dict_train = fill_feed_dict(data_sets.train,
-                                       images_placeholder,
-                                       labels_placeholder,
-                                       keep_prob_placeholder,
-                                       FLAGS.keep_prob)
-
-      feed_dict_eval = fill_feed_dict(data_sets.train,
-                                      images_placeholder,
-                                      labels_placeholder,
-                                      keep_prob_placeholder,
-                                      1.0)
+      feed_dict = fill_feed_dict(data_sets.train,
+                                 images_placeholder,
+                                 labels_placeholder,
+                                 keep_prob_placeholder,
+                                 FLAGS.keep_prob)
 
       # Run one step of the model.  The return values are the activations
       # from the `train_op` (which is discarded) and the `loss` Op.  To
@@ -196,7 +190,7 @@ def run_training():
       # in the list passed to sess.run() and the value tensors will be
       # returned in the tuple from the call.
       _, loss_value = sess.run([train_op, loss],
-                               feed_dict=feed_dict_train)
+                               feed_dict=feed_dict)
 
       duration = time.time() - start_time
 
@@ -205,7 +199,7 @@ def run_training():
         # Print status to stdout.
         print('Step %d: loss = %.2f (%.3f sec)' % (step, loss_value, duration))
         # Update the events file.
-        summary_str = sess.run(summary_op, feed_dict=feed_dict_eval)
+        summary_str = sess.run(summary_op, feed_dict=feed_dict)
         summary_writer.add_summary(summary_str, step)
 
       # Save a checkpoint and evaluate the model periodically.

--- a/tensorflow/examples/tutorials/mnist/mnist.py
+++ b/tensorflow/examples/tutorials/mnist/mnist.py
@@ -42,7 +42,7 @@ IMAGE_SIZE = 28
 IMAGE_PIXELS = IMAGE_SIZE * IMAGE_SIZE
 
 
-def inference(images, hidden1_units, hidden2_units):
+def inference(images, hidden1_units, hidden2_units, keep_prob_pl):
   """Build the MNIST model up to where it may be used for inference.
 
   Args:
@@ -62,6 +62,7 @@ def inference(images, hidden1_units, hidden2_units):
     biases = tf.Variable(tf.zeros([hidden1_units]),
                          name='biases')
     hidden1 = tf.nn.relu(tf.matmul(images, weights) + biases)
+    hidden1_drop = tf.nn.dropout(hidden1, keep_prob_pl)
   # Hidden 2
   with tf.name_scope('hidden2'):
     weights = tf.Variable(
@@ -70,7 +71,8 @@ def inference(images, hidden1_units, hidden2_units):
         name='weights')
     biases = tf.Variable(tf.zeros([hidden2_units]),
                          name='biases')
-    hidden2 = tf.nn.relu(tf.matmul(hidden1, weights) + biases)
+    hidden2 = tf.nn.relu(tf.matmul(hidden1_drop, weights) + biases)
+    hidden2_drop = tf.nn.dropout(hidden2, keep_prob_pl)
   # Linear
   with tf.name_scope('softmax_linear'):
     weights = tf.Variable(
@@ -79,7 +81,7 @@ def inference(images, hidden1_units, hidden2_units):
         name='weights')
     biases = tf.Variable(tf.zeros([NUM_CLASSES]),
                          name='biases')
-    logits = tf.matmul(hidden2, weights) + biases
+    logits = tf.matmul(hidden2_drop, weights) + biases
   return logits
 
 

--- a/tensorflow/g3doc/tutorials/mnist/pros/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/pros/index.md
@@ -333,20 +333,6 @@ h_pool2_flat = tf.reshape(h_pool2, [-1, 7*7*64])
 h_fc1 = tf.nn.relu(tf.matmul(h_pool2_flat, W_fc1) + b_fc1)
 ```
 
-#### Dropout
-
-To reduce overfitting, we will apply dropout before the readout layer.
-We create a `placeholder` for the probability that a neuron's output is kept
-during dropout. This allows us to turn dropout on during training, and turn it
-off during testing.
-TensorFlow's `tf.nn.dropout` op automatically handles scaling neuron outputs in
-addition to masking them, so dropout just works without any additional scaling.
-
-```python
-keep_prob = tf.placeholder(tf.float32)
-h_fc1_drop = tf.nn.dropout(h_fc1, keep_prob)
-```
-
 ### Readout Layer
 
 Finally, we add a softmax layer, just like for the one layer softmax regression
@@ -356,7 +342,7 @@ above.
 W_fc2 = weight_variable([1024, 10])
 b_fc2 = bias_variable([10])
 
-y_conv=tf.nn.softmax(tf.matmul(h_fc1_drop, W_fc2) + b_fc2)
+y_conv=tf.nn.softmax(tf.matmul(h_fc1, W_fc2) + b_fc2)
 ```
 
 ### Train and Evaluate the Model
@@ -365,9 +351,8 @@ How well does this model do?
 To train and evaluate it we will use code that is nearly identical to that for
 the simple one layer SoftMax network above.
 The differences are that: we will replace the steepest gradient descent
-optimizer with the more sophisticated ADAM optimizer; we will include the
-additional parameter `keep_prob` in `feed_dict` to control the dropout rate;
-and we will add logging to every 100th iteration in the training process.
+optimizer with the more sophisticated ADAM optimizer; and we will add logging to
+every 100th iteration in the training process.
 
 ```python
 cross_entropy = -tf.reduce_sum(y_*tf.log(y_conv))
@@ -379,12 +364,12 @@ for i in range(20000):
   batch = mnist.train.next_batch(50)
   if i%100 == 0:
     train_accuracy = accuracy.eval(feed_dict={
-        x:batch[0], y_: batch[1], keep_prob: 1.0})
+        x:batch[0], y_: batch[1]})
     print("step %d, training accuracy %g"%(i, train_accuracy))
-  train_step.run(feed_dict={x: batch[0], y_: batch[1], keep_prob: 0.5})
+  train_step.run(feed_dict={x: batch[0], y_: batch[1]})
 
 print("test accuracy %g"%accuracy.eval(feed_dict={
-    x: mnist.test.images, y_: mnist.test.labels, keep_prob: 1.0}))
+    x: mnist.test.images, y_: mnist.test.labels}))
 ```
 
 The final test set accuracy after running this code should be approximately 99.2%.

--- a/tensorflow/g3doc/tutorials/mnist/tf/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/tf/index.md
@@ -152,9 +152,9 @@ of the input placeholders or the output tensors of the previous layer.
 
 After all training epochs, the accuracy on test data will be around 98.5%.
 However if we remove dropout in the network architecture, the accuracy will
-decrease to 98.2%. This is becasue dropout can reduce the effect of overfitting.
+decrease to 98.2%. This is because dropout can reduce the effect of overfitting.
 If we do not have dropout, the accuracy on training data will eventually become
-1.0, however the accuracy on test data will soon increase to 98.2% but get
+100%, however the accuracy on test data will soon increase to 98.2% but get
 stalled there. By adding dropout, the accuracy on training data increase slower,
 but the generalization ability will become better.
 

--- a/tensorflow/g3doc/tutorials/mnist/tf/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/tf/index.md
@@ -61,7 +61,7 @@ tutorial.
 
 ### Inputs and Placeholders
 
-The `placeholder_inputs()` function creates two [`tf.placeholder`](../../../api_docs/python/io_ops.md#placeholder)
+The `placeholder_inputs()` function creates three [`tf.placeholder`](../../../api_docs/python/io_ops.md#placeholder)
 ops that define the shape of the inputs, including the `batch_size`, to the
 rest of the graph and into which the actual training examples will be fed.
 
@@ -69,6 +69,7 @@ rest of the graph and into which the actual training examples will be fed.
 images_placeholder = tf.placeholder(tf.float32, shape=(batch_size,
                                                        IMAGE_PIXELS))
 labels_placeholder = tf.placeholder(tf.int32, shape=(batch_size))
+keep_prob_placeholder = tf.placeholder(tf.float32)
 ```
 
 Further down, in the training loop, the full image and label datasets are
@@ -99,8 +100,8 @@ The `inference()` function builds the graph as far as needed to
 return the tensor that would contain the output predictions.
 
 It takes the images placeholder as input and builds on top
-of it a pair of fully connected layers with ReLu activation followed by a ten
-node linear layer specifying the output logits.
+of it a pair of fully connected layers with ReLu activation and dropout
+followed by a ten node linear layer specifying the output logits.
 
 Each layer is created beneath a unique [`tf.name_scope`](../../../api_docs/python/framework.md#name_scope)
 that acts as a prefix to the items created within that scope.
@@ -142,22 +143,34 @@ Then the biases are initialized with [`tf.zeros`](../../../api_docs/python/const
 to ensure they start with all zero values, and their shape is simply the number
 of units in the layer to which they connect.
 
-The graph's three primary ops -- two [`tf.nn.relu`](../../../api_docs/python/nn.md#relu)
+The graph's five primary ops -- one [`tf.nn.relu`](../../../api_docs/python/nn.md#relu)
 ops wrapping [`tf.matmul`](../../../api_docs/python/math_ops.md#matmul)
-for the hidden layers and one extra `tf.matmul` for the logits -- are then
+and one [`tf.nn.dropout`](../../../api_docs/python/nn.md#dropout)
+for each hidden layer and one extra `tf.matmul` for the logits -- are then
 created, each in turn, with separate `tf.Variable` instances connected to each
 of the input placeholders or the output tensors of the previous layer.
 
+After all training epochs, the accuracy on test data will be around 98.5%.
+However if we remove dropout in the network architecture, the accuracy will
+decrease to 98.2%. This is becasue dropout can reduce the effect of overfitting.
+If we do not have dropout, the accuracy on training data will eventually become
+1.0, however the accuracy on test data will soon increase to 98.2% but get
+stalled there. By adding dropout, the accuracy on training data increase slower,
+but the generalization ability will become better.
+
+
 ```python
 hidden1 = tf.nn.relu(tf.matmul(images, weights) + biases)
+hidden1_drop = tf.nn.dropout(hidden1, keep_prob_pl)
 ```
 
 ```python
-hidden2 = tf.nn.relu(tf.matmul(hidden1, weights) + biases)
+hidden2 = tf.nn.relu(tf.matmul(hidden1_drop, weights) + biases)
+hidden2_drop = tf.nn.dropout(hidden2, keep_prob_pl)
 ```
 
 ```python
-logits = tf.matmul(hidden2, weights) + biases
+logits = tf.matmul(hidden2_drop, weights) + biases
 ```
 
 Finally, the `logits` tensor that will contain the output is returned.
@@ -332,8 +345,9 @@ the representative feed tensors as values.
 
 ```python
 feed_dict = {
-    images_placeholder: images_feed,
-    labels_placeholder: labels_feed,
+    images_pl: images_feed,
+    labels_pl: labels_feed,
+    keep_prob_pl: keep_prob,    
 }
 ```
 
@@ -348,7 +362,9 @@ The code specifies two values to fetch in its run call: `[train_op, loss]`.
 for step in xrange(FLAGS.max_steps):
     feed_dict = fill_feed_dict(data_sets.train,
                                images_placeholder,
-                               labels_placeholder)
+                               labels_placeholder,
+                               keep_prob_placeholder,
+                               FLAGS.keep_prob)
     _, loss_value = sess.run([train_op, loss],
                              feed_dict=feed_dict)
 ```
@@ -443,18 +459,21 @@ do_eval(sess,
         eval_correct,
         images_placeholder,
         labels_placeholder,
+        keep_prob_placeholder,
         data_sets.train)
 print 'Validation Data Eval:'
 do_eval(sess,
         eval_correct,
         images_placeholder,
         labels_placeholder,
+        keep_prob_placeholder,
         data_sets.validation)
 print 'Test Data Eval:'
 do_eval(sess,
         eval_correct,
         images_placeholder,
         labels_placeholder,
+        keep_prob_placeholder,
         data_sets.test)
 ```
 
@@ -499,7 +518,9 @@ against the `eval_correct` op to evaluate the model on the given dataset.
 for step in xrange(steps_per_epoch):
     feed_dict = fill_feed_dict(data_set,
                                images_placeholder,
-                               labels_placeholder)
+                               labels_placeholder,
+                               keep_prob_placeholder,
+                               1.0)
     true_count += sess.run(eval_correct, feed_dict=feed_dict)
 ```
 


### PR DESCRIPTION
@Sohl-Dickstein 
This is to replace #1620 ,
remove dropout in the very beginning tutorial on MNIST since it doesn't work in that network architecture,
and move it to Tensorflow Mechanics 101, where it can truly work and we give more detailed explanation on dropout:

`After all training epochs, the accuracy on test data will be around 98.5%.
However if we remove dropout in the network architecture, the accuracy will
decrease to 98.2%. This is because dropout can reduce the effect of overfitting.
If we do not have dropout, the accuracy on training data will eventually become
100%, however the accuracy on test data will soon increase to 98.2% but get
stalled there. By adding dropout, the accuracy on training data increase slower,
but the generalization ability will become better.`
