### PR TITLE
change an error in annotation`

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -2432,7 +2432,7 @@ class Graph(object):
 
   @property
   def building_function(self):
-    """Returns True iff this graph represents a function."""
+    """Returns True if this graph represents a function."""
     return self._building_function
 
   # Helper functions to create operations.


### PR DESCRIPTION
there is an error in annotation of ops.py in tensorflow\tensorflow\python\ops. I think it is just a spelling mistake