### PR TITLE
Switch back to Ubuntu 14.04 for our releases.

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.android
+++ b/tensorflow/tools/ci_build/Dockerfile.android
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:14.04
 
 MAINTAINER Jan Prach <jendap@google.com>
 
@@ -6,6 +6,7 @@ MAINTAINER Jan Prach <jendap@google.com>
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
+    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_bazel.sh

--- a/tensorflow/tools/ci_build/Dockerfile.android
+++ b/tensorflow/tools/ci_build/Dockerfile.android
@@ -6,7 +6,6 @@ MAINTAINER Jan Prach <jendap@google.com>
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
-    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_bazel.sh

--- a/tensorflow/tools/ci_build/Dockerfile.cmake
+++ b/tensorflow/tools/ci_build/Dockerfile.cmake
@@ -7,9 +7,10 @@ COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN /install/install_deb_packages.sh
 
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends python-pip
 RUN pip install --upgrade numpy
 
 # Install golang
 RUN add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
-RUN apt-get update
 RUN apt-get install -y golang

--- a/tensorflow/tools/ci_build/Dockerfile.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:14.04
 
 MAINTAINER Jan Prach <jendap@google.com>
 
@@ -6,6 +6,7 @@ MAINTAINER Jan Prach <jendap@google.com>
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
+    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_pip_packages.sh

--- a/tensorflow/tools/ci_build/Dockerfile.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu
@@ -6,7 +6,6 @@ MAINTAINER Jan Prach <jendap@google.com>
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
-    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_pip_packages.sh

--- a/tensorflow/tools/ci_build/Dockerfile.gpu
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu
@@ -1,6 +1,11 @@
-FROM nvidia/cuda:8.0-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn5-devel-ubuntu14.04
 
 MAINTAINER Jan Prach <jendap@google.com>
+
+# In the Ubuntu 14.04 images, cudnn is placed in system paths. Move them to
+# /usr/local/cuda
+RUN cp /usr/include/cudnn.h /usr/local/cuda/include
+RUN cp /usr/lib/x86_64-linux-gnu/libcudnn* /usr/local/cuda/lib64
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/

--- a/tensorflow/tools/ci_build/Dockerfile.gpu
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04
+FROM nvidia/cuda:8.0-cudnn5-devel
 
 MAINTAINER Jan Prach <jendap@google.com>
 
@@ -6,6 +6,7 @@ MAINTAINER Jan Prach <jendap@google.com>
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
+    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_pip_packages.sh

--- a/tensorflow/tools/ci_build/Dockerfile.gpu
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu
@@ -11,7 +11,6 @@ RUN cp /usr/lib/x86_64-linux-gnu/libcudnn* /usr/local/cuda/lib64
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
-    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_pip_packages.sh

--- a/tensorflow/tools/ci_build/Dockerfile.hadoop
+++ b/tensorflow/tools/ci_build/Dockerfile.hadoop
@@ -6,7 +6,6 @@ MAINTAINER Jonathan Hseu <jhseu@google.com>
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
-    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_pip_packages.sh

--- a/tensorflow/tools/ci_build/Dockerfile.hadoop
+++ b/tensorflow/tools/ci_build/Dockerfile.hadoop
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:14.04
 
 MAINTAINER Jonathan Hseu <jhseu@google.com>
 
@@ -6,6 +6,7 @@ MAINTAINER Jonathan Hseu <jhseu@google.com>
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
+    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_pip_packages.sh

--- a/tensorflow/tools/ci_build/Dockerfile.tensorboard
+++ b/tensorflow/tools/ci_build/Dockerfile.tensorboard
@@ -6,7 +6,6 @@ MAINTAINER Jan Prach <jendap@google.com>
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
-    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_tensorboard_packages.sh

--- a/tensorflow/tools/ci_build/Dockerfile.tensorboard
+++ b/tensorflow/tools/ci_build/Dockerfile.tensorboard
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:14.04
 
 MAINTAINER Jan Prach <jendap@google.com>
 
@@ -6,6 +6,7 @@ MAINTAINER Jan Prach <jendap@google.com>
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
+    add-apt-repository -y ppa:mc3man/trusty-media && \
     add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
 RUN /install/install_tensorboard_packages.sh

--- a/tensorflow/tools/ci_build/ci_parameterized_build.sh
+++ b/tensorflow/tools/ci_build/ci_parameterized_build.sh
@@ -19,7 +19,7 @@
 #
 # The script obeys the following required environment variables:
 #   TF_BUILD_CONTAINER_TYPE:   (CPU | GPU | ANDROID | ANDROID_FULL)
