### PR TITLE
Add `skip_empty` option to `tf.string_split`

### DIFF
--- a/tensorflow/core/ops/string_ops.cc
+++ b/tensorflow/core/ops/string_ops.cc
@@ -202,6 +202,7 @@ REGISTER_OP("StringSplit")
     .Output("indices: int64")
     .Output("values: string")
     .Output("shape: int64")
+    .Attr("skip_empty: bool = true")
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle unused;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 1, &unused));
@@ -238,6 +239,7 @@ For example:
 
 input: 1-D. Strings to split.
 delimiter: 0-D. Delimiter characters (bytes), or empty string.
+skip_empty: A `bool`. If `True`, skip the empty strings from the result.
 indices: A dense matrix of int64 representing the indices of the sparse tensor.
 values: A vector of strings corresponding to the splited values.
 shape: a length-2 vector of int64 representing the shape of the sparse

--- a/tensorflow/python/kernel_tests/string_split_op_test.py
+++ b/tensorflow/python/kernel_tests/string_split_op_test.py
@@ -126,6 +126,24 @@ class StringSplitOpTest(test.TestCase):
                           [b"hello", b"cruel", b"world", b"hello cruel world"])
       self.assertAllEqual(shape, [2, 3])
 
+  def testStringSplitWithNoSkipEmpty(self):
+    strings = ["#a", "b#", "#c#"]
+
+    with self.test_session() as sess:
+      tokens = string_ops.string_split(strings, "#", skip_empty=False)
+      indices, values, shape = sess.run(tokens)
+      self.assertAllEqual(indices, [[0, 0], [0, 1],
+                                    [1, 0], [1, 1],
+                                    [2, 0], [2, 1], [2, 2]])
+      self.assertAllEqual(values, [b"", b"a", b"b", b"", b"", b"c", b""])
+      self.assertAllEqual(shape, [3, 3])
+
+    with self.test_session() as sess:
+      tokens = string_ops.string_split(strings, "#")
+      indices, values, shape = sess.run(tokens)
+      self.assertAllEqual(values, [b"a", b"b", b"c"])
+      self.assertAllEqual(indices, [[0, 0], [1, 0], [2, 0]])
+      self.assertAllEqual(shape, [3, 1])
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -50,7 +50,7 @@ from tensorflow.python.util import deprecation
 # pylint: enable=wildcard-import
 
 
-def string_split(source, delimiter=" "):  # pylint: disable=invalid-name
+def string_split(source, delimiter=" ", skip_empty=True):  # pylint: disable=invalid-name
   """Split elements of `source` based on `delimiter` into a `SparseTensor`.
 
   Let N be the size of source (typically N will be the batch size). Split each
@@ -78,6 +78,7 @@ def string_split(source, delimiter=" "):  # pylint: disable=invalid-name
     source: `1-D` string `Tensor`, the strings to split.
     delimiter: `0-D` string `Tensor`, the delimiter character, the string should
       be length 0 or 1.
+    skip_empty: A `bool`. If `True`, skip the empty strings from the result.
 
   Raises:
     ValueError: If delimiter is not a string.
@@ -92,7 +93,7 @@ def string_split(source, delimiter=" "):  # pylint: disable=invalid-name
 
   # pylint: disable=protected-access
   indices, values, shape = gen_string_ops._string_split(
-      source, delimiter=delimiter)
+      source, delimiter=delimiter, skip_empty=skip_empty)
   # pylint: enable=protected-access
   indices.set_shape([None, 2])
   values.set_shape([None])

--- a/tensorflow/tools/api/golden/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.pbtxt
@@ -1874,7 +1874,7 @@ tf_module {
   }
   member_method {
     name: "string_split"
-    argspec: "args=[\'source\', \'delimiter\'], varargs=None, keywords=None, defaults=[\' \'], "
+    argspec: "args=[\'source\', \'delimiter\', \'skip_empty\'], varargs=None, keywords=None, defaults=[\' \', \'True\'], "
   }
   member_method {
     name: "string_to_hash_bucket"


### PR DESCRIPTION
This fix add `skip_empty` to `tf.string_split` so that it is possible to have `tf.string_split` behaving similiarly with python.

This fix fixes #12108.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>