### PR TITLE
fix filter position for Im2Col

### DIFF
--- a/tensorflow/core/kernels/quantized_conv_ops.cc
+++ b/tensorflow/core/kernels/quantized_conv_ops.cc
@@ -233,9 +233,9 @@ class Im2ColConvFunctor {
     int filter_top_offset;
     if (padding == VALID) {
       filter_left_offset =
-          ((output_width - 1) * stride + filter_width - input_width) / 2;
+          ((output_width - 1) * stride + filter_width - input_width + 1) / 2;
       filter_top_offset =
-          ((output_height - 1) * stride + filter_height - input_height) / 2;
+          ((output_height - 1) * stride + filter_height - input_height + 1) / 2;
     } else {
       filter_left_offset =
           ((output_width - 1) * stride + filter_width - input_width) / 2;


### PR DESCRIPTION
cac52fdebb292bc7706383d07c7987be66882085 fixed the filter position for
the reference class but the same problem exists in the Im2Col class.

This patch makes the calculation of the filter position consistent
with the reference quantized class and the gemm/fused conv_ops
classes.

@petewarden you reviewed the reference class fix. Would you have the time to review this too?