### PR TITLE
Cauchy Distribution

### DIFF
--- a/tensorflow/contrib/distributions/BUILD
+++ b/tensorflow/contrib/distributions/BUILD
@@ -132,7 +132,7 @@ cuda_py_test(
 cuda_py_test(
     name = "cauchy_test",
     size = "medium",
-    srcs = ["cauchy_test.py"],
+    srcs = ["python/kernel_tests/cauchy_test.py"],
     additional_deps = [
         "//tensorflow/python/ops/distributions",
         "//third_party/py/numpy",

--- a/tensorflow/contrib/distributions/BUILD
+++ b/tensorflow/contrib/distributions/BUILD
@@ -130,6 +130,23 @@ cuda_py_test(
 )
 
 cuda_py_test(
+    name = "cauchy_test",
+    size = "medium",
+    srcs = ["cauchy_test.py"],
+    additional_deps = [
+        "//tensorflow/python/ops/distributions",
+        "//third_party/py/numpy",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:framework_test_lib",
+        "//tensorflow/python:gradients",
+        "//tensorflow/python:platform_test",
+        "//tensorflow/python:variables",
+    ],
+)
+
+cuda_py_test(
     name = "chi2_test",
     srcs = ["python/kernel_tests/chi2_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/distributions/BUILD
+++ b/tensorflow/contrib/distributions/BUILD
@@ -134,7 +134,7 @@ cuda_py_test(
     size = "medium",
     srcs = ["python/kernel_tests/cauchy_test.py"],
     additional_deps = [
-        "//tensorflow/python/ops/distributions",
+        ":distributions_py",
         "//third_party/py/numpy",
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client_testlib",

--- a/tensorflow/contrib/distributions/__init__.py
+++ b/tensorflow/contrib/distributions/__init__.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 
 from tensorflow.contrib.distributions.python.ops import bijectors
 from tensorflow.contrib.distributions.python.ops.binomial import *
+from tensorflow.contrib.distributions.python.ops.cauchy import *
 from tensorflow.contrib.distributions.python.ops.chi2 import *
 from tensorflow.contrib.distributions.python.ops.conditional_distribution import *
 from tensorflow.contrib.distributions.python.ops.conditional_transformed_distribution import *
@@ -83,6 +84,7 @@ from tensorflow.python.util.all_util import remove_undocumented
 
 _allowed_symbols = [
     'bijectors',
+    'Cauchy',
     'ConditionalDistribution',
     'ConditionalTransformedDistribution',
     'FULLY_REPARAMETERIZED',

--- a/tensorflow/contrib/distributions/__init__.py
+++ b/tensorflow/contrib/distributions/__init__.py
@@ -85,6 +85,7 @@ from tensorflow.python.util.all_util import remove_undocumented
 _allowed_symbols = [
     'bijectors',
     'Cauchy',
+    'CauchyWithSoftplusScale',
     'ConditionalDistribution',
     'ConditionalTransformedDistribution',
     'FULLY_REPARAMETERIZED',

--- a/tensorflow/contrib/distributions/__init__.py
+++ b/tensorflow/contrib/distributions/__init__.py
@@ -85,7 +85,6 @@ from tensorflow.python.util.all_util import remove_undocumented
 _allowed_symbols = [
     'bijectors',
     'Cauchy',
-    'CauchyWithSoftplusScale',
     'ConditionalDistribution',
     'ConditionalTransformedDistribution',
     'FULLY_REPARAMETERIZED',

--- a/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -86,14 +86,6 @@ class CauchyTest(test.TestCase):
     self._testParamStaticShapes(
         tensor_shape.TensorShape(sample_shape), sample_shape)
 
-  def testCauchyWithSoftplusScale(self):
-    with self.test_session():
-      loc = array_ops.zeros((10, 3))
-      rho = array_ops.ones((10, 3)) * -2.
-      cauchy = cauchy_lib.CauchyWithSoftplusScale(loc=loc, scale=rho)
-      self.assertAllEqual(loc.eval(), cauchy.loc.eval())
-      self.assertAllEqual(nn_ops.softplus(rho).eval(), cauchy.scale.eval())
-
   def testCauchyLogPDF(self):
     with self.test_session():
       batch_size = 6
@@ -104,16 +96,16 @@ class CauchyTest(test.TestCase):
 
       log_pdf = cauchy.log_prob(x)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
-                          log_pdf.get_shape())
+                          log_pdf.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
                           log_pdf.eval().shape)
-      self.assertAllEqual(cauchy.batch_shape, log_pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, log_pdf.shape)
       self.assertAllEqual(cauchy.batch_shape, log_pdf.eval().shape)
 
       pdf = cauchy.prob(x)
-      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf.eval().shape)
-      self.assertAllEqual(cauchy.batch_shape, pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, pdf.shape)
       self.assertAllEqual(cauchy.batch_shape, pdf.eval().shape)
 
       if not stats:
@@ -133,20 +125,20 @@ class CauchyTest(test.TestCase):
 
       log_pdf = cauchy.log_prob(x)
       log_pdf_values = log_pdf.eval()
-      self.assertEqual(log_pdf.get_shape(), (6, 2))
+      self.assertEqual(log_pdf.shape, (6, 2))
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
-                          log_pdf.get_shape())
+                          log_pdf.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
                           log_pdf.eval().shape)
-      self.assertAllEqual(cauchy.batch_shape, log_pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, log_pdf.shape)
       self.assertAllEqual(cauchy.batch_shape, log_pdf.eval().shape)
 
       pdf = cauchy.prob(x)
       pdf_values = pdf.eval()
-      self.assertEqual(pdf.get_shape(), (6, 2))
-      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf.get_shape())
+      self.assertEqual(pdf.shape, (6, 2))
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf_values.shape)
-      self.assertAllEqual(cauchy.batch_shape, pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, pdf.shape)
       self.assertAllEqual(cauchy.batch_shape, pdf_values.shape)
 
       if not stats:
@@ -164,9 +156,9 @@ class CauchyTest(test.TestCase):
 
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
       cdf = cauchy.cdf(x)
-      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), cdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), cdf.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(), cdf.eval().shape)
-      self.assertAllEqual(cauchy.batch_shape, cdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, cdf.shape)
       self.assertAllEqual(cauchy.batch_shape, cdf.eval().shape)
       if not stats:
         return
