### PR TITLE
Make binary ops delegate to rhs when tensor conversion fails

### DIFF
--- a/tensorflow/python/kernel_tests/tensor_priority_test.py
+++ b/tensorflow/python/kernel_tests/tensor_priority_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for the __tensor_priority__ mechanism."""
+"""Tests for the binary ops priority mechanism."""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tensorflow/python/kernel_tests/tensor_priority_test.py
+++ b/tensorflow/python/kernel_tests/tensor_priority_test.py
@@ -1,0 +1,79 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the __tensor_priority__ mechanism."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow import Tensor
+from tensorflow import register_tensor_conversion_function
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import test as test_lib
+
+
+class TensorPriorityTest(test_lib.TestCase):
+
+  def testSupportedRhsWithoutDelegation(self):
+    class NumpyArraySubclass(np.ndarray):
+      pass
+    supported_rhs_without_delegation = (
+      3,
+      3.0,
+      [1.0, 2.0],
+      np.array([1.0, 2.0]),
+      NumpyArraySubclass(shape=(1,2), buffer=np.array([1.0, 2.0])),
+      ops.convert_to_tensor([[1.0, 2.0]]))
+    for rhs in supported_rhs_without_delegation:
+      tensor = ops.convert_to_tensor([[10.0, 20.0]])
+      res = tensor + rhs
+      self.assertIsInstance(res, Tensor)
+
+  def testUnsupportedRhsWithoutDelegation(self):
+    class WithoutReverseAdd(object):
+      pass
+    tensor = ops.convert_to_tensor([[10.0, 20.0]])
+    rhs = WithoutReverseAdd()
+    with self.assertRaisesWithPredicateMatch(
+        TypeError, lambda e: "Expected float" in str(e)):
+      res = tensor + rhs
+
+  def testUnsupportedRhsWithDelegation(self):
+    class WithReverseAdd(object):
+      def __radd__(self, lhs):
+        return "Works!"
+    tensor = ops.convert_to_tensor([[10.0, 20.0]])
+    rhs = WithReverseAdd()
+    res = tensor + rhs
+    self.assertEqual(res, "Works!")
+
+  def testFullDelegationControlUsingRegistry(self):
+    class NumpyArraySubclass(np.ndarray):
+      def __radd__(self, lhs):
+        return "Works!"
+    def raise_to_delegate(value, dtype=None, name=None, as_ref=False):
+      raise TypeError
+    register_tensor_conversion_function(NumpyArraySubclass, raise_to_delegate,
+                                        priority=0)
+    tensor = ops.convert_to_tensor([[10.0, 20.0]])
+    rhs = NumpyArraySubclass(shape=(1,2), buffer=np.array([1.0, 2.0]))
+    res = tensor + rhs
+    self.assertEqual(res, "Works!")
+
+
+if __name__ == "__main__":
+  test_lib.main()

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -799,6 +799,9 @@ def _OverrideBinaryOperatorHelper(func, op_name, clazz_object=ops.Tensor):
         try:
           y = ops.convert_to_tensor(y, dtype=x.dtype.base_dtype, name="y")
         except TypeError:
+          # If the RHS is not a tensor, it might be a tensor aware object
+          # that can implement the operator with knowledge of itself
+          # and the tensor.
           if hasattr(type(y), "__r%s__" % op_name):
             return NotImplemented
           else:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -796,7 +796,13 @@ def _OverrideBinaryOperatorHelper(func, op_name, clazz_object=ops.Tensor):
   def binary_op_wrapper(x, y):
     with ops.name_scope(None, op_name, [x, y]) as name:
       if not isinstance(y, sparse_tensor.SparseTensor):
-        y = ops.convert_to_tensor(y, dtype=x.dtype.base_dtype, name="y")
+        try:
+          y = ops.convert_to_tensor(y, dtype=x.dtype.base_dtype, name="y")
+        except TypeError:
+          if hasattr(type(y), "__r%s__" % op_name):
+            return NotImplemented
+          else:
+            raise
       return func(x, y, name=name)
 
   def binary_op_wrapper_sparse(sp_x, y):


### PR DESCRIPTION
Fixes #8051.

The goal is to allow users to choose whether `tensor + something` should call `tensor`'s `__add__()` method or `something`'s `__radd__()` method.

Example usage:

```
>>> import tensorflow as tf
>>> tensor = tf.constant(3.0)
>>> class MagicMatrix(object):
...   def __radd__(self, lhs):
...     print("MagicMatrix.__radd__", lhs)
... 
>>> tensor + MagicMatrix()
MagicMatrix.__radd__ Tensor("Const:0", shape=(), dtype=float32)
```

If the RHS's type does not define the reverse method (in this example `__radd__()`) then the usual behavior applies:

```
>>> class MagicMatrix(object):
...   pass
... 
>>> tensor + MagicMatrix()
Traceback (most recent call last):
[...]
TypeError: Expected float32, got <__main__.MagicMatrix object at 0x7f14e32aa978> of type 'MagicMatrix' instead.
```
