### PR TITLE
Update Eigen version to fix CUDA 8 compilation error (second attempt)

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -7,8 +7,8 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
   # These lines need to be changed when updating Eigen. They are parsed from
   # this file by the cmake and make builds to determine the eigen version and hash.
-  eigen_version = "9922b9d5adfe"
-  eigen_sha256 = "b4e1a5ddd94aa7a0b601c68bbf316b8c9778b8f282957a4a76d53609be1ab821"
+  eigen_version = "9e1b48c333aa"
+  eigen_sha256 = "ad2c990401a0b5529324e000737569f5f60d827f38586d5e02490252b3325c11"
 
   native.new_http_archive(
     name = "eigen_archive",


### PR DESCRIPTION
The last attempt (#3818) at fixing the compilation errors in didn't work, because bitbucket turned the merged PR into an empty commit: https://bitbucket.org/eigen/eigen/commits/5fea06b2707993a43c5b31105b8224266ecc2c8f.

This PR now definitely updates Eigen to a version that includes the fixes.
