### PR TITLE
fix the issue: "libcuda.so.1 not found" and add some minor changes.

### DIFF
--- a/tensorflow/tools/docker/Dockerfile.devel-gpu-cuda9-cudnn7
+++ b/tensorflow/tools/docker/Dockerfile.devel-gpu-cuda9-cudnn7
@@ -4,7 +4,7 @@ MAINTAINER Gunhan Gulsoy <gunan@google.com>
 
 # It is possible to override these for releases.
 ARG TF_BRANCH=master
-ARG BAZEL_VERSION=0.5.4
+ARG BAZEL_VERSION=0.6.1
 ARG TF_AVAILABLE_CPUS=32
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         python-dev \
         python-pip \
+        python-wheel \
         rsync \
         software-properties-common \
         unzip \
@@ -79,23 +80,43 @@ RUN git clone https://github.com/tensorflow/tensorflow.git && \
     git checkout ${TF_BRANCH}
 WORKDIR /tensorflow
 
-# Configure the build for our CUDA configuration.
-ENV CI_BUILD_PYTHON python
-ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
-ENV TF_NEED_CUDA 1
-ENV TF_CUDA_COMPUTE_CAPABILITIES 3.0,3.5,5.2,6.0,6.1
-ENV TF_CUDA_VERSION 9.0
-ENV TF_CUDNN_VERSION 7
-RUN ./configure
+# Tell TensorFlow how to configure the build, in detail.
+ENV CI_BUILD_PYTHON=python \
+    LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:${LD_LIBRARY_PATH} \
+    CUDNN_INSTALL_PATH=/usr/lib/x86_64-linux-gnu \
+    PYTHON_BIN_PATH=/usr/bin/python \
+    PYTHON_LIB_PATH=/usr/local/lib/python2.7/dist-packages \
+    TF_NEED_CUDA=1 \
+    TF_CUDA_VERSION=9.0 \
+    TF_CUDA_COMPUTE_CAPABILITIES=3.0,3.5,5.2,6.0,6.1,7.0 \
+    TF_CUDNN_VERSION=7 \
+    TF_NEED_JEMALLOC=1 \
+    TF_NEED_GCP=0 \
+    TF_NEED_HDFS=0 \
+    TF_ENABLE_XLA=1 \
+    TF_NEED_GDR=0 \
+    TF_NEED_VERBS=0 \
+    TF_NEED_OPENCL=0 \
+    TF_NEED_S3=0 \
+    TF_CUDA_CLANG=0 \
+    TF_NEED_MPI=0
 
-RUN LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH} \
-    bazel build -c opt --config=cuda --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" \
-        --jobs=${TF_AVAILABLE_CPUS} \
-        tensorflow/tools/pip_package:build_pip_package && \
-    mkdir -p /pip_pkg && \
+# Configure, Build and Install TensorFlow.
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH} \
+    tensorflow/tools/ci_build/builds/configured GPU \
+    bazel build -c opt \
+                --config=cuda \
+                --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" \
+                --jobs=${TF_AVAILABLE_CPUS} \
+                tensorflow/tools/pip_package:build_pip_package && \
+    mkdir /pip_pkg && \
     bazel-bin/tensorflow/tools/pip_package/build_pip_package /pip_pkg
 
 RUN pip --no-cache-dir install --upgrade /pip_pkg/tensorflow-*.whl && \
+    rm -rf /pip_pkg && \
+    rm -rf /root/.cache
+# Clean up pip wheel and Bazel cache when done.
 
 WORKDIR /root
 

--- a/tensorflow/tools/docker/Dockerfile.devel-gpu-cuda9-cudnn7
+++ b/tensorflow/tools/docker/Dockerfile.devel-gpu-cuda9-cudnn7
@@ -4,7 +4,7 @@ MAINTAINER Gunhan Gulsoy <gunan@google.com>
 
 # It is possible to override these for releases.
 ARG TF_BRANCH=master
-ARG BAZEL_VERSION=0.6.1
+ARG BAZEL_VERSION=0.5.4
 ARG TF_AVAILABLE_CPUS=32
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         python-dev \
         python-pip \
-        python-wheel \
         rsync \
         software-properties-common \
         unzip \
