### PR TITLE
Improve  documentation for tf.split_v

### DIFF
--- a/tensorflow/g3doc/api_docs/python/array_ops.md
+++ b/tensorflow/g3doc/api_docs/python/array_ops.md
@@ -791,7 +791,7 @@ For example:
 ```python
 # 'value' is a tensor with shape [5, 30]
 # Split 'value' into 3 tensors with sizes [4, 15, 11] along dimension 1
-split0, split1, split2 = tf.split_v(1, [4, 15, 11], value)
+split0, split1, split2 = tf.split_v(value, [4, 15, 11], 1)
 tf.shape(split0) ==> [5, 4]
 tf.shape(split1) ==> [5, 15]
 tf.shape(split2) ==> [5, 11]


### PR DESCRIPTION
Hi,

I was reading through [`tf.split_v`](https://www.tensorflow.org/versions/r0.12/api_docs/python/array_ops.html#split_v) documentation. I got confused because `num_split` is not there in the function arguments. To understand better, I read the examples and found that the argument order is not correct. 

So, this pull request currently fixes the example of `tf.split_v`. If you agree that the documentation is not proper, then I can fix that too. Thanks!