### PR TITLE
[XLA] Rename symbols for OS/X only - it doesn't have sincos

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
+++ b/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
@@ -41,8 +41,8 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 
 #if defined(__APPLE__)
-static void sincos()  __attribute__((weakref ("__sincos")));
-static void sincosf() __attribute__((weakref ("__sincosf")));
+static void sincos(double, double*, double*)  __attribute__((weakref ("__sincos")));
+static void sincosf(float, float*, float*) __attribute__((weakref ("__sincosf")));
 #endif
 
 namespace xla {

--- a/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
+++ b/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
@@ -40,6 +40,11 @@ limitations under the License.
 #include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/core/platform/logging.h"
 
+#if defined(__APPLE__)
+static void sincos()  __attribute__((weakref ("__sincos")));
+static void sincosf() __attribute__((weakref ("__sincosf")));
+#endif
+
 namespace xla {
 namespace cpu {
 namespace {


### PR DESCRIPTION
On OS/X the sincos and sincosf are apparently not present.  There is a __sincos and __sincosf.  This change creates an alias for them on OS/X.

