### PR TITLE
Add go format check as part of the sanity check

### DIFF
--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -101,7 +101,7 @@ func NewTensor(value interface{}) (*Tensor, error) {
 			return nil, bug("NewTensor incorrectly calculated the size of a tensor with type %v and shape %v as %v bytes instead of %v", dataType, shape, nbytes, buf.Len())
 		}
 	} else {
-		e := stringEncoder{offsets: buf, data: raw[nflattened*8 : len(raw)], status: newStatus()}
+		e := stringEncoder{offsets: buf, data: raw[nflattened*8:], status: newStatus()}
 		if err := e.encode(reflect.ValueOf(value), shape); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In go, it is very common to format the code with `gofmt -s -w file.go`. This fix adds the gofmt check as part of the sanity check.

There was only one file `tensorflow/go/tensor.go` in the whole `tensorflow/go` directory that is not properly formatted.

This fix formatted `tensorflow/go/tensor.go` with `gofmt -s -w` as well.

It is also possible to check the format status in:
https://goreportcard.com/report/github.com/tensorflow/tensorflow

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>