### PR TITLE
Remove tensorboard if we are building tf_nightly.

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -59,6 +59,7 @@ if 'tf_nightly' in project_name:
   for package in REQUIRED_PACKAGES:
     if 'tensorflow-tensorboard' in package:
       REQUIRED_PACKAGES.remove(package)
+      break
 
 # weakref.finalize was introduced in Python 3.4
 if sys.version_info < (3, 4):

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -54,6 +54,12 @@ else:
   # mock comes with unittest.mock for python3, need to install for python2
   REQUIRED_PACKAGES.append('mock >= 2.0.0')
 
+# remove tensorboard from tf-nightly packages
+if 'tf_nightly' in project_name:
+  for package in REQUIRED_PACKAGES:
+    if 'tensorflow-tensorboard' in package:
+      REQUIRED_PACKAGES.remove(package)
+
 # weakref.finalize was introduced in Python 3.4
 if sys.version_info < (3, 4):
   REQUIRED_PACKAGES.append('backports.weakref >= 1.0rc1')

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -76,6 +76,10 @@ CONSOLE_SCRIPTS = [
 ]
 # pylint: enable=line-too-long
 
+# remove the tensorboard console script if building tf_nightly
+if 'tf_nightly' in project_name:
+  CONSOLE_SCRIPTS.remove('tensorboard = tensorboard.main:main')
+
 TEST_PACKAGES = [
     'scipy >= 0.15.1',
 ]


### PR DESCRIPTION
Once there are consistent nightly tensorboard builds I'll have the update_version script just update the tensorboard dependency tag. 