### PR TITLE
Fix: For mac non-docker GPU builds fix handling of test concurrency.

### DIFF
--- a/tensorflow/tools/ci_build/builds/test_installation.sh
+++ b/tensorflow/tools/ci_build/builds/test_installation.sh
@@ -47,9 +47,6 @@
 # TF_BUILD_BAZEL_CLEAN, if set to any non-empty and non-0 value, directs the
 # script to perform bazel clean prior to main build and test steps.
 #
-# TF_BUILD_USE_GPU, if set to 1, limits the number of concurrent tests to
-# the number stored in TF_GPU_COUNT and assigns each test to a different GPU.
-#
 # TF_GPU_COUNT, Set the number of GPUs in the system. We run only this many
 # concurrent tests when running GPU tests.
 #
@@ -410,7 +407,7 @@ SKIP_COUNTER=0
 FAILED_TESTS=""
 FAILED_TEST_LOGS=""
 
-if [[ "${TF_BUILD_USE_GPU}" == "1" ]]; then
+if [[ "${IS_GPU}" == "1" ]]; then
   N_JOBS=$TF_GPU_COUNT
 else
   N_JOBS=$(grep -c ^processor /proc/cpuinfo)
@@ -484,7 +481,7 @@ while true; do
     TEST_LOGS="${TEST_LOGS} ${TEST_LOG}"
 
     # Launch test asynchronously
-    if [[ "${TF_BUILD_USE_GPU}" == "1" ]]; then
+    if [[ "${IS_GPU}" == "1" ]]; then
       "${SCRIPT_DIR}/../gpu_build/parallel_gpu_execute.sh" \
         "${SCRIPT_DIR}/py_test_delegate.sh" \
         "${PYTHON_BIN_PATH}" "${PY_TEST_DIR}/${TEST_BASENAME}" "${TEST_LOG}" &

--- a/tensorflow/tools/ci_build/ci_build.sh
+++ b/tensorflow/tools/ci_build/ci_build.sh
@@ -103,10 +103,8 @@ WORKSPACE="${WORKSPACE:-$(upsearch WORKSPACE)}"
 BUILD_TAG="${BUILD_TAG:-tf_ci}"
 
 # Add extra params for cuda devices and libraries for GPU container.
-if [ "${CONTAINER_TYPE}" == "gpu" ]; then
-  # GPU pip tests-on-install concurrency is limited to the number of GPUs.
-  GPU_EXTRA_PARAMS="${GPU_EXTRA_PARAMS} -e TF_BUILD_USE_GPU=1"
-else
+# And clear them if we are not building for GPU.
+if [ "${CONTAINER_TYPE}" != "gpu" ]; then
   GPU_EXTRA_PARAMS=""
 fi
 


### PR DESCRIPTION
@mrry This should fix mac-gpu tests.
@yifeif, let me test this. After that we should also cherrypick this into r0.11.

@caisq I keep messing up this change, please feel free to point out any problems or concerns you see.
