### PR TITLE
Batch normalization dtype depends on inputs dtype

### DIFF
--- a/tensorflow/python/layers/normalization.py
+++ b/tensorflow/python/layers/normalization.py
@@ -653,6 +653,7 @@ def batch_normalization(inputs,
       trainable=trainable,
       num_virtual_batches=num_virtual_batches,
       name=name,
+      dtype=inputs.dtype.base_dtype,
       _reuse=reuse,
       _scope=name)
   return layer.apply(inputs, training=training)


### PR DESCRIPTION
Make the batch normalization layer dtype be the same type as the inputs,
before it was always float32