### PR TITLE
Fix syntax error in sample code

### DIFF
--- a/tensorflow/contrib/slim/python/slim/evaluation.py
+++ b/tensorflow/contrib/slim/python/slim/evaluation.py
@@ -81,7 +81,7 @@ more summaries and call the evaluation_loop method:
 
   # Evaluate every 10 minutes:
   slim.evaluation_loop(
-      master='',
+      '',
       checkpoint_dir,
       logdir,
       num_evals=num_evals,


### PR DESCRIPTION
This would have otherwise caused a non-keyword arg after keyword arg