### PR TITLE
Add an actionable error message for build_info ImportError

### DIFF
--- a/tensorflow/python/platform/self_check.py
+++ b/tensorflow/python/platform/self_check.py
@@ -21,7 +21,13 @@ from __future__ import print_function
 import os
 
 
-from tensorflow.python.platform import build_info
+try:
+  from tensorflow.python.platform import build_info
+except ImportError:
+  raise ImportError("Could not import tensorflow. Do not import tensorflow "
+                    "from its source directory; change directory to outside "
+                    "the TensorFlow source tree, and relaunch your Python "
+                    "interpreter from there.")
 
 
 def preload_check():


### PR DESCRIPTION
This `import` statement is now the first point where we attempt to import a generated file, and hence could see a failure if the user tries to `import tensorflow` from the root of the git repository source tree. When this `import` fails, raise a more actionable error message.

Fixes #13526.