### PR TITLE
fix windows gpu build by disabling nccl which currently will not compile/work on windows

### DIFF
--- a/tensorflow/contrib/cmake/tf_core_kernels.cmake
+++ b/tensorflow/contrib/cmake/tf_core_kernels.cmake
@@ -102,6 +102,10 @@ if(WIN32)
       "${tensorflow_source_dir}/tensorflow/contrib/rnn/kernels/lstm_ops.cc"
       "${tensorflow_source_dir}/tensorflow/contrib/rnn/ops/gru_ops.cc"
       "${tensorflow_source_dir}/tensorflow/contrib/rnn/ops/lstm_ops.cc"
+      # temporarily disable nccl (nccl itself needs to be ported to windows first)
+      "${tensorflow_source_dir}/tensorflow/contrib/nccl/kernels/nccl_manager.cc"
+      "${tensorflow_source_dir}/tensorflow/contrib/nccl/kernels/nccl_ops.cc"
+      "${tensorflow_source_dir}/tensorflow/contrib/nccl/ops/nccl_ops.cc"
   )
   list(REMOVE_ITEM tf_core_kernels_srcs ${tf_core_kernels_windows_exclude_srcs})
 endif(WIN32)


### PR DESCRIPTION
Windows gpu builds got broken because nccl was include in cmake (https://github.com/tensorflow/tensorflow/commit/08a3e36c97a644377c07d39d6c707d1abfb2c394). 
nccl currently does not compile/work on windows (unfortunate). To make nccl compile/work is more work so I disable the nccl op from windows for now to make the gpu build happy. There is a PR (https://github.com/NVIDIA/nccl/pull/31) for nccl that makes it mostly work on windows ... watching that and if merged we can try to make this work.
