### PR TITLE
ENH: row_shape supports unknown dim in Dataset.dense_to_sparse_batch

### DIFF
--- a/tensorflow/contrib/data/python/kernel_tests/batch_dataset_op_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/batch_dataset_op_test.py
@@ -280,7 +280,7 @@ class BatchDatasetTest(test.TestCase):
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
 
-  def testDenseToSparseBatchDatasetWithInvaildShape(self):
+  def testDenseToSparseBatchDatasetWithInvalidShape(self):
     input_tensor = array_ops.constant([[1]])
     iterator = (dataset_ops.Dataset.from_tensors(input_tensor)
                 .dense_to_sparse_batch(4, [-2]).make_initializable_iterator())

--- a/tensorflow/contrib/data/python/kernel_tests/batch_dataset_op_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/batch_dataset_op_test.py
@@ -252,33 +252,33 @@ class BatchDatasetTest(test.TestCase):
         sess.run(get_next)
 
   def testDenseToSparseBatchDatasetWithUnknownShape(self):
-      components = np.random.randint(5, size=(40,)).astype(np.int32)
-      iterator = (dataset_ops.Dataset.from_tensor_slices(components)
-                  .map(lambda x: array_ops.fill([x, x], x)).dense_to_sparse_batch(
-          4, [5, -1]).make_initializable_iterator())
-      init_op = iterator.initializer
-      get_next = sparse_tensor.SparseTensor(*iterator.get_next())
+    components = np.random.randint(5, size=(40,)).astype(np.int32)
+    iterator = (dataset_ops.Dataset.from_tensor_slices(components)
+                .map(lambda x: array_ops.fill([x, x], x)).dense_to_sparse_batch(
+                    4, [5, -1]).make_initializable_iterator())
+    init_op = iterator.initializer
+    get_next = sparse_tensor.SparseTensor(*iterator.get_next())
 
-      with self.test_session() as sess:
-          sess.run(init_op)
+    with self.test_session() as sess:
+      sess.run(init_op)
 
-          for start in range(0, len(components), 4):
-              results = sess.run(get_next)
-              self.assertAllEqual(
-                  [[i, j, z] for i, c in enumerate(components[start:start+4])
-                   for j in range(c) for z in range(c)], results.indices)
-              self.assertAllEqual(
-                  [c for c in components[start:start+4]
-                     for _ in range(c) for _ in range(c)],
-                  results.values)
-              self.assertAllEqual(
-                  [min(4, len(components) - start),
-                   5,
-                   np.max(components[start:start+4])],
-                  results.dense_shape)
+      for start in range(0, len(components), 4):
+        results = sess.run(get_next)
+        self.assertAllEqual(
+            [[i, j, z] for i, c in enumerate(components[start:start+4])
+             for j in range(c) for z in range(c)], results.indices)
+        self.assertAllEqual(
+            [c for c in components[start:start+4]
+             for _ in range(c) for _ in range(c)],
+            results.values)
+        self.assertAllEqual(
+            [min(4, len(components) - start),
+             5,
+             np.max(components[start:start+4])],
+            results.dense_shape)
 
-          with self.assertRaises(errors.OutOfRangeError):
-              sess.run(get_next)
+      with self.assertRaises(errors.OutOfRangeError):
+        sess.run(get_next)
 
   def testDenseToSparseBatchDatasetShapeErrors(self):
     input_tensor = array_ops.placeholder(dtypes.int32)

--- a/tensorflow/contrib/data/python/kernel_tests/batch_dataset_op_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/batch_dataset_op_test.py
@@ -280,6 +280,17 @@ class BatchDatasetTest(test.TestCase):
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
 
