### PR TITLE
Find correct path of libcudnn.dylib on macOS in configure script.

### DIFF
--- a/configure
+++ b/configure
@@ -279,7 +279,7 @@ while true; do
       TF_CUDNN_VERSION=${BASH_REMATCH[1]}
       echo "libcudnn.so resolves to libcudnn${TF_CUDNN_EXT}"
     elif [[ "$REALVAL" =~ ([0-9]*).dylib ]]; then
-      TF_CUDNN_EXT=${BASH_REMATCH[1]}".dylib"
+      TF_CUDNN_EXT="."${BASH_REMATCH[1]}".dylib"
       TF_CUDNN_VERSION=${BASH_REMATCH[1]}
       echo "libcudnn.dylib resolves to libcudnn${TF_CUDNN_EXT}"
     fi


### PR DESCRIPTION
The libcudnn file is stored like `libcudnn.5.dylib` on macOS, but the original script looks for `libcudnn5.dylib`, which would produce an invalid path error. And the issue only affects the auto-detecting part.