### PR TITLE
Fixed _linear(.) to use *batch* matrix multiplication.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules
 __pycache__
 *.swp
 .vscode/
+.sublime-*

--- a/tensorflow/contrib/grid_rnn/python/kernel_tests/grid_rnn_test.py
+++ b/tensorflow/contrib/grid_rnn/python/kernel_tests/grid_rnn_test.py
@@ -63,10 +63,10 @@ class GridRNNCellTest(test.TestCase):
         self.assertEqual(res_s[1].c.shape, (1, 2))
         self.assertEqual(res_s[1].h.shape, (1, 2))
 
-        self.assertAllClose(res_g, ([[0.36617181, 0.36617181]],))
+        self.assertAllClose(res_g, ([[0.27813572, 0.27813572]],))
         self.assertAllClose(
-            res_s, (([[0.71053141, 0.71053141]], [[0.36617181, 0.36617181]]),
-                    ([[0.72320831, 0.80555487]], [[0.39102408, 0.42150158]])))
+            res_s, (([[0.58389962, 0.58389962]], [[0.27813572, 0.27813572]]),
+                    ([[0.52472770, 0.60331118]], [[0.27650252, 0.30985516]])))
 
         # emulate a loop through the input sequence,
         # where we call cell() multiple times
@@ -86,10 +86,10 @@ class GridRNNCellTest(test.TestCase):
         self.assertEqual(res_s2[0].h.shape, (1, 2))
         self.assertEqual(res_s2[1].c.shape, (1, 2))
         self.assertEqual(res_s2[1].h.shape, (1, 2))
-        self.assertAllClose(res_g2[0], [[0.58847463, 0.58847463]])
+        self.assertAllClose(res_g2[0], [[0.44053382, 0.44053382]])
         self.assertAllClose(
-            res_s2, (([[1.40469193, 1.40469193]], [[0.58847463, 0.58847463]]),
-                     ([[0.97726452, 1.04626071]], [[0.4927212, 0.51137757]])))
+            res_s2, (([[1.1822226, 1.18222260]], [[0.44053382, 0.44053382]]),
+                     ([[0.6710391, 0.73025036]], [[0.30998221, 0.32985979]])))
 
   def testGrid2BasicLSTMCellTied(self):
     with self.test_session(use_gpu=False) as sess:
@@ -121,18 +121,18 @@ class GridRNNCellTest(test.TestCase):
         self.assertEqual(res_s[1].c.shape, (1, 2))
         self.assertEqual(res_s[1].h.shape, (1, 2))
 
-        self.assertAllClose(res_g[0], [[0.36617181, 0.36617181]])
+        self.assertAllClose(res_g[0], [[0.27813572, 0.27813572]])
         self.assertAllClose(
-            res_s, (([[0.71053141, 0.71053141]], [[0.36617181, 0.36617181]]),
-                    ([[0.72320831, 0.80555487]], [[0.39102408, 0.42150158]])))
+            res_s, (([[0.58389962, 0.58389962]], [[0.27813572, 0.27813572]]),
+                    ([[0.52472770, 0.60331118]], [[0.27650252, 0.30985516]])))
 
         res_g, res_s = sess.run([g, s], {x: np.array([[1., 1., 1.]]), m: res_s})
         self.assertEqual(res_g[0].shape, (1, 2))
 
-        self.assertAllClose(res_g[0], [[0.36703536, 0.36703536]])
+        self.assertAllClose(res_g[0], [[0.27634764, 0.27634764]])
         self.assertAllClose(
-            res_s, (([[0.71200621, 0.71200621]], [[0.36703536, 0.36703536]]),
-                    ([[0.80941606, 0.87550586]], [[0.40108523, 0.42199609]])))
+            res_s, (([[0.58274859, 0.58274859]], [[0.27634764, 0.27634764]]),
+                    ([[0.52718318, 0.58639443]], [[0.25576338, 0.27909029]])))
 
   def testGrid2BasicLSTMCellWithRelu(self):
     with self.test_session(use_gpu=False) as sess:
@@ -155,9 +155,9 @@ class GridRNNCellTest(test.TestCase):
             m: ((np.array([[0.1, 0.2]]), np.array([[0.3, 0.4]])),)
         })
         self.assertEqual(res_g[0].shape, (1, 2))
