### PR TITLE
Configure script code reduction (no merge please)

### DIFF
--- a/configure
+++ b/configure
@@ -355,20 +355,7 @@ if [[ "$TF_NEED_JEMALLOC" == "1" ]]; then
   write_to_bazelrc 'build --define with_jemalloc=true'
 fi
 
-while [[ "$TF_NEED_GCP" == "" ]]; do
-  read -p "Do you wish to build TensorFlow with "\
-"Google Cloud Platform support? [y/N] " INPUT
-  case $INPUT in
-    [Yy]* ) echo "Google Cloud Platform support will be enabled for "\
-"TensorFlow"; TF_NEED_GCP=1;;
-    [Nn]* ) echo "No Google Cloud Platform support will be enabled for "\
-"TensorFlow"; TF_NEED_GCP=0;;
-    "" ) echo "No Google Cloud Platform support will be enabled for "\
-"TensorFlow"; TF_NEED_GCP=0;;
-    * ) echo "Invalid selection: " $INPUT;;
-  esac
-done
-
+build_with TF_NEED_GCP "Google Cloud Platform" "disabled"
 if [[ "$TF_NEED_GCP" == "1" ]]; then
   write_to_bazelrc 'build --define with_gcp_support=true'
 fi

--- a/configure
+++ b/configure
@@ -241,17 +241,7 @@ fi
 setup_python
 
 ## Set up MKL related environment settings
-while [ "$TF_NEED_MKL" == "" ]; do
-  fromuser=""
-  read -p "Do you wish to build TensorFlow with MKL support? [y/N] " INPUT
-  fromuser="1"
-  case $INPUT in
-    [Yy]* ) echo "MKL support will be enabled for TensorFlow"; TF_NEED_MKL=1;;
-    [Nn]* ) echo "No MKL support will be enabled for TensorFlow"; TF_NEED_MKL=0;;
-    "" ) echo "No MKL support will be enabled for TensorFlow"; TF_NEED_MKL=0;;
-    * ) echo "Invalid selection: " $INPUT;;
-  esac
-done
+build_with TF_NEED_MKL "MKL" "disabled"
 
 OSNAME=`uname -s`
 

--- a/configure
+++ b/configure
@@ -360,20 +360,7 @@ if [[ "$TF_NEED_GCP" == "1" ]]; then
   write_to_bazelrc 'build --define with_gcp_support=true'
 fi
 
-while [[ "$TF_NEED_HDFS" == "" ]]; do
-  read -p "Do you wish to build TensorFlow with "\
-"Hadoop File System support? [y/N] " INPUT
-  case $INPUT in
-    [Yy]* ) echo "Hadoop File System support will be enabled for "\
-"TensorFlow"; TF_NEED_HDFS=1;;
-    [Nn]* ) echo "No Hadoop File System support will be enabled for "\
-"TensorFlow"; TF_NEED_HDFS=0;;
-    "" ) echo "No Hadoop File System support will be enabled for "\
-"TensorFlow"; TF_NEED_HDFS=0;;
-    * ) echo "Invalid selection: " $INPUT;;
-  esac
-done
-
+build_with TF_NEED_HDFS "Hadoop File System" "disabled"
 if [[ "$TF_NEED_HDFS" == "1" ]]; then
   write_to_bazelrc 'build --define with_hdfs_support=true'
 fi

--- a/configure
+++ b/configure
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
+declare -A array_test=( [one]="position_one" [two]="position_two" [three]="position_three" )
+array_ans=""
+positional_test=( one two three )
+positional_ans="position_oneposition_twoposition_three"
 
+for x in "${positional_test[@]}" ; do
+  array_ans+="$(eval echo \${array_test[$x]})"
+done
+
+if [[ ! "$array_ans" == "$positional_ans" ]] ; then
+  echo "dec arrays not supported"
+  exit 1
+fi
+ 
 set -e
 set -o pipefail
 

--- a/configure
+++ b/configure
@@ -157,11 +157,57 @@ function version {
   echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }';
 }
 
+function build_with {
+  # don't change value if it is already set
+  if [[ "$(eval echo \"\$$1\")" ]] ; then
+    return
+  fi
+  local needed="$1"
+  local build_ask="$2"
+  # default is 'enabled' or 'disabled'
+  local default="$3"
+
+  if [[ "$4" ]] ; then
+    local build_ans_yes="$4"
+    local build_ans_no="$5"
+  else
+    local build_ans_yes="$build_ask support will be enabled for TensorFlow."
+    local build_ans_no="No $build_ans_yes"
+    local build_ask="Do you wish to build TensorFlow with $build_ask support?"
+  fi
+
+  if [[ "$default" == "enabled" ]] ; then
+    local build_ask="$build_ask [Y/n] "
+  else
+    local build_ask="$build_ask [y/N] "
+  fi
+
+  while true; do
+    read -p "$build_ask" user_input
+
+    case "$user_input" in
+      [Yy]* ) echo "$build_ans_yes"
+        eval $needed=1
+        break;;
+      [Nn]* ) echo "$build_ans_no"
+        eval $needed=0
+        break;;
+      "" ) if [[ "$default" == "enabled" ]] ; then
+          echo "$build_ans_yes"
+          eval $needed=1
+        else
+          echo "$build_ans_no"
+          eval $needed=0
+        fi
+        break;;
+      * ) echo "Invalid selection: $user_input";;
+    esac
+  done
+}
 
 bazel version > bazel.version
 curr_bazel_version=$(head -n 1 bazel.version | cut -d ' ' -f3)
 rm -f bazel.version
-
 
 echo "You have bazel $curr_bazel_version installed."
 if [ -z "$curr_bazel_version" ]; then

--- a/configure
+++ b/configure
@@ -388,21 +388,10 @@ chmod a+x ${GEN_GIT_SOURCE}
 "${PYTHON_BIN_PATH}" ${GEN_GIT_SOURCE} --configure "${SOURCE_BASE_DIR}"
 
 build_with TF_NEED_OPENCL "OpenCL" "disabled"
-
-## Set up Cuda-related environment settings
-while [ "$TF_NEED_CUDA" == "" ]; do
-  read -p "Do you wish to build TensorFlow with CUDA support? [y/N] " INPUT
-  case $INPUT in
-    [Yy]* ) echo "CUDA support will be enabled for TensorFlow"; TF_NEED_CUDA=1;;
-    [Nn]* ) echo "No CUDA support will be enabled for TensorFlow"; TF_NEED_CUDA=0;;
-    "" ) echo "No CUDA support will be enabled for TensorFlow"; TF_NEED_CUDA=0;;
-    * ) echo "Invalid selection: " $INPUT;;
-  esac
-done
+build_with TF_NEED_CUDA "CUDA" "disabled"
 
 export TF_NEED_CUDA
 write_action_env_to_bazelrc "TF_NEED_CUDA" "$TF_NEED_CUDA"
-
 export TF_NEED_OPENCL
 write_action_env_to_bazelrc "TF_NEED_OPENCL" "$TF_NEED_OPENCL"
 

--- a/configure
+++ b/configure
@@ -71,35 +71,8 @@ END
 function setup_python {
   ## Set up python-related environment settings:
   get_path PYTHON_BIN_PATH "python" "bin" "python3"
-  if [ -z "$PYTHON_LIB_PATH" ]; then
-    # Split python_path into an array of paths, this allows path containing spaces
-    IFS=',' read -r -a python_lib_path <<< "$(python_path)"
-
-    if [ 1 = "$USE_DEFAULT_PYTHON_LIB_PATH" ]; then
-      PYTHON_LIB_PATH=${python_lib_path[0]}
-      echo "Using python library path: $PYTHON_LIB_PATH"
-
-    else
-      echo "Found possible Python library paths:"
-      for x in "${python_lib_path[@]}"; do
-        echo "  $x"
-      done
-      set -- "${python_lib_path[@]}"
-      echo "Please input the desired Python library path to use.  Default is [$1]"
-      read b || true
-      if [ "$b" == "" ]; then
-        PYTHON_LIB_PATH=${python_lib_path[0]}
-        echo "Using python library path: $PYTHON_LIB_PATH"
-      else
-        PYTHON_LIB_PATH="$b"
-      fi
-    fi
-  fi
-
-  if [ ! -x "$PYTHON_BIN_PATH" ]  || [ -d "$PYTHON_BIN_PATH" ]; then
-    echo "PYTHON_BIN_PATH is not executable.  Is it the python binary?"
-    exit 1
-  fi
+  IFS=',' read -r -a python_lib_array <<< "$(python_path)"
+  get_path PYTHON_LIB_PATH "python" "lib" "$python_lib_array"
 
   local python_major_version
   python_major_version=$("${PYTHON_BIN_PATH}" -c 'from __future__ import print_function; import sys; print(sys.version_info[0]);' | head -c1)

--- a/configure
+++ b/configure
@@ -217,7 +217,9 @@ elif [ "$(version "$MIN_BAZEL_VERSION")" -gt "$(version "$curr_bazel_version")" 
 fi
 
 # This file contains customized config settings.
-rm -f .tf_configure.bazelrc
+if [[ -f .tf_configure.bazelrc ]] ; then
+  rm -f .tf_configure.bazelrc
+fi
 touch .tf_configure.bazelrc
 if [[ ! -e .bazelrc ]]; then
   if [[ -e "${HOME}/.bazelrc" ]]; then

--- a/configure
+++ b/configure
@@ -365,17 +365,8 @@ if [[ "$TF_NEED_HDFS" == "1" ]]; then
   write_to_bazelrc 'build --define with_hdfs_support=true'
 fi
 
-## Enable XLA.
-while [[ "$TF_ENABLE_XLA" == "" ]]; do
-  read -p "Do you wish to build TensorFlow with the XLA just-in-time compiler (experimental)? [y/N] " INPUT
-  case $INPUT in
-    [Yy]* ) echo "XLA JIT support will be enabled for TensorFlow"; TF_ENABLE_XLA=1;;
-    [Nn]* ) echo "No XLA JIT support will be enabled for TensorFlow"; TF_ENABLE_XLA=0;;
-    "" ) echo "No XLA support will be enabled for TensorFlow"; TF_ENABLE_XLA=0;;
-    * ) echo "Invalid selection: " $INPUT;;
-  esac
-done
-
+build_with TF_ENABLE_XLA "Do you wish to build TensorFlow with the XLA just-in-time compiler (experimental)?" \
+  "disabled" "XLA JIT support will be enabled for TensorFlow" "No XLA support will be enabled for TensorFlow"
 if [[ "$TF_ENABLE_XLA" == "1" ]]; then
   write_to_bazelrc 'build --define with_xla_support=true'
 fi

