### PR TITLE
Make tf.pow work for integer inputs.

### DIFF
--- a/tensorflow/core/kernels/cwise_op_pow.cc
+++ b/tensorflow/core/kernels/cwise_op_pow.cc
@@ -16,12 +16,17 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER7(BinaryOp, CPU, "Pow", functor::pow, float, Eigen::half, double, int32,
-          int64, complex64, complex128);
+REGISTER5(BinaryOp, CPU, "Pow", functor::pow, float, Eigen::half, double,
+          complex64, complex128);
+
+#if !defined(IS_MOBILE_PLATFORM)
+REGISTER2(BinaryOp, CPU, "IntegralPow", functor::pow, int32, int64);
+#endif
 
 #if GOOGLE_CUDA
-REGISTER4(BinaryOp, GPU, "Pow", functor::pow, float, Eigen::half, double,
-          int64);
+REGISTER3(BinaryOp, GPU, "Pow", functor::pow, float, Eigen::half, double);
+
+REGISTER(BinaryOp, GPU, "IntegralPow", functor::pow, int64);
 #endif
 #ifdef TENSORFLOW_USE_SYCL
 REGISTER2(BinaryOp, SYCL, "Pow", functor::pow, float, double);

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -748,6 +748,28 @@ tf.pow(x, y) ==> [[256, 65536], [9, 27]]
 ```
 )doc");
 
+REGISTER_OP("IntegralPow")
+    .Input("x: T")
+    .Input("y: T")
+    .Output("z: double")
+    .Attr("T: {int32, int64}")
+    .SetShapeFn(shape_inference::BroadcastBinaryOpShapeFn)
+    .Doc(R"doc(
+Computes the power of one value to another.
+
+Given two integer tensors `x` and `y`, this operation computes \\(x^y\\) for
+corresponding elements in `x` and `y`. For example:
+
+```
+# tensor 'x' is [[2, 2]], [3, 3]]
+# tensor 'y' is [[8, 16], [2, 3]]
+tf.pow(x, y) ==> [[256, 65536], [9, 27]]
+```
+
+Note, the returned tensor is of type float64, in order to handle negative
+powers.
+)doc");
+
 REGISTER_OP("Igammac")
     .Input("a: T")
     .Input("x: T")

--- a/tensorflow/python/ops/hidden_ops.txt
+++ b/tensorflow/python/ops/hidden_ops.txt
@@ -260,6 +260,7 @@ Min
 Mul
 Neg
 Pow
+IntegralPow
 Prod
 Range
 RealDiv

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -541,8 +541,15 @@ def pow(x, y, name=None):
 
   Returns:
     A `Tensor`.
+    Note, for `int32` or `int64` inputs, the returned `Tensor` will be of type
+    `float64`.
   """
   with ops.name_scope(name, "Pow", [x]) as name:
+    x = ops.convert_to_tensor(x, name="x")
+    y = ops.convert_to_tensor(y, name="y")
+    if (x.dtype in (dtypes.int32, dtypes.int64) and
+        y.dtype in (dtypes.int32, dtypes.int64)):
+      return gen_math_ops._integral_pow(x, y, name=name)
     return gen_math_ops._pow(x, y, name=name)
 
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -471,7 +471,7 @@ class DivAndModTest(test_util.TensorFlowTestCase):
 
 class PowTest(test_util.TensorFlowTestCase):
 
-  def testInt(self):
+  def testNegativeExponent(self):
     for i_dtype in (np.int32, np.int64):
       x = np.array([2, 3, 4, 5], dtype=i_dtype)
       y = np.array([-1, -2, -3, 3], dtype=i_dtype)
@@ -480,6 +480,15 @@ class PowTest(test_util.TensorFlowTestCase):
         z_np = math_ops.pow(x, y).eval()
         self.assertEqual(z_np.dtype, z.dtype)
         self.assertAllClose(z_np, z)
+
+  def testTypeInference(self):
+    x = np.array([2, 3], dtype=np.int64)
+    y = [2, 3]
+    z = np.array([4.0, 27.0], dtype=np.float64)
+    with self.test_session():
+      z_np = math_ops.pow(x, y).eval()
+      self.assertEqual(z_np.dtype, z.dtype)
+      self.assertAllClose(z_np, z)
 
   def testComplex(self):
     for i_dtype in (np.complex64, np.complex128):

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -469,5 +469,30 @@ class DivAndModTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(tf_result, expanded_nums)
 
 
+class PowTest(test_util.TensorFlowTestCase):
+
+  def testInt(self):
+    for i_dtype in (np.int32, np.int64):
+      x = np.array([2, 3, 4, 5], dtype=i_dtype)
+      y = np.array([-1, -2, -3, 3], dtype=i_dtype)
+      z = np.array([0.5, 1.0 / 9.0, 1.0 / 64.0, 125.0], dtype=np.float64)
+      with self.test_session():
+        z_np = math_ops.pow(x, y).eval()
+        self.assertEqual(z_np.dtype, z.dtype)
+        self.assertAllClose(z_np, z)
+
+  def testComplex(self):
+    for i_dtype in (np.complex64, np.complex128):
+      x = np.array([2 + 1j, 3 + 2j], dtype=i_dtype)
+      y = np.array([-2, 2], dtype=i_dtype)
+      z = np.array([3.0 / 25.0 - 4.0j / 25.0, 5 + 12j], dtype=i_dtype)
+      with self.test_session():
+        x_tf = constant_op.constant(x, shape=x.shape)
+        y_tf = constant_op.constant(y, shape=y.shape)
+        z_np = math_ops.pow(x_tf, y_tf).eval()
+        self.assertEqual(z_np.dtype, z.dtype)
+        self.assertAllClose(z_np, z)
+
+
 if __name__ == "__main__":
   googletest.main()


### PR DESCRIPTION
Currently tf.pow freezes if both inputs are integer tensors and y contains negative values. For example
the call
`tf.pow(5, -2).eval()`
never finishes.

The cause is the implementation of pow in Eigen. To get around this issue I've changed the
underlying C++ functor to treat differently integer inputs. However, tf.pow now returns float tensors on
input integer tensors.

In order to pass the backwards compatibility test, I had to create a new op IntegralPow for the case of
integer inputs. This mirrors the implementation of abs using Abs and ComplexAbs. I've made this
op hidden.

I've also added tests for the pow function in python.

This should fix issue #9560.