### PR TITLE
Imply default argument in docstring properly

### DIFF
--- a/tensorflow/python/framework/graph_io.py
+++ b/tensorflow/python/framework/graph_io.py
@@ -29,7 +29,7 @@ from tensorflow.python.lib.io import file_io
 def write_graph(graph_or_graph_def, logdir, name, as_text=True):
   """Writes a graph proto to a file.
 
-  The graph is written as a binary proto unless `as_text` is `True`.
+  The graph is written as a text proto unless `as_text` is `False`.
 
   ```python
   v = tf.Variable(0, name='my_variable')


### PR DESCRIPTION
Since the default is `as_text=True` the current docstring is a real gotcha IMO. Clearer to flip the explanation around.