### PR TITLE
Fix typos

### DIFF
--- a/tensorflow/contrib/factorization/kernels/wals_solver_ops.cc
+++ b/tensorflow/contrib/factorization/kernels/wals_solver_ops.cc
@@ -213,7 +213,7 @@ class WALSComputePartialLhsAndRhsOp : public OpKernel {
       CHECK_LE(shard.second, perm.size());
       CHECK_LE(shard.first, shard.second);
       const int64 input_index = get_input_index(perm[shard.first]);
-      // Acccumulate the rhs and lhs terms in the normal equations
+      // Accumulate the rhs and lhs terms in the normal equations
       // for the non-zero elements in the row or column of the sparse matrix
       // corresponding to input_index.
       int num_batched = 0;

--- a/tensorflow/contrib/framework/python/ops/ops.py
+++ b/tensorflow/contrib/framework/python/ops/ops.py
@@ -68,6 +68,6 @@ def get_name_scope():
     would print the string `scope1/scope2`.
 
   Returns:
-    A string represnting the current name scope.
+    A string representing the current name scope.
   """
   return ops.get_default_graph().get_name_scope()

--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -549,7 +549,7 @@ class SparseReduceTest(test_util.TensorFlowTestCase):
 
   # [[1, ?, 2]
   #  [?, 3, ?]]
-  # where ? is implictly-zero.
+  # where ? is implicitly-zero.
   ind = np.array([[0, 0], [0, 2], [1, 1]]).astype(np.int64)
   vals = np.array([1, 1, 1]).astype(np.int32)
   dense_shape = np.array([2, 3]).astype(np.int64)


### PR DESCRIPTION
This PR fixes some typos: `Acccumulate`, `represnting`, and `implictly`.