### PR TITLE
Fix gradient of prod op using cumprod

### DIFF
--- a/tensorflow/python/kernel_tests/reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/reduction_ops_test.py
@@ -435,7 +435,7 @@ class ProdReductionTest(tf.test.TestCase):
   def testGradient(self):
     s = [2, 3, 4, 2]
     # NOTE(kearnes): divide by 20 so product is a reasonable size
-    x = np.arange(1.0, 49.0).reshape(s).astype(np.float32) / 20.
+    x = np.arange(0.0, 48.0).reshape(s).astype(np.float32) / 20.
     with self.test_session():
       t = tf.convert_to_tensor(x)
 
@@ -465,20 +465,6 @@ class ProdReductionTest(tf.test.TestCase):
                                                   x_init_value=x,
                                                   delta=1)
       self.assertAllClose(jacob_t, jacob_n, rtol=1e-3, atol=1e-3)
-
-    # NOTE(kearnes): the current gradient calculation gives NaNs for 0 inputs
-    x = np.arange(0.0, 48.0).reshape(s).astype(np.float32) / 20.
-    with self.test_session():
-      t = tf.convert_to_tensor(x)
-      su = tf.reduce_prod(t, [])
-      jacob_t, _ = tf.test.compute_gradient(t,
-                                            s,
-                                            su,
-                                            [2, 3, 4, 2],
-                                            x_init_value=x,
-                                            delta=1)
-      with self.assertRaisesOpError("Tensor had NaN values"):
-        tf.check_numerics(jacob_t, message="_ProdGrad NaN test").op.run()
 
   def testEmptyGradients(self):
     with self.test_session():


### PR DESCRIPTION
This is an initial shot at fixing #2641 (NaNs in the gradient of `tf.reduce_prod` when the input is `0`).
@girving suggested to use two calls to `cumprod` and to multiply the outputs to produce an array containing the products of all values without the current one, like this:

```
input: [0, 1, 2, 3, 4]
cumprod1: [1, 0, 0, 0, 0]
cumprod2 (reverse): [24, 24, 12, 4, 1]
gradient: [24, 0, 0, 0, 0]
```

The difficulty with this is handling the fact that `tf.reduce_prod` can calculate the product over a subset of the tensor dimensions.
When solving this in Python, quite a bit of transposing and reshaping is required.
The idea is to reshape the input into a tensor with shape `[N, M]`, where the first dimension contains all the entries that we reduced over, and the second dimension contains the remaining ones.
I've pushed a Python solution using the approach that makes the reduction op tests pass.
As you can see, the gradient code is a bit complicated.
Maybe someone knows a shortcut that makes this simpler?

There might be other solutions that could be better here:
@benoitsteiner suggested that `tf.cumprod` could be changed to take a list of dimensions to scan over instead of a single axis. This would bring it more in line with the reduction ops.
I think this could be implemented without modifying Eigen, by using various Eigen methods to reshape and transpose the input.