--- a/configure
+++ b/configure
@@ -485,32 +485,12 @@ if [ "$TF_NEED_CUDA" == "1" ]; then
 
   # Set up which gcc nvcc should use as the host compiler
   # No need to set this on Windows
-  while [[ "$TF_CUDA_CLANG" != "1" ]] && ! is_windows && true; do
-    fromuser=""
-    if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
-      default_gcc_host_compiler_path=$(which gcc || true)
-      cuda_bin_symlink="$CUDA_TOOLKIT_PATH/bin/gcc"
-      if [ -L "$cuda_bin_symlink" ]; then
-        default_gcc_host_compiler_path=$(readlink $cuda_bin_symlink)
-      fi
-      read -p "Please specify which gcc should be used by nvcc as the host compiler. [Default is $default_gcc_host_compiler_path]: " GCC_HOST_COMPILER_PATH
-      fromuser="1"
-      if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
-        GCC_HOST_COMPILER_PATH="$default_gcc_host_compiler_path"
-      fi
-    fi
-    if [ -e "$GCC_HOST_COMPILER_PATH" ]; then
-      export GCC_HOST_COMPILER_PATH
-      write_action_env_to_bazelrc "GCC_HOST_COMPILER_PATH" "$GCC_HOST_COMPILER_PATH"
-      break
-    fi
-    echo "Invalid gcc path. ${GCC_HOST_COMPILER_PATH} cannot be found" 1>&2
-    if [ -z "$fromuser" ]; then
-      exit 1
-    fi
-    GCC_HOST_COMPILER_PATH=""
-    # Retry
-  done
+  if (( "$TF_CUDA_CLANG" )) && ! is_windows ; then
+    echo "Which gcc hould be used by nvcc as the host compiler?"
+    get_path GCC_HOST_COMPILER_PATH "gcc" "bin" "$(readlink $CUDA_TOOLKIT_PATH/bin/gcc 2>/dev/null)"
+    export GCC_HOST_COMPILER_PATH
+    write_action_env_to_bazelrc "GCC_HOST_COMPILER_PATH" "$GCC_HOST_COMPILER_PATH"
+  fi
 
   # Find out where the cuDNN library is installed
   while true; do

--- a/configure
+++ b/configure
@@ -679,87 +679,86 @@ fi
 # OpenCL configuration
 
 if [ "$TF_NEED_OPENCL" == "1" ]; then
-
-# Determine which C++ compiler should be used as the host compiler
-while true; do
-  fromuser=""
-  if [ -z "$HOST_CXX_COMPILER" ]; then
-    default_cxx_host_compiler=$(which g++ || true)
-    read -p "Please specify which C++ compiler should be used as the host C++ compiler. [Default is $default_cxx_host_compiler]: " HOST_CXX_COMPILER
-    fromuser="1"
+  # Determine which C++ compiler should be used as the host compiler
+  while true; do
+    fromuser=""
     if [ -z "$HOST_CXX_COMPILER" ]; then
-      HOST_CXX_COMPILER=$default_cxx_host_compiler
+      default_cxx_host_compiler=$(which g++ || true)
+      read -p "Please specify which C++ compiler should be used as the host C++ compiler. [Default is $default_cxx_host_compiler]: " HOST_CXX_COMPILER
+      fromuser="1"
+      if [ -z "$HOST_CXX_COMPILER" ]; then
+        HOST_CXX_COMPILER=$default_cxx_host_compiler
+      fi
     fi
-  fi
-  if [ -e "$HOST_CXX_COMPILER" ]; then
-    export HOST_CXX_COMPILER
-    write_action_env_to_bazelrc "HOST_CXX_COMPILER" "$HOST_CXX_COMPILER"
-    break
-  fi
-  echo "Invalid C++ compiler path. ${HOST_CXX_COMPILER} cannot be found" 1>&2
-  if [ -z "$fromuser" ]; then
-    exit 1
-  fi
-  HOST_CXX_COMPILER=""
-  # Retry
-done
+    if [ -e "$HOST_CXX_COMPILER" ]; then
+      export HOST_CXX_COMPILER
+      write_action_env_to_bazelrc "HOST_CXX_COMPILER" "$HOST_CXX_COMPILER"
+      break
+    fi
+    echo "Invalid C++ compiler path. ${HOST_CXX_COMPILER} cannot be found" 1>&2
+    if [ -z "$fromuser" ]; then
+      exit 1
+    fi
+    HOST_CXX_COMPILER=""
+    # Retry
+  done
 
-# Determine which C compiler should be used as the host compiler
-while true; do
-  fromuser=""
-  if [ -z "$HOST_C_COMPILER" ]; then
-    default_c_host_compiler=$(which gcc || true)
-    read -p "Please specify which C compiler should be used as the host C compiler. [Default is $default_c_host_compiler]: " HOST_C_COMPILER
-    fromuser="1"
+  # Determine which C compiler should be used as the host compiler
+  while true; do
+    fromuser=""
     if [ -z "$HOST_C_COMPILER" ]; then
-      HOST_C_COMPILER=$default_c_host_compiler
+      default_c_host_compiler=$(which gcc || true)
+      read -p "Please specify which C compiler should be used as the host C compiler. [Default is $default_c_host_compiler]: " HOST_C_COMPILER
+      fromuser="1"
+      if [ -z "$HOST_C_COMPILER" ]; then
+        HOST_C_COMPILER=$default_c_host_compiler
+      fi
     fi
-  fi
-  if [ -e "$HOST_C_COMPILER" ]; then
-    export HOST_C_COMPILER
-    write_action_env_to_bazelrc "HOST_C_COMPILER" "$HOST_C_COMPILER"
-    break
-  fi
-  echo "Invalid C compiler path. ${HOST_C_COMPILER} cannot be found" 1>&2
-  if [ -z "$fromuser" ]; then
-    exit 1
-  fi
-  HOST_C_COMPILER=""
-  # Retry
-done
+    if [ -e "$HOST_C_COMPILER" ]; then
+      export HOST_C_COMPILER
+      write_action_env_to_bazelrc "HOST_C_COMPILER" "$HOST_C_COMPILER"
+      break
+    fi
+    echo "Invalid C compiler path. ${HOST_C_COMPILER} cannot be found" 1>&2
+    if [ -z "$fromuser" ]; then
+      exit 1
+    fi
+    HOST_C_COMPILER=""
+    # Retry
+  done
 
-while true; do
-  # Configure the OPENCL version to use.
-  TF_OPENCL_VERSION="1.2"
+  while true; do
+    # Configure the OPENCL version to use.
+    TF_OPENCL_VERSION="1.2"
 
-  # Point to ComputeCpp root
-  if [ -z "$COMPUTECPP_TOOLKIT_PATH" ]; then
-    default_computecpp_toolkit_path=/usr/local/computecpp
-    read -p "Please specify the location where ComputeCpp for SYCL $TF_OPENCL_VERSION is installed. [Default is $default_computecpp_toolkit_path]: " COMPUTECPP_TOOLKIT_PATH
-    fromuser="1"
+    # Point to ComputeCpp root
     if [ -z "$COMPUTECPP_TOOLKIT_PATH" ]; then
-      COMPUTECPP_TOOLKIT_PATH=$default_computecpp_toolkit_path
+      default_computecpp_toolkit_path=/usr/local/computecpp
+      read -p "Please specify the location where ComputeCpp for SYCL $TF_OPENCL_VERSION is installed. [Default is $default_computecpp_toolkit_path]: " COMPUTECPP_TOOLKIT_PATH
+      fromuser="1"
+      if [ -z "$COMPUTECPP_TOOLKIT_PATH" ]; then
+        COMPUTECPP_TOOLKIT_PATH=$default_computecpp_toolkit_path
+      fi
     fi
-  fi
 
-  if is_linux; then
-    SYCL_RT_LIB_PATH="lib/libComputeCpp.so"
-  fi
+    if is_linux; then
+      SYCL_RT_LIB_PATH="lib/libComputeCpp.so"
+    fi
 
