### PR TITLE
golang: ~2x speedup for encodeTensor()

### DIFF
--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -328,6 +328,14 @@ func encodeTensor(w *bytes.Buffer, v reflect.Value, shape []int64) error {
 			}
 		}
 
+		// Optimisation: if only one dimension is left we can use binary.Write() directly for this slice
+		if len(shape) == 1 && v.Len() > 0 {
+			switch v.Index(0).Kind() {
+			case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
+				return binary.Write(w, nativeEndian, v.Interface())
+			}
+		}
+
 		subShape := shape[1:]
 		for i := 0; i < v.Len(); i++ {
 			err := encodeTensor(w, v.Index(i), subShape)


### PR DESCRIPTION
This is duplicate of https://github.com/tensorflow/tensorflow/pull/14368, but now it can be merged safely because https://github.com/tensorflow/tensorflow/pull/14331 is merged.

CC: https://github.com/tensorflow/tensorflow/pull/14408

before:

$ go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/tensorflow/tensorflow/tensorflow/go
BenchmarkNewTensor/[150528]-8                200           6792809 ns/op
PASS
ok      github.com/tensorflow/tensorflow/tensorflow/go  2.116s

after:

$ go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/tensorflow/tensorflow/tensorflow/go
BenchmarkNewTensor/[150528]-8                500           3269740 ns/op
PASS
ok      github.com/tensorflow/tensorflow/tensorflow/go  2.021s

