### PR TITLE
Fixed wrong documentation on ctc_beam_search_decoder

### DIFF
--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -213,8 +213,8 @@ def ctc_beam_search_decoder(inputs, sequence_length, beam_width=100,
   """Performs beam search decoding on the logits given in input.
 
   **Note** The `ctc_greedy_decoder` is a special case of the
-  `ctc_beam_search_decoder` with `top_paths=1` (but that decoder is faster
-  for this special case).
+  `ctc_beam_search_decoder` with `top_paths=1` and `beam_width=1` (but
+  that decoder is faster for this special case).
 
   If `merge_repeated` is `True`, merge repeated classes in the output beams.
   This means that if consecutive entries in a beam are the same,


### PR DESCRIPTION
The documentation for `ctc_beam_search_decoder` has an error. It claims that it is equivalent to `ctc_greedy_decoder` when `top_paths=1`. This gives the impression that if we only care about the best result, we should always use `ctc_greedy_decoder`. However, `ctc_greedy_decoder` just does a simple argmax at each timestep, which is not equivalent result to a beam_search with `beam_width=100` and `top_paths=1`.

The only case they are equivalent is when both `beam_width` and `top_paths` are `1`. This pull request corrects this documentation error.