### PR TITLE
Fix typos in datasets guide

### DIFF
--- a/tensorflow/docs_src/programmers_guide/datasets.md
+++ b/tensorflow/docs_src/programmers_guide/datasets.md
@@ -44,7 +44,7 @@ To start an input pipeline, you must define a *source*. For example, to
 construct a `Dataset` from some tensors in memory, you can use
 `tf.data.Dataset.from_tensors()` or
 `tf.data.Dataset.from_tensor_slices()`. Alternatively, if your input
-data are on disk in the recommend TFRecord format, you can construct a
+data is on disk in the recommended TFRecord format, you can construct a
 `tf.data.TFRecordDataset`.
 
 Once you have a `Dataset` object, you can *transform* it into a new `Dataset` by

--- a/tensorflow/docs_src/programmers_guide/datasets.md
+++ b/tensorflow/docs_src/programmers_guide/datasets.md
@@ -44,7 +44,7 @@ To start an input pipeline, you must define a *source*. For example, to
 construct a `Dataset` from some tensors in memory, you can use
 `tf.data.Dataset.from_tensors()` or
 `tf.data.Dataset.from_tensor_slices()`. Alternatively, if your input
-data is on disk in the recommended TFRecord format, you can construct a
+data are on disk in the recommended TFRecord format, you can construct a
 `tf.data.TFRecordDataset`.
 
 Once you have a `Dataset` object, you can *transform* it into a new `Dataset` by


### PR DESCRIPTION
I think `recommend`->`recommended` is definitely necessary.

`are` to `is` are apparently both technically accepted usages, but `is` is far more common and I believe `are` will sound jarring here to most native English speakers.