### PR TITLE
 Remove useless RecvTensorResponse allocation in GDR

### DIFF
--- a/tensorflow/contrib/gdr/gdr_worker.cc
+++ b/tensorflow/contrib/gdr/gdr_worker.cc
@@ -99,8 +99,6 @@ void GdrWorker::GrpcRecvTensorAsync(CallOptions* opts,
               alloc_attrs.set_on_host(true);
               Allocator* alloc = src_dev->GetAllocator(alloc_attrs);
               Tensor* copy = new Tensor(alloc, val.dtype(), val.shape());
-              RecvTensorResponse* tmp = new RecvTensorResponse;
-              tmp->set_is_dead(is_dead);
               CHECK(send_dev_context)
                   << "send dev name: " << src_dev->name()
                   << " gpu_info: " << src_dev->tensorflow_gpu_device_info();


### PR DESCRIPTION
See [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc#L347) for your reference.