### PR TITLE
Adding support for Big Endian in graph_constructor_test and wav_io

### DIFF
--- a/tensorflow/core/lib/wav/wav_io.cc
+++ b/tensorflow/core/lib/wav/wav_io.cc
@@ -111,7 +111,7 @@ Status ReadValue(const string& data, T* value, int* offset) {
         reinterpret_cast<const uint8*>(data.data() + *offset);
     int shift = 0;
     for (int i = 0; i < sizeof(T); ++i, shift += 8) {
-      *value = *value | (data_buf[i] >> shift);
+      *value = *value | (data_buf[i] << shift);
     }
   }
   *offset = new_offset;


### PR DESCRIPTION
PR to add support for Big Endian for resolving below failures:

1. //tensorflow/core:graph_graph_constructor_test
2. //tensorflow/core/kernels:decode_wav_op_test
3. //tensorflow/core:lib_wav_wav_io_test
4. //tensorflow/core/kernels:encode_wav_op_test

The `tensor_content` in `graph_constructor_test` needs to be corrected for big endian.
Also the `ReadValue` in `wav_io.cc` needs to be shifted other way for big endian.
