### PR TITLE
Pin TensorBoard 0.4 to TensorFlow 1.4

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -36,7 +36,7 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.12.1',
     'six >= 1.10.0',
     'protobuf >= 3.3.0',
-    'tensorflow-tensorboard >= 0.1.0, < 0.2.0',
+    'tensorflow-tensorboard >= 0.4.0rc1, < 0.5.0',
 ]
 
 project_name = 'tensorflow'


### PR DESCRIPTION
See also:
- https://pypi.python.org/pypi/tensorflow-tensorboard
- https://github.com/tensorflow/tensorboard/releases/tag/0.4.0-rc1