### PR TITLE
Update `tf.nn.in_top_k` to use v2 kernel.

### DIFF
--- a/tensorflow/python/kernel_tests/in_topk_op_test.py
+++ b/tensorflow/python/kernel_tests/in_topk_op_test.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import errors_impl
-from tensorflow.python.ops import gen_nn_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import test
 
@@ -77,9 +76,7 @@ class InTopKTest(test.TestCase):
     k = constant_op.constant(3)
     np_ans = np.array([False, True])
     with self.test_session():
-      # TODO (yongtang): The test will be switch to nn_ops.in_top
-      # once nn_ops.in_top points to _in_top_kv2 later
-      precision = gen_nn_ops._in_top_kv2(predictions, target, k)
+      precision = nn_ops.in_top_k(predictions, target, k)
       out = precision.eval()
       self.assertAllClose(np_ans, out)
       self.assertShapeEqual(np_ans, precision)

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2145,5 +2145,4 @@ def in_top_k(predictions, targets, k, name=None):
     A `Tensor` of type `bool`. Computed Precision at `k` as a `bool Tensor`.
   """
   with ops.name_scope(name, 'in_top_k'):
-    # TODO (yongtang): Need to switch to v2 after 3 weeks.
-    return gen_nn_ops._in_top_k(predictions, targets, k, name=name)
+    return gen_nn_ops._in_top_kv2(predictions, targets, k, name=name)


### PR DESCRIPTION
This fix is a follow up to PR #11197 so that `tf.nn.in_top_k` uses V2 kernel now.

This fix follows the API compatibility workflow (3 weeks).

This fix also updates related tests so that `gen_nn_ops` could be removed.

This fix fixes #9717.

NOTE: In the original PR #11197, the `_in_top_kv2` was incorrectly called even the comments specified to wait for 3 weeks. That was fixed by commit https://github.com/tensorflow/tensorflow/commit/3e3eebd6adb3512b69e28b6e7acce9a59527f699
(Thanks @vrv for the fix).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>