### PR TITLE
Adding disabling mechanism for plugins

### DIFF
--- a/tensorflow/compiler/tests/build_defs.bzl
+++ b/tensorflow/compiler/tests/build_defs.bzl
@@ -59,6 +59,9 @@ def tf_xla_py_test(name, srcs=[], deps=[], tags=[], data=[], main=None,
       backend_args += ["--test_device=" + plugins[backend]["device"],
                        "--types=" + plugins[backend]["types"]]
       backend_tags += plugins[backend]["tags"]
+      backend_args += plugins[backend]["args"]
+      backend_deps += plugins[backend]["deps"]
+      backend_data += plugins[backend]["data"]
     else:
       fail("Unknown backend {}".format(backend))
 

--- a/tensorflow/compiler/tests/plugin.bzl
+++ b/tensorflow/compiler/tests/plugin.bzl
@@ -18,6 +18,13 @@
 #   git update-index --assume-unchanged tensorflow/compiler/tests/plugin.bzl
 
 plugins = {
-  #"poplar": {"device":"XLA_IPU", "types":"DT_FLOAT,DT_INT32", "tags":[]},
+  #"example": {
+  #  "device":"XLA_MY_DEVICE",
+  #  "types":"DT_FLOAT,DT_HALF,DT_INT32",
+  #   "tags":[],
+  #   "args":["--disabled_manifest=tensorflow/compiler/plugin/example/disabled_manifest.txt"],
+  #   "data":["//tensorflow/compiler/plugin/example:disabled_manifest.txt"],
+  #   "deps":[],
+  #},
 }
 


### PR DESCRIPTION
This adds a scheme to allow 3rd party XLA drivers to disable python tests using the disabled-manifest mechanism already in existence.

