### PR TITLE
Update protobuf.cmake to b04e5cba356212e4e8c66c61bbe0c3a20537c5b9

### DIFF
--- a/tensorflow/contrib/cmake/external/protobuf.cmake
+++ b/tensorflow/contrib/cmake/external/protobuf.cmake
@@ -15,8 +15,8 @@
 include (ExternalProject)
 
 set(PROTOBUF_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/src)
-set(PROTOBUF_URL https://github.com/mrry/protobuf.git)  # Includes MSVC fix.
-set(PROTOBUF_TAG 1d2c7b6c7376f396c8c7dd9b6afd2d4f83f3cb05)
+set(PROTOBUF_URL https://github.com/google/protobuf.git)
+set(PROTOBUF_TAG b04e5cba356212e4e8c66c61bbe0c3a20537c5b9)
 
 if(WIN32)
   set(protobuf_STATIC_LIBRARIES 


### PR DESCRIPTION
This fix tries to address the issue raised in #8187 where protobuf.cmake used different version as bazel.

The reason for discrepancy was due to the fact that a customerized protobuf was needed with Windows patch. Since the patch has been merged in (https://github.com/google/protobuf/pull/2203), it makes sense to update protobuf.cmake so that the same version of cmake is used.

This fix fixes #8187.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>