### PR TITLE
fix relaxed-constexpr warning

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -53,6 +53,7 @@ CURRENT_DIR = os.path.dirname(sys.argv[0])
 NVCC_PATH = CURRENT_DIR + '/../../../cuda/bin/nvcc'
 LLVM_HOST_COMPILER_PATH = ('/usr/bin/gcc')
 PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH)
+NVCC_VERSION = '%{cuda_version}'
 
 def Log(s):
   print('gpus/crosstool: {0}'.format(s))
@@ -114,6 +115,14 @@ def GetHostCompilerOptions(argv):
 
   return opts
 
+def _update_options(nvcc_options):
+  if NVCC_VERSION in ("7.0",):
+    return nvcc_options
+
+  update_options = { "relaxed-constexpr" : "expt-relaxed-constexpr" }
+  return [ update_options[opt] if opt in update_options else opt
+                    for opt in nvcc_options ]
+
 def GetNvccOptions(argv):
   """Collect the -nvcc_options values from argv.
 
@@ -130,7 +139,8 @@ def GetNvccOptions(argv):
   args, _ = parser.parse_known_args(argv)
 
   if args.nvcc_options:
-    return ' '.join(['--'+a for a in sum(args.nvcc_options, [])])
+    options = _update_options(sum(args.nvcc_options, []))
+    return ' '.join(['--'+a for a in options])
   return ''
 
 

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -695,6 +695,7 @@ def _create_cuda_repository(repository_ctx):
        "crosstool:clang/bin/crosstool_wrapper_driver_is_not_gcc",
        {
            "%{cpu_compiler}": str(cc),
+           "%{cuda_version}": cuda_config.cuda_version,
            "%{gcc_host_compiler_path}": str(cc),
            "%{cuda_compute_capabilities}": ", ".join(
                ["\"%s\"" % c for c in cuda_config.compute_capabilities]),


### PR DESCRIPTION
This patch should remove the warning for nvcc 7.5, 8.0 and still work on nvcc 7.0:
```
INFO: From Compiling *.cu.cc:
nvcc warning : option '--relaxed-constexpr' has been deprecated and replaced by option '--expt-relaxed-constexpr'.
nvcc warning : option '--relaxed-constexpr' has been deprecated and replaced by option '--expt-relaxed-constexpr'.
```

This warning has been out for a lot of time see:

#5799 
#5833 
#5256
#3980

