### PR TITLE
Disable building the MatrixDiag and OneHot kernels for GPU on Windows.

### DIFF
--- a/tensorflow/contrib/cmake/tf_core_kernels.cmake
+++ b/tensorflow/contrib/cmake/tf_core_kernels.cmake
@@ -112,7 +112,11 @@ if(WIN32 AND tensorflow_ENABLE_GPU)
   add_dependencies(tf_core_kernels_cpu_only tf_core_cpu)
   # Undefine GOOGLE_CUDA to avoid registering unsupported GPU kernel symbols.
   get_target_property(target_compile_flags tf_core_kernels_cpu_only COMPILE_FLAGS)
-  set(target_compile_flags "${target_compile_flags} /UGOOGLE_CUDA")
+  if(target_compile_flags STREQUAL "target_compile_flags-NOTFOUND")
+    set(target_compile_flags "/UGOOGLE_CUDA")
+  else()
+    set(target_compile_flags "${target_compile_flags} /UGOOGLE_CUDA")
+  endif()
   set_target_properties(tf_core_kernels_cpu_only PROPERTIES COMPILE_FLAGS ${target_compile_flags})
 endif(WIN32 AND tensorflow_ENABLE_GPU)
 

--- a/tensorflow/contrib/cmake/tf_core_kernels.cmake
+++ b/tensorflow/contrib/cmake/tf_core_kernels.cmake
@@ -102,6 +102,20 @@ file(GLOB_RECURSE tf_core_gpu_kernels_srcs
    "${tensorflow_source_dir}/tensorflow/contrib/rnn/kernels/*.cu.cc"
 )
 
+if(WIN32 AND tensorflow_ENABLE_GPU)
+  file(GLOB_RECURSE tf_core_kernels_cpu_only_srcs
+      # GPU implementation not working on Windows yet.
+      "${tensorflow_source_dir}/tensorflow/core/kernels/matrix_diag_op.cc"
+      "${tensorflow_source_dir}/tensorflow/core/kernels/one_hot_op.cc")
+  list(REMOVE_ITEM tf_core_kernels_srcs ${tf_core_kernels_cpu_only_srcs})
+  add_library(tf_core_kernels_cpu_only OBJECT ${tf_core_kernels_srcs})
+  add_dependencies(tf_core_kernels_cpu_only tf_core_cpu)
+  # Undefine GOOGLE_CUDA to avoid registering unsupported GPU kernel symbols.
+  get_target_property(target_compile_flags tf_core_kernels_cpu_only COMPILE_FLAGS)
+  set(target_compile_flags "${target_compile_flags} /UGOOGLE_CUDA")
+  set_target_properties(tf_core_kernels_cpu_only PROPERTIES COMPILE_FLAGS ${target_compile_flags})
+endif(WIN32 AND tensorflow_ENABLE_GPU)
+
 add_library(tf_core_kernels OBJECT ${tf_core_kernels_srcs})
 add_dependencies(tf_core_kernels tf_core_cpu)
 

--- a/tensorflow/contrib/cmake/tf_core_kernels.cmake
+++ b/tensorflow/contrib/cmake/tf_core_kernels.cmake
@@ -108,7 +108,7 @@ if(WIN32 AND tensorflow_ENABLE_GPU)
       "${tensorflow_source_dir}/tensorflow/core/kernels/matrix_diag_op.cc"
       "${tensorflow_source_dir}/tensorflow/core/kernels/one_hot_op.cc")
   list(REMOVE_ITEM tf_core_kernels_srcs ${tf_core_kernels_cpu_only_srcs})
-  add_library(tf_core_kernels_cpu_only OBJECT ${tf_core_kernels_srcs})
+  add_library(tf_core_kernels_cpu_only OBJECT ${tf_core_kernels_cpu_only_srcs})
   add_dependencies(tf_core_kernels_cpu_only tf_core_cpu)
   # Undefine GOOGLE_CUDA to avoid registering unsupported GPU kernel symbols.
   get_target_property(target_compile_flags tf_core_kernels_cpu_only COMPILE_FLAGS)

--- a/tensorflow/contrib/cmake/tf_python.cmake
+++ b/tensorflow/contrib/cmake/tf_python.cmake
@@ -584,6 +584,7 @@ add_library(pywrap_tensorflow SHARED
     $<TARGET_OBJECTS:tf_core_direct_session>
     $<$<BOOL:${tensorflow_ENABLE_GRPC_SUPPORT}>:$<TARGET_OBJECTS:tf_core_distributed_runtime>>
     $<TARGET_OBJECTS:tf_core_kernels>
+    $<$<BOOL:${tensorflow_ENABLE_GPU}>:$<TARGET_OBJECTS:tf_core_kernels_cpu_only>>
     $<$<BOOL:${tensorflow_ENABLE_GPU}>:$<TARGET_OBJECTS:tf_stream_executor>>
 )
 target_include_directories(pywrap_tensorflow PUBLIC

--- a/tensorflow/contrib/cmake/tf_tests.cmake
+++ b/tensorflow/contrib/cmake/tf_tests.cmake
@@ -148,6 +148,7 @@ if (tensorflow_BUILD_PYTHON_TESTS)
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/variable_scope_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/reshape_op_test.py"
       "${tensorflow_source_dir}/tensorflow/tensorboard/backend/server_test.py"
+      "${tensorflow_source_dir}/tensorflow/python/kernel_tests/diag_op_test.py"  # Silently failing with GPU kernel disabled.
       # int32/int64 mixup
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/functional_ops_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/py_func_test.py"

--- a/tensorflow/contrib/cmake/tf_tests.cmake
+++ b/tensorflow/contrib/cmake/tf_tests.cmake
@@ -151,10 +151,6 @@ if (tensorflow_BUILD_PYTHON_TESTS)
       # int32/int64 mixup
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/functional_ops_test.py"
       "${tensorflow_source_dir}/tensorflow/python/kernel_tests/py_func_test.py"
-      # cuda launch failed
-      "${tensorflow_source_dir}/tensorflow/python/kernel_tests/diag_op_test.py"
-      "${tensorflow_source_dir}/tensorflow/python/kernel_tests/trace_op_test.py"
-      "${tensorflow_source_dir}/tensorflow/python/kernel_tests/one_hot_op_test.py" # gpu, T=uint8
       # training tests
       "${tensorflow_source_dir}/tensorflow/python/training/basic_session_run_hooks_test.py"  # Needs tf.contrib fix.
       "${tensorflow_source_dir}/tensorflow/python/training/localhost_cluster_performance_test.py"  # Needs portpicker.


### PR DESCRIPTION
This is a temporary workaround for issue #6509, while the root cause of the runtime errors is under investigation.