### PR TITLE
Update einsum to check whether uncompacted_shape has multiple None values

### DIFF
--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -340,6 +340,22 @@ def _einsum_reduction(t0, t0_axis_labels, t1, t1_axis_labels, axes_to_sum):
         t0_shape[:len(preserved_axes)+len(broadcast_axes[0])] +
         t1_shape[len(t1_shape)-len(broadcast_axes[1]):]
     )
+
+    # Check the number of None values and replace them with Tensors containing
+    # corresponding dimensions if there exist two or more None values
+    num_none_dims = sum(1 for d in uncompacted_shape if d is None)
+    if num_none_dims > 1:
+      uncompacted_shape = list(uncompacted_shape)
+      for i in xrange(len(uncompacted_shape)):
+        if uncompacted_shape[i] is None:
+          if i < len(preserved_axes) + len(broadcast_axes[0]):
+            uncompacted_shape[i] = array_ops.shape(inputs[0])[i]
+          else:
+            idx = (i - len(preserved_axes) - len(broadcast_axes[0])
+                   + len(t1_shape) - len(broadcast_axes[1]))
+            uncompacted_shape[i] = array_ops.shape(inputs[1])[idx]
+      uncompacted_shape = tuple(uncompacted_shape)
+
     product = _reshape_if_necessary(product, uncompacted_shape)
 
     product_axes = (

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -308,6 +308,18 @@ class EinsumTest(test.TestCase):
         np.testing.assert_almost_equal(
             [[[7]]], sess.run(out, feed_dict=feed_dict))
 
+    with ops.Graph().as_default():
+      m0 = array_ops.placeholder(dtypes.int32, shape=(None, None, 2))
+      m1 = array_ops.placeholder(dtypes.int32, shape=(2,))
+      out = special_math_ops.einsum('ijk,k->ij', m0, m1)
+      with session.Session() as sess:
+        feed_dict = {
+            m0: [[[1, 2]]],
+            m1: [3, 2],
+        }
+        np.testing.assert_almost_equal(
+            [[7]], sess.run(out, feed_dict=feed_dict))
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -283,6 +283,31 @@ class EinsumTest(test.TestCase):
         }
         np.testing.assert_almost_equal([7], sess.run(out, feed_dict=feed_dict))
 
+    # Tests for placeholders which have two or more None values
+    with ops.Graph().as_default():
+      m0 = array_ops.placeholder(dtypes.int32, shape=(None, None, 2))
+      m1 = array_ops.placeholder(dtypes.int32, shape=(2, 1))
+      out = special_math_ops.einsum('ijk,kl->ijl', m0, m1)
+      with session.Session() as sess:
+        feed_dict = {
+            m0: [[[1,2]]],
+            m1: [[3], [2]],
+        }
+        np.testing.assert_almost_equal(
+            [[[7]]], sess.run(out, feed_dict=feed_dict))
+
+    with ops.Graph().as_default():
+      m0 = array_ops.placeholder(dtypes.int32, shape=(2, 1))
+      m1 = array_ops.placeholder(dtypes.int32, shape=(None, None, 2))
+      out = special_math_ops.einsum('kl,ijk->ijl', m0, m1)
+      with session.Session() as sess:
+        feed_dict = {
+            m0: [[3], [2]],
+            m1: [[[1,2]]],
+        }
+        np.testing.assert_almost_equal(
+            [[[7]]], sess.run(out, feed_dict=feed_dict))
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Fixes #6824.
It checks `uncompacted_shape`, which contains the 'final' shape of `matmul` of two tensors, if it contains two or more `None` values.
If `uncompacted_shape` contains two or more `None` values, it means that it cannot be directly given to `reshape` as parameter.
This PR resolves this issue, by querying the dimension value using `tf.shape` function for that case.