### PR TITLE
Add QOL improvements for tf.one_hot()

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -488,6 +488,7 @@ tf_gen_op_wrapper_py(
         "EditDistance",
         "MirrorPad",
         "MirrorPadGrad",
+        "OneHot",
         "Pack",
         "Pad",
         "Placeholder",

--- a/tensorflow/python/kernel_tests/one_hot_op_test.py
+++ b/tensorflow/python/kernel_tests/one_hot_op_test.py
@@ -24,20 +24,25 @@ import tensorflow as tf
 
 class OneHotTest(tf.test.TestCase):
 
-  def _testOneHot(self, truth, use_gpu=False, expected_err_re=None, **inputs):
+  def _testOneHot(self, truth, use_gpu=False, expected_err_re=None, 
+                  raises=None, **inputs):
     with self.test_session(use_gpu=use_gpu):
-      ans = tf.one_hot(**inputs)
-      if expected_err_re is None:
-        tf_ans = ans.eval()
-        self.assertAllClose(tf_ans, truth, atol=1e-10)
-        self.assertEqual(tf_ans.shape, ans.get_shape())
+      if raises is not None:
+        with self.assertRaises(raises):
+          tf.one_hot(**inputs)
       else:
-        with self.assertRaisesOpError(expected_err_re):
-          ans.eval()
+        ans = tf.one_hot(**inputs)
+        if expected_err_re is None:
+          tf_ans = ans.eval()
+          self.assertAllClose(tf_ans, truth, atol=1e-10)
+          self.assertEqual(tf_ans.shape, ans.get_shape())
+        else:
+          with self.assertRaisesOpError(expected_err_re):
+            ans.eval()
 
-  def _testBothOneHot(self, truth, expected_err_re=None, **inputs):
-    self._testOneHot(truth, True, expected_err_re, **inputs)
-    self._testOneHot(truth, False, expected_err_re, **inputs)
+  def _testBothOneHot(self, truth, expected_err_re=None, raises=None, **inputs):
+    self._testOneHot(truth, True, expected_err_re, raises, **inputs)
+    self._testOneHot(truth, False, expected_err_re, raises, **inputs)
 
   def _testBasic(self, dtype):
     indices = np.asarray([0, 2, -1, 1], dtype=np.int64)
@@ -58,6 +63,7 @@ class OneHotTest(tf.test.TestCase):
         depth=depth,
         on_value=on_value,
         off_value=off_value,
+        dtype=dtype,
         truth=truth)
 
     # axis == 0
@@ -67,22 +73,54 @@ class OneHotTest(tf.test.TestCase):
         on_value=on_value,
         off_value=off_value,
         axis=0,
+        dtype=dtype,
         truth=truth.T)  # Output is transpose version in this case
+
+  def _testDefaultBasic(self, dtype):
+    indices = np.asarray([0, 2, -1, 1], dtype=dtype)
+    depth = 3
+
+    truth = np.asarray(
+            [[1.0, 0.0, 0.0],
+             [0.0, 0.0, 1.0],
+             [0.0, 0.0, 0.0],
+             [0.0, 1.0, 0.0]],
+            dtype=dtype)
+
+    # axis == -1
+    self._testBothOneHot(
+            indices=indices,
+            depth=depth,
+            dtype=dtype,
+            truth=truth)
+
+    # axis == 0
+    self._testBothOneHot(
+            indices=indices,
+            depth=depth,
+            axis=0,
+            dtype=dtype,
+            truth=truth.T)  # Output is transpose version in this case
 
   def testFloatBasic(self):
     self._testBasic(np.float32)
+    self._testDefaultBasic(np.float32)
 
   def testDoubleBasic(self):
     self._testBasic(np.float64)
+    self._testDefaultBasic(np.float64)
 
   def testInt32Basic(self):
     self._testBasic(np.int32)
+    self._testDefaultBasic(np.int32)
 
   def testInt64Basic(self):
     self._testBasic(np.int64)
+    self._testDefaultBasic(np.int64)
 
   def testComplexBasic(self):
     self._testBasic(np.complex64)
+    self._testDefaultBasic(np.complex64)
 
   def _testBatch(self, dtype):
     indices = np.asarray([[0, 2, -1, 1],
@@ -109,6 +147,7 @@ class OneHotTest(tf.test.TestCase):
         depth=depth,
         on_value=on_value,
         off_value=off_value,
+        dtype=dtype,
         truth=truth)
 
     # axis == 1
@@ -118,22 +157,165 @@ class OneHotTest(tf.test.TestCase):
         on_value=on_value,
         off_value=off_value,
         axis=1,
+        dtype=dtype,
         truth=[truth[0].T, truth[1].T])  # Do not transpose the batch
