### PR TITLE
solve the building issues "Undefined reference to symbol 'ceil@@GLIBC_2.2.5'"

### DIFF
--- a/tensorflow/tools/proto_text/BUILD
+++ b/tensorflow/tools/proto_text/BUILD
@@ -43,10 +43,12 @@ cc_library(
     srcs = ["gen_proto_text_functions_lib.cc"],
     hdrs = ["gen_proto_text_functions_lib.h"],
     linkopts = [
-        "-lpthread",
         "-lm",
-        "-lrt",
-    ],    
+        "-lpthread",
+    ] + select({
+        "//tensorflow:darwin": [],
+        "//conditions:default": ["-lrt"]
+    }),    
     deps = [
         "//tensorflow/core:lib",
     ],

--- a/tensorflow/tools/proto_text/BUILD
+++ b/tensorflow/tools/proto_text/BUILD
@@ -42,6 +42,11 @@ cc_library(
     name = "gen_proto_text_functions_lib",
     srcs = ["gen_proto_text_functions_lib.cc"],
     hdrs = ["gen_proto_text_functions_lib.h"],
+    linkopts = [
+        "-lpthread",
+        "-lm",
+        "-lrt",
+    ],    
     deps = [
         "//tensorflow/core:lib",
     ],


### PR DESCRIPTION
This is to solve the bug `Undefined reference to symbol 'ceil@@GLIBC_2.2.5'`
https://github.com/tensorflow/tensorflow/issues/3070,
the solution is inspired from https://github.com/bazelbuild/bazel/issues/934 and https://github.com/tensorflow/tensorflow/issues/1171