@@ -183,9 +175,9 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
       sf = cauchy.survival_function(x)
-      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), sf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), sf.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(), sf.eval().shape)
-      self.assertAllEqual(cauchy.batch_shape, sf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, sf.shape)
       self.assertAllEqual(cauchy.batch_shape, sf.eval().shape)
       if not stats:
         return
@@ -202,9 +194,9 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
       cdf = cauchy.log_cdf(x)
-      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), cdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), cdf.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(), cdf.eval().shape)
-      self.assertAllEqual(cauchy.batch_shape, cdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, cdf.shape)
       self.assertAllEqual(cauchy.batch_shape, cdf.eval().shape)
 
       if not stats:
@@ -242,9 +234,9 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
       sf = cauchy.log_survival_function(x)
-      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), sf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), sf.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(), sf.eval().shape)
-      self.assertAllEqual(cauchy.batch_shape, sf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, sf.shape)
       self.assertAllEqual(cauchy.batch_shape, sf.eval().shape)
 
       if not stats:
@@ -260,10 +252,10 @@ class CauchyTest(test.TestCase):
 
       entropy = cauchy.entropy()
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
-                          entropy.get_shape())
+                          entropy.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
                           entropy.eval().shape)
-      self.assertAllEqual(cauchy.batch_shape, entropy.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, entropy.shape)
       self.assertAllEqual(cauchy.batch_shape, entropy.eval().shape)
 
       if not stats:
@@ -279,10 +271,10 @@ class CauchyTest(test.TestCase):
 
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
-      self.assertAllEqual((3,), cauchy.median().get_shape())
+      self.assertAllEqual((3,), cauchy.median().shape)
       self.assertAllEqual([7., 7, 7], cauchy.median().eval())
 
-      self.assertAllEqual((3,), cauchy.mode().get_shape())
+      self.assertAllEqual((3,), cauchy.mode().shape)
       self.assertAllEqual([7., 7, 7], cauchy.mode().eval())
 
   def testCauchyMean(self):
