### PR TITLE
[bugfix] chase version to tensorflow/workspace.bzl

### DIFF
--- a/tensorflow/contrib/cmake/external/eigen.cmake
+++ b/tensorflow/contrib/cmake/external/eigen.cmake
@@ -7,7 +7,7 @@
 
 include (ExternalProject)
 
-set(eigen_archive_hash "ed4c9730b545")
+set(eigen_archive_hash "3d9f227afae2")
 
 set(eigen_INCLUDE_DIRS
     ${CMAKE_CURRENT_BINARY_DIR}
@@ -16,7 +16,7 @@ set(eigen_INCLUDE_DIRS
     ${tensorflow_source_dir}/third_party/eigen3
 )
 set(eigen_URL https://bitbucket.org/eigen/eigen/get/${eigen_archive_hash}.tar.gz)
-set(eigen_HASH SHA256=3d9eceb8a2add299e37b1f32759157cc2574f7684936c151552a5ae3f33aebd5)
+set(eigen_HASH SHA256=bf2638b7e1085de0b430b000c07e090dc71c83dd7f5b934a06f68b7db02676bf)
 set(eigen_BUILD ${CMAKE_CURRENT_BINARY_DIR}/eigen/src/eigen)
 set(eigen_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/eigen/install)
 


### PR DESCRIPTION
Fix #1720 . With original version we will have errors like:

> /Users/clsung/git/tensorflow/third_party/eigen3/unsupported/Eigen/CXX11/Tensor:1:10: fatal error:
>       'eigen-eigen-3d9f227afae2/unsupported/Eigen/CXX11/Tensor' file not found
> # include "eigen-eigen-3d9f227afae2/unsupported/Eigen/CXX11/Tensor"
> 
> ```
>      ^
> ```
> 
> 1 error generated.
