### PR TITLE
Templatize dtype in RGBToHSV and HSVToRGB

### DIFF
--- a/tensorflow/core/kernels/colorspace_op.cc
+++ b/tensorflow/core/kernels/colorspace_op.cc
@@ -64,7 +64,7 @@ class RGBToHSVOp : public OpKernel {
 
     Tensor trange;
     OP_REQUIRES_OK(
-        context, context->allocate_temp(DataTypeToEnum<float>::value,
+        context, context->allocate_temp(DataTypeToEnum<T>::value,
                                         TensorShape({input_data.dimension(0)}),
                                         &trange));
 
@@ -114,6 +114,7 @@ class HSVToRGBOp : public OpKernel {
                           HSVToRGBOp<CPUDevice, T>);          \
   template class HSVToRGBOp<CPUDevice, T>;
 TF_CALL_float(REGISTER_CPU);
+TF_CALL_double(REGISTER_CPU);
 
 #if GOOGLE_CUDA
 // Forward declarations of the function specializations for GPU (to prevent
@@ -132,6 +133,7 @@ namespace functor {
       TTypes<T, 2>::Tensor output_data);                      \
   extern template struct HSVToRGB<GPUDevice, T>;
 TF_CALL_float(DECLARE_GPU);
+TF_CALL_double(DECLARE_GPU);
 }  // namespace functor
 #define REGISTER_GPU(T)                                       \
   REGISTER_KERNEL_BUILDER(Name("RGBToHSV").Device(DEVICE_GPU) \
@@ -141,6 +143,7 @@ TF_CALL_float(DECLARE_GPU);
                               .TypeConstraint<T>("T"),        \
                           HSVToRGBOp<GPUDevice, T>);
 TF_CALL_float(REGISTER_GPU);
+TF_CALL_double(REGISTER_GPU);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/colorspace_op.cc
+++ b/tensorflow/core/kernels/colorspace_op.cc
@@ -36,7 +36,7 @@ namespace tensorflow {
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
 
-template <typename Device>
+template <typename Device, typename T>
 class RGBToHSVOp : public OpKernel {
  public:
   explicit RGBToHSVOp(OpKernelConstruction* context) : OpKernel(context) {}
@@ -59,8 +59,8 @@ class RGBToHSVOp : public OpKernel {
 
     // Make a canonical image, maintaining the last (channel) dimension, while
     // flattening all others do give the functor easy to work with data.
-    TTypes<float, 2>::ConstTensor input_data = input.flat_inner_dims<float>();
-    TTypes<float, 2>::Tensor output_data = output->flat_inner_dims<float>();
+    typename TTypes<T, 2>::ConstTensor input_data = input.flat_inner_dims<T>();
+    typename TTypes<T, 2>::Tensor output_data = output->flat_inner_dims<T>();
 
     Tensor trange;
     OP_REQUIRES_OK(
@@ -68,14 +68,14 @@ class RGBToHSVOp : public OpKernel {
                                         TensorShape({input_data.dimension(0)}),
                                         &trange));
 
-    TTypes<float, 1>::Tensor range = trange.tensor<float, 1>();
+    typename TTypes<T, 1>::Tensor range = trange.tensor<T, 1>();
 
-    functor::RGBToHSV<Device>()(context->eigen_device<Device>(), input_data,
-                                range, output_data);
+    functor::RGBToHSV<Device, T>()(context->eigen_device<Device>(), input_data,
+                                   range, output_data);
   }
 };
 
-template <typename Device>
+template <typename Device, typename T>
 class HSVToRGBOp : public OpKernel {
  public:
   explicit HSVToRGBOp(OpKernelConstruction* context) : OpKernel(context) {}
@@ -96,41 +96,51 @@ class HSVToRGBOp : public OpKernel {
     OP_REQUIRES_OK(context,
                    context->allocate_output(0, input.shape(), &output));
 
-    TTypes<float, 2>::ConstTensor input_data = input.flat_inner_dims<float>();
-    TTypes<float, 2>::Tensor output_data = output->flat_inner_dims<float>();
+    typename TTypes<T, 2>::ConstTensor input_data = input.flat_inner_dims<T>();
+    typename TTypes<T, 2>::Tensor output_data = output->flat_inner_dims<T>();
 
-    functor::HSVToRGB<Device>()(context->eigen_device<Device>(), input_data,
-                                output_data);
+    functor::HSVToRGB<Device, T>()(context->eigen_device<Device>(), input_data,
+                                   output_data);
   }
 };
 
-REGISTER_KERNEL_BUILDER(Name("RGBToHSV").Device(DEVICE_CPU),
-                        RGBToHSVOp<CPUDevice>);
-template class RGBToHSVOp<CPUDevice>;
-REGISTER_KERNEL_BUILDER(Name("HSVToRGB").Device(DEVICE_CPU),
-                        HSVToRGBOp<CPUDevice>);
-template class HSVToRGBOp<CPUDevice>;
+#define REGISTER_CPU(T)                                       \
+  REGISTER_KERNEL_BUILDER(Name("RGBToHSV").Device(DEVICE_CPU) \
+                              .TypeConstraint<T>("T"),        \
+                          RGBToHSVOp<CPUDevice, T>);          \
+  template class RGBToHSVOp<CPUDevice, T>;                    \
+  REGISTER_KERNEL_BUILDER(Name("HSVToRGB").Device(DEVICE_CPU) \
+                              .TypeConstraint<T>("T"),        \
+                          HSVToRGBOp<CPUDevice, T>);          \
+  template class HSVToRGBOp<CPUDevice, T>;
+TF_CALL_float(REGISTER_CPU);
 
 #if GOOGLE_CUDA
 // Forward declarations of the function specializations for GPU (to prevent
 // building the GPU versions here, they will be built compiling _gpu.cu.cc).
 namespace functor {
-template <>
-void RGBToHSV<GPUDevice>::operator()(const GPUDevice& d,
-                                     TTypes<float, 2>::ConstTensor input_data,
-                                     TTypes<float, 1>::Tensor range,
-                                     TTypes<float, 2>::Tensor output_data);
-extern template struct RGBToHSV<GPUDevice>;
-template <>
-void HSVToRGB<GPUDevice>::operator()(const GPUDevice& d,
-                                     TTypes<float, 2>::ConstTensor input_data,
-                                     TTypes<float, 2>::Tensor output_data);
-extern template struct HSVToRGB<GPUDevice>;
+#define DECLARE_GPU(T)                                        \
+  template <>                                                 \
+  void RGBToHSV<GPUDevice, T>::operator()(const GPUDevice& d, \
+      TTypes<T, 2>::ConstTensor input_data,                   \
+      TTypes<T, 1>::Tensor range,                             \
+      TTypes<T, 2>::Tensor output_data);                      \
+  extern template struct RGBToHSV<GPUDevice, T>;              \
+  template <>                                                 \
+  void HSVToRGB<GPUDevice, T>::operator()(const GPUDevice& d, \
+      TTypes<T, 2>::ConstTensor input_data,                   \
+      TTypes<T, 2>::Tensor output_data);                      \
+  extern template struct HSVToRGB<GPUDevice, T>;
+TF_CALL_float(DECLARE_GPU);
 }  // namespace functor
-REGISTER_KERNEL_BUILDER(Name("RGBToHSV").Device(DEVICE_GPU),
-                        RGBToHSVOp<GPUDevice>);
-REGISTER_KERNEL_BUILDER(Name("HSVToRGB").Device(DEVICE_GPU),
-                        HSVToRGBOp<GPUDevice>);
+#define REGISTER_GPU(T)                                       \
+  REGISTER_KERNEL_BUILDER(Name("RGBToHSV").Device(DEVICE_GPU) \
+                              .TypeConstraint<T>("T"),        \
+                          RGBToHSVOp<GPUDevice, T>);          \
+  REGISTER_KERNEL_BUILDER(Name("HSVToRGB").Device(DEVICE_GPU) \
+                              .TypeConstraint<T>("T"),        \
+                          HSVToRGBOp<GPUDevice, T>);
+TF_CALL_float(REGISTER_GPU);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/colorspace_op.h
+++ b/tensorflow/core/kernels/colorspace_op.h
@@ -48,17 +48,18 @@ struct RGBToHSV {
 
     range.device(d) = V - input_data.minimum(channel_axis);
 
-    S.device(d) = (V > 0.f).select(range / V, V.constant(0.f));
+    S.device(d) = (V > T(0)).select(range / V, V.constant(T(0)));
 
-    auto norm = range.inverse() * (1.f / 6.f);
+    auto norm = range.inverse() * (T(1) / T(6));
     // TODO(wicke): all these assignments are only necessary because a combined
     // expression is larger than kernel parameter space. A custom kernel is
     // probably in order.
     H.device(d) = (R == V).select(norm * (G - B),
-                                  (G == V).select(norm * (B - R) + 2.f / 6.f,
-                                                  norm * (R - G) + 4.f / 6.f));
-    H.device(d) = (range > 0.f).select(H, H.constant(0.f));
-    H.device(d) = (H < 0.f).select(H + 1.f, H);
+                                  (G == V).select(
+                                      norm * (B - R) + T(2) / T(6),
+                                      norm * (R - G) + T(4) / T(6)));
+    H.device(d) = (range > T(0)).select(H, H.constant(T(0)));
+    H.device(d) = (H < T(0)).select(H + T(1), H);
   }
 };
 
