### PR TITLE
Deprecated array and embedding ops in contrib.learn

### DIFF
--- a/tensorflow/contrib/learn/python/learn/ops/array_ops.py
+++ b/tensorflow/contrib/learn/python/learn/ops/array_ops.py
@@ -22,8 +22,12 @@ from __future__ import print_function
 from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import array_ops as array_ops_
 from tensorflow.python.ops import math_ops
+from tensorflow.python.util import deprecation
 
 
+@deprecation.deprecated("2016-12-01",
+            "one_hot_matrix is deprecated, "
+            "please use tf.one_hot instead")
 def one_hot_matrix(tensor_in, num_classes, on_value=1.0, off_value=0.0):
   """Encodes indices from given tensor as one-hot tensor.
 

--- a/tensorflow/contrib/learn/python/learn/ops/embeddings_ops.py
+++ b/tensorflow/contrib/learn/python/learn/ops/embeddings_ops.py
@@ -28,8 +28,12 @@ from tensorflow.python.ops import array_ops as array_ops_
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn
 from tensorflow.python.ops import variable_scope as vs
+from tensorflow.python.util import deprecation
 
 
+@deprecation.deprecated("2016-12-01",
+            "embedding_lookup is deprecated, "
+            "please use tf.contrib.layers.embed_sequence instead")
 def embedding_lookup(params, ids, name="embedding_lookup"):
   """Provides a N dimensional version of tf.embedding_lookup.
 
@@ -63,6 +67,9 @@ def embedding_lookup(params, ids, name="embedding_lookup"):
     return embeds
 
 
+@deprecation.deprecated("2016-12-01",
+            "categorical_variable is deprecated, "
+            "please use tf.contrib.layers.embed_sequence instead")
 def categorical_variable(tensor_in, n_classes, embedding_size, name):
   """Creates an embedding for categorical variable with given number of classes.
 

--- a/tensorflow/contrib/learn/python/learn/ops/embeddings_ops.py
+++ b/tensorflow/contrib/learn/python/learn/ops/embeddings_ops.py
@@ -33,7 +33,7 @@ from tensorflow.python.util import deprecation
 
 @deprecation.deprecated("2016-12-01",
             "embedding_lookup is deprecated, "
-            "please use tf.contrib.layers.embed_sequence instead")
+            "please use embedding_lookup ops in tf.contrib.layers instead")
 def embedding_lookup(params, ids, name="embedding_lookup"):
   """Provides a N dimensional version of tf.embedding_lookup.
 


### PR DESCRIPTION
Same functionalities exist as specified in the deprecation description. The examples were updated though. 