### PR TITLE
Fix to download eigen library

### DIFF
--- a/tensorflow/contrib/makefile/download_dependencies.sh
+++ b/tensorflow/contrib/makefile/download_dependencies.sh
@@ -19,9 +19,12 @@ set -e
 DOWNLOADS_DIR=tensorflow/contrib/makefile/downloads
 BZL_FILE_PATH=tensorflow/workspace.bzl
 
-# Temporarily specify the Eigen URL manually while we're waiting on the build
-# file changes to be synced.
-EIGEN_URL=http://bitbucket.org/eigen/eigen/get/8106cca06137.tar.gz
+EIGEN_VERSION="$(sed -ne 's/^[ \t]*eigen_version = "\(.*\)".*$/\1/p' "${BZL_FILE_PATH}")"
+if [ "${EIGEN_VERSION}" == '' ]; then
+    echo "Cannot extract eigen_version from ${BZL_FILE_PATH}" >&2
+    exit 1
+fi
+EIGEN_URL="$(grep -o 'http.*bitbucket.org/eigen/eigen/get/' "${BZL_FILE_PATH}")${EIGEN_VERSION}.tar.gz"
 GEMMLOWP_URL="$(grep -o 'http.*github.com/google/gemmlowp/.*tar\.gz' "${BZL_FILE_PATH}")"
 GOOGLETEST_URL="https://github.com/google/googletest/archive/release-1.8.0.tar.gz"
 PROTOBUF_URL="$(grep -o 'http.*github.com/google/protobuf/.*tar\.gz' "${BZL_FILE_PATH}")"


### PR DESCRIPTION
URL for eigen library is extracted from `tensorflow/workspace.bzl`,
but expression is used to construct the URL in the code,
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace.bzl#L22
so extracted URL using simple `grep` is not correct.

This change get version code for eigen library from the file,
and construct URL with it.

It looks cmake handles the URL in same way:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/cmake/external/eigen.cmake#L13
