### PR TITLE
Fix the TensorBoard README link on the how to page.

### DIFF
--- a/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
+++ b/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
@@ -12,7 +12,7 @@ TensorBoard is fully configured, it looks like this:
 [*Click try a TensorBoard with data from this tutorial!*](http://tensorflow.org/tensorboard)
 
 This tutorial is intended to get you started with simple TensorBoard usage.
-There are other resources available as well! The [TensorBoard README](../../../tensorboard/README.md)
+There are other resources available as well! The [TensorBoard README](https://www.tensorflow.org/code/tensorflow/tensorboard/README.md)
 has a lot more information on TensorBoard usage, including tips & tricks, and
 debugging information.
 


### PR DESCRIPTION
Change: 125799092

Backporting this change from master to r0.9 to fix the link in the r0.9 TensorBoard how-to too.
