### PR TITLE
Enable protobuf's --with-pic option

### DIFF
--- a/tensorflow/contrib/makefile/compile_linux_protobuf.sh
+++ b/tensorflow/contrib/makefile/compile_linux_protobuf.sh
@@ -38,7 +38,7 @@ then
   exit 1
 fi
 
-./configure --prefix="${GENDIR}"
+./configure --prefix="${GENDIR}" --with-pic
 if [ $? -ne 0 ]
 then
   echo "./configure command failed."


### PR DESCRIPTION
This PR only applies to **contrib/makefile** project.

`libtensorflow-core.a` static library is built with position independent code (i.e., -fPIC option), however, `libprotobuf.a` static library is not. This MR enables the protobuf's `--with-pic` option in order to be able to use `libprotobuf.a` when building a shared library.