### PR TITLE
Add links and fix typos

### DIFF
--- a/tensorflow/docs_src/community/documentation.md
+++ b/tensorflow/docs_src/community/documentation.md
@@ -1,6 +1,6 @@
 # Writing TensorFlow Documentation
 
-We welcome contributions to the Tensorflow documentation from the community.
+We welcome contributions to the TensorFlow documentation from the community.
 This document explains how you can contribute to that documentation. In
 particular, this document explains the following:
 
@@ -8,28 +8,30 @@ particular, this document explains the following:
 * How to make conformant edits.
 * How to build and test your documentation changes before you submit them.
 
-You can view Tensorflow documentation on https://www.tensorflow.org, and you
-can view and edit the raw files on Github. We're publishing our docs on Github
-so everybody can contribute. Whatever gets checked in tensorflow/docs_src will
-be published soon after on https://www.tensorflow.org. 
+You can view TensorFlow documentation on https://www.tensorflow.org, and you
+can view and edit the raw files on
+[GitHub](https://www.tensorflow.org/code/tensorflow/docs_src/). 
+We're publishing our docs on GitHub so everybody can contribute. Whatever gets
+checked in to `tensorflow/docs_src` will be published soon after on
+https://www.tensorflow.org. 
 
 Republishing TensorFlow documentation in different forms is absolutely allowed,
 but we are unlikely to accept other documentation formats (or the tooling to
 generate them) into our repository. If you do choose to republish our
 documentation in another form, please be sure to include:
 
-* The version of the API this represents (i.e. r1.0, master, etc.)
+* The version of the API this represents (for example, r1.0, master, etc.)
 * The commit or version from which the documentation was generated
 * Where to get the latest documentation (that is, https://www.tensorflow.org)
 * The Apache 2.0 license.
 
-## A Note on Versions
+## A note on versions
 
 tensorflow.org, at root, shows documentation for the latest stable binary.  This
 is the documentation you should be reading if you are using `pip` to install
 TensorFlow.
 
-However, most developers will contribute documentation into the master Github
+However, most developers will contribute documentation into the master GitHub
 branch, which is published, occasionally,
 at [tensorflow.org/versions/master](https://www.tensorflow.org/versions/master).
 
@@ -49,8 +51,9 @@ in the code:
 To modify the reference documentation, you edit the appropriate code comments.
 
 Non-reference documentation (for example, the TensorFlow installation guides) is
-authored by humans. This documentation is located in the `tensorflow/docs_src`
-directory.  Each subdirectory of `docs_src` contains a set of related Tensorflow
+authored by humans. This documentation is located in the
+[`tensorflow/docs_src`](https://www.tensorflow.org/code/tensorflow/docs_src/)
+directory.  Each subdirectory of `docs_src` contains a set of related TensorFlow
 documentation. For example, the TensorFlow installation guides are all in the
 `docs_src/install` directory.
 
@@ -183,7 +186,7 @@ documentation in the `/tmp/tfdocs` dir:
 
 Note: You must set `src_dir` and `output_dir` to absolute file paths.
 
-## Generating Python API Documentation
+## Generating Python API documentation
 
 Ops, classes, and utility functions are defined in Python modules, such as
 `image_ops.py`. Python modules contain a module docstring. For example:
@@ -216,7 +219,7 @@ the following:
 Only top level modules (currently just `tf` and `tfdbg`) need to be manually
 added to the generate script.
 
-### Sealing Modules
+### Sealing modules
 
 Because the doc generator walks all visible symbols, and descends into anything
 it finds, it will document any accidentally exposed symbols. If a module only
@@ -242,7 +245,7 @@ following options for dealing with them:
 
 We'll discuss these options in detail below.
 
-#### Private Symbols and Imports
+#### Private symbols and imports
 
 The easiest way to conform to the API sealing expectations is to make non-public
 symbols private (by prepending an underscore _). The doc generator respects
@@ -288,7 +291,7 @@ are public. All `@@`s will eventually be removed. If you see them, however,
 please do not randomly delete them as they are still in use by some of our
 systems.
 
-#### Traversal Blacklist
+#### Traversal blacklist
 
 If all else fails, you may add entries to the traversal blacklist in
 `generate_lib.py.` **Almost all entries in this list are an abuse of its
@@ -311,7 +314,7 @@ flags, ...) included for platform abstraction can be documented without
 documenting their interior. Its use beyond this purpose is a shortcut that may
 be acceptable for contrib, but not for core tensorflow.
 
-## Op Documentation Style Guide
+## Op documentation style guide
 
 Long, descriptive module-level documentation for modules should go in the API
 Guides in `docs_src/api_guides/python`.
@@ -334,7 +337,7 @@ is [here](https://daringfireball.net/projects/markdown/). You are allowed to
 use [MathJax](https://www.mathjax.org) notation for equations (see above for
 restrictions).
 
-### Writing About Code
+### Writing about code
 
 Put backticks around these things when they're used in text:
 
@@ -375,7 +378,7 @@ Two notes about backticks for code samples in Markdown:
    However, do NOT indent four spaces and use backticks simultaneously. Use one
    or the other.
 
-### Tensor Dimensions
+### Tensor dimensions
 
 When you're talking about a tensor in general, don't capitalize the word tensor.
 When you're talking about the specific object that's provided to an op as an
@@ -500,7 +503,7 @@ def foo(x, y, name="bar"):
   """
 ```
 
-## Description of the Docstring Sections
+## Description of the docstring sections
 
 This section details each of the elements in docstrings.
 


### PR DESCRIPTION
Add links to the docs in GitHub, to make it easier for contributors to find them. Also fix some typos in the names of GitHub and TensorFlow, and standardise capitalisation in headings.