### PR TITLE
[Windows/CMake] Run ctest in parallel

### DIFF
--- a/tensorflow/tools/ci_build/windows/cpu/cmake/run_py.bat
+++ b/tensorflow/tools/ci_build/windows/cpu/cmake/run_py.bat
@@ -43,4 +43,4 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Run all python tests if the installation succeeded.
 echo Running tests...
-ctest -C Release --output-on-failure
+ctest -C Release --output-on-failure -j 32


### PR DESCRIPTION
Using 32 parallel jobs, as we're using that degree of parallelism for the build too.