### PR TITLE
Enhance cuda kernel helper.

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1823,6 +1823,18 @@ tf_cc_tests_gpu(
 )
 
 tf_cc_test_gpu(
+    name = "cuda_kernel_helper_test",
+    size = "small",
+    srcs = ["util/cuda_kernel_helper_test.cc"],
+    linkstatic = tf_kernel_tests_linkstatic(),
+    tags = tf_cuda_tests_tags(),
+    deps = [
+        ":test",
+        ":test_main",
+    ],
+)
+
+tf_cc_test_gpu(
     name = "cuda_libdevice_path_test",
     size = "small",
     srcs = ["platform/cuda_libdevice_path_test.cc"],

--- a/tensorflow/core/util/cuda_kernel_helper.h
+++ b/tensorflow/core/util/cuda_kernel_helper.h
@@ -257,6 +257,20 @@ __global__ void SetZero(const int nthreads, T* data) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) { *(data + index) = T(0); }
 }
 
+template <typename T>
+__global__ void SetConstant(const int nthreads, T* data, const T value) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {*(data + index) = value;}
+}
+
+template <typename T>
+__global__ void ReplaceValue(const int nthreads, T* data, const T old_value, const T new_value) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    if (*(data + index) == old_value) {
+      *(data + index) = new_value;
+    }
+  }
+}
+
 // For atomicSub.
 
 // Custom implementation for sub by just negating the value.

--- a/tensorflow/core/util/cuda_kernel_helper.h
+++ b/tensorflow/core/util/cuda_kernel_helper.h
@@ -142,27 +142,6 @@ USE_CUDA_ATOMIC(Add, uint32);
 USE_CUDA_ATOMIC(Add, uint64);
 USE_CUDA_ATOMIC(Add, float);
 
-// For atomicMax.
-USE_CUDA_ATOMIC(Max, int32);
-USE_CUDA_ATOMIC(Max, uint32);
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 350
-USE_CUDA_ATOMIC(Max, uint64);
-#else
-// The uint64 overload of atomicMax() is only available for __CUDA_ARCH__ >=
-// 350.  If not satisfied, we provide a custom implementation using atomicCAS().
-CUDA_ATOMIC_WRAPPER(Max, uint64) {
-  uint64* address_as_ull = reinterpret_cast<uint64*>(address);
-  uint64 old = *address_as_ull, assumed;
-
-  do {
-    assumed = old;
-    old = atomicCAS(address_as_ull, assumed, max(val, assumed));
-  } while (assumed != old);
-
-  return old;
-}
-#endif
-
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 600
 USE_CUDA_ATOMIC(Add, double);
 #else
@@ -256,6 +235,27 @@ CUDA_ATOMIC_WRAPPER(Add, Eigen::half) {
     return ret;
   }
 }
+
+// For atomicMax.
+USE_CUDA_ATOMIC(Max, int32);
+USE_CUDA_ATOMIC(Max, uint32);
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 350
+USE_CUDA_ATOMIC(Max, uint64);
+#else
+// The uint64 overload of atomicMax() is only available for __CUDA_ARCH__ >=
+// 350.  If not satisfied, we provide a custom implementation using atomicCAS().
+CUDA_ATOMIC_WRAPPER(Max, uint64) {
+  uint64* address_as_ull = reinterpret_cast<uint64*>(address);
+  uint64 old = *address_as_ull, assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed, max(val, assumed));
+  } while (assumed != old);
+
+  return old;
+}
+#endif
 
 template <typename T>
 __global__ void SetZero(const int nthreads, T* data) {

--- a/tensorflow/core/util/cuda_kernel_helper.h
+++ b/tensorflow/core/util/cuda_kernel_helper.h
@@ -257,6 +257,32 @@ CUDA_ATOMIC_WRAPPER(Max, uint64) {
 }
 #endif
 
+CUDA_ATOMIC_WRAPPER(Max, float) {
+  int32* address_as_int = reinterpret_cast<int32*>(address);
+  int32 old = *address_as_int, assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_int, assumed,
+                    __float_as_int(max(val,  __int_as_float(assumed))));;
+  } while (assumed != old);
+
+  return __int_as_float(old);
+}
+
+CUDA_ATOMIC_WRAPPER(Max, double) {
+  uint64* address_as_ull = reinterpret_cast<uint64*>(address);
+  uint64 old = *address_as_ull, assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    __double_as_longlong(max(val,  __longlong_as_double(assumed))));;
+  } while (assumed != old);
+
+  return __longlong_as_double(old);
+}
+
 template <typename T>
 __global__ void SetZero(const int nthreads, T* data) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) { *(data + index) = T(0); }

--- a/tensorflow/core/util/cuda_kernel_helper.h
+++ b/tensorflow/core/util/cuda_kernel_helper.h
@@ -163,7 +163,11 @@ CUDA_ATOMIC_WRAPPER(Max, uint64) {
 }
 #endif
 
