### PR TITLE
Remove multiple includes of gpu_tracer.cc in Makefile build

### DIFF
--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -512,7 +512,6 @@ $(wildcard tensorflow/core/grappler/clusters/single_machine.*)
 # Filter out all the excluded files.
 TF_CC_SRCS := $(filter-out $(CORE_CC_EXCLUDE_SRCS), $(CORE_CC_ALL_SRCS))
 # Add in any extra files that don't fit the patterns easily
-TF_CC_SRCS += tensorflow/core/platform/default/gpu_tracer.cc
 TF_CC_SRCS += tensorflow/contrib/makefile/downloads/fft2d/fftsg.c
 # Also include the op and kernel definitions.
 TF_CC_SRCS += $(shell cat $(MAKEFILE_DIR)/tf_op_files.txt)


### PR DESCRIPTION
Currently the `tensorflow/core/platform/default/gpu_tracer.cc` is included by both https://github.com/tensorflow/tensorflow/blob/702d595822e9e5f5232b8140c6296683612c33a9/tensorflow/contrib/makefile/Makefile#L468 and https://github.com/tensorflow/tensorflow/blob/702d595822e9e5f5232b8140c6296683612c33a9/tensorflow/contrib/makefile/Makefile#L515 in the Makefile. 

Leading to multiple definition build failure when the built tensorflow static lib is linked by other project.

> <ndk_root>/toolchains/x86_64-4.9/prebuilt/darwin-x86_64/lib/gcc/x86_64-linux-android/4.9.x/../../../../x86_64-linux-android/bin/ld: error: <tensorflow_root>/lib/x86_64/libtensorflow-core.a(gpu_tracer.o): multiple definition of 'tensorflow::CreateGPUTracer()'
<ndk_root>/toolchains/x86_64-4.9/prebuilt/darwin-x86_64/lib/gcc/x86_64-linux-android/4.9.x/../../../../x86_64-linux-android/bin/ld: <tensorflow_root>/lib/x86_64/libtensorflow-core.a(gpu_tracer.o): previous definition here
clang++: error: linker command failed with exit code 1 (use -v to see invocation)

Problem should be introduced from 083f5433f65b92a406f41806e7bc8c5d0ae679ac

So removed the later include to resolve the problem.