### PR TITLE
Update the misleading comment for cifar10.py's softmax_linear layer

### DIFF
--- a/tensorflow/models/image/cifar10/cifar10.py
+++ b/tensorflow/models/image/cifar10/cifar10.py
@@ -257,8 +257,9 @@ def inference(images):
     _activation_summary(local4)
 
   # linear layer(WX + b),
-  # We don't apply softmax here because tf.nn.sparse_softmax_cross_entropy_with_logits
-  # accepts the unscaled logits and performs the softmax internally for efficiency.
+  # We don't apply softmax here because 
+  # tf.nn.sparse_softmax_cross_entropy_with_logits accepts the unscaled logits 
+  # and performs the softmax internally for efficiency.
   with tf.variable_scope('softmax_linear') as scope:
     weights = _variable_with_weight_decay('weights', [192, NUM_CLASSES],
                                           stddev=1/192.0, wd=0.0)

--- a/tensorflow/models/image/cifar10/cifar10.py
+++ b/tensorflow/models/image/cifar10/cifar10.py
@@ -256,7 +256,8 @@ def inference(images):
     local4 = tf.nn.relu(tf.matmul(local3, weights) + biases, name=scope.name)
     _activation_summary(local4)
 
-  # softmax, i.e. softmax(WX + b)
+  # linear layer(WX + b),
+  # no softmax ops here because tf.nn.sparse_softmax_cross_entropy_with_logits() only accept unscaled logits.
   with tf.variable_scope('softmax_linear') as scope:
     weights = _variable_with_weight_decay('weights', [192, NUM_CLASSES],
                                           stddev=1/192.0, wd=0.0)

--- a/tensorflow/models/image/cifar10/cifar10.py
+++ b/tensorflow/models/image/cifar10/cifar10.py
@@ -257,7 +257,8 @@ def inference(images):
     _activation_summary(local4)
 
   # linear layer(WX + b),
-  # no softmax ops here because tf.nn.sparse_softmax_cross_entropy_with_logits() only accept unscaled logits.
+  # We don't apply softmax here because tf.nn.sparse_softmax_cross_entropy_with_logits
+  # accepts the unscaled logits and performs the softmax internally for efficiency.
   with tf.variable_scope('softmax_linear') as scope:
     weights = _variable_with_weight_decay('weights', [192, NUM_CLASSES],
                                           stddev=1/192.0, wd=0.0)


### PR DESCRIPTION
A fix for the issue #5251, make the comment more meaningful.
