### PR TITLE
Extended adjust_hue and adjust_saturation to work on 4D tensors

### DIFF
--- a/tensorflow/python/ops/image_ops.py
+++ b/tensorflow/python/ops/image_ops.py
@@ -252,13 +252,12 @@ def _slice_channels(image):
     list of tensor, one for each channel.
   """
 
-  image_shape = image.get_shape()
-  image_rank = len(image_shape)
+  image_rank = array_ops.rank(image)
 
   begin = [0] * (image_rank - 1)
   size = [-1] * (image_rank - 1) + [1]
 
-  channels = [array_ops.slice(image, begin + [i], size) for i in range(image_shape[-1])]
+  channels = [array_ops.slice(image, begin + [i], size) for i in range(3)]
   return channels
 
 
@@ -1152,7 +1151,7 @@ def adjust_hue(image, delta, name=None):
     # floating point number since delta is [-0.5, 0.5].
     hue = math_ops.mod(hue + (delta + 1.), 1.)
 
-    hsv_altered = array_ops.concat(len(image.get_shape()) - 1, [hue, saturation, value])
+    hsv_altered = array_ops.concat(array_ops.rank(image) - 1, [hue, saturation, value])
     rgb_altered = gen_image_ops.hsv_to_rgb(hsv_altered)
 
     return convert_image_dtype(rgb_altered, orig_dtype)
@@ -1224,7 +1223,7 @@ def adjust_saturation(image, saturation_factor, name=None):
     saturation *= saturation_factor
     saturation = clip_ops.clip_by_value(saturation, 0.0, 1.0)
 
-    hsv_altered = array_ops.concat(len(image.get_shape()) - 1, [hue, saturation, value])
+    hsv_altered = array_ops.concat(array_ops.rank(image) - 1, [hue, saturation, value])
     rgb_altered = gen_image_ops.hsv_to_rgb(hsv_altered)
 
     return convert_image_dtype(rgb_altered, orig_dtype)

--- a/tensorflow/python/ops/image_ops.py
+++ b/tensorflow/python/ops/image_ops.py
@@ -242,6 +242,26 @@ def _CheckAtLeast3DImage(image):
                      image.get_shape())
 
 
+def _slice_channels(image):
+  """Slices a tensor into one tensor for each 'channel' (the last dimension).
+
+  Args:
+    images: Tensor containing the images to be sliced.
+
+  Returns:
+    list of tensor, one for each channel.
+  """
+
+  image_shape = image.get_shape()
+  image_rank = len(image_shape)
+
+  begin = [0] * (image_rank - 1)
+  size = [-1] * (image_rank - 1) + [1]
+
+  channels = [array_ops.slice(image, begin + [i], size) for i in range(image_shape[-1])]
+  return channels
+
+
 def random_flip_up_down(image, seed=None):
   """Randomly flips an image vertically (upside down).
 
@@ -1126,15 +1146,13 @@ def adjust_hue(image, delta, name=None):
 
     hsv = gen_image_ops.rgb_to_hsv(flt_image)
 
-    hue = array_ops.slice(hsv, [0, 0, 0], [-1, -1, 1])
-    saturation = array_ops.slice(hsv, [0, 0, 1], [-1, -1, 1])
-    value = array_ops.slice(hsv, [0, 0, 2], [-1, -1, 1])
+    hue, saturation, value = _slice_channels(hsv)
 
     # Note that we add 2*pi to guarantee that the resulting hue is a positive
     # floating point number since delta is [-0.5, 0.5].
     hue = math_ops.mod(hue + (delta + 1.), 1.)
 
-    hsv_altered = array_ops.concat(2, [hue, saturation, value])
+    hsv_altered = array_ops.concat(len(image.get_shape()) - 1, [hue, saturation, value])
     rgb_altered = gen_image_ops.hsv_to_rgb(hsv_altered)
 
     return convert_image_dtype(rgb_altered, orig_dtype)
@@ -1201,14 +1219,12 @@ def adjust_saturation(image, saturation_factor, name=None):
 
     hsv = gen_image_ops.rgb_to_hsv(flt_image)
 
-    hue = array_ops.slice(hsv, [0, 0, 0], [-1, -1, 1])
-    saturation = array_ops.slice(hsv, [0, 0, 1], [-1, -1, 1])
-    value = array_ops.slice(hsv, [0, 0, 2], [-1, -1, 1])
+    hue, saturation, value = _slice_channels(hsv)
 
     saturation *= saturation_factor
     saturation = clip_ops.clip_by_value(saturation, 0.0, 1.0)
 
-    hsv_altered = array_ops.concat(2, [hue, saturation, value])
+    hsv_altered = array_ops.concat(len(image.get_shape()) - 1, [hue, saturation, value])
     rgb_altered = gen_image_ops.hsv_to_rgb(hsv_altered)
 
     return convert_image_dtype(rgb_altered, orig_dtype)


### PR DESCRIPTION
I noticed that adjust_hue and adjust_saturation only worked on single images (3D tensors), but I couldn't really see a reason for that, so I extended it to work on 4D. I don't know if you want this in the main repo?

I based the work on the r0.9 branch because that's what I'm using, but I can do it for the master branch if that is more suitable.
