### PR TITLE
Remove `non-fused` version of `adjust_hue` as GPU kernel is already in place

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1212,26 +1212,7 @@ def adjust_hue(image, delta, name=None):
     orig_dtype = image.dtype
     flt_image = convert_image_dtype(image, dtypes.float32)
 
-    # TODO(zhengxq): we will switch to the fused version after we add a GPU
-    # kernel for that.
-    fused = os.environ.get('TF_ADJUST_HUE_FUSED', '')
-    fused = fused.lower() in ('true', 't', '1')
-
-    if not fused:
-      hsv = gen_image_ops.rgb_to_hsv(flt_image)
-
-      hue = array_ops.slice(hsv, [0, 0, 0], [-1, -1, 1])
-      saturation = array_ops.slice(hsv, [0, 0, 1], [-1, -1, 1])
-      value = array_ops.slice(hsv, [0, 0, 2], [-1, -1, 1])
-
-      # Note that we add 2*pi to guarantee that the resulting hue is a positive
-      # floating point number since delta is [-0.5, 0.5].
-      hue = math_ops.mod(hue + (delta + 1.), 1.)
-
-      hsv_altered = array_ops.concat([hue, saturation, value], 2)
-      rgb_altered = gen_image_ops.hsv_to_rgb(hsv_altered)
-    else:
-      rgb_altered = gen_image_ops.adjust_hue(flt_image, delta)
+    rgb_altered = gen_image_ops.adjust_hue(flt_image, delta)
 
     return convert_image_dtype(rgb_altered, orig_dtype)
 


### PR DESCRIPTION
Was looking into adding batch support for `tf.image.random_hue` (#8926) and noticed that the `non-fused` version of `adjust_hue` was still in place. The `non-fused` is for non-GPU support of `adjust_hue`.

As GPU kernel for `AdjustHue` has already been added in PR #6818, I think it makes sense to remove the non-fused version. Besides, the env `TF_ADJUST_HUE_FUSED` seems not in use anyway.

This fix removed `non-fused` version of `adjust_hue` as GPU kernel is already in place.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>