### PR TITLE
Batch norm docs -> r1.2

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -393,16 +393,18 @@ def batch_norm(inputs,
 
   Can be used as a normalizer function for conv2d and fully_connected.
 
-  Note: When is_training is True the moving_mean and moving_variance need to be
-  updated, by default the update_ops are placed in `tf.GraphKeys.UPDATE_OPS` so
-  they need to be added as a dependency to the `train_op`, example:
+  Note: when training, the moving_mean and moving_variance need to be updated.
+  By default the update ops are placed in `tf.GraphKeys.UPDATE_OPS`, so they
+  need to be added as a dependency to the `train_op`. For example:
 
+  ```python
     update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
     with tf.control_dependencies(update_ops):
       train_op = optimizer.minimize(loss)
+  ```
 
   One can set updates_collections=None to force the updates in place, but that
-  can have speed penalty, especially in distributed settings.
+  can have a speed penalty, especially in distributed settings.
 
   Args:
     inputs: A tensor with 2 or more dimensions, where the first dimension has

--- a/tensorflow/python/layers/normalization.py
+++ b/tensorflow/python/layers/normalization.py
@@ -363,23 +363,14 @@ def batch_normalization(inputs,
 
   Sergey Ioffe, Christian Szegedy
 
-  Note: the operations which update the `moving_mean` and `moving_variance`
-  variables will not be added as dependencies of your training operation and so
-  must be run separately. For example:
+  Note: when training, the moving_mean and moving_variance need to be updated.
+  By default the update ops are placed in `tf.GraphKeys.UPDATE_OPS`, so they
+  need to be added as a dependency to the `train_op`. For example:
 
-  ```
-  extra_update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
-  sess.run([train_op, extra_update_ops], ...)
-  ```
-  Alternatively, add the operations as a dependency to your training operation
-  manually, and then just run your training operation as normal:
-
-  ```
-  extra_update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
-  with tf.control_dependencies(extra_update_ops):
-    train_op = optimizer.minimize(loss)
-  ...
-  sess.run([train_op], ...)
+  ```python
+    update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
+    with tf.control_dependencies(update_ops):
+      train_op = optimizer.minimize(loss)
   ```
 
   Arguments:


### PR DESCRIPTION
Fixed up the documentation for tf.contrib.layers.batch_norm and tf.layers.batch_normalization explaining how to include the update ops in the train_op. Also simplified the existing tf.layers.batch_normalization documentation to the least error-prone option (adding to the train_op).

PiperOrigin-RevId: 156609483

See https://github.com/tensorflow/tensorflow/commit/675f0f9073e9e6ac6df8018e972f2b38f2c4c23c for the same change in master.