### PR TITLE
Expose canned estimators in core

### DIFF
--- a/tensorflow/python/estimator/estimator_lib.py
+++ b/tensorflow/python/estimator/estimator_lib.py
@@ -31,6 +31,7 @@ from tensorflow.python.util.all_util import remove_undocumented
 
 _allowed_symbols = [
     'inputs',
+    'canned',
     'export',
     'Estimator',
     'EstimatorSpec',


### PR DESCRIPTION
I know this is still WIP but it would be good to expose this for adventurous external users. 