### PR TITLE
Show usage when no arguments passed to import_pb_to_tensorboard.py

### DIFF
--- a/tensorflow/python/tools/import_pb_to_tensorboard.py
+++ b/tensorflow/python/tools/import_pb_to_tensorboard.py
@@ -64,11 +64,13 @@ if __name__ == "__main__":
       "--model_dir",
       type=str,
       default="",
+      required=True,
       help="The location of the protobuf (\'pb\') model to visualize.")
   parser.add_argument(
       "--log_dir",
       type=str,
       default="",
+      required=True,
       help="The location for the Tensorboard log to begin visualization from.")
   FLAGS, unparsed = parser.parse_known_args()
   app.run(main=main, argv=[sys.argv[0]] + unparsed)


### PR DESCRIPTION
It seems like `--model_dir` and `--log_dir` should be required arguments.  After adding at least one required argument, then `parseargs` handles no arguments cleanly.

TESTING

Running it before the fix:
```
$ python import_pb_to_tensorboard.py 
Traceback (most recent call last):
  File "import_pb_to_tensorboard.py", line 74, in <module>
    app.run(main=main, argv=[sys.argv[0]] + unparsed)
TypeError: run() got an unexpected keyword argument 'argv'
```

Running it after the fix:
```
$ python import_pb_to_tensorboard.py 
usage: import_pb_to_tensorboard.py [-h] --model_dir MODEL_DIR --log_dir
                                   LOG_DIR
import_pb_to_tensorboard.py: error: argument --model_dir is required
```

I was unable to test the success path due to this issue: https://github.com/tensorflow/tensorflow/issues/11519

Testing done on Mac OSX Sierra 10.12.5 using Python 2.7.6.

ALTERNATIVE SUGGESTION

Let me know if you prefer that no arguments are required.  If that is the case, I was considering this solution (from [this Stackoverflow answer](https://stackoverflow.com/a/29293080/112705)):
```
  try:
    app.run(main=main, argv=[sys.argv[0]] + unparsed)
  except:
    # Print the usage if the user provides no arguments
    parser.print_help()
    sys.exit(0)
```

OTHER THOUGHTS

It seems like `model_dir` should maybe be renamed to `model_path` (assuming that it should link the file, not the directory which it is in)?