@@ -72,11 +73,11 @@ struct HSVToRGB {
     auto V = input_data.template chip<1>(2);
 
     // TODO(wicke): compute only the fractional part of H for robustness
-    auto dh = H * 6.f;
-    auto dr = ((dh - 3.f).abs() - 1.f).cwiseMax(0.f).cwiseMin(1.f);
-    auto dg = (-(dh - 2.f).abs() + 2.f).cwiseMax(0.f).cwiseMin(1.f);
-    auto db = (-(dh - 4.f).abs() + 2.f).cwiseMax(0.f).cwiseMin(1.f);
-    auto one_s = -S + 1.f;
+    auto dh = H * T(6);
+    auto dr = ((dh - T(3)).abs() - T(1)).cwiseMax(T(0)).cwiseMin(T(1));
+    auto dg = (-(dh - T(2)).abs() + T(2)).cwiseMax(T(0)).cwiseMin(T(1));
+    auto db = (-(dh - T(4)).abs() + T(2)).cwiseMax(T(0)).cwiseMin(T(1));
+    auto one_s = -S + T(1);
 
     auto R = output_data.template chip<1>(0);
     auto G = output_data.template chip<1>(1);

--- a/tensorflow/core/kernels/colorspace_op.h
+++ b/tensorflow/core/kernels/colorspace_op.h
@@ -24,18 +24,19 @@ namespace tensorflow {
 
 namespace functor {
 
-template <typename Device>
+template <typename Device, typename T>
 struct RGBToHSV {
-  void operator()(const Device &d, TTypes<float, 2>::ConstTensor input_data,
-                  TTypes<float, 1>::Tensor range,
-                  TTypes<float, 2>::Tensor output_data) {
-    auto H = output_data.chip<1>(0);
-    auto S = output_data.chip<1>(1);
-    auto V = output_data.chip<1>(2);
+  void operator()(const Device &d,
+                  typename TTypes<T, 2>::ConstTensor input_data,
+                  typename TTypes<T, 1>::Tensor range,
+                  typename TTypes<T, 2>::Tensor output_data) {
+    auto H = output_data.template chip<1>(0);
+    auto S = output_data.template chip<1>(1);
+    auto V = output_data.template chip<1>(2);
 
-    auto R = input_data.chip<1>(0);
-    auto G = input_data.chip<1>(1);
-    auto B = input_data.chip<1>(2);
+    auto R = input_data.template chip<1>(0);
+    auto G = input_data.template chip<1>(1);
+    auto B = input_data.template chip<1>(2);
 
 #if !defined(EIGEN_HAS_INDEX_LIST)
     Eigen::array<int, 1> channel_axis{{1}};
@@ -61,13 +62,14 @@ struct RGBToHSV {
   }
 };
 
-template <typename Device>
+template <typename Device, typename T>
 struct HSVToRGB {
-  void operator()(const Device &d, TTypes<float, 2>::ConstTensor input_data,
-                  TTypes<float, 2>::Tensor output_data) {
-    auto H = input_data.chip<1>(0);
-    auto S = input_data.chip<1>(1);
-    auto V = input_data.chip<1>(2);
+  void operator()(const Device &d,
+                  typename TTypes<T, 2>::ConstTensor input_data,
+                  typename TTypes<T, 2>::Tensor output_data) {
+    auto H = input_data.template chip<1>(0);
+    auto S = input_data.template chip<1>(1);
+    auto V = input_data.template chip<1>(2);
 
     // TODO(wicke): compute only the fractional part of H for robustness
     auto dh = H * 6.f;
@@ -76,9 +78,9 @@ struct HSVToRGB {
     auto db = (-(dh - 4.f).abs() + 2.f).cwiseMax(0.f).cwiseMin(1.f);
     auto one_s = -S + 1.f;
 
-    auto R = output_data.chip<1>(0);
-    auto G = output_data.chip<1>(1);
-    auto B = output_data.chip<1>(2);
+    auto R = output_data.template chip<1>(0);
+    auto G = output_data.template chip<1>(1);
+    auto B = output_data.template chip<1>(2);
 
     R.device(d) = (one_s + S * dr) * V;
     G.device(d) = (one_s + S * dg) * V;

--- a/tensorflow/core/kernels/colorspace_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/colorspace_op_gpu.cu.cc
@@ -28,6 +28,7 @@ typedef Eigen::GpuDevice GPUDevice;
   template class functor::RGBToHSV<GPUDevice, T>; \
   template class functor::HSVToRGB<GPUDevice, T>;
 TF_CALL_float(INSTANTIATE_GPU);
+TF_CALL_double(INSTANTIATE_GPU);
 }
 
 #endif  // GOOGLE_CUDA

--- a/tensorflow/core/kernels/colorspace_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/colorspace_op_gpu.cu.cc
@@ -24,8 +24,10 @@ namespace tensorflow {
 
 typedef Eigen::GpuDevice GPUDevice;
 
-template class functor::RGBToHSV<GPUDevice>;
-template class functor::HSVToRGB<GPUDevice>;
+#define INSTANTIATE_GPU(T)                        \
+  template class functor::RGBToHSV<GPUDevice, T>; \
+  template class functor::HSVToRGB<GPUDevice, T>;
+TF_CALL_float(INSTANTIATE_GPU);
 }
 
 #endif  // GOOGLE_CUDA

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -353,7 +353,7 @@ contents: 0-D. PNG-encoded image.
 REGISTER_OP("RGBToHSV")
     .Input("images: T")
     .Output("output: T")
-    .Attr("T: {float, double}")
+    .Attr("T: {float, double} = DT_FLOAT")
     .Doc(R"doc(
 Converts one or more images from RGB to HSV.
 
@@ -373,7 +373,7 @@ output: `images` converted to HSV.
 REGISTER_OP("HSVToRGB")
     .Input("images: T")
     .Output("output: T")
-    .Attr("T: {float, double}")
+    .Attr("T: {float, double} = DT_FLOAT")
     .Doc(R"doc(
 Convert one or more images from HSV to RGB.
 

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -353,7 +353,7 @@ contents: 0-D. PNG-encoded image.
 REGISTER_OP("RGBToHSV")
     .Input("images: T")
     .Output("output: T")
-    .Attr("T: {float}")
+    .Attr("T: {float, double}")
     .Doc(R"doc(
 Converts one or more images from RGB to HSV.
 
@@ -373,7 +373,7 @@ output: `images` converted to HSV.
 REGISTER_OP("HSVToRGB")
     .Input("images: T")
     .Output("output: T")
-    .Attr("T: {float}")
+    .Attr("T: {float, double}")
     .Doc(R"doc(
 Convert one or more images from HSV to RGB.
 

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -351,8 +351,9 @@ contents: 0-D. PNG-encoded image.
 
 // --------------------------------------------------------------------------
 REGISTER_OP("RGBToHSV")
-    .Input("images: float")
-    .Output("output: float")
+    .Input("images: T")
+    .Output("output: T")
+    .Attr("T: {float}")
     .Doc(R"doc(
 Converts one or more images from RGB to HSV.
 
@@ -370,8 +371,9 @@ output: `images` converted to HSV.
 
 // --------------------------------------------------------------------------
 REGISTER_OP("HSVToRGB")
-    .Input("images: float")
-    .Output("output: float")
+    .Input("images: T")
+    .Output("output: T")
+    .Attr("T: {float}")
     .Doc(R"doc(
 Convert one or more images from HSV to RGB.
 

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -40,34 +40,37 @@ class RGBToHSVTest(test_util.TensorFlowTestCase):
     np.random.seed(7)
     batch_size = 5
     shape = (batch_size, 2, 7, 3)
-    inp = np.random.rand(*shape).astype(np.float32)
 
-    # Convert to HSV and back, as a batch and individually
-    with self.test_session() as sess:
-      batch0 = constant_op.constant(inp)
-      batch1 = image_ops.rgb_to_hsv(batch0)
-      batch2 = image_ops.hsv_to_rgb(batch1)
-      split0 = array_ops.unpack(batch0)
-      split1 = list(map(image_ops.rgb_to_hsv, split0))
-      split2 = list(map(image_ops.hsv_to_rgb, split1))
-      join1 = array_ops.pack(split1)
-      join2 = array_ops.pack(split2)
-      batch1, batch2, join1, join2 = sess.run([batch1, batch2, join1, join2])
+    for nptype in [np.float32, np.float64]:
+      inp = np.random.rand(*shape).astype(nptype)
 
-    # Verify that processing batch elements together is the same as separate
-    self.assertAllClose(batch1, join1)
-    self.assertAllClose(batch2, join2)
-    self.assertAllClose(batch2, inp)
+      # Convert to HSV and back, as a batch and individually
+      with self.test_session() as sess:
+        batch0 = constant_op.constant(inp)
+        batch1 = image_ops.rgb_to_hsv(batch0)
+        batch2 = image_ops.hsv_to_rgb(batch1)
+        split0 = array_ops.unpack(batch0)
+        split1 = list(map(image_ops.rgb_to_hsv, split0))
+        split2 = list(map(image_ops.hsv_to_rgb, split1))
+        join1 = array_ops.pack(split1)
+        join2 = array_ops.pack(split2)
+        batch1, batch2, join1, join2 = sess.run([batch1, batch2, join1, join2])
+
+      # Verify that processing batch elements together is the same as separate
+      self.assertAllClose(batch1, join1)
+      self.assertAllClose(batch2, join2)
+      self.assertAllClose(batch2, inp)
 
   def testRGBToHSVRoundTrip(self):
     data = [0, 5, 13, 54, 135, 226, 37, 8, 234, 90, 255, 1]
-    rgb_np = np.array(data, dtype=np.float32).reshape([2, 2, 3]) / 255.
-    for use_gpu in [True, False]:
-      with self.test_session(use_gpu=use_gpu):
-        hsv = image_ops.rgb_to_hsv(rgb_np)
-        rgb = image_ops.hsv_to_rgb(hsv)
-        rgb_tf = rgb.eval()
-    self.assertAllClose(rgb_tf, rgb_np)
+    for nptype in [np.float32, np.float64]:
+      rgb_np = np.array(data, dtype=nptype).reshape([2, 2, 3]) / 255.
+      for use_gpu in [True, False]:
+        with self.test_session(use_gpu=use_gpu):
+          hsv = image_ops.rgb_to_hsv(rgb_np)
+          rgb = image_ops.hsv_to_rgb(hsv)
+          rgb_tf = rgb.eval()
+      self.assertAllClose(rgb_tf, rgb_np)
 
 
 class GrayscaleToRGBTest(test_util.TensorFlowTestCase):


### PR DESCRIPTION
`RGBToHSV` and `HSVToRGB` currently work only for `float32` inputs. Made the data type a template parameter so that other input types like `float16` and `float64` can be used. This change is towards resolving #1140 for the above mentioned operations.

This change does not enable `float64`, as incorporating new types will also need new tests, something I'm not sure about at this point. (Addressed to whoever looks at the PR) Could you explain how the tests in `core/kernels/colorspace_op_test.cc` can be executed, and how they need to be changed in case `float64` is enabled?
