### PR TITLE
Fix 'partition_info' crash

### DIFF
--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -665,7 +665,8 @@ class _VariableStore(object):
         if partition_info is not None:
           init_val = lambda: initializer(
               shape.as_list(), dtype=dtype, partition_info=partition_info)
-        else:
+        else: 
+          # Backward compatible custom initializer.
           init_val = lambda: initializer(
               shape.as_list(), dtype=dtype)
         variable_dtype = dtype.base_dtype

--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -662,8 +662,12 @@ class _VariableStore(object):
         init_val = initializer
         variable_dtype = None
       else:
-        init_val = lambda: initializer(
-            shape.as_list(), dtype=dtype, partition_info=partition_info)
+        if partition_info is not None:
+          init_val = lambda: initializer(
+              shape.as_list(), dtype=dtype, partition_info=partition_info)
+        else:
+          init_val = lambda: initializer(
+              shape.as_list(), dtype=dtype)
         variable_dtype = dtype.base_dtype
 
     # Create the variable.


### PR DESCRIPTION
Fixes this crash by not forcing partition_info if it is None:
Traceback (most recent call last):
File "main.py", line 33, in 
global_network = UnrealModel(action_size, -1, device)
File "/Users/babaktr/Desktop/unreal/model.py", line 35, in init
self._create_network(for_display)
File "/Users/babaktr/Desktop/unreal/model.py", line 45, in _create_network
self._create_base_network()
File "/Users/babaktr/Desktop/unreal/model.py", line 71, in _create_base_network
base_conv_output = self._base_conv_layers(self.base_input)
File "/Users/babaktr/Desktop/unreal/model.py", line 90, in _base_conv_layers
W_conv1, b_conv1 = self._conv_variable([8, 8, 3, 16], "base_conv1")
File "/Users/babaktr/Desktop/unreal/model.py", line 423, in _conv_variable
initializer=conv_initializer(w, h, input_channels))
File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 1024, in get_variable
custom_getter=custom_getter)
File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 850, in get_variable
custom_getter=custom_getter)
File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 346, in get_variable
validate_shape=validate_shape)
File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 331, in _true_getter
caching_device=caching_device, validate_shape=validate_shape)
File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 677, in _get_single_variable
expected_shape=shape)
File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/variables.py", line 224, in init
expected_shape=expected_shape)
File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/variables.py", line 327, in _init_from_args
initial_value(), name="initial_value", dtype=dtype)
File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/variable_scope.py", line 665, in 
shape.as_list(), dtype=dtype, partition_info=partition_info)
TypeError: _initializer() got an unexpected keyword argument 'partition_info'