### PR TITLE
Fixes issue #10258

### DIFF
--- a/tensorflow/contrib/image/kernels/image_ops.h
+++ b/tensorflow/contrib/image/kernels/image_ops.h
@@ -66,7 +66,13 @@ class ProjectiveGenerator {
         projection;
 
     // TODO(ringwalt): Add a fill value input.
+#if (defined __CUDA_ARCH__) && (CUDART_VERSION < 8000)
+    // On CUDA versions previous to 8.0, only __shared__ variables
+    // could be declared as static in the device code.
+    const T fill_value = T(0);
+#else
     static const T fill_value = T(0);
+#endif
     switch (interpolation_) {
       case INTERPOLATION_NEAREST:
         // Switch the order of x and y again for indexing into the image.


### PR DESCRIPTION
On CUDA versions previous to 8.0, only __shared__ variables could be declared as static in the device code.