### PR TITLE
Support pandas Series and DataFrame as input for tf.constant

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -355,6 +355,10 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False):
       nparray = values.astype(dtype.as_numpy_dtype)
     else:
       nparray = values
+  elif callable(getattr(values, "__array__", None)):
+    # If a class has the __array__ method, then it is possible to convert
+    # to numpy array.
+    nparray = np.asarray(values, dtype=dtype)
   else:
     if values is None:
       raise ValueError("None values not supported.")

--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -663,6 +663,32 @@ class TensorUtilTest(test.TestCase):
     self.assertFalse(tensor_util.ShapeEquals(t, [1, 4]))
     self.assertFalse(tensor_util.ShapeEquals(t, [4]))
 
+  def testMockArray(self):
+    class MockArray(object):
+      def __init__(self, array):
+        self.array = array
+
+      def __array__(self, dtype=None):
+        return np.asarray(self.array, dtype)
+
+    ma = MockArray(np.array([10, 20, 30]))
+    t = tensor_util.make_tensor_proto(ma)
+    if sys.byteorder == "big":  
+      self.assertProtoEquals("""  
+        dtype: DT_INT64  
+        tensor_shape { dim { size: 3 } }  
+        tensor_content: "\000\000\000\000\000\000\000\\n\000\000\000\000\000\000\000\024\000\000\000\000\000\000\000\036"  
+        """, t)  
+    else:  
+      self.assertProtoEquals("""
+        dtype: DT_INT64
+        tensor_shape { dim { size: 3 } }
+        tensor_content: "\\n\000\000\000\000\000\000\000\024\000\000\000\000\000\000\000\036\000\000\000\000\000\000\000"
+        """, t)
+    a = tensor_util.MakeNdarray(t)
+    self.assertEquals(np.int64, a.dtype)
+    self.assertAllClose(np.array([10, 20, 30], dtype=np.int64), a)
+
   def testSeries(self):
     df = pd.Series([10, 20, 30])
     t = tensor_util.make_tensor_proto(df)

--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -19,11 +19,11 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import pandas as pd
 import sys
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.ops import array_ops
@@ -671,61 +671,13 @@ class TensorUtilTest(test.TestCase):
       def __array__(self, dtype=None):
         return np.asarray(self.array, dtype)
 
-    ma = MockArray(np.array([10, 20, 30]))
-    t = tensor_util.make_tensor_proto(ma)
-    if sys.byteorder == "big":  
-      self.assertProtoEquals("""  
-        dtype: DT_INT64  
-        tensor_shape { dim { size: 3 } }  
-        tensor_content: "\000\000\000\000\000\000\000\\n\000\000\000\000\000\000\000\024\000\000\000\000\000\000\000\036"  
-        """, t)  
-    else:  
-      self.assertProtoEquals("""
-        dtype: DT_INT64
-        tensor_shape { dim { size: 3 } }
-        tensor_content: "\\n\000\000\000\000\000\000\000\024\000\000\000\000\000\000\000\036\000\000\000\000\000\000\000"
-        """, t)
-    a = tensor_util.MakeNdarray(t)
-    self.assertEquals(np.int64, a.dtype)
-    self.assertAllClose(np.array([10, 20, 30], dtype=np.int64), a)
+    with self.test_session() as sess:
+      ma = MockArray(np.array([10, 20, 30]))
+      t = ops.convert_to_tensor(ma)
+      a = sess.run(t)
+      self.assertEquals(np.int64, a.dtype)
+      self.assertAllClose(np.array([10, 20, 30], dtype=np.int64), a)
 
-  def testSeries(self):
-    df = pd.Series([10, 20, 30])
-    t = tensor_util.make_tensor_proto(df)
-    if sys.byteorder == "big":  
-      self.assertProtoEquals("""  
-        dtype: DT_INT64  
-        tensor_shape { dim { size: 3 } }  
-        tensor_content: "\000\000\000\000\000\000\000\\n\000\000\000\000\000\000\000\024\000\000\000\000\000\000\000\036"  
-        """, t)  
-    else:  
-      self.assertProtoEquals("""
-        dtype: DT_INT64
-        tensor_shape { dim { size: 3 } }
-        tensor_content: "\\n\000\000\000\000\000\000\000\024\000\000\000\000\000\000\000\036\000\000\000\000\000\000\000"
-        """, t)
-    a = tensor_util.MakeNdarray(t)
-    self.assertEquals(np.int64, a.dtype)
-    self.assertAllClose(np.array([10, 20, 30], dtype=np.int64), a)
-
-  def testDataFrame(self):
-    df = pd.DataFrame({'A': [10], 'B': [20], 'C': [30]})
-    t = tensor_util.make_tensor_proto(df)
-    if sys.byteorder == "big":  
-      self.assertProtoEquals("""  
-        dtype: DT_INT64  
-        tensor_shape { dim { size: 1 } dim { size: 3 } }  
-        tensor_content: "\000\000\000\000\000\000\000\\n\000\000\000\000\000\000\000\024\000\000\000\000\000\000\000\036"  
-        """, t)  
-    else: 
-      self.assertProtoEquals("""
-        dtype: DT_INT64
-        tensor_shape { dim { size: 1 } dim { size: 3 } }
-        tensor_content: "\\n\000\000\000\000\000\000\000\024\000\000\000\000\000\000\000\036\000\000\000\000\000\000\000"
-        """, t)
-    a = tensor_util.MakeNdarray(t)
-    self.assertEquals(np.int64, a.dtype)
-    self.assertAllClose(np.array([[10, 20, 30]], dtype=np.int64), a)
 
 class ConstantValueTest(test.TestCase):
 


### PR DESCRIPTION
This fix tries to address the proposal raised in #2318 to support pandas Series and DataFrame as input for tf.constant.

As was explained in #2318, Series and DataFrame has `__array__` method, which is the standard API used for indicating that an object is coercible into NumPy arrays.

This fix adds the support for objects with `__array__` to be served as input for tf.constant.

This fix fixes #2318.