### PR TITLE
[XLA] Add F16 support to the Literal protobuf and LiteralUtils class.

### DIFF
--- a/tensorflow/compiler/tf2xla/xla_helpers.cc
+++ b/tensorflow/compiler/tf2xla/xla_helpers.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/compiler/tf2xla/type_util.h"
 #include "tensorflow/compiler/tf2xla/xla_context.h"
 #include "tensorflow/compiler/xla/client/computation_builder.h"
+#include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/lib/gtl/array_slice.h"
 
@@ -89,7 +90,9 @@ xla::ComputationDataHandle XlaHelpers::IntegerLiteral(
     case xla::U16:
       LOG(FATAL) << "u16/s16 literals not yet implemented";
     case xla::F16:
-      LOG(FATAL) << "f16 literals not yet implemented";
+      literal = *xla::LiteralUtil::CreateR0<xla::half>(
+              static_cast<xla::half>(value));
+      break;
     case xla::TUPLE:
       LOG(FATAL) << "tuple element type is not integral";
     case xla::OPAQUE:
@@ -112,6 +115,9 @@ xla::ComputationDataHandle XlaHelpers::FloatLiteral(xla::ComputationBuilder* b,
       break;
     case xla::F64:
       return b->ConstantR0<double>(value);
+      break;
+    case xla::F16:
+      return b->ConstantR0<xla::half>(static_cast<xla::half>(value));
       break;
     default:
       LOG(FATAL) << "unhandled element type " << type;

--- a/tensorflow/compiler/tf2xla/xla_helpers.cc
+++ b/tensorflow/compiler/tf2xla/xla_helpers.cc
@@ -110,14 +110,14 @@ xla::ComputationDataHandle XlaHelpers::FloatLiteral(xla::ComputationBuilder* b,
   xla::PrimitiveType type;
   TF_CHECK_OK(DataTypeToPrimitiveType(data_type, &type));
   switch (type) {
+    case xla::F16:
+      return b->ConstantR0<xla::half>(static_cast<xla::half>(value));
+      break;
     case xla::F32:
       return b->ConstantR0<float>(static_cast<float>(value));
       break;
     case xla::F64:
       return b->ConstantR0<double>(value);
-      break;
-    case xla::F16:
-      return b->ConstantR0<xla::half>(static_cast<xla::half>(value));
       break;
     default:
       LOG(FATAL) << "unhandled element type " << type;

--- a/tensorflow/compiler/xla/literal_util.cc
+++ b/tensorflow/compiler/xla/literal_util.cc
@@ -154,6 +154,9 @@ template <typename T>
     case F64:
       return CopyRange<double>(src_literal, src_base, dest_literal, dest_base,
                                copy_size);
+    case F16:
+      return CopyRange<half>(src_literal, src_base, dest_literal, dest_base,
+                             copy_size);
     case PRED:
       return CopyRange<bool>(src_literal, src_base, dest_literal, dest_base,
                              copy_size);
@@ -188,7 +191,7 @@ template <typename T>
     case U16:
       LOG(FATAL) << "u16/s16 literals not yet implemented";
     case F16:
-      LOG(FATAL) << "f16 literals not yet implemented";
+      return *LiteralUtil::CreateR0<half>((half)0.0f);
     case TUPLE:
       LOG(FATAL) << "tuple element type cannot take on value of 0";
     case OPAQUE:
@@ -222,7 +225,7 @@ template <typename T>
     case U16:
       LOG(FATAL) << "u16/s16 literals not yet implemented";
     case F16:
-      LOG(FATAL) << "f16 literals not yet implemented";
+      return *LiteralUtil::CreateR0<half>((half)1.0f);
     case TUPLE:
       LOG(FATAL) << "tuple element type cannot take on value of 1";
     case OPAQUE:
@@ -258,7 +261,8 @@ template <typename T>
     case U16:
       LOG(FATAL) << "u16/s16 literals not yet implemented";
     case F16:
-      LOG(FATAL) << "f16 literals not yet implemented";
+      return *LiteralUtil::CreateR0<half>((half)
+              -std::numeric_limits<float>::infinity());
     case TUPLE:
       LOG(FATAL) << "tuple element type has no minimum value";
     case OPAQUE:
@@ -294,7 +298,8 @@ template <typename T>
     case U16:
       LOG(FATAL) << "u16/s16 literals not yet implemented";
     case F16:
-      LOG(FATAL) << "f16 literals not yet implemented";
+      return *LiteralUtil::CreateR0<half>((half)
+              std::numeric_limits<float>::infinity());
     case TUPLE:
       LOG(FATAL) << "tuple element type has no maximum value";
     case OPAQUE:
@@ -498,6 +503,8 @@ template <typename T>
       return tensorflow::strings::StrCat(Get<float>(literal, multi_index));
     case F64:
       return tensorflow::strings::StrCat(Get<double>(literal, multi_index));
+    case F16:
+      return tensorflow::strings::StrCat(Get<half>(literal, multi_index));
     default:
       return tensorflow::strings::StrCat(
           "[", PrimitiveType_Name(literal.shape().element_type()), "]");
@@ -652,6 +659,8 @@ template <typename T>
       return reinterpret_cast<const void*>(literal.f32s().data());
     case F64:
       return reinterpret_cast<const void*>(literal.f64s().data());
+    case F16:
+      return reinterpret_cast<const void*>(literal.f16s().data());
     default:
       LOG(FATAL) << "primitive type not supported in literals: "
                  << PrimitiveType_Name(literal.shape().element_type());
@@ -691,6 +700,8 @@ template <typename T>
       break;
     case F64:
       Resize<double>(num_elements, 0, literal);
+    case F16:
+      Resize<half>(num_elements, (half)0.0f, literal);
       break;
     default:
       LOG(FATAL) << "primitive type not supported in literals: "
@@ -727,6 +738,9 @@ template <typename T>
       break;
     case F64:
       actual = literal.f64s_size();
+      break;
+    case F16:
+      actual = literal.f16s().size() / 2;
       break;
     default:
       return tensorflow::errors::Unimplemented(
@@ -818,6 +832,8 @@ bool EqualElements(const Literal& literal1, const Literal& literal2,
         return EqualElements<float>(literal1, literal2, 0, &multi_index);
       case F64:
         return EqualElements<double>(literal1, literal2, 0, &multi_index);
+      case F16:
+        return EqualElements<half>(literal1, literal2, 0, &multi_index);
       default:
         LOG(FATAL) << "Unimplemented: LiteralUtil::Equal for type "
                    << PrimitiveType_Name(literal1.shape().element_type());
@@ -917,6 +933,16 @@ LiteralUtil::GetMutableArraySlice(Literal* literal) {
 }
 
 template <>
+/* static */ tensorflow::gtl::MutableArraySlice<half>
+LiteralUtil::GetMutableArraySlice<half>(Literal* literal) {
+  // C++11 standard, basic_string 21.4.1.5, values should be stored
+  // contiguously. From C++17 a mutable data() member will be provided.
+  auto values = literal->mutable_f16s();
+  return tensorflow::gtl::MutableArraySlice<half>(
+          reinterpret_cast<half*>(&(*values)[0]), values->size() / 2);
+}
+
+template <>
 /* static */ tensorflow::gtl::ArraySlice<bool> LiteralUtil::GetArraySlice<bool>(
     const Literal& literal) {
   CHECK_EQ(literal.shape().element_type(), PRED);
@@ -976,6 +1002,15 @@ LiteralUtil::GetArraySlice<double>(const Literal& literal) {
   return literal.f64s();
 }
 
+template <>
+/* static */ tensorflow::gtl::ArraySlice<half>
+LiteralUtil::GetArraySlice<half>(const Literal& literal) {
+  CHECK_EQ(literal.shape().element_type(), F16);
+  return tensorflow::gtl::ArraySlice<half>(
+          reinterpret_cast<const half*>(literal.f16s().data()),
+          literal.f16s().size() / 2);
+}
+
 template <typename NativeT>
 static bool AllElementsEqualValue(const Literal& literal, NativeT value) {
   for (int64 i = 0; i < ShapeUtil::ElementsIn(literal.shape()); ++i) {
@@ -1015,6 +1050,8 @@ static bool AllElementsEqualValue(const Literal& literal, NativeT value) {
       return AllElementsEqualValue<float>(literal, value);
     case F64:
       return AllElementsEqualValue<double>(literal, value);
+    case F16:
+      return AllElementsEqualValue<half>(literal, (half)value);
     case PRED:
       if (value == 0) {
         return AllElementsEqualValue<bool>(literal, false);
@@ -1034,6 +1071,8 @@ static bool AllElementsEqualValue(const Literal& literal, NativeT value) {
       return AllElementsEqualValue<float>(literal, value);
     case F64:
       return AllElementsEqualValue<double>(literal, value);
+    case F16:
+      return AllElementsEqualValue<half>(literal, (half)value);
     default:
       return false;
   }
@@ -1058,6 +1097,8 @@ static bool AllElementsEqualValue(const Literal& literal, NativeT value) {
       return Get<float>(literal, indices) == 0.0f;
     case F64:
       return Get<double>(literal, indices) == 0.0;
+    case F16:
+      return Get<half>(literal, indices) == (half)0.0f;
     case PRED:
       return Get<bool>(literal, indices) == false;
     default:
@@ -1126,6 +1167,17 @@ template <>
                                               Literal* literal) {
   CHECK_EQ(ShapeUtil::ElementsIn(literal->shape()), num_elements);
   literal->mutable_f64s()->Resize(num_elements, value);
+}
+
+template <>
+/* static */ void LiteralUtil::Resize<half>(int64 num_elements, half value,
+                                            Literal* literal) {
+  CHECK_EQ(ShapeUtil::ElementsIn(literal->shape()), num_elements);
+  literal->mutable_f16s()->resize(num_elements * 2);
+  auto data = GetMutableArraySlice<half>(literal);
+  for (int i = 0; i< num_elements; i++) {
+    data[i] = value;
+  }
 }
 
 }  // namespace xla

--- a/tensorflow/compiler/xla/literal_util.cc
+++ b/tensorflow/compiler/xla/literal_util.cc
@@ -225,7 +225,7 @@ template <typename T>
     case U16:
       LOG(FATAL) << "u16/s16 literals not yet implemented";
     case F16:
-      return *LiteralUtil::CreateR0<half>((half)1.0f);
+      return *LiteralUtil::CreateR0<half>(static_cast<half>(1.0f));
     case TUPLE:
       LOG(FATAL) << "tuple element type cannot take on value of 1";
     case OPAQUE:
@@ -261,8 +261,8 @@ template <typename T>
     case U16:
       LOG(FATAL) << "u16/s16 literals not yet implemented";
     case F16:
-      return *LiteralUtil::CreateR0<half>((half)
-              -std::numeric_limits<float>::infinity());
+      return *LiteralUtil::CreateR0<half>(
+              static_cast<half>(-std::numeric_limits<float>::infinity()));
     case TUPLE:
       LOG(FATAL) << "tuple element type has no minimum value";
     case OPAQUE:
@@ -298,8 +298,8 @@ template <typename T>
     case U16:
       LOG(FATAL) << "u16/s16 literals not yet implemented";
     case F16:
-      return *LiteralUtil::CreateR0<half>((half)
-              std::numeric_limits<float>::infinity());
+      return *LiteralUtil::CreateR0<half>(
+              static_cast<half>(std::numeric_limits<float>::infinity()));
     case TUPLE:
       LOG(FATAL) << "tuple element type has no maximum value";
     case OPAQUE:
@@ -701,7 +701,7 @@ template <typename T>
     case F64:
       Resize<double>(num_elements, 0, literal);
     case F16:
-      Resize<half>(num_elements, (half)0.0f, literal);
+      Resize<half>(num_elements, static_cast<half>(0.0f), literal);
       break;
     default:
       LOG(FATAL) << "primitive type not supported in literals: "
@@ -1176,7 +1176,7 @@ template <>
 /* static */ void LiteralUtil::Resize<half>(int64 num_elements, half value,
                                             Literal* literal) {
   CHECK_EQ(ShapeUtil::ElementsIn(literal->shape()), num_elements);
-  literal->mutable_f16s()->resize(num_elements * 2);
+  literal->mutable_f16s()->resize(num_elements * sizeof(half));
   auto data = GetMutableArraySlice<half>(literal);
   for (int i = 0; i < num_elements; i++) {
     data[i] = value;

--- a/tensorflow/compiler/xla/literal_util.h
+++ b/tensorflow/compiler/xla/literal_util.h
@@ -506,6 +506,10 @@ template <>
 LiteralUtil::GetArraySlice<double>(const Literal& literal);
 
 template <>
+/* static */ tensorflow::gtl::ArraySlice<half>
+LiteralUtil::GetArraySlice<half>(const Literal& literal);
+
+template <>
 /* static */ tensorflow::gtl::MutableArraySlice<bool>
 LiteralUtil::GetMutableArraySlice(Literal* literal);
 
@@ -540,6 +544,50 @@ LiteralUtil::GetMutableArraySlice(Literal* literal);
 template <>
 /* static */ tensorflow::gtl::MutableArraySlice<double>
 LiteralUtil::GetMutableArraySlice(Literal* literal);
+
+template <>
+/* static */ tensorflow::gtl::MutableArraySlice<half>
+LiteralUtil::GetMutableArraySlice(Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<bool>(int64 num_elements, bool value,
+                                            Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<int8>(int64 num_elements, int8 value,
+                                            Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<uint8>(int64 num_elements, uint8 value,
+                                             Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<int32>(int64 num_elements, int32 value,
+                                             Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<uint32>(int64 num_elements, uint32 value,
+                                              Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<int64>(int64 num_elements, int64 value,
+                                             Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<uint64>(int64 num_elements, uint64 value,
+                                              Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<float>(int64 num_elements, float value,
+                                             Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<double>(int64 num_elements, double value,
+                                              Literal* literal);
+
+template <>
+/* static */ void LiteralUtil::Resize<half>(int64 num_elements, half value,
+                                            Literal* literal);
 
 template <typename NativeT>
 /* static */ std::unique_ptr<Literal> LiteralUtil::CreateR0(NativeT value) {
@@ -770,6 +818,14 @@ template <>
   return literal.u8s()[linear_index];
 }
 
+template <>
+/* static */ inline half LiteralUtil::Get<half>(
+    const Literal& literal, tensorflow::gtl::ArraySlice<int64> multi_index) {
+  CHECK(literal.shape().element_type() == F16);
+  int64 linear_index = LinearIndex(literal, multi_index);
+  return GetArraySlice<half>(literal)[linear_index];
+}
+
 template <typename NativeT>
 /* static */ void LiteralUtil::Set(
     Literal* literal, tensorflow::gtl::ArraySlice<int64> multi_index,
@@ -834,76 +890,13 @@ template <typename NativeT>
   } while (IndexUtil::BumpIndices(literal.shape(), &indices));
 }
 
-template <>
-/* static */ inline void LiteralUtil::PopulateR0<bool>(bool value,
-                                                       Literal* literal) {
+template <typename NativeT>
+/* static */ inline void LiteralUtil::PopulateR0(NativeT value,
+                                                 Literal* literal) {
   *literal->mutable_shape() =
-      ShapeUtil::MakeShape(primitive_util::NativeToPrimitiveType<bool>(), {});
-  literal->mutable_preds()->Add(value);
-}
-
-template <>
-/* static */ inline void LiteralUtil::PopulateR0<uint8>(uint8 value,
-                                                        Literal* literal) {
-  *literal->mutable_shape() =
-      ShapeUtil::MakeShape(primitive_util::NativeToPrimitiveType<uint8>(), {});
-  literal->mutable_u8s()->push_back(value);
-}
-
-template <>
-/* static */ inline void LiteralUtil::PopulateR0<int8>(int8 value,
-                                                       Literal* literal) {
-  *literal->mutable_shape() =
-      ShapeUtil::MakeShape(primitive_util::NativeToPrimitiveType<int8>(), {});
-  literal->mutable_u8s()->push_back(value);
-}
-
-template <>
-/* static */ inline void LiteralUtil::PopulateR0<uint32>(uint32 value,
-                                                         Literal* literal) {
-  *literal->mutable_shape() =
-      ShapeUtil::MakeShape(primitive_util::NativeToPrimitiveType<uint32>(), {});
-  literal->mutable_u32s()->Add(value);
-}
-
-template <>
-/* static */ inline void LiteralUtil::PopulateR0<int32>(int32 value,
-                                                        Literal* literal) {
-  *literal->mutable_shape() =
-      ShapeUtil::MakeShape(primitive_util::NativeToPrimitiveType<int32>(), {});
-  literal->mutable_s32s()->Add(value);
-}
-
-template <>
-/* static */ inline void LiteralUtil::PopulateR0<uint64>(uint64 value,
-                                                         Literal* literal) {
-  *literal->mutable_shape() =
-      ShapeUtil::MakeShape(primitive_util::NativeToPrimitiveType<uint64>(), {});
-  literal->mutable_u64s()->Add(value);
-}
-
-template <>
-/* static */ inline void LiteralUtil::PopulateR0<int64>(int64 value,
-                                                        Literal* literal) {
-  *literal->mutable_shape() =
-      ShapeUtil::MakeShape(primitive_util::NativeToPrimitiveType<int64>(), {});
-  literal->mutable_s64s()->Add(value);
-}
-
-template <>
-/* static */ inline void LiteralUtil::PopulateR0<float>(float value,
-                                                        Literal* literal) {
-  *literal->mutable_shape() =
-      ShapeUtil::MakeShape(primitive_util::NativeToPrimitiveType<float>(), {});
-  literal->mutable_f32s()->Add(value);
-}
-
-template <>
-/* static */ inline void LiteralUtil::PopulateR0<double>(double value,
-                                                         Literal* literal) {
-  *literal->mutable_shape() =
-      ShapeUtil::MakeShape(primitive_util::NativeToPrimitiveType<double>(), {});
-  literal->mutable_f64s()->Add(value);
+      ShapeUtil::MakeShape(
+              primitive_util::NativeToPrimitiveType<NativeT>(), {});
+  Resize<NativeT>(1, value, literal);
 }
 
 template <typename NativeT>
@@ -1115,42 +1108,6 @@ template <typename NativeSrcT, typename NativeDestT>
   }
   return result_literal;
 }
-
-template <>
-/* static */ void LiteralUtil::Resize<bool>(int64 num_elements, bool value,
-                                            Literal* literal);
-
-template <>
-/* static */ void LiteralUtil::Resize<int8>(int64 num_elements, int8 value,
-                                            Literal* literal);
-
-template <>
-/* static */ void LiteralUtil::Resize<uint8>(int64 num_elements, uint8 value,
-                                             Literal* literal);
-
-template <>
-/* static */ void LiteralUtil::Resize<int32>(int64 num_elements, int32 value,
-                                             Literal* literal);
-
-template <>
-/* static */ void LiteralUtil::Resize<uint32>(int64 num_elements, uint32 value,
-                                              Literal* literal);
-
-template <>
-/* static */ void LiteralUtil::Resize<int64>(int64 num_elements, int64 value,
-                                             Literal* literal);
-
-template <>
-/* static */ void LiteralUtil::Resize<uint64>(int64 num_elements, uint64 value,
-                                              Literal* literal);
-
-template <>
-/* static */ void LiteralUtil::Resize<float>(int64 num_elements, float value,
-                                             Literal* literal);
-
-template <>
-/* static */ void LiteralUtil::Resize<double>(int64 num_elements, double value,
-                                              Literal* literal);
 
 template <typename NativeT>
 /* static */ std::unique_ptr<Literal>

--- a/tensorflow/compiler/xla/literal_util_test.cc
+++ b/tensorflow/compiler/xla/literal_util_test.cc
@@ -105,6 +105,9 @@ TEST_F(LiteralUtilTest, LiteralScalarToString) {
 
   auto f32_lit = LiteralUtil::CreateR0<float>(3.14f);
   ASSERT_EQ("3.14", LiteralUtil::ToString(*f32_lit));
+
+  auto f16_lit = LiteralUtil::CreateR0<half>((half)0.5f);
+  ASSERT_EQ("0.5", LiteralUtil::ToString(*f16_lit));
 }
 
 TEST_F(LiteralUtilTest, LiteralVectorToString) {
@@ -372,6 +375,15 @@ TEST_F(LiteralUtilTest, IsAll) {
       LiteralUtil::IsAll(*LiteralUtil::CreateR2<uint64>({{8, 8}, {8, 9}}), 8));
   EXPECT_FALSE(
       LiteralUtil::IsAll(*LiteralUtil::CreateR2<uint64>({{9, 8}, {8, 8}}), 8));
+
+  half h8 = (half)8.0f;
+  half h9 = (half)9.0f;
+  EXPECT_TRUE(
+      LiteralUtil::IsAll(*LiteralUtil::CreateR2<half>({{h8}, {h8}}), 8));
+  EXPECT_FALSE(
+      LiteralUtil::IsAll(*LiteralUtil::CreateR2<half>({{h8}, {h9}}), 8));
+  EXPECT_FALSE(
+      LiteralUtil::IsAll(*LiteralUtil::CreateR2<half>({{h9}, {h8}}), 8));
 
   auto uint64_max = std::numeric_limits<uint64>::max();
   EXPECT_FALSE(LiteralUtil::IsAll(
@@ -659,6 +671,30 @@ TEST_F(LiteralUtilTest, PopulateWithValueR2U64) {
   EXPECT_TRUE(LiteralUtil::Equal(output, *expected));
 }
 
+TEST_F(LiteralUtilTest, PopulateWithValueR0F16) {
+  Literal output;
+  half h = (half)0.25f;
+  LiteralUtil::PopulateWithValue<half>(h, {}, &output);
+  auto expected = LiteralUtil::CreateR0<half>(h);
+  EXPECT_TRUE(LiteralUtil::Equal(output, *expected));
+}
+
+TEST_F(LiteralUtilTest, PopulateWithValueR1F16) {
+  Literal output;
+  half h = (half)0.5f;
+  LiteralUtil::PopulateWithValue<half>(h, {3}, &output);
+  auto expected = LiteralUtil::CreateR1<half>({h, h, h});
+  EXPECT_TRUE(LiteralUtil::Equal(output, *expected));
+}
+
+TEST_F(LiteralUtilTest, PopulateWithValueR2F16) {
+  Literal output;
+  half h = (half)2.0f;
+  LiteralUtil::PopulateWithValue<half>(h, {2, 2}, &output);
+  auto expected = LiteralUtil::CreateR2<half>({{h, h}, {h, h}});
+  EXPECT_TRUE(LiteralUtil::Equal(output, *expected));
+}
+
 TEST_F(LiteralUtilTest, ReplicateR2U32) {
   auto input = LiteralUtil::CreateR2<uint32>(
       {{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}});
@@ -728,6 +764,38 @@ TEST_F(LiteralUtilTest, CopyScalars) {
   EXPECT_EQ(LiteralUtil::Get<uint32>(*zero, {}), 17);
   TF_EXPECT_OK(LiteralUtil::Copy(*zero, {}, vect.get(), {4}, {}));
   EXPECT_EQ(LiteralUtil::Get<uint32>(*vect, {4}), 17);
+}
+
+TEST_F(LiteralUtilTest, F16) {
+  auto m1 = LiteralUtil::CreateFromShape(ShapeUtil::MakeShape(F16, {2, 2}));
+  Literal* l1 = m1.get();
+  const char* d1 = (const char*)LiteralUtil::InternalData(*l1);
+  EXPECT_EQ(d1[0], 0);
+  EXPECT_EQ(d1[1], 0);
+  EXPECT_EQ(d1[2], 0);
+  EXPECT_EQ(d1[3], 0);
+  EXPECT_EQ(d1[4], 0);
+  EXPECT_EQ(d1[5], 0);
+  EXPECT_EQ(d1[6], 0);
+  EXPECT_EQ(d1[7], 0);
+  EXPECT_EQ(LiteralUtil::InternalData(*l1),
+            LiteralUtil::MutableInternalData(l1));
+
+  half h1 = (half)1.0f;
+  half h2 = (half)2.0f;
+  auto m2 = LiteralUtil::CreateR2<half>({{h1, h2}, {h2, h1}});
+  Literal* l2 = m2.get();
+  const char* d2 = (const char*)LiteralUtil::InternalData(*l2);
+  EXPECT_EQ(d2[0], 0);
+  EXPECT_EQ(d2[1], 0x3C);
+  EXPECT_EQ(d2[2], 0);
+  EXPECT_EQ(d2[3], 0x40);
+  EXPECT_EQ(d2[4], 0);
+  EXPECT_EQ(d2[5], 0x40);
+  EXPECT_EQ(d2[6], 0);
+  EXPECT_EQ(d2[7], 0x3C);
+  EXPECT_EQ(LiteralUtil::InternalData(*l2),
+            LiteralUtil::MutableInternalData(l2));
 }
 
 TEST_F(LiteralUtilTest, Populate) {

--- a/tensorflow/compiler/xla/literal_util_test.cc
+++ b/tensorflow/compiler/xla/literal_util_test.cc
@@ -106,7 +106,7 @@ TEST_F(LiteralUtilTest, LiteralScalarToString) {
   auto f32_lit = LiteralUtil::CreateR0<float>(3.14f);
   ASSERT_EQ("3.14", LiteralUtil::ToString(*f32_lit));
 
-  auto f16_lit = LiteralUtil::CreateR0<half>((half)0.5f);
+  auto f16_lit = LiteralUtil::CreateR0<half>(static_cast<half>(0.5f));
   ASSERT_EQ("0.5", LiteralUtil::ToString(*f16_lit));
 }
 
@@ -376,8 +376,8 @@ TEST_F(LiteralUtilTest, IsAll) {
   EXPECT_FALSE(
       LiteralUtil::IsAll(*LiteralUtil::CreateR2<uint64>({{9, 8}, {8, 8}}), 8));
 
-  half h8 = (half)8.0f;
-  half h9 = (half)9.0f;
+  half h8(8.0f);
+  half h9(9.0f);
   EXPECT_TRUE(
       LiteralUtil::IsAll(*LiteralUtil::CreateR2<half>({{h8}, {h8}}), 8));
   EXPECT_FALSE(
@@ -673,7 +673,7 @@ TEST_F(LiteralUtilTest, PopulateWithValueR2U64) {
 
 TEST_F(LiteralUtilTest, PopulateWithValueR0F16) {
   Literal output;
-  half h = (half)0.25f;
+  half h(0.25f);
   LiteralUtil::PopulateWithValue<half>(h, {}, &output);
   auto expected = LiteralUtil::CreateR0<half>(h);
   EXPECT_TRUE(LiteralUtil::Equal(output, *expected));
@@ -681,7 +681,7 @@ TEST_F(LiteralUtilTest, PopulateWithValueR0F16) {
 
 TEST_F(LiteralUtilTest, PopulateWithValueR1F16) {
   Literal output;
-  half h = (half)0.5f;
+  half h(0.5f);
   LiteralUtil::PopulateWithValue<half>(h, {3}, &output);
   auto expected = LiteralUtil::CreateR1<half>({h, h, h});
   EXPECT_TRUE(LiteralUtil::Equal(output, *expected));
@@ -689,7 +689,7 @@ TEST_F(LiteralUtilTest, PopulateWithValueR1F16) {
 
 TEST_F(LiteralUtilTest, PopulateWithValueR2F16) {
   Literal output;
-  half h = (half)2.0f;
+  half h(2.0f);
   LiteralUtil::PopulateWithValue<half>(h, {2, 2}, &output);
   auto expected = LiteralUtil::CreateR2<half>({{h, h}, {h, h}});
   EXPECT_TRUE(LiteralUtil::Equal(output, *expected));
@@ -784,8 +784,8 @@ TEST_F(LiteralUtilTest, F16) {
   EXPECT_EQ(LiteralUtil::InternalData(*l1),
             LiteralUtil::MutableInternalData(l1));
 
-  half h1 = (half)1.0f;
-  half h2 = (half)2.0f;
+  half h1(1.0f);
+  half h2(2.0f);
   auto m2 = LiteralUtil::CreateR2<half>({{h1, h2}, {h2, h1}});
   Literal* l2 = m2.get();
   const char* d2 = (const char*)LiteralUtil::InternalData(*l2);

--- a/tensorflow/compiler/xla/literal_util_test.cc
+++ b/tensorflow/compiler/xla/literal_util_test.cc
@@ -767,6 +767,9 @@ TEST_F(LiteralUtilTest, CopyScalars) {
 }
 
 TEST_F(LiteralUtilTest, F16) {
+  // Verify that the internal data views are consistent and that they
+  // are in little endian format
+  // TODO - modify if we make the data format machine endianess dependent
   auto m1 = LiteralUtil::CreateFromShape(ShapeUtil::MakeShape(F16, {2, 2}));
   Literal* l1 = m1.get();
   const char* d1 = (const char*)LiteralUtil::InternalData(*l1);

--- a/tensorflow/compiler/xla/primitive_util.cc
+++ b/tensorflow/compiler/xla/primitive_util.cc
@@ -78,6 +78,11 @@ PrimitiveType NativeToPrimitiveType<double>() {
   return F64;
 }
 
+template <>
+PrimitiveType NativeToPrimitiveType<half>() {
+  return F16;
+}
+
 bool IsFloatingPointType(PrimitiveType type) {
   return type == F16 || type == F32 || type == F64;
 }

--- a/tensorflow/compiler/xla/primitive_util.h
+++ b/tensorflow/compiler/xla/primitive_util.h
@@ -75,6 +75,8 @@ template <>
 PrimitiveType NativeToPrimitiveType<float>();
 template <>
 PrimitiveType NativeToPrimitiveType<double>();
+template <>
+PrimitiveType NativeToPrimitiveType<half>();
 
 bool IsFloatingPointType(PrimitiveType type);
 
@@ -149,6 +151,10 @@ struct PrimitiveTypeToNative<F32> {
 template <>
 struct PrimitiveTypeToNative<F64> {
   using type = double;
+};
+template <>
+struct PrimitiveTypeToNative<F16> {
+  using type = half;
 };
 
 }  // namespace primitive_util

--- a/tensorflow/compiler/xla/types.h
+++ b/tensorflow/compiler/xla/types.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 #include "tensorflow/core/platform/types.h"
 
+#include <Eigen/Core>
+
 namespace xla {
 
 using ::tensorflow::string;
@@ -31,6 +33,8 @@ using ::tensorflow::uint8;
 using ::tensorflow::uint16;
 using ::tensorflow::uint32;
 using ::tensorflow::uint64;
+
+using ::Eigen::half;
 
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/xla_data.proto
+++ b/tensorflow/compiler/xla/xla_data.proto
@@ -286,7 +286,7 @@ message Literal {
   repeated float f32s = 8;
   repeated double f64s = 9;
   repeated Literal tuple_literals = 10;
-  bytes f16s = 11;
+  bytes f16s = 11; // Note: the F16s are encoded in little endian byte order
 }
 
 message WindowDimension {

--- a/tensorflow/compiler/xla/xla_data.proto
+++ b/tensorflow/compiler/xla/xla_data.proto
@@ -286,6 +286,7 @@ message Literal {
   repeated float f32s = 8;
   repeated double f64s = 9;
   repeated Literal tuple_literals = 10;
+  bytes f16s = 11;
 }
 
 message WindowDimension {


### PR DESCRIPTION
No support has been added to any public back-end, however the unit tests demonstrate that the literals can store and retrieve data correctly.

[Note: Resize needed to be moved so it could be used in a subsequent function]


