### PR TITLE
Fix value error generated on is_scalar check

### DIFF
--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -300,7 +300,8 @@ class _VariableStore(object):
                      initializer=None, regularizer=None, reuse=None,
                      trainable=True, collections=None, caching_device=None,
                      partitioner=None, validate_shape=True, use_resource=None):
-      is_scalar = shape is not None and not isinstance(shape, collections_lib.Sequence)
+      is_scalar = (shape is not None and isinstance(shape, collections_lib.Sequence)
+                   and len(shape) == 0)
       # Partitioned variable case
       if partitioner is not None and not is_scalar:
         if not callable(partitioner):

--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -300,7 +300,7 @@ class _VariableStore(object):
                      initializer=None, regularizer=None, reuse=None,
                      trainable=True, collections=None, caching_device=None,
                      partitioner=None, validate_shape=True, use_resource=None):
-      is_scalar = shape is not None and not isinstance(shape, tuple)
+      is_scalar = shape is not None and not isinstance(shape, collections_lib.Sequence)
       # Partitioned variable case
       if partitioner is not None and not is_scalar:
         if not callable(partitioner):

--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -300,7 +300,7 @@ class _VariableStore(object):
                      initializer=None, regularizer=None, reuse=None,
                      trainable=True, collections=None, caching_device=None,
                      partitioner=None, validate_shape=True, use_resource=None):
-      is_scalar = shape is not None and not shape
+      is_scalar = shape is not None and not isinstance(shape, tuple)
       # Partitioned variable case
       if partitioner is not None and not is_scalar:
         if not callable(partitioner):


### PR DESCRIPTION
`is_scalar = shape is not None and not shape` raises a value error when shape is a scalar, "ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()"