### PR TITLE
[android demo] fix issue #12431 Java implementation of YUV420SP to ARGB8888 converting

### DIFF
--- a/tensorflow/examples/android/src/org/tensorflow/demo/CameraActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/CameraActivity.java
@@ -110,7 +110,7 @@ public abstract class CameraActivity extends Activity implements OnImageAvailabl
         rgbBytes = new int[previewWidth * previewHeight];
         onPreviewSizeChosen(new Size(previewSize.width, previewSize.height), 90);
       }
-      ImageUtils.convertYUV420SPToARGB8888(bytes, rgbBytes, previewWidth, previewHeight, false);
+      ImageUtils.convertYUV420SPToARGB8888(bytes, rgbBytes, previewWidth, previewHeight);
     } catch (final Exception e) {
       LOGGER.e(e, "Exception!");
       return;

--- a/tensorflow/examples/android/src/org/tensorflow/demo/CameraActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/CameraActivity.java
@@ -110,7 +110,7 @@ public abstract class CameraActivity extends Activity implements OnImageAvailabl
         rgbBytes = new int[previewWidth * previewHeight];
         onPreviewSizeChosen(new Size(previewSize.width, previewSize.height), 90);
       }
-      ImageUtils.convertYUV420SPToARGB8888(bytes, rgbBytes, previewWidth, previewHeight);
+      ImageUtils.convertYUV420SPToARGB8888(bytes, previewWidth, previewHeight, rgbBytes);
     } catch (final Exception e) {
       LOGGER.e(e, "Exception!");
       return;

--- a/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
@@ -27,7 +27,7 @@ import java.io.FileOutputStream;
 public class ImageUtils {
   @SuppressWarnings("unused")
   private static final Logger LOGGER = new Logger();
-  
+
   static {
     try {
       System.loadLibrary("tensorflow_demo");
@@ -103,13 +103,13 @@ public class ImageUtils {
       int width,
       int height,
       int[] output) {
-
     if (useNativeConversion) {
       try {
         ImageUtils.convertYUV420SPToARGB8888(input, output, width, height, false);
         return;
       } catch (UnsatisfiedLinkError e) {
-        LOGGER.w("Native YUV420SP -> RGB implementation not found, falling back to Java implementation");
+        LOGGER.w(
+            "Native YUV420SP -> RGB implementation not found, falling back to Java implementation");
         useNativeConversion = false;
       }
     }
@@ -128,13 +128,12 @@ public class ImageUtils {
           u = 0xff & input[uvp++];
         }
 
-        output[yp] = YUV2RGB( y, u, v);
+        output[yp] = YUV2RGB(y, u, v);
       }
     }
   }
 
   private static int YUV2RGB(int y, int u, int v) {
-
     // Adjust and check YUV values
     y = (y - 16) < 0 ? 0 : (y - 16);
     u -= 128;
@@ -175,7 +174,8 @@ public class ImageUtils {
             yData, uData, vData, out, width, height, yRowStride, uvRowStride, uvPixelStride, false);
         return;
       } catch (UnsatisfiedLinkError e) {
-        LOGGER.w("Native YUV -> RGB implementation not found, falling back to Java implementation");
+        LOGGER.w(
+            "Native YUV420 -> RGB implementation not found, falling back to Java implementation");
         useNativeConversion = false;
       }
     }

--- a/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
@@ -127,30 +127,39 @@ public class ImageUtils {
           u = (0xff & input[uvp++]) - 128;
         }
 
-        int y1192 = 1192 * y;
-        int r = (y1192 + 1634 * v);
-        int g = (y1192 - 833 * v - 400 * u);
-        int b = (y1192 + 2066 * u);
-
-        if (r < 0)
-          r = 0;
-        else if (r > kMaxChannelValue)
-          r = kMaxChannelValue;
-        if (g < 0)
-          g = 0;
-        else if (g > kMaxChannelValue)
-          g = kMaxChannelValue;
-        if (b < 0)
-          b = 0;
-        else if (b > kMaxChannelValue)
-          b = kMaxChannelValue;
-
-        output[yp] = 0xff000000 | ((r << 6) & 0xff0000)
-                | ((g >> 2) & 0xff00) | ((b >> 10) & 0xff);
-
+        output[yp] = YUV2RGB(y,u,v);
       }
     }
   }
+
+  // This is the floating point equivalent. We do the conversion in integer
+  // because some Android devices do not have floating point in hardware.
+  // nR = (int)(1.164 * nY + 2.018 * nU);
+  // nG = (int)(1.164 * nY - 0.813 * nV - 0.391 * nU);
+  // nB = (int)(1.164 * nY + 1.596 * nV);
+  private static int YUV2RGB(int y, int u, int v) {
+
+    int y1192 = 1192 * y;
+    int r = (y1192 + 1634 * v);
+    int g = (y1192 - 833 * v - 400 * u);
+    int b = (y1192 + 2066 * u);
+
+    if (r < 0)
+      r = 0;
+    else if (r > kMaxChannelValue)
+      r = kMaxChannelValue;
+    if (g < 0)
+      g = 0;
+    else if (g > kMaxChannelValue)
+      g = kMaxChannelValue;
+    if (b < 0)
+      b = 0;
+    else if (b > kMaxChannelValue)
+      b = kMaxChannelValue;
+
+    return 0xff000000 | ((r << 6) & 0xff0000) | ((g >> 2) & 0xff00) | ((b >> 10) & 0xff);
+  }
+
 
   public static void convertYUV420ToARGB8888(
       byte[] yData,
@@ -186,33 +195,7 @@ public class ImageUtils {
         if (nY < 0)
           nY = 0;
 
-        // This is the floating point equivalent. We do the conversion in integer
-        // because some Android devices do not have floating point in hardware.
-        // nR = (int)(1.164 * nY + 2.018 * nU);
-        // nG = (int)(1.164 * nY - 0.813 * nV - 0.391 * nU);
-        // nB = (int)(1.164 * nY + 1.596 * nV);
-
-        final int foo = 1192 * nY;
-        int nR = foo + 1634 * nV;
-        int nG = foo - 833 * nV - 400 * nU;
-        int nB = foo + 2066 * nU;
-
-        if (nR < 0)
-          nR = 0;
-        else if (nR > kMaxChannelValue)
-          nR = kMaxChannelValue;
-        if (nG < 0)
-          nG = 0;
-        else if (nG > kMaxChannelValue)
-          nG = kMaxChannelValue;
-        if (nB < 0)
-          nB = 0;
-        else if (nB > kMaxChannelValue)
-          nB = kMaxChannelValue;
-
-        out[i++] = 0xff000000 | ((nR << 6) & 0x00ff0000)
-                | ((nG >> 2) & 0x0000FF00) | ((nB >> 10) & 0xff);
-
+        out[i++] = YUV2RGB( nY, nU, nV);
       }
     }
   }

