### PR TITLE
Disable all tests depending on *half_plus_two* genrules.

### DIFF
--- a/tensorflow/cc/saved_model/BUILD
+++ b/tensorflow/cc/saved_model/BUILD
@@ -48,6 +48,7 @@ tf_cc_test(
         "//tensorflow/python/saved_model/example:saved_model_half_plus_two_data",
     ],
     linkstatic = 1,
+    tags = ["manual"],
     deps = [
         ":constants",
         ":loader",

--- a/tensorflow/contrib/session_bundle/BUILD
+++ b/tensorflow/contrib/session_bundle/BUILD
@@ -145,6 +145,7 @@ cc_test(
     ],
     # Link in all registered kernels.
     linkstatic = 1,
+    tags = ["manual"],
     visibility = ["//visibility:private"],
     deps = [
         ":session_bundle",
@@ -182,6 +183,7 @@ py_test(
     ],
     main = "session_bundle_test.py",
     srcs_version = "PY2AND3",
+    tags = ["manual"],
     deps = [
         ":constants",
         ":manifest_proto_py",
@@ -285,6 +287,7 @@ cc_test(
     ],
     # Link in all registered kernels.
     linkstatic = 1,
+    tags = ["manual"],
     deps = [
         ":bundle_shim",
         ":test_util",


### PR DESCRIPTION
This is a measure to stabilize flaky GPU builds.

This is a fix for the CUDA out of memory error issues we have been seeing.