### PR TITLE
deepdream: fix trivial typos

### DIFF
--- a/tensorflow/examples/tutorials/deepdream/README.md
+++ b/tensorflow/examples/tutorials/deepdream/README.md
@@ -3,7 +3,7 @@
 by [Alexander Mordvintsev](mailto:moralex@google.com)
 
 This directory contains Jupyter notebook that demonstrates a number of Convolutional Neural Network 
-image generation techiques implemented with TensorFlow:
+image generation techniques implemented with TensorFlow:
 
 - visualizing individual feature channels and their combinations to explore the space of patterns learned by the neural network (see [GoogLeNet](http://storage.googleapis.com/deepdream/visualz/tensorflow_inception/index.html) and [VGG16](http://storage.googleapis.com/deepdream/visualz/vgg16/index.html) galleries)
 - embedding TensorBoard graph visualizations into Jupyter notebooks

--- a/tensorflow/examples/tutorials/deepdream/deepdream.ipynb
+++ b/tensorflow/examples/tutorials/deepdream/deepdream.ipynb
@@ -38,7 +38,7 @@
     "id": "-PLC9SvcQgkG"
    },
    "source": [
-    "This notebook demonstrates a number of Convolutional Neural Network image generation techiques impelemented with TensorFlow for fun and science:\n",
+    "This notebook demonstrates a number of Convolutional Neural Network image generation techniques implemented with TensorFlow for fun and science:\n",
     "\n",
     "- visualize individual feature channels and their combinations to explore the space of patterns learned by the neural network (see [GoogLeNet](http://storage.googleapis.com/deepdream/visualz/tensorflow_inception/index.html) and [VGG16](http://storage.googleapis.com/deepdream/visualz/vgg16/index.html) galleries)\n",
     "- embed TensorBoard graph visualizations into Jupyter notebooks\n",
@@ -831,7 +831,7 @@
    },
    "source": [
     "<a id=\"playing\"></a>\n",
-    "## Playing with feature visualzations\n",
+    "## Playing with feature visualizations\n",
     "\n",
     "We got a nice smooth image using only 10 iterations per octave. In case of running on GPU this takes just a few seconds. Let's try to visualize another channel from the same layer. The network can generate wide diversity of patterns."
    ]


### PR DESCRIPTION
This pull request fixes trivial typos under deepdream/ directory.
