### PR TITLE
Add GPU and CPU implementation of `tf.histogram_fixed_width`.

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -781,6 +781,7 @@ cc_library(
         "//tensorflow/core/kernels:dataset_ops",
         "//tensorflow/core/kernels:fake_quant_ops",
         "//tensorflow/core/kernels:function_ops",
+        "//tensorflow/core/kernels:histogram_op",
         "//tensorflow/core/kernels:image",
         "//tensorflow/core/kernels:io",
         "//tensorflow/core/kernels:linalg",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2499,6 +2499,7 @@ cc_library(
         ":cross_op",
         ":cwise_op",
         ":fft_ops",
+        ":histogram_op",
         ":matmul_op",
         ":population_count_op",
         ":reduction_ops",
@@ -3094,6 +3095,17 @@ tf_kernel_library(
         "//tensorflow/core:lib_internal",
         "//third_party/eigen3",
     ],
+)
+
+tf_kernel_library(
+    name = "histogram_op",
+    prefix = "histogram_op",
+    deps = [
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//third_party/eigen3",
+    ] + if_cuda(["@cub_archive//:cub"]),
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/histogram_op.cc
+++ b/tensorflow/core/kernels/histogram_op.cc
@@ -1,0 +1,143 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/math_ops.cc.
+
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/kernels/histogram_op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/lib/core/threadpool.h"
+#include "tensorflow/core/platform/types.h"
+
+namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+typedef Eigen::GpuDevice GPUDevice;
+
+namespace functor {
+
+template <typename T, typename Tout>
+struct HistogramFixedWidthFunctor<CPUDevice, T, Tout> {
+  static Status Compute(OpKernelContext* context,
+                        const typename TTypes<T, 1>::ConstTensor& values,
+                        const typename TTypes<T, 1>::ConstTensor& value_range,
+                        int32 nbins, typename TTypes<Tout, 1>::Tensor& out) {
+    const CPUDevice& d = context->eigen_device<CPUDevice>();
+
+    Tensor temp_tensor;
+    TF_RETURN_IF_ERROR(context->allocate_temp(DataTypeToEnum<int32>::value,
+                                              TensorShape({values.size()}),
+                                              &temp_tensor));
+    auto temp = temp_tensor.flat<int32>();
+
+    const double step = static_cast<double>(value_range(1) - value_range(0)) /
+                        static_cast<double>(nbins);
+
+    // The calculation is done by finding the slot of each value in `values`.
+    // With [a, b]:
+    //   step = (b - a) / nbins
+    //   (x - a) / step
+    temp.device(d) =
+        ((values.cwiseMax(value_range(0)) - values.constant(value_range(0)))
+             .template cast<double>() /
+         step)
+            .template cast<int32>()
+            .cwiseMin(nbins - 1);
+
+    for (int32 i = 0; i < temp.size(); i++) {
+      out(temp(i)) += Tout(1);
+    }
+    return Status::OK();
+  }
+};
+
+}  // namespace functor
+
+template <typename Device, typename T, typename Tout>
+class HistogramFixedWidthOp : public OpKernel {
+ public:
+  explicit HistogramFixedWidthOp(OpKernelConstruction* ctx) : OpKernel(ctx) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& values_tensor = ctx->input(0);
+    const Tensor& value_range_tensor = ctx->input(1);
+    const Tensor& nbins_tensor = ctx->input(2);
+
+    OP_REQUIRES(ctx, TensorShapeUtils::IsVector(value_range_tensor.shape()),
+                errors::InvalidArgument("value_range should be a vector."));
+    OP_REQUIRES(ctx, (value_range_tensor.shape().num_elements() == 2),
+                errors::InvalidArgument(
+                    "value_range should be a vector of 2 elements."));
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(nbins_tensor.shape()),
+                errors::InvalidArgument("nbins should be a scalar."));
+
+    const auto values = values_tensor.flat<T>();
+    const auto value_range = value_range_tensor.flat<T>();
+    int32 nbins = nbins_tensor.scalar<int32>()();
+
+    Tensor* out_tensor;
+    OP_REQUIRES_OK(ctx,
+                   ctx->allocate_output(0, TensorShape({nbins}), &out_tensor));
+    auto out = out_tensor->flat<Tout>();
+
+    OP_REQUIRES_OK(
+        ctx, functor::HistogramFixedWidthFunctor<Device, T, Tout>::Compute(
+                 ctx, values, value_range, nbins, out));
+  }
+};
+
+#define REGISTER_KERNELS(type)                                           \
+  REGISTER_KERNEL_BUILDER(Name("HistogramFixedWidth")                    \
+                              .Device(DEVICE_CPU)                        \
+                              .TypeConstraint<type>("T")                 \
+                              .TypeConstraint<int32>("Tout"),            \
+                          HistogramFixedWidthOp<CPUDevice, type, int32>) \
+  REGISTER_KERNEL_BUILDER(Name("HistogramFixedWidth")                    \
+                              .Device(DEVICE_CPU)                        \
+                              .TypeConstraint<type>("T")                 \
+                              .TypeConstraint<int64>("Tout"),            \
+                          HistogramFixedWidthOp<CPUDevice, type, int64>)
+
+TF_CALL_REAL_NUMBER_TYPES(REGISTER_KERNELS);
+#undef REGISTER_KERNELS
+
+#if GOOGLE_CUDA
+#define REGISTER_KERNELS(type)                                           \
+  REGISTER_KERNEL_BUILDER(Name("HistogramFixedWidth")                    \
+                              .Device(DEVICE_GPU)                        \
+                              .HostMemory("value_range")                 \
+                              .HostMemory("nbins")                       \
+                              .HostMemory("out")                         \
+                              .TypeConstraint<type>("T")                 \
+                              .TypeConstraint<int32>("Tout"),            \
+                          HistogramFixedWidthOp<GPUDevice, type, int32>) \
+  REGISTER_KERNEL_BUILDER(Name("HistogramFixedWidth")                    \
+                              .Device(DEVICE_GPU)                        \
+                              .HostMemory("value_range")                 \
+                              .HostMemory("nbins")                       \
+                              .HostMemory("out")                         \
+                              .TypeConstraint<type>("T")                 \
+                              .TypeConstraint<int64>("Tout"),            \
+                          HistogramFixedWidthOp<GPUDevice, type, int64>)
+
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_KERNELS);
+#undef REGISTER_KERNELS
+
+#endif  // GOOGLE_CUDA
+
+}  // end namespace tensorflow

