### PR TITLE
Fix rnn cell scope bug in _linear

### DIFF
--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -837,6 +837,8 @@ def _linear(args, output_size, bias, bias_start=0.0, scope=None):
     raise ValueError("`args` must be specified")
   if not nest.is_sequence(args):
     args = [args]
+  if scope is None:
+    scope = vs.get_variable_scope()
 
   # Calculate the total size of arguments on dimension 1.
   total_arg_size = 0
@@ -853,7 +855,6 @@ def _linear(args, output_size, bias, bias_start=0.0, scope=None):
   dtype = [a.dtype for a in args][0]
 
   # Now the computation.
-  scope = vs.get_variable_scope()
   with vs.variable_scope(scope) as outer_scope:
     weights = vs.get_variable(
         "weights", [total_arg_size, output_size], dtype=dtype)


### PR DESCRIPTION
The optional `scope` argument of `_linear` is currently ignored, as explained here: https://github.com/tensorflow/tensorflow/issues/6065

This pull request should fix that bug.