### PR TITLE
python_configure.bzl: Add python import library on Windows

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -847,10 +847,10 @@ def _genrule(src_dir, genrule_name, command, outs):
       genrule_name + '",\n' +
       '    outs = [\n' +
       outs +
-      '    ],\n' +
+      '\n    ],\n' +
       '    cmd = """\n' +
       command +
-      '    """,\n' +
+      '\n   """,\n' +
       ')\n\n'
   )
 

--- a/third_party/py/BUILD.tpl
+++ b/third_party/py/BUILD.tpl
@@ -6,6 +6,16 @@ cc_library(
     name = "python_headers",
     hdrs = [":python_include"],
     includes = ["python_include"],
+    data = select({
+      ":windows" : [":python_import_lib"],
+      "//conditions:default": [],
+    }),
+    linkopts = select({
+      # TODO(pcloudy): Ideally, this should just go into deps after resolving
+      # https://github.com/bazelbuild/bazel/issues/3237,
+      ":windows" : ["$(locations :python_import_lib)"],
+      "//conditions:default": [],
+    }),
 )
 
 cc_library(
@@ -21,5 +31,7 @@ config_setting(
 )
 
 %{PYTHON_INCLUDE_GENRULE}
+
+%{PYTHON_IMPORT_LIB_GENRULE}
 
 %{NUMPY_INCLUDE_GENRULE}

--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -117,10 +117,10 @@ def _genrule(src_dir, genrule_name, command, outs):
       genrule_name + '",\n' +
       '    outs = [\n' +
       outs +
-      '    ],\n' +
+      '\n    ],\n' +
       '    cmd = """\n' +
       command +
-      '    """,\n' +
+      '\n   """,\n' +
       ')\n\n'
   )
 
@@ -133,15 +133,20 @@ def _norm_path(path):
   return path
 
 
-def _symlink_genrule_for_dir(repository_ctx, src_dir, dest_dir, genrule_name):
+def _symlink_genrule_for_dir(repository_ctx, src_dir, dest_dir, genrule_name,
+    src_files = [], dest_files = []):
   """Returns a genrule to symlink(or copy if on Windows) a set of files.
+
+  If src_dir is passed, files will be read from the given directory; otherwise
+  we assume files are in src_files and dest_files
   """
-  src_dir = _norm_path(src_dir)
-  dest_dir = _norm_path(dest_dir)
-  files = _read_dir(repository_ctx, src_dir)
-  # Create a list with the src_dir stripped to use for outputs.
-  dest_files = files.replace(src_dir, '').splitlines()
-  src_files = files.splitlines()
+  if src_dir != None:
+    src_dir = _norm_path(src_dir)
+    dest_dir = _norm_path(dest_dir)
+    files = _read_dir(repository_ctx, src_dir)
+    # Create a list with the src_dir stripped to use for outputs.
+    dest_files = files.replace(src_dir, '').splitlines()
+    src_files = files.splitlines()
   command = []
   outs = []
   for i in range(len(dest_files)):
@@ -217,8 +222,20 @@ def _get_python_include(repository_ctx, python_bin):
                      'print(sysconfig.get_python_inc())'],
                     error_msg="Problem getting python include path.",
                     error_details=("Is the Python binary path set up right? " +
-                                   "(See ./configure or BAZEL_BIN_PATH.) " +
+                                   "(See ./configure or PYTHON_BIN_PATH.) " +
                                    "Is distutils installed?"))
+  return result.stdout.splitlines()[0]
+
+
+def _get_python_import_lib_name(repository_ctx, python_bin):
+  """Get Python import library name (pythonXY.lib) on Windows."""
+  result = _execute(repository_ctx,
+                    [python_bin, "-c",
+                     'import sys;' +
+                     'print("python" + str(sys.version_info[0]) + str(sys.version_info[1]) + ".lib")'],
+                    error_msg="Problem getting python import library.",
+                    error_details=("Is the Python binary path set up right? " +
+                                   "(See ./configure or PYTHON_BIN_PATH.) "))
   return result.stdout.splitlines()[0]
 
 
