### PR TITLE
ZlibInputBuffer::Inflate() incorrectly considers Z_STREAM_END an error

### DIFF
--- a/tensorflow/core/lib/io/zlib_inputbuffer.cc
+++ b/tensorflow/core/lib/io/zlib_inputbuffer.cc
@@ -163,7 +163,7 @@ Status ZlibInputBuffer::ReadNBytes(int64 bytes_to_read, string* result) {
 
 Status ZlibInputBuffer::Inflate() {
   int error = inflate(z_stream_.get(), zlib_options_.flush_mode);
-  if (error != Z_OK && error != Z_FINISH) {
+  if (error != Z_OK && error != Z_STREAM_END) {
     string error_string =
         strings::StrCat("inflate() failed with error ", error);
     if (z_stream_->msg != NULL) {

--- a/tensorflow/python/kernel_tests/reader_ops_test.py
+++ b/tensorflow/python/kernel_tests/reader_ops_test.py
@@ -21,8 +21,10 @@ from __future__ import print_function
 
 import collections
 import os
+import six
 import threading
 import tensorflow as tf
+import zlib
 
 
 class IdentityReaderTest(tf.test.TestCase):
@@ -455,6 +457,47 @@ class TFRecordWriterZlibTest(tf.test.TestCase):
       with self.assertRaisesOpError("is closed and has insufficient elements "
                                     "\\(requested 1, current size 0\\)"):
         k, v = sess.run([key, value])
+
+  def testZLibFlushRecord(self):
+    fn = os.path.join(self.get_temp_dir(), "tf_record.txt")
+
+    writer = tf.python_io.TFRecordWriter(fn, options=None)
+    writer.write(b"small record")
+    writer.close()
+    del writer
+
+    with open(fn, "rb") as h:
+      buff = h.read()
+
+    # creating more blocks and trailing blocks shouldn't break reads
+    compressor = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS)
+
+    output = b""
+    for c in buff:
+      if type(c) == int:
+        c = six.int2byte(c)
+      output += compressor.compress(c)
+      output += compressor.flush(zlib.Z_FULL_FLUSH)
+
+    output += compressor.flush(zlib.Z_FULL_FLUSH)
+    output += compressor.flush(zlib.Z_FULL_FLUSH)
+    output += compressor.flush(zlib.Z_FINISH)
+
+    # overwrite the original file with the compressed data
+    with open(fn, "wb") as h:
+      h.write(output)
+
+    with self.test_session() as sess:
+      options = tf.python_io.TFRecordOptions(
+          compression_type=tf.python_io.TFRecordCompressionType.ZLIB)
+      reader = tf.TFRecordReader(name="test_reader", options=options)
+      queue = tf.FIFOQueue(1, [tf.string], shapes=())
+      key, value = reader.read(queue)
+      queue.enqueue(fn).run()
+      queue.close().run()
+      k, v = sess.run([key, value])
+      self.assertTrue(tf.compat.as_text(k).startswith("%s:" % fn))
+      self.assertAllEqual(b"small record", v)
 
 
 class TFRecordIteratorTest(tf.test.TestCase):


### PR DESCRIPTION
When reading compressed records produced by something other than TFRecordWriter it is possible to produce valid files that are not readable by Tensorflow.

This fix adds a test that creates a deflate file using the builtin zlib module that previously caused TFRecordReader to raise an exception:

`DataLossError: inflate() failed with error 1`

Full stack is below:

```
======================================================================
ERROR: testZLibFlushRecord (__main__.TFRecordWriterZlibTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/source/tensorflow/tensorflow/python/kernel_tests/reader_ops_test.py", line 495, in testZLibFlushRecord
    k, v = sess.run([key, value])
  File "/Users/nhowell/.virtualenvs/tensorflow/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 710, in run
    run_metadata_ptr)
  File "/Users/nhowell/.virtualenvs/tensorflow/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 908, in _run
    feed_dict_string, options, run_metadata)
  File "/Users/nhowell/.virtualenvs/tensorflow/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 958, in _do_run
    target_list, options, run_metadata)
  File "/Users/nhowell/.virtualenvs/tensorflow/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 978, in _do_call
    raise type(e)(node_def, op, message)
DataLossError: inflate() failed with error 1
     [[Node: ReaderRead = ReaderRead[_class=["loc:@fifo_queue", "loc:@test_reader"], _device="/job:localhost/replica:0/task:0/cpu:0"](test_reader, fifo_queue)]]
```
