### PR TITLE
Removing slightly confusing ">" from output

### DIFF
--- a/tensorflow/python/tools/import_pb_to_tensorboard.py
+++ b/tensorflow/python/tools/import_pb_to_tensorboard.py
@@ -51,7 +51,7 @@ def import_to_tensorboard(model_dir, log_dir):
     pb_visual_writer = summary.FileWriter(log_dir)
     pb_visual_writer.add_graph(sess.graph)
     print("Model Imported. Visualize by running: "
-          "> tensorboard --logdir={}".format(log_dir))
+          "tensorboard --logdir={}".format(log_dir))
 
 
 def main(unused_args):


### PR DESCRIPTION
I found the `>` a bit confusing in the output of `import_pb_to_tensorboard.py`:
```
$ python import_pb_to_tensorboard.py --model_dir ~/mnist_model_graph.pb --log_dir /tmp/tensorflow_logdir
Model Imported. Visualize by running: > tensorboard --logdir=/tmp/tensorflow_logdir
```
If you include that symbol when trying to launch tensorboard, it fails:
```
$ > tensorboard --logdir=/tmp/tensorflow_logdir
-bash: --logdir=/tmp/tensorflow_logdir: No such file or directory
```
Yes, this is relatively obvious to a knowledgable programmer, but if this isn't there for a specific reason, then we may as well remove it. ¯\_(ツ)_/¯

**AFTER THE FIX**

Tested on Mac OS X Siera 10.12.6.
```
$ python import_pb_to_tensorboard.py --model_dir ~/mnist_model_graph.pb --log_dir /tmp/tensorflow_logdir
Model Imported. Visualize by running: tensorboard --logdir=/tmp/tensorflow_logdir
```