### PR TITLE
Fixed `needs_broadcasting` expression in tf.layers.normalization

### DIFF
--- a/tensorflow/python/layers/normalization.py
+++ b/tensorflow/python/layers/normalization.py
@@ -162,7 +162,7 @@ class BatchNormalization(base._Layer):  # pylint: disable=protected-access
     broadcast_shape[self.axis] = input_shape[self.axis].value
 
     # Determines whether broadcasting is needed.
-    needs_broadcasting = (sorted(reduction_axes) != range(ndim)[:-1])
+    needs_broadcasting = (sorted(reduction_axes) != list(range(ndim))[:-1])
 
     # Determine a boolean value for `training`: could be True, False, or None.
     training_value = utils.constant_value(training)


### PR DESCRIPTION
in Python3, `range()` function doesn't create lists, so `[0, 1, 2] != range(4)[:-1]` always returns `True`.