### PR TITLE
Fix misleading SaveDef V2 format warning

### DIFF
--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -1289,6 +1289,7 @@ class Saver(object):
       logging.warning("Consider switching to the more efficient V2 format now:")
       logging.warning("   `tf.train.Saver(write_version=tf.train.SaverDef.V2)`")
       logging.warning("to prevent breakage.")
+      logging.warning("Notice: the V2 format output different set of files")
       logging.warning("*******************************************************")
 
     if os.path.split(latest_filename)[0]:


### PR DESCRIPTION
Adding a line: **Notice: the V2 format output different set of files**

The original warning made me think I can switch simply by adding the `write_graph` argument, but it turns out the outputs of `saver.save(sess, "model.ckpt")` are also different with the new format.

Originally, it writes to the file `model.ckpt`, but now it writes to `model.ckpt.index` and `model.ckpt.data.*`, which breaks the logic.