### PR TITLE
Fix TensorBoard projector plugin reading tensor file in python 3.

### DIFF
--- a/tensorflow/tensorboard/plugins/projector/plugin.py
+++ b/tensorflow/tensorboard/plugins/projector/plugin.py
@@ -56,7 +56,7 @@ def _read_tensor_file(fpath):
     tensor = []
     for line in f:
       if line:
-        tensor.append(map(float, line.rstrip('\n').split('\t')))
+        tensor.append(list(map(float, line.rstrip('\n').split('\t'))))
   return np.array(tensor, dtype='float32')
 
 


### PR DESCRIPTION
Current code throws an error in Python 3, since map() returns a map object and not a list.