### PR TITLE
Make stage tests less sensitive to timeouts

### DIFF
--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -2382,11 +2382,6 @@ cuda_py_test(
         "//tensorflow/python:util",
         "//tensorflow/python:data_flow_ops",
     ],
-    tags = [
-        "manual",  # http://b/62429636
-        "noguitar",
-        "notap",
-    ],
 )
 
 cuda_py_test(
@@ -2400,11 +2395,6 @@ cuda_py_test(
         "//tensorflow/python:math_ops",
         "//tensorflow/python:util",
         "//tensorflow/python:data_flow_ops",
-    ],
-    tags = [
-        "manual",  # http://b/62429636
-        "noguitar",
-        "notap",
     ],
 )
 


### PR DESCRIPTION
Previously, staging tests used the number of failed token dequeues (with 50 ms timeouts) on
a signalling queue to indicate blocked puts. This was probably too sensitive on highly contended testing systems. Basically, there's no good way to distinguish between a put that took too long and a blocking put.

Staging tests now simply count the number of iterations before a timeout of 1s occurs on the signalling queue. This should mean that:

1. The test case is less brittle around what is considered a block vs  the putting thread not being able to keep up.
2. Both stage_op_test and map_stage_op_test take slightly longer, ~2.5s vs ~1s, to run on an uncontended system..

Also simplified the tests cases in general.

/cc @ekelsen @jhseu I saw #10516 and the duration of test runs (~30s on your test systems vs ~1s on my laptop) made me reconsider the duration on the blocking timeout. I've upped it 20X from 50ms to 1s.

In an ideal world, the test cases wouldn't depend on a timeout when running -- if you can suggest a different method of testing blocking puts and gets, please let me know.

I also relooked at the multi-threaded code in the StagingArea, but I think the standard producer/consumer queue has been implemented correctly.

I hope this helps.