### PR TITLE
Fix broken link in `tensorflow/go/README.md`

### DIFF
--- a/tensorflow/go/README.md
+++ b/tensorflow/go/README.md
@@ -23,9 +23,9 @@ from source.
 
 -   [bazel](https://www.bazel.build/versions/master/docs/install.html)
 -   Environment to build TensorFlow from source code
-    ([Linux](https://www.tensorflow.org/versions/master/get_started/os_setup.html#prepare-environment-for-linux)
+    ([Linux](https://www.tensorflow.org/install/install_sources#PrepareLinux)
     or [OS
-    X](https://www.tensorflow.org/versions/master/get_started/os_setup.html#prepare-environment-for-mac-os-x)).
+    X](https://www.tensorflow.org/install/install_sources#PrepareMac)).
     If you don't need GPU support, then try the following: `sh # Linux sudo
     apt-get install python swig python-numpy # OS X with homebrew brew install
     swig`


### PR DESCRIPTION
Fix broken link in `tensorflow/go/README.md`. This is related to #12145 (`tensorflow/java/README.md`) but is in go's README.md instead.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>