### PR TITLE
Fix python bath in python_config script

### DIFF
--- a/util/python/python_config.sh
+++ b/util/python/python_config.sh
@@ -46,7 +46,7 @@ function main {
 }
 
 function python_path {
-  python - <<END
+  $PYTHON_BIN_PATH - <<END
 from __future__ import print_function
 import site
 import os
@@ -80,7 +80,7 @@ END
 }
 
 function default_python_path {
-  PYTHON_ARG="$1" python - <<END
+  PYTHON_ARG="$1" $PYTHON_BIN_PATH - <<END
 from __future__ import print_function
 import os
 


### PR DESCRIPTION
When runing `./configure`, two places in the script `python_config` try to invoke `python` but don't use the python-related environment variable `PYTHON_BIN_PATH`. So it will cause the error that can't find python during configuration.
