### PR TITLE
Add support for broadcasting shapes.

### DIFF
--- a/tensorflow/python/framework/tensor_shape.py
+++ b/tensorflow/python/framework/tensor_shape.py
@@ -753,6 +753,64 @@ class TensorShape(object):
     if not self.is_compatible_with(other):
       raise ValueError("Shapes %s and %s are incompatible" % (self, other))
 
+  def is_broadcastable_with(self, other):
+    """Returns True iff `self` can be broadcast with `other`, i.e. an elementwise
+    operation would succeed.
+
+    Two possibly-partially-defined shapes are broadcastable if the last dimensions
+    are compatible, where a dimension of size `1` is treated in the same manner as
+    an undefined dimension. For example:
+
+    * TensorShape(None) is broadcastable with all shapes.
+
+    * TensorShape([None] * n) is also broadcastable with all shapes because only
+      the last dimensions must match for two shapes to be broadcastable.
+
+    * TensorShape([32, None]) is broadcastable with all shapes that are at least
+      two-dimensional with size 32 in the 2nd to last dimension. It is not broadcastable
+      with, for example, TensorShape([64, None]).
+
+    * TensorShape([32, 784]) is broadcastable with itself, and also
+      TensorShape([32, None]), TensorShape([None, 784]), TensorShape([None,
+      None]) and TensorShape(None). It is not broadcastable with, for example,
+      TensorShape([32, 1, 784]) or TensorShape([64]).
+
+    The broadcastability relation is reflexive and symmetric, but not
+    transitive. For example, TensorShape([32, 784]) is broadcastable with
+    TensorShape(None), and TensorShape(None) is broadcastable with
+    TensorShape([4, 4]), but TensorShape([32, 784]) is not broadcastable with
+    TensorShape([4, 4]).
+
+    Args:
+      other: Another TensorShape.
+
+    Returns:
+      True iff `self` is broadcastable with `other`.
+    """
+    other = as_shape(other)
+    # The two shapes are broadcastable if one of them is not defined
+    if self._dims is None or other._dims is None:
+      return True
+    # Iterate over the dimensions from the back
+    for x_dim, y_dim in zip(reversed(self._dims), reversed(other.dims)):
+      if not x_dim.is_compatible_with(y_dim) and x_dim.value != 1 and y_dim.value != 1:
+        return False
+    return True
+
+  def assert_is_broadcastable_with(self, other):
+    """Raises exception if `self` and `other` cannot be broadcast.
+
+    This method can be used to assert that `self` and `other` can be broadcast.
+
+    Args:
+      other: Another TensorShape.
+
+    Raises:
+      ValueError: If `self` and `other` cannot be broadcast.
+    """
+    if not self.is_broadcastable_with(other):
+      raise ValueError("Shapes %s and %s are not broadcastable" % (self, other))
+
   def is_fully_defined(self):
     """Returns True iff `self` is fully defined in every dimension."""
     return (self._dims is not None

--- a/tensorflow/python/framework/tensor_shape_test.py
+++ b/tensorflow/python/framework/tensor_shape_test.py
@@ -410,6 +410,12 @@ class ShapeTest(test_util.TensorFlowTestCase):
             "is_broadcastable violated symmetry"
           assert broadcastable == shape1.is_broadcastable_with(shape2), "%s should %s be " \
             "broadcastable with %s" % (dims1, "" if broadcastable else "not", dims2)
+          # Get the resulting shape
+          if broadcastable:
+            broadcast_shape = shape1.broadcast_with(shape2)
+          else:
+            self.assertRaises(ValueError, lambda: shape1.broadcast_with(shape2))
+            broadcast_shape = None
           # Double check with numpy if fully defined
           if shape1.is_fully_defined() and shape2.is_fully_defined():
               x = np.zeros(dims1)
@@ -417,6 +423,8 @@ class ShapeTest(test_util.TensorFlowTestCase):
               # Do the multiplication to test
               try:
                   z = x * y
+                  assert broadcast_shape.as_list() == list(z.shape), "expected shape %s but got %s" % \
+                    (z.shape, broadcast_shape)
                   assert broadcastable, "%s and %s can be broadcast" % (dims1, dims2)
               except ValueError:
                   assert not broadcastable,"%s and %s cannot be broadcast" % (dims1, dims2)


### PR DESCRIPTION
This PR adds functionality to `TensorShape` to allow for broadcasting. In particular,

* `TensorShape.broadcast_with(other)` returns the shape resulting from broadcasting a tensor of the given shape with a tensor of shape `other`. It raises a `ValueError` if the shapes are not broadcastable.
* `TensorShape.is_broadcastable_with(other)` determines whether two shapes are broadcastable
* `TensorShape.assert_is_broadcastable_with(other)` asserts that two shapes are broadcastable