### PR TITLE
convert Dimension to Int for sparse_merge in _IndicatorColumn

### DIFF
--- a/tensorflow/python/feature_column/feature_column.py
+++ b/tensorflow/python/feature_column/feature_column.py
@@ -2473,7 +2473,7 @@ class _IndicatorColumn(_DenseColumn,
       weighted_column = sparse_ops.sparse_merge(
           sp_ids=id_tensor,
           sp_values=weight_tensor,
-          vocab_size=self._variable_shape[-1])
+          vocab_size=int(self._variable_shape[-1]))
       return sparse_ops.sparse_tensor_to_dense(weighted_column)
 
     dense_id_tensor = sparse_ops.sparse_tensor_to_dense(

--- a/tensorflow/python/feature_column/feature_column_test.py
+++ b/tensorflow/python/feature_column/feature_column_test.py
@@ -3207,13 +3207,14 @@ class IndicatorColumnTest(test.TestCase):
       self.assertAllEqual([[0, 0, 1], [1, 0, 0]], indicator_tensor.eval())
 
   def test_transform_with_weighted_column(self):
-    id_ = fc.categorical_column_with_vocabulary_list(
-      key='id', vocabulary_list=('a', 'b', 'c'))
-    weight = fc.weighted_categorical_column(id_, 'weight')
-    indicator = fc.indicator_column(weight)
+    # Github issue 12557
+    ids = fc.categorical_column_with_vocabulary_list(
+      key='ids', vocabulary_list=('a', 'b', 'c'))
+    weights = fc.weighted_categorical_column(ids, 'weights')
+    indicator = fc.indicator_column(weights)
     features = {
-      'id': constant_op.constant(['c', 'b', 'a'], shape=(1, 3)),
-      'weight': constant_op.constant([2., 4., 6.], shape=(1, 3))
+      'ids': constant_op.constant(['c', 'b', 'a'], shape=(1, 3)),
+      'weights': constant_op.constant([2., 4., 6.], shape=(1, 3))
     }
     indicator_tensor = _transform_features(features, [indicator])[indicator]
     with _initialized_session():

--- a/tensorflow/python/feature_column/feature_column_test.py
+++ b/tensorflow/python/feature_column/feature_column_test.py
@@ -3208,16 +3208,16 @@ class IndicatorColumnTest(test.TestCase):
 
   def test_transform_with_weighted_column(self):
     id = fc.categorical_column_with_vocabulary_list(
-      key='id', vocabulary_list=('omar', 'stringer', 'marlo'))
+      key='id', vocabulary_list=('a', 'b', 'c'))
     weight = fc.weighted_categorical_column(id, 'weight')
     indicator = fc.indicator_column(weight)
     features = {
-      'id': constant_op.constant(['marlo', 'skywalker', 'omar']),
-      'weight': constant_op.constant([2., 4., 6.])
+      'id': constant_op.constant(['c', 'b', 'a'], shape=(1, 3)),
+      'weight': constant_op.constant([2., 4., 6.], shape=(1, 3))
     }
     indicator_tensor = _transform_features(features, [indicator])[indicator]
     with _initialized_session():
-      self.assertAllEqual([6., 0., 2.], indicator_tensor.eval())
+      self.assertAllEqual([[6., 4., 2.]], indicator_tensor.eval())
 
   def test_linear_model(self):
     animal = fc.indicator_column(

--- a/tensorflow/python/feature_column/feature_column_test.py
+++ b/tensorflow/python/feature_column/feature_column_test.py
@@ -3206,6 +3206,19 @@ class IndicatorColumnTest(test.TestCase):
     with _initialized_session():
       self.assertAllEqual([[0, 0, 1], [1, 0, 0]], indicator_tensor.eval())
 
+  def test_transform_with_weighted_column(self):
+    id = fc.categorical_column_with_vocabulary_list(
+      key='id', vocabulary_list=('omar', 'stringer', 'marlo'))
+    weight = fc.weighted_categorical_column(id, 'weight')
+    indicator = fc.indicator_column(weight)
+    features = {
+      'id': constant_op.constant(['marlo', 'skywalker', 'omar']),
+      'weight': constant_op.constant([2., 4., 6.])
+    }
+    indicator_tensor = _transform_features(features, [indicator])[indicator]
+    with _initialized_session():
+      self.assertAllEqual([6., 0., 2.], indicator_tensor.eval())
+
   def test_linear_model(self):
     animal = fc.indicator_column(
         fc.categorical_column_with_identity('animal', num_buckets=4))

--- a/tensorflow/python/feature_column/feature_column_test.py
+++ b/tensorflow/python/feature_column/feature_column_test.py
@@ -3207,9 +3207,9 @@ class IndicatorColumnTest(test.TestCase):
       self.assertAllEqual([[0, 0, 1], [1, 0, 0]], indicator_tensor.eval())
 
   def test_transform_with_weighted_column(self):
-    id = fc.categorical_column_with_vocabulary_list(
+    id_ = fc.categorical_column_with_vocabulary_list(
       key='id', vocabulary_list=('a', 'b', 'c'))
-    weight = fc.weighted_categorical_column(id, 'weight')
+    weight = fc.weighted_categorical_column(id_, 'weight')
     indicator = fc.indicator_column(weight)
     features = {
       'id': constant_op.constant(['c', 'b', 'a'], shape=(1, 3)),


### PR DESCRIPTION
The PR is aimed to fix #12557 .

`sparse_merge` cannot handle `Dimension`,  hence casting Dimension to int when invoked.

### How to test

+ [x] add an unit test.
+ [ ] pass all tests.