### PR TITLE
Android demo: Explicitly import R.java

### DIFF
--- a/tensorflow/examples/android/src/org/tensorflow/demo/CameraActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/CameraActivity.java
@@ -45,7 +45,7 @@ import java.nio.ByteBuffer;
 import org.tensorflow.demo.env.ImageUtils;
 import org.tensorflow.demo.env.Logger;
 
-// Eplicit import needed for internal Google builds.
+// Explicit import needed for internal Google builds.
 import org.tensorflow.demo.R;
 
 public abstract class CameraActivity extends Activity implements OnImageAvailableListener, Camera.

--- a/tensorflow/examples/android/src/org/tensorflow/demo/CameraActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/CameraActivity.java
@@ -45,6 +45,9 @@ import java.nio.ByteBuffer;
 import org.tensorflow.demo.env.ImageUtils;
 import org.tensorflow.demo.env.Logger;
 
+// Eplicit import needed for internal Google builds.
+import org.tensorflow.demo.R;
+
 public abstract class CameraActivity extends Activity implements OnImageAvailableListener, Camera.
         PreviewCallback {
   private static final Logger LOGGER = new Logger();

--- a/tensorflow/examples/android/src/org/tensorflow/demo/ClassifierActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/ClassifierActivity.java
@@ -36,7 +36,7 @@ import org.tensorflow.demo.env.BorderedText;
 import org.tensorflow.demo.env.ImageUtils;
 import org.tensorflow.demo.env.Logger;
 
-// Eplicit import needed for internal Google builds.
+// Explicit import needed for internal Google builds.
 import org.tensorflow.demo.R;
 
 public class ClassifierActivity extends CameraActivity implements OnImageAvailableListener {

--- a/tensorflow/examples/android/src/org/tensorflow/demo/ClassifierActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/ClassifierActivity.java
@@ -36,6 +36,9 @@ import org.tensorflow.demo.env.BorderedText;
 import org.tensorflow.demo.env.ImageUtils;
 import org.tensorflow.demo.env.Logger;
 
+// Eplicit import needed for internal Google builds.
+import org.tensorflow.demo.R;
+
 public class ClassifierActivity extends CameraActivity implements OnImageAvailableListener {
   private static final Logger LOGGER = new Logger();
 

--- a/tensorflow/examples/android/src/org/tensorflow/demo/LegacyCameraConnectionFragment.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/LegacyCameraConnectionFragment.java
@@ -35,6 +35,9 @@ import android.hardware.Camera.CameraInfo;
 
 import org.tensorflow.demo.env.Logger;
 
+// Eplicit import needed for internal Google builds.
+import org.tensorflow.demo.R;
+
 public class LegacyCameraConnectionFragment extends Fragment {
 
   private Camera camera;

--- a/tensorflow/examples/android/src/org/tensorflow/demo/LegacyCameraConnectionFragment.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/LegacyCameraConnectionFragment.java
@@ -35,7 +35,7 @@ import android.hardware.Camera.CameraInfo;
 
 import org.tensorflow.demo.env.Logger;
 
-// Eplicit import needed for internal Google builds.
+// Explicit import needed for internal Google builds.
 import org.tensorflow.demo.R;
 
 public class LegacyCameraConnectionFragment extends Fragment {

--- a/tensorflow/examples/android/src/org/tensorflow/demo/StylizeActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/StylizeActivity.java
@@ -60,7 +60,7 @@ import org.tensorflow.demo.env.BorderedText;
 import org.tensorflow.demo.env.ImageUtils;
 import org.tensorflow.demo.env.Logger;
 
-// Eplicit import needed for internal Google builds.
+// Explicit import needed for internal Google builds.
 import org.tensorflow.demo.R;
 
 /**

--- a/tensorflow/examples/android/src/org/tensorflow/demo/StylizeActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/StylizeActivity.java
@@ -60,6 +60,9 @@ import org.tensorflow.demo.env.BorderedText;
 import org.tensorflow.demo.env.ImageUtils;
 import org.tensorflow.demo.env.Logger;
 
+// Eplicit import needed for internal Google builds.
+import org.tensorflow.demo.R;
+
 /**
  * Sample activity that stylizes the camera preview according to "A Learned Representation For
  * Artistic Style" (https://arxiv.org/abs/1610.07629)


### PR DESCRIPTION
Add explicit import of the R class to fix Google-internal Android demo builds.