### PR TITLE
tensorflow/go: add in LDFLAGS to support android

### DIFF
--- a/tensorflow/go/android.go
+++ b/tensorflow/go/android.go
@@ -1,0 +1,6 @@
+// +build android
+
+package tensorflow
+
+// #cgo LDFLAGS: -landroid -llog -lm -lz -ldl
+import "C"


### PR DESCRIPTION
This is required since the libtensorflow_inference.so generated by contrib/android links against these libraries. Go requires these to be specified when compiling against it.