### PR TITLE
Pass through -fno-canonical-system-headers

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -95,6 +95,7 @@ def GetHostCompilerOptions(argv):
   parser.add_argument('-iquote', nargs='*', action='append')
   parser.add_argument('--sysroot', nargs=1)
   parser.add_argument('-g', nargs='*', action='append')
+  parser.add_argument('-fno-canonical-system-headers', action='store_true')
 
   args, _ = parser.parse_known_args(argv)
 
@@ -106,6 +107,8 @@ def GetHostCompilerOptions(argv):
     opts += ' -iquote ' + ' -iquote '.join(sum(args.iquote, []))
   if args.g:
     opts += ' -g' + ' -g'.join(sum(args.g, []))
+  if args.fno_canonical_system_headers:
+    opts += ' -fno-canonical-system-headers'
   if args.sysroot:
     opts += ' --sysroot ' + args.sysroot[0]
 


### PR DESCRIPTION
This fixes the critical build issue #3743. After I figured out what was causing the issue, I couldn't really get a discussion of possible solutions going. I figured I would just go ahead and create a PR with the simplest and most immediate fix to get the ball rolling.

The fix is simple, gcc needs to be passed `-fno-canonical-system-headers`, and this PR makes it recognize this flag if it's passed to `crosstool_wrapper_driver_is_not_gcc` and pass it along to the compiler command.

However, one could argue that there are more general and better solutions, such as passing through all `-f...` flags (there are actually currently many flags that are passed into the Python script that are not passed along). If anyone feels strongly about such an alternative solution, I would like to discuss the details of it before putting together a replacement PR.

I might need to rebase this build before it can be merged. I cloned an older commit since the master head is broken for me (#4312).
