### PR TITLE
Adding mechanism for XLA device plugins to be loaded into the python unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 node_modules
 /.bazelrc
 /bazel-*
+/tensorflow/compiler/tests/plugin_config.py
+/tensorflow/compiler/tests/plugin/BUILD
 /third_party/py/numpy/numpy_include
 /tools/bazel.rc
 /tools/python_bin_path.sh

--- a/tensorflow/compiler/tests/build_defs.bzl
+++ b/tensorflow/compiler/tests/build_defs.bzl
@@ -3,10 +3,10 @@
 load("@local_config_cuda//cuda:build_defs.bzl", "cuda_is_configured")
 
 def all_backends():
+  b = ["cpu", "plugin"]
   if cuda_is_configured():
-    return ["cpu", "gpu"]
-  else:
-    return ["cpu"]
+    b += ["gpu"]
+  return b
 
 def tf_xla_py_test(name, srcs=[], deps=[], tags=[], data=[], main=None,
                    disabled_backends=None, **kwargs):
@@ -39,6 +39,12 @@ def tf_xla_py_test(name, srcs=[], deps=[], tags=[], data=[], main=None,
     disabled_backends = []
 
   enabled_backends = [b for b in all_backends() if b not in disabled_backends]
+
+  load_plugin = False
+  if "xla_test" in native.existing_rules():
+    if ":plugin_config.py" in native.existing_rules()["xla_test"]["srcs"]:
+      load_plugin = True
+
   test_names = []
   for backend in enabled_backends:
     test_name = "{}_{}".format(name, backend)
@@ -53,6 +59,12 @@ def tf_xla_py_test(name, srcs=[], deps=[], tags=[], data=[], main=None,
       backend_args += ["--test_device=XLA_GPU",
                        "--types=DT_FLOAT,DT_DOUBLE,DT_INT32,DT_INT64,DT_BOOL"]
       backend_tags += ["requires-gpu-sm35"]
+    elif backend == "plugin":
+      if load_plugin:
+        backend_args += ["--load_plugin=true"]
+        backend_deps += ["//tensorflow/compiler/tests/plugin:deps"]
+      else:
+        continue
     else:
       fail("Unknown backend {}".format(backend))
 

--- a/tensorflow/compiler/tests/plugin/BUILD.tpl
+++ b/tensorflow/compiler/tests/plugin/BUILD.tpl
@@ -1,0 +1,17 @@
+licenses(["notice"])  # Apache 2.0
+
+#
+# In order to include a loadable XLA plugin in the unit test
+# runfiles, this file should be copied to 'BUILD' and have the
+# data attribute updated to include one or more targets that
+# describe the binary and its associated data files.
+#
+# See also //tensorflow/compiler/tests/plugin_config.tpl
+#
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "deps",
+    data = ["//...."],
+)

--- a/tensorflow/compiler/tests/plugin_config.tpl
+++ b/tensorflow/compiler/tests/plugin_config.tpl
@@ -1,0 +1,14 @@
+# Configuration for a plugin
+#
+# Copy this file to plugin_config.py, and insert plugin specific
+# information.  The unit test framework will then include a backend
+# which tests the device and types named below.
+#
+# The loader value should name a python module that is used to load
+# the device.
+#
+# See //tensorflow/compiler/tests/plugin/BUILD.tpl
+
+device = "XLA_MY_DEVICE"
+types = "DT_FLOAT,DT_INT32"
+loader = "tensorflow.xla.plugin.loader.module"


### PR DESCRIPTION
By copying and configuring 2 files, the unit test framework will include a plugin when running.

1) tensorflow/compiler/tests/plugin_config.tpl -> tensorflow/compiler/tests/plugin_config.py

This file should contain the registered name of the device, the types that it supports, and the name of a python module that loads the plugin.

2) tensorflow/compiler/tests/plugin/BUILD.tpl -> tensorflow/compiler/tests/plugin/BUILD

This should contain a rule called 'deps' that contains attributes for ensuring that the plugin and its associated files are included in the runfiles of the unit tests. A 'data' attribute is probably most appropriate.