### PR TITLE
Make tensorflow pip install work in dist_test Dockerfile

### DIFF
--- a/tensorflow/tools/dist_test/Dockerfile
+++ b/tensorflow/tools/dist_test/Dockerfile
@@ -23,7 +23,7 @@ FROM ubuntu:16.04
 MAINTAINER Shanqing Cai <cais@google.com>
 
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install -y \
     curl \
     python \
     python-numpy \


### PR DESCRIPTION
Recently added dependencies of the pip package no longer work with the
--no-install-recommended flag of apt-get install python python-pip.