### PR TITLE
Determinant-operation on the GPU

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2159,7 +2159,7 @@ tf_kernel_library(
 tf_kernel_library(
     name = "determinant_op",
     prefix = "determinant_op",
-    deps = LINALG_DEPS,
+    deps = LINALG_DEPS + if_cuda([":cuda_solvers"]),
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/cholesky_op.cc
+++ b/tensorflow/core/kernels/cholesky_op.cc
@@ -174,6 +174,10 @@ REGISTER_LINALG_OP_GPU("Cholesky", (CholeskyOpGpu<float>), float);
 REGISTER_LINALG_OP_GPU("Cholesky", (CholeskyOpGpu<double>), double);
 REGISTER_LINALG_OP_GPU("Cholesky", (CholeskyOpGpu<complex64>), complex64);
 REGISTER_LINALG_OP_GPU("Cholesky", (CholeskyOpGpu<complex128>), complex128);
+REGISTER_LINALG_OP_GPU("BatchCholesky", (CholeskyOpGpu<float>), float);
+REGISTER_LINALG_OP_GPU("BatchCholesky", (CholeskyOpGpu<double>), double);
+REGISTER_LINALG_OP_GPU("BatchCholesky", (CholeskyOpGpu<float>), complex64);
+REGISTER_LINALG_OP_GPU("BatchCholesky", (CholeskyOpGpu<double>), complex128);
 
 #endif  // GOOGLE_CUDA
 

--- a/tensorflow/core/kernels/cuda_solvers.cc
+++ b/tensorflow/core/kernels/cuda_solvers.cc
@@ -202,6 +202,8 @@ Status CudaSolver::CopyLapackInfoToHostAsync(
 // numeric types.
 #define TF_CALL_LAPACK_TYPES(m) \
   m(float, S) m(double, D) m(std::complex<float>, C) m(std::complex<double>, Z)
+#define TF_CALL_LAPACK_TYPES_NO_COMPLEX(m) \
+  m(float, S) m(double, D)
 
 // Macros to construct cusolverDn method names.
 #define DN_SOLVER_FN(method, lapack_prefix) cusolverDn##lapack_prefix##method
@@ -251,6 +253,43 @@ static inline Status PotrfImpl(BufSizeFnT bufsize, SolverFnT solver,
   }
 
 TF_CALL_LAPACK_TYPES(POTRF_INSTANCE);
+
+
+template <typename Scalar, typename BufSizeFnT, typename SolverFnT>
+static inline Status GetrfImpl(BufSizeFnT bufsize, SolverFnT solver,
+                               OpKernelContext* context,
+                               cusolverDnHandle_t cusolver_dn_handle,
+                               int m, int n, Scalar* A,
+                               int lda,
+                               int* dev_ipiv, int* dev_lapack_info) {
+  /* Get amount of workspace memory required. */
+  int lwork;
+  TF_RETURN_IF_CUSOLVER_ERROR(
+      bufsize(cusolver_dn_handle, m, n, A, lda, &lwork));
+  /* Allocate device memory for workspace. */
+  ScratchSpace<Scalar> dev_workspace(context, lwork, /* on_host */ false);
+  /* Launch the solver kernel. */
+  TF_RETURN_IF_CUSOLVER_ERROR(solver(
+      cusolver_dn_handle, 
+      m, n, CUDAComplex(A), lda, 
+      CUDAComplex(dev_workspace.mutable_data()), dev_ipiv, dev_lapack_info));
+  return Status::OK();
+}
+
+#define GETRF_INSTANCE(Scalar, lapack_prefix)                                \
+  template <>                                                                \
+  Status CudaSolver::Getrf<Scalar>(                                          \
+             int m, int n, Scalar* dev_A, int lda,                           \
+             int* dev_ipiv, int* dev_lapack_info) const {                    \
+    return GetrfImpl(DN_BUFSIZE_FN(getrf, lapack_prefix),                    \
+                     DN_SOLVER_FN(getrf, lapack_prefix), context_,           \
+                     cusolver_dn_handle_,                                    \
+                     m, n, dev_A, lda,                                       \
+                     dev_ipiv, dev_lapack_info);                             \
+  }
+
+TF_CALL_LAPACK_TYPES_NO_COMPLEX(GETRF_INSTANCE);
+
 
 template <typename Scalar, typename SolverFnT>
 static inline Status GeamImpl(SolverFnT solver, cublasHandle_t cublas_handle,

--- a/tensorflow/core/kernels/cuda_solvers.cc
+++ b/tensorflow/core/kernels/cuda_solvers.cc
@@ -171,25 +171,25 @@ Status CudaSolver::CopyLapackInfoToHostAsync(
 
   // This callback checks that all batch items in all calls were processed
   // successfully and passes status to the info_checker_callback accordingly.
-  auto wrapped_info_checker_callback =
-      [info_checker_callback](std::vector<HostLapackInfo> host_lapack_infos) {
-        Status status;
-        for (const auto& host_lapack_info : host_lapack_infos) {
-          for (int i = 0; i < host_lapack_info.size() && status.ok(); ++i) {
-            const int info_value = (host_lapack_info.data())[i];
-            if (info_value != 0) {
-              status = errors::InvalidArgument(
-                  "Got info = ", info_value, " for batch index ", i,
-                  ", expected info = 0. Debug_info =",
-                  host_lapack_info.debug_info());
-            }
-          }
-          if (!status.ok()) {
-            break;
-          }
+  auto wrapped_info_checker_callback = [info_checker_callback](
+      std::vector<HostLapackInfo> host_lapack_infos) {
+    Status status;
+    for (const auto& host_lapack_info : host_lapack_infos) {
+      for (int i = 0; i < host_lapack_info.size() && status.ok(); ++i) {
+        const int info_value = (host_lapack_info.data())[i];
+        if (info_value != 0) {
+          status = errors::InvalidArgument("Got info = ", info_value,
+                                           " for batch index ", i,
+                                           ", expected info = 0. Debug_info =",
+                                           host_lapack_info.debug_info());
         }
-        info_checker_callback(status, host_lapack_infos);
-      };
+      }
+      if (!status.ok()) {
+        break;
+      }
+    }
+    info_checker_callback(status, host_lapack_infos);
+  };
   auto cb =
       std::bind(wrapped_info_checker_callback, std::move(host_lapack_infos));
   auto stream = context_->op_device_context()->stream();
@@ -202,8 +202,7 @@ Status CudaSolver::CopyLapackInfoToHostAsync(
 // numeric types.
 #define TF_CALL_LAPACK_TYPES(m) \
   m(float, S) m(double, D) m(std::complex<float>, C) m(std::complex<double>, Z)
-#define TF_CALL_LAPACK_TYPES_NO_COMPLEX(m) \
-  m(float, S) m(double, D)
+#define TF_CALL_LAPACK_TYPES_NO_COMPLEX(m) m(float, S) m(double, D)
 
 // Macros to construct cusolverDn method names.
 #define DN_SOLVER_FN(method, lapack_prefix) cusolverDn##lapack_prefix##method
@@ -254,14 +253,12 @@ static inline Status PotrfImpl(BufSizeFnT bufsize, SolverFnT solver,
 
 TF_CALL_LAPACK_TYPES(POTRF_INSTANCE);
 
-
 template <typename Scalar, typename BufSizeFnT, typename SolverFnT>
 static inline Status GetrfImpl(BufSizeFnT bufsize, SolverFnT solver,
                                OpKernelContext* context,
-                               cusolverDnHandle_t cusolver_dn_handle,
-                               int m, int n, Scalar* A,
-                               int lda,
-                               int* dev_ipiv, int* dev_lapack_info) {
+                               cusolverDnHandle_t cusolver_dn_handle, int m,
+                               int n, Scalar* A, int lda, int* dev_ipiv,
+                               int* dev_lapack_info) {
   /* Get amount of workspace memory required. */
   int lwork;
   TF_RETURN_IF_CUSOLVER_ERROR(
@@ -270,26 +267,23 @@ static inline Status GetrfImpl(BufSizeFnT bufsize, SolverFnT solver,
   ScratchSpace<Scalar> dev_workspace(context, lwork, /* on_host */ false);
   /* Launch the solver kernel. */
   TF_RETURN_IF_CUSOLVER_ERROR(solver(
-      cusolver_dn_handle, 
-      m, n, CUDAComplex(A), lda, 
+      cusolver_dn_handle, m, n, CUDAComplex(A), lda,
       CUDAComplex(dev_workspace.mutable_data()), dev_ipiv, dev_lapack_info));
   return Status::OK();
 }
 
-#define GETRF_INSTANCE(Scalar, lapack_prefix)                                \
-  template <>                                                                \
-  Status CudaSolver::Getrf<Scalar>(                                          \
-             int m, int n, Scalar* dev_A, int lda,                           \
-             int* dev_ipiv, int* dev_lapack_info) const {                    \
-    return GetrfImpl(DN_BUFSIZE_FN(getrf, lapack_prefix),                    \
-                     DN_SOLVER_FN(getrf, lapack_prefix), context_,           \
-                     cusolver_dn_handle_,                                    \
-                     m, n, dev_A, lda,                                       \
-                     dev_ipiv, dev_lapack_info);                             \
+#define GETRF_INSTANCE(Scalar, lapack_prefix)                            \
+  template <>                                                            \
+  Status CudaSolver::Getrf<Scalar>(int m, int n, Scalar* dev_A, int lda, \
+                                   int* dev_ipiv, int* dev_lapack_info)  \
+      const {                                                            \
+    return GetrfImpl(DN_BUFSIZE_FN(getrf, lapack_prefix),                \
+                     DN_SOLVER_FN(getrf, lapack_prefix), context_,       \
+                     cusolver_dn_handle_, m, n, dev_A, lda, dev_ipiv,    \
+                     dev_lapack_info);                                   \
   }
 
 TF_CALL_LAPACK_TYPES_NO_COMPLEX(GETRF_INSTANCE);
-
 
 template <typename Scalar, typename SolverFnT>
 static inline Status GeamImpl(SolverFnT solver, cublasHandle_t cublas_handle,

--- a/tensorflow/core/kernels/cuda_solvers.h
+++ b/tensorflow/core/kernels/cuda_solvers.h
@@ -176,7 +176,8 @@ class CudaSolver {
   template <typename Scalar>
   Status Potrs(cublasFillMode_t uplo, int n, int nrhs, const Scalar* dev_A, int
   lda, Scalar* dev_B, int ldb, int* dev_lapack_info) const;
-
+  */
+ 
   // LU factorization.
   // Computes LU factorization with partial pivoting P * A = L * U.
   // See: http://docs.nvidia.com/cuda/cusolver/#cuds-lt-t-gt-getrf
@@ -184,6 +185,7 @@ class CudaSolver {
   Status Getrf(int m, int n, Scalar* dev_A, int lda, int* dev_pivots,
              int* dev_lapack_info) const;
 
+  /*
   // Uses LU factorization to solve A * X = B.
   // See: http://docs.nvidia.com/cuda/cusolver/#cuds-lt-t-gt-getrs
   template <typename Scalar>

--- a/tensorflow/core/kernels/cuda_solvers.h
+++ b/tensorflow/core/kernels/cuda_solvers.h
@@ -177,13 +177,13 @@ class CudaSolver {
   Status Potrs(cublasFillMode_t uplo, int n, int nrhs, const Scalar* dev_A, int
   lda, Scalar* dev_B, int ldb, int* dev_lapack_info) const;
   */
- 
+
   // LU factorization.
   // Computes LU factorization with partial pivoting P * A = L * U.
   // See: http://docs.nvidia.com/cuda/cusolver/#cuds-lt-t-gt-getrf
   template <typename Scalar>
   Status Getrf(int m, int n, Scalar* dev_A, int lda, int* dev_pivots,
-             int* dev_lapack_info) const;
+               int* dev_lapack_info) const;
 
   /*
   // Uses LU factorization to solve A * X = B.

--- a/tensorflow/core/kernels/determinant_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/determinant_op_gpu.cu.cc
@@ -1,0 +1,231 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA
+
+// See docs in ../ops/linalg_ops.cc.
+#include <cmath>
+
+#include "tensorflow/core/framework/kernel_def_builder.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/kernels/linalg_ops_common.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/types.h"
+
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "tensorflow/core/kernels/cuda_solvers.h"
+#include "tensorflow/core/platform/stream_executor.h"
+#include "cuda/include/thrust/device_ptr.h"
+#include "cuda/include/thrust/fill.h"
+#include "cuda/include/thrust/reduce.h"
+#include "cuda/include/thrust/tuple.h"
+#include "cuda/include/thrust/iterator/zip_iterator.h"
+#include "cuda/include/thrust/iterator/counting_iterator.h"
+#include "cuda/include/thrust/functional.h"
+
+
+typedef Eigen::GpuDevice GPUDevice;
+
+namespace tensorflow {
+
+namespace {
+//https://stackoverflow.com/a/29485908
+template <typename Iterator>
+class strided_range
+{
+    public:
+
+    typedef typename thrust::iterator_difference<Iterator>::type difference_type;
+
+    struct stride_functor : public thrust::unary_function<difference_type,difference_type>
+    {
+        difference_type stride;
+
+        stride_functor(difference_type stride)
+            : stride(stride) {}
+
+        __host__ __device__
+        difference_type operator()(const difference_type& i) const
+        {
+            return stride * i;
+        }
+    };
+
+    typedef typename thrust::counting_iterator<difference_type>                   CountingIterator;
+    typedef typename thrust::transform_iterator<stride_functor, CountingIterator> TransformIterator;
+    typedef typename thrust::permutation_iterator<Iterator,TransformIterator>     PermutationIterator;
+
+    // type of the strided_range iterator
+    typedef PermutationIterator iterator;
+
+    // construct strided_range for the range [first,last)
+    strided_range(Iterator first, Iterator last, difference_type stride)
+        : first(first), last(last), stride(stride) {}
+
+    iterator begin(void) const
+    {
+        return PermutationIterator(first, TransformIterator(CountingIterator(0), stride_functor(stride)));
+    }
+
+    iterator end(void) const
+    {
+        return begin() + ((last - first) + (stride - 1)) / stride;
+    }
+
+    protected:
+    Iterator first;
+    Iterator last;
+    difference_type stride;
+};
+
+// This took some experiments, cuSolver stores the permutation in a very strange way.
+struct compute_parity : public thrust::unary_function<int, int>
+{
+    int* perm;
+    int n;
+    compute_parity(int* perm, int n) : perm(perm), n(n) {}
+    __device__ int32 operator()(int i) {
+        int pi = perm[i];
+        return (i+1 != pi) ? -1 : 1;
+    }
+};
+
+}
+
+template <class Scalar>
+class DeterminantOpGpu : public OpKernel {
+ public:
+  explicit DeterminantOpGpu(OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) final {
+    const Tensor& input = context->input(0);
+    const int ndims = input.dims();
+    const int64 n = input.dim_size(ndims - 1);
+    // Validate inputs.
+    OP_REQUIRES(
+        context, ndims >= 2,
+        errors::InvalidArgument("Input must have rank >= 2, got ", ndims));
+    OP_REQUIRES(
+        context, input.dim_size(ndims - 2) == n,
+        errors::InvalidArgument("Input matrices must be squares, got",
+                                input.dim_size(ndims - 2), " != ", n));
+
+    // Allocate output.
+    Tensor* output;
+    TensorShape outputShape = input.shape();
+    outputShape.RemoveDim(outputShape.dims()-1); //remove matrix dimension,
+    outputShape.RemoveDim(outputShape.dims()-1); //leave only batch shape
+    OP_REQUIRES_OK(context,
+                   context->allocate_output(
+                   0, outputShape, &output));
+    Scalar* outputData = output->flat<Scalar>().data();
+
+    if (n == 0) {
+      // If X is an empty matrix (0 rows, 0 col),
+      // the determinant is one by definition
+      for (int64 i=0; i<outputShape.num_elements(); ++i) {
+          outputData[i] = 1;
+      }
+      return;
+    }
+ 
+    // This tensor will hold the intermediate LU factorization
+    Tensor lu;
+    OP_REQUIRES_OK(context,
+                   context->allocate_temp(
+                   output->dtype(), TensorShape({n,n}), &lu));
+    Scalar* lu_ptr = lu.flat<Scalar>().data();
+    Tensor pivot;
+    OP_REQUIRES_OK(context,
+                   context->allocate_temp(
+                   DT_INT32, TensorShape({n}), &pivot));
+    int* pivot_ptr = pivot.flat<int>().data();
+
+    auto input_reshaped = input.template flat_inner_dims<Scalar, 3>();
+    auto output_reshaped = output->template flat_inner_dims<Scalar, 1>();
+
+    // Launch a Cholesky kernel for each matrix in the batch.
+    const int64 batch_size = input_reshaped.dimension(0);
+    int* dev_info_ptr;
+    cudaMalloc(&dev_info_ptr, sizeof(int));
+    // TODO(rmlarsen): Parallelize over batches if it turns out to be
+    // an important use case.
+    Scalar* output_ptr = output_reshaped.data();
+    CudaSolver solver(context);
+    for (int64 i = 0; i < batch_size; ++i) {
+      const Scalar* input_ptr = input_reshaped.data() + i * n * n;
+      
+      //1. copy sub-matrix to temp memory
+      cudaMemcpy(lu_ptr, input_ptr, sizeof(Scalar) * n * n, cudaMemcpyDeviceToDevice);
+      
+      //2. perform LU factorization
+      OP_REQUIRES_OK(
+          context,
+          solver.Getrf(n, n, lu_ptr, n, pivot_ptr, dev_info_ptr));
+      int host_info;
+      cudaMemcpy(&host_info, dev_info_ptr, sizeof(int), cudaMemcpyDeviceToHost);
+      
+      OP_REQUIRES(context, host_info >= 0, 
+            errors::InvalidArgument("LU factorization failed for batch ", i,
+                                ", error code: ", host_info));
+    
+      if (host_info > 0) {
+          //singular matrix -> determinant is zero
+          output_ptr[i] = 0;
+          continue;
+      }
+          
+      //3. perform a strided reduction to multiply the diagonal entries together
+      //   https://stackoverflow.com/a/29485908
+      int stride = n + 1;
+      thrust::device_ptr<Scalar> dev_ptr(lu_ptr);
+      strided_range<thrust::device_ptr<Scalar>> pos(dev_ptr, dev_ptr + n * n, stride);
+      Scalar det = thrust::reduce(pos.begin(), pos.end(), (Scalar) 1, thrust::multiplies<Scalar>());
+      
+      //4. compute the sign of the permutation
+      thrust::counting_iterator<int> counting_it(0);
+      auto transform_it = thrust::make_transform_iterator(counting_it, compute_parity(pivot_ptr, n));
+      int sign = thrust::reduce(transform_it, transform_it + n, 1, thrust::multiplies<int>());
+      
+      det *= sign;
+      
+      //5. Set output
+      output_ptr[i] = det;
+    }
+
+  }
+};
+
+#define REGISTER_DETERMINANT_OP(OpName, Scalar)  \
+    REGISTER_KERNEL_BUILDER(                     \
+      Name(OpName)                               \
+      .Device(DEVICE_GPU)                        \
+      .TypeConstraint<Scalar>("T")               \
+      .HostMemory("output"),                     \
+     DeterminantOpGpu<Scalar>)
+
+REGISTER_DETERMINANT_OP("MatrixDeterminant", float);
+REGISTER_DETERMINANT_OP("MatrixDeterminant", double);
+REGISTER_DETERMINANT_OP("BatchMatrixDeterminant", float);
+REGISTER_DETERMINANT_OP("BatchMatrixDeterminant", double);
+
+#undef REGISTER_DETERMINANT_OP
+
+}
+
+#endif  // GOOGLE_CUDA

--- a/tensorflow/core/kernels/determinant_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/determinant_op_gpu.cu.cc
@@ -26,84 +26,79 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/types.h"
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
-#include "tensorflow/core/kernels/cuda_solvers.h"
-#include "tensorflow/core/platform/stream_executor.h"
 #include "cuda/include/thrust/device_ptr.h"
 #include "cuda/include/thrust/fill.h"
+#include "cuda/include/thrust/functional.h"
+#include "cuda/include/thrust/iterator/counting_iterator.h"
+#include "cuda/include/thrust/iterator/zip_iterator.h"
 #include "cuda/include/thrust/reduce.h"
 #include "cuda/include/thrust/tuple.h"
-#include "cuda/include/thrust/iterator/zip_iterator.h"
-#include "cuda/include/thrust/iterator/counting_iterator.h"
-#include "cuda/include/thrust/functional.h"
-
+#include "tensorflow/core/kernels/cuda_solvers.h"
+#include "tensorflow/core/platform/stream_executor.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 typedef Eigen::GpuDevice GPUDevice;
 
 namespace tensorflow {
 
 namespace {
-//https://stackoverflow.com/a/29485908
+// https://stackoverflow.com/a/29485908
 template <typename Iterator>
-class strided_range
-{
-    public:
+class strided_range {
+ public:
+  typedef typename thrust::iterator_difference<Iterator>::type difference_type;
 
-    typedef typename thrust::iterator_difference<Iterator>::type difference_type;
-
-    struct stride_functor : public thrust::unary_function<difference_type,difference_type>
-    {
-        difference_type stride;
-
-        stride_functor(difference_type stride)
-            : stride(stride) {}
-
-        __host__ __device__
-        difference_type operator()(const difference_type& i) const
-        {
-            return stride * i;
-        }
-    };
-
-    typedef typename thrust::counting_iterator<difference_type>                   CountingIterator;
-    typedef typename thrust::transform_iterator<stride_functor, CountingIterator> TransformIterator;
-    typedef typename thrust::permutation_iterator<Iterator,TransformIterator>     PermutationIterator;
-
-    // type of the strided_range iterator
-    typedef PermutationIterator iterator;
-
-    // construct strided_range for the range [first,last)
-    strided_range(Iterator first, Iterator last, difference_type stride)
-        : first(first), last(last), stride(stride) {}
-
-    iterator begin(void) const
-    {
-        return PermutationIterator(first, TransformIterator(CountingIterator(0), stride_functor(stride)));
-    }
-
-    iterator end(void) const
-    {
-        return begin() + ((last - first) + (stride - 1)) / stride;
-    }
-
-    protected:
-    Iterator first;
-    Iterator last;
+  struct stride_functor
+      : public thrust::unary_function<difference_type, difference_type> {
     difference_type stride;
-};
 
-// This took some experiments, cuSolver stores the permutation in a very strange way.
-struct compute_parity : public thrust::unary_function<int, int>
-{
-    int* perm;
-    int n;
-    compute_parity(int* perm, int n) : perm(perm), n(n) {}
-    __device__ int32 operator()(int i) {
-        int pi = perm[i];
-        return (i+1 != pi) ? -1 : 1;
+    stride_functor(difference_type stride) : stride(stride) {}
+
+    __host__ __device__ difference_type
+    operator()(const difference_type& i) const {
+      return stride * i;
     }
+  };
+
+  typedef typename thrust::counting_iterator<difference_type> CountingIterator;
+  typedef typename thrust::transform_iterator<stride_functor, CountingIterator>
+      TransformIterator;
+  typedef typename thrust::permutation_iterator<Iterator, TransformIterator>
+      PermutationIterator;
+
+  // type of the strided_range iterator
+  typedef PermutationIterator iterator;
+
+  // construct strided_range for the range [first,last)
+  strided_range(Iterator first, Iterator last, difference_type stride)
+      : first(first), last(last), stride(stride) {}
+
+  iterator begin(void) const {
+    return PermutationIterator(
+        first, TransformIterator(CountingIterator(0), stride_functor(stride)));
+  }
+
+  iterator end(void) const {
+    return begin() + ((last - first) + (stride - 1)) / stride;
+  }
+
+ protected:
+  Iterator first;
+  Iterator last;
+  difference_type stride;
 };
 
+// This took some experiments, cuSolver stores the permutation in a very strange
+// way.
+struct compute_parity : public thrust::unary_function<int, int> {
+  int* perm;
+  int n;
+  compute_parity(int* perm, int n) : perm(perm), n(n) {}
+  __device__ int32 operator()(int i) {
+    int pi = perm[i];
+    return (i + 1 != pi) ? -1 : 1;
+  }
+};
 }
 
 template <class Scalar>
@@ -120,40 +115,35 @@ class DeterminantOpGpu : public OpKernel {
     OP_REQUIRES(
         context, ndims >= 2,
         errors::InvalidArgument("Input must have rank >= 2, got ", ndims));
-    OP_REQUIRES(
-        context, input.dim_size(ndims - 2) == n,
-        errors::InvalidArgument("Input matrices must be squares, got",
-                                input.dim_size(ndims - 2), " != ", n));
+    OP_REQUIRES(context, input.dim_size(ndims - 2) == n,
+                errors::InvalidArgument("Input matrices must be squares, got",
+                                        input.dim_size(ndims - 2), " != ", n));
 
     // Allocate output.
     Tensor* output;
     TensorShape outputShape = input.shape();
-    outputShape.RemoveDim(outputShape.dims()-1); //remove matrix dimension,
-    outputShape.RemoveDim(outputShape.dims()-1); //leave only batch shape
-    OP_REQUIRES_OK(context,
-                   context->allocate_output(
-                   0, outputShape, &output));
+    outputShape.RemoveDim(outputShape.dims() - 1);  // remove matrix dimension,
+    outputShape.RemoveDim(outputShape.dims() - 1);  // leave only batch shape
+    OP_REQUIRES_OK(context, context->allocate_output(0, outputShape, &output));
     Scalar* outputData = output->flat<Scalar>().data();
 
     if (n == 0) {
       // If X is an empty matrix (0 rows, 0 col),
       // the determinant is one by definition
-      for (int64 i=0; i<outputShape.num_elements(); ++i) {
-          outputData[i] = 1;
+      for (int64 i = 0; i < outputShape.num_elements(); ++i) {
+        outputData[i] = 1;
       }
       return;
     }
- 
+
     // This tensor will hold the intermediate LU factorization
     Tensor lu;
-    OP_REQUIRES_OK(context,
-                   context->allocate_temp(
-                   output->dtype(), TensorShape({n,n}), &lu));
+    OP_REQUIRES_OK(context, context->allocate_temp(output->dtype(),
+                                                   TensorShape({n, n}), &lu));
     Scalar* lu_ptr = lu.flat<Scalar>().data();
     Tensor pivot;
     OP_REQUIRES_OK(context,
-                   context->allocate_temp(
-                   DT_INT32, TensorShape({n}), &pivot));
+                   context->allocate_temp(DT_INT32, TensorShape({n}), &pivot));
     int* pivot_ptr = pivot.flat<int>().data();
 
     auto input_reshaped = input.template flat_inner_dims<Scalar, 3>();
@@ -169,55 +159,58 @@ class DeterminantOpGpu : public OpKernel {
     CudaSolver solver(context);
     for (int64 i = 0; i < batch_size; ++i) {
       const Scalar* input_ptr = input_reshaped.data() + i * n * n;
-      
-      //1. copy sub-matrix to temp memory
-      cudaMemcpy(lu_ptr, input_ptr, sizeof(Scalar) * n * n, cudaMemcpyDeviceToDevice);
-      
-      //2. perform LU factorization
-      OP_REQUIRES_OK(
-          context,
-          solver.Getrf(n, n, lu_ptr, n, pivot_ptr, dev_info_ptr));
+
+      // 1. copy sub-matrix to temp memory
+      cudaMemcpy(lu_ptr, input_ptr, sizeof(Scalar) * n * n,
+                 cudaMemcpyDeviceToDevice);
+
+      // 2. perform LU factorization
+      OP_REQUIRES_OK(context,
+                     solver.Getrf(n, n, lu_ptr, n, pivot_ptr, dev_info_ptr));
       int host_info;
       cudaMemcpy(&host_info, dev_info_ptr, sizeof(int), cudaMemcpyDeviceToHost);
-      
-      OP_REQUIRES(context, host_info >= 0, 
-            errors::InvalidArgument("LU factorization failed for batch ", i,
-                                ", error code: ", host_info));
-    
+
+      OP_REQUIRES(context, host_info >= 0,
+                  errors::InvalidArgument("LU factorization failed for batch ",
+                                          i, ", error code: ", host_info));
+
       if (host_info > 0) {
-          //singular matrix -> determinant is zero
-          output_ptr[i] = 0;
-          continue;
+        // singular matrix -> determinant is zero
+        output_ptr[i] = 0;
+        continue;
       }
-          
-      //3. perform a strided reduction to multiply the diagonal entries together
+
+      // 3. perform a strided reduction to multiply the diagonal entries
+      // together
       //   https://stackoverflow.com/a/29485908
       int stride = n + 1;
       thrust::device_ptr<Scalar> dev_ptr(lu_ptr);
-      strided_range<thrust::device_ptr<Scalar>> pos(dev_ptr, dev_ptr + n * n, stride);
-      Scalar det = thrust::reduce(pos.begin(), pos.end(), (Scalar) 1, thrust::multiplies<Scalar>());
-      
-      //4. compute the sign of the permutation
+      strided_range<thrust::device_ptr<Scalar>> pos(dev_ptr, dev_ptr + n * n,
+                                                    stride);
+      Scalar det = thrust::reduce(pos.begin(), pos.end(), (Scalar)1,
+                                  thrust::multiplies<Scalar>());
+
+      // 4. compute the sign of the permutation
       thrust::counting_iterator<int> counting_it(0);
-      auto transform_it = thrust::make_transform_iterator(counting_it, compute_parity(pivot_ptr, n));
-      int sign = thrust::reduce(transform_it, transform_it + n, 1, thrust::multiplies<int>());
-      
+      auto transform_it = thrust::make_transform_iterator(
+          counting_it, compute_parity(pivot_ptr, n));
+      int sign = thrust::reduce(transform_it, transform_it + n, 1,
+                                thrust::multiplies<int>());
+
       det *= sign;
-      
-      //5. Set output
+
+      // 5. Set output
       output_ptr[i] = det;
     }
-
   }
 };
 
-#define REGISTER_DETERMINANT_OP(OpName, Scalar)  \
-    REGISTER_KERNEL_BUILDER(                     \
-      Name(OpName)                               \
-      .Device(DEVICE_GPU)                        \
-      .TypeConstraint<Scalar>("T")               \
-      .HostMemory("output"),                     \
-     DeterminantOpGpu<Scalar>)
+#define REGISTER_DETERMINANT_OP(OpName, Scalar)            \
+  REGISTER_KERNEL_BUILDER(Name(OpName)                     \
+                              .Device(DEVICE_GPU)          \
+                              .TypeConstraint<Scalar>("T") \
+                              .HostMemory("output"),       \
+                          DeterminantOpGpu<Scalar>)
 
 REGISTER_DETERMINANT_OP("MatrixDeterminant", float);
 REGISTER_DETERMINANT_OP("MatrixDeterminant", double);
@@ -225,7 +218,6 @@ REGISTER_DETERMINANT_OP("BatchMatrixDeterminant", float);
 REGISTER_DETERMINANT_OP("BatchMatrixDeterminant", double);
 
 #undef REGISTER_DETERMINANT_OP
-
 }
 
 #endif  // GOOGLE_CUDA


### PR DESCRIPTION
This pull request implements the computation of the matrix determinant on the GPU using LU-factorization with cuSolver.

This is the second part of the use-case presented in pull request #11878 .

It uses the LU factorization instead of QR-factorization, because this allows to compute the determinant also for non-symmetric matrices. This is required by the definition of the operation in Tensorflow. Hence, I also had to implement the LU-interface to cuSolver, QR would have already been implemented.

Two further notes: 
First, the precision of this algorithm to compute the determinant is less precise than the Eigen-implementation. Hence I had to relax the allowed error in the unit test. This is especially important for singular or near-singular matrices.
Second, if this pull request and #11878 will both be accepted, they will probably clash in cuda_solvers.h and/or cuda_solvers.cc. I'll resolve the conflicts if it happens to be so.