### PR TITLE
Enable sandboxing for Android builds to prevent asset double-inclusion

### DIFF
--- a/tensorflow/tools/ci_build/builds/android.sh
+++ b/tensorflow/tools/ci_build/builds/android.sh
@@ -21,4 +21,6 @@ source "${SCRIPT_DIR}/builds_common.sh"
 configure_android_workspace
 
 CPUS=armeabi-v7a,x86_64
-bazel build -c opt --fat_apk_cpu=${CPUS} //tensorflow/examples/android:tensorflow_demo
+bazel --bazelrc=/dev/null build -c opt --fat_apk_cpu=${CPUS} \
+    --spawn_strategy=sandboxed --genrule_strategy=sandboxed \
+    //tensorflow/examples/android:tensorflow_demo

--- a/tensorflow/tools/ci_build/builds/android.sh
+++ b/tensorflow/tools/ci_build/builds/android.sh
@@ -21,6 +21,9 @@ source "${SCRIPT_DIR}/builds_common.sh"
 configure_android_workspace
 
 CPUS=armeabi-v7a,x86_64
+
+# Enable sandboxing so that zip archives don't get incorrectly packaged
+# in assets/ dir (see https://github.com/bazelbuild/bazel/issues/2334)
 bazel --bazelrc=/dev/null build -c opt --fat_apk_cpu=${CPUS} \
     --spawn_strategy=sandboxed --genrule_strategy=sandboxed \
     //tensorflow/examples/android:tensorflow_demo

--- a/tensorflow/tools/ci_build/builds/android.sh
+++ b/tensorflow/tools/ci_build/builds/android.sh
@@ -24,6 +24,7 @@ CPUS=armeabi-v7a,x86_64
 
 # Enable sandboxing so that zip archives don't get incorrectly packaged
 # in assets/ dir (see https://github.com/bazelbuild/bazel/issues/2334)
+# TODO(gunan): remove extra flags once sandboxing is enabled for all builds.
 bazel --bazelrc=/dev/null build -c opt --fat_apk_cpu=${CPUS} \
     --spawn_strategy=sandboxed --genrule_strategy=sandboxed \
     //tensorflow/examples/android:tensorflow_demo

--- a/tensorflow/tools/ci_build/builds/android_full.sh
+++ b/tensorflow/tools/ci_build/builds/android_full.sh
@@ -53,6 +53,7 @@ done
 # Build Jar and also demo containing native libs for all architectures.
 # Enable sandboxing so that zip archives don't get incorrectly packaged
 # in assets/ dir (see https://github.com/bazelbuild/bazel/issues/2334)
+# TODO(gunan): remove extra flags once sandboxing is enabled for all builds.
 echo "========== Building TensorFlow Android Jar and Demo =========="
 bazel --bazelrc=/dev/null build -c opt --fat_apk_cpu=${CPUS} \
     --spawn_strategy=sandboxed --genrule_strategy=sandboxed \

--- a/tensorflow/tools/ci_build/builds/android_full.sh
+++ b/tensorflow/tools/ci_build/builds/android_full.sh
@@ -51,8 +51,11 @@ do
 done
 
 # Build Jar and also demo containing native libs for all architectures.
+# Enable sandboxing so that zip archives don't get incorrectly packaged
+# in assets/ dir.
 echo "========== Building TensorFlow Android Jar and Demo =========="
-bazel build -c opt --fat_apk_cpu=${CPUS} \
+bazel --bazelrc=/dev/null build -c opt --fat_apk_cpu=${CPUS} \
+    --spawn_strategy=sandboxed --genrule_strategy=sandboxed \
     //tensorflow/contrib/android:android_tensorflow_inference_java \
     //tensorflow/examples/android:tensorflow_demo
 

--- a/tensorflow/tools/ci_build/builds/android_full.sh
+++ b/tensorflow/tools/ci_build/builds/android_full.sh
@@ -52,7 +52,7 @@ done
 
 # Build Jar and also demo containing native libs for all architectures.
 # Enable sandboxing so that zip archives don't get incorrectly packaged
-# in assets/ dir.
+# in assets/ dir (see https://github.com/bazelbuild/bazel/issues/2334)
 echo "========== Building TensorFlow Android Jar and Demo =========="
 bazel --bazelrc=/dev/null build -c opt --fat_apk_cpu=${CPUS} \
     --spawn_strategy=sandboxed --genrule_strategy=sandboxed \


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/2334 for context.