### PR TITLE
change tensorboard html data request path to relative

### DIFF
--- a/tensorflow/tensorboard/components/tf_backend/router.ts
+++ b/tensorflow/tensorboard/components/tf_backend/router.ts
@@ -35,7 +35,7 @@ module TF.Backend {
    * @param dataDir {string} The base prefix for finding data on server.
    * @param demoMode {boolean} Whether to modify urls for filesystem demo usage.
    */
-  export function router(dataDir = '/data', demoMode = false): Router {
+  export function router(dataDir = 'data', demoMode = false): Router {
     var clean = demoMode ? demoify : (x) => x;
     if (dataDir[dataDir.length - 1] === '/') {
       dataDir = dataDir.slice(0, dataDir.length - 1);

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -521,7 +521,7 @@ var TF;
          * @param demoMode {boolean} Whether to modify urls for filesystem demo usage.
          */
         function router(dataDir, demoMode) {
-            if (dataDir === void 0) { dataDir = 'data'; }
+            if (dataDir === void 0) { dataDir = '/data'; }
             if (demoMode === void 0) { demoMode = false; }
             var clean = demoMode ? Backend.demoify : function (x) { return x; };
             if (dataDir[dataDir.length - 1] === '/') {

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -521,7 +521,7 @@ var TF;
          * @param demoMode {boolean} Whether to modify urls for filesystem demo usage.
          */
         function router(dataDir, demoMode) {
-            if (dataDir === void 0) { dataDir = '/data'; }
+            if (dataDir === void 0) { dataDir = 'data'; }
             if (demoMode === void 0) { demoMode = false; }
             var clean = demoMode ? Backend.demoify : function (x) { return x; };
             if (dataDir[dataDir.length - 1] === '/') {


### PR DESCRIPTION
Tensorboard use a  absolute path  for data request like `/data/runs`, `/data/graph`, `/data/logdir`.

If someone want to deploy tensorboard with a **path** `http://host/tensorboard/`, the data xmlhttprequest would be  `http://host/data/runs`,  thus give not found 404 errors and tensorboard doesn't work properly.

To make the data request with `http://host/tensorboard/data/runs`, a relative  xmlhttprequest url for data request should be used.  The default `dataDir = '/data';` will change to `dataDir = 'data';`

The default  dataDir to `dataDir = 'data'` will always work whenever `tf-tensorboard.html` is placed or any context path is set.