### PR TITLE
Fix undefined reference to libtensorflow-core.a

### DIFF
--- a/tensorflow/contrib/pi_examples/label_image/Makefile
+++ b/tensorflow/contrib/pi_examples/label_image/Makefile
@@ -43,11 +43,11 @@ INCLUDES := \
 -I$(PROTOGENDIR) \
 -I$(PBTGENDIR)
 LIBS := \
+-ltensorflow-core \
 -lstdc++ \
 -lprotobuf \
 -Wl,--allow-multiple-definition \
 -Wl,--whole-archive \
--ltensorflow-core \
 -Wl,--no-whole-archive \
 -ldl \
 -lpthread \


### PR DESCRIPTION
Adjust parameter order to fix undefined reference error.