### PR TITLE
fix example typo (too many brackets)

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/run_config.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/run_config.py
@@ -88,9 +88,9 @@ class ClusterConfig(object):
     ```
       cluster = {'ps': ['host1:2222', 'host2:2222'],
                  'worker': ['host3:2222', 'host4:2222', 'host5:2222']}
-      os.environ['TF_CONFIG'] = json.dumps({
+      os.environ['TF_CONFIG'] = json.dumps(
           {'cluster': cluster,
-           'task': {'type': 'worker', 'index': 1}}})
+           'task': {'type': 'worker', 'index': 1}})
       config = ClusterConfig()
       assert config.master == 'host4:2222'
       assert config.task_id == 1


### PR DESCRIPTION
The example was like `json.dumps({{}})`, which fails because `{{}}` is not a valid data structure.

Also, just below this, there is `assert config.master == 'host4:2222'`, which I believe would fail since that value comes back as `'grpc://host4:2222'`, but I'm less sure about recommending this change.