### PR TITLE
Exposed more graph io methods

### DIFF
--- a/tensorflow/contrib/learn/__init__.py
+++ b/tensorflow/contrib/learn/__init__.py
@@ -73,6 +73,10 @@ See the @{$python/contrib.learn} guide.
 @@read_batch_examples
 @@read_batch_features
 @@read_batch_record_features
+@@read_keyed_batch_examples
+@@read_keyed_batch_examples_shared_queue
+@@read_keyed_batch_features
+@@read_keyed_batch_features_shared_queue
 
 @@InputFnOps
 @@ProblemType


### PR DESCRIPTION
I think these should probably be exposed since some of these are being used in examples, such as parsing utilities [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/estimator/canned/parsing_utils.py#L86). 