### PR TITLE
Hard-code libcuda version number to "1". Fixes #2865.

### DIFF
--- a/tensorflow/stream_executor/dso_loader.cc
+++ b/tensorflow/stream_executor/dso_loader.cc
@@ -72,7 +72,7 @@ string GetCudnnVersion() { return ""; }
 }
 
 /* static */ port::Status DsoLoader::GetLibcudaDsoHandle(void** dso_handle) {
-  return GetDsoHandle(FindDsoPath(tensorflow::internal::FormatLibraryFileName("cuda", ""),
+  return GetDsoHandle(FindDsoPath(tensorflow::internal::FormatLibraryFileName("cuda", "1"),
                                   GetCudaDriverLibraryPath()),
                       dso_handle);
 }


### PR DESCRIPTION
As per comments from nvidia-docker dev @3XX0, hardcoding "1" should be
reasonably safe. The TF_CUDA_VERSION variable from the configure script
is not appropriate here (it will contain something like "7.0" or "7.5",
while the libcuda soname major version number should be "1").

/CC @rdadolf  and @martinwicke 
