### PR TITLE
docs(slim): fixes typos and capitalizes Tensorflow

### DIFF
--- a/tensorflow/contrib/cmake/README.md
+++ b/tensorflow/contrib/cmake/README.md
@@ -185,9 +185,9 @@ You should see an output similar to:
 
      Running main() from gmock_main.cc
      [==========] Running 1546 tests from 165 test cases.
-     
+
      ...
-     
+
      [==========] 1546 tests from 165 test cases ran. (2529 ms total)
      [  PASSED  ] 1546 tests.
 
@@ -207,7 +207,7 @@ To run specific tests:
      [ RUN      ] AnyTest.TestIs
      [       OK ] AnyTest.TestIs (0 ms)
      [----------] 3 tests from AnyTest (1 ms total)
-     
+
      [----------] Global test environment tear-down
      [==========] 3 tests from 1 test case ran. (2 ms total)
      [  PASSED  ] 3 tests.
@@ -231,7 +231,7 @@ You can also build project *INSTALL* from Visual Studio solution.
 It sounds not so strange and it works.
 
 This will create the following folders under the *install* location:
-  * bin - that contains tensorflow binaries;
+  * bin - that contains TensorFlow binaries;
   * include - that contains C++ headers and TensorFlow *.proto files;
   * lib - that contains linking libraries and *CMake* configuration files for
     *tensorflow* package.
@@ -276,7 +276,7 @@ public interface, and that you statically link them into your library.
 Notes on Compiler Warnings
 ==========================
 
-The following warnings have been disabled while building the tensorflow
+The following warnings have been disabled while building the TensorFlow
 libraries and binaries.  You may have to disable some of them in your own
 project as well, or live with them.
 

--- a/tensorflow/contrib/slim/README.md
+++ b/tensorflow/contrib/slim/README.md
@@ -2,7 +2,7 @@
 
 TF-Slim is a lightweight library for defining, training and evaluating complex
 models in TensorFlow. Components of tf-slim can be freely mixed with native
-Tensorflow, as well as other frameworks, such as tf.contrib.learn.
+TensorFlow, as well as other frameworks, such as tf.contrib.learn.
 
 ## Usage
 ```python
@@ -86,7 +86,7 @@ layers and scopes. Each of these elements is defined below.
 
 Creating
 [`Variables`](https://www.tensorflow.org/how_tos/variables/index.html)
-in native Tensorflow requires either a predefined value or an initialization
+in native TensorFlow requires either a predefined value or an initialization
 mechanism (e.g. randomly sampled from a Gaussian). Furthermore, if a variable
 needs to be created
 on a specific device, such as a GPU, the specification must be
@@ -413,7 +413,7 @@ def vgg16(inputs):
 
 ## Training Models
 
-Training Tensorflow models requires a model, a loss function, the gradient
+Training TensorFlow models requires a model, a loss function, the gradient
 computation and a training routine that iteratively computes the gradients
 of the model weights relative to the loss and updates the weights accordingly.
 TF-Slim provides both common loss functions and a set of helper functions

--- a/tensorflow/contrib/slim/README.md
+++ b/tensorflow/contrib/slim/README.md
@@ -2,7 +2,7 @@
 
 TF-Slim is a lightweight library for defining, training and evaluating complex
 models in TensorFlow. Components of tf-slim can be freely mixed with native
-tensorflow, as well as other frameworks, such as tf.contrib.learn.
+Tensorflow, as well as other frameworks, such as tf.contrib.learn.
 
 ## Usage
 ```python
@@ -11,7 +11,7 @@ import tensorflow.contrib.slim as slim
 
 ## Why TF-Slim?
 
-TF-Slim is a library that makes building, training and evaluation neural
+TF-Slim is a library that makes building, training and evaluating neural
 networks simple:
 
 * Allows the user to define models much more compactly by eliminating
@@ -36,7 +36,7 @@ algorithms by using pieces of pre-existing model checkpoints.
 
 ## What are the various components of TF-Slim?
 
