### PR TITLE
tf.train.Saver: be verbose about ckpt load errors

### DIFF
--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -935,11 +935,11 @@ def get_checkpoint_state(checkpoint_dir, latest_filename=None):
           ckpt.all_model_checkpoint_paths[i] = os.path.join(checkpoint_dir, p)
   except errors.OpError as e:
     # It's ok if the file cannot be read
-    logging.warning(str(e))
+    logging.warning("%s: %s" % (type(e).__name__, e))
     logging.warning("%s: Checkpoint ignored", coord_checkpoint_filename)
     return None
   except text_format.ParseError as e:
-    logging.warning(str(e))
+    logging.warning("%s: %s" % (type(e).__name__, e))
     logging.warning("%s: Checkpoint ignored", coord_checkpoint_filename)
     return None
   finally:


### PR DESCRIPTION
I've just had an AbortedError which resulted in the following log:
```
WARNING:tensorflow:/path/to/checkpoint
WARNING:tensorflow:/path/to/checkpoint: Checkpoint ignored
```

With this addition, I get

```
WARNING:tensorflow:tensorflow.python.framework.errors_impl.AbortedError: /path/to/checkpoint
WARNING:tensorflow:/path/to/checkpoint: Checkpoint ignored
```

which is a bit nicer.