### PR TITLE
Fix "depsets cannot contain mutable items" error when using Bazel 0.5.3

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -106,7 +106,7 @@ def _get_cxx_inc_directories_impl(repository_ctx, cc, lang_is_cpp):
   else:
     inc_dirs = result.stderr[index1 + 1:index2].strip()
 
-  return [repository_ctx.path(_cxx_inc_convert(p))
+  return [str(repository_ctx.path(_cxx_inc_convert(p)))
           for p in inc_dirs.split("\n")]
 
 def get_cxx_inc_directories(repository_ctx, cc):


### PR DESCRIPTION
Allows CUDA builds with more recent versions of Bazel. Fixes https://github.com/tensorflow/tensorflow/issues/11871. Perhaps we should also file a Bazel bug, although it would be nice to have the workaround in the meantime.