### PR TITLE
Added atrous_conv1d and 3d. Refactored 2d.

### DIFF
--- a/tensorflow/python/ops/nn.py
+++ b/tensorflow/python/ops/nn.py
@@ -31,7 +31,9 @@
 @@depthwise_conv2d
 @@depthwise_conv2d_native
 @@separable_conv2d
+@@atrous_conv1d
 @@atrous_conv2d
+@@atrous_conv3d
 @@atrous_conv2d_transpose
 @@conv2d_transpose
 @@conv1d

--- a/tensorflow/python/ops/nn.py
+++ b/tensorflow/python/ops/nn.py
@@ -31,9 +31,7 @@
 @@depthwise_conv2d
 @@depthwise_conv2d_native
 @@separable_conv2d
-@@atrous_conv1d
 @@atrous_conv2d
-@@atrous_conv3d
 @@atrous_conv2d_transpose
 @@conv2d_transpose
 @@conv1d

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -806,11 +806,12 @@ def pool(input,  # pylint: disable=redefined-builtin
 
 
 def atrous_conv2d(value, filters, rate, padding, strides=None, name=None):
-  """This function is a simpler wrapper around the more general
+  """Atrous convolution (a.k.a. convolution with holes or dilated convolution).
+
+  This function is a simpler wrapper around the more general
   @{tf.nn.convolution}, and exists only for backwards compatibility. You can
   use @{tf.nn.convolution} to perform 1-D, 2-D, or 3-D atrous convolution.
 
-  Atrous convolution (a.k.a. convolution with holes or dilated convolution).
 
   Computes a 2-D atrous convolution, also known as convolution with holes or
   dilated convolution, given 4-D `value` and `filters` tensors. If the `rate`

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -805,55 +805,12 @@ def pool(input,  # pylint: disable=redefined-builtin
         filter_shape=window_shape)
 
 
-def atrous_conv1d(input, filter, rate, padding, strides=None, name=None):
-  """Atrous convolution (a.k.a. convolution with holes or dilated convolution).
-
-  Computes a 1-D atrous convolution, also known as convolution with holes or
-  dilated convolution, given 3-D `input` and `filter` tensors. If the `rate`
-  parameter is equal to one, it performs regular 1-D convolution. If the `rate`
-  parameter is greater than one, it performs convolution with holes, sampling
-  the input values every `rate` points.
-  This is equivalent to convolving the input with a set of upsampled filters,
-  produced by inserting `rate - 1` zeros between two consecutive values of the
-  filters along the `height` dimensions, hence the name atrous
-  convolution or convolution with holes (the French word trous means holes in
-  English).
-
-  See @{tf.nn.atrous_conv2d}
-
-  Args:
-  input: A 3-D `Tensor` of type `float`. It needs to be in the default "NHWC"
-    format. Its shape is `[batch, in_height, in_channels]`.
-  filter: A 3-D `Tensor` with the same type as `input` and shape
-    `[filter_height, in_channels, out_channels]`. `filter`'
-    `in_channels` dimension must match that of `input`. Atrous convolution is
-    equivalent to standard convolution with upsampled filters with effective
-    height `filter_height + (filter_height - 1) * (rate - 1)`, produced by
-    inserting `rate - 1` zeros along consecutive elements across the
-    `filter`' spatial dimensions.
-  rate: A positive int32. The stride with which we sample input values across
-    the `height` and `width` dimensions. Equivalently, the rate by which we
-    upsample the filter values by inserting zeros across the `height` and
-    `width` dimensions. In the literature, the same parameter is sometimes
-    called `input stride` or `dilation`.
-  padding: A string, either `'VALID'` or `'SAME'`. The padding algorithm.
-  strides: Optional.  Sequence of 1 ints >= 1.  Specifies the output stride.
-    Defaults to [1].  If any value of strides is > 1, then all values of
-    dilation_rate must be 1.
-  name: Optional name for the returned tensor.
-  Returns:
-    A `Tensor` with the same type as `value`.
-  Raises:
-    ValueError: If input/output depth does not match `filters`' shape, or if
-      padding is other than `'VALID'` or `'SAME'`.
-
-  """
-  return convolution(input=input, filter=filter, padding=padding,
-                     dilation_rate=np.broadcast_to(rate, (1, )),
-                     strides=strides, name=name)
-
 def atrous_conv2d(value, filters, rate, padding, strides=None, name=None):
-  """Atrous convolution (a.k.a. convolution with holes or dilated convolution).
+  """This function is a simpler wrapper around the more general
+  @{tf.nn.convolution}, and exists only for backwards compatibility. You can
+  use @{tf.nn.convolution} to perform 1-D, 2-D, or 3-D atrous convolution.
+
+  Atrous convolution (a.k.a. convolution with holes or dilated convolution).
 
   Computes a 2-D atrous convolution, also known as convolution with holes or
   dilated convolution, given 4-D `value` and `filters` tensors. If the `rate`
@@ -966,57 +923,6 @@ def atrous_conv2d(value, filters, rate, padding, strides=None, name=None):
                      dilation_rate=np.broadcast_to(rate, (2, )),
                      strides=strides, name=name)
 
