### PR TITLE
Enable a mechanism for filtering out log messages using

### DIFF
--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/lib/core/stringpiece.h"
 #include "tensorflow/core/platform/default/logging.h"
 #include "tensorflow/core/platform/macros.h"
 
@@ -94,15 +93,18 @@ int64 MinLogLevel() {
   // Ideally we would use env_var / safe_strto64, but it is
   // hard to use here without pulling in a lot of dependencies,
   // so we do a poor-man's parsing.
-  StringPiece min_log_level_sp(tf_env_var_val);
-  string min_log_level_str(min_log_level_sp.data(), min_log_level_sp.size());
-  if (min_log_level_str == "1") {
+  string min_log_level(tf_env_var_val);
+  if (min_log_level == "1") {
+    // Maps to WARNING
     return 1;
-  } else if (min_log_level_str == "2") {
+  } else if (min_log_level == "2") {
+    // Maps to ERROR
     return 2;
-  } else if (min_log_level_str == "3") {
+  } else if (min_log_level == "3") {
+    // Maps to FATAL
     return 3;
   } else {
+    // Maps to INFO (the default).
     return 0;
   }
 }


### PR DESCRIPTION
an environment variable.  Reads the environment variable
on the first call to LOG, uses it to filter out based on the
severity of the log message.

By default, min log level is 0, mapping to INFO.
If you set the env var to 1, INFO is filtered out b t
WARNING still gets printed.

Parsing code is rudimentary, to avoid bringing in
dependencies into platform (e.g., strings/lib/numbers.h,
env_var.h, etc).  For this use-case it is probably fine.

Fixes #1258.
