### PR TITLE
configure: Handle existing TF_CUDNN_VERSION correctly on OSX.

### DIFF
--- a/configure
+++ b/configure
@@ -289,7 +289,11 @@ while true; do
       echo "libcudnn.dylib resolves to libcudnn${TF_CUDNN_EXT}"
     fi
   else
-    TF_CUDNN_EXT=".$TF_CUDNN_VERSION"
+    if [ "$OSNAME" == "Darwin" ]; then
+      TF_CUDNN_EXT=".${TF_CUDNN_VERSION}.dylib"
+    else
+      TF_CUDNN_EXT=".$TF_CUDNN_VERSION"
+    fi
   fi
 
   if is_windows; then


### PR DESCRIPTION
The configure script sets TF_CUDNN_EXT based on the desired CuDNN version. When TF_CUDNN_VERSION does not exist, the script correctly extracts the version from CuDNN's library symlink and uses it to populate TF_CUDNN_EXT. When TF_CUDNN_VERSION does exist, the script uses it to derive TF_CUDNN_EXT.

Unfortunately, the logic for the latter case does not cover the special case in OSX naming. This commit adds logic to handle the special case in OSX.