### PR TITLE
Update documentation for BN

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -160,9 +160,8 @@ def _fused_batch_norm(
   they need to be added as a dependency to the `train_op`, example:
 
     update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
-    if update_ops:
-      updates = tf.group(*update_ops)
-      total_loss = control_flow_ops.with_dependencies([updates], total_loss)
+    with tf.control_dependencies(update_ops):
+      train_op = optimizer.minimize(loss)
 
   One can set updates_collections=None to force the updates in place, but that
   can have speed penalty, especially in distributed settings.
@@ -393,9 +392,8 @@ def batch_norm(
   they need to be added as a dependency to the `train_op`, example:
 
     update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
-    if update_ops:
-      updates = tf.group(*update_ops)
-      total_loss = control_flow_ops.with_dependencies([updates], total_loss)
+    with tf.control_dependencies(update_ops):
+      train_op = optimizer.minimize(loss)
 
   One can set updates_collections=None to force the updates in place, but that
   can have speed penalty, especially in distributed settings.


### PR DESCRIPTION
The [documentation code](https://www.tensorflow.org/api_docs/python/tf/contrib/layers/batch_norm) to update `moving_mean` and `moving_variance` for BN raise an error with TF 1.0:
 
```
AttributeError: module 'tensorflow' has no attribute 'control_flow_ops'
``` 

It seems the new way to add dependencies between ops is to use the `tf.control_dependencies`.

I also attached the `updates_op` to the `train_op` instead of `total_loss` to be more coherent with the associated warning: `[...] they need to be added as a dependency to the train_op, example:`. It also make more sense as we don't want to update `moving_mean` when computing the loss on the testing set.