### PR TITLE
bug fix when iterators stops at multiple of batch_size

### DIFF
--- a/tensorflow/contrib/learn/python/learn/graph_actions.py
+++ b/tensorflow/contrib/learn/python/learn/graph_actions.py
@@ -285,8 +285,13 @@ def _monitored_train(graph,
         hooks=all_hooks) as super_sess:
       loss = None
       while not super_sess.should_stop():
-        _, loss = super_sess.run([train_op, loss_op], feed_fn() if feed_fn else
-                                 None)
+        feed_dict = feed_fn() if feed_fn else None
+        # check for case when iterator stopped exactly at multiple of batch_size
+        # In such case, all the returned numpy array are len zero.
+        edge_condition = True if feed_dict and all(len(v) == 0 for v in feed_dict.values()) else False
+        if not edge_condition:
+          _, loss = super_sess.run([train_op, loss_op], feed_dict)
+          
       return loss
 
 

--- a/tensorflow/contrib/learn/python/learn/graph_actions.py
+++ b/tensorflow/contrib/learn/python/learn/graph_actions.py
@@ -285,13 +285,8 @@ def _monitored_train(graph,
         hooks=all_hooks) as super_sess:
       loss = None
       while not super_sess.should_stop():
-        feed_dict = feed_fn() if feed_fn else None
-        # check for case when iterator stopped exactly at multiple of batch_size
-        # In such case, all the returned numpy array are len zero.
-        edge_condition = True if feed_dict and all(len(v) == 0 for v in feed_dict.values()) else False
-        if not edge_condition:
-          _, loss = super_sess.run([train_op, loss_op], feed_dict)
-          
+        _, loss = super_sess.run([train_op, loss_op], feed_fn() if feed_fn else None)
+        
       return loss
 
 

--- a/tensorflow/contrib/learn/python/learn/graph_actions.py
+++ b/tensorflow/contrib/learn/python/learn/graph_actions.py
@@ -287,7 +287,6 @@ def _monitored_train(graph,
       while not super_sess.should_stop():
         _, loss = super_sess.run([train_op, loss_op], feed_fn() if feed_fn else
                                  None)
-        
       return loss
 
 

--- a/tensorflow/contrib/learn/python/learn/graph_actions.py
+++ b/tensorflow/contrib/learn/python/learn/graph_actions.py
@@ -285,7 +285,8 @@ def _monitored_train(graph,
         hooks=all_hooks) as super_sess:
       loss = None
       while not super_sess.should_stop():
-        _, loss = super_sess.run([train_op, loss_op], feed_fn() if feed_fn else None)
+        _, loss = super_sess.run([train_op, loss_op], feed_fn() if feed_fn else
+                                 None)
         
       return loss
 

--- a/tensorflow/contrib/learn/python/learn/learn_io/data_feeder.py
+++ b/tensorflow/contrib/learn/python/learn/learn_io/data_feeder.py
@@ -507,10 +507,13 @@ class StreamingDataFeeder(DataFeeder):
           inp[i, :] = six.next(self._x)
         except StopIteration:
           self.stopped = True
-          inp = inp[:i, :]
-          if self._y is not None:
-            out = out[:i]
-          break
+          if i==0:
+            raise StopIteration
+          else:
+            inp = inp[:i, :]
+            if self._y is not None:
+              out = out[:i]
+            break
 
         if self._y is not None:
           y = six.next(self._y)

--- a/tensorflow/contrib/learn/python/learn/learn_io/data_feeder.py
+++ b/tensorflow/contrib/learn/python/learn/learn_io/data_feeder.py
@@ -509,11 +509,10 @@ class StreamingDataFeeder(DataFeeder):
           self.stopped = True
           if i == 0:
             raise StopIteration
-          else:
-            inp = inp[:i, :]
-            if self._y is not None:
-              out = out[:i]
-            break
+          inp = inp[:i, :]
+          if self._y is not None:
+            out = out[:i]
+          break
 
         if self._y is not None:
           y = six.next(self._y)

--- a/tensorflow/contrib/learn/python/learn/learn_io/data_feeder.py
+++ b/tensorflow/contrib/learn/python/learn/learn_io/data_feeder.py
@@ -508,7 +508,7 @@ class StreamingDataFeeder(DataFeeder):
         except StopIteration:
           self.stopped = True
           if i == 0:
-            raise StopIteration
+            raise
           inp = inp[:i, :]
           if self._y is not None:
             out = out[:i]

--- a/tensorflow/contrib/learn/python/learn/learn_io/data_feeder.py
+++ b/tensorflow/contrib/learn/python/learn/learn_io/data_feeder.py
@@ -507,7 +507,7 @@ class StreamingDataFeeder(DataFeeder):
           inp[i, :] = six.next(self._x)
         except StopIteration:
           self.stopped = True
-          if i==0:
+          if i == 0:
             raise StopIteration
           else:
             inp = inp[:i, :]


### PR DESCRIPTION
In contrib.learn framwork,  `Estmator.fit()` supports `x`, `y` and `batch_size` arguments where `x` and `y` could be iterators/generators. However, when iterator finishes right at the edge, after exactly integer multiple of batch_size, a run is made anyway with batch_size = 0. This causes NaN errors with following code snippet. 

[Gist Link](https://www.google.com/url?q=https%3A%2F%2Fgist.github.com%2Fabhitopia%2Fb6b60cb8bf9bab58a78b221fb3c4473b&sa=D&sntz=1&usg=AFQjCNEgS-muOb4Z0UC3SDBQ-F5KcfBMbQ) - to reproduce error.

For more information on the issue see
[Tensorflow google group discussion](https://groups.google.com/a/tensorflow.org/forum/#!topic/discuss/ZEzEa1TyYuE)

Simply skipping session.run when feed_dict is empty solves the problem.
