### PR TITLE
tf.const now supports verification of a shape of values. 

### DIFF
--- a/tensorflow/python/framework/constant_op.py
+++ b/tensorflow/python/framework/constant_op.py
@@ -114,7 +114,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_util
 
 
-def constant(value, dtype=None, shape=None, name="Const"):
+def constant(value, dtype=None, shape=None, name="Const", verify_shape=False):
   """Creates a constant tensor.
 
    The resulting tensor is populated with values of type `dtype`, as
@@ -146,13 +146,15 @@ def constant(value, dtype=None, shape=None, name="Const"):
    ```
 
   Args:
-    value:     A constant value (or list) of output type `dtype`.
+    value:          A constant value (or list) of output type `dtype`.
 
-    dtype:     The type of the elements of the resulting tensor.
+    dtype:          The type of the elements of the resulting tensor.
 
-    shape:     Optional dimensions of resulting tensor.
+    shape:          Optional dimensions of resulting tensor.
 
-    name:      Optional name for the tensor.
+    name:           Optional name for the tensor.
+
+    verify_shape:   Boolean that enables verification of a shape of values.
 
   Returns:
     A Constant Tensor.
@@ -160,7 +162,7 @@ def constant(value, dtype=None, shape=None, name="Const"):
   g = ops.get_default_graph()
   tensor_value = attr_value_pb2.AttrValue()
   tensor_value.tensor.CopyFrom(
-      tensor_util.make_tensor_proto(value, dtype=dtype, shape=shape))
+      tensor_util.make_tensor_proto(value, dtype=dtype, shape=shape, verify_shape=verify_shape))
   dtype_value = attr_value_pb2.AttrValue(type=tensor_value.tensor.dtype)
   const_tensor = g.create_op(
       "Const", [], [dtype_value.type],

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -290,13 +290,14 @@ def _AssertCompatible(values, dtype):
                       (dtype.name, repr(mismatch), type(mismatch).__name__))
 
 
-def make_tensor_proto(values, dtype=None, shape=None):
+def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False):
   """Create a TensorProto.
 
   Args:
-    values:    Values to put in the TensorProto.
-    dtype:     Optional tensor_pb2 DataType value.
-    shape:     List of integers representing the dimensions of tensor.
+    values:         Values to put in the TensorProto.
+    dtype:          Optional tensor_pb2 DataType value.
+    shape:          List of integers representing the dimensions of tensor.
+    verify_shape:   Boolean that enables verification of a shape of values.
 
   Returns:
     A TensorProto. Depending on the type, it may contain data in the
@@ -306,7 +307,8 @@ def make_tensor_proto(values, dtype=None, shape=None):
 
   Raises:
     TypeError:  if unsupported types are provided.
-    ValueError: if arguments have inappropriate values.
+    ValueError: if arguments have inappropriate values or if verify_shape is
+     True and shape of values is not equals to a shape from the argument.
 
   make_tensor_proto accepts "values" of a python scalar, a python list, a
   numpy ndarray, or a numpy scalar.
@@ -395,6 +397,11 @@ def make_tensor_proto(values, dtype=None, shape=None):
     shape = [int(dim) for dim in shape]
     shape_size = np.prod(shape)
     is_same_size = shape_size == nparray.size
+
+    if verify_shape:
+        if not nparray.shape == tuple(shape):
+            raise TypeError("Expected Tensor's shape: %s, got %s." %
+                            (tuple(shape), nparray.shape))
 
     if nparray.size > shape_size:
       raise ValueError(

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -399,9 +399,9 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False):
     is_same_size = shape_size == nparray.size
 
     if verify_shape:
-        if not nparray.shape == tuple(shape):
-            raise TypeError("Expected Tensor's shape: %s, got %s." %
-                            (tuple(shape), nparray.shape))
+      if not nparray.shape == tuple(shape):
+        raise TypeError("Expected Tensor's shape: %s, got %s." %
+                        (tuple(shape), nparray.shape))
 
     if nparray.size > shape_size:
       raise ValueError(

--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -517,6 +517,16 @@ class TensorUtilTest(tf.test.TestCase):
     with self.assertRaises(TypeError):
       tensor_util.make_tensor_proto(np.array([1]), 0)
 
+  def testTensorShapeVerification(self):
+    array = np.array([[1], [2]])
+    correct_shape = (2, 1)
+    incorrect_shape = (1, 2)
+    tensor_util.make_tensor_proto(array, shape=correct_shape,
+        verify_shape=True)
+    with self.assertRaises(TypeError):
+      tensor_util.make_tensor_proto(array, shape=incorrect_shape,
+          verify_shape=True)
+
   def testShapeTooLarge(self):
     with self.assertRaises(ValueError):
       tensor_util.make_tensor_proto(np.array([1, 2]), shape=[1])


### PR DESCRIPTION
If shape that is passed via the argument is not consistent with the value in the shape variable ValueError will be raised. Example:

"Expected Tensor's shape: (2, 1), got (1, 2)"