### PR TITLE
replace sleep macro with an inline function

### DIFF
--- a/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
+++ b/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
@@ -1,9 +1,11 @@
-#ifdef _WIN32
-#define sleep(seconds) Sleep(1000*seconds)
-#endif  // _WIN32
 #include "unsupported/Eigen/CXX11/Tensor"
 
 #ifdef _WIN32
+#ifndef SLEEP_FUNC_HEADER_GUARD
+#define SLEEP_FUNC_HEADER_GUARD
+inline void sleep(unsigned int seconds) { Sleep(1000*seconds); }
+#endif
+
 // On Windows, Eigen will include Windows.h, which defines various
 // macros that conflict with TensorFlow symbols. Undefine them here to
 // prevent clashes.


### PR DESCRIPTION
The file third_party/eigen3/unsupported/Eigen/CXX11/Tensor contains a macro called sleep which is only defined for windows. I assume this is added to cover the use of the posix function sleep(seconds) which is not available on windows. However, the function Sleep(microseconds) is. Unfortunately this macro has the nasty effect that you can't define or use any functions named sleep, even if it is in another namespace or class. A function with this name exists in most thread libraries such as boost::thread and qthread. Thus if you try to use tensorflow in an application which also use a threading library it will not compile.

I suggest replacing the macro with an inline function instead. As far as I can see, this function is not really used that much in the tensorflow code, thus other options than creating a global sleep function may be possible and more desirable.