### PR TITLE
Add methods to fill and read Tensors from Java NIO buffers.

### DIFF
--- a/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
+++ b/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
@@ -17,6 +17,10 @@ package org.tensorflow.contrib.android;
 
 import android.content.res.AssetManager;
 import android.util.Log;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
 import java.util.Random;
 
 /**
@@ -91,16 +95,31 @@ public class TensorFlowInferenceInterface {
    */
   public native void close();
 
-  // Methods for creating a native Tensor and filling it with values.
+  // Methods for taking a native Tensor and filling it with values from Java arrays.
   public native void fillNodeFloat(String inputName, int[] dims, float[] values);
   public native void fillNodeInt(String inputName, int[] dims, int[] values);
   public native void fillNodeDouble(String inputName, int[] dims, double[] values);
   public native void fillNodeByte(String inputName, int[] dims, byte[] values);
 
-  public native void readNodeFloat(String outputName, float[] values);
-  public native void readNodeInt(String outputName, int[] values);
-  public native void readNodeDouble(String outputName, double[] values);
-  public native void readNodeByte(String outputName, byte[] values);
+  // Methods for taking a native Tensor and filling it with values from Java
+  // native IO buffers.
+  public native void fillNodeFromFloatBuffer(String inputName, IntBuffer dims, FloatBuffer values);
+  public native void fillNodeFromIntBuffer(String inputName, IntBuffer dims, IntBuffer values);
+  public native void fillNodeFromDoubleBuffer(String inputName, IntBuffer dims, DoubleBuffer values);
+  public native void fillNodeFromByteBuffer(String inputName, IntBuffer dims, ByteBuffer values);
+
+  // Methods for taking reading from a native Tensor and copying the data into Java arrays.
+  public native int readNodeFloat(String outputName, float[] values);
+  public native int readNodeInt(String outputName, int[] values);
+  public native int readNodeDouble(String outputName, double[] values);
+  public native int readNodeByte(String outputName, byte[] values);
+
+  // Methods for taking reading from a native Tensor and copying the data into
+  // Java native IO buffers.
+  public native void readNodeIntoFloatBuffer(String outputName, FloatBuffer dst);
+  public native void readNodeIntoFloatBuffer(String outputName, IntBuffer dst);
+  public native void readNodeIntoFloatBuffer(String outputName, DoubleBuffer dst);
+  public native void readNodeIntoFloatBuffer(String outputName, ByteBuffer dst);
 
   /**
    * Canary method solely for determining if the tensorflow_inference native library should be

--- a/tensorflow/contrib/android/jni/tensorflow_inference_jni.h
+++ b/tensorflow/contrib/android/jni/tensorflow_inference_jni.h
@@ -35,10 +35,20 @@ extern "C" {
       JNIEnv * env, jobject thiz, jstring node_name, jintArray dims, \
       j##JAVA_DTYPE##Array arr)
 
-#define READ_NODE_SIGNATURE(DTYPE, JAVA_DTYPE)               \
-  JNIEXPORT jint TENSORFLOW_METHOD(readNode##DTYPE)(         \
-      JNIEnv * env, jobject thiz, jstring node_name_jstring, \
+#define FILL_NODE_NIO_BUFFER_SIGNATURE(DTYPE)                        \
+  JNIEXPORT void TENSORFLOW_METHOD(fillNodeFrom##DTYPE##Buffer)(     \
+      JNIEnv * env, jobject thiz, jstring node_name,                 \
+      jobject dims_buffer, jobject src_buffer)
+
+#define READ_NODE_SIGNATURE(DTYPE, JAVA_DTYPE)                       \
+  JNIEXPORT jint TENSORFLOW_METHOD(readNode##DTYPE)(                 \
+      JNIEnv * env, jobject thiz, jstring node_name,                 \
       j##JAVA_DTYPE##Array arr)
+
+#define READ_NODE_NIO_BUFFER_SIGNATURE(DTYPE)                        \
+  JNIEXPORT jint TENSORFLOW_METHOD(readNodeInto##DTYPE##Buffer)(     \
+      JNIEnv * env, jobject thiz, jstring node_name,                 \
+      jobject dst_buffer)
 
 JNIEXPORT void JNICALL TENSORFLOW_METHOD(testLoaded)(JNIEnv* env, jobject thiz);
 
@@ -61,10 +71,20 @@ FILL_NODE_SIGNATURE(Int, int);
 FILL_NODE_SIGNATURE(Double, double);
 FILL_NODE_SIGNATURE(Byte, byte);
 
+FILL_NODE_NIO_BUFFER_SIGNATURE(Float);
+FILL_NODE_NIO_BUFFER_SIGNATURE(Int);
+FILL_NODE_NIO_BUFFER_SIGNATURE(Double);
+FILL_NODE_NIO_BUFFER_SIGNATURE(Byte);
+
 READ_NODE_SIGNATURE(Float, float);
 READ_NODE_SIGNATURE(Int, int);
 READ_NODE_SIGNATURE(Double, double);
 READ_NODE_SIGNATURE(Byte, byte);
+
+READ_NODE_NIO_BUFFER_SIGNATURE(Float);
+READ_NODE_NIO_BUFFER_SIGNATURE(Int);
+READ_NODE_NIO_BUFFER_SIGNATURE(Double);
+READ_NODE_NIO_BUFFER_SIGNATURE(Byte);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
- This eliminates extra copies on Android apps where buffers are allocated in
  native memory (e.g., camera2 ImageReader Images, Bitmaps).