### PR TITLE
Remove argv argument from tf.app.run()

### DIFF
--- a/tensorflow/models/image/imagenet/classify_image.py
+++ b/tensorflow/models/image/imagenet/classify_image.py
@@ -224,4 +224,4 @@ if __name__ == '__main__':
       help='Display this many predictions.'
   )
   FLAGS, unparsed = parser.parse_known_args()
-  tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
+  tf.app.run(main=main)


### PR DESCRIPTION
The second argument in tf.app.run is causing a TypeError and I think we can remove this.  

    $ python classify_image.py 
    Traceback (most recent call last):
      File "classify_image.py", line 227, in <module>
        tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
    TypeError: run() got an unexpected keyword argument 'argv'
