### PR TITLE
Update tf.nn.max_pool docs for ksize/strides == 4

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1721,9 +1721,9 @@ def avg_pool(value, ksize, strides, padding, data_format="NHWC", name=None):
   Args:
     value: A 4-D `Tensor` of shape `[batch, height, width, channels]` and type
       `float32`, `float64`, `qint8`, `quint8`, or `qint32`.
-    ksize: A list of ints that has length >= 4.
+    ksize: A 1-D int Tensor of 4 elements.
       The size of the window for each dimension of the input tensor.
-    strides: A list of ints that has length >= 4.
+    strides: A 1-D int Tensor of 4 elements
       The stride of the sliding window for each dimension of the
       input tensor.
     padding: A string, either `'VALID'` or `'SAME'`. The padding algorithm.
@@ -1750,9 +1750,9 @@ def max_pool(value, ksize, strides, padding, data_format="NHWC", name=None):
   Args:
     value: A 4-D `Tensor` with shape `[batch, height, width, channels]` and
       type `tf.float32`.
-    ksize: A list of ints that has length >= 4.  The size of the window for
+    ksize: A 1-D int Tensor of 4 elements.  The size of the window for
       each dimension of the input tensor.
-    strides: A list of ints that has length >= 4.  The stride of the sliding
+    strides: A 1-D int Tensor of 4 elements.  The stride of the sliding
       window for each dimension of the input tensor.
     padding: A string, either `'VALID'` or `'SAME'`. The padding algorithm.
       See the @{tf.nn.convolution$comment here}


### PR DESCRIPTION
Update tf.nn.max_pool docs for `ksize/strides == 4`, instead of '>= 4' in the existing docs.

As both `max_pool` and `avg_pool` are wrapped in the python code, this fix only changes the docstring in `tensorflow/python/ops/nn_ops.py`.

This fix fixes #10729.

Note: I also tried using `:=` syntax, as was suggested in https://github.com/tensorflow/tensorflow/issues/10729#issuecomment-309133461 However, it seems that the `:=` only works with `Input`, not with `Attr`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>