### PR TITLE
Fix typos and minor issues in Docker README.md

### DIFF
--- a/tensorflow/tools/docker/README.md
+++ b/tensorflow/tools/docker/README.md
@@ -10,16 +10,16 @@ General installation instructions are
 quick links here:
 
 * [OSX](https://www.docker.com/products/docker#/mac)
-* [ubuntu](https://docs.docker.com/engine/installation/linux/ubuntulinux/)
+* [Ubuntu](https://docs.docker.com/engine/installation/linux/ubuntulinux/)
 
 ## Which containers exist?
 
-We currently maintain three Docker container images:
+We currently maintain two Docker container images:
 
 * `gcr.io/tensorflow/tensorflow` - TensorFlow with all dependencies - CPU only!
 
 * `gcr.io/tensorflow/tensorflow:latest-gpu` - TensorFlow with all dependencies
-  and support for Nvidia Cuda
+  and support for NVidia CUDA
 
 Note: We also publish the same containers into
 [Docker Hub](https://hub.docker.com/r/tensorflow/tensorflow/tags/).
@@ -37,9 +37,9 @@ For GPU support install NVidia drivers (ideally latest) and
     $ nvidia-docker run -it -p 8888:8888 gcr.io/tensorflow/tensorflow:latest-gpu
 
 
-Note: If you would have a problem running nvidia-docker you may try the old way
-we have used. But it is not recomended. If you find a bug in nvidia-docker report
-it there please and try using the nvidia-docker as described above.
+Note: If you would have a problem running nvidia-docker you may try the old method
+we have used. But it is not recommended. If you find a bug in nvidia-docker, please report
+it there and try using nvidia-docker as described above.
 
     $ export CUDA_SO=$(\ls /usr/lib/x86_64-linux-gnu/libcuda.* | xargs -I{} echo '-v {}:{}')
     $ export DEVICES=$(\ls /dev/nvidia* | xargs -I{} echo '--device {}:{}')
@@ -49,7 +49,7 @@ it there please and try using the nvidia-docker as described above.
 ## More containers
 
 See all available [tags](https://hub.docker.com/r/tensorflow/tensorflow/tags/)
-for additional containers like release candidates or nighlty builds.
+for additional containers, such as release candidates or nightly builds.
 
 
 ## Rebuilding the containers


### PR DESCRIPTION
Fix typos, company/product name capitalization, and other minor issues.

### Typos:
recomended &#x27F6; recommended
nighlty &#x27F6; nightly

### Capitalization (changed to capitalization that's most consistent with rest of TensorFlow repo):
ubuntu &#x27F6; Ubuntu
Nvidia &#x27F6; NVidia
Cuda &#x27F6; CUDA

### Note:
The change from three Docker container images to only two being listed happened in [this commit](https://github.com/tensorflow/tensorflow/commit/60796d7c0d401e5e7b7a139f165e78ce778583be).