### PR TITLE
Fix `tf.py_func()` and `Dataset.from_generator()` on Python 3.

### DIFF
--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -148,6 +148,21 @@ class PyOpTest(test.TestCase):
       z, = script_ops.py_func(read_and_return_strings, [x, y], [dtypes.string])
       self.assertListEqual(list(z.eval()), [b"hello there", b"hi there"])
 
+  def testObjectArraysAreConvertedToBytes(self):
+
+    def read_object_array():
+      return np.array([b" there", u" ya"], dtype=np.object)
+
+    def read_and_return_strings(x, y):
+      return x + y
+
+    with self.test_session():
+      x = constant_op.constant(["hello", "hi"], dtypes.string)
+      y, = script_ops.py_func(read_object_array, [],
+                              [dtypes.string])
+      z, = script_ops.py_func(read_and_return_strings, [x, y], [dtypes.string])
+      self.assertListEqual(list(z.eval()), [b"hello there", b"hi ya"])
+
   def testStringPadding(self):
     correct = [b"this", b"is", b"a", b"test"]
     with self.test_session():

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -297,8 +297,15 @@ Status ConvertNdarrayToTensor(PyObject* obj, Tensor* ret) {
         char* el;
         Py_ssize_t el_size;
         if (PyBytes_AsStringAndSize(input_data[i], &el, &el_size) == -1) {
-          return errors::Unimplemented("Unsupported object type ",
-                                       input_data[i]->ob_type->tp_name);
+#if PY_MAJOR_VERSION >= 3
+          el = PyUnicode_AsUTF8AndSize(input_data[i], &el_size);
+          if (!el) {
+#endif
+            return errors::Unimplemented("Unsupported object type ",
+                                         input_data[i]->ob_type->tp_name);
+#if PY_MAJOR_VERSION >= 3
+          }
+#endif
         }
         tflat(i) = string(el, el_size);
       }


### PR DESCRIPTION
Cherry pick to make `Dataset.from_generator()` work on Python 3 when the generator yields (unicode) strings.