### PR TITLE
Make orthogonal initializer use qr factorization (instead of svd)

### DIFF
--- a/tensorflow/contrib/keras/python/keras/initializers_test.py
+++ b/tensorflow/contrib/keras/python/keras/initializers_test.py
@@ -120,7 +120,7 @@ class KerasInitializersTest(test.TestCase):
                    target_mean=0., target_std=None, target_max=2 * scale)
 
   def test_orthogonal(self):
-    tensor_shape = (10, 10)
+    tensor_shape = (20, 20)
     with self.test_session():
       self._runner(keras.initializers.orthogonal(seed=123), tensor_shape,
                    target_mean=0.)

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -40,6 +40,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import linalg_ops
 from tensorflow.python.ops import random_ops
+from tensorflow.python.ops import math_ops
 
 
 class Initializer(object):
@@ -490,6 +491,11 @@ class Orthogonal(Initializer):
     a = random_ops.random_normal(flat_shape, dtype=dtype, seed=self.seed)
     # Compute the qr factorization
     q, r = linalg_ops.qr(a, full_matrices=False)
+    # Make q uniform
+    square_len = math_ops.minimum(num_rows, num_cols)
+    d = array_ops.diag_part(r[:square_len, :square_len])
+    ph = d / math_ops.abs(d)
+    q *= ph
     # Pad zeros to Q (if rows smaller than cols)
     if num_rows < num_cols:
       padding = array_ops.zeros([num_rows, num_cols - num_rows], dtype=dtype)

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -487,16 +487,13 @@ class Orthogonal(Initializer):
     flat_shape = (num_rows, num_cols)
 
     # Generate a random matrix
-    a = random_ops.random_uniform(flat_shape, dtype=dtype, seed=self.seed)
-    # Compute the svd
-    _, u, v = linalg_ops.svd(a, full_matrices=False)
-    # Pick the appropriate singular value decomposition
-    if num_rows > num_cols:
-      q = u
-    else:
-      # Tensorflow departs from numpy conventions
-      # such that we need to transpose axes here
-      q = array_ops.transpose(v)
+    a = random_ops.random_normal(flat_shape, dtype=dtype, seed=self.seed)
+    # Compute the qr factorization
+    q, r = linalg_ops.qr(a, full_matrices=False)
+    # Pad zeros to Q (if rows smaller than cols)
+    if num_rows < num_cols:
+      padding = array_ops.zeros([num_rows, num_cols - num_rows], dtype=dtype)
+      q = array_ops.concat([q, padding], 1)
     return self.gain * array_ops.reshape(q, shape)
 
   def get_config(self):

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -491,7 +491,7 @@ class Orthogonal(Initializer):
     a = random_ops.random_normal(flat_shape, dtype=dtype, seed=self.seed)
     # Compute the qr factorization
     q, r = linalg_ops.qr(a, full_matrices=False)
-    # Make q uniform
+    # Make Q uniform
     square_len = math_ops.minimum(num_rows, num_cols)
     d = array_ops.diag_part(r[:square_len, :square_len])
     ph = d / math_ops.abs(d)


### PR DESCRIPTION
Use QR factorization in orthogonal initializer to get better efficiency when computing orthogonal matrix.