### PR TITLE
Enable tf.rank() for SparseTensor

### DIFF
--- a/tensorflow/python/kernel_tests/shape_ops_test.py
+++ b/tensorflow/python/kernel_tests/shape_ops_test.py
@@ -65,8 +65,7 @@ class ShapeOpsTest(tf.test.TestCase):
     self.assertAllEqual(np_ans, result)
     self.assertShapeEqual(np_ans, tf_ans)
 
-  def _compareRankSparse(self, x_shape, use_gpu=False):
-    x_np = np.random.randn(*x_shape)
+  def _compareRankSparse(self, x_np, use_gpu=False):
     np_ans = np.asarray(np.ndim(x_np))
     x_tf, nnz = _sparsify(x_np)
     with self.test_session(use_gpu=use_gpu):
@@ -88,38 +87,26 @@ class ShapeOpsTest(tf.test.TestCase):
     self._compareShapeN(x, use_gpu=False)
     self._compareRank(x, use_gpu=False)
     self._compareSize(x, use_gpu=False)
-
-  def _testCpuSparse(self, x_shape):
-    self._compareRankSparse(x_shape, use_gpu=False)
+    self._compareRankSparse(x, use_gpu=False)
 
   def _testGpu(self, x):
     self._compareShape(x, use_gpu=True)
     self._compareShapeN(x, use_gpu=True)
     self._compareRank(x, use_gpu=True)
     self._compareSize(x, use_gpu=True)
+    self._compareRankSparse(x, use_gpu=True)
 
   def _testAll(self, x):
     self._testCpu(x)
     self._testGpu(x)
 
-  def _testAllSparse(self, x_shape):
-    self._testCpuSparse(x_shape)
-
   def testBasic(self):
-    self._testAll(np.zeros([2]))
-    self._testAll(np.zeros([2, 3]))
-    self._testAll(np.zeros([2, 3, 5]))
-    self._testAll(np.zeros([2, 3, 5, 7]))
-    self._testAll(np.zeros([2, 3, 5, 7, 11]))
-    self._testAll(np.zeros([2, 3, 5, 7, 11, 13]))
-
-  def testBasicSparse(self):
-    self._testAllSparse([2])
-    self._testAllSparse([2, 3])
-    self._testAllSparse([2, 3, 5])
-    self._testAllSparse([2, 3, 5, 7])
-    self._testAllSparse([2, 3, 5, 7, 11])
-    self._testAllSparse([2, 3, 5, 7, 11, 13])
+    self._testAll(np.random.randn(2))
+    self._testAll(np.random.randn(2, 3))
+    self._testAll(np.random.randn(2, 3, 5))
+    self._testAll(np.random.randn(2, 3, 5, 7))
+    self._testAll(np.random.randn(2, 3, 5, 7, 11))
+    self._testAll(np.random.randn(2, 3, 5, 7, 11, 13))
 
   def _compareExpandDims(self, x, dim, use_gpu):
     np_ans = np.expand_dims(x, axis=dim)

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -106,7 +106,7 @@ def rank(input, name=None):
 
   For example:
 
-  ```prettyprint
+  ```python
   # 't' is [[[1, 1, 1], [2, 2, 2]], [[3, 3, 3], [4, 4, 4]]]
   # shape of tensor 't' is [2, 2, 3]
   rank(t) ==> 3
@@ -125,9 +125,9 @@ def rank(input, name=None):
   """
   with ops.op_scope([input], name, "Rank") as name:
     if isinstance(input, ops.SparseTensor):
-      return gen_array_ops.size(input.shape)
+      return gen_array_ops.size(input.shape, name=name)
     else:
-      return gen_array_ops.rank(input)
+      return gen_array_ops.rank(input, name=name)
 
 # DEPRECATED use init_ops.zeros_initializer
 # TODO(irving) Move it to init_ops.py

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -100,19 +100,34 @@ listdiff = gen_array_ops.list_diff
 
 
 def rank(input, name=None):
-  """Override for gen_array_ops.rank(), making it work for SparseTensor.
+  """Returns the rank of a tensor.
+
+  This operation returns an integer representing the rank of `input`.
+
+  For example:
+
+  ```prettyprint
+  # 't' is [[[1, 1, 1], [2, 2, 2]], [[3, 3, 3], [4, 4, 4]]]
+  # shape of tensor 't' is [2, 2, 3]
+  rank(t) ==> 3
+  ```
+
+  **Note**: The rank of a tensor is not the same as the rank of a matrix. The
+  rank of a tensor is the number of indices required to uniquely select each
+  element of the tensor. Rank is also known as "order", "degree", or "ndims."
 
   Args:
-    input: A `Tensor` or `SparseTensor` object.
+    input: A `Tensor` or `SparseTensor`.
     name: A name for the operation (optional).
 
   Returns:
     A `Tensor` of type `int32`.
   """
-  if isinstance(input, ops.SparseTensor):
-    return size(input.shape)
-  else:
-    return gen_array_ops.rank(input)
+  with ops.op_scope([input], name, "Rank") as name:
+    if isinstance(input, ops.SparseTensor):
+      return gen_array_ops.size(input.shape)
+    else:
+      return gen_array_ops.rank(input)
 
 # DEPRECATED use init_ops.zeros_initializer
 # TODO(irving) Move it to init_ops.py

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -99,6 +99,21 @@ _baseslice = slice
 listdiff = gen_array_ops.list_diff
 
 
+def rank(input, name=None):
+  """Override for gen_array_ops.rank(), making it work for SparseTensor.
+
+  Args:
+    input: A `Tensor` or `SparseTensor` object.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of type `int32`.
+  """
+  if isinstance(input, ops.SparseTensor):
+    return size(input.shape)
+  else:
+    return gen_array_ops.rank(input)
+
 # DEPRECATED use init_ops.zeros_initializer
 # TODO(irving) Move it to init_ops.py
 def zeros_initializer(shape, dtype=dtypes.float32):


### PR DESCRIPTION
Added an override for `tf.rank()`, that takes care of `SparseTensor` objects as well. Added tests and verified locally. This partially addresses #1968.
