### PR TITLE
Use passthrough args rather than wrapper functions

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/estimator.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimator.py
@@ -964,7 +964,7 @@ def _identity_feature_engineering_fn(features, labels):
 class Estimator(BaseEstimator):
   """Estimator class is the basic TensorFlow model trainer/evaluator.
   """
-  @deprecated_args('2017-2-1', 'Pass parameters as keyword arguments to')
+  @deprecated_args(PARAMS_DATE, PARAMS_INSTRUCTIONS, 'params')
   def __init__(self,
                model_fn=None,
                model_dir=None,
@@ -1026,10 +1026,9 @@ class Estimator(BaseEstimator):
     """
     super(Estimator, self).__init__(model_dir=model_dir, config=config)
     self._model_fn = model_fn
-    self._model_fn_args = model_fn_args
+    self._model_fn_args = [params] if params else []
+    self._model_fn_args.extend(model_fn_args)
     self._model_fn_kwargs = model_fn_kwargs
-    if params is not None:
-      self._model_fn_kwargs.update(params)
     self._feature_engineering_fn = (
         feature_engineering_fn or _identity_feature_engineering_fn)
 
@@ -1052,7 +1051,7 @@ class Estimator(BaseEstimator):
     model_fn_args = _get_arguments(self._model_fn)
     if 'mode' in model_fn_args:
         model_fn_results = self._model_fn(
-            features, labels, mode=mode, *self._model_fn_args, **self.model_fn_kwargs)
+            features, labels, mode, *self._model_fn_args, **self.model_fn_kwargs)
     else:
       model_fn_results = self._model_fn(features, labels, *self._model_fn_args, **self._model_fn_kwargs)
 

--- a/tensorflow/contrib/learn/python/learn/estimators/estimator.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimator.py
@@ -73,6 +73,11 @@ SCIKIT_DECOUPLE_INSTRUCTIONS = (
     'available in the SKCompat class, Estimator will only accept input_fn.\n'
     'Example conversion:\n'
     '  est = Estimator(...) -> est = SKCompat(Estimator(...))')
+PARAMS_DATE = '2017-02-1'
+PARAMS_INSTRUCTIONS = """\
+    Pass params to the Estimator constructor as individual keyword (or positional) arguments
+    and they will be passed through to the model_fn when it is called
+    """
 
 
 # TODO(roumposg): Migrate external users to tf.learn.contrib.ModeKeys and delete
@@ -343,7 +348,7 @@ class BaseEstimator(
       SCIKIT_DECOUPLE_DATE, SCIKIT_DECOUPLE_INSTRUCTIONS, 'x', 'y', 'batch_size'
   )
   def fit(self, x=None, y=None, input_fn=None, steps=None, batch_size=None,
-          monitors=None, max_steps=None):
+          monitors=None, max_steps=None, *input_fn_args, **input_fn_kwargs):
     # pylint: disable=g-doc-args,g-doc-return-or-yield
     """See `Trainable`.
 
@@ -357,11 +362,14 @@ class BaseEstimator(
     input_fn, feed_fn = _get_input_fn(x, y, input_fn, feed_fn=None,
                                       batch_size=batch_size, shuffle=True,
                                       epochs=None)
-    loss = self._train_model(input_fn=input_fn,
+    loss = self._train_model(input_fn,
+                             input_fn_args,
+                             input_fn_kwargs,
                              feed_fn=feed_fn,
                              steps=steps,
                              monitors=monitors,
                              max_steps=max_steps)
+
     logging.info('Loss for final step: %s.', loss)
     return self
 
@@ -414,7 +422,7 @@ class BaseEstimator(
   )
   def evaluate(
       self, x=None, y=None, input_fn=None, feed_fn=None, batch_size=None,
-      steps=None, metrics=None, name=None):
+      steps=None, metrics=None, name=None, *input_fn_args, **inputs_fn_kwargs):
     # pylint: disable=g-doc-args,g-doc-return-or-yield
     """See `Evaluable`.
 
@@ -433,7 +441,9 @@ class BaseEstimator(
                                                      feed_fn=feed_fn,
                                                      steps=steps,
                                                      metrics=metrics,
-                                                     name=name)
+                                                     name=name,
+                                                     *input_fn_args,
+                                                     **inputs_fn_kwargs)
     if eval_results is not None:
       eval_results.update({'global_step': global_step})
     return eval_results
@@ -444,7 +454,7 @@ class BaseEstimator(
   )
   def predict(
       self, x=None, input_fn=None, batch_size=None, outputs=None,
-      as_iterable=True):
+      as_iterable=True, *input_fn_args, **input_fn_kwargs):
     """Returns predictions for given features.
 
     Args:
@@ -460,6 +470,10 @@ class BaseEstimator(
         for each example until inputs are exhausted. Note: The inputs must
         terminate if you want the iterable to terminate (e.g. be sure to pass
         num_epochs=1 if you are using something like read_batch_features).
+      *input_fn_args: Any remaining positional arguments will be passed through
+        to `input_fn`. Ignored if `input_fn` is not specified.
+      **input_fn_kwargs: Any remaining keyword arguments will be passed through
+        to `input_fn`. Ignored if `input_fn` is not specified.
 
     Returns:
       A numpy array of predicted classes or regression values if the
@@ -474,7 +488,7 @@ class BaseEstimator(
         x, None, input_fn=input_fn, feed_fn=None, batch_size=batch_size,
         shuffle=False, epochs=1)
     return self._infer_model(
-        input_fn=input_fn, feed_fn=feed_fn, outputs=outputs,
+        input_fn, input_fn_args, input_fn_kwargs, feed_fn=feed_fn, outputs=outputs,
         as_iterable=as_iterable)
 
   def get_variable_value(self, name):
@@ -517,7 +531,9 @@ class BaseEstimator(
              signature_fn=None,
              prediction_key=None,
              default_batch_size=1,
-             exports_to_keep=None):
+             exports_to_keep=None,
+             *input_fn_args,
+             **input_fn_kwargs):
     """Exports inference graph into given dir.
 
     Args:
@@ -544,6 +560,12 @@ class BaseEstimator(
         `signature_fn` without filtering.
       default_batch_size: Default batch size of the `Example` placeholder.
       exports_to_keep: Number of exports to keep.
+      *input_fn_args: Any remaining positional arguments will be passed through
+        to `input_fn`. Ignored if `input_fn` is not specified. Not passed through
+        if `use_deprecated_input_fn` is True.
+      **input_fn_kwargs: Any remaining keyword arguments will be passed through
+        to `input_fn`. Ignored if `input_fn` is not specified. Not passed through
+        if `use_deprecated_input_fn` is True.
 
     Returns:
       The string path to the exported directory. NB: this functionality was
@@ -558,6 +580,8 @@ class BaseEstimator(
         signature_fn=signature_fn,
         prediction_key=prediction_key,
         input_fn=input_fn,
+        input_fn_args=input_fn_args,
+        input_fn_kwargs=input_fn_kwargs,
         input_feature_key=input_feature_key,
         use_deprecated_input_fn=use_deprecated_input_fn,
         default_batch_size=default_batch_size,
@@ -664,6 +688,8 @@ class BaseEstimator(
 
   def _train_model(self,
                    input_fn,
+                   input_fn_args,
+                   input_fn_kwargs,
                    steps,
                    feed_fn=None,
                    init_op=None,
@@ -696,7 +722,7 @@ class BaseEstimator(
     with self._graph.as_default() as g, g.device(device_fn):
       random_seed.set_random_seed(self._config.tf_random_seed)
       global_step = contrib_framework.create_global_step(g)
-      features, labels = input_fn()
+      features, labels = input_fn(*input_fn_args, **input_fn_kwargs)
       self._check_inputs(features, labels)
 
       # The default return type of _get_train_ops is ModelFnOps. But there are
@@ -770,7 +796,9 @@ class BaseEstimator(
                       steps,
                       feed_fn=None,
                       metrics=None,
-                      name=''):
+                      name='',
+                      *input_fn_args,
+                      **input_fn_kwargs):
     # TODO(wicke): Remove this once Model and associated code are gone.
     if (hasattr(self._config, 'execution_mode') and
         self._config.execution_mode not in ('all', 'evaluate', 'eval_evalset')):
@@ -789,7 +817,7 @@ class BaseEstimator(
     with ops.Graph().as_default() as g:
       random_seed.set_random_seed(self._config.tf_random_seed)
       global_step = contrib_framework.create_global_step(g)
-      features, labels = input_fn()
+      features, labels = input_fn(*input_fn_args, **input_fn_kwargs)
       self._check_inputs(features, labels)
 
       # The default return type of _get_eval_ops is ModelFnOps. But there are
@@ -819,14 +847,19 @@ class BaseEstimator(
 
       return eval_results, current_global_step
 
-  def _get_features_from_input_fn(self, input_fn):
-    result = input_fn()
+  def _get_features_from_input_fn(self, input_fn, input_fn_args, input_fn_kwargs):
+    result = input_fn(*input_fn_args, **input_fn_kwargs)
     if isinstance(result, (list, tuple)):
       return result[0]
     return result
 
-  def _infer_model(
-      self, input_fn, feed_fn=None, outputs=None, as_iterable=True):
+  def _infer_model(self,
+                   input_fn,
+                   input_fn_args,
+                   input_fn_kwargs,
+                   feed_fn=None,
+                   outputs=None,
+                   as_iterable=True):
     # Check that model has been trained.
     checkpoint_path = saver.latest_checkpoint(self._model_dir)
     if not checkpoint_path:
@@ -836,7 +869,7 @@ class BaseEstimator(
     with ops.Graph().as_default() as g:
       random_seed.set_random_seed(self._config.tf_random_seed)
       contrib_framework.create_global_step(g)
-      features = self._get_features_from_input_fn(input_fn)
+      features = self._get_features_from_input_fn(input_fn, input_fn_args, input_fn_kwargs)
 
       # The default return type of _get_predict_ops is ModelFnOps. But there are
       # some subclasses of tf.contrib.learn.Estimator which override this
@@ -931,13 +964,15 @@ def _identity_feature_engineering_fn(features, labels):
 class Estimator(BaseEstimator):
   """Estimator class is the basic TensorFlow model trainer/evaluator.
   """
-
+  @deprecated_args('2017-2-1', 'Pass parameters as keyword arguments to')
   def __init__(self,
                model_fn=None,
                model_dir=None,
                config=None,
+               feature_engineering_fn=None,
                params=None,
-               feature_engineering_fn=None):
+               *model_fn_args,
+               **model_fn_kwargs):
     """Constructs an `Estimator` instance.
 
     Args:
@@ -952,9 +987,6 @@ class Estimator(BaseEstimator):
                  `labels=None`.
           * `mode` specifies if this training, evaluation or
                  prediction. See `ModeKeys`.
-          * `params` is a `dict` of hyperparameters. Will receive what
-                 is passed to Estimator in `params` parameter. This allows
-                 to configure Estimators from hyper parameter tuning.
 
         * Returns:
           `ModelFnOps`
@@ -967,11 +999,10 @@ class Estimator(BaseEstimator):
           * loss: Scalar loss `Output`.
           * train_op: Training update `Output` or `Operation`.
 
-        Supports next three signatures for the function:
+        Supports next two signatures for the function:
 
           * `(features, labels) -> (predictions, loss, train_op)`
           * `(features, labels, mode) -> (predictions, loss, train_op)`
-          * `(features, labels, mode, params) -> (predictions, loss, train_op)`
 
       model_dir: Directory to save model parameters, graph and etc. This can
         also be used to load checkpoints from the directory into a estimator to
@@ -979,29 +1010,26 @@ class Estimator(BaseEstimator):
       config: Configuration object.
       params: `dict` of hyper parameters that will be passed into `model_fn`.
               Keys are names of parameters, values are basic python types.
+              This usage is deprecated; instead use `model_fn_kwargs`
       feature_engineering_fn: Feature engineering function. Takes features and
                               labels which are the output of `input_fn` and
                               returns features and labels which will be fed
                               into `model_fn`. Please check `model_fn` for
                               a definition of features and labels.
+      *model_fn_args: Any additional positional arguments will be passed through
+        to the model_fn when the graph is created
+      **model_fn_kwargs: Any additional keyword arguments will be passed through
+        to the model_fn when the graph is created
 
     Raises:
       ValueError: parameters of `model_fn` don't match `params`.
     """
     super(Estimator, self).__init__(model_dir=model_dir, config=config)
-    if model_fn is not None:
-      # Check number of arguments of the given function matches requirements.
-      model_fn_args = _get_arguments(model_fn)
-      if params is not None and 'params' not in model_fn_args:
-        raise ValueError('Estimator\'s model_fn (%s) has less than 4 '
-                         'arguments, but not None params (%s) are passed.' %
-                         (model_fn, params))
-      if params is None and 'params' in model_fn_args:
-        logging.warning('Estimator\'s model_fn (%s) includes params '
-                        'argument, but params are not passed to Estimator.',
-                        model_fn)
     self._model_fn = model_fn
-    self.params = params
+    self._model_fn_args = model_fn_args
+    self._model_fn_kwargs = model_fn_kwargs
+    if params is not None:
+      self._model_fn_kwargs.update(params)
     self._feature_engineering_fn = (
         feature_engineering_fn or _identity_feature_engineering_fn)
 
@@ -1023,13 +1051,10 @@ class Estimator(BaseEstimator):
     features, labels = self._feature_engineering_fn(features, labels)
     model_fn_args = _get_arguments(self._model_fn)
     if 'mode' in model_fn_args:
-      if 'params' in model_fn_args:
-        model_fn_results = self._model_fn(features, labels, mode=mode,
-                                          params=self.params)
-      else:
-        model_fn_results = self._model_fn(features, labels, mode=mode)
+        model_fn_results = self._model_fn(
+            features, labels, mode=mode, *self._model_fn_args, **self.model_fn_kwargs)
     else:
-      model_fn_results = self._model_fn(features, labels)
+      model_fn_results = self._model_fn(features, labels, *self._model_fn_args, **self._model_fn_kwargs)
 
     if isinstance(model_fn_results, ModelFnOps):
       return model_fn_results

--- a/tensorflow/contrib/learn/python/learn/evaluable.py
+++ b/tensorflow/contrib/learn/python/learn/evaluable.py
@@ -30,7 +30,7 @@ class Evaluable(object):
   @abc.abstractmethod
   def evaluate(
       self, x=None, y=None, input_fn=None, feed_fn=None, batch_size=None,
-      steps=None, metrics=None, name=None):
+      steps=None, metrics=None, name=None, *input_fn_args, **input_fn_kwargs):
     """Evaluates given model with provided evaluation data.
 
     Stop conditions - we evaluate on the given input data until one of the
@@ -75,12 +75,15 @@ class Evaluable(object):
         friendly names for the metric to a `MetricSpec` object defining which
         model outputs to evaluate against which labels with which metric
         function.
-
         Metric ops should support streaming, e.g., returning `update_op` and
         `value` tensors. For example, see the options defined in
         `../../../metrics/python/ops/metrics_ops.py`.
       name: Name of the evaluation if user needs to run multiple evaluations on
         different data sets, such as on training data vs test data.
+      *input_fn_args: Any remaining positional arguments will be passed through
+        to `input_fn`. Ignored if `input_fn` is not specified.
+      **input_fn_kwargs: Any remaining keyword arguments will be passed through
+        to `input_fn`. Ignored if `input_fn` is not specified.
 
     Returns:
       Returns `dict` with evaluation results.

--- a/tensorflow/contrib/learn/python/learn/experiment.py
+++ b/tensorflow/contrib/learn/python/learn/experiment.py
@@ -106,6 +106,10 @@ class Experiment(object):
                estimator,
                train_input_fn,
                eval_input_fn,
+               train_input_args=None,
+               train_input_kwargs=None,
+               eval_input_args=None,
+               eval_input_kwargs=None,
                eval_metrics=None,
                train_steps=None,
                eval_steps=100,
@@ -159,6 +163,10 @@ class Experiment(object):
     self._estimator = estimator
     self._train_input_fn = train_input_fn
     self._eval_input_fn = eval_input_fn
+    self._train_input_args = train_input_args or []
+    self._train_input_kwargs = train_input_kwargs or {}
+    self._eval_input_args = eval_input_args or []
+    self._eval_input_kwargs = eval_input_kwargs or {}
     self._eval_metrics = eval_metrics
     self._train_steps = train_steps
     self._eval_steps = eval_steps
@@ -215,7 +223,9 @@ class Experiment(object):
 
     return self._estimator.fit(input_fn=self._train_input_fn,
                                max_steps=self._train_steps,
-                               monitors=self._train_monitors + extra_hooks)
+                               monitors=self._train_monitors + extra_hooks
+                               *self._train_input_args,
+                               **self._train_input_kwargs)
 
   def evaluate(self, delay_secs=None):
     """Evaluate on the evaluation data.
@@ -243,7 +253,9 @@ class Experiment(object):
     return self._estimator.evaluate(input_fn=self._eval_input_fn,
                                     steps=self._eval_steps,
                                     metrics=self._eval_metrics,
-                                    name="one_pass")
+                                    name="one_pass",
+                                    *self._eval_input_args,
+                                    **self._eval_input_kwargs)
 
   @deprecated(
       "2016-10-23",
@@ -292,7 +304,9 @@ class Experiment(object):
         self._estimator.evaluate(input_fn=input_fn,
                                  steps=self._eval_steps,
                                  metrics=self._eval_metrics,
-                                 name=name)
+                                 name=name,
+                                 *self._eval_input_args,
+                                 **self._eval_input_kwargs)
       except NotFittedError:
         # Print warning message every 10 mins.
         if time.time() - last_fitted_error_time > 600:
@@ -366,7 +380,9 @@ class Experiment(object):
     return self._estimator.evaluate(input_fn=self._eval_input_fn,
                                     steps=self._eval_steps,
                                     metrics=self._eval_metrics,
-                                    name=eval_dir_suffix)
+                                    name=eval_dir_suffix,
+                                    *self._eval_input_args,
+                                    **self._eval_input_kwargs)
 
 
   def run_std_server(self):
@@ -388,12 +404,16 @@ class Experiment(object):
     """
     self._estimator.fit(input_fn=self._train_input_fn,
                         steps=1,
-                        monitors=self._train_monitors)
+                        monitors=self._train_monitors
+                        *self._train_input_args,
+                        **self._train_input_kwargs)
 
     return self._estimator.evaluate(input_fn=self._eval_input_fn,
                                     steps=1,
                                     metrics=self._eval_metrics,
-                                    name="one_pass")
+                                    name="one_pass",
+                                    *self._eval_input_args,
+                                    **self._eval_input_kwargs)
 
   def _start_server(self):
     """Creates, starts, and returns a server_lib.Server."""

