### PR TITLE
Enable segment reduction ops for complex numbers

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops.cc
@@ -172,50 +172,48 @@ class SegmentReductionOp : public OpKernel {
   }
 };
 
-#define REGISTER_CPU_KERNELS(type, index_type)                 \
-  REGISTER_KERNEL_BUILDER(                                     \
-      Name("SegmentSum")                                       \
-          .Device(DEVICE_CPU)                                  \
-          .TypeConstraint<type>("T")                           \
-          .TypeConstraint<index_type>("Tindices"),             \
-      SegmentReductionOp<CPUDevice, type, index_type,          \
-                         Eigen::internal::SumReducer<type>>);  \
-  REGISTER_KERNEL_BUILDER(                                     \
-      Name("SegmentMean")                                      \
-          .Device(DEVICE_CPU)                                  \
-          .TypeConstraint<type>("T")                           \
-          .TypeConstraint<index_type>("Tindices"),             \
-      SegmentReductionOp<CPUDevice, type, index_type,          \
-                         Eigen::internal::MeanReducer<type>>); \
-  REGISTER_KERNEL_BUILDER(                                     \
-      Name("SegmentProd")                                      \
-          .Device(DEVICE_CPU)                                  \
-          .TypeConstraint<type>("T")                           \
-          .TypeConstraint<index_type>("Tindices"),             \
-      SegmentReductionOp<CPUDevice, type, index_type,          \
-                         Eigen::internal::ProdReducer<type>>); \
-  REGISTER_KERNEL_BUILDER(                                     \
-      Name("SegmentMin")                                       \
-          .Device(DEVICE_CPU)                                  \
-          .TypeConstraint<type>("T")                           \
-          .TypeConstraint<index_type>("Tindices"),             \
-      SegmentReductionOp<CPUDevice, type, index_type,          \
-                         Eigen::internal::MinReducer<type>>);  \
-  REGISTER_KERNEL_BUILDER(                                     \
-      Name("SegmentMax")                                       \
-          .Device(DEVICE_CPU)                                  \
-          .TypeConstraint<type>("T")                           \
-          .TypeConstraint<index_type>("Tindices"),             \
-      SegmentReductionOp<CPUDevice, type, index_type,          \
-                         Eigen::internal::MaxReducer<type>>);
+#define REGISTER_CPU_KERNEL_SEGMENT(name, functor, type, index_type) \
+  REGISTER_KERNEL_BUILDER(                                           \
+      Name(name)                                                     \
+          .Device(DEVICE_CPU)                                        \
+          .TypeConstraint<type>("T")                                 \
+          .TypeConstraint<index_type>("Tindices"),                   \
+      SegmentReductionOp<CPUDevice, type, index_type, functor>)
 
-#define REGISTER_CPU_KERNELS_ALL(type) \
-  REGISTER_CPU_KERNELS(type, int32);   \
-  REGISTER_CPU_KERNELS(type, int64);
+#define REGISTER_REAL_CPU_KERNELS(type, index_type)                         \
+  REGISTER_CPU_KERNEL_SEGMENT(                                              \
+      "SegmentSum", Eigen::internal::SumReducer<type>, type, index_type);   \
+  REGISTER_CPU_KERNEL_SEGMENT(                                              \
+      "SegmentMean", Eigen::internal::MeanReducer<type>, type, index_type); \
+  REGISTER_CPU_KERNEL_SEGMENT(                                              \
+      "SegmentProd", Eigen::internal::ProdReducer<type>, type, index_type); \
+  REGISTER_CPU_KERNEL_SEGMENT(                                              \
+      "SegmentMin", Eigen::internal::MinReducer<type>, type, index_type);   \
+  REGISTER_CPU_KERNEL_SEGMENT(                                              \
+      "SegmentMax", Eigen::internal::MaxReducer<type>, type, index_type)
 
-TF_CALL_REAL_NUMBER_TYPES(REGISTER_CPU_KERNELS_ALL);
-#undef REGISTER_CPU_KERNELS
-#undef REGISTER_CPU_KERNELS_ALL
+#define REGISTER_COMPLEX_CPU_KERNELS(type, index_type)                      \
+  REGISTER_CPU_KERNEL_SEGMENT(                                              \
+      "SegmentSum", Eigen::internal::SumReducer<type>, type, index_type);   \
+  REGISTER_CPU_KERNEL_SEGMENT(                                              \
+      "SegmentProd", Eigen::internal::ProdReducer<type>, type, index_type)
+
+#define REGISTER_REAL_CPU_KERNELS_ALL(type) \
+  REGISTER_REAL_CPU_KERNELS(type, int32);   \
+  REGISTER_REAL_CPU_KERNELS(type, int64)
+
+#define REGISTER_COMPLEX_CPU_KERNELS_ALL(type) \
+  REGISTER_COMPLEX_CPU_KERNELS(type, int32);   \
+  REGISTER_COMPLEX_CPU_KERNELS(type, int64)
+
+TF_CALL_REAL_NUMBER_TYPES(REGISTER_REAL_CPU_KERNELS_ALL);
+REGISTER_COMPLEX_CPU_KERNELS_ALL(complex64);
+REGISTER_COMPLEX_CPU_KERNELS_ALL(complex128);
+#undef REGISTER_CPU_KERNEL_SEGMENT
+#undef REGISTER_REAL_CPU_KERNELS
+#undef REGISTER_COMPLEX_CPU_KERNELS
+#undef REGISTER_REAL_CPU_KERNELS_ALL
+#undef REGISTER_COMPLEX_CPU_KERNELS_ALL
 
 // Similar to SegmentReductionOp but can handle unsorted segment definitions and
 // specifying size of output.
