### PR TITLE
Fix linking errors of lmdb on Windows

### DIFF
--- a/third_party/lmdb.BUILD
+++ b/third_party/lmdb.BUILD
@@ -18,8 +18,20 @@ cc_library(
     copts = [
         "-w",
     ],
-    linkopts = [
-        "-lpthread",
-    ],
+    linkopts = select({
+        ":windows": ["-Wl,advapi32.lib"], # InitializeSecurityDescriptor, SetSecurityDescriptorDacl
+        ":windows_msvc": ["-Wl,advapi32.lib"],
+        "//conditions:default": ["-lpthread"],
+    }),
     visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
+
+config_setting(
+    name = "windows_msvc",
+    values = {"cpu": "x64_windows_msvc"},
 )


### PR DESCRIPTION
http://ci.tensorflow.org/job/tf-master-win-bzl/1041/console
The error was introduced in https://github.com/tensorflow/tensorflow/commit/e6f58186363279496c46563e6f065ce7ea16c501

```
23:09:48 liblmdb.a(mdb.o) : error LNK2019: unresolved external symbol __imp_InitializeSecurityDescriptor referenced in function mdb_env_setup_locks
23:09:48 liblmdb.a(mdb.o) : error LNK2019: unresolved external symbol __imp_SetSecurityDescriptorDacl referenced in function mdb_env_setup_locks
```
@gunan 