### PR TITLE
Fix several minor issues with C++ custom ops (`adding_an_op.md`) documentation

### DIFF
--- a/tensorflow/docs_src/extend/adding_an_op.md
+++ b/tensorflow/docs_src/extend/adding_an_op.md
@@ -229,7 +229,7 @@ do the following to run it from Python :
 
 ```python
 import tensorflow as tf
-zero_out_module = tf.load_op_library('zero_out.so')
+zero_out_module = tf.load_op_library('./zero_out.so')
 with tf.Session(''):
   zero_out_module.zero_out([[1, 2], [3, 4]]).eval()
 
@@ -243,14 +243,13 @@ named `ZeroOut` in the C++ files, the python function will be called `zero_out`.
 
 To make the op available as a regular function `import`-able from a Python
 module, it maybe useful to have the `load_op_library` call in a Python source
-file as follows (see [zero_out_op_1.py](https://www.tensorflow.org/code/tensorflow/examples/adding_an_op/zero_out_op_1.py))
-:
+file as follows:
 
 ```python
 import tensorflow as tf
 
-_zero_out_module = tf.load_op_library('zero_out_op_kernel_1.so')
-zero_out = _zero_out_module.zero_out
+zero_out_module = tf.load_op_library('./zero_out.so')
+zero_out = zero_out_module.zero_out
 ```
 
 ## Verify that the op works
@@ -264,7 +263,7 @@ import tensorflow as tf
 
 class ZeroOutTest(tf.test.TestCase):
   def testZeroOut(self):
-    zero_out_module = tf.load_op_library('zero_out.so')
+    zero_out_module = tf.load_op_library('./zero_out.so')
     with self.test_session():
       result = zero_out_module.zero_out([5, 4, 3, 2, 1])
       self.assertAllEqual(result.eval(), [5, 0, 0, 0, 0])


### PR DESCRIPTION
This fix tries to address several issues related to C++ custom ops (`adding_an_op.md`) documentation:
1. The `tf.load_op_library('zero_out.so')` should use full path or relative path (`./`)
   This issue has been raised in #4727 as well.
2. The mentioning of `zero_out_op_1.py` and `tf.load_op_library('zero_out_op_kernel_1.so')`
   is really misleading. While `zero_out_op_1.py` is located in  `tensorflow/examples/adding_an_op/`,
   the documentation (`adding_an_op.md`) does not  really use `zero_out_op_1.py`.
   It is better to use the `zero_out.cc` that is presented in the doc instead to avoid confusion.

This fix changes `tf.load_op_library('zero_out.so')` to `tf.load_op_library('./zero_out.so')`
and updates a few places so that following the documentation could have the expected result.

This fix fixes #4727.