### PR TITLE
Fix build error with boringssl

### DIFF
--- a/third_party/boringssl/add_boringssl_s390x.patch
+++ b/third_party/boringssl/add_boringssl_s390x.patch
@@ -1,13 +1,23 @@
-diff --git a/src/include/openssl/base.h b/src/include/openssl/base.h
-index 7a3adfb..88012ad 100644
---- a/src/include/openssl/base.h
-+++ b/src/include/openssl/base.h
-@@ -94,6 +94,8 @@ extern "C" {
+diff -ur a/BUILD b/BUILD
+--- a/BUILD	2017-10-10 15:50:34.000000000 +0000
++++ b/BUILD	2017-10-15 19:58:58.509491455 +0000
+@@ -63,6 +63,7 @@
+     "-Wwrite-strings",
+     "-Wshadow",
+     "-fno-common",
++    "-Wno-maybe-uninitialized",
+ 
+     # Modern build environments should be able to set this to use atomic
+     # operations for reference counting rather than locks. However, it's
+diff -ur a/src/include/openssl/base.h b/src/include/openssl/base.h
+--- a/src/include/openssl/base.h	2017-10-10 15:50:34.000000000 +0000
++++ b/src/include/openssl/base.h	2017-10-15 19:49:38.182154627 +0000
+@@ -106,6 +106,8 @@
  #define OPENSSL_PNACL
  #elif defined(__myriad2__)
  #define OPENSSL_32_BIT
 +#elif defined(__s390x__)
 +#define OPENSSL_64_BIT
  #else
- #error "Unknown target CPU"
- #endif
+ // Note BoringSSL only supports standard 32-bit and 64-bit two's-complement,
+ // little-endian architectures. Functions will not produce the correct answer

--- a/third_party/boringssl/add_boringssl_s390x.patch
+++ b/third_party/boringssl/add_boringssl_s390x.patch
@@ -1,11 +1,11 @@
 diff -ur a/BUILD b/BUILD
 --- a/BUILD	2017-10-10 15:50:34.000000000 +0000
-+++ b/BUILD	2017-10-15 19:58:58.509491455 +0000
++++ b/BUILD	2017-10-15 21:19:02.057606476 +0000
 @@ -63,6 +63,7 @@
      "-Wwrite-strings",
      "-Wshadow",
      "-fno-common",
-+    "-Wno-maybe-uninitialized",
++    "-Wno-uninitialized",
  
      # Modern build environments should be able to set this to use atomic
      # operations for reference counting rather than locks. However, it's


### PR DESCRIPTION
This fix tries to fix build error with boringssl on `Ubuntu 16.04`, `gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)`, and `bazel` `0.6.1`:

```sh
  /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -B/usr/bin -B/usr/bin -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections -fdata-sections '-march=native' -MD -MF bazel-out/local-opt/bin/external/curl/_objs/curl/external/curl/lib/curl_multibyte.pic.d -fPIC -iquote external/curl -iquote bazel-out/local-opt/genfiles/external/curl -iquote external/zlib_archive -iquote bazel-out/local-opt/genfiles/external/zlib_archive -iquote external/bazel_tools -iquote bazel-out/local-opt/genfiles/external/bazel_tools -iquote external/boringssl -iquote bazel-out/local-opt/genfiles/external/boringssl -isystem external/curl/include -isystem bazel-out/local-opt/genfiles/external/curl/include -isystem external/zlib_archive -isystem bazel-out/local-opt/genfiles/external/zlib_archive -isystem external/bazel_tools/tools/cpp/gcc3 -isystem external/boringssl/src/include -isystem bazel-out/local-opt/genfiles/external/boringssl/src/include -Iexternal/curl/lib -D_GNU_SOURCE -DHAVE_CONFIG_H -DCURL_DISABLE_FTP -DCURL_DISABLE_NTLM -DHAVE_LIBZ -DHAVE_ZLIB_H -Wno-string-plus-int '-DCURL_MAX_WRITE_SIZE=65536' -fno-canonical-system-headers -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -c external/curl/lib/curl_multibyte.c -o bazel-out/local-opt/bin/external/curl/_objs/curl/external/curl/lib/curl_multibyte.pic.o)
ERROR: /home/ubuntu/.cache/bazel/_bazel_ubuntu/ad1e09741bb4109fbc70ef8216b59ee2/external/boringssl/BUILD:128:1: C++ compilation of rule '@boringssl//:ssl' failed (Exit 1)
external/boringssl/src/ssl/t1_lib.cc: In function 'int bssl::ssl_ext_key_share_parse_clienthello(bssl::SSL_HANDSHAKE*, bool*, bssl::Array<unsigned char>*, uint8_t*, CBS*)':
external/boringssl/src/ssl/t1_lib.cc:2189:7: error: 'peer_key.cbs_st::len' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   CBS peer_key;
           ^
external/boringssl/src/ssl/t1_lib.cc:2189:7: error: 'peer_key.cbs_st::data' may be used uninitialized in this function [-Werror=maybe-uninitialized]
cc1plus: all warnings being treated as errors
Target //tensorflow/tools/pip_package:build_pip_package failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 107.966s, Critical Path: 18.12s
FAILED: Build did NOT complete successfully
```

This fix is related to PR #13638

This fix fixes #13733.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>