-TF-Slim is composed of several parts which were design to exist independently.
+TF-Slim is composed of several parts which were designed to exist independently.
 These include the following main pieces (explained in detail below).
 
 * [arg_scope](https://www.tensorflow.org/code/tensorflow/contrib/framework/python/ops/arg_scope.py):
@@ -80,13 +80,13 @@ provides convenience wrappers for variable creation and manipulation.
 ## Defining Models
 
 Models can be succinctly defined using TF-Slim by combining its variables,
-layers and scopes. Each of these elements are defined below.
+layers and scopes. Each of these elements is defined below.
 
 ### Variables
 
 Creating
 [`Variables`](https://www.tensorflow.org/how_tos/variables/index.html)
-in native tensorflow requires either a predefined value or an initialization
+in native Tensorflow requires either a predefined value or an initialization
 mechanism (e.g. randomly sampled from a Gaussian). Furthermore, if a variable
 needs to be created
 on a specific device, such as a GPU, the specification must be
@@ -110,7 +110,7 @@ weights = variables.variable('weights',
 
 Note that in native TensorFlow, there are two types of variables: regular
 variables and local (transient) variables. The vast majority of variables are
-regular variables: once created, they can be saved to disk using a
+regular variables. Once created, they can be saved to disk using a
 [saver](https://www.tensorflow.org/versions/r0.9/api_docs/python/state_ops.html#Saver).
 Local variables are those variables that only exist for the duration of a
 session and are not saved to disk.
@@ -164,7 +164,7 @@ slim.add_model_variable(my_model_variable)
 
 While the set of TensorFlow operations is quite extensive, developers of
 neural networks typically think of models in terms of higher level concepts
-like "layers", "losses", "metrics", and "networks". A layer,
+like "layers", "losses", "metrics", and "networks." A layer,
 such as a Convolutional Layer, a Fully Connected Layer or a BatchNorm Layer
 are more abstract than a single TensorFlow operation and typically involve
 several operations. Furthermore, a layer usually (but not always) has
@@ -341,7 +341,7 @@ net = slim.conv2d(net, 256, [11, 11],
 ```
 
 This solution ensures that all three convolutions share the exact same parameter
-values but doesn't reduce completely the code clutter. By using an `arg_scope`,
+values, but doesn't completely reduce the code clutter. By using an `arg_scope`,
 we can both ensure that each layer uses the same values and simplify the code:
 
 ```python
@@ -354,7 +354,7 @@ we can both ensure that each layer uses the same values and simplify the code:
 ```
 
 As the example illustrates, the use of arg_scope makes the code cleaner,
-simpler and easier to maintain. Notice that while argument values are specifed
+simpler and easier to maintain. Notice that while argument values are specified
 in the arg_scope, they can be overwritten locally. In particular, while
 the padding argument has been set to 'SAME', the second convolution overrides
 it with the value of 'VALID'.

--- a/tensorflow/g3doc/api_docs/cc/ClassEnv.md
+++ b/tensorflow/g3doc/api_docs/cc/ClassEnv.md
@@ -1,6 +1,6 @@
 # `class tensorflow::Env`
 
-An interface used by the tensorflow implementation to access operating system functionality like the filesystem etc.
+An interface used by the TensorFlow implementation to access operating system functionality like the filesystem etc.
 
 Callers may wish to provide a custom Env object to get fine grain control.
 

--- a/tensorflow/g3doc/api_docs/python/client.md
+++ b/tensorflow/g3doc/api_docs/python/client.md
@@ -84,7 +84,7 @@ the session constructor.
 
 
 *  <b>`target`</b>: (Optional.) The execution engine to connect to.
-    Defaults to using an in-process engine. See [Distributed Tensorflow]
+    Defaults to using an in-process engine. See [Distributed TensorFlow]
     (https://www.tensorflow.org/how_tos/distributed/index.html)
     for more examples.
 *  <b>`graph`</b>: (Optional.) The `Graph` to be launched (described above).

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard0/tf.py_func.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard0/tf.py_func.md
@@ -1,6 +1,6 @@
 ### `tf.py_func(func, inp, Tout, stateful=True, name=None)` {#py_func}
 
-Wraps a python function and uses it as a tensorflow op.
+Wraps a python function and uses it as a TensorFlow op.
 
 Given a python function `func`, which takes numpy arrays as its
 inputs and returns numpy arrays as its outputs. E.g.,
@@ -21,7 +21,7 @@ sinh(x) as an op in the graph.
 
 *  <b>`func`</b>: A python function.
 *  <b>`inp`</b>: A list of `Tensor`.
-*  <b>`Tout`</b>: A list of tensorflow data types indicating what `func`
+*  <b>`Tout`</b>: A list of TensorFlow data types indicating what `func`
         returns.
 *  <b>`stateful`</b>: A boolean indicating whether the function should be considered
             stateful or stateless. I.e. whether it, given the same input, will

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard6/tf.train.Supervisor.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard6/tf.train.Supervisor.md
@@ -92,7 +92,7 @@ following values for the --master flag:
 
 * Specifying `'grpc://hostname:port'` requests a session that uses
   the RPC interface to a specific , and also allows the in-process
-  master to access remote tensorflow workers. Often, it is
+  master to access remote TensorFlow workers. Often, it is
   appropriate to pass `server.target` (for some `tf.train.Server`
   named `server).
 

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard8/tf.Session.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard8/tf.Session.md
@@ -68,7 +68,7 @@ the session constructor.
 
 
 *  <b>`target`</b>: (Optional.) The execution engine to connect to.
-    Defaults to using an in-process engine. See [Distributed Tensorflow]
+    Defaults to using an in-process engine. See [Distributed TensorFlow]
     (https://www.tensorflow.org/how_tos/distributed/index.html)
     for more examples.
 *  <b>`graph`</b>: (Optional.) The `Graph` to be launched (described above).

--- a/tensorflow/g3doc/api_docs/python/script_ops.md
+++ b/tensorflow/g3doc/api_docs/python/script_ops.md
@@ -17,7 +17,7 @@ TensorFlow operators.
 
 ### `tf.py_func(func, inp, Tout, stateful=True, name=None)` {#py_func}
 
-Wraps a python function and uses it as a tensorflow op.
+Wraps a python function and uses it as a TensorFlow op.
 
 Given a python function `func`, which takes numpy arrays as its
 inputs and returns numpy arrays as its outputs. E.g.,

--- a/tensorflow/g3doc/api_docs/python/train.md
+++ b/tensorflow/g3doc/api_docs/python/train.md
@@ -311,7 +311,7 @@ Construct a new gradient descent optimizer.
 
 ### `class tf.train.AdadeltaOptimizer` {#AdadeltaOptimizer}
 
-Optimizer that implements the Adadelta algorithm. 
+Optimizer that implements the Adadelta algorithm.
 
 See [M. D. Zeiler](http://arxiv.org/abs/1212.5701)
 ([pdf](http://arxiv.org/pdf/1212.5701v1.pdf))
@@ -1839,7 +1839,7 @@ following values for the --master flag:
 
 * Specifying `'grpc://hostname:port'` requests a session that uses
   the RPC interface to a specific , and also allows the in-process
-  master to access remote tensorflow workers. Often, it is
+  master to access remote TensorFlow workers. Often, it is
   appropriate to pass `server.target` (for some `tf.train.Server`
   named `server).
 

--- a/tensorflow/g3doc/how_tos/adding_an_op/index.md
+++ b/tensorflow/g3doc/how_tos/adding_an_op/index.md
@@ -1075,7 +1075,7 @@ Details about registering gradient functions with
 
 Note that at the time the gradient function is called, only the data flow graph
 of ops is available, not the tensor data itself.  Thus, all computation must be
-performed using other tensorflow ops, to be run at graph execution time.
+performed using other TensorFlow ops, to be run at graph execution time.
 
 ## Implement a shape function in Python
 

--- a/tensorflow/g3doc/tutorials/index.md
+++ b/tensorflow/g3doc/tutorials/index.md
@@ -2,7 +2,7 @@
 
 ## Basic Neural Networks
 
-The first few Tensorflow tutorials guide you through training and testing a
+The first few TensorFlow tutorials guide you through training and testing a
 simple neural network to classify handwritten digits from the MNIST database of
 digit images.
 

--- a/tensorflow/g3doc/tutorials/mnist/beginners/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/beginners/index.md
@@ -54,8 +54,8 @@ What we will accomplish in this tutorial:
 - Create a function that is a model for recognizing digits, based on looking at
   every pixel in the image
 
-- Use Tensorflow to train the model to recognize digits by having it "look" at
-  thousands of examples (and run our first Tensorflow session to do so)
+- Use TensorFlow to train the model to recognize digits by having it "look" at
+  thousands of examples (and run our first TensorFlow session to do so)
 
 - Check the model's accuracy with our test data
 
@@ -223,7 +223,7 @@ More compactly, we can just write:
 
 $$y = \text{softmax}(Wx + b)$$
 
-Now let's turn that into something that Tensorflow can use.
+Now let's turn that into something that TensorFlow can use.
 
 ## Implementing the Regression
 

--- a/tensorflow/g3doc/tutorials/mnist/pros/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/pros/index.md
@@ -16,7 +16,7 @@ a background with them, check out the
 
 The first part of this tutorial explains what is happening in the
 [mnist_softmax.py](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/mnist_softmax.py)
-code, which is a basic implementation of a Tensorflow model.  The second part
+code, which is a basic implementation of a TensorFlow model.  The second part
 shows some ways to improve the accuracy.
 
 You can copy and paste each code snippet from this tutorial into a Python
@@ -27,8 +27,8 @@ What we will accomplish in this tutorial:
 - Create a softmax regression function that is a model for recognizing MNIST
   digits, based on looking at every pixel in the image
 
-- Use Tensorflow to train the model to recognize digits by having it "look" at
-  thousands of examples (and run our first Tensorflow session to do so)
+- Use TensorFlow to train the model to recognize digits by having it "look" at
+  thousands of examples (and run our first TensorFlow session to do so)
 
 - Check the model's accuracy with our test data
 
@@ -176,7 +176,7 @@ between the target and the model's prediction:
 cross_entropy = tf.reduce_mean(-tf.reduce_sum(y_ * tf.log(y), reduction_indices=[1]))
 ```
 
-Note that `tf.reduce_sum` sums across all classes and `tf.reduce_mean` takes 
+Note that `tf.reduce_sum` sums across all classes and `tf.reduce_mean` takes
 the average over these sums.
 
 ## Train the Model
@@ -379,7 +379,7 @@ y_conv=tf.nn.softmax(tf.matmul(h_fc1_drop, W_fc2) + b_fc2)
 How well does this model do? To train and evaluate it we will use code that is
 nearly identical to that for the simple one layer SoftMax network above.
 
-The differences are that: 
+The differences are that:
 
 - We will replace the steepest gradient descent optimizer with the more
   sophisticated ADAM optimizer.


### PR DESCRIPTION
Updates to docs:
- A few misspellings
- Grammar
- "tensorflow" -> "Tensorflow"
