### PR TITLE
Fixing bug in Adadelta implementation

### DIFF
--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -64,7 +64,8 @@ struct ApplyAdadelta<GPUDevice, T> {
     bcast[0] = grad.dimension(0);
     Eigen::Sizes<1> single;
 
-    accum.device(d) = accum_update * rho.reshape(single).broadcast(bcast) +
+    //accum.device(d) = accum_update * rho.reshape(single).broadcast(bcast) +
+    accum.device(d) = accum * rho.reshape(single).broadcast(bcast) +
                       grad.square() * (grad.constant(T(1)) -
                                        rho.reshape(single).broadcast(bcast));
     const auto update =

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -64,7 +64,6 @@ struct ApplyAdadelta<GPUDevice, T> {
     bcast[0] = grad.dimension(0);
     Eigen::Sizes<1> single;
 
-    //accum.device(d) = accum_update * rho.reshape(single).broadcast(bcast) +
     accum.device(d) = accum * rho.reshape(single).broadcast(bcast) +
                       grad.square() * (grad.constant(T(1)) -
                                        rho.reshape(single).broadcast(bcast));

--- a/tensorflow/python/training/adadelta_test.py
+++ b/tensorflow/python/training/adadelta_test.py
@@ -25,7 +25,6 @@ import tensorflow as tf
 class AdadeltaOptimizerTest(tf.test.TestCase):
   def testBasic(self):
     num_updates = 4 # number of ADADELTA steps to perform
-
     for dtype in [tf.half, tf.float32]:
       for grad in [0.2, 0.1, 0.01]:
         for lr in [1.0, 0.5, 0.1]:

--- a/tensorflow/python/training/adadelta_test.py
+++ b/tensorflow/python/training/adadelta_test.py
@@ -25,6 +25,7 @@ import tensorflow as tf
 class AdadeltaOptimizerTest(tf.test.TestCase):
   def testBasic(self):
     num_updates = 4 # number of ADADELTA steps to perform
+
     for dtype in [tf.half, tf.float32]:
       for grad in [0.2, 0.1, 0.01]:
         for lr in [1.0, 0.5, 0.1]:
@@ -91,18 +92,18 @@ class AdadeltaOptimizerTest(tf.test.TestCase):
               for slot_idx in range(2):
                 self.assertAllCloseAccordingToType(
                   np.array([accum, accum], dtype=dtype.as_numpy_dtype()),
-                  slot[slot_idx].eval(), rtol=1e-2, atol=1e-2)
+                  slot[slot_idx].eval(), rtol=1e-3)
 
                 self.assertAllCloseAccordingToType(
                   np.array([accum_update, accum_update],
                   dtype=dtype.as_numpy_dtype()),
-                  slot_update[slot_idx].eval())
+                  slot_update[slot_idx].eval(), rtol=1e-3)
 
               # Check that the parameters have been updated
               self.assertAllCloseAccordingToType(
                 np.array([var0_init[0] - tot_update,
                 var0_init[1] - tot_update], dtype=dtype.as_numpy_dtype()),
-                var0.eval(), rtol=1e-2)
+                var0.eval(), rtol=1e-3)
 
               self.assertAllCloseAccordingToType(
                 np.array([var1_init[0] - tot_update,


### PR DESCRIPTION
The updated accum vector should be computed as:
\rho * accum + (1.0 - \rho) * grad^2,
according to Algorithm1 in Zeiler 2012 (https://arxiv.org/pdf/1212.5701v1.pdf).