### PR TITLE
fix missing cudnn dependencies

### DIFF
--- a/tensorflow/tools/docker/Dockerfile.gpu
+++ b/tensorflow/tools/docker/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:7.5-cudnn4-runtime
+FROM nvidia/cuda:7.5-cudnn4-devel
 
 MAINTAINER Craig Citro <craigcitro@google.com>
 


### PR DESCRIPTION
This is the simplest solution to fix missing cudnn dependencies.  Just use the devel image from nvidia/cuda
