### PR TITLE
c++ gradients for mean and sum

### DIFF
--- a/tensorflow/cc/BUILD
+++ b/tensorflow/cc/BUILD
@@ -276,6 +276,7 @@ cc_library(
         ":cc_ops",
         ":cc_ops_internal",
         ":grad_op_registry",
+        ":gradients",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/cc/gradients/math_grad_test.cc
+++ b/tensorflow/cc/gradients/math_grad_test.cc
@@ -937,6 +937,24 @@ class NaryGradTest : public ::testing::Test {
   Scope scope_;
 };
 
+TEST_F(NaryGradTest, Sum) {
+  TensorShape x1_shape({1, 2, 3});
+  TensorShape y_shape({1, 3});
+  auto x1 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x1_shape));
+  Tensor x2 = test::AsTensor<int32>({1}, {1});
+  auto y = Sum(scope_, x1, x2);
+  RunTest({x1}, {x1_shape}, {y}, {y_shape});
+}
+
+TEST_F(NaryGradTest, Mean) {
+  TensorShape x1_shape({1, 2, 3});
+  TensorShape y_shape({1, 3});
+  auto x1 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x1_shape));
+  Tensor x2 = test::AsTensor<int32>({1}, {1});
+  auto y = Mean(scope_, x1, x2);
+  RunTest({x1}, {x1_shape}, {y}, {y_shape});
+}
+
 TEST_F(NaryGradTest, AddN) {
   TensorShape shape({3, 2, 5});
   std::vector<Output> xs;


### PR DESCRIPTION
Gradients for the math ops, Mean and Sum. Ported from python:

https://github.com/tensorflow/tensorflow/blob/86d9171b006a2f4a65055228aa13d83d60916052/tensorflow/python/ops/math_grad.py#L95

I grouped these together because they share helper functions.

cc @suharshs


