### PR TITLE
- fix for memory corruption: on windows use _aligned_free() for memor…

### DIFF
--- a/tensorflow/contrib/cmake/tf_core_kernels.cmake
+++ b/tensorflow/contrib/cmake/tf_core_kernels.cmake
@@ -85,33 +85,34 @@ list(REMOVE_ITEM tf_core_kernels_srcs ${tf_core_kernels_exclude_srcs})
 if(WIN32)
   file(GLOB_RECURSE tf_core_kernels_windows_exclude_srcs
       # not working on windows yet
-      "${tensorflow_source_dir}/tensorflow/core/kernels/depthwise_conv_op.cc"  # Cannot find symbol: tensorflow::LaunchConv2DOp<struct Eigen::ThreadPoolDevice, double>::launch(...).
       "${tensorflow_source_dir}/tensorflow/core/kernels/fact_op.cc"
-      "${tensorflow_source_dir}/tensorflow/core/kernels/immutable_constant_op.cc"
-      "${tensorflow_source_dir}/tensorflow/core/kernels/immutable_constant_op.h"
-      "${tensorflow_source_dir}/tensorflow/core/kernels/meta_support.*"
-      "${tensorflow_source_dir}/tensorflow/core/kernels/sparse_matmul_op.cc"
-      "${tensorflow_source_dir}/tensorflow/core/kernels/sparse_matmul_op.h"
       "${tensorflow_source_dir}/tensorflow/core/kernels/*quantiz*.h"
       "${tensorflow_source_dir}/tensorflow/core/kernels/*quantiz*.cc"
+      "${tensorflow_source_dir}/tensorflow/core/kernels/meta_support.*"
       "${tensorflow_source_dir}/tensorflow/core/kernels/svd*.cc"
       "${tensorflow_source_dir}/tensorflow/core/kernels/avgpooling_op.*"
   )
   list(REMOVE_ITEM tf_core_kernels_srcs ${tf_core_kernels_windows_exclude_srcs})
 endif(WIN32)
 
-file(GLOB_RECURSE tf_core_gpu_kernels_srcs
-   "${tensorflow_source_dir}/tensorflow/core/kernels/*.cu.cc"
-   "${tensorflow_source_dir}/tensorflow/contrib/rnn/kernels/*.cu.cc"
-)
+if(WIN32 AND tensorflow_ENABLE_GPU)
+  file(GLOB_RECURSE tf_core_gpu_kernels_srcs
+     "${tensorflow_source_dir}/tensorflow/core/kernels/*.cu.cc"
+     "${tensorflow_source_dir}/tensorflow/contrib/rnn/kernels/*.cu.cc"
+  )
 
-if(WIN32)
   file(GLOB_RECURSE tf_core_gpu_kernels_exclude_srcs
       # not working on windows yet
       "${tensorflow_source_dir}/tensorflow/core/kernels/avgpooling_op_gpu.cu.cc"
   )
   list(REMOVE_ITEM tf_core_gpu_kernels_srcs ${tf_core_gpu_kernels_exclude_srcs})
-endif(WIN32)
+
+  # if we build for gpu include those  
+  list(APPEND tf_core_kernels_srcs 
+     "${tensorflow_source_dir}/tensorflow/core/kernels/debug_ops.h"
+     "${tensorflow_source_dir}/tensorflow/core/kernels/debug_ops.cc"
+  )
+endif(WIN32 AND tensorflow_ENABLE_GPU)
 
 add_library(tf_core_kernels OBJECT ${tf_core_kernels_srcs})
 add_dependencies(tf_core_kernels tf_core_cpu)

--- a/tensorflow/core/common_runtime/gpu/pool_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/pool_allocator.h
@@ -173,7 +173,11 @@ class BasicCPUAllocator : public SubAllocator {
   void* Alloc(size_t alignment, size_t num_bytes) override {
     return port::aligned_malloc(num_bytes, alignment);
   }
+#if defined(PLATFORM_WINDOWS)
+  void Free(void* ptr, size_t num_bytes)  override { _aligned_free(ptr); }
+#else
   void Free(void* ptr, size_t num_bytes) override { free(ptr); }
+#endif
 };
 
 // Allocator for pinned CPU RAM that is made known to CUDA for the

