### PR TITLE
Use 'LABEL maintainer=' in Dockerfile

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.android
+++ b/tensorflow/tools/ci_build/Dockerfile.android
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER Jan Prach <jendap@google.com>
+LABEL maintainer="Jan Prach <jendap@google.com>"
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/

--- a/tensorflow/tools/ci_build/Dockerfile.cmake
+++ b/tensorflow/tools/ci_build/Dockerfile.cmake
@@ -14,7 +14,7 @@
 # ==============================================================================
 FROM ubuntu:16.04
 
-MAINTAINER Shanqing Cai <cais@google.com>
+LABEL maintainer="Shanqing Cai <cais@google.com>"
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/

--- a/tensorflow/tools/ci_build/Dockerfile.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER Jan Prach <jendap@google.com>
+LABEL maintainer="Jan Prach <jendap@google.com>"
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/

--- a/tensorflow/tools/ci_build/Dockerfile.debian.jessie.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.debian.jessie.cpu
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-MAINTAINER Jan Prach <jendap@google.com>
+LABEL maintainer="Jan Prach <jendap@google.com>"
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/

--- a/tensorflow/tools/ci_build/Dockerfile.gpu
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu14.04
 
-MAINTAINER Jan Prach <jendap@google.com>
+LABEL maintainer="Jan Prach <jendap@google.com>"
 
 # In the Ubuntu 14.04 images, cudnn is placed in system paths. Move them to
 # /usr/local/cuda

--- a/tensorflow/tools/ci_build/Dockerfile.gpu_clang
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu_clang
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu14.04
 
-MAINTAINER Ilya Biryukov <ibiryukov@google.com>
+LABEL maintainer="Ilya Biryukov <ibiryukov@google.com>"
 
 # In the Ubuntu 14.04 images, cudnn is placed in system paths. Move them to
 # /usr/local/cuda

--- a/tensorflow/tools/ci_build/Dockerfile.hadoop
+++ b/tensorflow/tools/ci_build/Dockerfile.hadoop
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER Jonathan Hseu <jhseu@google.com>
+LABEL maintainer="Jonathan Hseu <jhseu@google.com>"
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/

--- a/tensorflow/tools/ci_build/Dockerfile.pi
+++ b/tensorflow/tools/ci_build/Dockerfile.pi
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER Jan Prach <jendap@google.com>
+LABEL maintainer="Jan Prach <jendap@google.com>"
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/

--- a/tensorflow/tools/ci_build/Dockerfile.pi-python3
+++ b/tensorflow/tools/ci_build/Dockerfile.pi-python3
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER Jan Prach <jendap@google.com>
+LABEL maintainer="Jan Prach <jendap@google.com>"
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/

--- a/tensorflow/tools/dist_test/Dockerfile
+++ b/tensorflow/tools/dist_test/Dockerfile
@@ -20,7 +20,7 @@
 
 FROM ubuntu:16.04
 
-MAINTAINER Shanqing Cai <cais@google.com>
+LABEL maintainer="Shanqing Cai <cais@google.com>"
 
 RUN apt-get update
 RUN apt-get install -y \

--- a/tensorflow/tools/dist_test/Dockerfile.local
+++ b/tensorflow/tools/dist_test/Dockerfile.local
@@ -19,7 +19,7 @@
 
 FROM ubuntu:16.04
 
-MAINTAINER Shanqing Cai <cais@google.com>
+LABEL maintainer="Shanqing Cai <cais@google.com>"
 
 # Pick up some TF dependencies.
 RUN apt-get update && apt-get install -y \

--- a/tensorflow/tools/dist_test/local/Dockerfile
+++ b/tensorflow/tools/dist_test/local/Dockerfile
@@ -1,6 +1,6 @@
 FROM jpetazzo/dind
 
-MAINTAINER Shanqing Cai <cais@google.com>
+LABEL maintainer="Shanqing Cai <cais@google.com>"
 
 RUN apt-get update
 

--- a/tensorflow/tools/dist_test/server/Dockerfile
+++ b/tensorflow/tools/dist_test/server/Dockerfile
@@ -19,7 +19,7 @@
 
 FROM ubuntu:16.04
 
-MAINTAINER Shanqing Cai <cais@google.com>
+LABEL maintainer="Shanqing Cai <cais@google.com>"
 
 # Pick up some TF dependencies
 RUN apt-get update && apt-get install -y \

--- a/tensorflow/tools/dist_test/server/Dockerfile.test
+++ b/tensorflow/tools/dist_test/server/Dockerfile.test
@@ -19,7 +19,7 @@
 
 FROM ubuntu:16.04
 
-MAINTAINER Shanqing Cai <cais@google.com>
+LABEL maintainer="Shanqing Cai <cais@google.com>"
 
 # Pick up some TF dependencies
 RUN apt-get update && apt-get install -y \

--- a/tensorflow/tools/docker/Dockerfile.devel-gpu-cuda9-cudnn7
+++ b/tensorflow/tools/docker/Dockerfile.devel-gpu-cuda9-cudnn7
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
-MAINTAINER Gunhan Gulsoy <gunan@google.com>
+LABEL maintainer="Gunhan Gulsoy <gunan@google.com>"
 
 # It is possible to override these for releases.
 ARG TF_BRANCH=master

--- a/tensorflow/tools/gcs_test/Dockerfile
+++ b/tensorflow/tools/gcs_test/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER Shanqing Cai <cais@google.com>
+LABEL maintainer="Shanqing Cai <cais@google.com>"
 
 RUN apt-get update
 RUN apt-get install -y \


### PR DESCRIPTION
This fix is a follow up of #13661 to replace `MAINTAINER` with `LABEL maintainer=` in Dockerfile.

The keyword `MAINTAINER` has long been deprecated and is replaced by `LABEL`, which is much more flexible and is easily searchable through `docker inspect`.

This fix replaces remaining `MAINTAINER` with `LABEL`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>