### PR TITLE
fixing $PATH search when running ffmpeg.

### DIFF
--- a/tensorflow/contrib/ffmpeg/default/ffmpeg_lib.cc
+++ b/tensorflow/contrib/ffmpeg/default/ffmpeg_lib.cc
@@ -70,8 +70,7 @@ bool IsBinaryInstalled(const string& binary_name) {
     const string binary_path = io::JoinPath(dir, binary_name);
     char absolute_path[PATH_MAX + 1];
     if (::realpath(binary_path.c_str(), absolute_path) == NULL) {
-      LOG(ERROR) << "Invalid binary path: " << binary_path;
-      return false;
+      continue;
     }
     struct stat statinfo;
     int result = ::stat(absolute_path, &statinfo);


### PR DESCRIPTION
Previous code bailed on first failure of realpath() which didn't proceed to the rest of $PATH