### PR TITLE
Respect `optimize` parameter in `zeros_like`

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1481,7 +1481,8 @@ def zeros_like(tensor, dtype=None, name=None, optimize=True):
     # For now, variant types must be created via zeros_like; as we need to
     # pass the input variant object to the proper zeros callback.
 
-    if tensor.shape.is_fully_defined() and tensor.dtype != dtypes.variant:
+    if optimize and tensor.shape.is_fully_defined() and \
+        tensor.dtype != dtypes.variant:
       # We can produce a zeros tensor independent of the value of 'tensor',
       # since the shape is known statically.
       return zeros(tensor.shape, dtype=dtype or tensor.dtype, name=name)


### PR DESCRIPTION
This fix address the issue in #12436 where `optimize` flag was not respected when shape is fully defined for `zeros_like`.

This fix fixes #12436.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>