### PR TITLE
Re-enable some python tests in Windows Bazel build

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -809,7 +809,6 @@ py_test(
     srcs = ["framework/meta_graph_test.py"],
     main = "framework/meta_graph_test.py",
     srcs_version = "PY2AND3",
-    tags = ["no_windows"],
     deps = [
         ":array_ops",
         ":client_testlib",
@@ -2182,7 +2181,6 @@ cuda_py_test(
         ":test_ops",
         "//third_party/py/numpy",
     ],
-    tags = ["no_windows"],
 )
 
 cuda_py_test(
@@ -2917,7 +2915,6 @@ cuda_py_test(
         ":variables",
         "//third_party/py/numpy",
     ],
-    tags = ["no_windows"],
 )
 
 tf_py_test(
@@ -2932,7 +2929,6 @@ tf_py_test(
         ":training",
         ":variables",
     ],
-    tags = ["no_windows"],
 )
 
 py_library(
@@ -3237,7 +3233,6 @@ cuda_py_test(
         "@six_archive//:six",
         "//tensorflow/core:protos_all_py",
     ],
-    tags = ["no_windows"],
 )
 
 py_test(

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -799,7 +799,6 @@ tf_py_test(
         "//tensorflow/python:logging_ops",
         "//tensorflow/python:summary",
     ],
-    tags = ["no_windows"],
 )
 
 tf_py_test(
@@ -2144,7 +2143,6 @@ cuda_py_test(
         "//tensorflow/python:nn_grad",
         "//tensorflow/python:nn_ops",
     ],
-    tags = ["no_windows"],
 )
 
 tf_py_test(
@@ -2632,7 +2630,6 @@ tf_py_test(
         "//tensorflow/python:sets",
         "//tensorflow/python:sparse_ops",
     ],
-    tags = ["no_windows"],
 )
 
 tf_py_test(


### PR DESCRIPTION
```
//py_test_dir/tensorflow/python:framework_meta_graph_test                PASSED in 7.2s
//py_test_dir/tensorflow/python:gradients_test                           PASSED in 14.6s
//py_test_dir/tensorflow/python/kernel_tests:depthwise_conv_op_test      PASSED in 32.1s
//py_test_dir/tensorflow/python/kernel_tests:sets_test                   PASSED in 21.1s
//py_test_dir/tensorflow/python/kernel_tests:summary_ops_test            PASSED in 5.5s
//py_test_dir/tensorflow/python:localhost_cluster_performance_test       PASSED in 6.4s
//py_test_dir/tensorflow/python:saver_test                               PASSED in 40.1s
//py_test_dir/tensorflow/python:sync_replicas_optimizer_test             PASSED in 12.8s
```

These tests are passing on Windows and not flaky.