### PR TITLE
nsync lib name change

### DIFF
--- a/tensorflow/contrib/makefile/compile_nsync.sh
+++ b/tensorflow/contrib/makefile/compile_nsync.sh
@@ -289,7 +289,8 @@ for arch in $archs; do
                 echo "$makefile" | sed $'s,^[ \t]*,,' > "$nsync_platform_dir/Makefile"
                 touch "$nsync_platform_dir/dependfile"
         fi
-        if (cd "$nsync_platform_dir" && make depend libnsync.a >&2); then
+        if (cd "$nsync_platform_dir" && make depend nsync.a >&2 \
+            && mv "$nsync_platform_dir/nsync.a" "$nsync_platform_dir/libnsync.a"); then
                 case "$target_platform" in
                 ios)    platform_libs="$platform_libs '$nsync_platform_dir/libnsync.a'";;
                 *)      echo "$nsync_platform_dir/libnsync.a";;

--- a/tensorflow/contrib/makefile/compile_nsync.sh
+++ b/tensorflow/contrib/makefile/compile_nsync.sh
@@ -289,10 +289,10 @@ for arch in $archs; do
                 echo "$makefile" | sed $'s,^[ \t]*,,' > "$nsync_platform_dir/Makefile"
                 touch "$nsync_platform_dir/dependfile"
         fi
-        if (cd "$nsync_platform_dir" && make depend nsync.a >&2); then
+        if (cd "$nsync_platform_dir" && make depend libnsync.a >&2); then
                 case "$target_platform" in
-                ios)    platform_libs="$platform_libs '$nsync_platform_dir/nsync.a'";;
-                *)      echo "$nsync_platform_dir/nsync.a";;
+                ios)    platform_libs="$platform_libs '$nsync_platform_dir/libnsync.a'";;
+                *)      echo "$nsync_platform_dir/libnsync.a";;
                 esac
         else
                 exit 2  # The if-statement suppresses the "set -e" on the "make".
@@ -302,7 +302,7 @@ done
 case "$target_platform" in
 ios)    nsync_platform_dir="$nsync_builds_dir/lipo.$target_platform.c++11"
         mkdir "$nsync_platform_dir"
-        eval lipo $platform_libs -create -output '$nsync_platform_dir/nsync.a'
-        echo "$nsync_platform_dir/nsync.a"
+        eval lipo $platform_libs -create -output '$nsync_platform_dir/libnsync.a'
+        echo "$nsync_platform_dir/libnsync.a"
         ;;
 esac

--- a/tensorflow/contrib/makefile/compile_nsync.sh
+++ b/tensorflow/contrib/makefile/compile_nsync.sh
@@ -290,7 +290,7 @@ for arch in $archs; do
                 touch "$nsync_platform_dir/dependfile"
         fi
         if (cd "$nsync_platform_dir" && make depend nsync.a >&2 \
-            && mv "$nsync_platform_dir/nsync.a" "$nsync_platform_dir/libnsync.a"); then
+            && mv nsync.a libnsync.a); then
                 case "$target_platform" in
                 ios)    platform_libs="$platform_libs '$nsync_platform_dir/libnsync.a'";;
                 *)      echo "$nsync_platform_dir/libnsync.a";;


### PR DESCRIPTION
Now, the lib name is `nsync.a`. It will cause problem `lnsync` not found in cmake. So, change it to `libnsync.a`