### PR TITLE
fix some documentation style faults for dynamic_rnn, dynamic_rnn_decod…

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/seq2seq.py
+++ b/tensorflow/contrib/seq2seq/python/ops/seq2seq.py
@@ -76,6 +76,7 @@ def dynamic_rnn_decoder(cell, decoder_fn, inputs=None, sequence_length=None,
 
       The input to `cell` at each time step will be a `Tensor` with dimensions
         `[batch_size, ...]`.
+
     sequence_length: (optional) An int32/int64 vector sized `[batch_size]`.
       if `inputs` is not None and `sequence_length` is None it is inferred
       from the `inputs` as the maximal possible sequence length.

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2169,7 +2169,7 @@ def tensordot(a, b, axes, name=None):
   Example 2: When `a` and `b` are matrices (order 2), the case
   `axes = [[1], [0]]` is equivalent to matrix multiplication.
 
-  Example 3: Suppose that \\(a_ijk\\) and \\(b_lmn\\) represent two
+  Example 3: Suppose that \\(a_{ijk}\\) and \\(b_{lmn}\\) represent two
   tensors of order 3. Then, `contract(a, b, [0], [2])` is the order 4 tensor
   \\(c_{jklm}\\) whose entry
   corresponding to the indices \\((j,k,l,m)\\) is given by:

--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -419,6 +419,7 @@ def dynamic_rnn(cell, inputs, sequence_length=None, initial_state=None,
 
       The input to `cell` at each time step will be a `Tensor` or (possibly
       nested) tuple of Tensors each with dimensions `[batch_size, ...]`.
+
     sequence_length: (optional) An int32/int64 vector sized `[batch_size]`.
     initial_state: (optional) An initial state for the RNN.
       If `cell.state_size` is an integer, this must be


### PR DESCRIPTION
fix some documentation style faults for dynamic_rnn, dynamic_rnn_decoder and tensordot
See: 
https://www.tensorflow.org/api_docs/python/tf/contrib/seq2seq/dynamic_rnn_decoder
https://www.tensorflow.org/api_docs/python/tf/tensordot
https://www.tensorflow.org/api_docs/python/tf/nn/dynamic_rnn