### PR TITLE
Fix serveral typos in docs.

### DIFF
--- a/tensorflow/docs_src/api_guides/python/reading_data.md
+++ b/tensorflow/docs_src/api_guides/python/reading_data.md
@@ -57,7 +57,7 @@ A typical pipeline for reading records from files has the following stages:
 7.  *Optional* preprocessing
 8.  Example queue
 
-Note: This section discusses implementing input pipelines useing the
+Note: This section discusses implementing input pipelines using the
 queue-based APIs which can be cleanly replaced by the ${$datasets$Dataset API}.
 
 ### Filenames, shuffling, and epoch limits
@@ -498,4 +498,4 @@ session.
 Note: Regardless of the implementation, many
 operations (like ${tf.layers.batch_normalization}, and @{tf.layers.dropout})
 need to know if they are in training or evaluation mode, and you must be
-careful to set this apropriately if you change the data source.
+careful to set this appropriately if you change the data source.

--- a/tensorflow/docs_src/programmers_guide/threading_and_queues.md
+++ b/tensorflow/docs_src/programmers_guide/threading_and_queues.md
@@ -60,7 +60,7 @@ prepare inputs for training a model as follows:
 
 We recommend using the @{tf.contrib.data.Dataset.shuffle$`shuffle`}
 and @{tf.contrib.data.Dataset.batch$`batch`} methods of a
-@{tf.contrib.data.Dataset$`Dataset`} to acomplish this. However, if you'd prefer
+@{tf.contrib.data.Dataset$`Dataset`} to accomplish this. However, if you'd prefer
 to use a queue-based version instead, you can find a full implementation in the
 @{tf.train.shuffle_batch} function.
 


### PR DESCRIPTION
Signed-off-by: Ti Zhou <tizhou1986@gmail.com>

Fix serveral typos in docs.

Including:
tensorflow/docs_src/programmers_guide/threading_and_queues.md
tensorflow/docs_src/api_guides/python/reading_data.md