### PR TITLE
Fix init value in inner_product

### DIFF
--- a/tensorflow/core/kernels/edit_distance_op.cc
+++ b/tensorflow/core/kernels/edit_distance_op.cc
@@ -179,7 +179,7 @@ class EditDistanceOp : public OpKernel {
 
       if (g_truth == g_hypothesis) {
         auto loc = std::inner_product(g_truth.begin(), g_truth.end(),
-                                      output_strides.begin(), 0);
+                                      output_strides.begin(), int64{0});
         output_t(loc) =
             gtl::LevenshteinDistance<T>(truth_seq, hypothesis_seq, cmp);
         if (normalize_) output_t(loc) /= truth_seq.size();
@@ -188,13 +188,13 @@ class EditDistanceOp : public OpKernel {
         ++truth_iter;
       } else if (g_truth > g_hypothesis) {  // missing truth @ this hypothesis
         auto loc = std::inner_product(g_hypothesis.begin(), g_hypothesis.end(),
-                                      output_strides.begin(), 0);
+                                      output_strides.begin(), int64{0});
         output_t(loc) = hypothesis_seq.size();
         if (normalize_) output_t(loc) /= 0.0;
         ++hypothesis_iter;
       } else {  // missing hypothesis @ this truth
         auto loc = std::inner_product(g_truth.begin(), g_truth.end(),
-                                      output_strides.begin(), 0);
+                                      output_strides.begin(), int64{0});
         output_t(loc) = (normalize_) ? 1.0 : truth_seq.size();
         ++truth_iter;
       }
@@ -204,7 +204,7 @@ class EditDistanceOp : public OpKernel {
       std::vector<int64> g_hypothesis = hypothesis_j.group();
       auto hypothesis_seq = hypothesis_j.values<T>();
       auto loc = std::inner_product(g_hypothesis.begin(), g_hypothesis.end(),
-                                    output_strides.begin(), 0);
+                                    output_strides.begin(), int64{0});
       output_t(loc) = hypothesis_seq.size();
       if (normalize_) output_t(loc) /= 0.0;
       ++hypothesis_iter;
@@ -214,7 +214,7 @@ class EditDistanceOp : public OpKernel {
       std::vector<int64> g_truth = truth_i.group();
       auto truth_seq = truth_i.values<T>();
       auto loc = std::inner_product(g_truth.begin(), g_truth.end(),
-                                    output_strides.begin(), 0);
+                                    output_strides.begin(), int64{0});
       output_t(loc) = (normalize_) ? 1.0 : truth_seq.size();
       ++truth_iter;
     }


### PR DESCRIPTION
inner_product accumulates into the type of the initial value
meaning that the result actually has type int instead of int64.
This will lead to truncation errors resulting in invalid writes
on buffers larger than 4GB.
