### PR TITLE
Implement CRF decode (Viterbi decode) for tensor

### DIFF
--- a/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
+++ b/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
@@ -250,7 +250,7 @@ class CrfTest(test.TestCase):
     tag_indices_v = np.random.randint(low=0,
                                       high=num_tags,
                                       size=[batch_size, max_seq_len])
-    # decode using numpy version
+    # decode using numpy version.
     np_pred_tags, np_scores = np_crf_decode(potentials_v,
                                             trans_params_v,
                                             seq_lens_v)
@@ -262,8 +262,7 @@ class CrfTest(test.TestCase):
       seq_lens = constant_op.constant(seq_lens_v, dtype=dtypes.int32)
       trans_params = constant_op.constant(trans_params_v, dtype=dtypes.float32)
       potentials = constant_op.constant(potentials_v, dtype=dtypes.float32)
-      tag_indices = constant_op.constant(tag_indices_v, dtype=dtypes.int32)
-      # decode usig tensor version
+      # decode using tensor version.
       pred_tags, scores = crf.crf_decode(potentials,
                                          trans_params,
                                          seq_lens)
@@ -274,7 +273,7 @@ class CrfTest(test.TestCase):
                                   tag_indices_v,
                                   seq_lens_v)
 
-      self.assertLess(np.abs(tf_accuracy - np_accuracy), 1e-5)
+      self.assertLess(abs(tf_accuracy - np_accuracy), 1e-5)
 
       for b in range(batch_size):
         self.assertEqual(list(tf_pred_tags[b])[:seq_lens_v[b]],

--- a/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
+++ b/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
@@ -215,7 +215,6 @@ class CrfTest(test.TestCase):
         pred_tags: a list
         scores: a list
       '''
-      B, T, _ = potentials.shape
       pred_tags, scores = [], []
       for p, seq_len in zip(potentials, seq_lens):
         p = p[:seq_len]

--- a/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
+++ b/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
@@ -203,21 +203,23 @@ class CrfTest(test.TestCase):
   def testCrfDecode(self):
 
     def np_crf_decode(potentials, transition_params, seq_lens):
-      '''
-      This is a function for numpy arrays.
-      potentials: [B, T, num_tags]
-      transition_params: [num_tags, num_tags]
-      seq_lens: [B]
-      tag_indices: [B, T]
+      '''This is a function for numpy arrays.
 
-      pred_tags: a list
-      scores: a list
+      Args:
+        potentials: [B, T, num_tags]
+        transition_params: [num_tags, num_tags]
+        seq_lens: [B]
+        tag_indices: [B, T]
+
+      Returns:
+        pred_tags: a list
+        scores: a list
       '''
       B, T, _ = potentials.shape
       pred_tags, scores = [], []
       for p, seq_len in zip(potentials, seq_lens):
         p = p[:seq_len]
-        pred_tag, score = tf.contrib.crf.viterbi_decode(p, transition_params)
+        pred_tag, score = crf.viterbi_decode(p, transition_params)
         pred_tags.append(pred_tag)
         scores.append(score)
       return pred_tags, scores
@@ -238,16 +240,16 @@ class CrfTest(test.TestCase):
     num_tags = 4
 
     # np.random.seed(1)
-    seq_lens_v = np.random.random_integers(low=max(max_seq_len / 2, 1),
-                                           high=max_seq_len,
-                                           size=[batch_size])
+    seq_lens_v = np.random.randint(low=max(max_seq_len / 2, 1),
+                                   high=max_seq_len,
+                                   size=[batch_size])
 
     trans_params_v = np.random.rand(num_tags, num_tags)
 
     potentials_v = np.random.rand(batch_size, max_seq_len, num_tags)
-    tag_indices_v = np.random.random_integers(low=0,
-                                              high=num_tags,
-                                              size=[batch_size,  max_seq_len])
+    tag_indices_v = np.random.randint(low=0,
+                                      high=num_tags,
+                                      size=[batch_size, max_seq_len])
     # decode using numpy version
     np_pred_tags, np_scores = np_crf_decode(potentials_v,
                                             trans_params_v,

--- a/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
+++ b/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
@@ -203,18 +203,22 @@ class CrfTest(test.TestCase):
   def testCrfDecode(self):
 
     def np_crf_decode(potentials, transition_params, seq_lens):
-      '''This is a function for numpy arrays.
+      """This is a function for numpy arrays.
 
       Args:
-        potentials: [B, T, num_tags]
-        transition_params: [num_tags, num_tags]
-        seq_lens: [B]
-        tag_indices: [B, T]
+        potentials: A [batch_size, max_seq_len, num_tags] array containing
+                    unary potentials.
+        transition_params: A [num_tags, num_tags] array containing binary
+                    potentials.
+        seq_lens: A [batch_size] array containing true sequence lengths.
 
       Returns:
-        pred_tags: a list
-        scores: a list
-      '''
+        pred_tags: A list of 1-d array, with length batch_size and i-th
+                   element's length seq_lens[i]. Contains the highest scoring
+                   tag indicies.
+        scores: A list of integers, with length batch_size. Contains the score
+                   of pred_tags.
+      """
       pred_tags, scores = [], []
       for p, seq_len in zip(potentials, seq_lens):
         p = p[:seq_len]
@@ -238,7 +242,7 @@ class CrfTest(test.TestCase):
     max_seq_len = 100
     num_tags = 4
 
-    # np.random.seed(1)
+    np.random.seed(1)
     seq_lens_v = np.random.randint(low=max(max_seq_len / 2, 1),
                                    high=max_seq_len,
                                    size=[batch_size])
@@ -249,7 +253,7 @@ class CrfTest(test.TestCase):
     tag_indices_v = np.random.randint(low=0,
                                       high=num_tags,
                                       size=[batch_size, max_seq_len])
-    # decode using numpy version.
+    # Decode using numpy version.
     np_pred_tags, np_scores = np_crf_decode(potentials_v,
                                             trans_params_v,
                                             seq_lens_v)
@@ -261,7 +265,7 @@ class CrfTest(test.TestCase):
       seq_lens = constant_op.constant(seq_lens_v, dtype=dtypes.int32)
       trans_params = constant_op.constant(trans_params_v, dtype=dtypes.float32)
       potentials = constant_op.constant(potentials_v, dtype=dtypes.float32)
-      # decode using tensor version.
+      # Decode using tensor version.
       pred_tags, scores = crf.crf_decode(potentials,
                                          trans_params,
                                          seq_lens)

--- a/tensorflow/contrib/crf/python/ops/crf.py
+++ b/tensorflow/contrib/crf/python/ops/crf.py
@@ -43,6 +43,7 @@ import numpy as np
 
 from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import rnn
 from tensorflow.python.ops import rnn_cell
@@ -50,7 +51,9 @@ from tensorflow.python.ops import variable_scope as vs
 
 __all__ = [
     "crf_sequence_score", "crf_log_norm", "crf_log_likelihood",
-    "crf_unary_score", "crf_binary_score", "CrfForwardRnnCell", "viterbi_decode"
+    "crf_unary_score", "crf_binary_score", "CrfForwardRnnCell",
+    "viterbi_decode", "crf_decode", "CrfDecodeForwardRnnCell",
+    "CrfDecodeBackwardRnnCell"
 ]
 
 
@@ -310,3 +313,149 @@ def viterbi_decode(score, transition_params):
 
   viterbi_score = np.max(trellis[-1])
   return viterbi, viterbi_score
+
+
+class CrfDecodeForwardRnnCell(rnn_cell.RNNCell):
+  """Computes the forward decoding in a linear-chain CRF.
+  """
+
+  def __init__(self, transition_params):
+    """Initialize the CrfDecodeForwardRnnCell.
+
+    Args:
+      transition_params: A [num_tags, num_tags] matrix of binary
+        potentials. This matrix is expanded into a
+        [1, num_tags, num_tags] in preparation for the broadcast
+        summation occurring within the cell.
+    """
+    self._transition_params = array_ops.expand_dims(transition_params, 0)
+    self._num_tags = transition_params.get_shape()[0].value
+
+  @property
+  def state_size(self):
+    return self._num_tags
+
+  @property
+  def output_size(self):
+    return self._num_tags
+
+  def __call__(self, inputs, state, scope=None):
+    """Build the CrfDecodeForwardRnnCell.
+
+    Args:
+      inputs: A [batch_size, num_tags] matrix of unary potentials.
+      state: A [batch_size, num_tags] matrix containing the previous step's
+            score values.
+      scope: Unused variable scope of this cell.
+
+    Returns:
+      backpointers: [batch_size, num_tags], containing backpointers.
+      new_state: [batch_size, num_tags], containing new score values.
+    """
+    state = array_ops.expand_dims(state, 2)         # [B, T, 1]
+
+    # This addition op broadcasts self._transitions_params along the zeroth
+    # dimension and state along the second dimension.
+    # [B, num_tags, 1] + [1, num_tags, num_tags] ->
+    # [B, num_tags, num_tags]
+    transition_scores = state + self._transition_params
+    new_state = inputs + math_ops.reduce_max(transition_scores, [1])
+    backpointers = math_ops.argmax(transition_scores, 1)
+    backpointers = math_ops.cast(backpointers, dtype=dtypes.int32)
+    return backpointers, new_state
+
+
+class CrfDecodeBackwardRnnCell(rnn_cell.RNNCell):
+  """Computes backward decoding in a linear-chain CRF.
+  """
+
+  def __init__(self, num_tags):
+    """Initialize the CrfDecodeBackwardRnnCell.
+
+    Args:
+      num_tags
+    """
+    self._num_tags = num_tags
+
+  @property
+  def state_size(self):
+    return 1
+
+  @property
+  def output_size(self):
+    return 1
+
+  def __call__(self, inputs, state, scope=None):
+    """Build the CrfDecodeBackwardRnnCell.
+
+    Args:
+      inputs: [batch_size, num_tags], backpointer of next step (in time order).
+      state: [batch_size, 1], next position's tag index
+      scope: Unused variable scope of this cell.
+
+    Returns:
+      new_tags, new_tags: A pair of [batch_size, num_tags]
+        tensors containing the new tag indices.
+    """
+    state = array_ops.squeeze(state, axis=[1])                # [B]
+    batch_size = array_ops.shape(inputs)[0]
+    b_indices = math_ops.range(batch_size)                    # [B]
+    indices = array_ops.stack([b_indices, state], axis=1)     # [B, 2]
+    new_tags = array_ops.expand_dims(
+      gen_array_ops.gather_nd(inputs, indices),               # [B]
+      axis=-1)                                                # [B, 1]
+
+    return new_tags, new_tags
+
+
+def crf_decode(potentials, transition_params, sequence_length):
+  '''
+  This is a function for tensor.
+  Args:
+    potentials: a [batch_size, max_length, num_tags] tensor, matrix of
+              unary potentials.
+    transition_params: a [num_tags, num_tags] tensor, matrix of
+              binary potentials
+    sequence_length: a [batch_size] tensor
+
+  Returns:
+    decode_tags: a [batch_size, max_length] tensor, tf.int32. Contains the
+              highest scoring tag indicies.
+    best_score: a [batch_size] tensor, containing the score of decode_tags
+  '''
+  B, T, O = potentials.shape.as_list()
+
+  # Computes forward decoding. Get last score and backpointers
+  crf_fwd_cell = CrfDecodeForwardRnnCell(transition_params)
+  initial_state = array_ops.slice(potentials, [0, 0, 0], [-1, 1, -1])
+  initial_state = array_ops.squeeze(initial_state, axis=[1])      # [B, O]
+  inputs = array_ops.slice(potentials, [0, 1, 0], [-1, -1, -1])   # [B, T-1, O]
+  backpointers, last_score = rnn.dynamic_rnn(
+    crf_fwd_cell,
+    inputs=inputs,
+    sequence_length=sequence_length - 1,
+    initial_state=initial_state,
+    time_major=False,
+    dtype=dtypes.int32)             # [B, T - 1, O], [B, O]
+  backpointers = gen_array_ops.reverse_sequence(
+    backpointers, sequence_length - 1, seq_dim=1)                 # [B, T-1, O]
+
+  # Computes backward decoding. Extract tag indices from backpointers
+  crf_bwd_cell = CrfDecodeBackwardRnnCell(O)
+  initial_state = math_ops.cast(math_ops.argmax(last_score, axis=1),
+                                dtype=dtypes.int32)               # [B]
+  initial_state = array_ops.expand_dims(initial_state, axis=-1)   # [B, 1]
+  decode_tags, _ = rnn.dynamic_rnn(
+    crf_bwd_cell,
+    inputs=backpointers,
+    sequence_length=sequence_length - 1,
+    initial_state=initial_state,
+    time_major=False,
+    dtype=dtypes.int32)           # [B, T - 1, 1]
+  decode_tags = array_ops.squeeze(decode_tags, axis=[2])           # [B, T - 1]
+  decode_tags = array_ops.concat([initial_state, decode_tags], axis=1)  # [B, T]
+  decode_tags = gen_array_ops.reverse_sequence(
+    decode_tags, sequence_length, seq_dim=1)                       # [B, T]
+
+  best_score = math_ops.reduce_max(last_score, axis=1)             # [B]
+  return decode_tags, best_score

--- a/tensorflow/contrib/crf/python/ops/crf.py
+++ b/tensorflow/contrib/crf/python/ops/crf.py
@@ -363,7 +363,7 @@ class CrfDecodeForwardRnnCell(rnn_cell.RNNCell):
       backpointers: [batch_size, num_tags], containing backpointers.
       new_state: [batch_size, num_tags], containing new score values.
     """
-    # for simplicity, in shape comments, denote:
+    # For simplicity, in shape comments, denote:
     # 'batch_size' by 'B', 'max_seq_len' by 'T' , 'num_tags' by 'O' (output).
     state = array_ops.expand_dims(state, 2)                         # [B, O, 1]
 
@@ -437,7 +437,7 @@ def crf_decode(potentials, transition_params, sequence_length):
                 Contains the highest scoring tag indicies.
     best_score: A [batch_size] tensor, containing the score of decode_tags.
   """
-  # for simplicity, in shape comments, denote:
+  # For simplicity, in shape comments, denote:
   # 'batch_size' by 'B', 'max_seq_len' by 'T' , 'num_tags' by 'O' (output).
   num_tags = potentials.get_shape()[2].value
 


### PR DESCRIPTION
Currently, Tensorflow doesn't support CRF decoding (Viterbi decoding) for tensor. Although `tf.contrib.crf.viterbi_decode` function can do CRF decoding, it can only be used at test time, since it accepts Numpy arrays as inputs.

Implementing CRF decoding for tensor benefits us a lot, as this makes our model more portable (e.g. we can freeze model, save it to a `.pb` file and then load it in `Golang` at test time).

This PR implements CRF decoding for tensor and adds test code for it. 

This PR's change is compatible with current API.
