### PR TITLE
Fix an error message.

### DIFF
--- a/tensorflow/core/kernels/argmax_op.cc
+++ b/tensorflow/core/kernels/argmax_op.cc
@@ -59,7 +59,7 @@ class ArgOp : public OpKernel {
 
     OP_REQUIRES(context, dim >= 0, errors::InvalidArgument("dim must be >= 0"));
     OP_REQUIRES(context, dim < input_dims,
-                errors::InvalidArgument("Minimum tensor rank: ", dim,
+                errors::InvalidArgument("Minimum tensor rank: ", dim + 1,
                                         " but got: ", input_dims));
     OP_REQUIRES(
         context, input.dim_size(dim) > 0,


### PR DESCRIPTION
Minimum tensor rank should be `dim + 1` instead of `dim`.

Example:

``` python
tf.argmin(x, 1)  # x is a 1-d vector.
```

before:

> InvalidArgumentError: Minimum tensor rank: 1 but got: 1

after:

> InvalidArgumentError: Minimum tensor rank: 2 but got: 1
