### PR TITLE
Fixes #12401: Use traceback instead of inspect for frame information

### DIFF
--- a/tensorflow/contrib/framework/python/ops/arg_scope.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope.py
@@ -181,7 +181,7 @@ def add_arg_scope(func):
     return func(*args, **current_args)
   _add_op(func)
   setattr(func_with_args, '_key_op', _key_op(func))
-  return tf_decorator.make_decorator(func, func_with_args)
+  return tf_decorator.make_decorator(func, func_with_args, decorator_name='add_arg_scope')
 
 
 def has_arg_scope(func):

--- a/tensorflow/contrib/framework/python/ops/arg_scope.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope.py
@@ -181,7 +181,7 @@ def add_arg_scope(func):
     return func(*args, **current_args)
   _add_op(func)
   setattr(func_with_args, '_key_op', _key_op(func))
-  return tf_decorator.make_decorator(func, func_with_args, decorator_name='add_arg_scope')
+  return tf_decorator.make_decorator(func, func_with_args)
 
 
 def has_arg_scope(func):

--- a/tensorflow/python/util/tf_decorator.py
+++ b/tensorflow/python/util/tf_decorator.py
@@ -60,7 +60,7 @@ from __future__ import division
 from __future__ import print_function
 
 import functools as _functools
-import inspect as _inspect
+import traceback as _traceback
 
 
 def make_decorator(target,
@@ -83,7 +83,9 @@ def make_decorator(target,
     The `decorator_func` argument with new metadata attached.
   """
   if decorator_name is None:
-    decorator_name = _inspect.stack()[1][3]  # Caller's name.
+    frame = _traceback.extract_stack(limit=2)[0]
+    # frame name is tuple[2] in python2, and object.name in python3
+    decorator_name = getattr(frame, 'name', name[2]) # Caller's name
   decorator = TFDecorator(decorator_name, target, decorator_doc,
                           decorator_argspec)
   setattr(decorator_func, '_tf_decorator', decorator)

--- a/tensorflow/python/util/tf_decorator.py
+++ b/tensorflow/python/util/tf_decorator.py
@@ -85,7 +85,7 @@ def make_decorator(target,
   if decorator_name is None:
     frame = _traceback.extract_stack(limit=2)[0]
     # frame name is tuple[2] in python2, and object.name in python3
-    decorator_name = getattr(frame, 'name', name[2]) # Caller's name
+    decorator_name = getattr(frame, 'name', frame[2]) # Caller's name
   decorator = TFDecorator(decorator_name, target, decorator_doc,
                           decorator_argspec)
   setattr(decorator_func, '_tf_decorator', decorator)

--- a/tensorflow/python/util/tf_decorator.py
+++ b/tensorflow/python/util/tf_decorator.py
@@ -60,7 +60,7 @@ from __future__ import division
 from __future__ import print_function
 
 import functools as _functools
-import inspect as _inspect
+import traceback as _traceback
 
 
 def make_decorator(target,
@@ -83,8 +83,9 @@ def make_decorator(target,
     The `decorator_func` argument with new metadata attached.
   """
   if decorator_name is None:
-    prev_frame = _inspect.currentframe().f_back
-    decorator_name = _inspect.getframeinfo(prev_frame)[2]  # Caller's name.
+    frame = _traceback.extract_stack(limit=2)[0]
+    # frame name is tuple[2] in python2, and object.name in python3
+    decorator_name = getattr(frame, 'name', name[2]) # Caller's name
   decorator = TFDecorator(decorator_name, target, decorator_doc,
                           decorator_argspec)
   setattr(decorator_func, '_tf_decorator', decorator)


### PR DESCRIPTION
#12401 - import tensorflow.contrib.layers takes a very long time

I learned (while rebasing this diff) that the issue of slow imports of tensorflow.contrib.layers was fixed earlier this week: https://github.com/tensorflow/tensorflow/pull/11830. 🎉 Since the diff is ready,  I want to put up the diff for the sake of history, but I understand if at this point the further speedup is minor enough to ignore.

The speedup is a factor of 2, while the original fix is a factor of 100.   

----

My performance tests compared three versions:
- original implementation with inspect.stack()
- traceback(limit)
- current_frame + inspect

I also found that the original implementation was sensitive to the depth of the current stack, and a file importing another file generally increased that call depth by 5.  Which is to say, in practice, my code importing `tensorflow.config` at an import depth of 7 had much worse performance than the baseline test of just importing `tensorflow.config`


| Test  | Timing |
| -- | -- |
| python2 - inspect.stack |  7.8 sec |
| python2 - inspect.getframeinfo  |  0.12 sec   |
| python2 - traceback.extract_stack  |  0.04 sec   |
| python3 - inspect.stack |  22.8 sec |
| python3 - inspect.getframeinfo  |  0.14 sec   |
| python3 - traceback.extract_stack  |  0.07 sec   |

^ tests are the total of 1000 runs with a stack of 200, to give easy to compare numbers.
https://gist.github.com/JettJones/c236494013f22723c1822126df944b12

This functionality of adding a decorator name from the call stack is covered by the existing unit test:
* testSetsDecoratorNameToFunctionThatCallsMakeDecoratorIfAbsent

And pylint did not report any issues on these changes
