### PR TITLE
Getting rid from unnecessary call 'inspect.stack'

### DIFF
--- a/tensorflow/contrib/framework/python/ops/arg_scope.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope.py
@@ -181,7 +181,7 @@ def add_arg_scope(func):
     return func(*args, **current_args)
   _add_op(func)
   setattr(func_with_args, '_key_op', _key_op(func))
-  return tf_decorator.make_decorator(func, func_with_args)
+  return tf_decorator.make_decorator(func, func_with_args, 'add_arg_scope')
 
 
 def has_arg_scope(func):


### PR DESCRIPTION
Getting rid from unnecessary call 'inspect.stack' in making of decorator in 'tf.contrib.framework.add_arg_scope'

P.S.
On my laptop this call gives big overhead for initialization of tensorflow