### PR TITLE
Tensorboard URL for visiting

### DIFF
--- a/tensorflow/tensorboard/tensorboard.py
+++ b/tensorflow/tensorboard/tensorboard.py
@@ -139,9 +139,8 @@ def main(unused_argv=None):
   status_bar.SetupStatusBarInsideGoogle('TensorBoard %s' % tag, FLAGS.port)
   print('Starting TensorBoard %s on port %d' % (tag, FLAGS.port))
 
-  hostname = socket.gethostname()
   if FLAGS.host == "0.0.0.0":
-    print('(You can navigate to http://%s:%d)' % (socket.gethostname(), FLAGS.port))
+    print('(You can navigate to http://%s:%d)' % (socket.gethostbyname(socket.gethostname()), FLAGS.port))
   else:
     print('(You can navigate to http://%s:%d)' % (FLAGS.host, FLAGS.port))
 

--- a/tensorflow/tensorboard/tensorboard.py
+++ b/tensorflow/tensorboard/tensorboard.py
@@ -138,7 +138,13 @@ def main(unused_argv=None):
 
   status_bar.SetupStatusBarInsideGoogle('TensorBoard %s' % tag, FLAGS.port)
   print('Starting TensorBoard %s on port %d' % (tag, FLAGS.port))
-  print('(You can navigate to http://%s:%d)' % (FLAGS.host, FLAGS.port))
+
+  hostname = socket.gethostname()
+  if FLAGS.host == "0.0.0.0":
+    print('(You can navigate to http://%s:%d)' % (socket.gethostname(), FLAGS.port))
+  else:
+    print('(You can navigate to http://%s:%d)' % (FLAGS.host, FLAGS.port))
+
   tb_server.serve_forever()
 
 


### PR DESCRIPTION
Run last week into the 'issue' that one of the users tried to go to `http://0.0.0.0:6006` as instructed on the command line.

``` bash
$ python tensorboard.py --logdir ~/tmp/logs/
Starting TensorBoard b'23' on port 6006
(You can navigate to http://0.0.0.0:6006)
```

Modified the message that if `FLAGS.host` is `0.0.0.0` it identifies the correct IP-address for showing in the message (in this case the local-IP is `172.16.3.13`)

``` bash
$ python tensorboard.py --logdir ~/tmp/logs/
Starting TensorBoard b'23' on port 6006
(You can navigate to http://172.16.3.13:6006)
```
