### PR TITLE
cudnn: Fix symlink includes handling

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -875,8 +875,8 @@ def _create_cuda_repository(repository_ctx):
   included_files = _read_dir(repository_ctx, cuda_include_path).replace(
       cuda_include_path, '').splitlines()
   if '/cudnn.h' not in included_files:
-    genrules.append(_symlink_genrule_for_dir(repository_ctx, None, "",
-        "cudnn-include", [cudnn_header_dir + "/cudnn.h"], ["include/cudnn.h"]))
+    genrules.append(_symlink_genrule_for_dir(repository_ctx, cudnn_header_dir,
+        "include", "cudnn-include"))
   else:
     genrules.append(
             'filegroup(\n' +


### PR DESCRIPTION
Following a change to symlink creation for cuda_configure.bzl, the cudnn
include path symlink would try to link to a path ending with
'includeinclude/cudnn.h' rather than the correct path, 'include/cudnn.h'.
It appears this is caused by the way _symlink_genrule_for_dir handles
particular source header files. Since the cudnn library only exports a single
include file, cuda_configure.bzl can just use _symlink_genrule_for_dir
without explicitly specifying the header files to symlink.