### PR TITLE
Remove a premature checkpoint existence test in Saver.restore().

### DIFF
--- a/tensorflow/contrib/slim/python/slim/evaluation_test.py
+++ b/tensorflow/contrib/slim/python/slim/evaluation_test.py
@@ -26,6 +26,7 @@ import time
 import numpy as np
 import tensorflow as tf
 
+from tensorflow.python.framework import errors
 from tensorflow.python.platform import flags
 from tensorflow.python.platform import gfile
 
@@ -275,7 +276,7 @@ class SingleEvaluationTest(tf.test.TestCase):
     checkpoint_path = os.path.join(self.get_temp_dir(),
                                    'this_file_doesnt_exist')
     log_dir = os.path.join(self.get_temp_dir(), 'error_raised')
-    with self.assertRaises(ValueError):
+    with self.assertRaises(errors.NotFoundError):
       slim.evaluation.evaluate_once('', checkpoint_path, log_dir)
 
   def testRestoredModelPerformance(self):

--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -1326,21 +1326,9 @@ class Saver(object):
     Args:
       sess: A `Session` to use to restore the parameters.
       save_path: Path where parameters were previously saved.
-
-    Raises:
-      ValueError: If the given `save_path` does not point to a file.
     """
     if self._is_empty:
       return
-
-    # Performs this check only for V1, as the V2 restore op can read either a
-    # V1 ckpt or a V2 ckpt, making this check invalid.
-    if self.saver_def.version == saver_pb2.SaverDef.V1:
-      file_path = _prefix_to_checkpoint_path(save_path, self.saver_def.version)
-      if not file_io.get_matching_files(file_path):
-        raise ValueError("Restore called with invalid save path: %r. "
-                         "File path is: %r" % (save_path, file_path))
-
     sess.run(self.saver_def.restore_op_name,
              {self.saver_def.filename_tensor_name: save_path})
 

--- a/tensorflow/python/training/saver_test.py
+++ b/tensorflow/python/training/saver_test.py
@@ -191,8 +191,8 @@ class SaverTest(tf.test.TestCase):
     v0 = tf.Variable(0, name="v0")
     with self.test_session() as sess:
       save = tf.train.Saver({"v0": v0})
-      with self.assertRaisesRegexp(ValueError,
-                                   "^Restore called with invalid save path.*"):
+      with self.assertRaisesRegexp(errors.NotFoundError,
+                                   "Failed to find any matching files for"):
         save.restore(sess, "invalid path")
 
   def testInt64(self):


### PR DESCRIPTION
The correct way to perform such a check is inside the Op kernel.
Change: 138212174

(cherry picked from commit a2f0f07f59b318d255ba86c8ab3486466dece5a8)