-  if [ -e "${COMPUTECPP_TOOLKIT_PATH}/${SYCL_RT_LIB_PATH}" ]; then
-    export COMPUTECPP_TOOLKIT_PATH
-    write_action_env_to_bazelrc "COMPUTECPP_TOOLKIT_PATH" "$COMPUTECPP_TOOLKIT_PATH"
-    break
-  fi
-  echo "Invalid SYCL $TF_OPENCL_VERSION library path. ${COMPUTECPP_TOOLKIT_PATH}/${SYCL_RT_LIB_PATH} cannot be found"
+    if [ -e "${COMPUTECPP_TOOLKIT_PATH}/${SYCL_RT_LIB_PATH}" ]; then
+      export COMPUTECPP_TOOLKIT_PATH
+      write_action_env_to_bazelrc "COMPUTECPP_TOOLKIT_PATH" "$COMPUTECPP_TOOLKIT_PATH"
+      break
+    fi
+    echo "Invalid SYCL $TF_OPENCL_VERSION library path. ${COMPUTECPP_TOOLKIT_PATH}/${SYCL_RT_LIB_PATH} cannot be found"
 
-  if [ -z "$fromuser" ]; then
-    exit 1
-  fi
-  # Retry
-  TF_OPENCL_VERSION=""
-  COMPUTECPP_TOOLKIT_PATH=""
-done
+    if [ -z "$fromuser" ]; then
+      exit 1
+    fi
+    # Retry
+    TF_OPENCL_VERSION=""
+    COMPUTECPP_TOOLKIT_PATH=""
+  done
 
 # end of if "$TF_NEED_OPENCL" == "1"
 fi

--- a/configure
+++ b/configure
@@ -396,15 +396,9 @@ export TF_NEED_OPENCL
 write_action_env_to_bazelrc "TF_NEED_OPENCL" "$TF_NEED_OPENCL"
 
 if [ "$TF_NEED_CUDA" == "1" ]; then
-  while [[ "$TF_CUDA_CLANG" == "" ]]; do
-    read -p "Do you want to use clang as CUDA compiler? [y/N] " INPUT
-    case $INPUT in
-      [Yy]* ) echo "Clang will be used as CUDA compiler"; TF_CUDA_CLANG=1;;
-      [Nn]* ) echo "nvcc will be used as CUDA compiler"; TF_CUDA_CLANG=0;;
-      "" ) echo "nvcc will be used as CUDA compiler"; TF_CUDA_CLANG=0;;
-      * ) echo "Invalid selection: " $INPUT;;
-    esac
-  done
+  build_with TF_CUDA_CLANG "Do you want to use clang as the CUDA compiler?" \
+    "disabled" "Clang will be used as the CUDA compiler." \
+    "nvcc will be used as the CUDA compiler."
 
   export TF_CUDA_CLANG
   write_action_env_to_bazelrc "TF_CUDA_CLANG" "$TF_CUDA_CLANG"

--- a/configure
+++ b/configure
@@ -411,28 +411,11 @@ if [ "$TF_NEED_CUDA" == "1" ]; then
   write_action_env_to_bazelrc "TF_CUDA_CLANG" "$TF_CUDA_CLANG"
 
   # Set up which clang we should use as the cuda / host compiler.
-  while [[ "$TF_CUDA_CLANG" == "1" ]] && true; do
-    fromuser=""
-    if [ -z "$CLANG_CUDA_COMPILER_PATH" ]; then
-      default_clang_host_compiler_path=$(which clang || true)
-      read -p "Please specify which clang should be used as device and host compiler. [Default is $default_clang_host_compiler_path]: " CLANG_CUDA_COMPILER_PATH
-      fromuser="1"
-      if [ -z "$CLANG_CUDA_COMPILER_PATH" ]; then
-        CLANG_CUDA_COMPILER_PATH="$default_clang_host_compiler_path"
-      fi
-    fi
-    if [ -e "$CLANG_CUDA_COMPILER_PATH" ]; then
-      export CLANG_CUDA_COMPILER_PATH
-      write_action_env_to_bazelrc "CLANG_CUDA_COMPILER_PATH" "$CLANG_CUDA_COMPILER_PATH"
-      break
-    fi
-    echo "Invalid clang path. ${CLANG_CUDA_COMPILER_PATH} cannot be found" 1>&2
-    if [ -z "$fromuser" ]; then
-      exit 1
-    fi
-    CLANG_CUDA_COMPILER_PATH=""
-    # Retry
-  done
+  if (( "$TF_CUDA_CLANG" )) ; then
+    get_path CLANG_CUDA_COMPILER_PATH "clang" "bin"
+    export CLANG_CUDA_COMPILER_PATH
+    write_action_env_to_bazelrc "CLANG_CUDA_COMPILER_PATH" "$CLANG_CUDA_COMPILER_PATH"
+  fi
 
   # Find out where the CUDA toolkit is installed
   while true; do

--- a/configure
+++ b/configure
@@ -795,13 +795,11 @@ while true; do
     MPI_HOME=""
 done
 
-
 if [ "$TF_NEED_MPI" == "1" ]; then
   write_to_bazelrc 'build --define with_mpi_support=true'
 
   #Link the MPI header files
   ln -sf "${MPI_HOME}/include/mpi.h" third_party/mpi/mpi.h
-
 
   #Determine if we use OpenMPI or MVAPICH, these require different header files
   #to be included here to make bazel dependency checker happy
@@ -817,7 +815,6 @@ if [ "$TF_NEED_MPI" == "1" ]; then
         sed -i -e "s/MPI_LIB_IS_OPENMPI=True/MPI_LIB_IS_OPENMPI=False/" third_party/mpi/mpi.bzl
  fi
 
-
   if [ -e "${MPI_HOME}/lib/libmpi.so" ]; then
     ln -sf "${MPI_HOME}/lib/libmpi.so" third_party/mpi/
   else
@@ -825,6 +822,5 @@ if [ "$TF_NEED_MPI" == "1" ]; then
     exit 1
   fi
 fi
-
 
 echo "Configuration finished"

--- a/configure
+++ b/configure
@@ -763,21 +763,7 @@ if [ "$TF_NEED_OPENCL" == "1" ]; then
 # end of if "$TF_NEED_OPENCL" == "1"
 fi
 
-
-while [ "$TF_NEED_MPI" == "" ]; do
-  read -p "Do you wish to build TensorFlow with "\
-"MPI support? [y/N] " INPUT
-  case $INPUT in
-    [Yy]* ) echo "MPI support will be enabled for "\
-"TensorFlow"; TF_NEED_MPI=1;;
-    [Nn]* ) echo "MPI support will not be enabled for "\
-"TensorFlow"; TF_NEED_MPI=0;;
-    "" ) echo "MPI support will not be enabled for "\
-"TensorFlow"; TF_NEED_MPI=0;;
-    * ) echo "Invalid selection: " $INPUT;;
-  esac
-done
-
+build_with TF_NEED_MPI "MPI" "disabled"
 # Find out where the MPI toolkit is installed
 while true; do
     if [ "$TF_NEED_MPI" == "0" ]; then

--- a/configure
+++ b/configure
@@ -205,6 +205,60 @@ function build_with {
   done
 }
 
+function get_path {
+  if [[ "$(eval echo \"\$$1\")" ]] ; then
+    return
+  fi
+  local sys_path="$1"
+  local path_for="$2"
+  # looking for a path for a bin or lib
+  local type_of_path="$3"
+  # optional search for bin, array of paths for lib
+  local generic_path="$4"
+  local default_path=""
+
+  if [[ "$type_of_path" == "bin" ]] ; then
+    local default_path="$(which $path_for || true)"
+    if [[ !"$default_path" ]] && [[ "$generic_path" ]] ; then
+      local default_path="$(which $generic_path || true)"
+    fi
+    local ask_for_path="Please specify the location of $path_for. [Default is $default_path]:"
+  else
+    echo "Possible library path(s): "
+    for x in "${generic_path[@]}" ; do
+      if [[ "$x" ]] && [[ ! "$default_path" ]] ; then
+        local default_path="$x"
+      fi
+      echo "    $x"
+    done
+    local ask_for_path="Please input the desired $path_for library path to use. [Default is $default_path]:"
+  fi
+
+  while true; do
+    read -p "$ask_for_path " $sys_path
+
+    if [[ ! "$(eval echo \$$sys_path)" ]] ; then
+      if [[ -e "$default_path" ]] ; then
+        eval $sys_path="$default_path"
+      elif [[ -e "$generic_path" ]] && [[ "$type_of_path" == "bin" ]] ; then
+        eval $sys_path="$default_path"
+      else
+        echo "ERROR! I cannot find a default path and one was not specified." 1>&2
+      fi
+    fi
+
+    if [[ -e "$(eval echo \$$sys_path)" ]] ; then
+      if [[ "$type_of_path" == "bin" ]] && [[ ! -x "$(eval echo \$$sys_path)" ]] ; then
+        echo "ERROR! \$$sys_path is not executable." 1>&2
+      else
+        break
+      fi
+    else
+      echo "ERROR! $(eval echo \$$sys_path) does not seem to be a valid path to $path_for." 1>&2
+    fi
+  done
+}
+
 curr_bazel_version="$(bazel version | grep label | cut -d ' ' -f3 | grep -o '[0-9.]*')"
 echo "You have bazel $curr_bazel_version installed."
 if [ -z "$curr_bazel_version" ]; then

