### PR TITLE
Add cumsum and cumprod ops

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -1060,6 +1060,7 @@ tf_kernel_libraries(
         "matmul_op",
         "reduction_ops",
         "segment_reduction_ops",
+        "scan_ops",
         "sequence_ops",
         "sparse_matmul_op",
     ],

--- a/tensorflow/core/kernels/scan_ops.cc
+++ b/tensorflow/core/kernels/scan_ops.cc
@@ -1,0 +1,175 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#define EIGEN_USE_THREADS
+#if GOOGLE_CUDA
+#define EIGEN_USE_GPU
+#endif  // GOOGLE_CUDA
+
+#include "tensorflow/core/framework/numeric_op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/kernels/bounds_check.h"
+
+#include "third_party/eigen3/Eigen/Core"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+#include "tensorflow/core/kernels/scan_ops.h"
+
+namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+typedef Eigen::GpuDevice GPUDevice;
+
+template <typename Device, class T, typename Reducer>
+class ScanOp : public OpKernel {
+public:
+  explicit ScanOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("reverse", &reverse_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& input = ctx->input(0);
+    const Tensor& tensor_axis = ctx->input(1);
+
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(tensor_axis.shape()),
+                errors::InvalidArgument("ScanOp: axis must be a scalar, not ",
+                                        tensor_axis.shape().DebugString()));
+
+    const int axis = internal::SubtleMustCopy(tensor_axis.scalar<int>()());
+
+    OP_REQUIRES(
+        ctx, FastBoundsCheck(axis, input.dims()),
+        errors::InvalidArgument("ScanOp: Expected scan axis in the range [", 0,
+                                ", ", input.dims(), "), but got ", axis));
+
+    TensorShape output_shape = input.shape();
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, output_shape, &output));
+
+    const Device& d = ctx->eigen_device<Device>();
+    Reducer reducer;
+
+#define HANDLE_SCAN(NDIMS)                                                  \
+  case NDIMS:                                                               \
+    functor::Scan<Device, Reducer, T, NDIMS>()(d, input.tensor<T, NDIMS>(), \
+                                               output->tensor<T, NDIMS>(),  \
+                                               reducer, axis, reverse_);    \
+    return;
+
+    switch (input.dims()) {
+      // input.dims() == 0 can't occur as there
+      // is no valid axis parameter in this case
+      HANDLE_SCAN(1);
+      HANDLE_SCAN(2);
+      HANDLE_SCAN(3);
+      HANDLE_SCAN(4);
+      HANDLE_SCAN(5);
+      HANDLE_SCAN(6);
+      HANDLE_SCAN(7);
+      HANDLE_SCAN(8);
+      default:
+        OP_REQUIRES(ctx, false, errors::InvalidArgument(
+                                    "Scan does not support tensors with "
+                                    "more than 8 dimensions",
+                                    input.dims()));
+    }
+#undef HANDLE_SCAN
+  }
+
+private:
+  bool reverse_;
+};
+
+#ifdef GOOGLE_CUDA
+namespace functor {
+
+// Forward declarations of GPU functors
+#define DECLARE(REDUCER, T, D)                          \
+  template <>                                           \
+  void Scan<GPUDevice, REDUCER, T, D>::operator()(      \
+      const GPUDevice& d, TTypes<T, D>::ConstTensor in, \
+      TTypes<T, D>::Tensor out, const REDUCER& reducer, \
+      const Eigen::Index& axis, bool reverse);          \
+  extern template struct Scan<GPUDevice, REDUCER, T, D>;
+
+#define DECLARE_FOR_ALL_DIMS(REDUCER, T) \
+  DECLARE(REDUCER, T, 1);                \
+  DECLARE(REDUCER, T, 2);                \
+  DECLARE(REDUCER, T, 3);                \
+  DECLARE(REDUCER, T, 4);                \
+  DECLARE(REDUCER, T, 5);                \
+  DECLARE(REDUCER, T, 6);                \
+  DECLARE(REDUCER, T, 7);                \
+  DECLARE(REDUCER, T, 8);
+
+#define DECLARE_FOR_ALL_REDUCERS(T)                        \
+  DECLARE_FOR_ALL_DIMS(Eigen::internal::SumReducer<T>, T); \
+  DECLARE_FOR_ALL_DIMS(Eigen::internal::ProdReducer<T>, T);
+
+TF_CALL_GPU_NUMBER_TYPES(DECLARE_FOR_ALL_REDUCERS);
+
+#undef DECLARE_FOR_ALL_REDUCERS
+#undef DECLARE_FOR_ALL_DIMS
+#undef DECLARE
+
+}  // namespace functor
+#endif  // GOOGLE_CUDA
+
+
+// Register Cumsum kernels
+#define REGISTER_CPU_KERNELS(type)                                 \
+  REGISTER_KERNEL_BUILDER(                                         \
+      Name("Cumsum").Device(DEVICE_CPU).TypeConstraint<type>("T"), \
+      ScanOp<CPUDevice, type, Eigen::internal::SumReducer<type>>)
+TF_CALL_NUMBER_TYPES(REGISTER_CPU_KERNELS);
+#undef REGISTER_CPU_KERNELS
+
+#if GOOGLE_CUDA
+#define REGISTER_GPU_KERNELS(type)   \
+  REGISTER_KERNEL_BUILDER(           \
+      Name("Cumsum")                 \
+          .Device(DEVICE_GPU)        \
+          .TypeConstraint<type>("T") \
+          .HostMemory("axis"),       \
+      ScanOp<GPUDevice, type, Eigen::internal::SumReducer<type>>)
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNELS)
+#undef REGISTER_GPU_KERNELS
+#endif // GOOGLE_CUDA
+
+
+// Register Cumprod kernels
+#define REGISTER_CPU_KERNELS(type)                                  \
+  REGISTER_KERNEL_BUILDER(                                          \
+      Name("Cumprod").Device(DEVICE_CPU).TypeConstraint<type>("T"), \
+      ScanOp<CPUDevice, type, Eigen::internal::ProdReducer<type>>)
+TF_CALL_NUMBER_TYPES(REGISTER_CPU_KERNELS);
+#undef REGISTER_CPU_KERNELS
+
+#if GOOGLE_CUDA
+#define REGISTER_GPU_KERNELS(type)   \
+  REGISTER_KERNEL_BUILDER(           \
+      Name("Cumprod")                \
+          .Device(DEVICE_GPU)        \
+          .TypeConstraint<type>("T") \
+          .HostMemory("axis"),       \
+      ScanOp<GPUDevice, type, Eigen::internal::ProdReducer<type>>)
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNELS)
+#undef REGISTER_GPU_KERNELS
+#endif // GOOGLE_CUDA
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/scan_ops.h
+++ b/tensorflow/core/kernels/scan_ops.h
@@ -1,0 +1,51 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_KERNELS_SCAN_OPS_H_
+#define TENSORFLOW_KERNELS_SCAN_OPS_H_
+
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "tensorflow/core/framework/tensor_types.h"
+
+namespace tensorflow {
+namespace functor {
+
+typedef Eigen::Index Index;
+
+template <typename Device, typename Reducer, typename T, int Dims>
+struct Scan {
+  void operator()(const Device& d, typename TTypes<T, Dims>::ConstTensor in,
+                  typename TTypes<T, Dims>::Tensor out, const Reducer& reducer,
+                  const Index& axis, bool reverse) {
+    if (reverse) {
+      // Perform the reverse ops directly with Eigen, which avoids copying the
+      // tensor twice compared to executing this as individual ops.
+      Eigen::array<bool, Dims> dims;
+      for (int i = 0; i < dims.size(); i++) {
+        dims[i] = (i == axis);
+      }
+      To32Bit(out).device(d) = To32Bit(in).reverse(dims)
+                                          .scan(axis, reducer)
+                                          .reverse(dims);
+    } else {
+      To32Bit(out).device(d) = To32Bit(in).scan(axis, reducer);
+    }
+  }
+};
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_KERNELS_SCAN_OPS_H_

--- a/tensorflow/core/kernels/scan_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/scan_ops_gpu.cu.cc
@@ -1,0 +1,54 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA
+
+#define EIGEN_USE_GPU
+
+#include "tensorflow/core/framework/numeric_types.h"
+#include "tensorflow/core/framework/register_types.h"
+
+#include "tensorflow/core/kernels/scan_ops.h"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+typedef Eigen::Index Index;
+
+#define DEFINE(REDUCER, T, D) \
+  template struct functor::Scan<GPUDevice, REDUCER, T, D>;
+
+#define DEFINE_FOR_ALL_DIMS(REDUCER, T) \
+  DEFINE(REDUCER, T, 1);                \
+  DEFINE(REDUCER, T, 2);                \
+  DEFINE(REDUCER, T, 3);                \
+  DEFINE(REDUCER, T, 4);                \
+  DEFINE(REDUCER, T, 5);                \
+  DEFINE(REDUCER, T, 6);                \
+  DEFINE(REDUCER, T, 7);                \
+  DEFINE(REDUCER, T, 8)
+
+#define DEFINE_FOR_ALL_REDUCERS(T)                        \
+  DEFINE_FOR_ALL_DIMS(Eigen::internal::SumReducer<T>, T); \
+  DEFINE_FOR_ALL_DIMS(Eigen::internal::ProdReducer<T>, T);
+
+TF_CALL_GPU_NUMBER_TYPES(DEFINE_FOR_ALL_REDUCERS);
+#undef DEFINE_FOR_ALL_REDUCERS
+#undef DEFINE_FOR_ALL_DIMS
+#undef DEFINE
+
+}  // end namespace tensorflow
+
+#endif  // GOOGLE_CUDA

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1812,4 +1812,56 @@ b: Another tensor, of same type and shape as `a`.
 product: Pairwise cross product of the vectors in `a` and `b`.
 )doc");
 
