### PR TITLE
[OpenCL] Fixes grpc test failure for SYCL devices (#87)

### DIFF
--- a/tensorflow/core/debug/grpc_session_debug_test.cc
+++ b/tensorflow/core/debug/grpc_session_debug_test.cc
@@ -280,9 +280,12 @@ TEST_F(GrpcSessionDebugTest, MultiDevices_String) {
 
         DeleteDumpDir();
       } else {
+        // CUDA and SYCL devices do not have an Identity op for strings
         LOG(ERROR) << "Error: " << s;
         ASSERT_TRUE((a_dev.device_type() == DEVICE_GPU) ||
-                    (b_dev.device_type() == DEVICE_GPU));
+                    (a_dev.device_type() == DEVICE_SYCL) ||
+                    (b_dev.device_type() == DEVICE_GPU) ||
+                    (b_dev.device_type() == DEVICE_SYCL));
         ASSERT_FALSE(s.ok());
       }
     }


### PR DESCRIPTION
The test constructs a graph containing an IdentityOp on strings,
which doesn't exist on CUDA and SYCL devices. The test expects to fail
for CUDA devices, so add the same expectation for SYCL devices.