### PR TITLE
[BACKPORT-r0.12] Fix loading of libhdfs.so when installed in non-standard directory

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -112,6 +112,11 @@ class LibHDFS {
     }
     string path = io::JoinPath(hdfs_home, "lib", "native", "libhdfs.so");
     status_ = TryLoadAndBind(path.c_str(), &handle_);
+    if (!status_.ok()) {
+      // try load libhdfs.so using dynamic loader's search path in case libhdfs.so
+      // is installed in non-standard location
+      status_ = TryLoadAndBind("libhdfs.so", &handle_);
+    }
     return;
   }
 

--- a/tensorflow/g3doc/how_tos/hadoop/index.md
+++ b/tensorflow/g3doc/how_tos/hadoop/index.md
@@ -32,7 +32,9 @@ be set:
 source $HADOOP_HOME/libexec/hadoop-config.sh
 ```
 
-*   **LD_LIBRARY_PATH**: To include the path to libjvm.so. On Linux:
+*   **LD_LIBRARY_PATH**: To include the path to libjvm.so, and optionally the path 
+    to libhdfs.so if your Hadoop distribution does not install libhdfs.so in 
+    `$HADOOP_HDFS_HOME/lib/native`. On Linux:
 
 ```shell
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JAVA_HOME/jre/lib/amd64/server


### PR DESCRIPTION
This PR is to backport #5911 to branch r0.12