### PR TITLE
Add GPU implementation for tf.segment_sum.

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2410,7 +2410,9 @@ tf_kernel_library(
 tf_kernel_library(
     name = "segment_reduction_ops",
     prefix = "segment_reduction_ops",
-    deps = MATH_DEPS,
+    deps = MATH_DEPS + if_cuda([
+        ":cuda_solvers",
+    ]),
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/segment_reduction_ops.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops.cc
@@ -241,7 +241,7 @@ class SegmentSumGPUOp : public AsyncOpKernel {
                                   output_rows_device, sizeof(Index))
                      .ok(),
         errors::Internal(
-            "SegmentSumGPUOp: failed to copy num_true from device"),
+            "SegmentSumGPUOp: failed to copy output_rows from device"),
         done);
 
     functor::SegmentSumFunctor<T, Index> functor_;
@@ -254,6 +254,10 @@ class SegmentSumGPUOp : public AsyncOpKernel {
 
       Index output_rows = *output_rows_host.data();
       output_rows++;
+      OP_REQUIRES_ASYNC(context, output_rows > 0,
+                        errors::InvalidArgument("segment ids must be >= 0"),
+                        done);
+
       TensorShape output_shape = input.shape();
       output_shape.set_dim(0, output_rows);
 

--- a/tensorflow/core/kernels/segment_reduction_ops.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops.cc
@@ -197,6 +197,19 @@ class SegmentReductionOp : public OpKernel {
 
 #ifdef GOOGLE_CUDA
 //  SegmentSumGPUOp is a segment sum operator implemented for GPU only.
+//  TODO: This implementation of SegmentSumGPUOp is sometimes slower than
+//  its unsorted counterpart (mostly when problem size is small).
+//  This is due to the following two main reasons and a cost-effective way
+//  to resolve these problems is desirable.
+//  1. Sorted segment sum requires a memory transfer from device to host in
+//     order to know the size of the output dimension whereas unsorted segment
+//     sum receives the size of the output dimension as an input parameter.
+//  2. Sorted segment sum is essentially a tiled version of unsorted segment
+//     sum and therefore such optimization comes at an inherent cost. However
+//     such cost may not be justified when the problem size is small. When to
+//     use the tiled version or the untiled version depends on many factors
+//     including data alignments, ratio of calculation to memory traffic and
+//     obviously, the problem sizes.
 template <class T, class Index>
 class SegmentSumGPUOp : public AsyncOpKernel {
  public:

--- a/tensorflow/core/kernels/segment_reduction_ops.h
+++ b/tensorflow/core/kernels/segment_reduction_ops.h
@@ -28,6 +28,7 @@ class OpKernelContext;
 namespace functor {
 
 #ifdef GOOGLE_CUDA
+typedef Eigen::GpuDevice GPUDevice;
 // Functor for SegmentSumGPUOp.
 // 'output_rows': the number of output segments (unique segment ids in
 //                'segment_ids').
@@ -37,8 +38,6 @@ namespace functor {
 // 'data_size': size of input data tensor.
 // 'data': input data tensor.
 // 'output': output reshaped to {output_rows, output.size/output_rows}
-typedef Eigen::GpuDevice GPUDevice;
-
 template <typename T, typename Index>
 struct SegmentSumFunctor {
   void operator()(OpKernelContext* ctx, const GPUDevice& d,

--- a/tensorflow/core/kernels/segment_reduction_ops.h
+++ b/tensorflow/core/kernels/segment_reduction_ops.h
@@ -26,6 +26,29 @@ namespace tensorflow {
 class OpKernelContext;
 
 namespace functor {
+
+#ifdef GOOGLE_CUDA
+// Functor for SegmentSumGPUOp.
+// 'output_rows': the number of output segments (unique segment ids in
+//                'segment_ids').
+// 'segment_ids_shape': shape of 'segment_ids' tensor.
+// 'segment_ids': unsorted map from input to output segment ids at which to
+//                perform segment sum operation.
+// 'data_size': size of input data tensor.
+// 'data': input data tensor.
+// 'output': output reshaped to {output_rows, output.size/output_rows}
+typedef Eigen::GpuDevice GPUDevice;
+
+template <typename T, typename Index>
+struct SegmentSumFunctor {
+  void operator()(OpKernelContext* ctx, const GPUDevice& d,
+                  const Index output_rows, const TensorShape& segment_ids_shape,
+                  typename TTypes<Index>::ConstFlat segment_ids,
+                  const Index data_size, const T* data,
+                  typename TTypes<T, 2>::Tensor output);
+};
+#endif
+
 // BaseFunctor for definition of UnsorteSegmentReductionOp
 // for usage without templates.
 template <typename Device, typename T, typename Index>

--- a/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
@@ -54,6 +54,74 @@ __device__ __forceinline__ void AccumulateInto(
   CudaAtomicAdd(dest_scalar + 1, value.imag());
 }
 
+// SortedSegmentSumFunctor kernel reduces input data just as
+// UnsortedSegmentSumCustomKernel does except that input data
+// is partitioned along the outer reduction dimension. This is
+// because consecutive rows (elements in a row share the same
+// outer dimension index) in the flattened 2D input data likely
+// belong to the same segment in sorted segment sum operation.
+// Therefore such partitioning strategy has two advantages over
+// the UnsortedSegmentSumFunctor kernel:
+// 1. Each thread reduces across multiple rows before writing
+// answers to the global memory, we can therefore
+// write reduction results to global memory less often.
+// 2. We may know that the current thread is the only contributor
+// to an output element because of the increasing nature of segment
+// ids. In such cases, we do not need to use atomic operations
+// to write results to global memory.
+// In the flattened view of input data (with only outer and inner
+// dimension), every thread processes a strip of input data of
+// size OUTER_DIM_TILE_SIZE x 1. This strip runs across multiple
+// rows of input data and all reduction elements share one inner
+// dimension index.
+#define OUTER_DIM_TILE_SIZE 8
+#define CEIL_DIV(x, y) (1 + (((x)-1) / (y)))
+template <typename T, typename Index>
+__global__ void SortedSegmentSumCustomKernel(const Index input_outer_dim_size,
+                                             const Index inner_dim_size,
+                                             const Index output_outer_dim_size,
+                                             const Index* segment_ids,
+                                             const T* input, T* output) {
+  const Index input_outer_dim_num_strip =
+      CEIL_DIV(input_outer_dim_size, OUTER_DIM_TILE_SIZE);
+  const Index total_stripe_count = inner_dim_size * input_outer_dim_num_strip;
+
+  CUDA_1D_KERNEL_LOOP(strip_index, total_stripe_count) {
+    const Index segment_offset = strip_index % inner_dim_size;
+    const Index input_outer_dim_index_base =
+        strip_index / inner_dim_size * OUTER_DIM_TILE_SIZE;
+
+    T sum = T(0);
+    Index first_segment_id = segment_ids[input_outer_dim_index_base];
+    Index last_output_segment_id = output_outer_dim_size;
+    const Index actual_stripe_height = MIN(
+        OUTER_DIM_TILE_SIZE, input_outer_dim_size - input_outer_dim_index_base);
+    for (Index j = 0; j < actual_stripe_height; j++) {
+      Index current_output_segment_id =
+          segment_ids[input_outer_dim_index_base + j];
+      // decide whether to write result to global memory
+      if (current_output_segment_id > last_output_segment_id) {
+        const Index output_index =
+            last_output_segment_id * inner_dim_size + segment_offset;
+        // decide whether to write result to global memory using atomic
+        // operations
+        if (last_output_segment_id == first_segment_id) {
+          AccumulateInto<T>(output + output_index, sum);
+        } else {
+          *(output + output_index) = sum;
+        }
+        sum = T(0);
+      }
+      sum += ldg(input + (input_outer_dim_index_base + j) * inner_dim_size +
+                 segment_offset);
+      last_output_segment_id = current_output_segment_id;
+    }
+    const Index output_index =
+        last_output_segment_id * inner_dim_size + segment_offset;
+    AccumulateInto<T>(output + output_index, sum);
+  }
+}
+
 // UnsortedSegmentSumFunctor kernel processes 'input_total_size' elements.
 // Each element is mapped from input to output by a combination of its
 // 'segment_ids' mapping and 'inner_dim_size'.
@@ -79,6 +147,44 @@ __global__ void UnsortedSegmentSumCustomKernel(
 }
 
 namespace functor {
+
+template <typename T, typename Index>
+void SegmentSumFunctor<T, Index>::operator()(
+    OpKernelContext* ctx, const GPUDevice& d, const Index output_rows,
+    const TensorShape& segment_ids_shape,
+    typename TTypes<Index>::ConstFlat segment_ids, const Index data_size,
+    const T* data, typename TTypes<T, 2>::Tensor output) {
+  if (output.size() == 0) {
+    return;
+  }
+  // Set 'output' to zeros.
+  CudaLaunchConfig config = GetCudaLaunchConfig(output.size(), d);
+  SetZero<<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
+      output.size(), output.data());
+  if (data_size == 0 || segment_ids_shape.num_elements() == 0) {
+    return;
+  }
+
+  // Launch kernel to compute sorted segment sum.
+  // Notes:
+  // *) 'input_total_size' is the total number of elements to process.
+  // *) 'segment_ids.shape' is a prefix of data's shape.
+  // *) 'input_outer_dim_size' is the total number of segments to process.
+  const Index input_total_size = data_size;
+  const Index input_outer_dim_size = segment_ids.dimension(0);
+  const Index input_inner_dim_size = input_total_size / input_outer_dim_size;
+
+  const Index input_outer_dim_num_strip =
+      1 + (input_outer_dim_size - 1) / OUTER_DIM_TILE_SIZE;
+  const Index total_stripe_count =
+      input_inner_dim_size * input_outer_dim_num_strip;
+
+  config = GetCudaLaunchConfig(total_stripe_count, d);
+  SortedSegmentSumCustomKernel<
+      T, Index><<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
+      input_outer_dim_size, input_inner_dim_size, output_rows,
+      segment_ids.data(), data, output.data());
+};
 
 // UnsortedSegmentSumFunctor implementation for GPUDevice.
 template <typename T, typename Index>
@@ -116,6 +222,15 @@ struct UnsortedSegmentSumFunctor<GPUDevice, T, Index>: UnsortedSegmentBaseFuncto
         segment_ids.data(), data, output.data());
   }
 };
+
+#define DEFINE_SORTED_GPU_SPECS_INDEX(T, Index) \
+  template struct SegmentSumFunctor<T, Index>
+
+#define DEFINE_SORTED_GPU_SPECS(T)         \
+  DEFINE_SORTED_GPU_SPECS_INDEX(T, int32); \
+  DEFINE_SORTED_GPU_SPECS_INDEX(T, int64);
+
+TF_CALL_GPU_NUMBER_TYPES(DEFINE_SORTED_GPU_SPECS);
 
 #define DEFINE_GPU_SPECS_INDEX(T, Index) \
   template struct UnsortedSegmentSumFunctor<GPUDevice, T, Index>

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -631,13 +631,15 @@ cuda_py_test(
 
 tf_py_test(
     name = "segment_reduction_ops_test",
-    size = "small",
+    size = "medium",
     srcs = ["segment_reduction_ops_test.py"],
     additional_deps = [
         "//third_party/py/numpy",
+        "//tensorflow/python:client",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:framework_for_generated_wrappers",
         "//tensorflow/python:math_ops",
+        "//tensorflow/python:variables",
         "//tensorflow/python:nn_grad",
     ],
 )


### PR DESCRIPTION
As per #11228, a GPU version of segment sum has been created. 
## Performance 
On a Tesla K40c GPU, the following performance tests have been performed. 
- The test case sizes are represented using 3-tuples of integers. The first two integers correspond to the outer and inner dimension of the input data and the last integer corresponds to the outer dimension of the output data, which is also the total number of segments. 
- The first three rows of data are obtained by running reductions on float32 input type whereas the last three rows of data are obtained by running reductions on float64 input type. 
- We use the GPU version of unsorted segment reduction as the baseline. 
- During experiments, they share the same input data and outputs are compared for consistency.

|  | (1024, 1024, 128)            |   (2048, 2048, 256)          |    (4096, 4096, 512)         | 
|-------------------------------------------------------------|-------------|-------------|-------------| 
| t_unsorted                                                  | 84.942us    | 332.12us    | 1.3170ms    | 
| t_sorted                                                    | 71.047us    | 264.16us    | 1.0391ms    | 
| speedup                                                     | 1.20  | 1.26 | 1.27  | 
|                                                             |             |             |             | 
| t_unsorted                                                  | 160.69us    | 594.93us    | 2.2895ms    | 
| t_sorted                                                    | 106.94us    | 395.19us    | 1.5662ms    | 
| speedup                                                     | 1.50 | 1.51 | 1.46 | 

## Known Limitations:
- We do not check segment_id to make sure that they are within [0, num_outputs-1].
- We do not verify that segment_id is increasing.