### PR TITLE
Including batch_norm as the normalizer function by default, as mentioned in function description

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -1087,7 +1087,7 @@ def convolution2d_transpose(
   """Adds a convolution2d_transpose with an optional batch normalization layer.
 
   The function creates a variable called `weights`, representing the
-  kernel, that is convolved with the input. If `batch_norm_params` is `None`, a
+  kernel, that is convolved with the input. If `normalizer_fn` is `None`, a
   second variable called 'biases' is added to the result of the operation.
 
   Args:
@@ -1831,7 +1831,7 @@ def separable_convolution2d(
     padding='SAME',
     rate=1,
     activation_fn=nn.relu,
-    normalizer_fn=None,
+    normalizer_fn=batch_norm,
     normalizer_params=None,
     weights_initializer=initializers.xavier_initializer(),
     weights_regularizer=None,
@@ -1847,7 +1847,7 @@ def separable_convolution2d(
   This op first performs a depthwise convolution that acts separately on
   channels, creating a variable called `depthwise_weights`. If `num_outputs`
   is not None, it adds a pointwise convolution that mixes channels, creating a
-  variable called `pointwise_weights`. Then, if `batch_norm_params` is None,
+  variable called `pointwise_weights`. Then, if `normalizer_fn` is None,
   it adds bias to the result, creating a variable called 'biases', otherwise
   it adds a batch normalization layer. It finally applies an activation function
   to produce the end result.

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -1831,7 +1831,7 @@ def separable_convolution2d(
     padding='SAME',
     rate=1,
     activation_fn=nn.relu,
-    normalizer_fn=batch_norm,
+    normalizer_fn=None,
     normalizer_params=None,
     weights_initializer=initializers.xavier_initializer(),
     weights_regularizer=None,
@@ -1848,8 +1848,8 @@ def separable_convolution2d(
   channels, creating a variable called `depthwise_weights`. If `num_outputs`
   is not None, it adds a pointwise convolution that mixes channels, creating a
   variable called `pointwise_weights`. Then, if `normalizer_fn` is None,
-  it adds bias to the result, creating a variable called 'biases', otherwise
-  it adds a batch normalization layer. It finally applies an activation function
+  it adds bias to the result, creating a variable called 'biases', otherwise,
+  a normalization layer could be applied. It finally applies an activation function
   to produce the end result.
 
   Args:

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -1849,7 +1849,7 @@ def separable_convolution2d(
   is not None, it adds a pointwise convolution that mixes channels, creating a
   variable called `pointwise_weights`. Then, if `normalizer_fn` is None,
   it adds bias to the result, creating a variable called 'biases', otherwise,
-  a normalization layer could be applied. It finally applies an activation function
+  the `normalizer_fn` is applied. It finally applies an activation function
   to produce the end result.
 
   Args:


### PR DESCRIPTION
Changed the description error that includes `batch_norm_params`, which no longer exists, to `normalizer_fn`. `normalizer_fn = None` is changed to `normalizer_fn = batch_norm` by default, following what the original description says the function will do.