### PR TITLE
Add SingleImageRandomDotStereogramsOp to Contrib

### DIFF
--- a/tensorflow/contrib/BUILD
+++ b/tensorflow/contrib/BUILD
@@ -26,6 +26,7 @@ py_library(
         "//tensorflow/contrib/graph_editor:graph_editor_py",
         "//tensorflow/contrib/grid_rnn:grid_rnn_py",
         "//tensorflow/contrib/image:image_py",
+        "//tensorflow/contrib/image:single_image_random_dot_stereograms_py",
         "//tensorflow/contrib/input_pipeline:input_pipeline_py",
         "//tensorflow/contrib/integrate:integrate_py",
         "//tensorflow/contrib/labeled_tensor",

--- a/tensorflow/contrib/image/BUILD
+++ b/tensorflow/contrib/image/BUILD
@@ -71,6 +71,41 @@ cuda_py_test(
     ],
 )
 
+
+
+tf_custom_op_library(
+    name = "python/ops/_single_image_random_dot_stereograms.so",
+    srcs = [
+        "kernels/single_image_random_dot_stereograms_ops.cc",
+        "ops/single_image_random_dot_stereograms_ops.cc",
+        ],
+)
+
+tf_gen_op_libs(
+    op_lib_names = ["single_image_random_dot_stereograms_ops"],
+)
+
+tf_gen_op_wrapper_py(
+    name = "single_image_random_dot_stereograms_ops",
+    deps = [":single_image_random_dot_stereograms_ops_op_lib"],
+)
+
+py_library(
+    name = "single_image_random_dot_stereograms_py",
+    srcs = glob(["python/ops/single*.py"]) +  ["__init__.py"],
+    data = [":python/ops/_single_image_random_dot_stereograms.so"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":single_image_random_dot_stereograms_ops",
+#        "//tensorflow/contrib/util:util_py",
+#        "//tensorflow/python:array_ops",
+#        "//tensorflow/python:framework",
+#        "//tensorflow/python:framework_for_generated_wrappers",
+#        "//tensorflow/python:math_ops",
+#        "//tensorflow/python:platform",
+    ],
+)
+
 filegroup(
     name = "all_files",
     srcs = glob(

--- a/tensorflow/contrib/image/__init__.py
+++ b/tensorflow/contrib/image/__init__.py
@@ -23,6 +23,7 @@ transforms (including rotation) are supported.
 
 @@rotate
 @@transform
+@@single_image_random_dot_stereograms
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -31,6 +32,7 @@ from __future__ import print_function
 # pylint: disable=line-too-long
 from tensorflow.contrib.image.python.ops.image_ops import rotate
 from tensorflow.contrib.image.python.ops.image_ops import transform
+from tensorflow.contrib.image.python.ops.single_image_random_dot_stereograms import single_image_random_dot_stereograms
 
 from tensorflow.python.util.all_util import remove_undocumented
 

--- a/tensorflow/contrib/image/kernels/single_image_random_dot_stereograms_ops.cc
+++ b/tensorflow/contrib/image/kernels/single_image_random_dot_stereograms_ops.cc
@@ -1,0 +1,486 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/shape_inference.h"
+ 
+namespace tensorflow {
+ 
+using shape_inference::InferenceContext;
+
+template <typename T>
+class SingleImageRandomDotStereogramsOp : public OpKernel {
+ private:
+   int        E2Epixels;	// Pixels from eye to eye = eye_to_eye_inches * DPI
+
+   int        input_Xvalue; // X value of input Z values (width)
+   int        input_Yvalue; // Y value of input Z values (height)
+
+   int        output_Ximage;  // X value of output image (width)
+   int        output_Yimage;  // Y value of output image (height)
+   int        output_Cimage;  // color value of output image (color, 1 or 3)  (3 not implemented)
+
+   int        data_box_left;      // X starting value for DATA window 
+   int        data_box_top;       // Y starting value for DATA window
+   int        data_box_width;     // width of scan line
+   int        data_box_height;    // hight of image
+
+   int        converge_dot_box_end;    // Row convergences dots end on
+
+   uint8*     outputImage;        // Output Image flat as a buffer (Tensor Connection)
+   double*    ZBuffer;            // For internal use, allow for MASK, etc later, actual Z used for Stereogram, XxY (X is the row index, y is col index like a screen)
+// 0 (far) -> 1.0(near) range
+   bool       hidden_surface_removal;
+   int        convergence_dots_size;
+   int        dots_per_inch;
+   float      eye_separation;
+   float      mu;
+   bool       normalize;
+   float      normalize_max;
+   float      normalize_min;
+   float      boarder_level;
+   int        number_colors;
+   string     generation_mode;
+   ::tensorflow::TensorShapeProto      output_image_shape;
+   ::tensorflow::TensorShapeProto      output_data_window;
+
+   uint8    Cblack=(uint8)0;
+   uint8    Cwhite=(uint8)255;
+
+   int indexMode=0;	// 0 - truncate XY, 1 - round XY, 2 - Interpolate XY (not implemented yet, keep default of 0)
+   int interp_x,interp_y;	// 1 - yes, 0 - no  interpolation directions (not implemented yet)
+
+   bool debugging = true;
+
+   int round(double x) { return((int)(x+.5)); }
+   int separation(double z)
+   {
+      return(round((1-mu*z)*E2Epixels/(2-mu*z)));
+   }
+
+   int get_far_width() { return(separation(0.0)); }
+   int get_near_width() { return(separation(1.0)); }
+
+ public:
+  explicit SingleImageRandomDotStereogramsOp(OpKernelConstruction* context) : OpKernel(context) 
+  {// Constructor
+    OP_REQUIRES_OK(context,context->GetAttr("hidden_surface_removal", &hidden_surface_removal));
+    OP_REQUIRES_OK(context,context->GetAttr("convergence_dots_size", &convergence_dots_size));
+    OP_REQUIRES_OK(context,context->GetAttr("dots_per_inch", &dots_per_inch));
+    OP_REQUIRES_OK(context,context->GetAttr("eye_separation", &eye_separation));
+    OP_REQUIRES_OK(context,context->GetAttr("mu", &mu));
+    OP_REQUIRES_OK(context,context->GetAttr("normalize", &normalize));
+    OP_REQUIRES_OK(context,context->GetAttr("normalize_max", &normalize_max));
+    OP_REQUIRES_OK(context,context->GetAttr("normalize_min", &normalize_min));
+    OP_REQUIRES_OK(context,context->GetAttr("boarder_level", &boarder_level));
+    OP_REQUIRES_OK(context,context->GetAttr("number_colors", &number_colors));
+    OP_REQUIRES_OK(context,context->GetAttr("generation_mode", &generation_mode));
+    OP_REQUIRES_OK(context,context->GetAttr("output_image_shape", &output_image_shape));
+    OP_REQUIRES_OK(context,context->GetAttr("output_data_window", &output_data_window));
+    
+    E2Epixels=eye_separation*dots_per_inch;  // Initialize pixels from eye to eye
+  }
+
+  ~SingleImageRandomDotStereogramsOp()
+  {// Destructor
+
+  }  
+
+  void Compute(OpKernelContext* context) override {
+
+    const Tensor&       input_tensor = context->input(0);
+    input_Xvalue=input_tensor.shape().dim_size(1); // X value is the number of columns of the input matrix
+    input_Yvalue=input_tensor.shape().dim_size(0); // Y value is the number of rows
+
+    output_Ximage=output_image_shape.dim(0).size();
+    output_Yimage=output_image_shape.dim(1).size();
+    output_Cimage=output_image_shape.dim(2).size();
+
+    if (number_colors>256)  // Go to full color image
+      output_Cimage=3;
+
+    int data_Xwindow=output_data_window.dim(0).size();
+    int data_Ywindow=output_data_window.dim(1).size();
+
+    int deltaX_boarder_image=output_Ximage-data_Xwindow;
+    int deltaY_boarder_image=output_Yimage-data_Ywindow;
+
+    if (convergence_dots_size>0) // 3 frame sections in Y direction due to DOTS
+    {
+        deltaY_boarder_image=deltaY_boarder_image-convergence_dots_size;  // Take off space for Convergence Dots
+        deltaY_boarder_image=std::max(0,deltaY_boarder_image);
+        data_box_top=deltaY_boarder_image/3;
+
+        if (deltaY_boarder_image>=0)
+        {
+          converge_dot_box_end=output_Yimage-1-data_box_top;
+        }
+        else
+        {
+          converge_dot_box_end=output_Yimage-1;
+        }
+    }
+    else    // Otherwise only 2, no convergence dot
+    {
+        data_box_top=deltaY_boarder_image/2;    // Center DATA in Y dimension  
+        converge_dot_box_end=output_Yimage-1;
+    }
+
+    data_box_left=deltaX_boarder_image/2;       // Center DATA in X dimension
+    data_box_width=data_Xwindow;                // width of scan line
+    data_box_height=data_Ywindow;               // hight of image    
+ 
+    if (debugging)
+    {
+        LOG(INFO)<<"input_Xvalue "<<input_Xvalue;
+        LOG(INFO)<<"input_Yvalue "<<input_Yvalue;
+        LOG(INFO)<<"output_Ximage "<<output_Ximage;
+        LOG(INFO)<<"output_Yimage "<<output_Yimage;
+        LOG(INFO)<<"output_Cimage "<<output_Cimage;
+        LOG(INFO)<<"data_Xwindow "<<data_Xwindow;
+        LOG(INFO)<<"data_Ywindow "<<data_Ywindow;
+        LOG(INFO)<<"deltaX_boarder_image "<<deltaX_boarder_image;
+        LOG(INFO)<<"deltaY_boarder_image "<<deltaY_boarder_image;
+        LOG(INFO)<<"data_box_left "<<data_box_left;
+        LOG(INFO)<<"data_box_top "<<data_box_top;
+        LOG(INFO)<<"data_box_width "<<data_box_width;
+        LOG(INFO)<<"data_box_height "<<data_box_height;
+        LOG(INFO)<<"converge_dot_box_end "<<converge_dot_box_end;
+
+        LOG(INFO)<<"=@@======================================================= ";
+        LOG(INFO)<<"SingleImageRandomDotStereogramsOp output_data_window "<<output_data_window.DebugString();
+        LOG(INFO)<<"SingleImageRandomDotStereogramsOp output_image_shape "<<output_image_shape.DebugString();
+        LOG(INFO)<<"SingleImageRandomDotStereogramsOp Compute "<<input_tensor.DebugString();
+    }
+
+    const T* inputZ = input_tensor.flat<T>().data();  // Flatten input Z buffer
+
+    BuildZBuffer(inputZ);
+
+    // Output a scalar string.
+    Tensor* output_tensor = NULL;    
+    OP_REQUIRES_OK(context,context->allocate_output(0, TensorShape({output_Yimage,output_Ximage,output_Cimage}), &output_tensor));
+    
+    outputImage = output_tensor->flat<uint8>().data();
+    if (debugging)
+        LOG(INFO)<<"output_tensor->flat<uint8>().data(); "<<output_tensor->DebugString();//<<output_image_shape.DebugString();
+
+    generate_stereogram();
+
+    delete[] ZBuffer;
+  }
+  
+  //***************************************************************************
+  //***************************************************************************
+  // Move input into standard Z format to reduce complexity of algorithm
+  //
+  void BuildZBuffer(const T* Z,bool log=false)
+  {
+    double MaxValue =1.0;
+    double MinValue =0.0;    
+    ZBuffer  = new double[input_Xvalue*input_Yvalue];  // Used to computer final Z values before rendering to output
+
+    if (normalize)
+    {
+      // Init Min/Max to first value
+      if (normalize_max<normalize_min)  // Autoscale if MIN>MAX
+      {
+        MaxValue =(double)*Z;
+        MinValue =(double)*Z;
+
+        for (int y=0;y<input_Yvalue;++y)
+          for (int x=0;x<input_Xvalue;++x)
+          {
+            double value=getZfromInputImage(Z,x,y);
+            if (value>MaxValue)
+              MaxValue=value;
+            if (value<MinValue)
+              MinValue=value;
+          }
+      }
+      else
+      {
+        MaxValue =normalize_max;
+        MinValue =normalize_min;
+      }
+    }
+
+    for (int y=0;y<input_Yvalue;++y)
+      for (int x=0;x<input_Xvalue;++x)
+      {
+        double value=getZfromInputImage(Z,x,y);
+
+        if (normalize)
+        {
+          value=(value-MinValue)/(MaxValue-MinValue);
+        }
+
+        if (value>1.0)
+          value=1.0;
+        if (value<0.0)
+          value=0.0;
+
+        *(ZBuffer+(input_Xvalue*y+x))=value;  
+      }
+  }
+
+  //***************************************************************************
+  //***************************************************************************
+  double getZfromInputImage(const T* Z,int x,int y)
+  {
+    double return_val;
+    
+    return_val=(double)*(Z+input_Xvalue*y+x);  // Get value
+    return return_val;
+  }
+
+  //***************************************************************************
+  //***************************************************************************
+  // All normalized, not checking required
+  // Possible Projection issue if DATA is bigger or smaller than Input
+  //  Modes include:
+  //         Truncate value (Default)
+  //         Round-off value
+  //         Interpolate between values
+  //
+  double getZfromZbuffer(double x,double y)
+  {
+    int xi,yi;
+
+    switch (indexMode)
+    {
+      case 0: // Truncate
+        xi=int(x);
+        yi=int(y);
+        return (*(ZBuffer+(xi+input_Xvalue*yi)));
+        break;
+      case 1: // Round-off
+        xi=round(x);
+        yi=round(y);
+        return (*(ZBuffer+(xi+input_Xvalue*yi)));
+        break;
+      case 2: // Interpolate (Not implemented yet, will need 4 points [x,y],[x+1,y],[x,y+1],[x+1,y+1], then interpolate)
+        xi=int(x);
+        yi=int(y);
+        return (*(ZBuffer+(xi+input_Xvalue*yi)));
+        break;                
+      default: // Round-off is the default
+        xi=int(x+0.5);
+        yi=int(y+0.5);
+        return (*(ZBuffer+(xi+input_Xvalue*yi)));
+        break;
+    }
+  }
+
+  //***************************************************************************
+  //***************************************************************************
+
+  int getOutputImageIndex(int x,int y,int channel)
+  {// No error checking for some optimization, calling routine required to make sure there is no violation
+    return ((output_Ximage*output_Cimage)*y+x*output_Cimage+channel);
+  }
+
+  //***************************************************************************
+  //***************************************************************************
+
+  double getZFromOutputPixel(int x,int y)
+  {
+    double xofz,yofz,returnval;
+    
+    // Convert pixel units to Z units, do this as "double" 
+    
+    xofz=(double)input_Xvalue*(x-data_box_left)/((double)data_box_width);
+    yofz=(double)input_Yvalue*(y-data_box_top)/((double)data_box_height);
+    
+    if ((xofz<0) || (yofz<0) || (yofz>=input_Yvalue) || (xofz>=input_Xvalue))
+    {	// Top of left side boarder hit or  Right side or bottom boarder hit
+    // Send BOARDER Z value
+        return(boarder_level);
+    }
+    
+    { 	// in data set Z interpolate if need
+        double gz;
+        // int xi,yi;
+        // double dx1,dy1,x1,x2,gz1;
+        
+        // xi=xofz;
+        // yi=yofz;
+        
+        gz=getZfromZbuffer(xofz,yofz);
+        // if ((interp_x || interp_y) && (false)) // Disable this for now, getZfromZbuffer should handle in the future
+        // {
+        //   gz1=getZfromZbuffer(xi,yi+1);
+              
+        //   dx1=(xofz-((double)xi))*(double)interp_x;	// result = 0 if no interpolation
+        //   dy1=(yofz-((double)yi))*(double)interp_y;	// result = 0 if no interpolation
+              
+        //   x1=gz+(getZfromZbuffer(xi+1,yi)-gz)*dx1;
+        //   x2=gz1+(getZfromZbuffer(xi+1,yi+1)-gz1)*dx1;
+          
+        //   returnval=x1+(x2-x1)*dy1;
+        // }
+        // else
+          returnval=gz;
+    }
+    
+    return(returnval);
+  }
+
+  //***************************************************************************
+  //***************************************************************************
+
+  void generate_stereogram()
+  {
+    int s,left,right,visible,t,l;
+    double zt,gz;
+    // Scan line
+    uint8*   pix; // Scan row color for each pixel
+    int*     same;  // Used to determine if Pixel needs to be the same as another pixel in the row
+
+    
+    pix = new uint8[output_Ximage*output_Cimage];
+    same= new int[output_Ximage];
+    
+    for (int y=0;y<output_Yimage;++y)
+    {
+        // Set no dependencies on any pixels, tie each one back to itself
+        for (int x=0;x<output_Ximage;++x)
+          same[x]=x;
+    
+        for (int x=0;x<output_Ximage;++x)
+        {
+          gz=getZFromOutputPixel(x,y);
+          s=separation(gz);
+          left=x-s/2;
+          right=left+s;
+
+          if ((left>=0)&&(right<output_Ximage))
+          {
+              t=1;
+              visible=1;
+              if (hidden_surface_removal)
+                do
+                {
+                    zt=gz+2*(2-mu*gz)*t/(mu*E2Epixels);
+                    visible=(getZFromOutputPixel(x-t,y)<zt) && (getZFromOutputPixel(x+t,y)<zt);
+                    ++t;
+                } while ((visible) && (zt<1));
+              
+              if (visible)
+              {
+                l=same[left];
+                while ((l != left) && (l!=right))
+                    if (l<right)
+                    {
+                      left=l;
+                      l=same[left];
+                    }
+                    else
+                    {
+                      same[left]=right;
+                      left=right;
+                      l=same[left];
+                      right=l;
+                    }
+                same[left]=right;
+              }
+          }
+        }
+        // Set colors for scan row, use channels and number_colors
+        for (int x=output_Ximage-1;x>=0;x--)
+        {
+          for (int channel=0;channel<output_Cimage;++channel)
+          {
+            if (same[x]==x) 
+            {// Pick a random color
+              if (number_colors==2)
+              {
+                if ((rand()%2)==0)
+                {
+                  pix[x*output_Cimage+channel]=Cblack;
+                }
+                else
+                {
+                  pix[x*output_Cimage+channel]=Cwhite;
+                }
+              }
+              else
+              {
+                pix[x*output_Cimage+channel]=rand()%256;
+              }
+            }
+            else 
+              pix[x*output_Cimage+channel]=pix[same[x]*output_Cimage+channel];
+
+            setpixel(x,y,channel,pix[x*output_Cimage+channel]);
+          }
+        }  
+    }
+
+    draw_convergence_dots();   
+
+    delete[] pix;
+    delete[] same;
+  }
+
+
+  //***************************************************************************
+  //***************************************************************************
+
+  void draw_convergence_dots()
+  {
+    int x1,x2;			// center position for convergence dots
+
+    if (convergence_dots_size==0)   // No dot, return
+      return;
+    
+    x1=output_Ximage/2-get_far_width()/2;
+    x2=output_Ximage/2+get_far_width()/2;
+    
+    for (int lloop=0;lloop<convergence_dots_size;++lloop)
+        for (int wloop=0;wloop<convergence_dots_size;++wloop)
+          for (int channel=0;channel<output_Cimage;++channel)
+          {
+            setpixel(x1-(convergence_dots_size/2)+wloop,converge_dot_box_end-lloop,channel,Cblack);
+            setpixel(x2-(convergence_dots_size/2)+wloop,converge_dot_box_end-lloop,channel,Cblack);
+          }	
+  }
+
+
+  //***************************************************************************
+  //***************************************************************************
+
+
+  void setpixel(int x,int y,int channel,uint8 color)
+  {
+    *(outputImage+getOutputImageIndex(x,y,channel))=color;
+  }
+      
+};
+
+#define REGISTER_KERNEL(T)                                                               \
+  REGISTER_KERNEL_BUILDER(                                                                  \
+      Name("SingleImageRandomDotStereograms").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
+      SingleImageRandomDotStereogramsOp<T> );
+
+REGISTER_KERNEL(int32);
+REGISTER_KERNEL(int64);
+REGISTER_KERNEL(float);
+REGISTER_KERNEL(double);
+
+#undef REGISTER_KERNEL
+
+}  // end namespace tensorflow

--- a/tensorflow/contrib/image/kernels/single_image_random_dot_stereograms_ops.cc
+++ b/tensorflow/contrib/image/kernels/single_image_random_dot_stereograms_ops.cc
@@ -63,7 +63,7 @@ class SingleImageRandomDotStereogramsOp : public OpKernel {
    int indexMode=0;	// 0 - truncate XY, 1 - round XY, 2 - Interpolate XY (not implemented yet, keep default of 0)
    int interp_x,interp_y;	// 1 - yes, 0 - no  interpolation directions (not implemented yet)
 
-   bool debugging = true;
+   bool debugging = false;
 
    int round(double x) { return((int)(x+.5)); }
    int separation(double z)

--- a/tensorflow/contrib/image/ops/single_image_random_dot_stereograms_ops.cc
+++ b/tensorflow/contrib/image/ops/single_image_random_dot_stereograms_ops.cc
@@ -1,0 +1,97 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+
+using shape_inference::InferenceContext;
+
+REGISTER_OP("SingleImageRandomDotStereograms")
+    .Attr("T: {double,float,int64,int32}")   
+    .Input("depth_values: T")
+    .Output("image: uint8")
+    .Attr("hidden_surface_removal: bool = true")
+    .Attr("convergence_dots_size: int = 8")
+    .Attr("dots_per_inch: int = 72")
+    .Attr("eye_separation: float = 2.5")
+    .Attr("mu: float = .3333")
+    .Attr("normalize: bool = true")
+    .Attr("normalize_max: float = -100.0")
+    .Attr("normalize_min: float = 100.0")
+    .Attr("boarder_level: float = 0.0")
+    .Attr("number_colors: int = 256")    
+    .Attr("generation_mode: string = 'SIRDS'")
+    .Attr("output_image_shape: shape = { dim {size:1024} dim {size: 768} dim {size: 1}}")
+    .Attr("output_data_window: shape = { dim {size:1022} dim {size: 757}}")
+    // TODO(Mazecreator):  Add "SetShapeFN" to reflect proper output shape & Rank 2 error checking on Input
+    // TODO(Mazecreator):  Add better error handling for output shapes / windows settings
+    // .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
+    //   ::tensorflow::shape_inference::ShapeHandle input;
+    //   ::tensorflow::shape_inference::ShapeHandle output;
+    //   TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 2, &input));
+    //   TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 2, &output));
+    //   c->set_output(0,output);
+    //   return Status::OK();
+    // })
+    .Doc(R"doc(
+Output a RandomDotStereogram Tensor of shape "output_image_shape" for export via encode_PNG or encode_JPG OP.
+
+Based upon:
+'http://www.learningace.com/doc/4331582/b6ab058d1e206d68ab60e4e1ead2fe6e/sirds-paper'
+
+Example use which outputs a SIRDS image as picture_out.png:
+img=[[1,2,3,3,2,1],
+     [1,2,3,4,5,2],
+     [1,2,3,4,5,3],
+     [1,2,3,4,5,4],
+     [6,5,4,4,5,5]]
+
+session = tf.InteractiveSession()
+
+sirds = single_image_random_dot_stereograms(img,convergence_dots_size=8,number_colors=256,normalize=True)
+
+out = sirds.eval()
+
+png = tf.image.encode_png(out).eval()
+
+with open('picture_out.png', 'wb') as f:
+    f.write(png)
+
+
+depth_values:           Z values of data to encode into "output_data_window" window, lower further away {0.0 floor(far), 1.0 ceiling(near) after normalization}, must be rank 2
+hidden_surface_removal: Activate hidden surface removal (True)
+convergence_dots_size:  Black dot size in pixels to help view converge image, drawn on bottom of image (8 pixels)
+dots_per_inch:	        Output device in dots/inch (72 default)
+eye_separation:         Separation between eyes in inches (2.5 inchs)
+mu:                     Depth of field, Fraction of viewing distance (1/3 = .3333)
+normalize:              Normalize input data to [0.0, 1.0] (True)
+normalize_max:          Fix MAX value for Normalization (0.0) - if < MIN, autoscale
+normalize_min:          Fix MIN value for Normalization (0.0) - if > MAX, autoscale
+boarder_level:          Value of board in depth 0.0 {far} to 1.0 {near} (0.0)
+number_colors:          2 (Black & White),256 (grayscale), and Numbers > 256 (Full Color) are all that are supported currently
+generation_mode:        Mode for Stereogram
+                            SIRDS - 2 color stereogram (Default)
+output_image_shape:     Output size of returned image in X,Y, Channels 1-grayscale, 3 color (1024, 768, 1), channels will be updated to 3 if number_colors > 256
+output_data_window:     Size of "DATA" window, must be equal to or smaller than output_image_shape, will be centered
+                          and use convergence_dots_size for best fit to avoid overlap if possible
+
+image:                  returns a Tensor of size output_image_shape with depth_values encoded into image
+
+)doc");
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/image/python/ops/single_image_random_dot_stereograms.py
+++ b/tensorflow/contrib/image/python/ops/single_image_random_dot_stereograms.py
@@ -1,0 +1,119 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Python layer for image_ops."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib.util import loader
+from tensorflow.python.framework import common_shapes
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import resource_loader
+
+_sirds_ops = loader.load_op_library(
+    resource_loader.get_path_to_datafile("_single_image_random_dot_stereograms.so"))
+
+def single_image_random_dot_stereograms(depth_values,
+                                        hidden_surface_removal=None,
+                                        convergence_dots_size=None,
+                                        dots_per_inch=None,
+                                        eye_separation=None, mu=None,
+                                        normalize=None, normalize_max=None,
+                                        normalize_min=None,
+                                        boarder_level=None,
+                                        number_colors=None,
+                                        generation_mode=None,
+                                        output_image_shape=None,
+                                        output_data_window=None):
+  r"""Output a RandomDotStereogram Tensor of shape "output_image_shape" for export via encode_PNG or encode_JPG OP.
+
+  Based upon:
+  'http://www.learningace.com/doc/4331582/b6ab058d1e206d68ab60e4e1ead2fe6e/sirds-paper'
+
+  Example use which outputs a SIRDS image as picture_out.png:
+  img=[[1,2,3,3,2,1],
+       [1,2,3,4,5,2],
+       [1,2,3,4,5,3],
+       [1,2,3,4,5,4],
+       [6,5,4,4,5,5]]
+
+  session = tf.InteractiveSession()
+
+  sirds = single_image_random_dot_stereograms(img,convergence_dots_size=8,number_colors=256,normalize=True)
+
+  out = sirds.eval()
+
+  png = tf.image.encode_png(out).eval()
+
+  with open('picture_out.png', 'wb') as f:
+      f.write(png)
+
+  Args:
+    depth_values: A `Tensor`. Must be one of the following types: `float64`, `float32`, `int64`, `int32`.
+      Z values of data to encode into "output_data_window" window, lower further away {0.0 floor(far), 1.0 ceiling(near) after normalization}, must be rank 2
+    hidden_surface_removal: An optional `bool`. Defaults to `True`.
+      Activate hidden surface removal (True)
+    convergence_dots_size: An optional `int`. Defaults to `8`.
+      Black dot size in pixels to help view converge image, drawn on bottom of image (8 pixels)
+    dots_per_inch: An optional `int`. Defaults to `72`.
+      Output device in dots/inch (72 default)
+    eye_separation: An optional `float`. Defaults to `2.5`.
+      Separation between eyes in inches (2.5 inchs)
+    mu: An optional `float`. Defaults to `0.3333`.
+      Depth of field, Fraction of viewing distance (1/3 = .3333)
+    normalize: An optional `bool`. Defaults to `True`.
+      Normalize input data to [0.0, 1.0] (True)
+    normalize_max: An optional `float`. Defaults to `-100`.
+      Fix MAX value for Normalization (0.0) - if < MIN, autoscale
+    normalize_min: An optional `float`. Defaults to `100`.
+      Fix MIN value for Normalization (0.0) - if > MAX, autoscale
+    boarder_level: An optional `float`. Defaults to `0`.
+      Value of board in depth 0.0 {far} to 1.0 {near} (0.0)
+    number_colors: An optional `int`. Defaults to `256`.
+      2 (Black & White),256 (grayscale), and Numbers > 256 (Full Color) are all that are supported currently
+    generation_mode: An optional `string`. Defaults to `"SIRDS"`.
+      Mode for Stereogram
+      SIRDS - 2 color stereogram (Default)
+    output_image_shape: An optional `tf.TensorShape` or list of `ints`. Defaults to `[1024, 768, 1]`.
+      Output size of returned image in X,Y, Channels 1-grayscale, 3 color (1024, 768, 1), channels will be updated to 3 if number_colors > 256
+    output_data_window: An optional `tf.TensorShape` or list of `ints`. Defaults to `[1022, 757]`.
+      Size of "DATA" window, must be equal to or smaller than output_image_shape, will be centered
+      and use convergence_dots_size for best fit to avoid overlap if possible
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of type `uint8`.
+    returns a Tensor of size output_image_shape with depth_values encoded into image
+  """
+  result = _sirds_ops.single_image_random_dot_stereograms( depth_values=depth_values,
+                                hidden_surface_removal=hidden_surface_removal,
+                                convergence_dots_size=convergence_dots_size,
+                                dots_per_inch=dots_per_inch,
+                                eye_separation=eye_separation, mu=mu,
+                                normalize=normalize,
+                                normalize_max=normalize_max,
+                                normalize_min=normalize_min,
+                                boarder_level=boarder_level,
+                                number_colors=number_colors,
+                                generation_mode=generation_mode,
+                                output_image_shape=output_image_shape,
+                                output_data_window=output_data_window)
+  return result
+
+
+ops.NotDifferentiable("SingleImageRandomDotStereograms")


### PR DESCRIPTION
Updated code, closed 8074 pull request.  Could not merge to master without README file in the pull request so pulling R1.0.

This update add an Op to convert 3D data into a 2D image SIRDS (Single Image Random Dot Stereogram) for scientific data review.

It is related to this discussion:
https://github.com/tensorflow/tensorflow/issues/8022
