### PR TITLE
Add `as_default()` to `MonitoredSession`, `MonitoredTrainingSession` and `SingularMonitoredSession`.

### DIFF
--- a/tensorflow/python/training/monitored_session.py
+++ b/tensorflow/python/training/monitored_session.py
@@ -525,6 +525,16 @@ class _MonitoredSession(object):
   def close(self):
     self._close_internal()
 
+  def as_default(self):
+    """Returns a context manager that makes this object the default session.
+
+    Use with the `with` keyword to specify that calls to @{tf.Operation.run}
+    or @{tf.Tensor.eval} should be executed in this session.
+
+    Equivalent to @{tf.Session.as_default}.
+    """
+    return ops.default_session(self)
+
   def __enter__(self):
     return self
 

--- a/tensorflow/python/training/monitored_session_test.py
+++ b/tensorflow/python/training/monitored_session_test.py
@@ -338,6 +338,13 @@ class MonitoredTrainingSessionTest(test.TestCase):
           is_chief=True, checkpoint_dir=logdir) as session:
         self.assertEqual(0, session.run(gstep))
 
+  def test_as_default(self):
+    with ops.Graph().as_default():
+      with monitored_session.MonitoredTrainingSession() as session:
+        self.assertEqual(None, ops.get_default_session())
+        with session.as_default():
+          self.assertEqual(session, ops.get_default_session())
+
 
 class StopAtNSession(monitored_session._WrappedSession):
   """A wrapped session that stops at the N-th call to _check_stop."""
@@ -1243,6 +1250,13 @@ class MonitoredSessionTest(test.TestCase):
             isinstance(hook.run_metadata_list[0], config_pb2.RunMetadata))
         self.assertGreater(len(hook.run_metadata_list[0].partition_graphs), 0)
 
+  def test_as_default(self):
+    with ops.Graph().as_default():
+      with monitored_session.MonitoredSession() as session:
+        self.assertEqual(None, ops.get_default_session())
+        with session.as_default():
+          self.assertEqual(session, ops.get_default_session())
+
 
 class SingularMonitoredSessionTest(test.TestCase):
   """Tests SingularMonitoredSession."""
@@ -1336,6 +1350,13 @@ class SingularMonitoredSessionTest(test.TestCase):
     with ops.Graph().as_default():
       with monitored_session.SingularMonitoredSession() as session:
         self.assertTrue(isinstance(session.raw_session(), session_lib.Session))
+
+  def test_as_default(self):
+    with ops.Graph().as_default():
+      with monitored_session.SingularMonitoredSession() as session:
+        self.assertEqual(None, ops.get_default_session())
+        with session.as_default():
+          self.assertEqual(session, ops.get_default_session())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Equivalent to `tf.Session.as_default()`, allows refetching the session from elsewhere in code using `tf.get_default_session()`.

Notes:
- (additive) public API change.
- If there is a better way to get the current session when using these `tf.Session` wrappers, this may be unnecessary. I just couldn't find it.
