### PR TITLE
Fixes 'batch_size' may be used uninitialized

### DIFF
--- a/tensorflow/core/kernels/batch_dataset_op.cc
+++ b/tensorflow/core/kernels/batch_dataset_op.cc
@@ -31,7 +31,7 @@ class BatchDatasetOp : public UnaryDatasetOpKernel {
 
   void MakeDataset(OpKernelContext* ctx, DatasetBase* input,
                    DatasetBase** output) override {
-    int64 batch_size;
+    int64 batch_size = 0;
     OP_REQUIRES_OK(ctx,
                    ParseScalarArgument<int64>(ctx, "batch_size", &batch_size));
     OP_REQUIRES(


### PR DESCRIPTION
 clang++-3.6: warning: 'batch_size' may be used uninitialized in this function