### PR TITLE
don't lock markdown version and bring CI deps install script in sync with setup.py

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -28,24 +28,24 @@ pip2 install wheel
 pip3 install wheel
 
 # Install six.
-pip2 install --upgrade six==1.10.0
-pip3 install --upgrade six==1.10.0
+pip2 install --upgrade six>=1.10.0
+pip3 install --upgrade six>=1.10.0
 
 # Install werkzeug.
-pip2 install --upgrade werkzeug==0.11.10
-pip3 install --upgrade werkzeug==0.11.10
+pip2 install --upgrade werkzeug>=0.11.10
+pip3 install --upgrade werkzeug>=0.11.10
 
 # Install bleach. html5lib will be picked up as a dependency.
 pip2 install --upgrade bleach==1.5.0
 pip3 install --upgrade bleach==1.5.0
 
 # Install markdown.
-pip2 install --upgrade markdown==2.6.8
-pip3 install --upgrade markdown==2.6.8
+pip2 install --upgrade markdown>=2.6.8
+pip3 install --upgrade markdown>=2.6.8
 
 # Install protobuf.
-pip2 install --upgrade protobuf==3.2.0
-pip3 install --upgrade protobuf==3.2.0
+pip2 install --upgrade protobuf>=3.2.0
+pip3 install --upgrade protobuf>=3.2.0
 
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
 rm -rf /usr/lib/python3/dist-packages/six*
@@ -53,8 +53,8 @@ rm -rf /usr/lib/python3/dist-packages/six*
 # numpy needs to be installed from source to fix segfaults. See:
 # https://github.com/tensorflow/tensorflow/issues/6968
 # This workaround isn't needed for Ubuntu 16.04 or later.
-pip2 install --no-binary=:all: --upgrade numpy==1.12.0
-pip3 install --no-binary=:all: --upgrade numpy==1.12.0
+pip2 install --no-binary=:all: --upgrade numpy>=1.11.0
+pip3 install --no-binary=:all: --upgrade numpy>=1.11.0
 
 pip2 install scipy==0.18.1
 pip3 install scipy==0.18.1

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -37,7 +37,7 @@ REQUIRED_PACKAGES = [
     'protobuf >= 3.2.0',
     'werkzeug >= 0.11.10',
     'html5lib == 0.9999999',  # identical to 1.0b8
-    'markdown == 2.2.0',
+    'markdown >= 2.2.0',
     'bleach == 1.5.0',
     'backports.weakref == 1.0rc1',
 ]


### PR DESCRIPTION
This markdown version lock could cause versioning conflict for downstream (e.g. if requirements are compiled and resolved by `pip-compile`). Wondering If there's a reason to lock this version 

Seems someone pushed `1.2.0` to PYPI and it cause some dependency conflict. 
