### PR TITLE
Remove redundant code of slice_op.cc

### DIFF
--- a/tensorflow/core/kernels/slice_op.cc
+++ b/tensorflow/core/kernels/slice_op.cc
@@ -262,7 +262,6 @@ class MklSliceOp : public OpKernel {
       HANDLE_DIM(1);
       HANDLE_DIM(2);
       HANDLE_DIM(3);
-      HANDLE_DIM(4);
       HANDLE_DIM(5);
       HANDLE_DIM(6);
 


### PR DESCRIPTION
In `slice_op.cc` line 252, when `input_dims` is 4, it is handle as a special case. 

```
if (input_dims == 4) {
        HandleCase4D(context, begin, size, result);
} else {
      HANDLE_DIM(1);
      HANDLE_DIM(2);
      HANDLE_DIM(3);
      HANDLE_DIM(4); // Not necessary
      HANDLE_DIM(5);
      HANDLE_DIM(6);
}
````
So it is not necessary to handle the 4 case when `input_dims` is not  4.