### PR TITLE
Add tensorflow/core/kernels/function_ops.cc to Makefile

### DIFF
--- a/tensorflow/contrib/makefile/tf_op_files.txt
+++ b/tensorflow/contrib/makefile/tf_op_files.txt
@@ -101,6 +101,7 @@ tensorflow/core/kernels/identity_op.cc
 tensorflow/core/kernels/gather_op.cc
 tensorflow/core/kernels/gather_functor.cc
 tensorflow/core/kernels/fused_batch_norm_op.cc
+tensorflow/core/kernels/function_ops.cc
 tensorflow/core/kernels/fill_functor.cc
 tensorflow/core/kernels/fifo_queue.cc
 tensorflow/core/kernels/fake_quant_ops.cc


### PR DESCRIPTION
This should fix the breakage in Makefile-based builds after 858e0afcc45c39b6428bf82ab1444323e925cfd8.

Fixes #9453.