### PR TITLE
Add undocumented pre-required tool for building iOS library

### DIFF
--- a/tensorflow/contrib/makefile/README.md
+++ b/tensorflow/contrib/makefile/README.md
@@ -142,7 +142,7 @@ xcode-select --install
 If this is a new install, you will need to run XCode once to agree to the
 license before continuing.
 
-Then install [automake](https://en.wikipedia.org/wiki/Automake)/libtool:
+Then install [automake](https://en.wikipedia.org/wiki/Automake)/[libtool](https://en.wikipedia.org/wiki/GNU_Libtool):
 
 ```bash
 brew install automake

--- a/tensorflow/contrib/makefile/README.md
+++ b/tensorflow/contrib/makefile/README.md
@@ -142,10 +142,11 @@ xcode-select --install
 If this is a new install, you will need to run XCode once to agree to the
 license before continuing.
 
-Then install [automake](https://en.wikipedia.org/wiki/Automake):
+Then install [automake](https://en.wikipedia.org/wiki/Automake)/libtool:
 
 ```bash
 brew install automake
+brew install libtool
 ```
 
 Also, download the graph if you haven't already:


### PR DESCRIPTION
'libtool' is not mentioned for building iOS library, which will cause 'build_all_ios.sh' failure if it is missing.