-        self.assertAllClose(res_g[0], [[0.31667367, 0.31667367]])
-        self.assertAllClose(res_s, (([[0.29530135, 0.37520045]],
-                                     [[0.17044567, 0.21292259]]),))
+        self.assertAllClose(res_g[0], [[0.29142371, 0.29142371]])
+        self.assertAllClose(res_s, (([[0.20757815, 0.28334612]],
+                                     [[0.10947458, 0.14764377]]),))
 
   """LSTMCell
   """
@@ -192,10 +192,10 @@ class GridRNNCellTest(test.TestCase):
         self.assertEqual(res_s[1].c.shape, (1, 2))
         self.assertEqual(res_s[1].h.shape, (1, 2))
 
-        self.assertAllClose(res_g[0], [[0.95686918, 0.95686918]])
+        self.assertAllClose(res_g[0], [[0.83462638, 0.83462638]])
         self.assertAllClose(
-            res_s, (([[2.41515064, 2.41515064]], [[0.95686918, 0.95686918]]),
-                    ([[1.38917875, 1.49043763]], [[0.83884692, 0.86036491]])))
+            res_s, (([[2.19742370, 2.19742370]], [[0.83462638, 0.83462638]]),
+                    ([[1.21154201, 1.30832052]], [[0.66558737, 0.69353604]])))
 
   def testGrid2LSTMCellTied(self):
     with self.test_session(use_gpu=False) as sess:
@@ -227,10 +227,10 @@ class GridRNNCellTest(test.TestCase):
         self.assertEqual(res_s[1].c.shape, (1, 2))
         self.assertEqual(res_s[1].h.shape, (1, 2))
 
-        self.assertAllClose(res_g[0], [[0.95686918, 0.95686918]])
+        self.assertAllClose(res_g[0], [[0.83462638, 0.83462638]])
         self.assertAllClose(
-            res_s, (([[2.41515064, 2.41515064]], [[0.95686918, 0.95686918]]),
-                    ([[1.38917875, 1.49043763]], [[0.83884692, 0.86036491]])))
+            res_s, (([[2.19742370, 2.19742370]], [[0.83462638, 0.83462638]]),
+                    ([[1.21154201, 1.30832052]], [[0.66558737, 0.69353604]])))
 
   def testGrid2LSTMCellWithRelu(self):
     with self.test_session() as sess:
@@ -253,9 +253,9 @@ class GridRNNCellTest(test.TestCase):
             m: ((np.array([[0.1, 0.2]]), np.array([[0.3, 0.4]])),)
         })
         self.assertEqual(res_g[0].shape, (1, 2))
-        self.assertAllClose(res_g[0], [[2.1831727, 2.1831727]])
-        self.assertAllClose(res_s, (([[0.92270052, 1.02325559]],
-                                     [[0.66159075, 0.70475441]]),))
+        self.assertAllClose(res_g[0], [[1.98171163, 1.98171163]])
+        self.assertAllClose(res_s, (([[0.82688755, 0.91509962]],
+                                     [[0.46301097, 0.50041234]]),))
 
   """RNNCell
   """
@@ -285,11 +285,11 @@ class GridRNNCellTest(test.TestCase):
         self.assertEqual(res_s[0].shape, (2, 2))
         self.assertEqual(res_s[1].shape, (2, 2))
 
-        self.assertAllClose(res_g, ([[0.94685763, 0.94685763],
-                                     [0.99480951, 0.99480951]],))
+        self.assertAllClose(res_g, ([[0.76159418, 0.40584856],
+                                     [0.96402758, 0.52317500]],))
         self.assertAllClose(
-            res_s, ([[0.94685763, 0.94685763], [0.99480951, 0.99480951]],
-                    [[0.80049908, 0.80049908], [0.97574311, 0.97574311]]))
+            res_s, ([[0.76159418, 0.40584856], [0.96402758, 0.523175]],
+                    [[0.76159418, 0.09966799], [0.96402758, 0.19737528]]))
 
   def testGrid2BasicRNNCellTied(self):
     with self.test_session() as sess:
@@ -316,11 +316,11 @@ class GridRNNCellTest(test.TestCase):
         self.assertEqual(res_s[0].shape, (2, 2))
         self.assertEqual(res_s[1].shape, (2, 2))
 
-        self.assertAllClose(res_g, ([[0.94685763, 0.94685763],
-                                     [0.99480951, 0.99480951]],))
+        self.assertAllClose(res_g, ([[0.76159418, 0.40584856],
+                                     [0.96402758, 0.52317500]],))
         self.assertAllClose(
-            res_s, ([[0.94685763, 0.94685763], [0.99480951, 0.99480951]],
-                    [[0.80049908, 0.80049908], [0.97574311, 0.97574311]]))
+            res_s, ([[0.76159418, 0.40584856], [0.96402758, 0.52317500]],
+                    [[0.76159418, 0.09966799], [0.96402758, 0.19737528]]))
 
   def testGrid2BasicRNNCellWithRelu(self):
     with self.test_session() as sess:
@@ -341,8 +341,8 @@ class GridRNNCellTest(test.TestCase):
                      m: np.array([[0.1, 0.1]])})
         self.assertEqual(res_g[0].shape, (1, 2))
         self.assertEqual(res_s[0].shape, (1, 2))
-        self.assertAllClose(res_g, ([[1.80049896, 1.80049896]],))
-        self.assertAllClose(res_s, ([[0.80049896, 0.80049896]],))
+        self.assertAllClose(res_g, ([[1.43063116, 1.43063116]],))
+        self.assertAllClose(res_s, ([[0.76159418, 0.09966799]],))
 
   """1-LSTM
   """
@@ -735,10 +735,10 @@ class GridRNNCellTest(test.TestCase):
         })
         self.assertEqual(res[0].shape, (1, 2))
         self.assertEqual(res[1].shape, (1, 8))
-        self.assertAllClose(res[0], [[0.95686918, 0.95686918]])
+        self.assertAllClose(res[0], [[0.83462638, 0.83462638]])
         self.assertAllClose(res[1], [[
-            2.41515064, 2.41515064, 0.95686918, 0.95686918, 1.38917875,
-            1.49043763, 0.83884692, 0.86036491
+            2.19742370, 2.19742370, 0.83462638, 0.83462638, 1.21154201,
+            1.30832052, 0.66558737, 0.69353604
         ]])
 
 if __name__ == '__main__':

--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_test.py
@@ -78,7 +78,7 @@ class RNNCellTest(test.TestCase):
         cell = rnn_cell_impl.BasicRNNCell(2)
         g, _ = cell(x, m)
         self.assertEqual([
-            "root/basic_rnn_cell/%s:0" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
+            "root/basic_rnn_cell/%s_batch:0" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
             "root/basic_rnn_cell/%s:0" % rnn_cell_impl._BIAS_VARIABLE_NAME
         ], [v.name for v in cell.trainable_variables])
         self.assertFalse(cell.non_trainable_variables)
@@ -103,7 +103,7 @@ class RNNCellTest(test.TestCase):
         g, _ = cell(x, m)
         self.assertFalse(cell.trainable_variables)
         self.assertEqual([
-            "root/basic_rnn_cell/%s:0" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
+            "root/basic_rnn_cell/%s_batch:0" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
             "root/basic_rnn_cell/%s:0" % rnn_cell_impl._BIAS_VARIABLE_NAME
         ], [v.name for v in cell.non_trainable_variables])
         sess.run([variables_lib.global_variables_initializer()])
@@ -124,7 +124,7 @@ class RNNCellTest(test.TestCase):
             [g], {x.name: np.array([[1., 1.]]),
                   m.name: np.array([[0.1, 0.1]])})
         # Smoke test