--- a/configure
+++ b/configure
@@ -396,288 +396,288 @@ export TF_NEED_OPENCL
 write_action_env_to_bazelrc "TF_NEED_OPENCL" "$TF_NEED_OPENCL"
 
 if [ "$TF_NEED_CUDA" == "1" ]; then
-while [[ "$TF_CUDA_CLANG" == "" ]]; do
-  read -p "Do you want to use clang as CUDA compiler? [y/N] " INPUT
-  case $INPUT in
-    [Yy]* ) echo "Clang will be used as CUDA compiler"; TF_CUDA_CLANG=1;;
-    [Nn]* ) echo "nvcc will be used as CUDA compiler"; TF_CUDA_CLANG=0;;
-    "" ) echo "nvcc will be used as CUDA compiler"; TF_CUDA_CLANG=0;;
-    * ) echo "Invalid selection: " $INPUT;;
-  esac
-done
+  while [[ "$TF_CUDA_CLANG" == "" ]]; do
+    read -p "Do you want to use clang as CUDA compiler? [y/N] " INPUT
+    case $INPUT in
+      [Yy]* ) echo "Clang will be used as CUDA compiler"; TF_CUDA_CLANG=1;;
+      [Nn]* ) echo "nvcc will be used as CUDA compiler"; TF_CUDA_CLANG=0;;
+      "" ) echo "nvcc will be used as CUDA compiler"; TF_CUDA_CLANG=0;;
+      * ) echo "Invalid selection: " $INPUT;;
+    esac
+  done
 
-export TF_CUDA_CLANG
-write_action_env_to_bazelrc "TF_CUDA_CLANG" "$TF_CUDA_CLANG"
+  export TF_CUDA_CLANG
+  write_action_env_to_bazelrc "TF_CUDA_CLANG" "$TF_CUDA_CLANG"
 
-# Set up which clang we should use as the cuda / host compiler.
-while [[ "$TF_CUDA_CLANG" == "1" ]] && true; do
-  fromuser=""
-  if [ -z "$CLANG_CUDA_COMPILER_PATH" ]; then
-    default_clang_host_compiler_path=$(which clang || true)
-    read -p "Please specify which clang should be used as device and host compiler. [Default is $default_clang_host_compiler_path]: " CLANG_CUDA_COMPILER_PATH
-    fromuser="1"
+  # Set up which clang we should use as the cuda / host compiler.
+  while [[ "$TF_CUDA_CLANG" == "1" ]] && true; do
+    fromuser=""
     if [ -z "$CLANG_CUDA_COMPILER_PATH" ]; then
-      CLANG_CUDA_COMPILER_PATH="$default_clang_host_compiler_path"
-    fi
-  fi
-  if [ -e "$CLANG_CUDA_COMPILER_PATH" ]; then
-    export CLANG_CUDA_COMPILER_PATH
-    write_action_env_to_bazelrc "CLANG_CUDA_COMPILER_PATH" "$CLANG_CUDA_COMPILER_PATH"
-    break
-  fi
-  echo "Invalid clang path. ${CLANG_CUDA_COMPILER_PATH} cannot be found" 1>&2
-  if [ -z "$fromuser" ]; then
-    exit 1
-  fi
-  CLANG_CUDA_COMPILER_PATH=""
-  # Retry
-done
-
-# Find out where the CUDA toolkit is installed
-while true; do
-  # Configure the Cuda SDK version to use.
-  if [ -z "$TF_CUDA_VERSION" ]; then
-    read -p "Please specify the CUDA SDK version you want to use, e.g. 7.0. [Leave empty to default to CUDA 8.0]: " TF_CUDA_VERSION
-  fi
-
-  fromuser=""
-  if [ -z "$CUDA_TOOLKIT_PATH" ]; then
-    default_cuda_path=/usr/local/cuda
-    if is_windows; then
-      if [ -z "$CUDA_PATH" ]; then
-        default_cuda_path="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0"
-      else
-        default_cuda_path="$(cygpath -m "$CUDA_PATH")"
-      fi
-    elif is_linux; then
-      # If the default doesn't exist, try an alternative default.
-      if [ ! -d $default_cuda_path ] && [ -d /opt/cuda ]; then
-        default_cuda_path=/opt/cuda
+      default_clang_host_compiler_path=$(which clang || true)
+      read -p "Please specify which clang should be used as device and host compiler. [Default is $default_clang_host_compiler_path]: " CLANG_CUDA_COMPILER_PATH
+      fromuser="1"
+      if [ -z "$CLANG_CUDA_COMPILER_PATH" ]; then
+        CLANG_CUDA_COMPILER_PATH="$default_clang_host_compiler_path"
       fi
     fi
-    read -p "Please specify the location where CUDA $TF_CUDA_VERSION toolkit is installed. Refer to README.md for more details. [Default is $default_cuda_path]: " CUDA_TOOLKIT_PATH
-    fromuser="1"
+    if [ -e "$CLANG_CUDA_COMPILER_PATH" ]; then
+      export CLANG_CUDA_COMPILER_PATH
+      write_action_env_to_bazelrc "CLANG_CUDA_COMPILER_PATH" "$CLANG_CUDA_COMPILER_PATH"
+      break
+    fi
+    echo "Invalid clang path. ${CLANG_CUDA_COMPILER_PATH} cannot be found" 1>&2
+    if [ -z "$fromuser" ]; then
+      exit 1
+    fi
+    CLANG_CUDA_COMPILER_PATH=""
+    # Retry
+  done
+
+  # Find out where the CUDA toolkit is installed
+  while true; do
+    # Configure the Cuda SDK version to use.
+    if [ -z "$TF_CUDA_VERSION" ]; then
+      read -p "Please specify the CUDA SDK version you want to use, e.g. 7.0. [Leave empty to default to CUDA 8.0]: " TF_CUDA_VERSION
+    fi
+
+    fromuser=""
     if [ -z "$CUDA_TOOLKIT_PATH" ]; then
-      CUDA_TOOLKIT_PATH="$default_cuda_path"
+      default_cuda_path=/usr/local/cuda
+      if is_windows; then
+        if [ -z "$CUDA_PATH" ]; then
+          default_cuda_path="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0"
+        else
+          default_cuda_path="$(cygpath -m "$CUDA_PATH")"
+        fi
+      elif is_linux; then
+        # If the default doesn't exist, try an alternative default.
+        if [ ! -d $default_cuda_path ] && [ -d /opt/cuda ]; then
+          default_cuda_path=/opt/cuda
+        fi
+      fi
+      read -p "Please specify the location where CUDA $TF_CUDA_VERSION toolkit is installed. Refer to README.md for more details. [Default is $default_cuda_path]: " CUDA_TOOLKIT_PATH
+      fromuser="1"
+      if [ -z "$CUDA_TOOLKIT_PATH" ]; then
+        CUDA_TOOLKIT_PATH="$default_cuda_path"
+      fi
     fi
-  fi
 
