### PR TITLE
Change required cuDNN from v5.1 to v6.0 for Linux in the docs

### DIFF
--- a/tensorflow/docs_src/install/install_linux.md
+++ b/tensorflow/docs_src/install/install_linux.md
@@ -33,7 +33,7 @@ must be installed on your system:
     `LD_LIBRARY_PATH` environment variable as described in the
     NVIDIA documentation.
   * The NVIDIA drivers associated with CUDA Toolkit 8.0.
-  * cuDNN v5.1. For details, see
+  * cuDNN v6.0. For details, see
     [NVIDIA's documentation](https://developer.nvidia.com/cudnn).
     Ensure that you create the `CUDA_HOME` environment variable as
     described in the NVIDIA documentation.


### PR DESCRIPTION
This fix changes the required cuDNN from v5.1 to v6.0 for Linux in `tensorflow/docs_src/install/install_linux.md` as the build is linked against libcudnn.so.6 now (not libcudnn.so.5)

This fix fixed #12416.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>