### PR TITLE
Add CMake v3.8 as working version

### DIFF
--- a/tensorflow/contrib/cmake/README.md
+++ b/tensorflow/contrib/cmake/README.md
@@ -45,7 +45,7 @@ bindings.
 
 ### Pre-requisites
 
-* CMake version 3.5 up to 3.6 or 3.8
+* CMake version 3.5 or later.
 
 * [Git](http://git-scm.com)
 

--- a/tensorflow/contrib/cmake/README.md
+++ b/tensorflow/contrib/cmake/README.md
@@ -45,7 +45,7 @@ bindings.
 
 ### Pre-requisites
 
-* CMake version 3.5 up to 3.6
+* CMake version 3.5 up to 3.6 or 3.8
 
 * [Git](http://git-scm.com)
 


### PR DESCRIPTION
While CMake 3.7 was causing build errors with GPU ON. I was able to compile Tensorflow (master) with CMake 3.8 with GPU enabled perfectly fine