### PR TITLE
Remove hard coded file system scheme checking in tensorboard code

### DIFF
--- a/tensorflow/core/lib/io/path.cc
+++ b/tensorflow/core/lib/io/path.cc
@@ -196,6 +196,7 @@ void ParseURI(StringPiece remaining, StringPiece* scheme, StringPiece* host,
   // 0. Parse scheme
   // Make sure scheme matches [a-zA-Z][0-9a-zA-Z.]*
   // TODO(keveman): Allow "+" and "-" in the scheme.
+  // Keep URI pattern in tensorboard/backend/server.py updated accordingly
   if (!strings::Scanner(remaining)
            .One(strings::Scanner::LETTER)
            .Many(strings::Scanner::LETTER_DIGIT_DOT)

--- a/tensorflow/tensorboard/backend/server.py
+++ b/tensorflow/tensorboard/backend/server.py
@@ -25,6 +25,7 @@ import functools
 import os
 import threading
 import time
+import re
 
 import six
 from six.moves import BaseHTTPServer
@@ -67,21 +68,19 @@ def ParseEventFilesSpec(logdir):
   files = {}
   if logdir is None:
     return files
+  uri_pattern = re.compile("[^:/]+://.*")
   for specification in logdir.split(','):
-    # If it's a gcs or hdfs path, don't split on colon
-    if (io_wrapper.IsGCSPath(specification) or
-        specification.startswith('hdfs://')):
-      run_name = None
-      path = specification
-    # If the spec looks like /foo:bar/baz, then we assume it's a path with a
-    # colon.
-    elif ':' in specification and specification[0] != '/':
+    # Check if the spec contains group. A spec start with xyz:// is regarded as
+    # URI path spec instead of group spec. If the spec looks like /foo:bar/baz,
+    # then we assume it's a path with a colon.
+    if uri_pattern.match(specification) is None and \
+       ':' in specification and specification[0] != '/':
       # We split at most once so run_name:/path:with/a/colon will work.
       run_name, _, path = specification.partition(':')
     else:
       run_name = None
       path = specification
-    if not (io_wrapper.IsGCSPath(path) or path.startswith('hdfs://')):
+    if uri_pattern.match(path) is None:
       path = os.path.realpath(path)
     files[path] = run_name
   return files

--- a/tensorflow/tensorboard/backend/server.py
+++ b/tensorflow/tensorboard/backend/server.py
@@ -68,7 +68,8 @@ def ParseEventFilesSpec(logdir):
   files = {}
   if logdir is None:
     return files
-  uri_pattern = re.compile("[^:/]+://.*")
+  # Make sure keeping consistent with ParseURI in core/lib/io/path.cc
+  uri_pattern = re.compile("[a-zA-Z][0-9a-zA-Z.]://.*")
   for specification in logdir.split(','):
     # Check if the spec contains group. A spec start with xyz:// is regarded as
     # URI path spec instead of group spec. If the spec looks like /foo:bar/baz,

--- a/tensorflow/tensorboard/backend/server_test.py
+++ b/tensorflow/tensorboard/backend/server_test.py
@@ -470,6 +470,11 @@ class ParseEventFilesSpecTest(tf.test.TestCase):
     expected = {'gs://foo/./path//..': None}
     self.assertEqual(server.ParseEventFilesSpec(logdir_string), expected)
 
+  def testRunNameWithGCSPath(self):
+    logdir_string = 'lol:gs://foo/path'
+    expected = {'gs://foo/path': 'lol'}
+    self.assertEqual(server.ParseEventFilesSpec(logdir_string), expected)
+
 
 class TensorBoardAssetsTest(tf.test.TestCase):
 


### PR DESCRIPTION
This pull request addresses https://github.com/tensorflow/tensorflow/issues/5322.

This patch also fixes the case `run_name:gs://path` incorrect parsing issue.

There is still one file not cleaned up: [directory_watcher.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/summary/impl/directory_watcher.py#L181). However, this does not affecting adding other file systems.

That one can't be removed now because in GCS `Stat` for folder is not supported. However, according to [GCS API document](https://cloud.google.com/storage/docs/json_api/v1/objects/list), stat for a folder can be supported by summing sizes of all objects with that common prefix (In fact, our blob store has similar interface, and stat for folder is implemented likewise).