### PR TITLE
Enable bitcode compilation

### DIFF
--- a/tensorflow/contrib/makefile/build_all_ios.sh
+++ b/tensorflow/contrib/makefile/build_all_ios.sh
@@ -18,7 +18,7 @@ set -e
 
 # Make sure we're on OS X.
 if [[ $(uname) != "Darwin" ]]; then
-    echo "ERROR: This makefile build requires OS X, which the current system "\
+    echo "ERROR: This makefile build requires macOS, which the current system "\
     "is not."
     exit 1
 fi
@@ -37,7 +37,9 @@ rm -rf tensorflow/contrib/makefile/downloads
 #
 #    ld: -bind_at_load and -bitcode_bundle (Xcode setting ENABLE_BITCODE=YES) cannot be used together
 #
-export MACOSX_DEPLOYMENT_TARGET="10.10"
+if [[ -n MACOSX_DEPLOYMENT_TARGET ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)
+fi
 
 # Pull down the required versions of the frameworks we need.
 tensorflow/contrib/makefile/download_dependencies.sh
@@ -48,6 +50,5 @@ tensorflow/contrib/makefile/compile_ios_protobuf.sh
 # Build the iOS TensorFlow libraries.
 tensorflow/contrib/makefile/compile_ios_tensorflow.sh "-O3"
 
-# Creates a static universal library in 
+# Creates a static universal library in
 # tensorflow/contrib/makefile/gen/lib/libtensorflow-core.a
-

--- a/tensorflow/contrib/makefile/compile_ios_protobuf.sh
+++ b/tensorflow/contrib/makefile/compile_ios_protobuf.sh
@@ -15,8 +15,11 @@
 # ==============================================================================
 # Builds protobuf 3 for iOS.
 
-set -x
 set -e
+
+if [[ -n MACOSX_DEPLOYMENT_TARGET ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)
+fi
 
 SCRIPT_DIR=$(dirname $0)
 source "${SCRIPT_DIR}/build_helper.subr"

--- a/tensorflow/contrib/makefile/compile_ios_tensorflow.sh
+++ b/tensorflow/contrib/makefile/compile_ios_tensorflow.sh
@@ -31,6 +31,10 @@ function less_than_required_version() {
   )
 }
 
+if [[ -n MACOSX_DEPLOYMENT_TARGET ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)
+fi
+
 ACTUAL_XCODE_VERSION=$(xcodebuild -version | head -n 1 | sed 's/Xcode //')
 REQUIRED_XCODE_VERSION=7.3.0
 if less_than_required_version $ACTUAL_XCODE_VERSION 7 3 0
@@ -44,7 +48,7 @@ LIBDIR=${GENDIR}lib
 LIB_PREFIX=libtensorflow-core
 
 make -j"${JOB_COUNT}" -f tensorflow/contrib/makefile/Makefile \
-TARGET=IOS IOS_ARCH=ARMV7 LIB_NAME=${LIB_PREFIX}-armv7.a OPTFLAGS="$1" 
+TARGET=IOS IOS_ARCH=ARMV7 LIB_NAME=${LIB_PREFIX}-armv7.a OPTFLAGS="$1"
 if [ $? -ne 0 ]
 then
   echo "armv7 compilation failed."


### PR DESCRIPTION
In order to enable bitcode compilation it is necessary more than adding `-fembed-bitcode`. The `MACOSX_DEPLOYMENT_TARGET` variable must be defined and exported as well.

In this commit the variable is defined grabbing the version of the underlying running macOS.