### PR TITLE
Return output_graph_def in tools/freeze_graph.py

### DIFF
--- a/tensorflow/python/tools/freeze_graph.py
+++ b/tensorflow/python/tools/freeze_graph.py
@@ -115,9 +115,14 @@ def freeze_graph_with_def_protos(
         output_node_names.split(","),
         variable_names_blacklist=variable_names_blacklist)
 
-  with gfile.GFile(output_graph, "wb") as f:
-    f.write(output_graph_def.SerializeToString())
+  # Write GraphDef to file if output path has been given.
+  if output_graph:
+    with gfile.GFile(output_graph, "wb") as f:
+      f.write(output_graph_def.SerializeToString())
+
   print("%d ops in the final graph." % len(output_graph_def.node))
+
+  return output_graph_def
 
 
 def _parse_input_graph_proto(input_graph, input_binary):


### PR DESCRIPTION
It makes sense that `def freeze_graph` works with files for both the input graph and frozen output graph.

It does not make sense that `def freeze_graph_with_def_protos` only uses a tf.GraphDef for the input, but doesn't actually return the frozen graph (and instead only writes it to a file).

This pull request changes `freeze_graph_with_def_protos` to optionally write the output to file (for backwards-compatibility) when `output_graph` is set as usual, but also returns the GraphDef protobuf to make the API more symmetric.

Otherwise you have to write and read from a tempfile just to use freeze_graph, which is a hassle.