### PR TITLE
Produce binary release tarballs for the TensorFlow C API

### DIFF
--- a/tensorflow/tools/ci_build/builds/libtensorflow.sh
+++ b/tensorflow/tools/ci_build/builds/libtensorflow.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Script to generate a tarball containing the TensorFlow C-library which
+# consists of the C API header file and libtensorflow.so.
+#
+# Work in progress but this is a step towards a "binary" distribution of the
+# TensorFlow C-library allowing TensorFlow language bindings to be used
+# without having to recompile the TensorFlow framework from sources, which
+# takes a while and also introduces many other dependencies.
+#
+# Usage:
+# - Source this file in another bash script
+# - Execute build_libtensorflow_tarball SUFFIX
+#
+# Produces: lib_package/libtensorflow${SUFFIX}.tar.gz
+#
+# ASSUMPTIONS:
+# - build_libtensorflow_tarball is invoked from the root of the git tree.
+# - Any environment variables needed by the "configure" script have been set.
+
+function build_libtensorflow_tarball() {
+  # Sanity check that this is being run from the root of the git repository.
+  if [ ! -e "WORKSPACE" ]; then
+    echo "Must run this from the root of the bazel workspace"
+    exit 1
+  fi
+  TARBALL_SUFFIX="${1}"
+  BAZEL="bazel --bazelrc ./tensorflow/tools/ci_build/install/.bazelrc"
+  BAZEL_OPTS="-c opt"
+  if [ "${TF_NEED_CUDA}" == "1" ]; then
+    BAZEL_OPTS="${BAZEL_OPTS} --config=cuda"
+  fi
+  bazel clean --expunge
+  yes "" | ./configure
+  
+  # TODO(ashankar): Once 
+  # https://github.com/tensorflow/tensorflow/commit/1b32b698eddc10c0d85b0b8cf838f42023394de7  
+  # can be undone, i.e., when bazel supports pkg_tar with python3+ then all of this below
+  # can be replaced with something like:
+  # bazel build ${BAZEL_OPTS} //tensorflow/tools/lib_package:libtensorflow.tar.gz
+  
+  bazel build ${BAZEL_OPTS} //tensorflow:libtensorflow.so
+  DIR=lib_package
+  rm -rf ${DIR}
+  mkdir -p ${DIR}/build/lib
+  mkdir -p ${DIR}/build/include/tensorflow/c
+  cp bazel-bin/tensorflow/libtensorflow.so ${DIR}/build/lib
+  cp tensorflow/c/c_api.h ${DIR}/build/include/tensorflow/c
+  tar -C ${DIR}/build -cvf ${DIR}/libtensorflow${TARBALL_SUFFIX}.tar.gz include/tensorflow/c/c_api.h lib/libtensorflow.so
+  rm -rf ${DIR}/build
+}

--- a/tensorflow/tools/ci_build/linux/libtensorflow.sh
+++ b/tensorflow/tools/ci_build/linux/libtensorflow.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Script to produce a tarball release of the C-library and associated C API
+# header file. Intended to be run inside a docker container. See
+# libtensorflow_docker.sh
+
+set -ex
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# See comments at the top of this file for details.
+source "${SCRIPT_DIR}/../builds/libtensorflow.sh"
+
+SUFFIX="-linux-cpu-"
+if [ "${TF_NEED_CUDA}" == "1" ]; then
+  SUFFIX="-linux-gpu-"
+fi
+
+build_libtensorflow_tarball "${SUFFIX}$(uname -m)"

--- a/tensorflow/tools/ci_build/linux/libtensorflow_cpu.sh
+++ b/tensorflow/tools/ci_build/linux/libtensorflow_cpu.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Script to build a binary release tarball for the TensorFlow C-library without
+# GPU support.
+
+set -ex
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TF_NEED_CUDA=0
+"${SCRIPT_DIR}/libtensorflow_docker.sh"

