### PR TITLE
Import numpy before a call to sys.setdlopenflags

### DIFF
--- a/tensorflow/python/__init__.py
+++ b/tensorflow/python/__init__.py
@@ -40,6 +40,10 @@ import traceback
 # the mode to RTLD_GLOBAL to make the symbols visible, so libraries such
 # as the ones implementing custom ops can have access to tensorflow
 # framework's symbols.
+# one catch is that numpy *must* be imported before the call to
+# setdlopenflags(), or there is a risk that later c modules will segfault
+# when importing numpy (gh-2034).
+import numpy as np
 _default_dlopen_flags = sys.getdlopenflags()
 sys.setdlopenflags(_default_dlopen_flags | ctypes.RTLD_GLOBAL)
 from tensorflow.python import pywrap_tensorflow


### PR DESCRIPTION
Must import numpy before a call to sys.setdlopenflags, or there may be a segfault in certain situations. Fixes #2034.

The situation occurs when users have compiled TensorFlow, but use binary distributions of SciPy. Alternatives to this patch would be documentation stating that users who compile TensorFlow from source should also recompile SciPy if they need it.
