### PR TITLE
Force precision to be float for the MNIST fully connected example.

### DIFF
--- a/tensorflow/examples/tutorials/mnist/fully_connected_feed.py
+++ b/tensorflow/examples/tutorials/mnist/fully_connected_feed.py
@@ -108,7 +108,7 @@ def do_eval(sess,
                                images_placeholder,
                                labels_placeholder)
     true_count += sess.run(eval_correct, feed_dict=feed_dict)
-  precision = true_count / num_examples
+  precision = float(true_count) / num_examples
   print('  Num examples: %d  Num correct: %d  Precision @ 1: %0.04f' %
         (num_examples, true_count, precision))
 


### PR DESCRIPTION
Right now, when the example runs precision is always 0 because it computed by dividing two ints and the result is always less than 1.