### PR TITLE
Fix TSNE invocation in Udacity word2vec assignment

### DIFF
--- a/tensorflow/examples/udacity/5_word2vec.ipynb
+++ b/tensorflow/examples/udacity/5_word2vec.ipynb
@@ -806,7 +806,7 @@
       "source": [
         "num_points = 400\n",
         "\n",
-        "tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=5000)\n",
+        "tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=5000, method='exact')\n",
         "two_d_embeddings = tsne.fit_transform(final_embeddings[1:num_points+1, :])"
       ],
       "outputs": [],


### PR DESCRIPTION
Default TSNE method recently changed to the approximate `method='barnes_hut'` which fails to converge per https://github.com/tensorflow/tensorflow/pull/11455