### PR TITLE
expose build_default_serving_input_fn

### DIFF
--- a/tensorflow/contrib/learn/__init__.py
+++ b/tensorflow/contrib/learn/__init__.py
@@ -80,6 +80,7 @@ See the @{$python/contrib.learn} guide.
 
 @@InputFnOps
 @@ProblemType
+@@build_default_serving_input_fn
 @@build_parsing_serving_input_fn
 @@make_export_strategy
 """

--- a/tensorflow/docs_src/api_guides/python/contrib.learn.md
+++ b/tensorflow/docs_src/api_guides/python/contrib.learn.md
@@ -58,5 +58,6 @@ Queue and read batched input data.
 
 Export utilities
 
+*   @{tf.contrib.learn.build_default_serving_input_fn}
 *   @{tf.contrib.learn.build_parsing_serving_input_fn}
 *   @{tf.contrib.learn.ProblemType}


### PR DESCRIPTION
For #12508, I find that `build_default_serving_input_fn` is hidden like #12568 . I don't know whether it is intentional. 

CF pr #12617.