### PR TITLE
PrefetchDataset with buffer_size==0 results in deadlock

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1604,6 +1604,7 @@ class PrefetchDataset(Dataset):
 
   def __init__(self, input_dataset, buffer_size):
     """See `Dataset.prefetch()` for details."""
+    assert buffer_size > 0, "The buffer_size ({}) has to be > 0.".format(buffer_size)
     super(PrefetchDataset, self).__init__()
     self._input_dataset = input_dataset
     self._buffer_size = ops.convert_to_tensor(buffer_size, dtype=dtypes.int64,


### PR DESCRIPTION
Hey, 

I experimented with `tf.data.Dataset.prefetch` and found that an assert inside the code is missing.
When `buffer_size` is zero, I got a deadlock.
Here is a toy example to reproduce my bug:

```python
import tensorflow as tf
def test(buffer_size):
    ds = tf.data.Dataset.range(5)
    ds = ds.prefetch(buffer_size=buffer_size)
    iterator = ds.make_one_shot_iterator()
    entry = iterator.get_next()
    with tf.Session() as sess:
        try:
            while True:
                print(sess.run(entry))
        except tf.errors.OutOfRangeError:
            pass
        
test(1)
test(0)  # deadlock
```
and here my tensorflow version
```bash
$ pip show tensorflow
Name: tensorflow
Version: 1.4.0
Summary: TensorFlow helps the tensors flow
Home-page: https://www.tensorflow.org/
Author: Google Inc.
Author-email: opensource@google.com
License: Apache 2.0
Location: .../lib/python3.6/site-packages
Requires: protobuf, numpy, wheel, tensorflow-tensorboard, absl-py, six, enum34
```
