### PR TITLE
avoid confict when installing pip3

### DIFF
--- a/tensorflow/tools/docker/Dockerfile.devel-gpu-cuda9-cudnn7
+++ b/tensorflow/tools/docker/Dockerfile.devel-gpu-cuda9-cudnn7
@@ -18,7 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libzmq3-dev \
         pkg-config \
         python-dev \
-        python-pip \
         rsync \
         software-properties-common \
         unzip \
@@ -30,9 +29,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+    
+RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+        python get-pip.py && \
+        rm get-pip.py
 
 RUN pip --no-cache-dir install --upgrade \
-        pip setuptools
+        setuptools
 
 RUN pip --no-cache-dir install \
         ipykernel \


### PR DESCRIPTION
When using [ parameterized_docker_build.sh](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/parameterized_docker_build.sh) to build a tensorflow docker image from [nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04](https://hub.docker.com/r/nvidia/cuda/). There is [code](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/parameterized_docker_build.sh#L259) that change "pip" to "pip3" which will cause an error while installing pip3 because it change "python-pip" to "python-pip3".

error: install pip
```bash
Fetched 24.6 MB in 19s (1269 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package python-pip3
The command '/bin/sh -c apt-get update && apt-get install -y --no-install-recommends         build-essential         curl         git         golang         libcurl3-dev         libfreetype6-dev         libpng12-dev         libzmq3-dev         pkg-config         python-dev python3-dev         python-pip3       rsync         software-properties-common         unzip         zip         zlib1g-dev         openjdk-8-jdk         openjdk-8-jre-headless         wget         &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
FAIL: nvidia-docker build of boss/tensorflow:latest-devel-gpu-py3 with Dockerfile /tmp/tmp.AO2xpf3Pw2/Dockerfile failed
```

error: upgrade pip
``` bash
 ---> 2798f59d37c5
Removing intermediate container 70f5cd7aac81
Step 8/26 : RUN pip3 --no-cache-dir install --upgrade         pip3 setuptools
 ---> Running in ecd6622f86c0
Collecting pip3
  Could not find a version that satisfies the requirement pip3 (from versions: )
No matching distribution found for pip3
The command '/bin/sh -c pip3 --no-cache-dir install --upgrade         pip3 setuptools' returned a non-zero code: 1
FAIL: nvidia-docker build of boss/tensorflow:latest-devel-gpu-py3 with Dockerfile /tmp/tmp.SFqy9rSx1b/Dockerfile failed
```