### PR TITLE
Fix typos

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/cpu_parallelization_preparation.h
+++ b/tensorflow/compiler/xla/service/cpu/cpu_parallelization_preparation.h
@@ -63,7 +63,7 @@ class ParallelizationPreparation : public HloPassInterface {
 
   // Outlines 'instruction' from entry computation, if it had
   // been assigned parallel tasks in an earlier pass through the computation.
-  // Returns true if 'instruction' was succesfully outlined, false otherwise.
+  // Returns true if 'instruction' was successfully outlined, false otherwise.
   bool OutlineParallelizableInstruction(HloInstruction* instruction);
 
   // Returns true if 'instruction' can be outlined into the same sub-computation

--- a/tensorflow/compiler/xla/service/cpu/shape_partition.cc
+++ b/tensorflow/compiler/xla/service/cpu/shape_partition.cc
@@ -20,7 +20,7 @@ namespace cpu {
 
 std::vector<int64> ShapePartitionAssigner::Run(int64 target_partition_count) {
   // Gather outer-most dims where dim_size >= 'target_partition_count'.
-  // Note: always leave inner-dim static for vectorization/optimzations.
+  // Note: always leave inner-dim static for vectorization/optimizations.
   std::vector<int64> outer_dims;
   int64 outer_dim_size = 1;
   // TODO(b/27458679) Consider reserving enough minor dimensions (based on

--- a/tensorflow/contrib/boosted_trees/lib/learner/stochastic/handlers/sparse-quantized-feature-column-handler.cc
+++ b/tensorflow/contrib/boosted_trees/lib/learner/stochastic/handlers/sparse-quantized-feature-column-handler.cc
@@ -124,7 +124,7 @@ void SparseQuantizedFeatureColumnHandler::GenerateFeatureSplitCandidates(
 
     // Determine if we need a backward pass by checking if the residual gradient
     // after forward aggregation is almost the same as the aggregated gradient.
-    // for the current root. This helps avoid unecessary computation as well
+    // for the current root. This helps avoid unnecessary computation as well
     // as consistency due to floating point precision.
     if (!right_gradient_stats.IsAlmostZero()) {
       // Backward pass with left default direction.

--- a/tensorflow/contrib/boosted_trees/python/kernel_tests/prediction_ops_test.py
+++ b/tensorflow/contrib/boosted_trees/python/kernel_tests/prediction_ops_test.py
@@ -1149,7 +1149,7 @@ class PredictionOpsTest(test_util.TensorFlowTestCase):
       adjusted_tree_ensemble_config = (
           tree_config_pb2.DecisionTreeEnsembleConfig())
       # When we say to average over more trees than possible, it is averaging
-      # accross all trees.
+      # across all trees.
       total_num = 100
       for i in range(0, total_num):
         tree = tree_ensemble_config.trees.add()

--- a/tensorflow/contrib/learn/python/learn/experiment.py
+++ b/tensorflow/contrib/learn/python/learn/experiment.py
@@ -523,7 +523,7 @@ class Experiment(object):
       differences in resource control. First, the resources (e.g., memory) used
       by training will be released before evaluation (`train_and_evaluate` takes
       double resources). Second, more checkpoints will be saved as a checkpoint
-      is generated at the end of each trainning iteration.
+      is generated at the end of each training iteration.
 
       3. As the estimator.train starts from scratch (new graph, new states for
       input, etc) at each iteration, it is recommended to have the

--- a/tensorflow/contrib/tensor_forest/kernels/v4/grow_stats.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/grow_stats.h
@@ -104,7 +104,7 @@ class GrowStats {
 
   const TensorForestParams& params_;
 
-  // We cache these beacuse they're used often.
+  // We cache these because they're used often.
   const int split_after_samples_;
   const int num_splits_to_consider_;
 

--- a/tensorflow/python/util/deprecation_test.py
+++ b/tensorflow/python/util/deprecation_test.py
@@ -608,7 +608,7 @@ class DeprecatedArgsTest(test.TestCase):
     self._assert_subset(set(["after " + date, instructions, "d2"]),
                         set(args2[1:]))
 
-    # Assert calls with the deprecated arguments dont log warnings if
+    # Assert calls with the deprecated arguments don't log warnings if
     # the value matches the 'ok_val'.
     mock_warning.reset_mock()
     self.assertEqual(3, _fn(1, None, 2, d2="my_ok_val"))


### PR DESCRIPTION
This PR fixes some typos: `succesfully`, `optimzations`, `unecessary`, `accross`, `trainning`, `beacuse`, and `dont`.