### PR TITLE
Fix issue 3186: buffer alignment needs to be 8-byte for uint64 vals 

### DIFF
--- a/tensorflow/core/lib/gtl/inlined_vector.h
+++ b/tensorflow/core/lib/gtl/inlined_vector.h
@@ -276,6 +276,9 @@ class InlinedVector {
     unsigned char data[kSize];
     // Force data to be aligned enough for a pointer.
     T* unused_aligner;
+    // Some values placed here are uint64, which may require 8 byte alignment
+    // but on 32 bit archtectures, pointers are insufficiently aligned
+    uint64_t unused_aligner_64;
   } u_;
 
   inline void InitRep() { u_.data[kSize - 1] = 0; }


### PR DESCRIPTION
This Closes #3186 

Add uint64_t to the u_ union to ensure 8-byte alignment, pointers are not 8-byte aligned on 32 bit architectures.
