### PR TITLE
Fix CMD in Dockerfile

### DIFF
--- a/tensorflow/examples/udacity/Dockerfile
+++ b/tensorflow/examples/udacity/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install scikit-learn pyreadline Pillow
 RUN rm -rf /notebooks/*
 ADD *.ipynb /notebooks/
 WORKDIR /notebooks
-CMD ["/run_jupyter.sh"]
+CMD ["/run_jupyter.sh", "--allow-root"]


### PR DESCRIPTION
Currently Notebook fails execution because default user for this container is root, and unless explicitly allowed, jupyter notebook will not start.