### PR TITLE
Update(mnist):ps/worker cluster framework

### DIFF
--- a/tensorflow/tools/dist_test/python/mnist_replica.py
+++ b/tensorflow/tools/dist_test/python/mnist_replica.py
@@ -20,8 +20,8 @@ A simple softmax model with one hidden layer is defined. The parameters
 ops are defined on a worker node. The TF sessions also run on the worker
 node.
 Multiple invocations of this script can be done in parallel, with different
-values for --worker_index. There should be exactly one invocation with
---worker_index, which will create a master session that carries out variable
+values for --task_index. There should be exactly one invocation with
+--task_index, which will create a master session that carries out variable
 initialization. The other, non-master, sessions will wait for the master
 session to finish the initialization before proceeding to the training stage.
 
@@ -52,29 +52,24 @@ flags.DEFINE_string("data_dir", "/tmp/mnist-data",
 flags.DEFINE_boolean("download_only", False,
                      "Only perform downloading of data; Do not proceed to "
                      "session preparation, model definition or training")
-flags.DEFINE_integer("worker_index", 0,
-                     "Worker task index, should be >= 0. worker_index=0 is "
+flags.DEFINE_integer("task_index", 0,
+                     "Worker task index, should be >= 0. task_index=0 is "
                      "the master worker task the performs the variable "
                      "initialization ")
 flags.DEFINE_integer("num_workers", 2,
                      "Total number of workers (must be >= 1)")
-flags.DEFINE_integer("num_parameter_servers", 1,
-                     "Total number of parameter servers (must be >= 1)")
+flags.DEFINE_integer("num_gpu", 4,
+                     "Total number of gpus for each machine (must be >= 1")
 flags.DEFINE_integer("replicas_to_aggregate", None,
                      "Number of replicas to aggregate before parameter update"
                      "is applied (For sync_replicas mode only; default: "
                      "num_workers)")
-flags.DEFINE_integer("grpc_port", 2222,
-                     "TensorFlow GRPC port")
 flags.DEFINE_integer("hidden_units", 100,
                      "Number of units in the hidden layer of the NN")
-flags.DEFINE_integer("train_steps", 20000,
+flags.DEFINE_integer("train_steps", 200,
                      "Number of (global) training steps to perform")
 flags.DEFINE_integer("batch_size", 100, "Training batch size")
 flags.DEFINE_float("learning_rate", 0.01, "Learning rate")
-flags.DEFINE_string("worker_grpc_url", None,
-                    "Worker GRPC URL (e.g., grpc://1.2.3.4:2222, or "
-                    "grpc://tf-worker0:2222)")
 flags.DEFINE_boolean("sync_replicas", False,
                      "Use the sync_replicas (synchronized replicas) mode, "
                      "wherein the parameter updates from workers are aggregated "
@@ -94,68 +89,38 @@ PARAM_SERVER_PREFIX = "tf-ps"  # Prefix of the parameter servers' domain names
 WORKER_PREFIX = "tf-worker"  # Prefix of the workers' domain names
 
 
-def get_cluster_setter():
-  """Get a cluster setter.
+def main(unused_argv):
+  mnist = input_data.read_data_sets(FLAGS.data_dir, one_hot=True)
+  if FLAGS.download_only:
+    sys.exit(0)
 
-  Returns:
-    Cluster setter and server object.
-  """
-
+  print("job name = %s" % FLAGS.job_name)
+  print("task index = %d" % FLAGS.task_index)
+  
+  #Construct the cluster and start the server
   ps_spec = FLAGS.ps_hosts.split(",")
   worker_spec = FLAGS.worker_hosts.split(",")
-
-  print(ps_spec)
-  print(worker_spec)
 
   cluster = tf.train.ClusterSpec({
       "ps": ps_spec,
       "worker": worker_spec})
   server = tf.train.Server(cluster,
                            job_name=FLAGS.job_name,
-                           task_index=FLAGS.worker_index)
-
-  # Get device setter from the cluster spec
-  return cluster, server
-
-
-def main(unused_argv):
-  mnist = input_data.read_data_sets(FLAGS.data_dir, one_hot=True)
-  if FLAGS.download_only:
-    sys.exit(0)
-
-  print("Worker GRPC URL: %s" % FLAGS.worker_grpc_url)
-  print("Worker index = %d" % FLAGS.worker_index)
-  print("Number of workers = %d" % FLAGS.num_workers)
-
-  # Sanity check on the number of workers and the worker index
-  if FLAGS.worker_index >= FLAGS.num_workers:
-    raise ValueError("Worker index %d exceeds number of workers %d " %
-                     (FLAGS.worker_index, FLAGS.num_workers))
-
-  # Sanity check on the number of parameter servers
-  if FLAGS.num_parameter_servers <= 0:
-    raise ValueError("Invalid num_parameter_servers value: %d" %
-                     FLAGS.num_parameter_servers)
-
-  # Construct cluster setter object
-  cluster, server = get_cluster_setter()
+                           task_index=FLAGS.task_index)
   
   if FLAGS.job_name == "ps":
     server.join()
   elif FLAGS.job_name == "worker":
-
-    is_chief = (FLAGS.worker_index == 0)
-
-    if FLAGS.sync_replicas:
-      if FLAGS.replicas_to_aggregate is None:
-        replicas_to_aggregate = FLAGS.num_workers
-      else:
-        replicas_to_aggregate = FLAGS.replicas_to_aggregate
-
+    is_chief = (FLAGS.task_index == 0)
+    # Avoid gpu allocation conflict: now allocate task_num -> #gpu 
+    # for each worker in the corresponding machine
+    gpu = (FLAGS.task_index % FLAGS.num_gpu)
     # The device setter will automatically place Variables ops on separate
     # parameter servers (ps). The non-Variable ops will be placed on the workers.
+    # The ps use CPU and workers use corresponding GPU
     with tf.device(tf.train.replica_device_setter(
-        worker_device="/job:worker/task:%d" % FLAGS.worker_index,
+        worker_device="/job:worker/task:%d/gpu:%d" % (FLAGS.task_index, gpu),
+        ps_device="/job:ps/cpu:0",
         cluster=cluster)):
       global_step = tf.Variable(0, name="global_step", trainable=False)
 
@@ -172,7 +137,7 @@ def main(unused_argv):
           name="sm_w")
       sm_b = tf.Variable(tf.zeros([10]), name="sm_b")
 
-      # Ops: located on the worker specified with FLAGS.worker_index
+      # Ops: located on the worker specified with FLAGS.task_index
       x = tf.placeholder(tf.float32, [None, IMAGE_PIXELS * IMAGE_PIXELS])
       y_ = tf.placeholder(tf.float32, [None, 10])
 
@@ -183,13 +148,19 @@ def main(unused_argv):
       cross_entropy = -tf.reduce_sum(y_ *
                                      tf.log(tf.clip_by_value(y, 1e-10, 1.0)))
 
+      if FLAGS.sync_replicas:
+        if FLAGS.replicas_to_aggregate is None:
+          replicas_to_aggregate = FLAGS.num_workers
+        else:
+          replicas_to_aggregate = FLAGS.replicas_to_aggregate
+
       opt = tf.train.AdamOptimizer(FLAGS.learning_rate)
       if FLAGS.sync_replicas:
         opt = tf.train.SyncReplicasOptimizer(
             opt,
             replicas_to_aggregate=replicas_to_aggregate,
             total_num_replicas=FLAGS.num_workers,
-            replica_id=FLAGS.worker_index,
+            replica_id=FLAGS.task_index,
             name="mnist_sync_replicas")
 
       train_step = opt.minimize(cross_entropy,
@@ -210,21 +181,21 @@ def main(unused_argv):
 
       sess_config = tf.ConfigProto(
           allow_soft_placement=True,
-          log_device_placement=True,
-          device_filters=["/job:ps", "/job:worker/task:%d" % FLAGS.worker_index])
+          log_device_placement=False,
+          device_filters=["/job:ps", "/job:worker/task:%d" % FLAGS.task_index])
 
-      # The chief worker (worker_index==0) session will prepare the session,
+      # The chief worker (task_index==0) session will prepare the session,
       # while the remaining workers will wait for the preparation to complete.
       if is_chief:
-        print("Worker %d: Initializing session..." % FLAGS.worker_index)
+        print("Worker %d: Initializing session..." % FLAGS.task_index)
       else:
         print("Worker %d: Waiting for session to be initialized..." %
-              FLAGS.worker_index)
+              FLAGS.task_index)
 
       sess = sv.prepare_or_wait_for_session(server.target,
                                             config=sess_config)
 
-      print("Worker %d: Session initialization complete." % FLAGS.worker_index)
+      print("Worker %d: Session initialization complete." % FLAGS.task_index)
 
       if FLAGS.sync_replicas and is_chief:
         # Chief worker will start the chief queue runner and call the init op
@@ -248,7 +219,7 @@ def main(unused_argv):
 
         now = time.time()
         print("%f: Worker %d: training step %d done (global step: %d)" %
-              (now, FLAGS.worker_index, local_step, step))
+              (now, FLAGS.task_index, local_step, step))
 
         if step >= FLAGS.train_steps:
           break

