### PR TITLE
Remove unnecessary specification for default kernel name

### DIFF
--- a/tensorflow/tools/docker/jupyter_notebook_config.py
+++ b/tensorflow/tools/docker/jupyter_notebook_config.py
@@ -18,7 +18,6 @@ from IPython.lib import passwd
 c.NotebookApp.ip = '*'
 c.NotebookApp.port = int(os.getenv('PORT', 8888))
 c.NotebookApp.open_browser = False
-c.MultiKernelManager.default_kernel_name = 'python2'
 
 # sets a password if PASSWORD is set in the environment
 if 'PASSWORD' in os.environ:


### PR DESCRIPTION
This line doesn't effect in any cases.

The docker container for latest-py2 is working well even without this line.
Although it's written `= 'python2'`, the docker container for latest-py3 is working.

`parameterized_docker_build.sh` or other scripts are not overwriting the line.
It should be removed, or overwritten when the images are built.