### PR TITLE
Concurrent access lock

### DIFF
--- a/tensorflow/models/embedding/word2vec.py
+++ b/tensorflow/models/embedding/word2vec.py
@@ -281,7 +281,7 @@ class Word2Vec(object):
     lr = opts.learning_rate * tf.maximum(
         0.0001, 1.0 - tf.cast(self._words, tf.float32) / words_to_train)
     self._lr = lr
-    optimizer = tf.train.GradientDescentOptimizer(lr)
+    optimizer = tf.train.GradientDescentOptimizer(lr, use_locking=True)
     train = optimizer.minimize(loss,
                                global_step=self.global_step,
                                gate_gradients=optimizer.GATE_NONE)


### PR DESCRIPTION
sess.run() is called concurrently by multiple threads in word2vec. Set use_locking=True in GradientDescentOptimizer to prohibit concurrent parameter read and update.
