### PR TITLE
[XLA] Ensure constants conform to the specified index type

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
@@ -344,8 +344,12 @@ class StridedSliceAssignOp : public XlaOpKernel {
       // and remove this workaround.
       lhs = rhs;
     } else {
+      xla::PrimitiveType xla_index_type;
+      OP_REQUIRES_OK(ctx,
+                     DataTypeToPrimitiveType(index_type_, &xla_index_type));
       lhs = ctx->builder()->DynamicUpdateSlice(
-          lhs, rhs, ctx->builder()->ConstantR1<int64>(slice_begin));
+          lhs, rhs, ctx->builder()->ConstantR1<int64>(xla_index_type,
+                                                      slice_begin));
     }
 
     OP_REQUIRES_OK(ctx, ctx->AssignVariable(0, lhs_type, lhs));

--- a/tensorflow/compiler/xla/client/computation_builder.h
+++ b/tensorflow/compiler/xla/client/computation_builder.h
@@ -148,6 +148,17 @@ class ComputationBuilder {
   template <typename NativeT>
   ComputationDataHandle ConstantR4FromArray4D(const Array4D<NativeT>& values);
 
+  // Enqueues a constant onto the computation.  The templated parameter
+  // indicates the type of the constant value, while the primitive_type
+  // parameter indicates the type of the literal constant.  Useful for when the
+  // data type must be determined at runtime.
+  template <typename NativeT>
+  ComputationDataHandle ConstantR0(PrimitiveType type, NativeT value);
+  template <typename NativeT>
+  ComputationDataHandle ConstantR1(PrimitiveType type,
+                                   tensorflow::gtl::ArraySlice<NativeT> values);
+
+
   // Enqueues a rank one constant (vector) onto the computation. The vector has
   // size 'length' and every element has the value 'value'.
   template <typename NativeT>
@@ -781,12 +792,38 @@ ComputationDataHandle ComputationBuilder::ConstantR0(NativeT value) {
 }
 
 template <typename NativeT>
+ComputationDataHandle ComputationBuilder::ConstantR0(PrimitiveType type,
+                                                     NativeT value) {
+  return ConstantOp(
+          [value, type](Literal* literal) {
+            std::unique_ptr<Literal> l = LiteralUtil::ConvertIfSrcTypeMatches(
+                    *(LiteralUtil::CreateR0<NativeT>(value)), type)
+                    .ConsumeValueOrDie();
+            *literal = *l;
+          });
+}
+
+template <typename NativeT>
 ComputationDataHandle ComputationBuilder::ConstantR1(
     tensorflow::gtl::ArraySlice<NativeT> values) {
   return ConstantOp([&values](Literal* literal) {
     LiteralUtil::PopulateR1(values, literal);
   });
 }
+
+template <typename NativeT>
+ComputationDataHandle ComputationBuilder::ConstantR1(
+        PrimitiveType type,
+        tensorflow::gtl::ArraySlice<NativeT> values) {
+  return ConstantOp(
+          [values, type](Literal* literal) {
+            std::unique_ptr<Literal> l = LiteralUtil::ConvertIfSrcTypeMatches(
+                    *(LiteralUtil::CreateR1<NativeT>(values)), type)
+                    .ConsumeValueOrDie();
+            *literal = *l;
+          });
+}
+
 
 template <typename NativeT>
 ComputationDataHandle ComputationBuilder::ConstantR1(int64 length,


### PR DESCRIPTION
The strided slice update introduces constants into the HLO graph which are not of the type specified by the core op.

This adds methods to the computation builder to allow the creation of literals with types determined at runtime, and makes the strided slice update op use them.

it depends on https://github.com/tensorflow/tensorflow/pull/10164
