### PR TITLE
remove unused member vairable, and clear compiler warning

### DIFF
--- a/tensorflow/core/platform/cpu_info.cc
+++ b/tensorflow/core/platform/cpu_info.cc
@@ -255,7 +255,6 @@ class CPUIDInfo {
   int model_num() { return model_num_; }
 
  private:
-  int highest_eax_;
   int have_adx_ : 1;
   int have_aes_ : 1;
   int have_avx_ : 1;


### PR DESCRIPTION
I remove `highest_eax_` and clear this compiler warning, because it is unused.