### PR TITLE
Revert "Added absolute path expansion of parent directory check in saver.py, …"

### DIFF
--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -1376,7 +1376,7 @@ class Saver(object):
             "'latest_filename' collides with 'save_path': '%s' and '%s'" %
             (latest_filename, save_path))
 
-    if not gfile.IsDirectory(os.path.dirname(os.path.abspath(save_path))):
+    if not gfile.IsDirectory(os.path.dirname(save_path)):
       raise ValueError(
           "Parent directory of {} doesn't exist, can't save.".format(save_path))
 
@@ -1453,7 +1453,7 @@ class Saver(object):
       return
     logging.info("Restoring parameters from %s", save_path)
     sess.run(self.saver_def.restore_op_name,
-             {self.saver_def.filename_tensor_name: os.path.abspath(save_path)})
+             {self.saver_def.filename_tensor_name: save_path})
 
   @staticmethod
   def _add_collection_def(meta_graph_def, key, export_scope=None):

--- a/tensorflow/python/training/saver_test.py
+++ b/tensorflow/python/training/saver_test.py
@@ -565,51 +565,6 @@ class SaverTest(test.TestCase):
       ):
         save.save(sess, save_path)
 
-  def testSaveToCurrentDirectory(self):
-
-    temp_dir = self.get_temp_dir()
-
-    # Store original current dir for later recovery, set current dir to temp_dir
-    old_current_dir = os.getcwd()
-    os.chdir(temp_dir)
-
-    try:    
-
-      # Save to current directory, no ./ prepended to path name
-      save_path = "variables"
-
-      with session.Session("", graph=ops_lib.Graph()) as sess:
-
-        one = variables.Variable(1.0)
-        twos = variables.Variable([2.0, 2.0, 2.0])
-        
-        init = variables.global_variables_initializer()
-        save = saver_module.Saver()
-
-        init.run()
-        save.save(sess, save_path)
-
-      with session.Session("", graph=ops_lib.Graph()) as sess:
-
-        one = variables.Variable(0.0)
-        twos = variables.Variable([0.0, 0.0, 0.0])
-
-        # Saver with no arg, defaults to 'all variables'.
-        save = saver_module.Saver()
-        save.restore(sess, save_path)
-
-        self.assertAllClose(1.0, one.eval())
-        self.assertAllClose([2.0, 2.0, 2.0], twos.eval())
-
-        # Go back to original current dir
-        os.chdir(old_current_dir)
-
-    except Exception as exception:
-
-      # Go back to original current dir and then bubble up the exception
-      os.chdir(old_current_dir)
-      raise exception
-
 
 class SaveRestoreShardedTest(test.TestCase):
 


### PR DESCRIPTION
Reverts tensorflow/tensorflow#6601

Breaks saving to all non-local filesystem paths.