@@ -291,7 +283,7 @@ class CauchyTest(test.TestCase):
       scale = [7.]
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
-      self.assertAllEqual((3,), cauchy.mean().get_shape())
+      self.assertAllEqual((3,), cauchy.mean().shape)
       self.assertAllEqual([float("nan")] * 3, cauchy.mean().eval())
 
   def testCauchyNanMean(self):
@@ -313,9 +305,9 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
       x = cauchy.quantile(p)
 
-      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), x.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), x.shape)
       self.assertAllEqual(cauchy.batch_shape_tensor().eval(), x.eval().shape)
-      self.assertAllEqual(cauchy.batch_shape, x.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, x.shape)
       self.assertAllEqual(cauchy.batch_shape, x.eval().shape)
 
       if not stats:
@@ -330,7 +322,7 @@ class CauchyTest(test.TestCase):
       scale = [7.]
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
-      self.assertAllEqual((3,), cauchy.variance().get_shape())
+      self.assertAllEqual((3,), cauchy.variance().shape)
       self.assertAllEqual([float("nan")] * 3, cauchy.variance().eval())
 
   def testCauchyNanVariance(self):
@@ -350,7 +342,7 @@ class CauchyTest(test.TestCase):
       scale = [7.]
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
-      self.assertAllEqual((3,), cauchy.stddev().get_shape())
+      self.assertAllEqual((3,), cauchy.stddev().shape)
       self.assertAllEqual([float("nan")] * 3, cauchy.stddev().eval())
 
   def testCauchyNanStandardDeviation(self):
@@ -379,13 +371,13 @@ class CauchyTest(test.TestCase):
       expected_shape = tensor_shape.TensorShape([n.eval()]).concatenate(
           tensor_shape.TensorShape(cauchy.batch_shape_tensor().eval()))
 
-      self.assertAllEqual(expected_shape, samples.get_shape())
+      self.assertAllEqual(expected_shape, samples.shape)
       self.assertAllEqual(expected_shape, sample_values.shape)
 
       expected_shape = (tensor_shape.TensorShape(
           [n.eval()]).concatenate(cauchy.batch_shape))
 
-      self.assertAllEqual(expected_shape, samples.get_shape())
+      self.assertAllEqual(expected_shape, samples.shape)
       self.assertAllEqual(expected_shape, sample_values.shape)
 
   def testCauchySampleMultiDimensional(self):
@@ -398,18 +390,18 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
       samples = cauchy.sample(n)
       sample_values = samples.eval()
-      self.assertEqual(samples.get_shape(), (100000, batch_size, 2))
+      self.assertEqual(samples.shape, (100000, batch_size, 2))
       self.assertAllClose(sample_values[:, 0, 0].median(), loc_v[0], atol=1e-1)
       self.assertAllClose(sample_values[:, 0, 1].median(), loc_v[1], atol=1e-1)
 
       expected_shape = tensor_shape.TensorShape([n.eval()]).concatenate(
           tensor_shape.TensorShape(cauchy.batch_shape_tensor().eval()))
-      self.assertAllEqual(expected_shape, samples.get_shape())
+      self.assertAllEqual(expected_shape, samples.shape)
       self.assertAllEqual(expected_shape, sample_values.shape)
 
       expected_shape = (tensor_shape.TensorShape(
           [n.eval()]).concatenate(cauchy.batch_shape))
-      self.assertAllEqual(expected_shape, samples.get_shape())
+      self.assertAllEqual(expected_shape, samples.shape)
       self.assertAllEqual(expected_shape, sample_values.shape)
 
   def testCauchyNegativeLocFails(self):

--- a/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
@@ -30,6 +30,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradients_impl
+from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 from tensorflow.python.platform import tf_logging
@@ -84,6 +85,14 @@ class CauchyTest(test.TestCase):
     self._testParamStaticShapes(sample_shape, sample_shape)
     self._testParamStaticShapes(
         tensor_shape.TensorShape(sample_shape), sample_shape)
+
+  def testCauchyWithSoftplusScale(self):
+    with self.test_session():
+      loc = array_ops.zeros((10, 3))
+      rho = array_ops.ones((10, 3)) * -2.
+      cauchy = cauchy_lib.CauchyWithSoftplusScale(loc=loc, scale=rho)
+      self.assertAllEqual(loc.eval(), cauchy.loc.eval())
+      self.assertAllEqual(nn_ops.softplus(rho).eval(), cauchy.scale.eval())
 
   def testCauchyLogPDF(self):
     with self.test_session():