-        self.assertAllClose(res[0], [[0.175991, 0.175991]])
+        self.assertAllClose(res[0], [[0.26522645, 0.09696632]])
       with variable_scope.variable_scope(
           "other", initializer=init_ops.constant_initializer(0.5)):
         x = array_ops.zeros(
@@ -153,11 +153,11 @@ class RNNCellTest(test.TestCase):
             state_is_tuple=False)
         g, out_m = cell(x, m)
         expected_variable_names = [
-            "root/multi_rnn_cell/cell_0/basic_lstm_cell/%s:0" %
+            "root/multi_rnn_cell/cell_0/basic_lstm_cell/%s_batch:0" %
             rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
             "root/multi_rnn_cell/cell_0/basic_lstm_cell/%s:0" %
             rnn_cell_impl._BIAS_VARIABLE_NAME,
-            "root/multi_rnn_cell/cell_1/basic_lstm_cell/%s:0" %
+            "root/multi_rnn_cell/cell_1/basic_lstm_cell/%s_batch:0" %
             rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
             "root/multi_rnn_cell/cell_1/basic_lstm_cell/%s:0" %
             rnn_cell_impl._BIAS_VARIABLE_NAME
@@ -174,10 +174,10 @@ class RNNCellTest(test.TestCase):
         variables = variables_lib.global_variables()
         self.assertEqual(expected_variable_names, [v.name for v in variables])
         # The numbers in results were not calculated, this is just a smoke test.
-        self.assertAllClose(res[0], [[0.24024698, 0.24024698]])
+        self.assertAllClose(res[0], [[0.12291578, 0.12291578]])
         expected_mem = np.array([[
-            0.68967271, 0.68967271, 0.44848421, 0.44848421, 0.39897051,
-            0.39897051, 0.24024698, 0.24024698
+            0.631796, 0.631796, 0.29361436, 0.29361436, 0.23855942,
+            0.23855942, 0.12291578, 0.12291578
         ]])
         self.assertAllClose(res[1], expected_mem)
       with variable_scope.variable_scope(
@@ -286,11 +286,11 @@ class RNNCellTest(test.TestCase):
         # The numbers in results were not calculated, this is just a smoke test.
         # Note, however, these values should match the original
         # version having state_is_tuple=False.
-        self.assertAllClose(res[0], [[0.24024698, 0.24024698]])
+        self.assertAllClose(res[0], [[0.12291578, 0.12291578]])
         expected_mem0 = np.array(
-            [[0.68967271, 0.68967271, 0.44848421, 0.44848421]])
+            [[0.63179600, 0.63179600, 0.29361436, 0.29361436]])
         expected_mem1 = np.array(
-            [[0.39897051, 0.39897051, 0.24024698, 0.24024698]])
+            [[0.23855942, 0.23855940, 0.12291570, 0.12291578]])
         self.assertAllClose(res[1], expected_mem0)
         self.assertAllClose(res[2], expected_mem1)
 
@@ -346,9 +346,10 @@ class RNNCellTest(test.TestCase):
             state_is_tuple=False)
         cell(x, m)  # Execute to create variables
       variables = variables_lib.global_variables()
-      self.assertEquals(variables[0].op.name, "root/lstm_cell/kernel")
-      self.assertEquals(variables[1].op.name, "root/lstm_cell/bias")
-      self.assertEquals(variables[2].op.name,
+      self.assertEquals(variables[0].op.name, "root/lstm_cell/kernel_seq0")
+      self.assertEquals(variables[1].op.name, "root/lstm_cell/kernel_seq1")
+      self.assertEquals(variables[2].op.name, "root/lstm_cell/bias")
+      self.assertEquals(variables[3].op.name,
                         "root/lstm_cell/projection/kernel")
 
   def testOutputProjectionWrapper(self):
@@ -366,7 +367,7 @@ class RNNCellTest(test.TestCase):
         })
         self.assertEqual(res[1].shape, (1, 3))
         # The numbers in results were not calculated, this is just a smoke test.
-        self.assertAllClose(res[0], [[0.231907, 0.231907]])
+        self.assertAllClose(res[0], [[0.44842762, 0.44842762]])
 
   def testInputProjectionWrapper(self):
     with self.test_session() as sess:
@@ -384,7 +385,7 @@ class RNNCellTest(test.TestCase):
              m.name: np.array([[0.1, 0.1, 0.1]])})
         self.assertEqual(res[1].shape, (1, 3))
         # The numbers in results were not calculated, this is just a smoke test.
-        self.assertAllClose(res[0], [[0.154605, 0.154605, 0.154605]])
+        self.assertAllClose(res[0], [[0.29895175, 0.29895175, 0.29895175]])
 
   def testResidualWrapper(self):
     with self.test_session() as sess:
