### PR TITLE
Add link that helps explain feed_dict parameter

### DIFF
--- a/tensorflow/docs_src/get_started/get_started.md
+++ b/tensorflow/docs_src/get_started/get_started.md
@@ -139,7 +139,8 @@ adder_node = a + b  # + provides a shortcut for tf.add(a, b)
 The preceding three lines are a bit like a function or a lambda in which we
 define two input parameters (a and b) and then an operation on them. We can
 evaluate this graph with multiple inputs by using the feed_dict parameter to
-specify Tensors that provide concrete values to these placeholders:
+the [run operation](https://www.tensorflow.org/api_docs/python/tf/Session#run)
+to specify Tensors that provide concrete values to these placeholders:
 
 ```python
 print(sess.run(adder_node, {a: 3, b:4.5}))

--- a/tensorflow/docs_src/get_started/get_started.md
+++ b/tensorflow/docs_src/get_started/get_started.md
@@ -138,9 +138,9 @@ adder_node = a + b  # + provides a shortcut for tf.add(a, b)
 
 The preceding three lines are a bit like a function or a lambda in which we
 define two input parameters (a and b) and then an operation on them. We can
-evaluate this graph with multiple inputs by using the feed_dict parameter to
-the [run operation](https://www.tensorflow.org/api_docs/python/tf/Session#run)
-to specify Tensors that provide concrete values to these placeholders:
+evaluate this graph with multiple inputs by using the feed_dict argument to
+the [run method](https://www.tensorflow.org/api_docs/python/tf/Session#run)
+to feed concrete values to the placeholders:
 
 ```python
 print(sess.run(adder_node, {a: 3, b:4.5}))


### PR DESCRIPTION
The current tutorial mentions using feed_dict parameter, but there is not further mention.  The example code does not explain where feed_dict is used.  By linking to the run documentation, the reader can see it is the second parameter to the run command.