### PR TITLE
Fix unpickling/copying tf.app.flags.FLAGS

### DIFF
--- a/tensorflow/python/platform/flags.py
+++ b/tensorflow/python/platform/flags.py
@@ -44,7 +44,12 @@ class _FlagValues(object):
 
   def __getattr__(self, name):
     """Retrieves the 'value' attribute of the flag --name."""
-    if not self.__dict__['__parsed']:
+    try:
+      parsed = self.__dict__['__parsed']
+    except KeyError:
+      # May happen during pickle.load or copy.copy
+      raise AttributeError(name)
+    if not parsed:
       self._parse_flags()
     if name not in self.__dict__['__flags']:
       raise AttributeError(name)

--- a/tensorflow/python/platform/flags_test.py
+++ b/tensorflow/python/platform/flags_test.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import copy
 import sys
 import unittest
 
@@ -78,6 +79,10 @@ class FlagsTest(unittest.TestCase):
     self.assertEquals(42.0, res)
     FLAGS.float_foo = -1.0
     self.assertEqual(-1.0, FLAGS.float_foo)
+
+  def test_copy(self):
+    copied = copy.copy(FLAGS)
+    self.assertEqual(copied.__dict__, FLAGS.__dict__)
 
 
 def main(_):


### PR DESCRIPTION
pickle.load() and copy.copy() check for the presence of  __setstate__().
The problem is that this check is made in the freshly allocated instance which
has not been __init__()-ed. Thus it's __dict__ is completely empty and
__getattr__() fail with KeyError.

The fix is to check if __parsed is in the __dict__ and raise
AttributeError if it isn't.