### PR TITLE
Cover the numpy-ndarray bug on s390x

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -627,7 +627,7 @@ def _ConstantValue(tensor, partial):
   elif tensor.op.type == "Rank":
     input_shape = tensor.op.inputs[0].get_shape()
     if input_shape.ndims is not None:
-      return np.ndarray(shape=(), buffer=np.array([input_shape.ndims]),
+      return np.ndarray(shape=(), buffer=np.array([input_shape.ndims], dtype=np.int32),
                         dtype=np.int32)
     else:
       return None


### PR DESCRIPTION
NumPy's low-level method for instantiating an array (ndarray constructor) is behaving differently for s390x architecture. Providing the data type of the array's elements explicitly is solving the issue. Please refer to [issue#11431](https://github.com/tensorflow/tensorflow/issues/11431) for the detailed discussion. Though this a bug with NumPy implementation, adding data type for array elements should be safe.