### PR TITLE
Add control input dependency to Java bindings

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/OperationBuilder.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/OperationBuilder.java
@@ -74,15 +74,17 @@ public final class OperationBuilder {
   }
 
   /**
-   * A control input is an Operation that must be executed or computed
-   * before running the operation currently being built.
+   * Ensure that the operation does not execute before the control operation does.
    *
-   *<p>For example, an Assert operation may be added as a control
+   * <p>A control input is an Operation that must be executed before
+   * running the operation currently being built.
+   *
+   * <p>For example, an Assert operation may be added as a control
    * input for this operation. The Assert now behaves as a
    * pre-condition that will always verify itself before running the
    * operation.
    *
-   * @param control operation that must be computed before running this
+   * @param control operation that must be executed before running this
    *     operation.
    * @return the OperationBuilder instance for chaining.
    */

--- a/tensorflow/java/src/main/java/org/tensorflow/OperationBuilder.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/OperationBuilder.java
@@ -73,6 +73,29 @@ public final class OperationBuilder {
     return this;
   }
 
+  /**
+   * A control input is an Operation that must be executed or computed
+   * before running the operation currently being built.
+   *
+   *<p>For example, an Assert operation may be added as a control
+   * input for this operation. The Assert now behaves as a
+   * pre-condition that will always verify itself before running the
+   * operation.
+   *
+   * @param control operation that must be computed before running this
+   *     operation.
+   * @return the OperationBuilder instance for chaining.
+   */
+  public OperationBuilder addControlInput(Operation control) {
+    Graph.Reference r = graph.ref();
+    try {
+      addControlInput(unsafeNativeHandle, control.getUnsafeNativeHandle());
+    } finally {
+      r.close();
+    }
+    return this;
+  }
+
   public OperationBuilder addInputList(Output[] inputs) {
     Graph.Reference r = graph.ref();
     try {
@@ -243,6 +266,8 @@ public final class OperationBuilder {
   private static native void addInput(long handle, long opHandle, int index);
 
   private static native void addInputList(long handle, long[] opHandles, int[] indices);
+
+  private static native void addControlInput(long handle, long opHandle);
 
   private static native void setDevice(long handle, String device);
 

--- a/tensorflow/java/src/main/native/operation_builder_jni.cc
+++ b/tensorflow/java/src/main/native/operation_builder_jni.cc
@@ -29,15 +29,6 @@ TF_OperationDescription* requireHandle(JNIEnv* env, jlong handle) {
   return reinterpret_cast<TF_OperationDescription*>(handle);
 }
 
-TF_Operation* requireOperation(JNIEnv* env, jlong handle) {
-  if (handle == 0) {
-    throwException(env, kIllegalStateException,
-                   "Operation has not been built");
-    return nullptr;
-  }
-  return reinterpret_cast<TF_Operation*>(handle);
-}
-
 bool resolveOutput(JNIEnv* env, jlong op_handle, jint index, TF_Output* out) {
   if (op_handle == 0) {
     throwException(env, kIllegalStateException,
@@ -126,8 +117,13 @@ JNIEXPORT void JNICALL Java_org_tensorflow_OperationBuilder_addInputList(
 
 JNIEXPORT void JNICALL Java_org_tensorflow_OperationBuilder_addControlInput(
     JNIEnv* env, jclass clazz, jlong handle, jlong op_handle) {
-  TF_Operation* control = requireOperation(env, op_handle);
-  if (control == nullptr) return;
+  if (op_handle == 0) {
+    throwException(env, kIllegalStateException,
+                   "control input is not valid, "
+                   "perhaps the Graph containing it has been closed()?");
+    return;
+  }
+  TF_Operation* control = reinterpret_cast<TF_Operation*>(op_handle);
   TF_OperationDescription* d = requireHandle(env, handle);
   if (d == nullptr) return;
   TF_AddControlInput(d, control);

--- a/tensorflow/java/src/main/native/operation_builder_jni.cc
+++ b/tensorflow/java/src/main/native/operation_builder_jni.cc
@@ -29,6 +29,15 @@ TF_OperationDescription* requireHandle(JNIEnv* env, jlong handle) {
   return reinterpret_cast<TF_OperationDescription*>(handle);
 }
 
+TF_Operation* requireOperation(JNIEnv* env, jlong handle) {
+  if (handle == 0) {
+    throwException(env, kIllegalStateException,
+                   "Operation has not been built");
+    return nullptr;
+  }
+  return reinterpret_cast<TF_Operation*>(handle);
+}
+
 bool resolveOutput(JNIEnv* env, jlong op_handle, jint index, TF_Output* out) {
   if (op_handle == 0) {
     throwException(env, kIllegalStateException,
@@ -113,6 +122,15 @@ JNIEXPORT void JNICALL Java_org_tensorflow_OperationBuilder_addInputList(
   env->ReleaseLongArrayElements(op_handles, oph, JNI_ABORT);
   if (!ok) return;
   TF_AddInputList(d, o.get(), n);
+}
+
+JNIEXPORT void JNICALL Java_org_tensorflow_OperationBuilder_addControlInput(
+    JNIEnv* env, jclass clazz, jlong handle, jlong op_handle) {
+  TF_Operation* control = requireOperation(env, op_handle);
+  if (control == nullptr) return;
+  TF_OperationDescription* d = requireHandle(env, handle);
+  if (d == nullptr) return;
+  TF_AddControlInput(d, control);
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_OperationBuilder_setDevice(

--- a/tensorflow/java/src/main/native/operation_builder_jni.h
+++ b/tensorflow/java/src/main/native/operation_builder_jni.h
@@ -57,6 +57,14 @@ JNIEXPORT void JNICALL Java_org_tensorflow_OperationBuilder_addInputList(
 
 /*
  * Class:     org_tensorflow_OperationBuilder
+ * Method:    addControlInput
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_org_tensorflow_OperationBuilder_addControlInput(
+    JNIEnv *, jclass, jlong, jlong);
+
+/*
+ * Class:     org_tensorflow_OperationBuilder
  * Method:    setDevice
  * Signature: (JLjava/lang/String;)V
  */


### PR DESCRIPTION
Add a builder method to OperationBuilder to allow adding
control inputs to Operations.