### PR TITLE
Fix nccl when referenced from a different repo

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -405,12 +405,16 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
       actual = "@zlib_archive//:zlib",
   )
 
-  native.new_http_archive(
+  temp_workaround_http_archive(
       name = "nccl_archive",
-      url = "https://github.com/nvidia/nccl/archive/024d1e267845f2ed06f3e2e42476d50f04a00ee6.tar.gz",
+      urls = [
+          "http://bazel-mirror.storage.googleapis.com/github.com/nvidia/nccl/archive/024d1e267845f2ed06f3e2e42476d50f04a00ee6.tar.gz",
+          "https://github.com/nvidia/nccl/archive/024d1e267845f2ed06f3e2e42476d50f04a00ee6.tar.gz",
+      ],
       sha256 = "6787f0eed88d52ee8e32956fa4947d92c139da469f1d8e311c307f27d641118e",
       strip_prefix = "nccl-024d1e267845f2ed06f3e2e42476d50f04a00ee6",
       build_file = str(Label("//third_party:nccl.BUILD")),
+      repository = tf_repo_name,
   )
 
   # Make junit-4.12 available as //external:junit

--- a/third_party/nccl.BUILD
+++ b/third_party/nccl.BUILD
@@ -44,17 +44,17 @@ cc_library(
         "-O3",
     ] + cuda_default_copts(),
     linkopts = select({
-        "@//tensorflow:android": [
+        "@%ws%//tensorflow:android": [
             "-pie",
         ],
-        "@//tensorflow:darwin": [
+        "@%ws%//tensorflow:darwin": [
             "-Wl,-framework",
             "-Wl,CoreFoundation",
             "-Wl,-framework",
             "-Wl,Security",
         ],
-        "@//tensorflow:ios": [],
-        "@//tensorflow:windows": [
+        "@%ws%//tensorflow:ios": [],
+        "@%ws%//tensorflow:windows": [
             "ws2_32.lib",
         ],
         "//conditions:default": [


### PR DESCRIPTION
This fixes the following error:

ERROR: external/nccl_archive/BUILD.bazel:33:1: no such package 'tensorflow': Package crosses into repository `@org_tensorflow` and referenced by `'@nccl_archive//:nccl'`.

Also mirror URL for great justice.

CC @cwhipkey