### PR TITLE
Fix static initialization based registry patterns with shared libraries.

### DIFF
--- a/third_party/gpus/crosstool/BUILD.tpl
+++ b/third_party/gpus/crosstool/BUILD.tpl
@@ -21,7 +21,11 @@ cc_toolchain(
     objcopy_files = ":empty",
     static_runtime_libs = [":empty"],
     strip_files = ":empty",
-    supports_param_files = 0,
+    # To support linker flags that need to go to the start of command line
+    # we need the toolchain to support parameter files. Parameter files are
+    # last on the command line and contain all shared libraries to link, so all
+    # regular options will be left of them.
+    supports_param_files = 1,
 )
 
 cc_toolchain(

--- a/third_party/gpus/crosstool/CROSSTOOL.tpl
+++ b/third_party/gpus/crosstool/CROSSTOOL.tpl
@@ -54,6 +54,10 @@ toolchain {
   # Use "-std=c++11" for nvcc. For consistency, force both the host compiler
   # and the device compiler to use "-std=c++11".
   cxx_flag: "-std=c++11"
+  # Some distributions set -as-needed by default; to allow static initializer
+  # based registry patterns with shared object, ensure -no-as-needed is
+  # explicitly passed.
+  linker_flag: "-Wl,-no-as-needed"
   linker_flag: "-lstdc++"
   linker_flag: "-B/usr/bin/"
 


### PR DESCRIPTION
We rely on static initializers of shared libraries of which no other
code is used to be run; thus, the shared libraries need to be linked
into the final binary. Some distributions default to -as-needed for
linking shared libraries into binaries, which discards libraries that
are not actively referenced.