### PR TITLE
Add camera permission for iOS 10

### DIFF
--- a/tensorflow/contrib/ios_examples/camera/Info.plist
+++ b/tensorflow/contrib/ios_examples/camera/Info.plist
@@ -36,5 +36,7 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Capture images to detect object</string>
 </dict>
 </plist>


### PR DESCRIPTION
To avoid shutting the  application down on iOS 10,
adding `NSCameraUsageDescription` to `Info.plist` is necessary.

https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24

> Important: To protect user privacy, an iOS app linked on or after
> iOS 10.0, and which accesses the device’s camera, must statically
> declare the intent to do so. Include the NSCameraUsageDescription key
> in your app’s Info.plist file and provide a purpose string for this
> key. If your app attempts to access the device’s camera without a
> corresponding purpose string, your app exits.
