### PR TITLE
Update protobuf to get a fix from upstream

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -98,9 +98,9 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
   native.http_archive(
     name = "protobuf",
-    url = "http://github.com/google/protobuf/archive/v3.1.0.tar.gz",
-    sha256 = "0a0ae63cbffc274efb573bdde9a253e3f32e458c41261df51c5dbc5ad541e8f7",
-    strip_prefix = "protobuf-3.1.0",
+    url = "http://github.com/google/protobuf/archive/c2b3e70efd2038a54ef8973771ac58192885125e.tar.gz",
+    sha256 = "eafc1bc4c27970d62effe64ba6610823fdd66711f440d8ca4a168167786a2fcb",
+    strip_prefix = "protobuf-c2b3e70efd2038a54ef8973771ac58192885125e",
   )
 
   native.new_http_archive(


### PR DESCRIPTION
We already have a fix in protbuf https://github.com/google/protobuf/pull/2246
This makes TF build with Bazel at HEAD again.
Fix https://github.com/bazelbuild/bazel/issues/1929

I understand TF is currently using a release version of protobuf, is this change acceptable?

BTW @mrry 's fix will also get fetched by this change
https://github.com/google/protobuf/pull/2203
