### PR TITLE
Fix ../makefile/download_dependencies.sh on OSX

### DIFF
--- a/tensorflow/contrib/makefile/download_dependencies.sh
+++ b/tensorflow/contrib/makefile/download_dependencies.sh
@@ -54,7 +54,7 @@ download_and_extract() {
   elif [[ "${url}" == *zip ]]; then
     tempdir=$(mktemp -d)
     tempdir2=$(mktemp -d)
-    wget ${url} -P ${tempdir}
+    wget -P ${tempdir} ${url}
     unzip ${tempdir}/* -d ${tempdir2}
     # unzip has no strip components, so unzip to a temp dir, and move the files
     # we want from the tempdir to destination.


### PR DESCRIPTION
wget expects parameters before the URL on OSX (tested on
version 1.16 and 1.19)

It would fail trying to use -P as a URL

Resolving -p... failed: nodename nor servname provided, or not known.
wget: unable to resolve host address ‘-p’