### PR TITLE
Fix incorrect references of `tf.learn` -> `tf.contrib.learn`

### DIFF
--- a/tensorflow/docs_src/tutorials/linear.md
+++ b/tensorflow/docs_src/tutorials/linear.md
@@ -1,23 +1,23 @@
 # Large-scale Linear Models with TensorFlow
 
-The tf.learn API provides (among other things) a rich set of tools for working
+The tf.contrib.learn API provides (among other things) a rich set of tools for working
 with linear models in TensorFlow. This document provides an overview of those
 tools. It explains:
 
    * what a linear model is.
    * why you might want to use a linear model.
-   * how tf.learn makes it easy to build linear models in TensorFlow.
-   * how you can use tf.learn to combine linear models with
+   * how tf.contrib.learn makes it easy to build linear models in TensorFlow.
+   * how you can use tf.contrib.learn to combine linear models with
    deep learning to get the advantages of both.
 
-Read this overview to decide whether the tf.learn linear model tools might be
+Read this overview to decide whether the tf.contrib.learn linear model tools might be
 useful to you. Then do the @{$wide$Linear Models tutorial} to
 give it a try. This overview uses code samples from the tutorial, but the
 tutorial walks through the code in greater detail.
 
 To understand this overview it will help to have some familiarity
 with basic machine learning concepts, and also with
-@{$tflearn$tf.learn}.
+@{$tflearn$tf.contrib.learn}.
 
 [TOC]
 
@@ -52,16 +52,16 @@ Linear models:
    * provide an excellent starting point for learning about machine learning.
    * are widely used in industry.
 
-## How does tf.learn help you build linear models?
+## How does tf.contrib.learn help you build linear models?
 
 You can build a linear model from scratch in TensorFlow without the help of a
-special API. But tf.learn provides some tools that make it easier to build
+special API. But tf.contrib.learn provides some tools that make it easier to build
 effective large-scale linear models.
 
 ### Feature columns and transformations
 
 Much of the work of designing a linear model consists of transforming raw data
-into suitable input features. tf.learn uses the `FeatureColumn` abstraction to
+into suitable input features. tf.contrib.learn uses the `FeatureColumn` abstraction to
 enable these transformations.
 
 A `FeatureColumn` represents a single feature in your data. A `FeatureColumn`
@@ -86,9 +86,9 @@ become [0, 1, 0] and 'green' would become [0, 0, 1]. These vectors are called
 "sparse" because they may be very long, with many zeros, when the set of
 possible values is very large (such as all English words).
 
-While you don't need to use sparse columns to use tf.learn linear models, one
+While you don't need to use sparse columns to use tf.contrib.learn linear models, one
 of the strengths of linear models is their ability to deal with large sparse
-vectors. Sparse features are a primary use case for the tf.learn linear model
+vectors. Sparse features are a primary use case for the tf.contrib.learn linear model
 tools.
 
 ##### Encoding sparse columns
