### PR TITLE
Propagate TF_BUILD_ENABLE_XLA environment variable into the CI build …

### DIFF
--- a/tensorflow/tools/ci_build/ci_parameterized_build.sh
+++ b/tensorflow/tools/ci_build/ci_parameterized_build.sh
@@ -137,11 +137,14 @@ PARALLEL_GPU_TEST_CMD='//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execut
 
 BENCHMARK_CMD="${CI_BUILD_DIR}/builds/benchmark.sh"
 
+EXTRA_PARAMS=""
+
 export TF_BUILD_ENABLE_XLA=${TF_BUILD_ENABLE_XLA:-0}
 if [[ -z $TF_BUILD_ENABLE_XLA ]] || [ $TF_BUILD_ENABLE_XLA == 0 ]; then
   BAZEL_TARGET="//tensorflow/... -//tensorflow/compiler/..."
 else
   BAZEL_TARGET="//tensorflow/compiler/..."
+  EXTRA_PARAMS="${EXTRA_PARAMS} -e TF_BUILD_ENABLE_XLA=1"
 fi
 
 TUT_TEST_DATA_DIR="/tmp/tf_tutorial_test_data"
@@ -182,6 +185,8 @@ echo "  TF_BUILD_INTEGRATION_TESTS=${TF_BUILD_INTEGRATION_TESTS}"
 echo "  TF_BUILD_RUN_BENCHMARKS=${TF_BUILD_RUN_BENCHMARKS}"
 echo "  TF_BUILD_DISABLE_GCP=${TF_BUILD_DISABLE_GCP}"
 echo "  TF_BUILD_OPTIONS=${TF_BUILD_OPTIONS}"
+echo "  TF_BUILD_ENABLE_XLA=${TF_BUILD_ENABLE_XLA}"
+
 
 # Function that tries to determine CUDA capability, if deviceQuery binary
 # is available on path
@@ -252,8 +257,6 @@ else
   die "Unrecognized value in TF_BUILD_CONTAINER_TYPE: "\
 "\"${TF_BUILD_CONTAINER_TYPE}\""
 fi
-
-EXTRA_PARAMS=""
 
 # Determine if this is a benchmarks job
 RUN_BENCHMARKS=0


### PR DESCRIPTION
…docker container from ci_parameterized_build.sh.

Fixes XLA continuous builds.
Change: 145100608