### PR TITLE
Improve docs for tf.nn.depthwise_conv2d_native

### DIFF
--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -831,11 +831,13 @@ a different filter to each input channel (expanding from 1 channel to
 `channel_multiplier` channels for each), then concatenates the results
 together. Thus, the output has `in_channels * channel_multiplier` channels.
 
+```
 for k in 0..in_channels-1
   for q in 0..channel_multiplier-1
     output[b, i, j, k * channel_multiplier + q] =
       sum_{di, dj} input[b, strides[1] * i + di, strides[2] * j + dj, k] *
                         filter[di, dj, k, q]
+```
 
 Must have `strides[0] = strides[3] = 1`.  For the most common case of the same
 horizontal and vertices strides, `strides = [1, stride, stride, 1]`.


### PR DESCRIPTION
Hi,

In [`depthwise_conv2d_native` docs](https://www.tensorflow.org/api_docs/python/tf/nn/depthwise_conv2d_native), the formula to calculate the output tensor is not written inside "code" tag for markdown.

Screenshot of the docs -

![screenshot from 2017-06-21 21-38-21](https://user-images.githubusercontent.com/3175743/27394554-461c57aa-56ca-11e7-874e-587a02d53f7a.png)
