### PR TITLE
Add SONAME for Makefile-built libtensorflow_inference.so

### DIFF
--- a/tensorflow/contrib/makefile/sub_makefiles/android/Makefile.in
+++ b/tensorflow/contrib/makefile/sub_makefiles/android/Makefile.in
@@ -52,7 +52,9 @@ $(INFERENCE_SO_PATH): $(LIB_OBJS) $(INFERENCE_OBJS)
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) \
 	-o $@ $(INFERENCE_OBJS) $(LIB_OBJS) \
-	$(LIBFLAGS) $(LDFLAGS) -shared $(LIBS)
+	$(LIBFLAGS) $(LDFLAGS) \
+	-shared -Wl,-soname,$(INFERENCE_SO_NAME) \
+	$(LIBS)
 
 $(INFERENCE_SO_NAME): $(INFERENCE_SO_PATH)
 


### PR DESCRIPTION
Currently if we build our own shared library that depends on Makefile-built Tensorflow shared library, our built library is linking the Tensorflow library with **absolute path**. So added a `SONAME` to Makefile-built Tensorflow shared library to resolve this problem.