### PR TITLE
README.md: make the settings.gradle and build.gradle example code match

### DIFF
--- a/tensorflow/contrib/android/cmake/README.md
+++ b/tensorflow/contrib/android/cmake/README.md
@@ -21,8 +21,8 @@ findProject(":TensorFlow-Android-Inference").projectDir =
 * application's build.gradle (adding dependency):
 
 ```
-debugCompile project(path: ':tensorflow_inference', configuration: 'debug')
-releaseCompile project(path: ':tensorflow_inference', configuration: 'release')
+debugCompile project(path: ':TensorFlow-Android-Inference', configuration: 'debug')
+releaseCompile project(path: ':TensorFlow-Android-Inference', configuration: 'release')
 ```
 Note: this makes native code in the lib traceable from your app.
 


### PR DESCRIPTION
As currently written, the example code that README.md recommends adding to settings.gradle and build.gradle doesn't match. Adding the code as-is results in a Gradle error.

This change fixes the discrepancy, making it easier to get started using the TensorFlow Android interface.