### PR TITLE
[Windows] Fix GetMatchingPaths for use on Windows.

### DIFF
--- a/tensorflow/contrib/cmake/tf_tests.cmake
+++ b/tensorflow/contrib/cmake/tf_tests.cmake
@@ -115,7 +115,8 @@ if (tensorflow_BUILD_PYTHON_TESTS)
   
   # include all test
   file(GLOB_RECURSE tf_test_src_py
-    "${tensorflow_source_dir}/tensorflow/python/kernel_tests/*.py"
+    "${tensorflow_source_dir}/tensorflow/python/kernel_tests/*_test.py"
+    "${tensorflow_source_dir}/tensorflow/python/training/*_test.py"
   )
 
   # exclude the onces we don't want
@@ -146,8 +147,6 @@ if (tensorflow_BUILD_PYTHON_TESTS)
       # int32/int64 mixup
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/functional_ops_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/py_func_test.py"
-      # issues related to windows fs
-      "${tensorflow_source_dir}/tensorflow/python/kernel_tests/io_ops_test.py"
       # missing kernel      
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/conv_ops_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/depthwise_conv_op_test.py"
@@ -155,6 +154,14 @@ if (tensorflow_BUILD_PYTHON_TESTS)
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/diag_op_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/trace_op_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/one_hot_op_test.py" # gpu, T=uint8
+      # training tests
+      "${tensorflow_source_dir}/tensorflow/python/training/basic_session_run_hooks_test.py"  # Needs tf.contrib fix.
+      "${tensorflow_source_dir}/tensorflow/python/training/localhost_cluster_performance_test.py"  # Needs portpicker.
+      "${tensorflow_source_dir}/tensorflow/python/training/monitored_session_test.py"  # Needs tf.contrib fix.
+      "${tensorflow_source_dir}/tensorflow/python/training/saver_large_variable_test.py"  # Overflow error.
+      "${tensorflow_source_dir}/tensorflow/python/training/saver_test.py"  # Needs tf.contrib fix.
+      "${tensorflow_source_dir}/tensorflow/python/training/supervisor_test.py"  # Flaky I/O error on rename.
+      "${tensorflow_source_dir}/tensorflow/python/training/sync_replicas_optimizer_test.py"  # Needs portpicker.
     )
   endif()
   list(REMOVE_ITEM tf_test_src_py ${tf_test_src_py_exclude})

--- a/tensorflow/core/platform/windows/windows_file_system.cc
+++ b/tensorflow/core/platform/windows/windows_file_system.cc
@@ -467,6 +467,23 @@ Status WindowsFileSystem::RenameFile(const string& src, const string& target) {
   return result;
 }
 
