### PR TITLE
r1.3 fix Bazel 0.5.3 build error

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -106,7 +106,7 @@ def _get_cxx_inc_directories_impl(repository_ctx, cc, lang_is_cpp):
   else:
     inc_dirs = result.stderr[index1 + 1:index2].strip()
 
-  return [repository_ctx.path(_cxx_inc_convert(p))
+  return [str(repository_ctx.path(_cxx_inc_convert(p)))
           for p in inc_dirs.split("\n")]
 
 def get_cxx_inc_directories(repository_ctx, cc):


### PR DESCRIPTION
This is the patch necessary for TensorFlow r1.3 to compile with Bazel 0.5.3, which is set to be merged before the 1.3 release.

@martinwicke Mentioned in https://github.com/tensorflow/tensorflow/pull/11949#issuecomment-321956462 from which this change is cherry picked:

> @av8ramit is this on the 1.3 branch? If not, can you cherry-pick it? It's build only so no need for another RC because of this.

I can confirm it isn't on the 1.3 branch. I'm building on Bazel 0.5.3, and I can also confirm that the r1.3 build works locally on my Ubuntu 16.04 once this patch is added, but does not work without it.

change description:
Fix "depsets cannot contain mutable items" error with CUDA builds in Bazel 0.5.3"

(cherry picked from commit c5d311eaf8cc6471643b5c43810a1feb19662d6c)