### PR TITLE
Non-scalar Multinomial draws

### DIFF
--- a/tensorflow/python/kernel_tests/distributions/multinomial_test.py
+++ b/tensorflow/python/kernel_tests/distributions/multinomial_test.py
@@ -291,7 +291,7 @@ class MultinomialTest(test.TestCase):
       dist = multinomial.Multinomial(
           total_count=[7., 6., 5.],
           logits=math_ops.log(2. * self._rng.rand(4, 3, 2).astype(np.float32)))
-      n = int(3e3)
+      n = int(3e4)
       x = dist.sample(n, seed=0)
       sample_mean = math_ops.reduce_mean(x, 0)
       # Cyclically rotate event dims left.

--- a/tensorflow/python/kernel_tests/distributions/multinomial_test.py
+++ b/tensorflow/python/kernel_tests/distributions/multinomial_test.py
@@ -254,7 +254,7 @@ class MultinomialTest(test.TestCase):
     with self.test_session() as sess:
       # batch_shape=[3, 2], event_shape=[3]
       dist = multinomial.Multinomial(n, theta)
-      x = dist.sample(int(250e3), seed=1)
+      x = dist.sample(int(1000e3), seed=1)
       sample_mean = math_ops.reduce_mean(x, 0)
       x_centered = x - sample_mean[array_ops.newaxis, ...]
       sample_cov = math_ops.reduce_mean(math_ops.matmul(

--- a/tensorflow/python/kernel_tests/distributions/multinomial_test.py
+++ b/tensorflow/python/kernel_tests/distributions/multinomial_test.py
@@ -250,11 +250,9 @@ class MultinomialTest(test.TestCase):
     theta = np.array([[1., 2, 3],
                       [2.5, 4, 0.01]], dtype=np.float32)
     theta /= np.sum(theta, 1)[..., array_ops.newaxis]
-    # Ideally we'd be able to test broadcasting but, the multinomial sampler
-    # doesn't support different total counts.
-    n = np.float32(5)
+    n = np.array([[10., 9.], [8., 7.], [6., 5.]], dtype=np.float32)
     with self.test_session() as sess:
-      # batch_shape=[2], event_shape=[3]
+      # batch_shape=[3, 2], event_shape=[3]
       dist = multinomial.Multinomial(n, theta)
       x = dist.sample(int(250e3), seed=1)
       sample_mean = math_ops.reduce_mean(x, 0)
@@ -291,7 +289,7 @@ class MultinomialTest(test.TestCase):
   def testSampleUnbiasedNonScalarBatch(self):
     with self.test_session() as sess:
       dist = multinomial.Multinomial(
-          total_count=5.,
+          total_count=[7., 6., 5.],
           logits=math_ops.log(2. * self._rng.rand(4, 3, 2).astype(np.float32)))
       n = int(3e3)
       x = dist.sample(n, seed=0)

--- a/tensorflow/python/ops/distributions/multinomial.py
+++ b/tensorflow/python/ops/distributions/multinomial.py
@@ -240,11 +240,11 @@ class Multinomial(distribution.Distribution):
     n_draws = array_ops.ones_like(
         self.logits[..., 0], dtype=n_draws.dtype) * n_draws
     logits = array_ops.ones_like(
-        n_draws[..., None], dtype=self.logits.dtype) * self.logits
+        n_draws[..., array_ops.newaxis], dtype=self.logits.dtype) * self.logits
 
     # flatten the total_count and logits
-    flat_logits = array_ops.reshape(logits, [-1, k]) # [B1*B2*...*Bm, k]
-    flat_ndraws = n * array_ops.reshape(n_draws, [-1]) # [B1*B2*...*Bm]
+    flat_logits = array_ops.reshape(logits, [-1, k]) # [B1B2...Bm, k]
+    flat_ndraws = n * array_ops.reshape(n_draws, [-1]) # [B1B2...Bm]
 
     # computes each total_count and logits situation by map_fn
     def _sample_single(args):
@@ -256,7 +256,7 @@ class Multinomial(distribution.Distribution):
       return x
     x = functional_ops.map_fn(_sample_single,
                               [flat_logits, flat_ndraws],
-                              dtype=self.dtype) # [B1*B2*...Bm, n, k]
+                              dtype=self.dtype) # [B1B2...Bm, n, k]
 
     # reshape the results to proper shape
     x = array_ops.transpose(x, perm=[1, 0, 2])

