### PR TITLE
Re-instate the plugin BUILD

### DIFF
--- a/tensorflow/compiler/jit/BUILD
+++ b/tensorflow/compiler/jit/BUILD
@@ -33,6 +33,7 @@ cc_library(
     deps = [
         ":xla_cpu_device",
         ":xla_cpu_jit",
+        "//tensorflow/compiler/plugin",
     ] + if_cuda_is_configured([
         ":xla_gpu_device",
         ":xla_gpu_jit",

--- a/tensorflow/compiler/plugin/BUILD
+++ b/tensorflow/compiler/plugin/BUILD
@@ -1,0 +1,42 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Configuration file for an XLA plugin.
+
+  please don't check in changes to this file. to prevent changes appearing
+  in git status, use:
+
+  git update-index --assume-unchanged tensorflow/compiler/plugin/BUILD
+
+  To add additional devices to the XLA subsystem, add targets to the
+  dependency list in the 'plugin' target. For instance:
+
+    deps = ["//tensorflow/compiler/plugin/example:plugin_lib"],
+
+  ** Please don't remove this file - it is supporting some 3rd party plugins **
+"""
+
+licenses(["notice"])
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "plugin",
+    deps = [
+        #"//tensorflow/compiler/plugin/example:example_lib",
+    ],
+)

--- a/tensorflow/compiler/plugin/README.md
+++ b/tensorflow/compiler/plugin/README.md
@@ -1,0 +1,16 @@
+3rd party XLA devices
+---------------------
+
+This directory is intended as a place for 3rd party XLA devices which are _not_
+integrated into the public repository.
+
+By adding entries to the BUILD target in this directory, a third party device
+can be included as a dependency of the JIT subsystem.
+
+For integration into the unit test system, see the files:
+
+- tensorflow/compiler/tests/plugin.bzl
+- tensorflow/compiler/xla/tests/plugin.bzl
+
+
+- 


### PR DESCRIPTION
This change re-instates the plugin BUILD link which was removed in commit 7de939bb74c5edbc2f45e77a5d4696e70bb59e5b