### PR TITLE
CIFAR-10 init routine breaks simple usages

### DIFF
--- a/tensorflow/models/image/cifar10/__init__.py
+++ b/tensorflow/models/image/cifar10/__init__.py
@@ -17,6 +17,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from tensorflow.models.image.cifar10 import cifar10
-from tensorflow.models.image.cifar10 import cifar10_input


### PR DESCRIPTION
This is partly breaking the CIFAR-10 example, and it doesn't make sense.

The files `cifar10.py` and `cifar10_input_test.py` already import `cifar10_input`, so the initialization doesn't seem to be needed at all.
If one tries to copy the code of `cifar10.py` and run it, it will break, since `__init__.py` imports cifar10, which defines the flags `batch_size` and `data_dir`, causing an error when your `cifar10.py` tries to redefine them.

To reproduce the problem, create a file exactly like `cifar10.py` and try to run it.
