### PR TITLE
Fixed fused_batch_norm gradients

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -308,7 +308,7 @@ def _fused_batch_norm(
 
     # If `is_training` doesn't have a constant value, because it is a `Tensor`,
     # a `Variable` or `Placeholder` then is_training_value will be None and
-    # `needs_updates` will be true.
+    # `need_updates` will be true.
     is_training_value = utils.constant_value(is_training)
     need_updates = is_training_value is None or is_training_value
     if need_updates:

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -204,24 +204,36 @@ def _fused_batch_norm(
   Raises:
     ValueError: if `data_format` is neither `NHWC` nor `NCHW`.
     ValueError: if the rank of `inputs` is undefined.
-    ValueError: if rank or last dimension of `inputs` is undefined.
+    ValueError: if the rank of `inputs` is neither 2 or 4.
+    ValueError: if rank or `C` dimension of `inputs` is undefined.
   """
   if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
     raise ValueError('data_format has to be either NCHW or NHWC.')
   with variable_scope.variable_scope(
       scope, 'BatchNorm', [inputs], reuse=reuse) as sc:
     inputs = ops.convert_to_tensor(inputs)
+    original_shape = inputs.get_shape()
+    original_rank = original_shape.ndims
+    if original_rank is None:
+      raise ValueError('Inputs %s has undefined rank' % inputs.name)
+    elif original_rank not in [2, 4]:
+      raise ValueError('Inputs %s has unsupported rank. \
+          Expected 2 or 4 but got %d' % (inputs.name, original_rank))
+    if original_rank == 2:
+      channels = inputs.get_shape()[-1].value
+      if channels is None:
+        raise ValueError('`C` dimension must be known but is None')
+      new_shape = [-1, channels, 1, 1] if data_format == 'NCHW' else \
+          [-1, 1, 1, channels]
+      inputs = array_ops.reshape(inputs, new_shape)
     inputs_shape = inputs.get_shape()
-    inputs_rank = inputs_shape.ndims
-    if inputs_rank is None:
-      raise ValueError('Inputs %s has undefined rank.' % inputs.name)
     dtype = inputs.dtype.base_dtype
     if data_format == DATA_FORMAT_NHWC:
       params_shape = inputs_shape[-1:]
     else:
       params_shape = inputs_shape[1:2]
     if not params_shape.is_fully_defined():
-      raise ValueError('Inputs %s has undefined last dimension %s.' %
+      raise ValueError('Inputs %s has undefined `C` dimension %s.' %
                        (inputs.name, params_shape))
 
     # Allocate parameters for the beta and gamma of the normalization.
@@ -277,31 +289,31 @@ def _fused_batch_norm(
         trainable=False,
         collections=moving_variance_collections)
 
+    def _fused_batch_norm_training():
+      return nn.fused_batch_norm(
+          inputs, gamma, beta, epsilon=epsilon, data_format=data_format)
+    def _fused_batch_norm_inference():
+      return nn.fused_batch_norm(
+          inputs,
+          gamma,
+          beta,
+          mean=moving_mean,
+          variance=moving_variance,
+          epsilon=epsilon,
+          is_training=False,
+          data_format=data_format)
+    outputs, mean, variance = utils.smart_cond(is_training,
+                                               _fused_batch_norm_training,
+                                               _fused_batch_norm_inference)
+
     # If `is_training` doesn't have a constant value, because it is a `Tensor`,
     # a `Variable` or `Placeholder` then is_training_value will be None and
-    # `needs_moments` will be true.
+    # `needs_updates` will be true.
     is_training_value = utils.constant_value(is_training)
-    need_moments = is_training_value is None or is_training_value
-    if need_moments:
-      # Calculate the moments based on the individual batch.
-      def _fused_batch_norm_training():
-        return nn.fused_batch_norm(
-            inputs, gamma, beta, epsilon=epsilon, data_format=data_format)
-      def _fused_batch_norm_inference():
-        return nn.fused_batch_norm(
-            inputs,
-            gamma,
-            beta,
-            mean=moving_mean,
-            variance=moving_variance,
-            epsilon=epsilon,
-            is_training=False,
-            data_format=data_format)
-      outputs, mean, variance = utils.smart_cond(is_training,
-                                                 _fused_batch_norm_training,
-                                                 _fused_batch_norm_inference)
-      moving_vars_fn = lambda: (moving_mean, moving_variance)
+    need_updates = is_training_value is None or is_training_value
+    if need_updates:
       if updates_collections is None:
+        _no_updates = lambda: outputs
         def _force_updates():
           """Internal function forces updates moving_vars if is_training."""
           update_moving_mean = moving_averages.assign_moving_average(
@@ -310,12 +322,10 @@ def _fused_batch_norm(
               moving_variance, variance, decay)
           with ops.control_dependencies(
               [update_moving_mean, update_moving_variance]):
-            return array_ops.identity(mean), array_ops.identity(variance)
-        mean, variance = utils.smart_cond(is_training, _force_updates,
-                                          moving_vars_fn)
-        with ops.control_dependencies([mean, variance]):
-          outputs = array_ops.identity(outputs)
+            return array_ops.identity(outputs)
+        outputs = utils.smart_cond(is_training, _force_updates, _no_updates)
       else:
+        moving_vars_fn = lambda: (moving_mean, moving_variance)
         def _delay_updates():
           """Internal function that delay updates moving_vars if is_training."""
           update_moving_mean = moving_averages.assign_moving_average(
@@ -328,22 +338,10 @@ def _fused_batch_norm(
                                                         moving_vars_fn)
         ops.add_to_collections(updates_collections, update_mean)
         ops.add_to_collections(updates_collections, update_variance)
-        # Use computed moments during training and moving_vars otherwise.
-        vars_fn = lambda: (mean, variance)
-        mean, variance = utils.smart_cond(is_training, vars_fn, moving_vars_fn)
-    else:
-      mean, variance = moving_mean, moving_variance
-      outputs, _, _ = nn.fused_batch_norm(
-          inputs,
-          gamma,
-          beta,
-          mean=moving_mean,
-          variance=moving_variance,
-          epsilon=epsilon,
-          is_training=False,
-          data_format=data_format)
 
     outputs.set_shape(inputs_shape)
+    if original_shape.ndims == 2:
+      outputs = array_ops.reshape(outputs, original_shape)
     if activation_fn is not None:
       outputs = activation_fn(outputs)
     return utils.collect_named_outputs(outputs_collections,
@@ -603,6 +601,7 @@ def bias_add(inputs,
              variables_collections=None,
              outputs_collections=None,
              trainable=True,
+             data_format='NHWC',
              scope=None):
   """Adds a bias to the inputs.
 
@@ -622,11 +621,17 @@ def bias_add(inputs,
     outputs_collections: collections to add the outputs.
     trainable: If `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+    data_format: A string. 'NHWC' and 'NCHW' are supported.
     scope: Optional scope for variable_scope.
 
   Returns:
     a tensor representing the result of adding biases to the inputs.
+
+  Raises:
+    ValueError: if `data_format` is neither `NHWC` nor `NCHW`.
   """
+  if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+    raise ValueError('data_format has to be either NCHW or NHWC.')
   with variable_scope.variable_scope(scope, 'BiasAdd', [inputs],
                                      reuse=reuse) as sc:
     inputs = ops.convert_to_tensor(inputs)
@@ -641,7 +646,7 @@ def bias_add(inputs,
                                       regularizer=regularizer,
                                       collections=biases_collections,
                                       trainable=trainable)
-    outputs = nn.bias_add(inputs, biases)
+    outputs = nn.bias_add(inputs, biases, data_format=data_format)
     if activation_fn is not None:
       outputs = activation_fn(outputs)
     return utils.collect_named_outputs(outputs_collections,

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -601,7 +601,7 @@ def bias_add(inputs,
              variables_collections=None,
              outputs_collections=None,
              trainable=True,
-             data_format='NHWC',
+             data_format=DATA_FORMAT_NHWC,
              scope=None):
   """Adds a bias to the inputs.
 

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -223,7 +223,7 @@ def _fused_batch_norm(
       channels = inputs.get_shape()[-1].value
       if channels is None:
         raise ValueError('`C` dimension must be known but is None')
-      new_shape = [-1, channels, 1, 1] if data_format == 'NCHW' else \
+      new_shape = [-1, channels, 1, 1] if data_format == DATA_FORMAT_NCHW else \
           [-1, 1, 1, channels]
       inputs = array_ops.reshape(inputs, new_shape)
     inputs_shape = inputs.get_shape()

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -351,13 +351,16 @@ REGISTER_OP("FusedBatchNormGrad")
     .Attr("T: numbertype")
     .Attr("epsilon: float = 0.0001")
     .Attr("data_format: string = 'NHWC'")
+    .Attr("is_training: bool = true")
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle y_backprop;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &y_backprop));
       ShapeHandle x;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 4, &x));
 
+      bool is_training;
       string data_format;
+      c->GetAttr("is_training", &is_training);
       c->GetAttr("data_format", &data_format);
       DimensionHandle channel_dim = (data_format == "NHWC")
                                         ? c->Dim(y_backprop, 3)
@@ -386,8 +389,16 @@ REGISTER_OP("FusedBatchNormGrad")
       c->set_output(0, x_backprop);
       c->set_output(1, c->Vector(channel_dim));
       c->set_output(2, c->Vector(channel_dim));
-      c->set_output(3, c->Vector(0));
-      c->set_output(4, c->Vector(0));
+      // set the correct shapes for reserve_spaces
+      // so that gradients can be performed when
+      // the op is in a symbolic condition
+      if (is_training) {
+        c->set_output(3, c->Vector(0));
+        c->set_output(4, c->Vector(0));
+      } else {
+        c->set_output(3, c->Vector(channel_dim));
+        c->set_output(4, c->Vector(channel_dim));
+      }
       return Status::OK();
     })
     .Doc(R"doc(
@@ -412,6 +423,8 @@ T: The data type for the elements of input and output Tensors.
 epsilon: A small float number added to the variance of x.
 data_format: The data format for y_backprop, x, x_backprop.
              Either "NHWC" (default) or "NCHW".
+is_training: A bool value to indicate the operation is for training (default)
+             or inference.
 )doc");
 
 // --------------------------------------------------------------------------

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -389,9 +389,9 @@ REGISTER_OP("FusedBatchNormGrad")
       c->set_output(0, x_backprop);
       c->set_output(1, c->Vector(channel_dim));
       c->set_output(2, c->Vector(channel_dim));
-      // set the correct shapes for reserve_spaces
+      // Set the correct shapes for reserve_spaces
       // so that gradients can be performed when
-      // the op is in a symbolic condition
+      // the op is in a symbolic condition.
       if (is_training) {
         c->set_output(3, c->Vector(0));
         c->set_output(4, c->Vector(0));

--- a/tensorflow/python/ops/nn.py
+++ b/tensorflow/python/ops/nn.py
@@ -1029,7 +1029,7 @@ def fused_batch_norm(x, scale, offset,  # pylint: disable=invalid-name
       offset,
       mean,
       variance,
-      epsilon=epsilon,
+      epsilon=epsilon + 1e-12,
       data_format=data_format,
       is_training=is_training,
       name=name)

--- a/tensorflow/python/ops/nn.py
+++ b/tensorflow/python/ops/nn.py
@@ -1023,7 +1023,7 @@ def fused_batch_norm(x, scale, offset,  # pylint: disable=invalid-name
     mean = constant_op.constant([])
   if variance is None:
     variance = constant_op.constant([])
-  #Add 1e-12 to epsilon when epsilon=1e-5 to prevent cudnn exception.
+  # Add 1e-12 to epsilon when epsilon <= 1e-5 to prevent CUDNN exception.
   epsilon = epsilon if epsilon > 1e-5 else epsilon + 1e-12
   y, batch_mean, batch_var, _, _ = gen_nn_ops.fused_batch_norm(
       x,

--- a/tensorflow/python/ops/nn.py
+++ b/tensorflow/python/ops/nn.py
@@ -1023,13 +1023,15 @@ def fused_batch_norm(x, scale, offset,  # pylint: disable=invalid-name
     mean = constant_op.constant([])
   if variance is None:
     variance = constant_op.constant([])
+  #Add 1e-12 to epsilon when epsilon=1e-5 to prevent cudnn exception.
+  epsilon = epsilon if epsilon > 1e-5 else epsilon + 1e-12
   y, batch_mean, batch_var, _, _ = gen_nn_ops.fused_batch_norm(
       x,
       scale,
       offset,
       mean,
       variance,
-      epsilon=epsilon + 1e-12,
+      epsilon=epsilon,
       data_format=data_format,
       is_training=is_training,
       name=name)

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -210,36 +210,36 @@ def _BiasAddGradGrad(op, received_grad):
   Args:
     op: BiasAddGrad op for which we are calculating gradients.
     received_grad: The gradients passed to the BiasAddGrad op.
-    
+
   Returns:
     A single gradient Tensor for the input to BiasAddGrad (which
     is the gradient of the bias term in BiasAdd)
   """
-  
+
   try:
     data_format = op.get_attr("data_format")
   except ValueError:
     data_format = None
-  
+
   shape = array_ops.shape(op.inputs[0])
   rank = array_ops.rank(op.inputs[0])
   bias_shape = array_ops.shape(received_grad)
-  
+
   if data_format == b"NCHW":
     expanded_shape = array_ops.concat(
       0,
       [array_ops.ones_like(shape[:-3]), bias_shape, array_ops.ones_like(shape[-2:])]
     )
-    
+
     tile_mults = array_ops.concat(0, [shape[:-3], [1], shape[-2:]])
-    
+
   else:
     expanded_shape = array_ops.concat(0, [array_ops.ones_like(shape[:-1]), bias_shape])
     tile_mults = array_ops.concat(0, [shape[:-1], [1]])
-  
+
   expanded_grad = array_ops.reshape(received_grad, expanded_shape)
   return array_ops.tile(expanded_grad, tile_mults)
-  
+
 
 @ops.RegisterGradient("BiasAddV1")
 def _BiasAddGradV1(unused_bias_op, received_grad):
@@ -498,7 +498,8 @@ def _FusedBatchNormGrad(op, *grad):
       op.outputs[3],
       op.outputs[4],
       epsilon=op.get_attr("epsilon"),
-      data_format=op.get_attr("data_format"))
+      data_format=op.get_attr("data_format"),
+      is_training=op.get_attr("is_training"))
 
 
 @ops.RegisterGradient("L2Loss")

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -230,9 +230,7 @@ def _BiasAddGradGrad(op, received_grad):
       0,
       [array_ops.ones_like(shape[:-3]), bias_shape, array_ops.ones_like(shape[-2:])]
     )
-
     tile_mults = array_ops.concat(0, [shape[:-3], [1], shape[-2:]])
-
   else:
     expanded_shape = array_ops.concat(0, [array_ops.ones_like(shape[:-1]), bias_shape])
     tile_mults = array_ops.concat(0, [shape[:-1], [1]])


### PR DESCRIPTION
Fixed issues with fused_batch_norm as discussed in #4899, added support to `2D` tensor for fused_batch_norm and added `data_format` option for `bias_add`. 

Also the `nn.fused_batch_norm` op should be able to take minimum `epsilon=1e-5`. This value is set as  mininum value in `cudnn` and has been used in several models in `slim.nets`. At the moment `nn.fused_batch_norm` throw `CUDNN_STATUS_BAD_PARAM` when `epsilon=1e-5`, probably due to the numerical/casting error. This pull added `epsilon=epsilon+1e-12` in `nn.fused_batch_norm` (`1e-5 + 1e-12` works but `1e-5 + 1e-13` doesn't).
