### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@ tensorflow/java/* @asimshankar
 
 # contrib
 
-# NEED OWNER: tensorflow/contrib/avro	
+# NEED OWNER: tensorflow/contrib/avro/*
 tensorflow/contrib/batching/* @alextp @chrisolston
 tensorflow/contrib/bayesflow/* @ebrevdo @rsepassi @jvdillon
 tensorflow/contrib/cmake/* @mrry @benoitsteiner
@@ -16,9 +16,9 @@ tensorflow/contrib/data/* @mrry
 tensorflow/contrib/distributions/* @jvdillon @langmore @rsepassi
 tensorflow/contrib/factorization/* @agarwal-ashish @xavigonzalvo
 tensorflow/contrib/ffmpeg/* @fredbertsch
-tensorflow/contrib/framework/*	joel-shor
-tensorflow/contrib/graph_editor/*	@purpledog
-# NEED OWNER: tensorflow/contrib/grid_rnn
+# NEED OWNERT: tensorflow/contrib/framework/*
+tensorflow/contrib/graph_editor/* @purpledog
+# NEED OWNER: tensorflow/contrib/grid_rnn/*
 tensorflow/contrib/hvx/* @satok16
 tensorflow/contrib/imperative/* @keveman
 tensorflow/contrib/integrate/* @shoyer
@@ -29,7 +29,7 @@ tensorflow/contrib/layers/* @fchollet @martinwicke
 tensorflow/contrib/learn/* @martinwicke @ispirmustafa @alextp
 tensorflow/contrib/linalg/* @langmore
 tensorflow/contrib/linear_optimizer/* @petrosmol @andreasst @katsiapis
-tensorflow/contrib/lookup/*	@ysuematsu @andreasst
+tensorflow/contrib/lookup/* @ysuematsu @andreasst
 tensorflow/contrib/losses/* @alextp @ispirmustafa
 tensorflow/contrib/makefile/* @petewarden @satok16 @wolffg
 tensorflow/contrib/metrics/* @alextp @honkentuber @ispirmustafa

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,50 @@
+# Where component owners are known, add them here.
+
+tensorflow/tensorboard/* @jart @dandelionmane
+tensorflow/tools/docs/* @markdaoust
+tensorflow/java/* @asimshankar
+
+# contrib
+
+# NEED OWNER: tensorflow/contrib/avro	
+tensorflow/contrib/batching/* @alextp @chrisolston
+tensorflow/contrib/bayesflow/* @ebrevdo @rsepassi @jvdillon
+tensorflow/contrib/cmake/* @mrry @benoitsteiner
+tensorflow/contrib/copy_graph/* @tucker @poxvoculi
+tensorflow/contrib/crf/* @kentonl
+tensorflow/contrib/data/* @mrry
+tensorflow/contrib/distributions/* @jvdillon @langmore @rsepassi
+tensorflow/contrib/factorization/* @agarwal-ashish @xavigonzalvo
+tensorflow/contrib/ffmpeg/* @fredbertsch
+tensorflow/contrib/framework/*	joel-shor
+tensorflow/contrib/graph_editor/*	@purpledog
+# NEED OWNER: tensorflow/contrib/grid_rnn
+tensorflow/contrib/hvx/* @satok16
+tensorflow/contrib/imperative/* @keveman
+tensorflow/contrib/integrate/* @shoyer
+tensorflow/contrib/kernel_methods/* @petrosmol
+tensorflow/contrib/ios_examples/* @petewarden
+tensorflow/contrib/labeled_tensor/* @shoyer
+tensorflow/contrib/layers/* @fchollet @martinwicke
+tensorflow/contrib/learn/* @martinwicke @ispirmustafa @alextp
+tensorflow/contrib/linalg/* @langmore
+tensorflow/contrib/linear_optimizer/* @petrosmol @andreasst @katsiapis
+tensorflow/contrib/lookup/*	@ysuematsu @andreasst
+tensorflow/contrib/losses/* @alextp @ispirmustafa
+tensorflow/contrib/makefile/* @petewarden @satok16 @wolffg
+tensorflow/contrib/metrics/* @alextp @honkentuber @ispirmustafa
+tensorflow/contrib/nccl/* @cwhipkey @zheng-xq
+tensorflow/contrib/opt/* @strategist333
+tensorflow/contrib/pi_examples/* @maciekcc
+tensorflow/contrib/quantization/* @petewarden @cwhipkey @keveman
+tensorflow/contrib/rnn/* @ebrevdo
+tensorflow/contrib/saved_model/* @nfiedel @sukritiramesh
+tensorflow/contrib/seq2seq/* @lukaszkaiser
+tensorflow/contrib/session_bundle/* @nfiedel @sukritiramesh
+tensorflow/contrib/slim/* @sguada @thenbasilmanran
+tensorflow/contrib/stateless/* @girving
+tensorflow/contrib/tensor_forest/* @gilberthendry @thomascolthurst
+tensorflow/contrib/testing/* @dandelionmane
+tensorflow/contrib/timeseries/* @allenlavoie
+tensorflow/contrib/training/* @joel-shor @ebrevdo
+tensorflow/contrib/util/* @sherrym


### PR DESCRIPTION
Added what we know about contrib mainly, and some well-separated components.

The list of names behind each component is not perfect, I took this from a partially definitely outdated doc, but I suggest we maintain it here instead of in that doc.