### PR TITLE
Double check after regex search for cudnn_path in configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -685,7 +685,9 @@ def set_tf_cunn_version(environ_cp):
       ldconfig_bin = which('ldconfig') or '/sbin/ldconfig'
       cudnn_path_from_ldconfig = run_shell([ldconfig_bin, '-p'])
       cudnn_path_from_ldconfig = re.search('.*libcudnn.so .* => (.*)',
-                                           cudnn_path_from_ldconfig).group(1)
+                                           cudnn_path_from_ldconfig)
+      if cudnn_path_from_ldconfig != None:
+        cudnn_path_from_ldconfig = cudnn_path_from_ldconfig.group(1)
       if os.path.exists('%s.%s' % (cudnn_path_from_ldconfig, tf_cudnn_version)):
         cudnn_install_path = os.path.dirname(cudnn_path_from_ldconfig)
         break

--- a/configure.py
+++ b/configure.py
@@ -686,11 +686,11 @@ def set_tf_cunn_version(environ_cp):
       cudnn_path_from_ldconfig = run_shell([ldconfig_bin, '-p'])
       cudnn_path_from_ldconfig = re.search('.*libcudnn.so .* => (.*)',
                                            cudnn_path_from_ldconfig)
-      if cudnn_path_from_ldconfig != None:
+      if cudnn_path_from_ldconfig:
         cudnn_path_from_ldconfig = cudnn_path_from_ldconfig.group(1)
-      if os.path.exists('%s.%s' % (cudnn_path_from_ldconfig, tf_cudnn_version)):
-        cudnn_install_path = os.path.dirname(cudnn_path_from_ldconfig)
-        break
+        if os.path.exists('%s.%s' % (cudnn_path_from_ldconfig, tf_cudnn_version)):
+          cudnn_install_path = os.path.dirname(cudnn_path_from_ldconfig)
+          break
 
     # Reset and Retry
     print(


### PR DESCRIPTION
If chose wrong `cuDNN` version on `linux`, `configure.py` will throw an exception as shown below:

```shell
Please specify the location where cuDNN 6 library is installed. Refer to README.md for more details. [Default is /usr/local/cuda]:

Traceback (most recent call last):
  File "configure.py", line 1021, in <module>
    main()
  File "configure.py", line 997, in main
    set_tf_cunn_version(environ_cp)
  File "configure.py", line 688, in set_tf_cunn_version
    cudnn_path_from_ldconfig).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```

This is because these code return `None`:

```python
cudnn_path_from_ldconfig = re.search('.*libcudnn.so .* => (.*)',
                                     cudnn_path_from_ldconfig)
```

This PR add double check after regex search.

Related PR: https://github.com/tensorflow/tensorflow/pull/12347 

@wangqr @yifeif PTAL.