### PR TITLE
Add support for the matmul (@) operator.

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -265,7 +265,9 @@ class Tensor(_TensorLike):
       # Unary.
       "__invert__",
       "__neg__",
-      "__abs__"
+      "__abs__",
+      "__matmul__",
+      "__rmatmul__"
   }
 
   def __init__(self, op, value_index, dtype):

--- a/tensorflow/python/kernel_tests/matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/matmul_op_test.py
@@ -483,6 +483,12 @@ class MatMulInfixOperatorTest(test.TestCase):
         ops.convert_to_tensor([[10.0, 20.0, 30.0]]),
         ops.convert_to_tensor([[40.0, 50.0], [60.0, 70.0]]))
 
+  def testInfixMatmulIsTfMatmul(self):
+      a = ops.convert_to_tensor([[10.0, 20.0, 30.0]])
+      b = ops.convert_to_tensor([[40.0, 50.0], [60.0, 70.0], [80.0, 90.0]])
+      c = infix_matmul(a, b)
+      self.assertEqual(c.op.type, 'MatMul')
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/matmul_op_test.py
@@ -445,11 +445,11 @@ class MatMulStatsTest(test.TestCase):
 # @ operator supported since python 3.5.
 if sys.version_info >= (3, 5):
   # Use eval() to avoid a compilation error on earlier versions.
-  _MATMUL = lambda x, y: eval("x @ y")
+  infix_matmul = lambda x, y: eval("x @ y")
 else:
   # For earlier versions of python, emulate regular behavior.
   # Useful to build and test for 3.5+ on earlier versions.
-  def _MATMUL(x, y):
+  def infix_matmul(x, y):
     try:
       r = type(x).__matmul__(x, y)
     except AttributeError:
@@ -472,14 +472,14 @@ class MatMulInfixOperatorTest(test.TestCase):
   def testMismatchedShape(self):
     with self.assertRaisesWithPredicateMatch(
         ValueError, lambda e: "Shape must" in str(e)):
-      _MATMUL(
+      infix_matmul(
         ops.convert_to_tensor([10.0, 20.0, 30.0]),
         ops.convert_to_tensor([[40.0, 50.0], [60.0, 70.0]]))
 
   def testMismatchedDimensions(self):
     with self.assertRaisesWithPredicateMatch(
         ValueError, lambda e: "Dimensions must" in str(e)):
-      _MATMUL(
+      infix_matmul(
         ops.convert_to_tensor([[10.0, 20.0, 30.0]]),
         ops.convert_to_tensor([[40.0, 50.0], [60.0, 70.0]]))
 

--- a/tensorflow/python/kernel_tests/matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/matmul_op_test.py
@@ -466,7 +466,7 @@ except AttributeError:
     return r
 
 
-class MatMulInfixOperatorTest(test.TestCase):
+class MatMulInfixOperatorTest(test_lib.TestCase):
 
   def testMismatchedShape(self):
     with self.assertRaisesWithPredicateMatch(

--- a/tensorflow/python/kernel_tests/matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/matmul_op_test.py
@@ -443,8 +443,8 @@ class MatMulStatsTest(test.TestCase):
 
 
 try:
-    # @ operator supported since python 3.5.
-    infix_matmul = operator.matmul
+  # @ operator supported since python 3.5.
+  infix_matmul = operator.matmul
 except AttributeError:
   # For earlier versions of python, emulate regular behavior.
   # Useful to build and test for 3.5+ on earlier versions.

--- a/tensorflow/python/kernel_tests/variables_test.py
+++ b/tensorflow/python/kernel_tests/variables_test.py
@@ -318,6 +318,10 @@ class VariablesTestCase(test.TestCase):
       var_t = variables.Variable(rnd)
       slice_v = var_t[2, 0:0]
 
+      var_m = variables.Variable([[2.0, 3.0]])
+      matmul = var_m.__matmul__([[10.0],[20.0]])
+      rmatmul = var_m.__rmatmul__([[10.0],[20.0]])
+
       variables.global_variables_initializer().run()
       self.assertAllClose([2.0], add.eval())
       self.assertAllClose([3.0], radd.eval())
@@ -347,6 +351,9 @@ class VariablesTestCase(test.TestCase):
       self.assertAllClose([False, True], invert_v.eval())
 
       self.assertAllClose(rnd[2, 0:0], slice_v.eval())
+
+      self.assertAllClose([[80.0]], matmul.eval())
+      self.assertAllClose([[20.0, 30.0], [40.0, 60.0]], rmatmul.eval())
 
   def testSession(self):
     with self.test_session() as sess:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1685,6 +1685,12 @@ def matmul(a,
                            [229 244]],
                           [[508 532]
                            [697 730]]]
+
+  # Since python >= 3.5 the @ operator is supported (see PEP 465).
+  # In TensorFlow, it simply calls the `tf.matmul()` function, so the
+  # following lines are equivalent:
+  d = a @ b @ [[10.], [11.]]
+  d = tf.matmul(tf.matmul(a, b), [[10.], [11.]])
   ```
 
   Args:
@@ -1770,6 +1776,8 @@ def matmul(a,
       return gen_math_ops._mat_mul(
           a, b, transpose_a=transpose_a, transpose_b=transpose_b, name=name)
 
+
+_OverrideBinaryOperatorHelper(matmul, "matmul")
 
 sparse_matmul = gen_math_ops._sparse_mat_mul
 


### PR DESCRIPTION
This PR closes #1062.
Assuming `a` and `b` are tensors, `a @ b`  is equivalent to `tf.matmul(a, b)`.

Note that either `a` or `b` can be a NumPy array or a regular python array, for example the following expressions are valid:
* `a @ [[1.], [2.]]`
* `[[1., 2.]] @ a`
* `a @ np.array([[1.], [2.]])`
* `np.array([[1., 2.]]) @ a`
