### PR TITLE
Update seq2seq

### DIFF
--- a/tensorflow/models/rnn/translate/seq2seq_model.py
+++ b/tensorflow/models/rnn/translate/seq2seq_model.py
@@ -83,17 +83,15 @@ class Seq2SeqModel(object):
     softmax_loss_function = None
     # Sampled softmax only makes sense if we sample less than vocabulary size.
     if num_samples > 0 and num_samples < self.target_vocab_size:
-      with tf.device("/cpu:0"):
-        w = tf.get_variable("proj_w", [size, self.target_vocab_size])
-        w_t = tf.transpose(w)
-        b = tf.get_variable("proj_b", [self.target_vocab_size])
+      w = tf.get_variable("proj_w", [size, self.target_vocab_size])
+      w_t = tf.transpose(w)
+      b = tf.get_variable("proj_b", [self.target_vocab_size])
       output_projection = (w, b)
 
       def sampled_loss(inputs, labels):
-        with tf.device("/cpu:0"):
-          labels = tf.reshape(labels, [-1, 1])
-          return tf.nn.sampled_softmax_loss(w_t, b, inputs, labels, num_samples,
-                                            self.target_vocab_size)
+        labels = tf.reshape(labels, [-1, 1])
+        return tf.nn.sampled_softmax_loss(w_t, b, inputs, labels, num_samples,
+                self.target_vocab_size)
       softmax_loss_function = sampled_loss
 
     # Create the internal multi-layer cell for our RNN.

--- a/tensorflow/python/ops/seq2seq.py
+++ b/tensorflow/python/ops/seq2seq.py
@@ -257,9 +257,8 @@ def embedding_rnn_decoder(decoder_inputs, initial_state, cell, num_symbols,
     proj_biases.get_shape().assert_is_compatible_with([num_symbols])
 
   with variable_scope.variable_scope(scope or "embedding_rnn_decoder"):
-    with ops.device("/cpu:0"):
-      embedding = variable_scope.get_variable("embedding",
-                                              [num_symbols, embedding_size])
+    embedding = variable_scope.get_variable("embedding",
+            [num_symbols, embedding_size])
     loop_function = _extract_argmax_and_embed(
         embedding, output_projection,
         update_embedding_for_previous) if feed_previous else None
@@ -395,9 +394,8 @@ def embedding_tied_rnn_seq2seq(encoder_inputs, decoder_inputs, cell,
     proj_biases.get_shape().assert_is_compatible_with([num_symbols])
 
   with variable_scope.variable_scope(scope or "embedding_tied_rnn_seq2seq"):
-    with ops.device("/cpu:0"):
-      embedding = variable_scope.get_variable("embedding",
-                                              [num_symbols, embedding_size])
+    embedding = variable_scope.get_variable("embedding",
+            [num_symbols, embedding_size])
 
     emb_encoder_inputs = [embedding_ops.embedding_lookup(embedding, x)
                           for x in encoder_inputs]
@@ -633,9 +631,8 @@ def embedding_attention_decoder(decoder_inputs, initial_state, attention_states,
     proj_biases.get_shape().assert_is_compatible_with([num_symbols])
 
   with variable_scope.variable_scope(scope or "embedding_attention_decoder"):
-    with ops.device("/cpu:0"):
-      embedding = variable_scope.get_variable("embedding",
-                                              [num_symbols, embedding_size])
+    embedding = variable_scope.get_variable("embedding",
+            [num_symbols, embedding_size])
     loop_function = _extract_argmax_and_embed(
         embedding, output_projection,
         update_embedding_for_previous) if feed_previous else None


### PR DESCRIPTION
This PR brings updates to the seq2seq examples, removing all of the `with ops.device("/cpu:0"):`. 

There are many ops implemented with cuda kernels recently, so maybe it's time to remove some cpu device specifications from the translate.py examples.

I don't have profile numbers for the translate.py example, but according to a similar experiment, this will boost the speed 5~6 times on a NVIDIA Titan GPU, especially when there are more than one independent runs going together.

Side note: when training with multiple cards (independent runs), the frequent data transfer between gpu and cpu is particularly harmful in my case.
