### PR TITLE
TensorFlowInferenceInterface Constructor with Graph

### DIFF
--- a/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
+++ b/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
@@ -111,6 +111,22 @@ public class TensorFlowInferenceInterface {
       throw new RuntimeException("Failed to load model from the input stream", e);
     }
   }
+  
+  /*
+   * Construct a TensorFlowInferenceInterface with provided Graph
+   *
+   * @param g The Graph to use to construct this interface.
+   */
+  public TensorFlowInferenceInterface(Graph g) {
+    prepareNativeRuntime();
+      
+    // modelName is redundant here, here is for
+    // avoiding error in initialization as modelName is marked final.
+    this.modelName = "";
+    this.g = g;
+    this.sess = new Session(g);
+    this.runner = sess.runner();
+  }
 
   /**
    * Runs inference between the previously registered input nodes (via feed*) and the requested


### PR DESCRIPTION
Added a new Constructor with `Graph` object only, it would be very useful for custom graph loading. Combining with #12668, user can even perform custom graph loading in C/C++ via Android NDK as well.

New Constructor Signature: `public TensorFlowInferenceInterface(Graph g)`