### PR TITLE
[WIP] Gradient reversal op

### DIFF
--- a/tensorflow/core/user_ops/BUILD
+++ b/tensorflow/core/user_ops/BUILD
@@ -1,0 +1,6 @@
+load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
+
+tf_custom_op_library(
+    name = "flip_gradient.so",
+    srcs = ["flip_gradient.cc"],
+)

--- a/tensorflow/core/user_ops/flip_gradient.cc
+++ b/tensorflow/core/user_ops/flip_gradient.cc
@@ -22,6 +22,7 @@ class FlipGradientOp : public OpKernel {
 
 REGISTER_OP("FlipGradient")
     .Input("input: T")
+    .Input("s: T")
     .Output("output: T")
     .Attr("T: type")
     .Doc(R"Doc(

--- a/tensorflow/core/user_ops/flip_gradient.cc
+++ b/tensorflow/core/user_ops/flip_gradient.cc
@@ -1,0 +1,33 @@
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+// #include "tensorflow/core/kernels/identity_op.h"
+
+using namespace tensorflow;
+
+// TODO: replace with IdentityOp
+class FlipGradientOp : public OpKernel {
+ public:
+  explicit FlipGradientOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    if (IsRefType(context->input_dtype(0))) {
+      context->forward_ref_input_to_ref_output(0, 0);
+    } else {
+      context->set_output(0, context->input(0));
+    }
+  }
+
+  bool IsExpensive() override { return false; }
+};
+
+REGISTER_OP("FlipGradient")
+    .Input("input: T")
+    .Output("output: T")
+    .Attr("T: type")
+    .Doc(R"Doc(
+Return a tensor with the same shape and contents as the input tensor or value,
+but flip gradients for gradient computation.
+)Doc");
+
+REGISTER_KERNEL_BUILDER(Name("FlipGradient").Device(DEVICE_CPU), FlipGradientOp);
+// REGISTER_KERNEL_BUILDER(Name("FlipGradient").Device(DEVICE_CPU), IdentityOp);


### PR DESCRIPTION
"[Unsupervised Domain Adaptation by Backpropagation](http://sites.skoltech.ru/compvision/projects/grl/files/paper.pdf)" introduces a very simple but effective "gradient reversal layer" that is the identity for the forward computation and flips the gradient during backpropagation. This PR implements this as a user op called `FlipGradientOp`. The gradient registration is [here](https://github.com/pumpikano/tf-dann/blob/master/flip_gradient.py) (with a small MNIST experiment in that repo that uses the op).

I created the PR to gauge if there is any interest in getting something like this into core or at least contrib. As you can see, the operation itself is dead simple and very general. The same effect can be achieved by processing gradients before application, but the op implementation means that everything works naturally as a result of autodiff. I may have missed a way to achieve this functionality with existing operations - if so, let me know!

The example implementation here of `FlipGradientOp` effectively multiplies the gradient by -1. It may be worth generalizing this as a `ScaleGradientOp` that scales the incoming gradient by an arbitrary scalar tensor.

I'm happy to get this in mergeable shape if the tensorflow team approves.
