### PR TITLE
Fix build issue in c++14 for condition_variable

### DIFF
--- a/tensorflow/stream_executor/host/host_stream.h
+++ b/tensorflow/stream_executor/host/host_stream.h
@@ -48,7 +48,7 @@ class HostStream : public internal::StreamInterface {
 
   mutex mu_;
   int pending_tasks_ GUARDED_BY(mu_) = 0;
-  condition_variable completion_condition_;
+  ConditionVariableForMutex completion_condition_;
 };
 
 }  // namespace host

--- a/tensorflow/stream_executor/platform/default/mutex.h
+++ b/tensorflow/stream_executor/platform/default/mutex.h
@@ -42,8 +42,10 @@ enum ConditionResult { kCond_Timeout, kCond_MaybeNotified };
 
 #ifdef STREAM_EXECUTOR_USE_SHARED_MUTEX
 typedef std::shared_timed_mutex BaseMutex;
+typedef std::condition_variable_any ConditionVariableForMutex;
 #else
 typedef std::mutex BaseMutex;
+typedef std::condition_variable ConditionVariableForMutex;
 #endif
 
 // A class that wraps around the std::mutex implementation, only adding an
@@ -82,7 +84,7 @@ typedef mutex_lock shared_lock;
 using std::condition_variable;
 
 inline ConditionResult WaitForMilliseconds(mutex_lock* mu,
-                                           condition_variable* cv, int64 ms) {
+                                           ConditionVariableForMutex* cv, int64 ms) {
   std::cv_status s = cv->wait_for(*mu, std::chrono::milliseconds(ms));
   return (s == std::cv_status::timeout) ? kCond_Timeout : kCond_MaybeNotified;
 }


### PR DESCRIPTION
This fix fixes the issue raised in #12017 where `condition_variable_any` has to be used in c++14.

This fix defines ConditionVariableForMutex as `std::condition_variable_any` in c++14 and `std::condition_variable` otherwise.

The fix is verified with
```
bazel build -s --config=opt --cxxopt=-std=c++14 ...
```

This fix fixes #12017.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>