### PR TITLE
Install numpy from pip

### DIFF
--- a/tensorflow/tools/docker/Dockerfile
+++ b/tensorflow/tools/docker/Dockerfile
@@ -12,9 +12,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         python \
         python-dev \
-        python-numpy \
-        python-pip \
-        python-scipy \
         rsync \
         unzip \
         && \
@@ -29,6 +26,8 @@ RUN pip --no-cache-dir install \
         ipykernel \
         jupyter \
         matplotlib \
+        numpy \
+        scipy \
         && \
     python -m ipykernel.kernelspec
 

--- a/tensorflow/tools/docker/Dockerfile.devel
+++ b/tensorflow/tools/docker/Dockerfile.devel
@@ -11,8 +11,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libzmq3-dev \
         pkg-config \
         python-dev \
-        python-numpy \
-        python-pip \
         rsync \
         software-properties-common \
         swig \
@@ -31,6 +29,7 @@ RUN pip --no-cache-dir install \
         ipykernel \
         jupyter \
         matplotlib \
+        numpy \
         && \
     python -m ipykernel.kernelspec
 

--- a/tensorflow/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow/tools/docker/Dockerfile.devel-gpu
@@ -12,8 +12,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         python \
         python-dev \
-        python-numpy \
-        python-pip \
         rsync \
         software-properties-common \
         swig \
@@ -32,6 +30,7 @@ RUN pip --no-cache-dir install \
         ipykernel \
         jupyter \
         matplotlib \
+        numpy \
         && \
     python -m ipykernel.kernelspec
 

--- a/tensorflow/tools/docker/Dockerfile.gpu
+++ b/tensorflow/tools/docker/Dockerfile.gpu
@@ -12,9 +12,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         python \
         python-dev \
-        python-numpy \
-        python-pip \
-        python-scipy \
         rsync \
         unzip \
         && \
@@ -29,6 +26,8 @@ RUN pip --no-cache-dir install \
         ipykernel \
         jupyter \
         matplotlib \
+        numpy \
+        scipy \
         && \
     python -m ipykernel.kernelspec
 


### PR DESCRIPTION
- Pip is installed using `get-pip`
- The version of numpy in apt repos is ancient (1.8) AND a newer version seems to be pulled in from pypi anyway.
