### PR TITLE
gif decoder returns 4-D tensor, remove the first dim

### DIFF
--- a/tensorflow/examples/label_image/main.cc
+++ b/tensorflow/examples/label_image/main.cc
@@ -30,6 +30,9 @@ limitations under the License.
 // the top of the main() function.
 //
 // The googlenet_graph.pb file included by default is created from Inception.
+//
+// Note that, for GIF inputs, to reuse existing code, only single-frame ones
+// are supported.
 
 #include <fstream>
 #include <utility>

--- a/tensorflow/examples/label_image/main.cc
+++ b/tensorflow/examples/label_image/main.cc
@@ -103,7 +103,10 @@ Status ReadTensorFromImageFile(const string& file_name, const int input_height,
     image_reader = DecodePng(root.WithOpName("png_reader"), file_reader,
                              DecodePng::Channels(wanted_channels));
   } else if (tensorflow::StringPiece(file_name).ends_with(".gif")) {
-    image_reader = DecodeGif(root.WithOpName("gif_reader"), file_reader);
+    // gif decoder returns 4-D tensor, remove the first dim
+    image_reader = Squeeze(root.WithOpName("squeeze_first_dim"),
+                           DecodeGif(root.WithOpName("gif_reader"),
+                                     file_reader));
   } else {
     // Assume if it's neither a PNG nor a GIF then it must be a JPEG.
     image_reader = DecodeJpeg(root.WithOpName("jpeg_reader"), file_reader,


### PR DESCRIPTION
What returned by the gif decoder returns is a 4-D tensor [frames, height, width, channels]. Since only the single frame gif will be used in this label_image, frames should be 1. So we can use Squeeze() to remove it. 

The patch solve https://github.com/tensorflow/tensorflow/issues/8572