### PR TITLE
[Java] Bulk data transfer for Tensor class

### DIFF
--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -73,6 +73,7 @@ java_test(
     test_class = "org.tensorflow.TensorTest",
     deps = [
         ":tensorflow",
+        ":testutil",
         "//external:junit",
     ],
 )

--- a/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
@@ -16,6 +16,13 @@ limitations under the License.
 package org.tensorflow;
 
 import java.lang.reflect.Array;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
 import java.util.Arrays;
 
 /**
@@ -34,6 +41,115 @@ import java.util.Arrays;
  * }</pre>
  */
 public final class Tensor implements AutoCloseable {
+
+  /**
+   * Create a Tensor with data from the given buffer.
+   *
+   * <p>Provide a {@link ByteBuffer} to create a Tensor of any datatype.  Note that primitive
+   * data must be in native byte order. Provide a {@link FloatBuffer}, {@link IntBuffer}, {@link DoubleBuffer},
+   * or {@link LongBuffer} to create a Tensor with a datatype of {@code FLOAT}, {@code INT32}, {@code DOUBLE},
+   * or {@code INT64} respectively.
+   *
+   * <p> This method copies
+   * <i>n</i>&nbsp;=&nbsp;<tt>src.remaining()</tt> elements from the given
+   * buffer into the tensor, starting at the buffer's current position.
+   * The position of the buffer is then incremented by <i>n</i>.
+   *
+   * @param dataType the tensor datatype.
+   * @param shape the tensor shape.
+   * @param data a buffer containing the tensor data.
+   */
+  public static Tensor create(DataType dataType, long[] shape, Buffer data) {
+    Tensor t = new Tensor();
+    t.dtype = dataType;
+    t.shapeCopy = Arrays.copyOf(shape, shape.length);
+
+    int elemsize = 0;
+    if(data instanceof ByteBuffer) elemsize = 1;
+    else if(data instanceof IntBuffer) elemsize = Integer.SIZE / Byte.SIZE;
+    else if(data instanceof FloatBuffer) elemsize = Float.SIZE / Byte.SIZE;
+    else if(data instanceof DoubleBuffer) elemsize = Double.SIZE / Byte.SIZE;
+    else if(data instanceof LongBuffer) elemsize = Long.SIZE / Byte.SIZE;
+    else throwIncompatibleBuffer();
+
+    t.nativeHandle = allocate(t.dtype.c(), t.shapeCopy, elemsize * data.remaining());
+    try {
+      ByteBuffer dst = getBuffer(t.nativeHandle);
+      if(data instanceof ByteBuffer) {
+        dst.put((ByteBuffer) data);
+      }
+      else if(data instanceof IntBuffer) {
+        if(t.dtype != DataType.INT32) throwIncompatibleBuffer();
+        dst.asIntBuffer().put((IntBuffer) data);
+      }
+      else if(data instanceof FloatBuffer) {
+        if(t.dtype != DataType.FLOAT) throwIncompatibleBuffer();
+        dst.asFloatBuffer().put((FloatBuffer) data);
+      }
+      else if(data instanceof DoubleBuffer) {
+        if(t.dtype != DataType.DOUBLE) throwIncompatibleBuffer();
+        dst.asDoubleBuffer().put((DoubleBuffer) data);
+      }
+      else if(data instanceof LongBuffer) {
+        if(t.dtype != DataType.INT64) throwIncompatibleBuffer();
+        dst.asLongBuffer().put((LongBuffer) data);
+      }
+
+      return t;
+    }
+    catch(RuntimeException e) {
+      delete(t.nativeHandle);
+      throw e;
+    }
+  }
+
+  /**
+   * Gets the size (in bytes) of the tensor data.
+   *
+   * <p>Use this size information when constructing a buffer with which to call {@link #readData(Buffer)}.
+   */
+  public int getDataByteSize() {
+    return getBuffer(nativeHandle).remaining();
+  }
+    
+  /**
+   * Reads the tensor data into the given buffer.
+   *
+   * <p>Provide a {@link ByteBuffer} to read a Tensor of any datatype.  Note that primitive
+   * data is in native byte order. Provide a {@link FloatBuffer}, {@link IntBuffer}, {@link DoubleBuffer},
+   * or {@link LongBuffer} to read a Tensor with a datatype of {@code FLOAT}, {@code INT32}, {@code DOUBLE},
+   * or {@code INT64} respectively.
+   *
+   * @param dst the destination buffer.
+   */
+  public void readData(Buffer dst) {
+    ByteBuffer src = getBuffer(nativeHandle);
+    if(dst instanceof ByteBuffer) {
+      ((ByteBuffer) dst).put(src);
+    }
+    else if(dst instanceof IntBuffer) {
+      if(dtype != DataType.INT32) throwIncompatibleBuffer();
+      ((IntBuffer) dst).put(src.asIntBuffer());
+    }
+    else if(dst instanceof FloatBuffer) {
+      if(dtype != DataType.FLOAT) throwIncompatibleBuffer();
+      ((FloatBuffer) dst).put(src.asFloatBuffer());
+    }
+    else if(dst instanceof DoubleBuffer) {
+      if(dtype != DataType.DOUBLE) throwIncompatibleBuffer();
+      ((DoubleBuffer) dst).put(src.asDoubleBuffer());
+    }
+    else if(dst instanceof LongBuffer) {
+      if(dtype != DataType.INT64) throwIncompatibleBuffer();
+      ((LongBuffer) dst).put(src.asLongBuffer());
+    }
+    else throwIncompatibleBuffer();
+  }
+
+  private static void throwIncompatibleBuffer() {
+    throw new IllegalArgumentException("incompatible buffer for Tensor data");
+  }
+
   /**
    * Create a Tensor from a Java object.
    *
@@ -71,7 +187,7 @@ public final class Tensor implements AutoCloseable {
     t.shapeCopy = new long[numDimensions(obj)];
     fillShape(obj, 0, t.shapeCopy);
     if (t.dtype != DataType.STRING) {
-      t.nativeHandle = allocate(t.dtype.c(), t.shapeCopy);
+      t.nativeHandle = allocateNDArray(t.dtype.c(), t.shapeCopy);
       setValue(t.nativeHandle, obj);
     } else if (t.shapeCopy.length != 0) {
       throw new UnsupportedOperationException(
@@ -317,7 +433,15 @@ public final class Tensor implements AutoCloseable {
     }
   }
 
-  private static native long allocate(int dtype, long[] shape);
+  private static ByteBuffer getBuffer(long nativeHandle) {
+    return buffer(nativeHandle).order(ByteOrder.nativeOrder());
+  }
+
+  private static native ByteBuffer buffer(long handle);
+
+  private static native long allocate(int dtype, long[] shape, long sizeInBytes);
+
+  private static native long allocateNDArray(int dtype, long[] shape);
 
   private static native long allocateScalarBytes(byte[] value);
 

--- a/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
@@ -279,7 +279,7 @@ public final class Tensor implements AutoCloseable {
   /**
    * Write the tensor data into the given buffer.
    *
-   * <p>This method copies {@code getDataByteSize()/Integer.BYTES} bytes to the buffer.
+   * <p>This method copies {@code numElements()} elements to the buffer.
    *
    * <p>This method may be used to read tensor data of type {@link DataType#INT32}.
    *
@@ -302,7 +302,7 @@ public final class Tensor implements AutoCloseable {
   /**
    * Write the tensor data into the given buffer.
    *
-   * <p>This method copies {@code getDataByteSize()/Float.BYTES} bytes to the buffer.
+   * <p>This method copies {@code numElements()} elements to the buffer.
    *
    * <p>This method may be used to read tensor data of type {@link DataType#FLOAT}.
    *
@@ -325,7 +325,7 @@ public final class Tensor implements AutoCloseable {
   /**
    * Write the tensor data into the given buffer.
    *
-   * <p>This method copies {@code getDataByteSize()/Double.BYTES} bytes to the buffer.
+   * <p>This method copies {@code numElements()} elements to the buffer.
    *
    * <p>This method may be used to read tensor data of type {@link DataType#DOUBLE}.
    *
@@ -348,7 +348,7 @@ public final class Tensor implements AutoCloseable {
   /**
    * Write the tensor data into the given buffer.
    *
-   * <p>This method copies {@code getDataByteSize()/Long.BYTES} bytes to the buffer.
+   * <p>This method copies {@code numElements()} elements to the buffer.
    *
    * <p>This method may be used to read tensor data of type {@link DataType#INT64}.
    *
@@ -371,7 +371,7 @@ public final class Tensor implements AutoCloseable {
   /**
    * Write the tensor data into the given buffer.
    *
-   * <p>This method copies {@code getDataByteSize()} bytes to the buffer.
+   * <p>This method copies {@code byteSize()} bytes to the buffer.
    *
    * <p>This method may be used to read tensor data of any type.  Note that
    * primitive data is in native byte order.

--- a/tensorflow/java/src/main/native/tensor_jni.h
+++ b/tensorflow/java/src/main/native/tensor_jni.h
@@ -24,14 +24,6 @@ extern "C" {
 
 /*
  * Class:     org_tensorflow_Tensor
- * Method:    buffer
- * Signature: (J)Ljava/nio/ByteBuffer;
- */
-JNIEXPORT jobject JNICALL Java_org_tensorflow_Tensor_buffer(JNIEnv *, jclass,
-                                                              jlong);
-
-/*
- * Class:     org_tensorflow_Tensor
  * Method:    allocate
  * Signature: (I[JJ)J
  */
@@ -53,6 +45,14 @@ Java_org_tensorflow_Tensor_allocateScalarBytes(JNIEnv *, jclass, jbyteArray);
  */
 JNIEXPORT void JNICALL Java_org_tensorflow_Tensor_delete(JNIEnv *, jclass,
                                                          jlong);
+
+/*
+ * Class:     org_tensorflow_Tensor
+ * Method:    buffer
+ * Signature: (J)Ljava/nio/ByteBuffer;
+ */
+JNIEXPORT jobject JNICALL Java_org_tensorflow_Tensor_buffer(JNIEnv *, jclass,
+                                                              jlong);
 
 /*
  * Class:     org_tensorflow_Tensor

--- a/tensorflow/java/src/main/native/tensor_jni.h
+++ b/tensorflow/java/src/main/native/tensor_jni.h
@@ -24,10 +24,26 @@ extern "C" {
 
 /*
  * Class:     org_tensorflow_Tensor
+ * Method:    buffer
+ * Signature: (J)Ljava/nio/ByteBuffer;
+ */
+JNIEXPORT jobject JNICALL Java_org_tensorflow_Tensor_buffer(JNIEnv *, jclass,
+                                                              jlong);
+
+/*
+ * Class:     org_tensorflow_Tensor
  * Method:    allocate
- * Signature: (I[J)J
+ * Signature: (I[JJ)J
  */
 JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_allocate(JNIEnv *, jclass,
+                                                            jint, jlongArray, jlong);
+
+/*
+ * Class:     org_tensorflow_Tensor
+ * Method:    allocateNDArray
+ * Signature: (I[J)J
+ */
+JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_allocateNDArray(JNIEnv *, jclass,
                                                             jint, jlongArray);
 
 /*

--- a/tensorflow/java/src/main/native/tensor_jni.h
+++ b/tensorflow/java/src/main/native/tensor_jni.h
@@ -40,14 +40,6 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_allocate(JNIEnv *, jclass,
 
 /*
  * Class:     org_tensorflow_Tensor
- * Method:    allocateNDArray
- * Signature: (I[J)J
- */
-JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_allocateNDArray(JNIEnv *, jclass,
-                                                            jint, jlongArray);
-
-/*
- * Class:     org_tensorflow_Tensor
  * Method:    allocateScalarBytes
  * Signature: ([B)J
  */

--- a/tensorflow/java/src/test/java/org/tensorflow/TestUtil.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/TestUtil.java
@@ -15,6 +15,8 @@ limitations under the License.
 
 package org.tensorflow;
 
+import java.lang.reflect.Array;
+
 /** Static utility functions. */
 public class TestUtil {
   public static Output constant(Graph g, String name, Object value) {
@@ -48,5 +50,44 @@ public class TestUtil {
 
   public static void transpose_A_times_X(Graph g, int[][] a) {
     matmul(g, "Y", constant(g, "A", a), placeholder(g, "X", DataType.INT32), true, false);
+  }
+
+  public static int numElements(Object array) {
+    int count = 0;
+    for (int i = 0; i < Array.getLength(array); i++) {
+      Object e = Array.get(array, i);
+      if(!e.getClass().isArray()) {
+        count += 1;
+      }
+      else {
+        count += numElements(e);
+      }
+    }
+    return count;
+  }
+
+  public static Object flatten(Object array, Class<?> elementType) {
+    Object out = Array.newInstance(elementType, numElements(array));
+    flatten(array, out, 0);
+    return out;
+  }
+
+  private static int flatten(Object array, Object out, int next) {
+    for (int i = 0; i < Array.getLength(array); i++) {
+      Object e = Array.get(array, i);
+      if(!e.getClass().isArray()) {
+        Array.set(out, next++, e);
+      }
+      else {
+        next = flatten(e, out, next);
+      }
+    }
+    return next;
+  }
+
+  public static byte[] bool2byte(boolean[] array) {
+    byte[] out = new byte[array.length];
+    for(int i = 0; i< array.length; i++) out[i] = array[i] ? (byte) 1 : (byte) 0;
+    return out;
   }
 }

--- a/tensorflow/java/src/test/java/org/tensorflow/TestUtil.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/TestUtil.java
@@ -52,7 +52,12 @@ public class TestUtil {
     matmul(g, "Y", constant(g, "A", a), placeholder(g, "X", DataType.INT32), true, false);
   }
 
-  public static int numElements(Object array) {
+  /**
+   * Counts the total number of elements in an ND array.
+   * @param array the array to count the elements of
+   * @return the number of elements
+   */
+  public static int flattenedNumElements(Object array) {
     int count = 0;
     for (int i = 0; i < Array.getLength(array); i++) {
       Object e = Array.get(array, i);
@@ -60,14 +65,20 @@ public class TestUtil {
         count += 1;
       }
       else {
-        count += numElements(e);
+        count += flattenedNumElements(e);
       }
     }
     return count;
   }
 
+  /**
+   * Flattens an ND-array into a 1D-array with the same elements.
+   * @param array the array to flatten
+   * @param elementType the element class (e.g. {@code Integer.TYPE} for an {@code int[]})
+   * @return a flattened array
+   */
   public static Object flatten(Object array, Class<?> elementType) {
-    Object out = Array.newInstance(elementType, numElements(array));
+    Object out = Array.newInstance(elementType, flattenedNumElements(array));
     flatten(array, out, 0);
     return out;
   }
@@ -85,9 +96,29 @@ public class TestUtil {
     return next;
   }
 
+  /**
+   * Converts a {@code boolean[]} to a {@code byte[]}.
+   *
+   * <p>Suitable for creating tensors of type {@link DataType#BOOL} using {@link java.nio.ByteBuffer}.
+   */
   public static byte[] bool2byte(boolean[] array) {
     byte[] out = new byte[array.length];
-    for(int i = 0; i< array.length; i++) out[i] = array[i] ? (byte) 1 : (byte) 0;
+    for(int i = 0; i< array.length; i++) {
+      out[i] = array[i] ? (byte) 1 : (byte) 0;
+    }
+    return out;
+  }
+
+  /**
+   * Converts a {@code byte[]} to a {@code boolean[]}.
+   *
+   * <p>Suitable for reading tensors of type {@link DataType#BOOL} using {@link java.nio.ByteBuffer}.
+   */
+  public static boolean[] byte2bool(byte[] array) {
+    boolean[] out = new boolean[array.length];
+    for(int i = 0; i< array.length; i++) {
+      out[i] = array[i] != 0;
+    }
     return out;
   }
 }


### PR DESCRIPTION
Closes #6576

Introduces bulk data-access pattern to `Tensor`, with tests.
- `Tensor::create(DataType dt, long[] shape, Buffer data)` method
- `Tensor::getDataByteSize()` method
- `Tensor::readData(Buffer data)` method

Details:
- rename `allocate` to `allocateNDArray` since it is designed for the
NDarray scenario.
- introduce a native `allocate` method that accepts the data size in
bytes, rather than computing the size with shape information (which
isn’t always sufficient, e.g. TF_STRING).
- introduce a private `buffer` accessor to access the TF data as a
direct `ByteBuffer`.
- implement `create` and `readData` methods to read and write data
using a variety of `Buffer` variants.   Supports typed buffers and
direct buffers.