### PR TITLE
decode the read bytes before passing to text_format.Merge

### DIFF
--- a/tensorflow/python/tools/freeze_graph.py
+++ b/tensorflow/python/tools/freeze_graph.py
@@ -117,7 +117,10 @@ def freeze_graph(input_graph,
         if input_binary:
           saver_def.ParseFromString(f.read())
         else:
-          text_format.Merge(f.read(), saver_def)
+          text = f.read()
+          if six.PY3:
+            text = text.decode()
+          text_format.Merge(text, saver_def)
         saver = saver_lib.Saver(saver_def=saver_def)
         saver.restore(sess, input_checkpoint)
     else:

--- a/tensorflow/python/tools/freeze_graph.py
+++ b/tensorflow/python/tools/freeze_graph.py
@@ -39,6 +39,7 @@ from __future__ import print_function
 
 import argparse
 import sys
+import six
 
 from google.protobuf import text_format
 
@@ -94,7 +95,7 @@ def freeze_graph(input_graph,
       input_graph_def.ParseFromString(f.read())
     else:
       text = f.read()
-      if sys.version_info > (3, 0):
+      if six.PY3:
         # The Merge function in the text_format module applies split('\n') upon its
         # first argument, which has type 'bytes' in Python3 and not compatible with
         # the '\n' in split('\n'). Thus decode() is required to transform text into

--- a/tensorflow/python/tools/freeze_graph.py
+++ b/tensorflow/python/tools/freeze_graph.py
@@ -73,7 +73,6 @@ def freeze_graph(input_graph,
   if not gfile.Exists(input_graph):
     print("Input graph file '" + input_graph + "' does not exist!")
     return -1
-  print(gfile.Exists(input_graph))
 
   if input_saver and not gfile.Exists(input_saver):
     print("Input saver file '" + input_saver + "' does not exist!")

--- a/tensorflow/python/tools/freeze_graph.py
+++ b/tensorflow/python/tools/freeze_graph.py
@@ -73,6 +73,7 @@ def freeze_graph(input_graph,
   if not gfile.Exists(input_graph):
     print("Input graph file '" + input_graph + "' does not exist!")
     return -1
+  print(gfile.Exists(input_graph))
 
   if input_saver and not gfile.Exists(input_saver):
     print("Input saver file '" + input_saver + "' does not exist!")
@@ -93,7 +94,14 @@ def freeze_graph(input_graph,
     if input_binary:
       input_graph_def.ParseFromString(f.read())
     else:
-      text_format.Merge(f.read().decode(), input_graph_def)
+      text = f.read()
+      if sys.version_info > (3, 0):
+        # The Merge function in the text_format module applies split('\n') upon its
+        # first argument, which has type 'bytes' in Python3 and not compatible with
+        # the '\n' in split('\n'). Thus decode() is required to transform text into
+        # a 'str' type object.
+        text = text.decode()
+      text_format.Merge(text, input_graph_def)
   # Remove all the explicit device specifications for this node. This helps to
   # make the graph more portable.
   if clear_devices:

--- a/tensorflow/python/tools/freeze_graph.py
+++ b/tensorflow/python/tools/freeze_graph.py
@@ -93,7 +93,7 @@ def freeze_graph(input_graph,
     if input_binary:
       input_graph_def.ParseFromString(f.read())
     else:
-      text_format.Merge(f.read(), input_graph_def)
+      text_format.Merge(f.read().decode(), input_graph_def)
   # Remove all the explicit device specifications for this node. This helps to
   # make the graph more portable.
   if clear_devices:


### PR DESCRIPTION
When using `freeze_graph.py` in Python 3, there will be error output as follows:

```
Traceback (most recent call last):
  File "../tensorflow/tensorflow/python/tools/freeze_graph.py", line 220, in <module>
    app.run(main=main, argv=[sys.argv[0]] + unparsed)
  File "$HOME/anaconda3/lib/python3.6/site-packages/tensorflow/python/platform/app.py", line 44, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "../tensorflow/tensorflow/python/tools/freeze_graph.py", line 152, in main
    FLAGS.variable_names_blacklist)
  File "../tensorflow/tensorflow/python/tools/freeze_graph.py", line 98, in freeze_graph
    text_format.Merge(text, input_graph_def)
  File "$HOME/anaconda3/lib/python3.6/site-packages/google/protobuf/text_format.py", line 472, in Merge
    text.split('\n'),
TypeError: a bytes-like object is required, not 'str'
```

After performing the fix in this patch, there will be no more `TypeError` like this.