### PR TITLE
Updates to documentation of two tf.contrib.metrics functions.

### DIFF
--- a/tensorflow/contrib/metrics/python/ops/confusion_matrix_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/confusion_matrix_ops.py
@@ -33,26 +33,27 @@ def confusion_matrix(predictions, labels, num_classes=None, dtype=dtypes.int32,
   Calculate the Confusion Matrix for a pair of prediction and
   label 1-D int arrays.
 
-  Considering a prediction array such as: `[1, 2, 3]`
-  And a label array such as: `[2, 2, 3]`
-
-  The confusion matrix returned would be the following one:
-
-  ```python
-      [[0, 0, 0]
-       [0, 1, 0]
-       [0, 1, 0]
-       [0, 0, 1]]
-  ```
-
-  If `weights` is not None, then the confusion matrix elements are the
-  corresponding `weights` elements.
-
-  Where the matrix rows represent the prediction labels and the columns
+  The matrix rows represent the prediction labels and the columns
   represents the real labels. The confusion matrix is always a 2-D array
-  of shape [n, n], where n is the number of valid labels for a given
+  of shape `[n, n]`, where `n` is the number of valid labels for a given
   classification task. Both prediction and labels must be 1-D arrays of
   the same shape in order for this function to work.
+
+  Class labels are expected to start at 0. E.g., if there were
+  three classes then the possible labels would be `[0, 1, 2]`.
+
+  If `weights` is not `None`, then each prediction contributes its
+  corresponding weight to the total value of the confusion matrix cell.
+
+  For example:
+
+  ```python
+    tf.contrib.metrics.confusion_matrix([1, 2, 3], [2, 2, 3]) ==>
+      [[0, 0, 0, 0]
+       [0, 0, 1, 0]
+       [0, 0, 1, 0]
+       [0, 0, 0, 1]]
+  ```
 
   Args:
     predictions: A 1-D array representing the predictions for a given

--- a/tensorflow/contrib/metrics/python/ops/confusion_matrix_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/confusion_matrix_ops.py
@@ -39,8 +39,10 @@ def confusion_matrix(predictions, labels, num_classes=None, dtype=dtypes.int32,
   classification task. Both prediction and labels must be 1-D arrays of
   the same shape in order for this function to work.
 
-  Class labels are expected to start at 0. E.g., if there were
-  three classes then the possible labels would be `[0, 1, 2]`.
+  If `num_classes` is None, then `num_classes` will be set to the one plus
+  the maximum value in either predictions or labels.
+  Class labels are expected to start at 0. E.g., if `num_classes` was
+  three, then the possible labels would be `[0, 1, 2]`.
 
   If `weights` is not `None`, then each prediction contributes its
   corresponding weight to the total value of the confusion matrix cell.
@@ -48,12 +50,16 @@ def confusion_matrix(predictions, labels, num_classes=None, dtype=dtypes.int32,
   For example:
 
   ```python
-    tf.contrib.metrics.confusion_matrix([1, 2, 3], [2, 2, 3]) ==>
-      [[0, 0, 0, 0]
-       [0, 0, 1, 0]
-       [0, 0, 1, 0]
-       [0, 0, 0, 1]]
+    tf.contrib.metrics.confusion_matrix([1, 2, 4], [2, 2, 4]) ==>
+        [[0 0 0 0 0]
+         [0 0 1 0 0]
+         [0 0 1 0 0]
+         [0 0 0 0 0]
+         [0 0 0 0 1]]
   ```
+
+  Note that the possible labels are assumed to be `[0, 1, 2, 3, 4]`,
+  resulting in a 5x5 confusion matrix.
 
   Args:
     predictions: A 1-D array representing the predictions for a given

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -2900,6 +2900,7 @@ def aggregate_metric_map(names_to_tuples):
   This function is useful for pairing metric names with their associated value
   and update ops when the list of metrics is long. For example:
 
+  ```python
     metrics_to_values, metrics_to_updates = slim.metrics.aggregate_metric_map({
         'Mean Absolute Error': new_slim.metrics.streaming_mean_absolute_error(
             predictions, labels, weights),
@@ -2910,6 +2911,7 @@ def aggregate_metric_map(names_to_tuples):
         'RMSE Log': new_slim.metrics.streaming_root_mean_squared_error(
             predictions, labels, weights),
     })
+  ```
 
   Args:
     names_to_tuples: a map of metric names to tuples, each of which contain the


### PR DESCRIPTION
- Added code wrapping markdown for function `tf.contrib.metrics.aggregate_metrics`.
- General editing of `tf.contrib.metrics.confusion_matrix` for clarity.
