### PR TITLE
MPI based communication path for tensor exchange operations

### DIFF
--- a/configure
+++ b/configure
@@ -763,6 +763,84 @@ done
 # end of if "$TF_NEED_OPENCL" == "1"
 fi
 
+
+while [ "$TF_NEED_MPI" == "" ]; do
+  read -p "Do you wish to build TensorFlow with "\
+"MPI support? [y/N] " INPUT
+  case $INPUT in
+    [Yy]* ) echo "MPI support will be enabled for "\
+"TensorFlow"; TF_NEED_MPI=1;;
+    [Nn]* ) echo "MPI support will not be enabled for "\
+"TensorFlow"; TF_NEED_MPI=0;;
+    "" ) echo "MPI support will not be enabled for "\
+"TensorFlow"; TF_NEED_MPI=0;;
+    * ) echo "Invalid selection: " $INPUT;;
+  esac
+done
+
+# Find out where the MPI toolkit is installed
+while true; do
+    if [ "$TF_NEED_MPI" == "0" ]; then
+        break;
+    fi
+
+    fromuser=""
+    if [ -z "$MPI_HOME" ]; then
+        #Get the base folder by removing the bin path
+        default_path=$(dirname $(dirname $(which mpirun)) || dirname $(dirname $(which mpiexec))  || true)
+        read -p "Please specify the MPI toolkit folder. [Default is $default_mpi_path]: " MPI_HOME
+        fromuser="1"
+        if [ -z "$MPI_HOME" ]; then
+            MPI_HOME=$default_path
+        fi
+    fi
+
+    #Check that the include and library folders are where we expect them to be
+    if [ -e "$MPI_HOME/include" -a -e "$MPI_HOME/lib" ]; then
+        break
+    fi
+ 
+    echo "Invalid path to the MPI Toolkit. ${MPI_HOME}/include or ${MPI_HOME}/lib cannot be found."
+    if [ -z "$fromuser" ]; then
+        exit 1
+    fi
+
+    # Retry
+    MPI_HOME="" 
+done
+    
+    
+if [ "$TF_NEED_MPI" == "1" ]; then
+  write_to_bazelrc 'build --define with_mpi_support=true'
+
+  #Link the MPI header files
+  ln -sf "${MPI_HOME}/include/mpi.h" third_party/mpi/mpi.h
+
+
+  #Determine if we use OpenMPI or MVAPICH, these require different header files 
+  #to be included here to make bazel dependency checker happy
+
+  if [ -e "${MPI_HOME}/include/mpi_portable_platform.h" ]; then
+        #OpenMPI 
+        ln -sf "${MPI_HOME}/include/mpi_portable_platform.h" third_party/mpi/
+        sed -i -e "s/MPI_LIB_IS_OPENMPI=False/MPI_LIB_IS_OPENMPI=True/" third_party/mpi/mpi.bzl
+ else
+        #MVAPICH / MPICH
+        ln -sf "${MPI_HOME}/include/mpio.h" third_party/mpi/
+        ln -sf "${MPI_HOME}/include/mpicxx.h" third_party/mpi/
+        sed -i -e "s/MPI_LIB_IS_OPENMPI=True/MPI_LIB_IS_OPENMPI=False/" third_party/mpi/mpi.bzl
+ fi
+
+  
+  if [ -e "${MPI_HOME}/lib/libmpi.so" ]; then
+    ln -sf "${MPI_HOME}/lib/libmpi.so" third_party/mpi/
+  else
+    echo "Cannot find the MPI library file in ${MPI_HOME}/lib "
+    exit 1
+  fi
+fi
+
+
 # TODO(gunan): Remove once bazel correctly handles changes in remote repositories.
 bazel clean
 echo "Configuration finished"

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -155,6 +155,12 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "with_mpi_support",
+    values = {"define": "with_mpi_support=true"},
+    visibility = ["//visibility:public"],
+)
+
 package_group(
     name = "internal",
     packages = ["//tensorflow/..."],

--- a/tensorflow/contrib/mpi/BUILD
+++ b/tensorflow/contrib/mpi/BUILD
@@ -1,0 +1,90 @@
+# Description:
+#   MPI based communication interfaces and implementations for TensorFlow.
+
+package(default_visibility = [
+    "//tensorflow:__subpackages__",
+])
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "**/METADATA",
+            "**/OWNERS",
+        ],
+    ),
+    visibility = ["//tensorflow:__subpackages__"],
+)
+
+filegroup(
+    name = "c_srcs",
+    data = glob([
+        "**/*.cc",
+        "**/*.h",
+    ]),
+)
+
+# For platform specific build config
+load(
+    "//tensorflow/core:platform/default/build_config.bzl",
+    "tf_proto_library_cc",
+)
+
+tf_proto_library_cc(
+    name = "mpi_msg_proto",
+    srcs = ["mpi_msg.proto"],
+    cc_api_version = 2,
+    protodeps = ["//tensorflow/core:worker_proto"],
+    visibility = [
+        "//tensorflow:__subpackages__",
+    ],
+)
+
+cc_library(
+    name = "mpi_utils",
+    srcs = ["mpi_utils.cc"],
+    hdrs = ["mpi_utils.h"],
+    deps = [
+        "//tensorflow/core:core_cpu_internal",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//third_party/mpi",
+    ],
+)
+
+cc_library(
+    name = "mpi_rendezvous_mgr",
+    srcs = ["mpi_rendezvous_mgr.cc"],
+    hdrs = ["mpi_rendezvous_mgr.h"],
+    deps = [
+        ":mpi_msg_proto_cc",
+        ":mpi_utils",
+        "//tensorflow/core:core_cpu_internal",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:gpu_runtime",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_cc",
+        "//tensorflow/core:worker_proto_cc",
+        "//tensorflow/core/distributed_runtime:base_rendezvous_mgr",
+        "//tensorflow/core/distributed_runtime:session_mgr",
+        "//tensorflow/core/distributed_runtime:worker_env",
+        "//third_party/mpi",
+    ],
+)
+
+cc_library(
+    name = "mpi_server_lib",
+    srcs = ["mpi_server_lib.cc"],
+    hdrs = ["mpi_server_lib.h"],
+    linkstatic = 1,  # Seems to be needed since alwayslink is broken in bazel
+    deps = [
+        ":mpi_rendezvous_mgr",
+        "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib",
+    ],
+    alwayslink = 1,
+)

