### PR TITLE
Use string_to_hash_bucket_fast in feature_column

### DIFF
--- a/tensorflow/contrib/layers/python/layers/feature_column.py
+++ b/tensorflow/contrib/layers/python/layers/feature_column.py
@@ -344,7 +344,7 @@ class _SparseColumnHashed(_SparseColumn):
 
   def insert_transformed_feature(self, columns_to_tensors):
     """Handles sparse column to id conversion."""
-    sparse_id_values = string_ops.string_to_hash_bucket(
+    sparse_id_values = string_ops.string_to_hash_bucket_fast(
         columns_to_tensors[self.name].values,
         self.bucket_size,
         name=self.name + "_lookup")


### PR DESCRIPTION
Updated feature_column to use string_to_hash_bucket_fast instead of deprecated string_to_hash_bucket.
