### PR TITLE
Added TensorBoard to the keras.callbacks API

### DIFF
--- a/tensorflow/contrib/keras/api/keras/callbacks/__init__.py
+++ b/tensorflow/contrib/keras/api/keras/callbacks/__init__.py
@@ -29,6 +29,7 @@ from tensorflow.contrib.keras.python.keras.callbacks import ModelCheckpoint
 from tensorflow.contrib.keras.python.keras.callbacks import ProgbarLogger
 from tensorflow.contrib.keras.python.keras.callbacks import ReduceLROnPlateau
 from tensorflow.contrib.keras.python.keras.callbacks import RemoteMonitor
+from tensorflow.contrib.keras.python.keras.callbacks import TensorBoard
 
 del absolute_import
 del division


### PR DESCRIPTION
When porting my code from Keras to use `tensorflow.contrib.keras`, I found that I couldn't use the `TensorBoard` callback anymore. Even though the code is still present, it was removed from the API `__init__.py` file during [the port](https://github.com/tensorflow/tensorflow/commits/master/tensorflow/contrib/keras/python/keras/callbacks.py) by @fchollet.

I couldn't find it in the commit history but I assume there was a reason to not bring along TensorBoard right away. This PR is a request for this feature and I'll happily help wherever I can to bring it about.