### PR TITLE
[Windows] Add Windows instructions to the 0.12 docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </div>
 -----------------
 
-|  **`Linux CPU`**   |  **`Linux GPU PIP`** | **`Mac OS CPU`** |  **`Android`** |
-|-------------------|----------------------|------------------|----------------|
-| [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-cpu)](https://ci.tensorflow.org/job/tensorflow-master-cpu) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-gpu_pip)](https://ci.tensorflow.org/job/tensorflow-master-gpu_pip) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-mac)](https://ci.tensorflow.org/job/tensorflow-master-mac) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-android)](https://ci.tensorflow.org/job/tensorflow-master-android) |
+| **`Linux CPU`** | **`Linux GPU PIP`** | **`Mac OS CPU`** | **`Windows CPU`** | **`Android`** |
+|-----------------|---------------------|------------------|-------------------|---------------|
+| [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-cpu)](https://ci.tensorflow.org/job/tensorflow-master-cpu) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-gpu_pip)](https://ci.tensorflow.org/job/tensorflow-master-gpu_pip) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-mac)](https://ci.tensorflow.org/job/tensorflow-master-mac) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-win-cmake-py)](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-win-cmake-py) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-android)](https://ci.tensorflow.org/job/tensorflow-master-android) |
 
 **TensorFlow** is an open source software library for numerical computation using
 data flow graphs.  Nodes in the graph represent mathematical operations, while

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -38,11 +38,13 @@ Docker images are listed in the corresponding installation sections.
 If you encounter installation errors, see
 [common problems](#common-problems) for some solutions.
 
-## Pip Installation
+## Pip installation
 
 [Pip](https://en.wikipedia.org/wiki/Pip_(package_manager)) is a package
 management system used to install and manage software packages written in
-Python.
+Python. We provide pip packages for TensorFlow on Linux, Mac OS X, and
+Windows. For Windows instructions, please see [Pip installation on
+Windows](#pip-installation-on-windows).
 
 The packages that will be installed or upgraded during the pip install are
 listed in the [REQUIRED_PACKAGES section of
@@ -113,6 +115,36 @@ protobuf dependency.
 
 
 You can now [test your installation](#test-the-tensorflow-installation).
+
+
+### Pip installation on Windows
+
+TensorFlow supports only 64-bit Python 3.5 on Windows. We have tested
+the pip packages with the following distributions of Python:
+
+* [Python 3.5 from python.org](https://www.python.org/downloads/release/python-352/)
+* [Python 3.5 from Anaconda](https://www.continuum.io/downloads#windows)
+
+Both distributions include pip. To install the CPU-only version of
+TensorFlow, enter the following command at a command prompt:
+
+```bat
+C:\> pip install --upgrade https://storage.googleapis.com/tensorflow/windows/cpu/tensorflow-0.12.0rc0-cp35-cp35m-win_amd64.whl
+```
+
+To install the GPU version of TensorFlow, enter the following command
+at a command prompt:
+
+```bat
+C:\> pip install --upgrade https://storage.googleapis.com/tensorflow/windows/gpu/tensorflow-0.12.0rc0-cp35-cp35m-win_amd64.whl
+```
+
+You can now [test your installation](#test-the-tensorflow-installation).
+
+You can also [use Virtualenv](#virtualenv-installation) or [Anaconda
+environments](#anaconda-installation) to manage your installation of
+TensorFlow on Windows.
+
 
 ## Virtualenv installation
 
@@ -532,6 +564,12 @@ $ python /usr/local/lib/python2.7/dist-packages/tensorflow/models/image/mnist/co
 When installing from source you will build a pip wheel that you then install
 using pip. You'll need pip for that, so install it as described
 [above](#pip-installation).
+
+To build TensorFlow from source on Windows, you can use experimental
+support for [Bazel on
+Windows](https://bazel.build/versions/master/docs/windows.html) or the
+[TensorFlow CMake
+build](https://github.com/tensorflow/tensorflow/tree/r0.12/tensorflow/contrib/cmake).
 
 ### Clone the TensorFlow repository
 

--- a/tensorflow/g3doc/resources/roadmap.md
+++ b/tensorflow/g3doc/resources/roadmap.md
@@ -30,7 +30,6 @@ C and C++ APIs for:
 
 ### Platforms
 * OpenCL support ([#22](https://github.com/tensorflow/tensorflow/issues/22))
-* Windows support ([#17](https://github.com/tensorflow/tensorflow/issues/17))
 
 ### Community
 * More educational resources


### PR DESCRIPTION
Added some instructions for installing/building TensorFlow on Windows, and made minor changes to other docs.