### PR TITLE
Corrected dimension notes in attention_wrapper.py

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
+++ b/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
@@ -979,9 +979,9 @@ def _compute_attention(attention_mechanism, cell_output, previous_alignments,
   # alignments shape is
   #   [batch_size, 1, memory_time]
   # attention_mechanism.values shape is
-  #   [batch_size, memory_time, attention_mechanism.num_units]
+  #   [batch_size, memory_time, memory_size]
   # the batched matmul is over memory_time, so the output shape is
-  #   [batch_size, 1, attention_mechanism.num_units].
+  #   [batch_size, 1, memory_size].
   # we then squeeze out the singleton dim.
   context = math_ops.matmul(expanded_alignments, attention_mechanism.values)
   context = array_ops.squeeze(context, [1])


### PR DESCRIPTION
I was following along your Bahdanau implementation while doing my own and noticed a bug in the documentation. While it's true you can project memory and query to `attention.num_inputs`, the context is of shape `[B, memory_size]`.

To illustrate the lines around the ones I edited:
```
# D_attention: num_units
# D_encoded: memory size, encoder dimensionality, ...
# T: time

alignments # B x T x D_attention
alignments_reduced # B x T
memory     # B x T x D_encoded

alignments_reduced x memory # B x D_encoded
```

The `alignments_reduced` is computed in [attention_wrapper.py#L447](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py#L447). ~~Additionally, I do not see mention of this step in the original paper but can see how it might be needed to make calculation of `context` possible.~~

~~Maybe this is an incorrect interpretation of the original paper? It does not seem to mention a projection to a common dimensionality of both memory and query (`D_attention` above), denoted by `num_inputs` in the `BahdanauAttention` constructor. Say now we leave `D_attention = D_encoded`. The result would be that `alignments` and `memory` are of the same dimensionality, can safely be multiplied component-wise and then sum-reduced along the time dimension. This is an alternative interpretation of the paper, an approach that does not introduce `num_inputs` for attention and does not compute the sum along the last `num_inputs` axis (`alignments_reduced`).~~
