### PR TITLE
unexpected pipe read status

### DIFF
--- a/tensorflow/contrib/framework/python/ops/arg_scope.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope.py
@@ -33,7 +33,7 @@
   The first call to conv2d will use predefined args:
     layers.conv2d(inputs, 64, [11, 11], 4, padding='VALID', ..., scope='conv1')
 
-  The second call to Conv will overwrite padding:
+  The second call to conv2d will overwrite padding:
     layers.conv2d(inputs, 256, [5, 5], padding='SAME', ..., scope='conv2')
 
   Example of how to reuse an arg_scope:

--- a/tensorflow/g3doc/tutorials/input_fn/index.md
+++ b/tensorflow/g3doc/tutorials/input_fn/index.md
@@ -286,7 +286,7 @@ accept a _pandas_ `Dataframe` and return feature column and label values as
 
 ```python
 def input_fn(data_set):
-  feature_cols = {k: tf.constant(data_set[k].values
+  feature_cols = {k: tf.constant(data_set[k].values)
                   for k in FEATURES}
   labels = tf.constant(data_set[LABEL].values)
   return feature_cols, labels

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -225,7 +225,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
   native.new_http_archive(
     name = "zlib_archive",
-    url = "http://zlib.net/zlib-1.2.8.tar.gz",
+    url = "http://zlib.net/fossils/zlib-1.2.8.tar.gz",
     sha256 = "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d",
     strip_prefix = "zlib-1.2.8",
     build_file = str(Label("//:zlib.BUILD")),


### PR DESCRIPTION
Hello,everyone!
I am new about tensorflow,and I am just trying to build tensorflow from source according to the steps described step by step, but I get the following error, Is there anyone who can help on it? That would be very kind of you!
Thank you very much!

cynthia@cynthia-pc:~/tensorflow$ ./configure

..........continue........
then the result came with the following......
I guess that maybe something wrong with my bazel ,but I'm new about this,and I'm really no idea how to solve it.

unexpected pipe read status: No such file or directory
Server presumed dead. Now printing '/home/cynthia/.cache/bazel/_bazel_cynthia/581b5660c7c191b39a76e8a607014a30/server/jvm.out':
Java HotSpot(TM) Server VM warning: You have loaded library /home/cynthia/.cache/bazel/_bazel_cynthia/install/6a615f09339464d6ea7e8fe00f96c132/_embedded_binaries/libunix.so which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c ', or link it with '-z noexecstack'.
JNI initialization failed: /home/cynthia/.cache/bazel/_bazel_cynthia/install/6a615f09339464d6ea7e8fe00f96c132/_embedded_binaries/libunix.so: /home/cynthia/.cache/bazel/_bazel_cynthia/install/6a615f09339464d6ea7e8fe00f96c132/_embedded_binaries/libunix.so: wrong ELF class: ELFCLASS64 (Possible cause: architecture word width mismatch). Possibly your installation has been corrupted; if this problem persists, try 'rm -fr /home/cynthia/.cache/bazel/_bazel_cynthia/install/6a615f09339464d6ea7e8fe00f96c132'.
java.lang.UnsatisfiedLinkError: /home/cynthia/.cache/bazel/_bazel_cynthia/install/6a615f09339464d6ea7e8fe00f96c132/_embedded_binaries/libunix.so: /home/cynthia/.cache/bazel/_bazel_cynthia/install/6a615f09339464d6ea7e8fe00f96c132/_embedded_binaries/libunix.so: wrong ELF class: ELFCLASS64 (Possible cause: architecture word width mismatch)
at java.lang.ClassLoader$NativeLibrary.load(Native Method)
at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1941)
at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1857)
at java.lang.Runtime.loadLibrary0(Runtime.java:870)
at java.lang.System.loadLibrary(System.java:1122)
at com.google.devtools.build.lib.UnixJniLoader.loadJni(UnixJniLoader.java:28)
at com.google.devtools.build.lib.unix.ProcessUtils.(ProcessUtils.java:28)
at com.google.devtools.build.lib.util.ProcessUtils.getpid(ProcessUtils.java:47)
at com.google.devtools.build.lib.util.OsUtils.forceJNI(OsUtils.java:55)
at com.google.devtools.build.lib.util.OsUtils.maybeForceJNI(OsUtils.java:43)
at com.google.devtools.build.lib.runtime.BlazeRuntime.newRuntime(BlazeRuntime.java:934)
at com.google.devtools.build.lib.runtime.BlazeRuntime.createBlazeRPCServer(BlazeRuntime.java:838)
at com.google.devtools.build.lib.runtime.BlazeRuntime.serverMain(BlazeRuntime.java:777)
at com.google.devtools.build.lib.runtime.BlazeRuntime.main(BlazeRuntime.java:565)
at com.google.devtools.build.lib.bazel.BazelMain.main(BazelMain.java:57)