### PR TITLE
Add logical_or and less_equal to tf_op_files.txt

### DIFF
--- a/tensorflow/contrib/makefile/tf_op_files.txt
+++ b/tensorflow/contrib/makefile/tf_op_files.txt
@@ -143,8 +143,10 @@ tensorflow/core/kernels/cwise_op_minimum.cc
 tensorflow/core/kernels/cwise_op_maximum.cc
 tensorflow/core/kernels/cwise_op_logical_not.cc
 tensorflow/core/kernels/cwise_op_logical_and.cc
+tensorflow/core/kernels/cwise_op_logical_or.cc
 tensorflow/core/kernels/cwise_op_log.cc
 tensorflow/core/kernels/cwise_op_less.cc
+tensorflow/core/kernels/cwise_op_less_equal.cc
 tensorflow/core/kernels/cwise_op_isfinite.cc
 tensorflow/core/kernels/cwise_op_invert.cc
 tensorflow/core/kernels/cwise_op_greater_equal.cc


### PR DESCRIPTION
Add below ops implementations to the list
tensorflow/core/kernels/cwise_op_logical_or.cc
tensorflow/core/kernels/cwise_op_less_equal.cc

When I am using the Android and iOS lib, above ops are not registered while in full version they are available. I think these are very basic ops and should add to the list by default.