### PR TITLE
Revert "Added assertion error in reset_default_graph() (#11158)"

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -3873,9 +3873,6 @@ class _DefaultStack(threading.local):
   def reset(self):
     self.stack = []
 
-  def is_cleared(self):
-    return self.stack == []
-
   @property
   def enforce_nesting(self):
     return self._enforce_nesting
@@ -4081,13 +4078,7 @@ def reset_default_graph():
   a `tf.Session` or `tf.InteractiveSession` is active will result in undefined
   behavior. Using any previously created `tf.Operation` or `tf.Tensor` objects
   after calling this function will result in undefined behavior.
-  Raises:
-    AssertionError: If this function is called within a nested graph.
   """
-  if not _default_graph_stack.is_cleared():
-    raise AssertionError("Do not use tf.reset_default_graph() to clear "
-                         "nested graphs. If you need a cleared graph, "
-                         "exit the nesting and create a new graph.")
   _default_graph_stack.reset()
 
 

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -1315,12 +1315,6 @@ class GraphTest(test_util.TensorFlowTestCase):
   def _AssertDefault(self, expected):
     self.assertIs(expected, ops.get_default_graph())
 
-  def testResetDefaultGraphNesting(self):
-    g0 = ops.Graph()
-    with self.assertRaises(AssertionError):
-      with g0.as_default():
-        ops.reset_default_graph()
-
   def testGraphContextManager(self):
     g0 = ops.Graph()
     with g0.as_default() as g1:


### PR DESCRIPTION
This reverts commit 3db38f15877457c8c2a5c92d66afc0df29fe1f66.

Appears to fail on Mac, see:
http://ci.tensorflow.org/view/Tensorflow%20Jenkins%20Monitored%20builds/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=NO_PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=mac-slave/537/consoleFull

See PR thread for more information.