### PR TITLE
API Doc: Moved the usual termination code into a finally block

### DIFF
--- a/tensorflow/g3doc/how_tos/threading_and_queues/index.md
+++ b/tensorflow/g3doc/how_tos/threading_and_queues/index.md
@@ -167,10 +167,10 @@ try:
             break
         sess.run(train_op)
 except Exception, e:
-   # Report exceptions to the coordinator.
-   coord.request_stop(e)
-
-# Terminate as usual.  It is innocuous to request stop twice.
-coord.request_stop()
-coord.join(threads)
+    # Report exceptions to the coordinator.
+    coord.request_stop(e)
+finally:
+    # Terminate as usual.  It is innocuous to request stop twice.
+    coord.request_stop()
+    coord.join(threads)
 ```


### PR DESCRIPTION
Moved the usual termination code into a finally block so that the code can be executed even when SystemExit, KeyboardInterrupt, GeneratorExit raised (These exceptions derive not Exception but BaseException.)
