### PR TITLE
Fix incorrect version string in gcs_test/Dockerfile

### DIFF
--- a/tensorflow/tools/ci_build/update_version.sh
+++ b/tensorflow/tools/ci_build/update_version.sh
@@ -142,14 +142,6 @@ check_existence file "${TEST_SERVER_DOCKER_FILE}"
 
 sed -i -r -e "s/(.*tensorflow-)([0-9]+\.[0-9]+\.[[:alnum:]]+)(-.*\.whl)/\1${MAJOR}.${MINOR}.${PATCH}\3/g" "${TEST_SERVER_DOCKER_FILE}"
 
-# Update tensorflow/tools/gcs_test/Dockerfile
-GCS_TEST_DOCKER_FILE="${TF_SRC_DIR}/tools/gcs_test/Dockerfile"
-
-check_existence file "${GCS_TEST_DOCKER_FILE}"
-
-sed -i -r -e "s/(.*tensorflow-)([0-9]+\.[0-9]+\.[[:alnum:]]+)(-.*\.whl)/\1${MAJOR}.${MINOR}.${PATCH}\3/g" "${GCS_TEST_DOCKER_FILE}"
-
-
 # Updates to be made if there are major / minor version changes
 MAJOR_MINOR_CHANGE=0
 if [[ ${OLD_MAJOR} != ${MAJOR} ]] || [[ ${OLD_MINOR} != ${MINOR} ]]; then

--- a/tensorflow/tools/gcs_test/Dockerfile
+++ b/tensorflow/tools/gcs_test/Dockerfile
@@ -15,9 +15,9 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_clou
 RUN chmod +x install_google_cloud_sdk.bash
 RUN ./install_google_cloud_sdk.bash --disable-prompts --install-dir=/var/gcloud
 
-# Install nightly TensorFlow pip
-RUN pip install \
-   https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-0.12.0-rc0-0rc-0rc-cp27-none-linux_x86_64.whl
+# Install TensorFlow pip from build context.
+COPY tensorflow-*.whl /
+RUN pip install /tensorflow-*.whl
 
 # Copy test files
 RUN mkdir -p /gcs-smoke/python

--- a/tensorflow/tools/gcs_test/gcs_smoke.sh
+++ b/tensorflow/tools/gcs_test/gcs_smoke.sh
@@ -17,9 +17,10 @@
 # Driver script for TensorFlow-GCS smoke test.
 #
 # Usage:
-#   gcs_smoke.sh <GCLOUD_JSON_KEY_PATH> <GCS_BUCKET_URL>
+#   gcs_smoke.sh <WHL_URL> <GCLOUD_JSON_KEY_PATH> <GCS_BUCKET_URL>
 #
 # Input arguments:
+#   WHL_URL: URL to the TensorFlow wheel file to use in this test.
 #   GCLOUD_KEY_JSON_PATH: Path to the Google Cloud JSON key file.
 #     See https://cloud.google.com/storage/docs/authentication for details.
 #
@@ -34,13 +35,13 @@ print_usage() {
   echo ""
 }
 
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../ci_build/builds/builds_common.sh"
 
 # Check input arguments
-GCLOUD_JSON_KEY_PATH=$1
-GCS_BUCKET_URL=$2
+WHL_URL=$1
+GCLOUD_JSON_KEY_PATH=$2
+GCS_BUCKET_URL=$3
 if [[ -z "${GCLOUD_JSON_KEY_PATH}" ]]; then
   print_usage
   die "ERROR: Command-line argument GCLOUD_JSON_KEY_PATH is not supplied"
@@ -55,15 +56,35 @@ if [[ ! -f "${GCLOUD_JSON_KEY_PATH}" ]]; then
 "${GCLOUD_JSON_KEY_PATH}\""
 fi
 
-DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
+# Create temporary directory for docker build
+BUILD_DIR=$(mktemp -d)
+echo ""
+echo "Using whl file URL: ${WHL_URL}"
+echo "Building in temporary directory: ${BUILD_DIR}"
+
+cp -r ${SCRIPT_DIR}/* "${BUILD_DIR}"/ || \
+    die "Failed to copy files to ${BUILD_DIR}"
+
+# Download whl file into the build context directory.
+wget -P "${BUILD_DIR}" ${WHL_URL} || \
+    die "Failed to download tensorflow whl file from URL: ${WHL_URL}"
+
+DOCKERFILE="${BUILD_DIR}/Dockerfile"
 if [[ ! -f "${DOCKERFILE}" ]]; then
   die "ERROR: Cannot find Dockerfile at expected path ${DOCKERFILE}"
 fi
 
+# Download whl file into the build context directory.
+wget -P "${BUILD_DIR}" ${WHL_URL} || \
+    die "Failed to download tensorflow whl file from URL: ${WHL_URL}"
+
 # Build the docker image for testing
 docker build --no-cache \
-    -f "${DOCKERFILE}" -t "${DOCKER_IMG}" "${SCRIPT_DIR}" || \
+    -f "${DOCKERFILE}" -t "${DOCKER_IMG}" "${BUILD_DIR}" || \
     die "FAIL: Failed to build docker image for testing"
+
+# Clean up docker build context directory.
+rm -rf "${BUILD_DIR}"
 
 # Run the docker image with the GCS key file mapped and the gcloud-required
 # environment variables set.


### PR DESCRIPTION
Also avoid hard-coding version string in the Dockerfile.
The pip wheel is now specified as an argument to gcs_smoke.sh.