### PR TITLE
Ensure that TensorBoard is still available when pip installed.

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -60,6 +60,11 @@ if sys.version_info < (3, 4):
 # pylint: disable=line-too-long
 CONSOLE_SCRIPTS = [
     'saved_model_cli = tensorflow.python.tools.saved_model_cli:main',
+    # We need to keep the TensorBoard command, even though the console script
+    # is now declared by the tensorboard pip package. If we remove the
+    # TensorBoard command, pip will inappropriately remove it during install,
+    # even though the command is not removed, just moved to a different wheel.
+    'tensorboard = tensorboard.main:main',
 ]
 # pylint: enable=line-too-long
 


### PR DESCRIPTION
Context:

After r1.2, TensorBoard moved out of the TensorFlow repository, into its own
repository and its own pip package (presently tensorflow-tensorboard, will later
switch to just tensorboard). The new pip package specifies the `tensorboard`
command, so I removed it from the list of console scripts forTensorFlow. I also
added tensorflow-tensorboard as a pip dependency.

However, it turns out that the pip order of operations is:
- install pip dependencies (thus getting tensorflow-tensorboard and the new
  tensorboard command)
- remove deprecated console scripts (thus erroneously removing the new pointer
  to tensorboard)

To fix this, I returned the `tensorboard` console script to tensorflow's
setup.py, except it now references the tensorboard package rather than the
tensorflow package. Thus, the console script declaration in tensorflow and
tensorboard are identical. We can be confident that the tensorboard package is
available, because it is specified by the pip dependency.

Test Plan:

- Create a clean virtualenv.
- pip install tensorflow < 1.3.
- verify that the tensorboard command works properly
- pip install tensorflow 1.3 using a pip package generated with this change
- verify that the tensorboard command still works

This is the fix for master. I sent a separate PR to move this fix into r1.3