### PR TITLE
Remove implicit iteration from third_party/toolchains/cpu/CROSSTOOL

### DIFF
--- a/third_party/toolchains/cpus/CROSSTOOL
+++ b/third_party/toolchains/cpus/CROSSTOOL
@@ -374,12 +374,15 @@ toolchain {
       action: 'c++-header-preprocessing'
       action: 'c++-module-compile'
       flag_group {
+        iterate_over: 'quote_include_paths'
         flag: '/I%{quote_include_paths}'
       }
       flag_group {
+        iterate_over: 'include_paths'
         flag: '/I%{include_paths}'
       }
       flag_group {
+        iterate_over: 'system_include_paths'
         flag: '/I%{system_include_paths}'
       }
     }
@@ -630,6 +633,7 @@ toolchain {
       action: 'c++-link-dynamic-library'
       expand_if_all_available: 'linkstamp_paths'
       flag_group {
+        iterate_over: 'linkstamp_paths'
         flag: '%{linkstamp_paths}'
       }
     }
@@ -671,6 +675,7 @@ toolchain {
       action: 'c++-link-pic-static-library'
       action: 'c++-link-alwayslink-pic-static-library'
       flag_group {
+        iterate_over: 'libopts'
         flag: '%{libopts}'
       }
     }
@@ -691,6 +696,7 @@ toolchain {
           }
           iterate_over: 'libraries_to_link.object_files'
           flag_group {
+            iterate_over: 'libraries_to_link.object_files'
             flag: '%{libraries_to_link.object_files}'
           }
         }
@@ -770,6 +776,7 @@ toolchain {
       action: 'c++-link-executable'
       action: 'c++-link-dynamic-library'
       flag_group {
+        iterate_over: 'legacy_link_flags'
         flag: '%{legacy_link_flags}'
       }
     }

--- a/third_party/toolchains/cpus/CROSSTOOL
+++ b/third_party/toolchains/cpus/CROSSTOOL
@@ -696,7 +696,6 @@ toolchain {
           }
           iterate_over: 'libraries_to_link.object_files'
           flag_group {
-            iterate_over: 'libraries_to_link.object_files'
             flag: '%{libraries_to_link.object_files}'
           }
         }


### PR DESCRIPTION
Bazel will stop supporting implicit iteration soon, and will require explicit
'iterate_over' message. This cl updates the only affected Tensorflow crosstool.