--- a/tensorflow/core/kernels/histogram_op.h
+++ b/tensorflow/core/kernels/histogram_op.h
@@ -20,10 +20,8 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/lib/core/errors.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
-
 namespace functor {
 
 template <typename Device, typename T, typename Tout>
@@ -35,7 +33,6 @@ struct HistogramFixedWidthFunctor {
 };
 
 }  // end namespace functor
-
 }  // end namespace tensorflow
 
 #endif  // TENSORFLOW_HISTOGRAM_OP_H_

--- a/tensorflow/core/kernels/histogram_op.h
+++ b/tensorflow/core/kernels/histogram_op.h
@@ -1,0 +1,41 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_HISTOGRAM_OP_H_
+#define TENSORFLOW_HISTOGRAM_OP_H_
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+namespace tensorflow {
+
+namespace functor {
+
+template <typename Device, typename T, typename Tout>
+struct HistogramFixedWidthFunctor {
+  static Status Compute(OpKernelContext* context,
+                        const typename TTypes<T, 1>::ConstTensor& values,
+                        const typename TTypes<T, 1>::ConstTensor& value_range,
+                        int32 nbins, typename TTypes<Tout, 1>::Tensor& out);
+};
+
+}  // end namespace functor
+
+}  // end namespace tensorflow
+
+#endif  // TENSORFLOW_HISTOGRAM_OP_H_

