### PR TITLE
Fixes for Raspberry Pi cross-compilation issues

### DIFF
--- a/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
+++ b/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
@@ -64,7 +64,7 @@ cd ..
 
 CROSSTOOL_CC=$(pwd)/toolchain/tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc
 
-rm -rf openblas
+sudo rm -rf openblas
 git clone https://github.com/xianyi/OpenBLAS openblas
 cd openblas
 make CC=${CROSSTOOL_CC} FC=${CROSSTOOL_CC} HOSTCC=gcc TARGET=ARMV6

--- a/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
+++ b/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
@@ -47,9 +47,14 @@ sed -i 's/ca7beac153d4059c02c8fc59816c82d54ea47fe58365e8aded4082ded0b820c4/a34b2
 sudo sed -i 's/define CURL_SIZEOF_LONG 8/define CURL_SIZEOF_LONG 4/g' /usr/include/curl/curlbuild.h
 sudo sed -i 's/define CURL_SIZEOF_CURL_OFF_T 8/define CURL_SIZEOF_CURL_OFF_T 4/g' /usr/include/curl/curlbuild.h
 
+# The system-installed OpenSSL headers get pulled in by the latest BoringSSL
+# release on this configuration, so move them before we build:
+mv /usr/include/openssl /usr/include/openssl.original
+
 # Build the OpenBLAS library, which is faster than Eigen on the Pi Zero/One.
 # TODO(petewarden) - It would be nicer to move this into the main Bazel build
 # process if we can maintain a build file for this.
+rm -rf toolchain
 mkdir toolchain
 cd toolchain
 curl -L https://github.com/raspberrypi/tools/archive/0e906ebc527eab1cdbf7adabff5b474da9562e9f.tar.gz -o toolchain.tar.gz
@@ -59,6 +64,7 @@ cd ..
 
 CROSSTOOL_CC=$(pwd)/toolchain/tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc
 
+rm -rf openblas
 git clone https://github.com/xianyi/OpenBLAS openblas
 cd openblas
 make CC=${CROSSTOOL_CC} FC=${CROSSTOOL_CC} HOSTCC=gcc TARGET=ARMV6

--- a/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
+++ b/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
@@ -54,7 +54,7 @@ sudo mv /usr/include/openssl /usr/include/openssl.original
 # Build the OpenBLAS library, which is faster than Eigen on the Pi Zero/One.
 # TODO(petewarden) - It would be nicer to move this into the main Bazel build
 # process if we can maintain a build file for this.
-rm -rf toolchain
+sudo rm -rf toolchain
 mkdir toolchain
 cd toolchain
 curl -L https://github.com/raspberrypi/tools/archive/0e906ebc527eab1cdbf7adabff5b474da9562e9f.tar.gz -o toolchain.tar.gz

--- a/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
+++ b/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
@@ -49,7 +49,7 @@ sudo sed -i 's/define CURL_SIZEOF_CURL_OFF_T 8/define CURL_SIZEOF_CURL_OFF_T 4/g
 
 # The system-installed OpenSSL headers get pulled in by the latest BoringSSL
 # release on this configuration, so move them before we build:
-mv /usr/include/openssl /usr/include/openssl.original
+sudo mv /usr/include/openssl /usr/include/openssl.original
 
 # Build the OpenBLAS library, which is faster than Eigen on the Pi Zero/One.
 # TODO(petewarden) - It would be nicer to move this into the main Bazel build


### PR DESCRIPTION
The nightly builds have been failing recently, and it's due to a BoringSSL change that brings in system headers on our cross-compilation Docker image. I've worked around this my moving the system headers for OpenSSL, and made a couple of other changes to improve reliability by ensuring the workspace is clean before starting.