### PR TITLE
show proper error message when run `saved_model_cli` without arguments instead of an error said `AttributeError: 'Namespace' object has no attribute 'func'`

### DIFF
--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -646,6 +646,8 @@ def create_parser():
 def main():
   parser = create_parser()
   args = parser.parse_args()
+  if not hasattr(args.func):
+    parser.error("too few arguments")
   args.func(args)
 
 


### PR DESCRIPTION
before:
```bash
$ saved_model_cli
Traceback (most recent call last):
  File "/home/yjmade/Envs/tf1.3/bin/saved_model_cli", line 11, in <module>
    sys.exit(main())
  File "/home/yjmade/Envs/tf1.3/lib/python3.5/site-packages/tensorflow/python/tools/saved_model_cli.py", line 649, in main
    args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
```

after:
```bash
$ saved_model_cli
usage: saved_model_cli [-h] [-v] {show,run} ...
saved_model_cli: error: too few parameters
```
