### PR TITLE
change tf.contrib.learn.datasets.load_dataset('boston') to sklearn.da…

### DIFF
--- a/tensorflow/examples/learn/boston.py
+++ b/tensorflow/examples/learn/boston.py
@@ -19,12 +19,14 @@ from __future__ import print_function
 from sklearn import cross_validation
 from sklearn import metrics
 from sklearn import preprocessing
+from sklearn import datasets
 import tensorflow as tf
 
 
 def main(unused_argv):
   # Load dataset
-  boston = tf.contrib.learn.datasets.load_dataset('boston')
+  boston = datasets.load_boston()
+
   x, y = boston.data, boston.target
 
   # Split dataset into train / test

--- a/tensorflow/examples/learn/iris.py
+++ b/tensorflow/examples/learn/iris.py
@@ -18,12 +18,13 @@ from __future__ import division
 from __future__ import print_function
 from sklearn import cross_validation
 from sklearn import metrics
+from sklearn import datasets
 import tensorflow as tf
 
 
 def main(unused_argv):
   # Load dataset.
-  iris = tf.contrib.learn.datasets.load_dataset('iris')
+  iris = datasets.load_iris()
   x_train, x_test, y_train, y_test = cross_validation.train_test_split(
       iris.data, iris.target, test_size=0.2, random_state=42)
 


### PR DESCRIPTION
change tf.contrib.learn.datasets.load_dataset('boston') to sklearn.datasets.load_boston()

change tf.contrib.learn.datasets.load_dataset('iris') to sklearn.datasets.load_iris()

because when run examples/learn/iris.py and examples/learn/boston.py  with python35, errors like followings occurs:
UnicodeEncodeError: 'utf-16-le' codec can't encode character '\udcds' in position 166: surrogates not allowed
so it's better to change sklearn's method.
