### PR TITLE
Fix issues due to old numpy versions in dist_test and gcs_test

### DIFF
--- a/tensorflow/tools/dist_test/Dockerfile
+++ b/tensorflow/tools/dist_test/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update
 RUN apt-get install -y \
     curl \
     python \
-    python-numpy \
     python-pip \
     && \
     apt-get clean && \

--- a/tensorflow/tools/dist_test/Dockerfile.local
+++ b/tensorflow/tools/dist_test/Dockerfile.local
@@ -23,7 +23,6 @@ MAINTAINER Shanqing Cai <cais@google.com>
 
 # Pick up some TF dependencies.
 RUN apt-get update && apt-get install -y \
-        python-numpy \
         python-pip \
         && \
     apt-get clean && \

--- a/tensorflow/tools/gcs_test/Dockerfile
+++ b/tensorflow/tools/gcs_test/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get install -y \
     curl \
     libcurl4-openssl-dev \
     python \
-    python-numpy \
     python-pip
 
 # Install Google Cloud SDK


### PR DESCRIPTION
Previously numpy was installed with apt-get, leading to a version too
old to be compatible with the recently-added autograd dependency of
tensorflow. This change set fixes that.