--- a/tensorflow/core/kernels/immutable_constant_op.cc
+++ b/tensorflow/core/kernels/immutable_constant_op.cc
@@ -96,9 +96,9 @@ void ImmutableConstantOp::Compute(OpKernelContext* ctx) {
 }
 
 ImmutableConstantOp::~ImmutableConstantOp() {}
-constexpr char ImmutableConstantOp::kDTypeAttr[];
-constexpr char ImmutableConstantOp::kShapeAttr[];
-constexpr char ImmutableConstantOp::kMemoryRegionNameAttr[];
+constexpr char* ImmutableConstantOp::kDTypeAttr;
+constexpr char* ImmutableConstantOp::kShapeAttr;
+constexpr char* ImmutableConstantOp::kMemoryRegionNameAttr;
 
 REGISTER_KERNEL_BUILDER(Name("ImmutableConst").Device(DEVICE_CPU),
                         ImmutableConstantOp);

--- a/tensorflow/core/kernels/immutable_constant_op.h
+++ b/tensorflow/core/kernels/immutable_constant_op.h
@@ -33,9 +33,9 @@ class ImmutableConstantOp : public OpKernel {
   ~ImmutableConstantOp() override;
 
   // Names of attributes that are used by this op
-  static constexpr char kDTypeAttr[] = "dtype";
-  static constexpr char kShapeAttr[] = "shape";
-  static constexpr char kMemoryRegionNameAttr[] = "memory_region_name";
+  static constexpr char* kDTypeAttr = "dtype";
+  static constexpr char* kShapeAttr = "shape";
+  static constexpr char* kMemoryRegionNameAttr = "memory_region_name";
 
  private:
   string region_name_;

--- a/tensorflow/core/kernels/sparse_matmul_op.cc
+++ b/tensorflow/core/kernels/sparse_matmul_op.cc
@@ -79,7 +79,7 @@ static const int N = 128;
 // index_offset.
 template <typename T>
 struct SparseSlice {
-  typedef Eigen::TensorMap<Eigen::Tensor<const T, 2, Eigen::RowMajor>,
+  typedef Eigen::TensorMap<Eigen::Tensor<const typename T, 2, Eigen::RowMajor>,
                            Eigen::Aligned>
       ConstMatrixMap;
 
@@ -109,7 +109,7 @@ struct SparseSlice {
   // size (num_rows, num_cols).
   // If Transpose is true, implicitly transposes mat.
   template <bool Transpose = false>
-  void Initialize(const ConstMatrixMap& mat, int col_offset);
+  void Initialize(const typename ConstMatrixMap& mat, int col_offset);
 
   void Clear();
 
@@ -134,7 +134,7 @@ struct SparseSlice {
 
 template <typename T>
 template <bool Transpose>
-void SparseSlice<T>::Initialize(const SparseSlice<T>::ConstMatrixMap& mat,
+void SparseSlice<T>::Initialize(const typename SparseSlice<T>::ConstMatrixMap& mat,
                                 int col_offset) {
   const int mat_rows = Transpose ? mat.dimension(1) : mat.dimension(0);
   const int mat_cols = Transpose ? mat.dimension(0) : mat.dimension(1);
@@ -950,7 +950,7 @@ class SparseMatMulOp : public OpKernel {
 template <typename TL, typename TR>
 inline void SparseMatMul<TL, TR>::ComputeOutputBlock(
     const std::vector<SparseSlice<TL>*>& left,
-    const SparseMatMul<TL, TR>::ConstMatrixMapR& right, int num_cols,
+    const typename SparseMatMul<TL, TR>::ConstMatrixMapR& right, int num_cols,
     int output_row_offset, int output_col_offset, bool assign,
     bool transpose_output, MatrixMap* output) {
   static const Eigen::array<int, 2> perm({1, 0});
@@ -1000,7 +1000,7 @@ inline void SparseMatMul<TL, TR>::ComputeOutputBlock(
 
 template <typename TL, typename TR>
 inline BlockingCounter* SparseMatMul<TL, TR>::CreateSparseSlices(
-    const SparseMatMul<TL, TR>::ConstMatrixMapL& mat, bool transpose,
+    const typename SparseMatMul<TL, TR>::ConstMatrixMapL& mat, bool transpose,
     int slice_num_rows, int slice_block_size, int slice_num_cols,
     std::vector<std::vector<SparseSlice<TL>*>>* mat_slices,
     const DeviceBase::CpuWorkerThreads* thread_pool) {
@@ -1044,7 +1044,7 @@ inline BlockingCounter* SparseMatMul<TL, TR>::CreateSparseSlices(
           new SparseSlice<TL>(num_rows, num_cols, slice_block_size);
       (*mat_slices)[i][j] = sparse_slice;
       thread_pool->workers->Schedule(
-          [=]() { work(sparse_slice, slice, slice_num_cols * j); });
+          std::bind(work, sparse_slice, slice, slice_num_cols * j));
     }
   }
   return counter;
@@ -1096,7 +1096,7 @@ ALWAYS_INLINE void CopyAndMayBeInterleave(void* dst, const void* src,
 
 template <typename TL, typename TR>
 inline BlockingCounter* SparseMatMul<TL, TR>::ShuffleMatrix(
-    const SparseMatMul<TL, TR>::ConstMatrixMapR& mat, int slice_row_start,
+    const typename SparseMatMul<TL, TR>::ConstMatrixMapR& mat, int slice_row_start,
     int slice_num_rows, int slice_col_start, int slice_num_cols, const int N,
     const DeviceBase::CpuWorkerThreads* thread_pool, MatrixR* buffer) {
   DCHECK_EQ(N % 2, 0);
@@ -1143,7 +1143,7 @@ inline BlockingCounter* SparseMatMul<TL, TR>::ShuffleMatrix(
   DCHECK_LE(num_out_rows, buffer->dimension(0));
   for (int i = std::max(1, num_threads); i > 0; --i) {
     end = start + num_out_rows / i;
-    thread_pool->workers->Schedule([=]() { shuffle_work(start, end); });
+    thread_pool->workers->Schedule(std::bind(shuffle_work, start, end));
     num_out_rows -= (end - start);
     start = end;
   }
@@ -1153,7 +1153,7 @@ inline BlockingCounter* SparseMatMul<TL, TR>::ShuffleMatrix(
 template <typename TL, typename TR>
 inline void SparseMatMul<TL, TR>::SliceMatrix(
     const MatrixR& mat, const int num_rows, const int num_slices,
-    std::vector<SparseMatMul<TL, TR>::ConstMatrixMapR*>* slices) {
+    std::vector<typename SparseMatMul<TL, TR>::ConstMatrixMapR*>* slices) {
   slices->resize(num_slices);
   DSizes d(num_rows, mat.dimension(1));
   DCHECK_LE(num_rows * num_slices, mat.dimension(0));
@@ -1164,10 +1164,10 @@ inline void SparseMatMul<TL, TR>::SliceMatrix(
 
 template <typename TL, typename TR>
 inline BlockingCounter* SparseMatMul<TL, TR>::CreateDenseSlices(
-    const SparseMatMul<TL, TR>::ConstMatrixMapR& mat, int row_start,
+    const typename SparseMatMul<TL, TR>::ConstMatrixMapR& mat, int row_start,
     int num_rows, int col_start, int num_cols,
     const DeviceBase::CpuWorkerThreads* thread_pool, MatrixR* buffer,
-    std::vector<SparseMatMul<TL, TR>::ConstMatrixMapR*>* slices) {
+    std::vector<typename SparseMatMul<TL, TR>::ConstMatrixMapR*>* slices) {
   BlockingCounter* shuffle_counter = ShuffleMatrix(
       mat, row_start, num_rows, col_start, num_cols, N, thread_pool, buffer);
   const int num_slices = (num_cols + N - 1) / N;
@@ -1177,8 +1177,8 @@ inline BlockingCounter* SparseMatMul<TL, TR>::CreateDenseSlices(
 
 template <typename TL, typename TR>
 inline void SparseMatMul<TL, TR>::ComputeBlockSizes(
-    const SparseMatMul<TL, TR>::ConstMatrixMapL& left,
-    const SparseMatMul<TL, TR>::ConstMatrixMapR& right, bool transpose_left,
+    const typename SparseMatMul<TL, TR>::ConstMatrixMapL& left,
+    const typename SparseMatMul<TL, TR>::ConstMatrixMapR& right, bool transpose_left,
     int num_threads, int* KR, int* NR, int* KL, int* JB, int* IB) {
   // Heuristics for calculating block sizes
   // Assume two hyperthreads per core.
@@ -1248,8 +1248,8 @@ inline void SparseMatMul<TL, TR>::ComputeBlockSizes(
 //    {l_i} and JB elements from {r_j} and compute the IB * JB inner products.
 template <typename TL, typename TR>
 inline void SparseMatMul<TL, TR>::Compute(
-    const SparseMatMul<TL, TR>::ConstMatrixMapL& left,
-    const SparseMatMul<TL, TR>::ConstMatrixMapR& right, bool transpose_left,
+    const typename SparseMatMul<TL, TR>::ConstMatrixMapL& left,
+    const typename SparseMatMul<TL, TR>::ConstMatrixMapR& right, bool transpose_left,
     const DeviceBase::CpuWorkerThreads* thread_pool, bool transpose_output,
     MatrixMap* output) {
   const int num_threads = thread_pool->num_threads;

--- a/tensorflow/core/kernels/sparse_matmul_op.h
+++ b/tensorflow/core/kernels/sparse_matmul_op.h
@@ -18,6 +18,22 @@ limitations under the License.
 
 #include "third_party/eigen3/Eigen/Core"
 #include "tensorflow/core/platform/types.h"
+#ifdef _MSC_VER
+#define _mm_load_pd1 _mm_load1_pd
+static inline int
+_mm256_extract_epi32(__m256i a, const int i)
+{
+  return a.m256i_i32[i & 7];
+}
+
+static inline __m256i
+_mm256_insert_epi32(__m256i a, int b, const int i)
+{
+  __m256i c = a;
+  c.m256i_i32[i & 7] = b;
+  return c;
+}
+#endif
 
 namespace Eigen {
 namespace internal {

--- a/tensorflow/core/platform/test.cc
+++ b/tensorflow/core/platform/test.cc
@@ -13,6 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#ifdef PLATFORM_WINDOWS
+#include <Windows.h>
+#endif
+
 #include "tensorflow/core/platform/types.h"
 
 #if defined(PLATFORM_GOOGLE) || defined(PLATFORM_POSIX_ANDROID) || \
@@ -37,7 +41,14 @@ string TmpDir() {
   if (env && env[0] != '\0') {
     return env;
   }
+#ifdef PLATFORM_WINDOWS
+  char buffer[MAX_PATH + 1];
+  buffer[0] = '\0';
+  ::GetTempPath(sizeof(buffer), buffer);
+  return buffer;
+#else
   return "/tmp";
+#endif
 }
 string SrcDir() {
   // Bazel makes data dependencies available via a relative path.

--- a/tensorflow/stream_executor/dso_loader.cc
+++ b/tensorflow/stream_executor/dso_loader.cc
@@ -117,7 +117,10 @@ string GetCudnnVersion() { return TF_CUDNN_VERSION; }
       port::Env::Default()->LoadLibrary(path_string.c_str(), dso_handle);
   if (!s.ok()) {
     LOG(INFO) << "Couldn't open CUDA library " << path
-              << ". LD_LIBRARY_PATH: " << getenv("LD_LIBRARY_PATH");
+#if !defined(PLATFORM_WINDOWS)
+              << ". LD_LIBRARY_PATH: " << getenv("LD_LIBRARY_PATH")
+#endif
+    ;
     return port::Status(port::error::FAILED_PRECONDITION,
                         port::StrCat("could not dlopen DSO: ", path,
                                      "; dlerror: ", s.error_message()));


### PR DESCRIPTION
…y allocated with aligned_alloc()
- enabled sparse_matmul and immutable_constant_op
- don't print LD_LIBRARY_PATH on error for windows (its null and crashes)
  with this python kernel tests pass (well, some error left related to stl float Inf)
