### PR TITLE
Add a new contrib/avro directory and initial schema for tf.Example.

### DIFF
--- a/avro.BUILD
+++ b/avro.BUILD
@@ -1,0 +1,35 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+prefix_dir = "avro-cpp-1.8.0"
+
+cc_library(
+    name = "avrocpp",
+    srcs = glob(
+        [
+            prefix_dir + "/impl/**/*.cc",
+            prefix_dir + "/impl/**/*.hh",
+        ],
+        exclude = [
+            prefix_dir + "/impl/avrogencpp.cc",
+        ],
+    ),
+    hdrs = glob([prefix_dir + "/api/**/*.hh"]),
+    includes = [prefix_dir + "/api"],
+    deps = [
+        "@boost_archive//:boost",
+        "@boost_archive//:filesystem",
+        "@boost_archive//:iostreams",
+        "@boost_archive//:system",
+    ],
+)
+
+cc_binary(
+    name = "avrogencpp",
+    srcs = [prefix_dir + "/impl/avrogencpp.cc"],
+    deps = [
+        ":avrocpp",
+        "@boost_archive//:program_options",
+    ],
+)

--- a/boost.BUILD
+++ b/boost.BUILD
@@ -1,0 +1,57 @@
+# Description:
+#   The Boost library collection (http://www.boost.org)
+#
+# Most Boost libraries are header-only, in which case you only need to depend
+# on :boost. If you need one of the libraries that has a separately-compiled
+# implementation, depend on the appropriate libs rule.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Boost software license
+
+prefix_dir = "boost_1_61_0"
+
+cc_library(
+    name = "boost",
+    hdrs = glob([
+        prefix_dir + "/boost/**/*.hpp",
+        prefix_dir + "/boost/**/*.h",
+        prefix_dir + "/boost/**/*.ipp",
+    ]),
+    includes = [prefix_dir],
+)
+
+cc_library(
+    name = "filesystem",
+    srcs = glob([prefix_dir + "/libs/filesystem/src/*.cpp"]),
+    deps = [
+        ":boost",
+        ":system",
+    ],
+)
+
+cc_library(
+    name = "iostreams",
+    srcs = glob([prefix_dir + "/libs/iostreams/src/*.cpp"]),
+    deps = [
+        ":boost",
+        "@bzip2_archive//:bz2lib",
+        "@zlib_archive//:zlib",
+    ],
+)
+
+cc_library(
+    name = "program_options",
+    srcs = glob([prefix_dir + "/libs/program_options/src/*.cpp"]),
+    deps = [
+        ":boost",
+    ],
+)
+
+cc_library(
+    name = "system",
+    srcs = glob([prefix_dir + "/libs/system/src/*.cpp"]),
+    deps = [
+        ":boost",
+    ],
+)

--- a/bzip2.BUILD
+++ b/bzip2.BUILD
@@ -1,0 +1,36 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # BSD derivative
+
+prefix_dir = "bzip2-1.0.6"
+
+BZ2LIB_SRCS = [
+    # these are in the same order as their corresponding .o files are in OBJS in
+    # Makefile (rather than lexicographic order) for easy comparison (that they
+    # are identical).
+    "blocksort.c",
+    "huffman.c",
+    "crctable.c",
+    "randtable.c",
+    "compress.c",
+    "decompress.c",
+    "bzlib.c",
+]
+
+cc_library(
+    name = "bz2lib",
+    srcs = [prefix_dir + "/" + source for source in BZ2LIB_SRCS] +
+        [prefix_dir + "/bzlib_private.h"],
+    hdrs = [prefix_dir + "/bzlib.h"],
+    includes = [prefix_dir],
+)
+
+cc_binary(
+    name = "bzip2",
+    srcs = [
+        "bzip2.c",
+    ],
+    deps = [
+        ":bz2lib",
+    ],
+)

--- a/tensorflow/contrib/avro/BUILD
+++ b/tensorflow/contrib/avro/BUILD
@@ -1,0 +1,30 @@
+# Description:
+#   Contains ops for reading and writing Apache Avro files.
+#   (https://avro.apache.org/)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+package(default_visibility = ["//third_party/tensorflow:__subpackages__"])
+
+load("//tensorflow/contrib/avro:build_defs.bzl", "avro_gen_cpp")
+
+avro_gen_cpp(
+    name = "example_h",
+    srcs = ["example.json"],
+    outs = ["example.h"],
+    namespace = "tensorflow",
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "**/METADATA",
+            "**/OWNERS",
+        ],
+    ),
+    visibility = ["//third_party/tensorflow:__subpackages__"],
+)

