### PR TITLE
Remove conflict include statments in port.cc

### DIFF
--- a/tensorflow/core/platform/windows/port.cc
+++ b/tensorflow/core/platform/windows/port.cc
@@ -21,8 +21,6 @@ limitations under the License.
 #endif
 
 #include <Windows.h>
-#include <WinSock2.h>
-#pragma comment(lib, "Ws2_32.lib")
 
 #include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/demangle.h"


### PR DESCRIPTION
I was getting errors like following when building PIP package with Bazel:

```
C:\Program Files (x86)\Windows Kits\8.1\include\\um\WinSock2.h(2699): error C2375: 'WSAAsyncSelect': redefinition; different linkage
C:\Program Files (x86)\Windows Kits\8.1\include\\um\winsock.h(933): note: see declaration of 'WSAAsyncSelect'
```

Turned out these two line was removed at 46110c5aecfafcce220252bb8455b6188389b91d,

```
-#include <WinSock2.h>      
-#pragma comment(lib, "Ws2_32.lib")
```

But brought back at https://github.com/tensorflow/tensorflow/commit/c5ab3dd177dc16bb211821e38219f350a613b5e8
Seems like a merge error to me.
