### PR TITLE
Apply fully connected activation function on flat data

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -537,12 +537,12 @@ def fully_connected(inputs,
                                           collections=biases_collections,
                                           trainable=trainable)
         outputs = nn.bias_add(outputs, biases)
+    if activation_fn:
+      outputs = activation_fn(outputs)
     if len(static_shape) > 2:
       # Reshape back outputs
       outputs = array_ops.reshape(outputs, array_ops.pack(out_shape))
       outputs.set_shape(static_shape)
-    if activation_fn:
-      outputs = activation_fn(outputs)
     return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
 
 


### PR DESCRIPTION
`layers.fully_connected` flattens all dimensions of the input but the last, transforms the flat rows using the same weight matrix, and unflattens the result. One use case is to apply the same layer to each output of an RNN like in this example.

``` python
from tensorflow.models.rnn import rnn
from tensorflow.contrib import layers

output, _ = rnn.dynamic_rnn(...)
prediction = layers.fully_connected(output, out_size, tf.nn.softmax)
```

However, the example failed using `tf.nn.softmax` since the activation function was applied on the unflattened result already. This pull request applies the activation function before unflattening so that any activation function that works with normal layers (without flattening) can be used.
