### PR TITLE
fix assert_shallow_structure for dicts

### DIFF
--- a/tensorflow/python/data/util/nest.py
+++ b/tensorflow/python/data/util/nest.py
@@ -367,6 +367,16 @@ def assert_shallow_structure(shallow_tree, input_tree, check_types=True):
           "structure has length %s, while shallow structure has length %s."
           % (len(input_tree), len(shallow_tree)))
 
+    if check_types and isinstance(shallow_tree, dict):
+      if set(input_tree) != set(shallow_tree):
+        raise ValueError(
+          "The two structures don't have the same keys. Input "
+          "structure has keys %s, while shallow structure has keys %s."
+          % (list(_six.iterkeys(input_tree)),
+             list(_six.iterkeys(shallow_tree))))
+      input_tree = list(_six.iteritems(input_tree))
+      shallow_tree = list(_six.iteritems(shallow_tree))
+
     for shallow_branch, input_branch in zip(shallow_tree, input_tree):
       assert_shallow_structure(shallow_branch, input_branch,
                                check_types=check_types)

--- a/tensorflow/python/data/util/nest_test.py
+++ b/tensorflow/python/data/util/nest_test.py
@@ -254,6 +254,14 @@ class NestTest(test.TestCase):
       nest.assert_shallow_structure(inp_ab2, inp_ab1)
     nest.assert_shallow_structure(inp_ab2, inp_ab1, check_types=False)
 
+    inp_ab1 = {"a": (1, 1), "b": {"c": (2, 2)}}
+    inp_ab2 = {"a": (1, 1), "b": {"d": (2, 2)}}
+    expected_message = (
+        "The two structures don't have the same keys. Input "
+        "structure has keys \['c'\], while shallow structure has keys \['d'\].")
+    with self.assertRaisesRegexp(ValueError, expected_message):
+      nest.assert_shallow_structure(inp_ab2, inp_ab1)
+
   def testFlattenUpTo(self):
     input_tree = (((2, 2), (3, 3)), ((4, 9), (5, 5)))
     shallow_tree = ((True, True), (False, True))

--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -452,6 +452,17 @@ def assert_shallow_structure(shallow_tree, input_tree, check_types=True):
           "structure has length %s, while shallow structure has length %s."
           % (len(input_tree), len(shallow_tree)))
 
+    if check_types and isinstance(shallow_tree, dict):
+      if set(input_tree) != set(shallow_tree):
+        raise ValueError(
+            "The two structures don't have the same keys. Input "
+            "structure has keys %s, while shallow structure has keys %s."
+            % (list(_six.iterkeys(input_tree)),
+               list(_six.iterkeys(shallow_tree))))
+
+      input_tree = list(_six.iteritems(input_tree))
+      shallow_tree = list(_six.iteritems(shallow_tree))
+
     for shallow_branch, input_branch in zip(shallow_tree, input_tree):
       assert_shallow_structure(shallow_branch, input_branch,
                                check_types=check_types)

--- a/tensorflow/python/util/nest_test.py
+++ b/tensorflow/python/util/nest_test.py
@@ -439,7 +439,7 @@ class NestTest(test.TestCase):
                                                               input_tree)
     self.assertEqual(input_tree_flattened_as_shallow_tree, [0, 1, 2, 3, 4])
     shallow_tree = collections.OrderedDict([("a", 0),
-                                            ("b", {"d": 3, "e": 1})])
+                                            ("c", {"d": 3, "e": 1})])
     input_tree_flattened_as_shallow_tree = nest.flatten_up_to(shallow_tree,
                                                               input_tree)
     self.assertEqual(input_tree_flattened_as_shallow_tree,

--- a/tensorflow/python/util/nest_test.py
+++ b/tensorflow/python/util/nest_test.py
@@ -385,6 +385,15 @@ class NestTest(test.TestCase):
       nest.assert_shallow_structure(inp_ab2, inp_ab1)
     nest.assert_shallow_structure(inp_ab2, inp_ab1, check_types=False)
 
+    inp_ab1 = {"a": (1, 1), "b": {"c": (2, 2)}}
+    inp_ab2 = {"a": (1, 1), "b": {"d": (2, 2)}}
+    expected_message = (
+        "The two structures don't have the same keys. Input "
+        "structure has keys \['c'\], while shallow structure has keys \['d'\].")
+
+    with self.assertRaisesRegexp(ValueError, expected_message):
+      nest.assert_shallow_structure(inp_ab2, inp_ab1)
+
   def testFlattenUpTo(self):
     # Shallow tree ends at scalar.
     input_tree = [[[2, 2], [3, 3]], [[4, 9], [5, 5]]]


### PR DESCRIPTION
The function `tensorflow.python.data.util.nest.flatten_up_to` used in `tf.data.Dataset.from_generator` does not compare the dict keys (only the length of the dict)
```python
tf_tree = dict(A=tf.placeholder(tf.float32), B=tf.placeholder(tf.float64))
np_tree = dict(A=np.zeros([1], np.float32), C=np.zeros([2], np.float64))
nest.flatten_up_to(tf_tree, np_tree)  # Fails now
```
and ignores nested dict's (Bug, iterate over keys in `tensorflow.python.data.util.assert_shallow_structure`)
```python
tf_tree = dict(A=tf.placeholder(tf.float32), B=dict(C=tf.placeholder(tf.float64)))
np_tree = dict(A=np.zeros([1], np.float32), B=dict(D=np.zeros([2], np.float64)))
nest.flatten_up_to(tf_tree, np_tree)  # Fails now
```

This PR fix `tensorflow.python.data.util.assert_shallow_structure` that is used in `tensorflow.python.data.util.nest.flatten_up_to`, but there may also other function that have such a bug.