### PR TITLE
install Pillow in Dockerfile

### DIFF
--- a/tensorflow/tools/docker/Dockerfile
+++ b/tensorflow/tools/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN pip --no-cache-dir install \
         numpy \
         scipy \
         sklearn \
+        Pillow \
         && \
     python -m ipykernel.kernelspec
 


### PR DESCRIPTION
Hi team,

When i used **tensorflow** in python, sometimes i try the code like 
`scipy.misc.imread('test.tif')`
but i get an error:
`AttributeError: 'module' object has no attribute 'imread'. `

After some digging, i find i need to install PIL from [the docs](https://docs.scipy.org/doc/scipy/reference/misc.html) on scipy.misc. i guess there may be some other developers using tensorflow in my way (e.g. [fast-style-transfer src/utils.py/#9](https://github.com/lengstrom/fast-style-transfer/blob/master/src/utils.py)). 

So i would like to suggest adding Pillow into docker image build. 

