### PR TITLE
Fix bugs in configure and cuda_configure.bzl re. lib paths

### DIFF
--- a/configure
+++ b/configure
@@ -279,7 +279,7 @@ while true; do
       TF_CUDNN_VERSION=${BASH_REMATCH[1]}
       echo "libcudnn.so resolves to libcudnn${TF_CUDNN_EXT}"
     elif [[ "$REALVAL" =~ ([0-9]*).dylib ]]; then
-      TF_CUDNN_EXT="."${BASH_REMATCH[1]}".dylib"
+      TF_CUDNN_EXT=${BASH_REMATCH[1]}".dylib"
       TF_CUDNN_VERSION=${BASH_REMATCH[1]}
       echo "libcudnn.dylib resolves to libcudnn${TF_CUDNN_EXT}"
     fi

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -297,6 +297,11 @@ def _lib_name(lib, cpu_value, version="", static=False):
   elif cpu_value == "Windows":
     return "%s.lib" % lib
   elif cpu_value == "Darwin":
+    if static:
+      return "lib%s.a" % lib
+    else:
+      if version:
+        version = ".%s" % version
     return "lib%s%s.dylib" % (lib, version)
   else:
     auto_configure_fail("Invalid cpu_value: %s" % cpu_value)


### PR DESCRIPTION
See log of failed mac build from yesterday:
http://ci.tensorflow.org/view/Nightly/job/nightly-matrix-mac-gpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=gpu-mac/156/console

Caused by PRs:
https://github.com/tensorflow/tensorflow/commit/dfae1931365dae3354a8980829dfabcd59761232
https://github.com/tensorflow/tensorflow/pull/5944/files