### PR TITLE
Fix typo at description of tf.nn.conv1d

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2040,7 +2040,7 @@ def conv1d(value, filters, stride, padding,
     [1, filter_width, in_channels, out_channels].
   The result is then reshaped back to
     [batch, out_width, out_channels]
-  (where out_width is a function of the stride and padding as in conv2d) and
+  \(where out_width is a function of the stride and padding as in conv2d\) and
   returned to the caller.
 
   Args:


### PR DESCRIPTION
As you see [description of tf.nn.conv1d](https://www.tensorflow.org/versions/master/api_docs/python/tf/nn/conv1d), `batch, out_width, out_channels` is linked, because markdown recognizes it as link. [batch, out_width, out_channels]\(...\)

So, add escape character to parentheses!