### PR TITLE
Replace deprecated tf.op_scope by tf.name_scope

### DIFF
--- a/tensorflow/g3doc/how_tos/style_guide.md
+++ b/tensorflow/g3doc/how_tos/style_guide.md
@@ -134,7 +134,7 @@ Example:
                 output_collections=['MY_OPS'], name='add_t1t2')
       [2.3, 3.4]
     """
-    with tf.op_scope([tensor_in, other_tensor_in], name, "my_op"):
+    with tf.name_scope(name, "my_op", [tensor_in, other_tensor_in]):
       tensor_in = tf.convert_to_tensor(tensor_in)
       other_tensor_in = tf.convert_to_tensor(other_tensor_in)
       result = my_param * tensor_in + other_param * other_tensor_in


### PR DESCRIPTION
Since tf.op_scope is deprecated (see https://www.tensorflow.org/api_docs/python/framework/defining_new_operations#op_scope) it should probably be removed from the style guide.