### PR TITLE
Fixed documentation for batch_normalization

### DIFF
--- a/tensorflow/g3doc/api_docs/python/nn.md
+++ b/tensorflow/g3doc/api_docs/python/nn.md
@@ -3221,9 +3221,9 @@ Batch normalization.
 
 As described in http://arxiv.org/abs/1502.03167.
 Normalizes a tensor by `mean` and `variance`, and applies (optionally) a
-`scale` \\\\(\gamma\\\\) to it, as well as an `offset` \\\\(\\beta\\\\):
+`scale` \\(\gamma\\) to it, as well as an `offset` \\(\beta\\):
 
-\\\\(\\frac{\gamma(x-\mu)}{\sigma}+\\beta\\\\)
+$$\frac{\gamma(x-\mu)}{\sigma}+\beta$$
 
 `mean`, `variance`, `offset` and `scale` are all expected to be of one of two
 shapes:
@@ -3251,9 +3251,9 @@ shapes:
 *  <b>`x`</b>: Input `Tensor` of arbitrary dimensionality.
 *  <b>`mean`</b>: A mean `Tensor`.
 *  <b>`variance`</b>: A variance `Tensor`.
-*  <b>`offset`</b>: An offset `Tensor`, often denoted \\\\(\\beta\\\\) in equations, or
+*  <b>`offset`</b>: An offset `Tensor`, often denoted \\(\beta\\) in equations, or
     None. If present, will be added to the normalized tensor.
-*  <b>`scale`</b>: A scale `Tensor`, often denoted \\\\(\gamma\\\\) in equations, or
+*  <b>`scale`</b>: A scale `Tensor`, often denoted \\(\gamma\\) in equations, or
     `None`. If present, the scale is applied to the normalized tensor.
 *  <b>`variance_epsilon`</b>: A small float number to avoid dividing by 0.
 *  <b>`name`</b>: A name for this operation (optional).


### PR DESCRIPTION
Fixed batch_normalization part of the nn python Documentation.

Fixed syntax errors restricting the latex code to load in the markdown documentation file for "tf.nn.batch_normalization(...)".
