### PR TITLE
Fix obsoleted tf.train.SummaryWriter() in the document page of Embedding Visualization

### DIFF
--- a/tensorflow/g3doc/how_tos/embedding_viz/index.md
+++ b/tensorflow/g3doc/how_tos/embedding_viz/index.md
@@ -75,7 +75,7 @@ tensor so TensorBoard knows about it.
 ```python
 from tensorflow.contrib.tensorboard.plugins import projector
 # Use the same LOG_DIR where you stored your checkpoint.
-summary_writer = tf.train.SummaryWriter(LOG_DIR)
+summary_writer = tf.summary.FileWriter(LOG_DIR)
 
 # Format: tensorflow/contrib/tensorboard/plugins/projector/projector_config.proto
 config = projector.ProjectorConfig()


### PR DESCRIPTION
The original document use an incorrect function to instantiate the summary file writer.  