### PR TITLE
GPU Tracer: Add peer-to-peer memcpy annotations

### DIFF
--- a/tensorflow/core/platform/default/gpu_tracer.cc
+++ b/tensorflow/core/platform/default/gpu_tracer.cc
@@ -54,6 +54,8 @@ const char *getMemcpyKindString(CUpti_ActivityMemcpyKind kind) {
       return "DtoD";
     case CUPTI_ACTIVITY_MEMCPY_KIND_HTOH:
       return "HtoH";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_PTOP:
+      return "PtoP";
     default:
       break;
   }
@@ -544,6 +546,15 @@ void GPUTracerImpl::ActivityCallback(const CUpti_Activity &record) {
           memcpy->dstKind, memcpy->bytes});
       break;
     }
+    case CUPTI_ACTIVITY_KIND_MEMCPY2: {
+      if (memcpy_records_.size() >= kMaxRecords) return;
+      auto *memcpy = reinterpret_cast<const CUpti_ActivityMemcpy2 *>(&record);
+      memcpy_records_.push_back(MemcpyRecord{
+          memcpy->start, memcpy->end, memcpy->deviceId, memcpy->streamId,
+          memcpy->correlationId, memcpy->copyKind, memcpy->srcKind,
+          memcpy->dstKind, memcpy->bytes});
+      break;
+    }
     case CUPTI_ACTIVITY_KIND_KERNEL:
     case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL: {
       if (kernel_records_.size() >= kMaxRecords) return;
@@ -554,6 +565,7 @@ void GPUTracerImpl::ActivityCallback(const CUpti_Activity &record) {
       break;
     }
     default:
+      VLOG(1) << "ActivityCallback unhandled kind";
       break;
   }
 }


### PR DESCRIPTION
In order to trace memory copies between devices with more recent versions of
CUDA, the GPU tracer must capture peer-to-peer (i.e. device-to-device) memory
transfers (e.g. cuMemcpyDtoD, cudaMemcpy(., ., ., cudaMemcpyDeviceToDevice)).
Add handling to capture these.