### PR TITLE
Fix incorrect error message in TensorArray.scatter

### DIFF
--- a/tensorflow/core/kernels/tensor_array_ops.cc
+++ b/tensorflow/core/kernels/tensor_array_ops.cc
@@ -1069,7 +1069,7 @@ class TensorArrayUnpackOrScatterOp : public OpKernel {
     } else {
       OP_REQUIRES(
           ctx, max_index < array_size,
-          errors::InvalidArgument("Max scatter index must be <= array size (",
+          errors::InvalidArgument("Max scatter index must be < array size (",
                                   max_index, " vs. ", array_size, ")"));
     }
     element_shape.RemoveDim(0);


### PR DESCRIPTION
This fix tries to fix the issue raised in #12403 where the error message in TensorArray.scatter is incorrect. Specifically, in
```
      OP_REQUIRES(
          ctx, max_index < array_size,
          errors::InvalidArgument("Max scatter index must be <= array size (",
                                  max_index, " vs. ", array_size, ")"));
```

The `<= array size` in error message should be `< array size` as the maximum value of index (0-based) should always be smaller than array size.

This fix fixes #12403.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>