### PR TITLE
Add a .mention-bot config.

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,11 @@
+{
+  "maxReviewers": 2,
+  "numFilesToCheck": 10, // Number of files to check against, default is 5
+  "userBlacklist": ["tensorflower-gardener"], // users in this list will never be mentioned by mention-bot
+  "requiredOrgs": ["tensorflow"], // mention-bot will only mention user who are a member of one of these organizations
+  "skipAlreadyAssignedPR": true, // mention-bot will ignore already assigned PR's
+  "skipAlreadyMentionedPR": true, // mention-bot will ignore if there is already existing an exact mention
+  "skipTitle": "Branch", // mention-bot will ignore PR that includes text in the title,
+  "delayed": true, // mention-bot will wait to comment until specified time in `delayedUntil` value
+  "delayedUntil": "10m",
+}


### PR DESCRIPTION
Notable configs:
- Only mention people in "tensorflow" org
- Our tensorflow-gardener catch-all github user is never mentioned.
- Wait 10 minutes for mentioning (to avoid spam when we manually assign)
- Skip assignment for internal pushes