### PR TITLE
[CMake] Fix the Python build with -Dtensorflow_ENABLE_GRPC_SUPPORT=OFF.

### DIFF
--- a/tensorflow/contrib/cmake/tf_core_cpu.cmake
+++ b/tensorflow/contrib/cmake/tf_core_cpu.cmake
@@ -6,6 +6,8 @@ file(GLOB_RECURSE tf_core_cpu_srcs
     "${tensorflow_source_dir}/tensorflow/cc/saved_model/*.cc"
     "${tensorflow_source_dir}/tensorflow/core/common_runtime/*.h"
     "${tensorflow_source_dir}/tensorflow/core/common_runtime/*.cc"
+    "${tensorflow_source_dir}/tensorflow/core/distributed_runtime/server_lib.h"
+    "${tensorflow_source_dir}/tensorflow/core/distributed_runtime/server_lib.cc"
     "${tensorflow_source_dir}/tensorflow/core/graph/*.h"
     "${tensorflow_source_dir}/tensorflow/core/graph/*.cc"
     "${tensorflow_source_dir}/tensorflow/core/public/*.h"

--- a/tensorflow/contrib/cmake/tf_core_distributed_runtime.cmake
+++ b/tensorflow/contrib/cmake/tf_core_distributed_runtime.cmake
@@ -7,6 +7,7 @@ file(GLOB_RECURSE tf_core_distributed_runtime_srcs
 )
 
 file(GLOB_RECURSE tf_core_distributed_runtime_exclude_srcs
+    "${tensorflow_source_dir}/tensorflow/core/distributed_runtime/server_lib.cc"  # Build in tf_core_cpu instead.
     "${tensorflow_source_dir}/tensorflow/core/distributed_runtime/*test*.h"
     "${tensorflow_source_dir}/tensorflow/core/distributed_runtime/*test*.cc"
     "${tensorflow_source_dir}/tensorflow/core/distributed_runtime/rpc/grpc_tensorflow_server.cc"

--- a/tensorflow/contrib/cmake/tf_tools.cmake
+++ b/tensorflow/contrib/cmake/tf_tools.cmake
@@ -18,10 +18,10 @@ target_link_libraries(${proto_text} PUBLIC
   tf_protos_cc
 )
 
-add_dependencies(${proto_text}
-    tf_core_lib
-    grpc
-)
+add_dependencies(${proto_text} tf_core_lib)
+if(tensorflow_ENABLE_GRPC_SUPPORT)
+    add_dependencies(${proto_text} grpc)
+endif(tensorflow_ENABLE_GRPC_SUPPORT)
 
 file(GLOB_RECURSE tf_tools_transform_graph_lib_srcs
     "${tensorflow_source_dir}/tensorflow/tools/graph_transforms/*.h"


### PR DESCRIPTION
The SWIG wrapper could not resolve the server-creation function, which
is unconditionally referenced in server_lib.i, but not built when gRPC
support is disabled. This change fixes the problem by building
server_lib.cc as part of tf_core_cpu, so it can always be resolved,
even when gRPC support is disabled.

Fixes #7019. Thanks to @iantheconway for finding the bug.