### PR TITLE
In the line 240, the string 'conv_3' miss the %d

### DIFF
--- a/tensorflow/contrib/slim/README.md
+++ b/tensorflow/contrib/slim/README.md
@@ -237,7 +237,7 @@ One way to reduce this code duplication would be via a `for` loop:
 ```python
 net = ...
 for i in range(3):
-  net = slim.conv2d(net, 256, [3, 3], scope='conv3_' % (i+1))
+  net = slim.conv2d(net, 256, [3, 3], scope='conv3_%d' % (i+1))
 net = slim.max_pool2d(net, [2, 2], scope='pool2')
 ```
 


### PR DESCRIPTION
I think the author missed the '%d' to name the related net scope, so the correct code is :
net = slim.conv2d(net, 256, [3, 3], scope='conv3_%d' % (i+1)) NOT net = slim.conv2d(net, 256, [3, 3], scope='conv3_' % (i+1))