### PR TITLE
Fix path to boringssl_err_data_c in workspace.bzl.

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -149,7 +149,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
   native.bind(
     name = "boringssl_err_data_c",
-    actual = "@//" + path_prefix + "third_party/boringssl:err_data_c",
+    actual = tf_repo_name + "//third_party/boringssl:err_data_c",
   )
 
   native.new_git_repository(


### PR DESCRIPTION
Passing in an absolute path for `path_prefix` gave me this error:

```
invalid package name '.../boringssl': package names may not start with '/'.
```

I believe the intent was to refer to the target within the TF repo, and
I think that `tf_repo_name` is supposed to accomplish this.
