### PR TITLE
Implement IRFFT as a CPU kernel

### DIFF
--- a/tensorflow/python/kernel_tests/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/fft_ops_test.py
@@ -210,9 +210,8 @@ class FFTOpsTest(BaseFFTOpsTest):
 class RFFTOpsTest(BaseFFTOpsTest):
 
   def _CompareBackward(self, x, rank, fft_length=None, use_placeholder=False):
-    if test.is_gpu_available(cuda_only=True):
-      super(RFFTOpsTest, self)._CompareBackward(x, rank, fft_length,
-                                                use_placeholder)
+    super(RFFTOpsTest, self)._CompareBackward(x, rank, fft_length,
+                                              use_placeholder)
 
   def _tfFFT(self, x, rank, fft_length=None, use_gpu=False, feed_dict=None):
     with self.test_session(use_gpu=use_gpu):
@@ -268,8 +267,7 @@ class RFFTOpsTest(BaseFFTOpsTest):
         x = np.zeros((0,) * dims).astype(np.float32)
         self.assertEqual(x.shape, self._tfFFT(x, rank).shape)
         x = np.zeros((0,) * dims).astype(np.complex64)
-        if test.is_gpu_available(cuda_only=True):
-          self.assertEqual(x.shape, self._tfIFFT(x, rank).shape)
+        self.assertEqual(x.shape, self._tfIFFT(x, rank).shape)
 
   def testBasic(self):
     for rank in VALID_FFT_RANKS:
@@ -353,43 +351,41 @@ class RFFTOpsTest(BaseFFTOpsTest):
           self._tfIFFT(x, rank, fft_length)
 
   def testGrad_Simple(self):
-    if test.is_gpu_available(cuda_only=True):
-      for rank in VALID_FFT_RANKS:
-        # rfft3d/irfft3d do not have gradients yet.
-        if rank == 3:
-          continue
-        for dims in xrange(rank, rank + 2):
-          for size in (
-              5,
-              6,):
-            re = np.ones(shape=(size,) * dims, dtype=np.float32)
-            im = -np.ones(shape=(size,) * dims, dtype=np.float32)
-            self._checkGradReal(self._tfFFTForRank(rank), re, use_gpu=True)
-            self._checkGradComplex(
-                self._tfIFFTForRank(rank),
-                re,
-                im,
-                result_is_complex=False,
-                use_gpu=True)
+    for rank in VALID_FFT_RANKS:
+      # rfft3d/irfft3d do not have gradients yet.
+      if rank == 3:
+        continue
+      for dims in xrange(rank, rank + 2):
+        for size in (
+            5,
+            6,):
+          re = np.ones(shape=(size,) * dims, dtype=np.float32)
+          im = -np.ones(shape=(size,) * dims, dtype=np.float32)
+          self._checkGradReal(self._tfFFTForRank(rank), re, use_gpu=True)
+          self._checkGradComplex(
+              self._tfIFFTForRank(rank),
+              re,
+              im,
+              result_is_complex=False,
+              use_gpu=True)
 
   def testGrad_Random(self):
-    if test.is_gpu_available(cuda_only=True):
-      np.random.seed(54321)
-      for rank in VALID_FFT_RANKS:
-        # rfft3d/irfft3d do not have gradients yet.
-        if rank == 3:
-          continue
-        for dims in xrange(rank, rank + 2):
-          for size in (5, 6):
-            re = np.random.rand(*((size,) * dims)).astype(np.float32) * 2 - 1
-            im = np.random.rand(*((size,) * dims)).astype(np.float32) * 2 - 1
-            self._checkGradReal(self._tfFFTForRank(rank), re, use_gpu=True)
-            self._checkGradComplex(
-                self._tfIFFTForRank(rank),
-                re,
-                im,
-                result_is_complex=False,
-                use_gpu=True)
+    np.random.seed(54321)
+    for rank in VALID_FFT_RANKS:
+      # rfft3d/irfft3d do not have gradients yet.
+      if rank == 3:
+        continue
+      for dims in xrange(rank, rank + 2):
+        for size in (5, 6):
+          re = np.random.rand(*((size,) * dims)).astype(np.float32) * 2 - 1
+          im = np.random.rand(*((size,) * dims)).astype(np.float32) * 2 - 1
+          self._checkGradReal(self._tfFFTForRank(rank), re, use_gpu=True)
+          self._checkGradComplex(
+              self._tfIFFTForRank(rank),
+              re,
+              im,
+              result_is_complex=False,
+              use_gpu=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Mentioned in issue #386 and #9029. TF is now supporting FFT operators. However, there still remains IRFFT as a CPU kernel unimplemented. In this PR I made up the missing part of `FFTCPU` class, and get the CPU kernel for IRFFT work.
I remove the limitation of `if test.is_gpu_available(cuda_only=True):` in `fft_ops_test.py`, and passed all test cases by `bazel test --config=opt -k //tensorflow/python/kernel_tests:fft_ops_test`.

The code is linted by clang-format 3.8 using google code style.