### PR TITLE
Add jni methods to support creating string Tensors from string bytes

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
@@ -618,6 +618,12 @@ public final class Tensor implements AutoCloseable {
 
   private static native byte[] scalarBytes(long handle);
 
+  private static native int getEncodedStringSize(int numStringBytes);
+
+  private static native int setStringBytes(byte[] value, ByteBuffer buffer);
+
+  private static native byte[] getStringBytes(ByteBuffer buffer);
+
   private static native void readNDArray(long handle, Object value);
 
   static {

--- a/tensorflow/java/src/main/native/tensor_jni.h
+++ b/tensorflow/java/src/main/native/tensor_jni.h
@@ -141,6 +141,31 @@ JNIEXPORT jbyteArray JNICALL Java_org_tensorflow_Tensor_scalarBytes(JNIEnv *,
 JNIEXPORT void JNICALL Java_org_tensorflow_Tensor_readNDArray(JNIEnv *, jclass,
                                                               jlong, jobject);
 
+/*
+ * Class:     org_tensorflow_Tensor
+ * Method:    getEncodedStringSize
+ * Signature: (I)I
+ */
+JNIEXPORT jint JNICALL Java_org_tensorflow_Tensor__getEncodedStringSize
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     org_tensorflow_Tensor
+ * Method:    setStringBytes
+ * Signature: ([BL)I
+ */
+JNIEXPORT jint JNICALL Java_org_tensorflow_Tensor__setStringBytes
+  (JNIEnv *, jobject, jbyteArray, jobject);
+
+/*
+ * Class:     org_tensorflow_Tensor
+ * Method:    getStringBytes
+ * Signature: (L)V
+ */
+JNIEXPORT jbyteArray JNICALL Java_org_tensorflow_Tensor__getStringBytes
+  (JNIEnv *, jobject, jobject);
+
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
Here are native methods to support creating string Tensors by string bytes. The implement of Tensor class and test will be soon available.