### PR TITLE
Improve shape inference for `tf.slice`

### DIFF
--- a/tensorflow/python/kernel_tests/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/slice_op_test.py
@@ -217,6 +217,17 @@ class SliceTest(test.TestCase):
     self.assertEqual(expected_val.shape, slice_t.get_shape())
     self.assertEqual(expected_val.shape, slice2_t.get_shape())
 
+  def testPartialShapeInference(self):
+    z = array_ops.zeros((1, 2, 3))
+    self.assertAllEqual(z.get_shape().as_list(), [1, 2, 3])
+
+    m1 = array_ops.slice(z, [0, 0, 0], [-1, -1, -1])
+    self.assertAllEqual(m1.get_shape().as_list(), [1, 2, 3])
+
+    m2 = array_ops.slice(z, [0, 0, 0], [constant_op.constant(1) + 0, 2, -1])
+    self.assertAllEqual(m2.get_shape().as_list(), [None, 2, None])
+
+
   def _testGradientSlice(self, input_shape, slice_begin, slice_size):
     with self.test_session(use_gpu=True):
       num_inputs = np.prod(input_shape)


### PR DESCRIPTION
This fix is an effort to address the issue raised by #4590 where improvement of shape inference for `tf.slice` is needed.

When one of the size element is unknwon, the output shape is completely unknwon (with right rank):
```python
>>> import tensorflow as tf
>>> z = tf.zeros((1, 2, 3))
>>> z.get_shape().as_list()
[1, 2, 3]
>>> m = tf.slice(z, [0, 0, 0], [tf.constant(1) + 0, 2, -1])
>>> m.get_shape().as_list()
[None, None, None]
```

This fix improves the shape inference so that as long as the size element is not unknown or `-1`, the right shape will shown up:
```python
>>> import tensorflow as tf
>>> z = tf.zeros((1, 2, 3))
>>> z.get_shape().as_list()
[1, 2, 3]
>>> m = tf.slice(z, [0, 0, 0], [tf.constant(1) + 0, 2, -1])
>>> m.get_shape().as_list()
[None, 2, None]
```

Note: this fix does not handle the case where one of the size element is `-1` and one of the size element is unknown. However, it is an improvement nevertheless.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>