### PR TITLE
Remove overly restrictive check on gradient types.

### DIFF
--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -160,6 +160,12 @@ class DType(object):
                                                    np.floating)
 
   @property
+  def is_real(self):
+    """Return whether this is a representation of a real floating point type.
+    Can be quantized."""
+    return self.base_dtype in (float16, float32, float64, bfloat16)
+
+  @property
   def is_complex(self):
     """Returns whether this is a complex floating point type."""
     return self.base_dtype in (complex64, complex128)

--- a/tensorflow/python/ops/gradients_impl.py
+++ b/tensorflow/python/ops/gradients_impl.py
@@ -225,12 +225,6 @@ def _DefaultGradYs(grad_ys, ys, colocate_gradients_with_ops):
         grad_ys[i] = array_ops.fill(
             array_ops.shape(y), constant_op.constant(
                 1, dtype=y.dtype))
-    else:
-      if grad_y.dtype != y.dtype:
-        raise ValueError("Y and ys_grad must be of the same type, "
-                         "not y: %s, ys_grad: %s " %
-                         (dtypes.as_dtype(y.dtype).name,
-                          dtypes.as_dtype(grad_y.dtype).name))
   return grad_ys
 
 

--- a/tensorflow/python/ops/gradients_impl.py
+++ b/tensorflow/python/ops/gradients_impl.py
@@ -241,7 +241,7 @@ def _IsTrainable(tensor):
 
 
 def _VerifyGeneratedGradients(grads, op):
-  """Verify that gradients are valid in number and type.
+  """Verify that gradients are valid in number.
 
   Args:
     grads: List of generated gradients.
@@ -253,15 +253,6 @@ def _VerifyGeneratedGradients(grads, op):
   if len(grads) != len(op.inputs):
     raise ValueError("Num gradients %d generated for op %s do not match num "
                      "inputs %d" % (len(grads), op.node_def, len(op.inputs)))
-  for i in xrange(len(grads)):
-    grad = grads[i]
-    inp = op.inputs[i]
-    if grad is not None:
-      if not grad.dtype.is_compatible_with(inp.dtype):
-        raise ValueError("Gradient type %s generated for op %s does "
-                         "not match input type %s" %
-                         (dtypes.as_dtype(grad.dtype).name, op.node_def,
-                          dtypes.as_dtype(inp.dtype).name))
 
 
 def _StopOps(from_ops, pending_count):

--- a/tensorflow/python/ops/gradients_impl.py
+++ b/tensorflow/python/ops/gradients_impl.py
@@ -229,21 +229,21 @@ def _DefaultGradYs(grad_ys, ys, colocate_gradients_with_ops):
       continue
     if y.dtype.is_real or y.dtype.is_integer:
       if not grad_y.dtype.is_real and not grad_y.dtype.is_integer:
-          raise TypeError("Gradient type %s generated for real or "
-                           "integer-valued tensor %s with type %s must be "
-                           "real or integer" %
-                           (dtypes.as_dtype(grad_y.dtype).name, y,
-                            dtypes.as_dtype(y.dtype).name))
+        raise TypeError("Gradient type %s generated for real or "
+                         "integer-valued tensor %s with type %s must be "
+                         "real or integer" %
+                         (dtypes.as_dtype(grad_y.dtype).name, y,
+                          dtypes.as_dtype(y.dtype).name))
     elif y.dtype.is_complex:
       if not grad_y.dtype.is_complex:
-          raise TypeError("Gradient type %s generated for complex-valued "
-                           "tensor %s with type %s must be real" %
-                           (dtypes.as_dtype(grad_y.dtype).name, y,
-                            dtypes.as_dtype(y.dtype).name))
+        raise TypeError("Gradient type %s generated for complex-valued "
+                         "tensor %s with type %s must be real" %
+                         (dtypes.as_dtype(grad_y.dtype).name, y,
+                          dtypes.as_dtype(y.dtype).name))
     else:
       raise TypeError("Tensor %s with type %s must be numeric "
-                       "to obtain a default gradient" %
-                       (y, dtypes.as_dtype(y.dtype).name))
+                      "to obtain a default gradient" %
+                      (y, dtypes.as_dtype(y.dtype).name))
   return grad_ys
 
 

--- a/tensorflow/python/ops/gradients_impl.py
+++ b/tensorflow/python/ops/gradients_impl.py
@@ -253,7 +253,13 @@ def _VerifyGeneratedGradients(grads, op):
   if len(grads) != len(op.inputs):
     raise ValueError("Num gradients %d generated for op %s do not match num "
                      "inputs %d" % (len(grads), op.node_def, len(op.inputs)))
