### PR TITLE
Adapt TensorFlowTestCase.setUp() to new reset_default_graph() semantics

### DIFF
--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -266,7 +266,12 @@ class TensorFlowTestCase(googletest.TestCase):
     self._ClearCachedSession()
     random.seed(random_seed.DEFAULT_GRAPH_SEED)
     np.random.seed(random_seed.DEFAULT_GRAPH_SEED)
-    ops.reset_default_graph()
+    # Note: we avoid calling ops.reset_default_graph() here due to the fact that
+    # under certain Python versions, test methods that error out from within
+    # nested graph contexts may leave ops._default_graph_stack non-empty,
+    # which would cause ops.reset_default_graph() to throw an exception if it
+    # were used in the following line.
+    ops._default_graph_stack.reset()  # pylint: disable=protected-access
     ops.get_default_graph().seed = random_seed.DEFAULT_GRAPH_SEED
 
   def tearDown(self):

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -266,12 +266,14 @@ class TensorFlowTestCase(googletest.TestCase):
     self._ClearCachedSession()
     random.seed(random_seed.DEFAULT_GRAPH_SEED)
     np.random.seed(random_seed.DEFAULT_GRAPH_SEED)
-    # Note: we avoid calling ops.reset_default_graph() here due to the fact that
-    # under certain Python versions, test methods that error out from within
-    # nested graph contexts may leave ops._default_graph_stack non-empty,
-    # which would cause ops.reset_default_graph() to throw an exception if it
-    # were used in the following line.
+    # Note: The following line is necessary because some test methods may error
+    # out from within nested graph contexts (e.g., via assertRaises and
+    # assertRaisesRegexp), which may leave ops._default_graph_stack non-empty
+    # under certain versions of Python. That would cause
+    # ops.reset_default_graph() to throw an exception if the stack were not
+    # cleared first.
     ops._default_graph_stack.reset()  # pylint: disable=protected-access
+    ops.reset_default_graph()
     ops.get_default_graph().seed = random_seed.DEFAULT_GRAPH_SEED
 
   def tearDown(self):


### PR DESCRIPTION
Avoid calling reset_default_graph() directly to prevent exceptions in
cases where test methods error out from within nested graph contexts,
which can leave _default_graph_stack non-empty in certain Python
versions.

This should address the test failures (tensorflow/python:session_test and tensorflow/contrib/session_bundle:exporter_test) introduced by #11158 in certain Python versions (e.g., Mac Python 3.5).
cc @Thenerdstation