### PR TITLE
Allow the output of `tf.argmax` as index type

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -470,7 +470,10 @@ def _SliceHelper(tensor, slice_spec, var=None):
     else:
       begin.append(s)
       end.append(s + 1)
-      strides.append(1)
+      if isinstance(s, ops.Tensor):
+        strides.append(constant(1, s.dtype))
+      else:
+        strides.append(np.ones_like(s).dtype.type(1))
       shrink_axis_mask |= (1 << index)
     index += 1
 


### PR DESCRIPTION
This fix tries to fix the issue raised in #8951 where the following will raise a `TypeError`:
```
a = tf.constant([1, 2, 3], dtype=tf.float32)
b = tf.argmax(a)
tf.Session().run(a[b])

TypeError: Input 'strides' of 'StridedSlice' Op has type int32 that does not match type int64 of argument 'begin'.
```

The reason for the erorr is that, `strides` is added  as `append(1)` without type while `begin` is appended with type. (See commit diff).

The mismatch of `strides` and `begin` causes the error.

This fix fixes the issue by cast the stride with the same type as `begin` when needed.

This issue was raised in #8951. It was also raised earlier in https://github.com/tensorflow/tensorflow/issues/206#issuecomment-259076860

This fix fixes #8951.