### PR TITLE
Fix web link to tool_developers guide

### DIFF
--- a/tensorflow/tools/graph_transforms/README.md
+++ b/tensorflow/tools/graph_transforms/README.md
@@ -764,7 +764,7 @@ heart, all of the transforms take in a valid GraphDef, make some changes, and
 output a new GraphDef. Each GraphDef is just a list of NodeDefs, each defining
 one node in the graph and its connections. You can find more information on the
 format at [this guide to TensorFlow model
-files](https://www.tensorflow.org/versions/master/how_tos/tool_developers/index.html),
+files](https://www.tensorflow.org/versions/master/extend/tool_developers/index.html),
 but for a simple example take a look at
 [tensorflow/tools/graph_transforms/rename_op.cc](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/graph_transforms/rename_op.cc),
 which implements the [rename_op](#rename_op) transform:


### PR DESCRIPTION
Fix web link in README.md by changing it from:
[https://www.tensorflow.org/versions/master/how_tos/tool_developers/index.html](https://www.tensorflow.org/versions/master/how_tos/tool_developers/index.html)
to:
[https://www.tensorflow.org/versions/master/extend/tool_developers/index.html](https://www.tensorflow.org/versions/master/extend/tool_developers/index.html)