### PR TITLE
Fix 'sttdev' to 'stddev' in tutorial(mnist_with_summaries.py)

### DIFF
--- a/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
@@ -76,7 +76,7 @@ def train():
       tf.scalar_summary('mean/' + name, mean)
       with tf.name_scope('stddev'):
         stddev = tf.sqrt(tf.reduce_mean(tf.square(var - mean)))
-      tf.scalar_summary('sttdev/' + name, stddev)
+      tf.scalar_summary('stddev/' + name, stddev)
       tf.scalar_summary('max/' + name, tf.reduce_max(var))
       tf.scalar_summary('min/' + name, tf.reduce_min(var))
       tf.histogram_summary(name, var)


### PR DESCRIPTION
When I study the tensorflow recently, I found the wrong characters of the summary directory in tutorial code.

So I made the pull request to fix it.

Thanks for making tutorials!
