### PR TITLE
Add sess.close() in document (g3doc/get_started/index.md)

### DIFF
--- a/tensorflow/g3doc/get_started/index.md
+++ b/tensorflow/g3doc/get_started/index.md
@@ -43,6 +43,9 @@ for step in range(201):
         print(step, sess.run(W), sess.run(b))
 
 # Learns best fit is W: [0.1], b: [0.3]
+
+# Close the Session when we're done.
+sess.close()
 ```
 
 The first part of this code builds the data flow graph.  TensorFlow does not


### PR DESCRIPTION
I read from tensorflow Session management document that 

A session may own resources, such as variables, queues, and readers. It is important to release these resources when they are no longer required. 
To do this, either **invoke the close() method on the session**, or **use the session as a context manager.** The following two examples are equivalent:

but I found g3doc/get_started/index.md didn't

so I made the pull request for add sess.close() at the end of code.

Thank you for making tensorflow
