### PR TITLE
Fix warning initialize_all_variables is deprecated

### DIFF
--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -323,7 +323,7 @@ class DivAndModTest(test_util.TensorFlowTestCase):
       a = variables.Variable(2.)
       b = variables.Variable(4.)
       with self.test_session() as sess:
-        sess.run(variables.initialize_all_variables())
+        sess.run(variables.global_variables_initializer())
         c_grad = gradients.gradients(math_ops.divide(a, b), [a, b])
         self.assertAllEqual([x.eval() for x in c_grad], [.25, -.125])
         c_grad = gradients.gradients(math_ops.div(a, b), [a, b])


### PR DESCRIPTION
Replace initialize_all_variables with global_variables_initializer.