### PR TITLE
install_linux.md: add missing closing <tt> tag

### DIFF
--- a/tensorflow/docs_src/install/install_linux.md
+++ b/tensorflow/docs_src/install/install_linux.md
@@ -440,7 +440,7 @@ Take the following steps to install TensorFlow in an Anaconda environment:
   2. Create a conda environment named <tt>tensorflow</tt> to run a version
      of Python by invoking the following command:
 
-     <tt>$ <b>conda create -n tensorflow</b> 
+     <tt>$ <b>conda create -n tensorflow</b> </tt>
 
   3. Activate the conda environment by issuing the following command:
 


### PR DESCRIPTION
There is a simple formatting error in install_linux.md which leads to the lower section of https://www.tensorflow.org/install/install_linux#run_a_short_tensorflow_program  being rendered entirely in monospaced font. Add a closing ``<tt>`` tag to correct formatting.