### PR TITLE
Improve docstrings involving package structure

### DIFF
--- a/tensorflow/contrib/layers/python/layers/feature_column.py
+++ b/tensorflow/contrib/layers/python/layers/feature_column.py
@@ -15,13 +15,13 @@
 """This API defines FeatureColumn abstraction.
 
 FeatureColumns provide a high level abstraction for ingesting and representing
-features in tf.learn Estimator models.
+features in `Estimator` models.
 
 FeatureColumns are the primary way of encoding features for pre-canned
-tf.learn Estimators.
+`Estimator` models.
 
-When using FeatureColumns with tf.learn models, the type of feature column you
-should choose depends on (1) the feature type and (2) the model type.
+When using FeatureColumns with `Estimator` models, the type of feature column
+you should choose depends on (1) the feature type and (2) the model type.
 
 (1) Feature type:
 
@@ -74,7 +74,7 @@ should choose depends on (1) the feature type and (2) the model type.
       columns=[department_column, bucketized_age_column],
       hash_bucket_size=1000)
 
-Example of building tf.learn model using FeatureColumns:
+Example of building an `Estimator` model using FeatureColumns:
 
   # Define features and transformations
   deep_feature_columns = [age_column, embedded_dept_column]
@@ -104,7 +104,7 @@ FeatureColumns can also be transformed into a generic input layer for
 custom models using `input_from_feature_columns` within
 `feature_column_ops.py`.
 
-Example of building non-tf.learn model using FeatureColumns:
+Example of building a non-`Estimator` model using FeatureColumns:
 
   # Building model via layers
 

--- a/tensorflow/contrib/learn/python/learn/dataframe/tensorflow_dataframe.py
+++ b/tensorflow/contrib/learn/python/learn/dataframe/tensorflow_dataframe.py
@@ -600,7 +600,7 @@ class TensorFlowDataFrame(df.DataFrame):
                   shuffle=True,
                   seed=None,
                   data_name="pandas_data"):
-    """Create a `tf.learn.DataFrame` from a `pandas.DataFrame`.
+    """Create a `DataFrame` from a `pandas.DataFrame`.
 
     Args:
       pandas_dataframe: `pandas.DataFrame` that serves as a data source.
@@ -615,7 +615,7 @@ class TensorFlowDataFrame(df.DataFrame):
       data_name: a scope name identifying the data.
 
     Returns:
-      A `tf.learn.DataFrame` that contains batches drawn from the given
+      A `DataFrame` that contains batches drawn from the given
       `pandas_dataframe`.
     """
     pandas_source = in_memory_source.PandasSource(
@@ -643,7 +643,7 @@ class TensorFlowDataFrame(df.DataFrame):
                  shuffle=True,
                  seed=None,
                  data_name="numpy_data"):
-    """Creates a `tf.learn.DataFrame` from a `numpy.ndarray`.
+    """Creates a `DataFrame` from a `numpy.ndarray`.
 
     The returned `DataFrame` contains two columns: 'index' and 'value'. The
     'value' column contains a row from the array. The 'index' column contains
@@ -662,7 +662,7 @@ class TensorFlowDataFrame(df.DataFrame):
       data_name: a scope name identifying the data.
 
     Returns:
-      A `tf.learn.DataFrame` that contains batches drawn from the given
+      A `DataFrame` that contains batches drawn from the given
       array.
     """
     numpy_source = in_memory_source.NumpySource(
@@ -690,7 +690,7 @@ class TensorFlowDataFrame(df.DataFrame):
                        shuffle=True,
                        seed=None,
                        data_name="numpy_data"):
-    """Creates a `tf.learn.DataFrame` from an `OrderedDict` of `numpy.ndarray`.
+    """Creates a `DataFrame` from an `OrderedDict` of `numpy.ndarray`.
 
     The returned `DataFrame` contains a column for each key of the dict plus an
     extra 'index' column. The 'index' column contains the row number. Each of
@@ -710,7 +710,7 @@ class TensorFlowDataFrame(df.DataFrame):
       data_name: a scope name identifying the data.
 
     Returns:
-      A `tf.learn.DataFrame` that contains batches drawn from the given arrays.
+      A `DataFrame` that contains batches drawn from the given arrays.
 
     Raises:
       ValueError: `ordered_dict_of_arrays` contains the reserved name 'index'.

--- a/tensorflow/contrib/learn/python/learn/estimators/estimator.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimator.py
@@ -356,7 +356,7 @@ class BaseEstimator(
     sklearn.BaseEstimator, evaluable.Evaluable, trainable.Trainable):
   """Abstract BaseEstimator class to train and evaluate TensorFlow models.
 