-  if [[ -z "$TF_CUDA_VERSION" ]]; then
-    TF_CUDA_EXT=""
-  else
-    TF_CUDA_EXT=".$TF_CUDA_VERSION"
-  fi
-
-  if is_windows; then
-    CUDA_RT_LIB_PATH="lib/x64/cudart.lib"
-  elif is_linux; then
-    CUDA_RT_LIB_PATH="lib64/libcudart.so${TF_CUDA_EXT}"
-  elif is_macos; then
-    CUDA_RT_LIB_PATH="lib/libcudart${TF_CUDA_EXT}.dylib"
-  fi
-
-  if [ -e "${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH}" ]; then
-    export CUDA_TOOLKIT_PATH
-    write_action_env_to_bazelrc "CUDA_TOOLKIT_PATH" "$CUDA_TOOLKIT_PATH"
-    export TF_CUDA_VERSION
-    break
-  fi
-  echo "Invalid path to CUDA $TF_CUDA_VERSION toolkit. ${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH} cannot be found"
-
-  if [ -z "$fromuser" ]; then
-    exit 1
-  fi
-  # Retry
-  TF_CUDA_VERSION=""
-  CUDA_TOOLKIT_PATH=""
-done
-
-# Set default CUDA version if not set
-if [ -z "$TF_CUDA_VERSION" ]; then
-  TF_CUDA_VERSION="8.0"
-  export TF_CUDA_VERSION
-fi
-write_action_env_to_bazelrc "TF_CUDA_VERSION" "$TF_CUDA_VERSION"
-
-# Set up which gcc nvcc should use as the host compiler
-# No need to set this on Windows
-while [[ "$TF_CUDA_CLANG" != "1" ]] && ! is_windows && true; do
-  fromuser=""
-  if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
-    default_gcc_host_compiler_path=$(which gcc || true)
-    cuda_bin_symlink="$CUDA_TOOLKIT_PATH/bin/gcc"
-    if [ -L "$cuda_bin_symlink" ]; then
-      default_gcc_host_compiler_path=$(readlink $cuda_bin_symlink)
-    fi
-    read -p "Please specify which gcc should be used by nvcc as the host compiler. [Default is $default_gcc_host_compiler_path]: " GCC_HOST_COMPILER_PATH
-    fromuser="1"
-    if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
-      GCC_HOST_COMPILER_PATH="$default_gcc_host_compiler_path"
-    fi
-  fi
-  if [ -e "$GCC_HOST_COMPILER_PATH" ]; then
-    export GCC_HOST_COMPILER_PATH
-    write_action_env_to_bazelrc "GCC_HOST_COMPILER_PATH" "$GCC_HOST_COMPILER_PATH"
-    break
-  fi
-  echo "Invalid gcc path. ${GCC_HOST_COMPILER_PATH} cannot be found" 1>&2
-  if [ -z "$fromuser" ]; then
-    exit 1
-  fi
-  GCC_HOST_COMPILER_PATH=""
-  # Retry
-done
-
-# Find out where the cuDNN library is installed
-while true; do
-  # Configure the cuDNN version to use.
-  if [ -z "$TF_CUDNN_VERSION" ]; then
-    read -p "Please specify the cuDNN version you want to use. [Leave empty to default to cuDNN 6.0]: " TF_CUDNN_VERSION
-  fi
-
-  fromuser=""
-  if [ -z "$CUDNN_INSTALL_PATH" ]; then
-    default_cudnn_path=${CUDA_TOOLKIT_PATH}
-    read -p "Please specify the location where cuDNN $TF_CUDNN_VERSION library is installed. Refer to README.md for more details. [Default is $default_cudnn_path]: " CUDNN_INSTALL_PATH
-    fromuser="1"
-    if [ -z "$CUDNN_INSTALL_PATH" ]; then
-      CUDNN_INSTALL_PATH=$default_cudnn_path
-    fi
-    # Result returned from "read" will be used unexpanded. That make "~" unusable.
-    # Going through one more level of expansion to handle that.
-    CUDNN_INSTALL_PATH=`"${PYTHON_BIN_PATH}" -c "import os; print(os.path.realpath(os.path.expanduser('${CUDNN_INSTALL_PATH}')))"`
-    if is_windows; then
-      CUDNN_INSTALL_PATH="$(cygpath -m "$CUDNN_INSTALL_PATH")"
-    fi
-  fi
-
-  if [[ -z "$TF_CUDNN_VERSION" ]]; then
-    TF_CUDNN_EXT=""
-  else
-    TF_CUDNN_EXT=".$TF_CUDNN_VERSION"
-  fi
-
-  if is_windows; then
-    CUDA_DNN_LIB_PATH="lib/x64/cudnn.lib"
-    CUDA_DNN_LIB_ALT_PATH="lib/x64/cudnn.lib"
-  elif is_linux; then
-    CUDA_DNN_LIB_PATH="lib64/libcudnn.so${TF_CUDNN_EXT}"
-    CUDA_DNN_LIB_ALT_PATH="libcudnn.so${TF_CUDNN_EXT}"
-  elif is_macos; then
-    CUDA_DNN_LIB_PATH="lib/libcudnn${TF_CUDNN_EXT}.dylib"
-    CUDA_DNN_LIB_ALT_PATH="libcudnn${TF_CUDNN_EXT}.dylib"
-  fi
-
-  if [ -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_ALT_PATH}" ] || [ -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_PATH}" ]; then
-    export TF_CUDNN_VERSION
-    write_action_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
-    export CUDNN_INSTALL_PATH
-    write_action_env_to_bazelrc "CUDNN_INSTALL_PATH" "$CUDNN_INSTALL_PATH"
-    break
-  fi
-
-  if is_linux; then
-    if ! type ldconfig > /dev/null 2>&1; then
-        LDCONFIG_BIN=/sbin/ldconfig
+    if [[ -z "$TF_CUDA_VERSION" ]]; then
+      TF_CUDA_EXT=""
     else
-        LDCONFIG_BIN=ldconfig
+      TF_CUDA_EXT=".$TF_CUDA_VERSION"
     fi
-    CUDNN_PATH_FROM_LDCONFIG="$($LDCONFIG_BIN -p | sed -n 's/.*libcudnn.so .* => \(.*\)/\1/p')"
-    if [ -e "${CUDNN_PATH_FROM_LDCONFIG}${TF_CUDNN_EXT}" ]; then
+
+    if is_windows; then
+      CUDA_RT_LIB_PATH="lib/x64/cudart.lib"
+    elif is_linux; then
+      CUDA_RT_LIB_PATH="lib64/libcudart.so${TF_CUDA_EXT}"
+    elif is_macos; then
+      CUDA_RT_LIB_PATH="lib/libcudart${TF_CUDA_EXT}.dylib"
+    fi
+
+    if [ -e "${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH}" ]; then
+      export CUDA_TOOLKIT_PATH
+      write_action_env_to_bazelrc "CUDA_TOOLKIT_PATH" "$CUDA_TOOLKIT_PATH"
+      export TF_CUDA_VERSION
+      break
+    fi
+    echo "Invalid path to CUDA $TF_CUDA_VERSION toolkit. ${CUDA_TOOLKIT_PATH}/${CUDA_RT_LIB_PATH} cannot be found"
+
+    if [ -z "$fromuser" ]; then
+      exit 1
+    fi
+    # Retry
+    TF_CUDA_VERSION=""
+    CUDA_TOOLKIT_PATH=""
+  done
+
+  # Set default CUDA version if not set
+  if [ -z "$TF_CUDA_VERSION" ]; then
+    TF_CUDA_VERSION="8.0"
+    export TF_CUDA_VERSION
+  fi
+  write_action_env_to_bazelrc "TF_CUDA_VERSION" "$TF_CUDA_VERSION"
+
+  # Set up which gcc nvcc should use as the host compiler
+  # No need to set this on Windows
+  while [[ "$TF_CUDA_CLANG" != "1" ]] && ! is_windows && true; do
+    fromuser=""
+    if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
+      default_gcc_host_compiler_path=$(which gcc || true)
+      cuda_bin_symlink="$CUDA_TOOLKIT_PATH/bin/gcc"
+      if [ -L "$cuda_bin_symlink" ]; then
+        default_gcc_host_compiler_path=$(readlink $cuda_bin_symlink)
+      fi
+      read -p "Please specify which gcc should be used by nvcc as the host compiler. [Default is $default_gcc_host_compiler_path]: " GCC_HOST_COMPILER_PATH
+      fromuser="1"
+      if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
+        GCC_HOST_COMPILER_PATH="$default_gcc_host_compiler_path"
+      fi
+    fi
+    if [ -e "$GCC_HOST_COMPILER_PATH" ]; then
+      export GCC_HOST_COMPILER_PATH
+      write_action_env_to_bazelrc "GCC_HOST_COMPILER_PATH" "$GCC_HOST_COMPILER_PATH"
+      break
+    fi
+    echo "Invalid gcc path. ${GCC_HOST_COMPILER_PATH} cannot be found" 1>&2
+    if [ -z "$fromuser" ]; then
+      exit 1
+    fi
+    GCC_HOST_COMPILER_PATH=""
+    # Retry
+  done
+
+  # Find out where the cuDNN library is installed
+  while true; do
+    # Configure the cuDNN version to use.
+    if [ -z "$TF_CUDNN_VERSION" ]; then
+      read -p "Please specify the cuDNN version you want to use. [Leave empty to default to cuDNN 6.0]: " TF_CUDNN_VERSION
+    fi
+
+    fromuser=""
+    if [ -z "$CUDNN_INSTALL_PATH" ]; then
+      default_cudnn_path=${CUDA_TOOLKIT_PATH}
+      read -p "Please specify the location where cuDNN $TF_CUDNN_VERSION library is installed. Refer to README.md for more details. [Default is $default_cudnn_path]: " CUDNN_INSTALL_PATH
+      fromuser="1"
+      if [ -z "$CUDNN_INSTALL_PATH" ]; then
+        CUDNN_INSTALL_PATH=$default_cudnn_path
+      fi
+      # Result returned from "read" will be used unexpanded. That make "~" unusable.
+      # Going through one more level of expansion to handle that.
+      CUDNN_INSTALL_PATH=`"${PYTHON_BIN_PATH}" -c "import os; print(os.path.realpath(os.path.expanduser('${CUDNN_INSTALL_PATH}')))"`
+      if is_windows; then
+        CUDNN_INSTALL_PATH="$(cygpath -m "$CUDNN_INSTALL_PATH")"
+      fi
+    fi
+
+    if [[ -z "$TF_CUDNN_VERSION" ]]; then
+      TF_CUDNN_EXT=""
+    else
+      TF_CUDNN_EXT=".$TF_CUDNN_VERSION"
+    fi
+
+    if is_windows; then
+      CUDA_DNN_LIB_PATH="lib/x64/cudnn.lib"
+      CUDA_DNN_LIB_ALT_PATH="lib/x64/cudnn.lib"
+    elif is_linux; then
+      CUDA_DNN_LIB_PATH="lib64/libcudnn.so${TF_CUDNN_EXT}"
+      CUDA_DNN_LIB_ALT_PATH="libcudnn.so${TF_CUDNN_EXT}"
+    elif is_macos; then
+      CUDA_DNN_LIB_PATH="lib/libcudnn${TF_CUDNN_EXT}.dylib"
+      CUDA_DNN_LIB_ALT_PATH="libcudnn${TF_CUDNN_EXT}.dylib"
+    fi
+
+    if [ -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_ALT_PATH}" ] || [ -e "$CUDNN_INSTALL_PATH/${CUDA_DNN_LIB_PATH}" ]; then
       export TF_CUDNN_VERSION
+      write_action_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
       export CUDNN_INSTALL_PATH
