### PR TITLE
Switch stream_executor to use portable dlopen()

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_blas.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas.cc
@@ -33,8 +33,6 @@ limitations under the License.
 
 #include "tensorflow/stream_executor/cuda/cuda_blas.h"
 
-#include <dlfcn.h>
-
 #include <complex>
 
 #include "tensorflow/stream_executor/cuda/cuda_activation.h"
@@ -44,6 +42,7 @@ limitations under the License.
 #include "tensorflow/stream_executor/cuda/cuda_stream.h"
 #include "tensorflow/stream_executor/device_memory.h"
 #include "tensorflow/stream_executor/dso_loader.h"
+#include "tensorflow/stream_executor/lib/env.h"
 #include "tensorflow/stream_executor/lib/initialize.h"
 #include "tensorflow/stream_executor/lib/status.h"
 #include "tensorflow/stream_executor/lib/status_macros.h"
@@ -71,14 +70,20 @@ namespace dynload {
       static auto status = internal::CachedDsoLoader::GetCublasDsoHandle(); \
       return status.ValueOrDie();                                           \
     }                                                                       \
-    static FuncPointerT DynLoad() {                                         \
-      static void *f = dlsym(GetDsoHandle(), kName);                        \
-      CHECK(f != nullptr) << "could not find " << kName                     \
-                          << " in cuBLAS DSO; dlerror: " << dlerror();      \
+    static FuncPointerT LoadOrDie() {                                       \
+      void *f;                                                              \
+      port::Status s = port::Env::Default()->GetSymbolFromLibrary(          \
+          GetDsoHandle(), kName, &f);                                       \
+      CHECK(s.ok()) << "could not find " << kName                           \
+                    << " in cuBLAS DSO; dlerror: " << s.error_message();    \
       return reinterpret_cast<FuncPointerT>(f);                             \
     }                                                                       \
+    static FuncPointerT DynLoad() {                                         \
+      static FuncPointerT f = LoadOrDie();                                  \
+      return f;                                                             \
+    }                                                                       \
     template <typename... Args>                                             \
-    cublasStatus_t operator()(CUDAExecutor * parent, Args... args) {        \
+    cublasStatus_t operator()(CUDAExecutor *parent, Args... args) {         \
       cuda::ScopedActivateExecutorContext sac{parent};                      \
       return DynLoad()(args...);                                            \
     }                                                                       \

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/stream_executor/cuda/cuda_dnn.h"
 
-#include <dlfcn.h>
 #include <functional>
 #include <memory>
 
@@ -137,36 +136,47 @@ void* GetDsoHandle() {
   return result.ValueOrDie();
 }
 
-// Calls cudnnGetVersion in the loaded DSO.
-size_t cudnnGetVersion() {
-  static void* f = dlsym(GetDsoHandle(), "cudnnGetVersion");
+static void* DynLoadGetVersionOrDie() {
+  void* f;
+  port::Status s = port::Env::Default()->GetSymbolFromLibrary(
+      GetDsoHandle(), "cudnnGetVersion", &f);
   if (f == nullptr) {
     LOG(FATAL) << "could not find cudnnGetVersion in cudnn DSO; dlerror: "
-               << dlerror();
+               << s.error_message();
   }
+  return f;
+}
+
+// Calls cudnnGetVersion in the loaded DSO.
+size_t cudnnGetVersion() {
+  static void* f = DynLoadGetVersionOrDie();
   auto callable = reinterpret_cast<size_t (*)(void)>(f);
   return callable();
 }
 
-#define PERFTOOLS_GPUTOOLS_CUDNN_WRAP(__name)                        \
-  struct DynLoadShim__##__name {                                     \
-    static const char* kName;                                        \
-    typedef std::add_pointer<decltype(::__name)>::type FuncPointerT; \
-    static FuncPointerT DynLoad() {                                  \
-      static void* f = dlsym(GetDsoHandle(), kName);                 \
-      if (f == nullptr) {                                            \
-        LOG(FATAL) << "could not find " << kName                     \
-                   << " in cudnn DSO; dlerror: " << dlerror();       \
-      }                                                              \
-      return reinterpret_cast<FuncPointerT>(f);                      \
-    }                                                                \
-    template <typename... Args>                                      \
-    cudnnStatus_t operator()(CUDAExecutor* parent, Args... args) {   \
-      cuda::ScopedActivateExecutorContext sac{parent};               \
-      cudnnStatus_t retval = DynLoad()(args...);                     \
-      return retval;                                                 \
-    }                                                                \
-  } __name;                                                          \
+#define PERFTOOLS_GPUTOOLS_CUDNN_WRAP(__name)                           \
+  struct DynLoadShim__##__name {                                        \
+    static const char* kName;                                           \
+    typedef std::add_pointer<decltype(::__name)>::type FuncPointerT;    \
+    static FuncPointerT LoadOrDie() {                                   \
+      void* f;                                                          \
+      port::Status s = port::Env::Default()->GetSymbolFromLibrary(      \
+          GetDsoHandle(), kName, &f);                                   \
+      CHECK(s.ok()) << "could not find " << kName                       \
+                    << " in cudnn DSO; dlerror: " << s.error_message(); \
+      return reinterpret_cast<FuncPointerT>(f);                         \
+    }                                                                   \
+    static FuncPointerT DynLoad() {                                     \
+      static FuncPointerT f = LoadOrDie();                              \
+      return f;                                                         \
+    }                                                                   \
+    template <typename... Args>                                         \
+    cudnnStatus_t operator()(CUDAExecutor* parent, Args... args) {      \
+      cuda::ScopedActivateExecutorContext sac{parent};                  \
+      cudnnStatus_t retval = DynLoad()(args...);                        \
+      return retval;                                                    \
+    }                                                                   \
+  } __name;                                                             \
   const char* DynLoadShim__##__name::kName = #__name;
 
 // clang-format off

--- a/tensorflow/stream_executor/cuda/cuda_driver.cc
+++ b/tensorflow/stream_executor/cuda/cuda_driver.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/stream_executor/cuda/cuda_driver.h"
 
-#include <dlfcn.h>
 #include <map>
 #include <stdint.h>
 #include <stdlib.h>
@@ -53,25 +52,29 @@ namespace cuda {
 
 namespace dynload {
 
-#define PERFTOOLS_GPUTOOLS_LIBCUDA_WRAP(__name)                              \
-  struct DynLoadShim__##__name {                                             \
-    static const char *kName;                                                \
-    using FuncPointerT = std::add_pointer<decltype(::__name)>::type;         \
-    static void *GetDsoHandle() {                                            \
-      static auto status = internal::CachedDsoLoader::GetLibcudaDsoHandle(); \
-      return status.ValueOrDie();                                            \
-    }                                                                        \
-    static FuncPointerT DynLoad() {                                          \
-      static void *f = dlsym(GetDsoHandle(), kName);                         \
-      CHECK(f != nullptr) << "could not find " << kName                      \
-                          << "in libcuda DSO; dlerror: " << dlerror();       \
-      return reinterpret_cast<FuncPointerT>(f);                              \
-    }                                                                        \
-    template <typename... Args>                                              \
-    CUresult operator()(Args... args) {                                      \
-      return DynLoad()(args...);                                             \
-    }                                                                        \
-  } __name;                                                                  \
+#define PERFTOOLS_GPUTOOLS_CUDNN_WRAP(__name)                           \
+  struct DynLoadShim__##__name {                                        \
+    static const char *kName;                                           \
+    typedef std::add_pointer<decltype(::__name)>::type FuncPointerT;    \
+    static FuncPointerT LoadOrDie() {                                   \
+      void *f;                                                          \
+      port::Status s = port::Env::Default()->GetSymbolFromLibrary(      \
+          GetDsoHandle(), kName, &f);                                   \
+      CHECK(s.ok()) << "could not find " << kName                       \
+                    << " in cudnn DSO; dlerror: " << s.error_message(); \
+      return reinterpret_cast<FuncPointerT>(f);                         \
+    }                                                                   \
+    static FuncPointerT DynLoad() {                                     \
+      static FuncPointerT f = LoadOrDie();                              \
+      return f;                                                         \
+    }                                                                   \
+    template <typename... Args>                                         \
+    cudnnStatus_t operator()(CUDAExecutor *parent, Args... args) {      \
+      cuda::ScopedActivateExecutorContext sac{parent};                  \
+      cudnnStatus_t retval = DynLoad()(args...);                        \
+      return retval;                                                    \
+    }                                                                   \
+  } __name;                                                             \
   const char *DynLoadShim__##__name::kName = #__name;
 
 PERFTOOLS_GPUTOOLS_LIBCUDA_WRAP(cuCtxCreate_v2);

--- a/tensorflow/stream_executor/cuda/cuda_fft.cc
+++ b/tensorflow/stream_executor/cuda/cuda_fft.cc
@@ -45,28 +45,28 @@ namespace dynload {
 // manner on first use. This dynamic loading technique is used to avoid DSO
 // dependencies on vendor libraries which may or may not be available in the
 // deployed binary environment.
-#define PERFTOOLS_GPUTOOLS_CUFFT_WRAP(__name)                                  \
-  struct DynLoadShim__##__name {                                               \
-    static const char *kName;                                                  \
-    using FuncPointerT = std::add_pointer<decltype(::__name)>::type;           \
-    static void *GetDsoHandle() {                                              \
-      static auto status = internal::CachedDsoLoader::GetCufftDsoHandle();     \
-      return status.ValueOrDie();                                              \
-    }                                                                          \
-    static FuncPointerT DynLoad() {                                            \
-      static void *f;                                                          \
-      port::Status s =                                                         \
-          port::Env::Default->GetSymbolFromLibrary(GetDsoHandle(), kName, &f); \
-      CHECK(s.ok()) << "could not find " << kName                              \
-                    << " in cuFFT DSO; dlerror: " << s.error_message();        \
-      return reinterpret_cast<FuncPointerT>(f);                                \
-    }                                                                          \
-    template <typename... Args>                                                \
-    cufftResult operator()(CUDAExecutor *parent, Args... args) {               \
-      cuda::ScopedActivateExecutorContext sac{parent};                         \
-      return DynLoad()(args...);                                               \
-    }                                                                          \
-  } __name;                                                                    \
+#define PERFTOOLS_GPUTOOLS_CUFFT_WRAP(__name)                              \
+  struct DynLoadShim__##__name {                                           \
+    static const char *kName;                                              \
+    using FuncPointerT = std::add_pointer<decltype(::__name)>::type;       \
+    static void *GetDsoHandle() {                                          \
+      static auto status = internal::CachedDsoLoader::GetCufftDsoHandle(); \
+      return status.ValueOrDie();                                          \
+    }                                                                      \
+    static FuncPointerT DynLoad() {                                        \
+      static void *f;                                                      \
+      port::Status s = port::Env::Default()->GetSymbolFromLibrary(         \
+          GetDsoHandle(), kName, &f);                                      \
+      CHECK(s.ok()) << "could not find " << kName                          \
+                    << " in cuFFT DSO; dlerror: " << s.error_message();    \
+      return reinterpret_cast<FuncPointerT>(f);                            \
+    }                                                                      \
+    template <typename... Args>                                            \
+    cufftResult operator()(CUDAExecutor *parent, Args... args) {           \
+      cuda::ScopedActivateExecutorContext sac{parent};                     \
+      return DynLoad()(args...);                                           \
+    }                                                                      \
+  } __name;                                                                \
   const char *DynLoadShim__##__name::kName = #__name;
 
 #define CUFFT_ROUTINE_EACH(__macro)                                         \

