### PR TITLE
Fixed broken link to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ tracking requests and bugs, but please see
 and discussion.**
 
 ## Installation
-*See [Download and Setup](tensorflow/g3doc/get_started/os_setup.md) for instructions on how to install our release binaries or how to build from source.*
+*See [Download and Setup](tensorflow/docs_src/install/index.md) for instructions on how to install our release binaries or how to build from source.*
 
 People who are a little more adventurous can also try our nightly binaries:
 


### PR DESCRIPTION
This link was broken when the docs were moved (and apparently restructured a bit).

It looks like the original file, os_setup.md doesn't exist anymore, but it looks like install.md is the most appropriate replacement.