### PR TITLE
Fixed Minor Bug in tensorflow/python/platform/googletest.py

### DIFF
--- a/tensorflow/python/platform/googletest.py
+++ b/tensorflow/python/platform/googletest.py
@@ -99,6 +99,7 @@ def main(argv=None):  # pylint: disable=function-redefined
 
 def GetTempDir():
   """Return a temporary directory for tests to use."""
+  global _googletest_temp_dir
   if not _googletest_temp_dir:
     first_frame = inspect.stack()[-1][0]
     temp_dir = os.path.join(
@@ -115,7 +116,6 @@ def GetTempDir():
         logging.error('Error removing %s: %s', dirname, e)
 
     atexit.register(delete_temp_dir)
-    global _googletest_temp_dir
     _googletest_temp_dir = temp_dir
 
   return _googletest_temp_dir


### PR DESCRIPTION
There was a bug in the function `GetTempDir` of the module, in line 118.
I found this bug when I built tensorflow from source on my system and tried to test the install and it gave the following error while simply importing tensorflow in python shell. 
```
SyntaxError: name '_googletest_temp_dir' is used prior to global declaration
```
The variable was already reference at line number : 103 so thats why the error was showing up.
The global declaration was moved to staring of the function to solve the issue.