### PR TITLE
gemmlopw has been added to external dependencies.

### DIFF
--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -95,6 +95,7 @@ set(tensorflow_EXTERNAL_DEPENDENCIES
     highwayhash_copy_headers_to_destination
     protobuf
     eigen
+    gemmlowp
 )
 
 include_directories(


### PR DESCRIPTION
Hi guys,
I was building tf using CMake in ubuntu. I found out that an external dependency (gemmlowp) is missing from the CMakeLists.txt file. The building failed while compiling tf_core_kernels files. I just added the dependency and everything went OK.
