### PR TITLE
Bugfix in gradient code for tf.image.resize_nearest_neighbor

### DIFF
--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -36,10 +36,16 @@ def _ResizeNearestNeighborGrad(op, grad):
   Returns:
     The gradients w.r.t. the input and the output.
   """
+  image = op.inputs[0]
+  if image.get_shape()[1:3].is_fully_defined():
+    image_shape = image.get_shape()[1:3]
+  else:
+    image_shape = array_ops.shape(image)[1:3]
+
   # pylint: disable=protected-access
   grads = gen_image_ops._resize_nearest_neighbor_grad(
       grad,
-      op.inputs[0].get_shape()[1:3],
+      image_shape,
       align_corners=op.get_attr("align_corners"))
   # pylint: enable=protected-access
   return [grads, None]


### PR DESCRIPTION
This PR prevents errors when computing gradients that involve `tf.image.resize_nearest_neighbor` and tensors with partially defined shapes.