### PR TITLE
Change file system FileExists interface to return Status

### DIFF
--- a/tensorflow/cc/saved_model/loader_test.cc
+++ b/tensorflow/cc/saved_model/loader_test.cc
@@ -50,7 +50,9 @@ class LoaderTest : public ::testing::Test {
         io::JoinPath(export_dir, kSavedModelAssetsDirectory);
     const string asset_filename = "foo.txt";
     const string asset_filepath = io::JoinPath(asset_directory, asset_filename);
-    EXPECT_TRUE(Env::Default()->FileExists(asset_filepath));
+    bool result;
+    EXPECT_TRUE(Env::Default()->FileExists(asset_filepath, &result).ok() &&
+                result);
 
     std::vector<Tensor> path_outputs;
     TF_ASSERT_OK(

--- a/tensorflow/contrib/session_bundle/session_bundle.cc
+++ b/tensorflow/contrib/session_bundle/session_bundle.cc
@@ -107,10 +107,13 @@ string GetVariablesFilename(const StringPiece export_dir) {
   const char kVariablesFilename[] = "export";
   const string kVariablesIndexFilename = MetaFilename("export");  // V2 ckpts
   const char kVariablesFilenamePattern[] = "export-\?\?\?\?\?-of-\?\?\?\?\?";
-  if (Env::Default()->FileExists(
-          io::JoinPath(export_dir, kVariablesFilename)) ||
-      Env::Default()->FileExists(
-          io::JoinPath(export_dir, kVariablesIndexFilename))) {
+  bool result;
+  if ((Env::Default()->FileExists(
+          io::JoinPath(export_dir, kVariablesFilename), &result).ok() &&
+       result) ||
+      (Env::Default()->FileExists(
+          io::JoinPath(export_dir, kVariablesIndexFilename), &result).ok() &&
+       result)) {
     return io::JoinPath(export_dir, kVariablesFilename);
   } else {
     return io::JoinPath(export_dir, kVariablesFilenamePattern);
@@ -248,7 +251,9 @@ Status LoadSessionBundleFromPathUsingRunOptions(const SessionOptions& options,
 bool IsPossibleExportDirectory(const StringPiece directory) {
   const string meta_graph_def_path =
       io::JoinPath(directory, kMetaGraphDefFilename);
-  return Env::Default()->FileExists(meta_graph_def_path);
+  bool result;
+  return Env::Default()->FileExists(meta_graph_def_path, &result).ok() &&
+         result;
 }
 
 }  // namespace serving

--- a/tensorflow/core/debug/debug_io_utils_test.cc
+++ b/tensorflow/core/debug/debug_io_utils_test.cc
@@ -170,10 +170,11 @@ TEST_F(DebugIOUtilsTest, DumpTensorToFileCannotCreateDirectory) {
   const string test_dir = testing::TmpDir();
   const string txt_file_name = strings::StrCat(test_dir, "/baz");
 
-  if (!env_->FileExists(test_dir)) {
+  bool result;
+  if (env_->FileExists(test_dir, &result).ok() && !result) {
     ASSERT_TRUE(env_->CreateDir(test_dir).ok());
   }
-  ASSERT_FALSE(env_->FileExists(txt_file_name));
+  ASSERT_TRUE(env_->FileExists(txt_file_name, &result).ok() && !result);
 
   std::unique_ptr<WritableFile> file;
   ASSERT_TRUE(env_->NewWritableFile(txt_file_name, &file).ok());
@@ -182,7 +183,7 @@ TEST_F(DebugIOUtilsTest, DumpTensorToFileCannotCreateDirectory) {
   file->Close();
 
   // Verify that the path exists and that it is a file, not a directory.
-  ASSERT_TRUE(env_->FileExists(txt_file_name));
+  ASSERT_TRUE(env_->FileExists(txt_file_name, &result).ok() && result);
   ASSERT_FALSE(env_->IsDirectory(txt_file_name).ok());
 
   // Second, try to dump the tensor to a path that requires "baz" to be a

--- a/tensorflow/core/kernels/debug_ops_test.cc
+++ b/tensorflow/core/kernels/debug_ops_test.cc
@@ -90,7 +90,8 @@ TEST_F(DebugIdentityOpTest, Int32Success_6_FileURLs) {
   test::ExpectTensorEqual<int32>(expected, *GetOutput(0));
 
   for (int i = 0; i < kNumDumpDirs; ++i) {
-    ASSERT_TRUE(env_->FileExists(dump_roots[i]));
+    bool result;
+    ASSERT_TRUE(env_->FileExists(dump_roots[i], &result).ok() && result);
     ASSERT_TRUE(env_->IsDirectory(dump_roots[i]).ok());
 
     DIR* dir = opendir(dump_roots[i].c_str());

--- a/tensorflow/core/platform/cloud/gcs_file_system.h
+++ b/tensorflow/core/platform/cloud/gcs_file_system.h
@@ -51,7 +51,7 @@ class GcsFileSystem : public FileSystem {
       const string& filename,
       std::unique_ptr<ReadOnlyMemoryRegion>* result) override;
 
-  bool FileExists(const string& fname) override;
+  Status FileExists(const string& fname, bool* result) override;
 
   Status Stat(const string& fname, FileStatistics* stat) override;
 

--- a/tensorflow/core/platform/cloud/gcs_file_system_test.cc
+++ b/tensorflow/core/platform/cloud/gcs_file_system_test.cc
@@ -496,7 +496,9 @@ TEST(GcsFileSystemTest, FileExists_YesAsObject) {
                        new FakeHttpRequestFactory(&requests)),
                    0 /* read ahead bytes */, 5 /* max upload attempts */);
 
-  EXPECT_TRUE(fs.FileExists("gs://bucket/path/file1.txt"));
+  bool result;
+  EXPECT_TRUE(fs.FileExists("gs://bucket/path/file1.txt", &result).ok() &&
+              result);
 }
 
 TEST(GcsFileSystemTest, FileExists_YesAsFolder) {
@@ -518,7 +520,9 @@ TEST(GcsFileSystemTest, FileExists_YesAsFolder) {
                        new FakeHttpRequestFactory(&requests)),
                    0 /* read ahead bytes */, 5 /* max upload attempts */);
 
-  EXPECT_TRUE(fs.FileExists("gs://bucket/path/subfolder"));
+  bool result;
+  EXPECT_TRUE(fs.FileExists("gs://bucket/path/subfolder", &result).ok() &&
+              result);
 }
 
 TEST(GcsFileSystemTest, FileExists_YesAsBucket) {
@@ -536,8 +540,9 @@ TEST(GcsFileSystemTest, FileExists_YesAsBucket) {
                        new FakeHttpRequestFactory(&requests)),
                    0 /* read ahead bytes */, 5 /* max upload attempts */);
 
-  EXPECT_TRUE(fs.FileExists("gs://bucket1"));
-  EXPECT_TRUE(fs.FileExists("gs://bucket1/"));
+  bool result;
+  EXPECT_TRUE(fs.FileExists("gs://bucket1", &result).ok() && result);
+  EXPECT_TRUE(fs.FileExists("gs://bucket1/", &result).ok() && result);
 }
 
 TEST(GcsFileSystemTest, FileExists_NotAsObjectOrFolder) {
@@ -558,7 +563,9 @@ TEST(GcsFileSystemTest, FileExists_NotAsObjectOrFolder) {
                        new FakeHttpRequestFactory(&requests)),
                    0 /* read ahead bytes */, 5 /* max upload attempts */);
 
-  EXPECT_FALSE(fs.FileExists("gs://bucket/path/file1.txt"));
+  bool result;
+  EXPECT_TRUE(fs.FileExists("gs://bucket/path/file1.txt", &result).ok() &&
+              !result);
 }
 
 TEST(GcsFileSystemTest, FileExists_NotAsBucket) {
@@ -575,8 +582,9 @@ TEST(GcsFileSystemTest, FileExists_NotAsBucket) {
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
                    0 /* read ahead bytes */, 5 /* max upload attempts */);
-  EXPECT_FALSE(fs.FileExists("gs://bucket2/"));
-  EXPECT_FALSE(fs.FileExists("gs://bucket2"));
+  bool result;
+  EXPECT_TRUE(fs.FileExists("gs://bucket2/", &result).ok() && !result);
+  EXPECT_TRUE(fs.FileExists("gs://bucket2", &result).ok() && !result);
 }
 
 TEST(GcsFileSystemTest, GetChildren_NoItems) {

--- a/tensorflow/core/platform/cloud/retrying_file_system.cc
+++ b/tensorflow/core/platform/cloud/retrying_file_system.cc
@@ -162,9 +162,10 @@ Status RetryingFileSystem::NewReadOnlyMemoryRegionFromFile(
                          initial_delay_microseconds_);
 }
 
-bool RetryingFileSystem::FileExists(const string& fname) {
-  // No status -- no retries.
-  return base_file_system_->FileExists(fname);
+Status RetryingFileSystem::FileExists(const string& fname, bool* result) {
+  return CallWithRetries(std::bind(&FileSystem::FileExists,
+                                   base_file_system_.get(), fname, result),
+                         initial_delay_microseconds_);
 }
 
 Status RetryingFileSystem::Stat(const string& fname, FileStatistics* stat) {

--- a/tensorflow/core/platform/cloud/retrying_file_system.h
+++ b/tensorflow/core/platform/cloud/retrying_file_system.h
@@ -45,7 +45,7 @@ class RetryingFileSystem : public FileSystem {
       const string& filename,
       std::unique_ptr<ReadOnlyMemoryRegion>* result) override;
 
-  bool FileExists(const string& fname) override;
+  Status FileExists(const string& fname, bool* result) override;
 
   Status GetChildren(const string& dir, std::vector<string>* result) override;
 

--- a/tensorflow/core/platform/cloud/retrying_file_system_test.cc
+++ b/tensorflow/core/platform/cloud/retrying_file_system_test.cc
@@ -100,7 +100,9 @@ class MockFileSystem : public FileSystem {
     return calls_.ConsumeNextCall("NewReadOnlyMemoryRegionFromFile");
   }
 
-  bool FileExists(const string& fname) override { return true; }
+  Status FileExists(const string& fname, bool* result) override {
+    return calls_.ConsumeNextCall("FileExists");
+  }
 
   Status GetChildren(const string& dir, std::vector<string>* result) override {
     return calls_.ConsumeNextCall("GetChildren");

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -117,12 +117,10 @@ Status Env::NewAppendableFile(const string& fname,
   return fs->NewAppendableFile(fname, result);
 }
 
-bool Env::FileExists(const string& fname) {
+Status Env::FileExists(const string& fname, bool* result) {
   FileSystem* fs;
-  if (!GetFileSystemForFile(fname, &fs).ok()) {
-    return false;
-  }
-  return fs->FileExists(fname);
+  TF_RETURN_IF_ERROR(GetFileSystemForFile(fname, &fs));
+  return fs->FileExists(fname, result);
 }
 
 Status Env::GetChildren(const string& dir, std::vector<string>* result) {

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -132,8 +132,11 @@ class Env {
   Status NewReadOnlyMemoryRegionFromFile(
       const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result);
 
-  /// Returns true iff the named file exists.
-  bool FileExists(const string& fname);
+  /// \brief Stores in *result true if the named file exists, else false.
+  ///
+  /// On success, set *result and returns OK. On failure *result is undefined
+  /// and returns non-OK.
+  Status FileExists(const string& fname, bool* result);
 
   /// \brief Stores in *result the names of the children of the specified
   /// directory. The names are relative to "dir".

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -61,7 +61,7 @@ class FileSystem {
   virtual Status NewReadOnlyMemoryRegionFromFile(
       const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result) = 0;
 
-  virtual bool FileExists(const string& fname) = 0;
+  virtual Status FileExists(const string& fname, bool* result) = 0;
 
   /// \brief Returns the immediate children in the given directory.
   ///
@@ -178,7 +178,10 @@ class NullFileSystem : public FileSystem {
         "NewReadOnlyMemoryRegionFromFile unimplemented");
   }
 
-  bool FileExists(const string& fname) override { return false; }
+  Status FileExists(const string& fname, bool* result) override {
+    *result = false;
+    return errors::Unimplemented("FileExists unimplemented");
+  }
 
   Status GetChildren(const string& dir, std::vector<string>* result) override {
     return errors::Unimplemented("GetChildren unimplemented");

--- a/tensorflow/core/platform/file_system_test.cc
+++ b/tensorflow/core/platform/file_system_test.cc
@@ -31,10 +31,11 @@ static const char* const kPrefix = "ipfs://solarsystem";
 // cannot have children further.
 class InterPlanetaryFileSystem : public NullFileSystem {
  public:
-  bool FileExists(const string& fname) override {
+  Status FileExists(const string& fname, bool* result) override {
     string parsed_path;
     ParsePath(fname, &parsed_path);
-    return BodyExists(parsed_path);
+    *result = BodyExists(parsed_path);
+    return Status::OK();
   }
 
   // Adds the dir to the parent's children list and creates an entry for itself.

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.h
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.h
@@ -45,7 +45,7 @@ class HadoopFileSystem : public FileSystem {
       const string& fname,
       std::unique_ptr<ReadOnlyMemoryRegion>* result) override;
 
-  bool FileExists(const string& fname) override;
+  Status FileExists(const string& fname, bool* result) override;
 
   Status GetChildren(const string& dir, std::vector<string>* result) override;
 

--- a/tensorflow/core/platform/hadoop/hadoop_file_system_test.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system_test.cc
@@ -100,9 +100,10 @@ TEST_F(HadoopFileSystemTest, WritableFile) {
 TEST_F(HadoopFileSystemTest, FileExists) {
   const string fname =
       "file://" + io::JoinPath(testing::TmpDir(), "FileExists");
-  EXPECT_FALSE(hdfs.FileExists(fname));
+  bool result;
+  EXPECT_TRUE(hdfs.FileExists(fname, &result).ok() && !result);
   TF_ASSERT_OK(WriteString(fname, "test"));
-  EXPECT_TRUE(hdfs.FileExists(fname));
+  EXPECT_TRUE(hdfs.FileExists(fname, &result).ok() && result);
 }
 
 TEST_F(HadoopFileSystemTest, GetChildren) {
@@ -175,7 +176,8 @@ TEST_F(HadoopFileSystemTest, RenameFile_Overwrite) {
       "file://" + io::JoinPath(testing::TmpDir(), "RenameFile2");
 
   TF_ASSERT_OK(WriteString(fname2, "test"));
-  EXPECT_TRUE(hdfs.FileExists(fname2));
+  bool result;
+  EXPECT_TRUE(hdfs.FileExists(fname2, &result).ok() && result);
 
   TF_ASSERT_OK(WriteString(fname1, "test"));
   TF_EXPECT_OK(hdfs.RenameFile(fname1, fname2));

--- a/tensorflow/core/platform/posix/posix_file_system.cc
+++ b/tensorflow/core/platform/posix/posix_file_system.cc
@@ -191,8 +191,16 @@ Status PosixFileSystem::NewReadOnlyMemoryRegionFromFile(
   return s;
 }
 
-bool PosixFileSystem::FileExists(const string& fname) {
-  return access(TranslateName(fname).c_str(), F_OK) == 0;
+Status PosixFileSystem::FileExists(const string& fname, bool* result) {
+  if (access(TranslateName(fname).c_str(), F_OK) != 0) {
+    if (errno != ENOENT) {
+      return IOError(fname, errno);
+    }
+    *result = false;
+  } else {
+    *result = true;
+  }
+  return Status::OK();
 }
 
 Status PosixFileSystem::GetChildren(const string& dir,

--- a/tensorflow/core/platform/posix/posix_file_system.h
+++ b/tensorflow/core/platform/posix/posix_file_system.h
@@ -40,7 +40,7 @@ class PosixFileSystem : public FileSystem {
       const string& filename,
       std::unique_ptr<ReadOnlyMemoryRegion>* result) override;
 
-  bool FileExists(const string& fname) override;
+  Status FileExists(const string& fname, bool* result) override;
 
   Status GetChildren(const string& dir, std::vector<string>* result) override;
 

--- a/tensorflow/core/platform/windows/windows_file_system.cc
+++ b/tensorflow/core/platform/windows/windows_file_system.cc
@@ -371,9 +371,18 @@ Status WindowsFileSystem::NewReadOnlyMemoryRegionFromFile(
   return s;
 }
 
-bool WindowsFileSystem::FileExists(const string& fname) {
+Status WindowsFileSystem::FileExists(const string& fname, bool* result) {
   constexpr int kOk = 0;
-  return _access(TranslateName(fname).c_str(), kOk) == 0;
+  if (_access(TranslateName(fname).c_str(), kOk) != 0) {
+    if (errno != ENOENT) {
+      return IOError("Failed to access file: " + fname, errno);
+    }
+    *result = false;
+  } else {
+    *result = true;
+  }
+
+  return Status::OK();
 }
 
 Status WindowsFileSystem::GetChildren(const string& dir,

--- a/tensorflow/core/platform/windows/windows_file_system.h
+++ b/tensorflow/core/platform/windows/windows_file_system.h
@@ -43,7 +43,7 @@ class WindowsFileSystem : public FileSystem {
       const string& fname,
       std::unique_ptr<ReadOnlyMemoryRegion>* result) override;
 
-  bool FileExists(const string& fname) override;
+  Status FileExists(const string& fname, bool* result) override;
 
   Status GetChildren(const string& dir, std::vector<string>* result) override;
 

--- a/tensorflow/core/util/events_writer.cc
+++ b/tensorflow/core/util/events_writer.cc
@@ -154,7 +154,8 @@ bool EventsWriter::Close() {
 }
 
 bool EventsWriter::FileHasDisappeared() {
-  if (env_->FileExists(filename_)) {
+  bool result;
+  if (env_->FileExists(filename_, &result).ok() && result) {
     return false;
   } else {
     // This can happen even with non-null recordio_writer_ if some other

--- a/tensorflow/core/util/events_writer_test.cc
+++ b/tensorflow/core/util/events_writer_test.cc
@@ -61,7 +61,8 @@ static bool ReadEventProto(io::RecordReader* reader, uint64* offset,
 }
 
 void VerifyFile(const string& filename) {
-  CHECK(env()->FileExists(filename));
+  bool result;
+  CHECK(env()->FileExists(filename, &result).ok() && result);
   std::unique_ptr<RandomAccessFile> event_file;
   TF_CHECK_OK(env()->NewRandomAccessFile(filename, &event_file));
   io::RecordReader* reader = new io::RecordReader(event_file.get());
@@ -139,11 +140,12 @@ TEST(EventWriter, FailFlush) {
   EventsWriter writer(file_prefix);
   string filename = writer.FileName();
   WriteFile(&writer);
-  EXPECT_TRUE(env()->FileExists(filename));
+  bool result;
+  EXPECT_TRUE(env()->FileExists(filename, &result).ok() && result);
   env()->DeleteFile(filename);
-  EXPECT_FALSE(env()->FileExists(filename));
+  EXPECT_TRUE(env()->FileExists(filename, &result).ok() && !result);
   EXPECT_FALSE(writer.Flush());
-  EXPECT_FALSE(env()->FileExists(filename));
+  EXPECT_TRUE(env()->FileExists(filename, &result).ok() && !result);
 }
 
 TEST(EventWriter, FailClose) {
@@ -151,11 +153,12 @@ TEST(EventWriter, FailClose) {
   EventsWriter writer(file_prefix);
   string filename = writer.FileName();
   WriteFile(&writer);
-  EXPECT_TRUE(env()->FileExists(filename));
+  bool result;
+  EXPECT_TRUE(env()->FileExists(filename, &result).ok() && result);
   env()->DeleteFile(filename);
-  EXPECT_FALSE(env()->FileExists(filename));
+  EXPECT_TRUE(env()->FileExists(filename, &result).ok() && !result);
   EXPECT_FALSE(writer.Close());
-  EXPECT_FALSE(env()->FileExists(filename));
+  EXPECT_TRUE(env()->FileExists(filename, &result).ok() && !result);
 }
 
 TEST(EventWriter, InitWriteClose) {
@@ -163,7 +166,8 @@ TEST(EventWriter, InitWriteClose) {
   EventsWriter writer(file_prefix);
   EXPECT_TRUE(writer.Init());
   string filename0 = writer.FileName();
-  EXPECT_TRUE(env()->FileExists(filename0));
+  bool result;
+  EXPECT_TRUE(env()->FileExists(filename0, &result).ok() && result);
   WriteFile(&writer);
   EXPECT_TRUE(writer.Close());
   string filename1 = writer.FileName();
@@ -175,7 +179,8 @@ TEST(EventWriter, NameWriteClose) {
   string file_prefix = GetDirName("/namewriteclose_test");
   EventsWriter writer(file_prefix);
   string filename = writer.FileName();
-  EXPECT_TRUE(env()->FileExists(filename));
+  bool result;
+  EXPECT_TRUE(env()->FileExists(filename, &result).ok() && result);
   WriteFile(&writer);
   EXPECT_TRUE(writer.Close());
   VerifyFile(filename);
@@ -186,7 +191,8 @@ TEST(EventWriter, NameClose) {
   EventsWriter writer(file_prefix);
   string filename = writer.FileName();
   EXPECT_TRUE(writer.Close());
-  EXPECT_TRUE(env()->FileExists(filename));
+  bool result;
+  EXPECT_TRUE(env()->FileExists(filename, &result).ok() && result);
   env()->DeleteFile(filename);
 }
 
@@ -194,7 +200,8 @@ TEST(EventWriter, FileDeletionBeforeWriting) {
   string file_prefix = GetDirName("/fdbw_test");
   EventsWriter writer(file_prefix);
   string filename0 = writer.FileName();
-  EXPECT_TRUE(env()->FileExists(filename0));
+  bool result;
+  EXPECT_TRUE(env()->FileExists(filename0, &result).ok() && result);
   env()->SleepForMicroseconds(
       2000000);  // To make sure timestamp part of filename will differ.
   env()->DeleteFile(filename0);

--- a/tensorflow/core/util/memmapped_file_system.cc
+++ b/tensorflow/core/util/memmapped_file_system.cc
@@ -79,12 +79,13 @@ class RandomAccessFileFromMemmapped : public RandomAccessFile {
 
 MemmappedFileSystem::MemmappedFileSystem() {}
 
-bool MemmappedFileSystem::FileExists(const string& fname) {
+Status MemmappedFileSystem::FileExists(const string& fname, bool* result) {
   if (!mapped_memory_) {
-    return false;
+    return errors::FailedPrecondition("MemmappedEnv is not initialized");
   }
   const auto dir_element = directory_.find(fname);
-  return dir_element != directory_.end();
+  *result = dir_element != directory_.end();
+  return Status::OK();
 }
 
 Status MemmappedFileSystem::NewRandomAccessFile(

--- a/tensorflow/core/util/memmapped_file_system.h
+++ b/tensorflow/core/util/memmapped_file_system.h
@@ -60,7 +60,7 @@ class MemmappedFileSystem : public FileSystem {
 
   MemmappedFileSystem();
   ~MemmappedFileSystem() override = default;
-  bool FileExists(const string& fname) override;
+  Status FileExists(const string& fname, bool* result) override;
   Status NewRandomAccessFile(
       const string& filename,
       std::unique_ptr<RandomAccessFile>* result) override;

--- a/tensorflow/core/util/memmapped_file_system_test.cc
+++ b/tensorflow/core/util/memmapped_file_system_test.cc
@@ -102,8 +102,10 @@ TEST(MemmappedFileSystemTest, SimpleTest) {
           .code());
 
   // Check FileExists.
-  EXPECT_TRUE(memmapped_env.FileExists(kTensor2FileName));
-  EXPECT_FALSE(memmapped_env.FileExists("bla-bla-bla"));
+  bool result;
+  EXPECT_TRUE(memmapped_env.FileExists(kTensor2FileName, &result).ok() &&
+              result);
+  EXPECT_TRUE(memmapped_env.FileExists("bla-bla-bla", &result).ok() && !result);
 }
 
 TEST(MemmappedFileSystemTest, NotInitalized) {

--- a/tensorflow/core/util/reporter.cc
+++ b/tensorflow/core/util/reporter.cc
@@ -54,7 +54,9 @@ Status TestReporter::Initialize() {
   string mangled_fname = strings::StrCat(
       fname_, str_util::Join(str_util::Split(test_name_, '/'), "__"));
   Env* env = Env::Default();
-  if (env->FileExists(mangled_fname)) {
+  bool result;
+  TF_RETURN_IF_ERROR(env->FileExists(mangled_fname, &result));
+  if (result) {
     return errors::InvalidArgument("Cannot create TestReporter, file exists: ",
                                    mangled_fname);
   }

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
@@ -364,7 +364,9 @@ TEST(TensorBundleTest, DirectoryStructure) {
                              gtl::ArraySlice<string> expected_files) {
     StringPiece dir = io::Dirname(bundle_prefix);
     for (const string& expected_file : expected_files) {
-      EXPECT_TRUE(env->FileExists(io::JoinPath(dir, expected_file)));
+      bool result;
+      EXPECT_TRUE(env->FileExists(
+            io::JoinPath(dir, expected_file), &result).ok() && result);
     }
   };
 

--- a/tensorflow/g3doc/api_docs/cc/ClassEnv.md
+++ b/tensorflow/g3doc/api_docs/cc/ClassEnv.md
@@ -78,7 +78,7 @@ The returned memory region can be accessed from many threads in parallel.
 
 The ownership of the returned ReadOnlyMemoryRegion is passed to the caller and the object should be deleted when is not used. The memory region object shouldn&apos;t live longer than the Env object.
 
-#### `bool tensorflow::Env::FileExists(const string &fname)` {#bool_tensorflow_Env_FileExists}
+#### `Status tensorflow::Env::FileExists(const string &fname, bool *result)` {#Status_tensorflow_Env_FileExists}
 
 Returns true iff the named file exists.
 

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -190,9 +190,13 @@ def file_exists(filename):
     filename: string, a path
 
   Returns:
-    True if the path exists, whether its a file or a directory.
+    True if the path exists, ether its a file or a directory.
+
+  Raises:
+    errors.OpError: Propagates any errors reported by the FileSystem API.
   """
-  return pywrap_tensorflow.FileExists(compat.as_bytes(filename))
+  with errors.raise_exception_on_not_ok_status() as status:
+    return pywrap_tensorflow.FileExists(compat.as_bytes(filename), status)
 
 
 def delete_file(filename):

--- a/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
+++ b/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
@@ -177,7 +177,8 @@ bool CUDAExecutor::FindOnDiskForComputeCapability(
   // have been migrated.
   string cc_specific = port::StrCat(filename.ToString(), ".cc", cc_major_,
                                     cc_minor_, canonical_suffix.ToString());
-  if (port::FileExists(cc_specific)) {
+  bool result;
+  if (port::FileExists(cc_specific, &result).ok() && result) {
     VLOG(2) << "found compute-capability-specific file, using that: "
             << cc_specific;
     *found_filename = cc_specific;
@@ -186,7 +187,7 @@ bool CUDAExecutor::FindOnDiskForComputeCapability(
 
   VLOG(2) << "could not find compute-capability specific file at: "
           << cc_specific;
-  if (port::FileExists(filename.ToString())) {
+  if (port::FileExists(filename.ToString(), &result).ok() && result) {
     *found_filename = filename.ToString();
     return true;
   }

--- a/tensorflow/stream_executor/lib/env.h
+++ b/tensorflow/stream_executor/lib/env.h
@@ -29,12 +29,12 @@ using tensorflow::ReadFileToString;
 using tensorflow::Thread;
 using tensorflow::WriteStringToFile;
 
-inline bool FileExists(const string& filename) {
-  return Env::Default()->FileExists(filename);
+inline Status FileExists(const string& filename, bool* result) {
+  return Env::Default()->FileExists(filename, result);
 }
 
-inline bool FileExists(const port::StringPiece& filename) {
-  return Env::Default()->FileExists(filename.ToString());
+inline Status FileExists(const port::StringPiece& filename, bool* result) {
+  return Env::Default()->FileExists(filename.ToString(), result);
 }
 
 }  // namespace port


### PR DESCRIPTION
The pull request addresses issue https://github.com/tensorflow/tensorflow/issues/5321.

The calling code are modified to handle error condition at best effort, if the outer caller function does not return error, it's simply changed to
```c++
FileExists(name, &result).ok() && result
```

Tests:
Tests run except windows implementation. HDFS is tested with 2.7.3 pseudo-distributed mode.

PS: The folowwing tests may fail when all tests run together, but pass when run standalone, should not related to this change
```
//tensorflow/contrib/session_bundle:exporter_test
//tensorflow/tensorboard/backend:server_test
//tensorflow/contrib/tensor_forest/hybrid:k_feature_routing_function_op_test
//tensorflow/contrib/learn:random_forest_test
```