### PR TITLE
Update doc string to indicate clip_by_value accepts tensors as min and max arguments too

### DIFF
--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -41,8 +41,10 @@ def clip_by_value(t, clip_value_min, clip_value_max,
 
   Args:
     t: A `Tensor`.
-    clip_value_min: A 0-D (scalar) `Tensor`. The minimum value to clip by.
-    clip_value_max: A 0-D (scalar) `Tensor`. The maximum value to clip by.
+    clip_value_min: A 0-D (scalar) `Tensor`, or a `Tensor` with the sampe shape
+      as `t`. The minimum value to clip by.
+    clip_value_max: A 0-D (scalar) `Tensor`, or a `Tensor` with the sampe shape
+      as `t`. The maximum value to clip by.
     name: A name for the operation (optional).
 
   Returns:

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -41,9 +41,9 @@ def clip_by_value(t, clip_value_min, clip_value_max,
 
   Args:
     t: A `Tensor`.
-    clip_value_min: A 0-D (scalar) `Tensor`, or a `Tensor` with the sampe shape
+    clip_value_min: A 0-D (scalar) `Tensor`, or a `Tensor` with the same shape
       as `t`. The minimum value to clip by.
-    clip_value_max: A 0-D (scalar) `Tensor`, or a `Tensor` with the sampe shape
+    clip_value_max: A 0-D (scalar) `Tensor`, or a `Tensor` with the same shape
       as `t`. The maximum value to clip by.
     name: A name for the operation (optional).
 


### PR DESCRIPTION
`tf.clip_by_value`'s current documentation mentions that it accepts only scalars as min and max arguments, but it can accept tensors too. This PR fixes that, and resolves the confusion raised in #7225  