### PR TITLE
[XLA] Any unrecognised fusion type should be described as kCustom

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -2381,7 +2381,7 @@ string ToString(HloInstruction::FusionKind kind) {
       return "kConvBackwardFilter";
     case HloInstruction::FusionKind::kConvBackwardInput:
       return "kConvBackwardInput";
-    case HloInstruction::FusionKind::kCustom:
+    default:
       return "kCustom";
   }
 }


### PR DESCRIPTION
@majnemer @vrv 

Hi,  

this is the knock on from cancelling having a fusion sub-type.  if I use (kCustom+N) as types of fusion then I need the printing routine to not fail when given a type that is not recognised.

The cancelled PR was https://github.com/tensorflow/tensorflow/pull/11719