-      CUDNN_INSTALL_PATH="$(dirname ${CUDNN_PATH_FROM_LDCONFIG})"
       write_action_env_to_bazelrc "CUDNN_INSTALL_PATH" "$CUDNN_INSTALL_PATH"
       break
     fi
-  fi
-  echo "Invalid path to cuDNN ${CUDNN_VERSION} toolkit. Neither of the following two files can be found:"
-  echo "${CUDNN_INSTALL_PATH}/${CUDA_DNN_LIB_PATH}"
-  echo "${CUDNN_INSTALL_PATH}/${CUDA_DNN_LIB_ALT_PATH}"
-  if is_linux; then
-    echo "${CUDNN_PATH_FROM_LDCONFIG}${TF_CUDNN_EXT}"
-  fi
 
-  if [ -z "$fromuser" ]; then
-    exit 1
+    if is_linux; then
+      if ! type ldconfig > /dev/null 2>&1; then
+          LDCONFIG_BIN=/sbin/ldconfig
+      else
+          LDCONFIG_BIN=ldconfig
+      fi
+      CUDNN_PATH_FROM_LDCONFIG="$($LDCONFIG_BIN -p | sed -n 's/.*libcudnn.so .* => \(.*\)/\1/p')"
+      if [ -e "${CUDNN_PATH_FROM_LDCONFIG}${TF_CUDNN_EXT}" ]; then
+        export TF_CUDNN_VERSION
+        export CUDNN_INSTALL_PATH
+        CUDNN_INSTALL_PATH="$(dirname ${CUDNN_PATH_FROM_LDCONFIG})"
+        write_action_env_to_bazelrc "CUDNN_INSTALL_PATH" "$CUDNN_INSTALL_PATH"
+        break
+      fi
+    fi
+    echo "Invalid path to cuDNN ${CUDNN_VERSION} toolkit. Neither of the following two files can be found:"
+    echo "${CUDNN_INSTALL_PATH}/${CUDA_DNN_LIB_PATH}"
+    echo "${CUDNN_INSTALL_PATH}/${CUDA_DNN_LIB_ALT_PATH}"
+    if is_linux; then
+      echo "${CUDNN_PATH_FROM_LDCONFIG}${TF_CUDNN_EXT}"
+    fi
+
+    if [ -z "$fromuser" ]; then
+      exit 1
+    fi
+    # Retry
+    TF_CUDNN_VERSION=""
+    CUDNN_INSTALL_PATH=""
+  done
+
+  # Set default CUDNN version if not set
+  if [ -z "$TF_CUDNN_VERSION" ]; then
+    TF_CUDNN_VERSION="6"
+    export TF_CUDNN_VERSION
   fi
-  # Retry
-  TF_CUDNN_VERSION=""
-  CUDNN_INSTALL_PATH=""
-done
+  write_action_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
 
-# Set default CUDNN version if not set
-if [ -z "$TF_CUDNN_VERSION" ]; then
-  TF_CUDNN_VERSION="6"
-  export TF_CUDNN_VERSION
-fi
-write_action_env_to_bazelrc "TF_CUDNN_VERSION" "$TF_CUDNN_VERSION"
-
-# Configure the compute capabilities that TensorFlow builds for.
-# Since Cuda toolkit is not backward-compatible, this is not guaranteed to work.
-function get_native_cuda_compute_capabilities {
-  device_query_bin="$CUDA_TOOLKIT_PATH/extras/demo_suite/deviceQuery" # Also works on Windows without .exe
-  "$device_query_bin" | grep 'Capability' | grep -o '[0-9]*\.[0-9]*' | sed ':a;{N;s/\n/,/};ba'
-  exit 0 # ensure that this function always exit success even if device detection fails, to prevent the whole configure from aborting
-}
-while true; do
-  fromuser=""
-  native_cuda_compute_capabilities=$(get_native_cuda_compute_capabilities)
-  default_cuda_compute_capabilities=${native_cuda_compute_capabilities:-"3.5,5.2"}
-  if [ -z "$TF_CUDA_COMPUTE_CAPABILITIES" ]; then
+  # Configure the compute capabilities that TensorFlow builds for.
+  # Since Cuda toolkit is not backward-compatible, this is not guaranteed to work.
+  function get_native_cuda_compute_capabilities {
+    device_query_bin="$CUDA_TOOLKIT_PATH/extras/demo_suite/deviceQuery" # Also works on Windows without .exe
+    "$device_query_bin" | grep 'Capability' | grep -o '[0-9]*\.[0-9]*' | sed ':a;{N;s/\n/,/};ba'
+    exit 0 # ensure that this function always exit success even if device detection fails, to prevent the whole configure from aborting
+  }
+  while true; do
+    fromuser=""
+    native_cuda_compute_capabilities=$(get_native_cuda_compute_capabilities)
+    default_cuda_compute_capabilities=${native_cuda_compute_capabilities:-"3.5,5.2"}
+    if [ -z "$TF_CUDA_COMPUTE_CAPABILITIES" ]; then
 cat << EOF
 Please specify a list of comma-separated Cuda compute capabilities you want to build with.
 You can find the compute capability of your device at: https://developer.nvidia.com/cuda-gpus.
 Please note that each additional compute capability significantly increases your build time and binary size.
 EOF
-    read -p "[Default is: \"$default_cuda_compute_capabilities\"]: " TF_CUDA_COMPUTE_CAPABILITIES
-    fromuser=1
-  fi
-  if [ -z "$TF_CUDA_COMPUTE_CAPABILITIES" ]; then
-    TF_CUDA_COMPUTE_CAPABILITIES=$default_cuda_compute_capabilities
-  fi
-  # Check whether all capabilities from the input is valid
-  COMPUTE_CAPABILITIES=${TF_CUDA_COMPUTE_CAPABILITIES//,/ }
-  ALL_VALID=1
-  for CAPABILITY in $COMPUTE_CAPABILITIES; do
-    if [[ ! "$CAPABILITY" =~ [0-9]+.[0-9]+ ]]; then
-      echo "Invalid compute capability: " $CAPABILITY
-      ALL_VALID=0
+      read -p "[Default is: \"$default_cuda_compute_capabilities\"]: " TF_CUDA_COMPUTE_CAPABILITIES
+      fromuser=1
+    fi
+    if [ -z "$TF_CUDA_COMPUTE_CAPABILITIES" ]; then
+      TF_CUDA_COMPUTE_CAPABILITIES=$default_cuda_compute_capabilities
+    fi
+    # Check whether all capabilities from the input is valid
+    COMPUTE_CAPABILITIES=${TF_CUDA_COMPUTE_CAPABILITIES//,/ }
+    ALL_VALID=1
+    for CAPABILITY in $COMPUTE_CAPABILITIES; do
+      if [[ ! "$CAPABILITY" =~ [0-9]+.[0-9]+ ]]; then
+        echo "Invalid compute capability: " $CAPABILITY
+        ALL_VALID=0
+        break
+      fi
+    done
+    if [ "$ALL_VALID" == "0" ]; then
+      if [ -z "$fromuser" ]; then
+        exit 1
+      fi
+    else
+      export TF_CUDA_COMPUTE_CAPABILITIES
+      write_action_env_to_bazelrc "TF_CUDA_COMPUTE_CAPABILITIES" "$TF_CUDA_COMPUTE_CAPABILITIES"
       break
     fi
+    TF_CUDA_COMPUTE_CAPABILITIES=""
   done
-  if [ "$ALL_VALID" == "0" ]; then
-    if [ -z "$fromuser" ]; then
-      exit 1
-    fi
-  else
-    export TF_CUDA_COMPUTE_CAPABILITIES
-    write_action_env_to_bazelrc "TF_CUDA_COMPUTE_CAPABILITIES" "$TF_CUDA_COMPUTE_CAPABILITIES"
-    break
-  fi
-  TF_CUDA_COMPUTE_CAPABILITIES=""
-done
 
-if is_windows; then
-  # The following three variables are needed for MSVC toolchain configuration in Bazel
-  export CUDA_PATH="$CUDA_TOOLKIT_PATH"
-  export CUDA_COMPUTE_CAPABILITIES="$TF_CUDA_COMPUTE_CAPABILITIES"
-  export NO_WHOLE_ARCHIVE_OPTION=1
-  write_action_env_to_bazelrc "CUDA_PATH" "$CUDA_PATH"
-  write_action_env_to_bazelrc "CUDA_COMPUTE_CAPABILITIES" "$CUDA_COMPUTE_CAPABILITIES"
-  write_action_env_to_bazelrc "NO_WHOLE_ARCHIVE_OPTION" "1"
-  write_to_bazelrc "build --config=win-cuda"
-  write_to_bazelrc "test --config=win-cuda"
-else
-  # If CUDA is enabled, always use GPU during build and test.
-  if [ "$TF_CUDA_CLANG" == "1" ]; then
-    write_to_bazelrc "build --config=cuda_clang"
-    write_to_bazelrc "test --config=cuda_clang"
+  if is_windows; then
+    # The following three variables are needed for MSVC toolchain configuration in Bazel
+    export CUDA_PATH="$CUDA_TOOLKIT_PATH"
+    export CUDA_COMPUTE_CAPABILITIES="$TF_CUDA_COMPUTE_CAPABILITIES"
+    export NO_WHOLE_ARCHIVE_OPTION=1
+    write_action_env_to_bazelrc "CUDA_PATH" "$CUDA_PATH"
+    write_action_env_to_bazelrc "CUDA_COMPUTE_CAPABILITIES" "$CUDA_COMPUTE_CAPABILITIES"
+    write_action_env_to_bazelrc "NO_WHOLE_ARCHIVE_OPTION" "1"
+    write_to_bazelrc "build --config=win-cuda"
+    write_to_bazelrc "test --config=win-cuda"
   else
-    write_to_bazelrc "build --config=cuda"
-    write_to_bazelrc "test --config=cuda"
+    # If CUDA is enabled, always use GPU during build and test.
+    if [ "$TF_CUDA_CLANG" == "1" ]; then
+      write_to_bazelrc "build --config=cuda_clang"
+      write_to_bazelrc "test --config=cuda_clang"
+    else
+      write_to_bazelrc "build --config=cuda"
+      write_to_bazelrc "test --config=cuda"
+    fi
   fi
-fi
 
 # end of if "$TF_NEED_CUDA" == "1"
 fi

--- a/configure
+++ b/configure
@@ -205,10 +205,7 @@ function build_with {
   done
 }
 
-bazel version > bazel.version
-curr_bazel_version=$(head -n 1 bazel.version | cut -d ' ' -f3)
-rm -f bazel.version
-
+curr_bazel_version="$(bazel version | grep label | cut -d ' ' -f3 | grep -o '[0-9.]*')"
 echo "You have bazel $curr_bazel_version installed."
 if [ -z "$curr_bazel_version" ]; then
   echo "WARNING: current bazel installation is not a release version."

--- a/configure
+++ b/configure
@@ -371,21 +371,7 @@ if [[ "$TF_ENABLE_XLA" == "1" ]]; then
   write_to_bazelrc 'build --define with_xla_support=true'
 fi
 
-# Verbs configuration
-while [ "$TF_NEED_VERBS" == "" ]; do
-  read -p "Do you wish to build TensorFlow with "\
-"VERBS support? [y/N] " INPUT
-  case $INPUT in
-    [Yy]* ) echo "VERBS support will be enabled for "\
-"TensorFlow"; TF_NEED_VERBS=1;;
-    [Nn]* ) echo "No VERBS support will be enabled for "\
-"TensorFlow"; TF_NEED_VERBS=0;;
-    "" ) echo "No VERBS support will be enabled for "\
-"TensorFlow"; TF_NEED_VERBS=0;;
-    * ) echo "Invalid selection: " $INPUT;;
-  esac
-done
-
+build_with TF_NEED_VERBS "VERBS" "disabled"
 if [[ "$TF_NEED_VERBS" == "1" ]]; then
   write_to_bazelrc 'build --define with_verbs_support=true'
 fi

