### PR TITLE
Propagate -DPCRE_STATIC from pcre.BUILD to swig.BUILD

### DIFF
--- a/third_party/pcre.BUILD
+++ b/third_party/pcre.BUILD
@@ -50,12 +50,12 @@ cc_library(
         "-DNEWLINE=10",
         "-DNO_RECURSE",
         "-DPARENS_NEST_LIMIT=50",
-        "-DPCRE_STATIC=1",
         "-DPOSIX_MALLOC_THRESHOLD=10",
         "-DSTDC_HEADERS=1",
         "-DSUPPORT_UCP",
         "-DSUPPORT_UTF",
     ],
+    defines = ["PCRE_STATIC=1"],
     includes = ["."],
     visibility = ["@swig//:__pkg__"],  # Please use RE2
     alwayslink = 1,


### PR DESCRIPTION
pcre_internal.h uses this macro to determine the content of PCRE_EXP_DECL. So, in order to keep consistent, every file who includes pcre_internal.h  directly or indirectly should also have this macro defined.

This pull request is for fix a build error on Windows:
<hr/>
ERROR: C:/os/t/external/swig/BUILD.bazel:5:1: Linking of rule '@swig//:swig' failed (Exit 1120): link.exe failed: error executing command                          <br/>
misc.o : error LNK2019: unresolved external symbol __imp_pcre_compile referenced in function Swig_string_regex <br/>                      
naming.o : error LNK2001: unresolved external symbol __imp_pcre_compile                       
misc.o : error LNK2019: unresolved external symbol __imp_pcre_exec referenced in function Swig_string_regex   <br/>                    
naming.o : error LNK2001: unresolved external symbol __imp_pcre_exec        <br/>               
misc.o : error LNK2019: unresolved external symbol __imp_pcre_version referenced in function Swig_pcre_version                       <br/>
misc.o : error LNK2001: unresolved external symbol __imp_pcre_free            <br/>           
naming.o : error LNK2001: unresolved external symbol __imp_pcre_free           <br/>            
bazel-out/host/bin/external/swig/swig.exe : fatal error LNK1120: 4 unresolved externals    <br/>                   
<hr/>
