### PR TITLE
Fix variable names on confusion matrix metric

### DIFF
--- a/tensorflow/contrib/metrics/python/kernel_tests/confusion_matrix_ops_test.py
+++ b/tensorflow/contrib/metrics/python/kernel_tests/confusion_matrix_ops_test.py
@@ -23,15 +23,15 @@ import tensorflow as tf
 
 class ConfusionMatrixTest(tf.test.TestCase):
 
-  def _testConfMatrix(self, predictions, targets, truth):
+  def _testConfMatrix(self, predictions, labels, truth):
     with self.test_session():
-      ans = tf.contrib.metrics.confusion_matrix(predictions, targets)
+      ans = tf.contrib.metrics.confusion_matrix(predictions, labels)
       tf_ans = ans.eval()
       self.assertAllClose(tf_ans, truth, atol=1e-10)
 
   def _testBasic(self, dtype):
     predictions = np.arange(5, dtype=dtype)
-    targets = np.arange(5, dtype=dtype)
+    labels = np.arange(5, dtype=dtype)
 
     truth = np.asarray(
       [[1, 0, 0, 0, 0],
@@ -43,7 +43,7 @@ class ConfusionMatrixTest(tf.test.TestCase):
 
     self._testConfMatrix(
       predictions=predictions,
-      targets=targets,
+      labels=labels,
       truth=truth)
 
   def testInt32Basic(self, dtype=np.int32):
@@ -54,7 +54,7 @@ class ConfusionMatrixTest(tf.test.TestCase):
 
   def _testDiffentLabelsInPredictionAndTarget(self, dtype):
     predictions = np.asarray([1, 2, 3], dtype=dtype)
-    targets = np.asarray([4, 5, 6], dtype=dtype)
+    labels = np.asarray([4, 5, 6], dtype=dtype)
 
     truth = np.asarray(
       [[0, 0, 0, 0, 0, 0, 0],
@@ -68,7 +68,7 @@ class ConfusionMatrixTest(tf.test.TestCase):
 
     self._testConfMatrix(
       predictions=predictions,
-      targets=targets,
+      labels=labels,
       truth=truth)
 
   def testInt32DifferentLabels(self, dtype=np.int32):
@@ -79,7 +79,7 @@ class ConfusionMatrixTest(tf.test.TestCase):
 
   def _testMultipleLabels(self, dtype):
     predictions = np.asarray([1, 1, 2, 3, 5, 6, 1, 2, 3, 4], dtype=dtype)
-    targets = np.asarray([1, 1, 2, 3, 5, 1, 3, 6, 3, 1], dtype=dtype)
+    labels = np.asarray([1, 1, 2, 3, 5, 1, 3, 6, 3, 1], dtype=dtype)
 
     truth = np.asarray(
       [[0, 0, 0, 0, 0, 0, 0],
@@ -93,7 +93,7 @@ class ConfusionMatrixTest(tf.test.TestCase):
 
     self._testConfMatrix(
       predictions=predictions,
-      targets=targets,
+      labels=labels,
       truth=truth)
 
   def testInt32MultipleLabels(self, dtype=np.int32):
@@ -104,24 +104,24 @@ class ConfusionMatrixTest(tf.test.TestCase):
 
   def testInvalidRank(self):
     predictions = np.asarray([[1, 2, 3]])
-    targets = np.asarray([1, 2, 3])
+    labels = np.asarray([1, 2, 3])
     self.assertRaisesRegexp(
         ValueError, "are not compatible",
-        tf.contrib.metrics.confusion_matrix, predictions, targets)
+        tf.contrib.metrics.confusion_matrix, predictions, labels)
 
     predictions = np.asarray([1, 2, 3])
-    targets = np.asarray([[1, 2, 3]])
+    labels = np.asarray([[1, 2, 3]])
     self.assertRaisesRegexp(
         ValueError, "are not compatible",
-        tf.contrib.metrics.confusion_matrix, predictions, targets)
+        tf.contrib.metrics.confusion_matrix, predictions, labels)
 
   def testInputDifferentSize(self):
     predictions = np.asarray([1, 2, 3])
-    targets = np.asarray([1, 2])
+    labels = np.asarray([1, 2])
     self.assertRaisesRegexp(
           ValueError,
           "are not compatible",
-          tf.contrib.metrics.confusion_matrix, predictions, targets)
+          tf.contrib.metrics.confusion_matrix, predictions, labels)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow/contrib/metrics/python/ops/confusion_matrix_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/confusion_matrix_ops.py
@@ -27,14 +27,14 @@ from tensorflow.python.ops import sparse_ops
 """Confusion matrix related metrics."""
 
 
-def confusion_matrix(predictions, targets, num_classes=None, name=None):
-  """Computes the confusion matrix from predictions and targets
+def confusion_matrix(predictions, labels, num_classes=None, name=None):
+  """Computes the confusion matrix from predictions and labels
 
   Calculate the Confusion Matrix for a pair of prediction and
-  target 1-D int arrays.
+  label 1-D int arrays.
 
   Considering a prediction array such as: `[1, 2, 3]`
-  And a target array such as: `[2, 2, 3]`
+  And a label array such as: `[2, 2, 3]`
 
   The confusion matrix returned would be the following one:
       [[0, 0, 0]
@@ -43,41 +43,41 @@ def confusion_matrix(predictions, targets, num_classes=None, name=None):
        [0, 0, 1]]
 
   Where the matrix rows represent the prediction labels and the columns
-  represents the target labels. The confusion matrix is always a 2-D array
+  represents the real labels. The confusion matrix is always a 2-D array
   of shape [n, n], where n is the number of valid labels for a given
-  classification task. Both prediction and target must be 1-D arrays of
+  classification task. Both prediction and labels must be 1-D arrays of
   the same shape in order for this function to work.
 
   Args:
     predictions: A 1-D array represeting the predictions for a given
                  classification.
-    targets: A 1-D represeting the real labels for the classification task.
+    labels: A 1-D represeting the real labels for the classification task.
     num_classes: The possible number of labels the classification task can
                  have. If this value is not provided, it will be calculated
-                 using both predictions and targets array.
+                 using both predictions and labels array.
 
   Returns:
     A l X l matrix represeting the confusion matrix, where l in the number of
     possible labels in the classification task.
 
   Raises:
-    ValueError: If both predictions and targets are not 1-D vectors and do not
+    ValueError: If both predictions and labels are not 1-D vectors and do not
                 have the same size.
   """
-  with ops.op_scope([predictions, targets, num_classes], name,
+  with ops.op_scope([predictions, labels, num_classes], name,
                     'confusion_matrix') as name:
     predictions = ops.convert_to_tensor(
       predictions, name="predictions", dtype=dtypes.int64)
-    targets = ops.convert_to_tensor(
-      targets, name="targets", dtype=dtypes.int64)
+    labels = ops.convert_to_tensor(
+      labels, name="labels", dtype=dtypes.int64)
 
     if num_classes is None:
       num_classes = math_ops.maximum(math_ops.reduce_max(predictions),
-                                     math_ops.reduce_max(targets)) + 1
+                                     math_ops.reduce_max(labels)) + 1
 
     shape = array_ops.pack([num_classes, num_classes])
     indices = array_ops.transpose(
-      array_ops.pack([predictions, targets]))
+      array_ops.pack([predictions, labels]))
     values = array_ops.ones_like(predictions, dtype=dtypes.int32)
     cm_sparse = ops.SparseTensor(
       indices=indices, values=values, shape=shape)


### PR DESCRIPTION
Considering that tensorflow metrics documentation states that every metric receives the parameters predictions and labels, this merge request fix the name of one of the confusion matrix variable, which is named "targets" and now is named "labels".
