### PR TITLE
tf_upgrade should rename tf.batch_fft2d to tf.fft2d

### DIFF
--- a/tensorflow/tools/compatibility/tf_upgrade.py
+++ b/tensorflow/tools/compatibility/tf_upgrade.py
@@ -140,6 +140,7 @@ class APIChangeSpec(object):
         "tf.batch_svd": "tf.svd",
         "tf.batch_fft": "tf.fft",
         "tf.batch_ifft": "tf.ifft",
+        "tf.batch_fft2d": "tf.fft2d",
         "tf.batch_ifft2d": "tf.ifft2d",
         "tf.batch_fft3d": "tf.fft3d",
         "tf.batch_ifft3d": "tf.ifft3d",


### PR DESCRIPTION
Updating a module with `tf_upgrade.py` should rename tf.batch_fft2d to tf.fft2d similarly to the others fft / ifft functions.