### PR TITLE
update reader._file_to_word_ids

### DIFF
--- a/tensorflow/models/rnn/ptb/reader.py
+++ b/tensorflow/models/rnn/ptb/reader.py
@@ -45,7 +45,7 @@ def _build_vocab(filename):
 
 def _file_to_word_ids(filename, word_to_id):
   data = _read_words(filename)
-  return [word_to_id[word] for word in data]
+  return [word_to_id[word] for word in data if word in word_to_id]
 
 
 def ptb_raw_data(data_path=None):


### PR DESCRIPTION
_file_to_word_ids throws a key error if there is a word in the validation or test data that doesn't exist in the training data.

The unknown words won't exist in word_to_id dictionary and so will throw a key error while converting validation and test files into ids.

Changed to way the file id sequence is built by checking if the word exists in the word_to_id dictionary to prevent the key error.
