### PR TITLE
Fix typos

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
+++ b/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
@@ -299,7 +299,7 @@ def _luong_score(query, keys, scale):
   #   [batch_size, 1, depth] . [batch_size, depth, max_time]
   # resulting in an output shape of:
   #   [batch_time, 1, max_time].
-  # we then squeee out the center singleton dimension.
+  # we then squeeze out the center singleton dimension.
   score = math_ops.matmul(query, keys, transpose_b=True)
   score = array_ops.squeeze(score, [1])
 

--- a/tensorflow/python/debug/lib/debug_data.py
+++ b/tensorflow/python/debug/lib/debug_data.py
@@ -1397,7 +1397,7 @@ class DebugDumpDir(object):
     Args:
       node_name: Name of the node in question.
       device_name: (`str`) name of the device. If there is only one device or if
-        node_name exists on only one device, this argumnet is optional.
+        node_name exists on only one device, this argument is optional.
 
     Returns:
       Attributes of the node.
@@ -1419,7 +1419,7 @@ class DebugDumpDir(object):
       is_control: (`bool`) Whether control inputs, rather than non-control
         inputs, are to be returned.
       device_name: (`str`) name of the device. If there is only one device or if
-        node_name exists on only one device, this argumnet is optional.
+        node_name exists on only one device, this argument is optional.
 
     Returns:
       (`list` of `str`) inputs to the node, as a list of node names.
@@ -1455,7 +1455,7 @@ class DebugDumpDir(object):
         the source (e.g., A in this case). So the reverse direction of the ref
         edge reflects the direction of information flow.
       device_name: (`str`) name of the device. If there is only one device or if
-        node_name exists on only one device, this argumnet is optional.
+        node_name exists on only one device, this argument is optional.
 
     Returns:
       (`list` of `str`) all transitive inputs to the node, as a list of node
@@ -1524,7 +1524,7 @@ class DebugDumpDir(object):
         the source (e.g., A in this case). So the reverse direction of the ref
         edge reflects the direction of information flow.
       device_name: (`str`) name of the device. If there is only one device or if
-        node_name exists on only one device, this argumnet is optional.
+        node_name exists on only one device, this argument is optional.
 
     Returns:
       A path from the src_node_name to dst_node_name, as a `list` of `str`, if
@@ -1581,7 +1581,7 @@ class DebugDumpDir(object):
       is_control: (`bool`) whether control outputs, rather than non-control
         outputs, are to be returned.
       device_name: (`str`) name of the device. If there is only one device or if
-        node_name exists on only one device, this argumnet is optional.
+        node_name exists on only one device, this argument is optional.
 
     Returns:
       (`list` of `str`) all inputs to the node, as a list of node names.
@@ -1675,7 +1675,7 @@ class DebugDumpDir(object):
     Args:
       node_name: (`str`) name of the node.
       device_name: (`str`) name of the device. If there is only one device or if
-        node_name exists on only one device, this argumnet is optional.
+        node_name exists on only one device, this argument is optional.
 
     Returns:
       (`str`) op type of the node.
@@ -1698,7 +1698,7 @@ class DebugDumpDir(object):
     Args:
       node_name: (`str`) name of the node.
       device_name: (`str`) name of the device. If there is only one device or if
-        node_name exists on only one device, this argumnet is optional.
+        node_name exists on only one device, this argument is optional.
 
     Returns:
       (`list` of `str`) all debug tensor watch keys. Returns an empty list if
@@ -1732,7 +1732,7 @@ class DebugDumpDir(object):
     Args:
       debug_watch_key: (`str`) debug watch key.
       device_name: (`str`) name of the device. If there is only one device or if
-        the specified debug_watch_key exists on only one device, this argumnet
+        the specified debug_watch_key exists on only one device, this argument
         is optional.
 
     Returns:
@@ -1813,7 +1813,7 @@ class DebugDumpDir(object):
       output_slot: (`int`) output slot index of tensor.
       debug_op: (`str`) name of the debug op.
       device_name: (`str`) name of the device. If there is only one device or if
-        the specified debug_watch_key exists on only one device, this argumnet
+        the specified debug_watch_key exists on only one device, this argument
         is optional.
 
     Returns:
@@ -1846,7 +1846,7 @@ class DebugDumpDir(object):
       output_slot: (`int`) output slot index of tensor.
       debug_op: (`str`) name of the debug op.
       device_name: (`str`) name of the device. If there is only one device or if
-        the specified debug_watch_key exists on only one device, this argumnet
+        the specified debug_watch_key exists on only one device, this argument
         is optional.
 
     Returns:
@@ -1884,7 +1884,7 @@ class DebugDumpDir(object):
       output_slot: (`int`) output slot index of tensor.
       debug_op: (`str`) name of the debug op.
       device_name: (`str`) name of the device. If there is only one device or if
-        the specified debug_watch_key exists on only one device, this argumnet
+        the specified debug_watch_key exists on only one device, this argument
         is optional.
 
     Returns:
@@ -1918,7 +1918,7 @@ class DebugDumpDir(object):
       output_slot: (`int`) output slot index of tensor.
       debug_op: (`str`) name of the debug op.
       device_name: (`str`) name of the device. If there is only one device or if
-        the specified debug_watch_key exists on only one device, this argumnet
+        the specified debug_watch_key exists on only one device, this argument
         is optional.
 
     Returns:

--- a/tensorflow/stream_executor/lib/demangle.cc
+++ b/tensorflow/stream_executor/lib/demangle.cc
@@ -41,7 +41,7 @@ string Demangle(const char *mangled) {
 #if HAS_CXA_DEMANGLE
   result = abi::__cxa_demangle(mangled, nullptr, nullptr, &status);
 #endif
-  if (status == 0 && result != nullptr) {  // Demangling succeeeded.
+  if (status == 0 && result != nullptr) {  // Demangling succeeded.
     demangled.append(result);
     free(result);
   }

--- a/tensorflow/tools/api/lib/python_object_to_proto_visitor.py
+++ b/tensorflow/tools/api/lib/python_object_to_proto_visitor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # ==============================================================================
-"""A visitor class that generates protobufs for each pyton object."""
+"""A visitor class that generates protobufs for each python object."""
 
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
This PR fixes some typos: `squeee`, `argumnet`, `succeeeded`, and `pyton`.