### PR TITLE
Padding queue support for tf.estimator generator input pipeline

### DIFF
--- a/tensorflow/contrib/learn/python/learn/learn_io/generator_io.py
+++ b/tensorflow/contrib/learn/python/learn/learn_io/generator_io.py
@@ -32,7 +32,7 @@ def generator_input_fn(x,
                        shuffle=True,
                        queue_capacity=1000,
                        num_threads=1,
-                       pad_data=False):
+                       pad_value=None):
   """Returns input function that would dicts of numpy arrays
        yielded from a generator.
 
@@ -69,6 +69,7 @@ def generator_input_fn(x,
       time.
     queue_capacity: Integer, size of queue to accumulate.
     num_threads: Integer, number of threads used for reading and enqueueing.
+    pad_value: default value for dynamic padding of data samples, if provided.
 
   Returns:
     Function, that returns a feature `dict` with `Tensors` and an optional
@@ -119,7 +120,7 @@ def generator_input_fn(x,
         num_threads=num_threads,
         enqueue_size=batch_size,
         num_epochs=num_epochs,
-        pad_data=pad_data)
+        pad_value=pad_value)
 
     features = (queue.dequeue_many(batch_size)
                 if num_epochs is None else queue.dequeue_up_to(batch_size))

--- a/tensorflow/contrib/learn/python/learn/learn_io/generator_io.py
+++ b/tensorflow/contrib/learn/python/learn/learn_io/generator_io.py
@@ -31,7 +31,8 @@ def generator_input_fn(x,
                        num_epochs=1,
                        shuffle=True,
                        queue_capacity=1000,
-                       num_threads=1):
+                       num_threads=1,
+                       pad_data=False):
   """Returns input function that would dicts of numpy arrays
        yielded from a generator.
 
@@ -117,7 +118,8 @@ def generator_input_fn(x,
         shuffle=shuffle,
         num_threads=num_threads,
         enqueue_size=batch_size,
-        num_epochs=num_epochs)
+        num_epochs=num_epochs,
+        pad_data=pad_data)
 
     features = (queue.dequeue_many(batch_size)
                 if num_epochs is None else queue.dequeue_up_to(batch_size))

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -66,7 +66,7 @@ def _fill_array(arr, seq, fillvalue=0):
     arr[len_:] = fillvalue
   else:
     for subarr, subseq in six.moves.zip_longest(arr, seq, fillvalue=()):
-      _fill_array(subarr, subseq)
+      _fill_array(subarr, subseq, fillvalue)
 
 
 def _pad_if_needed(batch_key_item):

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -23,7 +23,6 @@ import random
 import types as tp
 import numpy as np
 import six
-from six.moves import zip_longest
 
 from tensorflow.python.estimator.inputs.queues import feeding_queue_runner as fqr
 from tensorflow.python.framework import dtypes
@@ -56,7 +55,7 @@ def _fill_array(arr, seq, fillvalue=0):
     arr: Padded tensor of shape [batch_size, ..., max_padded_dim_len].
     seq: Non-padded list of data sampels of shape 
       [batch_size, ..., padded_dim(None)]
