### PR TITLE
Fix Inconsistency in the seq2seq documentation.

### DIFF
--- a/tensorflow/contrib/legacy_seq2seq/python/ops/seq2seq.py
+++ b/tensorflow/contrib/legacy_seq2seq/python/ops/seq2seq.py
@@ -1111,7 +1111,7 @@ def sequence_loss(logits,
     average_across_timesteps: If set, divide the returned cost by the total
       label weight.
     average_across_batch: If set, divide the returned cost by the batch size.
-    softmax_loss_function: Function (inputs-batch, labels-batch) -> loss-batch
+    softmax_loss_function: Function (labels-batch, inputs-batch) -> loss-batch
       to be used instead of the standard softmax (the default if this is None).
     name: Optional name for this operation, defaults to "sequence_loss".
 
@@ -1160,7 +1160,7 @@ def model_with_buckets(encoder_inputs,
     seq2seq: A sequence-to-sequence model function; it takes 2 input that
       agree with encoder_inputs and decoder_inputs, and returns a pair
       consisting of outputs and states (as, e.g., basic_rnn_seq2seq).
-    softmax_loss_function: Function (inputs-batch, labels-batch) -> loss-batch
+    softmax_loss_function: Function (labels-batch, inputs-batch) -> loss-batch
       to be used instead of the standard softmax (the default if this is None).
     per_example_loss: Boolean. If set, the returned loss will be a batch-sized
       tensor of losses for each sequence in the batch. If unset, it will be


### PR DESCRIPTION
With TF 1.0, the parameters `softmax_loss_function` has changed from `Function (inputs-batch, labels-batch)` to `Function (labels-batch, inputs-batch)`.

The documentation has been updated for `sequence_loss_by_example`:
https://github.com/tensorflow/tensorflow/blob/a83290927bc2c7d64560d442d8aaec2d1cf155ab/tensorflow/contrib/legacy_seq2seq/python/ops/seq2seq.py#L1063

But not for `sequence_loss` and `model_with_buckets` even if those are calling `sequence_loss_by_example` internally:
https://github.com/tensorflow/tensorflow/blob/a83290927bc2c7d64560d442d8aaec2d1cf155ab/tensorflow/contrib/legacy_seq2seq/python/ops/seq2seq.py#L1114

Edit: Here is the commit that made the change but forgot to update the documentation in some places: https://github.com/tensorflow/tensorflow/commit/24246a1097048883bc83951cda347c447c562bcc