### PR TITLE
Use -DGPR_BACKWARDS_COMPATIBILITY_MODE in gRPC.

### DIFF
--- a/grpc.BUILD
+++ b/grpc.BUILD
@@ -145,6 +145,12 @@ cc_library(
     "include",
     ".",
   ],
+  defines = [
+    "GPR_BACKWARDS_COMPATIBILITY_MODE",
+  ],
+  copts = [
+    "-std=c99",
+  ],
   deps = [
   ],
 )


### PR DESCRIPTION
This avoids using `secure_getenv()`, which prevents building on
operating systems with a GLIBC < 2.17.
