### PR TITLE
Fix failing build on Fedora 26 (stropts.h)

### DIFF
--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -477,7 +477,6 @@ genrule(
         "#  define HAVE_RAND_EGD 1",
         "#  define HAVE_RAND_STATUS 1",
         "#  define HAVE_SSL_GET_SHUTDOWN 1",
-        "#  define HAVE_STROPTS_H 1",
         "#  define HAVE_TERMIOS_H 1",
         "#  define OS \"x86_64-pc-linux-gnu\"",
         "#  define RANDOM_FILE \"/dev/urandom\"",


### PR DESCRIPTION
Tensorflow branches 1.4 and master do not build on Fedora 26. When bazel builds curl as a third-party package, the file `stropts.h` is always included, while it is no longer present on many Linux distributions (including Fedora). Curl can be easily built without it by removing the `HAVE_STROPTS` flag.

This problem was already mentioned (tensorflow/serving#320). The solution proposed there is to create an empty `/usr/include/stropts.h` as root. Because that is not always possible, just removing the HAVE_STROPTS flag seems to be a better solution.