### PR TITLE
Replace 0.12.0 deprecated functions in python, contrib, and models directories

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -85,7 +85,7 @@
   removed.
 * `tf.all_variables`, `tf.VARIABLES` and `tf.initialize_all_variables` renamed
   to `tf.global_variables`, `tf.GLOBAL_VARIABLES` and
-  `tf.global_variables_initializers` respectively.
+  `tf.global_variables_initializer` respectively.
 
 ## Bug Fixes and Other Changes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -85,7 +85,7 @@
   removed.
 * `tf.all_variables`, `tf.VARIABLES` and `tf.initialize_all_variables` renamed
   to `tf.global_variables`, `tf.GLOBAL_VARIABLES` and
-  `tf.global_variable_initializers` respectively.
+  `tf.global_variables_initializers` respectively.
 
 ## Bug Fixes and Other Changes
 

--- a/tensorflow/contrib/bayesflow/python/kernel_tests/stochastic_variables_test.py
+++ b/tensorflow/contrib/bayesflow/python/kernel_tests/stochastic_variables_test.py
@@ -42,8 +42,8 @@ class StochasticVariablesTest(tf.test.TestCase):
 
     self.assertEqual(
         {"stochastic_variables/sv_mu", "stochastic_variables/sv_sigma"},
-        set([v.op.name for v in tf.all_variables()]))
-    self.assertEqual(set(tf.trainable_variables()), set(tf.all_variables()))
+        set([v.op.name for v in tf.global_variables()]))
+    self.assertEqual(set(tf.trainable_variables()), set(tf.global_variables()))
 
     v = tf.convert_to_tensor(v)
     self.assertEqual(list(shape), v.get_shape().as_list())
@@ -64,7 +64,7 @@ class StochasticVariablesTest(tf.test.TestCase):
             })):
       v = tf.get_variable("sv")
 
-    for var in tf.all_variables():
+    for var in tf.global_variables():
       if "mu" in var.name:
         mu_var = var
       if "sigma" in var.name:
@@ -96,7 +96,7 @@ class StochasticVariablesTest(tf.test.TestCase):
             })):
       v = tf.get_variable("sv", shape)
 
-    for var in tf.all_variables():
+    for var in tf.global_variables():
       if "mu" in var.name:
         mu_var = var
       if "sigma" in var.name:

--- a/tensorflow/contrib/framework/python/ops/prettyprint_ops_test.py
+++ b/tensorflow/contrib/framework/python/ops/prettyprint_ops_test.py
@@ -50,7 +50,7 @@ class PrettyPrintOpsTest(tf.test.TestCase):
     a = tf.Variable(1.0)
     a = tf.contrib.framework.print_op(a)
     with self.test_session():
-      tf.global_variable_initializer().run()
+      tf.global_variables_initializer().run()
       a.eval()
 
 if __name__ == "__main__":

--- a/tensorflow/contrib/framework/python/ops/prettyprint_ops_test.py
+++ b/tensorflow/contrib/framework/python/ops/prettyprint_ops_test.py
@@ -50,7 +50,7 @@ class PrettyPrintOpsTest(tf.test.TestCase):
     a = tf.Variable(1.0)
     a = tf.contrib.framework.print_op(a)
     with self.test_session():
-      tf.initialize_all_variables().run()
+      tf.global_variable_initializer().run()
       a.eval()
 
 if __name__ == "__main__":

--- a/tensorflow/contrib/layers/python/layers/feature_column_ops_test.py
+++ b/tensorflow/contrib/layers/python/layers/feature_column_ops_test.py
@@ -1207,7 +1207,7 @@ class WeightedSumTest(tf.test.TestCase):
     logits, _, _ = tf.contrib.layers.weighted_sum_from_feature_columns(
         features, [hashed_sparse], num_outputs=5)
     with self.test_session():
-      tf.initialize_all_variables().run()
+      tf.global_variable_initializer().run()
       self.assertAllEqual(logits.eval().shape, [2, 5])
 
   def testWeightedSparseColumn(self):
@@ -1242,7 +1242,7 @@ class WeightedSumTest(tf.test.TestCase):
         features, [weighted_ids], num_outputs=5)
 
     with self.test_session():
-      tf.initialize_all_variables().run()
+      tf.global_variable_initializer().run()
       tf.initialize_all_tables().run()
       self.assertAllEqual(logits.eval().shape, [2, 5])
 
