### PR TITLE
Automatically convert inputs to tensors in Dataset.from_tensor_slices

### DIFF
--- a/tensorflow/contrib/data/python/ops/dataset_ops.py
+++ b/tensorflow/contrib/data/python/ops/dataset_ops.py
@@ -887,6 +887,10 @@ class TensorSliceDataset(Dataset):
     """See `Dataset.from_tensor_slices()` for details."""
     super(TensorSliceDataset, self).__init__()
     with ops.name_scope("tensors"):
+      tensors = ops.convert_n_to_tensor_or_indexed_slices(tensors)
+      if not tensors:
+        raise ValueError(
+            "Expected at least one tensor in Dataset.from_tensor_slices().")
       flat_tensors = [
           ops.convert_to_tensor(t, name="component_%d" % i)
           for i, t in enumerate(nest.flatten(tensors))


### PR DESCRIPTION
Allows usage like:
```python
tf.contrib.data.Dataset.from_tensor_slices([['img1.jpg', 'img2.jpg'], [1, 2]])
```
Otherwise, the two input lists (2 of size 2 here) were flattened into 1 list (of size 4), which resulted in a "list index out of range" error.

My correction was inspired by how the `tf.train.slice_input_producer` is defined: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/training/input.py#L302

Also see pull request #10079.
