### PR TITLE
Make XLA command-line option to mnist_softmax_xla.py actually work.

### DIFF
--- a/tensorflow/examples/tutorials/mnist/mnist_softmax_xla.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_softmax_xla.py
@@ -102,6 +102,14 @@ if __name__ == '__main__':
       default='/tmp/tensorflow/mnist/input_data',
       help='Directory for storing input data')
   parser.add_argument(
-      '--xla', type=bool, default=True, help='Turn xla via JIT on')
+      '--no-xla',
+      dest='xla', action='store_false',
+      help='Turn xla via JIT off (default is on)')
+  parser.add_argument(
+      '--xla',
+      dest='xla', action='store_true',
+      help='Turn xla via JIT on (default is on)')
+  parser.set_defaults(xla=True)
+
   FLAGS, unparsed = parser.parse_known_args()
   tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)


### PR DESCRIPTION
The --xla command-line argument to mnist_softmax_xla.py is effectively always true, so the example on https://www.tensorflow.org/versions/master/experimental/xla/jit (i.e. `python mnist_softmax_xla.py --xla=false`) still runs XLA.  This PR gives the script --xla and --no-xla optional arguments, with --xla as the default.