### PR TITLE
Add Windows GPU support with Bazel

### DIFF
--- a/configure
+++ b/configure
@@ -52,7 +52,6 @@ done
 if is_windows; then
   TF_NEED_GCP=0
   TF_NEED_HDFS=0
-  TF_NEED_CUDA=0
   TF_NEED_OPENCL=0
 fi
 
@@ -150,14 +149,15 @@ fi
 
 if [ "$TF_NEED_CUDA" == "1" ]; then
 # Set up which gcc nvcc should use as the host compiler
-while true; do
+# No need to set this on Windows
+while ! is_windows && true; do
   fromuser=""
   if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
     default_gcc_host_compiler_path=$(which gcc || true)
     read -p "Please specify which gcc should be used by nvcc as the host compiler. [Default is $default_gcc_host_compiler_path]: " GCC_HOST_COMPILER_PATH
     fromuser="1"
     if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
-      GCC_HOST_COMPILER_PATH=$default_gcc_host_compiler_path
+      GCC_HOST_COMPILER_PATH="$default_gcc_host_compiler_path"
     fi
   fi
   if [ -e "$GCC_HOST_COMPILER_PATH" ]; then
@@ -184,10 +184,13 @@ while true; do
   fromuser=""
   if [ -z "$CUDA_TOOLKIT_PATH" ]; then
     default_cuda_path=/usr/local/cuda
+    if is_windows; then
+      default_cuda_path="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0"
+    fi
     read -p "Please specify the location where CUDA $TF_CUDA_VERSION toolkit is installed. Refer to README.md for more details. [Default is $default_cuda_path]: " CUDA_TOOLKIT_PATH
     fromuser="1"
     if [ -z "$CUDA_TOOLKIT_PATH" ]; then
-      CUDA_TOOLKIT_PATH=$default_cuda_path
+      CUDA_TOOLKIT_PATH="$default_cuda_path"
     fi
   fi
 
@@ -197,7 +200,9 @@ while true; do
     TF_CUDA_EXT=".$TF_CUDA_VERSION"
   fi
 
-  if [ "$OSNAME" == "Linux" ]; then
+  if is_windows; then
+    CUDA_RT_LIB_PATH="lib/x64/cudart.lib"
+  elif [ "$OSNAME" == "Linux" ]; then
     CUDA_RT_LIB_PATH="lib64/libcudart.so${TF_CUDA_EXT}"
   elif [ "$OSNAME" == "Darwin" ]; then
     CUDA_RT_LIB_PATH="lib/libcudart${TF_CUDA_EXT}.dylib"
@@ -235,14 +240,17 @@ while true; do
     fi
     # Result returned from "read" will be used unexpanded. That make "~" unuseable.
     # Going through one more level of expansion to handle that.
-    CUDNN_INSTALL_PATH=`${PYTHON_BIN_PATH} -c "import os; print(os.path.realpath(os.path.expanduser('${CUDNN_INSTALL_PATH}')))"`
+    CUDNN_INSTALL_PATH=`"${PYTHON_BIN_PATH}" -c "import os; print(os.path.realpath(os.path.expanduser('${CUDNN_INSTALL_PATH}')))"`
   fi
 
   if [[ -z "$TF_CUDNN_VERSION" ]]; then
     TF_CUDNN_EXT=""
     cudnn_lib_path=""
     cudnn_alt_lib_path=""
-    if [ "$OSNAME" == "Linux" ]; then
+    if is_windows; then
+      cudnn_lib_path="${CUDNN_INSTALL_PATH}/lib/x64/cudnn.lib"
+      cudnn_alt_lib_path="${CUDNN_INSTALL_PATH}/lib/x64/cudnn.lib"
+    elif [ "$OSNAME" == "Linux" ]; then
       cudnn_lib_path="${CUDNN_INSTALL_PATH}/lib64/libcudnn.so"
       cudnn_alt_lib_path="${CUDNN_INSTALL_PATH}/libcudnn.so"
     elif [ "$OSNAME" == "Darwin" ]; then
@@ -255,9 +263,9 @@ while true; do
     # If the path is not a symlink, readlink will exit with an error code, so
     # in that case, we return the path itself.
     if [ -f "$cudnn_lib_path" ]; then
