### PR TITLE
Fix bug #7647 in image retraining example retrain.py so that the --pr…

### DIFF
--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -893,7 +893,8 @@ def main(_):
     print('=== MISCLASSIFIED TEST IMAGES ===')
     for i, test_filename in enumerate(test_filenames):
       if predictions[i] != test_ground_truth[i].argmax():
-        print('%70s  %s' % (test_filename, image_lists.keys()[predictions[i]]))
+        print('%70s  %s' % (test_filename, 
+                            list(image_lists.keys())[predictions[i]]))
 
   # Write out the trained graph and labels with the weights stored as constants.
   output_graph_def = graph_util.convert_variables_to_constants(


### PR DESCRIPTION
Fix bug #7647 in image retraining example retrain.py so that the --print_misclassified_test_images flag now works properly in Python 3.