### PR TITLE
Bug in builds/pip.sh causes failure if NO_TEST_ON_INSTALL=1

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip.sh
+++ b/tensorflow/tools/ci_build/builds/pip.sh
@@ -354,7 +354,7 @@ do_virtualenv_pip_test() {
   # Create virtualenv directory for install test
   VENV_DIR="${PIP_TEST_ROOT}/venv"
   create_activate_virtualenv_and_install_tensorflow \
-    "${CLEAN_VENV_DIR}" "${WHL_PATH}"
+    "${VENV_DIR}" "${WHL_PATH}"
 
   # Install extra pip packages required by the test-on-install
   for PACKAGE in ${INSTALL_EXTRA_PIP_PACKAGES}; do


### PR DESCRIPTION
do_virtualenv_pip_test() uses ${CLEAN_VENV_DIR} which is defined in
do_clean_virtualenv_smoke_test(). But if NO_TEST_ON_INSTALL is set to 1
${CLEAN_VENV_DIR} would never be defined, and pip.sh will fail.

It is very likely that we actually meant to use ${VENV_DIR} instead.