### PR TITLE
[issue#4453]Get rid of the variable_op wrapper.

### DIFF
--- a/tensorflow/python/framework/graph_util_test.py
+++ b/tensorflow/python/framework/graph_util_test.py
@@ -25,8 +25,8 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import graph_util
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_util
+from tensorflow.python.ops import gen_state_ops
 from tensorflow.python.ops import math_ops  # pylint: disable=unused-import
-from tensorflow.python.ops import state_ops
 
 
 # Utility device function to use for testing
@@ -40,17 +40,23 @@ class DeviceFunctionsTest(tf.test.TestCase):
 
   def testTwoDeviceFunctions(self):
     with ops.Graph().as_default() as g:
-      var_0 = state_ops.variable_op([1], dtype=dtypes.float32)
-
+      var_0 = gen_state_ops._variable(shape=[1], dtype=dtypes.float32, 
+          name="var_0", container="", shared_name="")
       with g.device(test_device_func_pin_variable_to_cpu):
-        var_1 = state_ops.variable_op([1], dtype=dtypes.float32)
-      var_2 = state_ops.variable_op([1], dtype=dtypes.float32)
-      var_3 = state_ops.variable_op([1], dtype=dtypes.float32)
+        var_1 = gen_state_ops._variable(shape=[1], dtype=dtypes.float32, 
+            name="var_1", container="", shared_name="")
+      var_2 = gen_state_ops._variable(shape=[1], dtype=dtypes.float32, 
+          name="var_2", container="", shared_name="")
+      var_3 = gen_state_ops._variable(shape=[1], dtype=dtypes.float32, 
+          name="var_3", container="", shared_name="")
       with g.device(test_device_func_pin_variable_to_cpu):
-        var_4 = state_ops.variable_op([1], dtype=dtypes.float32)
+        var_4 = gen_state_ops._variable(shape=[1], dtype=dtypes.float32, 
+            name="var_4", container="", shared_name="")
         with g.device("/device:GPU:0"):
-          var_5 = state_ops.variable_op([1], dtype=dtypes.float32)
-        var_6 = state_ops.variable_op([1], dtype=dtypes.float32)
+          var_5 = gen_state_ops._variable(shape=[1], dtype=dtypes.float32, 
+              name="var_5", container="", shared_name="")
+        var_6 = gen_state_ops._variable(shape=[1], dtype=dtypes.float32, 
+            name="var_6", container="", shared_name="")
 
     self.assertDeviceEqual(var_0.device, None)
     self.assertDeviceEqual(var_1.device, "/device:CPU:0")

--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -23,7 +23,7 @@ import tensorflow as tf
 
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_util
-from tensorflow.python.ops import state_ops
+from tensorflow.python.ops import gen_state_ops
 
 
 class TensorUtilTest(tf.test.TestCase):
@@ -552,7 +552,8 @@ class ConstantValueTest(tf.test.TestCase):
     self.assertAllClose(np_val, tf.contrib.util.constant_value(tf_val))
 
   def testUnknown(self):
-    tf_val = state_ops.variable_op(shape=[3, 4, 7], dtype=tf.float32)
+    tf_val = gen_state_ops._variable(shape=[3, 4, 7], dtype=tf.float32, 
+        name="tf_val", container="", shared_name="")
     self.assertIs(None, tf.contrib.util.constant_value(tf_val))
 
   def testShape(self):

--- a/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
+++ b/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
@@ -33,6 +33,7 @@ from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import gen_data_flow_ops
 from tensorflow.python.ops import gen_logging_ops
+from tensorflow.python.ops import gen_state_ops
 from tensorflow.python.ops import state_ops
 from tensorflow.python.util import nest
 
@@ -430,7 +431,8 @@ class ControlFlowTest(tf.test.TestCase):
 
   def testCondRef(self):
     with self.test_session():
-      x = state_ops.variable_op([1], tf.float32)
+      x = gen_state_ops._variable(shape=[1], dtype=tf.float32, 
+          name="x", container="", shared_name="")
       true_fn = lambda: x
       false_fn = lambda: tf.constant([2.0])
       r = tf.cond(tf.constant(False), true_fn, false_fn)
@@ -438,7 +440,8 @@ class ControlFlowTest(tf.test.TestCase):
 
   def testUninitializedRefIdentity(self):
     with self.test_session() as sess:
-      v = state_ops.variable_op([1], tf.float32)
+      v = gen_state_ops._variable(shape=[1], dtype=tf.float32, 
+          name="v", container="", shared_name="")      
       inited = state_ops.is_variable_initialized(v)
       v_f, v_t = control_flow_ops.ref_switch(v, inited)
       # Both v_f and v_t are uninitialized references. However, an actual use

--- a/tensorflow/python/kernel_tests/variables_test.py
+++ b/tensorflow/python/kernel_tests/variables_test.py
@@ -24,8 +24,8 @@ import numpy as np
 import tensorflow as tf
 
 from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import gen_state_ops
 from tensorflow.python.ops import random_ops
-from tensorflow.python.ops import state_ops
 from tensorflow.python.ops import variables
 
 
@@ -535,7 +535,8 @@ class VariableContainerTest(tf.test.TestCase):
         v1 = tf.Variable([1])
         with tf.container("l2"):
           v2 = tf.Variable([2])
-          special_v = state_ops.variable_op([1], tf.float32, container="l3")
+          special_v = gen_state_ops._variable(shape=[1], dtype=tf.float32, 
+              name="VariableInL3", container="l3", shared_name="")
         v3 = tf.Variable([3])
       v4 = tf.Variable([4])
     self.assertEqual(tf.compat.as_bytes(""), v0.op.get_attr("container"))

--- a/tensorflow/python/training/learning_rate_decay_test.py
+++ b/tensorflow/python/training/learning_rate_decay_test.py
@@ -22,6 +22,7 @@ import math
 
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import test_util
+from tensorflow.python.ops import gen_state_ops
 from tensorflow.python.ops import state_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import googletest
@@ -39,7 +40,8 @@ class LRDecayTest(test_util.TensorFlowTestCase):
 
   def testStaircase(self):
     with self.test_session():
-      step = state_ops.variable_op([], dtypes.int32)
+      step = gen_state_ops._variable(shape=[], dtype=dtypes.int32, 
+          name="step", container="", shared_name="")
       assign_100 = state_ops.assign(step, 100)
       assign_1 = state_ops.assign(step, 1)
       assign_2 = state_ops.assign(step, 2)
@@ -223,7 +225,8 @@ class ExponentialDecayTest(test_util.TensorFlowTestCase):
     initial_lr = 0.1
     k = 10
     decay_rate = 0.96
-    step = state_ops.variable_op([], dtypes.int32)
+    step = gen_state_ops._variable(shape=[], dtype=dtypes.int32, 
+        name="step", container="", shared_name="")
     assign_step = state_ops.assign(step, 0)
     increment_step = state_ops.assign_add(step, 1)
     decayed_lr = learning_rate_decay.natural_exp_decay(initial_lr, step,
@@ -239,7 +242,8 @@ class ExponentialDecayTest(test_util.TensorFlowTestCase):
     initial_lr = 0.1
     k = 10
     decay_rate = 0.96
-    step = state_ops.variable_op([], dtypes.int32)
+    step = gen_state_ops._variable(shape=[], dtype=dtypes.int32, 
+        name="step", container="", shared_name="")
     assign_step = state_ops.assign(step, 0)
     increment_step = state_ops.assign_add(step, 1)
     decayed_lr = learning_rate_decay.natural_exp_decay(initial_lr,
@@ -261,7 +265,8 @@ class InverseDecayTest(test_util.TensorFlowTestCase):
     initial_lr = 0.1
     k = 10
     decay_rate = 0.96
-    step = state_ops.variable_op([], dtypes.int32)
+    step = gen_state_ops._variable(shape=[], dtype=dtypes.int32, 
+        name="step", container="", shared_name="")    
     assign_step = state_ops.assign(step, 0)
     increment_step = state_ops.assign_add(step, 1)
     decayed_lr = learning_rate_decay.inverse_time_decay(initial_lr,
@@ -279,7 +284,8 @@ class InverseDecayTest(test_util.TensorFlowTestCase):
     initial_lr = 0.1
     k = 10
     decay_rate = 0.96
-    step = state_ops.variable_op([], dtypes.int32)
+    step = gen_state_ops._variable(shape=[], dtype=dtypes.int32, 
+        name="step", container="", shared_name="")
     assign_step = state_ops.assign(step, 0)
     increment_step = state_ops.assign_add(step, 1)
     decayed_lr = learning_rate_decay.inverse_time_decay(initial_lr,

--- a/tensorflow/python/training/moving_averages_test.py
+++ b/tensorflow/python/training/moving_averages_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow.python.ops import state_ops
+from tensorflow.python.ops import gen_state_ops
 from tensorflow.python.training import moving_averages
 
 
@@ -270,7 +270,9 @@ class ExponentialMovingAverageTest(tf.test.TestCase):
     with tf.device("/job:dev_v0"):
       v0 = tf.Variable(10.0, name="v0")
     with tf.device("/job:dev_v1"):
-      v1 = state_ops.variable_op(shape=[1], dtype=tf.float32, name="v1")
+      v1 = gen_state_ops._variable(shape=[1], dtype=tf.float32, 
+          name="v1", container="", shared_name="")
+      v1.set_shape([1])
     tensor2 = v0 + v1
     ema = tf.train.ExponentialMovingAverage(0.25, name="foo_avg")
     with tf.device("/job:default"):


### PR DESCRIPTION
PR for the `# TODO(mrry): Move this to where it is used, so we can get rid of this op wrapper?`
in the [state_ops.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/state_ops.py#L151)

Details refer to [issue#4453](https://github.com/tensorflow/tensorflow/issues/4453)

Changed file list which call the `state_ops.variable_op()`:

```
Variables.py
Variables_test.py
Tensor_util_test.py
Moving_averages_test.py
Learning_rate_decay_test.py
Graph_util_test.py
Control_flow_ops_py_test.py
```

@drpngx Please review
