### PR TITLE
avoid tf.int32-only call to gather in moments, thereby keeping kernel on GPU

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -469,9 +469,9 @@ def sufficient_statistics(x, axes, shift=None, keep_dims=False, name=None):
         counts *= x_shape[d].value
       counts = constant_op.constant(counts, dtype=x.dtype)
     else:  # shape needs to be inferred at runtime.
-      x_dims = array_ops.gather(array_ops.shape(x), axes)
-      counts = math_ops.cast(
-          math_ops.reduce_prod(x_dims), x.dtype, name="count")
+      # float32-cast circumvents (int32 --> CPU) issue
+      x_dims = array_ops.gather(math_ops.cast(array_ops.shape(x), dtypes.float32), axes)
+      counts = math_ops.cast(math_ops.reduce_prod(x_dims), x.dtype, name="count")
     if shift is not None:
       shift = ops.convert_to_tensor(shift, name="shift")
       m_ss = math_ops.sub(x, shift)


### PR DESCRIPTION
Fixes #6027 (tested locally)
@vincentvanhoucke 
Sorry for being late here. I think this might be a slightly better fix. I tested this locally, and it did resolve the cpu-gather behavior that I was seeing.
@poxvoculi 
I thought about it for a while, and I couldn't figure out how to avoid `tf.gather` completely in a reasonable manner. I hope that this patch is acceptable.