### PR TITLE
add Pillow installation into Dockerfile for fixing scipy.misc.imread …

### DIFF
--- a/tensorflow/tools/docker/Dockerfile
+++ b/tensorflow/tools/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN pip --no-cache-dir install \
         numpy \
         scipy \
         sklearn \
+        Pillow \
         && \
     python -m ipykernel.kernelspec
 

--- a/tensorflow/tools/docker/Dockerfile.gpu
+++ b/tensorflow/tools/docker/Dockerfile.gpu
@@ -30,6 +30,7 @@ RUN pip --no-cache-dir install \
         numpy \
         scipy \
         sklearn \
+        Pillow \
         && \
     python -m ipykernel.kernelspec
 


### PR DESCRIPTION
@caisq this is a new PR related to [PR #5693 install Pillow in Dockerfile](https://github.com/tensorflow/tensorflow/pull/5693) and [PR #5711 add Pillow into docker build file](https://github.com/tensorflow/tensorflow/pull/5711). 2 changes are incorprated:
1. add Pillow installation into tensorflow/tools/docker/Dockerfile
2. add Pillow installation into tensorflow/tools/docker/Dockerfile.gpu

the following information for image size comparison:

**gpu version image size drops, i guess latest-gpu tagged image is too old.**

> REPOSITORY                     TAG                 IMAGE ID            CREATED             SIZE
> gcr.io/tensorflow/tensorflow   gpu                 8ca00ec56643        8 minutes ago       2.658 GB
> gcr.io/tensorflow/tensorflow   latest-gpu          dd645f420f1d        10 days ago         2.713 GB

**cpu version image size increases about 22MB < 2.5% up**

> REPOSITORY                     TAG                 IMAGE ID            CREATED             SIZE
> gcr.io/tensorflow/tensorflow   Pillow              dff6ac3189bd        17 hours ago        981.6 MB
> gcr.io/tensorflow/tensorflow   latest              5547120ff897        10 days ago         959.6 MB

Hao