### PR TITLE
Fix a lost wakeup bug in `Notification::WaitForNotificationWithTimeout()`

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -175,6 +175,7 @@ cc_library(
         "platform/mem.h",
         "platform/net.h",
         "platform/mutex.h",
+        "platform/notification.h",
         "platform/protobuf.h",  # TODO(josh11b): make internal
         "platform/regexp.h",
         "platform/strong_hash.h",
@@ -1008,6 +1009,7 @@ filegroup(
         "platform/default/integral_types.h",
         "platform/default/logging.h",
         "platform/default/mutex.h",
+        "platform/default/notification.h",
         "platform/default/protobuf.h",
         "platform/default/thread_annotations.h",
         "platform/env.h",
@@ -1020,6 +1022,7 @@ filegroup(
         "platform/mem.h",
         "platform/mutex.h",
         "platform/net.h",
+        "platform/notification.h",
         "platform/platform.h",
         "platform/protobuf.h",
         "platform/strong_hash.h",

--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -1011,9 +1011,9 @@ DirectSession::RunState::~RunState() {
 void DirectSession::WaitForNotification(RunState* run_state,
                                         int64 timeout_in_ms) {
   if (timeout_in_ms > 0) {
-    bool timed_out =
-        run_state->executors_done.WaitForNotificationWithTimeout(timeout_in_ms);
-    if (timed_out) {
+    bool notified = WaitForNotificationWithTimeout(&run_state->executors_done,
+                                                   timeout_in_ms);
+    if (!notified) {
       {
         mutex_lock l(run_state->mu_);
         run_state->status.Update(Status(error::DEADLINE_EXCEEDED,

--- a/tensorflow/core/lib/core/notification.h
+++ b/tensorflow/core/lib/core/notification.h
@@ -16,52 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_UTIL_NOTIFICATION_H_
 #define TENSORFLOW_UTIL_NOTIFICATION_H_
 
-#include <assert.h>
-#include <chrono>              // NOLINT
-#include <condition_variable>  // NOLINT
-
-#include "tensorflow/core/platform/mutex.h"
-#include "tensorflow/core/platform/types.h"
-
-namespace tensorflow {
-
-class Notification {
- public:
-  Notification() : notified_(false) {}
-  ~Notification() {}
-
-  void Notify() {
-    mutex_lock l(mu_);
-    assert(!notified_);
-    notified_ = true;
-    cv_.notify_all();
-  }
-
-  bool HasBeenNotified() {
-    mutex_lock l(mu_);
-    return notified_;
-  }
-
-  void WaitForNotification() {
-    mutex_lock l(mu_);
-    while (!notified_) {
-      cv_.wait(l);
-    }
-  }
-
-  bool WaitForNotificationWithTimeout(int64 timeout_in_ms) {
-    mutex_lock l(mu_);
-    std::cv_status s =
-        cv_.wait_for(l, std::chrono::milliseconds(timeout_in_ms));
-    return (s == std::cv_status::timeout) ? true : false;
-  }
-
- private:
-  mutex mu_;
-  condition_variable cv_;
-  bool notified_;
-};
-
-}  // namespace tensorflow
+// Notification implementation is platform-dependent, to support
+// alternative synchronization primitives.
+#include "tensorflow/core/platform/notification.h"
 
 #endif  // TENSORFLOW_UTIL_NOTIFICATION_H_

--- a/tensorflow/core/lib/core/notification_test.cc
+++ b/tensorflow/core/lib/core/notification_test.cc
@@ -76,5 +76,11 @@ TEST(NotificationTest, TestMultipleThreadsWaitingOnNotification) {
   EXPECT_EQ(4, counter);
 }
 
+TEST(NotificationTest, TestWaitWithTimeoutOnNotifiedNotification) {
+  Notification n;
+  n.Notify();
+  EXPECT_TRUE(WaitForNotificationWithTimeout(&n, 1000));
+}
+
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/core/platform/default/notification.h
+++ b/tensorflow/core/platform/default/notification.h
@@ -1,0 +1,73 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_PLATFORM_DEFAULT_NOTIFICATION_H_
+#define TENSORFLOW_CORE_PLATFORM_DEFAULT_NOTIFICATION_H_
+
+#include <assert.h>
+#include <chrono>              // NOLINT
+#include <condition_variable>  // NOLINT
+
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/types.h"
+
+namespace tensorflow {
+
+class Notification {
+ public:
+  Notification() : notified_(false) {}
+  ~Notification() {}
+
+  void Notify() {
+    mutex_lock l(mu_);
+    assert(!notified_);
+    notified_ = true;
+    cv_.notify_all();
+  }
+
+  bool HasBeenNotified() {
+    mutex_lock l(mu_);
+    return notified_;
+  }
+
+  void WaitForNotification() {
+    mutex_lock l(mu_);
+    while (!notified_) {
+      cv_.wait(l);
+    }
+  }
+
+ private:
+  friend bool WaitForNotificationWithTimeout(Notification* n,
+                                             int64 timeout_in_ms);
+  bool WaitForNotificationWithTimeout(int64 timeout_in_ms) {
+    mutex_lock l(mu_);
+    return cv_.wait_for(l, std::chrono::milliseconds(timeout_in_ms),
+                        [this]() { return notified_; });
+  }
+
+  mutex mu_;
+  condition_variable cv_;
+  bool notified_;
+};
+
+inline bool WaitForNotificationWithTimeout(Notification* n,
+                                           int64 timeout_in_ms) {
+  return n->WaitForNotificationWithTimeout(timeout_in_ms);
+}
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_PLATFORM_DEFAULT_NOTIFICATION_H_

--- a/tensorflow/core/platform/notification.h
+++ b/tensorflow/core/platform/notification.h
@@ -1,0 +1,31 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_PLATFORM_NOTIFICATION_H_
+#define TENSORFLOW_CORE_PLATFORM_NOTIFICATION_H_
+
+#include "tensorflow/core/platform/platform.h"
+
+// Include appropriate platform-dependent implementations of Notification.
+#if defined(PLATFORM_GOOGLE)
+#include "tensorflow/core/platform/google/notification.h"
+#elif defined(PLATFORM_POSIX) || defined(PLATFORM_POSIX_ANDROID) || \
+    defined(PLATFORM_GOOGLE_ANDROID)
+#include "tensorflow/core/platform/default/notification.h"
+#else
+#error Define the appropriate PLATFORM_<foo> macro for this platform
+#endif
+
+#endif  // TENSORFLOW_CORE_PLATFORM_NOTIFICATION_H_

--- a/tensorflow/stream_executor/lib/notification.h
+++ b/tensorflow/stream_executor/lib/notification.h
@@ -16,7 +16,7 @@ limitations under the License.
 #ifndef TENSORFLOW_STREAM_EXECUTOR_LIB_NOTIFICATION_H_
 #define TENSORFLOW_STREAM_EXECUTOR_LIB_NOTIFICATION_H_
 
-#include "tensorflow/core/lib/core/notification.h"
+#include "tensorflow/core/platform/notification.h"
 
 namespace perftools {
 namespace gputools {


### PR DESCRIPTION
(Cherry pick for r0.10 branch.)

If the notification was set before waiting, the waiter would never wake up.

Added a test to cover this case. Fixes #3978.
Change: 131247138
