### PR TITLE
Fixes of AutoParallel bug

### DIFF
--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -50,7 +50,7 @@ struct GrapplerItem {
   std::vector<QueueRunnerDef> queue_runners;
 
   // Variables of this model.
-  std::vector<VariableDef> variables;
+  std::vector<VariableDef> variable_def;
 
   // Return the set of node evaluated during a regular train/inference step.
   std::vector<const NodeDef*> MainOpsFanin() const;

--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -49,9 +49,6 @@ struct GrapplerItem {
   // Queue runner(s) required to run the queue(s) of this model.
   std::vector<QueueRunnerDef> queue_runners;
 
-  // Variables of this model.
-  std::vector<VariableDef> variable_def;
-
   // Return the set of node evaluated during a regular train/inference step.
   std::vector<const NodeDef*> MainOpsFanin() const;
   // Return the set nodes used by TensorFlow to initialize the graph.

--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -23,6 +23,7 @@ limitations under the License.
 
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/variable.pb.h"
 #include "tensorflow/core/protobuf/queue_runner.pb.h"
 
 namespace tensorflow {
@@ -47,6 +48,9 @@ struct GrapplerItem {
 
   // Queue runner(s) required to run the queue(s) of this model.
   std::vector<QueueRunnerDef> queue_runners;
+
+  // Variables of this model.
+  std::vector<VariableDef> variables;
 
   // Return the set of node evaluated during a regular train/inference step.
   std::vector<const NodeDef*> MainOpsFanin() const;

--- a/tensorflow/core/grappler/grappler_item_builder.cc
+++ b/tensorflow/core/grappler/grappler_item_builder.cc
@@ -261,7 +261,6 @@ std::unique_ptr<GrapplerItem> GrapplerItemFromMetaGraphDef(
       if (!var.initializer_name().empty()) {
         new_item->init_ops.push_back(var.initializer_name());
       }
-      new_item->variable_def.push_back(var);
     }
   }
 

--- a/tensorflow/core/grappler/grappler_item_builder.cc
+++ b/tensorflow/core/grappler/grappler_item_builder.cc
@@ -261,6 +261,7 @@ std::unique_ptr<GrapplerItem> GrapplerItemFromMetaGraphDef(
       if (!var.initializer_name().empty()) {
         new_item->init_ops.push_back(var.initializer_name());
       }
+      new_item->variables.push_back(var);
     }
   }
 

--- a/tensorflow/core/grappler/grappler_item_builder.cc
+++ b/tensorflow/core/grappler/grappler_item_builder.cc
@@ -261,7 +261,7 @@ std::unique_ptr<GrapplerItem> GrapplerItemFromMetaGraphDef(
       if (!var.initializer_name().empty()) {
         new_item->init_ops.push_back(var.initializer_name());
       }
-      new_item->variables.push_back(var);
+      new_item->variable_def.push_back(var);
     }
   }
 

--- a/tensorflow/core/grappler/optimizers/auto_parallel.cc
+++ b/tensorflow/core/grappler/optimizers/auto_parallel.cc
@@ -97,7 +97,7 @@ Status AutoParallel::Initialize(const GrapplerItem& item) {
     VLOG(2) << "Variable: " << var->name();
   }
 
-  for (const auto& var : item.variables) {
+  for (const auto& var : item.variable_def) {
     variables_.insert(std::make_pair(var.variable_name(), var));
   }
 
@@ -172,12 +172,10 @@ Status AutoParallel::Initialize(const GrapplerItem& item) {
     dont_replicate_nodes.insert(variable->name());
     VariableDef var = variables_[strings::StrCat(variable->name(), ":0")];
     if (!var.initializer_name().empty()) {
-      dont_replicate_nodes.insert(
-        var.initializer_name().substr(0, var.initializer_name().size() - 2));
+      dont_replicate_nodes.insert(NodeName(var.initializer_name()));
     }
     if (!var.snapshot_name().empty()) {
-      dont_replicate_nodes.insert(
-        var.snapshot_name().substr(0, var.snapshot_name().size() - 2));
+      dont_replicate_nodes.insert(NodeName(var.initializer_name()));
     }
   }
 

--- a/tensorflow/core/grappler/optimizers/auto_parallel.cc
+++ b/tensorflow/core/grappler/optimizers/auto_parallel.cc
@@ -97,10 +97,6 @@ Status AutoParallel::Initialize(const GrapplerItem& item) {
     VLOG(2) << "Variable: " << var->name();
   }
 
-  for (const auto& var : item.variable_def) {
-    variables_.insert(std::make_pair(var.variable_name(), var));
-  }
-
   const std::set<string> apply_gradients_ops = {"ApplyGradientDescent",
                                                 "ApplyProximalGradientDescent",
                                                 "ApplyAdadelta",
@@ -170,13 +166,10 @@ Status AutoParallel::Initialize(const GrapplerItem& item) {
   std::set<string> dont_replicate_nodes;
   for (const auto& variable : item.MainVariables()) {
     dont_replicate_nodes.insert(variable->name());
-    VariableDef var = variables_[strings::StrCat(variable->name(), ":0")];
-    if (!var.initializer_name().empty()) {
-      dont_replicate_nodes.insert(NodeName(var.initializer_name()));
-    }
-    if (!var.snapshot_name().empty()) {
-      dont_replicate_nodes.insert(NodeName(var.initializer_name()));
-    }
+  }
+
+  for (const auto& init : item.init_ops) {
+    dont_replicate_nodes.insert(NodeName(init));
   }
 
   // Don't replicate all input nodes, except the dequeue node.

--- a/tensorflow/core/grappler/optimizers/auto_parallel.h
+++ b/tensorflow/core/grappler/optimizers/auto_parallel.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_GRAPPLER_OPTIMIZERS_AUTO_PARALLEL_H_
 
 #include "tensorflow/core/grappler/optimizers/graph_optimizer.h"
+#include "tensorflow/core/framework/variable.pb.h"
 #include "tensorflow/core/lib/core/status.h"
 
 namespace tensorflow {
@@ -44,6 +45,7 @@ class AutoParallel : public GraphOptimizer {
   std::set<string> apply_gradients_nodes_;
   std::set<string> replica_nodes_;
   std::set<string> shared_nodes_;
+  std::map<string, VariableDef> variables_;
   const GrapplerItem* item_;
   int num_replicas_;
   int num_gpus_;

--- a/tensorflow/core/grappler/optimizers/auto_parallel.h
+++ b/tensorflow/core/grappler/optimizers/auto_parallel.h
@@ -45,7 +45,6 @@ class AutoParallel : public GraphOptimizer {
   std::set<string> apply_gradients_nodes_;
   std::set<string> replica_nodes_;
   std::set<string> shared_nodes_;
-  std::map<string, VariableDef> variables_;
   const GrapplerItem* item_;
   int num_replicas_;
   int num_gpus_;

--- a/tensorflow/core/grappler/optimizers/auto_parallel_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_parallel_test.cc
@@ -49,7 +49,7 @@ TEST_F(AutoParallelTest, SimpleParallel) {
   var_def.set_variable_name("var");
   var_def.set_initializer_name("assign");
   var_def.set_snapshot_name("identity");
-  item.variables.push_back(var_def);
+  item.variable_def.push_back(var_def);
   TF_CHECK_OK(s.ToGraphDef(&item.graph));
 
   AutoParallel parallel(2);

--- a/tensorflow/core/grappler/optimizers/auto_parallel_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_parallel_test.cc
@@ -33,6 +33,7 @@ TEST_F(AutoParallelTest, SimpleParallel) {
   Output constant_b = ops::Const(s.WithOpName("constant_b"), 1, {1});
   Output var = ops::Variable(s.WithOpName("var"), {1}, DT_FLOAT);
   Output assign = ops::Assign(s.WithOpName("assign"), {var}, {constant_a});
+  Output identity = ops::Identity(s.WithOpName("identity"), {var});
   Output fifo_queue = ops::FIFOQueue(s.WithOpName("fifo_queue"), {DT_FLOAT});
   auto dequeue = ops::QueueDequeueMany(s.WithOpName("dequeue"), {fifo_queue},
                                        {constant_b}, {DT_FLOAT});
@@ -44,13 +45,18 @@ TEST_F(AutoParallelTest, SimpleParallel) {
   GrapplerItem item;
   item.init_ops.push_back("assign");
   item.fetch.push_back("apply_gradient");
+  VariableDef var_def;
+  var_def.set_variable_name("var");
+  var_def.set_initializer_name("assign");
+  var_def.set_snapshot_name("identity");
+  item.variables.push_back(var_def);
   TF_CHECK_OK(s.ToGraphDef(&item.graph));
 
   AutoParallel parallel(2);
   GraphDef output;
   Status status = parallel.Optimize(nullptr, item, &output);
   TF_EXPECT_OK(status);
-  EXPECT_EQ(20, output.node_size());
+  EXPECT_EQ(21, output.node_size());
 
   const NodeDef& node_assign = output.node(0);
   EXPECT_EQ("assign", node_assign.name());
@@ -62,60 +68,64 @@ TEST_F(AutoParallelTest, SimpleParallel) {
   const NodeDef& node_fifo_queue = output.node(2);
   EXPECT_EQ("fifo_queue", node_fifo_queue.name());
 
-  const NodeDef& node_var = output.node(3);
+  const NodeDef& node_identity = output.node(3);
+  EXPECT_EQ("identity", node_identity.name());
+  EXPECT_EQ("var", node_identity.input(0));
+
+  const NodeDef& node_var = output.node(4);
   EXPECT_EQ("var", node_var.name());
 
-  const NodeDef& node_div_const0 = output.node(4);
+  const NodeDef& node_div_const0 = output.node(5);
   EXPECT_EQ("AutoParallel-Replica-0/AutoParallel-Div-Const",
             node_div_const0.name());
 
-  const NodeDef& node_div0 = output.node(5);
+  const NodeDef& node_div0 = output.node(6);
   EXPECT_EQ("AutoParallel-Replica-0/AutoParallel-Div-apply_gradient",
             node_div0.name());
-  const NodeDef& node_add0 = output.node(6);
+  const NodeDef& node_add0 = output.node(7);
   EXPECT_EQ("AutoParallel-Replica-0/add", node_add0.name());
 
-  const NodeDef& node_gradient0 = output.node(7);
+  const NodeDef& node_gradient0 = output.node(8);
   EXPECT_EQ("AutoParallel-Replica-0/apply_gradient", node_gradient0.name());
 
-  const NodeDef& node_constant_a0 = output.node(8);
+  const NodeDef& node_constant_a0 = output.node(9);
   EXPECT_EQ("AutoParallel-Replica-0/constant_a", node_constant_a0.name());
 
-  const NodeDef& node_dequeue0 = output.node(9);
+  const NodeDef& node_dequeue0 = output.node(10);
   EXPECT_EQ("AutoParallel-Replica-0/dequeue", node_dequeue0.name());
 
-  const NodeDef& node_learning_rate0 = output.node(10);
+  const NodeDef& node_learning_rate0 = output.node(11);
   EXPECT_EQ("AutoParallel-Replica-0/learning_rate", node_learning_rate0.name());
 
-  const NodeDef& node_div_const1 = output.node(11);
+  const NodeDef& node_div_const1 = output.node(12);
   EXPECT_EQ("AutoParallel-Replica-1/AutoParallel-Div-Const",
             node_div_const1.name());
 
-  const NodeDef& node_div1 = output.node(12);
+  const NodeDef& node_div1 = output.node(13);
   EXPECT_EQ("AutoParallel-Replica-1/AutoParallel-Div-apply_gradient",
             node_div1.name());
 
-  const NodeDef& node_add1 = output.node(13);
+  const NodeDef& node_add1 = output.node(14);
   EXPECT_EQ("AutoParallel-Replica-1/add", node_add1.name());
 
-  const NodeDef& node_gradient1 = output.node(14);
+  const NodeDef& node_gradient1 = output.node(15);
   EXPECT_EQ("AutoParallel-Replica-1/apply_gradient", node_gradient1.name());
 
-  const NodeDef& node_constant_a1 = output.node(15);
+  const NodeDef& node_constant_a1 = output.node(16);
   EXPECT_EQ("AutoParallel-Replica-1/constant_a", node_constant_a1.name());
 
-  const NodeDef& node_dequeue1 = output.node(16);
+  const NodeDef& node_dequeue1 = output.node(17);
   EXPECT_EQ("AutoParallel-Replica-1/dequeue", node_dequeue1.name());
 
-  const NodeDef& node_learning_rate1 = output.node(17);
+  const NodeDef& node_learning_rate1 = output.node(18);
   EXPECT_EQ("AutoParallel-Replica-1/learning_rate", node_learning_rate1.name());
 
-  const NodeDef& node_fetch = output.node(18);
+  const NodeDef& node_fetch = output.node(19);
   EXPECT_EQ("AutoParallel-Control-Fetch", node_fetch.name());
   EXPECT_EQ("^AutoParallel-Replica-0/apply_gradient", node_fetch.input(0));
   EXPECT_EQ("^AutoParallel-Replica-1/apply_gradient", node_fetch.input(1));
 
-  const NodeDef& node_gradient = output.node(19);
+  const NodeDef& node_gradient = output.node(20);
   EXPECT_EQ("apply_gradient", node_gradient.name());
   EXPECT_EQ("^AutoParallel-Control-Fetch", node_gradient.input(0));
 }

--- a/tensorflow/core/grappler/optimizers/auto_parallel_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_parallel_test.cc
@@ -45,11 +45,7 @@ TEST_F(AutoParallelTest, SimpleParallel) {
   GrapplerItem item;
   item.init_ops.push_back("assign");
   item.fetch.push_back("apply_gradient");
-  VariableDef var_def;
-  var_def.set_variable_name("var");
-  var_def.set_initializer_name("assign");
-  var_def.set_snapshot_name("identity");
-  item.variable_def.push_back(var_def);
+  item.init_ops.push_back("assign");
   TF_CHECK_OK(s.ToGraphDef(&item.graph));
 
   AutoParallel parallel(2);


### PR DESCRIPTION
This PR fixes the bug that AutoParallel sets variables as don't_replicate_nodes, but not for variable initializers and snapshot nodes. This can break variable collections in meta graph because variable initializers and snapshot nodes could be replicated with different names.

This issue is already discussed in #9906.