### PR TITLE
Remove concat_v2 from r1.0 branch

### DIFF
--- a/tensorflow/contrib/learn/python/learn/models.py
+++ b/tensorflow/contrib/learn/python/learn/models.py
@@ -274,10 +274,10 @@ def bidirectional_rnn(cell_fw,
   output_bw = _reverse_seq(tmp, sequence_length)
   # Concat each of the forward/backward outputs
   outputs = [
-      array_ops_.concat_v2([fw, bw], 1) for fw, bw in zip(output_fw, output_bw)
+      array_ops_.concat([fw, bw], 1) for fw, bw in zip(output_fw, output_bw)
   ]
 
-  return outputs, array_ops_.concat_v2([state_fw, state_bw], 1)
+  return outputs, array_ops_.concat([state_fw, state_bw], 1)
 
 
 # End of TensorFlow 0.7

--- a/tensorflow/contrib/learn/python/learn/ops/embeddings_ops.py
+++ b/tensorflow/contrib/learn/python/learn/ops/embeddings_ops.py
@@ -59,7 +59,7 @@ def embedding_lookup(params, ids, name='embedding_lookup'):
     ids_flat = array_ops_.reshape(
         ids, math_ops.reduce_prod(shape, keep_dims=True))
     embeds_flat = nn.embedding_lookup(params, ids_flat, name)
-    embed_shape = array_ops_.concat_v2([shape, [-1]], 0)
+    embed_shape = array_ops_.concat([shape, [-1]], 0)
     embeds = array_ops_.reshape(embeds_flat, embed_shape)
     embeds.set_shape(ids.get_shape().concatenate(params.get_shape()[1:]))
     return embeds

--- a/tensorflow/g3doc/api_docs/python/array_ops.md
+++ b/tensorflow/g3doc/api_docs/python/array_ops.md
@@ -3135,8 +3135,6 @@ Compute gradients for a FakeQuantWithMinMaxVarsPerChannel operation.
 ## Other Functions and Classes
 - - -
 
-### `tf.concat_v2(values, axis, name='concat_v2')` {#concat_v2}
-
 
 
 

--- a/tensorflow/g3doc/api_docs/python/array_ops.md
+++ b/tensorflow/g3doc/api_docs/python/array_ops.md
@@ -3135,6 +3135,8 @@ Compute gradients for a FakeQuantWithMinMaxVarsPerChannel operation.
 ## Other Functions and Classes
 - - -
 
+### `tf.concat_v2(values, axis, name='concat_v2')` {#concat_v2}
+
 
 
 

--- a/tensorflow/python/kernel_tests/scalar_strict_test.py
+++ b/tensorflow/python/kernel_tests/scalar_strict_test.py
@@ -70,13 +70,13 @@ class ScalarStrictTest(test.TestCase):
               self.assertAllEqual(r, correct)
 
   def testConcat(self):
-    self.check(array_ops.concat_v2, (([2], [3], [7]), [0]),
+    self.check(array_ops.concat, (([2], [3], [7]), [0]),
                'axis tensor should be a scalar integer', [2, 3, 7])
     for data in (2, 3, 7), (2, [3], 7), (2, 3, [7]):
-      self.check(array_ops.concat_v2, (data, 0),
+      self.check(array_ops.concat, (data, 0),
                  r'Expected \w+ dimensions in the range \[0, 0\)', [2, 3, 7])
     for data in ([2], 3, 7), ([2], [3], 7):
-      self.check(array_ops.concat_v2, (data, 0),
+      self.check(array_ops.concat, (data, 0),
                  r'Ranks of all input tensors should match', [2, 3, 7])
 
   def testFill(self):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -979,12 +979,6 @@ def unstack(value, num=None, axis=0, name="unstack"):
   return gen_array_ops._unpack(value, num=num, axis=axis, name=name)
 
 
-# concat_v2 is an alias for concat. concat_v2 will be deprecated and removed
-# soon, please use concat.
-def concat_v2(values, axis, name="concat_v2"):
-  return concat(values, axis, name)
-
-
 def concat(values, axis, name="concat"):
   """Concatenates tensors along one dimension.
 

--- a/tensorflow/python/ops/weights_broadcast_ops.py
+++ b/tensorflow/python/ops/weights_broadcast_ops.py
@@ -34,7 +34,7 @@ def _has_valid_dims(weights_shape, values_shape):
   with ops.name_scope(
       None, "has_invalid_dims", (weights_shape, values_shape)) as scope:
     values_shape_2d = array_ops.expand_dims(values_shape, -1)
-    valid_dims = array_ops.concat_v2(
+    valid_dims = array_ops.concat(
         (values_shape_2d, array_ops.ones_like(values_shape_2d)), axis=1)
     weights_shape_2d = array_ops.expand_dims(weights_shape, -1)
     invalid_dims = sets.set_difference(weights_shape_2d, valid_dims)


### PR DESCRIPTION
Removing concat_v2 and references. tf.concat now has the same signature as tf.concat_v2. So, tf.concat should be used instead of tf.concat_v2.