### PR TITLE
Make curl forward/backward compatible

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -54,6 +54,30 @@ temp_workaround_http_archive = repository_rule(
       "strip_prefix": attr.string(default = ""),
    })
 
+def _repos_are_siblings():
+  return Label("@foo//bar").workspace_root.startswith("../")
+
+def _curl_repo_impl(ctx):
+  ctx.download_and_extract(
+      [
+          "http://bazel-mirror.storage.googleapis.com/curl.haxx.se/download/curl-7.49.1.tar.gz",
+          "https://curl.haxx.se/download/curl-7.49.1.tar.gz",
+      ], "", "ff3e80c1ca6a068428726cd7dd19037a47cc538ce58ef61c59587191039b2ca6", "", "curl-7.49.1")
+  prefix = "external"
+  if _repos_are_siblings():
+    prefix = ".."
+  ctx.template(
+      'BUILD',
+      Label("//third_party:curl.BUILD"),
+      substitutions = {"{%prefix%}" : prefix},
+      executable = False
+  )
+
+
+curl_repo = repository_rule(
+    implementation = _curl_repo_impl,
+)
+
 # If TensorFlow is linked as a submodule.
 # path_prefix and tf_repo_name are no longer used.
 def tf_workspace(path_prefix = "", tf_repo_name = ""):
@@ -270,16 +294,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
       build_file = str(Label("//third_party:swig.BUILD")),
   )
 
-  native.new_http_archive(
-      name = "curl",
-      sha256 = "ff3e80c1ca6a068428726cd7dd19037a47cc538ce58ef61c59587191039b2ca6",
-      urls = [
-          "http://bazel-mirror.storage.googleapis.com/curl.haxx.se/download/curl-7.49.1.tar.gz",
-          "https://curl.haxx.se/download/curl-7.49.1.tar.gz",
-      ],
-      strip_prefix = "curl-7.49.1",
-      build_file = str(Label("//third_party:curl.BUILD")),
-  )
+  curl_repo(name = "curl")
 
   # grpc expects //external:protobuf_clib and //external:protobuf_compiler
   # to point to the protobuf's compiler library.

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -232,7 +232,7 @@ cc_library(
     ],
     copts = select({
         ":windows": [
-            "/Iexternal/curl/lib",
+            "/I{%prefix%}/curl/lib",
             "/DHAVE_CONFIG_H",
             "/DCURL_DISABLE_FTP",
             "/DCURL_DISABLE_NTLM",
@@ -245,7 +245,7 @@ cc_library(
             "/D_USING_V110_SDK71_",
         ],
         "//conditions:default": [
-            "-Iexternal/curl/lib",
+            "-I{%prefix%}/curl/lib",
             "-D_GNU_SOURCE",
             "-DHAVE_CONFIG_H",
             "-DCURL_DISABLE_FTP",
@@ -387,12 +387,12 @@ cc_binary(
     ],
     copts = select({
         ":windows": [
-            "/Iexternal/curl/lib",
+            "/I{%prefix%}/curl/lib",
             "/DHAVE_CONFIG_H",
             "/DCURL_DISABLE_LIBCURL_OPTION",
         ],
         "//conditions:default": [
-            "-Iexternal/curl/lib",
+            "-I{%prefix%}/curl/lib",
             "-D_GNU_SOURCE",
             "-DHAVE_CONFIG_H",
             "-DCURL_DISABLE_LIBCURL_OPTION",

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -232,7 +232,7 @@ cc_library(
     ],
     copts = select({
         ":windows": [
-            "/I{%prefix%}/curl/lib",
+            "/I%prefix%/curl/lib",
             "/DHAVE_CONFIG_H",
             "/DCURL_DISABLE_FTP",
             "/DCURL_DISABLE_NTLM",
@@ -245,7 +245,7 @@ cc_library(
             "/D_USING_V110_SDK71_",
         ],
         "//conditions:default": [
-            "-I{%prefix%}/curl/lib",
+            "-I%prefix%/curl/lib",
             "-D_GNU_SOURCE",
             "-DHAVE_CONFIG_H",
             "-DCURL_DISABLE_FTP",
@@ -387,12 +387,12 @@ cc_binary(
     ],
     copts = select({
         ":windows": [
-            "/I{%prefix%}/curl/lib",
+            "/I%prefix%/curl/lib",
             "/DHAVE_CONFIG_H",
             "/DCURL_DISABLE_LIBCURL_OPTION",
         ],
         "//conditions:default": [
-            "-I{%prefix%}/curl/lib",
+            "-I%prefix%/curl/lib",
             "-D_GNU_SOURCE",
             "-DHAVE_CONFIG_H",
             "-DCURL_DISABLE_LIBCURL_OPTION",


### PR DESCRIPTION
I'm working on fixing https://github.com/bazelbuild/bazel/issues/1262, which will change the way Bazel organizes the execution root.  The curl library needs to use ../curl as an include prefix in new versions of Bazel and external/curl in old versions.

This patch should be forward/backward compatible.