### PR TITLE
Disable nn_test on Windows

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -2378,6 +2378,7 @@ cuda_py_test(
         ":variables",
         "//third_party/py/numpy",
     ],
+    tags = ["no_windows"],
 )
 
 cuda_py_test(


### PR DESCRIPTION
Disable `//tensorflow/python:nn_test` util it's fixed.
Related issue: https://github.com/tensorflow/tensorflow/issues/11345
@gunan 