### PR TITLE
np.float64("np.inf").astype(np.int32) is negative on x86 but positive on ppc64le

### DIFF
--- a/tensorflow/core/platform/profile_utils/cpu_utils.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.cc
@@ -28,8 +28,8 @@ namespace profile_utils {
 
 static ICpuUtilsHelper* cpu_utils_helper_instance_ = nullptr;
 
-/* static */ int64 CpuUtils::GetCycleCounterFrequency() {
-  static const int64 cpu_frequency = GetCycleCounterFrequencyImpl();
+/* static */ uint64 CpuUtils::GetCycleCounterFrequency() {
+  static const uint64 cpu_frequency = GetCycleCounterFrequencyImpl();
   return cpu_frequency;
 }
 
@@ -53,7 +53,7 @@ static ICpuUtilsHelper* cpu_utils_helper_instance_ = nullptr;
                                        GetCycleCounterFrequency());
 }
 
-/* static */ int64 CpuUtils::GetCycleCounterFrequencyImpl() {
+/* static */ uint64 CpuUtils::GetCycleCounterFrequencyImpl() {
 // TODO(satok): do not switch by macro here
 #if defined(__ANDROID__)
   return GetCpuUtilsHelperSingletonInstance().CalculateCpuFrequency();

--- a/tensorflow/core/platform/profile_utils/cpu_utils.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.cc
@@ -60,7 +60,7 @@ static ICpuUtilsHelper* cpu_utils_helper_instance_ = nullptr;
                                        GetCycleCounterFrequency());
 }
 
