### PR TITLE
Add `decode_libsvm` for libsvm format support

### DIFF
--- a/tensorflow/contrib/BUILD
+++ b/tensorflow/contrib/BUILD
@@ -53,6 +53,7 @@ py_library(
         "//tensorflow/contrib/layers:layers_py",
         "//tensorflow/contrib/learn",
         "//tensorflow/contrib/legacy_seq2seq:seq2seq_py",
+        "//tensorflow/contrib/libsvm",
         "//tensorflow/contrib/linalg:linalg_py",
         "//tensorflow/contrib/linear_optimizer:sdca_estimator_py",
         "//tensorflow/contrib/linear_optimizer:sdca_ops_py",

--- a/tensorflow/contrib/cmake/python_modules.txt
+++ b/tensorflow/contrib/cmake/python_modules.txt
@@ -289,6 +289,10 @@ tensorflow/contrib/learn/python/learn/utils
 tensorflow/contrib/legacy_seq2seq
 tensorflow/contrib/legacy_seq2seq/python
 tensorflow/contrib/legacy_seq2seq/python/ops
+tensorflow/contrib/libsvm
+tensorflow/contrib/libsvm/python
+tensorflow/contrib/libsvm/python/kernel_tests
+tensorflow/contrib/libsvm/python/ops
 tensorflow/contrib/linalg
 tensorflow/contrib/linalg/python
 tensorflow/contrib/linalg/python/ops

--- a/tensorflow/contrib/cmake/tf_core_kernels.cmake
+++ b/tensorflow/contrib/cmake/tf_core_kernels.cmake
@@ -85,6 +85,8 @@ if(tensorflow_BUILD_CONTRIB_KERNELS)
       "${tensorflow_source_dir}/tensorflow/contrib/image/ops/single_image_random_dot_stereograms_ops.cc"
       "${tensorflow_source_dir}/tensorflow/contrib/layers/kernels/sparse_feature_cross_kernel.cc"
       "${tensorflow_source_dir}/tensorflow/contrib/layers/ops/sparse_feature_cross_op.cc"
+      "${tensorflow_source_dir}/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc"
+      "${tensorflow_source_dir}/tensorflow/contrib/libsvm/ops/libsvm_ops.cc"
       "${tensorflow_source_dir}/tensorflow/contrib/nccl/kernels/nccl_manager.cc"
       "${tensorflow_source_dir}/tensorflow/contrib/nccl/kernels/nccl_ops.cc"
       "${tensorflow_source_dir}/tensorflow/contrib/nccl/ops/nccl_ops.cc"

--- a/tensorflow/contrib/libsvm/BUILD
+++ b/tensorflow/contrib/libsvm/BUILD
@@ -1,0 +1,102 @@
+package(
+    default_visibility = ["//visibility:private"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
+load("//tensorflow:tensorflow.bzl", "tf_gen_op_libs")
+load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
+load("//tensorflow:tensorflow.bzl", "tf_kernel_library")
+load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
+load("//tensorflow:tensorflow.bzl", "tf_py_test")
+
+tf_custom_op_library(
+    name = "python/ops/_libsvm_ops.so",
+    srcs = [
+        "kernels/decode_libsvm_op.cc",
+        "ops/libsvm_ops.cc",
+    ],
+    deps = [
+        "//tensorflow/core/kernels:bounds_check_lib",
+    ],
+)
+
+tf_kernel_library(
+    name = "libsvm_kernels",
+    srcs = ["kernels/decode_libsvm_ops.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core/kernels:bounds_check_lib",
+    ],
+)
+
+tf_gen_op_libs(
+    op_lib_names = ["libsvm_ops"],
+    deps = [
+        "//tensorflow/core:lib",
+    ],
+)
+
+tf_gen_op_wrapper_py(
+    name = "libsvm_ops",
+    deps = [":libsvm_ops_op_lib"],
+)
+
+tf_custom_op_py_library(
+    name = "libsvm",
+    srcs = [
+        "__init__.py",
+        "python/ops/libsvm_ops.py",
+    ],
+    dso = [
+        ":python/ops/_libsvm_ops.so",
+    ],
+    kernels = [
+        ":libsvm_kernels",
+        ":libsvm_ops_op_lib",
+    ],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":libsvm_ops",
+        "//tensorflow/contrib/util:util_py",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:control_flow_ops",
+        "//tensorflow/python:framework",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:platform",
+        "//tensorflow/python:state_ops",
+        "//tensorflow/python:training",
+    ],
+)
+
+tf_py_test(
+    name = "decode_libsvm_op_test",
+    srcs = ["python/kernel_tests/decode_libsvm_op_test.py"],
+    additional_deps = [
+        ":libsvm",
+        "//third_party/py/numpy",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:framework",
+        "//tensorflow/python:framework_test_lib",
+        "//tensorflow/python:platform_test",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "**/METADATA",
+            "**/OWNERS",
+        ],
+    ),
+    visibility = ["//tensorflow:__subpackages__"],
+)

--- a/tensorflow/contrib/libsvm/BUILD
+++ b/tensorflow/contrib/libsvm/BUILD
@@ -26,7 +26,7 @@ tf_custom_op_library(
 
 tf_kernel_library(
     name = "libsvm_kernels",
-    srcs = ["kernels/decode_libsvm_ops.cc"],
+    srcs = ["kernels/decode_libsvm_op.cc"],
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/libsvm/__init__.py
+++ b/tensorflow/contrib/libsvm/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Libsvm decoder.
+
+@@decode_libsvm
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib.libsvm.python.ops.libsvm_ops import decode_libsvm
+
+from tensorflow.python.util.all_util import remove_undocumented
+
+_allowed_symbols = [
+    "decode_libsvm",
+]
+
+remove_undocumented(__name__)

--- a/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
+++ b/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
@@ -28,6 +28,9 @@ class DecodeLibsvmOp : public OpKernel {
  public:
   explicit DecodeLibsvmOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("num_features", &num_features_));
+    OP_REQUIRES(ctx, (num_features_ >= 1),
+                errors::InvalidArgument("Invalid number of features \"",
+                                        num_features_, "\""));
   }
 
   void Compute(OpKernelContext* ctx) override {

--- a/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
+++ b/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
@@ -1,0 +1,112 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/strings/numbers.h"
+#include "tensorflow/core/lib/strings/str_util.h"
+
+namespace tensorflow {
+
+template <typename T>
+class DecodeLibsvmOp : public OpKernel {
+ public:
+  explicit DecodeLibsvmOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("num_features", &num_features_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(ctx, ctx->input("input", &input_tensor));
+    const auto& input_flat = input_tensor->flat<string>();
+
+    Tensor* label_tensor;
+    Tensor* feature_tensor;
+    OP_REQUIRES_OK(ctx,
+                   ctx->allocate_output(0, TensorShape({input_flat.size()}),
+                                        &label_tensor));
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(
+                            1, TensorShape({input_flat.size(), num_features_}),
+                            &feature_tensor));
+
+    auto label = label_tensor->flat<int64>();
+    auto feature = feature_tensor->matrix<T>();
+    for (int i = 0; i < input_flat.size(); ++i) {
+      std::vector<string> entries =
+          str_util::Split(input_flat(i), " ", str_util::SkipEmpty());
+      OP_REQUIRES(ctx, (entries.size() > 0),
+                  errors::InvalidArgument("No entries found for input[", i,
+                                          "]: \"", input_flat(i), "\""));
+      int64 label_value;
+      OP_REQUIRES(
+          ctx, strings::safe_strto64(entries[0].c_str(), &label_value),
+          errors::InvalidArgument("Label format incorrect: ", entries[0]));
+      label(i) = label_value;
+      for (int j = 1; j < entries.size(); j++) {
+        std::vector<string> pair = str_util::Split(entries[j], ":");
+        OP_REQUIRES(
+            ctx, (pair.size() == 2),
+            errors::InvalidArgument("Invalid feature \"", entries[j], "\""));
+        int64 feature_index;
+        OP_REQUIRES(
+            ctx, strings::safe_strto64(pair[0].c_str(), &feature_index),
+            errors::InvalidArgument("Feature format incorrect: ", entries[j]));
+        T feature_value;
+        OP_REQUIRES(
+            ctx, Convert(pair[1], &feature_value),
+            errors::InvalidArgument("Feature format incorrect: ", entries[j]));
+        feature(i, feature_index) = feature_value;
+      }
+    }
+  }
+
+ private:
+  int64 num_features_;
+
+  bool Convert(const string& s, T* value);
+};
+
+template <>
+bool DecodeLibsvmOp<float>::Convert(const string& s, float* value) {
+  return strings::safe_strtof(s.c_str(), value);
+}
+template <>
+bool DecodeLibsvmOp<double>::Convert(const string& s, double* value) {
+  return strings::safe_strtod(s.c_str(), value);
+}
+template <>
+bool DecodeLibsvmOp<int32>::Convert(const string& s, int32* value) {
+  return strings::safe_strto32(s.c_str(), value);
+}
+template <>
+bool DecodeLibsvmOp<int64>::Convert(const string& s, int64* value) {
+  return strings::safe_strto64(s.c_str(), value);
+}
+
+#define REGISTER_KERNEL(type)                                                \
+  REGISTER_KERNEL_BUILDER(                                                   \
+      Name("DecodeLibsvm").Device(DEVICE_CPU).TypeConstraint<type>("dtype"), \
+      DecodeLibsvmOp<type>);
+
+REGISTER_KERNEL(float);
+REGISTER_KERNEL(double);
+REGISTER_KERNEL(int32);
+REGISTER_KERNEL(int64);
+#undef REGISTER_KERNEL
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/libsvm/ops/libsvm_ops.cc
+++ b/tensorflow/contrib/libsvm/ops/libsvm_ops.cc
@@ -1,0 +1,43 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+
+using shape_inference::InferenceContext;
+
+REGISTER_OP("DecodeLibsvm")
+    .Input("input: string")
+    .Output("label: int64")
+    .Output("feature: dtype")
+    .Attr("dtype: {float, double, int32, int64} = DT_FLOAT")
+    .Attr("num_features: int >= 1")
+    .SetShapeFn(shape_inference::UnknownShape)
+    .Doc(R"doc(
+Convert LibSVM input to tensors. The output consists of
+a label and a feature tensor. The shape of the label tensor
+is the same as input and the shape of the feature tensor is
+`[input_shape, num_features]`.
+
+input: Each string is a record/row in the LibSVM.
+label: A tensor of the same shape as input.
+feature: A tensor of the shape `[input_shape, num_features]`.
+num_features: The number of features.
+)doc");
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/libsvm/ops/libsvm_ops.cc
+++ b/tensorflow/contrib/libsvm/ops/libsvm_ops.cc
@@ -47,7 +47,7 @@ a label and a feature tensor. The shape of the label tensor
 is the same as input and the shape of the feature tensor is
 `[input_shape, num_features]`.
 
-input: Each string is a record/row in the LibSVM.
+input: Each string is a record in the LibSVM.
 label: A tensor of the same shape as input.
 feature_indices: A 2-D int64 tensor of dense_shape [N, ndims].
 feature_values: A 1-D tensor of any type and dense_shape [N].

--- a/tensorflow/contrib/libsvm/ops/libsvm_ops.cc
+++ b/tensorflow/contrib/libsvm/ops/libsvm_ops.cc
@@ -24,11 +24,12 @@ using shape_inference::ShapeHandle;
 
 REGISTER_OP("DecodeLibsvm")
     .Input("input: string")
-    .Output("label: int64")
+    .Output("label: label_dtype")
     .Output("feature_indices: int64")
     .Output("feature_values: dtype")
     .Output("feature_shape: int64")
     .Attr("dtype: {float, double, int32, int64} = DT_FLOAT")
+    .Attr("label_dtype: {float, double, int32, int64} = DT_INT64")
     .Attr("num_features: int >= 1")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->input(0));

--- a/tensorflow/contrib/libsvm/ops/libsvm_ops.cc
+++ b/tensorflow/contrib/libsvm/ops/libsvm_ops.cc
@@ -25,18 +25,18 @@ using shape_inference::ShapeHandle;
 REGISTER_OP("DecodeLibsvm")
     .Input("input: string")
     .Output("label: int64")
-    .Output("feature: dtype")
+    .Output("feature_indices: int64")
+    .Output("feature_values: dtype")
+    .Output("feature_shape: int64")
     .Attr("dtype: {float, double, int32, int64} = DT_FLOAT")
     .Attr("num_features: int >= 1")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->input(0));
 
-      int32 num_features;
-      TF_RETURN_IF_ERROR(c->GetAttr("num_features", &num_features));
-      ShapeHandle out;
-      TF_RETURN_IF_ERROR(
-          c->Concatenate(c->input(0), c->Vector(num_features), &out));
-      c->set_output(1, out);
+      c->set_output(1, c->Matrix(InferenceContext::kUnknownDim,
+                                 InferenceContext::kUnknownDim));
+      c->set_output(2, c->Vector(InferenceContext::kUnknownDim));
+      c->set_output(3, c->Vector(InferenceContext::kUnknownDim));
 
       return Status::OK();
     })
