### PR TITLE
Correct the learning rate as per the code snippet

### DIFF
--- a/tensorflow/docs_src/get_started/mnist/beginners.md
+++ b/tensorflow/docs_src/get_started/mnist/beginners.md
@@ -367,7 +367,7 @@ train_step = tf.train.GradientDescentOptimizer(0.05).minimize(cross_entropy)
 
 In this case, we ask TensorFlow to minimize `cross_entropy` using the
 [gradient descent algorithm](https://en.wikipedia.org/wiki/Gradient_descent)
-with a learning rate of 0.5. Gradient descent is a simple procedure, where
+with a learning rate of 0.05. Gradient descent is a simple procedure, where
 TensorFlow simply shifts each variable a little bit in the direction that
 reduces the cost. But TensorFlow also provides
 @{$python/train#Optimizers$many other optimization algorithms}:


### PR DESCRIPTION
The training step, `train_step = tf.train.GradientDescentOptimizer(0.05).minimize(cross_entropy)` states the learning rate as 0.05, whereas the documentation states 0.5. This needs to be corrected.