### PR TITLE
Fix sparse_placeholder error when int is passed in shape argument

### DIFF
--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -909,5 +909,16 @@ class SparseTransposeTest(test.TestCase):
           self.assertAllEqual(dn_trans, expected_trans)
 
 
+class SparsePlaceholderTest(test.TestCase):
+
+  def testPlaceholder(self):
+    with self.test_session(use_gpu=False):
+      foo = array_ops.sparse_placeholder(dtypes.float32, shape=(10, 47))
+      self.assertAllEqual([10, 47], foo.get_shape())
+
+      foo = array_ops.sparse_placeholder(dtypes.float32, shape=(None, 47))
+      self.assertAllEqual(None, foo.get_shape())
+
+
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1548,7 +1548,7 @@ def _normalize_sparse_shape(shape, name):
     for el in shape:
       if el is None:
         return None
-  return ops.convert_to_tensor(shape, name=name)
+  return ops.convert_to_tensor(shape, dtype=dtypes.int64, name=name)
 
 
 def sparse_placeholder(dtype, shape=None, name=None):


### PR DESCRIPTION
This fix tries to address the issue raised in #6749 where and error
```
ValueError: Tensor conversion requested dtype int64 for Tensor with dtype int32: 'Tensor("Const:0", shape=(2,), dtype=int32)'
```
is thrown out in case int is passed in the shape argument.

This fix fixes the issue and adds test cases for it.

This fix fixes #6749.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>