### PR TITLE
Feature: log-log scale

### DIFF
--- a/tensorflow/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
+++ b/tensorflow/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
@@ -34,6 +34,7 @@ Generic layout for a dashboard.
     <style include="scrollbar-style"></style>
     <style>
       #sidebar {
+        border-right: solid 1px rgba(0, 0, 0, 0.12);
         width: inherit;
         height: 100%;
         overflow: ellipsis;

--- a/tensorflow/tensorboard/components/tf_scalar_dashboard/tf-line-chart-sidebar.html
+++ b/tensorflow/tensorboard/components/tf_scalar_dashboard/tf-line-chart-sidebar.html
@@ -1,0 +1,123 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
+<link rel="import" href="../paper-scroll-header-panel/paper-scroll-header-panel.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+
+<!--
+tf-sidebar creates an input component for exponential smoothing.
+-->
+<dom-module id="tf-line-chart-sidebar">
+  <template>
+    <paper-scroll-header-panel fixed>
+      <div class="paper-header">
+        <paper-icon-button
+          class="sidebar-close-button"
+          icon="arrow-back"
+          on-tap="_closeSidebar"
+          title="Close sidebar"
+          ></paper-icon-button>
+          [[chart.title]]
+      </div>
+      <div class="sidebar-section">
+        <h4>Y-Axis</h4>
+        <tf-option-selector
+          id="yScaleTypeSelector"
+          name="Scale"
+          selected-id="{{yScaleType}}"
+          >
+          <paper-button id="linear">Linear</paper-button>
+          <paper-button id="log">Log</paper-button>
+        </tf-option-selector>
+      </div>
+      <div class="sidebar-section">
+        <h4>X-Axis</h4>
+        <tf-option-selector
+          id="xScaleTypeSelector"
+          name="Scale"
+          selected-id="{{xScaleType}}"
+          >
+          <paper-button id="linear">Linear</paper-button>
+          <paper-button id="log">Log</paper-button>
+        </tf-option-selector>
+      </div>
+    </paper-scroll-header-panel>
+    <style is="custom-style" include="dashboard-style"></style>
+    <style>
+      .paper-header {
+        align-items: center;
+        background-color: #fff;
+        display: flex;
+        height: 50px;
+        margin-top: 2px;
+      }
+
+      .sidebar-section {
+        flex-direction: column;
+      }
+    </style>
+  </template>
+  <script>
+    Polymer({
+      is: "tf-line-chart-sidebar",
+
+      properties: {
+        chart: {
+          type: Object,
+          notify: true
+        },
+        yScaleType: {
+          type: String,
+          value: 'linear'
+        },
+        xScaleType: {
+          type: String,
+          value: 'linear'
+        }
+      },
+
+      observers: [
+        '_toggleYLogScale(chart, yScaleType)',
+        '_toggleXLogScale(chart, xScaleType)'
+      ],
+
+      _closeSidebar: function() {
+        this.chart = null;
+      },
+
+      _toggleYLogScale: function(chart, yScaleType) {
+        if (!chart) {
+          return;
+        }
+
+        chart.instance.yScaleType = yScaleType;
+        chart.instance.redraw();
+      },
+
+      _toggleXLogScale: function(chart, xScaleType) {
+        if (!chart) {
+          return;
+        }
+
+        chart.instance.xScaleType = xScaleType;
+        chart.instance.redraw();
+      }
+    });
+  </script>
+</dom-module>

