### PR TITLE
docker exec -it to start the interactive terminal

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -370,7 +370,9 @@ After Docker is installed, launch a Docker container with the TensorFlow binary
 image as follows.
 
 ```bash
-$ docker run -it -p 8888:8888 gcr.io/tensorflow/tensorflow
+$ docker run -d -p 8888:8888 --name="tensor" gcr.io/tensorflow/tensorflow
+
+$ docker exec -it tensor bash
 ```
 
 The option `-p 8888:8888` is used to publish the Docker container᾿s internal port to the host machine, in this case to ensure Jupyter notebook connection.

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -380,7 +380,7 @@ The format of the port mapping is `hostPort:containerPort`. You can specify any 
 To start a command-line interface:
 
 ```bash
-$ docker run -it -p 8888:8888 --name="tensor" --entrypoint=/bin/bash gcr.io/tensorflow/tensorflow
+$ docker run --rm -it -p 8888:8888 --name="tensor" --entrypoint=/bin/bash gcr.io/tensorflow/tensorflow
 ```
 
 

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -371,13 +371,18 @@ image as follows.
 
 ```bash
 $ docker run -d -p 8888:8888 --name="tensor" gcr.io/tensorflow/tensorflow
-
-$ docker exec -it tensor bash
 ```
 
 The option `-p 8888:8888` is used to publish the Docker container᾿s internal port to the host machine, in this case to ensure Jupyter notebook connection.
 
 The format of the port mapping is `hostPort:containerPort`. You can specify any valid port number for the host port but have to use `8888` for the container port portion.
+
+To start a command-line interface:
+
+```bash
+$ docker run -it -p 8888:8888 --name="tensor" --entrypoint=/bin/bash gcr.io/tensorflow/tensorflow
+```
+
 
 For NVidia GPU support install latest NVidia drivers and
 [nvidia-docker](https://github.com/NVIDIA/nvidia-docker).


### PR DESCRIPTION
As per the current documentation, 
$ docker run -it -p 8888:8888  gcr.io/tensorflow/tensorflow should be used to access the CLI. 
However, the previous command starts the Notebook App. The CLI is not available. To access the CLI, we need to access the container by creating a new interactive terminal to it. 
Hence, I added a second step using docker exec.
