### PR TITLE
update tflearn example digits.py

### DIFF
--- a/tensorflow/examples/skflow/digits.py
+++ b/tensorflow/examples/skflow/digits.py
@@ -54,6 +54,6 @@ val_monitor = monitors.ValidationMonitor(X_val, y_val, every_n_steps=50)
 classifier = learn.TensorFlowEstimator(model_fn=conv_model, n_classes=10,
                                         steps=1000, learning_rate=0.05,
                                         batch_size=128)
-classifier.fit(X_train, y_train, val_monitor)
+classifier.fit(X_train, y_train, monitors=[val_monitor])
 score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Test Accuracy: {0:f}'.format(score))


### PR DESCRIPTION
the previous `classifier.fit(X_train, y_train, val_monitor)` has a problem,
the `learn.TensorFlowEstimator.fit(x, y, steps=None, monitors=None, logdir=None)` now has `monitors` as the fourth argument, and should be a `list`
I modified it to `classifier.fit(X_train, y_train, monitors=[val_monitor])` but this cause a new problem.
Is is this a bug from `TensorFlowEstimators` or `ValidationMonitor`

```
TypeError                                 Traceback (most recent call last)
/home/wenjian/digits.py in <module>()
     55                                         steps=1000, learning_rate=0.05,
     56                                         batch_size=128)
---> 57 classifier.fit(X_train, y_train, monitors=[val_monitor])
     58 score = metrics.accuracy_score(y_test, classifier.predict(X_test))
     59 print('Test Accuracy: {0:f}'.format(score))

/home/wenjian/anaconda3/lib/python3.5/site-packages/tensorflow/contrib/learn/python/learn/estimators/base.py in fit(self, x, y, steps, monitors, logdir)
    164                       feed_fn=self._data_feeder.get_feed_dict_fn(),
    165                       steps=steps or self.steps,
--> 166                       monitors=monitors)
    167     return self
    168 

/home/wenjian/anaconda3/lib/python3.5/site-packages/tensorflow/contrib/learn/python/learn/estimators/estimator.py in _train_model(self, input_fn, steps, feed_fn, init_op, init_feed_fn, init_fn, device_fn, monitors, log_every_steps, fail_on_nan_loss, max_steps)
    528           fail_on_nan_loss=fail_on_nan_loss,
    529           monitors=monitors,
--> 530           max_steps=max_steps)
    531 
    532   def _extract_metric_update_ops(self, eval_dict):

/home/wenjian/anaconda3/lib/python3.5/site-packages/tensorflow/contrib/learn/python/learn/graph_actions.py in train(graph, output_dir, train_op, loss_op, global_step_tensor, init_op, init_feed_dict, init_fn, log_every_steps, supervisor_is_chief, supervisor_master, supervisor_save_model_secs, keep_checkpoint_max, supervisor_save_summaries_steps, feed_fn, steps, fail_on_nan_loss, monitors, max_steps)
    362       finally:
    363         if excinfo:
--> 364           reraise(*excinfo)
    365     return loss_value
    366 

/home/wenjian/anaconda3/lib/python3.5/site-packages/six.py in reraise(tp, value, tb)
    684         if value.__traceback__ is not tb:
    685             raise value.with_traceback(tb)
--> 686         raise value
    687 
    688 else:

/home/wenjian/anaconda3/lib/python3.5/site-packages/tensorflow/contrib/learn/python/learn/graph_actions.py in train(graph, output_dir, train_op, loss_op, global_step_tensor, init_op, init_feed_dict, init_fn, log_every_steps, supervisor_is_chief, supervisor_master, supervisor_save_model_secs, keep_checkpoint_max, supervisor_save_summaries_steps, feed_fn, steps, fail_on_nan_loss, monitors, max_steps)
    287         try:
    288           outputs, should_stop = _run_with_monitors(
--> 289               session, last_step + 1, [train_op, loss_op], feed_dict, monitors)
    290         except errors.AbortedError as e:
    291           # Happens when PS restarts, keep training.

/home/wenjian/anaconda3/lib/python3.5/site-packages/tensorflow/contrib/learn/python/learn/graph_actions.py in _run_with_monitors(session, step, tensors, feed_dict, monitors)
    121   should_stop = False
    122   for monitor in monitors:
--> 123     induce_stop = monitor.step_end(step, outputs)
    124     should_stop = should_stop or induce_stop
    125   return outputs, should_stop

/home/wenjian/anaconda3/lib/python3.5/site-packages/tensorflow/contrib/learn/python/learn/monitors.py in step_end(self, step, output)
    205     if (self._active_step is not None) and (self._active_step == step):
    206       self._last_step = step
--> 207       to_stop = self.every_n_step_end(step, output)
    208       self._active_step = None
    209     return to_stop

/home/wenjian/anaconda3/lib/python3.5/site-packages/tensorflow/contrib/learn/python/learn/monitors.py in every_n_step_end(self, step, outputs)
    371     outputs = self._estimator.evaluate(
    372         x=self.x, y=self.y, input_fn=self.input_fn, batch_size=self.batch_size,
--> 373         steps=self.eval_steps, metrics=self.metrics, name=self.name)
    374     stats = []
    375     for name in outputs:

TypeError: evaluate() got an unexpected keyword argument 'batch_size'
```
