### PR TITLE
DOC modify install_mac and install_linux

### DIFF
--- a/tensorflow/docs_src/install/install_linux.md
+++ b/tensorflow/docs_src/install/install_linux.md
@@ -69,6 +69,8 @@ supported choices are as follows:
   * ["native" pip](#InstallingNativePip)
   * [Docker](#InstallingDocker)
   * [Anaconda](#InstallingAnaconda)
+  * installing from sources, which is for experts and is documented in
+    [a separate guide](https://www.tensorflow.org/install/install_sources).
 
 **We recommend the virtualenv installation.**
 [Virtualenv](https://virtualenv.pypa.io/en/stable/)

--- a/tensorflow/docs_src/install/install_linux.md
+++ b/tensorflow/docs_src/install/install_linux.md
@@ -69,7 +69,7 @@ supported choices are as follows:
   * ["native" pip](#InstallingNativePip)
   * [Docker](#InstallingDocker)
   * [Anaconda](#InstallingAnaconda)
-  * installing from sources, which is for experts and is documented in
+  * installing from sources, which is documented in
     [a separate guide](https://www.tensorflow.org/install/install_sources).
 
 **We recommend the virtualenv installation.**

--- a/tensorflow/docs_src/install/install_mac.md
+++ b/tensorflow/docs_src/install/install_mac.md
@@ -11,7 +11,7 @@ You must pick the mechanism by which you install TensorFlow. The supported choic
   * virtualenv
   * "native" pip
   * Docker
-  * installing from sources, which is for experts and is documented in
+  * installing from sources, which is documented in
     [a separate guide](https://www.tensorflow.org/install/install_sources).
 
 **We recommend the virtualenv installation.**

--- a/tensorflow/docs_src/install/install_mac.md
+++ b/tensorflow/docs_src/install/install_mac.md
@@ -12,7 +12,7 @@ You must pick the mechanism by which you install TensorFlow. The supported choic
   * "native" pip
   * Docker
   * installing from sources, which is for experts and is documented in
-    a separate guide.
+    [a separate guide](https://www.tensorflow.org/install/install_sources).
 
 **We recommend the virtualenv installation.**
 [Virtualenv](https://virtualenv.pypa.io/en/stable/)


### PR DESCRIPTION
Originally in [install_mac](https://www.tensorflow.org/install/install_mac) it says 

> installing from sources, which is for experts and is documented in a separate guide.

But it didn't say what that separate guide is. I think that is wield, so I added a link to that.
Also, [install_linux](https://www.tensorflow.org/install/install_linux) didn't mention install from source option, so I added one to that too

