### PR TITLE
Switch to use tf.losses.softmax_cross_entropy in examples

### DIFF
--- a/tensorflow/examples/learn/iris_custom_model.py
+++ b/tensorflow/examples/learn/iris_custom_model.py
@@ -43,7 +43,7 @@ def my_model(features, target):
 
   # Compute logits (1 per class) and compute loss.
   logits = layers.fully_connected(features, 3, activation_fn=None)
-  loss = tf.contrib.losses.softmax_cross_entropy(logits, target)
+  loss = tf.losses.softmax_cross_entropy(logits, target)
 
   # Create a tensor for training op.
   train_op = tf.contrib.layers.optimize_loss(

--- a/tensorflow/examples/learn/iris_custom_model.py
+++ b/tensorflow/examples/learn/iris_custom_model.py
@@ -43,7 +43,7 @@ def my_model(features, target):
 
   # Compute logits (1 per class) and compute loss.
   logits = layers.fully_connected(features, 3, activation_fn=None)
-  loss = tf.losses.softmax_cross_entropy(logits, target)
+  loss = tf.losses.softmax_cross_entropy(target, logits)
 
   # Create a tensor for training op.
   train_op = tf.contrib.layers.optimize_loss(

--- a/tensorflow/examples/learn/mnist.py
+++ b/tensorflow/examples/learn/mnist.py
@@ -67,7 +67,7 @@ def conv_model(feature, target, mode):
 
   # Compute logits (1 per class) and compute loss.
   logits = layers.fully_connected(h_fc1, 10, activation_fn=None)
-  loss = tf.contrib.losses.softmax_cross_entropy(logits, target)
+  loss = tf.losses.softmax_cross_entropy(logits, target)
 
   # Create a tensor for training op.
   train_op = layers.optimize_loss(

--- a/tensorflow/examples/learn/mnist.py
+++ b/tensorflow/examples/learn/mnist.py
@@ -67,7 +67,7 @@ def conv_model(feature, target, mode):
 
   # Compute logits (1 per class) and compute loss.
   logits = layers.fully_connected(h_fc1, 10, activation_fn=None)
-  loss = tf.losses.softmax_cross_entropy(logits, target)
+  loss = tf.losses.softmax_cross_entropy(target, logits)
 
   # Create a tensor for training op.
   train_op = layers.optimize_loss(

--- a/tensorflow/examples/learn/multiple_gpu.py
+++ b/tensorflow/examples/learn/multiple_gpu.py
@@ -60,7 +60,7 @@ def my_model(features, target):
   with tf.device('/gpu:2'):
     # Compute logits (1 per class) and compute loss.
     logits = layers.fully_connected(features, 3, activation_fn=None)
-    loss = tf.contrib.losses.softmax_cross_entropy(logits, target)
+    loss = tf.losses.softmax_cross_entropy(logits, target)
 
     # Create a tensor for training op.
     train_op = tf.contrib.layers.optimize_loss(

--- a/tensorflow/examples/learn/multiple_gpu.py
+++ b/tensorflow/examples/learn/multiple_gpu.py
@@ -60,7 +60,7 @@ def my_model(features, target):
   with tf.device('/gpu:2'):
     # Compute logits (1 per class) and compute loss.
     logits = layers.fully_connected(features, 3, activation_fn=None)
-    loss = tf.losses.softmax_cross_entropy(logits, target)
+    loss = tf.losses.softmax_cross_entropy(target, logits)
 
     # Create a tensor for training op.
     train_op = tf.contrib.layers.optimize_loss(

--- a/tensorflow/examples/learn/resnet.py
+++ b/tensorflow/examples/learn/resnet.py
@@ -144,7 +144,7 @@ def res_net(x, y, activation=tf.nn.relu):
 
   target = tf.one_hot(y, depth=10, dtype=tf.float32)
   logits = tf.contrib.layers.fully_connected(net, 10, activation_fn=None)
-  loss = tf.contrib.losses.softmax_cross_entropy(logits, target)
+  loss = tf.losses.softmax_cross_entropy(logits, target)
   return tf.softmax(logits), loss
 
 

--- a/tensorflow/examples/learn/resnet.py
+++ b/tensorflow/examples/learn/resnet.py
@@ -144,7 +144,7 @@ def res_net(x, y, activation=tf.nn.relu):
 
   target = tf.one_hot(y, depth=10, dtype=tf.float32)
   logits = tf.contrib.layers.fully_connected(net, 10, activation_fn=None)
-  loss = tf.losses.softmax_cross_entropy(logits, target)
+  loss = tf.losses.softmax_cross_entropy(target, logits)
   return tf.softmax(logits), loss
 
 

--- a/tensorflow/examples/learn/text_classification_character_cnn.py
+++ b/tensorflow/examples/learn/text_classification_character_cnn.py
@@ -73,7 +73,7 @@ def char_cnn_model(features, target):
 
   # Apply regular WX + B and classification.
   logits = tf.contrib.layers.fully_connected(pool2, 15, activation_fn=None)
-  loss = tf.contrib.losses.softmax_cross_entropy(logits, target)
+  loss = tf.losses.softmax_cross_entropy(logits, target)
 
   train_op = tf.contrib.layers.optimize_loss(
       loss,

--- a/tensorflow/examples/learn/text_classification_character_cnn.py
+++ b/tensorflow/examples/learn/text_classification_character_cnn.py
@@ -73,7 +73,7 @@ def char_cnn_model(features, target):
 
   # Apply regular WX + B and classification.
   logits = tf.contrib.layers.fully_connected(pool2, 15, activation_fn=None)
-  loss = tf.losses.softmax_cross_entropy(logits, target)
+  loss = tf.losses.softmax_cross_entropy(target, logits)
 
   train_op = tf.contrib.layers.optimize_loss(
       loss,


### PR DESCRIPTION
`tf.contrib.losses` is deprecated. This only updates the examples. Leaving the actual removal of the`tf.contrib.losses` module to you guys internally. 