### PR TITLE
Enable whole batch whitening.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@
 
 
 ## Big Fixes and Other Changes
- * `tf.nn.per_image_whitening(images)` is now able to handel batches.
+ * `tf.nn.per_image_whitening(images)` is now able to handle batches.
     Parameter got renamed from `image` to `images`.
 
 # Release 0.9.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,11 @@
 * `env.h` replaces use of `New*File()` functions to use `std::unique_ptr`
   return arguments, removing the old raw pointer returns.
 
+
+## Big Fixes and Other Changes
+ * `tf.nn.per_image_whitening(images)` is now able to handel batches.
+    Parameter got renamed from `image` to `images`.
+
 # Release 0.9.0
 
 ## Major Features and Improvements

--- a/tensorflow/python/ops/image_ops.py
+++ b/tensorflow/python/ops/image_ops.py
@@ -780,38 +780,41 @@ def resize_images(images,
   return images
 
 
-def per_image_whitening(image):
-  """Linearly scales `image` to have zero mean and unit norm.
+def per_image_whitening(images):
+  """Linearly scales `images` to have zero mean and unit norm.
 
   This op computes `(x - mean) / adjusted_stddev`, where `mean` is the average
-  of all values in image, and
-  `adjusted_stddev = max(stddev, 1.0/sqrt(image.NumElements()))`.
+  of all values in images, and
+  `adjusted_stddev = max(stddev, 1.0/sqrt(images.NumElements()))`.
 
-  `stddev` is the standard deviation of all values in `image`. It is capped
+  `stddev` is the standard deviation of all values in `images`. It is capped
   away from zero to protect against division by 0 when handling uniform images.
 
   Note that this implementation is limited:
-  *  It only whitens based on the statistics of an individual image.
+  *  It only whitens based on the marginal statistics of the supplied images.
+      A single standard deviation and mean is calculated for all images provided
+      as input to this function.
   *  It does not take into account the covariance structure.
 
   Args:
-    image: 3-D tensor of shape `[height, width, channels]`.
+    images: 4-D Tensor of shape [batch, height, width, channels] or
+            3-D Tensor of shape [height, width, channels].
 
   Returns:
-    The whitened image with same shape as `image`.
+    An output tensor with same shape as `images`.
 
   Raises:
-    ValueError: if the shape of 'image' is incompatible with this function.
+    ValueError: if the shape of 'images' is incompatible with this function.
   """
-  image = ops.convert_to_tensor(image, name='image')
-  _Check3DImage(image, require_static=False)
-  num_pixels = math_ops.reduce_prod(array_ops.shape(image))
+  images = ops.convert_to_tensor(images, name='images')
+  _CheckAtLeast3DImage(images)
+  num_pixels = math_ops.reduce_prod(array_ops.shape(images))
 
-  image = math_ops.cast(image, dtype=dtypes.float32)
-  image_mean = math_ops.reduce_mean(image)
+  images = math_ops.cast(images, dtype=dtypes.float32)
+  images_mean = math_ops.reduce_mean(images)
 
-  variance = (math_ops.reduce_mean(math_ops.square(image)) -
-              math_ops.square(image_mean))
+  variance = (math_ops.reduce_mean(math_ops.square(images)) -
+              math_ops.square(images_mean))
   variance = gen_nn_ops.relu(variance)
   stddev = math_ops.sqrt(variance)
 
@@ -819,11 +822,11 @@ def per_image_whitening(image):
   min_stddev = math_ops.inv(
       math_ops.sqrt(math_ops.cast(num_pixels, dtypes.float32)))
   pixel_value_scale = math_ops.maximum(stddev, min_stddev)
-  pixel_value_offset = image_mean
+  pixel_value_offset = images_mean
 
-  image = math_ops.sub(image, pixel_value_offset)
-  image = math_ops.div(image, pixel_value_scale)
-  return image
+  images = math_ops.sub(images, pixel_value_offset)
+  images = math_ops.div(images, pixel_value_scale)
+  return images
 
 
 def random_brightness(image, max_delta, seed=None):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -468,8 +468,27 @@ class PerImageWhiteningTest(test_util.TensorFlowTestCase):
       y_tf = y.eval()
       self.assertAllClose(y_tf, y_np, atol=1e-4)
 
+  def testBatch(self):
+    x_shape = [5, 9, 3, 3]
+    x_np = np.arange(0, np.prod(x_shape), dtype=np.int32).reshape(x_shape)
+    y_np = self._NumpyPerImageWhitening(x_np)
+
+    with self.test_session():
+      x = constant_op.constant(x_np, shape=x_shape)
+      y = image_ops.per_image_whitening(x)
+      y_tf = y.eval()
+      self.assertAllClose(y_tf, y_np, atol=1e-4)
+
   def testUniformImage(self):
     im_np = np.ones([19, 19, 3]).astype(np.float32) * 249
+    im = constant_op.constant(im_np)
+    whiten = image_ops.per_image_whitening(im)
+    with self.test_session():
+      whiten_np = whiten.eval()
+      self.assertFalse(np.any(np.isnan(whiten_np)))
+
+  def testUniformImage4d(self):
+    im_np = np.ones([19, 19, 3, 3]).astype(np.float32) * 249
     im = constant_op.constant(im_np)
     whiten = image_ops.per_image_whitening(im)
     with self.test_session():


### PR DESCRIPTION
The function tf.image.per_image_whitening() can now be applied to a whole batch. `Mean` and `adjusted_stddev` is then computed over all batch dimensions.

I find it very useful to be able to ably tf.image.whitening to an entire batch.
1) In some situations a batch is given (due to previous computation in the graph). Splitting the batch into individual images, in order to be able to apply whitening seams to be a bit redundant.
2) Applying whitening to a batch is statistically superior (and more elegant when used in combination with Batch Normalization).

It might be considered to rename the function in `per_batch_whitening`. As this would now be more accurate.
