### PR TITLE
[Anaconda Installation Tutorial]As in issue #5832, pip installed TF s…

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -252,7 +252,8 @@ Follow the instructions on the [Anaconda download
 site](https://www.continuum.io/downloads).
 
 Note: If tensorflow has been installed via pip previously, then one should 
-uninstall it before installation in Anaconda environment. 
+uninstall it before installation in Anaconda environment. Because Anaconda 
+searches system site-packages from `.local` with higher priority.
 ```
 # Python 2
 $ pip uninstall tensorflow
@@ -260,7 +261,7 @@ $ pip uninstall tensorflow
 # Python 3
 $ pip3 uninstall tensorflow
 ```
-Since Anaconda searches system site-packages from `.local` with higher priority.
+
 
 Create a conda environment called `tensorflow`:
 

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -251,6 +251,17 @@ Install Anaconda:
 Follow the instructions on the [Anaconda download
 site](https://www.continuum.io/downloads).
 
+Note: If tensorflow has been installed via pip previously, then one should 
+uninstall it before installation in Anaconda environment. 
+```
+# Python 2
+$ pip uninstall tensorflow
+
+# Python 3
+$ pip3 uninstall tensorflow
+```
+Since Anaconda searches system site-packages from `.local` with higher priority.
+
 Create a conda environment called `tensorflow`:
 
 ```bash

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -254,7 +254,7 @@ site](https://www.continuum.io/downloads).
 Note: If tensorflow has been installed via pip previously, then one should 
 uninstall it before installation in Anaconda environment. Because Anaconda 
 searches system site-packages from `.local` with higher priority.
-```
+```bash
 # Python 2
 $ pip uninstall tensorflow
 

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -251,9 +251,10 @@ Install Anaconda:
 Follow the instructions on the [Anaconda download
 site](https://www.continuum.io/downloads).
 
-Note: If tensorflow has been installed via pip previously, then one should 
-uninstall it before installation in Anaconda environment. Because Anaconda 
-searches system site-packages from `.local` with higher priority.
+Note: If tensorflow has been installed via pip outside the Anaconda environment
+previously, then one should uninstall it if one wants to use the tensorflow 
+installed within an Anaconda environment, because Anaconda searches system 
+site-packages from `.local` with higher priority.
 ```bash
 # Python 2
 $ pip uninstall tensorflow


### PR DESCRIPTION
…hould be uninstalled if one want to use TF with Anaconda environment, because Anaconda will search system site-packages with higher priority, this might result in the latest upgrade of TF within Anaconda environment inaccessible.