### PR TITLE
fix the number on ImageNet classification validation error

### DIFF
--- a/tensorflow/g3doc/tutorials/image_recognition/index.md
+++ b/tensorflow/g3doc/tutorials/image_recognition/index.md
@@ -42,8 +42,8 @@ For example, here are the results from [AlexNet] classifying some images:
 To compare models, we examine how often the model fails to predict the
 correct answer as one of their top 5 guesses -- termed "top-5 error rate".
 [AlexNet] achieved by setting a top-5 error rate of 15.3% on the 2012
-validation data set; [BN-Inception-v2] achieved 6.66%;
-[Inception-v3] reaches 3.46%.
+validation data set; [Inception (GoogLeNet)] achieved 6.67%; 
+[BN-Inception-v2] achieved 4.9%; [Inception-v3] reaches 3.46%.
 
 > How well do humans do on ImageNet Challenge? There's a [blog post] by
 Andrej Karpathy who attempted to measure his own performance. He reached


### PR DESCRIPTION
According to the three paper, Inception(https://arxiv.org/pdf/1409.4842v1.pdf), Inception V2(https://arxiv.org/pdf/1502.03167v3.pdf), Inception V3(https://arxiv.org/pdf/1512.00567v3.pdf).
Their ImageNet Classification Validation Error should be 6.67%, 4.9%, 3.46%。