### PR TITLE
Fix broken link for object detection model

### DIFF
--- a/tensorflow/examples/android/README.md
+++ b/tensorflow/examples/android/README.md
@@ -26,7 +26,7 @@ on API >= 14 devices.
         in an overlay on the camera image.
 2. [TF Detect](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/android/src/org/tensorflow/demo/DetectorActivity.java):
         Demonstrates an SSD-Mobilenet model trained using the
-        [Tensorflow Object Detection API](https://github.com/tensorflow/models/tree/master/object_detection/)
+        [Tensorflow Object Detection API](https://github.com/tensorflow/models/tree/master/research/object_detection/)
         introduced in [Speed/accuracy trade-offs for modern convolutional object detectors](https://arxiv.org/abs/1611.10012) to
         localize and track objects (from 80 categories) in the camera preview
         in real-time.

--- a/tensorflow/examples/android/src/org/tensorflow/demo/TensorFlowObjectDetectionAPIModel.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/TensorFlowObjectDetectionAPIModel.java
@@ -35,7 +35,7 @@ import org.tensorflow.demo.env.Logger;
 
 /**
  * Wrapper for frozen detection models trained using the Tensorflow Object Detection API:
- * github.com/tensorflow/models/tree/master/object_detection
+ * github.com/tensorflow/models/tree/master/research/object_detection
  */
 public class TensorFlowObjectDetectionAPIModel implements Classifier {
   private static final Logger LOGGER = new Logger();


### PR DESCRIPTION
In tensorflow/models repo the models have been moved under the directory `research`.

This fix fixes a couple of broken links associated with `object_direction`:
`object_detection/` -> `research/object_detection/`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>