### PR TITLE
Enable GPU for L2Loss float64

### DIFF
--- a/tensorflow/core/kernels/l2loss_op.cc
+++ b/tensorflow/core/kernels/l2loss_op.cc
@@ -68,6 +68,7 @@ namespace functor {
   extern template struct L2Loss<GPUDevice, T>;
 
 DECLARE_GPU_SPEC(float);
+DECLARE_GPU_SPEC(double);
 DECLARE_GPU_SPEC(Eigen::half);
 #undef DECLARE_GPU_SPEC
 }  // namespace functor
@@ -79,6 +80,7 @@ DECLARE_GPU_SPEC(Eigen::half);
       L2LossOp<GPUDevice, T>);
 
 REGISTER_GPU_KERNEL(float);
+REGISTER_GPU_KERNEL(double);
 REGISTER_GPU_KERNEL(Eigen::half);
 #undef REGISTER_GPU_KERNEL
 

--- a/tensorflow/core/kernels/l2loss_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/l2loss_op_gpu.cu.cc
@@ -25,6 +25,7 @@ namespace tensorflow {
 
 typedef Eigen::GpuDevice GPUDevice;
 template struct functor::L2Loss<GPUDevice, float>;
+template struct functor::L2Loss<GPUDevice, double>;
 template struct functor::L2Loss<GPUDevice, Eigen::half>;
 
 }  // namespace tensorflow

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -86,11 +86,13 @@ class SoftmaxTest(tf.test.TestCase):
 class L2LossTest(tf.test.TestCase):
 
   def testL2Loss(self):
-    with self.test_session():
-      x = tf.constant([1.0, 0.0, 3.0, 2.0], shape=[2, 2], name="x")
-      l2loss = tf.nn.l2_loss(x)
-      value = l2loss.eval()
-    self.assertAllClose(7.0, value)
+    for dtype in [tf.float32, tf.float64]:
+      with self.test_session():
+        x = tf.constant([1.0, 0.0, 3.0, 2.0], shape=[2, 2], name="x",
+                        dtype=dtype)
+        l2loss = tf.nn.l2_loss(x)
+        value = l2loss.eval()
+      self.assertAllClose(7.0, value)
 
   def testGradient(self):
     x_shape = [20, 7, 3]


### PR DESCRIPTION
Enabled GPU registration for L2Loss operations of type double. This partially addresses #1140.

Tested locally. I'm assuming that there won't be any change in the tests because of [this commit](https://github.com/tensorflow/tensorflow/commit/a1bc10f9e28cd3d33e91bfaedd8199e4590f2893).
