### PR TITLE
Add support for decoding RGBA images in tfexample_decoder.

### DIFF
--- a/tensorflow/contrib/slim/python/slim/data/tfexample_decoder.py
+++ b/tensorflow/contrib/slim/python/slim/data/tfexample_decoder.py
@@ -314,7 +314,9 @@ class Image(ItemHandler):
     def decode_raw():
       return parsing_ops.decode_raw(image_buffer, dtypes.uint8)
     def decode_jpg():
-      return image_ops.decode_jpeg(image_buffer, self._channels)
+      # JPEG decoder cannot support channels >3.
+      channels = min(self._channels, 3)
+      return image_ops.decode_jpeg(image_buffer, channels)
 
     image = control_flow_ops.case({
         math_ops.logical_or(math_ops.equal(image_format, 'png'),

--- a/tensorflow/contrib/slim/python/slim/data/tfexample_decoder.py
+++ b/tensorflow/contrib/slim/python/slim/data/tfexample_decoder.py
@@ -294,10 +294,7 @@ class Image(ItemHandler):
     image_buffer = keys_to_tensors[self._image_key]
     image_format = keys_to_tensors[self._format_key]
 
-    image = self._decode(image_buffer, image_format)
-    if self._shape is not None:
-      image = array_ops.reshape(image, self._shape)
-    return image
+    return self._decode(image_buffer, image_format)
 
   def _decode(self, image_buffer, image_format):
     """Decodes the image buffer.

--- a/tensorflow/contrib/slim/python/slim/data/tfexample_decoder_test.py
+++ b/tensorflow/contrib/slim/python/slim/data/tfexample_decoder_test.py
@@ -168,7 +168,7 @@ class TFExampleDecoderTest(tf.test.TestCase):
       self.assertEqual(tf_decoded_image.get_shape().ndims, 3)
 
   def testDecodeExampleWithPngEncoding(self):
-    test_image_channels = [1, 3]
+    test_image_channels = [1, 3, 4]
     for channels in test_image_channels:
       image_shape = (2, 3, channels)
       image, serialized_example = self.GenerateImage(
@@ -183,7 +183,7 @@ class TFExampleDecoderTest(tf.test.TestCase):
       self.assertAllClose(image, decoded_image, atol=0)
 
   def testDecodeExampleWithPNGEncoding(self):
-    test_image_channels = [1, 3]
+    test_image_channels = [1, 3, 4]
     for channels in test_image_channels:
       image_shape = (2, 3, channels)
       image, serialized_example = self.GenerateImage(


### PR DESCRIPTION
Tensorflow's image decoding API's support RGBA images with png/raw formats, but the tfexample_decoder module cannot handle them due to an exception that is thrown when the decode_jpg() case is evaluated with channels >3. This PR works around that limitation by eliminating JPEG as a decoding option when the number channels is >3.
