### PR TITLE
update:tf_inspect.py

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -253,7 +253,7 @@ try:
   from sklearn.manifold import TSNE
   import matplotlib.pyplot as plt
 
-  tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=5000)
+  tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=5000, method='exact')
   plot_only = 500
   low_dim_embs = tsne.fit_transform(final_embeddings[:plot_only, :])
   labels = [reverse_dictionary[i] for i in xrange(plot_only)]

--- a/tensorflow/python/util/tf_inspect.py
+++ b/tensorflow/python/util/tf_inspect.py
@@ -31,6 +31,8 @@ def currentframe():
 
 def getargspec(object):  # pylint: disable=redefined-builtin
   """TFDecorator-aware replacement for inspect.getargspec.
+     inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
+    
 
   Args:
     object: A callable, possibly decorated.
@@ -42,7 +44,7 @@ def getargspec(object):  # pylint: disable=redefined-builtin
   """
   decorators, target = tf_decorator.unwrap(object)
   return next((d.decorator_argspec for d in decorators
-               if d.decorator_argspec is not None), _inspect.getargspec(target))
+               if d.decorator_argspec is not None), _inspect.signature(target))
 
 
 def getcallargs(func, *positional, **named):


### PR DESCRIPTION
DeprecationWarning: inspect.getargspec() is deprecated, use
inspect.signature() or inspect.getfullargspec()
if d.decorator_argspec is not None), _inspect.getargspec(target))