### PR TITLE
Add `<` operator for IndicesRowIterator

### DIFF
--- a/tensorflow/contrib/boosted_trees/lib/utils/sparse_column_iterable.cc
+++ b/tensorflow/contrib/boosted_trees/lib/utils/sparse_column_iterable.cc
@@ -101,6 +101,11 @@ class IndicesRowIterator
     return (row_idx_ == other.row_idx_);
   }
 
+  bool operator<(const IndicesRowIterator& other) const {
+    QCHECK_LT(iter_, other.iter_);
+    return (row_idx_ < other.row_idx_);
+  }
+
   Eigen::Index row_idx() const { return row_idx_; }
 
  private:


### PR DESCRIPTION
This fix adds the `<` operator for IndicesRowIterator to address C2678 error in VS Debug mode, as was specified in #12000.

This fix fixes #12000.