### PR TITLE
word2vec_basic.py : to prevent possible issue with libpng

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -19,13 +19,14 @@ from __future__ import print_function
 
 import collections
 import math
+import matplotlib.pyplot as plt
+import numpy as np
 import os
 import random
 import zipfile
-
-import numpy as np
 from six.moves import urllib
 from six.moves import xrange  # pylint: disable=redefined-builtin
+
 import tensorflow as tf
 
 # Step 1: Download the data.
@@ -234,7 +235,6 @@ def plot_with_labels(low_dim_embs, labels, filename='tsne.png'):
 
 try:
   from sklearn.manifold import TSNE
-  import matplotlib.pyplot as plt
 
   tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=5000)
   plot_only = 500


### PR DESCRIPTION
Following error message stopped with this pull request.

        libpng warning: Application was compiled with png.h from libpng-1.6.17
        libpng warning: Application  is  running with png.c from libpng-1.2.53
        libpng error: Incompatible libpng version in application and library

I was running this example on
    \* Ubuntu 16.04
    \* python 2.7.11
    \* Anaconda 4.0.0 +
    \* TensorFlow 0.8.0
    \* matplotlib 1.5.1
    \* numpy 1.11.1
    \* nomlk 1.0

Let me know any questions or comments.

KW
