### PR TITLE
Don't fetch sample Android app deps in configure.

### DIFF
--- a/configure
+++ b/configure
@@ -24,7 +24,8 @@ function bazel_clean_and_fetch() {
   if ! is_windows; then
     bazel clean --expunge
   fi
-  bazel fetch //tensorflow/...
+  # TODO(https://github.com/bazelbuild/bazel/issues/2220) Remove the nested `bazel query`.
+  bazel fetch $(bazel query "//tensorflow/... -//tensorflow/examples/android/...")
 }
 
 ## Set up python-related environment settings


### PR DESCRIPTION
`bazel fetch` runs the Bazel loading phase on the given targets. At the
moment, the loading phase of an android_binary succeeds even if an
android_sdk_repository is not set up in the WORKSPACE. However, this is
deceptive as the purpose of the loading phase is to ensure that all
files needed for the build are present. Without an android_sdk_repository
set up, this is not the case. In the future, Bazel will likely not allow
the loading phase to succeed for android_binary without an
android_sdk_repository.

Unfortunately, `bazel fetch` does net support the target substitution
syntax (see https://github.com/bazelbuild/bazel/issues/2220) so I've
added a TODO to remove the necessary nested `bazel query` once that
issue is resolved.