### PR TITLE
Fix gradient of complex op when broadcasting

### DIFF
--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -1655,10 +1655,25 @@ class ComplexMakeRealImagTest(tf.test.TestCase):
                                                   delta=epsilon)
     self.assertAllClose(jacob_t, jacob_n, rtol=epsilon, atol=epsilon)
 
+  def _compareBroadcastGradient(self, x):
+    x_ = tf.convert_to_tensor(x)
+    epsilon = 1e-3
+    with self.test_session():
+      for args in [(x_, 0.), (0., x_)]:
+          z = tf.reduce_sum(tf.complex_abs(tf.complex(*args)))
+          jacob_t, jacob_n = tf.test.compute_gradient(x_,
+                                                      list(x.shape),
+                                                      z,
+                                                      [1],
+                                                      x_init_value=x,
+                                                      delta=epsilon)
+          self.assertAllClose(jacob_t, jacob_n, rtol=epsilon, atol=epsilon)
+
   def testGradient(self):
     # complex64
     data = np.arange(1, 2, 0.10).reshape([5, 2]).astype(np.float32)
     self._compareGradient(data)
+    self._compareBroadcastGradient(data)
     # complex128
     data = np.arange(1, 2, 0.10).reshape([5, 2]).astype(np.float64)
     self._compareGradient(data)

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -681,9 +681,15 @@ ops.NoGradient("LinSpace")
 
 
 @ops.RegisterGradient("Complex")
-def _ComplexGrad(_, grad):
+def _ComplexGrad(op, grad):
   """Returns the real and imaginary components of 'grad', respectively."""
-  return math_ops.real(grad), math_ops.imag(grad)
+  x = op.inputs[0]
+  y = op.inputs[1]
+  sx = array_ops.shape(x)
+  sy = array_ops.shape(y)
+  rx, ry = gen_array_ops._broadcast_gradient_args(sx, sy)
+  return (array_ops.reshape(math_ops.reduce_sum(math_ops.real(grad), rx), sx),
+          array_ops.reshape(math_ops.reduce_sum(math_ops.imag(grad), ry), sy))
 
 
 @ops.RegisterGradient("Real")


### PR DESCRIPTION
The gradient of the complex op didn't take into account that it can broadcast its parameters.
I've also added a test that should check this in the future.
This fixes #2627.
