### PR TITLE
Fixed off-by-one error in L115-116 in wordvec_basic.py

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -112,6 +112,8 @@ def generate_batch(batch_size, num_skips, skip_window):
       labels[i * num_skips + j, 0] = buffer[target]
     buffer.append(data[data_index])
     data_index = (data_index + 1) % len(data)
+  # Backtrack a little bit to avoid skipping words in the end of a batch
+  data_index = (data_index + len(data) - span) % len(data)
   return batch, labels
 
 batch, labels = generate_batch(batch_size=8, num_skips=2, skip_window=1)


### PR DESCRIPTION
In the original tensorflow word2vec tutorial, words in the end of a batch will be skipped.
Check [issue 6860](https://github.com/tensorflow/tensorflow/issues/6860) for details.

Fixes #6860 