### PR TITLE
Windows: Fix cuda_configure.bzl for Bazel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .ipynb_checkpoints
 node_modules
 /.bazelrc
+/.tf_configure.bazelrc
 /bazel-*
 /third_party/py/numpy/numpy_include
 /tools/bazel.rc

--- a/configure
+++ b/configure
@@ -46,6 +46,11 @@ function sed_hyphen_i() {
   fi
 }
 
+function write_env_to_bazelrc() {
+  sed_hyphen_i "/$1/d" .bazelrc
+  echo "build --action_env $1=\"$2\"" >> .bazelrc
+}
+
 # Delete any leftover BUILD files from the Makefile build, which would interfere
 # with Bazel parsing.
 MAKEFILE_DOWNLOAD_DIR=tensorflow/contrib/makefile/downloads
@@ -310,7 +315,7 @@ while [[ "$TF_CUDA_CLANG" != "1" ]] && ! is_windows && true; do
   fi
   if [ -e "$GCC_HOST_COMPILER_PATH" ]; then
     export GCC_HOST_COMPILER_PATH
-    echo "build --action_env GCC_HOST_COMPILER_PATH=$GCC_HOST_COMPILER_PATH" >>.bazelrc
+    write_env_to_bazelrc "GCC_HOST_COMPILER_PATH" "$GCC_HOST_COMPILER_PATH"
     break
   fi
   echo "Invalid gcc path. ${GCC_HOST_COMPILER_PATH} cannot be found" 1>&2
@@ -385,9 +390,9 @@ while true; do
 
   if [ -e "${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH}" ]; then
     export CUDA_TOOLKIT_PATH
-    echo "build --action_env CUDA_TOOLKIT_PATH=$CUDA_TOOLKIT_PATH" >>.bazelrc
+    write_env_to_bazelrc "CUDA_TOOLKIT_PATH" "$CUDA_TOOLKIT_PATH"
     export TF_CUDA_VERSION
-    echo "build --action_env TF_CUDA_VERSION=$TF_CUDA_VERSION" >>.bazelrc
+    write_env_to_bazelrc "TF_CUDA_VERSION" "$TF_CUDA_VERSION"
     break
   fi
   echo "Invalid path to CUDA $TF_CUDA_VERSION toolkit. ${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH} cannot be found"
@@ -439,9 +444,9 @@ while true; do
 
   if [ -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_ALT_PATH}" -o -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_PATH}" ]; then
     export TF_CUDNN_VERSION
-    echo "build --action_env TF_CUDNN_VERSION=$TF_CUDNN_VERSION" >>.bazelrc
+    write_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
     export CUDNN_INSTALL_PATH
-    echo "build --action_env CUDNN_INSTALL_PATH=$CUDNN_INSTALL_PATH" >>.bazelrc
+    write_env_to_bazelrc "CUDNN_INSTALL_PATH" "$CUDNN_INSTALL_PATH"
     break
   fi
 
@@ -454,9 +459,9 @@ while true; do
     CUDNN_PATH_FROM_LDCONFIG="$($LDCONFIG_BIN -p | sed -n 's/.*libcudnn.so .* => \(.*\)/\1/p')"
     if [ -e "${CUDNN_PATH_FROM_LDCONFIG}${TF_CUDNN_EXT}" ]; then
       export TF_CUDNN_VERSION
-      echo "build --action_env TF_CUDNN_VERSION=$TF_CUDNN_VERSION" >>.bazelrc
+      write_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
       export CUDNN_INSTALL_PATH="$(dirname ${CUDNN_PATH_FROM_LDCONFIG})"
-      echo "build --action_env CUDNN_INSTALL_PATH=$CUDNN_INSTALL_PATH" >>.bazelrc
+      write_env_to_bazelrc "CUDNN_INSTALL_PATH" "$CUDNN_INSTALL_PATH"
       break
     fi
   fi
@@ -508,7 +513,7 @@ EOF
     fi
   else
     export TF_CUDA_COMPUTE_CAPABILITIES
