### PR TITLE
Revised CMake rules for SWIG wrapper generation.

### DIFF
--- a/tensorflow/contrib/cmake/setup.py
+++ b/tensorflow/contrib/cmake/setup.py
@@ -177,7 +177,6 @@ setup(
     include_package_data=True,
     package_data={
         'tensorflow': ['python/_pywrap_tensorflow.so',
-                       'python/libpython_deps.so',
                      ] + matches,
     },
     zip_safe=False,


### PR DESCRIPTION
Instead of generating a separate `python_deps.so` and `_pywrap_tensorflow.so`, we now generate a single `_pywrap_tensorflow.so` containing the entire runtime, like the Bazel build. This simplifies the linkage on other platforms.
