### PR TITLE
Add a method to remove entries from registry.

### DIFF
--- a/tensorflow/python/framework/registry.py
+++ b/tensorflow/python/framework/registry.py
@@ -83,3 +83,12 @@ class Registry(object):
     else:
       raise LookupError(
           "%s registry has no entry for: %s" % (self._name, name))
+
+  def unregister(self, name):
+    """Removes registration for the given "name" if one exists.
+
+    Args:
+      name: string specifying registry key to delete.
+    """
+    if name in self._registry:
+      del self._registry[name]


### PR DESCRIPTION
I'm using this to remove incompatible shape functions from the registry to make "immediate" tensors work as a drop-in replacement for regular TensorFlow tensors.

Since "static shape inference" doesn't make sense for persistent tensors, I'm returning Dimension(None) for the shape for such tensors. But, there's at least one shape function which doesn't allow `Dimension(None)` -- (`_ReverseShape(op):`), so as a work-around, I'm using `unregister followed by`register(None)` 

@mrry 
