### PR TITLE
Add header only build rules for XLA external plugins

### DIFF
--- a/tensorflow/compiler/jit/BUILD
+++ b/tensorflow/compiler/jit/BUILD
@@ -18,7 +18,16 @@ package(
     default_visibility = [":internal"],
 )
 
+load("//tensorflow:tensorflow.bzl", "cc_header_only_library")
 load("//tensorflow:tensorflow.bzl", "tf_kernel_library")
+
+cc_header_only_library(
+    name = "xla_jit_headers_lib",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":jit",
+    ],
+)
 
 # Target that bundles up the XLA CPU and GPU JIT devices.
 cc_library(

--- a/tensorflow/compiler/xla/BUILD
+++ b/tensorflow/compiler/xla/BUILD
@@ -16,6 +16,7 @@ package_group(
     ],
 )
 
+load("//tensorflow:tensorflow.bzl", "cc_header_only_library")
 load("//tensorflow/compiler/xla:xla.bzl", "xla_proto_library")
 
 # Filegroup used to collect source files for dependency checking.
@@ -40,6 +41,20 @@ xla_proto_library(
     deps = [
         ":xla_data_proto",
         "//tensorflow/compiler/xla/service:session_proto",
+    ],
+)
+
+cc_header_only_library(
+    name = "xla_headers_lib",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorflow/core:framework_headers_lib",
+        "//tensorflow/core:stream_executor_headers_lib",
+        "//tensorflow/compiler/xla:xla_proto",
+        "//tensorflow/compiler/xla:xla_data_proto",
+        "//tensorflow/compiler/xla/client:client_library",
+        "//tensorflow/compiler/xla/legacy_flags:layout_util_flags",
+        "//tensorflow/compiler/xla/service:hlo",
     ],
 )
 

--- a/tensorflow/tf_exported_symbols.lds
+++ b/tensorflow/tf_exported_symbols.lds
@@ -1,3 +1,9 @@
 *tensorflow*
 *perftools*gputools*
 *tf_*
+*xla*
+*protobuf*Arena*AddListNode*
+*protobuf*Arena*AllocateAligned*
+*protobuf*internal*RepeatedPtrFieldBase*
+*protobuf*internal*fixed_address_empty_string*
+*protobuf*internal*LogMessage*

--- a/tensorflow/tf_version_script.lds
+++ b/tensorflow/tf_version_script.lds
@@ -2,6 +2,12 @@ tensorflow {
   global:
     *tensorflow*;
     *perftools*gputools*;
+    *xla*;
+    *protobuf*Arena*AddListNode*;
+    *protobuf*Arena*AllocateAligned*;
+    *protobuf*internal*RepeatedPtrFieldBase*;
+    *protobuf*internal*fixed_address_empty_string*;
+    *protobuf*internal*LogMessage*;
   local:
     *;
 };


### PR DESCRIPTION
This change includes the exporting of XLA symbols in the main python plugin.

This allows external shared-object plugins to be built against the XLA source header files
and to be loaded into a running process.

Note:  I have only exposed some protobuf symbols.  Exposing *protobuf* causes tensorboard to fail to load. 
