### PR TITLE
Enable Android lib bazel build for mips and mips64

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,6 +32,9 @@ load("//tensorflow:workspace.bzl", "tf_workspace")
 #    name="androidndk",
 #    path="<PATH_TO_NDK>",
 #    # This needs to be 14 or higher to compile TensorFlow.
+#    # Please specify API level to >= 21 to build for 64-bit
+#    # archtectures or the Android NDK will automatically select biggest
+#    # API level that it supports without notice.
 #    # Note that the NDK version is not the API level.
 #    api_level=14)
 

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -64,6 +64,24 @@ config_setting(
 )
 
 config_setting(
+    name = "android_mips",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "mips",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "android_mips64",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "mips64",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "darwin",
     values = {"cpu": "darwin"},
     visibility = ["//visibility:public"],

--- a/tensorflow/contrib/android/BUILD
+++ b/tensorflow/contrib/android/BUILD
@@ -11,6 +11,7 @@ load(
     "//tensorflow:tensorflow.bzl",
     "tf_copts",
     "if_android",
+    "if_android_mips",
 )
 
 exports_files([
@@ -85,7 +86,7 @@ cc_binary(
         "-Wl,--gc-sections",
         "-Wl,--version-script",  # This line must be directly followed by LINKER_SCRIPT.
         LINKER_SCRIPT,
-    ]),
+    ]) + if_android_mips(["-latomic"]),
     linkshared = 1,
     linkstatic = 1,
     tags = [

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -64,6 +64,7 @@ load(
     "//tensorflow:tensorflow.bzl",
     "full_path",
     "if_android",
+    "if_not_android_mips_and_mips64",
     "if_ios",
     "if_linux_x86_64",
     "if_not_mobile",
@@ -933,9 +934,7 @@ filegroup(
 cc_library(
     name = "android_tensorflow_lib_lite",
     srcs = if_android(["//tensorflow/core:android_srcs"]),
-    copts = tf_copts() + [
-        "-Os",
-    ],
+    copts = tf_copts() + if_not_android_mips_and_mips64(["-Os"]),
     linkopts = ["-lz"],
     tags = [
         "manual",

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -72,9 +72,24 @@ def if_android_arm64(a):
   })
 
 
+def if_android_mips(a):
+  return select({
+      clean_dep("//tensorflow:android_mips"): a,
+      "//conditions:default": [],
+  })
+
+
 def if_not_android(a):
   return select({
       clean_dep("//tensorflow:android"): [],
+      "//conditions:default": a,
+  })
+
+
+def if_not_android_mips_and_mips64(a):
+  return select({
+      clean_dep("//tensorflow:android_mips"): [],
+      clean_dep("//tensorflow:android_mips64"): [],
       "//conditions:default": a,
   })
 


### PR DESCRIPTION
Currently the Android .so lib bazel build is failing for `--cpu=mips` and `--cpu=mips64`. This PR is fixing this.

The changes are:

- Add "-latomic" linkopt for `--cpu=mips`,  this is to avoid failing at the end for `undefined reference to '__atomic_*'` alike errors.
- Remove `-Os` optimization flag for `--cpu=mips` and `--cpu=mips64`, this is to avoid failing in compiling `tensorflow/core/lib/core/threadpool.o` for `failure memory model cannot be stronger than success memory model for '__atomic_compare_exchange'` errors.
- Added some hints in `tensorflow/workspace.bzl` for API level selection when compiling 64-bit lib.

By checking online, seems there is a bug in gcc compiler (at least the gcc inside NDK r12b, I did try using newer NDK version, however since r13b, the default compiler is changed to clang, and bazel is only working with clang with NDK r13b or higher, as well as currently, compiling Tensorflow with clang is failing for some strange errors to me, so it did not work), that in some cases, `-Os` flag would crash the compiling. Removing `-Os` for `--cpu=mips` and `--cpu=mips64` is only a sub-optimal solution as the generated .so lib will be relatively bigger (but not much).