### PR TITLE
Second derivative computation in softmax xent op

### DIFF
--- a/tensorflow/python/kernel_tests/xent_op_test.py
+++ b/tensorflow/python/kernel_tests/xent_op_test.py
@@ -195,17 +195,17 @@ class XentTest(test.TestCase):
                                                    name="xent")
       loss = math_ops.reduce_sum(x)
 
-      trivia_loss = -math_ops.reduce_sum(l * math_ops.log(nn_ops.softmax(f)))
+      hessians = gradients_impl.hessians(loss, [f])[0]
 
-      hessians = sess.run(gradients_impl.hessians(loss, [f]))
-      trivia_hessians = sess.run(gradients_impl.hessians(trivia_loss, [f]))
-
-      self.assertAllClose(hessians, trivia_hessians)
+      err = gradient_checker.compute_gradient_error(f, [12], hessians, [12, 12])
 
       # Check that second derivative is calculated.
       # (it is equivalent to being `BatchMatMul` op in the graph because of implementation of xentropy grad)
       op_names = [op.op_def.name for op in sess.graph.get_operations() if op.op_def]
       self.assertIn('BatchMatMul', op_names)
+
+    print("cross entropy hessian err = ", err)
+    self.assertLess(err, 5e-8)
 
   def testWrapper(self):
     features = np.array(

--- a/tensorflow/python/kernel_tests/xent_op_test.py
+++ b/tensorflow/python/kernel_tests/xent_op_test.py
@@ -195,9 +195,9 @@ class XentTest(test.TestCase):
                                                    name="xent")
       loss = math_ops.reduce_sum(x)
 
-      hessians = gradients_impl.hessians(loss, [f])[0]
+      gradients = gradients_impl.gradients(loss, [f])[0]
 
-      err = gradient_checker.compute_gradient_error(f, [12], hessians, [12, 12])
+      err = gradient_checker.compute_gradient_error(f, [12], gradients, [12])
 
       # Check that second derivative is calculated.
       # (it is equivalent to being `BatchMatMul` op in the graph because of implementation of xentropy grad)

--- a/tensorflow/python/kernel_tests/xent_op_test.py
+++ b/tensorflow/python/kernel_tests/xent_op_test.py
@@ -157,7 +157,7 @@ class XentTest(test.TestCase):
         np.array([[0., 0., 0., 1.], [0., .5, .5, 0.]]).astype(np.float64))
 
   def testGradient(self):
-    with self.test_session():
+    with self.test_session() as sess:
       l = constant_op.constant(
           [0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.5],
           shape=[3, 4],
@@ -171,14 +171,21 @@ class XentTest(test.TestCase):
       x = nn_ops.softmax_cross_entropy_with_logits(labels=l, logits=f,
                                                    name="xent")
       err = gradient_checker.compute_gradient_error(f, [3, 4], x, [3])
+
+      # Check that no extra computation performed. When only first derivative is requested,
+      # second derivative must not be computed. So when there is no second derivative,
+      # there is no `BatchMatMul` op in the graph.
+      op_names = [op.op_def.name for op in sess.graph.get_operations() if op.op_def]
+      self.assertNotIn('BatchMatMul', op_names)
+
     print("cross entropy gradient err = ", err)
     self.assertLess(err, 5e-8)
 
   def testSecondGradient(self):
-    with self.test_session():
-      l = constant_op.constant([0.0, 0.0, 1.0, 0.0,
-                                1.0, 0.0, 0.0, 0.0,
-                                0.0, 0.5, 0.0, 0.5], shape=[12],
+    with self.test_session() as sess:
+      l = constant_op.constant([0.0, 0.0, 1.0/3, 0.0,
+                                1.0/3, 0.0, 0.0, 0.0,
+                                0.0, 0.5/3, 0.0, 0.5/3], shape=[12],
                                dtype=dtypes.float64, name="l")
       f = constant_op.constant([0.1, 0.2, 0.3, 0.4,
                                 0.1, 0.4, 0.9, 1.6,
@@ -186,13 +193,19 @@ class XentTest(test.TestCase):
                                dtype=dtypes.float64, name="f")
       x = nn_ops.softmax_cross_entropy_with_logits(labels=l, logits=f,
                                                    name="xent")
-      loss = math_ops.reduce_mean(x)
+      loss = math_ops.reduce_sum(x)
 
-    # Taking ths second gradient should fail, since it is not
-    # yet supported.
-    with self.assertRaisesRegexp(LookupError,
-                                 "explicitly disabled"):
-      _ = gradients_impl.hessians(loss, [f])
+      trivia_loss = -math_ops.reduce_sum(l * math_ops.log(nn_ops.softmax(f)))
+
+      hessians = sess.run(gradients_impl.hessians(loss, [f]))
+      trivia_hessians = sess.run(gradients_impl.hessians(trivia_loss, [f]))
+
+      self.assertAllClose(hessians, trivia_hessians)
+
+      # Check that second derivative is calculated.
+      # (it is equivalent to being `BatchMatMul` op in the graph because of implementation of xentropy grad)
+      op_names = [op.op_def.name for op in sess.graph.get_operations() if op.op_def]
+      self.assertIn('BatchMatMul', op_names)
 
   def testWrapper(self):
     features = np.array(

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -333,10 +333,10 @@ def _SoftmaxCrossEntropyWithLogitsGrad(op, grad_loss, grad_grad):
   grad = _BroadcastMul(grad_loss, softmax_grad)
 
   if grad_grad.op.type not in ('ZerosLike', 'Zeros'):
-      logits = op.inputs[0]
-      softmax = nn_ops.softmax(logits)
+    logits = op.inputs[0]
+    softmax = nn_ops.softmax(logits)
 
-      grad += ((grad_grad - array_ops.squeeze(math_ops.matmul(grad_grad[:, None, :],
+    grad += ((grad_grad - array_ops.squeeze(math_ops.matmul(grad_grad[:, None, :],
                                                               softmax[:, :, None]), axis=1)) * softmax)
 
   return grad, None


### PR DESCRIPTION
PR for issue #7403

@girving I rewrited second derivative with reshapes and one `matmul`, no more `diag_part` or `reduce_sum`.

* Also, I writed test for checking that no extra computation performed when only first gradient is requested.

* I am not sure whether I implemented hessian correctness test properly, but if I did it poorly, please guide me into right way.

* Is such fix suites trivially for `_SparseSoftmaxCrossEntropyWithLogitsGrad`? If so, I will modify it too.

* I think that I can fix `SoftmaxGrad` op, because it uses `reduce_sum(grad * softmax)` approach to compute the derivative. I could do it with `matmul` and reshapes.