### PR TITLE
Update mnist beginners softmax variables

### DIFF
--- a/tensorflow/docs_src/get_started/mnist/beginners.md
+++ b/tensorflow/docs_src/get_started/mnist/beginners.md
@@ -180,11 +180,11 @@ You can think of it as converting tallies
 of evidence into probabilities of our input being in each class.
 It's defined as:
 
-$$\text{softmax}(x) = \text{normalize}(\exp(x))$$
+$$\text{softmax}(evidence) = \text{normalize}(\exp(evidence))$$
 
 If you expand that equation out, you get:
 
-$$\text{softmax}(x)_i = \frac{\exp(x_i)}{\sum_j \exp(x_j)}$$
+$$\text{softmax}(evidence)_i = \frac{\exp(evidence_i)}{\sum_j \exp(evidence_j)}$$
 
 But it's often more helpful to think of softmax the first way: exponentiating
 its inputs and then normalizing them.  The exponentiation means that one more


### PR DESCRIPTION
The usage of variable 'x' when describing the softmax function can be confusing to newcomers since 'x' is used immediately prior to represent the unweighted input. Continuing the usage of 'evidence' helps with continuity.