### PR TITLE
Disable denormal_test on ppc64le platform

### DIFF
--- a/tensorflow/python/kernel_tests/denormal_test.py
+++ b/tensorflow/python/kernel_tests/denormal_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import platform
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import array_ops
@@ -34,6 +35,10 @@ class DenormalTest(test.TestCase):
       self.assertEqual(tiny, tiny / 16 * 16)
 
   def _flushDenormalsTest(self, use_gpu, dtypes):
+    if platform.machine() == "ppc64le":
+      # Disabled denormal_test on power platform
+      # Check relevant discussion - https://github.com/tensorflow/tensorflow/issues/11902
+      return
     with self.test_session(use_gpu=use_gpu):
       array_ops.identity(7).eval()
       for dtype in dtypes:


### PR DESCRIPTION
Please find the relevant discussion - https://github.com/tensorflow/tensorflow/issues/11902

https://github.com/tensorflow/tensorflow/blob/v1.2.1/tensorflow/core/platform/denormal.cc#L43-L73
_MM_GET_FLUSH_ZERO_MODE
_MM_GET_DENORMALS_ZERO_MODE
_MM_SET_FLUSH_ZERO_MODE
_MM_SET_DENORMALS_ZERO_MODE

Some embedded machines perform slight better in this mode, but POWER servers do not. So for POWER you do not need this and should simply disable it.