### PR TITLE
Clarify tf.matmul documentation

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1686,8 +1686,9 @@ def matmul(a,
            name=None):
   """Multiplies matrix `a` by matrix `b`, producing `a` * `b`.
 
-  The inputs must be matrices (or tensors of rank > 2, representing batches of
-  matrices), with matching inner dimensions, possibly after transposition.
+  The inputs must, following any transpositions, be tensors of rank ≥ 2 
+  where the inner 2 dimensions specify valid matrix multiplication arguments, 
+  and any further outer dimensions match.
 
   Both matrices must be of the same type. The supported types are:
   `float16`, `float32`, `float64`, `int32`, `complex64`, `complex128`.

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1686,7 +1686,7 @@ def matmul(a,
            name=None):
   """Multiplies matrix `a` by matrix `b`, producing `a` * `b`.
 
-  The inputs must, following any transpositions, be tensors of rank ≥ 2 
+  The inputs must, following any transpositions, be tensors of rank >= 2 
   where the inner 2 dimensions specify valid matrix multiplication arguments, 
   and any further outer dimensions match.
 


### PR DESCRIPTION
Maybe I'm confused about what "inner" and "outer" tensor dimensions are, but the documentation for `tf.matmul` puzzles me:

> The inputs must be matrices (or tensors of rank > 2, representing
> batches of matrices), with matching inner dimensions, possibly after
> transposition.

Isn't it the case that R-rank arguments need to have matching (or no) R-2 outer dimensions, and that (as in normal matrix multiplication) the Rth, inner dimension of the first argument must match the R-1st dimension of the second. That is, in

    A = tf.constant(..., shape=[a, ..., z, p, x])
    B = tf.constant(..., shape=[a', ..., z', x', q]) 
    C = tf.matmul(A, B)

The outer dimensions `a, ..., z` must be identical to `a', ..., z'` (or not exist), and `x` and `x'` must match (while `p` and `q` can be anything).

Or put another way, shouldn't the docs say: 

> The inputs must, following any transpositions, be tensors of rank ≥ 2 where the inner 2 dimensions specify valid matrix multiplication arguments, and any further outer dimensions match.