### PR TITLE
Fix deprecated usage of variable_op_scope

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -1370,7 +1370,7 @@ def layer_norm(inputs,
     outputs_collections: collections to add the outputs.
     trainable: If `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
-    scope: Optional scope for `variable_op_scope`.
+    scope: Optional scope for `variable_scope`.
 
   Returns:
     A `Tensor` representing the output of the operation.

--- a/tensorflow/contrib/learn/python/learn/estimators/linear.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/linear.py
@@ -142,8 +142,8 @@ def _linear_classifier_model_fn(features, labels, mode, params):
       max_partitions=num_ps_replicas,
       min_slice_size=64 << 20)
 
-  with variable_scope.variable_op_scope(
-      features.values(), parent_scope, partitioner=partitioner) as scope:
+  with variable_scope.variable_scope(
+      parent_scope, values=features.values(), partitioner=partitioner) as scope:
     if joint_weights:
       logits, _, _ = (
           layers.joint_weighted_sum_from_feature_columns(


### PR DESCRIPTION
`variable_scope.variable_op_scope` was deprecated in commit 3d1ee95, but some of codes or documentations are not updated. This patch fixes them in favor of `variable_scope`.
