### PR TITLE
Optimize non_max_suppression by iterating backwards

### DIFF
--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -122,7 +122,9 @@ void DoNonMaxSuppressionOp(OpKernelContext* context,
   for (int i = 0; i < num_boxes; ++i) {
     if (selected.size() >= output_size) break;
     bool should_select = true;
-    for (int j = 0; j < num_selected; ++j) {
+    // Overlapping boxes are likely to have similar scores,
+    // therefore we iterate through the selected boxes backwards.
+    for (int j = num_selected - 1; j >= 0; --j) {
       if (IOUGreaterThanThreshold(boxes_data, sorted_indices[i],
                                   sorted_indices[selected_indices[j]],
                                   iou_threshold)) {


### PR DESCRIPTION
In typical scenarios, high-overlapping boxes are likely to have similar scores.
Therefore if there are any high-overlapping boxes, it's faster to find them starting from boxes that have similar scores.

This simple heuristic improves performance of the op on several actual workload by 10%~20%. The workloads are like ~10k boxes produced by a region proposal network.