### PR TITLE
The type of `seq_len_max` should be int64

### DIFF
--- a/tensorflow/contrib/rnn/python/ops/lstm_ops.py
+++ b/tensorflow/contrib/rnn/python/ops/lstm_ops.py
@@ -635,7 +635,7 @@ class LSTMBlockFusedCell(LSTMBlockWrapper):
       wci = wco = wcf = array_ops.zeros([self._num_units], dtype=dtype)
 
     if sequence_length is None:
-      max_seq_len = time_len
+      max_seq_len = math_ops.to_int64(time_len)
     else:
       max_seq_len = math_ops.to_int64(math_ops.reduce_max(sequence_length))
 


### PR DESCRIPTION
If the `sequence_length` is not given, `max_seq_len` will be assigned to `time_len`.
By default, the type of `time_len` is `tf.int32`. But we need `tf.int64`.
So we need to cast it to `int64`, too. (Just like line 640)