### PR TITLE
Add environment variable to configure usage of default python library path

### DIFF
--- a/util/python/python_config.sh
+++ b/util/python/python_config.sh
@@ -120,20 +120,28 @@ function setup_python {
     IFS=','
     python_lib_path=($(python_path))
     unset IFS
-    echo "Found possible Python library paths:"
-    for x in "${python_lib_path[@]}"; do
-      echo "  $x"
-    done
-    set -- "${python_lib_path[@]}"
-    echo "Please input the desired Python library path to use.  Default is ["$1"]"
-    read b || true
-    if [ "$b" == "" ]; then
+
+    if [ 1 -eq $USE_DEFAULT_PYTHON_LIB_PATH ]; then
       PYTHON_LIB_PATH="$(default_python_path "${python_lib_path[0]}")"
-      echo $PYTHON_LIB_PATH
+      echo "Using python library path: $PYTHON_LIB_PATH"
+
     else
-      PYTHON_LIB_PATH="$b"
+      echo "Found possible Python library paths:"
+      for x in "${python_lib_path[@]}"; do
+        echo "  $x"
+      done
+      set -- "${python_lib_path[@]}"
+      echo "Please input the desired Python library path to use.  Default is ["$1"]"
+      read b || true
+      if [ "$b" == "" ]; then
+        PYTHON_LIB_PATH="$(default_python_path "${python_lib_path[0]}")"
+        echo $PYTHON_LIB_PATH
+      else
+        PYTHON_LIB_PATH="$b"
+      fi
     fi
   fi
+    
   if test -d "$PYTHON_LIB_PATH" -a -x "$PYTHON_LIB_PATH"; then
     python_lib="$PYTHON_LIB_PATH"
   else


### PR DESCRIPTION
Some changes to `util/python_config.sh` since release version r0.10 introduced the problem that the user is asked to choose the python library path during `./configure`. The problem with this is that automated scripts / builds have no option to choose the default python library path. 

In PR #5135, an environment variable has been introduced to configure the python library path via an environment variable to get around this problem. However, it leaves the script using `./configure` with the task to find a correct python library path. In many scenarios this cannot be hard coded and determining it with code means to replicate the logic that is already in the script.

Therefore this PR adds an additional environment variable named `USE_DEFAULT_PYTHON_LIB_PATH`. Like the name says, if this variable is set to `1`, the default python library path is used without user interaction. 