### PR TITLE
Fix formatting problems in "Adding an Op" doc

### DIFF
--- a/tensorflow/docs_src/extend/adding_an_op.md
+++ b/tensorflow/docs_src/extend/adding_an_op.md
@@ -178,9 +178,7 @@ suggested implementation is to:
    file, but the specialization for the GPUDevice is defined in a .cu.cc file,
    since it will be compiled with the CUDA compiler.
 
-<!--zippy-->
-
-Expand this to see the example implementation.
+Here is an example implementation.
 
 ```c++
 // example.h
@@ -306,8 +304,6 @@ template struct ExampleFunctor<GPUDevice, int32>;
 
 #endif  // GOOGLE_CUDA
 ```
-
-<!--endzippy-->
 
 ## Build the op library
 ### Compile the op using your system compiler (TensorFlow binary installation)
@@ -763,7 +759,7 @@ Your op registration now specifies that the input's type must be `float`, or
 >   """
 > ```
 
-<pre><pre class="prettyprint"><code class="lang-cpp">
+<pre class="prettyprint"><code class="lang-cpp">
 \#include "tensorflow/core/framework/op_kernel.h"<br/>
 class ZeroOut<b>Int32</b>Op : public OpKernel {
   // as before
@@ -803,7 +799,7 @@ REGISTER\_KERNEL\_BUILDER(
     .Device(DEVICE\_CPU)
     .TypeConstraint&lt;float&gt;("T"),
     ZeroOutFloatOp);
-</b></code></pre></pre>
+</b></code></pre>
 
 > To preserve [backwards compatibility](#backwards-compatibility), you should
 > specify a [default value](#default-values-constraints) when adding an attr to


### PR DESCRIPTION
I noticed some minor code formatting issues while reading through [https://www.tensorflow.org/extend/adding_an_op]:
1. At line 181 of the Markdown file, there is some non-working HTML to show/hide a code listing.
2. At line 766 of the Markdown file, there is a code listing that ends up with a bunch of extra backslashes when rendered to HTML.
3. At line 1113 of the Markdown file, there is a code listing (a `REGISTER_OP` macro) that does not display properly in the HTML version of the document.

This PR fixes 1 and 2 above. The third problem appears to be a bug in the script that generates the HTML, and I wasn't able to find that script anywhere in the source tree.