### PR TITLE
Fix documentation error in tf.reverse docstring (#1)

### DIFF
--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -1117,7 +1117,7 @@ For example:
 #                  [20, 21, 22, 23]]]]
 # tensor 't' shape is [1, 2, 3, 4]
 
-# 'dims' is [3] or 'dims' is -1
+# 'dims' is [3] or 'dims' is [-1]
 reverse(t, dims) ==> [[[[ 3,  2,  1,  0],
                         [ 7,  6,  5,  4],
                         [ 11, 10, 9, 8]],


### PR DESCRIPTION
The first example in the tf.reverse docstring causes a ValueError, as shown below.  `tf.reverse` requires `axis` to be 1D; -1 is not 1D, it's 0D; it should be [-1].

```Python
In [1]: import tensorflow as tf
In [2]: t = tf.constant([[[[ 0,  1,  2,  3], [ 4,  5,  6,  7], [ 8,  9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]])
In [3]: dims = -1
In [4]: sess = tf.InteractiveSession()
In [5]: tf.reverse(t, dims).eval()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-7752813cc8a9> in <module>()
----> 1 tf.reverse(t, dims).eval()

/Users/craffel/.pyenv/versions/2.7.13/lib/python2.7/site-packages/tensorflow/python/ops/array_ops.pyc in reverse(tensor, axis, name)
   2332
   2333 def reverse(tensor, axis, name=None):
-> 2334   return gen_array_ops.reverse_v2(tensor, axis, name)
   2335 reverse.__doc__ = gen_array_ops.reverse_v2.__doc__
   2336

/Users/craffel/.pyenv/versions/2.7.13/lib/python2.7/site-packages/tensorflow/python/ops/gen_array_ops.pyc in reverse_v2(tensor, axis, name)
   2697   """
   2698   result = _op_def_lib.apply_op("ReverseV2", tensor=tensor, axis=axis,
-> 2699                                 name=name)
   2700   return result
   2701

/Users/craffel/.pyenv/versions/2.7.13/lib/python2.7/site-packages/tensorflow/python/framework/op_def_library.pyc in apply_op(self, op_type_name, name, **keywords)
    765         op = g.create_op(op_type_name, inputs, output_types, name=scope,
    766                          input_types=input_types, attrs=attr_protos,
--> 767                          op_def=op_def)
    768         if output_structure:
    769           outputs = op.outputs

/Users/craffel/.pyenv/versions/2.7.13/lib/python2.7/site-packages/tensorflow/python/framework/ops.pyc in create_op(self, op_type, inputs, dtypes, input_types, name, attrs, op_def, compute_shapes, compute_device)
   2506                     original_op=self._default_original_op, op_def=op_def)
   2507     if compute_shapes:
-> 2508       set_shapes_for_outputs(ret)
   2509     self._add_op(ret)
   2510     self._record_op_seen_by_control_dependencies(ret)

/Users/craffel/.pyenv/versions/2.7.13/lib/python2.7/site-packages/tensorflow/python/framework/ops.pyc in set_shapes_for_outputs(op)
   1871       shape_func = _call_cpp_shape_fn_and_require_op
   1872
-> 1873   shapes = shape_func(op)
   1874   if shapes is None:
   1875     raise RuntimeError(

/Users/craffel/.pyenv/versions/2.7.13/lib/python2.7/site-packages/tensorflow/python/framework/ops.pyc in call_with_requiring(op)
   1821
   1822   def call_with_requiring(op):
-> 1823     return call_cpp_shape_fn(op, require_shape_fn=True)
   1824
   1825   _call_cpp_shape_fn_and_require_op = call_with_requiring

/Users/craffel/.pyenv/versions/2.7.13/lib/python2.7/site-packages/tensorflow/python/framework/common_shapes.pyc in call_cpp_shape_fn(op, input_tensors_needed, input_tensors_as_shapes_needed, debug_python_shape_fn, require_shape_fn)
    608     res = _call_cpp_shape_fn_impl(op, input_tensors_needed,
    609                                   input_tensors_as_shapes_needed,
--> 610                                   debug_python_shape_fn, require_shape_fn)
    611     if not isinstance(res, dict):
    612       # Handles the case where _call_cpp_shape_fn_impl calls unknown_shape(op).

/Users/craffel/.pyenv/versions/2.7.13/lib/python2.7/site-packages/tensorflow/python/framework/common_shapes.pyc in _call_cpp_shape_fn_impl(op, input_tensors_needed, input_tensors_as_shapes_needed, debug_python_shape_fn, require_shape_fn)
    674       missing_shape_fn = True
    675     else:
--> 676       raise ValueError(err.message)
    677
    678   if missing_shape_fn:

ValueError: Shape must be rank 1 but is rank 0 for 'ReverseV2' (op: 'ReverseV2') with input shapes: [1,2,3,4], [].
```