### PR TITLE
Add a function for generating random values with predefined seed

### DIFF
--- a/tensorflow/core/lib/random/random.cc
+++ b/tensorflow/core/lib/random/random.cc
@@ -22,16 +22,27 @@ limitations under the License.
 namespace tensorflow {
 namespace random {
 
-std::mt19937_64* InitRng() {
+namespace {
+std::mt19937_64* InitRngWithRandomSeed() {
   std::random_device device("/dev/urandom");
   return new std::mt19937_64(device());
 }
+std::mt19937_64 InitRngWithDefaultSeed() { return std::mt19937_64(); }
+
+}  // anonymous namespace
 
 uint64 New64() {
-  static std::mt19937_64* rng = InitRng();
+  static std::mt19937_64* rng = InitRngWithRandomSeed();
   static mutex mu;
   mutex_lock l(mu);
   return (*rng)();
+}
+
+uint64 New64DefaultSeed() {
+  static std::mt19937_64 rng = InitRngWithDefaultSeed();
+  static mutex mu;
+  mutex_lock l(mu);
+  return rng();
 }
 
 }  // namespace random

--- a/tensorflow/core/lib/random/random.h
+++ b/tensorflow/core/lib/random/random.h
@@ -26,7 +26,7 @@ namespace random {
 uint64 New64();
 
 // Return a 64-bit random value. Uses
-// std::mersenne_twister_engine::default_seed as seed value
+// std::mersenne_twister_engine::default_seed as seed value.
 uint64 New64DefaultSeed();
 
 }  // namespace random

--- a/tensorflow/core/lib/random/random.h
+++ b/tensorflow/core/lib/random/random.h
@@ -25,6 +25,10 @@ namespace random {
 // in different processes.
 uint64 New64();
 
+// Return a 64-bit random value. Uses
+// std::mersenne_twister_engine::default_seed as seed value
+uint64 New64DefaultSeed();
+
 }  // namespace random
 }  // namespace tensorflow
 


### PR DESCRIPTION
I added a seeded random function, as it was requested in [this PR](https://github.com/tensorflow/tensorflow/pull/11530#issuecomment-315590857):

> Please use seeded rands to make the tests deterministic and easier to debug.