### PR TITLE
Force clean+fetch when re-running configure with different settings.

### DIFF
--- a/configure
+++ b/configure
@@ -5,6 +5,11 @@ pushd `dirname $0` #> /dev/null
 SOURCE_BASE_DIR=`pwd -P`
 popd > /dev/null
 
+function bazel_clean_and_fetch() {
+  bazel clean --expunge
+  bazel fetch //tensorflow/...
+}
+
 ## Set up python-related environment settings
 while true; do
   fromuser=""
@@ -114,6 +119,7 @@ done
 export TF_NEED_CUDA
 if [ "$TF_NEED_CUDA" == "0" ]; then
   echo "Configuration finished"
+  bazel_clean_and_fetch
   exit
 fi
 
@@ -300,7 +306,6 @@ EOF
   TF_CUDA_COMPUTE_CAPABILITIES=""
 done
 
-bazel clean --expunge
-bazel fetch //...
+bazel_clean_and_fetch
 
 echo "Configuration finished"

--- a/third_party/gpus/crosstool/BUILD.tpl
+++ b/third_party/gpus/crosstool/BUILD.tpl
@@ -2,10 +2,12 @@ licenses(["restricted"])
 
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
-    name = "crosstool",
-    srcs = ["CROSSTOOL"],
-    output_licenses = ["unencumbered"],
+cc_toolchain_suite(
+    name = "toolchain",
+    toolchains = {
+        "local|compiler": ":cc-compiler-local",
+        "darwin|compiler": ":cc-compiler-darwin",
+    },
 )
 
 cc_toolchain(

--- a/tools/bazel.rc.template
+++ b/tools/bazel.rc.template
@@ -1,4 +1,4 @@
-build:cuda --crosstool_top=@local_config_cuda//crosstool
+build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
 build:cuda --define=using_cuda=true --define=using_cuda_nvcc=true
 
 build --force_python=py$PYTHON_MAJOR_VERSION


### PR DESCRIPTION
- Run bazel clean and bazel fetch in the configure script even when building
  without GPU support to force clean+fetch if the user re-runs ./configure
  with a different setting.
- Print a more actionable error messsage if the user attempts to build with
  --config=cuda but did not configure TensorFlow to build with GPU support.
- Update the BUILD file in @local_config_cuda to use repository-local labels.

Fixes #4105
