### PR TITLE
Fix test_tutorial failure due to d9d7fa

### DIFF
--- a/tensorflow/tools/ci_build/builds/test_tutorials.sh
+++ b/tensorflow/tools/ci_build/builds/test_tutorials.sh
@@ -146,7 +146,7 @@ test_mnist_with_summaries() {
 
   run_in_directory "${TEST_DIR}" "${LOG_FILE}" \
     tensorflow/examples/tutorials/mnist/mnist_with_summaries.py \
-    --data_dir="${TUT_TEST_DATA_DIR}/mnist" --summaries_dir="${SUMMARIES_DIR}"
+    --data_dir="${TUT_TEST_DATA_DIR}/mnist" --log_dir="${SUMMARIES_DIR}"
 
   # Verify final accuracy
   FINAL_ACCURACY=$(grep "Accuracy at step" "${LOG_FILE}" \


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/commit/d9d7fa28a069eb34c829c1a0d4221e73a7677d5a

See tutorial test failure example at: http://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/269/console
