### PR TITLE
Add `.idea/**` into .gitignore for JetBrains IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 __pycache__
 *.swp
 .vscode/
+.idea/**


### PR DESCRIPTION
We usually use `PyCharm` for reading the source code of `Tensorflow`, so it is necessary for most developers to add `.idea/**` into .gitignore for `JetBrains` IDE to ignore those non-project files.