### PR TITLE
Enable tf.shape() for SparseTensor

### DIFF
--- a/tensorflow/python/kernel_tests/shape_ops_test.py
+++ b/tensorflow/python/kernel_tests/shape_ops_test.py
@@ -50,7 +50,7 @@ class ShapeOpsTest(tf.test.TestCase):
 
   def _compareShapeSparse(self, x_np, use_gpu=False):
     np_ans = np.array(np.shape(x_np))
-    x_tf, nnz = _sparsify(x_np)
+    x_tf, unused_nnz = _sparsify(x_np)
     with self.test_session(use_gpu=use_gpu):
       tf_ans = tf.shape(x_tf)
       result = tf_ans.eval()
@@ -76,7 +76,7 @@ class ShapeOpsTest(tf.test.TestCase):
 
   def _compareRankSparse(self, x_np, use_gpu=False):
     np_ans = np.asarray(np.ndim(x_np))
-    x_tf, nnz = _sparsify(x_np)
+    x_tf, unused_nnz = _sparsify(x_np)
     with self.test_session(use_gpu=use_gpu):
       tf_ans = tf.rank(x_tf)
       result = tf_ans.eval()

--- a/tensorflow/python/kernel_tests/shape_ops_test.py
+++ b/tensorflow/python/kernel_tests/shape_ops_test.py
@@ -48,6 +48,15 @@ class ShapeOpsTest(tf.test.TestCase):
     self.assertAllEqual(np_ans, result)
     self.assertShapeEqual(np_ans, tf_ans)
 
+  def _compareShapeSparse(self, x_np, use_gpu=False):
+    np_ans = np.array(np.shape(x_np))
+    x_tf, nnz = _sparsify(x_np)
+    with self.test_session(use_gpu=use_gpu):
+      tf_ans = tf.shape(x_tf)
+      result = tf_ans.eval()
+    self.assertAllEqual(np_ans, result)
+    self.assertShapeEqual(np_ans, tf_ans)
+
   def _compareShapeN(self, x, use_gpu=False):
     np_ans = np.array(np.shape(x))
     with self.test_session(use_gpu=use_gpu) as sess:
@@ -87,6 +96,7 @@ class ShapeOpsTest(tf.test.TestCase):
     self._compareShapeN(x, use_gpu=False)
     self._compareRank(x, use_gpu=False)
     self._compareSize(x, use_gpu=False)
+    self._compareShapeSparse(x, use_gpu=False)
     self._compareRankSparse(x, use_gpu=False)
 
   def _testGpu(self, x):
@@ -94,6 +104,7 @@ class ShapeOpsTest(tf.test.TestCase):
     self._compareShapeN(x, use_gpu=True)
     self._compareRank(x, use_gpu=True)
     self._compareSize(x, use_gpu=True)
+    self._compareShapeSparse(x, use_gpu=True)
     self._compareRankSparse(x, use_gpu=True)
 
   def _testAll(self, x):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -100,6 +100,31 @@ _baseslice = slice
 listdiff = gen_array_ops.list_diff
 
 
+def shape(input, name=None):
+  """Returns the shape of a tensor.
+
+  This operation returns a 1-D integer tensor representing the shape of `input`.
+
+  For example:
+
+  ```python
+  # 't' is [[[1, 1, 1], [2, 2, 2]], [[3, 3, 3], [4, 4, 4]]]
+  shape(t) ==> [2, 2, 3]
+  ```
+
+  Args:
+    input: A `Tensor` or `SparseTensor`.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of type `int32`.
+  """
+  with ops.op_scope([input], name, "Shape") as name:
+    if isinstance(input, ops.SparseTensor):
+      return input.shape
+    else:
+      return gen_array_ops.shape(input, name=name)
+
 def rank(input, name=None):
   """Returns the rank of a tensor.
 


### PR DESCRIPTION
Added an override for `tf.shape()`, that takes care of `SparseTensor` objects as well. Added tests and verified locally. This partially addresses #1968.
