### PR TITLE
Fix docs for tf.tanh, tf.sigmoid and tf.tan.

### DIFF
--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -362,7 +362,7 @@ REGISTER_OP("Cos").UNARY_COMPLEX().Doc(R"doc(
 Computes cos of x element-wise.
 )doc");
 
-REGISTER_OP("Tan").UNARY_REAL().Doc(R"doc(
+REGISTER_OP("Tan").UNARY().Doc(R"doc(
 Computes tan of x element-wise.
 )doc");
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -362,7 +362,7 @@ REGISTER_OP("Cos").UNARY_COMPLEX().Doc(R"doc(
 Computes cos of x element-wise.
 )doc");
 
-REGISTER_OP("Tan").UNARY().Doc(R"doc(
+REGISTER_OP("Tan").UNARY_REAL().Doc(R"doc(
 Computes tan of x element-wise.
 )doc");
 

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2089,13 +2089,12 @@ def sigmoid(x, name=None):
   Specifically, `y = 1 / (1 + exp(-x))`.
 
   Args:
-    x: A Tensor with type `float32`, `float64`, `int32`, `complex64`, `int64`,
-      or `qint32`.
+    x: A Tensor with type `float16`, `float32`, `float64`, `complex64`,
+      or `complex128`.
     name: A name for the operation (optional).
 
   Returns:
-    A Tensor with the same type as `x` if `x.dtype != qint32`
-      otherwise the return type is `quint8`.
+    A Tensor with the same type as `x`.
 
   @compatibility(numpy)
   Equivalent to np.scipy.special.expit
@@ -2128,8 +2127,8 @@ def tanh(x, name=None):
   """Computes hyperbolic tangent of `x` element-wise.
 
   Args:
-    x: A Tensor or SparseTensor with type `float`, `double`, `int32`,
-      `complex64`, or `int64`.
+    x: A Tensor or SparseTensor with type `float16`, `float32`, `double`,
+      `complex64`, or `complex128`.
     name: A name for the operation (optional).
 
   Returns:


### PR DESCRIPTION
The API docs incorrectly state that tf.tanh accepts int32
or int64 inputs. This was referenced in issue #10376, however,
the fix to #10376 only removed the reference to qint32. A look
at the implementation in cwise_op_tanh.cc shows that int32 and
int64 are indeed not supported. This fix removes them from
the API docs.

Similarly, we remove int32, int64 and qint32 from tf.sigmoid
API docs.

Finally, tf.tan is defined only for float and double, so I
changed in math_ops.cc to use UNARY_REAL.