### PR TITLE
Matching the tutorial code with mnist_softmax.py

### DIFF
--- a/tensorflow/g3doc/tutorials/mnist/beginners/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/beginners/index.md
@@ -376,21 +376,19 @@ to your graph which implement backpropagation and gradient descent. Then it
 gives you back a single operation which, when run, does a step of gradient
 descent training, slightly tweaking your variables to reduce the loss.
 
-Now we have our model set up to train. One last thing before we launch it, we
-have to create an operation to initialize the variables we created. Note that
-this defines the operation but does not run it yet:
+
+We can now launch the model in an `InteractiveSession`:
 
 ```python
-init = tf.global_variables_initializer()
+sess = tf.InteractiveSession()
 ```
 
-We can now launch the model in a `Session`, and now we run the operation that
-initializes the variables:
+We first have to create an operation to initialize the variables we created:
 
 ```python
-sess = tf.Session()
-sess.run(init)
+tf.global_variables_initializer().run()
 ```
+
 
 Let's train -- we'll run the training step 1000 times!
 


### PR DESCRIPTION
The `MNIST For ML Beginners` tutorial is an explanation, line by line, of what is happening in the [mnist_softmax.py](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/mnist_softmax.py) code, but some lines didn't match.