### PR TITLE
Add new op BytesInUse, similar to MaxBytesInUse

### DIFF
--- a/tensorflow/contrib/memory_stats/__init__.py
+++ b/tensorflow/contrib/memory_stats/__init__.py
@@ -14,10 +14,12 @@
 # ==============================================================================
 """Ops for memory statistics.
 
+@@BytesInUse
 @@BytesLimit
 @@MaxBytesInUse
 """
 
+from tensorflow.contrib.memory_stats.python.ops.memory_stats_ops import BytesInUse
 from tensorflow.contrib.memory_stats.python.ops.memory_stats_ops import BytesLimit
 from tensorflow.contrib.memory_stats.python.ops.memory_stats_ops import MaxBytesInUse
 

--- a/tensorflow/contrib/memory_stats/kernels/memory_stats_ops.cc
+++ b/tensorflow/contrib/memory_stats/kernels/memory_stats_ops.cc
@@ -16,6 +16,31 @@ limitations under the License.
 
 namespace tensorflow {
 
+// Op that measures current memory in bytes.
+class BytesInUseOp : public MemoryStatsOp {
+ public:
+  explicit BytesInUseOp(OpKernelConstruction* context)
+      : MemoryStatsOp(context) {}
+
+ private:
+  int64 ExtractAllocatorStats(
+      const AllocatorStats& allocator_stats) const override {
+    return allocator_stats.bytes_in_use;
+  }
+};
+
+// register this op on GPU only, see comment for MaxBytesInUse for reason
+REGISTER_KERNEL_BUILDER(
+    Name("BytesInUse").Device(DEVICE_GPU).HostMemory("out"),
+    BytesInUseOp);
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("MaxBytesInUse").Device(DEVICE_SYCL).HostMemory("out"),
+    MaxBytesInUseOp);
+#endif // TENSORFLOW_USE_SYCL
+
+
 // Base class of ops that collects statistics of the allocator of a device.
 class MemoryStatsOp : public OpKernel {
  public:

--- a/tensorflow/contrib/memory_stats/kernels/memory_stats_ops.cc
+++ b/tensorflow/contrib/memory_stats/kernels/memory_stats_ops.cc
@@ -16,31 +16,6 @@ limitations under the License.
 
 namespace tensorflow {
 
-// Op that measures current memory in bytes.
-class BytesInUseOp : public MemoryStatsOp {
- public:
-  explicit BytesInUseOp(OpKernelConstruction* context)
-      : MemoryStatsOp(context) {}
-
- private:
-  int64 ExtractAllocatorStats(
-      const AllocatorStats& allocator_stats) const override {
-    return allocator_stats.bytes_in_use;
-  }
-};
-
-// register this op on GPU only, see comment for MaxBytesInUse for reason
-REGISTER_KERNEL_BUILDER(
-    Name("BytesInUse").Device(DEVICE_GPU).HostMemory("out"),
-    BytesInUseOp);
-
-#ifdef TENSORFLOW_USE_SYCL
-REGISTER_KERNEL_BUILDER(
-    Name("MaxBytesInUse").Device(DEVICE_SYCL).HostMemory("out"),
-    MaxBytesInUseOp);
-#endif // TENSORFLOW_USE_SYCL
-
-
 // Base class of ops that collects statistics of the allocator of a device.
 class MemoryStatsOp : public OpKernel {
  public:
@@ -64,6 +39,30 @@ class MemoryStatsOp : public OpKernel {
   virtual int64 ExtractAllocatorStats(
       const AllocatorStats& allocator_stats) const = 0;
 };
+
+// Op that measures current memory in bytes.
+class BytesInUseOp : public MemoryStatsOp {
+ public:
+  explicit BytesInUseOp(OpKernelConstruction* context)
+      : MemoryStatsOp(context) {}
+
+ private:
+  int64 ExtractAllocatorStats(
+      const AllocatorStats& allocator_stats) const override {
+    return allocator_stats.bytes_in_use;
+  }
+};
+
+// Register this op on GPU only, see comment for MaxBytesInUse for reason
+REGISTER_KERNEL_BUILDER(
+    Name("BytesInUse").Device(DEVICE_GPU).HostMemory("out"),
+    BytesInUseOp);
+
+#ifdef TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("BytesInUse").Device(DEVICE_SYCL).HostMemory("out"),
+    MaxBytesInUseOp);
+#endif // TENSORFLOW_USE_SYCL
 
 // Op that measures the total memory (in bytes) of a device.
 class BytesLimitOp : public MemoryStatsOp {

--- a/tensorflow/contrib/memory_stats/ops/memory_stats_ops.cc
+++ b/tensorflow/contrib/memory_stats/ops/memory_stats_ops.cc
@@ -17,6 +17,10 @@ limitations under the License.
 
 namespace tensorflow {
 
+REGISTER_OP("BytesInUse")
+    .Output("out: int64")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::ScalarShape);
 REGISTER_OP("BytesLimit")
     .Output("out: int64")
     .SetIsStateful()

--- a/tensorflow/contrib/memory_stats/python/kernel_tests/memory_stats_ops_test.py
+++ b/tensorflow/contrib/memory_stats/python/kernel_tests/memory_stats_ops_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 from tensorflow.contrib.memory_stats.python.ops import memory_stats_ops
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import math_ops
@@ -64,12 +65,26 @@ class MemoryStatsOpsTest(test_util.TensorFlowTestCase):
       d = math_ops.matmul(c, b)
       sess.run(d)
 
-      max_bytes_in_use = sess.run(memory_stats_ops.MaxBytesInUse())
-      bytes_in_use = sess.run(memory_stats_ops.BytesInUse())
+      max_bytes_in_use_op = memory_stats_ops.MaxBytesInUse()
+      max_bytes_in_use = sess.run(max_bytes_in_use_op)
       self.assertGreaterEqual(max_bytes_in_use, matrix_size_in_bytes * 3)
       self.assertLess(max_bytes_in_use, matrix_size_in_bytes * 4)
-      self.assertGreaterEqual(bytes_in_use, matrix_size_in_bytes * 3)
-      self.assertLess(bytes_in_use, matrix_size_in_bytes * 4)
+
+      # run chain with 2 ops, make sure BytesInUse captures intermediate
+      # memory usage
+      a = random_ops.random_uniform(matrix_shape, dtype=dtype)
+      with ops.control_dependencies([a]):
+        bytes_in_use_op = memory_stats_ops.BytesInUse()
+      with ops.control_dependencies([bytes_in_use_op]):
+        b = random_ops.random_uniform(matrix_shape, dtype=dtype)
+
+      _, bytes_in_use, max_bytes_in_use = sess.run([a, bytes_in_use_op,
+                                                    max_bytes_in_use_op])
+
+      # intermediate result allocates 1 matrix, max usage is at least 2
+      self.assertGreaterEqual(bytes_in_use, matrix_size_in_bytes * 1)
+      self.assertLess(bytes_in_use, matrix_size_in_bytes * 2)
+      self.assertGreaterEqual(max_bytes_in_use, matrix_size_in_bytes * 2)
 
 
 if __name__ == '__main__':

--- a/tensorflow/contrib/memory_stats/python/kernel_tests/memory_stats_ops_test.py
+++ b/tensorflow/contrib/memory_stats/python/kernel_tests/memory_stats_ops_test.py
@@ -65,8 +65,11 @@ class MemoryStatsOpsTest(test_util.TensorFlowTestCase):
       sess.run(d)
 
       max_bytes_in_use = sess.run(memory_stats_ops.MaxBytesInUse())
+      bytes_in_use = sess.run(memory_stats_ops.BytesInUse())
       self.assertGreaterEqual(max_bytes_in_use, matrix_size_in_bytes * 3)
       self.assertLess(max_bytes_in_use, matrix_size_in_bytes * 4)
+      self.assertGreaterEqual(bytes_in_use, matrix_size_in_bytes * 3)
+      self.assertLess(bytes_in_use, matrix_size_in_bytes * 4)
 
 
 if __name__ == '__main__':

--- a/tensorflow/contrib/memory_stats/python/kernel_tests/memory_stats_ops_test.py
+++ b/tensorflow/contrib/memory_stats/python/kernel_tests/memory_stats_ops_test.py
@@ -84,7 +84,9 @@ class MemoryStatsOpsTest(test_util.TensorFlowTestCase):
       # intermediate result allocates 1 matrix, max usage is at least 2
       self.assertGreaterEqual(bytes_in_use, matrix_size_in_bytes * 1)
       self.assertLess(bytes_in_use, matrix_size_in_bytes * 2)
-      self.assertGreaterEqual(max_bytes_in_use, matrix_size_in_bytes * 2)
+
+      # max usage is still 3 because it reflects maxium from previous .run call
+      self.assertGreaterEqual(max_bytes_in_use, matrix_size_in_bytes * 3)
 
 
 if __name__ == '__main__':

--- a/tensorflow/contrib/memory_stats/python/ops/memory_stats_ops.py
+++ b/tensorflow/contrib/memory_stats/python/ops/memory_stats_ops.py
@@ -26,6 +26,11 @@ _memory_stats_ops_so = loader.load_op_library(
     resource_loader.get_path_to_datafile("_memory_stats_ops.so"))
 
 
+def BytesInUse():
+  """Generates an op that computes the current memory of a device."""
+  return gen_memory_stats_ops.bytes_in_use()
+
+
 def BytesLimit():
   """Generates an op that measures the total memory (in bytes) of a device."""
   return gen_memory_stats_ops.bytes_limit()


### PR DESCRIPTION
Adding BytesInUse
This is more useful than MaxBytesInUse for getting peak memory for a given session.run call because the latter gives maximum memory usage over lifetime of allocator, which can span multiple session.run calls/multiple session objects