### PR TITLE
Improve docs for incompatible protobuf error

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -1212,6 +1212,12 @@ installed, such as:
 $ pip install --upgrade protobuf
 ```
 
+Or (if you have protobuf installed with Homebrew):
+
+```bash
+$ brew upgrade protobuf
+```
+
 ### Mac OS X: Segmentation Fault when import tensorflow
 
 On Mac OS X, you might get the following error when importing tensorflow in python:


### PR DESCRIPTION
On Mac OS X, importing tensorflow can result in the error: "TypeError: `__init__()` got an unexpected keyword argument 'syntax'". As explained in the doc, this is caused by an incompatible protobuf version. The suggested fix, "pip install --upgrade protobuf", doesn't resolve the issue if the user has installed protobuf via Homebrew. This commit adds an example command to fix the error in this case.