### PR TITLE
Add fused_batch_norm layer

### DIFF
--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -351,13 +351,17 @@ REGISTER_OP("FusedBatchNormGrad")
     .Attr("T: numbertype")
     .Attr("epsilon: float = 0.0001")
     .Attr("data_format: string = 'NHWC'")
+    .Attr("is_training: bool = true")
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle y_backprop;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &y_backprop));
       ShapeHandle x;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 4, &x));
 
+      bool is_training;
       string data_format;
+
+      c->GetAttr("is_training", &is_training);
       c->GetAttr("data_format", &data_format);
       DimensionHandle channel_dim = (data_format == "NHWC")
                                         ? c->Dim(y_backprop, 3)
@@ -386,8 +390,16 @@ REGISTER_OP("FusedBatchNormGrad")
       c->set_output(0, x_backprop);
       c->set_output(1, c->Vector(channel_dim));
       c->set_output(2, c->Vector(channel_dim));
-      c->set_output(3, c->Vector(0));
-      c->set_output(4, c->Vector(0));
+      // set the correct shapes for reserve_spaces
+      // so that gradients can be performed when
+      // the op is in a symbolic condition
+      if (is_training) {
+        c->set_output(3, c->Vector(0));
+        c->set_output(4, c->Vector(0));
+      } else {
+        c->set_output(3, c->Vector(channel_dim));
+        c->set_output(4, c->Vector(channel_dim));
+      }
       return Status::OK();
     })
     .Doc(R"doc(
@@ -412,6 +424,8 @@ T: The data type for the elements of input and output Tensors.
 epsilon: A small float number added to the variance of x.
 data_format: The data format for y_backprop, x, x_backprop.
              Either "NHWC" (default) or "NCHW".
+is_training: A bool value to indicate the operation is for training (default)
+             or inference.
 )doc");
 
 // --------------------------------------------------------------------------

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -210,36 +210,36 @@ def _BiasAddGradGrad(op, received_grad):
   Args:
     op: BiasAddGrad op for which we are calculating gradients.
     received_grad: The gradients passed to the BiasAddGrad op.
-    
+
   Returns:
     A single gradient Tensor for the input to BiasAddGrad (which
     is the gradient of the bias term in BiasAdd)
   """
-  
+
   try:
     data_format = op.get_attr("data_format")
   except ValueError:
     data_format = None
-  
+
   shape = array_ops.shape(op.inputs[0])
   rank = array_ops.rank(op.inputs[0])
   bias_shape = array_ops.shape(received_grad)
-  
+
   if data_format == b"NCHW":
     expanded_shape = array_ops.concat(
       0,
       [array_ops.ones_like(shape[:-3]), bias_shape, array_ops.ones_like(shape[-2:])]
     )
-    
+
     tile_mults = array_ops.concat(0, [shape[:-3], [1], shape[-2:]])
-    
+
   else:
     expanded_shape = array_ops.concat(0, [array_ops.ones_like(shape[:-1]), bias_shape])
     tile_mults = array_ops.concat(0, [shape[:-1], [1]])
-  
+
   expanded_grad = array_ops.reshape(received_grad, expanded_shape)
   return array_ops.tile(expanded_grad, tile_mults)
-  
+
 
 @ops.RegisterGradient("BiasAddV1")
 def _BiasAddGradV1(unused_bias_op, received_grad):
@@ -498,7 +498,8 @@ def _FusedBatchNormGrad(op, *grad):
       op.outputs[3],
       op.outputs[4],
       epsilon=op.get_attr("epsilon"),
-      data_format=op.get_attr("data_format"))
+      data_format=op.get_attr("data_format"),
+      is_training=op.get_attr("is_training"))
 
 
 @ops.RegisterGradient("L2Loss")


### PR DESCRIPTION
Add data_format option for convolution2d, bias_add, max_pool2d, and avg_pool2d as well. This helps to fully utilize the cudnn speed for normal convnets with 'NCHW' data layout. 
