### PR TITLE
Update docs for `begin_params_axis`

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -1992,7 +1992,7 @@ def layer_norm(inputs,
 
   Given a tensor `inputs` of rank `R`, moments are calculated and normalization
   is performed over axes `begin_norm_axis ... R - 1`.  Scaling and centering,
-  if requested, is performed over axes `begin_shift_axis .. R - 1`.
+  if requested, is performed over axes `begin_params_axis .. R - 1`.
 
   By default, `begin_norm_axis = 1` and `begin_params_axis = -1`,
   meaning that normalization is performed over all but the first axis


### PR DESCRIPTION
This fix fixes the issue raised in #13975 where `begin_shift_axis` should actually be `begin_params_axis`.

This fix fixes #13975.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>