### PR TITLE
Adding support for s390x for boringssl 

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -520,7 +520,7 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
       actual = "@jsoncpp_git//:jsoncpp",
   )
 
-  native.http_archive(
+  patched_http_archive(
       name = "boringssl",
       urls = [
           "http://mirror.bazel.build/github.com/google/boringssl/archive/bbcaa15b0647816b9a1a9b9e0d209cd6712f0105.tar.gz",
@@ -528,6 +528,9 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
       ],
       sha256 = "025264d6e9a7ad371f2f66d17a28b6627de0c9592dc2eb54afd062f68f1f9aa3",
       strip_prefix = "boringssl-bbcaa15b0647816b9a1a9b9e0d209cd6712f0105",
+
+      # Add patch to boringssl code to support s390x
+      patch_file = str(Label("//third_party/boringssl:add_boringssl_s390x.patch")),
   )
 
   native.new_http_archive(

--- a/third_party/boringssl/add_boringssl_s390x.patch
+++ b/third_party/boringssl/add_boringssl_s390x.patch
@@ -1,0 +1,14 @@
+diff --git a/src/include/openssl/base.h b/src/include/openssl/base.h
+index 7a3adfb..88012ad 100644
+--- a/src/include/openssl/base.h
++++ b/src/include/openssl/base.h
+@@ -94,6 +94,8 @@ extern "C" {
+ #elif defined(__pnacl__)
+ #define OPENSSL_32_BIT
+ #define OPENSSL_PNACL
++#elif defined(__s390x__)
++#define OPENSSL_64_BIT
+ #else
+ #error "Unknown target CPU"
+ #endif
+


### PR DESCRIPTION
Adding support for s390x for boringssl through patched_http_archive rule. 