### PR TITLE
Fix Issue  #2225 InvalidArgumentError: No OpKernel T=DT_INT32 for log, exp, etc.

### DIFF
--- a/tensorflow/core/kernels/cwise_op_cos.cc
+++ b/tensorflow/core/kernels/cwise_op_cos.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER4(UnaryOp, CPU, "Cos", functor::cos, float, Eigen::half, double,
-          complex64);
+REGISTER6(UnaryOp, CPU, "Cos", functor::cos, float, Eigen::half, double, int32,
+         int64, complex64);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Cos", functor::cos, float, Eigen::half, double);
 #endif

--- a/tensorflow/core/kernels/cwise_op_exp.cc
+++ b/tensorflow/core/kernels/cwise_op_exp.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER4(UnaryOp, CPU, "Exp", functor::exp, float, Eigen::half, double,
-          complex64);
+REGISTER6(UnaryOp, CPU, "Exp", functor::exp, float, Eigen::half, double, int32,
+         int64, complex64);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Exp", functor::exp, float, Eigen::half, double);
 #endif

--- a/tensorflow/core/kernels/cwise_op_log.cc
+++ b/tensorflow/core/kernels/cwise_op_log.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER4(UnaryOp, CPU, "Log", functor::log, float, Eigen::half, double,
-          complex64);
+REGISTER6(UnaryOp, CPU, "Log", functor::log, float, Eigen::half, double, int32,
+         int64, complex64);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Log", functor::log, float, Eigen::half, double);
 #endif

--- a/tensorflow/core/kernels/cwise_op_rsqrt.cc
+++ b/tensorflow/core/kernels/cwise_op_rsqrt.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER4(UnaryOp, CPU, "Rsqrt", functor::rsqrt, float, Eigen::half, double,
-          complex64);
+REGISTER6(UnaryOp, CPU, "Rsqrt", functor::rsqrt, float, Eigen::half, double, int32,
+         int64, complex64);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Rsqrt", functor::rsqrt, float, Eigen::half, double);
 #endif

--- a/tensorflow/core/kernels/cwise_op_sin.cc
+++ b/tensorflow/core/kernels/cwise_op_sin.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER4(UnaryOp, CPU, "Sin", functor::sin, float, Eigen::half, double,
-          complex64);
+REGISTER6(UnaryOp, CPU, "Sin", functor::sin, float, Eigen::half, double, int32,
+         int64, complex64);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Sin", functor::sin, float, Eigen::half, double);
 #endif

--- a/tensorflow/core/kernels/cwise_op_sqrt.cc
+++ b/tensorflow/core/kernels/cwise_op_sqrt.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER4(UnaryOp, CPU, "Sqrt", functor::sqrt, float, Eigen::half, double,
-          complex64);
+REGISTER6(UnaryOp, CPU, "Sqrt", functor::sqrt, float, Eigen::half, double, int32,
+         int64, complex64);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Sqrt", functor::sqrt, float, Eigen::half, double);
 #endif

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -28,6 +28,64 @@ from tensorflow.python.platform import googletest
 exp = np.exp
 log = np.log
 
+class ExpTest(test_util.TensorFlowTestCase):
+
+  def testLog(self):
+    x_i32 = np.array([0], dtype=np.int32)
+    x_i64 = np.array([0], dtype=np.int64)
+    x_f32 = np.array([0], dtype=np.float32)
+
+    with self.test_session():
+      y_i32 = math_ops.exp(x_i32).eval()
+      y_i64 = math_ops.exp(x_i64).eval()
+      y_f32 = math_ops.exp(x_f32).eval()
+
+      self.assertEqual(y_i32, 1)
+      self.assertEqual(y_i32, y_f32)
+      self.assertEqual(y_i64, y_f32)
+
+class LogTest(test_util.TensorFlowTestCase):
+
+  def testLog(self):
+    x_i32 = np.array([1], dtype=np.int32)
+    x_i64 = np.array([1], dtype=np.int64)
+    x_f32 = np.array([1], dtype=np.float32)
+
+    with self.test_session():
+      y_i32 = math_ops.log(x_i32).eval()
+      y_i64 = math_ops.log(x_i64).eval()
+      y_f32 = math_ops.log(x_f32).eval()
+
+      self.assertEqual(y_i32, 0)
+      self.assertEqual(y_i32, y_f32)
+      self.assertEqual(y_i64, y_f32)
+
+class SinCosTest(test_util.TensorFlowTestCase):
+
+  def setUp(self):
+    self.x_i32 = np.array([0], dtype=np.int32)
+    self.x_i64 = np.array([0], dtype=np.int64)
+    self.x_f32 = np.array([0], dtype=np.float32)
+
+  def testSin(self):
+    with self.test_session():
+      y_i32 = math_ops.sin(self.x_i32).eval()
+      y_i64 = math_ops.sin(self.x_i64).eval()
+      y_f32 = math_ops.sin(self.x_f32).eval()
+
+      self.assertEqual(y_i32, 0)
+      self.assertEqual(y_i32, y_f32)
+      self.assertEqual(y_i64, y_f32)
+
+  def testCos(self):
+    with self.test_session():
+      y_i32 = math_ops.cos(self.x_i32).eval()
+      y_i64 = math_ops.cos(self.x_i64).eval()
+      y_f32 = math_ops.cos(self.x_f32).eval()
+
+      self.assertEqual(y_i32, 1)
+      self.assertEqual(y_i32, y_f32)
+      self.assertEqual(y_i64, y_f32)
 
 class ReduceTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -30,7 +30,7 @@ log = np.log
 
 class ExpTest(test_util.TensorFlowTestCase):
 
