### PR TITLE
Fix wrong description for tf.nn.max_pool_with_argmax

### DIFF
--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -1301,8 +1301,7 @@ REGISTER_OP("MaxPoolWithArgmax")
 Performs max pooling on the input and outputs both max values and indices.
 
 The indices in `argmax` are flattened, so that a maximum value at position
-`[b, y, x, c]` becomes flattened index
-`((b * height + y) * width + x) * channels + c`.
+`[b, y, x, c]` becomes flattened index `(y * width + x) * channels + c`.
 
 ksize: The size of the window for each dimension of the input tensor.
 strides: The stride of the sliding window for each dimension of the

--- a/tensorflow/g3doc/api_docs/python/nn.md
+++ b/tensorflow/g3doc/api_docs/python/nn.md
@@ -1209,8 +1209,7 @@ Performs the max pooling on the input.
 Performs max pooling on the input and outputs both max values and indices.
 
 The indices in `argmax` are flattened, so that a maximum value at position
-`[b, y, x, c]` becomes flattened index
-`((b * height + y) * width + x) * channels + c`.
+`[b, y, x, c]` becomes flattened index `(y * width + x) * channels + c`.
 
 ##### Args:
 


### PR DESCRIPTION
The description for indices is wrong. The real format is (y * width + x) * channels + c, batch index is ignored which can be seen [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/maxpooling_op_gpu.cu.cc#L78).

Fixed pull request from https://github.com/tensorflow/tensorflow/pull/7090