-/* static */ uint64 CpuUtils::GetCycleCounterFrequencyImpl() {
+/* static */ int64 CpuUtils::GetCycleCounterFrequencyImpl() {
 // TODO(satok): do not switch by macro here
 #if defined(__ANDROID__)
   return GetCpuUtilsHelperSingletonInstance().CalculateCpuFrequency();

--- a/tensorflow/core/platform/profile_utils/cpu_utils.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.cc
@@ -28,7 +28,7 @@ namespace profile_utils {
 
 static ICpuUtilsHelper* cpu_utils_helper_instance_ = nullptr;
 
-#if defined(__powerpc__) || defined(__ppc__)
+#if defined(__powerpc__) || defined(__ppc__) && ( __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
    /* static */ uint64 CpuUtils::GetCycleCounterFrequency() {
      static const uint64 cpu_frequency = GetCycleCounterFrequencyImpl();
      return cpu_frequency;

--- a/tensorflow/core/platform/profile_utils/cpu_utils.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.cc
@@ -28,10 +28,17 @@ namespace profile_utils {
 
 static ICpuUtilsHelper* cpu_utils_helper_instance_ = nullptr;
 
-/* static */ uint64 CpuUtils::GetCycleCounterFrequency() {
-  static const uint64 cpu_frequency = GetCycleCounterFrequencyImpl();
-  return cpu_frequency;
+#if defined(__powerpc__) || defined(__ppc__)
+   /* static */ uint64 CpuUtils::GetCycleCounterFrequency() {
+     static const uint64 cpu_frequency = GetCycleCounterFrequencyImpl();
+     return cpu_frequency;
 }
+#else
+   /* static */ int64 CpuUtils::GetCycleCounterFrequency() {
+     static const int64 cpu_frequency = GetCycleCounterFrequencyImpl();
+     return cpu_frequency;
+}
+#endif
 
 /* static */ double CpuUtils::GetMicroSecPerClock() {
   static const double micro_sec_per_clock =

--- a/tensorflow/core/platform/profile_utils/cpu_utils.h
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.h
@@ -97,7 +97,11 @@ class CpuUtils {
   // Return cycle counter frequency.
   // As this method caches the cpu frequency internally,
   // the first call will incur overhead, but not subsequent calls.
-  static uint64 GetCycleCounterFrequency();
+  #if defined(__powerpc__) || defined(__ppc__)
+     static uint64 GetCycleCounterFrequency();
+  #else
+     static int64 GetCycleCounterFrequency();
+  #endif
 
   // Return micro secound per each clock
   // As this method caches the cpu frequency internally,

--- a/tensorflow/core/platform/profile_utils/cpu_utils.h
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.h
@@ -97,7 +97,7 @@ class CpuUtils {
   // Return cycle counter frequency.
   // As this method caches the cpu frequency internally,
   // the first call will incur overhead, but not subsequent calls.
-  static int64 GetCycleCounterFrequency();
+  static uint64 GetCycleCounterFrequency();
 
   // Return micro secound per each clock
   // As this method caches the cpu frequency internally,
@@ -134,7 +134,7 @@ class CpuUtils {
   // CAVEAT: as this method calls system call and parse the mssage,
   // this call may be slow. This is why this class caches the value by
   // StaticVariableInitializer.
-  static int64 GetCycleCounterFrequencyImpl();
+  static uint64 GetCycleCounterFrequencyImpl();
 
   // Return a singleton of ICpuUtilsHelper
   // ICpuUtilsHelper is declared as a function-local static variable

--- a/tensorflow/core/platform/profile_utils/cpu_utils.h
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.h
@@ -97,7 +97,7 @@ class CpuUtils {
   // Return cycle counter frequency.
   // As this method caches the cpu frequency internally,
   // the first call will incur overhead, but not subsequent calls.
-  #if defined(__powerpc__) || defined(__ppc__)
+  #if defined(__powerpc__) || defined(__ppc__) && ( __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
      static uint64 GetCycleCounterFrequency();
   #else
      static int64 GetCycleCounterFrequency();

--- a/tensorflow/core/platform/profile_utils/cpu_utils.h
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.h
@@ -138,7 +138,7 @@ class CpuUtils {
   // CAVEAT: as this method calls system call and parse the mssage,
   // this call may be slow. This is why this class caches the value by
   // StaticVariableInitializer.
-  static uint64 GetCycleCounterFrequencyImpl();
+  static int64 GetCycleCounterFrequencyImpl();
 
   // Return a singleton of ICpuUtilsHelper
   // ICpuUtilsHelper is declared as a function-local static variable

--- a/tensorflow/core/platform/profile_utils/cpu_utils_test.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils_test.cc
@@ -53,9 +53,9 @@ TEST_F(CpuUtilsTest, CheckGetCurrentClockCycle) {
 }
 
 TEST_F(CpuUtilsTest, CheckCycleCounterFrequency) {
-  const int64 cpu_frequency = CpuUtils::GetCycleCounterFrequency();
+  const uint64 cpu_frequency = CpuUtils::GetCycleCounterFrequency();
   CHECK_GT(cpu_frequency, 0);
-  CHECK_NE(cpu_frequency, CpuUtils::INVALID_FREQUENCY);
+  CHECK_NE(cpu_frequency, unsigned(CpuUtils::INVALID_FREQUENCY));
   if (DBG) {
     LOG(INFO) << "Cpu frequency = " << cpu_frequency;
   }

--- a/tensorflow/core/platform/profile_utils/cpu_utils_test.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils_test.cc
@@ -53,9 +53,15 @@ TEST_F(CpuUtilsTest, CheckGetCurrentClockCycle) {
 }
 
 TEST_F(CpuUtilsTest, CheckCycleCounterFrequency) {
-  const uint64 cpu_frequency = CpuUtils::GetCycleCounterFrequency();
-  CHECK_GT(cpu_frequency, 0);
-  CHECK_NE(cpu_frequency, unsigned(CpuUtils::INVALID_FREQUENCY));
+  #if defined(__powerpc__) || defined(__ppc__)
+     const uint64 cpu_frequency = CpuUtils::GetCycleCounterFrequency();
+     CHECK_GT(cpu_frequency, 0);
+     CHECK_NE(cpu_frequency, unsigned(CpuUtils::INVALID_FREQUENCY));
+  #else
+     const int64 cpu_frequency = CpuUtils::GetCycleCounterFrequency();
+     CHECK_GT(cpu_frequency, 0);
+     CHECK_NE(cpu_frequency, CpuUtils::INVALID_FREQUENCY);
+  #endif
   if (DBG) {
     LOG(INFO) << "Cpu frequency = " << cpu_frequency;
   }

--- a/tensorflow/core/platform/profile_utils/cpu_utils_test.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils_test.cc
@@ -53,7 +53,7 @@ TEST_F(CpuUtilsTest, CheckGetCurrentClockCycle) {
 }
 
 TEST_F(CpuUtilsTest, CheckCycleCounterFrequency) {
-  #if defined(__powerpc__) || defined(__ppc__)
+  #if defined(__powerpc__) || defined(__ppc__) && ( __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
      const uint64 cpu_frequency = CpuUtils::GetCycleCounterFrequency();
      CHECK_GT(cpu_frequency, 0);
      CHECK_NE(cpu_frequency, unsigned(CpuUtils::INVALID_FREQUENCY));

--- a/tensorflow/python/kernel_tests/cast_op_test.py
+++ b/tensorflow/python/kernel_tests/cast_op_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import numpy as np
 import sys
+import platform
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
@@ -146,9 +147,16 @@ class CastOpTest(test.TestCase):
     if sys.byteorder == "big":  
       self._compare(np.inf, np.int32, i4.max, False)  
       self._compare(np.inf, np.int64, i8.max, False)  
-    else:  
-      self._compare(np.inf, np.int32, i4.min, False)  
-      self._compare(np.inf, np.int64, i8.min, False)  
+    else:
+      #np.float64("np.inf").astype(np.int32) is negative on x86 but positive on ppc64le
+      #Numpy link to relevant discussion - https://github.com/numpy/numpy/issues/9040
+      #Tensorflow link to relevant discussion - https://github.com/tensorflow/tensorflow/issues/9360
+      if platform.machine() == "ppc64le":
+        self._compare(-np.inf, np.int32, i4.min, False)
+        self._compare(-np.inf, np.int64, i8.min, False)
+      else:
+        self._compare(np.inf, np.int32, i4.min, False)
+        self._compare(np.inf, np.int64, i8.min, False)  
     self._compare(-np.inf, np.float32, -np.inf, False)
     self._compare(-np.inf, np.float64, -np.inf, False)
     self._compare(-np.inf, np.int32, i4.min, False)

--- a/tensorflow/python/kernel_tests/cast_op_test.py
+++ b/tensorflow/python/kernel_tests/cast_op_test.py
@@ -148,9 +148,9 @@ class CastOpTest(test.TestCase):
       self._compare(np.inf, np.int32, i4.max, False)  
       self._compare(np.inf, np.int64, i8.max, False)  
     else:
-      #np.float64("np.inf").astype(np.int32) is negative on x86 but positive on ppc64le
-      #Numpy link to relevant discussion - https://github.com/numpy/numpy/issues/9040
-      #Tensorflow link to relevant discussion - https://github.com/tensorflow/tensorflow/issues/9360
+      # np.float64("np.inf").astype(np.int32) is negative on x86 but positive on ppc64le
+      # Numpy link to relevant discussion - https://github.com/numpy/numpy/issues/9040
+      # Tensorflow link to relevant discussion - https://github.com/tensorflow/tensorflow/issues/9360
       if platform.machine() == "ppc64le":
         self._compare(-np.inf, np.int32, i4.min, False)
         self._compare(-np.inf, np.int64, i8.min, False)


### PR DESCRIPTION
- np.float64("np.inf").astype(np.int32) is negative on x86 but positive on ppc64le, that is the reason we 
  added this special case for ppc64le

- Discussed with numpy community and they mentioned as follows -
1) Doing this cast incurs undefined behaviour, so it's hard to say which platform is incorrect here.
    I'd argue that we should just issue a warning and leave the platform-specific behaviour.
2) This is also true of any C program that tries to cast float to int. If the author of a python package 
    included a C extension that does this cast, they still have the problem. 
   The same argument you use for "we should fix this is numpy, not in the user package" can be 
    applied to "we should fix this in C, not in numpy". Presumably for speed reasons, that argument was 
    rejected during the  design of C.
    Having said that, we already diverge from C behaviour in some place (eg, integer promotion for 
    arithmetic and comparison), so it wouldn't be unreasonable  to add special casing here.
    
Numpy link to relevant discussion - https://github.com/numpy/numpy/issues/9040
Also discussed this on Tensorflow , link to relevant discussion - https://github.com/tensorflow/tensorflow/issues/9360
