### PR TITLE
Added support for case callables to return namedtuples

### DIFF
--- a/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
+++ b/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
@@ -2171,12 +2171,15 @@ class ControlFlowTest(test.TestCase):
 
   def testCase(self):
     with self.test_session():
+      nt = collections.namedtuple('named_tuple', ['a', 'b'])
       x = constant_op.constant(1)
       y = constant_op.constant(2)
       z = constant_op.constant(3)
       f1 = lambda: constant_op.constant(17)
       f2 = lambda: constant_op.constant(23)
       f3 = lambda: constant_op.constant(-1)
+      f4 = lambda: nt(constant_op.constant(1), constant_op.constant(2))
+      f5 = lambda: nt(constant_op.constant(3), constant_op.constant(4))
 
       r1 = control_flow_ops.case(
           {
@@ -2221,6 +2224,11 @@ class ControlFlowTest(test.TestCase):
           default=lambda: constant_op.constant(2))
 
       self.assertAllEqual(r6.eval(), 0)
+
+      # Case operation with a Python callable that returns a namedtuple.
+      r7 = control_flow_ops.case([(x < y, f4)], default=f5)
+      self.assertAllEqual(r7[0].eval(), 1)
+      self.assertAllEqual(r7[1].eval(), 2)
 
   def testCaseSideEffects(self):
     with self.test_session() as sess:

--- a/tensorflow/python/ops/control_flow_ops.py
+++ b/tensorflow/python/ops/control_flow_ops.py
@@ -2952,7 +2952,12 @@ def case(pred_fn_pairs, default, exclusive=False, name="case"):
 
       if isinstance(dummy_value, collections.Sequence):
         dummy_type = type(dummy_value)
-        empty = lambda: dummy_type(_correct_empty(v) for v in dummy_value)
+        def _create_dummy_instance():
+          if hasattr(dummy_type, '_make'):
+            return dummy_type._make(_correct_empty(v) for v in dummy_value)
+          else:
+            return dummy_type(_correct_empty(v) for v in dummy_value)
+        empty = _create_dummy_instance
       else:
         empty = lambda: _correct_empty(dummy_value)
 


### PR DESCRIPTION
This commit adds support for` namedtuple` to be used with `tf.case`. 

`tf.cond` already supports `namedtuple`:

```
nt = collections.namedtuple('Point', ['x', 'y'])
f1 = lambda: nt(tf.Variable(1), tf.Variable(2))
f2 = lambda: nt(tf.Variable(3), tf.Variable(4))
c  = tf.cond(tf.less(1,0), f1, f2)
print c

Output
[<tf.Tensor 'cond/Merge:0' shape=() dtype=int32>, <tf.Tensor 'cond/Merge_1:0' shape=() dtype=int32>]
```

However, if 
```
c =  tf.case([(tf.less(1,0), f1)], default=f2)
print c

Output
TypeError: __new__() takes exactly 3 arguments (2 given)
```

After this commit, the output for above is
`[<tf.Tensor 'case/If_1/Merge:0' shape=() dtype=int32>, <tf.Tensor 'case/If_1/Merge_1:0' shape=() dtype=int32>]
`

Using `namedtuple` with `tf.case` should have the same effect as using a regular tuple.

```
nt = collections.namedtuple('Point', ['x', 'y'])

f1 = lambda: nt(tf.Variable(1), tf.Variable(2))
f2 = lambda: nt(tf.Variable(3), tf.Variable(4))

f3 = lambda: (tf.Variable(1), tf.Variable(2))
f4 = lambda: (tf.Variable(3), tf.Variable(4))

c1  = tf.case([(tf.less(1,0), f1)], default=f2)
c2  = tf.case([(tf.less(1,0), f3)], default=f4)

with tf.Session() as sess:
    sess.run(tf.global_variables_initializer())

    print "With namedtuple: ",
    v = sess.run(c1)
    print v

    print "With tuple: ",
    v2 = sess.run(c2)
    print v2

Output
With namedtuple:  [3, 4]
With tuple:  [3, 4]
```

