### PR TITLE
fixed run_path_pairs AttributeError

### DIFF
--- a/tensorflow/tensorboard/plugins/projector/plugin.py
+++ b/tensorflow/tensorboard/plugins/projector/plugin.py
@@ -136,7 +136,7 @@ class ProjectorPlugin(TBPlugin):
   @property
   def configs(self):
     """Returns a map of run paths to `ProjectorConfig` protos."""
-    run_path_pairs = self.run_paths.items()
+    run_path_pairs = list(self.run_paths.items())
     # If there are no summary event files, the projector should still work,
     # treating the `logdir` as the model checkpoint directory.
     if not run_path_pairs:


### PR DESCRIPTION
In python3,  `dict.items()` is a little different.
```
D.items() -> a set-like object providing a view on D's items
```
Otherwise, `AttributeError: 'dict_items' object has no attribute 'append'` will be raised.