### PR TITLE
Fix error caused in MonitoredSession.close()

### DIFF
--- a/tensorflow/python/training/monitored_session.py
+++ b/tensorflow/python/training/monitored_session.py
@@ -566,6 +566,8 @@ class _MonitoredSession(object):
           h.end(self._coordinated_creator.tf_sess)
     finally:
       try:
+        if self._sess is None:
+          raise RuntimeError('Session is already closed.')
         self._sess.close()
       finally:
         self._sess = None

--- a/tensorflow/python/training/monitored_session_test.py
+++ b/tensorflow/python/training/monitored_session_test.py
@@ -1414,6 +1414,12 @@ class MonitoredSessionTest(test.TestCase):
             isinstance(hook.run_metadata_list[0], config_pb2.RunMetadata))
         self.assertGreater(len(hook.run_metadata_list[0].partition_graphs), 0)
 
+  def test_with_statement_and_close(self):
+    # Test case for https://github.com/tensorflow/tensorflow/issues/12224
+    # where close() inside the with should have a better error message.
+    with self.assertRaisesRegexp(RuntimeError, 'Session is already closed'):
+      with monitored_session.MonitoredSession() as session:
+        session.close()
 
 class SingularMonitoredSessionTest(test.TestCase):
   """Tests SingularMonitoredSession."""


### PR DESCRIPTION
This fix tries to address the error raised in #12224:
```
>>> import tensorflow as tf
>>> with tf.train.MonitoredTrainingSession() as sess:
...   sess.close()
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/training/monitored_session.py", line 534, in __exit__
    self._close_internal(exception_type)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/training/monitored_session.py", line 569, in _close_internal
    self._sess.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

The error was caused by double call on `_internal_close()`.

This fix fixes the issue by skipping the error at the end of the `close()`.

This fix fixes #12224

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>