### PR TITLE
solve compatibility issue for ubuntu 16.04

### DIFF
--- a/third_party/gpus/crosstool/CROSSTOOL
+++ b/third_party/gpus/crosstool/CROSSTOOL
@@ -50,6 +50,7 @@ toolchain {
   # Use "-std=c++11" for nvcc. For consistency, force both the host compiler
   # and the device compiler to use "-std=c++11".
   cxx_flag: "-std=c++11"
+  cxx_flag: "-D_FORCE_INLINES"
   linker_flag: "-lstdc++"
   linker_flag: "-B/usr/bin/"
 


### PR DESCRIPTION
Ubuntu 16.04 LTS has update default `gcc` to 5.3 and `string.h` as well, even we install a `gcc-4.9`,
we will get a bug like

```
usr/include/string.h: In function 'void* __mempcpy_inline(void*, const void*, size_t)':
/usr/include/string.h:652:42: error: 'memcpy' was not declared in this scope
     return (char *) memcpy (__dest, __src, __n) + __n;
```

this bus is described in https://github.com/tensorflow/tensorflow/issues/1346
and can be solved by 
insert `cxx_flag: "-D_FORCE_INLINES"` into `tensorflow/third_party/gpus/crosstool/CROSSTOOL`
