### PR TITLE
Add meshgrid function

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -157,7 +157,7 @@ class MeshgridTest(test_util.TensorFlowTestCase):
   def _compare(self, n, np_dtype, use_gpu):
     inputs = []
     for i in range(n):
-      x = np.linspace(-10, 10, 5, dtype=np_dtype)
+      x = np.linspace(-10, 10, 5).astype(np_dtype)
       if np_dtype in (np.complex64, np.complex128):
         x += 1j
       inputs.append(x)

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -166,7 +166,6 @@ class MeshgridTest(test_util.TensorFlowTestCase):
     with self.test_session(use_gpu=use_gpu):
       tf_out = array_ops.meshgrid(*inputs)
       for X, _X in zip(numpy_out, tf_out):
-        print(X, _X)
         self.assertAllEqual(X, _X.eval())
 
   def testCompare(self):
@@ -178,8 +177,12 @@ class MeshgridTest(test_util.TensorFlowTestCase):
       self._compare(4, t, False)
       self._compare(5, t, False)
 
-    with self.assertRaises(ValueError):
-      self._compare(6, np.float32, False)
+    # Test for inputs with rank not equal to 1
+    x = [[1, 1], [1, 1]]
+    with self.assertRaises(errors.InvalidArgumentError):
+      with self.test_session():
+        X, _ = array_ops.meshgrid(x, x)
+        X.eval()
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -152,5 +152,35 @@ class ReverseTest(test_util.TensorFlowTestCase):
         self.assertAllEqual(x_tf, np.asarray(x_np)[::-1])
 
 
+class MeshgridTest(test_util.TensorFlowTestCase):
+
+  def _compare(self, n, np_dtype, use_gpu):
+    inputs = []
+    for i in range(n):
+      x = np.linspace(-10, 10, 5, dtype=np_dtype)
+      if np_dtype in (np.complex64, np.complex128):
+        x += 1j
+      inputs.append(x)
+
+    numpy_out = np.meshgrid(*inputs)
+    with self.test_session(use_gpu=use_gpu):
+      tf_out = array_ops.meshgrid(*inputs)
+      for X, _X in zip(numpy_out, tf_out):
+        print(X, _X)
+        self.assertAllEqual(X, _X.eval())
+
+  def testCompare(self):
+    for t in (np.float16, np.float32, np.float64, np.int32, np.int64,
+            np.complex64, np.complex128):
+      self._compare(1, t, False)
+      self._compare(2, t, False)
+      self._compare(3, t, False)
+      self._compare(4, t, False)
+      self._compare(5, t, False)
+
+    with self.assertRaises(ValueError):
+      self._compare(6, np.float32, False)
+
+
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -179,7 +179,7 @@ class MeshgridTest(test_util.TensorFlowTestCase):
 
     # Test for inputs with rank not equal to 1
     x = [[1, 1], [1, 1]]
-    with self.assertRaises(errors.InvalidArgumentError):
+    with self.assertRaisesRegexp(errors.InvalidArgumentError, "needs to have rank 1"):
       with self.test_session():
         X, _ = array_ops.meshgrid(x, x)
         X.eval()

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -179,7 +179,8 @@ class MeshgridTest(test_util.TensorFlowTestCase):
 
     # Test for inputs with rank not equal to 1
     x = [[1, 1], [1, 1]]
-    with self.assertRaisesRegexp(errors.InvalidArgumentError, "needs to have rank 1"):
+    with self.assertRaisesRegexp(errors.InvalidArgumentError,
+                                 "needs to have rank 1"):
       with self.test_session():
         X, _ = array_ops.meshgrid(x, x)
         X.eval()

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -171,7 +171,8 @@ class MeshgridTest(test_util.TensorFlowTestCase):
   def testCompare(self):
     for t in (np.float16, np.float32, np.float64, np.int32, np.int64,
             np.complex64, np.complex128):
