### PR TITLE
use 'typedef' instead of 'using' to compile on gcc4.8.2

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/grpc_call.h
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_call.h
@@ -247,7 +247,7 @@ class Call : public UntypedCall<Service> {
 
   // Used as void* completion markers from grpc to indicate different
   // events of interest for a Call.
-  using typename UntypedCall<Service>::Tag;
+  typedef typename UntypedCall<Service>::Tag Tag;
   Tag request_received_tag_{this, Tag::kRequestReceived};
   Tag response_sent_tag_{this, Tag::kResponseSent};
   Tag cancelled_tag_{this, Tag::kCancelled};


### PR DESCRIPTION
Currently, gcc 4.8.2 complains with the following error message:

```
In file included from tensorflow/core/distributed_runtime/rpc/grpc_master_service.cc:38:0:
./tensorflow/core/distributed_runtime/rpc/grpc_call.h:251:35: error: 'Tag' is not a class, namespace, or enumeration
   Tag request_received_tag_{this, Tag::kRequestReceived};
                                   ^
./tensorflow/core/distributed_runtime/rpc/grpc_call.h:252:32: error: 'Tag' is not a class, namespace, or enumeration
   Tag response_sent_tag_{this, Tag::kResponseSent};
                                ^
./tensorflow/core/distributed_runtime/rpc/grpc_call.h:253:28: error: 'Tag' is not a class, namespace, or enumeration
   Tag cancelled_tag_{this, Tag::kCancelled};                            ^
```

This PR proposes to use old fashioned typedef, and the build has passed with gcc4.8.2