@@ -49,7 +49,9 @@ is the same as input and the shape of the feature tensor is
 
 input: Each string is a record/row in the LibSVM.
 label: A tensor of the same shape as input.
-feature: A tensor of the shape `[input_shape, num_features]`.
+feature_indices: A 2-D int64 tensor of dense_shape [N, ndims].
+feature_values: A 1-D tensor of any type and dense_shape [N].
+feature_shape: A 1-D int64 tensor of dense_shape [ndims].
 num_features: The number of features.
 )doc");
 

--- a/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
+++ b/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
@@ -1,0 +1,43 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for DecodeLibsvm op."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import sys
+from tensorflow.contrib.libsvm.python.ops import libsvm_ops
+from tensorflow.python.platform import test
+
+
+class DecodeLibsvmOpTest(test.TestCase):
+
+  def testBasic(self):
+    with self.test_session() as sess:
+      content = ["1 1:3.4 2:0.5 4:0.231",
+                 "1 2:2.5 3:0.1 5:0.503",
+                 "2 3:2.5 2:0.1 1:0.105"]
+      label, feature = libsvm_ops.decode_libsvm(content, num_features=6)
+      label, feature = sess.run([label, feature])
+      self.assertAllEqual(label, [1, 1, 2])
+      self.assertAllClose(feature, [[0, 3.4, 0.5, 0, 0.231, 0],
+                                    [0, 0, 2.5, 0.1, 0, 0.503],
+                                    [0, 0.105, 0.1, 2.5, 0, 0]])
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
+++ b/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.contrib.libsvm.python.ops import libsvm_ops
+from tensorflow.python.ops import sparse_ops
 from tensorflow.python.platform import test
 
 
