### PR TITLE
python: remove the TRAINABLE_RESOURCE_VARIABLES graph key

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -4363,8 +4363,6 @@ class GraphKeys(object):
   # Key to collect all shared resources used in this graph which need to be
   # initialized once per session.
   LOCAL_RESOURCES = "local_resources"
-  # Trainable resource-style variables.
-  TRAINABLE_RESOURCE_VARIABLES = "trainable_resource_variables"
 
   # Key to indicate various ops.
   INIT_OP = "init_op"

--- a/tensorflow/python/training/optimizer.py
+++ b/tensorflow/python/training/optimizer.py
@@ -367,9 +367,7 @@ class Optimizer(object):
     if grad_loss is not None:
       self._assert_valid_dtypes([grad_loss])
     if var_list is None:
-      var_list = (
-          variables.trainable_variables() +
-          ops.get_collection(ops.GraphKeys.TRAINABLE_RESOURCE_VARIABLES))
+      var_list = variables.trainable_variables()
     else:
       var_list = nest.flatten(var_list)
     # pylint: disable=protected-access

--- a/tensorflow/tools/api/golden/tensorflow.-graph-keys.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.-graph-keys.pbtxt
@@ -103,10 +103,6 @@ tf_class {
     mtype: "<type \'str\'>"
   }
   member {
-    name: "TRAINABLE_RESOURCE_VARIABLES"
-    mtype: "<type \'str\'>"
-  }
-  member {
     name: "TRAINABLE_VARIABLES"
     mtype: "<type \'str\'>"
   }


### PR DESCRIPTION
The graph key `TRAINABLE_RESOURCE_VARIABLES` seems to have been removed, drop the lines in this PR.