### PR TITLE
Maunally setting TF_NEED_CUDA=0 in build_tf_windows.sh

### DIFF
--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -53,6 +53,8 @@ export BAZEL_VS="C:/Program Files (x86)/Microsoft Visual Studio 14.0"
 # '/usr/bin/env python' as a shebang
 export PATH="/c/Program Files/Anaconda3:$PATH"
 
+export TF_NEED_CUDA=0
+
 # bazel clean --expunge doesn't work on Windows yet.
 # Clean the output base manually to ensure build correctness
 bazel clean


### PR DESCRIPTION
Soon TF_NEED_CUDA won't be False by default on Windows, we need this to make sure [tf-master-win-bzl ](http://ci.tensorflow.org/job/tf-master-win-bzl/) won't fail. @gunan 