### PR TITLE
Make grpc buildable on Windows

### DIFF
--- a/grpc.BUILD
+++ b/grpc.BUILD
@@ -1224,6 +1224,7 @@ cc_library(
   deps = [
     ":gpr",
     "//external:nanopb",
+    "@zlib_archive//:zlib",
   ],
   copts = [
     "-std=gnu99",

--- a/grpc.BUILD
+++ b/grpc.BUILD
@@ -1224,7 +1224,7 @@ cc_library(
   deps = [
     ":gpr",
     "//external:nanopb",
-    "@zlib_archive//:zlib",
+    "//external:zlib",
   ],
   copts = [
     "-std=gnu99",

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -204,3 +204,8 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
     sha256 = "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d",
     build_file = str(Label("//:zlib.BUILD")),
   )
+
+  native.bind(
+    name = "zlib",
+    actual = "@zlib_archive//:zlib",
+  )


### PR DESCRIPTION
grpc++_unsecure needs zlib to build, adding @zlib_archive as a dependency

With this patch `@grpc//:grpc_cpp_plugin` and `@grpc//:grpc++_unsecure` is buildable on Windows
@mrry @damienmg @dslomov
