### PR TITLE
Change gpu_device.cc so that per process fraction uses total memory fraction, not available memory

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -604,7 +604,7 @@ LocalDevice* BaseGPUDeviceFactory::CreateGPUDevice(
       allocated_memory -= min_system_memory;
     }
   } else {
-    allocated_memory *= config_memory_fraction;
+    allocated_memory = total_memory * config_memory_fraction;
   }
 
   Bytes allocated_bytes = static_cast<Bytes>(allocated_memory);

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -595,10 +595,11 @@ LocalDevice* BaseGPUDeviceFactory::CreateGPUDevice(
   int64 total_memory, available_memory;
   CHECK(se->DeviceMemoryUsage(&available_memory, &total_memory));
 
-  int64 allocated_memory = available_memory;
+  int64 allocated_memory;
   double config_memory_fraction =
       options.config.gpu_options().per_process_gpu_memory_fraction();
   if (config_memory_fraction == 0) {
+      allocated_memory = available_memory;
     const int64 min_system_memory = MinSystemMemory(available_memory);
     if (min_system_memory < allocated_memory) {
       allocated_memory -= min_system_memory;

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -599,7 +599,7 @@ LocalDevice* BaseGPUDeviceFactory::CreateGPUDevice(
   double config_memory_fraction =
       options.config.gpu_options().per_process_gpu_memory_fraction();
   if (config_memory_fraction == 0) {
-      allocated_memory = available_memory;
+    allocated_memory = available_memory;
     const int64 min_system_memory = MinSystemMemory(available_memory);
     if (min_system_memory < allocated_memory) {
       allocated_memory -= min_system_memory;


### PR DESCRIPTION
This change is for making the memory allocation from the whole memory not only the remaining memory to achieve better configuration for multi processes
