### PR TITLE
Make sure to uninstall the old pip package and install the newly built

### DIFF
--- a/tensorflow/tools/ci_build/windows/cpu/cmake/run_py.bat
+++ b/tensorflow/tools/ci_build/windows/cpu/cmake/run_py.bat
@@ -28,10 +28,10 @@ CALL %REPO_ROOT%\tensorflow\tools\ci_build\windows\cpu\cmake\run_build.bat
 SET PIP_EXE="C:\Program Files\Anaconda3\Scripts\pip.exe"
 
 :: Uninstall tensorflow pip package, which might be a leftover from old runs.
-%PIP_EXE% uninstall tensorflow
+%PIP_EXE% uninstall -y tensorflow
 
 :: Install the pip package.
-%PIP_EXE% install %REPO_ROOT%\%BUILD_DIR%\tf_python\dist\tensorflow-0.11.0rc2_cmake_experimental-py3-none-any.whl
+%PIP_EXE% install --upgrade %REPO_ROOT%\%BUILD_DIR%\tf_python\dist\tensorflow-0.11.0rc2_cmake_experimental-py3-none-any.whl
 
 :: Run all python tests
 ctest -C Release --output-on-failure


### PR DESCRIPTION
one when running windows tests on TF CI.