### PR TITLE
make "smart_cond" api public and reusable

### DIFF
--- a/tensorflow/python/layers/utils.py
+++ b/tensorflow/python/layers/utils.py
@@ -195,19 +195,7 @@ def smart_cond(pred, fn1, fn2, name=None):
   Raises:
     TypeError: If `fn1` or `fn2` is not callable.
   """
-  if not callable(fn1):
-    raise TypeError('`fn1` must be callable.')
-  if not callable(fn2):
-    raise TypeError('`fn2` must be callable.')
-
-  pred_value = constant_value(pred)
-  if pred_value is not None:
-    if pred_value:
-      return fn1()
-    else:
-      return fn2()
-  else:
-    return control_flow_ops.cond(pred, fn1, fn2, name)
+  return control_flow_ops.smart_cond(pred, fn1, fn2, name)
 
 
 def constant_value(pred):
@@ -223,12 +211,4 @@ def constant_value(pred):
   Raises:
     TypeError: If `pred` is not a Variable, Tensor or bool.
   """
-  if isinstance(pred, bool):
-    pred_value = pred
-  elif isinstance(pred, variables.Variable):
-    pred_value = None
-  elif isinstance(pred, ops.Tensor):
-    pred_value = tensor_util.constant_value(pred)
-  else:
-    raise TypeError('`pred` must be a Tensor, a Variable, or a Python bool.')
-  return pred_value
+  return control_flow_ops.constant_value(pred)

--- a/tensorflow/python/layers/utils.py
+++ b/tensorflow/python/layers/utils.py
@@ -195,19 +195,7 @@ def smart_cond(pred, fn1, fn2, name=None):
   Raises:
     TypeError: If `fn1` or `fn2` is not callable.
   """
-  if not callable(fn1):
-    raise TypeError('`fn1` must be callable.')
-  if not callable(fn2):
-    raise TypeError('`fn2` must be callable.')
-
-  pred_value = constant_value(pred)
-  if pred_value is not None:
-    if pred_value:
-      return fn1()
-    else:
-      return fn2()
-  else:
-    return control_flow_ops.cond(pred, fn1, fn2, name)
+  return control_flow_ops.smart_cond(pred, fn1, fn2, name=None)
 
 
 def constant_value(pred):
@@ -223,12 +211,4 @@ def constant_value(pred):
   Raises:
     TypeError: If `pred` is not a Variable, Tensor or bool.
   """
-  if isinstance(pred, bool):
-    pred_value = pred
-  elif isinstance(pred, variables.Variable):
-    pred_value = None
-  elif isinstance(pred, ops.Tensor):
-    pred_value = tensor_util.constant_value(pred)
-  else:
-    raise TypeError('`pred` must be a Tensor, a Variable, or a Python bool.')
-  return pred_value
+  return control_flow_ops.constant_value(pred)

