### PR TITLE
Java API to get the size of specified input list of operations.

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/Operation.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Operation.java
@@ -102,9 +102,7 @@ public final class Operation {
    *
    * <p>An Operation has multiple named inputs, each of which contains either
    * a single tensor or a list of tensors. This method returns the size of
-   * the list of tensors for a specific named input of the operation.The length
-   * of the list should be equal to the number of inputs specified by this
-   * operation's op def.
+   * the list of tensors for a specific named input of the operation.
    *
    * @param name identifier of the list of tensors (of which there may
    *        be many) inputs to this operation.

--- a/tensorflow/java/src/main/java/org/tensorflow/Operation.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Operation.java
@@ -97,6 +97,30 @@ public final class Operation {
     return new Output(this, idx);
   }
 
+  /**
+   * Returns the size of the given inputs list of Tensors for this operation.
+   *
+   * <p>An Operation has multiple named inputs, each of which contains either
+   * a single tensor or a list of tensors. This method returns the size of
+   * the list of tensors for a specific named input of the operation.The length
+   * of the list should be equal to the number of inputs specified by this
+   * operation's op def.
+   *
+   * @param name identifier of the list of tensors (of which there may
+   *        be many) inputs to this operation.
+   * @returns the size of the list of Tensors produced by this named input.
+   * @throws IllegalArgumentException if this operation has no input
+   *         with the provided name.
+   */
+  public int inputListLength(final String name) {
+    Graph.Reference r = graph.ref();
+    try {
+      return inputListLength(unsafeNativeHandle, name);
+    } finally {
+      r.close();
+    }
+  }
+
   long getUnsafeNativeHandle() {
     return unsafeNativeHandle;
   }
@@ -131,6 +155,8 @@ public final class Operation {
   private static native int numOutputs(long handle);
 
   private static native int outputListLength(long handle, String name);
+
+  private static native int inputListLength(long handle, String name);
 
   private static native long[] shape(long graphHandle, long opHandle, int output);
 

--- a/tensorflow/java/src/main/native/operation_jni.cc
+++ b/tensorflow/java/src/main/native/operation_jni.cc
@@ -156,3 +156,21 @@ JNIEXPORT jint JNICALL Java_org_tensorflow_Operation_dtype(JNIEnv* env,
 
   return static_cast<jint>(TF_OperationOutputType(TF_Output{op, output_index}));
 }
+
+JNIEXPORT jint JNICALL Java_org_tensorflow_Operation_inputListLength(JNIEnv* env,
+                                                                      jclass clazz,
+                                                                      jlong handle,
+                                                                      jstring name) {
+  TF_Operation* op = requireHandle(env, handle);
+  if (op == nullptr) return 0;
+
+  TF_Status* status = TF_NewStatus();
+
+  const char* cname = env->GetStringUTFChars(name, nullptr);
+  int result = TF_OperationInputListLength(op, cname, status);
+  env->ReleaseStringUTFChars(name, cname);
+
+  throwExceptionIfNotOK(env, status);
+  TF_DeleteStatus(status);
+  return result;
+}

--- a/tensorflow/java/src/main/native/operation_jni.h
+++ b/tensorflow/java/src/main/native/operation_jni.h
@@ -73,6 +73,17 @@ JNIEXPORT jlongArray JNICALL Java_org_tensorflow_Operation_shape(JNIEnv *,
 JNIEXPORT jint JNICALL Java_org_tensorflow_Operation_dtype(JNIEnv *, jclass,
                                                            jlong, jlong, jint);
 
+
+/*
+ * Class:     org_tensorflow_Operation
+ * Method:    inputListLength
+ * Signature: (JLjava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_org_tensorflow_Operation_inputListLength(JNIEnv *,
+                                                                      jclass,
+                                                                      jlong,
+                                                                      jstring);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tensorflow/java/src/test/java/org/tensorflow/OperationTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/OperationTest.java
@@ -52,6 +52,16 @@ public class OperationTest {
     assertEquals(3, split(new int[] {0, 1, 2}, 3));
   }
 
+  @Test
+  public void inputListLength() {
+    assertEquals(1, splitWithInputList(new int[] {0, 1}, 1, "split_dim"));
+    try {
+      splitWithInputList(new int[] {0, 1}, 2, "inputs");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+  }
+
   private static int split(int[] values, int num_split) {
     try (Graph g = new Graph()) {
       return g.opBuilder("Split", "Split")
@@ -60,6 +70,17 @@ public class OperationTest {
           .setAttr("num_split", num_split)
           .build()
           .outputListLength("output");
+    }
+  }
+
+  private static int splitWithInputList(int[] values, int num_split, String name) {
+    try (Graph g = new Graph()) {
+      return g.opBuilder("Split", "Split")
+          .addInput(TestUtil.constant(g, "split_dim", 0))
+          .addInput(TestUtil.constant(g, "values", values))
+          .setAttr("num_split", num_split)
+          .build()
+          .inputListLength(name);
     }
   }
 }


### PR DESCRIPTION
This opens up access to the TF_OperationInputListLength C API from java, for operations that return specified input lists.