### PR TITLE
Add wget to be installed in docker images

### DIFF
--- a/tensorflow/tools/docker/Dockerfile
+++ b/tensorflow/tools/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         rsync \
         software-properties-common \
         unzip \
+	wget \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/tensorflow/tools/docker/Dockerfile.devel
+++ b/tensorflow/tools/docker/Dockerfile.devel
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         zlib1g-dev \
         openjdk-8-jdk \
         openjdk-8-jre-headless \
+	wget \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/tensorflow/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow/tools/docker/Dockerfile.devel-gpu
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         zlib1g-dev \
         openjdk-8-jdk \
         openjdk-8-jre-headless \
+	wget \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/tensorflow/tools/docker/Dockerfile.gpu
+++ b/tensorflow/tools/docker/Dockerfile.gpu
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         rsync \
         software-properties-common \
         unzip \
+	wget \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
same as #11215 but changes suggested for all docker files.

### System information
- **Have I written custom code (as opposed to using a stock example script provided in TensorFlow)**: Using scripts provided with tensorflow to download and build imagenet from scratch.
- **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**: Ubuntu 16.04
- **TensorFlow installed from (source or binary)**: binary
- **TensorFlow version (use command below)**: ('v1.2.0-5-g435cdfc', '1.2.1')
- **Python version**: 2.7.12
- **Bazel version (if compiling from source)**: NA
- **CUDA/cuDNN version**: 8.0
- **GPU model and memory**: Nvidia GRID M6-8Q(8GB)
- **Exact command to reproduce**: bazel-bin/inception/download_and_preprocess_imagenet "${DATA_DIR}"

### Describe the problem
I am trying to train inception v3 net for imagenet dataset using instructions at-
[](https://github.com/tensorflow/models/tree/master/slim)
[](https://github.com/tensorflow/models/blob/master/inception/README.md#getting-started)

After setting the download path using following command - 
```
# location of where to place the ImageNet data
DATA_DIR=$HOME/imagenet-data
```
I ran the bazel command to build preprocessing script-
```
# build the preprocessing script.
cd tensorflow-models/inception
bazel build //inception:download_and_preprocess_imagenet
```
And then run it-
```
# run it
bazel-bin/inception/download_and_preprocess_imagenet "${DATA_DIR}"
```
Running above command fails saying it cannot find `wget` - 

> root@docker_container:/data/workspace/models/inception# bazel-bin/inception/download_and_preprocess_imagenet "${DATA_DIR}"
> In order to download the imagenet data, you have to create an account with
> image-net.org. This will get you a username and an access key. You can set the
> IMAGENET_USERNAME and IMAGENET_ACCESS_KEY environment variables, or you can
> enter the credentials here.
> Username: <my username>
> Access key: <my password>
> Saving downloaded files to /data/imagenet-data/raw-data/
> Downloading bounding box annotations.
> bazel-bin/inception/download_and_preprocess_imagenet.runfiles/inception/inception/data/download_imagenet.sh: line 58: wget: command not found
> bazel-bin/inception/download_and_preprocess_imagenet.runfiles/inception/inception/data/download_imagenet.sh: line 64: wget: command not found

I have reported this as bug #11214 as well