### PR TITLE
Add support for 3d convolutions

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -72,6 +72,16 @@ cc_library(
 )
 
 cc_library(
+    name = "conv_3d",
+    hdrs = ["conv_3d.h"],
+    deps = [
+        ":eigen_helpers",
+        "//tensorflow/core:framework",
+        "//third_party/eigen3",
+    ],
+)
+
+cc_library(
     name = "fill_functor",
     hdrs = ["fill_functor.h"],
     deps = [
@@ -1103,6 +1113,21 @@ tf_kernel_library(
 )
 
 tf_kernel_library(
+    name = "conv3d_ops",
+    srcs = ["conv3d_grad_ops.cc"],
+    prefix = "conv3d_ops",
+    deps = [
+        ":bounds_check",
+        ":conv_3d",
+        ":ops_util",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:nn_ops_op_lib",
+    ],
+)
+
+tf_kernel_library(
     name = "depthwise_conv_op",
     prefix = "depthwise_conv_op",
     deps = [
@@ -1148,6 +1173,8 @@ tf_kernel_libraries(
         ":bounds_check",
         ":conv_2d",
         ":conv_ops",
+        ":conv_3d",
+        ":conv3d_ops",
         ":depthwise_conv_grad_op",
         ":depthwise_conv_op",
         ":ops_util",

--- a/tensorflow/core/kernels/conv3d_grad_ops.cc
+++ b/tensorflow/core/kernels/conv3d_grad_ops.cc
@@ -1,0 +1,292 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/nn_ops.cc.
+
+#define USE_EIGEN_TENSOR
+#define EIGEN_USE_THREADS
+
+#include <vector>
+#include "tensorflow/core/framework/numeric_op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_slice.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/kernels/conv_3d.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/gtl/array_slice.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/util/padding.h"
+#include "tensorflow/core/util/tensor_format.h"
+#include "tensorflow/core/util/use_cudnn.h"
+#include "tensorflow/core/util/work_sharder.h"
+
+// #if GOOGLE_CUDA
+// GPU operations not yet implemented.
+// #include "tensorflow/core/kernels/conv3d_ops_gpu.h"
+// #include "tensorflow/core/platform/stream_executor.h"
+// #endif  // GOOGLE_CUDA
+
+namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+typedef Eigen::GpuDevice GPUDevice;
+
+// The operation to compute Conv3D gradients.
+//
+// Largly based off the logic and operations for 2d convolutions in
+// conv_grad_ops.cc
+
+#define EXTRACT_AND_VERIFY_DIMENSIONS_3D(label)                                \
+  const Tensor& out_backprop = context->input(2);                              \
+  OP_REQUIRES(                                                                 \
+      context, input_shape.dims() == 5,                                        \
+      errors::InvalidArgument(label, ": input must be 5-dimensional"));        \
+  OP_REQUIRES(                                                                 \
+      context, filter_shape.dims() == 5,                                       \
+      errors::InvalidArgument(label, ": filter must be 5-dimensional"));       \
+  OP_REQUIRES(                                                                 \
+      context, out_backprop.dims() == 5,                                       \
+      errors::InvalidArgument(label, ": out_backprop must be 5-dimensional")); \
+  const int64 batch = GetTensorDim(input_shape, data_format_, 'N');            \
+  OP_REQUIRES(                                                                 \
+      context, batch == GetTensorDim(out_backprop, data_format_, 'N'),         \
+      errors::InvalidArgument(                                                 \
+          label, ": input and out_backprop must have the same batch size"));   \
+  const int64 input_depth = GetTensorDim(input_shape, data_format_, 'D');      \
+  const int64 input_rows = GetTensorDim(input_shape, data_format_, 'H');       \
+  const int64 input_cols = GetTensorDim(input_shape, data_format_, 'W');       \
+  const int64 filter_depth = filter_shape.dim_size(0);                         \
+  const int64 filter_rows = filter_shape.dim_size(1);                          \
+  const int64 filter_cols = filter_shape.dim_size(2);                          \
+  const int64 output_depth = GetTensorDim(out_backprop, data_format_, 'D');    \
+  const int64 output_rows = GetTensorDim(out_backprop, data_format_, 'H');     \
+  const int64 output_cols = GetTensorDim(out_backprop, data_format_, 'W');     \
+  const int64 in_chan = GetTensorDim(input_shape, data_format_, 'C');          \
+  OP_REQUIRES(context, in_chan == filter_shape.dim_size(3),                    \
+              errors::InvalidArgument(                                         \
+                  label, ": input and filter must have the same depth"));      \
+  const int64 out_chan = filter_shape.dim_size(4);                             \
+  OP_REQUIRES(                                                                 \
+      context, out_chan == GetTensorDim(out_backprop, data_format_, 'C'),      \
+      errors::InvalidArgument(                                                 \
+          label, ": filter and out_backprop must have the same out_chan"));    \
+  const auto stride_depth = GetTensorDim(strides_, data_format_, 'D');         \
+  const auto stride_rows = GetTensorDim(strides_, data_format_, 'H');          \
+  const auto stride_cols = GetTensorDim(strides_, data_format_, 'W');          \
+  int out_depth = 0, out_rows = 0, out_cols = 0;                               \
+  int pad_depth = 0, pad_rows = 0, pad_cols = 0;                               \
+                                                                               \
+  OP_REQUIRES_OK(                                                              \
+        context,                                                               \
+        Get3dOutputSize(input_rows, input_cols, input_depth,                   \
+                        filter_rows, filter_cols, filter_depth,                \
+                        stride_rows, stride_cols, stride_depth,                \
+                        padding_, &out_rows, &out_cols, &out_depth,            \
+                        &pad_rows, &pad_cols, &pad_depth) );                   \
+                                                                               \
+  OP_REQUIRES(                                                                 \
+      context, output_rows == out_rows,                                        \
+      errors::InvalidArgument(                                                 \
+          label, ": Number of rows of out_backprop doesn't match computed: ",  \
+          "actual = ", output_rows, ", computed = ", out_rows));               \
+  OP_REQUIRES(                                                                 \
+      context, output_cols == out_cols,                                        \
+      errors::InvalidArgument(                                                 \
+          label, ": Number of cols of out_backprop doesn't match computed: ",  \
+          "actual = ", output_cols, ", computed = ", out_cols));               \
+  OP_REQUIRES(                                                                 \
+      context, output_depth == out_depth,                                      \
+      errors::InvalidArgument(                                                 \
+          label, ": Number of depth of out_backprop doesn't match computed: ", \
+          "actual = ", output_depth, ", computed = ", out_depth));             \
+  const auto expanded_out_depth = (output_depth - 1) * stride_depth + 1;       \
+  const auto expanded_out_rows = (output_rows - 1) * stride_rows + 1;          \
+  const auto expanded_out_cols = (output_cols - 1) * stride_cols + 1;          \
+  const auto padded_out_depth = input_depth + filter_depth - 1;                \
+  const auto padded_out_rows = input_rows + filter_rows - 1;                   \
+  const auto padded_out_cols = input_cols + filter_cols - 1;                   \
+  const int front_pad_depth = filter_depth - 1 - pad_depth;                    \
+  const int top_pad_rows = filter_rows - 1 - pad_rows;                         \
+  const int left_pad_cols = filter_cols - 1 - pad_cols;                        \
+  const int back_pad_depth =                                                   \
+      padded_out_depth - expanded_out_depth - front_pad_depth;                 \
+  const int bottom_pad_rows =                                                  \
+      padded_out_rows - expanded_out_rows - top_pad_rows;                      \
+  const int right_pad_cols =                                                   \
+      padded_out_cols - expanded_out_cols - left_pad_cols;                     \
+  Eigen::DSizes<int, 5> strides{1, stride_depth, stride_rows, stride_cols, 1}; \
+  VLOG(2) << "Conv3d: " << label                                               \
+          << ": expanded_out_depth = " << expanded_out_depth                   \
+          << ": expanded_out_rows = " << expanded_out_rows                     \
+          << ", expanded_out_cols = " << expanded_out_cols                     \
+          << ", filter_depth = " << filter_depth                               \
+          << ", filter_rows = " << filter_rows                                 \
+          << ", filter_cols = " << filter_cols                                 \
+          << ", padded_out_depth = " << padded_out_depth                       \
+          << ", padded_out_rows = " << padded_out_rows                         \
+          << ", padded_out_cols = " << padded_out_cols                         \
+
+namespace {
+
+Status VectorToShape(const TTypes<int32>::ConstVec& sizes, TensorShape* out) {
+  using Index = TTypes<int32>::ConstVec::Index;
+  const Index dims = sizes.size();
+  for (Index i = 0; i < dims; ++i) {
+    if (sizes(i) >= 0) {
+      out->AddDim(sizes(i));
+    } else {
+      return errors::InvalidArgument("Dimension ", sizes(i), " must be >= 0");
+    }
+  }
+
+  return Status::OK();
+}
+}  // namespace
+
+// The fast versions using eigen computations directly. They are only enabled
+// for CPU for now since nvcc times out when trying to compile them.
+// TODO(yangke): enable them for GPUs when we have a faster compiler.
+
+template <typename Device, class T>
+class Conv3DFastBackpropInputOp : public OpKernel {
+ public:
+  explicit Conv3DFastBackpropInputOp(OpKernelConstruction* context)
+      : OpKernel(context) {
+    string data_format;
+    OP_REQUIRES_OK(context, context->GetAttr("data_format", &data_format));
+    OP_REQUIRES(context, FormatFromString(data_format, &data_format_),
+                errors::InvalidArgument("Invalid data format"));
+    OP_REQUIRES(context, data_format_ == FORMAT_NDHWC,
+                errors::InvalidArgument(
+                    "Eigen Conv3DFastBackpropInputOp only supports NDHWC."));
+    OP_REQUIRES_OK(context, context->GetAttr("strides", &strides_));
+    OP_REQUIRES(context, strides_.size() == 5,
+                errors::InvalidArgument("Sliding window strides field must "
+                                        "specify 5 dimensions"));
+    OP_REQUIRES(
+        context, (strides_[0] == 1 && strides_[4] == 1),
+        errors::InvalidArgument("Current implementation does not yet support "
+                                "strides in the batch and depth dimensions."));
+    OP_REQUIRES_OK(context, context->GetAttr("padding", &padding_));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor& input_sizes = context->input(0);
+    const Tensor& filter = context->input(1);
+    OP_REQUIRES(
+        context, TensorShapeUtils::IsVector(input_sizes.shape()),
+        errors::InvalidArgument(
+            "Conv3DBackpropInput: input_sizes input must be 1-dim, not ",
+            input_sizes.dims()));
+    TensorShape input_shape;
+    OP_REQUIRES_OK(context,
+                   VectorToShape(input_sizes.vec<int32>(), &input_shape));
+    const TensorShape& filter_shape = filter.shape();
+
+    EXTRACT_AND_VERIFY_DIMENSIONS_3D("Conv3DBackpropInput");
+    Tensor* in_backprop = nullptr;
+    OP_REQUIRES_OK(context,
+                   context->allocate_output(0, input_shape, &in_backprop));
+    functor::CuboidConvolutionBackwardInput<Device, T>()(
+        context->eigen_device<Device>(), in_backprop->tensor<T, 5>(),
+        filter.tensor<T, 5>(), out_backprop.tensor<T, 5>(),
+        input_depth, input_rows, input_cols,
+        stride_depth, stride_rows, stride_cols);
+  }
+
+ private:
+  std::vector<int32> strides_;
+  Padding padding_;
+  TensorFormat data_format_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(Conv3DFastBackpropInputOp);
+};
+
+REGISTER_KERNEL_BUILDER(Name("Conv3DBackpropInput")
+                            .Device(DEVICE_CPU)
+                            // .Label("eigen_tensor")
+                            .TypeConstraint<float>("T"),
+                        Conv3DFastBackpropInputOp<CPUDevice, float>);
+
+template <typename Device, class T>
+class Conv3DFastBackpropFilterOp : public OpKernel {
+ public:
+  explicit Conv3DFastBackpropFilterOp(OpKernelConstruction* context)
+      : OpKernel(context) {
+    string data_format;
+    OP_REQUIRES_OK(context, context->GetAttr("data_format", &data_format));
+    OP_REQUIRES(context, FormatFromString(data_format, &data_format_),
+                errors::InvalidArgument("Invalid data format"));
+    OP_REQUIRES(context, data_format_ == FORMAT_NDHWC,
+                errors::InvalidArgument(
+                    "Conv3DFastBackpropFilterOp only supports NHDWC."));
+    OP_REQUIRES_OK(context, context->GetAttr("strides", &strides_));
+    OP_REQUIRES(context, strides_.size() == 5,
+                errors::InvalidArgument("Sliding window strides field must "
+                                        "specify 5 dimensions"));
+    OP_REQUIRES(
+        context, (strides_[0] == 1 && strides_[4] == 1),
+        errors::InvalidArgument("Current implementation does not yet support "
+                                "strides in the batch and depth dimensions."));
+    OP_REQUIRES_OK(context, context->GetAttr("padding", &padding_));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor& input = context->input(0);
+    const Tensor& filter_sizes = context->input(1);
+    OP_REQUIRES(
+        context, TensorShapeUtils::IsVector(filter_sizes.shape()),
+        errors::InvalidArgument(
+            "Conv2DBackpropFilter: filter_sizes input must be 1-dim, not ",
+            filter_sizes.dims()));
+    const TensorShape& input_shape = input.shape();
+    TensorShape filter_shape;
+    OP_REQUIRES_OK(context,
+                   VectorToShape(filter_sizes.vec<int32>(), &filter_shape));
+
+    EXTRACT_AND_VERIFY_DIMENSIONS_3D("Conv3DBackpropFilter");
+    Tensor* filter_backprop = nullptr;
+    OP_REQUIRES_OK(context,
+                   context->allocate_output(0, filter_shape, &filter_backprop));
+
+    functor::CuboidConvolutionBackwardKernel<Device, T>()(
+        context->eigen_device<Device>(), filter_backprop->tensor<T, 5>(),
+        input.tensor<T, 5>(), out_backprop.tensor<T, 5>(),
+        filter_depth, filter_rows, filter_cols,
+        stride_depth, stride_rows, stride_cols);
+  }
+
+ private:
+  std::vector<int32> strides_;
+  Padding padding_;
+  TensorFormat data_format_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(Conv3DFastBackpropFilterOp);
+};
+
+REGISTER_KERNEL_BUILDER(Name("Conv3DBackpropFilter")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<float>("T"),
+                        Conv3DFastBackpropFilterOp<CPUDevice, float>);
+
+// // GPU definitions of both ops are not implemented yet.
+#if GOOGLE_CUDA
+// // TODO: Implement a version that compiles for GPU.
+#endif  // GOOGLE_CUDA
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/conv3d_ops.cc
+++ b/tensorflow/core/kernels/conv3d_ops.cc
@@ -1,0 +1,246 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/nn_ops.cc.
+
+#define USE_EIGEN_TENSOR
+#define EIGEN_USE_THREADS
+
+#include <vector>
+#include "tensorflow/core/framework/numeric_op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_slice.h"
+#include "tensorflow/core/kernels/bounds_check.h"
+#include "tensorflow/core/kernels/conv_3d.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/gtl/array_slice.h"
+#include "tensorflow/core/lib/strings/numbers.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/util/padding.h"
+#include "tensorflow/core/util/tensor_format.h"
+#include "tensorflow/core/util/use_cudnn.h"
+
+#if GOOGLE_CUDA
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/platform/stream_executor.h"
+#endif  // GOOGLE_CUDA
+
+
+namespace tensorflow {
+
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+typedef Eigen::GpuDevice GPUDevice;
+
+
+template <typename Device, typename T>
+struct LaunchGeneric3D {
+  static void launch(OpKernelContext* ctx, const Tensor& input,
+                     const Tensor& filter, int depth_stride, int row_stride,
+                     int col_stride, const Eigen::PaddingType& padding,
+                     Tensor* output, TensorFormat data_format) {
+    CHECK(data_format == FORMAT_NDHWC) << "Generic 3d conv implementation only "
+                                         "supports NDHWC tensor format.";
+
+    functor::CuboidConvolution<Device, T>()(
+        ctx->eigen_device<Device>(), output->tensor<T, 5>(),
+        input.tensor<T, 5>(), filter.tensor<T, 5>(), depth_stride,
+        row_stride, col_stride, padding);
+  }
+};
+
+template <typename Device, typename T>
+struct LaunchConv3DOp;
+
+template <typename T>
+struct LaunchConv3DOp<CPUDevice, T> {
+  static void launch(OpKernelContext* ctx, bool use_cudnn, const Tensor& input,
+                     const Tensor& filter, int depth_stride, int row_stride,
+                     int col_stride, const Eigen::PaddingType& padding,
+                     Tensor* output, TensorFormat data_format) {
+    LaunchGeneric3D<CPUDevice, T>::launch(ctx, input, filter, depth_stride,
+                                        row_stride, col_stride, padding,
+                                        output, data_format);
+  }
+};
+
+
+template <typename Device, typename T>
+class Conv3DOp : public BinaryOp<T> {
+ public:
+  explicit Conv3DOp(OpKernelConstruction* context) : BinaryOp<T>(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("strides", &strides_));
+    string data_format;
+    OP_REQUIRES_OK(context, context->GetAttr("data_format", &data_format));
+    OP_REQUIRES(context, FormatFromString(data_format, &data_format_),
+                errors::InvalidArgument("Invalid data format"));
+    OP_REQUIRES_OK(context, context->GetAttr("use_cudnn_on_gpu", &use_cudnn_));
+    use_cudnn_ &= CanUseCudnn();
+    OP_REQUIRES(context, strides_.size() == 5,
+                errors::InvalidArgument("Sliding window strides field must "
+                                        "specify 5 dimensions"));
+    const int64 stride_n = GetTensorDim(strides_, data_format_, 'N');
+    const int64 stride_c = GetTensorDim(strides_, data_format_, 'C');
+    OP_REQUIRES(
+        context, stride_n == 1 && stride_c == 1,
+        errors::InvalidArgument("Current implementation does not yet support "
+                                "strides in the batch and depth dimensions."));
+    OP_REQUIRES_OK(context, context->GetAttr("padding", &padding_));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    // Input tensor is of the following dimensions:
+    // [ batch, D, H, W, in_chan ]
+    const Tensor& input = context->input(0);
+    // Input filter is of the following dimensions:
+    // [ D, H, W, in_chan, out_chan]
+    const Tensor& filter = context->input(1);
+
+    // For 3D convolution, there should be 5 dimensions.
+    OP_REQUIRES(context, input.dims() == 5,
+                errors::InvalidArgument("Input must be 5-dimensional",
+                                        input.shape().DebugString()));
+    OP_REQUIRES(context, filter.dims() == 5,
+                errors::InvalidArgument("Filter must be 5-dimensional: ",
+                                        filter.shape().DebugString()));
+
+    for (int i = 0; i < 4; i++) {
+      OP_REQUIRES(context, FastBoundsCheck(filter.dim_size(i),
+                                           std::numeric_limits<int>::max()),
+                  errors::InvalidArgument("filter too large"));
+    }
+
+    // The last dimension for input is in_chan. It must be the same as the
+    // filter's in_chan.
+    const int64 in_chan = GetTensorDim(input, data_format_, 'C');
+    OP_REQUIRES(
+        context, in_chan == filter.dim_size(3),
+        errors::InvalidArgument("input and filter must have the same in_chan: ",
+                                in_chan, " vs ", filter.dim_size(3)));
+
+    // The last dimension for filter is out_chan.
+    const int out_chan = static_cast<int>(filter.dim_size(4));
+
+    // The second dimension for input is depth.
+    // The first dimension for filter is depth.
+    const int64 input_depth_raw = GetTensorDim(input, data_format_, 'D');
+    OP_REQUIRES(context, FastBoundsCheck(input_depth_raw,
+                                         std::numeric_limits<int>::max()),
+                errors::InvalidArgument("Input depth too large"));
+    const int input_depth = static_cast<int>(input_depth_raw);
+    const int filter_depth = static_cast<int>(filter.dim_size(0));
+
+    // The third dimension for input is rows/height.
+    // The second dimension for filter is rows/height.
+    const int64 input_rows_raw = GetTensorDim(input, data_format_, 'H');
+    OP_REQUIRES(context, FastBoundsCheck(input_rows_raw,
+                                         std::numeric_limits<int>::max()),
+                errors::InvalidArgument("Input rows too large"));
+    const int input_rows = static_cast<int>(input_rows_raw);
+    const int filter_rows = static_cast<int>(filter.dim_size(1));
+
+    // The fourth dimension for input is columns/width.
+    // The third dimension for filter is columns/width.
+    const int64 input_cols_raw = GetTensorDim(input, data_format_, 'W');
+    OP_REQUIRES(context, FastBoundsCheck(input_cols_raw,
+                                         std::numeric_limits<int>::max()),
+                errors::InvalidArgument("Input cols too large"));
+    const int input_cols = static_cast<int>(input_cols_raw);
+    const int filter_cols = static_cast<int>(filter.dim_size(2));
+
+
+    // The first dimension for input is batch.
+    const int64 batch_raw = GetTensorDim(input, data_format_, 'N');
+    OP_REQUIRES(context,
+                FastBoundsCheck(batch_raw, std::numeric_limits<int>::max()),
+                errors::InvalidArgument("batch is too large"));
+    const int batch = static_cast<int>(batch_raw);
+
+    // For now we take the stride from the second, third, fourth dimensions only
+    // (we do not support striding on the batch or depth dimension).
+    const int stride_depth = GetTensorDim(strides_, data_format_, 'D');
+    const int stride_rows = GetTensorDim(strides_, data_format_, 'H');
+    const int stride_cols = GetTensorDim(strides_, data_format_, 'W');
+
+    int out_rows = 0, out_cols = 0, out_depth = 0;
+    int pad_rows = 0, pad_cols = 0, pad_depth = 0;
+
+
+    OP_REQUIRES_OK(
+        context,
+        Get3dOutputSize(input_rows, input_cols, input_depth,
+                        filter_rows, filter_cols, filter_depth,
+                        stride_rows, stride_cols, stride_depth,
+                        padding_, &out_rows, &out_cols, &out_depth,
+                        &pad_rows, &pad_cols, &pad_depth));
+
+    TensorShape out_shape =
+        ShapeFromFormat3D(data_format_, batch, out_rows, out_cols,
+                        out_depth, out_chan);
+
+    // Output tensor is of the following dimensions:
+    // [ in_batch, out_depth, out_rows, out_cols, out_chan ]
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, out_shape, &output));
+
+    VLOG(2) << "Conv3D: in_chan = " << in_chan
+            << ", input_cols = " << input_cols
+            << ", filter_cols = " << filter_cols
+            << ", input_rows = " << input_rows
+            << ", filter_rows = " << filter_rows
+            << ", input_depth = " << input_depth
+            << ", filter_depth = " << filter_depth
+            << ", stride_rows = " << stride_rows
+            << ", stride_cols = " << stride_cols
+            << ", stride_depth = " << stride_depth
+            << ", out_chan = " << out_chan;
+
+    // If there is nothing to compute, return.
+    if (out_shape.num_elements() == 0) {
+      return;
+    }
+    LaunchConv3DOp<Device, T>::launch(
+        context, use_cudnn_, input, filter, stride_depth, stride_rows,
+        stride_cols, BrainPadding2EigenPadding(padding_),
+        output, data_format_);
+  }
+
+ private:
+  std::vector<int32> strides_;
+  bool use_cudnn_;
+  Padding padding_;
+  TensorFormat data_format_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(Conv3DOp);
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("Conv3D").Device(DEVICE_CPU).TypeConstraint<float>("T"),
+    Conv3DOp<CPUDevice, float>);
+
+
+
+
+// #if GOOGLE_CUDA
+
+// GPU version remains to be implemented.
+
+// #endif  // GOOGLE_CUDA
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/conv3d_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/conv3d_ops_gpu.cu.cc
@@ -1,0 +1,20 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// #if GOOGLE_CUDA
+
+// GPU Version of conv3d op not yet implemented.
+
+// #endif  // GOOGLE_CUDA

--- a/tensorflow/core/kernels/conv3d_ops_gpu.h
+++ b/tensorflow/core/kernels/conv3d_ops_gpu.h
@@ -1,0 +1,25 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_CONV_3D_OPS_GPU_H_
+#define TENSORFLOW_CORE_KERNELS_CONV_3D_OPS_GPU_H_
+
+// #if GOOGLE_CUDA
+
+// GPU version of conv3d not yet implemented.
+
+// #endif  // GOOGLE_CUDA
+
+#endif  // TENSORFLOW_CORE_KERNELS_CONV_3D_OPS_GPU_H_

--- a/tensorflow/core/kernels/conv_3d.h
+++ b/tensorflow/core/kernels/conv_3d.h
@@ -1,0 +1,86 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_KERNELS_CONV_3D_H_
+#define TENSORFLOW_KERNELS_CONV_3D_H_
+
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/kernels/eigen_cuboid_convolution.h"
+#include "tensorflow/core/kernels/eigen_backward_cuboid_convolutions.h"
+#include "tensorflow/core/util/tensor_format.h"
+
+namespace tensorflow {
+namespace functor {
+
+
+template <typename Device, typename Input, typename Filter, typename Output>
+void CuboidConvolutionFunc(const Device& d, Output output, Input input,
+                            Filter filter, int depth_stride, int row_stride,
+                            int col_stride, const Eigen::PaddingType& padding) {
+  // Need to shuffle DHW -> WHD for eigen
+  output.device(d) =
+      Eigen::CuboidConvolution(input, filter, col_stride, row_stride,
+                               depth_stride, padding);
+};
+
+template <typename Device, typename T>
+struct CuboidConvolution {
+  void operator()(const Device& d, typename TTypes<T, 5>::Tensor output,
+                  typename TTypes<T, 5>::ConstTensor input,
+                  typename TTypes<T, 5>::ConstTensor filter, int depth_stride,
+                  int row_stride, int col_stride,
+                  const Eigen::PaddingType& padding) {
+    CuboidConvolutionFunc(d, output, input, filter, depth_stride, row_stride,
+                          col_stride, padding);
+  }
+};
+
+template <typename Device, typename T>
+struct CuboidConvolutionBackwardInput {
+  void operator()(const Device& d, typename TTypes<T, 5>::Tensor input_backward,
+                  typename TTypes<T, 5>::ConstTensor kernel,
+                  typename TTypes<T, 5>::ConstTensor output_backward,
+                  int input_depth, int input_rows, int input_cols,
+                  int depth_stride, int row_stride, int col_stride) {
+    // Need to shuffle DHW -> WHD for eigen
+    input_backward.device(d) = Eigen::CuboidConvolutionBackwardInput(
+        kernel, output_backward,
+        input_cols, input_rows, input_depth,
+        col_stride, row_stride, depth_stride);
+  }
+};
+
+template <typename Device, typename T>
+struct CuboidConvolutionBackwardKernel {
+  void operator()(const Device& d,
+                  typename TTypes<T, 5>::Tensor kernel_backward,
+                  typename TTypes<T, 5>::ConstTensor input,
+                  typename TTypes<T, 5>::ConstTensor output_backward,
+                  int kernel_depth, int kernel_rows, int kernel_cols,
+                  int depth_stride, int row_stride, int col_stride) {
+    // Need to shuffle DHW -> WHD for eigen
+    kernel_backward.device(d) = Eigen::CuboidConvolutionBackwardKernel(
+        input, output_backward,
+        kernel_cols, kernel_rows, kernel_depth,
+        col_stride, row_stride, depth_stride);
+  }
+};
+
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_KERNELS_CONV_3D_H_

--- a/tensorflow/core/kernels/ops_util.h
+++ b/tensorflow/core/kernels/ops_util.h
@@ -89,6 +89,25 @@ Status Get2dOutputSizeVerbose(const int in_height, const int in_width,
                               int* new_height, int* new_width, int* pad_top,
                               int* pad_bottom, int* pad_left, int* pad_right);
 
+
+Status Get3dOutputSize(const int in_height, const int in_width,
+                       const int in_depth, int filter_height,
+                       int filter_width, int filter_depth,
+                       int row_stride, int col_stride, int depth_stride,
+                       Padding padding, int* new_height, int* new_width,
+                       int* new_depth, int* pad_rows, int* pad_cols,
+                       int* pad_depth);
+
+Status Get3dOutputSizeVerbose(const int in_height, const int in_width,
+                              const int in_depth, int filter_height,
+                              int filter_width, int filter_depth,
+                              int row_stride, int col_stride, int depth_stride,
+                              Padding padding, int* new_height, int* new_width,
+                              int* new_depth, int* pad_top, int* pad_bottom,
+                              int* pad_left, int* pad_right, int* pad_front,
+                              int* pad_back);
+
+
 // Calculates broadcast starting index and size.  For SAME padding, addition
 // padding could be applied to right, left, top and bottom.  Depending on the
 // current index, input size, kernel size, stride, padding size, the starting

--- a/tensorflow/core/ops/nn_grad.cc
+++ b/tensorflow/core/ops/nn_grad.cc
@@ -132,6 +132,43 @@ Status Conv2DGrad(const AttrSlice& attrs, FunctionDef* g) {
 }
 REGISTER_OP_GRADIENT("Conv2D", Conv2DGrad);
 
+
+Status Conv3DGrad(const AttrSlice& attrs, FunctionDef* g) {
+  // clang-format off
+  *g = FDH::Define(
+    // Arg defs
+    {"input: T", "filter: T", "grad: T"},
+    // Ret val defs
+    {"input_grad: T", "filter_grad: T"},
+    // Attr defs
+    {"T: {float, double}",
+     "strides: list(int)",
+     "use_cudnn_on_gpu: bool = true",
+     GetPaddingAttrString(),
+     GetConv3DDataFormatAttrString()},
+    // Nodes
+    {
+      {{"i_shape"}, "Shape", {"input"}, {{"T", "$T"}}},
+      {{"input_grad"}, "Conv3DBackpropInput", {"i_shape", "filter", "grad"},
+       /*Attrs=*/{{"T", "$T"},
+                  {"strides", "$strides"},
+                  {"padding", "$padding"},
+                  {"data_format", "$data_format"},
+                  {"use_cudnn_on_gpu", "$use_cudnn_on_gpu"}}},
+
+      {{"f_shape"}, "Shape", {"filter"}, {{"T", "$T"}}},
+      {{"filter_grad"}, "Conv3DBackpropFilter", {"input", "f_shape", "grad"},
+       /*Attrs=*/{{"T", "$T"},
+                  {"strides", "$strides"},
+                  {"padding", "$padding"},
+                  {"data_format", "$data_format"},
+                  {"use_cudnn_on_gpu", "$use_cudnn_on_gpu"}}},
+    });
+  // clang-format on
+  return Status::OK();
+}
+REGISTER_OP_GRADIENT("Conv3D", Conv3DGrad);
+
 Status MaxPoolGrad(const AttrSlice& attrs, FunctionDef* g) {
   // clang-format off
   *g = FDH::Define(

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -331,6 +331,91 @@ data_format: Specify the data format of the input and output data. With the
     Alternatively, the format could be "NCHW", the data storage order of:
         [batch, in_channels, in_height, in_width].
 )doc");
+// --------------------------------------------------------------------------
+
+REGISTER_OP("Conv3D")
+    .Input("input: T")
+    .Input("filter: T")
+    .Output("output: T")
+    .Attr("T: {float, double}")
+    .Attr("strides: list(int)")
+    .Attr("use_cudnn_on_gpu: bool = true")
+    .Attr(GetPaddingAttrString())
+    .Attr(GetConv3DDataFormatAttrString())
+    .Doc(R"doc(
+Computes a 3-D convolution given 5-D `input` and `filter` tensors.
+
+Input: 5-D with shape`[num_batches, depth, height, width, channels]`.
+Filter: 5-D with shape `[filter_depth, filter_height, filter_width, in_channels, out_channels]`.
+
+strides: 1-D of length 5.  The stride of the sliding window for each dimension
+  of `input`. Must be in the same order as the dimension specified with format.
+padding: The type of padding algorithm to use, "SAME" or "VALID"
+data_format: Specify the data format of the input and output data. This only supports
+    "NDHWC" for 5-D convolutions currently.
+
+)doc");
+
+REGISTER_OP("Conv3DBackpropInput")
+    .Input("input_sizes: int32")
+    .Input("filter: T")
+    .Input("out_backprop: T")
+    .Output("output: T")
+    .Attr("T: {float, double}")
+    .Attr("strides: list(int)")
+    .Attr("use_cudnn_on_gpu: bool = true")
+    .Attr(GetPaddingAttrString())
+    .Attr(GetConv3DDataFormatAttrString())
+    .Doc(R"doc(
+Computes the gradients of a 3D convolution with respect to the input.
+
+input_sizes: An integer vector representing the shape of `input`,
+  where `input` is a 5-D `[batch, depth, height, width, channels]` tensor.
+filter: 5-D with shape
+  `[filter_depth, filter_height, filter_width, in_channels, out_channels]`.
+out_backprop: 5-D with shape `[batch, out_depth, out_height, out_width, out_channels]`.
+  Gradients w.r.t. the output of the convolution.
+strides: The stride of the sliding window for each dimension of the input
+  of the convolution. Must be in the same order as the dimension specified with
+  format.
+padding: The type of padding algorithm to use.
+output: 4-D with shape `[batch, in_depth, in_height, in_width, in_channels]`.  Gradient
+  w.r.t. the input of the convolution.
+data_format: Specify the data format of the input and output data. This only supports
+    "NDHWC" for 5-D convolutions currently.
+
+)doc");
+
+REGISTER_OP("Conv3DBackpropFilter")
+    .Input("input: T")
+    .Input("filter_sizes: int32")
+    .Input("out_backprop: T")
+    .Output("output: T")
+    .Attr("T: {float, double}")
+    .Attr("strides: list(int)")
+    .Attr("use_cudnn_on_gpu: bool = true")
+    .Attr(GetPaddingAttrString())
+    .Attr(GetConv3DDataFormatAttrString())
+    .Doc(R"doc(
+Computes the gradients of a 3D convolution with respect to the filter.
+
+input: 5-D with shape `[batch, in_depth, in_height, in_width, in_channels]`.
+filter_sizes: An integer vector representing the tensor shape of `filter`,
+  where `filter` is a 5-D
+  `[filter_depth, filter_height, filter_width, in_channels, out_channels]` tensor.
+out_backprop: 5-D with shape `[batch, out_depth, out_height, out_width, out_channels]`.
+  Gradients w.r.t. the output of the convolution.
+strides: The stride of the sliding window for each dimension of the input
+  of the convolution. Must be in the same order as the dimension specified with
+  format.
+padding: The type of padding algorithm to use.
+output: 5-D with shape
+  `[filter_depth, filter_height, filter_width, in_channels, out_channels]`.  Gradient w.r.t.
+  the `filter` input of the convolution.
+data_format: Specify the data format of the input and output data. This only supports
+    "NDHWC" for 5-D convolutions currently.
+
+)doc");
 
 // --------------------------------------------------------------------------
 

--- a/tensorflow/core/ops/ops.pbtxt
+++ b/tensorflow/core/ops/ops.pbtxt
@@ -2757,6 +2757,210 @@ op {
   summary: "Computes the gradients of convolution with respect to the input."
 }
 op {
+  name: "Conv3D"
+  input_arg {
+    name: "input"
+    type_attr: "T"
+  }
+  input_arg {
+    name: "filter"
+    type_attr: "T"
+  }
+  output_arg {
+    name: "output"
+    type_attr: "T"
+  }
+  attr {
+    name: "T"
+    type: "type"
+    allowed_values {
+      list {
+        type: DT_FLOAT
+        type: DT_DOUBLE
+      }
+    }
+  }
+  attr {
+    name: "strides"
+    type: "list(int)"
+    description: "1-D of length 5.  The stride of the sliding window for each dimension\nof `input`. Must be in the same order as the dimension specified with format."
+  }
+  attr {
+    name: "use_cudnn_on_gpu"
+    type: "bool"
+    default_value {
+      b: true
+    }
+  }
+  attr {
+    name: "padding"
+    type: "string"
+    description: "The type of padding algorithm to use."
+    allowed_values {
+      list {
+        s: "SAME"
+        s: "VALID"
+      }
+    }
+  }
+  attr {
+    name: "data_format"
+    type: "string"
+    default_value {
+      s: "NDHWC"
+    }
+    description: "Specify the data format of the input and output data. With the\ndefault format \"NDHWC\", the data is stored in the order of:\n    [batch, in_depth, in_height, in_width, in_channels].\n"
+    allowed_values {
+      list {
+        s: "NDHWC"
+      }
+    }
+  }
+  summary: "Computes a 3-D convolution given 5-D `input` and `filter` tensors."
+  description: "Given an input tensor of shape `[batch, in_depth, in_height, in_width, in_channels]`\nand a filter / kernel tensor of shape\n`[filter_depth, filter_height, filter_width, in_channels, out_channels]`, this op\nperforms a 3d convolution."
+}
+op {
+  name: "Conv3DBackpropFilter"
+  input_arg {
+    name: "input"
+    description: "5-D with shape `[batch, in_depth, in_height, in_width, in_channels]`."
+    type_attr: "T"
+  }
+  input_arg {
+    name: "filter_sizes"
+    description: "An integer vector representing the tensor shape of `filter`,\nwhere `filter` is a 5-D\n`[filter_depth, filter_height, filter_width, in_channels, out_channels]` tensor."
+    type: DT_INT32
+  }
+  input_arg {
+    name: "out_backprop"
+    description: "5-D with shape `[batch, out_depth, out_height, out_width, out_channels]`.\nGradients w.r.t. the output of the convolution."
+    type_attr: "T"
+  }
+  output_arg {
+    name: "output"
+    description: "5-D with shape\n`[filter_depth, filter_height, filter_width, in_channels, out_channels]`.  Gradient w.r.t.\nthe `filter` input of the convolution."
+    type_attr: "T"
+  }
+  attr {
+    name: "T"
+    type: "type"
+    allowed_values {
+      list {
+        type: DT_FLOAT
+        type: DT_DOUBLE
+      }
+    }
+  }
+  attr {
+    name: "strides"
+    type: "list(int)"
+    description: "The stride of the sliding window for each dimension of the input\nof the convolution. Must be in the same order as the dimension specified with\nformat."
+  }
+  attr {
+    name: "use_cudnn_on_gpu"
+    type: "bool"
+    default_value {
+      b: true
+    }
+  }
+  attr {
+    name: "padding"
+    type: "string"
+    description: "The type of padding algorithm to use."
+    allowed_values {
+      list {
+        s: "SAME"
+        s: "VALID"
+      }
+    }
+  }
+  attr {
+    name: "data_format"
+    type: "string"
+    default_value {
+      s: "NDHWC"
+    }
+    description: "Specify the data format of the input and output data."
+    allowed_values {
+      list {
+        s: "NDHWC"
+      }
+    }
+  }
+  summary: "Computes the gradients of convolution with respect to the filter."
+}
+op {
+  name: "Conv3DBackpropInput"
+  input_arg {
+    name: "input_sizes"
+    description: "An integer vector representing the shape of `input`,\nwhere `input` is a 5-D `[batch, depth, height, width, channels]` tensor."
+    type: DT_INT32
+  }
+  input_arg {
+    name: "filter"
+    description: "5-D with shape\n`[filter_depth, filter_height, filter_width, in_channels, out_channels]`."
+    type_attr: "T"
+  }
+  input_arg {
+    name: "out_backprop"
+    description: "5-D with shape `[batch, out_depth, out_height, out_width, out_channels]`.\nGradients w.r.t. the output of the convolution."
+    type_attr: "T"
+  }
+  output_arg {
+    name: "output"
+    description: "5-D with shape `[batch, in_depth, in_height, in_width, in_channels]`.  Gradient\nw.r.t. the input of the convolution."
+    type_attr: "T"
+  }
+  attr {
+    name: "T"
+    type: "type"
+    allowed_values {
+      list {
+        type: DT_FLOAT
+        type: DT_DOUBLE
+      }
+    }
+  }
+  attr {
+    name: "strides"
+    type: "list(int)"
+    description: "The stride of the sliding window for each dimension of the input\nof the convolution. Must be in the same order as the dimension specified with\nformat."
+  }
+  attr {
+    name: "use_cudnn_on_gpu"
+    type: "bool"
+    default_value {
+      b: true
+    }
+  }
+  attr {
+    name: "padding"
+    type: "string"
+    description: "The type of padding algorithm to use."
+    allowed_values {
+      list {
+        s: "SAME"
+        s: "VALID"
+      }
+    }
+  }
+  attr {
+    name: "data_format"
+    type: "string"
+    default_value {
+      s: "NDHWC"
+    }
+    description: "Specify the data format of the input and output data."
+    allowed_values {
+      list {
+        s: "NDHWC"
+      }
+    }
+  }
+  summary: "Computes the gradients of convolution with respect to the input."
+}
+
+op {
   name: "Cos"
   input_arg {
     name: "x"

--- a/tensorflow/core/util/tensor_format.cc
+++ b/tensorflow/core/util/tensor_format.cc
@@ -21,6 +21,10 @@ string GetConvnetDataFormatAttrString() {
   return "data_format: { 'NHWC', 'NCHW' } = 'NHWC' ";
 }
 
+string GetConv3DDataFormatAttrString() {
+  return "data_format: { 'NDHWC' } = 'NDHWC' ";
+}
+
 string ToString(TensorFormat format) {
   switch (format) {
     case FORMAT_NHWC:
@@ -39,6 +43,9 @@ bool FormatFromString(const string& format_str, TensorFormat* format) {
     return true;
   } else if (format_str == "NCHW") {
     *format = FORMAT_NCHW;
+    return true;
+  } else if (format_str == "NDHWC") {
+    *format = FORMAT_NDHWC;
     return true;
   }
   return false;

--- a/tensorflow/python/kernel_tests/conv3d_ops_test.py
+++ b/tensorflow/python/kernel_tests/conv3d_ops_test.py
@@ -1,0 +1,676 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Functional tests for 3d convolutional operations."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+from tensorflow.python.framework import test_util
+
+
+def GetTestConfigs():
+    """Get all the valid tests configs to run.
+
+    Returns:
+    all the valid test configs as tuples of data_format and use_gpu.
+    """
+    test_configs = [("NDHWC", False)]
+    # TODO: Implement GPU version
+    # if test_util.IsGoogleCudaEnabled():
+    #     test_configs += [("NDHWC", True)]
+    return test_configs
+
+
+class Conv3DTest(tf.test.TestCase):
+
+    def _SetupValuesForDevice(self, tensor_in_sizes, filter_in_sizes, strides,
+                              padding, data_format, use_gpu):
+        """Verifies the output values of the convolution function.
+
+        Args:
+          tensor_in_sizes: Input tensor dimensions in
+            [batch, input_depth, input_height, input_width, input_channels].
+          filter_in_sizes: Filter tensor dimensions in
+                [kernel_depth, kernel_width, kernel_height,
+                in_channels, out_channels].
+          strides: Stride: [depth_stride, height_stride, width_stride].
+            (Batch and channel strides are not supported at the moment)
+          padding: Padding type.
+          data_format: Format of the data tensors.
+          use_gpu: True if the operations should be run on GPU
+        Returns:
+          Symbolic tensor value that can be used to execute the computation
+        """
+        total_size_1 = 1
+        total_size_2 = 1
+        for s in tensor_in_sizes:
+            total_size_1 *= s
+        for s in filter_in_sizes:
+            total_size_2 *= s
+        # Initializes the input tensor with array containing incrementing
+        # numbers from 1.
+        x1 = [f * 1.0 for f in range(1, total_size_1 + 1)]
+        x2 = [f * 1.0 for f in range(1, total_size_2 + 1)]
+        with self.test_session(use_gpu=use_gpu):
+            t1 = tf.constant(x1, shape=tensor_in_sizes)
+            t2 = tf.constant(x2, shape=filter_in_sizes)
+            strides = [1] + strides + [1]
+            conv = tf.nn.conv3d(t1, t2, strides=strides,
+                                padding=padding,
+                                data_format=data_format)
+            return conv
+
+    def _VerifyValues(self, tensor_in_sizes, filter_in_sizes,
+                      strides, padding, expected):
+        tensors = []
+        for (data_format, use_gpu) in GetTestConfigs():
+            result = self._SetupValuesForDevice(
+                tensor_in_sizes, filter_in_sizes, strides,
+                padding, data_format, use_gpu=use_gpu)
+            tensors.append(result)
+        with self.test_session() as sess:
+            values = sess.run(tensors)
+            for i in range(len(tensors)):
+                conv = tensors[i]
+                value = values[i]
+                flat_value = np.ravel(value)
+                print("expected = ", expected)
+                print("actual = ", flat_value)
+                self.assertArrayNear(expected, flat_value, 1e-5)
+                self.assertShapeEqual(value, conv)
+
+    def testConv3D1x1Filter(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [1, 2, 2, 4, 3, 6, 4, 8, 5, 10, 6, 12,
+                           7, 14, 8, 16, 9, 18, 10, 20, 11, 22,
+                           12, 24, 13, 26, 14, 28, 15, 30, 16, 32]
+        self._VerifyValues(tensor_in_sizes=[2, 2, 2, 2, 1],
+                           filter_in_sizes=[1, 1, 1, 1, 2],
+                           strides=[1, 1, 1], padding="VALID",
+                           expected=expected_output)
+
+    def testConv3DEmpty(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = []
+        self._VerifyValues(tensor_in_sizes=[0, 2, 2, 3, 3],
+                           filter_in_sizes=[1, 1, 1, 3, 3],
+                           strides=[1, 1, 1], padding="VALID",
+                           expected=expected_output)
+
+    def testConv3D2x2Filter(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [540, 576, 612]
+        self._VerifyValues(tensor_in_sizes=[1, 2, 2, 2, 1],
+                           filter_in_sizes=[2, 2, 2, 1, 3],
+                           strides=[1, 1, 1], padding="VALID",
+                           expected=expected_output)
+
+    def testConv3D1x2x3FilterA(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [
+            2748, 2862, 2976, 3168, 3306, 3444, 3588, 3750,
+            3912, 4008, 4194, 4380, 5268, 5526, 5784, 5688,
+            5970, 6252, 6108, 6414, 6720, 6528, 6858, 7188,
+            7788, 8190, 8592, 8208, 8634, 9060, 8628, 9078,
+            9528, 9048, 9522, 9996, 12828, 13518, 14208, 13248,
+            13962, 14676, 13668, 14406, 15144, 14088, 14850, 15612,
+            15348, 16182, 17016, 15768, 16626, 17484, 16188, 17070,
+            17952, 16608, 17514, 18420, 17868, 18846, 19824, 18288,
+            19290, 20292, 18708, 19734, 20760, 19128, 20178, 21228]
+        self._VerifyValues(tensor_in_sizes=[1, 2, 4, 6, 2],
+                           filter_in_sizes=[1, 2, 3, 2, 3],
+                           strides=[1, 1, 1], padding="VALID",
+                           expected=expected_output)
+
+    def testConv3D1x2x3FilterB(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [
+            161, 182, 269, 308, 485, 560, 593, 686, 809, 938,
+            917, 1064]
+        self._VerifyValues(tensor_in_sizes=[1, 3, 3, 3, 1],
+                           filter_in_sizes=[1, 2, 3, 1, 2],
+                           strides=[1, 1, 1], padding="VALID",
+                           expected=expected_output)
+
+    def testConv3D2x2FilterStride2(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [
+            2184, 2316, 2448, 2368, 2516, 2664, 3104,
+            3316, 3528, 3288, 3516, 3744, 6784, 7316,
+            7848, 6968, 7516, 8064, 7704, 8316, 8928,
+            7888, 8516, 9144]
+        self._VerifyValues(tensor_in_sizes=[1, 5, 5, 5, 1],
+                           filter_in_sizes=[2, 2, 2, 1, 3],
+                           strides=[2, 2, 2], padding="VALID",
+                           expected=expected_output)
+
+    def testConv3D2x2FilterStride1x2x1(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [652, 712, 716, 784, 1228, 1360, 1292, 1432]
+        self._VerifyValues(tensor_in_sizes=[1, 3, 3, 3, 1],
+                           filter_in_sizes=[2, 2, 2, 1, 2],
+                           strides=[1, 2, 1], padding="VALID",
+                           expected=expected_output)
+
+    def testConv3D2x2FilterStride2x1x1(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [652, 712, 716, 784, 844, 928, 908, 1000]
+        self._VerifyValues(tensor_in_sizes=[1, 3, 3, 3, 1],
+                           filter_in_sizes=[2, 2, 2, 1, 2],
+                           strides=[2, 1, 1], padding="VALID",
+                           expected=expected_output)
+
+    def testConv3D2x2FilterStride2Same(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [560, 632, 848, 920, 1712, 1784, 2000, 2072]
+        self._VerifyValues(tensor_in_sizes=[1, 4, 4, 4, 1],
+                           filter_in_sizes=[2, 2, 2, 1, 1],
+                           strides=[2, 2, 2], padding="SAME",
+                           expected=expected_output)
+
+    def testConv3D3x3x3FilterSame(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [
+            1412, 2198, 1508, 2370, 3648, 2478,
+            1652, 2522, 1700, 2982, 4512, 3018, 4608,
+            6930, 4608, 3018, 4512, 2982, 1700, 2522,
+            1652, 2478, 3648, 2370, 1508, 2198, 1412]
+        self._VerifyValues(tensor_in_sizes=[1, 3, 3, 3, 1],
+                           filter_in_sizes=[3, 3, 3, 1, 1],
+                           strides=[1, 1, 1], padding="SAME",
+                           expected=expected_output)
+
+    def testConv3DKernelSmallerThanStrideSame(self):
+        # Outputs are computed through 3rd party implementations
+        expected_output = [
+            3188, 3524, 4892, 5036, 8900, 8420, 7724, 7052]
+        self._VerifyValues(tensor_in_sizes=[1, 5, 5, 5, 1],
+                           filter_in_sizes=[3, 3, 3, 1, 1],
+                           strides=[4, 4, 4], padding="SAME",
+                           expected=expected_output)
+
+
+class Conv3DBackpropTest(tf.test.TestCase):
+
+    def _RunAndVerifyBackpropInput(self, input_sizes, filter_sizes,
+                                   output_sizes, strides, padding,
+                                   expected, data_format, use_gpu):
+        total_output_size = 1
+        total_filter_size = 1
+        for s in output_sizes:
+            total_output_size *= s
+        for s in filter_sizes:
+            total_filter_size *= s
+        # Initializes the input tensor with array containing incrementing
+        # numbers from 1.
+        x1 = [f * 1.0 for f in range(1, total_filter_size + 1)]
+        x2 = [f * 1.0 for f in range(1, total_output_size + 1)]
+        with self.test_session(use_gpu=use_gpu) as sess:
+            t0 = tf.constant(input_sizes, shape=[len(input_sizes)])
+            t1 = tf.constant(x1, shape=filter_sizes)
+            t2 = tf.constant(x2, shape=output_sizes)
+            strides = [1] + strides + [1]
+            conv = tf.nn.conv3d_backprop_input(t0, t1, t2,
+                                               strides=strides,
+                                               padding=padding,
+                                               data_format=data_format)
+            # "values" consists of two tensors for two backprops
+            value = sess.run(conv)
+            self.assertShapeEqual(value, conv)
+        print("expected = ", expected)
+        flat = value.flatten()
+        print("actual = ", flat)
+        self.assertArrayNear(expected, flat, 1e-5)
+
+    def testConv3DValidBackpropInput(self):
+        # Gradients are computed through 3rd party implementations
+        expected_output = [1]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropInput(input_sizes=[1, 1, 1, 1, 1],
+                                            filter_sizes=[1, 1, 1, 1, 1],
+                                            output_sizes=[1, 1, 1, 1, 1],
+                                            strides=[1, 1, 1],
+                                            padding="VALID",
+                                            expected=expected_output,
+                                            data_format=data_format,
+                                            use_gpu=use_gpu)
+
+    def testConv3D2x2x2x3ValidBackpropInput(self):
+        # Gradients are computed through 3rd party implementations
+        expected_output = [
+            14, 32, 50, 68, 86, 104, 122, 140]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropInput(input_sizes=[1, 2, 2, 2, 1],
+                                            filter_sizes=[2, 2, 2, 1, 3],
+                                            output_sizes=[1, 1, 1, 1, 3],
+                                            strides=[1, 1, 1],
+                                            padding="VALID",
+                                            expected=expected_output,
+                                            data_format=data_format,
+                                            use_gpu=use_gpu)
+
+    def testConv3DStride2ValidBackpropInput(self):
+        # Gradients are computed through 3rd party implementations
+        expected_output = [
+            14, 32, 32, 77, 50, 68, 122, 167, 50, 122, 68, 167,
+            194, 266, 266, 365, 86, 104, 212, 257, 122, 140, 302,
+            347, 338, 410, 464, 563, 482, 554, 662, 761, 86, 212,
+            104, 257, 338, 464, 410, 563, 122, 302, 140, 347, 482, 662,
+            554, 761, 590, 716, 716, 869, 842, 968, 1022, 1175, 842,
+            1022, 968, 1175, 1202, 1382, 1382, 1589]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropInput(input_sizes=[1, 4, 4, 4, 1],
+                                            filter_sizes=[2, 2, 2, 1, 3],
+                                            output_sizes=[1, 2, 2, 2, 3],
+                                            strides=[2, 2, 2],
+                                            padding="VALID",
+                                            expected=expected_output,
+                                            data_format=data_format,
+                                            use_gpu=use_gpu)
+
+    def testConv3DStride123ValidBackpropInput(self):
+        expected_output = [
+            5, 11, 0, 0, 17, 23, 0, 0, 11, 25, 0, 0, 39,
+            53, 0, 0, 46, 74, 0, 0, 102, 130, 0, 0, 90, 134, 0, 0, 178,
+            222, 0, 0, 134, 194, 0, 0, 254, 314, 0, 0, 178, 254,
+            0, 0, 330, 406, 0, 0, 181, 219, 0, 0, 257, 295, 0,
+            0, 219, 265, 0, 0, 311, 357, 0, 0]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropInput(input_sizes=[1, 4, 4, 4, 1],
+                                            filter_sizes=[2, 2, 2, 1, 2],
+                                            output_sizes=[1, 3, 2, 1, 2],
+                                            strides=[1, 2, 3],
+                                            padding="VALID",
+                                            expected=expected_output,
+                                            data_format=data_format,
+                                            use_gpu=use_gpu)
+
+    def testConv3DFilter123ValidBackpropInput(self):
+        # Gradients are computed through 3rd party implementations
+        expected_output = [
+            5, 11, 17, 0, 23, 29, 35, 0, 11, 25, 39, 0, 53, 67, 81, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 39, 61,
+            0, 83, 105, 127, 0, 23, 53, 83, 0, 113, 143, 173, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropInput(input_sizes=[1, 4, 4, 4, 1],
+                                            filter_sizes=[1, 2, 3, 1, 2],
+                                            output_sizes=[1, 2, 2, 1, 2],
+                                            strides=[2, 2, 2],
+                                            padding="VALID",
+                                            expected=expected_output,
+                                            data_format=data_format,
+                                            use_gpu=use_gpu)
+
+    def _RunAndVerifyBackpropFilter(self, input_sizes, filter_sizes,
+                                    output_sizes, strides, padding,
+                                    expected, data_format, use_gpu):
+        total_input_size = 1
+        total_output_size = 1
+        for s in input_sizes:
+            total_input_size *= s
+        for s in output_sizes:
+            total_output_size *= s
+        # Initializes the input tensor with array containing incrementing
+        # numbers from 1.
+        x0 = [f * 1.0 for f in range(1, total_input_size + 1)]
+        x2 = [f * 1.0 for f in range(1, total_output_size + 1)]
+        with self.test_session(use_gpu=use_gpu) as sess:
+            t0 = tf.constant(x0, shape=input_sizes)
+            t1 = tf.constant(filter_sizes, shape=[len(filter_sizes)])
+            t2 = tf.constant(x2, shape=output_sizes)
+            strides = [1] + strides + [1]
+            conv = tf.nn.conv3d_backprop_filter(t0, t1, t2,
+                                                strides=strides,
+                                                padding=padding,
+                                                data_format=data_format)
+            value = sess.run(conv)
+            self.assertShapeEqual(value, conv)
+        print("expected = ", expected)
+        flat = value.flatten()
+        print("actual = ", flat)
+        self.assertArrayNear(expected, flat, 1e-5)
+
+    def testConv3D1x1x1ValidBackpropFilter(self):
+        # Gradients are computed through 3rd party implementations
+        expected = [204]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropFilter(input_sizes=[1, 2, 2, 2, 1],
+                                             filter_sizes=[1, 1, 1, 1, 1],
+                                             output_sizes=[1, 2, 2, 2, 1],
+                                             strides=[1, 1, 1],
+                                             padding="VALID",
+                                             expected=expected,
+                                             data_format=data_format,
+                                             use_gpu=use_gpu)
+
+    def testConv3D2x2x2x2ValidBackpropFilter(self):
+        # Gradients are computed through 3rd party implementations
+        expected = [
+            652, 712, 716, 784, 844, 928, 908, 1000, 1228,
+            1360, 1292, 1432, 1420, 1576, 1484, 1648]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropFilter(input_sizes=[1, 3, 3, 3, 1],
+                                             filter_sizes=[2, 2, 2, 1, 2],
+                                             output_sizes=[1, 2, 2, 2, 2],
+                                             strides=[1, 1, 1],
+                                             padding="VALID",
+                                             expected=expected,
+                                             data_format=data_format,
+                                             use_gpu=use_gpu)
+
+    def testConv3DFilter123ValidBackpropFilter(self):
+        expected = [567, 636, 603, 678, 639, 720, 675,
+                    762, 711, 804, 747, 846]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropFilter(input_sizes=[1, 3, 3, 3, 1],
+                                             filter_sizes=[1, 2, 3, 1, 2],
+                                             output_sizes=[1, 3, 2, 1, 2],
+                                             strides=[1, 1, 1],
+                                             padding="VALID",
+                                             expected=expected,
+                                             data_format=data_format,
+                                             use_gpu=use_gpu)
+
+    def testConv3DStride123ValidBackpropFilter(self):
+        expected = [
+            1036, 1162, 1072, 1204, 1180, 1330, 1216,
+            1372, 1612, 1834, 1648, 1876, 1756, 2002, 1792, 2044]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropFilter(input_sizes=[1, 4, 4, 4, 1],
+                                             filter_sizes=[2, 2, 2, 1, 2],
+                                             output_sizes=[1, 3, 2, 1, 2],
+                                             strides=[1, 2, 3],
+                                             padding="VALID",
+                                             expected=expected,
+                                             data_format=data_format,
+                                             use_gpu=use_gpu)
+
+    def testConv3DFilter123Stride123ValidBackpropFilter(self):
+        expected = [1804, 1968, 1868, 2040, 1932, 2112, 2188,
+                    2400, 2252, 2472, 2316, 2544]
+        for (data_format, use_gpu) in GetTestConfigs():
+            self._RunAndVerifyBackpropFilter(input_sizes=[1, 2, 4, 6, 1],
+                                             filter_sizes=[1, 2, 3, 1, 2],
+                                             output_sizes=[1, 2, 2, 2, 2],
+                                             strides=[1, 2, 3],
+                                             padding="VALID",
+                                             expected=expected,
+                                             data_format=data_format,
+                                             use_gpu=use_gpu)
+
+    def ConstructAndTestGradient(self, batch, input_depth, input_rows,
+                                 input_cols, filter_depth, filter_rows,
+                                 filter_cols, in_channels, out_channels,
+                                 stride_depth, stride_rows, stride_cols,
+                                 padding, test_input, data_format, use_gpu):
+        input_shape = [batch, input_depth, input_rows, input_cols, in_channels]
+        filter_shape = [filter_depth, filter_rows, filter_cols,
+                        in_channels, out_channels]
+
+        if padding == "VALID":
+            output_depth = (input_depth - filter_depth + stride_depth)
+            output_depth //= stride_depth
+            output_rows = (input_rows - filter_rows + stride_rows)
+            output_rows //= stride_rows
+            output_cols = (input_cols - filter_cols + stride_cols)
+            output_cols //= stride_cols
+        else:
+            output_depth = (input_depth + stride_depth - 1) // stride_depth
+            output_rows = (input_rows + stride_rows - 1) // stride_rows
+            output_cols = (input_cols + stride_cols - 1) // stride_cols
+        output_shape = [batch, output_depth, output_rows,
+                        output_cols, out_channels]
+        input_size = 1
+        for x in input_shape:
+            input_size *= x
+        filter_size = 1
+        for x in filter_shape:
+            filter_size *= x
+        input_data = [x * 1.0 / input_size for x in range(0, input_size)]
+        filter_data = [x * 1.0 / filter_size for x in range(0, filter_size)]
+        with self.test_session(use_gpu=use_gpu):
+            # Conv3DGrad functions are not compiled for double due to
+            # a problem in the way Eigen's Conv3DGrad works for double.
+            # So we disable the DOUBLE path.  We should re-enable this
+            # when double support returns for CPU and/or GPU.
+
+            # data_type = tf.float64
+            # tolerance = 1e-8
+
+            data_type = tf.float32
+            tolerance = 0.002
+            input_tensor = tf.constant(input_data, shape=input_shape,
+                                       dtype=data_type, name="input")
+            filter_tensor = tf.constant(filter_data, shape=filter_shape,
+                                        dtype=data_type, name="filter")
+            strides = [1, stride_depth, stride_rows, stride_cols, 1]
+            conv = tf.nn.conv3d(input_tensor, filter_tensor, strides,
+                                padding, data_format=data_format, name="conv")
+            self.assertEqual(output_shape, conv.get_shape())
+            if test_input:
+                err = tf.test.compute_gradient_error(input_tensor, input_shape,
+                                                     conv, output_shape)
+            else:
+                err = tf.test.compute_gradient_error(filter_tensor,
+                                                     filter_shape, conv,
+                                                     output_shape)
+            print("conv3d gradient error = ", err)
+            self.assertLess(err, tolerance)
+
+    def testInputGradientValidPaddingStrideOne(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=4, input_rows=4, input_cols=4,
+                filter_depth=2, filter_rows=2, filter_cols=2,
+                in_channels=2, out_channels=3, stride_depth=1,
+                stride_rows=1, stride_cols=1, padding="VALID",
+                test_input=True, data_format=data_format, use_gpu=use_gpu)
+
+    def testFilterGradientValidPaddingStrideOne(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=4, input_rows=4, input_cols=4,
+                filter_depth=2, filter_rows=2, filter_cols=2,
+                in_channels=2, out_channels=3, stride_depth=1,
+                stride_rows=1, stride_cols=1, padding="VALID",
+                test_input=False, data_format=data_format, use_gpu=use_gpu)
+
+    def testInputGradientValidPaddingStrideTwo(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=4, input_rows=4, input_cols=4,
+                filter_depth=2, filter_rows=2, filter_cols=2,
+                in_channels=2, out_channels=3, stride_depth=2,
+                stride_rows=2, stride_cols=2, padding="VALID",
+                test_input=True, data_format=data_format, use_gpu=use_gpu)
+
+    def testFilterGradientValidPaddingStrideTwo(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=4, input_rows=4, input_cols=4,
+                filter_depth=2, filter_rows=2, filter_cols=2,
+                in_channels=2, out_channels=3, stride_depth=2,
+                stride_rows=2, stride_cols=2, padding="VALID",
+                test_input=False, data_format=data_format, use_gpu=use_gpu)
+
+    def testInputGradientValidPaddingStrideThree(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=5, input_rows=6, input_cols=7,
+                filter_depth=3, filter_rows=3, filter_cols=3,
+                in_channels=2, out_channels=3, stride_depth=3,
+                stride_rows=3, stride_cols=3, padding="VALID",
+                test_input=True, data_format=data_format, use_gpu=use_gpu)
+
+    def testFilterGradientValidPaddingStrideThree(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=5, input_rows=6, input_cols=7,
+                filter_depth=3, filter_rows=3, filter_cols=3,
+                in_channels=2, out_channels=3, stride_depth=3,
+                stride_rows=3, stride_cols=3, padding="VALID",
+                test_input=False, data_format=data_format, use_gpu=use_gpu)
+
+    def testInputGradientValidPaddingFilter123(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=5, input_rows=6, input_cols=7,
+                filter_depth=1, filter_rows=2, filter_cols=3,
+                in_channels=2, out_channels=3, stride_depth=2,
+                stride_rows=2, stride_cols=32, padding="VALID",
+                test_input=True, data_format=data_format, use_gpu=use_gpu)
+
+    def testFilterGradientValidPaddingFilter123(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=5, input_rows=6, input_cols=7,
+                filter_depth=1, filter_rows=2, filter_cols=3,
+                in_channels=2, out_channels=3, stride_depth=2,
+                stride_rows=2, stride_cols=2, padding="VALID",
+                test_input=False, data_format=data_format, use_gpu=use_gpu)
+
+    def testInputGradientSamePaddingStrideOne(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=4, input_rows=5, input_cols=6,
+                filter_depth=2, filter_rows=3, filter_cols=3,
+                in_channels=2, out_channels=3, stride_depth=1,
+                stride_rows=1, stride_cols=1, padding="SAME",
+                test_input=True, data_format=data_format, use_gpu=use_gpu)
+
+    def testFilterGradientSamePaddingStrideOne(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=4, input_depth=4, input_rows=5, input_cols=6,
+                filter_depth=2, filter_rows=2, filter_cols=2,
+                in_channels=2, out_channels=3, stride_depth=1,
+                stride_rows=1, stride_cols=1, padding="SAME",
+                test_input=False, data_format=data_format, use_gpu=use_gpu)
+
+    def testInputGradientSamePaddingStrideTwo(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=4, input_rows=5, input_cols=6,
+                filter_depth=2, filter_rows=3, filter_cols=3,
+                in_channels=2, out_channels=3, stride_depth=2,
+                stride_rows=2, stride_cols=2, padding="SAME",
+                test_input=True, data_format=data_format, use_gpu=use_gpu)
+
+    def testFilterGradientSamePaddingStrideTwo(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=4, input_depth=4, input_rows=5, input_cols=6,
+                filter_depth=2, filter_rows=2, filter_cols=2,
+                in_channels=2, out_channels=3, stride_depth=2,
+                stride_rows=2, stride_cols=2, padding="SAME",
+                test_input=False, data_format=data_format, use_gpu=use_gpu)
+
+    def testInputGradientSamePaddingStrideThree(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=4, input_depth=5, input_rows=6, input_cols=8,
+                filter_depth=2, filter_rows=3, filter_cols=2,
+                in_channels=1, out_channels=2, stride_depth=3,
+                stride_rows=3, stride_cols=3, padding="SAME",
+                test_input=True, data_format=data_format, use_gpu=use_gpu)
+
+    def testFilterGradientSamePaddingStrideThree(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=4, input_depth=5, input_rows=6, input_cols=8,
+                filter_depth=2, filter_rows=3, filter_cols=2,
+                in_channels=1, out_channels=2, stride_depth=3,
+                stride_rows=3, stride_cols=3, padding="SAME",
+                test_input=False, data_format=data_format, use_gpu=use_gpu)
+
+    def testInputGradientSamePaddingStride123(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=6, input_rows=8, input_cols=7,
+                filter_depth=2, filter_rows=4, filter_cols=4,
+                in_channels=2, out_channels=3, stride_depth=1,
+                stride_rows=2, stride_cols=3, padding="SAME",
+                test_input=True, data_format=data_format, use_gpu=use_gpu)
+
+    def testFilterGradientSamePaddingStride123(self):
+        for (data_format, use_gpu) in GetTestConfigs():
+            self.ConstructAndTestGradient(
+                batch=2, input_depth=6, input_rows=8, input_cols=7,
+                filter_depth=2, filter_rows=4, filter_cols=4,
+                in_channels=2, out_channels=3, stride_depth=1,
+                stride_rows=2, stride_cols=3, padding="SAME",
+                test_input=False, data_format=data_format, use_gpu=use_gpu)
+
+    def testShapeFunctionEdgeCases(self):
+        # All shapes unknown.
+        c1 = tf.nn.conv3d(tf.placeholder(tf.float32),
+                          tf.placeholder(tf.float32),
+                          strides=[1, 1, 1, 1, 1], padding="SAME")
+        self.assertEqual([None, None, None, None, None],
+                         c1.get_shape().as_list())
+
+        # Incorrect input shape.
+        with self.assertRaises(ValueError):
+            tf.nn.conv3d(tf.placeholder(tf.float32, shape=[1, 3, 2]),
+                         tf.placeholder(tf.float32),
+                         strides=[1, 1, 1, 1, 1], padding="SAME")
+
+        # Incorrect filter shape.
+        with self.assertRaises(ValueError):
+            tf.nn.conv3d(tf.placeholder(tf.float32),
+                         tf.placeholder(tf.float32, shape=[2, 1, 3]),
+                         strides=[1, 1, 1, 1, 1], padding="SAME")
+
+        # Channel mismatch.
+        with self.assertRaises(ValueError):
+            tf.nn.conv3d(tf.placeholder(tf.float32, shape=[32, 20, 20, 10, 3]),
+                         tf.placeholder(tf.float32, shape=[5, 4, 4, 2, 2]),
+                         strides=[1, 1, 1, 1, 1], padding="SAME")
+
+        # Illegal strides.
+        with self.assertRaisesRegexp(ValueError,
+                                     "strides in the batch and depth"):
+            tf.nn.conv3d(tf.placeholder(tf.float32),
+                         tf.placeholder(tf.float32),
+                         strides=[2, 1, 1, 1, 1], padding="SAME")
+
+        with self.assertRaisesRegexp(ValueError,
+                                     "strides in the batch and depth"):
+            tf.nn.conv3d(tf.placeholder(tf.float32),
+                         tf.placeholder(tf.float32),
+                         strides=[1, 1, 1, 1, 2], padding="SAME")
+
+        # Filter larger than input.
+        with self.assertRaisesRegexp(
+                ValueError, "filter must not be larger than the input"):
+            tf.nn.conv3d(
+                tf.placeholder(tf.float32, shape=[32, 20, 20, 20, 3]),
+                tf.placeholder(tf.float32, shape=[20, 20, 21, 3, 2]),
+                strides=[1, 1, 1, 1, 1], padding="SAME")
+
+        with self.assertRaisesRegexp(
+                ValueError, "filter must not be larger than the input"):
+            tf.nn.conv3d(
+                tf.placeholder(tf.float32, shape=[32, 15, 20, 20, 3]),
+                tf.placeholder(tf.float32, shape=[16, 20, 20, 3, 2]),
+                strides=[1, 1, 1, 1, 1], padding="SAME")
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -50,6 +50,28 @@ def _Conv2DBackpropGrad(op, grad):
               op.get_attr("data_format"))]
 
 
+@ops.RegisterGradient("Conv3DBackpropInput")
+def _Conv3DBackpropGrad(op, grad):
+  """The derivatives for deconvolution.
+
+  Args:
+    op: the Deconvolution op.
+    grad: the tensor representing the gradient w.r.t. the output
+
+  Returns:
+    the gradients w.r.t. the input and the filter
+  """
+  return [None,
+          nn_ops.conv3d_backprop_filter(
+              grad, array_ops.shape(op.inputs[1]), op.inputs[2],
+              op.get_attr("strides"), op.get_attr("padding"),
+              op.get_attr("use_cudnn_on_gpu"), op.get_attr("data_format")),
+          nn_ops.conv3d(
+              grad, op.inputs[1], op.get_attr("strides"),
+              op.get_attr("padding"), op.get_attr("use_cudnn_on_gpu"),
+              op.get_attr("data_format"))]
+
+
 @ops.RegisterGradient("Softmax")
 def _SoftmaxGrad(op, grad_softmax):
   """The derivative of the softmax nonlinearity.
@@ -203,6 +225,22 @@ def _Conv2DGrad(op, grad):
                                        op.get_attr("use_cudnn_on_gpu"),
                                        op.get_attr("data_format")),
           nn_ops.conv2d_backprop_filter(op.inputs[0],
+                                        array_ops.shape(op.inputs[1]), grad,
+                                        op.get_attr("strides"),
+                                        op.get_attr("padding"),
+                                        op.get_attr("use_cudnn_on_gpu"),
+                                        op.get_attr("data_format"))]
+
+
+@ops.RegisterGradient("Conv3D")
+def _Conv3DGrad(op, grad):
+  return [nn_ops.conv3d_backprop_input(array_ops.shape(op.inputs[0]),
+                                       op.inputs[1], grad,
+                                       op.get_attr("strides"),
+                                       op.get_attr("padding"),
+                                       op.get_attr("use_cudnn_on_gpu"),
+                                       op.get_attr("data_format")),
+          nn_ops.conv3d_backprop_filter(op.inputs[0],
                                         array_ops.shape(op.inputs[1]), grad,
                                         op.get_attr("strides"),
                                         op.get_attr("padding"),

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -679,6 +679,28 @@ def _Conv2DBackpropInputShape(op):
     # gradients either.
     return [tensor_shape.unknown_shape(ndims=4)]
 
+ops.RegisterShape("Conv3D")(common_shapes.conv3d_shape)
+
+
+@ops.RegisterShape("Conv3DBackpropFilter")
+def _Conv3DBackpropFilterShape(op):
+  """Shape function for the Conv3DBackpropFilter op."""
+  filter_shape = tensor_util.constant_value(op.inputs[1])
+  if filter_shape is not None:
+    return [tensor_shape.TensorShape(filter_shape.tolist())]
+  else:
+    return [tensor_shape.unknown_shape(ndims=5)]
+
+
+@ops.RegisterShape("Conv3DBackpropInput")
+def _Conv3DBackpropInputShape(op):
+  """Shape function for the Conv3DBackpropInput op."""
+  input_shape = tensor_util.constant_value(op.inputs[0])
+  if input_shape is not None:
+    return [tensor_shape.TensorShape(input_shape.tolist())]
+  else:
+    return [tensor_shape.unknown_shape(ndims=5)]
+
 
 @ops.RegisterShape("DepthwiseConv2dNativeBackpropFilter")
 def _DepthwiseConv2dNativeBackpropFilterShape(op):


### PR DESCRIPTION
This patch is a WIP, but adds functionality for 3d convolutions as requested in #150.
### Approach

This patch adds 3d kernels and glue code, largely based off the 2d kernels, as separate modules. We add `conv_3d`, `conv3d_ops`, `conv3d_grad_ops`, and others to the original `conv_2d`, `conv_ops`, and `conv_grad_ops`, which remain unchanged.

As there is logic in the 2d kernels which the 3d kernel simply replicates, this patch is quite large. Generalizing the conv operator to n dimensions might solve 1d and 4d use cases (#1661 and #1136) as well as reducing the overall quantity of code in the codebase.  As this patch includes a comprehensive test suite, this patch should help if or when that happens. 
### Progress
- [x] Test suite for GPU/CPU
- [x] CPU kernel implementation
- [ ] GPU kernel implementation 

Currently, there are ~40 tests in `tensorflow/python/kernel_tests/conv3d_ops_test.py` which test shapes, outputs, strides, and gradients for a variety of input. They pass on my CPU instance: 

![image](https://cloud.githubusercontent.com/assets/3162580/15002320/d0bdaec0-1154-11e6-8e44-f9082e3108c6.png)

I currently lack access to a GPU so I haven't worked on the GPU kernel yet, but hopefully that should happen soon.
### Todo

This is a learning project for me, so I'd love to get feedback on how this might become more helpful, or how it might fit in better with the TF team's architectural design.  Thanks!