--- a/tensorflow/core/kernels/histogram_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/histogram_op_gpu.cu.cc
@@ -1,0 +1,135 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA
+
+#define EIGEN_USE_GPU
+
+#include "tensorflow/core/kernels/histogram_op.h"
+#include <cmath>
+#include <vector>
+#include "external/cub_archive/cub/device/device_histogram.cuh"
+#include "external/cub_archive/cub/iterator/counting_input_iterator.cuh"
+#include "external/cub_archive/cub/iterator/transform_input_iterator.cuh"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/cuda_kernel_helper.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+namespace functor {
+
+template <typename T, typename Tout>
+struct HistogramFixedWidthFunctor<GPUDevice, T, Tout> {
+  static Status Compute(OpKernelContext* context,
+                        const typename TTypes<T, 1>::ConstTensor& values,
+                        const typename TTypes<T, 1>::ConstTensor& value_range,
+                        int32 nbins, typename TTypes<Tout, 1>::Tensor& out) {
+    // It seems int64 of atomicAdd is not supported yet.
+    // We use int32 and then cast to int64 for output
+    tensorflow::AllocatorAttributes pinned_allocator;
+    pinned_allocator.set_on_host(true);
+    pinned_allocator.set_gpu_compatible(true);
+
+    Tensor histogram_tensor;
+    TF_RETURN_IF_ERROR(context->allocate_temp(
+        DataTypeToEnum<int32>::value, TensorShape({out.size()}),
+        &histogram_tensor, pinned_allocator));
+    auto histogram = histogram_tensor.flat<int32>();
+    histogram.setZero();
+
+    Tensor levels_tensor;
+    TF_RETURN_IF_ERROR(context->allocate_temp(
+        DataTypeToEnum<T>::value, TensorShape({nbins + 1}), &levels_tensor,
+        pinned_allocator));
+    auto levels = levels_tensor.flat<T>();
+
+    const double step = static_cast<double>(value_range(1) - value_range(0)) /
+                        static_cast<double>(nbins);
+    double curr = static_cast<double>(value_range(0)) + step;
+    levels(0) = std::numeric_limits<T>::lowest();
+    for (int i = 1; i < nbins; i++) {
+      levels(i) = T(curr);
+      curr += step;
+    }
+    levels(nbins) = std::numeric_limits<T>::max();
+
+    size_t temp_storage_bytes = 0;
+    const T* d_samples = values.data();
+    int32* d_histogram = histogram.data();
+    int num_levels = levels.size();
+    T* d_levels = levels.data();
+    int num_samples = values.size();
+    const cudaStream_t& stream = GetCudaStream(context);
+
+    auto err = cub::DeviceHistogram::HistogramRange(
+        /* d_temp_storage */ NULL,
+        /* temp_storage_bytes */ temp_storage_bytes,
+        /* d_samples */ d_samples,
+        /* d_histogram */ d_histogram,
+        /* num_levels */ num_levels,
+        /* d_levels */ d_levels,
+        /* num_samples */ num_samples,
+        /* stream */ stream);
+    if (err != cudaSuccess) {
+      return errors::Internal("Could not launch HistogramFixedWidthKernel: ",
+                              cudaGetErrorString(err), ".");
+    }
+
+    Tensor temp_storage;
+    TF_RETURN_IF_ERROR(context->allocate_temp(
+        DataTypeToEnum<int8>::value,
+        TensorShape({static_cast<int64>(temp_storage_bytes)}), &temp_storage));
+
+    void* d_temp_storage = temp_storage.flat<int8>().data();
+
+    err = cub::DeviceHistogram::HistogramRange(
+        /* d_temp_storage */ d_temp_storage,
+        /* temp_storage_bytes */ temp_storage_bytes,
+        /* d_samples */ d_samples,
+        /* d_histogram */ d_histogram,
+        /* num_levels */ num_levels,
+        /* d_levels */ d_levels,
+        /* num_samples */ num_samples,
+        /* stream */ stream);
+    if (err != cudaSuccess) {
+      return errors::Internal("Could not launch HistogramFixedWidthKernel: ",
+                              cudaGetErrorString(err), ".");
+    }
+    out = histogram.template cast<Tout>();
+
+    return Status::OK();
+  }
+};
+
+}  // end namespace functor
+
+#define REGISTER_GPU_SPEC(type)                                                \
+  template struct functor::HistogramFixedWidthFunctor<GPUDevice, type, int32>; \
+  template struct functor::HistogramFixedWidthFunctor<GPUDevice, type, int64>;
+
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPEC);
+#undef REGISTER_GPU_SPEC
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -2253,10 +2253,10 @@ product: Pairwise cross product of the vectors in `a` and `b`.
 REGISTER_OP("HistogramFixedWidth")
     .Input("values: T")
     .Input("value_range: T")
