### PR TITLE
Update fft2d.cmake

### DIFF
--- a/tensorflow/contrib/cmake/external/fft2d.cmake
+++ b/tensorflow/contrib/cmake/external/fft2d.cmake
@@ -45,7 +45,7 @@ else()
       DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
       BUILD_IN_SOURCE 1
       PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/patches/fft2d/CMakeLists.txt ${fft2d_BUILD}/src/fft2d/CMakeLists.txt
-      INSTALL_DIR $(fft2d_INSTALL)
+      INSTALL_DIR ${fft2d_INSTALL}
       INSTALL_COMMAND echo
       BUILD_COMMAND $(MAKE))
     


### PR DESCRIPTION
The cmake fft2d library was installing to '(fft2d_INSTALL)' instead of the appropriate variable set by CMake. I suspect this was unintentional. 

Changing the parentheses to curly brackets fixes this.