### PR TITLE
Fix to code in Getting Started Guide

### DIFF
--- a/tensorflow/docs_src/get_started/monitors.md
+++ b/tensorflow/docs_src/get_started/monitors.md
@@ -282,18 +282,15 @@ validation_metrics = {
     "accuracy":
         tf.contrib.learn.MetricSpec(
             metric_fn=tf.contrib.metrics.streaming_accuracy,
-            prediction_key=tf.contrib.learn.prediction_key.PredictionKey.
-            CLASSES),
+            prediction_key=tf.contrib.learn.PredictionKey.CLASSES),
     "precision":
         tf.contrib.learn.MetricSpec(
             metric_fn=tf.contrib.metrics.streaming_precision,
-            prediction_key=tf.contrib.learn.prediction_key.PredictionKey.
-            CLASSES),
+            prediction_key=tf.contrib.learn.PredictionKey.CLASSES),
     "recall":
         tf.contrib.learn.MetricSpec(
             metric_fn=tf.contrib.metrics.streaming_recall,
-            prediction_key=tf.contrib.learn.prediction_key.PredictionKey.
-            CLASSES)
+            prediction_key=tf.contrib.learn.PredictionKey.CLASSES)
 }
 ```
 


### PR DESCRIPTION
Fix no attribute prediction_key error. This compliments [PR:8735](https://github.com/tensorflow/tensorflow/pull/8735).

```
tf.contrib.learn.prediction_key.PredictionKey.CLASSES),
AttributeError: module 'tensorflow.contrib.learn' has no attribute 'prediction_key'
```