### PR TITLE
set save_model_secs=60 in mnist_replica.py

### DIFF
--- a/tensorflow/tools/dist_test/python/mnist_replica.py
+++ b/tensorflow/tools/dist_test/python/mnist_replica.py
@@ -206,14 +206,16 @@ def main(unused_argv):
           init_op=init_op,
           local_init_op=local_init_op,
           ready_for_local_init_op=ready_for_local_init_op,
-          recovery_wait_secs=1,
+          save_model_secs=60,
+          recovery_wait_secs=10,
           global_step=global_step)
     else:
       sv = tf.train.Supervisor(
           is_chief=is_chief,
           logdir=train_dir,
           init_op=init_op,
-          recovery_wait_secs=1,
+          save_model_secs=60,
+          recovery_wait_secs=10,
           global_step=global_step)
 
     sess_config = tf.ConfigProto(


### PR DESCRIPTION
This would make restoring from a checkpoint more easily. The default value for save_model_secs is 600 which is relatively too long for this tutorial example model.