### PR TITLE
Fix position of arguments of nce_loss calculation on tensorflow_basic tutorial

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -158,8 +158,12 @@ with graph.as_default():
   # tf.nce_loss automatically draws a new sample of the negative labels each
   # time we evaluate the loss.
   loss = tf.reduce_mean(
-      tf.nn.nce_loss(nce_weights, nce_biases, embed, train_labels,
-                     num_sampled, vocabulary_size))
+      tf.nn.nce_loss(weights=nce_weights,
+                     biases=nce_biases,
+                     labels=train_labels,
+                     inputs=embed,
+                     num_sampled=num_sampled,
+                     num_classes=vocabulary_size))
 
   # Construct the SGD optimizer using a learning rate of 1.0.
   optimizer = tf.train.GradientDescentOptimizer(1.0).minimize(loss)


### PR DESCRIPTION
The nce_loss positional arguments in word2vec_simple.py are incorrect, leading to the following traceback:

Traceback (most recent call last):
  File "word2vec_simple.py", line 168, in <module>
    num_sampled, vocabulary_size))
  File "/anaconda2/envs/tensorflow/lib/python2.7/site-packages/tensorflow/python/ops/nn_impl.py", line 1151, in nce_loss
    name=name)
  File "/anaconda2/envs/tensorflow/lib/python2.7/site-packages/tensorflow/python/ops/nn_impl.py",line 981, in _compute_sampled_logits
    sampled_logits = math_ops.matmul(inputs, sampled_w, transpose_b=True)
  File "/anaconda2/envs/tensorflow/lib/python2.7/site-packages/tensorflow/python/ops/math_ops.py", line 1844, in matmul
    a, b, transpose_a=transpose_a, transpose_b=transpose_b, name=name)
  File "/anaconda2/envs/tensorflow/lib/python2.7/site-packages/tensorflow/python/ops/gen_math_ops.py", line 1289, in _mat_mul
    transpose_b=transpose_b, name=name)
  File "/anaconda2/envs/tensorflow/lib/python2.7/site-packages/tensorflow/python/framework/op_def_library.py", line 526, in apply_op
    inferred_from[input_arg.type_attr]))
TypeError: Input 'b' of 'MatMul' Op has type float32 that does not match type int32 of argument 'a'.

This patch fixes the positional arguments of nce_loss, and adds keyword arguments to make it more explicit.