### PR TITLE
Fix Windows build after 5c7f9e316d8c7735308a217310350d416d7498cc

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -251,7 +251,7 @@ def reset_tf_configure_bazelrc():
   if not os.path.exists('.bazelrc'):
     if os.path.exists(os.path.join(home, '.bazelrc')):
       with open('.bazelrc', 'a') as f:
-        f.write('import %s/.bazelrc\n' % home)
+        f.write('import %s/.bazelrc\n' % home.replace('\\', '/'))
     else:
       open('.bazelrc', 'w').close()
 

--- a/tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh
+++ b/tensorflow/tools/ci_build/windows/bazel/bazel_test_lib.sh
@@ -97,15 +97,7 @@ exclude_cpu_cc_tests="${failing_cpu_cc_tests} + ${broken_cpu_cc_tests}"
 exclude_gpu_cc_tests="${extra_failing_gpu_cc_tests} + ${exclude_cpu_cc_tests}"
 
 function clean_output_base() {
-  # TODO(pcloudy): bazel clean --expunge doesn't work on Windows yet.
-  # Clean the output base manually to ensure build correctness
-  bazel clean
-  output_base=$(bazel info output_base)
-  bazel shutdown
-  # Sleep 5s to wait for jvm shutdown completely
-  # otherwise rm will fail with device or resource busy error
-  sleep 5
-  rm -rf ${output_base}
+  bazel clean --expunge
 }
 
 function run_configure_for_cpu_build {

--- a/tensorflow/tools/ci_build/windows/bazel/common_env.sh
+++ b/tensorflow/tools/ci_build/windows/bazel/common_env.sh
@@ -55,8 +55,11 @@ export PATH="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v8.0/extras/CUPT
 export PATH="/c/tools/cuda/bin:$PATH"
 
 # Set the common build options on Windows
-export BUILD_OPTS='--copt=-w --host_copt=-w --verbose_failures --experimental_ui'
+export BUILD_OPTS='--config=monolithic --copt=-w --host_copt=-w --verbose_failures --experimental_ui'
 
 # Build TF with wrapper-less CROSSTOOL
 # TODO(pcloudy): Remove this after wrapper-less CROSSTOOL becomes default
 export NO_MSVC_WRAPPER=1
+
+export USE_DYNAMIC_CRT=1
+


### PR DESCRIPTION
Fix http://ci.tensorflow.org/job/tf-master-win-bzl/1629/console
Dynamic linking on Windows is not well supported yet, we can only still use the monolithic for now.
@gunan 