--- a/configure
+++ b/configure
@@ -387,19 +387,9 @@ GEN_GIT_SOURCE=tensorflow/tools/git/gen_git_source.py
 chmod a+x ${GEN_GIT_SOURCE}
 "${PYTHON_BIN_PATH}" ${GEN_GIT_SOURCE} --configure "${SOURCE_BASE_DIR}"
 
-## Set up SYCL-related environment settings
-while [ "$TF_NEED_OPENCL" == "" ]; do
-  read -p "Do you wish to build TensorFlow with OpenCL support? [y/N] " INPUT
-  case $INPUT in
-    [Yy]* ) echo "OpenCL support will be enabled for TensorFlow"; TF_NEED_OPENCL=1;;
-    [Nn]* ) echo "No OpenCL support will be enabled for TensorFlow"; TF_NEED_OPENCL=0;;
-    "" ) echo "No OpenCL support will be enabled for TensorFlow"; TF_NEED_OPENCL=0;;
-    * ) echo "Invalid selection: " $INPUT;;
-  esac
-done
+build_with TF_NEED_OPENCL "OpenCL" "disabled"
 
 ## Set up Cuda-related environment settings
-
 while [ "$TF_NEED_CUDA" == "" ]; do
   read -p "Do you wish to build TensorFlow with CUDA support? [y/N] " INPUT
   case $INPUT in

--- a/configure
+++ b/configure
@@ -344,16 +344,8 @@ if is_windows; then
 fi
 
 if is_linux; then
-  while [ "$TF_NEED_JEMALLOC" == "" ]; do
-    read -p "Do you wish to use jemalloc as the malloc implementation? [Y/n] "\
-      INPUT
-    case $INPUT in
-      [Yy]* ) echo "jemalloc enabled"; TF_NEED_JEMALLOC=1;;
-      [Nn]* ) echo "jemalloc disabled"; TF_NEED_JEMALLOC=0;;
-      "" ) echo "jemalloc enabled"; TF_NEED_JEMALLOC=1;;
-      * ) echo "Invalid selection: " $INPUT;;
-    esac
-  done
+  build_with TF_NEED_JEMALLOC "Do you wish to use jemalloc as the malloc implementation?" \
+    "enabled" "jemalloc enabled." "jemalloc disabled."
 else
   TF_NEED_JEMALLOC=0
 fi

--- a/configure
+++ b/configure
@@ -70,27 +70,7 @@ END
 
 function setup_python {
   ## Set up python-related environment settings:
-  while true; do
-    fromuser=""
-    if [ -z "$PYTHON_BIN_PATH" ]; then
-      default_python_bin_path=$(which python || which python3 || true)
-      read -p "Please specify the location of python. [Default is $default_python_bin_path]: " PYTHON_BIN_PATH
-      fromuser="1"
-      if [ -z "$PYTHON_BIN_PATH" ]; then
-        PYTHON_BIN_PATH=$default_python_bin_path
-      fi
-    fi
-    if [ -e "$PYTHON_BIN_PATH" ]; then
-      break
-    fi
-    echo "Invalid python path. ${PYTHON_BIN_PATH} cannot be found" 1>&2
-    if [ -z "$fromuser" ]; then
-      exit 1
-    fi
-    PYTHON_BIN_PATH=""
-    # Retry
-  done
-
+  get_path PYTHON_BIN_PATH "python" "bin" "python3"
   if [ -z "$PYTHON_LIB_PATH" ]; then
     # Split python_path into an array of paths, this allows path containing spaces
     IFS=',' read -r -a python_lib_path <<< "$(python_path)"

--- a/configure
+++ b/configure
@@ -246,17 +246,8 @@ build_with TF_NEED_MKL "MKL" "disabled"
 OSNAME=`uname -s`
 
 if [ "$TF_NEED_MKL" == "1" ]; then # TF_NEED_MKL
-  while [ "$TF_DOWNLOAD_MKL" == "" ]; do
-    fromuser=""
-    read -p "Do you wish to download MKL LIB from the web? [Y/n] " INPUT
-    fromuser="1"
-    case $INPUT in
-      [Yy]* ) TF_DOWNLOAD_MKL=1;;
-      [Nn]* ) TF_DOWNLOAD_MKL=0;;
-      "" )    TF_DOWNLOAD_MKL=1;;
-      * )     echo "Invalid selection: " $INPUT; exit 1;;
-    esac
-  done
+  build_with TF_DOWNLOAD_MKL "Do you wish to download MKL LIB from the web?" \
+    "enabled" "Downloading..." "Will not download MKL LIB."
 
   if [[ "$TF_DOWNLOAD_MKL" == "1" ]]; then
     DST=`dirname $0`

--- a/configure
+++ b/configure
@@ -648,54 +648,14 @@ fi
 
 # OpenCL configuration
 
-if [ "$TF_NEED_OPENCL" == "1" ]; then
-  # Determine which C++ compiler should be used as the host compiler
-  while true; do
-    fromuser=""
-    if [ -z "$HOST_CXX_COMPILER" ]; then
-      default_cxx_host_compiler=$(which g++ || true)
-      read -p "Please specify which C++ compiler should be used as the host C++ compiler. [Default is $default_cxx_host_compiler]: " HOST_CXX_COMPILER
-      fromuser="1"
-      if [ -z "$HOST_CXX_COMPILER" ]; then
-        HOST_CXX_COMPILER=$default_cxx_host_compiler
-      fi
-    fi
-    if [ -e "$HOST_CXX_COMPILER" ]; then
-      export HOST_CXX_COMPILER
-      write_action_env_to_bazelrc "HOST_CXX_COMPILER" "$HOST_CXX_COMPILER"
-      break
-    fi
-    echo "Invalid C++ compiler path. ${HOST_CXX_COMPILER} cannot be found" 1>&2
-    if [ -z "$fromuser" ]; then
-      exit 1
-    fi
-    HOST_CXX_COMPILER=""
-    # Retry
-  done
+if (( "$TF_NEED_OPENCL" )) ; then
+  get_path HOST_CXX_COMPILER "g++" "bin"
+  export HOST_CXX_COMPILER
+  write_action_env_to_bazelrc "HOST_CXX_COMPILER" "$HOST_CXX_COMPILER"
 
