### PR TITLE
fix InvalidArgumentError when using cv2 with tf.py_func()

### DIFF
--- a/tensorflow/docs_src/programmers_guide/datasets.md
+++ b/tensorflow/docs_src/programmers_guide/datasets.md
@@ -540,7 +540,7 @@ import cv2
 # Use a custom OpenCV function to read the image, instead of the standard
 # TensorFlow `tf.read_file()` operation.
 def _read_py_function(filename, label):
-  image_decoded = cv2.imread(image_string, cv2.IMREAD_GRAYSCALE)
+  image_decoded = cv2.imread(filename.decode(), cv2.IMREAD_GRAYSCALE)
   return image_decoded, label
 
 # Use standard TensorFlow operations to resize the image to a fixed shape.


### PR DESCRIPTION
If we use `cv2.imread(filename, cv2.IMREAD_GRAYSCALE)` here, we'll get an `InvalidArgumentError: TypeError: bad argument type for built-in operation`, using `cv2.imread(filename.decode(), cv2.IMREAD_GRAYSCALE)` instead solves this issue.