### PR TITLE
Updated the link to tensorflow.org to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Hello, TensorFlow!
 
 ## For more information
 
-* [TensorFlow website](http://tensorflow.org)
+* [TensorFlow website](https://tensorflow.org)
 * [TensorFlow whitepaper](http://download.tensorflow.org/paper/whitepaper2015.pdf)
 * [TensorFlow Model Zoo](https://github.com/tensorflow/models)
 * [TensorFlow MOOC on Udacity](https://www.udacity.com/course/deep-learning--ud730)


### PR DESCRIPTION
This is a very minor change. 

I just updated the link to tensorflow.org so that it uses https instead of http, and users aren't redirected. 

^ _ ^