### PR TITLE
word2vec: Create directories for saving summaries, if necessary.

### DIFF
--- a/tensorflow/models/embedding/word2vec.py
+++ b/tensorflow/models/embedding/word2vec.py
@@ -147,6 +147,8 @@ class Options(object):
 
     # Where to write out summaries.
     self.save_path = FLAGS.save_path
+    if not os.path.exists(self.save_path):
+        os.makedirs(self.save_path)
 
     # Eval options.
     # The text file for eval.

--- a/tensorflow/models/embedding/word2vec.py
+++ b/tensorflow/models/embedding/word2vec.py
@@ -148,7 +148,7 @@ class Options(object):
     # Where to write out summaries.
     self.save_path = FLAGS.save_path
     if not os.path.exists(self.save_path):
-        os.makedirs(self.save_path)
+      os.makedirs(self.save_path)
 
     # Eval options.
     # The text file for eval.

--- a/tensorflow/models/embedding/word2vec_optimized.py
+++ b/tensorflow/models/embedding/word2vec_optimized.py
@@ -127,7 +127,7 @@ class Options(object):
     # Where to write out summaries.
     self.save_path = FLAGS.save_path
     if not os.path.exists(self.save_path):
-        os.makedirs(self.save_path)
+      os.makedirs(self.save_path)
 
     # Eval options.
 

--- a/tensorflow/models/embedding/word2vec_optimized.py
+++ b/tensorflow/models/embedding/word2vec_optimized.py
@@ -126,6 +126,8 @@ class Options(object):
 
     # Where to write out summaries.
     self.save_path = FLAGS.save_path
+    if not os.path.exists(self.save_path):
+        os.makedirs(self.save_path)
 
     # Eval options.
 


### PR DESCRIPTION
Simple change to allow passing a directory that doesn't exist to `--save_path` in the word2vec examples.