### PR TITLE
Adding support for Linux s390x in sparse_split_op

### DIFF
--- a/tensorflow/core/kernels/sparse_split_op.cc
+++ b/tensorflow/core/kernels/sparse_split_op.cc
@@ -30,7 +30,7 @@ class SparseSplitOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    const int32 split_dim = context->input(0).scalar<int>()();
+    const int64 split_dim = context->input(0).scalar<int64>()();
     const Tensor& input_indices = context->input(1);
     const Tensor& input_values = context->input(2);
     const Tensor& input_shape = context->input(3);


### PR DESCRIPTION
Changing the data type of split_dim to resolve sparse_split_op_test failure on Big Endian System.