### PR TITLE
Make Graph(long) Constructor Public

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/Graph.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Graph.java
@@ -33,7 +33,7 @@ public final class Graph implements AutoCloseable {
   }
 
   /** Create a Graph from an existing handle (takes ownership). */
-  Graph(long nativeHandle) {
+  public Graph(long nativeHandle) {
     this.nativeHandle = nativeHandle;
   }
 


### PR DESCRIPTION
It would be very useful when user wants to do custom model loading in C/C++ via JNI then return the handle to Java and use this constructor to wrap/maintain the graph object.

Changed Graph(long) from `Graph(long)` To `public Graph(long)`.