+// --------------------------------------------------------------------------
+
+REGISTER_OP("Cumsum")
+    .Input("x: T")
+    .Input("axis: int32")
+    .Attr("reverse: bool")
+    .Output("out: T")
+    .Attr("T: numbertype")
+    .Doc(R"doc(
+Compute the cumulative sum of the tensor `x` along `axis`.
+
+The output `out` at any given index i is equal to the sum of all
+elements `x_j` of `x` with j <= i.
+
+By setting the `reverse` operation to `True`, the sum is performed in the
+reverse order. In contrast to using `tf.reverse`, this avoids copying the
+tensor.
+
+For example:
+
+```prettyprint
+# tensor 'x' is [1, 2, 3, 4, 5]
+tf.cumsum(x)               ==> [1, 3, 6, 10, 15]
+tf.cumsum(x, reverse=True) ==> [15, 14, 12, 9, 5]
+```
+)doc");
+
+REGISTER_OP("Cumprod")
+    .Input("x: T")
+    .Input("axis: int32")
+    .Attr("reverse: bool")
+    .Output("out: T")
+    .Attr("T: numbertype")
+    .Doc(R"doc(
+Compute the cumulative product of the tensor `x` along `axis`.
+
+The output `out` at any given index i is equal to the product of all
+elements `x_j` of `x` with j <= i.
+
+By setting the `reverse` operation to `True`, the product is performed in the
+reverse order. In contrast to using `tf.reverse`, this avoids copying the
+tensor.
+
+For example:
+
+```prettyprint
+# tensor 'x' is [1, 2, 3, 4, 5]
+tf.cumprod(x)               ==> [1, 2, 6, 24, 120]
+tf.cumprod(x, reverse=True) ==> [120, 120, 60, 20, 5]
+```
+)doc");
+
 }  // namespace tensorflow

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -127,6 +127,7 @@ cuda_py_tests(
         "reverse_sequence_op_test.py",
         "rnn_cell_test.py",
         "scalar_strict_test.py",
+        "scan_ops_test.py",
         "session_ops_test.py",
         "shape_ops_test.py",
         "softmax_op_test.py",

--- a/tensorflow/python/kernel_tests/scan_ops_test.py
+++ b/tensorflow/python/kernel_tests/scan_ops_test.py
@@ -1,0 +1,215 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Functional tests for scan ops."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+
+def numpy_reverse(x, axis):
+  ix = [slice(None, None, -1)
+        if i == axis else slice(None) for i in range(len(x.shape))]
+  return x[ix]
+
+
+class CumsumTest(tf.test.TestCase):
+
+  valid_dtypes = [np.int32, np.int64, np.float16, np.float32,
+                  np.float64, np.complex64, np.complex128]
+
+  def _compare(self, x, axis, reverse, use_gpu=False):
+    np_out = x
+    if reverse:
+      np_out = numpy_reverse(np_out, axis)
+    np_out = np.cumsum(np_out, axis=axis)
+    if reverse:
+      np_out = numpy_reverse(np_out, axis)
+
+    with self.test_session(use_gpu=use_gpu):
+      tf_out = tf.cumsum(x, axis, reverse).eval()
+
+    self.assertAllClose(np_out, tf_out)
+
+  def _compareAll(self, x, axis):
+    self._compare(x, axis, False, False)
+    self._compare(x, axis, True, False)
+    self._compare(x, axis, False, True)
+    self._compare(x, axis, True, True)
+
+  def test1D(self):
+    for dtype in self.valid_dtypes:
+      x = np.arange(1, 6).reshape([5]).astype(dtype)
+      self._compareAll(x, 0)
+
+  def test2D(self):
+    for dtype in self.valid_dtypes:
+      x = np.arange(0, 10).reshape([2, 5]).astype(dtype)
+      self._compareAll(x, 0)
+      self._compareAll(x, 1)
+
+  def test3D(self):
+    for dtype in self.valid_dtypes:
+      x = np.arange(0, 20).reshape([2, 2, 5]).astype(dtype)
+      self._compareAll(x, 0)
+      self._compareAll(x, 1)
+      self._compareAll(x, 2)
+
+  def test8D(self):
+    for dtype in self.__class__.valid_dtypes:
+      x = np.arange(0, 2**8).reshape([2] * 8).astype(dtype)
+      for n in range(8):
+        self._compareAll(x, n)
+
+  def testInvalidAxis(self):
+    x = np.arange(0, 10).reshape([2, 5]).astype(np.float32)
+    input_tensor = tf.convert_to_tensor(x)
+    with self.test_session():
+      with self.assertRaisesWithPredicateMatch(
+          tf.errors.InvalidArgumentError,
+          lambda e: "Expected scan axis in the range" in str(e)):
+        tf.cumsum(input_tensor, -1).eval()
+      with self.assertRaisesWithPredicateMatch(
+          tf.errors.InvalidArgumentError,
+          lambda e: "Expected scan axis in the range" in str(e)):
+        tf.cumsum(input_tensor, 2).eval()
+      with self.assertRaisesWithPredicateMatch(
+          tf.errors.InvalidArgumentError,
+          lambda e: "axis must be a scalar" in str(e)):
+        tf.cumsum(input_tensor, [0]).eval()
+
+  def _compareGradient(self, shape, axis, reverse):
+    x = np.arange(0, 50).reshape(shape).astype(np.float64)
+    with self.test_session():
+      t = tf.convert_to_tensor(x)
+      result = tf.cumsum(t, axis, reverse)
+      jacob_t, jacob_n = tf.test.compute_gradient(t,
+                                                  shape,
+                                                  result,
+                                                  shape,
+                                                  x_init_value=x,
+                                                  delta=1)
+    self.assertAllClose(jacob_t, jacob_n, rtol=1e-8, atol=1e-8)
+
+  def testGradient(self):
+    self._compareGradient([50], 0, False)
+
+  def testGradientReverse(self):
+    self._compareGradient([50], 0, True)
+
+  def testGradient2D(self):
+    self._compareGradient([5, 10], 0, False)
+    self._compareGradient([5, 10], 1, False)
+    self._compareGradient([5, 10], 0, True)
+    self._compareGradient([5, 10], 1, True)
+
+
+class CumprodTest(tf.test.TestCase):
+
+  valid_dtypes = [np.int32, np.int64, np.float16, np.float32,
+                  np.float64, np.complex64, np.complex128]
+
+  def _compare(self, x, axis, reverse, use_gpu=False):
+    np_out = x
+    if reverse:
+      np_out = numpy_reverse(np_out, axis)
+    np_out = np.cumprod(np_out, axis=axis)
+    if reverse:
+      np_out = numpy_reverse(np_out, axis)
+
+    with self.test_session(use_gpu=use_gpu):
+      tf_out = tf.cumprod(x, axis, reverse).eval()
+
+    self.assertAllClose(np_out, tf_out)
+
+  def _compareAll(self, x, axis):
+    self._compare(x, axis, False, False)
+    self._compare(x, axis, True, False)
+    self._compare(x, axis, False, True)
+    self._compare(x, axis, True, True)
+
+  def test1D(self):
+    for dtype in self.valid_dtypes:
+      x = np.arange(1, 6).reshape([5]).astype(dtype)
+      self._compareAll(x, 0)
+
+  def test2D(self):
+    for dtype in self.valid_dtypes:
+      x = np.arange(1, 11).reshape([2, 5]).astype(dtype)
+      self._compareAll(x, 0)
+      self._compareAll(x, 1)
+
+  def test3D(self):
+    for dtype in self.valid_dtypes:
+      x = np.arange(1, 21).reshape([2, 2, 5]).astype(dtype)
+      self._compareAll(x, 0)
+      self._compareAll(x, 1)
+      self._compareAll(x, 2)
+
+  def test8D(self):
+    for dtype in self.__class__.valid_dtypes:
+      x = np.arange(1, 2**8+1).reshape([2] * 8).astype(dtype)
+      for n in range(8):
+        self._compareAll(x, n)
+
+  def testInvalidAxis(self):
+    x = np.arange(0, 10).reshape([2, 5]).astype(np.float32)
+    input_tensor = tf.convert_to_tensor(x)
+    with self.test_session():
+      with self.assertRaisesWithPredicateMatch(
+          tf.errors.InvalidArgumentError,
+          lambda e: "Expected scan axis in the range" in str(e)):
+        tf.cumprod(input_tensor, -1).eval()
+      with self.assertRaisesWithPredicateMatch(
+          tf.errors.InvalidArgumentError,
+          lambda e: "Expected scan axis in the range" in str(e)):
+        tf.cumprod(input_tensor, 2).eval()
+      with self.assertRaisesWithPredicateMatch(
+          tf.errors.InvalidArgumentError,
+          lambda e: "axis must be a scalar" in str(e)):
+        tf.cumprod(input_tensor, [0]).eval()
+
+  def _compareGradient(self, shape, axis, reverse):
+    x = np.arange(1, 9).reshape(shape).astype(np.float64)
+    with self.test_session():
+      t = tf.convert_to_tensor(x)
+      result = tf.cumprod(t, axis, reverse)
+      jacob_t, jacob_n = tf.test.compute_gradient(t,
+                                                  shape,
+                                                  result,
+                                                  shape,
+                                                  x_init_value=x,
+                                                  delta=1)
+    self.assertAllClose(jacob_t, jacob_n, rtol=1e-8, atol=1e-8)
+
+  def testGradient(self):
+    self._compareGradient([8], 0, False)
+
+  def testGradientReverse(self):
+    self._compareGradient([8], 0, True)
+
+  def testGradient2D(self):
+    self._compareGradient([2, 4], 0, False)
+    self._compareGradient([2, 4], 1, False)
+    self._compareGradient([2, 4], 0, True)
+    self._compareGradient([2, 4], 1, True)
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -837,3 +837,22 @@ def _CrossGrad(op, grad):
   u = op.inputs[0]
   v = op.inputs[1]
   return (math_ops.cross(v, grad), math_ops.cross(grad, u))
+
+
+@ops.RegisterGradient("Cumsum")
+def _CumsumGrad(op, grad):
+  axis = op.inputs[1]
+  reverse = op.get_attr("reverse")
+  return [math_ops.cumsum(grad, axis=axis, reverse=(not reverse)), None]
+
+
+@ops.RegisterGradient("Cumprod")
+def _CumprodGrad(op, grad):
+  x = op.inputs[0]
+  axis = op.inputs[1]
+  reverse = op.get_attr("reverse")
+
+  # TODO This fails when x contains 0 and should be fixed
+  prod = math_ops.cumprod(x, axis=axis, reverse=reverse)
+  out = math_ops.cumsum(prod * grad, axis=axis, reverse=(not reverse))
+  return [out / x, None]

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -143,6 +143,14 @@ common math computations that reduce various dimensions of a tensor.
 
 @@accumulate_n
 
+## Scan
+
+TensorFlow provides several operations that you can use to perform scans
+(running totals) across one axis of a tensor.
+
+@@cumsum
+@@cumprod
+
 ## Segmentation
 
 TensorFlow provides several operations that you can use to perform common
@@ -1583,6 +1591,74 @@ def tanh(x, name=None):
       return gen_math_ops._tanh(x, name=name)
 
 
+def cumsum(x, axis=0, reverse=False, name=None):
+    """Compute the cumulative sum of the tensor `x` along `axis`.
+
+    The output `out` at any given index i is equal to the sum of all
+    elements `x_j` of `x` with j <= i.
+
+    By setting the `reverse` operation to `True`, the sum is performed in the
+    reverse order. In contrast to using `tf.reverse`, this avoids copying the
+    tensor.
+
+    For example:
+
+    ```prettyprint
+    # tensor 'x' is [1, 2, 3, 4, 5]
+    tf.cumsum(x)               ==> [1, 3, 6, 10, 15]
+    tf.cumsum(x, reverse=True) ==> [15, 14, 12, 9, 5]
+    ```
+
+    Args:
+      x: A `Tensor`. Must be one of the following types: `float32`, `float64`,
+       `int64`, `int32`, `uint8`, `uint16`, `int16`, `int8`, `complex64`,
+       `complex128`, `qint8`, `quint8`, `qint32`, `half`.
+      axis: A `Tensor` of type `int32` (default: 0).
+      reverse: A `bool` (default: False).
+      name: A name for the operation (optional).
+
+    Returns:
+      A `Tensor`. Has the same type as `x`.
+    """
+    with ops.op_scope([x], name, "Cumsum") as name:
+      x = ops.convert_to_tensor(x, name="x")
+      return gen_math_ops.cumsum(x, axis, reverse, name=name)
+
+
+def cumprod(x, axis=0, reverse=False, name=None):
+    """Compute the cumulative product of the tensor `x` along `axis`.
+
+    The output `out` at any given index i is equal to the product of all
+    elements `x_j` of `x` with j <= i.
+
+    By setting the `reverse` operation to `True`, the product is performed in the
+    reverse order. In contrast to using `tf.reverse`, this avoids copying the
+    tensor.
+
+    For example:
+
+    ```prettyprint
+    # tensor 'x' is [1, 2, 3, 4, 5]
+    tf.cumprod(x)               ==> [1, 2, 6, 24, 120]
+    tf.cumprod(x, reverse=True) ==> [120, 120, 60, 20, 5]
+    ```
+
+    Args:
+      x: A `Tensor`. Must be one of the following types: `float32`, `float64`,
+       `int64`, `int32`, `uint8`, `uint16`, `int16`, `int8`, `complex64`,
+       `complex128`, `qint8`, `quint8`, `qint32`, `half`.
+      axis: A `Tensor` of type `int32` (default: 0).
+      reverse: A `bool` (default: False).
+      name: A name for the operation (optional).
+
+    Returns:
+      A `Tensor`. Has the same type as `x`.
+    """
+    with ops.op_scope([x], name, "Cumprod") as name:
+      x = ops.convert_to_tensor(x, name="x")
+      return gen_math_ops.cumprod(x, axis, reverse, name=name)
+
+
 ops.RegisterShape("Abs")(common_shapes.unchanged_shape)
 ops.RegisterShape("Acos")(common_shapes.unchanged_shape)
 ops.RegisterShape("Asin")(common_shapes.unchanged_shape)
@@ -1630,6 +1706,8 @@ ops.RegisterShape("BatchFFT3D")(common_shapes.unchanged_shape)
 ops.RegisterShape("BatchIFFT3D")(common_shapes.unchanged_shape)
 ops.RegisterShape("TanhGrad")(common_shapes.unchanged_shape)
 ops.RegisterShape("SigmoidGrad")(common_shapes.unchanged_shape)
+ops.RegisterShape("Cumsum")(common_shapes.unchanged_shape)
+ops.RegisterShape("Cumprod")(common_shapes.unchanged_shape)
 
 
 @ops.RegisterShape("Add")


### PR DESCRIPTION
This implements `tf.scan_sum` (cumulative sum) and `tf.scan_prod` (cumulative product) ops.
Unfortunately, this won't compile with the current version of eigen, as I have to make some small changes to `TensorScanOp.h`
But this should be useful to discuss how the API should look and whether we want to have inclusive/exclusive ops, and so on.

I'll also add tests and gradients to the two ops.

This relates to #813.
