### PR TITLE
Fix Jenkins build error (`//tensorflow/go:test`) on HEAD

### DIFF
--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -331,7 +331,7 @@ func encodeTensor(w *bytes.Buffer, v reflect.Value, shape []int64) error {
 		// Optimization: if only one dimension is left we can use binary.Write() directly for this slice
 		if len(shape) == 1 && v.Len() > 0 {
 			switch v.Index(0).Kind() {
-			case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
+			case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uint16, reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
 				return binary.Write(w, nativeEndian, v.Interface())
 			}
 		}


### PR DESCRIPTION
This fix fixes Jenkins build error of `//tensorflow/go:test` on HEAD introduced by #14368:

/cc @anight @asimshankar @martinwicke 

```
INFO: From Testing //tensorflow/go:test:
==================== Test output for //tensorflow/go:test:
...
...
--- FAIL: TestNewTensor (0.00s)
	tensor_test.go:112: NewTensor([5]): <nil>
	tensor_test.go:115: NewTensor([5]) = &{0x7f71f4009e80 [1]}, want nil
	tensor_test.go:112: NewTensor([5]): <nil>
	tensor_test.go:115: NewTensor([5]) = &{0x7f71f400af10 [1]}, want nil
FAIL
FAIL	github.com/tensorflow/tensorflow/tensorflow/go	0.392s
ok  	github.com/tensorflow/tensorflow/tensorflow/go/op	0.138s
================================================================================
```

The error was introduced by #14368 because Uint32 and Uint64 has not been supported by TensorFlow yet.

See Ln 74 of `tensorflow/go/tensor_test.go`
Compare Ln 334 and 316 of `tensorflow/go/tensor.go` before this PR.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>