### PR TITLE
Rename Tensor "summary_op" to "summary" in the 101 tutorial

### DIFF
--- a/tensorflow/examples/tutorials/mnist/fully_connected_feed.py
+++ b/tensorflow/examples/tutorials/mnist/fully_connected_feed.py
@@ -148,8 +148,8 @@ def run_training():
     # Add the Op to compare the logits to the labels during evaluation.
     eval_correct = mnist.evaluation(logits, labels_placeholder)
 
-    # Build the summary operation based on the TF collection of Summaries.
-    summary_op = tf.merge_all_summaries()
+    # Build the summary Tensor based on the TF collection of Summaries.
+    summary = tf.merge_all_summaries()
 
     # Add the variable initializer Op.
     init = tf.initialize_all_variables()
@@ -193,7 +193,7 @@ def run_training():
         # Print status to stdout.
         print('Step %d: loss = %.2f (%.3f sec)' % (step, loss_value, duration))
         # Update the events file.
-        summary_str = sess.run(summary_op, feed_dict=feed_dict)
+        summary_str = sess.run(summary, feed_dict=feed_dict)
         summary_writer.add_summary(summary_str, step)
         summary_writer.flush()
 

--- a/tensorflow/g3doc/tutorials/mnist/tf/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/tf/index.md
@@ -356,11 +356,11 @@ if step % 100 == 0:
 #### Visualize the Status
 
 In order to emit the events files used by [TensorBoard](../../../how_tos/summaries_and_tensorboard/index.md),
-all of the summaries (in this case, only one) are collected into a single op
+all of the summaries (in this case, only one) are collected into a single Tensor
 during the graph building phase.
 
 ```python
-summary_op = tf.merge_all_summaries()
+summary = tf.merge_all_summaries()
 ```
 
 And then after the session is created, a [`tf.train.SummaryWriter`](../../../api_docs/python/train.md#SummaryWriter)
@@ -372,11 +372,11 @@ summary_writer = tf.train.SummaryWriter(FLAGS.train_dir, sess.graph)
 ```
 
 Lastly, the events file will be updated with new summary values every time the
-`summary_op` is run and the output passed to the writer's `add_summary()`
+`summary` is evaluated and the output passed to the writer's `add_summary()`
 function.
 
 ```python
-summary_str = sess.run(summary_op, feed_dict=feed_dict)
+summary_str = sess.run(summary, feed_dict=feed_dict)
 summary_writer.add_summary(summary_str, step)
 ```
 


### PR DESCRIPTION
"summary_op" is a Tensor, so it's incorrectly labeled as an op. This change renames it to "summary", and makes the corresponding changes in the explanation.
