### PR TITLE
Add the sched_getaffinity support for Android.

### DIFF
--- a/tensorflow/core/platform/posix/port.cc
+++ b/tensorflow/core/platform/posix/port.cc
@@ -21,7 +21,7 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/types.h"
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__)
 #include <sched.h>
 #endif
 #include <stdio.h>
@@ -48,7 +48,7 @@ string Hostname() {
 }
 
 int NumSchedulableCPUs() {
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__) 
   cpu_set_t cpuset;
   if (sched_getaffinity(0, sizeof(cpu_set_t), &cpuset) == 0) {
     return CPU_COUNT(&cpuset);


### PR DESCRIPTION
Now the NumSchedulableCPUs() always chooses to  return 4 cores for Android, other than try the Bionic supported sched_getaffinity to get the actual available cores. Here I remove the "!defined(__ANDROID__)" macro and just keep the " __linux__" macro to work for both pure-linux and android-linux platform. 
The reason why we can drop the "__ANDROID__" marco is that the GNU toolchain would always has the system-specific predefined macros "__linux__"  setting to 1. 
 