### PR TITLE
Fix a bug in topk_op.cc

### DIFF
--- a/tensorflow/core/kernels/topk_op.cc
+++ b/tensorflow/core/kernels/topk_op.cc
@@ -93,7 +93,7 @@ class TopK : public OpKernel {
       rows_by_one.set(0, num_rows);
 #else
       Eigen::array<int, 1> reduce_on_cols = {1};
-      Eigen::array<int, 1> rows_by_one = {static_cast<int>(num_rows), 1};
+      Eigen::array<int, 2> rows_by_one = {static_cast<int>(num_rows), 1};
 #endif
 
       values.device(d) =


### PR DESCRIPTION
307df7080a8fe0538e05754170695b9925e2cea2 is causing failures in
http://ci.tensorflow.org/job/tf-master-win-bzl/1110/console : 
```
03:15:56 //py_test_dir/tensorflow/python/kernel_tests:metrics_test                FAILED in 3 out of 3 in 54.3s
03:15:56 //py_test_dir/tensorflow/python/kernel_tests:topk_op_test                FAILED in 3.6s
```
The test output doesn't show useful information:
```
03:13:23 FAIL: //py_test_dir/tensorflow/python/kernel_tests:metrics_test (shard 3 of 3) (see C:/tmp/_bazel_system/424zmya1/execroot/tf-master-win-bzl/bazel-out/msvc_x64-py3-opt/testlogs/py_test_dir/tensorflow/python/kernel_tests/metrics_test/shard_3_of_3/test.log)
03:13:23 INFO: From Testing //py_test_dir/tensorflow/python/kernel_tests:metrics_test (shard 3 of 3):
03:13:23 ==================== Test output for //py_test_dir/tensorflow/python/kernel_tests:metrics_test (shard 3 of 3):
03:13:23 .....C:\Program Files\Anaconda3\lib\site-packages\tensorflow\python\util\tf_inspect.py:45: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
03:13:23   if d.decorator_argspec is not None), _inspect.getargspec(target))
03:13:23 ....................\\?\c:\tmp\Bazel.runfiles_tbl0oj21\runfiles\org_tensorflow\py_test_dir\tensorflow\python\kernel_tests\metrics_test.py:163: DeprecationWarning: Please use assertEqual instead.
03:13:23   set(expected), set(v.name for v in variables.local_variables()))
03:13:23 ..................================================================================================
```
But when running the test locally I saw:
![capture_topk_failure](https://user-images.githubusercontent.com/4171702/27226378-044bad8c-529f-11e7-9241-48c6ac705040.PNG)

This change fixed them.

@gunan 