### PR TITLE
./configure: A better way to exclude fetching //tensorflow/examples/android/...

### DIFF
--- a/configure
+++ b/configure
@@ -23,13 +23,8 @@ function bazel_clean_and_fetch() {
   # TODO(pcloudy): Re-enable it after bazel clean --expunge is fixed.
   if ! is_windows; then
     bazel clean --expunge
-    # TODO(https://github.com/bazelbuild/bazel/issues/2220) Remove the nested `bazel query`.
-    bazel fetch $(bazel query "//tensorflow/... -//tensorflow/examples/android/...")
-  else
-    # TODO(pcloudy): Also filter out //tensorflow/examples/android/... on Windows after
-    # https://github.com/bazelbuild/bazel/issues/2248 is fixed.
-    bazel fetch //tensorflow/...
   fi
+  bazel fetch "//tensorflow/... -//tensorflow/examples/android/..."
 }
 
 ## Set up python-related environment settings


### PR DESCRIPTION
Bazel at HEAD currently [breaks TF Windows build](http://ci.bazel.io/job/TensorFlow/BAZEL_VERSION=HEAD,PLATFORM_NAME=windows-x86_64/601/console).

After https://github.com/bazelbuild/bazel/commit/0b9ebfee8d7f3bd5cf68f4dba4790bf3fed9349d, `//tensorflow/examples/android/...` has to be excluded during bazel fetch.

Using the workaround mentioned in https://github.com/bazelbuild/bazel/issues/2220, so that it works on both Linux and Windows.

@gunan 