### PR TITLE
Fixes #11829: Faster to import tensorflow.contrib on Python 3

### DIFF
--- a/tensorflow/python/util/tf_decorator.py
+++ b/tensorflow/python/util/tf_decorator.py
@@ -83,7 +83,8 @@ def make_decorator(target,
     The `decorator_func` argument with new metadata attached.
   """
   if decorator_name is None:
-    decorator_name = _inspect.stack()[1][3]  # Caller's name.
+    prev_frame = _inspect.currentframe().f_back
+    decorator_name = _inspect.getframeinfo(prev_frame)[2]  # Caller's name.
   decorator = TFDecorator(decorator_name, target, decorator_doc,
                           decorator_argspec)
   setattr(decorator_func, '_tf_decorator', decorator)


### PR DESCRIPTION
As described in #11829, a lot of time is spent doing `inspect.stack()` when importing `import tensorflow.contrib` with Python 3. (There does not seem to be any issue with Python 2.)

By replacing `_inspect.stack()` with only getting the current and previous frame and then getting the frame info for just the previous frame, this unnecessary overhead is removed.

The time to import tensorflow.contrib, as reported by `time python2/3 -c "import tensorflow.contrib"` before and after my commit:

When|Python 2.7.13|Python 3.6.2|
------|-------------|-------------|
before|3.2|7.5|
after|3.1|3.3|

There are unit tests that would catch if the `decorator_name` would be incorrect after my change, specifically these tests:
* testSetsDecoratorNameToFunctionThatCallsMakeDecoratorIfAbsent
* testUnwrapReturnsDecoratorListFromOutermostToInnermost
* testUnwrapBoundMethods

All Python unit tests passed (in Docker). I didn't find any issues when linting the changed file.