### PR TITLE
better visualization name for mnist_with_summaries.py

### DIFF
--- a/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
@@ -122,7 +122,7 @@ def train():
     diff = tf.nn.softmax_cross_entropy_with_logits(y, y_)
     with tf.name_scope('total'):
       cross_entropy = tf.reduce_mean(diff)
-  tf.summary.scalar('cross_entropy', cross_entropy)
+  tf.summary.scalar('cross_entropy/', cross_entropy)
 
   with tf.name_scope('train'):
     train_step = tf.train.AdamOptimizer(FLAGS.learning_rate).minimize(
@@ -133,7 +133,7 @@ def train():
       correct_prediction = tf.equal(tf.argmax(y, 1), tf.argmax(y_, 1))
     with tf.name_scope('accuracy'):
       accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
-  tf.summary.scalar('accuracy', accuracy)
+  tf.summary.scalar('accuracy/', accuracy)
 
   # Merge all the summaries and write them out to /tmp/mnist_logs (by default)
   merged = tf.summary.merge_all()


### PR DESCRIPTION
**Before the modification**, the name showed in tensorboard:

![before](https://cloud.githubusercontent.com/assets/16507370/21415270/11bd23c4-c843-11e6-96d4-ab5e8a76b425.png)


**After the modification**:

![after](https://cloud.githubusercontent.com/assets/16507370/21415229/9e755314-c842-11e6-8290-702f056bb3bd.png)


