### PR TITLE
Fix bazel warnings by using their official names in the other repo WORKSPACE

### DIFF
--- a/tensorflow/core/platform/cloud/BUILD
+++ b/tensorflow/core/platform/cloud/BUILD
@@ -173,7 +173,7 @@ tf_cc_test(
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
-        "@boringssl_git//:crypto",
+        "@boringssl//:crypto",
     ],
 )
 

--- a/tensorflow/core/platform/cloud/BUILD
+++ b/tensorflow/core/platform/cloud/BUILD
@@ -104,7 +104,7 @@ cc_library(
         ":http_request",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
-        "@boringssl_git//:crypto",
+        "@boringssl//:crypto",
         "@jsoncpp_git//:jsoncpp",
     ],
 )

--- a/tensorflow/core/platform/default/build_config/BUILD
+++ b/tensorflow/core/platform/default/build_config/BUILD
@@ -58,12 +58,12 @@ cc_library(
     copts = tf_copts(),
     deps = [
         "//tensorflow/core:protos_cc",
+        "@com_googlesource_code_re2//:re2",
         "@farmhash_archive//:farmhash",
         "@gif_archive//:gif",
         "@highwayhash//:sip_hash",
         "@jpeg_archive//:jpeg",
         "@png_archive//:png",
-        "@re2//:re2",
     ],
 )
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -158,7 +158,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
   )
 
   native.git_repository(
-    name = "boringssl_git",
+    name = "boringssl",
     remote = "https://github.com/google/boringssl.git",
     commit = "bbcaa15b0647816b9a1a9b9e0d209cd6712f0105",  # 2016-07-11
   )

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -22,9 +22,9 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
   )
 
   native.git_repository(
-    name = "re2",
+    name = "com_googlesource_code_re2",
     remote = "https://github.com/google/re2.git",
-    commit = "791beff",
+    commit = "fc6337a382bfd4f7c861abea08f872d3c85b31da",
   )
 
   native.git_repository(
@@ -48,7 +48,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
   native.git_repository(
     name = "highwayhash",
     remote = "https://github.com/google/highwayhash.git",
-    commit = "be5edafc2e1a455768e260ccd68ae7317b6690ee",
+    commit = "4bce8fc6a9ca454d9d377dbc4c4d33488bbab78f",
     init_submodules = True,
   )
 


### PR DESCRIPTION
Updated the commits to points where they have this new name.  highwayhash update also
might include windows support, which is a bonus.

As far as I can tell, protobuf and gemmlowp don't have these name declarations yet.  gemmlowp doesn't even have a WORKSPACE file
