### PR TITLE
tv.Variable doc: fix typo

### DIFF
--- a/tensorflow/g3doc/api_docs/python/state_ops.md
+++ b/tensorflow/g3doc/api_docs/python/state_ops.md
@@ -43,7 +43,7 @@ w = tf.Variable(<initial-value>, name=<optional-name>)
 y = tf.matmul(w, ...another variable or tensor...)
 
 # The overloaded operators are available too.
-z = tf.sigmoid(w + b)
+z = tf.sigmoid(w + y)
 
 # Assign a new value to the variable with `assign()` or a related method.
 w.assign(w + 1.0)

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -56,7 +56,7 @@ class Variable(object):
   y = tf.matmul(w, ...another variable or tensor...)
 
   # The overloaded operators are available too.
-  z = tf.sigmoid(w + b)
+  z = tf.sigmoid(w + y)
 
   # Assign a new value to the variable with `assign()` or a related method.
   w.assign(w + 1.0)


### PR DESCRIPTION
'b' does not exist in the example, probably 'y' was meant.
