### PR TITLE
Add PIL formats(gif,png...) support for retrain.py

### DIFF
--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -14,37 +14,51 @@
 # ==============================================================================
 """Simple transfer learning with an Inception v3 architecture model which
 displays summaries in TensorBoard.
+
 This example shows how to take a Inception v3 architecture model trained on
 ImageNet images, and train a new top layer that can recognize other classes of
 images.
+
 The top layer receives as input a 2048-dimensional vector for each image. We
 train a softmax layer on top of this representation. Assuming the softmax layer
 contains N labels, this corresponds to learning N + 2048*N model parameters
 corresponding to the learned biases and weights.
+
 Here's an example, which assumes you have a folder containing class-named
 subfolders, each full of images for each label. The example folder flower_photos
 should have a structure like this:
+
 ~/flower_photos/daisy/photo1.jpg
 ~/flower_photos/daisy/photo2.jpg
 ...
 ~/flower_photos/rose/anotherphoto77.jpg
 ...
 ~/flower_photos/sunflower/somepicture.jpg
+
 The subfolder names are important, since they define what label is applied to
 each image, but the filenames themselves don't matter. Once your images are
 prepared, you can run the training with a command like this:
+
 bazel build third_party/tensorflow/examples/image_retraining:retrain && \
 bazel-bin/third_party/tensorflow/examples/image_retraining/retrain \
 --image_dir ~/flower_photos
+
 You can replace the image_dir argument with any folder containing subfolders of
 images. The label for each image is taken from the name of the subfolder it's
 in.
+
 This produces a new model file that can be loaded and run by any TensorFlow
 program, for example the label_image sample code.
+
+
 To use with TensorBoard:
+
 By default, this script will log summaries to /tmp/retrain_logs directory
+
 Visualize the summaries with this command:
+
 tensorboard --logdir /tmp/retrain_logs
+
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -158,13 +172,16 @@ MAX_NUM_IMAGES_PER_CLASS = 2 ** 27 - 1  # ~134M
 
 def create_image_lists(image_dir, testing_percentage, validation_percentage):
   """Builds a list of training images from the file system.
+
   Analyzes the sub folders in the image directory, splits them into stable
   training, testing, and validation sets, and returns a data structure
   describing the lists of images for each label and their paths.
+
   Args:
     image_dir: String path to a folder containing subfolders of images.
     testing_percentage: Integer percentage of the images to reserve for tests.
     validation_percentage: Integer percentage of images reserved for validation.
+
   Returns:
     A dictionary containing an entry for each label subfolder, with images split
     into training, testing, and validation sets within each label.
@@ -180,7 +197,7 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage):
     if is_root_dir:
       is_root_dir = False
       continue
-    extensions = ['jpg', 'jpeg', 'JPG', 'JPEG','gif','png']
+    extensions = ['jpg', 'jpeg', 'JPG', 'JPEG', 'gif', 'png']
     file_list = []
     dir_name = os.path.basename(sub_dir)
     if dir_name == image_dir:
@@ -237,6 +254,7 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage):
 
 def get_image_path(image_lists, label_name, index, image_dir, category):
   """"Returns a path to an image for a label at the given index.
+
   Args:
     image_lists: Dictionary of training images for each label.
     label_name: Label string we want to get an image for.
@@ -246,8 +264,10 @@ def get_image_path(image_lists, label_name, index, image_dir, category):
     images.
     category: Name string of set to pull images from - training, testing, or
     validation.
+
   Returns:
     File system path string to an image that meets the requested parameters.
+
   """
   if label_name not in image_lists:
     tf.logging.fatal('Label does not exist %s.', label_name)
@@ -268,6 +288,7 @@ def get_image_path(image_lists, label_name, index, image_dir, category):
 def get_bottleneck_path(image_lists, label_name, index, bottleneck_dir,
                         category):
   """"Returns a path to a bottleneck file for a label at the given index.
+
   Args:
     image_lists: Dictionary of training images for each label.
     label_name: Label string we want to get an image for.
@@ -276,6 +297,7 @@ def get_bottleneck_path(image_lists, label_name, index, bottleneck_dir,
     bottleneck_dir: Folder string holding cached files of bottleneck values.
     category: Name string of set to pull images from - training, testing, or
     validation.
+
   Returns:
     File system path string to an image that meets the requested parameters.
   """
