### PR TITLE
Fix how error message is generated when running configure

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -192,8 +192,8 @@ def _cuda_version(repository_ctx, cuda_toolkit_path, cpu_value):
     environ_version = repository_ctx.os.environ[_TF_CUDA_VERSION].strip()
   if environ_version and version != environ_version:
     auto_configure_fail(
-        "CUDA version detected from nvcc (%s) does not match " +
-        "TF_CUDA_VERSION (%s)" % (version, environ_version))
+        ("CUDA version detected from nvcc (%s) does not match " +
+         "TF_CUDA_VERSION (%s)") % (version, environ_version))
 
   if cpu_value == "Windows":
     version = "64_" + version.replace(".", "")


### PR DESCRIPTION
Very minor fix:

When your TF_CUDA_VERSION does not match the observed CUDA version, an error is raised. Before this patch, the error message generation fails because the `%` operator is applied to only half of the format string. After this patch it correctly creates the error message and displays it as expected.