### PR TITLE
Add Windows link to "Common installation problems"

### DIFF
--- a/tensorflow/docs_src/install/install_sources.md
+++ b/tensorflow/docs_src/install/install_sources.md
@@ -367,6 +367,7 @@ of one of the following guides:
 
   * @{$install_linux#CommonInstallationProblems$Installing TensorFlow on Linux}
   * @{$install_mac#CommonInstallationProblems$Installing TensorFlow on Mac OS}
+  * @{$install_windows#CommonInstallationProblems$Installing TensorFlow on Windows}
 
 Beyond the errors documented in those two guides, the following table
 notes additional errors specific to building TensorFlow.  Note that we


### PR DESCRIPTION
The link we provide our users when `import tensorflow` fails only points to Linux and Mac OS. Add a link to the Windows instructions to match.