### PR TITLE
Adding equals and hashCode to Shape.

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/Shape.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Shape.java
@@ -119,7 +119,7 @@ public final class Shape {
 
   private boolean hasUnknownDimension() {
     if (shape == null) {
-      return false;
+      return true;
     }
 
     for (long dimension : shape) {

--- a/tensorflow/java/src/main/java/org/tensorflow/Shape.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Shape.java
@@ -77,6 +77,24 @@ public final class Shape {
     return shape[i];
   }
 
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(shape);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj instanceof Shape && Arrays.equals(this.shape, ((Shape) obj).shape)) {
+      return true;
+    }
+
+    return super.equals(obj);
+  }
+
   /** Succinct description of the shape meant for debugging. */
   @Override
   public String toString() {

--- a/tensorflow/java/src/main/java/org/tensorflow/Shape.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Shape.java
@@ -89,7 +89,7 @@ public final class Shape {
     }
 
     if (obj instanceof Shape && Arrays.equals(this.shape, ((Shape) obj).shape)) {
-      return true;
+      return !hasUnknownDimension();
     }
 
     return super.equals(obj);
@@ -116,4 +116,18 @@ public final class Shape {
   }
 
   private long[] shape;
+
+  private boolean hasUnknownDimension() {
+    if (shape == null) {
+      return false;
+    }
+
+    for (long dimension : shape) {
+      if (dimension == -1) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/tensorflow/java/src/test/java/org/tensorflow/ShapeTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/ShapeTest.java
@@ -81,13 +81,16 @@ public class ShapeTest {
 
   @Test
   public void equalsWorksCorrectly() {
-    assertEquals(Shape.make(-1, 2, 3), Shape.make(-1, 2, 3));
     assertEquals(Shape.scalar(), Shape.scalar());
     assertEquals(Shape.unknown(), Shape.unknown());
+    assertEquals(Shape.make(1, 2, 3), Shape.make(1, 2, 3));
 
     assertNotEquals(Shape.make(1,2), null);
     assertNotEquals(Shape.make(1,2), new Object());
-    assertNotEquals(Shape.make(-1, 2, 3), Shape.make(-1, 2, 4));
+    assertNotEquals(Shape.make(1, 2, 3), Shape.make(1, 2, 4));
+
+    assertNotEquals(Shape.make(-1), Shape.make(-1));
+    assertNotEquals(Shape.make(1, -1, 3), Shape.make(1, -1, 3));
   }
 
   @Test

--- a/tensorflow/java/src/test/java/org/tensorflow/ShapeTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/ShapeTest.java
@@ -16,10 +16,13 @@ limitations under the License.
 package org.tensorflow;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
 
 /** Unit tests for {@link Shape}. */
 @RunWith(JUnit4.class)
@@ -77,4 +80,36 @@ public class ShapeTest {
       assertEquals(5, n.shape().size(1));
     }
   }
+
+  @Test
+  public void equalsWorksCorrectly() {
+    Shape s1 = Shape.make(-1, 2, 3);
+    Shape s2 = s1;
+    Shape s3 = Shape.make(-1, 2, 3);
+    Shape s4 = Shape.make(-1, 2, 4);
+    Shape s5 = Shape.make(-1, 2, 3, 4);
+    Shape s6 = Shape.make(-1, 2);
+    Object o = new Object();
+
+    assertEquals(s1, s2);
+    assertEquals(s1, s3);
+    assertNotEquals(s1, s4);
+    assertNotEquals(s1, s5);
+    assertNotEquals(s1, s6);
+    assertNotEquals(s1, o);
+    assertNotEquals(s1, null);
+  }
+
+  @Test
+  public void hashCodeIsAsExpected() {
+    long[] d1 = new long[] {1, 2, 3, 4};
+    long[] d2 = new long[] {};
+
+    Shape s1 = Shape.make(1, 2, 3, 4);
+    Shape s2 = Shape.scalar();
+
+    assertEquals(Arrays.hashCode(d1), s1.hashCode());
+    assertEquals(Arrays.hashCode(d2), s2.hashCode());
+  }
 }
+

--- a/tensorflow/java/src/test/java/org/tensorflow/ShapeTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/ShapeTest.java
@@ -82,13 +82,14 @@ public class ShapeTest {
   @Test
   public void equalsWorksCorrectly() {
     assertEquals(Shape.scalar(), Shape.scalar());
-    assertEquals(Shape.unknown(), Shape.unknown());
     assertEquals(Shape.make(1, 2, 3), Shape.make(1, 2, 3));
 
     assertNotEquals(Shape.make(1,2), null);
     assertNotEquals(Shape.make(1,2), new Object());
     assertNotEquals(Shape.make(1, 2, 3), Shape.make(1, 2, 4));
 
+
+    assertNotEquals(Shape.unknown(), Shape.unknown());
     assertNotEquals(Shape.make(-1), Shape.make(-1));
     assertNotEquals(Shape.make(1, -1, 3), Shape.make(1, -1, 3));
   }

--- a/tensorflow/java/src/test/java/org/tensorflow/ShapeTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/ShapeTest.java
@@ -22,8 +22,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.Arrays;
-
 /** Unit tests for {@link Shape}. */
 @RunWith(JUnit4.class)
 public class ShapeTest {
@@ -83,33 +81,22 @@ public class ShapeTest {
 
   @Test
   public void equalsWorksCorrectly() {
-    Shape s1 = Shape.make(-1, 2, 3);
-    Shape s2 = s1;
-    Shape s3 = Shape.make(-1, 2, 3);
-    Shape s4 = Shape.make(-1, 2, 4);
-    Shape s5 = Shape.make(-1, 2, 3, 4);
-    Shape s6 = Shape.make(-1, 2);
-    Object o = new Object();
+    assertEquals(Shape.make(-1, 2, 3), Shape.make(-1, 2, 3));
+    assertEquals(Shape.scalar(), Shape.scalar());
+    assertEquals(Shape.unknown(), Shape.unknown());
 
-    assertEquals(s1, s2);
-    assertEquals(s1, s3);
-    assertNotEquals(s1, s4);
-    assertNotEquals(s1, s5);
-    assertNotEquals(s1, s6);
-    assertNotEquals(s1, o);
-    assertNotEquals(s1, null);
+    assertNotEquals(Shape.make(1,2), null);
+    assertNotEquals(Shape.make(1,2), new Object());
+    assertNotEquals(Shape.make(-1, 2, 3), Shape.make(-1, 2, 4));
   }
 
   @Test
   public void hashCodeIsAsExpected() {
-    long[] d1 = new long[] {1, 2, 3, 4};
-    long[] d2 = new long[] {};
+    assertEquals(Shape.make(1, 2, 3, 4).hashCode(), Shape.make(1, 2, 3, 4).hashCode());
+    assertEquals(Shape.scalar().hashCode(), Shape.scalar().hashCode());
+    assertEquals(Shape.unknown().hashCode(), Shape.unknown().hashCode());
 
-    Shape s1 = Shape.make(1, 2, 3, 4);
-    Shape s2 = Shape.scalar();
-
-    assertEquals(Arrays.hashCode(d1), s1.hashCode());
-    assertEquals(Arrays.hashCode(d2), s2.hashCode());
+    assertNotEquals(Shape.make(1, 2).hashCode(), Shape.make(1, 3).hashCode());
   }
 }
 


### PR DESCRIPTION
Hello, I know this is a bit of a simple and trivial pull request.  However, for some other work I'm doing I wanted to compare `Shape` instances in some tests and I found that it didn't work in the standard way.  Hence this pull request to just add an `equals` method. It has some tests and also does `hashCode` because it's a common thing to do at the same time.