### PR TITLE
fix compiler issues with intrinsics under Windows for Build Tools for VS2017

### DIFF
--- a/tensorflow/core/platform/windows/cpu_info.h
+++ b/tensorflow/core/platform/windows/cpu_info.h
@@ -16,6 +16,9 @@ limitations under the License.
 #ifndef TENSORFLOW_PLATFORM_WINDOWS_CPU_INFO_H_
 #define TENSORFLOW_PLATFORM_WINDOWS_CPU_INFO_H_
 
+// included so __cpuidex function is available for GETCPUID on Windows
+#include <intrin.h>
+
 // Byte order defines provided by gcc. MSVC doesn't define those so
 // we define them here.
 // We assume that all windows platform out there are little endian.

--- a/tensorflow/core/platform/windows/intrinsics_port.h
+++ b/tensorflow/core/platform/windows/intrinsics_port.h
@@ -25,8 +25,8 @@ limitations under the License.
 
 #define _mm_load_pd1 _mm_load1_pd
 
-// only define these intrinsics if imminitrin.h by Intel wasn't included
-#ifndef _INCLUDED_IMM
+// only define these intrinsics if immintrin.h doesn't have them (VS2015 and earlier)
+#if _MSC_VER < 1910
 static inline int
 _mm256_extract_epi32(__m256i a, const int i)
 {

--- a/tensorflow/core/platform/windows/intrinsics_port.h
+++ b/tensorflow/core/platform/windows/intrinsics_port.h
@@ -24,6 +24,9 @@ limitations under the License.
 #include "tensorflow/core/platform/types.h"
 
 #define _mm_load_pd1 _mm_load1_pd
+
+// only define these intrinsics if imminitrin.h by Intel wasn't included
+#ifndef _INCLUDED_IMM
 static inline int
 _mm256_extract_epi32(__m256i a, const int i)
 {
@@ -37,5 +40,6 @@ _mm256_insert_epi32(__m256i a, int b, const int i)
   c.m256i_i32[i & 7] = b;
   return c;
 }
+#endif
 #endif
 #endif


### PR DESCRIPTION
Based on discussion in Issue #7966 

two changes made:
1) add `#include <intrin.h>` to `tensorflow\core\platform\windows\cpu_info.h ` for availability of `__cpuidex` function based on [this](https://msdn.microsoft.com/en-us/library/hskdteyh.aspx)

2) do not define functions `_mm256_extract_epi32 `and `_mm256_insert_epi32 `in `tensorflow/core/platform/windows/intrinsics_port.h` because they are already declared in `immintrin.h` in VS2017 (as extern as they are intrinsics now)

Quote from `immintrin.h`
```
// Insert integer into 256-bit packed integer array at element selected by index
extern __m256i __cdecl _mm256_insert_epi8 (__m256i /* dst */, int /* src */, const int /* index */);
extern __m256i __cdecl _mm256_insert_epi16(__m256i /* dst */, int /* src */, const int /* index */);
extern __m256i __cdecl _mm256_insert_epi32(__m256i /* dst */, int /* src */, const int /* index */);
#if defined(_M_X64)
extern __m256i __cdecl _mm256_insert_epi64(__m256i /* dst */, __int64 /* src */, const int /* index */);
#endif  // defined (_M_X64)

// Extract integer element selected by index from 256-bit packed integer array
extern int __cdecl _mm256_extract_epi8 (__m256i /* src */, const int /* index */);
extern int __cdecl _mm256_extract_epi16(__m256i /* src */, const int /* index */);
extern int __cdecl _mm256_extract_epi32(__m256i /* src */, const int /* index */);
#if defined(_M_X64)
extern __int64 __cdecl _mm256_extract_epi64(__m256i /* src */, const int /* index */);
#endif  // defined (_M_X64)
```