### PR TITLE
Windows: Fix CUDNN_INSTALL_PATH in ./configure

### DIFF
--- a/configure
+++ b/configure
@@ -590,6 +590,9 @@ while true; do
     # Result returned from "read" will be used unexpanded. That make "~" unusable.
     # Going through one more level of expansion to handle that.
     CUDNN_INSTALL_PATH=`"${PYTHON_BIN_PATH}" -c "import os; print(os.path.realpath(os.path.expanduser('${CUDNN_INSTALL_PATH}')))"`
+    if is_windows; then
+      CUDNN_INSTALL_PATH="$(cygpath -m "$CUDNN_INSTALL_PATH")"
+    fi
   fi
 
   if [[ -z "$TF_CUDNN_VERSION" ]]; then


### PR DESCRIPTION
Convert `CUDNN_INSTALL_PATH` from path style like `c:\tools\cuda` to `c:/tools/cuda`
Didn't notice this before debugging https://github.com/tensorflow/tensorflow/pull/10995, because on CI, we set CUDNN_INSTALL_PATH directly.