### PR TITLE
[tensorboard] make projector plugin request data path relative

### DIFF
--- a/tensorflow/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorflow/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -254,7 +254,7 @@ allows the user to toggle between various dashboards.
           new TF.Dashboard.TfGraphDashboard(backend, debuggerDataEnabled),
           new TF.Dashboard.TfDistributionDashboard(backend),
           new TF.Dashboard.TfHistogramDashboard(backend),
-          new TF.Dashboard.VzProjectorDashboard('/data/plugin/projector'),
+          new TF.Dashboard.VzProjectorDashboard('data/plugin/projector'),
           new TF.Dashboard.TfTextDashboard(backend),
         ];
       },

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -20108,7 +20108,7 @@ var TF;
           new TF.Dashboard.TfGraphDashboard(backend, debuggerDataEnabled),
           new TF.Dashboard.TfDistributionDashboard(backend),
           new TF.Dashboard.TfHistogramDashboard(backend),
-          new TF.Dashboard.VzProjectorDashboard('/data/plugin/projector'),
+          new TF.Dashboard.VzProjectorDashboard('data/plugin/projector'),
           new TF.Dashboard.TfTextDashboard(backend),
         ];
       },


### PR DESCRIPTION
this PR solves #8342 
As in version 1.1rc0, the changes are made:
>TensorBoard uses a relative data directory, for easier embedding.


but the request of project plugin data in Embeddings panel, e.g. `/data/plugin/projector/runs` still requests in a absolute path.  the code 
```html
<vz-projector-dashboard
            id="projector"
            route-prefix="/data/plugin/projector">
```
with the leading slash leads the  absolutely path request.
this PR remove the leading slash.


UPDATED:
new version of code is:
```new TF.Dashboard.VzProjectorDashboard('/data/plugin/projector'),```
still has a leading slash.

