### PR TITLE
[mnist]Fix the array type bug

### DIFF
--- a/tensorflow/tools/dist_test/scripts/dist_mnist_test.sh
+++ b/tensorflow/tools/dist_test/scripts/dist_mnist_test.sh
@@ -133,7 +133,7 @@ timeout ${TIMEOUT} python "${MNIST_REPLICA}" \
 # Get N_PS by PS_HOSTS
 N_PS=$(echo ${PS_HOSTS} | awk -F "," '{printf NF}')
 # Replace the delimiter with " "
-PS_ARRAY=$(echo ${PS_HOSTS} | awk -F "," '{for(i=1;i<=NF;i++){printf $i" "}}')
+PS_ARRAY=($(echo ${PS_HOSTS} | awk -F "," '{for(i=1;i<=NF;i++){printf $i" "}}'))
 # Run a number of ps in parallel. In general, we only set 1 ps.
 echo "${N_PS} ps process(es) running in parallel..."
 
@@ -166,7 +166,7 @@ fi
 # Get N_WORKERS by WORKER_HOSTS
 N_WORKERS=$(echo ${WORKER_HOSTS} | awk -F "," '{printf NF}')
 # Replace the delimiter with " "
-WORKER_ARRAY=$(echo ${WORKER_HOSTS} | awk -F "," '{for(i=1;i<=NF;i++){printf $i" "}}')
+WORKER_ARRAY=($(echo ${WORKER_HOSTS} | awk -F "," '{for(i=1;i<=NF;i++){printf $i" "}}'))
 # Run a number of workers in parallel
 echo "${N_WORKERS} worker process(es) running in parallel..."
 


### PR DESCRIPTION
Fix the `PS_ARRAY` and `WORKER_ARRAY`  bug. They should be arrays, but in fact they are strings. The problem is the wrong way for assigning bash array. 
The log info before fixing:

```
2 worker process(es) running in parallel...
Worker 0: 
  WORKER HOST: localhost:2223 localhost:2224 
  log file: /tmp/worker0.log
Worker 1: 
  WORKER HOST: 
  log file: /tmp/worker1.log
```

After:

```
2 worker process(es) running in parallel...
Worker 0: 
  WORKER HOST: localhost:2223
  log file: /tmp/worker0.log
Worker 1: 
  WORKER HOST: localhost:2224
  log file: /tmp/worker1.log
```

I made a mistake on my branch, so I have to open a new PR to fix the bug. 
@caisq  Plz check
