### PR TITLE
Allow num parameter in tf.linspace to be int64.

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2635,6 +2635,24 @@ tf_kernel_library(
     deps = MATH_DEPS,
 )
 
+tf_cc_test(
+    name = "sequence_ops_test",
+    size = "small",
+    srcs = ["sequence_ops_test.cc"],
+    deps = [
+        ":ops_testutil",
+        ":ops_util",
+        ":sequence_ops",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+    ],
+)
+
 tf_cuda_cc_test(
     name = "cast_op_test",
     size = "small",

--- a/tensorflow/core/kernels/sequence_ops.cc
+++ b/tensorflow/core/kernels/sequence_ops.cc
@@ -96,7 +96,7 @@ TF_CALL_double(REGISTER_SYCL_KERNEL);
 TF_CALL_int32(REGISTER_SYCL_KERNEL);
 TF_CALL_int64(REGISTER_SYCL_KERNEL);
 #undef REGISTER_SYCL_KERNEL
-#endif // TENSORFLOW_USE_SYCL
+#endif  // TENSORFLOW_USE_SYCL
 
 TF_CALL_float(REGISTER_CPU_KERNEL);
 TF_CALL_double(REGISTER_CPU_KERNEL);
@@ -116,7 +116,7 @@ TF_CALL_int64(REGISTER_GPU_KERNEL);
 #undef REGISTER_CPU_KERNEL
 #undef REGISTER_GPU_KERNEL
 
-template <typename T>
+template <typename T, typename Tnum>
 class LinSpaceOp : public OpKernel {
  public:
   explicit LinSpaceOp(OpKernelConstruction* context) : OpKernel(context) {}
@@ -136,7 +136,7 @@ class LinSpaceOp : public OpKernel {
                                         num_in.shape().DebugString()));
     const T start = start_in.scalar<T>()();
     const T stop = stop_in.scalar<T>()();
-    const int32 num = num_in.scalar<int32>()();
+    const Tnum num = num_in.scalar<Tnum>()();
     OP_REQUIRES(context, num > 0,
                 errors::InvalidArgument("Requires num > 0: ", num));
     Tensor* out = nullptr;
@@ -147,34 +147,46 @@ class LinSpaceOp : public OpKernel {
       flat(0) = start;
     } else {
       const T step = (stop - start) / (num - 1);
-      for (int32 i = 0; i < num; ++i) flat(i) = start + step * i;
+      for (Tnum i = 0; i < num; ++i) flat(i) = start + step * i;
     }
   }
 };
 
-#define REGISTER_KERNEL(DEV, T)                              \
-  REGISTER_KERNEL_BUILDER(Name("LinSpace")                   \
-                              .Device(DEV)                   \
-                              .TypeConstraint<T>("T")        \
-                              .TypeConstraint<int32>("Tidx") \
-                              .HostMemory("start")           \
-                              .HostMemory("stop")            \
-                              .HostMemory("num")             \
-                              .HostMemory("output"),         \
-                          LinSpaceOp<T>);
-#define REGISTER_CPU_KERNEL(T) REGISTER_KERNEL(DEVICE_CPU, T)
+#define REGISTER_KERNEL(DEV, T, Tidx)                       \
+  REGISTER_KERNEL_BUILDER(Name("LinSpace")                  \
+                              .Device(DEV)                  \
+                              .TypeConstraint<T>("T")       \
+                              .TypeConstraint<Tidx>("Tidx") \
+                              .HostMemory("start")          \
+                              .HostMemory("stop")           \
+                              .HostMemory("num")            \
+                              .HostMemory("output"),        \
+                          LinSpaceOp<T, Tidx>);
+
+#define REGISTER_KERNEL_ALL_NUMS(dev, T) \
+  REGISTER_KERNEL(dev, T, int32);        \
+  REGISTER_KERNEL(dev, T, int64)
+
+#define REGISTER_CPU_KERNEL(T) REGISTER_KERNEL_ALL_NUMS(DEVICE_CPU, T)
 TF_CALL_float(REGISTER_CPU_KERNEL);
 TF_CALL_double(REGISTER_CPU_KERNEL);
 
 // NOTE(touts): We register the op on GPU but it still runs on CPU
 // because its inputs and outputs are tagged as HostMemory.
