### PR TITLE
Enable setting HDFS user

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -60,6 +60,7 @@ class LibHDFS {
   std::function<int(const char*, char**)> hdfsConfGetStr;
   std::function<void(hdfsBuilder*, const char* kerbTicketCachePath)>
       hdfsBuilderSetKerbTicketCachePath;
+  std::function<void(hdfsBuilder*, const char*)> hdfsBuilderSetUserName;
   std::function<int(hdfsFS, hdfsFile)> hdfsCloseFile;
   std::function<tSize(hdfsFS, hdfsFile, tOffset, void*, tSize)> hdfsPread;
   std::function<tSize(hdfsFS, hdfsFile, const void*, tSize)> hdfsWrite;
@@ -87,6 +88,7 @@ class LibHDFS {
       BIND_HDFS_FUNC(hdfsBuilderSetNameNode);
       BIND_HDFS_FUNC(hdfsConfGetStr);
       BIND_HDFS_FUNC(hdfsBuilderSetKerbTicketCachePath);
+      BIND_HDFS_FUNC(hdfsBuilderSetUserName);
       BIND_HDFS_FUNC(hdfsCloseFile);
       BIND_HDFS_FUNC(hdfsPread);
       BIND_HDFS_FUNC(hdfsWrite);
@@ -170,6 +172,12 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
   if (ticket_cache_path != nullptr) {
     hdfs_->hdfsBuilderSetKerbTicketCachePath(builder, ticket_cache_path);
   }
+
+  const char* hdfs_user = getenv("HADOOP_USER_NAME");
+  if (hdfs_user != nullptr) {
+    hdfs_->hdfsBuilderSetUserName(builder, hdfs_user);
+  }
+  
   *fs = hdfs_->hdfsBuilderConnect(builder);
   if (*fs == nullptr) {
     return errors::NotFound(strerror(errno));

--- a/tensorflow/docs_src/deploy/hadoop.md
+++ b/tensorflow/docs_src/deploy/hadoop.md
@@ -61,5 +61,15 @@ be set:
     export KRB5CCNAME=/tmp/krb5cc_10002
     ```
 
+If you want TensorFlow to access HDFS as a specific HDFS user, the following environment
+variable must be set:
+
+*   **HADOOP_USER_NAME**: HDFS user TensorFlow will perform operations on the file system. You can
+    export this environment variable by running:
+
+    ```shell
+    export HADOOP_USER_NAME=hdfs_user
+    ```
+    
 If you are running @{$distributed$Distributed TensorFlow}, then all
 workers must have the environment variables set and Hadoop installed.


### PR DESCRIPTION
Following issue https://github.com/tensorflow/tensorflow/issues/13627 add enable TensorFlow to access HDFS as a specific HDFS user instead of the the system user owning the Tf process