--- a/tensorflow/tools/dist_test/python/mnist_replica.py
+++ b/tensorflow/tools/dist_test/python/mnist_replica.py
@@ -56,9 +56,9 @@ flags.DEFINE_integer("worker_index", 0,
                      "Worker task index, should be >= 0. worker_index=0 is "
                      "the master worker task the performs the variable "
                      "initialization ")
-flags.DEFINE_integer("num_workers", 2,
+flags.DEFINE_integer("num_workers", None,
                      "Total number of workers (must be >= 1)")
-flags.DEFINE_integer("num_parameter_servers", 1,
+flags.DEFINE_integer("num_parameter_servers", 2,
                      "Total number of parameter servers (must be >= 1)")
 flags.DEFINE_integer("replicas_to_aggregate", None,
                      "Number of replicas to aggregate before parameter update"
@@ -68,7 +68,7 @@ flags.DEFINE_integer("grpc_port", 2222,
                      "TensorFlow GRPC port")
 flags.DEFINE_integer("hidden_units", 100,
                      "Number of units in the hidden layer of the NN")
-flags.DEFINE_integer("train_steps", 20000,
+flags.DEFINE_integer("train_steps", 200,
                      "Number of (global) training steps to perform")
 flags.DEFINE_integer("batch_size", 100, "Training batch size")
 flags.DEFINE_float("learning_rate", 0.01, "Learning rate")
@@ -79,12 +79,6 @@ flags.DEFINE_boolean("sync_replicas", False,
                      "Use the sync_replicas (synchronized replicas) mode, "
                      "wherein the parameter updates from workers are aggregated "
                      "before applied to avoid stale gradients")
-flags.DEFINE_string("ps_hosts","localhost:2222",
-                    "Comma-separated list of hostname:port pairs")
-flags.DEFINE_string("worker_hosts", "localhost:2223,localhost:2224", 
-                    "Comma-separated list of hostname:port pairs")
-flags.DEFINE_string("job_name", "","job name: worker or ps")
-
 FLAGS = flags.FLAGS
 
 
@@ -94,28 +88,34 @@ PARAM_SERVER_PREFIX = "tf-ps"  # Prefix of the parameter servers' domain names
 WORKER_PREFIX = "tf-worker"  # Prefix of the workers' domain names
 
 
-def get_cluster_setter():
-  """Get a cluster setter.
+def get_device_setter(num_parameter_servers, num_workers):
+  """Get a device setter given number of servers in the cluster.
+
+  Given the numbers of parameter servers and workers, construct a device
+  setter object using ClusterSpec.
+
+  Args:
+    num_parameter_servers: Number of parameter servers
+    num_workers: Number of workers
 
   Returns:
-    Cluster setter and server object.
+    Device setter object.
   """
 
-  ps_spec = FLAGS.ps_hosts.split(",")
-  worker_spec = FLAGS.worker_hosts.split(",")
+  ps_spec = []
+  for j in range(num_parameter_servers):
+    ps_spec.append("%s%d:%d" % (PARAM_SERVER_PREFIX, j, FLAGS.grpc_port))
 
-  print(ps_spec)
-  print(worker_spec)
+  worker_spec = []
+  for k in range(num_workers):
+    worker_spec.append("%s%d:%d" % (WORKER_PREFIX, k, FLAGS.grpc_port))
 
-  cluster = tf.train.ClusterSpec({
+  cluster_spec = tf.train.ClusterSpec({
       "ps": ps_spec,
       "worker": worker_spec})
-  server = tf.train.Server(cluster,
-                           job_name=FLAGS.job_name,
-                           task_index=FLAGS.worker_index)
 
   # Get device setter from the cluster spec
-  return cluster, server
+  return tf.train.replica_device_setter(cluster=cluster_spec)
 
 
 def main(unused_argv):
@@ -137,135 +137,128 @@ def main(unused_argv):
     raise ValueError("Invalid num_parameter_servers value: %d" %
                      FLAGS.num_parameter_servers)
 
-  # Construct cluster setter object
-  cluster, server = get_cluster_setter()
-  print(cluster)
-  if FLAGS.job_name == "ps":
-    server.join()
-  elif FLAGS.job_name == "worker":
+  is_chief = (FLAGS.worker_index == 0)
 
-    is_chief = (FLAGS.worker_index == 0)
+  if FLAGS.sync_replicas:
+    if FLAGS.replicas_to_aggregate is None:
+      replicas_to_aggregate = FLAGS.num_workers
+    else:
+      replicas_to_aggregate = FLAGS.replicas_to_aggregate
 
+  # Construct device setter object
+  device_setter = get_device_setter(FLAGS.num_parameter_servers,
+                                    FLAGS.num_workers)
+
+  # The device setter will automatically place Variables ops on separate
+  # parameter servers (ps). The non-Variable ops will be placed on the workers.
+  with tf.device(device_setter):
+    global_step = tf.Variable(0, name="global_step", trainable=False)
+
+    # Variables of the hidden layer
+    hid_w = tf.Variable(
+        tf.truncated_normal([IMAGE_PIXELS * IMAGE_PIXELS, FLAGS.hidden_units],
+                            stddev=1.0 / IMAGE_PIXELS), name="hid_w")
+    hid_b = tf.Variable(tf.zeros([FLAGS.hidden_units]), name="hid_b")
+
+    # Variables of the softmax layer
+    sm_w = tf.Variable(
+        tf.truncated_normal([FLAGS.hidden_units, 10],
+                            stddev=1.0 / math.sqrt(FLAGS.hidden_units)),
+        name="sm_w")
+    sm_b = tf.Variable(tf.zeros([10]), name="sm_b")
+
+    # Ops: located on the worker specified with FLAGS.worker_index
+    x = tf.placeholder(tf.float32, [None, IMAGE_PIXELS * IMAGE_PIXELS])
+    y_ = tf.placeholder(tf.float32, [None, 10])
+
+    hid_lin = tf.nn.xw_plus_b(x, hid_w, hid_b)
+    hid = tf.nn.relu(hid_lin)
+
+    y = tf.nn.softmax(tf.nn.xw_plus_b(hid, sm_w, sm_b))
+    cross_entropy = -tf.reduce_sum(y_ *
+                                   tf.log(tf.clip_by_value(y, 1e-10, 1.0)))
+
+    opt = tf.train.AdamOptimizer(FLAGS.learning_rate)
     if FLAGS.sync_replicas:
-      if FLAGS.replicas_to_aggregate is None:
-        replicas_to_aggregate = FLAGS.num_workers
-      else:
-        replicas_to_aggregate = FLAGS.replicas_to_aggregate
+      opt = tf.train.SyncReplicasOptimizer(
+          opt,
+          replicas_to_aggregate=replicas_to_aggregate,
+          total_num_replicas=FLAGS.num_workers,
+          replica_id=FLAGS.worker_index,
+          name="mnist_sync_replicas")
 
-    print(cluster)
-    print('------')
-    # The device setter will automatically place Variables ops on separate
-    # parameter servers (ps). The non-Variable ops will be placed on the workers.
-    with tf.device(tf.train.replica_device_setter(
-        worker_device="/job:worker/task:%d" % FLAGS.worker_index,
-        cluster=cluster)):
-      global_step = tf.Variable(0, name="global_step", trainable=False)
+    train_step = opt.minimize(cross_entropy,
+                              global_step=global_step)
 
-      # Variables of the hidden layer
-      hid_w = tf.Variable(
-          tf.truncated_normal([IMAGE_PIXELS * IMAGE_PIXELS, FLAGS.hidden_units],
-                              stddev=1.0 / IMAGE_PIXELS), name="hid_w")
-      hid_b = tf.Variable(tf.zeros([FLAGS.hidden_units]), name="hid_b")
+    if FLAGS.sync_replicas and is_chief:
+      # Initial token and chief queue runners required by the sync_replicas mode
+      chief_queue_runner = opt.get_chief_queue_runner()
+      init_tokens_op = opt.get_init_tokens_op()
 
-      # Variables of the softmax layer
-      sm_w = tf.Variable(
-          tf.truncated_normal([FLAGS.hidden_units, 10],
-                              stddev=1.0 / math.sqrt(FLAGS.hidden_units)),
-          name="sm_w")
-      sm_b = tf.Variable(tf.zeros([10]), name="sm_b")
+    init_op = tf.initialize_all_variables()
+    train_dir = tempfile.mkdtemp()
+    sv = tf.train.Supervisor(is_chief=is_chief,
+                             logdir=train_dir,
+                             init_op=init_op,
+                             recovery_wait_secs=1,
+                             global_step=global_step)
 
-      # Ops: located on the worker specified with FLAGS.worker_index
-      x = tf.placeholder(tf.float32, [None, IMAGE_PIXELS * IMAGE_PIXELS])
-      y_ = tf.placeholder(tf.float32, [None, 10])
+    sess_config = tf.ConfigProto(
+        allow_soft_placement=True,
+        log_device_placement=True,
+        device_filters=["/job:ps", "/job:worker/task:%d" % FLAGS.worker_index])
 
-      hid_lin = tf.nn.xw_plus_b(x, hid_w, hid_b)
-      hid = tf.nn.relu(hid_lin)
+    # The chief worker (worker_index==0) session will prepare the session,
+    # while the remaining workers will wait for the preparation to complete.
+    if is_chief:
+      print("Worker %d: Initializing session..." % FLAGS.worker_index)
+    else:
+      print("Worker %d: Waiting for session to be initialized..." %
+            FLAGS.worker_index)
 
-      y = tf.nn.softmax(tf.nn.xw_plus_b(hid, sm_w, sm_b))
-      cross_entropy = -tf.reduce_sum(y_ *
-                                     tf.log(tf.clip_by_value(y, 1e-10, 1.0)))
+    sess = sv.prepare_or_wait_for_session(FLAGS.worker_grpc_url,
+                                          config=sess_config)
 
-      opt = tf.train.AdamOptimizer(FLAGS.learning_rate)
-      if FLAGS.sync_replicas:
-        opt = tf.train.SyncReplicasOptimizer(
-            opt,
-            replicas_to_aggregate=replicas_to_aggregate,
-            total_num_replicas=FLAGS.num_workers,
-            replica_id=FLAGS.worker_index,
-            name="mnist_sync_replicas")
+    print("Worker %d: Session initialization complete." % FLAGS.worker_index)
 
-      train_step = opt.minimize(cross_entropy,
-                                global_step=global_step)
+    if FLAGS.sync_replicas and is_chief:
+      # Chief worker will start the chief queue runner and call the init op
+      print("Starting chief queue runner and running init_tokens_op")
+      sv.start_queue_runners(sess, [chief_queue_runner])
+      sess.run(init_tokens_op)
 
-      if FLAGS.sync_replicas and is_chief:
-        # Initial token and chief queue runners required by the sync_replicas mode
-        chief_queue_runner = opt.get_chief_queue_runner()
-        init_tokens_op = opt.get_init_tokens_op()
+    # Perform training
+    time_begin = time.time()
+    print("Training begins @ %f" % time_begin)
 
-      init_op = tf.initialize_all_variables()
-      train_dir = tempfile.mkdtemp()
-      sv = tf.train.Supervisor(is_chief=is_chief,
-                               logdir=train_dir,
-                               init_op=init_op,
-                               recovery_wait_secs=1,
-                               global_step=global_step)
+    local_step = 0
+    while True:
+      # Training feed
+      batch_xs, batch_ys = mnist.train.next_batch(FLAGS.batch_size)
+      train_feed = {x: batch_xs,
+                    y_: batch_ys}
 
-      sess_config = tf.ConfigProto(
-          allow_soft_placement=True,
-          log_device_placement=True,
-          device_filters=["/job:ps", "/job:worker/task:%d" % FLAGS.worker_index])
+      _, step = sess.run([train_step, global_step], feed_dict=train_feed)
+      local_step += 1
 
-      # The chief worker (worker_index==0) session will prepare the session,
-      # while the remaining workers will wait for the preparation to complete.
-      if is_chief:
-        print("Worker %d: Initializing session..." % FLAGS.worker_index)
-      else:
-        print("Worker %d: Waiting for session to be initialized..." %
-              FLAGS.worker_index)
+      now = time.time()
+      print("%f: Worker %d: training step %d done (global step: %d)" %
+            (now, FLAGS.worker_index, local_step, step))
 
-      sess = sv.prepare_or_wait_for_session(server.target,
-                                            config=sess_config)
+      if step >= FLAGS.train_steps:
+        break
 
-      print("Worker %d: Session initialization complete." % FLAGS.worker_index)
+    time_end = time.time()
+    print("Training ends @ %f" % time_end)
+    training_time = time_end - time_begin
+    print("Training elapsed time: %f s" % training_time)
 
-      if FLAGS.sync_replicas and is_chief:
-        # Chief worker will start the chief queue runner and call the init op
-        print("Starting chief queue runner and running init_tokens_op")
-        sv.start_queue_runners(sess, [chief_queue_runner])
-        sess.run(init_tokens_op)
-
-      # Perform training
-      time_begin = time.time()
-      print("Training begins @ %f" % time_begin)
-
-      local_step = 0
-      while True:
-        # Training feed
-        batch_xs, batch_ys = mnist.train.next_batch(FLAGS.batch_size)
-        train_feed = {x: batch_xs,
-                      y_: batch_ys}
-
-        _, step = sess.run([train_step, global_step], feed_dict=train_feed)
-        local_step += 1
-
-        now = time.time()
-        print("%f: Worker %d: training step %d done (global step: %d)" %
-              (now, FLAGS.worker_index, local_step, step))
-
-        if step >= FLAGS.train_steps:
-          break
-
-      time_end = time.time()
-      print("Training ends @ %f" % time_end)
-      training_time = time_end - time_begin
-      print("Training elapsed time: %f s" % training_time)
-
-      # Validation feed
-      val_feed = {x: mnist.validation.images,
-                  y_: mnist.validation.labels}
-      val_xent = sess.run(cross_entropy, feed_dict=val_feed)
-      print("After %d training step(s), validation cross entropy = %g" %
-            (FLAGS.train_steps, val_xent))
+    # Validation feed
+    val_feed = {x: mnist.validation.images,
+                y_: mnist.validation.labels}
+    val_xent = sess.run(cross_entropy, feed_dict=val_feed)
+    print("After %d training step(s), validation cross entropy = %g" %
+          (FLAGS.train_steps, val_xent))
 
 
 if __name__ == "__main__":

--- a/tensorflow/tools/dist_test/python/mnist_replica.py
+++ b/tensorflow/tools/dist_test/python/mnist_replica.py
@@ -69,7 +69,7 @@ flags.DEFINE_integer("train_steps", 200,
                      "Number of (global) training steps to perform")
 flags.DEFINE_integer("batch_size", 100, "Training batch size")
 flags.DEFINE_float("learning_rate", 0.01, "Learning rate")
-flags.DEFINE_boolean("sync_replicas", False,
+flags.DEFINE_boolean("sync_replicas", True,
                      "Use the sync_replicas (synchronized replicas) mode, "
                      "wherein the parameter updates from workers are aggregated "
                      "before applied to avoid stale gradients")

--- a/tensorflow/tools/dist_test/python/mnist_replica.py
+++ b/tensorflow/tools/dist_test/python/mnist_replica.py
@@ -58,7 +58,7 @@ flags.DEFINE_integer("task_index", None,
                      "initialization ")
 flags.DEFINE_integer("num_gpus", 1,
                      "Total number of gpus for each machine."
-                     "If you don't   GPU, please set it to '0'")
+                     "If you don't use GPU, please set it to '0'")
 flags.DEFINE_integer("replicas_to_aggregate", None,
                      "Number of replicas to aggregate before parameter update"
                      "is applied (For sync_replicas mode only; default: "

--- a/tensorflow/tools/dist_test/python/mnist_replica.py
+++ b/tensorflow/tools/dist_test/python/mnist_replica.py
@@ -56,9 +56,9 @@ flags.DEFINE_integer("worker_index", 0,
                      "Worker task index, should be >= 0. worker_index=0 is "
                      "the master worker task the performs the variable "
                      "initialization ")
-flags.DEFINE_integer("num_workers", None,
+flags.DEFINE_integer("num_workers", 2,
                      "Total number of workers (must be >= 1)")
-flags.DEFINE_integer("num_parameter_servers", 2,
+flags.DEFINE_integer("num_parameter_servers", 1,
                      "Total number of parameter servers (must be >= 1)")
 flags.DEFINE_integer("replicas_to_aggregate", None,
                      "Number of replicas to aggregate before parameter update"
@@ -68,7 +68,7 @@ flags.DEFINE_integer("grpc_port", 2222,
                      "TensorFlow GRPC port")
 flags.DEFINE_integer("hidden_units", 100,
                      "Number of units in the hidden layer of the NN")
-flags.DEFINE_integer("train_steps", 200,
+flags.DEFINE_integer("train_steps", 20000,
                      "Number of (global) training steps to perform")
 flags.DEFINE_integer("batch_size", 100, "Training batch size")
 flags.DEFINE_float("learning_rate", 0.01, "Learning rate")
@@ -79,6 +79,12 @@ flags.DEFINE_boolean("sync_replicas", False,
                      "Use the sync_replicas (synchronized replicas) mode, "
                      "wherein the parameter updates from workers are aggregated "
                      "before applied to avoid stale gradients")
+flags.DEFINE_string("ps_hosts","localhost:2222",
+                    "Comma-separated list of hostname:port pairs")
+flags.DEFINE_string("worker_hosts", "localhost:2223,localhost:2224", 
+                    "Comma-separated list of hostname:port pairs")
+flags.DEFINE_string("job_name", "","job name: worker or ps")
+
 FLAGS = flags.FLAGS
 
 
@@ -88,34 +94,28 @@ PARAM_SERVER_PREFIX = "tf-ps"  # Prefix of the parameter servers' domain names
 WORKER_PREFIX = "tf-worker"  # Prefix of the workers' domain names
 
 
-def get_device_setter(num_parameter_servers, num_workers):
-  """Get a device setter given number of servers in the cluster.
-
-  Given the numbers of parameter servers and workers, construct a device
-  setter object using ClusterSpec.
-
-  Args:
-    num_parameter_servers: Number of parameter servers
-    num_workers: Number of workers
+def get_cluster_setter():
+  """Get a cluster setter.
 
   Returns:
-    Device setter object.
+    Cluster setter and server object.
   """
 
-  ps_spec = []
-  for j in range(num_parameter_servers):
-    ps_spec.append("%s%d:%d" % (PARAM_SERVER_PREFIX, j, FLAGS.grpc_port))
+  ps_spec = FLAGS.ps_hosts.split(",")
+  worker_spec = FLAGS.worker_hosts.split(",")
 
-  worker_spec = []
-  for k in range(num_workers):
-    worker_spec.append("%s%d:%d" % (WORKER_PREFIX, k, FLAGS.grpc_port))
+  print(ps_spec)
+  print(worker_spec)
 
-  cluster_spec = tf.train.ClusterSpec({
+  cluster = tf.train.ClusterSpec({
       "ps": ps_spec,
       "worker": worker_spec})
+  server = tf.train.Server(cluster,
+                           job_name=FLAGS.job_name,
+                           task_index=FLAGS.worker_index)
 
   # Get device setter from the cluster spec
-  return tf.train.replica_device_setter(cluster=cluster_spec)
+  return cluster, server
 
 
 def main(unused_argv):
@@ -137,128 +137,135 @@ def main(unused_argv):
     raise ValueError("Invalid num_parameter_servers value: %d" %
                      FLAGS.num_parameter_servers)
 
-  is_chief = (FLAGS.worker_index == 0)
+  # Construct cluster setter object
+  cluster, server = get_cluster_setter()
+  print(cluster)
+  if FLAGS.job_name == "ps":
+    server.join()
+  elif FLAGS.job_name == "worker":
 
-  if FLAGS.sync_replicas:
-    if FLAGS.replicas_to_aggregate is None:
-      replicas_to_aggregate = FLAGS.num_workers
-    else:
-      replicas_to_aggregate = FLAGS.replicas_to_aggregate
+    is_chief = (FLAGS.worker_index == 0)
 
-  # Construct device setter object
-  device_setter = get_device_setter(FLAGS.num_parameter_servers,
-                                    FLAGS.num_workers)
-
-  # The device setter will automatically place Variables ops on separate
-  # parameter servers (ps). The non-Variable ops will be placed on the workers.
-  with tf.device(device_setter):
-    global_step = tf.Variable(0, name="global_step", trainable=False)
-
-    # Variables of the hidden layer
-    hid_w = tf.Variable(
-        tf.truncated_normal([IMAGE_PIXELS * IMAGE_PIXELS, FLAGS.hidden_units],
-                            stddev=1.0 / IMAGE_PIXELS), name="hid_w")
-    hid_b = tf.Variable(tf.zeros([FLAGS.hidden_units]), name="hid_b")
-
-    # Variables of the softmax layer
-    sm_w = tf.Variable(
-        tf.truncated_normal([FLAGS.hidden_units, 10],
-                            stddev=1.0 / math.sqrt(FLAGS.hidden_units)),
-        name="sm_w")
-    sm_b = tf.Variable(tf.zeros([10]), name="sm_b")
-
-    # Ops: located on the worker specified with FLAGS.worker_index
-    x = tf.placeholder(tf.float32, [None, IMAGE_PIXELS * IMAGE_PIXELS])
-    y_ = tf.placeholder(tf.float32, [None, 10])
-
-    hid_lin = tf.nn.xw_plus_b(x, hid_w, hid_b)
-    hid = tf.nn.relu(hid_lin)
-
-    y = tf.nn.softmax(tf.nn.xw_plus_b(hid, sm_w, sm_b))
-    cross_entropy = -tf.reduce_sum(y_ *
-                                   tf.log(tf.clip_by_value(y, 1e-10, 1.0)))
-
-    opt = tf.train.AdamOptimizer(FLAGS.learning_rate)
     if FLAGS.sync_replicas:
-      opt = tf.train.SyncReplicasOptimizer(
-          opt,
-          replicas_to_aggregate=replicas_to_aggregate,
-          total_num_replicas=FLAGS.num_workers,
-          replica_id=FLAGS.worker_index,
-          name="mnist_sync_replicas")
+      if FLAGS.replicas_to_aggregate is None:
+        replicas_to_aggregate = FLAGS.num_workers
+      else:
+        replicas_to_aggregate = FLAGS.replicas_to_aggregate
 
-    train_step = opt.minimize(cross_entropy,
-                              global_step=global_step)
+    print(cluster)
+    print('------')
+    # The device setter will automatically place Variables ops on separate
+    # parameter servers (ps). The non-Variable ops will be placed on the workers.
+    with tf.device(tf.train.replica_device_setter(
+        worker_device="/job:worker/task:%d" % FLAGS.worker_index,
+        cluster=cluster)):
+      global_step = tf.Variable(0, name="global_step", trainable=False)
 
-    if FLAGS.sync_replicas and is_chief:
-      # Initial token and chief queue runners required by the sync_replicas mode
-      chief_queue_runner = opt.get_chief_queue_runner()
-      init_tokens_op = opt.get_init_tokens_op()
+      # Variables of the hidden layer
+      hid_w = tf.Variable(
+          tf.truncated_normal([IMAGE_PIXELS * IMAGE_PIXELS, FLAGS.hidden_units],
+                              stddev=1.0 / IMAGE_PIXELS), name="hid_w")
+      hid_b = tf.Variable(tf.zeros([FLAGS.hidden_units]), name="hid_b")
 
-    init_op = tf.initialize_all_variables()
-    train_dir = tempfile.mkdtemp()
-    sv = tf.train.Supervisor(is_chief=is_chief,
-                             logdir=train_dir,
-                             init_op=init_op,
-                             recovery_wait_secs=1,
-                             global_step=global_step)
+      # Variables of the softmax layer
+      sm_w = tf.Variable(
+          tf.truncated_normal([FLAGS.hidden_units, 10],
+                              stddev=1.0 / math.sqrt(FLAGS.hidden_units)),
+          name="sm_w")
+      sm_b = tf.Variable(tf.zeros([10]), name="sm_b")
 
-    sess_config = tf.ConfigProto(
-        allow_soft_placement=True,
-        log_device_placement=True,
-        device_filters=["/job:ps", "/job:worker/task:%d" % FLAGS.worker_index])
+      # Ops: located on the worker specified with FLAGS.worker_index
+      x = tf.placeholder(tf.float32, [None, IMAGE_PIXELS * IMAGE_PIXELS])
+      y_ = tf.placeholder(tf.float32, [None, 10])
 
-    # The chief worker (worker_index==0) session will prepare the session,
-    # while the remaining workers will wait for the preparation to complete.
-    if is_chief:
-      print("Worker %d: Initializing session..." % FLAGS.worker_index)
-    else:
-      print("Worker %d: Waiting for session to be initialized..." %
-            FLAGS.worker_index)
+      hid_lin = tf.nn.xw_plus_b(x, hid_w, hid_b)
+      hid = tf.nn.relu(hid_lin)
 
-    sess = sv.prepare_or_wait_for_session(FLAGS.worker_grpc_url,
-                                          config=sess_config)
+      y = tf.nn.softmax(tf.nn.xw_plus_b(hid, sm_w, sm_b))
+      cross_entropy = -tf.reduce_sum(y_ *
+                                     tf.log(tf.clip_by_value(y, 1e-10, 1.0)))
 
-    print("Worker %d: Session initialization complete." % FLAGS.worker_index)
+      opt = tf.train.AdamOptimizer(FLAGS.learning_rate)
+      if FLAGS.sync_replicas:
+        opt = tf.train.SyncReplicasOptimizer(
+            opt,
+            replicas_to_aggregate=replicas_to_aggregate,
+            total_num_replicas=FLAGS.num_workers,
+            replica_id=FLAGS.worker_index,
+            name="mnist_sync_replicas")
 
-    if FLAGS.sync_replicas and is_chief:
-      # Chief worker will start the chief queue runner and call the init op
-      print("Starting chief queue runner and running init_tokens_op")
-      sv.start_queue_runners(sess, [chief_queue_runner])
-      sess.run(init_tokens_op)
+      train_step = opt.minimize(cross_entropy,
+                                global_step=global_step)
 
-    # Perform training
-    time_begin = time.time()
-    print("Training begins @ %f" % time_begin)
+      if FLAGS.sync_replicas and is_chief:
+        # Initial token and chief queue runners required by the sync_replicas mode
+        chief_queue_runner = opt.get_chief_queue_runner()
+        init_tokens_op = opt.get_init_tokens_op()
 
-    local_step = 0
-    while True:
-      # Training feed
-      batch_xs, batch_ys = mnist.train.next_batch(FLAGS.batch_size)
-      train_feed = {x: batch_xs,
-                    y_: batch_ys}
+      init_op = tf.initialize_all_variables()
+      train_dir = tempfile.mkdtemp()
+      sv = tf.train.Supervisor(is_chief=is_chief,
+                               logdir=train_dir,
+                               init_op=init_op,
+                               recovery_wait_secs=1,
+                               global_step=global_step)
 
-      _, step = sess.run([train_step, global_step], feed_dict=train_feed)
-      local_step += 1
+      sess_config = tf.ConfigProto(
+          allow_soft_placement=True,
+          log_device_placement=True,
+          device_filters=["/job:ps", "/job:worker/task:%d" % FLAGS.worker_index])
 
-      now = time.time()
-      print("%f: Worker %d: training step %d done (global step: %d)" %
-            (now, FLAGS.worker_index, local_step, step))
+      # The chief worker (worker_index==0) session will prepare the session,
+      # while the remaining workers will wait for the preparation to complete.
+      if is_chief:
+        print("Worker %d: Initializing session..." % FLAGS.worker_index)
+      else:
+        print("Worker %d: Waiting for session to be initialized..." %
+              FLAGS.worker_index)
 
-      if step >= FLAGS.train_steps:
-        break
+      sess = sv.prepare_or_wait_for_session(server.target,
+                                            config=sess_config)
 
-    time_end = time.time()
-    print("Training ends @ %f" % time_end)
-    training_time = time_end - time_begin
-    print("Training elapsed time: %f s" % training_time)
+      print("Worker %d: Session initialization complete." % FLAGS.worker_index)
 
-    # Validation feed
-    val_feed = {x: mnist.validation.images,
-                y_: mnist.validation.labels}
-    val_xent = sess.run(cross_entropy, feed_dict=val_feed)
-    print("After %d training step(s), validation cross entropy = %g" %
-          (FLAGS.train_steps, val_xent))
+      if FLAGS.sync_replicas and is_chief:
+        # Chief worker will start the chief queue runner and call the init op
+        print("Starting chief queue runner and running init_tokens_op")
+        sv.start_queue_runners(sess, [chief_queue_runner])
+        sess.run(init_tokens_op)
+
+      # Perform training
+      time_begin = time.time()
+      print("Training begins @ %f" % time_begin)
+
+      local_step = 0
+      while True:
+        # Training feed
+        batch_xs, batch_ys = mnist.train.next_batch(FLAGS.batch_size)
+        train_feed = {x: batch_xs,
+                      y_: batch_ys}
+
+        _, step = sess.run([train_step, global_step], feed_dict=train_feed)
+        local_step += 1
+
+        now = time.time()
+        print("%f: Worker %d: training step %d done (global step: %d)" %
+              (now, FLAGS.worker_index, local_step, step))
+
+        if step >= FLAGS.train_steps:
+          break
+
+      time_end = time.time()
+      print("Training ends @ %f" % time_end)
+      training_time = time_end - time_begin
+      print("Training elapsed time: %f s" % training_time)
+
+      # Validation feed
+      val_feed = {x: mnist.validation.images,
+                  y_: mnist.validation.labels}
+      val_xent = sess.run(cross_entropy, feed_dict=val_feed)
+      print("After %d training step(s), validation cross entropy = %g" %
+            (FLAGS.train_steps, val_xent))
 
 
 if __name__ == "__main__":

--- a/tensorflow/tools/dist_test/python/mnist_replica.py
+++ b/tensorflow/tools/dist_test/python/mnist_replica.py
@@ -26,7 +26,7 @@ initialization. The other, non-master, sessions will wait for the master
 session to finish the initialization before proceeding to the training stage.
 
 The coordination between the multiple worker invocations occurs due to
-the definition of the para  meters on the same ps devices. The parameter updates
+the definition of the parameters on the same ps devices. The parameter updates
 from one worker is visible to all other workers. As such, the workers can
 perform forward computation and gradient calculation in parallel, which
 should lead to increased training speed for the simple model.

--- a/tensorflow/tools/dist_test/python/mnist_replica.py
+++ b/tensorflow/tools/dist_test/python/mnist_replica.py
@@ -69,7 +69,7 @@ flags.DEFINE_integer("train_steps", 200,
                      "Number of (global) training steps to perform")
 flags.DEFINE_integer("batch_size", 100, "Training batch size")
 flags.DEFINE_float("learning_rate", 0.01, "Learning rate")
-flags.DEFINE_boolean("sync_replicas", True,
+flags.DEFINE_boolean("sync_replicas", False,
                      "Use the sync_replicas (synchronized replicas) mode, "
                      "wherein the parameter updates from workers are aggregated "
                      "before applied to avoid stale gradients")

--- a/tensorflow/tools/dist_test/scripts/dist_mnist_test.sh
+++ b/tensorflow/tools/dist_test/scripts/dist_mnist_test.sh
@@ -68,7 +68,9 @@ while true; do
     N_GPUS=$2
   elif [[ "$1" == "--sync-replicas" ]]; then
     SYNC_REPLICAS="1"
-    break
+    die "ERROR: --sync-replicas (synchronized-replicas) mode is not fully "\
+"supported by this test yet."
+    # TODO(cais): Remove error message once sync-replicas is fully supported
   fi
   shift 2
 

--- a/tensorflow/tools/dist_test/scripts/dist_mnist_test.sh
+++ b/tensorflow/tools/dist_test/scripts/dist_mnist_test.sh
@@ -19,9 +19,9 @@
 # grpc pods and service set up.
 #
 # Usage:
-#    dist_mnist_test.sh <worker_grpc_urls>
-#                       [--num-workers <NUM_WORKERS>]
-#                       [--num-parameter-servers <NUM_PARAMETER_SERVERS>]
+#    dist_mnist_test.sh [--ps-hosts <PS_HOSTS>] 
+#                       [--worker-hosts <WORKER_HOSTS>]
+#                       [--num-gpus <NUM_GPUS>]
 #                       [--sync-replicas]
 #
 # --sync-replicas
@@ -29,12 +29,17 @@
 #   (workers) will be aggregated before applied, which avoids stale parameter
 #   updates.
 #
-# worker_grp_url is the list of IP addresses or the GRPC URLs of the worker of
-# the worker sessions, separated with spaces,
-# e.g., "grpc://1.2.3.4:2222 grpc://5.6.7.8:2222"
+# ps-hosts/worker-hosts is the list of IP addresses or the GRPC URLs of the ps/worker of
+# the worker sessions, separated with ","
+# e.g., "localhost:2222,localhost:2223"
 #
-# --num-workers <NUM_WORKERS>:
-#   Specifies the number of workers to run
+# --num-gpus <NUM_GPUS>:
+#   Specifies the number of gpus to use
+#
+# NOTES: 
+# If you have the error "$'\r': command not found"
+# Please run the command below to remove trailing '\r' character that causes the error:
+#   sed -i 's/\r$//' dist_mnist_test.sh 
 
 
 # Configurations
@@ -47,30 +52,25 @@ die() {
 }
 
 if [[ $# == "0" ]]; then
-  die "Usage: $0 <WORKER_GRPC_URLS> [--num-workers <NUM_WORKERS>] "\
-"[--num-parameter-servers <NUM_PARAMETER_SERVERS>] [--sync-replicas]"
+  die "Usage: $0 [--ps-hosts <PS_HOSTS>] [--worker-hosts <WORKER_HOSTS>] "\
+"[--num-gpus <NUM_GPUS>] [--sync-replicas]"
 fi
 
-WORKER_GRPC_URLS=$1
-shift
-
 # Process additional input arguments
-N_WORKERS=2  # Default value
-N_PS=2  # Default value
 SYNC_REPLICAS=0
 
 while true; do
-  if [[ "$1" == "--num-workers" ]]; then
-    N_WORKERS=$2
-  elif [[ "$1" == "--num-parameter-servers" ]]; then
-    N_PS=$2
+  if [[ "$1" == "--ps-hosts" ]]; then
+  	PS_HOSTS=$2
+  elif [[ "$1" == "--worker-hosts" ]]; then
+    WORKER_HOSTS=$2
+  elif [[ "$1" == "--num-gpus" ]]; then
+    N_GPUS=$2
   elif [[ "$1" == "--sync-replicas" ]]; then
     SYNC_REPLICAS="1"
-    die "ERROR: --sync-replicas (synchronized-replicas) mode is not fully "\
-"supported by this test yet."
-    # TODO(cais): Remove error message once sync-replicas is fully supported
+    break
   fi
-  shift
+  shift 2
 
   if [[ -z "$1" ]]; then
     break
@@ -79,21 +79,17 @@ done
 
 SYNC_REPLICAS_FLAG=""
 if [[ ${SYNC_REPLICAS} == "1" ]]; then
-  SYNC_REPLICAS_FLAG="--sync_replicas"
+  SYNC_REPLICAS_FLAG="True"
+else
+  SYNC_REPLICAS_FLAG="False"
 fi
 
-echo "N_WORKERS = ${N_WORKERS}"
-echo "N_PS = ${N_PS}"
+echo "PS_HOSTS = ${PS_HOSTS}"
+echo "WORKER_HOSTS = ${WORKER_HOSTS}"
+echo "NUM_GPUS = ${N_GPUS}"
 echo "SYNC_REPLICAS = ${SYNC_REPLICAS}"
 echo "SYNC_REPLICAS_FLAG = ${SYNC_REPLICAS_FLAG}"
 
-# Verify the validity of the GRPC URLs
-for WORKER_GRPC_URL in ${WORKER_GRPC_URLS}; do
-  if [[ -z $(echo "${WORKER_GRPC_URL}" | \
-       grep -E "^grpc://.+:[0-9]+") ]]; then
-    die "Invalid worker GRPC URL: \"${WORKER_GRPC_URL}\""
-  fi
-done
 
 # Current working directory
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -102,36 +98,69 @@ PY_DIR=$(dirname "${DIR}")/python
 MNIST_REPLICA="${PY_DIR}/mnist_replica.py"
 
 WKR_LOG_PREFIX="/tmp/worker"
+PS_LOG_PREFIX="/tmp/ps"
 
 # First, download the data from a single process, to avoid race-condition
 # during data downloading
-WORKER_GRPC_URL_0=$(echo ${WORKER_GRPC_URLS} | awk '{print $1}')
 
 timeout ${TIMEOUT} python "${MNIST_REPLICA}" \
-    --worker_grpc_url="${WORKER_GRPC_URL_0}" \
-    --worker_index=0 \
-    --num_workers=${N_WORKERS} \
-    --num_parameter_servers=${N_PS} \
-    ${SYNC_REPLICAS_FLAG} \
+    --ps_hosts="${PS_HOSTS}" \
+    --worker_hosts="${WORKER_HOSTS}" \
+    --job_name="worker" \
+    --task_index=0 \
+    --num_gpus=${N_GPUS} \
+    --sync_replicas=${SYNC_REPLICAS_FLAG} \
     --download_only || \
     die "Download-only step of MNIST replica FAILED"
 
+
+# Get N_PS by PS_HOSTS
+N_PS=$(echo ${PS_HOSTS} | awk -F "," '{printf NF}')
+# Replace the delimiter with " "
+PS_ARRAY=$(echo ${PS_HOSTS} | awk -F "," '{for(i=1;i<=NF;i++){printf $i" "}}')
+# Run a number of ps in parallel. In general, we only set 1 ps.
+echo "${N_PS} ps process(es) running in parallel..."
+
+IDX=0
+PS=($PS_HOSTS)
+while true; do
+  timeout ${TIMEOUT} python "${MNIST_REPLICA}" \
+      --ps_hosts="${PS_HOSTS}" \
+      --worker_hosts="${WORKER_HOSTS}" \
+      --job_name="ps" \
+      --task_index=${IDX} \
+      --num_gpus=${N_GPUS} \
+      --sync_replicas=${SYNC_REPLICAS_FLAG} \ | tee "${PS_LOG_PREFIX}${IDX}.log" &
+  echo "PS ${IDX}: "
+  echo "  PS HOST: ${PS_ARRAY[IDX]}"
+  echo "  log file: ${PS_LOG_PREFIX}${IDX}.log"
+
+  ((IDX++))
+  if [[ "${IDX}" == "${N_PS}" ]]; then
+    break
+  fi
+done
+
+
+# Get N_WORKERS by WORKER_HOSTS
+N_WORKERS=$(echo ${WORKER_HOSTS} | awk -F "," '{printf NF}')
+# Replace the delimiter with " "
+WORKER_ARRAY=$(echo ${WORKER_HOSTS} | awk -F "," '{for(i=1;i<=NF;i++){printf $i" "}}')
 # Run a number of workers in parallel
 echo "${N_WORKERS} worker process(es) running in parallel..."
 
 INDICES=""
 IDX=0
-URLS=($WORKER_GRPC_URLS)
 while true; do
-  WORKER_GRPC_URL="${URLS[IDX]}"
   timeout ${TIMEOUT} python "${MNIST_REPLICA}" \
-      --worker_grpc_url="${WORKER_GRPC_URL}" \
-      --worker_index=${IDX} \
-      --num_workers=${N_WORKERS} \
-      --num_parameter_servers=${N_PS} \
-      ${SYNC_REPLICAS_FLAG} 2>&1 | tee "${WKR_LOG_PREFIX}${IDX}.log" &
+      --ps_hosts="${PS_HOSTS}" \
+      --worker_hosts="${WORKER_HOSTS}" \
+      --job_name="worker" \
+      --task_index=${IDX} \
+      --num_gpus=${N_GPUS} \
+      --sync_replicas=${SYNC_REPLICAS_FLAG} \ | tee "${WKR_LOG_PREFIX}${IDX}.log" &
   echo "Worker ${IDX}: "
-  echo "  GRPC URL: ${WORKER_GRPC_URL}"
+  echo "  WORKER HOST: ${WORKER_ARRAY[IDX]}"
   echo "  log file: ${WKR_LOG_PREFIX}${IDX}.log"
 
   INDICES="${INDICES} ${IDX}"
@@ -141,6 +170,9 @@ while true; do
     break
   fi
 done
+
+
+
 
 # Poll until all final validation cross entropy values become available or
 # operation times out


### PR DESCRIPTION
I updated the cluster setter function of `mnist_replica.py` with the latest and easy-understanding way in distributed tutorial [here](https://www.tensorflow.org/versions/r0.9/how_tos/distributed/index.html#putting-it-all-together-example-trainer-program).
1. `worker_grpc_url` -> ps_hosts / worker_hosts / server.target
2.Add the `FLAGS.job_name` to distinguish the `ps job` from `worker job`
