### PR TITLE
Update the github docs link in the error msg upon import failure

### DIFF
--- a/tensorflow/python/pywrap_tensorflow.py
+++ b/tensorflow/python/pywrap_tensorflow.py
@@ -46,8 +46,12 @@ try:
     sys.setdlopenflags(_default_dlopen_flags)
 except ImportError:
   msg = """%s\n\nFailed to load the native TensorFlow runtime.\n
-See https://github.com/tensorflow/tensorflow/blob/master/tensorflow/g3doc/get_started/os_setup.md#import_error\n
-for some common reasons and solutions.  Include the entire stack trace
+Visit https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/install/index.md\n
+and click on the link that corresponds to your operating system to read about\n
+common reasons and solutions in the "Common installation problems"\n
+subsection.
+
+Include the entire stack trace
 above this error message when asking for help.""" % traceback.format_exc()
   raise ImportError(msg)
 

--- a/tensorflow/python/pywrap_tensorflow.py
+++ b/tensorflow/python/pywrap_tensorflow.py
@@ -46,7 +46,7 @@ try:
     sys.setdlopenflags(_default_dlopen_flags)
 except ImportError:
   msg = """%s\n\nFailed to load the native TensorFlow runtime.\n
-Visit https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/install/index.md
+Visit https://www.tensorflow.org/install/
 and click on the link that corresponds to your operating system to read about
 common reasons and solutions in the "Common installation problems"
 subsection.

--- a/tensorflow/python/pywrap_tensorflow.py
+++ b/tensorflow/python/pywrap_tensorflow.py
@@ -46,9 +46,9 @@ try:
     sys.setdlopenflags(_default_dlopen_flags)
 except ImportError:
   msg = """%s\n\nFailed to load the native TensorFlow runtime.\n
-Visit https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/install/index.md\n
-and click on the link that corresponds to your operating system to read about\n
-common reasons and solutions in the "Common installation problems"\n
+Visit https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/install/index.md
+and click on the link that corresponds to your operating system to read about
+common reasons and solutions in the "Common installation problems"
 subsection.
 
 Include the entire stack trace


### PR DESCRIPTION
Hi,
since the docs have moved from `g3doc` to `docs_src` (and have been refactored), I thought it would be good to update the link in the error message that comes up upon import failures.