### PR TITLE
Don't reimport numpy from py_func

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -80,12 +80,27 @@ py_tests(
 )
 
 cc_library(
+    name = "numpy_lib",
+    srcs = ["lib/core/numpy.cc"],
+    hdrs = [
+        "lib/core/numpy.h",
+    ],
+    deps = [
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//third_party/py/numpy:headers",
+        "//util/python:python_headers",
+    ],
+)
+
+cc_library(
     name = "py_func_lib",
     srcs = ["lib/core/py_func.cc"],
     hdrs = [
         "lib/core/py_func.h",
     ],
     deps = [
+        ":numpy_lib",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:script_ops_op_lib",
@@ -962,6 +977,7 @@ tf_cuda_library(
     hdrs = ["client/tf_session_helper.h"],
     deps = [
         ":construction_fails_op",
+        ":numpy_lib",
         ":test_ops_kernels",
         "//tensorflow/core",
         "//tensorflow/core:all_kernels",
@@ -1006,6 +1022,7 @@ tf_py_wrap_cc(
         "util/py_checkpoint_reader.i",
     ],
     deps = [
+        ":numpy_lib",
         ":py_checkpoint_reader",
         ":py_func_lib",
         ":py_record_reader_lib",

--- a/tensorflow/python/client/tf_session_helper.cc
+++ b/tensorflow/python/client/tf_session_helper.cc
@@ -13,10 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// We define the PY_ARRAY_UNIQUE_SYMBOL in this .cc file and provide an
-// ImportNumpy function to populate it.
-#define TF_IMPORT_NUMPY
-
 #include "tensorflow/python/client/tf_session_helper.h"
 
 #include <cstring>
@@ -635,8 +631,6 @@ void TF_PRun_wrapper(TF_Session* session, const char* handle,
   TF_Run_wrapper_helper(session, handle, nullptr, inputs, output_names,
                         NameVector(), out_status, out_values, nullptr);
 }
-
-void ImportNumpy() { import_array1(); }
 
 string EqualGraphDefWrapper(const string& actual, const string& expected) {
   GraphDef actual_def;

--- a/tensorflow/python/client/tf_session_helper.h
+++ b/tensorflow/python/client/tf_session_helper.h
@@ -16,22 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_PYTHON_CLIENT_TF_SESSION_HELPER_H_
 #define TENSORFLOW_PYTHON_CLIENT_TF_SESSION_HELPER_H_
 
-#ifdef PyArray_Type
-#error "Numpy cannot be included before tf_session_helper.h."
-#endif
-
-// Disallow Numpy 1.7 deprecated symbols.
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-
-// We import_array in the tensorflow init function only.
-#define PY_ARRAY_UNIQUE_SYMBOL _tensorflow_numpy_api
-#ifndef TF_IMPORT_NUMPY
-#define NO_IMPORT_ARRAY
-#endif
-
-#include <Python.h>
-
-#include "numpy/arrayobject.h"
+// Must be included first
+#include "tensorflow/python/lib/core/numpy.h"
 
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/lib/core/errors.h"
@@ -109,11 +95,6 @@ void TF_PRunSetup_wrapper(TF_Session* session, const NameVector& input_names,
 void TF_PRun_wrapper(TF_Session* session, const char* handle,
                      const FeedVector& inputs, const NameVector& output_names,
                      Status* out_status, PyObjectVector* out_values);
-
-// Import numpy.  This wrapper function exists so that the
-// PY_ARRAY_UNIQUE_SYMBOL can be safely defined in a .cc file to
-// avoid weird linking issues.
-void ImportNumpy();
 
 // Convenience wrapper around EqualGraphDef to make it easier to wrap.
 // Returns an explanation if a difference is found, or the empty string

--- a/tensorflow/python/lib/core/numpy.cc
+++ b/tensorflow/python/lib/core/numpy.cc
@@ -1,0 +1,28 @@
+/* Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// We define the PY_ARRAY_UNIQUE_SYMBOL in this .cc file and provide an
+// ImportNumpy function to populate it.
+#define TF_IMPORT_NUMPY
+
+#include "tensorflow/python/lib/core/numpy.h"
+
+namespace tensorflow {
+
+void ImportNumpy() {
+  import_array1();
+}
+
+}  // namespace tensorflow

--- a/tensorflow/python/lib/core/numpy.h
+++ b/tensorflow/python/lib/core/numpy.h
@@ -1,0 +1,46 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_PYTHON_LIB_CORE_NUMPY_H_
+#define TENSORFLOW_PYTHON_LIB_CORE_NUMPY_H_
+
+#ifdef PyArray_Type
+#error "Numpy cannot be included before numpy.h."
+#endif
+
+// Disallow Numpy 1.7 deprecated symbols.
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+// We import_array in the tensorflow init function only.
+#define PY_ARRAY_UNIQUE_SYMBOL _tensorflow_numpy_api
+#ifndef TF_IMPORT_NUMPY
+#define NO_IMPORT_ARRAY
+#endif
+
+#include <Python.h>
+
+#include "numpy/arrayobject.h"
+
+namespace tensorflow {
+
+// Import numpy.  This wrapper function exists so that the
+// PY_ARRAY_UNIQUE_SYMBOL can be safely defined in a .cc file to
+// avoid weird linking issues.  Should be called only from our
+// module initialization function.
+void ImportNumpy();
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_PYTHON_LIB_CORE_NUMPY_H_

--- a/tensorflow/python/lib/core/py_func.h
+++ b/tensorflow/python/lib/core/py_func.h
@@ -16,10 +16,11 @@ limitations under the License.
 #ifndef TENSORFLOW_PYTHON_LIB_CORE_PY_FUNC_H_
 #define TENSORFLOW_PYTHON_LIB_CORE_PY_FUNC_H_
 
+// Must be included first
+#include "tensorflow/python/lib/core/numpy.h"
+
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/lib/core/status.h"
-
-#include <Python.h>
 
 namespace tensorflow {
 


### PR DESCRIPTION
Numpy is supposed to be imported only at module initialization time.
Fix this by factoring our numpy import logic into lib/core/numpy.{h,cc}
and using from both tf_session_helper.h and py_func.h.
