### PR TITLE
Skflow fix imports

### DIFF
--- a/tensorflow/contrib/skflow/BUILD
+++ b/tensorflow/contrib/skflow/BUILD
@@ -11,7 +11,7 @@ py_library(
     name = "skflow",
     srcs = glob([
         "python/skflow/**/*.py",
-    ]),
+    ]) + ["__init__.py", "python/__init__.py"],
     srcs_version = "PY2AND3",
     deps = ["//tensorflow/python:framework"],
 )

--- a/tensorflow/contrib/skflow/__init__.py
+++ b/tensorflow/contrib/skflow/__init__.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from python import *
+from tensorflow.contrib.skflow.python.skflow import *

--- a/tensorflow/contrib/skflow/python/__init__.py
+++ b/tensorflow/contrib/skflow/python/__init__.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from skflow import * 
+from tensorflow.contrib.skflow.python.skflow import *


### PR DESCRIPTION
Currently `from tensorflow.contrib import skflow` doesn't import all the things. This adds `__init__.py` files to the BUILD file and correct absolute imports.
