### PR TITLE
Initialize fetchTensors to fix NullPointerException

### DIFF
--- a/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
+++ b/tensorflow/contrib/android/java/org/tensorflow/contrib/android/TensorFlowInferenceInterface.java
@@ -616,7 +616,7 @@ public class TensorFlowInferenceInterface {
   private List<String> feedNames = new ArrayList<String>();
   private List<Tensor<?>> feedTensors = new ArrayList<Tensor<?>>();
   private List<String> fetchNames = new ArrayList<String>();
-  private List<Tensor<?>> fetchTensors = null;
+  private List<Tensor<?>> fetchTensors = new ArrayList<Tensor<?>>();
 
   // Mutable state.
   private RunStats runStats;


### PR DESCRIPTION
fetchTensors should not be null. This was broken by the refactoring in https://github.com/tensorflow/tensorflow/commit/244b8d6b0767c0fb63e58e56f58d03bd97c27822