### PR TITLE
[OpenCL] DenseUpdate sync

### DIFF
--- a/tensorflow/core/kernels/dense_update_functor.h
+++ b/tensorflow/core/kernels/dense_update_functor.h
@@ -24,6 +24,9 @@ limitations under the License.
 namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
+#ifdef TENSORFLOW_USE_SYCL
+typedef Eigen::SyclDevice SYCLDevice;
+#endif  // TENSORFLOW_USE_SYCL
 
 enum DenseUpdateType { ADD, SUB, ASSIGN };
 
@@ -58,6 +61,32 @@ struct DenseUpdate<CPUDevice, T, ASSIGN> {
     params.device(d) = update;
   }
 };
+
+#ifdef TENSORFLOW_USE_SYCL
+template <typename T>
+struct DenseUpdate<SYCLDevice, T, ADD> {
+  void operator()(const SYCLDevice& d, typename TTypes<T>::Flat params,
+                  typename TTypes<T>::ConstFlat update) {
+    params.device(d) += update;
+  }
+};
+
+template <typename T>
+struct DenseUpdate<SYCLDevice, T, SUB> {
+  void operator()(const SYCLDevice& d, typename TTypes<T>::Flat params,
+                  typename TTypes<T>::ConstFlat update) {
+    params.device(d) -= update;
+  }
+};
+
+template <typename T>
+struct DenseUpdate<SYCLDevice, T, ASSIGN> {
+  void operator()(const SYCLDevice& d, typename TTypes<T>::Flat params,
+                  typename TTypes<T>::ConstFlat update) {
+    params.device(d) = update;
+  }
+};
+#endif  // TENSORFLOW_USE_SYCL
 
 }  // end namespace functor
 }  // end namespace tensorflow


### PR DESCRIPTION
Fixes undefined symbol for tensorflow::functor::DenseUpdate<Eigen::SyclDevice, linking error.