### PR TITLE
fix spelling/insert correct reference to udacity notebook

### DIFF
--- a/tensorflow/examples/udacity/3_regularization.ipynb
+++ b/tensorflow/examples/udacity/3_regularization.ipynb
@@ -60,7 +60,7 @@
         "colab_type": "text"
       },
       "source": [
-        "First reload the data we generated in _notmist.ipynb_."
+        "First reload the data we generated in `1_notmnist.ipynb`."
       ]
     },
     {


### PR DESCRIPTION
This pull request corrects the spelling of the notebook *notmist.ipynb* -> `1_notmnist.ipynb` in notebook `3_regularization.ipynb`.