### PR TITLE
[XLA] Add filtering of tests for 3rd party devices on the python suite

### DIFF
--- a/tensorflow/compiler/tests/build_defs.bzl
+++ b/tensorflow/compiler/tests/build_defs.bzl
@@ -40,6 +40,10 @@ def tf_xla_py_test(name, srcs=[], deps=[], tags=[], data=[], main=None,
   if disabled_backends == None:
     disabled_backends = []
 
+  for p in plugins:
+    if name in plugins[p]["disabled"]:
+      disabled_backends += [p]
+
   enabled_backends = [b for b in all_backends() if b not in disabled_backends]
   test_names = []
   for backend in enabled_backends:

--- a/tensorflow/compiler/tests/plugin.bzl
+++ b/tensorflow/compiler/tests/plugin.bzl
@@ -18,6 +18,11 @@
 #   git update-index --assume-unchanged tensorflow/compiler/tests/plugin.bzl
 
 plugins = {
-  #"poplar": {"device":"XLA_IPU", "types":"DT_FLOAT,DT_INT32", "tags":[]},
+  #"example": {
+  #  "device":"XLA_EXAMPLE",
+  #  "types":"DT_FLOAT,DT_INT32,DT_INT64",
+  #  "tags":[],
+  #  "disabled": ["a_test","a_n_other_test"],
+  #},
 }
 


### PR DESCRIPTION
Currently the tests are marked with specific exclusions for devices.

For 3rd party devices where we don't want their names and configs in the public repo, this change allows the devices to specify which tests they want to exclude.

No change for the CPU/GPU builtin devices.

