### PR TITLE
Fix typo in documentation of `gate_gradients`

### DIFF
--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard5/tf.train.Optimizer.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard5/tf.train.Optimizer.md
@@ -184,7 +184,7 @@ applies gradients.
 
 ### Gating Gradients
 
-Both `minimize()` and `compute_gradients()` accept a `gate_gradient` argument
+Both `minimize()` and `compute_gradients()` accept a `gate_gradients` argument
 that controls the degree of parallelism during the application of the
 gradients.
 

--- a/tensorflow/g3doc/api_docs/python/train.md
+++ b/tensorflow/g3doc/api_docs/python/train.md
@@ -204,7 +204,7 @@ applies gradients.
 
 ### Gating Gradients
 
-Both `minimize()` and `compute_gradients()` accept a `gate_gradient` argument
+Both `minimize()` and `compute_gradients()` accept a `gate_gradients` argument
 that controls the degree of parallelism during the application of the
 gradients.
 

--- a/tensorflow/python/training/optimizer.py
+++ b/tensorflow/python/training/optimizer.py
@@ -89,9 +89,9 @@ class Optimizer(object):
 
   ### Gating Gradients
 
-  Both `minimize()` and `compute_gradients()` accept a `gate_gradient` argument
-  that controls the degree of parallelism during the application of the
-  gradients.
+  Both `minimize()` and `compute_gradients()` accept a `gate_gradients`
+  argument that controls the degree of parallelism during the application of
+  the gradients.
 
   The possible values are: `GATE_NONE`, `GATE_OP`, and `GATE_GRAPH`.
 


### PR DESCRIPTION
The documentation said `gate_gradient` in several places; however, the
option is named `gate_gradients`. This PR fixes this in all the
places that `gate_gradient` occurs.
