### PR TITLE
Passing exit code of the test back to bazel

### DIFF
--- a/tensorflow/tools/ci_build/gpu_build/parallel_gpu_execute.sh
+++ b/tensorflow/tools/ci_build/gpu_build/parallel_gpu_execute.sh
@@ -37,8 +37,9 @@ for i in `seq 0 $((TF_GPU_COUNT-1))`; do
       echo "Running test $@ on GPU $CUDA_VISIBLE_DEVICES"
       $@
     )
+    return_code=$?
     flock -u "$lock_fd"
-    exit 0
+    exit $return_code
   fi
 done
 


### PR DESCRIPTION
Script used for parallel GPU execution does not pass the exit code of the test to bazel (always return with exit 0), so failures are shown as PASS in the summary.