### PR TITLE
Java API to get the size of output list operations

### DIFF
--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -55,6 +55,18 @@ java_test(
 )
 
 java_test(
+    name = "OperationTest",
+    size = "small",
+    srcs = ["src/test/java/org/tensorflow/OperationTest.java"],
+    test_class = "org.tensorflow.OperationTest",
+    deps = [
+        ":tensorflow",
+        ":testutil",
+        "@junit",
+    ],
+)
+
+java_test(
     name = "SavedModelBundleTest",
     size = "small",
     srcs = ["src/test/java/org/tensorflow/SavedModelBundleTest.java"],

--- a/tensorflow/java/src/main/java/org/tensorflow/Operation.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Operation.java
@@ -71,13 +71,17 @@ public final class Operation {
   }
 
   /**
-   * Given the name of an output producing a tensor list, return the
-   * size of the list.
+   * Returns the size of the list of Tensors produced by this operation.
    *
-   * @param name is the name of the output.
-   * @return the size of the tensor list produced by this output.
+   * <p>An Operation has multiple named outputs, each of which produces either
+   * a single tensor or a list of tensors. This method returns the size of
+   * the list of tensors for a specific named output of the operation.
+   *
+   * @param name identifier of the list of tensors (of which there may
+   *        be many) produced by this operation.
+   * @returns the size of the list of Tensors produced by this named output.
    * @throws IllegalArgumentException if this operation has no output
-   *         with the provided name, or does not return a tensor list.
+   *         with the provided name.
    */
   public int outputListLength(final String name) {
     Graph.Reference r = graph.ref();

--- a/tensorflow/java/src/main/java/org/tensorflow/Operation.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Operation.java
@@ -70,6 +70,24 @@ public final class Operation {
     }
   }
 
+  /**
+   * Given the name of an output producing a tensor list, return the
+   * size of the list.
+   *
+   * @param name is the name of the output.
+   * @return the size of the tensor list produced by this output.
+   * @throws IllegalArgumentException if this operation has no output
+   *         with the provided name, or does not return a tensor list.
+   */
+  public int outputListLength(final String name) {
+    Graph.Reference r = graph.ref();
+    try {
+      return outputListLength(unsafeNativeHandle, name);
+    } finally {
+      r.close();
+    }
+  }
+
   /** Returns a symbolic handle to one of the tensors produced by this operation. */
   public Output output(int idx) {
     return new Output(this, idx);
@@ -107,6 +125,8 @@ public final class Operation {
   private static native String type(long handle);
 
   private static native int numOutputs(long handle);
+
+  private static native int outputListLength(long handle, String name);
 
   private static native long[] shape(long graphHandle, long opHandle, int output);
 

--- a/tensorflow/java/src/main/native/operation_jni.cc
+++ b/tensorflow/java/src/main/native/operation_jni.cc
@@ -66,6 +66,24 @@ JNIEXPORT jint JNICALL Java_org_tensorflow_Operation_numOutputs(JNIEnv* env,
   return TF_OperationNumOutputs(op);
 }
 
+JNIEXPORT jint JNICALL Java_org_tensorflow_Operation_outputListLength(JNIEnv* env,
+                                                                      jclass clazz,
+                                                                      jlong handle,
+                                                                      jstring name) {
+  TF_Operation* op = requireHandle(env, handle);
+  if (op == nullptr) return 0;
+
+  TF_Status* status = TF_NewStatus();
+
+  const char* cname = env->GetStringUTFChars(name, nullptr);
+  int result = TF_OperationOutputListLength(op, cname, status);
+  env->ReleaseStringUTFChars(name, cname);
+
+  throwExceptionIfNotOK(env, status);
+  TF_DeleteStatus(status);
+  return result;
+}
+
 JNIEXPORT jlongArray JNICALL Java_org_tensorflow_Operation_shape(
     JNIEnv* env, jclass clazz, jlong graph_handle, jlong op_handle,
     jint output_index) {

--- a/tensorflow/java/src/main/native/operation_jni.h
+++ b/tensorflow/java/src/main/native/operation_jni.h
@@ -48,6 +48,16 @@ JNIEXPORT jint JNICALL Java_org_tensorflow_Operation_numOutputs(JNIEnv *,
 
 /*
  * Class:     org_tensorflow_Operation
+ * Method:    outputListLength
+ * Signature: (JLjava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_org_tensorflow_Operation_outputListLength(JNIEnv *,
+                                                                      jclass,
+                                                                      jlong,
+                                                                      jstring);
+
+/*
+ * Class:     org_tensorflow_Operation
  * Method:    shape
  * Signature: (JJI)[J
  */

--- a/tensorflow/java/src/test/java/org/tensorflow/OperationTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/OperationTest.java
@@ -1,0 +1,58 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package org.tensorflow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.List;
+
+/** Unit tests for {@link org.tensorflow.Operation}. */
+@RunWith(JUnit4.class)
+public class OperationTest {
+
+  @Test
+  public void outputListLength() {
+    try (Graph g = new Graph()) {
+
+      checkSplit(g, "t1", new int[] {0, 1}, 1);
+      checkSplit(g, "t2", new int[] {0, 1}, 2);
+      checkSplit(g, "t3", new int[] {0, 1, 2}, 3);
+    }
+  }
+
+  private void checkSplit(Graph g, String name, int[] values, int num) {
+    Operation op =
+        g.opBuilder("Split", "split_op_" + name)
+            .addInput(TestUtil.constant(g, "split_dim_" + name, 0))
+            .addInput(TestUtil.constant(g, "values_" + name, values))
+            .setAttr("num_split", num)
+            .build();
+
+    assertEquals(num, op.numOutputs());
+    try {
+      op.outputListLength("unknown_name");
+      fail("Did not catch bad name");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+    assertEquals(num, op.outputListLength("output"));
+  }
+}

--- a/tensorflow/java/src/test/java/org/tensorflow/OperationTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/OperationTest.java
@@ -29,30 +29,38 @@ import java.util.List;
 public class OperationTest {
 
   @Test
-  public void outputListLength() {
+  public void  outputListLengthFailsOnInvalidName() {
     try (Graph g = new Graph()) {
+      Operation op = g.opBuilder("Add", "Add")
+          .addInput(TestUtil.constant(g, "x", 1))
+          .addInput(TestUtil.constant(g, "y", 2))
+          .build();
+      assertEquals(1, op.outputListLength("z"));
 
-      checkSplit(g, "t1", new int[] {0, 1}, 1);
-      checkSplit(g, "t2", new int[] {0, 1}, 2);
-      checkSplit(g, "t3", new int[] {0, 1, 2}, 3);
+      try {
+        op.outputListLength("unknown");
+        fail("Did not catch bad name");
+      } catch (IllegalArgumentException iae) {
+        // expected
+      }
     }
   }
 
-  private void checkSplit(Graph g, String name, int[] values, int num) {
-    Operation op =
-        g.opBuilder("Split", "split_op_" + name)
-            .addInput(TestUtil.constant(g, "split_dim_" + name, 0))
-            .addInput(TestUtil.constant(g, "values_" + name, values))
-            .setAttr("num_split", num)
-            .build();
+  @Test
+  public void outputListLength() {
+    assertEquals(1, split(new int[]{0, 1}, 1));
+    assertEquals(2, split(new int[]{0, 1}, 2));
+    assertEquals(3, split(new int[]{0, 1, 2}, 3));
+  }
 
-    assertEquals(num, op.numOutputs());
-    try {
-      op.outputListLength("unknown_name");
-      fail("Did not catch bad name");
-    } catch (IllegalArgumentException iae) {
-      // expected
+  private int split(int[] values, int num_split) {
+    try (Graph g = new Graph()) {
+      return g.opBuilder("Split", "Split")
+          .addInput(TestUtil.constant(g, "split_dim", 0))
+          .addInput(TestUtil.constant(g, "values", values))
+          .setAttr("num_split", num_split)
+          .build()
+          .outputListLength("output");
     }
-    assertEquals(num, op.outputListLength("output"));
   }
 }


### PR DESCRIPTION
This opens up access to the TF_OperationOutputListLength C API from java, for operations that return output lists.