### PR TITLE
Fix quantization tutorial

### DIFF
--- a/tensorflow/docs_src/performance/quantization.md
+++ b/tensorflow/docs_src/performance/quantization.md
@@ -108,12 +108,6 @@ versus 91MB). You can still run this model using exactly the same inputs and
 outputs though, and you should get equivalent results. Here's an example:
 
 ```sh
-# Note: You need to add the dependencies of the quantization operation to the
-#       cc_binary in the BUILD file of the label_image program:
-#
-#     //tensorflow/contrib/quantization:cc_ops
-#     //tensorflow/contrib/quantization/kernels:quantized_ops
-
 bazel build tensorflow/examples/label_image:label_image
 bazel-bin/tensorflow/examples/label_image/label_image \
 --image=<input-image> \

--- a/tensorflow/docs_src/performance/quantization.md
+++ b/tensorflow/docs_src/performance/quantization.md
@@ -93,7 +93,7 @@ curl http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.t
 tar xzf /tmp/inceptionv3.tgz -C /tmp/
 bazel build tensorflow/tools/graph_transforms:transform_graph
 bazel-bin/tensorflow/tools/graph_transforms/transform_graph \
-  --in_graph=/tmp/classify_image_graph_def.pb \
+  --inputs="Mul" --in_graph=/tmp/classify_image_graph_def.pb \
   --outputs="softmax" --out_graph=/tmp/quantized_graph.pb \
   --transforms='add_default_attributes strip_unused_nodes(type=float, shape="1,299,299,3")
     remove_nodes(op=Identity, op=CheckNumerics) fold_constants(ignore_errors=true)


### PR DESCRIPTION
Fix [this tutorial on quantization](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/performance/quantization.md).

1. Remove outdated dependencies, as pointed out in #10463.

1. The change made in #10592 was incomplete. The [example](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/performance/quantization.md#how-can-you-quantize-your-models) on how to run `transform_graph` to quantize a graph should follow [this tutorial](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/graph_transforms#eight-bit-calculations) about `graph_transforms`, but the argument `--inputs='Mul'` is missing.

@petewarden I'm also wondering when/how will [the tutorial on tensorflow.org](https://www.tensorflow.org/performance/quantization) get updated? I'm assuming it should be the same as `quantization.md` that I'm fixing?

Related to #11181.

Thanks!