### PR TITLE
Add support for quantized operations to pip wheel

### DIFF
--- a/tensorflow/contrib/quantization/BUILD
+++ b/tensorflow/contrib/quantization/BUILD
@@ -69,6 +69,8 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":ops",
+        "//tensorflow/contrib/quantization:quantized_ops_py",
+        "//tensorflow/contrib/quantization/kernels:quantized_kernels_py",
     ],
 )
 


### PR DESCRIPTION
While quantized op layers are currently part of the built pip package
already, the underlying libraries are not included with the build. This
commit adds support by adding both ops & kernel libs to the pip package
dependencies.
