### PR TITLE
Fix spelling of Bahdanau in BahdanauAttention docstring

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
+++ b/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
@@ -336,9 +336,9 @@ class LuongAttention(_BaseAttentionMechanism):
 
 
 class BahdanauAttention(_BaseAttentionMechanism):
-  """Implements Bhadanau-style (additive) attention.
+  """Implements Bahdanau-style (additive) attention.
 
-  This attention has two forms.  The first is Bhandanau attention,
+  This attention has two forms.  The first is Bahdanau attention,
   as described in:
 
   Dzmitry Bahdanau, Kyunghyun Cho, Yoshua Bengio.


### PR DESCRIPTION
Looks like "Bahdanau" was mispelled in the docstring, this fixes it.