### PR TITLE
Changed inconsistent conv1d docs to use 'input' param instead of 'value'

### DIFF
--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard1/tf.nn.conv1d.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard1/tf.nn.conv1d.md
@@ -1,4 +1,4 @@
-### `tf.nn.conv1d(value, filters, stride, padding, use_cudnn_on_gpu=None, data_format=None, name=None)` {#conv1d}
+### `tf.nn.conv1d(input, filters, stride, padding, use_cudnn_on_gpu=None, data_format=None, name=None)` {#conv1d}
 
 Computes a 1-D convolution given 3-D input and filter tensors.
 
@@ -47,4 +47,3 @@ returned to the caller.
 
 
 *  <b>`ValueError`</b>: if `data_format` is invalid.
-

--- a/tensorflow/g3doc/api_docs/python/nn.md
+++ b/tensorflow/g3doc/api_docs/python/nn.md
@@ -755,7 +755,7 @@ deconvolution.
 
 - - -
 
-### `tf.nn.conv1d(value, filters, stride, padding, use_cudnn_on_gpu=None, data_format=None, name=None)` {#conv1d}
+### `tf.nn.conv1d(input, filters, stride, padding, use_cudnn_on_gpu=None, data_format=None, name=None)` {#conv1d}
 
 Computes a 1-D convolution given 3-D input and filter tensors.
 
@@ -3630,5 +3630,3 @@ This is useful in summaries to measure and report sparsity.  For example,
 ##### Returns:
 
   The fraction of zeros in `value`, with type `float32`.
-
-


### PR DESCRIPTION
Fixed inconsistency in documentation for conv1d.  Partial fix for issue #6379

