### PR TITLE
correcting bottleneck residual function

### DIFF
--- a/tensorflow/examples/skflow/resnet.py
+++ b/tensorflow/examples/skflow/resnet.py
@@ -83,7 +83,7 @@ def res_net(x, y, activation=tf.nn.relu):
 
             # 1x1 convolution responsible for reducing dimension
             with tf.variable_scope(name + '/conv_in'):
-                conv = skflow.ops.conv2d(net, block.num_filters,
+                conv = skflow.ops.conv2d(net, block.bottleneck_size,
                                          [1, 1], [1, 1, 1, 1],
                                          padding='VALID',
                                          activation=activation,


### PR DESCRIPTION
As described in He _et al._ [1] the first 1x1 convolution inside the bottleneck architecture reduces the dimension to save FLOPs. Hence the correct number of filters is `block.bottleneck_size` instead of `block.num_filters`.

<img width="1081" alt="06cf6894-d197-11e5-8f2f-33d48c225961 2" src="https://cloud.githubusercontent.com/assets/1241240/14230730/5db7a902-f931-11e5-826a-3074cbd85618.png">

[1] http://arxiv.org/pdf/1512.03385.pdf
