### PR TITLE
Allow `1/0` to be compatible with tf.bool

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -261,7 +261,9 @@ def _FilterStr(v):
 def _FilterBool(v):
   if isinstance(v, (list, tuple)):
     return _FirstNotNone([_FilterBool(x) for x in v])
-  return None if isinstance(v, bool) else _NotNone(v)
+  return None if (isinstance(v, bool)
+                  or (isinstance(v, compat.integral_types)
+                      and (v == 0 or v == 1))) else _NotNone(v)
 
 
 def _FilterNotTensor(v):

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
@@ -437,6 +438,25 @@ class DivAndModTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(tf3_result, expanded_nums)
       # Consistent with desire to get numerator
       self.assertAllEqual(tf_result, expanded_nums)
+
+
+class ConstantEqualTest(test_util.TensorFlowTestCase):
+
+  def testBoolEqual(self):
+    x = constant_op.constant(1, dtype=dtypes.bool)
+    y = np.bool(1)
+    z = True
+    with self.test_session(use_gpu=True):
+      z_tf = math_ops.equal(x, y).eval()
+      self.assertAllEqual(z, z_tf)
+
+  def testBoolArrayEqual(self):
+    x = constant_op.constant(np.array([1, 0, 1]), dtype=dtypes.bool)
+    y = np.array([1, 1, 1], dtype=np.bool)
+    z = np.array([True, False, True])
+    with self.test_session(use_gpu=True):
+      z_tf = math_ops.equal(x, y).eval()
+      self.assertAllEqual(z, z_tf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fix tries to address the issue raised in #5407 where
```
import numpy as np
from tensorflow.python.ops import math_ops
import tensorflow as tf

label = tf.constant(np.array([1, 0, 1]), dtype=tf.bool)
math_ops.equal(label, 1)
```
will raise an exception of type mismatch.

This fix updated the `_AssertCompatible` so that `1/0`
is compatible with `tf.bool` types.

Additional test cases have been added.

This fix fixes #5407

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>