### PR TITLE
Add orthogonal initialization

### DIFF
--- a/tensorflow/contrib/layers/python/layers/initializers.py
+++ b/tensorflow/contrib/layers/python/layers/initializers.py
@@ -20,12 +20,14 @@ from __future__ import print_function
 
 import math
 
+import numpy as np
+
 from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import random_ops
 
 
 __all__ = ['xavier_initializer', 'xavier_initializer_conv2d',
-           'variance_scaling_initializer']
+           'variance_scaling_initializer', 'orthogonal_initializer']
 
 
 def xavier_initializer(uniform=True, seed=None, dtype=dtypes.float32):
@@ -150,4 +152,38 @@ def variance_scaling_initializer(factor=2.0, mode='FAN_IN', uniform=False,
                                          seed=seed)
   # pylint: enable=unused-argument
 
+  return _initializer
+
+
+def orthogonal_initializer(scale=1.0, seed=None, dtype=dtypes.float32):
+  """Returns an initializer performing orthogonal initialization for weights.
+  
+  This function implements the weight initialization from:
+
+  Andrew M. Saxe, James L. McClelland, Surya Ganguli (2014):
+           Exact solutions to the nonlinear dynamics of learning in deep 
+           linear neural networks. International Conference on Learning 
+           Representations.
+
+  This initializer is designed to reflect independent modes of variation 
+  in the input, by using a orthogonal projection of a random matrix.
+
+  Args:
+    scale: A Python float. Used to scale weights. Set to 1.0 if the weights 
+      will be input to a linear or sigmoid activation function. Use sqrt(2) 
+      for rectified linear units, and sqrt(2 / 1 + leakiness**2)) if leaky. 
+    seed: A Python integer. Used to create random seeds. See
+      [`set_random_seed`](../../api_docs/python/constant_op.md#set_random_seed)
+      for behavior.
+    dtype: The data type. Only floating point types are supported.
+
+  Returns:
+    An initializer for a weight matrix.
+  """
+  def _initializer(shape, dtype=dtype):
+    flat = (shape[0], np.prod(shape[1:]))
+    a = np.random.normal(0.0, 1.0, flat)
+    u, _, v = np.linalg.svd(a, full_matrices=False)
+    q = (u if u.shape == flat else v).reshape(shape)
+    return tf.constant(scale * q[:shape[0], :shape[1]], dtype=dtype)
   return _initializer


### PR DESCRIPTION
[Lasagne has orthogonal initialization](https://github.com/Lasagne/Lasagne/blob/master/lasagne/init.py#L327-L367) like in [this reference](https://arxiv.org/abs/1312.6120) and it's pretty useful (and quite intuitive: make sure random weights are orthogonal so they should tend to learn different modes in the input and not converge to being redundant).

# TODO
 - [ ] Add unit test
 - [ ] Verify code style
 - [ ] Verify docstring style
 - [ ] Don't import NumPy if possible (is there a SVD in TensorFlow somewhere?)