### PR TITLE
Fix doc typo from `Tensor.run` to `Tensor.eval`

### DIFF
--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -205,7 +205,7 @@ class BaseSession(SessionInterface):
 
     Use with the `with` keyword to specify that calls to
     [`Operation.run()`](../../api_docs/python/framework.md#Operation.run) or
-    [`Tensor.run()`](../../api_docs/python/framework.md#Tensor.run) should be
+    [`Tensor.eval()`](../../api_docs/python/framework.md#Tensor.eval) should be
     executed in this session.
 
     ```python


### PR DESCRIPTION
Quick documentation in session.py to fix to point to correct function name and permalink id.
