### PR TITLE
Update os_setup.md

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -630,7 +630,7 @@ $ bazel build -c opt --config=cuda //tensorflow/tools/pip_package:build_pip_pack
 $ bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg
 
 # The name of the .whl file will depend on your platform.
-$ pip install /tmp/tensorflow_pkg/tensorflow-0.8.0-py2-none-linux_x86_64.whl
+$ sudo pip install /tmp/tensorflow_pkg/tensorflow-0.8.0-py2-none-any.whl
 ```
 
 ## Setting up TensorFlow for Development


### PR DESCRIPTION
From PR#2095, I've checked command to Installing from sources on OS X.

To set up the TensorFlow form source on OS X, pip installation need root permission. 

> sudo pip install /tmp/tensorflow_pkg/tensorflow-0.8.0-py2-none-any.whl
