### PR TITLE
Update the directory of cuDNN in doc of install cuda

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -517,8 +517,8 @@ to reflect the cuDNN version you downloaded):
 
 ``` bash
 tar xvzf cudnn-7.5-linux-x64-v4.tgz
-sudo cp cudnn-7.5-linux-x64-v4/cudnn.h /usr/local/cuda/include
-sudo cp cudnn-7.5-linux-x64-v4/libcudnn* /usr/local/cuda/lib64
+sudo cp cuda/include/cudnn.h /usr/local/cuda/include
+sudo cp cuda/lib64/libcudnn* /usr/local/cuda/lib64
 sudo chmod a+r /usr/local/cuda/include/cudnn.h /usr/local/cuda/lib64/libcudnn*
 ```
 


### PR DESCRIPTION
The directory of cuDNN has been changed to `cuda`. It would be better to update the doc.
