### PR TITLE
Update OSS protobuf git depedency version to 3.0.0

### DIFF
--- a/tensorflow/core/example/feature_util.cc
+++ b/tensorflow/core/example/feature_util.cc
@@ -28,7 +28,7 @@ namespace internal {
 }  //  namespace internal
 
 template <>
-bool ExampleHasFeature<int64>(const string& name, const Example& example) {
+bool ExampleHasFeature<pb_int64_t>(const string& name, const Example& example) {
   auto it = example.features().feature().find(name);
   return (it != example.features().feature().end()) &&
          (it->second.kind_case() == Feature::KindCase::kInt64List);
@@ -49,13 +49,13 @@ bool ExampleHasFeature<string>(const string& name, const Example& example) {
 }
 
 template <>
-const protobuf::RepeatedField<int64>& GetFeatureValues<int64>(
+const protobuf::RepeatedField<pb_int64_t>& GetFeatureValues<pb_int64_t>(
     const string& name, const Example& example) {
   return example.features().feature().at(name).int64_list().value();
 }
 
 template <>
-protobuf::RepeatedField<int64>* GetFeatureValues<int64>(const string& name,
+protobuf::RepeatedField<pb_int64_t>* GetFeatureValues<pb_int64_t>(const string& name,
                                                         Example* example) {
   return internal::ExampleFeature(name, example)
       .mutable_int64_list()

--- a/tensorflow/core/example/feature_util.h
+++ b/tensorflow/core/example/feature_util.h
@@ -60,6 +60,8 @@ limitations under the License.
 
 namespace tensorflow {
 
+typedef protobuf::int64 pb_int64_t;
+
 namespace internal {
 
 // Returns a reference to a feature corresponding to the name.
@@ -73,8 +75,8 @@ template <typename FeatureType>
 struct RepeatedFieldTrait;
 
 template <>
-struct RepeatedFieldTrait<int64> {
-  using Type = protobuf::RepeatedField<int64>;
+struct RepeatedFieldTrait<pb_int64_t> {
+  using Type = protobuf::RepeatedField<pb_int64_t>;
 };
 
 template <>
@@ -95,7 +97,7 @@ struct FeatureTrait;
 template <typename ValueType>
 struct FeatureTrait<ValueType, typename std::enable_if<
                                    std::is_integral<ValueType>::value>::type> {
-  using Type = int64;
+  using Type = pb_int64_t;
 };
 
 template <typename ValueType>
@@ -178,7 +180,7 @@ void AppendFeatureValues(std::initializer_list<ValueType> container,
 }
 
 template <>
-bool ExampleHasFeature<int64>(const string& name, const Example& example);
+bool ExampleHasFeature<pb_int64_t>(const string& name, const Example& example);
 
 template <>
 bool ExampleHasFeature<float>(const string& name, const Example& example);
@@ -187,11 +189,11 @@ template <>
 bool ExampleHasFeature<string>(const string& name, const Example& example);
 
 template <>
-const protobuf::RepeatedField<int64>& GetFeatureValues<int64>(
+const protobuf::RepeatedField<pb_int64_t>& GetFeatureValues<pb_int64_t>(
     const string& name, const Example& example);
 
 template <>
-protobuf::RepeatedField<int64>* GetFeatureValues<int64>(const string& name,
+protobuf::RepeatedField<pb_int64_t>* GetFeatureValues<pb_int64_t>(const string& name,
                                                         Example* example);
 
 template <>

--- a/tensorflow/core/example/feature_util_test.cc
+++ b/tensorflow/core/example/feature_util_test.cc
@@ -32,7 +32,7 @@ TEST(GetFeatureValuesInt64Test, ReadsASingleValue) {
       .mutable_int64_list()
       ->add_value(42);
 
-  auto tag = GetFeatureValues<int64>("tag", example);
+  auto tag = GetFeatureValues<pb_int64_t>("tag", example);
 
   ASSERT_EQ(1, tag.size());
   EXPECT_EQ(42, tag.Get(0));
@@ -41,7 +41,7 @@ TEST(GetFeatureValuesInt64Test, ReadsASingleValue) {
 TEST(GetFeatureValuesInt64Test, WritesASingleValue) {
   Example example;
 
-  GetFeatureValues<int64>("tag", &example)->Add(42);
+  GetFeatureValues<pb_int64_t>("tag", &example)->Add(42);
 
   ASSERT_EQ(1,
             example.features().feature().at("tag").int64_list().value_size());
@@ -53,7 +53,7 @@ TEST(GetFeatureValuesInt64Test, CheckUntypedFieldExistence) {
 
   EXPECT_FALSE(ExampleHasFeature("tag", example));
 
-  GetFeatureValues<int64>("tag", &example)->Add(0);
+  GetFeatureValues<pb_int64_t>("tag", &example)->Add(0);
 
   EXPECT_TRUE(ExampleHasFeature("tag", example));
 }
@@ -62,12 +62,12 @@ TEST(GetFeatureValuesInt64Test, CheckTypedFieldExistence) {
   Example example;
 
   GetFeatureValues<float>("tag", &example)->Add(3.14);
-  ASSERT_FALSE(ExampleHasFeature<int64>("tag", example));
+  ASSERT_FALSE(ExampleHasFeature<pb_int64_t>("tag", example));
 
-  GetFeatureValues<int64>("tag", &example)->Add(42);
+  GetFeatureValues<pb_int64_t>("tag", &example)->Add(42);
 
-  EXPECT_TRUE(ExampleHasFeature<int64>("tag", example));
-  auto tag_ro = GetFeatureValues<int64>("tag", example);
+  EXPECT_TRUE(ExampleHasFeature<pb_int64_t>("tag", example));
+  auto tag_ro = GetFeatureValues<pb_int64_t>("tag", example);
   ASSERT_EQ(1, tag_ro.size());
   EXPECT_EQ(42, tag_ro.Get(0));
 }
@@ -78,9 +78,9 @@ TEST(GetFeatureValuesInt64Test, CopyIterableToAField) {
 
   std::copy(values.begin(), values.end(),
             protobuf::RepeatedFieldBackInserter(
-                GetFeatureValues<int64>("tag", &example)));
+                GetFeatureValues<pb_int64_t>("tag", &example)));
 
-  auto tag_ro = GetFeatureValues<int64>("tag", example);
+  auto tag_ro = GetFeatureValues<pb_int64_t>("tag", example);
   ASSERT_EQ(3, tag_ro.size());
   EXPECT_EQ(1, tag_ro.Get(0));
   EXPECT_EQ(2, tag_ro.Get(1));
@@ -114,7 +114,7 @@ TEST(GetFeatureValuesFloatTest, WritesASingleValue) {
 TEST(GetFeatureValuesFloatTest, CheckTypedFieldExistence) {
   Example example;
 
-  GetFeatureValues<int64>("tag", &example)->Add(42);
+  GetFeatureValues<pb_int64_t>("tag", &example)->Add(42);
   ASSERT_FALSE(ExampleHasFeature<float>("tag", example));
 
   GetFeatureValues<float>("tag", &example)->Add(3.14);
@@ -151,7 +151,7 @@ TEST(GetFeatureValuesStringTest, WritesASingleValue) {
 TEST(GetFeatureValuesBytesTest, CheckTypedFieldExistence) {
   Example example;
 
-  GetFeatureValues<int64>("tag", &example)->Add(42);
+  GetFeatureValues<pb_int64_t>("tag", &example)->Add(42);
   ASSERT_FALSE(ExampleHasFeature<string>("tag", example));
 
   *GetFeatureValues<string>("tag", &example)->Add() = "FOO";
@@ -190,9 +190,10 @@ TEST(AppendFeatureValuesTest, FloatValuesUsingInitializerList) {
 TEST(AppendFeatureValuesTest, Int64ValuesUsingInitializerList) {
   Example example;
 
-  AppendFeatureValues({1, 2, 3}, "tag", &example);
+  std::vector<pb_int64_t> values{1, 2, 3};
+  AppendFeatureValues(values, "tag", &example);
 
-  auto tag_ro = GetFeatureValues<int64>("tag", example);
+  auto tag_ro = GetFeatureValues<pb_int64_t>("tag", example);
   ASSERT_EQ(3, tag_ro.size());
   EXPECT_EQ(1, tag_ro.Get(0));
   EXPECT_EQ(2, tag_ro.Get(1));

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -90,7 +90,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
   native.git_repository(
     name = "protobuf",
     remote = "https://github.com/google/protobuf",
-    commit = "ed87c1fe2c6e1633cadb62cf54b2723b2b25c280",
+    commit = "e8ae137c96444ea313485ed1118c5e43b2099cf1",  # Release 3.0.0.
   )
 
   native.new_http_archive(


### PR DESCRIPTION
from 3.0.0-beta-2

Add a level of indirection to the int64 type in
core/example/feature_util.h, feature_util.cc and the places where the
type is used. This is for dealing with the variability of "int64" type
definition among different platforms. On some systems, int64 is "long
int", while on others it is "long long int". See GitHub Issue for more
details: https://github.com/tensorflow/tensorflow/issues/3626
