### PR TITLE
Update Eigen to new version with cumsum/cumprod fixes

### DIFF
--- a/eigen.BUILD
+++ b/eigen.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-archive_dir = "eigen-eigen-5f86b31739cd"
+archive_dir = "eigen-eigen-33b6158ab608"
 
 cc_library(
     name = "eigen",

--- a/tensorflow/contrib/cmake/external/eigen.cmake
+++ b/tensorflow/contrib/cmake/external/eigen.cmake
@@ -7,7 +7,7 @@
 
 include (ExternalProject)
 
-set(eigen_archive_hash "5f86b31739cd")
+set(eigen_archive_hash "33b6158ab608")
 
 set(eigen_INCLUDE_DIRS
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -6,8 +6,8 @@
 def tf_workspace(path_prefix = "", tf_repo_name = ""):
   native.new_http_archive(
     name = "eigen_archive",
-    url = "https://bitbucket.org/eigen/eigen/get/5f86b31739cd.tar.gz",
-    sha256 = "e1101422f198a5d8c07e008eb801aeac385bf3022d88a0f041acc9f77e09d26e",
+    url = "https://bitbucket.org/eigen/eigen/get/33b6158ab608.tar.gz",
+    sha256 = "e8b9991edd9e294c16bad958de95643e72eecc33d776f1352de3b2f08a00ce79",
     build_file = path_prefix + "eigen.BUILD",
   )
 

--- a/third_party/eigen3/Eigen/Cholesky
+++ b/third_party/eigen3/Eigen/Cholesky
@@ -1,1 +1,1 @@
-#include "eigen-eigen-5f86b31739cd/Eigen/Cholesky"
+#include "eigen-eigen-33b6158ab608/Eigen/Cholesky"

--- a/third_party/eigen3/Eigen/Core
+++ b/third_party/eigen3/Eigen/Core
@@ -1,1 +1,1 @@
-#include "eigen-eigen-5f86b31739cd/Eigen/Core"
+#include "eigen-eigen-33b6158ab608/Eigen/Core"

--- a/third_party/eigen3/Eigen/Eigenvalues
+++ b/third_party/eigen3/Eigen/Eigenvalues
@@ -1,1 +1,1 @@
-#include "eigen-eigen-5f86b31739cd/Eigen/Eigenvalues"
+#include "eigen-eigen-33b6158ab608/Eigen/Eigenvalues"

--- a/third_party/eigen3/Eigen/LU
+++ b/third_party/eigen3/Eigen/LU
@@ -1,1 +1,1 @@
-#include "eigen-eigen-5f86b31739cd/Eigen/LU"
+#include "eigen-eigen-33b6158ab608/Eigen/LU"

--- a/third_party/eigen3/Eigen/QR
+++ b/third_party/eigen3/Eigen/QR
@@ -1,1 +1,1 @@
-#include "eigen-eigen-5f86b31739cd/Eigen/QR"
+#include "eigen-eigen-33b6158ab608/Eigen/QR"

--- a/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
+++ b/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
@@ -1,1 +1,1 @@
-#include "eigen-eigen-5f86b31739cd/unsupported/Eigen/CXX11/Tensor"
+#include "eigen-eigen-33b6158ab608/unsupported/Eigen/CXX11/Tensor"


### PR DESCRIPTION
Would it be okay to update the version of Eigen to one that contains the fixes needed for #2711 to get merged?
This PR changes the version to the one right after the fixes were merged.
