### PR TITLE
added reuse in kwargs checking for reusing shared variable

### DIFF
--- a/tensorflow/python/keras/_impl/keras/engine/topology.py
+++ b/tensorflow/python/keras/_impl/keras/engine/topology.py
@@ -134,6 +134,7 @@ class Layer(tf_base_layers.Layer):
         'name',
         'trainable',
         'weights',
+        'reuse'
     }
     # Validate optional keyword arguments.
     for kwarg in kwargs:
@@ -155,7 +156,7 @@ class Layer(tf_base_layers.Layer):
     # and core TF layers.
     super(Layer, self).__init__(
         name=name, dtype=dtype, trainable=trainable,
-        activity_regularizer=kwargs.get('activity_regularizer'))
+        activity_regularizer=kwargs.get('activity_regularizer'), _reuse=kwargs.get('reuse'))
 
     # Add properties that are Keras-only for now.
     self.supports_masking = False


### PR DESCRIPTION
When I am implementing DeepID2 from "Deep Learning Face Representation by Joint
Identification-Verification by Yi Sun, Xiaogang Wang and Xiaoou Tang", I realise that using same architecture for two inputs (two face image) and sharing weight (if I didn't misunderstand) when feedforward, there is a layer called locally connected convolution, and only keras implemented LocallyConnected2D, when I trying to reuse weight, but failed because the layer didn't allow "reuse" as a kwargs, so when I added it, it seems working (I am not expert in deep learning, so I am not sure if I am doing it correct, so I'm always trying any way)