### PR TITLE
Added gradients + tests for ImageProjectiveTransform

### DIFF
--- a/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
+++ b/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
@@ -26,6 +26,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import gradient_checker
 from tensorflow.python.platform import googletest
 
 _DTYPES = set(
@@ -109,6 +110,28 @@ class ImageOpsTest(test_util.TensorFlowTestCase):
                              [0, 1, 0, 1],
                              [0, 1, 0, 1],
                              [0, 1, 1, 1]])
+
+
+  def _test_grad(self, shape_to_test):
+    with self.test_session():
+      test_image_shape = shape_to_test
+      test_image = np.random.randn(*test_image_shape)
+      test_image_tensor = constant_op.constant(test_image, shape=test_image_shape)
+      test_transform = image_ops.angles_to_projective_transforms(np.pi / 2, 4, 4)
+      test_transform_shape = test_transform.shape
+
+
+      output_shape = test_image_shape
+      output = image_ops.transform(test_image_tensor, test_transform)
+      left_err = gradient_checker.compute_gradient_error(
+        test_image_tensor, test_image_shape, output, output_shape,
+        x_init_value=test_image)
+      self.assertLess(left_err, 1e-10)
+
+  def test_grad(self):
+    self._test_grad([16, 16])
+    self._test_grad([4, 12, 12])
+    self._test_grad([3, 4, 12, 12])
 
 
 if __name__ == "__main__":

--- a/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
+++ b/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
@@ -116,16 +116,18 @@ class ImageOpsTest(test_util.TensorFlowTestCase):
     with self.test_session():
       test_image_shape = shape_to_test
       test_image = np.random.randn(*test_image_shape)
-      test_image_tensor = constant_op.constant(test_image, shape=test_image_shape)
-      test_transform = image_ops.angles_to_projective_transforms(np.pi / 2, 4, 4)
+      test_image_tensor = constant_op.constant(test_image, 
+                                               shape=test_image_shape)
+      test_transform = image_ops.angles_to_projective_transforms(np.pi / 2, 
+                                                                 4, 
+                                                                 4)
       test_transform_shape = test_transform.shape
-
 
       output_shape = test_image_shape
       output = image_ops.transform(test_image_tensor, test_transform)
       left_err = gradient_checker.compute_gradient_error(
-        test_image_tensor, test_image_shape, output, output_shape,
-        x_init_value=test_image)
+          test_image_tensor, test_image_shape, output, output_shape,
+          x_init_value=test_image)
       self.assertLess(left_err, 1e-10)
 
   def test_grad(self):

--- a/tensorflow/contrib/image/python/ops/image_ops.py
+++ b/tensorflow/contrib/image/python/ops/image_ops.py
@@ -25,6 +25,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import linalg_ops
 from tensorflow.python.platform import resource_loader
 
 _image_ops_so = loader.load_op_library(
@@ -214,4 +215,40 @@ def _transform_matrices_to_flat(transform_matrices):
   return transforms[:, :8]
 
 
-ops.NotDifferentiable("ImageProjectiveTransform")
+@ops.RegisterGradient("ImageProjectiveTransform")
+def _image_projective_transform_grad(op, grad):
+  images = op.inputs[0]
+  transforms = op.inputs[1]
+
+  image_or_images = ops.convert_to_tensor(images, name="images")
+  transform_or_transforms = ops.convert_to_tensor(
+      transforms, name="transforms", dtype=dtypes.float32)
+
+  if image_or_images.dtype.base_dtype not in _IMAGE_DTYPES:
+    raise TypeError("Invalid dtype %s." % image_or_images.dtype)
+  if len(image_or_images.get_shape()) == 2:
+    images = image_or_images[None, :, :, None]
+  elif len(image_or_images.get_shape()) == 3:
+    images = image_or_images[None, :, :, :]
+  elif len(image_or_images.get_shape()) == 4:
+    images = image_or_images
+  else:
+    raise TypeError("Images should have rank between 2 and 4")
+  if len(transform_or_transforms.get_shape()) == 1:
+    transforms = transform_or_transforms[None]
+  elif len(transform_or_transforms.get_shape()) == 2:
+    transforms = transform_or_transforms
+  else:
+    raise TypeError("Transforms should have rank 1 or 2.")
+
+  # Invert transformations
+  transforms = _flat_transforms_to_matrices(transforms=transforms)
+  inverse = linalg_ops.matrix_inverse(transforms)
+  transforms = _transform_matrices_to_flat(inverse)
+  output = gen_image_ops.image_projective_transform(grad, transforms)
+  if len(image_or_images.get_shape()) == 2:
+    return [output[0, :, :, 0], None]
+  elif len(image_or_images.get_shape()) == 3:
+    return [output[0, :, :, :], None]
+  else:
+    return [output, None]


### PR DESCRIPTION
Fixes #9423 by providing gradients for the base op.

Gradients are computed using the inverse of the transformation matrix which can be slow (even though it's 3x3 matrices only) but allows for dynamic transformation matrices. In case the transform is static, this might be precomputed. No gradients for the transform itself yet.

Disclaimer: First time TF contributor, feedback is welcome.