### PR TITLE
Fix PATH error with non-system GCC (#7543).

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -228,7 +228,7 @@ def InvokeNvcc(argv, log=False):
 
   # TODO(zhengxq): for some reason, 'gcc' needs this help to find 'as'.
   # Need to investigate and fix.
-  cmd = 'PATH=' + PREFIX_DIR + ' ' + cmd
+  cmd = 'PATH=' + PREFIX_DIR + ':$PATH ' + cmd
   if log: Log(cmd)
   return os.system(cmd)
 


### PR DESCRIPTION
I have been getting errors from `gcc` not finding `as`, due to my user-set PATH not being respected. See issue #7543.
For example, the following setting on Ubuntu 17.04 failed:

    export PATH=$HOME/compilers/gcc540/install/bin:$PATH
    export LD_LIBRARY_PATH=$HOME/compilers/gcc540/install/lib64:$LD_LIBRARY_PATH
    ./configure
        [...]
    bazel build --config=opt --config=cuda //tensorflow/tools/pip_package:build_pip_package

A fix seems to be rather simple. By just adding `:$PATH` to the respective command, TensorFlow now builds correctly. See diff.
However, I did not try to understand the full Python script, so I can't judge potential side effects.