### PR TITLE
Added colocate gradients argument to optimize_loss

### DIFF
--- a/tensorflow/contrib/layers/python/layers/optimizers.py
+++ b/tensorflow/contrib/layers/python/layers/optimizers.py
@@ -61,7 +61,8 @@ def optimize_loss(loss,
                   update_ops=None,
                   variables=None,
                   name=None,
-                  summaries=None):
+                  summaries=None,
+                  colocate_gradients=False):
   """Given loss and parameters for optimizer, returns a training op.
 
   Various ways of passing optimizers, include:
@@ -184,7 +185,8 @@ def optimize_loss(loss,
       variables = vars_.trainable_variables()
 
     # Compute gradients.
-    gradients = opt.compute_gradients(loss, variables)
+    gradients = opt.compute_gradients(loss, variables,
+                                      colocate_gradients_with_ops=colocate_gradients)
 
     # Optionally add gradient noise.
     if gradient_noise_scale is not None:

--- a/tensorflow/contrib/layers/python/layers/optimizers.py
+++ b/tensorflow/contrib/layers/python/layers/optimizers.py
@@ -62,7 +62,7 @@ def optimize_loss(loss,
                   variables=None,
                   name=None,
                   summaries=None,
-                  colocate_gradients=False):
+                  colocate_gradients_with_ops=False):
   """Given loss and parameters for optimizer, returns a training op.
 
   Various ways of passing optimizers, include:
@@ -112,6 +112,8 @@ def optimize_loss(loss,
     summaries: List of internal quantities to visualize on tensorboard. If not
                set only the loss and the learning rate will be reported. The
                complete list is in OPTIMIZER_SUMMARIES.
+    colocate_gradients_with_ops: If True, try colocating gradients with the 
+                                 corresponding op.
 
   Returns:
     Training op.

--- a/tensorflow/contrib/layers/python/layers/optimizers.py
+++ b/tensorflow/contrib/layers/python/layers/optimizers.py
@@ -188,7 +188,7 @@ def optimize_loss(loss,
 
     # Compute gradients.
     gradients = opt.compute_gradients(loss, variables,
-                                      colocate_gradients_with_ops=colocate_gradients)
+                                      colocate_gradients_with_ops=colocate_gradients_with_ops)
 
     # Optionally add gradient noise.
     if gradient_noise_scale is not None:


### PR DESCRIPTION
This PR adds a colocate gradients argument to optimize_loss which is useful for multi GPU training where the model is split across multiple GPUs.
