### PR TITLE
spelling mistake of hight is fixed

### DIFF
--- a/tensorflow/g3doc/tutorials/image_recognition/index.md
+++ b/tensorflow/g3doc/tutorials/image_recognition/index.md
@@ -262,7 +262,7 @@ output data.
 
 This gives us a vector of `Tensor` objects, which in this case we know will only be a
 single object long. You can think of a `Tensor` as a multi-dimensional array in this
-context, and it holds a 299 pixel hight, 299 pixel width, 3 channel image as float
+context, and it holds a 299 pixel height, 299 pixel width, 3 channel image as float
 values. If you have your own image-processing framework in your product already, you
 should be able to use that instead, as long as you apply the same transformations
 before you feed images into the main graph.

--- a/tensorflow/g3doc/tutorials/image_recognition/index.md
+++ b/tensorflow/g3doc/tutorials/image_recognition/index.md
@@ -262,7 +262,7 @@ output data.
 
 This gives us a vector of `Tensor` objects, which in this case we know will only be a
 single object long. You can think of a `Tensor` as a multi-dimensional array in this
-context, and it holds a 299 pixel height, 299 pixel width, 3 channel image as float
+context, and it holds a 299 pixel high, 299 pixel wide, 3 channel image as float
 values. If you have your own image-processing framework in your product already, you
 should be able to use that instead, as long as you apply the same transformations
 before you feed images into the main graph.

--- a/tensorflow/g3doc/tutorials/image_recognition/index.md
+++ b/tensorflow/g3doc/tutorials/image_recognition/index.md
@@ -262,7 +262,7 @@ output data.
 
 This gives us a vector of `Tensor` objects, which in this case we know will only be a
 single object long. You can think of a `Tensor` as a multi-dimensional array in this
-context, and it holds a 299 pixel high, 299 pixel width, 3 channel image as float
+context, and it holds a 299 pixel hight, 299 pixel width, 3 channel image as float
 values. If you have your own image-processing framework in your product already, you
 should be able to use that instead, as long as you apply the same transformations
 before you feed images into the main graph.


### PR DESCRIPTION
At link https://www.tensorflow.org/versions/r0.10/tutorials/image_recognition/index.html 

Fix for the typo mistake of **hight** in line "it holds a 299 pixel **high**, 299 pixel width,".
