### PR TITLE
Fixed DeepDream example for Python 3.5

### DIFF
--- a/tensorflow/examples/tutorials/deepdream/README.md
+++ b/tensorflow/examples/tutorials/deepdream/README.md
@@ -18,7 +18,7 @@ service.
 
 In order to run the notebook locally, the following dependencies must be installed:
 
-- Python 2.7
+- Python 2.7 or 3.5
 - TensorFlow (>=r0.7)
 - NumPy
 - Jupyter Notebook

--- a/tensorflow/examples/tutorials/deepdream/deepdream.ipynb
+++ b/tensorflow/examples/tutorials/deepdream/deepdream.ipynb
@@ -278,7 +278,7 @@
     "            tensor = n.attr['value'].tensor\n",
     "            size = len(tensor.tensor_content)\n",
     "            if size > max_const_size:\n",
-    "                tensor.tensor_content = \"<stripped %d bytes>\"%size\n",
+    "                tensor.tensor_content = bytes(\"<stripped %d bytes>\"%size, 'utf-8')\n",
     "    return strip_def\n",
     "  \n",
     "def rename_nodes(graph_def, rename_func):\n",


### PR DESCRIPTION
The DeepDream example currently fails on Python 3.5 with

```
  <ipython-input-4-abee32f79a5a> in show_graph(graph_def, max_const_size)
     35     if hasattr(graph_def, 'as_graph_def'):
     36         graph_def = graph_def.as_graph_def()
---> 37     strip_def = strip_consts(graph_def, max_const_size=max_const_size)
     38     code = """
     39         <script>

<ipython-input-4-abee32f79a5a> in strip_consts(graph_def, max_const_size)
     18             size = len(tensor.tensor_content)
     19             if size > max_const_size:
---> 20                 tensor.tensor_content = ("<stripped %d bytes>"%size )
     21     return strip_def
     22 

TypeError: '<stripped 37632 bytes>' has type <class 'str'>, but expected one of: (<class 'bytes'>,)
```

This fix converts the string to bytes before calling strip_consts.
