### PR TITLE
Disable contrib/integrate/python/ops/odes_test due to timeout

### DIFF
--- a/tensorflow/tools/ci_build/builds/test_installation.sh
+++ b/tensorflow/tools/ci_build/builds/test_installation.sh
@@ -108,6 +108,7 @@ PY_TEST_BLACKLIST="${PY_TEST_BLACKLIST}:"\
 PY_TEST_GPU_BLACKLIST="${PY_TEST_GPU_BLACKLIST}:"\
 "tensorflow/python/client/session_test.py:"\
 "tensorflow/python/framework/function_test.py:"\
+"tensorflow/contrib/integrate/python/ops/odes_test.py:"\
 "tensorflow/contrib/tensor_forest/python/kernel_tests/scatter_add_ndim_op_test.py"
 
 # Tests that should be run in the exclusive mode (i.e., not parallel with


### PR DESCRIPTION
The test hangs during PIP tests on GPU (but not CPU).