### PR TITLE
Allocation tracking of pre-tracked buffer returned in a tuple should increment the buffer by 2

### DIFF
--- a/tensorflow/compiler/xla/service/allocation_tracker.cc
+++ b/tensorflow/compiler/xla/service/allocation_tracker.cc
@@ -64,8 +64,9 @@ GlobalDataHandle AllocationTracker::RegisterInternal(
     auto& allocation = FindOrDie(handle_to_allocation_, handle);
     int ref_count = allocation->ref_count();
     CHECK_GT(ref_count, 0);
-    VLOG(2) << "ref_count: " << ref_count << " -> " << ref_count + 1;
-    allocation->increment_ref_count();
+    VLOG(2) << "ref_count: " << ref_count << " -> " <<
+            (ref_count + initial_ref_count);
+    allocation->increment_ref_count(initial_ref_count);
   } else {
     handle = next_handle_++;
     VLOG(2) << "ref_count: " << initial_ref_count;

--- a/tensorflow/compiler/xla/service/allocation_tracker.h
+++ b/tensorflow/compiler/xla/service/allocation_tracker.h
@@ -65,7 +65,7 @@ class Allocation {
   }
   void increment_ref_count(int inc) {
     CHECK_GT(ref_count_, 0);
-    CHECK_GT(ref_count_+inc, 0);
+    CHECK_LT(ref_count_, INT_MAX-inc-1);
     ref_count_ += inc;
   }
   void decrement_ref_count() {

--- a/tensorflow/compiler/xla/service/allocation_tracker.h
+++ b/tensorflow/compiler/xla/service/allocation_tracker.h
@@ -65,7 +65,7 @@ class Allocation {
   }
   void increment_ref_count(int inc) {
     CHECK_GT(ref_count_, 0);
-    CHECK_LT(ref_count_, INT_MAX-inc-1);
+    CHECK_LE(ref_count_, INT_MAX - inc);
     ref_count_ += inc;
   }
   void decrement_ref_count() {

--- a/tensorflow/compiler/xla/service/allocation_tracker.h
+++ b/tensorflow/compiler/xla/service/allocation_tracker.h
@@ -63,10 +63,10 @@ class Allocation {
     CHECK_GE(ref_count_, 0);
     return ref_count_;
   }
-  void increment_ref_count() {
+  void increment_ref_count(int inc) {
     CHECK_GT(ref_count_, 0);
-    CHECK_LT(ref_count_, INT_MAX);
-    ++ref_count_;
+    CHECK_GT(ref_count_+inc, 0);
+    ref_count_ += inc;
   }
   void decrement_ref_count() {
     CHECK_GT(ref_count_, 0);


### PR DESCRIPTION
A buffer not pre-tracked has its ref-count set to 2 when it is part of a tuple. A buffer
pre-tracked has its value increased by 1, whether it is part of a tuple or not.  This is
an error.

This fix increments a pre-tracked buffer by the amount of the 'initial_ref_count', which
is really the number of references that a buffer acquires as part of being returned (1 for
a single buffer, but 2 when it is part of a tuple).

