### PR TITLE
Fix to run on Xcode 8.0

### DIFF
--- a/tensorflow/contrib/makefile/compile_ios_tensorflow.sh
+++ b/tensorflow/contrib/makefile/compile_ios_tensorflow.sh
@@ -16,9 +16,21 @@
 # Builds the TensorFlow core library with ARM and x86 architectures for iOS, and
 # packs them into a fat file.
 
+function less_than_required_version() {
+  echo $1 | (IFS=. read major minor micro
+    if [ $major -ne $2 ]; then
+      [ $major -lt $2 ]
+    elif [ $minor -ne $3 ]; then
+      [ $minor -lt $3 ]
+    else
+      [ ${micro:-0} -lt $4 ]
+    fi
+  )
+}
+
 ACTUAL_XCODE_VERSION=`xcodebuild -version | head -n 1 | sed 's/Xcode //'`
 REQUIRED_XCODE_VERSION=7.3.0
-if [ ${ACTUAL_XCODE_VERSION//.} -lt ${REQUIRED_XCODE_VERSION//.} ]
+if less_than_required_version $ACTUAL_XCODE_VERSION 7 3 0
 then
     echo "error: Xcode ${REQUIRED_XCODE_VERSION} or later is required."
     exit 1


### PR DESCRIPTION
Xcode 8.0 shows its version code as `Xcode 8.0` (no micro version)
so the version check failed,
because `80` is less than `730`.

This change checks required major/minor/micro version separately,
and makes the script to run on Xcode 8.0.
