### PR TITLE
Update MNIST source url, original url is dead

### DIFF
--- a/tensorflow/contrib/learn/python/learn/datasets/mnist.py
+++ b/tensorflow/contrib/learn/python/learn/datasets/mnist.py
@@ -27,7 +27,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 from tensorflow.contrib.learn.python.learn.datasets import base
 from tensorflow.python.framework import dtypes
 
-SOURCE_URL = 'http://yann.lecun.com/exdb/mnist/'
+SOURCE_URL = 'https://github.com/MostafaGazar/datasets/raw/master/mnist/'
 
 
 def _read32(bytestream):


### PR DESCRIPTION
http://yann.lecun.com/exdb/mnist/ is not accessible