### PR TITLE
[WIP] Multi-bus support with NUMA-aware allocator

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device_factory.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_factory.cc
@@ -42,7 +42,8 @@ class GPUDevice : public BaseGPUDevice {
     if (attr.on_host()) {
       if (attr.gpu_compatible() || force_gpu_compatible_) {
         ProcessState* ps = ProcessState::singleton();
-        return ps->GetCUDAHostAllocator(0);
+        int numa_node = executor()->GetDeviceDescription().numa_node();
+        return ps->GetCUDAHostAllocator(numa_node);
       } else {
         return cpu_allocator_;
       }

--- a/tensorflow/core/common_runtime/gpu/process_state.cc
+++ b/tensorflow/core/common_runtime/gpu/process_state.cc
@@ -152,11 +152,7 @@ Allocator* ProcessState::GetGPUAllocator(const GPUOptions& options, int gpu_id,
 }
 
 Allocator* ProcessState::GetCPUAllocator(int numa_node) {
-  // Although we're temporarily ignoring numa_node, check for legality.
   CHECK_GE(numa_node, 0);
-  // TODO(tucker): actually maintain separate CPUAllocators for
-  // different numa_nodes.  For now, just one.
-  numa_node = 0;
   mutex_lock lock(mu_);
   while (cpu_allocators_.size() <= static_cast<size_t>(numa_node)) {
     bool use_bfc_allocator = false;
@@ -196,18 +192,14 @@ Allocator* ProcessState::GetCPUAllocator(int numa_node) {
     }
     cpu_allocators_.push_back(allocator);
   }
-  return cpu_allocators_[0];
+  return cpu_allocators_[numa_node];
 }
 
 Allocator* ProcessState::GetCUDAHostAllocator(int numa_node) {
   if (!HasGPUDevice() || !FLAGS_brain_mem_reg_cuda_dma) {
     return cpu_allocator();
   }
-  // Although we're temporarily ignoring numa_node, check for legality.
   CHECK_GE(numa_node, 0);
-  // TODO(tucker): actually maintain separate CPUAllocators for
-  // different numa_nodes.  For now, just one.
-  numa_node = 0;
   mutex_lock lock(mu_);
 
   // Find the first valid StreamExecutor to request CUDA host memory

--- a/tensorflow/core/common_runtime/gpu/process_state.cc
+++ b/tensorflow/core/common_runtime/gpu/process_state.cc
@@ -249,8 +249,8 @@ Allocator* ProcessState::GetCUDAHostAllocator(int numa_node) {
           &mem_desc_map_, cuda_host_allocators_.back(), md, &mu_));
     }
   }
-  if (FLAGS_brain_gpu_record_mem_types) return cuda_al_[0];
-  return cuda_host_allocators_[0];
+  if (FLAGS_brain_gpu_record_mem_types) return cuda_al_[numa_node];
+  return cuda_host_allocators_[numa_node];
 }
 
 void ProcessState::AddGPUAllocVisitor(int bus_id, AllocVisitor visitor) {

--- a/tensorflow/core/common_runtime/gpu/process_state.h
+++ b/tensorflow/core/common_runtime/gpu/process_state.h
@@ -71,7 +71,6 @@ class ProcessState {
   MemDesc PtrType(const void* ptr);
 
   // Returns the one CPUAllocator used for the given numa_node.
-  // TEMPORARY: ignores numa_node.
   Allocator* GetCPUAllocator(int numa_node);
 
   // Returns the one GPU allocator used for the indexed GPU.


### PR DESCRIPTION
As the title suggests, this is a WIP to partially address issues brought by @poxvoculi in #5986. 

In our testbed, we have a multi-bus topology where 4 K40m GPUs are connected by different PCI-e root, as shown with the following command:

```
$ nvidia-smi topo -m
	GPU0	GPU1	GPU2	GPU3	mlx4_0	CPU Affinity
GPU0	 X 	PHB	SOC	SOC	SOC	0-5
GPU1	PHB	 X 	SOC	SOC	SOC	0-5
GPU2	SOC	SOC	 X 	PHB	PHB	6-11
GPU3	SOC	SOC	PHB	 X 	PHB	6-11
mlx4_0	SOC	SOC	PHB	PHB	 X

Legend:

  X   = Self
  SOC  = Connection traversing PCIe as well as the SMP link between CPU sockets(e.g. QPI)
  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
  PXB  = Connection traversing multiple PCIe switches (without traversing the PCIe Host Bridge)
  PIX  = Connection traversing a single PCIe switch
  NV#  = Connection traversing a bonded set of # NVLinks
```

Current TF always allocates the host memory used to transfer from/to GPU on NUMA node 0, which is sub-optimal for GPUs with other CPU affinity. This could be further validated by adjusting `CUDA_VISIBLE_DEVICES` and `numactl -m <numa_node> -N <numa_node>` prepended to TF process.

The basic idea is simple: use ``numa_alloc_onnode`` and other related functions available in [libnuma](https://linux.die.net/man/3/numa) to allocate memory for CUDA host allocator. There are some pieces of code, e.g. [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/common_runtime/gpu/gpu_device.cc#L669), [there](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc#L951), and [there](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc#L855) to identify bus id and numa node for each device, and I plan to reuse those as much as possible.

I am wondering if anyone in the TF team could give me some advice so I can start to implement it.