### PR TITLE
Add a resource container for sync tokens in SyncReplicasOptimizerV2.

### DIFF
--- a/tensorflow/python/training/sync_replicas_optimizer.py
+++ b/tensorflow/python/training/sync_replicas_optimizer.py
@@ -301,11 +301,12 @@ class SyncReplicasOptimizerV2(optimizer.Optimizer):
 
       # Create token queue.
       with ops.device(global_step.device), ops.name_scope(""):
-        sync_token_queue = (
-            data_flow_ops.FIFOQueue(-1,
-                                    global_step.dtype.base_dtype,
-                                    shapes=(),
-                                    shared_name="sync_token_q"))
+        with ops.container("sync-tokens"):
+          sync_token_queue = (
+              data_flow_ops.FIFOQueue(-1,
+                                      global_step.dtype.base_dtype,
+                                      shapes=(),
+                                      shared_name="sync_token_q"))
         self._sync_token_queue = sync_token_queue
 
         # dummy_queue is passed to the queue runner. Don't use the real queues


### PR DESCRIPTION
Not sure if this aligns with how resource containers are planned to be used in tensorflow. I wanted to be able to reset sync token queues without also resetting other variables defined in the optimizer.
