### PR TITLE
Fix list formatting

### DIFF
--- a/tensorflow/python/estimator/run_config.py
+++ b/tensorflow/python/estimator/run_config.py
@@ -528,6 +528,7 @@ class RunConfig(object):
     """Returns a new instance of `RunConfig` replacing specified properties.
 
     Only the properties in the following list are allowed to be replaced:
+
       - `model_dir`.
       - `tf_random_seed`,
       - `save_summary_steps`,


### PR DESCRIPTION
Markdown needs a blank line before the list to render it correctly.

https://www.tensorflow.org/api_docs/python/tf/estimator/RunConfig#replace