### PR TITLE
check_version: fails if native.bazel_version is undefined

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -25,7 +25,7 @@ def src_to_test_name(src):
 def check_version(bazel_version):
   if "bazel_version" not in dir(native):
     fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" % bazel_version)
-  if not native.bazel_version:
+  elif not native.bazel_version:
     print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
     print("Make sure that you are running at least Bazel %s.\n" % bazel_version)
   else:
@@ -34,6 +34,7 @@ def check_version(bazel_version):
     if minimum_bazel_version > current_bazel_version:
       fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
           native.bazel_version, bazel_version))
+  pass
 
 # Return the options to use for a C++ library or binary build.
 # Uses the ":optmode" config_setting to pick the options.

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -23,13 +23,17 @@ def src_to_test_name(src):
 
 # Check that a specific bazel version is being used.
 def check_version(bazel_version):
-  if "bazel_version" in dir(native) and native.bazel_version:
+  if "bazel_version" not in dir(native):
+    fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" % bazel_version)
+  if not native.bazel_version:
+    print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
+    print("Make sure that you are running at least Bazel %s.\n" % bazel_version)
+  else:
     current_bazel_version = _parse_bazel_version(native.bazel_version)
     minimum_bazel_version = _parse_bazel_version(bazel_version)
     if minimum_bazel_version > current_bazel_version:
       fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
           native.bazel_version, bazel_version))
-  pass
 
 # Return the options to use for a C++ library or binary build.
 # Uses the ":optmode" config_setting to pick the options.


### PR DESCRIPTION
This feature is in Bazel since 0.2.1, TensorFlow requires 0.3.0
at least and should error out if the feature is not present.

Also give a warning when the version number is not present
(when Bazel is built from HEAD) for better debugging.

See http://stackoverflow.com/questions/39811568/error-function-repository-rule-does-not-exist-while-trying-to-compile-tensor.
