### PR TITLE
configure: Bugfix

### DIFF
--- a/configure
+++ b/configure
@@ -45,9 +45,10 @@ function bazel_clean_and_fetch() {
     bazel clean --expunge
   fi
   if [ -z "$TF_BAZEL_TARGETS" ]; then
-    TF_BAZEL_TARGETS="//tensorflow/... -//tensorflow/contrib/nccl/... -//tensorflow/examples/android/..."
+    bazel fetch "//tensorflow/... -//tensorflow/contrib/nccl/... -//tensorflow/examples/android/..."
+  else
+    bazel fetch $TF_BAZEL_TARGETS
   fi
-  bazel fetch "$TF_BAZEL_TARGETS"
 }
 
 function sed_hyphen_i() {


### PR DESCRIPTION
commit 429d14d435259899ff0436014187fe35c6cdd1d7 introduced
TF_BAZEL_TARGETS. However, it turns out that if:

`TF_BAZEL_TARGETS="//tensorflow/... -//tensorflow/contrib/nccl/..."`
then
`bazel fetch "$TF_BAZEL_TARGETS"`
works out fine, but
`bazel fetch $TF_BAZEL_TARGETS`
fails with
`"Invalid options syntax: -//tensorflow/contrib/nccl/...`

However, if
`TF_BAZEL_TARGETS="//tensorflow:libtensorflow.so //tensorflow/tools/lib_packages:clicences_generate"`
then
`bazel fetch "$TF_BAZEL_TARGETS"`
fails with:
`  ERROR: Error while parsing 'deps(//tensorflow:libtensorflow.so  //tensorflow/tools/lib_packages:clicences_generate)'`
while
`bazel fetch $TF_BAZEL_TARGETS`
succeeds.

The latter is used in the Windows libtensorflow release scripts.
For now, a quick fix to make the intended usage of TF_BAZEL_TARGETS
work. Revisit the appropriate fix later.