### PR TITLE
Enable denormal test in open source

### DIFF
--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -58,6 +58,7 @@ if(WIN32)
   add_definitions(-DNOMINMAX -D_WIN32_WINNT=0x0A00 -DLANG_CXX11 -DCOMPILER_MSVC -D__VERSION__=\"MSVC\")
   add_definitions(-DWIN32 -DOS_WIN -D_MBCS -DWIN64 -DWIN32_LEAN_AND_MEAN -DNOGDI -DPLATFORM_WINDOWS)
   add_definitions(-DTENSORFLOW_USE_EIGEN_THREADPOOL -DEIGEN_HAS_C99_MATH -D_ITERATOR_DEBUG_LEVEL=0)
+  add_definitions(-DEIGEN_VECTORIZE_SSE3)  # Needed to suppress denormals without __SSE3__ in MSVC
   add_definitions(-DNDEBUG /O2)  # Equivalent of -c opt in Bazel.
   add_definitions(/bigobj /nologo /EHsc /GF /FC /MP /Gm-)
   # Suppress warnings to reduce build log size.

--- a/tensorflow/core/platform/denormal.cc
+++ b/tensorflow/core/platform/denormal.cc
@@ -14,7 +14,9 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/core/platform/denormal.h"
-#ifdef __SSE3__
+#include "third_party/eigen3/Eigen/Core"
+// Check EIGEN_VECTORIZE_SSE3 since Windows doesn't define __SSE3__ properly
+#ifdef EIGEN_VECTORIZE_SSE3
 #include <pmmintrin.h>
 #endif
 
@@ -24,7 +26,7 @@ namespace port {
 ScopedFlushDenormal::ScopedFlushDenormal() {
 // For now, we flush denormals only on SSE 3.  Other architectures such as ARM
 // can be added as needed.
-#ifdef __SSE3__
+#ifdef EIGEN_VECTORIZE_SSE3
   // Save existing flags
   flush_zero_mode_ = _MM_GET_FLUSH_ZERO_MODE() == _MM_FLUSH_ZERO_ON;
   denormals_zero_mode_ = _MM_GET_DENORMALS_ZERO_MODE() == _MM_DENORMALS_ZERO_ON;
@@ -38,7 +40,7 @@ ScopedFlushDenormal::ScopedFlushDenormal() {
 }
 
 ScopedFlushDenormal::~ScopedFlushDenormal() {
-#ifdef __SSE3__
+#ifdef EIGEN_VECTORIZE_SSE3
   // Restore flags
   _MM_SET_FLUSH_ZERO_MODE(flush_zero_mode_ ? _MM_FLUSH_ZERO_ON
                                            : _MM_FLUSH_ZERO_OFF);

--- a/tensorflow/python/kernel_tests/denormal_test.py
+++ b/tensorflow/python/kernel_tests/denormal_test.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import array_ops
-from tensorflow.python.platform import control_imports
 from tensorflow.python.platform import test
 
 
@@ -35,9 +34,6 @@ class DenormalTest(test.TestCase):
       self.assertEqual(tiny, tiny / 16 * 16)
 
   def _flushDenormalsTest(self, use_gpu, dtypes):
-    if control_imports.USE_OSS:
-      # TODO(irving): Fix denormal flushing for open source.
-      return
     with self.test_session(use_gpu=use_gpu):
       array_ops.identity(7).eval()
       for dtype in dtypes:


### PR DESCRIPTION
They seem to work fine; not sure what changed since ages ago.  The test works fine on my linux desktop and my OS X laptop; we'll see how it fares on the rest of the Jenkins machines.