### PR TITLE
Update seq2seq tutorial

### DIFF
--- a/tensorflow/g3doc/tutorials/seq2seq/index.md
+++ b/tensorflow/g3doc/tutorials/seq2seq/index.md
@@ -25,11 +25,17 @@ prepare it for training and train. It takes about 20GB of disk space,
 and a while to download and prepare (see [later](#lets-run-it) for details),
 so you can start and leave it running while reading this tutorial.
 
+This tutorial references the following files from `python/ops/`.
+
+File | What's in it?
+--- | ---
+`python/ops/seq2seq.py` | Library for building sequence-to-sequence models.
+
+
 This tutorial references the following files from `models/rnn`.
 
 File | What's in it?
 --- | ---
-`seq2seq.py` | Library for building sequence-to-sequence models.
 `translate/seq2seq_model.py` | Neural translation sequence-to-sequence model.
 `translate/data_utils.py` | Helper functions for preparing translation data.
 `translate/translate.py` | Binary that trains and runs the translation model.
@@ -74,7 +80,7 @@ attention mechanism in the decoder looks like this.
 As you can see above, there are many different sequence-to-sequence
 models. Each of these models can use different RNN cells, but all
 of them accept encoder inputs and decoder inputs. This motivates
-the interfaces in the TensorFlow seq2seq library (`models/rnn/seq2seq.py`).
+the interfaces in the TensorFlow seq2seq library (`python/ops/seq2seq.py`).
 The basic RNN encoder-decoder sequence-to-sequence model works as follows.
 
 ```python
@@ -151,7 +157,7 @@ have similar interfaces, so we will not describe them in detail. We will use
 ## Neural Translation Model
 
 While the core of the sequence-to-sequence model is constructed by
-the functions in `models/rnn/seq2seq.py`, there are still a few tricks
+the functions in `python/ops/seq2seq.py`, there are still a few tricks
 that are worth mentioning that are used in our translation model in
 `models/rnn/translate/seq2seq_model.py`.
 

--- a/tensorflow/g3doc/tutorials/seq2seq/index.md
+++ b/tensorflow/g3doc/tutorials/seq2seq/index.md
@@ -25,20 +25,14 @@ prepare it for training and train. It takes about 20GB of disk space,
 and a while to download and prepare (see [later](#lets-run-it) for details),
 so you can start and leave it running while reading this tutorial.
 
-This tutorial references the following files from `python/ops/`.
+This tutorial references the following files.
 
 File | What's in it?
 --- | ---
 `python/ops/seq2seq.py` | Library for building sequence-to-sequence models.
-
-
-This tutorial references the following files from `models/rnn`.
-
-File | What's in it?
---- | ---
-`translate/seq2seq_model.py` | Neural translation sequence-to-sequence model.
-`translate/data_utils.py` | Helper functions for preparing translation data.
-`translate/translate.py` | Binary that trains and runs the translation model.
+`models/rnn/translate/seq2seq_model.py` | Neural translation sequence-to-sequence model.
+`models/rnn/translate/data_utils.py` | Helper functions for preparing translation data.
+`models/rnn/translate/translate.py` | Binary that trains and runs the translation model.
 
 
 ## Sequence-to-Sequence Basics


### PR DESCRIPTION
The seq2seq tutorial still refers to models/rnn/seq2seq.py, but it has been moved to tf.nn.seq2seq (python/ops/seq2seq.py) on master