--- a/tensorflow/stream_executor/cuda/cuda_fft.cc
+++ b/tensorflow/stream_executor/cuda/cuda_fft.cc
@@ -57,7 +57,7 @@ namespace dynload {
       static void *f;                                                          \
       port::Status s =                                                         \
           port::Env::Default->GetSymbolFromLibrary(GetDsoHandle(), kName, &f); \
-      CHECK(f.ok()) << "could not find " << kName                              \
+      CHECK(s.ok()) << "could not find " << kName                              \
                     << " in cuFFT DSO; dlerror: " << s.error_message();        \
       return reinterpret_cast<FuncPointerT>(f);                                \
     }                                                                          \

--- a/tensorflow/stream_executor/cuda/cuda_rng.cc
+++ b/tensorflow/stream_executor/cuda/cuda_rng.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/stream_executor/cuda/cuda_stream.h"
 #include "tensorflow/stream_executor/device_memory.h"
 #include "tensorflow/stream_executor/dso_loader.h"
+#include "tensorflow/stream_executor/lib/env.h"
 #include "tensorflow/stream_executor/lib/initialize.h"
 #include "tensorflow/stream_executor/lib/status.h"
 #include "tensorflow/stream_executor/platform/logging.h"
@@ -72,14 +73,20 @@ namespace dynload {
       static auto status = internal::CachedDsoLoader::GetCurandDsoHandle(); \
       return status.ValueOrDie();                                           \
     }                                                                       \
