### PR TITLE
Fix analogy response of word2vec interactive when the response is unicode.

### DIFF
--- a/tensorflow/models/embedding/word2vec.py
+++ b/tensorflow/models/embedding/word2vec.py
@@ -477,8 +477,8 @@ class Word2Vec(object):
     for c in [self._id2word[i] for i in idx[0, :]]:
       if c not in [w0, w1, w2]:
         print(c)
-        return
-    return "unknown"
+        break
+    print("unknown")
 
   def nearby(self, words, num=20):
     """Prints out nearby words given a list of words."""

--- a/tensorflow/models/embedding/word2vec.py
+++ b/tensorflow/models/embedding/word2vec.py
@@ -476,7 +476,8 @@ class Word2Vec(object):
     idx = self._predict(wid)
     for c in [self._id2word[i] for i in idx[0, :]]:
       if c not in [w0, w1, w2]:
-        return c
+        print(c)
+        return
     return "unknown"
 
   def nearby(self, words, num=20):

--- a/tensorflow/models/embedding/word2vec_optimized.py
+++ b/tensorflow/models/embedding/word2vec_optimized.py
@@ -382,8 +382,8 @@ class Word2Vec(object):
     for c in [self._id2word[i] for i in idx[0, :]]:
       if c not in [w0, w1, w2]:
         print(c)
-        return
-    return "unknown"
+        break
+    print("unknown")
 
   def nearby(self, words, num=20):
     """Prints out nearby words given a list of words."""

--- a/tensorflow/models/embedding/word2vec_optimized.py
+++ b/tensorflow/models/embedding/word2vec_optimized.py
@@ -381,7 +381,8 @@ class Word2Vec(object):
     idx = self._predict(wid)
     for c in [self._id2word[i] for i in idx[0, :]]:
       if c not in [w0, w1, w2]:
-        return c
+        print(c)
+        return
     return "unknown"
 
   def nearby(self, words, num=20):


### PR DESCRIPTION
I run word2vec.py with interactive mode.

```
$ python word2vec.py --interactive --train_data=t --eval_data=q --save_path=save
...
In [3]: model.analogy(b'남자', b'여자', b'아빠')
Out[3]: '\xec\x97\x84\xeb\xa7\x88'
```

The response of analogy couldn't be readable.

So I fix the response and then rerun the code.

```
In [3]: model.analogy(b'남자', b'여자', b'아빠')
엄마
```

Now I can see the response.
