### PR TITLE
Mofify seq2seq.py

### DIFF
--- a/tensorflow/contrib/legacy_seq2seq/python/ops/seq2seq.py
+++ b/tensorflow/contrib/legacy_seq2seq/python/ops/seq2seq.py
@@ -792,6 +792,7 @@ def embedding_attention_seq2seq(encoder_inputs,
                                 num_encoder_symbols,
                                 num_decoder_symbols,
                                 embedding_size,
+                                encoder_cell=None,
                                 num_heads=1,
                                 output_projection=None,
                                 feed_previous=False,
@@ -818,6 +819,9 @@ def embedding_attention_seq2seq(encoder_inputs,
     num_encoder_symbols: Integer; number of symbols on the encoder side.
     num_decoder_symbols: Integer; number of symbols on the decoder side.
     embedding_size: Integer, the length of the embedding vector for each symbol.
+    encoder_cell: core_rnn_cell.RNNCell defining the encoder_cell function and
+      size. This allows user to explicitly provide a cell for the encoding step.
+      If it's none (default), deepcopy the 'cell' arg.
     num_heads: Number of attention heads that read from attention_states.
     output_projection: None or a pair (W, B) of output projection weights and
       biases; W has shape [output_size x num_decoder_symbols] and B has
@@ -846,7 +850,8 @@ def embedding_attention_seq2seq(encoder_inputs,
       scope or "embedding_attention_seq2seq", dtype=dtype) as scope:
     dtype = scope.dtype
     # Encoder.
-    encoder_cell = copy.deepcopy(cell)
+    if encoder_cell is None:
+      encoder_cell = copy.deepcopy(cell)
     encoder_cell = core_rnn_cell.EmbeddingWrapper(
         encoder_cell,
         embedding_classes=num_encoder_symbols,


### PR DESCRIPTION
Modify the tf.contrib.legacy_seq2seq.embedding_attention_seq2seq so that it allows user to explicitly provide a second cell for the encoding step, and if it's None then to fallback on the deepcopy.