### PR TITLE
bug fix: the benchmark only run FLAGS.num_batches-1 times

### DIFF
--- a/tensorflow/models/image/alexnet/alexnet_benchmark.py
+++ b/tensorflow/models/image/alexnet/alexnet_benchmark.py
@@ -176,7 +176,7 @@ def time_tensorflow_run(session, target, info_string):
     start_time = time.time()
     _ = session.run(target)
     duration = time.time() - start_time
-    if i > num_steps_burn_in:
+    if i >= num_steps_burn_in:
       if not i % 10:
         print ('%s: step %d, duration = %.3f' %
                (datetime.now(), i - num_steps_burn_in, duration))


### PR DESCRIPTION
I found that if I set num_batches = 100, then it only runs 99 batches.
Because i is [0, 110), and it starts to count the time when i > 10, so valid i is (10, 110), it only contains 99 elements. So i should be [10, 110), which means '> ' in line 179 should be changed with '>='. 
