### PR TITLE
make data file configurable(issue#13876)

### DIFF
--- a/tensorflow/python/keras/_impl/keras/datasets/cifar10.py
+++ b/tensorflow/python/keras/_impl/keras/datasets/cifar10.py
@@ -27,15 +27,22 @@ from tensorflow.python.keras._impl.keras.datasets.cifar import load_batch
 from tensorflow.python.keras._impl.keras.utils.data_utils import get_file
 
 
-def load_data():
+def load_data(fname=None):
   """Loads CIFAR10 dataset.
 
+  Arguments:
+    fname: Name of the file. If an absolute path /path/to/file.txt is
+        specified the file will be saved at that location.
+        
   Returns:
       Tuple of Numpy arrays: `(x_train, y_train), (x_test, y_test)`.
   """
-  dirname = 'cifar-10-batches-py'
-  origin = 'http://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz'
-  path = get_file(dirname, origin=origin, untar=True)
+  if fname is None:
+    dirname = 'cifar-10-batches-py'
+    origin = 'http://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz'
+    path = get_file(dirname, origin=origin, untar=True)
+  else:
+    path = fname
 
   num_train_samples = 50000
 


### PR DESCRIPTION
Fix [issue#13876](https://github.com/tensorflow/tensorflow/issues/13876).

- Add `fname` argument to set the data file of CIFAR10 dataset.

@drpngx Please check if it is acceptable to add the flexibility in this way. If so, I'd like to update the [cifar100.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/_impl/keras/datasets/cifar100.py), [mnist.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/_impl/keras/datasets/mnist.py)  and so on. 

@fchollet Should I make the PR in keras repo or here?

@uZeroJ Do you think whether it is necessary to add the `untar` argument?