### PR TITLE
pass -O options when generating dependency

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -213,7 +213,7 @@ def InvokeNvcc(argv, log=False):
            ' --compiler-options "' + host_compiler_options + '"' +
            ' --compiler-bindir=' + GCC_HOST_COMPILER_PATH +
            ' -I .' +
-           ' -x cu ' + includes + ' ' + srcs + ' -M -o ' + depfile)
+           ' -x cu ' + opt + includes + ' ' + srcs + ' -M -o ' + depfile)
     if log: Log(cmd)
     exit_status = os.system(cmd)
     if exit_status != 0:


### PR DESCRIPTION
In the current implementation, when generating the dependency in [L126](https://github.com/tensorflow/tensorflow/blob/master/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl#L216), the optimization option is not passed to nvcc, which makes nvcc to generate a lot of warnings that looks like:

```
_FORTIFY_SOURCE requires compiling with optimization (-O)
```
This PR clear these warnings by passing optimization option when generating dependency.

The following issues are fixed by this PR: 
https://github.com/tensorflow/tensorflow/issues/9149
https://github.com/tensorflow/tensorflow/issues/2153