### PR TITLE
install cub under external/cub_archive to fix windows gpu build

### DIFF
--- a/tensorflow/contrib/cmake/external/cub.cmake
+++ b/tensorflow/contrib/cmake/external/cub.cmake
@@ -18,6 +18,7 @@ set(cub_URL https://github.com/NVlabs/cub/archive/1.6.4.zip)
 set(cub_HASH SHA256=966d0c4f41e2bdc81aebf9ccfbf0baffaac5a74f00b826b06f4dee79b2bb8cee)
 set(cub_BUILD ${CMAKE_CURRENT_BINARY_DIR}/cub/src/cub)
 set(cub_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub/src/cub)
+set(cub_ARCHIVE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/cub_archive)
 
 ExternalProject_Add(cub
     PREFIX cub
@@ -26,4 +27,4 @@ ExternalProject_Add(cub
     DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
     BUILD_IN_SOURCE 1
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/patches/cub/CMakeLists.txt ${cub_BUILD}
-    INSTALL_COMMAND "")
+    INSTALL_COMMAND  ${CMAKE_COMMAND} -E copy_directory  ${cub_INCLUDE_DIR}/cub ${cub_ARCHIVE_DIR}/cub)


### PR DESCRIPTION
Fix cmake/windows gpu build. 
install cub under external/cub_archive so  where_op_gpu.cu.cc will find it for cmake and bazel in the same place.
https://github.com/tensorflow/tensorflow/commit/8280e0ae9083a65b23608b34723f07e028a56dc8
