### PR TITLE
Windows: Make TensorFlow build with Bazel again

### DIFF
--- a/configure
+++ b/configure
@@ -138,6 +138,7 @@ function setup_python {
   # Convert python path to Windows style before writing into bazel.rc
   if is_windows; then
     PYTHON_BIN_PATH="$(cygpath -m "$PYTHON_BIN_PATH")"
+    PYTHON_LIB_PATH="$(cygpath -m "$PYTHON_LIB_PATH")"
   fi
 
   # Set-up env variables used by python_configure.bzl

--- a/tensorflow/core/distributed_runtime/BUILD
+++ b/tensorflow/core/distributed_runtime/BUILD
@@ -29,6 +29,7 @@ filegroup(
 
 load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_test")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_tests")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 # For platform specific build config
 load(
@@ -322,6 +323,7 @@ cc_library(
     name = "base_rendezvous_mgr",
     srcs = ["base_rendezvous_mgr.cc"],
     hdrs = ["base_rendezvous_mgr.h"],
+    copts = tf_copts(),
     deps = [
         ":rendezvous_mgr_interface",
         ":worker_cache",

--- a/tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh
+++ b/tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh
@@ -137,6 +137,8 @@ function get_failing_cpu_py_tests() {
     //$1/tensorflow/python/kernel_tests:string_to_number_op_test + \
     //$1/tensorflow/python/kernel_tests:summary_ops_test + \
     //$1/tensorflow/python/kernel_tests:variable_scope_test + \
+    //$1/tensorflow/python/tools:saved_model_cli_test + \
+    //$1/tensorflow/python/feature_column:feature_column_test + \
     //$1/tensorflow/python/saved_model:saved_model_test \
     "
 }

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -42,9 +42,9 @@ source "tensorflow/tools/ci_build/windows/bazel/common_env.sh" \
 source "tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh" \
   || { echo "Failed to source bazel_test_lib.sh" >&2; exit 1; }
 
-clean_output_base
-
 run_configure_for_cpu_build
+
+clean_output_base
 
 bazel build -c opt $BUILD_OPTS tensorflow/tools/pip_package:build_pip_package || exit $?
 

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -74,8 +74,11 @@ py_binary(
         "//tensorflow/python/debug:debug_pip",
         "//tensorflow/python/saved_model",
         "//tensorflow/python/tools:tools_pip",
-        "//tensorflow/tensorboard",
         # These targets don't build on Windows yet. Exclude them for now.
+        # rules_closure currently doesn't build on Windows due to
+        # https://github.com/bazelbuild/rules_closure/pull/206
+        # Since tensorboard dependes on rules_closure, exclude tensorboard until it's fixed. 
+        # "//tensorflow/tensorboard",
         # "//tensorflow/contrib/ndlstm",
         # "//tensorflow/contrib/slim",
         # "//tensorflow/contrib/slim/python/slim/nets:nets_pip",

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -77,7 +77,7 @@ py_binary(
         # These targets don't build on Windows yet. Exclude them for now.
         # rules_closure currently doesn't build on Windows due to
         # https://github.com/bazelbuild/rules_closure/pull/206
-        # Since tensorboard dependes on rules_closure, exclude tensorboard until it's fixed. 
+        # Since tensorboard dependes on rules_closure, exclude tensorboard until it's fixed.
         # "//tensorflow/tensorboard",
         # "//tensorflow/contrib/ndlstm",
         # "//tensorflow/contrib/slim",


### PR DESCRIPTION
1. [rules_closure](https://github.com/bazelbuild/rules_closure) doesn't work on Windows, since `//tensorflow/tensorboard` depends on it, we exclude it from dependencies of pip package for now.
Sent https://github.com/bazelbuild/rules_closure/pull/206 to fix one of the rules_closure problems on Windows.

2. `base_rendezvous_mgr` needs `tf_opts` to build correctly.

3. `bazel_test_lib.sh`: move `run_configure_for_cpu_build` function in front of `clean_output_base`, because we need the correct .bazelrc to be written before running bazel command.

4. Excluded `//tensorflow/python/tools:saved_model_cli_test` and `//tensorflow/python/feature_column:feature_column_test` on Windows.
The reason is [`test_src_dir_path`](https://github.com/tensorflow/tensorflow/blob/1a1527ab1fcffd94f692b1301fdbe87903ce7bdb/tensorflow/python/platform/googletest.py#L133) doesn't work on Windows, because `TEST_SRCDIR` points to the runfiles directory which doesn't exist on Windows, and besides, we run tests from `py_test_dir` directory, so `org_tensorflow/tensorflow` should be `org_tensorflow/py_test_dir/tensorflow`.
I couldn't find an easy fix for these problem, so skip the tests for now.


