### PR TITLE
refine benchmark_test.py

### DIFF
--- a/tensorflow/python/kernel_tests/benchmark_test.py
+++ b/tensorflow/python/kernel_tests/benchmark_test.py
@@ -188,7 +188,7 @@ class BenchmarkTest(tf.test.TestCase):
       full_trace = read_benchmark_3.extras["full_trace_chrome_format"]
       json_trace = json.loads(full_trace.string_value)
       self.assertTrue(isinstance(json_trace, dict))
-      self.assertTrue("traceEvents" in json_trace.keys())
+      self.assertTrue("traceEvents" in json_trace)
 
     finally:
       tf.gfile.DeleteRecursively(tempdir)


### PR DESCRIPTION
delete .keys()
no need to get keys()
just use 'in' instead
