### PR TITLE
Adding a decode to support Python 3.5 on Windows.

### DIFF
--- a/tensorflow/tools/ci_build/update_version.py
+++ b/tensorflow/tools/ci_build/update_version.py
@@ -276,8 +276,9 @@ def check_for_lingering_string(lingering_string):
   """Check for given lingering strings."""
   formatted_string = lingering_string.replace(".", r"\.")
   try:
-    linger_strs = subprocess.check_output(
-        ['grep', '-rnoH', formatted_string, TF_SRC_DIR]).split("\n")
+    linger_str_output = subprocess.check_output(
+        ['grep', '-rnoH', formatted_string, TF_SRC_DIR])
+    linger_strs = linger_str_output.decode('utf8').split("\n")
   except subprocess.CalledProcessError:
     linger_strs = []
 


### PR DESCRIPTION
Fix this error: python 3.5: TypeError: a bytes-like object is required, not 'str'

