### PR TITLE
Update resnet_v2.py

### DIFF
--- a/tensorflow/contrib/slim/python/slim/nets/resnet_v2.py
+++ b/tensorflow/contrib/slim/python/slim/nets/resnet_v2.py
@@ -63,6 +63,8 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import variable_scope
 
+resnet_arg_scope = resnet_utils.resnet_arg_scope
+
 
 @add_arg_scope
 def bottleneck(inputs,


### PR DESCRIPTION
I've added "resnet_arg_scope = resnet_utils.resnet_arg_scope" line to make sure that user can call resnet_v2.resnet_arg_scope(is_training). It is also present in resnet_v1.py