### PR TITLE
[fix] add estimators to allowed_symbols in contrib.learn

### DIFF
--- a/tensorflow/contrib/learn/__init__.py
+++ b/tensorflow/contrib/learn/__init__.py
@@ -72,7 +72,7 @@ from tensorflow.contrib.learn.python.learn import *
 
 from tensorflow.python.util.all_util import remove_undocumented
 
-_allowed_symbols = ['datasets', 'head', 'io', 'models',
+_allowed_symbols = ['datasets', 'estimators', 'head', 'io', 'models',
                     'monitors', 'NotFittedError', 'ops', 'preprocessing',
                     'utils', 'graph_actions']
 


### PR DESCRIPTION
Fix 
```py
import tensorflow as tf
tf.contrib.learn.estimators
```
results in 
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'estimators'

```