### PR TITLE
[Bash] Prefer read -a to split exit codes

### DIFF
--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -463,7 +463,7 @@ while [[ ${COUNTER} -lt "${#SANITY_STEPS[@]}" ]]; do
     ((PASS_COUNTER++))
   fi
 
-  STEP_EXIT_CODES+=(${RESULT})
+  IFS=" " read -r -a STEP_EXIT_CODES <<< "${RESULT}"
 
   echo ""
   ((COUNTER++))


### PR DESCRIPTION
As proposed by static analysis tool:
https://github.com/koalaman/shellcheck/wiki/SC2206