### PR TITLE
Fix build error on Windows.

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/rpc_rendezvous_mgr.cc
+++ b/tensorflow/core/distributed_runtime/rpc/rpc_rendezvous_mgr.cc
@@ -92,7 +92,7 @@ class RpcRecvTensorCall : public BaseRecvTensorCall {
     // RpcRecvTensorCall, and it always sets this->wi_ to null when
     // a call object is released to it, we can assert that this->wi_ is
     // always null at the point of deletion.
-    CHECK_EQ(nullptr, wi_)
+    CHECK_EQ(static_cast<WorkerInterface*>(nullptr), wi_)
         << "Leaking WorkerInterface in RpcRecvTensorCall destructor.";
   }
 


### PR DESCRIPTION
MSVC cannot resolve the type of `nullptr` in `CHECK_EQ(nullptr, ...)`, so we use a static cast to make it explicit.