### PR TITLE
typo fix

### DIFF
--- a/tensorflow/contrib/makefile/compile_pi_protobuf.sh
+++ b/tensorflow/contrib/makefile/compile_pi_protobuf.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-# Builds protobuf 3 for iOS.
+# Builds protobuf 3 for Raspberry Pi.
 
 cd tensorflow/contrib/makefile || exit 1
 


### PR DESCRIPTION
found while trying to compile on ARM based Raspberry Pi 2 in branch `r.1.3`