### PR TITLE
Fixed 32-bit build error in tensor_forest.

### DIFF
--- a/tensorflow/contrib/tensor_forest/kernels/v4/input_target.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/input_target.h
@@ -21,7 +21,7 @@ namespace tensorflow {
 namespace tensorforest {
 
 typedef Eigen::TensorMap<
-    Eigen::Tensor<const float, 1, 1, long>, 0>  // NOLINT(runtime/int)
+    Eigen::Tensor<const float, 1, 1>, 0>  // NOLINT(runtime/int)
     SingleDimStorageType;
 
 // Base class for classes that hold labels and weights. Mostly for testing


### PR DESCRIPTION
This patch fixes the build error described in #11229.