### PR TITLE
Default optimizer initialization in the LinearRegressor fix

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/linear.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/linear.py
@@ -638,9 +638,10 @@ class LinearRegressor(evaluable.Evaluable, trainable.Trainable):
     """
     self._feature_columns = feature_columns
     assert self._feature_columns
-    self._optimizer = _get_default_optimizer(feature_columns)
     if optimizer:
       self._optimizer = _get_optimizer(optimizer)
+    else:
+      self._optimizer = _get_default_optimizer(feature_columns)
 
     chief_hook = None
     if (isinstance(optimizer, sdca_optimizer.SDCAOptimizer) and


### PR DESCRIPTION
Default optimizer of the LinearRegressor should be set only if the users have not provided custom optimizer.