--- a/tensorflow/contrib/learn/python/learn/experiment.py
+++ b/tensorflow/contrib/learn/python/learn/experiment.py
@@ -373,7 +373,7 @@ class Experiment(object):
         self._train_monitors += [monitors.ValidationMonitor(
             input_fn=self._eval_input_fn, eval_steps=self._eval_steps,
             metrics=self._eval_metrics, every_n_steps=self._min_eval_frequency,
-            name=eval_dir_suffix,
+            name=eval_dir_suffix, *self._eval_input_args, **self._eval_input_kwargs
         )]
       self.train(delay_secs=0)
 

--- a/tensorflow/contrib/learn/python/learn/learn_runner.py
+++ b/tensorflow/contrib/learn/python/learn/learn_runner.py
@@ -23,7 +23,11 @@ from tensorflow.contrib.learn.python.learn.experiment import Experiment
 from tensorflow.python.platform import tf_logging as logging
 
 
-def run(experiment_fn, output_dir, schedule=None):
+def run(experiment_fn,
+        output_dir,
+        schedule=None,
+        *experiment_fn_args,
+        **experiment_fn_kwargs):
   """Make and run an experiment.
 
   It creates an Experiment by calling `experiment_fn`. Then it calls the
@@ -59,6 +63,10 @@ def run(experiment_fn, output_dir, schedule=None):
       `Experiment`.
     output_dir: Base output directory.
     schedule: The name of the  method in the `Experiment` to run.
+    *experiment_fn_args: Any additional positional arguments are passed through
+      to `experiment_fn` when it is called.
+    **experiment_fn_kwargs: Any additional keyword arguments are passed through
+      to `experiment_fn` when it is called.
 
   Returns:
     The return value of function `schedule`.
@@ -76,7 +84,7 @@ def run(experiment_fn, output_dir, schedule=None):
                     experiment_fn)
 
   # Call the builder
-  experiment = experiment_fn(output_dir=output_dir)
+  experiment = experiment_fn(output_dir=output_dir, *experiment_fn_args, **experiment_fn_kwargs)
   if not isinstance(experiment, Experiment):
     raise TypeError('Experiment builder did not return an Experiment '
                     'instance, got %s instead.' % type(experiment))

--- a/tensorflow/contrib/learn/python/learn/monitors.py
+++ b/tensorflow/contrib/learn/python/learn/monitors.py
@@ -618,7 +618,8 @@ class ValidationMonitor(EveryN):
                eval_steps=None,
                every_n_steps=100, metrics=None, early_stopping_rounds=None,
                early_stopping_metric="loss",
-               early_stopping_metric_minimize=True, name=None):
+               early_stopping_metric_minimize=True, name=None,
+               *input_fn_args, **input_fn_kwargs):
     """Initializes a ValidationMonitor.
 
     Args:
