### PR TITLE
Documentation fix - clarifying sum in softmax function.

### DIFF
--- a/tensorflow/docs_src/get_started/mnist/beginners.md
+++ b/tensorflow/docs_src/get_started/mnist/beginners.md
@@ -184,7 +184,7 @@ $$\text{softmax}(evidence) = \text{normalize}(\exp(evidence))$$
 
 If you expand that equation out, you get:
 
-$$\text{softmax}(evidence)_i = \frac{\exp(evidence_i)}{\sum_j \exp(evidence_j)}$$
+$$\text{softmax}(evidence)_i = \frac{\exp(evidence_i)}{\sum_{j=1}^{10} \exp(evidence_j)}$$
 
 But it's often more helpful to think of softmax the first way: exponentiating
 its inputs and then normalizing them.  The exponentiation means that one more


### PR DESCRIPTION
This notational fix makes it more clear that you're summing over the classes in the denominator of the softmax function.