### PR TITLE
Make tutorial_example_trainer build on Windows with Bazel

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -45,6 +45,12 @@ config_setting(
 )
 
 config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows_msvc"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "ios",
     values = {
         "crosstool_top": "//tools/osx/crosstool:crosstool",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -981,10 +981,11 @@ cc_library(
                     "**/*test*",
                     "platform/**/cuda.h",
                     "platform/**/stream_executor.h",
-                ] +
+                ] 
                 # Protobuf deps already included through the ":lib_proto_parsing"
                 # dependency.
-                tf_additional_proto_srcs(),
+                # Excluding logging.h from srcs will cause a linking error
+                # + tf_additional_proto_srcs(),
     ),
     hdrs = tf_additional_lib_hdrs() + [
         "lib/core/blocking_counter.h",
@@ -1057,6 +1058,7 @@ tf_version_info_genrule()
 cc_library(
     name = "version_lib",
     srcs = ["util/version_info.cc"],
+    copts = tf_copts(),
 )
 
 tf_cuda_library(

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -141,6 +141,7 @@ cc_library(
         "platform/protobuf.h",
         "platform/types.h",
     ] + glob(tf_additional_proto_hdrs()),
+    copts = tf_copts(),
     deps = [
         ":protos_all_cc",
         "//tensorflow/core/platform/default/build_config:proto_parsing",
@@ -979,11 +980,10 @@ cc_library(
                     "**/*test*",
                     "platform/**/cuda.h",
                     "platform/**/stream_executor.h",
-                ] 
+                ] +
                 # Protobuf deps already included through the ":lib_proto_parsing"
                 # dependency.
-                # Excluding logging.h from srcs will cause a linking error
-                # + tf_additional_proto_srcs(),
+                tf_additional_proto_srcs(),
     ),
     hdrs = tf_additional_lib_hdrs() + [
         "lib/core/blocking_counter.h",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -535,8 +535,6 @@ cc_library(
         "//tensorflow/core/kernels:fact_op",
         "//tensorflow/core/kernels:array_not_windows",
         "//tensorflow/core/kernels:math_not_windows",
-        "//tensorflow/core/kernels:linalg_not_windows",
-        "//tensorflow/core/kernels:logging_not_windows",
     ]),
 )
 

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -64,6 +64,7 @@ load(
     "//tensorflow:tensorflow.bzl",
     "if_android",
     "if_ios",
+    "if_not_windows",
     "tf_copts",
     "tf_cc_test",
     "tf_cc_tests",
@@ -871,12 +872,12 @@ cc_library(
 # Libraries with GPU facilities that are useful for writing kernels.
 cc_library(
     name = "gpu_lib",
-    srcs = [
+    srcs = if_not_windows([
         "common_runtime/gpu/gpu_event_mgr.cc",
-    ],
-    hdrs = [
+    ]),
+    hdrs = if_not_windows([
         "common_runtime/gpu/gpu_event_mgr.h",
-    ],
+    ]),
     copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
@@ -886,8 +887,7 @@ cc_library(
         ":lib_internal",
         ":proto_text",
         ":protos_all_cc",
-        ":stream_executor",
-    ],
+    ] + if_not_windows([":stream_executor"]),
 )
 
 cc_library(
@@ -1341,7 +1341,7 @@ tf_cuda_library(
 
 tf_cuda_library(
     name = "gpu_runtime",
-    srcs = [
+    srcs = if_not_windows([
         "common_runtime/gpu/gpu_bfc_allocator.cc",
         "common_runtime/gpu/gpu_debug_allocator.cc",
         "common_runtime/gpu/gpu_device.cc",
@@ -1353,8 +1353,8 @@ tf_cuda_library(
         "common_runtime/gpu/pool_allocator.cc",
         "common_runtime/gpu/process_state.cc",
         "common_runtime/gpu_device_context.h",
-    ],
-    hdrs = [
+    ]),
+    hdrs = if_not_windows([
         "common_runtime/gpu/gpu_bfc_allocator.h",
         "common_runtime/gpu/gpu_debug_allocator.h",
         "common_runtime/gpu/gpu_device.h",
@@ -1363,7 +1363,7 @@ tf_cuda_library(
         "common_runtime/gpu/gpu_util.h",
         "common_runtime/gpu/pool_allocator.h",
         "common_runtime/gpu/process_state.h",
-    ],
+    ]),
     copts = tf_copts(),
     linkstatic = 1,
     deps = [
@@ -1375,9 +1375,8 @@ tf_cuda_library(
         ":lib",
         ":lib_internal",
         ":protos_all_cc",
-        ":stream_executor",
         "//third_party/eigen3",
-    ],
+    ] + if_not_windows([":stream_executor"]),
     alwayslink = 1,
 )
 

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -312,11 +312,11 @@ tf_cuda_library(
         "util/util.h",
         "util/work_sharder.h",
     ] + select({
-            "//tensorflow:windows" : [],
-            "//conditions:default" : [
-                "util/memmapped_file_system.h",
-                "util/memmapped_file_system_writer.h",
-            ],
+        "//tensorflow:windows": [],
+        "//conditions:default": [
+            "util/memmapped_file_system.h",
+            "util/memmapped_file_system_writer.h",
+        ],
     }),
     visibility = ["//visibility:public"],
     deps = [":framework_internal"],
@@ -952,38 +952,44 @@ tf_proto_library_cc(
 cc_library(
     name = "lib_internal",
     srcs = select({
-                "//tensorflow:windows" : glob([
-                    "lib/**/*.h",
-                    "lib/**/*.cc",
-                    "platform/*.h",
-                    "platform/*.cc",
-                ],  exclude = [
-                    "**/*test*",
-                    "platform/**/cuda.h",
-                    "platform/**/stream_executor.h",
-                    "platform/load_library.cc",
-                ]),
-                "//conditions:default" : glob([
-                    "lib/**/*.h",
-                    "lib/**/*.cc",
-                    "platform/*.h",
-                    "platform/*.cc",
-                    "platform/profile_utils/**/*.h",
-                    "platform/profile_utils/**/*.cc",
-                ],  exclude = [
-                    "**/*test*",
-                    "platform/**/cuda.h",
-                    "platform/**/stream_executor.h",
-                ]),
+        "//tensorflow:windows": glob(
+            [
+                "lib/**/*.h",
+                "lib/**/*.cc",
+                "platform/*.h",
+                "platform/*.cc",
+            ],
+            exclude = [
+                "**/*test*",
+                "platform/**/cuda.h",
+                "platform/**/stream_executor.h",
+                "platform/load_library.cc",
+            ],
+        ),
+        "//conditions:default": glob(
+            [
+                "lib/**/*.h",
+                "lib/**/*.cc",
+                "platform/*.h",
+                "platform/*.cc",
+                "platform/profile_utils/**/*.h",
+                "platform/profile_utils/**/*.cc",
+            ],
+            exclude = [
+                "**/*test*",
+                "platform/**/cuda.h",
+                "platform/**/stream_executor.h",
+            ],
+        ),
     }) + tf_additional_lib_srcs(
-                exclude = [
-                    "**/*test*",
-                    "platform/**/cuda.h",
-                    "platform/**/stream_executor.h",
-                ] +
-                # Protobuf deps already included through the ":lib_proto_parsing"
-                # dependency.
-                tf_additional_proto_srcs(),
+        exclude = [
+            "**/*test*",
+            "platform/**/cuda.h",
+            "platform/**/stream_executor.h",
+        ] +
+        # Protobuf deps already included through the ":lib_proto_parsing"
+        # dependency.
+        tf_additional_proto_srcs(),
     ),
     hdrs = tf_additional_lib_hdrs() + [
         "lib/core/blocking_counter.h",
@@ -1082,11 +1088,11 @@ tf_cuda_library(
             "util/memmapped_file_system_writer.*",
         ],
     ) + select({
-            "//tensorflow:windows" : [],
-            "//conditions:default" : glob([
-                "util/memmapped_file_system.*",
-                "util/memmapped_file_system_writer.*",
-            ]),
+        "//tensorflow:windows": [],
+        "//conditions:default": glob([
+            "util/memmapped_file_system.*",
+            "util/memmapped_file_system_writer.*",
+        ]),
     }),
     hdrs = [
         "framework/op_segment.h",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -293,8 +293,6 @@ tf_cuda_library(
         "util/example_proto_fast_parsing.h",
         "util/example_proto_helper.h",
         "util/guarded_philox_random.h",
-        "util/memmapped_file_system.h",
-        "util/memmapped_file_system_writer.h",
         "util/mirror_pad_mode.h",
         "util/padding.h",
         "util/port.h",
@@ -311,7 +309,13 @@ tf_cuda_library(
         "util/use_cudnn.h",
         "util/util.h",
         "util/work_sharder.h",
-    ],
+    ] + select({
+            "//tensorflow:windows" : [],
+            "//conditions:default" : [
+                "util/memmapped_file_system.h",
+                "util/memmapped_file_system_writer.h",
+            ],
+    }),
     visibility = ["//visibility:public"],
     deps = [":framework_internal"],
 )
@@ -949,20 +953,34 @@ cc_library(
             "lib/**/*.cc",
             "platform/*.h",
             "platform/*.cc",
-            "platform/profile_utils/**/*.h",
-            "platform/profile_utils/**/*.cc",
-        ] + tf_additional_lib_srcs(),
-        exclude =
-            [
-                "**/*test*",
-                "platform/**/cuda.h",
-                "platform/**/stream_executor.h",
-            ] +
-            # Protobuf deps already included through the ":lib_proto_parsing"
-            # dependency.
-            tf_additional_proto_srcs(),
+       ],
+        exclude = [
+            "**/*test*",
+            "platform/**/cuda.h",
+            "platform/**/stream_executor.h",
+        ]
+    ) + select({
+                "//tensorflow:windows" : [],
+                "//conditions:default" : glob([
+                    "platform/profile_utils/**/*.h",
+                    "platform/profile_utils/**/*.cc",
+                ],
+                exclude = [
+                    "**/*test*",
+                    "platform/**/cuda.h",
+                    "platform/**/stream_executor.h",
+                ]),
+    }) + tf_additional_lib_srcs(
+                exclude = [
+                    "**/*test*",
+                    "platform/**/cuda.h",
+                    "platform/**/stream_executor.h",
+                ] +
+                # Protobuf deps already included through the ":lib_proto_parsing"
+                # dependency.
+                tf_additional_proto_srcs(),
     ),
-    hdrs = glob(tf_additional_lib_hdrs()) + [
+    hdrs = tf_additional_lib_hdrs() + [
         "lib/core/blocking_counter.h",
         "lib/core/refcount.h",
         "lib/gif/gif_io.h",
@@ -1054,8 +1072,16 @@ tf_cuda_library(
             "util/reporter.h",
             "util/reporter.cc",
             "framework/fake_input.*",
+            "util/memmapped_file_system.*",
+            "util/memmapped_file_system_writer.*",
         ],
-    ),
+    ) + select({
+            "//tensorflow:windows" : [],
+            "//conditions:default" : glob([
+                "util/memmapped_file_system.*",
+                "util/memmapped_file_system_writer.*",
+            ]),
+    }),
     hdrs = [
         "framework/op_segment.h",
         "framework/rendezvous.h",  # only needed for tests

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -947,25 +947,26 @@ tf_proto_library_cc(
 
 cc_library(
     name = "lib_internal",
-    srcs = glob(
-        [
-            "lib/**/*.h",
-            "lib/**/*.cc",
-            "platform/*.h",
-            "platform/*.cc",
-       ],
-        exclude = [
-            "**/*test*",
-            "platform/**/cuda.h",
-            "platform/**/stream_executor.h",
-        ]
-    ) + select({
-                "//tensorflow:windows" : [],
+    srcs = select({
+                "//tensorflow:windows" : glob([
+                    "lib/**/*.h",
+                    "lib/**/*.cc",
+                    "platform/*.h",
+                    "platform/*.cc",
+                ],  exclude = [
+                    "**/*test*",
+                    "platform/**/cuda.h",
+                    "platform/**/stream_executor.h",
+                    "platform/load_library.cc",
+                ]),
                 "//conditions:default" : glob([
+                    "lib/**/*.h",
+                    "lib/**/*.cc",
+                    "platform/*.h",
+                    "platform/*.cc",
                     "platform/profile_utils/**/*.h",
                     "platform/profile_utils/**/*.cc",
-                ],
-                exclude = [
+                ],  exclude = [
                     "**/*test*",
                     "platform/**/cuda.h",
                     "platform/**/stream_executor.h",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -513,7 +513,6 @@ cc_library(
         "//tensorflow/core/kernels:control_flow_ops",
         "//tensorflow/core/kernels:ctc_ops",
         "//tensorflow/core/kernels:data_flow",
-        "//tensorflow/core/kernels:fact_op",
         "//tensorflow/core/kernels:function_ops",
         "//tensorflow/core/kernels:image",
         "//tensorflow/core/kernels:io",
@@ -532,7 +531,13 @@ cc_library(
         "//tensorflow/core/kernels:string",
         "//tensorflow/core/kernels:training_ops",
         "//tensorflow/models/embedding:word2vec_kernels",
-    ],
+    ] + if_not_windows([
+        "//tensorflow/core/kernels:fact_op",
+        "//tensorflow/core/kernels:array_not_windows",
+        "//tensorflow/core/kernels:math_not_windows",
+        "//tensorflow/core/kernels:linalg_not_windows",
+        "//tensorflow/core/kernels:logging_not_windows",
+    ]),
 )
 
 tf_cuda_library(

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1090,8 +1090,10 @@ tf_cuda_library(
     ) + select({
         "//tensorflow:windows": [],
         "//conditions:default": glob([
-            "util/memmapped_file_system.*",
-            "util/memmapped_file_system_writer.*",
+            "util/memmapped_file_system.h",
+            "util/memmapped_file_system.cc",
+            "util/memmapped_file_system_writer.h",
+            "util/memmapped_file_system_writer.cc",
         ]),
     }),
     hdrs = [
@@ -1387,7 +1389,9 @@ tf_cuda_library(
         ":lib_internal",
         ":protos_all_cc",
         "//third_party/eigen3",
-    ] + if_not_windows([":stream_executor"]),
+    ] + if_not_windows([
+        ":stream_executor",
+    ]),
     alwayslink = 1,
 )
 

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -379,37 +379,39 @@ cc_header_only_library(
 
 # OpKernel libraries ----------------------------------------------------------
 
+ARRAY_DEPS = [
+    ":batch_space_ops",
+    ":bounds_check",
+    ":concat_lib",
+    ":cuda_device_array",
+    ":depth_space_ops",
+    ":extract_image_patches_op",
+    ":fill_functor",
+    ":gather_functor",
+    ":ops_util",
+    ":split_lib",
+    ":strided_slice_op",
+    ":transpose_functor",
+    "//tensorflow/core:array_grad",
+    "//tensorflow/core:array_ops_op_lib",
+    "//tensorflow/core:core_cpu",
+    "//tensorflow/core:framework",
+    "//tensorflow/core:gpu_runtime",
+    "//tensorflow/core:lib",
+    "//tensorflow/core:lib_internal",
+    "//tensorflow/core:proto_text",
+    "//tensorflow/core:protos_all_cc",
+    "//tensorflow/core/debug:debug_io_utils",
+    "//third_party/eigen3",
+]
+
 tf_kernel_libraries(
     name = "array_not_windows",
     prefixes = [
         "debug_ops",
         "immutable_constant_op",
     ],
-    deps = [
-        ":batchtospace_op",
-        ":bounds_check",
-        ":concat_lib",
-        ":cuda_device_array",
-        ":depth_space_ops",
-        ":extract_image_patches_op",
-        ":fill_functor",
-        ":ops_util",
-        ":spacetobatch_op",
-        ":split_lib",
-        ":strided_slice_op",
-        ":transpose_functor",
-        "//tensorflow/core:array_grad",
-        "//tensorflow/core:array_ops_op_lib",
-        "//tensorflow/core:core_cpu",
-        "//tensorflow/core:framework",
-        "//tensorflow/core:gpu_runtime",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
-        "//tensorflow/core:proto_text",
-        "//tensorflow/core:protos_all_cc",
-        "//tensorflow/core/debug:debug_io_utils",
-        "//third_party/eigen3",
-    ],
+    deps = ARRAY_DEPS,
 )
 
 tf_kernel_libraries(
@@ -445,31 +447,7 @@ tf_kernel_libraries(
         "unpack_op",
         "where_op",
     ],
-    deps = [
-        ":batch_space_ops",
-        ":bounds_check",
-        ":concat_lib",
-        ":cuda_device_array",
-        ":depth_space_ops",
-        ":extract_image_patches_op",
-        ":fill_functor",
-        ":gather_functor",
-        ":ops_util",
-        ":split_lib",
-        ":strided_slice_op",
-        ":transpose_functor",
-        "//tensorflow/core:array_grad",
-        "//tensorflow/core:array_ops_op_lib",
-        "//tensorflow/core:core_cpu",
-        "//tensorflow/core:framework",
-        "//tensorflow/core:gpu_runtime",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
-        "//tensorflow/core:proto_text",
-        "//tensorflow/core:protos_all_cc",
-        "//tensorflow/core/debug:debug_io_utils",
-        "//third_party/eigen3",
-    ],
+    deps = ARRAY_DEPS,
 )
 
 tf_cc_test(
@@ -1321,23 +1299,25 @@ tf_cc_tests(
     ],
 )
 
+MATH_DEPS = [
+    ":bounds_check",
+    ":fill_functor",
+    ":transpose_functor",
+    "//tensorflow/core:core_cpu",
+    "//tensorflow/core:framework",
+    "//tensorflow/core:lib",
+    "//tensorflow/core:lib_internal",
+    "//tensorflow/core:math_grad",
+    "//tensorflow/core:math_ops_op_lib",
+    "//third_party/eigen3",
+]
+
 tf_kernel_libraries(
     name = "math_not_windows",
     prefixes = [
         "sparse_matmul_op",
     ],
-    deps = [
-        ":bounds_check",
-        ":fill_functor",
-        ":transpose_functor",
-        "//tensorflow/core:core_cpu",
-        "//tensorflow/core:framework",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
-        "//tensorflow/core:math_grad",
-        "//tensorflow/core:math_ops_op_lib",
-        "//third_party/eigen3",
-    ],
+    deps = MATH_DEPS,
 )
 
 tf_kernel_libraries(
@@ -1358,18 +1338,7 @@ tf_kernel_libraries(
         "scan_ops",
         "sequence_ops",
     ],
-    deps = [
-        ":bounds_check",
-        ":fill_functor",
-        ":transpose_functor",
-        "//tensorflow/core:core_cpu",
-        "//tensorflow/core:framework",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
-        "//tensorflow/core:math_grad",
-        "//tensorflow/core:math_ops_op_lib",
-        "//third_party/eigen3",
-    ],
+    deps = MATH_DEPS,
 )
 
 tf_cuda_cc_test(

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -1248,20 +1248,6 @@ tf_cc_tests(
 )
 
 tf_kernel_libraries(
-    name = "linalg_not_windows",
-    prefixes = [
-        "svd_op",
-    ],
-    deps = [
-        ":linalg_ops_common",
-        "//tensorflow/core:framework",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:linalg_ops_op_lib",
-        "//third_party/eigen3",
-    ],
-)
-
-tf_kernel_libraries(
     name = "linalg",
     prefixes = [
         "cholesky_op",
@@ -1273,7 +1259,7 @@ tf_kernel_libraries(
         "matrix_solve_ls_op",
         "matrix_solve_op",
         "matrix_triangular_solve_op",
-        # "svd_op",
+        "svd_op",
     ],
     deps = [
         ":linalg_ops_common",
@@ -1297,25 +1283,10 @@ cc_library(
 )
 
 tf_kernel_libraries(
-    name = "logging_not_windows",
-    prefixes = [
-    # This is causing following error on Windows during the linking of tutorial_example_trainer:
-    # LINK : fatal error LNK1000: unknown error at 000000013F8D4241; consult documentation for technical support options
-        "summary_audio_op",
-    ],
-    deps = [
-        "//tensorflow/core:framework",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
-        "//tensorflow/core:logging_ops_op_lib",
-        "//tensorflow/core:protos_all_cc",
-    ],
-)
-
-tf_kernel_libraries(
     name = "logging",
     prefixes = [
         "logging_ops",
+        "summary_audio_op",
         "summary_image_op",
         "summary_op",
         "summary_tensor_op",
@@ -1353,7 +1324,6 @@ tf_cc_tests(
 tf_kernel_libraries(
     name = "math_not_windows",
     prefixes = [
-        "cwise_op",
         "sparse_matmul_op",
     ],
     deps = [
@@ -1380,6 +1350,7 @@ tf_kernel_libraries(
         "cast_op",
         "check_numerics_op",
         "cross_op",
+        "cwise_op",
         "fft_ops",
         "matmul_op",
         "reduction_ops",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -25,6 +25,7 @@ package_group(
 
 load(
     "//tensorflow:tensorflow.bzl",
+    "if_not_windows",
     "tf_cc_test",
     "tf_cc_tests",
     "tf_copts",
@@ -379,13 +380,45 @@ cc_header_only_library(
 # OpKernel libraries ----------------------------------------------------------
 
 tf_kernel_libraries(
+    name = "array_not_windows",
+    prefixes = [
+        "debug_ops",
+        "immutable_constant_op",
+    ],
+    deps = [
+        ":batchtospace_op",
+        ":bounds_check",
+        ":concat_lib",
+        ":cuda_device_array",
+        ":depth_space_ops",
+        ":extract_image_patches_op",
+        ":fill_functor",
+        ":ops_util",
+        ":spacetobatch_op",
+        ":split_lib",
+        ":strided_slice_op",
+        ":transpose_functor",
+        "//tensorflow/core:array_grad",
+        "//tensorflow/core:array_ops_op_lib",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:gpu_runtime",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:proto_text",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core/debug:debug_io_utils",
+        "//third_party/eigen3",
+    ],
+)
+
+tf_kernel_libraries(
     name = "array",
     prefixes = [
         "bcast_ops",
         "bitcast_op",
         "concat_op",
         "constant_op",
-        "debug_ops",
         "diag_op",
         "matrix_band_part_op",
         "matrix_diag_op",
@@ -394,7 +427,6 @@ tf_kernel_libraries(
         "gather_op",
         "gather_nd_op",
         "identity_op",
-        "immutable_constant_op",
         "listdiff_op",
         "mirror_pad_op",
         "one_hot_op",
@@ -1216,6 +1248,20 @@ tf_cc_tests(
 )
 
 tf_kernel_libraries(
+    name = "linalg_not_windows",
+    prefixes = [
+        "svd_op",
+    ],
+    deps = [
+        ":linalg_ops_common",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:linalg_ops_op_lib",
+        "//third_party/eigen3",
+    ],
+)
+
+tf_kernel_libraries(
     name = "linalg",
     prefixes = [
         "cholesky_op",
@@ -1227,7 +1273,7 @@ tf_kernel_libraries(
         "matrix_solve_ls_op",
         "matrix_solve_op",
         "matrix_triangular_solve_op",
-        "svd_op",
+        # "svd_op",
     ],
     deps = [
         ":linalg_ops_common",
@@ -1251,10 +1297,25 @@ cc_library(
 )
 
 tf_kernel_libraries(
+    name = "logging_not_windows",
+    prefixes = [
+    # This is causing following error on Windows during the linking of tutorial_example_trainer:
+    # LINK : fatal error LNK1000: unknown error at 000000013F8D4241; consult documentation for technical support options
+        "summary_audio_op",
+    ],
+    deps = [
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:logging_ops_op_lib",
+        "//tensorflow/core:protos_all_cc",
+    ],
+)
+
+tf_kernel_libraries(
     name = "logging",
     prefixes = [
         "logging_ops",
-        "summary_audio_op",
         "summary_image_op",
         "summary_op",
         "summary_tensor_op",
@@ -1290,6 +1351,26 @@ tf_cc_tests(
 )
 
 tf_kernel_libraries(
+    name = "math_not_windows",
+    prefixes = [
+        "cwise_op",
+        "sparse_matmul_op",
+    ],
+    deps = [
+        ":bounds_check",
+        ":fill_functor",
+        ":transpose_functor",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:math_grad",
+        "//tensorflow/core:math_ops_op_lib",
+        "//third_party/eigen3",
+    ],
+)
+
+tf_kernel_libraries(
     name = "math",
     prefixes = [
         "aggregate_ops",
@@ -1299,14 +1380,12 @@ tf_kernel_libraries(
         "cast_op",
         "check_numerics_op",
         "cross_op",
-        "cwise_op",
         "fft_ops",
         "matmul_op",
         "reduction_ops",
         "segment_reduction_ops",
         "scan_ops",
         "sequence_ops",
-        "sparse_matmul_op",
     ],
     deps = [
         ":bounds_check",
@@ -1597,7 +1676,6 @@ tf_kernel_libraries(
         ":conv_2d",
         ":conv_ops",
         ":depthwise_conv_grad_op",
-        ":depthwise_conv_op",
         ":dilation_ops",
         ":fused_batch_norm_util_gpu",
         ":ops_util",
@@ -1608,7 +1686,9 @@ tf_kernel_libraries(
         "//tensorflow/core:nn_grad",
         "//tensorflow/core:nn_ops_op_lib",
         "//third_party/eigen3",
-    ],
+    ] + if_not_windows([
+        ":depthwise_conv_op",
+    ]),
 )
 
 tf_cuda_cc_test(

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -91,7 +91,7 @@ def tf_proto_library(name, srcs = [], has_services = None,
   )
 
 def tf_additional_lib_hdrs(exclude = []):
-  return  select({
+  return select({
     "//tensorflow:windows" : native.glob([
         "platform/default/*.h",
         "platform/windows/*.h",
@@ -104,7 +104,7 @@ def tf_additional_lib_hdrs(exclude = []):
   })
 
 def tf_additional_lib_srcs(exclude = []):
-  return  select({
+  return select({
     "//tensorflow:windows" : native.glob([
         "platform/default/*.cc",
         "platform/windows/*.cc",

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -94,6 +94,8 @@ def tf_additional_lib_hdrs(exclude = []):
   return  select({
     "//tensorflow:windows" : native.glob([
         "platform/default/*.h",
+        "platform/windows/*.h",
+        "platform/posix/error.h",
       ], exclude = exclude),
     "//conditions:default" : native.glob([
         "platform/default/*.h",
@@ -105,6 +107,8 @@ def tf_additional_lib_srcs(exclude = []):
   return  select({
     "//tensorflow:windows" : native.glob([
         "platform/default/*.cc",
+        "platform/windows/*.cc",
+        "platform/posix/error.cc",
       ], exclude = exclude),
     "//conditions:default" : native.glob([
         "platform/default/*.cc",

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -90,17 +90,27 @@ def tf_proto_library(name, srcs = [], has_services = None,
       visibility = visibility,
   )
 
-def tf_additional_lib_hdrs():
-  return [
-      "platform/default/*.h",
-      "platform/posix/*.h",
-  ]
+def tf_additional_lib_hdrs(exclude = []):
+  return  select({
+    "//tensorflow:windows" : native.glob([
+        "platform/default/*.h",
+      ], exclude = exclude),
+    "//conditions:default" : native.glob([
+        "platform/default/*.h",
+        "platform/posix/*.h",
+      ], exclude = exclude),
+  })
 
-def tf_additional_lib_srcs():
-  return [
-      "platform/default/*.cc",
-      "platform/posix/*.cc",
-  ]
+def tf_additional_lib_srcs(exclude = []):
+  return  select({
+    "//tensorflow:windows" : native.glob([
+        "platform/default/*.cc",
+      ], exclude = exclude),
+    "//conditions:default" : native.glob([
+        "platform/default/*.cc",
+        "platform/posix/*.cc",
+      ], exclude = exclude),
+  })
 
 def tf_additional_minimal_lib_srcs():
   return [

--- a/tensorflow/core/platform/windows/env.cc
+++ b/tensorflow/core/platform/windows/env.cc
@@ -32,6 +32,8 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/windows/windows_file_system.h"
 
+#pragma comment(lib, "Shlwapi.lib")
+
 namespace tensorflow {
 
 namespace {

--- a/tensorflow/core/platform/windows/port.cc
+++ b/tensorflow/core/platform/windows/port.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <snappy.h>
 #endif
 #include <WinSock2.h>
+#pragma comment(lib, "Ws2_32.lib")
 
 #include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/demangle.h"

--- a/tensorflow/core/util/tensor_bundle/BUILD
+++ b/tensorflow/core/util/tensor_bundle/BUILD
@@ -24,6 +24,7 @@ cc_library(
     name = "tensor_bundle",
     srcs = ["tensor_bundle.cc"],
     hdrs = ["tensor_bundle.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:framework",
@@ -34,7 +35,6 @@ cc_library(
         "//tensorflow/core:proto_text",
         "//tensorflow/core:protos_all_cc",
     ],
-    copts = tf_copts(),
 )
 
 cc_test(

--- a/tensorflow/core/util/tensor_bundle/BUILD
+++ b/tensorflow/core/util/tensor_bundle/BUILD
@@ -9,6 +9,8 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+load("//tensorflow:tensorflow.bzl", "tf_copts")
+
 # To be exported to tensorflow/core:android_srcs.
 filegroup(
     name = "android_srcs",
@@ -32,6 +34,7 @@ cc_library(
         "//tensorflow/core:proto_text",
         "//tensorflow/core:protos_all_cc",
     ],
+    copts = tf_copts(),
 )
 
 cc_test(

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -140,6 +140,12 @@ def if_not_mobile(a):
       "//conditions:default": a,
   })
 
+def if_not_windows(a):
+  return select({
+      "//tensorflow:windows": [],
+      "//conditions:default": a,
+  })  
+
 def tf_copts():
   return (["-fno-exceptions", "-DEIGEN_AVOID_STL_ARRAY"] +
           if_cuda(["-DGOOGLE_CUDA=1"]) +

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -157,6 +157,7 @@ def tf_copts():
                     "-O2",
                   ],
                   "//tensorflow:darwin": [],
+                  "//tensorflow:windows": ["/DLANG_CXX11"],
                   "//tensorflow:ios": ["-std=c++11",],
                   "//conditions:default": ["-pthread"]}))
 

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -157,7 +157,10 @@ def tf_copts():
                     "-O2",
                   ],
                   "//tensorflow:darwin": [],
-                  "//tensorflow:windows": ["/DLANG_CXX11"],
+                  "//tensorflow:windows": [
+                    "/DLANG_CXX11",
+                    "/D__VERSION__=\\\"MSVC\\\"",
+                  ],
                   "//tensorflow:ios": ["-std=c++11",],
                   "//conditions:default": ["-pthread"]}))
 

--- a/tensorflow/tools/proto_text/BUILD
+++ b/tensorflow/tools/proto_text/BUILD
@@ -42,12 +42,17 @@ cc_library(
     name = "gen_proto_text_functions_lib",
     srcs = ["gen_proto_text_functions_lib.cc"],
     hdrs = ["gen_proto_text_functions_lib.h"],
-    linkopts = [
-        "-lm",
-        "-lpthread",
-    ] + select({
-        "//tensorflow:darwin": [],
-        "//conditions:default": ["-lrt"],
+    linkopts = select({
+        "//tensorflow:windows": [],
+        "//tensorflow:darwin": [
+            "-lm",
+            "-lpthread",
+        ],
+        "//conditions:default": [
+            "-lm",
+            "-lpthread",
+            "-lrt",
+        ],
     }),
     deps = [
         "//tensorflow/core:lib_proto_parsing",

--- a/third_party/gpus/cuda/platform.bzl.tpl
+++ b/third_party/gpus/cuda/platform.bzl.tpl
@@ -14,6 +14,11 @@ def cuda_library_path(name, version = cuda_sdk_version()):
       return "lib/lib{}.dylib".format(name)
     else:
       return "lib/lib{}.{}.dylib".format(name, version)
+  elif PLATFORM == "Windows":
+    if not version:
+      return "lib/{}.dll".format(name)
+    else:
+      return "lib/{}{}.dll".format(name, version)
   else:
     if not version:
       return "lib64/lib{}.so".format(name)
@@ -23,6 +28,8 @@ def cuda_library_path(name, version = cuda_sdk_version()):
 def cuda_static_library_path(name):
   if PLATFORM == "Darwin":
     return "lib/lib{}_static.a".format(name)
+  elif PLATFORM == "Windows":
+    return "lib/{}_static.lib".format(name)
   else:
     return "lib64/lib{}_static.a".format(name)
 
@@ -32,6 +39,11 @@ def cudnn_library_path(version = cudnn_sdk_version()):
       return "lib/libcudnn.dylib"
     else:
       return "lib/libcudnn.{}.dylib".format(version)
+  elif PLATFORM == "Windows":
+    if not version:
+      return "lib/cudnn.dll"
+    else:
+      return "lib/cudnn{}.dll".format(version)
   else:
     if not version:
       return "lib64/libcudnn.so"
@@ -44,6 +56,11 @@ def cupti_library_path(version = cuda_sdk_version()):
       return "extras/CUPTI/lib/libcupti.dylib"
     else:
       return "extras/CUPTI/lib/libcupti.{}.dylib".format(version)
+  elif PLATFORM == "Windows":
+    if not version:
+      return "extras/CUPTI/lib/cupti.dll"
+    else:
+      return "extras/CUPTI/lib/cupti{}.dll".format(version)
   else:
     if not version:
       return "extras/CUPTI/lib64/libcupti.so"


### PR DESCRIPTION
With these changes, we are able to build the C++ example trainer by 
`bazel build --host_cpu=x64_windows_msvc --cpu=x64_windows_msvc -c opt tensorflow/cc:tutorials_example_trainer` 
with Bazel from HEAD on Windows.
I modified the BUILD files carefully, hopefully it won't break TF build on other platform.
@mrry @damienmg @dslomov
