### PR TITLE
Make scatter_* kernels to be multiple thread and gain 8x speedup.

### DIFF
--- a/tensorflow/core/kernels/scatter_functor.h
+++ b/tensorflow/core/kernels/scatter_functor.h
@@ -157,7 +157,7 @@ struct ScatterFunctor<CPUDevice, T, Index, op> {
 
     // store the result.
     mutex mu;
-    Index result = -1 GUARDED_BY(mu);
+    Index result = -1;
     auto work = [&params, &updates, &indices, &flags, flags_size, limit, &mu, &result]
             (int64 start, int64 end) {
       std::function<void(Index index, Index i)> assign_func;

--- a/tensorflow/python/kernel_tests/embedding_ops_test.py
+++ b/tensorflow/python/kernel_tests/embedding_ops_test.py
@@ -83,7 +83,7 @@ class ScatterAddSubTest(test.TestCase):
       else:
         p_init.reshape(shape[0], -1)[ind, :] -= (vals_init.reshape(
             vals_shape[0], -1)[i, :])
-    self.assertTrue(all((p_init == result).ravel()))
+    self.assertAllClose(p_init, result, rtol=0, atol=1e-5)
 
   def testNoRepetitions(self):
     self._TestCase([2, 2], [1])


### PR DESCRIPTION
Relate to [12358](https://github.com/tensorflow/tensorflow/issues/12358).
Use the lock to deal with the duplicate. After some test, the results show the atomic_flag and spin lock are the best choice and the performance is close  to the lock-free mode.
Benchmark with tfprof, the result shows about 8x speedup.
### Env
- **CPU**
32-cores
- **MEM**
126G
### Parameters
- ref: 10000000*100
- indices: 128000
- updates: 128000*100
```
# orignial
ScatterSub                    4400.00MB (65.69%, 6.66%),        39.50ms (43.19%, 9.00%),            0us (47.10%, 0.00%),        39.50ms (43.14%, 9.11%)
# lock-free
ScatterSub                    4400.00MB (65.69%, 6.66%),         3.84ms (50.64%, 2.20%),            0us (46.37%, 0.00%),         3.84ms (50.76%, 2.27%)
# with lock
ScatterSub                    4400.00MB (65.69%, 6.66%),         4.70ms (50.06%, 2.81%),            0us (45.62%, 0.00%),         4.70ms (50.19%, 2.90%)
```