### PR TITLE
enable python setup.py test using nose

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -57,6 +57,7 @@ CONSOLE_SCRIPTS = [
 # pylint: enable=line-too-long
 
 TEST_PACKAGES = [
+    'nose >= 1.3.7',
     'scipy >= 0.15.1',
 ]
 
@@ -202,4 +203,5 @@ setup(
         ],
     license='Apache 2.0',
     keywords='tensorflow tensor machine learning',
+    test_suite='nose.collector',
     )


### PR DESCRIPTION
when developing for the python package might be useful to use standard python testing 

`python setup.py test`