@@ -1844,7 +1844,7 @@ class WeightedSumTest(tf.test.TestCase):
                                                               [product],
                                                               num_outputs=1))
       with self.test_session() as sess:
-        tf.initialize_all_variables().run()
+        tf.global_variable_initializer().run()
         tf.initialize_all_tables().run()
         product_weights = column_to_variable[product][0]
         sess.run(product_weights.assign([[0.1], [0.2], [0.3], [0.4], [0.5]]))
@@ -1860,7 +1860,7 @@ class WeightedSumTest(tf.test.TestCase):
                                                               [product],
                                                               num_outputs=1))
       with self.test_session() as sess:
-        tf.initialize_all_variables().run()
+        tf.global_variable_initializer().run()
         tf.initialize_all_tables().run()
         product_weights = column_to_variable[product][0]
         sess.run(product_weights.assign([[0.1], [0.2], [0.3], [0.4], [0.5]]))

--- a/tensorflow/contrib/layers/python/layers/feature_column_ops_test.py
+++ b/tensorflow/contrib/layers/python/layers/feature_column_ops_test.py
@@ -1207,7 +1207,7 @@ class WeightedSumTest(tf.test.TestCase):
     logits, _, _ = tf.contrib.layers.weighted_sum_from_feature_columns(
         features, [hashed_sparse], num_outputs=5)
     with self.test_session():
-      tf.global_variable_initializer().run()
+      tf.global_variables_initializer().run()
       self.assertAllEqual(logits.eval().shape, [2, 5])
 
   def testWeightedSparseColumn(self):
@@ -1242,7 +1242,7 @@ class WeightedSumTest(tf.test.TestCase):
         features, [weighted_ids], num_outputs=5)
 
     with self.test_session():
-      tf.global_variable_initializer().run()
+      tf.global_variables_initializer().run()
       tf.initialize_all_tables().run()
       self.assertAllEqual(logits.eval().shape, [2, 5])
 
@@ -1844,7 +1844,7 @@ class WeightedSumTest(tf.test.TestCase):
                                                               [product],
                                                               num_outputs=1))
       with self.test_session() as sess:
-        tf.global_variable_initializer().run()
+        tf.global_variables_initializer().run()
         tf.initialize_all_tables().run()
         product_weights = column_to_variable[product][0]
         sess.run(product_weights.assign([[0.1], [0.2], [0.3], [0.4], [0.5]]))
@@ -1860,7 +1860,7 @@ class WeightedSumTest(tf.test.TestCase):
                                                               [product],
                                                               num_outputs=1))
       with self.test_session() as sess:
-        tf.global_variable_initializer().run()
+        tf.global_variables_initializer().run()
         tf.initialize_all_tables().run()
         product_weights = column_to_variable[product][0]
         sess.run(product_weights.assign([[0.1], [0.2], [0.3], [0.4], [0.5]]))

--- a/tensorflow/contrib/layers/python/layers/optimizers_test.py
+++ b/tensorflow/contrib/layers/python/layers/optimizers_test.py
@@ -195,7 +195,7 @@ class OptimizersTest(tf.test.TestCase):
       self.assertAlmostEqual(var_value, 9.8916, 4)
       self.assertEqual(global_step_value, 1)
       var_count = 0
-      for var in tf.all_variables():
+      for var in tf.global_variables():
         if var.name.startswith("OptimizeLoss/AdaptiveMaxNorm"):
           var_count += 1
       self.assertEqual(2, var_count)
@@ -366,7 +366,7 @@ class AdaptiveClipping(tf.test.TestCase):
           decay=0.5)(grads_and_vars)
 
       var_dict = {}
-      for var in tf.all_variables():
+      for var in tf.global_variables():
         if var.name.startswith("AdaptiveMaxNorm"):
           var_dict[var.name.split(":")[0]] = var
       self.assertEqual(2, len(var_dict))

--- a/tensorflow/contrib/rnn/python/kernel_tests/gru_ops_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/gru_ops_test.py
@@ -158,7 +158,7 @@ class GRUBlockCellTest(tf.test.TestCase):
         output = gru_ops.GRUBlockCell(cell_size)(x, h)
         sess.run([tf.global_variables_initializer()])
 
-        all_variables = tf.all_variables()[0:4]
+        all_variables = tf.global_variables()[0:4]
         [w_ru, b_ru, w_c, b_c] = all_variables
 
         d_new_h_wrt_x = tf.gradients([output], x)
