### PR TITLE
Logistic regression weights: Using a `tf.Tensor` as a Python `bool` is not allowed

### DIFF
--- a/tensorflow/contrib/learn/python/learn/models.py
+++ b/tensorflow/contrib/learn/python/learn/models.py
@@ -153,7 +153,7 @@ def logistic_regression(x,
                                   bias)
     # If no class weight provided, try to retrieve one from pre-defined
     # tensor name in the graph.
-    if not class_weight:
+    if class_weight is not None:
       try:
         class_weight = ops.get_default_graph().get_tensor_by_name(
             'class_weight:0')


### PR DESCRIPTION
Trying to use logistic_regression weights led me to the exception:

```
Traceback (most recent call last):
  File "train.py", line 22, in <module>
    results = run(X, y, hyperparams, args.model_name)
  File "/opt/app/app/logistic_classifier.py", line 104, in run
    logdir='/opt/app/log/' + model_name
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/contrib/learn/python/learn/estimators/base.py", line 227, in fit
    self._setup_training()
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/contrib/learn/python/learn/estimators/base.py", line 148, in _setup_training
    self._inp, self._out)
  File "/opt/app/app/logistic_classifier.py", line 204, in model
    init_mean=params['init_mean'], init_stddev=params['init_stddev']
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/contrib/learn/python/learn/models.py", line 158, in logistic_regression
    if not class_weight:
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/framework/ops.py", line 475, in __nonzero__
    raise TypeError("Using a `tf.Tensor` as a Python `bool` is not allowed. "
TypeError: Using a `tf.Tensor` as a Python `bool` is not allowed. Use `if t is not None:` instead of `if t:` to test if a tensor is defined, and use the logical TensorFlow ops to test the value of a tensor.
```

which is fixed by attached change.
