### PR TITLE
[CMake] Disable BUILD_TESTING for Eigen.

### DIFF
--- a/tensorflow/contrib/cmake/external/eigen.cmake
+++ b/tensorflow/contrib/cmake/external/eigen.cmake
@@ -36,4 +36,5 @@ ExternalProject_Add(eigen
         -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
         -DCMAKE_INSTALL_PREFIX:STRING=${eigen_INSTALL}
         -DINCLUDE_INSTALL_DIR:STRING=${CMAKE_CURRENT_BINARY_DIR}/external/eigen_archive
+        -DBUILD_TESTING:BOOL=OFF
 )


### PR DESCRIPTION
We don't actually run these tests, so building them is a waste of time. They can also cause surprising interactions with the environment (e.g. see issue #7374), in cases where some of the test dependencies are available.