### PR TITLE
Fix absl flag initialization in cloud_tpu_profiler

### DIFF
--- a/tensorflow/contrib/tpu/profiler/pip_package/cloud_tpu_profiler/main.py
+++ b/tensorflow/contrib/tpu/profiler/pip_package/cloud_tpu_profiler/main.py
@@ -24,22 +24,18 @@ import sys
 
 import tensorflow as tf
 
-
 tf.flags.DEFINE_string('service_addr', '',
                        'Address of TPU profiler service e.g. localhost:8466')
-
-
 tf.flags.DEFINE_string('logdir', '',
                        'Path of TensorBoard log directory e.g. /tmp/tb_log')
-
-
 tf.flags.DEFINE_integer('duration_ms', 2000, 'Duration of tracing in ms.')
 
-
 FLAGS = tf.flags.FLAGS
-
-
 EXECUTABLE = 'data/capture_tpu_profile'
+
+
+def run_main():
+  tf.app.run(main)
 
 
 def main(unused_argv=None):
@@ -54,4 +50,4 @@ def main(unused_argv=None):
 
 
 if __name__ == '__main__':
-  tf.app.run(main)
+  run_main()

--- a/tensorflow/contrib/tpu/profiler/pip_package/setup.py
+++ b/tensorflow/contrib/tpu/profiler/pip_package/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup
 _VERSION = '1.3.0-a1'
 
 CONSOLE_SCRIPTS = [
-    'capture_tpu_profile=cloud_tpu_profiler.main:main',
+    'capture_tpu_profile=cloud_tpu_profiler.main:run_main',
 ]
 
 REQUIRED_PACKAGES = [


### PR DESCRIPTION
This fixes a regression caused by 2652704b576adc16b4d735f651cea1024e88b72e where the command would not run. See also: tensorflow/tensorboard#716

This is caused by the PIP generated program wrapper not invoking the `tf.app.run` that normally goes in the `if __main__` clause of a script. That runner basically initializes flags. But as far as I can tell, this is the only pip console script in TensorFlow that still uses flags. The other two appear to have migrated to argparse. So this change should be sufficient.

CC: @nfelt @PrashantJalan @yifeif 