-      REALVAL=`readlink ${cudnn_lib_path} || echo "${cudnn_lib_path}"`
+      REALVAL=`readlink "${cudnn_lib_path}" || echo "${cudnn_lib_path}"`
     else
-      REALVAL=`readlink ${cudnn_alt_lib_path} || echo "${cudnn_alt_lib_path}"`
+      REALVAL=`readlink "${cudnn_alt_lib_path}" || echo "${cudnn_alt_lib_path}"`
     fi
 
     # Extract the version of the SONAME, if it was indeed symlinked to
@@ -275,7 +283,10 @@ while true; do
     TF_CUDNN_EXT=".$TF_CUDNN_VERSION"
   fi
 
-  if [ "$OSNAME" == "Linux" ]; then
+  if is_windows; then
+    CUDA_DNN_LIB_PATH="lib/x64/cudnn.lib"
+    CUDA_DNN_LIB_ALT_PATH="lib/x64/cudnn.lib"
+  elif [ "$OSNAME" == "Linux" ]; then
     CUDA_DNN_LIB_PATH="lib64/libcudnn.so${TF_CUDNN_EXT}"
     CUDA_DNN_LIB_ALT_PATH="libcudnn.so${TF_CUDNN_EXT}"
   elif [ "$OSNAME" == "Darwin" ]; then
@@ -349,6 +360,16 @@ EOF
   fi
   TF_CUDA_COMPUTE_CAPABILITIES=""
 done
+
+if is_windows; then
+  # The following three variables are needed for MSVC toolchain configuration in Bazel
+  export CUDA_PATH="$CUDA_TOOLKIT_PATH"
+  export CUDA_COMPUTE_CAPABILITIES="$TF_CUDA_COMPUTE_CAPABILITIES"
+  export NO_WHOLE_ARCHIVE_OPTION=1
+
+  # Set GCC_HOST_COMPILER_PATH to keep cuda_configure.bzl happy
+  export GCC_HOST_COMPILER_PATH="/usr/bin/dummy_compiler"
+fi
 
 # end of if "$TF_NEED_CUDA" == "1"
 fi

--- a/configure
+++ b/configure
@@ -185,7 +185,11 @@ while true; do
   if [ -z "$CUDA_TOOLKIT_PATH" ]; then
     default_cuda_path=/usr/local/cuda
     if is_windows; then
