### PR TITLE
The previous commit attempted to fix a problem for PowerPC

### DIFF
--- a/configure
+++ b/configure
@@ -26,7 +26,7 @@ function is_windows() {
 }
 
 function is_ppc64le() {
-  [[ "${uname -m}" == "ppc64le" ]]
+  [[ "$(uname -m)" == "ppc64le" ]]
 }
 
 function sed_in_place() {
@@ -298,15 +298,15 @@ fi # TF_NEED_MKL
 
 ## Set up architecture-dependent optimization flags.
 if [ -z "$CC_OPT_FLAGS" ]; then
-  if [ is_ppc64le ]; then
-    # gcc on ppc64le does not support -march, use mcpu instead
+  default_cc_opt_flags="-march=native"
+  if is_ppc64le; then
+    # gcc on ppc64le does not support -march, use -mcpu instead
     default_cc_opt_flags="-mcpu=native"
-  else
-    default_cc_opt_flags="-march=native"
   fi
   read -p "Please specify optimization flags to use during compilation when bazel option "\
 "\"--config=opt\" is specified [Default is $default_cc_opt_flags]: " CC_OPT_FLAGS
   if [ -z "$CC_OPT_FLAGS" ]; then
+    # override default with user flags
     CC_OPT_FLAGS=$default_cc_opt_flags
   fi
 fi


### PR DESCRIPTION
architectures, which require a different gcc optimization argument.
However, this addition had two implementation errors, which caused all
architectures to receive this deprecated compiler flag and therefore
produce a non-optimized tensorflow compilation.

Specifically, the introduced 'is_ppc()' used a syntactically incorrect variable
identification '${}' in the statement where command substitution '$()' should
have been used. This caused the command to always silently fail, and the
function to always return true regardless of architecture.

Additionally, where the function was called, the return value should be
controlling the if statement, but by encapsulating the call with '[..]', the
resulting expression evaluation was also always true.