### PR TITLE
[GO] Make utility for ops public

### DIFF
--- a/tensorflow/go/session_test.go
+++ b/tensorflow/go/session_test.go
@@ -187,7 +187,7 @@ func ExamplePartialRun() {
 		// Create a graph: a + 2 + 3 + b.
 		//
 		// Skipping error handling for brevity of this example.
-		// The 'op' package can be used to make graph construction code
+		// The package provides utilities used to make graph construction code
 		// with error handling more succinct.
 		g        = NewGraph()
 		a, _     = Placeholder(g, "a", Int32)

--- a/tensorflow/go/util.go
+++ b/tensorflow/go/util.go
@@ -14,6 +14,7 @@
 
 package tensorflow
 
+// Inserts a placeholder for a tensor that will be always fed.
 func Placeholder(g *Graph, name string, dt DataType) (Output, error) {
 	op, err := g.AddOperation(OpSpec{
 		Type: "Placeholder",
@@ -25,6 +26,8 @@ func Placeholder(g *Graph, name string, dt DataType) (Output, error) {
 	return op.Output(0), err
 }
 
+// Creates a constant tensor. The resulting tensor is populated
+// with values of type dtype, as specified by arguments value.
 func Const(g *Graph, name string, value interface{}) (Output, error) {
 	t, ok := value.(*Tensor)
 	if !ok {
@@ -44,6 +47,7 @@ func Const(g *Graph, name string, value interface{}) (Output, error) {
 	return op.Output(0), err
 }
 
+// Computes numerical negative value element-wise.
 func Neg(g *Graph, name string, port Output) (Output, error) {
 	op, err := g.AddOperation(OpSpec{
 		Type:  "Neg",
@@ -53,6 +57,7 @@ func Neg(g *Graph, name string, port Output) (Output, error) {
 	return op.Output(0), err
 }
 
+// Returns x + y element-wise.
 func Add(g *Graph, name string, x, y Output) (Output, error) {
 	op, err := g.AddOperation(OpSpec{
 		Type:  "Add",


### PR DESCRIPTION
Ops in util_test cannot be used because these are _test.go files. Since the usage
of these ops utils are writen in API docs, it is better to make it public.