### PR TITLE
solve the bug which the python include config gives out repeat results

### DIFF
--- a/util/python/python_config.sh
+++ b/util/python/python_config.sh
@@ -69,10 +69,9 @@ for path in all_paths:
 
 if len(paths) == 1:
   print(paths[0])
-ret_paths = ""
-for path in paths:
-  ret_paths += path + " "
-print(ret_paths)
+else:
+  ret_paths = " ".join(paths)
+  print(ret_paths)
 END
 }
 


### PR DESCRIPTION
```
./configure 
Please specify the location of python. [Default is /home/wenjian/anaconda3/bin/python]: 
Do you wish to build TensorFlow with Google Cloud Platform support? [y/N] N
No Google Cloud Platform support will be enabled for TensorFlow
Found possible Python library paths:
  /home/wenjian/anaconda3/lib/python3.5/site-packages
  /home/wenjian/anaconda3/lib/python3.5/site-packages
Please input the desired Python library path to use.  Default is [/home/wenjian/anaconda3/lib/python3.5/site-packages]
```

it shows repeat result in config on python includes, it is because the old code show paths[0] and ret_paths at the same time,
so I add a `else` condition and do some simple optimization by using `join`
