### PR TITLE
Fix skflow resnet example to work on v0.10.0

### DIFF
--- a/tensorflow/examples/learn/BUILD
+++ b/tensorflow/examples/learn/BUILD
@@ -85,6 +85,15 @@ py_binary(
 )
 
 py_binary(
+    name = "resnet",
+    srcs = ["resnet.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorflow:tensorflow_py",
+    ],
+)
+
+py_binary(
     name = "text_classification",
     srcs = ["text_classification.py"],
     srcs_version = "PY2AND3",
@@ -153,6 +162,7 @@ sh_test(
         ":iris_val_based_early_stopping",
         ":iris_with_pipeline",
         ":random_forest_mnist",
+        ":resnet",
         ":text_classification",
         ":text_classification_builtin_rnn_model",
         ":text_classification_character_cnn",

--- a/tensorflow/examples/learn/README.md
+++ b/tensorflow/examples/learn/README.md
@@ -23,6 +23,7 @@ Some examples use the `pandas` library for data processing (`sudo pip install pa
 ## Specialized Models
 * [Building a Random Forest Model](random_forest.py)
 * [Building a Wide & Deep Model](wide_n_deep_tutorial.py)
+* [Building a Residual Network Model](resnet.py)
 
 ## Text classification
 

--- a/tensorflow/examples/learn/examples_test.sh
+++ b/tensorflow/examples/learn/examples_test.sh
@@ -53,6 +53,7 @@ test iris_custom_decay_dnn
 test iris_run_config
 test iris_val_based_early_stopping
 test iris_with_pipeline
+test resnet
 test text_classification --test_with_fake_data
 test text_classification_builtin_rnn_model --test_with_fake_data
 test text_classification_cnn --test_with_fake_data

--- a/tensorflow/examples/learn/resnet.py
+++ b/tensorflow/examples/learn/resnet.py
@@ -32,7 +32,6 @@ from sklearn import metrics
 import tensorflow as tf
 from tensorflow.contrib import learn
 from tensorflow.contrib.layers import batch_norm, convolution2d
-from tensorflow.examples.tutorials.mnist import input_data
 
 
 def res_net(x, y, activation=tf.nn.relu):
@@ -136,14 +135,14 @@ def res_net(x, y, activation=tf.nn.relu):
   return learn.models.logistic_regression(net, y)
 
 # Download and load MNIST data.
-mnist = input_data.read_data_sets('MNIST_data')
+mnist = learn.datasets.load_dataset('mnist')
 
 # Create a new resnet classifier.
 classifier = learn.TensorFlowEstimator(
     model_fn=res_net, n_classes=10, batch_size=100, steps=100,
     learning_rate=0.001, continue_training=True)
 
-while True:
+for step in xrange(100):
   # Train model and save summaries into logdir.
   classifier.fit(
       mnist.train.images, mnist.train.labels, logdir='models/resnet/')

--- a/tensorflow/examples/skflow/BUILD
+++ b/tensorflow/examples/skflow/BUILD
@@ -99,15 +99,6 @@ py_binary(
 )
 
 py_binary(
-    name = "resnet",
-    srcs = ["resnet.py"],
-    srcs_version = "PY2AND3",
-    deps = [
-        "//tensorflow:tensorflow_py",
-    ],
-)
-
-py_binary(
     name = "text_classification_save_restore",
     srcs = ["text_classification_save_restore.py"],
     srcs_version = "PY2AND3",


### PR DESCRIPTION
I tried to run `resnet.py` skflow example on TensorFlow v0.10.0,
but an error occurred.

I have fixed the code to run on v0.10.0:
- `tensorflow.contrib.learn.ops.conv2d` was deprecated and has been removed in #4373 .
  So changed to use `contrib.layers.convolution2d` .
- `classifier` wasn't created if no previous model existed in `models/resnet/graph.pbtxt`,
  but it was failed to run at first time.
  `TensorFlowEstimator` creation was removed in #2863 , so revert the code removal.
