### PR TITLE
Correct minor typo in substr docs example

### DIFF
--- a/tensorflow/core/ops/string_ops.cc
+++ b/tensorflow/core/ops/string_ops.cc
@@ -381,7 +381,7 @@ input = b'thirteen'
 position = [1, 5, 7]
 length =   [3, 2, 1]
 
-output = [b'hir', b'ee', b'n"]
+output = [b'hir', b'ee', b'n']
 ```
 
 input: Tensor of strings


### PR DESCRIPTION
This fixes a very minor typo.
Python strings should be started and ended with same character.

Shows up at: https://www.tensorflow.org/api_docs/python/tf/substr

![error in doc webpage](https://user-images.githubusercontent.com/5127634/30311220-d618d526-97c6-11e7-9817-6382edc14036.png)


This was raised at https://github.com/malmaud/TensorFlow.jl/issues/318
by @shencebebetterme 