### PR TITLE
Fix a typo in export meta graph sample code.

### DIFF
--- a/tensorflow/g3doc/how_tos/meta_graph/index.md
+++ b/tensorflow/g3doc/how_tos/meta_graph/index.md
@@ -207,7 +207,7 @@ Here are some of the typical usage models:
     sess.run(logits)
     # Creates a saver.
     saver0 = tf.train.Saver()
-    saver0.save(sess, saver0_ckpt)
+    saver0.save(sess, 'my-save-dir/my-model-10000')
     # Generates MetaGraphDef.
     saver0.export_meta_graph('my-save-dir/my-model-10000.meta')
   ```


### PR DESCRIPTION
The sample code in How-tos "Exporting and Importing a MetaGraph" cause NameError: name 'saver0_ckpt' is not defined.
I think it should be `'my-save-dir/my-model-10000'` to be restored in the subsequent sample code.

I've signed the CLA before for other Google's project (https://github.com/GoogleCloudPlatform/DataflowJavaSDK). Do I have to make another agreement?