### PR TITLE
Add load method to tf.Variable

### DIFF
--- a/tensorflow/python/kernel_tests/variables_test.py
+++ b/tensorflow/python/kernel_tests/variables_test.py
@@ -372,12 +372,11 @@ class VariablesTestCase(tf.test.TestCase):
 
   def testLoad(self):
     with self.test_session():
-      var = tf.Variable(np.random.randn(5, 5))
+      var = tf.Variable(np.zeros((5,5), np.float32))
       tf.global_variables_initializer().run()
-      data = np.random.randn(5, 5)
-      var.load(data)
+      var.load(np.ones((5, 5), np.float32))
 
-      self.assertAllClose(data, var.eval())
+      self.assertAllClose(np.ones((5, 5), np.float32), var.eval())
 
 
 class IsInitializedTest(tf.test.TestCase):

--- a/tensorflow/python/kernel_tests/variables_test.py
+++ b/tensorflow/python/kernel_tests/variables_test.py
@@ -370,6 +370,15 @@ class VariablesTestCase(tf.test.TestCase):
       for i in v2.initializer.inputs:
         self.assertEqual(expected_group_v2, i.op.colocation_groups())
 
+  def testLoad(self):
+    with self.test_session():
+      var = tf.Variable(np.random.randn(5, 5))
+      tf.global_variables_initializer().run()
+      data = np.random.randn(5, 5)
+      var.load(data)
+
+      self.assertAllClose(data, var.eval())
+
 
 class IsInitializedTest(tf.test.TestCase):
 

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -649,6 +649,46 @@ class Variable(object):
     """
     return state_ops.count_up_to(self._variable, limit=limit)
 
+  def load(self, value, session=None):
+    """Load new value into this variable
+
+    Writes new value to variable's memory. Doesn't add ops to the graph.
+
+    This convenience method requires a session where the graph containing this
+    variable has been launched. If no session is passed, the default session is
+    used.  See the [Session class](../../api_docs/python/client.md#Session) for
+    more information on launching a graph and on sessions.
+
+    ```python
+    v = tf.Variable([1, 2])
+    init = tf.global_variables_initializer()
+
+    with tf.Session() as sess:
+        sess.run(init)
+        # Usage passing the session explicitly.
+        v.load([2, 3], sess)
+        print(v.eval(sess)) # prints [2 3]
+        # Usage with the default session.  The 'with' block
+        # above makes 'sess' the default session.
+        v.load([3, 4], sess)
+        print(v.eval()) # prints [3 4]
+    ```
+
+    Args:
+        value: New variable value
+        session: The session to use to evaluate this variable. If
+          none, the default session is used.
+
+    Raises:
+        ValueError: Session is not passed and no default session
+    """
+    session = session or ops.get_default_session()
+    if session is None:
+      raise ValueError(
+          "Either session argument should be provided or default session "
+          "should be established")
+    session.run(self._initializer_op, {self._initializer_op.inputs[1]: value})
+
   # Conversion to tensor.
   @staticmethod
   def _TensorConversionFunction(v, dtype=None, name=None, as_ref=False):  # pylint: disable=invalid-name


### PR DESCRIPTION
Allows loading new value into variable without adding new operations to the graph.

Sometimes it is convenient to just load new value into variable without adding new operations to the graph. For example one may want to load values into some weights from other model or model trained with other framework.