### PR TITLE
add Dummy gradient for LogUniformCandidateSampler

### DIFF
--- a/tensorflow/python/ops/candidate_sampling_ops.py
+++ b/tensorflow/python/ops/candidate_sampling_ops.py
@@ -391,3 +391,10 @@ def _ComputeAccidentalHitsShape(op):
       tensor_shape.matrix(None, num_true))
   output_shape = tensor_shape.vector(None)
   return [output_shape] * 3
+
+
+
+@ops.RegisterGradient("LogUniformCandidateSampler")
+def _LogUniformCandidateSamplerGrad(op, *grads): 
+  # input: true_classes grad
+  return [tf.cast(tf.zeros_like(grads[1]), tf.int64)]


### PR DESCRIPTION
I added a dummy Gradient for the LogUniformCandidateSampler, as proposed by Martin Wicke    in [this](https://groups.google.com/a/tensorflow.org/d/msg/discuss/P63KdpGGwvA/1ks-INGBAwAJ) discussion thread, to get rid of this error:

> WARNING:tensorflow:<tensorflow.python.ops.rnn_cell.BasicLSTMCell
> object at 0x7f50696455f8>: Using a concatenated state is slower and
> will soon be deprecated.  Use state_is_tuple=True. Traceback (most
> recent call last):   File
> "/home/aa/anaconda3/envs/master_tensorflow/lib/python3.5/site-packages/tensorflow/python/ops/gradients.py",
> line 448, in gradients
>     grad_fn = ops.get_gradient_function(op)   File "/home/aa/anaconda3/envs/master_tensorflow/lib/python3.5/site-packages/tensorflow/python/framework/ops.py",
> line 1634, in get_gradient_function
>     return _gradient_registry.lookup(op_type)   File "/home/aa/anaconda3/envs/master_tensorflow/lib/python3.5/site-packages/tensorflow/python/framework/registry.py",
> line 85, in lookup
>     "%s registry has no entry for: %s" % (self._name, name)) LookupError: gradient registry has no entry for:
> LogUniformCandidateSampler
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):   File
> "/home/aa/code/python/bb/dyn_main.py", line 176, in <module>
>     tf.app.run()   File "/home/aa/anaconda3/envs/master_tensorflow/lib/python3.5/site-packages/tensorflow/python/platform/app.py",
> line 30, in run
>     sys.exit(main(sys.argv))   File "/home/aa/code/python/bb/dyn_main.py", line 83, in main
>     gradients = tf.gradients(loss2, params)   File "/home/aa/anaconda3/envs/master_tensorflow/lib/python3.5/site-packages/tensorflow/python/ops/gradients.py",
> line 452, in gradients
>     (op.name, op.type)) LookupError: No gradient defined for operation 'dynamic_rnn_seq2seq/sequence_loss_by_example_dyn/while/cond/sampled_softmax_loss/LogUniformCandidateSampler'
> (op type: LogUniformCandidateSampler)

Thanks!