--- a/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
@@ -30,9 +30,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradients_impl
-from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import variables
-from tensorflow.python.ops.distributions import kullback_leibler
 from tensorflow.python.platform import test
 from tensorflow.python.platform import tf_logging
 
@@ -294,7 +292,7 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale, allow_nan_stats=False)
 
       with self.assertRaises(ValueError):
-        var = cauchy.mean()
+        cauchy.mean().eval()
 
   def testCauchyQuantile(self):
     with self.test_session():
@@ -334,7 +332,7 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale, allow_nan_stats=False)
 
       with self.assertRaises(ValueError):
-        var = cauchy.variance()
+        cauchy.variance().eval()
 
   def testCauchyStandardDeviation(self):
     with self.test_session():
@@ -354,14 +352,13 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale, allow_nan_stats=False)
 
       with self.assertRaises(ValueError):
-        var = cauchy.stddev()
+        cauchy.stddev().eval()
 
   def testCauchySample(self):
     with self.test_session():
       loc = constant_op.constant(3.0)
       scale = constant_op.constant(1.0)
       loc_v = 3.0
-      scale_v = 1.0
       n = constant_op.constant(100000)
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
       samples = cauchy.sample(n)
@@ -388,7 +385,6 @@ class CauchyTest(test.TestCase):
       loc = constant_op.constant([[3.0, -3.0]] * batch_size)
       scale = constant_op.constant([[0.5, 1.0]] * batch_size)
       loc_v = [3.0, -3.0]
-      scale_v = [0.5, 1.0]
       n = constant_op.constant(100000)
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
       samples = cauchy.sample(n)
@@ -438,6 +434,7 @@ class CauchyTest(test.TestCase):
           sess.run(cauchy.batch_shape_tensor(),
                    feed_dict={loc: 5.0,
                               scale: [1.0, 2.0]}), [2])
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
@@ -30,7 +30,6 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradients_impl
-from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 from tensorflow.python.platform import tf_logging

