### PR TITLE
Minor fix to MKL allocator to address a build regression

### DIFF
--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -51,7 +51,7 @@ class MklCPUAllocator : public Allocator {
   // Constructor and other standard functions
 
   /// Environment variable that user can set to upper bound on memory allocation
-  static constexpr const char kMaxLimitStr[] = "TF_MKL_ALLOC_MAX_BYTES";
+  static constexpr const char* kMaxLimitStr = "TF_MKL_ALLOC_MAX_BYTES";
 
   /// Default upper limit on allocator size - 64GB
   static const size_t kDefaultMaxLimit = 64LL << 30;
@@ -146,7 +146,7 @@ class MklCPUAllocator : public Allocator {
   static const bool kAllowGrowth = true;
 
   /// Name
-  static constexpr const char kName[] = "mklcpu";
+  static constexpr const char* kName = "mklcpu";
 
   /// The alignment that we need for the allocations
   static const size_t kAlignment = 64;

--- a/tensorflow/core/common_runtime/mkl_cpu_allocator_test.cc
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator_test.cc
@@ -23,8 +23,6 @@ limitations under the License.
 
 namespace tensorflow {
 
-constexpr char MklCPUAllocator::kMaxLimitStr[];
-
 TEST(MKLBFCAllocatorTest, TestMaxLimit) {
   AllocatorStats stats;
   setenv(MklCPUAllocator::kMaxLimitStr, "1000", 1);


### PR DESCRIPTION
Uses char* instead of char[] to deal with build issues related to allocator strings.