### PR TITLE
Fix broken link in performance guide

### DIFF
--- a/tensorflow/docs_src/performance/performance_guide.md
+++ b/tensorflow/docs_src/performance/performance_guide.md
@@ -93,7 +93,7 @@ Reading large numbers of small files significantly impacts I/O performance.
 One approach to get maximum I/O throughput is to preprocess input data into
 larger (~100MB) `TFRecord` files. For smaller data sets (200MB-1GB), the best
 approach is often to load the entire data set into memory. The document
-[Downloading and converting to TFRecord format](https://github.com/tensorflow/models/tree/master/slim#Data)
+[Downloading and converting to TFRecord format](https://github.com/tensorflow/models/tree/master/research/slim#Data)
 includes information and scripts for creating `TFRecords` and this
 [script](https://github.com/tensorflow/models/tree/master/tutorials/image/cifar10_estimator/generate_cifar10_tfrecords.py)
 converts the CIFAR-10 data set into `TFRecords`.


### PR DESCRIPTION
This fix fixes broken link in performance guide as models repo moved `slim` to `models/research/slim`
`https://github.com/tensorflow/models/tree/master/slim#Data`
->
`https://github.com/tensorflow/models/tree/master/research/slim#Data`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>