### PR TITLE
Removed orphaned declaration of extern "C" void RegisterOps(void *)

### DIFF
--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -964,8 +964,6 @@ typedef struct TF_Library TF_Library;
 // Pass "library_filename" to a platform-specific mechanism for dynamically
 // loading a library. The rules for determining the exact location of the
 // library are platform-specific and are not documented here.
-// Expects the symbols "RegisterKernels", and "GetOpList", to be
-// defined in the library.
 //
 // On success, place OK in status and return the newly created library handle.
 // The caller owns the library handle.

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -964,7 +964,7 @@ typedef struct TF_Library TF_Library;
 // Pass "library_filename" to a platform-specific mechanism for dynamically
 // loading a library. The rules for determining the exact location of the
 // library are platform-specific and are not documented here.
-// Expects the symbols "RegisterOps", "RegisterKernels", and "GetOpList", to be
+// Expects the symbols "RegisterKernels", and "GetOpList", to be
 // defined in the library.
 //
 // On success, place OK in status and return the newly created library handle.

--- a/tensorflow/core/framework/op.h
+++ b/tensorflow/core/framework/op.h
@@ -171,12 +171,6 @@ class OpListOpRegistry : public OpRegistryInterface {
   std::unordered_map<string, const OpRegistrationData*> index_;
 };
 
-// Treats 'registry_ptr' as a pointer to OpRegistry, and calls
-// registry_ptr->Register(op_def) for each op_def that has been registered with
-// the current library's global op registry (obtained by calling
-// OpRegistry::Global().
-extern "C" void RegisterOps(void* registry_ptr);
-
 // Support for defining the OpDef (specifying the semantics of the Op and how
 // it should be created) and registering it in the OpRegistry::Global()
 // registry.  Usage:

--- a/tensorflow/core/framework/op_kernel.h
+++ b/tensorflow/core/framework/op_kernel.h
@@ -1105,11 +1105,6 @@ void* GlobalKernelRegistry();
 Status FindKernelDef(DeviceType device_type, const NodeDef& node_def,
                      const KernelDef** def, string* kernel_class_name);
 
-// Treats 'registry_ptr' as a pointer to KernelRegistry. For each kernel 'k'
-// registered with the current library's global kernel registry (obtained by
-// calling GlobalKernelRegistry()), inserts 'k' into registry_ptr.
-extern "C" void RegisterKernels(void* registry_ptr);
-
 // Writes a list of all registered kernels to LOG(INFO), to help users debug
 // missing kernel errors.
 void LogAllRegisteredKernels();


### PR DESCRIPTION
In op.h the declaration of `extern "C" void RegisterOps(void *)` was missed when removing it's implementation in e774fa829a1d74ab2d410cefc62cbd47e20b0317. This PR removes the orphaned declaration.
