### PR TITLE
[Docs] tf.constant docstring: Whitespace fix

### DIFF
--- a/tensorflow/python/framework/constant_op.py
+++ b/tensorflow/python/framework/constant_op.py
@@ -106,33 +106,33 @@ def convert_to_eager_tensor(t, dtype=None):
 def constant(value, dtype=None, shape=None, name="Const", verify_shape=False):
   """Creates a constant tensor.
 
-   The resulting tensor is populated with values of type `dtype`, as
-   specified by arguments `value` and (optionally) `shape` (see examples
-   below).
+  The resulting tensor is populated with values of type `dtype`, as
+  specified by arguments `value` and (optionally) `shape` (see examples
+  below).
 
-   The argument `value` can be a constant value, or a list of values of type
-   `dtype`. If `value` is a list, then the length of the list must be less
-   than or equal to the number of elements implied by the `shape` argument (if
-   specified). In the case where the list length is less than the number of
-   elements specified by `shape`, the last element in the list will be used
-   to fill the remaining entries.
+  The argument `value` can be a constant value, or a list of values of type
+  `dtype`. If `value` is a list, then the length of the list must be less
+  than or equal to the number of elements implied by the `shape` argument (if
+  specified). In the case where the list length is less than the number of
+  elements specified by `shape`, the last element in the list will be used
+  to fill the remaining entries.
 
-   The argument `shape` is optional. If present, it specifies the dimensions of
-   the resulting tensor. If not present, the shape of `value` is used.
+  The argument `shape` is optional. If present, it specifies the dimensions of
+  the resulting tensor. If not present, the shape of `value` is used.
 
-   If the argument `dtype` is not specified, then the type is inferred from
-   the type of `value`.
+  If the argument `dtype` is not specified, then the type is inferred from
+  the type of `value`.
 
-   For example:
+  For example:
 
-   ```python
-   # Constant 1-D Tensor populated with value list.
-   tensor = tf.constant([1, 2, 3, 4, 5, 6, 7]) => [1 2 3 4 5 6 7]
+  ```python
+  # Constant 1-D Tensor populated with value list.
+  tensor = tf.constant([1, 2, 3, 4, 5, 6, 7]) => [1 2 3 4 5 6 7]
 
-   # Constant 2-D tensor populated with scalar value -1.
-   tensor = tf.constant(-1.0, shape=[2, 3]) => [[-1. -1. -1.]
-                                                [-1. -1. -1.]]
-   ```
+  # Constant 2-D tensor populated with scalar value -1.
+  tensor = tf.constant(-1.0, shape=[2, 3]) => [[-1. -1. -1.]
+                                               [-1. -1. -1.]]
+  ```
 
   Args:
     value:          A constant value (or list) of output type `dtype`.


### PR DESCRIPTION
This should allow the ` ```python ` section to properly render on the API page
    https://www.tensorflow.org/api_docs/python/tf/constant
which (at the time of writing) displays the fences in plain-text.