### PR TITLE
Implement bidirectional_dynamic_rnn (#1779)

### DIFF
--- a/tensorflow/python/kernel_tests/rnn_test.py
+++ b/tensorflow/python/kernel_tests/rnn_test.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import itertools
 import time
 import timeit
 
@@ -1131,6 +1132,113 @@ class BidirectionalRNNTest(tf.test.TestCase):
                                                     use_shape=True)
     self._testBidirectionalRNNWithoutSequenceLength(use_gpu=True,
                                                     use_shape=True)
+
+  def _createBidirectionalDynamicRNN(self, use_gpu, use_shape,
+                                     use_state_tuple, use_time_major):
+    num_units = 3
+    input_size = 5
+    batch_size = 2
+    max_length = 8
+
+    initializer = tf.random_uniform_initializer(-0.01, 0.01, seed=self._seed)
+    sequence_length = tf.placeholder(tf.int64)
+    cell_fw = tf.nn.rnn_cell.LSTMCell(num_units,
+                                      initializer=initializer,
+                                      state_is_tuple=use_state_tuple)
+    cell_bw = tf.nn.rnn_cell.LSTMCell(num_units,
+                                      initializer=initializer,
+                                      state_is_tuple=use_state_tuple)
+    inputs = max_length * [
+        tf.placeholder(tf.float32,
+                       shape=(batch_size if use_shape else None, input_size))]
+    inputs_c = tf.pack(inputs)
+    if not use_time_major:
+      inputs_c = tf.transpose(inputs_c, [1, 0, 2])
+    outputs, state_fw, state_bw = tf.nn.bidirectional_dynamic_rnn(
+        cell_fw,
+        cell_bw,
+        inputs_c,
+        sequence_length,
+        dtype=tf.float32,
+        time_major=use_time_major)
+    outputs_shape = [None, max_length, 2 * num_units]
+    if use_shape:
+      outputs_shape[0] = batch_size
+    if use_time_major:
+      outputs_shape[0], outputs_shape[1] = outputs_shape[1], outputs_shape[0]
+    self.assertEqual(
+        outputs.get_shape().as_list(),
+        outputs_shape)
+
+    input_value = np.random.randn(batch_size, input_size)
+    outputs = tf.pack(outputs)
+
+    return input_value, inputs, outputs, state_fw, state_bw, sequence_length
+
+  def _testBidirectionalDynamicRNN(self, use_gpu, use_shape,
+                                   use_state_tuple, use_time_major):
+    with self.test_session(use_gpu=use_gpu, graph=tf.Graph()) as sess:
+      input_value, inputs, outputs, state_fw, state_bw, sequence_length = (
+          self._createBidirectionalDynamicRNN(
+              use_gpu, use_shape, use_state_tuple, use_time_major))
+      tf.initialize_all_variables().run()
+      # Run with pre-specified sequence length of 2, 3
+      if use_state_tuple:
+        out, c_fw, m_fw, c_bw, m_bw = sess.run(
+            [outputs, state_fw[0], state_fw[1], state_bw[0], state_bw[1]],
+            feed_dict={inputs[0]: input_value,
+                       sequence_length: [2, 3]})
+        s_fw = (c_fw, m_fw)
+        s_bw = (c_bw, m_bw)
+      else:
+        out, s_fw, s_bw = sess.run([outputs, state_fw, state_bw],
+                                   feed_dict={inputs[0]: input_value,
+                                              sequence_length: [2, 3]})
+
+      # Since the forward and backward LSTM cells were initialized with the
+      # same parameters, the forward and backward output has to be the same,
+      # but reversed in time. The format is output[time][batch][depth], and
+      # due to depth concatenation (as num_units=3 for both RNNs):
+      # - forward output:  out[][][depth] for 0 <= depth < 3
+      # - backward output: out[][][depth] for 4 <= depth < 6
+      #
+      # First sequence in batch is length=2
+      # Check that the time=0 forward output is equal to time=1 backward output
+      if not use_time_major:
+        out = np.swapaxes(out, 0, 1)
+      self.assertEqual(out[0][0][0], out[1][0][3])
+      self.assertEqual(out[0][0][1], out[1][0][4])
+      self.assertEqual(out[0][0][2], out[1][0][5])
+      # Check that the time=1 forward output is equal to time=0 backward output
+      self.assertEqual(out[1][0][0], out[0][0][3])
+      self.assertEqual(out[1][0][1], out[0][0][4])
+      self.assertEqual(out[1][0][2], out[0][0][5])
+
+      # Second sequence in batch is length=3
+      # Check that the time=0 forward output is equal to time=2 backward output
+      self.assertEqual(out[0][1][0], out[2][1][3])
+      self.assertEqual(out[0][1][1], out[2][1][4])
+      self.assertEqual(out[0][1][2], out[2][1][5])
+      # Check that the time=1 forward output is equal to time=1 backward output
+      self.assertEqual(out[1][1][0], out[1][1][3])
+      self.assertEqual(out[1][1][1], out[1][1][4])
+      self.assertEqual(out[1][1][2], out[1][1][5])
+      # Check that the time=2 forward output is equal to time=0 backward output
+      self.assertEqual(out[2][1][0], out[0][1][3])
+      self.assertEqual(out[2][1][1], out[0][1][4])
+      self.assertEqual(out[2][1][2], out[0][1][5])
+      # Via the reasoning above, the forward and backward final state should be
+      # exactly the same
+      self.assertAllClose(s_fw, s_bw)
+
+  def testBidirectionalDynamicRNN(self):
+    # Generate 2^4 option values
+    # from [True, True, True, True] to [False, False, False, False]
+    options = itertools.product([True, False], repeat=4)
+    for option in options:
+      self._testBidirectionalDynamicRNN(use_gpu=option[0], use_shape=option[1],
+                                       use_state_tuple=option[2],
+                                       use_time_major=option[3])
 
 
 ######### Benchmarking RNN code

