### PR TITLE
Allows running "-m tensorflow.tensorboard" (alternative solution)

### DIFF
--- a/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
+++ b/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
@@ -182,7 +182,8 @@ You're now all set to visualize this data using TensorBoard.
 
 ## Launching TensorBoard
 
-To run TensorBoard, use the command
+To run TensorBoard, use the following command (alternatively `python -m
+tensorflow.tensorboard`)
 
 ```bash
 tensorboard --logdir=path/to/log-directory

--- a/tensorflow/tensorboard/BUILD
+++ b/tensorflow/tensorboard/BUILD
@@ -20,7 +20,10 @@ filegroup(
 
 py_binary(
     name = "tensorboard",
-    srcs = ["tensorboard.py"],
+    srcs = [
+        "__main__.py",
+        "tensorboard.py",
+    ],
     data = [":frontend"],
     srcs_version = "PY2AND3",
     deps = [

--- a/tensorflow/tensorboard/__main__.py
+++ b/tensorflow/tensorboard/__main__.py
@@ -1,0 +1,25 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+
+from tensorflow.tensorboard.tensorboard import main
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Allows running `python -m tensorflow.tensorboard`. This is a more gentle alternative of #3779.
