### PR TITLE
fesetround is not part of the C++ std library

### DIFF
--- a/tensorflow/core/platform/setround.cc
+++ b/tensorflow/core/platform/setround.cc
@@ -24,7 +24,7 @@ namespace port {
 
 ScopedSetRound::ScopedSetRound() {
 #ifdef __STDC_IEC_559__
-   std::fesetround(FE_TONEAREST);
+   fesetround(FE_TONEAREST);
 #endif
 }
 


### PR DESCRIPTION
fesetround() is not part of the C++ std library. It is defined in the [fenv.h header in the POSIX standard](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fesetround.html).

Addresses #7289 