### PR TITLE
Fix broken ./configure on mac because of non-portable sed syntax

### DIFF
--- a/configure
+++ b/configure
@@ -35,12 +35,9 @@ function is_windows() {
   fi
 }
 
-function sed_hyphen_i() {
-  if is_macos; then
-    sed -i '' "$@"
-  else
-    sed -i "$@"
-  fi
+function sed_in_place() {
+  sed -e $1 $2 > "$2.bak"
+  mv "$2.bak" $2
 }
 
 function write_to_bazelrc() {
@@ -170,7 +167,7 @@ function setup_python {
 rm -f .tf_configure.bazelrc
 touch .tf_configure.bazelrc
 touch .bazelrc
-sed_hyphen_i "/tf_configure/d" .bazelrc
+sed_in_place "/tf_configure/d" .bazelrc
 echo "import %workspace%/.tf_configure.bazelrc" >> .bazelrc
 
 # Delete any leftover BUILD files from the Makefile build, which would interfere


### PR DESCRIPTION
Running `./configure` on mac complains with the following error:

```shell
sed: can't read /tf_configure/d: No such file or directory
```

According to [this SO post](http://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux) the syntax to avoid creating backup files with sed on 10.9+ is without a space between `-i ''`.

Fixes #9553.