### PR TITLE
Deal with 1d shape in variance_scaling_initializer.

### DIFF
--- a/tensorflow/contrib/layers/python/layers/initializers.py
+++ b/tensorflow/contrib/layers/python/layers/initializers.py
@@ -112,7 +112,7 @@ def variance_scaling_initializer(factor=2.0, mode='FAN_IN', uniform=False,
       raise TypeError('Cannot create initializer for non-floating point type.')
     # Estimating fan_in and fan_out is not possible to do perfectly, but we try.
     # This is the right thing for matrix multiply and convolutions.
-    fan_in = float(shape[-2])
+    fan_in = float(shape[-2]) if len(shape) > 1 else float(shape[-1])
     fan_out = float(shape[-1])
     for dim in shape[:-2]:
       fan_in *= float(dim)

--- a/tensorflow/contrib/layers/python/layers/initializers_test.py
+++ b/tensorflow/contrib/layers/python/layers/initializers_test.py
@@ -168,5 +168,32 @@ class VarianceScalingInitializerTest(tf.test.TestCase):
                         mode='FAN_AVG',
                         uniform=True)
 
+  def test_1d_shape_fan_in(self):
+    for uniform in [False, True]:
+      self._test_variance(tf.contrib.layers.variance_scaling_initializer,
+                          shape=[100],
+                          variance=2. / 100.,
+                          factor=2.0,
+                          mode='FAN_IN',
+                          uniform=uniform)
+
+  def test_1d_shape_fan_out(self):
+    for uniform in [False, True]:
+      self._test_variance(tf.contrib.layers.variance_scaling_initializer,
+                          shape=[100],
+                          variance=2. / 100.,
+                          factor=2.0,
+                          mode='FAN_OUT',
+                          uniform=uniform)
+
+  def test_1d_shape_fan_avg(self):
+    for uniform in [False, True]:
+      self._test_variance(tf.contrib.layers.variance_scaling_initializer,
+                          shape=[100],
+                          variance=4. / (100. + 100.),
+                          factor=2.0,
+                          mode='FAN_AVG',
+                          uniform=uniform)
+
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
Fixes #3825.

An initializer could be used anywhere. If the shape for variance_scaling_initializer is 1d, we can use the same value for both fan_in & fan_out.
