### PR TITLE
Support channel groups in convolutional layers

### DIFF
--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -70,6 +70,15 @@ class _Conv(base.Layer):
     activation: Activation function. Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
+    groups: Integer, the number of channel groups. A channel group includes a
+      subset of input channels and output channels. The output channels in a
+      channel group are only connected to the input channels of the same group.
+      Assume the number of input channels is `n`, the number of output channels
+      is `m`, and the number of groups is `g`. Each group has `n/g` input
+      channels and `m/g` output channels which are connected via a kernel slice
+      with shape `(filter_height, filter_width, n/g, m/g)`. The full kernel has
+      the shape `(filter_height, filter_width, n/g, m)` and is split on the
+      output dimension.
     kernel_initializer: An initializer for the convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, no bias will
       be applied.
@@ -90,6 +99,7 @@ class _Conv(base.Layer):
                dilation_rate=1,
                activation=None,
                use_bias=True,
+               groups=1,
                kernel_initializer=None,
                bias_initializer=init_ops.zeros_initializer(),
                kernel_regularizer=None,
@@ -110,6 +120,7 @@ class _Conv(base.Layer):
         dilation_rate, rank, 'dilation_rate')
     self.activation = activation
     self.use_bias = use_bias
+    self.groups = groups
     self.kernel_initializer = kernel_initializer
     self.bias_initializer = bias_initializer
     self.kernel_regularizer = kernel_regularizer
@@ -127,7 +138,15 @@ class _Conv(base.Layer):
       raise ValueError('The channel dimension of the inputs '
                        'should be defined. Found `None`.')
     input_dim = input_shape[channel_axis].value
