### PR TITLE
Fix prototype mismatch of ByteCount in env.cc

### DIFF
--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -301,7 +301,7 @@ class FileStream : public ::tensorflow::protobuf::io::ZeroCopyInputStream {
     pos_ += count;
     return true;
   }
-  int64 ByteCount() const override { return pos_; }
+  google::protobuf::int64 ByteCount() const override { return pos_; }
   Status status() const { return status_; }
 
   bool Next(const void** data, int* size) override {


### PR DESCRIPTION
Currently, makefile build is broken due to the prototype mismatch of ByteCount.  This change fixes that build error.

Error log:
tensorflow/core/platform/env.cc:304:9: error: conflicting return type specified for ‘virtual tensorflow::int64 tensorflow::{anonymous}::FileStream::ByteCount() const’
   int64 ByteCount() const override { return pos_; }
         ^
In file included from ./tensorflow/core/platform/default/protobuf.h:26:0,
                 from ./tensorflow/core/platform/protobuf.h:31,
                 from ./tensorflow/core/platform/file_system.h:28,
                 from ./tensorflow/core/platform/env.h:27,
                 from tensorflow/core/platform/env.cc:23:
/usr/local/google/home/satok/tmpstorage/Develop/src-tf-git/tensorflow2/tensorflow/tensorflow/contrib/makefile/gen/protobuf-host/include/google/protobuf/io/zero_copy_stream.h:172:17: error:   overriding ‘virtual google::protobuf::int64 google::protobuf::io::ZeroCopyInputStream::ByteCount() const’
   virtual int64 ByteCount() const = 0;
                 ^****
