### PR TITLE
Fix #14324 and another compile error with mkl

### DIFF
--- a/tensorflow/core/kernels/slice_op.cc
+++ b/tensorflow/core/kernels/slice_op.cc
@@ -252,7 +252,22 @@ class MklSliceOp : public OpKernel {
       if (input_dims == 4) {
         HandleCase4D(context, begin, size, result);
       } else {
-        functor::Slice<Device, T, input_dims>()(
+#define HANDLE_DIM(NDIM)                                              \
+  if (input_dims == NDIM) {                                           \
+    functor::Slice<Device, T, NDIM>()(                                \
+        context->eigen_device<Device>(), result, input, begin, size); \
+    return;                                                           \
+  }
+        HANDLE_DIM(1);
+        HANDLE_DIM(2);
+        HANDLE_DIM(3);
+        HANDLE_DIM(5);
+        HANDLE_DIM(6);
+
+#undef HANDLE_DIM
+
+        // handle cases which dim >= 7
+        functor::Slice<Device, T, 7>()(
             context->eigen_device<Device>(), result, input, begin, size);
       }
     }
@@ -375,7 +390,7 @@ class MklSliceOp : public OpKernel {
     }
 
     functor::Slice<Device, T, 4>()(
-        context->eigen_device<Device>(), result, input, begin, size);
+        context->eigen_device<Device>(), result, context->input(0), begin, size);
   }
 };
 #endif


### PR DESCRIPTION
This fix fixes #14324 and another compile error with mkl below

> ERROR: /home/zhang/tensorflow/tensorflow/core/kernels/BUILD:780:1: C++ compilation of rule '//tensorflow/core/kernels:slice_op' failed (Exit 1)
tensorflow/core/kernels/slice_op.cc: In member function 'void tensorflow::MklSliceOp<Device, T>::HandleCase4D(tensorflow::OpKernelContext*, const tensorflow::gtl::ArraySlice<long long int>&, const tensorflow::gtl::ArraySlice<long long int>&, tensorflow::Tensor*)':
tensorflow/core/kernels/slice_op.cc:393:50: error: 'input' was not declared in this scope
         context->eigen_device<Device>(), result, input, begin, size);
                                                  ^
Target //tensorflow/tools/pip_package:build_pip_package failed to build
Use --verbose_failures to see the command lines of failed build steps.

Update:
Found a similar PR #14329 has been posted already.
But this fix improves that fix by removing redundant code. Should I close this PR and create a new one to improve that fix?