### PR TITLE
Make plugin_data optional instead of repeated

### DIFF
--- a/tensorflow/core/debug/debug_grpc_testlib.cc
+++ b/tensorflow/core/debug/debug_grpc_testlib.cc
@@ -56,17 +56,15 @@ namespace test {
 
       // Obtain the device name, which is encoded in JSON.
       third_party::tensorflow::core::debug::DebuggerEventMetadata metadata;
-      for (int i = 0; i < val.metadata().plugin_data_size(); i++) {
-        if (val.metadata().plugin_data(i).plugin_name() != "debugger") {
-          // This plugin data was meant for another plugin.
-          continue;
-        }
-        auto status = tensorflow::protobuf::util::JsonStringToMessage(
-            val.metadata().plugin_data(i).content(), &metadata);
-        if (status.ok()) {
-          // The device name has been determined.
-          break;
-        }
+      if (val.metadata().plugin_data().plugin_name() != "debugger") {
+        // This plugin data was meant for another plugin.
+        continue;
+      }
+      auto status = tensorflow::protobuf::util::JsonStringToMessage(
+          val.metadata().plugin_data().content(), &metadata);
+      if (!status.ok()) {
+        // The device name could not be determined.
+        continue;
       }
 
       device_names.push_back(metadata.device());

--- a/tensorflow/core/debug/debug_io_utils.cc
+++ b/tensorflow/core/debug/debug_io_utils.cc
@@ -83,7 +83,7 @@ Event PrepareChunkEventProto(const DebugNodeKey& debug_node_key,
   if (status.ok()) {
     // Store summary metadata. Set the plugin to use this data as "debugger".
     SummaryMetadata::PluginData* plugin_data =
-        value->mutable_metadata()->add_plugin_data();
+        value->mutable_metadata()->mutable_plugin_data();
     plugin_data->set_plugin_name(DebugIO::kDebuggerPluginName);
     plugin_data->set_content(json_output);
   } else {

--- a/tensorflow/core/debug/debug_io_utils_test.cc
+++ b/tensorflow/core/debug/debug_io_utils_test.cc
@@ -132,7 +132,7 @@ TEST_F(DebugIOUtilsTest, DumpStringTensorToFileSunnyDay) {
   // Determine and validate some information from the metadata.
   third_party::tensorflow::core::debug::DebuggerEventMetadata metadata;
   auto status = tensorflow::protobuf::util::JsonStringToMessage(
-      event.summary().value(0).metadata().plugin_data(0).content(), &metadata);
+      event.summary().value(0).metadata().plugin_data().content(), &metadata);
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(kDebugNodeKey.device_name, metadata.device());
   ASSERT_EQ(kDebugNodeKey.output_slot, metadata.output_slot());
@@ -245,8 +245,7 @@ TEST_F(DebugIOUtilsTest, PublishTensorToMultipleFileURLs) {
     // Determine and validate some information from the metadata.
     third_party::tensorflow::core::debug::DebuggerEventMetadata metadata;
     auto status = tensorflow::protobuf::util::JsonStringToMessage(
-        event.summary().value(0).metadata().plugin_data(0).content(),
-        &metadata);
+        event.summary().value().metadata().plugin_data(0).content(), &metadata);
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(kDebugNodeKey.device_name, metadata.device());
     ASSERT_EQ(kDebugNodeKey.output_slot, metadata.output_slot());
@@ -358,7 +357,7 @@ TEST_F(DebugIOUtilsTest, PublishTensorConcurrentlyToPartiallyOverlappingPaths) {
       // Determine and validate some information from the metadata.
       third_party::tensorflow::core::debug::DebuggerEventMetadata metadata;
       auto status = tensorflow::protobuf::util::JsonStringToMessage(
-          event.summary().value(0).metadata().plugin_data(0).content(),
+          event.summary().value(0).metadata().plugin_data().content(),
           &metadata);
       ASSERT_TRUE(status.ok());
       ASSERT_EQ(kDebugNodeKey.device_name, metadata.device());

--- a/tensorflow/core/debug/debug_io_utils_test.cc
+++ b/tensorflow/core/debug/debug_io_utils_test.cc
@@ -245,7 +245,7 @@ TEST_F(DebugIOUtilsTest, PublishTensorToMultipleFileURLs) {
     // Determine and validate some information from the metadata.
     third_party::tensorflow::core::debug::DebuggerEventMetadata metadata;
     auto status = tensorflow::protobuf::util::JsonStringToMessage(
-        event.summary().value().metadata().plugin_data().content(), &metadata);
+        event.summary().value(0).metadata().plugin_data().content(), &metadata);
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(kDebugNodeKey.device_name, metadata.device());
     ASSERT_EQ(kDebugNodeKey.output_slot, metadata.output_slot());

--- a/tensorflow/core/debug/debug_io_utils_test.cc
+++ b/tensorflow/core/debug/debug_io_utils_test.cc
@@ -245,7 +245,7 @@ TEST_F(DebugIOUtilsTest, PublishTensorToMultipleFileURLs) {
     // Determine and validate some information from the metadata.
     third_party::tensorflow::core::debug::DebuggerEventMetadata metadata;
     auto status = tensorflow::protobuf::util::JsonStringToMessage(
-        event.summary().value().metadata().plugin_data(0).content(), &metadata);
+        event.summary().value().metadata().plugin_data().content(), &metadata);
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(kDebugNodeKey.device_name, metadata.device());
     ASSERT_EQ(kDebugNodeKey.output_slot, metadata.output_slot());

--- a/tensorflow/core/framework/summary.proto
+++ b/tensorflow/core/framework/summary.proto
@@ -45,9 +45,9 @@ message SummaryMetadata {
     string content = 2;
   }
 
-  // A list of plugin data. A single summary value instance may be used by more
+  // Data that associates a summary with a certain plugin.
   // than 1 plugin.
-  repeated PluginData plugin_data = 1;
+  PluginData plugin_data = 1;
 
   // Display name for viewing in TensorBoard.
   string display_name = 2;

--- a/tensorflow/core/kernels/summary_tensor_op_test.cc
+++ b/tensorflow/core/kernels/summary_tensor_op_test.cc
@@ -67,14 +67,10 @@ TEST_F(SummaryTensorOpV2Test, BasicPluginData) {
 
   // Create a SummaryMetadata that stores data for 2 plugins.
   SummaryMetadata summary_metadata;
-  SummaryMetadata::PluginData* plugin_data_0 =
-      summary_metadata.add_plugin_data();
-  plugin_data_0->set_plugin_name("foo");
-  plugin_data_0->set_content("content_for_plugin_foo");
-  SummaryMetadata::PluginData* plugin_data_1 =
-      summary_metadata.add_plugin_data();
-  plugin_data_1->set_plugin_name("bar");
-  plugin_data_1->set_content("content_for_plugin_bar");
+  SummaryMetadata::PluginData* plugin_data =
+      summary_metadata.mutable_plugin_data();
+  plugin_data->set_plugin_name("foo");
+  plugin_data->set_content("content_for_plugin_foo");
   AddInputFromArray<string>(TensorShape({}),
                             {summary_metadata.SerializeAsString()});
 
@@ -95,13 +91,9 @@ TEST_F(SummaryTensorOpV2Test, BasicPluginData) {
 
   // Check plugin-related data.
   ASSERT_EQ("tag_foo", summary.value(0).tag());
-  ASSERT_EQ(2, summary.value(0).metadata().plugin_data_size());
-  ASSERT_EQ("foo", summary.value(0).metadata().plugin_data(0).plugin_name());
+  ASSERT_EQ("foo", summary.value(0).metadata().plugin_data().plugin_name());
   ASSERT_EQ("content_for_plugin_foo",
-            summary.value(0).metadata().plugin_data(0).content());
-  ASSERT_EQ("bar", summary.value(0).metadata().plugin_data(1).plugin_name());
-  ASSERT_EQ("content_for_plugin_bar",
-            summary.value(0).metadata().plugin_data(1).content());
+            summary.value(0).metadata().plugin_data().content());
 }
 
 }  // namespace

--- a/tensorflow/python/debug/lib/grpc_debug_server.py
+++ b/tensorflow/python/debug/lib/grpc_debug_server.py
@@ -197,8 +197,7 @@ class EventListenerBaseServicer(debug_service_pb2_grpc.EventListenerServicer):
     """
 
     value = event.summary.value[0]
-    debugger_plugin_metadata = json.loads(
-        value.metadata.plugin_data[0].content)
+    debugger_plugin_metadata = json.loads(value.metadata.plugin_data.content)
     device_name = debugger_plugin_metadata["device"]
     num_chunks = debugger_plugin_metadata["numChunks"]
     chunk_index = debugger_plugin_metadata["chunkIndex"]

--- a/tensorflow/python/debug/lib/grpc_debug_test_server.py
+++ b/tensorflow/python/debug/lib/grpc_debug_test_server.py
@@ -184,7 +184,7 @@ class EventListenerTestStreamHandler(
     if not summary_metadata.plugin_data:
       raise ValueError("The value lacks plugin data.")
     try:
-      content = json.loads(summary_metadata.plugin_data[0].content)
+      content = json.loads(summary_metadata.plugin_data.content)
     except ValueError as err:
       raise ValueError("Could not parse content into JSON: %r, %r" % (content,
                                                                       err))

--- a/tensorflow/python/summary/text_summary.py
+++ b/tensorflow/python/summary/text_summary.py
@@ -70,8 +70,8 @@ def text_summary(name, tensor, collections=None):
   summary_metadata = summary_pb2.SummaryMetadata()
   text_plugin_data = _TextPluginData()
   data_dict = text_plugin_data._asdict()  # pylint: disable=protected-access
-  summary_metadata.plugin_data.add(
-      plugin_name=PLUGIN_NAME, content=json.dumps(data_dict))
+  summary_metadata.plugin_data.plugin_name = PLUGIN_NAME
+  summary_metadata.plugin_data.content = json.dumps(data_dict)
   t_summary = tensor_summary(
       name=name,
       tensor=tensor,

--- a/tensorflow/python/summary/writer/writer_test.py
+++ b/tensorflow/python/summary/writer/writer_test.py
@@ -326,10 +326,12 @@ class SummaryWriterTestCase(test.TestCase):
     # We add 2 summaries with the same tags. They both have metadata. The writer
     # should strip the metadata from the second one.
     value = summary_pb2.Summary.Value(tag="foo", simple_value=10.0)
-    value.metadata.plugin_data.add(plugin_name="bar", content="... content ...")
+    value.metadata.plugin_data.plugin_name = "bar"
+    value.metadata.plugin_data.content = "... content ..."
     sw.add_summary(summary_pb2.Summary(value=[value]), 10)
     value = summary_pb2.Summary.Value(tag="foo", simple_value=10.0)
-    value.metadata.plugin_data.add(plugin_name="bar", content="... content ...")
+    value.metadata.plugin_data.plugin_name = "bar"
+    value.metadata.plugin_data.content = "... content ..."
     sw.add_summary(summary_pb2.Summary(value=[value]), 10)
 
     sw.close()


### PR DESCRIPTION
This patches tensorflow/tensorflow#11952 into master. Here is that PR's description:

Every summary op writes data for a single plugin to process. Hence, each
SummaryMetadata proto should have a single PluginData optional field
(instead of a repeated one). This removes much complexity from
TensorBoard logic that loops over the plugin data. It also simplifies
the SQL schema - it can now enforce a one-to-one relationship between
summary op and plugin.