### PR TITLE
Use correct variable scope for weights in rnn_cell._linear.

### DIFF
--- a/tensorflow/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/python/kernel_tests/rnn_cell_test.py
@@ -45,12 +45,21 @@ class RNNCellTest(tf.test.TestCase):
         with self.assertRaises(ValueError):
           l1 = linear([x], 2, False)
 
-        # But you can create a new one in a new scope and share the variables.
+        # But you can create a new one if you pass in a custom scope.
+        l2 = linear([x], 2, False, scope="l2")
+
+        # You can also create a new one in a new scope and share the variables.
         with tf.variable_scope("l1") as new_scope:
           l1 = linear([x], 2, False)
+          # If you pass in a custom scope, the parent scope is still used.
+          l2 = linear([x], 2, False, scope="l2")
+          # Sanity check that we can't accidentally create a shared function.
+          with self.assertRaises(ValueError):
+            linear([x], 2, False, scope="l2")
         with tf.variable_scope(new_scope, reuse=True):
           linear([l1], 2, False)
-        self.assertEqual(len(tf.trainable_variables()), 2)
+          linear([l2], 2, False, scope="l2")
+        self.assertEqual(len(tf.trainable_variables()), 4)
 
   def testBasicRNNCell(self):
     with self.test_session() as sess:

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -853,7 +853,7 @@ def _linear(args, output_size, bias, bias_start=0.0, scope=None):
   dtype = [a.dtype for a in args][0]
 
   # Now the computation.
-  scope = vs.get_variable_scope()
+  scope = scope or vs.get_variable_scope()
   with vs.variable_scope(scope) as outer_scope:
     weights = vs.get_variable(
         "weights", [total_arg_size, output_size], dtype=dtype)


### PR DESCRIPTION
If a scope is passed in it should be used for the variable scope
rather than always falling back to the default scope.

This change in behaviour was a consequence of recent cleanup in
92da8abf. The commit may alter the name of "weights" variable in saved
checkpoints but is necessary if two `rnn_cell._linear` layers exist in
the same parent variable scope.