### PR TITLE
Set re2 repository commit to the latest

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -26,7 +26,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
   native.git_repository(
     name = "com_googlesource_code_re2",
     remote = "https://github.com/google/re2.git",
-    commit = "fc6337a382bfd4f7c861abea08f872d3c85b31da",
+    commit = "7bab3dc83df6a838cc004cc7a7f51d5fe1a427d5",
   )
 
   native.git_repository(


### PR DESCRIPTION
This makes re2 buildable on Windows with MSVC toolchain. @mrry @damienmg @dslomov
