### PR TITLE
Relex restrictions on `tf.foldr` and `tf.foldl`

### DIFF
--- a/tensorflow/python/kernel_tests/functional_ops_test.py
+++ b/tensorflow/python/kernel_tests/functional_ops_test.py
@@ -120,6 +120,29 @@ class FunctionalOpsTest(test.TestCase):
         self.assertEqual(len(variables.trainable_variables()), 1)
         self.assertAllEqual(1282, r.eval())
 
+
+  def testFoldr_NoInferShape(self):
+    # Test case for 12019 (foldr)
+    with self.test_session():
+      a = constant_op.constant([[10, 10]])
+      b = constant_op.constant([[20, 20], [30, 30]])
+
+      r = functional_ops.foldr(
+          lambda a, b: array_ops.concat([b, a], axis = 0),
+          [a, b])
+      self.assertAllEqual([[10, 10], [20, 20], [30, 30]], r.eval())
+
+  def testFoldl_NoInferShape(self):
+    # Test case for 12019 (foldl)
+    with self.test_session():
+      a = constant_op.constant([[10, 10]])
+      b = constant_op.constant([[20, 20], [30, 30]])
+
+      r = functional_ops.foldl(
+          lambda a, b: array_ops.concat([a, b], axis = 0),
+          [a, b])
+      self.assertAllEqual([[10, 10], [20, 20], [30, 30]], r.eval())
+
   # pylint: disable=unnecessary-lambda
   def testFold_Grad(self):
     with self.test_session():

--- a/tensorflow/python/ops/functional_ops.py
+++ b/tensorflow/python/ops/functional_ops.py
@@ -97,13 +97,30 @@ def foldl(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
       varscope.set_caching_device(lambda op: op.device)
       varscope_caching_device_was_none = True
 
+    # Try to convert elems to tensor
+    elems_tensor = None
+    try:
+      elems_tensor = ops.convert_to_tensor(elems, name="elems")
+    except ValueError:
+      pass
+
     # Convert elems to tensor array.
-    elems = ops.convert_to_tensor(elems, name="elems")
-    n = array_ops.shape(elems)[0]
-    elems_ta = tensor_array_ops.TensorArray(dtype=elems.dtype, size=n,
-                                            dynamic_size=False,
-                                            infer_shape=True)
-    elems_ta = elems_ta.unstack(elems)
+    if elems_tensor is not None:
+      elems = elems_tensor
+      n = array_ops.shape(elems)[0]
+      elems_ta = tensor_array_ops.TensorArray(dtype=elems.dtype, size=n,
+                                              dynamic_size=False,
+                                              infer_shape=True)
+      elems_ta = elems_ta.unstack(elems)
+    else:
+      # Try to convert elems to tensor array, assuming elems is an iterable
+      n = sum(1 for e in elems)
+      elems_ta = tensor_array_ops.TensorArray(dtype=next(iter(elems)).dtype,
+                                              size=n,
+                                              dynamic_size=False,
+                                              infer_shape=False)
+      for index, value in enumerate(elems):
+        elems_ta = elems_ta.write(index, value)
 
     if initializer is None:
       a = elems_ta.read(0)
@@ -177,13 +194,30 @@ def foldr(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
       varscope.set_caching_device(lambda op: op.device)
       varscope_caching_device_was_none = True
 
+    # Try to convert elems to tensor
+    elems_tensor = None
+    try:
+      elems_tensor = ops.convert_to_tensor(elems, name="elems")
+    except ValueError:
+      pass
+
     # Convert elems to tensor array.
-    elems = ops.convert_to_tensor(elems, name="elems")
-    n = array_ops.shape(elems)[0]
-    elems_ta = tensor_array_ops.TensorArray(dtype=elems.dtype, size=n,
-                                            dynamic_size=False,
-                                            infer_shape=True)
-    elems_ta = elems_ta.unstack(elems)
+    if elems_tensor is not None:
+      elems = elems_tensor
+      n = array_ops.shape(elems)[0]
+      elems_ta = tensor_array_ops.TensorArray(dtype=elems.dtype, size=n,
+                                              dynamic_size=False,
+                                              infer_shape=True)
+      elems_ta = elems_ta.unstack(elems)
+    else:
+      # Try to convert elems to tensor array, assuming elems is an iterable
+      n = sum(1 for e in elems)
+      elems_ta = tensor_array_ops.TensorArray(dtype=next(iter(elems)).dtype,
+                                              size=n,
+                                              dynamic_size=False,
+                                              infer_shape=False)
+      for index, value in enumerate(elems):
+        elems_ta = elems_ta.write(index, value)
 
     if initializer is None:
       i = n - 1


### PR DESCRIPTION
This fix tries to address the issue raised in #12019 where `tf.foldr` and `tf.foldl` only accpet first shape dimensions be identical for all list elements.

The issue comes from the implementation of `tf.foldr` and `tf.foldl` where the input elems is converted to tensor, then converted to tensor array:
https://github.com/tensorflow/tensorflow/blob/1e1b3d90295f9396a25b9cfd4c571f7949716182/tensorflow/python/ops/functional_ops.py#L100-L106

It is possible to bypass the conversion to tensor, and go directly to tensor array, as long as the input elems is Iterable (and pass `infer_shape=False`)

This fix is an proposal to relex the restriction on `tf.foldr` and `tf.foldl` so that a list of elements with different shapes could be passed.

This fix fixes #12019.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>