### PR TITLE
Fix params docstring of embedding_lookup

### DIFF
--- a/tensorflow/python/ops/embedding_ops.py
+++ b/tensorflow/python/ops/embedding_ops.py
@@ -61,10 +61,11 @@ def embedding_lookup(params, ids, partition_strategy="mod", name=None,
   tensor. The returned tensor has shape `shape(ids) + shape(params)[1:]`.
 
   Args:
-    params: A list of tensors with the same type and which can be concatenated
-      along dimension 0. Alternatively, a `PartitionedVariable`, created by
-      partitioning along dimension 0.  Each element must be appropriately sized
-      for the given `partition_strategy`.
+    params: A single tensor representing the complete embedding tensor,
+      or a list of P tensors all of same shape except for the first dimension,
+      representing sharded embedding tensors.  Alternatively, a
+      `PartitionedVariable`, created by partitioning along dimension 0. Each
+      element must be appropriately sized for the given `partition_strategy`.
     ids: A `Tensor` with type `int32` or `int64` containing the ids to be looked
       up in `params`.
     partition_strategy: A string specifying the partitioning strategy, relevant
@@ -195,7 +196,8 @@ def embedding_lookup_sparse(params, sp_ids, sp_weights,
     params: A single tensor representing the complete embedding tensor,
       or a list of P tensors all of same shape except for the first dimension,
       representing sharded embedding tensors.  Alternatively, a
-      `PartitionedVariable`, created by partitioning along dimension 0.
+      `PartitionedVariable`, created by partitioning along dimension 0. Each
+      element must be appropriately sized for the given `partition_strategy`.
     sp_ids: N x M SparseTensor of int64 ids (typically from FeatureValueToId),
       where N is typically batch size and M is arbitrary.
     sp_weights: either a SparseTensor of float / double weights, or None to


### PR DESCRIPTION
The first parameter of embedding_lookup actually accept a single tensor.
```py
  if not isinstance(params, list):
    params = [params]
```
However, in the docstring it requires a list which is confusing.
This PR fix and unify the doc.