### PR TITLE
Protobuf must be compiled with the same version

### DIFF
--- a/tensorflow/contrib/makefile/README.md
+++ b/tensorflow/contrib/makefile/README.md
@@ -265,7 +265,7 @@ sudo apt-get install -y autoconf automake libtool gcc-4.8 g++-4.8
 cd tensorflow/contrib/makefile/downloads/protobuf/
 ./autogen.sh
 ./configure
-make
+make CXX=g++-4.8
 sudo make install
 sudo ldconfig  # refresh shared library cache
 cd ../../../../..


### PR DESCRIPTION
Added CXX=g++-4.8 to make command. On Raspberry PI protobuf must be compiled with the same gcc version as tensorflow, otherwise compile stops with error see tensorflow/tensorflow#5684.