### PR TITLE
Adding --verify_images to example image retrainer.

### DIFF
--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -170,8 +170,8 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage, ver
       if verify_images:
         # Prune invalid image files
         try:
-          im = Image.open(file_name)
-          im.verify()
+          im = Image.open(file_name, 'r')
+          im.load()
         except Exception as e:
           tf.logging.warning('Found invalid image: %s (%s)' % (file_name, str(e)))
           file_list.remove(file_name)


### PR DESCRIPTION
Adding --verify_images to allow soft checking of image files before bottleneck creation.
When enabled, invalid images are ignored with a warning instead of throwing an exception.