### PR TITLE
change boringssl resource from googlesource to github

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -143,7 +143,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
   native.new_git_repository(
     name = "boringssl_git",
     commit = "e72df93461c6d9d2b5698f10e16d3ab82f5adde3",
-    remote = "https://boringssl.googlesource.com/boringssl",
+    remote = "https://github.com/google/boringssl.git",
     build_file = path_prefix + "boringssl.BUILD",
   )
 


### PR DESCRIPTION
Due to the network issue in China, the `https://boringssl.googlesource.com/boringssl` can not be downloaded while using Bazel. So I suggest to change it to a github mirror `https://github.com/google/boringssl.git`.
