### PR TITLE
MKL build broken / Proposed fix here

### DIFF
--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -406,13 +406,10 @@ class MklConv2DOp : public OpKernel {
         CHECK_EQ(dnnConversionCreate_F32(&mkl_prim_convert_filter, lt_filter,
                                          mkl_lt_internal_filter),
                  E_SUCCESS);
-<<<<<<< HEAD
-        mkl_buf_convert_filter = const_cast<void*>(static_cast<const void*>(
+
+      mkl_buf_convert_filter = const_cast<void*>(static_cast<const void*>(
             output_filter->flat<T>().data()));
-=======
-        mkl_buf_convert_filter = const_cast<void*>(
-            static_cast<const void*>(output_filter->flat<T>().data()));
->>>>>>> e722358e7e96dd2aa20d7e2c56336e76845daa6a
+
         CHECK_EQ(
             dnnConversionExecute_F32(mkl_prim_convert_filter, mkl_buf_filter,
                                      mkl_buf_convert_filter),


### PR DESCRIPTION
The CPU version of TensorFlow wasn't building because the MKL was broken; it was broken because a merge conflict somehow made it all the way through to here.  See diff (!).