### PR TITLE
R0.9: Fixes URLs and headings

### DIFF
--- a/tensorflow/g3doc/tutorials/tflearn/index.md
+++ b/tensorflow/g3doc/tutorials/tflearn/index.md
@@ -1,4 +1,4 @@
-## tf.contrib.learn Quickstart
+# tf.contrib.learn Quickstart
 
 TensorFlow’s high-level machine learning API (tf.contrib.learn) makes it easy
 to configure, train, and evaluate a variety of machine learning models. In

--- a/tensorflow/g3doc/tutorials/wide/index.md
+++ b/tensorflow/g3doc/tutorials/wide/index.md
@@ -16,7 +16,7 @@ To try the code for this tutorial:
 already.
 
 2.  Download [the tutorial code](
-https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py).
+https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py).
 
 3.  Install the pandas data analysis library. tf.learn doesn't require pandas, but it does support it, and this tutorial uses pandas. To install pandas:
     1. Get `pip`:
@@ -392,7 +392,7 @@ transformations and see if you can do even better!
 
 If you'd like to see a working end-to-end example, you can download our [example
 code]
-(https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py)
+(https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py)
 and set the `model_type` flag to `wide`.
 
 ## Adding Regularization to Prevent Overfitting

--- a/tensorflow/g3doc/tutorials/wide_and_deep/index.md
+++ b/tensorflow/g3doc/tutorials/wide_and_deep/index.md
@@ -42,7 +42,7 @@ To try the code for this tutorial:
 already.
 
 2.  Download [the tutorial code](
-https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py).
+https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py).
 
 3.  Install the pandas data analysis library. tf.learn doesn't require pandas, but it does support it, and this tutorial uses pandas. To install pandas:
     1. Get `pip`:
@@ -134,7 +134,7 @@ of a neural network in the forward pass. The embedding values are initialized
 randomly, and are trained along with all other model parameters to minimize the
 training loss. If you're interested in learning more about embeddings, check out
 the TensorFlow tutorial on [Vector Representations of Words]
-(https://www.tensorflow.org/versions/r0.9/tutorials/word2vec/index.html), or
+(https://www.tensorflow.org/tutorials/word2vec/index.html), or
 [Word Embedding](https://en.wikipedia.org/wiki/Word_embedding) on Wikipedia.
 
 We'll configure the embeddings for the categorical columns using


### PR DESCRIPTION
Points links to wide_and_deep.py to master, fixes a heading, and changes a versioned URL to a generic URL.
