### PR TITLE
Float indexing test fix for Numpy >= 1.12+

### DIFF
--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -95,7 +95,7 @@ class RNNCellTest(test.TestCase):
       input_size = 4
       feature_size = 2
       frequency_skip = 1
-      num_shifts = (input_size - feature_size) / frequency_skip + 1
+      num_shifts = (input_size - feature_size) // frequency_skip + 1
       with variable_scope.variable_scope(
           "root", initializer=init_ops.constant_initializer(0.5)):
         x = array_ops.zeros([batch_size, input_size])


### PR DESCRIPTION
This fixes test failure for NumPy 1.12 that does not allow float indexing of arrays. Of course, it makes sense to index arrays using ints anyway, regardless of NumPy support. I assume this wasn't causing problems to people with NumPy up to 1.11.3, but it's better not to assume a specific NumPy version.