### PR TITLE
fixes bazel/skylark handling of grep terminal colors when checking cudnn version

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -267,7 +267,7 @@ def _find_cuda_define(repository_ctx, cudnn_header_dir, define):
   cudnn_h_path = repository_ctx.path("%s/cudnn.h" % cudnn_header_dir)
   if not cudnn_h_path.exists:
     auto_configure_fail("Cannot find cudnn.h at %s" % str(cudnn_h_path))
-  result = repository_ctx.execute(["grep", "-E", define, str(cudnn_h_path)])
+  result = repository_ctx.execute(["grep", "--color=never", "-E", define, str(cudnn_h_path)])
   if result.stderr:
     auto_configure_fail("Error reading %s: %s" %
                         (result.stderr, str(cudnn_h_path)))


### PR DESCRIPTION
Fixes #8702
The issue was that on some systems, the environment or terminal are set up to use `grep` in a way that produces color-related formatting. They cannot be circumvented easily by command line manipulations. These "silent" color-formatting characters then go on to cause difficult-to-diagnose issues with the version checking logic in bazel/skylark.

The updated skylark logic would address this issue.