### PR TITLE
Cherry-pick internal change: Reduce computation load in metric_ops_test to prevent timeout

### DIFF
--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -665,7 +665,7 @@ class StreamingAUCTest(tf.test.TestCase):
     return np.sum(tp[labels == 0] / num_negatives)
 
   def testWithMultipleUpdates(self):
-    num_samples = 5000
+    num_samples = 1000
     batch_size = 10
     num_batches = int(num_samples / batch_size)
 
@@ -904,7 +904,7 @@ class StreamingPrecisionRecallThresholdsTest(tf.test.TestCase):
       self.assertAlmostEqual(0, rec.eval(), 6)
 
   def testWithMultipleUpdates(self):
-    num_samples = 5000
+    num_samples = 1000
     batch_size = 10
     num_batches = num_samples / batch_size
 


### PR DESCRIPTION
The test methods named "testWithMultipleUpdates" in test classes "StreamingAUCTest and "StreamingPrecisionRecallThresholdsTest" previously used a large number of samples (5000), which lead to repeated test timeouts in non-copt builds in TensorFlow's OSS Jenkins. For example, see:
http://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_CONTAINER_TYPE=CPU,TF_BUILD_IS_OPT=NO_OPT,TF_BUILD_IS_PIP=NO_PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/111/console

Our Jenkins slaves are known to be substantially slower than the internal build machines.

This CL reduces the compute load in these two test methods. The average non-copt test time of metric_ops_test
Without this CL: ~175 s
With this CL: ~54 s
Change: 123628402
