### PR TITLE
BUG: Estimator.eval() runs feature_engineering_fn more than once.

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/estimator.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimator.py
@@ -1167,7 +1167,6 @@ class Estimator(BaseEstimator):
 
     return model_fn_ops
 
-
   def _get_train_ops(self, features, labels):
     """Method that builds model graph and returns trainer ops.
 

--- a/tensorflow/contrib/learn/python/learn/estimators/estimator.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimator.py
@@ -1118,13 +1118,14 @@ class Estimator(BaseEstimator):
     self._feature_engineering_fn = (
         feature_engineering_fn or _identity_feature_engineering_fn)
 
-  def _call_model_fn(self, features, labels, mode):
+  def _call_model_fn(self, features, labels, mode, metrics=None):
     """Calls model function with support of 2, 3 or 4 arguments.
 
     Args:
       features: features dict.
       labels: labels dict.
       mode: ModeKeys
+      metrics: Dict of metrics.
 
     Returns:
       A `ModelFnOps` object. If model_fn returns a tuple, wraps them up in a
@@ -1147,17 +1148,25 @@ class Estimator(BaseEstimator):
     model_fn_results = self._model_fn(features, labels, **kwargs)
 
     if isinstance(model_fn_results, model_fn_lib.ModelFnOps):
-      return model_fn_results
+      model_fn_ops = model_fn_results
+    else:
+      # Here model_fn_results should be a tuple with 3 elements.
+      if len(model_fn_results) != 3:
+        raise ValueError('Unrecognized value returned by model_fn, '
+                         'please return ModelFnOps.')
+      model_fn_ops = model_fn_lib.ModelFnOps(
+          mode=mode,
+          predictions=model_fn_results[0],
+          loss=model_fn_results[1],
+          train_op=model_fn_results[2])
 
-    # Here model_fn_results should be a tuple with 3 elements.
-    if len(model_fn_results) != 3:
-      raise ValueError('Unrecognized value returned by model_fn, '
-                       'please return ModelFnOps.')
-    return model_fn_lib.ModelFnOps(
-        mode=mode,
-        predictions=model_fn_results[0],
-        loss=model_fn_results[1],
-        train_op=model_fn_results[2])
+    # Custom metrics should overwrite defaults.
+    if metrics:
+      model_fn_ops.eval_metric_ops.update(_make_metrics_ops(
+        metrics, features, labels, model_fn_ops.predictions))
+
+    return model_fn_ops
+
 
   def _get_train_ops(self, features, labels):
     """Method that builds model graph and returns trainer ops.
@@ -1202,12 +1211,6 @@ class Estimator(BaseEstimator):
     """
     model_fn_ops = self._call_model_fn(
         features, labels, model_fn_lib.ModeKeys.EVAL)
-
-    features, labels = self._feature_engineering_fn(features, labels)
-    # Custom metrics should overwrite defaults.
-    if metrics:
-      model_fn_ops.eval_metric_ops.update(_make_metrics_ops(
-          metrics, features, labels, model_fn_ops.predictions))
 
     if metric_key.MetricKey.LOSS not in model_fn_ops.eval_metric_ops:
       model_fn_ops.eval_metric_ops[metric_key.MetricKey.LOSS] = (

--- a/tensorflow/contrib/learn/python/learn/estimators/estimator.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimator.py
@@ -1209,7 +1209,7 @@ class Estimator(BaseEstimator):
       ValueError: if `metrics` don't match `labels`.
     """
     model_fn_ops = self._call_model_fn(
-        features, labels, model_fn_lib.ModeKeys.EVAL)
+        features, labels, model_fn_lib.ModeKeys.EVAL, metrics)
 
     if metric_key.MetricKey.LOSS not in model_fn_ops.eval_metric_ops:
       model_fn_ops.eval_metric_ops[metric_key.MetricKey.LOSS] = (

--- a/tensorflow/contrib/learn/python/learn/estimators/estimators_test.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimators_test.py
@@ -77,6 +77,45 @@ class FeatureEngineeringFunctionTest(test.TestCase):
     # labels = transformed_y (99)
     self.assertEqual(99., metrics["label"])
 
+  def testFeatureEngineeringFnWithSameName(self):
+
+    def input_fn():
+      return {
+               "x": constant_op.constant(["9."])
+             }, {
+               "y": constant_op.constant(["99."])
+             }
+
+    def feature_engineering_fn(features, labels):
+      _, _ = features, labels
+      return {
+               "x": constant_op.constant([9.])
+             }, {
+               "y": constant_op.constant([99.])
+             }
+
+    def model_fn(features, labels):
+      # dummy variable:
+      _ = variables_lib.Variable([0.])
+      _ = labels
+      predictions = features["x"]
+      loss = constant_op.constant([2.])
+      update_global_step = variables.get_global_step().assign_add(1)
+      return predictions, loss, update_global_step
+
+    estimator = estimator_lib.Estimator(
+      model_fn=model_fn, feature_engineering_fn=feature_engineering_fn)
+    estimator.fit(input_fn=input_fn, steps=1)
+    prediction = next(estimator.predict(input_fn=input_fn, as_iterable=True))
+    # predictions = transformed_x (9)
+    self.assertEqual(9., prediction)
+    metrics = estimator.evaluate(
+      input_fn=input_fn, steps=1,
+      metrics={"label":
+                 metric_spec.MetricSpec(lambda predictions, labels: labels)})
+    # labels = transformed_y (99)
+    self.assertEqual(99., metrics["label"])
+
   def testNoneFeatureEngineeringFn(self):
 
     def input_fn():

--- a/tensorflow/contrib/learn/python/learn/estimators/estimators_test.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimators_test.py
@@ -30,6 +30,7 @@ from tensorflow.contrib.learn.python.learn.estimators import estimator as estima
 from tensorflow.contrib.learn.python.learn.estimators._sklearn import accuracy_score
 from tensorflow.contrib.learn.python.learn.estimators._sklearn import train_test_split
 from tensorflow.python.framework import constant_op
+from tensorflow.python.ops import string_ops
 from tensorflow.python.ops import variables as variables_lib
 from tensorflow.python.platform import test
 from tensorflow.python.training import momentum as momentum_lib
@@ -87,12 +88,11 @@ class FeatureEngineeringFunctionTest(test.TestCase):
              }
 
     def feature_engineering_fn(features, labels):
-      _, _ = features, labels
-      return {
-               "x": constant_op.constant([9.])
-             }, {
-               "y": constant_op.constant([99.])
-             }
+      # Github #12205: raise a TypeError if called twice.
+      _ = string_ops.string_split(features["x"])
+      features["x"] = constant_op.constant([9.])
+      label["y"] = constant_op.constant([99.])
+      return features, labels
 
     def model_fn(features, labels):
       # dummy variable:

--- a/tensorflow/contrib/learn/python/learn/estimators/estimators_test.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/estimators_test.py
@@ -91,7 +91,7 @@ class FeatureEngineeringFunctionTest(test.TestCase):
       # Github #12205: raise a TypeError if called twice.
       _ = string_ops.string_split(features["x"])
       features["x"] = constant_op.constant([9.])
-      label["y"] = constant_op.constant([99.])
+      labels["y"] = constant_op.constant([99.])
       return features, labels
 
     def model_fn(features, labels):


### PR DESCRIPTION
The PR is aimed to fix #12205.

### What changes were proposed in this pull request?

eliminate the second call of `feature_engineering_fn` in `evaluate` method.


### How was this patch tested?

+ [x] add an unit test.