### PR TITLE
TensorForestEstimator - removed unused continue_training and changed to use config in constructor

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/random_forest.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/random_forest.py
@@ -70,8 +70,7 @@ class TensorForestEstimator(estimator.BaseEstimator):
   def __init__(self, params, device_assigner=None, model_dir=None,
                graph_builder_class=tensor_forest.RandomForestGraphs,
                master='', accuracy_metric=None,
-               tf_random_seed=None, verbose=1,
-               config=None):
+               tf_random_seed=None, config=None):
     self.params = params.fill()
     self.accuracy_metric = (accuracy_metric or
                             ('r2' if self.params.regression else 'accuracy'))

--- a/tensorflow/contrib/learn/python/learn/estimators/random_forest.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/random_forest.py
@@ -70,8 +70,8 @@ class TensorForestEstimator(estimator.BaseEstimator):
   def __init__(self, params, device_assigner=None, model_dir=None,
                graph_builder_class=tensor_forest.RandomForestGraphs,
                master='', accuracy_metric=None,
-               tf_random_seed=None, continue_training=False, verbose=1,
-               max_to_keep=5, save_checkpoint_secs=300):
+               tf_random_seed=None, verbose=1,
+               config=None):
     self.params = params.fill()
     self.accuracy_metric = (accuracy_metric or
                             ('r2' if self.params.regression else 'accuracy'))
@@ -81,12 +81,6 @@ class TensorForestEstimator(estimator.BaseEstimator):
     self.graph_builder_class = graph_builder_class
     self.training_args = {}
     self.construction_args = {}
-
-    config = run_config.RunConfig(
-        master=master,
-        tf_random_seed=(tf_random_seed or int((time.time() * 1000) % 1000)),
-        save_checkpoints_secs=save_checkpoint_secs,
-        keep_checkpoint_max=max_to_keep)
 
     super(TensorForestEstimator, self).__init__(model_dir=model_dir,
                                                 config=config)


### PR DESCRIPTION
- Remove unused `continue_training`
- Remove unused `verbose`
- Switch to use config - `Estimator` handles case when `config=None` already 
