### PR TITLE
variable_summaries(...) missing parameter 'name'

### DIFF
--- a/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
+++ b/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
@@ -79,17 +79,17 @@ training. The code below is an excerpt; full source is
 [here](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py).
 
 ```python
-def variable_summaries(var):
-  """Attach a lot of summaries to a Tensor (for TensorBoard visualization)."""
+def variable_summaries(var, name):
+  """Attach a lot of summaries to a Tensor."""
   with tf.name_scope('summaries'):
     mean = tf.reduce_mean(var)
-    tf.summary.scalar('mean', mean)
+    tf.scalar_summary('mean/' + name, mean)
     with tf.name_scope('stddev'):
       stddev = tf.sqrt(tf.reduce_mean(tf.square(var - mean)))
-    tf.summary.scalar('stddev', stddev)
-    tf.summary.scalar('max', tf.reduce_max(var))
-    tf.summary.scalar('min', tf.reduce_min(var))
-    tf.summary.histogram('histogram', var)
+    tf.scalar_summary('stddev/' + name, stddev)
+    tf.scalar_summary('max/' + name, tf.reduce_max(var))
+    tf.scalar_summary('min/' + name, tf.reduce_min(var))
+    tf.histogram_summary(name, var)
 
 def nn_layer(input_tensor, input_dim, output_dim, layer_name, act=tf.nn.relu):
   """Reusable code for making a simple neural net layer.
@@ -103,15 +103,15 @@ def nn_layer(input_tensor, input_dim, output_dim, layer_name, act=tf.nn.relu):
     # This Variable will hold the state of the weights for the layer
     with tf.name_scope('weights'):
       weights = weight_variable([input_dim, output_dim])
-      variable_summaries(weights)
+      variable_summaries(weights, layer_name + '/weights')
     with tf.name_scope('biases'):
       biases = bias_variable([output_dim])
-      variable_summaries(biases)
+      variable_summaries(biases, layer_name + '/biases')
     with tf.name_scope('Wx_plus_b'):
       preactivate = tf.matmul(input_tensor, weights) + biases
-      tf.summary.histogram('pre_activations', preactivate)
-    activations = act(preactivate, name='activation')
-    tf.summary.histogram('activations', activations)
+      tf.histogram_summary(layer_name + '/pre_activations', preactivate)
+    activations = act(preactivate, 'activation')
+    tf.histogram_summary(layer_name + '/activations', activations)
     return activations
 
 hidden1 = nn_layer(x, 784, 500, 'layer1')


### PR DESCRIPTION
Versions 0.11 and 0.10 had a parameter named 'name' on variable_summaries function but this is now missing on master and 0.12