### PR TITLE
Fixed crf.py to force log norm of zero length sequences to zero

### DIFF
--- a/tensorflow/contrib/crf/python/ops/crf.py
+++ b/tensorflow/contrib/crf/python/ops/crf.py
@@ -122,6 +122,11 @@ def crf_log_norm(inputs, sequence_lengths, transition_params):
       initial_state=first_input,
       dtype=dtypes.float32)
   log_norm = math_ops.reduce_logsumexp(alphas, [1])
+  
+  # Force the log norm of zero length sequences to zero.
+  log_norm = log_norm * math_ops.cast(math_ops.greater(sequence_length, 0),
+                                      log_norm.dtype)
+
   return log_norm
 
 


### PR DESCRIPTION
The original log_norm function in crf.py will not output zero when sequence length is zero. This new version force it to be zero.