### PR TITLE
Word2vec basic show id and word together 

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -81,7 +81,7 @@ def build_dataset(words):
 data, count, dictionary, reverse_dictionary = build_dataset(words)
 del words  # Hint to reduce memory.
 print('Most common words (+UNK)', count[:5])
-print('Sample data', data[:10])
+print('Sample data', data[:10], [reverse_dictionary[i] for i in data[:10]])
 
 data_index = 0
 
@@ -113,8 +113,8 @@ def generate_batch(batch_size, num_skips, skip_window):
 
 batch, labels = generate_batch(batch_size=8, num_skips=2, skip_window=1)
 for i in range(8):
-  print(batch[i], '->', labels[i, 0])
-  print(reverse_dictionary[batch[i]], '->', reverse_dictionary[labels[i, 0]])
+    print(batch[i], reverse_dictionary[batch[i]],
+          '->', labels[i, 0], reverse_dictionary[labels[i, 0]])
 
 # Step 4: Build and train a skip-gram model.
 

--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -113,8 +113,8 @@ def generate_batch(batch_size, num_skips, skip_window):
 
 batch, labels = generate_batch(batch_size=8, num_skips=2, skip_window=1)
 for i in range(8):
-    print(batch[i], reverse_dictionary[batch[i]],
-          '->', labels[i, 0], reverse_dictionary[labels[i, 0]])
+  print(batch[i], reverse_dictionary[batch[i]],
+      '->', labels[i, 0], reverse_dictionary[labels[i, 0]])
 
 # Step 4: Build and train a skip-gram model.
 


### PR DESCRIPTION
When I first read the output, I spent a lot of time to understand these numbers to match them. Now, words along with the ids clearly show what's going on in the sample data and prediction pairs.

[New output]: clearly shows the word ids and corresponding words
      Sample data [5239, 3084, 12, 6, 195, 2, 3137, 46, 59, 156] ['anarchism', 'originated', 'as', 'a', 'term', 'of', 'abuse', 'first', 'used', 'against']
      3084 originated -> 12 as
      3084 originated -> 5239 anarchism
      12 as -> 6 a
      12 as -> 3084 originated
      6 a -> 12 as
      6 a -> 195 term
      195 term -> 6 a
      195 term -> 2 of

[Old output]: No words for Sample data. Word ids and words are mixed, so it's very hard to read
      Sample data [5239, 3084, 12, 6, 195, 2, 3137, 46, 59, 156] ['anarchism', 'originated', 'as', 'a', 'term', 'of', 'abuse', 'first', 'used', 'against']
      3084 -> 5239
      originated -> anarchism
      3084 -> 12
      originated -> as
      12 -> 3084
      as -> originated
      12 -> 6
      as -> a
      6 -> 195
      a -> term
      6 -> 12
      a -> as
      195 -> 6
      term -> a
      195 -> 2
      term -> of
