### PR TITLE
Fix minor typo in Programmer's Guide docs

### DIFF
--- a/tensorflow/docs_src/programmers_guide/tensors.md
+++ b/tensorflow/docs_src/programmers_guide/tensors.md
@@ -147,7 +147,7 @@ Passing a single number, however, returns a subvector of a matrix, as follows:
 
 
 ```python
-my_row_vetor = my_matrix[2]
+my_row_vector = my_matrix[2]
 my_column_vector = my_matrix[:, 3]
 ```
 


### PR DESCRIPTION
Change `my_row_vetor` to `my_row_vector` in the Tensors guide.