### PR TITLE
[Java] Don't strip symbols from C library when compiling in debug mode

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -70,6 +70,22 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "debug",
+    values = {
+        "compilation_mode": "dbg",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "optimize",
+    values = {
+        "compilation_mode": "opt",
+    },
+    visibility = ["//visibility:public"],
+)
+
 package_group(
     name = "internal",
     packages = ["//tensorflow/..."],

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -79,7 +79,7 @@ config_setting(
 )
 
 config_setting(
-    name = "optimize",
+    name = "optimized",
     values = {
         "compilation_mode": "opt",
     },

--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -111,6 +111,11 @@ cc_binary(
             LINKER_EXPORTED_SYMBOLS,
         ],
         "//tensorflow:windows": [],
+        "//tensorflow:debug" : [
+           	"-z defs",
+           	"-Wl,--version-script",  #  This line must be directly followed by LINKER_VERSION_SCRIPT
+           	LINKER_VERSION_SCRIPT,
+       	],
         "//conditions:default": [
             "-z defs",
             "-s",

--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -106,16 +106,12 @@ cc_binary(
     # symbols from the library. This reduces the size of the library
     # considerably (~50% as of January 2017).
     linkopts = select({
+        "//tensorflow:debug" : [], # Disable all custom linker options in debug mode
         "//tensorflow:darwin": [
             "-Wl,-exported_symbols_list",  # This line must be directly followed by LINKER_EXPORTED_SYMBOLS
             LINKER_EXPORTED_SYMBOLS,
         ],
         "//tensorflow:windows": [],
-        "//tensorflow:debug" : [
-           	"-z defs",
-           	"-Wl,--version-script",  #  This line must be directly followed by LINKER_VERSION_SCRIPT
-           	LINKER_VERSION_SCRIPT,
-       	],
         "//conditions:default": [
             "-z defs",
             "-s",

--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -106,7 +106,7 @@ cc_binary(
     # symbols from the library. This reduces the size of the library
     # considerably (~50% as of January 2017).
     linkopts = select({
-        "//tensorflow:debug" : [], # Disable all custom linker options in debug mode
+        "//tensorflow:debug": [],  # Disable all custom linker options in debug mode
         "//tensorflow:darwin": [
             "-Wl,-exported_symbols_list",  # This line must be directly followed by LINKER_EXPORTED_SYMBOLS
             LINKER_EXPORTED_SYMBOLS,


### PR DESCRIPTION
When building the Java client with "compilation_mode=dbg", the symbols in the C++ library should not be stripped otherwise we won't be able to attach a GDB to the java process for core debugging.

Also, I thought that knowing the active compilation mode might be something useful in general so I declared the "debug" and "optimize" config settings in the parent BUILD file.