### PR TITLE
Enable to pass feed_fn to fit method

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/dnn.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/dnn.py
@@ -423,8 +423,8 @@ class DNNClassifier(evaluable.Evaluable, trainable.Trainable):
         },
         feature_engineering_fn=feature_engineering_fn)
 
-  def fit(self, x=None, y=None, input_fn=None, steps=None, batch_size=None,
-          monitors=None, max_steps=None):
+  def fit(self, x=None, y=None, input_fn=None, feed_fn=None, steps=None,
+          batch_size=None, monitors=None, max_steps=None):
     """See trainable.Trainable."""
     # TODO(roumposg): Remove when deprecated monitors are removed.
     if monitors is not None:
@@ -436,9 +436,9 @@ class DNNClassifier(evaluable.Evaluable, trainable.Trainable):
         monitor.set_estimator(self)
         monitor._lock_estimator()  # pylint: disable=protected-access
 
-    result = self._estimator.fit(x=x, y=y, input_fn=input_fn, steps=steps,
-                                 batch_size=batch_size, monitors=monitors,
-                                 max_steps=max_steps)
+    result = self._estimator.fit(x=x, y=y, input_fn=input_fn, feed_fn=feed_fn,
+                                 steps=steps, batch_size=batch_size,
+                                 monitors=monitors, max_steps=max_steps)
 
     if monitors is not None:
       for monitor in deprecated_monitors:

--- a/tensorflow/contrib/learn/python/learn/estimators/dnn_sampled_softmax_classifier.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/dnn_sampled_softmax_classifier.py
@@ -414,12 +414,12 @@ class _DNNSampledSoftmaxClassifier(trainable.Trainable, evaluable.Evaluable):
   def get_estimator(self):
     return self._estimator
 
-  def fit(self, x=None, y=None, input_fn=None, steps=None, batch_size=None,
-          monitors=None, max_steps=None):
+  def fit(self, x=None, y=None, input_fn=None, feed_fn=None, steps=None,
+          batch_size=None, monitors=None, max_steps=None):
     """See trainable.Trainable."""
-    return self._estimator.fit(x=x, y=y, input_fn=input_fn, steps=steps,
-                               batch_size=batch_size, monitors=monitors,
-                               max_steps=max_steps)
+    return self._estimator.fit(x=x, y=y, input_fn=input_fn, feed_fn=feed_fn,
+                               steps=steps, batch_size=batch_size,
+                               monitors=monitors, max_steps=max_steps)
 
   def evaluate(self, x=None, y=None, input_fn=None, feed_fn=None,
                batch_size=None, steps=None, metrics=None, name=None,

--- a/tensorflow/contrib/learn/python/learn/estimators/estimator.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimator.py
@@ -311,8 +311,8 @@ class BaseEstimator(
     # TODO(wicke): make RunConfig immutable, and then return it without a copy.
     return copy.deepcopy(self._config)
 
-  def fit(self, x=None, y=None, input_fn=None, steps=None, batch_size=None,
-          monitors=None, max_steps=None):
+  def fit(self, x=None, y=None, input_fn=None, feed_fn=None, steps=None,
+          batch_size=None, monitors=None, max_steps=None):
     # pylint: disable=g-doc-args,g-doc-return-or-yield
     """See `Trainable`.
 
@@ -323,7 +323,7 @@ class BaseEstimator(
     if (steps is not None) and (max_steps is not None):
       raise ValueError('Can not provide both steps and max_steps.')
 
-    input_fn, feed_fn = _get_input_fn(x, y, input_fn, feed_fn=None,
+    input_fn, feed_fn = _get_input_fn(x, y, input_fn, feed_fn=feed_fn,
                                       batch_size=batch_size, shuffle=True,
                                       epochs=None)
     loss = self._train_model(input_fn=input_fn,

--- a/tensorflow/contrib/learn/python/learn/estimators/linear.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/linear.py
@@ -464,8 +464,8 @@ class LinearClassifier(evaluable.Evaluable, trainable.Trainable):
   def get_estimator(self):
     return self._estimator
 
-  def fit(self, x=None, y=None, input_fn=None, steps=None, batch_size=None,
-          monitors=None, max_steps=None):
+  def fit(self, x=None, y=None, input_fn=None, feed_fn=feed_fn, steps=None,
+          batch_size=None, monitors=None, max_steps=None):
     """See trainable.Trainable."""
     # TODO(roumposg): Remove when deprecated monitors are removed.
     if monitors is not None:

--- a/tensorflow/contrib/learn/python/learn/estimators/svm.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/svm.py
@@ -158,12 +158,12 @@ class SVM(trainable.Trainable, evaluable.Evaluable):
         },
         feature_engineering_fn=feature_engineering_fn)
 
-  def fit(self, x=None, y=None, input_fn=None, steps=None, batch_size=None,
-          monitors=None, max_steps=None):
+  def fit(self, x=None, y=None, input_fn=None, feed_fn=None, steps=None,
+          batch_size=None, monitors=None, max_steps=None):
     """See trainable.Trainable."""
-    return self._estimator.fit(x=x, y=y, input_fn=input_fn, steps=steps,
-                               batch_size=batch_size, monitors=monitors,
-                               max_steps=max_steps)
+    return self._estimator.fit(x=x, y=y, input_fn=input_fn, feed_fn=feed_fn,
+                               steps=steps, batch_size=batch_size,
+                               monitors=monitors, max_steps=max_steps)
 
   # pylint: disable=protected-access
   def evaluate(self, x=None, y=None, input_fn=None, feed_fn=None,

--- a/tensorflow/contrib/learn/python/learn/trainable.py
+++ b/tensorflow/contrib/learn/python/learn/trainable.py
@@ -28,8 +28,8 @@ class Trainable(object):
   __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
-  def fit(self, x=None, y=None, input_fn=None, steps=None, batch_size=None,
-          monitors=None, max_steps=None):
+  def fit(self, x=None, y=None, input_fn=None, feed_fn=None, steps=None,
+          batch_size=None, monitors=None, max_steps=None):
     """Trains a model given training data `x` predictions and `y` targets.
 
     Args:
@@ -44,6 +44,9 @@ class Trainable(object):
           features - Dictionary of string feature name to `Tensor` or `Tensor`.
           target - `Tensor` or dictionary of `Tensor` with target labels.
         If input_fn is set, `x`, `y`, and `batch_size` must be `None`.
+      feed_fn: A function that is called every iteration to produce a `feed_dict`
+        passed to `session.run` calls. Optional.
+        feed_fn is used only if `input_fn` is given, and not used with `x` nor `y`.
       steps: Number of steps for which to train model. If `None`, train forever.
         'steps' works incrementally. If you call two times fit(steps=10) then
         training occurs in total 20 steps. If you don't want to have incremental


### PR DESCRIPTION
There was no way to use `fit` method to pass `feed_fn`.

I tried to use [fit](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/learn/python/learn/estimators/estimator.py#L314) method of `learn.estimator.Estimator` (actually the method is defined in its parent `BaseEstimator`).

Also I tried to use [DataFeeder](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/learn/python/learn/learn_io/data_feeder.py#L217) to feed data. I can use `input_builder` and `get_feed_dict_fn()` of `DataFeeder` instance to extract data. But when I tried to feed data to `fit` method, I couldn't pass `feed_fn`, extracted from `DataFeeder`.

This change add `feed_fn` keyword argument to `fit` method, to handle above situation.
