### PR TITLE
Fix error handling for when swig isn't found.

### DIFF
--- a/configure
+++ b/configure
@@ -109,7 +109,7 @@ fi
 
 ## Find swig path
 if [ -z "$SWIG_PATH" ]; then
-  SWIG_PATH=`type -p swig 2> /dev/null`
+  SWIG_PATH=`type -p swig 2> /dev/null || true`
 fi
 if [[ ! -e "$SWIG_PATH" ]]; then
   echo "Can't find swig.  Ensure swig is in \$PATH or set \$SWIG_PATH."


### PR DESCRIPTION
Currently, if swig is not found, then the configure script fails but
does not print an error because we are redirecting the stderr of `type -p swig`
to /dev/null, which results in this command failing the configure script
immediately and silently before the subsequent error handling code can be
executed.

This script adds a `|| true` clause so that if swig isn't found, we will
use the error handling code below to print an error message.

Fixes #4928
