### PR TITLE
time_major parameter for ctc_loss op

### DIFF
--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -28,7 +28,7 @@ from tensorflow.python.ops.nn_grad import _BroadcastMul
 
 # pylint: disable=protected-access, invalid-name
 def ctc_loss(inputs, labels, sequence_length,
-             preprocess_collapse_repeated=False, ctc_merge_repeated=True):
+             preprocess_collapse_repeated=False, ctc_merge_repeated=True, time_major=True):
   """Computes the CTC (Connectionist Temporal Classification) Loss.
 
   This op implements the CTC loss as presented in the article:
@@ -83,8 +83,12 @@ def ctc_loss(inputs, labels, sequence_length,
     Untested.  Very likely will not learn to output repeated classes.
 
   Args:
-    inputs: 3-D `float` `Tensor` sized
-      `[max_time x batch_size x num_classes]`.  The logits.
+    inputs: 3-D `float` `Tensor` sized.
+      If time_major == False, this will be a `Tensor` shaped:
+        `[batch_size, max_time, num_classes]`.
+      If time_major == True (default), this will be a `Tensor` shaped:
+        `[max_time, batch_size, num_classes]`.
+      The logits.
     labels: An `int32` `SparseTensor`.
       `labels.indices[i, :] == [b, t]` means `labels.values[i]` stores
       the id for (batch b, time t).  See `core/ops/ctc_ops.cc` for more details.
@@ -93,6 +97,13 @@ def ctc_loss(inputs, labels, sequence_length,
     preprocess_collapse_repeated: Boolean.  Default: False.
       If True, repeated labels are collapsed prior to the CTC calculation.
     ctc_merge_repeated: Boolean.  Default: True.
+    time_major: The shape format of the `inputs` Tensors.
+      If true, these `Tensors` must be shaped `[max_time, batch_size, num_classes]`.
+      If false, these `Tensors` must be shaped `[batch_size, max_time, num_classes]`.
+      Using `time_major = True` (default) is a bit more efficient because it avoids
+      transposes at the beginning of the ctc_loss calculation.  However, most 
+      TensorFlow data is batch-major, so by this function also accepts inputs 
+      in batch-major form.
 
   Returns:
     A 1-D `float` `Tensor`, size `[batch]`, containing the negative log probabilities.
@@ -104,6 +115,10 @@ def ctc_loss(inputs, labels, sequence_length,
   # _CTCLossGrad() below.
   if not isinstance(labels, ops.SparseTensor):
     raise TypeError("Expected labels to be a SparseTensor")
+    
+  # For internal calculations, we transpose to [time, batch, num_classes]
+  if not time_major:
+    inputs = array_ops.transpose(inputs, [1, 0, 2])  # (B,T,N) => (T,B,N)
 
   loss, _ = gen_ctc_ops._ctc_loss(
       inputs,


### PR DESCRIPTION
Just as dynamic_rnn and to be more regular across the TensorFlow's code I added a flag capable of transpose the input data to be in time_major, required by gen_ctc_ops._ctc_loss. Note that, instead of set time_major=False (as the most of TensorFlow data), it was set False to be compatible with previous ctc_loss function call (but I don't think that this is a good idea).
