### PR TITLE
close opened file descriptors properly

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
+++ b/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
@@ -925,8 +925,10 @@ static int TryToReadNumaNode(const string &pci_bus_id, int device_ordinal) {
       LOG(INFO) << "successful NUMA node read from SysFS had negative value ("
                 << value << "), but there must be at least one NUMA node"
                             ", so returning NUMA node zero";
+      fclose(file);
       return 0;
     }
+    fclose(file);
     return value;
   }
 
@@ -934,6 +936,7 @@ static int TryToReadNumaNode(const string &pci_bus_id, int device_ordinal) {
       << "could not convert SysFS file contents to integral NUMA node value: "
       << content;
 
+  fclose(f);
   return kUnknownNumaNode;
 #endif
 }

--- a/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
+++ b/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
@@ -936,7 +936,7 @@ static int TryToReadNumaNode(const string &pci_bus_id, int device_ordinal) {
       << "could not convert SysFS file contents to integral NUMA node value: "
       << content;
 
-  fclose(f);
+  fclose(file);
   return kUnknownNumaNode;
 #endif
 }


### PR DESCRIPTION
Calling `fclose()` will ensure the file descriptor is properly disposed of and output buffers flushed so the data written to the file will be present in the file on disk.

Found by https://github.com/bryongloden/cppcheck
