### PR TITLE
Fix license declaration for Python headers

### DIFF
--- a/util/python/BUILD
+++ b/util/python/BUILD
@@ -1,4 +1,4 @@
-licenses(["restricted"])
+licenses(["notice"])  # New BSD, Python Software Foundation
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
This appears to be a legacy package so we might want to consider deleting it at some point too.

cc: @gunan 