### PR TITLE
fix error string format

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -1445,7 +1445,8 @@ def fully_connected(inputs,
     ValueError: If x has rank less than 2 or if its last dimension is not set.
   """
   if not isinstance(num_outputs, six.integer_types):
-    raise ValueError('num_outputs should be int or long, got %s.', num_outputs)
+    raise ValueError(
+        'num_outputs should be int or long, got %s.' % (num_outputs,))
 
   layer_variable_getter = _build_variable_getter({'bias': 'biases',
                                                   'kernel': 'weights'})


### PR DESCRIPTION
I just got this helpful error message, and I'm submitting a fix for the format.

ValueError: ('num_outputs should be int or long, got %s.', <tf.Tensor 'mul:0' shape=() dtype=int32>)

becomes

ValueError: num_outputs should be int or long, got Tensor("mul:0", shape=(), dtype=int32).