### PR TITLE
Enable building label_image with jpeg/gif/png decoder for Android.

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1395,6 +1395,86 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "android_jpeg_internal",
+    srcs = [
+        "lib/jpeg/jpeg_handle.cc",
+        "lib/jpeg/jpeg_mem.cc",
+        "platform/jpeg.h",
+    ],
+    hdrs = [
+        "lib/jpeg/jpeg_handle.h",
+        "lib/jpeg/jpeg_mem.h",
+        "platform/default/integral_types.h",
+        "platform/logging.h",
+        "platform/default/logging.h",
+        "platform/macros.h",
+        "platform/platform.h",
+        "platform/types.h",
+        "lib/core/stringpiece.h",
+        "platform/dynamic_annotations.h",
+        "platform/default/dynamic_annotations.h",
+        "platform/mem.h",
+    ],  
+    copts = tf_copts(),
+    linkopts = ["-ldl"],
+    deps = [
+        "//tensorflow/core/platform/default/build_config:jpeg",
+    ],
+)
+
+cc_library(
+    name = "android_gif_internal",
+    srcs = [
+        "lib/gif/gif_io.cc",
+        "platform/gif.h",
+    ],
+    hdrs = [
+         "lib/gif/gif_io.h",
+         "lib/core/stringpiece.h",
+         "platform/types.h",
+         "platform/platform.h",
+         "platform/default/integral_types.h",
+         "lib/gtl/cleanup.h",
+         "platform/macros.h",
+         "platform/logging.h",
+         "platform/default/logging.h",
+         "platform/mem.h",
+         "platform/dynamic_annotations.h",
+         "platform/default/dynamic_annotations.h",
+    ],
+    copts = tf_copts(),
+    linkopts = ["-ldl"],
+    deps = [
+        "//tensorflow/core/platform/default/build_config:gif",
+    ],
+)
+
+cc_library(
+    name = "android_png_internal",
+    srcs = [
+        "lib/png/png_io.cc",
+        "platform/png.h",
+    ],
+    hdrs = [
+        "lib/png/png_io.h",
+        "lib/core/casts.h",
+        "lib/core/stringpiece.h",
+        "platform/types.h",
+        "platform/platform.h",
+        "platform/default/integral_types.h",
+        "platform/cpu_info.h",
+        "platform/logging.h",
+        "platform/default/logging.h",
+        "platform/macros.h",
+     ],
+    copts = tf_copts(),
+    linkopts = ["-ldl"],
+    deps = [
+	"@png_archive//:png",
+    ],
+)
+
 proto_text_hdrs_and_srcs = tf_generate_proto_text_sources(
     name = "proto_text_srcs_all",
     srcs = CORE_PROTO_SRCS,

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4264,6 +4264,7 @@ filegroup(
         "batchtospace_op.cc",
         "ctc_decoder_ops.cc",
         "decode_bmp_op.cc",
+        "decode_image_op.cc",
         "depthtospace_op.cc",
         "dynamic_stitch_op.cc",
         "in_topk_op.cc",
@@ -4442,6 +4443,9 @@ cc_library(
         "//tensorflow/core:protos_cc",
         "//third_party/eigen3",
         "@gemmlowp//:gemmlowp",
+        "//tensorflow/core:android_jpeg_internal",
+        "//tensorflow/core:android_gif_internal",
+        "//tensorflow/core:android_png_internal",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/core/platform/gif.h
+++ b/tensorflow/core/platform/gif.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 #if defined(PLATFORM_GOOGLE)
 #include "tensorflow/core/platform/google/build_config/gif.h"
-#elif (defined(PLATFORM_POSIX) && !defined(IS_MOBILE_PLATFORM)) || defined(PLATFORM_WINDOWS)
+#elif defined(PLATFORM_POSIX)|| defined(PLATFORM_WINDOWS) ||defined(PLATFORM_POSIX_ANDROID)
 #include <gif_lib.h>
 #else
 #error Define the appropriate PLATFORM_<foo> macro for this platform

--- a/tensorflow/core/platform/jpeg.h
+++ b/tensorflow/core/platform/jpeg.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 #if defined(PLATFORM_GOOGLE)
 #include "tensorflow/core/platform/google/build_config/jpeg.h"
-#elif (defined(PLATFORM_POSIX) && !defined(IS_MOBILE_PLATFORM)) || defined(PLATFORM_WINDOWS)
+#elif defined(PLATFORM_POSIX)|| defined(PLATFORM_WINDOWS) ||defined(PLATFORM_POSIX_ANDROID)
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tensorflow/core/platform/png.h
+++ b/tensorflow/core/platform/png.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 #if defined(PLATFORM_GOOGLE)
 #include "tensorflow/core/platform/google/build_config/png.h"
-#elif (defined(PLATFORM_POSIX) && !defined(IS_MOBILE_PLATFORM)) || defined(PLATFORM_WINDOWS)
+#elif defined(PLATFORM_POSIX)|| defined(PLATFORM_WINDOWS) ||defined(PLATFORM_POSIX_ANDROID)
 #include <png.h>
 #else
 #error Define the appropriate PLATFORM_<foo> macro for this platform

--- a/third_party/gif.BUILD
+++ b/third_party/gif.BUILD
@@ -20,6 +20,15 @@ cc_library(
         "lib/quantize.c",
     ],
     hdrs = ["lib/gif_lib.h"],
+    defines = select({
+        #"@%ws%//tensorflow:android": [
+        ":android": [
+            "S_IREAD=S_IRUSR",
+            "S_IWRITE=S_IWUSR",
+            "S_IEXEC=S_IXUSR",
+        ],
+        "//conditions:default": [],
+    }),  
     includes = ["lib/."],
     visibility = ["//visibility:public"],
     deps = select({
@@ -54,3 +63,10 @@ config_setting(
         "cpu": "x64_windows",
     },
 )
+
+config_setting(
+    name = "android",
+    values = {"crosstool_top": "//external:android/crosstool"},
+)
+
+


### PR DESCRIPTION
This PR adds the Android platform building of the  jpeg, gif and png decoder to the C++ image classification demo "label_image". 
It enables the evaluation of practical dataset such as ImageNet on Android platform devices, for both model precision, and hardware performance. 