### PR TITLE
Fix TypeError in gradient clipping ops

### DIFF
--- a/tensorflow/python/kernel_tests/clip_ops_test.py
+++ b/tensorflow/python/kernel_tests/clip_ops_test.py
@@ -33,7 +33,7 @@ class ClipTest(tf.test.TestCase):
       clip_value = 4.4
       ans = tf.clip_by_value(x, -clip_value, clip_value)
       tf_ans = ans.eval()
-
+      
     self.assertAllClose(np_ans, tf_ans)
 
   def testClipByValueNonFinite(self):
@@ -43,7 +43,7 @@ class ClipTest(tf.test.TestCase):
       clip_value = 4.0
       ans = tf.clip_by_value(x, -clip_value, clip_value)
       tf_ans = ans.eval()
-
+      
     self.assertAllClose(np_ans, tf_ans)
 
   # ClipByNorm tests
@@ -57,8 +57,13 @@ class ClipTest(tf.test.TestCase):
       clip_norm = 4.0
       ans = tf.clip_by_norm(x, clip_norm)
       tf_ans = ans.eval()
+      
+      clip_tensor = tf.constant(4.0)
+      ans = tf.clip_by_norm(x, clip_norm)
+      tf_ans_tensor = ans.eval()
 
     self.assertAllClose(np_ans, tf_ans)
+    self.assertAllClose(np_ans, tf_ans_tensor)
 
   def testClipByNormNotClipped(self):
     # No norm clipping when clip_norm >= 5
@@ -133,6 +138,28 @@ class ClipTest(tf.test.TestCase):
       x1 = tf.constant([1.0, -2.0])
       # Global norm of x0 and x1 = sqrt(1 + 4^2 + 2^2 + 2^2) = 5
       clip_norm = 4.0
+
+      # Answers are the original tensors scaled by 4.0/5.0
+      np_ans_0 = [[-1.6, 0.0, 0.0],
+                  [3.2, 0.0, 0.0]]
+      np_ans_1 = [0.8, -1.6]
+
+      ans, norm = tf.clip_by_global_norm((x0, x1), clip_norm)
+      tf_ans_1 = ans[0].eval()
+      tf_ans_2 = ans[1].eval()
+      tf_norm = norm.eval()
+
+    self.assertAllClose(tf_norm, 5.0)
+    self.assertAllClose(np_ans_0, tf_ans_1)
+    self.assertAllClose(np_ans_1, tf_ans_2)
+
+  def testClipByGlobalNormClippedTensor(self):
+    # Norm clipping when clip_norm < 5
+    with self.test_session():
+      x0 = tf.constant([-2.0, 0.0, 0.0, 4.0, 0.0, 0.0], shape=[2, 3])
+      x1 = tf.constant([1.0, -2.0])
+      # Global norm of x0 and x1 = sqrt(1 + 4^2 + 2^2 + 2^2) = 5
+      clip_norm = tf.constant(4.0)
 
       # Answers are the original tensors scaled by 4.0/5.0
       np_ans_0 = [[-1.6, 0.0, 0.0],
@@ -254,6 +281,19 @@ class ClipTest(tf.test.TestCase):
       np_ans = [[-2.88, 0.0, 0.0],
                 [3.84, 0.0, 0.0]]
       clip_norm = 0.8
+      ans = tf.clip_by_average_norm(x, clip_norm)
+      tf_ans = ans.eval()
+
+    self.assertAllClose(np_ans, tf_ans)
+
+  def testClipByAverageNormClippedTensor(self):
+    # Norm clipping when average clip_norm < 0.83333333
+    with self.test_session():
+      x = tf.constant([-3.0, 0.0, 0.0, 4.0, 0.0, 0.0], shape=[2, 3])
+      # Average norm of x = sqrt(3^2 + 4^2) / 6 = 0.83333333
+      np_ans = [[-2.88, 0.0, 0.0],
+                [3.84, 0.0, 0.0]]
+      clip_norm = tf.constant(0.8)
       ans = tf.clip_by_average_norm(x, clip_norm)
       tf_ans = ans.eval()
 

--- a/tensorflow/python/kernel_tests/clip_ops_test.py
+++ b/tensorflow/python/kernel_tests/clip_ops_test.py
@@ -33,7 +33,7 @@ class ClipTest(tf.test.TestCase):
       clip_value = 4.4
       ans = tf.clip_by_value(x, -clip_value, clip_value)
       tf_ans = ans.eval()
-      
+
     self.assertAllClose(np_ans, tf_ans)
 
   def testClipByValueNonFinite(self):
@@ -43,7 +43,7 @@ class ClipTest(tf.test.TestCase):
       clip_value = 4.0
       ans = tf.clip_by_value(x, -clip_value, clip_value)
       tf_ans = ans.eval()
-      
+
     self.assertAllClose(np_ans, tf_ans)
 
   # ClipByNorm tests

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -205,7 +205,7 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     scale = clip_norm * math_ops.minimum(
         1.0 / use_norm,
-        constant_op.constant(1.0 / clip_norm, dtype=use_norm.dtype))
+        constant_op.constant(1.0, dtype=use_norm.dtype) / clip_norm)
 
     values = [
         ops.convert_to_tensor(
@@ -267,7 +267,7 @@ def clip_by_average_norm(t, clip_norm, name=None):
         math_ops.reduce_sum(t * t, math_ops.range(array_ops.rank(t))))
     tclip = array_ops.identity(
         t * clip_norm * math_ops.minimum(
-            l2norm_inv * n_element, constant_op.constant(1.0 / clip_norm)),
+            l2norm_inv * n_element, constant_op.constant(1.0) / clip_norm),
         name=name)
 
   return tclip


### PR DESCRIPTION
Two gradient clipping ops, `tf.clip_by_global_norm` and `tf.clip_by_average_norm`, raise TypeError if `clip_norm` is a Tensor. This PR fixes the issue.
