### PR TITLE
Fail configure script immediately on error.

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -o pipefail
+
 # Find out the absolute path to where ./configure resides
 pushd `dirname $0` #> /dev/null
 SOURCE_BASE_DIR=`pwd -P`
@@ -14,7 +17,7 @@ function bazel_clean_and_fetch() {
 while true; do
   fromuser=""
   if [ -z "$PYTHON_BIN_PATH" ]; then
-    default_python_bin_path=$(which python)
+    default_python_bin_path=$(which python || true)
     read -p "Please specify the location of python. [Default is $default_python_bin_path]: " PYTHON_BIN_PATH
     fromuser="1"
     if [ -z "$PYTHON_BIN_PATH" ]; then
@@ -47,7 +50,6 @@ while [ "$TF_NEED_GCP" == "" ]; do
 done
 
 if [ "$TF_NEED_GCP" == "1" ]; then
-
   ## Verify that libcurl header files are available.
   # Only check Linux, since on MacOS the header files are installed with XCode.
   if [[ $(uname -a) =~ Linux ]] && [[ ! -f "/usr/include/curl/curl.h" ]]; then
@@ -96,7 +98,7 @@ fi
 echo "$SWIG_PATH" > tensorflow/tools/swig/swig_path
 
 # Invoke python_config and set up symlinks to python includes
-(./util/python/python_config.sh --setup "$PYTHON_BIN_PATH";) || exit -1
+./util/python/python_config.sh --setup "$PYTHON_BIN_PATH"
 
 # Run the gen_git_source to create links where bazel can track dependencies for
 # git hash propagation
@@ -127,7 +129,7 @@ fi
 while true; do
   fromuser=""
   if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
-    default_gcc_host_compiler_path=$(which gcc)
+    default_gcc_host_compiler_path=$(which gcc || true)
     read -p "Please specify which gcc should be used by nvcc as the host compiler. [Default is $default_gcc_host_compiler_path]: " GCC_HOST_COMPILER_PATH
     fromuser="1"
     if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
@@ -217,15 +219,31 @@ while true; do
     # Resolve to the SONAME of the symlink.  Use readlink without -f
     # to resolve exactly once to the SONAME.  E.g, libcudnn.so ->
     # libcudnn.so.4
-    REALVAL=`readlink ${CUDNN_INSTALL_PATH}/lib64/libcudnn.so`
+    cudnn_lib_path=""
+    cudnn_alt_lib_path=""
+    if [ "$OSNAME" == "Linux" ]; then
+      cudnn_lib_path="${CUDNN_INSTALL_PATH}/lib64/libcudnn.so"
+      cudnn_alt_lib_path="${CUDNN_INSTALL_PATH}/libcudnn.so"
+    elif [ "$OSNAME" == "Darwin" ]; then
+      cudnn_lib_path="${CUDNN_INSTALL_PATH}/lib/libcudnn.dylib"
+      cudnn_alt_lib_path="${CUDNN_INSTALL_PATH}/libcudnn.dylib"
+    fi
+    if [ -f "$cudnn_lib_path" ]; then
+      REALVAL=`readlink -f ${cudnn_lib_path}`
+    else
+      REALVAL=`readlink -f ${cudnn_alt_lib_path}`
+    fi
 
     # Extract the version of the SONAME, if it was indeed symlinked to
     # the SONAME version of the file.
-    if [[ "$REALVAL" =~ .so[.]+([0-9]*) ]];
-    then
+    if [[ "$REALVAL" =~ .so[.]+([0-9]*) ]]; then
       TF_CUDNN_EXT="."${BASH_REMATCH[1]}
       TF_CUDNN_VERSION=${BASH_REMATCH[1]}
       echo "libcudnn.so resolves to libcudnn${TF_CUDNN_EXT}"
+    elif [[ "$REALVAL" =~ ([0-9]*).dylib ]]; then
+      TF_CUDNN_EXT=${BASH_REMATCH[1]}".dylib"
+      TF_CUDNN_VERSION=${BASH_REMATCH[1]}
+      echo "libcudnn.dylib resolves to libcudnn${TF_CUDNN_EXT}"
     fi
   else
     TF_CUDNN_EXT=".$TF_CUDNN_VERSION"

--- a/tensorflow/tools/ci_build/builds/configured
+++ b/tensorflow/tools/ci_build/builds/configured
@@ -49,8 +49,7 @@ else
 fi
 
 pushd "${CI_TENSORFLOW_SUBMODULE_PATH:-.}"
-echo '' > test_input.txt
-./configure < test_input.txt
+yes "" | ./configure
 popd
 
 # Gather and print build information


### PR DESCRIPTION
For lines such as `default_python_bin_path=$(which python)`, add a `|| true`
expression so that if the executable does not exist, the command will not exit
with a non-zero exit code, and the variable will be set to an empty string.

Also, use `yes` to automate the `./configure` script when running CI tests
rather than piping in an empty file, which causes subsequent `read` commands
to fail.

This change also augments the code in the configure script for resolving the
cuDNN library to search both the case where libcudnn is installed to a lib/lib64
directory (such as /usr/local/cuda-7.5/lib64) and when it is not (such as
/usr/lib/x86_64-linux-gnu), as well as when the platform is Darwin.

Fixes #4662
