### PR TITLE
Support older versions of git

### DIFF
--- a/tensorflow/tools/git/gen_git_source.py
+++ b/tensorflow/tools/git/gen_git_source.py
@@ -143,7 +143,7 @@ def get_git_version(git_base_path):
 
   unknown_label = "unknown"
   try:
-    val = subprocess.check_output(["git", "-C", git_base_path, "describe",
+    val = subprocess.check_output(["git", str("--git-dir="+git_base_path+"/.git"), str("--work-tree="+git_base_path), "describe",
                                    "--long", "--dirty", "--tags"]).strip()
     return val if val else unknown_label
   except subprocess.CalledProcessError:


### PR DESCRIPTION
The Parameter -C is unknown in git 1.7.1 but --exec-path= can be used.
