### PR TITLE
Fix build doc README

### DIFF
--- a/tensorflow/g3doc/README.txt
+++ b/tensorflow/g3doc/README.txt
@@ -5,7 +5,7 @@ go to:
 
 Documentation (on Github, tensorflow.org, and anywhere else we decide to
 serve it from) is now generated from the files in
-third_party/tensorflow/docs_src/ (for tutorials and other guides) and
+tensorflow/docs_src/ (for tutorials and other guides) and
 TensorFlow source code (for the API reference pages). If you see a problem with
 API reference, edit the code comments in the appropriate language. If you see a 
 problem with our other docs, edit the files in docs_src.
@@ -14,9 +14,10 @@ To preview the results of your changes, or generate an offline copy of
 the docs, run:
 
   bazel run -- tensorflow/tools/docs:generate \
-    --src_dir=tensorflow/docs_src/ \
+    --src_dir=/path/to/tensorflow/docs_src/ \
     --output_dir=/tmp/tfdocs/
 
+`src_dir` must be absolute path to documentation source.
 When authoring docs, note that we have some new syntax for references --
 at least for docs coming from Python docstrings or
 tensorflow/docs_src/.  Use:
@@ -25,7 +26,6 @@ tensorflow/docs_src/.  Use:
   symbol.  Note that class members don't get their own page, but the
   syntax still works, since @{tf.MyClass.method} links to the right
   part of the tf.MyClass page.
-
 
 * @{tensorflow::symbol} to make a link to the reference page for a C++
   symbol. (This only works for a few symbols but will work for more soon.)


### PR DESCRIPTION
README for generating documentation includes outdated information.

- `src_dir` must be absolute path
- docs_src was moved to `tensorflow/docs_src`