### PR TITLE
Fix a link error in the doc of histogram_summary

### DIFF
--- a/tensorflow/python/ops/logging_ops.py
+++ b/tensorflow/python/ops/logging_ops.py
@@ -124,7 +124,7 @@ def image_summary(tag, tensor, max_images=3, collections=None, name=None):
   """Outputs a `Summary` protocol buffer with images.
 
   For an explanation of why this op was deprecated, and information on how to
-  migrate, look ['here'](https://www.tensorflow.org/code/tensorflow/contrib/deprecated/__init__.py)
+  migrate, look ['here'](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/deprecated/__init__.py)
 
   The summary has up to `max_images` summary values containing images. The
   images are built from `tensor` which must be 4-D with shape `[batch_size,


### PR DESCRIPTION
As mentioned in [issue 9467](https://github.com/tensorflow/tensorflow/issues/9467), the link "look '[here](https://www.tensorflow.org/code/tensorflow/contrib/deprecated/__init__.py)'" can not point to the right page in the [doc of histogram_summary](https://www.tensorflow.org/api_docs/python/tf/contrib/deprecated/histogram_summary), so I change the link to https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/deprecated/__init__.py.