### PR TITLE
Fix typos

### DIFF
--- a/tensorflow/contrib/meta_graph_transform/meta_graph_transform.py
+++ b/tensorflow/contrib/meta_graph_transform/meta_graph_transform.py
@@ -749,7 +749,7 @@ def meta_graph_transform(
         base_meta_graph_def, meta_graph_def, collection_name,
         removed_op_names)
 
-  # Append newly added initalizers to collection.
+  # Append newly added initializers to collection.
   _add_new_inits_to_collection(meta_graph_def, updated_initializer_names)
 
   # Copy signature_defs, excluding any pruned nodes

--- a/tensorflow/core/framework/rendezvous.cc
+++ b/tensorflow/core/framework/rendezvous.cc
@@ -210,7 +210,7 @@ class LocalRendezvousImpl : public Rendezvous {
     ItemQueue* queue = &table_[key_hash];
     if (queue->empty() || !queue->front()->IsSendValue()) {
       // There is no message to pick up.
-      // Only recv-related fileds need to be filled.
+      // Only recv-related fields need to be filled.
       Item* item = new Item;
       item->waiter = std::move(done);
       item->recv_args = recv_args;

--- a/tensorflow/core/profiler/g3doc/options.md
+++ b/tensorflow/core/profiler/g3doc/options.md
@@ -43,7 +43,7 @@ In graph view, in means the number of hops in the <b>graph</b>.
 
 ### Times
 
-Most machines have mutli-core CPUs. Some installs one or more accelerators.
+Most machines have multi-core CPUs. Some installs one or more accelerators.
 Each accelerator usually performs massive parallel processing. The profiler
 tracks the accumulated processing times. Hence, the accumulated processing
 time is likely larger than the time of each step.

--- a/tensorflow/examples/get_started/regression/imports85.py
+++ b/tensorflow/examples/get_started/regression/imports85.py
@@ -127,7 +127,7 @@ def dataset(y_name="price", train_fraction=0.7):
   def in_test_set(line):
     """Returns a boolean tensor, true if the line is in the training set."""
     # Items not in the training set are in the test set.
-    # This line must use `~` instead of `not` beacuse `not` only works on python
+    # This line must use `~` instead of `not` because `not` only works on python
     # booleans but we are dealing with symbolic tensors.
     return ~in_training_set(line)
 

--- a/tensorflow/python/debug/cli/tensor_format.py
+++ b/tensorflow/python/debug/cli/tensor_format.py
@@ -480,7 +480,7 @@ def _pad_string_to_length(string, length):
 
 
 def numeric_summary(tensor):
-  """Get a text summmary of a numeric tensor.
+  """Get a text summary of a numeric tensor.
 
   This summary is only available for numeric (int*, float*, complex*) and
   Boolean tensors.


### PR DESCRIPTION
This PR fixes some typos: `initalizers`, `fileds`, `mutli`, `beacuse`, and `summmary`.