### PR TITLE
Add confusion matrix to tensorflow

### DIFF
--- a/tensorflow/contrib/metrics/BUILD
+++ b/tensorflow/contrib/metrics/BUILD
@@ -17,9 +17,9 @@ py_library(
 )
 
 cuda_py_tests(
-    name = "histogram_ops_test",
+    name = "metrics_ops_test",
     size = "medium",
-    srcs = ["python/kernel_tests/histogram_ops_test.py"],
+    srcs = glob(["python/kernel_tests/*_test.py"]),
     additional_deps = [
         ":metrics_py",
         "//tensorflow/python:framework_test_lib",

--- a/tensorflow/contrib/metrics/__init__.py
+++ b/tensorflow/contrib/metrics/__init__.py
@@ -24,3 +24,4 @@ from __future__ import print_function
 # pylint: disable=unused-import,line-too-long,g-importing-member,wildcard-import
 from tensorflow.contrib.metrics.python.metrics import *
 from tensorflow.contrib.metrics.python.ops.histogram_ops import auc_using_histogram
+from tensorflow.contrib.metrics.python.ops.confusion_matrix_ops import confusion_matrix

--- a/tensorflow/contrib/metrics/python/kernel_tests/confusion_matrix_ops_test.py
+++ b/tensorflow/contrib/metrics/python/kernel_tests/confusion_matrix_ops_test.py
@@ -1,0 +1,127 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for confusion_matrix_ops."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+
+class ConfusionMatrixTest(tf.test.TestCase):
+
+  def _testConfMatrix(self, predictions, targets, truth):
+    with self.test_session():
+      ans = tf.contrib.metrics.confusion_matrix(predictions, targets)
+      tf_ans = ans.eval()
+      self.assertAllClose(tf_ans, truth, atol=1e-10)
+
+  def _testBasic(self, dtype):
+    predictions = np.arange(5, dtype=dtype)
+    targets = np.arange(5, dtype=dtype)
+
+    truth = np.asarray(
+      [[1, 0, 0, 0, 0],
+       [0, 1, 0, 0, 0],
+       [0, 0, 1, 0, 0],
+       [0, 0, 0, 1, 0],
+       [0, 0, 0, 0, 1]],
+      dtype=dtype)
+
+    self._testConfMatrix(
+      predictions=predictions,
+      targets=targets,
+      truth=truth)
+
+  def testInt32Basic(self, dtype=np.int32):
+    self._testBasic(dtype)
+
+  def testInt64Basic(self, dtype=np.int64):
+    self._testBasic(dtype)
+
+  def _testDiffentLabelsInPredictionAndTarget(self, dtype):
+    predictions = np.asarray([1, 2, 3], dtype=dtype)
+    targets = np.asarray([4, 5, 6], dtype=dtype)
+
+    truth = np.asarray(
+      [[0, 0, 0, 0, 0, 0, 0],
+       [0, 0, 0, 0, 1, 0, 0],
+       [0, 0, 0, 0, 0, 1, 0],
+       [0, 0, 0, 0, 0, 0, 1],
+       [0, 0, 0, 0, 0, 0, 0],
+       [0, 0, 0, 0, 0, 0, 0],
+       [0, 0, 0, 0, 0, 0, 0]],
+      dtype=dtype)
+
+    self._testConfMatrix(
+      predictions=predictions,
+      targets=targets,
+      truth=truth)
+
+  def testInt32DifferentLabels(self, dtype=np.int32):
+    self._testDiffentLabelsInPredictionAndTarget(dtype)
+
+  def testInt64DifferentLabels(self, dtype=np.int64):
+    self._testDiffentLabelsInPredictionAndTarget(dtype)
+
+  def _testMultipleLabels(self, dtype):
+    predictions = np.asarray([1, 1, 2, 3, 5, 6, 1, 2, 3, 4], dtype=dtype)
+    targets = np.asarray([1, 1, 2, 3, 5, 1, 3, 6, 3, 1], dtype=dtype)
+
+    truth = np.asarray(
+      [[0, 0, 0, 0, 0, 0, 0],
+       [0, 2, 0, 1, 0, 0, 0],
+       [0, 0, 1, 0, 0, 0, 1],
+       [0, 0, 0, 2, 0, 0, 0],
+       [0, 1, 0, 0, 0, 0, 0],
+       [0, 0, 0, 0, 0, 1, 0],
+       [0, 1, 0, 0, 0, 0, 0]],
+      dtype=dtype)
+
+    self._testConfMatrix(
+      predictions=predictions,
+      targets=targets,
+      truth=truth)
+
+  def testInt32MultipleLabels(self, dtype=np.int32):
+    self._testMultipleLabels(dtype)
+
+  def testInt64MultipleLabels(self, dtype=np.int64):
+    self._testMultipleLabels(dtype)
+
+  def testInvalidRank(self):
+    predictions = np.asarray([[1, 2, 3]])
+    targets = np.asarray([1, 2, 3])
+    self.assertRaisesRegexp(
+        ValueError, "are not compatible",
+        tf.contrib.metrics.confusion_matrix, predictions, targets)
+
+    predictions = np.asarray([1, 2, 3])
+    targets = np.asarray([[1, 2, 3]])
+    self.assertRaisesRegexp(
+        ValueError, "are not compatible",
+        tf.contrib.metrics.confusion_matrix, predictions, targets)
+
+  def testInputDifferentSize(self):
+    predictions = np.asarray([1, 2, 3])
+    targets = np.asarray([1, 2])
+    self.assertRaisesRegexp(
+          ValueError,
+          "are not compatible",
+          tf.contrib.metrics.confusion_matrix, predictions, targets)
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow/contrib/metrics/python/ops/confusion_matrix_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/confusion_matrix_ops.py
@@ -1,0 +1,86 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import sparse_ops
+
+
+"""Confusion matrix related metrics."""
+
+
+def confusion_matrix(predictions, targets, num_classes=None, name=None):
+  """Computes the confusion matrix from predictions and targets
+
+  Calculate the Confusion Matrix for a pair of prediction and
+  target 1-D int arrays.
+
+  Considering a prediction array such as: `[1, 2, 3]`
+  And a target array such as: `[2, 2, 3]`
+
+  The confusion matrix returned would be the following one:
+      [[0, 0, 0]
+       [0, 1, 0]
+       [0, 1, 0]
+       [0, 0, 1]]
+
+  Where the matrix rows represent the prediction labels and the columns
+  represents the target labels. The confusion matrix is always a 2-D array
+  of shape [n, n], where n is the number of valid labels for a given
+  classification task. Both prediction and target must be 1-D arrays of
+  the same shape in order for this function to work.
+
+  Args:
+    predictions: A 1-D array represeting the predictions for a given
+                 classification.
+    targets: A 1-D represeting the real labels for the classification task.
+    num_classes: The possible number of labels the classification task can
+                 have. If this value is not provided, it will be calculated
+                 using both predictions and targets array.
+
+  Returns:
+    A l X l matrix represeting the confusion matrix, where l in the number of
+    possible labels in the classification task.
+
+  Raises:
+    ValueError: If both predictions and targets are not 1-D vectors and do not
+                have the same size.
+  """
+  with ops.op_scope([predictions, targets, num_classes], name,
+                    'confusion_matrix') as name:
+    predictions = ops.convert_to_tensor(
+      predictions, name="predictions", dtype=dtypes.int64)
+    targets = ops.convert_to_tensor(
+      targets, name="targets", dtype=dtypes.int64)
+
+    if num_classes is None:
+      num_classes = math_ops.maximum(math_ops.reduce_max(predictions),
+                                     math_ops.reduce_max(targets)) + 1
+
+    shape = array_ops.pack([num_classes, num_classes])
+    indices = array_ops.transpose(
+      array_ops.pack([predictions, targets]))
+    values = array_ops.ones_like(predictions, dtype=dtypes.int32)
+    cm_sparse = ops.SparseTensor(
+      indices=indices, values=values, shape=shape)
+    zero_matrix = array_ops.zeros(math_ops.to_int32(shape), dtypes.int32)
+
+    return sparse_ops.sparse_add(zero_matrix, cm_sparse)


### PR DESCRIPTION
This MR add a confusion matrix implementation for tensorflow. The function is named confusion_matrix and is a metric operation.

The function receives three parameters, both predictions and targets labels and an optional num_classes:

``` python
tf.contrib.metrics.confusion_matrix(predictions, targets, num_classes=None)
```

If num_classes is not provided, it will be computed using both predictions and targets parameters.

Both predictions and targets must be an 1-D array with dtype int32 or int64. This function will then infer the valid labels from both arrays and create a confusion matrix for them. The confusion matrix will always be a square matrix with shape L X L, considering L as the number of valid labels for a given classification task. The dtype of the confusion matrix will be the same as the predictions and target ones.

For example, given a prediction array: [1, 2, 3, 1], and a target array: [1, 2, 1, 1], the generated confusion matrix would be:

``` python
[[0 0 0],
 [2 0 0],
 [0 1 0],
 [1 0 0]]
```

The rows of the matrix represent the predictions array and the columns, the targets one.
Finally, this function was implemented only for CPU use. This MR resolves the issue #1606, but there is still work to be done on tensorboard considering this function.
