### PR TITLE
[OpenCL] Fix allocator destruction race condition (#136)

### DIFF
--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
@@ -36,6 +36,7 @@ SYCLAllocator::~SYCLAllocator() {
 string SYCLAllocator::Name() { return "device:SYCL"; }
 
 void* SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
+  mutex_lock lock(mu_);
   assert(sycl_device_);
   if (num_bytes == 0) {
     // Cannot allocate no bytes in SYCL, so instead allocate a single byte
@@ -45,7 +46,6 @@ void* SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
   const auto& allocated_buffer = sycl_device_->get_sycl_buffer(p);
   const std::size_t bytes_allocated = allocated_buffer.get_range().size();
 
-  mutex_lock lock(mu_);
   ++stats_.num_allocs;
   stats_.bytes_in_use += bytes_allocated;
   stats_.max_bytes_in_use =
@@ -57,10 +57,10 @@ void* SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
 }
 
 void SYCLAllocator::DeallocateRaw(void* ptr) {
+  mutex_lock lock(mu_);
   if (sycl_device_) {
     const auto& buffer_to_delete = sycl_device_->get_sycl_buffer(ptr);
     const std::size_t dealloc_size = buffer_to_delete.get_range().size();
-    mutex_lock lock(mu_);
     stats_.bytes_in_use -= dealloc_size;
     sycl_device_->deallocate(ptr);
   }
@@ -72,6 +72,7 @@ void SYCLAllocator::GetStats(AllocatorStats* stats) {
 }
 
 size_t SYCLAllocator::RequestedSize(void* ptr) {
+  mutex_lock lock(mu_);
   if(!sycl_device_) {
     return 0;
   }

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.cc
@@ -19,7 +19,7 @@ limitations under the License.
 
 namespace tensorflow {
 
-SYCLAllocator::SYCLAllocator(Eigen::QueueInterface *queue)
+SYCLAllocator::SYCLAllocator(Eigen::QueueInterface* queue)
     : sycl_device_(new Eigen::SyclDevice(queue)) {
   cl::sycl::queue& sycl_queue = sycl_device_->sycl_queue();
   const cl::sycl::device& device = sycl_queue.get_device();
@@ -28,14 +28,14 @@ SYCLAllocator::SYCLAllocator(Eigen::QueueInterface *queue)
 }
 
 SYCLAllocator::~SYCLAllocator() {
-  if(sycl_device_) {
+  if (sycl_device_) {
     delete sycl_device_;
   }
 }
 
 string SYCLAllocator::Name() { return "device:SYCL"; }
 
-void *SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
+void* SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
   assert(sycl_device_);
   if (num_bytes == 0) {
     // Cannot allocate no bytes in SYCL, so instead allocate a single byte
@@ -56,12 +56,12 @@ void *SYCLAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
   return p;
 }
 
-void SYCLAllocator::DeallocateRaw(void *ptr) {
-  const auto& buffer_to_delete = sycl_device_->get_sycl_buffer(ptr);
-  const std::size_t dealloc_size = buffer_to_delete.get_range().size();
-  mutex_lock lock(mu_);
-  stats_.bytes_in_use -= dealloc_size;
+void SYCLAllocator::DeallocateRaw(void* ptr) {
   if (sycl_device_) {
+    const auto& buffer_to_delete = sycl_device_->get_sycl_buffer(ptr);
+    const std::size_t dealloc_size = buffer_to_delete.get_range().size();
+    mutex_lock lock(mu_);
+    stats_.bytes_in_use -= dealloc_size;
     sycl_device_->deallocate(ptr);
   }
 }
@@ -72,6 +72,9 @@ void SYCLAllocator::GetStats(AllocatorStats* stats) {
 }
 
 size_t SYCLAllocator::RequestedSize(void* ptr) {
+  if(!sycl_device_) {
+    return 0;
+  }
   const auto& buffer = sycl_device_->get_sycl_buffer(ptr);
   return buffer.get_size();
 }

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.h
@@ -52,8 +52,11 @@ class SYCLAllocator : public Allocator {
   Eigen::SyclDevice* getSyclDevice() { return sycl_device_; }
   // Clear the SYCL device used by the Allocator
   void ClearSYCLDevice() {
-    delete sycl_device_;
-    sycl_device_ = nullptr;
+    if(sycl_device_) {
+      mutex_lock lock(mu_);
+      delete sycl_device_;
+      sycl_device_ = nullptr;
+    }
   }
 
  private:

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.h
@@ -37,6 +37,7 @@ class SYCLAllocator : public Allocator {
 
   virtual bool ShouldAllocateEmptyTensors() override final { return true; }
   void Synchronize() {
+    mutex_lock lock(mu_);
     if (sycl_device_) {
       sycl_device_->synchronize();
     }
@@ -52,17 +53,17 @@ class SYCLAllocator : public Allocator {
   Eigen::SyclDevice* getSyclDevice() { return sycl_device_; }
   // Clear the SYCL device used by the Allocator
   void ClearSYCLDevice() {
+    mutex_lock lock(mu_);
     if(sycl_device_) {
-      mutex_lock lock(mu_);
       delete sycl_device_;
       sycl_device_ = nullptr;
     }
   }
 
  private:
-  Eigen::SyclDevice* sycl_device_;  // owned
 
   mutable mutex mu_;
+  Eigen::SyclDevice* sycl_device_ GUARDED_BY(mu_);  // owned
   AllocatorStats stats_ GUARDED_BY(mu_);
 
   TF_DISALLOW_COPY_AND_ASSIGN(SYCLAllocator);

--- a/tensorflow/core/common_runtime/sycl/sycl_allocator.h
+++ b/tensorflow/core/common_runtime/sycl/sycl_allocator.h
@@ -29,15 +29,19 @@ namespace tensorflow {
 
 class SYCLAllocator : public Allocator {
  public:
-  SYCLAllocator(Eigen::QueueInterface *queue);
+  SYCLAllocator(Eigen::QueueInterface* queue);
   virtual ~SYCLAllocator() override;
   string Name() override;
-  void *AllocateRaw(size_t alignment, size_t num_bytes) override;
-  void DeallocateRaw(void *ptr) override;
+  void* AllocateRaw(size_t alignment, size_t num_bytes) override;
+  void DeallocateRaw(void* ptr) override;
 
   virtual bool ShouldAllocateEmptyTensors() override final { return true; }
-  void Synchronize() { sycl_device_->synchronize(); }
-  bool Ok() { return sycl_device_->ok(); }
+  void Synchronize() {
+    if (sycl_device_) {
+      sycl_device_->synchronize();
+    }
+  }
+  bool Ok() { return sycl_device_ && sycl_device_->ok(); }
   void GetStats(AllocatorStats* stats) override;
   // The SYCL buffers keep track of their size, so we already have tracking.
   bool TracksAllocationSizes() override { return true; }
@@ -46,8 +50,14 @@ class SYCLAllocator : public Allocator {
   // AllocatedSize(void* ptr) by default.
   size_t RequestedSize(void* ptr) override;
   Eigen::SyclDevice* getSyclDevice() { return sycl_device_; }
+  // Clear the SYCL device used by the Allocator
+  void ClearSYCLDevice() {
+    delete sycl_device_;
+    sycl_device_ = nullptr;
+  }
+
  private:
-  Eigen::SyclDevice *sycl_device_;  // owned
+  Eigen::SyclDevice* sycl_device_;  // owned
 
   mutable mutex mu_;
   AllocatorStats stats_ GUARDED_BY(mu_);

--- a/tensorflow/core/common_runtime/sycl/sycl_device.cc
+++ b/tensorflow/core/common_runtime/sycl/sycl_device.cc
@@ -22,20 +22,10 @@ limitations under the License.
 #include "tensorflow/core/platform/tracing.h"
 
 namespace tensorflow {
-std::mutex GSYCLInterface::mutex_;
-GSYCLInterface *GSYCLInterface::s_instance = 0;
-
-void ShutdownSycl() {
-  GSYCLInterface::Reset();
-}
-
-void SYCLDevice::RegisterDevice() {
-    atexit(ShutdownSycl);
-}
 
 SYCLDevice::~SYCLDevice() {}
 
-void SYCLDevice::Compute(OpKernel *op_kernel, OpKernelContext *context) {
+void SYCLDevice::Compute(OpKernel* op_kernel, OpKernelContext* context) {
   assert(context);
   if (port::Tracing::IsActive()) {
     // TODO(pbar) We really need a useful identifier of the graph node.
@@ -46,16 +36,16 @@ void SYCLDevice::Compute(OpKernel *op_kernel, OpKernelContext *context) {
   op_kernel->Compute(context);
 }
 
-Allocator *SYCLDevice::GetAllocator(AllocatorAttributes attr) {
+Allocator* SYCLDevice::GetAllocator(AllocatorAttributes attr) {
   if (attr.on_host())
     return cpu_allocator_;
   else
     return sycl_allocator_;
 }
 
-Status SYCLDevice::MakeTensorFromProto(const TensorProto &tensor_proto,
+Status SYCLDevice::MakeTensorFromProto(const TensorProto& tensor_proto,
                                        const AllocatorAttributes alloc_attrs,
-                                       Tensor *tensor) {
+                                       Tensor* tensor) {
   AllocatorAttributes attr;
   attr.set_on_host(true);
   Allocator* host_alloc = GetAllocator(attr);
@@ -79,18 +69,18 @@ Status SYCLDevice::MakeTensorFromProto(const TensorProto &tensor_proto,
     }
 
     device_context_->CopyCPUTensorToDevice(
-        &parsed, this, &copy, [&status](const Status &s) { status = s; });
+        &parsed, this, &copy, [&status](const Status& s) { status = s; });
     *tensor = copy;
   }
   return status;
 }
 
-Status SYCLDevice::FillContextMap(const Graph *graph,
-                                  DeviceContextMap *device_context_map) {
+Status SYCLDevice::FillContextMap(const Graph* graph,
+                                  DeviceContextMap* device_context_map) {
   // Fill in the context map.  It is OK for this map to contain
   // duplicate DeviceContexts so long as we increment the refcount.
   device_context_map->resize(graph->num_node_ids());
-  for (Node *n : graph->nodes()) {
+  for (Node* n : graph->nodes()) {
     device_context_->Ref();
     (*device_context_map)[n->id()] = device_context_;
   }


### PR DESCRIPTION
* [OpenCL] Changes SYCL Interface construction

Uses C++11 static initialisation to provide singleton instance, rather
than a mutex and pointer.

* [OpenCL] Adds const to SYCL Interface methods

* [OpenCL] Fix allocator destruction race condition

A Tensor's allocator must outlive it, however there is no easy way to
determine whether an Allocator has any Tensors still alive, and so we
cannot know when it is safe to destroy an allocator. The CPU allocator
gets round this by being deleted, so we adopt this convention here.

* [OpenCL] Reformats SYCL code

* [OpenCL] Fixes SYCL comments

* [OpenCL] Tidies SYCL device description

Adds check for whether the QueueInterface pointer is valid, as this
may not always be the case.

* [OpenCL] Adds nullptr checking to SYCL allocator

* [OpenCL] Adds const specifier to SYCL Interface