### PR TITLE
enable use of transform_graph tool with contrib/rnn

### DIFF
--- a/tensorflow/contrib/rnn/BUILD
+++ b/tensorflow/contrib/rnn/BUILD
@@ -328,6 +328,8 @@ tf_kernel_library(
     srcs = [
         "kernels/blas_gemm.cc",
         "kernels/blas_gemm.h",
+        "kernels/gru_ops.h",
+        "ops/gru_ops.cc",
     ],
     gpu_srcs = [
         "kernels/blas_gemm.h",
@@ -346,6 +348,8 @@ tf_kernel_library(
     srcs = [
         "kernels/blas_gemm.cc",
         "kernels/blas_gemm.h",
+        "kernels/lstm_ops.h",
+        "ops/lstm_ops.cc",
     ],
     gpu_srcs = [
         "kernels/blas_gemm.h",

--- a/tensorflow/contrib/rnn/BUILD
+++ b/tensorflow/contrib/rnn/BUILD
@@ -328,8 +328,6 @@ tf_kernel_library(
     srcs = [
         "kernels/blas_gemm.cc",
         "kernels/blas_gemm.h",
-        "kernels/gru_ops.h",
-        "ops/gru_ops.cc",
     ],
     gpu_srcs = [
         "kernels/blas_gemm.h",
@@ -348,8 +346,6 @@ tf_kernel_library(
     srcs = [
         "kernels/blas_gemm.cc",
         "kernels/blas_gemm.h",
-        "kernels/lstm_ops.h",
-        "ops/lstm_ops.cc",
     ],
     gpu_srcs = [
         "kernels/blas_gemm.h",

--- a/tensorflow/tools/graph_transforms/BUILD
+++ b/tensorflow/tools/graph_transforms/BUILD
@@ -130,8 +130,8 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core:tensorflow",
-        "//tensorflow/contrib/rnn:gru_ops_kernels",
-        "//tensorflow/contrib/rnn:lstm_ops_kernels",
+        "//tensorflow/contrib/rnn:gru_ops_op_lib",
+        "//tensorflow/contrib/rnn:lstm_ops_op_lib",
     ] + if_not_windows([
         "//tensorflow/core/kernels:quantized_ops",
         "//tensorflow/core/kernels:remote_fused_graph_rewriter_transform",

--- a/tensorflow/tools/graph_transforms/BUILD
+++ b/tensorflow/tools/graph_transforms/BUILD
@@ -130,6 +130,8 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core:tensorflow",
+        "//tensorflow/contrib/rnn:gru_ops_kernels",
+        "//tensorflow/contrib/rnn:lstm_ops_kernels",
     ] + if_not_windows([
         "//tensorflow/core/kernels:quantized_ops",
         "//tensorflow/core/kernels:remote_fused_graph_rewriter_transform",


### PR DESCRIPTION
This is a simple fix for using contrib/rnn with the transform_graph (and possibly other tools).

In particular, it fixes the following error:
```
2017-08-24 16:07:41.015752: E tensorflow/tools/graph_transforms/transform_graph.cc:210] Op type not registered 'BlockLSTM' in binary running on ip-172-31-30-181. Make sure the Op and Kernel are registered in the binary running in this process.
```

It's also possibly a remedy for issue #11847.
