### PR TITLE
move type2index into EIGEN_HAS_INDEX_LIST

### DIFF
--- a/tensorflow/core/kernels/cwise_op_gpu_select.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_select.cu.cc
@@ -39,7 +39,11 @@ struct SelectScalarFunctor<GPUDevice, T> {
                   typename TTypes<T>::ConstFlat then_flat,
                   typename TTypes<T>::ConstFlat else_flat) {
 
+#if !defined(EIGEN_HAS_INDEX_LIST)
+  Eigen::array<int, 2> rank1;
+#else
   Eigen::IndexList<Eigen::type2index<1>> rank1;
+#endif
   const int size  = then_flat.dimension(0);
   Eigen::array<int, 1> broadcast_dims{size};
 


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/5127 has a small issue that type2index / IndexList is used without checking for EIGEN_HAS_INDEX_LIST which broke the windows gpu build.
This makes it build again.
