### PR TITLE
Typo fixed in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 * `tf.keras` is now part of the core TensorFlow API.
 * [`tf.data`](http://tensorflow.org/programmers_guide/datasets) is now part of
   the core TensorFlow API.
-  * The API is now subject to backwards compatibility guarantees.
+  * The API is now subject to backward compatibility guarantees.
   * For a guide to migrating from the `tf.contrib.data` API, see the
     [README](https://github.com/tensorflow/tensorflow/blob/r1.4/tensorflow/contrib/data/README.md).
   * Major new features include `Dataset.from_generator()` (for building an input

--- a/tensorflow/tools/api/tests/README.txt
+++ b/tensorflow/tools/api/tests/README.txt
@@ -1,4 +1,4 @@
-TensorFlow API backwards compatibility test
+TensorFlow API backward compatibility test
 This test ensures all changes to the public API of TensorFlow are intended.
 
 If this test fails, it means a change has been made to the public API. Backwards


### PR DESCRIPTION
The spelling of `backwards` is a non-American variant. For consistency, consider replacing it with the American English spelling.