### PR TITLE
Fallback to legacy camera API for problematic devices in android demo app

### DIFF
--- a/tensorflow/examples/android/src/org/tensorflow/demo/CameraConnectionFragment.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/CameraConnectionFragment.java
@@ -353,58 +353,44 @@ public class CameraConnectionFragment extends Fragment {
     super.onPause();
   }
 
+  public void setCamera(String cameraId) {
+    this.cameraId = cameraId;
+  }
+
   /**
    * Sets up member variables related to camera.
-   *
-   * @param width  The width of available size for camera preview
-   * @param height The height of available size for camera preview
    */
-  private void setUpCameraOutputs(final int width, final int height) {
+  private void setUpCameraOutputs() {
     final Activity activity = getActivity();
     final CameraManager manager = (CameraManager) activity.getSystemService(Context.CAMERA_SERVICE);
     try {
-      for (final String cameraId : manager.getCameraIdList()) {
-        final CameraCharacteristics characteristics = manager.getCameraCharacteristics(cameraId);
+      final CameraCharacteristics characteristics = manager.getCameraCharacteristics(cameraId);
 
-        // We don't use a front facing camera in this sample.
-        final Integer facing = characteristics.get(CameraCharacteristics.LENS_FACING);
-        if (facing != null && facing == CameraCharacteristics.LENS_FACING_FRONT) {
-          continue;
-        }
+      final StreamConfigurationMap map =
+          characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
 
-        final StreamConfigurationMap map =
-            characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+      // For still image captures, we use the largest available size.
+      final Size largest =
+          Collections.max(
+              Arrays.asList(map.getOutputSizes(ImageFormat.YUV_420_888)),
+              new CompareSizesByArea());
 
-        if (map == null) {
-          continue;
-        }
+      sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
 
-        // For still image captures, we use the largest available size.
-        final Size largest =
-            Collections.max(
-                Arrays.asList(map.getOutputSizes(ImageFormat.YUV_420_888)),
-                new CompareSizesByArea());
+      // Danger, W.R.! Attempting to use too large a preview size could  exceed the camera
+      // bus' bandwidth limitation, resulting in gorgeous previews but the storage of
+      // garbage capture data.
+      previewSize =
+          chooseOptimalSize(map.getOutputSizes(SurfaceTexture.class),
+              inputSize.getWidth(),
+              inputSize.getHeight());
 
-        sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
-
-        // Danger, W.R.! Attempting to use too large a preview size could  exceed the camera
-        // bus' bandwidth limitation, resulting in gorgeous previews but the storage of
-        // garbage capture data.
-        previewSize =
-            chooseOptimalSize(
-                map.getOutputSizes(SurfaceTexture.class),
-                inputSize.getWidth(),
-                inputSize.getHeight());
-
-        // We fit the aspect ratio of TextureView to the size of preview we picked.
-        final int orientation = getResources().getConfiguration().orientation;
-        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-          textureView.setAspectRatio(previewSize.getWidth(), previewSize.getHeight());
-        } else {
-          textureView.setAspectRatio(previewSize.getHeight(), previewSize.getWidth());
-        }
-
-        CameraConnectionFragment.this.cameraId = cameraId;
+      // We fit the aspect ratio of TextureView to the size of preview we picked.
+      final int orientation = getResources().getConfiguration().orientation;
+      if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        textureView.setAspectRatio(previewSize.getWidth(), previewSize.getHeight());
+      } else {
+        textureView.setAspectRatio(previewSize.getHeight(), previewSize.getWidth());
       }
     } catch (final CameraAccessException e) {
       LOGGER.e(e, "Exception!");
@@ -425,7 +411,7 @@ public class CameraConnectionFragment extends Fragment {
    * Opens the camera specified by {@link CameraConnectionFragment#cameraId}.
    */
   private void openCamera(final int width, final int height) {
-    setUpCameraOutputs(width, height);
+    setUpCameraOutputs();
     configureTransform(width, height);
     final Activity activity = getActivity();
     final CameraManager manager = (CameraManager) activity.getSystemService(Context.CAMERA_SERVICE);

--- a/tensorflow/examples/android/src/org/tensorflow/demo/LegacyCameraConnectionFragment.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/LegacyCameraConnectionFragment.java
@@ -1,0 +1,205 @@
+package org.tensorflow.demo;
+
+/*
+ * Copyright 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.app.Fragment;
+import android.graphics.SurfaceTexture;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.util.SparseIntArray;
+import android.view.LayoutInflater;
+import android.view.Surface;
+import android.view.TextureView;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.io.IOException;
+
+import android.hardware.Camera;
+import android.hardware.Camera.CameraInfo;
+
+import org.tensorflow.demo.env.Logger;
+
+public class LegacyCameraConnectionFragment extends Fragment {
+
+  private Camera mCamera;
+  private static final Logger LOGGER = new Logger();
+  private Camera.PreviewCallback imageListener;
+
+  /**
+   * The layout identifier to inflate for this Fragment.
+   */
+  private int layout;
+
+  public LegacyCameraConnectionFragment(
+      final Camera.PreviewCallback imageListener,
+      final int layout) {
+    this.imageListener = imageListener;
+    this.layout = layout;
+  }
+
+  /**
+   * Conversion from screen rotation to JPEG orientation.
+   */
+  private static final SparseIntArray ORIENTATIONS = new SparseIntArray();
+
+  static {
+    ORIENTATIONS.append(Surface.ROTATION_0, 90);
+    ORIENTATIONS.append(Surface.ROTATION_90, 0);
+    ORIENTATIONS.append(Surface.ROTATION_180, 270);
+    ORIENTATIONS.append(Surface.ROTATION_270, 180);
+  }
+
+  /**
+   * {@link android.view.TextureView.SurfaceTextureListener} handles several lifecycle events on a
+   * {@link TextureView}.
+   */
+  private final TextureView.SurfaceTextureListener surfaceTextureListener =
+      new TextureView.SurfaceTextureListener() {
+        @Override
+        public void onSurfaceTextureAvailable(
+            final SurfaceTexture texture, final int width, final int height) {
+
+          int index = getCameraId();
+          mCamera = Camera.open(index);
+
+          try {
+            Camera.Parameters parameters = mCamera.getParameters();
+            parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+
+            mCamera.setDisplayOrientation(90);
+            mCamera.setParameters(parameters);
+            mCamera.setPreviewTexture(texture);
+          } catch (IOException exception) {
+            mCamera.release();
+          }
+
+          mCamera.setPreviewCallbackWithBuffer(imageListener);
+          Camera.Size s = mCamera.getParameters().getPreviewSize();
+          int bufferSize = s.height * s.width * 3 / 2;
+          mCamera.addCallbackBuffer(new byte[bufferSize]);
+
+          textureView.setAspectRatio(s.height, s.width);
+
+          mCamera.startPreview();
+        }
+
+        @Override
+        public void onSurfaceTextureSizeChanged(
+            final SurfaceTexture texture, final int width, final int height) {
+        }
+
+        @Override
+        public boolean onSurfaceTextureDestroyed(final SurfaceTexture texture) {
+          return true;
+        }
+
+        @Override
+        public void onSurfaceTextureUpdated(final SurfaceTexture texture) {
+        }
+      };
+
+  /**
+   * An {@link AutoFitTextureView} for camera preview.
+   */
+  private AutoFitTextureView textureView;
+
+  /**
+   * An additional thread for running tasks that shouldn't block the UI.
+   */
+  private HandlerThread backgroundThread;
+
+  @Override
+  public View onCreateView(
+      final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
+    return inflater.inflate(layout, container, false);
+  }
+
+  @Override
+  public void onViewCreated(final View view, final Bundle savedInstanceState) {
+    textureView = (AutoFitTextureView) view.findViewById(R.id.texture);
+  }
+
+  @Override
+  public void onActivityCreated(final Bundle savedInstanceState) {
+    super.onActivityCreated(savedInstanceState);
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    startBackgroundThread();
+    // When the screen is turned off and turned back on, the SurfaceTexture is already
+    // available, and "onSurfaceTextureAvailable" will not be called. In that case, we can open
+    // a camera and start preview from here (otherwise, we wait until the surface is ready in
+    // the SurfaceTextureListener).
+
+    if (textureView.isAvailable()) {
+      mCamera.startPreview();
+    } else {
+      textureView.setSurfaceTextureListener(surfaceTextureListener);
+    }
+  }
+
+  @Override
+  public void onPause() {
+    stopCamera();
+    stopBackgroundThread();
+    super.onPause();
+  }
+
+  /**
+   * Starts a background thread and its {@link Handler}.
+   */
+  private void startBackgroundThread() {
+    backgroundThread = new HandlerThread("CameraBackground");
+    backgroundThread.start();
+  }
+
+  /**
+   * Stops the background thread and its {@link Handler}.
+   */
+  private void stopBackgroundThread() {
+    backgroundThread.quitSafely();
+    try {
+      backgroundThread.join();
+      backgroundThread = null;
+    } catch (final InterruptedException e) {
+      LOGGER.e(e, "Exception!");
+    }
+  }
+
+  protected void stopCamera() {
+    if (mCamera != null) {
+      mCamera.stopPreview();
+      mCamera.setPreviewCallback(null);
+      mCamera.release();
+      mCamera = null;
+    }
+  }
+
+  private int getCameraId() {
+    CameraInfo ci = new CameraInfo();
+    for (int i = 0; i < Camera.getNumberOfCameras(); i++) {
+      Camera.getCameraInfo(i, ci);
+      if (ci.facing == CameraInfo.CAMERA_FACING_BACK)
+        return i;
+    }
+    return -1; // No camera found
+  }
+}


### PR DESCRIPTION
Fix #8550 
The camera 2 API is problematic in some devices.  Similar problem is also dicussed in #7464 .  One of the problem is shown here on a LG G4c device:
![screenshot_2017-03-27-00-47-09](https://cloud.githubusercontent.com/assets/8319689/24341265/23380fd6-12eb-11e7-91f5-f450eded4a42.png)

A space inversion is taken (left-right mirrored), and color turns green (which is reported also here https://code.google.com/p/android/issues/detail?id=81984).  It effectively makes all 3 demo app not working or crashes.

This PR attempts to take legacy camera API as fallback, in case `INFO_SUPPORTED_HARDWARE_LEVEL` is lower than FULL.  It is mostly a copy of the implementation [here](https://github.com/hamidb/tensorflow/blob/api20/tensorflow/examples/android/src/org/tensorflow/demo/CameraConnectionFragment.java).  Here is the working demo if fallback is taken:
![screenshot_2017-03-27-00-48-19](https://cloud.githubusercontent.com/assets/8319689/24341255/06df2fd6-12eb-11e7-81bf-bdcc10fade4d.png)

I would like to mention that I have no previous experience with the API, so the implementation may not be optimal.  Also please check if the demo still works on Android6+ devices because I only have 2 android5 for testing.  Please also notice that the "TF Detect" demo does not show red box on preview image, for which I cannot find out the cause.

![screenshot_2017-03-27-00-35-07](https://cloud.githubusercontent.com/assets/8319689/24341234/dd392d44-12ea-11e7-8a53-3fdd9de67eff.png)
