### PR TITLE
Correct height/width ordering to mnist docs

### DIFF
--- a/tensorflow/g3doc/tutorials/mnist/pros/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/pros/index.md
@@ -305,7 +305,7 @@ b_conv1 = bias_variable([32])
 ```
 
 To apply the layer, we first reshape `x` to a 4d tensor, with the second and
-third dimensions corresponding to image width and height, and the final
+third dimensions corresponding to image height and width, and the final
 dimension corresponding to the number of color channels.
 
 ```python


### PR DESCRIPTION
Not that it matters much, but I believe these two are swapped. Correct me if I'm wrong, but when convolving in only one dimension, I had to reverse the two in order to get good classification for a dataset.
