### PR TITLE
Fix link in CONTRIBUTING.md from "contributions welcome" to "stat:con…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If you have improvements to TensorFlow, send us your pull requests! For those
 just getting started, Github has a [howto](https://help.github.com/articles/using-pull-requests/).
 
 If you want to contribute but you're not sure where to start, take a look at the
-[issues with the "contributions welcome" label](https://github.com/tensorflow/tensorflow/labels/contributions%20welcome).
+[issues with the "contributions welcome" label](https://github.com/tensorflow/tensorflow/labels/stat%3Acontributions%20welcome).
 These are issues that we believe are particularly well suited for outside
 contributions, often because we probably won't get to them right now. If you
 decide to start on an issue, leave a comment so that other people know that


### PR DESCRIPTION
…tributions welcome"

I don't want to bother anyone with this, but the link in the CONTRIBUTING.md file points to a label that either doesn't exist or isn't used. I propose changing it to "stat:contributions welcome" to make sure that people won't think that there is nothing to contribute on.