### PR TITLE
Additional instructions on how to fix missing submodules

### DIFF
--- a/configure
+++ b/configure
@@ -7,8 +7,8 @@ DO_NOT_SUBMIT_WARNING="Unofficial setting. DO NOT SUBMIT!!!"
 if [[ ! -f "google/protobuf/protobuf.bzl" ]]; then
   echo "ERROR: It appears that the required submodule google/protobuf is not "\
 "available in this TensorFlow git clone."
-  echo "Please be sure to use the --recurse-submodules flag when performing "\
-"git clone of TensorFlow."
+  echo "Please re-run your git clone of Tensorflow with the --recurse-submodules flag or "\
+  "try git pull && git submodule init && git submodule update && git submodule status"
 
   exit 1
 fi


### PR DESCRIPTION
This adds a better hint on how to fix a repository that was cloned without `--recurse-submodules`.

Currently, it recommends to run `git clone` again, which may be a somewhat involved operation if the user has made modifications, pulled changesets from other branches etc. before their first attempt to compile.
#### Output:
##### Old:

`ERROR: It appears that the required submodule google/protobuf is not available in this TensorFlow git clone.
Please be sure to use the --recurse-submodules flag when performing git clone of TensorFlow.`
##### New:

`ERROR: It appears that the required submodule google/protobuf is not available in this TensorFlow git clone.
Please re-run your git clone of Tensorflow with the --recurse-submodules flag or try git pull && git submodule init && git submodule update && git submodule status`
