### PR TITLE
Update gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 /bazel-tf
 /tensorflow/contrib/cmake/build
 /tensorflow/core/util/version_info.cc
+/tensorflow/tools/git/gen
 /third_party/py/numpy/numpy_include
 /tools/bazel.rc
 /tools/python_bin_path.sh


### PR DESCRIPTION
`/tensorflow/tools/git/gen/` would be generated during build and it
should be ignored.
