### PR TITLE
Ignore generated bazel_config while configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ node_modules
 __pycache__
 *.swp
 .vscode/
+build_config.bzl-e
+build_config_root.bzl-e


### PR DESCRIPTION
`./configure` with default setting generates untracked files of bazel configs.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	tensorflow/core/platform/default/build_config.bzl-e
	tensorflow/core/platform/default/build_config_root.bzl-e
```