--- a/tensorflow/tensorboard/components/tf_scalar_dashboard/tf-scalar-dashboard-sidebar.html
+++ b/tensorflow/tensorboard/components/tf_scalar_dashboard/tf-scalar-dashboard-sidebar.html
@@ -1,0 +1,167 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="tf-smoothing-input.html">
+<link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
+<link rel="import" href="../tf-dashboard-common/tf-sidebar-helper.html">
+<link rel="import" href="../paper-checkbox/paper-checkbox.html">
+<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../paper-menu/paper-menu.html">
+<link rel="import" href="../paper-item/paper-item.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+
+<!--
+tf-sidebar creates an input component for exponential smoothing.
+-->
+<dom-module id="tf-scalar-dashboard-sidebar">
+  <template>
+    <tf-sidebar-helper
+      backend="[[backend]]"
+      categories="{{categories}}"
+      color-scale="[[colorScale]]"
+      run2tag="[[run2tag]]"
+      runs="[[runs]]"
+      selected-runs="{{selectedRuns}}"
+      >
+      <div class="sidebar-section">
+        <paper-checkbox
+          id="download-option"
+          checked="{{showDownloadLinks}}"
+          >Data download links</paper-checkbox>
+        <div id="tooltip-sorting">
+          <div id="tooltip-sorting-label">Tooltip sorting method:</div>
+          <paper-dropdown-menu
+            no-label-float
+            selected-item-label="{{tooltipSortingMethod}}"
+            >
+            <paper-menu class="dropdown-content" selected="0">
+              <paper-item>default</paper-item>
+              <paper-item>descending</paper-item>
+              <paper-item>ascending</paper-item>
+              <paper-item>nearest</paper-item>
+            </paper-menu>
+          </paper-dropdown-menu>
+        </div>
+      </div>
+      <div class="sidebar-section">
+        <tf-smoothing-input
+          weight="{{smoothingWeight}}"
+          step="0.001"
+          min="0"
+          max="1"
+          ></tf-smoothing-input>
+      </div>
+      <div class="sidebar-section">
+        <tf-option-selector
+          id="xTypeSelector"
+          name="Horizontal Axis"
+          selected-id="{{xType}}"
+          >
+          <paper-button id="step">step</paper-button>
+          <paper-button id="relative">relative</paper-button>
+          <paper-button id="wall_time">wall</paper-button>
+        </tf-option-selector>
+      </div>
+    </tf-sidebar-helper>
+    <style is="custom-style" include="dashboard-style"></style>
+    <style>
+      #tooltip-sorting {
+        display: flex;
+        font-size: 14px;
+        margin-top: 5px;
+      }
+
+      #tooltip-sorting-label {
+        margin-top: 13px;
+        margin-left: 28px;
+      }
+
+      #tooltip-sorting paper-dropdown-menu {
+        margin-left: 10px;
+        --paper-input-container-focus-color: var(--tb-orange-strong);
+        width: 105px;
+      }
+    </style>
+  </template>
+  <script>
+    Polymer({
+      is: "tf-scalar-dashboard-sidebar",
+
+      properties: {
+        /**
+         * The backend object used to issue requests.
+         */
+        backend: Object,
+
+        /**
+         * This is an output of the categories that the user selected to
+         * separate the different tags. Each category here should be given its
+         * own collapsible pane.
+         */
+        categories: {
+          type: Array,
+          notify: true,
+        },
+
+        /**
+         * Input of the colors that are used for the user's runs.
+         */
+        colorScale: Object,
+
+        /**
+         * Map from runs to the valid tags that have them.
+         */
+        run2tag: Object,
+
+        /**
+         * Input of all valid runs that can be selected by the user.
+         */
+        runs: Array,
+
+        /**
+         * Outputs an array with the runs that are selected by the user (i.e.
+         * valid to be displayed).
+         */
+        selectedRuns: {
+          type: Array,
+          notify: true,
+        },
+
+        showDownloadLinks: {
+          type: Boolean,
+          notify: true
+        },
+
+        smoothingWeight: {
+          type: Number,
+          notify: true
+        },
+
+        tooltipSortingMethod: {
+          type: String,
+          notify: true
+        },
+
+        xType: {
+          type: String,
+          notify: true
+        }
+      },
+    });
+  </script>
+</dom-module>

--- a/tensorflow/tensorboard/components/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorflow/tensorboard/components/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -16,20 +16,16 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="tf-smoothing-input.html">
+<link rel="import" href="tf-line-chart-sidebar.html">
+<link rel="import" href="tf-scalar-dashboard-sidebar.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
-<link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
 <link rel="import" href="../tf-dashboard-common/tf-panes-helper.html">
-<link rel="import" href="../tf-dashboard-common/tf-sidebar-helper.html">
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../vz-line-chart/vz-line-chart.html">
 <link rel="import" href="../iron-collapse/iron-collapse.html">
-<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../paper-menu/paper-menu.html">
-<link rel="import" href="../paper-item/paper-item.html">
 
 <!--
 tf-scalar-dashboard is a complete frontend that loads runs from a backend,
@@ -55,58 +51,29 @@ contains vz-line-charts embedded inside tf-panes-helper's.
         out-color-scale="{{_colorScale}}"
       ></tf-color-scale>
     </div>
-
     <tf-dashboard-layout>
