### PR TITLE
Verbs hang fix

### DIFF
--- a/tensorflow/contrib/verbs/rdma.h
+++ b/tensorflow/contrib/verbs/rdma.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/core/distributed_runtime/worker_env.h"
+#include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/platform/env.h"
@@ -225,6 +226,12 @@ class RdmaTensorBuffer : public RdmaBuffer {
   explicit RdmaTensorBuffer(RdmaChannel* channel, string name);
   virtual ~RdmaTensorBuffer() override {}
   void SendNextItem() override;
+  void PostCopyOperations(bool can_memcpy, size_t buffer_size,
+                          size_t tensor_bytes, const string& key,
+                          const Tensor& in, int64 step_id, bool is_dead,
+                          const string& key_with_step_id, const Tensor* copy,
+                          const TensorProto* proto,
+                          const StringPiece* copy_buf);
 };
 
 struct RdmaMessage {

--- a/tensorflow/contrib/verbs/verbs_util.cc
+++ b/tensorflow/contrib/verbs/verbs_util.cc
@@ -21,50 +21,17 @@ limitations under the License.
 namespace tensorflow {
 
 // static sync wrapper:
-Status VerbsUtil::CopyGPUTensorToCPUSync(Device* gpu_device,
-                              const DeviceContext* device_context,
-                              const Tensor* gpu_tensor,
-                              Tensor* cpu_tensor) {
-  Notification n;
-  Status status;
-  GPUUtil::CopyGPUTensorToCPU(gpu_device, device_context,
-                              gpu_tensor, cpu_tensor,
-                              [&n, &status](const Status& s) {
-                                status = s;
-                                n.Notify();
-                              });
-  n.WaitForNotification();
-  return status;
-}
-
-// static sync wrapper:
 Status VerbsUtil::CopyCPUTensorToGPUSync(const Tensor* cpu_tensor,
                                          const DeviceContext* device_context,
                                          Device* gpu_device,
                                          Tensor* gpu_tensor) {
   Notification n;
   Status status;
-  GPUUtil::CopyCPUTensorToGPU(cpu_tensor, device_context,
-                              gpu_device, gpu_tensor,
-                              [&n, &status](const Status& s) {
+  GPUUtil::CopyCPUTensorToGPU(cpu_tensor, device_context, gpu_device,
+                              gpu_tensor, [&n, &status](const Status& s) {
                                 status = s;
                                 n.Notify();
                               });
-  n.WaitForNotification();
-  return status;
-}
-
-// static sync wrapper:
-Status VerbsUtil::SetProtoFromGPUSync(const Tensor& tensor, Device* dev,
-                                      const DeviceContext* device_context,
-                                      TensorProto* proto, bool is_dead) {
-  Notification n;
-  Status status;
-  GPUUtil::SetProtoFromGPU(tensor, dev, device_context, proto, is_dead,
-                           [&n, &status](const Status& s) {
-                             status = s;
-                             n.Notify();
-                           });
   n.WaitForNotification();
   return status;
 }

--- a/tensorflow/contrib/verbs/verbs_util.cc
+++ b/tensorflow/contrib/verbs/verbs_util.cc
@@ -20,22 +20,6 @@ limitations under the License.
 #include "tensorflow/core/lib/strings/str_util.h"
 namespace tensorflow {
 
-// static sync wrapper:
-Status VerbsUtil::CopyCPUTensorToGPUSync(const Tensor* cpu_tensor,
-                                         const DeviceContext* device_context,
-                                         Device* gpu_device,
-                                         Tensor* gpu_tensor) {
-  Notification n;
-  Status status;
-  GPUUtil::CopyCPUTensorToGPU(cpu_tensor, device_context, gpu_device,
-                              gpu_tensor, [&n, &status](const Status& s) {
-                                status = s;
-                                n.Notify();
-                              });
-  n.WaitForNotification();
-  return status;
-}
-
 // static
 string VerbsUtil::AppendStepidToKey(const string& key, int64 step_id) {
   return strings::StrCat(key, ";", step_id);

--- a/tensorflow/contrib/verbs/verbs_util.h
+++ b/tensorflow/contrib/verbs/verbs_util.h
@@ -28,11 +28,6 @@ class TensorProto;
 
 class VerbsUtil {
  public:
-  // synchronous wrapper of CopyCPUTensorToGPU
-  static Status CopyCPUTensorToGPUSync(const Tensor* cpu_tensor,
-                                       const DeviceContext* device_context,
-                                       Device* gpu_device, Tensor* gpu_tensor);
-
   static string AppendStepidToKey(const string& key, int64 step_id);
   static void GetKeyAndStepId(const string& key_with_step_id, string& key,
                               int64& step_id);

--- a/tensorflow/contrib/verbs/verbs_util.h
+++ b/tensorflow/contrib/verbs/verbs_util.h
@@ -28,20 +28,11 @@ class TensorProto;
 
 class VerbsUtil {
  public:
-  // synchronous wrapper of CopyGPUTensorToCPU
-  static Status CopyGPUTensorToCPUSync(Device* gpu_device,
-                                       const DeviceContext* device_context,
-                                       const Tensor* gpu_tensor,
-                                       Tensor* cpu_tensor);
   // synchronous wrapper of CopyCPUTensorToGPU
   static Status CopyCPUTensorToGPUSync(const Tensor* cpu_tensor,
                                        const DeviceContext* device_context,
-                                       Device* gpu_device,
-                                       Tensor* gpu_tensor);
-  // synchronous wrapper of SetProtoFromGPU
-  static Status SetProtoFromGPUSync(const Tensor& tensor, Device* dev,
-                                    const DeviceContext* device_context,
-                                    TensorProto* proto, bool is_dead);
+                                       Device* gpu_device, Tensor* gpu_tensor);
+
   static string AppendStepidToKey(const string& key, int64 step_id);
   static void GetKeyAndStepId(const string& key_with_step_id, string& key,
                               int64& step_id);


### PR DESCRIPTION
Replaces the sync wrappers for device to device operations in verbs_util, with a call to the async function with a callback function. Resolves Issue #11725 

As mentioned in the issue:
I think the problem rises because the Sync deviceToDevice operation blocks the thread, preventing the earlier Async Device to Device operation from finishing- which, for some reason, blocks the later operation.

I've tested this fix in origin/r1.3 since origin/master is currently broken.

2nd commit only removes the unused functions from verbs_utils. It is not required for validity. 

@junshi15 , @shamoya , @byronyi , can you please go over this?