### PR TITLE
c: fix a possible segmentfault

### DIFF
--- a/tensorflow/c/c_api_test.cc
+++ b/tensorflow/c/c_api_test.cc
@@ -912,11 +912,13 @@ class CSession {
     for (TF_Operation* o : outputs) {
       outputs_.emplace_back(TF_Output{o, 0});
     }
+    output_values_.resize(outputs_.size());
   }
 
   void SetOutputs(const std::vector<TF_Output>& outputs) {
     ResetOutputValues();
     outputs_ = outputs;
+    output_values_.resize(outputs_.size());
   }
 
   void SetTargets(std::initializer_list<TF_Operation*> targets) {


### PR DESCRIPTION
We also need allocation for `output_values_` when updating `output_`, or we will get a segment fault on:

```c++
static void TF_Run_Setup(int noutputs, TF_Tensor** c_outputs,
                         TF_Status* status) {
  status->status = Status::OK();
  for (int i = 0; i < noutputs; ++i) {
    c_outputs[i] = nullptr;
  }
}
```
