### PR TITLE
Fix cmake build with `Dtensorflow_BUILD_ALL_KERNELS=OFF` error

### DIFF
--- a/tensorflow/contrib/cmake/tf_core_kernels.cmake
+++ b/tensorflow/contrib/cmake/tf_core_kernels.cmake
@@ -33,6 +33,8 @@ else(tensorflow_BUILD_ALL_KERNELS)
      "${tensorflow_source_dir}/tensorflow/core/kernels/matmul_op.cc"
      "${tensorflow_source_dir}/tensorflow/core/kernels/no_op.h"
      "${tensorflow_source_dir}/tensorflow/core/kernels/no_op.cc"
+     "${tensorflow_source_dir}/tensorflow/core/kernels/ops_util.h"
+     "${tensorflow_source_dir}/tensorflow/core/kernels/ops_util.cc"
      "${tensorflow_source_dir}/tensorflow/core/kernels/sendrecv_ops.h"
      "${tensorflow_source_dir}/tensorflow/core/kernels/sendrecv_ops.cc"
   )


### PR DESCRIPTION
This fix tries to address the issue raised in #11975 where cmake with `Dtensorflow_BUILD_ALL_KERNELS=OFF` will throw out an error:
```
[ 93%] Building CXX object CMakeFiles/tf_tools_transform_graph_lib.dir/workspace/tensorflow/tools/graph_transforms/freeze_requantization_ranges.cc.o
CMakeFiles/tf_core_cpu.dir/workspace/tensorflow/core/grappler/costs/measuring_cost_estimator.cc.o: In function `tensorflow::grappler::MeasuringCostEstimator::MeasuringCostEstimator(tensorflow::grappler::Cluster*, int, int)':
measuring_cost_estimator.cc:(.text+0x18c): undefined reference to `tensorflow::SanitizeThreadSuffix(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
collect2: error: ld returned 1 exit status
make[2]: *** [benchmark_model] Error 1
CMakeFiles/benchmark_model.dir/build.make:949: recipe for target 'benchmark_model' failed
make[1]: *** [CMakeFiles/benchmark_model.dir/all] Error 2
CMakeFiles/Makefile2:6884: recipe for target 'CMakeFiles/benchmark_model.dir/all' failed
make[1]: *** Waiting for unfinished jobs....
```

The issue is casued by `ops_util.cc` which is needed even if all kernels are OFF.

This fix fixes the issue with cmake file update.

This fix fixes #11975.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>