### PR TITLE
Fix contrib/makefile builds in 0.11

### DIFF
--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -426,6 +426,7 @@ $(wildcard tensorflow/core/platform/*/*/*.cc) \
 $(wildcard tensorflow/core/util/*.cc) \
 $(wildcard tensorflow/core/util/*/*.cc) \
 tensorflow/core/util/version_info.cc
+CORE_CC_ALL_SRCS := $(sort $(CORE_CC_ALL_SRCS))
 CORE_CC_EXCLUDE_SRCS := \
 $(wildcard tensorflow/core/*/*test.cc) \
 $(wildcard tensorflow/core/*/*testutil*) \


### PR DESCRIPTION
contrib/makefile builds include version_info.cc twice and end up with duplicate symbols in the resulting library.  As a result none of the iOS examples work and the resulting library can't be used.

This is simply the fix from master, https://github.com/tensorflow/tensorflow/commit/1283b84a49a9f5e14aca833cf981b61848aaf916.
