### PR TITLE
Register variable's proto function with key 'LOCAL_VARIABLES'

### DIFF
--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -502,3 +502,8 @@ ops.register_proto_function(
     proto_type=variable_pb2.VariableDef,
     to_proto=_to_proto_fn,
     from_proto=_from_proto_fn)
+ops.register_proto_function(
+    ops.GraphKeys.LOCAL_VARIABLES,
+    proto_type=variable_pb2.VariableDef,
+    to_proto=_to_proto_fn,
+    from_proto=_from_proto_fn)


### PR DESCRIPTION
When export/input meta graph, user expect all collections
been rebuilded on target graph, but it turns out local variables
on target collection is not Variable but Tensor because local variable
do not have it's proto fn registered