### PR TITLE
Export C API symbols in _pywrap_tensorflow_internal.so

### DIFF
--- a/tensorflow/tf_exported_symbols.lds
+++ b/tensorflow/tf_exported_symbols.lds
@@ -1,3 +1,4 @@
 *tensorflow*
 *perftools*gputools*
 *tf_*
+TF_*

--- a/tensorflow/tf_version_script.lds
+++ b/tensorflow/tf_version_script.lds
@@ -2,6 +2,7 @@ tensorflow {
   global:
     *tensorflow*;
     *perftools*gputools*;
+    TF_*;
   local:
     *;
 };


### PR DESCRIPTION
This PR exports C API symbols so that python extension libraries can use the C API.

As noted in #7541, there is currently a conflict between `_pywrap_tensorflow_internal.so` and `libtensorflow.so`. This conflict prevents use of the tensorflow C API and the python API in the same process. This PR attempts to implement a workaround suggested by @jhseu by exporting the C API symbols in the python library, so that the Python and C APIs are both available from the single `_pywrap_tensorflow_internal.so`.