### PR TITLE
Adjusted buffer size to reduce memory usage and increase performance

### DIFF
--- a/tensorflow/core/kernels/conv_ops_fused.cc
+++ b/tensorflow/core/kernels/conv_ops_fused.cc
@@ -43,8 +43,8 @@ namespace {
 // going to be extremely large, so break it into chunks if it's bigger than
 // a limit. Each chunk will be processed serially, so we can refill the
 // buffer for the next chunk and reuse it, keeping maximum memory size down.
-// In this case, we've picked 16 megabytes as a reasonable limit.
-const size_t kMaxChunkSize = (16 * 1024 * 1024);
+// In this case, we've picked 1 megabyte as a reasonable limit.
+const size_t kMaxChunkSize = (1 * 1024 * 1024);
 
 // Lookup method used when resizing.
 enum SamplingMode {

--- a/tensorflow/core/kernels/conv_ops_using_gemm.cc
+++ b/tensorflow/core/kernels/conv_ops_using_gemm.cc
@@ -256,8 +256,8 @@ class Im2ColConvFunctor {
     // going to be extremely large, so break it into chunks if it's bigger than
     // a limit. Each chunk will be processed serially, so we can refill the
     // buffer for the next chunk and reuse it, keeping maximum memory size down.
-    // In this case, we've picked 16 megabytes as a reasonable limit.
-    const size_t max_chunk_size = (16 * 1024 * 1024);
+    // In this case, we've picked 1 megabyte as a reasonable limit.
+    const size_t max_chunk_size = (1 * 1024 * 1024);
     OP_REQUIRES(context, (filter_value_count * sizeof(T1)) <= max_chunk_size,
                 errors::InvalidArgument("Im2Col patch too large for buffer"));
     const size_t patches_per_chunk =


### PR DESCRIPTION
This small tweak to the im2col buffer size shows improvements in some of our benchmark's latency, and reduces overall memory used.
