### PR TITLE
Fix a typo in g3doc/how_tos/tool_developers

### DIFF
--- a/tensorflow/g3doc/how_tos/tool_developers/index.md
+++ b/tensorflow/g3doc/how_tos/tool_developers/index.md
@@ -56,7 +56,7 @@ Here we get a file handle for the path we've passed in to the script
 
 ```python
   if FLAGS.input_binary:
-    graph_def.ParseFromString(f.read)
+    graph_def.ParseFromString(f.read())
   else:
     text_format.Merge(f.read(), graph_def)
 ```


### PR DESCRIPTION
Add `()' after f.read so we pass a string rather than a
function.
