### PR TITLE
Add an environment variable for the Python binary to enable Python 3.5 builds

### DIFF
--- a/tensorflow/tools/ci_build/protobuf/protobuf_optimized_pip.sh
+++ b/tensorflow/tools/ci_build/protobuf/protobuf_optimized_pip.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 PROTOBUF_VERSION="3.1.0"
-PYTHON=${PYTHON_BIN_PATH:-python}
+PYTHON_BIN_PATH=${PYTHON_BIN_PATH:-python}
 DIR=${PWD}/protobuf
 
 set -ex
@@ -30,4 +30,4 @@ CXXFLAGS="-fPIC -g -O2" ./configure
 make -j8
 export PROTOC=$DIR/src/protoc
 cd python
-$PYTHON setup.py bdist_wheel --cpp_implementation --compile_static_extension
+$PYTHON_BIN_PATH setup.py bdist_wheel --cpp_implementation --compile_static_extension

--- a/tensorflow/tools/ci_build/protobuf/protobuf_optimized_pip.sh
+++ b/tensorflow/tools/ci_build/protobuf/protobuf_optimized_pip.sh
@@ -15,6 +15,7 @@
 # ==============================================================================
 
 PROTOBUF_VERSION="3.1.0"
+PYTHON=${PYTHON_BIN_PATH:-python}
 DIR=${PWD}/protobuf
 
 set -ex
@@ -29,4 +30,4 @@ CXXFLAGS="-fPIC -g -O2" ./configure
 make -j8
 export PROTOC=$DIR/src/protoc
 cd python
-python setup.py bdist_wheel --cpp_implementation --compile_static_extension
+$PYTHON setup.py bdist_wheel --cpp_implementation --compile_static_extension

--- a/tensorflow/tools/ci_build/protobuf/protobuf_optimized_pip.sh
+++ b/tensorflow/tools/ci_build/protobuf/protobuf_optimized_pip.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 PROTOBUF_VERSION="3.1.0"
-PYTHON_BIN_PATH=${PYTHON_BIN_PATH:-python}
+PYTHON_BIN=${PYTHON_BIN:-python}
 DIR=${PWD}/protobuf
 
 set -ex
@@ -30,4 +30,4 @@ CXXFLAGS="-fPIC -g -O2" ./configure
 make -j8
 export PROTOC=$DIR/src/protoc
 cd python
-$PYTHON_BIN_PATH setup.py bdist_wheel --cpp_implementation --compile_static_extension
+$PYTHON_BIN setup.py bdist_wheel --cpp_implementation --compile_static_extension


### PR DESCRIPTION
Tested:
http://ci.tensorflow.org/view/Release/job/release-matrix-protobuf/