### PR TITLE
Add TF_CONTROL_SLOT to c_api

### DIFF
--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -1702,6 +1702,12 @@ void TF_ImportGraphDefOptionsAddInputMapping(TF_ImportGraphDefOptions* opts,
   opts->opts.input_map[TensorId(src_name, src_index)] = ToTensorId(dst);
 }
 
+void TF_ImportGraphDefOptionsRemapControlDependency(
+    TF_ImportGraphDefOptions* opts, const char* src_name, TF_Operation* dst) {
+  opts->opts.input_map[TensorId(src_name, tensorflow::Graph::kControlSlot)] =
+    TensorId(dst->node.name(), tensorflow::Graph::kControlSlot);
+}
+
 extern void TF_ImportGraphDefOptionsAddControlDependency(
     TF_ImportGraphDefOptions* opts, TF_Operation* oper) {
   opts->opts.control_dependencies.push_back(oper->node.name());

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -810,6 +810,14 @@ extern void TF_ImportGraphDefOptionsAddInputMapping(
     TF_ImportGraphDefOptions* opts, const char* src_name, int src_index,
     TF_Output dst);
 
+// Set any imported nodes with control input `src_name` to have that input
+// replaced with `dst`. `src_name` refers to a node in the graph to be imported,
+// `dst` references an operation already existing in the graph being imported
+// into.
+extern void TF_GraphImportGraphDefOptionsRemapControlDependency(
+    TF_ImportGraphDefOptions* opts, const char* src_name,
+    TF_Operation* dst);
+
 // Cause the imported graph to have a control dependency on `oper`. `oper`
 // should exist in the graph being imported into.
 extern void TF_ImportGraphDefOptionsAddControlDependency(


### PR DESCRIPTION
This lets users of `TF_ImportGraphDefOptionsAddInputMapping` remap control inputs without having to guess the magical value of the `kControlSlot` constant. 

cf #7508