### PR TITLE
Fix Bazel CI / TensorFlow project.

### DIFF
--- a/configure
+++ b/configure
@@ -147,17 +147,17 @@ function setup_python {
   # Set-up env variables used by python_configure.bzl
   write_action_env_to_bazelrc "PYTHON_BIN_PATH" "$PYTHON_BIN_PATH"
   write_action_env_to_bazelrc "PYTHON_LIB_PATH" "$PYTHON_LIB_PATH"
-  write_to_bazelrc "build --define PYTHON_BIN_PATH=$PYTHON_BIN_PATH"
-  write_to_bazelrc "build --define PYTHON_LIB_PATH=$PYTHON_LIB_PATH"
+  write_to_bazelrc "build --define PYTHON_BIN_PATH=\"$PYTHON_BIN_PATH\""
+  write_to_bazelrc "build --define PYTHON_LIB_PATH=\"$PYTHON_LIB_PATH\""
   write_to_bazelrc "build --force_python=py$python_major_version"
   write_to_bazelrc "build --host_force_python=py$python_major_version"
-  write_to_bazelrc "build --python${python_major_version}_path=$PYTHON_BIN_PATH"
+  write_to_bazelrc "build --python${python_major_version}_path=\"$PYTHON_BIN_PATH\""
   write_to_bazelrc "test --force_python=py$python_major_version"
   write_to_bazelrc "test --host_force_python=py$python_major_version"
-  write_to_bazelrc "test --define PYTHON_BIN_PATH=$PYTHON_BIN_PATH"
-  write_to_bazelrc "test --define PYTHON_LIB_PATH=$PYTHON_LIB_PATH"
-  write_to_bazelrc "run --define PYTHON_BIN_PATH=$PYTHON_BIN_PATH"
-  write_to_bazelrc "run --define PYTHON_LIB_PATH=$PYTHON_LIB_PATH"
+  write_to_bazelrc "test --define PYTHON_BIN_PATH=\"$PYTHON_BIN_PATH\""
+  write_to_bazelrc "test --define PYTHON_LIB_PATH=\"$PYTHON_LIB_PATH\""
+  write_to_bazelrc "run --define PYTHON_BIN_PATH=\"$PYTHON_BIN_PATH\""
+  write_to_bazelrc "run --define PYTHON_LIB_PATH=\"$PYTHON_LIB_PATH\""
 
   # Write tools/python_bin_path.sh
   echo "export PYTHON_BIN_PATH=\"$PYTHON_BIN_PATH\"" > tools/python_bin_path.sh

--- a/tensorflow/tools/ci_build/windows/bazel/common_env.sh
+++ b/tensorflow/tools/ci_build/windows/bazel/common_env.sh
@@ -34,6 +34,7 @@ export BAZEL_SH="C:/tools/msys64/usr/bin/bash"
 
 # Set Python path for ./configure
 export PYTHON_BIN_PATH="C:/Program Files/Anaconda3/python"
+export PYTHON_LIB_PATH="C:/Program Files/Anaconda3/lib/site-packages"
 
 # Set Python path for cc_configure.bzl
 export BAZEL_PYTHON="C:/Program Files/Anaconda3/python"


### PR DESCRIPTION
This change:

1. updates common_env.sh to export PYTHON_LIB_PATH
along with PYTHON_BIN_PATH so the configure
scripts doesn't have to guess

2. writes these paths to bazelrc with quotes
around, to guard agains spaces in the path (e.g.
"C:/Program Files/Anaconda3/python")

Fixes https://github.com/bazelbuild/bazel/issues/2892