### PR TITLE
model_dir keyword argument repeated

### DIFF
--- a/tensorflow/docs_src/tutorials/wide.md
+++ b/tensorflow/docs_src/tutorials/wide.md
@@ -426,8 +426,7 @@ m = tf.estimator.LinearClassifier(
     optimizer=tf.train.FtrlOptimizer(
       learning_rate=0.1,
       l1_regularization_strength=1.0,
-      l2_regularization_strength=1.0),
-    model_dir=model_dir)
+      l2_regularization_strength=1.0))
 ```
 
 One important difference between L1 and L2 regularization is that L1


### PR DESCRIPTION
In https://www.tensorflow.org/tutorials/wide#adding_regularization_to_prevent_overfitting, the code snippet repeats the model_dir keyword argument, causing a syntax error if you try to run it (`SyntaxError: keyword argument repeated`).  This removes the second occurrence of the model_dir param.