### PR TITLE
Make this not UnboundLocalError if the actual TF_NewStatus failed.

### DIFF
--- a/tensorflow/python/framework/errors_impl.py
+++ b/tensorflow/python/framework/errors_impl.py
@@ -459,8 +459,8 @@ def _make_specific_exception(node_def, op, message, error_code):
 
 @contextlib.contextmanager
 def raise_exception_on_not_ok_status():
+  status = pywrap_tensorflow.TF_NewStatus()
   try:
-    status = pywrap_tensorflow.TF_NewStatus()
     yield status
     if pywrap_tensorflow.TF_GetCode(status) != 0:
       raise _make_specific_exception(


### PR DESCRIPTION
Closes #7356.

Doesn't look like there are previous tests here, so unfortunately submitting this without any new tests, but if I've missed where they live let me know.