### PR TITLE
Fixed incorrect documentation in tf.contrib.nn.deprecated_flipped_spa…

### DIFF
--- a/tensorflow/contrib/nn/python/ops/cross_entropy.py
+++ b/tensorflow/contrib/nn/python/ops/cross_entropy.py
@@ -116,7 +116,7 @@ def deprecated_flipped_sparse_softmax_cross_entropy_with_logits(logits,
 
   Raises:
     ValueError: If logits are scalars (need to have rank >= 1) or if the rank
-      of the labels is not equal to the rank of the labels minus one.
+      of the labels is not equal to the rank of the logits minus one.
   """
   return nn.sparse_softmax_cross_entropy_with_logits(
       labels=labels, logits=logits, name=name)


### PR DESCRIPTION
…rse_softmax_cross_entropy_with_logits where it referenced labels rather than logits.

I was looking to fix #14450, but was unable to because it seems the site documentation is not the same as the in file documentation in master (which is correct in that case). It seems someone fixed it in master but the change was not made to 1.4. However, incidentally I noticed this identical error on `tf.contrib.nn.deprecated_flipped_sparse_softmax_cross_entropy_with_logits`. In this case, the error is on both the in file documentation and the website documentation. 