### PR TITLE
Fix bazel dependency failure for non-standard cuda toolkit path

### DIFF
--- a/third_party/gpus/crosstool/CROSSTOOL.tpl
+++ b/third_party/gpus/crosstool/CROSSTOOL.tpl
@@ -120,7 +120,7 @@ toolchain {
   # linker_flag: "-Wl,--detect-odr-violations"
 
   # Include directory for cuda headers.
-  cxx_builtin_include_directory: "/usr/local/cuda%{cuda_version}/include"
+  cxx_builtin_include_directory: "%{cuda_include_path}"
 
   compilation_mode_flags {
     mode: DBG
@@ -219,7 +219,7 @@ toolchain {
   linker_flag: "-no-canonical-prefixes"
 
   # Include directory for cuda headers.
-  cxx_builtin_include_directory: "/usr/local/cuda%{cuda_version}/include"
+  cxx_builtin_include_directory: "%{cuda_include_path}"
 
   compilation_mode_flags {
     mode: DBG


### PR DESCRIPTION
ArchLinux cuda package puts the toolkit to `/opt/cuda` without symlinks (no /opt/cuda-7.5 etc).
