### PR TITLE
Fix KeyError in quantize_graph round, quantize opt

### DIFF
--- a/tensorflow/tools/quantization/quantize_graph.py
+++ b/tensorflow/tools/quantization/quantize_graph.py
@@ -485,7 +485,7 @@ class GraphRewriter(object):
 
   def quantize_nodes_recursively(self, current_node):
     """The entry point for quantizing nodes to eight bit and back."""
-    if current_node.name in self.already_visited:
+    if (current_node.name in self.already_visited) and self.already_visited[current_node.name]:
       return
     self.already_visited[current_node.name] = True
     for input_node_name in current_node.input:
@@ -507,7 +507,7 @@ class GraphRewriter(object):
   def quantize_node(self, input_node):
     """Handles quantizing a single node."""
     input_name = input_node.name
-    if input_name in self.already_quantized:
+    if (current_node.name in self.already_visited) and self.already_visited[current_node.name]:
       return
     self.already_quantized[input_name] = True
     original_input_name = input_name + "_original"

--- a/tensorflow/tools/quantization/quantize_graph.py
+++ b/tensorflow/tools/quantization/quantize_graph.py
@@ -485,7 +485,7 @@ class GraphRewriter(object):
 
   def quantize_nodes_recursively(self, current_node):
     """The entry point for quantizing nodes to eight bit and back."""
-    if self.already_visited[current_node.name]:
+    if self.already_visited.get(current_node.name):
       return
     self.already_visited[current_node.name] = True
     for input_node_name in current_node.input:

--- a/tensorflow/tools/quantization/quantize_graph.py
+++ b/tensorflow/tools/quantization/quantize_graph.py
@@ -453,7 +453,7 @@ class GraphRewriter(object):
 
   def round_nodes_recursively(self, current_node):
     """The entry point for simple rounding quantization."""
-    if (current_node.name in self.already_visited) and self.already_visited[current_node.name]:
+    if self.already_visited.get(current_node.name, False):
       return
     self.already_visited[current_node.name] = True
     for input_node_name in current_node.input:
@@ -485,7 +485,7 @@ class GraphRewriter(object):
 
   def quantize_nodes_recursively(self, current_node):
     """The entry point for quantizing nodes to eight bit and back."""
-    if (current_node.name in self.already_visited) and self.already_visited[current_node.name]:
+    if self.already_visited.get(current_node.name, False):
       return
     self.already_visited[current_node.name] = True
     for input_node_name in current_node.input:
@@ -494,10 +494,6 @@ class GraphRewriter(object):
       self.quantize_nodes_recursively(input_node)
     nodes_to_quantize = ["Conv2D", "BiasAdd", "MatMul"]
     if any(current_node.op in s for s in nodes_to_quantize):
-      for input_name in current_node.input:
-        input_name = node_name_from_input(input_name)
-        input_node = self.nodes_map[input_name]
-        self.quantize_node(input_node)
       self.quantize_node(current_node)
     else:
       new_node = node_def_pb2.NodeDef()
@@ -507,7 +503,7 @@ class GraphRewriter(object):
   def quantize_node(self, input_node):
     """Handles quantizing a single node."""
     input_name = input_node.name
-    if (current_node.name in self.already_visited) and self.already_visited[current_node.name]:
+    if self.already_quantized.get(input_name, False):
       return
     self.already_quantized[input_name] = True
     original_input_name = input_name + "_original"

--- a/tensorflow/tools/quantization/quantize_graph.py
+++ b/tensorflow/tools/quantization/quantize_graph.py
@@ -453,7 +453,7 @@ class GraphRewriter(object):
 
   def round_nodes_recursively(self, current_node):
     """The entry point for simple rounding quantization."""
-    if self.already_visited.get(current_node.name, False):
+    if current_node.name in self.already_visited:
       return
     self.already_visited[current_node.name] = True
     for input_node_name in current_node.input:
@@ -485,7 +485,7 @@ class GraphRewriter(object):
 
   def quantize_nodes_recursively(self, current_node):
     """The entry point for quantizing nodes to eight bit and back."""
-    if self.already_visited.get(current_node.name, False):
+    if current_node.name in self.already_visited:
       return
     self.already_visited[current_node.name] = True
     for input_node_name in current_node.input:

--- a/tensorflow/tools/quantization/quantize_graph.py
+++ b/tensorflow/tools/quantization/quantize_graph.py
@@ -485,7 +485,7 @@ class GraphRewriter(object):
 
   def quantize_nodes_recursively(self, current_node):
     """The entry point for quantizing nodes to eight bit and back."""
