### PR TITLE
Fix build errors on AVX2+ hosts with -march=native.

### DIFF
--- a/third_party/eigen3/unsupported/Eigen/CXX11/FixedPoint
+++ b/third_party/eigen3/unsupported/Eigen/CXX11/FixedPoint
@@ -32,14 +32,22 @@
 
 // Use optimized implementations whenever available
 #ifdef EIGEN_VECTORIZE_AVX512
-#include "src/Tensor/TensorContractionThreadPool.h"
+
+// This include reaches into the original eigen3 files. The full relative path
+// is needed to avoid https://github.com/tensorflow/tensorflow/issues/6558
+#include "unsupported/Eigen/CXX11/src/Tensor/TensorContractionThreadPool.h"
+
 #include "src/FixedPoint/PacketMathAVX512.h"
 #include "src/FixedPoint/TypeCastingAVX512.h"
 
 #elif defined EIGEN_VECTORIZE_AVX2
 #define EIGEN_USE_OPTIMIZED_INT8_UINT8_MAT_MAT_PRODUCT
 #define EIGEN_USE_OPTIMIZED_INT16_INT16_MAT_MAT_PRODUCT
-#include "src/Tensor/TensorContractionThreadPool.h"
+
+// This include reaches into the original eigen3 files. The full relative path
+// is needed to avoid https://github.com/tensorflow/tensorflow/issues/6558
+#include "unsupported/Eigen/CXX11/src/Tensor/TensorContractionThreadPool.h"
+
 #include "src/FixedPoint/PacketMathAVX2.h"
 #include "src/FixedPoint/MatMatProductAVX2.h"
 #include "src/FixedPoint/TypeCastingAVX2.h"


### PR DESCRIPTION
third_party/eigen3/unsupported/Eigen/CXX/FixedPoint and third_party/eigen3/unsupported/Eigen/CXX/Tensor use different paths to reach into unsupported/Eigen/CXX/src/Tensor. The former's paths cause the build errors documented in #6558. This commit converges on the path in third_party/eigen3/unsupported/Eigen/CXX/Tensor, which fixes the build error.

I tested the PR with the following command, which fails without the patch.

```bash
bazel build -c opt --copt=-march=native //tensorflow:libtensorflow.so
```