-  # Determine which C compiler should be used as the host compiler
-  while true; do
-    fromuser=""
-    if [ -z "$HOST_C_COMPILER" ]; then
-      default_c_host_compiler=$(which gcc || true)
-      read -p "Please specify which C compiler should be used as the host C compiler. [Default is $default_c_host_compiler]: " HOST_C_COMPILER
-      fromuser="1"
-      if [ -z "$HOST_C_COMPILER" ]; then
-        HOST_C_COMPILER=$default_c_host_compiler
-      fi
-    fi
-    if [ -e "$HOST_C_COMPILER" ]; then
-      export HOST_C_COMPILER
-      write_action_env_to_bazelrc "HOST_C_COMPILER" "$HOST_C_COMPILER"
-      break
-    fi
-    echo "Invalid C compiler path. ${HOST_C_COMPILER} cannot be found" 1>&2
-    if [ -z "$fromuser" ]; then
-      exit 1
-    fi
-    HOST_C_COMPILER=""
-    # Retry
-  done
+  get_path HOST_C_COMPILER "gcc" "bin"
+  export HOST_C_COMPILER
+  write_action_env_to_bazelrc "HOST_C_COMPILER" "$HOST_C_COMPILER"
 
   while true; do
     # Configure the OPENCL version to use.
@@ -735,37 +695,21 @@ fi
 
 build_with TF_NEED_MPI "MPI" "disabled"
 # Find out where the MPI toolkit is installed
-while true; do
-    if [ "$TF_NEED_MPI" == "0" ]; then
-        break;
-    fi
-
-    fromuser=""
-    if [ -z "$MPI_HOME" ]; then
-        #Get the base folder by removing the bin path
-        default_mpi_path=$(dirname $(dirname $(which mpirun)) || dirname $(dirname $(which mpiexec))  || true)
-        read -p "Please specify the MPI toolkit folder. [Default is $default_mpi_path]: " MPI_HOME
-        fromuser="1"
-        if [ -z "$MPI_HOME" ]; then
-            MPI_HOME=$default_mpi_path
-        fi
-    fi
-
-    #Check that the include and library folders are where we expect them to be
-    if [ -e "$MPI_HOME/include" ] && [ -e "$MPI_HOME/lib" ]; then
-        break
-    fi
-
+if (( "$TF_NEED_MPI" )) ; then
+  mpi_lib_array=( )
+  if [[ "$(which mpirun 2>/dev/null)" ]] ; then
+    mpi_lib_array+="$(dirname $(dirname $(which mpirun)))"
+  fi
+  if [[ "$(which mpiexec 2>/dev/null)" ]] ; then
+    mpi_lib_array+="$(dirname $(dirname $(which mpiexec)))"
+  fi
+  get_path MPI_HOME "MPI" "lib" "$mpi_lib_array"
+  #Check that the include and library folders are where we expect them to be
+  if [[ ! -e "$MPI_HOME/include" ]] && [[ ! -e "$MPI_HOME/lib" ]]; then
     echo "Invalid path to the MPI Toolkit. ${MPI_HOME}/include or ${MPI_HOME}/lib cannot be found."
-    if [ -z "$fromuser" ]; then
-        exit 1
-    fi
+    exit 1
+  fi
 
-    # Retry
-    MPI_HOME=""
-done
-
-if [ "$TF_NEED_MPI" == "1" ]; then
   write_to_bazelrc 'build --define with_mpi_support=true'
 
   #Link the MPI header files
@@ -775,15 +719,15 @@ if [ "$TF_NEED_MPI" == "1" ]; then
   #to be included here to make bazel dependency checker happy
 
   if [ -e "${MPI_HOME}/include/mpi_portable_platform.h" ]; then
-        #OpenMPI
-        ln -sf "${MPI_HOME}/include/mpi_portable_platform.h" third_party/mpi/
-        sed -i -e "s/MPI_LIB_IS_OPENMPI=False/MPI_LIB_IS_OPENMPI=True/" third_party/mpi/mpi.bzl
- else
-        #MVAPICH / MPICH
-        ln -sf "${MPI_HOME}/include/mpio.h" third_party/mpi/
-        ln -sf "${MPI_HOME}/include/mpicxx.h" third_party/mpi/
-        sed -i -e "s/MPI_LIB_IS_OPENMPI=True/MPI_LIB_IS_OPENMPI=False/" third_party/mpi/mpi.bzl
- fi
+    #OpenMPI
+    ln -sf "${MPI_HOME}/include/mpi_portable_platform.h" third_party/mpi/
+    sed -i -e "s/MPI_LIB_IS_OPENMPI=False/MPI_LIB_IS_OPENMPI=True/" third_party/mpi/mpi.bzl
+  else
+    #MVAPICH / MPICH
+    ln -sf "${MPI_HOME}/include/mpio.h" third_party/mpi/
+    ln -sf "${MPI_HOME}/include/mpicxx.h" third_party/mpi/
+    sed -i -e "s/MPI_LIB_IS_OPENMPI=True/MPI_LIB_IS_OPENMPI=False/" third_party/mpi/mpi.bzl
+  fi
 
   if [ -e "${MPI_HOME}/lib/libmpi.so" ]; then
     ln -sf "${MPI_HOME}/lib/libmpi.so" third_party/mpi/


### PR DESCRIPTION
Please don't merge yet.

The configure script has a lot of repetition. Adding functions can reduce the number of lines of code, help prevent errors, and make life easier.

I noticed it was kind of long when editing another part.

This adds two functions: build_with and get_path
```bash
function build_with {
  # don't change value if it is already set
  if [[ "$(eval echo \"\$$1\")" ]] ; then
    return
  fi
  local needed="$1"
  local build_ask="$2"
  # default is 'enabled' or 'disabled'
  local default="$3"

  if [[ "$4" ]] ; then
    local build_ans_yes="$4"
    local build_ans_no="$5"
  else
    local build_ans_yes="$build_ask support will be enabled for TensorFlow."
    local build_ans_no="No $build_ans_yes"
    local build_ask="Do you wish to build TensorFlow with $build_ask support?"
  fi

  if [[ "$default" == "enabled" ]] ; then
    local build_ask="$build_ask [Y/n] "
  else
    local build_ask="$build_ask [y/N] "
  fi

  while true; do
    read -p "$build_ask" user_input

    case "$user_input" in
      [Yy]* ) echo "$build_ans_yes"
        eval $needed=1
        break;;
      [Nn]* ) echo "$build_ans_no"
        eval $needed=0
        break;;
      "" ) if [[ "$default" == "enabled" ]] ; then
          echo "$build_ans_yes"
          eval $needed=1
        else
          echo "$build_ans_no"
          eval $needed=0
        fi
        break;;
      * ) echo "Invalid selection: $user_input";;
    esac
  done
}
```

```bash
function get_path {
  if [[ "$(eval echo \"\$$1\")" ]] ; then
    return
  fi
  local sys_path="$1"
  local path_for="$2"
  # looking for a path for a bin or lib
  local type_of_path="$3"
  # optional search for bin, array of paths for lib
  local generic_path="$4"
  local default_path=""

  if [[ "$type_of_path" == "bin" ]] ; then
    local default_path="$(which $path_for || true)"
    if [[ !"$default_path" ]] && [[ "$generic_path" ]] ; then
      local default_path="$(which $generic_path || true)"
    fi
    local ask_for_path="Please specify the location of $path_for. [Default is $default_path]:"
  else
    echo "Possible library path(s): "
    for x in "${generic_path[@]}" ; do
      if [[ "$x" ]] && [[ ! "$default_path" ]] ; then
        local default_path="$x"
      fi
      echo "    $x"
    done
    local ask_for_path="Please input the desired $path_for library path to use. [Default is $default_path]:"
  fi

  while true; do
    read -p "$ask_for_path " $sys_path

    if [[ ! "$(eval echo \$$sys_path)" ]] ; then
      if [[ -e "$default_path" ]] ; then
        eval $sys_path="$default_path"
      elif [[ -e "$generic_path" ]] && [[ "$type_of_path" == "bin" ]] ; then
        eval $sys_path="$default_path"
      else
        echo "ERROR! I cannot find a default path and one was not specified." 1>&2
      fi
    fi

    if [[ -e "$(eval echo \$$sys_path)" ]] ; then
      if [[ "$type_of_path" == "bin" ]] && [[ ! -x "$(eval echo \$$sys_path)" ]] ; then
        echo "ERROR! \$$sys_path is not executable." 1>&2
      else
        break
      fi
    else
      echo "ERROR! $(eval echo \$$sys_path) does not seem to be a valid path to $path_for." 1>&2
    fi
  done
}
```

Those functions alone kill ~150 or so lines of code. I was going to do more reducing MKL, but I believe I rebased those changes away due to the discussion in  #11212

If possible, I'd like to run tests on this to see if there's any issue with cross compatibility. (I'm not sure what permissions are, and if I can run the tests myself?) I killed another 50 or so from the CUDA area, but I want to try it on a machine with CUDA before running it.

The selection below is just to see what versions you're supporting. TensorFlow is pretty new, and you're already using some more recent options in the script. I just wanted to test it to be sure.
```bash
declare -A array_test=( [one]="position_one" [two]="position_two" [three]="position_three" )
array_ans=""
positional_test=( one two three )
positional_ans="position_oneposition_twoposition_three"

for x in "${positional_test[@]}" ; do
  array_ans+="$(eval echo \${array_test[$x]})"
done

if [[ ! "$array_ans" == "$positional_ans" ]] ; then
  echo "dec arrays not supported"
  exit 1
fi
```

If that is successful, I can remove another 100 or so lines. It'll (probably) be more readable too, for instance you can just add something like:
```bash
declare -A GCP=( [tf_needs]="TF_NEED_GCP" [name]="Google Cloud Platform" [default]="disabled" \
                                [write_opts]="write_gcp" [enabled]=0 )
```
And have it iterate over fields instead of having an entire section of the script that has the same install process as TF_NEED_HDFS.