### PR TITLE
Fix integer overflow error

### DIFF
--- a/tensorflow/models/embedding/word2vec_kernels.cc
+++ b/tensorflow/models/embedding/word2vec_kernels.cc
@@ -116,7 +116,7 @@ class SkipgramOp : public OpKernel {
   int32 vocab_size_ = 0;
   Tensor word_;
   Tensor freq_;
-  int32 corpus_size_ = 0;
+  int64 corpus_size_ = 0;
   std::vector<int32> corpus_;
   std::vector<Example> precalc_examples_;
   int precalc_index_ = 0;


### PR DESCRIPTION
This sample crashes if used on big text files (>2B words).
Changing corpus_size_ to 64-bit int solves the problem.