### PR TITLE
Mention fix for building on 16.04 in Troubleshooting

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -891,6 +891,9 @@ SyntaxError: invalid syntax
 
 Solution: make sure you are using Python 2.7.
 
+If you are using Ubuntu 16.04, you need to patch in pull request #2073 to solve `error: 'memcpy' was not declared in this scope` problem
+
+
 ### Mac OS X: ImportError: No module named copyreg
 
 On Mac OS X, you may encounter the following when importing tensorflow.


### PR DESCRIPTION
I ended up using @fayeshine fix from https://github.com/tensorflow/tensorflow/pull/2073 to get tensorflow building on Ubuntu 16.04, add a mention to this work-around under "Linux Issues"