--- a/tensorflow/contrib/mpi/README.md
+++ b/tensorflow/contrib/mpi/README.md
@@ -1,0 +1,94 @@
+## How to compile and use MPI-enabled TensorFlow
+
+1. Follow the regular TF compilation instructions. During configure step, if you want MPI support, answer yes to this question:
+
+    ```Do you wish to build TensorFlow with MPI support [y/N]```
+
+2. To turn on the MPI connection, add the protocol "grpc+mpi" in the server definition:
+
+    ```server = tf.train.Server(cluster, job_name="local", task_index=0, protocol='grpc+mpi') # default protocol is 'grpc'```
+
+## Overview
+
+By using this protocol the TensorFlow can take advantage of the high performance networking primitives that are offered via the MPI API. This enables TensorFlow to take advantage of high performance low latency networks such as Infiniband. These changes are largely transparent to the user who only has to change the offered protocol and launch the script using the 'mpirun'  launcher. For example:
+    ```mpirun -np 2 python my_neuralnet.py ```
+
+
+
+
+
+## Runtime options
+
+The following environment variables can be set to modify the behavior at runtime:
+
+**MPI_DISABLED=[0,1]**
+
+This environment variable allows you to disable the MPI path before launch (e.g. for performance or correctness testing). 
+
+**MPI_OPTIMAL_PATH=[0,1]**
+
+When set to 0 it will use the default path where tensors are encoded to ProtoText before being copied to a remote process. When set to 1 a more optimal path will be taken where only the tensor description is encoded while the actual tensor data is transferred directly from the source buffer to the destination buffer.
+This path is disabled by default as it requires that MPI library can directly access the pointer to the data. For CPU backed buffers this is no problem, however for GPU backed buffers this requires MPI libraries that are built with CUDA support (CUDA Aware). When using non-CUDA aware MPI libraries and GPU buffers you will get segmentation faults.
+
+
+
+## Known problems
+
+For certain complex neural nets the implementation sometimes crashes inside the MPI libraries. This seems to be related to memory allocations/routines that register the memory for the Infiniband transfers. (The crashes do not happen when all MPI processes are within the same physical machine). 
+
+**MVAPICH**
+- The problem manifests itself with a segmentation fault inside a memory copy routine and during startup you will get the following warning: "WARNING: Error in initializing MVAPICH2 ptmalloc library. Continuing without InfiniBand registration cache support." 
+
+**OpenMPI**
+- With OpenMPI corrupt data will be received resulting in an assertion or the MPI library will print an error and exit. The error is "Attempt to free memory that is still in use by an ongoing MPI communication.  MPI job will now abort."
+
+## Implementation details
+
+
+The implementation takes over the responsibility for sending and receiving tensors between separate processes. This is facilitated by TensorFlow's ability to support different protocols. In this particular implementation, the standard gRPC library is used for all administrative operations while the MPI functions take over the tensor exchanges. On the sending side the tensors are placed in the standard waiting tables and nothing is changed there. On the receiving side the RecvFromRemoteAsync function is newly implemented and instead of requesting the data via gRPC the data is now requested via MPI calls.
+
+To this end once the code is loaded a dedicated thread will be launched that handles all MPI operations. This thread will loop through a set of operations:
+
+* Send requests placed on the request queue to the sending process
+Once a request for a tensor is received two callbacks are created. The first one is to request the tensor and the second one is executed once the requested data has arrived. To this end the request is placed in a queue and will be send once the MPI thread serves the queue. This sending is done using non-blocking MPI_Isend operations.
+
+* Send tensor data in response to a request call
+Once a request has arrived from a remote process the request is forwarded to the original TensorFlow code which looks up the tensor in the waiting table. Once the tensor has been found a callback is executed which places the found tensor on the sendQueue for the MPI thread. Once the sendQueue is served the tensor data will be send using non-blocking send operations (MP_Isend) to the remote process.
+
+* Receive tensor request
+The MPI thread will check if there are any incoming tensor request messages on the communication lines using MPI_Iprobe. Once a request has been received it will be passed on to the standard TensorFlow code and eventually will be placed on the sendQueue.
+
+* Receive tensor 
+At some point after a request has been send the remote process will transmit the tensor. This tensor will be received and we look-up the callback that is associated with this tensor in our request table and execute the callback on the received data.
+
+
+In the implementation all send operations are non-blocking, all probe operations are non-blocking and all receive-operations are blocking. The receive-operations are only executed after the probe has determined that there is something to receive. 
+The MPI processes identify each other using an MPI process ID. The TensorFlow gRPC processes identify each other using a name, during launch we create a mapping between the TensorFlow process name and the MPI process ID to allow the processes to communicate with the correct destinations when using MPI operations.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tensorflow/contrib/mpi/README.md
+++ b/tensorflow/contrib/mpi/README.md
@@ -10,7 +10,7 @@
 
 ## Overview
 
-By using this protocol the TensorFlow can take advantage of the high performance networking primitives that are offered via the MPI API. This enables TensorFlow to take advantage of high performance low latency networks such as Infiniband. These changes are largely transparent to the user who only has to change the offered protocol and launch the script using the 'mpirun'  launcher. For example:
+By using this protocol TensorFlow can take advantage of the high performance networking primitives that are offered via the MPI API. This enables TensorFlow to take advantage of high performance low latency networks such as Infiniband. These changes are largely transparent to the user who only has to change the offered protocol and launch the script using the 'mpirun'  launcher. For example:
     ```mpirun -np 2 python my_neuralnet.py ```
 
 
