### PR TITLE
fix debian jessie ci_build

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.debian.jessie.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.debian.jessie.cpu
@@ -5,7 +5,15 @@ MAINTAINER Jan Prach <jendap@google.com>
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
-RUN echo "deb http://http.debian.net/debian jessie-backports main" | tee -a /etc/apt/sources.list
+RUN echo "deb http://http.debian.net/debian jessie-backports main" | \
+    tee -a /etc/apt/sources.list
+# Workaround bug in Jessie backport repository deb packages
+# http://serverfault.com/questions/830636/cannot-install-openjdk-8-jre-headless-on-debian-jessie
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends -t jessie-backports \
+        openjdk-8-jre-headless ca-certificates-java && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 RUN /install/install_deb_packages.sh
 RUN /install/install_pip_packages.sh
 RUN /install/install_bazel.sh


### PR DESCRIPTION
Workaround deb packaging issue in debian jessie. The packages openjdk-8-jre-headless does not automatically install ca-certificates-java because there are wrong metadata in backport repository. The workaround is to force "-t jessie-backports".