### PR TITLE
Fix #10823 moving vlog to higher level

### DIFF
--- a/tensorflow/core/framework/op.cc
+++ b/tensorflow/core/framework/op.cc
@@ -77,9 +77,10 @@ Status OpRegistry::LookUp(const string& op_type_name,
     if (first_unregistered) {
       OpList op_list;
       Export(true, &op_list);
-      VLOG(1) << "All registered Ops:";
-      for (const auto& op : op_list.op()) {
-        VLOG(3) << SummarizeOpDef(op);
+      if (VLOG_IS_ON(3)) {
+         LOG(INFO) << "All registered Ops:";
+         for (const auto& op : op_list.op())
+            LOG(INFO) << SummarizeOpDef(op);
       }
       first_unregistered = false;
     }

--- a/tensorflow/core/framework/op.cc
+++ b/tensorflow/core/framework/op.cc
@@ -79,7 +79,7 @@ Status OpRegistry::LookUp(const string& op_type_name,
       Export(true, &op_list);
       VLOG(1) << "All registered Ops:";
       for (const auto& op : op_list.op()) {
-        VLOG(1) << SummarizeOpDef(op);
+        VLOG(3) << SummarizeOpDef(op);
       }
       first_unregistered = false;
     }


### PR DESCRIPTION
This PR contains fix for moving VLOG level to higher level as specified in the issue.
VLOG is moved to level 3 as suggested in the comments.