### PR TITLE
Fix negation of flags with dashes, add test.

### DIFF
--- a/tensorflow/python/platform/flags.py
+++ b/tensorflow/python/platform/flags.py
@@ -101,9 +101,12 @@ def DEFINE_boolean(flag_name, default_value, docstring):
                               help=docstring,
                               default=default_value,
                               type=str2bool)
+
+  # Add negated version, stay consistent with argparse with regard to
+  # dashes in flag names.
   _global_parser.add_argument('--no' + flag_name,
                               action='store_false',
-                              dest=flag_name)
+                              dest=flag_name.replace('-', '_'))
 
 
 # The internal google library defines the following alias, so we match

--- a/tensorflow/python/platform/flags_test.py
+++ b/tensorflow/python/platform/flags_test.py
@@ -31,6 +31,7 @@ flags.DEFINE_float("float_foo", 42.0, "HelpString")
 
 flags.DEFINE_boolean("bool_foo", True, "HelpString")
 flags.DEFINE_boolean("bool_negation", True, "HelpString")
+flags.DEFINE_boolean("bool-dash-negation", True, "HelpString")
 flags.DEFINE_boolean("bool_a", False, "HelpString")
 flags.DEFINE_boolean("bool_c", False, "HelpString")
 flags.DEFINE_boolean("bool_d", True, "HelpString")
@@ -64,6 +65,10 @@ class FlagsTest(googletest.TestCase):
     # --bool_flag=True sets to True
     self.assertEqual(True, FLAGS.bool_c)
 
+    # --no before the flag mirrors argparse's behavior with
+    # regard to dashes in flag names
+    self.assertEqual(False, FLAGS.bool_dash_negation)
+
     # --bool_flag=False sets to False
     self.assertEqual(False, FLAGS.bool_d)
 
@@ -85,9 +90,9 @@ class FlagsTest(googletest.TestCase):
 
 if __name__ == "__main__":
   # Test command lines
-  sys.argv.extend(["--bool_a", "--nobool_negation", "--bool_c=True",
-                   "--bool_d=False", "--bool_e=gibberish", "--unknown_flag",
-                   "and_argument"])
+  sys.argv.extend(["--bool_a", "--nobool_negation", "--nobool-dash-negation",
+                   "--bool_c=True", "--bool_d=False", "--bool_e=gibberish",
+                   "--unknown_flag", "and_argument"])
 
   # googletest.main() tries to interpret the above flags, so use the
   # direct functions instead.


### PR DESCRIPTION
This fixes issue #2880 by replacing dashes with underscores when adding the negated version of a boolean flag. I also added a test making sure it behaves as expected.
