### PR TITLE
CPU kernels for FFT (WIP)

### DIFF
--- a/tensorflow/core/kernels/fft_ops.cc
+++ b/tensorflow/core/kernels/fft_ops.cc
@@ -84,7 +84,7 @@ class FFTBase : public OpKernel {
   virtual bool IsForward() const = 0;
   virtual bool IsReal() const = 0;
 
-  // The function that actually computes the FFT
+  // The function that actually computes the FFT.
   virtual void DoFFT(OpKernelContext* ctx, const Tensor& in, uint64* fft_shape,
                      Tensor* out) = 0;
 };
@@ -96,17 +96,11 @@ template <typename Device, typename TInput, typename TOutput,
 struct FFTFunctor {
   void operator()(const Device& d,
                   typename TTypes<TOutput, FFTRank + 1>::Tensor output,
-                  typename TTypes<TInput, FFTRank + 1>::ConstTensor input) {
-      // Cast to non-const data type to ensure we can call the template fft
-      // function
-      // TODO(tillahoffmann): Remove reinterpret_cast once Eigen supports const
-      // arguments for tensor fft
-      auto casted_input =
-       *reinterpret_cast<typename TTypes<TInput, FFTRank + 1>::Tensor*>(&input);
-      // Create the axes (which are always trailing)
+                  typename TTypes<TInput, FFTRank + 1>::Tensor input) {
+      // Create the axes (which are always trailing).
       auto axes = Eigen::ArrayXi::LinSpaced(FFTRank, 1, FFTRank);
-      // Evaluate the fft on the specified device
-      output.device(d) = casted_input.template fft<FFTResultType, FFTDir>(axes);
+      // Evaluate the fft on the specified device.
+      output.device(d) = input.template fft<FFTResultType, FFTDir>(axes);
   }
 };
 
