### PR TITLE
training.slot_creator: support for non-fully-defined shaped vars

### DIFF
--- a/tensorflow/python/training/slot_creator.py
+++ b/tensorflow/python/training/slot_creator.py
@@ -52,7 +52,8 @@ def _create_slot_var(primary, val, scope):
   # scope.
   current_partitioner = variable_scope.get_variable_scope().partitioner
   variable_scope.get_variable_scope().set_partitioner(None)
-  slot = variable_scope.get_variable(scope, initializer=val, trainable=False)
+  slot = variable_scope.get_variable(scope, initializer=val, trainable=False,
+                                     validate_shape=primary.get_shape().is_fully_defined())
   variable_scope.get_variable_scope().set_partitioner(current_partitioner)
 
   # pylint: disable=protected-access
@@ -118,6 +119,8 @@ def create_zeros_slot(primary, name, dtype=None, colocate_with_primary=True):
   """
   if dtype is None:
     dtype = primary.dtype
-  val = array_ops.zeros(primary.get_shape().as_list(), dtype=dtype)
+  val = array_ops.zeros(
+      primary.get_shape().as_list() if primary.get_shape().is_fully_defined() else array_ops.shape(primary),
+      dtype=dtype)
   return create_slot(primary, val, name,
                      colocate_with_primary=colocate_with_primary)


### PR DESCRIPTION
This is a possible solution for #5972.

With this patch, the `AdamOptimizer` (and other optimizers) can optimize variables with non-fully-defined shape which would raise an exception without the patch because `primary.get_shape().as_list()` does not work.
