### PR TITLE
Update sample_distorted_bounding_box to use Tensor Input for min_object_covered

### DIFF
--- a/tensorflow/core/kernels/sample_distorted_bounding_box_op.cc
+++ b/tensorflow/core/kernels/sample_distorted_bounding_box_op.cc
@@ -192,18 +192,20 @@ bool GenerateRandomCrop(int original_width, int original_height,
 }  // namespace
 
 template <typename T>
-class SampleDistortedBoundingBoxOp : public OpKernel {
+class SampleDistortedBoundingBoxV2Op : public OpKernel {
  public:
-  explicit SampleDistortedBoundingBoxOp(OpKernelConstruction* context)
+  explicit SampleDistortedBoundingBoxV2Op(OpKernelConstruction* context)
       : OpKernel(context) {
     OP_REQUIRES_OK(context, generator_.Init(context));
 
-    OP_REQUIRES_OK(
-        context, context->GetAttr("min_object_covered", &min_object_covered_));
-    OP_REQUIRES(
-        context, min_object_covered_ >= 0,
-        errors::InvalidArgument("Min object covered must be non-negative: ",
-                                min_object_covered_));
+    if (context->num_inputs() == 2) {
+      OP_REQUIRES_OK(context, context->GetAttr("min_object_covered",
+                                               &min_object_covered_));
+      OP_REQUIRES(
+          context, min_object_covered_ >= 0,
+          errors::InvalidArgument("Min object covered must be non-negative: ",
+                                  min_object_covered_));
+    }
 
     OP_REQUIRES_OK(context, context->GetAttr("use_image_if_no_bounding_boxes",
                                              &use_image_if_no_bounding_boxes_));
@@ -275,6 +277,25 @@ class SampleDistortedBoundingBoxOp : public OpKernel {
                     "bounding boxes must have shape [4] or [*, 4], got ",
                     input_boxes.shape().DebugString()));
 
+    float min_object_covered_val = 0.0;
+    if (context->num_inputs() == 3) {
+      const Tensor& min_object_covered = context->input(2);
+
+      OP_REQUIRES(
+          context, TensorShapeUtils::IsScalar(min_object_covered.shape()),
+          errors::InvalidArgument("min_object_covered must be 0-D, got shape ",
+                                  min_object_covered.shape().DebugString()));
+
+      min_object_covered_val = min_object_covered.scalar<float>()();
+
+      OP_REQUIRES(
+          context, min_object_covered_val >= 0,
+          errors::InvalidArgument("Min object covered must be non-negative: ",
+                                  min_object_covered_val));
+    } else {
+      min_object_covered_val = min_object_covered_;
+    }
+
     std::vector<Rectangle> bounding_boxes;
     if (input_boxes.NumElements() > 0) {
       TTypes<float>::ConstMatrix boxes = input_boxes.flat_inner_dims<float>();
@@ -325,7 +346,7 @@ class SampleDistortedBoundingBoxOp : public OpKernel {
 
       if (GenerateRandomCrop(width, height, min_sample_area, max_sample_area,
                              sample_aspect_ratio, &random, &crop_rect)) {
-        if (SatisfiesOverlapConstraints(crop_rect, min_object_covered_,
+        if (SatisfiesOverlapConstraints(crop_rect, min_object_covered_val,
                                         bounding_boxes)) {
           sample_generated = true;
           break;
@@ -399,11 +420,15 @@ class SampleDistortedBoundingBoxOp : public OpKernel {
   bool use_image_if_no_bounding_boxes_;
 };
 
-#define REGISTER_KERNELS(type)                               \
-  REGISTER_KERNEL_BUILDER(                                   \
-      Name("SampleDistortedBoundingBox").Device(DEVICE_CPU)   \
-           .TypeConstraint<type>("T"),                       \
-      SampleDistortedBoundingBoxOp<type>)
+#define REGISTER_KERNELS(type)                                  \
+  REGISTER_KERNEL_BUILDER(Name("SampleDistortedBoundingBox")    \
+                              .Device(DEVICE_CPU)               \
+                              .TypeConstraint<type>("T"),       \
+                          SampleDistortedBoundingBoxV2Op<type>) \
+  REGISTER_KERNEL_BUILDER(Name("SampleDistortedBoundingBoxV2")  \
+                              .Device(DEVICE_CPU)               \
+                              .TypeConstraint<type>("T"),       \
+                          SampleDistortedBoundingBoxV2Op<type>)
 
 TF_CALL_INTEGRAL_TYPES(REGISTER_KERNELS);
 #undef REGISTER_KERNELS

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -82,9 +82,8 @@ Status DecodeImageShapeFn(InferenceContext* c) {
     channels_dim = c->MakeDim(channels);
   }
 
-  c->set_output(0,
-                c->MakeShape({InferenceContext::kUnknownDim,
-                              InferenceContext::kUnknownDim, channels_dim}));
+  c->set_output(0, c->MakeShape({InferenceContext::kUnknownDim,
+                                 InferenceContext::kUnknownDim, channels_dim}));
   return Status::OK();
 }
 
@@ -628,10 +627,9 @@ REGISTER_OP("DecodeGif")
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle unused;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &unused));
-      c->set_output(0,
-                    c->MakeShape({InferenceContext::kUnknownDim,
-                                  InferenceContext::kUnknownDim,
-                                  InferenceContext::kUnknownDim, 3}));
+      c->set_output(0, c->MakeShape({InferenceContext::kUnknownDim,
+                                     InferenceContext::kUnknownDim,
+                                     InferenceContext::kUnknownDim, 3}));
       return Status::OK();
     })
     .Doc(R"doc(
@@ -801,6 +799,98 @@ min_object_covered: The cropped area of the image must contain at least this
   fraction of any bounding box supplied. The value of this parameter should be
   non-negative. In the case of 0, the cropped area does not need to overlap
   any of the bounding boxes supplied.
+aspect_ratio_range: The cropped area of the image must have an aspect ratio =
+  width / height within this range.
+area_range: The cropped area of the image must contain a fraction of the
+  supplied image within in this range.
+max_attempts: Number of attempts at generating a cropped region of the image
+  of the specified constraints. After `max_attempts` failures, return the entire
+  image.
+use_image_if_no_bounding_boxes: Controls behavior if no bounding boxes supplied.
+  If true, assume an implicit bounding box covering the whole input. If false,
+  raise an error.
+)doc");
+
+REGISTER_OP("SampleDistortedBoundingBoxV2")
+    .Input("image_size: T")
+    .Input("bounding_boxes: float")
+    .Input("min_object_covered: float")
+    .Output("begin: T")
+    .Output("size: T")
+    .Output("bboxes: float")
+    .Attr("T: {uint8, int8, int16, int32, int64}")
+    .Attr("seed: int = 0")
+    .Attr("seed2: int = 0")
+    .Attr("aspect_ratio_range: list(float) = [0.75, 1.33]")
+    .Attr("area_range: list(float) = [0.05, 1.0]")
+    .Attr("max_attempts: int = 100")
+    .Attr("use_image_if_no_bounding_boxes: bool = false")
+    .SetIsStateful()
+    .SetShapeFn([](InferenceContext* c) {
+      c->set_output(0, c->Vector(3));
+      c->set_output(1, c->Vector(3));
+      c->set_output(2, c->MakeShape({1, 1, 4}));
+      return Status::OK();
+    })
+    .Doc(R"doc(
+Generate a single randomly distorted bounding box for an image.
+
+Bounding box annotations are often supplied in addition to ground-truth labels
+in image recognition or object localization tasks. A common technique for
+training such a system is to randomly distort an image while preserving
+its content, i.e. *data augmentation*. This Op outputs a randomly distorted
+localization of an object, i.e. bounding box, given an `image_size`,
+`bounding_boxes` and a series of constraints.
+
+The output of this Op is a single bounding box that may be used to crop the
+original image. The output is returned as 3 tensors: `begin`, `size` and
+`bboxes`. The first 2 tensors can be fed directly into `tf.slice` to crop the
+image. The latter may be supplied to `tf.image.draw_bounding_boxes` to visualize
+what the bounding box looks like.
+
+Bounding boxes are supplied and returned as `[y_min, x_min, y_max, x_max]`. The
+bounding box coordinates are floats in `[0.0, 1.0]` relative to the width and
+height of the underlying image.
+
+For example,
+
+```python
+    # Generate a single distorted bounding box.
+    begin, size, bbox_for_draw = tf.image.sample_distorted_bounding_box(
+        tf.shape(image),
+        bounding_boxes=bounding_boxes)
+
+    # Draw the bounding box in an image summary.
+    image_with_box = tf.image.draw_bounding_boxes(tf.expand_dims(image, 0),
+                                                  bbox_for_draw)
+    tf.image_summary('images_with_box', image_with_box)
+
+    # Employ the bounding box to distort the image.
+    distorted_image = tf.slice(image, begin, size)
+```
+
+Note that if no bounding box information is available, setting
+`use_image_if_no_bounding_boxes = true` will assume there is a single implicit
+bounding box covering the whole image. If `use_image_if_no_bounding_boxes` is
+false and no bounding boxes are supplied, an error is raised.
+
+image_size: 1-D, containing `[height, width, channels]`.
+bounding_boxes: 3-D with shape `[batch, N, 4]` describing the N bounding boxes
+  associated with the image.
+min_object_covered: The cropped area of the image must contain at least this
+  fraction of any bounding box supplied. The value of this parameter should be
+  non-negative. In the case of 0, the cropped area does not need to overlap
+  any of the bounding boxes supplied.
+begin: 1-D, containing `[offset_height, offset_width, 0]`. Provide as input to
+  `tf.slice`.
+size: 1-D, containing `[target_height, target_width, -1]`. Provide as input to
+  `tf.slice`.
+bboxes: 3-D with shape `[1, 1, 4]` containing the distorted bounding box.
+  Provide as input to `tf.image.draw_bounding_boxes`.
+seed: If either `seed` or `seed2` are set to non-zero, the random number
+  generator is seeded by the given `seed`.  Otherwise, it is seeded by a random
+  seed.
+seed2: A second seed to avoid seed collision.
 aspect_ratio_range: The cropped area of the image must have an aspect ratio =
   width / height within this range.
 area_range: The cropped area of the image must contain a fraction of the
@@ -1030,16 +1120,16 @@ method: A string specifying the interpolation method. Only 'bilinear' is
 // --------------------------------------------------------------------------
 
 REGISTER_OP("NonMaxSuppression")
-  .Input("boxes: float")
-  .Input("scores: float")
-  .Input("max_output_size: int32")
-  .Output("selected_indices: int32")
-  .Attr("iou_threshold: float = 0.5")
-  .SetShapeFn([](InferenceContext* c) {
+    .Input("boxes: float")
+    .Input("scores: float")
+    .Input("max_output_size: int32")
+    .Output("selected_indices: int32")
+    .Attr("iou_threshold: float = 0.5")
+    .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->Vector(c->UnknownDim()));
       return Status::OK();
     })
-  .Doc(R"doc(
+    .Doc(R"doc(
 Greedily selects a subset of bounding boxes in descending order of score,
 pruning away boxes that have high intersection-over-union (IOU) overlap
 with previously selected boxes.  Bounding boxes are supplied as

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -812,27 +812,27 @@ use_image_if_no_bounding_boxes: Controls behavior if no bounding boxes supplied.
 )doc");
 
 REGISTER_OP("SampleDistortedBoundingBoxV2")
-    .Input("image_size: T")
-    .Input("bounding_boxes: float")
-    .Input("min_object_covered: float")
-    .Output("begin: T")
-    .Output("size: T")
-    .Output("bboxes: float")
-    .Attr("T: {uint8, int8, int16, int32, int64}")
-    .Attr("seed: int = 0")
-    .Attr("seed2: int = 0")
-    .Attr("aspect_ratio_range: list(float) = [0.75, 1.33]")
-    .Attr("area_range: list(float) = [0.05, 1.0]")
-    .Attr("max_attempts: int = 100")
-    .Attr("use_image_if_no_bounding_boxes: bool = false")
-    .SetIsStateful()
-    .SetShapeFn([](InferenceContext* c) {
-      c->set_output(0, c->Vector(3));
-      c->set_output(1, c->Vector(3));
-      c->set_output(2, c->MakeShape({1, 1, 4}));
-      return Status::OK();
-    })
-    .Doc(R"doc(
+  .Input("image_size: T")
+  .Input("bounding_boxes: float")
+  .Input("min_object_covered: float")
+  .Output("begin: T")
+  .Output("size: T")
+  .Output("bboxes: float")
+  .Attr("T: {uint8, int8, int16, int32, int64}")
+  .Attr("seed: int = 0")
+  .Attr("seed2: int = 0")
+  .Attr("aspect_ratio_range: list(float) = [0.75, 1.33]")
+  .Attr("area_range: list(float) = [0.05, 1.0]")
+  .Attr("max_attempts: int = 100")
+  .Attr("use_image_if_no_bounding_boxes: bool = false")
+  .SetIsStateful()
+  .SetShapeFn([](InferenceContext* c) {
+    c->set_output(0, c->Vector(3));
+    c->set_output(1, c->Vector(3));
+    c->set_output(2, c->MakeShape({1, 1, 4}));
+    return Status::OK();
+  })
+  .Doc(R"doc(
 Generate a single randomly distorted bounding box for an image.
 
 Bounding box annotations are often supplied in addition to ground-truth labels
@@ -1120,16 +1120,16 @@ method: A string specifying the interpolation method. Only 'bilinear' is
 // --------------------------------------------------------------------------
 
 REGISTER_OP("NonMaxSuppression")
-    .Input("boxes: float")
-    .Input("scores: float")
-    .Input("max_output_size: int32")
-    .Output("selected_indices: int32")
-    .Attr("iou_threshold: float = 0.5")
-    .SetShapeFn([](InferenceContext* c) {
+  .Input("boxes: float")
+  .Input("scores: float")
+  .Input("max_output_size: int32")
+  .Output("selected_indices: int32")
+  .Attr("iou_threshold: float = 0.5")
+  .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->Vector(c->UnknownDim()));
       return Status::OK();
     })
-    .Doc(R"doc(
+  .Doc(R"doc(
 Greedily selects a subset of bounding boxes in descending order of score,
 pruning away boxes that have high intersection-over-union (IOU) overlap
 with previously selected boxes.  Bounding boxes are supplied as

--- a/tensorflow/python/ops/hidden_ops.txt
+++ b/tensorflow/python/ops/hidden_ops.txt
@@ -157,6 +157,8 @@ ResizeBilinearGrad
 ResizeNearestNeighborGrad
 AdjustContrastv2
 ScaleImageGrad
+SampleDistortedBoundingBox
+SampleDistortedBoundingBoxV2
 
 # io_ops
 FixedLengthRecordReader

--- a/tensorflow/python/ops/image_ops.py
+++ b/tensorflow/python/ops/image_ops.py
@@ -62,6 +62,7 @@ See the @{$python/image} guide.
 @@non_max_suppression
 @@non_max_suppression_v2
 @@sample_distorted_bounding_box
+@@sample_distorted_bounding_box_v2
 @@total_variation
 """
 from __future__ import absolute_import

--- a/tensorflow/python/ops/image_ops.py
+++ b/tensorflow/python/ops/image_ops.py
@@ -62,7 +62,6 @@ See the @{$python/image} guide.
 @@non_max_suppression
 @@non_max_suppression_v2
 @@sample_distorted_bounding_box
-@@sample_distorted_bounding_box_v2
 @@total_variation
 """
 from __future__ import absolute_import

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -47,6 +47,7 @@ ops.NotDifferentiable('RGBToHSV')
 ops.NotDifferentiable('HSVToRGB')
 ops.NotDifferentiable('DrawBoundingBoxes')
 ops.NotDifferentiable('SampleDistortedBoundingBox')
+ops.NotDifferentiable('SampleDistortedBoundingBoxV2')
 # TODO(bsteiner): Implement the gradient function for extract_glimpse
 # TODO(b/31222613): This op may be differentiable, and there may be
 # latent bugs here.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1473,3 +1473,104 @@ def total_variation(images, name=None):
                math_ops.reduce_sum(math_ops.abs(pixel_dif2), axis=sum_axis))
 
   return tot_var
+
+
+def sample_distorted_bounding_box(image_size, bounding_boxes, seed=None,
+                                  seed2=None, min_object_covered=None,
+                                  aspect_ratio_range=None, area_range=None,
+                                  max_attempts=None,
+                                  use_image_if_no_bounding_boxes=None,
+                                  name=None):
+  """Generate a single randomly distorted bounding box for an image.
+
+  Bounding box annotations are often supplied in addition to ground-truth labels
+  in image recognition or object localization tasks. A common technique for
+  training such a system is to randomly distort an image while preserving
+  its content, i.e. *data augmentation*. This Op outputs a randomly distorted
+  localization of an object, i.e. bounding box, given an `image_size`,
+  `bounding_boxes` and a series of constraints.
+
+  The output of this Op is a single bounding box that may be used to crop the
+  original image. The output is returned as 3 tensors: `begin`, `size` and
+  `bboxes`. The first 2 tensors can be fed directly into `tf.slice` to crop the
+  image. The latter may be supplied to `tf.image.draw_bounding_boxes` to visualize
+  what the bounding box looks like.
+
+  Bounding boxes are supplied and returned as `[y_min, x_min, y_max, x_max]`. The
+  bounding box coordinates are floats in `[0.0, 1.0]` relative to the width and
+  height of the underlying image.
+
+  For example,
+
+  ```python
+      # Generate a single distorted bounding box.
+      begin, size, bbox_for_draw = tf.image.sample_distorted_bounding_box(
+          tf.shape(image),
+          bounding_boxes=bounding_boxes)
+
+      # Draw the bounding box in an image summary.
+      image_with_box = tf.image.draw_bounding_boxes(tf.expand_dims(image, 0),
+                                                    bbox_for_draw)
+      tf.image_summary('images_with_box', image_with_box)
+
+      # Employ the bounding box to distort the image.
+      distorted_image = tf.slice(image, begin, size)
+  ```
+
+  Note that if no bounding box information is available, setting
+  `use_image_if_no_bounding_boxes = true` will assume there is a single implicit
+  bounding box covering the whole image. If `use_image_if_no_bounding_boxes` is
+  false and no bounding boxes are supplied, an error is raised.
+
+  Args:
+    image_size: A `Tensor`. Must be one of the following types: `uint8`, `int8`, `int16`, `int32`, `int64`.
+      1-D, containing `[height, width, channels]`.
+    bounding_boxes: A `Tensor` of type `float32`.
+      3-D with shape `[batch, N, 4]` describing the N bounding boxes
+      associated with the image.
+    seed: An optional `int`. Defaults to `0`.
+      If either `seed` or `seed2` are set to non-zero, the random number
+      generator is seeded by the given `seed`.  Otherwise, it is seeded by a random
+      seed.
+    seed2: An optional `int`. Defaults to `0`.
+      A second seed to avoid seed collision.
+    min_object_covered: An optional `float`. Defaults to `0.1`.
+      The cropped area of the image must contain at least this
+      fraction of any bounding box supplied. The value of this parameter should be
+      non-negative. In the case of 0, the cropped area does not need to overlap
+      any of the bounding boxes supplied.
+    aspect_ratio_range: An optional list of `floats`. Defaults to `[0.75, 1.33]`.
+      The cropped area of the image must have an aspect ratio =
+      width / height within this range.
+    area_range: An optional list of `floats`. Defaults to `[0.05, 1]`.
+      The cropped area of the image must contain a fraction of the
+      supplied image within in this range.
+    max_attempts: An optional `int`. Defaults to `100`.
+      Number of attempts at generating a cropped region of the image
+      of the specified constraints. After `max_attempts` failures, return the entire
+      image.
+    use_image_if_no_bounding_boxes: An optional `bool`. Defaults to `False`.
+      Controls behavior if no bounding boxes supplied.
+      If true, assume an implicit bounding box covering the whole input. If false,
+      raise an error.
+    name: A name for the operation (optional).
+
+  Returns:
+    A tuple of `Tensor` objects (begin, size, bboxes).
+
+    begin: A `Tensor`. Has the same type as `image_size`. 1-D, containing `[offset_height, offset_width, 0]`. Provide as input to
+      `tf.slice`.
+    size: A `Tensor`. Has the same type as `image_size`. 1-D, containing `[target_height, target_width, -1]`. Provide as input to
+      `tf.slice`.
+    bboxes: A `Tensor` of type `float32`. 3-D with shape `[1, 1, 4]` containing the distorted bounding box.
+      Provide as input to `tf.image.draw_bounding_boxes`.
+  """
+  with ops.name_scope(name, 'sample_distorted_bounding_box'):
+    # TODO (yongtang): Need to switch to v2 after 3 weeks.
+    return gen_image_ops._sample_distorted_bounding_box(image_size,
+                bounding_boxes, seed=seed,
+                seed2=seed2, min_object_covered=min_object_covered,
+                aspect_ratio_range=aspect_ratio_range, area_range=area_range,
+                max_attempts=max_attempts,
+                use_image_if_no_bounding_boxes=use_image_if_no_bounding_boxes,
+                name=name)

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1504,7 +1504,7 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
 
       # sample_distorted_bounding_box and sample_distorted_bounding_box_v2
       for op in [image_ops.sample_distorted_bounding_box,
-                 image_ops.sample_distorted_bounding_box_v2]:
+                 gen_image_ops._sample_distorted_bounding_box_v2]:
         begin, size, _ = op(
             image_size=image_size_tf,
             bounding_boxes=bounding_box_tf,
@@ -1526,7 +1526,7 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
 
       # sample_distorted_bounding_box_v2
       min_object_covered_placeholder = array_ops.placeholder(dtypes.float32)
-      begin, size, _ = image_ops.sample_distorted_bounding_box_v2(
+      begin, size, _ = gen_image_ops._sample_distorted_bounding_box_v2(
           image_size=image_size_tf,
           bounding_boxes=bounding_box_tf,
           min_object_covered=min_object_covered_placeholder,
@@ -1631,7 +1631,7 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
           shape=[4],
           dtype=dtypes.float32,)
       for op in [image_ops.sample_distorted_bounding_box,
-                 image_ops.sample_distorted_bounding_box_v2]:
+                 gen_image_ops._sample_distorted_bounding_box_v2]:
         begin, end, bbox_for_drawing = op(
             image_size=image_size,
             bounding_boxes=bounding_box,

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1501,16 +1501,41 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
           image_size_np, shape=image_size_np.shape)
       bounding_box_tf = constant_op.constant(
           bounding_box_np, dtype=dtypes.float32, shape=bounding_box_np.shape)
-      begin, size, _ = image_ops.sample_distorted_bounding_box(
+
+      # sample_distorted_bounding_box and sample_distorted_bounding_box_v2
+      for op in [image_ops.sample_distorted_bounding_box,
+                 image_ops.sample_distorted_bounding_box_v2]:
+        begin, size, _ = op(
+            image_size=image_size_tf,
+            bounding_boxes=bounding_box_tf,
+            min_object_covered=min_object_covered,
+            aspect_ratio_range=aspect_ratio_range,
+            area_range=area_range)
+        y = array_ops.strided_slice(image_tf, begin, begin + size)
+
+        for _ in xrange(num_iter):
+          y_tf = y.eval()
+          crop_height = y_tf.shape[0]
+          crop_width = y_tf.shape[1]
+          aspect_ratio = float(crop_width) / float(crop_height)
+          area = float(crop_width * crop_height)
+
+          aspect_ratios.append(aspect_ratio)
+          area_ratios.append(area / original_area)
+          fraction_object_covered.append(float(np.sum(y_tf)) / bounding_box_area)
+
+      # sample_distorted_bounding_box_v2
+      min_object_covered_placeholder = array_ops.placeholder(dtypes.float32)
+      begin, size, _ = image_ops.sample_distorted_bounding_box_v2(
           image_size=image_size_tf,
           bounding_boxes=bounding_box_tf,
-          min_object_covered=min_object_covered,
+          min_object_covered=min_object_covered_placeholder,
           aspect_ratio_range=aspect_ratio_range,
           area_range=area_range)
       y = array_ops.strided_slice(image_tf, begin, begin + size)
 
       for _ in xrange(num_iter):
-        y_tf = y.eval()
+        y_tf = y.eval(feed_dict={min_object_covered_placeholder: min_object_covered})
         crop_height = y_tf.shape[0]
         crop_width = y_tf.shape[1]
         aspect_ratio = float(crop_width) / float(crop_height)
@@ -1605,10 +1630,24 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
           [0.0, 0.0, 1.0, 1.0],
           shape=[4],
           dtype=dtypes.float32,)
-      begin, end, bbox_for_drawing = image_ops.sample_distorted_bounding_box(
+      for op in [image_ops.sample_distorted_bounding_box,
+                 image_ops.sample_distorted_bounding_box_v2]:
+        begin, end, bbox_for_drawing = op(
+            image_size=image_size,
+            bounding_boxes=bounding_box,
+            min_object_covered=0.1,
+            aspect_ratio_range=(0.75, 1.33),
+            area_range=(0.05, 1.0))
+
+        # Test that the shapes are correct.
+        self.assertAllEqual([3], begin.get_shape().as_list())
+        self.assertAllEqual([3], end.get_shape().as_list())
+        self.assertAllEqual([1, 1, 4], bbox_for_drawing.get_shape().as_list())
+
+      begin, end, bbox_for_drawing = op(
           image_size=image_size,
           bounding_boxes=bounding_box,
-          min_object_covered=0.1,
+          min_object_covered=array_ops.placeholder(dtypes.float32),
           aspect_ratio_range=(0.75, 1.33),
           area_range=(0.05, 1.0))
 


### PR DESCRIPTION
This fix tries to address the issue raised in #10715 where it was not possible
to use dynamic values for min_object_covered in sample_distorted_bounding_box.

This fix created an Op of SampleDistortedBoundingBoxV2 so that min_object_covered
takes input. SampleDistortedBoundingBox remains the same (min_object_covered as attr).

Additional test cases have been added.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>