### PR TITLE
Update device string comments in node_def.proto

### DIFF
--- a/tensorflow/core/framework/node_def.proto
+++ b/tensorflow/core/framework/node_def.proto
@@ -35,7 +35,7 @@ message NodeDef {
   // CONSTRAINT ::= ("job:" JOB_NAME)
   //              | ("replica:" [1-9][0-9]*)
   //              | ("task:" [1-9][0-9]*)
-  //              | ("device:" ("gpu" | "cpu") ":" ([1-9][0-9]* | "*") )
+  //              | ("device:" [A-Za-z]* ":" ([1-9][0-9]* | "*") )
   //
   // Valid values for this string include:
   // * "/job:worker/replica:0/task:1/device:GPU:3"  (full specification)


### PR DESCRIPTION
Clarifying comments for valid device string in NodeDef, as discussed in PR #13874.

Notes:
1. The device string is as returned by device.py to_string() 
2. parse_from_string() in device.py seems currently allows an empty string for device_type (line 167). This commit reflects that.  Is this actually intended behavior?
3. I notice our regex convention does not use '+' (e.g. XX* instead of X+).