-      <div class="sidebar">
-        <tf-sidebar-helper
+      <template is="dom-if" if="{{!_selectedChart}}">
+        <tf-scalar-dashboard-sidebar
+          class="sidebar"
           backend="[[backend]]"
           categories="{{_categories}}"
           color-scale="[[_colorScale]]"
           run2tag="[[run2tag]]"
           runs="[[runs]]"
           selected-runs="{{_selectedRuns}}"
-          >
-          <div class="extend-first-section">
-            <paper-checkbox
-              id="download-option"
-              checked="{{_showDownloadLinks}}"
-              >Data download links</paper-checkbox>
-            <div id="tooltip-sorting">
-              <div id="tooltip-sorting-label">Tooltip sorting method:</div>
-              <paper-dropdown-menu
-                no-label-float
-                selected-item-label="{{_tooltipSortingMethod}}"
-                >
-                <paper-menu class="dropdown-content" selected="0">
-                  <paper-item>default</paper-item>
-                  <paper-item>descending</paper-item>
-                  <paper-item>ascending</paper-item>
-                  <paper-item>nearest</paper-item>
-                </paper-menu>
-              </paper-dropdown-menu>
-            </div>
-          </div>
-          <div class="sidebar-section">
-            <tf-smoothing-input
-              weight="{{_smoothingWeight}}"
-              step="0.001"
-              min="0"
-              max="1"
-              ></tf-smoothing-input>
-          </div>
-          <div class="sidebar-section">
-            <tf-option-selector
-              id="xTypeSelector"
-              name="Horizontal Axis"
-              selected-id="{{_xType}}"
-              >
-              <paper-button id="step">step</paper-button>
-              <paper-button id="relative">relative</paper-button>
-              <paper-button id="wall_time">wall</paper-button>
-            </tf-option-selector>
-          </div>
-        </tf-sidebar-helper>
-      </div>
+          show-download-links="{{_showDownloadLinks}}"
+          tooltip-sorting-method="{{_tooltipSortingMethod}}"
+          smoothing-weight="{{_smoothingWeight}}"
+          x-type="{{_xType}}"
+          ></tf-scalar-dashboard-sidebar>
+      </template>
+      <template is="dom-if" if="{{_selectedChart}}">
+        <tf-line-chart-sidebar
+          class="sidebar vertical"
+          chart="{{_selectedChart}}"
+          title=""
+          ></tf-line-chart-sidebar>
+      </template>
       <div class="center">
         <tf-panes-helper
           categories="[[_categories]]"
@@ -127,9 +94,9 @@ contains vz-line-charts embedded inside tf-panes-helper's.
               tooltip-sorting-method="[[_tooltipSortingMethod]]"
               ></vz-line-chart>
             <paper-icon-button
-              class="log-button"
-              icon="line-weight"
-              on-tap="toggleLogScale"
+              class="chart-settings-button"
+              icon="perm-data-setting"
+              on-tap="_toggleChartSettings"
               title="Toggle y-axis log scale"
               ></paper-icon-button>
           </template>
@@ -137,9 +104,8 @@ contains vz-line-charts embedded inside tf-panes-helper's.
       </div>
     </tf-dashboard-layout>
 
-    <style include="dashboard-style"></style>
     <style>
-      .log-button {
+      .chart-settings-button {
         position: absolute;
         left: 35px;
         bottom: -35px;
@@ -151,28 +117,15 @@ contains vz-line-charts embedded inside tf-panes-helper's.
         border-radius: 100%;
       }
 
-      .log-button-selected {
+      .chart-settings-button-selected {
         background: var(--tb-ui-light-accent);
       }
 
-      #tooltip-sorting {
-        display: flex;
-        font-size: 14px;
-        margin-top: 5px;
-      }
-
-      #tooltip-sorting-label {
-        margin-top: 13px;
-        margin-left: 28px;
-      }
-
-      #tooltip-sorting paper-dropdown-menu {
-        margin-left: 10px;
-        --paper-input-container-focus-color: var(--tb-orange-strong);
-        width: 105px;
+      .sidebar {
+        display: block;
+        width: 320px;
       }
     </style>
-
   </template>
 
   <script>
