### PR TITLE
Adding checks for broken bottleneck files

### DIFF
--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -392,9 +392,12 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
     with open(bottleneck_path, 'w') as bottleneck_file:
       bottleneck_file.write(bottleneck_string)
 
-  with open(bottleneck_path, 'r') as bottleneck_file:
-    bottleneck_string = bottleneck_file.read()
-  bottleneck_values = [float(x) for x in bottleneck_string.split(',')]
+  try:
+    bottleneck_values = [float(x) for x in bottleneck_string.split(',')]
+  except:
+    print("Invalid float found, sending None instead")
+    return None
+
   return bottleneck_values
 
 
@@ -427,12 +430,13 @@ def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,
     for category in ['training', 'testing', 'validation']:
       category_list = label_lists[category]
       for index, unused_base_name in enumerate(category_list):
-        get_or_create_bottleneck(sess, image_lists, label_name, index,
+        bNeck = get_or_create_bottleneck(sess, image_lists, label_name, index,
                                  image_dir, category, bottleneck_dir,
                                  jpeg_data_tensor, bottleneck_tensor)
-        how_many_bottlenecks += 1
-        if how_many_bottlenecks % 100 == 0:
-          print(str(how_many_bottlenecks) + ' bottleneck files created.')
+        if bNeck is not None:
+          how_many_bottlenecks += 1
+          if how_many_bottlenecks % 100 == 0:
+            print(str(how_many_bottlenecks) + ' bottleneck files created.')
 
 
 def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
@@ -477,11 +481,12 @@ def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
                                             image_index, image_dir, category,
                                             bottleneck_dir, jpeg_data_tensor,
                                             bottleneck_tensor)
-      ground_truth = np.zeros(class_count, dtype=np.float32)
-      ground_truth[label_index] = 1.0
-      bottlenecks.append(bottleneck)
-      ground_truths.append(ground_truth)
-      filenames.append(image_name)
+      if bottleneck is not None:
+        ground_truth = np.zeros(class_count, dtype=np.float32)
+        ground_truth[label_index] = 1.0
+        bottlenecks.append(bottleneck)
+        ground_truths.append(ground_truth)
+        filenames.append(image_name)
   else:
     # Retrieve all bottlenecks.
     for label_index, label_name in enumerate(image_lists.keys()):
@@ -493,11 +498,12 @@ def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
                                               image_index, image_dir, category,
                                               bottleneck_dir, jpeg_data_tensor,
                                               bottleneck_tensor)
-        ground_truth = np.zeros(class_count, dtype=np.float32)
-        ground_truth[label_index] = 1.0
-        bottlenecks.append(bottleneck)
-        ground_truths.append(ground_truth)
-        filenames.append(image_name)
+        if bottleneck is not None:
+          ground_truth = np.zeros(class_count, dtype=np.float32)
+          ground_truth[label_index] = 1.0
+          bottlenecks.append(bottleneck)
+          ground_truths.append(ground_truth)
+          filenames.append(image_name)
   return bottlenecks, ground_truths, filenames
 
 

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -498,6 +498,7 @@ def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
       ground_truth[label_index] = 1.0
       bottlenecks.append(bottleneck)
       ground_truths.append(ground_truth)
+      filenames.append(image_name)
   else:
     # Retrieve all bottlenecks.
     for label_index, label_name in enumerate(image_lists.keys()):
@@ -509,12 +510,11 @@ def get_random_cached_bottlenecks(sess, image_lists, how_many, category,
                                               image_index, image_dir, category,
                                               bottleneck_dir, jpeg_data_tensor,
                                               bottleneck_tensor)
-        if bottleneck is not None:
-          ground_truth = np.zeros(class_count, dtype=np.float32)
-          ground_truth[label_index] = 1.0
-          bottlenecks.append(bottleneck)
-          ground_truths.append(ground_truth)
-          filenames.append(image_name)
+        ground_truth = np.zeros(class_count, dtype=np.float32)
+        ground_truth[label_index] = 1.0
+        bottlenecks.append(bottleneck)
+        ground_truths.append(ground_truth)
+        filenames.append(image_name)
   return bottlenecks, ground_truths, filenames
 
 

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -350,13 +350,13 @@ def create_bottleneck_file(bottleneck_path, image_lists, label_name, index,
                            image_dir, category, sess, jpeg_data_tensor, bottleneck_tensor):
   print('Creating bottleneck at ' + bottleneck_path)
   image_path = get_image_path(image_lists, label_name, index, image_dir, category)
