### PR TITLE
Tensorboard smoothing 1st order lag filter

### DIFF
--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -441,15 +441,14 @@ module VZ {
       let data = dataset.data();
       let kernelRadius = Math.floor(data.length * factor / 2);
       data.forEach(function (d, i) {
-          var start = Math.max(0, i - kernelRadius);
-          var end = Math.min(data.length-1, i + kernelRadius);
-          // Only smooth finite numbers.
-          if (!_.isFinite(d.scalar)) {
-              d.smoothed = d.scalar;
-          }
-          else {
-              d.smoothed = d3.mean(data.slice(start, end).filter(function (d) { return _.isFinite(d.scalar); }), function (d) { return d.scalar; });
-          }
+        var start = Math.max(0, i - kernelRadius);
+        var end = Math.min(data.length - 1, i + kernelRadius);
+        // Only smooth finite numbers.
+        if (!_.isFinite(d.scalar)) {
+          d.smoothed = d.scalar;
+        } else {
+          d.smoothed = d3.mean(data.slice(start, end).filter(function (d) { return _.isFinite(d.scalar); }), function (d) { return d.scalar; });
+        }
       });
 
     }

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -441,8 +441,8 @@ module VZ {
       let data = dataset.data();
       let kernelRadius = Math.floor(data.length * factor / 2);
       data.forEach(function (d, i) {
-        var actualKernelRadius = Math.min(kernelRadius, i)
-        var start = Math.max(0, i - actualKernelRadius);
+        var actualKernelRadius = Math.min(kernelRadius, i);
+        var start = i - actualKernelRadius;
         var end = Math.min(data.length - 1, i + actualKernelRadius);
         // Only smooth finite numbers.
         if (!_.isFinite(d.scalar)) {

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -441,8 +441,9 @@ module VZ {
       let data = dataset.data();
       let kernelRadius = Math.floor(data.length * factor / 2);
       data.forEach(function (d, i) {
-        var start = Math.max(0, i - kernelRadius);
-        var end = Math.min(data.length - 1, i + kernelRadius);
+        var actualKernelRadius = Math.min(kernelRadius, i)
+        var start = Math.max(0, i - actualKernelRadius);
+        var end = Math.min(data.length - 1, i + actualKernelRadius);
         // Only smooth finite numbers.
         if (!_.isFinite(d.scalar)) {
           d.smoothed = d.scalar;

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -432,22 +432,17 @@ module VZ {
     private resmoothDataset(dataset: Plottable.Dataset) {
       var data = dataset.data();
       var smoothingWeight = this.smoothingWeight;
-      data.forEach(function (d, i) {
-        if (!_.isFinite(d.scalar)) {
+      let last = data.length > 0 ? data[0].scalar : NaN;
+      data.forEach((d) => {
+        if (!_.isFinite(last)) {
           d.smoothed = d.scalar;
+        } else {
+          // 1st-order IIR low-pass filter to attenuate the higher-
+          // frequency components of the time-series.
+          d.smoothed = last * smoothingWeight +
+                       (1 - smoothingWeight) * d.scalar;
         }
-        else if (i == 0) {
-          d.smoothed = d.scalar;
-        }
-        else {
-          var prev_index = i - 1;
-          if (!_.isFinite(data[prev_index].smoothed)) {
-            d.smoothed = d.scalar
-          }
-          else {
-            d.smoothed = data[prev_index].smoothed * smoothingWeight + (1.0 - smoothingWeight) * d.scalar;
-          }
-        }
+        last = d.smoothed;
       });
     }
 

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -434,15 +434,15 @@ module VZ {
       var smoothingWeight = this.smoothingWeight;
       data.forEach(function (d, i) {
         if (!_.isFinite(d.scalar)) {
-            d.smoothed = d.scalar;
+          d.smoothed = d.scalar;
         }
         else if (i == 0) {
-            d.smoothed = d.scalar;
+          d.smoothed = d.scalar;
         }
         else {
-          var prev_index = i > 0 ? i - 1 : 0;
+          var prev_index = i - 1;
           if (!_.isFinite(data[prev_index].smoothed)) {
-              d.smoothed = d.scalar
+            d.smoothed = d.scalar
           }
           else {
             d.smoothed = data[prev_index].smoothed * smoothingWeight + (1.0 - smoothingWeight) * d.scalar;

--- a/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorflow/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -440,26 +440,18 @@ module VZ {
       let factor = (Math.pow(1000, this.smoothingWeight) - 1) / 999;
       let data = dataset.data();
       let kernelRadius = Math.floor(data.length * factor / 2);
-
-      data.forEach((d, i) => {
-        let actualKernelRadius = Math.min(kernelRadius, i);
-        let start = i - actualKernelRadius;
-        let end = i + actualKernelRadius + 1;
-        if (end >= data.length) {
-          // In the beginning, it's OK for the smoothing window to be small,
-          // but this is not desirable towards the end. Rather than shrinking
-          // the window, or extrapolating data to fill the gap, we're simply
-          // not going to display the smoothed line towards the end.
-          d.smoothed = Infinity;
-        } else if (!_.isFinite(d.scalar)) {
+      data.forEach(function (d, i) {
+          var start = Math.max(0, i - kernelRadius);
+          var end = Math.min(data.length-1, i + kernelRadius);
           // Only smooth finite numbers.
-          d.smoothed = d.scalar;
-        } else {
-          d.smoothed = d3.mean(
-              data.slice(start, end).filter((d) => _.isFinite(d.scalar)),
-              (d) => d.scalar);
-        }
+          if (!_.isFinite(d.scalar)) {
+              d.smoothed = d.scalar;
+          }
+          else {
+              d.smoothed = d3.mean(data.slice(start, end).filter(function (d) { return _.isFinite(d.scalar); }), function (d) { return d.scalar; });
+          }
       });
+
     }
 
     private getDataset(name: string) {

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3856,8 +3856,9 @@ var VZ;
             var data = dataset.data();
             var kernelRadius = Math.floor(data.length * factor / 2);
             data.forEach(function (d, i) {
-                var start = Math.max(0, i - kernelRadius);
-                var end = Math.min(data.length-1, i + kernelRadius);
+                var actualKernelRadius = Math.min(kernelRadius, i)
+                var start = Math.max(0, i - actualKernelRadius);
+                var end = Math.min(data.length-1, i + actualKernelRadius);
                 // Only smooth finite numbers.
                 if (!_.isFinite(d.scalar)) {
                     d.smoothed = d.scalar;

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3856,9 +3856,9 @@ var VZ;
             var data = dataset.data();
             var kernelRadius = Math.floor(data.length * factor / 2);
             data.forEach(function (d, i) {
-                var actualKernelRadius = Math.min(kernelRadius, i)
-                var start = Math.max(0, i - actualKernelRadius);
-                var end = Math.min(data.length-1, i + actualKernelRadius);
+                var actualKernelRadius = Math.min(kernelRadius, i, data.length - i - 1);
+                var start = i - actualKernelRadius;
+                var end = i + actualKernelRadius + 1;
                 // Only smooth finite numbers.
                 if (!_.isFinite(d.scalar)) {
                     d.smoothed = d.scalar;

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3847,22 +3847,17 @@ var VZ;
         LineChart.prototype.resmoothDataset = function (dataset) {
             var data = dataset.data();
             var smoothingWeight = this.smoothingWeight;
-            data.forEach(function (d, i) {
-              if (!_.isFinite(d.scalar)) {
+            let last = data.length > 0 ? data[0].scalar : NaN;
+            data.forEach((d) => {
+              if (!_.isFinite(last)) {
                 d.smoothed = d.scalar;
+              } else {
+                // 1st-order IIR low-pass filter to attenuate the higher-
+                // frequency components of the time-series.
+                d.smoothed = last * smoothingWeight +
+                             (1 - smoothingWeight) * d.scalar;
               }
-              else if (i == 0) {
-                d.smoothed = d.scalar;
-              }
-              else {
-                var prev_index = i - 1;
-                if (!_.isFinite(data[prev_index].smoothed)) {
-                  d.smoothed = d.scalar
-                }
-                else {
-                  d.smoothed = data[prev_index].smoothed * smoothingWeight + (1.0 - smoothingWeight) * d.scalar;
-                }
-              }
+              last = d.smoothed;
             });
         };
         LineChart.prototype.getDataset = function (name) {

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3845,19 +3845,27 @@ var VZ;
             }
         };
         LineChart.prototype.resmoothDataset = function (dataset) {
+            // When increasing the smoothing window, it smoothes a lot with the first
+            // few points and then starts to gradually smooth slower, so using an
+            // exponential function makes the slider more consistent. 1000^x has a
+            // range of [1, 1000], so subtracting 1 and dividing by 999 results in a
+            // range of [0, 1], which can be used as the percentage of the data, so
+            // that the kernel size can be specified as a percentage instead of a
+            // hardcoded number, what would be bad with multiple series.
+            var factor = (Math.pow(1000, this.smoothingWeight) - 1) / 999;
             var data = dataset.data();
-            var smoothingWeight = this.smoothingWeight;
-            let last = data.length > 0 ? data[0].scalar : NaN;
-            data.forEach((d) => {
-              if (!_.isFinite(last)) {
-                d.smoothed = d.scalar;
-              } else {
-                // 1st-order IIR low-pass filter to attenuate the higher-
-                // frequency components of the time-series.
-                d.smoothed = last * smoothingWeight +
-                             (1 - smoothingWeight) * d.scalar;
-              }
-              last = d.smoothed;
+            var kernelRadius = Math.floor(data.length * factor / 2);
+            data.forEach(function (d, i) {
+                var actualKernelRadius = Math.min(kernelRadius, i, data.length - i - 1);
+                var start = i - actualKernelRadius;
+                var end = i + actualKernelRadius + 1;
+                // Only smooth finite numbers.
+                if (!_.isFinite(d.scalar)) {
+                    d.smoothed = d.scalar;
+                }
+                else {
+                    d.smoothed = d3.mean(data.slice(start, end).filter(function (d) { return _.isFinite(d.scalar); }), function (d) { return d.scalar; });
+                }
             });
         };
         LineChart.prototype.getDataset = function (name) {

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3845,27 +3845,24 @@ var VZ;
             }
         };
         LineChart.prototype.resmoothDataset = function (dataset) {
-            // When increasing the smoothing window, it smoothes a lot with the first
-            // few points and then starts to gradually smooth slower, so using an
-            // exponential function makes the slider more consistent. 1000^x has a
-            // range of [1, 1000], so subtracting 1 and dividing by 999 results in a
-            // range of [0, 1], which can be used as the percentage of the data, so
-            // that the kernel size can be specified as a percentage instead of a
-            // hardcoded number, what would be bad with multiple series.
-            var factor = (Math.pow(1000, this.smoothingWeight) - 1) / 999;
             var data = dataset.data();
-            var kernelRadius = Math.floor(data.length * factor / 2);
+            var smoothingWeight = this.smoothingWeight;
             data.forEach(function (d, i) {
-                var actualKernelRadius = Math.min(kernelRadius, i, data.length - i - 1);
-                var start = i - actualKernelRadius;
-                var end = i + actualKernelRadius + 1;
-                // Only smooth finite numbers.
-                if (!_.isFinite(d.scalar)) {
-                    d.smoothed = d.scalar;
+              if (!_.isFinite(d.scalar)) {
+                  d.smoothed = d.scalar;
+              }
+              else if (i == 0) {
+                  d.smoothed = d.scalar;
+              }
+              else {
+                var prev_index = i > 0 ? i - 1 : 0;
+                if (!_.isFinite(data[prev_index].smoothed)) {
+                    d.smoothed = d.scalar
                 }
                 else {
-                    d.smoothed = d3.mean(data.slice(start, end).filter(function (d) { return _.isFinite(d.scalar); }), function (d) { return d.scalar; });
+                  d.smoothed = data[prev_index].smoothed * smoothingWeight + (1.0 - smoothingWeight) * d.scalar;
                 }
+              }
             });
         };
         LineChart.prototype.getDataset = function (name) {

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3856,9 +3856,8 @@ var VZ;
             var data = dataset.data();
             var kernelRadius = Math.floor(data.length * factor / 2);
             data.forEach(function (d, i) {
-                var actualKernelRadius = Math.min(kernelRadius, i, data.length - i - 1);
-                var start = i - actualKernelRadius;
-                var end = i + actualKernelRadius + 1;
+                var start = Math.max(0, i - kernelRadius);
+                var end = Math.min(data.length-1, i + kernelRadius);
                 // Only smooth finite numbers.
                 if (!_.isFinite(d.scalar)) {
                     d.smoothed = d.scalar;

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3849,15 +3849,15 @@ var VZ;
             var smoothingWeight = this.smoothingWeight;
             data.forEach(function (d, i) {
               if (!_.isFinite(d.scalar)) {
-                  d.smoothed = d.scalar;
+                d.smoothed = d.scalar;
               }
               else if (i == 0) {
-                  d.smoothed = d.scalar;
+                d.smoothed = d.scalar;
               }
               else {
-                var prev_index = i > 0 ? i - 1 : 0;
+                var prev_index = i - 1;
                 if (!_.isFinite(data[prev_index].smoothed)) {
-                    d.smoothed = d.scalar
+                  d.smoothed = d.scalar
                 }
                 else {
                   d.smoothed = data[prev_index].smoothed * smoothingWeight + (1.0 - smoothingWeight) * d.scalar;


### PR DESCRIPTION
@dandelionmane  This is an alternative to [PR7891](https://github.com/tensorflow/tensorflow/pull/7891), since you mentioned you are considering alternative ways forward. 

It replaces the use of a moving average window with a simple first-order lag filter. It has a few advantages: 1) A bit less code. 2) It doesn't require visiting a potentially large number of values in the window to be averaged when computing each smoothed value. 3) The degree of smoothing doesn't change when you get near the end of the curve.

I left the changes in the html file so you could just run it without having to rebuild.

Here's what it does on the same data shown in the other PR.
![p_alt](https://cloud.githubusercontent.com/assets/2138320/23866631/64b05b3a-07e7-11e7-9fe8-24cd4668011c.png)

