### PR TITLE
Parameter keep_prob now dropout

### DIFF
--- a/tensorflow/contrib/learn/python/learn/README.md
+++ b/tensorflow/contrib/learn/python/learn/README.md
@@ -105,7 +105,7 @@ iris = datasets.load_iris()
 
 def my_model(X, y):
     """This is DNN with 10, 20, 10 hidden layers, and dropout of 0.5 probability."""
-    layers = learn.ops.dnn(X, [10, 20, 10], keep_prob=0.5)
+    layers = learn.ops.dnn(X, [10, 20, 10], dropout=0.5)
     return learn.models.logistic_regression(layers, y)
 
 classifier = learn.TensorFlowEstimator(model_fn=my_model, n_classes=3)


### PR DESCRIPTION
Seems as parameter keep_prob is now called dropout. Because of the comment above I'm pretty sure droupout is meant.
