### PR TITLE
Correction to word2vec exercise.

### DIFF
--- a/tensorflow/examples/udacity/5_word2vec.ipynb
+++ b/tensorflow/examples/udacity/5_word2vec.ipynb
@@ -339,6 +339,8 @@
         "  batch = np.ndarray(shape=(batch_size), dtype=np.int32)\n",
         "  labels = np.ndarray(shape=(batch_size, 1), dtype=np.int32)\n",
         "  span = 2 * skip_window + 1 # [ skip_window target skip_window ]\n",
+        "  if data_index > len(data) - span:\n"
+        "    data_index = 0 # don't split span across beginning and end of data\n"
         "  buffer = collections.deque(maxlen=span)\n",
         "  for _ in range(span):\n",
         "    buffer.append(data[data_index])\n",


### PR DESCRIPTION
In its existing form, `2 * skip_window` training examples for the skip gram model are incorrect because they draw context words from both the beginning and end of `data`.

I have an individual CLA with Google already.