@@ -285,7 +283,7 @@ class UnsortedSegmentSumOp : public OpKernel {
   REGISTER_CPU_UNSORTED_KERNELS(type, int32);   \
   REGISTER_CPU_UNSORTED_KERNELS(type, int64);
 
-TF_CALL_REAL_NUMBER_TYPES(REGISTER_CPU_UNSORTED_KERNELS_ALL);
+TF_CALL_NUMBER_TYPES(REGISTER_CPU_UNSORTED_KERNELS_ALL);
 #undef REGISTER_CPU_UNSORTED_KERNELS
 #undef REGISTER_CPU_UNSORTED_KERNELS_ALL
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -811,7 +811,7 @@ REGISTER_OP("SegmentSum")
     .Input("data: T")
     .Input("segment_ids: Tindices")
     .Output("output: T")
-    .Attr("T: realnumbertype")
+    .Attr("T: numbertype")
     .Attr("Tindices: {int32,int64}")
     .Doc(R"doc(
 Computes the sum along segments of a tensor.
@@ -867,7 +867,7 @@ REGISTER_OP("SegmentProd")
     .Input("data: T")
     .Input("segment_ids: Tindices")
     .Output("output: T")
-    .Attr("T: realnumbertype")
+    .Attr("T: numbertype")
     .Attr("Tindices: {int32,int64}")
     .Doc(R"doc(
 Computes the product along segments of a tensor.
@@ -951,7 +951,7 @@ REGISTER_OP("UnsortedSegmentSum")
     .Input("segment_ids: Tindices")
     .Input("num_segments: int32")
     .Output("output: T")
-    .Attr("T: realnumbertype")
+    .Attr("T: numbertype")
     .Attr("Tindices: {int32,int64}")
     .Doc(R"doc(
 Computes the sum along segments of a tensor.

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
@@ -70,7 +70,9 @@ class SegmentReductionOpTest(SegmentReductionHelper):
     dtypes = [tf.float32,
               tf.float64,
               tf.int64,
-              tf.int32]
+              tf.int32,
+              tf.complex64,
+              tf.complex128]
 
     # Each item is np_op1, np_op2, tf_op
     ops_list = [(np.add, None, tf.segment_sum),
@@ -79,14 +81,23 @@ class SegmentReductionOpTest(SegmentReductionHelper):
                 (np.ndarray.__mul__, None, tf.segment_prod),
                 (np.minimum, None, tf.segment_min),
                 (np.maximum, None, tf.segment_max)]
+    
+    # A subset of ops has been enabled for complex numbers
+    complex_ops_list = [(np.add, None, tf.segment_sum),
+                        (np.ndarray.__mul__, None, tf.segment_prod)]
 
     n = 10
     shape = [n, 2]
     indices = [i // 3 for i in range(n)]
     for dtype in dtypes:
+      if dtype in (tf.complex64, tf.complex128):
+          curr_ops_list = complex_ops_list
+      else:
+          curr_ops_list = ops_list
+
       with self.test_session(use_gpu=False):
         tf_x, np_x = self._input(shape, dtype=dtype)
-        for np_op1, np_op2, tf_op in ops_list:
+        for np_op1, np_op2, tf_op in curr_ops_list:
           np_ans = self._segmentReduce(indices, np_x, np_op1, np_op2)
           s = tf_op(data=tf_x, segment_ids=indices)
           tf_ans = s.eval()
@@ -213,7 +224,9 @@ class UnsortedSegmentSumTest(SegmentReductionHelper):
     dtypes = [tf.float32,
               tf.float64,
               tf.int64,
-              tf.int32]
+              tf.int32,
+              tf.complex64,
+              tf.complex128]
     indices_flat = np.array([0, 4, 0, 8, 3, 8, 4, 7, 7, 3])
     num_segments = 12
     for indices in indices_flat, indices_flat.reshape(5, 2):


### PR DESCRIPTION
I've enabled segment reduction ops for complex 64 and complex128 on the CPU,
in order to bring their behavior in line with the regular reduction ops.
Only sum and prod reductions have been enabled, as min and max are not
appropriate and mean would require changes to the code and is probably
not worth it.

This fixes #2255
