### PR TITLE
Fix: replace deprecated nvcc flag with its replacement.

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -416,7 +416,7 @@ def _cuda_copts():
         "@local_config_cuda//cuda:using_nvcc": (
             common_cuda_opts +
             [
-                "-nvcc_options=relaxed-constexpr",
+                "-nvcc_options=expt-relaxed-constexpr",
                 "-nvcc_options=ftz=true",
             ]
         ),


### PR DESCRIPTION
Remedy for the warning:
INFO: From Compiling *.cu.cc:
nvcc warning : option '--relaxed-constexpr' has been deprecated and replaced by option '--expt-relaxed-constexpr'.
nvcc warning : option '--relaxed-constexpr' has been deprecated and replaced by option '--expt-relaxed-constexpr'.
