### PR TITLE
Fix a bug of initializing

### DIFF
--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -685,7 +685,7 @@ class _VariableStore(object):
       else:
         # Instantiate initializer if provided initializer is a type object.
         if isinstance(initializer, type(init_ops.Initializer)):
-          initializer=initializer(dtype)
+          initializer=initializer(dtype=dtype)
         init_val = lambda: initializer(  # pylint: disable=g-long-lambda
             shape.as_list(), dtype=dtype, partition_info=partition_info)
         variable_dtype = dtype.base_dtype

--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -683,6 +683,8 @@ class _VariableStore(object):
         init_val = initializer
         variable_dtype = None
       else:
+        if type(initializer)==type:
+          initializer=initializer(dtype)
         init_val = lambda: initializer(  # pylint: disable=g-long-lambda
             shape.as_list(), dtype=dtype, partition_info=partition_info)
         variable_dtype = dtype.base_dtype

--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -683,7 +683,8 @@ class _VariableStore(object):
         init_val = initializer
         variable_dtype = None
       else:
-        if type(initializer)==type:
+        # Instantiate initializer if provided initializer is a type object.
+        if isinstance(initializer, type(init_ops.Initializer)):
           initializer=initializer(dtype)
         init_val = lambda: initializer(  # pylint: disable=g-long-lambda
             shape.as_list(), dtype=dtype, partition_info=partition_info)


### PR DESCRIPTION
Prevent the exceptional illegal call of __initializer.\_\_init\_\_(shape, dtype, partition_info)__ appears when the param "initializer" is an init_ops class instead of its instance.