### PR TITLE
Tensorboard change NPM script name prepare to prep

### DIFF
--- a/tensorflow/tensorboard/DEVELOPMENT.md
+++ b/tensorflow/tensorboard/DEVELOPMENT.md
@@ -21,7 +21,7 @@ Then, cd into the TensorBoard directory:
 
 and install dependencies:
 
-`npm run prepare`
+`npm run prep`
 
 Then, run gulp: `gulp`
 

--- a/tensorflow/tensorboard/package.json
+++ b/tensorflow/tensorboard/package.json
@@ -4,7 +4,7 @@
   "description": "Visualizers for TensorFlow",
   "scripts": {
     "test": "gulp test",
-    "prepare": "npm install && bower install && typings install",
+    "prep": "npm install && bower install && typings install",
     "compile": "gulp compile"
   },
   "keywords": [


### PR DESCRIPTION
NPM 4.3 now calls the 'prepare' script as part of the install process.
As a result, running 'npm install' or 'npm run prepare' causes an
infinite loop. This removes the infinite loop. Relates to issue #8326 