### PR TITLE
Revert "Logistic regression weights: Using a `tf.Tensor` as a Python `bool` is not allowed"

### DIFF
--- a/tensorflow/contrib/learn/python/learn/models.py
+++ b/tensorflow/contrib/learn/python/learn/models.py
@@ -154,7 +154,7 @@ def logistic_regression(x,
                                   bias)
     # If no class weight provided, try to retrieve one from pre-defined
     # tensor name in the graph.
-    if class_weight is not None:
+    if not class_weight:
       try:
         class_weight = ops.get_default_graph().get_tensor_by_name(
             'class_weight:0')


### PR DESCRIPTION
Reverts tensorflow/tensorflow#2757 because check is the reverse.
