### PR TITLE
Remove mentions of `with_dependencies` from API docs

### DIFF
--- a/tensorflow/g3doc/api_docs/python/control_flow_ops.md
+++ b/tensorflow/g3doc/api_docs/python/control_flow_ops.md
@@ -47,7 +47,7 @@ argument tensors can be computed in parallel, but the values of any tensor
 returned by `tuple` are only available after all the parallel computations
 are done.
 
-See also `group` and `with_dependencies`.
+See also [`tf.group()`](#group) and [`tf.control_dependencies()`](../../api_docs/python/framework.md#control_dependencies).
 
 ##### Args:
 
@@ -77,7 +77,7 @@ Create an op that groups multiple operations.
 When this op finishes, all ops in `input` have finished. This op has no
 output.
 
-See also `tuple` and `with_dependencies`.
+See also [`tf.tuple()`](#tuple) and [`tf.control_dependencies()`](../../api_docs/python/framework.md#control_dependencies).
 
 ##### Args:
 
@@ -745,12 +745,14 @@ Asserts that the given condition is true.
 If `condition` evaluates to false, print the list of tensors in `data`.
 `summarize` determines how many entries of the tensors to print.
 
-NOTE: To ensure that Assert executes, one usually attaches a dependency:
+NOTE: To ensure that Assert executes, one usually attaches a control
+dependency:
 
 ```python
  # Ensure maximum element of x is smaller or equal to 1
 assert_op = tf.Assert(tf.less_equal(tf.reduce_max(x), 1.), [x])
-x = tf.with_dependencies([assert_op], x)
+with tf.control_dependencies([assert_op]):
+  x = tf.identity(x)
 ```
 
 ##### Args:

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard0/tf.tuple.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard0/tf.tuple.md
@@ -14,7 +14,7 @@ argument tensors can be computed in parallel, but the values of any tensor
 returned by `tuple` are only available after all the parallel computations
 are done.
 
-See also `group` and `with_dependencies`.
+See also [`tf.group()`](#group) and [`tf.control_dependencies()`](../../api_docs/python/framework.md#control_dependencies).
 
 ##### Args:
 

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard3/tf.group.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard3/tf.group.md
@@ -5,7 +5,7 @@ Create an op that groups multiple operations.
 When this op finishes, all ops in `input` have finished. This op has no
 output.
 
-See also `tuple` and `with_dependencies`.
+See also [`tf.tuple()`](#tuple) and [`tf.control_dependencies()`](../../api_docs/python/framework.md#control_dependencies).
 
 ##### Args:
 

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard4/tf.Assert.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard4/tf.Assert.md
@@ -5,12 +5,14 @@ Asserts that the given condition is true.
 If `condition` evaluates to false, print the list of tensors in `data`.
 `summarize` determines how many entries of the tensors to print.
 
-NOTE: To ensure that Assert executes, one usually attaches a dependency:
+NOTE: To ensure that Assert executes, one usually attaches a control
+dependency:
 
 ```python
  # Ensure maximum element of x is smaller or equal to 1
 assert_op = tf.Assert(tf.less_equal(tf.reduce_max(x), 1.), [x])
-x = tf.with_dependencies([assert_op], x)
+with tf.control_dependencies([assert_op]):
+  x = tf.identity(x)
 ```
 
 ##### Args:

--- a/tensorflow/python/ops/control_flow_ops.py
+++ b/tensorflow/python/ops/control_flow_ops.py
@@ -1974,7 +1974,7 @@ def group(*inputs, **kwargs):
   When this op finishes, all ops in `input` have finished. This op has no
   output.
 
-  See also `tuple` and `with_dependencies`.
+  See also [`tf.tuple()`](#tuple) and [`tf.control_dependencies()`](../../api_docs/python/framework.md#control_dependencies).
 
   Args:
     *inputs: Zero or more tensors to group.
@@ -2037,7 +2037,7 @@ def tuple(tensors, name=None, control_inputs=None):
   returned by `tuple` are only available after all the parallel computations
   are done.
 
-  See also `group` and `with_dependencies`.
+  See also [`tf.group()`](#group) and [`tf.control_dependencies()`](../../api_docs/python/framework.md#control_dependencies).
 
   Args:
     tensors: A list of `Tensor`s or `IndexedSlices`, some entries can be `None`.

--- a/tensorflow/python/ops/logging_ops.py
+++ b/tensorflow/python/ops/logging_ops.py
@@ -37,12 +37,14 @@ def Assert(condition, data, summarize=None, name=None):
   If `condition` evaluates to false, print the list of tensors in `data`.
   `summarize` determines how many entries of the tensors to print.
 
-  NOTE: To ensure that Assert executes, one usually attaches a dependency:
+  NOTE: To ensure that Assert executes, one usually attaches a control
+  dependency:
 
   ```python
    # Ensure maximum element of x is smaller or equal to 1
   assert_op = tf.Assert(tf.less_equal(tf.reduce_max(x), 1.), [x])
-  x = tf.with_dependencies([assert_op], x)
+  with tf.control_dependencies([assert_op]):
+    x = tf.identity(x)
   ```
 
   Args:


### PR DESCRIPTION
We no longer (perhaps never did?) expose this function in our public API, so it shouldn't be mentioned in our public API docs.
