### PR TITLE
Fixed error with NaN an None elements in Wide & Deep Learning Tutorial

### DIFF
--- a/tensorflow/examples/learn/wide_n_deep_tutorial.py
+++ b/tensorflow/examples/learn/wide_n_deep_tutorial.py
@@ -180,6 +180,10 @@ def train_and_eval():
       skiprows=1,
       engine="python")
 
+  # remove NaN elements
+  df_train = df_train.dropna(how='any', axis=0)
+  df_test = df_test.dropna(how='any', axis=0)
+
   df_train[LABEL_COLUMN] = (
       df_train["income_bracket"].apply(lambda x: ">50K" in x)).astype(int)
   df_test[LABEL_COLUMN] = (


### PR DESCRIPTION
There was an error after reading the dataset, looks like the last line (of the dataset) contains NaN values, giving an error when converting to integer (to generate the labels):

> Traceback (most recent call last):
>   File "tensorflow/examples/learn/wide_n_deep_tutorial.py", line 203, in <module>
>     tf.app.run()
>   File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/platform/app.py", line 30, in run
>     sys.exit(main(sys.argv[:1] + flags_passthrough))
>   File "tensorflow/examples/learn/wide_n_deep_tutorial.py", line 199, in main
>     train_and_eval()
>   File "tensorflow/examples/learn/wide_n_deep_tutorial.py", line 184, in train_and_eval
>     df_train["income_bracket"].apply(lambda x: ">50K" in x)).astype(int)
>   File "/usr/lib/python2.7/dist-packages/pandas/core/series.py", line 2023, in apply
>     mapped = lib.map_infer(values, f, convert=convert_dtype)
>   File "inference.pyx", line 920, in pandas.lib.map_infer (pandas/lib.c:44780)
>   File "tensorflow/examples/learn/wide_n_deep_tutorial.py", line 184, in <lambda>
>     df_train["income_bracket"].apply(lambda x: ">50K" in x)).astype(int)
> TypeError: argument of type 'NoneType' is not iterable

This was fixed droping every line that contains NaN elements:

>   # remove NaN elements
>   df_train = df_train.dropna(how='any', axis=0)
>   df_test = df_test.dropna(how='any', axis=0)
