### PR TITLE
Remove comments about an unused argument

### DIFF
--- a/tensorflow/python/training/input.py
+++ b/tensorflow/python/training/input.py
@@ -879,9 +879,6 @@ def batch(tensors, batch_size, num_threads=1, capacity=32,
   `get_shape` method will have a first `Dimension` value of `None`, and
   operations that depend on fixed batch_size would fail.
 
-  Note: if `num_epochs` is not `None`, this function creates local counter
-  `epochs`. Use `local_variables_initializer()` to initialize local variables.
-
   Args:
     tensors: The list or dictionary of tensors to enqueue.
     batch_size: The new batch size pulled from the queue.
@@ -1180,9 +1177,6 @@ def shuffle_batch(tensors, batch_size, capacity, min_after_dequeue,
   In addition, all output tensors' static shapes, as accessed via the
   `get_shape` method will have a first `Dimension` value of `None`, and
   operations that depend on fixed batch_size would fail.
-
-  Note: if `num_epochs` is not `None`, this function creates local counter
-  `epochs`. Use `local_variables_initializer()` to initialize local variables.
 
   Args:
     tensors: The list or dictionary of tensors to enqueue.


### PR DESCRIPTION
Remove comments about an unused argument in `tf.train.suffle_batch` and `tf.train.batch`. There are commented lines which exactly is:

> Note: if `num_epochs` is not `None`, this function creates local counter
  `epochs`. Use `local_variables_initializer()` to initialize local variables.

But, there is no argument called `num_epochs`. So, it is unnecessary comments! 😄 