### PR TITLE
reimplement viterbi decoding in tensorflow way

### DIFF
--- a/tensorflow/contrib/crf/python/ops/crf.py
+++ b/tensorflow/contrib/crf/python/ops/crf.py
@@ -314,4 +314,4 @@ def viterbi_decode(score, transition_params):
   viterbi.reverse()
 
   viterbi_score = tf.reduce_max(prev, reduction_indices=1)
-    return tf.pack(viterbi, axis=1), viterbi_score
+  return tf.pack(viterbi, axis=1), viterbi_score


### PR DESCRIPTION
The original viterbi decoding in `tensorflow.contrib.crf` is implemented in numpy way and can only be used in testing. This update reimplement viterbi decoding in tensorflow style, can provide more flexibility during model building.
