### PR TITLE
docs only: removes sudo from pip/easy_install in instructions

### DIFF
--- a/tensorflow/examples/skflow/README.md
+++ b/tensorflow/examples/skflow/README.md
@@ -4,8 +4,8 @@ Scikit Flow is high level API that allows to create,
 train and use deep learning models easily with well
 known Scikit Learn API.
 
-To run these examples, you need to have `scikit learn` library installed (`sudo pip install sklearn`).
-Some examples use the `pandas` library for data processing (`sudo pip install pandas`).
+To run these examples, you need to have `scikit learn` library installed (`pip install sklearn`).
+Some examples use the `pandas` library for data processing (`pip install pandas`).
 
 * [Deep Neural Network Regression with Boston Data](boston.py)
 * [Convolutional Neural Networks with Digits Data](digits.py)

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -49,37 +49,37 @@ Install pip (or pip3 for python3) if it is not already installed:
 $ sudo apt-get install python-pip python-dev
 
 # Mac OS X
-$ sudo easy_install pip
+$ easy_install pip
 ```
 
 Install TensorFlow:
 
 ```bash
 # Ubuntu/Linux 64-bit, CPU only:
-$ sudo pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0rc0-cp27-none-linux_x86_64.whl
+$ pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0rc0-cp27-none-linux_x86_64.whl
 
 # Ubuntu/Linux 64-bit, GPU enabled. Requires CUDA toolkit 7.5 and CuDNN v4.  For
 # other versions, see "Install from sources" below.
-$ sudo pip install --upgrade https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0rc0-cp27-none-linux_x86_64.whl
+$ pip install --upgrade https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0rc0-cp27-none-linux_x86_64.whl
 
 # Mac OS X, CPU only:
-$ sudo easy_install --upgrade six
-$ sudo pip install --upgrade https://storage.googleapis.com/tensorflow/mac/tensorflow-0.8.0rc0-py2-none-any.whl
+$ easy_install --upgrade six
+$ pip install --upgrade https://storage.googleapis.com/tensorflow/mac/tensorflow-0.8.0rc0-py2-none-any.whl
 ```
 
 For python3:
 
 ```bash
 # Ubuntu/Linux 64-bit, CPU only:
-$ sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0rc0-cp34-cp34m-linux_x86_64.whl
+$ pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0rc0-cp34-cp34m-linux_x86_64.whl
 
 # Ubuntu/Linux 64-bit, GPU enabled. Requires CUDA toolkit 7.5 and CuDNN v4.  For
 # other versions, see "Install from sources" below.
-$ sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0rc0-cp34-cp34m-linux_x86_64.whl
+$ pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0rc0-cp34-cp34m-linux_x86_64.whl
 
 # Mac OS X, CPU only:
-$ sudo easy_install --upgrade six
-$ sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/mac/tensorflow-0.8.0rc0-py3-none-any.whl
+$ easy_install --upgrade six
+$ pip3 install --upgrade https://storage.googleapis.com/tensorflow/mac/tensorflow-0.8.0rc0-py3-none-any.whl
 ```
 
 NOTE: If you are upgrading from a previous installation of TensorFlow < 0.7.1,
@@ -114,7 +114,7 @@ $ sudo apt-get install python-pip python-dev python-virtualenv
 
 # Mac OS X
 $ sudo easy_install pip
-$ sudo pip install --upgrade virtualenv
+$ pip install --upgrade virtualenv
 ```
 
 Create a Virtualenv environment in the directory `~/tensorflow`:
@@ -575,16 +575,16 @@ You can install the python dependencies using easy_install or pip. Using
 easy_install, run
 
 ```bash
-$ sudo easy_install -U six
-$ sudo easy_install -U numpy
-$ sudo easy_install wheel
+$ easy_install -U six
+$ easy_install -U numpy
+$ easy_install wheel
 ```
 
 We also recommend the [ipython](https://ipython.org) enhanced python shell,
 which you can install as follows:
 
 ```bash
-$ sudo easy_install ipython
+$ easy_install ipython
 ```
 
 #### Configure the installation
@@ -804,7 +804,7 @@ You can resolve the issue in one of the following ways:
 * Upgrade the Python installation with the current version of `six`:
 
 ```bash
-$ sudo easy_install -U six
+$ easy_install -U six
 ```
 
 * Install TensorFlow with a separate Python library:
@@ -822,7 +822,7 @@ On El Capitan, "six" is a special package that can't be modified, and this
 error is reported when "pip install" tried to modify this package. To fix use
 "ignore_installed" flag, ie
 
-sudo pip install --ignore-installed six https://storage.googleapis.com/....
+pip install --ignore-installed six https://storage.googleapis.com/....
 
 
 ### Mac OS X: TypeError: `__init__()` got an unexpected keyword argument 'syntax'

--- a/tensorflow/tensorboard/DEVELOPMENT.md
+++ b/tensorflow/tensorboard/DEVELOPMENT.md
@@ -9,7 +9,7 @@ nodejs-legacy npm`.
 
 Next, you'll want to install [gulp](http://gulpjs.com/) and
 [bower](http://bower.io/), which are used for build tooling and dependency
-management respectively. `sudo npm install -g gulp bower` will install them
+management respectively. `npm install -g gulp bower` will install them
 globally for convenience.
 
 Then, cd into the TensorBoard directory:


### PR DESCRIPTION
`sudo`, where removed in the below instances, is superfluous, nonstandard, and is not a sensible default.  When using a virtualenv or similar, this can cause unsafety later on. Below examples work when pip/easy_install/npm are installed in userland. `pip` will complain if it needs root.
