### PR TITLE
update message to ask user to also install scipy

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -243,4 +243,4 @@ try:
   plot_with_labels(low_dim_embs, labels)
 
 except ImportError:
-  print("Please install sklearn and matplotlib to visualize embeddings.")
+  print("Please install sklearn, matplotlib, and scipy to visualize embeddings.")


### PR DESCRIPTION
Following the word2vec tutorial instructions I tried "pip3 install sklearn matplotlib" but this didn't install the required "scipy". Adding that to the ImportError message.

```
>>> from sklearn.manifold import TSNE
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.5/site-packages/sklearn/__init__.py", line 57, in <module>
    from .base import clone
  File "/usr/local/lib/python3.5/site-packages/sklearn/base.py", line 9, in <module>
    from scipy import sparse
ImportError: No module named 'scipy'
```
