### PR TITLE
Clarified difference between FIFOQueue and StagingArea

### DIFF
--- a/tensorflow/docs_src/performance/performance_models.md
+++ b/tensorflow/docs_src/performance/performance_models.md
@@ -29,12 +29,12 @@ implementation is made up of 3 stages:
 
 The dominant part of each stage is executed in parallel with the other stages
 using `data_flow_ops.StagingArea`. `StagingArea` is a queue-like operator
-similar to @{tf.FIFOQueue}. The difference is that `StagingArea` offers simpler
-functionality and can be executed on both CPU and GPU in parallel with other
-stages. Breaking the input pipeline into 3 stages that operate independently in
-parallel is scalable and takes full advantage of large multi-core environments.
-The rest of this section details the stages followed by details about using
-`data_flow_ops.StagingArea`.
+similar to @{tf.FIFOQueue}. The difference is that `StagingArea`  does not 
+guarantee FIFO ordering, but offers simpler functionality and can be executed 
+on both CPU and GPU in parallel with other stages. Breaking the input pipeline
+into 3 stages that operate independently inparallel is scalable and takes full
+advantage of large multi-core environments. The rest of this section details
+the stages followed by details about using `data_flow_ops.StagingArea`.
 
 ### Parallelize I/O Reads
 

--- a/tensorflow/docs_src/performance/performance_models.md
+++ b/tensorflow/docs_src/performance/performance_models.md
@@ -32,7 +32,7 @@ using `data_flow_ops.StagingArea`. `StagingArea` is a queue-like operator
 similar to @{tf.FIFOQueue}. The difference is that `StagingArea`  does not 
 guarantee FIFO ordering, but offers simpler functionality and can be executed 
 on both CPU and GPU in parallel with other stages. Breaking the input pipeline
-into 3 stages that operate independently inparallel is scalable and takes full
+into 3 stages that operate independently in parallel is scalable and takes full
 advantage of large multi-core environments. The rest of this section details
 the stages followed by details about using `data_flow_ops.StagingArea`.
 


### PR DESCRIPTION
Clarified that StagingArea doesn't guarantee ordered delivery, contrasting tf.FIFOQueue