### PR TITLE
Don't use __has_builtin with version of apple clang that doesn't supp…

### DIFF
--- a/tensorflow/core/lib/hash/crc32c_accelerate.cc
+++ b/tensorflow/core/lib/hash/crc32c_accelerate.cc
@@ -31,6 +31,12 @@ limitations under the License.
 #endif
 #endif /* __SSE4_2__ */
 
+// This version of Apple clang has a bug,  claiming support for
+// __has_builtin, but lacking the __cpu_model symbol required by it
+#if defined(__APPLE__) && (__clang_major__ == 7) && (__clang_minor__ == 3)
+#undef USE_SSE_CRC32C
+#endif
+
 #ifdef USE_SSE_CRC32C
 #include <nmmintrin.h>
 #endif

--- a/tensorflow/core/lib/hash/crc32c_accelerate.cc
+++ b/tensorflow/core/lib/hash/crc32c_accelerate.cc
@@ -31,9 +31,9 @@ limitations under the License.
 #endif
 #endif /* __SSE4_2__ */
 
-// This version of Apple clang has a bug,  claiming support for
-// __has_builtin, but lacking the __cpu_model symbol required by it
-#if defined(__APPLE__) && (__clang_major__ == 7) && (__clang_minor__ == 3)
+// This version of Apple clang has a bug:
+// https://llvm.org/bugs/show_bug.cgi?id=25510
+#if defined(__APPLE__) && (__clang_major__ <= 8)
 #undef USE_SSE_CRC32C
 #endif
 


### PR DESCRIPTION
This is a small fix to allow the clang compiler in OS/X El Capitan "Apple LLVM version 7.3.0 (clang-703.0.31)"  to compile the CRC acceleration code.

It is a fix for issue: https://github.com/tensorflow/tensorflow/issues/7223