@@ -285,6 +307,7 @@ def get_bottleneck_path(image_lists, label_name, index, bottleneck_dir,
 
 def create_inception_graph():
   """"Creates a graph from saved GraphDef file and returns a Graph object.
+
   Returns:
     Graph holding the trained Inception network, and various tensors we'll be
     manipulating.
@@ -305,11 +328,13 @@ def create_inception_graph():
 def run_bottleneck_on_image(sess, image_data, image_data_tensor,
                             bottleneck_tensor):
   """Runs inference on an image to extract the 'bottleneck' summary layer.
+
   Args:
     sess: Current active TensorFlow Session.
     image_data: String of raw JPEG data.
     image_data_tensor: Input data layer in the graph.
     bottleneck_tensor: Layer before the final softmax.
+
   Returns:
     Numpy array of bottleneck values.
   """
@@ -322,6 +347,7 @@ def run_bottleneck_on_image(sess, image_data, image_data_tensor,
 
 def maybe_download_and_extract():
   """Download and extract model tar file.
+
   If the pretrained model we're using doesn't already exist, this function
   downloads it from the TensorFlow.org website and unpacks it into a directory.
   """
@@ -349,6 +375,7 @@ def maybe_download_and_extract():
 
 def ensure_dir_exists(dir_name):
   """Makes sure the folder exists on disk.
+
   Args:
     dir_name: Path string to the folder we want to create.
   """
@@ -358,9 +385,11 @@ def ensure_dir_exists(dir_name):
 
 def write_list_of_floats_to_file(list_of_floats , file_path):
   """Writes a given list of floats to a binary file.
+
   Args:
     list_of_floats: List of floats we want to write to a file.
     file_path: Path to a file where list of floats will be stored.
+
   """
 
   s = struct.pack('d' * BOTTLENECK_TENSOR_SIZE, *list_of_floats)
@@ -370,10 +399,12 @@ def write_list_of_floats_to_file(list_of_floats , file_path):
 
 def read_list_of_floats_from_file(file_path):
   """Reads list of floats from a given file.
+
   Args:
     file_path: Path to a file where list of floats was stored.
   Returns:
     Array of bottleneck values (list of floats).
+
   """
 
   with open(file_path, 'rb') as f:
@@ -388,8 +419,10 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
                              category, bottleneck_dir, jpeg_data_tensor,
                              bottleneck_tensor):
   """Retrieves or calculates bottleneck values for an image.
+
   If a cached version of the bottleneck data exists on-disk, return that,
   otherwise calculate the data and save it to disk for future use.
+
   Args:
     sess: The current active TensorFlow Session.
     image_lists: Dictionary of training images for each label.
@@ -403,6 +436,7 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
     bottleneck_dir: Folder string holding cached files of bottleneck values.
     jpeg_data_tensor: The tensor to feed loaded jpeg data into.
     bottleneck_tensor: The output tensor for the bottleneck values.
+
   Returns:
     Numpy array of values produced by the bottleneck layer for the image.
   """
@@ -418,18 +452,17 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
                                 category)
     if not gfile.Exists(image_path):
       tf.logging.fatal('File does not exist %s', image_path)
-
     jpgext = ['jpg', 'jpeg', 'JPG', 'JPEG']
-    if(image_path.split('.')[-1] in jpgext):
-        image_data = gfile.FastGFile(image_path, 'rb').read()
-    else:
-        with BytesIO() as output:
-            with Image.open(image_path) as img:
-                img.convert('RGB').save(output, 'JPEG')
-            image_data = output.getvalue()
+        if (image_path.split('.')[-1] in jpgext):
+            image_data = gfile.FastGFile(image_path, 'rb').read()
+        else:
+            with BytesIO() as output:
+                with Image.open(image_path) as img:
+                    img.convert('RGB').save(output, 'JPEG')
+                image_data = output.getvalue()
     bottleneck_values = run_bottleneck_on_image(sess, image_data,
-                                                jpeg_data_tensor,
-                                                bottleneck_tensor)
+                                                    jpeg_data_tensor,
+                                                    bottleneck_tensor)     
     bottleneck_string = ','.join(str(x) for x in bottleneck_values)
     with open(bottleneck_path, 'w') as bottleneck_file:
       bottleneck_file.write(bottleneck_string)
@@ -443,12 +476,14 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
 def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,
                       jpeg_data_tensor, bottleneck_tensor):
   """Ensures all the training, testing, and validation bottlenecks are cached.
+
   Because we're likely to read the same image multiple times (if there are no
   distortions applied during training) it can speed things up a lot if we
   calculate the bottleneck layer values once for each image during
   preprocessing, and then just read those cached values repeatedly during
   training. Here we go through all the images we've found, calculate those
   values, and save them off.
