### PR TITLE
Fix error of version_info.cc not being generated on windows

### DIFF
--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -229,6 +229,12 @@ if (tensorflow_ENABLE_GPU)
   endif()
 endif()
 
+# Find python executable
+include(FindPythonInterp)
+if(NOT ${PYTHONINTERP_FOUND})
+    message(FATAL_ERROR "CMake was unable to find a python interpreter.")
+endif()
+
 # Let's get to work!
 include(tf_core_framework.cmake)
 # NOTE: Disabled until issue #3996 is fixed.

--- a/tensorflow/contrib/cmake/tf_python.cmake
+++ b/tensorflow/contrib/cmake/tf_python.cmake
@@ -27,7 +27,6 @@
 
 # 1. Resolve the installed version of Python (for Python.h and python).
 # TODO(mrry): Parameterize the build script to enable Python 3 building.
-include(FindPythonInterp)
 if(NOT PYTHON_INCLUDE_DIR)
   set(PYTHON_NOT_FOUND false)
   exec_program("${PYTHON_EXECUTABLE}"


### PR DESCRIPTION
If tensorflow_BUILD_PYTHON_BINDINGS is disabled in CMake, the Python interpreter is never resolved in CMake, but it is needed in tf_core_framework.cmake for generating the version_info.cc file with the script tensorflow/tools/git/gen_git_source.py. This seems to only be a problem on windows, resulting in a failed build complaining about version_info.cc missing. This is not an issue on linux, probably because of the shebang #!/usr/bin/env python in the script. 

I suggest moving the part in tf_python.cmake that sets up the python interpreter to the CMakeLists.txt as done in this PR so that it is always executed.