### PR TITLE
change cnn_mnist example to use Adam optimizer; added a 'loss' summary

### DIFF
--- a/tensorflow/examples/tutorials/layers/cnn_mnist.py
+++ b/tensorflow/examples/tutorials/layers/cnn_mnist.py
@@ -100,10 +100,11 @@ def cnn_model_fn(features, labels, mode):
   onehot_labels = tf.one_hot(indices=tf.cast(labels, tf.int32), depth=10)
   loss = tf.losses.softmax_cross_entropy(
       onehot_labels=onehot_labels, logits=logits)
+  tf.summary.scalar('loss', loss)
 
   # Configure the Training Op (for TRAIN mode)
   if mode == tf.estimator.ModeKeys.TRAIN:
-    optimizer = tf.train.GradientDescentOptimizer(learning_rate=0.001)
+    optimizer = tf.train.AdamOptimizer(learning_rate=1e-4)
     train_op = optimizer.minimize(
         loss=loss,
         global_step=tf.train.get_global_step())


### PR DESCRIPTION
I remember that other (non-estimator) versions of this example used the Adam optimizer, which has nicer convergence -- could we use it in this example?
Also, I added a summary for `loss`, so that it would show up on TensorBoard.

(I'd also like to add support for passing in `num_steps`, `model_dir`, etc. as command-line args with defaults, but I'll make that a separate PR unless you'd like it bundled with this one).