### PR TITLE
[done] update zeros_initializer()

### DIFF
--- a/tensorflow/contrib/layers/python/layers/feature_column.py
+++ b/tensorflow/contrib/layers/python/layers/feature_column.py
@@ -1244,7 +1244,7 @@ class _RealValuedColumn(_FeatureColumn, collections.namedtuple(
       return variable_scope.get_variable(
           name,
           shape=[self.dimension, num_outputs],
-          initializer=array_ops.zeros_initializer,
+          initializer=init_ops.zeros_initializer,
           collections=_add_variable_collection(weight_collections))
 
     if self.name:
@@ -1834,7 +1834,7 @@ class DataFrameColumn(_FeatureColumn,
       return variable_scope.get_variable(
           name,
           shape=[self.dimension, num_outputs],
-          initializer=array_ops.zeros_initializer,
+          initializer=init_ops.zeros_initializer,
           collections=_add_variable_collection(weight_collections))
 
     if self.name:

--- a/tensorflow/contrib/layers/python/layers/feature_column_ops.py
+++ b/tensorflow/contrib/layers/python/layers/feature_column_ops.py
@@ -375,7 +375,7 @@ def weighted_sum_from_feature_columns(columns_to_tensors,
           variable = [contrib_variables.model_variable(
               name='weight',
               shape=[tensor.get_shape()[1], num_outputs],
-              initializer=array_ops.zeros_initializer,
+              initializer=init_ops.zeros_initializer,
               collections=weight_collections)]
           predictions = math_ops.matmul(tensor, variable[0], name='matmul')
       except ValueError as ee:

--- a/tensorflow/contrib/metrics/python/ops/histogram_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/histogram_ops.py
@@ -152,7 +152,7 @@ def _auc_hist_accumulate(hist_true, hist_false, nbins, collections):
     # Holds running total histogram of scores for records labeled True.
     hist_true_acc = variable_scope.get_variable(
         'hist_true_acc',
-        initializer=array_ops.zeros_initializer(
+        initializer=init_ops.zeros_initializer(
             [nbins],
             dtype=hist_true.dtype),
         collections=collections,
@@ -160,7 +160,7 @@ def _auc_hist_accumulate(hist_true, hist_false, nbins, collections):
     # Holds running total histogram of scores for records labeled False.
     hist_false_acc = variable_scope.get_variable(
         'hist_false_acc',
-        initializer=array_ops.zeros_initializer(
+        initializer=init_ops.zeros_initializer(
             [nbins],
             dtype=hist_false.dtype),
         collections=collections,

--- a/tensorflow/contrib/metrics/python/ops/histogram_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/histogram_ops.py
@@ -28,6 +28,7 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import histogram_ops
 from tensorflow.python.ops import math_ops

--- a/tensorflow/contrib/metrics/python/ops/histogram_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/histogram_ops.py
@@ -28,9 +28,9 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import histogram_ops
+from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import variable_scope

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -205,7 +205,7 @@ class CoupledInputForgetGateLSTMCell(rnn_cell.RNNCell):
 
       b = vs.get_variable(
           "B", shape=[3 * self._num_units],
-          initializer=array_ops.zeros_initializer, dtype=dtype)
+          initializer=init_ops.zeros_initializer, dtype=dtype)
 
       # j = new_input, f = forget_gate, o = output_gate
       cell_inputs = array_ops.concat(1, [inputs, m_prev])
@@ -332,7 +332,7 @@ class TimeFreqLSTMCell(rnn_cell.RNNCell):
           dtype, self._num_unit_shards)
       b = vs.get_variable(
           "B", shape=[4 * self._num_units],
-          initializer=array_ops.zeros_initializer, dtype=dtype)
+          initializer=init_ops.zeros_initializer, dtype=dtype)
 
       # Diagonal connections
       if self._use_peepholes:
@@ -535,7 +535,7 @@ class GridLSTMCell(rnn_cell.RNNCell):
           dtype, self._num_unit_shards)
       b_f = vs.get_variable(
           "B_f", shape=[num_gates * self._num_units],
-          initializer=array_ops.zeros_initializer, dtype=dtype)
+          initializer=init_ops.zeros_initializer, dtype=dtype)
       if not self._share_time_frequency_weights:
         concat_w_t = _get_concat_variable(
             "W_t", [actual_input_size + 2 * self._num_units,
@@ -543,7 +543,7 @@ class GridLSTMCell(rnn_cell.RNNCell):
             dtype, self._num_unit_shards)
         b_t = vs.get_variable(
             "B_t", shape=[num_gates * self._num_units],
-            initializer=array_ops.zeros_initializer, dtype=dtype)
+            initializer=init_ops.zeros_initializer, dtype=dtype)
 
       if self._use_peepholes:
         # Diagonal connections

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -23,8 +23,8 @@ import math
 
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import clip_ops
+from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import rnn_cell

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -23,6 +23,7 @@ import math
 
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import clip_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -259,13 +259,6 @@ def rank_internal(input, name=None, optimize=True):
       return gen_array_ops.rank(input, name=name)
 
 
-# DEPRECATED use init_ops.zeros_initializer
-# TODO(irving) Move it to init_ops.py
-def zeros_initializer(shape, dtype=dtypes.float32, partition_info=None):
-  """An adaptor for zeros() to match the Initializer spec."""
-  return zeros(shape, dtype)
-
-
 def _SliceHelper(tensor, slice_spec, var=None):
   """Overload for Tensor.__getitem__.
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -259,10 +259,6 @@ def rank_internal(input, name=None, optimize=True):
       return gen_array_ops.rank(input, name=name)
 
 
-#DEPRECATED
-zeros_initializer = init_ops.zeros_initializer
-
-
 def _SliceHelper(tensor, slice_spec, var=None):
   """Overload for Tensor.__getitem__.
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -259,6 +259,10 @@ def rank_internal(input, name=None, optimize=True):
       return gen_array_ops.rank(input, name=name)
 
 
+#DEPRECATED
+zeros_initializer = init_ops.zeros_initializer
+
+
 def _SliceHelper(tensor, slice_spec, var=None):
   """Overload for Tensor.__getitem__.
 

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -61,8 +61,9 @@ def _assert_float_dtype(dtype):
   return dtype
 
 
-# TODO(irving) Move array_ops.zeros_initializer here.
-zeros_initializer = array_ops.zeros_initializer
+def zeros_initializer(shape, dtype=dtypes.float32, partition_info=None):
+  """An adaptor for zeros() to match the Initializer spec."""
+  return array_ops.zeros(shape, dtype)
 
 
 def ones_initializer(shape, dtype=dtypes.float32, partition_info=None):

--- a/tensorflow/python/ops/rnn_cell.py
+++ b/tensorflow/python/ops/rnn_cell.py
@@ -495,7 +495,7 @@ class LSTMCell(RNNCell):
 
       b = vs.get_variable(
           "B", shape=[4 * self._num_units],
-          initializer=array_ops.zeros_initializer, dtype=dtype)
+          initializer=init_ops.zeros_initializer, dtype=dtype)
 
       # i = input_gate, j = new_input, f = forget_gate, o = output_gate
       cell_inputs = array_ops.concat(1, [inputs, m_prev])


### PR DESCRIPTION
I'm reading source code this day, and I find there is a `#TODO` in [array_ops.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/array_ops.py#L263) saying that move `zeros_initializer()` to [init_ops.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/init_ops.py#L64). 

So, I think I can help update the change. Not only move `zeros_initializer()` to `init_ops.py`, but also update the reference files which call `array_ops.zeros_initializer()`.

BTW,  I list all of them as below:
- init_ops.py
- array_ops.py
- rnn_cell.py

**3 files in contrib/..**
- feature_column.py
- histogram_ops.py
- rnn_cell.py

@girving  Could you have a look? 
