### PR TITLE
Improve tensorboard smoothing

### DIFF
--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -441,15 +441,14 @@ module VZ {
       let data = dataset.data();
       let kernelRadius = Math.floor(data.length * factor / 2);
       data.forEach(function (d, i) {
-          var start = Math.max(0, i - kernelRadius);
-          var end = Math.min(data.length-1, i + kernelRadius);
-          // Only smooth finite numbers.
-          if (!_.isFinite(d.scalar)) {
-              d.smoothed = d.scalar;
-          }
-          else {
-              d.smoothed = d3.mean(data.slice(start, end).filter(function (d) { return _.isFinite(d.scalar); }), function (d) { return d.scalar; });
-          }
+        var start = Math.max(0, i - kernelRadius);
+        var end = Math.min(data.length - 1, i + kernelRadius);
+        // Only smooth finite numbers.
+        if (!_.isFinite(d.scalar)) {
+          d.smoothed = d.scalar;
+        } else {
+          d.smoothed = d3.mean(data.slice(start, end).filter(function (d) { return _.isFinite(d.scalar); }), function (d) { return d.scalar; });
+        }
       });
 
     }

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -441,8 +441,8 @@ module VZ {
       let data = dataset.data();
       let kernelRadius = Math.floor(data.length * factor / 2);
       data.forEach(function (d, i) {
-        var actualKernelRadius = Math.min(kernelRadius, i)
-        var start = Math.max(0, i - actualKernelRadius);
+        var actualKernelRadius = Math.min(kernelRadius, i);
+        var start = i - actualKernelRadius;
         var end = Math.min(data.length - 1, i + actualKernelRadius);
         // Only smooth finite numbers.
         if (!_.isFinite(d.scalar)) {

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -441,8 +441,9 @@ module VZ {
       let data = dataset.data();
       let kernelRadius = Math.floor(data.length * factor / 2);
       data.forEach(function (d, i) {
-        var start = Math.max(0, i - kernelRadius);
-        var end = Math.min(data.length - 1, i + kernelRadius);
+        var actualKernelRadius = Math.min(kernelRadius, i)
+        var start = Math.max(0, i - actualKernelRadius);
+        var end = Math.min(data.length - 1, i + actualKernelRadius);
         // Only smooth finite numbers.
         if (!_.isFinite(d.scalar)) {
           d.smoothed = d.scalar;

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -440,26 +440,18 @@ module VZ {
       let factor = (Math.pow(1000, this.smoothingWeight) - 1) / 999;
       let data = dataset.data();
       let kernelRadius = Math.floor(data.length * factor / 2);
-
-      data.forEach((d, i) => {
-        let actualKernelRadius = Math.min(kernelRadius, i);
-        let start = i - actualKernelRadius;
-        let end = i + actualKernelRadius + 1;
-        if (end >= data.length) {
-          // In the beginning, it's OK for the smoothing window to be small,
-          // but this is not desirable towards the end. Rather than shrinking
-          // the window, or extrapolating data to fill the gap, we're simply
-          // not going to display the smoothed line towards the end.
-          d.smoothed = Infinity;
-        } else if (!_.isFinite(d.scalar)) {
+      data.forEach(function (d, i) {
+          var start = Math.max(0, i - kernelRadius);
+          var end = Math.min(data.length-1, i + kernelRadius);
           // Only smooth finite numbers.
-          d.smoothed = d.scalar;
-        } else {
-          d.smoothed = d3.mean(
-              data.slice(start, end).filter((d) => _.isFinite(d.scalar)),
-              (d) => d.scalar);
-        }
+          if (!_.isFinite(d.scalar)) {
+              d.smoothed = d.scalar;
+          }
+          else {
+              d.smoothed = d3.mean(data.slice(start, end).filter(function (d) { return _.isFinite(d.scalar); }), function (d) { return d.scalar; });
+          }
       });
+
     }
 
     private getDataset(name: string) {

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3856,8 +3856,9 @@ var VZ;
             var data = dataset.data();
             var kernelRadius = Math.floor(data.length * factor / 2);
             data.forEach(function (d, i) {
-                var start = Math.max(0, i - kernelRadius);
-                var end = Math.min(data.length-1, i + kernelRadius);
+                var actualKernelRadius = Math.min(kernelRadius, i)
+                var start = Math.max(0, i - actualKernelRadius);
+                var end = Math.min(data.length-1, i + actualKernelRadius);
                 // Only smooth finite numbers.
                 if (!_.isFinite(d.scalar)) {
                     d.smoothed = d.scalar;

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3856,9 +3856,9 @@ var VZ;
             var data = dataset.data();
             var kernelRadius = Math.floor(data.length * factor / 2);
             data.forEach(function (d, i) {
-                var actualKernelRadius = Math.min(kernelRadius, i)
-                var start = Math.max(0, i - actualKernelRadius);
-                var end = Math.min(data.length-1, i + actualKernelRadius);
+                var actualKernelRadius = Math.min(kernelRadius, i, data.length - i - 1);
+                var start = i - actualKernelRadius;
+                var end = i + actualKernelRadius + 1;
                 // Only smooth finite numbers.
                 if (!_.isFinite(d.scalar)) {
                     d.smoothed = d.scalar;

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3856,9 +3856,8 @@ var VZ;
             var data = dataset.data();
             var kernelRadius = Math.floor(data.length * factor / 2);
             data.forEach(function (d, i) {
-                var actualKernelRadius = Math.min(kernelRadius, i, data.length - i - 1);
-                var start = i - actualKernelRadius;
-                var end = i + actualKernelRadius + 1;
+                var start = Math.max(0, i - kernelRadius);
+                var end = Math.min(data.length-1, i + kernelRadius);
                 // Only smooth finite numbers.
                 if (!_.isFinite(d.scalar)) {
                     d.smoothed = d.scalar;


### PR DESCRIPTION
The smoothing of training loss in Tensorboard was frustrating; it would seemingly select a random set of unfiltered points near the end of the loss history leaving one unable to see the most recent trend.

I see that at least one other person was annoyed at this, as a change has been committed to master that changes the behavior. I think the change in this PR is superior. The previous one appears to have just truncated the smoothed curve, whereas this one will smooth all the way up until the end. When I'm 400K training iterations in, I find myself really wanting to see how the trend has gone in those last 20K iterations.

I also notice that the previous commit didn't update `dist/tf-tensorboard.html`, which I think is the only thing that affects most people running latest master.