### PR TITLE
Make sure to set _GLIBCXX_USE_CXX11_ABI=0 if it's not defined

### DIFF
--- a/tensorflow/core/public/version.h
+++ b/tensorflow/core/public/version.h
@@ -116,7 +116,7 @@ extern const char* tf_compiler_version();
 // The git commit designator when tensorflow was built
 // If no git repository, this will be "internal".
 extern const char* tf_git_version();
-// Value of the _GLIBCXX_USE_CXX11_ABI flag, or -1 if it's not set.
+// Value of the _GLIBCXX_USE_CXX11_ABI flag, or 0 if it's not set.
 extern const int tf_cxx11_abi_flag();
 
 #endif  // TENSORFLOW_CORE_PUBLIC_VERSION_H_

--- a/tensorflow/python/platform/sysconfig.py
+++ b/tensorflow/python/platform/sysconfig.py
@@ -64,8 +64,7 @@ def get_compile_flags():
   flags = []
   flags.append('-I%s' % get_include())
   flags.append('-I%s/external/nsync/public' % get_include())
-  if _CXX11_ABI_FLAG != -1:
-    flags.append('-D_GLIBCXX_USE_CXX11_ABI=%d' % _CXX11_ABI_FLAG)
+  flags.append('-D_GLIBCXX_USE_CXX11_ABI=%d' % _CXX11_ABI_FLAG)
   return flags
 
 

--- a/tensorflow/tools/git/gen_git_source.py
+++ b/tensorflow/tools/git/gen_git_source.py
@@ -177,7 +177,7 @@ const int tf_cxx11_abi_flag() {
 #ifdef _GLIBCXX_USE_CXX11_ABI
   return _GLIBCXX_USE_CXX11_ABI;
 #else
-  return -1;
+  return 0;
 #endif
 }
 """ % git_version

--- a/tensorflow/tools/git/gen_git_source.sh
+++ b/tensorflow/tools/git/gen_git_source.sh
@@ -33,7 +33,7 @@ const int tf_cxx11_abi_flag() {
 #ifdef _GLIBCXX_USE_CXX11_ABI
   return _GLIBCXX_USE_CXX11_ABI;
 #else
-  return -1;
+  return 0;
 #endif
 }
 EOF


### PR DESCRIPTION
This is necessary to make sure we can compile TensorFlow with gcc4 and compile custom operator with gcc5.