### PR TITLE
added patch needed for jetson tx2/1

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
+++ b/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
@@ -866,6 +866,9 @@ static int TryToReadNumaNode(const string &pci_bus_id, int device_ordinal) {
 #elif defined(PLATFORM_WINDOWS)
   // Windows support for NUMA is not currently implemented. Return node 0.
   return 0;
+#elif defined(__aarch64__)
+  LOG(INFO) << "ARM64 does not support NUMA - returning NUMA node zero";
+  return 0;
 #else
   VLOG(2) << "trying to read NUMA node for device ordinal: " << device_ordinal;
   static const int kUnknownNumaNode = -1;


### PR DESCRIPTION
arm64 does not support NUMA, so TryToReadNumaNode in cuda_gpu_executor.cc has to be modified accordingly to avoid a failure at runtime. 

Currently everybody using a jetson board needs to apply this patch manually, which is a pain if you forget, because it fails at runtime, and not at build. This means that you compile for a couple of hours only to realize you should've done this first. 