--- a/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
@@ -1,0 +1,156 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for Cauchy."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import math
+
+import numpy as np
+
+from tensorflow.contrib.distributions.python.ops import cauchy as cauchy_lib
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gradients_impl
+from tensorflow.python.ops import nn_ops
+from tensorflow.python.ops import variables
+from tensorflow.python.ops.distributions import kullback_leibler
+from tensorflow.python.platform import test
+from tensorflow.python.platform import tf_logging
+
+
+def try_import(name):  # pylint: disable=invalid-name
+  module = None
+  try:
+    module = importlib.import_module(name)
+  except ImportError as e:
+    tf_logging.warning("Could not import %s: %s" % (name, str(e)))
+  return module
+
+stats = try_import("scipy.stats")
+
+
+class CauchyTest(test.TestCase):
+
+  def setUp(self):
+    self._rng = np.random.RandomState(123)
+
+  def assertAllFinite(self, tensor):
+    is_finite = np.isfinite(tensor.eval())
+    all_true = np.ones_like(is_finite, dtype=np.bool)
+    self.assertAllEqual(all_true, is_finite)
+
+  def _testParamShapes(self, sample_shape, expected):
+    with self.test_session():
+      param_shapes = cauchy_lib.Cauchy.param_shapes(sample_shape)
+      loc_shape, scale_shape = param_shapes["loc"], param_shapes["scale"]
+      self.assertAllEqual(expected, loc_shape.eval())
+      self.assertAllEqual(expected, scale_shape.eval())
+      loc = array_ops.zeros(loc_shape)
+      scale = array_ops.ones(scale_shape)
+      self.assertAllEqual(
+          expected,
+          array_ops.shape(cauchy_lib.Cauchy(loc, scale).sample()).eval())
+
+  def _testParamStaticShapes(self, sample_shape, expected):
+    param_shapes = cauchy_lib.Cauchy.param_static_shapes(sample_shape)
+    loc_shape, scale_shape = param_shapes["loc"], param_shapes["scale"]
+    self.assertEqual(expected, loc_shape)
+    self.assertEqual(expected, scale_shape)
+
+  def testParamShapes(self):
+    sample_shape = [10, 3, 4]
+    self._testParamShapes(sample_shape, sample_shape)
+    self._testParamShapes(constant_op.constant(sample_shape), sample_shape)
+
+  def testParamStaticShapes(self):
+    sample_shape = [10, 3, 4]
+    self._testParamStaticShapes(sample_shape, sample_shape)
+    self._testParamStaticShapes(
+        tensor_shape.TensorShape(sample_shape), sample_shape)
+
+  def testCauchyLogPDF(self):
+    with self.test_session():
+      batch_size = 6
+      loc = constant_op.constant([3.0] * batch_size)
+      scale = constant_op.constant([math.sqrt(10.0)] * batch_size)
+      x = np.array([-2.5, 2.5, 4.0, 0.0, -1.0, 2.0], dtype=np.float32)
+      cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
+
+      log_pdf = cauchy.log_prob(x)
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
+                          log_pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
+                          log_pdf.eval().shape)
+      self.assertAllEqual(cauchy.batch_shape, log_pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, log_pdf.eval().shape)
+
+      pdf = cauchy.prob(x)
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf.eval().shape)
+      self.assertAllEqual(cauchy.batch_shape, pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, pdf.eval().shape)
+
+      if not stats:
+        return
+      expected_log_pdf = stats.cauchy(loc.eval(), scale.eval()).logpdf(x)
+      self.assertAllClose(expected_log_pdf, log_pdf.eval())
+      self.assertAllClose(np.exp(expected_log_pdf), pdf.eval())
+
+  def testCauchyLogPDFMultidimensional(self):
+    with self.test_session():
+      batch_size = 6
+      loc = constant_op.constant([[3.0, -3.0]] * batch_size)
+      scale = constant_op.constant([[math.sqrt(10.0), math.sqrt(15.0)]] *
+                                   batch_size)
+      x = np.array([[-2.5, 2.5, 4.0, 0.0, -1.0, 2.0]], dtype=np.float32).T
+      cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
+
+      log_pdf = cauchy.log_prob(x)
+      log_pdf_values = log_pdf.eval()
+      self.assertEqual(log_pdf.get_shape(), (6, 2))
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
+                          log_pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(),
+                          log_pdf.eval().shape)
+      self.assertAllEqual(cauchy.batch_shape, log_pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, log_pdf.eval().shape)
+
+      pdf = cauchy.prob(x)
+      pdf_values = pdf.eval()
+      self.assertEqual(pdf.get_shape(), (6, 2))
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape_tensor().eval(), pdf_values.shape)
+      self.assertAllEqual(cauchy.batch_shape, pdf.get_shape())
+      self.assertAllEqual(cauchy.batch_shape, pdf_values.shape)
+
+      if not stats:
+        return
+      expected_log_pdf = stats.cauchy(loc.eval(), scale.eval()).logpdf(x)
+      self.assertAllClose(expected_log_pdf, log_pdf_values)
+      self.assertAllClose(np.exp(expected_log_pdf), pdf_values)
+
+
+
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/cauchy_test.py
@@ -19,8 +19,6 @@ from __future__ import division
 from __future__ import print_function
 
 import importlib
-import math
-
 import numpy as np
 
 from tensorflow.contrib.distributions.python.ops import cauchy as cauchy_lib
@@ -89,7 +87,7 @@ class CauchyTest(test.TestCase):
     with self.test_session():
       batch_size = 6
       loc = constant_op.constant([3.0] * batch_size)
-      scale = constant_op.constant([math.sqrt(10.0)] * batch_size)
+      scale = constant_op.constant([np.sqrt(10.0)] * batch_size)
       x = np.array([-2.5, 2.5, 4.0, 0.0, -1.0, 2.0], dtype=np.float32)
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
@@ -117,7 +115,7 @@ class CauchyTest(test.TestCase):
     with self.test_session():
       batch_size = 6
       loc = constant_op.constant([[3.0, -3.0]] * batch_size)
