### PR TITLE
optional arguments should be optional

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/rnn_test.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/rnn_test.py
@@ -133,5 +133,16 @@ class RNNTest(tf.test.TestCase):
     predictions = classifier.predict(data[:2])
     self.assertAllClose(predictions, labels[:2])
 
+def testNoInputFnRNN(self):
+    # Classification
+    classifier = tf.contrib.learn.TensorFlowRNNClassifier(rnn_size=2,
+                                                          cell_type="lstm",
+                                                          n_classes=2,
+                                                          steps=100)
+    classifier.fit(data, labels)
+    predictions = classifier.predict(data[:2])
+    self.assertAllClose(predictions, labels[:2])
+
+    
 if __name__ == "__main__":
   tf.test.main()


### PR DESCRIPTION
the input_op_fn appears to be optional (it has a default value), but the default value is trash and causes the function to crash with a less than useful argument.

I don't have the skill to fix the rnn.py function at the moment, but it seems to me that the null_input_op_fn should make some guess at how the data should be unwrapped rather than just return something that will cause a crash.
