### PR TITLE
Fix issue #10399

### DIFF
--- a/tensorflow/contrib/learn/python/learn/experiment.py
+++ b/tensorflow/contrib/learn/python/learn/experiment.py
@@ -594,8 +594,8 @@ class Experiment(object):
   def _maybe_export(self, eval_result, checkpoint_path=None):
     """Export the Estimator using export_fn, if defined."""
     export_dir_base = os.path.join(
-        compat.as_bytes(self._estimator.model_dir),
-        compat.as_bytes("export"))
+        self._estimator.model_dir,
+        "export")
 
     export_results = []
     for strategy in self._export_strategies:
@@ -603,8 +603,8 @@ class Experiment(object):
           strategy.export(
               self._estimator,
               os.path.join(
-                  compat.as_bytes(export_dir_base),
-                  compat.as_bytes(strategy.name)),
+                  export_dir_base,
+                  strategy.name),
               checkpoint_path=checkpoint_path,
               eval_result=eval_result))
 


### PR DESCRIPTION
Because of the bytes compatibility this function is returning bytes
when it should be returning strings.

Fixes issue "TypeError: Can't mix strings and bytes in path
components" when using `tf.contrib.learn.learn_runner` with
experiments with an `export_strategy`.

See issue #10399 for a code example reference.

I didn't find obvious mistakes, but this is my first contribution and
I may have missed something.