### PR TITLE
Replace squeeze/split with unpack

### DIFF
--- a/tensorflow/models/rnn/ptb/ptb_word_lm.py
+++ b/tensorflow/models/rnn/ptb/ptb_word_lm.py
@@ -130,7 +130,7 @@ class PTBModel(object):
     #
     # The alternative version of the code below is:
     #
-    # inputs = tf.unpack(inputs, num_steps, 1)
+    # inputs = tf.unstack(inputs, num_steps, 1)
     # outputs, state = tf.nn.rnn(cell, inputs, initial_state=self._initial_state)
     outputs = []
     state = self._initial_state

--- a/tensorflow/models/rnn/ptb/ptb_word_lm.py
+++ b/tensorflow/models/rnn/ptb/ptb_word_lm.py
@@ -130,7 +130,7 @@ class PTBModel(object):
     #
     # The alternative version of the code below is:
     #
-    # inputs = tf.unstack(inputs, num_steps, 1)
+    # inputs = tf.unstack(inputs, num=num_steps, axis=1)
     # outputs, state = tf.nn.rnn(cell, inputs, initial_state=self._initial_state)
     outputs = []
     state = self._initial_state

--- a/tensorflow/models/rnn/ptb/ptb_word_lm.py
+++ b/tensorflow/models/rnn/ptb/ptb_word_lm.py
@@ -130,8 +130,7 @@ class PTBModel(object):
     #
     # The alternative version of the code below is:
     #
-    # inputs = [tf.squeeze(input_step, [1])
-    #           for input_step in tf.split(1, num_steps, inputs)]
+    # inputs = tf.unpack(inputs, num_steps, 1)
     # outputs, state = tf.nn.rnn(cell, inputs, initial_state=self._initial_state)
     outputs = []
     state = self._initial_state


### PR DESCRIPTION
In [Recurrent Neural Networks](https://www.tensorflow.org/versions/r0.11/tutorials/recurrent/index.html) tutorial file `ptb_word_lm.py` I've replaced the alternative version of the code with `unpack` in place of `squeeze` and `split` (as in [documentation](https://www.tensorflow.org/versions/r0.11/api_docs/python/array_ops.html#split)).