-  Users should not instantiate or subclass this class. Instead, use `Estimator`.
+  Users should not instantiate or subclass this class. Instead, use an `Estimator`.
   """
   __metaclass__ = abc.ABCMeta
 

--- a/tensorflow/contrib/learn/python/learn/estimators/kmeans.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/kmeans.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Implementation of k-means clustering on top of tf.learn API."""
+"""Implementation of k-means clustering on top of `Estimator` API."""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorflow/contrib/learn/python/learn/estimators/logistic_regressor.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/logistic_regressor.py
@@ -111,7 +111,7 @@ def LogisticRegressor(  # pylint: disable=invalid-name
                       into the model.
 
   Returns:
-    A `tf.contrib.learn.Estimator` instance.
+    An `Estimator` instance.
   """
   return estimator.Estimator(
       model_fn=_get_model_fn_with_logistic_metrics(model_fn),

--- a/tensorflow/contrib/learn/python/learn/estimators/run_config.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/run_config.py
@@ -64,7 +64,7 @@ class TaskType(object):
 class ClusterConfig(object):
   """This class specifies the configurations for a distributed run.
 
-  If you're using `tf.learn` `Estimators`, you should probably use the subclass
+  If you're using an `Estimator`, you should probably use the subclass
   RunConfig instead.
   """
 

--- a/tensorflow/contrib/learn/python/learn/estimators/svm.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/svm.py
@@ -43,9 +43,9 @@ class SVM(estimator.Estimator):
   num_loss_partitions is larger or equal to this value, convergence is
   guaranteed but becomes slower as num_loss_partitions increases. If it is set
   to a smaller value, the optimizer is more aggressive in reducing the global
-  loss but convergence is not guaranteed. The recommended value in tf.learn
-  (where there is one process per worker) is the number of workers running the
-  train steps. It defaults to 1 (single machine).
+  loss but convergence is not guaranteed. The recommended value in an
+  `Estimator` (where there is one process per worker) is the number of workers
+  running the train steps. It defaults to 1 (single machine).
 
   Example:
 

--- a/tensorflow/contrib/learn/python/learn/metric_spec.py
+++ b/tensorflow/contrib/learn/python/learn/metric_spec.py
@@ -233,7 +233,7 @@ class MetricSpec(object):
   `Estimator` then knows which predictions, labels, and weight to use to call a
   given metric function.
 
-  When building the ops to run in evaluation, `Estimator` will call
+  When building the ops to run in evaluation, an `Estimator` will call
   `create_metric_ops`, which will connect the given `metric_fn` to the model
   as detailed in the docstring for `create_metric_ops`, and return the metric.
 

--- a/tensorflow/python/estimator/model_fn.py
+++ b/tensorflow/python/estimator/model_fn.py
@@ -58,9 +58,9 @@ class EstimatorSpec(
         'export_outputs', 'training_chief_hooks', 'training_hooks',
         'scaffold'
     ])):
-  """Ops and objects returned from a `model_fn` and passed to `Estimator`.
+  """Ops and objects returned from a `model_fn` and passed to an `Estimator`.
 
-  `EstimatorSpec` fully defines the model to be run by `Estimator`.
+  `EstimatorSpec` fully defines the model to be run by an `Estimator`.
   """
 
   def __new__(cls,
@@ -81,8 +81,8 @@ class EstimatorSpec(
     * For `mode == ModeKeys.PREDICT`: required fields are `predictions`.
 
     model_fn can populate all arguments independent of mode. In this case, some
-    arguments will be ignored by `Estimator`. E.g. `train_op` will be ignored
-    in eval and infer modes. Example:
+    arguments will be ignored by an `Estimator`. E.g. `train_op` will be
+    ignored in eval and infer modes. Example:
 
     ```python
     def my_model_fn(mode, features, labels):

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -62,7 +62,7 @@ pip3 install scipy==0.18.1
 pip2 install scikit-learn==0.18.1
 pip3 install scikit-learn==0.18.1
 
-# pandas required by tf.learn/inflow
+# pandas required by `inflow`
 pip2 install pandas==0.19.2
 pip3 install pandas==0.19.2
 

--- a/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
@@ -80,7 +80,7 @@ pip3.5 install scipy==0.18.1
 
 pip3.5 install scikit-learn==0.18.1
 
-# pandas required by tf.learn/inflow
+# pandas required by `inflow`
 pip3 install pandas==0.19.2
 
 # Install recent-enough version of wheel for Python 3.5 wheel builds


### PR DESCRIPTION
This PR improves docstrings involving `tf.learn`. In the case of `tensorflow_dataframe.py`, I think it is better to put just `DataFrame` in order to keep consistency within one file. Except for the case, all the `tf.learn`s are replaced by `tf.contrib.learn`s.