### PR TITLE
Adding a hint to the XLA op metadata, set when the op is updating a variable

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/variable_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/variable_ops.cc
@@ -64,7 +64,7 @@ class AssignAddVariableOp : public XlaOpKernel {
   void Compile(XlaOpKernelContext* ctx) override {
     xla::ComputationDataHandle handle;
     OP_REQUIRES_OK(ctx, ctx->ReadVariableInput(0, &handle));
-    handle = ctx->builder()->Add(handle, ctx->Input(1));
+    handle = ctx->builder()->AssignAdd(handle, ctx->Input(1));
     OP_REQUIRES_OK(ctx, ctx->AssignVariable(0, ctx->input_type(1), handle));
   }
 };
@@ -78,7 +78,7 @@ class AssignSubVariableOp : public XlaOpKernel {
   void Compile(XlaOpKernelContext* ctx) override {
     xla::ComputationDataHandle handle;
     OP_REQUIRES_OK(ctx, ctx->ReadVariableInput(0, &handle));
-    handle = ctx->builder()->Sub(handle, ctx->Input(1));
+    handle = ctx->builder()->AssignSub(handle, ctx->Input(1));
     OP_REQUIRES_OK(ctx, ctx->AssignVariable(0, ctx->input_type(1), handle));
   }
 };

