### PR TITLE
Fix #11152: Adding import for pythons threading library

### DIFF
--- a/tensorflow/docs_src/programmers_guide/threading_and_queues.md
+++ b/tensorflow/docs_src/programmers_guide/threading_and_queues.md
@@ -79,6 +79,9 @@ Any thread can decide that the computation should stop.  It only has to call
 return `True`.
 
 ```python
+# Using Python's threading library.
+import threading
+
 # Thread body: loop until the coordinator indicates a stop was requested.
 # If some condition becomes true, ask the coordinator to stop.
 def MyLoop(coord):


### PR DESCRIPTION
State in the `programmers_guide/threading_and_queues` example where the `threading.Thread` is coming from. This fixes #11152.

This is based on the comment by @ali01 in https://github.com/tensorflow/tensorflow/issues/11152#issuecomment-312393705.
