### PR TITLE
Use environment invalidation for cuda_configure

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ load("//tensorflow:workspace.bzl", "check_version", "tf_workspace")
 # We must check the bazel version before trying to parse any other BUILD files,
 # in case the parsing of those build files depends on the bazel version we
 # require here.
-check_version("0.4.2")
+check_version("0.4.5")
 
 # Uncomment and update the paths in these entries to build the Android demo.
 #android_sdk_repository(

--- a/configure
+++ b/configure
@@ -39,11 +39,6 @@ function is_windows() {
 }
 
 function bazel_clean_and_fetch() {
-  # bazel clean --expunge currently doesn't work on Windows
-  # TODO(pcloudy): Re-enable it after bazel clean --expunge is fixed.
-  if ! is_windows; then
-    bazel clean --expunge
-  fi
   if [ -z "$TF_BAZEL_TARGETS" ]; then
     bazel fetch "//tensorflow/... -//tensorflow/contrib/nccl/... -//tensorflow/examples/android/..."
   else

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -824,10 +824,20 @@ def _cuda_autoconf_impl(repository_ctx):
     _create_cuda_repository(repository_ctx)
 
 
+
 cuda_configure = repository_rule(
     implementation = _cuda_autoconf_impl,
-    local = True,
+    environ = [
+        _GCC_HOST_COMPILER_PATH,
+        "TF_NEED_CUDA",
+        _CUDA_TOOLKIT_PATH,
+        _CUDNN_INSTALL_PATH,
+        _TF_CUDA_VERSION,
+        _TF_CUDNN_VERSION,
+        _TF_CUDA_COMPUTE_CAPABILITIES,
+    ],
 )
+
 """Detects and configures the local CUDA toolchain.
 
 Add the following to your WORKSPACE FILE:


### PR DESCRIPTION
This removes the needs for clean --expunge in configure :) but
request the incoming bazel 0.4.5.

This should fix #4848