-#define REGISTER_GPU_KERNEL(T) REGISTER_KERNEL(DEVICE_GPU, T)
+#define REGISTER_GPU_KERNEL(T) REGISTER_KERNEL_ALL_NUMS(DEVICE_GPU, T)
 TF_CALL_float(REGISTER_GPU_KERNEL);
 TF_CALL_double(REGISTER_GPU_KERNEL);
+#undef REGISTER_GPU_KERNEL
 
 #ifdef TENSORFLOW_USE_SYCL
-#define REGISTER_SYCL_KERNEL(T) REGISTER_KERNEL(DEVICE_SYCL, T)
+#define REGISTER_SYCL_KERNEL(T) REGISTER_KERNEL_ALL_NUMS(DEVICE_SYCL, T)
 TF_CALL_float(REGISTER_SYCL_KERNEL);
 TF_CALL_double(REGISTER_SYCL_KERNEL);
-#endif // TENSORFLOW_USE_SYCL
+#undef REGISTER_SYCL_KERNEL
+#endif  // TENSORFLOW_USE_SYCL
+
+#undef REGISTER_CPU_KERNEL
+#undef REGISTER_KERNEL_ALL_NUMS
+#undef REGISTER_KERNEL
+
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/sequence_ops_test.cc
+++ b/tensorflow/core/kernels/sequence_ops_test.cc
@@ -1,0 +1,148 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/allocator.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_testutil.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+namespace {
+
+class RangeOpTest : public OpsTestBase {
+ protected:
+  void MakeOp(DataType variable_ref_type) {
+    TF_ASSERT_OK(NodeDefBuilder("myop", "Range")
+                     .Input(FakeInput(variable_ref_type))
+                     .Input(FakeInput(variable_ref_type))
+                     .Input(FakeInput(variable_ref_type))
+                     .Finalize(node_def()));
+    TF_ASSERT_OK(InitOp());
+  }
+};
+
+class LinSpaceOpTest : public OpsTestBase {
+ protected:
+  void MakeOp(DataType variable_ref_type, DataType num_type) {
+    TF_ASSERT_OK(NodeDefBuilder("myop", "LinSpace")
+                     .Input(FakeInput(variable_ref_type))
+                     .Input(FakeInput(variable_ref_type))
+                     .Input(FakeInput(num_type))
+                     .Finalize(node_def()));
+    TF_ASSERT_OK(InitOp());
+  }
+};
+
+TEST_F(RangeOpTest, Simple_D32) {
+  MakeOp(DT_INT32);
+
+  // Feed and run
+  AddInputFromArray<int32>(TensorShape({}), {0});
+  AddInputFromArray<int32>(TensorShape({}), {10});
+  AddInputFromArray<int32>(TensorShape({}), {2});
+  TF_ASSERT_OK(RunOpKernel());
+
+  // Check the output
+  Tensor expected(allocator(), DT_INT32, TensorShape({5}));
+  test::FillValues<int32>(&expected, {0, 2, 4, 6, 8});
+  test::ExpectTensorEqual<int32>(expected, *GetOutput(0));
+}
+
+TEST_F(RangeOpTest, Simple_Float) {
+  MakeOp(DT_FLOAT);
+
+  // Feed and run
+  AddInputFromArray<float>(TensorShape({}), {0.5});
+  AddInputFromArray<float>(TensorShape({}), {2});
+  AddInputFromArray<float>(TensorShape({}), {0.3});
+  TF_ASSERT_OK(RunOpKernel());
+
+  // Check the output
+  Tensor expected(allocator(), DT_FLOAT, TensorShape({5}));
+  test::FillValues<float>(&expected, {0.5, 0.8, 1.1, 1.4, 1.7});
+  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
+}
+
+TEST_F(RangeOpTest, Large_Double) {
+  MakeOp(DT_DOUBLE);
+
+  // Feed and run
+  AddInputFromArray<double>(TensorShape({}), {0.0});
+  AddInputFromArray<double>(TensorShape({}), {10000});
+  AddInputFromArray<double>(TensorShape({}), {0.5});
+  TF_ASSERT_OK(RunOpKernel());
+
+  // Check the output
+  Tensor expected(allocator(), DT_DOUBLE, TensorShape({20000}));
+  std::vector<double> result;
+  for (int32 i = 0; i < 20000; ++i) result.push_back(i * 0.5);
+  test::FillValues<double>(&expected, gtl::ArraySlice<double>(result));
+  test::ExpectTensorEqual<double>(expected, *GetOutput(0));
+}
+
+TEST_F(LinSpaceOpTest, Simple_D32) {
+  MakeOp(DT_FLOAT, DT_INT32);
+
+  // Feed and run
+  AddInputFromArray<float>(TensorShape({}), {3.0});
+  AddInputFromArray<float>(TensorShape({}), {7.0});
+  AddInputFromArray<int32>(TensorShape({}), {3});
+  TF_ASSERT_OK(RunOpKernel());
+
+  // Check the output
+  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
+  test::FillValues<float>(&expected, {3.0, 5.0, 7.0});
+  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
+}
+
+TEST_F(LinSpaceOpTest, Single_D64) {
+  MakeOp(DT_FLOAT, DT_INT64);
+
+  // Feed and run
+  AddInputFromArray<float>(TensorShape({}), {9.0});
+  AddInputFromArray<float>(TensorShape({}), {100.0});
+  AddInputFromArray<int64>(TensorShape({}), {1});
+  TF_ASSERT_OK(RunOpKernel());
+
+  // Check the output
+  Tensor expected(allocator(), DT_FLOAT, TensorShape({1}));
+  test::FillValues<float>(&expected, {9.0});
+  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
+}
+
+TEST_F(LinSpaceOpTest, Simple_Double) {
+  MakeOp(DT_DOUBLE, DT_INT32);
+
+  // Feed and run
+  AddInputFromArray<double>(TensorShape({}), {5.0});
+  AddInputFromArray<double>(TensorShape({}), {6.0});
+  AddInputFromArray<int32>(TensorShape({}), {6});
+  TF_ASSERT_OK(RunOpKernel());
+
+  // Check the output
+  Tensor expected(allocator(), DT_DOUBLE, TensorShape({6}));
+  test::FillValues<double>(&expected, {5.0, 5.2, 5.4, 5.6, 5.8, 6.0});
+  test::ExpectTensorEqual<double>(expected, *GetOutput(0));
+}
+
+}  // namespace
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/sequence_ops_test.cc
+++ b/tensorflow/core/kernels/sequence_ops_test.cc
@@ -30,11 +30,11 @@ namespace {
 
 class RangeOpTest : public OpsTestBase {
  protected:
-  void MakeOp(DataType variable_ref_type) {
+  void MakeOp(DataType input_type) {
     TF_ASSERT_OK(NodeDefBuilder("myop", "Range")
-                     .Input(FakeInput(variable_ref_type))
-                     .Input(FakeInput(variable_ref_type))
-                     .Input(FakeInput(variable_ref_type))
+                     .Input(FakeInput(input_type))
+                     .Input(FakeInput(input_type))
+                     .Input(FakeInput(input_type))
                      .Finalize(node_def()));
     TF_ASSERT_OK(InitOp());
   }
@@ -42,11 +42,11 @@ class RangeOpTest : public OpsTestBase {
 
 class LinSpaceOpTest : public OpsTestBase {
  protected:
-  void MakeOp(DataType variable_ref_type, DataType num_type) {
+  void MakeOp(DataType input_type, DataType index_type) {
     TF_ASSERT_OK(NodeDefBuilder("myop", "LinSpace")
-                     .Input(FakeInput(variable_ref_type))
-                     .Input(FakeInput(variable_ref_type))
-                     .Input(FakeInput(num_type))
+                     .Input(FakeInput(input_type))
+                     .Input(FakeInput(input_type))
+                     .Input(FakeInput(index_type))
                      .Finalize(node_def()));
     TF_ASSERT_OK(InitOp());
   }


### PR DESCRIPTION
According to the API, tf.linspace is defined for num int32 or int64.
However the C++ kernel only allows int32, even though the op in core/ops/math_ops permits int64 too.
So I slightly changed the kernel to allow int64 too. I also added tests for RangeOp and LinSpaceOp.

The following code shows the issue:

```
import numpy as np
import tensorflow as tf

with tf.device("/cpu:0"):
    step = tf.constant(1, tf.int64)
    x = tf.linspace(10.0, 12.0, step)

with tf.Session() as sess:
   x_np = sess.run(x)
   print(x_np)
```