### PR TITLE
Update 1_notmnist.ipynb

### DIFF
--- a/tensorflow/examples/udacity/1_notmnist.ipynb
+++ b/tensorflow/examples/udacity/1_notmnist.ipynb
@@ -109,7 +109,7 @@
         "outputId": "0d0f85df-155f-4a89-8e7e-ee32df36ec8d"
       },
       "source": [
-        "url = 'http://commondatastorage.googleapis.com/books1000/'\n",
+        "url = 'http://yaroslavvb.com/upload/notMNIST/'\n",
         "last_percent_reported = None\n",
         "\n",
         "def download_progress_hook(count, blockSize, totalSize):\n",


### PR DESCRIPTION
I'm learning Tensorflow on the Udacity,and while I flow the course to test code,I found that the url in Update 1_notmnist.ipynb is wrong,it can't be open.After a while,I found the url in the video is different from the one in the file,so I pause the vedio and remenber the url.This url is ok and it pass the test perfectly. Thx for ur attention.