### PR TITLE
Adds renormalization #7476

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -313,7 +313,7 @@ def _fused_batch_norm(
           inputs, gamma, beta, epsilon=epsilon, data_format=data_format)
       if renorm:
           moving_inv = math_ops.rsqrt(moving_variance + epsilon)
-          r = tf.stop_gradient(tf.clip_by_value(tf.sqrt(variance + epsilon) * moving_inv, 1/r_max, r_max))
+          r = tf.stop_gradient(tf.clip_by_value(tf.sqrt(variance + epsilon) * moving_inv, 1./r_max, r_max))
           d = tf.stop_gradient(tf.clip_by_value((mean - moving_mean) * moving_inv, -d_max, d_max))
           outputs = outputs * r + d
       return outputs, mean, variance

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -185,12 +185,11 @@ def _fused_batch_norm(
       not used. When the next layer is linear (also e.g. `nn.relu`), this can be
       disabled since the scaling can be done by the next layer.
     epsilon: Small float added to variance to avoid dividing by zero.
-    renorm: Boolean value to set whether the
-    use stop Gradient on gamma and beta parameters as described based here 
-    https://arxiv.org/pdf/1702.03275.pdf will be used or not
-    r_max: scalar tensor or float sets the clipping bound on the r value
+    renorm: If True, apply stop gradient on gamma and beta parameters as described
+    here Batch Renormalization: https://arxiv.org/pdf/1702.03275.pdf
+    r_max: scalar tensor or float, sets the clipping bounds on the r value
     (used in place of gamma in batch renormalization)
-    d_max: scalar tensor or float value sets the clipping bound on the d value
+    d_max: scalar tensor or float, sets the clipping bounds on the d value
     (used in place of beta in batch renormalization)
     activation_fn: Activation function, default set to None to skip it and
       maintain a linear activation.


### PR DESCRIPTION
Adds an additional parameter called renorm to add a stop gradient on gamma, beta parameters during the training phase. This has been discussed here https://github.com/tensorflow/tensorflow/issues/7476