### PR TITLE
Initialize local variables in fully_connected_preloaded example to resolve #3168

### DIFF
--- a/tensorflow/examples/how_tos/reading_data/fully_connected_preloaded.py
+++ b/tensorflow/examples/how_tos/reading_data/fully_connected_preloaded.py
@@ -94,8 +94,8 @@ def run_training():
     saver = tf.train.Saver()
 
     # Create the op for initializing variables.
-    init_op = tf.initialize_all_variables()
-
+    init_op = tf.group(tf.initialize_all_variables(),
+                       tf.initialize_local_variables())
     # Create a session for running Ops on the Graph.
     sess = tf.Session()
 


### PR DESCRIPTION
fully_connected_reader example was fixed while fully_connected_preloaded was not
