### PR TITLE
[OpenCL] Fixes device name comparison stage_op_test 

### DIFF
--- a/tensorflow/python/kernel_tests/stage_op_test.py
+++ b/tensorflow/python/kernel_tests/stage_op_test.py
@@ -102,7 +102,8 @@ class StageTest(test.TestCase):
       with ops.device(gpu_dev):
         stager = data_flow_ops.StagingArea([dtypes.float32])
         y = stager.put([v])
-        self.assertEqual(y.device, gpu_dev)
+        expected_name = gpu_dev if 'gpu' not in gpu_dev else '/device:GPU:0'
+        self.assertEqual(y.device, expected_name)
       with ops.device('/cpu:0'):
         x = stager.get()
         self.assertEqual(x.device, '/device:CPU:0')

--- a/tensorflow/python/kernel_tests/stage_op_test.py
+++ b/tensorflow/python/kernel_tests/stage_op_test.py
@@ -102,8 +102,7 @@ class StageTest(test.TestCase):
       with ops.device(gpu_dev):
         stager = data_flow_ops.StagingArea([dtypes.float32])
         y = stager.put([v])
-        self.assertEqual(y.device, '/device:GPU:0' if gpu_dev
-                                                   else gpu_dev)
+        self.assertEqual(y.device, gpu_dev)
       with ops.device('/cpu:0'):
         x = stager.get()
         self.assertEqual(x.device, '/device:CPU:0')


### PR DESCRIPTION
Changes the fixed '/device:GPU:0' expected device name string to the name returned by 'test/gpu_device_name()', as the device name could be '/device:SYCL:0' or '/device:GPU:0'.

Resubmission of #10682 