### PR TITLE
make `gather` cpu kernel to be multiple threads.

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -1098,7 +1098,7 @@ tf_kernel_library(
     visibility = [":friends"],
     deps = [
         ":bounds_check",
-        "//tensorflow/core:framework_lite",
+        "//tensorflow/core:framework",
         "//third_party/eigen3",
     ],
 )

--- a/tensorflow/core/kernels/gather_functor.cc
+++ b/tensorflow/core/kernels/gather_functor.cc
@@ -28,7 +28,7 @@ namespace functor {
 #define DECLARE_GPU_SPECS_INDEX(T, Index)                             \
   template <>                                                         \
   int64 GatherFunctor<GPUDevice, T, Index>::operator()(               \
-      const GPUDevice& d, typename TTypes<T, 3>::ConstTensor Tparams, \
+      OpKernelContext* ctx, typename TTypes<T, 3>::ConstTensor Tparams, \
       typename TTypes<Index>::ConstFlat Tindices,                     \
       typename TTypes<T, 3>::Tensor Tout);                            \
   extern template struct GatherFunctor<GPUDevice, T, Index>;

--- a/tensorflow/core/kernels/gather_functor.h
+++ b/tensorflow/core/kernels/gather_functor.h
@@ -34,7 +34,8 @@ namespace functor {
 // Helper method to copy using memcpy.
 template <typename T, typename Index, typename SliceIndex,
           SliceIndex static_slice_elems>
-SliceIndex HandleCopies(typename TTypes<T, 3>::ConstTensor params,
+SliceIndex HandleCopies(OpKernelContext* ctx,
+                        typename TTypes<T, 3>::ConstTensor params,
                         typename TTypes<Index>::ConstFlat indices,
                         SliceIndex slice_elems,
                         typename TTypes<T, 3>::Tensor out) {
@@ -49,104 +50,13 @@ SliceIndex HandleCopies(typename TTypes<T, 3>::ConstTensor params,
   }
   // Compute slice_bytes here so that static knowledge is available
   const size_t slice_bytes = slice_elems * sizeof(T);
-  for (SliceIndex b = 0; b < batch_size; b++) {
-    for (SliceIndex i = 0; i < indices_size; i++) {
-      const SliceIndex i_next = i + 1;
-      const SliceIndex b_next = b + 1;
-      if (i_next < indices_size) {
-        port::prefetch<port::PREFETCH_HINT_T0>(&params(b, indices(i_next), 0));
-        port::prefetch<port::PREFETCH_HINT_T0>(&out(b, i_next, 0));
-      } else if (b_next < batch_size) {
-        port::prefetch<port::PREFETCH_HINT_T0>(&params(b_next, indices(0), 0));
-        port::prefetch<port::PREFETCH_HINT_T0>(&out(b_next, 0, 0));
-      }
-      // Grab the index and check its validity.  An earlier version of the
-      // code checked it and then grabbed it from memory a second time, which
-      // was a security risk since it could have changed in between.
-      const Index index = internal::SubtleMustCopy(indices(i));
-      if (!FastBoundsCheck(index, limit)) return i;
-      // Copy using memcpy if possible, otherwise an Eigen loop
-      // TODO(cwhipkey): avoid linking to framework to get Allocator (to improve
-      // ahead-of-time compilation binary size).
-      if (is_simple_type<T>::value) {
-        // Avoid auto-promotion to Index from SliceIndex by casting.
-        memcpy(out_base + (b * indices_size + i) * slice_elems,
-               params_base + (b * static_cast<SliceIndex>(limit) +
-                              static_cast<SliceIndex>(index)) *
-                                 slice_elems,
-               slice_bytes);
-      } else {
-        // For non-"simple" types (e.g. strings).
-        out.template chip<1>(i) = params.template chip<1>(index);
-      }
-    }
-  }
-  return -1;
-}
-
-template <typename T, typename Index>
-struct GatherFunctorCPU {
-  int64 operator()(typename TTypes<T, 3>::ConstTensor params,
-                   typename TTypes<Index>::ConstFlat indices,
-                   typename TTypes<T, 3>::Tensor out) {
-    const int64 N = indices.size();
-    const int64 slice_size = out.dimension(2);
-    int64 bad_i;
-
-    bool use_large = (slice_size > std::numeric_limits<int32>::max() ||
-                      params.size() > std::numeric_limits<int32>::max() ||
-                      N > std::numeric_limits<int32>::max());
-#define CALL(elems)                                                   \
-  do {                                                                \
-    if (use_large) {                                                  \
-      bad_i = HandleCopies<T, Index, int64, elems>(params, indices,   \
-                                                   slice_size, out);  \
-    } else {                                                          \
-      const int32 small_slice = static_cast<int32>(slice_size);       \
-      bad_i = HandleCopies<T, Index, int32, elems>(params, indices,   \
-                                                   small_slice, out); \
-    }                                                                 \
-  } while (0)
-
-    if (slice_size == 10)
-      CALL(10);
-    else if (slice_size == 20)
-      CALL(20);
-    else
-      CALL(-1);
-#undef CALL
-
-    return bad_i;
-  }
-};
-
-// Helper method to copy using memcpy.
-template <typename T, typename Index, typename SliceIndex,
-        SliceIndex static_slice_elems>
-SliceIndex HandleCopiesMT(OpKernelContext* ctx,
-                          typename TTypes<T, 3>::ConstTensor params,
-                          typename TTypes<Index>::ConstFlat indices,
-                          SliceIndex slice_elems,
-                          typename TTypes<T, 3>::Tensor out) {
-  const SliceIndex indices_size = static_cast<SliceIndex>(indices.dimension(0));
-  const SliceIndex batch_size = static_cast<SliceIndex>(params.dimension(0));
-  const Index limit = static_cast<Index>(params.dimension(1));
-  T* out_base = &out(0, 0, 0);
-  const T* params_base = &params(0, 0, 0);
-  if (static_slice_elems >= 0) {
-    // Give compiler static knowledge of the number of elements/bytes
-    slice_elems = static_slice_elems;
-  }
-  // Compute slice_bytes here so that static knowledge is available
-  const size_t slice_bytes = slice_elems * sizeof(T);
   auto worker_threads = ctx->device()->tensorflow_cpu_worker_threads();
   mutex mu;
   SliceIndex result = -1 GUARDED_BY(mu);
-  auto work = [&params, params_base, &indices, &out, out_base, &slice_bytes,
-          &indices_size, &limit, &slice_elems, &mu, &result] (int64 start, int64 end) {
+  auto work = [&] (int64 start, int64 end) {
     for(int64 i = start; i < end; ++i) {
-      int64 batch_idx = i / indices_size;
-      int64 indices_idx = i % indices_size;
+      SliceIndex batch_idx = static_cast<SliceIndex>(i / indices_size);
+      SliceIndex indices_idx = static_cast<SliceIndex>(i % indices_size);
       // Grab the index and check its validity.  An earlier version of the
       // code checked it and then grabbed it from memory a second time, which
       // was a security risk since it could have changed in between.
@@ -178,6 +88,43 @@ SliceIndex HandleCopiesMT(OpKernelContext* ctx,
   return result;
 }
 
+template <typename T, typename Index>
+struct GatherFunctorCPU {
+  int64 operator()(OpKernelContext* ctx,
+                   typename TTypes<T, 3>::ConstTensor params,
+                   typename TTypes<Index>::ConstFlat indices,
+                   typename TTypes<T, 3>::Tensor out) {
+  const int64 N = indices.size();
+  const int64 slice_size = out.dimension(2);
+  int64 bad_i;
+
+  bool use_large = (slice_size > std::numeric_limits<int32>::max() ||
+                    params.size() > std::numeric_limits<int32>::max() ||
+                    N > std::numeric_limits<int32>::max());
+#define CALL(elems)                                                   \
+  do {                                                                \
+    if (use_large) {                                                  \
+      bad_i = HandleCopies<T, Index, int64, elems>(ctx, params, indices,   \
+                                                   slice_size, out);  \
+    } else {                                                          \
+      const int32 small_slice = static_cast<int32>(slice_size);       \
+      bad_i = HandleCopies<T, Index, int32, elems>(ctx, params, indices,   \
+                                                   small_slice, out); \
+    }                                                                 \
+  } while (0)
+
+    if (slice_size == 10)
+      CALL(10);
+    else if (slice_size == 20)
+      CALL(20);
+    else
+      CALL(-1);
+#undef CALL
+
+    return bad_i;
+  }
+};
+
 template <typename Device, typename T, typename Index>
 struct GatherFunctor {
   int64 operator()(OpKernelContext* ctx, typename TTypes<T, 3>::ConstTensor params,
@@ -191,24 +138,7 @@ struct GatherFunctor<CPUDevice, T, Index> {
                    typename TTypes<T, 3>::ConstTensor params,
                    typename TTypes<Index>::ConstFlat indices,
                    typename TTypes<T, 3>::Tensor out) {
-  const int64 slice_size = out.dimension(2);
-  int64 bad_i;
-
-#define CALL(elems)                                                   \
-  do {                                                                \
-    bad_i = HandleCopiesMT<T, Index, int64, elems>(ctx, params, indices,   \
-                                                 slice_size, out);  \
-  } while (0)
-
-    if (slice_size == 10)
-      CALL(10);
-    else if (slice_size == 20)
-      CALL(20);
-    else
-      CALL(-1);
-#undef CALL
-
-    return bad_i;
+    return GatherFunctorCPU<T, Index>()(ctx, params, indices, out);
   }
 };
 

--- a/tensorflow/core/kernels/gather_functor.h
+++ b/tensorflow/core/kernels/gather_functor.h
@@ -74,9 +74,6 @@ SliceIndex HandleCopies(OpKernelContext* ctx,
         port::prefetch<port::PREFETCH_HINT_T0>(&out(b_next, 0, 0));
         i_next = 0;
       }
-      // Grab the index and check its validity.  An earlier version of the
-      // code checked it and then grabbed it from memory a second time, which
-      // was a security risk since it could have changed in between.
       const Index index = internal::SubtleMustCopy(indices(indices_idx));
       if (!FastBoundsCheck(index, limit)) {
         mutex_lock l(mu);

--- a/tensorflow/core/kernels/gather_functor.h
+++ b/tensorflow/core/kernels/gather_functor.h
@@ -112,23 +112,23 @@ struct GatherFunctorCPU {
                    typename TTypes<T, 3>::ConstTensor params,
                    typename TTypes<Index>::ConstFlat indices,
                    typename TTypes<T, 3>::Tensor out) {
-  const int64 N = indices.size();
-  const int64 slice_size = out.dimension(2);
-  int64 bad_i;
+    const int64 N = indices.size();
+    const int64 slice_size = out.dimension(2);
+    int64 bad_i;
 
-  bool use_large = (slice_size > std::numeric_limits<int32>::max() ||
-                    params.size() > std::numeric_limits<int32>::max() ||
-                    N > std::numeric_limits<int32>::max());
-#define CALL(elems)                                                   \
-  do {                                                                \
-    if (use_large) {                                                  \
+    bool use_large = (slice_size > std::numeric_limits<int32>::max() ||
+                      params.size() > std::numeric_limits<int32>::max() ||
+                      N > std::numeric_limits<int32>::max());
+#define CALL(elems)                                                        \
+  do {                                                                     \
+    if (use_large) {                                                       \
       bad_i = HandleCopies<T, Index, int64, elems>(ctx, params, indices,   \
-                                                   slice_size, out);  \
-    } else {                                                          \
-      const int32 small_slice = static_cast<int32>(slice_size);       \
+                                                   slice_size, out);       \
+    } else {                                                               \
+      const int32 small_slice = static_cast<int32>(slice_size);            \
       bad_i = HandleCopies<T, Index, int32, elems>(ctx, params, indices,   \
-                                                   small_slice, out); \
-    }                                                                 \
+                                                   small_slice, out);      \
+    }                                                                      \
   } while (0)
 
     if (slice_size == 10)

--- a/tensorflow/core/kernels/gather_functor.h
+++ b/tensorflow/core/kernels/gather_functor.h
@@ -52,6 +52,7 @@ SliceIndex HandleCopies(OpKernelContext* ctx,
   const size_t slice_bytes = slice_elems * sizeof(T);
   auto worker_threads = ctx->device()->tensorflow_cpu_worker_threads();
   mutex mu;
+  // Store the value of invalidate index for printing error information, it's a shared variable.
   SliceIndex result = -1 GUARDED_BY(mu);
   auto work = [&] (int64 start, int64 end) {
     SliceIndex batch_idx = static_cast<SliceIndex>(start / indices_size);

--- a/tensorflow/core/kernels/gather_functor.h
+++ b/tensorflow/core/kernels/gather_functor.h
@@ -53,7 +53,7 @@ SliceIndex HandleCopies(OpKernelContext* ctx,
   auto worker_threads = ctx->device()->tensorflow_cpu_worker_threads();
   mutex mu;
   // Store the value of invalidate index for printing error information, it's a shared variable.
-  SliceIndex result = -1 GUARDED_BY(mu);
+  SliceIndex result = -1;
   auto work = [&] (int64 start, int64 end) {
     SliceIndex batch_idx = static_cast<SliceIndex>(start / indices_size);
     SliceIndex indices_idx = static_cast<SliceIndex>(start % indices_size);

--- a/tensorflow/core/kernels/gather_functor_gpu.cu.h
+++ b/tensorflow/core/kernels/gather_functor_gpu.cu.h
@@ -72,10 +72,11 @@ __global__ void GatherOpKernel(const T* params, const Index* indices, T* out,
 namespace functor {
 template <typename T, typename Index>
 struct GatherFunctor<GPUDevice, T, Index> {
-  int64 operator()(const GPUDevice& d,
+  int64 operator()(OpKernelContext* ctx,
                    typename TTypes<T, 3>::ConstTensor params,
                    typename TTypes<Index>::ConstFlat indices,
                    typename TTypes<T, 3>::Tensor out) {
+    const GPUDevice& d = ctx->eigen_gpu_device();
     const int64 out_size = out.size();
     if (out_size == 0) {
       // We need a check here since the CPU version does useful error checking

--- a/tensorflow/core/kernels/gather_op.cc
+++ b/tensorflow/core/kernels/gather_op.cc
@@ -106,7 +106,7 @@ class GatherOp : public OpKernel {
       auto out_flat = out->shaped<T, 3>({outer_size, N, inner_size});
 
       functor::GatherFunctor<Device, T, Index> functor;
-      int64 bad_i = functor(c->eigen_device<Device>(), params_flat,
+      int64 bad_i = functor(c, params_flat,
                             indices_flat, out_flat);
 
       OP_REQUIRES(

--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -464,7 +464,7 @@ class ResourceGatherOp : public OpKernel {
       auto out_flat = out->shaped<T, 3>({1, N, out->NumElements() / N});
 
       functor::GatherFunctor<Device, T, Index> functor;
-      int64 bad_i = functor(c->eigen_device<Device>(), params_flat,
+      int64 bad_i = functor(c, params_flat,
                             indices_flat, out_flat);
 
       OP_REQUIRES(


### PR DESCRIPTION
related to [11709](https://github.com/tensorflow/tensorflow/issues/11709).
On a single machine, profiling the [embedding_lookup_sparse](https://gist.github.com/nolanliou/c00af5938b2aecfdc5ea1189426b8624) with tfprof, the result shows that gather Op takes a lot of time. I checked the code and found that the CPU version gather op is single-thread. 

Then I modify the gather Op to multi-threads, the result shows about 6x speedup. 

### Profiling result
```
node name | requested bytes | total execution time | accelerator execution t    ime | cpu execution time`
# old `gather`
Gather     2048.00MB (100.00%, 2.27%),   622.96ms (99.99%, 22.97%),    0us (0.00%, 0.00%),  622.96ms (99.99%, 22.97%)
# multi-threads `gather`
Gather    2048.00MB (100.00%, 49.96%),   107.91ms (99.99%, 5.50%),     0us (0.00%, 0.00%),   107.91ms (99.99%, 5.50%)
```