### PR TITLE
Add complex dtype support to cast

### DIFF
--- a/tensorflow/core/kernels/cast_op.cc
+++ b/tensorflow/core/kernels/cast_op.cc
@@ -33,6 +33,9 @@ namespace tensorflow {
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
 
+using Eigen::internal::complex64;
+using Eigen::internal::complex128;
+
 namespace functor {
 
 template <typename O, typename I>
@@ -55,7 +58,9 @@ struct CastFunctor<CPUDevice, O, I> {
   FN(arg0, int64);             \
   FN(arg0, Eigen::half);       \
   FN(arg0, float);             \
-  FN(arg0, double)
+  FN(arg0, double);            \
+  FN(arg0, complex64);         \
+  FN(arg0, complex128)
 
 #define CURRY_TYPES3(FN, arg0, arg1) \
   FN(arg0, arg1, bool);              \
@@ -67,7 +72,9 @@ struct CastFunctor<CPUDevice, O, I> {
   FN(arg0, arg1, int64);             \
   FN(arg0, arg1, Eigen::half);       \
   FN(arg0, arg1, float);             \
-  FN(arg0, arg1, double)
+  FN(arg0, arg1, double);            \
+  FN(arg0, arg1, complex64);         \
+  FN(arg0, arg1, complex128)
 
 #define CAST_CASE(DEVICE, IN, OUT)                                         \
   if (DataTypeToEnum<IN>::value == src_dtype_ &&                           \
@@ -134,6 +141,8 @@ class CpuCastOp : public CastOpBase {
     CURRY_TYPES3(CAST_CASE, CPUDevice, Eigen::half);
     CURRY_TYPES3(CAST_CASE, CPUDevice, float);
     CURRY_TYPES3(CAST_CASE, CPUDevice, double);
+    CURRY_TYPES3(CAST_CASE, CPUDevice, complex64);
+    CURRY_TYPES3(CAST_CASE, CPUDevice, complex128);
 
     if (src_dtype_ == DT_BFLOAT16 && dst_dtype_ == DT_FLOAT) {
       work_ = [](OpKernelContext* ctx, const Tensor& inp, Tensor* out) {
@@ -191,6 +200,8 @@ class GpuCastOp : public CastOpBase {
     CURRY_TYPES3(CAST_CASE, GPUDevice, Eigen::half);
     CURRY_TYPES3(CAST_CASE, GPUDevice, float);
     CURRY_TYPES3(CAST_CASE, GPUDevice, double);
+    CURRY_TYPES3(CAST_CASE, GPUDevice, complex64);
+    CURRY_TYPES3(CAST_CASE, GPUDevice, complex128);
     CAST_CASE(GPUDevice, float, bfloat16);
     CAST_CASE(GPUDevice, bfloat16, float);
     return Unimplemented();
@@ -219,6 +230,8 @@ CURRY_TYPES2(REGISTER_CAST_GPU, int64);
 CURRY_TYPES2(REGISTER_CAST_GPU, Eigen::half);
 CURRY_TYPES2(REGISTER_CAST_GPU, float);
 CURRY_TYPES2(REGISTER_CAST_GPU, double);
+CURRY_TYPES2(REGISTER_CAST_GPU, complex64);
+CURRY_TYPES2(REGISTER_CAST_GPU, complex128);
 REGISTER_CAST_GPU(float, bfloat16);
 REGISTER_CAST_GPU(bfloat16, float);
 

--- a/tensorflow/core/kernels/cast_op.cc
+++ b/tensorflow/core/kernels/cast_op.cc
@@ -33,9 +33,6 @@ namespace tensorflow {
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
 
-using Eigen::internal::complex64;
-using Eigen::internal::complex128;
-
 namespace functor {
 
 template <typename O, typename I>
@@ -48,33 +45,33 @@ struct CastFunctor<CPUDevice, O, I> {
 
 }  // namespace functor
 
-#define CURRY_TYPES2(FN, arg0) \
-  FN(arg0, bool);              \
-  FN(arg0, uint8);             \
-  FN(arg0, int8);              \
-  FN(arg0, uint16);            \
-  FN(arg0, int16);             \
-  FN(arg0, int32);             \
-  FN(arg0, int64);             \
-  FN(arg0, Eigen::half);       \
-  FN(arg0, float);             \
-  FN(arg0, double);            \
-  FN(arg0, complex64);         \
-  FN(arg0, complex128)
+#define CURRY_TYPES2(FN, arg0)   \
+  FN(arg0, bool);                \
+  FN(arg0, uint8);               \
+  FN(arg0, int8);                \
+  FN(arg0, uint16);              \
+  FN(arg0, int16);               \
+  FN(arg0, int32);               \
+  FN(arg0, int64);               \
+  FN(arg0, Eigen::half);         \
+  FN(arg0, float);               \
+  FN(arg0, double);              \
+  FN(arg0, std::complex<float>); \
+  FN(arg0, std::complex<double>)
 
-#define CURRY_TYPES3(FN, arg0, arg1) \
-  FN(arg0, arg1, bool);              \
-  FN(arg0, arg1, uint8);             \
-  FN(arg0, arg1, int8);              \
-  FN(arg0, arg1, uint16);            \
-  FN(arg0, arg1, int16);             \
-  FN(arg0, arg1, int32);             \
-  FN(arg0, arg1, int64);             \
-  FN(arg0, arg1, Eigen::half);       \
-  FN(arg0, arg1, float);             \
-  FN(arg0, arg1, double);            \
-  FN(arg0, arg1, complex64);         \
-  FN(arg0, arg1, complex128)
+#define CURRY_TYPES3(FN, arg0, arg1)   \
+  FN(arg0, arg1, bool);                \
+  FN(arg0, arg1, uint8);               \
+  FN(arg0, arg1, int8);                \
+  FN(arg0, arg1, uint16);              \
+  FN(arg0, arg1, int16);               \
+  FN(arg0, arg1, int32);               \
+  FN(arg0, arg1, int64);               \
+  FN(arg0, arg1, Eigen::half);         \
+  FN(arg0, arg1, float);               \
+  FN(arg0, arg1, double);              \
+  FN(arg0, arg1, std::complex<float>); \
+  FN(arg0, arg1, std::complex<double>)
 
 #define CAST_CASE(DEVICE, IN, OUT)                                         \
   if (DataTypeToEnum<IN>::value == src_dtype_ &&                           \
@@ -141,8 +138,8 @@ class CpuCastOp : public CastOpBase {
     CURRY_TYPES3(CAST_CASE, CPUDevice, Eigen::half);
     CURRY_TYPES3(CAST_CASE, CPUDevice, float);
     CURRY_TYPES3(CAST_CASE, CPUDevice, double);
-    CURRY_TYPES3(CAST_CASE, CPUDevice, complex64);
-    CURRY_TYPES3(CAST_CASE, CPUDevice, complex128);
+    CURRY_TYPES3(CAST_CASE, CPUDevice, std::complex<float>);
+    CURRY_TYPES3(CAST_CASE, CPUDevice, std::complex<double>);
 
     if (src_dtype_ == DT_BFLOAT16 && dst_dtype_ == DT_FLOAT) {
       work_ = [](OpKernelContext* ctx, const Tensor& inp, Tensor* out) {
@@ -200,8 +197,8 @@ class GpuCastOp : public CastOpBase {
     CURRY_TYPES3(CAST_CASE, GPUDevice, Eigen::half);
     CURRY_TYPES3(CAST_CASE, GPUDevice, float);
     CURRY_TYPES3(CAST_CASE, GPUDevice, double);
-    CURRY_TYPES3(CAST_CASE, GPUDevice, complex64);
-    CURRY_TYPES3(CAST_CASE, GPUDevice, complex128);
+    CURRY_TYPES3(CAST_CASE, GPUDevice, std::complex<float>);
+    CURRY_TYPES3(CAST_CASE, GPUDevice, std::complex<double>);
     CAST_CASE(GPUDevice, float, bfloat16);
     CAST_CASE(GPUDevice, bfloat16, float);
     return Unimplemented();
@@ -230,8 +227,8 @@ CURRY_TYPES2(REGISTER_CAST_GPU, int64);
 CURRY_TYPES2(REGISTER_CAST_GPU, Eigen::half);
 CURRY_TYPES2(REGISTER_CAST_GPU, float);
 CURRY_TYPES2(REGISTER_CAST_GPU, double);
-CURRY_TYPES2(REGISTER_CAST_GPU, complex64);
-CURRY_TYPES2(REGISTER_CAST_GPU, complex128);
+CURRY_TYPES2(REGISTER_CAST_GPU, std::complex<float>);
+CURRY_TYPES2(REGISTER_CAST_GPU, std::complex<double>);
 REGISTER_CAST_GPU(float, bfloat16);
 REGISTER_CAST_GPU(bfloat16, float);
 

--- a/tensorflow/core/kernels/cast_op.h
+++ b/tensorflow/core/kernels/cast_op.h
@@ -43,6 +43,111 @@ struct CastFunctor {
 namespace Eigen {
 namespace internal {
 
+// Eigen can't convert to/from complex numbers, because it is limited to cases
+// that can be static_casted. But numpy is able to cast to/from complex, which
+// we want to emulate. So we add specializations for complex here.
+typedef std::complex<float> complex64;
+typedef std::complex<double> complex128;
+using tensorflow::uint8;
+using tensorflow::int8;
+using tensorflow::uint16;
+using tensorflow::int16;
+using tensorflow::int32;
+using tensorflow::int64;
+
+// These are seperate definitions of what should happen when we cast from/to
+// complex numbers. The actual template specializations are instantiated below.
+template<typename From, typename To>
+struct cast_from_complex_impl {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE To operator()(const From& a) const {
+    return static_cast<To>(a.real());
+  }
+};
+
+template<typename From, typename To>
+struct cast_to_complex_impl {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE To operator()(const From& a) const {
+    return To(static_cast<typename To::value_type>(a), typename To::value_type(0));
+  }
+};
+
+template<typename From, typename To>
+struct cast_from_to_complex_impl {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE To operator()(
+    const From& a) const {
+    return To(static_cast<typename To::value_type>(a.real()),
+              static_cast<typename To::value_type>(a.imag()));
+  }
+};
+
+template<typename From, typename To>
+struct functor_traits_complex_impl {
+  enum { Cost = NumTraits<To>::AddCost, PacketAccess = false };
+};
+
+#define FROM_COMPLEX(C, T)                    \
+  template<>                                  \
+  struct scalar_cast_op<C, T>                 \
+    : cast_from_complex_impl<C, T> {};        \
+  template<>                                  \
+  struct functor_traits<scalar_cast_op<C, T>> \
+    : functor_traits_complex_impl<C, T> {}
+
+#define TO_COMPLEX(T, C)                      \
+  template <>                                 \
+  struct scalar_cast_op<T, C>                 \
+    : cast_to_complex_impl<T, C> {};          \
+  template<>                                  \
+  struct functor_traits<scalar_cast_op<T, C>> \
+    : functor_traits_complex_impl<T, C> {}
+
+#define FROM_TO_COMPLEX(C1, C2)                 \
+  template <>                                   \
+  struct scalar_cast_op<C1, C2>                 \
+    : cast_from_to_complex_impl<C1, C2> {};     \
+  template<>                                    \
+  struct functor_traits<scalar_cast_op<C1, C2>> \
+    : functor_traits_complex_impl<C1, C2> {}
+
+#define CURRY_TYPES_FROM(FN, arg0) \
+  FN(arg0, bool);                  \
+  FN(arg0, uint8);                 \
+  FN(arg0, int8);                  \
+  FN(arg0, uint16);                \
+  FN(arg0, int16);                 \
+  FN(arg0, int32);                 \
+  FN(arg0, int64);                 \
+  FN(arg0, Eigen::half);           \
+  FN(arg0, float);                 \
+  FN(arg0, double)
+
+#define CURRY_TYPES_TO(FN, arg0) \
+  FN(bool,        arg0);         \
+  FN(uint8,       arg0);         \
+  FN(int8,        arg0);         \
+  FN(uint16,      arg0);         \
+  FN(int16,       arg0);         \
+  FN(int32,       arg0);         \
+  FN(int64,       arg0);         \
+  FN(Eigen::half, arg0);         \
+  FN(float,       arg0);         \
+  FN(double,      arg0)
+
+CURRY_TYPES_FROM(FROM_COMPLEX, complex64);
+CURRY_TYPES_FROM(FROM_COMPLEX, complex128);
+CURRY_TYPES_TO(TO_COMPLEX, complex64);
+CURRY_TYPES_TO(TO_COMPLEX, complex128);
+FROM_TO_COMPLEX(complex64, complex64);
+FROM_TO_COMPLEX(complex64, complex128);
+FROM_TO_COMPLEX(complex128, complex64);
+FROM_TO_COMPLEX(complex128, complex128);
+
+#undef FROM_COMPLEX
+#undef TO_COMPLEX
+#undef FROM_TO_COMPLEX
+#undef CURRY_TYPES_FROM
+#undef CURRY_TYPES_TO
+
 // Specialized cast op impls for bfloat16.
 template <>
 struct scalar_cast_op< ::tensorflow::bfloat16, float> {

--- a/tensorflow/core/kernels/cast_op.h
+++ b/tensorflow/core/kernels/cast_op.h
@@ -45,38 +45,31 @@ namespace internal {
 
 // Eigen can't convert to/from complex numbers, because it is limited to cases
 // that can be static_casted. But numpy is able to cast to/from complex, which
-// we want to emulate. So we add specializations for complex here.
-typedef std::complex<float> complex64;
-typedef std::complex<double> complex128;
-using tensorflow::uint8;
-using tensorflow::int8;
-using tensorflow::uint16;
-using tensorflow::int16;
-using tensorflow::int32;
-using tensorflow::int64;
-
-// These are seperate definitions of what should happen when we cast from/to
-// complex numbers. The actual template specializations are instantiated below.
+// we want to replicate. So we add specializations for complex here.
 template<typename From, typename To>
-struct cast_from_complex_impl {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE To operator()(const From& a) const {
+struct scalar_cast_op<std::complex<From>, To> {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+  To operator()(const std::complex<From>& a) const {
+    // Replicate numpy behaviour of returning just the real part
     return static_cast<To>(a.real());
   }
 };
 
 template<typename From, typename To>
-struct cast_to_complex_impl {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE To operator()(const From& a) const {
-    return To(static_cast<typename To::value_type>(a), typename To::value_type(0));
+struct scalar_cast_op<From, std::complex<To>> {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+  std::complex<To> operator()(const From& a) const {
+    // Replicate numpy behaviour of setting the imaginary part to 0
+    return std::complex<To>(static_cast<To>(a), To(0));
   }
 };
 
 template<typename From, typename To>
-struct cast_from_to_complex_impl {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE To operator()(
-    const From& a) const {
-    return To(static_cast<typename To::value_type>(a.real()),
-              static_cast<typename To::value_type>(a.imag()));
+struct scalar_cast_op<std::complex<From>, std::complex<To>> {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+  std::complex<To> operator()(const std::complex<From>& a) const {
+    return std::complex<To>(static_cast<To>(a.real()),
+                            static_cast<To>(a.imag()));
   }
 };
 
@@ -85,68 +78,16 @@ struct functor_traits_complex_impl {
   enum { Cost = NumTraits<To>::AddCost, PacketAccess = false };
 };
 
-#define FROM_COMPLEX(C, T)                    \
-  template<>                                  \
-  struct scalar_cast_op<C, T>                 \
-    : cast_from_complex_impl<C, T> {};        \
-  template<>                                  \
-  struct functor_traits<scalar_cast_op<C, T>> \
-    : functor_traits_complex_impl<C, T> {}
-
-#define TO_COMPLEX(T, C)                      \
-  template <>                                 \
-  struct scalar_cast_op<T, C>                 \
-    : cast_to_complex_impl<T, C> {};          \
-  template<>                                  \
-  struct functor_traits<scalar_cast_op<T, C>> \
-    : functor_traits_complex_impl<T, C> {}
-
-#define FROM_TO_COMPLEX(C1, C2)                 \
-  template <>                                   \
-  struct scalar_cast_op<C1, C2>                 \
-    : cast_from_to_complex_impl<C1, C2> {};     \
-  template<>                                    \
-  struct functor_traits<scalar_cast_op<C1, C2>> \
-    : functor_traits_complex_impl<C1, C2> {}
-
-#define CURRY_TYPES_FROM(FN, arg0) \
-  FN(arg0, bool);                  \
-  FN(arg0, uint8);                 \
-  FN(arg0, int8);                  \
-  FN(arg0, uint16);                \
-  FN(arg0, int16);                 \
-  FN(arg0, int32);                 \
-  FN(arg0, int64);                 \
-  FN(arg0, Eigen::half);           \
-  FN(arg0, float);                 \
-  FN(arg0, double)
-
-#define CURRY_TYPES_TO(FN, arg0) \
-  FN(bool,        arg0);         \
-  FN(uint8,       arg0);         \
-  FN(int8,        arg0);         \
-  FN(uint16,      arg0);         \
-  FN(int16,       arg0);         \
-  FN(int32,       arg0);         \
-  FN(int64,       arg0);         \
-  FN(Eigen::half, arg0);         \
-  FN(float,       arg0);         \
-  FN(double,      arg0)
-
-CURRY_TYPES_FROM(FROM_COMPLEX, complex64);
-CURRY_TYPES_FROM(FROM_COMPLEX, complex128);
-CURRY_TYPES_TO(TO_COMPLEX, complex64);
-CURRY_TYPES_TO(TO_COMPLEX, complex128);
-FROM_TO_COMPLEX(complex64, complex64);
-FROM_TO_COMPLEX(complex64, complex128);
-FROM_TO_COMPLEX(complex128, complex64);
-FROM_TO_COMPLEX(complex128, complex128);
-
-#undef FROM_COMPLEX
-#undef TO_COMPLEX
-#undef FROM_TO_COMPLEX
-#undef CURRY_TYPES_FROM
-#undef CURRY_TYPES_TO
+template<typename From, typename To>
+struct functor_traits<scalar_cast_op<std::complex<From>, To>>
+  : functor_traits_complex_impl<std::complex<From>, To> {};
+template<typename From, typename To>
+struct functor_traits<scalar_cast_op<From, std::complex<To>>>
+  : functor_traits_complex_impl<From, std::complex<To>> {};
+// Needed to avoid ambiguous partial specialization
+template<typename From, typename To>
+struct functor_traits<scalar_cast_op<std::complex<From>, std::complex<To>>>
+  : functor_traits_complex_impl<std::complex<From>, std::complex<To>> {};
 
 // Specialized cast op impls for bfloat16.
 template <>

--- a/tensorflow/core/kernels/cast_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/cast_op_gpu.cu.cc
@@ -24,6 +24,8 @@ namespace tensorflow {
 namespace functor {
 
 typedef Eigen::GpuDevice GPUDevice;
+using Eigen::internal::complex64;
+using Eigen::internal::complex128;
 
 template <typename O, typename I>
 struct CastFunctor<GPUDevice, O, I> {
@@ -44,7 +46,9 @@ struct CastFunctor<GPUDevice, O, I> {
   DEFINE(in_type, int64);        \
   DEFINE(in_type, Eigen::half);  \
   DEFINE(in_type, float);        \
-  DEFINE(in_type, double)
+  DEFINE(in_type, double);       \
+  DEFINE(in_type, complex64);    \
+  DEFINE(in_type, complex128)
 
 DEFINE_ALL_FROM(bool);
 DEFINE_ALL_FROM(uint8);
@@ -56,6 +60,8 @@ DEFINE_ALL_FROM(int64);
 DEFINE_ALL_FROM(Eigen::half);
 DEFINE_ALL_FROM(float);
 DEFINE_ALL_FROM(double);
+DEFINE_ALL_FROM(complex64);
+DEFINE_ALL_FROM(complex128);
 DEFINE(bfloat16, float);
 DEFINE(float, bfloat16);
 

--- a/tensorflow/core/kernels/cast_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/cast_op_gpu.cu.cc
@@ -24,8 +24,6 @@ namespace tensorflow {
 namespace functor {
 
 typedef Eigen::GpuDevice GPUDevice;
-using Eigen::internal::complex64;
-using Eigen::internal::complex128;
 
 template <typename O, typename I>
 struct CastFunctor<GPUDevice, O, I> {
@@ -36,19 +34,19 @@ struct CastFunctor<GPUDevice, O, I> {
 };
 
 #define DEFINE(O, I) template struct CastFunctor<GPUDevice, O, I>
-#define DEFINE_ALL_FROM(in_type) \
-  DEFINE(in_type, bool);         \
-  DEFINE(in_type, uint8);        \
-  DEFINE(in_type, int8);         \
-  DEFINE(in_type, uint16);       \
-  DEFINE(in_type, int16);        \
-  DEFINE(in_type, int32);        \
-  DEFINE(in_type, int64);        \
-  DEFINE(in_type, Eigen::half);  \
-  DEFINE(in_type, float);        \
-  DEFINE(in_type, double);       \
-  DEFINE(in_type, complex64);    \
-  DEFINE(in_type, complex128)
+#define DEFINE_ALL_FROM(in_type)        \
+  DEFINE(in_type, bool);                \
+  DEFINE(in_type, uint8);               \
+  DEFINE(in_type, int8);                \
+  DEFINE(in_type, uint16);              \
+  DEFINE(in_type, int16);               \
+  DEFINE(in_type, int32);               \
+  DEFINE(in_type, int64);               \
+  DEFINE(in_type, Eigen::half);         \
+  DEFINE(in_type, float);               \
+  DEFINE(in_type, double);              \
+  DEFINE(in_type, std::complex<float>); \
+  DEFINE(in_type, std::complex<double>)
 
 DEFINE_ALL_FROM(bool);
 DEFINE_ALL_FROM(uint8);
@@ -60,8 +58,8 @@ DEFINE_ALL_FROM(int64);
 DEFINE_ALL_FROM(Eigen::half);
 DEFINE_ALL_FROM(float);
 DEFINE_ALL_FROM(double);
-DEFINE_ALL_FROM(complex64);
-DEFINE_ALL_FROM(complex128);
+DEFINE_ALL_FROM(std::complex<float>);
+DEFINE_ALL_FROM(std::complex<double>);
 DEFINE(bfloat16, float);
 DEFINE(float, bfloat16);
 

--- a/tensorflow/python/kernel_tests/cast_op_test.py
+++ b/tensorflow/python/kernel_tests/cast_op_test.py
@@ -36,6 +36,10 @@ class CastOpTest(tf.test.TestCase):
       return tf.int64
     elif dtype == np.bool:
       return tf.bool
+    elif dtype == np.complex64:
+      return tf.complex64
+    elif dtype == np.complex128:
+      return tf.complex128
     else:
       return None
 
@@ -53,9 +57,11 @@ class CastOpTest(tf.test.TestCase):
   def _testTypes(self, x, use_gpu=False):
     """Tests cast(x) to different tf."""
     if use_gpu:
-      type_list = [np.float32, np.float64, np.int64]
+      type_list = [np.float32, np.float64, np.int64,
+                   np.complex64, np.complex128]
     else:
-      type_list = [np.float32, np.float64, np.int32, np.int64]
+      type_list = [np.float32, np.float64, np.int32,
+                   np.int64, np.complex64, np.complex128]
     for from_type in type_list:
       for to_type in type_list:
         self._test(x.astype(from_type), to_type, use_gpu)
@@ -157,7 +163,7 @@ class CastOpTest(tf.test.TestCase):
       self.assertEqual(1.0, sess.run(cast))
 
   def testGradients(self):
-    t = [tf.float32, tf.float64]
+    t = [tf.float32, tf.float64, tf.complex64, tf.complex128]
     for src_t in t:
       for dst_t in t:
         with self.test_session():

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -775,7 +775,8 @@ def _ComplexAbsGrad(op, grad):
 
 @ops.RegisterGradient("Cast")
 def _CastGrad(op, grad):
-  t = [dtypes.float16, dtypes.float32, dtypes.float64, dtypes.bfloat16]
+  t = [dtypes.float16, dtypes.float32, dtypes.float64,
+       dtypes.bfloat16, dtypes.complex64, dtypes.complex128]
   src_type = op.inputs[0].dtype.base_dtype
   dst_type = grad.dtype.base_dtype
   if src_type in t and dst_type in t:


### PR DESCRIPTION
This PR enables the `tf.cast` op to convert from/to complex numbers.
This is something that users might expect to work, as it's possible in numpy.
I've also extended the tests and gradient code.

I didn't quite know what to put as the cost for the cast operation, so I picked `NumTraits<To>::AddCost`, which is similar to what's used by `bfloat16`.

This fixes #3346.
