### PR TITLE
Fix GetDsoHandle segfault

### DIFF
--- a/tensorflow/stream_executor/dso_loader.cc
+++ b/tensorflow/stream_executor/dso_loader.cc
@@ -123,9 +123,13 @@ static mutex& GetRpathMutex() {
   port::Status s =
       port::Env::Default()->LoadLibrary(path_string.c_str(), dso_handle);
   if (!s.ok()) {
+#if !defined(PLATFORM_WINDOWS)
+    char* ld_library_path = getenv("LD_LIBRARY_PATH");
+#endif
     LOG(INFO) << "Couldn't open CUDA library " << path
 #if !defined(PLATFORM_WINDOWS)
-              << ". LD_LIBRARY_PATH: " << getenv("LD_LIBRARY_PATH")
+              << ". LD_LIBRARY_PATH: "
+              << (ld_library_path != nullptr ? ld_library_path : "")
 #endif
     ;
     return port::Status(port::error::FAILED_PRECONDITION,


### PR DESCRIPTION
Currently segfaults when LD_PRELOAD_PATH isn't set when it tries to include it in a log message:

```
Process 86579 launched: '/Users/spinlock/src/carpedm20/DCGAN-tensorflow/.venv/bin/python' (x86_64)
I tensorflow/stream_executor/dso_loader.cc:135] successfully opened CUDA library libcublas.8.0.dylib locally
Process 86579 stopped
* thread #1: tid = 0x15ed75, 0x00007fff89152132 libsystem_c.dylib`strlen + 18, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x00007fff89152132 libsystem_c.dylib`strlen + 18
libsystem_c.dylib`strlen:
->  0x7fff89152132 <+18>: pcmpeqb xmm0, xmmword ptr [rdi]
    0x7fff89152136 <+22>: pmovmskb esi, xmm0
    0x7fff8915213a <+26>: and    rcx, 0xf
    0x7fff8915213e <+30>: or     rax, -0x1
(lldb) bt
* thread #1: tid = 0x15ed75, 0x00007fff89152132 libsystem_c.dylib`strlen + 18, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x00007fff89152132 libsystem_c.dylib`strlen + 18
    frame #1: 0x000000010651cd8a _pywrap_tensorflow.so`perftools::gputools::internal::DsoLoader::GetDsoHandle(tensorflow::StringPiece, void**, perftools::gputools::internal::DsoLoader::LoadKind) + 282
...
    0x10651cd31 <+193>: lea    rsi, [rip + 0xf7545a]     ; "Couldn't open CUDA library "
    0x10651cd38 <+200>: lea    rdi, [rbp - 0x228]
    0x10651cd3f <+207>: mov    edx, 0x1b
    0x10651cd44 <+212>: call   0x1043d2620               ; std::__1::basic_ostream<char, std::__1::char_traits<char> >& std::__1::__put_character_sequence<char, std::__1::char_traits<char> >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, char const*, unsigned long)
    0x10651cd49 <+217>: lea    rdi, [rbp - 0x228]
    0x10651cd50 <+224>: mov    rsi, r12
    0x10651cd53 <+227>: mov    rdx, r15
    0x10651cd56 <+230>: call   0x1067f9c80               ; tensorflow::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, tensorflow::StringPiece)
    0x10651cd5b <+235>: lea    rsi, [rip + 0xf7544c]     ; ". LD_LIBRARY_PATH: "
    0x10651cd62 <+242>: lea    rdi, [rbp - 0x228]
    0x10651cd69 <+249>: mov    edx, 0x13
    0x10651cd6e <+254>: call   0x1043d2620               ; std::__1::basic_ostream<char, std::__1::char_traits<char> >& std::__1::__put_character_sequence<char, std::__1::char_traits<char> >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, char const*, unsigned long)
    0x10651cd73 <+259>: lea    rdi, [rip + 0xf6ffd4]     ; "LD_LIBRARY_PATH"
    0x10651cd7a <+266>: call   0x106af84c8               ; symbol stub for: getenv
    0x10651cd7f <+271>: mov    rbx, rax
    0x10651cd82 <+274>: mov    rdi, rbx
    0x10651cd85 <+277>: call   0x106af87fe               ; symbol stub for: strlen
    0x10651cd8a <+282>: lea    rdi, [rbp - 0x228]
    0x10651cd91 <+289>: mov    rsi, rbx
    0x10651cd94 <+292>: mov    rdx, rax
    0x10651cd97 <+295>: call   0x1043d2620               ; std::__1::basic_ostream<char, std::__1::char_traits<char> >& std::__1::__put_character_sequence<char, std::__1::char_traits<char> >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, char const*, unsigned long)
    0x10651cd9c <+300>: lea    rdi, [rbp - 0x228]
    0x10651cda3 <+307>: call   0x10681be90               ; tensorflow::internal::LogMessage::~LogMessage()
    0x10651cda8 <+312>: lea    rax, [rip + 0xf75413]     ; "could not dlopen DSO: "
```

Trying to verify but still trying to get a working dev environment setup.