### PR TITLE
[bug]unmatched quote causes big problem

### DIFF
--- a/tensorflow/g3doc/api_docs/python/state_ops.md
+++ b/tensorflow/g3doc/api_docs/python/state_ops.md
@@ -2382,10 +2382,6 @@ tensor shape, the initializer will raise a `ValueError`.
 
   An initializer that generates tensors with constant values.
 
-##### Raises:
-
-*  <b>`ValueError`</b>: Too many elements provided. Needed at most 6, but received 8
-
 ##### Examples:
 
   The following example can be rewritten using a numpy.ndarray instead
@@ -2429,8 +2425,9 @@ tensor shape, the initializer will raise a `ValueError`.
   >>> with tf.Session():
   >>>   x = tf.get_variable('x', shape=[2, 3], initializer=init)
 
-```
-  
+
+*  <b>`ValueError`</b>: Too many elements provided. Needed at most 6, but received 8
+  ```
 - - -
 
 ### `tf.random_normal_initializer(mean=0.0, stddev=1.0, seed=None, dtype=tf.float32)` {#random_normal_initializer}

--- a/tensorflow/g3doc/api_docs/python/state_ops.md
+++ b/tensorflow/g3doc/api_docs/python/state_ops.md
@@ -2382,6 +2382,10 @@ tensor shape, the initializer will raise a `ValueError`.
 
   An initializer that generates tensors with constant values.
 
+##### Raises:
+
+*  <b>`ValueError`</b>: Too many elements provided. Needed at most 6, but received 8
+
 ##### Examples:
 
   The following example can be rewritten using a numpy.ndarray instead
@@ -2425,11 +2429,8 @@ tensor shape, the initializer will raise a `ValueError`.
   >>> with tf.Session():
   >>>   x = tf.get_variable('x', shape=[2, 3], initializer=init)
 
-
-*  <b>`ValueError`</b>: Too many elements provided. Needed at most 6, but received 8
-  ```
-
-
+```
+  
 - - -
 
 ### `tf.random_normal_initializer(mean=0.0, stddev=1.0, seed=None, dtype=tf.float32)` {#random_normal_initializer}

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -97,7 +97,7 @@ def constant_initializer(value=0, dtype=dtypes.float32):
     An initializer that generates tensors with constant values.
     
   Raises:  
-    ValueError: When total number of elements in value is more than the number of elements required by the tensor shape as explained above.
+    ValueError: If total number of elements greater than required by tensor shape.
     
   Examples:
     The following example can be rewritten using a numpy.ndarray instead

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -97,8 +97,7 @@ def constant_initializer(value=0, dtype=dtypes.float32):
     An initializer that generates tensors with constant values.
     
   Raises:  
-    ValueError: When total number of elements in value is more than the number 
-    of elements required by the tensor shape as explained above.
+    ValueError: When total number of elements in value is more than the number of elements required by the tensor shape as explained above.
     
   Examples:
     The following example can be rewritten using a numpy.ndarray instead

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -97,7 +97,8 @@ def constant_initializer(value=0, dtype=dtypes.float32):
     An initializer that generates tensors with constant values.
     
   Raises:  
-    ValueError: When number of elements provided more than in the shape definition. 
+    ValueError: When total number of elements in value is more than the number 
+    of elements required by the tensor shape as explained above.
     
   Examples:
     The following example can be rewritten using a numpy.ndarray instead

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -95,7 +95,10 @@ def constant_initializer(value=0, dtype=dtypes.float32):
 
   Returns:
     An initializer that generates tensors with constant values.
-
+    
+  Raises:  
+    ValueError: When number of elements provided more than in the shape definition. 
+    
   Examples:
     The following example can be rewritten using a numpy.ndarray instead
     of the `value` list, even reshaped, as shown in the two commented lines
@@ -138,8 +141,8 @@ def constant_initializer(value=0, dtype=dtypes.float32):
     >>> with tf.Session():
     >>>   x = tf.get_variable('x', shape=[2, 3], initializer=init)
 
-    ValueError: Too many elements provided. Needed at most 6, but received 8
-    ```
+    ValueError: Too many elements provided. Needed at most 6, but received 8.
+  ``` 
   """
   def _initializer(shape, dtype=dtype, partition_info=None):
     return constant_op.constant(value, dtype=dtype, shape=shape)


### PR DESCRIPTION
An unmatched quote causes thousands lines typesetting error. Look at the api docs, from [here](https://www.tensorflow.org/versions/r0.11/api_docs/python/state_ops.html#constant_initializer) to [here](https://www.tensorflow.org/versions/r0.11/api_docs/python/state_ops.html#IndexedSlices) has the problem, which influence almost 30 functions api docs from `constant_initializer` to `IndexedSlices`. 

We'd better fix it ASAP
