### PR TITLE
Android Improvements

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,7 +33,7 @@ check_version("0.4.2")
 #android_ndk_repository(
 #    name="androidndk",
 #    path="<PATH_TO_NDK>",
-#    api_level=21)
+#    api_level=14)
 
 # Please add all new TensorFlow dependencies in workspace.bzl.
 tf_workspace()

--- a/tensorflow/contrib/android/BUILD
+++ b/tensorflow/contrib/android/BUILD
@@ -72,13 +72,14 @@ LINKER_SCRIPT = "//tensorflow/contrib/android:jni/version_script.lds"
 cc_binary(
     name = "libtensorflow_inference.so",
     srcs = [],
-    copts = tf_copts(),
+    copts = tf_copts() + ["-ffunction-sections", "-fdata-sections"],
     linkopts = if_android([
         "-landroid",
         "-llog",
         "-lm",
         "-z defs",
         "-s",
+        "-Wl,--gc-sections",
         "-Wl,--version-script",  # This line must be directly followed by LINKER_SCRIPT.
         LINKER_SCRIPT,
     ]),

--- a/tensorflow/contrib/android/BUILD
+++ b/tensorflow/contrib/android/BUILD
@@ -72,7 +72,10 @@ LINKER_SCRIPT = "//tensorflow/contrib/android:jni/version_script.lds"
 cc_binary(
     name = "libtensorflow_inference.so",
     srcs = [],
-    copts = tf_copts() + ["-ffunction-sections", "-fdata-sections"],
+    copts = tf_copts() + [
+        "-ffunction-sections",
+        "-fdata-sections",
+    ],
     linkopts = if_android([
         "-landroid",
         "-llog",


### PR DESCRIPTION
This branch adds minor improvements to TensorFlow on Android.

1. e02edef lowers API support to level 14 — which is confirmed to work, rather than level 21 as indicated right now. This setting is commented out by default, but could be a useful guideline to most users. It might be more interesting to update the CI server to naturally produce nightly builds at that level, but it doesn’t seem like I can send a PR for that (unless I missed it).

2. 5971f69 introduces the use of [GC sections](https://gcc.gnu.org/onlinedocs/gnat_ugn/Compilation-options.html) when compiling libtensorflow_inference.so, which has the effect of reducing final binary size.

    At the time of this PR, the following improvements were observed:
    
    |  arch | master | this branch | delta | % |
    |  ------ | ------ | ------ | ------ | ------ |
    |  armeabi-v7a | 10197000 bytes | 9353164 bytes | -0.8 MB | -8% |
    |  arm64-v8a | 16568952 bytes | 14693056 bytes | -1.8 MB | -11% |
    |  x86 | 16631748 bytes | 14751612 bytes | -1.8 MB | -11% |
    |  x86_64 | 16509880 bytes | 14715632 bytes | -1.7 MB | -11% |

    Final observed impact on an app is around 1MB on a unified release APK.