@@ -122,11 +116,11 @@ class FFTCPU : public FFTBase {
   void DoFFT(OpKernelContext* ctx, const Tensor& in, uint64* fft_shape,
              Tensor* out) override {
     // TODO(tillahoffmann): Support RFFTs by slicing away the negative
-    // frequency components
+    // frequency components.
     OP_REQUIRES(ctx, !IsReal(), errors::Internal("Real FFT not supported."));
-    auto input = in.flat_inner_dims<complex64, FFTRank + 1>();
+    auto input = ((Tensor) in).flat_inner_dims<complex64, FFTRank + 1>();
 
-    // Apply the functor
+    // Apply the functor.
     FFTFunctor<CPUDevice, complex64, complex64, Eigen::BothParts,
                Forward ? Eigen::FFT_FORWARD : Eigen::FFT_REVERSE,
                FFTRank> functor;

--- a/tensorflow/python/kernel_tests/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/fft_ops_test.py
@@ -39,30 +39,28 @@ class BaseFFTOpsTest(test.TestCase):
     self._CompareBackward(x, rank, fft_length, use_placeholder)
 
   def _CompareForward(self, x, rank, fft_length=None, use_placeholder=False):
-    if test.is_gpu_available(cuda_only=True):
-      x_np = self._npFFT(x, rank, fft_length)
-      if use_placeholder:
-        x_ph = array_ops.placeholder(dtype=dtypes.as_dtype(x.dtype))
-        x_tf = self._tfFFT(x_ph, rank, fft_length, use_gpu=True,
-                           feed_dict={x_ph: x})
-      else:
-        x_tf = self._tfFFT(x, rank, fft_length, use_gpu=True)
+    x_np = self._npFFT(x, rank, fft_length)
+    if use_placeholder:
+      x_ph = array_ops.placeholder(dtype=dtypes.as_dtype(x.dtype))
+      x_tf = self._tfFFT(x_ph, rank, fft_length, use_gpu=True,
+                          feed_dict={x_ph: x})
+    else:
+      x_tf = self._tfFFT(x, rank, fft_length, use_gpu=True)
 
-      # GPU/Forward
-      self.assertAllClose(x_np, x_tf, rtol=1e-4, atol=1e-4)
+    # GPU/Forward
+    self.assertAllClose(x_np, x_tf, rtol=1e-4, atol=1e-4)
 
   def _CompareBackward(self, x, rank, fft_length=None, use_placeholder=False):
-    if test.is_gpu_available(cuda_only=True):
-      x_np = self._npIFFT(x, rank, fft_length)
-      if use_placeholder:
-        x_ph = array_ops.placeholder(dtype=dtypes.as_dtype(x.dtype))
-        x_tf = self._tfIFFT(x_ph, rank, fft_length, use_gpu=True,
-                            feed_dict={x_ph: x})
-      else:
-        x_tf = self._tfIFFT(x, rank, fft_length, use_gpu=True)
+    x_np = self._npIFFT(x, rank, fft_length)
+    if use_placeholder:
+      x_ph = array_ops.placeholder(dtype=dtypes.as_dtype(x.dtype))
+      x_tf = self._tfIFFT(x_ph, rank, fft_length, use_gpu=True,
+                          feed_dict={x_ph: x})
+    else:
+      x_tf = self._tfIFFT(x, rank, fft_length, use_gpu=True)
 
-      # GPU/Backward
-      self.assertAllClose(x_np, x_tf, rtol=1e-4, atol=1e-4)
+    # GPU/Backward
+    self.assertAllClose(x_np, x_tf, rtol=1e-4, atol=1e-4)
 
   def _checkGradComplex(self, func, x, y, result_is_complex=True,
                         use_gpu=False):
@@ -151,12 +149,11 @@ class FFTOpsTest(BaseFFTOpsTest):
       raise ValueError("invalid rank")
 
   def testEmpty(self):
-    if test.is_gpu_available(cuda_only=True):
-      for rank in VALID_FFT_RANKS:
-        for dims in xrange(rank, rank + 3):
-          x = np.zeros((0,) * dims).astype(np.complex64)
-          self.assertEqual(x.shape, self._tfFFT(x, rank).shape)
-          self.assertEqual(x.shape, self._tfIFFT(x, rank).shape)
+    for rank in VALID_FFT_RANKS:
+      for dims in xrange(rank, rank + 3):
+        x = np.zeros((0,) * dims).astype(np.complex64)
+        self.assertEqual(x.shape, self._tfFFT(x, rank).shape)
+        self.assertEqual(x.shape, self._tfIFFT(x, rank).shape)
 
   def testBasic(self):
     for rank in VALID_FFT_RANKS:
@@ -184,40 +181,47 @@ class FFTOpsTest(BaseFFTOpsTest):
         self._Compare(gen((4,) * dims), rank)
 
   def testError(self):
-    if test.is_gpu_available(cuda_only=True):
-      for rank in VALID_FFT_RANKS:
-        for dims in xrange(0, rank):
-          x = np.zeros((1,) * dims).astype(np.complex64)
-          with self.assertRaisesWithPredicateMatch(
-              ValueError, "Shape must be .*rank {}.*".format(rank)):
-            self._tfFFT(x, rank)
-          with self.assertRaisesWithPredicateMatch(
-              ValueError, "Shape must be .*rank {}.*".format(rank)):
-            self._tfIFFT(x, rank)
+    for rank in VALID_FFT_RANKS:
+      for dims in xrange(0, rank):
+        x = np.zeros((1,) * dims).astype(np.complex64)
+        with self.assertRaisesWithPredicateMatch(
+            ValueError, "Shape must be .*rank {}.*".format(rank)):
+          self._tfFFT(x, rank)
+        with self.assertRaisesWithPredicateMatch(
+            ValueError, "Shape must be .*rank {}.*".format(rank)):
+          self._tfIFFT(x, rank)
 
   def testGrad_Simple(self):
-    if test.is_gpu_available(cuda_only=True):
-      for rank in VALID_FFT_RANKS:
-        for dims in xrange(rank, rank + 2):
-          re = np.ones(shape=(4,) * dims, dtype=np.float32) / 10.0
-          im = np.zeros(shape=(4,) * dims, dtype=np.float32)
-          self._checkGradComplex(self._tfFFTForRank(rank), re, im, use_gpu=True)
-          self._checkGradComplex(
-              self._tfIFFTForRank(rank), re, im, use_gpu=True)
+    for rank in VALID_FFT_RANKS:
+      for dims in xrange(rank, rank + 2):
+        re = np.ones(shape=(4,) * dims, dtype=np.float32) / 10.0
+        im = np.zeros(shape=(4,) * dims, dtype=np.float32)
+        self._checkGradComplex(self._tfFFTForRank(rank), re, im, use_gpu=True)
+        self._checkGradComplex(
+            self._tfIFFTForRank(rank), re, im, use_gpu=True)
 
   def testGrad_Random(self):
-    if test.is_gpu_available(cuda_only=True):
-      np.random.seed(54321)
-      for rank in VALID_FFT_RANKS:
-        for dims in xrange(rank, rank + 2):
-          re = np.random.rand(*((3,) * dims)).astype(np.float32) * 2 - 1
-          im = np.random.rand(*((3,) * dims)).astype(np.float32) * 2 - 1
-          self._checkGradComplex(self._tfFFTForRank(rank), re, im, use_gpu=True)
-          self._checkGradComplex(
-              self._tfIFFTForRank(rank), re, im, use_gpu=True)
+    np.random.seed(54321)
+    for rank in VALID_FFT_RANKS:
+      for dims in xrange(rank, rank + 2):
+        re = np.random.rand(*((3,) * dims)).astype(np.float32) * 2 - 1
+        im = np.random.rand(*((3,) * dims)).astype(np.float32) * 2 - 1
+        self._checkGradComplex(self._tfFFTForRank(rank), re, im, use_gpu=True)
+        self._checkGradComplex(
+            self._tfIFFTForRank(rank), re, im, use_gpu=True)
 
 
 class RFFTOpsTest(BaseFFTOpsTest):
+
+  def _CompareForward(self, x, rank, fft_length=None, use_placeholder=False):
+    if test.is_gpu_available(cuda_only=True):
+      super(RFFTOpsTest, self)._CompareForward(x, rank, fft_length,
+                                               use_placeholder)
+
+  def _CompareBackward(self, x, rank, fft_length=None, use_placeholder=False):
+    if test.is_gpu_available(cuda_only=True):
+      super(RFFTOpsTest, self)._CompareBackward(x, rank, fft_length,
+                                                use_placeholder)
 
   def _tfFFT(self, x, rank, fft_length=None, use_gpu=False, feed_dict=None):
     with self.test_session(use_gpu=use_gpu):

--- a/tensorflow/python/kernel_tests/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/fft_ops_test.py
@@ -213,16 +213,6 @@ class FFTOpsTest(BaseFFTOpsTest):
 
 class RFFTOpsTest(BaseFFTOpsTest):
 
-  def _CompareForward(self, x, rank, fft_length=None, use_placeholder=False):
-    if test.is_gpu_available(cuda_only=True):
-      super(RFFTOpsTest, self)._CompareForward(x, rank, fft_length,
-                                               use_placeholder)
-
-  def _CompareBackward(self, x, rank, fft_length=None, use_placeholder=False):
-    if test.is_gpu_available(cuda_only=True):
-      super(RFFTOpsTest, self)._CompareBackward(x, rank, fft_length,
-                                                use_placeholder)
-
   def _tfFFT(self, x, rank, fft_length=None, use_gpu=False, feed_dict=None):
     with self.test_session(use_gpu=use_gpu):
       return self._tfFFTForRank(rank)(x, fft_length).eval(feed_dict=feed_dict)


### PR DESCRIPTION
This PR adds CPU kernels for FFTs (cf #386). A few points to note:

* This PR does not yet support RFFTs. These can in principle be implemented by slicing such that the negative frequency components of the FFT are removed. Maybe @benoitsteiner has some better ideas though.
* Does it make sense to split up the code into multiple files to avoid having `#if GOOGLE_CUDA` half way?
* @rryan, because the tensor FFT in Eigen is templated, I couldn't avoid bloating the binary a bit as discussed via e-mail.