### PR TITLE
fix cuda DNN lib path for mac

### DIFF
--- a/configure
+++ b/configure
@@ -299,8 +299,8 @@ while true; do
     CUDA_DNN_LIB_PATH="lib64/libcudnn.so${TF_CUDNN_EXT}"
     CUDA_DNN_LIB_ALT_PATH="libcudnn.so${TF_CUDNN_EXT}"
   elif [ "$OSNAME" == "Darwin" ]; then
-    CUDA_DNN_LIB_PATH="lib/libcudnn${TF_CUDNN_EXT}"
-    CUDA_DNN_LIB_ALT_PATH="libcudnn${TF_CUDNN_EXT}"
+    CUDA_DNN_LIB_PATH="lib/libcudnn${TF_CUDNN_EXT}.dylib"
+    CUDA_DNN_LIB_ALT_PATH="libcudnn${TF_CUDNN_EXT}.dylib"
   fi
 
   if [ -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_ALT_PATH}" -o -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_PATH}" ]; then


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/commit/ddedb9e094fe3c0e942fdf9d70c21d4df87f8c35 introduced an error providing a non-existent lib.

From the Tensorflow docs:
https://www.tensorflow.org/get_started/os_setup under the section: Optional: Setup GPU for Mac:

> Finally, you will also want to install the CUDA Deep Neural Network (cuDNN v5) library which currently requires an Accelerated Computing Developer Program account. Once you have it downloaded locally, you can unzip and move the header and libraries to your local CUDA Toolkit folder:
> 
> ```
> $ sudo mv include/cudnn.h /Developer/NVIDIA/CUDA-8.0/include/
> $ sudo mv lib/libcudnn* /Developer/NVIDIA/CUDA-8.0/lib
> $ sudo ln -s /Developer/NVIDIA/CUDA-8.0/lib/libcudnn* /usr/local/cuda/lib/
> ```

The cuDNN v5 library provided by Nvidia at https://developer.nvidia.com/rdp/cudnn-download, `cudnn-8.0-osx-x64-v5.1.tgz`, has `libcudnn.5.dylib`, not `libcudnn.5`. 


Here's the output of ./configure, run on a Macbook Pro 10.11.6:

Before (buggy) version that gets stuck on specifying the cuDNN path: 

```
➜  tensorflow git:(master) ./configure
~/os/tensorflow ~/os/tensorflow
Please specify the location of python. [Default is /usr/bin/python]:
Do you wish to build TensorFlow with Google Cloud Platform support? [y/N]
No Google Cloud Platform support will be enabled for TensorFlow
Do you wish to build TensorFlow with Hadoop File System support? [y/N]
No Hadoop File System support will be enabled for TensorFlow
Found possible Python library paths:
  /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python
  /Library/Python/2.7/site-packages
Please input the desired Python library path to use.  Default is [/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python]

Using python library path: /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python
Do you wish to build TensorFlow with OpenCL support? [y/N]
No OpenCL support will be enabled for TensorFlow
Do you wish to build TensorFlow with CUDA support? [y/N] y
CUDA support will be enabled for TensorFlow
Please specify which gcc should be used by nvcc as the host compiler. [Default is /usr/bin/gcc]:
Please specify the CUDA SDK version you want to use, e.g. 7.0. [Leave empty to use system default]:
Please specify the location where CUDA  toolkit is installed. Refer to README.md for more details. [Default is /usr/local/cuda]:
Please specify the Cudnn version you want to use. [Leave empty to use system default]: 5
Please specify the location where cuDNN 5 library is installed. Refer to README.md for more details. [Default is /usr/local/cuda]: /Developer/NVIDIA/CUDA-8.0/
Invalid path to cuDNN  toolkit. Neither of the following two files can be found:
/Developer/NVIDIA/CUDA-8.0/lib/libcudnn.5
/Developer/NVIDIA/CUDA-8.0/libcudnn.5
Please specify the Cudnn version you want to use. [Leave empty to use system default]:
```

After my changes:


```
➜  tensorflow git:(master) ./configure
~/os/tensorflow ~/os/tensorflow
Please specify the location of python. [Default is /usr/bin/python]:
Do you wish to build TensorFlow with Google Cloud Platform support? [y/N]
No Google Cloud Platform support will be enabled for TensorFlow
Do you wish to build TensorFlow with Hadoop File System support? [y/N]
No Hadoop File System support will be enabled for TensorFlow
Found possible Python library paths:
  /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python
  /Library/Python/2.7/site-packages
Please input the desired Python library path to use.  Default is [/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python]

Using python library path: /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python
Do you wish to build TensorFlow with OpenCL support? [y/N]
No OpenCL support will be enabled for TensorFlow
Do you wish to build TensorFlow with CUDA support? [y/N] y
CUDA support will be enabled for TensorFlow
Please specify which gcc should be used by nvcc as the host compiler. [Default is /usr/bin/gcc]:
Please specify the CUDA SDK version you want to use, e.g. 7.0. [Leave empty to use system default]:
Please specify the location where CUDA  toolkit is installed. Refer to README.md for more details. [Default is /usr/local/cuda]:
Please specify the Cudnn version you want to use. [Leave empty to use system default]: 5
Please specify the location where cuDNN 5 library is installed. Refer to README.md for more details. [Default is /usr/local/cuda]: /Developer/NVIDIA/CUDA-8.0/
Please specify a list of comma-separated Cuda compute capabilities you want to build with.
You can find the compute capability of your device at: https://developer.nvidia.com/cuda-gpus.
Please note that each additional compute capability significantly increases your build time and binary size.
[Default is: "3.5,5.2"]: 3.0
............
INFO: Starting clean (this may take a while). Consider using --expunge_async if the clean takes more than several minutes.
........
____Loading package: tensorflow
____Loading package: tensorflow/contrib/tfprof/python/tools/tfprof
____Downloading http://bazel-mirror.storage.googleapis.com/github.com/google/protobuf/archive/008b5a228b37c054f46ba478ccafa5e855cb16db.tar.gz: 157,769 bytes
[truncated]
Configuration finished
```
