### PR TITLE
Only use weakref.finalize from backports in Python < 3.4

### DIFF
--- a/tensorflow/python/util/tf_should_use.py
+++ b/tensorflow/python/util/tf_should_use.py
@@ -25,7 +25,12 @@ import types
 
 import six  # pylint: disable=unused-import
 
-from backports import weakref  # pylint: disable=g-bad-import-order
+# pylint: disable=g-bad-import-order
+try:
+  from weakref import finalize
+except ImportError:
+  from backports.weakref import finalize
+# pylint: enable=g-bad-import-order
 
 from tensorflow.python.platform import tf_logging
 from tensorflow.python.util import tf_decorator
@@ -107,7 +112,7 @@ def _add_should_use_warning(x, fatal_error=False):
       # garbage collected.  Can't add self as the args because the
       # loop will break garbage collection.  We keep track of
       # ourselves via python ids.
-      weakref.finalize(self, _deleted, self._tf_ref_id, fatal_error)
+      finalize(self, _deleted, self._tf_ref_id, fatal_error)
 
     # Not sure why this pylint warning is being used; this is not an
     # old class form.

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -35,7 +35,6 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.11.0',
     'six >= 1.10.0',
     'protobuf >= 3.2.0',
-    'backports.weakref == 1.0rc1',
     'tensorflow-tensorboard',
 ]
 
@@ -53,6 +52,10 @@ else:
   REQUIRED_PACKAGES.append('wheel')
   # mock comes with unittest.mock for python3, need to install for python2
   REQUIRED_PACKAGES.append('mock >= 2.0.0')
+
+# weakref.finalize was introduced in Python 3.4
+if sys.version_info < (3, 4):
+  REQUIRED_PACKAGES.append('backports.weakref >= 1.0rc1')
 
 # pylint: disable=line-too-long
 CONSOLE_SCRIPTS = [


### PR DESCRIPTION
The `backports` module should not be forced as a dependency for Python >= 3.4 as `weakref.finalize` has been introduced in Python 3.4. This solves #11082 and an [Arch Linux bug](https://bugs.archlinux.org/task/54606).