### PR TITLE
Add port mapping in the setup documentation to make sure Jupyter notebook server port is exposed.

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -309,7 +309,7 @@ After Docker is installed, launch a Docker container with the TensorFlow binary
 image as follows.
 
 ```bash
-$ docker run -it gcr.io/tensorflow/tensorflow
+$ docker run -it -p 8888:8888 gcr.io/tensorflow/tensorflow
 ```
 
 If you're using a container with GPU support, some additional flags must be

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -312,6 +312,10 @@ image as follows.
 $ docker run -it -p 8888:8888 gcr.io/tensorflow/tensorflow
 ```
 
+The option `-p 8888:8888` is used to publish the Docker container᾿s internal port to the host machine, in this case to ensure Jupyter notebook connection.
+
+The format of the port mapping `hostPort:containerPort`. You can speficy any valid port number for the host port but has to be `8888` for the container port portion.
+
 If you're using a container with GPU support, some additional flags must be
 passed to expose the GPU device to the container. For the default config, we
 include a


### PR DESCRIPTION
Need to add `-p 8888:8888` to expose the port to host in the Docker documentation.
