### PR TITLE
Fix issue where TensorBoard run selector can become non-responsive.

### DIFF
--- a/tensorflow/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.html
+++ b/tensorflow/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.html
@@ -183,6 +183,7 @@ handle these situations gracefully.
       // if undefined, default value (enable for first k runs, disable after).
         type: Object,
         value: TF.URIStorage.getObjectInitializer('runSelectionState', {}),
+        observer: "_storeRunToIsCheckedMapping",
       },
       // (Allows state to persist across regex filtering)
       outSelected: {
@@ -231,24 +232,7 @@ handle these situations gracefully.
     },
     observers: [
       "_setIsolatorIcon(runSelectionState, names)",
-      "_storeRunToIsCheckedMappingWithDefault(runSelectionState, namesMatchingRegex)",
     ],
-    _storeRunToIsCheckedMappingWithDefault() {
-      var runSelectionStateIsDefault = Object.keys(this.runSelectionState).length == 0;
-      if (runSelectionStateIsDefault || this.namesMatchingRegex == null) {
-        return;
-      }
-      var _this = this;
-      var allToggledOn = this.namesMatchingRegex
-              .every(function(n) {return _this.runSelectionState[n]});
-      var allToggledOff = this.namesMatchingRegex
-              .every(function(n) {return !_this.runSelectionState[n]});
-      var defaultOff = this.namesMatchingRegex.length > this.maxRunsToEnableByDefault;
-      if (defaultOff && allToggledOff || !defaultOff && allToggledOn) {
-        this.runSelectionState = {};
-      }
-      this._storeRunToIsCheckedMapping(this.runSelectionState);
-    },
     _storeRunToIsCheckedMapping: TF.URIStorage.getObjectObserver('runSelectionState', {}),
     _makeRegex: function(regex) {
       try {

--- a/tensorflow/tensorboard/dist/tf-tensorboard.html
+++ b/tensorflow/tensorboard/dist/tf-tensorboard.html
@@ -3325,6 +3325,7 @@ var Categorizer;
       // if undefined, default value (enable for first k runs, disable after).
         type: Object,
         value: TF.URIStorage.getObjectInitializer('runSelectionState', {}),
+        observer: "_storeRunToIsCheckedMapping",
       },
       // (Allows state to persist across regex filtering)
       outSelected: {
@@ -3373,24 +3374,7 @@ var Categorizer;
     },
     observers: [
       "_setIsolatorIcon(runSelectionState, names)",
-      "_storeRunToIsCheckedMappingWithDefault(runSelectionState, namesMatchingRegex)",
     ],
-    _storeRunToIsCheckedMappingWithDefault() {
-      var runSelectionStateIsDefault = Object.keys(this.runSelectionState).length == 0;
-      if (runSelectionStateIsDefault || this.namesMatchingRegex == null) {
-        return;
-      }
-      var _this = this;
-      var allToggledOn = this.namesMatchingRegex
-              .every(function(n) {return _this.runSelectionState[n]});
-      var allToggledOff = this.namesMatchingRegex
-              .every(function(n) {return !_this.runSelectionState[n]});
-      var defaultOff = this.namesMatchingRegex.length > this.maxRunsToEnableByDefault;
-      if (defaultOff && allToggledOff || !defaultOff && allToggledOn) {
-        this.runSelectionState = {};
-      }
-      this._storeRunToIsCheckedMapping(this.runSelectionState);
-    },
     _storeRunToIsCheckedMapping: TF.URIStorage.getObjectObserver('runSelectionState', {}),
     _makeRegex: function(regex) {
       try {


### PR DESCRIPTION
Various dashboards in TensorBoard store the same runSelector state via the url bar. However, the text dashboard may have a different number of runs, because it only shows runs that have text data to display. Some logic that I added to try to keep the runSelector state short actually causes state updates to be lost when the text dashboard and scalar dashboard have very different numbers of runs. I removed the clever update logic in this commit.