### PR TITLE
Reverting a commit that is causing compilation errors.

### DIFF
--- a/tensorflow/core/kernels/qr_op_impl.h
+++ b/tensorflow/core/kernels/qr_op_impl.h
@@ -20,9 +20,6 @@ limitations under the License.
 // improve compilation times.
 #include <algorithm>
 
-#ifdef INTEL_MKL
-#define EIGEN_USE_MKL_ALL
-#endif // INTEL_MKL
 
 #include "third_party/eigen3/Eigen/QR"
 #include "tensorflow/core/framework/kernel_def_builder.h"


### PR DESCRIPTION
MKL optimized Tensorflow does not support EIGEN_USE_MKL_ALL currently.