### PR TITLE
Fix capitalization of "TensorFlow".

### DIFF
--- a/tensorflow/g3doc/tutorials/mnist/beginners/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/beginners/index.md
@@ -223,7 +223,7 @@ More compactly, we can just write:
 
 $$y = \text{softmax}(Wx + b)$$
 
-Now let's turn that into something that Tensorflow can use.
+Now let's turn that into something that TensorFlow can use.
 
 ## Implementing the Regression
 


### PR DESCRIPTION
Fix capitalization of "TensorFlow" in MNIST For ML Beginners tutorial.