### PR TITLE
Readded build rule for image resize benchmarks, extended for bilinear.

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -1723,6 +1723,22 @@ tf_cuda_cc_test(
     ],
 )
 
+tf_cuda_cc_test(
+    name = "resize_benchmark_test",
+    srcs = ["resize_op_benchmark_test.cc"],
+    deps = [
+        ":image",
+        ":ops_testutil",
+        ":ops_util",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+    ],
+)
+
 cc_library(
     name = "io",
     deps = [

--- a/tensorflow/core/kernels/resize_op_benchmark_test.cc
+++ b/tensorflow/core/kernels/resize_op_benchmark_test.cc
@@ -21,7 +21,7 @@ limitations under the License.
 
 namespace tensorflow {
 
-static Graph* BM_ResizeNearestNeighbor(int batches, int width, int height) {
+static Graph* BM_Resize(const char* algorithm, int batches, int width, int height) {
   Graph* g = new Graph(OpRegistry::Global());
   Tensor in(DT_FLOAT, TensorShape({batches, width, height, 3}));
   in.flat<float>().setRandom();
@@ -32,21 +32,25 @@ static Graph* BM_ResizeNearestNeighbor(int batches, int width, int height) {
   out_size_flat(1) = height * 2;
 
   Node* ret;
-  NodeBuilder(g->NewName("n"), "ResizeNearestNeighbor")
+  NodeBuilder(g->NewName("n"), algorithm)
       .Input(test::graph::Constant(g, in))
       .Input(test::graph::Constant(g, out_size))
       .Finalize(g, &ret);
   return g;
 }
 
-#define BM_ResizeNearestNeighborDev(DEVICE, B, W, H)                           \
-  static void BM_ResizeNearestNeighbor_##DEVICE##_##B##_##W##_##H(int iters) { \
-    testing::ItemsProcessed(iters* B* W* H * 3);                               \
-    test::Benchmark(#DEVICE, BM_ResizeNearestNeighbor(B, W, H)).Run(iters);    \
-  }                                                                            \
-  BENCHMARK(BM_ResizeNearestNeighbor_##DEVICE##_##B##_##W##_##H)
+#define BM_ResizeDev(DEVICE, ALGORITHM, B, W, H)                                \
+  static void BM_Resize_##ALGORITHM##_##DEVICE##_##B##_##W##_##H(int iters) {   \
+    testing::ItemsProcessed(iters* B* W* H * 3);                                \
+    test::Benchmark(#DEVICE, BM_Resize(#ALGORITHM, B, W, H)).Run(iters);        \
+  }                                                                             \
+  BENCHMARK(BM_Resize_##ALGORITHM##_##DEVICE##_##B##_##W##_##H)
 
-BM_ResizeNearestNeighborDev(cpu, 1, 499, 499);
-BM_ResizeNearestNeighborDev(gpu, 1, 499, 499);
+BM_ResizeDev(cpu, ResizeNearestNeighbor, 10, 499, 499);
+BM_ResizeDev(gpu, ResizeNearestNeighbor, 10, 499, 499);
 
-}  // namespace tensorflow
+BM_ResizeDev(cpu, ResizeBilinear, 10, 499, 499);
+BM_ResizeDev(gpu, ResizeBilinear, 10, 499, 499);
+
+}  // tensorflow
+


### PR DESCRIPTION
Build rule was deleted somewhere along the way. Connected to discussion of issue #533. Benchmark results on my configuration (GTX 960):

```
Benchmark                                  Time(ns) Iterations
--------------------------------------------------------------
BM_Resize_NearestNeighbor_cpu_10_499_499   36575420        100 204.2M items/s
BM_Resize_NearestNeighbor_gpu_10_499_499    5042070        100 1481.5M items/s
BM_Resize_Bilinear_cpu_10_499_499          31493990        100 237.2M items/s
BM_Resize_Bilinear_gpu_10_499_499           5754130        100 1298.2M items/s
```