### PR TITLE
[minor] Silenced the 'pushd'

### DIFF
--- a/configure
+++ b/configure
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 # Find out the absolute path to where ./configure resides
-pushd `dirname $0` #> /dev/null
+pushd `dirname $0` > /dev/null
 SOURCE_BASE_DIR=`pwd -P`
 popd > /dev/null
 


### PR DESCRIPTION
It doesn't fix the #6555, it just silences the `pushd` during the `./configure` step.