### PR TITLE
Fixed fixed_unigram_candidate_sampler docs

### DIFF
--- a/tensorflow/python/ops/candidate_sampling_ops.py
+++ b/tensorflow/python/ops/candidate_sampling_ops.py
@@ -249,7 +249,7 @@ def fixed_unigram_candidate_sampler(true_classes,
       `distortion = 1.0` gives regular unigram sampling (as defined by the vocab
       file), and `distortion = 0.0` gives a uniform distribution.
     num_reserved_ids: Optionally some reserved IDs can be added in the range
-      `[0, num_reserved_ids]` by the users. One use case is that a special
+      `[0, num_reserved_ids)` by the users. One use case is that a special
       unknown word token is used as ID 0. These IDs will have a sampling
       probability of 0.
     num_shards: A sampler can be used to sample from a subset of the original


### PR DESCRIPTION
Implementation of `tf.nn.fixed_unigram_candidate_sampler` (https://github.com/waleedka/tensorflow/blob/master/tensorflow/core/kernels/range_sampler.cc#L273) seems that the range of reserved ids is `[0, num_reserved_ids)`.
Fixed the docstring about `num_reserved_ids`.