### PR TITLE
Handle nil return from TF_TensorData

### DIFF
--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -207,6 +207,9 @@ func (t *Tensor) WriteContentsTo(w io.Writer) (int64, error) {
 func tensorData(c *C.TF_Tensor) []byte {
 	// See: https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
 	cbytes := C.TF_TensorData(c)
+	if cbytes == nil {
+		return nil
+	}
 	length := int(C.TF_TensorByteSize(c))
 	slice := (*[1 << 30]byte)(unsafe.Pointer(cbytes))[:length:length]
 	return slice


### PR DESCRIPTION
With some memory allocators, attempting to allocate 0 bytes will return
a null pointer. This specifically happens when building tensorflow with
mkl support. If TF_TensorData returns null, the go code to create a
slice from the data leads to a null pointer exception. This fixes the
issue by checking for the nil return and returning a slice zero value to
(nil) to the caller. Fixes #13764.