### PR TITLE
Add layer_norm op to contrib.layers.

### DIFF
--- a/tensorflow/contrib/layers/__init__.py
+++ b/tensorflow/contrib/layers/__init__.py
@@ -27,6 +27,7 @@ common machine learning algorithms.
 @@convolution2d_transpose
 @@flatten
 @@fully_connected
+@@layer_norm
 @@max_pool2d
 @@one_hot_encoding
 @@repeat

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -52,6 +52,7 @@ __all__ = ['avg_pool2d',
            'dropout',
            'flatten',
            'fully_connected',
+           'layer_norm',
            'linear',
            'max_pool2d',
            'one_hot_encoding',
@@ -837,6 +838,92 @@ def fully_connected(inputs,
       outputs.set_shape(static_shape)
     return utils.collect_named_outputs(outputs_collections,
                                        sc.original_name_scope, outputs)
+
+
+@add_arg_scope
+def layer_norm(inputs,
+               center=True,
+               scale=False,
+               epsilon=0.001,
+               activation_fn=None,
+               reuse=None,
+               variables_collections=None,
+               outputs_collections=None,
+               trainable=True,
+               scope=None):
+  """Adds a Layer Normalization layer from https://arxiv.org/abs/1607.06450.
+
+    "Layer Normalization"
+
+    Jimmy Lei Ba, Jamie Ryan Kiros, Geoffrey E. Hinton
+
+  Can be used as a normalizer function for conv2d and fully_connected.
+
+  Args:
+    inputs: a tensor of size `[batch_size, height, width, channels]`
+            or `[batch_size, channels]`.
+    center: If True, subtract `beta`. If False, `beta` is ignored.
+    scale: If True, multiply by `gamma`. If False, `gamma` is
+      not used. When the next layer is linear (also e.g. `nn.relu`), this can be
+      disabled since the scaling can be done by the next layer.
+    epsilon: small float added to variance to avoid dividing by zero.
+    activation_fn: Optional activation function.
+    reuse: whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: optional collections for the variables.
+    outputs_collections: collections to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+    scope: Optional scope for `variable_op_scope`.
+
+  Returns:
+    A `Tensor` representing the output of the operation.
+
+  Raises:
+    ValueError: if rank or last dimension of `inputs` is undefined.
+  """
+  with variable_scope.variable_op_scope([inputs],
+                                        scope, 'LayerNorm', reuse=reuse) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    inputs_shape = inputs.get_shape()
+    inputs_rank = inputs_shape.ndims
+    if inputs_rank is None:
+      raise ValueError('Inputs %s has undefined rank.' % inputs.name)
+    dtype = inputs.dtype.base_dtype
+    axis = list(range(1, inputs_rank))
+    params_shape = inputs_shape[-1:]
+    if not params_shape.is_fully_defined():
+      raise ValueError('Inputs %s has undefined last dimension %s.' % (
+          inputs.name, params_shape))
+    # Allocate parameters for the beta and gamma of the normalization.
+    beta, gamma = None, None
+    if center:
+      beta_collections = utils.get_variable_collections(variables_collections,
+                                                        'beta')
+      beta = variables.model_variable('beta',
+                                      shape=params_shape,
+                                      dtype=dtype,
+                                      initializer=init_ops.zeros_initializer,
+                                      collections=beta_collections,
+                                      trainable=trainable)
+    if scale:
+      gamma_collections = utils.get_variable_collections(variables_collections,
+                                                         'gamma')
+      gamma = variables.model_variable('gamma',
+                                       shape=params_shape,
+                                       dtype=dtype,
+                                       initializer=init_ops.ones_initializer,
+                                       collections=gamma_collections,
+                                       trainable=trainable)
+    # Calculate the moments on the last axis (layer activations).
+    mean, variance = nn.moments(inputs, axis, keep_dims=True)
+    # Compute layer normalization using the batch_normalization function.
+    outputs = nn.batch_normalization(
+        inputs, mean, variance, beta, gamma, epsilon)
+    outputs.set_shape(inputs_shape)
+    if activation_fn:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
 
 
 @add_arg_scope

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -843,8 +843,7 @@ def fully_connected(inputs,
 @add_arg_scope
 def layer_norm(inputs,
                center=True,
-               scale=False,
-               epsilon=0.001,
+               scale=True,
                activation_fn=None,
                reuse=None,
                variables_collections=None,
@@ -866,7 +865,6 @@ def layer_norm(inputs,
     scale: If True, multiply by `gamma`. If False, `gamma` is
       not used. When the next layer is linear (also e.g. `nn.relu`), this can be
       disabled since the scaling can be done by the next layer.
-    epsilon: small float added to variance to avoid dividing by zero.
     activation_fn: Optional activation function.
     reuse: whether or not the layer and its variables should be reused. To be
       able to reuse the layer scope must be given.
@@ -918,8 +916,9 @@ def layer_norm(inputs,
     # Calculate the moments on the last axis (layer activations).
     mean, variance = nn.moments(inputs, axis, keep_dims=True)
     # Compute layer normalization using the batch_normalization function.
+    variance_epsilon = 1E-12
     outputs = nn.batch_normalization(
-        inputs, mean, variance, beta, gamma, epsilon)
+        inputs, mean, variance, beta, gamma, variance_epsilon)
     outputs.set_shape(inputs_shape)
     if activation_fn:
       outputs = activation_fn(outputs)

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -859,8 +859,8 @@ def layer_norm(inputs,
   Can be used as a normalizer function for conv2d and fully_connected.
 
   Args:
-    inputs: a tensor of size `[batch_size, height, width, channels]`
-            or `[batch_size, channels]`.
+    inputs: a tensor with 2 or more dimensions. The normalization
+            occurs over all but the first dimension.
     center: If True, subtract `beta`. If False, `beta` is ignored.
     scale: If True, multiply by `gamma`. If False, `gamma` is
       not used. When the next layer is linear (also e.g. `nn.relu`), this can be
@@ -880,8 +880,8 @@ def layer_norm(inputs,
   Raises:
     ValueError: if rank or last dimension of `inputs` is undefined.
   """
-  with variable_scope.variable_op_scope([inputs],
-                                        scope, 'LayerNorm', reuse=reuse) as sc:
+  with variable_scope.variable_scope(scope, 'LayerNorm', [inputs],
+                                     reuse=reuse) as sc:
     inputs = ops.convert_to_tensor(inputs)
     inputs_shape = inputs.get_shape()
     inputs_rank = inputs_shape.ndims
@@ -922,7 +922,9 @@ def layer_norm(inputs,
     outputs.set_shape(inputs_shape)
     if activation_fn:
       outputs = activation_fn(outputs)
-    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+    return utils.collect_named_outputs(outputs_collections,
+                                       sc.original_name_scope,
+                                       outputs)
 
 
 @add_arg_scope

--- a/tensorflow/contrib/layers/python/layers/layers_test.py
+++ b/tensorflow/contrib/layers/python/layers/layers_test.py
@@ -1571,9 +1571,8 @@ class LayerNormTest(tf.test.TestCase):
       # output_train and output_eval should be the same.
       self.assertAllClose(sess.run([output_train]), sess.run([output_eval]))
 
-  def testOutput(self):
+  def doOutputTest(self, input_shape):
     with self.test_session() as sess:
-      input_shape = (10, 100)
       input_values = np.random.rand(*input_shape)
       inputs = tf.constant(input_values, shape=input_shape, dtype=tf.float32)
       output_op = tf.contrib.layers.layer_norm(inputs,
@@ -1584,14 +1583,20 @@ class LayerNormTest(tf.test.TestCase):
       sess.run(tf.initialize_all_variables())
       # The mean and variance of the output should be close to 0 and 1
       # respectively.
+      moments_axis = tuple([i for i in range(1, len(input_shape))])
       outputs = sess.run(output_op)
       expected_mean = np.zeros(input_shape[0])
       expected_var = np.ones(input_shape[0])
-      mean = np.mean(outputs, axis=(1))
-      var = np.var(outputs, axis=(1))
-      self.assertAllClose(mean, expected_mean)
-      self.assertAllClose(var, expected_var)
+      mean = np.mean(outputs, axis=moments_axis)
+      var = np.var(outputs, axis=moments_axis)
+      self.assertAllClose(mean, expected_mean, rtol=1e-5)
+      self.assertAllClose(var, expected_var, rtol=1e-5)
 
+  def testOutput2DInput(self):
+    self.doOutputTest((10, 300))
+
+  def testOutput4DInput(self):
+    self.doOutputTest((100, 10, 10, 3))
 
 class MaxPool2DTest(tf.test.TestCase):
 

--- a/tensorflow/contrib/layers/python/layers/layers_test.py
+++ b/tensorflow/contrib/layers/python/layers/layers_test.py
@@ -1511,6 +1511,89 @@ class BatchNormTest(tf.test.TestCase):
       self.assertTrue(np.allclose(output_true, output_false))
 
 
+class LayerNormTest(tf.test.TestCase):
+
+  def testUnknownShape(self):
+    with tf.Graph().as_default() as g, self.test_session(g):
+      inputs = tf.placeholder(dtype=tf.float32)
+      with self.assertRaisesRegexp(ValueError, 'undefined rank'):
+        tf.contrib.layers.batch_norm(inputs)
+
+  def testUnknownLastDim(self):
+    with tf.Graph().as_default() as g, self.test_session(g):
+      inputs = tf.placeholder(dtype=tf.float32)
+      inputs.set_shape(tf.TensorShape((5, 3, 3, None)))
+      with self.assertRaisesRegexp(ValueError, 'undefined last dimension'):
+        tf.contrib.layers.batch_norm(inputs)
+
+  def testCreateOp(self):
+    height, width = 3, 3
+    with self.test_session():
+      images = np.random.uniform(size=(5, height, width, 3))
+      output = tf.contrib.layers.layer_norm(images)
+      self.assertTrue(output.op.name.startswith('LayerNorm/batchnorm'))
+      self.assertListEqual(output.get_shape().as_list(), [5, height, width, 3])
+
+  def testCreateVariables(self):
+    height, width = 3, 3
+    with self.test_session():
+      images = tf.random_uniform((5, height, width, 3), seed=1)
+      tf.contrib.layers.layer_norm(images, scale=True)
+      beta = tf.contrib.framework.get_variables_by_name('beta')[0]
+      gamma = tf.contrib.framework.get_variables_by_name('gamma')[0]
+      self.assertEquals(beta.op.name, 'LayerNorm/beta')
+      self.assertEquals(gamma.op.name, 'LayerNorm/gamma')
+
+  def testReuseVariables(self):
+    height, width = 3, 3
+    with self.test_session():
+      images = tf.random_uniform((5, height, width, 3), seed=1)
+      tf.contrib.layers.layer_norm(images, scale=True, scope='ln')
+      tf.contrib.layers.layer_norm(images, scale=True, scope='ln', reuse=True)
+      beta = tf.contrib.framework.get_variables_by_name('beta')
+      gamma = tf.contrib.framework.get_variables_by_name('gamma')
+      self.assertEquals(len(beta), 1)
+      self.assertEquals(len(gamma), 1)
+
+  def testReuseVars(self):
+    height, width = 3, 3
+    with self.test_session() as sess:
+      image_shape = (10, height, width, 3)
+      image_values = np.random.rand(*image_shape)
+      images = tf.constant(image_values, shape=image_shape, dtype=tf.float32)
+      output_train = tf.contrib.layers.layer_norm(images,
+                                                  scope='LN')
+      output_eval = tf.contrib.layers.layer_norm(images,
+                                                 scope='LN',
+                                                 reuse=True)
+      # Initialize all variables
+      sess.run(tf.initialize_all_variables())
+      # output_train and output_eval should be the same.
+      self.assertAllClose(sess.run([output_train]), sess.run([output_eval]))
+
+  def testOutput(self):
+    with self.test_session() as sess:
+      input_shape = (10, 100)
+      input_values = np.random.rand(*input_shape)
+      inputs = tf.constant(input_values, shape=input_shape, dtype=tf.float32)
+      output_op = tf.contrib.layers.layer_norm(inputs,
+                                               center=True,
+                                               scale=True,
+                                               epsilon=1E-10,
+                                               scope='LN')
+      # Initialize all variables
+      sess.run(tf.initialize_all_variables())
+      # The mean and variance of the output should be close to 0 and 1
+      # respectively.
+      outputs = sess.run(output_op)
+      expected_mean = np.zeros(input_shape[0])
+      expected_var = np.ones(input_shape[0])
+      mean = np.mean(outputs, axis=(1))
+      var = np.var(outputs, axis=(1))
+      self.assertAllClose(mean, expected_mean)
+      self.assertAllClose(var, expected_var)
+
+
 class MaxPool2DTest(tf.test.TestCase):
 
   def testCreateMaxPool(self):

--- a/tensorflow/contrib/layers/python/layers/layers_test.py
+++ b/tensorflow/contrib/layers/python/layers/layers_test.py
@@ -1538,7 +1538,7 @@ class LayerNormTest(tf.test.TestCase):
     height, width = 3, 3
     with self.test_session():
       images = tf.random_uniform((5, height, width, 3), seed=1)
-      tf.contrib.layers.layer_norm(images, scale=True)
+      tf.contrib.layers.layer_norm(images)
       beta = tf.contrib.framework.get_variables_by_name('beta')[0]
       gamma = tf.contrib.framework.get_variables_by_name('gamma')[0]
       self.assertEquals(beta.op.name, 'LayerNorm/beta')
@@ -1548,8 +1548,8 @@ class LayerNormTest(tf.test.TestCase):
     height, width = 3, 3
     with self.test_session():
       images = tf.random_uniform((5, height, width, 3), seed=1)
-      tf.contrib.layers.layer_norm(images, scale=True, scope='ln')
-      tf.contrib.layers.layer_norm(images, scale=True, scope='ln', reuse=True)
+      tf.contrib.layers.layer_norm(images, scope='ln')
+      tf.contrib.layers.layer_norm(images, scope='ln', reuse=True)
       beta = tf.contrib.framework.get_variables_by_name('beta')
       gamma = tf.contrib.framework.get_variables_by_name('gamma')
       self.assertEquals(len(beta), 1)
@@ -1561,8 +1561,7 @@ class LayerNormTest(tf.test.TestCase):
       image_shape = (10, height, width, 3)
       image_values = np.random.rand(*image_shape)
       images = tf.constant(image_values, shape=image_shape, dtype=tf.float32)
-      output_train = tf.contrib.layers.layer_norm(images,
-                                                  scope='LN')
+      output_train = tf.contrib.layers.layer_norm(images, scope='LN')
       output_eval = tf.contrib.layers.layer_norm(images,
                                                  scope='LN',
                                                  reuse=True)
@@ -1575,10 +1574,7 @@ class LayerNormTest(tf.test.TestCase):
     with self.test_session() as sess:
       input_values = np.random.rand(*input_shape)
       inputs = tf.constant(input_values, shape=input_shape, dtype=tf.float32)
-      output_op = tf.contrib.layers.layer_norm(inputs,
-                                               center=True,
-                                               scale=True,
-                                               scope='LN')
+      output_op = tf.contrib.layers.layer_norm(inputs, scope='LN')
       # Initialize all variables
       sess.run(tf.initialize_all_variables())
       # The mean and variance of the output should be close to 0 and 1

--- a/tensorflow/contrib/layers/python/layers/layers_test.py
+++ b/tensorflow/contrib/layers/python/layers/layers_test.py
@@ -1517,14 +1517,14 @@ class LayerNormTest(tf.test.TestCase):
     with tf.Graph().as_default() as g, self.test_session(g):
       inputs = tf.placeholder(dtype=tf.float32)
       with self.assertRaisesRegexp(ValueError, 'undefined rank'):
-        tf.contrib.layers.batch_norm(inputs)
+        tf.contrib.layers.layer_norm(inputs)
 
   def testUnknownLastDim(self):
     with tf.Graph().as_default() as g, self.test_session(g):
       inputs = tf.placeholder(dtype=tf.float32)
       inputs.set_shape(tf.TensorShape((5, 3, 3, None)))
       with self.assertRaisesRegexp(ValueError, 'undefined last dimension'):
-        tf.contrib.layers.batch_norm(inputs)
+        tf.contrib.layers.layer_norm(inputs)
 
   def testCreateOp(self):
     height, width = 3, 3

--- a/tensorflow/contrib/layers/python/layers/layers_test.py
+++ b/tensorflow/contrib/layers/python/layers/layers_test.py
@@ -1579,7 +1579,6 @@ class LayerNormTest(tf.test.TestCase):
       output_op = tf.contrib.layers.layer_norm(inputs,
                                                center=True,
                                                scale=True,
-                                               epsilon=1E-10,
                                                scope='LN')
       # Initialize all variables
       sess.run(tf.initialize_all_variables())


### PR DESCRIPTION
Addresses #3621 for python at least. The new op is modeled after batch_norm and borrows code from it heavily.
