### PR TITLE
Fix unnecessary sync_memops cuda pointer attr in GDR

### DIFF
--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -19,7 +19,6 @@
 #include "tensorflow/core/common_runtime/device.h"
 #include "tensorflow/core/common_runtime/dma_helper.h"
 #if GOOGLE_CUDA
-#include "cuda/include/cuda.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_util.h"
 #include "tensorflow/core/common_runtime/gpu/process_state.h"
 #endif  // GOOGLE_CUDA
@@ -291,7 +290,7 @@ Status GdrMemoryManager::Init() {
 
 #if GOOGLE_CUDA
   VisitableAllocator::Visitor cuda_alloc_visitor =
-      std::bind(&GdrMemoryManager::InsertCUDAMemoryRegion, this, _1, _2);
+      std::bind(&GdrMemoryManager::InsertMemoryRegion, this, _1, _2);
   if (IsGDRAvailable()) {
     // Note we don't free allocated GPU memory so there is no free visitor
     int32_t bus_id = TryToReadNumaNode(listening_->verbs->device) + 1;
@@ -644,27 +643,6 @@ void GdrMemoryManager::InsertMemoryRegion(void* addr, size_t length) {
     LOG(WARNING) << "Cannot register memory region";
   }
 }
-
-#if GOOGLE_CUDA
-void GdrMemoryManager::InsertCUDAMemoryRegion(void* addr, size_t length) {
-  if (length == 0) return;
-  unsigned int flag = 1;
-  CUresult result =
-      cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                            reinterpret_cast<uintptr_t>(addr));
-  if (result != CUDA_SUCCESS) {
-    LOG(WARNING) << "Cannot register memory region to GPU";
-  }
-  ibv_mr* mr = rdma_reg_read(listening_.get(), addr, length);
-  if (mr != nullptr) {
-    mutex_lock l(alloc_mu_);
-    auto iter = std::upper_bound(mrs_.begin(), mrs_.end(), addr, &Comparator);
-    mrs_.insert(iter, {mr, &MRDeleter});
-  } else {
-    LOG(WARNING) << "Cannot register memory region to NIC";
-  }
-}
-#endif
 
 void GdrMemoryManager::EvictMemoryRegion(void* addr, size_t length) {
   if (length == 0) return;


### PR DESCRIPTION
See the comments [here](https://github.com/tensorflow/tensorflow/pull/11392#discussion_r132026389). I've tested on my local boxes and it seems removing `CU_POINTER_ATTRIBUTE_SYNC_MEMOPS` slightly improves the training throughput while introducing no data race.