### PR TITLE
Einsum dynamic shape bug fix

### DIFF
--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -182,8 +182,8 @@ def einsum(axes, *inputs):
       idx_in[i] = sorted_idx
 
   reduction_idx = []
-  shapes = [[dim if dim else -1
-             for dim in tensor.get_shape().as_list()]
+  shapes = [[dim if dim is not None else -1
+             for dim in array_ops.unpack(array_ops.shape(tensor))]
             for tensor in inputs]
 
   # validate shapes for broadcasting


### PR DESCRIPTION
I fixed a bug in einsum that did not allow for dynamic tensor shapes. I'm not sure if that's the only change necessary and I'm also not sure what conventions you follow to write tests for this, so since I have a paper deadline approaching I'll leave it at that for now. It seems to be working fine for me but I haven't tested any edge cases.
