### PR TITLE
Fix unsorted_segment_max for negative floats

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops.cc
@@ -254,7 +254,7 @@ struct UnsortedSegmentMaxFunctor<CPUDevice, T, Index>
                   typename TTypes<Index>::ConstFlat segment_ids,
                   const Index data_size, const T* data,
                   typename TTypes<T, 2>::Tensor output) override {
-    output.setConstant(std::numeric_limits<T>::min());
+    output.setConstant(std::numeric_limits<T>::lowest());
     if (data_size == 0) {
       return;
     }


### PR DESCRIPTION
Fixes the following bug due to std::numeric_limits<float>::min() returning the smallest positive value of a float.

```
with tf.Session() as sess:
    x = tf.constant([-1.0, -2.0, -3.0, -4.0])
    segment_ids = tf.constant([0, 1, 2, 3])
    unsorted_seg_max = tf.unsorted_segment_max(x, segment_ids, 4)
    print(sess.run(unsorted_seg_max))
>>> [  1.17549435e-38   1.17549435e-38   1.17549435e-38   1.17549435e-38]
```