--- a/tensorflow/python/ops/distributions/multinomial.py
+++ b/tensorflow/python/ops/distributions/multinomial.py
@@ -26,6 +26,7 @@ from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import random_ops
+from tensorflow.python.ops import functional_ops
 from tensorflow.python.ops.distributions import distribution
 from tensorflow.python.ops.distributions import util as distribution_util
 
@@ -231,16 +232,36 @@ class Multinomial(distribution.Distribution):
 
   def _sample_n(self, n, seed=None):
     n_draws = math_ops.cast(self.total_count, dtype=dtypes.int32)
-    if self.total_count.get_shape().ndims is not None:
-      if self.total_count.get_shape().ndims != 0:
-        raise NotImplementedError(
-            "Sample only supported for scalar number of draws.")
-    elif self.validate_args:
-      is_scalar = check_ops.assert_rank(
-          n_draws, 0,
-          message="Sample only supported for scalar number of draws.")
-      n_draws = control_flow_ops.with_dependencies([is_scalar], n_draws)
     k = self.event_shape_tensor()[0]
+
+    if self.total_count.get_shape().ndims > 0:
+
+      # n_draws should has shape [B1, B2, ... Bm], same as batch_shape
+      if self.validate_args:
+        n_draws = control_flow_ops.with_dependencies(
+            check_ops.assert_equal(
+                self.batch_shape, self.total_count.get_shape(),
+                message='The shape refered from logits should have the same shape with total_count')
+            , n_draws)
+
+      flat_logits = array_ops.reshape(self.logits, [-1, k])   # [B1*B2*...*Bm, k]
+      flat_total_count = n * array_ops.reshape(n_draws, [-1]) # [B1*B2*...*Bm]
+      
+      def _sample_single(args):
+        logits, n_draw = args[0], args[1] # [K], []
+        x = random_ops.multinomial(logits[array_ops.newaxis, ...], n_draw, seed) # [1, n*n_draw]
+        x = array_ops.reshape(x, shape=[n, -1]) # [n, n_draw]
+        x = math_ops.reduce_sum(array_ops.one_hot(x, depth=k), axis=-2) # [n, k]
+        return x
+
+      x = functional_ops.map_fn(_sample_single,
+              [flat_logits, flat_total_count],
+              dtype=self.dtype) # [B1*B2*...Bm, n, k]
+      x = array_ops.transpose(x, perm=[1, 0, 2])
+      final_shape = array_ops.concat([[n], self.batch_shape_tensor(), [k]], 0)
+      x = array_ops.reshape(x, final_shape) # [n, B1, B2,..., Bm, k]
+      return x
+
     # Flatten batch dims so logits has shape [B, k],
     # where B = reduce_prod(self.batch_shape_tensor()).
     x = random_ops.multinomial(

--- a/tensorflow/python/ops/distributions/multinomial.py
+++ b/tensorflow/python/ops/distributions/multinomial.py
@@ -141,6 +141,8 @@ class Multinomial(distribution.Distribution):
 
   counts = [[2., 1, 1], [3, 1, 1]]
   dist.prob(counts)  # Shape [2]
+
+  dist.sample(5) # Shape [5, 2, 3]
   ```
   """
 

--- a/tensorflow/python/ops/distributions/multinomial.py
+++ b/tensorflow/python/ops/distributions/multinomial.py
@@ -234,49 +234,33 @@ class Multinomial(distribution.Distribution):
     n_draws = math_ops.cast(self.total_count, dtype=dtypes.int32)
     k = self.event_shape_tensor()[0]
 
-    if self.total_count.get_shape().ndims > 0:
+    # boardcast the total_count and logits to same shape
+    n_draws = array_ops.ones_like(
+        self.logits[..., 0], dtype=n_draws.dtype) * n_draws
+    logits = array_ops.ones_like(
+        n_draws[..., None], dtype=self.logits.dtype) * self.logits
 
-      # n_draws should has shape [B1, B2, ... Bm], same as batch_shape
-      if self.validate_args:
-        n_draws = control_flow_ops.with_dependencies(
-            check_ops.assert_equal(
-                self.batch_shape, self.total_count.get_shape(),
-                message='The shape refered from logits should have '\
-                        'the same shape with total_count')
-            , n_draws)
+    # flatten the total_count and logits
+    flat_logits = array_ops.reshape(logits, [-1, k]) # [B1*B2*...*Bm, k]
+    flat_ndraws = n * array_ops.reshape(n_draws, [-1]) # [B1*B2*...*Bm]
 
-      flat_logits = array_ops.reshape(self.logits, [-1, k]) # [B1*B2*...*Bm, k]
-      flat_total_count = n * array_ops.reshape(n_draws, [-1]) # [B1*B2*...*Bm]
-
-      def _sample_single(args):
-        logits, n_draw = args[0], args[1] # [K], []
-        x = random_ops.multinomial(logits[array_ops.newaxis, ...],
-                                   n_draw, seed) # [1, n*n_draw]
-        x = array_ops.reshape(x, shape=[n, -1]) # [n, n_draw]
-        x = math_ops.reduce_sum(array_ops.one_hot(x, depth=k), axis=-2) # [n, k]
-        return x
-
-      x = functional_ops.map_fn(_sample_single,
-                                [flat_logits, flat_total_count],
-                                dtype=self.dtype) # [B1*B2*...Bm, n, k]
-      x = array_ops.transpose(x, perm=[1, 0, 2])
-      final_shape = array_ops.concat([[n], self.batch_shape_tensor(), [k]], 0)
-      x = array_ops.reshape(x, final_shape) # [n, B1, B2,..., Bm, k]
+    # computes each total_count and logits situation by map_fn
+    def _sample_single(args):
+      logits, n_draw = args[0], args[1] # [K], []
+      x = random_ops.multinomial(logits[array_ops.newaxis, ...],
+                                 n_draw, seed) # [1, n*n_draw]
+      x = array_ops.reshape(x, shape=[n, -1]) # [n, n_draw]
+      x = math_ops.reduce_sum(array_ops.one_hot(x, depth=k), axis=-2) # [n, k]
       return x
+    x = functional_ops.map_fn(_sample_single,
+                              [flat_logits, flat_ndraws],
+                              dtype=self.dtype) # [B1*B2*...Bm, n, k]
 
-    # Flatten batch dims so logits has shape [B, k],
-    # where B = reduce_prod(self.batch_shape_tensor()).
-    x = random_ops.multinomial(
-        logits=array_ops.reshape(self.logits, [-1, k]),
-        num_samples=n * n_draws,
-        seed=seed)
-    x = array_ops.reshape(x, shape=[-1, n, n_draws])
-    x = math_ops.reduce_sum(array_ops.one_hot(x, depth=k),
-                            axis=-2)  # shape: [B, n, k]
+    # reshape the results to proper shape
     x = array_ops.transpose(x, perm=[1, 0, 2])
     final_shape = array_ops.concat([[n], self.batch_shape_tensor(), [k]], 0)
-    x = array_ops.reshape(x, final_shape)
-    return math_ops.cast(x, self.dtype)
+    x = array_ops.reshape(x, final_shape) # [n, B1, B2,..., Bm, k]
+    return x
 
   @distribution_util.AppendDocstring(_multinomial_sample_note)
   def _log_prob(self, counts):


### PR DESCRIPTION
This PR tries to fix the issue in [#12804](https://github.com/tensorflow/tensorflow/issues/12804) where supports total_count to be a non-scalar tensor and broadcasts by `map_fn`.

The reason why I use `map_fn` to broadcast manually is that current `tf.multinomial` sampler op don't support to produce different total_count within a batch, and `map_fn` can enhance this underlying op effectively without modifying it.

It's a little dilemma if we modify the underlying op to support different total_count within a batch, because that will produce variable-length draws within a batch, unless we add a new function with different interface for multinomial sampler.