### PR TITLE
Bump the required protobuf version for the pip package

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -34,7 +34,7 @@ _VERSION = '1.3.0-rc0'
 REQUIRED_PACKAGES = [
     'numpy >= 1.11.0',
     'six >= 1.10.0',
-    'protobuf >= 3.2.0',
+    'protobuf >= 3.3.0',
     'tensorflow-tensorboard',
 ]
 


### PR DESCRIPTION
Forgot to do this as part of https://github.com/tensorflow/tensorflow/pull/10660

Related: b/62969990