### PR TITLE
Remove --recurse-submodules from docs

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -410,13 +410,13 @@ using pip. You'll need pip for that, so install it as described
 ### Clone the TensorFlow repository
 
 ```bash
-$ git clone --recurse-submodules https://github.com/tensorflow/tensorflow
+$ git clone https://github.com/tensorflow/tensorflow
 ```
 
-`--recurse-submodules` is required to fetch the protobuf library that TensorFlow
-depends on. Note that these instructions will install the latest master branch
+Note that these instructions will install the latest master branch
 of tensorflow. If you want to install a specific branch (such as a release branch),
-pass `-b <branchname>` to the `git clone` command.
+pass `-b <branchname>` to the `git clone` command and `--recurse-submodules` for
+r0.8 and earlier to fetch the protobuf library that TensorFlow depends on. 
 
 ### Installation for Linux
 

--- a/tensorflow/tools/ci_build/README.md
+++ b/tensorflow/tools/ci_build/README.md
@@ -20,7 +20,7 @@ run continuous integration [ci.tensorflow.org](http://ci.tensorflow.org).
 2. Clone tensorflow repository.
 
    ```bash
-git clone --recurse-submodules https://github.com/tensorflow/tensorflow.git
+git clone https://github.com/tensorflow/tensorflow.git
 ```
 
 3. Go to tensorflow directory


### PR DESCRIPTION
Now that https://github.com/tensorflow/tensorflow/pull/1289 has been merged, the documentation for master doesn't need the `--recurse-submodules` argument to `git clone` unless cloning earlier releases.
