### PR TITLE
add recovery_wait_secs option for MonitoredTrainingSession

### DIFF
--- a/tensorflow/python/training/monitored_session.py
+++ b/tensorflow/python/training/monitored_session.py
@@ -317,7 +317,8 @@ def MonitoredTrainingSession(master='',  # pylint: disable=invalid-name
       `close()` has been called.
     log_step_count_steps: The frequency, in number of global steps, that the
       global step/sec is logged.
-    recovery_wait_secs: Number of seconds between checks that the model is ready.
+    recovery_wait_secs: Number of seconds that this is used by worker jobs to 
+      check whether chief initialized/restored session or not.
 
   Returns:
     A `MonitoredSession` object.

--- a/tensorflow/python/training/monitored_session.py
+++ b/tensorflow/python/training/monitored_session.py
@@ -277,7 +277,8 @@ def MonitoredTrainingSession(master='',  # pylint: disable=invalid-name
                              save_summaries_secs=USE_DEFAULT,
                              config=None,
                              stop_grace_period_secs=120,
-                             log_step_count_steps=100):
+                             log_step_count_steps=100,
+                             recovery_wait_secs=30):
   """Creates a `MonitoredSession` for training.
 
   For a chief, this utility sets proper session initializer/restorer. It also
@@ -316,6 +317,7 @@ def MonitoredTrainingSession(master='',  # pylint: disable=invalid-name
       `close()` has been called.
     log_step_count_steps: The frequency, in number of global steps, that the
       global step/sec is logged.
+    recovery_wait_secs: Number of seconds between checks that the model is ready.
 
   Returns:
     A `MonitoredSession` object.
@@ -331,7 +333,8 @@ def MonitoredTrainingSession(master='',  # pylint: disable=invalid-name
   scaffold = scaffold or Scaffold()
   if not is_chief:
     session_creator = WorkerSessionCreator(
-        scaffold=scaffold, master=master, config=config)
+        scaffold=scaffold, master=master, config=config,
+        recovery_wait_secs=recovery_wait_secs)
     return MonitoredSession(session_creator=session_creator, hooks=hooks or [],
                             stop_grace_period_secs=stop_grace_period_secs)
 
@@ -428,7 +431,8 @@ class ChiefSessionCreator(SessionCreator):
 class WorkerSessionCreator(SessionCreator):
   """Creates a tf.Session for a worker."""
 
-  def __init__(self, scaffold=None, master='', config=None):
+  def __init__(self, scaffold=None, master='', config=None,
+               recovery_wait_secs=30):
     """Initializes a worker session creator.
 
     Args:
@@ -436,11 +440,13 @@ class WorkerSessionCreator(SessionCreator):
         not specified a default one is created. It's used to finalize the graph.
       master: `String` representation of the TensorFlow master to use.
       config: `ConfigProto` proto used to configure the session.
+      recovery_wait_secs: Number of seconds between checks that the model is ready.
     """
     self._scaffold = scaffold or Scaffold()
     self._session_manager = None
     self._master = master
     self._config = config
+    self._recovery_wait_secs = recovery_wait_secs
 
   def _get_session_manager(self):
     if self._session_manager:
@@ -450,7 +456,8 @@ class WorkerSessionCreator(SessionCreator):
         local_init_op=self._scaffold.local_init_op,
         ready_op=self._scaffold.ready_op,
         ready_for_local_init_op=self._scaffold.ready_for_local_init_op,
-        graph=ops.get_default_graph())
+        graph=ops.get_default_graph(),
+        recovery_wait_secs=self._recovery_wait_secs)
     return self._session_manager
 
   def create_session(self):

--- a/tensorflow/python/training/monitored_session.py
+++ b/tensorflow/python/training/monitored_session.py
@@ -317,7 +317,7 @@ def MonitoredTrainingSession(master='',  # pylint: disable=invalid-name
       `close()` has been called.
     log_step_count_steps: The frequency, in number of global steps, that the
       global step/sec is logged.
-    recovery_wait_secs: Number of seconds that this is used by worker jobs to 
+    recovery_wait_secs: Number of seconds that is used by worker jobs to 
       check whether chief initialized/restored session or not.
 
   Returns:


### PR DESCRIPTION
In order to reduce the sleep time by worker to wait for a model to be initialized or restored , 
，we add  recovery_wait_secs option for MonitoredTrainingSession，and we are able to start distributed training faster.