### PR TITLE
configure.py: Disable AWS support on Windows by default

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -976,6 +976,7 @@ def main():
   run_gen_git_source(environ_cp)
 
   if is_windows():
+    environ_cp['TF_NEED_S3'] = '0'
     environ_cp['TF_NEED_GCP'] = '0'
     environ_cp['TF_NEED_HDFS'] = '0'
     environ_cp['TF_NEED_JEMALLOC'] = '0'


### PR DESCRIPTION
This is a follow up to https://github.com/tensorflow/tensorflow/pull/13662
@gunan 