### PR TITLE
Fix python3 incompatibility in encode_audio_op_test.py

### DIFF
--- a/tensorflow/contrib/ffmpeg/encode_audio_op_test.py
+++ b/tensorflow/contrib/ffmpeg/encode_audio_op_test.py
@@ -47,8 +47,8 @@ class EncodeAudioOpTest(tf.test.TestCase):
     # Skip header size
     self.assertEqual(original[20:36], encoded[20:36])
     # Skip extra bits inserted by ffmpeg.
-    self.assertEqual(original[original.find('data'):],
-                     encoded[encoded.find('data'):])
+    self.assertEqual(original[original.find(b'data'):],
+                     encoded[encoded.find(b'data'):])
 
   def testRoundTrip(self):
     """Reads a wav file, writes it, and compares them."""


### PR DESCRIPTION
This fixes test failure as in: http://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_CONTAINER_TYPE=CPU,TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/108/console
Change: 123507798
