### PR TITLE
Make sure that concat complains about concat_dim < 0

### DIFF
--- a/tensorflow/python/kernel_tests/concat_op_test.py
+++ b/tensorflow/python/kernel_tests/concat_op_test.py
@@ -274,22 +274,22 @@ class ConcatOpTest(tf.test.TestCase):
     # Rank doesn't match.
     with self.assertRaises(ValueError):
       tf.concat(1, [tf.constant(10.0, shape=[4, 4, 4, 4]),
-                           tf.constant(20.0, shape=[4, 4, 4])])
+                    tf.constant(20.0, shape=[4, 4, 4])])
 
     # Dimensions don't match in a non-concat dim.
     with self.assertRaises(ValueError):
       tf.concat(1, [tf.constant(10.0, shape=[1, 2, 1]),
-                           tf.constant(20.0, shape=[3, 2, 1])])
+                    tf.constant(20.0, shape=[3, 2, 1])])
 
     # concat_dim out of range.
     with self.assertRaises(ValueError):
       tf.concat(3, [tf.constant(10.0, shape=[4, 4, 4]),
-                           tf.constant(20.0, shape=[4, 4, 4])])
+                    tf.constant(20.0, shape=[4, 4, 4])])
 
     # concat_dim < 0
     with self.assertRaises(ValueError):
       tf.concat(-1, [tf.constant(10.0, shape=[4, 4, 4]),
-                           tf.constant(20.0, shape=[4, 4, 4])])
+                     tf.constant(20.0, shape=[4, 4, 4])])
 
   def testShapeWithUnknownConcatDim(self):
     p1 = tf.placeholder(tf.float32)

--- a/tensorflow/python/kernel_tests/concat_op_test.py
+++ b/tensorflow/python/kernel_tests/concat_op_test.py
@@ -286,6 +286,11 @@ class ConcatOpTest(tf.test.TestCase):
       tf.concat(3, [tf.constant(10.0, shape=[4, 4, 4]),
                            tf.constant(20.0, shape=[4, 4, 4])])
 
+    # concat_dim < 0
+    with self.assertRaises(ValueError):
+      tf.concat(-1, [tf.constant(10.0, shape=[4, 4, 4]),
+                           tf.constant(20.0, shape=[4, 4, 4])])
+
   def testShapeWithUnknownConcatDim(self):
     p1 = tf.placeholder(tf.float32)
     c1 = tf.constant(10.0, shape=[4, 4, 4, 4])

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -525,14 +525,14 @@ def _ConcatShape(op):
     # output shape.
     concat_dim = int(concat_dim)
     if concat_dim < 0:
-        raise ValueError("Expected concat_dim >= 0, but got %d" % concat_dim)
+      raise ValueError("Expected concat_dim >= 0, but got %d" % concat_dim)
 
     output_shape = op.inputs[1].get_shape()
     for value in op.inputs[2:]:
       value_shape = value.get_shape()
       if value_shape.ndims is not None and concat_dim >= value_shape.ndims:
         raise ValueError("Expected concat_dim in range [0, %d), but got %d" %
-                (concat_dim, value_shape.ndims))
+                         (value_shape.ndims, concat_dim))
       before = output_shape[:concat_dim].merge_with(value_shape[:concat_dim])
       at = output_shape[concat_dim] + value_shape[concat_dim]
       after = output_shape[

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -524,12 +524,15 @@ def _ConcatShape(op):
     # Merge all the non-concat dims, and sum the concat dim to make an
     # output shape.
     concat_dim = int(concat_dim)
+    if concat_dim < 0:
+        raise ValueError("Expected concat_dim >= 0, but got %d" % concat_dim)
+
     output_shape = op.inputs[1].get_shape()
     for value in op.inputs[2:]:
       value_shape = value.get_shape()
       if value_shape.ndims is not None and concat_dim >= value_shape.ndims:
-        raise ValueError("concat_dim is out of range (values rank = %d)" %
-                         value_shape.ndims)
+        raise ValueError("Expected concat_dim in range [0, %d), but got %d" %
+                (concat_dim, value_shape.ndims))
       before = output_shape[:concat_dim].merge_with(value_shape[:concat_dim])
       at = output_shape[concat_dim] + value_shape[concat_dim]
       after = output_shape[


### PR DESCRIPTION
`tf.concat` already checks whether `concat_dim` is too large for
the provided arguments at graph construction (if that's possible), but it
should also make sure that `concat_dim >= 0`.

This fixes #2868.
