### PR TITLE
Fix XLA build breakage on Mac OS X.

### DIFF
--- a/tensorflow/compiler/xla/service/allocation_tracker.cc
+++ b/tensorflow/compiler/xla/service/allocation_tracker.cc
@@ -171,8 +171,7 @@ StatusOr<std::vector<GlobalDataHandle>> AllocationTracker::DeconstructTuple(
           executor, allocation->device_memory(), allocation->shape()));
 
   std::vector<GlobalDataHandle> element_handles;
-  for (std::vector<se::DeviceMemoryBase>::size_type i = 0;
-       i < element_bases.size(); ++i) {
+  for (int i = 0; i < element_bases.size(); ++i) {
     element_handles.push_back(RegisterInternal(
         allocation->backend(), allocation->device_ordinal(), element_bases[i],
         ShapeUtil::GetSubshape(allocation->shape(), {i}),

--- a/tensorflow/compiler/xla/service/call_graph.h
+++ b/tensorflow/compiler/xla/service/call_graph.h
@@ -141,7 +141,7 @@ class CallGraph {
   using VisitorFunction = std::function<Status(const CallGraphNode&)>;
 
   // Build and return a call graph for the given HLO module.
-  static StatusOr<CallGraph> Build(const HloModule* module);
+  static StatusOr<std::unique_ptr<CallGraph>> Build(const HloModule* module);
 
   // Public default constructor required for StatusOr<CallGraph>.
   CallGraph() = default;


### PR DESCRIPTION
Fixes two compilation problems on Mac OS X:
* call_graph.*: `error: incomplete type 'xla::CallGraph' used in type trait expression`
* allocation_tracker.cc: `error: non-constant-expression cannot be narrowed from type 'std::vector<se::DeviceMemoryBase>::size_type' (aka 'unsigned long') to 'long long' in initializer list [-Wc++11-narrowing]`