### PR TITLE
Speed up retraining times  approximately 2x

### DIFF
--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -406,6 +406,9 @@ def read_list_of_floats_from_file(file_path):
   return list(s)
 	
 
+bottleneck_path_2_bottleneck_values = {}
+
+	
 def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
                              category, bottleneck_dir, jpeg_data_tensor,
                              bottleneck_tensor):
@@ -437,20 +440,39 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
   ensure_dir_exists(sub_dir_path)
   bottleneck_path = get_bottleneck_path(image_lists, label_name, index,
                                         bottleneck_dir, category)
-  if not os.path.exists(bottleneck_path):
-    print('Creating bottleneck at ' + bottleneck_path)
-    image_path = get_image_path(image_lists, label_name, index, image_dir,
-                                category)
-    if not gfile.Exists(image_path):
-      tf.logging.fatal('File does not exist %s', image_path)
-    image_data = gfile.FastGFile(image_path, 'rb').read()
-    bottleneck_values = run_bottleneck_on_image(sess, image_data,
-                                                jpeg_data_tensor,
-                                                bottleneck_tensor)
-    bottleneck_values = read_list_of_floats_from_file(bottleneck_path)	
+										
+  #if key in map, take it form there and  return
+  #else
+  #     if file does not exist
+  #         create bottleneck file
+  #     read file from disk
+  #     put bottleneck values to map
+  #     return
+  
+  if bottleneck_path in bottleneck_path_2_bottleneck_values:
+      assert (bottleneck_path in bottleneck_path_2_bottleneck_values), "Attempt to use unassigned key value."
+      return bottleneck_path_2_bottleneck_values[bottleneck_path]
+  else:
+      if not os.path.exists(bottleneck_path):
+        print('Creating bottleneck at ' + bottleneck_path)
+        image_path = get_image_path(image_lists, label_name, index, image_dir,
+                                    category)
+        if not gfile.Exists(image_path):
+          tf.logging.fatal('File does not exist %s', image_path)
+        image_data = gfile.FastGFile(image_path, 'rb').read()
+        bottleneck_values = run_bottleneck_on_image(sess, image_data,
+                                                    jpeg_data_tensor,
+                                                    bottleneck_tensor)
+        write_list_of_floats_to_file(bottleneck_values, bottleneck_path)
 
-  bottleneck_values = read_list_of_floats_from_file(bottleneck_path)  
-  return bottleneck_values
+      bottleneck_values = read_list_of_floats_from_file(bottleneck_path)
+
+      assert(not (bottleneck_path in bottleneck_path_2_bottleneck_values)), "Attempt to overwrite map value."
+
+      bottleneck_path_2_bottleneck_values[bottleneck_path] = bottleneck_values
+
+      return bottleneck_values
+
 
 
 def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -382,10 +382,8 @@ def write_list_of_floats_to_file(list_of_floats , file_path):
   """
 
   s = struct.pack('d' * BOTTLENECK_TENSOR_SIZE, *list_of_floats)
-
-  f = open(file_path, 'wb')
-  f.write(s)
-  f.close()
+  with open(file_path, 'wb') as f:
+    f.write(s)
 
 
 def read_list_of_floats_from_file(file_path):
@@ -398,11 +396,9 @@ def read_list_of_floats_from_file(file_path):
 
   """
 
-  f = open(file_path, 'rb')
-  s = []
-  s = struct.unpack('d' * BOTTLENECK_TENSOR_SIZE, f.read())
-  f.close()
-  return list(s)
+  with open(file_path, 'rb') as f:
+    s = struct.unpack('d' * BOTTLENECK_TENSOR_SIZE, f.read())
+    return list(s)
 
 
 bottleneck_path_2_bottleneck_values = {}

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -371,13 +371,13 @@ def ensure_dir_exists(dir_name):
   if not os.path.exists(dir_name):
     os.makedirs(dir_name)
 
-	
+
 def write_list_of_floats_to_file(list_of_floats , file_path):
   """Writes a given list of floats to a binary file.
 
   Args:
     list_of_floats: List of floats we want to write to a file.
-	file_path: Path to a file where list of floats will be stored.
+    file_path: Path to a file where list of floats will be stored.
 
   """
 
@@ -387,28 +387,29 @@ def write_list_of_floats_to_file(list_of_floats , file_path):
   f.write(s)
   f.close()
 
-	
+
 def read_list_of_floats_from_file(file_path):
   """Reads list of floats from a given file.
 
   Args:    
-	file_path: Path to a file where list of floats was stored.
+    file_path: Path to a file where list of floats was stored.
   Returns:
     Array of bottleneck values (list of floats).
 
   """