--- a/tensorflow/contrib/avro/README.md
+++ b/tensorflow/contrib/avro/README.md
@@ -1,0 +1,4 @@
+# TensorFlow Avro support
+
+This directory contains code for reading and writing
+[Apache Avro](https://avro.apache.org/) data in TensorFlow.

--- a/tensorflow/contrib/avro/__init__.py
+++ b/tensorflow/contrib/avro/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Ops for reading/writing Apache Avro files.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function

--- a/tensorflow/contrib/avro/build_defs.bzl
+++ b/tensorflow/contrib/avro/build_defs.bzl
@@ -1,0 +1,28 @@
+"""Build extension for generating C++ header file from an Avro schema.
+
+Example usage:
+
+load("//tensorflow/contrib/avro:build_defs.bzl", "avro_gen_cpp")
+
+avro_gen_cpp(
+    name = "myrule",
+    srcs = ["myschema.json"],
+    outs = ["myschema.h"],
+    namespace = "mynamespace",
+)
+"""
+
+def avro_gen_cpp(name, srcs, outs, namespace, visibility=None):
+    native.genrule(
+        name = name,
+        srcs = srcs,
+        outs = outs,
+        cmd = ("$(location @avro_archive//:avrogencpp)" +
+               " --include-prefix external/avro_archive/avro-cpp-1.8.0/api" +
+               " --namespace " + namespace +
+               " --no-union-typedef" +
+               " --input $(SRCS)" +
+               " --output $@"),
+        tools = ["@avro_archive//:avrogencpp"],
+        visibility = visibility,
+    )

--- a/tensorflow/contrib/avro/example.json
+++ b/tensorflow/contrib/avro/example.json
@@ -1,0 +1,71 @@
+{
+  "type": "record",
+  "name": "Example",
+  "fields": [
+    {
+      "name": "features",
+      "type": {
+        "type": "record",
+        "name": "Features",
+        "fields": [
+          {
+            "name": "feature",
+            "type": {
+              "type": "map",
+              "values": {
+                "type": "record",
+                "name": "Feature",
+                "fields": [
+                  {
+                    "name": "values",
+                    "type": [
+                      {
+                        "type": "record",
+                        "name": "BytesList",
+                        "fields": [
+                          {
+                            "name": "value",
+                            "type": {
+                              "type": "array",
+                              "items": "bytes"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "record",
+                        "name": "FloatList",
+                        "fields": [
+                          {
+                            "name": "value",
+                            "type": {
+                              "type": "array",
+                              "items": "float"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "record",
+                        "name": "Int64List",
+                        "fields": [
+                          {
+                            "name": "value",
+                            "type": {
+                              "type": "array",
+                              "items": "long"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -127,3 +127,32 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
     remote = "https://boringssl.googlesource.com/boringssl",
     build_file = path_prefix + "boringssl.BUILD",
   )
+
+  native.new_http_archive(
+    name = "avro_archive",
+    url = "http://www-us.apache.org/dist/avro/avro-1.8.0/cpp/avro-cpp-1.8.0.tar.gz",
+    sha256 = "ec6e2ec957e95ca07f70cc25f02f5c416f47cb27bd987a6ec770dcbe72527368",
+    build_file = path_prefix + "avro.BUILD",
+  )
+
+  native.new_http_archive(
+    name = "boost_archive",
+    url = "http://pilotfiber.dl.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.tar.gz",
+    sha256 = "a77c7cc660ec02704c6884fbb20c552d52d60a18f26573c9cee0788bf00ed7e6",
+    build_file = path_prefix + "boost.BUILD",
+  )
+
+  native.new_http_archive(
+    name = "bzip2_archive",
+    url = "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz",
+    sha256 = "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd",
+    build_file = path_prefix + "bzip2.BUILD",
+  )
+
+  native.new_http_archive(
+    name = "zlib_archive",
+    url = "http://zlib.net/zlib-1.2.8.tar.gz",
+    sha256 = "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d",
+    build_file = path_prefix + "zlib.BUILD",
+  )
+

--- a/zlib.BUILD
+++ b/zlib.BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # BSD/MIT-like license (for zlib)
+
+prefix_dir = "zlib-1.2.8"
+
+cc_library(
+    name = "zlib",
+    srcs = glob([prefix_dir + "/*.c"]),
+    hdrs = glob([prefix_dir + "/*.h"]),
+    includes = [prefix_dir],
+)


### PR DESCRIPTION
Since Google Cloud Dataflow has native support for [Avro](https://cloud.google.com/dataflow/model/avro-io), we'd like to add Avro support to TensorFlow so that Google Cloud users can train directly on their Dataflow output.
