### PR TITLE
Fix dynamic_stitch gradient implementation

### DIFF
--- a/tensorflow/python/kernel_tests/dynamic_stitch_op_test.py
+++ b/tensorflow/python/kernel_tests/dynamic_stitch_op_test.py
@@ -21,8 +21,10 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import data_flow_ops
-from tensorflow.python.ops import gradients_impl
+from tensorflow.python.ops import gradient_checker
 import tensorflow.python.ops.data_flow_grad  # pylint: disable=unused-import
 from tensorflow.python.platform import test
 
@@ -32,7 +34,7 @@ class DynamicStitchTest(test.TestCase):
   def testScalar(self):
     with self.test_session():
       indices = [constant_op.constant(0), constant_op.constant(1)]
-      data = [constant_op.constant(40), constant_op.constant(60)]
+      data = [constant_op.constant(40.), constant_op.constant(60.)]
       for step in -1, 1:
         stitched_t = data_flow_ops.dynamic_stitch(indices[::step], data)
         stitched_val = stitched_t.eval()
@@ -42,14 +44,21 @@ class DynamicStitchTest(test.TestCase):
         # length.
         self.assertEqual([None], stitched_t.get_shape().as_list())
 
+        # Test gradients
+        self.assertLess(
+            gradient_checker.compute_gradient_error(
+                data, [x.get_shape().as_list() for x in data],
+                stitched_t, array_ops.shape(stitched_t).eval()),
+            1e-4)
+
   def testSimpleOneDimensional(self):
     with self.test_session():
       indices = [
           constant_op.constant([0, 4, 7]), constant_op.constant([1, 6, 2, 3, 5])
       ]
       data = [
-          constant_op.constant([0, 40, 70]),
-          constant_op.constant([10, 60, 20, 30, 50])
+          constant_op.constant([0, 40, 70], dtypes.float32),
+          constant_op.constant([10, 60, 20, 30, 50], dtypes.float32)
       ]
       stitched_t = data_flow_ops.dynamic_stitch(indices, data)
       stitched_val = stitched_t.eval()
@@ -59,10 +68,18 @@ class DynamicStitchTest(test.TestCase):
       # length.
       self.assertEqual([None], stitched_t.get_shape().as_list())
 
+      # Test gradients
+      self.assertLess(
+          gradient_checker.compute_gradient_error(
+              data, [x.get_shape().as_list() for x in data],
+              stitched_t, array_ops.shape(stitched_t).eval()),
+          1e-4)
+
   def testOneListOneDimensional(self):
     with self.test_session():
       indices = [constant_op.constant([1, 6, 2, 3, 5, 0, 4, 7])]
-      data = [constant_op.constant([10, 60, 20, 30, 50, 0, 40, 70])]
+      data = [constant_op.constant([10, 60, 20, 30, 50, 0, 40, 70],
+                                   dtypes.float32)]
       stitched_t = data_flow_ops.dynamic_stitch(indices, data)
       stitched_val = stitched_t.eval()
       self.assertAllEqual([0, 10, 20, 30, 40, 50, 60, 70], stitched_val)
@@ -70,6 +87,13 @@ class DynamicStitchTest(test.TestCase):
       # can only infer that the output is a vector of some unknown
       # length.
       self.assertEqual([None], stitched_t.get_shape().as_list())
+
+      # Test gradients
+      self.assertLess(
+          gradient_checker.compute_gradient_error(
+              data, [x.get_shape().as_list() for x in data],
+              stitched_t, array_ops.shape(stitched_t).eval()),
+          1e-4)
 
   def testSimpleTwoDimensional(self):
     with self.test_session():
