### PR TITLE
docs(distributed): Fixed environment variable

### DIFF
--- a/tensorflow/tools/dist_test/README.md
+++ b/tensorflow/tools/dist_test/README.md
@@ -35,7 +35,7 @@ For example:
 
     export TF_DIST_GCLOUD_PROJECT="tensorflow-testing"
     export TF_DIST_GCLOUD_COMPUTE_ZONE="us-central1-f"
-    export CONTAINER_CLUSTER="test-cluster-1"
+    export TF_DIST_CONTAINER_CLUSTER="test-cluster-1"
     export TF_DIST_GCLOUD_KEY_FILE_DIR="/tmp/gcloud-secrets"
     ./remote_test.sh
 


### PR DESCRIPTION
The environment variable for setting container cluster should be `TF_DIST_CONTAINER_CLUSTER` instead of `CONTAINER_CLUSTER`
