### PR TITLE
Fix sec_per_batch in a multi-GPU CIFAR-10 example

### DIFF
--- a/tensorflow/models/image/cifar10/cifar10_multi_gpu_train.py
+++ b/tensorflow/models/image/cifar10/cifar10_multi_gpu_train.py
@@ -251,7 +251,7 @@ def train():
       if step % 10 == 0:
         num_examples_per_step = FLAGS.batch_size * FLAGS.num_gpus
         examples_per_sec = num_examples_per_step / duration
-        sec_per_batch = duration / FLAGS.num_gpus
+        sec_per_batch = float(duration)
 
         format_str = ('%s: step %d, loss = %.2f (%.1f examples/sec; %.3f '
                       'sec/batch)')


### PR DESCRIPTION
In a multi-GPU CIFAR-10 example, 'sec_per_batch' should be computed in the same way as a single GPU example. It's identical with the [inception-v3 example](https://github.com/tensorflow/models/blob/master/inception/inception/inception_train.py#L346-L351).
