### PR TITLE
Refactoring of canned estimators

### DIFF
--- a/tensorflow/python/estimator/BUILD
+++ b/tensorflow/python/estimator/BUILD
@@ -35,7 +35,6 @@ py_library(
         ":model_fn",
         ":parsing_utils",
         ":run_config",
-        ":training",
         "//tensorflow/python:util",
     ],
 )
@@ -124,28 +123,6 @@ py_test(
 )
 
 py_library(
-    name = "training",
-    srcs = ["training.py"],
-    srcs_version = "PY2AND3",
-    deps = [
-        ":estimator",
-        "//tensorflow/python:training",
-        "@six_archive//:six",
-    ],
-)
-
-py_test(
-    name = "training_test",
-    size = "small",
-    srcs = ["training_test.py"],
-    srcs_version = "PY2AND3",
-    deps = [
-        ":training",
-        "//tensorflow/python:client_testlib",
-    ],
-)
-
-py_library(
     name = "run_config",
     srcs = ["run_config.py"],
     srcs_version = "PY2AND3",
@@ -173,17 +150,32 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":estimator",
-        ":head",
         ":model_fn",
-        ":optimizers",
+        ":utils",
         "//tensorflow/python:init_ops",
         "//tensorflow/python:layers",
         "//tensorflow/python:nn",
+        "//tensorflow/python:variable_scope",
+        "//tensorflow/python/feature_column",
+        "@six_archive//:six",
+    ],
+)
+
+py_library(
+    name = "utils",
+    srcs = ["canned/utils.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":head",
+        ":optimizers",
+        "//tensorflow/python:control_flow_ops",
+        "//tensorflow/python:framework_ops",
+        "//tensorflow/python:nn",
         "//tensorflow/python:partitioned_variables",
+        "//tensorflow/python:state_ops",
         "//tensorflow/python:summary",
         "//tensorflow/python:training",
         "//tensorflow/python:variable_scope",
-        "//tensorflow/python/feature_column",
         "@six_archive//:six",
     ],
 )
