### PR TITLE
Fix word2vec excepction when words contain chinese.

### DIFF
--- a/tensorflow/models/embedding/word2vec.py
+++ b/tensorflow/models/embedding/word2vec.py
@@ -378,7 +378,8 @@ class Word2Vec(object):
     opts = self._options
     with open(os.path.join(opts.save_path, "vocab.txt"), "w") as f:
       for i in xrange(opts.vocab_size):
-        f.write("%s %d\n" % (tf.compat.as_text(opts.vocab_words[i]).encode('utf-8'),
+        vocab_word = tf.compat.as_text(opts.vocab_words[i]).encode("utf-8")
+        f.write("%s %d\n" % (vocab_word,
                              opts.vocab_counts[i]))
 
   def _train_thread_body(self):

--- a/tensorflow/models/embedding/word2vec.py
+++ b/tensorflow/models/embedding/word2vec.py
@@ -378,7 +378,7 @@ class Word2Vec(object):
     opts = self._options
     with open(os.path.join(opts.save_path, "vocab.txt"), "w") as f:
       for i in xrange(opts.vocab_size):
-        f.write("%s %d\n" % (tf.compat.as_text(opts.vocab_words[i]),
+        f.write("%s %d\n" % (tf.compat.as_text(opts.vocab_words[i]).encode('utf-8'),
                              opts.vocab_counts[i]))
 
   def _train_thread_body(self):


### PR DESCRIPTION
When word2vec deal with Chinese language, it will break out below exception.

```
Traceback (most recent call last):
  File "word2vec_tf.py", line 58, in <module>
    main()
  File "word2vec_tf.py", line 47, in main
    model = Word2Vec(options, session)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/models/embedding/word2vec.py", line 166, in __init__
    self.save_vocab()
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/models/embedding/word2vec.py", line 382, in save_vocab
    opts.vocab_counts[i]))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u90fd' in position 0: ordinal not in range(128)
```

I fix this exception by adding `encode('utf-8')` , and then it successful run word2vec model.
