### PR TITLE
Add annotations support for tf.estimator.Estimator

### DIFF
--- a/tensorflow/python/estimator/estimator.py
+++ b/tensorflow/python/estimator/estimator.py
@@ -20,7 +20,6 @@ from __future__ import division
 from __future__ import print_function
 
 import copy
-import inspect
 import os
 import tempfile
 
@@ -58,30 +57,6 @@ from tensorflow.python.util import nest
 
 _VALID_MODEL_FN_ARGS = set(
     ['features', 'labels', 'mode', 'params', 'self', 'config'])
-
-
-def _model_fn_args(fn):
-  # The _model_fn is called with args directly so no unwrap like other places
-
-  spec_fn = getattr(inspect, 'getfullargspec', getattr(inspect, 'getargspec'))
-  # Handle callables.
-  if hasattr(fn, '__call__') and inspect.ismethod(fn.__call__):
-    return tuple(spec_fn(fn.__call__).args)
-
-  # Handle functools.partial and similar objects.
-  if hasattr(fn, 'func') and hasattr(fn, 'keywords') and hasattr(fn, 'args'):
-    # Handle nested partial.
-    original_args = _model_fn_args(fn.func)
-    if not original_args:
-      return tuple()
-
-    return tuple([
-        arg for arg in original_args[len(fn.args):]
-        if arg not in set((fn.keywords or {}).keys())
-    ])
-
-  # Handle function.
-  return tuple(spec_fn(fn).args)
 
 
 class Estimator(object):
@@ -715,7 +690,7 @@ class Estimator(object):
     Raises:
       ValueError: if model_fn returns invalid objects.
     """
-    model_fn_args = _model_fn_args(self._model_fn)
+    model_fn_args = util.fn_args(self._model_fn)
     kwargs = {}
     if 'labels' in model_fn_args:
       kwargs['labels'] = labels
@@ -948,7 +923,7 @@ def _get_replica_device_setter(config):
 
 def _verify_model_fn_args(model_fn, params):
   """Verifies model fn arguments."""
-  args = set(_model_fn_args(model_fn))
+  args = set(util.fn_args(model_fn))
   if 'features' not in args:
     raise ValueError('model_fn (%s) must include features argument.' % model_fn)
   if params is not None and 'params' not in args:

--- a/tensorflow/python/estimator/util.py
+++ b/tensorflow/python/estimator/util.py
@@ -52,7 +52,7 @@ def fn_args(fn):
   else:
     if _is_callable_object(fn):
       fn = fn.__call__
-    args = tf_inspect.getargspec(fn).args
+    args = tf_inspect.getfullargspec(fn).args
     if _is_bounded_method(fn):
       args.remove('self')
   return tuple(args)

--- a/tensorflow/python/util/tf_inspect.py
+++ b/tensorflow/python/util/tf_inspect.py
@@ -45,6 +45,26 @@ def getargspec(object):  # pylint: disable=redefined-builtin
                if d.decorator_argspec is not None), _inspect.getargspec(target))
 
 
+def getfullargspec(obj):  # pylint: disable=redefined-builtin
+  """TFDecorator-aware replacement for inspect.getfullargspec and fallback to
+  inspect.getargspec in Python 2.
+
+  Args:
+    obj: A callable, possibly decorated.
+
+  Returns:
+    The `FullArgSpec` (`ArgSpec` in Python 2) that describes the signature of
+    the outermost decorator that changes the callable's signature. If the
+    callable is not decorated, `inspect.getfullargspec()`
+    (`inspect.getargspec()` in Python 2) will be called directly on the
+    callable.
+  """
+  spec_fn = getattr(_inspect, 'getfullargspec', getattr(_inspect, 'getargspec'))
+  decorators, target = tf_decorator.unwrap(obj)
+  return next((d.decorator_argspec for d in decorators
+               if d.decorator_argspec is not None), spec_fn(target))
+
+
 def getcallargs(func, *positional, **named):
   """TFDecorator-aware replacement for inspect.getcallargs.
 


### PR DESCRIPTION
This fix adds annotations support for tf.estimator.Estimator so that the following works in python 3:
```
import tensorflow as tf

def model_fn(features: dict, labels: tf.Tensor, mode: str):
    pass

estimator = tf.estimator.Estimator(model_fn)
```

This fix fixes #12249.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>