### PR TITLE
Resolve the libcudnn library to its SONAME, when possible,

### DIFF
--- a/configure
+++ b/configure
@@ -174,6 +174,19 @@ while true; do
 
   if [[ -z "$TF_CUDNN_VERSION" ]]; then
     TF_CUDNN_EXT=""
+    # Resolve to the SONAME of the symlink.  Use readlink without -f
+    # to resolve exactly once to the SONAME.  E.g, libcudnn.so ->
+    # libcudnn.so.4
+    REALVAL=`readlink ${CUDNN_INSTALL_PATH}/lib64/libcudnn.so`
+
+    # Extract the version of the SONAME, if it was indeed symlinked to
+    # the SONAME version of the file.
+    if [[ "$REALVAL" =~ .so[.]+([0-9]*) ]];
+    then
+      TF_CUDNN_EXT="."${BASH_REMATCH[1]}
+      TF_CUDNN_VERSION=${BASH_REMATCH[1]}
+      echo "libcudnn.so resolves to libcudnn${TF_CUDNN_EXT}"
+    fi
   else
     TF_CUDNN_EXT=".$TF_CUDNN_VERSION"
   fi


### PR DESCRIPTION
and build the binary with that SONAME, which is supposed to be
ABI-compatible.

When we build our pip packages, we will now build with precisely
the version of the SONAME that we intend to support with the
binary packages.  This is the solution recommended by @3XX0.

Tested by installing cudnn 5.1.3 RC and seeing that the source code
modifications show the use of version "5" (the SONAME version
pointed to by libcudnn.so symlink).

In addition, installing the pip package shows:

> > > import tensorflow as tf
> > > I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcublas.so locally
> > > I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcudnn.so.5 locally
> > > I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcufft.so locally
> > > I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcuda.so.1 locally
> > > I tensorflow/stream_executor/dso_loader.cc:108] successfully opened CUDA library libcurand.so locally
