### PR TITLE
Add bazel build configs for cpu type 'x64_windows_msvc'

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -190,6 +190,9 @@ def tf_additional_test_srcs():
       "//tensorflow:windows" : [
           "platform/windows/test.cc"
         ],
+      "//tensorflow:windows_msvc" : [
+          "platform/windows/test.cc"
+        ],
       "//conditions:default" : [
           "platform/posix/test.cc",
         ],

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1039,6 +1039,7 @@ def tf_py_wrap_cc(name,
       srcs_version="PY2AND3",
       data=select({
           clean_dep("//tensorflow:windows"): [":" + cc_library_pyd_name],
+          clean_dep("//tensorflow:windows_msvc"): [":" + cc_library_pyd_name],
           "//conditions:default": [":" + cc_library_name],
       }))
 


### PR DESCRIPTION
Without this fix, the final generated whl file will contain a '_pywrap_tensorflow_internal.so' instead of '_pywrap_tensorflow_internal.pyd'