### PR TITLE
update description for Tensorflow Mechanics 101 Tutorial

### DIFF
--- a/tensorflow/g3doc/tutorials/index.md
+++ b/tensorflow/g3doc/tutorials/index.md
@@ -115,5 +115,3 @@ version of the [Deep Dream](https://github.com/google/deepdream) neural network
 visual hallucination software.
 
 [View Tutorial](https://www.tensorflow.org/code/tensorflow/examples/tutorials/deepdream/deepdream.ipynb)
-
-


### PR DESCRIPTION
I changed: "We use again MNIST as the example." to "We again use MNIST as the example." as this seemed to make more sense. 
