### PR TITLE
Fix botched merge in conv_grad_ops.cc.

### DIFF
--- a/tensorflow/core/kernels/conv_grad_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_ops.cc
@@ -888,8 +888,9 @@ class Conv2DSlowBackpropInputOp : public OpKernel {
       if (!blas_launch_status) {
         context->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
                                             ", n=", n, ", k=", k));
-        return;
       }
+
+      return;
     }
 
     TensorShape compatible_input_shape;
@@ -1152,8 +1153,8 @@ class Conv2DSlowBackpropFilterOp : public OpKernel {
       if (!blas_launch_status) {
         context->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
                                             ", n=", n, ", k=", k));
-        return;
       }
+      return;
     }
 
     Tensor compatible_input;

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -301,8 +301,9 @@ struct LaunchConvOp<GPUDevice, T> {
       if (!blas_launch_status) {
         ctx->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
                                         ", n=", n, ", k=", k));
-        return;
       }
+
+      return;
     }
     int padding_rows = 0;
     int padding_cols = 0;


### PR DESCRIPTION
We returned in the wrong location, so that we ended up doing twice the
work: the optimal gemm and then the suboptimal conv (for 1x1 filter).

No tests failed because the result was the same.
