### PR TITLE
CP 1.0

### DIFF
--- a/tensorflow/stream_executor/lib/status_macros.h
+++ b/tensorflow/stream_executor/lib/status_macros.h
@@ -59,7 +59,7 @@ limitations under the License.
 #define SE_RETURN_STATUS_AS_BOOL(__status) \
   do {                                     \
     auto status = __status;                \
-    if (__status.ok()) {                   \
+    if (status.ok()) {                     \
       return true;                         \
     }                                      \
     LOG(ERROR) << status;                  \


### PR DESCRIPTION
Fix double evaluation of macro argument that was causing duplicate CUDA batched GEMM calls.

Change: 147025110

(cherry picked from commit f439016532a8b310bb4cc984eed1c331b4d3be8a)