### PR TITLE
Fix contrib.seq2seq.BeamSearchDecoder #9855

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/beam_search_decoder.py
+++ b/tensorflow/contrib/seq2seq/python/ops/beam_search_decoder.py
@@ -503,7 +503,11 @@ def _beam_search_step(time, logits, beam_state, batch_size, beam_width,
       lambda: scores[:, 0])
 
   # Pick the next beams according to the specified successors function
-  next_beam_size = min(beam_width, scores_flat.shape[-1].value)
+  next_beam_size = math_ops.minimum(
+      ops.convert_to_tensor(
+          beam_width, dtype=dtypes.int32, name="beam_width"),
+      ops.convert_to_tensor(
+          scores_flat.shape[-1], dtype=dtypes.int32, name="num_available"))
   next_beam_scores, word_indices = nn_ops.top_k(scores_flat, k=next_beam_size)
   next_beam_scores.set_shape([static_batch_size, beam_width])
   word_indices.set_shape([static_batch_size, beam_width])

--- a/tensorflow/contrib/seq2seq/python/ops/beam_search_decoder.py
+++ b/tensorflow/contrib/seq2seq/python/ops/beam_search_decoder.py
@@ -562,7 +562,8 @@ def _get_scores(log_probs, sequence_lengths, length_penalty_weight):
   """Calculates scores for beam search hypotheses.
 
   Args:
-    log_probs: The log probabilities with shape [batch_size, beam_width].
+    log_probs: The log probabilities with shape
+      `[batch_size, beam_width, vocab_size]`.
     sequence_lengths: The array of sequence lengths.
     length_penalty_weight: Float weight to penalize length. Disabled with 0.0.
 

--- a/tensorflow/contrib/seq2seq/python/ops/beam_search_decoder.py
+++ b/tensorflow/contrib/seq2seq/python/ops/beam_search_decoder.py
@@ -503,7 +503,8 @@ def _beam_search_step(time, logits, beam_state, batch_size, beam_width,
       lambda: scores[:, 0])
 
   # Pick the next beams according to the specified successors function
-  next_beam_scores, word_indices = nn_ops.top_k(scores_flat, k=beam_width)
+  next_beam_size = min(beam_width, scores_flat.shape[-1].value)
+  next_beam_scores, word_indices = nn_ops.top_k(scores_flat, k=next_beam_size)
   next_beam_scores.set_shape([static_batch_size, beam_width])
   word_indices.set_shape([static_batch_size, beam_width])
 


### PR DESCRIPTION
Fixed Issue 9855 by shielding the `top_k` op's input with `min`.
Also fixed wrong `log_probs `shape at `_get_scores` method docstring. 