### PR TITLE
[Windows] Export nsync symbols from the Python extension DLL

### DIFF
--- a/tensorflow/contrib/cmake/tf_python.cmake
+++ b/tensorflow/contrib/cmake/tf_python.cmake
@@ -914,6 +914,7 @@ if(WIN32)
         $<TARGET_FILE:pywrap_tensorflow_internal_static>
         $<TARGET_FILE:tf_protos_cc>
         $<TARGET_FILE:tf_python_protos_cc>
+	${nsync_STATIC_LIBRARIES}
     )
 
     set(pywrap_tensorflow_deffile "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/pywrap_tensorflow.def")

--- a/tensorflow/contrib/cmake/tools/create_def_file.py
+++ b/tensorflow/contrib/cmake/tools/create_def_file.py
@@ -63,6 +63,7 @@ INCLUDE_RE = re.compile(r"^(TF_\w*)$|"
                         r"^(TFE_\w*)$|"
                         r"tensorflow::|"
                         r"functor::|"
+                        r"nsync_|"
                         r"perftools::gputools")
 
 # We want to identify data members explicitly in the DEF file, so that no one
@@ -71,7 +72,6 @@ INCLUDE_RE = re.compile(r"^(TF_\w*)$|"
 # __declspec(dllimport). It is easier to detect what a data symbol does 
 # NOT look like, so doing it with the below regex.
 DATA_EXCLUDE_RE = re.compile(r"[)(]|"
-                             r"nsync_|"
                              r"vftable|"
                              r"vbtable|"
                              r"vcall|"

--- a/tensorflow/contrib/cmake/tools/create_def_file.py
+++ b/tensorflow/contrib/cmake/tools/create_def_file.py
@@ -71,6 +71,7 @@ INCLUDE_RE = re.compile(r"^(TF_\w*)$|"
 # __declspec(dllimport). It is easier to detect what a data symbol does 
 # NOT look like, so doing it with the below regex.
 DATA_EXCLUDE_RE = re.compile(r"[)(]|"
+                             r"nsync_|"
                              r"vftable|"
                              r"vbtable|"
                              r"vcall|"


### PR DESCRIPTION
Some extension modules (e.g. `_gru_ops.dll`) expect to be able to link against `nsync` symbols in the Python extension DLL. Any use of `tensorflow::mutex` in an extension module will rely on these symbols being exported. However, these are not currently exported as part of the Windows build.

This change modifies the Windows build to export symbols containing `nsync_` explicitly.