### PR TITLE
Store step stats in benchmark model and use python timeline to visual…

### DIFF
--- a/tensorflow/tools/benchmark/README.md
+++ b/tensorflow/tools/benchmark/README.md
@@ -55,3 +55,11 @@ $bazel-bin/tensorflow/tools/benchmark/benchmark_model \
 
 The Inception graph used as an example here may be downloaded from
 https://storage.googleapis.com/download.tensorflow.org/models/inception5h.zip
+
+## To visualize benchmark
+
+Since [timeline](https://github.com/tensorflow/tensorflow/blob/27711108b5fce2e1692f9440631a183b3808fa01/tensorflow/python/client/timeline.py) is a python only visualization tool, we need to write collected **StepStats** to a file and then use timeline to generate JSON-formatted file in Chrome Trace format.
+
+To store collected **StepStats**, set `benchmark_model`' s `--step_stats_name` flag to the name of the file you want to write to.
+
+To generate Chrome Trace format, run `transform_chrome_trace.py` directly with **StepStats** file and desired JSON file as arguments. Navigate to `chrome://tracing` to visualize the benchmark.

--- a/tensorflow/tools/benchmark/benchmark_model.h
+++ b/tensorflow/tools/benchmark/benchmark_model.h
@@ -38,7 +38,8 @@ Status InitializeSession(int num_threads, const string& graph,
 // Does a single run of the model that's been loaded into the given session.
 Status RunBenchmark(const std::vector<InputLayerInfo>& inputs,
                     const std::vector<string>& outputs, Session* session,
-                    StatSummarizer* stats, int64* inference_time_us);
+                    StatSummarizer* stats, int64* inference_time_us,
+                    StepStats* step_stats_out=nullptr);
 
 // Runs the model multiple time, keeping track of timing information.
 Status TimeMultipleRuns(double sleep_seconds, int num_runs,

--- a/tensorflow/tools/benchmark/transform_chrome_trace.py
+++ b/tensorflow/tools/benchmark/transform_chrome_trace.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+""" Transform dumped step stats to chrome formatted timeline json file
+"""
+
+import argparse
+import json
+import pdb
+
+import tensorflow as tf
+from tensorflow.python.client import timeline
+from tensorflow.core.framework.step_stats_pb2 import StepStats
+
+def main():
+    parser = argparse.ArgumentParser(description='Transform dumped step stats to chrome formatted timeline json file')
+    parser.add_argument('step_stats', help='dumped step stats file')
+    parser.add_argument('output', help='json file to save to')
+    args = parser.parse_args()
+    with open(args.step_stats) as step_stats_file:
+        step_stats = StepStats()
+        step_stats.ParseFromString(step_stats_file.read())
+    trace = timeline.Timeline(step_stats=step_stats)
+    with open(args.output, 'w') as output_file:
+        output_file.write(trace.generate_chrome_trace_format())
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
…ize it

Since [timeline](https://github.com/tensorflow/tensorflow/blob/27711108b5fce2e1692f9440631a183b3808fa01/tensorflow/python/client/timeline.py) is a python only visualization tool. To visualize benchmark_model, we need to write collected **StepStats** to a file and then use timeline to generate JSON-formatted file in Chrome Trace format.