### PR TITLE
Fix broken link in Android example README

### DIFF
--- a/tensorflow/examples/android/README.md
+++ b/tensorflow/examples/android/README.md
@@ -83,7 +83,7 @@ instead.
 Bazel is the primary build system for TensorFlow. To build with Bazel,
 it and the Android NDK and SDK must be installed on your system.
 
-1. Get the recommended Bazel version listed in [os_setup.html](https://www.tensorflow.org/versions/master/get_started/os_setup.html#source)
+1. Install the latest version of Bazel as per the instructions [on the Bazel website](https://bazel.build/versions/master/docs/install.html).
 2. The Android NDK is required to build the native (C/C++) TensorFlow code.
         The current recommended version is 12b, which may be found
         [here](https://developer.android.com/ndk/downloads/older_releases.html#ndk-12b-downloads).


### PR DESCRIPTION
Issue  #8742 identified that the link to os_setup.html does not work for the master version.

os_setup.html is still available for old versions ( https://www.tensorflow.org/versions/r0.11/get_started/os_setup#prepare_environment_for_linux ), but it makes more sense to link directly to the Bazel installation instructions.