### PR TITLE
improve production condition of debug log with VLOG

### DIFF
--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -29,8 +29,8 @@ limitations under the License.
 namespace tensorflow {
 namespace internal {
 
-LogMessage::LogMessage(const char* fname, int line, int severity)
-    : fname_(fname), line_(line), severity_(severity) {}
+LogMessage::LogMessage(const char* fname, int line, int severity, int64 vlog_lvl)
+    : fname_(fname), line_(line), severity_(severity), vlog_lvl_(vlog_lvl) {}
 
 #if defined(PLATFORM_POSIX_ANDROID)
 void LogMessage::GenerateLogMessage() {
@@ -86,8 +86,16 @@ void LogMessage::GenerateLogMessage() {
 	   localtime(&now_seconds));
 
   // TODO(jeff,sanjay): Replace this with something that logs through the env.
-  fprintf(stderr, "%s.%06d: %c %s:%d] %s\n", time_buffer, micros_remainder,
-	  "IWEF"[severity_], fname_, line_, str().c_str());
+  if (vlog_lvl_ != 0) {
+    // output VLOG
+    fprintf(stderr, "%s.%06d: %c V%lld %s:%d] %s\n", time_buffer,
+            micros_remainder, "IWEF"[severity_], vlog_lvl_, fname_, line_,
+            str().c_str());
+  } else {
+    // output LOG
+    fprintf(stderr, "%s.%06d: %c %s:%d] %s\n", time_buffer, micros_remainder,
+	    "IWEF"[severity_], fname_, line_, str().c_str());
+  }
 }
 #endif
 

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -38,7 +38,7 @@ namespace internal {
 
 class LogMessage : public std::basic_ostringstream<char> {
  public:
-  LogMessage(const char* fname, int line, int severity);
+  LogMessage(const char* fname, int line, int severity, int64 vlog_lvl=0);
   ~LogMessage();
 
   // Returns the minimum log level for VLOG statements.
@@ -53,6 +53,7 @@ class LogMessage : public std::basic_ostringstream<char> {
   const char* fname_;
   int line_;
   int severity_;
+  int64 vlog_lvl_;
 };
 
 // LogMessageFatal ensures the process will exit in failure after
@@ -88,7 +89,7 @@ class LogMessageFatal : public LogMessage {
 
 #define VLOG(lvl)                        \
   if (TF_PREDICT_FALSE(VLOG_IS_ON(lvl))) \
-  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, tensorflow::INFO)
+  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, tensorflow::INFO, lvl)
 
 // CHECK dies with a fatal error if condition is not true.  It is *not*
 // controlled by NDEBUG, so the check will be executed regardless of


### PR DESCRIPTION
This patch improve a debug logging **VLOG** .

New environment variable ```TF_CPP_MAX_VLOG_LEVEL``` is added to suppress log production with VLOG.
if ```TF_CPP_MAX_VLOG_LEVEL``` is set, VLOG only outputs log lower level than it.

For example, if an user sets environment variable ```TF_CPP_MAX_VLOG_LEVEL=2```, you can see the log only lower level than 2. And you can't see the log with level 1.

### Use case:

1. ```TF_CPP_MAX_VLOG_LEVEL=2``` and ```TF_CPP_MIN_VLOG_LEVEL=1```
   * ```VLOG(1)``` and ```VLOG(2)``` will output log
2. ```TF_CPP_MIN_VLOG_LEVEL=1```
   * Only ```VLOG(1)``` will output
3. ```TF_CPP_MAX_VLOG_LEVEL=3```
   * ```VLOG(3)``` , ```VLOG(4)``` ...  will output log