### PR TITLE
Fix mnist_softmax tutorial: W should be randomly initialized, should …

### DIFF
--- a/tensorflow/examples/tutorials/mnist/mnist_softmax.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_softmax.py
@@ -38,7 +38,7 @@ def main(_):
 
   # Create the model
   x = tf.placeholder(tf.float32, [None, 784])
-  W = tf.Variable(tf.zeros([784, 10]))
+  W = tf.Variable(tf.random_normal([784, 10]))
   b = tf.Variable(tf.zeros([10]))
   y = tf.matmul(x, W) + b
 


### PR DESCRIPTION
Fix mnist_softmax tutorial: W should be randomly initialized, should not be initialized as zeros. Otherwise, you will get a symmetric NN.
```
# This is wrong and misleading. W should not initialized as zeros. 
# If you do so, you will get a symmetric network. 
W = tf.Variable(tf.zeros([784, 10]))
```
Instead, W should be randomly initialized
```
W = tf.Variable(tf.random_normal([784, 10]))
```
Actually, there is another mistake:
```
# This is not how we use mini-batch in practical environment
for _ in range(1000):
    batch_xs, batch_ys = mnist.train.next_batch(100)
    sess.run(train_step, feed_dict={x: batch_xs, y_: batch_ys})
```
Instead, mini-batch should be used as follows:
```
for _ in range(1000):
   for batch in range(550):
      batch_xs, batch_ys = mnist.train.next_batch(100)
      sess.run(train_step, feed_dict={x: batch_xs, y_: batch_ys})
```
But maybe for simplicity, we can ignore this mistake