### PR TITLE
Add CUDA compute cap support of 3.0 for gpu.devel

### DIFF
--- a/tensorflow/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow/tools/docker/Dockerfile.devel-gpu
@@ -90,6 +90,7 @@ ENV CUDA_TOOLKIT_PATH /usr/local/cuda
 ENV CUDNN_INSTALL_PATH /usr/lib/x86_64-linux-gnu
 ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64
 ENV TF_NEED_CUDA 1
+ENV TF_CUDA_COMPUTE_CAPABILITIES=3.0,3.5,5.2
 
 RUN ./configure && \
     bazel build -c opt --config=cuda tensorflow/tools/pip_package:build_pip_package && \


### PR DESCRIPTION
See discussion in [#4048](https://github.com/tensorflow/tensorflow/issues/4048)
