### PR TITLE
Adding NewScopeWithGraph func to Scope struct. This enables the construction of an in-memory graph from a previously serialized form + new additions.

### DIFF
--- a/tensorflow/go/op/scope.go
+++ b/tensorflow/go/op/scope.go
@@ -49,6 +49,11 @@ func NewScope() *Scope {
 	return &Scope{graph: tf.NewGraph(), namemap: make(map[string]int), err: new(scopeErr)}
 }
 
+// NewScopeWithGraph creates a Scope initialized with the Graph thats passed in
+func NewScopeWithGraph(g *tf.Graph) *Scope {
+	return &Scope{graph: g, namemap: make(map[string]int), err: new(scopeErr)}
+}
+
 // Finalize returns the Graph on which this scope operates on and renders s
 // unusable. If there was an error during graph construction, that error is
 // returned instead.

--- a/tensorflow/go/op/scope_test.go
+++ b/tensorflow/go/op/scope_test.go
@@ -95,6 +95,40 @@ func TestMultipleGeneratedOps(t *testing.T) {
 	}
 }
 
+func TestScopeWithGraph(t *testing.T) {
+	s1 := NewScope()
+
+	var hello interface{} = "hello"
+	tensor1, _ := tf.NewTensor(hello)
+	s1.AddOperation(tf.OpSpec{
+		Type: "Const",
+		Name: hello.(string),
+		Attrs: map[string]interface{}{
+			"dtype": tensor1.DataType(),
+			"value": tensor1,
+		},
+	})
+	graph, err := s1.Finalize()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s2 := NewScopeWithGraph(graph)
+	var world interface{} = "world"
+	tensor2, _ := tf.NewTensor(world)
+	s2.AddOperation(tf.OpSpec{
+		Type: "Const",
+		Name: world.(string),
+		Attrs: map[string]interface{}{
+			"dtype": tensor2.DataType(),
+			"value": tensor2,
+		},
+	})
+	if _, err := s2.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func Example() {
 	// This example creates a Graph that multiplies a constant matrix with
 	// a matrix to be provided during graph execution (via

--- a/tensorflow/go/op/scope_test.go
+++ b/tensorflow/go/op/scope_test.go
@@ -97,34 +97,15 @@ func TestMultipleGeneratedOps(t *testing.T) {
 
 func TestScopeWithGraph(t *testing.T) {
 	s1 := NewScope()
-
-	var hello interface{} = "hello"
-	tensor1, _ := tf.NewTensor(hello)
-	s1.AddOperation(tf.OpSpec{
-		Type: "Const",
-		Name: hello.(string),
-		Attrs: map[string]interface{}{
-			"dtype": tensor1.DataType(),
-			"value": tensor1,
-		},
-	})
+	Const(s1, "hello")
 	graph, err := s1.Finalize()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	s2 := NewScopeWithGraph(graph)
-	var world interface{} = "world"
-	tensor2, _ := tf.NewTensor(world)
-	s2.AddOperation(tf.OpSpec{
-		Type: "Const",
-		Name: world.(string),
-		Attrs: map[string]interface{}{
-			"dtype": tensor2.DataType(),
-			"value": tensor2,
-		},
-	})
-	if _, err := s2.Finalize(); err != nil {
+	Const(s2.SubScope("addition"), "world")
+	if err := s2.Err(); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Found a use case that wasn't covered while developing with tensorflow in go.

Since working with multiple-graphs is an anti-pattern:
http://stackoverflow.com/questions/35955144/working-with-multiple-graphs-in-tensorflow

needed to reuse a previously trained GraphDef file (binary) and then make additions. 

What do you think?