--- a/tensorflow/python/kernel_tests/rnn_test.py
+++ b/tensorflow/python/kernel_tests/rnn_test.py
@@ -1154,13 +1154,15 @@ class BidirectionalRNNTest(tf.test.TestCase):
     inputs_c = tf.pack(inputs)
     if not use_time_major:
       inputs_c = tf.transpose(inputs_c, [1, 0, 2])
-    outputs, state_fw, state_bw = tf.nn.bidirectional_dynamic_rnn(
+    outputs, states = tf.nn.bidirectional_dynamic_rnn(
         cell_fw,
         cell_bw,
         inputs_c,
         sequence_length,
         dtype=tf.float32,
         time_major=use_time_major)
+    outputs = tf.concat(2, outputs)
+    state_fw, state_bw = states
     outputs_shape = [None, max_length, 2 * num_units]
     if use_shape:
       outputs_shape[0] = batch_size
@@ -1171,7 +1173,6 @@ class BidirectionalRNNTest(tf.test.TestCase):
         outputs_shape)
 
     input_value = np.random.randn(batch_size, input_size)
-    outputs = tf.pack(outputs)
 
     return input_value, inputs, outputs, state_fw, state_bw, sequence_length
 

--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -523,10 +523,15 @@ def bidirectional_dynamic_rnn(cell_fw, cell_bw, inputs, sequence_length=None,
       outputs: A tuple (output_fw, output_bw) containing the forward and
         the backward rnn output `Tensor`.
         If time_major == False (default),
-          each element will be a `Tensor` shaped:
-          `[batch_size, max_time, cell.output_size]`.
+          output_fw will be a `Tensor` shaped:
+          `[batch_size, max_time, cell_fw.output_size]`
+          and output_bw will be a `Tensor` shaped:
+          `[batch_size, max_time, cell_bw.output_size]`.
         If time_major == True, each element will be a `Tensor` shaped:
-          `[max_time, batch_size, cell.output_size]`.
+          output_fw will be a `Tensor` shaped:
+          `[max_time, batch_size, cell_fw.output_size]`
+          and output_bw will be a `Tensor` shaped:
+          `[max_time, batch_size, cell_bw.output_size]`.
         It returns a tuple instead of a single concatenated `Tensor`, unlike
         in the `bidirectional_rnn`. If the concatenated one is preferred,
         the forward and backward outputs can be concatenated as

--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -527,7 +527,7 @@ def bidirectional_dynamic_rnn(cell_fw, cell_bw, inputs, sequence_length=None,
           `[batch_size, max_time, cell_fw.output_size]`
           and output_bw will be a `Tensor` shaped:
           `[batch_size, max_time, cell_bw.output_size]`.
-        If time_major == True, each element will be a `Tensor` shaped:
+        If time_major == True,
           output_fw will be a `Tensor` shaped:
           `[max_time, batch_size, cell_fw.output_size]`
           and output_bw will be a `Tensor` shaped:

--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -463,6 +463,109 @@ def bidirectional_rnn(cell_fw, cell_bw, inputs,
   return (outputs, output_state_fw, output_state_bw)
 
 
+def bidirectional_dynamic_rnn(cell_fw, cell_bw, inputs, sequence_length=None,
+                              initial_state_fw=None, initial_state_bw=None,
+                              dtype=None, parallel_iterations=None,
+                              swap_memory=False, time_major=False, scope=None):
+  """Creates a bidirectional recurrent neural network, dynamic version.
+
+  Similar to the unidirectional case above (rnn) but takes input and builds
+  independent forward and backward RNNs with the final forward and backward
+  outputs depth-concatenated, such that the output will have the format
+  [time][batch][cell_fw.output_size + cell_bw.output_size]. The input_size of
+  forward and backward cell must match. The initial state for both directions
+  is zero by default (but can be set optionally) and no intermediate states are
+  ever returned -- the network is fully unrolled for the given (passed in)
+  length(s) of the sequence(s) or completely unrolled if length(s) is not given.
+
+  Args:
+    cell_fw: An instance of RNNCell, to be used for forward direction.
+    cell_bw: An instance of RNNCell, to be used for backward direction.
+    inputs: The RNN inputs.
+      If time_major == False (default), this must be a tensor of shape:
+        `[batch_size, max_time, input_size]`.
+      If time_major == True, this must be a tensor of shape:
+        `[max_time, batch_size, input_size]`.
+      [batch_size, input_size].
+    sequence_length: An int32/int64 vector, size `[batch_size]`,
+      containing the actual lengths for each of the sequences.
+    initial_state_fw: (optional) An initial state for the forward RNN.
+      This must be a tensor of appropriate type and shape
+      `[batch_size x cell_fw.state_size]`.
+      If `cell_fw.state_size` is a tuple, this should be a tuple of
+      tensors having shapes `[batch_size, s] for s in cell_fw.state_size`.
+    initial_state_bw: (optional) Same as for `initial_state_fw`, but using
+      the corresponding properties of `cell_bw`.
+    parallel_iterations: (Default: 32).  The number of iterations to run in
+      parallel.  Those operations which do not have any temporal dependency
+      and can be run in parallel, will be.  This parameter trades off
+      time for space.  Values >> 1 use more memory but take less time,
+      while smaller values use less memory but computations take longer.
+    swap_memory: Transparently swap the tensors produced in forward inference
+      but needed for back prop from GPU to CPU.  This allows training RNNs
+      which would typically not fit on a single GPU, with very minimal (or no)
+      performance penalty.
+    time_major: The shape format of the `inputs` and `outputs` Tensors.
+      If true, these `Tensors` must be shaped `[max_time, batch_size, depth]`.
+      If false, these `Tensors` must be shaped `[batch_size, max_time, depth]`.
+      Using `time_major = True` is a bit more efficient because it avoids
+      transposes at the beginning and end of the RNN calculation.  However,
+      most TensorFlow data is batch-major, so by default this function
+      accepts input and emits output in batch-major form.
+    dtype: (optional) The data type for the initial state.  Required if
+      initial_state is not provided.
+    sequence_length: An int32/int64 vector, size `[batch_size]`,
+      containing the actual lengths for each of the sequences.
+      either of the initial states are not provided.
+    scope: VariableScope for the created subgraph; defaults to "BiRNN"
+
+  Returns:
+    A tuple (outputs, output_state_fw, output_state_bw) where:
+      outputs: The RNN output `Tensor`.
+        If time_major == False (default), this will be a `Tensor` shaped:
+          `[batch_size, max_time, cell.output_size]`.
+        If time_major == True, this will be a `Tensor` shaped:
+          `[max_time, batch_size, cell.output_size]`.
+      output_state_fw is the final state of the forward rnn.
+      output_state_bw is the final state of the backward rnn.
+
+  Raises:
+    TypeError: If `cell_fw` or `cell_bw` is not an instance of `RNNCell`.
+    ValueError: If inputs is None or an empty list.
+  """
+
+  if not isinstance(cell_fw, rnn_cell.RNNCell):
+    raise TypeError("cell_fw must be an instance of RNNCell")
+  if not isinstance(cell_bw, rnn_cell.RNNCell):
+    raise TypeError("cell_bw must be an instance of RNNCell")
+
+  name = scope or "BiRNN"
+  # Forward direction
+  with vs.variable_scope(name + "_FW") as fw_scope:
+    output_fw, output_state_fw = dynamic_rnn(
+        cell_fw, inputs, sequence_length, initial_state_fw, dtype,
+        parallel_iterations, swap_memory, time_major, scope=fw_scope)
+  # Backward direction
+  if not time_major:
+    time_dim = 1
+    batch_dim = 0
+  else:
+    time_dim = 0
+    batch_dim = 1
+  with vs.variable_scope(name + "_BW") as bw_scope:
+    inputs_reverse = array_ops.reverse_sequence(
+        inputs, sequence_length, time_dim, batch_dim)
+    tmp, output_state_bw = dynamic_rnn(
+        cell_bw, inputs_reverse, sequence_length, initial_state_bw, dtype,
+        parallel_iterations, swap_memory, time_major, scope=bw_scope)
+  output_bw = array_ops.reverse_sequence(
+      tmp, sequence_length, time_dim, batch_dim)
+  # Concat each of the forward/backward outputs
+  outputs = array_ops.concat(2, [output_fw, output_bw])
+
+  return (outputs, output_state_fw, output_state_bw)
+
+
 def dynamic_rnn(cell, inputs, sequence_length=None, initial_state=None,
                 dtype=None, parallel_iterations=None, swap_memory=False,
                 time_major=False, scope=None):


### PR DESCRIPTION
In #1779, it seems that the problem of implementing bidirectional version of `dynamic_rnn` is that `tf.reverse_sequence` cannot reverse a sequence whose shape is unknown.
However, now it can reverse an unknown-shaped sequence according to #1816, so I implemented the dynamic version of `dynamic_rnn` and its tests.