@@ -192,6 +145,10 @@ contains vz-line-charts embedded inside tf-panes-helper's.
         scalarUrl: {
           type: Function,
           computed: "_getScalarUrl(router)"
+        },
+        _selectedChart: {
+          type: Object,
+          value: false
         },
         _showDownloadLinks: {
           type: Boolean,
@@ -230,14 +187,16 @@ contains vz-line-charts embedded inside tf-panes-helper's.
       _computeSmoothingEnabled: function(_smoothingWeight) {
         return _smoothingWeight > 0;
       },
-      toggleLogScale: function(e) {
-        var currentTarget = Polymer.dom(e.currentTarget);
-        var button = currentTarget.parentNode.querySelector('.log-button');
-        var chart = currentTarget.parentNode.querySelector('vz-line-chart');
 
-        button.classList.toggle("log-button-selected");
-        chart.yScaleType = chart.yScaleType === 'log' ? 'linear' : 'log';
-        chart.redraw();
+      _toggleChartSettings: function(e) {
+        var currentTarget = Polymer.dom(e.currentTarget);
+        var card = currentTarget.parentNode.closest('.card');
+        var title = card.querySelector('.card-title').textContent;
+        var instance = card.querySelector('vz-line-chart');
+        this._selectedChart = {
+          title,
+          instance
+        };
       },
     });
   </script>

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-chart-helpers.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-chart-helpers.ts
@@ -72,16 +72,16 @@ module VZ.ChartHelpers {
 
   export interface XComponents {
     /* tslint:disable */
-    scale: Plottable.Scales.Linear|Plottable.Scales.Time,
-        axis: Plottable.Axes.Numeric|Plottable.Axes.Time,
-        accessor: Plottable.Accessor<number|Date>,
+    scale: Plottable.QuantitativeScale<number|Date>,
+    axis: Plottable.Axes.Numeric|Plottable.Axes.Time,
+    accessor: Plottable.Accessor<number|Date>,
     /* tslint:enable */
   }
 
   export let stepFormatter =
       Plottable.Formatters.siSuffix(STEP_FORMATTER_PRECISION);
-  export function stepX(): XComponents {
-    let scale = new Plottable.Scales.Linear();
+  export function stepX(xScaleType: string): XComponents {
+    let scale = getScaleFromType(xScaleType);
     let axis = new Plottable.Axes.Numeric(scale, 'bottom');
     axis.formatter(stepFormatter);
     return {
@@ -140,8 +140,8 @@ module VZ.ChartHelpers {
     let seconds = Math.floor(n);
     return ret + seconds + 's';
   };
-  export function relativeX(): XComponents {
-    let scale = new Plottable.Scales.Linear();
+  export function relativeX(xScaleType): XComponents {
+    let scale = getScaleFromType(xScaleType);
     return {
       scale: scale,
       axis: new Plottable.Axes.Numeric(scale, 'bottom'),
@@ -153,16 +153,27 @@ module VZ.ChartHelpers {
   // or null, etc. False for Infinity or -Infinity
   export let isNaN = (x) => +x !== x;
 
-  export function getXComponents(xType: string): XComponents {
+  export function getXComponents(xType: string, xScaleType: string = 'linear'): XComponents {
     switch (xType) {
       case 'step':
-        return stepX();
+        return stepX(xScaleType);
       case 'wall_time':
         return wallX();
       case 'relative':
-        return relativeX();
+        return relativeX(xScaleType);
       default:
         throw new Error('invalid xType: ' + xType);
+    }
+  }
+
+  export function getScaleFromType(scaleType: string):
+      Plottable.QuantitativeScale<number> {
+    if (scaleType === 'log') {
+      return new Plottable.Scales.ModifiedLog();
+    } else if (scaleType === 'linear') {
+      return new Plottable.Scales.Linear();
+    } else {
+      throw new Error('Unrecognized scale type ' + scaleType);
     }
   }
 }

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.html
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.html
@@ -193,6 +193,16 @@ such as different X scales (linear and temporal), tooltips and smoothing.
         },
 
         /**
+         * The scale for the x-axis. Allows:
+         * - "linear" - linear scale (Plottable.Scales.Linear)
+         * - "log" - modified-log scale (Plottable.Scales.ModifiedLog)
+         */
+        xScaleType: {
+          type: String,
+          value: 'linear'
+        },
+
+        /**
          * The scale for the y-axis. Allows:
          * - "linear" - linear scale (Plottable.Scales.Linear)
          * - "log" - modified-log scale (Plottable.Scales.ModifiedLog)
@@ -240,7 +250,7 @@ such as different X scales (linear and temporal), tooltips and smoothing.
         }
       },
       observers: [
-        "_makeChart(xType, yScaleType, colorScale, _attached)",
+        "_makeChart(xType, xScaleType, yScaleType, colorScale, _attached)",
         "_reloadFromCache(_chart)",
         "_smoothingChanged(smoothingEnabled, smoothingWeight, _chart)",
         "_tooltipSortingMethodChanged(tooltipSortingMethod, _chart)",
@@ -296,7 +306,7 @@ such as different X scales (linear and temporal), tooltips and smoothing.
         this.scopeSubtree(this.$.tooltip, true);
         this.scopeSubtree(this.$.chartsvg, true);
       },
-      _makeChart: function(xType, yScaleType, colorScale, _attached) {
+      _makeChart: function(xType, xScaleType, yScaleType, colorScale, _attached) {
         if (this._makeChartAsyncCallbackId !== null) {
           this.cancelAsync(this._makeChartAsyncCallbackId);
           this._makeChartAsyncCallbackId = null;
@@ -307,7 +317,7 @@ such as different X scales (linear and temporal), tooltips and smoothing.
           if (!this._attached) return;
           if (this._chart) this._chart.destroy();
           var tooltip = d3.select(this.$.tooltip);
-          var chart = new VZ.LineChart(xType, yScaleType, colorScale, tooltip);
+          var chart = new VZ.LineChart(xType, xScaleType, yScaleType, colorScale, tooltip);
           var svg = d3.select(this.$.chartsvg);
           chart.renderTo(svg);
           this._chart = chart;

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -49,7 +49,7 @@ module VZ {
     private targetSVG: d3.Selection<any>;
 
     constructor(
-        xType: string, yScaleType: string, colorScale: Plottable.Scales.Color,
+        xType: string, xScaleType: string, yScaleType: string, colorScale: Plottable.Scales.Color,
         tooltip: d3.Selection<any>) {
       this.seriesNames = [];
       this.name2datasets = {};
@@ -63,19 +63,19 @@ module VZ {
       // need to do a single bind, so we can deregister the callback from
       // old Plottable.Datasets. (Deregistration is done by identity checks.)
       this.onDatasetChanged = this._onDatasetChanged.bind(this);
-      this.buildChart(xType, yScaleType);
+      this.buildChart(xType, xScaleType, yScaleType);
     }
 
-    private buildChart(xType: string, yScaleType: string) {
+    private buildChart(xType: string, xScaleType:string, yScaleType: string) {
       if (this.outer) {
         this.outer.destroy();
       }
-      let xComponents = VZ.ChartHelpers.getXComponents(xType);
+      let xComponents = VZ.ChartHelpers.getXComponents(xType, xScaleType);
       this.xAccessor = xComponents.accessor;
       this.xScale = xComponents.scale;
       this.xAxis = xComponents.axis;
       this.xAxis.margin(0).tickLabelPadding(3);
-      this.yScale = LineChart.getYScaleFromType(yScaleType);
+      this.yScale = VZ.ChartHelpers.getScaleFromType(yScaleType);
       this.yAxis = new Plottable.Axes.Numeric(this.yScale, 'left');
       let yFormatter = VZ.ChartHelpers.multiscaleFormatter(
           VZ.ChartHelpers.Y_AXIS_FORMATTER_PRECISION);
@@ -462,17 +462,6 @@ module VZ {
         this.name2datasets[name] = new Plottable.Dataset([], {name: name});
       }
       return this.name2datasets[name];
-    }
-
-    static getYScaleFromType(yScaleType: string):
-        Plottable.QuantitativeScale<number> {
-      if (yScaleType === 'log') {
-        return new Plottable.Scales.ModifiedLog();
-      } else if (yScaleType === 'linear') {
-        return new Plottable.Scales.Linear();
-      } else {
-        throw new Error('Unrecognized yScale type ' + yScaleType);
-      }
     }
 
     /**


### PR DESCRIPTION
This PR addresses #6532 and adds a toggle-able chart configuration sidebar, which should be useful for adding additional chart configuration options in the future, i.e. #1141

![tb-scales2](https://cloud.githubusercontent.com/assets/4740651/22040029/551cf23e-dcb6-11e6-8d78-ee71462d500e.gif)

As it stands right now, the log scale is only applied to the x-axis when the unit is `steps` or `relative`, otherwise it ignores the configuration and uses a linear scale for `wall`. I'm not sure if thats the best approach and happy to make any modifications.

This is my first foray into Polymer and would appreciate any feedback :)