### PR TITLE
[Windows/CMake] Use a more recent version of SWIG

### DIFF
--- a/tensorflow/tools/ci_build/windows/cpu/cmake/run_build.bat
+++ b/tensorflow/tools/ci_build/windows/cpu/cmake/run_build.bat
@@ -24,7 +24,7 @@ ECHO ON
 
 :: Some common variables to be shared between runs.
 SET CMAKE_EXE="C:\Program Files\cmake\bin\cmake.exe"
-SET SWIG_EXE="C:\ProgramData\chocolatey\bin\swig.exe"
+SET SWIG_EXE="C:\swigwin-3.0.10\swig.exe"
 SET PY_EXE="C:\Program Files\Anaconda3\python.exe"
 SET PY_LIB="C:\Program Files\Anaconda3\libs\python35.lib"
 


### PR DESCRIPTION
This fixes `reader_ops_test.py`, which was suffering from a bug in older versions of SWIG when using Python 3.5 and a SWIG-wrapped generator object.