### PR TITLE
Fixup url to MNIST fully-connected feed tutorial

### DIFF
--- a/tensorflow/g3doc/get_started/basic_usage.md
+++ b/tensorflow/g3doc/get_started/basic_usage.md
@@ -319,6 +319,6 @@ with tf.Session() as sess:
 A `placeholder()` operation generates an error if you do not supply a feed for
 it. See the
 [MNIST fully-connected feed tutorial](../tutorials/mnist/tf/index.md)
-([source code](https://www.tensorflow.org/code/tensorflow/g3doc/tutorials/mnist/fully_connected_feed.py))
+([source code](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/fully_connected_feed.py))
 for a larger-scale example of feeds.
 


### PR DESCRIPTION
Documentation at https://www.tensorflow.org/versions/r0.9/get_started/basic_usage.html ends with " See the MNIST fully-connected feed tutorial (source code) for a larger-scale example of feeds.", including a link to a broken url.  This changeset changes the source code url from https://www.tensorflow.org/code/tensorflow/g3doc/tutorials/mnist/fully_connected_feed.py to https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/fully_connected_feed.py so that the link resolves to relevant source code.
