### PR TITLE
Fix symbol duplication for iOS on Xcode/clang

### DIFF
--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -429,6 +429,8 @@ $(wildcard tensorflow/core/platform/*/*/*.cc) \
 $(wildcard tensorflow/core/util/*.cc) \
 $(wildcard tensorflow/core/util/*/*.cc) \
 tensorflow/core/util/version_info.cc
+# Remove duplicates (for version_info.cc)
+CORE_CC_ALL_SRCS := $(sort $(CORE_CC_ALL_SRCS))
 CORE_CC_EXCLUDE_SRCS := \
 $(wildcard tensorflow/core/*/*test.cc) \
 $(wildcard tensorflow/core/*/*testutil*) \


### PR DESCRIPTION
I tried to use Tensorflow on iPhone.
I successfully created library files for iOS (libtensorflow-core-*.a)
using `tensorflow/contrib/makefile/build_all_ios.sh`.

But when I tried to use the library, following linker error happened on Xcode:

```
duplicate symbol __Z14tf_git_versionv in:
    /Users/admin/tmp/tensorflow/tensorflow/contrib/ios_examples/simple/../../makefile/gen/lib/libtensorflow-core.a(version_info.o)
duplicate symbol __Z19tf_compiler_versionv in:
    /Users/admin/tmp/tensorflow/tensorflow/contrib/ios_examples/simple/../../makefile/gen/lib/libtensorflow-core.a(version_info.o)
ld: 2 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

These functions are defined in `tensorflow/core/util/version_info.cc`.
It seems the object file is added twice in Makefile:
(`$(wildcard tensorflow/core/util/*.cc)` and `tensorflow/core/util/version_info.cc`)

The source file `version_info.cc` is generated from a script
and not included in the repository,
so adding the source file to `CORE_CC_ALL_SRCS` manually on line 431 is necessary.
But once it is generated, it is listed on `$(wildcard tensorflow/core/util/*.cc)` too, and added twice.

Using `$(sort ...)` function removes this duplication and solves the problem.
