### PR TITLE
[Windows/CMake] Add tensorflow.models.* to the PIP package.

### DIFF
--- a/tensorflow/contrib/cmake/tf_core_kernels.cmake
+++ b/tensorflow/contrib/cmake/tf_core_kernels.cmake
@@ -64,7 +64,8 @@ if(tensorflow_BUILD_CONTRIB_KERNELS)
       "${tensorflow_source_dir}/tensorflow/contrib/tensor_forest/hybrid/core/ops/stochastic_hard_routing_gradient_op.cc"
       "${tensorflow_source_dir}/tensorflow/contrib/tensor_forest/hybrid/core/ops/unpack_path_op.cc"
       "${tensorflow_source_dir}/tensorflow/contrib/tensor_forest/hybrid/core/ops/utils.cc"
-  )
+      "${tensorflow_source_dir}/tensorflow/models/embedding/word2vec_kernels.cc" 
+    )
   list(APPEND tf_core_kernels_srcs ${tf_contrib_kernels_srcs})
 endif(tensorflow_BUILD_CONTRIB_KERNELS)
 

--- a/tensorflow/contrib/cmake/tf_core_ops.cmake
+++ b/tensorflow/contrib/cmake/tf_core_ops.cmake
@@ -67,6 +67,7 @@ file(GLOB_RECURSE tf_core_ops_srcs
     "${tensorflow_source_dir}/tensorflow/core/ops/*.cc"
     "${tensorflow_source_dir}/tensorflow/core/user_ops/*.h"
     "${tensorflow_source_dir}/tensorflow/core/user_ops/*.cc"
+    "${tensorflow_source_dir}/tensorflow/models/embedding/word2vec_ops.cc"
 )
 
 file(GLOB_RECURSE tf_core_ops_exclude_srcs

--- a/tensorflow/contrib/cmake/tf_core_ops.cmake
+++ b/tensorflow/contrib/cmake/tf_core_ops.cmake
@@ -46,7 +46,7 @@ GENERATE_CONTRIB_OP_LIBRARY(cudnn_rnn "${tensorflow_source_dir}/tensorflow/contr
 GENERATE_CONTRIB_OP_LIBRARY(factorization_clustering "${tensorflow_source_dir}/tensorflow/contrib/factorization/ops/clustering_ops.cc")
 GENERATE_CONTRIB_OP_LIBRARY(factorization_factorization "${tensorflow_source_dir}/tensorflow/contrib/factorization/ops/factorization_ops.cc")
 GENERATE_CONTRIB_OP_LIBRARY(framework_variable "${tensorflow_source_dir}/tensorflow/contrib/framework/ops/variable_ops.cc")
-
+GENERATE_CONTRIB_OP_LIBRARY(word2vec "${tensorflow_source_dir}/tensorflow/models/embedding/word2vec_ops.cc")
 
 ########################################################
 # tf_user_ops library

--- a/tensorflow/contrib/cmake/tf_python.cmake
+++ b/tensorflow/contrib/cmake/tf_python.cmake
@@ -384,6 +384,17 @@ add_python_module("tensorflow/contrib/training")
 add_python_module("tensorflow/contrib/training/python")
 add_python_module("tensorflow/contrib/training/python/training")
 add_python_module("tensorflow/contrib/util")
+add_python_module("tensorflow/models")
+add_python_module("tensorflow/models/embedding")
+add_python_module("tensorflow/models/image")
+add_python_module("tensorflow/models/image/alexnet")
+add_python_module("tensorflow/models/image/cifar10")
+add_python_module("tensorflow/models/image/imagenet")
+add_python_module("tensorflow/models/image/mnist")
+add_python_module("tensorflow/models/rnn")
+add_python_module("tensorflow/models/rnn/ptb")
+add_python_module("tensorflow/models/rnn/translate")
+
 
 # Additional directories with no Python sources.
 add_custom_command(TARGET tf_python_touchup_modules PRE_BUILD
@@ -487,6 +498,8 @@ GENERATE_PYTHON_OP_LIB("contrib_factorization_factorization_ops"
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tf_python/tensorflow/contrib/factorization/python/ops/gen_factorization_ops.py)
 GENERATE_PYTHON_OP_LIB("contrib_framework_variable_ops"
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tf_python/tensorflow/contrib/framework/python/ops/gen_variable_ops.py)
+GENERATE_PYTHON_OP_LIB("contrib_word2vec_ops"
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tf_python/tensorflow/models/embedding/gen_word2vec.py)
 
 add_custom_target(tf_python_ops SOURCES ${tf_python_ops_generated_files} ${PYTHON_PROTO_GENFILES})
 add_dependencies(tf_python_ops tf_python_op_gen_main)

--- a/tensorflow/contrib/cmake/tf_python.cmake
+++ b/tensorflow/contrib/cmake/tf_python.cmake
@@ -427,6 +427,7 @@ set(tf_python_op_lib_names
 )
 
 function(GENERATE_PYTHON_OP_LIB tf_python_op_lib_name)
+    set(options SHAPE_FUNCTIONS_NOT_REQUIRED)
     set(oneValueArgs DESTINATION)
     set(multiValueArgs ADDITIONAL_LIBRARIES)
     cmake_parse_arguments(GENERATE_PYTHON_OP_LIB
@@ -436,7 +437,12 @@ function(GENERATE_PYTHON_OP_LIB tf_python_op_lib_name)
       set(GENERATE_PYTHON_OP_LIB_DESTINATION
           "${python_ops_target_dir}/gen_${tf_python_op_lib_name}.py")
     endif()
-
+    if(GENERATE_PYTHON_OP_LIB_SHAPE_FUNCTIONS_NOT_REQUIRED)
+      set(require_shape_fn 0)
+    else()
+      set(require_shape_fn 1)
+    endif()
+    
     # Create a C++ executable that links in the appropriate op
     # registrations and generates Python wrapper code based on the
     # registered ops.
@@ -457,7 +463,7 @@ function(GENERATE_PYTHON_OP_LIB tf_python_op_lib_name)
     # containing the wrappers.
     add_custom_command(
       OUTPUT ${GENERATE_PYTHON_OP_LIB_DESTINATION}
-      COMMAND ${tf_python_op_lib_name}_gen_python @${tensorflow_source_dir}/tensorflow/python/ops/hidden_ops.txt 1 > ${GENERATE_PYTHON_OP_LIB_DESTINATION}
+      COMMAND ${tf_python_op_lib_name}_gen_python @${tensorflow_source_dir}/tensorflow/python/ops/hidden_ops.txt ${require_shape_fn} > ${GENERATE_PYTHON_OP_LIB_DESTINATION}
       DEPENDS ${tf_python_op_lib_name}_gen_python
     )
 
@@ -499,7 +505,8 @@ GENERATE_PYTHON_OP_LIB("contrib_factorization_factorization_ops"
 GENERATE_PYTHON_OP_LIB("contrib_framework_variable_ops"
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tf_python/tensorflow/contrib/framework/python/ops/gen_variable_ops.py)
 GENERATE_PYTHON_OP_LIB("contrib_word2vec_ops"
-  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tf_python/tensorflow/models/embedding/gen_word2vec.py)
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tf_python/tensorflow/models/embedding/gen_word2vec.py
+  SHAPE_FUNCTIONS_NOT_REQUIRED)
 
 add_custom_target(tf_python_ops SOURCES ${tf_python_ops_generated_files} ${PYTHON_PROTO_GENFILES})
 add_dependencies(tf_python_ops tf_python_op_gen_main)

--- a/tensorflow/contrib/cmake/tf_tests.cmake
+++ b/tensorflow/contrib/cmake/tf_tests.cmake
@@ -118,6 +118,7 @@ if (tensorflow_BUILD_PYTHON_TESTS)
     "${tensorflow_source_dir}/tensorflow/python/kernel_tests/*.py"
     "${tensorflow_source_dir}/tensorflow/python/training/*_test.py"
     "${tensorflow_source_dir}/tensorflow/tensorboard/*_test.py"
+    "${tensorflow_source_dir}/tensorflow/models/*_test.py"
   )
 
   # exclude the onces we don't want


### PR DESCRIPTION
Also runs the few tests in there, and builds the word2vec kernels.

Fixes #6024. Fixes #5953.