### PR TITLE
Remove explicit dependency on Python 2.7 from crosstool wrapper

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # Copyright 2015 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,8 @@ NOTES:
   //third_party/gpus/crosstool/v*/*/clang/bin/crosstool_wrapper_is_not_gcc
 """
 
+from __future__ import print_function
+
 __author__ = 'keveman@google.com (Manjunath Kudlur)'
 
 from argparse import ArgumentParser
@@ -54,7 +56,7 @@ LLVM_HOST_COMPILER_PATH = ('/usr/bin/gcc')
 PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH)
 
 def Log(s):
-  print 'gpus/crosstool: {0}'.format(s)
+  print('gpus/crosstool: {0}'.format(s))
 
 
 def GetOptionValue(argv, option):


### PR DESCRIPTION
Many superclusters need to compile TensorFlow from source due to an outdated glibc version (see #110). In @rdipietro's excellent workaround post (https://github.com/tensorflow/tensorflow/issues/110#issuecomment-219790730) he mentions issues with the referenced Python version in this file. I have issues as well, but of a different nature. In my case the build script is unable to find `libpython2.7.so.1.0`, since only Python 3 is present on my machine. The issue originates from `crosstool_wrapper_driver_is_not_gcc` where the only Python 2.7 exclusive feature is the `print` statement. By `import`ing `print_function from __future__` the explicit dependency can be dropped and both versions of Python are supported.
