### PR TITLE
Fix a bug #3994

### DIFF
--- a/tensorflow/python/training/optimizer.py
+++ b/tensorflow/python/training/optimizer.py
@@ -27,7 +27,7 @@ from tensorflow.python.ops import gradients
 from tensorflow.python.ops import state_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.training import slot_creator
-import tensorflow as tf
+
 
 class Optimizer(object):
   """Base class for optimizers.
@@ -283,38 +283,36 @@ class Optimizer(object):
     # by most optimizers.  It relies on the subclass implementing the following
     # methods: _create_slots(), _prepare(), _apply_dense(), and _apply_sparse().
 
-    grads_to_tensors_list = []
-    vars_list = []
     grads_and_vars = tuple(grads_and_vars)  # Make sure repeat iteration works
+    converted_grads_and_vars = []
     for g, v in grads_and_vars:
-      # Check if gradient is Variable. If so, convert it to tensor
-      if isinstance(g, (variables.Variable)):
-        g = tf.convert_to_tensor(g)
+      if g is not None:
+        try:
+          # Convert the grad to Tensor or IndexedSlices if necessary
+          g = ops.convert_to_tensor_or_indexed_slices(g)
+        except TypeError:
+          raise TypeError(
+              "Gradient must be convertible to a Tensor or IndexedSlices, or None: %s" %g)  
       if not isinstance(g, (ops.Tensor, ops.IndexedSlices, type(None))):
         raise TypeError(
             "Gradient must be a Tensor, IndexedSlices, or None: %s" % g)
       if not isinstance(v, variables.Variable):
         raise TypeError(
             "Variable must be a tf.Variable: %s" % v)
-      if g is not None:
-        self._assert_valid_dtypes([g, v])
-      # If all is well, append g and v to corresponding list separately 
-      grads_to_tensors_list.append(g)
-      vars_list.append(v) 
 
-    # Remake the grads_and_vars after checking and converting 
-    grads_and_vars = tuple(zip(grads_to_tensors_list, vars_list))
+      converted_grads_and_vars.append((g,v))
     
-    var_list = [v for g, v in grads_and_vars if g is not None]
+    converted_grads_and_vars = tuple(converted_grads_and_vars)
+    var_list = [v for g, v in converted_grads_and_vars if g is not None]
     if not var_list:
       raise ValueError("No gradients provided for any variable: %s" %
-                       (grads_and_vars,))
+                       (converted_grads_and_vars,))
     with ops.control_dependencies(None):
       self._create_slots(var_list)
     update_ops = []
     with ops.name_scope(name, self._name) as name:
       self._prepare()
-      for grad, var in grads_and_vars:
+      for grad, var in converted_grads_and_vars:
         if grad is None:
           continue
         # We colocate all ops created in _apply_dense or _apply_sparse

--- a/tensorflow/python/training/optimizer_test.py
+++ b/tensorflow/python/training/optimizer_test.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from tensorflow.python.framework import ops
 import tensorflow as tf
 
 
@@ -113,6 +114,32 @@ class OptimizerTest(tf.test.TestCase):
           # var1 has no gradient
           sgd_op.minimize(cost, global_step, [var1])
 
+  def testGradientsAsVariables(self):
+    for dtype in [tf.half, tf.float32, tf.float64]:
+      with self.test_session() as sess:
+        var0 = tf.Variable([1.0, 2.0], dtype=dtype)
+        var1 = tf.Variable([3.0, 4.0], dtype=dtype)
+        cost = 5 * var0 + 3 * var1
+        global_step = tf.Variable(tf.zeros([], tf.int64), name='global_step')
+        sgd_op = tf.train.GradientDescentOptimizer(3.0)
+        grads_and_vars = sgd_op.compute_gradients(cost, [var0, var1])
+        # Convert gradients to tf.Variables
+        converted_grads = [tf.Variable(tf.zeros([2], dtype)) for i in grads_and_vars]
+        convert_ops = [tf.assign(converted_grads[i], gv[0]) for i,gv in enumerate(grads_and_vars)]
+        
+        converted_grads_and_vars = list(zip(converted_grads, [var0, var1]))
+        with ops.control_dependencies(convert_ops):
+            opt_op = sgd_op.apply_gradients(converted_grads_and_vars, global_step)
+
+        tf.initialize_all_variables().run()
+        # Fetch params to validate initial values
+        self.assertAllClose([1.0, 2.0], var0.eval())
+        self.assertAllClose([3.0, 4.0], var1.eval())
+        # Run 1 step of sgd through optimizer
+        opt_op.run()
+        # Validate updated params
+        self.assertAllClose([-14., -13.], var0.eval())
+        self.assertAllClose([-6., -5.], var1.eval()) 
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow/python/training/optimizer_test.py
+++ b/tensorflow/python/training/optimizer_test.py
@@ -17,7 +17,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from tensorflow.python.framework import ops
 import tensorflow as tf
 
 
@@ -128,10 +127,11 @@ class OptimizerTest(tf.test.TestCase):
         convert_ops = [tf.assign(converted_grads[i], gv[0]) for i,gv in enumerate(grads_and_vars)]
         
         converted_grads_and_vars = list(zip(converted_grads, [var0, var1]))
-        with ops.control_dependencies(convert_ops):
-            opt_op = sgd_op.apply_gradients(converted_grads_and_vars, global_step)
+        opt_op = sgd_op.apply_gradients(converted_grads_and_vars, global_step)
 
         tf.initialize_all_variables().run()
+        # Run convert_ops to achieve the gradietns converting
+        sess.run(convert_ops)
         # Fetch params to validate initial values
         self.assertAllClose([1.0, 2.0], var0.eval())
         self.assertAllClose([3.0, 4.0], var1.eval())


### PR DESCRIPTION
I have fixed the bug[#3994](https://github.com/tensorflow/tensorflow/issues/3994). So, now, we can use `Variables` as gradients with the update.
Check if gradient is `tf.Variable`:
- Yes, convert it to tensor.
- No, check its type as before.

Then, remake the `grads_and_vars` after checking and converting.
