### PR TITLE
Fixed typo:

### DIFF
--- a/tensorflow/g3doc/get_started/basic_usage.md
+++ b/tensorflow/g3doc/get_started/basic_usage.md
@@ -234,7 +234,7 @@ one = tf.constant(1)
 new_value = tf.add(state, one)
 update = tf.assign(state, new_value)
 
-# Variables must be initialized by running an `init` Op after having
+# Variables must be initialized by running an `init` Op before having
 # launched the graph.  We first have to add the `init` Op to the graph.
 init_op = tf.initialize_all_variables()
 


### PR DESCRIPTION
Variables must be initialized by running an `init` Op
"before" having launched the graph, not "after".
