### PR TITLE
Handle case of zero time elapsed on estimated steps/sec

### DIFF
--- a/tensorflow/python/training/supervisor.py
+++ b/tensorflow/python/training/supervisor.py
@@ -1027,7 +1027,7 @@ class SVStepCounterThread(coordinator.LooperThread):
     elapsed_time = current_time - self._last_time
     self._last_time = current_time
     # Reports the number of steps done per second
-    steps_per_sec = added_steps / elapsed_time
+    steps_per_sec = added_steps / elapsed_time if elapsed_time != 0. else float("inf")
     summary = Summary(value=[Summary.Value(tag=self._summary_tag,
                                            simple_value=steps_per_sec)])
     if self._sv.summary_writer:


### PR DESCRIPTION
Explicitly produce inf in that case. Fixes #3172. 