### PR TITLE
[GDR] Eliminate several unnecessary sync barriers

### DIFF
--- a/tensorflow/contrib/gdr/gdr_memory_manager.h
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.h
@@ -39,15 +39,17 @@ class RemoteMemoryManager {
 
   // Encodes the tensor information to an arbitrary protocol buffer
   // The protocol buffer needs to be transmitted via some other channel
-  virtual Status TransportOptionsFromTensor(
+  virtual void TransportOptionsFromTensor(
       ::google::protobuf::Any* mutable_transport_options, const Tensor& tensor,
-      Device* device, DeviceContext* device_context, bool on_host) = 0;
+      Device* device, DeviceContext* device_context, bool on_host,
+      StatusCallback done) = 0;
 
   // Retrieve the tensor from the encoded protocol buffer
   // Note that the tensor has to be allocated, but not initialized
-  virtual Status TensorFromTransportOptions(
+  virtual void TensorFromTransportOptions(
       Tensor* tensor, const ::google::protobuf::Any& transport_options,
-      Device* device, DeviceContext* device_context, bool on_host) = 0;
+      Device* device, DeviceContext* device_context, bool on_host,
+      StatusCallback done) = 0;
 };
 
 RemoteMemoryManager* CreateRemoteMemoryManager(const string& host,

--- a/tensorflow/contrib/gdr/gdr_worker.cc
+++ b/tensorflow/contrib/gdr/gdr_worker.cc
@@ -86,24 +86,25 @@ void GdrWorker::GrpcRecvTensorAsync(CallOptions* opts,
           if (val.TotalBytes() > 0 && (!is_dead) &&
               DMAHelper::CanUseDMA(&val) && dma_ok) {
             // DMA cases.
-            RecvTensorResponse proto;
-            auto transport_options = proto.mutable_transport_options();
-            Status s = remote_memory_manager_->TransportOptionsFromTensor(
+            RecvTensorResponse* proto = new RecvTensorResponse;
+            proto->set_is_dead(is_dead);
+            proto->set_send_start_micros(Env::Default()->NowMicros());
+            TensorProto* tensor_proto = proto->mutable_tensor();
+            tensor_proto->set_dtype(val.dtype());
+            val.shape().AsProto(tensor_proto->mutable_tensor_shape());
+            auto transport_options = proto->mutable_transport_options();
+            remote_memory_manager_->TransportOptionsFromTensor(
                 transport_options, val, src_dev, send_args.device_context,
-                on_host);
-            if (s.ok()) {
-              proto.set_is_dead(is_dead);
-              proto.set_send_start_micros(Env::Default()->NowMicros());
-              TensorProto* tensor_proto = proto.mutable_tensor();
-              tensor_proto->set_dtype(val.dtype());
-              val.shape().AsProto(tensor_proto->mutable_tensor_shape());
-              grpc::EncodeRecvTensorResponseToByteBuffer(proto, response);
-              done(Status::OK());
-              return;
-            } else {
-              done(s);
-              return;
-            }
+                on_host, [proto, done, response](const Status& s) {
+                  if (s.ok()) {
+                    grpc::EncodeRecvTensorResponseToByteBuffer(*proto,
+                                                               response);
+                    done(Status::OK());
+                  } else {
+                    done(s);
+                  }
+                  delete proto;
+                });
           } else {
             // Non-DMA cases.
             if (src_dev->tensorflow_gpu_device_info() && (!on_host)) {


### PR DESCRIPTION
Following the plan I mentioned in https://github.com/tensorflow/tensorflow/pull/12361#issuecomment-323101744, I have refactored out the sync wrapper around copy between CPU and GPU.

Now the user need to supply a `StatusCallback` when calling `RemoteMemoryManager:: TransportOptionsFromTensor ` and `RemoteMemoryManager::TensorFromTransportOptions`, in order to prepare for the potential CPU-GPU tensor transfer.