### PR TITLE
Fix tensorboard CSV download in Python 3

### DIFF
--- a/tensorflow/tensorboard/backend/handler.py
+++ b/tensorflow/tensorboard/backend/handler.py
@@ -31,7 +31,7 @@ import mimetypes
 import os
 import re
 
-from six import BytesIO
+from six import BytesIO, StringIO
 from six.moves import BaseHTTPServer
 from six.moves import urllib
 from six.moves import xrange  # pylint: disable=redefined-builtin
@@ -276,7 +276,7 @@ class TensorboardHandler(BaseHTTPServer.BaseHTTPRequestHandler):
       values = self._multiplexer.Scalars(run, tag)
 
     if query_params.get('format') == _OutputFormat.CSV:
-      string_io = BytesIO()
+      string_io = StringIO()
       writer = csv.writer(string_io)
       writer.writerow(['Wall time', 'Step', 'Value'])
       writer.writerows(values)
@@ -353,7 +353,7 @@ class TensorboardHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     run = query_params.get('run')
     compressed_histograms = self._multiplexer.CompressedHistograms(run, tag)
     if query_params.get('format') == _OutputFormat.CSV:
-      string_io = BytesIO()
+      string_io = StringIO()
       writer = csv.writer(string_io)
 
       # Build the headers; we have two columns for timing and two columns for


### PR DESCRIPTION
In Python 3, the `csv` module cannot be used with `six.BytesIO` (`io.BytesIO` in Py3) as demonstrated by this example:

```
from six import BytesIO
import csv

out = BytesIO()
writer = csv.writer(out)
writer.writerow(('A', 'B'))
```

Which under Python 3 gives:

```
Traceback (most recent call last):
  File "bug.py", line 6, in <module>
    writer.writerow(('A', 'B'))
TypeError: a bytes-like object is required, not 'str'
```

This same problem happens when downloading CSV files from Tensorboard under Python 3.

This is a well-documented behavior and the solution is to change to `six.StringIO` ([1](http://stackoverflow.com/questions/37866883/unable-to-write-byte-like-string-using-csv-writer-in-python3), [2](http://stackoverflow.com/questions/9157314/python-write-data-into-csv-format-as-string-not-file?noredirect=1&lq=1), [3](http://stackoverflow.com/questions/13120127/how-can-i-use-io-stringio-with-the-csv-module?noredirect=1&lq=1)). This solution works for both Python 2 and Python 3.

There was a related problem with `BaseHTTPRequestHandler` not accepting unicode. This is also addressed in this PR by adding a `compat.as_bytes` before the `wfile.write` call.

Note: I think the `BytesIO` usage `in _send_gzip_response` is fine, which is why I did not remove the `BytesIO` import.
