### PR TITLE
nn_ops.py docs clarify atrous output dimensions

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -274,7 +274,8 @@ def with_space_to_batch(
       N=3, the valid value is "NDHWC".
 
   Returns:
-    The output Tensor as described above, dimensions will vary based on the op provided.
+    The output Tensor as described above, dimensions will vary based on the op
+    provided.
 
   Raises:
     ValueError: if `padding` is invalid or the arguments are incompatible.
@@ -848,11 +849,14 @@ def atrous_conv2d(value, filters, rate, padding, name=None):
 
   More specifically:
 
-      output[batch, height, width, out_channel] =
-            sum_{dheight, dwidth, in_channel}
-            filters[dheight, dwidth, in_channel, out_channel] * value[batch,
-            height + rate * dheight, width + rate * dwidth, in_channel]
-
+  ```
+  output[batch, height, width, out_channel] =
+      sum_{dheight, dwidth, in_channel} (
+          filters[dheight, dwidth, in_channel, out_channel] * 
+          value[batch, height + rate * dheight, width + rate * dwidth, in_channel]
+      )
+  ```
+  
   Atrous convolution allows us to explicitly control how densely to compute
   feature responses in fully convolutional networks. Used in conjunction with
   bilinear interpolation, it offers an alternative to `conv2d_transpose` in
@@ -940,8 +944,8 @@ def atrous_conv2d(value, filters, rate, padding, name=None):
     A `Tensor` with the same type as `value`.
     Output shape with `'VALID`` padding is:
 
-        [batch, height - 2 * (filter_width - 1),
-        width - 2 * (filter_height -1), out_channels].
+        [batch, height - 2 * (filter_width - 1), 
+         width - 2 * (filter_height - 1), out_channels].
     
     Output shape with `'SAME'` padding is:
 

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -274,7 +274,7 @@ def with_space_to_batch(
       N=3, the valid value is "NDHWC".
 
   Returns:
-    The output Tensor as described above.
+    The output Tensor as described above, dimensions will vary based on the op provided.
 
   Raises:
     ValueError: if `padding` is invalid or the arguments are incompatible.
@@ -848,8 +848,10 @@ def atrous_conv2d(value, filters, rate, padding, name=None):
 
   More specifically:
 
-      output[b, i, j, k] = sum_{di, dj, q} filters[di, dj, q, k] *
-            value[b, i + rate * di, j + rate * dj, q]
+      output[batch, height, width, out_channel] =
+            sum_{dheight, dwidth, in_channel}
+            filters[dheight, dwidth, in_channel, out_channel] * value[batch,
+            height + rate * dheight, width + rate * dwidth, in_channel]
 
   Atrous convolution allows us to explicitly control how densely to compute
   feature responses in fully convolutional networks. Used in conjunction with
@@ -936,6 +938,14 @@ def atrous_conv2d(value, filters, rate, padding, name=None):
 
   Returns:
     A `Tensor` with the same type as `value`.
+    Output shape with `'VALID`` padding is:
+
+        [batch, height - 2 * (filter_width - 1),
+        width - 2 * (filter_height -1), out_channels].
+    
+    Output shape with `'SAME'` padding is:
+
+        [batch, height, width, out_channels].
 
   Raises:
     ValueError: If input/output depth does not match `filters`' shape, or if


### PR DESCRIPTION
Clarifies documentation based on discussion in #4742, but does not solve that original issue.