### PR TITLE
Delete non-deterministic testEmpty() test

### DIFF
--- a/tensorflow/python/kernel_tests/matrix_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/matrix_solve_op_test.py
@@ -96,11 +96,6 @@ class MatrixSolveOpTest(test.TestCase):
             [[1., 0., -1.], [-1., 1., 0.], [0., -1., 1.]])
         linalg_ops.matrix_solve(matrix, matrix).eval()
 
-  def testEmpty(self):
-    with self.test_session():
-      self._verifySolve(np.empty([0, 0]), np.empty([0, 0]))
-      self._verifySolve(np.empty([2, 2]), np.empty([2, 0]))
-
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
Causing flaky Windows cmake tests because `np.empty()` may return a singular matrix.
```
15:26:41 ======================================================================
15:26:41 ERROR: testEmpty (__main__.MatrixSolveOpTest)
15:26:41 ----------------------------------------------------------------------
15:26:41 Traceback (most recent call last):
15:26:41   File "C:/tf_jenkins/home/workspace/tensorflow-master-win-cmake-py/tensorflow/python/kernel_tests/matrix_solve_op_test.py", line 102, in testEmpty
15:26:41     self._verifySolve(np.empty([2, 2]), np.empty([2, 0]))
15:26:41   File "C:/tf_jenkins/home/workspace/tensorflow-master-win-cmake-py/tensorflow/python/kernel_tests/matrix_solve_op_test.py", line 48, in _verifySolve
15:26:41     np_ans = np.linalg.solve(a_np, b)
15:26:41   File "C:\Program Files\Anaconda3\lib\site-packages\numpy\linalg\linalg.py", line 375, in solve
15:26:41     r = gufunc(a, b, signature=signature, extobj=extobj)
15:26:41   File "C:\Program Files\Anaconda3\lib\site-packages\numpy\linalg\linalg.py", line 90, in _raise_linalgerror_singular
15:26:41     raise LinAlgError("Singular matrix")
15:26:41 numpy.linalg.linalg.LinAlgError: Singular matrix
```