### PR TITLE
Fixing comment, wrong data type in argument description.

### DIFF
--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -321,7 +321,7 @@ def run_bottleneck_on_image(sess, image_data, image_data_tensor,
 
   Args:
     sess: Current active TensorFlow Session.
-    image_data: Numpy array of image data.
+    image_data: String of raw JPEG data.
     image_data_tensor: Input data layer in the graph.
     bottleneck_tensor: Layer before the final softmax.
 


### PR DESCRIPTION
Usage can be seen in lines 445->446, the file is read in and passed directly in, it is not a Numpy array, but rather just a string of raw JPEG data passed into the DecodeJpeg layer of an arbitrary network (by default Inception v3).
