### PR TITLE
Enable tf.exp() for SparseTensor

### DIFF
--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -206,6 +206,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareBoth(x, np.vectorize(math.erfc), tf.erfc)
 
     self._compareBothSparse(y, np.log, tf.log)
+    self._compareBothSparse(x, np.exp, tf.exp)
 
   def testFloatTanhEdge(self):
     x = np.arange(40, 40 + 6).reshape(6).astype(np.float32)
@@ -240,6 +241,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareBoth(x, np.arctan, tf.atan)
 
     self._compareBothSparse(x, np.log, tf.log)
+    self._compareBothSparse(x, np.exp, tf.exp)
 
   def testDoubleBasic(self):
     x = np.arange(-3, 3).reshape(1, 3, 2).astype(np.float64)
@@ -273,6 +275,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareBoth(k, np.tan, tf.tan)
 
     self._compareBothSparse(y, np.log, tf.log)
+    self._compareBothSparse(x, np.exp, tf.exp)
 
   def testHalfBasic(self):
     x = np.arange(-3, 3).reshape(1, 3, 2).astype(np.float16)
@@ -301,6 +304,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareBoth(x, np.vectorize(math.erfc), tf.erfc)
 
     self._compareBothSparse(y, np.log, tf.log)
+    self._compareBothSparse(x, np.exp, tf.exp)
 
   def testInt32Basic(self):
     x = np.arange(-6, 6, 2).reshape(1, 3, 2).astype(np.int32)
@@ -345,6 +349,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareCpu(y, complex_sign, tf.sign)
 
     self._compareBothSparse(y, np.log, tf.log)
+    self._compareBothSparse(x, np.exp, tf.exp)
 
   def testComplex128Basic(self):
     x = np.complex(1, 1) * np.arange(-3, 3).reshape(1, 3, 2).astype(
@@ -371,6 +376,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareCpu(y, complex_sign, tf.sign)
 
     self._compareBothSparse(y, np.log, tf.log)
+    self._compareBothSparse(x, np.exp, tf.exp)
 
 
 class BinaryOpTest(tf.test.TestCase):

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -330,6 +330,25 @@ def pow(x, y, name=None):
     return gen_math_ops._pow(x, y, name=name)
 
 
+def exp(x, name=None):
+  """Computes exponential of x element-wise.  \\(y = e^x\\).
+
+  Args:
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
+      `float32`, `float64`, `complex64`, `complex128`.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` or `SparseTensor`, respectively. Has the same type as `x`.
+  """
+  with ops.op_scope([x], name, "Exp") as name:
+    if isinstance(x, ops.SparseTensor):
+      x_exp = gen_math_ops.exp(x.values, name=name)
+      return ops.SparseTensor(indices=x.indices, values=x_exp, shape=x.shape)
+    else:
+      return gen_math_ops.exp(x, name=name)
+
+
 def log(x, name=None):
   """Computes natural logarithm of x element-wise.
 


### PR DESCRIPTION
Enabled `tf.exp()` for `SparseTensor`. Added tests and verified locally. This partially addresses #1828.
