### PR TITLE
Allow zero samples in RandomGamma

### DIFF
--- a/tensorflow/core/kernels/random_op.cc
+++ b/tensorflow/core/kernels/random_op.cc
@@ -303,10 +303,12 @@ class RandomGammaOp : public OpKernel {
                                                       &samples_shape));
     }
     const int64 num_samples = samples_shape.num_elements();
-    OP_REQUIRES(ctx, num_samples > 0,
-                errors::InvalidArgument(
-                    "Input shape should have non-zero element count, got: ",
-                    num_samples));
+    if (num_samples == 0) {
+      Tensor* samples_t = nullptr;
+      OP_REQUIRES_OK(ctx, ctx->allocate_output(0, TensorShape({0}),
+                                               &samples_t));
+      return;
+    }
 
     samples_shape.AppendShape(alpha_t.shape());
     // Allocate output samples.

--- a/tensorflow/core/kernels/random_op.cc
+++ b/tensorflow/core/kernels/random_op.cc
@@ -303,8 +303,7 @@ class RandomGammaOp : public OpKernel {
                                                       &samples_shape));
     }
     const int64 num_samples = samples_shape.num_elements();
-    if (num_samples == 0) 
-      return;
+    if (num_samples == 0) return;
 
     samples_shape.AppendShape(alpha_t.shape());
     // Allocate output samples.

--- a/tensorflow/core/kernels/random_op.cc
+++ b/tensorflow/core/kernels/random_op.cc
@@ -303,12 +303,8 @@ class RandomGammaOp : public OpKernel {
                                                       &samples_shape));
     }
     const int64 num_samples = samples_shape.num_elements();
-    if (num_samples == 0) {
-      Tensor* samples_t = nullptr;
-      OP_REQUIRES_OK(ctx, ctx->allocate_output(0, TensorShape({0}),
-                                               &samples_t));
+    if (num_samples == 0) 
       return;
-    }
 
     samples_shape.AppendShape(alpha_t.shape());
     // Allocate output samples.


### PR DESCRIPTION
Fixes #7406.  Instead of an error with zero samples,
we now return a zero-shape tensor.