### PR TITLE
Eliminate ':' in summary name of contrib.learn.estimators.

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/composable_model.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/composable_model.py
@@ -334,8 +334,8 @@ class DNNComposableModel(_ComposableModel):
 
   def _add_hidden_layer_summary(self, value, tag):
     # TODO(zakaria): Move this code to tf.learn and add test.
-    summary.scalar("%s:fraction_of_zero_values" % tag, nn.zero_fraction(value))
-    summary.histogram("%s:activation" % tag, value)
+    summary.scalar("%s/fraction_of_zero_values" % tag, nn.zero_fraction(value))
+    summary.histogram("%s/activation" % tag, value)
 
   def build_model(self, features, feature_columns, is_training):
     """See base class."""

--- a/tensorflow/contrib/learn/python/learn/estimators/dnn_linear_combined.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/dnn_linear_combined.py
@@ -377,9 +377,9 @@ def _linear_learning_rate(num_linear_feature_columns):
 
 
 def _add_hidden_layer_summary(value, tag):
-  logging_ops.scalar_summary("%s:fraction_of_zero_values" % tag,
+  logging_ops.scalar_summary("%s/fraction_of_zero_values" % tag,
                              nn.zero_fraction(value))
-  logging_ops.histogram_summary("%s:activation" % tag, value)
+  logging_ops.histogram_summary("%s/activation" % tag, value)
 
 
 def _get_embedding_variable(column, collection_key, input_layer_scope):


### PR DESCRIPTION
When I run the contrib.learn.DNNRegressor or contrib.learn.DNNClassifier model, I've got the log messages like below.

```
INFO:tensorflow:Summary name dnn/hiddenlayer_0:fraction_of_zero_values is illegal; using dnn/hiddenlayer_0_fraction_of_zero_values instead.
INFO:tensorflow:Summary name dnn/hiddenlayer_0:activation is illegal; using dnn/hiddenlayer_0_activation instead.
INFO:tensorflow:Summary name dnn/hiddenlayer_1:fraction_of_zero_values is illegal; using dnn/hiddenlayer_1_fraction_of_zero_values instead.
INFO:tensorflow:Summary name dnn/hiddenlayer_1:activation is illegal; using dnn/hiddenlayer_1_activation instead.
```

Tensorboard show me that the characters ':' in these summary name were replaced by '_'.

I think this change doesn't cause any big incompatibility issues.