-      self._compare(1, t, False)
+      # Don't test the one-dimensional case, as
+      # old numpy versions don't support it
       self._compare(2, t, False)
       self._compare(3, t, False)
       self._compare(4, t, False)

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1024,8 +1024,12 @@ def meshgrid(*args, **kwargs):
   Returns:
     outputs: A list of N `Tensor`s with rank N
   """
-  indexing = kwargs.get("indexing", "xy")
-  name = kwargs.get("name", "meshgrid")
+  indexing = kwargs.pop("indexing", "xy")
+  name = kwargs.pop("name", "meshgrid")
+  if len(kwargs) > 0:
+    key = list(kwargs.keys())[0]
+    raise TypeError("'{}' is an invalid keyword argument "
+                    "for this function".format(key))
 
   if indexing not in ("xy", "ij"):
     raise ValueError("indexing parameter must be either 'xy' or 'ij'")

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1048,8 +1048,8 @@ def meshgrid(*args, indexing="xy", name="meshgrid"):
       bcast[0], bcast[1] = bcast[1], bcast[0]
 
     results = []
-    for a, r, e in zip(args, shapes, bcast):
-      with ops.control_dependencies(asserts):
+    with ops.control_dependencies(asserts):
+      for a, r, e in zip(args, shapes, bcast):
         results.append(tile(reshape(a, r), e))
 
     return results

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -38,6 +38,7 @@ of a tensor and change the shape of a tensor.
 @@reshape
 @@squeeze
 @@expand_dims
+@@meshgrid
 
 ## Slicing and Joining
 
@@ -984,6 +985,62 @@ def pad(tensor, paddings, mode="CONSTANT", name=None):  # pylint: disable=invali
                                      mode="SYMMETRIC",
                                      name=name)
   raise ValueError("Unknown padding mode: %s" % mode)
+
+
+def meshgrid(*args, indexing="xy", name="meshgrid"):
+  """Broadcasts parameters for evaluation on an N-D grid.
+
+  Given N one-dimensional coordinate arrays `*args`, returns a list `outputs`
+  of N-D coordinate arrays for evaluating expressions on an N-D grid.
+
+  For example:
+
+  Calling `X, Y = meshgrid(x, y)` with the tensors
+  ```prettyprint
+    x = [1, 2, 3]
+    y = [4, 5, 6]
+  ```
+  results in
+  ```prettyprint
+    X = [[1, 1, 1],
+         [2, 2, 2],
+         [3, 3, 3]]
+    Y = [[4, 5, 6],
+         [4, 5, 6],
+         [4, 5, 6]]
+  ```
+
+  Args:
+    *args: `Tensor`s with rank 1
+
+  Returns:
+    outputs: A list of N `Tensor`s with rank N
+
+  """
+  if indexing not in ("xy", "ij"):
+    raise ValueError("indexing parameter must be either 'xy' or 'ij'")
+
+  num_inputs = len(args)
+
+  if num_inputs > 5:
+    raise ValueError("meshgrid only supports up to 5 dimensions")
+
+  ones = (1,) * num_inputs
+
+  with ops.op_scope(args, name, "meshgrid") as name:
+    # Prepare reshape by inserting dimensions with size 1 where needed
+    shapes = [ones[:i] + (-1,) + ones[i + 1:] for i in range(num_inputs)]
+    # Create parameters for broadcasting each tensor to the full size
+    sizes = [shape(x)[0] for x in args]
+    bcast = [sizes[:i] + [1] + sizes[i + 1:] for i in range(num_inputs)]
+
+    # By default, the numpy version swaps the instructions
+    # for the first and second dimension
+    if indexing == "xy" and num_inputs > 1:
+      shapes[0], shapes[1] = shapes[1], shapes[0]
+      bcast[0], bcast[1] = bcast[1], bcast[0]
+
+    return [tile(reshape(a, r), e) for a, r, e in zip(args, shapes, bcast)]
 
 
 @ops.RegisterShape("Placeholder")

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1018,7 +1018,8 @@ def meshgrid(*args, **kwargs):
 
   Args:
     *args: `Tensor`s with rank 1
-    indexing: Either 'xy' or 'ij' (default: 'xy')
+    indexing: Either 'xy' or 'ij' (optional, default: 'xy')
+    name: A name for the operation (optional).
 
   Returns:
     outputs: A list of N `Tensor`s with rank N

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -987,7 +987,7 @@ def pad(tensor, paddings, mode="CONSTANT", name=None):  # pylint: disable=invali
   raise ValueError("Unknown padding mode: %s" % mode)
 
 
-def meshgrid(*args, indexing="xy", name="meshgrid"):
+def meshgrid(*args, **kwargs):
   """Broadcasts parameters for evaluation on an N-D grid.
 
   Given N one-dimensional coordinate arrays `*args`, returns a list `outputs`
@@ -1023,6 +1023,9 @@ def meshgrid(*args, indexing="xy", name="meshgrid"):
   Returns:
     outputs: A list of N `Tensor`s with rank N
   """
+  indexing = kwargs.get("indexing", "xy")
+  name = kwargs.get("name", "meshgrid")
+
   if indexing not in ("xy", "ij"):
     raise ValueError("indexing parameter must be either 'xy' or 'ij'")
 


### PR DESCRIPTION
I needed to use something similar to [`np.meshgrid`](http://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.meshgrid.html) in tensorflow and decided to write my own version.
This can be implemented in pure Python by making use of `tf.reshape` and `tf.tile`.
I've placed the function in `array_ops.py` and added a simple test that compares the output to the numpy version.

One thing that's still missing is testing whether the inputs all have rank 1.
Seems like I might have to use `tf.rank` to check this at runtime.
Would `Assert` ops be the right tool for that?
