### PR TITLE
modify SaverDef default version with v2

### DIFF
--- a/tensorflow/core/protobuf/saver.proto
+++ b/tensorflow/core/protobuf/saver.proto
@@ -37,9 +37,9 @@ message SaverDef {
   enum CheckpointFormatVersion {
     // Internal legacy format.
     LEGACY = 0;
-    // Current format: tf.Saver() which works with tensorflow::table::Table.
+    // Deprecated format: tf.Saver() which works with tensorflow::table::Table.
     V1 = 1;
-    // Experimental format under development.
+    // Current format: more efficient.
     V2 = 2;
   }
   CheckpointFormatVersion version = 7;


### PR DESCRIPTION
SaverDef V1 has been deprecated, so modify default version with V2.