### PR TITLE
adding missing dep on jdk for gen_ops.bzl

### DIFF
--- a/tensorflow/java/src/gen/gen_ops.bzl
+++ b/tensorflow/java/src/gen/gen_ops.bzl
@@ -53,7 +53,7 @@ def tf_java_op_gen_srcjar(name,
 
   native.genrule(
       name=name,
-      srcs=["@local_jdk//:jar"],
+      srcs=["@local_jdk//:jar"] + ["@local_jdk//:jdk"],
       outs=[gen_srcjar],
       tools=gen_tools,
       cmd='&&'.join(gen_cmds))


### PR DESCRIPTION
sandboxed builds for this target are broken with the following error:
+ external/local_jdk/bin/jar cMf bazel-out/linux_gnu_x86-opt/genfiles/tensorflow/java/ops/java_op_gen_sources.srcjar -C bazel-out/linux_gnu_x86-opt/genfiles/tensorflow/java/ops .
external/local_jdk/bin/jar: error while loading shared libraries: libjli.so: cannot open shared object file: No such file or directory

I found a similar issue in bazelbuild (https://github.com/bazelbuild/bazel/issues/444), seems to be the case that this error is produced when a (e.g, the genrule in line 476) is missing the JDK as an input to the action.