### PR TITLE
Use hash url to memorize the currently opened tab.

### DIFF
--- a/tensorflow/tensorboard/dist/index.html
+++ b/tensorflow/tensorboard/dist/index.html
@@ -27,6 +27,6 @@ limitations under the License.
     <link rel="import" href="dist/tf-tensorboard.html">
   </head>
   <body>
-    <tf-tensorboard></tf-tensorboard>
+    <tf-tensorboard use-hash></tf-tensorboard>
   </body>
 </html>


### PR DESCRIPTION
We already do this internally. This enables it for the open-source version. See issue: #4354
Change: 153167734

Creating pull request against r1.1 because it will fix https://github.com/tensorflow/tensorflow/issues/9285