### PR TITLE
Remove read_analogies() from word2vec class initialization

### DIFF
--- a/tensorflow/models/embedding/word2vec.py
+++ b/tensorflow/models/embedding/word2vec.py
@@ -164,9 +164,8 @@ class Word2Vec(object):
     self.build_graph()
     self.build_eval_graph()
     self.save_vocab()
-    self._read_analogies()
 
-  def _read_analogies(self):
+  def read_analogies(self):
     """Reads through the analogy question file.
 
     Returns:
@@ -447,7 +446,11 @@ class Word2Vec(object):
     # How many questions we get right at precision@1.
     correct = 0
 
-    total = self._analogy_questions.shape[0]
+    try:
+        total = self._analogy_questions.shape[0]
+    except AttributeError as e:
+        raise AttributeError("Need to read analogy questions.")
+
     start = 0
     while start < total:
       limit = start + 2500
@@ -509,6 +512,7 @@ def main(_):
   with tf.Graph().as_default(), tf.Session() as session:
     with tf.device("/cpu:0"):
       model = Word2Vec(opts, session)
+      model.read_analogies() # Read analogy questions
     for _ in xrange(opts.epochs_to_train):
       model.train()  # Process one epoch
       model.eval()  # Eval analogies.

--- a/tensorflow/models/embedding/word2vec_optimized.py
+++ b/tensorflow/models/embedding/word2vec_optimized.py
@@ -229,7 +229,7 @@ class Word2Vec(object):
     self._labels = labels
     self._lr = lr
     self._train = train
-    self.step = global_step
+    self.global_step = global_step
     self._epoch = current_epoch
     self._words = total_words_processed
 
@@ -238,7 +238,8 @@ class Word2Vec(object):
     opts = self._options
     with open(os.path.join(opts.save_path, "vocab.txt"), "w") as f:
       for i in xrange(opts.vocab_size):
-        f.write("%s %d\n" % (tf.compat.as_text(opts.vocab_words[i]),
+        vocab_word = tf.compat.as_text(opts.vocab_words[i]).encode("utf-8")
+        f.write("%s %d\n" % (vocab_word,
                              opts.vocab_counts[i]))
 
   def build_eval_graph(self):
@@ -322,8 +323,8 @@ class Word2Vec(object):
     last_words, last_time = initial_words, time.time()
     while True:
       time.sleep(5)  # Reports our progress once a while.
-      (epoch, step, words,
-       lr) = self._session.run([self._epoch, self.step, self._words, self._lr])
+      (epoch, step, words, lr) = self._session.run(
+          [self._epoch, self.global_step, self._words, self._lr])
       now = time.time()
       last_words, last_time, rate = words, now, (words - last_words) / (
           now - last_time)
@@ -419,7 +420,7 @@ def main(_):
       model.eval()  # Eval analogies.
     # Perform a final save.
     model.saver.save(session, os.path.join(opts.save_path, "model.ckpt"),
-                     global_step=model.step)
+                     global_step=model.global_step)
     if FLAGS.interactive:
       # E.g.,
       # [0]: model.analogy(b'france', b'paris', b'russia')

--- a/tensorflow/models/embedding/word2vec_optimized.py
+++ b/tensorflow/models/embedding/word2vec_optimized.py
@@ -144,9 +144,8 @@ class Word2Vec(object):
     self.build_graph()
     self.build_eval_graph()
     self.save_vocab()
-    self._read_analogies()
 
-  def _read_analogies(self):
+  def read_analogies(self):
     """Reads through the analogy question file.
 
     Returns:
@@ -353,7 +352,11 @@ class Word2Vec(object):
     # How many questions we get right at precision@1.
     correct = 0
 
-    total = self._analogy_questions.shape[0]
+    try:
+        total = self._analogy_questions.shape[0]
+    except AttributeError as e:
+        raise AttributeError("Need to read analogy questions.")
+
     start = 0
     while start < total:
       limit = start + 2500
@@ -415,6 +418,7 @@ def main(_):
   with tf.Graph().as_default(), tf.Session() as session:
     with tf.device("/cpu:0"):
       model = Word2Vec(opts, session)
+      model.read_analogies() # Read analogy questions
     for _ in xrange(opts.epochs_to_train):
       model.train()  # Process one epoch
       model.eval()  # Eval analogies.


### PR DESCRIPTION
- Fix inconsistent between word2vec and word2vec_optimized.
- Remove read_analogies() from word2vec class initialization.

When I used word2vec model for training my target words directly, it lacked of analogies file for evaluation. Thus, it would raise file not found exception when model initialization. So I made read_analogies() public and called it after initialization.
