### PR TITLE
Use 'LABEL maintainer=' in Dockerfile

### DIFF
--- a/tensorflow/contrib/makefile/Dockerfile
+++ b/tensorflow/contrib/makefile/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER Gunhan Gulsoy <gunan@google.com>
+LABEL maintainer="Gunhan Gulsoy <gunan@google.com>"
 
 # Install make build dependencies for TensorFlow.
 RUN apt-get update

--- a/tensorflow/examples/udacity/Dockerfile
+++ b/tensorflow/examples/udacity/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/tensorflow/tensorflow:latest
-MAINTAINER Vincent Vanhoucke <vanhoucke@google.com>
+LABEL maintainer="Vincent Vanhoucke <vanhoucke@google.com>"
 
 # Pillow needs libjpeg by default as of 3.0.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tensorflow/tools/ci_build/Dockerfile.pi-python3
+++ b/tensorflow/tools/ci_build/Dockerfile.pi-python3
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER Jan Prach <jendap@google.com>
+LABEL maintainer="Jan Prach <jendap@google.com>"
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/


### PR DESCRIPTION
* Use 'LABEL maintainer=' in Dockerfile

This fix is a follow up of 13961 to replace `MAINTAINER`
with `LABEL maintainer=` in Dockerfile. The keyword
`MAINTAINER` has long been deprecated and is replaced by `LABEL`,
which is much more flexible and is easily searchable through `docker
inspect`.

This fix replaces remaining `MAINTAINER` with `LABEL`.

Signed-off-by: Charlie Lewis <clewis@iqt.org>

* Additional `MAITAINER` -> `LABEL`

Signed-off-by: Charlie Lewis <clewis@iqt.org>