### PR TITLE
enabling VocabularyProcessor.transform to also return document length.

### DIFF
--- a/tensorflow/contrib/learn/python/learn/preprocessing/tests/text_test.py
+++ b/tensorflow/contrib/learn/python/learn/preprocessing/tests/text_test.py
@@ -56,6 +56,14 @@ class TextTest(tf.test.TestCase):
     self.assertAllEqual(
         list(tokens), [[1, 2, 3, 0], [1, 2, 3, 0], [1, 2, 0, 3]])
 
+  def testVocabularyProcessorReturnDocLen(self):
+    vocab_processor = text.VocabularyProcessor(max_document_length=4,
+                                                 min_frequency=1)
+    tokens = vocab_processor.fit_transform(["a b c", "a\nb\nc", "a, b - c"],
+                                           return_docs_len=True)
+    self.assertAllEqual(
+        list(doc_len for tokens, doc_len in tokens), [3, 3, 4])
+
   def testVocabularyProcessorSaveRestore(self):
     filename = tf.test.get_temp_dir() + "test.vocab"
     vocab_processor = text.VocabularyProcessor(max_document_length=4,

--- a/tensorflow/contrib/learn/python/learn/preprocessing/text.py
+++ b/tensorflow/contrib/learn/python/learn/preprocessing/text.py
@@ -155,13 +155,13 @@ class VocabularyProcessor(object):
     self.vocabulary_.freeze()
     return self
 
-  def fit_transform(self, raw_documents, return_docs_len=False, unused_y=None):
+  def fit_transform(self, raw_documents, unused_y=None, return_docs_len=False):
     """Learn the vocabulary dictionary and return indexies of words.
 
     Args:
       raw_documents: An iterable which yield either str or unicode.
-      return_docs_len: Boolean if True yields number of tokens also.
       unused_y: to match fit_transform signature of estimators.
+      return_docs_len: Boolean if True yields number of tokens also.
 
     Returns:
       x: iterable, [n_samples, max_document_length]. Word-id matrix.

--- a/tensorflow/contrib/learn/python/learn/preprocessing/text.py
+++ b/tensorflow/contrib/learn/python/learn/preprocessing/text.py
@@ -155,20 +155,22 @@ class VocabularyProcessor(object):
     self.vocabulary_.freeze()
     return self
 
-  def fit_transform(self, raw_documents, unused_y=None):
+  def fit_transform(self, raw_documents, return_docs_len=False, unused_y=None):
     """Learn the vocabulary dictionary and return indexies of words.
 
     Args:
       raw_documents: An iterable which yield either str or unicode.
+      return_docs_len: Boolean if True yields number of tokens also.
       unused_y: to match fit_transform signature of estimators.
 
     Returns:
       x: iterable, [n_samples, max_document_length]. Word-id matrix.
+        Additional token count also returned is `return_docs_len= True`.
     """
     self.fit(raw_documents)
-    return self.transform(raw_documents)
+    return self.transform(raw_documents, return_docs_len)
 
-  def transform(self, raw_documents):
+  def transform(self, raw_documents, return_docs_len=False):
     """Transform documents to word-id matrix.
 
     Convert words to ids with vocabulary fitted with fit or the one
@@ -176,9 +178,11 @@ class VocabularyProcessor(object):
 
     Args:
       raw_documents: An iterable which yield either str or unicode.
+      return_docs_len: Boolean if True yields number of tokens also.
 
     Yields:
       x: iterable, [n_samples, max_document_length]. Word-id matrix.
+        Additional token count also returned is `return_docs_len= True`.
     """
     for tokens in self._tokenizer(raw_documents):
       word_ids = np.zeros(self.max_document_length, np.int64)
@@ -186,7 +190,10 @@ class VocabularyProcessor(object):
         if idx >= self.max_document_length:
           break
         word_ids[idx] = self.vocabulary_.get(token)
-      yield word_ids
+      if return_docs_len:
+        yield word_ids, idx+1
+      else:
+        yield word_ids
 
   def reverse(self, documents):
     """Reverses output of vocabulary mapping to words.


### PR DESCRIPTION
Currently, `VocabularyProcessor.transform()` ( and `VocabularyProcessor.fit_transform()` ) do not return the sequence length of ( number of tokens in )  individual raw documents. sequence lengths are required when dealing with variable length sequences ( eg. like `dynamic_rnn` where we need to also pass the lengths of individual sequences).

After the changes in PR, both `fit_transform()` and `fit()` has following signature - 
- `VocabularyProcessor.fit_transform( raw_documents, return_docs_len=False, unused_y=None)`
- `VocabularyProcessor.transform( raw_documents, return_docs_len=False)`

Setting `return_docs_len=True` makes above function to also yield the number of token in individual documents. 