### PR TITLE
Add ReceptiveField class and coordinate conversion methods.

### DIFF
--- a/tensorflow/contrib/receptive_field/python/util/receptive_field.py
+++ b/tensorflow/contrib/receptive_field/python/util/receptive_field.py
@@ -339,10 +339,10 @@ class ReceptiveField:
       ValueError: If the number of dimensions of the feature coordinates does
         not match the number of elements in `axis`.
     """
-    # Use all dimensions
+    # Use all dimensions.
     if axis is None:
       axis = range(self.size.size)
-    # Ensure axis is a list because tuples have different indexing behavior
+    # Ensure axis is a list because tuples have different indexing behavior.
     axis = list(axis)
     x = np.asarray(x)
     if x.shape[-1] != len(axis):
@@ -370,10 +370,10 @@ class ReceptiveField:
       ValueError: If the number of dimensions of the input center coordinates
         does not match the number of elements in `axis`.
     """
-    # Use all dimensions
+    # Use all dimensions.
     if axis is None:
       axis = range(self.size.size)
-    # Ensure axis is a list because tuples have different indexing behavior
+    # Ensure axis is a list because tuples have different indexing behavior.
     axis = list(axis)
     y = np.asarray(y)
     if y.shape[-1] != len(axis):
@@ -423,11 +423,11 @@ def compute_receptive_field_from_graph_def(graph_def, input_node, output_node,
       cannot be found. For network criterion alignment, see
       photos/vision/features/delf/g3doc/rf_computation.md
   """
-  # Convert a graph to graph_def if necessary
+  # Convert a graph to graph_def if necessary.
   if isinstance(graph_def, framework_ops.Graph):
     graph_def = graph_def.as_graph_def()
 
-  # Convert tensors to names
+  # Convert tensors to names.
   if isinstance(input_node, framework_ops.Tensor):
     input_node = input_node.op.name
   if isinstance(output_node, framework_ops.Tensor):
@@ -526,7 +526,7 @@ def compute_receptive_field_from_graph_def(graph_def, input_node, output_node,
 
       # Loop over this node's inputs and potentially propagate information down.
       for inp_name in node.input:
-        # Stop the propagation of the receptive field
+        # Stop the propagation of the receptive field.
         if any(inp_name.startswith(stop) for stop in stop_propagation):
           logging.vlog(3, "Skipping explicitly ignored node %s.", node.name)
           continue

--- a/tensorflow/contrib/receptive_field/python/util/receptive_field.py
+++ b/tensorflow/contrib/receptive_field/python/util/receptive_field.py
@@ -321,19 +321,20 @@ class ReceptiveField:
     self.stride = np.asarray(stride)
     self.padding = np.asarray(padding)
 
-  def compute_input_center_coordinates(self, x, axis=None):
+  def compute_input_center_coordinates(self, y, axis=None):
     """
     Computes the center of the receptive field that generated a feature.
 
     Args:
-      x: An array of feature coordinates with shape `(..., d)`, where `d` is the
+      y: An array of feature coordinates with shape `(..., d)`, where `d` is the
         number of dimensions of the coordinates.
       axis: The dimensions for which to compute the input center coordinates.
         If `None` (the default), compute the input center coordinates for all
         dimensions.
 
     Returns:
-      y: Center of the receptive field that generated the features.
+      x: Center of the receptive field that generated the features, at the input
+        of the network.
 
     Raises:
       ValueError: If the number of dimensions of the feature coordinates does
@@ -344,27 +345,27 @@ class ReceptiveField:
       axis = range(self.size.size)
     # Ensure axis is a list because tuples have different indexing behavior.
     axis = list(axis)
-    x = np.asarray(x)
-    if x.shape[-1] != len(axis):
-      raise ValueError("Dimensionality of the feature coordinates `x` (%d) "
+    y = np.asarray(y)
+    if y.shape[-1] != len(axis):
+      raise ValueError("Dimensionality of the feature coordinates `y` (%d) "
                        "does not match dimensionality of `axis` (%d)" %
-                       (x.shape[-1], len(axis)))
-    return - self.padding[axis] + x * self.stride[axis] + \
+                       (y.shape[-1], len(axis)))
+    return - self.padding[axis] + y * self.stride[axis] + \
       (self.size[axis] - 1) / 2
 
-  def compute_feature_coordinates(self, y, axis=None):
+  def compute_feature_coordinates(self, x, axis=None):
     """
     Computes the position of a feature given the center of a receptive field.
 
     Args:
-      y: An array of input center coordinates with shape `(..., d)`, where `d`
+      x: An array of input center coordinates with shape `(..., d)`, where `d`
         is the number of dimensions of the coordinates.
       axis: The dimensions for which to compute the feature coordinates.
         If `None` (the default), compute the feature coordinates for all
         dimensions.
 
     Returns:
-      x: Coordinates of the features.
+      y: Coordinates of the features.
 
     Raises:
       ValueError: If the number of dimensions of the input center coordinates
@@ -375,12 +376,12 @@ class ReceptiveField:
       axis = range(self.size.size)
     # Ensure axis is a list because tuples have different indexing behavior.
     axis = list(axis)
-    y = np.asarray(y)
-    if y.shape[-1] != len(axis):
-      raise ValueError("Dimensionality of the input center coordinates `y` "
+    x = np.asarray(x)
+    if x.shape[-1] != len(axis):
+      raise ValueError("Dimensionality of the input center coordinates `x` "
                        "(%d) does not match dimensionality of `axis` (%d)" %
-                       (y.shape[-1], len(axis)))
-    return (y + self.padding[axis] + (1 - self.size[axis]) / 2) / \
+                       (x.shape[-1], len(axis)))
+    return (x + self.padding[axis] + (1 - self.size[axis]) / 2) / \
       self.stride[axis]
 
   def __iter__(self):

--- a/tensorflow/contrib/receptive_field/python/util/receptive_field_test.py
+++ b/tensorflow/contrib/receptive_field/python/util/receptive_field_test.py
@@ -152,10 +152,10 @@ def create_test_network_5():
 
 
 def create_test_network_6():
-  """Aligned network for test.
+  """Aligned network with dropout for test.
 
-  The graph corresponds to the example from the second figure in
-  go/cnn-rf-computation#arbitrary-computation-graphs
+  The graph is similar to create_test_network_1(), except that the right branch
+  has dropout normalization.
 
   Returns:
     g: Tensorflow graph object (Graph proto).
@@ -273,7 +273,7 @@ class RfUtilsTest(test.TestCase):
 
     x = np.random.randint(0, 100, (50, 2))
     y = rf.compute_feature_coordinates(x)
-    x2 = rf.compute_input_coordinates(y)
+    x2 = rf.compute_input_center_coordinates(y)
 
     self.assertAllEqual(x, x2)
 

--- a/tensorflow/contrib/receptive_field/python/util/receptive_field_test.py
+++ b/tensorflow/contrib/receptive_field/python/util/receptive_field_test.py
@@ -251,7 +251,7 @@ class RfUtilsTest(test.TestCase):
     input_node = 'input_image'
     output_node = 'output'
     # Compute the receptive field but stop the propagation for the random
-    # uniform variable of the dropout
+    # uniform variable of the dropout.
     (receptive_field_x, receptive_field_y, effective_stride_x,
      effective_stride_y, effective_padding_x, effective_padding_y) = (
          receptive_field.compute_receptive_field_from_graph_def(

--- a/tensorflow/contrib/receptive_field/python/util/receptive_field_test.py
+++ b/tensorflow/contrib/receptive_field/python/util/receptive_field_test.py
@@ -151,6 +151,31 @@ def create_test_network_5():
   return g
 
 
+def create_test_network_6():
+  """Aligned network for test.
+
+  The graph corresponds to the example from the second figure in
+  go/cnn-rf-computation#arbitrary-computation-graphs
+
+  Returns:
+    g: Tensorflow graph object (Graph proto).
+  """
+  g = ops.Graph()
+  with g.as_default():
+    # An 8x8 test image.
+    x = array_ops.placeholder(dtypes.float32, (1, 8, 8, 1), name='input_image')
+    # Left branch.
+    l1 = slim.conv2d(x, 1, [1, 1], stride=4, scope='L1', padding='VALID')
+    # Right branch.
+    l2_pad = array_ops.pad(x, [[0, 0], [1, 0], [1, 0], [0, 0]])
+    l2 = slim.conv2d(l2_pad, 1, [3, 3], stride=2, scope='L2', padding='VALID')
+    l3 = slim.conv2d(l2, 1, [1, 1], stride=2, scope='L3', padding='VALID')
+    dropout = slim.dropout(l3)
+    # Addition.
+    nn.relu(l1 + dropout, name='output')
+  return g
+
+
 class RfUtilsTest(test.TestCase):
 
   def testComputeRFFromGraphDefAligned(self):
@@ -220,6 +245,24 @@ class RfUtilsTest(test.TestCase):
     self.assertEqual(effective_stride_y, 4)
     self.assertEqual(effective_padding_x, 0)
     self.assertEqual(effective_padding_y, 0)
+
+  def testComputeRFFromGraphDefStopPropagation(self):
+    graph_def = create_test_network_6().as_graph_def()
+    input_node = 'input_image'
+    output_node = 'output'
+    # Compute the receptive field but stop the propagation for the random
+    # uniform variable of the dropout
+    (receptive_field_x, receptive_field_y, effective_stride_x,
+     effective_stride_y, effective_padding_x, effective_padding_y) = (
+         receptive_field.compute_receptive_field_from_graph_def(
+             graph_def, input_node, output_node,
+             ['Dropout/dropout/random_uniform']))
+    self.assertEqual(receptive_field_x, 3)
+    self.assertEqual(receptive_field_y, 3)
+    self.assertEqual(effective_stride_x, 4)
+    self.assertEqual(effective_stride_y, 4)
+    self.assertEqual(effective_padding_x, 1)
+    self.assertEqual(effective_padding_y, 1)
 
   def testComputeCoordinatesRoundtrip(self):
     graph_def = create_test_network_1()

--- a/tensorflow/contrib/receptive_field/python/util/receptive_field_test.py
+++ b/tensorflow/contrib/receptive_field/python/util/receptive_field_test.py
@@ -25,6 +25,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import nn
 from tensorflow.python.platform import test
+import numpy as np
 
 
 def create_test_network_1():
@@ -220,6 +221,18 @@ class RfUtilsTest(test.TestCase):
     self.assertEqual(effective_padding_x, 0)
     self.assertEqual(effective_padding_y, 0)
 
+  def testComputeCoordinatesRoundtrip(self):
+    graph_def = create_test_network_1()
+    input_node = 'input_image'
+    output_node = 'output'
+    rf = receptive_field.compute_receptive_field_from_graph_def(
+      graph_def, input_node, output_node)
+
+    x = np.random.randint(0, 100, (50, 2))
+    y = rf.compute_feature_coordinates(x)
+    x2 = rf.compute_input_coordinates(y)
+
+    self.assertAllEqual(x, x2)
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
This PR adds a `ReceptiveField` class which supports coordinate conversion from the input to the feature space and vice versa while maintaining backwards compatibility.