### PR TITLE
Add auto-generated version_info.cc to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ node_modules
 /bazel-tensorflow
 /bazel-testlogs
 /bazel-tf
-/tensorflow/core/util/version_info.cc
 /tensorflow/contrib/cmake/build
+/tensorflow/core/util/version_info.cc
 /third_party/py/numpy/numpy_include
 /tools/bazel.rc
 /tools/python_bin_path.sh

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 /bazel-tensorflow
 /bazel-testlogs
 /bazel-tf
+/tensorflow/core/util/version_info.cc
 /tensorflow/contrib/cmake/build
 /third_party/py/numpy/numpy_include
 /tools/bazel.rc


### PR DESCRIPTION
This file is generated in-place during the CMake build, which risks it being checked into the repository.
