### PR TITLE
orthogonal_initializer bug fix

### DIFF
--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -384,7 +384,7 @@ def orthogonal_initializer(gain=1.0, dtype=dtypes.float32, seed=None):
     flat_shape = (num_rows, num_cols)
 
     # Generate a random matrix
-    a = random_ops.random_uniform(flat_shape, dtype=dtype, seed=seed)
+    a = random_ops.random_normal(flat_shape, dtype=dtype, seed=seed)
     # Compute the svd
     _, u, v = linalg_ops.svd(a, full_matrices=False)
     # Pick the appropriate singular value decomposition


### PR DESCRIPTION
Fixed a bug in "orthogonal_initializer" function in init_ops.py file.

The original way of generating a random matrix(**random_uniform**) is not scaled to make the mean value to 0. 
- This will cause the value in the first "block" of the returned matrix, which is corresponding to the largest singular value, very close to each other. 
- In convolutional neural network, if the initial parameters of a kernel are similar to each other, then all the parameters will update very similarly, which is a really bad thing for training.

The bug is fixed by simply using the **random_normal** function to generate the random matrix. This will work because the default parameters for random_normal are mean=0.0, stddev=1.0