### PR TITLE
Inconsistent normalization formula

### DIFF
--- a/tensorflow/examples/udacity/1_notmnist.ipynb
+++ b/tensorflow/examples/udacity/1_notmnist.ipynb
@@ -326,7 +326,7 @@
         "    image_file = os.path.join(folder, image)\n",
         "    try:\n",
         "      image_data = (ndimage.imread(image_file).astype(float) - \n",
-        "                    pixel_depth / 2) / pixel_depth\n",
+        "                    pixel_depth / 2) / (pixel_depth / 2)\n",
         "      if image_data.shape != (image_size, image_size):\n",
         "        raise Exception('Unexpected image shape: %s' % str(image_data.shape))\n",
         "      dataset[num_images, :, :] = image_data\n",


### PR DESCRIPTION
Hi there,

In the Input Normalization video, you normalize the pixels by dividing by 1/2 of the pixel depth; however, in the code you divide by the pixel depth. This confused me at first, and you may want to consider making the formula the same in both video and code.

Thanks!

All the best,
Jake