### PR TITLE
Disable stage_op_test and map_stage_op_test due to timeouts

### DIFF
--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -2378,7 +2378,7 @@ cuda_py_test(
 
 cuda_py_test(
     name = "stage_op_test",
-    size = "large",
+    size = "medium",
     srcs = ["stage_op_test.py"],
     additional_deps = [
         "//tensorflow/python:array_ops",
@@ -2388,11 +2388,12 @@ cuda_py_test(
         "//tensorflow/python:util",
         "//tensorflow/python:data_flow_ops",
     ],
+    tags = ["manual"],  # http://b/62429636
 )
 
 cuda_py_test(
     name = "map_stage_op_test",
-    size = "large",
+    size = "medium",
     srcs = ["map_stage_op_test.py"],
     additional_deps = [
         "//tensorflow/python:array_ops",
@@ -2402,6 +2403,7 @@ cuda_py_test(
         "//tensorflow/python:util",
         "//tensorflow/python:data_flow_ops",
     ],
+    tags = ["manual"],  # http://b/62429636
 )
 
 cuda_py_test(


### PR DESCRIPTION
For example:
http://ci.tensorflow.org/job/tensorflow-master-linux-gpu/2381/console

Also reverted the size to medium, since switching to large didn't fix the issue.