-    if not gfile.Exists(image_path):
-      tf.logging.fatal('File does not exist %s', image_path)
-    image_data = gfile.FastGFile(image_path, 'rb').read()
-    bottleneck_values = run_bottleneck_on_image(sess, image_data, jpeg_data_tensor, bottleneck_tensor)
-    bottleneck_string = ','.join(str(x) for x in bottleneck_values)
-    with open(bottleneck_path, 'w') as bottleneck_file:
-      bottleneck_file.write(bottleneck_string)
+  if not gfile.Exists(image_path):
+    tf.logging.fatal('File does not exist %s', image_path)
+  image_data = gfile.FastGFile(image_path, 'rb').read()
+  bottleneck_values = run_bottleneck_on_image(sess, image_data, jpeg_data_tensor, bottleneck_tensor)
+  bottleneck_string = ','.join(str(x) for x in bottleneck_values)
+  with open(bottleneck_path, 'w') as bottleneck_file:
+    bottleneck_file.write(bottleneck_string)
 
 def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
                              category, bottleneck_dir, jpeg_data_tensor,

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -348,18 +348,15 @@ bottleneck_path_2_bottleneck_values = {}
 
 def create_bottleneck_file(bottleneck_path, image_lists, label_name, index,
                            image_dir, category, sess, jpeg_data_tensor, bottleneck_tensor):
-    print('Creating bottleneck at ' + bottleneck_path)
-    image_path = get_image_path(image_lists, label_name, index, image_dir,
-                                category)
+  print('Creating bottleneck at ' + bottleneck_path)
+  image_path = get_image_path(image_lists, label_name, index, image_dir, category)
     if not gfile.Exists(image_path):
-        tf.logging.fatal('File does not exist %s', image_path)
+      tf.logging.fatal('File does not exist %s', image_path)
     image_data = gfile.FastGFile(image_path, 'rb').read()
-    bottleneck_values = run_bottleneck_on_image(sess, image_data,
-                                                jpeg_data_tensor,
-                                                bottleneck_tensor)
+    bottleneck_values = run_bottleneck_on_image(sess, image_data, jpeg_data_tensor, bottleneck_tensor)
     bottleneck_string = ','.join(str(x) for x in bottleneck_values)
     with open(bottleneck_path, 'w') as bottleneck_file:
-        bottleneck_file.write(bottleneck_string)
+      bottleneck_file.write(bottleneck_string)
 
 def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
                              category, bottleneck_dir, jpeg_data_tensor,
@@ -390,29 +387,24 @@ def get_or_create_bottleneck(sess, image_lists, label_name, index, image_dir,
   sub_dir = label_lists['dir']
   sub_dir_path = os.path.join(bottleneck_dir, sub_dir)
   ensure_dir_exists(sub_dir_path)
-  bottleneck_path = get_bottleneck_path(image_lists, label_name, index,
-                                        bottleneck_dir, category)
+  bottleneck_path = get_bottleneck_path(image_lists, label_name, index, bottleneck_dir, category)
   if not os.path.exists(bottleneck_path):
-      create_bottleneck_file(bottleneck_path, image_lists, label_name, index,
-                             image_dir, category, sess, jpeg_data_tensor, bottleneck_tensor)
+    create_bottleneck_file(bottleneck_path, image_lists, label_name, index, image_dir, category, sess, jpeg_data_tensor, bottleneck_tensor)
   with open(bottleneck_path, 'r') as bottleneck_file:
-      bottleneck_string = bottleneck_file.read()
+    bottleneck_string = bottleneck_file.read()
   did_hit_error = False
   try:
-      bottleneck_values = [float(x) for x in bottleneck_string.split(',')]
+    bottleneck_values = [float(x) for x in bottleneck_string.split(',')]
   except:
-      print("Invalid float found, recreating bottleneck")
-      did_hit_error = True
+    print("Invalid float found, recreating bottleneck")
+    did_hit_error = True
   if did_hit_error:
-      create_bottleneck_file(bottleneck_path, image_lists, label_name, index,
-                             image_dir, category, sess, jpeg_data_tensor, bottleneck_tensor)
-      with open(bottleneck_path, 'r') as bottleneck_file:
-          bottleneck_string = bottleneck_file.read()
-      # Allow exceptions to propagate here, since they shouldn't happen after a fresh creation
-      bottleneck_values = [float(x) for x in bottleneck_string.split(',')]
-
+    create_bottleneck_file(bottleneck_path, image_lists, label_name, index, image_dir, category, sess, jpeg_data_tensor, bottleneck_tensor)
+    with open(bottleneck_path, 'r') as bottleneck_file:
+      bottleneck_string = bottleneck_file.read()
+    # Allow exceptions to propagate here, since they shouldn't happen after a fresh creation
+    bottleneck_values = [float(x) for x in bottleneck_string.split(',')]
   return bottleneck_values
-
 
 def cache_bottlenecks(sess, image_lists, image_dir, bottleneck_dir,
                       jpeg_data_tensor, bottleneck_tensor):


### PR DESCRIPTION
An exception is raised when a broken cached bottleneck files is read. Such a file can be created as a result of sudden system failure. 

This commit refers the issue #2296 (https://github.com/tensorflow/tensorflow/issues/2296). Although closed but the problem still persists. Please view comments by @rizasif92 at the end. The changes contain nothing but error handling.