### PR TITLE
Add nth_element op

### DIFF
--- a/tensorflow/contrib/nn/__init__.py
+++ b/tensorflow/contrib/nn/__init__.py
@@ -32,7 +32,7 @@ from tensorflow.contrib.nn.python.ops.alpha_dropout import *
 from tensorflow.contrib.nn.python.ops.cross_entropy import *
 from tensorflow.contrib.nn.python.ops.sampling_ops import *
 from tensorflow.contrib.nn.python.ops.scaled_softplus import *
-from tensorflow.python.ops.gen_nn_ops import nth_element
+from tensorflow.python.ops.nn_ops import nth_element
 # pylint: enable=unused-import,wildcard-import
 
 from tensorflow.python.util.all_util import remove_undocumented

--- a/tensorflow/contrib/nn/__init__.py
+++ b/tensorflow/contrib/nn/__init__.py
@@ -18,6 +18,7 @@
 @@deprecated_flipped_softmax_cross_entropy_with_logits
 @@deprecated_flipped_sparse_softmax_cross_entropy_with_logits
 @@deprecated_flipped_sigmoid_cross_entropy_with_logits
+@@nth_element
 @@rank_sampled_softmax_loss
 @@scaled_softplus
 """
@@ -31,6 +32,7 @@ from tensorflow.contrib.nn.python.ops.alpha_dropout import *
 from tensorflow.contrib.nn.python.ops.cross_entropy import *
 from tensorflow.contrib.nn.python.ops.sampling_ops import *
 from tensorflow.contrib.nn.python.ops.scaled_softplus import *
+from tensorflow.python.ops.gen_nn_ops import nth_element
 # pylint: enable=unused-import,wildcard-import
 
 from tensorflow.python.util.all_util import remove_undocumented

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2999,6 +2999,7 @@ cc_library(
         ":softsign_op",
         ":topk_op",
         ":xent_op",
+        ":nth_element_op",
     ],
 )
 
@@ -3077,6 +3078,12 @@ tf_kernel_library(
     name = "topk_op",
     prefix = "topk_op",
     deps = NN_DEPS + if_cuda(["@cub_archive//:cub"]),
+)
+
+tf_kernel_library(
+    name = "nth_element_op",
+    prefix = "nth_element_op",
+    deps = NN_DEPS,
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2993,13 +2993,13 @@ cc_library(
         ":in_topk_op",
         ":l2loss_op",
         ":lrn_op",
+        ":nth_element_op",
         ":relu_op",
         ":softmax_op",
         ":softplus_op",
         ":softsign_op",
         ":topk_op",
         ":xent_op",
-        ":nth_element_op",
     ],
 )
 

--- a/tensorflow/core/kernels/nth_element_op.cc
+++ b/tensorflow/core/kernels/nth_element_op.cc
@@ -1,0 +1,139 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/nn_ops.cc.
+#include "tensorflow/core/kernels/nth_element_op.h"
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/util/work_sharder.h"
+#include <vector>
+#include <algorithm>
+#include <iostream>
+
+namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+template <typename Device, typename T>
+class NthElementOp : public OpKernel {
+ public:
+  explicit NthElementOp(OpKernelConstruction* context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("reverse", &reverse_));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    // The second args is N, which must be a positive scalar.
+    const auto& n_in = context->input(1);
+    OP_REQUIRES(context, TensorShapeUtils::IsScalar(n_in.shape()),
+                errors::InvalidArgument("N must be scalar, got shape ",
+                                        n_in.shape().DebugString()));
+    int n = n_in.scalar<int32>()();
+    OP_REQUIRES(context, n >= 0,
+                errors::InvalidArgument("Need n >= 0, got ", n));
+
+    // The first args is input tensor, which must have 1 dimension at least.
+    const Tensor& input_in = context->input(0);
+    const int num_dims = input_in.dims();
+    OP_REQUIRES(context, num_dims >= 1,
+                errors::InvalidArgument("Input must be >= 1-D, got shape ",
+                                        input_in.shape().DebugString()));
+    // The last dimension of input tensor must be greater than N.
+    OP_REQUIRES(context, input_in.dim_size(num_dims-1) > n,
+                errors::InvalidArgument("Input must have at least n+1 columns"));
+
+    // std::nth_element only support the nth-smallest selection.
+    if (reverse_) {
+      n = input_in.dim_size(num_dims - 1) - n - 1;
+    }
+
+    // Assume input_shape is [d1,d2,...dk], and output_shape is [d1,d2...dk-1].
+    TensorShape out_shape;
+    for (int i = 0; i < num_dims-1; ++i) {
+      out_shape.AddDim(input_in.dim_size(i));
+    }
+    Tensor* output_tensor = nullptr;
+    OP_REQUIRES_OK(context,
+                   context->allocate_output(0, out_shape, &output_tensor));
+
+    functor::NthElementFunctor<Device, T> nthElementFunc;
+    nthElementFunc(context, input_in, *output_tensor, n, reverse_);
+  }
+
+ private:
+  bool reverse_;
+};
+
+namespace functor {
+
+template <typename T>
+struct NthElementFunctor<CPUDevice, T> {
+  void operator() (OpKernelContext* context,
+                   const Tensor& input_tensor,
+                   Tensor& output_tensor,
+                   int n,
+                   bool reverse) {
+    const T* input = input_tensor.flat<T>().data();
+    T* output = output_tensor.flat<T>().data();
+
+    // Assume input_shape is [d1,d2,...dk], and output_shape is [d1,d2...dk-1],
+    // then num_rows = d1*d2...dk-1, last_dim = dk.
+    const int num_rows = output_tensor.NumElements();
+    const int last_dim = input_tensor.dim_size(input_tensor.dims()-1);
+
+    // Allocate each row to different shard.
+    auto SubNthElement = [&, input, output, last_dim, n](int start,
+                                                         int limit) {
+      // std::nth_element would rearrange the array, so we need a new buffer.
+      std::vector<T> buf(last_dim);
+
+      for (int b = start; b < limit; ++b) {
+        // Copy from one row of elements to buffer
+        const T* input_start = input + b * last_dim;
+        const T* input_end = input + (b+1) * last_dim;
+        std::copy(input_start, input_end, buf.begin());
+
+        std::nth_element(buf.begin(), buf.begin()+n, buf.end());
+        // The element placed in the nth position is exactly the element that
+        // would occur in this position if the range was fully sorted.
+        output[b] = buf[n];
+      }
+    };
+
+    auto worker_threads = *(context->device()->tensorflow_cpu_worker_threads());
+    // The average time complexity of partition-based nth_element (BFPRT) is O(n),
+    // althought the worst time complexity could be O(n^2).
+    // Here, 20 is a empirical factor of cost_per_unit.
+    Shard(worker_threads.num_threads, worker_threads.workers, num_rows,
+          20 * last_dim, SubNthElement);
+  }
+};
+
+}  // namespace functor
+
+
+#define REGISTER_NTHOP(T)                                           \
+  REGISTER_KERNEL_BUILDER(                                          \
+      Name("NthElement").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
+      NthElementOp<CPUDevice, T>)
+
+TF_CALL_REAL_NUMBER_TYPES(REGISTER_NTHOP);
+#undef REGISTER_NTHOP
+
+}  // end namespace tensorflow
+

--- a/tensorflow/core/kernels/nth_element_op.h
+++ b/tensorflow/core/kernels/nth_element_op.h
@@ -1,0 +1,39 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_NTH_ELEMENT_OP_H_
+#define TENSORFLOW_NTH_ELEMENT_OP_H_
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/platform/types.h"
+
+namespace tensorflow {
+
+namespace functor {
+
+template <typename Device, typename T>
+struct NthElementFunctor {
+  void operator() (OpKernelContext* context,
+                   const Tensor& input_tensor,
+                   Tensor& output_tensor,
+                   int n);
+};
+
+}  // namespace functor
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_NTH_ELEMENT_OP_H_

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -2260,6 +2260,56 @@ indices: The indices of `values` within the last dimension of `input`.
 
 // --------------------------------------------------------------------------
 
+REGISTER_OP("NthElement")
+    .Input("input: T")
+    .Input("n: int32")
+    .Output("values: T")
+    .Attr("reverse: bool = false")
+    .Attr("T: realnumbertype")
+    .SetShapeFn([](InferenceContext* c) {
+      ShapeHandle input;
+      TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &input));
+
+      // Get the n value from input tensor, and make sure which is a scalar.
+      DimensionHandle n_dim;
+      TF_RETURN_IF_ERROR(c->MakeDimForScalarInput(1, &n_dim));
+
+      // The last dimension of input tensor must be greater than N.
+      DimensionHandle last_dim = c->Dim(input, -1);
+      if (c->ValueKnown(last_dim) && c->ValueKnown(n_dim) &&
+          c->Value(last_dim) <= c->Value(n_dim)) {
+        return errors::InvalidArgument(
+            "Input must have last dimension > n = ", c->Value(n_dim), " but is ",
+            c->Value(last_dim));
+      }
+
+      // Reduce last_dim for output tensor
+      ShapeHandle s;
+      TF_RETURN_IF_ERROR(c->Subshape(input, 0, -1, &s));
+      c->set_output(0, s);
+      return Status::OK();
+    })
+    .Doc(R"doc(
+Finds values of the `n`-th order statistic for the last dmension.
+
+If the input is a vector (rank-1), finds the entries which is the nth-smallest
+value in the vector and outputs their values as scalar tensor.
+
+For matrices (resp. higher rank input), computes the entries which is the
+nth-smallest value in each row (resp. vector along the last dimension). Thus,
+
+    values.shape = input.shape[:-1]
+
+input: 1-D or higher with last dimension at least `n+1`.
+n: 0-D. Position of sorted vector to select along the last dimension (along
+  each row for matrices). Valid range of n is `[0, input.shape[:-1])`
+reverse: When set to True, find the nth-largest value in the vector and vice
+  versa.
+values: The `n`-th order statistic along each last dimensional slice.
+)doc");
+
+// --------------------------------------------------------------------------
+
 REGISTER_OP("FractionalMaxPool")
     .Input("value: T")
     .Output("output: T")

--- a/tensorflow/core/ops/nn_ops_test.cc
+++ b/tensorflow/core/ops/nn_ops_test.cc
@@ -81,6 +81,30 @@ TEST(NNOpsTest, TopKV2_ShapeFn) {
       op, "[1,2,3,4];[]");
 }
 
+TEST(NNOpsTest, NthElement_ShapeFn) {
+  ShapeInferenceTestOp op("NthElement");
+  op.input_tensors.resize(2);
+
+  Tensor n_t;
+  op.input_tensors[1] = &n_t;
+  n_t = test::AsScalar<int32>(20);
+
+  INFER_OK(op, "?;[]", "?");
+  INFER_OK(op, "[21];[]", "[]");
+  INFER_OK(op, "[2,?,?];[]", "[d0_0,d0_1]");
+  INFER_OK(op, "[?,3,?,21];[]", "[d0_0,d0_1,d0_2]");
+
+  INFER_ERROR("Shape must be at least rank 1 but is rank 0", op, "[];[]");
+  INFER_ERROR("Input must have last dimension > n = 20 but is 1", op,
+              "[1];[]");
+  INFER_ERROR("Input must have last dimension > n = 20 but is 20", op,
+              "[1,2,3,20];[]");
+  n_t = test::AsScalar<int32>(-1);
+  INFER_ERROR(
+     "Dimension size, given by scalar input 1, must be non-negative but is -1",
+     op, "[1,2,3,4];[]");
+}
+
 TEST(NNOpsTest, BatchNormWithGlobalNormalization_ShapeFn) {
   ShapeInferenceTestOp op("BatchNormWithGlobalNormalization");
 

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -917,6 +917,21 @@ cuda_py_test(
     ],
 )
 
+cuda_py_test(
+    name = "nth_element_op_test",
+    size = "small",
+    srcs = ["nth_element_op_test.py"],
+    additional_deps = [
+        "//third_party/py/numpy",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:gradients",
+        "//tensorflow/python:nn_grad",
+        "//tensorflow/python:nn_ops",
+    ],
+)
+
 tf_py_test(
     name = "unique_op_test",
     size = "small",

--- a/tensorflow/python/kernel_tests/nth_element_op_test.py
+++ b/tensorflow/python/kernel_tests/nth_element_op_test.py
@@ -1,0 +1,174 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+import tensorflow.python.ops.nn_grad  # pylint: disable=unused-import
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import nn_ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gradients_impl
+from tensorflow.python.platform import test
+
+
+class NthElementTest(test.TestCase):
+
+  def _validateNthElement(self, inputs, dtype, n, reverse, expected_values):
+    np_expected_values = np.array(expected_values)
+    with self.test_session(use_gpu=False) as sess:
+      inputs_op = ops.convert_to_tensor(inputs, dtype=dtype)
+      values_op = nn_ops.nth_element(inputs_op, n, reverse=reverse)
+      values = sess.run(values_op)
+
+      self.assertShapeEqual(np_expected_values, values_op)
+      self.assertAllClose(np_expected_values, values)
+
+  def testExample1(self):
+    inputs = [2.2, 4.4, 1.1, 5.5, 3.3]
+    self._validateNthElement(inputs, dtypes.float32, 1, False, 2.2)
+    self._validateNthElement(inputs, dtypes.float32, 1, True, 4.4)
+
+  def testExample2(self):
+    inputs = [[2.2, 4.4, 1.1], [5.5, 3.3, 6.6]]
+    self._validateNthElement(inputs, dtypes.float64, 2, False, [4.4, 6.6])
+    self._validateNthElement(inputs, dtypes.float64, 2, True, [1.1, 3.3])
+
+  def testExample3(self):
+    inputs = [[[2, 4, 1], [5, -3, 6]],
+              [[7, 9, -8], [9, 0, 4]]]
+    self._validateNthElement(inputs, dtypes.int32, 0, False,
+                             [[1, -3], [-8, 0]])
+    self._validateNthElement(inputs, dtypes.int64, 0, True,
+                             [[4, 6], [9, 9]])
+
+  def _testFloatLargeInput(self, input_shape):
+    inputs = np.random.random_sample(input_shape)
+    n = np.random.randint(input_shape[-1])
+    sort_inputs = np.sort(inputs)
+    expected_values = sort_inputs[..., n]
+    self._validateNthElement(
+        inputs, dtypes.float32, n, False, expected_values)
+    expected_values = sort_inputs[..., ::-1][..., n]
+    self._validateNthElement(
+        inputs, dtypes.float64, n, True, expected_values)
+
+  def _testIntLargeInput(self, input_shape):
+    inputs = np.random.randint(-1e3, 1e3, input_shape)
+    n = np.random.randint(input_shape[-1])
+    sort_inputs = np.sort(inputs)
+    expected_values = sort_inputs[..., n]
+    self._validateNthElement(
+        inputs, dtypes.int32, n, False, expected_values)
+    expected_values = sort_inputs[..., ::-1][..., n]
+    self._validateNthElement(
+        inputs, dtypes.int64, n, True, expected_values)
+
+  def _testLargeInput(self, input_shape):
+    self._testFloatLargeInput(input_shape)
+    self._testIntLargeInput(input_shape)
+
+  def testLargeInput(self):
+    self._testLargeInput([1])
+    self._testLargeInput([10])
+    self._testLargeInput([5, 10])
+    self._testLargeInput([50, 100])
+    self._testLargeInput([50, 10000])
+    self._testLargeInput([50, 10, 100])
+    self._testLargeInput([50, 10, 10, 100])
+
+  def _testEnumerateN(self, input_shape):
+    inputs = np.random.random_sample(input_shape)
+    sort_inputs = np.sort(inputs)
+    for n in range(input_shape[-1]):
+      expected_values = sort_inputs[..., n]
+      self._validateNthElement(
+          inputs, dtypes.float32, n, False, expected_values)
+      expected_values = sort_inputs[..., ::-1][..., n]
+      self._validateNthElement(
+          inputs, dtypes.float64, n, True, expected_values)
+
+  def testEnumerateN(self):
+    self._testEnumerateN([1])
+    self._testEnumerateN([10])
+    self._testEnumerateN([10, 10])
+    self._testEnumerateN([10, 10, 10])
+    self._testEnumerateN([10, 10, 10, 10])
+
+  def testInvalidInput(self):
+    with self.assertRaisesRegexp(ValueError,
+                                 "at least rank 1 but is rank 0"):
+      nn_ops.nth_element(5, 0)
+
+  def testInvalidInputAtEval(self):
+    with self.test_session(use_gpu=False):
+      v = array_ops.placeholder(dtype=dtypes.float32)
+      with self.assertRaisesOpError("Input must be >= 1-D"):
+        nn_ops.nth_element(v, 0).eval(feed_dict={v: 5.0})
+
+  def testInvalidN(self):
+    with self.assertRaisesRegexp(ValueError,
+                                 "non-negative but is -1"):
+      nn_ops.nth_element([5], -1)
+    with self.assertRaisesRegexp(ValueError,
+                                 "scalar but has rank 1"):
+      nn_ops.nth_element([5, 6, 3], [1])
+
+  def testInvalidNAtEval(self):
+    inputs = [[0.1, 0.2], [0.3, 0.4]]
+    with self.test_session(use_gpu=False):
+      n = array_ops.placeholder(dtypes.int32)
+      values = nn_ops.nth_element(inputs, n)
+      with self.assertRaisesOpError("Need n >= 0, got -7"):
+        values.eval(feed_dict={n: -7})
+
+  def testNTooLarge(self):
+    inputs = [[0.1, 0.2], [0.3, 0.4]]
+    with self.assertRaisesRegexp(ValueError,
+                                 "must have last dimension > n = 2"):
+      nn_ops.nth_element(inputs, 2)
+
+  def testNTooLargeAtEval(self):
+    inputs = [[0.1, 0.2], [0.3, 0.4]]
+    with self.test_session(use_gpu=False):
+      n = array_ops.placeholder(dtypes.int32)
+      values = nn_ops.nth_element(inputs, n)
+      with self.assertRaisesOpError(r"Input must have at least n\+1 columns"):
+        values.eval(feed_dict={n: 2})
+
+  def testGradients(self):
+    with self.test_session(use_gpu=False) as sess:
+      inputs = array_ops.placeholder(dtypes.int32, shape=[3, 5])
+      values = nn_ops.nth_element(inputs, 3)
+      grad = sess.run(
+          gradients_impl.gradients(
+              values, inputs, grad_ys=[[-1., 2., 5.]]),
+          feed_dict={inputs: [[2, -1, 1000, 3, 1000],
+                              [1, 5, 2, 4, 3],
+                              [2, 2, 2, 2, 2],
+                             ]})
+    self.assertAllClose(grad[0], [[0, 0, -0.5, 0, -0.5],
+                                  [0, 0, 0, 2, 0],
+                                  [1, 1, 1, 1, 1],
+                                 ])
+
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/ops/nn.py
+++ b/tensorflow/python/ops/nn.py
@@ -88,7 +88,6 @@ See the @{$python/nn} guide.
 @@ctc_beam_search_decoder
 @@top_k
 @@in_top_k
-@@nth_element
 @@nce_loss
 @@sampled_softmax_loss
 @@uniform_candidate_sampler

--- a/tensorflow/python/ops/nn.py
+++ b/tensorflow/python/ops/nn.py
@@ -88,6 +88,7 @@ See the @{$python/nn} guide.
 @@ctc_beam_search_decoder
 @@top_k
 @@in_top_k
+@@nth_element
 @@nce_loss
 @@sampled_softmax_loss
 @@uniform_candidate_sampler

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -934,3 +934,32 @@ def _TopKGrad(op, grad, _):
                                  validate_indices=False),
       in_shape), array_ops.zeros(
           [], dtype=dtypes.int32)]
+
+
+@ops.RegisterGradient("NthElement")
+def _NthElementGrad(op, grad):
+  """Return the gradients for NthElement.
+
+  Args:
+    op: The NthElementOp for which we need to generate gradients.
+    grad: Tensor. The gradients passed to the NthElementOp
+
+  Returns:
+    A list of two tensors, the first being the gradient w.r.t. the input,
+    the second being the gradient w.r.t. the N (None).
+  """
+  input = op.inputs[0]
+  output = op.outputs[0]
+
+  # Compute the number of elements which equal to output in each reduction
+  # dimension. If there are multiple elements then the gradient will be
+  # divided between them.
+  indicators = math_ops.cast(
+      math_ops.equal(array_ops.expand_dims(output, -1), input),
+      grad.dtype)
+
+  grad = array_ops.expand_dims(grad, -1)
+  num_selected = array_ops.expand_dims(
+      math_ops.reduce_sum(indicators, -1), -1)
+
+  return [math_ops.div(indicators, num_selected) * grad, None]

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2140,6 +2140,34 @@ def top_k(input, k=1, sorted=True, name=None):
   return gen_nn_ops._top_kv2(input, k=k, sorted=sorted, name=name)
 
 
+def nth_element(input, n, reverse=False, name=None):
+  r"""Finds values of the `n`-th order statistic for the last dmension.
+
+  If the input is a vector (rank-1), finds the entries which is the nth-smallest
+  value in the vector and outputs their values as scalar tensor.
+
+  For matrices (resp. higher rank input), computes the entries which is the
+  nth-smallest value in each row (resp. vector along the last dimension). Thus,
+
+      values.shape = input.shape[:-1]
+
+  Args:
+    input: 1-D or higher `Tensor` with last dimension at least `n+1`.
+    n: A `Tensor` of type `int32`.
+      0-D. Position of sorted vector to select along the last dimension (along
+      each row for matrices). Valid range of n is `[0, input.shape[:-1])`
+    reverse: An optional `bool`. Defaults to `False`.
+      When set to True, find the nth-largest value in the vector and vice
+      versa.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor`. Has the same type as `input`.
+    The `n`-th order statistic along each last dimensional slice.
+  """
+  return gen_nn_ops.nth_element(input, n, reverse=reverse, name=name)
+
+
 def conv1d(value, filters, stride, padding,
            use_cudnn_on_gpu=None, data_format=None,
            name=None):


### PR DESCRIPTION
This PR tries to settle the issue #13360 and add `NthElement` op in kernel and `tf.nn.nth_element` wrapper for python.

As in `std::nth_element`, this op finds values of the n-th order statistic for the last dmension, which the n-th order statistic is equal to its n-th smallest value. Median is not a reduce(fold) operation technically, this op could be a effective foundation of building `reduce_median` or other quantile function.

This PR support CPU device only. The internal implementation is based on [std::nth_element](http://www.cplusplus.com/reference/algorithm/nth_element/), which has fast average performance of `O(n)` and may has worst average performance of `O(n)` by introselect in some implementations like GCC 4.7 according to this [blog](https://stackoverflow.com/questions/11068429/nth-element-implementations-complexities), I believe it's efficient enough in most of case. And I enhance it in batch mode by multi-thread.

I also add the unit tests both in `core/ops/nn_ops_test.cc` and `python/kernel_tests/nth_element_op_test.py`, and register the gradient op accordingly. The reason why I choose putting it in `nn` module is that I noticed `tf.nn.top_k` which has the similar function did the same.

Furthermore, I'm glad to contribute `reduce_median` based on this op in the future. If there is anything I need to modify, please let me know. Thank you for your review.