### PR TITLE
Changed visibility of protos_cc to public

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1027,6 +1027,7 @@ tf_cuda_library(
 cc_library(
     name = "protos_cc",
     deps = ["//tensorflow/core/platform/default/build_config:protos_cc"],
+    visibility = ["//visibility:public"],
 )
 
 tf_cuda_library(


### PR DESCRIPTION
The only tensorflow package that is private and preventing us from creating custom kernels (with a custom set of operations), is the protos_cc. If we make this public, we can make our own kernels outside of the tensorflow repo, which means for Android/iOS we can make compact libraries with just the right amount of kernel ops.

There seems to be another approach which is `SELECTIVE_REGISTRATION`, but firstly according to #3549 no one has managed to provide a working example for it (tried myself but was not able to yet), and it also seems to be Android only. For the meantime, it seems the best method is to define our own kernel and therefore our own tensorflow_lib bazel files, but to do this we need to changes protos_cc to public.
