### PR TITLE
Add cmake generated files/dirs in Linux to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ __pycache__
 .vscode/
 cmake_build/
 .idea/**
+/build/
+/tensorflow/core/util/version_info.cc


### PR DESCRIPTION
This fix adds cmake generated files in Linux to .gitignore

Before this fix, after:
```sh
$ tensorflow/tools/ci_build/ci_build.sh CMAKE tensorflow/tools/ci_build/builds/cmake.sh
```
The following files/dirs are left out:
```sh
ubuntu@ubuntu:~/tensorflow$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        build/
        tensorflow/core/util/version_info.cc

nothing added to commit but untracked files present (use "git add" to track)
ubuntu@ubuntu:~/tensorflow$
```

This fix addresses the above issue.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>