### PR TITLE
Fix `go generate` error in case multiple directories in GOPATH exist

### DIFF
--- a/tensorflow/go/genop/generate.sh
+++ b/tensorflow/go/genop/generate.sh
@@ -20,8 +20,13 @@ go get github.com/golang/protobuf/proto
 go get github.com/golang/protobuf/protoc-gen-go
 
 cd $(dirname $0)
-TF_DIR=${GOPATH}/src/github.com/tensorflow/tensorflow
-PROTOC="${TF_DIR}/bazel-out/host/bin/external/protobuf/protoc"
+for g in $(echo $GOPATH | sed "s/:/ /g"); do
+    TF_DIR="${g}/src/github.com/tensorflow/tensorflow"
+    PROTOC="${TF_DIR}/bazel-out/host/bin/external/protobuf/protoc"
+    if [ -x "${PROTOC}" ]; then
+        break
+    fi
+done
 
 if [ ! -x "${PROTOC}" ]
 then


### PR DESCRIPTION
This fix tries to address the issue raised in #7136 where `go generate` will produce an error when multiple directories in GOPATH exists.

The issue is because, in case multiple directories exist in GOPATH, the following line in `generate.sh` will not work:
```
cd $(dirname $0)
TF_DIR=${GOPATH}/src/github.com/tensorflow/tensorflow
PROTOC="${TF_DIR}/bazel-out/host/bin/external/protobuf/protoc"
```

This fix address the issue by iterating througgh each directory in `GOPATH` so that `protoc` (`${PROTOC}`) could be correctly located:
```
for g in $(echo $GOPATH | sed "s/:/ /g"); do
    TF_DIR="${g}/src/github.com/tensorflow/tensorflow"
    PROTOC="${TF_DIR}/bazel-out/host/bin/external/protobuf/protoc"
    if [ -x "${PROTOC}" ]; then
        break
    fi
done
```

This fix fixes #7136.