### PR TITLE
find worker session by handle for worker

### DIFF
--- a/tensorflow/core/distributed_runtime/worker.h
+++ b/tensorflow/core/distributed_runtime/worker.h
@@ -111,6 +111,9 @@ class Worker : public WorkerInterface {
                          MutableRunGraphResponseWrapper* response,
                          StatusCallback done);
 
+  template<typename Request>
+  WorkerSession* FindWorkerSession(const Request* req) const;
+
   TF_DISALLOW_COPY_AND_ASSIGN(Worker);
 };
 

--- a/tensorflow/core/distributed_runtime/worker.h
+++ b/tensorflow/core/distributed_runtime/worker.h
@@ -112,7 +112,7 @@ class Worker : public WorkerInterface {
                          StatusCallback done);
 
   template<typename Request>
-  WorkerSession* FindWorkerSession(const Request* req) const;
+  WorkerSession* FindWorkerSessionBy(const Request* req) const;
 
   TF_DISALLOW_COPY_AND_ASSIGN(Worker);
 };


### PR DESCRIPTION
extract common template method to find worker session by handle, and remove duplicated implements.