### PR TITLE
Fixed documentation for batch_normalization

### DIFF
--- a/tensorflow/python/ops/nn.py
+++ b/tensorflow/python/ops/nn.py
@@ -936,9 +936,9 @@ def batch_normalization(x,
 
   As described in http://arxiv.org/abs/1502.03167.
   Normalizes a tensor by `mean` and `variance`, and applies (optionally) a
-  `scale` \\\\(\gamma\\\\) to it, as well as an `offset` \\\\(\\beta\\\\):
+  `scale` \\(\gamma\\) to it, as well as an `offset` \\(\beta\\):
 
-  \\\\(\\frac{\gamma(x-\mu)}{\sigma}+\\beta\\\\)
+  \\(\frac{\gamma(x-\mu)}{\sigma}+\beta\\)
 
   `mean`, `variance`, `offset` and `scale` are all expected to be of one of two
   shapes:
@@ -964,9 +964,9 @@ def batch_normalization(x,
     x: Input `Tensor` of arbitrary dimensionality.
     mean: A mean `Tensor`.
     variance: A variance `Tensor`.
-    offset: An offset `Tensor`, often denoted \\\\(\\beta\\\\) in equations, or
+    offset: An offset `Tensor`, often denoted \\(\beta\\) in equations, or
       None. If present, will be added to the normalized tensor.
-    scale: A scale `Tensor`, often denoted \\\\(\gamma\\\\) in equations, or
+    scale: A scale `Tensor`, often denoted \\(\gamma\\) in equations, or
       `None`. If present, the scale is applied to the normalized tensor.
     variance_epsilon: A small float number to avoid dividing by 0.
     name: A name for this operation (optional).


### PR DESCRIPTION
Fixed batch_normalization part of the nn python Documentation.

Fixed syntax errors restricting the latex code to load in the markdown documentation file for "tf.nn.batch_normalization(...)".
