### PR TITLE
Fixes a potential thread leak in the gRPC runtime.

### DIFF
--- a/tensorflow/core/distributed_runtime/master_session.cc
+++ b/tensorflow/core/distributed_runtime/master_session.cc
@@ -225,9 +225,9 @@ class MasterSession::ReffedClientGraph : public core::RefCounted {
                        const RunStepRequest& req, RunStepResponse* resp,
                        CancellationManager* cm);
 
-  // Calls workers to cleanup states for the step "step_id".  Waits
-  // till all cleanup rpcs complete.
-  Status CleanupPartitions(int64 step_id);
+  // Calls workers to cleanup states for the step "step_id".  Calls
+  // `done` when all cleanup RPCs have completed.
+  void CleanupPartitionsAsync(int64 step_id, StatusCallback done);
 
   // TODO(mrry): Runtime statistics collection.
 
@@ -607,31 +607,108 @@ Status MasterSession::ReffedClientGraph::RunPartitions(
   return status;
 }
 
-Status MasterSession::ReffedClientGraph::CleanupPartitions(int64 step_id) {
-  struct Call {
-    CleanupGraphRequest req;
-    CleanupGraphResponse resp;
-    Notification done;
-    Status status;
-  };
+class BlockingCounter {
+ public:
+  BlockingCounter(int initial_count) : count_(initial_count) {
+    CHECK_GE(count_, 0);
+  }
+
+  ~BlockingCounter() {}
+
+  inline void DecrementCount() {
+    mutex_lock l(mu_);
+    --count_;
+    CHECK(count_ >= 0);
+    if (count_ == 0) {
+      cond_var_.notify_all();
+    }
+  }
+
+  inline void Wait() {
+    mutex_lock l(mu_);
+    while (count_ > 0) {
+      cond_var_.wait(l);
+    }
+  }
+
+ private:
+  int count_;
+  mutex mu_;
+  condition_variable cond_var_;
+};
+
+
+namespace {
+
+class CleanupBroadcastHelper {
+ public:
+  CleanupBroadcastHelper(int64 step_id, int num_calls, StatusCallback done)
+      : resps_(num_calls), num_pending_(num_calls), done_(std::move(done)) {
+    req_.set_step_id(step_id);
+  }
+
+  // Returns a non-owned pointer to a request buffer for all calls.
+  CleanupGraphRequest* request() {
+    return &req_;
+  }
+
+  // Returns a non-owned pointer to a response buffer for the ith call.
+  CleanupGraphResponse* response(int i) {
+    return &resps_[i];
+  }
+
+  // Called when the ith response is received.
+  void call_done(int i, const Status &s) {
+    bool run_callback = false;
+    Status status_copy;
+    {
+      mutex_lock l(mu_);
+      status_.Update(s);
+      if (--num_pending_ == 0) {
+        run_callback = true;
+        status_copy = status_;
+      }
+    }
+    if (run_callback) {
+      done_(status_copy);
+      // This is the last call, so delete the helper object.
+      delete this;
+    }
+  }
+
+ private:
+  // A single request shared between all workers.
+  CleanupGraphRequest req_;
+  // One response buffer for each worker.
+  gtl::InlinedVector<CleanupGraphResponse, 4> resps_;
+
+  mutex mu_;
+  // Number of requests remaining to be collected.
+  int num_pending_ GUARDED_BY(mu_);
+  // Aggregate status of the operation.
+  Status status_ GUARDED_BY(mu_);
+  // Callback to be called when all operations complete.
+  StatusCallback done_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(CleanupBroadcastHelper);
+};
+
+}  // namespace
+
+
+void MasterSession::ReffedClientGraph::CleanupPartitionsAsync(
+    int64 step_id, StatusCallback done) {
   const int num = partitions_.size();
-  gtl::InlinedVector<Call, 4> calls(num);
+  // Helper object will be deleted when the final call completes.
+  CleanupBroadcastHelper* helper = new CleanupBroadcastHelper(
+      step_id, num, std::move(done));
   for (int i = 0; i < num; ++i) {
     const Part& part = partitions_[i];
-    Call* c = &calls[i];
-    c->req.set_step_id(step_id);
-    part.worker->CleanupGraphAsync(&c->req, &c->resp, [c](const Status& s) {
-      c->status = s;
-      c->done.Notify();
-    });
+    part.worker->CleanupGraphAsync(helper->request(), helper->response(i),
+                                   [helper, i](const Status& s) {
+                                     helper->call_done(i, s);
+                                   });
   }
-  Status s;
-  for (int i = num - 1; i >= 0; --i) {
-    Call* c = &calls[i];
-    c->done.WaitForNotification();
-    s.Update(c->status);
-  }
-  return s;
 }
 
 // Makes async calls to workers without waiting deregistering subgraphs.
@@ -920,19 +997,12 @@ Status MasterSession::DoRunWithLocalExecution(CallOptions* opts,
 
   pss.end_micros = Env::Default()->NowMicros();
 
-  // Schedule post-processing and cleanup to be done async.
-  rcg->Ref();
-  // TODO(tucker): We're doing the stats processing prior to returning
-  // the response to the client.  Ensure it's safe to do so, then schedule
-  // in a closure.
-  SchedClosure([this, rcg, step_id]() {
-    Status s = rcg->CleanupPartitions(step_id);
-    if (!s.ok()) {
-      LOG(ERROR) << "Cleanup partition error: " << s;
-    }
-    rcg->Unref();
-  });
-
+  // Schedule post-processing and cleanup to be done asynchronously.
+  rcg->CleanupPartitionsAsync(step_id, [](const Status& s) {
+      if (!s.ok()) {
+        LOG(ERROR) << "Cleanup partition error: " << s;
+      }
+    });
   return Status::OK();
 }
 

--- a/tensorflow/core/distributed_runtime/master_session.cc
+++ b/tensorflow/core/distributed_runtime/master_session.cc
@@ -607,37 +607,6 @@ Status MasterSession::ReffedClientGraph::RunPartitions(
   return status;
 }
 
-class BlockingCounter {
- public:
-  BlockingCounter(int initial_count) : count_(initial_count) {
-    CHECK_GE(count_, 0);
-  }
-
-  ~BlockingCounter() {}
-
-  inline void DecrementCount() {
-    mutex_lock l(mu_);
-    --count_;
-    CHECK(count_ >= 0);
-    if (count_ == 0) {
-      cond_var_.notify_all();
-    }
-  }
-
-  inline void Wait() {
-    mutex_lock l(mu_);
-    while (count_ > 0) {
-      cond_var_.wait(l);
-    }
-  }
-
- private:
-  int count_;
-  mutex mu_;
-  condition_variable cond_var_;
-};
-
-
 namespace {
 
 class CleanupBroadcastHelper {

--- a/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc
@@ -130,8 +130,10 @@ class GrpcWorkerService : public AsyncServiceInterface {
     for (int i = 0; i < 100; ++i) {
       ENQUEUE_REQUEST(RunGraph, true);
     }
+    for (int i = 0; i < 100; ++i) {
+      ENQUEUE_REQUEST(CleanupGraph, false);
+    }
 
-    ENQUEUE_REQUEST(CleanupGraph, false);
     ENQUEUE_REQUEST(Logging, false);
     ENQUEUE_REQUEST(Tracing, false);
 


### PR DESCRIPTION
- Increases the number of pending CleanupGraph requests that a WorkerService will handle to avoid requests being dropped (or backpressure causing an unbounded number of cleanup closure threads being created at the master).
- Avoids creating a thread every time the runtime wants to clean up a step.

Fixes #3470.
