### PR TITLE
make gcc-5 on Ubuntu 16.04 happy

### DIFF
--- a/tensorflow/core/kernels/mfcc_test.cc
+++ b/tensorflow/core/kernels/mfcc_test.cc
@@ -63,7 +63,7 @@ TEST(MfccTest, AvoidsNansWithZeroInput) {
   int expected_size = 13;
   ASSERT_EQ(expected_size, output.size());
   for (const double value : output) {
-    EXPECT_FALSE(isnan(value));
+    EXPECT_FALSE(std::isnan(value));
   }
 }
 

--- a/tensorflow/core/util/ctc/ctc_beam_search_test.cc
+++ b/tensorflow/core/util/ctc/ctc_beam_search_test.cc
@@ -215,7 +215,7 @@ TEST(CtcBeamSearch, AllBeamElementsHaveFiniteScores) {
   // Make sure all scores are finite.
   for (int path = 0; path < top_paths; ++path) {
     LOG(INFO) << "path " << path;
-    EXPECT_FALSE(isinf(score[0][path]));
+    EXPECT_FALSE(std::isinf(score[0][path]));
   }
 }
 


### PR DESCRIPTION
gcc-5 complains of ambiguity and refuses to go when doing something
like 'bazel build -c opt tensorflow/...'

Error messages:
> ...
> ERROR: /hack/freedom/tensorflow/freedom/tensorflow/tensorflow/core/kernels/BUILD:3854:1: C++ compilation of rule '//tensorflow/core/kernels:mfcc_test' failed: gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -B/usr/bin -B/usr/bin -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG ... (remaining 136 argument(s) skipped): com.google.devtools.build.lib.shell.BadExitStatusException: Process exited with status 1.
> In file included from external/gmock_archive/googletest/include/gtest/gtest.h:58:0,
>                  from ./tensorflow/core/platform/test.h:35,
>                  from tensorflow/core/kernels/mfcc_test.cc:18:
> tensorflow/core/kernels/mfcc_test.cc: In member function 'virtual void tensorflow::MfccTest_AvoidsNansWithZeroInput_Test::TestBody()':
> tensorflow/core/kernels/mfcc_test.cc:66:29: error: 'isnan' was not declared in this scope
>      EXPECT_FALSE(isnan(value));
>                              ^
> tensorflow/core/kernels/mfcc_test.cc:66:29: note: suggested alternatives:
> In file included from /usr/include/c++/5/complex:44:0,
>                  from ./tensorflow/core/framework/numeric_types.h:19,
>                  from ./tensorflow/core/framework/allocator.h:23,
>                  from ./tensorflow/core/framework/op_kernel.h:23,
>                  from ./tensorflow/core/kernels/mfcc_dct.h:23,
>                  from ./tensorflow/core/kernels/mfcc.h:23,
>                  from tensorflow/core/kernels/mfcc_test.cc:16:
> /usr/include/c++/5/cmath:641:5: note:   'std::isnan'
>      isnan(_Tp __x)
>      ^
> In file included from external/eigen_archive/unsupported/Eigen/CXX11/../../../Eigen/Core:536:0,
>                  from external/eigen_archive/unsupported/Eigen/CXX11/Tensor:14,
>                  from ./third_party/eigen3/unsupported/Eigen/CXX11/Tensor:1,
>                  from ./tensorflow/core/framework/numeric_types.h:21,
>                  from ./tensorflow/core/framework/allocator.h:23,
>                  from ./tensorflow/core/framework/op_kernel.h:23,
>                  from ./tensorflow/core/kernels/mfcc_dct.h:23,
>                  from ./tensorflow/core/kernels/mfcc.h:23,
>                  from tensorflow/core/kernels/mfcc_test.cc:16:
> external/eigen_archive/unsupported/Eigen/CXX11/../../../Eigen/src/Core/GlobalFunctions.h:88:3: note:   'Eigen::isnan'
>    EIGEN_ARRAY_DECLARE_GLOBAL_UNARY(isnan,scalar_isnan_op,not-a-number test,\sa Eigen::isinf DOXCOMMA Eigen::isfinite DOXCOMMA ArrayBase::isnan)
>    ^
> In file included from external/eigen_archive/unsupported/Eigen/CXX11/../../../Eigen/Core:371:0,
>                  from external/eigen_archive/unsupported/Eigen/CXX11/Tensor:14,
>                  from ./third_party/eigen3/unsupported/Eigen/CXX11/Tensor:1,
>                  from ./tensorflow/core/framework/numeric_types.h:21,
>                  from ./tensorflow/core/framework/allocator.h:23,
>                  from ./tensorflow/core/framework/op_kernel.h:23,
>                  from ./tensorflow/core/kernels/mfcc_dct.h:23,
>                  from ./tensorflow/core/kernels/mfcc.h:23,
>                  from tensorflow/core/kernels/mfcc_test.cc:16:
> external/eigen_archive/unsupported/Eigen/CXX11/../../../Eigen/src/Core/MathFunctions.h:1108:46: note:   'Eigen::numext::isnan'
>  template<typename T> EIGEN_DEVICE_FUNC bool (isnan)   (const T &x) { return internal::isnan_impl(x); }
>                                               ^
> In file included from external/eigen_archive/unsupported/Eigen/CXX11/../../../Eigen/Core:411:0,
>                  from external/eigen_archive/unsupported/Eigen/CXX11/Tensor:14,
>                  from ./third_party/eigen3/unsupported/Eigen/CXX11/Tensor:1,
>                  from ./tensorflow/core/framework/numeric_types.h:21,
>                  from ./tensorflow/core/framework/allocator.h:23,
>                  from ./tensorflow/core/framework/op_kernel.h:23,
>                  from ./tensorflow/core/kernels/mfcc_dct.h:23,
>                  from ./tensorflow/core/kernels/mfcc.h:23,
>                  from tensorflow/core/kernels/mfcc_test.cc:16:
> external/eigen_archive/unsupported/Eigen/CXX11/../../../Eigen/src/Core/arch/CUDA/Half.h:372:45: note:   'Eigen::half_impl::isnan'
>  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC bool (isnan)(const half& a) {
>                                              ^
> In file included from /usr/include/c++/5/complex:44:0,
>                  from ./tensorflow/core/framework/numeric_types.h:19,
>                  from ./tensorflow/core/framework/allocator.h:23,
>                  from ./tensorflow/core/framework/op_kernel.h:23,
>                  from ./tensorflow/core/kernels/mfcc_dct.h:23,
>                  from ./tensorflow/core/kernels/mfcc.h:23,
>                  from tensorflow/core/kernels/mfcc_test.cc:16:
> /usr/include/c++/5/cmath:641:5: note:   'std::isnan'
>      isnan(_Tp __x)
> 