### PR TITLE
Remove unused TF_NEED_SYCL from ./configure.

### DIFF
--- a/configure
+++ b/configure
@@ -145,7 +145,7 @@ while [ "$TF_NEED_CUDA" == "" ]; do
 done
 
 export TF_NEED_CUDA
-export TF_NEED_SYCL
+export TF_NEED_OPENCL
 if [[ "$TF_NEED_CUDA" == "0" ]] && [[ "$TF_NEED_OPENCL" == "0" ]]; then
   echo "Configuration finished"
   bazel_clean_and_fetch
@@ -465,7 +465,6 @@ while true; do
   COMPUTECPP_TOOLKIT_PATH=""
 done
 
-export TF_NEED_OPENCL
 # end of if "$TF_NEED_OPENCL" == "1"
 fi
 


### PR DESCRIPTION
TF_NEED_SYCL seems to be an old alias for TF_NEED_OPENCL. It does not appear anywhere else in the repository. This change replaces it with TF_NEED_OPENCL, using the same structure as TF_NEED_CUDA.