### PR TITLE
link to better jupyter notebook preview

### DIFF
--- a/tensorflow/g3doc/tutorials/index.md
+++ b/tensorflow/g3doc/tutorials/index.md
@@ -112,7 +112,7 @@ Building on the Inception recognition model, we will release a TensorFlow
 version of the [Deep Dream](https://github.com/google/deepdream) neural network
 visual hallucination software.
 
-[View Tutorial](https://www.tensorflow.org/code/tensorflow/examples/tutorials/deepdream/deepdream.ipynb)
+[View Tutorial](https://nbviewer.jupyter.org/github/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/deepdream/deepdream.ipynb)
 
 
 ## Language and Sequence Processing


### PR DESCRIPTION
As mentioned in [the deep dream tutorial readme](https://github.com/tensorflow/tensorflow/blob/bc64f05d4090262025a95438b42a54bfdc5bcc80/tensorflow/examples/tutorials/deepdream/README.md) the jupyter notebook preview on nbviewer is better than the one on github. Specifically, github removes the network graph visualizations.
