### PR TITLE
temporarily add /sbin to PATH for ldconfig call

### DIFF
--- a/configure
+++ b/configure
@@ -352,7 +352,12 @@ while true; do
   fi
 
   if [ "$OSNAME" == "Linux" ]; then
+    PATH_BEFORE_LDCONFIG="$PATH"
+    PATH="$PATH":/sbin
+    export PATH
     CUDNN_PATH_FROM_LDCONFIG="$(ldconfig -p | sed -n 's/.*libcudnn.so .* => \(.*\)/\1/p')"
+    PATH="$PATH_BEFORE_LDCONFIG"
+    export PATH
     if [ -e "${CUDNN_PATH_FROM_LDCONFIG}${TF_CUDNN_EXT}" ]; then
       export TF_CUDNN_VERSION
       export CUDNN_INSTALL_PATH="$(dirname ${CUDNN_PATH_FROM_LDCONFIG})"


### PR DESCRIPTION
For issue #6762 (keeping the PATH changes local to where it is used instead of making it global as initially suggested).