### PR TITLE
Fix gif build on Windows

### DIFF
--- a/gif.BUILD
+++ b/gif.BUILD
@@ -15,13 +15,49 @@ HEADERS = [
     "gif_lib_private.h",
 ]
 
+config_setting(
+        name = "windows",
+        values = {
+            "cpu": "x64_windows_msvc",
+        },
+        visibility = ["//visibility:public"],
+)
+
 prefix_dir = "giflib-5.1.4/lib"
+prefix_dir_windows = "windows/giflib-5.1.4/lib"
+
+genrule(
+  name = "srcs_without_unistd",
+  srcs = [prefix_dir + "/" + source for source in SOURCES],
+  outs = [prefix_dir_windows + "/" + source for source in SOURCES],
+  cmd = "for f in $(SRCS); do " +
+        "  sed 's/#include <unistd.h>//g' $$f > $(@D)/%s/$$(basename $$f);" % prefix_dir_windows +
+        "done",
+)
+
+genrule(
+  name = "hdrs_without_unistd",
+  srcs = [prefix_dir + "/" + hdrs for hdrs in HEADERS],
+  outs = [prefix_dir_windows + "/" + hdrs for hdrs in HEADERS],
+  cmd = "for f in $(SRCS); do " +
+        "  sed 's/#include <unistd.h>//g' $$f > $(@D)/%s/$$(basename $$f);" % prefix_dir_windows +
+        "done",
+)
 
 cc_library(
     name = "gif",
-    srcs = [prefix_dir + "/" + source for source in SOURCES],
-    hdrs = [prefix_dir + "/" + hdrs for hdrs in HEADERS],
-    includes = [prefix_dir],
+    srcs = select({
+        "//conditions:default" : [prefix_dir + "/" + source for source in SOURCES],
+        ":windows" : [":srcs_without_unistd"],
+    }),
+    hdrs = select({
+        "//conditions:default" : [prefix_dir + "/" + hdrs for hdrs in HEADERS],
+        ":windows" : [":hdrs_without_unistd"],
+    }),
+    includes = select({
+        "//conditions:default" : [prefix_dir],
+        ":windows" : [prefix_dir_windows],
+    }),
     defines = [
         "HAVE_CONFIG_H",
     ],


### PR DESCRIPTION
It fails on Windows because "'unistd.h': No such file or directory". "unistd.h" is included in some source files but never used. I can manually comment out these includes then the target is buildable. Since it's a new_http_archive, the only fix I can think of is to write a genrule to remove those include statments
Ideally, we want the include could be configurable, but that's not true in the source code yet. @mrry @damienmg @dslomov
