### PR TITLE
Second order derivaties for Pooling operations

### DIFF
--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -395,6 +395,13 @@ def _AvgPoolGrad(op, grad):
       data_format=op.get_attr("data_format"))
 
 
+@ops.RegisterGradient("AvgPoolGrad")
+def _AvgPoolGradGrad(op, grad):
+  print(op)
+  return (array_ops.zeros(shape = array_ops.shape(op.inputs[0]), dtype = op.inputs[0].dtype),
+          array_ops.ones(shape = array_ops.shape(op.inputs[1]), dtype = op.inputs[1].dtype))
+
+
 @ops.RegisterGradient("MaxPool")
 def _MaxPoolGrad(op, grad):
   return gen_nn_ops._max_pool_grad(op.inputs[0],
@@ -408,9 +415,9 @@ def _MaxPoolGrad(op, grad):
 
 @ops.RegisterGradient("MaxPoolGrad")
 def _MaxPoolGradGrad(op, grad):
-    return (array_ops.zeros(shape = array_ops.shape(op.inputs[0]), dtype = op.inputs[0].dtype),
-            array_ops.zeros(shape = array_ops.shape(op.inputs[1]), dtype = op.inputs[1].dtype),
-            array_ops.ones(shape = array_ops.shape(op.inputs[2]), dtype = op.inputs[2].dtype))
+  return (array_ops.zeros(shape = array_ops.shape(op.inputs[0]), dtype = op.inputs[0].dtype),
+          array_ops.zeros(shape = array_ops.shape(op.inputs[1]), dtype = op.inputs[1].dtype),
+          array_ops.ones(shape = array_ops.shape(op.inputs[2]), dtype = op.inputs[2].dtype))
 
 
 @ops.RegisterGradient("FractionalMaxPool")

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -406,6 +406,13 @@ def _MaxPoolGrad(op, grad):
                                    data_format=op.get_attr("data_format"))
 
 
+@ops.RegisterGradient("MaxPoolGrad")
+def _MaxPoolGradGrad(op, grad):
+    return (array_ops.zeros(shape = array_ops.shape(op.inputs[0]), dtype = op.inputs[0].dtype),
+            array_ops.zeros(shape = array_ops.shape(op.inputs[1]), dtype = op.inputs[1].dtype),
+            array_ops.ones(shape = array_ops.shape(op.inputs[2]), dtype = op.inputs[2].dtype))
+
+
 @ops.RegisterGradient("FractionalMaxPool")
 def _FractionalMaxPoolGrad(op, grad_0, unused_grad_1, unused_grad_2):
   """Returns gradient for FractionalMaxPool.


### PR DESCRIPTION
Fixes #6143
Fixes #6294 

This is still not a complete. I wanted to know whether this is the correct way? 
I ran the following code and it worked without any error.
If it is correct, then I will add the same for `avg_pool` too.
```
In [1]: import tensorflow as tf
I tensorflow/stream_executor/dso_loader.cc:128] successfully opened CUDA library libcublas.so.7.5 locally
I tensorflow/stream_executor/dso_loader.cc:128] successfully opened CUDA library libcudnn.so.4 locally
I tensorflow/stream_executor/dso_loader.cc:128] successfully opened CUDA library libcufft.so.7.5 locally
I tensorflow/stream_executor/dso_loader.cc:128] successfully opened CUDA library libcuda.so.1 locally
I tensorflow/stream_executor/dso_loader.cc:128] successfully opened CUDA library libcurand.so.7.5 locally

In [2]: x = tf.placeholder(tf.float32, shape=[1, 4, 4, 1])

In [3]: y = tf.nn.max_pool(x, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding='VALID')

In [4]: dy = tf.gradients(y, x)

In [5]: ddy = tf.gradients(dy, x)
```