### PR TITLE
Cast tf.shape() output to int32 for SparseTensor

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -125,7 +125,7 @@ def shape(input, name=None):
   """
   with ops.op_scope([input], name, "Shape") as name:
     if isinstance(input, ops.SparseTensor):
-      return input.shape
+      return gen_math_ops.cast(input.shape, dtypes.int32)
     else:
       return gen_array_ops.shape(input, name=name)
 


### PR DESCRIPTION
`input.shape` gives a `Tensor` of type `int64`, where `input` is a `SparseTensor`. Cast the output of `tf.shape()` to `int32` for a `SparseTensor` to be consistent with the doc. Tested and verified locally. This completes the changes for #1968.