-    if self.already_visited.get(current_node.name):
+    if current_node.name in self.already_visited:
       return
     self.already_visited[current_node.name] = True
     for input_node_name in current_node.input:
@@ -539,7 +539,7 @@ class GraphRewriter(object):
     set_attr_dtype(min_node, "T", dtypes.float32)
     set_attr_bool(min_node, "keep_dims", False)
     self.add_output_graph_node(min_node)
-    quantize_node = create_node("Quantize", quantize_name,
+    quantize_node = create_node("QuantizeV2", quantize_name,
                                 [original_input_name, min_name, max_name])
     set_attr_dtype(quantize_node, "T", dtypes.quint8)
     set_attr_string(quantize_node, "mode", b"MIN_FIRST")

--- a/tensorflow/tools/quantization/quantize_graph.py
+++ b/tensorflow/tools/quantization/quantize_graph.py
@@ -503,7 +503,7 @@ class GraphRewriter(object):
   def quantize_node(self, input_node):
     """Handles quantizing a single node."""
     input_name = input_node.name
-    if self.already_quantized.get(input_name, False):
+    if input_name in self.already_quantized:
       return
     self.already_quantized[input_name] = True
     original_input_name = input_name + "_original"

--- a/tensorflow/tools/quantization/quantize_graph_test.py
+++ b/tensorflow/tools/quantization/quantize_graph_test.py
@@ -164,13 +164,22 @@ def test_graph(float_graph_def, input_map, output_names, log_graph=False):
       [output_name + ":0" for output_name in output_names])
   # TODO(petewarden): round test is currently failing because there is no
   # RoundToSteps op available.
-  # round_rewriter = quantize_graph.GraphRewriter(float_graph_def, "round")
-  # round_graph_def = round_rewriter.rewrite(output_name)
-  # round_results = run_graph_def(round_graph_def, input_map,
-  #                               [output_name + ":0"])
+  round_rewriter = quantize_graph.GraphRewriter(
+      float_graph_def, "round", quantized_input_range=None)
+  round_graph_def = round_rewriter.rewrite(output_names)
+  # round_results = run_graph_def(
+  #     round_graph_def, input_map,
+  #     [output_name + ":0" for output_name in output_names])
   # assert are_tensors_near(expected, round_results[0], 1.0)
   #
   # TODO(petewarden): Add test for "quantize" mode.
+  quantize_rewriter = quantize_graph.GraphRewriter(
+      float_graph_def, "quantize", quantized_input_range=None)
+  quantize_graph_def = quantize_rewriter.rewrite(output_names)
+  round_results = run_graph_def(
+      quantize_graph_def, input_map,
+      [output_name + ":0" for output_name in output_names])
+  # assert are_tensors_near(expected, round_results[0], 1.0)
 
   eightbit_rewriter = quantize_graph.GraphRewriter(
       float_graph_def, "eightbit", quantized_input_range=None)

--- a/tensorflow/tools/quantization/quantize_graph_test.py
+++ b/tensorflow/tools/quantization/quantize_graph_test.py
@@ -170,16 +170,18 @@ def test_graph(float_graph_def, input_map, output_names, log_graph=False):
   # round_results = run_graph_def(
   #     round_graph_def, input_map,
   #     [output_name + ":0" for output_name in output_names])
-  # assert are_tensors_near(expected, round_results[0], 1.0)
+  # for expected, result in zip(float_results, round_results):
+  #   assert are_tensors_near(expected, round_results[0], 1.0)
   #
   # TODO(petewarden): Add test for "quantize" mode.
   quantize_rewriter = quantize_graph.GraphRewriter(
       float_graph_def, "quantize", quantized_input_range=None)
   quantize_graph_def = quantize_rewriter.rewrite(output_names)
-  round_results = run_graph_def(
+  quantize_results = run_graph_def(
       quantize_graph_def, input_map,
       [output_name + ":0" for output_name in output_names])
-  # assert are_tensors_near(expected, round_results[0], 1.0)
+  for expected, result in zip(float_results, quantize_results):
+    assert are_tensors_near(expected, result, 1.0)
 
   eightbit_rewriter = quantize_graph.GraphRewriter(
       float_graph_def, "eightbit", quantized_input_range=None)


### PR DESCRIPTION
The round/quantize paths check for a boolean value in a dictionary before it is set, leading to a KeyError. This change allows the input graph to be quantized using the 'round' and 'quantize' options. The quantized graph can't actually be used (for the 'round' option, at least) due to a lack of a `RoundToSteps` Op, but I figured I'd submit this anyway.

Pinging @petewarden for thoughts on whether this is worth incorporating now.