### PR TITLE
Fix too long sentence

### DIFF
--- a/tensorflow/models/rnn/translate/translate.py
+++ b/tensorflow/models/rnn/translate/translate.py
@@ -238,8 +238,12 @@ def decode():
       # Get token-ids for the input sentence.
       token_ids = data_utils.sentence_to_token_ids(tf.compat.as_bytes(sentence), en_vocab)
       # Which bucket does it belong to?
-      bucket_id = min([b for b in xrange(len(_buckets))
-                       if _buckets[b][0] > len(token_ids)])
+      for i, bucket in enumerate(_buckets):
+        if bucket[0]>=len(token_ids):
+          bucket_id = i
+          break
+        else:
+          bucket_id = len(_buckets)-1
       # Get a 1-element batch to feed the sentence to the model.
       encoder_inputs, decoder_inputs, target_weights = model.get_batch(
           {bucket_id: [(token_ids, [])]}, bucket_id)

--- a/tensorflow/models/rnn/translate/translate.py
+++ b/tensorflow/models/rnn/translate/translate.py
@@ -36,6 +36,7 @@ import os
 import random
 import sys
 import time
+import logging
 
 import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin

--- a/tensorflow/models/rnn/translate/translate.py
+++ b/tensorflow/models/rnn/translate/translate.py
@@ -238,12 +238,14 @@ def decode():
       # Get token-ids for the input sentence.
       token_ids = data_utils.sentence_to_token_ids(tf.compat.as_bytes(sentence), en_vocab)
       # Which bucket does it belong to?
+      bucket_id = len(_buckets) - 1
       for i, bucket in enumerate(_buckets):
-        if bucket[0]>=len(token_ids):
+        if bucket[0] >= len(token_ids):
           bucket_id = i
           break
-        else:
-          bucket_id = len(_buckets)-1
+      else:
+        logging.warning("Sentence truncated: %s", sentence) 
+
       # Get a 1-element batch to feed the sentence to the model.
       encoder_inputs, decoder_inputs, target_weights = model.get_batch(
           {bucket_id: [(token_ids, [])]}, bucket_id)


### PR DESCRIPTION
models/rnn/translate.py with --decode option raises exception if input sentence is longer than 20 (default lower bound on last bucket)

> 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
> Traceback (most recent call last):
> File "translate_edit.py", line 298, in
> tf.app.run()
> File "/home/modrymar/venv/lib/python3.5/site-packages/tensorflow/python/platform/app.py", line 30, in run
> sys.exit(main(sys.argv))
> File "translate_edit.py", line 293, in main
> decode()
> File "translate_edit.py", line 241, in decode
> bucket_id = min([b for b in xrange(len(_buckets))
> ValueError: min() arg is an empty sequence
