### PR TITLE
Add a note about how weights are initialized in Dense/dense to the docstrings

### DIFF
--- a/tensorflow/python/layers/core.py
+++ b/tensorflow/python/layers/core.py
@@ -56,7 +56,7 @@ class Dense(base.Layer):
     activation: Activation function (callable). Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
-    kernel_initializer:  Initializer function for the weight matrix.
+    kernel_initializer: Initializer function for the weight matrix.
       If `None` (default), weights are initialized using the default
       initializer used by `tf.get_variable`.
     bias_initializer: Initializer function for the bias.

--- a/tensorflow/python/layers/core.py
+++ b/tensorflow/python/layers/core.py
@@ -56,10 +56,9 @@ class Dense(base.Layer):
     activation: Activation function (callable). Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
-    kernel_initializer: Initializer function for the weight matrix.
-      If `None` (default), weights are initialized using the global default
-      initializer which uses the `glorot_uniform_initializer` defined in
-      `tensorflow.python.ops.init_ops`.
+    kernel_initializer:  Initializer function for the weight matrix.
+      If `None` (default), weights are initialized using the default
+      initializer used by `tf.get_variable`.
     bias_initializer: Initializer function for the bias.
     kernel_regularizer: Regularizer function for the weight matrix.
     bias_regularizer: Regularizer function for the bias.
@@ -194,9 +193,8 @@ def dense(
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
     kernel_initializer: Initializer function for the weight matrix.
-      If `None` (default), weights are initialized using the global default
-      initializer which uses the `glorot_uniform_initializer` defined in
-      `tensorflow.python.ops.init_ops`.
+      If `None` (default), weights are initialized using the default
+      initializer used by `tf.get_variable`.
     bias_initializer: Initializer function for the bias.
     kernel_regularizer: Regularizer function for the weight matrix.
     bias_regularizer: Regularizer function for the bias.

--- a/tensorflow/python/layers/core.py
+++ b/tensorflow/python/layers/core.py
@@ -57,6 +57,9 @@ class Dense(base.Layer):
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
     kernel_initializer: Initializer function for the weight matrix.
+      If `None` (default), weights are initialized using the global default
+      initializer which uses the `glorot_uniform_initializer` defined in
+      `tensorflow.python.ops.init_ops`.
     bias_initializer: Initializer function for the bias.
     kernel_regularizer: Regularizer function for the weight matrix.
     bias_regularizer: Regularizer function for the bias.

--- a/tensorflow/python/layers/core.py
+++ b/tensorflow/python/layers/core.py
@@ -191,6 +191,9 @@ def dense(
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
     kernel_initializer: Initializer function for the weight matrix.
+      If `None` (default), weights are initialized using the global default
+      initializer which uses the `glorot_uniform_initializer` defined in
+      `tensorflow.python.ops.init_ops`.
     bias_initializer: Initializer function for the bias.
     kernel_regularizer: Regularizer function for the weight matrix.
     bias_regularizer: Regularizer function for the bias.


### PR DESCRIPTION
Hi,
this PR adds a note about the default weight initializer to the `tf.layers.Dense` and `tf.layers.dense` docstrings to clarify how the default weights are initialized as discussed in #9744 .