### PR TITLE
Fix Linux pip install paths and instructions

### DIFF
--- a/tensorflow/docs_src/install/install_linux.md
+++ b/tensorflow/docs_src/install/install_linux.md
@@ -162,7 +162,7 @@ Take the following steps to install TensorFlow with Virtualenv:
      command to install TensorFlow in the active virtualenv environment:
 
      <pre>(tensorflow)$ <b>pip3 install --upgrade \
-     https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.0.0-py3-none-any.whl</b></pre>
+     https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.0.0-cp34-cp34m-linux_x86_64.whl</b></pre>
 
 If you encounter installation problems, see
 [Common Installation Problems](#CommonInstallationProblems).
@@ -260,19 +260,21 @@ take the following steps:
   3. (Optional.) If Step 2 failed, install the latest version of TensorFlow 
      by issuing a command of the following format:
 
-     <pre>$ <b>sudo pip  install --upgrade</b> <i>TF_BINARY_URL</i>   # Python 2.7
-     $ <b>sudo pip3 install --upgrade</b> <i>TF_BINARY_URL</i>   # Python 3.N </pre>
+     <pre>$ <b>sudo pip  install --upgrade</b> <i>TF_PYTHON_URL</i>   # Python 2.7
+     $ <b>sudo pip3 install --upgrade</b> <i>TF_PYTHON_URL</i>   # Python 3.N </pre>
 
-     where <i>TF_BINARY_URL</i> identifies the URL of the TensorFlow Python
-     package. The appropriate value of <i>TF_BINARY_URL</i> depends on the
-     operating system, Python version, and GPU support. Find the appropriate
-     For example, if you are installing TensorFlow for Linux,
-     Python version 3.4, and CPU-only support, the command to install
-     TensorFlow is as follows:
+     where <code><em>TF_PYTHON_URL</em></code> identifies the URL of the
+     TensorFlow Python package. The appropriate value of
+     <code><em>TF_PYTHON_URL</em></code>depends on the operating system,
+     Python version, and GPU support. Find the appropriate value for
+     <code><em>TF_PYTHON_URL</em></code> for your system
+     [here](#TF_PYTHON_URL).  For example, if you are installing TensorFlow
+     for Linux, Python version 3.4, and CPU-only support, issue the following
+     command:
 
      <pre>
      $ <b>sudo pip3 install --upgrade \
-     https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.0.0-py3-none-any.whl</b>
+     https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.0.0-cp34-cp34m-linux_x86_64.whl</b>
      </pre>
 
      If this step fails, see


### PR DESCRIPTION
I updated the wheel URLs (the old ones give 404s) and fixed the wording for the pip install instructions.