@@ -178,7 +178,7 @@ class GRUBlockCellTest(tf.test.TestCase):
         output = tf.nn.rnn_cell.GRUCell(cell_size)(x, h)
         sess.run([tf.global_variables_initializer()])
 
-        all_variables = tf.all_variables()[4:8]
+        all_variables = tf.global_variables()[4:8]
         [w_ru, b_ru, w_c, b_c] = all_variables
 
         d_new_h_wrt_x = tf.gradients([output], x)
@@ -281,7 +281,7 @@ class GRUBlockCellTest(tf.test.TestCase):
 
       sess.run([tf.global_variables_initializer()])
 
-      all_variables = tf.all_variables()
+      all_variables = tf.global_variables()
 
       [w_ru, b_ru, w_c, b_c] = all_variables[:4]
 

--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_test.py
@@ -382,7 +382,7 @@ class StackBidirectionalRNNTest(tf.test.TestCase):
 
       # check that all the variables names starts with the proper scope.
       tf.global_variables_initializer()
-      all_vars = tf.all_variables()
+      all_vars = tf.global_variables()
       prefix = prefix or "stack_bidirectional_rnn"
       scope_vars = [v for v in all_vars if v.name.startswith(prefix + "/")]
       tf.logging.info("StackRNN with scope: %s (%s)"

--- a/tensorflow/contrib/seq2seq/python/kernel_tests/seq2seq_test.py
+++ b/tensorflow/contrib/seq2seq/python/kernel_tests/seq2seq_test.py
@@ -103,7 +103,7 @@ class Seq2SeqTest(tf.test.TestCase):
                 scope=scope))
 
         # Run model
-        tf.initialize_all_variables().run()
+        tf.global_variable_initializer().run()
         decoder_outputs_train_res, decoder_state_train_res = sess.run(
             [decoder_outputs_train, decoder_state_train])
         decoder_outputs_inference_res, decoder_state_inference_res = sess.run(

--- a/tensorflow/contrib/seq2seq/python/kernel_tests/seq2seq_test.py
+++ b/tensorflow/contrib/seq2seq/python/kernel_tests/seq2seq_test.py
@@ -103,7 +103,7 @@ class Seq2SeqTest(tf.test.TestCase):
                 scope=scope))
 
         # Run model
