### PR TITLE
Fix import of spatial_softmax from tensorflow.contrib.layers

### DIFF
--- a/tensorflow/contrib/layers/__init__.py
+++ b/tensorflow/contrib/layers/__init__.py
@@ -47,6 +47,7 @@ See the @{$python/contrib.layers} guide.
 @@separable_conv2d
 @@separable_convolution2d
 @@softmax
+@@spatial_softmax
 @@stack
 @@unit_norm
 @@bow_encoder


### PR DESCRIPTION
Currently `spatial_softmax` cannot be imported from `tensorflow.contrib.layers`, but has to be imported all the way from `tensorflow.contrib.layers.python.layers`
