### PR TITLE
Enable password support for Jupyter in a Docker image

### DIFF
--- a/tensorflow/tools/docker/README.md
+++ b/tensorflow/tools/docker/README.md
@@ -40,13 +40,13 @@ accomplished via
 
     $ export CUDA_SO=$(\ls /usr/lib/x86_64-linux-gnu/libcuda.* | xargs -I{} echo '-v {}:{}')
     $ export DEVICES=$(\ls /dev/nvidia* | xargs -I{} echo '--device {}:{}')
-    $ docker run -it -p 8888:8888 $CUDA_SO $DEVICES gcr.io/tensorflow/tensorflow-devel-gpu
+    $ docker run -it -p 8888:8888 $CUDA_SO $DEVICES gcr.io/tensorflow/tensorflow-gpu
 
 Alternately, you can use the `docker_run_gpu.sh` script in this directory.
 
 In order to set Jupyter Notebook to require a password, the `-e PASSWORD=pass` option must be provided
 
-    $ docker run -it -p 8888:8888 $CUDA_SO $DEVICES -e PASSWORD=pass gcr.io/tensorflow/tensorflow-devel-gpu
+    $ docker run -it -p 8888:8888 $CUDA_SO $DEVICES -e PASSWORD=pass gcr.io/tensorflow/tensorflow-gpu
 
 ## Rebuilding the containers
 

--- a/tensorflow/tools/docker/README.md
+++ b/tensorflow/tools/docker/README.md
@@ -44,6 +44,10 @@ accomplished via
 
 Alternately, you can use the `docker_run_gpu.sh` script in this directory.
 
+In order to set Jupyter Notebook to require a password, the `-e PASSWORD=pass` option must be provided
+
+    $ docker run -it -p 8888:8888 $CUDA_SO $DEVICES -e PASSWORD=pass gcr.io/tensorflow/tensorflow-devel-gpu
+
 ## Rebuilding the containers
 
 Just pick the dockerfile corresponding to the container you want to build, and run;

--- a/tensorflow/tools/docker/jupyter_notebook_config.py
+++ b/tensorflow/tools/docker/jupyter_notebook_config.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import os
+from IPython.lib import passwd
 
 c.NotebookApp.ip = '*'
 c.NotebookApp.port = 8888
@@ -20,7 +22,5 @@ c.MultiKernelManager.default_kernel_name = 'python2'
 
 # sets a password if PASSWORD is set in the environment
 if 'PASSWORD' in os.environ:
-    import os
-    from IPython.lib import passwd
     c.NotebookApp.password = passwd(os.environ['PASSWORD'])
     del os.environ['PASSWORD']

--- a/tensorflow/tools/docker/jupyter_notebook_config.py
+++ b/tensorflow/tools/docker/jupyter_notebook_config.py
@@ -17,3 +17,10 @@ c.NotebookApp.ip = '*'
 c.NotebookApp.port = 8888
 c.NotebookApp.open_browser = False
 c.MultiKernelManager.default_kernel_name = 'python2'
+
+# sets a password if PASSWORD is set in the environment
+if 'PASSWORD' in os.environ:
+    import os
+    from IPython.lib import passwd
+    c.NotebookApp.password = passwd(os.environ['PASSWORD'])
+    del os.environ['PASSWORD']


### PR DESCRIPTION
This small update enables Jupyter to support passwords passed as an environment variable when instantianting a docker container. 

In the same way, `jupyter_notebook_config.py` could also be modified to support HTTPS by default. If there is an interest, I could also include these updates in the same PR.