-    echo "build --action_env TF_CUDA_COMPUTE_CAPABILITIES=$TF_CUDA_COMPUTE_CAPABILITIES" >>.bazelrc
+    write_env_to_bazelrc "TF_CUDA_COMPUTE_CAPABILITIES" "$TF_CUDA_COMPUTE_CAPABILITIES"
     break
   fi
   TF_CUDA_COMPUTE_CAPABILITIES=""
@@ -519,9 +524,9 @@ if is_windows; then
   export CUDA_PATH="$CUDA_TOOLKIT_PATH"
   export CUDA_COMPUTE_CAPABILITIES="$TF_CUDA_COMPUTE_CAPABILITIES"
   export NO_WHOLE_ARCHIVE_OPTION=1
-
-  # Set GCC_HOST_COMPILER_PATH to keep cuda_configure.bzl happy
-  export GCC_HOST_COMPILER_PATH="/usr/bin/dummy_compiler"
+  write_env_to_bazelrc "CUDA_PATH" "$CUDA_PATH"
+  write_env_to_bazelrc "CUDA_COMPUTE_CAPABILITIES" "$CUDA_COMPUTE_CAPABILITIES"
+  write_env_to_bazelrc "NO_WHOLE_ARCHIVE_OPTION" "1"
 fi
 
 # end of if "$TF_NEED_CUDA" == "1"

--- a/configure
+++ b/configure
@@ -168,6 +168,7 @@ if is_windows; then
   TF_NEED_HDFS=0
   TF_NEED_JEMALLOC=0
   TF_NEED_OPENCL=0
+  TF_CUDA_CLANG=0
 fi
 
 if is_linux; then

--- a/configure
+++ b/configure
@@ -8,9 +8,6 @@ pushd `dirname $0` > /dev/null
 SOURCE_BASE_DIR=`pwd -P`
 popd > /dev/null
 