-// Custom implementation of atomicAdd for double.
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 600
+USE_CUDA_ATOMIC(Add, double);
+#else
+// The double overload of atomicMax() is only available for __CUDA_ARCH__ >=
+// 600.  If not satisfied, we provide a custom implementation using atomicCAS().
 // This implementation is copied from CUDA manual.
 CUDA_ATOMIC_WRAPPER(Add, double) {
   uint64* address_as_ull = reinterpret_cast<uint64*>(address);
@@ -179,6 +183,7 @@ CUDA_ATOMIC_WRAPPER(Add, double) {
 
   return __longlong_as_double(old);
 }
+#endif
 
 // Helper functions for CudaAtomicAdd(half*, half), below.
 //

--- a/tensorflow/core/util/cuda_kernel_helper.h
+++ b/tensorflow/core/util/cuda_kernel_helper.h
@@ -128,6 +128,25 @@ __device__ __host__ inline T ldg(const T* address) {
 #endif
 }
 
+template <typename T>
+__global__ void SetZero(const int nthreads, T* data) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) { *(data + index) = T(0); }
+}
+
+template <typename T>
+__global__ void SetConstant(const int nthreads, T* data, const T value) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {*(data + index) = value;}
+}
+
+template <typename T>
+__global__ void ReplaceValue(const int nthreads, T* data, const T old_value, const T new_value) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    if (*(data + index) == old_value) {
+      *(data + index) = new_value;
+    }
+  }
+}
+
 // CUDA provides atomic ops, but not for all types.  We provide wrappers
 // for some ops and provide implementation for all reasonable types.
 #define CUDA_ATOMIC_WRAPPER(op, T) \
@@ -354,25 +373,6 @@ CUDA_ATOMIC_WRAPPER(Max, Eigen::half) {
     Eigen::half ret;
     ret.x = old >> 16;
     return ret;
-  }
-}
-
-template <typename T>
-__global__ void SetZero(const int nthreads, T* data) {
-  CUDA_1D_KERNEL_LOOP(index, nthreads) { *(data + index) = T(0); }
-}
-
-template <typename T>
-__global__ void SetConstant(const int nthreads, T* data, const T value) {
-  CUDA_1D_KERNEL_LOOP(index, nthreads) {*(data + index) = value;}
-}
-
-template <typename T>
-__global__ void ReplaceValue(const int nthreads, T* data, const T old_value, const T new_value) {
-  CUDA_1D_KERNEL_LOOP(index, nthreads) {
-    if (*(data + index) == old_value) {
-      *(data + index) = new_value;
-    }
   }
 }
 

--- a/tensorflow/core/util/cuda_kernel_helper.h
+++ b/tensorflow/core/util/cuda_kernel_helper.h
@@ -253,8 +253,8 @@ CUDA_ATOMIC_WRAPPER(Add, Eigen::half) {
 }
 
 template <typename T>
-__global__ void SetZero(const int nthreads, T* bottom_diff) {
-  CUDA_1D_KERNEL_LOOP(index, nthreads) { *(bottom_diff + index) = T(0); }
+__global__ void SetZero(const int nthreads, T* data) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) { *(data + index) = T(0); }
 }
 
 // For atomicSub.

--- a/tensorflow/core/util/cuda_kernel_helper_test.cc
+++ b/tensorflow/core/util/cuda_kernel_helper_test.cc
@@ -1,0 +1,66 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA
+
+
+#include <thrust/host_vector.h>
+#include <thrust/device_vector.h>
+
+#include "tensorflow/core/platform/test.h"
+
+#include "tensorflow/core/util/cuda_kernel_helper.h"
+
+namespace tensorflow {
+
+TEST(SetConstantTest, RandomValue) {
+  std::random_device r;
+  std::default_random_engine engine(r());
+  std::uniform_int_distribution<float> uniform_dist(0.0f, 1.0f);
+  const float random_value = uniform_dist(engine);
+
+  const int element_num = 4096;
+  thrust::device_vector<float> vec_d(element_num);
+
+  GPUDevice d;
+  const int32 count = element_num;
+  CudaLaunchConfig config = GetCudaLaunchConfig(count, d);
+  SetConstant<float><<<config.block_count, config.thread_per_block, 0, d.stream()>>>
+    (config.virtual_thread_count, thrust::raw_pointer_cast(vec_d.data()), random_value);
+
+  thrust::host_vector<float> vec_h = vec_d;
+  for (int i = 0; i < element_num; ++ i) {
+    EXPECT_EQ(vec_h[i], random_value);
+  }
+}
+
+TEST(ReplaceValueTest, RandomValue) {
+}
+
+TEST(CudaAtomicAddTest, DoubleType) {
+}
+
+TEST(CudaAtomicMaxTest, FloatType) {
+}
+
+TEST(CudaAtomicMaxTest, DoubleType) {
+}
+
+TEST(CudaAtomicMaxTest, HalfType) {
+}
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA


### PR DESCRIPTION
Changes on functionality:
1. Use native atomicAdd for double if `__CUDA_ARCH__ >= 600`.
2. Add max wrappers for float, double and Eigen::half.
3. Add `SetConstant` and `ReplaceValue` kernels. They are useful for example, when doing element-wise max: `SetConstant` to MIN, do max(), then `ReplaceValue` MIN with some friendly values, like zeros.

Changes on readability:
1. `SetZero(const int nthreads, T* bottom_diff)` to `SetZero(const int nthreads, T* data)`, `bottom_diff` maybe is from Caffe ;-), and is irrelevant here.
2. Reorder Add and Max wrappers, to make them better grouped together.