### PR TITLE
Passing config to MonitoredSession when using Estimator Class

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/estimator.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimator.py
@@ -978,7 +978,7 @@ class BaseEstimator(
           chief_only_hooks=chief_hooks + model_fn_ops.training_chief_hooks,
           save_checkpoint_secs=0,  # Saving is handled by a hook.
           save_summaries_steps=self._config.save_summary_steps,
-          config=None) as mon_sess:
+          config=self.config.tf_config) as mon_sess:
         loss = None
         while not mon_sess.should_stop():
           _, loss = mon_sess.run([model_fn_ops.train_op, model_fn_ops.loss])


### PR DESCRIPTION
While implementing my own Estimator class I noticed that although I supplied a RunConfig with `gpu_memory_fraction < 1`  all memory was allocated. After some investigation I think this is because the ConfigProto contained in the RunConfig is not passed to the MonitoredTrainingSession. 
Changing the argument in line 981 from `config=None` to `config=self.config.tf_config` did the trick for me.