### PR TITLE
Fixed _linear(.) to use *batch* matrix multiplication.

### DIFF
--- a/tensorflow/contrib/rnn/python/ops/core_rnn_cell_impl.py
+++ b/tensorflow/contrib/rnn/python/ops/core_rnn_cell_impl.py
@@ -985,7 +985,6 @@ def _linear(args, output_size, bias, bias_start=0.0):
     args = [args]
 
   # Calculate the total size of arguments on dimension 1.
-  total_arg_size = 0
   shapes = [a.get_shape() for a in args]
   for shape in shapes:
     if shape.ndims != 2:
@@ -993,20 +992,32 @@ def _linear(args, output_size, bias, bias_start=0.0):
     if shape[1].value is None:
       raise ValueError("linear expects shape[1] to be provided for shape %s, "
                        "but saw %s" % (shape, shape[1]))
-    else:
-      total_arg_size += shape[1].value
+    if shape[0] != shapes[0][0] or shape[1] != shapes[0][1]:
+      raise ValueError("all shapes in `args` must be equal (batch x n)")
 
   dtype = [a.dtype for a in args][0]
+  num_args = len(args)
+  if output_size % num_args:
+    raise ValueError("output_size must a multiple of len(args)")
+  batch_size, input_size = shapes[0].as_list()
 
   # Now the computation.
   scope = vs.get_variable_scope()
   with vs.variable_scope(scope) as outer_scope:
-    weights = vs.get_variable(
-        _WEIGHTS_VARIABLE_NAME, [total_arg_size, output_size], dtype=dtype)
-    if len(args) == 1:
+    if num_args == 1:
+      weights = vs.get_variable(
+        _WEIGHTS_VARIABLE_NAME, [input_size, output_size], dtype=dtype)
       res = math_ops.matmul(args[0], weights)
     else:
-      res = math_ops.matmul(array_ops.concat(args, 1), weights)
+      weights = vs.get_variable(
+        _WEIGHTS_VARIABLE_NAME,
+        [num_args, input_size, output_size / num_args], dtype=dtype)
+
+      res = math_ops.matmul(array_ops.stack(args, axis=0), weights)
+
+      # reshape to 2D tensor of size (batch x output_size)
+      res = array_ops.transpose(res, [1, 2, 0])
+      res = array_ops.reshape(res, [batch_size, output_size])
     if not bias:
       return res
     with vs.variable_scope(outer_scope) as inner_scope:

--- a/tensorflow/contrib/rnn/python/ops/core_rnn_cell_impl.py
+++ b/tensorflow/contrib/rnn/python/ops/core_rnn_cell_impl.py
@@ -1014,9 +1014,11 @@ def _linear(args, output_size, bias, bias_start=0.0):
         [num_args, input_size, output_size / num_args], dtype=dtype)
 
       res = math_ops.matmul(array_ops.stack(args, axis=0), weights)
-
-      # reshape to 2D tensor of size (batch x output_size)
-      res = array_ops.transpose(res, [1, 2, 0])
+      # below, we'll reshape our output such that:
+      # res.shape == (num_args, batch_size, output_size / num_args)
+      #           -> (batch_size, num_args, output_size / num_args)
+      #           -> (batch_size, output_size)
+      res = array_ops.transpose(res, [1, 0, 2])
       res = array_ops.reshape(res, [batch_size, output_size])
     if not bias:
       return res


### PR DESCRIPTION
In the `_linear` function (from the `tensorflow.contrib.rnn.python.ops.core_rnn_cell_impl` module), there's relatively subtle bug. The reason that this bug is subtle is that it only affects tensors used by `_linear` internally.

For future reference, the signature and docstring of `_linear` are:
```python
def _linear(args, output_size, bias, bias_start=0.0):
  """Linear map: sum_i(args[i] * W[i]), where W[i] is a variable.

  Args:
    args: a 2D Tensor or a list of 2D, batch x n, Tensors.
    output_size: int, second dimension of W[i].
    bias: boolean, whether to add a bias term or not.
    bias_start: starting value to initialize the bias; 0 by default.

  Returns:
    A 2D Tensor with shape [batch x output_size] equal to
    sum_i(args[i] * W[i]), where W[i]s are newly created matrices.

  Raises:
    ValueError: if some of the arguments has unspecified or wrong shape.
  """
```


**The Problem.**
From the docsting of `_linear`, the expected behavior of the function is that it should return an output `y` such that `y = sum_i(args[i] * W[i])`, indicating a batch-wise `matmul` (formerly known as `batch_matmul`). This wasn't actually how `_linear` was implemented, though. Instead, all `args` were concatenated and the weights were chosen to have rank 2, i.e.
```python
x = concat(args, axis=1)  # x.shape == (batch_size, total_arg_size)
w = Variable(...)         # w.shape == (total_arg_size, output_size)
y = matmul(x, w)          # y.shape == (batch_size, output_size)
```
Now, the main problem here is that **`w` is not block-diagonal**, which means that it contains more entries than it should.

**The Solution.**
The solution is to use batch-wise `matmul` instead. In order to do this, we need `x` and `w` to be rank-3 (rather than rank-2) tensors, e.g.
```python
x = stack(args, axis=0)  # x.shape == (num_args, batch_size, input_size)
w = Variable(...)        # w.shape == (num_args, input_size, output_size / num_args)
y = matmul(x, w)         # y.shape == (num_args, batch_size, output_size / num_args)
y = reshape(transpose(y, [1, 0, 2]), [batch_size, output_size])
```

**Tests.**
I ran `tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_impl_test.py`, but it was failing all over the place. I expected this, because the `_linear` is used in many of the rnn cell classes. The tests were failing in more places than just the place that covered `_linear`. Let me know if I need to update the unit tests too. Also, the change in the PR put somewhat more stringent constraints on the shapes of the input `args`, i.e. they must all be the same. In the previous implementation, only the axis-0 sizes (`batch_size`) needed to be the same. We could use padding and slicing if we need to be able to handle different axis-1 sizes (`input_size`).