### PR TITLE
Fix resources section link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Hello, TensorFlow!
 * [TensorFlow Model Zoo](https://github.com/tensorflow/models)
 * [TensorFlow MOOC on Udacity](https://www.udacity.com/course/deep-learning--ud730)
 
-The TensorFlow community has created amazing things with TensorFlow, please see the [resources section of tensorflow.org](https://www.tensorflow.org/versions/master/resources#community) for an incomplete list.
+The TensorFlow community has created amazing things with TensorFlow, please see the [resources section of tensorflow.org](https://www.tensorflow.org/about/#community) for an incomplete list.


### PR DESCRIPTION
Updated the resources section link in the README file to point to the correct page on tensorflow.org