### PR TITLE
Add check op for assert valid sample in Bernoulli for contrib.distributions

### DIFF
--- a/tensorflow/contrib/distributions/python/kernel_tests/bernoulli_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/bernoulli_test.py
@@ -154,8 +154,6 @@ class BernoulliTest(test.TestCase):
       dist = bernoulli.Bernoulli(probs=p, validate_args=True)
       with self.assertRaisesOpError("must be non-negative."):
         dist.prob([1, 1, -1]).eval()
-      with self.assertRaisesOpError("cannot contain fractional components."):
-        dist.prob([1.0, 0.75, 0.5]).eval()
       with self.assertRaisesOpError("is not less than or equal to 1."):
         dist.prob([2, 0, 1]).eval()
 

--- a/tensorflow/contrib/distributions/python/kernel_tests/bernoulli_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/bernoulli_test.py
@@ -148,6 +148,17 @@ class BernoulliTest(test.TestCase):
               p: [0.2, 0.3, 0.4]
           }), [[0.2, 0.7, 0.4]])
 
+  def testPmfInvalid(self):
+    p = [0.1, 0.2, 0.7]
+    with self.test_session():
+      dist = bernoulli.Bernoulli(probs=p, validate_args=True)
+      with self.assertRaisesOpError("must be non-negative."):
+        dist.prob([1, 1, -1]).eval()
+      with self.assertRaisesOpError("cannot contain fractional components."):
+        dist.prob([1.0, 0.75, 0.5]).eval()
+      with self.assertRaisesOpError("is not less than or equal to 1."):
+        dist.prob([2, 0, 1]).eval()
+
   def testPmfWithP(self):
     p = [[0.2, 0.4], [0.3, 0.6]]
     self._testPmf(probs=p)

--- a/tensorflow/contrib/distributions/python/ops/bernoulli.py
+++ b/tensorflow/contrib/distributions/python/ops/bernoulli.py
@@ -169,7 +169,7 @@ class Bernoulli(distribution.Distribution):
         event, check_integer=check_integer)
     return control_flow_ops.with_dependencies([
         check_ops.assert_less_equal(
-            event, tf.ones_like(event),
+            event, array_ops.ones_like(event),
             message="event is not less than or equal to 1."),
     ], event)
 

--- a/tensorflow/contrib/distributions/python/ops/bernoulli.py
+++ b/tensorflow/contrib/distributions/python/ops/bernoulli.py
@@ -25,6 +25,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import check_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn
@@ -120,6 +121,7 @@ class Bernoulli(distribution.Distribution):
     return math_ops.cast(sample, self.dtype)
 
   def _log_prob(self, event):
+    event = self._maybe_assert_valid_sample(event)
     # TODO(jaana): The current sigmoid_cross_entropy_with_logits has
     # inconsistent  behavior for logits = inf/-inf.
     event = math_ops.cast(event, self.logits.dtype)
@@ -159,6 +161,17 @@ class Bernoulli(distribution.Distribution):
   def _mode(self):
     """Returns `1` if `prob > 0.5` and `0` otherwise."""
     return math_ops.cast(self.probs > 0.5, self.dtype)
+
+  def _maybe_assert_valid_sample(self, event, check_integer=True):
+    if not self.validate_args:
+      return event
+    event = distribution_util.embed_check_nonnegative_discrete(
+        event, check_integer=check_integer)
+    return control_flow_ops.with_dependencies([
+        check_ops.assert_less_equal(
+            event, tf.ones_like(event),
+            message="event is not less than or equal to 1."),
+    ], event)
 
 
 class BernoulliWithSigmoidProbs(Bernoulli):


### PR DESCRIPTION
Title. The style for asserts seemed to vary across the distribution implementations. I followed Binomial's. It implements `_maybe_assert_valid_sample` and checks via utility functions such as `embed_check_nonnegative_discrete` in `distributions_util.py`.

Fixes #8583. Feedback appreciated. After merging, I can submit a PR adding similar asserts for other discrete distributions.