### PR TITLE
Fix an error in 'Adding a New Op' example code

### DIFF
--- a/tensorflow/g3doc/how_tos/adding_an_op/index.md
+++ b/tensorflow/g3doc/how_tos/adding_an_op/index.md
@@ -1071,7 +1071,7 @@ def _zero_out_grad(op, grad):
   shape = array_ops.shape(to_zero)
   index = array_ops.zeros_like(shape)
   first_grad = array_ops.reshape(grad, [-1])[0]
-  to_zero_grad = sparse_ops.sparse_to_dense(index, shape, first_grad, 0)
+  to_zero_grad = sparse_ops.sparse_to_dense([index], shape, first_grad, 0)
   return [to_zero_grad]  # List of one Tensor, since we have one input
 ```
 

--- a/tensorflow/g3doc/how_tos/adding_an_op/zero_out_2_test.py
+++ b/tensorflow/g3doc/how_tos/adding_an_op/zero_out_2_test.py
@@ -31,10 +31,23 @@ class ZeroOut2Test(tf.test.TestCase):
       result = zero_out_op_2.zero_out([5, 4, 3, 2, 1])
       self.assertAllEqual(result.eval(), [5, 0, 0, 0, 0])
 
+  def test_2d(self):
+    with self.test_session():
+      result = zero_out_op_2.zero_out([[6, 5, 4], [3, 2, 1]])
+      self.assertAllEqual(result.eval(), [[6, 0, 0], [0, 0, 0]])
+
   def test_grad(self):
     with self.test_session():
       shape = (5,)
       x = tf.constant([5, 4, 3, 2, 1], dtype=tf.float32)
+      y = zero_out_op_2.zero_out(x)
+      err = tf.test.compute_gradient_error(x, shape, y, shape)
+      self.assertLess(err, 1e-4)
+
+  def test_grad_2d(self):
+    with self.test_session():
+      shape = (2, 3)
+      x = tf.constant([[6, 5, 4], [3, 2, 1]], dtype=tf.float32)
       y = zero_out_op_2.zero_out(x)
       err = tf.test.compute_gradient_error(x, shape, y, shape)
       self.assertLess(err, 1e-4)

--- a/tensorflow/g3doc/how_tos/adding_an_op/zero_out_grad_2.py
+++ b/tensorflow/g3doc/how_tos/adding_an_op/zero_out_grad_2.py
@@ -40,5 +40,5 @@ def _zero_out_grad(op, grad):
   shape = array_ops.shape(to_zero)
   index = array_ops.zeros_like(shape)
   first_grad = array_ops.reshape(grad, [-1])[0]
-  to_zero_grad = sparse_ops.sparse_to_dense(index, shape, first_grad, 0)
+  to_zero_grad = sparse_ops.sparse_to_dense([index], shape, first_grad, 0)
   return [to_zero_grad]  # List of one Tensor, since we have one input


### PR DESCRIPTION
There is an error in the 'Adding a New Op' example code. By chance, the test code failed to catch it because only 1-D tensor is tested.