### PR TITLE
Fix /WHOLEARCHIVE linking on Windows in Bazel build

### DIFF
--- a/tensorflow/core/kernels/fused_batch_norm_op.cu.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cu.cc
@@ -67,4 +67,8 @@ template class InvVarianceToVariance<float>;
 }  // namespace functor
 }  // namespace tensorflow
 
+#else
+
+#include "tensorflow/core/kernels/fused_batch_norm_op.h"
+
 #endif  // GOOGLE_CUDA

--- a/tensorflow/core/kernels/gather_functor.cc
+++ b/tensorflow/core/kernels/gather_functor.cc
@@ -45,4 +45,8 @@ TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPECS);
 }  // namespace functor
 }  // namespace tensorflow
 
+#else
+
+#include "tensorflow/core/kernels/gather_functor.h"
+
 #endif  // GOOGLE_CUDA

--- a/tensorflow/core/kernels/scatter_functor.cc
+++ b/tensorflow/core/kernels/scatter_functor.cc
@@ -55,4 +55,8 @@ TF_CALL_GPU_NUMBER_TYPES_NO_HALF(DECLARE_GPU_SPECS);
 }  // namespace functor
 }  // namespace tensorflow
 
+#else
+
+#include "tensorflow/core/kernels/scatter_functor.h"
+
 #endif  // GOOGLE_CUDA


### PR DESCRIPTION
/WHOLEARCHIVE has a bug linking static library compiled from empty source file.

Fixed related source files by adding some include statements as placeholder.

This change will make users able to use Bazel to build C++ example trainer with Visual Studio 2015 update 2 (or newer verison). Older versions of VS works fine without this change because Bazel will directly link object files instead of using /WHOLEARCHIVE (it's not supported)
@mrry 
