### PR TITLE
Update os_setup.md cuDNN install instructions

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -610,7 +610,7 @@ to reflect the cuDNN version you downloaded):
 
 ``` bash
 tar xvzf cudnn-7.5-linux-x64-v5.1-ga.tgz
-sudo cp cuda/include/cudnn.h /usr/local/cuda/include
+sudo cp cuda/include/cudnn.h /usr/local/cuda/include/cudnn.h
 sudo cp cuda/lib64/libcudnn* /usr/local/cuda/lib64
 sudo chmod a+r /usr/local/cuda/include/cudnn.h /usr/local/cuda/lib64/libcudnn*
 ```


### PR DESCRIPTION
To install cuDNN:

The file `cudnn.h` is included in the destination for `cp` command since `/usr/local/cuda/include` is a directory.
