### PR TITLE
Typo, causing AttributeError

### DIFF
--- a/tensorflow/models/image/mnist/convolutional.py
+++ b/tensorflow/models/image/mnist/convolutional.py
@@ -59,7 +59,7 @@ def maybe_download(filename):
   if not tf.gfile.Exists(filepath):
     filepath, _ = urllib.request.urlretrieve(SOURCE_URL + filename, filepath)
     with tf.gfile.GFile(filepath) as f:
-      size = f.Size()
+      size = f.size()
     print('Successfully downloaded', filename, size, 'bytes.')
   return filepath
 


### PR DESCRIPTION
$ ~/mnist $ python convolutional.py
Traceback (most recent call last):
  File "convolutional.py", line 316, in <module>
    tf.app.run()
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/platform/app.py", line 30, in run
    sys.exit(main(sys.argv[:1] + flags_passthrough))
  File "convolutional.py", line 123, in main
    train_labels_filename = maybe_download('train-labels-idx1-ubyte.gz')
  File "convolutional.py", line 62, in maybe_download
    size = f.Size()
AttributeError: 'GFile' object has no attribute 'Size'