### PR TITLE
Fix issue #6036

### DIFF
--- a/tensorflow/examples/udacity/6_lstm.ipynb
+++ b/tensorflow/examples/udacity/6_lstm.ipynb
@@ -167,10 +167,10 @@
       },
       "source": [
         "def read_data(filename):\n",
-        "  f = zipfile.ZipFile(filename)\n",
-        "  for name in f.namelist():\n",
-        "    return tf.compat.as_str(f.read(name))\n",
-        "  f.close()\n",
+        "  with zipfile.ZipFile(filename) as f:\n",
+        "    name = f.namelist()[0]\n",
+        "    data = tf.compat.as_str(f.read(name))\n",
+        "  return data\n",
         "  \n",
         "text = read_data(filename)\n",
         "print('Data size %d' % len(text))"


### PR DESCRIPTION
As per the issue raised [here](https://github.com/tensorflow/tensorflow/issues/6036), changed the following code to the  [**6_lstm.ipynb**](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/udacity/6_lstm.ipynb) file.

**FROM:**
```python
def read_data(filename):
  f = zipfile.ZipFile(filename)
  for name in f.namelist():
    return tf.compat.as_str(f.read(name))
  f.close()
```

**TO:**

```python
def read_data(filename):
  with zipfile.ZipFile(filename) as f:
    name = f.namelist()[0]
    data = tf.compat.as_str(f.read(name))
  return data
```
