### PR TITLE
Fix breakages in Python 3.5 tests by using int type in indices (#7003)

### DIFF
--- a/tensorflow/contrib/bayesflow/python/kernel_tests/special_math_test.py
+++ b/tensorflow/contrib/bayesflow/python/kernel_tests/special_math_test.py
@@ -211,8 +211,8 @@ class NdtrGradientTest(test.TestCase):
       if self._use_log:
         g = np.reshape(grad_eval, [-1])
         half = np.ceil(len(g) / 2)
-        self.assert_all_true(g[:half] > 0.)
-        self.assert_all_true(g[half:] >= 0.)
+        self.assert_all_true(g[:int(half)] > 0.)
+        self.assert_all_true(g[int(half):] >= 0.)
       else:
         # The ndtr gradient will only be non-zero in the range [-14, 14] for
         # float32 and [-38, 38] for float64.

--- a/tensorflow/contrib/distributions/python/kernel_tests/bijector_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/bijector_test.py
@@ -1301,7 +1301,7 @@ class AffineBijectorTest(test.TestCase):
   def _matrix_diag(self, d):
     """Batch version of np.diag."""
     orig_shape = d.shape
-    d = np.reshape(d, (np.prod(d.shape[:-1]), d.shape[-1]))
+    d = np.reshape(d, (int(np.prod(d.shape[:-1])), d.shape[-1]))
     diag_list = []
     for i in range(d.shape[0]):
       diag_list.append(np.diag(d[i, ...]))

--- a/tensorflow/contrib/factorization/python/kernel_tests/clustering_ops_test.py
+++ b/tensorflow/contrib/factorization/python/kernel_tests/clustering_ops_test.py
@@ -125,7 +125,7 @@ class NearestCentersLargeTest(test.TestCase):
     # Tile points and expected results to reach requested size (num_points)
     (self._points, self._expected_nearest_neighbor_indices,
      self._expected_nearest_neighbor_squared_distances) = (
-         np.tile(x, (num_points / points_per_tile, 1))
+         np.tile(x, (int(num_points / points_per_tile), 1))
          for x in (points, expected_nearest_neighbor_indices,
                    expected_nearest_neighbor_squared_distances))
 

--- a/tensorflow/contrib/learn/python/learn/estimators/estimator_test.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimator_test.py
@@ -407,9 +407,9 @@ class EstimatorTest(test.TestCase):
     right_labels = lambda: np.ones(shape=[7, 10], dtype=np.int32)
     est.fit(right_features(), right_labels(), steps=1)
     # TODO(wicke): This does not fail for np.int32 because of data_feeder magic.
-    wrong_type_features = np.ones(shape=[7., 8.], dtype=np.int64)
+    wrong_type_features = np.ones(shape=[7, 8], dtype=np.int64)
     wrong_size_features = np.ones(shape=[7, 10])
-    wrong_type_labels = np.ones(shape=[7., 10.], dtype=np.float32)
+    wrong_type_labels = np.ones(shape=[7, 10], dtype=np.float32)
     wrong_size_labels = np.ones(shape=[7, 11])
     est.fit(x=right_features(), y=right_labels(), steps=1)
     with self.assertRaises(ValueError):

--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -106,7 +106,7 @@ class RNNCellTest(test.TestCase):
                           [2., 2., 2., 2.],
                           [3., 3., 3., 3.]]),
             m.name:
-                0.1 * np.ones((batch_size, state_size * (num_shifts)))
+                0.1 * np.ones((batch_size, int(state_size * (num_shifts))))
         })
         self.assertEqual(len(res), 2)
         # The numbers in results were not calculated, this is mostly just a


### PR DESCRIPTION
Need to fix py3.5 tests in release :)