### PR TITLE
Confusion with QueueRunner doc

### DIFF
--- a/tensorflow/g3doc/api_docs/python/train.md
+++ b/tensorflow/g3doc/api_docs/python/train.md
@@ -1332,6 +1332,7 @@ Wait till the Coordinator is told to stop.
 ### `class tf.train.QueueRunner` {#QueueRunner}
 
 Holds a list of enqueue operations for a queue, each to be run in a thread.
+It asynchronously runs the enqueue ops in different threads when the queuue is not full.
 
 Queues are a convenient TensorFlow mechanism to compute tensors
 asynchronously using multiple threads. For example in the canonical 'Input

--- a/tensorflow/g3doc/how_tos/threading_and_queues/index.md
+++ b/tensorflow/g3doc/how_tos/threading_and_queues/index.md
@@ -102,8 +102,8 @@ also has support to capture and report exceptions.  See the [Coordinator class](
 
 ## QueueRunner
 
-The `QueueRunner` class creates a number of threads that repeatedly run an
-enqueue op.  These threads can use a coordinator to stop together.  In
+The `QueueRunner` class creates a number of threads that run an
+enqueue op when the queue is not full.  These threads can use a coordinator to stop together.  In
 addition, a queue runner runs a *closer thread* that automatically closes the
 queue if an exception is reported to the coordinator.
 


### PR DESCRIPTION
When reading the threading_and_queues how_to and the doc of QueueRunner the phrase "repeatedly run an enqueue op" confused me.
I think these minor changes would save others a few minutes of confusion.
