### PR TITLE
Revert "Fix segfault when recording raw allocation returns nullptr"

### DIFF
--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -146,7 +146,7 @@ class TF_ManagedBuffer : public TensorBuffer {
 void* allocate_tensor(const char* operation, size_t len) {
   void* data =
       tensorflow::cpu_allocator()->AllocateRaw(EIGEN_MAX_ALIGN_BYTES, len);
-  if (tensorflow::LogMemory::IsEnabled() && data != nullptr) {
+  if (tensorflow::LogMemory::IsEnabled()) {
     tensorflow::LogMemory::RecordRawAllocation(
         operation, tensorflow::LogMemory::EXTERNAL_TENSOR_ALLOCATION_STEP_ID,
         len, data, tensorflow::cpu_allocator());

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -113,7 +113,8 @@ class EigenCudaStreamDevice : public ::Eigen::StreamInterface {
             << "EigenAllocator for GPU ran out of memory when allocating "
             << num_bytes << ". See error logs for more detailed info.";
       }
-    } else if (LogMemory::IsEnabled()) {
+    }
+    if (LogMemory::IsEnabled()) {
       LogMemory::RecordRawAllocation(operation_, step_id_, num_bytes, ret,
                                      allocator_);
     }


### PR DESCRIPTION
Reverts tensorflow/tensorflow#12074, in favour of a complete fix in 9bb2c8e.