### PR TITLE
Allowing a single Tensor in a StagingArea

### DIFF
--- a/tensorflow/python/ops/data_flow_ops.py
+++ b/tensorflow/python/ops/data_flow_ops.py
@@ -1686,7 +1686,7 @@ class StagingArea(BaseStagingArea):
                         self._scope_vals(values)) as scope:
 
       if not isinstance(values, (list, tuple)):
-          values = [values]
+        values = [values]
       # Hard-code indices for this staging area
       indices = list(six.moves.range(len(values)))
       vals, _ = self._check_put_dtypes(values, indices)

--- a/tensorflow/python/ops/data_flow_ops.py
+++ b/tensorflow/python/ops/data_flow_ops.py
@@ -1685,9 +1685,10 @@ class StagingArea(BaseStagingArea):
     with ops.name_scope(name, "%s_put" % self._name,
                         self._scope_vals(values)) as scope:
 
+      if not isinstance(values, (list, tuple)):
+          values = [values]
       # Hard-code indices for this staging area
-      indices = (list(six.moves.range(len(values)))
-                  if isinstance(values, (list, tuple)) else None)
+      indices = list(six.moves.range(len(values)))
       vals, _ = self._check_put_dtypes(values, indices)
 
       with ops.colocate_with(self._coloc_op):


### PR DESCRIPTION
This brings the code in line with the documentation so that both of the
following are valid:

    import tensorflow as tf
    from tensorflow.contrib import staging

    staging.StagingArea(dtypes=[tf.int32]).put(tf.constant(1))
    staging.StagingArea(dtypes=[tf.int32]).put([tf.constant(2), tf.constant(2)])

Fixes #13288