@@ -459,7 +460,7 @@ class RNNCellTest(test.TestCase):
              m.name: np.array([[0.1, 0.1]])})
         self.assertEqual(res[1].shape, (1, 2))
         # The numbers in results were not calculated, this is just a smoke test.
-        self.assertAllClose(res[0], [[0.17139, 0.17139]])
+        self.assertAllClose(res[0], [[0.19043511, 0.09539874]])
 
   def testEmbeddingWrapperWithDynamicRnn(self):
     with self.test_session() as sess:
@@ -494,7 +495,7 @@ class RNNCellTest(test.TestCase):
             m.name: np.array([[0.1, 0.1, 0.1, 0.1]])
         })
         # The numbers in results were not calculated, this is just a smoke test.
-        self.assertAllClose(res, [[0.175991, 0.175991, 0.13248, 0.13248]])
+        self.assertAllClose(res, [[0.26522645, 0.09696632, 0.11976498, 0.09409752]])
 
   def testMultiRNNCellWithStateTuple(self):
     with self.test_session() as sess:
@@ -524,14 +525,19 @@ class RNNCellTest(test.TestCase):
         # The numbers in results were not calculated, this is just a
         # smoke test.  However, these numbers should match those of
         # the test testMultiRNNCell.
-        self.assertAllClose(res[0], [[0.175991, 0.175991]])
-        self.assertAllClose(res[1], [[0.13248, 0.13248]])
+        self.assertAllClose(res[0], [[0.26522645, 0.09696632]])
+        self.assertAllClose(res[1], [[0.11976498, 0.09409752]])
 
 
 class DropoutWrapperTest(test.TestCase):
-
   def _testDropoutWrapper(self, batch_size=None, time_steps=None,
                           parallel_iterations=None, **kwargs):
+    true_full_output = np.array(
+        [[[0.41458178, 0.41458178, 0.41458178]],
+         [[0.59918302, 0.59918302, 0.59918302]]], dtype=np.float32)
+    true_full_final_c = np.array(
+        [[1.594966, 1.594966, 1.594966]], dtype=np.float32)
+
     with self.test_session() as sess:
       with variable_scope.variable_scope(
           "root", initializer=init_ops.constant_initializer(0.5)):
@@ -563,30 +569,20 @@ class DropoutWrapperTest(test.TestCase):
         self.assertEqual(res[0].shape, (time_steps, batch_size, 3))
         self.assertEqual(res[1].c.shape, (batch_size, 3))
         self.assertEqual(res[1].h.shape, (batch_size, 3))
-        return res
+        return res, true_full_output, true_full_final_c
 
   def testDropoutWrapperKeepAllConstantInput(self):
     keep = array_ops.ones([])
