### PR TITLE
Changed the path to graph directory

### DIFF
--- a/tensorflow/contrib/makefile/README.md
+++ b/tensorflow/contrib/makefile/README.md
@@ -75,7 +75,7 @@ To run the executable, use:
 
 ```bash
 tensorflow/contrib/makefile/gen/bin/benchmark \
- --graph=~/graphs/inception/tensorflow_inception_graph.pb
+ --graph=$HOME/graphs/inception/tensorflow_inception_graph.pb
 ```
 
 ## Android


### PR DESCRIPTION
Previously, it was showing "Could not create TensorFlow Graph: Not found: ~/graphs/inception/tensorflow_inception_graph.pb". Now, this change ensures that the graph generation will work for everyone smoothly.