### PR TITLE
Changed context creation to use primary context

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_driver.cc
+++ b/tensorflow/stream_executor/cuda/cuda_driver.cc
@@ -75,9 +75,11 @@ namespace dynload {
   const char *DynLoadShim__##__name::kName = #__name;
 
 PERFTOOLS_GPUTOOLS_LIBCUDA_WRAP(cuCtxCreate_v2);
+#if CUDA_VERSION >= 7000
 PERFTOOLS_GPUTOOLS_LIBCUDA_WRAP(cuDevicePrimaryCtxRetain);
 PERFTOOLS_GPUTOOLS_LIBCUDA_WRAP(cuDevicePrimaryCtxRelease);
 PERFTOOLS_GPUTOOLS_LIBCUDA_WRAP(cuDevicePrimaryCtxSetFlags);
+#endif
 PERFTOOLS_GPUTOOLS_LIBCUDA_WRAP(cuCtxDestroy);
 PERFTOOLS_GPUTOOLS_LIBCUDA_WRAP(cuCtxEnablePeerAccess);
 PERFTOOLS_GPUTOOLS_LIBCUDA_WRAP(cuCtxGetCurrent);
@@ -587,8 +589,12 @@ bool DeviceOptionsToContextFlags(DeviceOptions device_options, int *flags) {
     // TODO(leary) Need to see if NVIDIA can expunge the leakiness in their
     // context creation: see http://b/13248943
 
+#if CUDA_VERSION >= 7000
     res = dynload::cuDevicePrimaryCtxSetFlags(device, flags);
     res = dynload::cuDevicePrimaryCtxRetain(&new_context, device);
+#else
+    res = dynload::cuCtxCreate_v2(&new_context, flags, device);
+#endif
   }
   CHECK_EQ(CUDA_SUCCESS, dynload::cuCtxSetCurrent(former_context));
 
@@ -600,7 +606,11 @@ bool DeviceOptionsToContextFlags(DeviceOptions device_options, int *flags) {
     return port::Status::OK();
   }
 
+#if CUDA_VERSION >= 7000
   string message = "failed call to cuDevicePrimaryCtxRetain: " + ToString(res);
+#else
+  string message = "failed call to cuCtxCreate: " + ToString(res);
+#endif
   if (res == CUDA_ERROR_OUT_OF_MEMORY) {
     uint64 total_memory;
     if (GetDeviceTotalMemory(device, &total_memory)) {
@@ -617,6 +627,7 @@ bool DeviceOptionsToContextFlags(DeviceOptions device_options, int *flags) {
   if (context == nullptr) {
     return;
   }
+#if CUDA_VERSION >= 7000
   CUcontext former_context = CurrentContext();
   CUresult res = dynload::cuCtxSetCurrent(context->context());
   CUdevice device;
@@ -624,8 +635,12 @@ bool DeviceOptionsToContextFlags(DeviceOptions device_options, int *flags) {
   dynload::cuCtxSetCurrent(former_context);
 
   res = dynload::cuDevicePrimaryCtxRelease(device);
+#else
+  CUresult res = dynload::cuCtxDestroy_v2(context->context());
+#endif
+
   if (res != CUDA_SUCCESS) {
-    LOG(ERROR) << "failed to release primary CUDA context; leaking: " << ToString(res);
+    LOG(ERROR) << "failed to release CUDA context; leaking: " << ToString(res);
   }
 
   CreatedContexts::Remove(context->context());


### PR DESCRIPTION
Using cuCtxCreate/Destroy does not give any benefits over using primary context and is not advised by the CUDA documentation: http://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#multiple-contexts.
Moreover, it breaks interaction with some runtime API calls, like cudaPointerGetAttributes and cudaEnablePeerAccess (see section Context Interoperability in: http://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DRIVER.html#group__CUDART__DRIVER).
This PR changes how the context are obtained and released from cuCtxCreate/Destroy to cuDevicePrimaryCtxRetain/Release 
