### PR TITLE
Fix stackoverflow link to avoid redirect warning

### DIFF
--- a/tensorflow/docs_src/community/documentation.md
+++ b/tensorflow/docs_src/community/documentation.md
@@ -35,7 +35,7 @@ at [tensorflow.org/versions/master](https://www.tensorflow.org/versions/master).
 
 If you want documentation changes to appear at root, you will need to also
 contribute that change to the current stable binary branch (and/or
-[cherrypick](https://www.google.com/url?sa=D&q=http%3A%2F%2Fstackoverflow.com%2Fquestions%2F9339429%2Fwhat-does-cherry-picking-a-commit-with-git-mean)).
+[cherrypick](https://stackoverflow.com/questions/9339429/what-does-cherry-picking-a-commit-with-git-mean)).
 
 ## Reference vs. non-reference documentation
 


### PR DESCRIPTION
Redirect warning is always shown to go to stackoverflow.

<img width="1081" alt="screen shot 2017-07-23 at 16 50 25" src="https://user-images.githubusercontent.com/1713047/28497657-53ec0e8c-6fc7-11e7-8211-2919b9706dbb.png">
