### PR TITLE
Fix code block indent in TensorFlow Linear Model Tutorial

### DIFF
--- a/tensorflow/docs_src/tutorials/wide.md
+++ b/tensorflow/docs_src/tutorials/wide.md
@@ -27,7 +27,7 @@ https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/w
        # Mac OS X
        $ sudo easy_install pip
        $ sudo easy_install --upgrade six
-      ```
+       ```
 
     2. Use `pip` to install pandas:
 


### PR DESCRIPTION
This should fix the code blocks rendering. Right now they look like this:

![selection_230](https://cloud.githubusercontent.com/assets/699961/24356320/28145b56-1302-11e7-94c0-15647bd4fa53.png)
