### PR TITLE
To fix link error

### DIFF
--- a/tensorflow/cc/BUILD
+++ b/tensorflow/cc/BUILD
@@ -481,11 +481,23 @@ cc_binary(
     name = "tutorials_example_trainer",
     srcs = ["tutorials/example_trainer.cc"],
     copts = tf_copts(),
-    linkopts = [
-        "-lpthread",
-        "-lm",
-        "-lrt",
-    ],
+    linkopts = select({
+        "//tensorflow:windows": [],
+        "//tensorflow:windows_msvc": [],
+        "//tensorflow:darwin": [
+            "-lm",
+            "-lpthread",
+        ],
+        "//tensorflow:ios": [
+            "-lm",
+            "-lpthread",
+        ],
+        "//conditions:default": [
+            "-lm",
+            "-lpthread",
+            "-lrt",
+        ],
+    }),
     deps = [
         ":cc_ops",
         "//tensorflow/core:core_cpu",

--- a/tensorflow/cc/BUILD
+++ b/tensorflow/cc/BUILD
@@ -484,6 +484,7 @@ cc_binary(
     linkopts = [
         "-lpthread",
         "-lm",
+        "-lrt",
     ],
     deps = [
         ":cc_ops",


### PR DESCRIPTION
To fix link error when building //tensorflow/cc:tutorials_example_trainer
The local environment is centos release 6.8 (Final), gcc 4.9.2, bazel 0.5.0.
Error detail: /opt/rh/devtoolset-3/root/usr/bin/ld: bazel-out/local_linux-opt/bin/tensorflow/cc/_objs/tutorials_example_trainer/tensorflow/cc/tutorials/example_trainer.o: undefined reference to symbol 'clock_gettime@@GLIBC_2.2.5'