### PR TITLE
Better docs of returned tensor in ctc_ops.py

### DIFF
--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -95,7 +95,7 @@ def ctc_loss(inputs, labels, sequence_length,
     ctc_merge_repeated: Boolean.  Default: True.
 
   Returns:
-    A 1-D `float` `Tensor`, size `[batch]`, containing logits.
+    A 1-D `float` `Tensor`, size `[batch]`, containing the minus log probabilities.
 
   Raises:
     TypeError: if labels is not a `SparseTensor`.

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -95,7 +95,7 @@ def ctc_loss(inputs, labels, sequence_length,
     ctc_merge_repeated: Boolean.  Default: True.
 
   Returns:
-    A 1-D `float` `Tensor`, size `[batch]`, containing the minus log probabilities.
+    A 1-D `float` `Tensor`, size `[batch]`, containing the negative log probabilities.
 
   Raises:
     TypeError: if labels is not a `SparseTensor`.


### PR DESCRIPTION
'Logits' aren't a meaningful word for what the ctc_cost function returns. Browsing the implementation (tensorflow/tensorflow/core/util/ctc/) I saw that the cost function is returning the negative log probabilities of the target labelling, so, this new comment erases any doubt. Thanks!