-    kernel_shape = self.kernel_size + (input_dim, self.filters)
+    if input_dim % self.groups != 0:
+      raise ValueError('The number of input channels is not divisible '
+                       'by the number of channel group. %d %% %d = %d' %
+                       (input_dim, self.groups, input_dim % self.groups))
+    if self.filters % self.groups != 0:
+      raise ValueError('The number of output channels is not divisible '
+                       'by the number of channel group. %d %% %d = %d' %
+                       (self.filters, self.groups, self.filters % self.groups))
+    kernel_shape = self.kernel_size + (input_dim // self.groups, self.filters)
 
     self.kernel = self.add_variable(name='kernel',
                                     shape=kernel_shape,
@@ -149,13 +168,30 @@ class _Conv(base.Layer):
     self.built = True
 
   def call(self, inputs):
-    outputs = nn.convolution(
-        input=inputs,
-        filter=self.kernel,
-        dilation_rate=self.dilation_rate,
-        strides=self.strides,
-        padding=self.padding.upper(),
-        data_format=utils.convert_data_format(self.data_format, self.rank + 2))
+    if self.groups == 1:
+      outputs = nn.convolution(
+          input=inputs,
+          filter=self.kernel,
+          dilation_rate=self.dilation_rate,
+          strides=self.strides,
+          padding=self.padding.upper(),
+          data_format=utils.convert_data_format(self.data_format, self.rank + 2))
+    else:
+      if self.data_format == 'channels_first':
+        channel_axis = 1
+      else:
+        channel_axis = -1
+      input_slices = array_ops.split(inputs, self.groups, axis=channel_axis)
+      kernel_slices = array_ops.split(self.kernel, self.groups, axis=-1)
+      output_slices = [nn.convolution(
+          input=input_slice,
+          filter=kernel_slice,
+          dilation_rate=self.dilation_rate,
+          strides=self.strides,
+          padding=self.padding.upper(),
+          data_format=utils.convert_data_format(self.data_format, self.rank + 2))
+          for input_slice, kernel_slice in zip(input_slices, kernel_slices)]
+      outputs = array_ops.concat(output_slices, axis=channel_axis)
 
     if self.bias is not None:
       if self.data_format == 'channels_first':
@@ -246,6 +282,15 @@ class Conv1D(_Conv):
     activation: Activation function. Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
+    groups: Integer, the number of channel groups. A channel group includes a
+      subset of input channels and output channels. The output channels in a
+      channel group are only connected to the input channels of the same group.
+      Assume the number of input channels is `n`, the number of output channels
+      is `m`, and the number of groups is `g`. Each group has `n/g` input
+      channels and `m/g` output channels which are connected via a kernel slice
+      with shape `(filter_height, filter_width, n/g, m/g)`. The full kernel has
+      the shape `(filter_height, filter_width, n/g, m)` and is split on the
+      output dimension.
     kernel_initializer: An initializer for the convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, no bias will
       be applied.
@@ -265,6 +310,7 @@ class Conv1D(_Conv):
                dilation_rate=1,
                activation=None,
                use_bias=True,
+               groups=1,
                kernel_initializer=None,
                bias_initializer=init_ops.zeros_initializer(),
                kernel_regularizer=None,
@@ -283,6 +329,7 @@ class Conv1D(_Conv):
         dilation_rate=dilation_rate,
         activation=activation,
         use_bias=use_bias,
+        groups=groups,
         kernel_initializer=kernel_initializer,
         bias_initializer=bias_initializer,
         kernel_regularizer=kernel_regularizer,
@@ -301,6 +348,7 @@ def conv1d(inputs,
            dilation_rate=1,
            activation=None,
            use_bias=True,
+           groups=1,
            kernel_initializer=None,
            bias_initializer=init_ops.zeros_initializer(),
            kernel_regularizer=None,
@@ -340,6 +388,15 @@ def conv1d(inputs,
     activation: Activation function. Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
+    groups: Integer, the number of channel groups. A channel group includes a
+      subset of input channels and output channels. The output channels in a
+      channel group are only connected to the input channels of the same group.
+      Assume the number of input channels is `n`, the number of output channels
+      is `m`, and the number of groups is `g`. Each group has `n/g` input
+      channels and `m/g` output channels which are connected via a kernel slice
+      with shape `(filter_height, filter_width, n/g, m/g)`. The full kernel has
+      the shape `(filter_height, filter_width, n/g, m)` and is split on the
+      output dimension.
     kernel_initializer: An initializer for the convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, no bias will
       be applied.
@@ -364,6 +421,7 @@ def conv1d(inputs,
       dilation_rate=dilation_rate,
       activation=activation,
       use_bias=use_bias,
+      groups=groups,
       kernel_initializer=kernel_initializer,
       bias_initializer=bias_initializer,
       kernel_regularizer=kernel_regularizer,
@@ -414,6 +472,15 @@ class Conv2D(_Conv):
     activation: Activation function. Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
+    groups: Integer, the number of channel groups. A channel group includes a
+      subset of input channels and output channels. The output channels in a
+      channel group are only connected to the input channels of the same group.
+      Assume the number of input channels is `n`, the number of output channels
+      is `m`, and the number of groups is `g`. Each group has `n/g` input
+      channels and `m/g` output channels which are connected via a kernel slice
+      with shape `(filter_height, filter_width, n/g, m/g)`. The full kernel has
+      the shape `(filter_height, filter_width, n/g, m)` and is split on the
+      output dimension.
     kernel_initializer: An initializer for the convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, no bias will
       be applied.
@@ -433,6 +500,7 @@ class Conv2D(_Conv):
                dilation_rate=(1, 1),
                activation=None,
                use_bias=True,
+               groups=1,
                kernel_initializer=None,
                bias_initializer=init_ops.zeros_initializer(),
                kernel_regularizer=None,
@@ -451,6 +519,7 @@ class Conv2D(_Conv):
         dilation_rate=dilation_rate,
         activation=activation,
         use_bias=use_bias,
+        groups=groups,
         kernel_initializer=kernel_initializer,
         bias_initializer=bias_initializer,
         kernel_regularizer=kernel_regularizer,
@@ -469,6 +538,7 @@ def conv2d(inputs,
            dilation_rate=(1, 1),
            activation=None,
            use_bias=True,
+           groups=1,
            kernel_initializer=None,
            bias_initializer=init_ops.zeros_initializer(),
            kernel_regularizer=None,
@@ -515,6 +585,15 @@ def conv2d(inputs,
     activation: Activation function. Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
+    groups: Integer, the number of channel groups. A channel group includes a
+      subset of input channels and output channels. The output channels in a
+      channel group are only connected to the input channels of the same group.
+      Assume the number of input channels is `n`, the number of output channels
+      is `m`, and the number of groups is `g`. Each group has `n/g` input
+      channels and `m/g` output channels which are connected via a kernel slice
+      with shape `(filter_height, filter_width, n/g, m/g)`. The full kernel has
+      the shape `(filter_height, filter_width, n/g, m)` and is split on the
+      output dimension.
     kernel_initializer: An initializer for the convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, no bias will
       be applied.
@@ -539,6 +618,7 @@ def conv2d(inputs,
       dilation_rate=dilation_rate,
       activation=activation,
       use_bias=use_bias,
+      groups=groups,
       kernel_initializer=kernel_initializer,
       bias_initializer=bias_initializer,
       kernel_regularizer=kernel_regularizer,
@@ -590,6 +670,15 @@ class Conv3D(_Conv):
     activation: Activation function. Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
+    groups: Integer, the number of channel groups. A channel group includes a
+      subset of input channels and output channels. The output channels in a
+      channel group are only connected to the input channels of the same group.
+      Assume the number of input channels is `n`, the number of output channels
+      is `m`, and the number of groups is `g`. Each group has `n/g` input
+      channels and `m/g` output channels which are connected via a kernel slice
+      with shape `(filter_height, filter_width, n/g, m/g)`. The full kernel has
+      the shape `(filter_height, filter_width, n/g, m)` and is split on the
+      output dimension.
     kernel_initializer: An initializer for the convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, no bias will
       be applied.
@@ -609,6 +698,7 @@ class Conv3D(_Conv):
                dilation_rate=(1, 1, 1),
                activation=None,
                use_bias=True,
+               groups=1,
                kernel_initializer=None,
                bias_initializer=init_ops.zeros_initializer(),
                kernel_regularizer=None,
@@ -627,6 +717,7 @@ class Conv3D(_Conv):
         dilation_rate=dilation_rate,
         activation=activation,
         use_bias=use_bias,
+        groups=groups,
         kernel_initializer=kernel_initializer,
         bias_initializer=bias_initializer,
         kernel_regularizer=kernel_regularizer,
@@ -645,6 +736,7 @@ def conv3d(inputs,
            dilation_rate=(1, 1, 1),
            activation=None,
            use_bias=True,
+           groups=1,
            kernel_initializer=None,
            bias_initializer=init_ops.zeros_initializer(),
            kernel_regularizer=None,
@@ -692,6 +784,15 @@ def conv3d(inputs,
     activation: Activation function. Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
+    groups: Integer, the number of channel groups. A channel group includes a
+      subset of input channels and output channels. The output channels in a
+      channel group are only connected to the input channels of the same group.
+      Assume the number of input channels is `n`, the number of output channels
+      is `m`, and the number of groups is `g`. Each group has `n/g` input
+      channels and `m/g` output channels which are connected via a kernel slice
+      with shape `(filter_height, filter_width, n/g, m/g)`. The full kernel has
+      the shape `(filter_height, filter_width, n/g, m)` and is split on the
+      output dimension.
     kernel_initializer: An initializer for the convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, no bias will
       be applied.
@@ -716,6 +817,7 @@ def conv3d(inputs,
       dilation_rate=dilation_rate,
       activation=activation,
       use_bias=use_bias,
+      groups=groups,
       kernel_initializer=kernel_initializer,
       bias_initializer=bias_initializer,
       kernel_regularizer=kernel_regularizer,
@@ -1047,6 +1149,15 @@ class Conv2DTranspose(Conv2D):
     activation: Activation function. Set it to None to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
+    groups: Integer, the number of channel groups. A channel group includes a
+      subset of input channels and output channels. The output channels in a
+      channel group are only connected to the input channels of the same group.
+      Assume the number of input channels is `n`, the number of output channels
+      is `m`, and the number of groups is `g`. Each group has `n/g` input
+      channels and `m/g` output channels which are connected via a kernel slice
+      with shape `(filter_height, filter_width, n/g, m/g)`. The full kernel has
+      the shape `(filter_height, filter_width, n/g, m)` and is split on the
+      output dimension.
     kernel_initializer: An initializer for the convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, no bias will
       be applied.
@@ -1065,6 +1176,7 @@ class Conv2DTranspose(Conv2D):
                data_format='channels_last',
                activation=None,
                use_bias=True,
+               groups=1,
                kernel_initializer=None,
                bias_initializer=init_ops.zeros_initializer(),
                kernel_regularizer=None,
@@ -1081,6 +1193,7 @@ class Conv2DTranspose(Conv2D):
         data_format=data_format,
         activation=activation,
         use_bias=use_bias,
+        groups=groups,
         kernel_initializer=kernel_initializer,
         bias_initializer=bias_initializer,
         kernel_regularizer=kernel_regularizer,
@@ -1103,9 +1216,17 @@ class Conv2DTranspose(Conv2D):
     if input_shape[channel_axis] is None:
       raise ValueError('The channel dimension of the inputs '
                        'should be defined. Found `None`.')
-    input_dim = input_shape[channel_axis]
+    input_dim = input_shape[channel_axis].value
+    if input_dim % self.groups != 0:
+      raise ValueError('The number of input channels is not divisible '
+                       'by the number of channel group. %d %% %d = %d' %
+                       (input_dim, self.groups, input_dim % self.groups))
+    if self.filters % self.groups != 0:
+      raise ValueError('The number of output channels is not divisible '
+                       'by the number of channel group. %d %% %d = %d' %
+                       (self.filters, self.groups, self.filters % self.groups))
     self.input_spec = base.InputSpec(ndim=4, axes={channel_axis: input_dim})
-    kernel_shape = self.kernel_size + (self.filters, input_dim)
+    kernel_shape = self.kernel_size + (self.filters, input_dim // self.groups)
 
     self.kernel = self.add_variable(name='kernel',
                                     shape=kernel_shape,
@@ -1146,20 +1267,37 @@ class Conv2DTranspose(Conv2D):
                                            self.padding,
                                            stride_w)
     if self.data_format == 'channels_first':
-      output_shape = (batch_size, self.filters, out_height, out_width)
+      output_shape = (batch_size, self.filters // self.groups, out_height, out_width)
       strides = (1, 1, stride_h, stride_w)
     else:
-      output_shape = (batch_size, out_height, out_width, self.filters)
+      output_shape = (batch_size, out_height, out_width, self.filters // self.groups)
       strides = (1, stride_h, stride_w, 1)
 
     output_shape_tensor = array_ops.stack(output_shape)
-    outputs = nn.conv2d_transpose(
-        inputs,
-        self.kernel,
-        output_shape_tensor,
-        strides,
-        padding=self.padding.upper(),
-        data_format=utils.convert_data_format(self.data_format, ndim=4))
+    if self.groups == 1:
+      outputs = nn.conv2d_transpose(
+          inputs,
+          self.kernel,
+          output_shape_tensor,
+          strides,
+          padding=self.padding.upper(),
+          data_format=utils.convert_data_format(self.data_format, ndim=4))
+    else:
+      if self.data_format == 'channels_first':
+        channel_axis = 1
+      else:
+        channel_axis = -1
+      input_slices = array_ops.split(inputs, self.groups, axis=channel_axis)
+      kernel_slices = array_ops.split(self.kernel, self.groups, axis=-2)
+      output_slices = [nn.convolution(
+          input_slice,
+          kernel_slice,
+          output_shape_tensor,
+          strides,
+          padding=self.padding.upper(),
+          data_format=utils.convert_data_format(self.data_format, ndim=4))
+          for input_slice, kernel_slice in zip(input_slices, kernel_slices)]
+      outputs = array_ops.concat(output_slices, axis=channel_axis)
 
     # Infer the static output shape:
     out_shape = inputs.get_shape().as_list()
@@ -1211,6 +1349,7 @@ def conv2d_transpose(inputs,
                      data_format='channels_last',
                      activation=None,
                      use_bias=True,
+                     groups=1,
                      kernel_initializer=None,
                      bias_initializer=init_ops.zeros_initializer(),
                      kernel_regularizer=None,
@@ -1247,6 +1386,15 @@ def conv2d_transpose(inputs,
     activation: Activation function. Set it to `None` to maintain a
       linear activation.
     use_bias: Boolean, whether the layer uses a bias.
+    groups: Integer, the number of channel groups. A channel group includes a
+      subset of input channels and output channels. The output channels in a
+      channel group are only connected to the input channels of the same group.
+      Assume the number of input channels is `n`, the number of output channels
+      is `m`, and the number of groups is `g`. Each group has `n/g` input
+      channels and `m/g` output channels which are connected via a kernel slice
+      with shape `(filter_height, filter_width, n/g, m/g)`. The full kernel has
+      the shape `(filter_height, filter_width, n/g, m)` and is split on the
+      output dimension.
     kernel_initializer: An initializer for the convolution kernel.
     bias_initializer: An initializer for the bias vector. If `None`, then no
       bias will be applied.
@@ -1270,6 +1418,7 @@ def conv2d_transpose(inputs,
       data_format=data_format,
       activation=activation,
       use_bias=use_bias,
+      groups=groups,
       kernel_initializer=kernel_initializer,
       bias_initializer=bias_initializer,
       kernel_regularizer=kernel_regularizer,

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -58,6 +58,15 @@ class ConvTest(test.TestCase):
     with self.assertRaisesRegexp(ValueError, 'kernel_size'):
       conv_layers.conv2d(images, 32, None)
 
+  def testInvalidGroupSize(self):
+    height, width = 7, 9
+    images = random_ops.random_uniform((5, height, width, 3), seed=1)
+    with self.assertRaisesRegexp(ValueError, 'divisible'):
+      conv_layers.conv2d(images, 32, 8, groups=3)
+
+    with self.assertRaisesRegexp(ValueError, 'divisible'):
+      conv_layers.conv2d(images, 32, 8, groups=4)
+
   def testCreateConv2D(self):
     height, width = 7, 9
     images = random_ops.random_uniform((5, height, width, 4))
@@ -88,6 +97,16 @@ class ConvTest(test.TestCase):
                          [5, 32, height - 2, width - 2])
     self.assertListEqual(layer.kernel.get_shape().as_list(), [3, 3, 4, 32])
     self.assertListEqual(layer.bias.get_shape().as_list(), [32])
+
+  def testCreateConv2DChannelGroup(self):
+    height, width = 7, 9
+    images = random_ops.random_uniform((5, height, width, 6), seed=1)
+    layer = conv_layers.Conv2D(9, 3, groups=3)
+    output = layer.apply(images)
+    self.assertListEqual(output.get_shape().as_list(),
+                         [5, height - 2, width - 2, 9])
+    self.assertListEqual(layer.kernel.get_shape().as_list(), [3, 3, 2, 9])
+    self.assertListEqual(layer.bias.get_shape().as_list(), [9])
 
   def testUnknownInputChannels(self):
     images = random_ops.random_uniform((5, 7, 9, 4))
@@ -153,6 +172,15 @@ class ConvTest(test.TestCase):
     self.assertListEqual(layer.kernel.get_shape().as_list(), [3, 4, 32])
     self.assertListEqual(layer.bias.get_shape().as_list(), [32])
 
+  def testCreateConv1DChannelGroup(self):
+    width = 7
+    data = random_ops.random_uniform((5, width, 4), seed=1)
+    layer = conv_layers.Conv1D(8, 3, groups=2)
+    output = layer.apply(data)
+    self.assertListEqual(output.get_shape().as_list(), [5, width - 2, 8])
+    self.assertListEqual(layer.kernel.get_shape().as_list(), [3, 2, 8])
+    self.assertListEqual(layer.bias.get_shape().as_list(), [8])
+
   def testUnknownInputChannelsConv1D(self):
     data = random_ops.random_uniform((5, 4, 7))
     data._shape = tensor_shape.as_shape((5, 4, None))
@@ -179,6 +207,16 @@ class ConvTest(test.TestCase):
     self.assertListEqual(output.get_shape().as_list(),
                          [5, depth - 2, height - 2, width - 2, 32])
     self.assertListEqual(layer.kernel.get_shape().as_list(), [3, 3, 3, 4, 32])
+    self.assertListEqual(layer.bias.get_shape().as_list(), [32])
+
+  def testCreateConv3DChannelGroup(self):
+    depth, height, width = 6, 7, 9
+    volumes = random_ops.random_uniform((5, depth, height, width, 4))
+    layer = conv_layers.Conv3D(32, [3, 3, 3], groups=2)
+    output = layer.apply(volumes)
+    self.assertListEqual(output.get_shape().as_list(),
+                         [5, depth - 2, height - 2, width - 2, 32])
+    self.assertListEqual(layer.kernel.get_shape().as_list(), [3, 3, 3, 2, 32])
     self.assertListEqual(layer.bias.get_shape().as_list(), [32])
 
   def testUnknownInputChannelsConv3D(self):
@@ -510,6 +548,15 @@ class Conv2DTransposeTest(test.TestCase):
 
     with self.assertRaisesRegexp(ValueError, 'kernel_size'):
       conv_layers.conv2d_transpose(images, 32, None)
+
+  def testInvalidGroupSize(self):
+    height, width = 7, 9
+    images = random_ops.random_uniform((5, height, width, 3), seed=1)
+    with self.assertRaisesRegexp(ValueError, 'divisible'):
+      conv_layers.conv2d_transpose(images, 32, 8, groups=3)
+
+    with self.assertRaisesRegexp(ValueError, 'divisible'):
+      conv_layers.conv2d(images, 32, 8, groups=4)
 
   def testCreateConv2DTranspose(self):
     height, width = 7, 9


### PR DESCRIPTION
This PR implements the channel groups in convolutional layers (Conv1D, Conv2D, Conv3D, Conv2DTransposed).

The grouped convolution was firstly implemented in AlexNet as a way to share filter parameters across feature maps. A detailed discussion on this feature can be found on [here](https://github.com/BVLC/caffe/issues/778). This feature is supported by Caffe ([doc](http://caffe.berkeleyvision.org/tutorial/layers/convolution.html)) and used in its reference [caffenet](https://github.com/BVLC/caffe/blob/master/models/bvlc_reference_caffenet/train_val.prototxt#L128). Adding this feature to TensorFlow makes it easier to compare models on two different frameworks and migrate from Caffe to TensorFlow.
