### PR TITLE
https://github.com/tensorflow/tensorflow/issues/9481

### DIFF
--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -32,6 +32,7 @@ limitations under the License.
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/protobuf.h"
+#include "tensorflow/core/platform/windows/windows_file_system.h"
 
 namespace tensorflow {
 
@@ -262,8 +263,11 @@ string Env::GetExecutablePath() {
   _NSGetExecutablePath(unresolved_path, &buffer_size);
   CHECK(realpath(unresolved_path, exe_path));
 #elif defined(PLATFORM_WINDOWS)
-  HMODULE hModule = GetModuleHandle(NULL);
-  GetModuleFileName(hModule, exe_path, MAX_PATH);
+  HMODULE hModule = GetModuleHandleW(NULL);
+  WCHAR wc_file_path[MAX_PATH] = {0};
+  GetModuleFileNameW(hModule, wc_file_path, MAX_PATH);
+  string file_path = WindowsFileSystem::WideCharToUtf8(wc_file_path);
+  std::copy(file_path.begin(), file_path.end(), exe_path);
 #else
   CHECK_NE(-1, readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1));
 #endif

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #endif
 #if defined(PLATFORM_WINDOWS)
 #include <windows.h>
+#include "tensorflow/core/platform/windows/windows_file_system.h"
 #define PATH_MAX MAX_PATH
 #else
 #include <unistd.h>
@@ -32,7 +33,6 @@ limitations under the License.
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/protobuf.h"
-#include "tensorflow/core/platform/windows/windows_file_system.h"
 
 namespace tensorflow {
 

--- a/tensorflow/core/platform/windows/env.cc
+++ b/tensorflow/core/platform/windows/env.cc
@@ -124,7 +124,10 @@ class WindowsEnv : public Env {
     std::string file_name = library_filename;
     std::replace(file_name.begin(), file_name.end(), '/', '\\');
 
-    HMODULE hModule = LoadLibraryEx(file_name.c_str(), NULL,
+    WindowsFileSystem win_file_system;
+    std::wstring ws_file_name(win_file_system.Utf8ToWideChar(file_name));
+
+    HMODULE hModule = LoadLibraryExW(ws_file_name.c_str(), NULL,
       LOAD_WITH_ALTERED_SEARCH_PATH);
     if (!hModule) {
       return errors::NotFound(file_name + " not found");

--- a/tensorflow/core/platform/windows/env.cc
+++ b/tensorflow/core/platform/windows/env.cc
@@ -59,7 +59,7 @@ class WindowsEnv : public Env {
     // versions of Windows. For that reason, we try to look it up in
     // kernel32.dll at runtime and use an alternative option if the function
     // is not available.
-    HMODULE module = GetModuleHandle("kernel32.dll");
+    HMODULE module = GetModuleHandleW(L"kernel32.dll");
     if (module != NULL) {
       auto func = (FnGetSystemTimePreciseAsFileTime)GetProcAddress(
           module, "GetSystemTimePreciseAsFileTime");
@@ -72,7 +72,9 @@ class WindowsEnv : public Env {
   }
 
   bool MatchPath(const string& path, const string& pattern) override {
-    return PathMatchSpec(path.c_str(), pattern.c_str()) == TRUE;
+      std::wstring ws_path(WindowsFileSystem::Utf8ToWideChar(path));
+      std::wstring ws_pattern(WindowsFileSystem::Utf8ToWideChar(pattern));
+    return PathMatchSpecW(ws_path.c_str(), ws_pattern.c_str()) == TRUE;
   }
 
   void SleepForMicroseconds(int64 micros) override { Sleep(micros / 1000); }

--- a/tensorflow/core/platform/windows/env.cc
+++ b/tensorflow/core/platform/windows/env.cc
@@ -124,8 +124,7 @@ class WindowsEnv : public Env {
     std::string file_name = library_filename;
     std::replace(file_name.begin(), file_name.end(), '/', '\\');
 
-    WindowsFileSystem win_file_system;
-    std::wstring ws_file_name(win_file_system.Utf8ToWideChar(file_name));
+    std::wstring ws_file_name(WindowsFileSystem::Utf8ToWideChar(file_name));
 
     HMODULE hModule = LoadLibraryExW(ws_file_name.c_str(), NULL,
       LOAD_WITH_ALTERED_SEARCH_PATH);

--- a/tensorflow/core/platform/windows/env_time.cc
+++ b/tensorflow/core/platform/windows/env_time.cc
@@ -30,7 +30,7 @@ class WindowsEnvTime : public EnvTime {
     // versions of Windows. For that reason, we try to look it up in
     // kernel32.dll at runtime and use an alternative option if the function
     // is not available.
-    HMODULE module = GetModuleHandle("kernel32.dll");
+    HMODULE module = GetModuleHandleW(L"kernel32.dll");
     if (module != NULL) {
       auto func = (FnGetSystemTimePreciseAsFileTime)GetProcAddress(
           module, "GetSystemTimePreciseAsFileTime");

--- a/tensorflow/core/platform/windows/windows_file_system.cc
+++ b/tensorflow/core/platform/windows/windows_file_system.cc
@@ -404,10 +404,10 @@ Status WindowsFileSystem::GetChildren(const string& dir,
   }
 
   do {
-
-    const StringPiece basename = WideCharToUtf8(find_data.cFileName);
+	string file_name = WideCharToUtf8(find_data.cFileName);
+	const StringPiece basename = file_name;
     if (basename != "." && basename != "..") {
-      result->push_back(WideCharToUtf8(find_data.cFileName));
+      result->push_back(file_name);
     }
   } while (::FindNextFileW(find_handle, &find_data));
 
@@ -421,7 +421,8 @@ Status WindowsFileSystem::GetChildren(const string& dir,
 
 Status WindowsFileSystem::DeleteFile(const string& fname) {
   Status result;
-  if (unlink(TranslateName(fname).c_str()) != 0) {
+  std::wstring file_name = Utf8ToWideChar(fname);
+  if (_wunlink(file_name.c_str()) != 0) {
     result = IOError("Failed to delete a file: " + fname, errno);
   }
   return result;
@@ -429,7 +430,8 @@ Status WindowsFileSystem::DeleteFile(const string& fname) {
 
 Status WindowsFileSystem::CreateDir(const string& name) {
   Status result;
-  if (_mkdir(TranslateName(name).c_str()) != 0) {
+  std::wstring ws_name = Utf8ToWideChar(name);
+  if (_wmkdir(ws_name.c_str()) != 0) {
     result = IOError("Failed to create a directory: " + name, errno);
   }
   return result;
@@ -437,7 +439,8 @@ Status WindowsFileSystem::CreateDir(const string& name) {
 
 Status WindowsFileSystem::DeleteDir(const string& name) {
   Status result;
-  if (_rmdir(TranslateName(name).c_str()) != 0) {
+  std::wstring ws_name = Utf8ToWideChar(name);
+  if (_wrmdir(ws_name.c_str()) != 0) {
     result = IOError("Failed to remove a directory: " + name, errno);
   }
   return result;
@@ -497,7 +500,7 @@ Status WindowsFileSystem::Stat(const string& fname, FileStatistics* stat) {
   Status result;
   struct _stat sbuf;
   std::wstring ws_translated_fname = Utf8ToWideChar(TranslateName(fname));
-  if (_stat(TranslateName(fname).c_str(), &sbuf) != 0) {
+  if (_wstat(ws_translated_fname.c_str(), &sbuf) != 0) {
     result = IOError(fname, errno);
   } else {
     stat->mtime_nsec = sbuf.st_mtime * 1e9;

--- a/tensorflow/core/platform/windows/windows_file_system.cc
+++ b/tensorflow/core/platform/windows/windows_file_system.cc
@@ -227,6 +227,7 @@ class WinReadOnlyMemoryRegion : public ReadOnlyMemoryRegion {
 Status WindowsFileSystem::NewRandomAccessFile(
     const string& fname, std::unique_ptr<RandomAccessFile>* result) {
   string translated_fname = TranslateName(fname);
+  std::wstring ws_translated_fname = Utf8ToWideChar(translated_fname);
   result->reset();
 
   // Open the file for read-only random access
@@ -237,7 +238,7 @@ Status WindowsFileSystem::NewRandomAccessFile(
   // almost all tests would work with a possible exception of fault_injection.
   DWORD share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
 
-  HANDLE hfile = ::CreateFileA(translated_fname.c_str(), GENERIC_READ,
+  HANDLE hfile = ::CreateFileW(ws_translated_fname.c_str(), GENERIC_READ,
                                share_mode, NULL, OPEN_EXISTING, file_flags,
                                NULL);
 
@@ -253,10 +254,11 @@ Status WindowsFileSystem::NewRandomAccessFile(
 Status WindowsFileSystem::NewWritableFile(
     const string& fname, std::unique_ptr<WritableFile>* result) {
   string translated_fname = TranslateName(fname);
+  std::wstring ws_translated_fname = Utf8ToWideChar(translated_fname);
   result->reset();
 
   DWORD share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
-  HANDLE hfile = ::CreateFileA(translated_fname.c_str(), GENERIC_WRITE,
+  HANDLE hfile = ::CreateFileW(ws_translated_fname.c_str(), GENERIC_WRITE,
                                share_mode, NULL, CREATE_ALWAYS,
                                FILE_ATTRIBUTE_NORMAL, NULL);
 
@@ -272,10 +274,11 @@ Status WindowsFileSystem::NewWritableFile(
 Status WindowsFileSystem::NewAppendableFile(
     const string& fname, std::unique_ptr<WritableFile>* result) {
   string translated_fname = TranslateName(fname);
+  std::wstring ws_translated_fname = Utf8ToWideChar(translated_fname);
   result->reset();
 
   DWORD share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
-  HANDLE hfile = ::CreateFileA(translated_fname.c_str(), GENERIC_WRITE,
+  HANDLE hfile = ::CreateFileW(ws_translated_fname.c_str(), GENERIC_WRITE,
                                share_mode, NULL, OPEN_ALWAYS,
                                FILE_ATTRIBUTE_NORMAL, NULL);
 
@@ -301,6 +304,7 @@ Status WindowsFileSystem::NewAppendableFile(
 Status WindowsFileSystem::NewReadOnlyMemoryRegionFromFile(
     const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result) {
   string translated_fname = TranslateName(fname);
+  std::wstring ws_translated_fname = Utf8ToWideChar(translated_fname);
   result->reset();
   Status s = Status::OK();
 
@@ -312,7 +316,7 @@ Status WindowsFileSystem::NewReadOnlyMemoryRegionFromFile(
   file_flags |= FILE_FLAG_OVERLAPPED;
 
   DWORD share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
-  HANDLE hfile = ::CreateFileA(translated_fname.c_str(), GENERIC_READ,
+  HANDLE hfile = ::CreateFileW(ws_translated_fname.c_str(), GENERIC_READ,
                                share_mode, NULL, OPEN_EXISTING, file_flags,
                                NULL);
 
@@ -382,28 +386,30 @@ Status WindowsFileSystem::FileExists(const string& fname) {
 Status WindowsFileSystem::GetChildren(const string& dir,
                                       std::vector<string>* result) {
   string translated_dir = TranslateName(dir);
+  std::wstring ws_translated_dir = Utf8ToWideChar(translated_dir);
   result->clear();
 
-  string pattern = translated_dir;
+  std::wstring pattern = ws_translated_dir;
   if (!pattern.empty() && pattern.back() != '\\' && pattern.back() != '/') {
-    pattern += "\\*";
+    pattern += L"\\*";
   } else {
-    pattern += '*';
+    pattern += L'*';
   }
 
-  WIN32_FIND_DATA find_data;
-  HANDLE find_handle = ::FindFirstFileA(pattern.c_str(), &find_data);
+  WIN32_FIND_DATAW find_data;
+  HANDLE find_handle = ::FindFirstFileW(pattern.c_str(), &find_data);
   if (find_handle == INVALID_HANDLE_VALUE) {
     string context = "FindFirstFile failed for: " + translated_dir;
     return IOErrorFromWindowsError(context, ::GetLastError());
   }
 
   do {
-    const StringPiece basename = find_data.cFileName;
+
+    const StringPiece basename = WideCharToUtf8(find_data.cFileName);
     if (basename != "." && basename != "..") {
-      result->push_back(find_data.cFileName);
+      result->push_back(WideCharToUtf8(find_data.cFileName));
     }
-  } while (::FindNextFileA(find_handle, &find_data));
+  } while (::FindNextFileW(find_handle, &find_data));
 
   if (!::FindClose(find_handle)) {
     string context = "FindClose failed for: " + translated_dir;
@@ -439,9 +445,10 @@ Status WindowsFileSystem::DeleteDir(const string& name) {
 
 Status WindowsFileSystem::GetFileSize(const string& fname, uint64* size) {
   string translated_fname = TranslateName(fname);
+  std::wstring ws_translated_dir = Utf8ToWideChar(translated_fname);
   Status result;
   WIN32_FILE_ATTRIBUTE_DATA attrs;
-  if (TRUE == ::GetFileAttributesExA(translated_fname.c_str(),
+  if (TRUE == ::GetFileAttributesExW(ws_translated_dir.c_str(),
                                      GetFileExInfoStandard, &attrs)) {
     ULARGE_INTEGER file_size;
     file_size.HighPart = attrs.nFileSizeHigh;
@@ -459,7 +466,9 @@ Status WindowsFileSystem::RenameFile(const string& src, const string& target) {
   Status result;
   // rename() is not capable of replacing the existing file as on Linux
   // so use OS API directly
-  if (!::MoveFileExA(TranslateName(src).c_str(), TranslateName(target).c_str(),
+  std::wstring ws_translated_src = Utf8ToWideChar(TranslateName(src));
+  std::wstring ws_translated_target = Utf8ToWideChar(TranslateName(target));
+  if (!::MoveFileExW(ws_translated_src.c_str(), ws_translated_target.c_str(),
       MOVEFILE_REPLACE_EXISTING)) {
     string context(strings::StrCat("Failed to rename: ", src, " to: ", target));
     result = IOErrorFromWindowsError(context, ::GetLastError());
@@ -487,12 +496,13 @@ Status WindowsFileSystem::GetMatchingPaths(const string& pattern,
 Status WindowsFileSystem::Stat(const string& fname, FileStatistics* stat) {
   Status result;
   struct _stat sbuf;
+  std::wstring ws_translated_fname = Utf8ToWideChar(TranslateName(fname));
   if (_stat(TranslateName(fname).c_str(), &sbuf) != 0) {
     result = IOError(fname, errno);
   } else {
     stat->mtime_nsec = sbuf.st_mtime * 1e9;
     stat->length = sbuf.st_size;
-    stat->is_directory = PathIsDirectory(TranslateName(fname).c_str());
+    stat->is_directory = PathIsDirectoryW(ws_translated_fname.c_str());
   }
   return result;
 }

--- a/tensorflow/core/platform/windows/windows_file_system.h
+++ b/tensorflow/core/platform/windows/windows_file_system.h
@@ -67,19 +67,19 @@ class WindowsFileSystem : public FileSystem {
     return name;
   }
 
-  std::wstring Utf8ToWideChar(const string& utf8str) {
-      int size_required = MultiByteToWideChar(CP_UTF8, 0, &utf8str[0], (int)utf8str.size(), NULL, 0);
+  static std::wstring Utf8ToWideChar(const string& utf8str) {
+      int size_required = MultiByteToWideChar(CP_UTF8, 0, utf8str.c_str(), (int)utf8str.size(), NULL, 0);
       std::wstring ws_translated_str(size_required, 0);
-      MultiByteToWideChar(CP_UTF8, 0, &utf8str[0], (int)utf8str.size(), &ws_translated_str[0], size_required);
+      MultiByteToWideChar(CP_UTF8, 0, utf8str.c_str(), (int)utf8str.size(), &ws_translated_str[0], size_required);
       return ws_translated_str;
   }
 
-  string WideCharToUtf8(const std::wstring &wstr) {
+  static string WideCharToUtf8(const std::wstring &wstr) {
       if (wstr.empty()) return std::string();
-      int size_required = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
-      string utf8_str(size_required, 0);
-      WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &utf8_str[0], size_required, NULL, NULL);
-      return utf8_str;
+      int size_required = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), (int)wstr.size(), NULL, 0, NULL, NULL);
+      string utf8_translated_str(size_required, 0);
+      WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), (int)wstr.size(), &utf8_translated_str[0], size_required, NULL, NULL);
+      return utf8_translated_str;
   }
 };
 

--- a/tensorflow/core/platform/windows/windows_file_system.h
+++ b/tensorflow/core/platform/windows/windows_file_system.h
@@ -66,6 +66,21 @@ class WindowsFileSystem : public FileSystem {
   string TranslateName(const string& name) const override {
     return name;
   }
+
+  std::wstring Utf8ToWideChar(const string& utf8str) {
+      int size_required = MultiByteToWideChar(CP_UTF8, 0, &utf8str[0], (int)utf8str.size(), NULL, 0);
+      std::wstring ws_translated_str(size_required, 0);
+      MultiByteToWideChar(CP_UTF8, 0, &utf8str[0], (int)utf8str.size(), &ws_translated_str[0], size_required);
+      return ws_translated_str;
+  }
+
+  string WideCharToUtf8(const std::wstring &wstr) {
+      if (wstr.empty()) return std::string();
+      int size_required = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+      string utf8_str(size_required, 0);
+      WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &utf8_str[0], size_required, NULL, NULL);
+      return utf8_str;
+  }
 };
 
 class LocalWinFileSystem : public WindowsFileSystem {

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -1,3 +1,4 @@
+# This Python file uses the following encoding: utf-8
 # Copyright 2015 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -451,6 +451,12 @@ class FileIoTest(test.TestCase):
     lines = f.readlines()
     self.assertSequenceEqual(lines, data)
 
+  def testUTF8StringPath(self):
+    file_path = os.path.join(self._base_dir, "UTF8测试_file")
+    file_io.write_string_to_file(file_path, "testing")
+    with file_io.FileIO(file_path, mode="rb") as f:
+      self.assertEqual(b"testing", f.read())
+
   def testEof(self):
     """Test that reading past EOF does not raise an exception."""
 


### PR DESCRIPTION
Descrition:
Fix the bug that Tensorflow on Windows running into issues when there's UTF8 encoded characters in the file path.
Solution:
Switch to use WideChar API calls for Windows, like the CreateFileW,FindFirstFileW,FindNextFileW, LoadLibraryExW.
Test:
Install Tensorflow on Windows with path have Chinese characers in it. No issue.
Run command "from tensorflow.contrib.rnn.python.ops.gru_ops import *" No issue.