### PR TITLE
Add int64_t typemap for swig

### DIFF
--- a/tensorflow/python/platform/base.i
+++ b/tensorflow/python/platform/base.i
@@ -106,6 +106,10 @@ limitations under the License.
   $1 = &temp;
 }
 
+%typemap(out) int64_t {
+  $result = PyLong_FromLongLong($1);
+}
+
 %typemap(out) string {
   $result = PyBytes_FromStringAndSize($1.data(), $1.size());
 }


### PR DESCRIPTION
```Session.list_devices()```  gives  wrong memory bytes, and after the call, swig complains a memory leak: 
```
# on Win7, 1.3.0RC1
>>> s.list_devices()
[_DeviceAttributes(/job:localhost/replica:0/task:0/device:CPU:0, CPU, 69731600)]
>>> 1
swig/python detected a memory leak of type 'int64_t *', no destructor found.
1

# on Linux, 1.3.0RC2
>>> s.list_devices()
[_DeviceAttributes(/job:localhost/replica:0/task:0/device:CPU:0, CPU, 94080344021520), _DeviceAttributes(/job:localhost/replica:0/task:0/device:GPU:0, GPU, 94080320350144)]
>>> 1
swig/python detected a memory leak of type 'int64_t *', no destructor found.
swig/python detected a memory leak of type 'int64_t *', no destructor found.
1

```
The reason is the CAPI ```TF_DeviceListMemoryBytes``` returns value of type 'int64_t', for which swig can not generate a correct wrapper:
```
TF_CAPI_EXPORT extern int64_t TF_DeviceListMemoryBytes(
    const TF_DeviceList* list, int index, TF_Status*);
```
```
SWIGINTERN PyObject *_wrap_TF_DeviceListMemoryBytes(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
  //...
  result = TF_DeviceListMemoryBytes((TF_DeviceList const *)arg1,arg2,arg3);
  // problem  here
  resultobj = SWIG_NewPointerObj((new int64_t(static_cast< const int64_t& >(result))), }

 //...
}
```
This wrapper causes the python side code read the address rather than the value of the int64_t variable (which is why memory bytes is wrong). And since there is no destructor for int64_t, swig complains about it.

There is another CAPI ```TF_Dim``` that has the same problem.

The problem is solved by adding a ```int64_t```  typemap for swig, then the wrapper will be like this:
```
    result = TF_DeviceListMemoryBytes((TF_DeviceList const *)arg1,arg2,arg3);
    //...
    resultobj = PyLong_FromLongLong(result); 
```