### PR TITLE
Indentation in word2vec_basic.py

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -250,6 +250,6 @@ try:
   low_dim_embs = tsne.fit_transform(final_embeddings[:plot_only, :])
   labels = [reverse_dictionary[i] for i in xrange(plot_only)]
   plot_with_labels(low_dim_embs, labels)
-
+  
 except ImportError:
   print("Please install sklearn, matplotlib, and scipy to visualize embeddings.")

--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -139,25 +139,25 @@ num_sampled = 64    # Number of negative examples to sample.
 graph = tf.Graph()
 
 with graph.as_default():
-
+  
   # Input data.
   train_inputs = tf.placeholder(tf.int32, shape=[batch_size])
   train_labels = tf.placeholder(tf.int32, shape=[batch_size, 1])
   valid_dataset = tf.constant(valid_examples, dtype=tf.int32)
-
+  
   # Ops and variables pinned to the CPU because of missing GPU implementation
   with tf.device('/cpu:0'):
     # Look up embeddings for inputs.
     embeddings = tf.Variable(
         tf.random_uniform([vocabulary_size, embedding_size], -1.0, 1.0))
     embed = tf.nn.embedding_lookup(embeddings, train_inputs)
-
+    
     # Construct the variables for the NCE loss
     nce_weights = tf.Variable(
         tf.truncated_normal([vocabulary_size, embedding_size],
                             stddev=1.0 / math.sqrt(embedding_size)))
     nce_biases = tf.Variable(tf.zeros([vocabulary_size]))
-
+  
   # Compute the average NCE loss for the batch.
   # tf.nce_loss automatically draws a new sample of the negative labels each
   # time we evaluate the loss.
@@ -168,10 +168,10 @@ with graph.as_default():
                      inputs=embed,
                      num_sampled=num_sampled,
                      num_classes=vocabulary_size))
-
+  
   # Construct the SGD optimizer using a learning rate of 1.0.
   optimizer = tf.train.GradientDescentOptimizer(1.0).minimize(loss)
-
+  
   # Compute the cosine similarity between minibatch examples and all embeddings.
   norm = tf.sqrt(tf.reduce_sum(tf.square(embeddings), 1, keep_dims=True))
   normalized_embeddings = embeddings / norm
@@ -179,7 +179,7 @@ with graph.as_default():
       normalized_embeddings, valid_dataset)
   similarity = tf.matmul(
       valid_embeddings, normalized_embeddings, transpose_b=True)
-
+  
   # Add variable initializer.
   init = tf.global_variables_initializer()
 
@@ -190,25 +190,25 @@ with tf.Session(graph=graph) as session:
   # We must initialize all variables before we use them.
   init.run()
   print("Initialized")
-
+  
   average_loss = 0
   for step in xrange(num_steps):
     batch_inputs, batch_labels = generate_batch(
         batch_size, num_skips, skip_window)
     feed_dict = {train_inputs: batch_inputs, train_labels: batch_labels}
-
+    
     # We perform one update step by evaluating the optimizer op (including it
     # in the list of returned values for session.run()
     _, loss_val = session.run([optimizer, loss], feed_dict=feed_dict)
     average_loss += loss_val
-
+    
     if step % 2000 == 0:
       if step > 0:
         average_loss /= 2000
       # The average loss is an estimate of the loss over the last 2000 batches.
       print("Average loss at step ", step, ": ", average_loss)
       average_loss = 0
-
+    
     # Note that this is expensive (~20% slowdown if computed every 500 steps)
     if step % 10000 == 0:
       sim = similarity.eval()
@@ -238,13 +238,13 @@ def plot_with_labels(low_dim_embs, labels, filename='tsne.png'):
                  textcoords='offset points',
                  ha='right',
                  va='bottom')
-
+  
   plt.savefig(filename)
 
 try:
   from sklearn.manifold import TSNE
   import matplotlib.pyplot as plt
-
+  
   tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=5000)
   plot_only = 500
   low_dim_embs = tsne.fit_transform(final_embeddings[:plot_only, :])


### PR DESCRIPTION
Running the raw word2vec_basic.py in a python terminal threw a number of `IndentationError: unexpected indent` exceptions, and it looks like the cause is the indentation of the blank lines.

I’ve added the expected spacing into the blank lines here, and can confirm that the script now runs correctly.