### PR TITLE
[android demo] add check to SpeechActivity.java for call requestPermissions only with API>=23

### DIFF
--- a/tensorflow/examples/android/src/org/tensorflow/demo/SpeechActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/SpeechActivity.java
@@ -37,6 +37,7 @@ import android.content.pm.PackageManager;
 import android.media.AudioFormat;
 import android.media.AudioRecord;
 import android.media.MediaRecorder;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -155,8 +156,10 @@ public class SpeechActivity extends Activity {
   }
 
   private void requestMicrophonePermission() {
-    requestPermissions(
-        new String[] {android.Manifest.permission.RECORD_AUDIO}, REQUEST_RECORD_AUDIO);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      requestPermissions(
+              new String[]{android.Manifest.permission.RECORD_AUDIO}, REQUEST_RECORD_AUDIO);
+    }
   }
 
   @Override

--- a/tensorflow/examples/android/src/org/tensorflow/demo/SpeechActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/SpeechActivity.java
@@ -152,6 +152,7 @@ public class SpeechActivity extends Activity {
 
     // Start the recording and recognition threads.
     requestMicrophonePermission();
+    startRecording();
     startRecognition();
   }
 

--- a/tensorflow/examples/android/src/org/tensorflow/demo/SpeechActivity.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/SpeechActivity.java
@@ -159,7 +159,7 @@ public class SpeechActivity extends Activity {
   private void requestMicrophonePermission() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       requestPermissions(
-              new String[]{android.Manifest.permission.RECORD_AUDIO}, REQUEST_RECORD_AUDIO);
+          new String[]{android.Manifest.permission.RECORD_AUDIO}, REQUEST_RECORD_AUDIO);
     }
   }
 


### PR DESCRIPTION
`requestPermissions` call possible only with API>=23
`minSdkVersion` set to 21 for the Project. 
Hence check required, otherwise, on devices with API 21 and 22 we'll get the error:
```
...
09-02 15:14:21.979 24890-24890/org.tensorflow.demo E/AndroidRuntime: FATAL EXCEPTION: main
                                                                     Process: org.tensorflow.demo, PID: 24890
                                                                     java.lang.NoSuchMethodError: No virtual method requestPermissions([Ljava/lang/String;I)V in class Lorg/tensorflow/demo/SpeechActivity; or its super classes (declaration of 'org.tensorflow.demo.SpeechActivity' appears in /data/app/org.tensorflow.demo-1/split_lib_slice_7_apk.apk)
                                                                         at org.tensorflow.demo.SpeechActivity.requestMicrophonePermission(SpeechActivity.java:160)
...
```