+  def testDenseToSparseBatchDatasetWithInvaildShape(self):
+    input_tensor = array_ops.constant([[1]])
+    iterator = (dataset_ops.Dataset.from_tensors(input_tensor)
+                .dense_to_sparse_batch(4, [-2]).make_initializable_iterator())
+    init_op = iterator.initializer
+
+    with self.test_session() as sess:
+      with self.assertRaisesRegexp(errors.InvalidArgumentError,
+                                   "Dimension -2 must be >= -1"):
+        sess.run(init_op)
+
   def testDenseToSparseBatchDatasetShapeErrors(self):
     input_tensor = array_ops.placeholder(dtypes.int32)
     iterator = (dataset_ops.Dataset.from_tensors(input_tensor)

--- a/tensorflow/contrib/data/python/kernel_tests/batch_dataset_op_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/batch_dataset_op_test.py
@@ -251,6 +251,35 @@ class BatchDatasetTest(test.TestCase):
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
 
+  def testDenseToSparseBatchDatasetWithUnknownShape(self):
+      components = np.random.randint(5, size=(40,)).astype(np.int32)
+      iterator = (dataset_ops.Dataset.from_tensor_slices(components)
+                  .map(lambda x: array_ops.fill([x, x], x)).dense_to_sparse_batch(
+          4, [5, -1]).make_initializable_iterator())
+      init_op = iterator.initializer
+      get_next = sparse_tensor.SparseTensor(*iterator.get_next())
+
+      with self.test_session() as sess:
+          sess.run(init_op)
+
+          for start in range(0, len(components), 4):
+              results = sess.run(get_next)
+              self.assertAllEqual(
+                  [[i, j, z] for i, c in enumerate(components[start:start+4])
+                   for j in range(c) for z in range(c)], results.indices)
+              self.assertAllEqual(
+                  [c for c in components[start:start+4]
+                     for _ in range(c) for _ in range(c)],
+                  results.values)
+              self.assertAllEqual(
+                  [min(4, len(components) - start),
+                   5,
+                   np.max(components[start:start+4])],
+                  results.dense_shape)
+
+          with self.assertRaises(errors.OutOfRangeError):
+              sess.run(get_next)
+
   def testDenseToSparseBatchDatasetShapeErrors(self):
     input_tensor = array_ops.placeholder(dtypes.int32)
     iterator = (dataset_ops.Dataset.from_tensors(input_tensor)

--- a/tensorflow/core/kernels/dense_to_sparse_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/dense_to_sparse_batch_dataset_op.cc
@@ -195,12 +195,12 @@ class DenseToSparseBatchDatasetOp : public UnaryDatasetOpKernel {
           const auto& t_flat = t.flat<T>();
 
           // Take the maximum in the dimension if -1 is given.
-          for (int i = 0; i < row_ndims; ++i) {
-            if (row_shape.dim_size(i) == -1) {
-              if (t.dim_size(i) > dense_shape_vec(i + 1)) {
-                dense_shape_vec(i + 1) = t.dim_size(i);
+          for (int j = 0; j < row_ndims; ++j) {
+            if (row_shape.dim_size(j) == -1) {
+              if (t.dim_size(j) > dense_shape_vec(j + 1)) {
+                dense_shape_vec(j + 1) = t.dim_size(j);
               }
-            } else if (t.dim_size(i) > row_shape.dim_size(i)) {
+            } else if (t.dim_size(j) > row_shape.dim_size(j)) {
               return errors::DataLoss(
                   "Input element had shape (",
                   t.shape().DebugString(),

--- a/tensorflow/core/kernels/dense_to_sparse_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/dense_to_sparse_batch_dataset_op.cc
@@ -49,10 +49,7 @@ class DenseToSparseBatchDatasetOp : public UnaryDatasetOpKernel {
     OP_REQUIRES_OK(ctx, ctx->input("row_shape", &row_shape_t));
     OP_REQUIRES(ctx, TensorShapeUtils::IsVector(row_shape_t->shape()),
                 errors::InvalidArgument("row_shape must be a vector"));
-    TensorShape row_shape;
-    for (size_t i = 0; i < row_shape_t->dim_size(0); ++i) {
-      row_shape.AddDim(row_shape_t->vec<int64>()(i));
-    }
+    PartialTensorShape row_shape(row_shape_t->vec<int64>());
 
     *output = nullptr;
 
@@ -78,7 +75,7 @@ class DenseToSparseBatchDatasetOp : public UnaryDatasetOpKernel {
   template <class T>
   class Dataset : public DatasetBase {
    public:
-    Dataset(int64 batch_size, const TensorShape& row_shape,
+    Dataset(int64 batch_size, const PartialTensorShape& row_shape,
             const DatasetBase* input)
         : batch_size_(batch_size), row_shape_(row_shape), input_(input) {
       input_->Ref();
@@ -129,7 +126,7 @@ class DenseToSparseBatchDatasetOp : public UnaryDatasetOpKernel {
         int64 total_elements = 0;
         batch_elements.reserve(
             DatasetIterator<Dataset<T>>::dataset()->batch_size_);
-        const TensorShape& row_shape =
+        const PartialTensorShape& row_shape =
             DatasetIterator<Dataset<T>>::dataset()->row_shape_;
         const int row_ndims = row_shape.dims();
         {
@@ -249,7 +246,7 @@ class DenseToSparseBatchDatasetOp : public UnaryDatasetOpKernel {
     };
 
     const int64 batch_size_;
-    const TensorShape row_shape_;
+    const PartialTensorShape row_shape_;
     const DatasetBase* const input_;
     std::vector<PartialTensorShape> output_shapes_;
   };

--- a/tensorflow/core/kernels/dense_to_sparse_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/dense_to_sparse_batch_dataset_op.cc
@@ -194,9 +194,7 @@ class DenseToSparseBatchDatasetOp : public UnaryDatasetOpKernel {
           // Take the maximum in the dimension if -1 is given.
           for (int j = 0; j < row_ndims; ++j) {
             if (row_shape.dim_size(j) == -1) {
-              if (t.dim_size(j) > dense_shape_vec(j + 1)) {
-                dense_shape_vec(j + 1) = t.dim_size(j);
-              }
+              dense_shape_vec(j + 1) = std::max(t.dim_size(j), dense_shape_vec(j + 1));
             } else if (t.dim_size(j) > row_shape.dim_size(j)) {
               return errors::DataLoss(
                   "Input element had shape (",

--- a/tensorflow/core/kernels/dense_to_sparse_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/dense_to_sparse_batch_dataset_op.cc
@@ -49,7 +49,12 @@ class DenseToSparseBatchDatasetOp : public UnaryDatasetOpKernel {
     OP_REQUIRES_OK(ctx, ctx->input("row_shape", &row_shape_t));
     OP_REQUIRES(ctx, TensorShapeUtils::IsVector(row_shape_t->shape()),
                 errors::InvalidArgument("row_shape must be a vector"));
-    PartialTensorShape row_shape(row_shape_t->vec<int64>());
+    PartialTensorShape row_shape;
+    OP_REQUIRES_OK(ctx,
+                   PartialTensorShape::MakePartialShape(
+                       row_shape_t->vec<int64>().data(),
+                       row_shape_t->NumElements(),
+                       &row_shape));
 
     *output = nullptr;
 

--- a/tensorflow/core/ops/dataset_ops.cc
+++ b/tensorflow/core/ops/dataset_ops.cc
@@ -383,7 +383,8 @@ input_dataset: A handle to an input dataset. Must have a single component.
 batch_size: A scalar representing the number of elements to accumulate in a
   batch.
 row_shape: A vector representing the dense shape of each row in the produced
-  SparseTensor.
+  SparseTensor. The shape may be partially specified, using `-1` to indicate
+  that a particular dimension should use the maximum size of all batch elements.
 )doc");
 
 REGISTER_OP("RangeDataset")


### PR DESCRIPTION
see issue: #13216 

### What changes were proposed in this pull request?

eg: `row_shape = [20, -1, 10]`, `row_shape = [20, None, 10]`

### How to test

+ [x] add test cases.
+ [ ] pass all tests.