### PR TITLE
Fix two compiler warnings

### DIFF
--- a/tensorflow/core/grappler/optimizers/graph_optimizer.h
+++ b/tensorflow/core/grappler/optimizers/graph_optimizer.h
@@ -23,7 +23,7 @@ namespace tensorflow {
 namespace grappler {
 
 class Cluster;
-class GrapplerItem;
+struct GrapplerItem;
 
 // An abstract interface for an algorithm for generating a candidate
 // optimization of a GrapplerItem for running on a cluster.

--- a/tensorflow/core/platform/cpu_info.cc
+++ b/tensorflow/core/platform/cpu_info.cc
@@ -67,7 +67,8 @@ int GetXCR0EAX() {
 #endif
 
 // Structure for basic CPUID info
-struct CPUIDInfo {
+class CPUIDInfo {
+public:
   CPUIDInfo()
       : have_adx_(0),
         have_aes_(0),


### PR DESCRIPTION
warning C4099: 'tensorflow::port::`anonymous-namespace'::CPUIDInfo': type name first seen using 'class' now seen using 'struct'