@@ -43,6 +42,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        wheel \
         && \
     python -m ipykernel.kernelspec
 
@@ -80,7 +80,7 @@ RUN git clone https://github.com/tensorflow/tensorflow.git && \
     git checkout ${TF_BRANCH}
 WORKDIR /tensorflow
 
-# Tell TensorFlow how to configure the build, in detail.
+# Configure the build for our CUDA configuration.
 ENV CI_BUILD_PYTHON=python \
     LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:${LD_LIBRARY_PATH} \
     CUDNN_INSTALL_PATH=/usr/lib/x86_64-linux-gnu \
@@ -89,22 +89,12 @@ ENV CI_BUILD_PYTHON=python \
     TF_NEED_CUDA=1 \
     TF_CUDA_VERSION=9.0 \
     TF_CUDA_COMPUTE_CAPABILITIES=3.0,3.5,5.2,6.0,6.1,7.0 \
-    TF_CUDNN_VERSION=7 \
-    TF_NEED_JEMALLOC=1 \
-    TF_NEED_GCP=0 \
-    TF_NEED_HDFS=0 \
-    TF_ENABLE_XLA=1 \
-    TF_NEED_GDR=0 \
-    TF_NEED_VERBS=0 \
-    TF_NEED_OPENCL=0 \
-    TF_NEED_S3=0 \
-    TF_CUDA_CLANG=0 \
-    TF_NEED_MPI=0
+    TF_CUDNN_VERSION=7
+RUN ./configure
 
-# Configure, Build and Install TensorFlow.
+# Build and Install TensorFlow.
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH} \
-    tensorflow/tools/ci_build/builds/configured GPU \
     bazel build -c opt \
                 --config=cuda \
                 --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" \
@@ -113,10 +103,10 @@ RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/lib
     mkdir /pip_pkg && \
     bazel-bin/tensorflow/tools/pip_package/build_pip_package /pip_pkg
 
+# Clean up pip wheel and Bazel cache when done.
 RUN pip --no-cache-dir install --upgrade /pip_pkg/tensorflow-*.whl && \
     rm -rf /pip_pkg && \
     rm -rf /root/.cache
-# Clean up pip wheel and Bazel cache when done.
 
 WORKDIR /root
 


### PR DESCRIPTION
* The newer version of Bazel, i.e. ```BAZEL_VERSION=0.6.1``` won't cause any trouble. I've built the image that uses this version of Bazel successfully.
* ```python-wheel``` has to be installed, otherwise
    >error: invalid command 'bdist_wheel'

  pops out while building the docker image.
* I add *Compute Capability*```7.0``` in order to support *NVIDIA Tesla V100*.
* Currently, ```ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1``` is necessary, otherwise you will see the following warning while building the image:
    >/usr/bin/ld: warning: libcuda.so.1, needed by bazel-out/host/bin/_solib_local/_U_S_Stensorflow_Scc_Cops_Simage_Uops_Ugen_Ucc___Utensorflow/libtensorflow_framework.so, not found (try using -rpath or -rpath-link)

    and the installation of TensorFlow will fail due to this.
* I prefer ```tensorflow/tools/ci_build/builds/configured GPU``` rather than ```yes "" | ./configure``` when it comes to configure TensorFlow, since it outputs more information that sometimes could be helpful, such as: 
    > TF_BUILD_INFO = {container_type: "gpu", command: "", source_HEAD: "bedfe8ac14bddbf21c5acf80d55abff9df4a7967", source_remote_origin: "https://github.com/tensorflow/tensorflow.git", OS: "Linux", kernel: "4.4.0-92-generic", architecture: "x86_64", processor: "Intel(R) Xeon(R) CPU E5-2698 v4 @ 2.20GHz", processor_count: "80", memory_total: "528276076 kB", swap_total: "0 kB", Bazel_version: "Build label: 0.6.1", Java_version: "1.8.0_131", Python_version: "2.7.12", gpp_version: "g++ (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609", swig_version: "", NVIDIA_driver_version: "384.81", CUDA_device_count: "0", CUDA_device_names: "", CUDA_toolkit_version: "V9.0.176"}