### PR TITLE
Update os_setup.md

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -617,10 +617,10 @@ $ bazel build -c opt //tensorflow/tools/pip_package:build_pip_package
 # To build with GPU support:
 $ bazel build -c opt --config=cuda //tensorflow/tools/pip_package:build_pip_package
 
-$ bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
+$ sudo bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
 
 # The name of the .whl file will depend on your platform.
-$ pip install /tmp/tensorflow_pkg/tensorflow-0.8.0-py2-none-linux_x86_64.whl
+$ sudo pip install /tmp/tensorflow_pkg/tensorflow-0.8.0-py2-none-any.whl
 ```
 
 ## Setting up TensorFlow for Development


### PR DESCRIPTION
Fixed command to Installing from sources on OS X

In file "os_setup.md"

When try to build from sources on OS X, it need to root permission during

> sudo bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
> sudo pip install /tmp/tensorflow_pkg/tensorflow-0.8.0-py2-none-any.whl
