### PR TITLE
Fix AWS SDK missing symbols on Linux PPC

### DIFF
--- a/third_party/aws.BUILD
+++ b/third_party/aws.BUILD
@@ -18,6 +18,9 @@ cc_library(
         "@%ws%//tensorflow:darwin": glob([
             "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
         ]),
+        "@%ws%//tensorflow:linux_ppc64le": glob([
+            "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
+        ]),
         "//conditions:default": [],
     }) + glob([
         "aws-cpp-sdk-core/include/**/*.h",
@@ -54,6 +57,11 @@ cc_library(
         ],
         "@%ws%//tensorflow:darwin": [
             "PLATFORM_APPLE",
+            "ENABLE_CURL_CLIENT",
+            "ENABLE_NO_ENCRYPTION",
+        ],
+        "@%ws%//tensorflow:linux_ppc64le": [
+            "PLATFORM_LINUX",
             "ENABLE_CURL_CLIENT",
             "ENABLE_NO_ENCRYPTION",
         ],


### PR DESCRIPTION
TF on linux ppc64le builds but when loading the environment, some AWS related symbols are missing and thus resulting in a failure to load TF. This patch adds the same file inclusions/macro definitions to linux_ppc as one does to linux_x86 and this seems to fix the problem.

Error message reads:
```
Traceback (most recent call last):
  File "gru_ops_test.py", line 23, in <module>
    from tensorflow.contrib.rnn.python.kernel_tests import benchmarking
  File "/localhd/tjin/tensorflow_latest/local/lib/python2.7/site-packages/tensorflow/__init__.py", line 24, in <module>
    from tensorflow.python import *
  File "/localhd/tjin/tensorflow_latest/local/lib/python2.7/site-packages/tensorflow/python/__init__.py", line 49, in <module>
    from tensorflow.python import pywrap_tensorflow
  File "/localhd/tjin/tensorflow_latest/local/lib/python2.7/site-packages/tensorflow/python/pywrap_tensorflow.py", line 72, in <module>
    raise ImportError(msg)
ImportError: Traceback (most recent call last):
  File "/localhd/tjin/tensorflow_latest/local/lib/python2.7/site-packages/tensorflow/python/pywrap_tensorflow.py", line 58, in <module>
    from tensorflow.python.pywrap_tensorflow_internal import *
  File "/localhd/tjin/tensorflow_latest/local/lib/python2.7/site-packages/tensorflow/python/pywrap_tensorflow_internal.py", line 28, in <module>
    _pywrap_tensorflow_internal = swig_import_helper()
  File "/localhd/tjin/tensorflow_latest/local/lib/python2.7/site-packages/tensorflow/python/pywrap_tensorflow_internal.py", line 24, in swig_import_helper
    _mod = imp.load_module('_pywrap_tensorflow_internal', fp, pathname, description)
ImportError: /localhd/tjin/tensorflow_latest/local/lib/python2.7/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so: undefined symbol: _ZN3Aws4Time9LocalTimeEP2tml


Failed to load the native TensorFlow runtime.

See https://www.tensorflow.org/install/install_sources#common_installation_problems

for some common reasons and solutions.  Include the entire stack trace
above this error message when asking for help.
```