### PR TITLE
Fix configure script readlink incompatibility on Darwin.

### DIFF
--- a/configure
+++ b/configure
@@ -216,9 +216,6 @@ while true; do
 
   if [[ -z "$TF_CUDNN_VERSION" ]]; then
     TF_CUDNN_EXT=""
-    # Resolve to the SONAME of the symlink.  Use readlink without -f
-    # to resolve exactly once to the SONAME.  E.g, libcudnn.so ->
-    # libcudnn.so.4
     cudnn_lib_path=""
     cudnn_alt_lib_path=""
     if [ "$OSNAME" == "Linux" ]; then
@@ -228,10 +225,15 @@ while true; do
       cudnn_lib_path="${CUDNN_INSTALL_PATH}/lib/libcudnn.dylib"
       cudnn_alt_lib_path="${CUDNN_INSTALL_PATH}/libcudnn.dylib"
     fi
+    # Resolve to the SONAME of the symlink.  Use readlink without -f
+    # to resolve exactly once to the SONAME.  E.g, libcudnn.so ->
+    # libcudnn.so.4.
+    # If the path is not a symlink, readlink will exit with an error code, so
+    # in that case, we return the path itself.
     if [ -f "$cudnn_lib_path" ]; then
-      REALVAL=`readlink -f ${cudnn_lib_path}`
+      REALVAL=`readlink ${cudnn_lib_path} || echo "${cudnn_lib_path}"`
     else
-      REALVAL=`readlink -f ${cudnn_alt_lib_path}`
+      REALVAL=`readlink ${cudnn_alt_lib_path} || echo "${cudnn_alt_lib_path}"`
     fi
 
     # Extract the version of the SONAME, if it was indeed symlinked to


### PR DESCRIPTION
#4699 introduced a change that broken the build on OS X since `readlink` works

differently.

This change fixes the `readlink` invocations so that they work on both platforms
and avoid failing the `configure` script if the path is not a symlink.
