### PR TITLE
protobuf lib path bug fix for benckmark on osx

### DIFF
--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -190,6 +190,10 @@ LIBFLAGS :=
 
 # If we're on OS X, make sure that globals aren't stripped out.
 ifeq ($(TARGET),OSX)
+ifeq ($(HAS_GEN_HOST_PROTOC),true)
+	LIBFLAGS += -L$(MAKEFILE_DIR)/gen/protobuf-host/lib
+	export LD_LIBRARY_PATH=$(MAKEFILE_DIR)/gen/protobuf-host/lib
+endif
 	LDFLAGS += -all_load
 endif
 # Make sure that we don't strip global constructors on Linux.


### PR DESCRIPTION
### bug info
If not fixed, `/usr/local/lib` will before `tensorflow/contrib/makefile/gen/protobuf-host/lib/` in the library search path. It will cause `undefined symbol` problem of protobuf when building `benchmark` because of incompatibility of system installed protobuf.

### fix
Have tested on maxOS 10.12.6

@vrv 