### PR TITLE
Fix GRUBlockCell parameter naming inconsistency

### DIFF
--- a/tensorflow/contrib/rnn/python/ops/gru_ops.py
+++ b/tensorflow/contrib/rnn/python/ops/gru_ops.py
@@ -136,14 +136,17 @@ class GRUBlockCell(rnn_cell_impl.RNNCell):
     """Initialize the Block GRU cell.
 
     Args:
-      num_units: int, The number of units in the GRU cell
+      num_units: int, The number of units in the GRU cell.
+      cell_size: int, The old (deprecated) name for `num_units`.
+
+    Raises:
+      ValueError: if both cell_size and num_units are not None;
+        or both are None.
     """
-    if cell_size is not None:
-      if num_units is not None:
-        raise ValueError("Cannot specify both 'num_units' and 'cell_size'")
+    if (cell_size is None) == (num_units is None):
+      raise ValueError("Exactly one of num_units or cell_size must be provided.")
+    if num_units is None:
       num_units = cell_size
-    if num_units is None and cell_size is None:
-      raise ValueError("`num_units` and `cell_size` cannot both be None.")
     self._cell_size = num_units
 
   @property

--- a/tensorflow/contrib/rnn/python/ops/gru_ops.py
+++ b/tensorflow/contrib/rnn/python/ops/gru_ops.py
@@ -27,6 +27,7 @@ from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import rnn_cell_impl
 from tensorflow.python.ops import variable_scope as vs
 from tensorflow.python.platform import resource_loader
+from tensorflow.python.util.deprecation import deprecated_args
 
 _gru_ops_so = loader.load_op_library(
     resource_loader.get_path_to_datafile("_gru_ops.so"))
@@ -129,6 +130,8 @@ class GRUBlockCell(rnn_cell_impl.RNNCell):
 
   """
 
+  @deprecated_args(None, "cell_size is deprecated, use num_units instead",
+                   "cell_size")
   def __init__(self, num_units=None, cell_size=None):
     """Initialize the Block GRU cell.
 

--- a/tensorflow/contrib/rnn/python/ops/gru_ops.py
+++ b/tensorflow/contrib/rnn/python/ops/gru_ops.py
@@ -129,13 +129,19 @@ class GRUBlockCell(rnn_cell_impl.RNNCell):
 
   """
 
-  def __init__(self, cell_size):
+  def __init__(self, num_units=None, cell_size=None):
     """Initialize the Block GRU cell.
 
     Args:
-      cell_size: int, GRU cell size.
+      num_units: int, The number of units in the GRU cell
     """
-    self._cell_size = cell_size
+    if cell_size is not None:
+      if num_units is not None:
+        raise ValueError("Cannot specify both 'num_units' and 'cell_size'")
+      num_units = cell_size
+    if num_units is None and cell_size is None:
+      raise ValueError("`num_units` and `cell_size` cannot both be None.")
+    self._cell_size = num_units
 
   @property
   def state_size(self):


### PR DESCRIPTION
This fix tries to fix the issue in #13137 where parameter `cell_size` is used instead of `num_units`. This is inconsistent with other RNN cells.

This fix adds support of `num_units` while at the same time maintains backward compatiblility for `cell_size`.

This fix fixes #13137.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>