### PR TITLE
MNIST downloader doesn't work as expected

### DIFF
--- a/tensorflow/examples/tutorials/mnist/input_data.py
+++ b/tensorflow/examples/tutorials/mnist/input_data.py
@@ -26,4 +26,6 @@ import numpy
 from six.moves import urllib
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
-from tensorflow.contrib.learn.python.learn.datasets.mnist import read_data_sets
+
+from tensorflow.examples.tutorials.mnist import input_data
+mnist = input_data.read_data_sets('MNIST_data', one_hot=True)

--- a/tensorflow/examples/tutorials/mnist/input_data.py
+++ b/tensorflow/examples/tutorials/mnist/input_data.py
@@ -27,5 +27,6 @@ from six.moves import urllib
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
-from tensorflow.examples.tutorials.mnist import input_data
-mnist = input_data.read_data_sets('MNIST_data', one_hot=True)
+from tensorflow.contrib.learn.python.learn.datasets.mnist import read_data_sets
+
+mnist = read_data_sets('MNIST_data', one_hot=True)


### PR DESCRIPTION
See: https://www.tensorflow.org/versions/r0.9/tutorials/mnist/pros/index.html

> For your convenience, we've included a script which automatically downloads and imports the MNIST dataset. It will create a directory 'MNIST_data' in which to store the data files.

Linked to this file: https://github.com/tensorflow/tensorflow/blob/r0.9/tensorflow/examples/tutorials/mnist/input_data.py

Which currently doesn't create any folder.