-
+  for grad in grads:
+    if grad is None:
+      continue
+    if not (grad.dtype.is_floating or grad.dtype.is_quantized or
+            grad.dtype.is_integer or grad.dtype.is_complex):
+      raise ValueError("Gradient type %s generated for op %s is not numeric" %
+                       (dtypes.as_dtype(grad.dtype).name, op.node_def))
 
 def _StopOps(from_ops, pending_count):
   """The set of ops that terminate the gradient computation.

--- a/tensorflow/python/ops/gradients_impl.py
+++ b/tensorflow/python/ops/gradients_impl.py
@@ -212,7 +212,8 @@ def _DefaultGradYs(grad_ys, ys, colocate_gradients_with_ops):
     A list of gradients to use, without None.
 
   Raises:
-    ValueError: If one of the grad_ys is invalid.
+    ValueError: If sizes of gradients and inputs don't match
+    TypeError: If type of any gradient is not valid for its input.
   """
   if len(grad_ys) != len(ys):
     raise ValueError("Passed %d grad_ys for %d ys" % (len(grad_ys), len(ys)))
@@ -228,19 +229,19 @@ def _DefaultGradYs(grad_ys, ys, colocate_gradients_with_ops):
       continue
     if y.dtype.is_real or y.dtype.is_integer:
       if not grad_y.dtype.is_real and not grad_y.dtype.is_integer:
-          raise ValueError("Gradient type %s generated for real or "
+          raise TypeError("Gradient type %s generated for real or "
                            "integer-valued tensor %s with type %s must be "
                            "real or integer" %
                            (dtypes.as_dtype(grad_y.dtype).name, y,
                             dtypes.as_dtype(y.dtype).name))
     elif y.dtype.is_complex:
       if not grad_y.dtype.is_complex:
-          raise ValueError("Gradient type %s generated for complex-valued "
+          raise TypeError("Gradient type %s generated for complex-valued "
                            "tensor %s with type %s must be real" %
                            (dtypes.as_dtype(grad_y.dtype).name, y,
                             dtypes.as_dtype(y.dtype).name))
     else:
-      raise ValueError("Tensor %s with type %s must be numeric "
+      raise TypeError("Tensor %s with type %s must be numeric "
                        "to obtain a default gradient" %
                        (y, dtypes.as_dtype(y.dtype).name))
   return grad_ys
@@ -260,7 +261,8 @@ def _VerifyGeneratedGradients(grads, op):
     op: Operation for which the gradients where generated.
 
   Raises:
-    ValueError: if the gradients are invalid.
+    ValueError: if sizes of gradients and inputs don't match.
+    TypeError: if type of any gradient is not valid for its input.
   """
   if len(grads) != len(op.inputs):
     raise ValueError("Num gradients %d generated for op %s do not match num "
@@ -272,18 +274,18 @@ def _VerifyGeneratedGradients(grads, op):
         continue
       if grad.dtype.is_real:
         if not inp.dtype.is_real:
-          raise ValueError("Gradient type %s generated for real-valued op %s "
+          raise TypeError("Gradient type %s generated for real-valued op %s "
                            "with type %s must be real" %
                            (dtypes.as_dtype(grad.dtype).name, op.node_def,
                             dtypes.as_dtype(inp.dtype).name))
       elif grad.dtype.is_complex:
         if not inp.dtype.is_complex:
-          raise ValueError("Gradient type %s generated for complex-valued op %s"
+          raise TypeError("Gradient type %s generated for complex-valued op %s"
                            " with type %s must be complex" %
                            (dtypes.as_dtype(grad.dtype).name, op.node_def,
                             dtypes.as_dtype(inp.dtype).name))
       else:
-        raise ValueError("Gradient type %s generated for op %s "
+        raise TypeError("Gradient type %s generated for op %s "
                          "with type %s must be either real or complex" %
                          (dtypes.as_dtype(grad.dtype).name, op.node_def,
                           dtypes.as_dtype(inp.dtype).name))


### PR DESCRIPTION
Fixes #6858 

Currently gradient computation `input.is_compatible_with(backprop)` for every input. This fails if we have float16 activations and float32 backprops (ie `tf.float32.is_compatible_with(tf.float16)` returns False), this PR removes this check.