### PR TITLE
Update the C++ API guide [Doc only, should be in 1.4]

### DIFF
--- a/tensorflow/docs_src/api_guides/cc/guide.md
+++ b/tensorflow/docs_src/api_guides/cc/guide.md
@@ -1,4 +1,12 @@
 # C++ API
+
+Note: By default [tensorflow.org](http://tensorflow.org) shows docs for the
+most recent stable version. The instructions in this doc require building from
+source. You will probably want to build from the `master` version of tensorflow.
+You should, as a result, be sure you are following the
+[`master` version of this doc](https://www.tensorflow.org/versions/master/api_guides/cc/guide),
+in case there have been any changes.
+
 [TOC]
 
 TensorFlow's C++ API provides mechanisms for constructing and executing a data
@@ -48,7 +56,9 @@ TensorFlow
 `BUILD` file in the same directory with the following contents:
 
 ```python
-cc_binary(
+load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
+
+tf_cc_binary(
     name = "example",
     srcs = ["example.cc"],
     deps = [
@@ -59,8 +69,10 @@ cc_binary(
 )
 ```
 
-You should be able to build and run the example using the following command
-(be sure to run `./configure` in your build sandbox first):
+Use `tf_cc_binary` rather than Bazel's native `cc_binary` to link in necessary
+symbols from `libtensorflow_framework.so`. You should be able to build and run
+the example using the following command (be sure to run `./configure` in your
+build sandbox first):
 
 ```shell
 bazel run -c opt //tensorflow/cc/example:example


### PR DESCRIPTION
- Includes a documentation fix for 1.4 (cc_binary -> tf_cc_binary to avoid undefined symbols).
- Adds the standard warning at the top that people may want the master branch.

Fixes https://github.com/tensorflow/tensorflow/issues/13855.