### PR TITLE
在Windows上安装TensorFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,57 +4,46 @@
 
 -----------------
 
-| **`Linux CPU`** | **`Linux GPU`** | **`Mac OS CPU`** | **`Windows CPU`** | **`Android`** |
-|-----------------|---------------------|------------------|-------------------|---------------|
+| **`Linux CPU`**                          | **`Linux GPU`**                          | **`Mac OS CPU`**                         | **`Windows CPU`**                        | **`Android`**                            |
+| ---------------------------------------- | ---------------------------------------- | ---------------------------------------- | ---------------------------------------- | ---------------------------------------- |
 | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-cpu)](https://ci.tensorflow.org/job/tensorflow-master-cpu) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-linux-gpu)](https://ci.tensorflow.org/job/tensorflow-master-linux-gpu) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-mac)](https://ci.tensorflow.org/job/tensorflow-master-mac) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-win-cmake-py)](https://ci.tensorflow.org/job/tensorflow-master-win-cmake-py) | [![Build Status](https://ci.tensorflow.org/buildStatus/icon?job=tensorflow-master-android)](https://ci.tensorflow.org/job/tensorflow-master-android) |
 
-**TensorFlow** is an open source software library for numerical computation using
-data flow graphs.  The graph nodes represent mathematical operations, while
-the graph edges represent the multidimensional data arrays (tensors) that flow
-between them.  This flexible architecture lets you deploy computation to one
-or more CPUs or GPUs in a desktop, server, or mobile device without rewriting
-code.  TensorFlow also includes TensorBoard, a data visualization toolkit.
+**TensorFlow** 是一个使用数据流图进行数值计算开源软件库。
+图的节点表示数学运算，节点之间的边表示流动的多维数据数组（张量）。
+这种灵活的架构允许你在无需重写代码的情况下，将计算在桌面端、服务端或移动端部署到一个或多个 CPU 和 GPU 中。
+TensorFlow 还包含 TensorBoard，它是一个数据可视化工具包。
 
-TensorFlow was originally developed by researchers and engineers
-working on the Google Brain team within Google's Machine Intelligence Research
-organization for the purposes of conducting machine learning and deep neural
-networks research.  The system is general enough to be applicable in a wide
-variety of other domains, as well.
+TensorFlow 最初由 Google 机器智能研究机构内的 
+Google Brain 团队的研究人员和工程师开发，用于进行机器学习和深度神经网络研究。
+此系统一般足以适用于各种其他领域。
 
-**If you want to contribute to TensorFlow, be sure to review the [contribution
-guidelines](CONTRIBUTING.md). This project adheres to TensorFlow's
-[code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to
-uphold this code.**
+**如果你想参与贡献 TensorFlow，请先查看我们的 [贡献指南](CONTRIBUTING.md)。此项目遵循 TensorFlow
+[项目规范](CODE_OF_CONDUCT.md)。我们期望你能遵循此规范。**
 
-**We use [GitHub issues](https://github.com/tensorflow/tensorflow/issues) for
-tracking requests and bugs. So please see 
-[TensorFlow Discuss](https://groups.google.com/a/tensorflow.org/forum/#!forum/discuss) for general questions
-and discussion, and please direct specific questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/tensorflow).**
+**我们还使用 [GitHub issues](https://github.com/tensorflow/tensorflow/issues) 来跟进 requests 和 bugs。对于一般性问题和讨论请查看 
+[TensorFlow 讨论](https://groups.google.com/a/tensorflow.org/forum/#!forum/discuss)，或直接在 [Stack Overflow](https://stackoverflow.com/questions/tagged/tensorflow) 提问。**
 
-## Installation
-*See [Installing TensorFlow](https://www.tensorflow.org/get_started/os_setup.html) for instructions on how to install our release binaries or how to build from source.*
+## 安装
+*在 [安装 TensorFlow](https://www.tensorflow.org/get_started/os_setup.html) 页面中查看关于稳定二进制版的安装或从源码安装的安装步骤。*
 
-People who are a little more adventurous can also try our nightly binaries:
+喜欢挑战的人也可以尝试我们的开发版：
 
-**Nightly pip packages**
-* We are pleased to announce that TensorFlow now offers nightly pip packages
-under the [tf-nightly](https://pypi.python.org/pypi/tf-nightly) and
-[tf-nightly-gpu](https://pypi.python.org/pypi/tf-nightly-gpu) project on pypi.
-Simply run `pip install tf-nightly` or `pip install tf-nightly-gpu` in a clean
-environment to install the nightly TensorFlow build. We support CPU and GPU
-packages on Linux, Mac, and Windows.
+**开发版 pip 包**
+* 我们非常高兴发布 TensorFlow 的开发版，现在 pypi 提供开发版的 pip 包 [tf-nightly](https://pypi.python.org/pypi/tf-nightly) 和
+  [tf-nightly-gpu](https://pypi.python.org/pypi/tf-nightly-gpu) 项目。在干净的环境中简单运行 `pip install tf-nightly` 或 `pip install tf-nightly-gpu` 即可安装 TensorFlow 开发版。 我们为 Linux、Mac 和 Windows 提供  CPU 和 GPU 支持。
 
 
-**Individual whl files**
-* Linux CPU-only: [Python 2](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-cp27-none-linux_x86_64.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/)) / [Python 3.4](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-cp34-cp34m-linux_x86_64.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/)) / [Python 3.5](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3.5,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-cp35-cp35m-linux_x86_64.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3.5,label=cpu-slave/))
-* Linux GPU: [Python 2](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=gpu-linux/42/artifact/pip_test/whl/tf_nightly_gpu-1.head-cp27-none-linux_x86_64.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=gpu-linux/)) / [Python 3.4](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=gpu-linux/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly_gpu-1.head-cp34-cp34m-linux_x86_64.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=gpu-linux/)) / [Python 3.5](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3.5,label=gpu-linux/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly_gpu-1.head-cp35-cp35m-linux_x86_64.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3.5,label=gpu-linux/))
-* Mac CPU-only: [Python 2](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-mac/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=mac-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-py2-none-any.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-mac/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=mac-slave/)) / [Python 3](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-mac/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=mac-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-py3-none-any.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-mac/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=mac-slave/))
-* Windows CPU-only: [Python 3.5 64-bit](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows,PY=35/lastSuccessfulBuild/artifact/cmake_build/tf_python/dist/tf_nightly-1.head-cp35-cp35m-win_amd64.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows,PY=35/)) / [Python 3.6 64-bit](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows,PY=36/lastSuccessfulBuild/artifact/cmake_build/tf_python/dist/tf_nightly-1.head-cp36-cp36m-win_amd64.whl) ([build history](http://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows,PY=36/))
-* Windows GPU: [Python 3.5 64-bit](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows-gpu,PY=35/lastSuccessfulBuild/artifact/cmake_build/tf_python/dist/tf_nightly_gpu-1.head-cp35-cp35m-win_amd64.whl) ([build history](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows-gpu,PY=35/)) / [Python 3.6 64-bit](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows-gpu,PY=36/lastSuccessfulBuild/artifact/cmake_build/tf_python/dist/tf_nightly_gpu-1.head-cp36-cp36m-win_amd64.whl) ([build history](http://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows-gpu,PY=36/))
+**独立的 whl 文件**
+* Linux CPU-only: [Python 2](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-cp27-none-linux_x86_64.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/)) / [Python 3.4](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-cp34-cp34m-linux_x86_64.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/)) / [Python 3.5](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3.5,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-cp35-cp35m-linux_x86_64.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3.5,label=cpu-slave/))
+* Linux GPU: [Python 2](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=gpu-linux/42/artifact/pip_test/whl/tf_nightly_gpu-1.head-cp27-none-linux_x86_64.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=gpu-linux/)) / [Python 3.4](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=gpu-linux/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly_gpu-1.head-cp34-cp34m-linux_x86_64.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=gpu-linux/)) / [Python 3.5](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3.5,label=gpu-linux/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly_gpu-1.head-cp35-cp35m-linux_x86_64.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-linux/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3.5,label=gpu-linux/))
+* Mac CPU-only: [Python 2](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-mac/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=mac-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-py2-none-any.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-mac/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=mac-slave/)) / [Python 3](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-mac/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=mac-slave/lastSuccessfulBuild/artifact/pip_test/whl/tf_nightly-1.head-py3-none-any.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-mac/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=mac-slave/))
+* Windows CPU-only: [Python 3.5 64-bit](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows,PY=35/lastSuccessfulBuild/artifact/cmake_build/tf_python/dist/tf_nightly-1.head-cp35-cp35m-win_amd64.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows,PY=35/)) / [Python 3.6 64-bit](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows,PY=36/lastSuccessfulBuild/artifact/cmake_build/tf_python/dist/tf_nightly-1.head-cp36-cp36m-win_amd64.whl) ([构建历史](http://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows,PY=36/))
+* Windows GPU: [Python 3.5 64-bit](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows-gpu,PY=35/lastSuccessfulBuild/artifact/cmake_build/tf_python/dist/tf_nightly_gpu-1.head-cp35-cp35m-win_amd64.whl) ([构建历史](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows-gpu,PY=35/)) / [Python 3.6 64-bit](https://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows-gpu,PY=36/lastSuccessfulBuild/artifact/cmake_build/tf_python/dist/tf_nightly_gpu-1.head-cp36-cp36m-win_amd64.whl) ([构建历史](http://ci.tensorflow.org/view/tf-nightly/job/tf-nightly-windows/M=windows-gpu,PY=36/))
 * Android: [demo APK](https://ci.tensorflow.org/view/Nightly/job/nightly-android/lastSuccessfulBuild/artifact/out/tensorflow_demo.apk), [native libs](https://ci.tensorflow.org/view/Nightly/job/nightly-android/lastSuccessfulBuild/artifact/out/native/)
-([build history](https://ci.tensorflow.org/view/Nightly/job/nightly-android/))
+  ([构建历史](https://ci.tensorflow.org/view/Nightly/job/nightly-android/))
 
-#### *Try your first TensorFlow program*
+#### *开启你的第一个 TensorFlow 程序*
+
 ```shell
 $ python
 ```
@@ -71,16 +60,16 @@ $ python
 >>> sess.close()
 ```
 
-## For more information
+## 更多信息
 
-* [TensorFlow website](https://www.tensorflow.org)
-* [TensorFlow White Papers](https://www.tensorflow.org/about/bib)
-* [TensorFlow Model Zoo](https://github.com/tensorflow/models)
-* [TensorFlow MOOC on Udacity](https://www.udacity.com/course/deep-learning--ud730)
-* [TensorFlow course at Stanford](https://web.stanford.edu/class/cs20si)
+* [TensorFlow 网站](https://www.tensorflow.org)
+* [TensorFlow 白皮书](https://www.tensorflow.org/about/bib)
+* [TensorFlow 模型](https://github.com/tensorflow/models)
+* [TensorFlow MOOC 教程](https://www.udacity.com/course/deep-learning--ud730)
+* [TensorFlow Stanford 教程](https://web.stanford.edu/class/cs20si)
 
-Learn more about the TensorFlow community at the [community page of tensorflow.org](https://www.tensorflow.org/community) for a few ways to participate.
+你可以在 [tensorflow.org 社区页](https://www.tensorflow.org/community) 了解更多关于参与 TensorFlow 社区的方法。
 
-## License
+## 许可
 
-[Apache License 2.0](LICENSE)
+[Apache 许可 2.0](LICENSE)

--- a/tensorflow/docs_src/install/index.md
+++ b/tensorflow/docs_src/install/index.md
@@ -1,32 +1,25 @@
-# Installing TensorFlow
+# 安装 TensorFlow
 
-We've built and tested TensorFlow on the following 64-bit laptop/desktop
-operating systems:
-  * MacOS X 10.11 (El Capitan) or later.
-  * Ubuntu 14.04 or later
-  * Windows 7 or later.
-Although you might be able to install TensorFlow on other laptop or desktop
-systems, we only support (and only fix issues in) the preceding configurations.
+我们已经在以下便携式与桌面级 64 位操作系统中对 TensorFlow 进行了编译与测试：
+  * MacOS X 10.11 (El Capitan) 及以上版本
+  * Ubuntu 14.04 及以上版本
+  * Windows 7 及以上版本
+虽然您可能需要在其它便携式或桌面级系统中安装 TensorFlow，但我们仅会为上述配置环境提供支持（以及仅修复上述平台中的 issue）。
 
-The following guides explain how to install a version of TensorFlow
-that enables you to write applications in Python:
+以下指南将说明如何安装各版本的 TensorFlow，以使您能用 Python 编写应用：
 
-  * @{$install_linux$Installing TensorFlow on Ubuntu}
-  * @{$install_mac$Installing TensorFlow on macOS}
-  * @{$install_windows$Installing TensorFlow on Windows}
-  * @{$install_sources$Installing TensorFlow from Sources}
+  * @{$install_linux$在 Ubuntu 中安装 TensorFlow}
+  * @{$install_mac$在 macOS 中安装 TensorFlow}
+  * @{$install_windows$在 Windows 中安装 TensorFlow}
+  * @{$install_sources$由源代码安装 TensorFlow}
 
-Many aspects of the Python TensorFlow API changed from version 0.n to 1.0.
-The following guide explains how to migrate older TensorFlow applications
-to Version 1.0:
+在 Tensorflow 由 0.n 升级为 1.0 时，许多 Tensorflow Python API 发生了变化。
+下面的指南介绍了如何将老版本的 TensorFlow 应用迁移至 1.0 版本：
 
-  * @{$migration$Transitioning to TensorFlow 1.0}
+  * @{$migration$迁移至 TensorFlow 1.0}
 
-The following guides explain how to install TensorFlow libraries for use in
-other programming languages. These APIs are aimed at deploying TensorFlow
-models in applications and are not as extensive as the Python APIs.
+以下指南说明了如何在其它的编程语言中安装及使用 TensorFlow 库。这些语言的 API 旨在将 TensorFlow 模型部署于其它语言的应用中，没有 Python 的 API 全面。
 
-  * @{$install_java$Installing TensorFlow for Java}
-  * @{$install_c$Installing TensorFlow for C}
-  * @{$install_go$Installing TensorFlow for Go}
-
+  * @{$install_java$为 Java 安装 TensorFlow}
+  * @{$install_c$为 C 安装 TensorFlow}
+  * @{$install_go$为 Go 安装 TensorFlow}


### PR DESCRIPTION
本份指导将告诉您如何在 Windows 上安装 TensorFlow。
## 选择准备安装的 TensorFlow 类型
您需要在以下两种 TensorFlow 类型中选择您想安装的类型：

-  **仅支持 CPU 的 TensorFlow。** 如果您的系统并没有 NVIDIA® GPU 这样的 GPU，那么您只能安装仅支持 CPU 的 TensorFlow。需要特别说明的是，相比起另外一个版本的 TensorFlow，该版本的 TensorFlow 通常更加容易安装（一般而言5到10分钟即可完成安装），所以即使您拥有一个 NVIDIA 的 GPU，我们也更推荐您优先安装这个版本。


- **支持 GPU 的 TensorFlow。** 一般而言，TensorFlow 的程序在 GPU 上的运行速度要明显高于在 CPU 上的。因此，如果您的系统拥有符合以下要求的 NVIDIA ® GPU，且您需要运行的应用注重性能，那么您最终需要安装此版本的TensorFlow。

## 运行支持 GPU TensorFlow 版本的需求
不论您采用本份指导提供的哪种方式进行安装，如果您需要安装 GPU 的 TensorFlow，您必须在您的设备上安装以下NVIDIA软件：

- CUDA® Toolkit 8.0。关于它的详细说明请看[ NVIDIA 官方文档](http://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/)。请确保您讲 Cuda 相关的路径名都按照 NVIDIA 文档的描述方法加入到了%PATH%系统变量中。

- 与 CUDA Toolkit 8.0 相关的 NVIDIA 驱动。

- cuDNN v6.1版本。关于它的详细说明请看[ NVIDIA 官方文档](http://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/)。需要注意的是，一般而言，cuDNN的安装地址和其他CUDA DLL是不同的。同时，请确认您把您安装cuDNN DLL的安装地址加入到了%PATH%系统变量中。

- 带有 CUDA Compute Capability 3.0 或更高版本的 GPU 卡。请在[ NVIDIA 官方文档中](http://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/)查询具有条件的GPU清单。

如果您的版本与上述包所要求的版本不同，请改到我们所要求的版本。特别说明的是，cuDNN 的版本必须与要求的一致：如果无法找到 cuDNN64_6.dll，那么 TensorFlow 将无法加载。如果您想使用其他版本的 cuDNN，您需要从源代码开始重新编译。

## 安装 TensorFlow 的方式
您需要选择安装 TensorFlow 的方式。当前的可选方式如下：
- 原生的 pip 方法
- 使用 Anaconda

原生的 pip 方法可以直接在您的系统上安装 TensorFlow 而并不需要虚拟环境（virtual environment）。由于原生的一个pip安装应用并没有被隔离在一个独立的应用中，使用 pip 安装方法可能会影响到系统里其他基于Python的安装。但是，如果您了解您系统里的 pip 和 Python 环境，那么使用原生pip安装仅仅只需要一条命令就够了。而且，如果您使用原生的 pip 安装方法，那么用户可以从系统的任何路径去运行 TensorFlow 程序。

在 Anaconda 中，你可以使用 conda 去创建一个虚拟环境（virtural environment）。但是，如果是使用 Anaconda 方式，我们依然推荐使用 pip 安装命令来安装 TensorFlow，而不是 conda 安装命令。

**注意：** conda 包是由社区提供的，而不是官方。也就是说，TensorFlow 团队并不会测试也不会维护 conda 包。使用 conda 包需要您自己承担风险。

## 使用原生pip安装
如果您的机器上没有安装以下版本的Python，请立刻安装：
- [Python 3.5.x 64-bit from python.org](https://www.python.org/downloads/release/python-352/)
- [Python 3.6.x 64-bit from python.org](https://www.python.org/downloads/release/python-362/)

在 Windows 上，TensorFlow 支持 Python3.5.x 版本和 Python 3.6.x 版本。需要注意的是， Python 3 使用的是 pip3 包管理， 这也您用来安装 TensorFlow 的程序。
在安装 TensorFlow 时，请打开一个终端。然后在终端上运行正确的 pip3 安装命令。 如果是安装仅支持 CPU 的 TensorFlow 版本，请输入下面的命令：
`C:\> pip3 install --upgrade tensorflow`

如果是安装支持 GPU 的 TensorFlow 版本，请输入下面的命令：
`C:\> pip3 install --upgrade tensorflow-gpu`

## 使用 Anaconda 进行安装
**Anaconda 的安装包是由社区提供，并非官方提供的。**
在 Anaconda 的环境下，按照以下步骤进行 TensorFlow 的安装：
1.遵循 [Anaconda 下载站点](https://www.anaconda.com/download/)里的说明进行 Anaconda 的下载和安装。 
2.请通过使用以下命令来创建一个名为 tensorflow 的 conda 环境：
`C:\> conda create -n tensorflow pip python=3.5`
3.通过输入以下命令来激活一个 conda 环境：
`C:\> activate tensorflow`
`(tensorflow)C:\>  # Your prompt should change `
4.在您的 conda 环境里输入正确的命令来安装 TensorFlow。 如果是安装仅支持 CPU 的 TensorFlow 版本，请输入下面的命令：
`(tensorflow)C:\> pip install --ignore-installed --upgrade tensorflow `
如果是安装支持 GPU 的 TensorFlow 版本，请输入下面的命令：
`(tensorflow)C:\> pip install --ignore-installed --upgrade tensorflow-gpu `

## 常见安装问题
我们使用 Stack Overflow 来记录 TensorFlow 的安装问题和修正方法。下表中包含有一些常见安装问题在 Stack Overflow 上的回答链接。如果您遇到的错误消息或安装问题不在下表中，请在 Stack Overflow 上搜索它的答案。如果 Stack Overflow 上并没有显示这个错误消息或者安装问题的答案，请在 Stack Overflow 上提一个关于这个错误消息或者安装问题的新问题，并给这个问题指定一个 `tensorflow` 的标签。

| Stack Overflow 链接 | 错误消息 |
| ---------- | --------------- |
| [41007279](https://stackoverflow.com/questions/41007279/tensorflow-on-windows-couldnt-open-cuda-library-cudnn64-5-dll) | [...\stream_executor\dso_loader.cc] Couldn't open CUDA library nvcuda.dll |
| [41007279](https://stackoverflow.com/questions/41007279/tensorflow-on-windows-couldnt-open-cuda-library-cudnn64-5-dll) | [...\stream_executor\cuda\cuda_dnn.cc] Unable to load cuDNN DSO |
| [42006320](https://stackoverflow.com/questions/42011070/on-windows-running-import-tensorflow-generates-no-module-named-pywrap-tenso) | ImportError: Traceback (most recent call last):  File "...\tensorflow\core\framework\graph_pb2.py", line 6, in  <br>from google.protobuf import descriptor as _descriptor  <br>ImportError: cannot import name 'descriptor'  |
| [42011070](https://stackoverflow.com/questions/42011070/on-windows-running-import-tensorflow-generates-no-module-named-pywrap-tenso) | No module named "pywrap_tensorflow" |
| [42217532](https://stackoverflow.com/questions/42217532/tensorflow-version-1-0-0-rc2-on-windows-opkernel-op-bestsplits-device-typ) | OpKernel ('op: "BestSplits" device_type: "CPU"') for unknown op: BestSplits |
| [43134753](https://stackoverflow.com/questions/43134753/tensorflow-wasnt-compiled-to-use-sse-etc-instructions-but-these-are-availab) | The TensorFlow library wasn't compiled to use SSE instructions |