### PR TITLE
Accompany TF_LoadLibrary with TF_DeleteLibrary

### DIFF
--- a/tensorflow/core/client/tensor_c_api.cc
+++ b/tensorflow/core/client/tensor_c_api.cc
@@ -568,6 +568,10 @@ TF_Library* TF_LoadLibrary(const char* library_filename, TF_Status* status) {
   return lib_handle;
 }
 
+void TF_DeleteLibrary(TF_Library* library) {
+  delete library;
+}
+
 TF_Buffer TF_GetOpList(TF_Library* lib_handle) { return lib_handle->op_list; }
 
 }  // end extern "C"

--- a/tensorflow/core/public/tensor_c_api.h
+++ b/tensorflow/core/public/tensor_c_api.h
@@ -361,6 +361,8 @@ typedef struct TF_Library TF_Library;
 extern TF_Library* TF_LoadLibrary(const char* library_filename,
                                   TF_Status* status);
 
+extern void TF_DeleteLibrary(TF_Library*);
+
 // Get the OpList of OpDefs defined in the library pointed by lib_handle.
 //
 // Returns a TF_Buffer. The memory pointed to by the result is owned by


### PR DESCRIPTION
The pull request addresses issue #3213. Please let me know
- if I should add a comment to the new function, and
- if I should also change [tf_session.i](https://github.com/tensorflow/tensorflow/blob/r0.9/tensorflow/python/client/tf_session.i#L239) or [load_library.py](https://github.com/tensorflow/tensorflow/blob/r0.9/tensorflow/python/framework/load_library.py#L60).

Thanks!

Regards,
Ivan
