### PR TITLE
[skflow] Added support for different parameters per layer in dnn

### DIFF
--- a/tensorflow/contrib/learn/python/learn/ops/dnn_ops.py
+++ b/tensorflow/contrib/learn/python/learn/ops/dnn_ops.py
@@ -28,14 +28,43 @@ def dnn(tensor_in, hidden_units, activation=nn.relu, dropout=None):
   Args:
     tensor_in: tensor or placeholder for input features.
     hidden_units: list of counts of hidden units in each layer.
-    activation: activation function between layers. Can be None.
-    dropout: if not None, will add a dropout layer with given probability.
+    activation: activation function between layers. Can be None. Can be list of
+      activation function for each layer
+    dropout: if not None, will add a dropout layer with given probability. Can
+      be list of dropouts per layer
 
   Returns:
     A tensor which would be a deep neural network.
   """
+
+  def broadcast_or_noop(f, length, noop=lambda x:x):
+    """Creates given length list of functions, broadcasting for single functions
+
+    Args:
+      f: function to broadcast. If None, broadcast noop. If list of function
+        validate len(f) == length
+      length: output list size
+      noop: No operation to fill if None
+
+    Returns:
+      A list which has given lenght with optionally broadcasted function
+    """
+    if f is None:
+      return([noop for _ in range(length)])
+    try:
+      f[0]
+    except TypeError:
+      return [f for _ in range(length)]
+    if len(f) != length:
+      raise ValueError("invalid supplied argument size")
+    return f
+
+  activation = broadcast_or_noop(activation, len(hidden_units))
+  dropout = broadcast_or_noop(dropout, len(hidden_units), None)
+
   with vs.variable_scope('dnn'):
-    for i, n_units in enumerate(hidden_units):
+    for i, (n_units, activation_l, dropout_l) in \
+      enumerate(zip(hidden_units, activation, dropout)):
       with vs.variable_scope('layer%d' % i):
         # Weight initializer was set to None to replicate the behavior of
         # rnn_cell.linear. Using fully_connected's default initializer gets
@@ -46,8 +75,7 @@ def dnn(tensor_in, hidden_units, activation=nn.relu, dropout=None):
             weight_init=None,
             weight_collections=['dnn_weights'],
             bias_collections=['dnn_biases'])
-        if activation is not None:
-          tensor_in = activation(tensor_in)
-        if dropout is not None:
-          tensor_in = dropout_ops.dropout(tensor_in, prob=(1.0 - dropout))
+        tensor_in = activation_l(tensor_in)
+        if dropout_l is not None:
+          tensor_in = dropout_ops.dropout(tensor_in, prob=(1.0 - dropout_l))
     return tensor_in


### PR DESCRIPTION
Added support for per layer configuration of activation function and
dropout probabilities. Example usage as per following code:

``` python
def model(X, y):
    l3 = skflow.ops.dnn(
        X,
        hidden_units=[10, 20],
        activation=[tf.nn.tanh, tf.nn.relu6]
    )
    return skflow.models.linear_regression(l3, y)

regressor = skflow.TensorFlowEstimator(
    model_fn=model,
    n_classes=0,
    steps=50000,
    learning_rate=0.1,
    batch_size=128,
    verbose=1
)

regressor.fit(X_t, Y_t)
```

Tested with single activation function and with multiple ones that
nothing crashes. Seem to be working correctly
