### PR TITLE
Fix polynomial decay with cycle for global step=0

### DIFF
--- a/tensorflow/python/training/learning_rate_decay.py
+++ b/tensorflow/python/training/learning_rate_decay.py
@@ -260,8 +260,12 @@ def polynomial_decay(learning_rate, global_step, decay_steps,
     power = math_ops.cast(power, dtype)
     if cycle:
       # Find the first multiple of decay_steps that is bigger than global_step.
-      decay_steps = math_ops.multiply(decay_steps,
-                                      math_ops.ceil(global_step / decay_steps))
+      # If global_step is zero set the multiplier to 1
+      multiplier = control_flow_ops.cond(math_ops.equal(global_step, 0),
+                                         lambda: 1.0,
+                                         lambda: math_ops.ceil(
+                                             global_step / decay_steps))
+      decay_steps = math_ops.multiply(decay_steps, multiplier)
     else:
       # Make sure that the global_step used is not bigger than decay_steps.
       global_step = math_ops.minimum(global_step, decay_steps)

--- a/tensorflow/python/training/learning_rate_decay_test.py
+++ b/tensorflow/python/training/learning_rate_decay_test.py
@@ -245,6 +245,18 @@ class SqrtDecayTest(test_util.TensorFlowTestCase):
       expected = (lr - end_lr) * 0.25 ** power + end_lr
       self.assertAllClose(decayed_lr.eval(), expected, 1e-6)
 
+class PolynomialDecayTest(test_util.TensorFlowTestCase):
+
+  def testBeginWithCycle(self):
+    with self.test_session():
+      lr = 0.001
+      decay_steps = 10
+      step = 0
+      decayed_lr = learning_rate_decay.polynomial_decay(lr, step,
+                                                        decay_steps, cycle=True)
+      expected = lr
+      self.assertAllClose(decayed_lr.eval(), expected, 1e-6)
+
 
 class ExponentialDecayTest(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
For polynomial decay with cycle=True the learning rate at
step 0 becomes NaN, because in the process of calculating it we
devide by 0. This change should fix it, by setting the multiplier
for the decay steps to one for global_step=0.