### PR TITLE
verbs: Configure IB/RoCE QPs MTU according to the port MTU

### DIFF
--- a/tensorflow/contrib/verbs/rdma.cc
+++ b/tensorflow/contrib/verbs/rdma.cc
@@ -475,7 +475,11 @@ void RdmaChannel::Connect(const RdmaAddress& remoteAddr) {
     struct ibv_qp_attr attr;
     memset(&attr, 0, sizeof(ibv_qp_attr));
     attr.qp_state = IBV_QPS_RTR;
-    attr.path_mtu = IBV_MTU_4096;
+    struct ibv_port_attr port_attr;
+    CHECK(!ibv_query_port(adapter_->context_, (uint8_t)1, &port_attr))
+            << "Query port failed";
+    // This assumes both QP's ports are configured with the same MTU
+    attr.path_mtu = port_attr.active_mtu;
     attr.dest_qp_num = remoteAddr.qpn;
     attr.rq_psn = remoteAddr.psn;
     attr.max_dest_rd_atomic = 1;

--- a/tensorflow/contrib/verbs/rdma.cc
+++ b/tensorflow/contrib/verbs/rdma.cc
@@ -477,7 +477,7 @@ void RdmaChannel::Connect(const RdmaAddress& remoteAddr) {
     attr.qp_state = IBV_QPS_RTR;
     struct ibv_port_attr port_attr;
     CHECK(!ibv_query_port(adapter_->context_, (uint8_t)1, &port_attr))
-            << "Query port failed";
+        << "Query port failed";
     // This assumes both QP's ports are configured with the same MTU
     attr.path_mtu = port_attr.active_mtu;
     attr.dest_qp_num = remoteAddr.qpn;


### PR DESCRIPTION
For the verbs RDMA code to work on standard Ethernet networks,
where ports are configured with MTU 1500, need to set the path
MTU to 1K, as the previous 4K value is typical for IB networks.

@junshi15  @llhe @jhseu 