### PR TITLE
Sort shuffled indices before indexing NumpyFeed

### DIFF
--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -171,9 +171,10 @@ class _OrderedDictNumpyFeedFn(object):
 
     # Get sorted indices and remember how to reorder output.
     # This allows for the use of h5py databases which require ordered indexing.
-    sorted_integer_indexes, reorder_indexes = zip(
-        *sorted([(value, index)
-                 for index, value in enumerate(integer_indexes)]))
+    original_indexes, sorted_integer_indexes = \
+        zip(*sorted(enumerate(integer_indexes), key=lambda x: x[1]))
+    reorder_indexes, _ = \
+        zip(*sorted(enumerate(original_indexes), key=lambda x: x[1]))
     sorted_integer_indexes = list(sorted_integer_indexes)
     reorder_indexes = list(reorder_indexes)
 

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -170,6 +170,7 @@ class _OrderedDictNumpyFeedFn(object):
         total_epochs=self._num_epochs)
 
     # Get sorted indices and remember how to reorder output.
+    # This allows for the use of h5py databases which require ordered indexing.
     sorted_integer_indexes, reorder_indexes = zip(
         *sorted([(value, index)
                  for index, value in enumerate(integer_indexes)]))

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -169,7 +169,7 @@ class _OrderedDictNumpyFeedFn(object):
         current_epoch=self._epoch,
         total_epochs=self._num_epochs)
 
-    # Get sorted indices and remember how to reorder output
+    # Get sorted indices and remember how to reorder output.
     sorted_integer_indexes, reorder_indexes = zip(
         *sorted([(value, index)
                  for index, value in enumerate(integer_indexes)]))

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -169,10 +169,17 @@ class _OrderedDictNumpyFeedFn(object):
         current_epoch=self._epoch,
         total_epochs=self._num_epochs)
 
+    # Get sorted indices and remember how to reorder output
+    sorted_integer_indexes, reorder_indexes = zip(
+        *sorted([(value, index)
+                 for index, value in enumerate(integer_indexes)]))
+    sorted_integer_indexes = list(sorted_integer_indexes)
+    reorder_indexes = list(reorder_indexes)
+
     self._trav = (integer_indexes[-1] + 1) % self._max
     feed_dict = {self._index_placeholder: integer_indexes}
     cols = [
-        column[sorted(integer_indexes)]
+        column[sorted_integer_indexes][reorder_indexes]
         for column in self._ordered_dict_of_arrays.values()
     ]
     feed_dict.update(dict(zip(self._col_placeholders, cols)))

--- a/tensorflow/python/estimator/inputs/queues/feeding_functions.py
+++ b/tensorflow/python/estimator/inputs/queues/feeding_functions.py
@@ -172,7 +172,7 @@ class _OrderedDictNumpyFeedFn(object):
     self._trav = (integer_indexes[-1] + 1) % self._max
     feed_dict = {self._index_placeholder: integer_indexes}
     cols = [
-        column[integer_indexes]
+        column[sorted(integer_indexes)]
         for column in self._ordered_dict_of_arrays.values()
     ]
     feed_dict.update(dict(zip(self._col_placeholders, cols)))


### PR DESCRIPTION
It is possible to use `h5py` datasets with `tf.estimator.inputs.numpy_input_fn` as there is a high level of compatibility.

However, with `shuffle=True`, one can no longer do so due to the following error:

    TypeError: Indexing elements must be in increasing order

This small change allows for one to use large HDF5 datasets via `h5py` with shuffled batch indices.