### PR TITLE
Fix TensorFlow compilation errors with KNL optimization flags (-mavx512f)

### DIFF
--- a/tensorflow/core/kernels/eigen_pooling.h
+++ b/tensorflow/core/kernels/eigen_pooling.h
@@ -331,8 +331,10 @@ struct AvgPoolMeanReducer {
 #if (EIGEN_ARCH_i386 || EIGEN_ARCH_x86_64) && !defined(__CUDACC__)
 #ifdef EIGEN_VECTORIZE_AVX512
 #define pequal(a, b) \
-  _mm512_maskz_set1_epi32(_mm512_cmp_ps_mask(a, b, _CMP_EQ_UQ), -1)
-#define psel(a, b, false_mask) _mm512_ternarylogic_epi64(false_mask, a, b, 0xca)
+  _mm512_castsi512_ps(_mm512_maskz_set1_epi32(_mm512_cmp_ps_mask(a, b, _CMP_EQ_UQ), -1))
+#define psel(a, b, false_mask) \
+  _mm512_castsi512_ps(_mm512_ternarylogic_epi32(_mm512_castps_si512(false_mask),\
+                            _mm512_castps_si512(a), _mm512_castps_si512(b), 0xca))
 #elif defined EIGEN_VECTORIZE_AVX
 #define pequal(a, b) _mm256_cmp_ps(a, b, _CMP_EQ_UQ)
 #define psel(a, b, false_mask) _mm256_blendv_ps(a, b, false_mask)

--- a/tensorflow/core/kernels/eigen_pooling.h
+++ b/tensorflow/core/kernels/eigen_pooling.h
@@ -332,9 +332,16 @@ struct AvgPoolMeanReducer {
 #ifdef EIGEN_VECTORIZE_AVX512
 #define pequal(a, b) \
   _mm512_castsi512_ps(_mm512_maskz_set1_epi32(_mm512_cmp_ps_mask(a, b, _CMP_EQ_UQ), -1))
+ 
+// The ternarylogic function immediate determines the values in the result
+// In the case below, 0xd8 implies (false_mask) ? (b) : (a)
+// For details, refer to the vpternlogd instruction table at
+// http://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-2c-manual.pdf
 #define psel(a, b, false_mask) \
-  _mm512_castsi512_ps(_mm512_ternarylogic_epi32(_mm512_castps_si512(false_mask),\
-                            _mm512_castps_si512(a), _mm512_castps_si512(b), 0xca))
+  _mm512_castsi512_ps(_mm512_ternarylogic_epi32(_mm512_castps_si512(a), \
+                                                _mm512_castps_si512(b), \
+                                                _mm512_castps_si512(false_mask), \
+                                                0xd8))
 #elif defined EIGEN_VECTORIZE_AVX
 #define pequal(a, b) _mm256_cmp_ps(a, b, _CMP_EQ_UQ)
 #define psel(a, b, false_mask) _mm256_blendv_ps(a, b, false_mask)

--- a/tensorflow/core/kernels/sparse_matmul_op.h
+++ b/tensorflow/core/kernels/sparse_matmul_op.h
@@ -255,12 +255,12 @@ EIGEN_STRONG_INLINE Packet8d pbroadcast_second<Packet8d>(const Packet8d& a_in) {
 }
 template <>
 EIGEN_STRONG_INLINE Packet8d pbroadcast_third<Packet8d>(const Packet8d& a_in) {
-  Packet2d a = _mm512_extractf32x4_ps(a_in, 1);
+  Packet2d a = _mm256_extractf128_pd(_mm512_castpd512_pd256(a_in), 1);
   return _mm512_broadcastsd_pd(a);
 }
 template <>
 EIGEN_STRONG_INLINE Packet8d pbroadcast_fourth<Packet8d>(const Packet8d& a_in) {
-  Packet2d a = _mm_permute_pd(_mm512_extractf32x4_ps(a_in, 1), 3);
+  Packet2d a = _mm_permute_pd(_mm256_extractf128_pd(_mm512_castpd512_pd256(a_in), 1), 3);
   return _mm512_broadcastsd_pd(a);
 }
 template <>
@@ -417,14 +417,14 @@ EIGEN_STRONG_INLINE Packet8f pbroadcast_fourth<Packet8f>(const Packet8f& a) {
 
 template <typename Packet>
 EIGEN_DEVICE_FUNC inline Packet16f pexpand_bf16_l(const Packet16f& from) {
-  return _mm512_slli_epi32(_mm512_cvtepu16_epi32(_mm512_castsi512_si256(from)),
-                           16);
+  return _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(_mm512_castsi512_si256(_mm512_castps_si512(from))),
+                           16));
 }
 
 template <typename Packet>
 EIGEN_DEVICE_FUNC inline Packet16f pexpand_bf16_u(const Packet16f& from) {
-  return _mm512_slli_epi32(
-      _mm512_cvtepu16_epi32(_mm512_extractf64x4_pd(from, 1)), 16);
+  return _mm512_castsi512_ps(_mm512_slli_epi32(
+      _mm512_cvtepu16_epi32(_mm256_castpd_si256(_mm512_extractf64x4_pd(_mm512_castps_pd(from), 1))), 16));
 }
 
 #endif

--- a/third_party/eigen3/unsupported/Eigen/CXX11/FixedPoint
+++ b/third_party/eigen3/unsupported/Eigen/CXX11/FixedPoint
@@ -31,7 +31,7 @@
 #include "src/FixedPoint/FixedPointTypes.h"
 
 // Use optimized implementations whenever available
-#ifdef EIGEN_VECTORIZE_AVX512
+#if defined (EIGEN_VECTORIZE_AVX512DQ) || defined (EIGEN_VECTORIZE_AVX512BW)
 #include "src/FixedPoint/PacketMathAVX512.h"
 #include "src/FixedPoint/TypeCastingAVX512.h"
 


### PR DESCRIPTION
This fixes the compilation errors (listed below) encountered when building TensorFlow with -mavx512f flag. -mavx512f enables generation of AVX-512 Foundational instructions in TF/Eigen and are needed for optimal performance on Knights Landing (Intel Xeon Phi x200) architecture.

./tensorflow/core/kernels/sparse_matmul_op.h:258:46: error: cannot convert 'const Packet8d {aka const __vector(8) double}' to '__m512 {aka __vector(16) float}' for argument '1' to '__m128 _mm512_extractf32x4_ps(__m512, int)'
./tensorflow/core/kernels/sparse_matmul_op.h:263:61: error: cannot convert 'const Packet8d {aka const __vector(8) double}' to '__m512 {aka __vector(16) float}' for argument '1' to '__m128 _mm512_extractf32x4_ps(__m512, int)'
./tensorflow/core/kernels/sparse_matmul_op.h:420:77: error: cannot convert 'const Packet16f {aka const __vector(16) float}' to '__m512i {aka __vector(8) long long int}' for argument '1' to '__m256i _mm512_castsi512_si256(__m512i)'
./tensorflow/core/kernels/sparse_matmul_op.h:427:59: error: cannot convert 'const Packet16f {aka const __vector(16) float}' to '__m512d {aka __vector(8) double}' for argument '1' to '__m256d _mm512_extractf64x4_pd(__m512d, int)'
./tensorflow/core/kernels/eigen_pooling.h:334:67: error: cannot convert '__m512i {aka __vector(8) long long int}' to '__vector(16) float' in initialization
./tensorflow/core/kernels/eigen_pooling.h:335:57: error: cannot convert '__vector(16) float' to '__m512i {aka __vector(8) long long int}' for argument '1' to '__m512i _mm512_ternarylogic_epi64(__m512i, __m512i, __m512i, int)'
./tensorflow/core/kernels/eigen_pooling.h:335:57: error: cannot convert '__vector(16) float' to '__m512i {aka __vector(8) long long int}' for argument '1' to '__m512i _mm512_ternarylogic_epi64(__m512i, __m512i, __m512i, int)'