-  def testLog(self):
+  def testExp(self):
     x_i32 = np.array([0], dtype=np.int32)
     x_i64 = np.array([0], dtype=np.int64)
     x_f32 = np.array([0], dtype=np.float32)
@@ -82,6 +82,33 @@ class SinCosTest(test_util.TensorFlowTestCase):
       y_i32 = math_ops.cos(self.x_i32).eval()
       y_i64 = math_ops.cos(self.x_i64).eval()
       y_f32 = math_ops.cos(self.x_f32).eval()
+
+      self.assertEqual(y_i32, 1)
+      self.assertEqual(y_i32, y_f32)
+      self.assertEqual(y_i64, y_f32)
+
+class SqrtRsqrtTest(test_util.TensorFlowTestCase):
+
+  def setUp(self):
+    self.x_i32 = np.array([1], dtype=np.int32)
+    self.x_i64 = np.array([1], dtype=np.int64)
+    self.x_f32 = np.array([1], dtype=np.float32)
+
+  def testRsqrt(self):
+    with self.test_session():
+      y_i32 = math_ops.rsqrt(self.x_i32).eval()
+      y_i64 = math_ops.rsqrt(self.x_i64).eval()
+      y_f32 = math_ops.rsqrt(self.x_f32).eval()
+
+      self.assertEqual(y_i32, 1)
+      self.assertEqual(y_i32, y_f32)
+      self.assertEqual(y_i64, y_f32)
+
+  def testSqrt(self):
+    with self.test_session():
+      y_i32 = math_ops.sqrt(self.x_i32).eval()
+      y_i64 = math_ops.sqrt(self.x_i64).eval()
+      y_f32 = math_ops.sqrt(self.x_f32).eval()
 
       self.assertEqual(y_i32, 1)
       self.assertEqual(y_i32, y_f32)


### PR DESCRIPTION
This PR fixes  #2225,  InvalidArgumentError: No OpKernel T=DT_INT32 for log, exp, etc.
## Issue

https://www.tensorflow.org/versions/r0.8/api_docs/python/math_ops.html says, "A Tensor. Must be one of the following types: float32, float64, int32, complex64, int64", but code does not:

`REGISTER4(UnaryOp, CPU, "Cos", functor::cos, float, Eigen::half, double, complex64);`

They don't support int32 and int64. So this simple code fails:

```
x = np.array([1], dtype=np.int32)
sess = tf.Session()
print(sess.run(tf.log(x)))
```
## Solution

Thanks to a hint from @yaroslavvb, the patch is rather simple:

```
-REGISTER4(UnaryOp, CPU, "Log", functor::log, float, Eigen::half, double,        
-          complex64);       
+REGISTER6(UnaryOp, CPU, "Log", functor::log, float, Eigen::half, double, int32,
+         int64, complex64);
```
## Tests

I also added several tests to verify the patch. They all pass in my cpu-only machine:

```
...
//tensorflow/python:math_grad_test                                       PASSED in 2.8s
//tensorflow/python:math_ops_test                                        PASSED in 1.5s
//tensorflow/python:matmul_op_test                                       PASSED in 3.1s
...
//tensorflow/python:xent_op_test                                         PASSED in 1.4s

Executed 186 out of 187 tests: 187 tests pass.
```

If I just run math_ops_test without this patch, it fails with InvalidArgumentError: 

```
//tensorflow/python:math_ops_test                                        FAILED in 1.4s
  /home/hunkim/.cache/bazel/_bazel_hunkim/6785122ce03f8c29e79889062219c7d3/tensorflow/bazel-out/local-fastbuild/testlogs/tensorflow/python/math_ops_test/test.log

Executed 186 out of 187 tests: 186 tests pass and 1 fails locally.
```
