### PR TITLE
Update __init__.py

### DIFF
--- a/tensorflow/contrib/deprecated/__init__.py
+++ b/tensorflow/contrib/deprecated/__init__.py
@@ -94,14 +94,14 @@ from __future__ import division
 from __future__ import print_function
 
 
-# pylint: disable=unused-import,line-too-long
+# pylint: disable=unused-import
 from tensorflow.python.ops.logging_ops import audio_summary
 from tensorflow.python.ops.logging_ops import histogram_summary
 from tensorflow.python.ops.logging_ops import image_summary
 from tensorflow.python.ops.logging_ops import merge_all_summaries
 from tensorflow.python.ops.logging_ops import merge_summary
 from tensorflow.python.ops.logging_ops import scalar_summary
-# pylint: enable=unused-import,line-too-long
+# pylint: enable=unused-import
 
 from tensorflow.python.util.all_util import remove_undocumented
 _allowed_symbols = ['audio_summary', 'histogram_summary',

--- a/tensorflow/contrib/deprecated/__init__.py
+++ b/tensorflow/contrib/deprecated/__init__.py
@@ -54,6 +54,7 @@ underscores.
 
 Just as an example, consider the following "before" and "after" code snippets:
 
+```python
 # Before
 def add_activation_summaries(v, scope):
   tf.scalar_summary("%s/fraction_of_zero" % scope, tf.nn.fraction_of_zero(v))
@@ -63,6 +64,7 @@ def add_activation_summaries(v, scope):
 def add_activation_summaries(v):
   tf.summary.scalar("fraction_of_zero", tf.nn.fraction_of_zero(v))
   tf.summary.histogram("activations", v)
+```
 
 Now, so long as the add_activation_summaries function is called from within the
 right name scope, the behavior is the same.

--- a/tensorflow/contrib/deprecated/__init__.py
+++ b/tensorflow/contrib/deprecated/__init__.py
@@ -41,7 +41,7 @@ need to pass in a `tf.name_scope`, manually, to that function to create deduplic
 tags. Otherwise your program would fail with a runtime error due to tag
 collision.
 
-The new summary APIs under tf.summary throw away the "tag" as an independent
+The new summary APIs under `tf.summary` throw away the "tag" as an independent
 concept; instead, the first argument is the node name. So summary tags now 
 automatically inherit the surrounding `tf.name_scope`, and automatically
 are deduplicated if there is a conflict. Now however, the only allowed
@@ -64,25 +64,25 @@ def add_activation_summaries(v):
 ```
 
 Now, so long as the add_activation_summaries function is called from within the
-right namescope, the behavior is the same.
+right `tf.name_scope`, the behavior is the same.
 
 Because this change does modify the behavior and could break tests, we can't
 automatically migrate usage to the new APIs. That is why we are making the old
-APIs temporarily available here at tf.contrib.deprecated.
+APIs temporarily available here at `tf.contrib.deprecated`.
 
 In addition to the name change described above, there are two further changes
 to the new summary ops:
 
-- the "max_images" argument for tf.image_summary was renamed to "max_outputs
-  for tf.summary.image
-- tf.scalar_summary accepted arbitrary tensors of tags and values. However,
-  tf.summary.scalar requires a single scalar name and scalar value. In most
-  cases, you can create tf.summary.scalars in a loop to get the same behavior
+- the "max_images" argument for `tf.image_summary` was renamed to "max_outputs
+  for `tf.summary.image`
+- `tf.scalar_summary` accepted arbitrary tensors of tags and values. But
+  `tf.summary.scalar` requires a single scalar name and scalar value. In most
+  cases, you can create `tf.summary.scalar` in a loop to get the same behavior
 
-As before, TensorBoard groups charts by the top-level namescope. This may
-be inconvenient, since in the new summary ops the summary will inherit that
-namescope without user control. We plan to add more grouping mechanisms to
-TensorBoard, so it will be possible to specify the TensorBoard group for
+As before, TensorBoard groups charts by the top-level `tf.name_scope` which may
+be inconvenient, for in the new summary ops, the summary will inherit that
+`tf.name_scope` without user control. We plan to add more grouping mechanisms
+to TensorBoard, so it will be possible to specify the TensorBoard group for
 each summary via the summary API.
 
 """

--- a/tensorflow/contrib/deprecated/__init__.py
+++ b/tensorflow/contrib/deprecated/__init__.py
@@ -18,17 +18,14 @@ For TensorFlow 1.0, we have reorganized the TensorFlow summary ops into a
 submodule, and made some semantic tweaks. The first thing to note is that we
 moved the APIs around as follows:
 
+```python
 tf.scalar_summary -> tf.summary.scalar
-
 tf.histogram_summary -> tf.summary.histogram
-
 tf.audio_summary -> tf.summary.audio
-
 tf.image_summary -> tf.summary.image
-
 tf.merge_summary -> tf.summary.merge
-
 tf.merge_all_summaries -> tf.summary.merge_all
+```
 
 We think this API is cleaner and will improve long-term discoverability and
 clarity of the TensorFlow API. We however, also took the opportunity to make an
@@ -46,7 +43,7 @@ collision.
 
 The new summary APIs under tf.summary throw away the "tag" as an independent
 concept; instead, the first argument is the node name. So summary tags now 
-automatically inherit the surrounding TF name scope, and automatically
+automatically inherit the surrounding TF namescope, and automatically
 are deduplicated if there is a conflict. Now however, the only allowed
 characters are alphanumerics, underscores, and forward slashes. To make
 migration easier, the new APIs automatically convert illegal characters to
@@ -67,7 +64,7 @@ def add_activation_summaries(v):
 ```
 
 Now, so long as the add_activation_summaries function is called from within the
-right name scope, the behavior is the same.
+right namescope, the behavior is the same.
 
 Because this change does modify the behavior and could break tests, we can't
 automatically migrate usage to the new APIs. That is why we are making the old
@@ -82,9 +79,9 @@ to the new summary ops:
   tf.summary.scalar requires a single scalar name and scalar value. In most
   cases, you can create tf.summary.scalars in a loop to get the same behavior
 
-As before, TensorBoard groups charts by the top-level name scope. This may
+As before, TensorBoard groups charts by the top-level namescope. This may
 be inconvenient, since in the new summary ops the summary will inherit that
-name scope without user control. We plan to add more grouping mechanisms to
+namescope without user control. We plan to add more grouping mechanisms to
 TensorBoard, so it will be possible to specify the TensorBoard group for
 each summary via the summary API.
 

--- a/tensorflow/contrib/deprecated/__init__.py
+++ b/tensorflow/contrib/deprecated/__init__.py
@@ -30,18 +30,18 @@ tf.merge_summary -> tf.summary.merge
 
 tf.merge_all_summaries -> tf.summary.merge_all
 
-We think this is a cleaner API and will improve long-term discoverability and
-clarity of the TensorFlow API. However, we also took the opportunity to make an
+We think this API is cleaner and will improve long-term discoverability and
+clarity of the TensorFlow API. We however, also took the opportunity to make an
 important change to how summary "tags" work. The "tag" of a summary is the
 string that is associated with the output data, i.e. the key for organizing the
 generated protobufs.
 
-Previously, the tag was allowed to be any unique string, and had no relation
+Previously, the tag was allowed to be any unique string; it had no relation
 to the summary op generating it, and no relation to the TensorFlow name system.
-This made it very difficult to write re-usable code that would add summary
-ops to the graph. If you had a function that would add summary ops, you would
-need to manually pass in a name scope to that function to create deduplicated
-tags, otherwise your program would fail with a runtime error due to tag
+This behavior greatly complicates the reusability of the code that would add 
+summary ops to the graph. If you had a function to add summary ops, you would
+need to pass in a namescope, manually, to that function to create deduplicated
+tags. Otherwise your program would fail with a runtime error due to tag
 collision.
 
 The new summary APIs under tf.summary throw away the "tag" as an independent

--- a/tensorflow/contrib/deprecated/__init__.py
+++ b/tensorflow/contrib/deprecated/__init__.py
@@ -28,22 +28,22 @@ tf.merge_all_summaries -> tf.summary.merge_all
 ```
 
 We think this API is cleaner and will improve long-term discoverability and
-clarity of the TensorFlow API. We however, also took the opportunity to make an
+clarity of the TensorFlow API. But we also took the opportunity to make an
 important change to how summary "tags" work. The "tag" of a summary is the
 string that is associated with the output data, i.e. the key for organizing the
 generated protobufs.
 
 Previously, the tag was allowed to be any unique string; it had no relation
 to the summary op generating it, and no relation to the TensorFlow name system.
-This behavior greatly complicates the reusability of the code that would add 
+This behavior made it very difficult to write reusable  that would add 
 summary ops to the graph. If you had a function to add summary ops, you would
-need to pass in a namescope, manually, to that function to create deduplicated
+need to pass in a `tf.name_scope`, manually, to that function to create deduplicated
 tags. Otherwise your program would fail with a runtime error due to tag
 collision.
 
 The new summary APIs under tf.summary throw away the "tag" as an independent
 concept; instead, the first argument is the node name. So summary tags now 
-automatically inherit the surrounding TF namescope, and automatically
+automatically inherit the surrounding `tf.name_scope`, and automatically
 are deduplicated if there is a conflict. Now however, the only allowed
 characters are alphanumerics, underscores, and forward slashes. To make
 migration easier, the new APIs automatically convert illegal characters to


### PR DESCRIPTION
-Add Python formatting for TF website
-Refactor comment
-Import statements are shorter than 80 chars, so pylint should not need to be suppressed here
-Add python formatting to correct website formatting away newlines