### PR TITLE
Add a missing template explicit instantiation of SetZeroFunctor

### DIFF
--- a/tensorflow/core/kernels/fill_functor.cc
+++ b/tensorflow/core/kernels/fill_functor.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/framework/variant_encode_decode.h"
 
 namespace tensorflow {
 namespace functor {
@@ -50,6 +51,7 @@ DEFINE_SETZERO_CPU(int32);
 DEFINE_SETZERO_CPU(int64);
 DEFINE_SETZERO_CPU(complex64);
 DEFINE_SETZERO_CPU(complex128);
+DEFINE_SETZERO_CPU(Variant);
 #undef DEFINE_SETZERO_CPU
 
 #ifdef TENSORFLOW_USE_SYCL


### PR DESCRIPTION
To fix a build error on Windows:
```
libconstant_op.lo(constant_op.o) : error LNK2019: unresolved external symbol "public: void __cdecl tensorflow::functor::SetZeroFunctor<struct Eigen::ThreadPoolDevice,class tensorflow::Variant>::operator()(struct Eigen::ThreadPoolDevice const &,class Eigen::TensorMap<class Eigen::Tensor<class tensorflow::Variant,1,1,__int64>,16,struct Eigen::MakePointer>)" (??R?$SetZeroFunctor@UThreadPoolDevice@Eigen@@VVariant@tensorflow@@@functor@tensorflow@@QEAAXAEBUThreadPoolDevice@Eigen@@V?$TensorMap@V?$Tensor@VVariant@tensorflow@@$00$00_J@Eigen@@$0BA@UMakePointer@2@@4@@Z) referenced in function "public: virtual void __cdecl tensorflow::ZerosLikeOp<struct Eigen::ThreadPoolDevice,class tensorflow::Variant>::Compute(class tensorflow::OpKernelContext *)" (?Compute@?$ZerosLikeOp@UThreadPoolDevice@Eigen@@VVariant@tensorflow@@@tensorflow@@UEAAXPEAVOpKernelContext@2@@Z)
```