### PR TITLE
[XLA] Remove overly chatty output in fusion operation

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -561,7 +561,7 @@ HloInstruction* HloInstruction::CloneAndFuseInternal(
   CHECK_EQ(opcode_, HloOpcode::kFusion);
   CHECK(instruction_to_fuse->IsFusable());
   if (GetModule()) {
-    XLA_VLOG_LINES(1, GetModule()->ToString());
+    XLA_VLOG_LINES(3, GetModule()->ToString());
   }
   HloInstruction* clone = nullptr;
   if (called_computations_.empty()) {


### PR DESCRIPTION
when fusing a lot of operations in a large graph, this trace produces a lot of output.  It isn't really output that is helpful when trying to trace the high level operations occuring.  Perhaps it is better at a lower log level?

