### PR TITLE
Clean up code block in sparse_tensor_dense_matmul

### DIFF
--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -1242,9 +1242,10 @@ def sparse_tensor_dense_matmul(sp_a,
   GPU: NVidia Tesla k40c
 
   Compiled with:
-  -c opt --config=cuda --copt=-mavx
+  `-c opt --config=cuda --copt=-mavx`
 
-  ```tensorflow/python/sparse_tensor_dense_matmul_op_test --benchmarks
+  ```
+  tensorflow/python/sparse_tensor_dense_matmul_op_test --benchmarks
   A sparse [m, k] with % nonzero values between 1% and 80%
   B dense [k, n]
 


### PR DESCRIPTION
The documentation section that gives an [output of a benchmark for `sparse_tensor_dense_matmul`](https://www.tensorflow.org/versions/master/api_docs/python/sparse_ops/math_operations#sparse_tensor_dense_matmul) is formatted incorrectly- this patch should fix the HTML rendering problems.