### PR TITLE
Use str(Label(...)) in tensorflow.bzl for use as a submodule

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -27,79 +27,79 @@ load(
 
 # List of proto files for android builds
 def tf_android_core_proto_sources(core_proto_sources_relative):
-  return ["//tensorflow/core:" + p
+  return [str(Label("//tensorflow/core:" + p))
           for p in core_proto_sources_relative]
 
 # Returns the list of pb.h and proto.h headers that are generated for
 # tf_android_core_proto_sources().
 def tf_android_core_proto_headers(core_proto_sources_relative):
-  return (["//tensorflow/core/" + p.replace(".proto", ".pb.h")
+  return ([str(Label("//tensorflow/core/" + p.replace(".proto", ".pb.h")))
           for p in core_proto_sources_relative] +
-         ["//tensorflow/core/" + p.replace(".proto", ".proto.h")
+         [str(Label("//tensorflow/core/" + p.replace(".proto", ".proto.h")))
           for p in core_proto_sources_relative])
 
 def if_android_x86(a):
   return select({
-      "//tensorflow:android_x86": a,
-      "//tensorflow:android_x86_64": a,
+      str(Label("//tensorflow:android_x86")): a,
+      str(Label("//tensorflow:android_x86_64")): a,
       "//conditions:default": [],
   })
 
 
 def if_android_arm(a):
   return select({
-      "//tensorflow:android_arm": a,
+      str(Label("//tensorflow:android_arm")): a,
       "//conditions:default": [],
   })
 
 def if_android_arm64(a):
   return select({
-      "//tensorflow:android_arm64": a,
+      str(Label("//tensorflow:android_arm64")): a,
       "//conditions:default": [],
   })
 
 def if_not_android(a):
   return select({
-      "//tensorflow:android": [],
+      str(Label("//tensorflow:android")): [],
       "//conditions:default": a,
   })
 
 def if_android(a):
   return select({
-      "//tensorflow:android": a,
+      str(Label("//tensorflow:android")): a,
       "//conditions:default": [],
   })
 
 def if_ios(a):
   return select({
-      "//tensorflow:ios": a,
+      str(Label("//tensorflow:ios")): a,
       "//conditions:default": [],
   })
 
 def if_mobile(a):
   return select({
-      "//tensorflow:android": a,
-      "//tensorflow:ios": a,
+      str(Label("//tensorflow:android")): a,
+      str(Label("//tensorflow:ios")): a,
       "//conditions:default": [],
   })
 
 def if_not_mobile(a):
   return select({
-      "//tensorflow:android": [],
-      "//tensorflow:ios": [],
+      str(Label("//tensorflow:android")): [],
+      str(Label("//tensorflow:ios")): [],
       "//conditions:default": a,
   })
 
 def if_not_windows(a):
   return select({
-      "//tensorflow:windows": [],
+      str(Label("//tensorflow:windows")): [],
       "//conditions:default": a,
   })
 
 def if_x86(a):
   return select({
-      "//tensorflow:linux_x86_64": a,
-      "//tensorflow:windows": a,
+      str(Label("//tensorflow:linux_x86_64")): a,
+      str(Label("//tensorflow:windows")): a,
       "//conditions:default": [],
   })
 
@@ -114,13 +114,13 @@ def tf_copts():
           if_android_arm(["-mfpu=neon"]) +
           if_x86(["-msse3"]) +
           select({
-              "//tensorflow:android": [
+              str(Label("//tensorflow:android")): [
                   "-std=c++11",
                   "-DTF_LEAN_BINARY",
                   "-O2",
               ],
-              "//tensorflow:darwin": [],
-              "//tensorflow:windows": [
+              str(Label("//tensorflow:darwin")): [],
+              str(Label("//tensorflow:windows")): [
                 "/DLANG_CXX11",
                 "/D__VERSION__=\\\"MSVC\\\"",
                 "/DPLATFORM_WINDOWS",
@@ -128,7 +128,7 @@ def tf_copts():
                 "/DEIGEN_HAS_C99_MATH",
                 "/DTENSORFLOW_USE_EIGEN_THREADPOOL",
               ],
-              "//tensorflow:ios": ["-std=c++11"],
+              str(Label("//tensorflow:ios")): ["-std=c++11"],
               "//conditions:default": ["-pthread"]}))
 
 def tf_opts_nortti_if_android():
@@ -150,13 +150,13 @@ def tf_gen_op_libs(op_lib_names, deps=None):
     native.cc_library(name=n + "_op_lib",
                       copts=tf_copts(),
                       srcs=["ops/" + n + ".cc"],
-                      deps=deps + ["//tensorflow/core:framework"],
+                      deps=deps + [str(Label("//tensorflow/core:framework"))],
                       visibility=["//visibility:public"],
                       alwayslink=1,
                       linkstatic=1,)
 
 def tf_gen_op_wrapper_cc(name, out_ops_file, pkg="",
-                         op_gen="//tensorflow/cc:cc_op_gen_main",
+                         op_gen=str(Label("//tensorflow/cc:cc_op_gen_main")),
                          deps=None,
                          override_file=None,
                          include_internal_ops=0):
@@ -221,11 +221,11 @@ def tf_gen_op_wrappers_cc(name,
                           other_hdrs=[],
                           pkg="",
                           deps=[
-                              "//tensorflow/cc:ops",
-                              "//tensorflow/cc:scope",
-                              "//tensorflow/cc:const_op",
+                              str(Label("//tensorflow/cc:ops")),
+                              str(Label("//tensorflow/cc:scope")),
+                              str(Label("//tensorflow/cc:const_op")),
                           ],
-                          op_gen="//tensorflow/cc:cc_op_gen_main",
+                          op_gen=str(Label("//tensorflow/cc:cc_op_gen_main")),
                           override_file=None,
                           include_internal_ops=0,
                           visibility=None):
@@ -246,12 +246,12 @@ def tf_gen_op_wrappers_cc(name,
                     srcs=subsrcs,
                     hdrs=subhdrs,
                     deps=deps + if_not_android([
-                        "//tensorflow/core:core_cpu",
-                        "//tensorflow/core:framework",
-                        "//tensorflow/core:lib",
-                        "//tensorflow/core:protos_all_cc",
+                        str(Label("//tensorflow/core:core_cpu")),
+                        str(Label("//tensorflow/core:framework")),
+                        str(Label("//tensorflow/core:lib")),
+                        str(Label("//tensorflow/core:protos_all_cc")),
                     ]) + if_android([
-                        "//tensorflow/core:android_tensorflow_lib",
+                        str(Label("//tensorflow/core:android_tensorflow_lib")),
                     ]),
                     copts=tf_copts(),
                     alwayslink=1,
@@ -260,16 +260,16 @@ def tf_gen_op_wrappers_cc(name,
                     srcs=internalsrcs,
                     hdrs=internalhdrs,
                     deps=deps + if_not_android([
-                        "//tensorflow/core:core_cpu",
-                        "//tensorflow/core:framework",
-                        "//tensorflow/core:lib",
-                        "//tensorflow/core:protos_all_cc",
+                        str(Label("//tensorflow/core:core_cpu")),
+                        str(Label("//tensorflow/core:framework")),
+                        str(Label("//tensorflow/core:lib")),
+                        str(Label("//tensorflow/core:protos_all_cc")),
                     ]) + if_android([
-                        "//tensorflow/core:android_tensorflow_lib",
+                        str(Label("//tensorflow/core:android_tensorflow_lib")),
                     ]),
                     copts=tf_copts(),
                     alwayslink=1,
-                    visibility=["//tensorflow:internal"])
+                    visibility=[str(Label("//tensorflow:internal"))])
 
 # Invoke this rule in .../tensorflow/python to build the wrapper library.
 def tf_gen_op_wrapper_py(name, out=None, hidden=None, visibility=None, deps=[],
@@ -278,15 +278,15 @@ def tf_gen_op_wrapper_py(name, out=None, hidden=None, visibility=None, deps=[],
   # Construct a cc_binary containing the specified ops.
   tool_name = "gen_" + name + "_py_wrappers_cc"
   if not deps:
-    deps = ["//tensorflow/core:" + name + "_op_lib"]
+    deps = [str(Label("//tensorflow/core:" + name + "_op_lib"))]
   native.cc_binary(
       name = tool_name,
       linkopts = ["-lm"],
       copts = tf_copts(),
       linkstatic = 1,   # Faster to link this one-time-use binary dynamically
-      deps = (["//tensorflow/core:framework",
-               "//tensorflow/python:python_op_gen_main"] + deps),
-      visibility = ["//tensorflow:internal"],
+      deps = ([str(Label("//tensorflow/core:framework")),
+               str(Label("//tensorflow/python:python_op_gen_main"))] + deps),
+      visibility = [str(Label("//tensorflow:internal"))],
   )
 
   # Invoke the previous cc_binary to generate a python file.
@@ -329,7 +329,7 @@ def tf_gen_op_wrapper_py(name, out=None, hidden=None, visibility=None, deps=[],
                     srcs_version="PY2AND3",
                     visibility=visibility,
                     deps=[
-                        "//tensorflow/python:framework_for_generated_wrappers_v2",
+                        str(Label("//tensorflow/python:framework_for_generated_wrappers_v2")),
                     ],)
 
 # Define a bazel macro that creates cc_test for tensorflow.
@@ -369,7 +369,7 @@ def tf_cuda_cc_test(name, srcs=[], deps=[], tags=[], data=[], size="medium",
   tf_cc_test(name=name,
              srcs=srcs,
              suffix="_gpu",
-             deps=deps + if_cuda(["//tensorflow/core:gpu_runtime"]),
+             deps=deps + if_cuda([str(Label("//tensorflow/core:gpu_runtime"))]),
              linkstatic=if_cuda(1, 0),
              tags=tags + tf_cuda_tests_tags(),
              data=data,
@@ -449,8 +449,8 @@ def tf_gpu_kernel_library(srcs, copts=[], cuda_copts=[], deps=[], hdrs=[],
       hdrs = hdrs,
       copts = copts,
       deps = deps + if_cuda([
-          "//tensorflow/core:cuda",
-          "//tensorflow/core:gpu_lib",
+          str(Label("//tensorflow/core:cuda")),
+          str(Label("//tensorflow/core:gpu_lib")),
       ]),
       alwayslink=1,
       **kwargs)
@@ -480,7 +480,7 @@ def tf_cuda_library(deps=None, cuda_deps=None, copts=None, **kwargs):
 
   native.cc_library(
       deps = deps + if_cuda(cuda_deps + [
-          "//tensorflow/core:cuda",
+          str(Label("//tensorflow/core:cuda")),
           "@local_config_cuda//cuda:cuda_headers"
       ]),
       copts = copts + if_cuda(["-DGOOGLE_CUDA=1"]) + if_mkl(["-DINTEL_MKL=1"]),
@@ -526,7 +526,7 @@ def tf_kernel_library(name, prefix=None, srcs=None, gpu_srcs=None, hdrs=None,
                               exclude = ["*test*", "*.cu.cc"])
     hdrs = hdrs + native.glob([prefix + "*.h"], exclude = ["*test*", "*.cu.h"])
 
-  cuda_deps = ["//tensorflow/core:gpu_lib"]
+  cuda_deps = [str(Label("//tensorflow/core:gpu_lib"))]
   if gpu_srcs:
     for gpu_src in gpu_srcs:
       if gpu_src.endswith(".cc") and not gpu_src.endswith(".cu.cc"):
@@ -681,8 +681,8 @@ def cc_header_only_library(name, deps=[], **kwargs):
 def tf_custom_op_library_additional_deps():
   return [
       "@protobuf//:protobuf_headers",
-      "//third_party/eigen3",
-      "//tensorflow/core:framework_headers_lib",
+      str(Label("//third_party/eigen3")),
+      str(Label("//tensorflow/core:framework_headers_lib")),
   ]
 
 # Traverse the dependency graph along the "deps" attribute of the
@@ -739,7 +739,7 @@ check_deps = rule(
 # implementations of custom ops and kernels.
 def tf_custom_op_library(name, srcs=[], gpu_srcs=[], deps=[]):
   cuda_deps = [
-      "//tensorflow/core:stream_executor_headers_lib",
+      str(Label("//tensorflow/core:stream_executor_headers_lib")),
       "@local_config_cuda//cuda:cudart_static",
   ]
   deps = deps + tf_custom_op_library_additional_deps()
@@ -754,8 +754,8 @@ def tf_custom_op_library(name, srcs=[], gpu_srcs=[], deps=[]):
 
   check_deps(name=name+"_check_deps",
              deps=deps + if_cuda(cuda_deps),
-             disallowed_deps=["//tensorflow/core:framework",
-                              "//tensorflow/core:lib"])
+             disallowed_deps=[str(Label("//tensorflow/core:framework")),
+                              str(Label("//tensorflow/core:lib"))])
 
   native.cc_binary(name=name,
                    srcs=srcs,
@@ -767,7 +767,7 @@ def tf_custom_op_library(name, srcs=[], gpu_srcs=[], deps=[]):
                        "//conditions:default": [
                            "-lm",
                        ],
-                       "//tensorflow:darwin": [],
+                       str(Label("//tensorflow:darwin")): [],
                    }),
   )
 
@@ -794,22 +794,22 @@ def tf_py_wrap_cc(name, srcs, swig_includes=[], deps=[], copts=[], **kwargs):
   extra_linkopts = select({
       "@local_config_cuda//cuda:darwin": [
           "-Wl,-exported_symbols_list",
-          "//tensorflow:tf_exported_symbols.lds"
+          str(Label("//tensorflow:tf_exported_symbols.lds"))
       ],
-      "//tensorflow:windows": [
+      str(Label("//tensorflow:windows")): [
       ],
       "//conditions:default": [
           "-Wl,--version-script",
-          "//tensorflow:tf_version_script.lds"
+          str(Label("//tensorflow:tf_version_script.lds"))
       ]})
   extra_deps += select({
       "@local_config_cuda//cuda:darwin": [
-        "//tensorflow:tf_exported_symbols.lds"
+        str(Label("//tensorflow:tf_exported_symbols.lds"))
       ],
-      "//tensorflow:windows": [
+      str(Label("//tensorflow:windows")): [
       ],
       "//conditions:default": [
-        "//tensorflow:tf_version_script.lds"
+        str(Label("//tensorflow:tf_version_script.lds"))
       ]
   })
 
@@ -834,7 +834,7 @@ def tf_py_wrap_cc(name, srcs, swig_includes=[], deps=[], copts=[], **kwargs):
                     srcs=[":" + name + ".py"],
                     srcs_version="PY2AND3",
                     data=select({
-                      "//tensorflow:windows": [":" + cc_library_pyd_name],
+                      str(Label("//tensorflow:windows")): [":" + cc_library_pyd_name],
                       "//conditions:default": [":" + cc_library_name],
                     }))
 
@@ -842,7 +842,7 @@ def py_test(deps=[], **kwargs):
   native.py_test(
       deps=select({
           "//conditions:default" : deps,
-          "//tensorflow:no_tensorflow_py_deps" : []
+          str(Label("//tensorflow:no_tensorflow_py_deps")) : []
       }),
       **kwargs)
 
@@ -858,15 +858,15 @@ def tf_py_test(name, srcs, size="medium", data=[], main=None, args=[],
       main=main,
       args=args,
       tags=tags,
-      visibility=["//tensorflow:internal"],
+      visibility=[str(Label("//tensorflow:internal"))],
       shard_count=shard_count,
       data=data,
       deps=select({
           "//conditions:default" : [
-            "//tensorflow/python:extra_py_tests_deps",
-            "//tensorflow/python:gradient_checker",
+            str(Label("//tensorflow/python:extra_py_tests_deps")),
+            str(Label("//tensorflow/python:gradient_checker")),
           ] + additional_deps,
-          "//tensorflow:no_tensorflow_py_deps" : []
+          str(Label("//tensorflow:no_tensorflow_py_deps")) : []
       }),
       flaky=flaky,
       srcs_version="PY2AND3")
@@ -944,11 +944,11 @@ def tf_generate_proto_text_sources(name, srcs_relative_dir, srcs):
   out_srcs = [p.replace(".proto", ".pb_text.cc") for p in srcs]
   native.genrule(
         name = name,
-        srcs = srcs + ["//tensorflow/tools/proto_text:placeholder.txt"],
+        srcs = srcs + [str(Label("//tensorflow/tools/proto_text:placeholder.txt"))],
         outs = out_hdrs + out_srcs,
         cmd = "$(location //tensorflow/tools/proto_text:gen_proto_text_functions) " +
               "$(@D) " + srcs_relative_dir + " $(SRCS)",
-        tools = ["//tensorflow/tools/proto_text:gen_proto_text_functions"],
+        tools = [str(Label("//tensorflow/tools/proto_text:gen_proto_text_functions"))],
     )
   return struct(hdrs=out_hdrs, srcs=out_srcs)
 
@@ -962,14 +962,14 @@ def tf_version_info_genrule():
   native.genrule(
       name = "version_info_gen",
       srcs = [
-          "//tensorflow/tools/git:gen/spec.json",
-          "//tensorflow/tools/git:gen/head",
-          "//tensorflow/tools/git:gen/branch_ref",
+          str(Label("//tensorflow/tools/git:gen/spec.json")),
+          str(Label("//tensorflow/tools/git:gen/head")),
+          str(Label("//tensorflow/tools/git:gen/branch_ref")),
       ],
       outs = ["util/version_info.cc"],
       cmd = "$(location //tensorflow/tools/git:gen_git_source.py) --generate $(SRCS) \"$@\"",
       local = 1,
-      tools = ["//tensorflow/tools/git:gen_git_source.py"],
+      tools = [str(Label("//tensorflow/tools/git:gen_git_source.py"))],
   )
 
 def cc_library_with_android_deps(deps, android_deps=[],


### PR DESCRIPTION
tf_kernel_library and friends do not currently work if called from a
repo that contains tensorflow as submodule.  Justine recommended this
as the right fix.

Fixes #8439.