### PR TITLE
Run GPU tests on Windows with Bazel

### DIFF
--- a/tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh
+++ b/tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh
@@ -179,7 +179,7 @@ function run_configure_for_cpu_build {
 function run_configure_for_gpu_build {
   # Due to a bug in Bazel: https://github.com/bazelbuild/bazel/issues/2182
   # yes "" | ./configure doesn't work on Windows, so we set all the
-  # environment variables in advance to avoid interact with the script.    
+  # environment variables in advance to avoid interact with the script.
   export TF_NEED_CUDA=1
   export TF_CUDA_VERSION=8.0
   export CUDA_TOOLKIT_PATH="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0"
@@ -187,4 +187,15 @@ function run_configure_for_gpu_build {
   export CUDNN_INSTALL_PATH="C:/tools/cuda"
   export TF_CUDA_COMPUTE_CAPABILITIES="3.5,5.2"
   echo "" | ./configure
+}
+
+function create_python_test_dir() {
+  rm -rf "$1"
+  mkdir -p "$1"
+  cmd /c "mklink /J $1\\tensorflow .\\tensorflow"
+}
+
+function reinstall_tensorflow_pip() {
+  echo "y" | pip uninstall tensorflow -q || true
+  pip install ${1}
 }

--- a/tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh
+++ b/tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh
@@ -14,16 +14,10 @@
 # limitations under the License.
 # ==============================================================================
 #
-
-# All commands shall pass, and all should be visible.
-set -x
-set -e
-
 # C++ tests
 failing_cpu_cc_tests="\
+    //tensorflow/core/kernels:control_flow_ops_test + \
     //tensorflow/core:example_example_parser_configuration_test + \
-    //tensorflow/core/kernels:sparse_dense_binary_op_shared_test + \
-    //tensorflow/core/kernels:sparse_reduce_sum_op_test + \
     //tensorflow/core:lib_core_status_test + \
     //tensorflow/core:lib_monitoring_collection_registry_test + \
     //tensorflow/core:lib_strings_numbers_test + \
@@ -50,9 +44,6 @@ broken_cpu_cc_tests="\
     //tensorflow/core/platform/cloud:gcs_file_system_test + \
     //tensorflow/core/kernels/cloud:bigquery_table_accessor_test + \
     //tensorflow/core/kernels/hexagon:quantized_matmul_op_for_hexagon_test + \
-    //tensorflow/core/kernels:sparse_add_op_test + \
-    //tensorflow/core/kernels:spacetobatch_benchmark_test_gpu + \
-    //tensorflow/core/kernels:spacetobatch_benchmark_test + \
     //tensorflow/core/kernels:requantize_op_test + \
     //tensorflow/core/kernels:requantization_range_op_test + \
     //tensorflow/core/kernels:quantized_reshape_op_test + \
@@ -69,9 +60,6 @@ broken_cpu_cc_tests="\
     //tensorflow/core/kernels:quantize_and_dequantize_op_test + \
     //tensorflow/core/kernels:quantization_utils_test + \
     //tensorflow/core/kernels:debug_ops_test + \
-    //tensorflow/core/kernels:control_flow_ops_test + \
-    //tensorflow/core/kernels:cast_op_test_gpu + \
-    //tensorflow/core/kernels:cast_op_test + \
     //tensorflow/core/distributed_runtime/rpc:rpc_rendezvous_mgr_test_gpu + \
     //tensorflow/core/distributed_runtime/rpc:rpc_rendezvous_mgr_test + \
     //tensorflow/core/distributed_runtime/rpc:grpc_tensor_coding_test + \
@@ -89,15 +77,14 @@ broken_cpu_cc_tests="\
     //tensorflow/core:util_memmapped_file_system_test + \
     //tensorflow/core:platform_subprocess_test + \
     //tensorflow/core:platform_profile_utils_cpu_utils_test + \
-    //tensorflow/core:platform_port_test + \
-    //tensorflow/core:lib_strings_strcat_test + \
     //tensorflow/core:lib_jpeg_jpeg_mem_unittest + \
-    //tensorflow/core:lib_core_notification_test + \
-    //tensorflow/core:framework_partial_tensor_shape_test + \
     //tensorflow/core/debug:debug_io_utils_test \
 "
 
+# lib_core_threadpool_test is timeout, but it passes when running alone
 extra_failing_gpu_cc_tests="\
+    //tensorflow/core:lib_core_threadpool_test + \
+    //tensorflow/core:cuda_libdevice_path_test + \
     //tensorflow/core:common_runtime_direct_session_test + \
     //tensorflow/core:common_runtime_direct_session_with_tracking_alloc_test + \
     //tensorflow/core:gpu_tracer_test + \
@@ -112,6 +99,8 @@ exclude_gpu_cc_tests="${extra_failing_gpu_cc_tests} + ${exclude_cpu_cc_tests}"
 # The first argument is the name of the python test direcotry
 function get_failing_cpu_py_tests() {
     echo "
+    //$1/tensorflow/python/kernel_tests:rnn_test + \
+    //$1/tensorflow/python/kernel_tests:sets_test + \
     //$1/tensorflow/python/debug:cli_shared_test + \
     //$1/tensorflow/python/debug:command_parser_test + \
     //$1/tensorflow/python/debug:debug_data_test + \
@@ -130,7 +119,6 @@ function get_failing_cpu_py_tests() {
     //$1/tensorflow/python/debug:stepper_test + \
     //$1/tensorflow/python:dequantize_op_test + \
     //$1/tensorflow/python:directory_watcher_test + \
-    //$1/tensorflow/python:event_accumulator_test + \
     //$1/tensorflow/python:event_multiplexer_test + \
     //$1/tensorflow/python:file_io_test + \
     //$1/tensorflow/python:framework_meta_graph_test + \
@@ -156,8 +144,18 @@ function get_failing_cpu_py_tests() {
     //$1/tensorflow/python:protobuf_compare_test + \
     //$1/tensorflow/python:quantized_conv_ops_test + \
     //$1/tensorflow/python:saver_test + \
-    //$1/tensorflow/python:file_system_test + \
-    //$1/tensorflow/python:supervisor_test \
+    //$1/tensorflow/python:file_system_test \
+    "
+}
+
+function get_failing_gpu_py_tests() {
+    echo "
+    //$1/tensorflow/python/kernel_tests:rnn_test + \
+    //$1/tensorflow/python/kernel_tests:sets_test + \
+    //$1/tensorflow/python/kernel_tests:diag_op_test + \
+    //$1/tensorflow/python/kernel_tests:one_hot_op_test + \
+    //$1/tensorflow/python/kernel_tests:trace_op_test + \
+    $(get_failing_cpu_py_tests $1)
     "
 }
 
@@ -178,3 +176,15 @@ function run_configure_for_cpu_build {
   echo "" | ./configure
 }
 
+function run_configure_for_gpu_build {
+  # Due to a bug in Bazel: https://github.com/bazelbuild/bazel/issues/2182
+  # yes "" | ./configure doesn't work on Windows, so we set all the
+  # environment variables in advance to avoid interact with the script.    
+  export TF_NEED_CUDA=1
+  export TF_CUDA_VERSION=8.0
+  export CUDA_TOOLKIT_PATH="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0"
+  export TF_CUDNN_VERSION=5
+  export CUDNN_INSTALL_PATH="C:/tools/cuda"
+  export TF_CUDA_COMPUTE_CAPABILITIES="3.5,5.2"
+  echo "" | ./configure
+}

--- a/tensorflow/tools/ci_build/windows/bazel/common_env.sh
+++ b/tensorflow/tools/ci_build/windows/bazel/common_env.sh
@@ -47,3 +47,11 @@ export PATH="/c/Program Files/Anaconda3:$PATH"
 
 # Make sure we have pip in PATH
 export PATH="/c/Program Files/Anaconda3/Scripts:$PATH"
+
+# Add Cuda and Cudnn dll directories into PATH
+export PATH="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0/bin:$PATH"
+export PATH="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0/extras/CUPTI/libx64:$PATH"
+export PATH="/c/tools/cuda/bin:$PATH"
+
+# Set the common build options on Windows
+export BUILD_OPTS='--cpu=x64_windows_msvc --host_cpu=x64_windows_msvc --copt=/w --verbose_failures --experimental_ui'

--- a/tensorflow/tools/ci_build/windows/bazel/common_env.sh
+++ b/tensorflow/tools/ci_build/windows/bazel/common_env.sh
@@ -25,10 +25,6 @@
 #   - Anaconda3
 # * Bazel windows executable copied as "bazel.exe" and included in PATH.
 
-# All commands shall pass, and all should be visible.
-set -x
-set -e
-
 # Use a temporary directory with a short name.
 export TMPDIR="C:/tmp"
 mkdir -p "$TMPDIR"

--- a/tensorflow/tools/ci_build/windows/cpu/bazel/run_cc_test_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/bazel/run_cc_test_windows.sh
@@ -54,6 +54,5 @@ passing_tests=$(bazel query "kind(cc_test, //tensorflow/cc/... + //tensorflow/co
   # We need to strip \r so that the result could be store into a variable under MSYS
   tr '\r' ' ')
 
-BUILD_OPTS='--cpu=x64_windows_msvc --host_cpu=x64_windows_msvc --copt=/w --verbose_failures --experimental_ui'
 bazel test $BUILD_OPTS -k $slow_compiling_test --test_output=errors
 bazel test -c opt $BUILD_OPTS -k $passing_tests --test_output=errors

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -46,21 +46,17 @@ clean_output_base
 
 run_configure_for_cpu_build
 
-bazel build $BUILD_OPTS tensorflow/tools/pip_package:build_pip_package || exit $?
-
-rm -f ./tensorflow-*.whl
-./bazel-bin/tensorflow/tools/pip_package/build_pip_package $PWD
-
-# Running python tests on Windows needs pip package installed
-echo "y" | pip uninstall tensorflow -q || true
-PIP_NAME=$(ls tensorflow-*.whl)
-pip install ${PIP_NAME}
+bazel build -c opt $BUILD_OPTS tensorflow/tools/pip_package:build_pip_package || exit $?
 
 # Create a python test directory to avoid package name conflict
 PY_TEST_DIR="py_test_dir"
-rm -rf "${PY_TEST_DIR}"
-mkdir -p "${PY_TEST_DIR}"
-cmd /c "mklink /J ${PY_TEST_DIR}\\tensorflow .\\tensorflow"
+create_python_test_dir "${PY_TEST_DIR}"
+
+./bazel-bin/tensorflow/tools/pip_package/build_pip_package "$PWD/${PY_TEST_DIR}"
+
+# Running python tests on Windows needs pip package installed
+PIP_NAME=$(ls ${PY_TEST_DIR}/tensorflow-*.whl)
+reinstall_tensorflow_pip ${PIP_NAME}
 
 failing_cpu_py_tests=$(get_failing_cpu_py_tests ${PY_TEST_DIR})
 
@@ -68,9 +64,6 @@ passing_tests=$(bazel query "kind(py_test,  //${PY_TEST_DIR}/tensorflow/python/.
   # We need to strip \r so that the result could be store into a variable under MSYS
   tr '\r' ' ')
 
-BUILD_OPTS='-c opt --cpu=x64_windows_msvc --host_cpu=x64_windows_msvc --copt=/w --verbose_failures --experimental_ui'
 # Define no_tensorflow_py_deps=true so that every py_test has no deps anymore,
 # which will result testing system installed tensorflow
-bazel test $BUILD_OPTS -k $passing_tests --define=no_tensorflow_py_deps=true --test_output=errors
-
-
+bazel test -c opt $BUILD_OPTS -k $passing_tests --define=no_tensorflow_py_deps=true --test_output=errors

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -46,10 +46,9 @@ clean_output_base
 
 run_configure_for_cpu_build
 
-BUILD_OPTS='-c opt --cpu=x64_windows_msvc --host_cpu=x64_windows_msvc --copt=/w --verbose_failures --experimental_ui'
-
 bazel build $BUILD_OPTS tensorflow/tools/pip_package:build_pip_package || exit $?
 
+rm -f ./tensorflow-*.whl
 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package $PWD
 
 # Running python tests on Windows needs pip package installed
@@ -69,6 +68,7 @@ passing_tests=$(bazel query "kind(py_test,  //${PY_TEST_DIR}/tensorflow/python/.
   # We need to strip \r so that the result could be store into a variable under MSYS
   tr '\r' ' ')
 
+BUILD_OPTS='-c opt --cpu=x64_windows_msvc --host_cpu=x64_windows_msvc --copt=/w --verbose_failures --experimental_ui'
 # Define no_tensorflow_py_deps=true so that every py_test has no deps anymore,
 # which will result testing system installed tensorflow
 bazel test $BUILD_OPTS -k $passing_tests --define=no_tensorflow_py_deps=true --test_output=errors

--- a/tensorflow/tools/ci_build/windows/gpu/bazel/run_cc_test_windows.bat
+++ b/tensorflow/tools/ci_build/windows/gpu/bazel/run_cc_test_windows.bat
@@ -1,0 +1,1 @@
+c:\tools\msys64\usr\bin\bash -l %cd%/tensorflow/tools/ci_build/windows/gpu/bazel/run_cc_test_windows.sh %*

--- a/tensorflow/tools/ci_build/windows/gpu/bazel/run_cc_test_windows.sh
+++ b/tensorflow/tools/ci_build/windows/gpu/bazel/run_cc_test_windows.sh
@@ -46,7 +46,6 @@ clean_output_base
 
 run_configure_for_gpu_build
 
-
 # Compliling the following test is extremely slow with -c opt
 slow_compiling_test="//tensorflow/core/kernels:eigen_backward_spatial_convolutions_test"
 
@@ -55,8 +54,7 @@ passing_tests=$(bazel query "kind(cc_test, //tensorflow/cc/... + //tensorflow/co
   # We need to strip \r so that the result could be store into a variable under MSYS
   tr '\r' ' ')
 
-BUILD_OPTS='--config=win-cuda --cpu=x64_windows_msvc --host_cpu=x64_windows_msvc --copt=/w --verbose_failures --experimental_ui'
 # TODO(pcloudy): There is a bug in Bazel preventing build with GPU support without -c opt
 # Re-enable this test after it is fixed.
-# bazel test $BUILD_OPTS -k $slow_compiling_test --test_output=errors
-bazel test -c opt $BUILD_OPTS -k $passing_tests --test_output=errors
+# bazel test --config=win-cuda $BUILD_OPTS -k $slow_compiling_test --test_output=errors
+bazel test -c opt --config=win-cuda $BUILD_OPTS -k $passing_tests --test_output=errors

--- a/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
@@ -29,10 +29,10 @@
 set -x
 set -e
 
-# This script is under <repo_root>/tensorflow/tools/ci_build/windows/cpu/bazel
+# This script is under <repo_root>/tensorflow/tools/ci_build/windows/gpu/pip/
 # Change into repository root.
 script_dir=$(dirname $0)
-cd ${script_dir%%tensorflow/tools/ci_build/windows/cpu/bazel}.
+cd ${script_dir%%tensorflow/tools/ci_build/windows/gpu/pip}.
 
 # Setting up the environment variables Bazel and ./configure needs
 source "tensorflow/tools/ci_build/windows/bazel/common_env.sh" \
@@ -44,16 +44,34 @@ source "tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh" \
 
 clean_output_base
 
-run_configure_for_cpu_build
+run_configure_for_gpu_build
 
-# Compliling the following test is extremely slow with -c opt
-slow_compiling_test="//tensorflow/core/kernels:eigen_backward_spatial_convolutions_test"
+bazel build $BUILD_OPTS tensorflow/tools/pip_package:build_pip_package || exit $?
 
-# Find all the passing cc_tests on Windows and store them in a variable
-passing_tests=$(bazel query "kind(cc_test, //tensorflow/cc/... + //tensorflow/core/...) - (${exclude_cpu_cc_tests}) - ($slow_compiling_test)" |
+rm -f ./tensorflow-*.whl
+./bazel-bin/tensorflow/tools/pip_package/build_pip_package $PWD
+
+# Running python tests on Windows needs pip package installed
+echo "y" | pip uninstall tensorflow -q || true
+PIP_NAME=$(ls tensorflow-*.whl)
+pip install ${PIP_NAME}
+
+# Create a python test directory to avoid package name conflict
+PY_TEST_DIR="py_test_dir"
+rm -rf "${PY_TEST_DIR}"
+mkdir -p "${PY_TEST_DIR}"
+cmd /c "mklink /J ${PY_TEST_DIR}\\tensorflow .\\tensorflow"
+
+failing_gpu_py_tests=$(get_failing_gpu_py_tests ${PY_TEST_DIR})
+
+passing_tests=$(bazel query "kind(py_test,  //${PY_TEST_DIR}/tensorflow/python/...) - (${failing_gpu_py_tests})" |
   # We need to strip \r so that the result could be store into a variable under MSYS
   tr '\r' ' ')
 
-BUILD_OPTS='--cpu=x64_windows_msvc --host_cpu=x64_windows_msvc --copt=/w --verbose_failures --experimental_ui'
-bazel test $BUILD_OPTS -k $slow_compiling_test --test_output=errors
-bazel test -c opt $BUILD_OPTS -k $passing_tests --test_output=errors
+BUILD_OPTS='--config=win-cuda -c opt --cpu=x64_windows_msvc --host_cpu=x64_windows_msvc --copt=/w --verbose_failures --experimental_ui'
+# Define no_tensorflow_py_deps=true so that every py_test has no deps anymore,
+# which will result testing system installed tensorflow
+# GPU tests are very flaky when running concurently, so set local_test_jobs=5
+bazel test $BUILD_OPTS -k $passing_tests --define=no_tensorflow_py_deps=true --test_output=errors --local_test_jobs=5
+
+

--- a/tensorflow/tools/ci_build/windows/gpu/pip/run.bat
+++ b/tensorflow/tools/ci_build/windows/gpu/pip/run.bat
@@ -1,0 +1,1 @@
+c:\tools\msys64\usr\bin\bash -l %cd%/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh %*


### PR DESCRIPTION
After this change, we can run:

CPU build + python tests: `tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh`
CPU C++ tests: `tensorflow/tools/ci_build/windows/cpu/bazel/run_cc_test_windows.sh`
GPU build + python tests: `tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh`
GPU C++ tests: `tensorflow/tools/ci_build/windows/gpu/bazel/run_cc_test_windows.sh`