### PR TITLE
add metric op

### DIFF
--- a/tensorflow/contrib/slim/python/slim/learning.py
+++ b/tensorflow/contrib/slim/python/slim/learning.py
@@ -250,6 +250,8 @@ from __future__ import print_function
 import os
 import sys
 import time
+import tensorflow as tf
+import math
 
 from tensorflow.contrib.framework.python.ops import variables
 from tensorflow.contrib.training.python.training import training
@@ -279,94 +281,94 @@ __all__ = [
 
 
 def clip_gradient_norms(gradients_to_variables, max_norm):
-  """Clips the gradients by the given value.
+    """Clips the gradients by the given value.
 
-  Args:
-    gradients_to_variables: A list of gradient to variable pairs (tuples).
-    max_norm: the maximum norm value.
+    Args:
+      gradients_to_variables: A list of gradient to variable pairs (tuples).
+      max_norm: the maximum norm value.
 
-  Returns:
-    A list of clipped gradient to variable pairs.
-  """
-  clipped_grads_and_vars = []
-  for grad, var in gradients_to_variables:
-    if grad is not None:
-      if isinstance(grad, ops.IndexedSlices):
-        tmp = clip_ops.clip_by_norm(grad.values, max_norm)
-        grad = ops.IndexedSlices(tmp, grad.indices, grad.dense_shape)
-      else:
-        grad = clip_ops.clip_by_norm(grad, max_norm)
-    clipped_grads_and_vars.append((grad, var))
-  return clipped_grads_and_vars
+    Returns:
+      A list of clipped gradient to variable pairs.
+    """
+    clipped_grads_and_vars = []
+    for grad, var in gradients_to_variables:
+        if grad is not None:
+            if isinstance(grad, ops.IndexedSlices):
+                tmp = clip_ops.clip_by_norm(grad.values, max_norm)
+                grad = ops.IndexedSlices(tmp, grad.indices, grad.dense_shape)
+            else:
+                grad = clip_ops.clip_by_norm(grad, max_norm)
+        clipped_grads_and_vars.append((grad, var))
+    return clipped_grads_and_vars
 
 
 def multiply_gradients(grads_and_vars, gradient_multipliers):
-  """Multiply specified gradients.
+    """Multiply specified gradients.
 
-  Args:
-    grads_and_vars: A list of gradient to variable pairs (tuples).
-    gradient_multipliers: A map from either `Variables` or `Variable` op names
-      to the coefficient by which the associated gradient should be scaled.
+    Args:
+      grads_and_vars: A list of gradient to variable pairs (tuples).
+      gradient_multipliers: A map from either `Variables` or `Variable` op names
+        to the coefficient by which the associated gradient should be scaled.
 
-  Returns:
-    The updated list of gradient to variable pairs.
+    Returns:
+      The updated list of gradient to variable pairs.
 
-  Raises:
-    ValueError: If `grads_and_vars` is not a list or if `gradient_multipliers`
-    is empty or None or if `gradient_multipliers` is not a dictionary.
-  """
-  if not isinstance(grads_and_vars, list):
-    raise ValueError('`grads_and_vars` must be a list.')
-  if not gradient_multipliers:
-    raise ValueError('`gradient_multipliers` is empty.')
-  if not isinstance(gradient_multipliers, dict):
-    raise ValueError('`gradient_multipliers` must be a dict.')
+    Raises:
+      ValueError: If `grads_and_vars` is not a list or if `gradient_multipliers`
+      is empty or None or if `gradient_multipliers` is not a dictionary.
+    """
+    if not isinstance(grads_and_vars, list):
+        raise ValueError('`grads_and_vars` must be a list.')
+    if not gradient_multipliers:
+        raise ValueError('`gradient_multipliers` is empty.')
+    if not isinstance(gradient_multipliers, dict):
+        raise ValueError('`gradient_multipliers` must be a dict.')
 
-  multiplied_grads_and_vars = []
-  for grad, var in grads_and_vars:
-    if var in gradient_multipliers or var.op.name in gradient_multipliers:
-      key = var if var in gradient_multipliers else var.op.name
-      if grad is None:
-        raise ValueError('Requested multiple of `None` gradient.')
+    multiplied_grads_and_vars = []
+    for grad, var in grads_and_vars:
+        if var in gradient_multipliers or var.op.name in gradient_multipliers:
+            key = var if var in gradient_multipliers else var.op.name
+            if grad is None:
+                raise ValueError('Requested multiple of `None` gradient.')
 
-      multiplier = gradient_multipliers[key]
-      if not isinstance(multiplier, ops.Tensor):
-        multiplier = constant_op.constant(multiplier, dtype=grad.dtype)
+            multiplier = gradient_multipliers[key]
+            if not isinstance(multiplier, ops.Tensor):
+                multiplier = constant_op.constant(multiplier, dtype=grad.dtype)
 
-      if isinstance(grad, ops.IndexedSlices):
-        tmp = grad.values * multiplier
-        grad = ops.IndexedSlices(tmp, grad.indices, grad.dense_shape)
-      else:
-        grad *= multiplier
-    multiplied_grads_and_vars.append((grad, var))
-  return multiplied_grads_and_vars
+            if isinstance(grad, ops.IndexedSlices):
+                tmp = grad.values * multiplier
+                grad = ops.IndexedSlices(tmp, grad.indices, grad.dense_shape)
+            else:
+                grad *= multiplier
+        multiplied_grads_and_vars.append((grad, var))
+    return multiplied_grads_and_vars
 
 
 def add_gradients_summaries(grads_and_vars):
-  """Add summaries to gradients.
+    """Add summaries to gradients.
 
-  Args:
-    grads_and_vars: A list of gradient to variable pairs (tuples).
+    Args:
+      grads_and_vars: A list of gradient to variable pairs (tuples).
 
-  Returns:
-    The list of created summaries.
-  """
-  summaries = []
-  for grad, var in grads_and_vars:
-    if grad is not None:
-      if isinstance(grad, ops.IndexedSlices):
-        grad_values = grad.values
-      else:
-        grad_values = grad
-      summaries.append(
-          summary.histogram(var.op.name + '/gradient', grad_values))
-      summaries.append(
-          summary.scalar(var.op.name + '/gradient_norm',
-                         clip_ops.global_norm([grad_values])))
-    else:
-      logging.info('Var %s has no gradient', var.op.name)
+    Returns:
+      The list of created summaries.
+    """
+    summaries = []
+    for grad, var in grads_and_vars:
+        if grad is not None:
+            if isinstance(grad, ops.IndexedSlices):
+                grad_values = grad.values
+            else:
+                grad_values = grad
+            summaries.append(
+                summary.histogram(var.op.name + '/gradient', grad_values))
+            summaries.append(
+                summary.scalar(var.op.name + '/gradient_norm',
+                               clip_ops.global_norm([grad_values])))
+        else:
+            logging.info('Var %s has no gradient', var.op.name)
 
-  return summaries
+    return summaries
 
 
 _USE_GLOBAL_STEP = 0
@@ -384,146 +386,167 @@ def create_train_op(total_loss,
                     colocate_gradients_with_ops=False,
                     gradient_multipliers=None,
                     check_numerics=True):
-  """Creates an `Operation` that evaluates the gradients and returns the loss.
+    """Creates an `Operation` that evaluates the gradients and returns the loss.
 
-  Args:
-    total_loss: A `Tensor` representing the total loss.
-    optimizer: A tf.Optimizer to use for computing the gradients.
-    global_step: A `Tensor` representing the global step variable. If left as
-      `_USE_GLOBAL_STEP`, then slim.variables.global_step() is used.
-    update_ops: An optional list of updates to execute. If `update_ops` is
-      `None`, then the update ops are set to the contents of the
-      `tf.GraphKeys.UPDATE_OPS` collection. If `update_ops` is not `None`, but
-      it doesn't contain all of the update ops in `tf.GraphKeys.UPDATE_OPS`,
-      a warning will be displayed.
-    variables_to_train: an optional list of variables to train. If None, it will
-      default to all tf.trainable_variables().
-    clip_gradient_norm: If greater than 0 then the gradients would be clipped
-      by it.
-    summarize_gradients: Whether or not add summaries for each gradient.
-    gate_gradients: How to gate the computation of gradients. See tf.Optimizer.
-    aggregation_method: Specifies the method used to combine gradient terms.
-      Valid values are defined in the class `AggregationMethod`.
-    colocate_gradients_with_ops: Whether or not to try colocating the gradients
-      with the ops that generated them.
-    gradient_multipliers: A dictionary of either `Variables` or `Variable` op
-      names to the coefficient by which the associated gradient should be
-      scaled.
-    check_numerics: Whether or not we apply check_numerics.
+    Args:
+      total_loss: A `Tensor` representing the total loss.
+      optimizer: A tf.Optimizer to use for computing the gradients.
+      global_step: A `Tensor` representing the global step variable. If left as
+        `_USE_GLOBAL_STEP`, then slim.variables.global_step() is used.
+      update_ops: An optional list of updates to execute. If `update_ops` is
+        `None`, then the update ops are set to the contents of the
+        `tf.GraphKeys.UPDATE_OPS` collection. If `update_ops` is not `None`, but
+        it doesn't contain all of the update ops in `tf.GraphKeys.UPDATE_OPS`,
+        a warning will be displayed.
+      variables_to_train: an optional list of variables to train. If None, it will
+        default to all tf.trainable_variables().
+      clip_gradient_norm: If greater than 0 then the gradients would be clipped
+        by it.
+      summarize_gradients: Whether or not add summaries for each gradient.
+      gate_gradients: How to gate the computation of gradients. See tf.Optimizer.
+      aggregation_method: Specifies the method used to combine gradient terms.
+        Valid values are defined in the class `AggregationMethod`.
+      colocate_gradients_with_ops: Whether or not to try colocating the gradients
+        with the ops that generated them.
+      gradient_multipliers: A dictionary of either `Variables` or `Variable` op
+        names to the coefficient by which the associated gradient should be
+        scaled.
+      check_numerics: Whether or not we apply check_numerics.
 
-  Returns:
-    A `Tensor` that when evaluated, computes the gradients and returns the total
-      loss value.
-  """
-  def transform_grads_fn(grads):
-    if gradient_multipliers:
-      with ops.name_scope('multiply_grads'):
-        grads = multiply_gradients(grads, gradient_multipliers)
+    Returns:
+      A `Tensor` that when evaluated, computes the gradients and returns the total
+        loss value.
+    """
 
-    # Clip gradients.
-    if clip_gradient_norm > 0:
-      with ops.name_scope('clip_grads'):
-        grads = clip_gradient_norms(grads, clip_gradient_norm)
-    return grads
+    def transform_grads_fn(grads):
+        if gradient_multipliers:
+            with ops.name_scope('multiply_grads'):
+                grads = multiply_gradients(grads, gradient_multipliers)
 
-  return training.create_train_op(
-      total_loss=total_loss,
-      optimizer=optimizer,
-      global_step=global_step,
-      update_ops=update_ops,
-      variables_to_train=variables_to_train,
-      transform_grads_fn=transform_grads_fn,
-      summarize_gradients=summarize_gradients,
-      gate_gradients=gate_gradients,
-      aggregation_method=aggregation_method,
-      colocate_gradients_with_ops=colocate_gradients_with_ops,
-      check_numerics=check_numerics)
+        # Clip gradients.
+        if clip_gradient_norm > 0:
+            with ops.name_scope('clip_grads'):
+                grads = clip_gradient_norms(grads, clip_gradient_norm)
+        return grads
+
+    return training.create_train_op(
+        total_loss=total_loss,
+        optimizer=optimizer,
+        global_step=global_step,
+        update_ops=update_ops,
+        variables_to_train=variables_to_train,
+        transform_grads_fn=transform_grads_fn,
+        summarize_gradients=summarize_gradients,
+        gate_gradients=gate_gradients,
+        aggregation_method=aggregation_method,
+        colocate_gradients_with_ops=colocate_gradients_with_ops,
+        check_numerics=check_numerics)
 
 
 def _wait_for_step(sess, global_step, step):
-  """Wait till the global step has reached at least 'step'.
+    """Wait till the global step has reached at least 'step'.
 
-  Args:
-    sess: A session.
-    global_step: A Tensor.
-    step: Int.  The global step to reach.
-  """
-  while True:
-    if training_util.global_step(sess, global_step) >= step:
-      break
-    time.sleep(1.0)
+    Args:
+      sess: A session.
+      global_step: A Tensor.
+      step: Int.  The global step to reach.
+    """
+    while True:
+        if training_util.global_step(sess, global_step) >= step:
+            break
+        time.sleep(1.0)
 
 
-def train_step(sess, train_op, global_step, train_step_kwargs):
-  """Function that takes a gradient step and specifies whether to stop.
+def train_step(sess, train_op, global_step, train_step_kwargs, metric_op=None, reset_op=None):
+    """Function that takes a gradient step and specifies whether to stop.
 
-  Args:
-    sess: The current session.
-    train_op: An `Operation` that evaluates the gradients and returns the
-      total loss.
-    global_step: A `Tensor` representing the global training step.
-    train_step_kwargs: A dictionary of keyword arguments.
+    Args:
+      sess: The current session.
+      train_op: An `Operation` that evaluates the gradients and returns the
+        total loss.
+      global_step: A `Tensor` representing the global training step.
+      train_step_kwargs: A dictionary of keyword arguments.
 
-  Returns:
-    The total loss and a boolean indicating whether or not to stop training.
+    Returns:
+      The total loss and a boolean indicating whether or not to stop training.
 
-  Raises:
-    ValueError: if 'should_trace' is in `train_step_kwargs` but `logdir` is not.
-  """
-  start_time = time.time()
+    Raises:
+      ValueError: if 'should_trace' is in `train_step_kwargs` but `logdir` is not.
+    """
+    start_time = time.time()
 
-  trace_run_options = None
-  run_metadata = None
-  if 'should_trace' in train_step_kwargs:
-    if 'logdir' not in train_step_kwargs:
-      raise ValueError('logdir must be present in train_step_kwargs when '
-                       'should_trace is present')
-    if sess.run(train_step_kwargs['should_trace']):
-      trace_run_options = config_pb2.RunOptions(
-          trace_level=config_pb2.RunOptions.FULL_TRACE)
-      run_metadata = config_pb2.RunMetadata()
+    trace_run_options = None
+    run_metadata = None
+    if 'should_trace' in train_step_kwargs:
+        if 'logdir' not in train_step_kwargs:
+            raise ValueError('logdir must be present in train_step_kwargs when '
+                             'should_trace is present')
+        if sess.run(train_step_kwargs['should_trace']):
+            trace_run_options = config_pb2.RunOptions(
+                trace_level=config_pb2.RunOptions.FULL_TRACE)
+            run_metadata = config_pb2.RunMetadata()
 
-  total_loss, np_global_step = sess.run([train_op, global_step],
-                                        options=trace_run_options,
-                                        run_metadata=run_metadata)
-  time_elapsed = time.time() - start_time
+    if metric_op is not None:
+        total_loss, accuracy, np_global_step = sess.run([train_op, metric_op, global_step],
+                                                        options=trace_run_options,
+                                                        run_metadata=run_metadata)
+        # Get the number of epoch
+        step_per_epoch = train_step_kwargs['num_batches_per_epoch']
+        epoch_num = int(math.floor(np_global_step / float(step_per_epoch))) + 1
 
-  if run_metadata is not None:
-    tl = timeline.Timeline(run_metadata.step_stats)
-    trace = tl.generate_chrome_trace_format()
-    trace_filename = os.path.join(train_step_kwargs['logdir'],
-                                  'tf_trace-%d.json' % np_global_step)
-    logging.info('Writing trace to %s', trace_filename)
-    file_io.write_string_to_file(trace_filename, trace)
-    if 'summary_writer' in train_step_kwargs:
-      train_step_kwargs['summary_writer'].add_run_metadata(run_metadata,
-                                                           'run_metadata-%d' %
-                                                           np_global_step)
+        # Check if the training on the new epoch is starting.
+        if 'num_batches_per_epoch' in train_step_kwargs:
+            if np_global_step % train_step_kwargs['num_batches_per_epoch'] == 0:
+                print('goint to next epoch!')
+                sess.run(reset_op)
 
-  if 'should_log' in train_step_kwargs:
-    if sess.run(train_step_kwargs['should_log']):
-      logging.info('global step %d: loss = %.4f (%.3f sec/step)',
-                   np_global_step, total_loss, time_elapsed)
+    else:
+        total_loss, np_global_step = sess.run([train_op, global_step],
+                                              options=trace_run_options,
+                                              run_metadata=run_metadata)
 
-  # TODO(nsilberman): figure out why we can't put this into sess.run. The
-  # issue right now is that the stop check depends on the global step. The
-  # increment of global step often happens via the train op, which used
-  # created using optimizer.apply_gradients.
-  #
-  # Since running `train_op` causes the global step to be incremented, one
-  # would expected that using a control dependency would allow the
-  # should_stop check to be run in the same session.run call:
-  #
-  #   with ops.control_dependencies([train_op]):
-  #     should_stop_op = ...
-  #
-  # However, this actually seems not to work on certain platforms.
-  if 'should_stop' in train_step_kwargs:
-    should_stop = sess.run(train_step_kwargs['should_stop'])
-  else:
-    should_stop = False
+    time_elapsed = time.time() - start_time
 
-  return total_loss, should_stop
+    if run_metadata is not None:
+        tl = timeline.Timeline(run_metadata.step_stats)
+        trace = tl.generate_chrome_trace_format()
+        trace_filename = os.path.join(train_step_kwargs['logdir'],
+                                      'tf_trace-%d.json' % np_global_step)
+        logging.info('Writing trace to %s', trace_filename)
+        file_io.write_string_to_file(trace_filename, trace)
+        if 'summary_writer' in train_step_kwargs:
+            train_step_kwargs['summary_writer'].add_run_metadata(run_metadata,
+                                                                 'run_metadata-%d' %
+                                                                 np_global_step)
+    if metric_op is not None:
+        if 'should_log' in train_step_kwargs:
+            if sess.run(train_step_kwargs['should_log']):
+                logging.info('epoch %d, global step %d: loss = %.4f,accuracy = %.4f (%.3f sec/step)', epoch_num,
+                             np_global_step, total_loss, accuracy, time_elapsed)
+    else:
+        if 'should_log' in train_step_kwargs:
+            if sess.run(train_step_kwargs['should_log']):
+                logging.info('global step %d: loss = %.4f (%.3f sec/step)', np_global_step, total_loss, time_elapsed)
+
+    # TODO(nsilberman): figure out why we can't put this into sess.run. The
+    # issue right now is that the stop check depends on the global step. The
+    # increment of global step often happens via the train op, which used
+    # created using optimizer.apply_gradients.
+    #
+    # Since running `train_op` causes the global step to be incremented, one
+    # would expected that using a control dependency would allow the
+    # should_stop check to be run in the same session.run call:
+    #
+    #   with ops.control_dependencies([train_op]):
+    #     should_stop_op = ...
+    #
+    # However, this actually seems not to work on certain platforms.
+    if 'should_stop' in train_step_kwargs:
+        should_stop = sess.run(train_step_kwargs['should_stop'])
+    else:
+        should_stop = False
+
+    return total_loss, should_stop
 
 
 _USE_DEFAULT = 0
@@ -531,6 +554,8 @@ _USE_DEFAULT = 0
 
 def train(train_op,
           logdir,
+          metric_op=None,
+          metric_collection_name=None,
           train_step_fn=train_step,
           train_step_kwargs=_USE_DEFAULT,
           log_every_n_steps=1,
@@ -538,7 +563,10 @@ def train(train_op,
           master='',
           is_chief=True,
           global_step=None,
+          number_of_samples=None,
           number_of_steps=None,
+          number_of_epochs=None,
+          batch_size=None,
           init_op=_USE_DEFAULT,
           init_feed_dict=None,
           local_init_op=_USE_DEFAULT,
@@ -553,217 +581,254 @@ def train(train_op,
           sync_optimizer=None,
           session_config=None,
           trace_every_n_steps=None):
-  """Runs a training loop using a TensorFlow supervisor.
+    """Runs a training loop using a TensorFlow supervisor.
 
-  When the sync_optimizer is supplied, gradient updates are applied
-  synchronously. Otherwise, gradient updates are applied asynchronous.
+    When the sync_optimizer is supplied, gradient updates are applied
+    synchronously. Otherwise, gradient updates are applied asynchronous.
 
-  Args:
-    train_op: A `Tensor` that, when executed, will apply the gradients and
-      return the loss value.
-    logdir: The directory where training logs are written to. If None, model
-      checkpoints and summaries will not be written.
-    train_step_fn: The function to call in order to execute a single gradient
-      step. The function must have take exactly four arguments: the current
-      session, the `train_op` `Tensor`, a global step `Tensor` and a dictionary.
-    train_step_kwargs: A dictionary which is passed to the `train_step_fn`. By
-      default, two `Boolean`, scalar ops called "should_stop" and "should_log"
-      are provided.
-    log_every_n_steps: The frequency, in terms of global steps, that the loss
-      and global step and logged.
-    graph: The graph to pass to the supervisor. If no graph is supplied the
-      default graph is used.
-    master: The address of the tensorflow master.
-    is_chief: Specifies whether or not the training is being run by the primary
-      replica during replica training.
-    global_step: The `Tensor` representing the global step. If left as `None`,
-      then slim.variables.get_or_create_global_step() is used.
-    number_of_steps: The max number of gradient steps to take during training,
-      as measured by 'global_step': training will stop if global_step is
-      greater than 'number_of_steps'. If the value is left as None, training
-      proceeds indefinitely.
-    init_op: The initialization operation. If left to its default value, then
-      the session is initialized by calling `tf.global_variables_initializer()`.
-    init_feed_dict: A feed dictionary to use when executing the `init_op`.
-    local_init_op: The local initialization operation. If left to its default
-      value, then the session is initialized by calling
-      `tf.local_variables_initializer()` and `tf.tables_initializer()`.
-    init_fn: An optional callable to be executed after `init_op` is called. The
-      callable must accept one argument, the session being initialized.
-    ready_op: Operation to check if the model is ready to use. If left to its
-      default value, then the session checks for readiness by calling
-      `tf.report_uninitialized_variables()`.
-    summary_op: The summary operation.
-    save_summaries_secs: How often, in seconds, to save summaries.
-    summary_writer: `SummaryWriter` to use.  Can be `None`
-      to indicate that no summaries should be written. If unset, we
-      create a SummaryWriter.
-    startup_delay_steps: The number of steps to wait for before beginning. Note
-      that this must be 0 if a sync_optimizer is supplied.
-    saver: Saver to save checkpoints. If None, a default one will be created
-      and used.
-    save_interval_secs: How often, in seconds, to save the model to `logdir`.
-    sync_optimizer: an instance of tf.train.SyncReplicasOptimizer. If the
-      argument is supplied, gradient updates will be synchronous. If left as
-      `None`, gradient updates will be asynchronous.
-    session_config: An instance of `tf.ConfigProto` that will be used to
-      configure the `Session`. If left as `None`, the default will be used.
-    trace_every_n_steps: produce and save a `Timeline` in Chrome trace format
-      and add it to the summaries every `trace_every_n_steps`. If None, no trace
-      information will be produced or saved.
+    Args:
+      train_op: A `Tensor` that, when executed, will apply the gradients and
+        return the loss value.
 
-  Returns:
-    the value of the loss function after training.
+      metric_op: A `Tensor` that, when executed, will update the streaming_metrics ops.
+      metric_collection_name: The name associated with the metric_op.
+      logdir: The directory where training logs are written to. If None, model
+        checkpoints and summaries will not be written.
+      train_step_fn: The function to call in order to execute a single gradient
+        step. The function must have take exactly four arguments: the current
+        session, the `train_op` `Tensor`, a global step `Tensor` and a dictionary.
+      train_step_kwargs: A dictionary which is passed to the `train_step_fn`. By
+        default, two `Boolean`, scalar ops called "should_stop" and "should_log"
+        are provided.
+      log_every_n_steps: The frequency, in terms of global steps, that the loss
+        and global step and logged.
+      graph: The graph to pass to the supervisor. If no graph is supplied the
+        default graph is used.
+      master: The address of the tensorflow master.
+      is_chief: Specifies whether or not the training is being run by the primary
+        replica during replica training.
+      global_step: The `Tensor` representing the global step. If left as `None`,
+        then slim.variables.get_or_create_global_step() is used.
+      number_of_steps: The max number of gradient steps to take during training,
+        as measured by 'global_step': training will stop if global_step is
+        greater than 'number_of_steps'. If the value is left as None, training
+        proceeds indefinitely.
+      number_of_epochs: The total number of epochs per training.
+      batch_size: The number of samples in each batch.
+      init_op: The initialization operation. If left to its default value, then
+        the session is initialized by calling `tf.global_variables_initializer()`.
+      init_feed_dict: A feed dictionary to use when executing the `init_op`.
+      local_init_op: The local initialization operation. If left to its default
+        value, then the session is initialized by calling
+        `tf.local_variables_initializer()` and `tf.tables_initializer()`.
+      init_fn: An optional callable to be executed after `init_op` is called. The
+        callable must accept one argument, the session being initialized.
+      ready_op: Operation to check if the model is ready to use. If left to its
+        default value, then the session checks for readiness by calling
+        `tf.report_uninitialized_variables()`.
+      summary_op: The summary operation.
+      save_summaries_secs: How often, in seconds, to save summaries.
+      summary_writer: `SummaryWriter` to use.  Can be `None`
+        to indicate that no summaries should be written. If unset, we
+        create a SummaryWriter.
+      startup_delay_steps: The number of steps to wait for before beginning. Note
+        that this must be 0 if a sync_optimizer is supplied.
+      saver: Saver to save checkpoints. If None, a default one will be created
+        and used.
+      save_interval_secs: How often, in seconds, to save the model to `logdir`.
+      sync_optimizer: an instance of tf.train.SyncReplicasOptimizer. If the
+        argument is supplied, gradient updates will be synchronous. If left as
+        `None`, gradient updates will be asynchronous.
+      session_config: An instance of `tf.ConfigProto` that will be used to
+        configure the `Session`. If left as `None`, the default will be used.
+      trace_every_n_steps: produce and save a `Timeline` in Chrome trace format
+        and add it to the summaries every `trace_every_n_steps`. If None, no trace
+        information will be produced or saved.
 
-  Raises:
-    ValueError: if `train_op` is empty or if `startup_delay_steps` is
-      non-zero when `sync_optimizer` is supplied, if `number_of_steps` is
-      negative, or if `trace_every_n_steps` is not `None` and no `logdir` is
-      provided.
-  """
-  if train_op is None:
-    raise ValueError('train_op cannot be None.')
+    Returns:
+      the value of the loss function after training.
 
-  if logdir is None:
-    if summary_op != _USE_DEFAULT:
-      raise ValueError('Cannot provide summary_op because logdir=None')
-    if saver is not None:
-      raise ValueError('Cannot provide saver because logdir=None')
-    if trace_every_n_steps is not None:
-      raise ValueError('Cannot provide trace_every_n_steps because '
-                       'logdir=None')
+    Raises:
+      ValueError: if `train_op` is empty or if `startup_delay_steps` is
+        non-zero when `sync_optimizer` is supplied, if `number_of_steps` is
+        negative, or if `trace_every_n_steps` is not `None` and no `logdir` is
+        provided.
+    """
 
-  if sync_optimizer is not None and startup_delay_steps > 0:
-    raise ValueError(
-        'startup_delay_steps must be zero when sync_optimizer is supplied.')
+    # Check if the calculation of some metrics is desired.
+    if metric_op is not None:
 
-  if number_of_steps is not None and number_of_steps <= 0:
-    raise ValueError(
-        '`number_of_steps` must be either None or a positive number.')
+        # Check the necessary requirements
+        if metric_collection_name is None:
+            raise ValueError('metric_collection_name must be fed and cannot be No')
+        if number_of_samples is None:
+            raise ValueError('number_of_samples must be fed and cannot be No')
+        if number_of_steps is None:
+            raise ValueError('number_of_steps must be fed and cannot be No')
+        if number_of_epochs is None:
+            raise ValueError('number_of_epochs must be fed and cannot be No')
+        if batch_size is None:
+            raise ValueError('batch_size must be fed and cannot be None')
 
-  graph = graph or ops.get_default_graph()
-  with graph.as_default():
-    if global_step is None:
-      global_step = variables.get_or_create_global_step()
-    saver = saver or tf_saver.Saver()
+    if train_op is None:
+        raise ValueError('train_op cannot be None.')
 
-    with ops.name_scope('init_ops'):
-      if init_op == _USE_DEFAULT:
-        init_op = tf_variables.global_variables_initializer()
+    if logdir is None:
+        if summary_op != _USE_DEFAULT:
+            raise ValueError('Cannot provide summary_op because logdir=None')
+        if saver is not None:
+            raise ValueError('Cannot provide saver because logdir=None')
+        if trace_every_n_steps is not None:
+            raise ValueError('Cannot provide trace_every_n_steps because '
+                             'logdir=None')
 
-      if ready_op == _USE_DEFAULT:
-        ready_op = tf_variables.report_uninitialized_variables()
-
-      if local_init_op == _USE_DEFAULT:
-        local_init_op = control_flow_ops.group(
-            tf_variables.local_variables_initializer(),
-            lookup_ops.tables_initializer())
-
-      if sync_optimizer is not None and isinstance(
-          sync_optimizer, sync_replicas_optimizer.SyncReplicasOptimizer):
-        with ops.control_dependencies([local_init_op] if local_init_op is
-                                      not None else []):
-          if is_chief:
-            local_init_op = sync_optimizer.chief_init_op
-          else:
-            local_init_op = sync_optimizer.local_step_init_op
-        ready_for_local_init_op = sync_optimizer.ready_for_local_init_op
-      else:
-        ready_for_local_init_op = None
-
-    if summary_op == _USE_DEFAULT:
-      summary_op = summary.merge_all()
-
-    if summary_writer == _USE_DEFAULT:
-      summary_writer = supervisor.Supervisor.USE_DEFAULT
-
-    if is_chief and sync_optimizer is not None:
-      if not isinstance(sync_optimizer,
-                        (sync_replicas_optimizer.SyncReplicasOptimizer)):
+    if sync_optimizer is not None and startup_delay_steps > 0:
         raise ValueError(
-            '`sync_optimizer` must be a tf.train.SyncReplicasOptimizer.')
+            'startup_delay_steps must be zero when sync_optimizer is supplied.')
 
-      # Need to create these BEFORE the supervisor finalizes the graph:
-      init_tokens_op = sync_optimizer.get_init_tokens_op()
-      chief_queue_runner = sync_optimizer.get_chief_queue_runner()
+    if number_of_steps is not None and number_of_steps <= 0:
+        raise ValueError(
+            '`number_of_steps` must be either None or a positive number.')
 
-    if train_step_kwargs == _USE_DEFAULT:
-      with ops.name_scope('train_step'):
-        train_step_kwargs = {}
+    graph = graph or ops.get_default_graph()
+    with graph.as_default():
+        if global_step is None:
+            global_step = variables.get_or_create_global_step()
+        saver = saver or tf_saver.Saver()
 
-        if number_of_steps:
-          should_stop_op = math_ops.greater_equal(global_step, number_of_steps)
-        else:
-          should_stop_op = constant_op.constant(False)
-        train_step_kwargs['should_stop'] = should_stop_op
-        if log_every_n_steps > 0:
-          train_step_kwargs['should_log'] = math_ops.equal(
-              math_ops.mod(global_step, log_every_n_steps), 0)
-        if is_chief and trace_every_n_steps is not None:
-          train_step_kwargs['should_trace'] = math_ops.equal(
-              math_ops.mod(global_step, trace_every_n_steps), 0)
-          train_step_kwargs['logdir'] = logdir
+        with ops.name_scope('init_ops'):
+            if init_op == _USE_DEFAULT:
+                init_op = tf_variables.global_variables_initializer()
 
-  sv = supervisor.Supervisor(
-      graph=graph,
-      is_chief=is_chief,
-      logdir=logdir,
-      init_op=init_op,
-      init_feed_dict=init_feed_dict,
-      local_init_op=local_init_op,
-      ready_for_local_init_op=ready_for_local_init_op,
-      ready_op=ready_op,
-      summary_op=summary_op,
-      summary_writer=summary_writer,
-      global_step=global_step,
-      saver=saver,
-      save_summaries_secs=save_summaries_secs,
-      save_model_secs=save_interval_secs,
-      init_fn=init_fn)
+            if ready_op == _USE_DEFAULT:
+                ready_op = tf_variables.report_uninitialized_variables()
 
-  if summary_writer is not None:
-    train_step_kwargs['summary_writer'] = sv.summary_writer
+            if local_init_op == _USE_DEFAULT:
+                local_init_op = control_flow_ops.group(
+                    tf_variables.local_variables_initializer(),
+                    lookup_ops.tables_initializer())
 
-  should_retry = True
-  while should_retry:
-    try:
-      should_retry = False
-      with sv.managed_session(
-          master, start_standard_services=False, config=session_config) as sess:
-        logging.info('Starting Session.')
-        if is_chief:
-          if logdir:
-            sv.start_standard_services(sess)
-        elif startup_delay_steps > 0:
-          _wait_for_step(sess, global_step,
-                         min(startup_delay_steps, number_of_steps or
-                             sys.maxint))
-        threads = sv.start_queue_runners(sess)
-        logging.info('Starting Queues.')
+            if sync_optimizer is not None and isinstance(
+                    sync_optimizer, sync_replicas_optimizer.SyncReplicasOptimizer):
+                with ops.control_dependencies([local_init_op] if local_init_op is
+                not None else []):
+                    if is_chief:
+                        local_init_op = sync_optimizer.chief_init_op
+                    else:
+                        local_init_op = sync_optimizer.local_step_init_op
+                ready_for_local_init_op = sync_optimizer.ready_for_local_init_op
+            else:
+                ready_for_local_init_op = None
+
+        if summary_op == _USE_DEFAULT:
+            summary_op = summary.merge_all()
+
+        if summary_writer == _USE_DEFAULT:
+            summary_writer = supervisor.Supervisor.USE_DEFAULT
+
         if is_chief and sync_optimizer is not None:
-          sv.start_queue_runners(sess, [chief_queue_runner])
-          sess.run(init_tokens_op)
+            if not isinstance(sync_optimizer,
+                              (sync_replicas_optimizer.SyncReplicasOptimizer)):
+                raise ValueError(
+                    '`sync_optimizer` must be a tf.train.SyncReplicasOptimizer.')
+
+            # Need to create these BEFORE the supervisor finalizes the graph:
+            init_tokens_op = sync_optimizer.get_init_tokens_op()
+            chief_queue_runner = sync_optimizer.get_chief_queue_runner()
+
+        if train_step_kwargs == _USE_DEFAULT:
+            with ops.name_scope('train_step'):
+                train_step_kwargs = {}
+
+                if number_of_steps:
+                    should_stop_op = math_ops.greater_equal(global_step, number_of_steps)
+                else:
+                    should_stop_op = constant_op.constant(False)
+                train_step_kwargs['should_stop'] = should_stop_op
+                train_step_kwargs['should_log'] = math_ops.equal(
+                    math_ops.mod(global_step, log_every_n_steps), 0)
+                if is_chief and trace_every_n_steps is not None:
+                    train_step_kwargs['should_trace'] = math_ops.equal(
+                        math_ops.mod(global_step, trace_every_n_steps), 0)
+                    train_step_kwargs['logdir'] = logdir
+                if number_of_samples is not None and batch_size is not None:
+                    train_step_kwargs['num_batches_per_epoch'] = int(number_of_samples / float(batch_size))
+                if number_of_samples is not None and batch_size is not None:
+                    train_step_kwargs['num_steps_per_epoch'] = int(number_of_steps / float(number_of_epochs))
+
+        # If metric calculation is desired.
+        if metric_op is not None:
+            # The reset_op is defined for resetting the streaming_variables(streaming_acurracy,...)
+            # The reason for defining it here is that the supervisor finalized the graph and the graph will be fixed after it.
+            # By calling the reset_op in the train_step function, after each epoch the total & count variables will reset to zero.
+            # This help to have the averaged accuracy per epoch which is useful to realize if we are getting to the highest accuracy in the training.
+            stream_vars = [i for i in tf.local_variables() if i.name.split('/')[1] == metric_collection_name]
+            reset_op = tf.variables_initializer(stream_vars)
+
+    sv = supervisor.Supervisor(
+        graph=graph,
+        is_chief=is_chief,
+        logdir=logdir,
+        init_op=init_op,
+        init_feed_dict=init_feed_dict,
+        local_init_op=local_init_op,
+        ready_for_local_init_op=ready_for_local_init_op,
+        ready_op=ready_op,
+        summary_op=summary_op,
+        summary_writer=summary_writer,
+        global_step=global_step,
+        saver=saver,
+        save_summaries_secs=save_summaries_secs,
+        save_model_secs=save_interval_secs,
+        init_fn=init_fn)
+
+    if summary_writer is not None:
+        train_step_kwargs['summary_writer'] = sv.summary_writer
+
+    should_retry = True
+    while should_retry:
         try:
-          while not sv.should_stop():
-            total_loss, should_stop = train_step_fn(
-                sess, train_op, global_step, train_step_kwargs)
-            if should_stop:
-              logging.info('Stopping Training.')
-              sv.request_stop()
-              break
-        except errors.OutOfRangeError:
-          # OutOfRangeError is thrown when epoch limit per
-          # tf.train.limit_epochs is reached.
-          logging.info('Caught OutOfRangeError. Stopping Training.')
-        if logdir and sv.is_chief:
-          logging.info('Finished training! Saving model to disk.')
-          sv.saver.save(sess, sv.save_path, global_step=sv.global_step)
-          sv.stop(threads, close_summary_writer=True)
+            should_retry = False
 
-    except errors.AbortedError:
-      # Always re-run on AbortedError as it indicates a restart of one of the
-      # distributed tensorflow servers.
-      logging.info('Retrying training!')
-      should_retry = True
+            with sv.managed_session(
+                    master, start_standard_services=False, config=session_config) as sess:
 
-  return total_loss
+                logging.info('Starting Session.')
+                if is_chief:
+                    if logdir:
+                        sv.start_standard_services(sess)
+                elif startup_delay_steps > 0:
+                    _wait_for_step(sess, global_step,
+                                   min(startup_delay_steps, number_of_steps or
+                                       sys.maxint))
+                sv.start_queue_runners(sess)
+                logging.info('Starting Queues.')
+                if is_chief and sync_optimizer is not None:
+                    sv.start_queue_runners(sess, [chief_queue_runner])
+                    sess.run(init_tokens_op)
+                try:
+                    while not sv.should_stop():
+                        if metric_op is not None:
+                            total_loss, should_stop = train_step_fn(
+                                sess, train_op, global_step, train_step_kwargs, metric_op, reset_op)
+                        else:
+                            total_loss, should_stop = train_step_fn(
+                                sess, train_op, global_step, train_step_kwargs)
+                        if should_stop:
+                            logging.info('Stopping Training.')
+                            break
+                except errors.OutOfRangeError:
+                    # OutOfRangeError is thrown when epoch limit per
+                    # tf.train.limit_epochs is reached.
+                    logging.info('Caught OutOfRangeError. Stopping Training.')
+                if logdir and sv.is_chief:
+                    logging.info('Finished training! Saving model to disk.')
+                    sv.saver.save(sess, sv.save_path, global_step=sv.global_step)
+
+        except errors.AbortedError:
+            # Always re-run on AbortedError as it indicates a restart of one of the
+            # distributed tensorflow servers.
+            logging.info('Retrying training!')
+            should_retry = True
+
+    return total_loss


### PR DESCRIPTION
This pull request is aimed to create a metric_op for TF-Slim learning to be able to show the streaming metrics(accuracy,...) for the training phase.
The op reset the total and count local variables defined by streaming_metric(if it is streaming_accuracy ,...) per each epoch of training so the accumulative accuracy per epoch can be represented.