### PR TITLE
Improve resize_bicubic performance by reorganizing loops

### DIFF
--- a/tensorflow/core/kernels/resize_bicubic_op.cc
+++ b/tensorflow/core/kernels/resize_bicubic_op.cc
@@ -249,63 +249,146 @@ inline void interpolate_with_caching(
       const T* y_ptr_2 = input_b_ptr + y_wai.index_2 * in_row_width;
       const T* y_ptr_3 = input_b_ptr + y_wai.index_3 * in_row_width;
 
-      std::unique_ptr<float[]> cached_value(new float[4 * num_channels]);
-      for (int64 x = 0; x < resizer_state.out_width; ++x) {
-        const WeightsAndIndices& x_wai = x_wais[x];
-        // Shift values in cached_value to fill first 'advance' values.
-        switch (x_wai.advance) {
-          case 3:
-            for (int64 c = 0; c < num_channels; ++c) {
-              cached_value[4 * c + 0] = cached_value[4 * c + 1];
-              cached_value[4 * c + 1] = cached_value[4 * c + 2];
-              cached_value[4 * c + 2] = cached_value[4 * c + 3];
+      if (num_channels == 3) {
+        // Manually unroll case of 3 channels.
+        float cached_value_0[4] = {0};
+        float cached_value_1[4] = {0};
+        float cached_value_2[4] = {0};
+        for (int64 x = 0; x < resizer_state.out_width; ++x) {
+          const WeightsAndIndices& x_wai = x_wais[x];
+          // Shift values in cached_value_* to fill first 'advance' values.
+          switch (x_wai.advance) {
+            case 3:
+              cached_value_0[0] = cached_value_0[1];
+              cached_value_0[1] = cached_value_0[2];
+              cached_value_0[2] = cached_value_0[3];
+              cached_value_1[0] = cached_value_1[1];
+              cached_value_1[1] = cached_value_1[2];
+              cached_value_1[2] = cached_value_1[3];
+              cached_value_2[0] = cached_value_2[1];
+              cached_value_2[1] = cached_value_2[2];
+              cached_value_2[2] = cached_value_2[3];
+              break;
+            case 2:
+              cached_value_0[0] = cached_value_0[2];
+              cached_value_0[1] = cached_value_0[3];
+              cached_value_1[0] = cached_value_1[2];
+              cached_value_1[1] = cached_value_1[3];
+              cached_value_2[0] = cached_value_2[2];
+              cached_value_2[1] = cached_value_2[3];
+              break;
+            case 1: {
+              cached_value_0[0] = cached_value_0[3];
+              cached_value_1[0] = cached_value_1[3];
+              cached_value_2[0] = cached_value_2[3];
+              break;
             }
-            break;
-          case 2:
-            for (int64 c = 0; c < num_channels; ++c) {
-              cached_value[4 * c + 0] = cached_value[4 * c + 2];
-              cached_value[4 * c + 1] = cached_value[4 * c + 3];
-            }
-            break;
-          case 1: {
-            for (int64 c = 0; c < num_channels; ++c) {
-              cached_value[4 * c + 0] = cached_value[4 * c + 3];
-            }
-            break;
           }
-        }
 
-        // Set the remaining '4-advance' values by computing.
-        switch (x_wai.advance) {
-          case 0:
-            for (int64 c = 0; c < num_channels; ++c) {
-              cached_value[4 * c + 0] = ComputeYInterpolation(
-                  0, c, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
-            }
-            TF_FALLTHROUGH_INTENDED;
-          case 1:
-            for (int64 c = 0; c < num_channels; ++c) {
-              cached_value[4 * c + 1] = ComputeYInterpolation(
-                  1, c, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
-            }
-            TF_FALLTHROUGH_INTENDED;
-          case 2:
-            for (int64 c = 0; c < num_channels; ++c) {
-              cached_value[4 * c + 2] = ComputeYInterpolation(
-                  2, c, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
-            }
-            TF_FALLTHROUGH_INTENDED;
-          case 3:
-            for (int64 c = 0; c < num_channels; ++c) {
-              cached_value[4 * c + 3] = ComputeYInterpolation(
-                  3, c, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
-            }
-            break;
-        }
-        for (int64 c = 0; c < num_channels; ++c) {
-          output_y_ptr[x * num_channels + c] =
-              Compute(&cached_value[4 * c], x_wai.weight_0, x_wai.weight_1,
+          // Set the remaining '4-advance' values by computing.
+          switch (x_wai.advance) {
+            case 0:
+              cached_value_0[0] = ComputeYInterpolation(
+                  0, 0, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              cached_value_1[0] = ComputeYInterpolation(
+                  0, 1, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              cached_value_2[0] = ComputeYInterpolation(
+                  0, 2, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              TF_FALLTHROUGH_INTENDED;
+            case 1:
+              cached_value_0[1] = ComputeYInterpolation(
+                  1, 0, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              cached_value_1[1] = ComputeYInterpolation(
+                  1, 1, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              cached_value_2[1] = ComputeYInterpolation(
+                  1, 2, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              TF_FALLTHROUGH_INTENDED;
+            case 2:
+              cached_value_0[2] = ComputeYInterpolation(
+                  2, 0, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              cached_value_1[2] = ComputeYInterpolation(
+                  2, 1, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              cached_value_2[2] = ComputeYInterpolation(
+                  2, 2, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              TF_FALLTHROUGH_INTENDED;
+            case 3:
+              cached_value_0[3] = ComputeYInterpolation(
+                  3, 0, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              cached_value_1[3] = ComputeYInterpolation(
+                  3, 1, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              cached_value_2[3] = ComputeYInterpolation(
+                  3, 2, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              break;
+          }
+          output_y_ptr[x * num_channels + 0] =
+              Compute(cached_value_0, x_wai.weight_0, x_wai.weight_1,
                       x_wai.weight_2, x_wai.weight_3);
+          output_y_ptr[x * num_channels + 1] =
+              Compute(cached_value_1, x_wai.weight_0, x_wai.weight_1,
+                      x_wai.weight_2, x_wai.weight_3);
+          output_y_ptr[x * num_channels + 2] =
+              Compute(cached_value_2, x_wai.weight_0, x_wai.weight_1,
+                      x_wai.weight_2, x_wai.weight_3);
+        }
+      } else {
+        std::unique_ptr<float[]> cached_value(new float[4 * num_channels]);
+        for (int64 x = 0; x < resizer_state.out_width; ++x) {
+          const WeightsAndIndices& x_wai = x_wais[x];
+          // Shift values in cached_value to fill first 'advance' values.
+          switch (x_wai.advance) {
+            case 3:
+              for (int64 c = 0; c < num_channels; ++c) {
+                cached_value[4 * c + 0] = cached_value[4 * c + 1];
+                cached_value[4 * c + 1] = cached_value[4 * c + 2];
+                cached_value[4 * c + 2] = cached_value[4 * c + 3];
+              }
+              break;
+            case 2:
+              for (int64 c = 0; c < num_channels; ++c) {
+                cached_value[4 * c + 0] = cached_value[4 * c + 2];
+                cached_value[4 * c + 1] = cached_value[4 * c + 3];
+              }
+              break;
+            case 1: {
+              for (int64 c = 0; c < num_channels; ++c) {
+                cached_value[4 * c + 0] = cached_value[4 * c + 3];
+              }
+              break;
+            }
+          }
+
+          // Set the remaining '4-advance' values by computing.
+          switch (x_wai.advance) {
+            case 0:
+              for (int64 c = 0; c < num_channels; ++c) {
+                cached_value[4 * c + 0] = ComputeYInterpolation(
+                    0, c, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              }
+              TF_FALLTHROUGH_INTENDED;
+            case 1:
+              for (int64 c = 0; c < num_channels; ++c) {
+                cached_value[4 * c + 1] = ComputeYInterpolation(
+                    1, c, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              }
+              TF_FALLTHROUGH_INTENDED;
+            case 2:
+              for (int64 c = 0; c < num_channels; ++c) {
+                cached_value[4 * c + 2] = ComputeYInterpolation(
+                    2, c, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              }
+              TF_FALLTHROUGH_INTENDED;
+            case 3:
+              for (int64 c = 0; c < num_channels; ++c) {
+                cached_value[4 * c + 3] = ComputeYInterpolation(
+                    3, c, y_wai, y_ptr_0, y_ptr_1, y_ptr_2, y_ptr_3, x_wai);
+              }
+              break;
+          }
+          for (int64 c = 0; c < num_channels; ++c) {
+            output_y_ptr[x * num_channels + c] =
+                Compute(&cached_value[4 * c], x_wai.weight_0, x_wai.weight_1,
+                        x_wai.weight_2, x_wai.weight_3);
+          }
         }
       }
     }

--- a/tensorflow/core/kernels/resize_bicubic_op.cc
+++ b/tensorflow/core/kernels/resize_bicubic_op.cc
@@ -235,6 +235,7 @@ inline void interpolate_with_caching(
 
   const T* input_b_ptr = input_data.data();
   float* output_y_ptr = output_data.data();
+  std::vector<float> cached_value(num_channels == 3 ? 0 : 4 * num_channels, 0);
 
   for (int64 b = 0; b < resizer_state.batch_size;
        ++b, input_b_ptr += in_batch_width) {
@@ -331,7 +332,6 @@ inline void interpolate_with_caching(
                       x_wai.weight_2, x_wai.weight_3);
         }
       } else {
-        std::vector<float> cached_value(4 * num_channels, 0);
         for (int64 x = 0; x < resizer_state.out_width; ++x) {
           const WeightsAndIndices& x_wai = x_wais[x];
           // Shift values in cached_value to fill first 'advance' values.

--- a/tensorflow/core/kernels/resize_bicubic_op.cc
+++ b/tensorflow/core/kernels/resize_bicubic_op.cc
@@ -331,7 +331,7 @@ inline void interpolate_with_caching(
                       x_wai.weight_2, x_wai.weight_3);
         }
       } else {
-        std::unique_ptr<float[]> cached_value(new float[4 * num_channels]);
+        std::vector<float> cached_value(4 * num_channels, 0);
         for (int64 x = 0; x < resizer_state.out_width; ++x) {
           const WeightsAndIndices& x_wai = x_wais[x];
           // Shift values in cached_value to fill first 'advance' values.

--- a/tensorflow/core/kernels/resize_bicubic_op_test.cc
+++ b/tensorflow/core/kernels/resize_bicubic_op_test.cc
@@ -251,14 +251,15 @@ TEST_F(ResizeBicubicOpTest, TestAreaRandomDataSeveralInputsSizes4Channels) {
   RunManyRandomTests(4);
 }
 
-static Graph* ResizeBicubic(int batch_size, int size, int channels) {
+static Graph* ResizeBicubic(int batch_size, int size, int channels,
+                            float scale_y = 0.3, float scale_x = 0.7) {
   Graph* g = new Graph(OpRegistry::Global());
   Tensor input(DT_FLOAT, TensorShape({batch_size, size, size, channels}));
   input.flat<float>().setRandom();
   Tensor shape(DT_INT32, TensorShape({2}));
   auto shape_t = shape.flat<int32>();
-  shape_t(0) = 0.3 * size;
-  shape_t(1) = 0.7 * size;
+  shape_t(0) = scale_y * size;
+  shape_t(1) = scale_x * size;
   test::graph::Binary(g, "ResizeBicubic", test::graph::Constant(g, input),
                       test::graph::Constant(g, shape));
   return g;
@@ -284,5 +285,18 @@ BM_ResizeBicubicDev(32, 32, 3);
 BM_ResizeBicubicDev(32, 128, 3);
 BM_ResizeBicubicDev(32, 512, 3);
 BM_ResizeBicubicDev(32, 1024, 3);
+
+#define BM_ResizeBicubicExpand(BATCH, SIZE, CHANNELS)                          \
+  static void BM_ResizeBicubicExpand####BATCH####SIZE####CHANNELS(int iters) { \
+    testing::ItemsProcessed(static_cast<int64>(iters) * BATCH * SIZE * SIZE *  \
+                            CHANNELS * 8 * 8);                                 \
+    test::Benchmark("cpu", ResizeBicubic(BATCH, SIZE, CHANNELS, 8, 8))         \
+        .Run(iters);                                                           \
+  }                                                                            \
+  BENCHMARK(BM_ResizeBicubicExpand####BATCH####SIZE####CHANNELS);
+
+BM_ResizeBicubicExpand(12, 48, 1);
+BM_ResizeBicubicExpand(12, 48, 3);
+BM_ResizeBicubicExpand(12, 48, 40);
 
 }  // end namespace tensorflow

--- a/tensorflow/core/kernels/resize_bicubic_op_test.cc
+++ b/tensorflow/core/kernels/resize_bicubic_op_test.cc
@@ -287,13 +287,13 @@ BM_ResizeBicubicDev(32, 512, 3);
 BM_ResizeBicubicDev(32, 1024, 3);
 
 #define BM_ResizeBicubicExpand(BATCH, SIZE, CHANNELS)                          \
-  static void BM_ResizeBicubicExpand####BATCH####SIZE####CHANNELS(int iters) { \
+  static void BM_ResizeBicubicExpand##_##BATCH##_##SIZE##_##CHANNELS(int iters) { \
     testing::ItemsProcessed(static_cast<int64>(iters) * BATCH * SIZE * SIZE *  \
                             CHANNELS * 8 * 8);                                 \
     test::Benchmark("cpu", ResizeBicubic(BATCH, SIZE, CHANNELS, 8, 8))         \
         .Run(iters);                                                           \
   }                                                                            \
-  BENCHMARK(BM_ResizeBicubicExpand####BATCH####SIZE####CHANNELS);
+  BENCHMARK(BM_ResizeBicubicExpand##_##BATCH##_##SIZE##_##CHANNELS);
 
 BM_ResizeBicubicExpand(12, 48, 1);
 BM_ResizeBicubicExpand(12, 48, 3);


### PR DESCRIPTION
This fix tries to address the issue raised in #13693 where performance of `resize_bicubic` is subpar compared with opencv.

This fix rearranges the loops so that the logic for num_channel=40 and num_channel=3 are similar.

Before this PR, `num_channel=3` is treated specially. It looks like manual unrolling will improve the performance for `num_channel=3`. So this PR keeps `num_channel=3` as a special case.

Pre-fix:
```
CHANNEL=40
opencv: 145.08ms
tf: 314.26ms

CHANNEL=3
opencv: 11.95ms
tf: 8.95ms
```

Post-fix (without manual unrolling for `num_channel=3`):
```
CHANNEL=40
opencv: 144.25ms
tf: 214.55ms

CHANNEL=3
opencv: 11.78ms
tf: 14.07ms
```


Post-fix (with manual unrolling for `num_channel=3`):
```
CHANNEL=40
opencv: 144.80ms
tf: 212.54ms

CHANNEL=3
opencv: 11.74ms
tf: 9.46ms
```

This fix fixes #13693.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>