### PR TITLE
Use Tensors instead of TensorArrays for storing AttentionWrapper's alignment_history

### DIFF
--- a/tensorflow/contrib/seq2seq/python/kernel_tests/attention_wrapper_test.py
+++ b/tensorflow/contrib/seq2seq/python/kernel_tests/attention_wrapper_test.py
@@ -187,18 +187,20 @@ class AttentionWrapperTest(test.TestCase):
       if alignment_history:
         if is_multi:
           state_alignment_history = []
-          for history_array in final_state.alignment_history:
-            history = history_array.stack()
+          for history in final_state.alignment_history:
             self.assertEqual(
-                (None, batch_size, None),
+                (batch_size, None, None),
                 tuple(history.get_shape().as_list()))
             state_alignment_history.append(history)
           state_alignment_history = tuple(state_alignment_history)
         else:
-          state_alignment_history = final_state.alignment_history.stack()
+          state_alignment_history = final_state.alignment_history
           self.assertEqual(
-              (None, batch_size, None),
+              (batch_size, None, None),
               tuple(state_alignment_history.get_shape().as_list()))
+        nest.assert_same_structure(
+            cell.state_size,
+            cell.zero_state(batch_size, dtype('float32')))
         # Remove the history from final_state for purposes of the
         # remainder of the tests.
         final_state = final_state._replace(alignment_history=())  # pylint: disable=protected-access
@@ -255,7 +257,7 @@ class AttentionWrapperTest(test.TestCase):
             shape=(5, 8), dtype=dtype('float32'), mean=0.125),
         alignment_history=())
     expected_final_alignment_history = ResultSummary(
-        shape=(3, 5, 8), dtype=dtype('float32'), mean=0.12500001)
+        shape=(5, 3, 8), dtype=dtype('float32'), mean=0.12500001)
 
     self._testWithAttention(
         create_attention_mechanism,
@@ -546,7 +548,7 @@ class AttentionWrapperTest(test.TestCase):
             shape=(5, 8), dtype=dtype('float32'), mean=0.032228071),
         alignment_history=())
     expected_final_alignment_history = ResultSummary(
-        shape=(3, 5, 8), dtype=dtype('float32'), mean=0.050430927)
+        shape=(5, 3, 8), dtype=dtype('float32'), mean=0.050430927)
 
     self._testWithAttention(
         create_attention_mechanism,
@@ -579,7 +581,7 @@ class AttentionWrapperTest(test.TestCase):
             shape=(5, 8), dtype=dtype('float32'), mean=0.028698336),
         alignment_history=())
     expected_final_alignment_history = ResultSummary(
-        shape=(3, 5, 8), dtype=dtype('float32'), mean=0.046009291)
+        shape=(5, 3, 8), dtype=dtype('float32'), mean=0.046009291)
 
     self._testWithAttention(
         create_attention_mechanism,
@@ -612,7 +614,7 @@ class AttentionWrapperTest(test.TestCase):
             shape=(5, 8), dtype=dtype('float32'), mean=0.032198936),
         alignment_history=())
     expected_final_alignment_history = ResultSummary(
-        shape=(3, 5, 8), dtype=dtype('float32'), mean=0.050387777)
+        shape=(5, 3, 8), dtype=dtype('float32'), mean=0.050387777)
 
     self._testWithAttention(
         create_attention_mechanism,
@@ -646,7 +648,7 @@ class AttentionWrapperTest(test.TestCase):
             shape=(5, 8), dtype=dtype('float32'), mean=0.032198936),
         alignment_history=())
     expected_final_alignment_history = ResultSummary(
-        shape=(3, 5, 8), dtype=dtype('float32'), mean=0.050387777)
+        shape=(5, 3, 8), dtype=dtype('float32'), mean=0.050387777)
 
     self._testWithAttention(
         create_attention_mechanism,
@@ -681,8 +683,8 @@ class AttentionWrapperTest(test.TestCase):
         alignment_history=())
 
     expected_final_alignment_history = (
-        ResultSummary(shape=(3, 5, 8), dtype=dtype('float32'), mean=0.125),
-        ResultSummary(shape=(3, 5, 8), dtype=dtype('float32'), mean=0.125))
+        ResultSummary(shape=(5, 3, 8), dtype=dtype('float32'), mean=0.125),
+        ResultSummary(shape=(5, 3, 8), dtype=dtype('float32'), mean=0.125))
 
     self._testWithMaybeMultiAttention(
         True,
@@ -718,8 +720,8 @@ class AttentionWrapperTest(test.TestCase):
             ResultSummary(shape=(5, 8), dtype=dtype('float32'), mean=0.125)),
         alignment_history=())
     expected_final_alignment_history = (
-        ResultSummary(shape=(3, 5, 8), dtype=dtype('float32'), mean=0.125),
-        ResultSummary(shape=(3, 5, 8), dtype=dtype('float32'), mean=0.125))
+        ResultSummary(shape=(5, 3, 8), dtype=dtype('float32'), mean=0.125),
+        ResultSummary(shape=(5, 3, 8), dtype=dtype('float32'), mean=0.125))
 
     self._testWithMaybeMultiAttention(
         is_multi=True,
@@ -753,7 +755,7 @@ class AttentionWrapperTest(test.TestCase):
         alignment_history=())
 
     expected_final_alignment_history = (
-        ResultSummary(shape=(3, 5, 8), dtype=dtype('float32'), mean=0.125),)
+        ResultSummary(shape=(5, 3, 8), dtype=dtype('float32'), mean=0.125),)
 
     self._testWithMaybeMultiAttention(
         is_multi=True,  # pass the AttentionMechanism wrapped in a list

--- a/tensorflow/contrib/seq2seq/python/kernel_tests/beam_search_decoder_test.py
+++ b/tensorflow/contrib/seq2seq/python/kernel_tests/beam_search_decoder_test.py
@@ -225,7 +225,8 @@ class TestBeamStep(test.TestCase):
 
 class BeamSearchDecoderTest(test.TestCase):
 
-  def _testDynamicDecodeRNN(self, time_major, has_attention):
+  def _testDynamicDecodeRNN(self, time_major, has_attention,
+                            with_alignment_history=False):
     encoder_sequence_length = np.array([3, 2, 3, 1, 1])
     decoder_sequence_length = np.array([2, 0, 1, 2, 3])
     batch_size = 5
@@ -265,7 +266,7 @@ class BeamSearchDecoderTest(test.TestCase):
             cell=cell,
             attention_mechanism=attention_mechanism,
             attention_layer_size=attention_depth,
-            alignment_history=False)
+            alignment_history=with_alignment_history)
       cell_state = cell.zero_state(
           dtype=dtypes.float32, batch_size=batch_size_tensor * beam_width)
       if has_attention:
@@ -326,6 +327,12 @@ class BeamSearchDecoderTest(test.TestCase):
 
   def testDynamicDecodeRNNBatchMajorYesAttention(self):
     self._testDynamicDecodeRNN(time_major=False, has_attention=True)
+
+  def testDynamicDecodeRNNBatchMajorYesAttentionWithAlignmentHistory(self):
+    self._testDynamicDecodeRNN(
+        time_major=False,
+        has_attention=True,
+        with_alignment_history=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I would like to propose this fix for #13154.

This is a breaking change as it replaces `TensorArray`s of the `alignment_history` field with batch major `Tensor`s.

Additionally, the helper function used to gather beams in `BeamSearchDecoder` had to be updated to allow keeping the original values dimensions.