-    res = self._testDropoutWrapper(
+    res, true_full_output, true_full_final_c = self._testDropoutWrapper(
         input_keep_prob=keep, output_keep_prob=keep, state_keep_prob=keep)
-    true_full_output = np.array(
-        [[[0.751109, 0.751109, 0.751109]],
-         [[0.895509, 0.895509, 0.895509]]], dtype=np.float32)
-    true_full_final_c = np.array(
-        [[1.949385, 1.949385, 1.949385]], dtype=np.float32)
     self.assertAllClose(true_full_output, res[0])
     self.assertAllClose(true_full_output[1], res[1].h)
     self.assertAllClose(true_full_final_c, res[1].c)
 
   def testDropoutWrapperKeepAll(self):
     keep = variable_scope.get_variable("all", initializer=1.0)
-    res = self._testDropoutWrapper(
+    res, true_full_output, true_full_final_c  = self._testDropoutWrapper(
         input_keep_prob=keep, output_keep_prob=keep, state_keep_prob=keep)
-    true_full_output = np.array(
-        [[[0.751109, 0.751109, 0.751109]],
-         [[0.895509, 0.895509, 0.895509]]], dtype=np.float32)
-    true_full_final_c = np.array(
-        [[1.949385, 1.949385, 1.949385]], dtype=np.float32)
     self.assertAllClose(true_full_output, res[0])
     self.assertAllClose(true_full_output[1], res[1].h)
     self.assertAllClose(true_full_final_c, res[1].c)
@@ -598,7 +594,7 @@ class DropoutWrapperTest(test.TestCase):
     ## _testDropoutWrapper to ensure the (per-time step) dropout is
     ## consistent across both calls.  Otherwise the seed may not end
     ## up being munged consistently across both graphs.
-    res_standard_1 = self._testDropoutWrapper(
+    res_standard_1, _, _  = self._testDropoutWrapper(
         input_keep_prob=keep_some, output_keep_prob=keep_some,
         state_keep_prob=keep_some, seed=10,
         parallel_iterations=1)
@@ -606,7 +602,7 @@ class DropoutWrapperTest(test.TestCase):
     ops.reset_default_graph()
     self._ClearCachedSession()
     random_seed.set_random_seed(2)
-    res_standard_2 = self._testDropoutWrapper(
+    res_standard_2, _, _ = self._testDropoutWrapper(
         input_keep_prob=keep_some, output_keep_prob=keep_some,
         state_keep_prob=keep_some, seed=10,
         parallel_iterations=1)
@@ -617,14 +613,9 @@ class DropoutWrapperTest(test.TestCase):
   def testDropoutWrapperKeepNoOutput(self):
     keep_all = variable_scope.get_variable("all", initializer=1.0)
     keep_none = variable_scope.get_variable("none", initializer=1e-10)
-    res = self._testDropoutWrapper(
+    res, true_full_output, true_full_final_c  = self._testDropoutWrapper(
         input_keep_prob=keep_all, output_keep_prob=keep_none,
         state_keep_prob=keep_all)
-    true_full_output = np.array(
-        [[[0.751109, 0.751109, 0.751109]],
-         [[0.895509, 0.895509, 0.895509]]], dtype=np.float32)
-    true_full_final_c = np.array(
-        [[1.949385, 1.949385, 1.949385]], dtype=np.float32)
     self.assertAllClose(np.zeros(res[0].shape), res[0])
     self.assertAllClose(true_full_output[1], res[1].h)
     self.assertAllClose(true_full_final_c, res[1].c)
@@ -632,12 +623,9 @@ class DropoutWrapperTest(test.TestCase):
   def testDropoutWrapperKeepNoState(self):
     keep_all = variable_scope.get_variable("all", initializer=1.0)
     keep_none = variable_scope.get_variable("none", initializer=1e-10)
-    res = self._testDropoutWrapper(
+    res, true_full_output, true_full_final_c  = self._testDropoutWrapper(
         input_keep_prob=keep_all, output_keep_prob=keep_all,
         state_keep_prob=keep_none)
-    true_full_output = np.array(
-        [[[0.751109, 0.751109, 0.751109]],
-         [[0.895509, 0.895509, 0.895509]]], dtype=np.float32)
     self.assertAllClose(true_full_output[0], res[0][0])
     # Second output is modified by zero input state
     self.assertGreater(np.linalg.norm(true_full_output[1] - res[0][1]), 1e-4)
@@ -647,13 +635,8 @@ class DropoutWrapperTest(test.TestCase):
   def testDropoutWrapperKeepNoInput(self):
     keep_all = variable_scope.get_variable("all", initializer=1.0)
     keep_none = variable_scope.get_variable("none", initializer=1e-10)
-    true_full_output = np.array(
-        [[[0.751109, 0.751109, 0.751109]],
-         [[0.895509, 0.895509, 0.895509]]], dtype=np.float32)
-    true_full_final_c = np.array(
-        [[1.949385, 1.949385, 1.949385]], dtype=np.float32)
     # All outputs are different because inputs are zeroed out
-    res = self._testDropoutWrapper(
+    res, true_full_output, true_full_final_c  = self._testDropoutWrapper(
         input_keep_prob=keep_none, output_keep_prob=keep_all,
         state_keep_prob=keep_all)
     self.assertGreater(np.linalg.norm(res[0] - true_full_output), 1e-4)
@@ -663,7 +646,7 @@ class DropoutWrapperTest(test.TestCase):
   def testDropoutWrapperRecurrentOutput(self):
     keep_some = 0.8
     keep_all = variable_scope.get_variable("all", initializer=1.0)
-    res = self._testDropoutWrapper(
+    res, true_full_output, true_full_final_c  = self._testDropoutWrapper(
         input_keep_prob=keep_all, output_keep_prob=keep_some,
         state_keep_prob=keep_all, variational_recurrent=True,
         input_size=3, batch_size=5, time_steps=7)
@@ -674,7 +657,7 @@ class DropoutWrapperTest(test.TestCase):
 
   def testDropoutWrapperRecurrentStateInputAndOutput(self):
     keep_some = 0.9
-    res = self._testDropoutWrapper(
+    res, true_full_output, true_full_final_c  = self._testDropoutWrapper(
         input_keep_prob=keep_some, output_keep_prob=keep_some,
         state_keep_prob=keep_some, variational_recurrent=True,
         input_size=3, batch_size=5, time_steps=7)
@@ -700,7 +683,7 @@ class DropoutWrapperTest(test.TestCase):
     keep_some = 0.9
     random_seed.set_random_seed(2347)
     np.random.seed(23487)
-    res0 = self._testDropoutWrapper(
+    res0, _, _ = self._testDropoutWrapper(
         input_keep_prob=keep_some, output_keep_prob=keep_some,
         state_keep_prob=keep_some, variational_recurrent=True,
         input_size=3, batch_size=5, time_steps=7, seed=-234987)
@@ -708,7 +691,7 @@ class DropoutWrapperTest(test.TestCase):
     self._ClearCachedSession()
     random_seed.set_random_seed(2347)
     np.random.seed(23487)
-    res1 = self._testDropoutWrapper(
+    res1, _, _ = self._testDropoutWrapper(
         input_keep_prob=keep_some, output_keep_prob=keep_some,
         state_keep_prob=keep_some, variational_recurrent=True,
         input_size=3, batch_size=5, time_steps=7, seed=-234987)

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -1023,7 +1023,9 @@ def _linear(args,
       batch_size, input_size = shapes[0].as_list()
       weights = vs.get_variable(
         _WEIGHTS_VARIABLE_NAME + '_batch',
-        [num_args, input_size, output_size // num_args], dtype=dtype)
+        [num_args, input_size, output_size // num_args],
+        dtype=dtype,
+        initializer=kernel_initializer)
 
       """
       Below, we'll reshape our output such that:
@@ -1040,7 +1042,9 @@ def _linear(args,
       weights = [
         vs.get_variable(
           _WEIGHTS_VARIABLE_NAME + '_seq' + str(i),
-          [input_size, output_size], dtype=dtype)
+          [input_size, output_size],
+          dtype=dtype,
+          initializer=kernel_initializer)
         for i, (batch_size, input_size) in enumerate(shapes)]
       res = sum(math_ops.matmul(x, w) for x, w in zip(args, weights))
 

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -1026,7 +1026,7 @@ def _linear(args,
     else:
       weights = vs.get_variable(
         _WEIGHTS_VARIABLE_NAME,
-        [num_args, input_size, output_size / num_args], dtype=dtype)
+        [num_args, input_size, output_size // num_args], dtype=dtype)
 
       """
       Below, we'll reshape our output such that:

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -998,7 +998,6 @@ def _linear(args,
     args = [args]
 
   # Calculate the total size of arguments on dimension 1.
-  total_arg_size = 0
   shapes = [a.get_shape() for a in args]
   for shape in shapes:
     if shape.ndims != 2:
@@ -1006,22 +1005,40 @@ def _linear(args,
     if shape[1].value is None:
       raise ValueError("linear expects shape[1] to be provided for shape %s, "
                        "but saw %s" % (shape, shape[1]))
-    else:
-      total_arg_size += shape[1].value
+    if shape[0] != shapes[0][0] or shape[1] != shapes[0][1]:
+      raise ValueError("all shapes in `args` must be equal (batch x n)")
 
   dtype = [a.dtype for a in args][0]
+  num_args = len(args)
+  if output_size % num_args:
+    raise ValueError("output_size must a multiple of len(args)")
+  batch_size, input_size = shapes[0].as_list()
 
   # Now the computation.
   scope = vs.get_variable_scope()
   with vs.variable_scope(scope) as outer_scope:
-    weights = vs.get_variable(
-        _WEIGHTS_VARIABLE_NAME, [total_arg_size, output_size],
+    if num_args == 1:
+      weights = vs.get_variable(
+        _WEIGHTS_VARIABLE_NAME, [input_size, output_size],
         dtype=dtype,
         initializer=kernel_initializer)
-    if len(args) == 1:
       res = math_ops.matmul(args[0], weights)
     else:
-      res = math_ops.matmul(array_ops.concat(args, 1), weights)
+      weights = vs.get_variable(
+        _WEIGHTS_VARIABLE_NAME,
+        [num_args, input_size, output_size / num_args], dtype=dtype)
+
+      """
+      Below, we'll reshape our output such that:
+      res.shape == (num_args, batch_size, output_size / num_args)           (1)
+                -> (batch_size, num_args, output_size / num_args)           (2)
+                -> (batch_size, output_size)                                (3)
+      In a typical use case of _linear, the output is split into num_args
+      chunks, which is why we need to transpose in the exact order of (2).
+      """
+      res = math_ops.matmul(array_ops.stack(args, axis=0), weights)       # (1)
+      res = array_ops.transpose(res, [1, 0, 2])                           # (2)
+      res = array_ops.reshape(res, [batch_size, output_size])             # (3)
     if not bias:
       return res
     with vs.variable_scope(outer_scope) as inner_scope:


### PR DESCRIPTION
In the `_linear` function (from the `tensorflow.contrib.rnn.python.ops.core_rnn_cell_impl` module), there's relatively subtle bug. The reason that this bug is subtle is that it only affects tensors used by `_linear` internally.

For future reference, the signature and docstring of `_linear` are:
```python
def _linear(args, output_size, bias, bias_start=0.0):
  """Linear map: sum_i(args[i] * W[i]), where W[i] is a variable.

  Args:
    args: a 2D Tensor or a list of 2D, batch x n, Tensors.
    output_size: int, second dimension of W[i].
    bias: boolean, whether to add a bias term or not.
    bias_start: starting value to initialize the bias; 0 by default.

  Returns:
    A 2D Tensor with shape [batch x output_size] equal to
    sum_i(args[i] * W[i]), where W[i]s are newly created matrices.

  Raises:
    ValueError: if some of the arguments has unspecified or wrong shape.
  """
```


**The Problem.**
From the docsting of `_linear`, the expected behavior of the function is that it should return an output `y` such that `y = sum_i(args[i] * W[i])`, indicating a batch-wise `matmul` (formerly known as `batch_matmul`). This wasn't actually how `_linear` was implemented, though. Instead, all `args` were concatenated and the weights were chosen to have rank 2, i.e.
```python
x = concat(args, axis=1)  # x.shape == (batch_size, total_arg_size)
w = Variable(...)         # w.shape == (total_arg_size, output_size)
y = matmul(x, w)          # y.shape == (batch_size, output_size)
```
Now, the main problem here is that **`w` is not block-diagonal**, which means that it contains more entries than it should. There are two problems with this:
1. The **number of weights is too large** by a factor of `num_args`.
2. The extra "off-diagonal" weights yield **spurious connections** in the net architecture of e.g. LSTMCell.

**The Solution.**
The solution is to use batch-wise `matmul` instead. In order to do this, we need `x` and `w` to be rank-3 (rather than rank-2) tensors, e.g.
```python
x = stack(args, axis=0)                    # x.shape == (num_args, batch_size, input_size)
w = Variable(...)                          # w.shape == (num_args, input_size, output_size / num_args)
y = matmul(x, w)                           # y.shape == (num_args, batch_size, output_size / num_args)
y = transpose(y, [1, 0, 2])                # y.shape == (batch_size, num_args, output_size / num_args)
y = reshape(y, [batch_size, output_size])  # y.shape == (batch_size, output_size)
```

**Tests.**
I ran `tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_impl_test.py`, but it was failing all over the place. I expected this, because the `_linear` is used in many of the rnn cell classes. The tests were failing in more places than just the place that covered `_linear`. Let me know if I need to update the unit tests too. Also, the change in the PR put somewhat more stringent constraints on the shapes of the input `args`, i.e. they must all be the same. In the previous implementation, only the axis-0 sizes (`batch_size`) needed to be the same. We could use padding and slicing if we need to be able to handle different axis-1 sizes (`input_size`).