### PR TITLE
Fix unevaluated link in "Reading data" docs

### DIFF
--- a/tensorflow/docs_src/api_guides/python/reading_data.md
+++ b/tensorflow/docs_src/api_guides/python/reading_data.md
@@ -58,7 +58,7 @@ A typical pipeline for reading records from files has the following stages:
 8.  Example queue
 
 Note: This section discusses implementing input pipelines using the
-queue-based APIs which can be cleanly replaced by the ${$datasets$Dataset API}.
+queue-based APIs which can be cleanly replaced by the @{$datasets$Datasets API}.
 
 ### Filenames, shuffling, and epoch limits
 


### PR DESCRIPTION
In the pull-out in https://www.tensorflow.org/api_guides/python/reading_data#Reading_from_files
there's a link that's unevaluated due to beginning with a `$` instead of a `@`.