### PR TITLE
dynamic_raw_rnn

### DIFF
--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -1453,7 +1453,7 @@ def dynamic_raw_rnn(cell, inputs, sequence_length=None, initial_state=None,
     outputs_ta, final_state, _ = \
       raw_rnn(cell=cell, loop_fn=loop_fn,
               parallel_iterations=parallel_iterations,
-              swap_memory=swap_memory, scope=scope)
+              swap_memory=swap_memory, scope=varscope)
     outputs = outputs_ta.pack()
     if not time_major:
       # [seq, batch, features] -> [batch, seq, features]

--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -1354,12 +1354,10 @@ def dynamic_raw_rnn(cell, inputs, sequence_length=None, initial_state=None,
     inputs: The RNN inputs.
 
       If `time_major == False` (default), this must be a `Tensor` of shape:
-        `[batch_size, max_time, ...]`, or a nested tuple of such
-        elements.
+        `[batch_size, max_time, ...]`.
 
       If `time_major == True`, this must be a `Tensor` of shape:
-        `[max_time, batch_size, ...]`, or a nested tuple of such
-        elements.
+        `[max_time, batch_size, ...]`.
 
       The input to `cell` at each time step will be a `Tensor` with dimensions
       `[batch_size, ...]`.

--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -1419,10 +1419,6 @@ def dynamic_raw_rnn(cell, inputs, sequence_length=None, initial_state=None,
     if sequence_length is None:
       max_len = array_ops.shape(inputs)[0]
       sequence_length = array_ops.ones([batch_size], dtype=tf.int32) * max_len
-    # Setup input as TensorArray
-    inputs_ta = tensor_array_ops.TensorArray(dtype, size=0, dynamic_size=True)
-    inputs_ta = inputs_ta.unpack(inputs)
-
     # Setup initial state
     if initial_state is not None:
       state = initial_state
@@ -1432,6 +1428,9 @@ def dynamic_raw_rnn(cell, inputs, sequence_length=None, initial_state=None,
         raise ValueError("If no initial_state is provided, "
                          "dtype must be specified")
       state = cell.zero_state(batch_size, dtype)
+    # Setup input as TensorArray
+    inputs_ta = tensor_array_ops.TensorArray(dtype, size=0, dynamic_size=True)
+    inputs_ta = inputs_ta.unpack(inputs)
 
     # Define RNN: loop function (will run in the while_loop of 'raw_rnn')
     def loop_fn(time, cell_output, cell_state, loop_state):


### PR DESCRIPTION
Working example of the recent [raw_rnn](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/rnn.py#L1032) by @ebrevdo .

This working example implements the [dynamic_rnn](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/rnn.py#L685) without tuple support (yet) using the `raw_rnn` interface.

The working example builds on this [snippet](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/rnn.py#L1076), but is fully functional and provides the same interface as `dynamic_rnn` using the raw_rnn implementation.

The purpose is not to replace `dynamic_rnn` (at least not yet?), but to give a code base with commentaries for implementing custom RNNs using the `raw_rnn` interface.
