### PR TITLE
Support for `dtype` keyword in tf.layers.*

### DIFF
--- a/tensorflow/python/layers/base.py
+++ b/tensorflow/python/layers/base.py
@@ -56,7 +56,7 @@ class Layer(object):
   Properties:
     trainable: Whether the layer should be trained (boolean).
     name: The name of the layer (string).
-    dtype: Default dtype of the layer (dtypes.float32).
+    dtype: Data type of the layer. defaults to `float32` if None is passed.
     trainable_variables: List of trainable variables.
     non_trainable_variables: List of non-trainable variables.
     variables: List of all variables of this layer, trainable and non-trainable.
@@ -67,7 +67,7 @@ class Layer(object):
   """
 
   def __init__(self, trainable=True, name=None,
-               dtype=dtypes.float32, **kwargs):
+               dtype=None, **kwargs):
     # We use a kwargs dict here because these kwargs only exist
     # for compatibility reasons.
     # The list of kwargs is subject to changes in the future.
@@ -94,6 +94,8 @@ class Layer(object):
     self._graph = ops.get_default_graph()
     self._per_input_losses = {}
     self._per_input_updates = {}
+    if dtype is None:
+        dtype = dtypes.float32
     self.dtype = dtypes.as_dtype(dtype).name
     self.input_spec = None
 

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -79,6 +79,7 @@ class _Conv(base.Layer):
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
   """
 
   def __init__(self, rank,
@@ -97,9 +98,10 @@ class _Conv(base.Layer):
                activity_regularizer=None,
                trainable=True,
                name=None,
+               dtype=None,
                **kwargs):
     super(_Conv, self).__init__(trainable=trainable,
-                                name=name, **kwargs)
+                                name=name, dtype=dtype, **kwargs)
     self.rank = rank
     self.filters = filters
     self.kernel_size = utils.normalize_tuple(kernel_size, rank, 'kernel_size')
@@ -289,6 +291,7 @@ class Conv1D(_Conv):
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
   """
 
   def __init__(self, filters,
@@ -306,6 +309,7 @@ class Conv1D(_Conv):
                activity_regularizer=None,
                trainable=True,
                name=None,
+               dtype=None,
                **kwargs):
     super(Convolution1D, self).__init__(
         rank=1,
@@ -323,7 +327,7 @@ class Conv1D(_Conv):
         bias_regularizer=bias_regularizer,
         activity_regularizer=activity_regularizer,
         trainable=trainable,
-        name=name, **kwargs)
+        name=name, dtype=dtype, **kwargs)
 
 
 def conv1d(inputs,
@@ -342,6 +346,7 @@ def conv1d(inputs,
            activity_regularizer=None,
            trainable=True,
            name=None,
+           dtype=None,
            reuse=None):
   """Functional interface for 1D convolution layer (e.g. temporal convolution).
 