--- a/tensorflow/python/ops/control_flow_ops.py
+++ b/tensorflow/python/ops/control_flow_ops.py
@@ -16,7 +16,6 @@
 """Control Flow Operations.
 
 See the @{$python/control_flow_ops} guide.
-
 @@identity
 @@identity_n
 @@tuple
@@ -24,6 +23,7 @@ See the @{$python/control_flow_ops} guide.
 @@no_op
 @@count_up_to
 @@cond
+@@smart_cond
 @@case
 @@while_loop
 @@logical_and
@@ -71,6 +71,7 @@ from tensorflow.python.ops import gen_data_flow_ops
 from tensorflow.python.ops import gen_logging_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import tensor_array_ops
+from tensorflow.python.ops import variables
 # go/tf-wildcard-import
 # pylint: disable=wildcard-import,undefined-variable
 from tensorflow.python.ops.gen_control_flow_ops import *
@@ -1915,6 +1916,61 @@ def cond(pred, true_fn=None, false_fn=None, strict=False, name=None,
       merges = _UnpackIfSingleton(merges)
     return merges
 # pylint: enable=g-doc-args
+
+def smart_cond(pred, fn1=None, fn2=None, name=None):
+  """Return either `fn1()` or `fn2()` based on the boolean predicate `pred`.
+
+  If `pred` is a bool or has a constant value, we return either `fn1()`
+  or `fn2()`, otherwise we use `tf.cond` to dynamically route to both.
+
+  Arguments:
+    pred: A scalar determining whether to return the result of `fn1` or `fn2`.
+    fn1: The callable to be performed if pred is true.
+    fn2: The callable to be performed if pred is false.
+    name: Optional name prefix when using `tf.cond`.
+
+  Returns:
+    Tensors returned by the call to either `fn1` or `fn2`.
+
+  Raises:
+    TypeError: If `fn1` or `fn2` is not callable.
+  """
+  if not callable(fn1):
+    raise TypeError('`fn1` must be callable.')
+  if not callable(fn2):
+    raise TypeError('`fn2` must be callable.')
+
+  pred_value = constant_value(pred)
+  if pred_value is not None:
+    if pred_value:
+      return fn1()
+    else:
+      return fn2()
+  else:
+    return cond(pred, fn1, fn2, name)
+
+def constant_value(pred):
+  """Return the bool value for `pred`, or None if `pred` had a dynamic value.
+
+    Arguments:
+      pred: A scalar, either a Python bool or a TensorFlow boolean variable
+        or tensor.
+
+    Returns:
+      True or False if `pred` has a constant boolean value, None otherwise.
+
+    Raises:
+      TypeError: If `pred` is not a Variable, Tensor or bool.
+    """
+  if isinstance(pred, bool):
+    pred_value = pred
+  elif isinstance(pred, variables.Variable):
+    pred_value = None
+  elif isinstance(pred, ops.Tensor):
+    pred_value = tensor_util.constant_value(pred)
+  else:
+    raise TypeError('`pred` must be a Tensor, a Variable, or a Python bool.')
+  return pred_value
 
 
 def _resource_safe_shape(t):

--- a/tensorflow/python/ops/control_flow_ops_test.py
+++ b/tensorflow/python/ops/control_flow_ops_test.py
@@ -326,6 +326,44 @@ class SwitchTestCase(test_util.TensorFlowTestCase):
 
 
 @test_util.with_c_api
+class SmartCondTest(test_util.TensorFlowTestCase):
+
+  def testSmartCondTrue(self):
+    with ops.Graph().as_default():
+      with session.Session():
+        x = constant_op.constant(2)
+        y = constant_op.constant(5)
+        z = control_flow_ops.smart_cond(
+            True, lambda: math_ops.multiply(x, 16),
+            lambda: math_ops.multiply(y, 5))
+        self.assertEqual(z.eval(), 32)
+
+  def testSmartCondFalse(self):
+    with ops.Graph().as_default():
+      with session.Session():
+        x = constant_op.constant(4)
+        y = constant_op.constant(3)
+        z = control_flow_ops.smart_cond(
+            False, lambda: math_ops.multiply(x, 16),
+            lambda: math_ops.multiply(y, 3))
+        self.assertEqual(z.eval(), 9)
+
+  def testSmartCondMissingArg1(self):
+    with ops.Graph().as_default():
+      with session.Session():
+        x = constant_op.constant(1)
+        with self.assertRaises(TypeError):
+          control_flow_ops.smart_cond(True, fn2=lambda: x)
+
+  def testSmartCondMissingArg2(self):
+    with ops.Graph().as_default():
+      with session.Session():
+        x = constant_op.constant(1)
+        with self.assertRaises(TypeError):
+          control_flow_ops.smart_cond(True, lambda: x)
+
+
+@test_util.with_c_api
 class CondTest(test_util.TensorFlowTestCase):
 
   def testCondTrue(self):

--- a/tensorflow/python/ops/standard_ops.py
+++ b/tensorflow/python/ops/standard_ops.py
@@ -46,7 +46,6 @@ from tensorflow.python.ops.control_flow_ops import group
 from tensorflow.python.ops.control_flow_ops import no_op
 from tensorflow.python.ops.control_flow_ops import tuple
 from tensorflow.python.ops.control_flow_ops import cond
-from tensorflow.python.ops.control_flow_ops import smart_cond
 from tensorflow.python.ops.control_flow_ops import case
 from tensorflow.python.ops.control_flow_ops import smart_cond
 from tensorflow.python.ops.control_flow_ops import while_loop

--- a/tensorflow/python/ops/standard_ops.py
+++ b/tensorflow/python/ops/standard_ops.py
@@ -47,6 +47,7 @@ from tensorflow.python.ops.control_flow_ops import no_op
 from tensorflow.python.ops.control_flow_ops import tuple
 from tensorflow.python.ops.control_flow_ops import cond
 from tensorflow.python.ops.control_flow_ops import case
+from tensorflow.python.ops.control_flow_ops import smart_cond
 from tensorflow.python.ops.control_flow_ops import while_loop
 from tensorflow.python.ops.data_flow_ops import *
 from tensorflow.python.ops.functional_ops import *

--- a/tensorflow/python/ops/standard_ops.py
+++ b/tensorflow/python/ops/standard_ops.py
@@ -46,6 +46,7 @@ from tensorflow.python.ops.control_flow_ops import group
 from tensorflow.python.ops.control_flow_ops import no_op
 from tensorflow.python.ops.control_flow_ops import tuple
 from tensorflow.python.ops.control_flow_ops import cond
+from tensorflow.python.ops.control_flow_ops import smart_cond
 from tensorflow.python.ops.control_flow_ops import case
 from tensorflow.python.ops.control_flow_ops import while_loop
 from tensorflow.python.ops.data_flow_ops import *


### PR DESCRIPTION
Fix #13903 .

Move the implementation of "smart_cond" and "constant_value" from `tensorflow/python/layers/utils` to `tensorflow/python/ops/control_flow_ops` and add corresponding test and expose `smart_cond` to `tensorflow/python/ops/standard_ops`.

@martinwicke should I implement the API in this way or not? As I think ops should be lower level API than layers and `smart_cond` should be a kind of ops. It's my first time to contribute to TensorFlow. Please feel free to correct me if there's any problem with the design and codes.