### PR TITLE
fix word2vec_test's tmp path

### DIFF
--- a/tensorflow/models/embedding/word2vec_test.py
+++ b/tensorflow/models/embedding/word2vec_test.py
@@ -33,8 +33,8 @@ FLAGS = flags.FLAGS
 class Word2VecTest(tf.test.TestCase):
 
   def setUp(self):
-    FLAGS.train_data = os.path.join(self.get_temp_dir() + "test-text.txt")
-    FLAGS.eval_data = os.path.join(self.get_temp_dir() + "eval-text.txt")
+    FLAGS.train_data = os.path.join(self.get_temp_dir(), "test-text.txt")
+    FLAGS.eval_data = os.path.join(self.get_temp_dir(), "eval-text.txt")
     FLAGS.save_path = self.get_temp_dir()
     with open(FLAGS.train_data, "w") as f:
       f.write(


### PR DESCRIPTION
fix word2vec_test's tmp path:
'/tmp/word2vec_testtest-text.txt' to '/tmp/word2vec_test/test-text.txt'
'/tmp/word2vec_testeval-text.txt' to '/tmp/word2vec_test/eval-text.txt'
