### PR TITLE
fixing go get and var name

### DIFF
--- a/tensorflow/go/genop/generate.sh
+++ b/tensorflow/go/genop/generate.sh
@@ -16,7 +16,8 @@
 
 set -e
 
-go get github.com/golang/protobuf/{proto,protoc-gen-go}
+go get github.com/golang/protobuf/proto
+go get github.com/golang/protobuf/protoc-gen-go
 
 cd $(dirname $0)
 TF_DIR=${GOPATH}/src/github.com/tensorflow/tensorflow
@@ -32,7 +33,7 @@ then
     echo "bazel build -c opt @protobuf//:protoc"
     exit 1
   fi
-  PROTOC=PATH_PROTOC
+  PROTOC=$PATH_PROTOC
 fi
 
 mkdir -p ./internal/proto


### PR DESCRIPTION
go get complained about the github.com path, splitting them out fixes it
