### PR TITLE
Fix incorrect annotation tag in the docs of tf.Variable

### DIFF
--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -119,7 +119,7 @@ class Variable(object):
   various `Optimizer` classes use this collection as the default list of
   variables to optimize.
 
-  @compatiblity(eager)
+  @compatibility(eager)
   `tf.Variable` is not compatible with eager execution.  Use
   `tfe.Variable` instead which is compatable with both eager execution
   and graph construction.  See [the TensorFlow Eager Execution

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -125,7 +125,7 @@ class Variable(object):
   and graph construction.  See [the TensorFlow Eager Execution
   guide](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/eager/python/g3doc/guide.md#variables-and-optimizers)
   for details on how variables work in eager execution.
-  @end_compatiblity
+  @end_compatibility
   """
 
   def __init__(self,

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -118,14 +118,6 @@ class Variable(object):
   `trainable_variables()` returns the contents of this collection. The
   various `Optimizer` classes use this collection as the default list of
   variables to optimize.
-
-  @compatibility(eager)
-  `tf.Variable` is not compatible with eager execution.  Use
-  `tfe.Variable` instead which is compatable with both eager execution
-  and graph construction.  See [the TensorFlow Eager Execution
-  guide](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/eager/python/g3doc/guide.md#variables-and-optimizers)
-  for details on how variables work in eager execution.
-  @end_compatibility
   """
 
   def __init__(self,
@@ -197,6 +189,14 @@ class Variable(object):
       ValueError: If the initial value is not specified, or does not have a
         shape and `validate_shape` is `True`.
       RuntimeError: If eager execution is enabled.
+
+    @compatibility(eager)
+    `tf.Variable` is not compatible with eager execution.  Use
+    `tfe.Variable` instead which is compatable with both eager execution
+    and graph construction.  See [the TensorFlow Eager Execution
+    guide](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/eager/python/g3doc/guide.md#variables-and-optimizers)
+    for details on how variables work in eager execution.
+    @end_compatibility
     """
     if not context.in_graph_mode():
       raise RuntimeError("tf.Variable not supported in Eager mode. "


### PR DESCRIPTION
In tf.Variable the annotation tag of `@compatiblity` (missing `i`) should be `@compatibility` , without the fix the rendering of docs may be incorrect. 

See `add_check_numerics_ops()` for an example of `@compatibility`:
https://github.com/tensorflow/tensorflow/blob/e43e514b7418756a828c6a0f60e43aa6a638e961/tensorflow/python/ops/numerics.py#L68-L72


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>