### PR TITLE
bug fix in ApplyAdadelta update rule

### DIFF
--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -47,7 +47,9 @@ struct ApplyAdadelta<CPUDevice, T> {
                   typename TTypes<T>::ConstFlat grad) {
     accum.device(d) =
         accum * rho() + grad.square() * (static_cast<T>(1) - rho());
-    const auto update = accum_update * (accum + epsilon()).rsqrt() * grad;
+    const auto update = 
+	(accum_update + epsilon()).sqrt() *
+	(accum + epsilon()).rsqrt() * grad;
     accum_update.device(d) =
         accum_update * rho() + update.square() * (static_cast<T>(1) - rho());
     var.device(d) -= update * lr();

--- a/tensorflow/python/training/adadelta_test.py
+++ b/tensorflow/python/training/adadelta_test.py
@@ -20,104 +20,90 @@ from __future__ import print_function
 import tensorflow.python.platform
 
 import numpy as np
-from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
-
 class AdadeltaOptimizerTest(tf.test.TestCase):
-
   def testBasic(self):
+    num_updates = 4 # number of ADADELTA steps to perform
     for dtype in [tf.half, tf.float32]:
-      with self.test_session():
-        var0 = tf.Variable([1.0, 2.0], dtype=dtype)
-        var1 = tf.Variable([3.0, 4.0], dtype=dtype)
-        grads0 = tf.constant([0.1, 0.1], dtype=dtype)
-        grads1 = tf.constant([0.01, 0.01], dtype=dtype)
-        lr = 1.0
-        rho = 0.95
-        epsilon = 1e-8
+        for grad in [0.2, 0.1, 0.01]:
+            for lr in [1.0, 0.5, 0.1]:
+              with self.test_session():
+                var0_init = [1.0, 2.0]
+                var1_init = [3.0, 4.0]
+                var0 = tf.Variable(var0_init, dtype=dtype)
+                var1 = tf.Variable(var1_init, dtype=dtype)
 
-        adadelta_opt = tf.train.AdadeltaOptimizer(lr, rho=rho, epsilon=epsilon)
-        adadelta_update = adadelta_opt.apply_gradients(zip(
-            [grads0, grads1], [var0, var1]))
-        tf.initialize_all_variables().run()
+                grads = tf.constant([grad, grad], dtype=dtype)
 
-        # Check we have slots
-        self.assertEqual(["accum", "accum_update"],
-                         adadelta_opt.get_slot_names())
-        slot0 = adadelta_opt.get_slot(var0, "accum")
-        self.assertEquals(slot0.get_shape(), var0.get_shape())
-        self.assertFalse(slot0 in tf.trainable_variables())
+                accum = 0.0
+                accum_update = 0.0
 
-        slot0_update = adadelta_opt.get_slot(var0, "accum_update")
-        self.assertEquals(slot0_update.get_shape(), var0.get_shape())
-        self.assertFalse(slot0_update in tf.trainable_variables())
+                # ADADELTA gradient optimizer
+                rho = 0.95
+                epsilon = 1e-8
+                adadelta_opt = tf.train.AdadeltaOptimizer(lr, rho, epsilon)
+                adadelta_update = adadelta_opt.apply_gradients(zip(
+                    [grads, grads], [var0, var1]))
 
-        slot1 = adadelta_opt.get_slot(var1, "accum")
-        self.assertEquals(slot1.get_shape(), var1.get_shape())
-        self.assertFalse(slot1 in tf.trainable_variables())
+                tf.initialize_all_variables().run()
 
-        slot1_update = adadelta_opt.get_slot(var1, "accum_update")
-        self.assertEquals(slot1_update.get_shape(), var1.get_shape())
-        self.assertFalse(slot1_update in tf.trainable_variables())
+                # Assign slots
+                slot = [None]*2
+                slot_update = [None]*2
+                self.assertEqual(["accum", "accum_update"],
+                                 adadelta_opt.get_slot_names())
+                slot[0] = adadelta_opt.get_slot(var0, "accum")
+                self.assertEquals(slot[0].get_shape(), var0.get_shape())
+                self.assertFalse(slot[0] in tf.trainable_variables())
 
-        # Fetch params to validate initial values
-        self.assertAllClose([1.0, 2.0], var0.eval())
-        self.assertAllClose([3.0, 4.0], var1.eval())
+                slot_update[0] = adadelta_opt.get_slot(var0, "accum_update")
+                self.assertEquals(slot_update[0].get_shape(), var0.get_shape())
+                self.assertFalse(slot_update[0] in tf.trainable_variables())
 
-        adadelta_update.run()
+                slot[1] = adadelta_opt.get_slot(var1, "accum")
+                self.assertEquals(slot[1].get_shape(), var1.get_shape())
+                self.assertFalse(slot[1] in tf.trainable_variables())
 
-        # Check that the accumulators have been updated.
-        grad = 0.1
-        accum = 0
-        accum_update = 0
+                slot_update[1] = adadelta_opt.get_slot(var1, "accum_update")
+                self.assertEquals(slot_update[1].get_shape(), var1.get_shape())
+                self.assertFalse(slot_update[1] in tf.trainable_variables())
 
-        accum = accum * rho + (grad**2) * (1 - rho)
-        update1 = np.sqrt(accum_update + epsilon) * (
-            1. / np.sqrt(accum + epsilon)) * grad
-        accum_update = accum_update * rho + (update1**2) * (1.0 - rho)
+                # Fetch params to validate initial values
+                self.assertAllClose(var0_init, var0.eval())
+                self.assertAllClose(var1_init, var1.eval())
 
-        self.assertAllCloseAccordingToType(
-            np.array([accum, accum]), slot0.eval())
-        self.assertAllCloseAccordingToType(
-            np.array([accum_update, accum_update]), slot0_update.eval())
+                update = [None]*num_updates
+                tot_update = 0
+                for run_no in range(num_updates):
+                    # Run adadelta update for comparison
+                    adadelta_update.run()
 
-        # Check that the parameters have been updated.
-        self.assertAllCloseAccordingToType(
-            np.array([1.0 - update1 * lr, 2.0 - update1 * lr]),
-            var0.eval(),
-            rtol=1e-3)
+                    # Perform initial update without previous accum values
+                    accum = accum * rho + (grad**2) * (1 - rho)
+                    update[run_no] = (np.sqrt(accum_update + epsilon) *
+                        (1. / np.sqrt(accum + epsilon)) * grad)
+                    accum_update = accum_update * rho + (update[run_no]**2) * (1.0 - rho)
+                    tot_update += update[run_no] * lr
 
-        self.assertAllCloseAccordingToType(
-            np.array([3.0 - update1 * lr, 4.0 - update1 * lr]),
-            var1.eval(),
-            rtol=1e-3)
+                    # Check that the accumulators have been updated
+                    for slot_idx in range(2):
+                        self.assertAllCloseAccordingToType(
+                            np.array([accum, accum], dtype=dtype.as_numpy_dtype()),
+                            slot[slot_idx].eval())
 
-        # Step 2: the momentum accumulators contain the previous update.
-        accum = accum * rho + (grad**2) * (1 - rho)
-        update2 = ((accum_update + epsilon)**0.5 *
-                   (1. / (accum + epsilon)**0.5) * grad)
-        accum_update = accum_update * rho + (update2**2) * (1.0 - rho)
+                        self.assertAllCloseAccordingToType(
+                            np.array([accum_update, accum_update], dtype=dtype.as_numpy_dtype()),
+                            slot_update[slot_idx].eval())
 
-        adadelta_update.run()
+                    # Check that the parameters have been updated
+                    self.assertAllCloseAccordingToType(
+                        np.array([var0_init[0] - tot_update, var0_init[1] - tot_update],
+                        dtype=dtype.as_numpy_dtype()), var0.eval(), rtol=1e-3)
 
-        # Check that the momentum accumulators have been updated.
-        self.assertAllCloseAccordingToType(
-            np.array([accum, accum]), slot0.eval())
-        self.assertAllCloseAccordingToType(
-            np.array([accum_update, accum_update]), slot0_update.eval())
-
-        # Check that the parameters have been updated.
-        self.assertAllCloseAccordingToType(
-            np.array([1.0 - update1 - update2, 2.0 - update1 - update2]),
-            var0.eval(),
-            rtol=1e-3)
-
-        self.assertAllCloseAccordingToType(
-            np.array([3.0 - update1 - update2, 4.0 - update1 - update2]),
-            var1.eval(),
-            rtol=1e-3)
-
+                    self.assertAllCloseAccordingToType(
+                        np.array([var1_init[0] - tot_update, var1_init[1] - tot_update],
+                        dtype=dtype.as_numpy_dtype()), var1.eval(), rtol=1e-3)
 
 if __name__ == "__main__":
   tf.test.main()

--- a/tensorflow/python/training/adadelta_test.py
+++ b/tensorflow/python/training/adadelta_test.py
@@ -26,84 +26,88 @@ class AdadeltaOptimizerTest(tf.test.TestCase):
   def testBasic(self):
     num_updates = 4 # number of ADADELTA steps to perform
     for dtype in [tf.half, tf.float32]:
-        for grad in [0.2, 0.1, 0.01]:
-            for lr in [1.0, 0.5, 0.1]:
-              with self.test_session():
-                var0_init = [1.0, 2.0]
-                var1_init = [3.0, 4.0]
-                var0 = tf.Variable(var0_init, dtype=dtype)
-                var1 = tf.Variable(var1_init, dtype=dtype)
+      for grad in [0.2, 0.1, 0.01]:
+        for lr in [1.0, 0.5, 0.1]:
+          with self.test_session():
+            var0_init = [1.0, 2.0]
+            var1_init = [3.0, 4.0]
+            var0 = tf.Variable(var0_init, dtype=dtype)
+            var1 = tf.Variable(var1_init, dtype=dtype)
 
-                grads = tf.constant([grad, grad], dtype=dtype)
+            grads = tf.constant([grad, grad], dtype=dtype)
 
-                accum = 0.0
-                accum_update = 0.0
+            accum = 0.0
+            accum_update = 0.0
 
-                # ADADELTA gradient optimizer
-                rho = 0.95
-                epsilon = 1e-8
-                adadelta_opt = tf.train.AdadeltaOptimizer(lr, rho, epsilon)
-                adadelta_update = adadelta_opt.apply_gradients(zip(
-                    [grads, grads], [var0, var1]))
+            # ADADELTA gradient optimizer
+            rho = 0.95
+            epsilon = 1e-8
+            adadelta_opt = tf.train.AdadeltaOptimizer(lr, rho, epsilon)
+            adadelta_update = adadelta_opt.apply_gradients(zip(
+              [grads, grads], [var0, var1]))
 
-                tf.initialize_all_variables().run()
+            tf.initialize_all_variables().run()
 
-                # Assign slots
-                slot = [None]*2
-                slot_update = [None]*2
-                self.assertEqual(["accum", "accum_update"],
-                                 adadelta_opt.get_slot_names())
-                slot[0] = adadelta_opt.get_slot(var0, "accum")
-                self.assertEquals(slot[0].get_shape(), var0.get_shape())
-                self.assertFalse(slot[0] in tf.trainable_variables())
+            # Assign slots
+            slot = [None] * 2
+            slot_update = [None] * 2
+            self.assertEqual(["accum", "accum_update"],
+              adadelta_opt.get_slot_names())
+            slot[0] = adadelta_opt.get_slot(var0, "accum")
+            self.assertEquals(slot[0].get_shape(), var0.get_shape())
+            self.assertFalse(slot[0] in tf.trainable_variables())
 
-                slot_update[0] = adadelta_opt.get_slot(var0, "accum_update")
-                self.assertEquals(slot_update[0].get_shape(), var0.get_shape())
-                self.assertFalse(slot_update[0] in tf.trainable_variables())
+            slot_update[0] = adadelta_opt.get_slot(var0, "accum_update")
+            self.assertEquals(slot_update[0].get_shape(), var0.get_shape())
+            self.assertFalse(slot_update[0] in tf.trainable_variables())
 
-                slot[1] = adadelta_opt.get_slot(var1, "accum")
-                self.assertEquals(slot[1].get_shape(), var1.get_shape())
-                self.assertFalse(slot[1] in tf.trainable_variables())
+            slot[1] = adadelta_opt.get_slot(var1, "accum")
+            self.assertEquals(slot[1].get_shape(), var1.get_shape())
+            self.assertFalse(slot[1] in tf.trainable_variables())
 
-                slot_update[1] = adadelta_opt.get_slot(var1, "accum_update")
-                self.assertEquals(slot_update[1].get_shape(), var1.get_shape())
-                self.assertFalse(slot_update[1] in tf.trainable_variables())
+            slot_update[1] = adadelta_opt.get_slot(var1, "accum_update")
+            self.assertEquals(slot_update[1].get_shape(), var1.get_shape())
+            self.assertFalse(slot_update[1] in tf.trainable_variables())
 
-                # Fetch params to validate initial values
-                self.assertAllClose(var0_init, var0.eval())
-                self.assertAllClose(var1_init, var1.eval())
+            # Fetch params to validate initial values
+            self.assertAllClose(var0_init, var0.eval())
+            self.assertAllClose(var1_init, var1.eval())
 
-                update = [None]*num_updates
-                tot_update = 0
-                for run_no in range(num_updates):
-                    # Run adadelta update for comparison
-                    adadelta_update.run()
+            update = [None] * num_updates
+            tot_update = 0
+            for step in range(num_updates):
+              # Run adadelta update for comparison
+              adadelta_update.run()
 
-                    # Perform initial update without previous accum values
-                    accum = accum * rho + (grad**2) * (1 - rho)
-                    update[run_no] = (np.sqrt(accum_update + epsilon) *
-                        (1. / np.sqrt(accum + epsilon)) * grad)
-                    accum_update = accum_update * rho + (update[run_no]**2) * (1.0 - rho)
-                    tot_update += update[run_no] * lr
+              # Perform initial update without previous accum values
+              accum = accum * rho + (grad**2) * (1 - rho)
+              update[step] = (np.sqrt(accum_update + epsilon) *
+                (1. / np.sqrt(accum + epsilon)) * grad)
+              accum_update = (accum_update * rho + (update[step]**2) *
+                (1.0 - rho))
+              tot_update += update[step] * lr
 
-                    # Check that the accumulators have been updated
-                    for slot_idx in range(2):
-                        self.assertAllCloseAccordingToType(
-                            np.array([accum, accum], dtype=dtype.as_numpy_dtype()),
-                            slot[slot_idx].eval())
+              # Check that the accumulators have been updated
+              for slot_idx in range(2):
+                self.assertAllCloseAccordingToType(
+                  np.array([accum, accum], dtype=dtype.as_numpy_dtype()),
+                  slot[slot_idx].eval())
 
-                        self.assertAllCloseAccordingToType(
-                            np.array([accum_update, accum_update], dtype=dtype.as_numpy_dtype()),
-                            slot_update[slot_idx].eval())
+                self.assertAllCloseAccordingToType(
+                  np.array([accum_update, accum_update],
+                  dtype=dtype.as_numpy_dtype()),
+                  slot_update[slot_idx].eval())
 
-                    # Check that the parameters have been updated
-                    self.assertAllCloseAccordingToType(
-                        np.array([var0_init[0] - tot_update, var0_init[1] - tot_update],
-                        dtype=dtype.as_numpy_dtype()), var0.eval(), rtol=1e-3)
+              # Check that the parameters have been updated
+              self.assertAllCloseAccordingToType(
+                np.array([var0_init[0] - tot_update,
+                var0_init[1] - tot_update], dtype=dtype.as_numpy_dtype()),
+                var0.eval(), rtol=1e-3)
 
-                    self.assertAllCloseAccordingToType(
-                        np.array([var1_init[0] - tot_update, var1_init[1] - tot_update],
-                        dtype=dtype.as_numpy_dtype()), var1.eval(), rtol=1e-3)
+              self.assertAllCloseAccordingToType(
+                np.array([var1_init[0] - tot_update,
+                var1_init[1] - tot_update], dtype=dtype.as_numpy_dtype()),
+                var1.eval(), rtol=1e-3)
 
 if __name__ == "__main__":
   tf.test.main()


### PR DESCRIPTION
Following the Zeiler ADADELTA paper, numerator of update equation
should be RMS(accum_update) \* grad
