### PR TITLE
Fix typos

### DIFF
--- a/tensorflow/contrib/signal/python/ops/reconstruction_ops.py
+++ b/tensorflow/contrib/signal/python/ops/reconstruction_ops.py
@@ -37,7 +37,7 @@ def _shuffle_to_front(input_tensor, k):
     k: A scalar `Tensor` specifying how many indices to shuffle.
 
   Returns:
-    A tranposed version of `input_tensor` with `k` indices shuffled to the
+    A transposed version of `input_tensor` with `k` indices shuffled to the
     front.
 
   Raises:

--- a/tensorflow/contrib/timeseries/python/timeseries/model.py
+++ b/tensorflow/contrib/timeseries/python/timeseries/model.py
@@ -354,7 +354,7 @@ class SequentialTimeSeriesModel(TimeSeriesModel):
 
     Args:
       current_times: A [batch size] Tensor of times for each observation.
-      current_values: A [batch size] Tensor of values for each observaiton.
+      current_values: A [batch size] Tensor of values for each observation.
       state: Model state, updated to current_times.
       predictions: The outputs of _prediction_step
     Returns:

--- a/tensorflow/contrib/timeseries/python/timeseries/state_space_models/state_space_model.py
+++ b/tensorflow/contrib/timeseries/python/timeseries/state_space_models/state_space_model.py
@@ -391,7 +391,7 @@ class StateSpaceModel(model.SequentialTimeSeriesModel):
 
     Args:
       current_times: A [batch size] Tensor for times for each observation.
-      current_values: A [batch size] Tensor of values for each observaiton.
+      current_values: A [batch size] Tensor of values for each observation.
       state: A tuple of (mean, covariance, previous_times) having shapes
           mean; [batch size x state dimension]
           covariance; [batch size x state dimension x state dimension]

--- a/tensorflow/python/debug/lib/debug_gradients.py
+++ b/tensorflow/python/debug/lib/debug_gradients.py
@@ -303,7 +303,7 @@ class GradientsDebugger(object):
     """Register the gradient tensor for an x-tensor.
 
     Args:
-      x_tensor_name: (`str`) the name of the the independent `tf.Tensor`, i.e.,
+      x_tensor_name: (`str`) the name of the independent `tf.Tensor`, i.e.,
         the tensor on the denominator of the differentiation.
       gradient_tensor: the gradient `tf.Tensor`.
     """

--- a/tensorflow/python/framework/common_shapes.py
+++ b/tensorflow/python/framework/common_shapes.py
@@ -617,7 +617,7 @@ def call_cpp_shape_fn(op, require_shape_fn=True):
 
 def _call_cpp_shape_fn_impl(
     op, input_tensors_needed, input_tensors_as_shapes_needed, require_shape_fn):
-  """Core implementaton of call_cpp_shape_fn."""
+  """Core implementation of call_cpp_shape_fn."""
   graph_def_version = op.graph.graph_def_versions.producer
   node_def_str = op.node_def.SerializeToString()
 

--- a/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
@@ -60,7 +60,7 @@ reinstall_tensorflow_pip ${PIP_NAME}
 
 # Define no_tensorflow_py_deps=true so that every py_test has no deps anymore,
 # which will result testing system installed tensorflow
-# GPU tests are very flaky when running concurently, so set local_test_jobs=1
+# GPU tests are very flaky when running concurrently, so set local_test_jobs=1
 bazel test -c opt --config=win-cuda $BUILD_OPTS -k --test_output=errors \
   --define=no_tensorflow_py_deps=true --test_lang_filters=py \
   --test_tag_filters=-no_pip,-no_windows,-no_windows_gpu \


### PR DESCRIPTION
This PR fixes some typos: `tranposed`, `observaiton`, `the the`, `implementaton`, and `concurently`.