### PR TITLE
Fix gradient implementation documentation

### DIFF
--- a/tensorflow/docs_src/extend/adding_an_op.md
+++ b/tensorflow/docs_src/extend/adding_an_op.md
@@ -1118,8 +1118,8 @@ Details about registering gradient functions with
   about any attrs can be found via
   @{tf.Operation.get_attr}.
 
-* If the op has multiple outputs, the gradient function will take `op` and
-  `grads`, where `grads` is a list of gradients with respect to each output.
+* If the op has multiple inputs, the gradient function will take `op` and
+  `grads`, where `grads` is a list of gradients with respect to each input.
   The result of the gradient function must be a list of `Tensor` objects
   representing the gradients with respect to each input.
 


### PR DESCRIPTION
The docs for implementing gradients for a custom op are inconsistent. It seems that a gradient op for an op that takes multiple *inputs* should return a list of tensors with the gradients with respect to the individual inputs. The next paragraph matches this interpretation.