### PR TITLE
Prevent evaluating stale output node.

### DIFF
--- a/tensorflow/contrib/quantization/tools/quantize_graph.py
+++ b/tensorflow/contrib/quantization/tools/quantize_graph.py
@@ -328,6 +328,8 @@ class GraphRewriter(object):
         self.quantize_nodes_recursively(output_node)
     elif self.mode == "eightbit":
       self.set_input_graph(self.remove_unneeded_nodes(self.input_graph))
+      output_nodes = [self.nodes_map[output_node_name]
+                    for output_node_name in output_node_names]
       self.already_visited = {}
       self.layers_eightbitized = []
       for output_node in output_nodes:


### PR DESCRIPTION
When quantizing to 8-bit the Identity ops are removed ("spliced"). For graph's with a parameter-less output node like SoftMax, there is no issue. However, if the graph's output node received a constant input (i.e. a bias add with weights) the output node referenced [here](https://github.com/parvizp/tensorflow/blob/502ecd2c6c324a1c5c3f7b195c36dbafb45dafb3/tensorflow/contrib/quantization/tools/quantize_graph.py#L318) will be stale (still has Identity input) and result in a error.