-      scale = constant_op.constant([[math.sqrt(10.0), math.sqrt(15.0)]] *
+      scale = constant_op.constant([[np.sqrt(10.0), np.sqrt(15.0)]] *
                                    batch_size)
       x = np.array([[-2.5, 2.5, 4.0, 0.0, -1.0, 2.0]], dtype=np.float32).T
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
@@ -283,7 +281,7 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
       self.assertAllEqual((3,), cauchy.mean().shape)
-      self.assertAllEqual([float("nan")] * 3, cauchy.mean().eval())
+      self.assertAllEqual([np.nan] * 3, cauchy.mean().eval())
 
   def testCauchyNanMean(self):
     with self.test_session():
@@ -322,7 +320,7 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
       self.assertAllEqual((3,), cauchy.variance().shape)
-      self.assertAllEqual([float("nan")] * 3, cauchy.variance().eval())
+      self.assertAllEqual([np.nan] * 3, cauchy.variance().eval())
 
   def testCauchyNanVariance(self):
     with self.test_session():
@@ -342,7 +340,7 @@ class CauchyTest(test.TestCase):
       cauchy = cauchy_lib.Cauchy(loc=loc, scale=scale)
 
       self.assertAllEqual((3,), cauchy.stddev().shape)
-      self.assertAllEqual([float("nan")] * 3, cauchy.stddev().eval())
+      self.assertAllEqual([np.nan] * 3, cauchy.stddev().eval())
 
   def testCauchyNanStandardDeviation(self):
     with self.test_session():

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -31,6 +31,7 @@ from tensorflow.python.ops import random_ops
 from tensorflow.python.ops.distributions import distribution
 from tensorflow.python.ops.distributions import util as distribution_util
 
+
 __all__ = [
     "Cauchy",
 ]
@@ -84,11 +85,11 @@ class Cauchy(distribution.Distribution):
   ```python
   # Define a batch of two scalar valued Normals.
   # Both have mean 1, but different standard deviations.
-  dist = tf.distributions.Normal(loc=1., scale=[11, 22.])
+  dist = tf.contrib.distributions.Cauchy(loc=1., scale=[11, 22.])
   # Evaluate the pdf of both distributions on the same point, 3.0,
   # returning a length 2 tensor.
   dist.prob(3.0)
-    ```
+  ```
   """
 
   def __init__(self,
@@ -213,13 +214,19 @@ class Cauchy(distribution.Distribution):
       return z * self.scale + self.loc
 
   def _log_survival_function(self, x):
-    raise NotImplementedError()
+    return math_ops.log(self._survival_function(x))
 
   def _survival_function(self, x):
-    raise NotImplementedError()
+    return 1. - self._cdf(x)
 
   def _mean(self):
-    raise NotImplementedError()
+    if self.allow_nan_stats:
+      return float("nan")
+    else:
+      raise ValueError("`mean` is undefined for Cauchy distribution.")
 
   def _stddev(self):
-    raise NotImplementedError()
+    if self.allow_nan_stats:
+      return float("nan")
+    else:
+      raise ValueError("`stddev` is undefined for Cauchy distribution.")

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -44,7 +44,7 @@ class Cauchy(distribution.Distribution):
   The probability density function (pdf) is,
 
   ```none
-  pdf(x; loc, scale) = 1 / (pi*scale*(1+((x-loc)/scale)**2))
+  pdf(x; loc, scale) = 1 / (pi * scale * (1 + ((x - loc) / scale)**2))
   ```
   where `loc` is the location, and `scale` is the scale.
 

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -29,7 +29,6 @@ from tensorflow.python.ops import check_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
 from tensorflow.python.ops.distributions import distribution
-from tensorflow.python.ops.distributions import util as distribution_util
 
 
 __all__ = [

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -210,12 +210,14 @@ class Cauchy(distribution.Distribution):
 
   def _mean(self):
     if self.allow_nan_stats:
-      return float("nan") * array_ops.ones(self.batch_shape_tensor())
+      return array_ops.fill(self.batch_shape_tensor(),
+                            self.dtype.as_numpy_dtype(np.nan))
     else:
       raise ValueError("`mean` is undefined for Cauchy distribution.")
 
   def _stddev(self):
     if self.allow_nan_stats:
-      return float("nan") * array_ops.ones(self.batch_shape_tensor())
+      return array_ops.fill(self.batch_shape_tensor(),
+                            self.dtype.as_numpy_dtype(np.nan))
     else:
       raise ValueError("`stddev` is undefined for Cauchy distribution.")

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -33,6 +33,7 @@ from tensorflow.python.ops.distributions import distribution
 
 __all__ = [
     "Cauchy",
+    "CauchyWithSoftplusScale",
 ]
 
 

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -68,7 +68,7 @@ class Cauchy(distribution.Distribution):
   # Evaluate the cdf at 1, returning a scalar.
   dist.cdf(1.)
 
-  # Define a batch of two scalar valued Normals.
+  # Define a batch of two scalar valued Cauchy distributions.
   dist = Cauchy(loc=[1, 2.], scale=[11, 22.])
 
   # Evaluate the pdf of the first distribution on 0, and the second on 1.5,
@@ -82,8 +82,8 @@ class Cauchy(distribution.Distribution):
   Arguments are broadcast when possible.
 
   ```python
-  # Define a batch of two scalar valued Normals.
-  # Both have mean 1, but different standard deviations.
+  # Define a batch of two scalar valued Cauchy distributions.
+  # Both have median 1, but different scales.
   dist = tf.contrib.distributions.Cauchy(loc=1., scale=[11, 22.])
   # Evaluate the pdf of both distributions on the same point, 3.0,
   # returning a length 2 tensor.

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -89,7 +89,46 @@ class Cauchy(distribution.Distribution):
     ```
   """
 
-  def __init__(self):
+  def __init__(self,
+               loc,
+               scale,
+               validate_args=False,
+               allow_nan_stats=True,
+               name="Cauchy"):
+    """Construct Cauchy distributions with loc and and scale `loc` and `scale`.
+
+    The parameters `loc` and `scale` must be shaped in a way that supports
+    broadcasting (e.g. `loc + scale` is a valid operation).
+
+    Args:
+      loc: Floating point tensor; the modes of the distribution(s).
+      scale: Floating point tensor; the locations of the distribution(s).
+        Must contain only positive values.
+      validate_args: Python `bool`, default `False`. When `True` distribution
+        parameters are checked for validity despite possibly degrading runtime
+        performance. When `False` invalid inputs may silently render incorrect
+        outputs.
+      allow_nan_stats: Python `bool`, default `True`. When `True`,
+        statistics (e.g., mean, mode, variance) use the value "`NaN`" to
+        indicate the result is undefined. When `False`, an exception is raised
+        if one or more of the statistic's batch members are undefined.
+      name: Python `str` name prefixed to Ops created by this class.
+
+    Raises:
+      TypeError: if `loc` and `scale` have different `dtype`.
     """
-    """
-    pass
+    parameters = locals()
+    with ops.name_scope(name, values=[loc, scale]):
+      with ops.control_dependencies([check_ops.assert_positive(scale)] if
+                                    validate_args else []):
+        self._loc = array_ops.identity(loc, name="loc")
+        self._scale = array_ops.identity(scale, name="scale")
+        check_ops.assert_same_float_dtype([self._loc, self._scale])
+    super(Cauchy, self).__init__(
+        dtype=self._scale.dtype,
+        reparameterization_type=distribution.FULLY_REPARAMETERIZED,
+        validate_args=validate_args,
+        allow_nan_stats=allow_nan_stats,
+        parameters=parameters,
+        graph_parents=[self._loc, self._scale],
+        name=name)

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -229,3 +229,23 @@ class Cauchy(distribution.Distribution):
       return constant_op.constant(float("nan"), shape=self.batch_shape)
     else:
       raise ValueError("`stddev` is undefined for Cauchy distribution.")
+
+
+class CauchyWithSoftplusScale(Cauchy):
+  """Cauchy with softplus applied to `scale`."""
+
+  def __init__(self,
+               loc,
+               scale,
+               validate_args=False,
+               allow_nan_stats=True,
+               name="CauchyWithSoftplusScale"):
+    parameters = locals()
+    with ops.name_scope(name, values=[scale]):
+      super(CauchyWithSoftplusScale, self).__init__(
+          loc=loc,
+          scale=nn.softplus(scale, name="softplus_scale"),
+          validate_args=validate_args,
+          allow_nan_stats=allow_nan_stats,
+          name=name)
+    self._parameters = parameters

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -45,9 +45,9 @@ class Cauchy(distribution.Distribution):
   The probability density function (pdf) is,
 
   ```none
-  pdf(x; mu, gamma) = 1 / (pi*gamma*(1+((x-mu)/gamma)**2))
+  pdf(x; loc, scale) = 1 / (pi*scale*(1+((x-loc)/scale)**2))
   ```
-  where `loc = mu` is the mean, `scale = gamma` is the std. deviation.
+  where `loc` is the location, and `scale` is the scale.
 
   The Cauchy distribution is a member of the [location-scale family](
   https://en.wikipedia.org/wiki/Location-scale_family), i.e.
@@ -221,12 +221,12 @@ class Cauchy(distribution.Distribution):
 
   def _mean(self):
     if self.allow_nan_stats:
-      return float("nan")
+      return constant_op.constant(float("nan"), shape=self.batch_shape)
     else:
       raise ValueError("`mean` is undefined for Cauchy distribution.")
 
   def _stddev(self):
     if self.allow_nan_stats:
-      return float("nan")
+      return constant_op.constant(float("nan"), shape=self.batch_shape)
     else:
       raise ValueError("`stddev` is undefined for Cauchy distribution.")

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -1,0 +1,95 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The Cauchy distribution class."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import check_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import random_ops
+from tensorflow.python.ops.distributions import distribution
+from tensorflow.python.ops.distributions import util as distribution_util
+
+__all__ = [
+    "Cauchy",
+]
+
+
+class Cauchy(distribution.Distribution):
+  """The Cauchy distribution with location `loc` and scale `scale`.
+
+  #### Mathematical details
+
+  The probability density function (pdf) is,
+
+  ```none
+  pdf(x; mu, gamma) = 1 / (pi*gamma*(1+((x-mu)/gamma)**2))
+  ```
+  where `loc = mu` is the mean, `scale = gamma` is the std. deviation.
+
+  The Cauchy distribution is a member of the [location-scale family](
+  https://en.wikipedia.org/wiki/Location-scale_family), i.e.
+
+  ```none
+  X ~ Cauchy(loc=0, scale=1)
+  Y ~ Cauchy(loc=loc, scale=scale)
+  Y = loc + scale * X
+  ```
+
+  #### Examples
+
+  Examples of initialization of one or a batch of distributions.
+
+  ```python
+  # Define a single scalar Cauchy distribution.
+  dist = Cauchy(loc=0., scale=3.)
+
+  # Evaluate the cdf at 1, returning a scalar.
+  dist.cdf(1.)
+
+  # Define a batch of two scalar valued Normals.
+  dist = Cauchy(loc=[1, 2.], scale=[11, 22.])
+
+  # Evaluate the pdf of the first distribution on 0, and the second on 1.5,
+  # returning a length two tensor.
+  dist.prob([0, 1.5])
+
+  # Get 3 samples, returning a 3 x 2 tensor.
+  dist.sample([3])
+  ```
+
+  Arguments are broadcast when possible.
+
+  ```python
+  # Define a batch of two scalar valued Normals.
+  # Both have mean 1, but different standard deviations.
+  dist = tf.distributions.Normal(loc=1., scale=[11, 22.])
+  # Evaluate the pdf of both distributions on the same point, 3.0,
+  # returning a length 2 tensor.
+  dist.prob(3.0)
+    ```
+  """
+
+  def __init__(self):
+    """
+    """
+    pass

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -33,7 +33,6 @@ from tensorflow.python.ops.distributions import distribution
 
 __all__ = [
     "Cauchy",
-    "CauchyWithSoftplusScale",
 ]
 
 

--- a/tensorflow/contrib/distributions/python/ops/cauchy.py
+++ b/tensorflow/contrib/distributions/python/ops/cauchy.py
@@ -189,7 +189,7 @@ class Cauchy(distribution.Distribution):
     return np.log(np.pi) + math_ops.log(self.scale)
 
   def _entropy(self):
-    h = np.log(4 * np.pi) + math_ops.log(scale)
+    h = np.log(4 * np.pi) + math_ops.log(self.scale)
     return h * array_ops.ones_like(self.loc)
 
   def _quantile(self, p):


### PR DESCRIPTION
Added the cauchy distribution to `contrib.distributions`.

The cauchy distribution is an example of a distribution with undefined moments. I couldn't find an existing implementation to reference against, so I'm not sure if my approach to this:
```python
if self.allow_nan_stats:
  return constant_op.constant(float("nan"), shape=self.batch_shape)
else:
  raise ValueError("`mean` is undefined for Cauchy distribution.")
```
is correct, please advise.