### PR TITLE
Update input.py

### DIFF
--- a/tensorflow/python/training/input.py
+++ b/tensorflow/python/training/input.py
@@ -221,7 +221,7 @@ def string_input_producer(string_tensor,
       string_tensor = array_ops.identity(string_tensor)
     return input_producer(
         input_tensor=string_tensor,
-        element_shape=[],
+        element_shape=None,
         num_epochs=num_epochs,
         shuffle=shuffle,
         seed=seed,


### PR DESCRIPTION
When the input tensor of the tf.train.string_input_producer() is not fully defined (as a tf.placeholder(tf.string, ...)), then the element_shape is set as '[ ]'. There will raise a ValueError in line 150 "element_shape = input_tensor.get_shape()[1:].merge_with(element_shape)", since the input of the element is '[ ]', shapes will be not compatible. So I suggest the default 'element_shape' value should be set as 'None'.