### PR TITLE
Make VLOG minimum level can be updated via environment #6366

### DIFF
--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -84,8 +84,8 @@ void LogMessage::GenerateLogMessage() {
 
 namespace {
 
-int64 MinLogLevel() {
-  const char* tf_env_var_val = getenv("TF_CPP_MIN_LOG_LEVEL");
+// Parse log level (int64) from environment variable (char*)
+int64 LogLevelStrToInt(const char* tf_env_var_val) {
   if (tf_env_var_val == nullptr) {
     return 0;
   }
@@ -109,6 +109,16 @@ int64 MinLogLevel() {
   }
 }
 
+int64 MinLogLevel() {
+  const char* tf_env_var_val = getenv("TF_CPP_MIN_LOG_LEVEL");
+  return LogLevelStrToInt(tf_env_var_val);
+}
+
+int64 MinVLogLevel() {
+  const char* tf_env_var_val = getenv("TF_CPP_MIN_VLOG_LEVEL");
+  return LogLevelStrToInt(tf_env_var_val);
+}
+
 }  // namespace
 
 LogMessage::~LogMessage() {
@@ -116,6 +126,8 @@ LogMessage::~LogMessage() {
   static int64 min_log_level = MinLogLevel();
   if (TF_PREDICT_TRUE(severity_ >= min_log_level)) GenerateLogMessage();
 }
+
+int LogMessage::min_lvl_ = MinVLogLevel();
 
 LogMessageFatal::LogMessageFatal(const char* file, int line)
     : LogMessage(file, line, FATAL) {}

--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -92,21 +92,16 @@ int64 LogLevelStrToInt(const char* tf_env_var_val) {
 
   // Ideally we would use env_var / safe_strto64, but it is
   // hard to use here without pulling in a lot of dependencies,
-  // so we do a poor-man's parsing.
+  // so we use std:istringstream instead
   string min_log_level(tf_env_var_val);
-  if (min_log_level == "1") {
-    // Maps to WARNING
-    return 1;
-  } else if (min_log_level == "2") {
-    // Maps to ERROR
-    return 2;
-  } else if (min_log_level == "3") {
-    // Maps to FATAL
-    return 3;
-  } else {
-    // Maps to INFO (the default).
-    return 0;
+  std::istringstream ss(min_log_level);
+  int64 level;
+  if (!(ss >> level)) {
+    // Invalid vlog level setting, set level to default (0)
+    level = 0;
   }
+
+  return level;
 }
 
 int64 MinLogLevelFromEnv() {

--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -109,12 +109,12 @@ int64 LogLevelStrToInt(const char* tf_env_var_val) {
   }
 }
 
-int64 MinLogLevel() {
+int64 MinLogLevelFromEnv() {
   const char* tf_env_var_val = getenv("TF_CPP_MIN_LOG_LEVEL");
   return LogLevelStrToInt(tf_env_var_val);
 }
 
-int64 MinVLogLevel() {
+int64 MinVLogLevelFromEnv() {
   const char* tf_env_var_val = getenv("TF_CPP_MIN_VLOG_LEVEL");
   return LogLevelStrToInt(tf_env_var_val);
 }
@@ -123,11 +123,14 @@ int64 MinVLogLevel() {
 
 LogMessage::~LogMessage() {
   // Read the min log level once during the first call to logging.
-  static int64 min_log_level = MinLogLevel();
+  static int64 min_log_level = MinLogLevelFromEnv();
   if (TF_PREDICT_TRUE(severity_ >= min_log_level)) GenerateLogMessage();
 }
 
-int LogMessage::min_lvl_ = MinVLogLevel();
+int64 LogMessage::MinVLogLevel() {
+  static int64 min_vlog_level = MinVLogLevelFromEnv();
+  return min_vlog_level;
+}
 
 LogMessageFatal::LogMessageFatal(const char* file, int line)
     : LogMessage(file, line, FATAL) {}

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -40,7 +40,7 @@ class LogMessage : public std::basic_ostringstream<char> {
  public:
   LogMessage(const char* fname, int line, int severity);
   ~LogMessage();
-  static int min_lvl_;
+  static int64 MinVLogLevel();
 
  protected:
   void GenerateLogMessage();
@@ -72,11 +72,18 @@ class LogMessageFatal : public LogMessage {
 
 #define LOG(severity) _TF_LOG_##severity
 
-// Set TF_CPP_MIN_VLOG_LEVEL environment to update minimum log level of VLOG
-#define VLOG_IS_ON(lvl) ((lvl) <= ::tensorflow::internal::LogMessage::min_lvl_)
+#ifdef IS_MOBILE_PLATFORM
+// Turn VLOG off when under mobile devices for considerations of binary size.
+#define VLOG_IS_ON(lvl) ((lvl) <= 0)
+#else
+// Otherwise, Set TF_CPP_MIN_VLOG_LEVEL environment to update minimum log level
+// of VLOG
+#define VLOG_IS_ON(lvl) \
+  ((lvl) <= ::tensorflow::internal::LogMessage::MinVLogLevel())
+#endif
 
 #define VLOG(lvl)      \
-  if (VLOG_IS_ON(lvl)) \
+  if (TF_PREDICT_FALSE(VLOG_IS_ON(lvl))) \
   ::tensorflow::internal::LogMessage(__FILE__, __LINE__, tensorflow::INFO)
 
 // CHECK dies with a fatal error if condition is not true.  It is *not*

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -40,6 +40,7 @@ class LogMessage : public std::basic_ostringstream<char> {
  public:
   LogMessage(const char* fname, int line, int severity);
   ~LogMessage();
+  static int min_lvl_;
 
  protected:
   void GenerateLogMessage();
@@ -71,8 +72,8 @@ class LogMessageFatal : public LogMessage {
 
 #define LOG(severity) _TF_LOG_##severity
 
-// TODO(jeff): Define a proper implementation of VLOG_IS_ON
-#define VLOG_IS_ON(lvl) ((lvl) <= 0)
+// Set TF_CPP_MIN_VLOG_LEVEL environment to update minimum log level of VLOG
+#define VLOG_IS_ON(lvl) ((lvl) <= ::tensorflow::internal::LogMessage::min_lvl_)
 
 #define VLOG(lvl)      \
   if (VLOG_IS_ON(lvl)) \

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -43,7 +43,7 @@ class LogMessage : public std::basic_ostringstream<char> {
 
   // Returns the minimum log level for VLOG statements.
   // E.g., if MinVLogLevel() is 2, then VLOG(2) statements will produce output,
-  // but VLOG(3) will not. Defaults to 0
+  // but VLOG(3) will not. Defaults to 0.
   static int64 MinVLogLevel();
 
  protected:

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -40,6 +40,10 @@ class LogMessage : public std::basic_ostringstream<char> {
  public:
   LogMessage(const char* fname, int line, int severity);
   ~LogMessage();
+
+  // Returns the minimum log level for VLOG statements.
+  // E.g., if MinVLogLevel() is 2, then VLOG(2) statements will produce output,
+  // but VLOG(3) will not. Defaults to 0
   static int64 MinVLogLevel();
 
  protected:


### PR DESCRIPTION
Added changes to enable specifying VLOG minimum level. With this patch, user can specify VLOG log level to enable VLOG output, like
```
export TF_CPP_MIN_VLOG_LEVEL=2
```
Tested with fully_connected_feed.py. 

More details see issue #6366 

Thanks,