### PR TITLE
Queue item passed directly instead of via event

### DIFF
--- a/tensorflow/python/summary/writer/event_file_writer.py
+++ b/tensorflow/python/summary/writer/event_file_writer.py
@@ -136,9 +136,9 @@ class _EventLoggerThread(threading.Thread):
 
   def run(self):
     while True:
-      event = self._queue.get()
       try:
-        self._ev_writer.WriteEvent(event)
+        self._ev_writer.WriteEvent(self._queue.get())
+        
         # Flush the event writer every so often.
         now = time.time()
         if now > self._next_event_flush_time:

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -267,7 +267,7 @@ def _find_cuda_define(repository_ctx, cudnn_header_dir, define):
   cudnn_h_path = repository_ctx.path("%s/cudnn.h" % cudnn_header_dir)
   if not cudnn_h_path.exists:
     auto_configure_fail("Cannot find cudnn.h at %s" % str(cudnn_h_path))
-  result = repository_ctx.execute(["grep", "-E", define, str(cudnn_h_path)])
+  result = repository_ctx.execute(["grep", "--color=never", "-E", define, str(cudnn_h_path)])
   if result.stderr:
     auto_configure_fail("Error reading %s: %s" %
                         (result.stderr, str(cudnn_h_path)))


### PR DESCRIPTION
The event object created here was never being cleared till python termination when the worker was killed. This was causing memory leak as described in issue #8265  Resolving this by bypassing the object creation.