### PR TITLE
Expose TFRecordWriter.Flush() in Python

### DIFF
--- a/tensorflow/python/lib/io/py_record_writer.cc
+++ b/tensorflow/python/lib/io/py_record_writer.cc
@@ -55,6 +55,14 @@ bool PyRecordWriter::WriteRecord(tensorflow::StringPiece record) {
   return s.ok();
 }
 
+void PyRecordWriter::Flush(TF_Status* out_status) {
+  Status s = writer_->Flush();
+  if (!s.ok()) {
+    Set_TF_Status_from_Status(out_status, s);
+    return;
+  }
+}
+
 void PyRecordWriter::Close(TF_Status* out_status) {
   Status s = writer_->Close();
   if (!s.ok()) {

--- a/tensorflow/python/lib/io/py_record_writer.h
+++ b/tensorflow/python/lib/io/py_record_writer.h
@@ -44,6 +44,7 @@ class PyRecordWriter {
   ~PyRecordWriter();
 
   bool WriteRecord(tensorflow::StringPiece record);
+  void Flush(TF_Status* out_status);
   void Close(TF_Status* out_status);
 
  private:

--- a/tensorflow/python/lib/io/py_record_writer.i
+++ b/tensorflow/python/lib/io/py_record_writer.i
@@ -45,6 +45,7 @@ limitations under the License.
 %unignore tensorflow::io::PyRecordWriter;
 %unignore tensorflow::io::PyRecordWriter::~PyRecordWriter;
 %unignore tensorflow::io::PyRecordWriter::WriteRecord;
+%unignore tensorflow::io::PyRecordWriter::Flush;
 %unignore tensorflow::io::PyRecordWriter::Close;
 %unignore tensorflow::io::PyRecordWriter::New;
 

--- a/tensorflow/python/lib/io/tf_record.py
+++ b/tensorflow/python/lib/io/tf_record.py
@@ -121,6 +121,11 @@ class TFRecordWriter(object):
     """
     self._writer.WriteRecord(record)
 
+  def flush(self):
+    """Flush the file."""
+    with errors.raise_exception_on_not_ok_status() as status:
+      self._writer.Flush(status)
+
   def close(self):
     """Close the file."""
     with errors.raise_exception_on_not_ok_status() as status:

--- a/tensorflow/tools/api/golden/tensorflow.python_io.-t-f-record-writer.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.python_io.-t-f-record-writer.pbtxt
@@ -11,6 +11,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "flush"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "write"
     argspec: "args=[\'self\', \'record\'], varargs=None, keywords=None, defaults=None"
   }


### PR DESCRIPTION
This fix tries to address the issue raised in #10644 where it was not possible to call `TFRecordWriter.Flush()` in Python. The C++ interface already has the `Flush()` so this fix exposes it to python level.

This fix is related to #10644.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>