### PR TITLE
Fix typos

### DIFF
--- a/tensorflow/contrib/cudnn_rnn/python/ops/cudnn_rnn_ops.py
+++ b/tensorflow/contrib/cudnn_rnn/python/ops/cudnn_rnn_ops.py
@@ -197,7 +197,7 @@ class RNNParamsSaveable(saver.BaseSaverBuilder.SaveableObject):
       prefix = "multi_rnn_cell/cell_%d/cudnn_compatible_lstm_cell" % i
       w_names.append(prefix + "/kernel")
       # Three transformed bias tensors each layer:
-      # the 1st is for CudnnCompatbleLSTM(Block)Cell restore; the latter two
+      # the 1st is for CudnnCompatibleLSTM(Block)Cell restore; the latter two
       # sum up to the 1st, and are used for cuDNN restore.
       b_names.append(prefix + "/bias")
       b_names.extend([prefix + "/bias_cudnn_%d" % j for j in range(2)])

--- a/tensorflow/contrib/labeled_tensor/python/ops/core.py
+++ b/tensorflow/contrib/labeled_tensor/python/ops/core.py
@@ -199,7 +199,7 @@ class Axes(collections.Mapping):
   """Axis names and indices for a tensor.
 
   It is an ordered mapping, with keys given by axis name and values given
-  by Axis objets. Duplicate axis names are not allowed.
+  by Axis objects. Duplicate axis names are not allowed.
   """
 
   @tc.accepts(object, tc.List(AxisLike))

--- a/tensorflow/contrib/timeseries/python/timeseries/state_space_models/periodic.py
+++ b/tensorflow/contrib/timeseries/python/timeseries/state_space_models/periodic.py
@@ -50,7 +50,7 @@ class CycleStateSpaceModel(state_space_model.StateSpaceModel):
 
   def get_noise_transform(self):
     # transition_power_noise_accumulator makes assumptions about this
-    # transformation. If the noise transform is modified or overriden,
+    # transformation. If the noise transform is modified or overridden,
     # transition_power_noise_accumulator must be modified as well (or discarded,
     # as it is simply an optimization).
     return array_ops.pad(

--- a/tensorflow/core/lib/io/snappy/snappy_buffers_test.cc
+++ b/tensorflow/core/lib/io/snappy/snappy_buffers_test.cc
@@ -117,7 +117,7 @@ Status TestMultipleWrites(size_t compress_input_buf_size,
   io::SnappyInputBuffer in(file_reader.get(), uncompress_input_buf_size,
                            uncompress_output_buf_size);
 
-  // Run the test twice, reseting the stream after the first attempt.
+  // Run the test twice, resetting the stream after the first attempt.
   for (int attempt = 0; attempt < 2; ++attempt) {
     string actual_result;
     for (int i = 0; i < num_writes; i++) {

--- a/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
@@ -49,7 +49,7 @@ final class NativeLibrary {
       // Either:
       // (1) The native library has already been statically loaded, OR
       // (2) The required native code has been statically linked (through a custom launcher), OR
-      // (3) The native code is part of another library (such as an an application-level libraryh)
+      // (3) The native code is part of another library (such as an application-level library)
       // that has already been loaded. For example, tensorflow/examples/android and
       // tensorflow/contrib/android include the required native code in differently named libraries.
       //

--- a/tensorflow/python/lib/core/strings.i
+++ b/tensorflow/python/lib/core/strings.i
@@ -80,7 +80,7 @@ bool _BytesToStringPiece(PyObject* obj, tensorflow::StringPiece* result) {
   }
 }
 
-// Converts a C++ string vector to a a list of Python bytes objects.
+// Converts a C++ string vector to a list of Python bytes objects.
 %typemap(out) std::vector<string> {
   const int size = $1.size();
   auto temp_string_list = tensorflow::make_safe(PyList_New(size));


### PR DESCRIPTION
This PR fixes some typos: `Compatble`, `objets`, `overriden`, `reseting`, `an an`, `libraryh`, and `a a`.