### PR TITLE
Fix word2vec_optimized excepction when words contain unicode.

### DIFF
--- a/tensorflow/models/embedding/word2vec_optimized.py
+++ b/tensorflow/models/embedding/word2vec_optimized.py
@@ -238,7 +238,8 @@ class Word2Vec(object):
     opts = self._options
     with open(os.path.join(opts.save_path, "vocab.txt"), "w") as f:
       for i in xrange(opts.vocab_size):
-        f.write("%s %d\n" % (tf.compat.as_text(opts.vocab_words[i]),
+        vocab_word = tf.compat.as_text(opts.vocab_words[i]).encode("utf-8")
+        f.write("%s %d\n" % (vocab_word,
                              opts.vocab_counts[i]))
 
   def build_eval_graph(self):


### PR DESCRIPTION
When word2vec_optimized deal with Korean language, it will break out below exception.

```
Traceback (most recent call last):
  File "word2vec_optimized.py", line 432, in <module>
    tf.app.run()
  File "/Library/Python/2.7/site-packages/tensorflow/python/platform/app.py", line 30, in run
    sys.exit(main(sys.argv))
  File "word2vec_optimized.py", line 417, in main
    model = Word2Vec(opts, session)
  File "word2vec_optimized.py", line 146, in __init__
    self.save_vocab()
  File "word2vec_optimized.py", line 242, in save_vocab
    opts.vocab_counts[i]))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```

I fix this exception by adding encode('utf-8') , and then it successful run word2vec_optimized model.
