### PR TITLE
cmake external projects: pass --libdir to configure

### DIFF
--- a/tensorflow/contrib/cmake/external/farmhash.cmake
+++ b/tensorflow/contrib/cmake/external/farmhash.cmake
@@ -52,6 +52,7 @@ else()
       CONFIGURE_COMMAND
           ${farmhash_BUILD}/configure
           --prefix=${farmhash_INSTALL}
+          --libdir=${farmhash_INSTALL}/lib
           --enable-shared=yes
           CXXFLAGS=-fPIC)
 

--- a/tensorflow/contrib/cmake/external/gif.cmake
+++ b/tensorflow/contrib/cmake/external/gif.cmake
@@ -66,6 +66,7 @@ else()
           ${CMAKE_CURRENT_BINARY_DIR}/gif/src/gif/configure
           --with-pic
           --prefix=${gif_INSTALL}
+          --libdir=${gif_INSTALL}/lib
          --enable-shared=yes
   )
 

--- a/tensorflow/contrib/cmake/external/jpeg.cmake
+++ b/tensorflow/contrib/cmake/external/jpeg.cmake
@@ -74,6 +74,7 @@ else()
         CONFIGURE_COMMAND
             ${jpeg_BUILD}/configure
             --prefix=${jpeg_INSTALL}
+            --libdir=${jpeg_INSTALL}/lib
             --enable-shared=yes
 	    CFLAGS=-fPIC
     )


### PR DESCRIPTION
If `--libdir` is not set, configure will install into a subdirectory `lib64` on some platforms, while the build-system has `lib` hard-coded to find the static libraries later.
