### PR TITLE
Missing space;

### DIFF
--- a/tensorflow/contrib/makefile/download_dependencies.sh
+++ b/tensorflow/contrib/makefile/download_dependencies.sh
@@ -19,7 +19,7 @@ DOWNLOADS_DIR=tensorflow/contrib/makefile/downloads
 mkdir ${DOWNLOADS_DIR}
 
 EIGEN_HASH=62a2305d5734
-if [ -f eigen.BUILD]; then
+if [ -f eigen.BUILD ]; then
 	# Grab the current Eigen version name from the Bazel build file
 	EIGEN_HASH=$(cat eigen.BUILD | grep archive_dir | head -1 | cut -f3 -d- | cut -f1 -d\")
 fi


### PR DESCRIPTION
(1) bash file check will fail without the space;
