### PR TITLE
Dockerfile.gpu: use the runtime cuDNN v6 image

### DIFF
--- a/tensorflow/tools/docker/Dockerfile.gpu
+++ b/tensorflow/tools/docker/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04
+FROM nvidia/cuda:8.0-cudnn6-runtime-ubuntu16.04
 
 LABEL maintainer="Craig Citro <craigcitro@google.com>"
 


### PR DESCRIPTION
The generated Docker image will be approximately 900 MB smaller.

The Dockerfile switched to the devel image a long time ago to
workaround a bug when looking up CUDA libraries. This problem has been
fixed in the meantime.


@gunan let me know if I'm missing something and there is a good reason to keep the devel image as a base.