### PR TITLE
Reduction of CPU test time for cwise_ops_test and rnn_test.

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1084,16 +1084,19 @@ medium_kernel_test_list = glob([
     "kernel_tests/concat_op_test.py",
     "kernel_tests/division_future_test.py",
     "kernel_tests/fft_ops_test.py",
-    "kernel_tests/rnn_test.py",
     "kernel_tests/scatter_ops_test.py",
     "kernel_tests/seq2seq_test.py",
     "kernel_tests/slice_op_test.py",
 ])
 
 sharded_kernel_test_list = glob([
-    "kernel_tests/cwise_ops_test.py",
     "kernel_tests/embedding_ops_test.py",
     "kernel_tests/linalg_grad_test.py",
+])
+
+exclusive_kernel_test_list = glob([
+    "kernel_tests/rnn_test.py",
+    "kernel_tests/cwise_ops_test.py",
 ])
 
 cpu_only_kernel_test_list = glob([
@@ -1186,8 +1189,15 @@ cuda_py_tests(
         ["kernel_tests/*_test.py"],
         exclude = [
             "**/reader_ops_test.py",
-        ] + cpu_only_kernel_test_list + medium_kernel_test_list + sharded_kernel_test_list,
+        ] + cpu_only_kernel_test_list + medium_kernel_test_list + sharded_kernel_test_list + exclusive_kernel_test_list,
     ),
+)
+
+cuda_py_tests(
+    name = "exclusive_kernel_tests",
+    size = "small",
+    srcs = exclusive_kernel_test_list,
+    tags = ["exclusive"],
 )
 
 cuda_py_tests(

--- a/tensorflow/python/kernel_tests/rnn_test.py
+++ b/tensorflow/python/kernel_tests/rnn_test.py
@@ -560,7 +560,7 @@ class LSTMTest(tf.test.TestCase):
         self.assertAllEqual(out0, out1)
 
   def _testDynamicEquivalentToStaticRNN(self, use_gpu, use_sequence_length):
-    time_steps = 8
+    time_steps = 3
     num_units = 3
     num_proj = 4
     input_size = 5
@@ -749,10 +749,11 @@ class LSTMTest(tf.test.TestCase):
     self._testDynamicEquivalentToStaticRNN(
         use_gpu=False, use_sequence_length=False)
     self._testDynamicEquivalentToStaticRNN(
-        use_gpu=True, use_sequence_length=False)
-    self._testDynamicEquivalentToStaticRNN(
         use_gpu=False, use_sequence_length=True)
-    self._testDynamicEquivalentToStaticRNN(
+    if tf.test.is_built_with_cuda():
+      self._testDynamicEquivalentToStaticRNN(
+        use_gpu=True, use_sequence_length=False)
+      self._testDynamicEquivalentToStaticRNN(
         use_gpu=True, use_sequence_length=True)
 
 

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -552,7 +552,8 @@ def py_tests(name,
                additional_deps=additional_deps)
 
 
-def cuda_py_tests(name, srcs, size="medium", additional_deps=[], data=[], shard_count=1):
-  test_tags = tf_cuda_tests_tags()
+def cuda_py_tests(name, srcs, size="medium", additional_deps=[], data=[], shard_count=1,
+                  tags=[]):
+  test_tags = tf_cuda_tests_tags() + tags
   py_tests(name=name, size=size, srcs=srcs, additional_deps=additional_deps,
            data=data, tags=test_tags, shard_count=shard_count)


### PR DESCRIPTION
Reduce test scenarios for CPU-only tests by checking for whether
cuda has been enabled in the binary to avoid running CPU tests twice.

Also avoids testing the cross product of broadcasting shapes, dtypes,
and functions in the bcast code.  Instead, we only test broadcasting
of all the various shapes for exactly one datatype and function (add),
which should test the broadcasting behavior (which should not be function
or type specific), and then testing only the cross product of
datatypes and functions with one shape.  Reduces cwise_ops_test
in non-opt mode from 100 seconds to 20.

Also reduce the number of timesteps in one of the rnn_test tests
from 8 to 3 (enough to check the recurrency).  The changes reduce
the runtime from 65 seconds to 19, and there are probably other
changes that can be made to the test to reduce it further.
