### PR TITLE
More robust sed regex syntax in compile_nsync.sh

### DIFF
--- a/tensorflow/contrib/makefile/compile_nsync.sh
+++ b/tensorflow/contrib/makefile/compile_nsync.sh
@@ -286,7 +286,7 @@ for arch in $archs; do
 
         if [ ! -d "$nsync_platform_dir" ]; then
                 mkdir "$nsync_platform_dir"
-                echo "$makefile" | sed 's,^[ \t]*,,' > "$nsync_platform_dir/Makefile"
+                echo "$makefile" | sed $'s,^[ \t]*,,' > "$nsync_platform_dir/Makefile"
                 touch "$nsync_platform_dir/dependfile"
         fi
         if (cd "$nsync_platform_dir" && make depend nsync.a >&2); then


### PR DESCRIPTION
> The syntax \t for a tab character in sed is not standard. That escape is a [GNU sed extension](http://www.gnu.org/software/sed//manual/html_node/Escapes.html). 

> But [OS X sed](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/sed.1.html), like other *BSD sed, doesn't support `\t` for tab and instead treats `\t` as meaning `backslash` followed by `t`.

So currently, nsync Android build in MacOS fails with 

> ar cr nsync.a common.o counter.o cv.o debug.o dll.o mu.o mu_wait.o note.o once.o sem_wait.o time_internal.o wait.o "nsync_semaphore_mutex.o per_thread_waiter.o yield.o **ime_rep_timespec.o** nsync_panic.o"
ar: nsync_semaphore_mutex.o per_thread_waiter.o yield.o **ime_rep_timespec.o** nsync_panic.o: No such file or directory
make: *** [nsync.a] Error 1

So added a `$` to the seq syntax to enable [ANSI-C Quoting](http://www.gnu.org/software/bash/manual/bash.html#ANSI_002dC-Quoting), and problem resolved.

Reference: [Simple sed replacement of tabs mysteriously failing](https://unix.stackexchange.com/a/145385)