### PR TITLE
Disable denormal_test on s390x platform

### DIFF
--- a/tensorflow/python/kernel_tests/denormal_test.py
+++ b/tensorflow/python/kernel_tests/denormal_test.py
@@ -35,8 +35,8 @@ class DenormalTest(test.TestCase):
       self.assertEqual(tiny, tiny / 16 * 16)
 
   def _flushDenormalsTest(self, use_gpu, dtypes):
-    if platform.machine() == "ppc64le":
-      # Disabled denormal_test on power platform
+    if platform.machine() in ["ppc64le", "s390x"]:
+      # Disabled denormal_test on power/s390x platform
       # Check relevant discussion - https://github.com/tensorflow/tensorflow/issues/11902
       return
     with self.test_session(use_gpu=use_gpu):

--- a/tensorflow/python/kernel_tests/denormal_test.py
+++ b/tensorflow/python/kernel_tests/denormal_test.py
@@ -35,7 +35,7 @@ class DenormalTest(test.TestCase):
       self.assertEqual(tiny, tiny / 16 * 16)
 
   def _flushDenormalsTest(self, use_gpu, dtypes):
-    if platform.machine() in ["ppc64le", "s390x"]:
+    if platform.machine() == "ppc64le" or platform.machine() == "s390x":
       # Disabled denormal_test on power/s390x platform
       # Check relevant discussion - https://github.com/tensorflow/tensorflow/issues/11902
       return


### PR DESCRIPTION
As per the discussion happened on [11902](https://github.com/tensorflow/tensorflow/issues/11902), the mentioned modes are not applicable for s390x architecture as well. So disabling denormal_test for s390x platform.