### PR TITLE
Update random_forest_mnist.py

### DIFF
--- a/tensorflow/examples/learn/random_forest_mnist.py
+++ b/tensorflow/examples/learn/random_forest_mnist.py
@@ -62,9 +62,11 @@ def train_and_eval():
   monitor = random_forest.TensorForestLossHook(early_stopping_rounds)
 
   mnist = input_data.read_data_sets(FLAGS.data_dir, one_hot=False)
-
-  estimator.fit(x=mnist.train.images, y=mnist.train.labels,
-                batch_size=FLAGS.batch_size, monitors=[monitor])
+        
+        x=mnist.train.images
+        y=mnist.train.labels
+        
+  estimator.fit(x, y,batch_size=FLAGS.batch_size, monitors=[monitor])
 
   metric_name = 'accuracy'
   metric = {metric_name:
@@ -72,9 +74,7 @@ def train_and_eval():
                 eval_metrics.get_metric(metric_name),
                 prediction_key=eval_metrics.get_prediction_key(metric_name))}
 
-  results = estimator.evaluate(x=mnist.test.images, y=mnist.test.labels,
-                               batch_size=FLAGS.batch_size,
-                               metrics=metric)
+  results = estimator.evaluate(x,y,batch_size=FLAGS.batch_size,metrics=metric)
   for key in sorted(results):
     print('%s: %s' % (key, results[key]))
 


### PR DESCRIPTION
Calling x and y outside once, it will be clean and helpful for the programmers to understand quickly, x = mnist.train.images and y = mnist.train.labels has been called multiple times instead calling those once with the variable x and y assigned would be helpful for programmers