### PR TITLE
[XLA] RNG root instruction can be fused as it effectively has one user

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -1759,7 +1759,7 @@ bool HloInstruction::IsFusable() const {
     // Only fuse Rng if it is used once, otherwise the random numbers generated
     // will be different in each fusion.
     case HloOpcode::kRng:
-      return users_.size() == 1;
+      return users_.size() <= 1;
     default:
       return true;
   }

--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -1757,7 +1757,8 @@ bool HloInstruction::IsFusable() const {
     case HloOpcode::kRecv:
       return false;
     // Only fuse Rng if it is used once, otherwise the random numbers generated
-    // will be different in each fusion.
+    // will be different in each fusion. If it is the root (user count = 0)
+    // then it is the equivalent of having one user.
     case HloOpcode::kRng:
       return users_.size() <= 1;
     default:


### PR DESCRIPTION
The existing test checks for a single user when trying to fuse a random number generator instruction.   This is because if it is fused but has multiple users, the value may be generated an incorrect number of times.  (multiple users should receive the same random number, not different ones).

The test checks for users() length == 1.  This ignores the case there the instruction is the root, where users() length == 0, but there is effectively one user.