### PR TITLE
Make Dataset.map not unpack namedtuple

### DIFF
--- a/tensorflow/contrib/data/python/kernel_tests/map_dataset_op_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/map_dataset_op_test.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 import os
 import threading
+from collections import namedtuple
 
 import numpy as np
 
@@ -454,6 +455,40 @@ class MapDatasetTest(test.TestCase):
         self.assertEqual(i * 2 + i ** 2, sess.run(get_next))
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
+
+  def testMapNamedtuple(self, count=10):
+    # construct dataset of tuples
+    labels = dataset_ops.Dataset.range(count)
+    images = labels.map(lambda l: -l)
+    dataset_tuple = dataset_ops.Dataset.zip((labels, images))
+
+    # convert dataset of tuples to dataset of namedtuples
+    Example = namedtuple("Example", ["label", "image"])
+    dataset_namedtuple = dataset_tuple.map(Example)
+
+    def preprocess_tuple(label, image):
+      image = 2 * image
+      return label, image
+
+    def preprocess_namedtuple(example):
+      return example._replace(image=2 * example.image)
+
+    # preprocess both datasets
+    dataset_tuple = dataset_tuple.map(preprocess_tuple)
+    dataset_namedtuple = dataset_namedtuple.map(preprocess_namedtuple)
+
+    next_tuple = dataset_tuple.make_one_shot_iterator().get_next()
+    next_namedtuple = dataset_namedtuple.make_one_shot_iterator().get_next()
+
+    # make sure both datasets contain the same data
+    with self.test_session() as sess:
+      for i in range(count):
+        tuple_, namedtuple_ = sess.run([next_tuple, next_namedtuple])
+        self.assertEqual(tuple_, namedtuple_)
+        self.assertEqual(tuple_, (i, -2 * i))
+
+      with self.assertRaises(errors.OutOfRangeError):
+        sess.run(next_namedtuple)
 
   def testUseStepContainerInMap(self):
     row = np.arange(6)

--- a/tensorflow/contrib/data/python/ops/dataset_ops.py
+++ b/tensorflow/contrib/data/python/ops/dataset_ops.py
@@ -1879,8 +1879,7 @@ class DenseToSparseBatchDataset(Dataset):
 
 def _should_unpack_args(args):
   """Returns `True` if `args` should be `*args` when passed to a callable."""
-  is_namedtuple = isinstance(args, tuple) and hasattr(args, "_fields")
-  return nest.is_sequence(args) and not isinstance(args, dict) and not is_namedtuple
+  return type(args) is tuple  # pylint: disable=unidiomatic-typecheck
 
 
 class _ResourceDataset(Dataset):

--- a/tensorflow/contrib/data/python/ops/dataset_ops.py
+++ b/tensorflow/contrib/data/python/ops/dataset_ops.py
@@ -2126,7 +2126,7 @@ class InterleaveDataset(Dataset):
 
       nested_args = nest.pack_sequence_as(input_dataset.output_types, args)
 
-      if nest.is_sequence(nested_args):
+      if _should_unpack_args(nested_args):
         dataset = map_func(*nested_args)
       else:
         dataset = map_func(nested_args)

--- a/tensorflow/contrib/data/python/ops/dataset_ops.py
+++ b/tensorflow/contrib/data/python/ops/dataset_ops.py
@@ -1879,7 +1879,8 @@ class DenseToSparseBatchDataset(Dataset):
 
 def _should_unpack_args(args):
   """Returns `True` if `args` should be `*args` when passed to a callable."""
-  return nest.is_sequence(args) and not isinstance(args, dict)
+  is_namedtuple = isinstance(args, tuple) and hasattr(args, "_fields")
+  return nest.is_sequence(args) and not isinstance(args, dict) and not is_namedtuple
 
 
 class _ResourceDataset(Dataset):


### PR DESCRIPTION
The map method of tf.contrib.data.Dataset unpacks iterables before passing them to the mapped function. This is quite convenient. However, currently this also happens for namedtuples, which IMHO is not what one would expect. Consider, for example, the following code:

```python
import tensorflow as tf
from tensorflow.contrib.data import Dataset
from collections import namedtuple

Example = namedtuple("Example", ["label", "attributes", "bounding_box", "image"])


def read_example(serialized_example):
    # parse example
    label = ...
    attribute = ...
    bounding_box = ...
    image = ...
    
    return Example(label, attribute, bounding_box, image)


def preprocess_example(example):
    image = some_function(example.image, example.bounding_box)
    return example._replace(image=image)


dataset = tf.contrib.data.TFRecordDataset(filename)
dataset = dataset.map(read_example)
dataset = dataset.map(preprocess_example)
```

This does not work because the namedtuple instance is unpacked and its fields are passed as separate arguments to `preprocess_example`. So currently one has to reassemble the namedtuple manually. This is not a big deal, but it would be more convenient if namedtuples were not unpacked, as is also the case for dictionaries.

This can be easily achieved by making `_should_unpack_args` return False for namedtuples, as is done in this pull request.