@@ -240,11 +257,11 @@ def _create_local_python_repository(repository_ctx):
   empty_config = False
   # If local checks were requested, the python and numpy include will be auto
   # detected on the host config (using _PYTHON_BIN_PATH).
+  python_bin = _get_env_var(repository_ctx, _PYTHON_BIN_PATH,
+                            "/usr/bin/python")
   if repository_ctx.attr.local_checks:
     # TODO(nlopezgi): The default argument here is a workaround until
     #                 bazelbuild/bazel#3057 is resolved.
-    python_bin = _get_env_var(repository_ctx, _PYTHON_BIN_PATH,
-                              "/usr/bin/python")
     _check_python_bin(repository_ctx, python_bin)
     python_lib = _get_env_var(repository_ctx, _PYTHON_LIB_PATH,
                               _get_python_lib(repository_ctx, python_bin))
@@ -263,6 +280,10 @@ def _create_local_python_repository(repository_ctx):
                                       '    name = "python_include",\n' +
                                       '    srcs = [],\n' +
                                       ')\n'),
+        "%{PYTHON_IMPORT_LIB_GENRULE}": ('filegroup(\n' +
+                                      '    name = "python_import_lib",\n' +
+                                      '    srcs = [],\n' +
+                                      ')\n'),
         "%{NUMPY_INCLUDE_GENRULE}": ('filegroup(\n' +
                                       '    name = "numpy_include",\n' +
                                       '    srcs = [],\n' +
@@ -271,10 +292,21 @@ def _create_local_python_repository(repository_ctx):
   else:
     python_include_rule = _symlink_genrule_for_dir(
         repository_ctx, python_include, 'python_include', 'python_include')
+    python_import_lib_genrule = ""
+    # To build Python C/C++ extension on Windows, we need to link to python import library pythonXY.lib
+    # See https://docs.python.org/3/extending/windows.html
+    if _is_windows(repository_ctx):
+      python_include = _norm_path(python_include)
+      python_import_lib_name = _get_python_import_lib_name(repository_ctx, python_bin)
+      python_import_lib_src = python_include.rsplit('/', 1)[0] + "/libs/" + python_import_lib_name
+      python_import_lib_genrule = _symlink_genrule_for_dir(
+        repository_ctx, None, '', 'python_import_lib',
+        [python_import_lib_src], [python_import_lib_name])
     numpy_include_rule = _symlink_genrule_for_dir(
         repository_ctx, numpy_include, 'numpy_include/numpy', 'numpy_include')
     _tpl(repository_ctx, "BUILD", {
         "%{PYTHON_INCLUDE_GENRULE}": python_include_rule,
+        "%{PYTHON_IMPORT_LIB_GENRULE}": python_import_lib_genrule,
         "%{NUMPY_INCLUDE_GENRULE}": numpy_include_rule,
     })
 


### PR DESCRIPTION
When building a Python C/C++ extension on Windows, we need to link to the python [import library](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682592(v=vs.85).aspx) pythonXY.lib (eg. `C:\Program Files\Anaconda3\libs\python35.lib`)
See https://docs.python.org/3/extending/windows.html

Previously, TensorFlow relies on Bazel [adding ](https://github.com/bazelbuild/bazel/blob/master/tools/cpp/windows_cc_configure.bzl#L324)the python lib path `C:\Program Files\Anaconda3\libs` into `LIB` environment variable, the build will break after Bazel stop doing so.

To solve this problem, we generate a python_import_lib rule. Ideally, it should be a `cc_library`, but when building a dll, Bazel add /WHOLEARCHIVE to `python35.lib` because it cannot tell it's a static library or import library(they have the same extension `.lib`). This will cause a linking error. As a workaround, we put it into `linkopts` if `python_headers`.
See more details at https://github.com/bazelbuild/bazel/issues/3237