### PR TITLE
Fix typo & Clarify comment

### DIFF
--- a/tensorflow/python/profiler/model_analyzer.py
+++ b/tensorflow/python/profiler/model_analyzer.py
@@ -117,7 +117,7 @@ class Profiler(object):
   ```python
   Typical use case:
     # Currently we are only allowed to create 1 profiler per process.
-    profiler = Profile(sess.graph)
+    profiler = Profiler(sess.graph)
 
     for i in xrange(total_steps):
       if i % 10000 == 0:
@@ -174,7 +174,7 @@ class Profiler(object):
     """Add statistics of a step.
 
     Args:
-      step: A step uint64 used to identify the RunMetadata. Must be different
+      step: int, A step used to identify the RunMetadata. Must be different
          across different AddStep() calls.
       run_meta: RunMetadata proto that contains statistics of a session run.
     """


### PR DESCRIPTION
- Fix typo in comment : `Profiler` -> `Profile` 
- `uint64` can be misunderstood as `np.uint64`. So I propose to change it to `int`

This edit is to avoid misusage of tf.Profile by a developer using it for the first time. See the scenario below:

0. He or she follow this [instruction](https://github.com/tensorflow/tensorflow/blob/084d29e67a72e369958c18ae6abfe2752fcddcbf/tensorflow/python/profiler/model_analyzer.py#L120) from comment
1. He or she may want to pass evaluated [global_step](https://www.tensorflow.org/versions/r1.2/api_docs/python/tf/train/global_step) (which type is `np.int32`) to `profiler.add_step` 
```
global_step = tf.Variable(0, name="global_step", trainable=False)
step = session.run(global_step, ...)
profiler.add_step(step, run_meta)
```
2. `profiler.add_step` raise `TypeError: in method 'AddStep', argument 1 of type 'int64'`
3. So he or she may mistakenly try again to convert `np.uint32` `step` to `np.uint64` `step`. *Because comment said use `uint64` type for `step`*

```profiler.add_step(step.astype(np.uint64), run_meta) ```

4.  **BUT!** `TypeError: in method 'AddStep', argument 1 of type 'int64'` raise again! 
5. ... correct answer is to try to convert `step` as `int(step)`.
