### PR TITLE
Ensure stochastic_tensor_test runs.

### DIFF
--- a/tensorflow/contrib/bayesflow/python/kernel_tests/stochastic_tensor_test.py
+++ b/tensorflow/contrib/bayesflow/python/kernel_tests/stochastic_tensor_test.py
@@ -229,3 +229,8 @@ class ObservedStochasticTensorTest(tf.test.TestCase):
         distributions.Normal(mu=mu, sigma=sigma),
         value=tf.zeros(
             (1, 2), dtype=tf.int32))
+
+
+if __name__ == "__main__":
+  tf.test.main()
+


### PR DESCRIPTION
stochastic_tensor_test.py was missing a call to tf.test.main() so the
test wasn't actually running. This commit fixes that and the test
passes.