@@ -148,7 +148,7 @@ age = tf.contrib.layers.real_valued_column("age")
 ```
 
 Although, as a single real number, a continuous feature can often be input
-directly into the model, tf.learn offers useful transformations for this sort
+directly into the model, tf.contrib.learn offers useful transformations for this sort
 of column as well.
 
 ##### Bucketization
@@ -187,7 +187,7 @@ initiate training and testing, as described in the next section.
 
 ### Linear estimators
 
-tf.learn's estimator classes provide a unified training and evaluation harness
+tf.contrib.learn's estimator classes provide a unified training and evaluation harness
 for regression and classification models. They take care of the details of the
 training and evaluation loops and allow the user to focus on model inputs and
 architecture.
@@ -197,7 +197,7 @@ To build a linear estimator, you can use either the
 `tf.contrib.learn.LinearRegressor` estimator, for classification and
 regression respectively.
 
-As with all tf.learn estimators, to run the estimator you just:
+As with all tf.contrib.learn estimators, to run the estimator you just:
 
    1. Instantiate the estimator class. For the two linear estimator classes,
    you pass a list of `FeatureColumn`s to the constructor.
@@ -222,7 +222,7 @@ for key in sorted(results):
 
 ### Wide and deep learning
 
-The tf.learn API also provides an estimator class that lets you jointly train
+The tf.contrib.learn API also provides an estimator class that lets you jointly train
 a linear model and a deep neural network. This novel approach combines the
 ability of linear models to "memorize" key features with the generalization
 ability of neural nets. Use `tf.contrib.learn.DNNLinearCombinedClassifier` to

--- a/tensorflow/docs_src/tutorials/wide.md
+++ b/tensorflow/docs_src/tutorials/wide.md
@@ -1,6 +1,6 @@
 # TensorFlow Linear Model Tutorial
 
-In this tutorial, we will use the TF.Learn API in TensorFlow to solve a binary
+In this tutorial, we will use the tf.contrib.learn API in TensorFlow to solve a binary
 classification problem: Given census data about a person such as age, gender,
 education and occupation (the features), we will try to predict whether or not
 the person earns more than 50,000 dollars a year (the target label). We will
@@ -16,7 +16,7 @@ To try the code for this tutorial:
 
 2.  Download [the tutorial code](https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py).
 
-3.  Install the pandas data analysis library. tf.learn doesn't require pandas, but it does support it, and this tutorial uses pandas. To install pandas:
+3.  Install the pandas data analysis library. tf.contrib.learn doesn't require pandas, but it does support it, and this tutorial uses pandas. To install pandas:
 
     a. Get `pip`:
 
@@ -136,9 +136,9 @@ Here's a list of columns available in the Census Income dataset:
 
 ## Converting Data into Tensors
 
-When building a TF.Learn model, the input data is specified by means of an Input
+When building a tf.contrib.learn model, the input data is specified by means of an Input
 Builder function. This builder function will not be called until it is later
-passed to TF.Learn methods such as `fit` and `evaluate`. The purpose of this
+passed to tf.contrib.learn methods such as `fit` and `evaluate`. The purpose of this
 function is to construct the input data, which is represented in the form of
 @{tf.Tensor}s
 or
@@ -211,7 +211,7 @@ to predict the target label.
 ### Base Categorical Feature Columns
 
 To define a feature column for a categorical feature, we can create a
-`SparseColumn` using the TF.Learn API. If you know the set of all possible
+`SparseColumn` using the tf.contrib.learn API. If you know the set of all possible
 feature values of a column and there are only a few of them, you can use
 `sparse_column_with_keys`. Each key in the list will get assigned an
 auto-incremental ID starting from 0. For example, for the `gender` column we can
@@ -361,7 +361,7 @@ in `model_dir`.
 ## Training and Evaluating Our Model
 
 After adding all the features to the model, now let's look at how to actually
-train the model. Training a model is just a one-liner using the TF.Learn API:
+train the model. Training a model is just a one-liner using the tf.contrib.learn API:
 
 ```python
 m.fit(input_fn=train_input_fn, steps=200)
@@ -467,4 +467,4 @@ value would be high.
 
 If you're interested in learning more, check out our @{$wide_and_deep$Wide & Deep Learning Tutorial} where we'll show you how to combine
 the strengths of linear models and deep neural networks by jointly training them
-using the TF.Learn API.
+using the tf.contrib.learn API.

--- a/tensorflow/docs_src/tutorials/wide_and_deep.md
+++ b/tensorflow/docs_src/tutorials/wide_and_deep.md
@@ -9,7 +9,7 @@ great for training deep neural networks too, and you might be thinking which one
 you should choose—Well, why not both? Would it be possible to combine the
 strengths of both in one model?
 
-In this tutorial, we'll introduce how to use the TF.Learn API to jointly train a
+In this tutorial, we'll introduce how to use the tf.contrib.learn API to jointly train a
 wide linear model and a deep feed-forward neural network. This approach combines
 the strengths of memorization and generalization. It's useful for generic
 large-scale regression and classification problems with sparse input features
@@ -23,7 +23,7 @@ The figure above shows a comparison of a wide model (logistic regression with
 sparse features and transformations), a deep model (feed-forward neural network
 with an embedding layer and several hidden layers), and a Wide & Deep model
 (joint training of both). At a high level, there are only 3 steps to configure a
-wide, deep, or Wide & Deep model using the TF.Learn API:
+wide, deep, or Wide & Deep model using the tf.contrib.learn API:
 
 1.  Select features for the wide part: Choose the sparse base columns and
     crossed columns you want to use.
@@ -42,7 +42,7 @@ To try the code for this tutorial:
 
 2.  Download [the tutorial code](https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py).
 
-3.  Install the pandas data analysis library. tf.learn doesn't require pandas, but it does support it, and this tutorial uses pandas. To install pandas:
+3.  Install the pandas data analysis library. tf.contrib.learn doesn't require pandas, but it does support it, and this tutorial uses pandas. To install pandas:
 
     a. Get `pip`:
 


### PR DESCRIPTION
This fix fixes the incorrect references in docs (`linear.md`) where `tf.learn` was used (should be `tf.contrib.learn`).

This fix fixes #8718.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>