### PR TITLE
update dnn.py to clarify outputs arg to predict fn

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/dnn.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/dnn.py
@@ -382,20 +382,21 @@ class DNNClassifier(estimator.Estimator):
       as_iterable=False)
   @deprecated_arg_values(
       "2017-03-01",
-      "Please switch to predict_classes, or set `outputs` argument.",
+      "Please switch to predict_classes, or set `outputs="classes"`.",
       outputs=None)
   def predict(self, x=None, input_fn=None, batch_size=None, outputs=None,
               as_iterable=True):
     """Returns predictions for given features.
 
     By default, returns predicted classes. But this default will be dropped
-    soon. Users should either pass `outputs`, or call `predict_classes` method.
+    soon. Users should either pass `outputs="classes"`, or call `predict_classes` method.
 
     Args:
       x: features.
       input_fn: Input function. If set, x must be None.
       batch_size: Override default batch size.
-      outputs: list of `str`, name of the output to predict.
+      outputs: list of `str`, name of the output(s) to predict. Valid values are 
+      "classes", "probabilities", and "logits".
         If `None`, returns classes.
       as_iterable: If True, return an iterable which keeps yielding predictions
         for each example until inputs are exhausted. Note: The inputs must


### PR DESCRIPTION
It is unclear what the valid values are for predict(). Since the 2 variants are predict_classes and predict_proba, it's easy to think that the valid values are "classes" and "proba", which is untrue.
I _think_ I've listed all the relevant values for DNNClassifier -- at least that's what the error msg told me when I used "proba" as my arg :D