### PR TITLE
Update index.md

### DIFF
--- a/tensorflow/g3doc/tutorials/mnist/tf/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/tf/index.md
@@ -23,7 +23,9 @@ File | Purpose
 
 Simply run the `fully_connected_feed.py` file directly to start training:
 
-`python fully_connected_feed.py`
+```bash
+python fully_connected_feed.py
+```
 
 ## Prepare the Data
 


### PR DESCRIPTION
change the code style to `bash`
At before, it's quite like a sentence but not a command, especially in the following link: 
https://www.tensorflow.org/versions/master/tutorials/mnist/tf/index.html#tensorflow-mechanics-101

in the webpage, "`" only makes the code to be bold, but not code style
