### PR TITLE
Match conv2 weights stddev with cuda-convnet's layer def.

### DIFF
--- a/tensorflow/models/image/cifar10/cifar10.py
+++ b/tensorflow/models/image/cifar10/cifar10.py
@@ -204,7 +204,7 @@ def inference(images):
   # conv2
   with tf.variable_scope('conv2') as scope:
     kernel = _variable_with_weight_decay('weights', shape=[5, 5, 64, 64],
-                                         stddev=1e-4, wd=0.0)
+                                         stddev=1e-2, wd=0.0)
     conv = tf.nn.conv2d(norm1, kernel, [1, 1, 1, 1], padding='SAME')
     biases = _variable_on_cpu('biases', [64], tf.constant_initializer(0.1))
     bias = tf.nn.bias_add(conv, biases)


### PR DESCRIPTION
conv2 initW is 0.01 in cuda-convnet.

https://code.google.com/p/cuda-convnet/source/browse/trunk/example-layers/layers-conv-local-11pct.cfg

I'm trying [exercise](https://www.tensorflow.org/versions/r0.8/tutorials/deep_cnn/index.html#convolutional-neural-networks).

I change layer type from full connected to locally connected(just convolutional..).
Vanishing-Gradient problem is occurred at conv2.

Is this intended?