+
   f = open(file_path, 'rb')
   s = []
   s = struct.unpack('d' * BOTTLENECK_TENSOR_SIZE, f.read())
   f.close()
-  #print (list(s))
-  
+  # print (list(s))
+
   return list(s)
-	
+
 
 bottleneck_path_2_bottleneck_values = {}
 
-	
+
 def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
                              category, bottleneck_dir, jpeg_data_tensor,
                              bottleneck_tensor):
@@ -440,15 +441,15 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
   ensure_dir_exists(sub_dir_path)
   bottleneck_path = get_bottleneck_path(image_lists, label_name, index,
                                         bottleneck_dir, category)
-										
-  #if key in map, take it form there and  return
-  #else
+
+  # if key in map, take it form there and  return
+  # else
   #     if file does not exist
   #         create bottleneck file
   #     read file from disk
   #     put bottleneck values to map
   #     return
-  
+
   if bottleneck_path in bottleneck_path_2_bottleneck_values:
       assert (bottleneck_path in bottleneck_path_2_bottleneck_values), "Attempt to use unassigned key value."
       return bottleneck_path_2_bottleneck_values[bottleneck_path]
@@ -472,7 +473,6 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
       bottleneck_path_2_bottleneck_values[bottleneck_path] = bottleneck_values
 
       return bottleneck_values
-
 
 
 def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -402,8 +402,6 @@ def read_list_of_floats_from_file(file_path):
   s = []
   s = struct.unpack('d' * BOTTLENECK_TENSOR_SIZE, f.read())
   f.close()
-  # print (list(s))
-
   return list(s)
 
 

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -438,35 +438,29 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
 
   # if key in map, take it form there and  return
   # else
-  #     if file does not exist
-  #         create bottleneck file
-  #     read file from disk
-  #     put bottleneck values to map
-  #     return
+  #   if file does not exist
+  #     create bottleneck file
+  #   read file from disk
+  #   put bottleneck values to map
+  #   return
 
   if bottleneck_path in bottleneck_path_2_bottleneck_values:
-      assert (bottleneck_path in bottleneck_path_2_bottleneck_values), "Attempt to use unassigned key value."
-      return bottleneck_path_2_bottleneck_values[bottleneck_path]
+    assert (bottleneck_path in bottleneck_path_2_bottleneck_values), "Attempt to use unassigned key value."
+    return bottleneck_path_2_bottleneck_values[bottleneck_path]
   else:
-      if not os.path.exists(bottleneck_path):
-        print('Creating bottleneck at ' + bottleneck_path)
-        image_path = get_image_path(image_lists, label_name, index, image_dir,
-                                    category)
-        if not gfile.Exists(image_path):
-          tf.logging.fatal('File does not exist %s', image_path)
-        image_data = gfile.FastGFile(image_path, 'rb').read()
-        bottleneck_values = run_bottleneck_on_image(sess, image_data,
-                                                    jpeg_data_tensor,
-                                                    bottleneck_tensor)
-        write_list_of_floats_to_file(bottleneck_values, bottleneck_path)
+    if not os.path.exists(bottleneck_path):
+      print('Creating bottleneck at ' + bottleneck_path)
+      image_path = get_image_path(image_lists, label_name, index, image_dir, category)
+      if not gfile.Exists(image_path):
+        tf.logging.fatal('File does not exist %s', image_path)
+      image_data = gfile.FastGFile(image_path, 'rb').read()
+      bottleneck_values = run_bottleneck_on_image(sess, image_data, jpeg_data_tensor, bottleneck_tensor)
+      write_list_of_floats_to_file(bottleneck_values, bottleneck_path)
 
-      bottleneck_values = read_list_of_floats_from_file(bottleneck_path)
-
-      assert(not (bottleneck_path in bottleneck_path_2_bottleneck_values)), "Attempt to overwrite map value."
-
-      bottleneck_path_2_bottleneck_values[bottleneck_path] = bottleneck_values
-
-      return bottleneck_values
+    bottleneck_values = read_list_of_floats_from_file(bottleneck_path)
+    assert(not (bottleneck_path in bottleneck_path_2_bottleneck_values)), "Attempt to overwrite map value."
+    bottleneck_path_2_bottleneck_values[bottleneck_path] = bottleneck_values
+    return bottleneck_values
 
 
 def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,


### PR DESCRIPTION
Speed up is achieved by:
1. saving (and especially loading) bottleneck arrays in binary files instead of .txt files
2. caching already calculated bottleneck arrays in RAM, instead of reading them every time from disk

P.S.
2x speed up is achieved on SSD disks, on HDD disks speed up is even greater
