### PR TITLE
Qualify references with @org_tensorflow to make function importable

### DIFF
--- a/third_party/gpus/cuda/build_defs.bzl
+++ b/third_party/gpus/cuda/build_defs.bzl
@@ -8,7 +8,7 @@ def if_cuda(if_true, if_false = []):
 
     """
     return select({
-        "//third_party/gpus/cuda:using_nvcc": if_true,
-        "//third_party/gpus/cuda:using_gcudacc": if_true,
+        "@org_tensorflow//third_party/gpus/cuda:using_nvcc": if_true,
+        "@org_tensorflow//third_party/gpus/cuda:using_gcudacc": if_true,
         "//conditions:default": if_false
     })


### PR DESCRIPTION
Qualify references with @org_tensorflow to make function importable by other workspaces

E.g. by syntaxnet which uses this function.

I have signed CLA with Cobite, INC. but googlebot is confused.
