### PR TITLE
README: fix shell snippet markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ People who are a little bit adventurous can also try our nightly binaries:
 * [Android](http://ci.tensorflow.org/view/Nightly/job/nightly-matrix-android/TF_BUILD_CONTAINER_TYPE=ANDROID,TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=NO_PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=android-slave/lastSuccessfulBuild/artifact/bazel-out/local_linux/bin/tensorflow/examples/android/tensorflow_demo.apk) ([build history](http://ci.tensorflow.org/view/Nightly/job/nightly-matrix-android/TF_BUILD_CONTAINER_TYPE=ANDROID,TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=NO_PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=android-slave/))
 
 #### *Try your first TensorFlow program*
-```python
+```shell
 $ python
-
+```
+```python
 >>> import tensorflow as tf
 >>> hello = tf.constant('Hello, TensorFlow!')
 >>> sess = tf.Session()


### PR DESCRIPTION
Fixes shell snippet markdown, by ensuring that
the shell command `python` and the actual Python code
are separated in different code blocks. This is to prevent
a formatting nit because $ not in string form, is not
a valid Python token.
### Before

<img width="682" alt="screen shot 2016-06-23 at 11 38 15 pm" src="https://cloud.githubusercontent.com/assets/4898263/16330389/ac42f926-399d-11e6-84d6-4110fc3293b2.png">
### After

<img width="501" alt="screen shot 2016-06-23 at 11 54 38 pm" src="https://cloud.githubusercontent.com/assets/4898263/16330423/e8645ad0-399d-11e6-981a-9c2fa8756a42.png">
