### PR TITLE
Update docker setup docs

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -500,14 +500,13 @@ For NVidia GPU support install latest NVidia drivers and
 $ nvidia-docker run -it -p 8888:8888 gcr.io/tensorflow/tensorflow:latest-gpu
 ```
 
-If you have a problem running `nvidia-docker`, then using the default config, we
-include a
-[script](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/docker_run_gpu.sh)
-in the repo with these flags, so the command-line would look like
+Note: If you have a problem running `nvidia-docker`, you may try the old way
+we have used. But it is not recomended. If you find a bug in `nvidia-docker`, report
+it there please and try using the `nvidia-docker` as described above.
 
-```bash
-$ path/to/repo/tensorflow/tools/docker/docker_run_gpu.sh -p 8888:8888 gcr.io/tensorflow/tensorflow:latest-gpu
-```
+    $ export CUDA_SO=$(\ls /usr/lib/x86_64-linux-gnu/libcuda.* | xargs -I{} echo '-v {}:{}')
+    $ export DEVICES=$(\ls /dev/nvidia* | xargs -I{} echo '--device {}:{}')
+    $ docker run -it -p 8888:8888 $CUDA_SO $DEVICES gcr.io/tensorflow/tensorflow:latest-gpu
 
 For more details see [TensorFlow docker
 readme](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/docker).


### PR DESCRIPTION
According to [Using TensorFlow via Docker](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/README.md), `docker_run_gpu.sh` has been removed and only `nvidia-docker` is recommended for GPU support.

This PR updates getting started guide to reflect those changes.