### PR TITLE
Doc: update README iOS instructions [skip ci]

### DIFF
--- a/tensorflow/contrib/makefile/README.md
+++ b/tensorflow/contrib/makefile/README.md
@@ -141,6 +141,12 @@ xcode-select --install
 If this is a new install, you will need to run XCode once to agree to the
 license before continuing.
 
+Then install [automake](https://en.wikipedia.org/wiki/Automake):
+
+```bash
+brew install automake
+```
+
 Also, download the graph if you haven't already:
 
 ```bash


### PR DESCRIPTION
Automake seems to be required to build on MacOS 10.11.
Add instruction to the dedicated README to install this dependency.