--- a/tensorflow/tools/ci_build/linux/libtensorflow_docker.sh
+++ b/tensorflow/tools/ci_build/linux/libtensorflow_docker.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Script to produce a tarball release of the C-library and associated C API
+# header file. Builds a docker container and then builds the C-library in
+# said container.
+#
+# See libtensorflow_cpu.sh and libtensorflow_gpu.sh
+
+set -ex
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_CONTEXT_PATH="$(realpath ${SCRIPT_DIR}/..)"
+ROOT_DIR="$(realpath ${SCRIPT_DIR}/../../../../)"
+
+DOCKER_IMAGE="tf-libtensorflow-cpu"
+DOCKER_FILE="Dockerfile.cpu"
+DOCKER_BINARY="docker"
+if [ "${TF_NEED_CUDA}" == "1" ]; then
+	DOCKER_IMAGE="tf-tensorflow-gpu"
+	DOCKER_BINARY="nvidia-docker"
+	DOCKER_FILE="Dockerfile.gpu"
+fi
+
+docker build \
+  -t "${DOCKER_IMAGE}" \
+  -f "${DOCKER_CONTEXT_PATH}/${DOCKER_FILE}" \
+  "${DOCKER_CONTEXT_PATH}"
+
+${DOCKER_BINARY} run \
+  --rm \
+  --pid=host \
+  -v ${ROOT_DIR}:/workspace \
+  -w /workspace \
+  -e "PYTHON_BIN_PATH=/usr/bin/python" \
+  -e "TF_NEED_GCP=0" \
+  -e "TF_NEED_HDFS=0" \
+  -e "TF_NEED_CUDA=${TF_NEED_CUDA}" \
+  -e "TF_NEED_OPENCL=0" \
+  "${DOCKER_IMAGE}" \
+  "/workspace/tensorflow/tools/ci_build/linux/libtensorflow.sh"

--- a/tensorflow/tools/ci_build/linux/libtensorflow_gpu.sh
+++ b/tensorflow/tools/ci_build/linux/libtensorflow_gpu.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Script to build a binary release tarball for the TensorFlow C-library for
+# machines with GPUs.
+set -ex
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TF_NEED_CUDA=1
+"${SCRIPT_DIR}/libtensorflow_docker.sh"

--- a/tensorflow/tools/ci_build/osx/libtensorflow_cpu.sh
+++ b/tensorflow/tools/ci_build/osx/libtensorflow_cpu.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Script to produce a tarball release of the C-library and associated C API
+# header file.
+# Produces: lib_package/libtensorflow-gpu-darwin-x86_64.tar.gz
+
+set -ex
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# See comments at the top of this file for details.
+source "${SCRIPT_DIR}/../builds/libtensorflow.sh"
+
+# Configure script
+export PYTHON_BIN_PATH="/usr/bin/python"
+export TF_NEED_GCP=0
+export TF_NEED_HDFS=0
+export TF_NEED_CUDA=0
+export TF_NEED_OPENCL=0
+export COMPUTECPP_PATH="/usr/local"
+
+export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+build_libtensorflow_tarball "-darwin-cpu-$(uname -m)"

--- a/tensorflow/tools/ci_build/osx/libtensorflow_gpu.sh
+++ b/tensorflow/tools/ci_build/osx/libtensorflow_gpu.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Script to produce a tarball release of the C-library and associated C API
+# header file.
+# Produces: lib_package/libtensorflow-gpu-darwin-x86_64.tar.gz
+
+set -ex
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# See comments at the top of this file for details.
+source "${SCRIPT_DIR}/../builds/libtensorflow.sh"
+
+# Configure script
+export TF_NEED_CUDA=1
+export LD_LIBRARY_PATH="/usr/local/cuda/lib:/usr/local/cuda/extras/CUPTI/lib:${LD_LIBRARY_PATH}"
+export PYTHON_BIN_PATH="/usr/bin/python"
+export TF_NEED_GCP=0
+export TF_NEED_HDFS=0
+export TF_NEED_OPENCL=0
+export COMPUTECPP_PATH="/usr/local"
+
+export PATH="/usr/local/cuda/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+build_libtensorflow_tarball "-darwin-gpu-$(uname -m)"


### PR DESCRIPTION
These scripts are intended to be run with every release to
produce libtensorflow.tar.gz for CPU and GPU on Linux and OS X
for x86_64 architecture machines.
(Eventually there will be other operating systems and architectures).

These binary releases are then intended to make use of other language
bindings (such as [Rust](https://github.com/tensorflow/rust), [Haskell](https://github.com/tensorflow/haskell), [Go](https://godoc.org/github.com/tensorflow/tensorflow/tensorflow/go)) easier
as the common case would be to download the binary C-library release and
avoid the need to build TensorFlow from source (and all the time and
external dependencies doing so entails).

Files:
- tensorflow/tools/ci_build/builds/libtensorflow.sh - Baseline common script to build a tarball
- tensorflow/osx/libtensorflow_{cpu,gpu}.sh - Build tarballs for OS X with and without GPU support
- tensorflow/linux: Has similar top level scripts, but the build happens in a docker container so it contains 4 files - the two top level builds, one shared libtensorflow_docker.sh that is used to build and execute the docker container and libtensorflow.sh which is the script run inside the container.