### PR TITLE
Add ibverbs support for RoCEv2 networks

### DIFF
--- a/tensorflow/contrib/verbs/grpc_verbs_service.cc
+++ b/tensorflow/contrib/verbs/grpc_verbs_service.cc
@@ -117,6 +117,7 @@ Status GrpcVerbsService::GetRemoteAddressSync(
   ra.lid = request->channel().lid();
   ra.qpn = request->channel().qpn();
   ra.psn = request->channel().psn();
+  ra.gid = request->channel().gid();
   rc->SetRemoteAddress(ra, false);
   rc->Connect();
   int i = 0;
@@ -146,6 +147,7 @@ Status GrpcVerbsService::GetRemoteAddressSync(
   channel_info->set_lid(rc->self().lid);
   channel_info->set_qpn(rc->self().qpn);
   channel_info->set_psn(rc->self().psn);
+  channel_info->set_psn(rc->self().gid);
   for (int i = 0; i < RdmaChannel::kNumMessageBuffers; i++) {
     MemoryRegion* mr = response->add_mr();
     mr->set_remote_addr(reinterpret_cast<uint64>(mb[i]->buffer()));

--- a/tensorflow/contrib/verbs/grpc_verbs_service.cc
+++ b/tensorflow/contrib/verbs/grpc_verbs_service.cc
@@ -117,7 +117,8 @@ Status GrpcVerbsService::GetRemoteAddressSync(
   ra.lid = request->channel().lid();
   ra.qpn = request->channel().qpn();
   ra.psn = request->channel().psn();
-  ra.gid = request->channel().gid();
+  ra.snp = request->channel().snp();
+  ra.iid = request->channel().iid();
   rc->SetRemoteAddress(ra, false);
   rc->Connect();
   int i = 0;
@@ -147,7 +148,8 @@ Status GrpcVerbsService::GetRemoteAddressSync(
   channel_info->set_lid(rc->self().lid);
   channel_info->set_qpn(rc->self().qpn);
   channel_info->set_psn(rc->self().psn);
-  channel_info->set_psn(rc->self().gid);
+  channel_info->set_snp(rc->self().snp);
+  channel_info->set_iid(rc->self().iid);
   for (int i = 0; i < RdmaChannel::kNumMessageBuffers; i++) {
     MemoryRegion* mr = response->add_mr();
     mr->set_remote_addr(reinterpret_cast<uint64>(mb[i]->buffer()));

--- a/tensorflow/contrib/verbs/rdma.cc
+++ b/tensorflow/contrib/verbs/rdma.cc
@@ -477,7 +477,7 @@ void RdmaChannel::Connect(const RdmaAddress& remoteAddr) {
     attr.dest_qp_num = remoteAddr.qpn;
     attr.rq_psn = remoteAddr.psn;
     attr.max_dest_rd_atomic = 1;
-    attr.min_rnr_timer = 12;+    
+    attr.min_rnr_timer = 12;   
     attr.ah_attr.is_global = 1;
     attr.ah_attr.grh.dgid.global.subnet_prefix = remoteAddr.snp;
     attr.ah_attr.grh.dgid.global.interface_id = remoteAddr.iid;

--- a/tensorflow/contrib/verbs/rdma.cc
+++ b/tensorflow/contrib/verbs/rdma.cc
@@ -271,6 +271,10 @@ RdmaChannel::RdmaChannel(const RdmaAdapter* adapter, const string local_name,
     self_.lid = attr.lid;
     self_.qpn = qp_->qp_num;
     self_.psn = static_cast<uint32_t>(random::New64()) & 0xffffff;
+    union ibv_gid gid;
+    CHECK(!ibv_query_gid(adapter_->context_, (uint8_t) 1, 0, &gid)) << "Query gid";
+    self_.snp = gid.global.subnet_prefix;
+    self_.iid = gid.global.interface_id;
   }
 
   // create message and ack buffers, then initialize the tables.
@@ -320,11 +324,13 @@ void RdmaChannel::SetRemoteAddress(const RdmaAddress& ra, bool override) {
     remote_.lid = ra.lid;
     remote_.qpn = ra.qpn;
     remote_.psn = ra.psn;
+    remote_.gid = ra.gid;
     remote_set_ = true;
   } else {
     CHECK(remote_.lid == ra.lid);
     CHECK(remote_.qpn == ra.qpn);
     CHECK(remote_.psn == ra.psn);
+    CHECK(remote_.gid == ra.gid);
   }
 }
 
@@ -471,8 +477,12 @@ void RdmaChannel::Connect(const RdmaAddress& remoteAddr) {
     attr.dest_qp_num = remoteAddr.qpn;
     attr.rq_psn = remoteAddr.psn;
     attr.max_dest_rd_atomic = 1;
-    attr.min_rnr_timer = 12;
-    attr.ah_attr.is_global = 0;
+    attr.min_rnr_timer = 12;+    
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.grh.dgid.global.subnet_prefix = remoteAddr.snp;
+    attr.ah_attr.grh.dgid.global.interface_id = remoteAddr.iid;
+    attr.ah_attr.grh.flow_label = 0;
+    attr.ah_attr.grh.hop_limit = 3; 
     attr.ah_attr.dlid = remoteAddr.lid;
     attr.ah_attr.sl = 0;
     attr.ah_attr.src_path_bits = 0;

--- a/tensorflow/contrib/verbs/rdma.cc
+++ b/tensorflow/contrib/verbs/rdma.cc
@@ -324,13 +324,15 @@ void RdmaChannel::SetRemoteAddress(const RdmaAddress& ra, bool override) {
     remote_.lid = ra.lid;
     remote_.qpn = ra.qpn;
     remote_.psn = ra.psn;
-    remote_.gid = ra.gid;
+    remote_.snp = ra.snp;
+    remote_.iid = ra.iid;
     remote_set_ = true;
   } else {
     CHECK(remote_.lid == ra.lid);
     CHECK(remote_.qpn == ra.qpn);
     CHECK(remote_.psn == ra.psn);
-    CHECK(remote_.gid == ra.gid);
+    CHECK(remote_.snp == ra.snp);
+    CHECK(remote_.iid == ra.iid);
   }
 }
 

--- a/tensorflow/contrib/verbs/rdma.cc
+++ b/tensorflow/contrib/verbs/rdma.cc
@@ -484,7 +484,7 @@ void RdmaChannel::Connect(const RdmaAddress& remoteAddr) {
     attr.ah_attr.grh.dgid.global.subnet_prefix = remoteAddr.snp;
     attr.ah_attr.grh.dgid.global.interface_id = remoteAddr.iid;
     attr.ah_attr.grh.flow_label = 0;
-    attr.ah_attr.grh.hop_limit = 3; 
+    attr.ah_attr.grh.hop_limit = 255;
     attr.ah_attr.dlid = remoteAddr.lid;
     attr.ah_attr.sl = 0;
     attr.ah_attr.src_path_bits = 0;

--- a/tensorflow/contrib/verbs/rdma.h
+++ b/tensorflow/contrib/verbs/rdma.h
@@ -40,6 +40,8 @@ struct RdmaAddress {
   uint32_t lid;
   uint32_t qpn;
   uint32_t psn;
+  uint64_t snp;
+  uint64_t iid;
 };
 // structure to save information for remote memory regions.
 struct RemoteMR {

--- a/tensorflow/contrib/verbs/rdma_mgr.cc
+++ b/tensorflow/contrib/verbs/rdma_mgr.cc
@@ -69,6 +69,7 @@ void RdmaMgr::SetupChannels() {
     channel_info->set_lid(rc->self_.lid);
     channel_info->set_qpn(rc->self_.qpn);
     channel_info->set_psn(rc->self_.psn);
+    channel_info->set_psn(rc->self_.gid);
     for (int i = 0; i < RdmaChannel::kNumMessageBuffers; i++) {
       MemoryRegion* mr = req.add_mr();
       mr->set_remote_addr(
@@ -85,6 +86,7 @@ void RdmaMgr::SetupChannels() {
       ra.lid = resp.channel().lid();
       ra.qpn = resp.channel().qpn();
       ra.psn = resp.channel().psn();
+      ra.gid = resp.channel().gid();
       rc->SetRemoteAddress(ra, false);
       rc->Connect();
       int i = 0;

--- a/tensorflow/contrib/verbs/rdma_mgr.cc
+++ b/tensorflow/contrib/verbs/rdma_mgr.cc
@@ -69,7 +69,8 @@ void RdmaMgr::SetupChannels() {
     channel_info->set_lid(rc->self_.lid);
     channel_info->set_qpn(rc->self_.qpn);
     channel_info->set_psn(rc->self_.psn);
-    channel_info->set_gid(rc->self_.gid);
+    channel_info->set_snp(rc->self_.snp);
+    channel_info->set_iid(rc->self_.iid);
     for (int i = 0; i < RdmaChannel::kNumMessageBuffers; i++) {
       MemoryRegion* mr = req.add_mr();
       mr->set_remote_addr(
@@ -86,7 +87,8 @@ void RdmaMgr::SetupChannels() {
       ra.lid = resp.channel().lid();
       ra.qpn = resp.channel().qpn();
       ra.psn = resp.channel().psn();
-      ra.gid = resp.channel().gid();
+      ra.snp = resp.channel().snp();
+      ra.iid = resp.channel().iid();
       rc->SetRemoteAddress(ra, false);
       rc->Connect();
       int i = 0;

--- a/tensorflow/contrib/verbs/rdma_mgr.cc
+++ b/tensorflow/contrib/verbs/rdma_mgr.cc
@@ -69,7 +69,7 @@ void RdmaMgr::SetupChannels() {
     channel_info->set_lid(rc->self_.lid);
     channel_info->set_qpn(rc->self_.qpn);
     channel_info->set_psn(rc->self_.psn);
-    channel_info->set_psn(rc->self_.gid);
+    channel_info->set_gid(rc->self_.gid);
     for (int i = 0; i < RdmaChannel::kNumMessageBuffers; i++) {
       MemoryRegion* mr = req.add_mr();
       mr->set_remote_addr(

--- a/tensorflow/contrib/verbs/verbs_service.proto
+++ b/tensorflow/contrib/verbs/verbs_service.proto
@@ -30,6 +30,8 @@ message Channel {
   int32 lid = 1;
   int32 qpn = 2;
   int32 psn = 3;
+  uint64 snp = 4;
+  unit64 iid = 5;
 }
 
 message MemoryRegion {

--- a/tensorflow/contrib/verbs/verbs_service.proto
+++ b/tensorflow/contrib/verbs/verbs_service.proto
@@ -31,7 +31,7 @@ message Channel {
   int32 qpn = 2;
   int32 psn = 3;
   uint64 snp = 4;
-  unit64 iid = 5;
+  uint64 iid = 5;
 }
 
 message MemoryRegion {


### PR DESCRIPTION
Current support for ibverbs cannot run on RoCE networks, as RoCE requires the global identifier (gid) to connect. This patch adds gid information for RDMA connection setup.