### PR TITLE
Fix broken link in debugger doc

### DIFF
--- a/tensorflow/docs_src/programmers_guide/debugger.md
+++ b/tensorflow/docs_src/programmers_guide/debugger.md
@@ -440,7 +440,7 @@ accuracy_score = classifier.evaluate(x=test_set.data,
 
 
 [debug_tflearn_iris.py](https://www.tensorflow.org/code/tensorflow/python/debug/examples/debug_tflearn_iris.py),
-based on {$tflearn$tf-learn's iris tutorial}, contains a full example of how to
+based on @{$tflearn$tf-learn's iris tutorial}, contains a full example of how to
 use the tfdbg with `Estimator`s. To run this example, do:
 
 ```none


### PR DESCRIPTION
See https://www.tensorflow.org/programmers_guide/debugger

I'm not sure if this is the correct syntax to make the link render. But it's my best guess based on examining other files.