### PR TITLE
Documentation: Typo confusing `tf.training.Coordinator.should_stop` w…

### DIFF
--- a/tensorflow/python/training/coordinator.py
+++ b/tensorflow/python/training/coordinator.py
@@ -62,7 +62,7 @@ class Coordinator(object):
   #### Exception handling:
 
   A thread can report an exception to the coordinator as part of the
-  `should_stop()` call.  The exception will be re-raised from the
+  `request_stop()` call.  The exception will be re-raised from the
   `coord.join()` call.
 
   Thread code:


### PR DESCRIPTION
…ith `tf.training.Coordinator.request_stop`

The code makes it clear, but I wanted to remove the inconsistency between the discussion and the code.