### PR TITLE
Conversion to int64 for output_buffer_size

### DIFF
--- a/tensorflow/contrib/data/python/ops/dataset_ops.py
+++ b/tensorflow/contrib/data/python/ops/dataset_ops.py
@@ -1442,7 +1442,7 @@ class MapDataset(Dataset):
             output_buffer_size, dtype=dtypes.int64, name="output_buffer_size")
       else:
         self._output_buffer_size = ops.convert_to_tensor(
-            output_buffer_size, dtype=dtypes.int64, name="output_buffer_size")
+            self._num_threads, dtype=dtypes.int64, name="output_buffer_size")
     else:
       self._num_threads = None
       self._output_buffer_size = None

--- a/tensorflow/contrib/data/python/ops/dataset_ops.py
+++ b/tensorflow/contrib/data/python/ops/dataset_ops.py
@@ -1441,7 +1441,8 @@ class MapDataset(Dataset):
         self._output_buffer_size = ops.convert_to_tensor(
             output_buffer_size, dtype=dtypes.int64, name="output_buffer_size")
       else:
-        self._output_buffer_size = self._num_threads
+        self._output_buffer_size = ops.convert_to_tensor(
+            output_buffer_size, dtype=dtypes.int64, name="output_buffer_size")
     else:
       self._num_threads = None
       self._output_buffer_size = None


### PR DESCRIPTION
Add conversion to int64 when output_buffer_size is initialized with num_threads (of type int32).

The following snippet will output an error `Input 'output_buffer_size' of 'ParallelMapDataset' Op has type int32 that does not match expected type of int64` when `num_threads` is initialized but not `output_buffer_size`.

```python
dataset = tf.contrib.data.Dataset.range(10)
dataset = dataset.map(lambda x: x+1, num_threads=2)
iterator = dataset.make_one_shot_iterator()
```

This is because in this case, `output_buffer_size` is initialized with `num_threads` of type `tf.int32` without any conversion to `tf.int64`.