### PR TITLE
Add documentation about extra update ops to tf.layers.batch_normalization

### DIFF
--- a/tensorflow/python/layers/normalization.py
+++ b/tensorflow/python/layers/normalization.py
@@ -267,9 +267,9 @@ def batch_normalization(inputs,
 
   Sergey Ioffe, Christian Szegedy
 
-  Note: the operations which update moving_mean and moving_variance will not be
-  added as dependencies of your training operation and so must be run
-  separately. For example:
+  Note: the operations which update the `moving_mean` and `moving_variance`
+  variables will not be added as dependencies of your training operation and so
+  must be run separately. For example:
   ```
   extra_update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
   sess.run([train_op, extra_update_ops], ...)

--- a/tensorflow/python/layers/normalization.py
+++ b/tensorflow/python/layers/normalization.py
@@ -267,6 +267,23 @@ def batch_normalization(inputs,
 
   Sergey Ioffe, Christian Szegedy
 
+  Note: the operations which update moving_mean and moving_variance will not be
+  added as dependencies of your training operation and so must be run
+  separately. For example:
+  ```
+  extra_update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
+  sess.run([train_op, extra_update_ops], ...)
+  ```
+  Alternatively, add the operations as a dependency to your training operation
+  manually, and then just run your training operation as normal:
+  ```
+  extra_update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
+  with tf.control_dependencies(extra_update_ops):
+    train_op = optimizer.minimize(loss)
+  ...
+  sess.run([train_op], ...)
+  ```
+
   Arguments:
     inputs: Tensor input.
     axis: Integer, the axis that should be normalized (typically the features


### PR DESCRIPTION
`tf.layers.batch_normalization` uses extra ops for updating its moving_mean and moving_variance variables, but these are added to the graph in such a way that they will not be a dependency of the main training op. Instead, they must be run separately, accessed through the `tf.GraphKeys.UPDATE_OPS` collection. This was explained in the documentation for `tf.contrib.layers.batch_norm`, but this information seems not to have survived the transition to `tf.layers.batch_normalization`.

Long term, if possible, it would be really nice if we didn't have to do anything extra to get these update operations to work. But in the meantime, here's a patch for the documentation which explains how to make sure the extra ops do get run.