### PR TITLE
Fix gradle task dependencies

### DIFF
--- a/tensorflow/examples/android/build.gradle
+++ b/tensorflow/examples/android/build.gradle
@@ -61,12 +61,13 @@ task buildNative(type:Exec) {
        '--host_crosstool_top=@bazel_tools//tools/cpp:toolchain'
 }
 
-task copyNativeLibs(type: Copy) {
+task copyNativeLibs(type: Copy, dependsOn: "buildNative") {
     from('../../../bazel-bin/tensorflow/examples/android') { include '**/*.so' }
     into nativeDir
     duplicatesStrategy = 'include'
 }
 
-copyNativeLibs.dependsOn buildNative
-assemble.dependsOn copyNativeLibs
-assembleDebug.dependsOn copyNativeLibs
+afterEvaluate {
+    assemble.dependsOn copyNativeLibs
+    assembleDebug.dependsOn copyNativeLibs
+}


### PR DESCRIPTION
Without the `afterEvaluate` closure, gradle can’t find the `assembleDebug` task.

See: https://code.google.com/p/android/issues/detail?id=219732#c32