### PR TITLE
Remove type constraint on shape_invariants

### DIFF
--- a/tensorflow/python/ops/control_flow_ops.py
+++ b/tensorflow/python/ops/control_flow_ops.py
@@ -2768,7 +2768,8 @@ def while_loop(cond, body, loop_vars, shape_invariants=None,
       raise TypeError("parallel_iterations must be a positive integer.")
 
     if shape_invariants is not None:
-      nest.assert_same_structure(loop_vars, shape_invariants)
+      nest.assert_same_structure(loop_vars, shape_invariants,
+                                 check_types=False)
 
     context = WhileContext(parallel_iterations, back_prop, swap_memory, name)
     ops.add_to_collection(ops.GraphKeys.WHILE_CONTEXT, context)


### PR DESCRIPTION
This PR fixes the unnecessarily strict type checking addressed in issue #11115. Turning type checking off for the shape_invariants parameter in tf.while_loop will allow the parameter to be more easily used when, for example, trying to provide an invariant for an LSTMStateTuple variable.