@@ -383,6 +388,7 @@ def conv1d(inputs,
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
     reuse: Boolean, whether to reuse the weights of a previous layer
       by the same name.
 
@@ -405,6 +411,7 @@ def conv1d(inputs,
       activity_regularizer=activity_regularizer,
       trainable=trainable,
       name=name,
+      dtype=dtype,
       _reuse=reuse,
       _scope=name)
   return layer.apply(inputs)
@@ -457,6 +464,7 @@ class Conv2D(_Conv):
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
   """
 
   def __init__(self, filters,
@@ -474,6 +482,7 @@ class Conv2D(_Conv):
                activity_regularizer=None,
                trainable=True,
                name=None,
+               dtype=None,
                **kwargs):
     super(Conv2D, self).__init__(
         rank=2,
@@ -491,7 +500,7 @@ class Conv2D(_Conv):
         bias_regularizer=bias_regularizer,
         activity_regularizer=activity_regularizer,
         trainable=trainable,
-        name=name, **kwargs)
+        name=name, dtype=dtype, **kwargs)
 
 
 def conv2d(inputs,
@@ -510,6 +519,7 @@ def conv2d(inputs,
            activity_regularizer=None,
            trainable=True,
            name=None,
+           dtype=None,
            reuse=None):
   """Functional interface for the 2D convolution layer.
 
@@ -558,6 +568,7 @@ def conv2d(inputs,
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
     reuse: Boolean, whether to reuse the weights of a previous layer
       by the same name.
 
@@ -580,6 +591,7 @@ def conv2d(inputs,
       activity_regularizer=activity_regularizer,
       trainable=trainable,
       name=name,
+      dtype=dtype,
       _reuse=reuse,
       _scope=name)
   return layer.apply(inputs)
@@ -633,6 +645,7 @@ class Conv3D(_Conv):
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
   """
 
   def __init__(self, filters,
@@ -650,6 +663,7 @@ class Conv3D(_Conv):
                activity_regularizer=None,
                trainable=True,
                name=None,
+               dtype=None,
                **kwargs):
     super(Conv3D, self).__init__(
         rank=3,
@@ -667,7 +681,7 @@ class Conv3D(_Conv):
         bias_regularizer=bias_regularizer,
         activity_regularizer=activity_regularizer,
         trainable=trainable,
-        name=name, **kwargs)
+        name=name, dtype=dtype, **kwargs)
 
 
 def conv3d(inputs,
@@ -686,6 +700,7 @@ def conv3d(inputs,
            activity_regularizer=None,
            trainable=True,
            name=None,
+           dtype=None,
            reuse=None):
   """Functional interface for the 3D convolution layer.
 
@@ -735,6 +750,7 @@ def conv3d(inputs,
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
     reuse: Boolean, whether to reuse the weights of a previous layer
       by the same name.
 
@@ -757,6 +773,7 @@ def conv3d(inputs,
       activity_regularizer=activity_regularizer,
       trainable=trainable,
       name=name,
+      dtype=dtype,
       _reuse=reuse,
       _scope=name)
   return layer.apply(inputs)
@@ -814,6 +831,7 @@ class SeparableConv2D(Conv2D):
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
   """
 
   def __init__(self, filters,
@@ -834,6 +852,7 @@ class SeparableConv2D(Conv2D):
                activity_regularizer=None,
                trainable=True,
                name=None,
+               dtype=None,
                **kwargs):
     super(SeparableConv2D, self).__init__(
         filters=filters,
@@ -848,6 +867,7 @@ class SeparableConv2D(Conv2D):
         activity_regularizer=activity_regularizer,
         trainable=trainable,
         name=name,
+        dtype=dtype,
         **kwargs)
     self.depth_multiplier = depth_multiplier
     self.depthwise_initializer = depthwise_initializer
@@ -970,6 +990,7 @@ def separable_conv2d(inputs,
                      activity_regularizer=None,
                      trainable=True,
                      name=None,
+                     dtype=None,
                      reuse=None):
   """Functional interface for the depthwise separable 2D convolution layer.
 
@@ -1023,6 +1044,7 @@ def separable_conv2d(inputs,
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
     reuse: Boolean, whether to reuse the weights of a previous layer
       by the same name.
 
@@ -1048,6 +1070,7 @@ def separable_conv2d(inputs,
       activity_regularizer=activity_regularizer,
       trainable=trainable,
       name=name,
+      dtype=dtype,
       _reuse=reuse,
       _scope=name)
   return layer.apply(inputs)
@@ -1090,6 +1113,7 @@ class Conv2DTranspose(Conv2D):
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
   """
 
   def __init__(self, filters,
@@ -1106,6 +1130,7 @@ class Conv2DTranspose(Conv2D):
                activity_regularizer=None,
                trainable=True,
                name=None,
+               dtype=None,
                **kwargs):
     super(Conv2DTranspose, self).__init__(
         filters,
@@ -1122,6 +1147,7 @@ class Conv2DTranspose(Conv2D):
         activity_regularizer=activity_regularizer,
         trainable=trainable,
         name=name,
+        dtype=dtype,
         **kwargs)
     self.input_spec = base.InputSpec(ndim=4)
 
@@ -1252,6 +1278,7 @@ def conv2d_transpose(inputs,
                      activity_regularizer=None,
                      trainable=True,
                      name=None,
+                     dtype=None,
                      reuse=None):
   """Functional interface for transposed 2D convolution layer.
 
@@ -1290,6 +1317,7 @@ def conv2d_transpose(inputs,
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
     reuse: Boolean, whether to reuse the weights of a previous layer
       by the same name.
 
@@ -1311,6 +1339,7 @@ def conv2d_transpose(inputs,
       activity_regularizer=activity_regularizer,
       trainable=trainable,
       name=name,
+      dtype=None,
       _reuse=reuse,
       _scope=name)
   return layer.apply(inputs)
@@ -1349,6 +1378,7 @@ class Conv3DTranspose(Conv3D):
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
   """
 
   def __init__(self,
@@ -1366,6 +1396,7 @@ class Conv3DTranspose(Conv3D):
                activity_regularizer=None,
                trainable=True,
                name=None,
+               dtype=None,
                **kwargs):
     super(Conv3DTranspose, self).__init__(
         filters=filters,
@@ -1382,6 +1413,7 @@ class Conv3DTranspose(Conv3D):
         activity_regularizer=activity_regularizer,
         trainable=trainable,
         name=name,
+        dtype=dtype,
         **kwargs)
 
   def build(self, input_shape):
@@ -1517,6 +1549,7 @@ def conv3d_transpose(inputs,
                      activity_regularizer=None,
                      trainable=True,
                      name=None,
+                     dtype=None,
                      reuse=None):
   """Functional interface for transposed 3D convolution layer.
 
@@ -1548,6 +1581,7 @@ def conv3d_transpose(inputs,
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+    dtype: Data type used by the layer weights.
     reuse: Boolean, whether to reuse the weights of a previous layer
       by the same name.
 
@@ -1569,6 +1603,7 @@ def conv3d_transpose(inputs,
       activity_regularizer=activity_regularizer,
       trainable=trainable,
       name=name,
+      dtype=dtype,
       _reuse=reuse,
       _scope=name)
   return layer.apply(inputs)

--- a/tensorflow/python/layers/core.py
+++ b/tensorflow/python/layers/core.py
@@ -65,6 +65,7 @@ class Dense(base.Layer):
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: String, the name of the layer. Layers with the same name will
       share weights, but to avoid mistakes we require reuse=True in such cases.
+    dtype: Data type used by the layer weights.
     reuse: Boolean, whether to reuse the weights of a previous layer
       by the same name.
 
@@ -91,8 +92,10 @@ class Dense(base.Layer):
                activity_regularizer=None,
                trainable=True,
                name=None,
+               dtype=None,
                **kwargs):
-    super(Dense, self).__init__(trainable=trainable, name=name, **kwargs)
+    super(Dense, self).__init__(trainable=trainable, name=name,
+                                dtype=dtype, **kwargs)
     self.units = units
     self.activation = activation
     self.use_bias = use_bias
@@ -166,6 +169,7 @@ def dense(
     activity_regularizer=None,
     trainable=True,
     name=None,
+    dtype=None,
     reuse=None):
   """Functional interface for the densely-connected layer.
 
@@ -193,6 +197,7 @@ def dense(
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: String, the name of the layer.
+    dtype: Data type used by the layer weights.
     reuse: Boolean, whether to reuse the weights of a previous layer
       by the same name.
 


### PR DESCRIPTION
This pull request introduces the `dtype` keyword in functional interfaces for core layers to solve #9898. All the unit-tests seem to run fine on my machine after incorporating the changes. The default value has been kept as tf.float32 in order to ensure compatibility.