### PR TITLE
Use local variable for match_input_once to avoid saving it in checkpoint

### DIFF
--- a/tensorflow/python/training/input.py
+++ b/tensorflow/python/training/input.py
@@ -63,7 +63,8 @@ def match_filenames_once(pattern, name=None):
   """
   with ops.name_scope(name, "matching_filenames", [pattern]) as name:
     return variables.Variable(io_ops.matching_files(pattern), trainable=False,
-                              name=name, validate_shape=False)
+                              name=name, validate_shape=False,
+                              collections=[ops.GraphKeys.LOCAL_VARIABLES])
 
 
 def limit_epochs(tensor, num_epochs=None, name=None):


### PR DESCRIPTION
Fixes #6786 