### PR TITLE
Better support for initializing without explicit initializer(issue#4419)

### DIFF
--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -59,6 +59,7 @@ class DType(object):
   @@name
   @@base_dtype
   @@real_dtype
+  @@is_bool
   @@is_floating
   @@is_complex
   @@is_integer
@@ -140,6 +141,11 @@ class DType(object):
   def as_datatype_enum(self):
     """Returns a `types_pb2.DataType` enum value based on this `DType`."""
     return self._type_enum
+
+  @property
+  def is_bool(self):
+    """Returns whether this is a boolean data type"""
+    return self.base_dtype == bool
 
   @property
   def is_integer(self):

--- a/tensorflow/python/kernel_tests/variable_scope_test.py
+++ b/tensorflow/python/kernel_tests/variable_scope_test.py
@@ -22,6 +22,7 @@ import numpy
 import tensorflow as tf
 
 from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import variable_scope
 
@@ -94,6 +95,21 @@ class VariableScopeTest(tf.test.TestCase):
 
       with self.assertRaises(TypeError):
         tf.get_variable("x", initializer={})
+
+  def testInitFromNonInitializer(self):
+    with self.test_session() as sess:
+      # Test various dtypes with zeros initializer as following:
+      types = [tf.int8, tf.uint8, tf.int16, tf.uint16, tf.int32, tf.int64, 
+              tf.bool]
+
+      # Use different varibale_name to distinguish various dtypes
+      for (i, dtype) in enumerate(types):
+        x = tf.get_variable(name='x%d' % i, shape=(3, 4), dtype=dtype)
+        y = tf.get_variable(name='y%d' % i, dtype=dtype, 
+            initializer=init_ops.zeros_initializer(shape=(3, 4), dtype=dtype))
+        
+        tf.global_variables_initializer().run()
+        self.assertAllEqual(x.eval(), y.eval())
 
   def testVarScopeCachingDevice(self):
     with self.test_session():
@@ -671,6 +687,27 @@ def axis0_into3_partitioner(shape=None, **unused_kwargs):
 
 
 class VariableScopeWithPartitioningTest(tf.test.TestCase):
+
+  def testInitFromNonInitializer(self):
+    with self.test_session() as sess:
+      # Test various dtypes with zeros initializer as following:
+      types = [tf.int8, tf.uint8, tf.int16, tf.uint16, tf.int32, tf.int64, 
+              tf.bool]
+
+      # Use different varibale_name to distinguish various dtypes
+      for (i, dtype) in enumerate(types):
+        x = tf.get_variable(name='x%d' % i, shape=(3, 4), dtype=dtype,
+            partitioner=axis0_into2_partitioner)
+        y = tf.get_variable(name='y%d' % i, dtype=dtype, 
+            partitioner=axis0_into2_partitioner,
+            initializer=init_ops.zeros_initializer(shape=(6, 4), dtype=dtype))
+
+        tf.global_variables_initializer().run()
+        # x and y would become var list after partition
+        val_x = sess.run(list(x))
+        val_y = sess.run(list(y))
+
+        self.assertAllEqual(val_x, val_y)
 
   def testResultNameMatchesRequested(self):
     with tf.variable_scope("scope0", partitioner=axis0_into2_partitioner):

--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -525,9 +525,14 @@ class _VariableStore(object):
 
       var_full_name = "%s/part_%d" % (name, i)
       with ops.name_scope(var_full_name + "/PartitionedInitializer"):
+        # Create the tensor to initialize the variable with default value.
         if initializer is None:
-          init = init_ops.uniform_unit_scaling_initializer()
-          init_shape = var_shape
+          init, initializing_from_value = self._get_default_initializer(
+              name=name, shape=shape, dtype=dtype)
+          if initializing_from_value:
+            init_shape = None
+          else:
+            init_shape = var_shape
         elif callable(initializer):
           init = initializer
           init_shape = var_shape
@@ -652,9 +657,10 @@ class _VariableStore(object):
       raise ValueError("Shape of a new variable (%s) must be fully defined, "
                        "but instead was %s." % (name, shape))
 
-    # Create the tensor to initialize the variable.
+    # Create the tensor to initialize the variable with default value.
     if initializer is None:
-      initializer = init_ops.uniform_unit_scaling_initializer()
+      initializer, initializing_from_value = self._get_default_initializer(
+          name=name, shape=shape, dtype=dtype)
     # Clear control dependencies while creating the initializer.
     with ops.control_dependencies(None):
       if initializing_from_value:
@@ -690,6 +696,39 @@ class _VariableStore(object):
           ops.add_to_collection(ops.GraphKeys.REGULARIZATION_LOSSES, loss)
 
     return v
+
+
+  # Initialize variable when no initializer provided
+  def _get_default_initializer(self, name, shape=None, dtype=dtypes.float32):
+    """Provide a default initializer and a corresponding value.
+
+    Args:
+      name: see get_variable.
+      shape: see get_variable.
+      dtype: see get_variable.
+
+    Returns:
+      initializer and initializing_from_value. See get_variable above.
+
+    Raises:
+      ValueError: When giving unsupported dtype.
+    """
+    # If dtype is DT_FLOAT, provide a uniform unit scaling initializer
+    if dtype.is_floating:
+      initializer = init_ops.uniform_unit_scaling_initializer()
+      initializing_from_value = False
+    # If dtype is DT_INT/DT_UINT, provide a default value `zero`
+    # If dtype is DT_BOOL, provide a default value `FALSE`
+    elif dtype.is_integer or dtype.is_unsigned or dtype.is_bool:
+      initializer = init_ops.zeros_initializer(
+          shape=shape, dtype=dtype.base_dtype)
+      initializing_from_value = True
+    # NOTES:Do we need to support for handling DT_STRING and DT_COMPLEX here?
+    else:
+      raise ValueError("An initializer for variable %s of %s is required"
+          % (name, dtype.base_dtype))
+
+    return initializer, initializing_from_value
 
 
 # To stop regularization, use this regularizer


### PR DESCRIPTION
When using `tf.get_variable(name='foo', shape=(42,), dtype=tf.int32)` without explicit initializer, it causes the error:

```
TypeError: Expected int32, got -1.7320508075688772 of type 'float' instead.
```

The reason is as follows:
If no initializer provided, it would use the default initializer `uniform_unit_scaling_initializer` which just fit with `float`(notice that sqrt(3)==1.7320...). While, it always conflict with the required integer dtype.

The current solution is initialize the integer by `init_ops.zeros_initializer` when no initializer provided.

reference the [issus#4419](https://github.com/tensorflow/tensorflow/issues/4419)
