### PR TITLE
set correct target directory for tar extractall()

### DIFF
--- a/tensorflow/examples/udacity/1_notmnist.ipynb
+++ b/tensorflow/examples/udacity/1_notmnist.ipynb
@@ -219,7 +219,7 @@
         "    print('Extracting data for %s. This may take a while. Please wait.' % root)\n",
         "    tar = tarfile.open(filename)\n",
         "    sys.stdout.flush()\n",
-        "    tar.extractall()\n",
+        "    tar.extractall(data_root)\n",
         "    tar.close()\n",
         "  data_folders = [\n",
         "    os.path.join(root, d) for d in sorted(os.listdir(root))\n",


### PR DESCRIPTION
fixes a wrong path when data_root is other than '.'