### PR TITLE
Fix Windows Linking error

### DIFF
--- a/tensorflow/tools/proto_text/BUILD
+++ b/tensorflow/tools/proto_text/BUILD
@@ -34,7 +34,7 @@ cc_binary(
     visibility = ["//tensorflow:internal"],
     deps = [
         ":gen_proto_text_functions_lib",
-        "//tensorflow/core:lib_proto_parsing",
+        "//tensorflow/core:lib_internal",
     ],
 )
 


### PR DESCRIPTION
Fix https://github.com/tensorflow/tensorflow/issues/12117

`stringpiece.cc` is only the src of `lib_internal`, so we have to add it as a dependency.
@gunan @learyg