### PR TITLE
Apply correct filter tags to two tests

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -2990,7 +2990,7 @@ py_test(
     srcs = ["client/session_clusterspec_prop_test.py"],
     srcs_version = "PY2AND3",
     tags = [
-        "no_gpu",
+        "no_pip_gpu",
     ],
     deps = [
         ":array_ops",
@@ -3014,7 +3014,7 @@ py_test(
     srcs = ["client/session_list_devices_test.py"],
     srcs_version = "PY2AND3",
     tags = [
-        "no_gpu",
+        "no_pip_gpu",
     ],
     deps = [
         ":client",


### PR DESCRIPTION
session_clusterspec_prop_test
session_list_devices_test

Should fix ongoing breakage in nightly GPU builds:
http://ci.tensorflow.org/view/Tensorflow%20Jenkins%20Monitored%20builds/job/nightly-matrix-linux-gpu/528/