### PR TITLE
Fix misalign of code blocks in `tensorflow/tools/ci_build/README.md`

### DIFF
--- a/tensorflow/tools/ci_build/README.md
+++ b/tensorflow/tools/ci_build/README.md
@@ -20,20 +20,20 @@ run continuous integration [ci.tensorflow.org](https://ci.tensorflow.org).
 2. Clone tensorflow repository.
 
    ```bash
-git clone https://github.com/tensorflow/tensorflow.git
-```
+   git clone https://github.com/tensorflow/tensorflow.git
+   ```
 
 3. Go to tensorflow directory
 
    ```bash
-cd tensorflow
-```
+   cd tensorflow
+   ```
 
 4. Build what you want, for example
 
    ```bash
-tensorflow/tools/ci_build/ci_build.sh CPU bazel test //tensorflow/...
-```
+   tensorflow/tools/ci_build/ci_build.sh CPU bazel test //tensorflow/...
+   ```
 
 
 


### PR DESCRIPTION
The code blocks in `tensorflow/tools/ci_build/README.md` are misaligned,
due to the unaligned pair of "```bash" and "```".

The following was the previous screenshot:

<img width="1101" alt="screen shot 2017-03-18 at 6 06 18 am" src="https://cloud.githubusercontent.com/assets/6932348/24072287/5b68a9c4-0ba2-11e7-944e-9d1a3deabdd2.png">


This fix fixes the misalign. The following is the new screenshot:
<img width="972" alt="screen shot 2017-03-18 at 6 16 47 am" src="https://cloud.githubusercontent.com/assets/6932348/24072302/9f630cd2-0ba2-11e7-8810-032273cef17b.png">
