### PR TITLE
Update link in linear tutorial

### DIFF
--- a/tensorflow/g3doc/tutorials/linear/overview.md
+++ b/tensorflow/g3doc/tutorials/linear/overview.md
@@ -177,8 +177,7 @@ the data itself. You provide the data through an input function.
 The input function must return a dictionary of tensors. Each key corresponds
 to the name of a `FeatureColumn`. Each key's value is a tensor containing the
 values of that feature for all data instances. See `input_fn` in the [linear
-models tutorial code](
-https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py?l=160)
+models tutorial code](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py#L158)
 for an example of an input function.
 
 The input function is passed to the `fit()` and `evaluate()` calls that


### PR DESCRIPTION
The link to the wide_n_deep tutorial doesn't work.
Should it link to the one above?
