### PR TITLE
Fix some typos in the documation (tensorflow/docs_src)

### DIFF
--- a/tensorflow/docs_src/get_started/monitors.md
+++ b/tensorflow/docs_src/get_started/monitors.md
@@ -300,7 +300,7 @@ validation_metrics = {
 Add the above code before the `ValidationMonitor` constructor. Then revise the
 `ValidationMonitor` constructor as follows to add a `metrics` parameter to log
 the accuracy, precision, and recall metrics specified in `validation_metrics`
-(loss is always logged, and doesn't need to be explicity specified):
+(loss is always logged, and doesn't need to be explicitly specified):
 
 ```python
 validation_monitor = tf.contrib.learn.monitors.ValidationMonitor(

--- a/tensorflow/docs_src/performance/xla/index.md
+++ b/tensorflow/docs_src/performance/xla/index.md
@@ -10,7 +10,7 @@ XLA (Accelerated Linear Algebra) is a domain-specific compiler for linear
 algebra that optimizes TensorFlow computations. The results are improvements in
 speed, memory usage, and portability on server and mobile platforms. Initially,
 most users will not see large benefits from XLA, but are welcome to experiment
-by using XLA via @{$jit$just-in-time (JIT) compilaton} or @{$tfcompile$ahead-of-time (AOT) compilation}. Developers targeting new hardware accelerators are
+by using XLA via @{$jit$just-in-time (JIT) compilation} or @{$tfcompile$ahead-of-time (AOT) compilation}. Developers targeting new hardware accelerators are
 especially encouraged to try out XLA.
 
 The XLA framework is experimental and in active development. In particular,

--- a/tensorflow/docs_src/programmers_guide/debugger.md
+++ b/tensorflow/docs_src/programmers_guide/debugger.md
@@ -102,7 +102,7 @@ left corner of the screen to proceed.
 
 This will bring up another screen
 right after the `run()` call has ended, which will display all dumped
-intermedate tensors from the run. (These tensors can also be obtained by
+intermediate tensors from the run. (These tensors can also be obtained by
 running the command `lt` after you executed `run`.) This is called the
 **run-end UI**:
 

--- a/tensorflow/docs_src/programmers_guide/supervisor.md
+++ b/tensorflow/docs_src/programmers_guide/supervisor.md
@@ -278,7 +278,7 @@ constructor:
 
    If you do not pass one, the supervisor creates one for you by calling
    `tf.Saver()`, which add ops to save and restore all variables in your model.
-   This is usally what you need.
+   This is usually what you need.
 
 Example: Use a custom Saver and checkpoint every 30 seconds.
 

--- a/tensorflow/docs_src/tutorials/wide.md
+++ b/tensorflow/docs_src/tutorials/wide.md
@@ -294,7 +294,7 @@ only learn one of the three cases:
 1.  Income stays the same no matter at what age (no correlation)
 
 If we want to learn the fine-grained correlation between income and each age
-group seperately, we can leverage **bucketization**. Bucketization is a process
+group separately, we can leverage **bucketization**. Bucketization is a process
 of dividing the entire range of a continuous feature into a set of consecutive
 bins/buckets, and then converting the original numerical feature into a bucket
 ID (as a categorical feature) depending on which bucket that value falls into.

--- a/tensorflow/docs_src/tutorials/wide_and_deep.md
+++ b/tensorflow/docs_src/tutorials/wide_and_deep.md
@@ -269,4 +269,4 @@ familiar with the API. Wide & Deep Learning will be even more powerful if you
 try it on a large dataset with many sparse feature columns that have a large
 number of possible feature values. Again, feel free to take a look at our
 [research paper](http://arxiv.org/abs/1606.07792) for more ideas about how to
-apply Wide & Deep Learning in real-world large-scale maching learning problems.
+apply Wide & Deep Learning in real-world large-scale machine learning problems.


### PR DESCRIPTION
This fix fixes some typos in the documentation (`tensorflow/docs_src/**.md`)