### PR TITLE
contrib/quantization: Do not open dot file in binary mode

### DIFF
--- a/tensorflow/contrib/quantization/tools/graph_to_dot.py
+++ b/tensorflow/contrib/quantization/tools/graph_to_dot.py
@@ -46,7 +46,7 @@ def main(unused_args):
     return -1
 
   graph = graph_pb2.GraphDef()
-  with open(FLAGS.graph, "rb") as f:
+  with open(FLAGS.graph, "r") as f:
     if FLAGS.input_binary:
       graph.ParseFromString(f.read())
     else:


### PR DESCRIPTION
The Python 3 documentation states:

Since printed arguments are converted to text strings,
print() cannot be used with binary mode file objects.
