### PR TITLE
Only run test that requires int64 support when the driver supports int64

### DIFF
--- a/tensorflow/compiler/tests/nary_ops_test.py
+++ b/tensorflow/compiler/tests/nary_ops_test.py
@@ -116,12 +116,13 @@ class NAryOpsTest(XLATestCase):
                     np.array([1, 1], dtype=np.int32)],
                    expected=np.array([[], []], dtype=np.float32))
 
-    self._testNAry(lambda x: array_ops.strided_slice(*x),
-                   [np.array([[], [], []], dtype=np.float32),
-                    np.array([1, 0], dtype=np.int64),
-                    np.array([3, 0], dtype=np.int64),
-                    np.array([1, 1], dtype=np.int64)],
-                   expected=np.array([[], []], dtype=np.float32))
+    if (np.int64 in self.int_types):
+      self._testNAry(lambda x: array_ops.strided_slice(*x),
+                     [np.array([[], [], []], dtype=np.float32),
+                      np.array([1, 0], dtype=np.int64),
+                      np.array([3, 0], dtype=np.int64),
+                      np.array([1, 1], dtype=np.int64)],
+                     expected=np.array([[], []], dtype=np.float32))
 
     self._testNAry(lambda x: array_ops.strided_slice(*x),
                    [np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]],


### PR DESCRIPTION
Making a test that requires int64 support conditional on support from int64 in the device under test.
