### PR TITLE
Correct space in ValueError for input rank

### DIFF
--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -1233,7 +1233,7 @@ class Conv2DTranspose(Conv2D):
     if len(input_shape) != 4:
       raise ValueError('Inputs should have rank ' +
                        str(4) +
-                       'Received input shape:', str(input_shape))
+                       '. Received input shape:', str(input_shape))
     if self.data_format == 'channels_first':
       channel_axis = 1
     else:


### PR DESCRIPTION
The current error message is `ValueError: ('Inputs should have rank 4Received input shape:', '(?, n)')` where a space is missing, so the change would result in `ValueError: ('Inputs should have rank 4. Received input shape:', '(?, n)')`