### PR TITLE
Fix chat link at start of README

### DIFF
--- a/tensorflow/contrib/learn/python/learn/README.md
+++ b/tensorflow/contrib/learn/python/learn/README.md
@@ -1,4 +1,4 @@
-|License| |Join the chat at https://gitter.im/tensorflow/skflow|
+|License| |Join the chat at [https://gitter.im/tensorflow/skflow](https://gitter.im/tensorflow/skflow)|
 
 TF Learn (aka Scikit Flow)
 ===========


### PR DESCRIPTION
Original formatting for this link included the pipe character at the end, so that clicking it would lead to a 404. The more explicit URL formatting makes it so that clicking the link leads to the correct chat room.