-# This file contains customized config settings.
-touch .bazelrc
-
 PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
 
 function is_linux() {
@@ -46,10 +43,20 @@ function sed_hyphen_i() {
   fi
 }
 
-function write_env_to_bazelrc() {
-  sed_hyphen_i "/$1/d" .bazelrc
-  echo "build --action_env $1=\"$2\"" >> .bazelrc
+function write_to_bazelrc() {
+  echo "$1" >> .tf_configure.bazelrc
 }
+
+function write_action_env_to_bazelrc() {
+  write_to_bazelrc "build --action_env $1=\"$2\""
+}
+
+# This file contains customized config settings.
+rm -f .tf_configure.bazelrc
+touch .tf_configure.bazelrc
+touch .bazelrc
+sed_hyphen_i "/tf_configure/d" .bazelrc
+echo "import .tf_configure.bazelrc" >> .bazelrc
 
 # Delete any leftover BUILD files from the Makefile build, which would interfere
 # with Bazel parsing.
@@ -178,9 +185,8 @@ else
   TF_NEED_JEMALLOC=0
 fi
 
-sed_hyphen_i -e "/with_jemalloc/d" .bazelrc
 if [[ "$TF_NEED_JEMALLOC" == "1" ]]; then
-  echo 'build --define with_jemalloc=true' >>.bazelrc
+  write_to_bazelrc 'build --define with_jemalloc=true'
 fi
 
 while [[ "$TF_NEED_GCP" == "" ]]; do
@@ -197,9 +203,8 @@ while [[ "$TF_NEED_GCP" == "" ]]; do
   esac
 done
 
-sed_hyphen_i -e "/with_gcp_support/d" .bazelrc
 if [[ "$TF_NEED_GCP" == "1" ]]; then
-  echo 'build --define with_gcp_support=true' >>.bazelrc
+  write_to_bazelrc 'build --define with_gcp_support=true'
 fi
 
 while [[ "$TF_NEED_HDFS" == "" ]]; do
@@ -216,9 +221,8 @@ while [[ "$TF_NEED_HDFS" == "" ]]; do
   esac
 done
 
-sed_hyphen_i -e "/with_hdfs_support/d" .bazelrc
 if [[ "$TF_NEED_HDFS" == "1" ]]; then
-  echo 'build --define with_hdfs_support=true' >>.bazelrc
+  write_to_bazelrc 'build --define with_hdfs_support=true'
 fi
 
 ## Enable XLA.
@@ -232,9 +236,8 @@ while [[ "$TF_ENABLE_XLA" == "" ]]; do
   esac
 done
 
-sed_hyphen_i -e "/with_xla_support/d" .bazelrc
 if [[ "$TF_ENABLE_XLA" == "1" ]]; then
-  echo 'build --define with_xla_support=true' >>.bazelrc
+  write_to_bazelrc 'build --define with_xla_support=true'
 fi
 
 
@@ -315,7 +318,7 @@ while [[ "$TF_CUDA_CLANG" != "1" ]] && ! is_windows && true; do
   fi
   if [ -e "$GCC_HOST_COMPILER_PATH" ]; then
     export GCC_HOST_COMPILER_PATH
-    write_env_to_bazelrc "GCC_HOST_COMPILER_PATH" "$GCC_HOST_COMPILER_PATH"
+    write_action_env_to_bazelrc "GCC_HOST_COMPILER_PATH" "$GCC_HOST_COMPILER_PATH"
     break
   fi
   echo "Invalid gcc path. ${GCC_HOST_COMPILER_PATH} cannot be found" 1>&2
@@ -390,9 +393,9 @@ while true; do
 
   if [ -e "${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH}" ]; then
     export CUDA_TOOLKIT_PATH
-    write_env_to_bazelrc "CUDA_TOOLKIT_PATH" "$CUDA_TOOLKIT_PATH"
+    write_action_env_to_bazelrc "CUDA_TOOLKIT_PATH" "$CUDA_TOOLKIT_PATH"
     export TF_CUDA_VERSION
-    write_env_to_bazelrc "TF_CUDA_VERSION" "$TF_CUDA_VERSION"
+    write_action_env_to_bazelrc "TF_CUDA_VERSION" "$TF_CUDA_VERSION"
     break
   fi
   echo "Invalid path to CUDA $TF_CUDA_VERSION toolkit. ${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH} cannot be found"
@@ -444,9 +447,9 @@ while true; do
 
   if [ -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_ALT_PATH}" -o -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_PATH}" ]; then
     export TF_CUDNN_VERSION
-    write_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
+    write_action_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
     export CUDNN_INSTALL_PATH
-    write_env_to_bazelrc "CUDNN_INSTALL_PATH" "$CUDNN_INSTALL_PATH"
+    write_action_env_to_bazelrc "CUDNN_INSTALL_PATH" "$CUDNN_INSTALL_PATH"
     break
   fi
 
@@ -459,9 +462,9 @@ while true; do
     CUDNN_PATH_FROM_LDCONFIG="$($LDCONFIG_BIN -p | sed -n 's/.*libcudnn.so .* => \(.*\)/\1/p')"
     if [ -e "${CUDNN_PATH_FROM_LDCONFIG}${TF_CUDNN_EXT}" ]; then
       export TF_CUDNN_VERSION
-      write_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
+      write_action_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
       export CUDNN_INSTALL_PATH="$(dirname ${CUDNN_PATH_FROM_LDCONFIG})"
-      write_env_to_bazelrc "CUDNN_INSTALL_PATH" "$CUDNN_INSTALL_PATH"
+      write_action_env_to_bazelrc "CUDNN_INSTALL_PATH" "$CUDNN_INSTALL_PATH"
       break
     fi
   fi
@@ -513,7 +516,7 @@ EOF
     fi
   else
     export TF_CUDA_COMPUTE_CAPABILITIES
-    write_env_to_bazelrc "TF_CUDA_COMPUTE_CAPABILITIES" "$TF_CUDA_COMPUTE_CAPABILITIES"
+    write_action_env_to_bazelrc "TF_CUDA_COMPUTE_CAPABILITIES" "$TF_CUDA_COMPUTE_CAPABILITIES"
     break
   fi
   TF_CUDA_COMPUTE_CAPABILITIES=""
@@ -524,9 +527,9 @@ if is_windows; then
   export CUDA_PATH="$CUDA_TOOLKIT_PATH"
   export CUDA_COMPUTE_CAPABILITIES="$TF_CUDA_COMPUTE_CAPABILITIES"
   export NO_WHOLE_ARCHIVE_OPTION=1
-  write_env_to_bazelrc "CUDA_PATH" "$CUDA_PATH"
-  write_env_to_bazelrc "CUDA_COMPUTE_CAPABILITIES" "$CUDA_COMPUTE_CAPABILITIES"
-  write_env_to_bazelrc "NO_WHOLE_ARCHIVE_OPTION" "1"
+  write_action_env_to_bazelrc "CUDA_PATH" "$CUDA_PATH"
+  write_action_env_to_bazelrc "CUDA_COMPUTE_CAPABILITIES" "$CUDA_COMPUTE_CAPABILITIES"
+  write_action_env_to_bazelrc "NO_WHOLE_ARCHIVE_OPTION" "1"
 fi
 
 # end of if "$TF_NEED_CUDA" == "1"

--- a/configure
+++ b/configure
@@ -279,14 +279,8 @@ while [ "$TF_NEED_CUDA" == "" ]; do
   esac
 done
 
-sed_hyphen_i -e "/--action_env TF_NEED_CUDA/d" .bazelrc
-sed_hyphen_i -e "/--action_env CUD/d" .bazelrc
-sed_hyphen_i -e "/--action_env GCC_HOST/d" .bazelrc
-sed_hyphen_i -e "/--action_env TF_CUD/d" .bazelrc
-sed_hyphen_i -e "/--action_env CLANG_CUDA/d" .bazelrc
-
 export TF_NEED_CUDA
-echo "build --action_env TF_NEED_CUDA=$TF_NEED_CUDA" >>.bazelrc
+write_action_env_to_bazelrc "TF_NEED_CUDA" "$TF_NEED_CUDA"
 
 export TF_NEED_OPENCL
 
@@ -302,7 +296,7 @@ while [[ "$TF_CUDA_CLANG" == "" ]]; do
 done
 
 export TF_CUDA_CLANG
-echo "build --action_env TF_CUDA_CLANG=$TF_CUDA_CLANG" >>.bazelrc
+write_action_env_to_bazelrc "TF_CUDA_CLANG" "$TF_CUDA_CLANG"
 
 # Set up which gcc nvcc should use as the host compiler
 # No need to set this on Windows
@@ -342,7 +336,7 @@ while [[ "$TF_CUDA_CLANG" == "1" ]] && true; do
   fi
   if [ -e "$CLANG_CUDA_COMPILER_PATH" ]; then
     export CLANG_CUDA_COMPILER_PATH
-    echo "build --action_env CLANG_CUDA_COMPILER_PATH=\"$CLANG_CUDA_COMPILER_PATH\"" >>.bazelrc
+    write_action_env_to_bazelrc "CLANG_CUDA_COMPILER_PATH" "$CLANG_CUDA_COMPILER_PATH"
     break
   fi
   echo "Invalid clang path. ${CLANG_CUDA_COMPILER_PATH} cannot be found" 1>&2

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -39,6 +39,10 @@ _DEFAULT_CUDA_COMPUTE_CAPABILITIES = ["3.5", "5.2"]
 # BEGIN cc_configure common functions.
 def find_cc(repository_ctx):
   """Find the C++ compiler."""
+  # On Windows, we use Bazel's MSVC CROSSTOOL for GPU build
+  # Return a dummy value for GCC detection here to avoid error
+  if _cpu_value(repository_ctx) == "Windows":
+    return "/usr/bin/dummycompiler"
   if _use_cuda_clang(repository_ctx):
     target_cc_name = "clang"
     cc_path_envvar = _CLANG_CUDA_COMPILER_PATH

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -42,7 +42,8 @@ def find_cc(repository_ctx):
   # On Windows, we use Bazel's MSVC CROSSTOOL for GPU build
   # Return a dummy value for GCC detection here to avoid error
   if _cpu_value(repository_ctx) == "Windows":
-    return "/usr/bin/dummycompiler"
+    return "/use/--config x64_windows_msvc/instead"
+
   if _use_cuda_clang(repository_ctx):
     target_cc_name = "clang"
     cc_path_envvar = _CLANG_CUDA_COMPILER_PATH


### PR DESCRIPTION
1. Remove corresponding action_env before writing it
2. Add quote to environment variables
3. Return a dummpy value for gcc detection on Windows

@gunan @damienmg 