### PR TITLE
Fixed bug in train_test_split operation.

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/_sklearn.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/_sklearn.py
@@ -178,7 +178,7 @@ def _train_test_split(*args, **options):
 
   np.random.seed(random_state)
   indices = np.random.permutation(args[0].shape[0])
-  train_idx, test_idx = indices[:train_size], indices[:train_size]
+  train_idx, test_idx = indices[:train_size], indices[train_size:]
   result = []
   for x in args:
     result += [x.take(train_idx, axis=0), x.take(test_idx, axis=0)]


### PR DESCRIPTION
If scikit-learn is installed, tensorflow attempts to import the operation train_test_split from scikit-learn. Otherwise it provides a custom implementation. The custom implementation correctly computes the position to split the dataset, but returns the same set of indices for both the training set and the test set. Effectively this operations returns the training set for both the training and test sets. 
