### PR TITLE
Check None for elapsed_secs in LoggingTensorHook

### DIFF
--- a/tensorflow/python/training/basic_session_run_hooks.py
+++ b/tensorflow/python/training/basic_session_run_hooks.py
@@ -174,13 +174,14 @@ class LoggingTensorHook(session_run_hook.SessionRunHook):
       original = np.get_printoptions()
       np.set_printoptions(suppress=True)
       elapsed_secs, _ = self._timer.update_last_triggered_step(self._iter_count)
-      if self._formatter:
-        logging.info(self._formatter(run_values.results))
-      else:
-        stats = []
-        for tag in self._tag_order:
-          stats.append("%s = %s" % (tag, run_values.results[tag]))
-        logging.info("%s (%.3f sec)", ", ".join(stats), elapsed_secs)
+      if elapsed_secs is not None:
+        if self._formatter:
+          logging.info(self._formatter(run_values.results))
+        else:
+          stats = []
+          for tag in self._tag_order:
+            stats.append("%s = %s" % (tag, run_values.results[tag]))
+            logging.info("%s (%.3f sec)", ", ".join(stats), elapsed_secs)
       np.set_printoptions(**original)
     self._iter_count += 1
 


### PR DESCRIPTION
Fixed edge case when `elapsed_secs` is `None` that results in the following:

```
Traceback (most recent call last):
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: float argument required, not NoneType
Logged from file basic_session_run_hooks.py, line 183
```