### PR TITLE
Support specify the user name when writing data to HDFS。 You can spec…

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -57,6 +57,7 @@ class LibHDFS {
   std::function<hdfsFS(hdfsBuilder*)> hdfsBuilderConnect;
   std::function<hdfsBuilder*()> hdfsNewBuilder;
   std::function<void(hdfsBuilder*, const char*)> hdfsBuilderSetNameNode;
+  std::function<void(hdfsBuilder*, const char*)> hdfsBuilderSetUserName;
   std::function<int(const char*, char**)> hdfsConfGetStr;
   std::function<void(hdfsBuilder*, const char* kerbTicketCachePath)>
       hdfsBuilderSetKerbTicketCachePath;
@@ -85,6 +86,7 @@ class LibHDFS {
       BIND_HDFS_FUNC(hdfsBuilderConnect);
       BIND_HDFS_FUNC(hdfsNewBuilder);
       BIND_HDFS_FUNC(hdfsBuilderSetNameNode);
+      BIND_HDFS_FUNC(hdfsBuilderSetUserName);
       BIND_HDFS_FUNC(hdfsConfGetStr);
       BIND_HDFS_FUNC(hdfsBuilderSetKerbTicketCachePath);
       BIND_HDFS_FUNC(hdfsCloseFile);
@@ -163,6 +165,10 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
     hdfs_->hdfsBuilderSetNameNode(builder, "default");
   } else {
     hdfs_->hdfsBuilderSetNameNode(builder, nn.c_str());
+  }
+  char* tf_hdfs_user = getenv("TF_HDFS_USER");
+  if (tf_hdfs_user != nullptr) {
+    hdfs_->hdfsBuilderSetUserName(builder, tf_hdfs_user);
   }
   char* ticket_cache_path = getenv("KERB_TICKET_CACHE_PATH");
   if (ticket_cache_path != nullptr) {

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -166,7 +166,7 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
   } else {
     hdfs_->hdfsBuilderSetNameNode(builder, nn.c_str());
   }
-  char* tf_hdfs_user = getenv("TF_HDFS_USER");
+  const char* tf_hdfs_user = getenv("TF_HDFS_USER");
   if (tf_hdfs_user != nullptr) {
     hdfs_->hdfsBuilderSetUserName(builder, tf_hdfs_user);
   }

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -166,7 +166,7 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
   } else {
     hdfs_->hdfsBuilderSetNameNode(builder, nn.c_str());
   }
-  const char* tf_hdfs_user = getenv("TF_HDFS_USER");
+  const char* tf_hdfs_user = getenv("HADOOP_USER_NAME");
   if (tf_hdfs_user != nullptr) {
     hdfs_->hdfsBuilderSetUserName(builder, tf_hdfs_user);
   }


### PR DESCRIPTION
When I write data to HDFS I can not specify username
This scenario is used by multiple users using the same client as a local user.

You can specify the environment variable （TF_HDFS_USER） to modify the username.

 e.g:
export TF_HDFS_USER="username"