@@ -223,7 +215,6 @@ py_test(
     name = "dnn_test",
     size = "medium",
     srcs = ["canned/dnn_test.py"],
-    shard_count = 4,
     srcs_version = "PY2AND3",
     tags = ["no_pip"],
     deps = [
@@ -233,6 +224,7 @@ py_test(
         ":numpy_io",
         ":pandas_io",
         ":prediction_keys",
+        ":utils",
         "//tensorflow/core:protos_all_py",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:data_flow_ops",
@@ -254,20 +246,12 @@ py_library(
     deps = [
         ":dnn",
         ":estimator",
-        ":head",
         ":linear",
         ":model_fn",
-        ":optimizers",
-        "//tensorflow/python:control_flow_ops",
-        "//tensorflow/python:framework_ops",
+        ":utils",
         "//tensorflow/python:init_ops",
         "//tensorflow/python:layers",
         "//tensorflow/python:nn",
-        "//tensorflow/python:partitioned_variables",
-        "//tensorflow/python:state_ops",
-        "//tensorflow/python:summary",
-        "//tensorflow/python:training",
-        "//tensorflow/python:variable_scope",
         "//tensorflow/python/feature_column",
         "@six_archive//:six",
     ],
@@ -277,10 +261,11 @@ py_test(
     name = "dnn_linear_combined_test",
     size = "medium",
     srcs = ["canned/dnn_linear_combined_test.py"],
-    shard_count = 8,
+    shard_count = 4,
     srcs_version = "PY2AND3",
     tags = ["no_pip"],
     deps = [
+        ":dnn",
         ":dnn_linear_combined",
         ":dnn_testing_utils",
         ":export_export",
@@ -292,7 +277,6 @@ py_test(
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:dtypes",
         "//tensorflow/python:framework_ops",
-        "//tensorflow/python:nn",
         "//tensorflow/python:parsing_ops",
         "//tensorflow/python:platform",
         "//tensorflow/python:summary",
@@ -406,6 +390,7 @@ py_library(
 
 py_test(
     name = "parsing_utils_test",
+    size = "small",
     srcs = ["canned/parsing_utils_test.py"],
     srcs_version = "PY2AND3",
     deps = [
@@ -578,11 +563,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":estimator",
-        ":head",
-        ":optimizers",
-        "//tensorflow/python:partitioned_variables",
-        "//tensorflow/python:training",
-        "//tensorflow/python:variable_scope",
+        ":utils",
         "//tensorflow/python/feature_column",
         "@six_archive//:six",
     ],
@@ -627,9 +608,11 @@ py_test(
     name = "linear_test",
     size = "medium",
     srcs = ["canned/linear_test.py"],
-    shard_count = 4,
     srcs_version = "PY2AND3",
-    tags = ["no_pip"],
+    tags = [
+        "no_pip",
+        "noasan",  # times out b/63680444
+    ],
     deps = [
         ":linear",
         ":linear_testing_utils",

--- a/tensorflow/python/estimator/canned/dnn.py
+++ b/tensorflow/python/estimator/canned/dnn.py
@@ -22,29 +22,25 @@ import six
 
 from tensorflow.python.estimator import estimator
 from tensorflow.python.estimator import model_fn
-from tensorflow.python.estimator.canned import head as head_lib
-from tensorflow.python.estimator.canned import optimizers
-from tensorflow.python.feature_column import feature_column as feature_column_lib
+from tensorflow.python.feature_column import feature_column as feature_column_lib #pylint: disable=line-too-long
 from tensorflow.python.layers import core as core_layers
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import nn
-from tensorflow.python.ops import partitioned_variables
 from tensorflow.python.ops import variable_scope
-from tensorflow.python.summary import summary
-from tensorflow.python.training import training_util
+
+from tensorflow.python.estimator.canned.utils import common_model_fn
+from tensorflow.python.estimator.canned.utils import classifier_head
+from tensorflow.python.estimator.canned.utils import regression_head
+from tensorflow.python.estimator.canned.utils import add_layer_summary
+
 
 # The default learning rate of 0.05 is a historical artifact of the initial
 # implementation, but seems a reasonable choice.
 _LEARNING_RATE = 0.05
 
 
-def _add_hidden_layer_summary(value, tag):
-  summary.scalar('%s/fraction_of_zero_values' % tag, nn.zero_fraction(value))
-  summary.histogram('%s/activation' % tag, value)
-
-
-def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
-                          dropout, input_layer_partitioner):
+def _dnn_logit_fn_builder(units, hidden_units, feature_columns,
+                          activation_fn=nn.relu, dropout=None):
   """Function builder for a dnn logit_fn.
 
   Args:
@@ -67,7 +63,7 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
     raise ValueError('units must be an int or list.  Given type: {}'.format(
         type(units)))
 
-  def dnn_logit_fn(features, mode):
+  def dnn_logit_fn(features, mode, input_layer_partitioner):
     """Deep Neural Network logit_fn.
 
     Args:
@@ -99,7 +95,7 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
             name=hidden_layer_scope)
         if dropout is not None and mode == model_fn.ModeKeys.TRAIN:
           net = core_layers.dropout(net, rate=dropout, training=True)
-      _add_hidden_layer_summary(net, hidden_layer_scope.name)
+      add_layer_summary(net, hidden_layer_scope.name)
 
     if isinstance(units, int):
       with variable_scope.variable_scope(
@@ -110,7 +106,7 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
             activation=None,
             kernel_initializer=init_ops.glorot_uniform_initializer(),
             name=logits_scope)
-      _add_hidden_layer_summary(logits, logits_scope.name)
+      add_layer_summary(logits, logits_scope.name)
     else:
       logits = []
       for head_index, logits_dimension in enumerate(units):
@@ -122,88 +118,49 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
               activation=None,
               kernel_initializer=init_ops.glorot_uniform_initializer(),
               name=logits_scope)
-        _add_hidden_layer_summary(these_logits, logits_scope.name)
+        add_layer_summary(these_logits, logits_scope.name)
         logits.append(these_logits)
     return logits
 
   return dnn_logit_fn
 
-
-def _dnn_model_fn(
-    features, labels, mode, head, hidden_units, feature_columns,
-    optimizer='Adagrad', activation_fn=nn.relu, dropout=None,
-    input_layer_partitioner=None, config=None):
-  """Deep Neural Net model_fn.
-
-  Args:
-    features: dict of `Tensor`.
-    labels: `Tensor` of shape [batch_size, 1] or [batch_size] labels of
-      dtype `int32` or `int64` in the range `[0, n_classes)`.
-    mode: Defines whether this is training, evaluation or prediction.
-      See `ModeKeys`.
-    head: A `head_lib._Head` instance.
-    hidden_units: Iterable of integer number of hidden units per layer.
-    feature_columns: Iterable of `feature_column._FeatureColumn` model inputs.
-    optimizer: String, `tf.Optimizer` object, or callable that creates the
-      optimizer to use for training. If not specified, will use the Adagrad
-      optimizer with a default learning rate of 0.05.
-    activation_fn: Activation function applied to each layer.
-    dropout: When not `None`, the probability we will drop out a given
-      coordinate.
-    input_layer_partitioner: Partitioner for input layer. Defaults
-      to `min_max_variable_partitioner` with `min_slice_size` 64 << 20.
-    config: `RunConfig` object to configure the runtime settings.
-
-  Returns:
-    predictions: A dict of `Tensor` objects.
-    loss: A scalar containing the loss of the step.
-    train_op: The op for training.
-
-  Raises:
-    ValueError: If features has the wrong type.
-  """
-  if not isinstance(features, dict):
-    raise ValueError('features should be a dictionary of `Tensor`s. '
-                     'Given type: {}'.format(type(features)))
-  optimizer = optimizers.get_optimizer_instance(
-      optimizer, learning_rate=_LEARNING_RATE)
-  num_ps_replicas = config.num_ps_replicas if config else 0
-
-  partitioner = partitioned_variables.min_max_variable_partitioner(
-      max_partitions=num_ps_replicas)
-  with variable_scope.variable_scope(
-      'dnn',
-      values=tuple(six.itervalues(features)),
-      partitioner=partitioner):
-    input_layer_partitioner = input_layer_partitioner or (
-        partitioned_variables.min_max_variable_partitioner(
-            max_partitions=num_ps_replicas,
-            min_slice_size=64 << 20))
+class _DNN(estimator.Estimator):
+  """The common functionality of TensorFlow DNN models"""
+  def __init__(self,
+               head,
+               hidden_units,
+               feature_columns,
+               model_dir,
+               optimizer,
+               activation_fn,
+               dropout,
+               input_layer_partitioner,
+               config):
 
     logit_fn = _dnn_logit_fn_builder(
         units=head.logits_dimension,
         hidden_units=hidden_units,
-        feature_columns=feature_columns,
+        feature_columns=tuple(feature_columns or []),
         activation_fn=activation_fn,
-        dropout=dropout,
-        input_layer_partitioner=input_layer_partitioner)
-    logits = logit_fn(features=features, mode=mode)
+        dropout=dropout)
 
-    def _train_op_fn(loss):
-      """Returns the op to optimize the loss."""
-      return optimizer.minimize(
-          loss,
-          global_step=training_util.get_global_step())
+    def _model_fn(features, labels, mode, config):
+      return common_model_fn(
+          name='dnn',
+          features=features,
+          labels=labels,
+          mode=mode,
+          head=head,
+          logit_fn=logit_fn,
+          optimizer=optimizer,
+          learning_rate=_LEARNING_RATE,
+          input_layer_partitioner=input_layer_partitioner,
+          config=config)
 
-    return head.create_estimator_spec(
-        features=features,
-        mode=mode,
-        labels=labels,
-        train_op_fn=_train_op_fn,
-        logits=logits)
+    super(_DNN, self).__init__(
+        model_fn=_model_fn, model_dir=model_dir, config=config)
 
-
-class DNNClassifier(estimator.Estimator):
+class DNNClassifier(_DNN):
   """A classifier for TensorFlow DNN models.
 
   Example:
@@ -311,32 +268,23 @@ class DNNClassifier(estimator.Estimator):
         to `min_max_variable_partitioner` with `min_slice_size` 64 << 20.
       config: `RunConfig` object to configure the runtime settings.
     """
-    if n_classes == 2:
-      head = head_lib._binary_logistic_head_with_sigmoid_cross_entropy_loss(  # pylint: disable=protected-access
-          weight_column=weight_column,
-          label_vocabulary=label_vocabulary)
-    else:
-      head = head_lib._multi_class_head_with_softmax_cross_entropy_loss(  # pylint: disable=protected-access
-          n_classes, weight_column=weight_column,
-          label_vocabulary=label_vocabulary)
-    def _model_fn(features, labels, mode, config):
-      return _dnn_model_fn(
-          features=features,
-          labels=labels,
-          mode=mode,
-          head=head,
-          hidden_units=hidden_units,
-          feature_columns=tuple(feature_columns or []),
-          optimizer=optimizer,
-          activation_fn=activation_fn,
-          dropout=dropout,
-          input_layer_partitioner=input_layer_partitioner,
-          config=config)
+    head = classifier_head(
+        n_classes=n_classes,
+        weight_column=weight_column,
+        label_vocabulary=label_vocabulary)
+
     super(DNNClassifier, self).__init__(
-        model_fn=_model_fn, model_dir=model_dir, config=config)
+        head=head,
+        hidden_units=hidden_units,
+        feature_columns=feature_columns,
+        model_dir=model_dir,
+        optimizer=optimizer,
+        activation_fn=activation_fn,
+        dropout=dropout,
+        input_layer_partitioner=input_layer_partitioner,
+        config=config)
 
-
-class DNNRegressor(estimator.Estimator):
+class DNNRegressor(_DNN):
   """A regressor for TensorFlow DNN models.
 
   Example:
@@ -437,20 +385,17 @@ class DNNRegressor(estimator.Estimator):
         to `min_max_variable_partitioner` with `min_slice_size` 64 << 20.
       config: `RunConfig` object to configure the runtime settings.
     """
-    def _model_fn(features, labels, mode, config):
-      return _dnn_model_fn(
-          features=features,
-          labels=labels,
-          mode=mode,
-          head=head_lib.  # pylint: disable=protected-access
-          _regression_head_with_mean_squared_error_loss(
-              label_dimension=label_dimension, weight_column=weight_column),
-          hidden_units=hidden_units,
-          feature_columns=tuple(feature_columns or []),
-          optimizer=optimizer,
-          activation_fn=activation_fn,
-          dropout=dropout,
-          input_layer_partitioner=input_layer_partitioner,
-          config=config)
+    head = regression_head(
+        label_dimension=label_dimension,
+        weight_column=weight_column)
+
     super(DNNRegressor, self).__init__(
-        model_fn=_model_fn, model_dir=model_dir, config=config)
+        head=head,
+        hidden_units=hidden_units,
+        feature_columns=feature_columns,
+        model_dir=model_dir,
+        optimizer=optimizer,
+        activation_fn=activation_fn,
+        dropout=dropout,
+        input_layer_partitioner=input_layer_partitioner,
+        config=config)

--- a/tensorflow/python/estimator/canned/dnn_linear_combined.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined.py
@@ -23,19 +23,13 @@ import math
 import six
 
 from tensorflow.python.estimator import estimator
+from tensorflow.python.estimator.canned.utils import common_combined_model_fn
+from tensorflow.python.estimator.canned.utils import regression_head
+from tensorflow.python.estimator.canned.utils import classifier_head
 from tensorflow.python.estimator.canned import dnn
-from tensorflow.python.estimator.canned import head as head_lib
 from tensorflow.python.estimator.canned import linear
-from tensorflow.python.estimator.canned import optimizers
-from tensorflow.python.framework import ops
-from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import nn
-from tensorflow.python.ops import partitioned_variables
-from tensorflow.python.ops import state_ops
-from tensorflow.python.ops import variable_scope
-from tensorflow.python.summary import summary
 from tensorflow.python.training import sync_replicas_optimizer
-from tensorflow.python.training import training_util
 
 # The default learning rates are a historical artifact of the initial
 # implementation.
@@ -65,158 +59,82 @@ def _linear_learning_rate(num_linear_feature_columns):
   Returns:
     A float.
   """
-  default_learning_rate = 1. / math.sqrt(num_linear_feature_columns)
-  return min(_LINEAR_LEARNING_RATE, default_learning_rate)
+  if num_linear_feature_columns:
+    default_learning_rate = 1. / math.sqrt(num_linear_feature_columns)
+    return min(_LINEAR_LEARNING_RATE, default_learning_rate)
 
-
-def _add_layer_summary(value, tag):
-  summary.scalar('%s/fraction_of_zero_values' % tag, nn.zero_fraction(value))
-  summary.histogram('%s/activation' % tag, value)
-
-
-def _dnn_linear_combined_model_fn(
-    features, labels, mode, head,
-    linear_feature_columns=None, linear_optimizer='Ftrl',
-    dnn_feature_columns=None, dnn_optimizer='Adagrad', dnn_hidden_units=None,
-    dnn_activation_fn=nn.relu, dnn_dropout=None,
-    input_layer_partitioner=None, config=None):
-  """Deep Neural Net and Linear combined model_fn.
-
-  Args:
-    features: dict of `Tensor`.
-    labels: `Tensor` of shape [batch_size, 1] or [batch_size] labels of dtype
-      `int32` or `int64` in the range `[0, n_classes)`.
-    mode: Defines whether this is training, evaluation or prediction.
-      See `ModeKeys`.
-    head: A `Head` instance.
-    linear_feature_columns: An iterable containing all the feature columns used
-      by the Linear model.
-    linear_optimizer: string, `Optimizer` object, or callable that defines the
-      optimizer to use for training the Linear model. Defaults to the Ftrl
-      optimizer.
-    dnn_feature_columns: An iterable containing all the feature columns used by
-      the DNN model.
-    dnn_optimizer: string, `Optimizer` object, or callable that defines the
-      optimizer to use for training the DNN model. Defaults to the Adagrad
-      optimizer.
-    dnn_hidden_units: List of hidden units per DNN layer.
-    dnn_activation_fn: Activation function applied to each DNN layer. If `None`,
-      will use `tf.nn.relu`.
-    dnn_dropout: When not `None`, the probability we will drop out a given DNN
-      coordinate.
-    input_layer_partitioner: Partitioner for input layer.
-    config: `RunConfig` object to configure the runtime settings.
-
-  Returns:
-    `ModelFnOps`
-
-  Raises:
-    ValueError: If both `linear_feature_columns` and `dnn_features_columns`
-      are empty at the same time, or `input_layer_partitioner` is missing,
-      or features has the wrong type.
+class _DNNLinearCombined(estimator.Estimator):
+  """The common functionality for TensorFlow Linear and DNN combined
+     classificator and regressor
   """
-  if not isinstance(features, dict):
-    raise ValueError('features should be a dictionary of `Tensor`s. '
-                     'Given type: {}'.format(type(features)))
-  if not linear_feature_columns and not dnn_feature_columns:
-    raise ValueError(
-        'Either linear_feature_columns or dnn_feature_columns must be defined.')
-  num_ps_replicas = config.num_ps_replicas if config else 0
-  input_layer_partitioner = input_layer_partitioner or (
-      partitioned_variables.min_max_variable_partitioner(
-          max_partitions=num_ps_replicas,
-          min_slice_size=64 << 20))
+  def __init__(self,
+               head,
+               model_dir=None,
+               linear_feature_columns=None,
+               linear_optimizer='Ftrl',
+               dnn_feature_columns=None,
+               dnn_optimizer='Adagrad',
+               dnn_hidden_units=None,
+               dnn_activation_fn=nn.relu,
+               dnn_dropout=None,
+               partitioner=None,
+               input_layer_partitioner=None,
+               config=None):
+    """Initializes a _DNNLinearCombined instance."""
+    linear_feature_columns = linear_feature_columns or []
+    dnn_feature_columns = dnn_feature_columns or []
 
-  # Build DNN Logits.
-  dnn_parent_scope = 'dnn'
+    self._feature_columns = (
+        list(linear_feature_columns) + list(dnn_feature_columns))
+    if not self._feature_columns:
+      raise ValueError('Either linear_feature_columns or dnn_feature_columns '
+                       'must be defined.')
 
-  if not dnn_feature_columns:
-    dnn_logits = None
-  else:
-    dnn_optimizer = optimizers.get_optimizer_instance(
-        dnn_optimizer, learning_rate=_DNN_LEARNING_RATE)
-    _check_no_sync_replicas_optimizer(dnn_optimizer)
-    if not dnn_hidden_units:
+    if dnn_feature_columns and not dnn_hidden_units:
       raise ValueError(
           'dnn_hidden_units must be defined when dnn_feature_columns is '
           'specified.')
-    dnn_partitioner = (
-        partitioned_variables.min_max_variable_partitioner(
-            max_partitions=num_ps_replicas))
-    with variable_scope.variable_scope(
-        dnn_parent_scope,
-        values=tuple(six.itervalues(features)),
-        partitioner=dnn_partitioner):
 
+    # set default learning rates if necessary
+    dnn_learning_rate, linear_learning_rate = None, None
+    if isinstance(dnn_optimizer, six.string_types):
+      dnn_learning_rate = _DNN_LEARNING_RATE
+    if isinstance(linear_optimizer, six.string_types):
+      linear_learning_rate = _linear_learning_rate(len(linear_feature_columns))
+
+    dnn_logit_fn, linear_logit_fn = None, None
+    if dnn_feature_columns:
       dnn_logit_fn = dnn._dnn_logit_fn_builder(  # pylint: disable=protected-access
           units=head.logits_dimension,
           hidden_units=dnn_hidden_units,
           feature_columns=dnn_feature_columns,
           activation_fn=dnn_activation_fn,
-          dropout=dnn_dropout,
-          input_layer_partitioner=input_layer_partitioner)
-      dnn_logits = dnn_logit_fn(features=features, mode=mode)
+          dropout=dnn_dropout)
 
-  linear_parent_scope = 'linear'
-
-  if not linear_feature_columns:
-    linear_logits = None
-  else:
-    linear_optimizer = optimizers.get_optimizer_instance(
-        linear_optimizer,
-        learning_rate=_linear_learning_rate(len(linear_feature_columns)))
-    _check_no_sync_replicas_optimizer(linear_optimizer)
-    with variable_scope.variable_scope(
-        linear_parent_scope,
-        values=tuple(six.itervalues(features)),
-        partitioner=input_layer_partitioner) as scope:
-      logit_fn = linear._linear_logit_fn_builder(  # pylint: disable=protected-access
+    if linear_feature_columns:
+      linear_logit_fn = linear._linear_logit_fn_builder(  # pylint: disable=protected-access
           units=head.logits_dimension,
           feature_columns=linear_feature_columns)
-      linear_logits = logit_fn(features=features)
-      _add_layer_summary(linear_logits, scope.name)
 
-  # Combine logits and build full model.
-  if dnn_logits is not None and linear_logits is not None:
-    logits = dnn_logits + linear_logits
-  elif dnn_logits is not None:
-    logits = dnn_logits
-  else:
-    logits = linear_logits
+    def _model_fn(features, labels, mode, config):
+      return common_combined_model_fn(
+          features=features,
+          labels=labels,
+          mode=mode,
+          head=head,
+          name=('dnn', 'linear'),
+          logit_fn=(dnn_logit_fn, linear_logit_fn),
+          optimizer=(dnn_optimizer, linear_optimizer),
+          learning_rate=(dnn_learning_rate, linear_learning_rate),
+          partitioner=partitioner,
+          input_layer_partitioner=input_layer_partitioner,
+          config=config)
 
-  def _train_op_fn(loss):
-    """Returns the op to optimize the loss."""
-    train_ops = []
-    global_step = training_util.get_global_step()
-    if dnn_logits is not None:
-      train_ops.append(
-          dnn_optimizer.minimize(
-              loss,
-              var_list=ops.get_collection(
-                  ops.GraphKeys.TRAINABLE_VARIABLES,
-                  scope=dnn_parent_scope)))
-    if linear_logits is not None:
-      train_ops.append(
-          linear_optimizer.minimize(
-              loss,
-              var_list=ops.get_collection(
-                  ops.GraphKeys.TRAINABLE_VARIABLES,
-                  scope=linear_parent_scope)))
-
-    train_op = control_flow_ops.group(*train_ops)
-    with ops.control_dependencies([train_op]):
-      with ops.colocate_with(global_step):
-        return state_ops.assign_add(global_step, 1)
-
-  return head.create_estimator_spec(
-      features=features,
-      mode=mode,
-      labels=labels,
-      train_op_fn=_train_op_fn,
-      logits=logits)
+    super(_DNNLinearCombined, self).__init__(
+        model_fn=_model_fn, model_dir=model_dir, config=config)
 
 
-class DNNLinearCombinedClassifier(estimator.Estimator):
+class DNNLinearCombinedClassifier(_DNNLinearCombined):
   """An estimator for TensorFlow Linear and DNN joined classification models.
 
   Note: This estimator is also known as wide-n-deep.
@@ -291,9 +209,10 @@ class DNNLinearCombinedClassifier(estimator.Estimator):
                n_classes=2,
                weight_column=None,
                label_vocabulary=None,
+               partitioner=None,
                input_layer_partitioner=None,
                config=None):
-    """Initializes a DNNLinearCombinedClassifier instance.
+    """Initializes a _DNNLinearCombined instance.
 
     Args:
       model_dir: Directory to save model parameters, graph and etc. This can
@@ -339,43 +258,27 @@ class DNNLinearCombinedClassifier(estimator.Estimator):
       ValueError: If both linear_feature_columns and dnn_features_columns are
         empty at the same time.
     """
-    linear_feature_columns = linear_feature_columns or []
-    dnn_feature_columns = dnn_feature_columns or []
-    self._feature_columns = (
-        list(linear_feature_columns) + list(dnn_feature_columns))
-    if not self._feature_columns:
-      raise ValueError('Either linear_feature_columns or dnn_feature_columns '
-                       'must be defined.')
-    if n_classes == 2:
-      head = head_lib._binary_logistic_head_with_sigmoid_cross_entropy_loss(  # pylint: disable=protected-access
-          weight_column=weight_column,
-          label_vocabulary=label_vocabulary)
-    else:
-      head = head_lib._multi_class_head_with_softmax_cross_entropy_loss(  # pylint: disable=protected-access
-          n_classes,
-          weight_column=weight_column,
-          label_vocabulary=label_vocabulary)
-    def _model_fn(features, labels, mode, config):
-      return _dnn_linear_combined_model_fn(
-          features=features,
-          labels=labels,
-          mode=mode,
-          head=head,
-          linear_feature_columns=linear_feature_columns,
-          linear_optimizer=linear_optimizer,
-          dnn_feature_columns=dnn_feature_columns,
-          dnn_optimizer=dnn_optimizer,
-          dnn_hidden_units=dnn_hidden_units,
-          dnn_activation_fn=dnn_activation_fn,
-          dnn_dropout=dnn_dropout,
-          input_layer_partitioner=input_layer_partitioner,
-          config=config)
+    head = classifier_head(
+        n_classes=n_classes,
+        weight_column=weight_column,
+        label_vocabulary=label_vocabulary)
 
     super(DNNLinearCombinedClassifier, self).__init__(
-        model_fn=_model_fn, model_dir=model_dir, config=config)
+        head=head,
+        model_dir=model_dir,
+        linear_feature_columns=linear_feature_columns,
+        linear_optimizer=linear_optimizer,
+        dnn_feature_columns=dnn_feature_columns,
+        dnn_optimizer=dnn_optimizer,
+        dnn_hidden_units=dnn_hidden_units,
+        dnn_activation_fn=dnn_activation_fn,
+        dnn_dropout=dnn_dropout,
+        partitioner=partitioner,
+        input_layer_partitioner=input_layer_partitioner,
+        config=config)
 
 
-class DNNLinearCombinedRegressor(estimator.Estimator):
+class DNNLinearCombinedRegressor(_DNNLinearCombined):
   """An estimator for TensorFlow Linear and DNN joined models for regression.
 
   Note: This estimator is also known as wide-n-deep.
@@ -449,6 +352,7 @@ class DNNLinearCombinedRegressor(estimator.Estimator):
                dnn_dropout=None,
                label_dimension=1,
                weight_column=None,
+               partitioner=None,
                input_layer_partitioner=None,
                config=None):
     """Initializes a DNNLinearCombinedRegressor instance.
@@ -491,31 +395,19 @@ class DNNLinearCombinedRegressor(estimator.Estimator):
       ValueError: If both linear_feature_columns and dnn_features_columns are
         empty at the same time.
     """
-    linear_feature_columns = linear_feature_columns or []
-    dnn_feature_columns = dnn_feature_columns or []
-    self._feature_columns = (
-        list(linear_feature_columns) + list(dnn_feature_columns))
-    if not self._feature_columns:
-      raise ValueError('Either linear_feature_columns or dnn_feature_columns '
-                       'must be defined.')
-
-    def _model_fn(features, labels, mode, config):
-      return _dnn_linear_combined_model_fn(
-          features=features,
-          labels=labels,
-          mode=mode,
-          head=head_lib.  # pylint: disable=protected-access
-          _regression_head_with_mean_squared_error_loss(
-              label_dimension=label_dimension, weight_column=weight_column),
-          linear_feature_columns=linear_feature_columns,
-          linear_optimizer=linear_optimizer,
-          dnn_feature_columns=dnn_feature_columns,
-          dnn_optimizer=dnn_optimizer,
-          dnn_hidden_units=dnn_hidden_units,
-          dnn_activation_fn=dnn_activation_fn,
-          dnn_dropout=dnn_dropout,
-          input_layer_partitioner=input_layer_partitioner,
-          config=config)
+    head = regression_head(label_dimension=label_dimension,
+                           weight_column=weight_column)
 
     super(DNNLinearCombinedRegressor, self).__init__(
-        model_fn=_model_fn, model_dir=model_dir, config=config)
+        head=head,
+        model_dir=model_dir,
+        linear_feature_columns=linear_feature_columns,
+        linear_optimizer=linear_optimizer,
+        dnn_feature_columns=dnn_feature_columns,
+        dnn_optimizer=dnn_optimizer,
+        dnn_hidden_units=dnn_hidden_units,
+        dnn_activation_fn=dnn_activation_fn,
+        dnn_dropout=dnn_dropout,
+        partitioner=partitioner,
+        input_layer_partitioner=input_layer_partitioner,
+        config=config)

--- a/tensorflow/python/estimator/canned/dnn_linear_combined_test.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined_test.py
@@ -26,7 +26,9 @@ import six
 
 from tensorflow.core.example import example_pb2
 from tensorflow.core.example import feature_pb2
+from tensorflow.python.estimator.canned import dnn
 from tensorflow.python.estimator.canned import dnn_linear_combined
+from tensorflow.python.estimator.canned.utils import common_combined_model_fn
 from tensorflow.python.estimator.canned import dnn_testing_utils
 from tensorflow.python.estimator.canned import linear_testing_utils
 from tensorflow.python.estimator.canned import prediction_keys
@@ -36,7 +38,6 @@ from tensorflow.python.estimator.inputs import pandas_io
 from tensorflow.python.feature_column import feature_column
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
-from tensorflow.python.ops import nn
 from tensorflow.python.ops import parsing_ops
 from tensorflow.python.ops import variables as variables_lib
 from tensorflow.python.platform import gfile
@@ -62,31 +63,30 @@ class DNNOnlyModelFnTest(dnn_testing_utils.BaseDNNModelFnTest, test.TestCase):
 
   def __init__(self, methodName='runTest'):  # pylint: disable=invalid-name
     test.TestCase.__init__(self, methodName)
-    dnn_testing_utils.BaseDNNModelFnTest.__init__(self, self._dnn_only_model_fn)
+    dnn_testing_utils.BaseDNNModelFnTest.__init__(
+        self,
+        self._dnn_only_model_fn,
+        dnn._dnn_logit_fn_builder) # pylint: disable=protected-access
 
   def _dnn_only_model_fn(self,
+                         name,
                          features,
                          labels,
                          mode,
                          head,
-                         hidden_units,
-                         feature_columns,
+                         logit_fn,
                          optimizer='Adagrad',
-                         activation_fn=nn.relu,
-                         dropout=None,
                          input_layer_partitioner=None,
                          config=None):
-    return dnn_linear_combined._dnn_linear_combined_model_fn(
+
+    return common_combined_model_fn(
+        name=name,
         features=features,
         labels=labels,
         mode=mode,
         head=head,
-        linear_feature_columns=[],
-        dnn_hidden_units=hidden_units,
-        dnn_feature_columns=feature_columns,
-        dnn_optimizer=optimizer,
-        dnn_activation_fn=activation_fn,
-        dnn_dropout=dropout,
+        logit_fn=logit_fn,
+        optimizer=optimizer,
         input_layer_partitioner=input_layer_partitioner,
         config=config)
 
@@ -105,7 +105,7 @@ def _linear_regressor_fn(feature_columns,
       linear_optimizer=optimizer,
       label_dimension=label_dimension,
       weight_column=weight_column,
-      input_layer_partitioner=partitioner,
+      partitioner=partitioner,
       config=config)
 
 

--- a/tensorflow/python/estimator/canned/dnn_test.py
+++ b/tensorflow/python/estimator/canned/dnn_test.py
@@ -26,6 +26,7 @@ import six
 
 from tensorflow.core.example import example_pb2
 from tensorflow.core.example import feature_pb2
+from tensorflow.python.estimator.canned.utils import common_model_fn
 from tensorflow.python.estimator.canned import dnn
 from tensorflow.python.estimator.canned import dnn_testing_utils
 from tensorflow.python.estimator.canned import prediction_keys
@@ -62,7 +63,9 @@ class DNNModelFnTest(dnn_testing_utils.BaseDNNModelFnTest, test.TestCase):
 
   def __init__(self, methodName='runTest'):  # pylint: disable=invalid-name
     test.TestCase.__init__(self, methodName)
-    dnn_testing_utils.BaseDNNModelFnTest.__init__(self, dnn._dnn_model_fn)
+    dnn_testing_utils.BaseDNNModelFnTest.__init__(self,
+                                                  common_model_fn,
+                                                  dnn._dnn_logit_fn_builder)
 
 
 class DNNLogitFnTest(dnn_testing_utils.BaseDNNLogitFnTest, test.TestCase):

--- a/tensorflow/python/estimator/canned/dnn_testing_utils.py
+++ b/tensorflow/python/estimator/canned/dnn_testing_utils.py
@@ -220,8 +220,9 @@ def mock_optimizer(testcase, hidden_units, expected_loss=None):
 class BaseDNNModelFnTest(object):
   """Tests that _dnn_model_fn passes expected logits to mock head."""
 
-  def __init__(self, dnn_model_fn):
+  def __init__(self, dnn_model_fn, dnn_logit_fn_builder):
     self._dnn_model_fn = dnn_model_fn
+    self._dnn_logit_fn_builder = dnn_logit_fn_builder
 
   def setUp(self):
     self._model_dir = tempfile.mkdtemp()
@@ -241,17 +242,22 @@ class BaseDNNModelFnTest(object):
           hidden_units=hidden_units,
           logits_dimension=logits_dimension,
           expected_logits=expected_logits)
+
+      logit_fn = self._dnn_logit_fn_builder(
+          units=head.logits_dimension,
+          hidden_units=hidden_units,
+          feature_columns=[feature_column.numeric_column(
+              'age', shape=np.array(inputs).shape[1:])])
+
       estimator_spec = self._dnn_model_fn(
+          name='dnn',
           features={'age': constant_op.constant(inputs)},
           labels=constant_op.constant([[1]]),
           mode=mode,
           head=head,
-          hidden_units=hidden_units,
-          feature_columns=[
-              feature_column.numeric_column(
-                  'age', shape=np.array(inputs).shape[1:])
-          ],
+          logit_fn=logit_fn,
           optimizer=mock_optimizer(self, hidden_units))
+
       with monitored_session.MonitoredTrainingSession(
           checkpoint_dir=self._model_dir) as sess:
         if mode == model_fn.ModeKeys.TRAIN:
@@ -428,7 +434,17 @@ class BaseDNNModelFnTest(object):
             hidden_units=hidden_units,
             logits_dimension=logits_dimension,
             expected_logits=expected_logits)
+
+        logit_fn = self._dnn_logit_fn_builder(
+            units=head.logits_dimension,
+            hidden_units=hidden_units,
+            feature_columns=[
+                feature_column.numeric_column('age'),
+                feature_column.numeric_column('height')
+            ])
+
         estimator_spec = self._dnn_model_fn(
+            name='dnn',
             features={
                 'age': constant_op.constant(inputs[0]),
                 'height': constant_op.constant(inputs[1])
@@ -436,12 +452,9 @@ class BaseDNNModelFnTest(object):
             labels=constant_op.constant([[1]]),
             mode=mode,
             head=head,
-            hidden_units=hidden_units,
-            feature_columns=[
-                feature_column.numeric_column('age'),
-                feature_column.numeric_column('height')
-            ],
+            logit_fn=logit_fn,
             optimizer=mock_optimizer(self, hidden_units))
+
         with monitored_session.MonitoredTrainingSession(
             checkpoint_dir=self._model_dir) as sess:
           if mode == model_fn.ModeKeys.TRAIN:
@@ -467,17 +480,23 @@ class BaseDNNModelFnTest(object):
           hidden_units=hidden_units,
           logits_dimension=logits_dimension,
           expected_logits=expected_logits)
+
+      logit_fn = self._dnn_logit_fn_builder(
+          units=head.logits_dimension,
+          hidden_units=hidden_units,
+          feature_columns=[
+              feature_column.numeric_column(
+                  'age', shape=np.array(inputs).shape[1:])
+          ])
+
       with self.assertRaisesRegexp(ValueError, 'features should be a dict'):
         self._dnn_model_fn(
+            name='dnn',
             features=constant_op.constant(inputs),
             labels=constant_op.constant([[1]]),
             mode=model_fn.ModeKeys.TRAIN,
             head=head,
-            hidden_units=hidden_units,
-            feature_columns=[
-                feature_column.numeric_column(
-                    'age', shape=np.array(inputs).shape[1:])
-            ],
+            logit_fn=logit_fn,
             optimizer=mock_optimizer(self, hidden_units))
 
 
@@ -516,10 +535,11 @@ class BaseDNNLogitFnTest(object):
                     'age', shape=np.array(inputs).shape[1:])
             ],
             activation_fn=nn.relu,
-            dropout=None,
-            input_layer_partitioner=input_layer_partitioner)
+            dropout=None)
         logits = logit_fn(
-            features={'age': constant_op.constant(inputs)}, mode=mode)
+            features={'age': constant_op.constant(inputs)},
+            mode=mode,
+            input_layer_partitioner=input_layer_partitioner)
         with monitored_session.MonitoredTrainingSession(
             checkpoint_dir=self._model_dir) as sess:
           if multi_logit:
@@ -731,14 +751,14 @@ class BaseDNNLogitFnTest(object):
                   feature_column.numeric_column('height')
               ],
               activation_fn=nn.relu,
-              dropout=None,
-              input_layer_partitioner=input_layer_partitioner)
+              dropout=None)
           logits = logit_fn(
               features={
                   'age': constant_op.constant(inputs[0]),
                   'height': constant_op.constant(inputs[1])
               },
-              mode=mode)
+              mode=mode,
+              input_layer_partitioner=input_layer_partitioner)
           with monitored_session.MonitoredTrainingSession(
               checkpoint_dir=self._model_dir) as sess:
             self.assertAllClose(expected_logits, sess.run(logits))
@@ -1199,8 +1219,9 @@ def _assert_checkpoint(
 
   # Hidden layer weights.
   prev_layer_units = input_units
-  for i in range(len(hidden_units)):
-    layer_units = hidden_units[i]
+#  for i in range(len(hidden_units)):
+  #  layer_units = hidden_units[i]
+  for i, layer_units in enumerate(hidden_units):
     testcase.assertAllEqual(
         (prev_layer_units, layer_units),
         shapes[HIDDEN_WEIGHTS_NAME_PATTERN % i])

--- a/tensorflow/python/estimator/canned/head.py
+++ b/tensorflow/python/estimator/canned/head.py
@@ -21,14 +21,13 @@ from __future__ import print_function
 import abc
 import collections
 
-import collections
 import six
 
 from tensorflow.python.estimator import model_fn
 from tensorflow.python.estimator.canned import metric_keys
 from tensorflow.python.estimator.canned import prediction_keys
 from tensorflow.python.estimator.export import export_output
-from tensorflow.python.feature_column import feature_column as feature_column_lib
+from tensorflow.python.feature_column import feature_column as feature_column_lib #pylint: disable=line-too-long
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor

--- a/tensorflow/python/estimator/canned/head_test.py
+++ b/tensorflow/python/estimator/canned/head_test.py
@@ -28,7 +28,7 @@ from tensorflow.python.estimator.canned import head as head_lib
 from tensorflow.python.estimator.canned import metric_keys
 from tensorflow.python.estimator.canned import prediction_keys
 from tensorflow.python.estimator.inputs import numpy_io
-from tensorflow.python.feature_column import feature_column as feature_column_lib
+from tensorflow.python.feature_column import feature_column as feature_column_lib #pylint: disable=line-too-long
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors

--- a/tensorflow/python/estimator/canned/linear.py
+++ b/tensorflow/python/estimator/canned/linear.py
@@ -18,29 +18,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import math
-
-import six
-
 from tensorflow.python.estimator import estimator
-from tensorflow.python.estimator.canned import head as head_lib
-from tensorflow.python.estimator.canned import optimizers
-from tensorflow.python.feature_column import feature_column as feature_column_lib
-from tensorflow.python.ops import partitioned_variables
-from tensorflow.python.ops import variable_scope
-from tensorflow.python.training import ftrl
-from tensorflow.python.training import training_util
-
+from tensorflow.python.feature_column import feature_column as feature_column_lib #pylint: disable=line-too-long
+from tensorflow.python.estimator.canned.utils import common_model_fn
+from tensorflow.python.estimator.canned.utils import classifier_head
+from tensorflow.python.estimator.canned.utils import regression_head
+from tensorflow.python.estimator.canned.utils import add_layer_summary
 
 # The default learning rate of 0.2 is a historical artifact of the initial
 # implementation, but seems a reasonable choice.
 _LEARNING_RATE = 0.2
-
-
-def _get_default_optimizer(feature_columns):
-  learning_rate = min(_LEARNING_RATE, 1.0 / math.sqrt(len(feature_columns)))
-  return ftrl.FtrlOptimizer(learning_rate=learning_rate)
-
 
 def _linear_logit_fn_builder(units, feature_columns):
   """Function builder for a linear logit_fn.
@@ -55,7 +42,7 @@ def _linear_logit_fn_builder(units, feature_columns):
 
   """
 
-  def linear_logit_fn(features):
+  def linear_logit_fn(features, mode=None, input_layer_partitioner=None): #pylint: disable=unused-argument
     """Linear model logit_fn.
 
     Args:
@@ -66,72 +53,50 @@ def _linear_logit_fn_builder(units, feature_columns):
     Returns:
       A `Tensor` representing the logits.
     """
-    return feature_column_lib.linear_model(
+    logits = feature_column_lib.linear_model(
         features=features, feature_columns=feature_columns, units=units)
+    add_layer_summary(logits, 'linear')
+    return logits
+
 
   return linear_logit_fn
 
 
-def _linear_model_fn(features, labels, mode, head, feature_columns, optimizer,
-                     partitioner, config):
-  """A model_fn for linear models that use a gradient-based optimizer.
-
-  Args:
-    features: dict of `Tensor`.
-    labels: `Tensor` of shape `[batch_size, logits_dimension]`.
-    mode: Defines whether this is training, evaluation or prediction.
-      See `ModeKeys`.
-    head: A `Head` instance.
-    feature_columns: An iterable containing all the feature columns used by
-      the model.
-    optimizer: string, `Optimizer` object, or callable that defines the
-      optimizer to use for training. If `None`, will use a FTRL optimizer.
-    partitioner: Partitioner for variables.
-    config: `RunConfig` object to configure the runtime settings.
-
-  Returns:
-    An `EstimatorSpec` instance.
-
-  Raises:
-    ValueError: mode or params are invalid, or features has the wrong type.
-  """
-  if not isinstance(features, dict):
-    raise ValueError('features should be a dictionary of `Tensor`s. '
-                     'Given type: {}'.format(type(features)))
-  optimizer = optimizers.get_optimizer_instance(
-      optimizer or _get_default_optimizer(feature_columns),
-      learning_rate=_LEARNING_RATE)
-  num_ps_replicas = config.num_ps_replicas if config else 0
-
-  partitioner = partitioner or (
-      partitioned_variables.min_max_variable_partitioner(
-          max_partitions=num_ps_replicas,
-          min_slice_size=64 << 20))
-
-  with variable_scope.variable_scope(
-      'linear',
-      values=tuple(six.itervalues(features)),
-      partitioner=partitioner):
+class _Linear(estimator.Estimator):
+  """Common functionality for canned Linear models"""
+  def __init__(self,
+               head,
+               feature_columns,
+               model_dir,
+               optimizer,
+               config,
+               partitioner):
+    """Initializes a `_Linear` instance."""
 
     logit_fn = _linear_logit_fn_builder(
-        units=head.logits_dimension, feature_columns=feature_columns)
-    logits = logit_fn(features=features)
+        units=head.logits_dimension,
+        feature_columns=tuple(feature_columns or []))
 
-    def _train_op_fn(loss):
-      """Returns the op to optimize the loss."""
-      return optimizer.minimize(
-          loss,
-          global_step=training_util.get_global_step())
+    def _model_fn(features, labels, mode, config):
+      return common_model_fn(
+          name='linear',
+          features=features,
+          labels=labels,
+          mode=mode,
+          head=head,
+          logit_fn=logit_fn,
+          optimizer=optimizer,
+          learning_rate=_LEARNING_RATE,
+          partitioner=partitioner,
+          config=config)
 
-    return head.create_estimator_spec(
-        features=features,
-        mode=mode,
-        labels=labels,
-        train_op_fn=_train_op_fn,
-        logits=logits)
+    super(_Linear, self).__init__(
+        model_fn=_model_fn,
+        model_dir=model_dir,
+        config=config)
 
 
-class LinearClassifier(estimator.Estimator):
+class LinearClassifier(_Linear):
   """Linear classifier model.
 
   Train a linear model to classify instances into one of multiple possible
@@ -231,31 +196,21 @@ class LinearClassifier(estimator.Estimator):
     Raises:
       ValueError: if n_classes < 2.
     """
-    if n_classes == 2:
-      head = head_lib._binary_logistic_head_with_sigmoid_cross_entropy_loss(  # pylint: disable=protected-access
-          weight_column=weight_column,
-          label_vocabulary=label_vocabulary)
-    else:
-      head = head_lib._multi_class_head_with_softmax_cross_entropy_loss(  # pylint: disable=protected-access
-          n_classes, weight_column=weight_column,
-          label_vocabulary=label_vocabulary)
-    def _model_fn(features, labels, mode, config):
-      return _linear_model_fn(
-          features=features,
-          labels=labels,
-          mode=mode,
-          head=head,
-          feature_columns=tuple(feature_columns or []),
-          optimizer=optimizer,
-          partitioner=partitioner,
-          config=config)
+    head = classifier_head(
+        n_classes=n_classes,
+        weight_column=weight_column,
+        label_vocabulary=label_vocabulary)
+
     super(LinearClassifier, self).__init__(
-        model_fn=_model_fn,
+        head=head,
+        feature_columns=feature_columns,
         model_dir=model_dir,
-        config=config)
+        optimizer=optimizer,
+        config=config,
+        partitioner=partitioner)
 
 
-class LinearRegressor(estimator.Estimator):
+class LinearRegressor(_Linear):
   """An estimator for TensorFlow Linear regression problems.
 
   Train a linear regression model to predict label value given observation of
@@ -331,19 +286,14 @@ class LinearRegressor(estimator.Estimator):
       config: `RunConfig` object to configure the runtime settings.
       partitioner: Optional. Partitioner for input layer.
     """
-    head = head_lib._regression_head_with_mean_squared_error_loss(  # pylint: disable=protected-access
-        label_dimension=label_dimension, weight_column=weight_column)
-    def _model_fn(features, labels, mode, config):
-      return _linear_model_fn(
-          features=features,
-          labels=labels,
-          mode=mode,
-          head=head,
-          feature_columns=tuple(feature_columns or []),
-          optimizer=optimizer,
-          partitioner=partitioner,
-          config=config)
+    head = regression_head(
+        label_dimension=label_dimension,
+        weight_column=weight_column)
+
     super(LinearRegressor, self).__init__(
-        model_fn=_model_fn,
+        head=head,
+        feature_columns=feature_columns,
         model_dir=model_dir,
-        config=config)
+        optimizer=optimizer,
+        config=config,
+        partitioner=partitioner)

--- a/tensorflow/python/estimator/canned/linear_testing_utils.py
+++ b/tensorflow/python/estimator/canned/linear_testing_utils.py
@@ -36,7 +36,7 @@ from tensorflow.python.estimator.canned import metric_keys
 from tensorflow.python.estimator.export import export
 from tensorflow.python.estimator.inputs import numpy_io
 from tensorflow.python.estimator.inputs import pandas_io
-from tensorflow.python.feature_column import feature_column as feature_column_lib
+from tensorflow.python.feature_column import feature_column as feature_column_lib #pylint: disable=line-too-long
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor

--- a/tensorflow/python/estimator/canned/utils.py
+++ b/tensorflow/python/estimator/canned/utils.py
@@ -1,0 +1,261 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Common functionality for canned estimators."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import six
+
+from tensorflow.python.estimator.canned import head as head_lib
+from tensorflow.python.estimator.canned.optimizers import get_optimizer_instance
+from tensorflow.python.ops import partitioned_variables
+from tensorflow.python.ops import variable_scope
+from tensorflow.python.training import training_util
+from tensorflow.python.summary import summary
+from tensorflow.python.ops import nn
+from tensorflow.python.training import sync_replicas_optimizer
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import state_ops
+
+
+def add_layer_summary(value, tag):
+  summary.scalar('%s/fraction_of_zero_values' % tag, nn.zero_fraction(value))
+  summary.histogram('%s/activation' % tag, value)
+
+def _check_no_sync_replicas_optimizer(optimizer):
+  if isinstance(optimizer, sync_replicas_optimizer.SyncReplicasOptimizer):
+    raise ValueError(
+        'SyncReplicasOptimizer does not support multi optimizers case. '
+        'Therefore, it is not supported in DNNLinearCombined model. '
+        'If you want to use this optimizer, please use either DNN or Linear '
+        'model.')
+
+def common_model_fn(
+    features, labels, mode, head,
+    name, logit_fn, optimizer, learning_rate=None,
+    input_layer_partitioner=None, partitioner=None, config=None):
+  """Common model function for DNN and Linear canned models.
+
+  Args:
+    features: dict of `Tensor`.
+    labels: `Tensor` of shape [batch_size, 1] or [batch_size] labels of dtype
+      `int32` or `int64` in the range `[0, n_classes)`.
+    mode: Defines whether this is training, evaluation or prediction.
+      See `ModeKeys`.
+    head: A `Head` instance.
+    name: Name of the model.
+    logit_fn: Function with the following signature:
+      `logit_fn(features, mode, input_layer_partitioner)`.
+    learning_rate: Learning rate.
+    optimizer: string, `Optimizer` object, or callable that defines the
+      optimizer to use for training the model
+    input_layer_partitioner: Partitioner for input layer.
+    partitioner: Partitioner of variables used by the linear model.
+    config: `RunConfig` object to configure the runtime settings.
+
+  Returns:
+    `ModelFnOps`
+
+  Raises:
+    ValueError: If `features` is not a dictionary of `Tensor`,
+     or `name` is not a string type.
+  """
+  if not isinstance(features, dict):
+    raise ValueError('features should be a dictionary of `Tensor`s. '
+                     'Given type: {}'.format(type(features)))
+
+  if not isinstance(name, six.string_types):
+    raise ValueError('Name must be a string type')
+
+  return common_combined_model_fn(
+      features=features,
+      labels=labels,
+      mode=mode,
+      head=head,
+      name=[name],
+      logit_fn=[logit_fn],
+      optimizer=[optimizer],
+      learning_rate=[learning_rate],
+      input_layer_partitioner=input_layer_partitioner,
+      partitioner=partitioner,
+      config=config)
+
+def common_combined_model_fn(
+    features, labels, mode, head,
+    name, logit_fn, optimizer, learning_rate=None, input_layer_partitioner=None,
+    partitioner=None, config=None):
+  """Common model function for DNN and Linear combined models.
+
+  Args:
+    features: dict of `Tensor`.
+    labels: `Tensor` of shape [batch_size, 1] or [batch_size] labels of dtype
+      `int32` or `int64` in the range `[0, n_classes)`.
+    mode: Defines whether this is training, evaluation or prediction.
+      See `ModeKeys`.
+    head: A `Head` instance.
+    name: A collection of strings used for variables scopes.
+    logit_fn: A collection of logit functions (e.g. DNN and/or Linear logit
+              functions).
+    learning_rate: A collection of learning rates used by optimizers.
+    optimizer: A collection of:
+      string, `Optimizer` object, or callable that defines the
+      optimizer to use for training the model
+    input_layer_partitioner: Partitioner for input layer.
+    partitioner: Partitioner of variables used by the linear model.
+    config: `RunConfig` object to configure the runtime settings.
+
+  Returns:
+    `ModelFnOps`
+
+  Raises:
+    ValueError: If both `linear_feature_columns` and `dnn_features_columns`
+      are empty at the same time, or `input_layer_partitioner` is missing,
+      or features has the wrong type.
+  """
+  if not isinstance(features, dict):
+    raise ValueError('features should be a dictionary of `Tensor`s. '
+                     'Given type: {}'.format(type(features)))
+
+  # if name is a string, then assume logit_fn, optimizer and learning_rate
+  # parameters are not collections as well and convert everything to lists
+  if isinstance(name, six.string_types):
+    name = [name]
+    logit_fn = [logit_fn]
+    optimizer = [optimizer]
+    if learning_rate is not None:
+      learning_rate = [learning_rate]
+
+  # check if parameters have the same length (unless learning_rate is None)
+  if not(len(name) == len(logit_fn) and
+         len(logit_fn) == len(optimizer)):
+    raise ValueError('Parameters name, logit_fn and optimizer must have the '
+                     'same length. '
+                     'Given lengths: '
+                     'len(name) = {}\n'
+                     'len(logit_fn) = {}\n'
+                     'len(optimizer) = {}\n'.
+                     format(len(name), len(logit_fn), len(optimizer)))
+
+  # if learning_rate is None, make a list with None values because of zip
+  # function bellow
+  if learning_rate is None:
+    learning_rate = [None] * len(name)
+
+  if not(learning_rate is None or
+         len(learning_rate) == len(optimizer)):
+    raise ValueError('When learning_rate parameter is given, its length must '
+                     'be equal to length of the optimizer parameter. '
+                     'Given lengths are\n'
+                     'len(learning_rate) = {}\n'
+                     'len(optimizer) = {}\n'.format(len(learning_rate),
+                                                    len(optimizer)))
+
+  num_ps_replicas = config.num_ps_replicas if config else 0
+
+  partitioner = partitioner or (
+      partitioned_variables.min_max_variable_partitioner(
+          max_partitions=num_ps_replicas,
+          min_slice_size=64 << 20))
+
+  input_layer_partitioner = input_layer_partitioner or (
+      partitioned_variables.min_max_variable_partitioner(
+          max_partitions=num_ps_replicas,
+          min_slice_size=64 << 20))
+
+  logits = None
+  train_op_params = []
+  for scope, log_fn, opt, lr in zip(name, logit_fn, optimizer, learning_rate):
+    if log_fn:
+      # create optimizer and check for compatibility
+      opt = get_optimizer_instance(opt, learning_rate=lr)
+      _check_no_sync_replicas_optimizer(opt)
+
+      with variable_scope.variable_scope(
+          scope,
+          values=tuple(six.itervalues(features)),
+          partitioner=partitioner):
+
+        cur_logits = log_fn(
+            features=features,
+            mode=mode,
+            input_layer_partitioner=input_layer_partitioner)
+        logits = logits + cur_logits if logits is not None else cur_logits
+        train_op_params.append((opt, scope))
+
+  if logits is None:
+    raise ValueError('At least one item in logit_fns must be non-None.')
+
+  def _train_op_fn(loss):
+    """Returns the op to optimize the loss."""
+    if len(train_op_params) is 1:
+      optimizer, _ = train_op_params[0]
+      return optimizer.minimize(
+          loss,
+          global_step=training_util.get_global_step())
+
+    train_ops = []
+    global_step = training_util.get_global_step()
+    for optimizer, parent_scope in train_op_params:
+      train_ops.append(
+          optimizer.minimize(
+              loss,
+              var_list=ops.get_collection(
+                  ops.GraphKeys.TRAINABLE_VARIABLES,
+                  scope=parent_scope)))
+
+    train_op = control_flow_ops.group(*train_ops)
+    with ops.control_dependencies([train_op]):
+      with ops.colocate_with(global_step):
+        return state_ops.assign_add(global_step, 1)
+
+  return head.create_estimator_spec(
+      features=features,
+      mode=mode,
+      labels=labels,
+      train_op_fn=_train_op_fn,
+      logits=logits)
+
+
+def classifier_head(n_classes, weight_column, label_vocabulary):
+  """
+  Classifier head
+  :param n_classes: number of classes
+  :param weight_column: weights
+  :param label_vocabulary: label vocabulary
+  :return: classifier head
+  """
+  if n_classes == 2:
+    head = head_lib._binary_logistic_head_with_sigmoid_cross_entropy_loss(  # pylint: disable=protected-access
+        weight_column=weight_column,
+        label_vocabulary=label_vocabulary)
+  else:
+    head = head_lib._multi_class_head_with_softmax_cross_entropy_loss(  # pylint: disable=protected-access
+        n_classes, weight_column=weight_column,
+        label_vocabulary=label_vocabulary)
+
+  return head
+
+def regression_head(label_dimension, weight_column):
+  """
+  Regression head
+  :param label_dimension: label dimensions
+  :param weight_column:  weights
+  :return: regression head
+  """
+  return head_lib._regression_head_with_mean_squared_error_loss(  # pylint: disable=protected-access
+      label_dimension=label_dimension, weight_column=weight_column)


### PR DESCRIPTION
Class specific `model_fn()` used by each canned estimator are replaced by `common_model_fn()` and `common_combined_model_fn()` functions and moved to `utils.py`, together with common `classifier_head()` and `regression_head()` functions. Canned estimators are then refactored to use these common functions which simplified their code and increased readability.