### PR TITLE
Windows Bazel Build: Cut dependency on broken targets

### DIFF
--- a/tensorflow/python/debug/BUILD
+++ b/tensorflow/python/debug/BUILD
@@ -15,6 +15,7 @@ exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_test")
+load("//tensorflow:tensorflow.bzl", "if_not_windows")
 
 py_library(
     name = "debug_py",
@@ -33,11 +34,12 @@ py_library(
 py_library(
     name = "debug_pip",
     deps = [
-        ":debug_examples",
         ":debug_py",
         ":offline_analyzer",
         ":session_debug_testlib",
-    ],
+    ] + if_not_windows([
+        ":debug_examples",
+    ]),
 )
 
 py_library(


### PR DESCRIPTION
TensorFlow build with Bazel 0.4.5 is currently broken:
http://ci.bazel.io/job/TensorFlow/BAZEL_VERSION=latest,PLATFORM_NAME=windows-x86_64/735/console

In e8aefd216930667ff0b278d24cf411b216a9c100, a dependency:
```
//tensorflow/tools/pip_package:build_pip_package
//tensorflow/tools/pip_package:simple_console_for_windows
//tensorflow/python/debug:debug_pip
//tensorflow/python/debug:debug_examples
//tensorflow/python/debug:debug_mnist
//tensorflow/examples/tutorials/mnist:input_data
//tensorflow/contrib/learn/python/learn/datasets:datasets
//tensorflow/contrib/framework:framework_py
//tensorflow/contrib/framework:python/ops/_variable_ops.so
```
was introduced.

Cut this dependency by excluding :debug_examples on Windows

@gunan 