### PR TITLE
Use vector constructor to initialize Array3D.

### DIFF
--- a/tensorflow/compiler/xla/array3d.h
+++ b/tensorflow/compiler/xla/array3d.h
@@ -39,15 +39,11 @@ class Array3D {
  public:
   // Creates an array of dimensions n1 x n2 x n3, uninitialized values.
   Array3D(const int64 n1, const int64 n2, const int64 n3)
-      : n1_(n1), n2_(n2), n3_(n3) {
-    values_.resize(n1 * n2 * n3);
-  }
+      : n1_(n1), n2_(n2), n3_(n3), values_(n1 * n2 * n3) {}
 
   // Creates an array of dimensions n1 x n2 x n3, initialized to value.
   Array3D(const int64 n1, const int64 n2, const int64 n3, const T value)
-      : Array3D(n1, n2, n3) {
-    Fill(value);
-  }
+      : n1_(n1), n2_(n2), n3_(n3), values_(n1 * n2 * n3, value) {}
 
   // Creates an array from the given nested initializer list. The outer
   // initializer list is the first dimension, and so on.

--- a/tensorflow/compiler/xla/array4d.h
+++ b/tensorflow/compiler/xla/array4d.h
@@ -56,15 +56,19 @@ class Array4D {
  public:
   // Creates a 4D array, unitialized values.
   Array4D(int64 planes, int64 depth, int64 height, int64 width)
-      : planes_(planes), depth_(depth), height_(height), width_(width) {
-    values_.resize(planes * depth * height * width);
-  }
+      : planes_(planes),
+        depth_(depth),
+        height_(height),
+        width_(width),
+        values_(planes * depth * height * width) {}
 
   // Creates a 4D array, initalized to value.
   Array4D(int64 planes, int64 depth, int64 height, int64 width, T value)
-      : Array4D(planes, depth, height, width) {
-    Fill(value);
-  }
+      : planes_(planes),
+        depth_(depth),
+        height_(height),
+        width_(width),
+        values_(planes * depth * height * width, value) {}
 
   // Creates a 4D array, filled with values.
   //


### PR DESCRIPTION
Current constructor of Array3D calls resize to initialize the inner vector of
Array3D and follows up with a Fill call. This can be replaced with a simple
call to vector constructor. Vector constructor might also be more efficient.