-    .Input("nbins: int32")
-    .Output("out: Tout")
+    .Output("out: dtype")
+    .Attr("nbins: int = 100")
     .Attr("T: {int32, int64, float32, float64}")
-    .Attr("Tout: {int32, int64} = DT_INT32")
+    .Attr("dtype: {int32, int64} = DT_INT32")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->UnknownShapeOfRank(1));
       return Status::OK();

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -2265,7 +2265,7 @@ REGISTER_OP("HistogramFixedWidth")
 Return histogram of values.
 
 Given the tensor `values`, this operation returns a rank 1 histogram counting
-the number of entries in `values` that fell into every bin.  The bins are
+the number of entries in `values` that fall into every bin.  The bins are
 equal width and determined by the arguments `value_range` and `nbins`.
 
 ```python

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -2250,6 +2250,44 @@ product: Pairwise cross product of the vectors in `a` and `b`.
 
 // --------------------------------------------------------------------------
 
+REGISTER_OP("HistogramFixedWidth")
+    .Input("values: T")
+    .Input("value_range: T")
+    .Input("nbins: int32")
+    .Output("out: Tout")
+    .Attr("T: {int32, int64, float32, float64}")
+    .Attr("Tout: {int32, int64} = DT_INT32")
+    .SetShapeFn([](InferenceContext* c) {
+      c->set_output(0, c->UnknownShapeOfRank(1));
+      return Status::OK();
+    })
+    .Doc(R"doc(
+Return histogram of values.
+
+Given the tensor `values`, this operation returns a rank 1 histogram counting
+the number of entries in `values` that fell into every bin.  The bins are
+equal width and determined by the arguments `value_range` and `nbins`.
+
+```python
+# Bins will be:  (-inf, 1), [1, 2), [2, 3), [3, 4), [4, inf)
+nbins = 5
+value_range = [0.0, 5.0]
+new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
+
+with tf.get_default_session() as sess:
+  hist = tf.histogram_fixed_width(new_values, value_range, nbins=5)
+  variables.global_variables_initializer().run()
+  sess.run(hist) => [2, 1, 1, 0, 2]
+```
+
+values:  Numeric `Tensor`.
+value_range:  Shape [2] `Tensor` of same `dtype` as `values`.
+  values <= value_range[0] will be mapped to hist[0],
+  values >= value_range[1] will be mapped to hist[-1].
+nbins:  Scalar `int32 Tensor`.  Number of histogram bins.
+out: A 1-D `Tensor` holding histogram of values.
+)doc");
+
 REGISTER_OP("Bincount")
     .Input("arr: int32")
     .Input("size: int32")

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -28,6 +28,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import clip_ops
+from tensorflow.python.ops import gen_math_ops
 from tensorflow.python.ops import math_ops
 
 
@@ -69,30 +70,6 @@ def histogram_fixed_width(values,
   ```
   """
   with ops.name_scope(name, 'histogram_fixed_width',
-                      [values, value_range, nbins]) as scope:
-    values = ops.convert_to_tensor(values, name='values')
-    values = array_ops.reshape(values, [-1])
-    value_range = ops.convert_to_tensor(value_range, name='value_range')
-    nbins = ops.convert_to_tensor(nbins, dtype=dtypes.int32, name='nbins')
-    nbins_float = math_ops.cast(nbins, values.dtype)
-
-    # Map tensor values that fall within value_range to [0, 1].
-    scaled_values = math_ops.truediv(values - value_range[0],
-                                     value_range[1] - value_range[0],
-                                     name='scaled_values')
-
-    # map tensor values within the open interval value_range to {0,.., nbins-1},
-    # values outside the open interval will be zero or less, or nbins or more.
-    indices = math_ops.floor(nbins_float * scaled_values, name='indices')
-
-    # Clip edge cases (e.g. value = value_range[1]) or "outliers."
-    indices = math_ops.cast(
-        clip_ops.clip_by_value(indices, 0, nbins_float - 1), dtypes.int32)
-
-    # TODO(langmore) This creates an array of ones to add up and place in the
-    # bins.  This is inefficient, so replace when a better Op is available.
-    return math_ops.unsorted_segment_sum(
-        array_ops.ones_like(indices, dtype=dtype),
-        indices,
-        nbins,
-        name=scope)
+                      [values, value_range, nbins]) as name:
+    return gen_math_ops.histogram_fixed_width(values, value_range, nbins,
+                                              Tout=dtype, name=name)

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -72,4 +72,4 @@ def histogram_fixed_width(values,
   with ops.name_scope(name, 'histogram_fixed_width',
                       [values, value_range, nbins]) as name:
     return gen_math_ops.histogram_fixed_width(values, value_range, nbins,
-                                              Tout=dtype, name=name)
+                                              dtype=dtype, name=name)

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -36,7 +36,7 @@ class HistogramFixedWidthTest(test.TestCase):
     value_range = [0.0, 5.0]
     values = []
     expected_bin_counts = [0, 0, 0, 0, 0]
-    with self.test_session():
+    with self.test_session(use_gpu=True):
       hist = histogram_ops.histogram_fixed_width(values, value_range, nbins=5)
       self.assertEqual(dtypes.int32, hist.dtype)
       self.assertAllClose(expected_bin_counts, hist.eval())
@@ -47,7 +47,7 @@ class HistogramFixedWidthTest(test.TestCase):
     value_range = [0.0, 5.0]
     values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
     expected_bin_counts = [2, 1, 1, 0, 2]
-    with self.test_session():
+    with self.test_session(use_gpu=True):
       hist = histogram_ops.histogram_fixed_width(
           values, value_range, nbins=5, dtype=dtypes.int64)
       self.assertEqual(dtypes.int64, hist.dtype)
@@ -59,7 +59,7 @@ class HistogramFixedWidthTest(test.TestCase):
     value_range = np.float64([0.0, 5.0])
     values = np.float64([-1.0, 0.0, 1.5, 2.0, 5.0, 15])
     expected_bin_counts = [2, 1, 1, 0, 2]
-    with self.test_session():
+    with self.test_session(use_gpu=True):
       hist = histogram_ops.histogram_fixed_width(values, value_range, nbins=5)
       self.assertEqual(dtypes.int32, hist.dtype)
       self.assertAllClose(expected_bin_counts, hist.eval())
@@ -70,7 +70,7 @@ class HistogramFixedWidthTest(test.TestCase):
     value_range = [0.0, 5.0]
     values = [[-1.0, 0.0, 1.5], [2.0, 5.0, 15]]
     expected_bin_counts = [2, 1, 1, 0, 2]
-    with self.test_session():
+    with self.test_session(use_gpu=True):
       hist = histogram_ops.histogram_fixed_width(values, value_range, nbins=5)
       self.assertEqual(dtypes.int32, hist.dtype)
       self.assertAllClose(expected_bin_counts, hist.eval())


### PR DESCRIPTION
This fix adds the GPU and CPU implementation of `tf.histogram_fixed_width`.

The previous implementation was done in python. This fix adds C++ kernel for GPU and CPU.

The GPU version uses `CUB`'s API `cub::DeviceHistogram::HistogramRange`. The `range` is  constructed from the upper/lower limit and step size. (`HistogramEven` could not be used directly as the edge case is different).

The CPU version uses a transform to map the input into the bucket index, then did a bin count.

Note the output type of int64 on GPU is not supported yet as atomicAdd has no int64 at the moment.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>