### PR TITLE
Fix issue of `name` used in `build_default_serving_input_fn`

### DIFF
--- a/tensorflow/contrib/learn/BUILD
+++ b/tensorflow/contrib/learn/BUILD
@@ -881,6 +881,22 @@ py_test(
 )
 
 py_test(
+    name = "input_fn_utils_test",
+    size = "small",
+    srcs = ["python/learn/utils/input_fn_utils_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":learn",
+        "//tensorflow/contrib/layers:layers_py",
+        "//tensorflow/core:protos_all_py",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:platform",
+        "//tensorflow/python:util",
+    ],
+)
+
+py_test(
     name = "stability_test",
     size = "small",
     srcs = ["python/learn/estimators/stability_test.py"],

--- a/tensorflow/contrib/learn/python/learn/utils/input_fn_utils.py
+++ b/tensorflow/contrib/learn/python/learn/utils/input_fn_utils.py
@@ -109,7 +109,7 @@ def build_default_serving_input_fn(features, default_batch_size=None):
 
       features_placeholders[name] = array_ops.placeholder(dtype=t.dtype,
                                                           shape=shape,
-                                                          name=t.name)
+                                                          name=t.op.name)
     labels = None  # these are not known in serving!
     return InputFnOps(features_placeholders, labels, features_placeholders)
   return input_fn

--- a/tensorflow/contrib/learn/python/learn/utils/input_fn_utils_test.py
+++ b/tensorflow/contrib/learn/python/learn/utils/input_fn_utils_test.py
@@ -1,0 +1,39 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests of utilities for creating input_fns."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib.learn.python.learn.utils import input_fn_utils
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.platform import test
+
+class InputFnTest(test.TestCase):
+
+  def test_build_default_serving_input_fn_name(self):
+    """Test case for #12755"""
+    f = {
+        'feature':
+            array_ops.placeholder(
+                name='feature', shape=[32], dtype=dtypes.float32)
+    }
+    serving_input = input_fn_utils.build_default_serving_input_fn(f)
+    v = serving_input()
+    self.assertTrue(isinstance(v, input_fn_utils.InputFnOps))
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/estimator/export/export.py
+++ b/tensorflow/python/estimator/export/export.py
@@ -133,11 +133,12 @@ def build_raw_serving_input_receiver_fn(features, default_batch_size=None):
       shape_list[0] = default_batch_size
       shape = tensor_shape.TensorShape(shape_list)
 
-      # Reuse the feature tensor name for the placeholder, excluding the index
-      placeholder_name = t.name.split(':')[0]
+      # Reuse the feature tensor's op name (t.op.name) for the placeholder,
+      # excluding the index from the tensor's name (t.name):
+      # t.name = "%s:%d" % (t.op.name, t._value_index)
       receiver_tensors[name] = array_ops.placeholder(dtype=t.dtype,
                                                      shape=shape,
-                                                     name=placeholder_name)
+                                                     name=t.op.name)
     # TODO(b/34885899): remove the unnecessary copy
     # The features provided are simply the placeholders, but we defensively copy
     # the dict because it may be mutated.

--- a/tensorflow/python/estimator/export/export_test.py
+++ b/tensorflow/python/estimator/export/export_test.py
@@ -188,6 +188,18 @@ class ExportTest(test_util.TensorFlowTestCase):
         self.assertAllEqual([525.25],
                             sparse_result["float_feature"].values)
 
+  def test_build_raw_serving_input_receiver_fn_name(self):
+    """Test case for #12755"""
+    f = {
+        'feature':
+            array_ops.placeholder(
+                name='feature', shape=[32], dtype=dtypes.float32)
+    }
+    serving_input_receiver_fn = export.build_raw_serving_input_receiver_fn(f)
+    v = serving_input_receiver_fn()
+    self.assertTrue(isinstance(v, export.ServingInputReceiver))
+
+
   def test_build_raw_serving_input_receiver_fn(self):
     features = {"feature_1": constant_op.constant(["hello"]),
                 "feature_2": constant_op.constant([42])}


### PR DESCRIPTION
This fix tries to address the issue raised in #12755 where the name used in `build_default_serving_input_fn` is not a valid variable scope:
```
$ python -c "import tensorflow as tf
f = {'feature': tf.placeholder(name='feature', shape=[32], dtype=tf.float32) }
serving_input = tf.contrib.learn.utils.input_fn_utils.build_default_serving_input_fn(f)
serving_input()"
...
ValueError: 'feature:0' is not a valid scope name
```

In `build_default_serving_input_fn`, the name of the tensor is used directly which consists of the op name and the value index:
```
class Tensor(_TensorLike):
....
  @property
  def name(self):
    """The string name of this tensor."""
    if not self._op.name:
      raise ValueError("Operation was not named: %s" % self._op)
    return "%s:%d" % (self._op.name, self._value_index)
```

This fix fixes this issue by using the name of the tensor's op (not tensor): `t.op.name` instead, to avoid the ":0" (value index) at the end.

This fix fixes #12755.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>