### PR TITLE
Fix #11803: Force CUPTI to flush GPU activity buffers when stopping tracing.

### DIFF
--- a/tensorflow/core/platform/default/gpu_tracer.cc
+++ b/tensorflow/core/platform/default/gpu_tracer.cc
@@ -205,7 +205,7 @@ Status CUPTIManager::DisableTrace() {
   CUPTI_CALL(ActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY));
   CUPTI_CALL(ActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY2));
   CUPTI_CALL(ActivityDisable(CUPTI_ACTIVITY_KIND_MEMSET));
-  CUPTI_CALL(ActivityFlushAll(0));
+  CUPTI_CALL(ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
   {
     // Don't acquire this lock until Flush returns, since Flush
     // will potentially cause callbacks into BufferCompleted.


### PR DESCRIPTION
As described #11803, stopping GPU tracing, GPU events are not flushed. Then we cannot get GPU activities in performance statistics.

Calling  ActivityFlushAll() with flag CUPTI_ACTIVITY_FLAG_NONE causes this problem, so this commit changes the flag to CUPTI_ACTIVITY_FLAG_FLUSH_FORCED.