+
   Args:
     sess: The current active TensorFlow Session.
     image_lists: Dictionary of training images for each label.
@@ -457,6 +492,7 @@ def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,
     bottleneck_dir: Folder string holding cached files of bottleneck values.
     jpeg_data_tensor: Input tensor for jpeg data from file.
     bottleneck_tensor: The penultimate output layer of the graph.
+
   Returns:
     Nothing.
   """
@@ -478,9 +514,11 @@ def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
                                   bottleneck_dir, image_dir, jpeg_data_tensor,
                                   bottleneck_tensor):
   """Retrieves bottleneck values for cached images.
+
   If no distortions are being applied, this function can retrieve the cached
   bottleneck values directly from disk for images. It picks a random set of
   images from the specified category.
+
   Args:
     sess: Current TensorFlow Session.
     image_lists: Dictionary of training images for each label.
@@ -492,6 +530,7 @@ def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
     images.
     jpeg_data_tensor: The layer to feed jpeg image data into.
     bottleneck_tensor: The bottleneck output layer of the CNN graph.
+
   Returns:
     List of bottleneck arrays and their corresponding ground truths.
   """
@@ -517,11 +556,13 @@ def get_random_distorted_bottlenecks(
     sess, image_lists, how_many, category, image_dir, input_jpeg_tensor,
     distorted_image, resized_input_tensor, bottleneck_tensor):
   """Retrieves bottleneck values for training images, after distortions.
+
   If we're training with distortions like crops, scales, or flips, we have to
   recalculate the full model for every image, and so we can't use cached
   bottleneck values. Instead we find random images for the requested category,
   run them through the distortion graph, and then the full graph to get the
   bottleneck results for each.
+
   Args:
     sess: Current TensorFlow Session.
     image_lists: Dictionary of training images for each label.
