### PR TITLE
Fix: Check bazel version before trying to setup the workspace.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,12 @@
 workspace(name = "org_tensorflow")
 
+load("//tensorflow:workspace.bzl", "check_version", "tf_workspace")
+
+# We must check the bazel version before trying to parse any other BUILD files,
+# in case the parsing of those build files depends on the bazel version we
+# require here.
+check_version("0.4.2")
+
 # Uncomment and update the paths in these entries to build the Android demo.
 #android_sdk_repository(
 #    name = "androidsdk",
@@ -15,12 +22,7 @@ workspace(name = "org_tensorflow")
 #    api_level=21)
 
 # Please add all new TensorFlow dependencies in workspace.bzl.
-load("//tensorflow:workspace.bzl", "tf_workspace")
 tf_workspace()
-
-# Specify the minimum required bazel version.
-load("//tensorflow:tensorflow.bzl", "check_version")
-check_version("0.4.2")
 
 new_http_archive(
   name = "inception5h",

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1,40 +1,10 @@
 # -*- Python -*-
 
-# Parse the bazel version string from `native.bazel_version`.
-def _parse_bazel_version(bazel_version):
-  # Remove commit from version.
-  version = bazel_version.split(" ", 1)[0]
-
-  # Split into (release, date) parts and only return the release
-  # as a tuple of integers.
-  parts = version.split('-', 1)
-
-  # Turn "release" into a tuple of strings
-  version_tuple = ()
-  for number in parts[0].split('.'):
-    version_tuple += (str(number),)
-  return version_tuple
-
 # Given a source file, generate a test name.
 # i.e. "common_runtime/direct_session_test.cc" becomes
 #      "common_runtime_direct_session_test"
 def src_to_test_name(src):
   return src.replace("/", "_").split(".")[0]
-
-# Check that a specific bazel version is being used.
-def check_version(bazel_version):
-  if "bazel_version" not in dir(native):
-    fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" % bazel_version)
-  elif not native.bazel_version:
-    print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
-    print("Make sure that you are running at least Bazel %s.\n" % bazel_version)
-  else:
-    current_bazel_version = _parse_bazel_version(native.bazel_version)
-    minimum_bazel_version = _parse_bazel_version(bazel_version)
-    if minimum_bazel_version > current_bazel_version:
-      fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
-          native.bazel_version, bazel_version))
-  pass
 
 # Return the options to use for a C++ library or binary build.
 # Uses the ":optmode" config_setting to pick the options.

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -4,6 +4,36 @@ load("//third_party/gpus:cuda_configure.bzl", "cuda_configure")
 load("//third_party/sycl:sycl_configure.bzl", "sycl_configure")
 
 
+# Parse the bazel version string from `native.bazel_version`.
+def _parse_bazel_version(bazel_version):
+  # Remove commit from version.
+  version = bazel_version.split(" ", 1)[0]
+
+  # Split into (release, date) parts and only return the release
+  # as a tuple of integers.
+  parts = version.split('-', 1)
+
+  # Turn "release" into a tuple of strings
+  version_tuple = ()
+  for number in parts[0].split('.'):
+    version_tuple += (str(number),)
+  return version_tuple
+
+# Check that a specific bazel version is being used.
+def check_version(bazel_version):
+  if "bazel_version" not in dir(native):
+    fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" % bazel_version)
+  elif not native.bazel_version:
+    print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
+    print("Make sure that you are running at least Bazel %s.\n" % bazel_version)
+  else:
+    current_bazel_version = _parse_bazel_version(native.bazel_version)
+    minimum_bazel_version = _parse_bazel_version(bazel_version)
+    if minimum_bazel_version > current_bazel_version:
+      fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
+          native.bazel_version, bazel_version))
+  pass
+
 # If TensorFlow is linked as a submodule.
 # path_prefix and tf_repo_name are no longer used.
 def tf_workspace(path_prefix = "", tf_repo_name = ""):


### PR DESCRIPTION
I could not prevent all the other errors from showing up, but this way we at least get the bazel version error message at the end:

```
...
ERROR: /tensorflow/tensorflow/workspace.bzl:351:3: //external:zlib_archive: no such attribute 'urls' in 'new_http_archive' rule.
ERROR: /tensorflow/tensorflow/workspace.bzl:351:3: //external:zlib_archive: missing value for mandatory attribute 'url' in 'new_http_archive' rule.
ERROR: /tensorflow/WORKSPACE:6:1: Traceback (most recent call last):
	File "/tensorflow/WORKSPACE", line 6
		check_version("0.4.2")
	File "/tensorflow/tensorflow/workspace.bzl", line 32, in check_version
		fail("
Current Bazel version is {}, e...))

Current Bazel version is 0.3.2, expected at least 0.4.2
.
ERROR: Error evaluating WORKSPACE file.
ERROR: error loading package 'external': Package 'external' contains errors.
ERROR: missing fetch expression. Type 'bazel help fetch' for syntax and help.
```