### PR TITLE
[Java] [Feature] Tensor clone

### DIFF
--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -217,6 +217,11 @@ TF_Tensor* TF_NewTensor(TF_DataType dtype, const int64_t* dims, int num_dims,
   return new TF_Tensor{dtype, TensorShape(dimvec), buf};
 }
 
+TF_Tensor* TF_CloneTensor(TF_Tensor* t) {
+  t->buffer->Ref();
+  return new TF_Tensor{t->dtype, TensorShape(t->shape), t->buffer};
+}
+
 void TF_DeleteTensor(TF_Tensor* t) {
   t->buffer->Unref();
   delete t;

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -220,6 +220,9 @@ extern TF_Tensor* TF_NewTensor(TF_DataType, const int64_t* dims, int num_dims,
 extern TF_Tensor* TF_AllocateTensor(TF_DataType, const int64_t* dims,
                                     int num_dims, size_t len);
 
+// Clone a tensor.
+TF_Tensor* TF_CloneTensor(TF_Tensor* t);
+
 // Destroy a tensor.
 extern void TF_DeleteTensor(TF_Tensor*);
 

--- a/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
@@ -222,6 +222,20 @@ public final class Tensor implements AutoCloseable {
   }
 
   /**
+   * Create a copy of the Tensor using the same underlying resources.
+   *
+   * <p>The returned Tensor remains usable after {@code close} is called on the original Tensor.
+   */
+  @Override
+  protected Tensor clone() {
+    Tensor t = new Tensor();
+    t.dtype = dtype;
+    t.shapeCopy = Arrays.copyOf(shapeCopy, shapeCopy.length);
+    t.nativeHandle = clone(nativeHandle);
+    return t;
+  }
+
+  /**
    * Release resources associated with the Tensor.
    *
    * <p><b>WARNING:</b>If not invoked, memory will be leaked.
@@ -597,6 +611,8 @@ public final class Tensor implements AutoCloseable {
   private static native long allocate(int dtype, long[] shape, long byteSize);
 
   private static native long allocateScalarBytes(byte[] value);
+
+  private static native long clone(long handle);
 
   private static native void delete(long handle);
 

--- a/tensorflow/java/src/main/native/tensor_jni.cc
+++ b/tensorflow/java/src/main/native/tensor_jni.cc
@@ -287,6 +287,13 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_allocateScalarBytes(
   return reinterpret_cast<jlong>(t);
 }
 
+JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_clone(JNIEnv* env,
+                                                         jclass clazz,
+                                                         jlong handle) {
+  TF_Tensor* t = TF_CloneTensor(reinterpret_cast<TF_Tensor*>(handle));
+  return reinterpret_cast<jlong>(t);
+}
+
 JNIEXPORT void JNICALL Java_org_tensorflow_Tensor_delete(JNIEnv* env,
                                                          jclass clazz,
                                                          jlong handle) {

--- a/tensorflow/java/src/main/native/tensor_jni.h
+++ b/tensorflow/java/src/main/native/tensor_jni.h
@@ -40,6 +40,14 @@ Java_org_tensorflow_Tensor_allocateScalarBytes(JNIEnv *, jclass, jbyteArray);
 
 /*
  * Class:     org_tensorflow_Tensor
+ * Method:    clone
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_clone(JNIEnv *, jclass,
+                                                         jlong);
+
+/*
+ * Class:     org_tensorflow_Tensor
  * Method:    delete
  * Signature: (J)V
  */

--- a/tensorflow/java/src/test/java/org/tensorflow/TensorTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/TensorTest.java
@@ -457,6 +457,25 @@ public class TensorTest {
   }
 
   @Test
+  public void cloning() {
+    int[] x = {1,2,3};
+    int[] x2 = new int[x.length];
+    Tensor t2;
+    try (Tensor t = Tensor.create(x)) {
+      t2 = t.clone();
+    }
+    try {
+      t2.copyTo(x2);
+      assertEquals(DataType.INT32, t2.dataType());
+      assertArrayEquals(new long[]{x.length}, t2.shape());
+      assertArrayEquals(x, x2);
+    }
+    finally {
+      t2.close();
+    }
+  }
+
+  @Test
   public void useAfterClose() {
     int n = 4;
     Tensor t = Tensor.create(n);


### PR DESCRIPTION
Allows a tensor to be cloned (shallow), resulting in a new tensor
sharing the same underlying buffer.

The cloned tensor is still usable after the original is closed.  This
is possible because the buffer supports reference counting.

- Added `TF_Clone` to the C API.
- Added `Tensor::clone` to the Java API.