### PR TITLE
Verbs fix: Removed Dependency on Duplicate Recv Flag

### DIFF
--- a/tensorflow/contrib/verbs/rdma.cc
+++ b/tensorflow/contrib/verbs/rdma.cc
@@ -165,7 +165,8 @@ void RdmaAdapter::Process_CQ() {
           RdmaBuffer* ab = rc->tx_ack_buffer_;
           ab->SendNextItem();
           // find buffer
-          RdmaTensorBuffer* tb = reinterpret_cast<RdmaTensorBuffer*> (rc->FindBuffer(rm.name_));
+          RdmaTensorBuffer* tb =
+              reinterpret_cast<RdmaTensorBuffer*>(rc->FindBuffer(rm.name_));
           tb->SetBufferStatus(remote, idle);
           worker_env_->compute_pool->Schedule([tb]() { tb->ReSendNextItem(); });
         } else if (rm.type_ == RDMA_MESSAGE_BUFFER_REQUEST) {
@@ -198,7 +199,8 @@ void RdmaAdapter::Process_CQ() {
           RdmaBuffer* ab = rc->tx_ack_buffer_;
           ab->SendNextItem();
           // find buffer
-          RdmaTensorBuffer* tb = reinterpret_cast<RdmaTensorBuffer*> (rc->FindBuffer(rm.name_));
+          RdmaTensorBuffer* tb =
+              reinterpret_cast<RdmaTensorBuffer*>(rc->FindBuffer(rm.name_));
           CHECK(rm.buffer_size_ == tb->size_)
               << "rm.buffer_size = " << rm.buffer_size_
               << "tb->size_ = " << tb->size_ << "rm.name_ = " << rm.name_;
@@ -662,8 +664,8 @@ void RdmaMessageBuffer::SendNextItem() {
 }
 
 Rendezvous::DoneCallback RdmaTensorBuffer::getRecvTensorCallback(
-    const string& key_with_step_id, const string& key,
-    int64 step_id, const Rendezvous::ParsedKey& parsed) {
+    const string& key_with_step_id, const string& key, int64 step_id,
+    const Rendezvous::ParsedKey& parsed) {
   Rendezvous::DoneCallback cb = [this, key_with_step_id, key, step_id, parsed](
       const Status& status, const Rendezvous::Args& send_args,
       const Rendezvous::Args& recv_args, const Tensor& in, bool is_dead) {
@@ -840,7 +842,7 @@ void RdmaTensorBuffer::PostCopyOperations(
       VLOG(2) << "Extend RDMA buffer from " << size_ << " to " << buffer_size;
     }
     CreateCPUBuffer(buffer_size, false);
-    //Need to be recieved again, put into the re-recv queue and the table
+    // Need to be received again, put into the re-recv queue and the table
     requeue.push(key_with_step_id);
     ReItem* item = new ReItem(send_args, recv_args, in, is_dead);
     retable.insert(std::pair<string, ReItem*>(key_with_step_id, item));
@@ -891,7 +893,7 @@ void RdmaTensorBuffer::PostCopyOperations(
     }
     Write(imm_data, buffer_size);
   } else {
-    //Need to be recieved again, put into the re-recv queue and the table
+    // Need to be received again, put into the re-recv queue and the table
     requeue.push(key_with_step_id);
     ReItem* item = new ReItem(send_args, recv_args, in, is_dead);
     retable.insert(std::pair<string, ReItem*>(key_with_step_id, item));

--- a/tensorflow/contrib/verbs/rdma.h
+++ b/tensorflow/contrib/verbs/rdma.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/core/distributed_runtime/worker_env.h"
+#include "tensorflow/core/framework/rendezvous.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/types.h"
@@ -224,14 +225,36 @@ class RdmaMessageBuffer : public RdmaBuffer {
 class RdmaTensorBuffer : public RdmaBuffer {
  public:
   explicit RdmaTensorBuffer(RdmaChannel* channel, string name);
-  virtual ~RdmaTensorBuffer() override {}
+  virtual ~RdmaTensorBuffer() override;
   void SendNextItem() override;
   void PostCopyOperations(bool can_memcpy, size_t buffer_size,
                           size_t tensor_bytes, const string& key,
                           const Tensor& in, int64 step_id, bool is_dead,
                           const string& key_with_step_id, const Tensor* copy,
-                          const TensorProto* proto,
-                          const StringPiece* copy_buf);
+                          const TensorProto* proto, const StringPiece* copy_buf,
+                          const Rendezvous::Args& send_args,
+                          const Rendezvous::Args& recv_args);
+
+  void ReSendNextItem();
+
+ private:
+  Rendezvous::DoneCallback getRecvTensorCallback(
+      const string& key_with_step_id, const string& key,
+      int64 step_id, const Rendezvous::ParsedKey& parsed);
+
+  struct ReItem {
+    Status status;
+    Rendezvous::Args send_args;
+    Rendezvous::Args recv_args;
+    Tensor in;
+    bool is_dead;
+  };
+
+  typedef std::map<string, ReItem*> Table;
+  typedef Table::iterator Itable;
+
+  std::queue<string> requeue GUARDED_BY(mu_);
+  Table retable GUARDED_BY(mu_);
 };
 
 struct RdmaMessage {

--- a/tensorflow/contrib/verbs/rdma.h
+++ b/tensorflow/contrib/verbs/rdma.h
@@ -243,13 +243,29 @@ class RdmaTensorBuffer : public RdmaBuffer {
       int64 step_id, const Rendezvous::ParsedKey& parsed);
 
   struct ReItem {
-    Status status;
     Rendezvous::Args send_args;
     Rendezvous::Args recv_args;
     Tensor in;
     bool is_dead;
-  };
 
+    ReItem(const Rendezvous::Args& send_args_, const Rendezvous::Args& recv_args_, const Tensor& in_, bool is_dead_ ): send_args(send_args_), recv_args(recv_args_), in(in_), is_dead(is_dead_){
+      if (send_args.device_context){
+        send_args.device_context->Ref();
+      }
+      if (recv_args.device_context){
+        recv_args.device_context->Ref();
+      }
+    }
+
+    ~ReItem() {
+      if (send_args.device_context) {
+        send_args.device_context->Unref();
+      }
+      if (recv_args.device_context) {
+        recv_args.device_context->Unref();
+      }
+    }
+  };
   typedef std::map<string, ReItem*> Table;
   typedef Table::iterator Itable;
 

--- a/tensorflow/contrib/verbs/rdma.h
+++ b/tensorflow/contrib/verbs/rdma.h
@@ -239,8 +239,8 @@ class RdmaTensorBuffer : public RdmaBuffer {
 
  private:
   Rendezvous::DoneCallback getRecvTensorCallback(
-      const string& key_with_step_id, const string& key,
-      int64 step_id, const Rendezvous::ParsedKey& parsed);
+      const string& key_with_step_id, const string& key, int64 step_id,
+      const Rendezvous::ParsedKey& parsed);
 
   struct ReItem {
     Rendezvous::Args send_args;
@@ -248,11 +248,16 @@ class RdmaTensorBuffer : public RdmaBuffer {
     Tensor in;
     bool is_dead;
 
-    ReItem(const Rendezvous::Args& send_args_, const Rendezvous::Args& recv_args_, const Tensor& in_, bool is_dead_ ): send_args(send_args_), recv_args(recv_args_), in(in_), is_dead(is_dead_){
-      if (send_args.device_context){
+    ReItem(const Rendezvous::Args& send_args_,
+           const Rendezvous::Args& recv_args_, const Tensor& in_, bool is_dead_)
+        : send_args(send_args_),
+          recv_args(recv_args_),
+          in(in_),
+          is_dead(is_dead_) {
+      if (send_args.device_context) {
         send_args.device_context->Ref();
       }
-      if (recv_args.device_context){
+      if (recv_args.device_context) {
         recv_args.device_context->Ref();
       }
     }


### PR DESCRIPTION
This PR is a response for #11825 

I've added a new Queue and Table for the **RdmaTensorBuffer**, where the relevant information from the send-recv waiter table is stored in case the actual rdma-write does not occur (If the allocated buffer is too small, or busy). When we get a RDMA_MESSAGE_BUFFER_RESPONSE, or RDMA_MESSAGE_BUFFER_IDLE, we check the new queue/table instead of checking the waiter table. (This happens in the new ReSendNextItem() function).

Also added a new function that generates the callback lambda function, to avoid code redundancy.
The result is that the code is less clean- I am open to suggestions on making it more tidy.

@junshi15 @shamoya 