### PR TITLE
Allow tfcompile_flags to be a list

### DIFF
--- a/tensorflow/compiler/aot/tfcompile.bzl
+++ b/tensorflow/compiler/aot/tfcompile.bzl
@@ -127,6 +127,10 @@ def tf_library(name, graph, config,
   header_file = name + ".h"
   object_file = name + ".o"
   ep = ("__" + PACKAGE_NAME + "__" + name).replace("/", "_")
+  if type(tfcompile_flags) == type(""):
+    flags = tfcompile_flags
+  else:
+    flags = " ".join(["'" + arg.replace("'", "'\\''") + "'" for arg in (tfcompile_flags or [])])
   native.genrule(
       name=("gen_" + name),
       srcs=[
@@ -145,7 +149,7 @@ def tf_library(name, graph, config,
            " --target_triple=" + target_llvm_triple() +
            " --out_header=$(@D)/" + header_file +
            " --out_object=$(@D)/" + object_file +
-           " ".join(tfcompile_flags or [])),
+           flags),
       tools=[tfcompile_tool],
       visibility=visibility,
       testonly=testonly,

--- a/tensorflow/compiler/aot/tfcompile.bzl
+++ b/tensorflow/compiler/aot/tfcompile.bzl
@@ -145,7 +145,7 @@ def tf_library(name, graph, config,
            " --target_triple=" + target_llvm_triple() +
            " --out_header=$(@D)/" + header_file +
            " --out_object=$(@D)/" + object_file +
-           " " + (tfcompile_flags or "")),
+           " ".join(tfcompile_flags or [])),
       tools=[tfcompile_tool],
       visibility=visibility,
       testonly=testonly,

--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -626,7 +626,7 @@ tf_library(
     cpp_class = "LSTMLayerInference",
     graph = "lstm_layer_inference.pbtxt",
     tags = ["manual"],
-    tfcompile_flags = "--xla_cpu_multi_thread_eigen=false",
+    tfcompile_flags = ["--xla_cpu_multi_thread_eigen=false"],
 )
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This fix tries to fix the issue raised in #12767 where
it was not possible to specify tfcompile_flags as a list:
```
tf_library(
  ...
  tfcompile_flags = ["--target_cpu='core-avx2'", "--xla_enable_fast_math=false"]
)
```
will crash upon build with '+' operator applied to incompatible types (select of string, list)

This is inconsistent with other rules like 'copts' in cc_binary.

The issue is from tfcompile.bzl:
```
" " + (tfcompile_flags or "")),
```

This fix uses `" ".join(tfcompile_flags or [])` instead so that it
is possible to specify the list.

This fix fixes #12767.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>