### PR TITLE
Adding support for s390x in calculation of cpu_frequency

### DIFF
--- a/tensorflow/core/platform/profile_utils/cpu_utils.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.cc
@@ -33,6 +33,11 @@ static ICpuUtilsHelper* cpu_utils_helper_instance_ = nullptr;
      static const uint64 cpu_frequency = GetCycleCounterFrequencyImpl();
      return cpu_frequency;
 }
+#elif defined(__s390x__)
+   /* static */ uint64 CpuUtils::GetCycleCounterFrequency() {
+     static const uint64 cpu_frequency = GetCycleCounterFrequencyImpl();
+     return cpu_frequency;
+}
 #else
    /* static */ int64 CpuUtils::GetCycleCounterFrequency() {
      static const int64 cpu_frequency = GetCycleCounterFrequencyImpl();

--- a/tensorflow/core/platform/profile_utils/cpu_utils.h
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.h
@@ -99,6 +99,8 @@ class CpuUtils {
   // the first call will incur overhead, but not subsequent calls.
   #if defined(__powerpc__) || defined(__ppc__) && ( __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
      static uint64 GetCycleCounterFrequency();
+  #elif defined(__s390x__)
+     static uint64 GetCycleCounterFrequency();
   #else
      static int64 GetCycleCounterFrequency();
   #endif

--- a/tensorflow/core/platform/profile_utils/cpu_utils_test.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils_test.cc
@@ -57,6 +57,10 @@ TEST_F(CpuUtilsTest, CheckCycleCounterFrequency) {
      const uint64 cpu_frequency = CpuUtils::GetCycleCounterFrequency();
      CHECK_GT(cpu_frequency, 0);
      CHECK_NE(cpu_frequency, unsigned(CpuUtils::INVALID_FREQUENCY));
+  #elif defined(__s390x__)
+     const uint64 cpu_frequency = CpuUtils::GetCycleCounterFrequency();
+     CHECK_GT(cpu_frequency, 0);
+     CHECK_NE(cpu_frequency, unsigned(CpuUtils::INVALID_FREQUENCY));
   #else
      const int64 cpu_frequency = CpuUtils::GetCycleCounterFrequency();
      CHECK_GT(cpu_frequency, 0);


### PR DESCRIPTION
PR for changing the GetCycleCounterFrequency for s390x to fix test `//tensorflow/core:platform_profile_utils_cpu_utils_test`.

Facing issue similar to power reported [here](https://github.com/tensorflow/tensorflow/issues/10450#issuecomment-307097621) .

On s390x too `cpu_frequency = -1` and hence below test fails:
```
[ RUN      ] CpuUtilsTest.CheckCycleCounterFrequency
2017-07-17 04:43:02.050579: F tensorflow/core/platform/profile_utils/cpu_utils_test.cc:57] Check failed: cpu_frequency > 0 (-1 vs. 0)
```

Extending the fix added for PPC raised via [PR ](https://github.com/tensorflow/tensorflow/pull/10522#issuecomment-311064869)

