### PR TITLE
fix typos in tensor constructor docs

### DIFF
--- a/tensorflow/core/framework/tensor.h
+++ b/tensorflow/core/framework/tensor.h
@@ -99,11 +99,12 @@ class Tensor {
   /// for details.
   explicit Tensor(DataType type);
 
-  Tensor(const Tensor& other);  /// Copy constructor.
+  /// Copy constructor.
+  Tensor(const Tensor& other);
 
-  // Move constructor.  After this call, <other> is safely destructible and can
-  // be assigned to, but other calls on it (e.g. shape manipulation) are not
-  // valid.
+  /// \brief Move constructor. After this call, <other> is safely destructible and can
+  /// be assigned to, but other calls on it (e.g. shape manipulation) are not
+  /// valid.
   Tensor(Tensor&& other);
 
   ~Tensor();


### PR DESCRIPTION
A fix for a minor typo in the tensor.h constructor docs. This was causing "Copy constructor" to appear under the move constructor declaration, and was hiding the move constructor description in the generated docs.