### PR TITLE
split will move leading or trailing whitespace when sep is whitespace

### DIFF
--- a/tensorflow/models/rnn/translate/data_utils.py
+++ b/tensorflow/models/rnn/translate/data_utils.py
@@ -106,7 +106,7 @@ def get_wmt_enfr_dev_set(directory):
 def basic_tokenizer(sentence):
   """Very basic tokenizer: split the sentence into a list of tokens."""
   words = []
-  for space_separated_fragment in sentence.strip().split():
+  for space_separated_fragment in sentence.split():
     words.extend(_WORD_SPLIT.split(space_separated_fragment))
   return [w for w in words if w]
 


### PR DESCRIPTION
split will move leading or trailing whitespace when sep is whitespace, so strip() is useless

If sep is not specified or is None, a different splitting algorithm is applied: runs of consecutive whitespace are regarded as a single separator, and the result will contain no empty strings at the start or end if the string has leading or trailing whitespace. Consequently, splitting an empty string or a string consisting of just whitespace with a None separator returns [].

see https://docs.python.org/3/library/stdtypes.html?highlight=split#str.split