### PR TITLE
Update word2vec_basic.py in generate_batch

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -114,7 +114,7 @@ def generate_batch(batch_size, num_skips, skip_window):
       batch[i * num_skips + j] = buffer[skip_window]
       labels[i * num_skips + j, 0] = buffer[target]
     if data_index == len(data):
-      buffer[:] = data[:span]
+      buffer.extend(data[0:span])
       data_index = span
     else:
       buffer.append(data[data_index])


### PR DESCRIPTION
File "/word2vec_***_basic.py", line 139, in generate_batch
    buffer[:] = data[:span]
TypeError: sequence index must be integer, not 'slice'

got above messages running in python 2.7

updating line 139 from "buffer[:] = data[:span]" to :
       buffer.extend(data[0:span])
The updating has passed my own test and can works.

thanks.