### PR TITLE
Add `-Wno-write-strings` to remove the warning in external protobuf compilation

### DIFF
--- a/third_party/protobuf/add_noinlines.patch
+++ b/third_party/protobuf/add_noinlines.patch
@@ -1,3 +1,14 @@
+--- a/BUILD	2017-05-31 12:01:30.000000000 +0000
++++ b/BUILD	2017-08-25 18:55:24.690290712 +0000
+@@ -20,7 +20,7 @@
+     "//conditions:default": [
+         "-DHAVE_PTHREAD",
+         "-Wall",
+-        "-Wwrite-strings",
++        "-Wno-write-strings",
+         "-Woverloaded-virtual",
+         "-Wno-sign-compare",
+         "-Wno-unused-function",
 diff -u -r a/src/google/protobuf/compiler/cpp/cpp_file.cc b/src/google/protobuf/compiler/cpp/cpp_file.cc
 --- a/src/google/protobuf/compiler/cpp/cpp_file.cc	2017-02-10 23:55:34.000000000 +0100
 +++ b/src/google/protobuf/compiler/cpp/cpp_file.cc	2017-03-21 13:41:46.931979154 +0100


### PR DESCRIPTION
This fix is an effort based on the discussion https://github.com/tensorflow/tensorflow/issues/10838#issuecomment-311420644

Currently a big chunk (200+) of the warnings when compiling tensorflow are caused by `-Wwrite-strings` in external protobuf package:
```
external/protobuf_archive/python/google/protobuf/pyext/message_factory.cc:78:37: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
...
```

As protobuf is external, it makes sense to add the flag of `-Wno-write-strings` to reduce the number of warnings in the output.

This fix reduces 200+ warnings.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>