### PR TITLE
Disabling gmm_test.py on Windows builds as it's flaky on GPU nightly …

### DIFF
--- a/tensorflow/contrib/cmake/tf_tests.cmake
+++ b/tensorflow/contrib/cmake/tf_tests.cmake
@@ -183,6 +183,8 @@ if (tensorflow_BUILD_PYTHON_TESTS)
     # Loading resources in contrib doesn't seem to work on Windows
     "${tensorflow_source_dir}/tensorflow/contrib/tensor_forest/client/random_forest_test.py"
     "${tensorflow_source_dir}/tensorflow/contrib/tensor_forest/python/tensor_forest_test.py"
+    # Test is flaky on Windows GPU builds (b/38283730).
+    "${tensorflow_source_dir}/tensorflow/contrib/factorization/python/ops/gmm_test.py"
   )
   if (WIN32)
     set(tf_test_src_py_exclude


### PR DESCRIPTION
…builds.
CC: @xavigonzalvo Cannot add as a reviewer for some reason.