### PR TITLE
Definitions about @protobuf between the workspace.bzl and grpc

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -253,7 +253,7 @@ try:
   from sklearn.manifold import TSNE
   import matplotlib.pyplot as plt
 
-  tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=5000)
+  tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=5000, method='exact')
   plot_only = 500
   low_dim_embs = tsne.fit_transform(final_embeddings[:plot_only, :])
   labels = [reverse_dictionary[i] for i in xrange(plot_only)]

--- a/tensorflow/python/util/tf_inspect.py
+++ b/tensorflow/python/util/tf_inspect.py
@@ -31,6 +31,8 @@ def currentframe():
 
 def getargspec(object):  # pylint: disable=redefined-builtin
   """TFDecorator-aware replacement for inspect.getargspec.
+     inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
+    
 
   Args:
     object: A callable, possibly decorated.
@@ -42,7 +44,7 @@ def getargspec(object):  # pylint: disable=redefined-builtin
   """
   decorators, target = tf_decorator.unwrap(object)
   return next((d.decorator_argspec for d in decorators
-               if d.decorator_argspec is not None), _inspect.getargspec(target))
+               if d.decorator_argspec is not None), _inspect.signature(target))
 
 
 def getcallargs(func, *positional, **named):

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -442,7 +442,7 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
 
   native.bind(
       name = "protobuf_compiler",
-      actual = "@com_google_protobuf//:protoc",
+      actual = "@com_google_protobuf//:protoc_lib",
   )
 
   native.new_http_archive(

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -437,12 +437,12 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   # to point to the protobuf's compiler library.
   native.bind(
       name = "protobuf_clib",
-      actual = "@protobuf//:protoc_lib",
+      actual = "@com_google_protobuf//:protoc_lib",
   )
 
   native.bind(
       name = "protobuf_compiler",
-      actual = "@protobuf//:protoc_lib",
+      actual = "@com_google_protobuf//:protoc",
   )
 
   native.new_http_archive(


### PR DESCRIPTION
grpc expects //external:protobuf_clib and //external:protobuf_compiler to point to the protobuf's compiler library.

Definitions about @protobuf between the workspace.bzl and grpc(https://github.com/grpc/grpc/blob/master/WORKSPACE)
