### PR TITLE
Allow tfcompile_flags to be a list

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -657,7 +657,7 @@ tf_library(
     cpp_class = "LSTMLayerInference",
     graph = "lstm_layer_inference.pbtxt",
     tags = ["manual"],
-    tfcompile_flags = "--xla_cpu_multi_thread_eigen=false",
+    tfcompile_flags = ["--xla_cpu_multi_thread_eigen=false"],
 )
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR is a follow up to #12769 and #14333 to address the issue raised in #12767 so that it is possible to specify the flag with
```
tfcompile_flags = ["--target_cpu='core-avx2'", "--xla_enable_fast_math=false"]`
```
Previously it was only possible to specify the flag with:
```
tfcompile_flags = "--target_cpu='core-avx2' --xla_enable_fast_math=false"
```

This PR will fix #12767.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>