### PR TITLE
Docs(FIFOQueue):Fix a misspelling in line #594

### DIFF
--- a/tensorflow/python/ops/data_flow_ops.py
+++ b/tensorflow/python/ops/data_flow_ops.py
@@ -591,7 +591,7 @@ class RandomShuffleQueue(QueueBase):
 
 
 class FIFOQueue(QueueBase):
-  """A queue implementation that dequeues elements in first-in-first out order.
+  """A queue implementation that dequeues elements in first-in first-out order.
 
   See [`tf.QueueBase`](#QueueBase) for a description of the methods on
   this class.


### PR DESCRIPTION
Fix a misspelling which may confuse readers. It should keep same as the line #604 and others:
`first-in-first out` -> `first-in first-out`