--- a/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
@@ -100,9 +100,9 @@ public class ImageUtils {
 
   public static void convertYUV420SPToARGB8888(
       byte[] input,
-      int[] output,
       int width,
-      int height) {
+      int height,
+      int[] output) {
 
     if (useNativeConversion) {
       try {

--- a/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
@@ -144,18 +144,10 @@ public class ImageUtils {
     int g = (y1192 - 833 * v - 400 * u);
     int b = (y1192 + 2066 * u);
 
-    if (r < 0)
-      r = 0;
-    else if (r > kMaxChannelValue)
-      r = kMaxChannelValue;
-    if (g < 0)
-      g = 0;
-    else if (g > kMaxChannelValue)
-      g = kMaxChannelValue;
-    if (b < 0)
-      b = 0;
-    else if (b > kMaxChannelValue)
-      b = kMaxChannelValue;
+    // Clipping RGB values to be inside boundaries [ 0 , kMaxChannelValue ]
+    r = r > kMaxChannelValue ? kMaxChannelValue : (r < 0 ? 0 : r);
+    g = g > kMaxChannelValue ? kMaxChannelValue : (g < 0 ? 0 : g);
+    b = b > kMaxChannelValue ? kMaxChannelValue : (b < 0 ? 0 : b);
 
     return 0xff000000 | ((r << 6) & 0xff0000) | ((g >> 2) & 0xff00) | ((b >> 10) & 0xff);
   }

--- a/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/env/ImageUtils.java
@@ -230,7 +230,7 @@ public class ImageUtils {
    * @param halfSize If true, downsample to 50% in each dimension, otherwise not.
    */
   private static native void convertYUV420SPToARGB8888(
-          byte[] input, int[] output, int width, int height, boolean halfSize);
+      byte[] input, int[] output, int width, int height, boolean halfSize);
 
   /**
    * Converts YUV420 semi-planar data to ARGB 8888 data using the supplied width
@@ -247,16 +247,16 @@ public class ImageUtils {
    * @param output A pre-allocated array for the ARGB 8:8:8:8 output data.
    */
   private static native void convertYUV420ToARGB8888(
-          byte[] y,
-          byte[] u,
-          byte[] v,
-          int[] output,
-          int width,
-          int height,
-          int yRowStride,
-          int uvRowStride,
-          int uvPixelStride,
-          boolean halfSize);
+      byte[] y,
+      byte[] u,
+      byte[] v,
+      int[] output,
+      int width,
+      int height,
+      int yRowStride,
+      int uvRowStride,
+      int uvPixelStride,
+      boolean halfSize);
 
   /**
    * Converts YUV420 semi-planar data to RGB 565 data using the supplied width
@@ -269,7 +269,7 @@ public class ImageUtils {
    * @param height The height of the input image.
    */
   private static native void convertYUV420SPToRGB565(
-          byte[] input, byte[] output, int width, int height);
+      byte[] input, byte[] output, int width, int height);
 
   /**
    * Converts 32-bit ARGB8888 image data to YUV420SP data.  This is useful, for
@@ -282,7 +282,7 @@ public class ImageUtils {
    * @param height The height of the input image.
    */
   private static native void convertARGB8888ToYUV420SP(
-          int[] input, byte[] output, int width, int height);
+      int[] input, byte[] output, int width, int height);
 
   /**
    * Converts 16-bit RGB565 image data to YUV420SP data.  This is useful, for
@@ -295,7 +295,7 @@ public class ImageUtils {
    * @param height The height of the input image.
    */
   private static native void convertRGB565ToYUV420SP(
-          byte[] input, byte[] output, int width, int height);
+      byte[] input, byte[] output, int width, int height);
 
   /**
    * Returns a transformation matrix from one reference frame into another.


### PR DESCRIPTION
This PR fix issue #12431
Java implementation of `ImageUtils.convertYUV420SPToARGB8888` made and refactoring for Java implementation of `ImageUtils.convertYUV420ToARGB8888` made as well.

Despite the fact that code looks a bit 'nuddle-style' that was made for efficiency reasons. Breaking down it into few, more readable functions (like it was made before at `ImageUtils.convertYUV420ToARGB8888`) lead into 3-time function execution increase:
Previous implementation of `ImageUtils.convertYUV420ToARGB8888` cause invocation inside double nested circles 307200 times (`640x480`) of `YUV2RGB` function and three times more `convertByteToInt` with `Math.min` and `Math.max` functions. 

Total costs of classification at TF Classify was around 3000 ms on my test device (Meizu N2, API 22). Proposed implementation drops it down to 1000-1100 ms (which is comparable with native C implementation from `libtensorflow_demo.so`  ~700 ms).