### PR TITLE
Support CopyFile with streaming

### DIFF
--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -269,7 +269,7 @@ Status Env::CopyFile(const string& src, const string& target) {
   if (src_fs == target_fs) {
     return src_fs->CopyFile(src, target);
   }
-  return tensorflow::CopyFile(src_fs, src, target_fs, target);
+  return FileSystemCopyFile(src_fs, src, target_fs, target);
 }
 
 string Env::GetExecutablePath() {
@@ -375,8 +375,8 @@ Status WriteStringToFile(Env* env, const string& fname,
   return s;
 }
 
-Status CopyFile(FileSystem* src_fs, const string& src, FileSystem* target_fs,
-                const string& target) {
+Status FileSystemCopyFile(FileSystem* src_fs, const string& src,
+                          FileSystem* target_fs, const string& target) {
   std::unique_ptr<RandomAccessFile> src_file;
   TF_RETURN_IF_ERROR(src_fs->NewRandomAccessFile(src, &src_file));
 

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -377,6 +377,11 @@ struct ThreadOptions {
   size_t guard_size = 0;  // 0: use system default value
 };
 
+/// A utility routine: copy contents of `src` in file system `src_fs`
+/// to `target` in file system `target_fs`.
+Status CopyFile(FileSystem* src_fs, const string& src, FileSystem* target_fs,
+                const string& target);
+
 /// A utility routine: reads contents of named file into `*data`
 Status ReadFileToString(Env* env, const string& fname, string* data);
 
@@ -384,10 +389,6 @@ Status ReadFileToString(Env* env, const string& fname, string* data);
 /// (overwriting existing contents, if any).
 Status WriteStringToFile(Env* env, const string& fname,
                          const StringPiece& data);
-
-/// A utility routine: copy contents of `oldpath` to `newpath`
-Status CopyFile(Env* env, const string& oldpath, const string& newpath,
-                bool overwrite);
 
 /// Write binary representation of "proto" to the named file.
 Status WriteBinaryProto(Env* env, const string& fname,

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -211,6 +211,9 @@ class Env {
   /// replaced.
   Status RenameFile(const string& src, const string& target);
 
+  /// \brief Copy the src to target.
+  Status CopyFile(const string& src, const string& target);
+
   /// \brief Returns the absolute path of the current executable. It resolves
   /// symlinks if there is any.
   string GetExecutablePath();
@@ -279,7 +282,7 @@ class Env {
   // "version" should be the version of the library or NULL
   // returns the name that LoadLibrary() can use
   virtual string FormatLibraryFileName(const string& name,
-      const string& version) = 0;
+                                       const string& version) = 0;
 
  private:
   // Returns a possible list of local temporary directories.
@@ -346,6 +349,7 @@ class EnvWrapper : public Env {
                                const string& version) override {
     return target_->FormatLibraryFileName(name, version);
   }
+
  private:
   Env* target_;
 };

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -381,6 +381,10 @@ Status ReadFileToString(Env* env, const string& fname, string* data);
 Status WriteStringToFile(Env* env, const string& fname,
                          const StringPiece& data);
 
+/// A utility routine: copy contents of `oldpath` to `newpath`
+Status CopyFile(Env* env, const string& oldpath, const string& newpath,
+                bool overwrite);
+
 /// Write binary representation of "proto" to the named file.
 Status WriteBinaryProto(Env* env, const string& fname,
                         const ::tensorflow::protobuf::MessageLite& proto);

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -379,8 +379,8 @@ struct ThreadOptions {
 
 /// A utility routine: copy contents of `src` in file system `src_fs`
 /// to `target` in file system `target_fs`.
-Status CopyFile(FileSystem* src_fs, const string& src, FileSystem* target_fs,
-                const string& target);
+Status FileSystemCopyFile(FileSystem* src_fs, const string& src,
+                          FileSystem* target_fs, const string& target);
 
 /// A utility routine: reads contents of named file into `*data`
 Status ReadFileToString(Env* env, const string& fname, string* data);

--- a/tensorflow/core/platform/file_system.cc
+++ b/tensorflow/core/platform/file_system.cc
@@ -263,7 +263,7 @@ Status FileSystem::RecursivelyCreateDir(const string& dirname) {
 }
 
 Status FileSystem::CopyFile(const string& src, const string& target) {
-  return ::tensorflow::CopyFile(this, src, this, target);
+  return FileSystemCopyFile(this, src, this, target);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/file_system.cc
+++ b/tensorflow/core/platform/file_system.cc
@@ -263,7 +263,7 @@ Status FileSystem::RecursivelyCreateDir(const string& dirname) {
 }
 
 Status FileSystem::CopyFile(const string& src, const string& target) {
-  return tensorflow::CopyFile(this, src, this, target);
+  return ::tensorflow::CopyFile(this, src, this, target);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/file_system.cc
+++ b/tensorflow/core/platform/file_system.cc
@@ -33,6 +33,8 @@ namespace tensorflow {
 
 namespace {
 
+constexpr size_t kCopyFileBufferSize = 1024 * 1024;
+
 constexpr int kNumThreads = 8;
 
 // Run a function in parallel using a ThreadPool, but skip the ThreadPool
@@ -260,6 +262,52 @@ Status FileSystem::RecursivelyCreateDir(const string& dirname) {
     }
   }
   return Status::OK();
+}
+
+Status FileSystem::CopyFile(const string& src, const string& target) {
+  uint64 size;
+  Status s = GetFileSize(src, &size);
+  if (!s.ok()) {
+    return s;
+  }
+  std::unique_ptr<RandomAccessFile> src_file;
+  s = NewRandomAccessFile(src, &src_file);
+  if (!s.ok()) {
+    return s;
+  }
+  std::unique_ptr<WritableFile> target_file;
+  s = NewWritableFile(target, &target_file);
+  if (!s.ok()) {
+    return s;
+  }
+
+  uint64 offset = 0;
+  while (offset < size) {
+    char scratch[kCopyFileBufferSize];
+    StringPiece result;
+    size_t chunk =
+        offset + sizeof(scratch) < size ? sizeof(scratch) : size - offset;
+    s = src_file->Read(offset, chunk, &result, scratch);
+    if (!s.ok()) {
+      return s;
+    }
+
+    s = target_file->Append(result);
+    if (!s.ok()) {
+      return s;
+    }
+
+    offset += chunk;
+  }
+  s = GetFileSize(src, &size);
+  if (!s.ok()) {
+    return s;
+  }
+  if (offset != size) {
+    return errors::Aborted("File ", src, " changed while reading: ", size,
+                           " vs. ", offset);
+  }
+  return target_file->Close();
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -189,6 +189,9 @@ class FileSystem {
   /// \brief Overwrites the target if it exists.
   virtual Status RenameFile(const string& src, const string& target) = 0;
 
+  /// \brief Copy the src to target.
+  virtual Status CopyFile(const string& src, const string& target);
+
   /// \brief Translate an URI to a filename for the FileSystem implementation.
   ///
   /// The implementation in this class cleans up the path, removing

--- a/tensorflow/core/platform/posix/posix_file_system.cc
+++ b/tensorflow/core/platform/posix/posix_file_system.cc
@@ -304,7 +304,7 @@ Status PosixFileSystem::CopyFile(const string& src, const string& target) {
   while (offset < sbuf.st_size) {
     size_t chunk = (sbuf.st_size - offset) < SSIZE_MAX ? (sbuf.st_size - offset)
                                                        : SSIZE_MAX;
-    rc = sendfile64(target_fd, src_fd, &offset, chunk);
+    rc = sendfile(target_fd, src_fd, &offset, chunk);
     if (rc <= 0) {
       break;
     }

--- a/tensorflow/core/platform/posix/posix_file_system.cc
+++ b/tensorflow/core/platform/posix/posix_file_system.cc
@@ -278,9 +278,6 @@ Status PosixFileSystem::RenameFile(const string& src, const string& target) {
 }
 
 Status PosixFileSystem::CopyFile(const string& src, const string& target) {
-#if defined(PLATFORM_WINDOWS)
-  return FileSystem::CopyFile(src, target);
-#else
   string translated_src = TranslateName(src);
   struct stat sbuf;
   if (stat(translated_src.c_str(), &sbuf) != 0) {
@@ -291,6 +288,10 @@ Status PosixFileSystem::CopyFile(const string& src, const string& target) {
     return IOError(src, errno);
   }
   string translated_target = TranslateName(target);
+  // O_WRONLY | O_CREAT:
+  //   Open file for write and if file does not exist, create the file.
+  // S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH:
+  //   Create the file with permission of 0666
   int target_fd =
       open64(translated_target.c_str(), O_WRONLY | O_CREAT,
              S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
@@ -316,7 +317,6 @@ Status PosixFileSystem::CopyFile(const string& src, const string& target) {
     result = IOError(target, errno);
   }
   return result;
-#endif
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/posix/posix_file_system.cc
+++ b/tensorflow/core/platform/posix/posix_file_system.cc
@@ -307,7 +307,7 @@ Status PosixFileSystem::CopyFile(const string& src, const string& target) {
   off_t offset = 0;
   std::unique_ptr<char[]> buffer(new char[kPosixCopyFileBufferSize]);
   while (offset < sbuf.st_size) {
-    // Use uint64 for safe comapre SSIZE_MAX
+    // Use uint64 for safe compare SSIZE_MAX
     uint64 chunk = sbuf.st_size - offset;
     if (chunk > SSIZE_MAX) {
       chunk = SSIZE_MAX;
@@ -318,11 +318,11 @@ Status PosixFileSystem::CopyFile(const string& src, const string& target) {
     if (chunk > kPosixCopyFileBufferSize) {
       chunk = kPosixCopyFileBufferSize;
     }
-    rc = read(src_fd, buffer, static_cast<size_t>(chunk));
+    rc = read(src_fd, buffer.get(), static_cast<size_t>(chunk));
     if (rc <= 0) {
       break;
     }
-    rc = write(target_fd, buffer, static_cast<size_t>(chunk));
+    rc = write(target_fd, buffer.get(), static_cast<size_t>(chunk));
     offset += chunk;
 #endif
     if (rc <= 0) {

--- a/tensorflow/core/platform/posix/posix_file_system.h
+++ b/tensorflow/core/platform/posix/posix_file_system.h
@@ -56,6 +56,8 @@ class PosixFileSystem : public FileSystem {
   Status GetFileSize(const string& fname, uint64* size) override;
 
   Status RenameFile(const string& src, const string& target) override;
+
+  Status CopyFile(const string& src, const string& target) override;
 };
 
 Status IOError(const string& context, int err_number);

--- a/tensorflow/python/lib/io/file_io.i
+++ b/tensorflow/python/lib/io/file_io.i
@@ -112,19 +112,8 @@ void RecursivelyCreateDir(const string& dirname, TF_Status* out_status) {
 
 void CopyFile(const string& oldpath, const string& newpath, bool overwrite,
               TF_Status* out_status) {
-  // If overwrite is false and the newpath file exists then it's an error.
-  if (!overwrite && tensorflow::Env::Default()->FileExists(newpath).ok()) {
-    TF_SetStatus(out_status, TF_ALREADY_EXISTS, "file already exists");
-    return;
-  }
-  string file_content;
-  tensorflow::Status status = ReadFileToString(tensorflow::Env::Default(),
-      oldpath, &file_content);
-  if (!status.ok()) {
-    Set_TF_Status_from_Status(out_status, status);
-    return;
-  }
-  status = WriteStringToFile(tensorflow::Env::Default(), newpath, file_content);
+  tensorflow::Status status = CopyFile(tensorflow::Env::Default(),
+                                       oldpath, newpath, overwrite);
   if (!status.ok()) {
     Set_TF_Status_from_Status(out_status, status);
   }

--- a/tensorflow/python/lib/io/file_io.i
+++ b/tensorflow/python/lib/io/file_io.i
@@ -110,10 +110,15 @@ void RecursivelyCreateDir(const string& dirname, TF_Status* out_status) {
   }
 }
 
-void CopyFile(const string& oldpath, const string& newpath, bool overwrite,
+void CopyFile(const string& src, const string& target, bool overwrite,
               TF_Status* out_status) {
-  tensorflow::Status status = CopyFile(tensorflow::Env::Default(),
-                                       oldpath, newpath, overwrite);
+  // If overwrite is false and the target file exists then its an error.
+  if (!overwrite && tensorflow::Env::Default()->FileExists(target).ok()) {
+    TF_SetStatus(out_status, TF_ALREADY_EXISTS, "file already exists");
+    return;
+  }
+  tensorflow::Status status =
+      tensorflow::Env::Default()->CopyFile(src, target);
   if (!status.ok()) {
     Set_TF_Status_from_Status(out_status, status);
   }


### PR DESCRIPTION
This fix tries to address the issue raised in #12641 where it was not possible to have CopyFile with streaming. The original implementation copies the whole content of the file to a string
buffer and write to the file. This could be an issue if the file size is too large (than the memory of the host).

This fix streams the CopyFile operation.

*Also, sendfile is used if the file system is posix*

This fix fixes #12641.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>