### PR TITLE
standardize BUILD files format using buildifier

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -824,6 +824,7 @@ cc_library(
     hdrs = [
         "lib/core/blocking_counter.h",
         "lib/core/refcount.h",
+        "lib/gif/gif_io.h",
         "lib/gtl/edit_distance.h",
         "lib/gtl/int_type.h",
         "lib/gtl/iterator_range.h",
@@ -837,7 +838,6 @@ cc_library(
         "lib/io/zlib_outputbuffer.h",
         "lib/jpeg/jpeg_handle.h",
         "lib/png/png_io.h",
-        "lib/gif/gif_io.h",
         "lib/random/random.h",
         "lib/random/random_distributions.h",
         "lib/random/weighted_picker.h",

--- a/tensorflow/core/platform/default/build_config/BUILD
+++ b/tensorflow/core/platform/default/build_config/BUILD
@@ -47,13 +47,13 @@ cc_library(
     name = "platformlib",
     copts = tf_copts(),
     deps = [
+        "//tensorflow/core:protos_cc",
         "@farmhash_archive//:farmhash",
-        "@jpeg_archive//:jpeg",
-        "@png_archive//:png",
         "@gif_archive//:gif",
         "@highwayhash//:sip_hash",
+        "@jpeg_archive//:jpeg",
+        "@png_archive//:png",
         "@re2//:re2",
-        "//tensorflow/core:protos_cc",
     ],
 )
 

--- a/tensorflow/python/tools/BUILD
+++ b/tensorflow/python/tools/BUILD
@@ -55,8 +55,8 @@ py_binary(
     srcs = [
         "graph_metrics.py",
     ],
-    srcs_version = "PY2AND3",
     main = "graph_metrics.py",
+    srcs_version = "PY2AND3",
     deps = [
         "//tensorflow:tensorflow_py",
     ],

--- a/tensorflow/tensorboard/BUILD
+++ b/tensorflow/tensorboard/BUILD
@@ -10,10 +10,10 @@ exports_files(["LICENSE"])
 filegroup(
     name = "frontend",
     srcs = [
+        "TAG",
         "dist/index.html",
         "dist/tf-tensorboard.html",
-        "TAG",
-        "//tensorflow/tensorboard/bower:bower",
+        "//tensorflow/tensorboard/bower",
         "//tensorflow/tensorboard/lib:all_files",
     ],
 )

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -8,8 +8,8 @@ load("//tensorflow:tensorflow.bzl", "transitive_hdrs")
 transitive_hdrs(
     name = "other_headers",
     deps = [
-        "//third_party/eigen3",
         "//tensorflow/core:protos_all_cc",
+        "//third_party/eigen3",
     ],
 )
 
@@ -30,9 +30,9 @@ sh_binary(
         ":other_headers",
         ":simple_console",
         "//tensorflow:tensorflow_py",
-#        "//tensorflow/contrib/session_bundle:all_files",
-#        "//tensorflow/contrib/session_bundle:manifest_proto_py",
-#        "//tensorflow/contrib/session_bundle/example:half_plus_two",
+        #        "//tensorflow/contrib/session_bundle:all_files",
+        #        "//tensorflow/contrib/session_bundle:manifest_proto_py",
+        #        "//tensorflow/contrib/session_bundle/example:half_plus_two",
         "//tensorflow/contrib/slim:all_files",
         "//tensorflow/contrib/slim/python/slim/data:all_files",
         "//tensorflow/contrib/tensor_forest:all_files",

--- a/third_party/avro/BUILD
+++ b/third_party/avro/BUILD
@@ -1,4 +1,3 @@
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
-

--- a/third_party/gpus/cuda/BUILD
+++ b/third_party/gpus/cuda/BUILD
@@ -51,7 +51,10 @@ cc_library(
     hdrs = glob([
         "**/*.h",
     ]),
-    includes = [".", "include"],
+    includes = [
+        ".",
+        "include",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -66,7 +69,7 @@ cc_library(
         "-lpthread",
     ] + select({
         "//tensorflow:darwin": [],
-        "//conditions:default": ["-lrt"]
+        "//conditions:default": ["-lrt"],
     }),
     visibility = ["//visibility:public"],
 )
@@ -74,65 +77,65 @@ cc_library(
 cc_library(
     name = "cudart",
     srcs = [
-        cuda_library_path("cudart")
+        cuda_library_path("cudart"),
     ],
     data = [
-        cuda_library_path("cudart")
+        cuda_library_path("cudart"),
     ],
     includes = ["include/"],
-    visibility = ["//visibility:public"],
     linkstatic = 1,
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "cublas",
     srcs = [
-        cuda_library_path("cublas")
+        cuda_library_path("cublas"),
     ],
     data = [
-        cuda_library_path("cublas")
+        cuda_library_path("cublas"),
     ],
     includes = ["include/"],
-    visibility = ["//visibility:public"],
     linkstatic = 1,
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "cudnn",
     srcs = [
-        cudnn_library_path()
+        cudnn_library_path(),
     ],
     data = [
-        cudnn_library_path()
+        cudnn_library_path(),
     ],
     includes = ["include/"],
-    visibility = ["//visibility:public"],
     linkstatic = 1,
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "cufft",
     srcs = [
-        cuda_library_path("cufft")
+        cuda_library_path("cufft"),
     ],
     data = [
-        cuda_library_path("cufft")
+        cuda_library_path("cufft"),
     ],
     includes = ["include/"],
-    visibility = ["//visibility:public"],
     linkstatic = 1,
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "cuda",
+    visibility = ["//visibility:public"],
     deps = [
+        ":cublas",
         ":cuda_headers",
         ":cudart",
-        ":cublas",
         ":cudnn",
         ":cufft",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -140,7 +143,10 @@ cc_library(
     hdrs = glob([
         "**/*.h",
     ]),
-    includes = [".", "extras/CUPTI/include/"],
+    includes = [
+        ".",
+        "extras/CUPTI/include/",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -151,7 +157,6 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
 )
-
 
 # TODO(opensource): for now, we have to invoke the cuda_config.sh manually in the source tree.
 # This rule checks if Cuda libraries in the source tree has been properly configured.
@@ -182,21 +187,21 @@ genrule(
 
         # Under non-cuda config, create all dummy files to make the build go through
         ";".join([
-           "mkdir -p $(@D)/include",
-           "mkdir -p $(@D)/lib64",
-           "mkdir -p $(@D)/extras/CUPTI/include",
-           "mkdir -p $(@D)/extras/CUPTI/lib64",
-           "touch $(@D)/include/cuda.h",
-           "touch $(@D)/include/cublas.h",
-           "touch $(@D)/include/cudnn.h",
-           "touch $(@D)/extras/CUPTI/include/cupti.h",
-           "touch $(@D)/{}".format(cuda_static_library_path("cudart")),
-           "touch $(@D)/{}".format(cuda_library_path("cublas")),
-           "touch $(@D)/{}".format(cudnn_library_path()),
-           "touch $(@D)/{}".format(cuda_library_path("cudart")),
-           "touch $(@D)/{}".format(cuda_library_path("cufft")),
-           "touch $(@D)/{}".format(cupti_library_path()),
-         ]),
+            "mkdir -p $(@D)/include",
+            "mkdir -p $(@D)/lib64",
+            "mkdir -p $(@D)/extras/CUPTI/include",
+            "mkdir -p $(@D)/extras/CUPTI/lib64",
+            "touch $(@D)/include/cuda.h",
+            "touch $(@D)/include/cublas.h",
+            "touch $(@D)/include/cudnn.h",
+            "touch $(@D)/extras/CUPTI/include/cupti.h",
+            "touch $(@D)/{}".format(cuda_static_library_path("cudart")),
+            "touch $(@D)/{}".format(cuda_library_path("cublas")),
+            "touch $(@D)/{}".format(cudnn_library_path()),
+            "touch $(@D)/{}".format(cuda_library_path("cudart")),
+            "touch $(@D)/{}".format(cuda_library_path("cufft")),
+            "touch $(@D)/{}".format(cupti_library_path()),
+        ]),
     ),
     local = 1,
 )
@@ -212,7 +217,7 @@ genrule(
 
         # Under non-cuda config, create the dummy file
         ";".join([
-         "touch $(@D)/cuda.config",
+            "touch $(@D)/cuda.config",
         ]),
     ),
     local = 1,

--- a/util/python/BUILD
+++ b/util/python/BUILD
@@ -15,7 +15,7 @@ genrule(
     name = "python_check",
     srcs = [
         "python_config.sh",
-        "configure_files"
+        "configure_files",
     ],
     outs = [
         "python_checked",
@@ -27,6 +27,6 @@ genrule(
 filegroup(
     name = "configure_files",
     data = glob([
-      "*",
-    ])
+        "*",
+    ]),
 )


### PR DESCRIPTION
I just run `buildifier -mode=fix`find . -iname BUILD -type f`. 

`go get github.com/bazelbuild/buildifier` to install the tool.

I like to have one format for the build files. 
What is the general feeling about this ?
