### PR TITLE
tensorflow.bzl: strip bazel version number to work with patch bazel release

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -12,7 +12,7 @@ def _parse_bazel_version(bazel_version):
   # Turn "release" into a tuple of integers
   version_tuple = ()
   for number in parts[0].split('.'):
-    version_tuple += (int(number.strip('abcdefghij')),)
+    version_tuple += (str(number),)
   return version_tuple
 
 

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -12,7 +12,7 @@ def _parse_bazel_version(bazel_version):
   # Turn "release" into a tuple of integers
   version_tuple = ()
   for number in parts[0].split('.'):
-    version_tuple += (int(number),)
+    version_tuple += (int(number.strip('abcdefghij')),)
   return version_tuple
 
 

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -9,7 +9,7 @@ def _parse_bazel_version(bazel_version):
   # as a tuple of integers.
   parts = version.split('-', 1)
 
-  # Turn "release" into a tuple of integers
+  # Turn "release" into a tuple of strings 
   version_tuple = ()
   for number in parts[0].split('.'):
     version_tuple += (str(number),)


### PR DESCRIPTION
The newest bazel version number is 0.2.2b, when need to strip 2b
