### PR TITLE
Added possible responses for uname on Windows, fixes #6871

### DIFF
--- a/configure
+++ b/configure
@@ -11,7 +11,7 @@ popd > /dev/null
 PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
 function is_windows() {
   # On windows, the shell script is actually running in msys
-  if [[ "${PLATFORM}" =~ msys_nt* ]]; then
+  if [[ "${PLATFORM}" =~ msys_nt*|mingw*|cygwin*|uwin* ]]; then
     true
   else
     false


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Uname#Examples, other responses
are possible on Windows, added mingw, cygwin, and uwin