### PR TITLE
Fix undefined reference to libtensorflow-core.a

### DIFF
--- a/tensorflow/contrib/pi_examples/camera/Makefile
+++ b/tensorflow/contrib/pi_examples/camera/Makefile
@@ -43,13 +43,13 @@ INCLUDES := \
 -I$(PROTOGENDIR) \
 -I$(PBTGENDIR)
 LIBS := \
+-Wl,--allow-multiple-definition \
+-Wl,--whole-archive \
 -ltensorflow-core \
+-Wl,--no-whole-archive \
 -lstdc++ \
 -lprotobuf \
 -lv4l2 \
--Wl,--allow-multiple-definition \
--Wl,--whole-archive \
--Wl,--no-whole-archive \
 -ldl \
 -lpthread \
 -lm \

--- a/tensorflow/contrib/pi_examples/camera/Makefile
+++ b/tensorflow/contrib/pi_examples/camera/Makefile
@@ -43,12 +43,12 @@ INCLUDES := \
 -I$(PROTOGENDIR) \
 -I$(PBTGENDIR)
 LIBS := \
+-ltensorflow-core \
 -lstdc++ \
 -lprotobuf \
 -lv4l2 \
 -Wl,--allow-multiple-definition \
 -Wl,--whole-archive \
--ltensorflow-core \
 -Wl,--no-whole-archive \
 -ldl \
 -lpthread \

--- a/tensorflow/contrib/pi_examples/label_image/Makefile
+++ b/tensorflow/contrib/pi_examples/label_image/Makefile
@@ -43,11 +43,11 @@ INCLUDES := \
 -I$(PROTOGENDIR) \
 -I$(PBTGENDIR)
 LIBS := \
+-ltensorflow-core \
 -lstdc++ \
 -lprotobuf \
 -Wl,--allow-multiple-definition \
 -Wl,--whole-archive \
--ltensorflow-core \
 -Wl,--no-whole-archive \
 -ldl \
 -lpthread \


### PR DESCRIPTION
Adjust gcc parameter order to fix linker error. Tested on gcc version 5.4.0 20160609 (Ubuntu/Linaro 5.4.0-6ubuntu1~16.04.4) 