### PR TITLE
Fix typos

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_computation_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_computation_test.cc
@@ -310,7 +310,7 @@ TEST_F(HloComputationTest, DeepCopyArrayAtIndices) {
 }
 
 TEST_F(HloComputationTest, DeepCopyTupleAtIndices) {
-  // Test that DeepCopyInstruction properly copies elements of a a tuple as
+  // Test that DeepCopyInstruction properly copies elements of a tuple as
   // specified by the given indices.
   auto builder = HloComputation::Builder(TestName());
   auto constant1 = builder.AddInstruction(HloInstruction::CreateConstant(

--- a/tensorflow/contrib/all_reduce/python/all_reduce.py
+++ b/tensorflow/contrib/all_reduce/python/all_reduce.py
@@ -191,7 +191,7 @@ def _ragged_split(tensor, pieces):
 
 
 def _ring_permutations(num_workers, num_subchunks, gpu_perm):
-  """"Generate an array of device index arrays, one for for each subchunk.
+  """"Generate an array of device index arrays, one for each subchunk.
 
   In the basic ring reduction algorithm there are size(T)/num_devices
   data chunks and each device process one chunk per tick, i.e. sending

--- a/tensorflow/contrib/kfac/python/ops/loss_functions.py
+++ b/tensorflow/contrib/kfac/python/ops/loss_functions.py
@@ -104,7 +104,7 @@ class LossFunction(object):
 
   @abc.abstractmethod
   def multiply_hessian_factor_transpose(self, vector):
-    """Right-multiply a vector by the tranpose of a factor B of the Hessian.
+    """Right-multiply a vector by the transpose of a factor B of the Hessian.
 
     Here the 'Hessian' is the Hessian matrix (i.e. matrix of 2nd-derivatives)
     of the loss function with respect to its inputs.  Typically this will be
@@ -218,7 +218,7 @@ class NegativeLogProbLoss(LossFunction):
 
   @abc.abstractmethod
   def multiply_fisher_factor_transpose(self, vector):
-    """Right-multiply a vector by the tranpose of a factor B of the Fisher.
+    """Right-multiply a vector by the transpose of a factor B of the Fisher.
 
     Here the 'Fisher' is the Fisher information matrix (i.e. expected outer-
     product of gradients) with respect to the parameters of the underlying
@@ -397,7 +397,7 @@ class NormalMeanVarianceNegativeLogProbLoss(DistributionNegativeLogProbLoss):
 
   This class parameterizes a multivariate normal distribution with n independent
   dimensions. Unlike `NormalMeanNegativeLogProbLoss`, this class does not
-  assume the variance is held constant. The Fisher Information for for n = 1
+  assume the variance is held constant. The Fisher Information for n = 1
   is given by,
 
   F = [[1 / variance,                0],

--- a/tensorflow/contrib/kfac/python/ops/op_queue.py
+++ b/tensorflow/contrib/kfac/python/ops/op_queue.py
@@ -61,7 +61,7 @@ class OpQueue(object):
       sess: tf.Session.
 
     Returns:
-      Next Op chosen from from 'ops'.
+      Next Op chosen from 'ops'.
     """
     # In Python 3, type(next_op_name) == bytes. Calling bytes.decode('ascii')
     # returns a str.

--- a/tensorflow/core/kernels/conv_ops_gpu_3.cu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu_3.cu.cc
@@ -394,7 +394,7 @@ __global__ void SwapDimension1And2InTensor3SmallDim(const T* input,
     int output_block_idx = SmallDim2 ? block_offset : block_offset * small_dim;
     int output_block_origin_idx = output_block_offset + output_block_idx;
 
-    // Store the tranposed memory region in shared memory to device.
+    // Store the transposed memory region in shared memory to device.
     if (x < tile_height) {
       for (int y = 0; y < small_dim; y++) {
         int output_idx = output_block_origin_idx + x +

--- a/tensorflow/core/kernels/dataset.h
+++ b/tensorflow/core/kernels/dataset.h
@@ -471,7 +471,7 @@ class DatasetIterator : public IteratorBase {
     // Owns one reference on the shared dataset resource.
     const DatasetType* dataset;
 
-    // Identifies the sequence of iterators leading up to to this iterator.
+    // Identifies the sequence of iterators leading up to this iterator.
     const string prefix;
   };
 


### PR DESCRIPTION
This PR fixes some typos: `a a`, `for for`, `tranpose`, `from from`, and `to to`.