### PR TITLE
Clarify low-latency model stride length

### DIFF
--- a/tensorflow/examples/speech_commands/models.py
+++ b/tensorflow/examples/speech_commands/models.py
@@ -326,7 +326,7 @@ def create_low_latency_conv_model(fingerprint_input, model_settings,
   first_filter_height = input_time_size
   first_filter_count = 186
   first_filter_stride_x = 1
-  first_filter_stride_y = 4
+  first_filter_stride_y = 1
   first_weights = tf.Variable(
       tf.truncated_normal(
           [first_filter_height, first_filter_width, 1, first_filter_count],


### PR DESCRIPTION
`first_filter_stride_y = 4` has no effect, since `first_filter_height = input_time_size`. If `cnn-one-fstride4` should be used, then `first_filter_stride_x` should be 4 instead. However, during my experimentation `cnn-one-fstride4` provided significantly worse results than the current TF impl, so I think the impl is fine.

This small fix just clarifies that the model isn't striding in the time dimension.