### PR TITLE
Fix several issues with `go fmt` and `go lint`

### DIFF
--- a/tensorflow/go/example_inception_inference_test.go
+++ b/tensorflow/go/example_inception_inference_test.go
@@ -28,8 +28,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/tensorflow/tensorflow/tensorflow/go/op"
 	tf "github.com/tensorflow/tensorflow/tensorflow/go"
+	"github.com/tensorflow/tensorflow/tensorflow/go/op"
 )
 
 func Example() {

--- a/tensorflow/go/genop/internal/lib.go
+++ b/tensorflow/go/genop/internal/lib.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package internal generates Go source code with functions for TensorFlow operations.
 package internal
 
 // #cgo LDFLAGS: -ltensorflow

--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -99,7 +99,7 @@ func NewTensor(value interface{}) (*Tensor, error) {
 			return nil, bug("NewTensor incorrectly calculated the size of a tensor with type %v and shape %v as %v bytes instead of %v", dataType, shape, nbytes, buf.Len())
 		}
 	} else {
-		e := stringEncoder{offsets: buf, data: raw[nflattened*8 : len(raw)], status: newStatus()}
+		e := stringEncoder{offsets: buf, data: raw[nflattened*8:], status: newStatus()}
 		if err := e.encode(reflect.ValueOf(value)); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This fix fixes several issues related to `gofmt` and `golint` based on https://goreportcard.com/report/github.com/tensorflow/tensorflow

There are several changes:
- `gofmt -s tensorflow/go/tensor.go`
- `gofmt -s tensorflow/go/example_inception_inference_test.go`
- `golint tensorflow/go/genop/internal/lib.go`

At the moment there are still quite a few golint and ineffassign warnings in the current go code base. However, all of them are from `tensorflow/go/op/wrappers.go` which is machine generated code.

This fix does not cover `tensorflow/go/op/wrappers.go`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>