### PR TITLE
Fixed inconsistency of outputs collection

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -261,7 +261,8 @@ def batch_norm(inputs,
     outputs.set_shape(inputs_shape)
     if activation_fn:
       outputs = activation_fn(outputs)
-    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+    return utils.collect_named_outputs(outputs_collections,
+                                       sc.original_name_scope, outputs)
 
 
 @add_arg_scope
@@ -313,7 +314,8 @@ def bias_add(inputs,
     outputs = nn.bias_add(inputs, biases)
     if activation_fn:
       outputs = activation_fn(outputs)
-    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+    return utils.collect_named_outputs(outputs_collections,
+                                       sc.original_name_scope, outputs)
 
 
 @add_arg_scope
@@ -426,7 +428,8 @@ def convolution2d(inputs,
         outputs = nn.bias_add(outputs, biases)
     if activation_fn:
       outputs = activation_fn(outputs)
-    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+    return utils.collect_named_outputs(outputs_collections,
+                                       sc.original_name_scope, outputs)
 
 
 @add_arg_scope
@@ -526,7 +529,8 @@ def convolution2d_in_plane(
 
     if activation_fn:
       outputs = activation_fn(outputs)
-    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+    return utils.collect_named_outputs(outputs_collections,
+                                       sc.original_name_scope, outputs)
 
 
 @add_arg_scope
@@ -653,7 +657,8 @@ def convolution2d_transpose(
 
     if activation_fn:
       outputs = activation_fn(outputs)
-    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+    return utils.collect_named_outputs(outputs_collections,
+                                       sc.original_name_scope, outputs)
 
 
 @add_arg_scope
@@ -832,7 +837,8 @@ def fully_connected(inputs,
       # Reshape back outputs
       outputs = array_ops.reshape(outputs, array_ops.pack(out_shape))
       outputs.set_shape(static_shape)
-    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+    return utils.collect_named_outputs(outputs_collections,
+                                       sc.original_name_scope, outputs)
 
 
 @add_arg_scope
@@ -1081,7 +1087,8 @@ def separable_convolution2d(
 
     if activation_fn:
       outputs = activation_fn(outputs)
-    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+    return utils.collect_named_outputs(outputs_collections,
+                                       sc.original_name_scope, outputs)
 
 
 @add_arg_scope

--- a/tensorflow/contrib/layers/python/layers/layers_test.py
+++ b/tensorflow/contrib/layers/python/layers/layers_test.py
@@ -202,6 +202,16 @@ class Convolution2dTest(tf.test.TestCase):
       output = tf.contrib.layers.convolution2d(images, 32, [3, 3],
                                                scope='conv1')
       self.assertEquals(output.op.name, 'conv1/Relu')
+  
+  def testCreateConvWithCollection(self):
+    height, width = 3, 3
+    images = tf.random_uniform((5, height, width, 3), seed=1)
+    with tf.name_scope('fe'):
+      conv = tf.contrib.layers.convolution2d(
+        images, 32, [3, 3], outputs_collections='outputs',
+        scope='Conv')
+    namedOutputs = tf.get_collection('outputs')[0]
+    self.assertEquals(namedOutputs.name, 'fe/Conv')
 
   def testCreateConvWithoutActivation(self):
     height, width = 3, 3
@@ -988,6 +998,16 @@ class FCTest(tf.test.TestCase):
       inputs = tf.random_uniform((5, height * width * 3), seed=1)
       output = tf.contrib.layers.fully_connected(inputs, 32, scope='fc1')
       self.assertEquals(output.op.name, 'fc1/Relu')
+      
+  def testCreateFCWithCollection(self):
+    height, width = 3, 3
+    inputs = tf.random_uniform((5, height * width * 3), seed=1)
+    with tf.name_scope('fe'):
+      fc = tf.contrib.layers.fully_connected(
+        inputs, 7, outputs_collections='outputs',
+        scope='fc')
+    namedOutputs = tf.get_collection('outputs')[0]
+    self.assertEquals(namedOutputs.name, 'fe/fc')
 
   def testCreateFcCreatesWeightsAndBiasesVars(self):
     height, width = 3, 3


### PR DESCRIPTION
Because naming logic for utils.collect_named_outputs in max_pool2d and convolution2d is different, collection is getting filled with inconsistent names.
code to reproduce:

```
graph = tf.Graph()

node_collection = 'nodes'
with graph.as_default():
    x = tf.placeholder(tf.float32, (1, 20, 20, 3))

    with tf.name_scope('name_scope'):
        conv = tf.contrib.layers.conv2d(
            x, num_outputs=8, kernel_size=4,
            scope='conv', outputs_collections=node_collection)
        max_pool = tf.contrib.layers.max_pool2d(
                conv, kernel_size=2, stride=2, scope='max_pool',
                outputs_collections=node_collection)

print([nt.name for nt in graph.get_collection(node_collection)])
=============================================
['conv', 'name_scope/max_pool']
```

Expected output is ['name_scope/conv', 'name_scope/max_pool'].

It is also important for those who use tf.name_scope to distinguish processing of different inputs with the same layer, like in siamese neural network. Currently, they will get identical names.
Code to reproduce:

```
graph = tf.Graph()

node_collection = 'nodes'
with graph.as_default():
  input_a = tf.placeholder(tf.float32, (1, 20, 20, 3))
  input_b = tf.placeholder(tf.float32, (1, 20, 20, 3))
  with tf.variable_scope('feature_extractor') as vs:
    for name_scope, inputs in [('a', input_a), ('b', input_b)]:
      with tf.name_scope(name_scope):
        conv = tf.contrib.layers.conv2d(
          inputs, num_outputs=8, kernel_size=4,
          scope='conv', outputs_collections=node_collection)
        max_pool = tf.contrib.layers.max_pool2d(
          conv, kernel_size=2, stride=2, scope='max_pool',
          outputs_collections=node_collection)
      vs.reuse_variables()

print([nt.name for nt in graph.get_collection(node_collection)])
=============================================
['feature_extractor/conv', 'feature_extractor/a/max_pool', 'feature_extractor/conv', 'feature_extractor/b/max_pool']
```
