### PR TITLE
MSVC 2015 port.

### DIFF
--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -235,7 +235,7 @@ struct ProtoHelper {};
       return proto.N##_val().size();                                   \
     }                                                                  \
     static void Fill(const T* data, size_t n, TensorProto* proto) {    \
-      typename ProtoHelper<T>::FieldType copy(data, data + n);         \
+      ProtoHelper<T>::FieldType copy(data, data + n);         \
       proto->mutable_##N##_val()->Swap(&copy);                         \
     }                                                                  \
   };

--- a/tensorflow/core/framework/tensor_shape.h
+++ b/tensorflow/core/framework/tensor_shape.h
@@ -289,6 +289,11 @@ class TensorShapeUtils {
   static Status MakeShape(const int64* dims, int64 n, TensorShape* out);
   static Status MakeShape(gtl::ArraySlice<int32> shape, TensorShape* out);
   static Status MakeShape(gtl::ArraySlice<int64> shape, TensorShape* out);
+  // Convert from Eigen::TensorMap
+  template<typename T>
+  inline static Status MakeShape(T &t, TensorShape *out) {
+     return MakeShape( t.data(), t.size(), out );
+  }
 
   static string ShapeListString(const gtl::ArraySlice<TensorShape>& shapes);
 

--- a/tensorflow/core/framework/tensor_types.h
+++ b/tensorflow/core/framework/tensor_types.h
@@ -90,7 +90,7 @@ struct TTypes {
                                          IndexType> > UnalignedConstMatrix;
 };
 
-typedef typename TTypes<float, 1>::Tensor32Bit::Index Index32;
+typedef TTypes<float, 1>::Tensor32Bit::Index Index32;
 
 template <typename DSizes>
 Eigen::DSizes<Index32, DSizes::count> To32BitDims(const DSizes& in) {

--- a/tensorflow/core/graph/edgeset.h
+++ b/tensorflow/core/graph/edgeset.h
@@ -78,10 +78,10 @@ class EdgeSet {
 
 class EdgeSet::const_iterator {
  public:
-  typedef typename EdgeSet::value_type value_type;
-  typedef const typename EdgeSet::value_type& reference;
-  typedef const typename EdgeSet::value_type* pointer;
-  typedef typename EdgeSet::difference_type difference_type;
+  typedef EdgeSet::value_type value_type;
+  typedef const EdgeSet::value_type& reference;
+  typedef const EdgeSet::value_type* pointer;
+  typedef EdgeSet::difference_type difference_type;
   typedef std::forward_iterator_tag iterator_category;
 
   const_iterator() {}
@@ -99,7 +99,7 @@ class EdgeSet::const_iterator {
   friend class EdgeSet;
 
   void const* const* array_iter_ = nullptr;
-  typename std::set<const Edge*>::const_iterator tree_iter_;
+  std::set<const Edge*>::const_iterator tree_iter_;
 
 #ifdef NDEBUG
   inline void Init(const EdgeSet* e) {}

--- a/tensorflow/core/kernels/concat_lib_cpu.cc
+++ b/tensorflow/core/kernels/concat_lib_cpu.cc
@@ -65,7 +65,7 @@ void ConcatCPU(DeviceBase* d,
   template void ConcatCPU<T>(                                                  \
       DeviceBase*,                                                             \
       const std::vector<std::unique_ptr<typename TTypes<T, 2>::ConstMatrix>>&, \
-      typename TTypes<T, 2>::Matrix* output);
+      TTypes<T, 2>::Matrix* output);
 TF_CALL_ALL_TYPES(REGISTER)
 REGISTER(quint8)
 REGISTER(qint8)

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -111,9 +111,9 @@ struct LaunchBackwardInputConvolution {
 template <>
 struct LaunchBackwardInputConvolution<CPUDevice, float> {
   bool operator()(OpKernelContext* context, const CPUDevice& d,
-                  typename TTypes<float, 4>::Tensor input_backward,
-                  typename TTypes<float, 4>::ConstTensor kernel,
-                  typename TTypes<float, 4>::ConstTensor output_backward,
+                  TTypes<float, 4>::Tensor input_backward,
+                  TTypes<float, 4>::ConstTensor kernel,
+                  TTypes<float, 4>::ConstTensor output_backward,
                   int input_rows, int input_cols, int row_stride,
                   int col_stride, TensorFormat data_format) const {
     functor::SpatialConvolutionBackwardInput<CPUDevice, float>()(

--- a/tensorflow/core/kernels/dense_update_ops.cc
+++ b/tensorflow/core/kernels/dense_update_ops.cc
@@ -30,8 +30,8 @@ namespace functor {
 template <>
 struct DenseUpdate<Eigen::ThreadPoolDevice, string, ASSIGN> {
   void operator()(const Eigen::ThreadPoolDevice& d,
-                  typename TTypes<string>::Flat params,
-                  typename TTypes<string>::ConstFlat update) {
+                  TTypes<string>::Flat params,
+                  TTypes<string>::ConstFlat update) {
     if (params.dimension(0) == 1) {
       params.data()->resize(update.data()->size());
       auto work = [&params, &update](int64 start, int64 end) {

--- a/tensorflow/core/kernels/fake_quant_ops_functor.h
+++ b/tensorflow/core/kernels/fake_quant_ops_functor.h
@@ -191,7 +191,7 @@ struct FakeQuantWithMinMaxVarsGradientFunctor {
   }
 };
 
-using Index = typename tensorflow::TTypes<float>::ConstTensor::Index;
+using Index = tensorflow::TTypes<float>::ConstTensor::Index;
 
 // Functor called by FakeQuantWithMinMaxVarsPerChannelOp to do the work.
 // Compiles both for CPU and GPU.

--- a/tensorflow/core/kernels/fill_functor.cc
+++ b/tensorflow/core/kernels/fill_functor.cc
@@ -31,7 +31,7 @@ void SetZeroFunctor<Eigen::ThreadPoolDevice, T>::operator()(
 }
 
 void SetZeroFunctor<Eigen::ThreadPoolDevice, string>::operator()(
-    const Eigen::ThreadPoolDevice& d, typename TTypes<string>::Flat out) {
+    const Eigen::ThreadPoolDevice& d, TTypes<string>::Flat out) {
   out.device(d) = out.constant(string());
 }
 

--- a/tensorflow/core/kernels/fill_functor.h
+++ b/tensorflow/core/kernels/fill_functor.h
@@ -56,7 +56,7 @@ struct SetZeroFunctor<Eigen::SyclDevice, T> {
 template <>
 struct SetZeroFunctor<Eigen::ThreadPoolDevice, string> {
   void operator()(const Eigen::ThreadPoolDevice& d,
-                  typename TTypes<string>::Flat out);
+                  TTypes<string>::Flat out);
 };
 
 template <typename Device, typename T>
@@ -83,7 +83,7 @@ struct SetOneFunctor<Eigen::SyclDevice, T> {
 template <>
 struct SetOneFunctor<Eigen::ThreadPoolDevice, string> {
   void operator()(const Eigen::ThreadPoolDevice& d,
-                  typename TTypes<string>::Flat out);
+                  TTypes<string>::Flat out);
 };
 
 }  // namespace functor

--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -77,8 +77,8 @@ struct FusedBatchNorm<CPUDevice, T> {
 
 #if !defined(EIGEN_HAS_INDEX_LIST)
     Eigen::DSizes<Eigen::Index, 2> one_by_depth(1, depth);
-    Eigen::array<int, 1> reduce_dims({0});
-    Eigen::array<int, 2> bcast_spec({rest_size, 1});
+    Eigen::array<int, 1> reduce_dims{0};
+    Eigen::array<int, 2> bcast_spec{rest_size, 1};
 #else
     Eigen::IndexList<Eigen::type2index<1>, Eigen::Index> one_by_depth;
     one_by_depth.set(1, depth);
@@ -166,8 +166,8 @@ struct FusedBatchNormGrad<CPUDevice, T> {
 
 #if !defined(EIGEN_HAS_INDEX_LIST)
     Eigen::DSizes<Eigen::Index, 2> one_by_depth(1, depth);
-    Eigen::array<int, 1> reduce_dims({0});
-    Eigen::array<int, 2> bcast_spec({rest_size, 1});
+    Eigen::array<int, 1> reduce_dims{0};
+    Eigen::array<int, 2> bcast_spec{rest_size, 1};
 #else
     Eigen::IndexList<Eigen::type2index<1>, Eigen::Index> one_by_depth;
     one_by_depth.set(1, depth);
@@ -603,10 +603,10 @@ class FusedBatchNormGradOp : public OpKernel {
     // used for inference and thus not needed here for gradient computation.
     Tensor* placeholder_1 = nullptr;
     OP_REQUIRES_OK(
-        context, context->allocate_output(3, TensorShape({}), &placeholder_1));
+        context, context->allocate_output(3, TensorShape{}, &placeholder_1));
     Tensor* placeholder_2 = nullptr;
     OP_REQUIRES_OK(
-        context, context->allocate_output(4, TensorShape({}), &placeholder_2));
+        context, context->allocate_output(4, TensorShape{}, &placeholder_2));
 
     functor::FusedBatchNormGrad<Device, T>()(
         context, y_backprop, x, scale, saved_mean, saved_maybe_inv_var,

--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -65,7 +65,7 @@ static inline void DecreasingArgSort(const std::vector<float>& values,
 }
 
 // Compute intersection-over-union overlap between boxes i and j.
-static inline float ComputeIOU(typename TTypes<float, 2>::ConstTensor boxes,
+static inline float ComputeIOU(TTypes<float, 2>::ConstTensor boxes,
                                int i, int j) {
   const float ymin_i = std::min<float>(boxes(i, 0), boxes(i, 2));
   const float xmin_i = std::min<float>(boxes(i, 1), boxes(i, 3));

--- a/tensorflow/core/kernels/save_restore_v2_ops.cc
+++ b/tensorflow/core/kernels/save_restore_v2_ops.cc
@@ -204,8 +204,9 @@ class MergeV2Checkpoints : public OpKernel {
                     "Input destination_prefix should be a scalar tensor, got ",
                     destination_prefix.shape().DebugString(), " instead."));
 
+    auto flat = checkpoint_prefixes.flat<string>();
     const gtl::ArraySlice<string> input_prefixes =
-        gtl::ArraySlice<string>(checkpoint_prefixes.flat<string>());
+        gtl::ArraySlice<string>(flat.data(),flat.size());
     Env* env = Env::Default();
     const string& merged_prefix = destination_prefix.scalar<string>()();
     OP_REQUIRES_OK(

--- a/tensorflow/core/kernels/scatter_nd_op_cpu_impl.h
+++ b/tensorflow/core/kernels/scatter_nd_op_cpu_impl.h
@@ -158,10 +158,10 @@ struct ScatterNdFunctor<CPUDevice, T, Index, OP, IXDIM> {
       const CPUDevice& d, const Index slice_size,                            \
       const Eigen::array<Eigen::DenseIndex, CPU_PROVIDED_IXDIM>              \
           output_shape_prefix,                                               \
-      typename TTypes<T, 2>::Tensor Tparams,                                 \
-      typename TTypes<Index, 2>::ConstTensor Tindices,                       \
-      typename TTypes<T, 2>::ConstTensor Tupdates,                           \
-      typename TTypes<T, 2>::Tensor Toutput)
+      TTypes<T, 2>::Tensor Tparams,                                 \
+      TTypes<Index, 2>::ConstTensor Tindices,                       \
+      TTypes<T, 2>::ConstTensor Tupdates,                           \
+      TTypes<T, 2>::Tensor Toutput)
 
 #define REGISTER_SCATTER_ND_INDEX(type, op)  \
   REGISTER_SCATTER_ND_FULL(type, int32, op); \

--- a/tensorflow/core/kernels/sparse_matmul_op.cc
+++ b/tensorflow/core/kernels/sparse_matmul_op.cc
@@ -1032,7 +1032,7 @@ class SparseMatMulOp : public OpKernel {
           new Tensor(right->dtype(),
                      TensorShape({right->dim_size(1), right->dim_size(0)})));
 
-      Eigen::array<int, 2> perm({1, 0});
+      Eigen::array<int, 2> perm{1, 0};
       if (transpose_output) {
         right_tr->matrix<TL>().device(ctx->template eigen_device<CPUDevice>()) =
             right->matrix<TL>().shuffle(perm);
@@ -1076,7 +1076,7 @@ inline void SparseMatMul<TL, TR>::ComputeOutputBlock(
     const typename SparseMatMul<TL, TR>::ConstMatrixMapR& right, int num_cols,
     int output_row_offset, int output_col_offset, bool assign,
     bool transpose_output, MatrixMap* output) {
-  static const Eigen::array<int, 2> perm({1, 0});
+  static const Eigen::array<int, 2> perm{1, 0};
   int num_rows = left[0]->num_rows;
   const int rhs_num_cols = right.dimension(1);
   DCHECK_LE(num_cols, rhs_num_cols);

--- a/tensorflow/core/lib/gtl/array_slice_internal.h
+++ b/tensorflow/core/lib/gtl/array_slice_internal.h
@@ -86,7 +86,7 @@ struct HasGetHelper : public M {
 // Defines HasGet() for a particular method, container, and checker. If
 // HasGet()==true, provides Get() that delegates to the method.
 template <typename M, typename Checker, typename C,
-          bool /*has_get*/ = HasGetHelper<M, Checker, C>::HasGet()>
+          bool /*has_get*/ = typename HasGetHelper<M, Checker, C>::HasGet()>
 struct Wrapper {
   static constexpr bool HasGet() { return false; }
 };

--- a/tensorflow/core/util/saved_tensor_slice_util.h
+++ b/tensorflow/core/util/saved_tensor_slice_util.h
@@ -96,7 +96,7 @@ void Fill(T* data, size_t n, TensorProto* t);
   TENSOR_PROTO_EXTRACT_TYPE_HELPER(TYPE, FIELD, FTYPE, FTYPE)     \
   template <>                                                     \
   inline void Fill(const TYPE* data, size_t n, TensorProto* t) {  \
-    typename protobuf::RepeatedField<FTYPE> copy(data, data + n); \
+    protobuf::RepeatedField<FTYPE> copy(data, data + n); \
     t->mutable_##FIELD##_val()->Swap(&copy);                      \
   }
 
@@ -106,7 +106,7 @@ void Fill(T* data, size_t n, TensorProto* t);
   template <>                                                       \
   inline void Fill(const TYPE* data, size_t n, TensorProto* t) {    \
     const FTYPE* sub = reinterpret_cast<const FTYPE*>(data);        \
-    typename protobuf::RepeatedField<FTYPE> copy(sub, sub + 2 * n); \
+    protobuf::RepeatedField<FTYPE> copy(sub, sub + 2 * n); \
     t->mutable_##FIELD##_val()->Swap(&copy);                        \
   }
 
@@ -142,7 +142,7 @@ inline const int32* TensorProtoData<qint32>(const TensorProto& t) {
 
 inline void Fill(const qint32* data, size_t n, TensorProto* t) {
   const int32* p = reinterpret_cast<const int32*>(data);
-  typename protobuf::RepeatedField<int32> copy(p, p + n);
+  protobuf::RepeatedField<int32> copy(p, p + n);
   t->mutable_int_val()->Swap(&copy);
 }
 
@@ -168,7 +168,7 @@ inline protobuf::RepeatedField<int32>* MutableTensorProtoData<Eigen::half>(
 
 template <>
 inline void Fill(const Eigen::half* data, size_t n, TensorProto* t) {
-  typename protobuf::RepeatedField<int32>* val = t->mutable_half_val();
+  protobuf::RepeatedField<int32>* val = t->mutable_half_val();
   val->Resize(n, 0);
   for (size_t i = 0; i < n; ++i) {
     val->Set(i, data[i].x);
@@ -201,7 +201,7 @@ inline protobuf::RepeatedPtrField<string>* MutableTensorProtoData<string>(
 
 template <>
 inline void Fill(const string* data, size_t n, TensorProto* t) {
-  typename protobuf::RepeatedPtrField<string> copy(data, data + n);
+  protobuf::RepeatedPtrField<string> copy(data, data + n);
   t->mutable_string_val()->Swap(&copy);
 }
 

--- a/tensorflow/core/util/sparse/dim_comparator.h
+++ b/tensorflow/core/util/sparse/dim_comparator.h
@@ -44,7 +44,7 @@ namespace sparse {
 // the values in IX in particular columns (dimensions) of interest.
 class DimComparator {
  public:
-  typedef typename gtl::ArraySlice<int64> VarDimArray;
+  typedef gtl::ArraySlice<int64> VarDimArray;
 
   DimComparator(const TTypes<int64>::Matrix& ix, const VarDimArray& order,
                 const TensorShape& shape)

--- a/tensorflow/core/util/sparse/sparse_tensor.h
+++ b/tensorflow/core/util/sparse/sparse_tensor.h
@@ -38,7 +38,7 @@ namespace sparse {
 
 class SparseTensor {
  public:
-  typedef typename gtl::ArraySlice<int64> VarDimArray;
+  typedef gtl::ArraySlice<int64> VarDimArray;
 
   SparseTensor(Tensor ix, Tensor vals, const TensorShape& shape)
       : SparseTensor(ix, vals, shape, UndefinedOrder(shape)) {}


### PR DESCRIPTION
My version of MSVC 2015 has some issues with some newer c++ constructs.
There are 3 type of fixes:
1. Remove optional 'typename' specifications outside template definitions.  They are optional on newer compilers, but msvc does not thinks so.
2. Remove brackets from initializer lists, `perm({0,1})` becomes `perm{0,1}`. I am not sure why this is different on msvc.
3. Explicitly convert from `Eigen::TensorMap` to `gtl::ArraySlice` via .data() and .size().  Again, I'm not sure why this is required for msvc, but this solves the remaining compiler issues.