### PR TITLE
Update Eigen to version that includes scan op fix

### DIFF
--- a/eigen.BUILD
+++ b/eigen.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-archive_dir = "eigen-eigen-334b1d428283"
+archive_dir = "eigen-eigen-bbffe8ed5f26"
 cc_library(
     name = "eigen",
     hdrs = glob([archive_dir+"/**/*.h", archive_dir+"/unsupported/Eigen/CXX11/*", archive_dir+"/Eigen/*"]),

--- a/tensorflow/contrib/cmake/external/eigen.cmake
+++ b/tensorflow/contrib/cmake/external/eigen.cmake
@@ -7,7 +7,7 @@
 
 include (ExternalProject)
 
-set(eigen_archive_hash "802d984ade26")
+set(eigen_archive_hash "bbffe8ed5f26")
 
 set(eigen_INCLUDE_DIRS
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -6,8 +6,8 @@
 def tf_workspace(path_prefix = "", tf_repo_name = ""):
   native.new_http_archive(
     name = "eigen_archive",
-    url = "https://bitbucket.org/eigen/eigen/get/334b1d428283.tar.gz",
-    sha256 = "6d5efd02c7c11fbb9d02df4f0b64f22ecbd348e7549f8a83c13fb4d8d9e19d4b",
+    url = "https://bitbucket.org/eigen/eigen/get/bbffe8ed5f26.tar.gz",
+    sha256 = "5a9e2b6eb683d3665298d65b323dbb891b114f7d7654f2681342aa8794a2edc6",
     build_file = path_prefix + "eigen.BUILD",
   )
 

--- a/third_party/eigen3/Eigen/Cholesky
+++ b/third_party/eigen3/Eigen/Cholesky
@@ -1,1 +1,1 @@
-#include "eigen-eigen-334b1d428283/Eigen/Cholesky"
+#include "eigen-eigen-bbffe8ed5f26/Eigen/Cholesky"

--- a/third_party/eigen3/Eigen/Core
+++ b/third_party/eigen3/Eigen/Core
@@ -1,1 +1,1 @@
-#include "eigen-eigen-334b1d428283/Eigen/Core"
+#include "eigen-eigen-bbffe8ed5f26/Eigen/Core"

--- a/third_party/eigen3/Eigen/Eigenvalues
+++ b/third_party/eigen3/Eigen/Eigenvalues
@@ -1,1 +1,1 @@
-#include "eigen-eigen-334b1d428283/Eigen/Eigenvalues"
+#include "eigen-eigen-bbffe8ed5f26/Eigen/Eigenvalues"

--- a/third_party/eigen3/Eigen/LU
+++ b/third_party/eigen3/Eigen/LU
@@ -1,1 +1,1 @@
-#include "eigen-eigen-334b1d428283/Eigen/LU"
+#include "eigen-eigen-bbffe8ed5f26/Eigen/LU"

--- a/third_party/eigen3/Eigen/QR
+++ b/third_party/eigen3/Eigen/QR
@@ -1,1 +1,1 @@
-#include "eigen-eigen-334b1d428283/Eigen/QR"
+#include "eigen-eigen-bbffe8ed5f26/Eigen/QR"

--- a/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
+++ b/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
@@ -1,1 +1,1 @@
-#include "eigen-eigen-334b1d428283/unsupported/Eigen/CXX11/Tensor"
+#include "eigen-eigen-bbffe8ed5f26/unsupported/Eigen/CXX11/Tensor"


### PR DESCRIPTION
This updates Eigen to a newer version that includes a fix needed to merge #2711.
