### PR TITLE
Fix AttributeError in resnet.py

### DIFF
--- a/tensorflow/examples/learn/resnet.py
+++ b/tensorflow/examples/learn/resnet.py
@@ -145,7 +145,7 @@ def res_net(x, y, activation=tf.nn.relu):
   target = tf.one_hot(y, depth=10, dtype=tf.float32)
   logits = tf.contrib.layers.fully_connected(net, 10, activation_fn=None)
   loss = tf.losses.softmax_cross_entropy(target, logits)
-  return tf.softmax(logits), loss
+  return tf.nn.softmax(logits), loss
 
 
 def res_net_model(x, y):


### PR DESCRIPTION
There is no function tf.softmax() in Tensorflow 1.x.

When running the old code, Python interpreter complains:

File "resnet.py", line 152, in res_net_model
prediction, loss = res_net(x, y)
File "resnet.py", line 148, in res_net
return tf.softmax(logits), loss
AttributeError: 'module' object has no attribute 'softmax'