@@ -31,13 +32,13 @@ class DecodeLibsvmOpTest(test.TestCase):
       content = ["1 1:3.4 2:0.5 4:0.231",
                  "1 2:2.5 3:0.1 5:0.503",
                  "2 3:2.5 2:0.1 1:0.105"]
-      label, feature = libsvm_ops.decode_libsvm(content, num_features=6)
+      label, indices, values, shape = libsvm_ops.decode_libsvm(content,
+                                                               num_features=6)
+      feature = sparse_ops.sparse_to_dense(indices, shape, values,
+                                           validate_indices=False)
 
-      # shape inference
       self.assertAllEqual(label.get_shape().as_list(), [3])
-      self.assertAllEqual(feature.get_shape().as_list(), [3, 6])
 
-      # sess.run()
       label, feature = sess.run([label, feature])
       self.assertAllEqual(label, [1, 1, 2])
       self.assertAllClose(feature, [[0, 3.4, 0.5, 0, 0.231, 0],

--- a/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
+++ b/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
@@ -33,34 +33,34 @@ class DecodeLibsvmOpTest(test.TestCase):
       content = ["1 1:3.4 2:0.5 4:0.231",
                  "1 2:2.5 3:inf 5:0.503",
                  "2 3:2.5 2:nan 1:0.105"]
-      label, sparse_feature = libsvm_ops.decode_libsvm(content,
-                                                       num_features=6)
-      feature = sparse_ops.sparse_tensor_to_dense(sparse_feature,
-                                                  validate_indices=False)
+      sparse_features, labels = libsvm_ops.decode_libsvm(content,
+                                                         num_features=6)
+      features = sparse_ops.sparse_tensor_to_dense(sparse_features,
+                                                   validate_indices=False)
 
-      self.assertAllEqual(label.get_shape().as_list(), [3])
+      self.assertAllEqual(labels.get_shape().as_list(), [3])
 
-      label, feature = sess.run([label, feature])
-      self.assertAllEqual(label, [1, 1, 2])
-      self.assertAllClose(feature, [[0, 3.4, 0.5, 0, 0.231, 0],
-                                    [0, 0, 2.5, np.inf, 0, 0.503],
-                                    [0, 0.105, np.nan, 2.5, 0, 0]])
+      features, labels = sess.run([features, labels])
+      self.assertAllEqual(labels, [1, 1, 2])
+      self.assertAllClose(features, [[0, 3.4, 0.5, 0, 0.231, 0],
+                                     [0, 0, 2.5, np.inf, 0, 0.503],
+                                     [0, 0.105, np.nan, 2.5, 0, 0]])
 
   def testNDimension(self):
     with self.test_session() as sess:
       content = [["1 1:3.4 2:0.5 4:0.231", "1 1:3.4 2:0.5 4:0.231"],
                  ["1 2:2.5 3:inf 5:0.503", "1 2:2.5 3:inf 5:0.503"],
                  ["2 3:2.5 2:nan 1:0.105", "2 3:2.5 2:nan 1:0.105"]]
-      label, sparse_feature = libsvm_ops.decode_libsvm(
+      sparse_features, labels = libsvm_ops.decode_libsvm(
           content, num_features=6, label_dtype=dtypes.float64)
-      feature = sparse_ops.sparse_tensor_to_dense(sparse_feature,
-                                                  validate_indices=False)
+      features = sparse_ops.sparse_tensor_to_dense(sparse_features,
+                                                   validate_indices=False)
 
-      self.assertAllEqual(label.get_shape().as_list(), [3, 2])
+      self.assertAllEqual(labels.get_shape().as_list(), [3, 2])
 
-      label, feature = sess.run([label, feature])
-      self.assertAllEqual(label, [[1, 1], [1, 1], [2, 2]])
-      self.assertAllClose(feature, [[[0, 3.4, 0.5, 0, 0.231, 0],
+      features, labels = sess.run([features, labels])
+      self.assertAllEqual(labels, [[1, 1], [1, 1], [2, 2]])
+      self.assertAllClose(features, [[[0, 3.4, 0.5, 0, 0.231, 0],
                                      [0, 3.4, 0.5, 0, 0.231, 0]],
                                     [[0, 0, 2.5, np.inf, 0, 0.503],
                                      [0, 0, 2.5, np.inf, 0, 0.503]],

--- a/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
+++ b/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
@@ -30,20 +30,41 @@ class DecodeLibsvmOpTest(test.TestCase):
   def testBasic(self):
     with self.test_session() as sess:
       content = ["1 1:3.4 2:0.5 4:0.231",
-                 "1 2:2.5 3:0.1 5:0.503",
-                 "2 3:2.5 2:0.1 1:0.105"]
-      label, indices, values, shape = libsvm_ops.decode_libsvm(content,
-                                                               num_features=6)
-      feature = sparse_ops.sparse_to_dense(indices, shape, values,
-                                           validate_indices=False)
+                 "1 2:2.5 3:inf 5:0.503",
+                 "2 3:2.5 2:nan 1:0.105"]
+      label, sparse_feature = libsvm_ops.decode_libsvm(content,
+                                                       num_features=6)
+      feature = sparse_ops.sparse_tensor_to_dense(sparse_feature,
+                                                  validate_indices=False)
 
       self.assertAllEqual(label.get_shape().as_list(), [3])
 
       label, feature = sess.run([label, feature])
       self.assertAllEqual(label, [1, 1, 2])
       self.assertAllClose(feature, [[0, 3.4, 0.5, 0, 0.231, 0],
-                                    [0, 0, 2.5, 0.1, 0, 0.503],
-                                    [0, 0.105, 0.1, 2.5, 0, 0]])
+                                    [0, 0, 2.5, np.inf, 0, 0.503],
+                                    [0, 0.105, np.nan, 2.5, 0, 0]])
+
+  def testNDimension(self):
+    with self.test_session() as sess:
+      content = [["1 1:3.4 2:0.5 4:0.231", "1 1:3.4 2:0.5 4:0.231"],
+                 ["1 2:2.5 3:inf 5:0.503", "1 2:2.5 3:inf 5:0.503"],
+                 ["2 3:2.5 2:nan 1:0.105", "2 3:2.5 2:nan 1:0.105"]]
+      label, sparse_feature = libsvm_ops.decode_libsvm(content,
+                                                       num_features=6)
+      feature = sparse_ops.sparse_tensor_to_dense(sparse_feature,
+                                                  validate_indices=False)
+
+      self.assertAllEqual(label.get_shape().as_list(), [3, 2])
+
+      label, feature = sess.run([label, feature])
+      self.assertAllEqual(label, [[1, 1], [1, 1], [2, 2]])
+      self.assertAllClose(feature, [[[0, 3.4, 0.5, 0, 0.231, 0],
+                                     [0, 3.4, 0.5, 0, 0.231, 0]],
+                                    [[0, 0, 2.5, np.inf, 0, 0.503],
+                                     [0, 0, 2.5, np.inf, 0, 0.503]],
+                                    [[0, 0.105, np.nan, 2.5, 0, 0],
+                                     [0, 0.105, np.nan, 2.5, 0, 0]]])
 
 
 if __name__ == "__main__":

--- a/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
+++ b/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import sys
+
 from tensorflow.contrib.libsvm.python.ops import libsvm_ops
 from tensorflow.python.platform import test
 
@@ -32,6 +32,12 @@ class DecodeLibsvmOpTest(test.TestCase):
                  "1 2:2.5 3:0.1 5:0.503",
                  "2 3:2.5 2:0.1 1:0.105"]
       label, feature = libsvm_ops.decode_libsvm(content, num_features=6)
+
+      # shape inference
+      self.assertAllEqual(label.get_shape().as_list(), [3])
+      self.assertAllEqual(feature.get_shape().as_list(), [3, 6])
+
+      # sess.run()
       label, feature = sess.run([label, feature])
       self.assertAllEqual(label, [1, 1, 2])
       self.assertAllClose(feature, [[0, 3.4, 0.5, 0, 0.231, 0],

--- a/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
+++ b/tensorflow/contrib/libsvm/python/kernel_tests/decode_libsvm_op_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.contrib.libsvm.python.ops import libsvm_ops
+from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import sparse_ops
 from tensorflow.python.platform import test
 
@@ -50,8 +51,8 @@ class DecodeLibsvmOpTest(test.TestCase):
       content = [["1 1:3.4 2:0.5 4:0.231", "1 1:3.4 2:0.5 4:0.231"],
                  ["1 2:2.5 3:inf 5:0.503", "1 2:2.5 3:inf 5:0.503"],
                  ["2 3:2.5 2:nan 1:0.105", "2 3:2.5 2:nan 1:0.105"]]
-      label, sparse_feature = libsvm_ops.decode_libsvm(content,
-                                                       num_features=6)
+      label, sparse_feature = libsvm_ops.decode_libsvm(
+          content, num_features=6, label_dtype=dtypes.float64)
       feature = sparse_ops.sparse_tensor_to_dense(sparse_feature,
                                                   validate_indices=False)
 

--- a/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
+++ b/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
@@ -40,12 +40,12 @@ def decode_libsvm(content, num_features, dtype=None, label_dtype=None):
     label_dtype: The type of the output label tensor. Default to tf.int64.
 
   Returns:
-    label: A `Tensor` of the same shape as content.
-    feature: A `SparseTensor` of the shape `[input_shape, num_features]`.
+    features: A `SparseTensor` of the shape `[input_shape, num_features]`.
+    labels: A `Tensor` of the same shape as content.
   """
-  label, indices, values, shape = gen_libsvm_ops.decode_libsvm(
+  labels, indices, values, shape = gen_libsvm_ops.decode_libsvm(
       content, num_features, dtype=dtype, label_dtype=label_dtype)
-  return label, sparse_tensor.SparseTensor(indices, values, shape)
+  return sparse_tensor.SparseTensor(indices, values, shape), labels
 
 
 ops.NotDifferentiable('DecodeLibSVM')

--- a/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
+++ b/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
@@ -1,0 +1,47 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Libsvm decoder."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib.libsvm.ops import gen_libsvm_ops
+from tensorflow.contrib.util import loader
+from tensorflow.python.framework import common_shapes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import io_ops
+from tensorflow.python.platform import resource_loader
+
+
+_libsvm_ops_so = loader.load_op_library(
+    resource_loader.get_path_to_datafile("_libsvm_ops.so"))
+
+def decode_libsvm(content, num_features, dtype=None):
+  """Convert Libsvm records to a tensor of label and a tensor of feature.
+
+  Args:
+    content: A `Tensor` of type `string`. Each string is a record/row in
+      the Libsvm format.
+    num_features: The number of features.
+    dtype: The type of the output feature tensor. Default to tf.float32.
+
+  Returns:
+    label: A `Tensor` of the same shape as content.
+    feature: A `Tensor` of the shape `[input_shape, num_features]`.
+  """
+  return gen_libsvm_ops.decode_libsvm(content, num_features, dtype=dtype)
+
+
+ops.NotDifferentiable('DecodeLibSVM')

--- a/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
+++ b/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
@@ -29,7 +29,7 @@ from tensorflow.python.platform import resource_loader
 _libsvm_ops_so = loader.load_op_library(
     resource_loader.get_path_to_datafile("_libsvm_ops.so"))
 
-def decode_libsvm(content, num_features, dtype=None):
+def decode_libsvm(content, num_features, dtype=None, label_dtype=None):
   """Convert Libsvm records to a tensor of label and a tensor of feature.
 
   Args:
@@ -37,14 +37,14 @@ def decode_libsvm(content, num_features, dtype=None):
       the Libsvm format.
     num_features: The number of features.
     dtype: The type of the output feature tensor. Default to tf.float32.
+    label_dtype: The type of the output label tensor. Default to tf.int64.
 
   Returns:
     label: A `Tensor` of the same shape as content.
     feature: A `SparseTensor` of the shape `[input_shape, num_features]`.
   """
-  label, indices, values, shape = gen_libsvm_ops.decode_libsvm(content,
-                                                               num_features,
-                                                               dtype=dtype)
+  label, indices, values, shape = gen_libsvm_ops.decode_libsvm(
+      content, num_features, dtype=dtype, label_dtype=label_dtype)
   return label, sparse_tensor.SparseTensor(indices, values, shape)
 
 

--- a/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
+++ b/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
@@ -21,6 +21,7 @@ from tensorflow.contrib.libsvm.ops import gen_libsvm_ops
 from tensorflow.contrib.util import loader
 from tensorflow.python.framework import common_shapes
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.ops import io_ops
 from tensorflow.python.platform import resource_loader
 
@@ -39,9 +40,12 @@ def decode_libsvm(content, num_features, dtype=None):
 
   Returns:
     label: A `Tensor` of the same shape as content.
-    feature: A `Tensor` of the shape `[input_shape, num_features]`.
+    feature: A `SparseTensor` of the shape `[input_shape, num_features]`.
   """
-  return gen_libsvm_ops.decode_libsvm(content, num_features, dtype=dtype)
+  label, indices, values, shape = gen_libsvm_ops.decode_libsvm(content,
+                                                               num_features,
+                                                               dtype=dtype)
+  return label, sparse_tensor.SparseTensor(indices, values, shape)
 
 
 ops.NotDifferentiable('DecodeLibSVM')


### PR DESCRIPTION
This fix is an effort to add libsvm format support with the implementation of `decode_libsvm`, as was proposed in #14313.

The implementation is done in contrib with, e.g.,
```
label, feature = tf.contrib.libsvm.decode_libsvm(input, num_features=6)
```

where the input is a string tensor and the output is a tuple of label and feature.

The label tensor is the same shape as input. The feature tensor is of the shape `[input_shape, num_features]`.

This fix fixes #14313.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
