### PR TITLE
[XLA] Add scaffolding to allow XLA unit tests to run for other devices

### DIFF
--- a/tensorflow/compiler/xla/tests/build_defs.bzl
+++ b/tensorflow/compiler/xla/tests/build_defs.bzl
@@ -1,8 +1,9 @@
 """Build rules for XLA testing."""
 
 load("@local_config_cuda//cuda:build_defs.bzl", "cuda_is_configured")
+load("//tensorflow/compiler/xla/tests:plugin.bzl", "plugins")
 
-all_backends = ["cpu", "cpu_parallel", "gpu"]
+all_backends = ["cpu", "cpu_parallel", "gpu"] + plugins.keys()
 
 def filter_backends(backends):
   """Removes "gpu" from a backend list if CUDA is not enabled.
@@ -121,6 +122,11 @@ def xla_test(name,
       backend_deps = ["//tensorflow/compiler/xla/service:gpu_plugin"]
       backend_deps += ["//tensorflow/compiler/xla/tests:test_macros_gpu"]
       this_backend_tags += ["requires-gpu-sm35"]
+    elif backend in plugins:
+      backend_deps = plugins[backend]["deps"]
+      this_backend_copts += plugins[backend]["copts"]
+      this_backend_tags += plugins[backend]["tags"]
+      this_backend_args += plugins[backend]["args"]
     else:
       fail("Unknown backend %s" % backend)
 

--- a/tensorflow/compiler/xla/tests/plugin.bzl
+++ b/tensorflow/compiler/xla/tests/plugin.bzl
@@ -1,0 +1,28 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Additional XLA devices to be included in the unit test suite."""
+
+plugins = {
+  "poplar": {
+    "deps": [
+      "//tensorflow/compiler/plugin/poplar:poplar_lib",
+      "//tensorflow/compiler/xla/tests:test_macros_cpu",
+    ],
+    "copts": [],
+    "tags": [],
+    "args": []
+  },
+}
+

--- a/tensorflow/compiler/xla/tests/plugin.bzl
+++ b/tensorflow/compiler/xla/tests/plugin.bzl
@@ -14,15 +14,19 @@
 # ==============================================================================
 """Additional XLA devices to be included in the unit test suite."""
 
-plugins = {
-  "poplar": {
-    "deps": [
-      "//tensorflow/compiler/plugin/poplar:poplar_lib",
-      "//tensorflow/compiler/xla/tests:test_macros_cpu",
-    ],
-    "copts": [],
-    "tags": [],
-    "args": []
-  },
-}
+# Example:
+#
+#plugins = {
+#  "poplar": {
+#    "deps": [
+#      "//tensorflow/compiler/plugin/poplar:poplar_lib",
+#      "//tensorflow/compiler/xla/tests:test_macros_cpu",
+#    ],
+#    "copts": [],
+#    "tags": [],
+#    "args": []
+#  },
+#}
+
+plugins = {}
 

--- a/tensorflow/compiler/xla/tests/plugin.bzl
+++ b/tensorflow/compiler/xla/tests/plugin.bzl
@@ -17,10 +17,10 @@
 # Example:
 #
 #plugins = {
-#  "poplar": {
+#  "foo": {
 #    "deps": [
-#      "//tensorflow/compiler/plugin/poplar:poplar_lib",
-#      "//tensorflow/compiler/xla/tests:test_macros_cpu",
+#      "//tensorflow/compiler/plugin/foo:foo_lib",
+#      "//tensorflow/compiler/plugin/foo:test_macros",
 #    ],
 #    "copts": [],
 #    "tags": [],

--- a/tensorflow/compiler/xla/tests/plugin.bzl
+++ b/tensorflow/compiler/xla/tests/plugin.bzl
@@ -16,17 +16,17 @@
 
 # Example:
 #
-#plugins = {
-#  "foo": {
-#    "deps": [
-#      "//tensorflow/compiler/plugin/foo:foo_lib",
-#      "//tensorflow/compiler/plugin/foo:test_macros",
-#    ],
-#    "copts": [],
-#    "tags": [],
-#    "args": []
-#  },
-#}
+# plugins = {
+#   "foo": {
+#     "deps": [
+#       "//tensorflow/compiler/plugin/foo:foo_lib",
+#       "//tensorflow/compiler/plugin/foo:test_macros",
+#     ],
+#     "copts": [],
+#     "tags": [],
+#     "args": []
+#   },
+# }
 
 plugins = {}
 


### PR DESCRIPTION
This is an indentical change to the one in the compiler/tests directory.  It allows devices other than the CPU and GPU to be available targets when running the tests in compiler/xla/tests.

