### PR TITLE
fix zlib dependency (current one fails with 403 on ./configure)

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -228,9 +228,9 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
   native.new_http_archive(
     name = "zlib_archive",
-    url = "http://zlib.net/zlib-1.2.8.tar.gz",
-    sha256 = "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d",
-    strip_prefix = "zlib-1.2.8",
+    url = "http://zlib.net/zlib-1.2.10.tar.gz",
+    sha256 = "8d7e9f698ce48787b6e1c67e6bff79e487303e66077e25cb9784ac8835978017",
+    strip_prefix = "zlib-1.2.10",
     build_file = str(Label("//:zlib.BUILD")),
   )
 


### PR DESCRIPTION
Looks like 1.2.8 got deleted, ./configure fails with 
ERROR: /local_home/yaroslav/tensorflow_dbg.git/tensorflow/tensorflow/core/BUILD:970:1: no such package '@zlib_archive//': Error downloading [http://zlib.net/zlib-1.2.8.tar.gz] to /local_home/yaroslav/.cache/bazel/_bazel_yaroslav/687fadd894268346c74cc86e6f287d8c/external/zlib_archive/zlib-1.2.8.tar.gz: GET returned 404 Not Found and referenced by '//tensorflow/core:lib_internal'.
