### PR TITLE
MNIST tutorial incorrectly described a file

### DIFF
--- a/tensorflow/g3doc/tutorials/mnist/pros/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/pros/index.md
@@ -22,7 +22,7 @@ TensorFlow session.
 For your convenience, we've included
 [a script](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/input_data.py)
 which will help you download and import the MNIST dataset. Run the following commands to create a
-directory `'MNIST_data'` in the current folder, the data files will be stored inside of such directory.
+directory `'MNIST_data'` in the current folder, the data files will be stored inside that directory.
 
 ```python
 from tensorflow.examples.tutorials.mnist import input_data

--- a/tensorflow/g3doc/tutorials/mnist/pros/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/pros/index.md
@@ -21,8 +21,8 @@ TensorFlow session.
 
 For your convenience, we've included
 [a script](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/input_data.py)
-which automatically downloads and imports the MNIST dataset. It will create a
-directory `'MNIST_data'` in which to store the data files.
+which will help you download and import the MNIST dataset. Run the following commands to create a
+directory `'MNIST_data'` in the current folder, the data files will be stored inside of such directory.
 
 ```python
 from tensorflow.examples.tutorials.mnist import input_data


### PR DESCRIPTION
The file "input_data.py" from MNIST tutorial does not download any data, as previously stated.

Related to #2733.
