### PR TITLE
Fix cmake files for highwayhash and re2.

### DIFF
--- a/tensorflow/contrib/cmake/external/highwayhash.cmake
+++ b/tensorflow/contrib/cmake/external/highwayhash.cmake
@@ -12,9 +12,9 @@ set(highwayhash_STATIC_LIBRARIES
 )
 set(highwayhash_INCLUDES ${highwayhash_BUILD})
 
-set(highwayhash_HEADERS
-    "${highwayhash_BUILD}/highwayhash/*.h"
-)
+file(GLOB highwayhash_HEADERS RELATIVE
+     "${highwayhash_BUILD}/highwayhash"
+     "${highwayhash_BUILD}/highwayhash/*.h")
 
 ExternalProject_Add(highwayhash
     PREFIX highwayhash
@@ -37,5 +37,5 @@ add_custom_target(highwayhash_copy_headers_to_destination
 
 foreach(header_file ${highwayhash_HEADERS})
     add_custom_command(TARGET highwayhash_copy_headers_to_destination PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${header_file} ${highwayhash_INCLUDE_DIR}/highwayhash)
+    COMMAND ${CMAKE_COMMAND} -E copy ${highwayhash_BUILD}/highwayhash/${header_file} ${highwayhash_INCLUDE_DIR}/highwayhash)
 endforeach()

--- a/tensorflow/contrib/cmake/external/re2.cmake
+++ b/tensorflow/contrib/cmake/external/re2.cmake
@@ -1,7 +1,6 @@
 include (ExternalProject)
 
-set(re2_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/re2/re2
-    ${CMAKE_CURRENT_BINARY_DIR}/external/re2)
+set(re2_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/re2/re2)
 set(re2_EXTRA_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/re2/src/re2)
 set(re2_URL https://github.com/google/re2.git)
 set(re2_TAG 791beff)


### PR DESCRIPTION
Tested via the following:
$ cd tensorflow/contrib/cmake
$ mkdir build
$ cd build
$ cmake ..
$ make
