### PR TITLE
Fix deadlocks in Staging Areas.

### DIFF
--- a/tensorflow/core/kernels/map_stage_op.cc
+++ b/tensorflow/core/kernels/map_stage_op.cc
@@ -111,15 +111,21 @@ class StagingMap : public ResourceBase {
   void notify_inserters_if_bounded(std::unique_lock<std::mutex>* lock) {
     if (has_capacity() || has_memory_limit()) {
       lock->unlock();
-      full_.notify_one();
+      // Notify all inserters. The removal of an element
+      // may make memory available for many inserters
+      // to insert new elements
+      full_.notify_all();
     }
   }
 
-  // Notify any removers waiting to extract values
+  // Notify all removers waiting to extract values
   // that data is now available
   void notify_removers(std::unique_lock<std::mutex>* lock) {
     lock->unlock();
-    not_empty_.notify_one();
+    // Notify all removers. This is because they are
+    // waiting for specific keys to appear in the map
+    // so we don't know which one to wake up.
+    not_empty_.notify_all();
   }
 
   bool has_capacity() const { return capacity_ > 0; }


### PR DESCRIPTION
Previously, `notify_one` was used to notify inserters and removers waiting to insert and remove elements into the Staging Areas. This could result in deadlock when  many removers where waiting for
different keys in the case of the MapStagingArea, or were waiting on either peeks or get operations in the StagingArea.

For example, if two removers were waiting for keys 2 and 3 in a MapStaging Area respectively, and 2 was inserted but only 3's remover was notified, it is possible that 2's remover would never be notified resulting in deadlock. Thus, both should be notified.

Similarly in the case of the StagingArea with a remover and a peeker wanting to remove the last element and peek at a specific element respectively, it is not clear which one should be notified due to
an insert. Thus, both should be notified.

Additionally, all inserters are now notified when an element is removed. Consider the case where two inserters are waiting to small elements into the Staging Area and a remover removes a single large element. As there may be space for both insertion elements, both inserters should be notified.