### PR TITLE
fallback to find if locate is not used

### DIFF
--- a/configure
+++ b/configure
@@ -264,19 +264,27 @@ if [ "$TF_NEED_MKL" == "1" ]; then # TF_NEED_MKL
       exit 1
   fi
 
+  loc="$(locate -e libdl.so.2 2>/dev/null | sed -n 1p)"
+  if [[ ! "$loc" ]] ; then
+    printf "WARN: Could not use 'locate' command. Trying 'find'.\n"
+    loc="$(find / -mount -name 'libdl.so.2' -print 2>/dev/null | head -n1)"
+    if [[ ! "$loc" ]] ; then
+      printf "FATAL ERROR: Could not use commands 'find' or 'locate'\n"
+      exit
+    fi
+  fi
+
   if [ -e "$MKL_INSTALL_PATH/${MKL_ML_LIB_PATH}" ]; then
       ln -sf $MKL_INSTALL_PATH/${MKL_ML_LIB_PATH} third_party/mkl/
       ln -sf $MKL_INSTALL_PATH/${MKL_ML_OMP_LIB_PATH} third_party/mkl/
       ln -sf $MKL_INSTALL_PATH/include third_party/mkl/
       ln -sf $MKL_INSTALL_PATH/include third_party/eigen3/mkl_include
-      loc=$(locate -e libdl.so.2 | sed -n 1p)
       ln -sf $loc third_party/mkl/libdl.so.2
   elif [ -e "$MKL_INSTALL_PATH/${MKL_RT_LIB_PATH}" ]; then
       ln -sf $MKL_INSTALL_PATH/${MKL_RT_LIB_PATH} third_party/mkl/
       ln -sf $MKL_INSTALL_PATH/${MKL_RT_OMP_LIB_PATH} third_party/mkl/
       ln -sf $MKL_INSTALL_PATH/include third_party/mkl/
       ln -sf $MKL_INSTALL_PATH/include third_party/eigen3/mkl_include
-      loc=$(locate -e libdl.so.2 | sed -n 1p)
       ln -sf $loc third_party/mkl/libdl.so.2
   else
       echo "ERROR: $MKL_INSTALL_PATH/${MKL_ML_LIB_PATH} nor $MKL_INSTALL_PATH/${MKL_RT_LIB_PATH} exists";


### PR DESCRIPTION
Related to #11029 and discussion in #9580

Locate is non-standard, and not installed on every system. It is much faster than 'find', but 'find' should be on every system. Find is even in busybox. On extremely large systems, it can potentially run for a long period of time.

This fix will first attempt to use the locate command, piping any error messages to /dev/null. If locate did not generate output, the script will warn that it will attempt to use 'find', and then use 'find'.

When using find, piping stderr to /dev/null is required since 'find' will generate errors when it cannot access a file (for instance if permissions are enforced). Piping the output from 'find' into head -n1 will complete the line of code, and thus stop 'find' from running longer.