### PR TITLE
Fix error with default python path selection

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -175,7 +175,8 @@ def setup_python(environ_cp):
   if not python_lib_path:
     python_lib_paths = get_python_path(environ_cp)
     if environ_cp.get('USE_DEFAULT_PYTHON_LIB_PATH') == '1':
-      environ_cp['PYTHON_LIB_PATH'] = python_lib_paths[0]
+      python_lib_path = python_lib_paths[0]
+      environ_cp['PYTHON_LIB_PATH'] = python_lib_path
     else:
       print('Found possible Python library paths:\n%s' %
             '\n'.join(python_lib_paths))

--- a/configure.py
+++ b/configure.py
@@ -176,7 +176,6 @@ def setup_python(environ_cp):
     python_lib_paths = get_python_path(environ_cp)
     if environ_cp.get('USE_DEFAULT_PYTHON_LIB_PATH') == '1':
       python_lib_path = python_lib_paths[0]
-      environ_cp['PYTHON_LIB_PATH'] = python_lib_path
     else:
       print('Found possible Python library paths:\n%s' %
             '\n'.join(python_lib_paths))
@@ -186,7 +185,7 @@ def setup_python(environ_cp):
           % python_lib_paths[0])
       if not python_lib_path:
         python_lib_path = default_python_lib_path
-      environ_cp['PYTHON_LIB_PATH'] = python_lib_path
+    environ_cp['PYTHON_LIB_PATH'] = python_lib_path
 
   python_major_version = sys.version_info[0]
   # Convert python path to Windows style before writing into bazel.rc


### PR DESCRIPTION
When the env var USE_DEFAULT_PYTHON_LIB_PATH is set to 1, and there isn't PYTHON_LIB_PATH set, then the configure used to select the first entry that python itself returned.

this was broken recently. I suspect that it was a mistake rather than a deliberate choice.

