### PR TITLE
Remove sudo in virtualenv during installation

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -182,10 +182,10 @@ Finally install TensorFlow:
 
 ```bash
 # Python 2
-(tensorflow)$ sudo pip install --upgrade $TF_BINARY_URL
+(tensorflow)$ pip install --upgrade $TF_BINARY_URL
 
 # Python 3
-(tensorflow)$ sudo pip3 install --upgrade $TF_BINARY_URL
+(tensorflow)$ pip3 install --upgrade $TF_BINARY_URL
 ```
 
 With the Virtualenv environment activated, you can now
@@ -289,10 +289,10 @@ Finally install TensorFlow:
 
 ```bash
 # Python 2
-(tensorflow)$ sudo pip install --upgrade $TF_BINARY_URL
+(tensorflow)$ pip install --upgrade $TF_BINARY_URL
 
 # Python 3
-(tensorflow)$ sudo pip3 install --upgrade $TF_BINARY_URL
+(tensorflow)$ pip3 install --upgrade $TF_BINARY_URL
 ```
 
 With the conda environment activated, you can now


### PR DESCRIPTION
In r0.8 and r0.7, installation inside virtualenv did not need sudo.  Sudo appears in r0.9 document.  It seems a copy-and-paste typo.
