### PR TITLE
Fix broken link in `tensorflow/examples/learn/README.md`

### DIFF
--- a/tensorflow/examples/learn/README.md
+++ b/tensorflow/examples/learn/README.md
@@ -1,7 +1,7 @@
 # TF Learn Examples
 
 Learn is a high-level API for TensorFlow that allows you to create,
-train, and use deep learning models easily. See the [Quickstart tutorial](../../g3doc/tutorials/tflearn/index.md)
+train, and use deep learning models easily. See the [Quickstart tutorial](https://www.tensorflow.org/get_started/tflearn)
 for an introduction to the API.
 
 To run most of these examples, you need to install the `scikit learn` library (`sudo pip install sklearn`).


### PR DESCRIPTION
This fix fixes broken link in `tensorflow/examples/learn/README.md`
```
../../g3doc/tutorials/tflearn/index.md => https://www.tensorflow.org/get_started/tflearn
```

This fix change the g3doc into `www.tensorflow.org` link, as it is outside of docs_src (comment https://github.com/tensorflow/tensorflow/pull/8169#issuecomment-284800453)