-    fillvalue: Defaulf fillvalue to use.
+    fillvalue: Default fillvalue to use.
   """
   if arr.ndim == 1:
     try:
@@ -66,7 +65,7 @@ def _fill_array(arr, seq, fillvalue=0):
     arr[:len_] = seq
     arr[len_:] = fillvalue
   else:
-    for subarr, subseq in zip_longest(arr, seq, fillvalue=()):
+    for subarr, subseq in six.moves.zip_longest(arr, seq, fillvalue=()):
       _fill_array(subarr, subseq)
 
 
@@ -397,7 +396,7 @@ def _enqueue_data(data,
 
     if shuffle and pad_data:
       raise NotImplementedError(
-        "for now, there is now way to pad and shuffle data at the same time")
+        "padding and shuffling at the same time is not implemented")
 
     # TODO(jamieas): TensorBoard warnings for all warnings below once available.
 

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -326,10 +326,10 @@ class _GeneratorFeedFn(object):
 
     if self._pad_value is not None:
       feed_dict = {key: np.asarray(_pad_if_needed(item, self._pad_value))
-                 for key, item in list(list_dict.items())}
+                   for key, item in list(list_dict.items())}
     else:
       feed_dict = {key: np.asarray(item)
-                 for key, item in list(list_dict.items())}
+                   for key, item in list(list_dict.items())}
     return feed_dict
 
 
@@ -408,10 +408,10 @@ def _enqueue_data(data,
     pad_data = pad_value is not None
     if pad_data and get_feed_fn is not _GeneratorFeedFn:
       raise NotImplementedError(
-        "padding is only available with generator usage")
+          "padding is only available with generator usage")
     if shuffle and pad_data:
       raise NotImplementedError(
-        "padding and shuffling data at the same time is not implemented")
+          "padding and shuffling data at the same time is not implemented")
 
     # TODO(jamieas): TensorBoard warnings for all warnings below once available.
 

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -48,6 +48,16 @@ except ImportError:
 
 
 def _fill_array(arr, seq, fillvalue=0):
+  """ 
+  Recursively fills padded arr with elements from seq. 
+  If lenght of seq is less then arr padded length, fillvalue used.
+
+  Args:
+    arr: Padded tensor of shape [batch_size, ..., max_padded_dim_len].
+    seq: Non-padded list of data sampels of shape 
+      [batch_size, ..., padded_dim(None)]
+    fillvalue: Defaulf fillvalue to use.
+  """
   if arr.ndim == 1:
     try:
       len_ = len(seq)
@@ -61,6 +71,19 @@ def _fill_array(arr, seq, fillvalue=0):
 
 
 def _pad_if_needed(batch_key_item):
+  """ Returns padded batch.
+
+  Args:
+    batch_key_item: List of data samples of any type with shape 
+      [batch_size, ..., padded_dim(None)].
+
+  Returns:
+    Padded with zeros tensor of same type and shape 
+      [batch_size, ..., max_padded_dim_len].
+
+  Raises:
+    ValueError if data samples have different shapes (except last padded dim).
+  """
   shapes = [seq.shape[:-1] if len(seq.shape) > 0 else -1
             for seq in batch_key_item]
   if not all(shapes[0] == x for x in shapes):

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -23,6 +23,7 @@ import random
 import types as tp
 import numpy as np
 import six
+from six.moves import zip_longest
 
 from tensorflow.python.estimator.inputs.queues import feeding_queue_runner as fqr
 from tensorflow.python.framework import dtypes
@@ -34,11 +35,6 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.summary import summary
 from tensorflow.python.training import queue_runner
-
-try:
-  from itertools import zip_longest
-except ImportError:
-  from itertools import izip_longest as zip_longest
 
 try:
   # pylint: disable=g-import-not-at-top

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -267,8 +267,7 @@ class _GeneratorFeedFn(object):
                batch_size,
                random_start=False,
                seed=None,
-               num_epochs=None,
-               pad_data=False):
+               num_epochs=None):
     first_sample = next(generator())
     if len(placeholders) != len(first_sample):
       raise ValueError("Expected {} placeholders; got {}.".format(
@@ -279,7 +278,6 @@ class _GeneratorFeedFn(object):
     self._iterator = generator()
     self._batch_size = batch_size
     self._num_epochs = num_epochs
-    self._pad_data = pad_data
     self._epoch = 0
     random.seed(seed)
 
@@ -304,12 +302,8 @@ class _GeneratorFeedFn(object):
         list_dict.setdefault(self._col_placeholders[index],
                              list()).append(data_row[key])
         list_dict_size += 1
-    if self._pad_data:
-      feed_dict = {key: np.asarray(_pad_if_needed(item))
-                   for key, item in list(list_dict.items())}
-    else:
-      feed_dict = {key: np.asarray(item)
-                   for key, item in list(list_dict.items())}
+    feed_dict = {key: np.asarray(_pad_if_needed(item))
+                 for key, item in list(list_dict.items())}
     return feed_dict
 
 

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -324,7 +324,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
         np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
     actual = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     ff._fill_array(actual, a, fill_value)
-    expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
+    expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)l
     expected[:8, ..., 32:] = fill_value
     self.assertEqual(expected, actual)
 

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -331,6 +331,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
   def testPadIfNeededSmall(self):
     a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
          np.ones(shape=[32, 36], dtype=np.int32).tolist())
+    a = list(map(np.array, a))
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = 0
@@ -339,6 +340,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
   def testPadIfNeededLarge(self):
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
          np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
+    a = list(map(np.array, a))
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = 0
@@ -348,6 +350,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     fill_value = 8
     a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
          np.ones(shape=[32, 36], dtype=np.int32).tolist())
+    a = list(map(np.array, a))
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = fill_value
@@ -357,6 +360,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     fill_value = 8
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
          np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
+    a = list(map(np.array, a))
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = fill_value
@@ -366,6 +370,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     fill_value = False
     a = (np.ones(shape=[32, 32], dtype=np.bool).tolist() +
          np.ones(shape=[32, 36], dtype=np.bool).tolist())
+    a = list(map(np.array, a))
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.bool)
     expected[:32, 32:] = fill_value
@@ -375,6 +380,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     fill_value = False
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.bool).tolist() +
          np.ones(shape=[8, 8, 8, 8, 36], dtype=np.bool).tolist())
+    a = list(map(np.array, a))
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.bool)
     expected[:8, ..., 32:] = fill_value

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -308,6 +308,26 @@ class _FeedingFunctionsTestCase(test.TestCase):
     expected[:8, ..., 32:] = 0
     self.assertEqual(expected, actual)
 
+  def testFillArraySmallWithSpecifiedValue(self):
+    fill_value = 8
+    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    actual = np.ones(shape=[64, 36], dtype=np.int32)
+    ff._fill_array(actual, a, fill_value)
+    expected = np.ones(shape=[64, 36], dtype=np.int32)
+    expected[:32, 32:] = fill_value
+    self.assertEqual(expected, actual)
+
+  def testFillArrayLargeWithSpecifiedValue(self):
+    fill_value = 8
+    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    actual = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
+    ff._fill_array(actual, a, fill_value)
+    expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
+    expected[:8, ..., 32:] = fill_value
+    self.assertEqual(expected, actual)
+
   def testPadIfNeededSmall(self):
     a = np.ones(shape=[32, 32], dtype=np.int32).tolist() +
         np.ones(shape=[32, 36], dtype=np.int32).tolist()

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -329,7 +329,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     self.assertEqual(expected, actual)
 
   def testPadIfNeededSmall(self):
-    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() +
+    a = np.ones(shape=[32, 32], dtype=np.int32).tolistё() +
         np.ones(shape=[32, 36], dtype=np.int32).tolist()
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
@@ -342,6 +342,42 @@ class _FeedingFunctionsTestCase(test.TestCase):
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = 0
+    self.assertEqual(expected, actual)
+
+  def testPadIfNeededSmallWithSpecifiedValue(self):
+    fill_value = 8
+    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    actual = ff._pad_if_needed(a, fill_value)
+    expected = np.ones(shape=[64, 36], dtype=np.int32)
+    expected[:32, 32:] = fill_value
+    self.assertEqual(expected, actual)
+
+  def testPadIfNeededLargeWithSpecifiedValue(self):
+    fill_value = 8
+    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    actual = ff._pad_if_needed(a, fill_value)
+    expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
+    expected[:8, ..., 32:] = fill_value
+    self.assertEqual(expected, actual)
+
+  def testPadIfNeededSmallWithSpecifiedNonNumericValue(self):
+    fill_value = False
+    a = np.ones(shape=[32, 32], dtype=np.bool).tolist() +
+        np.ones(shape=[32, 36], dtype=np.bool).tolist()
+    actual = ff._pad_if_needed(a, fill_value)
+    expected = np.ones(shape=[64, 36], dtype=np.bool)
+    expected[:32, 32:] = fill_value
+    self.assertEqual(expected, actual)
+
+  def testPadIfNeededLargeWithSpecifiedNonNumericValue(self):
+    fill_value = False
+    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.bool).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.bool).tolist()
+    actual = ff._pad_if_needed(a, fill_value)
+    expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.bool)
+    expected[:8, ..., 32:] = fill_value
     self.assertEqual(expected, actual)
 
 

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -297,7 +297,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     ff._fill_array(actual, a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = 0
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
   def testFillArrayLarge(self):
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
@@ -306,7 +306,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     ff._fill_array(actual, a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = 0
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
   def testFillArraySmallWithSpecifiedValue(self):
     fill_value = 8
@@ -316,7 +316,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     ff._fill_array(actual, a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = fill_value
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
   def testFillArrayLargeWithSpecifiedValue(self):
     fill_value = 8
@@ -326,7 +326,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     ff._fill_array(actual, a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = fill_value
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
   def testPadIfNeededSmall(self):
     a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
@@ -335,7 +335,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = 0
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
   def testPadIfNeededLarge(self):
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
@@ -344,7 +344,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = 0
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
   def testPadIfNeededSmallWithSpecifiedValue(self):
     fill_value = 8
@@ -354,7 +354,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = fill_value
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
   def testPadIfNeededLargeWithSpecifiedValue(self):
     fill_value = 8
@@ -364,7 +364,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = fill_value
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
   def testPadIfNeededSmallWithSpecifiedNonNumericValue(self):
     fill_value = False
@@ -374,7 +374,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.bool)
     expected[:32, 32:] = fill_value
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
   def testPadIfNeededLargeWithSpecifiedNonNumericValue(self):
     fill_value = False
@@ -384,7 +384,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.bool)
     expected[:8, ..., 32:] = fill_value
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.tolist(), actual.tolist())
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -292,7 +292,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testFillArraySmall(self):
     a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[32, 36], dtype=np.int32).tolist())
+         np.ones(shape=[32, 36], dtype=np.int32).tolist())
     actual = np.ones(shape=[64, 36], dtype=np.int32)
     ff._fill_array(actual, a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
@@ -301,7 +301,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testFillArrayLarge(self):
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
+         np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
     actual = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     ff._fill_array(actual, a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
@@ -311,7 +311,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
   def testFillArraySmallWithSpecifiedValue(self):
     fill_value = 8
     a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[32, 36], dtype=np.int32).tolist())
+         np.ones(shape=[32, 36], dtype=np.int32).tolist())
     actual = np.ones(shape=[64, 36], dtype=np.int32)
     ff._fill_array(actual, a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
@@ -321,7 +321,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
   def testFillArrayLargeWithSpecifiedValue(self):
     fill_value = 8
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
+         np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
     actual = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     ff._fill_array(actual, a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
@@ -330,7 +330,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testPadIfNeededSmall(self):
     a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[32, 36], dtype=np.int32).tolist())
+         np.ones(shape=[32, 36], dtype=np.int32).tolist())
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = 0
@@ -338,7 +338,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testPadIfNeededLarge(self):
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
+         np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = 0
@@ -347,7 +347,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
   def testPadIfNeededSmallWithSpecifiedValue(self):
     fill_value = 8
     a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[32, 36], dtype=np.int32).tolist())
+         np.ones(shape=[32, 36], dtype=np.int32).tolist())
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = fill_value
@@ -356,7 +356,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
   def testPadIfNeededLargeWithSpecifiedValue(self):
     fill_value = 8
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
+         np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = fill_value
@@ -365,7 +365,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
   def testPadIfNeededSmallWithSpecifiedNonNumericValue(self):
     fill_value = False
     a = (np.ones(shape=[32, 32], dtype=np.bool).tolist() +
-        np.ones(shape=[32, 36], dtype=np.bool).tolist())
+         np.ones(shape=[32, 36], dtype=np.bool).tolist())
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.bool)
     expected[:32, 32:] = fill_value
@@ -374,7 +374,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
   def testPadIfNeededLargeWithSpecifiedNonNumericValue(self):
     fill_value = False
     a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.bool).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.bool).tolist())
+         np.ones(shape=[8, 8, 8, 8, 36], dtype=np.bool).tolist())
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.bool)
     expected[:8, ..., 32:] = fill_value

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -291,8 +291,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
     self.assertEqual(expected, vals_to_list(actual))
 
   def testFillArraySmall(self):
-    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() + \
-          np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[32, 36], dtype=np.int32).tolist()
     actual = np.ones(shape=[64, 36], dtype=np.int32)
     ff._fill_array(actual, a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
@@ -300,8 +300,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
     self.assertEqual(expected, actual)
 
   def testFillArrayLarge(self):
-    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() + \
-          np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
     actual = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     ff._fill_array(actual, a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
@@ -309,16 +309,16 @@ class _FeedingFunctionsTestCase(test.TestCase):
     self.assertEqual(expected, actual)
 
   def testPadIfNeededSmall(self):
-    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() + \
-          np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[32, 36], dtype=np.int32).tolist()
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = 0
     self.assertEqual(expected, actual)
 
   def testPadIfNeededLarge(self):
-    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() + \
-          np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = 0

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -329,7 +329,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
     self.assertEqual(expected, actual)
 
   def testPadIfNeededSmall(self):
-    a = (np.ones(shape=[32, 32], dtype=np.int32).tolistё() +
+    a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
         np.ones(shape=[32, 36], dtype=np.int32).tolist())
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -291,8 +291,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
     self.assertEqual(expected, vals_to_list(actual))
 
   def testFillArraySmall(self):
-    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[32, 36], dtype=np.int32).tolist())
     actual = np.ones(shape=[64, 36], dtype=np.int32)
     ff._fill_array(actual, a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
@@ -300,8 +300,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
     self.assertEqual(expected, actual)
 
   def testFillArrayLarge(self):
-    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
     actual = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     ff._fill_array(actual, a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
@@ -310,8 +310,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testFillArraySmallWithSpecifiedValue(self):
     fill_value = 8
-    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[32, 36], dtype=np.int32).tolist())
     actual = np.ones(shape=[64, 36], dtype=np.int32)
     ff._fill_array(actual, a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
@@ -320,8 +320,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testFillArrayLargeWithSpecifiedValue(self):
     fill_value = 8
-    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
     actual = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     ff._fill_array(actual, a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)l
@@ -329,16 +329,16 @@ class _FeedingFunctionsTestCase(test.TestCase):
     self.assertEqual(expected, actual)
 
   def testPadIfNeededSmall(self):
-    a = np.ones(shape=[32, 32], dtype=np.int32).tolistё() +
-        np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    a = (np.ones(shape=[32, 32], dtype=np.int32).tolistё() +
+        np.ones(shape=[32, 36], dtype=np.int32).tolist())
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = 0
     self.assertEqual(expected, actual)
 
   def testPadIfNeededLarge(self):
-    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
     actual = ff._pad_if_needed(a)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = 0
@@ -346,8 +346,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testPadIfNeededSmallWithSpecifiedValue(self):
     fill_value = 8
-    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    a = (np.ones(shape=[32, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[32, 36], dtype=np.int32).tolist())
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.int32)
     expected[:32, 32:] = fill_value
@@ -355,8 +355,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testPadIfNeededLargeWithSpecifiedValue(self):
     fill_value = 8
-    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = fill_value
@@ -364,8 +364,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testPadIfNeededSmallWithSpecifiedNonNumericValue(self):
     fill_value = False
-    a = np.ones(shape=[32, 32], dtype=np.bool).tolist() +
-        np.ones(shape=[32, 36], dtype=np.bool).tolist()
+    a = (np.ones(shape=[32, 32], dtype=np.bool).tolist() +
+        np.ones(shape=[32, 36], dtype=np.bool).tolist())
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[64, 36], dtype=np.bool)
     expected[:32, 32:] = fill_value
@@ -373,8 +373,8 @@ class _FeedingFunctionsTestCase(test.TestCase):
 
   def testPadIfNeededLargeWithSpecifiedNonNumericValue(self):
     fill_value = False
-    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.bool).tolist() +
-        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.bool).tolist()
+    a = (np.ones(shape=[8, 8, 8, 8, 32], dtype=np.bool).tolist() +
+        np.ones(shape=[8, 8, 8, 8, 36], dtype=np.bool).tolist())
     actual = ff._pad_if_needed(a, fill_value)
     expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.bool)
     expected[:8, ..., 32:] = fill_value

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -324,7 +324,7 @@ class _FeedingFunctionsTestCase(test.TestCase):
         np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist())
     actual = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     ff._fill_array(actual, a, fill_value)
-    expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)l
+    expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
     expected[:8, ..., 32:] = fill_value
     self.assertEqual(expected, actual)
 

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions_test.py
@@ -290,6 +290,40 @@ class _FeedingFunctionsTestCase(test.TestCase):
     actual = aff()
     self.assertEqual(expected, vals_to_list(actual))
 
+  def testFillArraySmall(self):
+    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() + \
+          np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    actual = np.ones(shape=[64, 36], dtype=np.int32)
+    ff._fill_array(actual, a)
+    expected = np.ones(shape=[64, 36], dtype=np.int32)
+    expected[:32, 32:] = 0
+    self.assertEqual(expected, actual)
+
+  def testFillArrayLarge(self):
+    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() + \
+          np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    actual = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
+    ff._fill_array(actual, a)
+    expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
+    expected[:8, ..., 32:] = 0
+    self.assertEqual(expected, actual)
+
+  def testPadIfNeededSmall(self):
+    a = np.ones(shape=[32, 32], dtype=np.int32).tolist() + \
+          np.ones(shape=[32, 36], dtype=np.int32).tolist()
+    actual = ff._pad_if_needed(a)
+    expected = np.ones(shape=[64, 36], dtype=np.int32)
+    expected[:32, 32:] = 0
+    self.assertEqual(expected, actual)
+
+  def testPadIfNeededLarge(self):
+    a = np.ones(shape=[8, 8, 8, 8, 32], dtype=np.int32).tolist() + \
+          np.ones(shape=[8, 8, 8, 8, 36], dtype=np.int32).tolist()
+    actual = ff._pad_if_needed(a)
+    expected = np.ones(shape=[16, 8, 8, 8, 36], dtype=np.int32)
+    expected[:8, ..., 32:] = 0
+    self.assertEqual(expected, actual)
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
So, as I desrcibe [here](https://github.com/tensorflow/tensorflow/issues/10680), there is no padding possibilities in current estimator's input pipelines.

For now I added simple possibility to you data have dynamic shape over last axis. 
If such solution looks good, then I am looking forward for next contributing steps.