### PR TITLE
fix symbol count in def file for windows

### DIFF
--- a/tensorflow/contrib/cmake/tools/create_def_file.py
+++ b/tensorflow/contrib/cmake/tools/create_def_file.py
@@ -44,7 +44,7 @@ UNDNAME = "undname.exe"
 DUMPBIN = "dumpbin.exe"
 
 # Exclude if matched
-EXCLUDE_RE = re.compile(r"deleting destructor|::internal::")
+EXCLUDE_RE = re.compile(r"RTTI|deleting destructor|::internal::")
 
 # Include if matched before exclude
 INCLUDEPRE_RE = re.compile(r"google::protobuf::internal::ExplicitlyConstructed|"
@@ -141,17 +141,17 @@ def main():
           continue
         if not INCLUDE_RE.search(line):
           continue
-          
+
       if "deleting destructor" in line:
         # Some of the symbols convered by INCLUDEPRE_RE export deleting
         # destructor symbols, which is a bad idea.
         # So we filter out such symbols here.
         continue
-          
+
       if DATA_EXCLUDE_RE.search(line):
         def_fp.write("\t" + decorated + "\n")
       else:
-        def_fp.write("\t" + decorated + " DATA\n")      
+        def_fp.write("\t" + decorated + " DATA\n")
       taken.add(decorated)
   exit_code = proc.wait()
   if exit_code != 0:


### PR DESCRIPTION
This fixes some issue introduced in the previous version where RTTI
was removed from the exclusion list. Because of this the number of
symbols in the def file was close to 64K for gpu builds and yesterday
a few added symbols pushed us over the 64K limit for the windows linker, breaking the windows gpu build
Adding RTTI back to the exclusion list.
