### PR TITLE
Revert "Removed unnecessary classproperty decorator"

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -43,7 +43,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import versions
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import compat
-from tensorflow.python.util import deprecation
+from tensorflow.python.util import decorator_utils
 
 
 def _override_helper(clazz_object, operator, func):
@@ -4063,12 +4063,12 @@ class GraphKeys(object):
   COND_CONTEXT = "cond_context"
   WHILE_CONTEXT = "while_context"
 
-  @property
-  @deprecation.deprecated("2017-03-02",
-              "VARIABLES collection name is deprecated, "
-              "please use GLOBAL_VARIABLES instead")
-  def VARIABLES(self):
-    return self.GLOBAL_VARIABLES
+  @decorator_utils.classproperty
+  def VARIABLES(cls):  # pylint: disable=no-self-argument
+    logging.warning("VARIABLES collection name is deprecated, "
+                    "please use GLOBAL_VARIABLES instead; "
+                    "VARIABLES will be removed after 2017-03-02.")
+    return cls.GLOBAL_VARIABLES
 
 
 def add_to_collection(name, value):

--- a/tensorflow/python/util/decorator_utils.py
+++ b/tensorflow/python/util/decorator_utils.py
@@ -60,3 +60,25 @@ def validate_callable(func, decorator_name):
         ' @property appears before @%s in your source code:'
         '\n\n@property\n@%s\ndef method(...)' % (
             func, decorator_name, decorator_name))
+
+
+class classproperty(object):  # pylint: disable=invalid-name
+  """Class property decorator.
+
+  Example usage:
+
+  class MyClass(object):
+
+    @classproperty
+    def value(cls):
+      return '123'
+
+  > print MyClass.value
+  123
+  """
+
+  def __init__(self, func):
+    self._func = func
+
+  def __get__(self, owner_self, owner_cls):
+    return self._func(owner_cls)


### PR DESCRIPTION
Reverts tensorflow/tensorflow#5510 because it fails legacy usage `GraphKeys.VARIABLES` reported #5877.