### PR TITLE
Fix type error in python_config.sh

### DIFF
--- a/util/python/python_config.sh
+++ b/util/python/python_config.sh
@@ -60,10 +60,10 @@ python_paths = []
 if os.getenv('PYTHONPATH') is not None:
   python_paths = os.getenv('PYTHONPATH').split(':')
 try:
-  library_paths =  site.getsitepackages()
+  library_paths = site.getsitepackages()
 except AttributeError:
  from distutils.sysconfig import get_python_lib
- library_paths = get_python_lib()
+ library_paths = [get_python_lib()]
 all_paths = set(python_paths + library_paths)
 
 paths = []


### PR DESCRIPTION
In the getsitepackages code path,
library_paths is a list.
Make the distutils code path a list as well.
Remove extraneous whitespace while we're here.

Without this, running ./configure:

$ ./configure 
Please specify the location of python. [Default is /Users/josh/.virtualenvs/tf/bin/python]: 
Do you wish to build TensorFlow with Google Cloud Platform support? [y/N] n
No Google Cloud Platform support will be enabled for TensorFlow
Traceback (most recent call last):
  File "<stdin>", line 18, in <module>
TypeError: can only concatenate list (not "str") to list
Found possible Python library paths:
Please input the desired Python library path to use.  Default is []

ln: util/python/python_lib: Invalid argument
