### PR TITLE
Fix Eigen-related compilation error when using -mavx2.

### DIFF
--- a/third_party/eigen3/unsupported/Eigen/CXX11/src/FixedPoint/PacketMathAVX2.h
+++ b/third_party/eigen3/unsupported/Eigen/CXX11/src/FixedPoint/PacketMathAVX2.h
@@ -344,29 +344,29 @@ EIGEN_STRONG_INLINE QInt8 predux_max<Packet32q8i>(const Packet32q8i& a) {
 
 // Vectorized scaling of Packet32q8i by float.
 template<>
-struct scalar_multiple2_op<QInt32, double> {
-  typedef Packet8q32i Packet1;
-  typedef typename scalar_product_traits<QInt32, double>::ReturnType result_type;
-  typedef typename packet_traits<result_type>::type packet_result_type;
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE scalar_multiple2_op(const scalar_multiple2_op& other) : m_other(other.m_other) { }
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE scalar_multiple2_op(const double& other) : m_other(other) { }
+struct scalar_product_op<QInt32, double> : binary_op_base<QInt32, double> {
+  typedef typename ScalarBinaryOpTraits<QInt32, double>::ReturnType result_type;
+#ifndef EIGEN_SCALAR_BINARY_OP_PLUGIN
+  EIGEN_EMPTY_STRUCT_CTOR(scalar_product_op)
+#else
+  scalar_product_op() {
+    EIGEN_SCALAR_BINARY_OP_PLUGIN
+  }
+#endif
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE result_type operator() (const QInt32& a, const double& b) const { return a * b; }
 
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE result_type operator() (const QInt32& a) const { return a * m_other; }
-
-  EIGEN_STRONG_INLINE const Packet8q32i packetOp(const Packet8q32i& a) const {
-    __m256d scale = _mm256_set1_pd(m_other);
+  EIGEN_STRONG_INLINE const Packet8q32i packetOp(const Packet8q32i& a, const double& b) const {
+    __m256d scale = _mm256_set1_pd(b);
     __m256d a_lo = _mm256_cvtepi32_pd(_mm256_castsi256_si128(a));
     __m128i result_lo = _mm256_cvtpd_epi32(_mm256_mul_pd(scale, a_lo));
     __m256d a_hi = _mm256_cvtepi32_pd(_mm256_extracti128_si256(a, 1));
     __m128i result_hi = _mm256_cvtpd_epi32(_mm256_mul_pd(scale, a_hi));
     return _mm256_insertf128_si256(_mm256_castsi128_si256(result_lo), result_hi, 1);
   }
-
-  const double m_other;
 };
 
 template <>
-struct functor_traits<scalar_multiple2_op<QInt32, double>> {
+struct functor_traits<scalar_product_op<QInt32, double>> {
   enum { Cost = 4 * NumTraits<float>::MulCost, PacketAccess = true };
 };
 


### PR DESCRIPTION
Since updating to use a newer version of Eigen [1], compilation with
-mavx2 causes an error caused by an undefined type. Eigen removed
the type `scalar_multipl2_op` [2] so `scalar_product_op` should now
be used.

This commit replaces uses of `scalar_multiple2_op` similarly to how
[2] did this.

[1] See chage 127264575, commit 10211a6c.
[2] See https://bitbucket.org/eigen/eigen/commits/03556a17eb548275bc9404d7cda8303ff6ca5c13