-#   TF_BUILD_PYTHON_VERSION:   (PYTHON2 | PYTHON3)
+#   TF_BUILD_PYTHON_VERSION:   (PYTHON2 | PYTHON3 | PYTHON3.5)
 #   TF_BUILD_IS_PIP:           (NO_PIP | PIP | BOTH)
 #
 # The below environment variable is required, but will be deprecated together
@@ -33,7 +33,8 @@
 #   ANDROID & PIP    (Android and PIP builds are mutually exclusive)
 #
 #   2) TF_BUILD_PYTHON_VERSION is set to PYTHON3, the build will use the version
-# pointed to by "which python3" on the system.
+# pointed to by "which python3" on the system, which is typically python3.4. To
+# build for python3.5, set the environment variable to PYTHON3.5
 #
 #
 # Additionally, the script follows the directions of optional environment
@@ -419,7 +420,9 @@ fi
 # Process Python version
 if [[ ${TF_BUILD_PYTHON_VERSION} == "python2" ]]; then
   :
-elif [[ ${TF_BUILD_PYTHON_VERSION} == "python3" ]]; then
+elif [[ ${TF_BUILD_PYTHON_VERSION} == "python3" || \
+        ${TF_BUILD_PYTHON_VERSION} == "python3.4" || \
+        ${TF_BUILD_PYTHON_VERSION} == "python3.5" ]]; then
   # Supply proper environment variable to select Python 3
   if [[ "${DO_DOCKER}" == "1" ]]; then
     EXTRA_PARAMS="${EXTRA_PARAMS} -e CI_BUILD_PYTHON=${TF_BUILD_PYTHON_VERSION}"
@@ -486,6 +489,30 @@ echo ""
 
 TMP_DIR=""
 DOCKERFILE_FLAG=""
+if [[ "${TF_BUILD_PYTHON_VERSION}" == "python3.5" ]]; then
+  # Modify Dockerfile for Python3.5 build
+  TMP_DIR=$(mktemp -d)
+  echo "Docker build will occur in temporary directory: ${TMP_DIR}"
+
+  # Copy the files required for the docker build
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  cp -r "${SCRIPT_DIR}/install" "${TMP_DIR}/install" || \
+      die "ERROR: Failed to copy directory ${SCRIPT_DIR}/install"
+
+  DOCKERFILE="${SCRIPT_DIR}/Dockerfile.${TF_BUILD_CONTAINER_TYPE}"
+  cp "${DOCKERFILE}" "${TMP_DIR}/" || \
+      die "ERROR: Failed to copy Dockerfile at ${DOCKERFILE}"
+  DOCKERFILE="${TMP_DIR}/Dockerfile.${TF_BUILD_CONTAINER_TYPE}"
+
+  # Replace a line in the Dockerfile
+  sed -i \
+      's/RUN \/install\/install_pip_packages.sh/RUN \/install\/install_python3.5_pip_packages.sh/g' \
+      "${DOCKERFILE}" && \
+      echo "Copied and modified Dockerfile for Python 3.5 build: ${DOCKERFILE}" || \
+      die "ERROR: Faild to copy and modify Dockerfile: ${DOCKERFILE}"
+
+  DOCKERFILE_FLAG="--dockerfile ${DOCKERFILE}"
+fi
 
 chmod +x ${TMP_SCRIPT}
 

