### PR TITLE
Update WorkerCacheLogger::RecordRecvTensor

### DIFF
--- a/tensorflow/core/distributed_runtime/worker_cache_logger.cc
+++ b/tensorflow/core/distributed_runtime/worker_cache_logger.cc
@@ -87,15 +87,17 @@ void WorkerCacheLogger::RecordRecvTensor(int64 step_id, int64 start_usecs,
                                          const string& tensor_name,
                                          const string& src_device,
                                          const string& dst_device,
-                                         int64 bytes) {
+                                         int64 bytes,
+                                         const string& note,
+                                         const string& title) {
   NodeExecStats* ns = new NodeExecStats;
-  ns->set_node_name("RecvTensor");
+  ns->set_node_name(title);
   string byte_string = strings::StrCat("[", bytes, "B] ");
   if (bytes >= 0.1 * 1048576.0) {
     byte_string = strings::Printf("[%.1fMB] ", bytes / 1048576.0);
   }
   ns->set_timeline_label(strings::StrCat(byte_string, tensor_name, " from ",
-                                         src_device, " to ", dst_device));
+                                         src_device, " to ", dst_device, note));
   ns->set_all_start_micros(start_usecs);
   ns->set_op_start_rel_micros(0);
   int64 elapsed = end_usecs - start_usecs;

--- a/tensorflow/core/distributed_runtime/worker_cache_logger.cc
+++ b/tensorflow/core/distributed_runtime/worker_cache_logger.cc
@@ -87,30 +87,40 @@ void WorkerCacheLogger::RecordRecvTensor(int64 step_id, int64 start_usecs,
                                          const string& tensor_name,
                                          const string& src_device,
                                          const string& dst_device,
-                                         int64 bytes,
-                                         const string& note,
-                                         const string& title) {
-  NodeExecStats* ns = new NodeExecStats;
-  ns->set_node_name(title);
-  string byte_string = strings::StrCat("[", bytes, "B] ");
-  if (bytes >= 0.1 * 1048576.0) {
-    byte_string = strings::Printf("[%.1fMB] ", bytes / 1048576.0);
-  }
-  ns->set_timeline_label(strings::StrCat(byte_string, tensor_name, " from ",
-                                         src_device, " to ", dst_device, note));
-  ns->set_all_start_micros(start_usecs);
-  ns->set_op_start_rel_micros(0);
-  int64 elapsed = end_usecs - start_usecs;
-  ns->set_op_end_rel_micros(elapsed);
-  ns->set_all_end_rel_micros(elapsed);
-  NodeOutput* no = ns->add_output();
-  no->set_slot(0);
-  // TODO(tucker): Maybe set the dimensions too, but then they'll
-  // need to be passed in.
-  no->mutable_tensor_description()
-      ->mutable_allocation_description()
-      ->set_requested_bytes(bytes);
-  Save(dst_device, step_id, ns);
+                                         int64 bytes) {
+  RecordDataTransfer(step_id, start_usecs, end_usecs, tensor_name, src_device,
+    dst_device, bytes, "", "RecvTensor");
 }
 
+void WorkerCacheLogger::RecordDataTransfer(int64 step_id, int64 start_usecs,
+                                           int64 end_usecs,
+                                           const string& tensor_name,
+                                           const string& src_device,
+                                           const string& dst_device,
+                                           int64 bytes,
+                                           const string& details,
+                                           const string& transfer_method_name){
+  NodeExecStats* ns = new NodeExecStats;
+    ns->set_node_name(transfer_method_name);
+    string byte_string = strings::StrCat("[", bytes, "B] ");
+    if (bytes >= 0.1 * 1048576.0) {
+      byte_string = strings::Printf("[%.1fMB] ", bytes / 1048576.0);
+    }
+    ns->set_timeline_label(strings::StrCat(byte_string, tensor_name, " from ",
+                                           src_device, " to ", dst_device,
+                                           details));
+    ns->set_all_start_micros(start_usecs);
+    ns->set_op_start_rel_micros(0);
+    int64 elapsed = end_usecs - start_usecs;
+    ns->set_op_end_rel_micros(elapsed);
+    ns->set_all_end_rel_micros(elapsed);
+    NodeOutput* no = ns->add_output();
+    no->set_slot(0);
+    // TODO(tucker): Maybe set the dimensions too, but then they'll
+    // need to be passed in.
+    no->mutable_tensor_description()
+        ->mutable_allocation_description()
+        ->set_requested_bytes(bytes);
+    Save(dst_device, step_id, ns);
+  }
 }  // namespace tensorflow

--- a/tensorflow/core/distributed_runtime/worker_cache_logger.h
+++ b/tensorflow/core/distributed_runtime/worker_cache_logger.h
@@ -58,7 +58,9 @@ class WorkerCacheLogger {
   // later retrieval by RetrieveLogs().
   void RecordRecvTensor(int64 step_id, int64 start_usecs, int64 end_usecs,
                         const string& tensor_name, const string& src_device,
-                        const string& dst_device, int64 bytes);
+                        const string& dst_device, int64 bytes,
+                        const string& node="",
+                        const string& title="RecvTensor");
 
  private:
   mutex count_mu_;

--- a/tensorflow/core/distributed_runtime/worker_cache_logger.h
+++ b/tensorflow/core/distributed_runtime/worker_cache_logger.h
@@ -58,9 +58,16 @@ class WorkerCacheLogger {
   // later retrieval by RetrieveLogs().
   void RecordRecvTensor(int64 step_id, int64 start_usecs, int64 end_usecs,
                         const string& tensor_name, const string& src_device,
-                        const string& dst_device, int64 bytes,
-                        const string& node="",
-                        const string& title="RecvTensor");
+                        const string& dst_device, int64 bytes, 
+                        const string& node);
+
+  // Generates a NodeExecStats record with the given data, and saves for
+  // later retrieval by RetrieveLogs().
+  void RecordDataTransfer(int64 step_id, int64 start_usecs, int64 end_usecs,
+                          const string& tensor_name, const string& src_device,
+                          const string& dst_device, int64 bytes,
+                          const string& details,
+                          const string& transfer_method_name);
 
  private:
   mutex count_mu_;

--- a/tensorflow/core/distributed_runtime/worker_cache_logger.h
+++ b/tensorflow/core/distributed_runtime/worker_cache_logger.h
@@ -58,8 +58,7 @@ class WorkerCacheLogger {
   // later retrieval by RetrieveLogs().
   void RecordRecvTensor(int64 step_id, int64 start_usecs, int64 end_usecs,
                         const string& tensor_name, const string& src_device,
-                        const string& dst_device, int64 bytes, 
-                        const string& node);
+                        const string& dst_device, int64 bytes);
 
   // Generates a NodeExecStats record with the given data, and saves for
   // later retrieval by RetrieveLogs().


### PR DESCRIPTION
Update WorkerCacheLogger::RecordRecvTensor to let future improvements to tracing tools:
* Add a placeholder for more details about a RecvTensor call.
* Custom title to possibly distinguish between control and data flow RecvTensor calls.