### PR TITLE
Fix CUDA capability version logic in ci_parameterized_build.sh for non-Docker cases

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip.sh
+++ b/tensorflow/tools/ci_build/builds/pip.sh
@@ -49,10 +49,11 @@
 # to run.
 #
 
-# Constants:
 # Fixed naming patterns for wheel (.whl) files given different python versions
-declare -A WHL_TAGS
-WHL_TAGS=(["2.7"]="cp27-none" ["3.4"]="cp34-cp34m" ["3.5"]="cp35-cp35m")
+if [[ $(uname) == "Linux" ]]; then
+  declare -A WHL_TAGS
+  WHL_TAGS=(["2.7"]="cp27-none" ["3.4"]="cp34-cp34m" ["3.5"]="cp35-cp35m")
+fi
 
 
 INSTALL_EXTRA_PIP_PACKAGES=${TF_BUILD_INSTALL_EXTRA_PIP_PACKAGES}


### PR DESCRIPTION
Fix CUDA capability version logic in ci_parameterized_build.sh for non-Docker cases

Allows proper specification of TF_CUDA_COMPUTE_CAPABILITIES for nightly Mac GPU builds, e.g., export TF_CUDA_COMPUTE_CAPABILITIES="3.0,3.5,5.2"

Tested:
opensource build.
Experimental Linux GPU PIP build: http://ci.tensorflow.org/job/experimental-cais-new-gpu/45/console (Jenkins login required)
Experimental Mac GPU PIP build: http://ci.tensorflow.org/job/experimental-cais-tensorflow-mac/44/console (Jenkins login required)