-      default_cuda_path="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0"
+      if [ -z "$CUDA_PATH" ]; then
+        default_cuda_path="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0"
+      else
+        default_cuda_path="$(cygpath -m "$CUDA_PATH")"
+      fi
     fi
     read -p "Please specify the location where CUDA $TF_CUDA_VERSION toolkit is installed. Refer to README.md for more details. [Default is $default_cuda_path]: " CUDA_TOOLKIT_PATH
     fromuser="1"

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -893,12 +893,12 @@ cc_library(
 # Libraries with GPU facilities that are useful for writing kernels.
 cc_library(
     name = "gpu_lib",
-    srcs = if_not_windows([
+    srcs = [
         "common_runtime/gpu/gpu_event_mgr.cc",
-    ]),
-    hdrs = if_not_windows([
+    ],
+    hdrs = [
         "common_runtime/gpu/gpu_event_mgr.h",
-    ]),
+    ],
     copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
@@ -908,7 +908,7 @@ cc_library(
         ":lib_internal",
         ":proto_text",
         ":protos_all_cc",
-    ] + if_not_windows([":stream_executor"]),
+    ] + [":stream_executor"],
 )
 
 cc_library(
@@ -1351,7 +1351,7 @@ tf_cuda_library(
 
 tf_cuda_library(
     name = "gpu_runtime",
-    srcs = if_not_windows([
+    srcs = [
         "common_runtime/gpu/gpu_bfc_allocator.cc",
         "common_runtime/gpu/gpu_debug_allocator.cc",
         "common_runtime/gpu/gpu_device.cc",
@@ -1363,8 +1363,8 @@ tf_cuda_library(
         "common_runtime/gpu/pool_allocator.cc",
         "common_runtime/gpu/process_state.cc",
         "common_runtime/gpu_device_context.h",
-    ]),
-    hdrs = if_not_windows([
+    ],
+    hdrs = [
         "common_runtime/gpu/gpu_bfc_allocator.h",
         "common_runtime/gpu/gpu_debug_allocator.h",
         "common_runtime/gpu/gpu_device.h",
@@ -1373,7 +1373,7 @@ tf_cuda_library(
         "common_runtime/gpu/gpu_util.h",
         "common_runtime/gpu/pool_allocator.h",
         "common_runtime/gpu/process_state.h",
-    ]),
+    ],
     copts = tf_copts(),
     linkstatic = 1,
     deps = [
@@ -1386,9 +1386,9 @@ tf_cuda_library(
         ":lib_internal",
         ":protos_all_cc",
         "//third_party/eigen3",
-    ] + if_not_windows([
+    ] + [
         ":stream_executor",
-    ]),
+    ],
     alwayslink = 1,
 )
 

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -908,7 +908,8 @@ cc_library(
         ":lib_internal",
         ":proto_text",
         ":protos_all_cc",
-    ] + [":stream_executor"],
+        ":stream_executor",
+    ],
 )
 
 cc_library(
@@ -1386,7 +1387,6 @@ tf_cuda_library(
         ":lib_internal",
         ":protos_all_cc",
         "//third_party/eigen3",
-    ] + [
         ":stream_executor",
     ],
     alwayslink = 1,

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1386,8 +1386,8 @@ tf_cuda_library(
         ":lib",
         ":lib_internal",
         ":protos_all_cc",
-        "//third_party/eigen3",
         ":stream_executor",
+        "//third_party/eigen3",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -1689,7 +1689,6 @@ tf_kernel_libraries(
         ":bounds_check",
         ":conv_2d",
         ":conv_ops",
-        ":depthwise_conv_grad_op",
         ":dilation_ops",
         ":fused_batch_norm_util_gpu",
         ":ops_util",
@@ -1701,6 +1700,7 @@ tf_kernel_libraries(
         "//tensorflow/core:nn_ops_op_lib",
         "//third_party/eigen3",
     ] + if_not_windows([
+        ":depthwise_conv_grad_op",
         ":depthwise_conv_op",
     ]),
 )

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1925,6 +1925,8 @@ tf_cuda_library(
 
 tf_py_wrap_cc(
     name = "pywrap_tensorflow",
+    # set linkstatic = 0 so that only apply whole archive to libraries that need to be force linked.
+    linkstatic = 0,
     srcs = ["tensorflow.i"],
     swig_includes = [
         "client/device_lib.i",
@@ -1965,8 +1967,6 @@ tf_py_wrap_cc(
         "//tensorflow/tools/tfprof/internal:print_model_analysis",
         "//util/python:python_headers",
     ] + tf_additional_lib_deps(),
-    # set linkstatic = 0 so that only apply whole archive to libraries that need to be force linked.
-    linkstatic = 0,
 )
 
 py_library(

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1926,8 +1926,6 @@ tf_cuda_library(
 tf_py_wrap_cc(
     name = "pywrap_tensorflow",
     srcs = ["tensorflow.i"],
-    # set linkstatic = 0 so that only apply whole archive to libraries that need to be force linked.
-    linkstatic = 0,
     swig_includes = [
         "client/device_lib.i",
         "client/events_writer.i",

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1965,6 +1965,8 @@ tf_py_wrap_cc(
         "//tensorflow/tools/tfprof/internal:print_model_analysis",
         "//util/python:python_headers",
     ] + tf_additional_lib_deps(),
+    # set linkstatic = 0 so that only apply whole archive to libraries that need to be force linked.
+    linkstatic = 0,
 )
 
 py_library(

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1925,9 +1925,9 @@ tf_cuda_library(
 
 tf_py_wrap_cc(
     name = "pywrap_tensorflow",
+    srcs = ["tensorflow.i"],
     # set linkstatic = 0 so that only apply whole archive to libraries that need to be force linked.
     linkstatic = 0,
-    srcs = ["tensorflow.i"],
     swig_includes = [
         "client/device_lib.i",
         "client/events_writer.i",

--- a/tensorflow/stream_executor/lib/process_state.cc
+++ b/tensorflow/stream_executor/lib/process_state.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <direct.h>
 #include <stdlib.h>
 #include <WinSock2.h>
+#pragma comment(lib, "Ws2_32.lib")
 #else
 #include <unistd.h>
 #endif

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -165,6 +165,9 @@ def tf_copts():
               "//tensorflow:windows": [
                 "/DLANG_CXX11",
                 "/D__VERSION__=\\\"MSVC\\\"",
+                "/DPLATFORM_WINDOWS",
+                "/DEIGEN_HAS_C99_MATH",
+                "/DTENSORFLOW_USE_EIGEN_THREADPOOL",
               ],
               "//tensorflow:ios": ["-std=c++11"],
               "//conditions:default": ["-pthread"]}))
@@ -417,7 +420,7 @@ def _cuda_copts():
         "@local_config_cuda//cuda:using_nvcc": (
             common_cuda_opts +
             [
-                "-nvcc_options=relaxed-constexpr",
+                "-nvcc_options=expt-relaxed-constexpr",
                 "-nvcc_options=ftz=true",
             ]
         ),
@@ -443,7 +446,7 @@ def _cuda_copts():
 # libraries needed by GPU kernels.
 def tf_gpu_kernel_library(srcs, copts=[], cuda_copts=[], deps=[], hdrs=[],
                           **kwargs):
-  copts = copts + _cuda_copts() + if_cuda(cuda_copts)
+  copts = copts + _cuda_copts() + if_cuda(cuda_copts) + tf_copts()
 
   native.cc_library(
       srcs = srcs,

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -797,7 +797,7 @@ def tf_extension_linkopts():
 def tf_extension_copts():
   return []  # No extension c opts
 
-def tf_py_wrap_cc(name, srcs, swig_includes=[], deps=[], copts=[], **kwargs):
+def tf_py_wrap_cc(name, srcs, swig_includes=[], deps=[], copts=[], linkstatic=1, **kwargs):
   module_name = name.split("/")[-1]
   # Convert a rule name such as foo/bar/baz to foo/bar/_baz.so
   # and use that as the name for the rule producing the .so file.
@@ -840,7 +840,7 @@ def tf_py_wrap_cc(name, srcs, swig_includes=[], deps=[], copts=[], **kwargs):
                       "-Wno-write-strings"]
              + tf_extension_copts()),
       linkopts=tf_extension_linkopts() + extra_linkopts,
-      linkstatic=1,
+      linkstatic=linkstatic,
       linkshared=1,
       deps=deps + extra_deps)
   native.genrule(

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -797,7 +797,7 @@ def tf_extension_linkopts():
 def tf_extension_copts():
   return []  # No extension c opts
 
-def tf_py_wrap_cc(name, srcs, swig_includes=[], deps=[], copts=[], linkstatic=1, **kwargs):
+def tf_py_wrap_cc(name, srcs, swig_includes=[], deps=[], copts=[], **kwargs):
   module_name = name.split("/")[-1]
   # Convert a rule name such as foo/bar/baz to foo/bar/_baz.so
   # and use that as the name for the rule producing the .so file.
@@ -840,7 +840,7 @@ def tf_py_wrap_cc(name, srcs, swig_includes=[], deps=[], copts=[], linkstatic=1,
                       "-Wno-write-strings"]
              + tf_extension_copts()),
       linkopts=tf_extension_linkopts() + extra_linkopts,
-      linkstatic=linkstatic,
+      linkstatic=1,
       linkshared=1,
       deps=deps + extra_deps)
   native.genrule(

--- a/third_party/gpus/cuda/platform.bzl.tpl
+++ b/third_party/gpus/cuda/platform.bzl.tpl
@@ -16,9 +16,9 @@ def cuda_library_path(name, version = cuda_sdk_version()):
       return "lib/lib{}.{}.dylib".format(name, version)
   elif PLATFORM == "Windows":
     if not version:
-      return "lib/{}.dll".format(name)
+      return "lib/x64/{}.lib".format(name)
     else:
-      return "lib/{}{}.dll".format(name, version)
+      return "lib/x64/{}{}.lib".format(name, version)
   else:
     if not version:
       return "lib64/lib{}.so".format(name)
@@ -29,7 +29,7 @@ def cuda_static_library_path(name):
   if PLATFORM == "Darwin":
     return "lib/lib{}_static.a".format(name)
   elif PLATFORM == "Windows":
-    return "lib/{}_static.lib".format(name)
+    return "lib/x64/{}_static.lib".format(name)
   else:
     return "lib64/lib{}_static.a".format(name)
 
@@ -41,9 +41,9 @@ def cudnn_library_path(version = cudnn_sdk_version()):
       return "lib/libcudnn.{}.dylib".format(version)
   elif PLATFORM == "Windows":
     if not version:
-      return "lib/cudnn.dll"
+      return "lib/x64/cudnn.lib"
     else:
-      return "lib/cudnn{}.dll".format(version)
+      return "lib/x64/cudnn{}.lib".format(version)
   else:
     if not version:
       return "lib64/libcudnn.so"
@@ -58,9 +58,9 @@ def cupti_library_path(version = cuda_sdk_version()):
       return "extras/CUPTI/lib/libcupti.{}.dylib".format(version)
   elif PLATFORM == "Windows":
     if not version:
-      return "extras/CUPTI/lib/cupti.dll"
+      return "extras/CUPTI/libx64/cupti.lib"
     else:
-      return "extras/CUPTI/lib/cupti{}.dll".format(version)
+      return "extras/CUPTI/libx64/cupti{}.lib".format(version)
   else:
     if not version:
       return "extras/CUPTI/lib64/libcupti.so"

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -235,14 +235,14 @@ def _cuda_symlink_files(cpu_value, cuda_version, cudnn_version):
   elif cpu_value == "Windows":
     return struct(
         cuda_lib_path = "lib",
-        cuda_rt_lib = "lib/cudart%s.dll" % cuda_ext,
-        cuda_rt_lib_static = "lib/cudart_static.lib",
-        cuda_blas_lib = "lib/cublas%s.dll" % cuda_ext,
-        cuda_dnn_lib = "lib/cudnn%s.dll" % cudnn_ext,
-        cuda_dnn_lib_alt = "cudnn%s.dll" % cudnn_ext,
-        cuda_rand_lib = "lib/curand%s.dll" % cuda_ext,
-        cuda_fft_lib = "lib/cufft%s.dll" % cuda_ext,
-        cuda_cupti_lib = "extras/CUPTI/lib/cupti%s.dll" % cuda_ext)
+        cuda_rt_lib = "lib/x64/cudart%s.lib" % cuda_ext,
+        cuda_rt_lib_static = "lib/x64/cudart_static.lib",
+        cuda_blas_lib = "lib/x64/cublas%s.lib" % cuda_ext,
+        cuda_dnn_lib = "lib/x64/cudnn%s.lib" % cudnn_ext,
+        cuda_dnn_lib_alt = "cudnn%s.lib" % cudnn_ext,
+        cuda_rand_lib = "lib/x64/curand%s.lib" % cuda_ext,
+        cuda_fft_lib = "lib/x64/cufft%s.lib" % cuda_ext,
+        cuda_cupti_lib = "extras/CUPTI/libx64/cupti%s.lib" % cuda_ext)
   else:
     auto_configure_fail("Not supported CPU value %s" % cpu_value)
 

--- a/tools/bazel.rc.template
+++ b/tools/bazel.rc.template
@@ -1,5 +1,6 @@
 build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
 build:cuda --define=using_cuda=true --define=using_cuda_nvcc=true
+build:win-cuda --define=using_cuda=true --define=using_cuda_nvcc=true
 
 build:sycl --crosstool_top=@local_config_sycl//crosstool:toolchain
 build:sycl --define=using_sycl=true


### PR DESCRIPTION
@mrry @dslomov @damienmg 

The change needed for Bazel is also ready to review:
https://bazel-review.googlesource.com/?polygerrit=0#/c/7351/
Once these changes are checked in, we should be able to build TensorFlow with GPU support on Windows by
`bazel build --confg=win-cuda -c opt --cpu=x64_windows_msvc --cpu=x64_windows tensorflow/tools/pip_package:build_pip_package`

I excluded `depthwise_conv_grad_op` which doesn't seem to be excluded in CMake build.
It caused a linking error like this, and only happens in GPU build:
```
depthwise_conv_grad_op.o : error LNK2019: unresolved external symbol "public: static void __cdecl tensorflow::DepthwiseConv2dBackpropInputGPULaunch<float>::Run(struct Eigen::GpuDevice const &,struct tensorflow::DepthwiseArgs,float const *,float const *,float *)" (?Run@?$DepthwiseConv2dBackpropInputGPULaunch@M@tensorflow@@SAXAEBUGpuDevice@Eigen@@UDepthwiseArgs@2@PEBM2PEAM@Z) referenced in function "public: static void __cdecl tensorflow::LaunchDepthwiseConvBackpropInputOp<struct Eigen::GpuDevice,float>::launch(class tensorflow::OpKernelContext *,struct tensorflow::DepthwiseArgs,float const *,float const *,float *)" (?launch@?$LaunchDepthwiseConvBackpropInputOp@UGpuDevice@Eigen@@M@tensorflow@@SAXPEAVOpKernelContext@2@UDepthwiseArgs@2@PEBM2PEAM@Z)
depthwise_conv_grad_op.o : error LNK2019: unresolved external symbol "public: static void __cdecl tensorflow::DepthwiseConv2dBackpropInputGPULaunch<double>::Run(struct Eigen::GpuDevice const &,struct tensorflow::DepthwiseArgs,double const *,double const *,double *)" (?Run@?$DepthwiseConv2dBackpropInputGPULaunch@N@tensorflow@@SAXAEBUGpuDevice@Eigen@@UDepthwiseArgs@2@PEBN2PEAN@Z) referenced in function "public: static void __cdecl tensorflow::LaunchDepthwiseConvBackpropInputOp<struct Eigen::GpuDevice,double>::launch(class tensorflow::OpKernelContext *,struct tensorflow::DepthwiseArgs,double const *,double const *,double *)" (?launch@?$LaunchDepthwiseConvBackpropInputOp@UGpuDevice@Eigen@@N@tensorflow@@SAXPEAVOpKernelContext@2@UDepthwiseArgs@2@PEBN2PEAN@Z)
depthwise_conv_grad_op.o : error LNK2019: unresolved external symbol "public: static void __cdecl tensorflow::DepthwiseConv2dBackpropFilterGPULaunch<float>::Run(struct Eigen::GpuDevice const &,struct tensorflow::DepthwiseArgs,float const *,float const *,float *)" (?Run@?$DepthwiseConv2dBackpropFilterGPULaunch@M@tensorflow@@SAXAEBUGpuDevice@Eigen@@UDepthwiseArgs@2@PEBM2PEAM@Z) referenced in function "public: static void __cdecl tensorflow::LaunchDepthwiseConvBackpropFilterOp<struct Eigen::GpuDevice,float>::launch(class tensorflow::OpKernelContext *,struct tensorflow::DepthwiseArgs,float const *,float const *,float *)" (?launch@?$LaunchDepthwiseConvBackpropFilterOp@UGpuDevice@Eigen@@M@tensorflow@@SAXPEAVOpKernelContext@2@UDepthwiseArgs@2@PEBM2PEAM@Z)
depthwise_conv_grad_op.o : error LNK2019: unresolved external symbol "public: static void __cdecl tensorflow::DepthwiseConv2dBackpropFilterGPULaunch<double>::Run(struct Eigen::GpuDevice const &,struct tensorflow::DepthwiseArgs,double const *,double const *,double *)" (?Run@?$DepthwiseConv2dBackpropFilterGPULaunch@N@tensorflow@@SAXAEBUGpuDevice@Eigen@@UDepthwiseArgs@2@PEBN2PEAN@Z) referenced in function "public: static void __cdecl tensorflow::LaunchDepthwiseConvBackpropFilterOp<struct Eigen::GpuDevice,double>::launch(class tensorflow::OpKernelContext *,struct tensorflow::DepthwiseArgs,double const *,double const *,double *)" (?launch@?$LaunchDepthwiseConvBackpropFilterOp@UGpuDevice@Eigen@@N@tensorflow@@SAXPEAVOpKernelContext@2@UDepthwiseArgs@2@PEBN2PEAN@Z)
bazel-out/vc_14_0_x64-py3-opt/bin/tensorflow/cc/tutorials_example_trainer.exe : fatal error LNK1120: 4 unresolved externals
Target //tensorflow/cc:tutorials_example_trainer failed to build
INFO: Elapsed time: 2180.664s, Critical Path: 1792.27s
```

The source file [depthwise_conv_grad_op.cc](https://github.com/tensorflow/tensorflow/blob/beb10ceb086fe94a6b1247b45397aafddd47e05d/tensorflow/core/kernels/depthwise_conv_grad_op.cc#L113) looks weird to me, because the syntax highlight starts go wrong from line 113. Might need some help to resolve this.