@@ -28,7 +28,7 @@ This environment variable allows you to disable the MPI path before launch (e.g.
 **MPI_OPTIMAL_PATH=[0,1]**
 
 When set to 0 it will use the default path where tensors are encoded to ProtoText before being copied to a remote process. When set to 1 a more optimal path will be taken where only the tensor description is encoded while the actual tensor data is transferred directly from the source buffer to the destination buffer.
-This path is disabled by default as it requires that MPI library can directly access the pointer to the data. For CPU backed buffers this is no problem, however for GPU backed buffers this requires MPI libraries that are built with CUDA support (CUDA Aware). When using non-CUDA aware MPI libraries and GPU buffers you will get segmentation faults.
+This path is disabled by default as it requires that the MPI library can directly access the pointer to the data. For CPU backed buffers this is no problem, however for GPU backed buffers this requires MPI libraries that are built with CUDA support (CUDA Aware). When using non-CUDA aware MPI libraries and GPU buffers you will get segmentation faults.
 
 
 
@@ -50,7 +50,7 @@ The implementation takes over the responsibility for sending and receiving tenso
 To this end once the code is loaded a dedicated thread will be launched that handles all MPI operations. This thread will loop through a set of operations:
 
 * Send requests placed on the request queue to the sending process
-Once a request for a tensor is received two callbacks are created. The first one is to request the tensor and the second one is executed once the requested data has arrived. To this end the request is placed in a queue and will be send once the MPI thread serves the queue. This sending is done using non-blocking MPI_Isend operations.
+Once a request for a tensor is received two callbacks are created. The first one is to request the tensor and the second one is executed once the requested data has arrived. To this end the request is placed in a queue and will be sent once the MPI thread services the queue. This sending is done using non-blocking MPI_Isend operations.
 
 * Send tensor data in response to a request call
 Once a request has arrived from a remote process the request is forwarded to the original TensorFlow code which looks up the tensor in the waiting table. Once the tensor has been found a callback is executed which places the found tensor on the sendQueue for the MPI thread. Once the sendQueue is served the tensor data will be send using non-blocking send operations (MP_Isend) to the remote process.
@@ -59,11 +59,11 @@ Once a request has arrived from a remote process the request is forwarded to the
 The MPI thread will check if there are any incoming tensor request messages on the communication lines using MPI_Iprobe. Once a request has been received it will be passed on to the standard TensorFlow code and eventually will be placed on the sendQueue.
 
 * Receive tensor 
-At some point after a request has been send the remote process will transmit the tensor. This tensor will be received and we look-up the callback that is associated with this tensor in our request table and execute the callback on the received data.
+At some point after a request has been sent the remote process will transmit the tensor. This tensor will be received and we look-up the callback that is associated with this tensor in our request table and execute the callback on the received data.
 
 
 In the implementation all send operations are non-blocking, all probe operations are non-blocking and all receive-operations are blocking. The receive-operations are only executed after the probe has determined that there is something to receive. 
-The MPI processes identify each other using an MPI process ID. The TensorFlow gRPC processes identify each other using a name, during launch we create a mapping between the TensorFlow process name and the MPI process ID to allow the processes to communicate with the correct destinations when using MPI operations.
+The MPI processes identify each other using an MPI process ID. The TensorFlow gRPC processes identify each other using a name. During launch we create a mapping between the TensorFlow process name and the MPI process ID to allow the processes to communicate with the correct destinations when using MPI operations.
 
 
 

--- a/tensorflow/contrib/mpi/mpi_msg.proto
+++ b/tensorflow/contrib/mpi/mpi_msg.proto
@@ -1,0 +1,19 @@
+
+syntax = "proto3";
+
+package tensorflow;
+option cc_enable_arenas = true;
+
+import "tensorflow/core/protobuf/worker.proto";
+
+
+message MPIRecvTensorResponse {
+    RecvTensorResponse response = 1;
+    bool              singleSend = 2;
+    string key = 3;
+    int64 step_id = 4;
+    uint64 checksum = 5;
+}
+
+
+

--- a/tensorflow/contrib/mpi/mpi_rendezvous_mgr.cc
+++ b/tensorflow/contrib/mpi/mpi_rendezvous_mgr.cc
@@ -1,0 +1,301 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/contrib/mpi/mpi_rendezvous_mgr.h"
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "tensorflow/core/distributed_runtime/tensor_coding.h"
+#include "tensorflow/core/common_runtime/device.h"
+#include "tensorflow/core/common_runtime/device_mgr.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_util.h"
+#include "tensorflow/core/distributed_runtime/session_mgr.h"
+
+namespace tensorflow {
+
+void MPIRemoteRendezvous::RecvFromRemoteAsync(
+    const Rendezvous::ParsedKey& parsed, const Rendezvous::Args& recv_args,
+    DoneCallback done) {
+
+  Status s = Status::OK();
+  MPIRequestTensorCall* rendezvous_call = new MPIRequestTensorCall();
+
+  VLOG(2) << "MPI User requested " << parsed.FullKey()
+          << " @ step: " << step_id_ << std::endl;
+
+  const int dst = mpiutils_->GetSourceID(parsed.FullKey().ToString());
+
+  Device* dst_device;
+  if (s.ok()) {
+    s = env_->device_mgr->LookupDevice(parsed.dst_device, &dst_device);
+  } else {
+    done(s, Args(), recv_args, Tensor{}, false);
+    return;
+  }
+
+  // Set properties of the request object and create the request function
+  rendezvous_call->Init(parsed, step_id_);
+
+  std::function<void()> request_call = [parsed, dst, rendezvous_call]() {
+    // Use MPI_Alloc_mem here to force allocation inside MPI thread
+    // this is not optimal, but prevents memory corruption and segmentation
+    // faults during inter-server transfers...
+    MPI_CHECK(MPI_Alloc_mem(rendezvous_call->request_buffer_size_,
+                            MPI_INFO_NULL, &rendezvous_call->request_buffer_));
+    rendezvous_call->req_.SerializeToArray(
+        rendezvous_call->request_buffer_,
+        rendezvous_call->request_buffer_size_);
+    MPI_CHECK(MPI_Isend(rendezvous_call->request_buffer_,
+                        rendezvous_call->request_buffer_size_, MPI_CHAR, dst,
+                        TAG_REQTENSOR, MPI_COMM_WORLD,
+                        &rendezvous_call->mpi_request_));
+  };
+
+  // Create the function which is called when the Tensor is send by remote
+  const int64 temp1 = step_id_;
+  rendezvous_call->recv_call_ = [this, parsed, recv_args, done, dst, temp1,
+                                 rendezvous_call](MPIRecvTensorResponse mRes) {
+    Status s;
+    Device* dst_device;
+    if (s.ok()) {
+      s = env_->device_mgr->LookupDevice(parsed.dst_device, &dst_device);
+    }
+
+    VLOG(3) << "MPI Received tensor " << parsed.FullKey()
+            << " @ step: " << temp1 << " single-send: " << mRes.singlesend()
+            << std::endl;
+
+    Tensor val;
+    if (mRes.singlesend()) {
+      dst_device->MakeTensorFromProto(mRes.response().tensor(),
+                                      recv_args.alloc_attrs, &val);
+    } else {
+      TensorResponse tr;
+      tr.InitAlloc(dst_device, recv_args.alloc_attrs);
+      tr.InitPartial(mRes.response());
+      const size_t nBytes = tr.tensor().TotalBytes();
+      void* data = const_cast<void*>(DMAHelper::base(&tr.tensor()));
+      MPI_Status status;
+      MPI_CHECK(MPI_Recv(data, static_cast<int>(nBytes), MPI_BYTE, dst,
+                         TAG_SENDTENSOR2, MPI_COMM_WORLD, &status));
+      val = std::move(tr.tensor());
+    }
+
+    done(s, Args(), recv_args, val, mRes.response().is_dead());
+  };
+
+  auto mgr = dynamic_cast<MPIRendezvousMgr*>(this->rendezvous_mgr_);
+  mgr->QueueRequest(parsed.FullKey().ToString(), step_id_,
+                    std::move(request_call), rendezvous_call);
+}
+
+MPIRemoteRendezvous::~MPIRemoteRendezvous() {
+  auto mgr = dynamic_cast<MPIRendezvousMgr*>(this->rendezvous_mgr_);
+  mgr->RemoveStepID(step_id_);
+}
+
+/*
+ * Add the request for one of our Tensors by a remote process
+ * to the local send/table. The here created callback will
+ * be called once the Tensor data has arrived and is
+ * ready to be send to the remote requester.
+ */
+void MPIRendezvousMgr::AddRequest(RecvTensorRequest request,
+                                  const int mpi_dst) {
+  const int64 step_id = request.step_id();
+  const std::string& key = request.rendezvous_key();
+  Rendezvous::ParsedKey parsed;
+  Status s = Rendezvous::ParseKey(key, &parsed);
+
+  MPIRecvTensorCallBack send_cb = [this, mpi_dst, parsed](
+      const Status& status, const Rendezvous::Args& send_args,
+      const Rendezvous::Args& recv_args, const Tensor& val, bool is_dead,
+      MPISendTensorCall* mpiSC) {
+    // TODO(jbedorf) this should be a loop over max size
+    CHECK(mpiSC->mRes_.ByteSize() < INT_MAX)
+        << "Buffer too large for single transfer";
+    MPI_CHECK(MPI_Alloc_mem(mpiSC->mRes_.ByteSize(), MPI_INFO_NULL,
+                            &mpiSC->send_buffer_));
+    mpiSC->mRes_.SerializeToArray(mpiSC->send_buffer_, mpiSC->mRes_.ByteSize());
+
+    MPI_CHECK(MPI_Isend(
+        mpiSC->send_buffer_, static_cast<int>(mpiSC->mRes_.ByteSize()),
+        MPI_CHAR, mpi_dst, TAG_SENDTENSOR, MPI_COMM_WORLD, &(mpiSC->msg1_)));
+    MPI_CHECK(MPI_Test(&mpiSC->msg1_, &mpiSC->done1_, MPI_STATUS_IGNORE));
+
+    if (!mpiSC->mRes_.singlesend()) {
+      const int tensor_size = static_cast<int>(val.TotalBytes());
+      void* temp = const_cast<void*>(DMAHelper::base(&val));
+
+      // If the MPI library is not GPU aware there should be a data transfer
+      // here to get the data on the host.
+      // if(src_dev->tensorflow_gpu_device_info()) //memcpy to send_buffer2_
+
+      // TODO(jbedorf)  this should be a loop over max size
+      MPI_CHECK(MPI_Isend(temp, tensor_size, MPI_CHAR, mpi_dst, TAG_SENDTENSOR2,
+                          MPI_COMM_WORLD, &mpiSC->msg2_));
+      mpiSC->done2_ = 0;
+    }
+    return mpiSC;
+  };
+
+  // Wrapper around the read callback to place the callback on our queue
+  Rendezvous::DoneCallback done_cb = [this, parsed, step_id, send_cb](
+      const Status& status, const Rendezvous::Args& send_args,
+      const Rendezvous::Args& recv_args, const Tensor& val, bool is_dead) {
+    if (!status.ok()) {
+      CHECK(status.ok()) << "RecvLocalAsync was not ok, key: "
+                         << parsed.FullKey() << " step: " << step_id
+                         << " error message: " << status.error_message();
+      return;
+    }
+
+    VLOG(3) << "MPI Sending tensor " << parsed.FullKey()
+            << " @ step: " << step_id << std::endl;
+
+    auto mpiSC = new MPISendTensorCall();
+    mpiSC->Init(parsed, step_id, is_dead);
+
+    Device* src_dev = nullptr;
+    Status s = this->worker_env_2->device_mgr->LookupDevice(parsed.src_device,
+                                                            &src_dev);
+    CHECK(s.ok()) << "src device not found";
+
+    // Control if shape and data should be send together or if we can optimize
+    // it in two different transfers, thereby reducing memory copies
+    bool doOptimalTransfer = true;
+    if (!DataTypeCanUseMemcpy(val.dtype())) doOptimalTransfer = false;
+    if (val.TotalBytes() < 1024) doOptimalTransfer = false;
+
+    doOptimalTransfer = doOptimalTransfer && use_optimal_transfer_;
+
+    if (doOptimalTransfer) {
+      // First send the Tensor description and in a follow up transfer the data
+      mpiSC->mRes_.mutable_response()->mutable_tensor()->set_dtype(val.dtype());
+      val.shape().AsProto(mpiSC->mRes_.mutable_response()
+                              ->mutable_tensor()
+                              ->mutable_tensor_shape());
+      mpiSC->mRes_.set_singlesend(false);
+    } else {
+      // Send the Tensor description and data in a single transfer
+      if (src_dev->tensorflow_gpu_device_info() &&
+          (!send_args.alloc_attrs.on_host())) {
+        Notification n;
+        GPUUtil::SetProtoFromGPU(
+            val, src_dev, send_args.device_context,
+            mpiSC->mRes_.mutable_response()->mutable_tensor(), is_dead,
+            [&n, &s](const Status& s_) {
+              s = s_;
+              n.Notify();
+            });
+        n.WaitForNotification();
+      } else {
+        val.AsProtoTensorContent(
+            mpiSC->mRes_.mutable_response()->mutable_tensor());
+      }
+    }
+
+    std::function<MPISendTensorCall*()> res =
+        std::bind(send_cb, status, send_args, recv_args, val, is_dead, mpiSC);
+
+    SendQueueEntry req(parsed.FullKey().ToString().c_str(), std::move(res));
+
+    this->QueueSendRequest(req);
+
+    // Wait for the notification that indicates the tensor has been
+    // succesfully transmitted to the remote process. Only needed if we
+    // have not parsed the tensor to proto
+    if (doOptimalTransfer) mpiSC->n_.WaitForNotification();
+  };  // done_cb
+
+  worker_env_2->compute_pool->Schedule([this, step_id, parsed, done_cb]() {
+    this->RecvLocalAsync(step_id, parsed, done_cb);
+  });
+}
+
+MPIRendezvousMgr::MPIRendezvousMgr(const WorkerEnv* env)
+    : BaseRendezvousMgr(env), worker_env_2(env), use_optimal_transfer_(false) {
+
+  const char* mpienv = getenv("MPI_OPTIMAL_PATH");
+  if (mpienv && mpienv[0] == '1') {
+    LOG(INFO) << "MPI Optimal copy path enabled (Requires CUDA-Aware MPI when "
+                 "using GPUs)\n";
+    use_optimal_transfer_ = true;
+  }
+
+  // extract worker-name from somewhere
+  std::string worker_name = env->local_devices[0]->name();
+  worker_name = worker_name.substr(0, worker_name.rfind('/'));  // Strip device
+
+  mpiutils_ = new MPIUtils(worker_name);
+  background_thread_ =
+      std::thread(&MPIRendezvousMgr::MPIBackgroundThread, this);
+}
+
+BaseRemoteRendezvous* MPIRendezvousMgr::Create(int64 step_id,
+                                               const WorkerEnv* worker_env) {
+  return new MPIRemoteRendezvous(worker_env, step_id, mpiutils_, this);
+}
+
+void MPIRendezvousMgr::MPIBackgroundThread() {
+  std::list<std::unique_ptr<MPISendTensorCall>> active_sends;
+
+  while (1) {
+    MPI_Status status;
+
+    // Check for incoming Tensor requests
+    RecvTensorRequest request;
+    if (ProbeForData(TAG_REQTENSOR, &status, &request)) {
+      this->AddRequest(request, status.MPI_SOURCE);
+    }
+
+    // Check for incoming Tensor reply
+    MPIRecvTensorResponse mRes;
+    if (ProbeForData(TAG_SENDTENSOR, &status, &mRes)) {
+      const int64 step_id = mRes.step_id();
+      std::string key = mRes.key();
+
+      std::shared_ptr<MPIRequestTensorCall> call;
+      GetRecvCall(step_id, key, &call);
+      call->recv_call_(mRes);
+      RemoveRecvCall(step_id, key);
+    }
+
+    // Remove sends that have been completed
+    active_sends.remove_if([](std::unique_ptr<MPISendTensorCall>& i) {
+      return i->IsFinished();
+    });
+
+    // send a Tensor request
+    RequestQueueEntry req;
+    if (GetRequest(&req)) req.second();
+
+    // Send a Tensor response
+    SendQueueEntry send;
+    if (GetResponse(&send)) {
+      std::unique_ptr<MPISendTensorCall> p(send.second());
+      active_sends.push_back(std::move(p));
+    }
+
+    //    std::this_thread::sleep_for(std::chrono::microseconds(1));
+  }
+}
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/mpi/mpi_rendezvous_mgr.cc
+++ b/tensorflow/contrib/mpi/mpi_rendezvous_mgr.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#ifdef TENSORFLOW_USE_MPI
+
 #include "tensorflow/contrib/mpi/mpi_rendezvous_mgr.h"
 
 #include <chrono>
@@ -310,3 +312,4 @@ void MPIRendezvousMgr::MPIBackgroundThread() {
 }
 
 }  // namespace tensorflow
+#endif  // TENSORFLOW_USE_MPI

--- a/tensorflow/contrib/mpi/mpi_rendezvous_mgr.h
+++ b/tensorflow/contrib/mpi/mpi_rendezvous_mgr.h
@@ -40,7 +40,8 @@ limitations under the License.
 
 namespace tensorflow {
 
-struct MPISendTensorCall {
+class MPISendTensorCall {
+ public:
   char* send_buffer_;
   char* send_buffer2_;
 
@@ -82,7 +83,8 @@ struct MPISendTensorCall {
   }
 };
 
-struct MPIRequestTensorCall {
+class MPIRequestTensorCall {
+ public:
   Rendezvous::DoneCallback done_;
   RecvTensorRequest req_;
   MPI_Request mpi_request_;

--- a/tensorflow/contrib/mpi/mpi_rendezvous_mgr.h
+++ b/tensorflow/contrib/mpi/mpi_rendezvous_mgr.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_MPI_MPI_RENDEZVOUS_MGR_H_
 #define TENSORFLOW_CONTRIB_MPI_MPI_RENDEZVOUS_MGR_H_
 
+#ifdef TENSORFLOW_USE_MPI
+
 #include <queue>
 #include <thread>
 #include <list>
@@ -254,4 +256,5 @@ class MPIRendezvousMgr : public BaseRendezvousMgr {
 };  // MPIRendezvousMgr
 }  // namespace tensorflow
 
+#endif  // TENSORFLOW_USE_MPI
 #endif  // TENSORFLOW_CONTRIB_MPI_MPI_RENDEZVOUS_MGR_H_

--- a/tensorflow/contrib/mpi/mpi_rendezvous_mgr.h
+++ b/tensorflow/contrib/mpi/mpi_rendezvous_mgr.h
@@ -1,0 +1,255 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CONTRIB_MPI_MPI_RENDEZVOUS_MGR_H_
+#define TENSORFLOW_CONTRIB_MPI_MPI_RENDEZVOUS_MGR_H_
+
+#include <queue>
+#include <thread>
+#include <list>
+#include <string>
+#include <memory>
+#include <map>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <iostream>
+
+#include "tensorflow/contrib/mpi/mpi_utils.h"
+#include "tensorflow/core/distributed_runtime/base_rendezvous_mgr.h"
+#include "tensorflow/core/distributed_runtime/worker_env.h"
+#include "tensorflow/contrib/mpi/mpi_msg.pb.h"
+#include "tensorflow/core/protobuf/worker.pb.h"
+
+#define TAG_REQTENSOR 1010
+#define TAG_SENDTENSOR 2020
+#define TAG_SENDTENSOR2 3030
+
+namespace tensorflow {
+
+struct MPISendTensorCall {
+  char* send_buffer_;
+  char* send_buffer2_;
+
+  MPI_Request msg1_;
+  MPI_Request msg2_;
+  int done1_;  // Int instead of bool for simpler IsFinished logic
+  int done2_;
+  MPIRecvTensorResponse mRes_;
+  Notification n_;
+
+  MPISendTensorCall()
+      : send_buffer_(nullptr), send_buffer2_(nullptr), done1_(1), done2_(1) {}
+
+  ~MPISendTensorCall() {
+    MPI_CHECK(MPI_Wait(&msg1_, MPI_STATUS_IGNORE));
+    n_.Notify();
+    MPI_CHECK(MPI_Free_mem(send_buffer_));
+    //    delete[] send_buffer_;
+    delete[] send_buffer2_;
+  }
+
+  MPISendTensorCall(MPISendTensorCall&&) = delete;
+
+  void Init(const Rendezvous::ParsedKey& parsed, const int64 step_id,
+            const bool is_dead) {
+    mRes_.set_key(parsed.FullKey().ToString());
+    mRes_.set_step_id(step_id);
+    mRes_.mutable_response()->set_is_dead(is_dead);
+    mRes_.mutable_response()->set_send_start_micros(
+        Env::Default()->NowMicros());
+    mRes_.set_singlesend(true);
+  }
+
+  bool IsFinished() {
+    MPI_Status status;
+    if (!done1_) MPI_CHECK(MPI_Test(&msg1_, &done1_, &status));
+    if (!done2_) MPI_CHECK(MPI_Test(&msg2_, &done2_, &status));
+    return done1_ && done2_;
+  }
+};
+
+struct MPIRequestTensorCall {
+  Rendezvous::DoneCallback done_;
+  RecvTensorRequest req_;
+  MPI_Request mpi_request_;
+  char* request_buffer_;
+  size_t request_buffer_size_;
+  std::function<void(MPIRecvTensorResponse)> recv_call_;
+
+  MPIRequestTensorCall() : request_buffer_(nullptr) {}
+  ~MPIRequestTensorCall() {
+    MPI_CHECK(MPI_Wait(&mpi_request_, MPI_STATUS_IGNORE));
+    // delete[] request_buffer_;
+    MPI_CHECK(MPI_Free_mem(request_buffer_));
+  }
+
+  void Init(const Rendezvous::ParsedKey& parsed, const int64 step_id) {
+    req_.set_step_id(step_id);
+    req_.set_rendezvous_key(parsed.FullKey().data(), parsed.FullKey().size());
+    request_buffer_size_ = req_.ByteSize();
+    //   request_buffer_ = new char[request_buffer_size_];
+    //  req_.SerializeToArray(request_buffer_, request_buffer_size_);
+  }
+};
+
+class MPIRemoteRendezvous : public BaseRemoteRendezvous {
+ public:
+  MPIRemoteRendezvous(const WorkerEnv* env, int64 step_id, const MPIUtils* util,
+                      BaseRendezvousMgr* mgr_)
+      : BaseRemoteRendezvous(env, step_id, false),
+        mpiutils_(util),
+        rendezvous_mgr_(mgr_) {}
+
+ protected:
+  void RecvFromRemoteAsync(const Rendezvous::ParsedKey& parsed,
+                           const Rendezvous::Args& args,
+                           DoneCallback done) override;
+
+ private:
+  ~MPIRemoteRendezvous() override;
+
+  const MPIUtils* mpiutils_;
+  BaseRendezvousMgr* rendezvous_mgr_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(MPIRemoteRendezvous);
+};
+
+class MPIRendezvousMgr : public BaseRendezvousMgr {
+ public:
+  explicit MPIRendezvousMgr(const WorkerEnv* env);
+  ~MPIRendezvousMgr() {
+    delete mpiutils_;
+    fprintf(stderr, "Delete MPIRendezvousMgr \n");
+    // TODO(jbedorf) stop background_thread_
+    MPI_CHECK(MPI_Finalize());
+  }
+
+  void QueueRequest(std::string key, int64 step_id,
+                    std::function<void()> request_call,
+                    MPIRequestTensorCall* rCall) {
+    mutex_lock l(mrq_);
+    request_queue_.push(RequestQueueEntry(key, std::move(request_call)));
+    recv_tensor_map_[step_id][key] =
+        std::shared_ptr<MPIRequestTensorCall>(rCall);
+  }
+
+  void RemoveStepID(const int64 step_id) {
+    mutex_lock l(mrq_);
+    CHECK(recv_tensor_map_[step_id].size() == 0) << "Removing unfinished step";
+    recv_tensor_map_.erase(step_id);
+    // TODO(jbedorf) Should we verify that the step_id is clear before remove?
+  }
+
+ protected:
+  BaseRemoteRendezvous* Create(int64 step_id,
+                               const WorkerEnv* worker_env) override;
+
+ private:
+  typedef std::function<MPISendTensorCall*(
+      const Status&, const Rendezvous::Args&, const Rendezvous::Args&,
+      const Tensor&, const bool, MPISendTensorCall*)> MPIRecvTensorCallBack;
+
+  typedef std::pair<std::string, std::function<void()>> RequestQueueEntry;
+  typedef std::pair<std::string, std::function<MPISendTensorCall*()>>
+      SendQueueEntry;
+
+  const WorkerEnv* worker_env_2;
+  std::thread background_thread_;
+  MPIUtils* mpiutils_;
+  bool use_optimal_transfer_;
+
+  mutex msq_;
+  mutex mrq_;
+
+  std::queue<SendQueueEntry> send_queue_ GUARDED_BY(msq_);
+  std::queue<RequestQueueEntry> request_queue_ GUARDED_BY(mrq_);
+  std::map<int64, std::unordered_map<std::string,
+                                     std::shared_ptr<MPIRequestTensorCall>>>
+      recv_tensor_map_ GUARDED_BY(mrq_);
+
+  void AddRequest(RecvTensorRequest, const int);
+  void MPIBackgroundThread();
+
+  void QueueSendRequest(SendQueueEntry req) {
+    mutex_lock l(msq_);
+    send_queue_.push(req);
+  }
+
+  void GetRecvCall(const int64 step_id, const std::string& key,
+                   std::shared_ptr<MPIRequestTensorCall>* call) {
+    mutex_lock l(mrq_);
+    if (recv_tensor_map_.find(step_id) == recv_tensor_map_.end()) {
+      LOG(FATAL) << "Step not found in recv_tensor_map_, step: " << step_id
+                 << " key:  " << key << std::endl;
+    }
+    if (recv_tensor_map_[step_id].find(key) !=
+        recv_tensor_map_[step_id].end()) {
+      *call = recv_tensor_map_[step_id][key];
+    } else {
+      LOG(FATAL) << "Key not found in recv_tensor_map_, step: " << step_id
+                 << " key:  " << key << std::endl;
+    }
+  }
+
+  void RemoveRecvCall(const int64 step_id, const std::string& key) {
+    mutex_lock l(mrq_);
+    recv_tensor_map_[step_id].erase(key);
+  }
+
+  bool GetRequest(RequestQueueEntry* req) {
+    mutex_lock l(mrq_);
+    if (!request_queue_.empty()) {
+      *req = request_queue_.front();
+      request_queue_.pop();
+      return true;
+    }
+    return false;
+  }
+
+  bool GetResponse(SendQueueEntry* send) {
+    mutex_lock l(msq_);
+    if (!send_queue_.empty()) {
+      *send = send_queue_.front();
+      send_queue_.pop();
+      return true;
+    }
+    return false;
+  }
+
+  template <typename T>
+  int ProbeForData(const int tag, MPI_Status* status, T* obj) {
+    int flag = 0, msg_size = 0;
+    MPI_Message msg;
+    // Receive the message, probe as size is variable
+    MPI_CHECK(
+        MPI_Improbe(MPI_ANY_SOURCE, tag, MPI_COMM_WORLD, &flag, &msg, status));
+    if (flag) {
+      MPI_CHECK(MPI_Get_count(status, MPI_CHAR, &msg_size));
+      MPI_Status stat2;
+      std::vector<char> request_buffer_(msg_size);
+      MPI_Mrecv(&request_buffer_[0], msg_size, MPI_CHAR, &msg, &stat2);
+      bool res = obj->ParseFromArray(&request_buffer_[0], msg_size);
+      CHECK(res) << "Failed to parse incomming message";
+    }
+    return flag;
+  }
+
+  TF_DISALLOW_COPY_AND_ASSIGN(MPIRendezvousMgr);
+};  // MPIRendezvousMgr
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CONTRIB_MPI_MPI_RENDEZVOUS_MGR_H_

--- a/tensorflow/contrib/mpi/mpi_server_lib.cc
+++ b/tensorflow/contrib/mpi/mpi_server_lib.cc
@@ -1,0 +1,110 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef TENSORFLOW_USE_MPI
+
+#include "tensorflow/contrib/mpi/mpi_server_lib.h"
+
+#include <string>
+#include <utility>
+
+#include "tensorflow/core/distributed_runtime/server_lib.h"
+#include "tensorflow/core/distributed_runtime/rpc/rpc_rendezvous_mgr.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/env.h"
+
+namespace tensorflow {
+
+namespace {
+// static utility function
+RendezvousMgrInterface* NewMPIRendezvousMgr(const WorkerEnv* env) {
+  // Runtime check to disable the MPI path
+  const char* mpienv = getenv("MPI_DISABLED");
+  if (mpienv && mpienv[0] == '1') {
+    LOG(INFO) << "MPI path disabled by environment variable\n";
+    return new RpcRendezvousMgr(env);
+  } else {
+    return new MPIRendezvousMgr(env);
+  }
+}
+
+}  // namespace
+
+MPIServer::MPIServer(const ServerDef& server_def, Env* env)
+    : GrpcServer(server_def, env) {}
+
+MPIServer::~MPIServer() {
+  TF_CHECK_OK(Stop());
+  TF_CHECK_OK(Join());
+}
+
+Status MPIServer::Init(ServiceInitFunction service_func,
+                       RendezvousMgrCreationFunction rendezvous_mgr_func) {
+  Status s = GrpcServer::Init(service_func, rendezvous_mgr_func);
+  return s;
+}
+
+Status MPIServer::Start() {
+  Status s = GrpcServer::Start();
+  return s;
+}
+
+Status MPIServer::Join() {
+  Status s = GrpcServer::Join();
+  return s;
+}
+
+/* static */
+Status MPIServer::Create(const ServerDef& server_def, Env* env,
+                         std::unique_ptr<ServerInterface>* out_server) {
+  std::unique_ptr<MPIServer> ret(new MPIServer(server_def, Env::Default()));
+  ServiceInitFunction service_func = nullptr;
+  TF_RETURN_IF_ERROR(ret->Init(service_func, NewMPIRendezvousMgr));
+  *out_server = std::move(ret);
+  return Status::OK();
+}
+
+namespace {
+
+class MPIServerFactory : public ServerFactory {
+ public:
+  bool AcceptsOptions(const ServerDef& server_def) override {
+    return server_def.protocol() == "grpc+mpi";
+  }
+
+  Status NewServer(const ServerDef& server_def,
+                   std::unique_ptr<ServerInterface>* out_server) override {
+    return MPIServer::Create(server_def, Env::Default(), out_server);
+  }
+};
+
+// Registers a `ServerFactory` for `MPIServer` instances.
+class MPIServerRegistrar {
+ public:
+  MPIServerRegistrar() {
+    gpr_allocation_functions alloc_fns;
+    alloc_fns.malloc_fn = port::Malloc;
+    alloc_fns.realloc_fn = port::Realloc;
+    alloc_fns.free_fn = port::Free;
+    gpr_set_allocation_functions(alloc_fns);
+    ServerFactory::Register("MPI_SERVER", new MPIServerFactory());
+  }
+};
+static MPIServerRegistrar registrar;
+
+}  // namespace
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_USE_MPI

--- a/tensorflow/contrib/mpi/mpi_server_lib.h
+++ b/tensorflow/contrib/mpi/mpi_server_lib.h
@@ -1,0 +1,54 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CONTRIB_MPI_MPI_SERVER_LIB_H_
+#define TENSORFLOW_CONTRIB_MPI_MPI_SERVER_LIB_H_
+
+#ifdef TENSORFLOW_USE_MPI
+
+#include <memory>
+
+#include "tensorflow/contrib/mpi/mpi_rendezvous_mgr.h"
+#include "tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h"
+
+namespace tensorflow {
+
+class MPIServer : public GrpcServer {
+ protected:
+  MPIServer(const ServerDef& server_def, Env* env);
+
+ public:
+  static Status Create(const ServerDef& server_def, Env* env,
+                       std::unique_ptr<ServerInterface>* out_server);
+
+  // Destruction is only supported in the factory method. Clean
+  // shutdown is not currently implemented for this server type.
+  ~MPIServer() override;
+
+  // Implementations of ServerInterface methods.
+  Status Start() override;
+  Status Join() override;
+
+ protected:
+  Status Init(ServiceInitFunction service_func,
+              RendezvousMgrCreationFunction rendezvous_mgr_func);
+  Status ChannelCacheFactory(const ServerDef& server_def,
+                             GrpcChannelCache** channel_cache);
+};
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_USE_MPI
+#endif  // TENSORFLOW_CONTRIB_MPI_MPI_SERVER_LIB_H_

--- a/tensorflow/contrib/mpi/mpi_utils.cc
+++ b/tensorflow/contrib/mpi/mpi_utils.cc
@@ -1,0 +1,68 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/contrib/mpi/mpi_utils.h"
+namespace tensorflow {
+
+#define max_worker_name_length 128
+
+MPIUtils::MPIUtils(const std::string& worker_name) {
+  InitMPI();
+  // Connect the MPI process IDs to the worker names that are used by TF.
+  // Gather the names of all the active processes (name can't be longer than
+  // 128 bytes)
+  int proc_id = 0, number_of_procs = 1;
+  char my_name[max_worker_name_length];
+  MPI_CHECK(MPI_Comm_rank(MPI_COMM_WORLD, &proc_id));
+  MPI_CHECK(MPI_Comm_size(MPI_COMM_WORLD, &number_of_procs));
+
+  CHECK(worker_name.size() < max_worker_name_length)
+      << "Specified worker name is too long.";
+  snprintf(my_name, max_worker_name_length, worker_name.c_str());
+  std::vector<char> worker_names(number_of_procs * max_worker_name_length);
+  MPI_CHECK(MPI_Allgather(my_name, max_worker_name_length, MPI_CHAR,
+                          &worker_names[0], max_worker_name_length, MPI_CHAR,
+                          MPI_COMM_WORLD));
+
+  if (proc_id == 0) LOG(INFO) << "MPI process-ID to gRPC server name map: \n";
+  for (int i = 0; i < number_of_procs; i++) {
+    name_to_id_[std::string(&worker_names[i * 128])] = i;
+    if (proc_id == 0)
+      LOG(INFO) << "Process: " << i
+                << "\tgRPC-name: " << std::string(&worker_names[i * 128])
+                << std::endl;
+  }
+}
+
+void MPIUtils::InitMPI() {
+  // Initialize the MPI environment if that hasn't been done
+  int flag = 0;
+  MPI_CHECK(MPI_Initialized(&flag));
+  if (!flag) {
+    int proc_id = 0, number_of_procs = 1, len = -1;
+    char my_host_name[max_worker_name_length];
+    // MPI_CHECK(MPI_Init_thread(0, 0, MPI_THREAD_MULTIPLE, &flag));
+    MPI_CHECK(MPI_Init(0, 0));
+    MPI_CHECK(MPI_Comm_rank(MPI_COMM_WORLD, &proc_id));
+    MPI_CHECK(MPI_Comm_size(MPI_COMM_WORLD, &number_of_procs));
+    MPI_CHECK(MPI_Get_processor_name(my_host_name, &len));
+    fprintf(stderr,
+            "MPI Environment initialised. Process id: %d Total processes: %d "
+            "|| Hostname: %s \n",
+            proc_id, number_of_procs, my_host_name);
+  }
+}
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/mpi/mpi_utils.cc
+++ b/tensorflow/contrib/mpi/mpi_utils.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#ifdef TENSORFLOW_USE_MPI
+
 #include "tensorflow/contrib/mpi/mpi_utils.h"
 namespace tensorflow {
 
@@ -66,3 +68,5 @@ void MPIUtils::InitMPI() {
 }
 
 }  // namespace tensorflow
+
+#endif  // TENSORFLOW_USE_MPI

--- a/tensorflow/contrib/mpi/mpi_utils.h
+++ b/tensorflow/contrib/mpi/mpi_utils.h
@@ -39,26 +39,16 @@ class MPIUtils {
  public:
   explicit MPIUtils(const std::string& worker_name);
 
-  const int GetSourceID(const std::string& key) const {
-    auto it = name_to_id_.find(GetWorkerName(key, 0));
+  const int GetSourceID(const std::string& task_id) const {
+    auto it = name_to_id_.find(task_id);
     if (it == name_to_id_.end()) {
-      LOG(FATAL) << "Failed to convert worker name to MPI index: " << key;
+      LOG(FATAL) << "Failed to convert worker name to MPI index: " << task_id;
     }
     return it->second;
   }
 
  private:
   void InitMPI();
-
-  // Returns the name of the destination specified in a rendezvous key
-  // For idx=0 it is the source, for idx=2 it is the destination
-  std::string GetWorkerName(const std::string& key, const int idx) const {
-    const std::vector<std::string> num_strings = str_util::Split(key, ';');
-    // Sanity check, should be 5 src;id;dst;name;frame_iter
-    assert(num_strings.size() == 5);
-    // Strip the device eg /cpu:0 to get the worker name
-    return num_strings[idx].substr(0, num_strings[idx].find_last_of('/'));
-  }
 
   std::map<std::string, int> name_to_id_;
 };

--- a/tensorflow/contrib/mpi/mpi_utils.h
+++ b/tensorflow/contrib/mpi/mpi_utils.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_MPI_MPI_UTILS_H_
 #define TENSORFLOW_CONTRIB_MPI_MPI_UTILS_H_
 
+#ifdef TENSORFLOW_USE_MPI
+
 #include <string>
 #include <map>
 #include <vector>
@@ -54,4 +56,5 @@ class MPIUtils {
 };
 }  // namespace tensorflow
 
+#endif  // TENSORFLOW_USE_MPI
 #endif  // TENSORFLOW_CONTRIB_MPI_MPI_UTILS_H_

--- a/tensorflow/contrib/mpi/mpi_utils.h
+++ b/tensorflow/contrib/mpi/mpi_utils.h
@@ -1,0 +1,67 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CONTRIB_MPI_MPI_UTILS_H_
+#define TENSORFLOW_CONTRIB_MPI_MPI_UTILS_H_
+
+#include <string>
+#include <map>
+#include <vector>
+
+#include "tensorflow/core/lib/strings/str_util.h"
+
+#include "third_party/mpi/mpi.h"
+#define MPI_CHECK(cmd)                                                \
+  do {                                                                \
+    int mpi_errno = cmd;                                              \
+    if (MPI_SUCCESS != mpi_errno) {                                   \
+      fprintf(stderr, "[%s:%d] MPI call failed with %d \n", __FILE__, \
+              __LINE__, mpi_errno);                                   \
+      exit(EXIT_FAILURE);                                             \
+    }                                                                 \
+    assert(MPI_SUCCESS == mpi_errno);                                 \
+  } while (false)
+
+namespace tensorflow {
+class MPIUtils {
+ public:
+  explicit MPIUtils(const std::string& worker_name);
+
+  const int GetSourceID(const std::string& key) const {
+    auto it = name_to_id_.find(GetWorkerName(key, 0));
+    if (it == name_to_id_.end()) {
+      LOG(FATAL) << "Failed to convert worker name to MPI index: " << key;
+    }
+    return it->second;
+  }
+
+ private:
+  void InitMPI();
+
+  // Returns the name of the destination specified in a rendezvous key
+  // For idx=0 it is the source, for idx=2 it is the destination
+  std::string GetWorkerName(const std::string& key, const int idx) const {
+    const std::vector<std::string> num_strings = str_util::Split(key, ';');
+    // Sanity check, should be 5 src;id;dst;name;frame_iter
+    assert(num_strings.size() == 5);
+    // Strip the device eg /cpu:0 to get the worker name
+    return num_strings[idx].substr(0, num_strings[idx].find_last_of('/'));
+  }
+
+  std::map<std::string, int> name_to_id_;
+};
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CONTRIB_MPI_MPI_UTILS_H_

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1285,9 +1285,9 @@ cc_library(
     ],
     copts = tf_copts(),
     defines = tf_additional_lib_defines() + [
-        "SNAPPY",
-    ] + tf_additional_verbs_lib_defines() + 
-        tf_additional_mpi_lib_defines(),
+                  "SNAPPY",
+              ] + tf_additional_verbs_lib_defines() +
+              tf_additional_mpi_lib_defines(),
     linkopts = select({
         "//tensorflow:freebsd": [],
         "//conditions:default": [

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -109,6 +109,7 @@ load(
     "tf_additional_cloud_kernel_deps",
     "tf_lib_proto_parsing_deps",
     "tf_additional_verbs_lib_defines",
+    "tf_additional_mpi_lib_defines",
 )
 load(
     "//tensorflow/core:platform/default/build_config_root.bzl",
@@ -1285,7 +1286,8 @@ cc_library(
     copts = tf_copts(),
     defines = tf_additional_lib_defines() + [
         "SNAPPY",
-    ] + tf_additional_verbs_lib_defines(),
+    ] + tf_additional_verbs_lib_defines() + 
+        tf_additional_mpi_lib_defines(),
     linkopts = select({
         "//tensorflow:freebsd": [],
         "//conditions:default": [

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -254,3 +254,9 @@ def tf_additional_verbs_lib_defines():
       "//tensorflow:with_verbs_support": ["TENSORFLOW_USE_VERBS"],
       "//conditions:default": [],
   })
+
+def tf_additional_mpi_lib_defines():
+  return select({
+      "//tensorflow:with_mpi_support": ["TENSORFLOW_USE_MPI"],
+      "//conditions:default": [],
+  })

--- a/tensorflow/core/platform/default/build_config_root.bzl
+++ b/tensorflow/core/platform/default/build_config_root.bzl
@@ -30,3 +30,10 @@ def tf_additional_verbs_deps():
       "//tensorflow/contrib/verbs:grpc_verbs_client"], 
       "//conditions:default": [],
   })
+
+def tf_additional_mpi_deps():
+  return select({
+      "//tensorflow:with_mpi_support": [
+      "//tensorflow/contrib/mpi:mpi_server_lib"],
+      "//conditions:default": [],
+  })

--- a/tensorflow/core/platform/default/build_config_root.bzl
+++ b/tensorflow/core/platform/default/build_config_root.bzl
@@ -27,7 +27,7 @@ def tf_additional_verbs_deps():
   return select({
       "//tensorflow:with_verbs_support": [
           "//tensorflow/contrib/verbs:verbs_server_lib",
-          "//tensorflow/contrib/verbs:grpc_verbs_client"
+          "//tensorflow/contrib/verbs:grpc_verbs_client",
       ], 
       "//conditions:default": [],
   })
@@ -35,7 +35,7 @@ def tf_additional_verbs_deps():
 def tf_additional_mpi_deps():
   return select({
       "//tensorflow:with_mpi_support": [
-          "//tensorflow/contrib/mpi:mpi_server_lib"
+          "//tensorflow/contrib/mpi:mpi_server_lib",
       ],
       "//conditions:default": [],
   })

--- a/tensorflow/core/platform/default/build_config_root.bzl
+++ b/tensorflow/core/platform/default/build_config_root.bzl
@@ -26,14 +26,16 @@ def tf_additional_license_deps():
 def tf_additional_verbs_deps():
   return select({
       "//tensorflow:with_verbs_support": [
-      "//tensorflow/contrib/verbs:verbs_server_lib",
-      "//tensorflow/contrib/verbs:grpc_verbs_client"], 
+          "//tensorflow/contrib/verbs:verbs_server_lib",
+          "//tensorflow/contrib/verbs:grpc_verbs_client"
+      ], 
       "//conditions:default": [],
   })
 
 def tf_additional_mpi_deps():
   return select({
       "//tensorflow:with_mpi_support": [
-      "//tensorflow/contrib/mpi:mpi_server_lib"],
+          "//tensorflow/contrib/mpi:mpi_server_lib"
+      ],
       "//conditions:default": [],
   })

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -26,6 +26,7 @@ load("//tensorflow/core:platform/default/build_config.bzl", "tf_additional_lib_d
 load("//tensorflow/core:platform/default/build_config_root.bzl", "tf_additional_plugin_deps")
 load("//tensorflow/python:build_defs.bzl", "tf_gen_op_wrapper_private_py")
 load("//tensorflow/core:platform/default/build_config_root.bzl", "tf_additional_verbs_deps")
+load("//tensorflow/core:platform/default/build_config_root.bzl", "tf_additional_mpi_deps")
 
 py_library(
     name = "python",
@@ -2657,7 +2658,8 @@ tf_py_wrap_cc(
         "//util/python:python_headers",
     ] + (tf_additional_lib_deps() +
          tf_additional_plugin_deps() +
-         tf_additional_verbs_deps()),
+         tf_additional_verbs_deps() +
+         tf_additional_mpi_deps()),
 )
 
 py_library(

--- a/third_party/mpi/BUILD
+++ b/third_party/mpi/BUILD
@@ -1,3 +1,4 @@
+licenses(["restricted"])
 
 filegroup(
     name = "all_files",

--- a/third_party/mpi/BUILD
+++ b/third_party/mpi/BUILD
@@ -13,12 +13,13 @@ filegroup(
 )
 
 load("//third_party/mpi:mpi.bzl", "mpi_hdr")
+load("//third_party/mpi:mpi.bzl", "if_mpi")
 
 cc_library(
     name = "mpi",
-    srcs = select({
-        "//conditions:default": ["libmpi.so"],
-    }),
-    hdrs = mpi_hdr(),
+    srcs = if_mpi([
+        "libmpi.so",
+    ]),
+    hdrs = if_mpi(mpi_hdr()),
     visibility = ["//visibility:public"],
 )

--- a/third_party/mpi/BUILD
+++ b/third_party/mpi/BUILD
@@ -1,4 +1,3 @@
-licenses(["notice"])  # Apache 2.0
 
 filegroup(
     name = "all_files",

--- a/third_party/mpi/BUILD
+++ b/third_party/mpi/BUILD
@@ -1,0 +1,24 @@
+licenses(["notice"])  # Apache 2.0
+
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "**/METADATA",
+            "**/OWNERS",
+        ],
+    ),
+    visibility = ["//tensorflow:__subpackages__"],
+)
+
+load("//third_party/mpi:mpi.bzl", "mpi_hdr")
+
+cc_library(
+    name = "mpi",
+    srcs = select({
+        "//conditions:default": ["libmpi.so"],
+    }),
+    hdrs = mpi_hdr(),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/mpi/mpi.bzl
+++ b/third_party/mpi/mpi.bzl
@@ -1,0 +1,11 @@
+#OpenMPI and Mvapich/mpich require different headers
+#based on the configuration options return one or the other
+
+def mpi_hdr():
+    MPI_LIB_IS_OPENMPI=True
+    hdrs = []    
+    if MPI_LIB_IS_OPENMPI:
+        hdrs = ["mpi.h", "mpi_portable_platform.h"]   #When using OpenMPI
+    else:
+        hdrs = ["mpi.h",  "mpio.h", "mpicxx.h"]        #When using MVAPICH
+    return hdrs

--- a/third_party/mpi/mpi.bzl
+++ b/third_party/mpi/mpi.bzl
@@ -9,3 +9,9 @@ def mpi_hdr():
     else:
         hdrs = ["mpi.h",  "mpio.h", "mpicxx.h"]        #When using MVAPICH
     return hdrs
+
+def if_mpi(if_true, if_false = []):
+    return select({
+        "//tensorflow:with_mpi_support": if_true,
+        "//conditions:default": if_false
+    })


### PR DESCRIPTION
This pull request adds an additional communication path to TensorFlow that allows Tensors to be exchanged using MPI based Send and Recieve routines when running distributed TensorFlow. T
The used MPI implementation will pick the most optimal path available between the two communication points allowing the user to take advantage of high performance networks such as Infiniband. 
Certain MPI implementations allow direct data-transfers from GPU buffers (CUDA Aware / GPUDirect RDMA), this option can be enabled using an environment variable. See the README for more details.

Note: Be aware of the known problems that results in unpredictable behavior for certain complex networks. Any help/insight on that from other MPI experts would be appreciated. 
