### PR TITLE
Fixing anaconda install command

### DIFF
--- a/tensorflow/docs_src/install/install_windows.md
+++ b/tensorflow/docs_src/install/install_windows.md
@@ -103,7 +103,7 @@ Take the following steps to install TensorFlow in an Anaconda environment:
   2. Create a conda environment named <tt>tensorflow</tt>
      by invoking the following command:
 
-     <pre>C:\> <b>conda create -n tensorflow</b> </pre>
+     <pre>C:\> <b>conda create -n tensorflow python=3.5</b> </pre>
 
   3. Activate the conda environment by issuing the following command:
 


### PR DESCRIPTION
3.6 is the standard python version of anaconda. In order to get tensorflow installed correctly, version 3.5 is needed. Passing the exact version of python to the anaconda environment is necessary.