### PR TITLE
CudaRoot() returns the configured CUDA toolkit path.

### DIFF
--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -462,9 +462,11 @@ $(wildcard tensorflow/core/lib/jpeg/*) \
 $(wildcard tensorflow/core/lib/png/*) \
 $(wildcard tensorflow/core/util/events_writer.*) \
 $(wildcard tensorflow/core/util/reporter.*) \
+$(wildcard tensorflow/core/platform/default/cuda_libdevice_path.*) \
 $(wildcard tensorflow/core/platform/default/stream_executor.*) \
 $(wildcard tensorflow/core/platform/default/test_benchmark.*) \
 $(wildcard tensorflow/core/platform/cuda.h) \
+$(wildcard tensorflow/core/platform/cuda_libdevice_path.*) \
 $(wildcard tensorflow/core/platform/cloud/*) \
 $(wildcard tensorflow/core/platform/google/*) \
 $(wildcard tensorflow/core/platform/google/*/*) \

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -169,10 +169,10 @@ def tf_additional_cupti_wrapper_deps():
   return ["//tensorflow/core/platform/default/gpu:cupti_wrapper"]
 
 def tf_additional_libdevice_data():
-  return ["@local_config_cuda//cuda:libdevice_root"]
+  return []
 
 def tf_additional_libdevice_deps():
-  return []
+  return ["@local_config_cuda//cuda:cuda_headers"]
 
 def tf_additional_libdevice_srcs():
   return ["platform/default/cuda_libdevice_path.cc"]

--- a/tensorflow/core/platform/default/cuda_libdevice_path.cc
+++ b/tensorflow/core/platform/default/cuda_libdevice_path.cc
@@ -17,27 +17,14 @@ limitations under the License.
 
 #include <stdlib.h>
 
-#include "tensorflow/core/lib/io/path.h"
-#include "tensorflow/core/lib/strings/strcat.h"
-#include "tensorflow/core/platform/env.h"
+#include "cuda/cuda_config.h"
 #include "tensorflow/core/platform/logging.h"
 
 namespace tensorflow {
 
 string CudaRoot() {
-  // 'bazel test' sets TEST_SRCDIR.
-  const string kRelativeCudaRoot = io::JoinPath("local_config_cuda", "cuda");
-  const char* test_srcdir = getenv("TEST_SRCDIR");
-  if (test_srcdir && test_srcdir[0] != '\0') {
-    return io::JoinPath(test_srcdir, kRelativeCudaRoot);
-  }
-
-  LOG(INFO) << "TEST_SRCDIR environment variable not set: using "
-            << kRelativeCudaRoot
-            << " under this executable's runfiles directory as the CUDA root.";
-  return io::JoinPath(
-      strings::StrCat(Env::Default()->GetExecutablePath(), ".runfiles"),
-      kRelativeCudaRoot);
+  VLOG(3) << "CUDA root = " << TF_CUDA_TOOLKIT_PATH;
+  return TF_CUDA_TOOLKIT_PATH;
 }
 
 }  // namespace tensorflow

--- a/third_party/gpus/cuda/cuda_config.h.tpl
+++ b/third_party/gpus/cuda/cuda_config.h.tpl
@@ -21,4 +21,6 @@ limitations under the License.
 #define TF_CUDA_VERSION "%{cuda_version}"
 #define TF_CUDNN_VERSION "%{cudnn_version}"
 
+#define TF_CUDA_TOOLKIT_PATH "%{cuda_toolkit_path}"
+
 #endif  // CUDA_CUDA_CONFIG_H_

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -700,6 +700,7 @@ def _create_dummy_repository(repository_ctx):
            "%{cuda_compute_capabilities}": ",".join([
                "CudaVersion(\"%s\")" % c
                for c in _DEFAULT_CUDA_COMPUTE_CAPABILITIES]),
+           "%{cuda_toolkit_path}": _DEFAULT_CUDA_TOOLKIT_PATH,
        })
 
   # If cuda_configure is not configured to build with GPU support, and the user
@@ -802,6 +803,7 @@ def _create_cuda_repository(repository_ctx):
            "%{cuda_compute_capabilities}": ",".join(
                ["CudaVersion(\"%s\")" % c
                 for c in cuda_config.compute_capabilities]),
+               "%{cuda_toolkit_path}": cuda_config.cuda_toolkit_path,
        })
 
 


### PR DESCRIPTION
Fixes the problem of XLA being unable to find libdevice files if not executed through bazel. For example,
http://stackoverflow.com/questions/41729019/notfounderror-running-tensorflow-xla-example-libdevice-compute-35-10-bc/41800414#41800414