### PR TITLE
Update doc and imports for crf_decode

### DIFF
--- a/tensorflow/contrib/crf/__init__.py
+++ b/tensorflow/contrib/crf/__init__.py
@@ -23,6 +23,7 @@ See the @{$python/contrib.crf} guide.
 @@crf_binary_score
 @@CrfForwardRnnCell
 @@viterbi_decode
+@@crf_decode
 """
 
 from __future__ import absolute_import
@@ -37,6 +38,7 @@ from tensorflow.contrib.crf.python.ops.crf import crf_sequence_score
 from tensorflow.contrib.crf.python.ops.crf import crf_unary_score
 from tensorflow.contrib.crf.python.ops.crf import CrfForwardRnnCell
 from tensorflow.contrib.crf.python.ops.crf import viterbi_decode
+from tensorflow.contrib.crf.python.ops.crf import crf_decode
 
 from tensorflow.python.util.all_util import remove_undocumented
 


### PR DESCRIPTION
A new method crf_decode was added recently (does the equivalent of viterbi_decode but with tf.Tensors as input).
However it is still not in the docs and it is not importable in tf.contrib.crf; hence the proposed changes.