### PR TITLE
Remove unnecessary check from docker_run_gpu.sh

### DIFF
--- a/tensorflow/tools/docker/docker_run_gpu.sh
+++ b/tensorflow/tools/docker/docker_run_gpu.sh
@@ -14,15 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-
 set -e
-
-export CUDA_HOME=${CUDA_HOME:-/usr/local/cuda}
-
-if [ ! -d ${CUDA_HOME}/lib64 ]; then
-  echo "Failed to locate CUDA libs at ${CUDA_HOME}/lib64."
-  exit 1
-fi
 
 export CUDA_SO=$(\ls /usr/lib/x86_64-linux-gnu/libcuda.* | \
                     xargs -I{} echo '-v {}:{}')


### PR DESCRIPTION
docker_run_gpu.sh was checking for /usr/local/cuda, which is not the default install location on ubuntu 16.04. The check was not being used by anything else anyways, so removing.
