### PR TITLE
Minor fix to saved_model/builder_impl.py docstring

### DIFF
--- a/tensorflow/python/saved_model/builder_impl.py
+++ b/tensorflow/python/saved_model/builder_impl.py
@@ -57,7 +57,7 @@ class SavedModelBuilder(object):
   Typical usage for the `SavedModelBuilder`:
   ```python
   ...
-  builder = saved_model_builder.SavedModelBuilder(export_dir)
+  builder = saved_model.builder.SavedModelBuilder(export_dir)
 
   with tf.Session(graph=tf.Graph()) as sess:
     ...


### PR DESCRIPTION
I believe that there is a minor problem with the python API documentation at https://www.tensorflow.org/api_docs/python/tf/saved_model/builder/SavedModelBuilder. The first line of the "typical usage" example should read 
`builder = saved_model.builder.SavedModelBuilder(export_dir)`
rather than 
`builder = saved_model_builder.SavedModelBuilder(export_dir)`. 

This pull request should fix the issue. 
