### PR TITLE
Determine output shape for SplitV Op

### DIFF
--- a/tensorflow/python/kernel_tests/split_op_test.py
+++ b/tensorflow/python/kernel_tests/split_op_test.py
@@ -121,6 +121,14 @@ class SplitOpTest(tf.test.TestCase):
     self.assertAllEqual(result[:, 0:1], inp_grads[0])
     self.assertAllEqual(result[:, 1:4], inp_grads[1])
 
+  def testOutputShape(self):
+    with self.test_session(use_gpu=False):
+      tensor = tf.placeholder(tf.float32, shape=[None, 12])
+      size_splits = [3, 7, 2]
+      outputs = tf.split(tensor, size_splits, 1)
+      for i, output in enumerate(outputs):
+        self.assertEqual(output.get_shape().as_list(), [None, size_splits[i]])
+
   def _compare(self, x, dim, num, use_gpu):
     np_ans = np.split(x, num, dim)
     with self.test_session(use_gpu=use_gpu) as sess:


### PR DESCRIPTION
Fixes #6186 
Fixes #5977 

I couldn't find any tests for SplitV in `array_ops_test.cc`. Is there any other file for SplitV test?