-    static FuncPointerT DynLoad() {                                         \
-      static void *f = dlsym(GetDsoHandle(), kName);                        \
-      CHECK(f != nullptr) << "could not find " << kName                     \
-                          << " in curand DSO; dlerror: " << dlerror();      \
+    static FuncPointerT LoadOrDie() {                                       \
+      void *f;                                                              \
+      port::Status s = port::Env::Default()->GetSymbolFromLibrary(          \
+          GetDsoHandle(), kName, &f);                                       \
+      CHECK(s.ok()) << "could not find " << kName                           \
+                    << " in curand DSO; dlerror: " << s.error_message();    \
       return reinterpret_cast<FuncPointerT>(f);                             \
     }                                                                       \
+    static FuncPointerT DynLoad() {                                         \
+      static FuncPointerT f = LoadOrDie();                                  \
+      return f;                                                             \
+    }                                                                       \
     template <typename... Args>                                             \
-    curandStatus_t operator()(CUDAExecutor * parent, Args... args) {        \
+    curandStatus_t operator()(CUDAExecutor *parent, Args... args) {         \
       cuda::ScopedActivateExecutorContext sac{parent};                      \
       return DynLoad()(args...);                                            \
     }                                                                       \

--- a/tensorflow/stream_executor/dso_loader.cc
+++ b/tensorflow/stream_executor/dso_loader.cc
@@ -105,7 +105,7 @@ string GetCudnnVersion() { return TF_CUDNN_VERSION; }
       RTLD_LAZY | (load_kind == LoadKind::kLocal ? RTLD_LOCAL : RTLD_GLOBAL);
   string path_string = path.ToString();
   port::Status s =
-      port::Env::Default->LoadLibrary(path_string.c_str(), dso_handle);
+      port::Env::Default()->LoadLibrary(path_string.c_str(), dso_handle);
   if (!s.ok()) {
     LOG(INFO) << "Couldn't open CUDA library " << path
               << ". LD_LIBRARY_PATH: " << getenv("LD_LIBRARY_PATH");

--- a/tensorflow/stream_executor/dso_loader.cc
+++ b/tensorflow/stream_executor/dso_loader.cc
@@ -29,8 +29,8 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/core/platform/load_library.h"
+#include "tensorflow/stream_executor/lib/env.h"
 #include "tensorflow/stream_executor/lib/error.h"
-#include "tensorflow/stream_executor/lib/str_util.h"
 #include "tensorflow/stream_executor/lib/str_util.h"
 #include "tensorflow/stream_executor/lib/strcat.h"
 #include "tensorflow/stream_executor/lib/stringprintf.h"
@@ -97,19 +97,23 @@ string GetCudnnVersion() { return TF_CUDNN_VERSION; }
 /* static */ port::Status DsoLoader::GetDsoHandle(port::StringPiece path,
                                                   void** dso_handle,
                                                   LoadKind load_kind) {
+  if (load_kind != LoadKind::kLocal) {
+    return port::Status(port::error::INVALID_ARGUMENT,
+                        "Only LoadKind::kLocal is currently supported");
+  }
   int dynload_flags =
       RTLD_LAZY | (load_kind == LoadKind::kLocal ? RTLD_LOCAL : RTLD_GLOBAL);
   string path_string = path.ToString();
-  *dso_handle = dlopen(path_string.c_str(), dynload_flags);
-  if (*dso_handle == nullptr) {
+  port::Status s =
+      port::Env::Default->LoadLibrary(path_string.c_str(), dso_handle);
+  if (!s.ok()) {
     LOG(INFO) << "Couldn't open CUDA library " << path
               << ". LD_LIBRARY_PATH: " << getenv("LD_LIBRARY_PATH");
-    return port::Status(
-        port::error::FAILED_PRECONDITION,
-        port::StrCat("could not dlopen DSO: ", path, "; dlerror: ", dlerror()));
+    return port::Status(port::error::FAILED_PRECONDITION,
+                        port::StrCat("could not dlopen DSO: ", path,
+                                     "; dlerror: ", s.error_message()));
   }
-  LOG(INFO) << "successfully opened CUDA library " << path
-            << (load_kind == LoadKind::kLocal ? " locally" : " globally");
+  LOG(INFO) << "successfully opened CUDA library " << path << " locally";
   return port::Status::OK();
 }
 


### PR DESCRIPTION
Use the functions from `port::Env` rather than `dlfcn.h`, to make it easier to port stream_executor to Windows.
