### PR TITLE
Fixed python 3 compatibility issue for DeepDream example notebook

### DIFF
--- a/tensorflow/examples/tutorials/deepdream/deepdream.ipynb
+++ b/tensorflow/examples/tutorials/deepdream/deepdream.ipynb
@@ -278,7 +278,7 @@
     "            tensor = n.attr['value'].tensor\n",
     "            size = len(tensor.tensor_content)\n",
     "            if size > max_const_size:\n",
-    "                tensor.tensor_content = bytes(\"<stripped %d bytes>\"%size)\n",
+    "                tensor.tensor_content = tf.compat.as_bytes(\"<stripped %d bytes>\"%size)\n",
     "    return strip_def\n",
     "  \n",
     "def rename_nodes(graph_def, rename_func):\n",


### PR DESCRIPTION
* Changed byte cast to compat.as_bytes() to ensure python 3.x compatibility