### PR TITLE
Update requirement for numpy.

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -32,7 +32,7 @@ from setuptools.dist import Distribution
 _VERSION = '1.3.0-rc2'
 
 REQUIRED_PACKAGES = [
-    'numpy >= 1.11.0',
+    'numpy >= 1.12.1',
     'six >= 1.10.0',
     'protobuf >= 3.3.0',
     'tensorflow-tensorboard >= 0.1.0, < 0.2.0',


### PR DESCRIPTION
Autograd requires numpy >= 1.12.1. If numpy 1.11.0 is already installed on the system, pip will not upgrade numpy when installing tensorflow.  Fix #12185.