### PR TITLE
Fix farmhash build on Windows

### DIFF
--- a/farmhash.BUILD
+++ b/farmhash.BUILD
@@ -1,9 +1,22 @@
 licenses(["notice"])  # MIT
 
+config_setting(
+    name = "windows",
+    values = {
+        "cpu": "x64_windows_msvc",
+    },
+)
+
+
 cc_library(
     name = "farmhash",
     srcs = ["farmhash.cc"],
     hdrs = ["farmhash.h"],
+    # Disable __builtin_expect support on Windows
+    copts = select({
+        ":windows" : ["/DFARMHASH_OPTIONAL_BUILTIN_EXPECT"],
+        "//conditions:default" : [],
+    }),
     includes = ["."],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
I tried to add windows `config_setting` in `tensorflow/BUILD`, but it's not accessible from external library, so I had to add into every relevant BUILD file. @mrry @damienmg @dslomov
