### PR TITLE
Sort out confusion around usage of selective registration

### DIFF
--- a/tensorflow/python/tools/print_selective_registration_header.py
+++ b/tensorflow/python/tools/print_selective_registration_header.py
@@ -28,7 +28,7 @@ When compiling for Android:
     --copt="-DSUPPORT_SELECTIVE_REGISTRATION" \
     //tensorflow/contrib/android:libtensorflow_inference.so \
     --host_crosstool_top=@bazel_tools//tools/cpp:toolchain \
-    --config=android_arm
+    --crosstool_top=//external:android/crosstool --cpu=armeabi-v7a
 """
 
 from __future__ import absolute_import


### PR DESCRIPTION
`--config=android_arm` is defined in [`tensorflow/BUILD`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/BUILD)
where it resolved to `--crosstool_top=//external:android/crosstool --cpu=armeabi-v7a`
seems like this cannot be referenced here