### PR TITLE
Fix to allow compilation for Android API 19

### DIFF
--- a/tensorflow/core/platform/posix/net.cc
+++ b/tensorflow/core/platform/posix/net.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/core/platform/net.h"
 
+#include <cerrno>
 #include <cstdlib>
 #include <unordered_set>
 


### PR DESCRIPTION
This is a (very) small change to allow compiling TensorFlow for Android API 19. Without this change, you get `tensorflow/core/platform/posix/net.cc:44:51: error: 'errno' was not declared in this scope` when compiling the example Android project with the `WORKSPACE` `android_ndk_repository` parameter `api_level` set to 19. This change resolves that error and allows compilation for this target.
