### PR TITLE
Fixed tf.contrib.crf.crf_log_norm to handle zero sequence length.

### DIFF
--- a/tensorflow/contrib/crf/python/ops/crf.py
+++ b/tensorflow/contrib/crf/python/ops/crf.py
@@ -122,6 +122,11 @@ def crf_log_norm(inputs, sequence_lengths, transition_params):
       initial_state=first_input,
       dtype=dtypes.float32)
   log_norm = math_ops.reduce_logsumexp(alphas, [1])
+  
+  # Force the log norm of zero length sequences to zero.
+  log_norm = log_norm * math_ops.cast(math_ops.greater(sequence_lengths, 0),
+                                      log_norm.dtype)
+
   return log_norm
 
 


### PR DESCRIPTION
The original version of tf.contrib.crf.crf_log_norm can not produce zero output when the sequence length is zero or a negtive number, which will leads tf.contrib.crf_log_likelihood to produce non-zero output, so that the training procedure can be disturbed.
This patch force the output to be zero when the sequence length is equal or less than zero.