### PR TITLE
Work on strings instead of binary in Python3

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -51,7 +51,7 @@ filename = maybe_download('text8.zip', 31344016)
 def read_data(filename):
   """Extract the first file enclosed in a zip file as a list of words"""
   with zipfile.ZipFile(filename) as f:
-    data = f.read(f.namelist()[0]).split()
+    data = tf.compat.as_str(f.read(f.namelist()[0])).split()
   return data
 
 words = read_data(filename)


### PR DESCRIPTION
Running word2vec_basic on Python3 gives silly byte-ish output since it reads the sentences as binary:

```
$ python3 word2vec_basic.py 
Found and verified text8.zip
Data size 17005207
Most common words (+UNK) [['UNK', 418391], (b'the', 1061396), (b'of', 593677), (b'and', 416629), (b'one', 411764)]
Sample data [5237, 3084, 12, 6, 195, 2, 3137, 46, 59, 156] [b'anarchism', b'originated', b'as', b'a', b'term', b'of', b'abuse', b'first', b'used', b'against']
3084 b'originated' -> 12 b'as'
3084 b'originated' -> 5237 b'anarchism'
12 b'as' -> 3084 b'originated'
12 b'as' -> 6 b'a'
6 b'a' -> 12 b'as'
6 b'a' -> 195 b'term'
195 b'term' -> 2 b'of'
195 b'term' -> 6 b'a'
```

... etc.

This patch uses the 'compat' to_str() as a sane way to read the text in either Pyhton 2.x or 3.x.
