### PR TITLE
change syntax of curl & tar

### DIFF
--- a/tensorflow/contrib/makefile/download_dependencies.sh
+++ b/tensorflow/contrib/makefile/download_dependencies.sh
@@ -48,7 +48,7 @@ download_and_extract() {
   local dir="${2:?${usage}}"
   echo "downloading ${url}" >&2
   mkdir -p "${dir}"
-  tar -C "${dir}" --strip-components=1 -xz < <(curl -Ls "${url}")
+  curl -Ls "${url}" | tar -C "${dir}" --strip-components=1 -xz
 }
 
 download_and_extract "${EIGEN_URL}" "${DOWNLOADS_DIR}/eigen"


### PR DESCRIPTION
Was throwing syntax error on osx 10.10

```
Error: tensorflow/contrib/makefile/download_dependencies.sh: line 51: syntax error near unexpected token `<'
```
#4710
