### PR TITLE
Fix typos

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/shape_partition.h
+++ b/tensorflow/compiler/xla/service/cpu/shape_partition.h
@@ -38,7 +38,7 @@ namespace cpu {
 //
 //     [0, 1), [1, 2), [2, 3), [3, 4), [4, 5) [5, 8)
 //
-//   Note that the last parition has residule because the dimension size is
+//   Note that the last partition has residule because the dimension size is
 //   not a multiple of the partition count.
 //
 //

--- a/tensorflow/contrib/layers/python/layers/embedding_ops.py
+++ b/tensorflow/contrib/layers/python/layers/embedding_ops.py
@@ -871,7 +871,7 @@ def _embedding_lookup_with_distributed_aggregation(params,
           p_segment_ids = array_ops.gather(segment_ids, pindices[p])
           # Number the p_segment_ids to meet segment_sum's requirements. Note
           # that unique_p_segment_ids contains unique segment ids of this
-          # partiton and these ids' order is unchanged.
+          # partition and these ids' order is unchanged.
           unique_p_segment_ids, unique_p_segment_idx = array_ops.unique(
               p_segment_ids)
           partitioned_segment_ids.append(unique_p_segment_ids)

--- a/tensorflow/contrib/tensor_forest/client/random_forest.py
+++ b/tensorflow/contrib/tensor_forest/client/random_forest.py
@@ -315,7 +315,7 @@ class TensorForestEstimator(estimator.Estimator):
         though training might be distributed.
       version: String indicating TensorForest version to use, for backward
         compatibility. Either 'v2', 'v4', or None to let system pick.
-        Overrides grpah_builder_class.
+        Overrides graph_builder_class.
 
     Returns:
       A `TensorForestEstimator` instance.

--- a/tensorflow/contrib/tpu/python/tpu/tpu_estimator.py
+++ b/tensorflow/contrib/tpu/python/tpu/tpu_estimator.py
@@ -480,7 +480,7 @@ def _convert_model_fn_to_train_step(model_fn, dequeue_fn, mode, run_config,
 
     # TODO(xiejw): how to do we support hook and savers in the original
     # model_fn. Realistically, the original
-    # model_fn will be excuted on TPU chips in a replica way. The hooks
+    # model_fn will be executed on TPU chips in a replica way. The hooks
     # returned by the model_fn cannot be supported at all. If we have to,
     # the graph construction part in the model_fn should be separated from the
     # control part (such as hooks and savers). By that the graph construction

--- a/tensorflow/core/kernels/hexagon/hexagon_ops_definitions.h
+++ b/tensorflow/core/kernels/hexagon/hexagon_ops_definitions.h
@@ -24,7 +24,7 @@ limitations under the License.
 
 namespace tensorflow {
 
-// HexagonOpsDefinitions provides ops definitons supported in hexagon library
+// HexagonOpsDefinitions provides ops definitions supported in hexagon library
 // TODO(satok): add a functionality to call functions in hexagon library
 class HexagonOpsDefinitions final : public IGraphTransferOpsDefinitions {
  public:

--- a/tensorflow/python/estimator/canned/linear_testing_utils.py
+++ b/tensorflow/python/estimator/canned/linear_testing_utils.py
@@ -124,7 +124,7 @@ def sigmoid(x):
 
 
 class CheckPartitionerVarHook(session_run_hook.SessionRunHook):
-  """A `SessionRunHook` to check a paritioned variable."""
+  """A `SessionRunHook` to check a partitioned variable."""
 
   def __init__(self, test_case, var_name, var_dim, partitions):
     self._test_case = test_case

--- a/tensorflow/python/ops/sets_impl.py
+++ b/tensorflow/python/ops/sets_impl.py
@@ -99,7 +99,7 @@ def _set_operation(a, b, set_operation, validate_indices=True):
     b: `Tensor` or `SparseTensor` of the same type as `a`. Must be
         `SparseTensor` if `a` is `SparseTensor`. If sparse, indices must be
         sorted in row-major order.
-    set_operation: String indicating set operaiton. See
+    set_operation: String indicating set operation. See
         SetOperationOp::SetOperationFromContext for valid values.
     validate_indices: Whether to validate the order and range of sparse indices
        in `a` and `b`.


### PR DESCRIPTION
This PR fixes some typos: `parition`, `partiton`, `grpah`, `excuted`, `definitons`, and `operaiton`.