### PR TITLE
Fixes code URLs and a heading in docs

### DIFF
--- a/tensorflow/g3doc/tutorials/tflearn/index.md
+++ b/tensorflow/g3doc/tutorials/tflearn/index.md
@@ -1,4 +1,4 @@
-## tf.contrib.learn Quickstart
+# tf.contrib.learn Quickstart
 
 TensorFlow’s high-level machine learning API (tf.contrib.learn) makes it easy
 to configure, train, and evaluate a variety of machine learning models. In
@@ -98,7 +98,7 @@ import numpy as np
 ```
 
 Next, load the training and test sets into `Dataset`s using the [`load_csv()`]
-(https://www.tensorflow.org/code/tensorflow/contrib/learn/python/learn/datasets/base.py)  method in `learn.datasets.base`. The
+(https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/contrib/learn/python/learn/datasets/base.py)  method in `learn.datasets.base`. The
 `load_csv()` method has two required arguments:
 
 *   `filename`, which takes the filepath to the CSV file, and 
@@ -180,7 +180,7 @@ classifier.fit(x=x_train, y=y_train, steps=100)
 
 <!-- TODO: When tutorial exists for monitoring, link to it here -->
 However, if you're looking to track the model while it trains, you'll likely
-want to instead use a TensorFlow [`monitor`](https://www.tensorflow.org/code/tensorflow/contrib/learn/python/learn/monitors.py)
+want to instead use a TensorFlow [`monitor`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/contrib/learn/python/learn/monitors.py)
 to perform logging operations.
 
 ## Evaluate Model Accuracy

--- a/tensorflow/g3doc/tutorials/tflearn/index.md
+++ b/tensorflow/g3doc/tutorials/tflearn/index.md
@@ -98,7 +98,7 @@ import numpy as np
 ```
 
 Next, load the training and test sets into `Dataset`s using the [`load_csv()`]
-(https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/contrib/learn/python/learn/datasets/base.py)  method in `learn.datasets.base`. The
+(https://www.tensorflow.org/code/tensorflow/contrib/learn/python/learn/datasets/base.py)  method in `learn.datasets.base`. The
 `load_csv()` method has two required arguments:
 
 *   `filename`, which takes the filepath to the CSV file, and 
@@ -180,7 +180,7 @@ classifier.fit(x=x_train, y=y_train, steps=100)
 
 <!-- TODO: When tutorial exists for monitoring, link to it here -->
 However, if you're looking to track the model while it trains, you'll likely
-want to instead use a TensorFlow [`monitor`](https://cs.corp.google.com/#piper///depot/google3/third_party/tensorflow/contrib/learn/python/learn/monitors.py)
+want to instead use a TensorFlow [`monitor`](https://www.tensorflow.org/code/tensorflow/contrib/learn/python/learn/monitors.py)
 to perform logging operations.
 
 ## Evaluate Model Accuracy

--- a/tensorflow/g3doc/tutorials/wide/index.md
+++ b/tensorflow/g3doc/tutorials/wide/index.md
@@ -16,7 +16,7 @@ To try the code for this tutorial:
 already.
 
 2.  Download [the tutorial code](
-https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py).
+https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py).
 
 3.  Install the pandas data analysis library. tf.learn doesn't require pandas, but it does support it, and this tutorial uses pandas. To install pandas:
     1. Get `pip`:
@@ -392,7 +392,7 @@ transformations and see if you can do even better!
 
 If you'd like to see a working end-to-end example, you can download our [example
 code]
-(https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py)
+(https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py)
 and set the `model_type` flag to `wide`.
 
 ## Adding Regularization to Prevent Overfitting

--- a/tensorflow/g3doc/tutorials/wide_and_deep/index.md
+++ b/tensorflow/g3doc/tutorials/wide_and_deep/index.md
@@ -42,7 +42,7 @@ To try the code for this tutorial:
 already.
 
 2.  Download [the tutorial code](
-https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py).
+https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py).
 
 3.  Install the pandas data analysis library. tf.learn doesn't require pandas, but it does support it, and this tutorial uses pandas. To install pandas:
     1. Get `pip`:


### PR DESCRIPTION
Points links to wide_n_deep.py to master, and adjusts the heading level of the top level heading in the tf.contrib.learn quickstart.
