### PR TITLE
Updating DNNRegressor module directory

### DIFF
--- a/tensorflow/examples/learn/boston.py
+++ b/tensorflow/examples/learn/boston.py
@@ -42,7 +42,7 @@ def main(unused_argv):
   # Build 2 layer fully connected DNN with 10, 10 units respectively.
   feature_columns = [
       tf.feature_column.numeric_column('x', shape=np.array(x_train).shape[1:])]
-  regressor = tf.estimator.DNNRegressor(
+  regressor = tf.contrib.learn.DNNRegressor(
       feature_columns=feature_columns, hidden_units=[10, 10])
 
   # Train.


### PR DESCRIPTION
The model is now located at tf.contrib.learn.DNNRegressor and the code will not run without this change. 

Documentation of the module is available here: https://www.tensorflow.org/api_docs/python/tf/contrib/learn/DNNRegressor