### PR TITLE
Enable tf.neg() for SparseTensor

### DIFF
--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -206,6 +206,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareBoth(x, np.vectorize(math.erfc), tf.erfc)
 
     self._compareBothSparse(x, np.abs, tf.abs)
+    self._compareBothSparse(x, np.negative, tf.neg)
 
   def testFloatTanhEdge(self):
     x = np.arange(40, 40 + 6).reshape(6).astype(np.float32)
@@ -240,6 +241,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareBoth(x, np.arctan, tf.atan)
 
     self._compareBothSparse(x, np.abs, tf.abs)
+    self._compareBothSparse(x, np.negative, tf.neg)
 
   def testDoubleBasic(self):
     x = np.arange(-3, 3).reshape(1, 3, 2).astype(np.float64)
@@ -273,6 +275,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareBoth(k, np.tan, tf.tan)
 
     self._compareBothSparse(x, np.abs, tf.abs)
+    self._compareBothSparse(x, np.negative, tf.neg)
 
   def testHalfBasic(self):
     x = np.arange(-3, 3).reshape(1, 3, 2).astype(np.float16)
@@ -301,6 +304,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareBoth(x, np.vectorize(math.erfc), tf.erfc)
 
     self._compareBothSparse(x, np.abs, tf.abs)
+    self._compareBothSparse(x, np.negative, tf.neg)
 
   def testInt32Basic(self):
     x = np.arange(-6, 6, 2).reshape(1, 3, 2).astype(np.int32)
@@ -312,6 +316,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareCpu(x, np.sign, tf.sign)
 
     self._compareBothSparse(x, np.abs, tf.abs)
+    self._compareBothSparse(x, np.negative, tf.neg)
 
   def testInt64Basic(self):
     x = np.arange(
@@ -324,6 +329,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareCpu(x, np.sign, tf.sign)
 
     self._compareBothSparse(x, np.abs, tf.abs)
+    self._compareBothSparse(x, np.negative, tf.neg)
 
   def testComplex64Basic(self):
     x = np.complex(1, 1) * np.arange(-3, 3).reshape(1, 3, 2).astype(
@@ -345,6 +351,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareCpu(x, np.cos, tf.cos)
 
     self._compareBothSparse(x, np.abs, tf.abs)
+    self._compareBothSparse(x, np.negative, tf.neg)
 
     # Numpy uses an incorrect definition of sign; use the right one instead.
     def complex_sign(x):
@@ -371,6 +378,7 @@ class UnaryOpTest(tf.test.TestCase):
     self._compareCpu(x, np.cos, tf.cos)
 
     self._compareBothSparse(x, np.abs, tf.abs)
+    self._compareBothSparse(x, np.negative, tf.neg)
 
     # Numpy uses an incorrect definition of sign; use the right one instead.
     def complex_sign(x):

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -261,6 +261,27 @@ def abs(x, name=None):
       return gen_math_ops._abs(x, name=name)
 
 
+def neg(x, name=None):
+  """Computes numerical negative value element-wise.
+
+  I.e., \\(y = -x\\).
+
+  Args:
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
+      `float32`, `float64`, `int32`, `int64`, `complex64`, `complex128`.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` or `SparseTensor`, respectively. Has the same type as `x`.
+  """
+  with ops.op_scope([x], name, "Neg") as name:
+    if isinstance(x, ops.SparseTensor):
+      x_neg = gen_math_ops.neg(x.values, name=name)
+      return ops.SparseTensor(indices=x.indices, values=x_neg, shape=x.shape)
+    else:
+      return gen_math_ops.neg(x, name=name)
+
+
 def complex_abs(x, name=None):
   r"""Computes the complex absolute value of a tensor.
 


### PR DESCRIPTION
Enabled `tf.neg()` for SparseTensor. Added tests and verified locally. This partially addresses #1828.
