### PR TITLE
Fix bug: variables outside won't update in DNNLinearCombinedRegressor

### DIFF
--- a/tensorflow/python/estimator/canned/dnn_linear_combined.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined.py
@@ -192,7 +192,7 @@ def _dnn_linear_combined_model_fn(
     global_step = training_util.get_global_step()
 
     if model == "combined":
-      all_vars = ops.trainable_variables()
+      all_vars = ops.get_collection(ops.GraphKeys.TRAINABLE_VARIABLES)
       linear_vars = ops.get_collection(
         ops.GraphKeys.TRAINABLE_VARIABLES,
         scope=linear_parent_scope)

--- a/tensorflow/python/estimator/canned/dnn_linear_combined.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined.py
@@ -196,7 +196,7 @@ def _dnn_linear_combined_model_fn(
       linear_vars = ops.get_collection(
         ops.GraphKeys.TRAINABLE_VARIABLES,
         scope=linear_parent_scope)
-      # variables left is optimized by dnn
+      # variables left are optimized by dnn
       dnn_vars = list(set(all_vars) - set(linear_vars))
       train_ops = [
         linear_optimizer.minimize(loss, var_list=linear_vars),

--- a/tensorflow/python/estimator/canned/dnn_linear_combined.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined.py
@@ -193,21 +193,19 @@ def _dnn_linear_combined_model_fn(
 
     if model == "combined":
       all_vars = ops.trainable_variables()
-      lr_vars = ops.get_collection(
+      linear_vars = ops.get_collection(
         ops.GraphKeys.TRAINABLE_VARIABLES,
         scope=linear_parent_scope)
       # variables left is optimized by dnn
-      dnn_vars = list(set(all_vars) - set(lr_vars))
+      dnn_vars = list(set(all_vars) - set(linear_vars))
       train_ops = [
-        linear_optimizer.minimize(loss, var_list=lr_vars),
+        linear_optimizer.minimize(loss, var_list=linear_vars),
         dnn_optimizer.minimize(loss, var_list=dnn_vars)]
       train_op = control_flow_ops.group(*train_ops)
     elif model == "dnn":
       train_op = dnn_optimizer.minimize(loss)
-    elif model == "linear":
-      train_op = linear_optimizer.minimize(loss)
     else:
-      raise ValueError("Invalid model")
+      train_op = linear_optimizer.minimize(loss)
 
     with ops.control_dependencies([train_op]):
       with ops.colocate_with(global_step):

--- a/tensorflow/python/estimator/canned/dnn_linear_combined.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined.py
@@ -197,7 +197,7 @@ def _dnn_linear_combined_model_fn(
         ops.GraphKeys.TRAINABLE_VARIABLES,
         scope=linear_parent_scope)
       # variables left are optimized by dnn
-      dnn_vars = list(set(all_vars) - set(linear_vars))
+      dnn_vars = [v for v in all_vars if v not in set(linear_vars)]
       train_ops = [
         linear_optimizer.minimize(loss, var_list=linear_vars),
         dnn_optimizer.minimize(loss, var_list=dnn_vars)]

--- a/tensorflow/python/estimator/canned/dnn_linear_combined_test.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined_test.py
@@ -714,7 +714,7 @@ class DNNLinearCombinedTests(test.TestCase):
         [0.0, 0.0],
         [1.0, 0.0],
         [0.0, 1.0]])
-      y = constant_op.constant([1.0, 1.0, 0.0, 0.0])
+      y = constant_op.constant([0.0, 0.0, 1.0, 1.0])
       with ops.name_scope(''):
         w = variables_lib.Variable(w_initial_values, name="input_fn_w")
       x = math_ops.matmul(x, w)


### PR DESCRIPTION
This fix is an proposal for #13419 

### What changes were proposed in this pull request?

There are two solutions to fix the problem in my opinion:
+ all variables except of linear is optimized by dnn.
+ which one of optimizers does the variables left (except of linear and dnn) use is selected by user, perhaps a new argument is needed.

The PR is implemented by the first one for simplicity.

### How to test

+ [x] add test case: I have no idea of how to write it, hence any suggestions will be appreciated.
+ [ ] pass all tests.