### PR TITLE
Fix casting to `size_t` for mkl conv filter dims

### DIFF
--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -288,8 +288,10 @@ class MklConv2DOp : public OpKernel {
     mkl_filter_output_mkl_shape.SetMklLayout(mkl_context.prim_fwd,
                                              dnnResourceFilter);
 
-    size_t filter_sizes[4] = {filter.dim_size(0), filter.dim_size(1),
-                              filter.dim_size(2), filter.dim_size(3)};
+    size_t filter_sizes[4] = {static_cast<size_t>(filter.dim_size(0)),
+                              static_cast<size_t>(filter.dim_size(1)),
+                              static_cast<size_t>(filter.dim_size(2)),
+                              static_cast<size_t>(filter.dim_size(3))};
     mkl_filter_output_mkl_shape.SetTfLayout(filter.dims(), filter_sizes,
                                             mkl_context.filter_strides);
 


### PR DESCRIPTION
Here's the output from clang regarding explicit casting `int64` to `size_t`.

```clang
tensorflow/core/kernels/mkl_conv_ops.cc:291:31: error: non-constant-expression cannot be narrowed from type 'int64' (aka 'long long') to 'size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
```

After modifying those lines I was able to compile successfully for CPU w/MKL + XLA.