### PR TITLE
Fix issue in the `Defun` docs

### DIFF
--- a/tensorflow/python/framework/function.py
+++ b/tensorflow/python/framework/function.py
@@ -82,8 +82,8 @@ class Defun(object):
     return x + y, x - y
 
   # Building the graph.
-  a = tf.Constant([1.0])
-  b = tf.Constant([2.0])
+  a = tf.constant([1.0])
+  b = tf.constant([2.0])
   c, d = MyFunc(a, b, name='mycall')
   ```
   """


### PR DESCRIPTION
This fix fixes a couple of typos in the `Defun` docs:
`tf.Constant` -> `tf.constant`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>