@@ -643,6 +644,8 @@ class ValidationMonitor(EveryN):
           loss metrics like mean squared error, and False for performance
           metrics like accuracy.
       name: See `BaseEstimator.evaluate`.
+      *input_fn_args: See `BaseEstimator.evaluate`.
+      **input_fn_kwargs: See `BaseEstimator.evaluate`.
 
     Raises:
       ValueError: If both x and input_fn are provided.
@@ -655,6 +658,8 @@ class ValidationMonitor(EveryN):
     self.x = x
     self.y = y
     self.input_fn = input_fn
+    self.input_fn_args = input_fn_args,
+    self.input_fn_kwargs = input_fn_kwargs,
     self.batch_size = batch_size
     self.eval_steps = eval_steps
     self.metrics = metrics
@@ -707,7 +712,8 @@ class ValidationMonitor(EveryN):
     # Run evaluation and log it.
     validation_outputs = self._estimator.evaluate(
         x=self.x, y=self.y, input_fn=self.input_fn, batch_size=self.batch_size,
-        steps=self.eval_steps, metrics=self.metrics, name=self.name)
+        steps=self.eval_steps, metrics=self.metrics, name=self.name,
+        *self.input_fn_args, **self.input_fn_kwargs)
     stats = []
     for name in validation_outputs:
       stats.append("%s = %s" % (name, str(validation_outputs[name])))

