### PR TITLE
Update golang to 1.9.2 in `install_golang.sh`

### DIFF
--- a/tensorflow/tools/ci_build/install/install_golang.sh
+++ b/tensorflow/tools/ci_build/install/install_golang.sh
@@ -16,7 +16,7 @@
 
 set -ex
 
-GOLANG_URL="https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz"
+GOLANG_URL="https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz"
 
 sudo mkdir -p /usr/local
 wget -q -O - "${GOLANG_URL}" | sudo tar -C /usr/local -xz


### PR DESCRIPTION
This fix updates install_golang.sh to `1.9.2`, see release:
https://golang.org/doc/devel/release.html#go1.9.minor

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>