### PR TITLE
Update index.md

### DIFF
--- a/tensorflow/g3doc/how_tos/using_gpu/index.md
+++ b/tensorflow/g3doc/how_tos/using_gpu/index.md
@@ -58,7 +58,7 @@ within that context will have the same device assignment.
 with tf.device('/cpu:0'):
   a = tf.constant([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], shape=[2, 3], name='a')
   b = tf.constant([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], shape=[3, 2], name='b')
-c = tf.matmul(a, b)
+  c = tf.matmul(a, b)
 # Creates a session with log_device_placement set to True.
 sess = tf.Session(config=tf.ConfigProto(log_device_placement=True))
 # Runs the op.


### PR DESCRIPTION
I just test it as I want to assign a, b and c to gpu3. Something wrong happened.
if the code "c = tf.matmul(a, b)" is not include in "with tf.device('/cpu:0')", then even you find b and a are assigned to cpu0，they just be assigned default. Because c is assigned to cpu0 default. a and b are used by c, so they are assigned to cpu0. 
