### PR TITLE
Fix #5143: Remove dependencies on test libraries

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1808,9 +1808,7 @@ tf_cuda_library(
     srcs = ["client/tf_session_helper.cc"],
     hdrs = ["client/tf_session_helper.h"],
     deps = [
-        ":construction_fails_op",
         ":numpy_lib",
-        ":test_ops_kernels",
         "//tensorflow/c:c_api",
         "//tensorflow/c:tf_status_helper",
         "//tensorflow/core",
@@ -1947,6 +1945,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":array_ops",
+        ":construction_fails_op",
         ":control_flow_ops",
         ":data_flow_ops",
         ":framework",


### PR DESCRIPTION
tensorflow/python:tf_session_helper has dependencies on some
test libraries. I don't believe these dependencies should have
ever existed.

Regardless, removing them now. In particular because recent
changes to bazel
(https://github.com/bazelbuild/bazel/commit/5f026f96118e76c8a6357c61e5710e0bd1bf0f54)
suggest that these dependencies will cause build failures in the next
release of bazel (or if bazel is built from source).

Fixes #5143 
