### PR TITLE
Catch exception on tf_session.TF_NewStatus()

### DIFF
--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -594,7 +594,8 @@ class BaseSession(SessionInterface):
       try:
         status = tf_session.TF_NewStatus()
         tf_session.TF_DeleteDeprecatedSession(self._session, status)
-      except:
+      except AttributeError:
+        # 'NoneType' object has no attribute 'TF_NewStatus'
         pass
       finally:
         if status is not None:

--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -594,6 +594,8 @@ class BaseSession(SessionInterface):
       try:
         status = tf_session.TF_NewStatus()
         tf_session.TF_DeleteDeprecatedSession(self._session, status)
+      except:
+        pass
       finally:
         if status is not None:
           tf_session.TF_DeleteStatus(status)


### PR DESCRIPTION
"try" and "finally" without "except" is not sufficient to catch the exception.  If the exception gets thrown, it can stop output from other threads from being printed, and the exception makes TF appear to be broken.  Fixes #8652