### PR TITLE
Support with statement for summary.FileWriter

### DIFF
--- a/tensorflow/python/summary/writer/writer.py
+++ b/tensorflow/python/summary/writer/writer.py
@@ -336,6 +336,14 @@ class FileWriter(SummaryToEventTransformer):
                                    filename_suffix)
     super(FileWriter, self).__init__(event_writer, graph, graph_def)
 
+  def __enter__(self):
+    """Make usable with "with" statement."""
+    return self
+
+  def __exit__(self, unused_type, unused_value, unused_traceback):
+    """Make usable with "with" statement."""
+    self.close()
+
   def get_logdir(self):
     """Returns the directory where event file will be written."""
     return self.event_writer.get_logdir()

--- a/tensorflow/python/summary/writer/writer_test.py
+++ b/tensorflow/python/summary/writer/writer_test.py
@@ -267,6 +267,13 @@ class SummaryWriterTestCase(test.TestCase):
     sw.close()
     self._assertRecent(time_before_close)
 
+  def testWithStatement(self):
+    test_dir = self._CleanTestDir("with_statement")
+    with writer.FileWriter(test_dir) as sw:
+      sw.add_session_log(event_pb2.SessionLog(status=SessionLog.START), 1)
+    event_paths = sorted(glob.glob(os.path.join(test_dir, "event*")))
+    self.assertEquals(1, len(event_paths))
+
   # Checks that values returned from session Run() calls are added correctly to
   # summaries.  These are numpy types so we need to check they fit in the
   # protocol buffers correctly.


### PR DESCRIPTION
This fix adds support of `with` for `summary.FileWriter`

This fix fixes #11750.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>