### PR TITLE
Add a collections attribute to node_def

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -2665,6 +2665,13 @@ class Graph(object):
     """
     self._check_not_finalized()
     with self._lock:
+      # if node does not have collections attr, create the key
+      if not value._variable.op.node_def.attr.__contains__('collections'):
+          value._variable.op.node_def.attr['collections'].list\
+                  .CopyFrom(attr_value_pb2.AttrValue.ListValue())
+      # then add collection to attr map if not exists
+      if not any([coll==name for coll in value._variable.op.node_def.attr['collections'].list.s]):
+         value._variable.op.node_def.attr['collections'].list.s.append(name)
       if name not in self._collections:
         self._collections[name] = [value]
       else:


### PR DESCRIPTION
This updates add_to_collection method in the Python API to update (or create) a ListValue of `collections` in the attr map of each node def. This has been prescribed by @jameswex to solve Issue #3495, in order to have tensorboard show the collections that a node belongs to in the node info box.
