### PR TITLE
[issue4339]Add adjust_gamma for image

### DIFF
--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -68,6 +68,8 @@ class DType(object):
 
   @@as_numpy_dtype
   @@as_datatype_enum
+  
+  @@limits
   """
 
   def __init__(self, type_enum):
@@ -215,6 +217,27 @@ class DType(object):
       except:
         raise TypeError("Cannot find maximum value of %s." % self)
 
+  @property
+  def limits(self, clip_negative=None):
+    """Return intensity limits, i.e. (min, max) tuple, of the dtype.
+    Args:
+      clip_negative : bool, optional
+          If True, clip the negative range (i.e. return 0 for min intensity)
+          even if the image dtype allows negative values.
+          The default behavior (None) is equivalent to True.
+    Returns
+      min, max : tuple
+        Lower and upper intensity limits.
+    """
+    if clip_negative is None:
+        clip_negative = True
+        #warn('The default of `clip_negative` in `skimage.util.dtype_limits` '
+        #     'will change to `False` in version 0.15.')
+    min, max = dtype_range[self.as_numpy_dtype]
+    if clip_negative:
+        min = 0
+    return min, max
+
   def is_compatible_with(self, other):
     """Returns True if the `other` DType will be converted to this DType.
 
@@ -270,6 +293,19 @@ class DType(object):
   def size(self):
     return np.dtype(self.as_numpy_dtype).itemsize
 
+# Define data type range of numpy dtype
+dtype_range = {np.bool_: (False, True),
+               np.bool8: (False, True),
+               np.uint8: (0, 255),
+               np.uint16: (0, 65535),
+               np.int8: (-128, 127),
+               np.int16: (-32768, 32767),
+               np.int64: (-2**63, 2**63 - 1),
+               np.uint64: (0, 2**64 - 1),
+               np.int32: (-2**31, 2**31 - 1),
+               np.uint32: (0, 2**32 - 1),
+               np.float32: (-1, 1),
+               np.float64: (-1, 1)}
 
 # Define standard wrappers for the types_pb2.DataType enum.
 float16 = DType(types_pb2.DT_HALF)

--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -218,24 +218,19 @@ class DType(object):
         raise TypeError("Cannot find maximum value of %s." % self)
 
   @property
-  def limits(self, clip_negative=None):
+  def limits(self, clip_negative=True):
     """Return intensity limits, i.e. (min, max) tuple, of the dtype.
     Args:
       clip_negative : bool, optional
           If True, clip the negative range (i.e. return 0 for min intensity)
           even if the image dtype allows negative values.
-          The default behavior (None) is equivalent to True.
     Returns
       min, max : tuple
         Lower and upper intensity limits.
     """
-    if clip_negative is None:
-        clip_negative = True
-        #warn('The default of `clip_negative` in `skimage.util.dtype_limits` '
-        #     'will change to `False` in version 0.15.')
     min, max = dtype_range[self.as_numpy_dtype]
     if clip_negative:
-        min = 0
+      min = 0
     return min, max
 
   def is_compatible_with(self, other):

--- a/tensorflow/python/ops/image_ops.py
+++ b/tensorflow/python/ops/image_ops.py
@@ -1014,12 +1014,12 @@ def adjust_gamma(image, gamma=1, gain=1):
     after scaling each pixel to the range 0 to 1.
 
   Args:
-    image : A tensor.
+    image : A Tensor.
     gamma : A scalar. Non negative real number.
     gain  : A scalar. The constant multiplier. 
 
   Returns:
-    A tensor. Gamma corrected output image
+    A Tensor. Gamma corrected output image.
 
   Notes:
     For gamma greater than 1, the histogram will shift towards left and
