### PR TITLE
WAV encoding/decoding fixes.

### DIFF
--- a/tensorflow/core/kernels/decode_wav_op_test.cc
+++ b/tensorflow/core/kernels/decode_wav_op_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/cc/ops/audio_ops.h"
 #include "tensorflow/cc/ops/const_op.h"
 #include "tensorflow/cc/ops/math_ops.h"
+#include "tensorflow/core/framework/shape_inference_testutil.h"
 #include "tensorflow/core/framework/tensor_testutil.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/framework/types.pb.h"
@@ -81,6 +82,45 @@ TEST(DecodeWavOpTest, DecodeWavTest) {
   EXPECT_NEAR(1.0f, audio.flat<float>()(2), 1e-4f);
   EXPECT_NEAR(-1.0f, audio.flat<float>()(3), 1e-4f);
   EXPECT_EQ(14099, sample_rate);
+}
+
+TEST(DecodeWavOpTest, DecodeWav_ShapeFn) {
+  const std::string op_name = "DecodeWav";
+  ShapeInferenceTestOp op(op_name);
+
+  INFER_ERROR("Shape must be rank 0 but is rank 1", op, "[1]");
+
+  // audio shape is unknown when desired_{samples,channels} are default.
+  TF_ASSERT_OK(NodeDefBuilder("test", op_name)
+                    .Input({"a", 0, DT_STRING})
+                    .Finalize(&op.node_def));
+  INFER_OK(op, "[]", "[?,?];[]");
+
+  TF_ASSERT_OK(NodeDefBuilder("test", op_name)
+                    .Input({"a", 0, DT_STRING})
+                    .Attr("desired_samples", 42)
+                    .Finalize(&op.node_def));
+  INFER_OK(op, "[]", "[42,?];[]");
+
+  // Negative sample value is rejected.
+  TF_ASSERT_OK(NodeDefBuilder("test", op_name)
+                    .Input({"a", 0, DT_STRING})
+                    .Attr("desired_samples", -2)
+                    .Finalize(&op.node_def));
+  INFER_ERROR("samples must be non-negative, got -2", op, "[]");
+
+  TF_ASSERT_OK(NodeDefBuilder("test", op_name)
+                    .Input({"a", 0, DT_STRING})
+                    .Attr("desired_channels", 2)
+                    .Finalize(&op.node_def));
+  INFER_OK(op, "[]", "[?,2];[]");
+
+  // Negative channel value is rejected.
+  TF_ASSERT_OK(NodeDefBuilder("test", op_name)
+                    .Input({"a", 0, DT_STRING})
+                    .Attr("desired_channels", -2)
+                    .Finalize(&op.node_def));
+  INFER_ERROR("channels must be non-negative, got -2", op, "[]");
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/lib/wav/wav_io.cc
+++ b/tensorflow/core/lib/wav/wav_io.cc
@@ -147,7 +147,8 @@ Status EncodeAudioAsS16LEWav(const float* audio, size_t sample_rate,
     return errors::InvalidArgument("num_frames must be positive.");
   }
 
-  const size_t bytes_per_second = sample_rate * kBytesPerSample;
+  const size_t bytes_per_second =
+    sample_rate * kBytesPerSample * num_channels;
   const size_t num_samples = num_frames * num_channels;
   const size_t data_size = num_samples * kBytesPerSample;
   const size_t file_size = kHeaderSize + num_samples * kBytesPerSample;
@@ -242,8 +243,7 @@ Status DecodeLin16WaveAsFloatVector(const string& wav_string,
         "Bad bytes per sample in WAV header: Expected ",
         expected_bytes_per_sample, " but got ", bytes_per_sample);
   }
