### PR TITLE
flatten inputs in tf.layers.dense

### DIFF
--- a/tensorflow/python/layers/core.py
+++ b/tensorflow/python/layers/core.py
@@ -136,10 +136,10 @@ class Dense(base._Layer):  # pylint: disable=protected-access
   def call(self, inputs):
     inputs = ops.convert_to_tensor(inputs, dtype=self.dtype)
     inputs_rank = inputs.get_shape().ndims
-    output_shape = shape[:1] + [self.units]
+    inputs_shape = array_ops.shape(inputs)
+    output_shape = [inputs_shape[0].value] + [self.units]
 
     if inputs_rank > 2:
-      inputs_shape = array_ops.shape(inputs)
       batch_dim = array_ops.slice(inputs_shape, [0], [1])
       spatial_dims = array_ops.slice(inputs_shape, [1], [inputs_rank - 1])
 

--- a/tensorflow/python/layers/core.py
+++ b/tensorflow/python/layers/core.py
@@ -29,6 +29,7 @@ import numpy as np
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import nn
 from tensorflow.python.ops import standard_ops
@@ -136,10 +137,10 @@ class Dense(base._Layer):  # pylint: disable=protected-access
   def call(self, inputs):
     inputs = ops.convert_to_tensor(inputs, dtype=self.dtype)
     inputs_rank = inputs.get_shape().ndims
-    inputs_shape = array_ops.shape(inputs)
-    output_shape = [inputs_shape[0].value] + [self.units]
+    output_shape = inputs.get_shape().as_list()[:1] + [self.units]
 
     if inputs_rank > 2:
+      inputs_shape = array_ops.shape(inputs)
       batch_dim = array_ops.slice(inputs_shape, [0], [1])
       spatial_dims = array_ops.slice(inputs_shape, [1], [inputs_rank - 1])
 

--- a/tensorflow/python/layers/core_test.py
+++ b/tensorflow/python/layers/core_test.py
@@ -102,11 +102,11 @@ class DenseTest(test.TestCase):
 
     inputs = random_ops.random_uniform((5, 2, 3), seed=1)
     outputs = dense(inputs)
-    self.assertEqual(outputs.get_shape().as_list(), [5, 2, 7])
+    self.assertEqual(outputs.get_shape().as_list(), [5, 7])
 
     inputs = random_ops.random_uniform((1, 2, 4, 3), seed=1)
     outputs = dense.apply(inputs)
-    self.assertEqual(outputs.get_shape().as_list(), [1, 2, 4, 7])
+    self.assertEqual(outputs.get_shape().as_list(), [1, 7])
 
   def testCallOnPlaceHolder(self):
     inputs = array_ops.placeholder(dtype=dtypes.float32)

--- a/tensorflow/python/layers/core_test.py
+++ b/tensorflow/python/layers/core_test.py
@@ -131,7 +131,8 @@ class DenseTest(test.TestCase):
 
     inputs = array_ops.placeholder(dtype=dtypes.float32, shape=[None, None, 3])
     dense = core_layers.Dense(4, name='my_dense')
-    dense(inputs)
+    with self.assertRaises(ValueError):
+      dense(inputs)
 
   def testActivation(self):
     dense = core_layers.Dense(2, activation=nn_ops.relu, name='dense1')
@@ -281,7 +282,7 @@ class DenseTest(test.TestCase):
         [None, 2],
         dense._compute_output_shape(ts([None, 3])).as_list())
     self.assertEqual(
-        [None, 4, 2],
+        [None, 2],
         dense._compute_output_shape(ts([None, 4, 3])).as_list())
     # pylint: enable=protected-access
 


### PR DESCRIPTION
In the document of `tf.layers.dense` is writen that: 

> Note: if the inputs tensor has a rank greater than 2, then it is flattened prior to the initial matrix multiply by kernel.

but inputs is not flattened.

I modified that to flatten inputs.