### PR TITLE
Fix random crashes in SessionRun()

### DIFF
--- a/tensorflow/go/session.go
+++ b/tensorflow/go/session.go
@@ -89,6 +89,10 @@ func (s *Session) Run(feeds map[Output]*Tensor, fetches []Output, targets []*Ope
 		ptrOutput(c.fetches), ptrTensor(c.fetchTensors), C.int(len(fetches)),
 		ptrOperation(c.targets), C.int(len(targets)),
 		nil, status.c)
+
+	// Make sure GC won't harvest input tensors until SessionRun() is finished
+	runtime.KeepAlive(feeds)
+
 	if err := status.Err(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch fixes https://github.com/tensorflow/tensorflow/issues/13129

The problem was with usage of runtime.SetFinalizer() in golang bindings. When a variable become unreferenced GC can harvest it any moment after. According to this https://tip.golang.org/pkg/runtime/#SetFinalizer:

> For example, if p points to a struct that contains a file descriptor d, and p has a finalizer that closes that file descriptor, and if the last use of p in a function is a call to syscall.Write(p.d, buf, size), then p may be unreachable as soon as the program enters syscall.Write. The finalizer may run at that moment, closing p.d, causing syscall.Write to fail because it is writing to a closed file descriptor (or, worse, to an entirely different file descriptor opened by a different goroutine). To avoid this problem, call runtime.KeepAlive(p) after the call to syscall.Write.

In our case unreferenced variable was "feeds", i.e. input tensors. After investigations I have found out that func (t *Tensor) finalize() { C.TF_DeleteTensor(t.c) } was called a way before SessionRun() was finished and that was the cause of crash in my case.

