### PR TITLE
Changed default `evalution_master` to also use cluster information

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/run_config.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/run_config.py
@@ -152,7 +152,9 @@ class ClusterConfig(object):
       self._is_chief = (self._task_type == TaskType.WORKER and
                         self._task_id == 0)
 
-    self._evaluation_master = evaluation_master or ''
+    self._evaluation_master = (evaluation_master if evaluation_master is not None else
+                    _get_master(self._cluster_spec, self._task_type,
+                                self._task_id) or '')
 
   @property
   def cluster_spec(self):
@@ -230,7 +232,7 @@ class RunConfig(ClusterConfig, core_run_config.RunConfig):
                save_checkpoints_steps=None,
                keep_checkpoint_max=5,
                keep_checkpoint_every_n_hours=10000,
-               evaluation_master='',
+               evaluation_master=None,
                model_dir=None,
                session_config=None):
     """Constructor.


### PR DESCRIPTION
When using the standard Estimator during evaluation in distributed setting (a `cluster_spec` was supplied) I encountered the following error message:

```
InvalidArgumentError (see above for traceback): Cannot assign a device for operation 
'save/RestoreV2_28': Operation was explicitly assigned to 
/job:ps/replica:0/task:0/device:CPU:0 but available devices are
[ /job:localhost/replica:0/task:0/cpu:0, /job:localhost/replica:0/task:0/gpu:0 ]. 
Make sure the device specification refers to a valid device.
```
```
[[Node: save/RestoreV2_28 = RestoreV2[dtypes=[DT_FLOAT], 
_device="/job:ps/replica:0/task:0/device:CPU:0"](save/Const, save/RestoreV2_28/tensor_names, 
save/ResyoreV2_28/shape_and_slices)]]
```
In short:
The evaluation graph is looking for Variables on ` /job:localhost` but they are on ` /job:ps`, as is intended. 

To fix this I changed the default settings of placing the `evaluation_master` on `localhost` to the same as for `master`. This means that when instancing a RunConfig with no `evaluation_master` given it will check if there is a `cluster_spec`. If so it will get the `evaluation_master` based on the `cluster_spec`. 

This fixes the problem for me and leads to correct behaviour.