### PR TITLE
[#issue7328]Validate ip address in distributed computation

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -133,7 +133,7 @@ Status GrpcServer::Init() {
         return errors::InvalidArgument(
             "Could not parse port for local server from \"", iter->second,
             "\"");
-      } else if (!IsValidIpAddr(hostname_port[0])) {
+      } else if (!port::IsValidIpAddr(hostname_port[0])) {
         return errors::InvalidArgument(
             "Invalid ip address for local server from \"", iter->second,
             "\"");

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -42,6 +42,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/host_info.h"
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/public/session_options.h"
 
@@ -131,6 +132,10 @@ Status GrpcServer::Init() {
           !strings::safe_strto32(hostname_port[1], &requested_port_)) {
         return errors::InvalidArgument(
             "Could not parse port for local server from \"", iter->second,
+            "\"");
+      } else if (!IsValidIpAddr(hostname_port[0])) {
+        return errors::InvalidArgument(
+            "Invalid ip address for local server from \"", iter->second,
             "\"");
       } else {
         break;

--- a/tensorflow/core/platform/host_info.h
+++ b/tensorflow/core/platform/host_info.h
@@ -24,6 +24,9 @@ namespace port {
 // Return the hostname of the machine on which this process is running
 string Hostname();
 
+// Check whether the current hostname and port is valid.
+bool IsValidIpAddr(const string& ip);
+
 }  // namespace port
 }  // namespace tensorflow
 

--- a/tensorflow/core/platform/port_test.cc
+++ b/tensorflow/core/platform/port_test.cc
@@ -16,12 +16,24 @@ limitations under the License.
 #include <condition_variable>
 #include "tensorflow/core/lib/core/threadpool.h"
 #include "tensorflow/core/platform/cpu_info.h"
+#include "tensorflow/core/platform/host_info.h"
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/test.h"
 
 namespace tensorflow {
 namespace port {
+
+TEST(IsValidIpAddr, Ip) {
+  EXPECT_TRUE(IsValidIpAddr("192.168.0.1"))
+  EXPECT_TRUE(IsValidIpAddr("255.255.255.255"))
+  EXPECT_TRUE(IsValidIpAddr("0.0.0.0"))
+
+  EXPECT_FALSE(IsValidIpAddr("192.168.0.1."))
+  EXPECT_FALSE(IsValidIpAddr("255.255.255."))
+  EXPECT_FALSE(IsValidIpAddr("255.255.255.256"))
+  EXPECT_FALSE(IsValidIpAddr("."))
+}
 
 TEST(Port, AlignedMalloc) {
   for (size_t alignment = 1; alignment <= 1 << 20; alignment <<= 1) {

--- a/tensorflow/core/platform/posix/port.cc
+++ b/tensorflow/core/platform/posix/port.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/types.h"
+#include <arpa/inet.h>
 #if defined(__linux__) && !defined(__ANDROID__)
 #include <sched.h>
 #endif
@@ -45,6 +46,11 @@ string Hostname() {
   gethostname(hostname, sizeof hostname);
   hostname[sizeof hostname - 1] = 0;
   return string(hostname);
+}
+
+bool IsValidIpAddr(const string& ip) {
+  struct sockaddr_in sa;
+  return inet_pton(AF_INET, ip.c_str(), &(sa.sin_addr))!=0;
 }
 
 int NumSchedulableCPUs() {

--- a/tensorflow/core/platform/windows/port.cc
+++ b/tensorflow/core/platform/windows/port.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #endif
 
 #include <Windows.h>
+#include <Ws2tcpip.h>
 
 #include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/demangle.h"
@@ -30,6 +31,8 @@ limitations under the License.
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/snappy.h"
 #include "tensorflow/core/platform/types.h"
+
+#pragma comment(lib, "ws2_32.lib")
 
 namespace tensorflow {
 namespace port {
@@ -44,6 +47,11 @@ string Hostname() {
     name[name_size] = 0;
   }
   return name;
+}
+
+bool IsValidIpAddr(const string& ip) {
+  struct sockaddr_in sa;
+  return inet_pton(AF_INET, ip.c_str(), &(sa.sin_addr))!=0;
 }
 
 int NumSchedulableCPUs() {


### PR DESCRIPTION
[#issue7328](https://github.com/tensorflow/tensorflow/issues/7328)

`inet_pton()` is a recommended and general way to validate ip address(including IPv4 and IPv6) both in [linux](https://linux.die.net/man/3/inet_pton) and [Windows](https://msdn.microsoft.com/en-us/library/windows/desktop/cc805844(v=vs.85).aspx). 

@mrry  Do I add the validation in the right place? I would add some unit tests tomorrow morning.

BTW:Does TensorFlow support IPv6 now?

