### PR TITLE
Configurable upper bound for MKL CPU allocator

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -2669,6 +2669,22 @@ tf_cc_tests(
 )
 
 tf_cc_test_mkl(
+    name = "mkl_runtime_tests",
+    size = "small",
+    srcs = ["common_runtime/mkl_cpu_allocator_test.cc"],
+    linkstatic = 1,
+    deps = [
+        ":core",
+        ":core_cpu",
+        ":framework",
+        ":framework_internal",
+        ":test",
+        ":test_main",
+        ":testlib",
+    ],
+)
+
+tf_cc_test_mkl(
     name = "mkl_related_tests",
     size = "small",
     srcs = [

--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -51,7 +51,7 @@ class MklCPUAllocator : public Allocator {
   // Constructor and other standard functions
 
   /// Environment variable that user can set to upper bound on memory allocation
-  static constexpr const char* kMaxLimitStr = "TF_MKL_ALLOC_MAX_BYTES";
+  static constexpr const char kMaxLimitStr[] = "TF_MKL_ALLOC_MAX_BYTES";
 
   /// Default upper limit on allocator size - 64GB
   static const size_t kDefaultMaxLimit = 64LL << 30;
@@ -146,7 +146,7 @@ class MklCPUAllocator : public Allocator {
   static const bool kAllowGrowth = true;
 
   /// Name
-  static constexpr const char* kName = "mklcpu";
+  static constexpr const char kName[] = "mklcpu";
 
   /// The alignment that we need for the allocations
   static const size_t kAlignment = 64;

--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -65,17 +65,17 @@ class MklCPUAllocator : public Allocator {
     if (user_mem_bytes != NULL) {
       uint64 user_val = 0;
       if (!strings::safe_strtou64(user_mem_bytes, &user_val)) {
-        string err_msg = "Invalid memory limit (" + string(user_mem_bytes) +
-                         ") specified for MKL allocator through " +
-                         string(kMaxAllocSize);
-        Status s = Status(error::Code::INVALID_ARGUMENT, err_msg.c_str());
-        TF_CHECK_OK(s);
+        TF_CHECK_OK(errors::InvalidArgument(
+            "Invalid memory limit (", user_mem_bytes,
+            ") specified for MKL allocator through ", kMaxAllocSize));
       }
 #if defined(_SC_PHYS_PAGES) && defined(_SC_PAGESIZE)
       if (user_val > max_mem_bytes) {
-        LOG(WARNING) << "User specified memory limit " << user_val
-                     << " greater than available physical memory "
-                     << max_mem_bytes << "!!! Could lead to perf slowdowns.";
+        LOG(WARNING) << "The user specifed a memory limit " << kMaxAllocSize
+                     << "=" << user_val
+                     << " greater than available physical memory: "
+                     << max_mem_bytes
+                     << ". This could significantly reduce performance!";
       }
 #endif
       max_mem_bytes = user_val;
@@ -137,7 +137,7 @@ class MklCPUAllocator : public Allocator {
   static constexpr const char* kName = "mklcpu";
 
   /// Environment variable that user can set to upper bound on memory allocation
-  static constexpr const char* kMaxAllocSize = "TF_MKLALLOC_MAX_BYTES";
+  static constexpr const char* kMaxAllocSize = "TF_MKL_ALLOC_MAX_BYTES";
 
   /// The alignment that we need for the allocations
   static const size_t kAlignment = 64;

--- a/tensorflow/core/common_runtime/mkl_cpu_allocator_test.cc
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator_test.cc
@@ -1,0 +1,53 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef INTEL_MKL
+
+#include "tensorflow/core/common_runtime/mkl_cpu_allocator.h"
+
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+
+TEST(MKLBFCAllocatorTest, TestMaxLimit) {
+  AllocatorStats stats;
+  setenv(MklCPUAllocator::kMaxLimitStr, "1000", 1);
+  MklCPUAllocator a;
+  TF_EXPECT_OK(a.Initialize());
+  a.GetStats(&stats);
+  EXPECT_EQ(stats.bytes_limit, 1000);
+
+  unsetenv(MklCPUAllocator::kMaxLimitStr);
+  TF_EXPECT_OK(a.Initialize());
+  a.GetStats(&stats);
+  uint64 max_mem_bytes = MklCPUAllocator::kDefaultMaxLimit;
+#if defined(_SC_PHYS_PAGES) && defined(_SC_PAGESIZE)
+  max_mem_bytes =
+      (uint64)sysconf(_SC_PHYS_PAGES) * (uint64)sysconf(_SC_PAGESIZE);
+#endif
+  EXPECT_EQ(stats.bytes_limit, max_mem_bytes);
+
+  setenv(MklCPUAllocator::kMaxLimitStr, "wrong-input", 1);
+  EXPECT_TRUE(errors::IsInvalidArgument(a.Initialize()));
+
+  setenv(MklCPUAllocator::kMaxLimitStr, "-20", 1);
+  EXPECT_TRUE(errors::IsInvalidArgument(a.Initialize()));
+}
+
+}  // namespace tensorflow
+
+#endif  // INTEL_MKL

--- a/tensorflow/core/common_runtime/mkl_cpu_allocator_test.cc
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator_test.cc
@@ -23,6 +23,8 @@ limitations under the License.
 
 namespace tensorflow {
 
+constexpr char MklCPUAllocator::kMaxLimitStr[];
+
 TEST(MKLBFCAllocatorTest, TestMaxLimit) {
   AllocatorStats stats;
   setenv(MklCPUAllocator::kMaxLimitStr, "1000", 1);


### PR DESCRIPTION
Multiple ways to configure upper bound on the MKL cpu allocator
- Default is 64 GB
- Overridden by DRAM capacity, if available
- Overridden by user configured limit if set through an environment variable.