### PR TITLE
Partially fixes #10838

### DIFF
--- a/tensorflow/core/framework/op_kernel.h
+++ b/tensorflow/core/framework/op_kernel.h
@@ -310,7 +310,7 @@ class OpKernelConstruction {
   FunctionLibraryRuntime* function_library() const { return flib_; }
 
   // The GraphDef version whose behavior we should follow.
-  const int graph_def_version() const { return graph_def_version_; }
+  int graph_def_version() const { return graph_def_version_; }
 
   // Helper routines for the OP_REQUIRES macros
   void CtxFailure(Status s);

--- a/tensorflow/stream_executor/device_description.h
+++ b/tensorflow/stream_executor/device_description.h
@@ -82,7 +82,7 @@ class DeviceDescription {
 
   // Returns the limit on the number of simultaneously resident blocks
   // on a multiprocessor.
-  const uint64 blocks_per_core_limit() const { return blocks_per_core_limit_; }
+  uint64 blocks_per_core_limit() const { return blocks_per_core_limit_; }
 
   // Returns the limit on the total number of threads that can be launched in a
   // single block; i.e. the limit on x * y * z dimensions of a ThreadDim.
@@ -141,7 +141,7 @@ class DeviceDescription {
   uint64 device_memory_size() const { return device_memory_size_; }
 
   // Returns the device's core clock rate in GHz.
-  const float clock_rate_ghz() const { return clock_rate_ghz_; }
+  float clock_rate_ghz() const { return clock_rate_ghz_; }
 
   // Returns whether ECC is enabled.
   bool ecc_enabled() const { return ecc_enabled_; }

--- a/tensorflow/stream_executor/kernel.h
+++ b/tensorflow/stream_executor/kernel.h
@@ -302,7 +302,7 @@ class KernelArgIterator {
   //
   // Returns a default-constructed KernelArg if there is no next argument.
   KernelArg next() {
-    KernelArg result;
+    KernelArg result = {};
     if (!has_next()) {
       return result;
     } else if ((shmem_indices_iter_ != shmem_indices_end_) &&


### PR DESCRIPTION
The following warnings seem to print for compiling many ops using gcc-4.9.

For example, in `cuda_solvers_gpu.cu.cc`:

```
INFO: From Compiling tensorflow/core/kernels/cuda_solvers_gpu.cu.cc:
./tensorflow/core/framework/op_kernel.h(313): warning: type qualifier on return type is meaningless

./tensorflow/stream_executor/kernel.h(307): warning: variable "result" is used before its value is set

./tensorflow/stream_executor/device_description.h(85): warning: type qualifier on return type is meaningless

./tensorflow/stream_executor/device_description.h(144): warning: type qualifier on return type is meaningless

./tensorflow/core/framework/op_kernel.h(313): warning: type qualifier on return type is meaningless

./tensorflow/stream_executor/kernel.h(307): warning: variable "result" is used before its value is set

./tensorflow/stream_executor/device_description.h(85): warning: type qualifier on return type is meaningless

./tensorflow/stream_executor/device_description.h(144): warning: type qualifier on return type is meaningless
```

In `beam_search_ops_gpu.cu.cc`:

```
INFO: From Compiling tensorflow/contrib/seq2seq/kernels/beam_search_ops_gpu.cu.cc:
./tensorflow/core/framework/op_kernel.h(313): warning: type qualifier on return type is meaningless

./tensorflow/stream_executor/kernel.h(307): warning: variable "result" is used before its value is set

./tensorflow/stream_executor/device_description.h(85): warning: type qualifier on return type is meaningless

./tensorflow/stream_executor/device_description.h(144): warning: type qualifier on return type is meaningless

./tensorflow/core/framework/op_kernel.h(313): warning: type qualifier on return type is meaningless

./tensorflow/stream_executor/kernel.h(307): warning: variable "result" is used before its value is set

./tensorflow/stream_executor/device_description.h(85): warning: type qualifier on return type is meaningless

./tensorflow/stream_executor/device_description.h(144): warning: type qualifier on return type is meaningless
```

I believe this fix will address many (but not all) of the warnings during the build.