+
+  def _testDefaultValuesBatch(self, dtype):
+    indices = np.asarray([[0, 2, -1, 1],
+                          [1, 0, 1, -1]],
+                         dtype=dtype)
+    depth = 3
+
+    truth = np.asarray(
+            [[[1.0, 0.0, 0.0],
+              [0.0, 0.0, 1.0],
+              [0.0, 0.0, 0.0],
+              [0.0, 1.0, 0.0]],
+             [[0.0, 1.0, 0.0],
+              [1.0, 0.0, 0.0],
+              [0.0, 1.0, 0.0],
+              [0.0, 0.0, 0.0]]],
+            dtype=dtype)
+
+    # axis == -1
+    self._testBothOneHot(
+            indices=indices,
+            depth=depth,
+            dtype=dtype,
+            truth=truth)
+
+    # axis == 1
+    self._testBothOneHot(
+            indices=indices,
+            depth=depth,
+            axis=1,
+            dtype=dtype,
+            truth=[truth[0].T, truth[1].T])  # Do not transpose the batch
+
+  def _testTypeBatch(self, dtype):
+    indices = np.asarray([[0, 2, -1, 1],
+                          [1, 0, 1, -1]],
+                         dtype=dtype)
+    depth = 3
+
+    on_value = np.asarray(1.0, dtype=dtype)
+    off_value = np.asarray(-1.0, dtype=dtype)
+
+    truth = np.asarray(
+        [[[1.0, -1.0, -1.0],
+          [-1.0, -1.0, 1.0],
+          [-1.0, -1.0, -1.0],
+          [-1.0, 1.0, -1.0]],
+         [[-1.0, 1.0, -1.0],
+          [1.0, -1.0, -1.0],
+          [-1.0, 1.0, -1.0],
+          [-1.0, -1.0, -1.0]]],
+        dtype=dtype)
+
+    # axis == -1
+    self._testBothOneHot(
+            indices=indices,
+            on_value=on_value,
+            off_value=off_value,
+            depth=depth,
+            truth=truth)
+
+    # axis == 1
+    self._testBothOneHot(
+            indices=indices,
+            on_value=on_value,
+            off_value=off_value,
+            depth=depth,
+            axis=1,
+            truth=[truth[0].T, truth[1].T])  # Do not transpose the batch
 
   def testFloatBatch(self):
     self._testBatch(np.float32)
+    self._testDefaultValuesBatch(np.float32)
+    self._testTypeBatch(np.float32)
 
   def testDoubleBatch(self):
     self._testBatch(np.float64)
+    self._testDefaultValuesBatch(np.float64)
+    self._testTypeBatch(np.float64)
 
   def testInt32Batch(self):
     self._testBatch(np.int32)
+    self._testDefaultValuesBatch(np.int32)
+    self._testTypeBatch(np.int32)
 
   def testInt64Batch(self):
     self._testBatch(np.int64)
+    self._testDefaultValuesBatch(np.int64)
+    self._testTypeBatch(np.int64)
 
   def testComplexBatch(self):
     self._testBatch(np.complex64)
+    self._testDefaultValuesBatch(np.complex64)
+    self._testTypeBatch(np.complex64)
+
+  def testSimpleCases(self):
+    indices = [0,1,2]
+    depth = 3
+    truth = np.asarray(
+      [[1.0, 0.0, 0.0],
+       [0.0, 1.0, 0.0],
+       [0.0, 0.0, 1.0]],
+       dtype=np.float32)
+    self._testBothOneHot(indices=indices, depth=depth, truth=truth)
+
+    indices = [0,1,2]
+    depth = 3
+    truth = np.asarray(
+      [[1, 0, 0],
+       [0, 1, 0],
+       [0, 0, 1]],
+       dtype=np.int32)
+    self._testBothOneHot(indices=indices, depth=depth, dtype=np.int32, 
+                         truth=truth)
+
+    indices = [0,1,2]
+    depth = 3
+    truth = np.asarray(
+      [[1, -1, -1],
+       [-1, 1, -1],
+       [-1, -1, 1]],
+       dtype=np.int32)
+    self._testBothOneHot(indices=indices, depth=depth, on_value=1,
+                         off_value=-1, truth=truth)
+
+  def testStringDtypeError(self):
+    indices = [0,1,2]
+    depth = 3
+    truth = np.asarray(
+      [[1.0, 0.0, 0.0],
+       [0.0, 1.0, 0.0],
+       [0.0, 0.0, 1.0]])
+    self._testBothOneHot(indices=indices, depth=depth, on_value=1,
+                         off_value=-1, dtype=tf.string, raises=TypeError,
+                         truth=truth)
+
+  def testSingleValueGiven(self):
+    # Only on_value provided
+    indices = [0,1,2]
+    depth = 3
+    truth = np.asarray(
+      [[1, 0, 0],
+       [0, 1, 0],
+       [0, 0, 1]],
+       dtype=np.int32)
+    self._testBothOneHot(indices=indices, depth=depth, on_value=1, truth=truth)
+
+    # Only off_value provided
+    indices = [0,1,2]
+    depth = 3
+    truth = np.asarray(
+      [[1, 0, 0],
+       [0, 1, 0],
+       [0, 0, 1]],
+       dtype=np.float32)
+    self._testBothOneHot(indices=indices, depth=depth,
+                         off_value=0.0, truth=truth)
 
 if __name__ == "__main__":
   tf.test.main()

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1757,6 +1757,111 @@ def _DepthToSpaceShape(op):
       [input_shape[0], height, width, new_depth])]
 
 