--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -105,7 +105,7 @@ do_pylint() {
   if [[ $1 == "PYTHON2" ]]; then
     PYLINT_BIN="python /usr/local/lib/python2.7/dist-packages/pylint/lint.py"
   elif [[ $1 == "PYTHON3" ]]; then
-    PYLINT_BIN="python3 /usr/local/lib/python3.5/dist-packages/pylint/lint.py"
+    PYLINT_BIN="python3 /usr/local/lib/python3.4/dist-packages/pylint/lint.py"
   else
     echo "Unrecognized python version (PYTHON2 | PYTHON3): $1"
     return 1

--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -43,13 +43,13 @@ apt-get install -y --no-install-recommends \
     pkg-config \
     python-dev \
     python-pip \
+    python-virtualenv \
     python3-dev \
     python3-pip \
     rsync \
     sudo \
     swig \
     unzip \
-    virtualenv \
     wget \
     zip \
     zlib1g-dev

--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -42,10 +42,10 @@ apt-get install -y --no-install-recommends \
     openjdk-8-jre-headless \
     pkg-config \
     python-dev \
-    python-pip \
+    python-setuptools \
     python-virtualenv \
     python3-dev \
-    python3-pip \
+    python3-setuptools \
     rsync \
     sudo \
     swig \

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -31,8 +31,8 @@ pip install --upgrade werkzeug==0.11.10
 pip3 install --upgrade werkzeug==0.11.10
 
 # Install protobuf.
-pip install --upgrade protobuf==3.0.0
-pip3 install --upgrade protobuf==3.0.0
+pip install --upgrade protobuf==3.2.0
+pip3 install --upgrade protobuf==3.2.0
 
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
 rm -rf /usr/lib/python3/dist-packages/six*

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -37,115 +37,21 @@ pip3 install --upgrade protobuf==3.0.0
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
 rm -rf /usr/lib/python3/dist-packages/six*
 
-set +e
-# Use pip to install numpy to a modern version, instead of 1.8.2 that comes
-# with apt-get in ubuntu:14.04.
-NUMPY_VERSION="1.11.0"
-numpy_ver_flat=$(echo $NUMPY_VERSION | sed 's/\.//g' | sed 's/^0*//g')
-local_numpy_ver=$(python -c "import numpy; print(numpy.__version__)")
-local_numpy_ver_flat=$(echo $local_numpy_ver | sed 's/\.//g' | sed 's/^0*//g')
-if [[ -z $local_numpy_ver_flat ]]; then
-  local_numpy_ver_flat=0
-fi
-if (( $local_numpy_ver_flat < $numpy_ver_flat )); then
-  set -e
-  wget -q https://pypi.python.org/packages/06/92/3c786303889e6246971ad4c48ac2b4e37a1b1c67c0dc2106dc85cb15c18e/numpy-1.11.0-cp27-cp27mu-manylinux1_x86_64.whl#md5=6ffb66ff78c28c55bfa09a2ceee487df
-  mv numpy-1.11.0-cp27-cp27mu-manylinux1_x86_64.whl \
-     numpy-1.11.0-cp27-none-linux_x86_64.whl
-  pip install numpy-1.11.0-cp27-none-linux_x86_64.whl
-  rm numpy-1.11.0-cp27-none-linux_x86_64.whl
-fi
+# numpy needs to be installed from source to fix segfaults. See:
+# https://github.com/tensorflow/tensorflow/issues/6968
+# This workaround isn't needed for Ubuntu 16.04 or later.
+pip install --no-binary=:all: --upgrade numpy
+pip3 install --no-binary=:all: --upgrade numpy
 
-set +e
-local_numpy_ver=$(python3 -c "import numpy; print(numpy.__version__)")
-local_numpy_ver_flat=$(echo $local_numpy_ver | sed 's/\.//g' | sed 's/^0*//g')
-if [[ -z $local_numpy_ver_flat ]]; then
-  local_numpy_ver_flat=0
-fi
-if (( $local_numpy_ver_flat < $numpy_ver_flat )); then
-  set -e
-  wget -q https://pypi.python.org/packages/ea/ca/5e48a68be496e6f79c3c8d90f7c03ea09bbb154ea4511f5b3d6c825cefe5/numpy-1.11.0-cp34-cp34m-manylinux1_x86_64.whl#md5=08a002aeffa20354aa5045eadb549361
-  mv numpy-1.11.0-cp34-cp34m-manylinux1_x86_64.whl \
-     numpy-1.11.0-cp34-none-linux_x86_64.whl
-  pip3 install numpy-1.11.0-cp34-none-linux_x86_64.whl
-  rm numpy-1.11.0-cp34-none-linux_x86_64.whl
-fi
+pip install scipy==0.18.1
+pip3 install scipy==0.18.1
 
-# Use pip to install scipy to get the latest version, instead of 0.13 through
-# apt-get.
-# pip install scipy==0.15.1
-set +e
-SCIPY_VERSION="0.15.1"
-scipy_ver_flat=$(echo $SCIPY_VERSION | sed 's/\.//g' | sed 's/^0*//g')
-local_scipy_ver=$(python -c "import scipy; print(scipy.__version__)")
-local_scipy_ver_flat=$(echo $local_scipy_ver | sed 's/\.//g' | sed 's/^0*//g')
-if [[ -z $local_scipy_ver_flat ]]; then
-  local_scipy_ver_flat=0
-fi
-if (( $local_scipy_ver_flat < $scipy_ver_flat )); then
-  set -e
-  wget -q https://pypi.python.org/packages/00/0f/060ec52cb74dc8df1a7ef1a524173eb0bcd329110404869b392685cfc5c8/scipy-0.15.1-cp27-cp27mu-manylinux1_x86_64.whl#md5=aaac02e6535742ab02f2075129890714
-  mv scipy-0.15.1-cp27-cp27mu-manylinux1_x86_64.whl \
-     scipy-0.15.1-cp27-none-linux_x86_64.whl
-  pip install scipy-0.15.1-cp27-none-linux_x86_64.whl
-  rm scipy-0.15.1-cp27-none-linux_x86_64.whl
-fi
-
-# pip3 install scipy==0.15.1
-set +e
-local_scipy_ver=$(python3 -c "import scipy; print(scipy.__version__)")
-local_scipy_ver_flat=$(echo $local_scipy_ver | sed 's/\.//g' | sed 's/^0*//g')
-if [[ -z $local_scipy_ver_flat ]]; then
-  local_scipy_ver_flat=0
-fi
-if (( $local_scipy_ver_flat < $scipy_ver_flat )); then
-  set -e
-  wget -q https://pypi.python.org/packages/56/c5/e0d36aaf719aa02ee3da19151045912e240d145586612e53b5eaa706e1db/scipy-0.15.1-cp34-cp34m-manylinux1_x86_64.whl#md5=d5243b0f9d85f4f4cb62514c82af93d4
-  mv scipy-0.15.1-cp34-cp34m-manylinux1_x86_64.whl \
-     scipy-0.15.1-cp34-cp34m-linux_x86_64.whl
-  pip3 install scipy-0.15.1-cp34-cp34m-linux_x86_64.whl
-  rm scipy-0.15.1-cp34-cp34m-linux_x86_64.whl
-fi
-
-# pip install sklearn
-set +e
-SKLEARN_VERSION="0.17.1"
-sklearn_ver_flat=$(echo $SKLEARN_VERSION | sed 's/\.//g' | sed 's/^0*//g')
-local_sklearn_ver=$(python -c "import sklearn; print(sklearn.__version__)")
-local_sklearn_ver_flat=$(echo $local_sklearn_ver | sed 's/\.//g' | sed 's/^0*//g')
-if [[ -z $local_sklearn_ver_flat ]]; then
-  local_sklearn_ver_flat=0
-fi
-if (( $local_sklearn_ver_flat < $sklearn_ver_flat )); then
-  set -e
-  wget -q https://pypi.python.org/packages/bf/80/06e77e5a682c46a3880ec487a5f9d910f5c8d919df9aca58052089687c7e/scikit_learn-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl#md5=337b91f502138ba7fd722803138f6dfd
-  mv scikit_learn-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl \
-     scikit_learn-0.17.1-cp27-none-linux_x86_64.whl
-  pip install scikit_learn-0.17.1-cp27-none-linux_x86_64.whl
-  rm scikit_learn-0.17.1-cp27-none-linux_x86_64.whl
-fi
-
-# pip3 install scikit-learn
-set +e
-local_sklearn_ver=$(python3 -c "import sklearn; print(sklearn.__version__)")
-local_sklearn_ver_flat=$(echo $local_sklearn_ver | sed 's/\.//g' | sed 's/^0*//g')
-if [[ -z $local_sklearn_ver_flat ]]; then
-  local_sklearn_ver_flat=0
-fi
-if (( $local_sklearn_ver_flat < $sklearn_ver_flat )); then
-  set -e
-  wget -q https://pypi.python.org/packages/7e/f1/1cc8a1ae2b4de89bff0981aee904ff05779c49a4c660fa38178f9772d3a7/scikit_learn-0.17.1-cp34-cp34m-manylinux1_x86_64.whl#md5=a722a7372b64ec9f7b49a2532d21372b
-  mv scikit_learn-0.17.1-cp34-cp34m-manylinux1_x86_64.whl \
-     scikit_learn-0.17.1-cp34-cp34m-linux_x86_64.whl
-  pip3 install scikit_learn-0.17.1-cp34-cp34m-linux_x86_64.whl
-  rm scikit_learn-0.17.1-cp34-cp34m-linux_x86_64.whl
-fi
-
-set -e
+pip install scikit-learn==0.18.1
+pip3 install scikit-learn==0.18.1
 
 # pandas required by tf.learn/inflow
-pip install pandas==0.18.1
-pip3 install pandas==0.18.1
+pip install pandas==0.19.2
+pip3 install pandas==0.19.2
 
 # Benchmark tests require the following:
 pip install psutil

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -24,19 +24,19 @@ easy_install3 -U pip
 # Install pip packages from whl files to avoid the time-consuming process of
 # building from source.
 
-pip install wheel
+pip2 install wheel
 pip3 install wheel
 
 # Install six.
-pip install --upgrade six==1.10.0
+pip2 install --upgrade six==1.10.0
 pip3 install --upgrade six==1.10.0
 
 # Install werkzeug.
-pip install --upgrade werkzeug==0.11.10
+pip2 install --upgrade werkzeug==0.11.10
 pip3 install --upgrade werkzeug==0.11.10
 
 # Install protobuf.
-pip install --upgrade protobuf==3.2.0
+pip2 install --upgrade protobuf==3.2.0
 pip3 install --upgrade protobuf==3.2.0
 
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
@@ -45,35 +45,35 @@ rm -rf /usr/lib/python3/dist-packages/six*
 # numpy needs to be installed from source to fix segfaults. See:
 # https://github.com/tensorflow/tensorflow/issues/6968
 # This workaround isn't needed for Ubuntu 16.04 or later.
-pip install --no-binary=:all: --upgrade numpy==1.12.0
+pip2 install --no-binary=:all: --upgrade numpy==1.12.0
 pip3 install --no-binary=:all: --upgrade numpy==1.12.0
 
-pip install scipy==0.18.1
+pip2 install scipy==0.18.1
 pip3 install scipy==0.18.1
 
-pip install scikit-learn==0.18.1
+pip2 install scikit-learn==0.18.1
 pip3 install scikit-learn==0.18.1
 
 # pandas required by tf.learn/inflow
-pip install pandas==0.19.2
+pip2 install pandas==0.19.2
 pip3 install pandas==0.19.2
 
 # Benchmark tests require the following:
-pip install psutil
+pip2 install psutil
 pip3 install psutil
-pip install py-cpuinfo
+pip2 install py-cpuinfo
 pip3 install py-cpuinfo
 
 # pylint tests require the following:
-pip install pylint
+pip2 install pylint
 pip3 install pylint
 
 # pep8 tests require the following:
-pip install pep8
+pip2 install pep8
 pip3 install pep8
 
 # tf.mock require the following for python2:
-pip install mock
+pip2 install mock
 
-pip install portpicker
+pip2 install portpicker
 pip3 install portpicker

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -16,6 +16,11 @@
 
 set -e
 
+# We don't apt-get install so that we can install a newer version of pip. Not
+# needed after we upgrade to Ubuntu 16.04
+easy_install -U pip
+easy_install3 -U pip
+
 # Install pip packages from whl files to avoid the time-consuming process of
 # building from source.
 
@@ -40,8 +45,8 @@ rm -rf /usr/lib/python3/dist-packages/six*
 # numpy needs to be installed from source to fix segfaults. See:
 # https://github.com/tensorflow/tensorflow/issues/6968
 # This workaround isn't needed for Ubuntu 16.04 or later.
-pip install --no-binary=:all: --upgrade numpy
-pip3 install --no-binary=:all: --upgrade numpy
+pip install --no-binary=:all: --upgrade numpy==1.12.0
+pip3 install --no-binary=:all: --upgrade numpy==1.12.0
 
 pip install scipy==0.18.1
 pip3 install scipy==0.18.1

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -31,24 +31,121 @@ pip install --upgrade werkzeug==0.11.10
 pip3 install --upgrade werkzeug==0.11.10
 
 # Install protobuf.
-pip install --upgrade protobuf==3.2.0
-pip3 install --upgrade protobuf==3.2.0
+pip install --upgrade protobuf==3.0.0
+pip3 install --upgrade protobuf==3.0.0
 
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
 rm -rf /usr/lib/python3/dist-packages/six*
 
-pip install --upgrade numpy==1.12.0
-pip3 install --upgrade numpy==1.12.0
+set +e
+# Use pip to install numpy to a modern version, instead of 1.8.2 that comes
+# with apt-get in ubuntu:14.04.
+NUMPY_VERSION="1.11.0"
+numpy_ver_flat=$(echo $NUMPY_VERSION | sed 's/\.//g' | sed 's/^0*//g')
+local_numpy_ver=$(python -c "import numpy; print(numpy.__version__)")
+local_numpy_ver_flat=$(echo $local_numpy_ver | sed 's/\.//g' | sed 's/^0*//g')
+if [[ -z $local_numpy_ver_flat ]]; then
+  local_numpy_ver_flat=0
+fi
+if (( $local_numpy_ver_flat < $numpy_ver_flat )); then
+  set -e
+  wget -q https://pypi.python.org/packages/06/92/3c786303889e6246971ad4c48ac2b4e37a1b1c67c0dc2106dc85cb15c18e/numpy-1.11.0-cp27-cp27mu-manylinux1_x86_64.whl#md5=6ffb66ff78c28c55bfa09a2ceee487df
+  mv numpy-1.11.0-cp27-cp27mu-manylinux1_x86_64.whl \
+     numpy-1.11.0-cp27-none-linux_x86_64.whl
+  pip install numpy-1.11.0-cp27-none-linux_x86_64.whl
+  rm numpy-1.11.0-cp27-none-linux_x86_64.whl
+fi
 
-pip install scipy==0.18.1
-pip3 install scipy==0.18.1
+set +e
+local_numpy_ver=$(python3 -c "import numpy; print(numpy.__version__)")
+local_numpy_ver_flat=$(echo $local_numpy_ver | sed 's/\.//g' | sed 's/^0*//g')
+if [[ -z $local_numpy_ver_flat ]]; then
+  local_numpy_ver_flat=0
+fi
+if (( $local_numpy_ver_flat < $numpy_ver_flat )); then
+  set -e
+  wget -q https://pypi.python.org/packages/ea/ca/5e48a68be496e6f79c3c8d90f7c03ea09bbb154ea4511f5b3d6c825cefe5/numpy-1.11.0-cp34-cp34m-manylinux1_x86_64.whl#md5=08a002aeffa20354aa5045eadb549361
+  mv numpy-1.11.0-cp34-cp34m-manylinux1_x86_64.whl \
+     numpy-1.11.0-cp34-none-linux_x86_64.whl
+  pip3 install numpy-1.11.0-cp34-none-linux_x86_64.whl
+  rm numpy-1.11.0-cp34-none-linux_x86_64.whl
+fi
 
-pip install scikit-learn==0.18.1
-pip3 install scikit-learn==0.18.1
+# Use pip to install scipy to get the latest version, instead of 0.13 through
+# apt-get.
+# pip install scipy==0.15.1
+set +e
+SCIPY_VERSION="0.15.1"
+scipy_ver_flat=$(echo $SCIPY_VERSION | sed 's/\.//g' | sed 's/^0*//g')
+local_scipy_ver=$(python -c "import scipy; print(scipy.__version__)")
+local_scipy_ver_flat=$(echo $local_scipy_ver | sed 's/\.//g' | sed 's/^0*//g')
+if [[ -z $local_scipy_ver_flat ]]; then
+  local_scipy_ver_flat=0
+fi
+if (( $local_scipy_ver_flat < $scipy_ver_flat )); then
+  set -e
+  wget -q https://pypi.python.org/packages/00/0f/060ec52cb74dc8df1a7ef1a524173eb0bcd329110404869b392685cfc5c8/scipy-0.15.1-cp27-cp27mu-manylinux1_x86_64.whl#md5=aaac02e6535742ab02f2075129890714
+  mv scipy-0.15.1-cp27-cp27mu-manylinux1_x86_64.whl \
+     scipy-0.15.1-cp27-none-linux_x86_64.whl
+  pip install scipy-0.15.1-cp27-none-linux_x86_64.whl
+  rm scipy-0.15.1-cp27-none-linux_x86_64.whl
+fi
+
+# pip3 install scipy==0.15.1
+set +e
+local_scipy_ver=$(python3 -c "import scipy; print(scipy.__version__)")
+local_scipy_ver_flat=$(echo $local_scipy_ver | sed 's/\.//g' | sed 's/^0*//g')
+if [[ -z $local_scipy_ver_flat ]]; then
+  local_scipy_ver_flat=0
+fi
+if (( $local_scipy_ver_flat < $scipy_ver_flat )); then
+  set -e
+  wget -q https://pypi.python.org/packages/56/c5/e0d36aaf719aa02ee3da19151045912e240d145586612e53b5eaa706e1db/scipy-0.15.1-cp34-cp34m-manylinux1_x86_64.whl#md5=d5243b0f9d85f4f4cb62514c82af93d4
+  mv scipy-0.15.1-cp34-cp34m-manylinux1_x86_64.whl \
+     scipy-0.15.1-cp34-cp34m-linux_x86_64.whl
+  pip3 install scipy-0.15.1-cp34-cp34m-linux_x86_64.whl
+  rm scipy-0.15.1-cp34-cp34m-linux_x86_64.whl
+fi
+
+# pip install sklearn
+set +e
+SKLEARN_VERSION="0.17.1"
+sklearn_ver_flat=$(echo $SKLEARN_VERSION | sed 's/\.//g' | sed 's/^0*//g')
+local_sklearn_ver=$(python -c "import sklearn; print(sklearn.__version__)")
+local_sklearn_ver_flat=$(echo $local_sklearn_ver | sed 's/\.//g' | sed 's/^0*//g')
+if [[ -z $local_sklearn_ver_flat ]]; then
+  local_sklearn_ver_flat=0
+fi
+if (( $local_sklearn_ver_flat < $sklearn_ver_flat )); then
+  set -e
+  wget -q https://pypi.python.org/packages/bf/80/06e77e5a682c46a3880ec487a5f9d910f5c8d919df9aca58052089687c7e/scikit_learn-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl#md5=337b91f502138ba7fd722803138f6dfd
+  mv scikit_learn-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl \
+     scikit_learn-0.17.1-cp27-none-linux_x86_64.whl
+  pip install scikit_learn-0.17.1-cp27-none-linux_x86_64.whl
+  rm scikit_learn-0.17.1-cp27-none-linux_x86_64.whl
+fi
+
+# pip3 install scikit-learn
+set +e
+local_sklearn_ver=$(python3 -c "import sklearn; print(sklearn.__version__)")
+local_sklearn_ver_flat=$(echo $local_sklearn_ver | sed 's/\.//g' | sed 's/^0*//g')
+if [[ -z $local_sklearn_ver_flat ]]; then
+  local_sklearn_ver_flat=0
+fi
+if (( $local_sklearn_ver_flat < $sklearn_ver_flat )); then
+  set -e
+  wget -q https://pypi.python.org/packages/7e/f1/1cc8a1ae2b4de89bff0981aee904ff05779c49a4c660fa38178f9772d3a7/scikit_learn-0.17.1-cp34-cp34m-manylinux1_x86_64.whl#md5=a722a7372b64ec9f7b49a2532d21372b
+  mv scikit_learn-0.17.1-cp34-cp34m-manylinux1_x86_64.whl \
+     scikit_learn-0.17.1-cp34-cp34m-linux_x86_64.whl
+  pip3 install scikit_learn-0.17.1-cp34-cp34m-linux_x86_64.whl
+  rm scikit_learn-0.17.1-cp34-cp34m-linux_x86_64.whl
+fi
+
+set -e
 
 # pandas required by tf.learn/inflow
-pip install pandas==0.19.2
-pip3 install pandas==0.19.2
+pip install pandas==0.18.1
+pip3 install pandas==0.18.1
 
 # Benchmark tests require the following:
 pip install psutil

--- a/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
@@ -64,7 +64,7 @@ set -e
 pip3.5 install --upgrade six==1.10.0
 
 # Install protobuf.
-pip3.5 install --upgrade protobuf==3.0.0
+pip3.5 install --upgrade protobuf==3.2.0
 
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
 rm -rf /usr/lib/python3/dist-packages/six*

--- a/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
@@ -74,7 +74,7 @@ rm -rf /usr/lib/python3/dist-packages/six*
 # numpy needs to be installed from source to fix segfaults. See:
 # https://github.com/tensorflow/tensorflow/issues/6968
 # This workaround isn't needed for Ubuntu 16.04 or later.
-pip3.5 install --no-binary=:all: --upgrade numpy
+pip3.5 install --no-binary=:all: --upgrade numpy==1.12.0
 
 pip3.5 install scipy==0.18.1
 

--- a/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Install packages required by Python3.5 build
+
+# TODO(cais): Remove this file once we upgrade to ubuntu:16.04 docker images for
+# Python 3.5 builds.
+
+# fkrull/deadsnakes is for Python3.5
+add-apt-repository -y ppa:fkrull/deadsnakes
+apt-get update
+
+set +e
+# Upgrade swig to 3.0.8
+SWIG_VERSION="3.0.8"
+swig_ver_flat=$(echo $SWIG_VERSION | sed 's/\.//g' | sed 's/^0*//g')
+local_swig_ver=$(swig -version | grep -i version | awk '{print $3}')
+local_swig_ver_flat=$(echo $local_swig_ver | sed 's/\.//g' | sed 's/^0*//g')
+if [[ -z $local_swig_ver_flat ]]; then
+  local_swig_ver_flat=0
+fi
+if (( $local_swig_ver_flat < $swig_ver_flat )); then
+  set -e
+  wget -q http://downloads.sourceforge.net/swig/swig-3.0.8.tar.gz
+  tar xzf swig-3.0.8.tar.gz
+  pushd swig-3.0.8
+  apt-get install -y --no-install-recommends libpcre3-dev
+  ./configure
+  make
+  make install
+  rm -f /usr/bin/swig
+  ln -s /usr/local/bin/swig /usr/bin/swig
+  popd
+  rm -rf swig-3.0.8 swig-3.0.8.tar.gz
+fi
+set -e
+# Install Python 3.5 and dev library
+apt-get install -y --no-install-recommends python3.5 libpython3.5-dev
+
+# Install pip3.5
+set +e
+pip35_version=$(pip3.5 --version | grep "python 3.5")
+if [[ -z $pip35_version ]]; then
+  set -e
+  wget -q https://bootstrap.pypa.io/get-pip.py
+  python3.5 get-pip.py
+  rm -f get-pip.py
+fi
+
+set -e
+# Install six.
+pip3.5 install --upgrade six==1.10.0
+
+# Install protobuf.
+pip3.5 install --upgrade protobuf==3.0.0
+
+# Remove obsolete version of six, which can sometimes confuse virtualenv.
+rm -rf /usr/lib/python3/dist-packages/six*
+
+# Install numpy, scipy and scikit-learn required by the builds
+
+# numpy needs to be installed from source to fix segfaults. See:
+# https://github.com/tensorflow/tensorflow/issues/6968
+# This workaround isn't needed for Ubuntu 16.04 or later.
+pip3.5 install --no-binary=:all: --upgrade numpy
+
+set +e
+SCIPY_VERSION="0.17.1"
+scipy_ver_flat=$(echo $SCIPY_VERSION | sed 's/\.//g' | sed 's/^0*//g')
+local_scipy_ver=$(python3.5 -c "import scipy; print(scipy.__version__)")
+local_scipy_ver_flat=$(echo $local_scipy_ver | sed 's/\.//g' | sed 's/^0*//g')
+if [[ -z $local_scipy_ver_flat ]]; then
+  local_scipy_ver_flat=0
+fi
+if (( $local_scipy_ver_flat < $scipy_ver_flat )); then
+  set -e
+  wget -q https://pypi.python.org/packages/91/f3/0052c245d53eb5f0e13b7215811e52af3791a8a7d31771605697c28466a0/scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl#md5=8e77756904c81a6f79ed10e3abf0c544
+  pip3.5 install --upgrade scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl
+  rm -f scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl
+fi
+
+set -e
+pip3.5 install --upgrade scikit-learn
+
+# Install recent-enough version of wheel for Python 3.5 wheel builds
+pip3.5 install wheel==0.29.0
+
+pip3.5 install --upgrade pandas==0.18.1
+
+pip3.5 install portpicker
+
+pip3.5 install werkzeug

--- a/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
@@ -76,28 +76,15 @@ rm -rf /usr/lib/python3/dist-packages/six*
 # This workaround isn't needed for Ubuntu 16.04 or later.
 pip3.5 install --no-binary=:all: --upgrade numpy
 
-set +e
-SCIPY_VERSION="0.17.1"
-scipy_ver_flat=$(echo $SCIPY_VERSION | sed 's/\.//g' | sed 's/^0*//g')
-local_scipy_ver=$(python3.5 -c "import scipy; print(scipy.__version__)")
-local_scipy_ver_flat=$(echo $local_scipy_ver | sed 's/\.//g' | sed 's/^0*//g')
-if [[ -z $local_scipy_ver_flat ]]; then
-  local_scipy_ver_flat=0
-fi
-if (( $local_scipy_ver_flat < $scipy_ver_flat )); then
-  set -e
-  wget -q https://pypi.python.org/packages/91/f3/0052c245d53eb5f0e13b7215811e52af3791a8a7d31771605697c28466a0/scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl#md5=8e77756904c81a6f79ed10e3abf0c544
-  pip3.5 install --upgrade scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl
-  rm -f scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl
-fi
+pip3.5 install scipy==0.18.1
 
-set -e
-pip3.5 install --upgrade scikit-learn
+pip3.5 install scikit-learn==0.18.1
+
+# pandas required by tf.learn/inflow
+pip3 install pandas==0.19.2
 
 # Install recent-enough version of wheel for Python 3.5 wheel builds
 pip3.5 install wheel==0.29.0
-
-pip3.5 install --upgrade pandas==0.18.1
 
 pip3.5 install portpicker
 


### PR DESCRIPTION
Haven't tested this yet. Letting Jenkins do the work.

@caisq fyi. Note that we should keep our Docker Hub images on Ubuntu 16.04 because that fixes the bugs users encounter.

Note for others looking at this change: we're downgrading to Ubuntu 14.04 for official releases so that it links against the older version of glibc and allows for wider compatibility.