-  const uint32 expected_bytes_per_second =
-      (bytes_per_sample * (*sample_rate)) / *channel_count;
+  const uint32 expected_bytes_per_second = bytes_per_sample * *sample_rate;
   if (bytes_per_second != expected_bytes_per_second) {
     return errors::InvalidArgument(
         "Bad bytes per second in WAV header: Expected ",

--- a/tensorflow/core/lib/wav/wav_io_test.cc
+++ b/tensorflow/core/lib/wav/wav_io_test.cc
@@ -97,5 +97,63 @@ TEST(WavIO, EncodeThenDecode) {
   }
 }
 
+TEST(WavIO, BasicMono) {
+  std::vector<uint8> wav_data = {
+      'R',  'I',  'F', 'F', // ChunkID
+      44, 0, 0, 0,          // ChunkSize: 36 + SubChunk2Size
+      'W', 'A', 'V', 'E',   // Format
+      'f', 'm', 't', ' ',   // Subchunk1ID
+      16, 0, 0, 0,          // Subchunk1Size
+      1, 0,                 // AudioFormat: 1=PCM
+      1, 0,                 // NumChannels
+      0x44, 0xac, 0, 0,     // SampleRate: 44100
+      0x88, 0x58, 0x1, 0,   // BytesPerSecond: SampleRate * NumChannels *
+                            //                 BitsPerSample/8
+      2, 0,                 // BytesPerSample: NumChannels * BitsPerSample/8
+      16, 0,                // BitsPerSample
+      'd', 'a', 't', 'a',   // Subchunk2ID
+      8, 0, 0, 0,           // Subchunk2Size: NumSamples * NumChannels *
+                            //                BitsPerSample/8
+      0, 0,                 // Sample 1: 0
+      0xff, 0x7f,           // Sample 2: 32767 (saturated)
+      0, 0,                 // Sample 3: 0
+      0x00, 0x80,           // Sample 4: -32768 (saturated)
+  };
+  string expected(wav_data.begin(), wav_data.end());
+  float audio[] = {0.0f, 1.0f, 0.0f, -1.0f};
+  string result;
+  TF_EXPECT_OK(EncodeAudioAsS16LEWav(audio, 44100, 1, 4, &result));
+  EXPECT_EQ(expected, result);
+}
+
+TEST(WavIO, BasicStereo) {
+  std::vector<uint8> wav_data = {
+      'R',  'I',  'F', 'F', // ChunkID
+      44, 0, 0, 0,          // ChunkSize: 36 + SubChunk2Size
+      'W', 'A', 'V', 'E',   // Format
+      'f', 'm', 't', ' ',   // Subchunk1ID
+      16, 0, 0, 0,          // Subchunk1Size
+      1, 0,                 // AudioFormat: 1=PCM
+      2, 0,                 // NumChannels
+      0x44, 0xac, 0, 0,     // SampleRate: 44100
+      0x10, 0xb1, 0x2, 0,   // BytesPerSecond: SampleRate * NumChannels *
+                            //                 BitsPerSample/8
+      4, 0,                 // BytesPerSample: NumChannels * BitsPerSample/8
+      16, 0,                // BitsPerSample
+      'd', 'a', 't', 'a',   // Subchunk2ID
+      8, 0, 0, 0,           // Subchunk2Size: NumSamples * NumChannels *
+                            //                BitsPerSample/8
+      0, 0,                 // Sample 1: 0
+      0xff, 0x7f,           // Sample 2: 32767 (saturated)
+      0, 0,                 // Sample 3: 0
+      0x00, 0x80,           // Sample 4: -32768 (saturated)
+  };
+  string expected(wav_data.begin(), wav_data.end());
+  float audio[] = {0.0f, 1.0f, 0.0f, -1.0f};
+  string result;
+  TF_EXPECT_OK(EncodeAudioAsS16LEWav(audio, 44100, 2, 2, &result));
+  EXPECT_EQ(expected, result);
+}
+
 }  // namespace wav
 }  // namespace tensorflow

--- a/tensorflow/core/ops/audio_ops.cc
+++ b/tensorflow/core/ops/audio_ops.cc
@@ -33,7 +33,7 @@ Status DecodeWavShapeFn(InferenceContext* c) {
   DimensionHandle channels_dim;
   int32 desired_channels;
   TF_RETURN_IF_ERROR(c->GetAttr("desired_channels", &desired_channels));
-  if (desired_channels == 0) {
+  if (desired_channels == -1) {
     channels_dim = c->UnknownDim();
   } else {
     if (desired_channels < 0) {
@@ -45,7 +45,7 @@ Status DecodeWavShapeFn(InferenceContext* c) {
   DimensionHandle samples_dim;
   int32 desired_samples;
   TF_RETURN_IF_ERROR(c->GetAttr("desired_samples", &desired_samples));
-  if (desired_samples == 0) {
+  if (desired_samples == -1) {
     samples_dim = c->UnknownDim();
   } else {
     if (desired_samples < 0) {


### PR DESCRIPTION
Hi,

This PR contains two WAV related fixes.

Fixes WAV encoding/decoding for multi-channel data:
* `DecodeLin16WaveAsFloatVector` was failing for multi-channel data with “Bad bytes per second” due to it expecting the byte rate to be that for a single channel, whereas the header specifies the byte rate for _all_ channels.
* `EncodeAudioAsS16LEWav` was incorrectly encoding the byte rate as that for a single channel instead of for _all_ channels.

Fixes shape function for the `DecodeWav` op:
* The function was returning a non-ok status when either `desired_{samples,channels}` attributes were default; now, we use the unknown-dim instead.

Cheers.