### PR TITLE
Removing a confusing statement about training op

### DIFF
--- a/tensorflow/g3doc/tutorials/mnist/tf/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/tf/index.md
@@ -214,7 +214,7 @@ optimizer = tf.train.GradientDescentOptimizer(learning_rate)
 We then generate a single variable to contain a counter for the global
 training step and the [`minimize()`](../../../api_docs/python/train.md#Optimizer.minimize)
 op is used to both update the trainable weights in the system and increment the
-global step.  This is, by convention, known as the `train_op` and is what must
+global step.  This op is, by convention, known as the `train_op` and is what must
 be run by a TensorFlow session in order to induce one full step of training
 (see below).
 
@@ -222,8 +222,6 @@ be run by a TensorFlow session in order to induce one full step of training
 global_step = tf.Variable(0, name='global_step', trainable=False)
 train_op = optimizer.minimize(loss, global_step=global_step)
 ```
-
-The tensor containing the outputs of the training op is returned.
 
 ## Train the Model
 

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -186,9 +186,6 @@ class Variable(object):
         If `None`, either the datatype will be kept (if `initial_value` is
         a Tensor), or `convert_to_tensor` will decide.
 
-    Returns:
-      A Variable.
-
     Raises:
       ValueError: If both `variable_def` and initial_value are specified.
       ValueError: If the initial value is not specified, or does not have a


### PR DESCRIPTION
The statement seemed to suggest that optimizer.minimize() returns a Tensor, which it doesn't; I removed the statement.

To make the point even more explicit, I'm emphasizing that this is an op rather than a Tensor, but maybe that's overkill.