+def one_hot(indices, depth, on_value=1, off_value=0,
+            axis=None, dtype=dtypes.float32, name=None):
+  """Returns a one-hot tensor.
+
+  The locations represented by indices in `indices` take value `on_value`,
+  while all other locations take value `off_value`. By default, `on_value` is 1,
+  and `off_value` is 0. The type of the output tensor is specified by `dtype`, 
+  which defaults to `tf.float32`.
+
+  If the input `indices` is rank `N`, the output will have rank `N+1`. The
+  new axis is created at dimension `axis` (default: the new axis is appended
+  at the end).
+
+  If `indices` is a scalar the output shape will be a vector of length `depth`
+
+  If `indices` is a vector of length `features`, the output shape will be:
+  ```
+    features x depth if axis == -1
+    depth x features if axis == 0
+  ```
+
+  If `indices` is a matrix (batch) with shape `[batch, features]`, the output
+  shape will be:
+  ```
+    batch x features x depth if axis == -1
+    batch x depth x features if axis == 1
+    depth x batch x features if axis == 0
+  ```
+
+
+  Examples
+  =========
+
+  Suppose that
+
+  ```
+    indices = [0, 2, -1, 1]
+    depth = 3
+    on_value = 5.0
+    off_value = 0.0
+    axis = -1
+  ```
+
+  Then output is `[4 x 3]`:
+
+  ```output =
+    [5.0 0.0 0.0]  // one_hot(0)
+    [0.0 0.0 5.0]  // one_hot(2)
+    [0.0 0.0 0.0]  // one_hot(-1)
+    [0.0 5.0 0.0]  // one_hot(1)
+  ```
+
+  Suppose that
+
+  ```
+    indices = [[0, 2], [1, -1]]
+    depth = 3
+    on_value = 1.0
+    off_value = 0.0
+    axis = -1
+  ```
+
+  Then output is `[2 x 2 x 3]`:
+
+  ```
+    output =
+    [
+      [1.0, 0.0, 0.0]  // one_hot(0)
+      [0.0, 0.0, 1.0]  // one_hot(2)
+    ][
+      [0.0, 1.0, 0.0]  // one_hot(1)
+      [0.0, 0.0, 0.0]  // one_hot(-1)
+    ]
+  ```
+
+  Args:
+    indices: A `Tensor` of indices.
+    depth: A scalar defining the depth of the one hot dimension.
+    on_value: A scalar defining the value to fill in output when `indices[j]
+      = i`. (default: 1)
+    off_value: A scalar defining the value to fill in output when `indices[j]
+      != i`. (default: 0)
+    axis: The axis to fill (default: -1, a new inner-most axis).
+    dtype: The data type of the output tensor.
+
+  Returns:
+    output: The one-hot tensor.
+
+  Raises:
+    TypeError: If dtype is `tf.string`
+  """
+  # Check for bad dtype specification
+  if dtype == dtypes.string:
+    raise TypeError("dtype must be a numeric type")
+
+  with ops.op_scope([indices, depth, on_value, off_value,
+            axis, dtype], name, "one_hot") as name:
+    on_value = ops.convert_to_tensor(on_value, dtype=dtype, name="on_value")
+    off_value = ops.convert_to_tensor(off_value, dtype=dtype, name="off_value")
+    indices = ops.convert_to_tensor(indices, dtype=dtypes.int64, name="indices")
+    depth = ops.convert_to_tensor(depth, dtype=dtypes.int32, name="depth")
+    return gen_array_ops._one_hot(indices, depth, on_value, 
+                                  off_value, axis, name)
+
+
 @ops.RegisterShape("OneHot")
 def _OneHotShape(op):
   """Shape function for the OneHot op.


### PR DESCRIPTION
This commit adds a Python wrapper for tf.one_hot(), and introduces two
main, backwards compatible, improvements, as mentioned in #1799:
1. The parameters `on_value` and `off_value` now have default values 1 and 0
   respectively, as 32-bit integers. Because the most common use case of
   one_hot() is to create Tensors for one-hot encoding, it will save users
   some headache to not have to manually type in these values by hand each
   time it is used. The parameters can still be given different values as
   before, and this does not any previous behavior.
2. `indices` and `depth` no longer have to be cast by hand as `int64` and
   `int32` values, respectively. Previously, one_hot() would complain if
   these values weren't of the exact right type- it now casts the values to
   the appropriate type on its own.

Pinging @ebrevdo for review.
