### PR TITLE
use with when calling TFRecordWriter

### DIFF
--- a/tensorflow/examples/how_tos/reading_data/convert_to_records.py
+++ b/tensorflow/examples/how_tos/reading_data/convert_to_records.py
@@ -52,17 +52,16 @@ def convert_to(data_set, name):
 
   filename = os.path.join(FLAGS.directory, name + '.tfrecords')
   print('Writing', filename)
-  writer = tf.python_io.TFRecordWriter(filename)
-  for index in range(num_examples):
-    image_raw = images[index].tostring()
-    example = tf.train.Example(features=tf.train.Features(feature={
-        'height': _int64_feature(rows),
-        'width': _int64_feature(cols),
-        'depth': _int64_feature(depth),
-        'label': _int64_feature(int(labels[index])),
-        'image_raw': _bytes_feature(image_raw)}))
-    writer.write(example.SerializeToString())
-  writer.close()
+  with tf.python_io.TFRecordWriter(filename) as writer:
+    for index in range(num_examples):
+      image_raw = images[index].tostring()
+      example = tf.train.Example(features=tf.train.Features(feature={
+          'height': _int64_feature(rows),
+          'width': _int64_feature(cols),
+          'depth': _int64_feature(depth),
+          'label': _int64_feature(int(labels[index])),
+          'image_raw': _bytes_feature(image_raw)}))
+      writer.write(example.SerializeToString())
 
 
 def main(unused_argv):


### PR DESCRIPTION
TFRecordWriter supports __enter__ and __exit__ . 
Calling it through with is more pythonic and does cleanup in case something throws an uncaught exception.