### PR TITLE
Set NDK_ROOT in android_full.sh to fix Makefile build

### DIFF
--- a/tensorflow/tools/ci_build/builds/android_full.sh
+++ b/tensorflow/tools/ci_build/builds/android_full.sh
@@ -67,4 +67,7 @@ cp bazel-bin/tensorflow/examples/android/tensorflow_demo.apk \
     bazel-bin/tensorflow/contrib/android/libandroid_tensorflow_inference_java.jar ${OUT_DIR}
 
 # Test Makefile build just to make sure it still works.
+if [ -z "$NDK_ROOT" ]; then
+   export NDK_ROOT=${ANDROID_NDK_HOME}
+fi
 tensorflow/contrib/makefile/build_all_android.sh


### PR DESCRIPTION
tensorflow/contrib/makefile/build_all_android.sh disagrees about the environment variable to use. This seems the easiest fix with the least chance of breaking anything else.