### PR TITLE
In non-devel Docker images, positively confirm --allow-root (#9021)

### DIFF
--- a/tensorflow/tools/docker/Dockerfile
+++ b/tensorflow/tools/docker/Dockerfile
@@ -66,4 +66,4 @@ EXPOSE 8888
 
 WORKDIR "/notebooks"
 
-CMD ["/run_jupyter.sh"]
+CMD ["/run_jupyter.sh", "--allow-root"]

--- a/tensorflow/tools/docker/Dockerfile.gpu
+++ b/tensorflow/tools/docker/Dockerfile.gpu
@@ -69,4 +69,4 @@ EXPOSE 8888
 
 WORKDIR "/notebooks"
 
-CMD ["/run_jupyter.sh"]
+CMD ["/run_jupyter.sh", "--allow-root"]


### PR DESCRIPTION
to avoid an error that started to happen recently:
[C 10:09:34.858 NotebookApp] Running as root is not recommended. Use
--allow-root to bypass.

E.g., see
http://ci.tensorflow.org/view/Nightly/job/nightly-docker-cpu/TF_DOCKER_BUILD_IS_DEVEL=NO,TF_DOCKER_BUILD_PYTHON_VERSION=PYTHON2,label=gcs-access/361/console