### PR TITLE
Add a custom tag for use by fusion ops

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_instruction.h
+++ b/tensorflow/compiler/xla/service/hlo_instruction.h
@@ -627,6 +627,16 @@ class HloInstruction {
     return fusion_kind_;
   }
 
+  unsigned int fusion_custom_tag() const {
+    CHECK_EQ(HloOpcode::kFusion, opcode_);
+    return fusion_custom_tag_;
+  }
+
+  void set_fusion_custom_tag(unsigned int tag) {
+    CHECK_EQ(HloOpcode::kFusion, opcode_);
+    fusion_custom_tag_ = tag;
+  }
+
   // Merges the fused instructions from 'instruction_to_merge' into the
   // fused instruction set of 'this', updating operands as necessary.
   //
@@ -945,6 +955,10 @@ class HloInstruction {
 
   // The type of the fusion. Used by kFusion only.
   FusionKind fusion_kind_;
+
+  // Tag for use by kFusion to provide arbitrary extra tagging of fused
+  // operations
+  unsigned int fusion_custom_tag_ = 0;
 
   // For parameter instructions this field holds the parameter number.
   int64 parameter_number_ = 0;


### PR DESCRIPTION
Currently when replacing an op with a fusion of many, the information which is carried by that fusion op is limited to a small fixed enumeration.

I have previously added a 'custom' entry to that enumeration, however it isn't really enough to label an arbitrary and non-fixed set of fuse results.

This adds a general integer that can be used by any back end to label fused ops arbitrarily.

There are other ways to achieve this:
- replacing the FusionKind enumeration with an integer field
- allowing read-write access to the metadata structure, and replacing it with something like a map
- some other thing I can't think of right now.

I'm happy to go with a different scheme, but I do think that the HloInstruction needs an annotation interface of some kind.



