### PR TITLE
Update to correct method name in local example.

### DIFF
--- a/tensorflow/g3doc/how_tos/distributed/index.md
+++ b/tensorflow/g3doc/how_tos/distributed/index.md
@@ -21,7 +21,7 @@ test your installation by starting a local server as follows:
 $ python
 >>> import tensorflow as tf
 >>> c = tf.constant("Hello, distributed TensorFlow!")
->>> server = tf.GrpcServer.new_local_server()
+>>> server = tf.GrpcServer.create_local_server()
 >>> sess = tf.Session(server.target)
 >>> sess.run(c)
 'Hello, distributed TensorFlow!'
@@ -29,7 +29,7 @@ $ python
 
 ## Cluster definition
 
-The `tf.GrpcServer.new_local_server()` method creates a single-process cluster.
+The `tf.GrpcServer.create_local_server()` method creates a single-process cluster.
 To create a more realistic distributed cluster, you create a `tf.GrpcServer` by
 passing in a `tf.ServerDef` that defines the membership of a TensorFlow cluster,
 and then run multiple processes that each have the same cluster definition.


### PR DESCRIPTION
There is an error in the current distributed TensorFlow documentation which caused me a little trouble when verifying that installation was correct.
