### PR TITLE
Implement strided slice (stride > 2) in tf2xla

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -157,6 +157,19 @@ tf_xla_py_test(
 )
 
 tf_xla_py_test(
+    name = "slice_ops_test",
+    size = "small",
+    srcs = ["slice_ops_test.py"],
+    deps = [
+        ":xla_test",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:data_flow_ops",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:platform_test",
+    ],
+)
+
+tf_xla_py_test(
     name = "function_test",
     size = "small",
     srcs = ["function_test.py"],

--- a/tensorflow/compiler/tests/slice_ops_test.py
+++ b/tensorflow/compiler/tests/slice_ops_test.py
@@ -117,7 +117,7 @@ class StridedSliceTest(XLATestCase):
         i = array_ops.placeholder(dtype, shape=[3, 4, 10])
         with self.test_scope():
           o = array_ops.strided_slice(i, [2, 2, 6], [0, 0, 2], [-1, -1, -2])
-      params = {
+        params = {
           i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
                [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
                [5, 3, 1, 7, 9, 2, 4, 6, 8, 0],

--- a/tensorflow/compiler/tests/slice_ops_test.py
+++ b/tensorflow/compiler/tests/slice_ops_test.py
@@ -1,0 +1,136 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for slicing."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow.compiler.tests.xla_test import XLATestCase
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.platform import googletest
+
+class SliceTest(XLATestCase):
+
+  def test1D(self):
+    with self.test_session():
+      i = array_ops.placeholder(dtypes.float32, shape=[10])
+      with self.test_scope():
+        o = array_ops.slice(i, [2], [4])
+      params = {
+        i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      }
+      result = o.eval(feed_dict=params)
+
+      self.assertAllEqual([2, 3, 4, 5], result)
+
+  def test3D(self):
+    with self.test_session():
+      i = array_ops.placeholder(dtypes.float32, shape=[3, 3, 10])
+      with self.test_scope():
+        o = array_ops.slice(i, [1, 2, 2], [1, 1, 4])
+      params = {
+        i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+             [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+             [5, 3, 1, 7, 9, 2, 4, 6, 8, 0]],
+            [[5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+             [8, 7, 6, 5, 4, 3, 2, 1, 8, 7]],
+            [[7, 5, 7, 5, 7, 5, 7, 5, 7, 5],
+             [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
+             [9, 8, 7, 9, 8, 7, 9, 8, 7, 9]]]
+      }
+      result = o.eval(feed_dict=params)
+
+      self.assertAllEqual([[[6, 5, 4, 3]]], result)
+
+class StridedSliceTest(XLATestCase):
+
+  def test1D(self):
+    with self.test_session():
+      i = array_ops.placeholder(dtypes.float32, shape=[10])
+      with self.test_scope():
+        o = array_ops.strided_slice(i, [2], [6], [2])
+      params = {
+        i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      }
+      result = o.eval(feed_dict=params)
+
+      self.assertAllEqual([2, 4], result)
+
+  def test1DNegtiveStride(self):
+    with self.test_session():
+      i = array_ops.placeholder(dtypes.float32, shape=[10])
+      with self.test_scope():
+        o = array_ops.strided_slice(i, [6], [2], [-2])
+      params = {
+        i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      }
+      result = o.eval(feed_dict=params)
+
+      self.assertAllEqual([6, 4], result)
+
+  def test3D(self):
+    with self.test_session():
+      i = array_ops.placeholder(dtypes.float32, shape=[3, 3, 10])
+      with self.test_scope():
+        o = array_ops.strided_slice(i, [0, 2, 2], [2, 3, 6], [1, 1, 2])
+      params = {
+        i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+             [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+             [5, 3, 1, 7, 9, 2, 4, 6, 8, 0]],
+            [[5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+             [8, 7, 6, 5, 4, 3, 2, 1, 8, 7]],
+            [[7, 5, 7, 5, 7, 5, 7, 5, 7, 5],
+             [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
+             [9, 8, 7, 9, 8, 7, 9, 8, 7, 9]]]
+      }
+      result = o.eval(feed_dict=params)
+
+      self.assertAllEqual([[[1, 9]],
+                           [[6, 4]]], result)
+
+  def test3DNegativeStride(self):
+    with self.test_session():
+      i = array_ops.placeholder(dtypes.float32, shape=[3, 4, 10])
+      with self.test_scope():
+        o = array_ops.strided_slice(i, [2, 2, 6], [0, 0, 2], [-1, -1, -2])
+      params = {
+        i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+             [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+             [5, 3, 1, 7, 9, 2, 4, 6, 8, 0],
+             [4, 5, 2, 4, 3, 7, 6, 8, 9, 4]],
+            [[5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+             [4, 3, 4, 5, 7, 6, 5, 3, 4, 5],
+             [8, 7, 6, 5, 4, 3, 2, 1, 8, 7],
+             [7, 1, 7, 1, 8, 1, 8, 1, 3, 1]],
+            [[7, 5, 7, 5, 7, 5, 7, 5, 7, 5],
+             [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
+             [9, 8, 7, 9, 8, 7, 9, 8, 7, 9],
+             [9, 9, 5, 5, 6, 6, 3, 3, 6, 6]]]
+      }
+      result = o.eval(feed_dict=params)
+
+      self.assertAllEqual([[[9, 8],
+                            [1, 1]],
+                           [[2, 4],
+                            [5, 7]]], result)
+
+if __name__ == "__main__":
+  googletest.main()

--- a/tensorflow/compiler/tests/slice_ops_test.py
+++ b/tensorflow/compiler/tests/slice_ops_test.py
@@ -28,109 +28,115 @@ from tensorflow.python.platform import googletest
 class SliceTest(XLATestCase):
 
   def test1D(self):
-    with self.test_session():
-      i = array_ops.placeholder(dtypes.float32, shape=[10])
-      with self.test_scope():
-        o = array_ops.slice(i, [2], [4])
-      params = {
-        i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-      }
-      result = o.eval(feed_dict=params)
+    for dtype in self.numeric_types:
+      with self.test_session():
+        i = array_ops.placeholder(dtype, shape=[10])
+        with self.test_scope():
+          o = array_ops.slice(i, [2], [4])
+        params = {
+          i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        }
+        result = o.eval(feed_dict=params)
 
-      self.assertAllEqual([2, 3, 4, 5], result)
+        self.assertAllEqual([2, 3, 4, 5], result)
 
   def test3D(self):
-    with self.test_session():
-      i = array_ops.placeholder(dtypes.float32, shape=[3, 3, 10])
-      with self.test_scope():
-        o = array_ops.slice(i, [1, 2, 2], [1, 1, 4])
-      params = {
-        i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-             [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
-             [5, 3, 1, 7, 9, 2, 4, 6, 8, 0]],
-            [[5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
-             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-             [8, 7, 6, 5, 4, 3, 2, 1, 8, 7]],
-            [[7, 5, 7, 5, 7, 5, 7, 5, 7, 5],
-             [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
-             [9, 8, 7, 9, 8, 7, 9, 8, 7, 9]]]
-      }
-      result = o.eval(feed_dict=params)
+    for dtype in self.numeric_types:
+      with self.test_session():
+        i = array_ops.placeholder(dtype, shape=[3, 3, 10])
+        with self.test_scope():
+          o = array_ops.slice(i, [1, 2, 2], [1, 1, 4])
+        params = {
+          i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+               [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+               [5, 3, 1, 7, 9, 2, 4, 6, 8, 0]],
+              [[5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+               [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+               [8, 7, 6, 5, 4, 3, 2, 1, 8, 7]],
+              [[7, 5, 7, 5, 7, 5, 7, 5, 7, 5],
+               [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
+               [9, 8, 7, 9, 8, 7, 9, 8, 7, 9]]]
+        }
+        result = o.eval(feed_dict=params)
 
-      self.assertAllEqual([[[6, 5, 4, 3]]], result)
+        self.assertAllEqual([[[6, 5, 4, 3]]], result)
 
 class StridedSliceTest(XLATestCase):
 
   def test1D(self):
-    with self.test_session():
-      i = array_ops.placeholder(dtypes.float32, shape=[10])
-      with self.test_scope():
-        o = array_ops.strided_slice(i, [2], [6], [2])
-      params = {
-        i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-      }
-      result = o.eval(feed_dict=params)
+    for dtype in self.numeric_types:
+      with self.test_session():
+        i = array_ops.placeholder(dtype, shape=[10])
+        with self.test_scope():
+          o = array_ops.strided_slice(i, [2], [6], [2])
+        params = {
+          i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        }
+        result = o.eval(feed_dict=params)
 
-      self.assertAllEqual([2, 4], result)
+        self.assertAllEqual([2, 4], result)
 
   def test1DNegtiveStride(self):
-    with self.test_session():
-      i = array_ops.placeholder(dtypes.float32, shape=[10])
-      with self.test_scope():
-        o = array_ops.strided_slice(i, [6], [2], [-2])
-      params = {
-        i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-      }
-      result = o.eval(feed_dict=params)
+    for dtype in self.numeric_types:
+      with self.test_session():
+        i = array_ops.placeholder(dtype, shape=[10])
+        with self.test_scope():
+          o = array_ops.strided_slice(i, [6], [2], [-2])
+        params = {
+          i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        }
+        result = o.eval(feed_dict=params)
 
-      self.assertAllEqual([6, 4], result)
+        self.assertAllEqual([6, 4], result)
 
   def test3D(self):
-    with self.test_session():
-      i = array_ops.placeholder(dtypes.float32, shape=[3, 3, 10])
-      with self.test_scope():
-        o = array_ops.strided_slice(i, [0, 2, 2], [2, 3, 6], [1, 1, 2])
-      params = {
-        i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-             [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
-             [5, 3, 1, 7, 9, 2, 4, 6, 8, 0]],
-            [[5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
-             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-             [8, 7, 6, 5, 4, 3, 2, 1, 8, 7]],
-            [[7, 5, 7, 5, 7, 5, 7, 5, 7, 5],
-             [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
-             [9, 8, 7, 9, 8, 7, 9, 8, 7, 9]]]
-      }
-      result = o.eval(feed_dict=params)
+    for dtype in self.numeric_types:
+      with self.test_session():
+        i = array_ops.placeholder(dtype, shape=[3, 3, 10])
+        with self.test_scope():
+          o = array_ops.strided_slice(i, [0, 2, 2], [2, 3, 6], [1, 1, 2])
+        params = {
+          i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+               [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+               [5, 3, 1, 7, 9, 2, 4, 6, 8, 0]],
+              [[5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+               [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+               [8, 7, 6, 5, 4, 3, 2, 1, 8, 7]],
+              [[7, 5, 7, 5, 7, 5, 7, 5, 7, 5],
+               [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
+               [9, 8, 7, 9, 8, 7, 9, 8, 7, 9]]]
+        }
+        result = o.eval(feed_dict=params)
 
-      self.assertAllEqual([[[1, 9]],
-                           [[6, 4]]], result)
+        self.assertAllEqual([[[1, 9]],
+                             [[6, 4]]], result)
 
   def test3DNegativeStride(self):
-    with self.test_session():
-      i = array_ops.placeholder(dtypes.float32, shape=[3, 4, 10])
-      with self.test_scope():
-        o = array_ops.strided_slice(i, [2, 2, 6], [0, 0, 2], [-1, -1, -2])
+    for dtype in self.numeric_types:
+      with self.test_session():
+        i = array_ops.placeholder(dtype, shape=[3, 4, 10])
+        with self.test_scope():
+          o = array_ops.strided_slice(i, [2, 2, 6], [0, 0, 2], [-1, -1, -2])
       params = {
-        i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-             [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
-             [5, 3, 1, 7, 9, 2, 4, 6, 8, 0],
-             [4, 5, 2, 4, 3, 7, 6, 8, 9, 4]],
-            [[5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
-             [4, 3, 4, 5, 7, 6, 5, 3, 4, 5],
-             [8, 7, 6, 5, 4, 3, 2, 1, 8, 7],
-             [7, 1, 7, 1, 8, 1, 8, 1, 3, 1]],
-            [[7, 5, 7, 5, 7, 5, 7, 5, 7, 5],
-             [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
-             [9, 8, 7, 9, 8, 7, 9, 8, 7, 9],
-             [9, 9, 5, 5, 6, 6, 3, 3, 6, 6]]]
-      }
-      result = o.eval(feed_dict=params)
+          i: [[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+               [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+               [5, 3, 1, 7, 9, 2, 4, 6, 8, 0],
+               [4, 5, 2, 4, 3, 7, 6, 8, 9, 4]],
+              [[5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+               [4, 3, 4, 5, 7, 6, 5, 3, 4, 5],
+               [8, 7, 6, 5, 4, 3, 2, 1, 8, 7],
+               [7, 1, 7, 1, 8, 1, 8, 1, 3, 1]],
+              [[7, 5, 7, 5, 7, 5, 7, 5, 7, 5],
+               [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
+               [9, 8, 7, 9, 8, 7, 9, 8, 7, 9],
+               [9, 9, 5, 5, 6, 6, 3, 3, 6, 6]]]
+        }
+        result = o.eval(feed_dict=params)
 
-      self.assertAllEqual([[[9, 8],
-                            [1, 1]],
-                           [[2, 4],
-                            [5, 7]]], result)
+        self.assertAllEqual([[[9, 8],
+                              [1, 1]],
+                             [[2, 4],
+                              [5, 7]]], result)
 
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
@@ -77,11 +77,9 @@ class StridedSliceOp : public XlaOpKernel {
 
     gtl::InlinedVector<int64, 4> dimensions_to_reverse;
     gtl::InlinedVector<int64, 4> slice_begin, slice_end;
+    bool simple_strides(true);
     for (int i = 0; i < begin.size(); ++i) {
-      // TODO(phawkins): implement strides != 1 when b/30878775 is fixed.
-      OP_REQUIRES(
-          ctx, strides[i] == 1 || strides[i] == -1,
-          errors::Unimplemented("Strides != 1 or -1 are not yet implemented"));
+      simple_strides &= (std::abs(strides[i]) == 1);
       if (strides[i] > 0) {
         slice_begin.push_back(begin[i]);
         slice_end.push_back(end[i]);
@@ -97,6 +95,30 @@ class StridedSliceOp : public XlaOpKernel {
         ctx->builder()->Slice(ctx->Input(0), slice_begin, slice_end);
     if (!dimensions_to_reverse.empty()) {
       slice = ctx->builder()->Rev(slice, dimensions_to_reverse);
+    }
+
+    if (!simple_strides) {
+      for (int d = 0; d < strides.size(); ++d) {
+        slice_end[d] -= slice_begin[d];
+        slice_begin[d] = 0;
+      }
+
+      for (int d = 0; d < strides.size(); ++d) {
+        int64 stride = std::abs(strides[d]);
+        if (stride > 1) {
+          std::vector<xla::ComputationDataHandle> to_concat;
+          int64 end = slice_end[d];
+          for (int64 i=0; i < end; i += stride) {
+            slice_begin[d] = i;
+            slice_end[d] = i+1;
+            to_concat.push_back(ctx->builder()->Slice(slice, slice_begin,
+                                                      slice_end));
+          }
+          slice = ctx->builder()->ConcatInDim(to_concat, d);
+          slice_begin[d] = 0;
+          slice_end[d] = to_concat.size();
+        }
+      }
     }
 
     slice = ctx->builder()->Reshape(slice, final_shape.dim_sizes());


### PR DESCRIPTION
Before, strides are not acceptable in strided_slice where the stride > 1 (or < -1).

This uses a concatenation of normal slices to implement strided_slice.

For backends where all tensor slicing/padding/concating/striding are just index manipulation, this implementation is as efficient as any other.