--- a/tensorflow/compiler/xla/client/computation_builder.cc
+++ b/tensorflow/compiler/xla/client/computation_builder.cc
@@ -555,42 +555,42 @@ ComputationDataHandle ComputationBuilder::GetTupleElement(
 ComputationDataHandle ComputationBuilder::Eq(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_EQ, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_EQ, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Ne(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_NE, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_NE, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Ge(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_GE, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_GE, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Gt(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_GT, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_GT, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Le(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_LE, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_LE, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Lt(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_LT, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_LT, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Dot(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs) {
-  return BinaryOp(BINOP_DOT, lhs, rhs, /*broadcast_dimensions=*/{});
+  return BinaryOp(BINOP_DOT, lhs, rhs, /*broadcast_dimensions=*/{}, false);
 }
 
 ComputationDataHandle ComputationBuilder::Conv(
@@ -880,55 +880,70 @@ ComputationDataHandle ComputationBuilder::CustomCall(
 ComputationDataHandle ComputationBuilder::Add(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_ADD, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_ADD, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Sub(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_SUB, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_SUB, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Mul(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_MUL, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_MUL, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Div(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_DIV, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_DIV, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Rem(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_REM, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_REM, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Max(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_MAX, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_MAX, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::Min(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_MIN, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_MIN, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::LogicalAnd(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_LOGICAL_AND, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_LOGICAL_AND, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::LogicalOr(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_LOGICAL_OR, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_LOGICAL_OR, lhs, rhs, broadcast_dimensions, false);
+}
+
+ComputationDataHandle ComputationBuilder::AssignAdd(
+    const ComputationDataHandle& lhs, const ComputationDataHandle& rhs) {
+  return BinaryOp(BINOP_ADD, lhs, rhs, {}, true);
+}
+
+ComputationDataHandle ComputationBuilder::AssignSub(
+    const ComputationDataHandle& lhs, const ComputationDataHandle& rhs) {
+  return BinaryOp(BINOP_SUB, lhs, rhs, {}, true);
+}
+
+ComputationDataHandle ComputationBuilder::AssignMul(
+    const ComputationDataHandle& lhs, const ComputationDataHandle& rhs) {
+  return BinaryOp(BINOP_MUL, lhs, rhs, {}, true);
 }
 
 ComputationDataHandle ComputationBuilder::LogicalNot(
@@ -1030,13 +1045,13 @@ ComputationDataHandle ComputationBuilder::Sort(
 ComputationDataHandle ComputationBuilder::SqrtF32(
     const ComputationDataHandle& operand) {
   return BinaryOp(BINOP_POW, operand, ConstantR0<float>(0.5),
-                  /*broadcast_dimensions=*/{});
+                  /*broadcast_dimensions=*/{}, false);
 }
 
 ComputationDataHandle ComputationBuilder::Pow(
     const ComputationDataHandle& lhs, const ComputationDataHandle& rhs,
     tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
-  return BinaryOp(BINOP_POW, lhs, rhs, broadcast_dimensions);
+  return BinaryOp(BINOP_POW, lhs, rhs, broadcast_dimensions, false);
 }
 
 ComputationDataHandle ComputationBuilder::ConvertElementType(
@@ -1071,13 +1086,13 @@ ComputationDataHandle ComputationBuilder::ConvertElementType(
 ComputationDataHandle ComputationBuilder::SquareF32(
     const ComputationDataHandle& operand) {
   return BinaryOp(BINOP_POW, operand, ConstantR0<float>(2.0),
-                  /*broadcast_dimensions=*/{});
+                  /*broadcast_dimensions=*/{}, false);
 }
 
 ComputationDataHandle ComputationBuilder::ReciprocalF32(
     const ComputationDataHandle& operand) {
   return BinaryOp(BINOP_POW, operand, ConstantR0<float>(-1.0),
-                  /*broadcast_dimensions=*/{});
+                  /*broadcast_dimensions=*/{}, false);
 }
 
 ComputationDataHandle ComputationBuilder::Neg(
@@ -1115,7 +1130,8 @@ ComputationDataHandle ComputationBuilder::UnaryOp(
 ComputationDataHandle ComputationBuilder::BinaryOp(
     BinaryOperation binop, const ComputationDataHandle& lhs,
     const ComputationDataHandle& rhs,
-    tensorflow::gtl::ArraySlice<int64> broadcast_dimensions) {
+    tensorflow::gtl::ArraySlice<int64> broadcast_dimensions,
+    bool hint_assignment) {
   if (!first_error_.ok() || !PrepareComputation().ok()) {
     return ComputationDataHandle();
   }
@@ -1131,6 +1147,7 @@ ComputationDataHandle ComputationBuilder::BinaryOp(
   *op_request.mutable_computation() = computation_.handle();
   *op_request.mutable_binary_op_request() = request;
   AddOpMetadata(&op_request);
+  op_request.mutable_metadata()->set_hint_assignment(hint_assignment);
   OpResponse response;
 
   VLOG(2) << "making binop request";

--- a/tensorflow/compiler/xla/client/computation_builder.h
+++ b/tensorflow/compiler/xla/client/computation_builder.h
@@ -444,6 +444,16 @@ class ComputationBuilder {
 
   ComputationDataHandle LogicalNot(const ComputationDataHandle& lhs);
 
+  // Binary ops that are part of a variable assignment
+  ComputationDataHandle AssignAdd(
+          const ComputationDataHandle& lhs, const ComputationDataHandle& rhs);
+
+  ComputationDataHandle AssignSub(
+          const ComputationDataHandle& lhs, const ComputationDataHandle& rhs);
+
+  ComputationDataHandle AssignMul(
+          const ComputationDataHandle& lhs, const ComputationDataHandle& rhs);
+
   // Reduces an array among the provided dimensions, given "computation" as a
   // reduction operator.
   ComputationDataHandle Reduce(
@@ -701,10 +711,13 @@ class ComputationBuilder {
   // Internal helper method that does the building for an arbitrary binary op.
   // broadcast_dimensions specifies which dimensions to use for broadcasting
   // when the operation is between tensors of different ranks.
+  // hint_assignment indicates if this operation is part of an assignment
+  // operation.
   ComputationDataHandle BinaryOp(
       BinaryOperation binop, const ComputationDataHandle& lhs,
       const ComputationDataHandle& rhs,
-      tensorflow::gtl::ArraySlice<int64> broadcast_dimensions);
+      tensorflow::gtl::ArraySlice<int64> broadcast_dimensions,
+      bool hint_assignment);
 
   // Internal helper method that does the building for an arbitrary ternary op.
   ComputationDataHandle TernaryOp(TernaryOperation triop,

--- a/tensorflow/compiler/xla/xla_data.proto
+++ b/tensorflow/compiler/xla/xla_data.proto
@@ -204,7 +204,7 @@ message OpMetadata {
 
   // Indicates that an operation is assigning to a variable, for instance the
   // add operation in an AssignAdd Op
-  bool hint_assignment = 6;
+  bool hint_assignment = 5;
 }
 
 // Profile data from the execution of a computation.

--- a/tensorflow/compiler/xla/xla_data.proto
+++ b/tensorflow/compiler/xla/xla_data.proto
@@ -201,6 +201,10 @@ message OpMetadata {
   // e.g. it could be be the file and line of user code that generated the op.
   string source_file = 3;
   int32 source_line = 4;
+
+  // Indicates that an operation is assigning to a variable, for instance the
+  // add operation in an AssignAdd Op
+  bool hint_assignment = 6;
 }
 
 // Profile data from the execution of a computation.


### PR DESCRIPTION
The hint can be used for ensuring that the buffer allocated to a variable remains at the same place.  For a static graph compiler, this prevents an extra copy at the end of the execution.