@@ -534,6 +575,7 @@ def get_random_distorted_bottlenecks(
     distorted_image: The output node of the distortion graph.
     resized_input_tensor: The input node of the recognition graph.
     bottleneck_tensor: The bottleneck output layer of the CNN graph.
+
   Returns:
     List of bottleneck arrays and their corresponding ground truths.
   """
@@ -567,12 +609,14 @@ def get_random_distorted_bottlenecks(
 def should_distort_images(flip_left_right, random_crop, random_scale,
                           random_brightness):
   """Whether any distortions are enabled, from the input flags.
+
   Args:
     flip_left_right: Boolean whether to randomly mirror images horizontally.
     random_crop: Integer percentage setting the total margin used around the
     crop box.
     random_scale: Integer percentage of how much to vary the scale by.
     random_brightness: Integer range to randomly multiply the pixel values by.
+
   Returns:
     Boolean value indicating whether any distortions should be applied.
   """
@@ -583,18 +627,22 @@ def should_distort_images(flip_left_right, random_crop, random_scale,
 def add_input_distortions(flip_left_right, random_crop, random_scale,
                           random_brightness):
   """Creates the operations to apply the specified distortions.
+
   During training it can help to improve the results if we run the images
   through simple distortions like crops, scales, and flips. These reflect the
   kind of variations we expect in the real world, and so can help train the
   model to cope with natural data more effectively. Here we take the supplied
   parameters and construct a network of operations to apply them to an image.
+
   Cropping
   ~~~~~~~~
+
   Cropping is done by placing a bounding box at a random position in the full
   image. The cropping parameter controls the size of that box relative to the
   input image. If it's zero, then the box is the same size as the input and no
   cropping is performed. If the value is 50%, then the crop box will be half the
   width and height of the input. In a diagram it looks like this:
+
   <       width         >
   +---------------------+
   |                     |
@@ -608,13 +656,16 @@ def add_input_distortions(flip_left_right, random_crop, random_scale,
   |                     |
   |                     |
   +---------------------+
+
   Scaling
   ~~~~~~~
+
   Scaling is a lot like cropping, except that the bounding box is always
   centered and its size varies randomly within the given range. For example if
   the scale percentage is zero, then the bounding box is the same size as the
   input and no scaling is applied. If it's 50%, then the bounding box will be in
   a random range between half the width and height and full size.
+
   Args:
     flip_left_right: Boolean whether to randomly mirror images horizontally.
     random_crop: Integer percentage setting the total margin used around the
@@ -622,6 +673,7 @@ def add_input_distortions(flip_left_right, random_crop, random_scale,
     random_scale: Integer percentage of how much to vary the scale by.
     random_brightness: Integer range to randomly multiply the pixel values by.
     graph.
+
   Returns:
     The jpeg input layer and the distorted result tensor.
   """
@@ -676,16 +728,20 @@ def variable_summaries(var, name):
 
 def add_final_training_ops(class_count, final_tensor_name, bottleneck_tensor):
   """Adds a new softmax and fully-connected layer for training.
+
   We need to retrain the top layer to identify our new classes, so this function
   adds the right operations to the graph, along with some variables to hold the
   weights, and then sets up all the gradients for the backward pass.
+
   The set up for the softmax and fully-connected layers is based on:
   https://tensorflow.org/versions/master/tutorials/mnist/beginners/index.html
+
   Args:
     class_count: Integer of how many categories of things we're trying to
     recognize.
     final_tensor_name: Name string for the new final node that produces results.
     bottleneck_tensor: The output of the main CNN graph.
+
   Returns:
     The tensors for the training and cross entropy results, and tensors for the
     bottleneck input and ground truth input.
@@ -733,10 +789,12 @@ def add_final_training_ops(class_count, final_tensor_name, bottleneck_tensor):
 
 def add_evaluation_step(result_tensor, ground_truth_tensor):
   """Inserts the operations we need to evaluate the accuracy of our results.
+
   Args:
     result_tensor: The new final node that produces results.
     ground_truth_tensor: The node we feed ground truth data
     into.
+
   Returns:
     Nothing.
   """

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -481,8 +481,8 @@ def read_image2RGBbytes(image_path):
   Returns:
     Bytes stream for RGB arrays of the image which can be fed directly into image_data_tensor in tensorflow.session.
   """
-  jpgext = ['jpg', 'jpeg', 'JPG', 'JPEG']
-  if (image_path.split('.')[-1] in jpgext):
+  jpgext = ['.jpg', '.jpeg', '.JPG', '.JPEG']
+  if (os.path.splitext(image_path)[1] in jpgext):
     image_data = gfile.FastGFile(image_path, 'rb').read()
   else:
     with BytesIO() as output:

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -470,16 +470,16 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
 
 
 def read_image2RGBbytes(image_path):
-  """Read the image into bytes stream.
+  """Reads the image into a byte stream.
 
-   For jpg/jpeg, gfile.FastGFile is enough.
-   For others like gif, png, use PIL to open them and convert them into RGB arrays. Then save them into bytes stream.
+  For jpg/jpeg, gfile.FastGFile is enough.
+  For others like gif, png, use PIL to open them and convert them into RGB arrays. Then save them into bytes stream.
 
   Args:
     image_path: relative or absolute path of the image.
 
   Returns:
-    Bytes stream for RGB arrays of the image which can be fed directly into image_data_tensor in tensorflow.session.
+    A byte stream for RGB arrays of the image which can be fed directly into image_data_tensor in tensorflow.session.
   """
   jpgext = ['.jpg', '.jpeg', '.JPG', '.JPEG']
   if (os.path.splitext(image_path)[1] in jpgext):

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -472,7 +472,7 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
 def read_image2RGBbytes(image_path):
   """Read images into bytes stream.
 
-   For jpg/jpeg, gfile.FastGFile is enugh
+   For jpg/jpeg, gfile.FastGFile is enough.
    For others like gif, png, use PIL to open them and convert them into RGB arrays. Then save them into bytes stream.
 
   Args:

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -461,8 +461,8 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
                     img.convert('RGB').save(output, 'JPEG')
                 image_data = output.getvalue()
     bottleneck_values = run_bottleneck_on_image(sess, image_data,
-                                                    jpeg_data_tensor,
-                                                    bottleneck_tensor)     
+                                                jpeg_data_tensor,
+                                                bottleneck_tensor)
     bottleneck_string = ','.join(str(x) for x in bottleneck_values)
     with open(bottleneck_path, 'w') as bottleneck_file:
       bottleneck_file.write(bottleneck_string)

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -470,13 +470,13 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
 
 
 def read_image2RGBbytes(image_path):
-  """Read images into bytes stream.
+  """Read the image into bytes stream.
 
    For jpg/jpeg, gfile.FastGFile is enough.
    For others like gif, png, use PIL to open them and convert them into RGB arrays. Then save them into bytes stream.
 
   Args:
-    image_path: relative or absolute path of an image.
+    image_path: relative or absolute path of the image.
 
   Returns:
     Bytes stream for RGB arrays of the image which can be fed directly into image_data_tensor in tensorflow.session.

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -453,13 +453,13 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
     if not gfile.Exists(image_path):
       tf.logging.fatal('File does not exist %s', image_path)
     jpgext = ['jpg', 'jpeg', 'JPG', 'JPEG']
-        if (image_path.split('.')[-1] in jpgext):
-            image_data = gfile.FastGFile(image_path, 'rb').read()
-        else:
-            with BytesIO() as output:
-                with Image.open(image_path) as img:
-                    img.convert('RGB').save(output, 'JPEG')
-                image_data = output.getvalue()
+    if (image_path.split('.')[-1] in jpgext):
+      image_data = gfile.FastGFile(image_path, 'rb').read()
+    else:
+      with BytesIO() as output:
+        with Image.open(image_path) as img:
+          img.convert('RGB').save(output, 'JPEG')
+        image_data = output.getvalue()
     bottleneck_values = run_bottleneck_on_image(sess, image_data,
                                                 jpeg_data_tensor,
                                                 bottleneck_tensor)

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -14,51 +14,37 @@
 # ==============================================================================
 """Simple transfer learning with an Inception v3 architecture model which
 displays summaries in TensorBoard.
-
 This example shows how to take a Inception v3 architecture model trained on
 ImageNet images, and train a new top layer that can recognize other classes of
 images.
-
 The top layer receives as input a 2048-dimensional vector for each image. We
 train a softmax layer on top of this representation. Assuming the softmax layer
 contains N labels, this corresponds to learning N + 2048*N model parameters
 corresponding to the learned biases and weights.
-
 Here's an example, which assumes you have a folder containing class-named
 subfolders, each full of images for each label. The example folder flower_photos
 should have a structure like this:
-
 ~/flower_photos/daisy/photo1.jpg
 ~/flower_photos/daisy/photo2.jpg
 ...
 ~/flower_photos/rose/anotherphoto77.jpg
 ...
 ~/flower_photos/sunflower/somepicture.jpg
-
 The subfolder names are important, since they define what label is applied to
 each image, but the filenames themselves don't matter. Once your images are
 prepared, you can run the training with a command like this:
-
 bazel build third_party/tensorflow/examples/image_retraining:retrain && \
 bazel-bin/third_party/tensorflow/examples/image_retraining/retrain \
 --image_dir ~/flower_photos
-
 You can replace the image_dir argument with any folder containing subfolders of
 images. The label for each image is taken from the name of the subfolder it's
 in.
-
 This produces a new model file that can be loaded and run by any TensorFlow
 program, for example the label_image sample code.
-
-
 To use with TensorBoard:
-
 By default, this script will log summaries to /tmp/retrain_logs directory
-
 Visualize the summaries with this command:
-
 tensorboard --logdir /tmp/retrain_logs
-
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -73,6 +59,8 @@ import re
 import sys
 import tarfile
 
+from PIL import Image
+from io import BytesIO
 import numpy as np
 from six.moves import urllib
 import tensorflow as tf
@@ -170,16 +158,13 @@ MAX_NUM_IMAGES_PER_CLASS = 2 ** 27 - 1  # ~134M
 
 def create_image_lists(image_dir, testing_percentage, validation_percentage):
   """Builds a list of training images from the file system.
-
   Analyzes the sub folders in the image directory, splits them into stable
   training, testing, and validation sets, and returns a data structure
   describing the lists of images for each label and their paths.
-
   Args:
     image_dir: String path to a folder containing subfolders of images.
     testing_percentage: Integer percentage of the images to reserve for tests.
     validation_percentage: Integer percentage of images reserved for validation.
-
   Returns:
     A dictionary containing an entry for each label subfolder, with images split
     into training, testing, and validation sets within each label.
@@ -195,7 +180,7 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage):
     if is_root_dir:
       is_root_dir = False
       continue
-    extensions = ['jpg', 'jpeg', 'JPG', 'JPEG']
+    extensions = ['jpg', 'jpeg', 'JPG', 'JPEG','gif','png']
     file_list = []
     dir_name = os.path.basename(sub_dir)
     if dir_name == image_dir:
@@ -252,7 +237,6 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage):
 
 def get_image_path(image_lists, label_name, index, image_dir, category):
   """"Returns a path to an image for a label at the given index.
-
   Args:
     image_lists: Dictionary of training images for each label.
     label_name: Label string we want to get an image for.
@@ -262,10 +246,8 @@ def get_image_path(image_lists, label_name, index, image_dir, category):
     images.
     category: Name string of set to pull images from - training, testing, or
     validation.
-
   Returns:
     File system path string to an image that meets the requested parameters.
-
   """
   if label_name not in image_lists:
     tf.logging.fatal('Label does not exist %s.', label_name)
@@ -286,7 +268,6 @@ def get_image_path(image_lists, label_name, index, image_dir, category):
 def get_bottleneck_path(image_lists, label_name, index, bottleneck_dir,
                         category):
   """"Returns a path to a bottleneck file for a label at the given index.
-
   Args:
     image_lists: Dictionary of training images for each label.
     label_name: Label string we want to get an image for.
@@ -295,7 +276,6 @@ def get_bottleneck_path(image_lists, label_name, index, bottleneck_dir,
     bottleneck_dir: Folder string holding cached files of bottleneck values.
     category: Name string of set to pull images from - training, testing, or
     validation.
-
   Returns:
     File system path string to an image that meets the requested parameters.
   """
@@ -305,7 +285,6 @@ def get_bottleneck_path(image_lists, label_name, index, bottleneck_dir,
 
 def create_inception_graph():
   """"Creates a graph from saved GraphDef file and returns a Graph object.
-
   Returns:
     Graph holding the trained Inception network, and various tensors we'll be
     manipulating.
@@ -326,13 +305,11 @@ def create_inception_graph():
 def run_bottleneck_on_image(sess, image_data, image_data_tensor,
                             bottleneck_tensor):
   """Runs inference on an image to extract the 'bottleneck' summary layer.
-
   Args:
     sess: Current active TensorFlow Session.
     image_data: String of raw JPEG data.
     image_data_tensor: Input data layer in the graph.
     bottleneck_tensor: Layer before the final softmax.
-
   Returns:
     Numpy array of bottleneck values.
   """
@@ -345,7 +322,6 @@ def run_bottleneck_on_image(sess, image_data, image_data_tensor,
 
 def maybe_download_and_extract():
   """Download and extract model tar file.
-
   If the pretrained model we're using doesn't already exist, this function
   downloads it from the TensorFlow.org website and unpacks it into a directory.
   """
@@ -373,7 +349,6 @@ def maybe_download_and_extract():
 
 def ensure_dir_exists(dir_name):
   """Makes sure the folder exists on disk.
-
   Args:
     dir_name: Path string to the folder we want to create.
   """
@@ -383,11 +358,9 @@ def ensure_dir_exists(dir_name):
 
 def write_list_of_floats_to_file(list_of_floats , file_path):
   """Writes a given list of floats to a binary file.
-
   Args:
     list_of_floats: List of floats we want to write to a file.
     file_path: Path to a file where list of floats will be stored.
-
   """
 
   s = struct.pack('d' * BOTTLENECK_TENSOR_SIZE, *list_of_floats)
@@ -397,12 +370,10 @@ def write_list_of_floats_to_file(list_of_floats , file_path):
 
 def read_list_of_floats_from_file(file_path):
   """Reads list of floats from a given file.
-
   Args:
     file_path: Path to a file where list of floats was stored.
   Returns:
     Array of bottleneck values (list of floats).
-
   """
 
   with open(file_path, 'rb') as f:
@@ -417,10 +388,8 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
                              category, bottleneck_dir, jpeg_data_tensor,
                              bottleneck_tensor):
   """Retrieves or calculates bottleneck values for an image.
-
   If a cached version of the bottleneck data exists on-disk, return that,
   otherwise calculate the data and save it to disk for future use.
-
   Args:
     sess: The current active TensorFlow Session.
     image_lists: Dictionary of training images for each label.
@@ -434,7 +403,6 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
     bottleneck_dir: Folder string holding cached files of bottleneck values.
     jpeg_data_tensor: The tensor to feed loaded jpeg data into.
     bottleneck_tensor: The output tensor for the bottleneck values.
-
   Returns:
     Numpy array of values produced by the bottleneck layer for the image.
   """
@@ -450,7 +418,15 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
                                 category)
     if not gfile.Exists(image_path):
       tf.logging.fatal('File does not exist %s', image_path)
-    image_data = gfile.FastGFile(image_path, 'rb').read()
+
+    jpgext = ['jpg', 'jpeg', 'JPG', 'JPEG']
+    if(image_path.split('.')[-1] in jpgext):
+        image_data = gfile.FastGFile(image_path, 'rb').read()
+    else:
+        with BytesIO() as output:
+            with Image.open(image_path) as img:
+                img.convert('RGB').save(output, 'JPEG')
+            image_data = output.getvalue()
     bottleneck_values = run_bottleneck_on_image(sess, image_data,
                                                 jpeg_data_tensor,
                                                 bottleneck_tensor)
@@ -467,14 +443,12 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
 def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,
                       jpeg_data_tensor, bottleneck_tensor):
   """Ensures all the training, testing, and validation bottlenecks are cached.
-
   Because we're likely to read the same image multiple times (if there are no
   distortions applied during training) it can speed things up a lot if we
   calculate the bottleneck layer values once for each image during
   preprocessing, and then just read those cached values repeatedly during
   training. Here we go through all the images we've found, calculate those
   values, and save them off.
-
   Args:
     sess: The current active TensorFlow Session.
     image_lists: Dictionary of training images for each label.
@@ -483,7 +457,6 @@ def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,
     bottleneck_dir: Folder string holding cached files of bottleneck values.
     jpeg_data_tensor: Input tensor for jpeg data from file.
     bottleneck_tensor: The penultimate output layer of the graph.
-
   Returns:
     Nothing.
   """
@@ -505,11 +478,9 @@ def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
                                   bottleneck_dir, image_dir, jpeg_data_tensor,
                                   bottleneck_tensor):
   """Retrieves bottleneck values for cached images.
-
   If no distortions are being applied, this function can retrieve the cached
   bottleneck values directly from disk for images. It picks a random set of
   images from the specified category.
-
   Args:
     sess: Current TensorFlow Session.
     image_lists: Dictionary of training images for each label.
@@ -521,7 +492,6 @@ def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
     images.
     jpeg_data_tensor: The layer to feed jpeg image data into.
     bottleneck_tensor: The bottleneck output layer of the CNN graph.
-
   Returns:
     List of bottleneck arrays and their corresponding ground truths.
   """
@@ -547,13 +517,11 @@ def get_random_distorted_bottlenecks(
     sess, image_lists, how_many, category, image_dir, input_jpeg_tensor,
     distorted_image, resized_input_tensor, bottleneck_tensor):
   """Retrieves bottleneck values for training images, after distortions.
-
   If we're training with distortions like crops, scales, or flips, we have to
   recalculate the full model for every image, and so we can't use cached
   bottleneck values. Instead we find random images for the requested category,
   run them through the distortion graph, and then the full graph to get the
   bottleneck results for each.
-
   Args:
     sess: Current TensorFlow Session.
     image_lists: Dictionary of training images for each label.
@@ -566,7 +534,6 @@ def get_random_distorted_bottlenecks(
     distorted_image: The output node of the distortion graph.
     resized_input_tensor: The input node of the recognition graph.
     bottleneck_tensor: The bottleneck output layer of the CNN graph.
-
   Returns:
     List of bottleneck arrays and their corresponding ground truths.
   """
@@ -600,14 +567,12 @@ def get_random_distorted_bottlenecks(
 def should_distort_images(flip_left_right, random_crop, random_scale,
                           random_brightness):
   """Whether any distortions are enabled, from the input flags.
-
   Args:
     flip_left_right: Boolean whether to randomly mirror images horizontally.
     random_crop: Integer percentage setting the total margin used around the
     crop box.
     random_scale: Integer percentage of how much to vary the scale by.
     random_brightness: Integer range to randomly multiply the pixel values by.
-
   Returns:
     Boolean value indicating whether any distortions should be applied.
   """
@@ -618,22 +583,18 @@ def should_distort_images(flip_left_right, random_crop, random_scale,
 def add_input_distortions(flip_left_right, random_crop, random_scale,
                           random_brightness):
   """Creates the operations to apply the specified distortions.
-
   During training it can help to improve the results if we run the images
   through simple distortions like crops, scales, and flips. These reflect the
   kind of variations we expect in the real world, and so can help train the
   model to cope with natural data more effectively. Here we take the supplied
   parameters and construct a network of operations to apply them to an image.
-
   Cropping
   ~~~~~~~~
-
   Cropping is done by placing a bounding box at a random position in the full
   image. The cropping parameter controls the size of that box relative to the
   input image. If it's zero, then the box is the same size as the input and no
   cropping is performed. If the value is 50%, then the crop box will be half the
   width and height of the input. In a diagram it looks like this:
-
   <       width         >
   +---------------------+
   |                     |
@@ -647,16 +608,13 @@ def add_input_distortions(flip_left_right, random_crop, random_scale,
   |                     |
   |                     |
   +---------------------+
-
   Scaling
   ~~~~~~~
-
   Scaling is a lot like cropping, except that the bounding box is always
   centered and its size varies randomly within the given range. For example if
   the scale percentage is zero, then the bounding box is the same size as the
   input and no scaling is applied. If it's 50%, then the bounding box will be in
   a random range between half the width and height and full size.
-
   Args:
     flip_left_right: Boolean whether to randomly mirror images horizontally.
     random_crop: Integer percentage setting the total margin used around the
@@ -664,7 +622,6 @@ def add_input_distortions(flip_left_right, random_crop, random_scale,
     random_scale: Integer percentage of how much to vary the scale by.
     random_brightness: Integer range to randomly multiply the pixel values by.
     graph.
-
   Returns:
     The jpeg input layer and the distorted result tensor.
   """
@@ -719,20 +676,16 @@ def variable_summaries(var, name):
 
 def add_final_training_ops(class_count, final_tensor_name, bottleneck_tensor):
   """Adds a new softmax and fully-connected layer for training.
-
   We need to retrain the top layer to identify our new classes, so this function
   adds the right operations to the graph, along with some variables to hold the
   weights, and then sets up all the gradients for the backward pass.
-
   The set up for the softmax and fully-connected layers is based on:
   https://tensorflow.org/versions/master/tutorials/mnist/beginners/index.html
-
   Args:
     class_count: Integer of how many categories of things we're trying to
     recognize.
     final_tensor_name: Name string for the new final node that produces results.
     bottleneck_tensor: The output of the main CNN graph.
-
   Returns:
     The tensors for the training and cross entropy results, and tensors for the
     bottleneck input and ground truth input.
@@ -780,12 +733,10 @@ def add_final_training_ops(class_count, final_tensor_name, bottleneck_tensor):
 
 def add_evaluation_step(result_tensor, ground_truth_tensor):
   """Inserts the operations we need to evaluate the accuracy of our results.
-
   Args:
     result_tensor: The new final node that produces results.
     ground_truth_tensor: The node we feed ground truth data
     into.
-
   Returns:
     Nothing.
   """


### PR DESCRIPTION
- Add PIL formats(gif,png...) support for retrain.py.
- Use PIL.Image to read images and io.BytesIO to serialize them.