-
-def atrous_conv3d(input, filter, rate, padding, strides=None, name=None):
-  """Atrous convolution (a.k.a. convolution with holes or dilated convolution).
-
-  Computes a 3-D atrous convolution, also known as convolution with holes or
-  dilated convolution, given 5-D `input` and `filter` tensors. If the `rate`
-  parameter is equal to one, it performs regular 3-D convolution. If the `rate`
-  parameter is greater than one, it performs convolution with holes, sampling
-  the input values every `rate` points.
-  This is equivalent to convolving the input with a set of upsampled filters,
-  produced by inserting `rate - 1` zeros between two consecutive values of the
-  filters along the `height`, `width` and `depth` dimensions, hence the name
-  atrous convolution or convolution with holes (the French word trous means
-  holes in English).
-
-  See @{tf.nn.atrous_conv2d}
-
-  Args:
-    input: A 5-D `Tensor` of type `float`. It needs to be in the default "NHWC"
-      format. Its shape is
-      `[batch, in_height, in_width, in_depth, in_channels]`.
-    filter: A 5-D `Tensor` with the same type as `input` and shape
-      `[filter_height, filter_width, filter_depth, in_channels, out_channels]`.
-      `filter`' `in_channels` dimension must match that of `input`. Atrous
-      convolution is equivalent to standard convolution with upsampled filters
-      with effective height `filter_height + (filter_height - 1) * (rate - 1)`,
-      produced by inserting `rate - 1` zeros along consecutive elements across
-      the `filter`' spatial dimensions.
-    rate: A positive int32. The stride with which we sample input values across
-      the `height` and `width` dimensions. Equivalently, the rate by which we
-      upsample the filter values by inserting zeros across the `height` and
-      `width` dimensions. In the literature, the same parameter is sometimes
-      called `input stride` or `dilation`. Altrenatively it could be 3 element
-      sequence denoting dilation rate in each dimension. padding: A string,
-      either `'VALID'` or `'SAME'`. The padding algorithm. strides: Optional.
-        Sequence of 3 ints >= 1.  Specifies the output stride. Defaults to
-        [1]*3.  If any value of strides is > 1, then all values of
-        dilation_rate must be 1.
-    name: Optional name for the returned tensor.
-
-  Returns:
-    A `Tensor` with the same type as `value`.
-
-  Raises:
-    ValueError: If input/output depth does not match `filters`' shape, or if
-      padding is other than `'VALID'` or `'SAME'`.
-
-  """
-  return convolution(input=input, filter=filter, padding=padding,
-                     dilation_rate=np.broadcast_to(rate, (3, )),
-                     strides=strides, name=name)
 
 def conv2d_transpose(value,
                      filter,

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -920,8 +920,7 @@ def atrous_conv2d(value, filters, rate, padding, name=None):
       padding is other than `'VALID'` or `'SAME'`.
   """
   return convolution(input=value, filter=filters, padding=padding,
-                     dilation_rate=np.broadcast_to(rate, (2, )),
-                     strides=strides, name=name)
+                     dilation_rate=np.broadcast_to(rate, (2, )), name=name)
 
 
 def conv2d_transpose(value,

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -805,7 +805,7 @@ def pool(input,  # pylint: disable=redefined-builtin
         filter_shape=window_shape)
 
 
-def atrous_conv2d(value, filters, rate, padding, strides=None, name=None):
+def atrous_conv2d(value, filters, rate, padding, name=None):
   """Atrous convolution (a.k.a. convolution with holes or dilated convolution).
 
   This function is a simpler wrapper around the more general
@@ -908,8 +908,7 @@ def atrous_conv2d(value, filters, rate, padding, strides=None, name=None):
       the `height` and `width` dimensions. Equivalently, the rate by which we
       upsample the filter values by inserting zeros across the `height` and
       `width` dimensions. In the literature, the same parameter is sometimes
-      called `input stride` or `dilation`. Alternatively it could be 3 element
-      sequence denoting dilation rate in each dimension.
+      called `input stride` or `dilation`.
     padding: A string, either `'VALID'` or `'SAME'`. The padding algorithm.
     name: Optional name for the returned tensor.
 

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -848,7 +848,9 @@ def atrous_conv1d(input, filter, rate, padding, strides=None, name=None):
       padding is other than `'VALID'` or `'SAME'`.
 
   """
-  return convolution(input=input, filter=filter, padding=padding, dilation_rate=np.broadcast_to(rate, (1, )), strides=strides, name=name)
+  return convolution(input=input, filter=filter, padding=padding,
+                     dilation_rate=np.broadcast_to(rate, (1, )),
+                     strides=strides, name=name)
 
 def atrous_conv2d(value, filters, rate, padding, strides=None, name=None):
   """Atrous convolution (a.k.a. convolution with holes or dilated convolution).
@@ -948,7 +950,8 @@ def atrous_conv2d(value, filters, rate, padding, strides=None, name=None):
       the `height` and `width` dimensions. Equivalently, the rate by which we
       upsample the filter values by inserting zeros across the `height` and
       `width` dimensions. In the literature, the same parameter is sometimes
-      called `input stride` or `dilation`. Altrenatively it could be 3 element sequence denoting dilation rate in each dimension.
+      called `input stride` or `dilation`. Alternatively it could be 3 element
+      sequence denoting dilation rate in each dimension.
     padding: A string, either `'VALID'` or `'SAME'`. The padding algorithm.
     name: Optional name for the returned tensor.
 
@@ -959,7 +962,10 @@ def atrous_conv2d(value, filters, rate, padding, strides=None, name=None):
     ValueError: If input/output depth does not match `filters`' shape, or if
       padding is other than `'VALID'` or `'SAME'`.
   """
-  return convolution(input=value, filter=filters, padding=padding, dilation_rate=np.broadcast_to(rate, (2, )), strides=strides, name=name)
+  return convolution(input=value, filter=filters, padding=padding,
+                     dilation_rate=np.broadcast_to(rate, (2, )),
+                     strides=strides, name=name)
+
 
 def atrous_conv3d(input, filter, rate, padding, strides=None, name=None):
   """Atrous convolution (a.k.a. convolution with holes or dilated convolution).
@@ -971,30 +977,33 @@ def atrous_conv3d(input, filter, rate, padding, strides=None, name=None):
   the input values every `rate` points.
   This is equivalent to convolving the input with a set of upsampled filters,
   produced by inserting `rate - 1` zeros between two consecutive values of the
-  filters along the `height`, `width` and `depth` dimensions, hence the name atrous convolution or convolution with holes (the French word trous means holes in
-  English).
+  filters along the `height`, `width` and `depth` dimensions, hence the name
+  atrous convolution or convolution with holes (the French word trous means
+  holes in English).
 
   See @{tf.nn.atrous_conv2d}
 
   Args:
     input: A 5-D `Tensor` of type `float`. It needs to be in the default "NHWC"
-      format. Its shape is `[batch, in_height, in_width, in_depth, in_channels]`.
+      format. Its shape is
+      `[batch, in_height, in_width, in_depth, in_channels]`.
     filter: A 5-D `Tensor` with the same type as `input` and shape
-      `[filter_height, filter_width, filter_depth, in_channels, out_channels]`. `filter`'
-      `in_channels` dimension must match that of `input`. Atrous convolution is
-      equivalent to standard convolution with upsampled filters with effective
-      height `filter_height + (filter_height - 1) * (rate - 1)`, produced by
-      inserting `rate - 1` zeros along consecutive elements across the
-      `filter`' spatial dimensions.
+      `[filter_height, filter_width, filter_depth, in_channels, out_channels]`.
+      `filter`' `in_channels` dimension must match that of `input`. Atrous
+      convolution is equivalent to standard convolution with upsampled filters
+      with effective height `filter_height + (filter_height - 1) * (rate - 1)`,
+      produced by inserting `rate - 1` zeros along consecutive elements across
+      the `filter`' spatial dimensions.
     rate: A positive int32. The stride with which we sample input values across
       the `height` and `width` dimensions. Equivalently, the rate by which we
       upsample the filter values by inserting zeros across the `height` and
       `width` dimensions. In the literature, the same parameter is sometimes
-      called `input stride` or `dilation`. Altrenatively it could be 3 element sequence denoting dilation rate in each dimension.
-    padding: A string, either `'VALID'` or `'SAME'`. The padding algorithm.
-    strides: Optional.  Sequence of 3 ints >= 1.  Specifies the output stride.
-      Defaults to [1]*3.  If any value of strides is > 1, then all values of
-      dilation_rate must be 1.
+      called `input stride` or `dilation`. Altrenatively it could be 3 element
+      sequence denoting dilation rate in each dimension. padding: A string,
+      either `'VALID'` or `'SAME'`. The padding algorithm. strides: Optional.
+        Sequence of 3 ints >= 1.  Specifies the output stride. Defaults to
+        [1]*3.  If any value of strides is > 1, then all values of
+        dilation_rate must be 1.
     name: Optional name for the returned tensor.
 
   Returns:
@@ -1005,7 +1014,9 @@ def atrous_conv3d(input, filter, rate, padding, strides=None, name=None):
       padding is other than `'VALID'` or `'SAME'`.
 
   """
-  return convolution(input=input, filter=filter, padding=padding, dilation_rate=np.broadcast_to(rate, (3, )), strides=strides, name=name)
+  return convolution(input=input, filter=filter, padding=padding,
+                     dilation_rate=np.broadcast_to(rate, (3, )),
+                     strides=strides, name=name)
 
 def conv2d_transpose(value,
                      filter,


### PR DESCRIPTION
This commit makes following changes:
* deleted most atrous_conv2d code to reuse existing tf.nn.convolution function
* added atrous_conv1d and atrous_conv3d with similar API as atrous_conv2d
* Added support for variable rate per dimension, e.g. for atrous_conv2d
  rate=2, or rate=[2,1] does different things. Former is equal to
  rate=[2,2]. rate_i determines dilation_rate in dimension i.
* added strides support with same API as in tf.nn.convolution function

This commit makes more code deletions then additions. However
documentation per function makes it appear large.

Test Plan:

Some simple tests to verify I haven't screwed something up:

```
A = np.array([1, 2, 3, 4, 5, 6], dtype=np.float32).reshape(1, 6, 1)
print(A)

kernel = np.array([100, 10, 1], dtype=np.float32).reshape(3, 1, 1)

with tf.Session() as sess:
    print(sess.run(tf.nn.atrous_conv1d(A, kernel, padding='SAME', rate=[2])))
```

```
B = np.arange(16, dtype=np.float32).reshape(1, 4, 4, 1)
kernel = np.array([1000, 100, 10, 1.0], dtype=np.float32).reshape(2, 2, 1, 1)

with tf.Session() as sess:
    a = sess.run(tf.nn.convolution(B, kernel, padding='SAME', dilation_rate=np.array([2, 2])))
    b = sess.run(tf.nn.atrous_conv2d(B, kernel, rate=2, padding='SAME'))
    print(np.allclose(a, b))
    print(a)
    print(b)
```

```
C = np.arange(4**3, dtype=np.float32).reshape(1, 4, 4, 4, 1)
kernel = (10**np.arange(8, 0, -1, dtype=np.float32)).reshape(2, 2, 2, 1, 1)

with tf.Session() as sess:
    a = sess.run(tf.nn.conv3d(C, kernel, strides=[1, 1,1,1,1], padding='SAME'))
    b = sess.run(tf.nn.atrous_conv3d(C, kernel, rate=1, padding='SAME'))
    print(np.allclose(a, b))
    print(a)
    print(b)
```

Also running atrous_conv2d unit tests to verify backward compatibility.