### PR TITLE
Add `fast_tensor_util.cpp` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cmake_build/
 .idea/**
 /build/
 /tensorflow/core/util/version_info.cc
+/tensorflow/python/framework/fast_tensor_util.cpp


### PR DESCRIPTION
While working on building TensorFlow I noticed that a file `fast_tensor_util.cpp` is generated:
```sh
ubuntu@ubuntu:~/tensorflow$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        tensorflow/python/framework/fast_tensor_util.cpp

nothing added to commit but untracked files present (use "git add" to track)
ubuntu@ubuntu:~/tensorflow$
```

This fix adds `fast_tensor_util.cpp` to .gitignore so that it will not be added inadvertently when adding commit with `git add -A`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>