### PR TITLE
Avoid use of sufficient_statistics in moments()

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -639,11 +639,13 @@ def moments(x, axes, shift=None, name=None, keep_dims=False):
           math_ops.reduce_mean(y, axes, keep_dims=True))
     else:
       shift = math_ops.cast(shift, y.dtype)
-    shifted_mean = math_ops.reduce_mean(math_ops.subtract(y, shift), axes, keep_dims=True)
+    shifted_mean = math_ops.reduce_mean(
+      math_ops.subtract(y, shift), axes, keep_dims=True, name="shifted_mean")
     variance = math_ops.subtract(
         math_ops.reduce_mean(math_ops.squared_difference(y, shift), axes, keep_dims=True),
-        math_ops.square(shifted_mean))
-    mean = math_ops.add(shifted_mean, shift)
+        math_ops.square(shifted_mean),
+        name="variance")
+    mean = math_ops.add(shifted_mean, shift, name="mean")
     if not keep_dims:
       # the dimensions for these axes are 1; use any reduce
       mean = math_ops.reduce_mean(mean, axes, keep_dims=False)

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -639,19 +639,20 @@ def moments(x, axes, shift=None, name=None, keep_dims=False):
           math_ops.reduce_mean(y, axes, keep_dims=True))
     else:
       shift = math_ops.cast(shift, y.dtype)
-    counts, m_ss, v_ss, shift = sufficient_statistics(
-        y, axes, shift=shift, keep_dims=keep_dims, name=name)
-    # Reshape shift as needed.
-    shift = array_ops.reshape(shift, array_ops.shape(m_ss))
-    shift.set_shape(m_ss.get_shape())
-    with ops.control_dependencies([counts, m_ss, v_ss]):
-      mean, variance = normalize_moments(counts, m_ss, v_ss, shift, name=name)
-      if x.dtype == dtypes.float16:
-        return (math_ops.cast(mean, dtypes.float16),
-                math_ops.cast(variance, dtypes.float16))
-      else:
-        return (mean, variance)
-
+    shifted_mean = math_ops.reduce_mean(math_ops.subtract(y, shift), axes, keep_dims=True)
+    variance = math_ops.subtract(
+        math_ops.reduce_mean(math_ops.squared_difference(y, shift), axes, keep_dims=True),
+        math_ops.square(shifted_mean))
+    mean = math_ops.add(shifted_mean, shift)
+    if not keep_dims:
+      # the dimensions for these axes are 1; use any reduce
+      mean = math_ops.reduce_mean(mean, axes, keep_dims=False)
+      variance = math_ops.reduce_mean(variance, axes, keep_dims=False)
+    if x.dtype == dtypes.float16:
+      return (math_ops.cast(mean, dtypes.float16),
+              math_ops.cast(variance, dtypes.float16))
+    else:
+      return (mean, variance)
 
 def weighted_moments(x, axes, frequency_weights, name=None, keep_dims=False):
   """Returns the frequency-weighted mean and variance of `x`.

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -647,9 +647,8 @@ def moments(x, axes, shift=None, name=None, keep_dims=False):
         name="variance")
     mean = math_ops.add(shifted_mean, shift, name="mean")
     if not keep_dims:
-      # the dimensions for these axes are 1; use any reduce
-      mean = math_ops.reduce_mean(mean, axes, keep_dims=False)
-      variance = math_ops.reduce_mean(variance, axes, keep_dims=False)
+      mean = array_ops.squeeze(mean, axes)
+      variance = array_ops.squeeze(variance, axes)
     if x.dtype == dtypes.float16:
       return (math_ops.cast(mean, dtypes.float16),
               math_ops.cast(variance, dtypes.float16))


### PR DESCRIPTION
When some of the dimensions are unknown, `tf.nn.sufficient_statistics()` uses `reduce_prod` to guess the size.
But `reduce_prod` is not differentiable on GPU (#8841). This commit avoids the usage of `sufficient_statistics` in `tf.nn.moments()`.

By this way, calling `moments()` won't involve any transfer between CPU and GPU. This can solve, for example, fchollet/keras#5802.

I didn't know how to test things, so I edited my source a little, downloaded `/tensorflow/python/ops/nn_test.py`, imported mine and added lines like:
```python
tf.nn.moments = patched_moments
```
and run the test. It passed all; the unshifted one had unstable output. But I might have done something wrong, so please double-check it.