### PR TITLE
fix failed copy for op without outputs but with control outputs

### DIFF
--- a/tensorflow/contrib/graph_editor/tests/transform_test.py
+++ b/tensorflow/contrib/graph_editor/tests/transform_test.py
@@ -58,7 +58,7 @@ class TransformTest(tf.test.TestCase):
       self.assertEqual(t.name, t_.name)
       self.assertEqual(info.original(t_), t)
 
-  def test_copy_Assert(self):
+  def test_copy_assert(self):
     tf.reset_default_graph()
     a = tf.constant(1)
     b = tf.constant(1)

--- a/tensorflow/contrib/graph_editor/tests/transform_test.py
+++ b/tensorflow/contrib/graph_editor/tests/transform_test.py
@@ -58,6 +58,20 @@ class TransformTest(tf.test.TestCase):
       self.assertEqual(t.name, t_.name)
       self.assertEqual(info.original(t_), t)
 
+  def test_copy_Assert(self):
+    tf.reset_default_graph()
+    a = tf.constant(1)
+    b = tf.constant(1)
+    eq = tf.equal(a, b)
+    assert_op = tf.Assert(eq, [a, b])
+    with tf.control_dependencies([assert_op]):
+      _ = tf.add(a, b)
+    sgv = ge.make_view([assert_op, eq.op, a.op, b.op])
+    copier = ge.Transformer()
+    copied_sgv, info = copier(sgv, sgv.graph, "", "")
+    new_assert_op = info.transformed(assert_op)
+    self.assertIsNotNone(new_assert_op)
+
   def test_transform(self):
     transformer = ge.Transformer()
     def my_transform_op_handler(info, op):

--- a/tensorflow/contrib/graph_editor/transform.py
+++ b/tensorflow/contrib/graph_editor/transform.py
@@ -446,10 +446,7 @@ class Transformer(object):
     # without any outputs. So the walk is now finalized from those roots.
     remaining_ops = [op for op in self._info.sgv.ops
                      if op not in self._info.transformed_ops]
-    remaining_roots = [
-        op for op in remaining_ops
-        if not op.outputs and not self._info.control_outputs.get(op)
-    ]
+    remaining_roots = [op for op in remaining_ops if not op.outputs]
     for op in remaining_roots:
       self._transform_op(op)
 


### PR DESCRIPTION
This PR fixed copying op without outputs but with control outputs. This kind of op (which is common, e.g. Assert) is not copied at all before this PR.
btw, I'd like to add tests for my changes but I cannot find how to run bazel tests. There seems to be no guidance for contributions to Tensorflow.