### PR TITLE
Revert accidentally changed android_test_proto_lib dep to protos_cc

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1161,7 +1161,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":android_tensorflow_lib",
-        ":android_test_proto_lib",
+        ":protos_cc",
         "//tensorflow/core/platform/default/build_config:gtest",
         "//third_party/eigen3",
     ],


### PR DESCRIPTION
android_test_proto_lib is a Google-internal target