+Status WindowsFileSystem::GetMatchingPaths(const string& pattern,
+                                           std::vector<string>* results) {
+  // NOTE(mrry): The existing implementation of FileSystem::GetMatchingPaths()
+  // does not handle Windows paths containing backslashes correctly. Since
+  // Windows APIs will accept forward and backslashes equivalently, we
+  // convert the pattern to use forward slashes exclusively. Note that this
+  // is not ideal, since the API expects backslash as an escape character,
+  // but no code appears to rely on this behavior.
+  string converted_pattern(pattern);
+  std::replace(converted_pattern.begin(), converted_pattern.end(), '\\', '/');
+  TF_RETURN_IF_ERROR(FileSystem::GetMatchingPaths(converted_pattern, results));
+  for (string& result : *results) {
+    std::replace(result.begin(), result.end(), '/', '\\');
+  }
+  return Status::OK();
+}
+
 Status WindowsFileSystem::Stat(const string& fname, FileStatistics* stat) {
   Status result;
   struct _stat sbuf;

--- a/tensorflow/core/platform/windows/windows_file_system.h
+++ b/tensorflow/core/platform/windows/windows_file_system.h
@@ -48,6 +48,9 @@ class WindowsFileSystem : public FileSystem {
 
   Status GetChildren(const string& dir, std::vector<string>* result) override;
 
+  Status GetMatchingPaths(const string& pattern,
+                          std::vector<string>* result) override;
+
   Status Stat(const string& fname, FileStatistics* stat) override;
 
   Status DeleteFile(const string& fname) override;

--- a/tensorflow/python/kernel_tests/io_ops_test.py
+++ b/tensorflow/python/kernel_tests/io_ops_test.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 # Copyright 2015 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
 import tempfile
 
 import tensorflow as tf
@@ -31,25 +32,31 @@ class IoOpsTest(tf.test.TestCase):
     cases = ['', 'Some contents', 'Неки садржаји на српском']
     for contents in cases:
       contents = tf.compat.as_bytes(contents)
-      temp = tempfile.NamedTemporaryFile(
-          prefix='ReadFileTest', dir=self.get_temp_dir())
-      open(temp.name, 'wb').write(contents)
+      with tempfile.NamedTemporaryFile(prefix='ReadFileTest',
+                                       dir=self.get_temp_dir(),
+                                       delete=False) as temp:
+        temp.write(contents)
       with self.test_session():
         read = tf.read_file(temp.name)
         self.assertEqual([], read.get_shape())
         self.assertEqual(read.eval(), contents)
+      os.remove(temp.name)
 
   def testWriteFile(self):
     cases = ['', 'Some contents']
     for contents in cases:
       contents = tf.compat.as_bytes(contents)
-      temp = tempfile.NamedTemporaryFile(
-          prefix='WriteFileTest', dir=self.get_temp_dir())
+      with tempfile.NamedTemporaryFile(prefix='WriteFileTest',
+                                       dir=self.get_temp_dir(),
+                                       delete=False) as temp:
+        pass
       with self.test_session() as sess:
         w = tf.write_file(temp.name, contents)
         sess.run(w)
-        file_contents = open(temp.name, 'rb').read()
+        with open(temp.name, 'rb') as f:
+          file_contents = f.read()
         self.assertEqual(file_contents, contents)
+      os.remove(temp.name)
 
   def _subset(self, files, indices):
     return set(tf.compat.as_bytes(files[i].name)
@@ -59,7 +66,7 @@ class IoOpsTest(tf.test.TestCase):
     cases = ['ABcDEF.GH', 'ABzDEF.GH', 'ABasdfjklDEF.GH', 'AB3DEF.GH',
              'AB4DEF.GH', 'ABDEF.GH', 'XYZ']
     files = [tempfile.NamedTemporaryFile(
-        prefix=c, dir=self.get_temp_dir()) for c in cases]
+        prefix=c, dir=self.get_temp_dir(), delete=True) for c in cases]
 
     with self.test_session():
       # Test exact match without wildcards.
@@ -77,10 +84,16 @@ class IoOpsTest(tf.test.TestCase):
                        self._subset(files, [0, 1, 3, 4]))
       self.assertEqual(set(tf.matching_files(pattern % '*').eval()),
                        self._subset(files, [0, 1, 2, 3, 4, 5]))
-      self.assertEqual(set(tf.matching_files(pattern % '[cxz]').eval()),
-                       self._subset(files, [0, 1]))
-      self.assertEqual(set(tf.matching_files(pattern % '[0-9]').eval()),
-                       self._subset(files, [3, 4]))
+      # NOTE(mrry): Windows uses PathMatchSpec to match file patterns, which
+      # does not support the following expressions.
+      if os.name != 'nt':
+        self.assertEqual(set(tf.matching_files(pattern % '[cxz]').eval()),
+                         self._subset(files, [0, 1]))
+        self.assertEqual(set(tf.matching_files(pattern % '[0-9]').eval()),
+                         self._subset(files, [3, 4]))
+
+    for f in files:
+      f.close()
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/training/saver_test.py
+++ b/tensorflow/python/training/saver_test.py
@@ -1162,7 +1162,7 @@ class CheckpointStateTest(tf.test.TestCase):
     train_dir = "train"
     os.mkdir(train_dir)
     abs_path = os.path.join(save_dir, "model-0")
-    rel_path = "train/model-2"
+    rel_path = os.path.join("train", "model-2")
     tf.train.update_checkpoint_state(
         train_dir,
         rel_path,


### PR DESCRIPTION
The existing implementation is not compatible with paths containing
backslashes. Use a workaround on Windows only (converting backslashes
to forward slashes).

Also enable several tests in python/training, and fix io_ops_test.py
and saver_test.py to work on Windows.

(saver_test.py and some other tests are disabled until #5634 is merged.)