### PR TITLE
replace AsProtoField with AsProtoTensorContent for efficiency

### DIFF
--- a/tensorflow/core/distributed_runtime/master_session.cc
+++ b/tensorflow/core/distributed_runtime/master_session.cc
@@ -438,7 +438,7 @@ static bool CopyIfNeeded(TensorProto* in, TensorProto* out) {
   } else {
     Tensor t(in->dtype());
     if (!t.FromProto(cpu_allocator(), *in)) return false;
-    t.AsProtoField(out);
+    t.AsProtoTensorContent(out);
   }
   return true;
 }

--- a/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc
@@ -369,7 +369,7 @@ class GrpcWorkerService : public AsyncServiceInterface {
               recv->set_key(key);
               // TODO(zhifengc): Deal with gpu -> cpu copy.
               TensorProto* proto = recv->mutable_val();
-              val.AsProtoField(proto);
+              val.AsProtoTensorContent(proto);
             }
           }
           delete collector;


### PR DESCRIPTION
This improves throughput of gRPC worker->client fetch about 25% (116 MB/s -> 151 MB/s) as measured by benchmark in https://github.com/tensorflow/tensorflow/issues/6256