### PR TITLE
Fix ambiguous type comparison in s3_crypto.cc

### DIFF
--- a/tensorflow/contrib/s3/s3_crypto.cc
+++ b/tensorflow/contrib/s3/s3_crypto.cc
@@ -71,7 +71,7 @@ class S3Sha256OpenSSLImpl : public Aws::Utils::Crypto::Hash {
     SHA256_Init(&sha256);
 
     auto currentPos = stream.tellg();
-    if (currentPos == -1) {
+    if (currentPos == std::streampos(std::streamoff(-1))) {
       currentPos = 0;
       stream.clear();
     }


### PR DESCRIPTION
We were seeing the following compilation error on Windows builds.

tensorflow/contrib/s3/s3_crypto.cc(74): error C2666:
'std::fpos<_Mbstatet>::operator ==': 3 overloads have similar conversions
could be 'bool std::fpos<_Mbstatet>::operator ==(std::streamoff) const'
or 'bool std::fpos<_Mbstatet>::operator ==(const std::fpos<_Mbstatet> &)
