### PR TITLE
Deprecate contrib.learn.ops{dropout, dnn}

### DIFF
--- a/tensorflow/contrib/learn/python/learn/ops/dnn_ops.py
+++ b/tensorflow/contrib/learn/python/learn/ops/dnn_ops.py
@@ -21,7 +21,9 @@ from __future__ import print_function
 
 from tensorflow.contrib import layers
 from tensorflow.contrib.learn.python.learn.ops import dropout_ops
+
 from tensorflow.python.framework import ops
+from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.ops import array_ops as array_ops_
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import nn
@@ -30,6 +32,7 @@ from tensorflow.python.ops import variable_scope as vs
 
 def dnn(tensor_in, hidden_units, activation=nn.relu, dropout=None):
   """Creates fully connected deep neural network subgraph.
+  This is deprecated. Please use contrib.layers.dnn instead.
 
   Args:
     tensor_in: tensor or placeholder for input features.
@@ -40,6 +43,8 @@ def dnn(tensor_in, hidden_units, activation=nn.relu, dropout=None):
   Returns:
     A tensor which would be a deep neural network.
   """
+  logging.warning("learn.ops.dnn is deprecated, \
+    please use contrib.layers.dnn.")
   with vs.variable_scope('dnn'):
     for i, n_units in enumerate(hidden_units):
       with vs.variable_scope('layer%d' % i):

--- a/tensorflow/contrib/learn/python/learn/ops/dropout_ops.py
+++ b/tensorflow/contrib/learn/python/learn/ops/dropout_ops.py
@@ -1,3 +1,4 @@
+
 # Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +22,10 @@ from __future__ import print_function
 
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import init_ops
-from tensorflow.python.ops import nn
 from tensorflow.python.ops import variable_scope as vs
+from tensorflow.python.platform import tf_logging as logging
+
+from tensorflow.contrib.layers import dropout as contrib_dropout
 
 # Key to collect dropout probabilities.
 DROPOUTS = "dropouts"
@@ -30,7 +33,8 @@ DROPOUTS = "dropouts"
 
 def dropout(tensor_in, prob, name=None):
   """Adds dropout node and stores probability tensor into graph collection.
-
+  This is deprecated. Please use contrib.layers.dropout instead. 
+  
   Args:
     tensor_in: Input tensor.
     prob: Float or Tensor.
@@ -42,10 +46,12 @@ def dropout(tensor_in, prob, name=None):
   Raises:
     ValueError: If `keep_prob` is not in `(0, 1]`.
   """
+  logging.warning("learn.ops.dropout is deprecated, \
+    please use contrib.layers.dropout.")
   with ops.op_scope([tensor_in], name, "dropout") as name:
     if isinstance(prob, float):
       prob = vs.get_variable("prob", [],
                              initializer=init_ops.constant_initializer(prob),
                              trainable=False)
     ops.add_to_collection(DROPOUTS, prob)
-    return nn.dropout(tensor_in, prob)
+    return contrib_dropout(tensor_in, keep_prob=prob)

--- a/tensorflow/contrib/learn/python/learn/ops/tests/dropout_ops_test.py
+++ b/tensorflow/contrib/learn/python/learn/ops/tests/dropout_ops_test.py
@@ -29,6 +29,7 @@ class DropoutTest(tf.test.TestCase):
 
   def test_dropout_float(self):
     with self.test_session() as session:
+      tf.add_to_collection("IS_TRAINING", True)
       x = tf.placeholder(tf.float32, [5, 5])
       ops.dropout(x, 0.5)
       probs = tf.get_collection(ops.DROPOUTS)
@@ -38,6 +39,7 @@ class DropoutTest(tf.test.TestCase):
 
   def test_dropout_tensor(self):
     with self.test_session():
+      tf.add_to_collection("IS_TRAINING", True)
       x = tf.placeholder(tf.float32, [5, 5])
       y = tf.get_variable("prob", [], initializer=tf.constant_initializer(0.5))
       ops.dropout(x, y)


### PR DESCRIPTION
For dnn, simply added a deprecation message. BTW, there's a bug in `TensorFlowEstimator` where dropout is still happening during testing. But I am guessing that's not critical at this moment since it will be deprecated anyways. 

Question: do we want a separate layer that combines both dnn and dropout in `contrib.layers`, e.g. `dnn_with_dropout`? 
