### PR TITLE
add support for android sdk version < 18

### DIFF
--- a/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
+++ b/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
@@ -371,9 +371,8 @@ public class TensorFlowInferenceInterface {
   private void loadGraph(InputStream is, Graph g) throws IOException {
     final long startMs = System.currentTimeMillis();
 
-    if( VERSION.SDK_INT >= 18 ){
+    if (VERSION.SDK_INT >= 18) {
       Trace.beginSection("initializeTensorFlow");
-
       Trace.beginSection("readGraphDef");
     }
 
@@ -388,9 +387,8 @@ public class TensorFlowInferenceInterface {
               + graphDef.length);
     }
 
-    if( VERSION.SDK_INT >= 18 ) {
-      Trace.endSection();
-
+    if (VERSION.SDK_INT >= 18) {
+      Trace.endSection(); // readGraphDef.
       Trace.beginSection("importGraphDef");
     }
 
@@ -400,9 +398,8 @@ public class TensorFlowInferenceInterface {
       throw new IOException("Not a valid TensorFlow Graph serialization: " + e.getMessage());
     }
 
-    if( VERSION.SDK_INT >= 18 ) {
-      Trace.endSection();
-
+    if (VERSION.SDK_INT >= 18) {
+      Trace.endSection(); // importGraphDef.
       Trace.endSection(); // initializeTensorFlow.
     }
 

--- a/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
+++ b/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
@@ -17,6 +17,7 @@ package org.tensorflow.contrib.android;
 
 import android.content.res.AssetManager;
 import android.os.Trace;
+import android.os.Build.VERSION;
 import android.text.TextUtils;
 import android.util.Log;
 import java.io.FileInputStream;
@@ -370,9 +371,12 @@ public class TensorFlowInferenceInterface {
   private void loadGraph(InputStream is, Graph g) throws IOException {
     final long startMs = System.currentTimeMillis();
 
-    Trace.beginSection("initializeTensorFlow");
+    if( VERSION.SDK_INT >= 18 ){
+      Trace.beginSection("initializeTensorFlow");
 
-    Trace.beginSection("readGraphDef");
+      Trace.beginSection("readGraphDef");
+    }
+
     // TODO(ashankar): Can we somehow mmap the contents instead of copying them?
     byte[] graphDef = new byte[is.available()];
     final int numBytesRead = is.read(graphDef);
@@ -383,17 +387,24 @@ public class TensorFlowInferenceInterface {
               + " of the graph, expected to read "
               + graphDef.length);
     }
-    Trace.endSection();
 
-    Trace.beginSection("importGraphDef");
+    if( VERSION.SDK_INT >= 18 ) {
+      Trace.endSection();
+
+      Trace.beginSection("importGraphDef");
+    }
+
     try {
       g.importGraphDef(graphDef);
     } catch (IllegalArgumentException e) {
       throw new IOException("Not a valid TensorFlow Graph serialization: " + e.getMessage());
     }
-    Trace.endSection();
 
-    Trace.endSection(); // initializeTensorFlow.
+    if( VERSION.SDK_INT >= 18 ) {
+      Trace.endSection();
+
+      Trace.endSection(); // initializeTensorFlow.
+    }
 
     final long endMs = System.currentTimeMillis();
     Log.i(


### PR DESCRIPTION
Alternatively, the trace calls could be removed completely or replaced by simple Log calls.