--- a/tensorflow/contrib/learn/python/learn/trainable.py
+++ b/tensorflow/contrib/learn/python/learn/trainable.py
@@ -29,7 +29,7 @@ class Trainable(object):
 
   @abc.abstractmethod
   def fit(self, x=None, y=None, input_fn=None, steps=None, batch_size=None,
-          monitors=None, max_steps=None):
+          monitors=None, max_steps=None, *input_fn_args, **input_fn_kwargs):
     """Trains a model given training data `x` predictions and `y` labels.
 
     Args:
@@ -62,6 +62,10 @@ class Trainable(object):
         iterations. On the other hand, two calls to `fit(max_steps=100)` means
         that the second call will not do any iteration since first call did
         all 100 steps.
+      *input_fn_args: Any remaining positional arguments will be passed through
+        to `input_fn`. Ignored if `input_fn` is not specified.
+      **input_fn_kwargs: Any remaining keyword arguments will be passed through
+        to `input_fn`. Ignored if `input_fn` is not specified.
 
     Returns:
       `self`, for chaining.

--- a/tensorflow/contrib/learn/python/learn/utils/export.py
+++ b/tensorflow/contrib/learn/python/learn/utils/export.py
@@ -274,6 +274,8 @@ def _export_estimator(estimator,
                       export_dir,
                       signature_fn,
                       input_fn,
+                      input_fn_args,
+                      input_fn_kwargs,
                       default_batch_size,
                       exports_to_keep,
                       input_feature_key=None,
@@ -294,7 +296,7 @@ def _export_estimator(estimator,
                                        name='input_example_tensor')
       features = input_fn(estimator, examples)
     else:
-      features, _ = input_fn()
+      features, _ = input_fn(*input_fn_args, **input_fn_kwargs)
       examples = None
       if input_feature_key is not None:
         examples = features.pop(input_feature_key)


### PR DESCRIPTION
Googlers can look see [this doc](https://docs.google.com/document/d/1gVcn_r5njuEOEZDXXW3HubWqAGJDs4M5APX1d_JLr4o/edit#heading=h.mgiweq7i3oas) for an explanation of why this change is being made.

This change was made in a backwards compatible way. Other changes referenced in that doc will likely depend on this change but not be backwards compatible. 