### PR TITLE
Add quick link to check compute capability

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -473,6 +473,10 @@ Supported cards include but are not limited to:
 * NVidia K20
 * NVidia K40
 
+##### Check NVIDIA Compute Capability of your GPU card
+
+https://developer.nvidia.com/cuda-gpus
+
 ##### Download and install Cuda Toolkit
 
 https://developer.nvidia.com/cuda-downloads


### PR DESCRIPTION
The same link also appears under "Configure TensorFlow's canonical view of Cuda libraries", but people might overlook it.
