### PR TITLE
fix the filter position cacluating for the VALID padding mode

### DIFF
--- a/tensorflow/core/kernels/quantized_conv_ops.cc
+++ b/tensorflow/core/kernels/quantized_conv_ops.cc
@@ -88,9 +88,9 @@ class ReferenceConvFunctor {
     int filter_top_offset;
     if (padding == VALID) {
       filter_left_offset =
-          ((output_width - 1) * stride + filter_width - input_width) / 2;
+          ((output_width - 1) * stride + filter_width - input_width + 1) / 2;
       filter_top_offset =
-          ((output_height - 1) * stride + filter_height - input_height) / 2;
+          ((output_height - 1) * stride + filter_height - input_height + 1) / 2;
     } else {
       filter_left_offset =
           ((output_width - 1) * stride + filter_width - input_width) / 2;


### PR DESCRIPTION
There is a typo for the filter position calculation for the padding mode of VALID. 
Here we fixing it by using the same way of ~/tensorflow/core/kernels/conv_ops_using_gemm.cc.
