### PR TITLE
[Windows] Re-enable the special function ops.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,9 +8,7 @@
   acceleration. Known limitations include: It is not currently possible to load
   a custom op library. The GCS and HDFS file systems are not currently
   supported. The following ops are not currently implemented:
-  DepthwiseConv2dNative, DepthwiseConv2dNativeBackpropFilter,
-  DepthwiseConv2dNativeBackpropInput, Dequantize, Digamma, Erf, Erfc, Igamma,
-  Igammac, Lgamma, Polygamma, QuantizeAndDequantize, QuantizedAvgPool,
+  Dequantize, QuantizeAndDequantize, QuantizedAvgPool,
   QuantizedBatchNomWithGlobalNormalization, QuantizedBiasAdd, QuantizedConcat,
   QuantizedConv2D, QuantizedMatmul, QuantizedMaxPool,
   QuantizeDownAndShrinkRange, QuantizedRelu, QuantizedRelu6, QuantizedReshape,

--- a/tensorflow/contrib/cmake/tf_tests.cmake
+++ b/tensorflow/contrib/cmake/tf_tests.cmake
@@ -142,7 +142,6 @@ if (tensorflow_BUILD_PYTHON_TESTS)
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/string_to_number_op_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/clip_ops_test.py"
       # misc
-      "${tensorflow_source_dir}/tensorflow/python/kernel_tests/cwise_ops_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/variable_scope_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/reshape_op_test.py"
       "${tensorflow_source_dir}/tensorflow/tensorboard/backend/server_test.py"

--- a/tensorflow/core/kernels/cwise_op_digamma.cc
+++ b/tensorflow/core/kernels/cwise_op_digamma.cc
@@ -16,12 +16,10 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-#if EIGEN_HAS_C99_MATH
 REGISTER3(UnaryOp, CPU, "Digamma", functor::digamma, float, Eigen::half,
           double);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Digamma", functor::digamma, float, Eigen::half,
           double);
 #endif  // GOOGLE_CUDA
-#endif  // EIGEN_HAS_C99_MATH
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_erf.cc
+++ b/tensorflow/core/kernels/cwise_op_erf.cc
@@ -16,10 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-#if EIGEN_HAS_C99_MATH
 REGISTER3(UnaryOp, CPU, "Erf", functor::erf, float, Eigen::half, double);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Erf", functor::erf, float, Eigen::half, double);
 #endif  // GOOGLE_CUDA
-#endif  // EIGEN_HAS_C99_MATH
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_erfc.cc
+++ b/tensorflow/core/kernels/cwise_op_erfc.cc
@@ -16,10 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-#if EIGEN_HAS_C99_MATH
 REGISTER3(UnaryOp, CPU, "Erfc", functor::erfc, float, Eigen::half, double);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Erfc", functor::erfc, float, Eigen::half, double);
 #endif  // GOOGLE_CUDA
-#endif  // EIGEN_HAS_C99_MATH
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_igammas.cc
+++ b/tensorflow/core/kernels/cwise_op_igammas.cc
@@ -16,8 +16,6 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-#if EIGEN_HAS_C99_MATH
 REGISTER2(BinaryOp, CPU, "Igamma", functor::igamma, float, double);
 REGISTER2(BinaryOp, CPU, "Igammac", functor::igammac, float, double);
-#endif  // EIGEN_HAS_C99_MATH
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_lgamma.cc
+++ b/tensorflow/core/kernels/cwise_op_lgamma.cc
@@ -16,11 +16,9 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-#if EIGEN_HAS_C99_MATH
 REGISTER3(UnaryOp, CPU, "Lgamma", functor::lgamma, float, Eigen::half, double);
 #if GOOGLE_CUDA
 REGISTER3(UnaryOp, GPU, "Lgamma", functor::lgamma, float, Eigen::half, double);
 #endif
-#endif  // EIGEN_HAS_C99_MATH
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_zeta.cc
+++ b/tensorflow/core/kernels/cwise_op_zeta.cc
@@ -17,7 +17,5 @@ limitations under the License.
 
 namespace tensorflow {
 REGISTER2(BinaryOp, CPU, "Zeta", functor::zeta, float, double);
-#if EIGEN_HAS_C99_MATH
 REGISTER2(BinaryOp, CPU, "Polygamma", functor::polygamma, float, double);
-#endif  // EIGEN_HAS_C99_MATH
 }  // namespace tensorflow


### PR DESCRIPTION
These were previously disabled under `#ifdef EIGEN_HAS_C99_MATH` due to a compiler error, which has since disappear. Re-enable these ops and their test.