### PR TITLE
Squelch warnings related to API deprecation in mnist.py example.

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/head.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/head.py
@@ -37,7 +37,6 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
-from tensorflow.python.ops import logging_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn
 from tensorflow.python.ops import sparse_ops
@@ -621,7 +620,7 @@ def _create_model_fn_ops(features,
     loss, weighted_average_loss = loss_fn(labels, logits, weight_tensor)
     # Uses the deprecated API to set the tag explicitly.
     # Without it, trianing and eval losses will show up in different graphs.
-    logging_ops.scalar_summary(
+    summary.scalar(
         _summary_key(head_name, mkey.LOSS), weighted_average_loss)
 
     if mode == model_fn.ModeKeys.TRAIN:

--- a/tensorflow/examples/learn/mnist.py
+++ b/tensorflow/examples/learn/mnist.py
@@ -86,24 +86,24 @@ def main(unused_args):
   ### Linear classifier.
   feature_columns = learn.infer_real_valued_columns_from_input(
       mnist.train.images)
-  classifier = learn.LinearClassifier(
-      feature_columns=feature_columns, n_classes=10)
+  classifier = learn.SKCompat(learn.LinearClassifier(
+      feature_columns=feature_columns, n_classes=10))
   classifier.fit(mnist.train.images,
                  mnist.train.labels.astype(np.int32),
                  batch_size=100,
                  steps=1000)
   score = metrics.accuracy_score(mnist.test.labels,
-                                 list(classifier.predict(mnist.test.images)))
+                                 classifier.predict(mnist.test.images)['classes'])
   print('Accuracy: {0:f}'.format(score))
 
   ### Convolutional network
-  classifier = learn.Estimator(model_fn=conv_model)
+  classifier = learn.SKCompat(learn.Estimator(model_fn=conv_model))
   classifier.fit(mnist.train.images,
                  mnist.train.labels,
                  batch_size=100,
                  steps=20000)
   score = metrics.accuracy_score(mnist.test.labels,
-                                 list(classifier.predict(mnist.test.images)))
+                                 classifier.predict(mnist.test.images)['classes'])
   print('Accuracy: {0:f}'.format(score))
 
 


### PR DESCRIPTION
For reference:

```
WARNING:tensorflow:From /home/.../head.py: scalar_summary (from tensorflow.python.ops.logging_ops) is deprecated and will be removed after 2016-11-30.
WARNING:tensorflow:From mnist.py: calling BaseEstimator.fit (from tensorflow.contrib.learn.python.learn.estimators.estimator) with batch_size is deprecated and will be removed after 2016-12-01.
```
