### PR TITLE
allow to run configure from a parent workspace

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,5 +2,20 @@ exports_files(
     [
         "LICENSE",
         "ACKNOWLEDGEMENTS",
+        "configure.py", 
+])
+
+py_binary(
+    name = "configure",
+    srcs = [
+        "configure.py",
     ],
+    data = [
+        "//tensorflow/tools/git:gen_git_source.py",
+        "//tools",
+    ],
+    args = [
+        "--workspace=.", 
+        "--tf_workspace=.", 
+    ]
 )

--- a/configure
+++ b/configure
@@ -8,7 +8,7 @@ if [ -z "$PYTHON_BIN_PATH" ]; then
 fi
 
 # Set all env variables
-"$PYTHON_BIN_PATH" configure.py
+"$PYTHON_BIN_PATH" configure.py 
 
 echo "Configuration finished"
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+  name="tools",
+  srcs=glob(["*.*"]),
+  visibility=['//visibility:public'],
+)


### PR DESCRIPTION
With this patch you can configure tensorflow directly using bazel.

Fixes #12761 

```
export TF_NEED_CUDA=1
export TF_CUDA_VERSION=8.0
export TF_CUDA_COMPUTE_CAPABILITIES=6.0
export TF_CUDNN_VERSION=6
export CUDNN_INSTALL_PATH=/usr/lib/x86_64-linux-gnu
export PYTHON_BIN_PATH=`which python2`
export TF_NEED_GCP=1
export TF_NEED_HDFS=0
export TF_ENABLE_XLA=1
export TF_NEED_VERBS=1
export CC_OPT_FLAGS="-mavx -msse4.2 -mfpmath=both -DEIGEN_USE_VML"
export TF_NEED_MKL=1
export TF_DOWNLOAD_MKL=1
bazel run @org_tensorflow//:configure -- --tf_workspace= $(bazel info output_base)/external/org_tensorflow`" --workspace=$(PWD)
```