@@ -1032,17 +1032,19 @@ def adjust_gamma(image, gamma=1, gain=1):
   """
 
   with ops.op_scope([image, gamma, gain], None, 'adjust_gamma') as name:
+    # Convert pixel value to DT_FLOAT for computing adjusted image
     img = ops.convert_to_tensor(image, name='img', dtype=dtypes.float32)
+    # Keep image dtype for computing the scale of corresponding dtype
     image = ops.convert_to_tensor(image, name='image')
 
     if gamma < 0:
       raise ValueError("Gamma should be a non-negative real number")
-
+    # scale = max(dtype) - min(dtype)
     scale = constant_op.constant(image.dtype.limits[1] - image.dtype.limits[0], dtype=dtypes.float32)
+    # According to the definition of gamma correction
+    adjusted_img = (img / scale) ** gamma * scale * gain
 
-    adjusted = (img / scale) ** gamma * scale * gain
-
-    return adjusted
+    return adjusted_img
     
 
 ops.RegisterShape('AdjustContrast')(common_shapes.call_cpp_shape_fn)

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -164,6 +164,80 @@ class GrayscaleToRGBTest(test_util.TensorFlowTestCase):
       self.assertFalse(rgb_unknown.get_shape())
 
 
+class AdjustGamma(test_util.TensorFlowTestCase):
+
+  def test_adjust_gamma_one(self):
+    """Same image should be returned for gamma equal to one"""
+    with self.test_session():
+      x_data = np.random.uniform(0, 255, (8, 8))
+      x_np = np.array(x_data, dtype=np.float32)
+
+      x = constant_op.constant(x_np, shape=x_np.shape)
+      y = image_ops.adjust_gamma(x, gamma=1)
+
+      y_tf = y.eval()
+      y_np = x_np
+
+      self.assertAllClose(y_tf, y_np, 1e-6)
+
+
+  def test_adjust_gamma_zero(self):
+    """White image should be returned for gamma equal to zero"""
+    with self.test_session():
+      x_data = np.random.uniform(0, 255, (8, 8))
+      x_np = np.array(x_data, dtype=np.float32)
+      
+      x = constant_op.constant(x_np, shape=x_np.shape)
+      y = image_ops.adjust_gamma(x, gamma=0)
+      
+      y_tf = y.eval()
+
+      dtype = x.dtype.as_numpy_dtype
+      y_np = np.array([dtypes.dtype_range[dtype][1]] * x_np.size)
+      y_np = y_np.reshape((8,8))
+      
+      self.assertAllClose(y_tf, y_np, 1e-6)
+      
+
+  def test_adjust_gamma_less_one(self):
+    """Verifying the output with expected results for gamma
+    correction with gamma equal to half"""
+    with self.test_session():
+      x_np = np.arange(0, 255, 4, np.uint8).reshape(8,8)
+      y = image_ops.adjust_gamma(x_np, gamma=0.5)
+      y_tf = np.trunc(y.eval())
+
+      y_np = np.array([[  0,  31,  45,  55,  63,  71,  78,  84],
+          [ 90,  95, 100, 105, 110, 115, 119, 123],
+          [127, 131, 135, 139, 142, 146, 149, 153],
+          [156, 159, 162, 165, 168, 171, 174, 177],
+          [180, 183, 186, 188, 191, 194, 196, 199],
+          [201, 204, 206, 209, 211, 214, 216, 218],
+          [221, 223, 225, 228, 230, 232, 234, 236],
+          [238, 241, 243, 245, 247, 249, 251, 253]], dtype=np.float32)
+      
+      self.assertAllClose(y_tf, y_np, 1e-6)
+
+def test_adjust_gamma_greater_one(self):
+    """Verifying the output with expected results for gamma
+    correction with gamma equal to two"""
+    with self.test_session():
+      x_np = np.arange(0, 255, 4, np.uint8).reshape(8,8)
+      y = image_ops.adjust_gamma(x_np, gamma=2)
+      y_tf = np.trunc(y.eval())
+
+      y_np = np.array([[  0,   0,   0,   0,   1,   1,   2,   3],
+          [  4,   5,   6,   7,   9,  10,  12,  14],
+          [ 16,  18,  20,  22,  25,  27,  30,  33],
+          [ 36,  39,  42,  45,  49,  52,  56,  60],
+          [ 64,  68,  72,  76,  81,  85,  90,  95],
+          [100, 105, 110, 116, 121, 127, 132, 138],
+          [144, 150, 156, 163, 169, 176, 182, 189],
+          [196, 203, 211, 218, 225, 233, 241, 249]], dtype=np.float32)
+
+      self.assertAllClose(y_tf, y_np, 1e-6)
+
+
 class AdjustHueTest(test_util.TensorFlowTestCase):
 
   def testAdjustNegativeHue(self):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -218,7 +218,7 @@ class AdjustGamma(test_util.TensorFlowTestCase):
       
       self.assertAllClose(y_tf, y_np, 1e-6)
 
-def test_adjust_gamma_greater_one(self):
+  def test_adjust_gamma_greater_one(self):
     """Verifying the output with expected results for gamma
     correction with gamma equal to two"""
     with self.test_session():


### PR DESCRIPTION
Add "Gamma Correction" Image Adjustment [issue4339](https://github.com/tensorflow/tensorflow/issues/4339) according to **scikit-image** [adjust_gamma](http://scikit-image.org/docs/dev/api/skimage.exposure.html#skimage.exposure.adjust_gamma)

Change list:
- Add `adjust_gamma` in `image_ops.py`
- Add corresponding tests in `image_ops_test.py`
  - test_adjust_gamma_one
  - test_adjust_gamma_zero
  - test_adjust_gamma_less_one
  - test_adjust_gamma_greater_one
- Add dtype range and limits for numpy dtype

Compare to scikit-image:
- [adjust_gamma](https://github.com/scikit-image/scikit-image/blob/master/skimage/exposure/exposure.py#L309)
- [Test Gamma Correction](https://github.com/scikit-image/scikit-image/blob/master/skimage/exposure/tests/test_exposure.py#L308)
- [dtype range](https://github.com/scikit-image/scikit-image/blob/master/skimage/util/dtype.py#L8)
- [dtype limits](https://github.com/scikit-image/scikit-image/blob/master/skimage/util/dtype.py#L32)

An explanation of [Gamma Correction](https://en.wikipedia.org/wiki/Gamma_correction) in Wikipedia
