### PR TITLE
Fix building for iOS #4640

### DIFF
--- a/tensorflow/contrib/makefile/compile_ios_protobuf.sh
+++ b/tensorflow/contrib/makefile/compile_ios_protobuf.sh
@@ -71,7 +71,6 @@ fi
 
 make distclean
 ./configure \
---build=x86_64-apple-${OSX_VERSION} \
 --host=i386-apple-${OSX_VERSION} \
 --disable-shared \
 --enable-cross-compile \
@@ -99,7 +98,6 @@ make install
 
 make distclean
 ./configure \
---build=x86_64-apple-${OSX_VERSION} \
 --host=x86_64-apple-${OSX_VERSION} \
 --disable-shared \
 --enable-cross-compile \
@@ -127,7 +125,6 @@ make install
 
 make distclean
 ./configure \
---build=x86_64-apple-${OSX_VERSION} \
 --host=armv7-apple-${OSX_VERSION} \
 --with-protoc="${PROTOC_PATH}" \
 --disable-shared \
@@ -151,7 +148,6 @@ make install
 
 make distclean
 ./configure \
---build=x86_64-apple-${OSX_VERSION} \
 --host=armv7s-apple-${OSX_VERSION} \
 --with-protoc="${PROTOC_PATH}" \
 --disable-shared \
@@ -175,7 +171,6 @@ make install
 
 make distclean
 ./configure \
---build=x86_64-apple-${OSX_VERSION} \
 --host=arm \
 --with-protoc="${PROTOC_PATH}" \
 --disable-shared \


### PR DESCRIPTION
Seems like the reason why compilation fails does not directly related to TensorFlow or even Protobuf:

The `configure` script of Protobuf (generated by `autogen`) has non trivial logic for detecting cross-compilation (currently there checks can be found in lines 3918–3976 at `configure` file). It tries to compile some simple C programs into executable and run it during the configuration process. It works fine except the case when we build for x86_64 iOS simulator: one the one hand we get native code for build platform one the other hand we can not execute test program because it is based on iOS sdk. As result the `configure` script generates error.

Frankly speaking I still do not fully understand the logic behind cross-compilation check, however I've found workaround for building Protobuf and TensorFlow for all platforms including x86_64 iOS simulator. The workaround is simple: just remove `--build=x86_64-apple-${OSX_VERSION} \` string for x86_64 in `compile_ios_protobuf.sh` file. Note, for consistency I also removed same strings for all other platforms (x386, armv7, armv7s, arm64), however it doesn't seems necessary.

My platform: macOS Sierra 10.12.1, Xcode 8.1, autoconf 2.69 (installed via homebrew).