### PR TITLE
increase size of nccl_manager_test

### DIFF
--- a/tensorflow/contrib/nccl/BUILD
+++ b/tensorflow/contrib/nccl/BUILD
@@ -84,7 +84,7 @@ cuda_py_test(
 
 tf_cuda_cc_test(
     name = "nccl_manager_test",
-    size = "small",
+    size = "medium",
     srcs = if_cuda(
         [
             "kernels/nccl_manager.cc",


### PR DESCRIPTION
This test timed out when testing https://github.com/tensorflow/tensorflow/pull/7197 , increasing size small->medium