### PR TITLE
use use_default_shell_env for SWIGing action

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -563,7 +563,8 @@ def _py_wrap_cc_impl(ctx):
              inputs=sorted(set([src]) + cc_includes + ctx.files.swig_includes +
                          ctx.attr.swig_deps.files),
              outputs=outputs,
-             progress_message="SWIGing {input}".format(input=src.path))
+             progress_message="SWIGing {input}".format(input=src.path),
+             use_default_shell_env=True)
   return struct(files=set(outputs))
 
 _py_wrap_cc = rule(


### PR DESCRIPTION
When swig is in the PATH but not in a standard bin location, bazel can't
find it unless the PATH is propagated.

_I have only spend two days on becoming familiar with tensorflow and bazel, so I could easily be wrong._
