### PR TITLE
Fix building r0.11 from source

### DIFF
--- a/configure
+++ b/configure
@@ -7,7 +7,8 @@ popd > /dev/null
 
 function bazel_clean_and_fetch() {
   bazel clean --expunge
-  bazel fetch //tensorflow/...
+  # TODO(https://github.com/bazelbuild/bazel/issues/2220) Remove the nested `bazel query`.
+  bazel fetch $(bazel query "//tensorflow/... -//tensorflow/examples/android/...")
 }
 
 ## Set up python-related environment settings

--- a/tensorflow/contrib/cmake/external/protobuf.cmake
+++ b/tensorflow/contrib/cmake/external/protobuf.cmake
@@ -1,8 +1,8 @@
 include (ExternalProject)
 
 set(PROTOBUF_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/src)
-set(PROTOBUF_URL https://github.com/google/protobuf/releases/download/v3.0.0/protobuf-cpp-3.0.0.zip)
-set(PROTOBUF_HASH SHA256=e886ea7d08267fc3d866ac42d6dd7461ae11c491836adef6f34c04cad0be3078)
+set(PROTOBUF_URL https://github.com/google/protobuf/releases/download/v3.1.0/protobuf-cpp-3.1.0.zip)
+set(PROTOBUF_HASH SHA256=0c18ccc99e921c407f359047f9b56cca196c3ab36eed79e5979df6c1f9e623b7)
 
 if(WIN32)
   set(PROTOBUF_LIBRARIES ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/${CMAKE_BUILD_TYPE}/libprotobuf.lib)
@@ -26,4 +26,3 @@ ExternalProject_Add(protobuf
         -Dprotobuf_MSVC_STATIC_RUNTIME:BOOL=OFF
         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
 )
-

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -860,7 +860,7 @@ and you left the Cuda or cuDNN version empty, try specifying them explicitly.
 ### Protobuf library related issues
 
 TensorFlow pip package depends on protobuf pip package version
-3.0.0b2. Protobuf's pip package downloaded from [PyPI](https://pypi.python.org)
+3.0.0. Protobuf's pip package downloaded from [PyPI](https://pypi.python.org)
 (when running `pip install protobuf`) is a Python only library, that has
 Python implementations of proto serialization/deserialization which can be
 10x-50x slower than the C++ implementation. Protobuf also supports a binary

--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -860,7 +860,7 @@ and you left the Cuda or cuDNN version empty, try specifying them explicitly.
 ### Protobuf library related issues
 
 TensorFlow pip package depends on protobuf pip package version
-3.0.0. Protobuf's pip package downloaded from [PyPI](https://pypi.python.org)
+3.1.0. Protobuf's pip package downloaded from [PyPI](https://pypi.python.org)
 (when running `pip install protobuf`) is a Python only library, that has
 Python implementations of proto serialization/deserialization which can be
 10x-50x slower than the C++ implementation. Protobuf also supports a binary

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1730,7 +1730,6 @@ tf_cuda_library(
     srcs = ["client/tf_session_helper.cc"],
     hdrs = ["client/tf_session_helper.h"],
     deps = [
-        ":construction_fails_op",
         ":numpy_lib",
         ":test_ops_kernels",
         "//tensorflow/c:c_api",

--- a/tensorflow/tools/ci_build/install/install_proto3.sh
+++ b/tensorflow/tools/ci_build/install/install_proto3.sh
@@ -19,7 +19,7 @@ set -e
 # Install protobuf3.
 
 # Select protobuf version.
-PROTOBUF_VERSION="3.0.0"
+PROTOBUF_VERSION="3.1.0"
 
 PROTOBUF_URL="https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip"
 PROTOBUF_ZIP=$(basename "${PROTOBUF_URL}")

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -31,7 +31,7 @@ _VERSION = '0.11.0'
 REQUIRED_PACKAGES = [
     'numpy >= 1.11.0',
     'six >= 1.10.0',
-    'protobuf == 3.0.0',
+    'protobuf == 3.1.0',
 ]
 
 # python3 requires wheel 0.26

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -98,9 +98,9 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
   native.http_archive(
     name = "protobuf",
-    url = "http://github.com/google/protobuf/archive/v3.0.2.tar.gz",
-    sha256 = "b700647e11556b643ccddffd1f41d8cb7704ed02090af54cc517d44d912d11c1",
-    strip_prefix = "protobuf-3.0.2",
+    url = "http://github.com/google/protobuf/archive/v3.1.0.tar.gz",
+    sha256 = "0a0ae63cbffc274efb573bdde9a253e3f32e458c41261df51c5dbc5ad541e8f7",
+    strip_prefix = "protobuf-3.1.0",
   )
 
   native.new_http_archive(

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -201,9 +201,9 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
   native.new_http_archive(
     name = "avro_archive",
-    url = "http://www-us.apache.org/dist/avro/avro-1.8.0/cpp/avro-cpp-1.8.0.tar.gz",
-    sha256 = "ec6e2ec957e95ca07f70cc25f02f5c416f47cb27bd987a6ec770dcbe72527368",
-    strip_prefix = "avro-cpp-1.8.0",
+    url = "http://www-us.apache.org/dist/avro/avro-1.8.1/cpp/avro-cpp-1.8.1.tar.gz",
+    sha256 = "6559755ac525e908e42a2aa43444576cba91e522fe989088ee7f70c169bcc403",
+    strip_prefix = "avro-cpp-1.8.1",
     build_file = str(Label("//:avro.BUILD")),
   )
 

--- a/util/python/python_config.sh
+++ b/util/python/python_config.sh
@@ -46,7 +46,7 @@ function main {
 }
 
 function python_path {
-  python - <<END
+  $1 - <<END
 from __future__ import print_function
 import site
 import os
@@ -114,7 +114,7 @@ function setup_python {
     exit 1
   fi
 
-  local python_lib_path=$(python_path)
+  local python_lib_path=$(python_path "${PYTHON_BIN_PATH}")
   echo "Found possible Python library paths:"
   for x in $python_lib_path; do
     echo "  $x"


### PR DESCRIPTION
Fixes a bunch of issues I had building from source on r0.11, including #9130 and #5143. With these changes I was able to successfully build tensorflow with cuda support with bazel 0.4.5.