### PR TITLE
retrain.py, changed graph_util import statement

### DIFF
--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -60,9 +60,9 @@ Visualize the summaries with this command:
 tensorboard --logdir /tmp/retrain_logs
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+
+
+
 
 from datetime import datetime
 import glob
@@ -77,7 +77,7 @@ import numpy as np
 from six.moves import urllib
 import tensorflow as tf
 
-from tensorflow.python.framework import graph_util
+from tensorflow.python.client import graph_util
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.platform import gfile
 
@@ -481,7 +481,7 @@ def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,
   """
   how_many_bottlenecks = 0
   ensure_dir_exists(bottleneck_dir)
-  for label_name, label_lists in image_lists.items():
+  for label_name, label_lists in list(image_lists.items()):
     for category in ['training', 'testing', 'validation']:
       category_list = label_lists[category]
       for index, unused_base_name in enumerate(category_list):
@@ -517,7 +517,7 @@ def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
   Returns:
     List of bottleneck arrays and their corresponding ground truths.
   """
-  class_count = len(image_lists.keys())
+  class_count = len(list(image_lists.keys()))
   bottlenecks = []
   ground_truths = []
   for unused_i in range(how_many):
@@ -562,7 +562,7 @@ def get_random_distorted_bottlenecks(
   Returns:
     List of bottleneck arrays and their corresponding ground truths.
   """
-  class_count = len(image_lists.keys())
+  class_count = len(list(image_lists.keys()))
   bottlenecks = []
   ground_truths = []
   for unused_i in range(how_many):
@@ -805,7 +805,7 @@ def main(_):
   # Look at the folder structure, and create lists of all the images.
   image_lists = create_image_lists(FLAGS.image_dir, FLAGS.testing_percentage,
                                    FLAGS.validation_percentage)
-  class_count = len(image_lists.keys())
+  class_count = len(list(image_lists.keys()))
   if class_count == 0:
     print('No valid folders of images found at ' + FLAGS.image_dir)
     return -1
@@ -833,7 +833,7 @@ def main(_):
 
   # Add the new layer that we'll be training.
   (train_step, cross_entropy, bottleneck_input, ground_truth_input,
-   final_tensor) = add_final_training_ops(len(image_lists.keys()),
+   final_tensor) = add_final_training_ops(len(list(image_lists.keys())),
                                           FLAGS.final_tensor_name,
                                           bottleneck_tensor)
 
@@ -915,7 +915,7 @@ def main(_):
   with gfile.FastGFile(FLAGS.output_graph, 'wb') as f:
     f.write(output_graph_def.SerializeToString())
   with gfile.FastGFile(FLAGS.output_labels, 'w') as f:
-    f.write('\n'.join(image_lists.keys()) + '\n')
+    f.write('\n'.join(list(image_lists.keys())) + '\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
First attempt at a Pull Request, please be gentle:

I tried the TensorFlow For Poets tutorial today and followed the instructions, but retrain.py kept crashing because graph_util was being imported from the wrong location.  That's line 80.

After the change, the tutorial went as planned!

I also ran 2to3 on it...which apparently got rid of the from **future_** statements.  Hmm.

The rest is just formatting changes, PEP8 stuff.
