### PR TITLE
Add Float64 support to CTC Decoder Ops

### DIFF
--- a/tensorflow/core/kernels/ctc_decoder_ops.cc
+++ b/tensorflow/core/kernels/ctc_decoder_ops.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/core/util/ctc/ctc_beam_search.h"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/logging.h"
@@ -32,11 +33,12 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 
-inline float RowMax(const TTypes<float>::UnalignedConstMatrix& m, int r,
+template <typename T>
+inline T RowMax(typename TTypes<T>::UnalignedConstMatrix& m, int r,
                     int* c) {
   *c = 0;
   CHECK_LT(0, m.dimension(1));
-  float p = m(r, 0);
+  T p = m(r, 0);
   for (int i = 1; i < m.dimension(1); ++i) {
     if (m(r, i) > p) {
       p = m(r, i);
@@ -168,6 +170,7 @@ class CTCDecodeHelper {
   TF_DISALLOW_COPY_AND_ASSIGN(CTCDecodeHelper);
 };
 
+template <typename T>
 class CTCGreedyDecoderOp : public OpKernel {
  public:
   explicit CTCGreedyDecoderOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
@@ -187,7 +190,7 @@ class CTCGreedyDecoderOp : public OpKernel {
 
     const TensorShape& inputs_shape = inputs->shape();
 
-    std::vector<TTypes<float>::UnalignedConstMatrix> input_list_t;
+    std::vector<typename TTypes<T>::UnalignedConstMatrix> input_list_t;
     const int64 max_time = inputs_shape.dim_size(0);
     const int64 batch_size = inputs_shape.dim_size(1);
     const int64 num_classes_raw = inputs_shape.dim_size(2);
@@ -196,14 +199,14 @@ class CTCGreedyDecoderOp : public OpKernel {
         errors::InvalidArgument("num_classes cannot exceed max int"));
     const int num_classes = static_cast<const int>(num_classes_raw);
 
-    auto inputs_t = inputs->tensor<float, 3>();
+    auto inputs_t = inputs->tensor<T, 3>();
 
     for (std::size_t t = 0; t < max_time; ++t) {
       input_list_t.emplace_back(inputs_t.data() + t * batch_size * num_classes,
                                 batch_size, num_classes);
     }
     auto seq_len_t = seq_len->vec<int32>();
-    auto log_prob_t = log_prob->matrix<float>();
+    auto log_prob_t = log_prob->matrix<T>();
 
     log_prob_t.setZero();
 
@@ -218,7 +221,7 @@ class CTCGreedyDecoderOp : public OpKernel {
       int prev_indices = -1;
       for (int t = 0; t < seq_len_t(b); ++t) {
         int max_class_indices;
-        log_prob_t(b, 0) += -RowMax(input_list_t[t], b, &max_class_indices);
+        log_prob_t(b, 0) += -RowMax<T>(input_list_t[t], b, &max_class_indices);
         if (max_class_indices != blank_index &&
             !(merge_repeated_ && max_class_indices == prev_indices)) {
           sequence.push_back(max_class_indices);
@@ -239,10 +242,14 @@ class CTCGreedyDecoderOp : public OpKernel {
   TF_DISALLOW_COPY_AND_ASSIGN(CTCGreedyDecoderOp);
 };
 
-REGISTER_KERNEL_BUILDER(Name("CTCGreedyDecoder").Device(DEVICE_CPU),
-                        CTCGreedyDecoderOp);
+#define REGISTER_GREEDY(T)                                                  \
+  REGISTER_KERNEL_BUILDER(Name("CTCGreedyDecoder").Device(DEVICE_CPU)       \
+                          .TypeConstraint<T>("T"), CTCGreedyDecoderOp<T>);
+TF_CALL_float(REGISTER_GREEDY);
+TF_CALL_double(REGISTER_GREEDY);
 
 // CTC beam search
+template <typename T>
 class CTCBeamSearchDecoderOp : public OpKernel {
  public:
   explicit CTCBeamSearchDecoderOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
@@ -264,9 +271,9 @@ class CTCBeamSearchDecoderOp : public OpKernel {
                             ctx, &inputs, &seq_len, &log_prob, &decoded_indices,
                             &decoded_values, &decoded_shape));
 
-    auto inputs_t = inputs->tensor<float, 3>();
+    auto inputs_t = inputs->tensor<T, 3>();
     auto seq_len_t = seq_len->vec<int32>();
-    auto log_prob_t = log_prob->matrix<float>();
+    auto log_prob_t = log_prob->matrix<T>();
 
     const TensorShape& inputs_shape = inputs->shape();
 
@@ -280,7 +287,7 @@ class CTCBeamSearchDecoderOp : public OpKernel {
 
     log_prob_t.setZero();
 
-    std::vector<TTypes<float>::UnalignedConstMatrix> input_list_t;
+    std::vector<typename TTypes<T>::UnalignedConstMatrix> input_list_t;
 
     for (std::size_t t = 0; t < max_time; ++t) {
       input_list_t.emplace_back(inputs_t.data() + t * batch_size * num_classes,
@@ -291,10 +298,10 @@ class CTCBeamSearchDecoderOp : public OpKernel {
                                             &beam_scorer_, 1 /* batch_size */,
                                             merge_repeated_);
     Tensor input_chip(DT_FLOAT, TensorShape({num_classes}));
-    auto input_chip_t = input_chip.flat<float>();
+    auto input_chip_t = input_chip.flat<T>();
 
     std::vector<std::vector<std::vector<int> > > best_paths(batch_size);
-    std::vector<float> log_probs;
+    std::vector<T> log_probs;
 
     // Assumption: the blank index is num_classes - 1
     for (int b = 0; b < batch_size; ++b) {
@@ -328,7 +335,10 @@ class CTCBeamSearchDecoderOp : public OpKernel {
   TF_DISALLOW_COPY_AND_ASSIGN(CTCBeamSearchDecoderOp);
 };
 
-REGISTER_KERNEL_BUILDER(Name("CTCBeamSearchDecoder").Device(DEVICE_CPU),
-                        CTCBeamSearchDecoderOp);
+#define REGISTER_BEAM(T)                                                    \
+  REGISTER_KERNEL_BUILDER(Name("CTCBeamSearchDecoder").Device(DEVICE_CPU)   \
+                          .TypeConstraint<T>("T"), CTCBeamSearchDecoderOp<T>);
+TF_CALL_float(REGISTER_BEAM);
+//TF_CALL_double(REGISTER_BEAM);
 
 }  // end namespace tensorflow

--- a/tensorflow/core/ops/ctc_ops.cc
+++ b/tensorflow/core/ops/ctc_ops.cc
@@ -50,13 +50,14 @@ gradient: The gradient of `loss`.  3-D, shape:
 )doc");
 
 REGISTER_OP("CTCGreedyDecoder")
-    .Input("inputs: float")
+    .Input("inputs: T")
     .Input("sequence_length: int32")
     .Attr("merge_repeated: bool = false")
+    .Attr("T: {float, double} = DT_FLOAT")
     .Output("decoded_indices: int64")
     .Output("decoded_values: int64")
     .Output("decoded_shape: int64")
-    .Output("log_probability: float")
+    .Output("log_probability: T")
     .Doc(R"doc(
 Performs greedy decoding on the logits given in inputs.
 
@@ -84,15 +85,16 @@ log_probability: Matrix, size `(batch_size x 1)`, containing sequence
 )doc");
 
 REGISTER_OP("CTCBeamSearchDecoder")
-    .Input("inputs: float")
+    .Input("inputs: T")
     .Input("sequence_length: int32")
     .Attr("beam_width: int >= 1")
     .Attr("top_paths: int >= 1")
     .Attr("merge_repeated: bool = true")
+    .Attr("T: {float, double} = DT_FLOAT")
     .Output("decoded_indices: top_paths * int64")
     .Output("decoded_values: top_paths * int64")
     .Output("decoded_shape: top_paths * int64")
-    .Output("log_probability: float")
+    .Output("log_probability: T")
     .Doc(R"doc(
 Performs beam search decoding on the logits given in input.
 

--- a/tensorflow/python/kernel_tests/ctc_decoder_ops_test.py
+++ b/tensorflow/python/kernel_tests/ctc_decoder_ops_test.py
@@ -85,7 +85,7 @@ class CTCGreedyDecoderTest(tf.test.TestCase):
         with self.assertRaisesOpError(expected_err_re):
           sess.run(decoded_unwrapped + [log_probability])
 
-  def testCTCGreedyDecoder(self):
+  def _testCTCGreedyDecoder(self, dtype):
     """Test two batch entries - best path decoder."""
     max_time_steps = 6
     # depth == 4
@@ -98,7 +98,7 @@ class CTCGreedyDecoderTest(tf.test.TestCase):
          [0.0, 0.9, 0.1, 0.0],  # t=3
          [0.0, 0.0, 0.0, 0.0],  # t=4 (ignored)
          [0.0, 0.0, 0.0, 0.0]],  # t=5 (ignored)
-        dtype=np.float32)
+        dtype=dtype)
     input_log_prob_matrix_0 = np.log(input_prob_matrix_0)
 
     seq_len_1 = 5
@@ -111,7 +111,7 @@ class CTCGreedyDecoderTest(tf.test.TestCase):
          [0.0, 0.9, 0.1, 0.1],  # t=3
          [0.9, 0.1, 0.0, 0.0],  # t=4
          [0.0, 0.0, 0.0, 0.0]],  # t=5 (ignored)
-        dtype=np.float32)
+        dtype=dtype)
     input_log_prob_matrix_1 = np.log(input_prob_matrix_1)
 
     # len max_time_steps array of batch_size x depth matrices
@@ -126,7 +126,7 @@ class CTCGreedyDecoderTest(tf.test.TestCase):
     log_prob_truth = np.array([
         np.sum(-np.log([1.0, 0.6, 0.6, 0.9])),
         np.sum(-np.log([0.9, 0.9, 0.9, 0.9, 0.9]))
-    ], np.float32)[:, np.newaxis]
+    ], dtype)[:, np.newaxis]
 
     # decode_truth: one SparseTensor (ix, vals, shape)
     decode_truth = [
@@ -145,6 +145,10 @@ class CTCGreedyDecoderTest(tf.test.TestCase):
     self._testCTCDecoder(
         tf.nn.ctc_greedy_decoder,
         inputs, seq_lens, log_prob_truth, decode_truth)
+
+  def testCTCGreedyDecoder(self):
+    self._testCTCGreedyDecoder(np.float32)
+    self._testCTCGreedyDecoder(np.float64)
 
   def testCTCDecoderBeamSearch(self):
     """Test one batch, two beams - hibernating beam search."""


### PR DESCRIPTION
**PR incomplete! Have question about best way to get around one line**

Chipping away at ops listed in #1140

This PR adds 64-bit floating point support for CTCGreedyDecoder and provides tests for it. However, CTCDecoderBeamSearch doesn't have support yet, as there's [a line that needs to be changed](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/ctc_decoder_ops.cc#L293), and I need help with it. What would be the best way to dynamically select the correct `DataType` here? Currently `DT_FLOAT` is hard-coded in, but it should be `DT_DOUBLE` when the template type is `double`. Thanks!
