### PR TITLE
Do not set testonly to //tensorflow/python:construction_fails_go

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1901,7 +1901,6 @@ py_library(
 # Just used by tests.
 tf_cuda_library(
     name = "construction_fails_op",
-    testonly = 1,
     srcs = ["client/test_construction_fails_op.cc"],
     deps = [
         "//tensorflow/core",


### PR DESCRIPTION
This target is shipped into the pip_package so it is not testonly. Current
version of Bazel does not enforce testonly but the next version will.
Tested by building build_pip_package.

Tracking bug: bazelbuild/bazel#1967