@@ -78,9 +102,9 @@ class DynamicStitchTest(test.TestCase):
           constant_op.constant([2, 3, 5])
       ]
       data = [
-          constant_op.constant([[0, 1], [40, 41], [70, 71]]),
-          constant_op.constant([[10, 11], [60, 61]]),
-          constant_op.constant([[20, 21], [30, 31], [50, 51]])
+          constant_op.constant([[0, 1], [40, 41], [70, 71]], dtypes.float32),
+          constant_op.constant([[10, 11], [60, 61]], dtypes.float32),
+          constant_op.constant([[20, 21], [30, 31], [50, 51]], dtypes.float32)
       ]
       stitched_t = data_flow_ops.dynamic_stitch(indices, data)
       stitched_val = stitched_t.eval()
@@ -91,16 +115,24 @@ class DynamicStitchTest(test.TestCase):
       # some unknown number of rows.
       self.assertEqual([None, 2], stitched_t.get_shape().as_list())
 
+      # Test gradients
+      self.assertLess(
+          gradient_checker.compute_gradient_error(
+              data, [x.get_shape().as_list() for x in data],
+              stitched_t, array_ops.shape(stitched_t).eval()),
+          1e-4)
+
   def testHigherRank(self):
-    with self.test_session() as sess:
+    with self.test_session():
       indices = [
           constant_op.constant(6), constant_op.constant([4, 1]),
           constant_op.constant([[5, 2], [0, 3]])
       ]
       data = [
-          constant_op.constant([61, 62]),
-          constant_op.constant([[41, 42], [11, 12]]),
-          constant_op.constant([[[51, 52], [21, 22]], [[1, 2], [31, 32]]])
+          constant_op.constant([61, 62], dtypes.float32),
+          constant_op.constant([[41, 42], [11, 12]], dtypes.float32),
+          constant_op.constant([[[51, 52], [21, 22]], [[1, 2], [31, 32]]],
+                               dtypes.float32)
       ]
       stitched_t = data_flow_ops.dynamic_stitch(indices, data)
       stitched_val = stitched_t.eval()
@@ -108,12 +140,35 @@ class DynamicStitchTest(test.TestCase):
       self.assertAllEqual(correct, stitched_val)
       self.assertEqual([None, 2], stitched_t.get_shape().as_list())
       # Test gradients
-      stitched_grad = 7 * stitched_val
-      grads = gradients_impl.gradients(stitched_t, indices + data,
-                                       stitched_grad)
-      self.assertEqual(grads[:3], [None] * 3)  # Indices have no gradients
-      for datum, grad in zip(data, sess.run(grads[3:])):
-        self.assertAllEqual(7 * datum.eval(), grad)
+      self.assertLess(
+          gradient_checker.compute_gradient_error(
+              data, [x.get_shape().as_list() for x in data],
+              stitched_t, array_ops.shape(stitched_t).eval()),
+          1e-4)
+
+  def testDuplicates(self):
+    with self.test_session():
+      indices = [
+        constant_op.constant([0, 1]), constant_op.constant([1, 2, 3]),
+        constant_op.constant([3, 4])
+      ]
+      data = [
+        constant_op.constant([1, 2], dtypes.float32),
+          constant_op.constant([12, 13, 14], dtypes.float32),
+        constant_op.constant([24, 25], dtypes.float32)
+      ]
+      stitched_t = data_flow_ops.dynamic_stitch(indices, data)
+      stitched_val = stitched_t.eval()
+      correct = [1, 12, 13, 24, 25]
+      self.assertAllEqual(correct, stitched_val)
+      self.assertEqual([None], stitched_t.get_shape().as_list())
+
+      # Test gradients
+      self.assertLess(
+        gradient_checker.compute_gradient_error(
+          data, [x.get_shape().as_list() for x in data],
+          stitched_t, array_ops.shape(stitched_t).eval()),
+        1e-4)
 
   def testErrorIndicesMultiDimensional(self):
     indices = [


### PR DESCRIPTION
This modifies the gradient calculation for the `dynamic_stitch` op so that it gives the correct gradient when the input indices have duplicate values (issue is described in more detail in #7397).

I also expanded the unit tests so that the gradient calculation is tested with a wider range of inputs (since it is now more complicated/error-prone), and added a test specifically for the duplicate indices case.

