### PR TITLE
Fix typo 'sttdev' to 'stddev'(2) (in how_tos/summaries_and_tensorboar…

### DIFF
--- a/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
+++ b/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
@@ -87,7 +87,7 @@ def variable_summaries(var, name):
     tf.scalar_summary('mean/' + name, mean)
     with tf.name_scope('stddev'):
       stddev = tf.sqrt(tf.reduce_mean(tf.square(var - mean)))
-    tf.scalar_summary('sttdev/' + name, stddev)
+    tf.scalar_summary('stddev/' + name, stddev)
     tf.scalar_summary('max/' + name, tf.reduce_max(var))
     tf.scalar_summary('min/' + name, tf.reduce_min(var))
     tf.histogram_summary(name, var)


### PR DESCRIPTION
…d/index.md)

Because of finding same typo error in other file, I open a PR again.

And also, I originally find it at website[[https://www.tensorflow.org/versions/r0.10/how_tos/summaries_and_tensorboard/index.html#tensorboard-visualizing-learning](https://www.tensorflow.org/versions/r0.10/how_tos/summaries_and_tensorboard/index.html#tensorboard-visualizing-learning)]. 