-        tf.global_variable_initializer().run()
+        tf.global_variables_initializer().run()
         decoder_outputs_train_res, decoder_state_train_res = sess.run(
             [decoder_outputs_train, decoder_state_train])
         decoder_outputs_inference_res, decoder_state_inference_res = sess.run(

--- a/tensorflow/contrib/slim/README.md
+++ b/tensorflow/contrib/slim/README.md
@@ -901,7 +901,7 @@ slim.evaluation.evaluation_loop(
     log_dir,
     num_evals=num_batches,
     eval_op=names_to_updates.values(),
-    summary_op=tf.merge_summary(summary_ops),
+    summary_op=tf.summary.merge(summary_ops),
     eval_interval_secs=eval_interval_secs)
 ```
 

--- a/tensorflow/contrib/slim/python/slim/learning_test.py
+++ b/tensorflow/contrib/slim/python/slim/learning_test.py
@@ -625,7 +625,7 @@ class TrainTest(tf.test.TestCase):
       tf.set_random_seed(2)
       train_op = self.create_train_op()
 
-      model_variables = tf.all_variables()
+      model_variables = tf.global_variables()
       model_path = os.path.join(logdir1, 'model.ckpt-300')
 
       init_op = tf.global_variables_initializer()
@@ -674,7 +674,7 @@ class TrainTest(tf.test.TestCase):
       tf.set_random_seed(2)
       train_op = self.create_train_op()
 
-      model_variables = tf.all_variables()
+      model_variables = tf.global_variables()
       model_path = os.path.join(logdir1, 'model.ckpt-300')
       saver = tf.train.Saver(model_variables)
       def RestoreFn(sess):

--- a/tensorflow/contrib/slim/python/slim/model_analyzer.py
+++ b/tensorflow/contrib/slim/python/slim/model_analyzer.py
@@ -84,7 +84,7 @@ def analyze_vars(variables, print_info=False):
   """Prints the names and shapes of the variables.
 
   Args:
-    variables: list of variables, for example tf.all_variables().
+    variables: list of variables, for example tf.global_variables().
     print_info: Optional, if true print variables and their shape.
 
   Returns:

--- a/tensorflow/contrib/specs/python/specs_test.py
+++ b/tensorflow/contrib/specs/python/specs_test.py
@@ -197,7 +197,7 @@ class SpecsTest(tf.test.TestCase):
                 initializer=tf.constant_initializer(42.0))
       inputs = tf.constant(_rand(10, 100))
       outputs = v.funcall(inputs)
-      self.assertEqual(len(tf.all_variables()), 1)
+      self.assertEqual(len(tf.global_variables()), 1)
       sess.run([outputs.initializer])
       outputs_value = outputs.eval()
       self.assertEqual(outputs_value.shape, (2, 2))
@@ -211,7 +211,7 @@ class SpecsTest(tf.test.TestCase):
         g = f | f | f | f
       inputs = tf.constant(_rand(10, 100))
       _ = g.funcall(inputs)
-      self.assertEqual(len(tf.all_variables()), 2)
+      self.assertEqual(len(tf.global_variables()), 2)
 
   def testAutoFunction(self):
     with self.test_session():

--- a/tensorflow/contrib/stat_summarizer/python/stat_summarizer_test.py
+++ b/tensorflow/contrib/stat_summarizer/python/stat_summarizer_test.py
@@ -34,7 +34,7 @@ class StatSummarizerTest(tf.test.TestCase):
           graph_def.SerializeToString())
 
       with self.test_session() as sess:
-        sess.run(tf.initialize_all_variables())
+        sess.run(tf.global_variable_initializer())
 
         for _ in range(20):
           run_metadata = tf.RunMetadata()

--- a/tensorflow/contrib/stat_summarizer/python/stat_summarizer_test.py
+++ b/tensorflow/contrib/stat_summarizer/python/stat_summarizer_test.py
@@ -34,7 +34,7 @@ class StatSummarizerTest(tf.test.TestCase):
           graph_def.SerializeToString())
 
       with self.test_session() as sess:
-        sess.run(tf.global_variable_initializer())
+        sess.run(tf.global_variables_initializer())
 
         for _ in range(20):
           run_metadata = tf.RunMetadata()

--- a/tensorflow/contrib/training/python/training/evaluation_test.py
+++ b/tensorflow/contrib/training/python/training/evaluation_test.py
@@ -51,7 +51,7 @@ class CheckpointIteratorTest(tf.test.TestCase):
     saver = tf.train.Saver()  # Saves the global step.
 
     with self.test_session() as session:
-      session.run(tf.initialize_all_variables())
+      session.run(tf.global_variable_initializer())
       save_path = os.path.join(checkpoint_dir, 'model.ckpt')
       saver.save(session, save_path, global_step=global_step)
 
@@ -81,7 +81,7 @@ class CheckpointIteratorTest(tf.test.TestCase):
         target='',
         config=tf.ConfigProto(device_count={'CPU': 2})) as session:
 
-      session.run(tf.initialize_all_variables())
+      session.run(tf.global_variable_initializer())
       save_path = os.path.join(checkpoint_dir, 'model.ckpt')
       saver.save(session, save_path, global_step=global_step)
 

--- a/tensorflow/contrib/training/python/training/evaluation_test.py
+++ b/tensorflow/contrib/training/python/training/evaluation_test.py
@@ -51,7 +51,7 @@ class CheckpointIteratorTest(tf.test.TestCase):
     saver = tf.train.Saver()  # Saves the global step.
 
     with self.test_session() as session:
-      session.run(tf.global_variable_initializer())
+      session.run(tf.global_variables_initializer())
       save_path = os.path.join(checkpoint_dir, 'model.ckpt')
       saver.save(session, save_path, global_step=global_step)
 
@@ -81,7 +81,7 @@ class CheckpointIteratorTest(tf.test.TestCase):
         target='',
         config=tf.ConfigProto(device_count={'CPU': 2})) as session:
 
-      session.run(tf.global_variable_initializer())
+      session.run(tf.global_variables_initializer())
       save_path = os.path.join(checkpoint_dir, 'model.ckpt')
       saver.save(session, save_path, global_step=global_step)
 

--- a/tensorflow/contrib/training/python/training/training_test.py
+++ b/tensorflow/contrib/training/python/training/training_test.py
@@ -310,7 +310,7 @@ class TrainTest(tf.test.TestCase):
       tf.set_random_seed(2)
       train_op = self.create_train_op()
 
-      model_variables = tf.all_variables()
+      model_variables = tf.global_variables()
       model_path = os.path.join(logdir1, 'model.ckpt-300')
 
       assign_fn = tf.contrib.framework.assign_from_checkpoint_fn(

--- a/tensorflow/models/image/cifar10/cifar10_multi_gpu_train.py
+++ b/tensorflow/models/image/cifar10/cifar10_multi_gpu_train.py
@@ -213,7 +213,7 @@ def train():
     train_op = tf.group(apply_gradient_op, variables_averages_op)
 
     # Create a saver.
-    saver = tf.train.Saver(tf.all_variables())
+    saver = tf.train.Saver(tf.global_variables())
 
     # Build the summary operation from the last tower summaries.
     summary_op = tf.contrib.deprecated.merge_summary(summaries)

--- a/tensorflow/models/rnn/translate/seq2seq_model.py
+++ b/tensorflow/models/rnn/translate/seq2seq_model.py
@@ -185,7 +185,7 @@ class Seq2SeqModel(object):
         self.updates.append(opt.apply_gradients(
             zip(clipped_gradients, params), global_step=self.global_step))
 
-    self.saver = tf.train.Saver(tf.all_variables())
+    self.saver = tf.train.Saver(tf.global_variables())
 
   def step(self, session, encoder_inputs, decoder_inputs, target_weights,
            bucket_id, forward_only):

--- a/tensorflow/python/kernel_tests/scalar_strict_test.py
+++ b/tensorflow/python/kernel_tests/scalar_strict_test.py
@@ -118,14 +118,14 @@ class ScalarStrictTest(tf.test.TestCase):
 
   def testImageSummary(self):
     image = np.zeros((2, 2, 2, 3), dtype=np.uint8)
-    self.check(tf.image_summary, (['img'], image), 'Tags must be a scalar')
+    self.check(tf.summary.image, (['img'], image), 'Tags must be a scalar')
 
   def testScalarSummary(self):
-    self.check(tf.scalar_summary, (['a'], 7), 'not the same shape')
-    self.check(tf.scalar_summary, ('a', [7]), 'not the same shape')
+    self.check(tf.summary.scalar, (['a'], 7), 'not the same shape')
+    self.check(tf.summary.scalar, ('a', [7]), 'not the same shape')
 
   def testHistogramSummary(self):
-    self.check(tf.histogram_summary, (['a'], 7), 'tags must be scalar')
+    self.check(tf.summary.histogram, (['a'], 7), 'tags must be scalar')
 
   def testTile(self):
     self.check(tf.tile, ([7], 2), 'Expected multiples to be 1-D', [7, 7])

--- a/tensorflow/python/kernel_tests/scalar_strict_test.py
+++ b/tensorflow/python/kernel_tests/scalar_strict_test.py
@@ -118,14 +118,14 @@ class ScalarStrictTest(tf.test.TestCase):
 
   def testImageSummary(self):
     image = np.zeros((2, 2, 2, 3), dtype=np.uint8)
-    self.check(tf.summary.image, (['img'], image), 'Tags must be a scalar')
+    self.check(tf.image_summary, (['img'], image), 'Tags must be a scalar')
 
   def testScalarSummary(self):
-    self.check(tf.summary.scalar, (['a'], 7), 'not the same shape')
-    self.check(tf.summary.scalar, ('a', [7]), 'not the same shape')
+    self.check(tf.scalar_summary, (['a'], 7), 'not the same shape')
+    self.check(tf.scalar_summary, ('a', [7]), 'not the same shape')
 
   def testHistogramSummary(self):
-    self.check(tf.summary.histogram, (['a'], 7), 'tags must be scalar')
+    self.check(tf.histogram_summary, (['a'], 7), 'tags must be scalar')
 
   def testTile(self):
     self.check(tf.tile, ([7], 2), 'Expected multiples to be 1-D', [7, 7])

--- a/tensorflow/python/kernel_tests/seq2seq_test.py
+++ b/tensorflow/python/kernel_tests/seq2seq_test.py
@@ -616,7 +616,7 @@ class Seq2SeqTest(tf.test.TestCase):
       with tf.variable_scope("root"):
         _, losses = SampleGRUSeq2Seq(inp, out, weights)
         updates = []
-        params = tf.all_variables()
+        params = tf.global_variables()
         optimizer = tf.train.AdamOptimizer(0.03, epsilon=1e-5)
         for i in range(len(buckets)):
           full_grads = tf.gradients(losses[i], params)

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -371,7 +371,7 @@ class AdjustHueBenchmark(test.Benchmark):
         delta = tf.constant(0.1, dtype=tf.float32)
         outputs = image_ops.adjust_hue(inputs, delta)
         run_op = tf.group(outputs)
-        sess.run(tf.initialize_all_variables())
+        sess.run(tf.global_variable_initializer())
         for i in xrange(warmup_rounds + benchmark_rounds):
           if i == warmup_rounds:
             start = time.time()

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -371,7 +371,7 @@ class AdjustHueBenchmark(test.Benchmark):
         delta = tf.constant(0.1, dtype=tf.float32)
         outputs = image_ops.adjust_hue(inputs, delta)
         run_op = tf.group(outputs)
-        sess.run(tf.global_variable_initializer())
+        sess.run(tf.global_variables_initializer())
         for i in xrange(warmup_rounds + benchmark_rounds):
           if i == warmup_rounds:
             start = time.time()

--- a/tensorflow/python/ops/template.py
+++ b/tensorflow/python/ops/template.py
@@ -44,7 +44,7 @@ def make_template(name_, func_, create_scope_now_=False, unique_name_=None,
      that are intended to be locals can be created by specifying
      `tf.Variable(..., trainable=false)`.
   * The function may use variable scopes and other templates internally to
-      create and reuse variables, but it shouldn't use `tf.all_variables` to
+      create and reuse variables, but it shouldn't use `tf.global_variables` to
       capture variables that are defined outside of the scope of the function.
   * Internal scopes and variable names should not depend on any arguments that
       are not supplied to `make_template`. In general you will get a ValueError

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -82,7 +82,7 @@ class Variable(object):
   ```
 
   The most common initialization pattern is to use the convenience function
-  `global_variables_initializers()` to add an Op to the graph that initializes
+  `global_variables_initializer()` to add an Op to the graph that initializes
   all the variables. You then run that Op after launching the graph.
 
   ```python
@@ -492,7 +492,7 @@ class Variable(object):
 
     ```python
     v = tf.Variable([1, 2])
-    init = tf.global_variables_initializers()
+    init = tf.global_variables_initializer()
 
     with tf.Session() as sess:
         sess.run(init)

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -82,7 +82,7 @@ class Variable(object):
   ```
 
   The most common initialization pattern is to use the convenience function
-  `global_variable_initializers()` to add an Op to the graph that initializes
+  `global_variables_initializers()` to add an Op to the graph that initializes
   all the variables. You then run that Op after launching the graph.
 
   ```python
@@ -492,7 +492,7 @@ class Variable(object):
 
     ```python
     v = tf.Variable([1, 2])
-    init = tf.global_variable_initializers()
+    init = tf.global_variables_initializers()
 
     with tf.Session() as sess:
         sess.run(init)

--- a/tensorflow/python/training/moving_averages.py
+++ b/tensorflow/python/training/moving_averages.py
@@ -329,7 +329,7 @@ class ExponentialMovingAverage(object):
 
     shadow variables are created with `trainable=False` and added to the
     `GraphKeys.ALL_VARIABLES` collection.  They will be returned by calls to
-    `tf.all_variables()`.
+    `tf.global_variables()`.
 
     Returns an op that updates all shadow variables as described above.
 

--- a/tensorflow/python/training/saver_test.py
+++ b/tensorflow/python/training/saver_test.py
@@ -1872,7 +1872,7 @@ class ScopedGraphTest(tf.test.TestCase):
         tf.add_to_collection("logits", logits)
 
       # The rest of the variables.
-      rest_variables = list(set(tf.all_variables()) - set(var_list.keys()))
+      rest_variables = list(set(tf.global_variables()) - set(var_list.keys()))
       init_rest_op = tf.initialize_variables(rest_variables)
 
     with self.test_session(graph=graph) as sess:

--- a/tensorflow/python/training/session_manager_test.py
+++ b/tensorflow/python/training/session_manager_test.py
@@ -154,7 +154,7 @@ class SessionManagerTest(tf.test.TestCase):
                                  "you must also pass a local_init_op "):
       tf.train.SessionManager(
           ready_for_local_init_op=tf.report_uninitialized_variables(
-              tf.all_variables()),
+              tf.global_variables()),
           local_init_op=None)
 
   def testRecoverSessionWithReadyForLocalInitOp(self):
@@ -192,7 +192,7 @@ class SessionManagerTest(tf.test.TestCase):
       sm2 = tf.train.SessionManager(
           ready_op=tf.report_uninitialized_variables(),
           ready_for_local_init_op=tf.report_uninitialized_variables(
-              tf.all_variables()),
+              tf.global_variables()),
           local_init_op=w.initializer)
       saver = tf.train.Saver({"v": v})
       sess, initialized = sm2.recover_session(
@@ -348,7 +348,7 @@ class SessionManagerTest(tf.test.TestCase):
           graph=graph,
           ready_op=tf.report_uninitialized_variables(),
           ready_for_local_init_op=tf.report_uninitialized_variables(
-              tf.all_variables()),
+              tf.global_variables()),
           local_init_op=w.initializer)
 
       # Initialize v but not w
@@ -417,7 +417,7 @@ class SessionManagerTest(tf.test.TestCase):
       sm2 = tf.train.SessionManager(
           ready_op=tf.report_uninitialized_variables(),
           ready_for_local_init_op=tf.report_uninitialized_variables(
-              tf.all_variables()),
+              tf.global_variables()),
           local_init_op=w.initializer)
       sess = sm2.prepare_session("", init_op=v.initializer)
       self.assertEqual(
@@ -462,7 +462,7 @@ class SessionManagerTest(tf.test.TestCase):
       sm2 = tf.train.SessionManager(
           ready_op=tf.report_uninitialized_variables(),
           ready_for_local_init_op=tf.report_uninitialized_variables(
-              tf.all_variables()),
+              tf.global_variables()),
           local_init_op=w.initializer)
       with self.assertRaisesRegexp(
           RuntimeError,

--- a/tensorflow/python/training/supervisor.py
+++ b/tensorflow/python/training/supervisor.py
@@ -248,7 +248,7 @@ class Supervisor(object):
         ready to run the local_init_op.
         The model is considered ready if it returns an empty array.  Defaults to
         the tensor returned from
-        `tf.report_uninitialized_variables(tf.all_variables())`. If `None`, the
+        `tf.report_uninitialized_variables(tf.global_variables())`. If `None`, the
         model is not checked for readiness before running local_init_op.
       is_chief: If True, create a chief supervisor in charge of initializing
         and restoring the model.  If False, create a supervisor that relies

--- a/tensorflow/python/training/supervisor_test.py
+++ b/tensorflow/python/training/supervisor_test.py
@@ -531,7 +531,7 @@ class SupervisorTest(tf.test.TestCase):
               collections=[tf.GraphKeys.LOCAL_VARIABLES],
               name="default_ready_for_local_init_op_w_" + str(uid))
           ready_for_local_init_op = tf.report_uninitialized_variables(
-              tf.all_variables())
+              tf.global_variables())
       sv = tf.train.Supervisor(
           logdir=logdir,
           is_chief=is_chief,
@@ -588,7 +588,7 @@ class SupervisorTest(tf.test.TestCase):
               collections=[tf.GraphKeys.LOCAL_VARIABLES],
               name="ready_for_local_init_op_restore_w_" + str(uid))
           ready_for_local_init_op = tf.report_uninitialized_variables(
-              tf.all_variables())
+              tf.global_variables())
       sv = tf.train.Supervisor(
           logdir=logdir,
           is_chief=is_chief,
@@ -624,7 +624,7 @@ class SupervisorTest(tf.test.TestCase):
 
       # This shouldn't add a variable to the VARIABLES collection responsible
       # for variables that are saved/restored from checkpoints.
-      self.assertEquals(len(tf.all_variables()), 0)
+      self.assertEquals(len(tf.global_variables()), 0)
 
       # Suppress normal variable inits to make sure the local one is
       # initialized via local_init_op.
@@ -644,7 +644,7 @@ class SupervisorTest(tf.test.TestCase):
                         collections=[tf.GraphKeys.LOCAL_VARIABLES])
         # This shouldn't add a variable to the VARIABLES collection responsible
         # for variables that are saved/restored from checkpoints.
-        self.assertEquals(len(tf.all_variables()), 0)
+        self.assertEquals(len(tf.global_variables()), 0)
 
       # Suppress normal variable inits to make sure the local one is
       # initialized via local_init_op.


### PR DESCRIPTION
Used [this script](https://github.com/samjabrahams/tensorcrack/blob/master/scripts/migrate_0.12/migrate.sh) to get initial changes, and then cleaned up using the diff.