### PR TITLE
Typo fix in Android Example (gradle)

### DIFF
--- a/tensorflow/examples/android/build.gradle
+++ b/tensorflow/examples/android/build.gradle
@@ -31,7 +31,7 @@ android {
     compileSdkVersion 24
     buildToolsVersion "24.0.1"
 
-    lintOptions {t
+    lintOptions {
         abortOnError false
     }
 


### PR DESCRIPTION
It seems like the `t` is a mistake, although it may be a feature which I'm unfamiliar with.
