### PR TITLE
Fix for compilation error in OS/X, due to size mismatch

### DIFF
--- a/tensorflow/compiler/xla/service/allocation_tracker.cc
+++ b/tensorflow/compiler/xla/service/allocation_tracker.cc
@@ -174,7 +174,7 @@ StatusOr<std::vector<GlobalDataHandle>> AllocationTracker::DeconstructTuple(
   for (int i = 0; i < element_bases.size(); ++i) {
     element_handles.push_back(RegisterInternal(
         allocation->backend(), allocation->device_ordinal(), element_bases[i],
-        ShapeUtil::GetSubshape(allocation->shape(), {i}),
+        ShapeUtil::GetSubshape(allocation->shape(), {static_cast<long long>(i)}),
         tensorflow::strings::StrCat(allocation->tag(), ".element_", i),
         /*initial_ref_count=*/2));
   }


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/issues/8238

Error was:

```
tensorflow/compiler/xla/service/allocation_tracker.cc:178:54: error: non-constant-expression cannot be narrowed from type 'std::vector<se::DeviceMemoryBase>::size_type' (aka 'unsigned long') to 'long long' in initializer list [-Wc++11-narrowing]
        ShapeUtil::GetSubshape(allocation->shape(), {i}),
                                                     ^
tensorflow/compiler/xla/service/allocation_tracker.cc:178:54: note: insert an explicit cast to silence this issue
        ShapeUtil::GetSubshape(allocation->shape(), {i}),
                                                     ^
                                                     static_cast<long long>( )
1 error generated.
```


