### PR TITLE
Add missing tf_copts calls

### DIFF
--- a/tensorflow/cc/BUILD
+++ b/tensorflow/cc/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "framework/while_gradients.h",
     ],
     hdrs = ["framework/gradients.h"],
+    copts = tf_copts(),
     deps = [
         ":cc_ops",
         ":cc_ops_internal",
@@ -86,6 +87,7 @@ cc_library(
     name = "gradient_checker",
     srcs = ["framework/gradient_checker.cc"],
     hdrs = ["framework/gradient_checker.h"],
+    copts = tf_copts(),
     deps = [
         ":cc_ops",
         ":client_session",
@@ -118,6 +120,7 @@ tf_cc_test(
 
 cc_library(
     name = "grad_ops",
+    copts = tf_copts(),
     deps = [
         ":array_grad",
         ":data_flow_grad",
@@ -131,6 +134,7 @@ cc_library(
     testonly = 1,
     srcs = ["gradients/grad_testutil.cc"],
     hdrs = ["gradients/grad_testutil.h"],
+    copts = tf_copts(),
     deps = [
         ":grad_op_registry",
         ":ops",
@@ -295,6 +299,7 @@ cc_library(
     name = "grad_op_registry",
     srcs = ["framework/grad_op_registry.cc"],
     hdrs = ["framework/grad_op_registry.h"],
+    copts = tf_copts(),
     deps = [
         ":ops",
         ":scope",
@@ -304,6 +309,7 @@ cc_library(
 cc_library(
     name = "array_grad",
     srcs = ["gradients/array_grad.cc"],
+    copts = tf_copts(),
     deps = [
         ":cc_ops",
         ":cc_ops_internal",
@@ -334,6 +340,7 @@ tf_cc_test(
 cc_library(
     name = "math_grad",
     srcs = ["gradients/math_grad.cc"],
+    copts = tf_copts(),
     deps = [
         ":cc_ops",
         ":cc_ops_internal",
@@ -363,6 +370,7 @@ tf_cc_test(
 cc_library(
     name = "nn_grad",
     srcs = ["gradients/nn_grad.cc"],
+    copts = tf_copts(),
     deps = [
         ":cc_ops",
         ":cc_ops_internal",
@@ -392,6 +400,7 @@ tf_cc_test(
 cc_library(
     name = "data_flow_grad",
     srcs = ["gradients/data_flow_grad.cc"],
+    copts = tf_copts(),
     deps = [
         ":cc_ops",
         ":cc_ops_internal",
@@ -566,6 +575,7 @@ tf_cc_test(
 cc_library(
     name = "test_op_op_lib",
     srcs = ["framework/test_op.cc"],
+    copts = tf_copts(),
     linkstatic = 1,
     deps = ["//tensorflow/core:framework"],
     alwayslink = 1,
@@ -576,6 +586,7 @@ cc_library(
     testonly = 1,
     srcs = ["framework/testutil.cc"],
     hdrs = ["framework/testutil.h"],
+    copts = tf_copts(),
     deps = [
         ":client_session",
         ":ops",
@@ -641,6 +652,7 @@ cc_library(
     name = "queue_runner",
     srcs = ["training/queue_runner.cc"],
     hdrs = ["training/queue_runner.h"],
+    copts = tf_copts(),
     deps = [
         ":coordinator",
         "//tensorflow/core:core_cpu",
@@ -675,6 +687,7 @@ cc_library(
     name = "coordinator",
     srcs = ["training/coordinator.cc"],
     hdrs = ["training/coordinator.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",

--- a/tensorflow/contrib/android/BUILD
+++ b/tensorflow/contrib/android/BUILD
@@ -29,7 +29,7 @@ filegroup(
 cc_library(
     name = "android_tensorflow_inference_jni",
     srcs = if_android([":android_tensorflow_inference_jni_srcs"]),
-    copts = tf_copts(),
+    copts = tf_copts(is_external = True),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:android_tensorflow_lib_lite",
@@ -72,7 +72,7 @@ LINKER_SCRIPT = "//tensorflow/contrib/android:jni/version_script.lds"
 cc_binary(
     name = "libtensorflow_inference.so",
     srcs = [],
-    copts = tf_copts() + [
+    copts = tf_copts(is_external = True) + [
         "-ffunction-sections",
         "-fdata-sections",
     ],

--- a/tensorflow/contrib/batching/BUILD
+++ b/tensorflow/contrib/batching/BUILD
@@ -156,6 +156,7 @@ tf_gen_op_wrapper_py(
 
 tf_kernel_library(
     name = "batch_ops_kernels",
+    is_external = True,
     deps = [
         "//tensorflow/contrib/batching/kernels:batch_kernels",
         "//tensorflow/contrib/batching/util:periodic_function",

--- a/tensorflow/contrib/boosted_trees/BUILD
+++ b/tensorflow/contrib/boosted_trees/BUILD
@@ -332,6 +332,7 @@ tf_custom_op_py_library(
 tf_kernel_library(
     name = "model_ops_kernels",
     srcs = ["kernels/model_ops.cc"],
+    is_external = True,
     deps = [
         "//tensorflow/contrib/boosted_trees/lib:utils",
         "//tensorflow/contrib/boosted_trees/resources:decision_tree_ensemble_resource",
@@ -403,6 +404,7 @@ tf_custom_op_py_library(
 tf_kernel_library(
     name = "split_handler_ops_kernels",
     srcs = ["kernels/split_handler_ops.cc"],
+    is_external = True,
     deps = [
         "//tensorflow/contrib/boosted_trees/lib:node-stats",
         "//tensorflow/contrib/boosted_trees/proto:split_info_proto_cc",
@@ -447,6 +449,7 @@ tf_custom_op_py_library(
 tf_kernel_library(
     name = "training_ops_kernels",
     srcs = ["kernels/training_ops.cc"],
+    is_external = True,
     deps = [
         "//tensorflow/contrib/boosted_trees/lib:utils",
         "//tensorflow/contrib/boosted_trees/lib:weighted_quantiles",
@@ -493,6 +496,7 @@ tf_custom_op_py_library(
 tf_kernel_library(
     name = "prediction_ops_kernels",
     srcs = ["kernels/prediction_ops.cc"],
+    is_external = True,
     deps = [
         "//tensorflow/contrib/boosted_trees/lib:example_partitioner",
         "//tensorflow/contrib/boosted_trees/lib:models",
@@ -541,6 +545,7 @@ tf_custom_op_py_library(
 tf_kernel_library(
     name = "quantile_ops_kernels",
     srcs = ["kernels/quantile_ops.cc"],
+    is_external = True,
     deps = [
         "//tensorflow/contrib/boosted_trees/lib:utils",
         "//tensorflow/contrib/boosted_trees/lib:weighted_quantiles",
@@ -585,6 +590,7 @@ tf_custom_op_py_library(
 tf_kernel_library(
     name = "stats_accumulator_ops_kernels",
     srcs = ["kernels/stats_accumulator_ops.cc"],
+    is_external = True,
     deps = [
         "//tensorflow/contrib/boosted_trees/lib:utils",
         "//tensorflow/contrib/boosted_trees/resources:stamped_resource",

--- a/tensorflow/contrib/boosted_trees/lib/BUILD
+++ b/tensorflow/contrib/boosted_trees/lib/BUILD
@@ -50,6 +50,7 @@ cc_library(
         "utils/sparse_column_iterable.h",
         "utils/tensor_utils.h",
     ],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/contrib/boosted_trees/proto:learner_proto_cc",
         "//tensorflow/core:framework_headers_lib",
@@ -126,6 +127,7 @@ cc_library(
     name = "models",
     srcs = ["models/multiple_additive_trees.cc"],
     hdrs = ["models/multiple_additive_trees.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":trees",
         ":utils",
@@ -157,6 +159,7 @@ cc_library(
     testonly = 1,
     srcs = ["testutil/batch_features_testutil.cc"],
     hdrs = ["testutil/batch_features_testutil.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":utils",
         "//tensorflow/core:framework_headers_lib",
@@ -169,6 +172,7 @@ cc_library(
     name = "random_tree_gen",
     srcs = ["testutil/random_tree_gen.cc"],
     hdrs = ["testutil/random_tree_gen.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/contrib/boosted_trees/proto:tree_config_proto_cc",
         "//tensorflow/core:lib",
@@ -195,6 +199,7 @@ cc_library(
         "quantiles/weighted_quantiles_stream.h",
         "quantiles/weighted_quantiles_summary.h",
     ],
+    copts = tf_copts(is_external = True),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework_headers_lib",
@@ -243,6 +248,7 @@ cc_library(
     name = "trees",
     srcs = ["trees/decision_tree.cc"],
     hdrs = ["trees/decision_tree.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/contrib/boosted_trees/lib:utils",
         "//tensorflow/contrib/boosted_trees/proto:tree_config_proto_cc",
@@ -356,6 +362,7 @@ py_test(
 cc_library(
     name = "class-partition-key",
     hdrs = ["learner/common/accumulators/class-partition-key.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
     ],
@@ -364,6 +371,7 @@ cc_library(
 cc_library(
     name = "feature-stats-accumulator",
     hdrs = ["learner/common/accumulators/feature-stats-accumulator.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":class-partition-key",
     ],
@@ -386,6 +394,7 @@ cc_library(
     name = "example_partitioner",
     srcs = ["learner/common/partitioners/example_partitioner.cc"],
     hdrs = ["learner/common/partitioners/example_partitioner.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/contrib/boosted_trees/lib:trees",
         "//tensorflow/contrib/boosted_trees/lib:utils",
@@ -409,6 +418,7 @@ tf_cc_test(
 cc_library(
     name = "gradient-stats",
     hdrs = ["learner/common/stats/gradient-stats.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
@@ -418,6 +428,7 @@ cc_library(
 cc_library(
     name = "node-stats",
     hdrs = ["learner/common/stats/node-stats.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":gradient-stats",
         "//tensorflow/contrib/boosted_trees/proto:learner_proto_cc",
@@ -430,6 +441,7 @@ cc_library(
 cc_library(
     name = "split-stats",
     hdrs = ["learner/common/stats/split-stats.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":node-stats",
     ],
@@ -438,6 +450,7 @@ cc_library(
 cc_library(
     name = "feature-split-candidate",
     hdrs = ["learner/common/stats/feature-split-candidate.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":split-stats",
         "//tensorflow/contrib/boosted_trees/proto:tree_config_proto_cc",

--- a/tensorflow/contrib/cloud/kernels/BUILD
+++ b/tensorflow/contrib/cloud/kernels/BUILD
@@ -37,6 +37,7 @@ filegroup(
 tf_kernel_library(
     name = "bigquery_reader_ops",
     srcs = ["bigquery_reader_ops.cc"],
+    is_external = True,
     visibility = ["//visibility:public"],
     deps = [
         ":bigquery_table_accessor",
@@ -52,7 +53,7 @@ cc_library(
     name = "bigquery_table_accessor",
     srcs = ["bigquery_table_accessor.cc"],
     hdrs = ["bigquery_table_accessor.h"],
-    copts = tf_copts(),
+    copts = tf_copts(is_external = True),
     linkstatic = 1,
     deps = [
         ":bigquery_table_partition_proto_cc",

--- a/tensorflow/contrib/cudnn_rnn/BUILD
+++ b/tensorflow/contrib/cudnn_rnn/BUILD
@@ -31,6 +31,7 @@ tf_custom_op_library(
 tf_kernel_library(
     name = "cudnn_rnn_kernels",
     srcs = ["kernels/cudnn_rnn_ops.cc"],
+    is_external = True,
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/data/python/ops/BUILD
+++ b/tensorflow/contrib/data/python/ops/BUILD
@@ -135,6 +135,7 @@ tf_gen_op_wrapper_py(
 
 tf_kernel_library(
     name = "prefetching_ops_kernels",
+    is_external = True,
     deps = [
         "//tensorflow/contrib/data/kernels:prefetching_kernels",
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/factorization/kernels/BUILD
+++ b/tensorflow/contrib/factorization/kernels/BUILD
@@ -7,9 +7,11 @@ exports_files(["LICENSE"])
 package(default_visibility = ["//tensorflow:__subpackages__"])
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 cc_library(
     name = "all_kernels",
+    copts = tf_copts(is_external = True),
     deps = [
         ":clustering_ops",
         ":masked_matmul_ops",
@@ -21,6 +23,7 @@ cc_library(
 cc_library(
     name = "wals_solver_ops",
     srcs = ["wals_solver_ops.cc"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
@@ -32,6 +35,7 @@ cc_library(
 cc_library(
     name = "clustering_ops",
     srcs = ["clustering_ops.cc"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
@@ -43,6 +47,7 @@ cc_library(
 cc_library(
     name = "masked_matmul_ops",
     srcs = ["masked_matmul_ops.cc"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//tensorflow/core/kernels:bounds_check",

--- a/tensorflow/contrib/ffmpeg/BUILD
+++ b/tensorflow/contrib/ffmpeg/BUILD
@@ -22,7 +22,7 @@ exports_files(["ffmpeg_lib.h"])
 cc_library(
     name = "decode_audio_op_cc",
     srcs = ["decode_audio_op.cc"],
-    copts = tf_copts(),
+    copts = tf_copts(is_external = True),
     linkstatic = 1,
     visibility = ["//visibility:private"],
     deps = [
@@ -36,7 +36,7 @@ cc_library(
 cc_library(
     name = "encode_audio_op_cc",
     srcs = ["encode_audio_op.cc"],
-    copts = tf_copts(),
+    copts = tf_copts(is_external = True),
     linkstatic = 1,
     visibility = ["//visibility:private"],
     deps = [
@@ -50,7 +50,7 @@ cc_library(
 cc_library(
     name = "decode_video_op_cc",
     srcs = ["decode_video_op.cc"],
-    copts = tf_copts(),
+    copts = tf_copts(is_external = True),
     linkstatic = 1,
     visibility = ["//visibility:private"],
     deps = [

--- a/tensorflow/contrib/framework/BUILD
+++ b/tensorflow/contrib/framework/BUILD
@@ -85,6 +85,7 @@ tf_kernel_library(
         "kernels/zero_initializer_op_gpu.cu.cc",
         "kernels/zero_initializer_op.h",
     ],
+    is_external = True,
     deps = [
         "//tensorflow/core:framework",
         "//third_party/eigen3",

--- a/tensorflow/contrib/fused_conv/BUILD
+++ b/tensorflow/contrib/fused_conv/BUILD
@@ -62,6 +62,7 @@ tf_kernel_library(
         "kernels/fused_conv2d_bias_activation_op.h",
         "kernels/fused_conv_ops_gpu.h",
     ],
+    is_external = True,
     prefix = "fused_conv2d_bias_activation_op",
     visibility = ["//visibility:public"],
     deps = [

--- a/tensorflow/contrib/hvx/clock_cycle_profiling/BUILD
+++ b/tensorflow/contrib/hvx/clock_cycle_profiling/BUILD
@@ -29,7 +29,7 @@ tf_cc_binary(
     name = "clock_cycle_profiling",
     testonly = 1,
     srcs = ["clock_cycle_profiling_main.cc"],
-    copts = tf_copts(),
+    copts = tf_copts(is_external = True),
     linkopts = select({
         "//tensorflow:android": [
             "-pie",

--- a/tensorflow/contrib/image/BUILD
+++ b/tensorflow/contrib/image/BUILD
@@ -43,6 +43,7 @@ tf_kernel_library(
         "kernels/image_ops_gpu.cu.cc",
         "kernels/image_ops.h",
     ],
+    is_external = True,
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",

--- a/tensorflow/contrib/input_pipeline/BUILD
+++ b/tensorflow/contrib/input_pipeline/BUILD
@@ -45,6 +45,7 @@ tf_gen_op_wrapper_py(
 
 tf_kernel_library(
     name = "input_pipeline_ops_kernels",
+    is_external = True,
     deps = [
         "//tensorflow/contrib/input_pipeline/kernels:input_pipeline_kernels",
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/input_pipeline/kernels/BUILD
+++ b/tensorflow/contrib/input_pipeline/kernels/BUILD
@@ -5,11 +5,14 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+load("//tensorflow:tensorflow.bzl", "tf_copts")
+
 package(default_visibility = ["//tensorflow:__subpackages__"])
 
 cc_library(
     name = "input_pipeline_kernels",
     srcs = ["input_pipeline_kernels.cc"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",

--- a/tensorflow/contrib/layers/BUILD
+++ b/tensorflow/contrib/layers/BUILD
@@ -40,6 +40,7 @@ tf_gen_op_wrapper_py(
 
 tf_kernel_library(
     name = "sparse_feature_cross_op_kernel",
+    is_external = True,
     deps = [
         "//tensorflow/contrib/layers/kernels:sparse_feature_cross_kernel",
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/layers/kernels/BUILD
+++ b/tensorflow/contrib/layers/kernels/BUILD
@@ -5,11 +5,14 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+load("//tensorflow:tensorflow.bzl", "tf_copts")
+
 package(default_visibility = ["//tensorflow:__subpackages__"])
 
 cc_library(
     name = "sparse_feature_cross_kernel",
     srcs = ["sparse_feature_cross_kernel.cc"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",

--- a/tensorflow/contrib/memory_stats/BUILD
+++ b/tensorflow/contrib/memory_stats/BUILD
@@ -27,6 +27,7 @@ tf_kernel_library(
     srcs = [
         "kernels/memory_stats_ops.cc",
     ],
+    is_external = True,
     deps = [
         "//tensorflow/core:framework",
     ],

--- a/tensorflow/contrib/nccl/BUILD
+++ b/tensorflow/contrib/nccl/BUILD
@@ -73,6 +73,7 @@ tf_kernel_library(
         "kernels/nccl_ops.cc",
         "kernels/nccl_rewrite.cc",
     ],
+    is_external = True,
     deps = [
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/nearest_neighbor/BUILD
+++ b/tensorflow/contrib/nearest_neighbor/BUILD
@@ -55,6 +55,7 @@ tf_custom_op_py_library(
 tf_kernel_library(
     name = "nearest_neighbor_ops_kernels",
     srcs = ["kernels/hyperplane_lsh_probes.cc"],
+    is_external = True,
     deps = [
         ":hyperplane_lsh_probes",
         ":nearest_neighbor_ops_op_lib",

--- a/tensorflow/contrib/reduce_slice_ops/BUILD
+++ b/tensorflow/contrib/reduce_slice_ops/BUILD
@@ -36,6 +36,7 @@ tf_kernel_library(
         "kernels/reduce_slice_ops.h",
         "kernels/reduce_slice_ops_gpu.cu.cc",
     ],
+    is_external = True,
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",

--- a/tensorflow/contrib/resampler/BUILD
+++ b/tensorflow/contrib/resampler/BUILD
@@ -40,6 +40,7 @@ tf_custom_op_py_library(
 
 tf_kernel_library(
     name = "resampler_ops_kernels",
+    is_external = True,
     prefix = "resampler_ops",
     deps = [
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/rnn/BUILD
+++ b/tensorflow/contrib/rnn/BUILD
@@ -350,6 +350,7 @@ tf_kernel_library(
     gpu_srcs = [
         "kernels/blas_gemm.h",
     ],
+    is_external = True,
     prefix = "kernels/gru_ops",
     deps = [
         "//tensorflow/core:framework",
@@ -368,6 +369,7 @@ tf_kernel_library(
     gpu_srcs = [
         "kernels/blas_gemm.h",
     ],
+    is_external = True,
     prefix = "kernels/lstm_ops",
     deps = [
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/seq2seq/BUILD
+++ b/tensorflow/contrib/seq2seq/BUILD
@@ -90,6 +90,7 @@ tf_gen_op_libs(
 
 tf_kernel_library(
     name = "beam_search_ops_kernels",
+    is_external = True,
     prefix = "kernels/beam_search_ops",
     deps = [
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/tensor_forest/BUILD
+++ b/tensorflow/contrib/tensor_forest/BUILD
@@ -124,6 +124,7 @@ py_library(
 tf_kernel_library(
     name = "tensor_forest_kernels",
     srcs = [":v2_op_sources"],
+    is_external = True,
     deps = [
         ":tree_utils",
         "//tensorflow/core:framework_headers_lib",
@@ -233,6 +234,7 @@ tf_gen_op_wrapper_py(
 
 tf_kernel_library(
     name = "model_ops_kernels",
+    is_external = True,
     deps = [
         ":model_ops_lib",
         "//tensorflow/core:framework",
@@ -329,6 +331,7 @@ tf_gen_op_wrapper_py(
 
 tf_kernel_library(
     name = "stats_ops_kernels",
+    is_external = True,
     deps = [
         ":stats_ops_lib",
         "//tensorflow/core:framework",

--- a/tensorflow/contrib/tensor_forest/hybrid/BUILD
+++ b/tensorflow/contrib/tensor_forest/hybrid/BUILD
@@ -3,6 +3,7 @@
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "py_test")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
@@ -48,6 +49,7 @@ cc_library(
         "core/ops/stochastic_hard_routing_gradient_op.cc",
         "core/ops/unpack_path_op.cc",
     ],
+    copts = tf_copts(is_external = True),
     deps = [
         ":utils",
         "//tensorflow/contrib/tensor_forest:tree_utils",
@@ -85,6 +87,7 @@ cc_library(
     name = "utils",
     srcs = ["core/ops/utils.cc"],
     hdrs = ["core/ops/utils.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",

--- a/tensorflow/contrib/tensor_forest/kernels/v4/BUILD
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/BUILD
@@ -1,6 +1,7 @@
 # TensorFlow code for training random forests.
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 load("//tensorflow/core:platform/default/build_config_root.bzl", "if_static")
 
 package(
@@ -35,6 +36,7 @@ DECISION_TREE_RESOURCE_DEPS = [
 cc_library(
     name = "decision-tree-resource",
     hdrs = ["decision-tree-resource.h"],
+    copts = tf_copts(is_external = True),
     deps = DECISION_TREE_RESOURCE_DEPS + if_static([":decision-tree-resource_impl"]),
 )
 
@@ -42,6 +44,7 @@ cc_library(
     name = "decision-tree-resource_impl",
     srcs = ["decision-tree-resource.cc"],
     hdrs = ["decision-tree-resource.h"],
+    copts = tf_copts(is_external = True),
     deps = DECISION_TREE_RESOURCE_DEPS,
 )
 
@@ -49,6 +52,7 @@ cc_library(
     name = "fertile-stats-resource",
     srcs = ["fertile-stats-resource.cc"],
     hdrs = ["fertile-stats-resource.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":decision_node_evaluator",
         ":input_data",
@@ -74,6 +78,7 @@ cc_library(
     name = "input_data",
     srcs = ["input_data.cc"],
     hdrs = ["input_data.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/contrib/tensor_forest:tree_utils",
         "//tensorflow/core:framework_headers_lib",
@@ -92,6 +97,7 @@ cc_library(
 cc_library(
     name = "input_target",
     hdrs = ["input_target.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
@@ -102,6 +108,7 @@ cc_library(
     name = "leaf_model_operators",
     srcs = ["leaf_model_operators.cc"],
     hdrs = ["leaf_model_operators.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":input_target",
         ":params",
@@ -140,6 +147,7 @@ cc_library(
     name = "grow_stats",
     srcs = ["grow_stats.cc"],
     hdrs = ["grow_stats.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":decision_node_evaluator",
         ":input_data",
@@ -183,6 +191,7 @@ cc_library(
     name = "candidate_graph_runner",
     srcs = ["candidate_graph_runner.cc"],
     hdrs = ["candidate_graph_runner.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":input_data",
         ":input_target",
@@ -206,6 +215,7 @@ cc_library(
     name = "decision_node_evaluator",
     srcs = ["decision_node_evaluator.cc"],
     hdrs = ["decision_node_evaluator.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":input_data",
         "//tensorflow/core:framework_headers_lib",
@@ -239,6 +249,7 @@ cc_library(
     name = "split_collection_operators",
     srcs = ["split_collection_operators.cc"],
     hdrs = ["split_collection_operators.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":grow_stats",
         ":input_data",
@@ -267,6 +278,7 @@ cc_library(
     name = "graph_collection_operator",
     srcs = ["graph_collection_operator.cc"],
     hdrs = ["graph_collection_operator.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":candidate_graph_runner",
         ":grow_stats",
@@ -294,6 +306,7 @@ cc_library(
     name = "stat_utils",
     srcs = ["stat_utils.cc"],
     hdrs = ["stat_utils.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
     ] + if_static(
@@ -311,6 +324,7 @@ cc_library(
 cc_library(
     name = "test_utils",
     hdrs = ["test_utils.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         ":input_data",
         ":input_target",
@@ -321,6 +335,7 @@ cc_library(
     name = "params",
     srcs = ["params.cc"],
     hdrs = ["params.h"],
+    copts = tf_copts(is_external = True),
     deps = [
         "//tensorflow/core:framework_headers_lib",
     ] + if_static(

--- a/tensorflow/contrib/text/BUILD
+++ b/tensorflow/contrib/text/BUILD
@@ -57,6 +57,7 @@ tf_custom_op_py_library(
 tf_kernel_library(
     name = "skip_gram_kernels",
     srcs = ["kernels/skip_gram_kernels.cc"],
+    is_external = True,
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -356,6 +356,7 @@ cc_library(
         "platform/types.h",
         "platform/windows/cpu_info.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":lib_internal",
@@ -503,6 +504,7 @@ cc_library(
     name = "reader_base",
     srcs = ["framework/reader_base.cc"],
     hdrs = ["framework/reader_base.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":framework",
@@ -523,6 +525,7 @@ cc_library(
     name = "op_gen_lib",
     srcs = ["framework/op_gen_lib.cc"],
     hdrs = ["framework/op_gen_lib.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":lib",
@@ -563,6 +566,7 @@ cc_library(
         "platform/thread_annotations.h",
         "platform/types.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps =
         [
@@ -644,6 +648,7 @@ cc_library(
 cc_library(
     name = "word2vec_ops",
     srcs = ["ops/word2vec_ops.cc"],
+    copts = tf_copts(),
     linkstatic = 1,
     visibility = ["//tensorflow:internal"],
     deps = ["//tensorflow/core:framework"],
@@ -652,6 +657,7 @@ cc_library(
 
 cc_library(
     name = "ops",
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":array_ops_op_lib",
@@ -696,6 +702,7 @@ cc_library(
 cc_library(
     name = "array_grad",
     srcs = ["ops/array_grad.cc"],
+    copts = tf_copts(),
     linkstatic = 1,  # Needed since alwayslink is broken in bazel b/27630669
     visibility = ["//visibility:public"],
     deps = [
@@ -709,6 +716,7 @@ cc_library(
 cc_library(
     name = "functional_grad",
     srcs = ["ops/functional_grad.cc"],
+    copts = tf_copts(),
     linkstatic = 1,  # Needed since alwayslink is broken in bazel b/27630669
     visibility = ["//visibility:public"],
     deps = [
@@ -725,6 +733,7 @@ cc_library(
         "ops/math_grad.cc",
         "ops/random_grad.cc",
     ],
+    copts = tf_copts(),
     linkstatic = 1,  # Needed since alwayslink is broken in bazel b/27630669
     visibility = ["//visibility:public"],
     deps = [
@@ -738,6 +747,7 @@ cc_library(
 cc_library(
     name = "nn_grad",
     srcs = ["ops/nn_grad.cc"],
+    copts = tf_copts(),
     linkstatic = 1,  # Needed since alwayslink is broken in bazel b/27630669
     visibility = ["//visibility:public"],
     deps = [

--- a/tensorflow/core/distributed_runtime/BUILD
+++ b/tensorflow/core/distributed_runtime/BUILD
@@ -50,6 +50,7 @@ cc_library(
     name = "partial_run_mgr",
     srcs = ["partial_run_mgr.cc"],
     hdrs = ["partial_run_mgr.h"],
+    copts = tf_copts(),
     deps = [
         ":worker_interface",
         "//tensorflow/core:framework",
@@ -73,6 +74,7 @@ cc_library(
     name = "message_wrappers",
     srcs = ["message_wrappers.cc"],
     hdrs = ["message_wrappers.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:master_proto_cc",
@@ -105,6 +107,7 @@ cc_library(
         "cluster_function_library_runtime.h",
         "worker_session.h",
     ],
+    copts = tf_copts(),
     deps = [
         ":graph_mgr",
         ":worker_cache",
@@ -138,6 +141,7 @@ cc_library(
     name = "session_mgr",
     srcs = ["session_mgr.cc"],
     hdrs = ["session_mgr.h"],
+    copts = tf_copts(),
     deps = [
         ":graph_mgr",
         ":worker_cache_wrapper",
@@ -164,6 +168,7 @@ tf_cc_test(
 cc_library(
     name = "worker_env",
     hdrs = ["worker_env.h"],
+    copts = tf_copts(),
     deps = ["//tensorflow/core:lib"],
 )
 
@@ -173,6 +178,7 @@ cc_library(
     hdrs = [
         "tensor_coding.h",
     ],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:framework",
@@ -187,6 +193,7 @@ cc_library(
     hdrs = [
         "worker_interface.h",
     ],
+    copts = tf_copts(),
     deps = [
         ":call_options",
         ":message_wrappers",
@@ -202,6 +209,7 @@ cc_library(
     hdrs = [
         "worker.h",
     ],
+    copts = tf_copts(),
     deps = [
         ":graph_mgr",
         ":partial_run_mgr",
@@ -219,6 +227,7 @@ cc_library(
     name = "call_options",
     srcs = ["call_options.cc"],
     hdrs = ["call_options.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:lib",
     ],
@@ -257,6 +266,7 @@ tf_cc_test(
 cc_library(
     name = "worker_cache",
     hdrs = ["worker_cache.h"],
+    copts = tf_copts(),
     deps = [
         ":worker_interface",
         "//tensorflow/core:lib",
@@ -267,6 +277,7 @@ cc_library(
 cc_library(
     name = "worker_cache_wrapper",
     hdrs = ["worker_cache_wrapper.h"],
+    copts = tf_copts(),
     deps = [
         ":worker_cache",
         "//tensorflow/core:lib",
@@ -278,6 +289,7 @@ cc_library(
     name = "remote_device",
     srcs = ["remote_device.cc"],
     hdrs = ["remote_device.h"],
+    copts = tf_copts(),
     deps = [
         ":worker_cache",
         ":worker_interface",
@@ -290,6 +302,7 @@ cc_library(
 cc_library(
     name = "master_interface",
     hdrs = ["master_interface.h"],
+    copts = tf_copts(),
     deps = [
         ":call_options",
         ":message_wrappers",
@@ -302,6 +315,7 @@ cc_library(
     name = "master",
     srcs = ["master.cc"],
     hdrs = ["master.h"],
+    copts = tf_copts(),
     deps = [
         ":call_options",
         ":master_env",
@@ -324,6 +338,7 @@ cc_library(
     name = "master_session",
     srcs = ["master_session.cc"],
     hdrs = ["master_session.h"],
+    copts = tf_copts(),
     deps = [
         ":call_options",
         ":master_env",
@@ -347,6 +362,7 @@ cc_library(
     name = "local_master",
     srcs = ["local_master.cc"],
     hdrs = ["local_master.h"],
+    copts = tf_copts(),
     deps = [
         ":master",
         ":master_interface",
@@ -358,6 +374,7 @@ cc_library(
     name = "rendezvous_mgr_interface",
     srcs = [],
     hdrs = ["rendezvous_mgr_interface.h"],
+    copts = tf_copts(),
     deps = [
         ":worker_env",
         "//tensorflow/core:framework_internal",
@@ -369,6 +386,7 @@ cc_library(
     name = "scheduler",
     srcs = ["scheduler.cc"],
     hdrs = ["scheduler.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:framework",
@@ -399,6 +417,7 @@ cc_library(
 cc_library(
     name = "master_env",
     hdrs = ["master_env.h"],
+    copts = tf_copts(),
     deps = [
         ":worker_cache",
         "//tensorflow/core:protos_all_cc",
@@ -410,6 +429,7 @@ cc_library(
     name = "graph_mgr",
     srcs = ["graph_mgr.cc"],
     hdrs = ["graph_mgr.h"],
+    copts = tf_copts(),
     deps = [
         ":message_wrappers",
         ":rendezvous_mgr_interface",
@@ -429,6 +449,7 @@ cc_library(
     name = "worker_cache_partial",
     srcs = ["worker_cache_partial.cc"],
     hdrs = ["worker_cache_partial.h"],
+    copts = tf_copts(),
     deps = [
         ":worker_cache",
         ":worker_interface",
@@ -443,6 +464,7 @@ cc_library(
     name = "worker_cache_logger",
     srcs = ["worker_cache_logger.cc"],
     hdrs = ["worker_cache_logger.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:lib",
@@ -454,6 +476,7 @@ cc_library(
     name = "server_lib",
     srcs = ["server_lib.cc"],
     hdrs = ["server_lib.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework_internal",
         "//tensorflow/core:lib",

--- a/tensorflow/core/distributed_runtime/rpc/BUILD
+++ b/tensorflow/core/distributed_runtime/rpc/BUILD
@@ -33,6 +33,7 @@ load(
 load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_test")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_tests")
 load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 # For platform specific build config
 load(
@@ -52,6 +53,7 @@ cc_library(
     name = "grpc_util",
     srcs = ["grpc_util.cc"],
     hdrs = ["grpc_util.h"],
+    copts = tf_copts(),
     deps = [
         "@grpc//:grpc_unsecure",
         "@grpc//:grpc++_unsecure",
@@ -65,6 +67,7 @@ cc_library(
     name = "grpc_client_cq_tag",
     srcs = [],
     hdrs = ["grpc_client_cq_tag.h"],
+    copts = tf_copts(),
     deps = [
         ":grpc_util",
         "//tensorflow/core:lib",
@@ -76,6 +79,7 @@ cc_library(
     name = "grpc_state",
     srcs = [],
     hdrs = ["grpc_state.h"],
+    copts = tf_copts(),
     deps = [
         ":grpc_client_cq_tag",
         ":grpc_util",
@@ -90,6 +94,7 @@ cc_library(
     name = "grpc_remote_worker",
     srcs = ["grpc_remote_worker.cc"],
     hdrs = ["grpc_remote_worker.h"],
+    copts = tf_copts(),
     deps = [
         ":grpc_client_cq_tag",
         ":grpc_state",
@@ -110,6 +115,7 @@ cc_library(
     name = "grpc_channel",
     srcs = ["grpc_channel.cc"],
     hdrs = ["grpc_channel.h"],
+    copts = tf_copts(),
     deps = [
         ":grpc_util",
         "//tensorflow/core:framework",
@@ -123,6 +129,7 @@ cc_library(
     name = "grpc_tensor_coding",
     srcs = ["grpc_tensor_coding.cc"],
     hdrs = ["grpc_tensor_coding.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:framework",
@@ -138,6 +145,7 @@ cc_library(
     name = "grpc_call",
     srcs = [],
     hdrs = ["grpc_call.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
@@ -149,6 +157,7 @@ cc_library(
     name = "async_service_interface",
     srcs = [],
     hdrs = ["async_service_interface.h"],
+    copts = tf_copts(),
     deps = [],
 )
 
@@ -156,6 +165,7 @@ cc_library(
     name = "grpc_worker_cache",
     srcs = ["grpc_worker_cache.cc"],
     hdrs = ["grpc_worker_cache.h"],
+    copts = tf_copts(),
     deps = [
         ":grpc_channel",
         ":grpc_client_cq_tag",
@@ -199,6 +209,7 @@ cc_library(
     name = "grpc_worker_service_impl",
     srcs = ["grpc_worker_service_impl.cc"],
     hdrs = ["grpc_worker_service_impl.h"],
+    copts = tf_copts(),
     deps = [
         ":grpc_serialization_traits",
         "//tensorflow/core:worker_proto_cc",
@@ -211,6 +222,7 @@ cc_library(
     name = "grpc_remote_master",
     srcs = ["grpc_remote_master.cc"],
     hdrs = ["grpc_remote_master.h"],
+    copts = tf_copts(),
     deps = [
         ":grpc_master_service_impl",
         ":grpc_util",
@@ -227,6 +239,7 @@ cc_library(
     name = "grpc_master_service",
     srcs = ["grpc_master_service.cc"],
     hdrs = ["grpc_master_service.h"],
+    copts = tf_copts(),
     deps = [
         ":async_service_interface",
         ":grpc_call",
@@ -245,6 +258,7 @@ cc_library(
     name = "grpc_master_service_impl",
     srcs = ["grpc_master_service_impl.cc"],
     hdrs = ["grpc_master_service_impl.h"],
+    copts = tf_copts(),
     deps = [
         ":grpc_serialization_traits",
         "//tensorflow/core:master_proto_cc",
@@ -256,6 +270,7 @@ cc_library(
     name = "grpc_serialization_traits",
     srcs = [],
     hdrs = ["grpc_serialization_traits.h"],
+    copts = tf_copts(),
     deps = [
         "@grpc//:grpc++_unsecure",
     ],
@@ -265,6 +280,7 @@ cc_library(
     name = "rpc_rendezvous_mgr",
     srcs = ["rpc_rendezvous_mgr.cc"],
     hdrs = ["rpc_rendezvous_mgr.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:framework",
@@ -281,6 +297,7 @@ cc_library(
     name = "grpc_server_lib",
     srcs = ["grpc_server_lib.cc"],
     hdrs = ["grpc_server_lib.h"],
+    copts = tf_copts(),
     linkstatic = 1,  # Seems to be needed since alwayslink is broken in bazel
     deps = [
         ":async_service_interface",
@@ -310,6 +327,7 @@ cc_library(
 
 cc_library(
     name = "grpc_runtime",
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":grpc_server_lib",
@@ -395,6 +413,7 @@ cc_library(
     name = "grpc_session",
     srcs = ["grpc_session.cc"],
     hdrs = ["grpc_session.h"],
+    copts = tf_copts(),
     deps = [
         ":grpc_channel",
         ":grpc_remote_master",

--- a/tensorflow/core/framework/types.cc
+++ b/tensorflow/core/framework/types.cc
@@ -35,9 +35,9 @@ std::ostream& operator<<(std::ostream& os, const DeviceType& d) {
   return os;
 }
 
-const char* const DEVICE_CPU = "CPU";
-const char* const DEVICE_GPU = "GPU";
-const char* const DEVICE_SYCL = "SYCL";
+TF_EXPORT const char* const DEVICE_CPU = "CPU";
+TF_EXPORT const char* const DEVICE_GPU = "GPU";
+TF_EXPORT const char* const DEVICE_SYCL = "SYCL";
 
 const std::string DeviceName<Eigen::ThreadPoolDevice>::value = DEVICE_CPU;
 #if GOOGLE_CUDA

--- a/tensorflow/core/framework/types.h
+++ b/tensorflow/core/framework/types.h
@@ -35,6 +35,7 @@ limitations under the License.
 #include "tensorflow/core/lib/gtl/array_slice.h"
 #include "tensorflow/core/lib/gtl/inlined_vector.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/platform/types.h"
 
 namespace tensorflow {

--- a/tensorflow/core/grappler/BUILD
+++ b/tensorflow/core/grappler/BUILD
@@ -2,6 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_library")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 filegroup(
     name = "all_files",
@@ -19,6 +20,7 @@ cc_library(
     name = "op_types",
     srcs = ["op_types.cc"],
     hdrs = ["op_types.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":utils",
@@ -32,6 +34,7 @@ cc_library(
     name = "utils",
     srcs = ["utils.cc"],
     hdrs = ["utils.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",
@@ -74,6 +77,7 @@ cc_library(
     name = "graph_view",
     srcs = ["graph_view.cc"],
     hdrs = ["graph_view.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":utils",
@@ -101,6 +105,7 @@ cc_library(
         "grappler_item.cc",
     ],
     hdrs = ["grappler_item.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":op_types",
@@ -116,6 +121,7 @@ cc_library(
         "grappler_item_builder.cc",
     ],
     hdrs = ["grappler_item_builder.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":grappler_item",

--- a/tensorflow/core/grappler/clusters/BUILD
+++ b/tensorflow/core/grappler/clusters/BUILD
@@ -2,6 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_library")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 filegroup(
     name = "all_files",
@@ -47,6 +48,7 @@ cc_library(
     hdrs = [
         "cluster.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",
@@ -63,6 +65,7 @@ cc_library(
     hdrs = [
         "virtual_cluster.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":cluster",
@@ -92,6 +95,7 @@ cc_library(
     hdrs = [
         "single_machine.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":cluster",

--- a/tensorflow/core/grappler/costs/BUILD
+++ b/tensorflow/core/grappler/costs/BUILD
@@ -1,6 +1,7 @@
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_cuda_library", "tf_cc_test")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 filegroup(
     name = "all_files",
@@ -42,6 +43,7 @@ cc_library(
     name = "graph_properties",
     srcs = ["graph_properties.cc"],
     hdrs = ["graph_properties.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":op_performance_data_cc",
@@ -82,6 +84,7 @@ cc_library(
     name = "graph_memory",
     srcs = ["graph_memory.cc"],
     hdrs = ["graph_memory.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":cost_estimator",
@@ -113,6 +116,7 @@ cc_library(
     name = "robust_stats",
     srcs = ["robust_stats.cc"],
     hdrs = ["robust_stats.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
 )
 
@@ -165,6 +169,7 @@ tf_cc_test(
 cc_library(
     name = "cost_estimator",
     hdrs = ["cost_estimator.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:lib",
@@ -175,6 +180,7 @@ cc_library(
     name = "virtual_placer",
     srcs = ["virtual_placer.cc"],
     hdrs = ["virtual_placer.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",
@@ -202,6 +208,7 @@ tf_cc_test(
 cc_library(
     name = "op_context",
     hdrs = ["op_context.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":op_performance_data_cc",
@@ -213,6 +220,7 @@ cc_library(
     name = "virtual_scheduler",
     srcs = ["virtual_scheduler.cc"],
     hdrs = ["virtual_scheduler.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":graph_properties",
@@ -249,6 +257,7 @@ cc_library(
     name = "measuring_cost_estimator",
     srcs = ["measuring_cost_estimator.cc"],
     hdrs = ["measuring_cost_estimator.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":robust_stats",
@@ -269,6 +278,7 @@ cc_library(
     name = "op_level_cost_estimator",
     srcs = ["op_level_cost_estimator.cc"],
     hdrs = ["op_level_cost_estimator.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":cost_estimator",
@@ -297,6 +307,7 @@ cc_library(
     name = "analytical_cost_estimator",
     srcs = ["analytical_cost_estimator.cc"],
     hdrs = ["analytical_cost_estimator.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":cost_estimator",

--- a/tensorflow/core/grappler/inputs/BUILD
+++ b/tensorflow/core/grappler/inputs/BUILD
@@ -1,6 +1,7 @@
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 filegroup(
     name = "all_files",
@@ -22,6 +23,7 @@ cc_library(
     hdrs = [
         "utils.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:lib",
@@ -47,6 +49,7 @@ cc_library(
     hdrs = [
         "input_yielder.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [],
 )
@@ -57,6 +60,7 @@ cc_library(
     hdrs = [
         "trivial_test_graph_input_yielder.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":input_yielder",
@@ -74,6 +78,7 @@ cc_library(
     hdrs = [
         "file_input_yielder.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":input_yielder",

--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -1,6 +1,7 @@
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 filegroup(
     name = "all_files",
@@ -20,6 +21,7 @@ cc_library(
     hdrs = [
         "static_schedule.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:lib",
@@ -57,6 +59,7 @@ cc_library(
     hdrs = [
         "auto_parallel.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":graph_optimizer",
@@ -91,6 +94,7 @@ cc_library(
     hdrs = [
         "constant_folding.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":graph_optimizer",
@@ -134,6 +138,7 @@ cc_library(
     hdrs = [
         "graph_rewriter.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",
@@ -148,6 +153,7 @@ cc_library(
     hdrs = [
         "graph_optimizer.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:lib",
@@ -161,6 +167,7 @@ cc_library(
     hdrs = [
         "arithmetic_optimizer.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":constant_folding",
@@ -201,6 +208,7 @@ cc_library(
     hdrs = [
         "dependency_optimizer.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":constant_folding",
@@ -242,6 +250,7 @@ cc_library(
     hdrs = [
         "model_pruner.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":graph_optimizer",
@@ -274,6 +283,7 @@ cc_library(
     hdrs = [
         "memory_optimizer.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":graph_optimizer",
@@ -312,6 +322,7 @@ cc_library(
     hdrs = [
         "layout_optimizer.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":graph_optimizer",
@@ -356,6 +367,7 @@ cc_library(
     hdrs = [
         "meta_optimizer.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":arithmetic_optimizer",

--- a/tensorflow/core/grappler/utils/BUILD
+++ b/tensorflow/core/grappler/utils/BUILD
@@ -1,6 +1,7 @@
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 filegroup(
     name = "all_files",
@@ -18,6 +19,7 @@ cc_library(
     name = "scc",
     srcs = ["scc.cc"],
     hdrs = ["scc.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:lib",
@@ -51,6 +53,7 @@ cc_library(
     name = "topological_sort",
     srcs = ["topological_sort.cc"],
     hdrs = ["topological_sort.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:lib",
@@ -77,6 +80,7 @@ cc_library(
     name = "frame",
     srcs = ["frame.cc"],
     hdrs = ["frame.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:lib",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -78,6 +78,7 @@ config_setting(
 cc_library(
     name = "assign_op",
     hdrs = ["assign_op.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//third_party/eigen3",
@@ -149,12 +150,14 @@ cc_library(
         "concat_lib.h",
         "concat_lib_cpu.h",
     ],
+    copts = tf_copts(),
     deps = ["//third_party/eigen3"],
 )
 
 cc_library(
     name = "conv_2d",
     hdrs = ["conv_2d.h"],
+    copts = tf_copts(),
     deps = [
         ":eigen_helpers",
         ":gpu_util_hdrs",
@@ -166,6 +169,7 @@ cc_library(
 cc_library(
     name = "conv_2d_hdrs",
     hdrs = ["conv_2d.h"],
+    copts = tf_copts(),
     deps = [
         ":eigen_helpers",
         "//third_party/eigen3",
@@ -188,6 +192,7 @@ tf_kernel_library(
 cc_library(
     name = "conv_3d",
     hdrs = ["conv_3d.h"],
+    copts = tf_copts(),
     deps = [
         ":eigen_helpers",
         "//tensorflow/core:framework",
@@ -198,6 +203,7 @@ cc_library(
     name = "fill_functor",
     srcs = ["fill_functor.cc"],
     hdrs = ["fill_functor.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//third_party/eigen3",
@@ -208,6 +214,7 @@ cc_library(
     name = "initializable_lookup_table",
     srcs = ["initializable_lookup_table.cc"],
     hdrs = ["initializable_lookup_table.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -218,6 +225,7 @@ cc_library(
     name = "lookup_util",
     srcs = ["lookup_util.cc"],
     hdrs = ["lookup_util.h"],
+    copts = tf_copts(),
     deps = [
         ":initializable_lookup_table",
         "//tensorflow/core:framework",
@@ -251,7 +259,7 @@ cc_library(
     name = "ops_util",
     srcs = ["ops_util.cc"],
     hdrs = ["ops_util.h"],
-    copts = if_not_windows(["-Wno-sign-compare"]),
+    copts = tf_copts() + if_not_windows(["-Wno-sign-compare"]),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -263,17 +271,20 @@ cc_library(
 cc_library(
     name = "ops_util_hdrs",
     hdrs = ["ops_util.h"],
+    copts = tf_copts(),
     deps = ["//third_party/eigen3"],
 )
 
 cc_library(
     name = "conv_ops_gpu_hdrs",
     hdrs = ["conv_ops_gpu.h"],
+    copts = tf_copts(),
 )
 
 cc_library(
     name = "gpu_util_hdrs",
     hdrs = ["gpu_utils.h"],
+    copts = tf_copts(),
 )
 
 tf_cc_test(
@@ -293,6 +304,7 @@ cc_library(
     name = "reshape_util",
     srcs = ["reshape_util.cc"],
     hdrs = ["reshape_util.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -337,6 +349,7 @@ cc_library(
     name = "queue_base",
     srcs = ["queue_base.cc"],
     hdrs = ["queue_base.h"],
+    copts = tf_copts(),
     deps = [
         ":batch_util",
         "//tensorflow/core:framework",
@@ -348,6 +361,7 @@ cc_library(
 cc_library(
     name = "queue_op",
     hdrs = ["queue_op.h"],
+    copts = tf_copts(),
     deps = [
         ":queue_base",
         "//tensorflow/core:framework",
@@ -359,6 +373,7 @@ cc_library(
     name = "priority_queue",
     srcs = ["priority_queue.cc"],
     hdrs = ["priority_queue.h"],
+    copts = tf_copts(),
     deps = [
         ":batch_util",
         ":queue_base",
@@ -386,7 +401,7 @@ cc_library(
     name = "save_restore_tensor",
     srcs = ["save_restore_tensor.cc"],
     hdrs = ["save_restore_tensor.h"],
-    copts = if_not_windows(["-Wno-sign-compare"]),
+    copts = tf_copts() + if_not_windows(["-Wno-sign-compare"]),
     deps = [
         ":bounds_check",
         "//tensorflow/core:framework",
@@ -416,6 +431,7 @@ cc_library(
     hdrs = [
         "split_lib.h",
     ],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework_lite",
         "//third_party/eigen3",
@@ -425,6 +441,7 @@ cc_library(
 cc_library(
     name = "typed_queue",
     hdrs = ["typed_queue.h"],
+    copts = tf_copts(),
     deps = [
         ":queue_base",
         "//tensorflow/core:framework",
@@ -435,6 +452,7 @@ cc_library(
     name = "training_op_helpers",
     srcs = ["training_op_helpers.cc"],
     hdrs = ["training_op_helpers.h"],
+    copts = tf_copts(),
     visibility = [":friends"],
     deps = [
         ":dense_update_functor",
@@ -447,6 +465,7 @@ cc_library(
 cc_library(
     name = "bounds_check",
     hdrs = ["bounds_check.h"],
+    copts = tf_copts(),
     visibility = [":friends"],
     deps = [
         "//tensorflow/core:framework_lite",
@@ -458,6 +477,7 @@ cc_library(
     name = "warn_about_ints",
     srcs = ["warn_about_ints.cc"],
     hdrs = ["warn_about_ints.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:protos_all_cc",
@@ -477,6 +497,7 @@ cc_library(
         "cuda_device_array.h",
         "cuda_device_array_gpu.h",
     ],
+    copts = tf_copts(),
     visibility = ["//tensorflow:__subpackages__"],
     deps = [
         "//tensorflow/core:framework",
@@ -498,6 +519,7 @@ cc_library(
         "eigen_spatial_convolutions.h",
         "eigen_volume_patch.h",
     ],
+    copts = tf_copts(),
     deps = [
         "//third_party/eigen3",
     ],
@@ -506,6 +528,7 @@ cc_library(
 cc_library(
     name = "image_resizer_state",
     hdrs = ["image_resizer_state.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:private"],
     deps = [
         ":bounds_check",
@@ -542,6 +565,7 @@ ARRAY_DEPS = [
 
 cc_library(
     name = "array_not_windows",
+    copts = tf_copts(),
     deps = [
         ":immutable_constant_op",
     ],
@@ -575,6 +599,7 @@ tf_kernel_library(
 
 cc_library(
     name = "array",
+    copts = tf_copts(),
     deps = [
         ":batch_space_ops",
         ":bcast_ops",
@@ -1151,6 +1176,7 @@ tf_kernel_library(
 cc_library(
     name = "gather_functor_hdr",
     hdrs = ["gather_functor.h"],
+    copts = tf_copts(),
 )
 
 tf_kernel_library(
@@ -1457,6 +1483,7 @@ cc_library(
     name = "range_sampler",
     srcs = ["range_sampler.cc"],
     hdrs = ["range_sampler.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:private"],
     deps = [
         "//tensorflow/core:lib",
@@ -1519,6 +1546,7 @@ tf_cc_test(
 
 cc_library(
     name = "data_flow",
+    copts = tf_copts(),
     deps = [
         ":barrier_ops",
         ":conditional_accumulator_base_op",
@@ -1544,6 +1572,7 @@ cc_library(
 
 cc_library(
     name = "lookup",
+    copts = tf_copts(),
     deps = [
         ":lookup_table_init_op",
         ":lookup_table_op",
@@ -1708,6 +1737,7 @@ tf_kernel_library(
 
 cc_library(
     name = "checkpoint_ops",
+    copts = tf_copts(),
     deps = [
         ":generate_vocab_remapping_op",
         ":load_and_remap_matrix_op",
@@ -1780,6 +1810,7 @@ cc_library(
     name = "fifo_queue",
     srcs = ["fifo_queue.cc"],
     hdrs = ["fifo_queue.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:private"],
     deps = [
         ":batch_util",
@@ -1795,6 +1826,7 @@ cc_library(
     name = "padding_fifo_queue",
     srcs = ["padding_fifo_queue.cc"],
     hdrs = ["padding_fifo_queue.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:private"],
     deps = [
         ":batch_util",
@@ -1813,6 +1845,7 @@ cc_library(
     hdrs = [
         "conditional_accumulator_base.h",
     ],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -1823,6 +1856,7 @@ cc_library(
 cc_library(
     name = "typed_conditional_accumulator_base",
     hdrs = ["typed_conditional_accumulator_base.h"],
+    copts = tf_copts(),
     deps = [
         ":conditional_accumulator_base",
     ],
@@ -1834,6 +1868,7 @@ cc_library(
         "conditional_accumulator.h",
         "conditional_accumulator_base_op.h",
     ],
+    copts = tf_copts(),
     deps = [
         ":conditional_accumulator_base",
         ":fill_functor",
@@ -1844,6 +1879,7 @@ cc_library(
 cc_library(
     name = "sparse_conditional_accumulator",
     hdrs = ["sparse_conditional_accumulator.h"],
+    copts = tf_copts(),
     deps = [
         ":typed_conditional_accumulator_base",
     ],
@@ -1903,6 +1939,7 @@ tf_kernel_library(
 
 cc_library(
     name = "image",
+    copts = tf_copts(),
     deps = [
         ":adjust_contrast_op",
         ":adjust_hue_op",
@@ -1949,6 +1986,7 @@ tf_kernel_library(
 cc_library(
     name = "adjust_hsv_gpu_lib",
     hdrs = ["adjust_hsv_gpu.cu.h"],
+    copts = tf_copts(),
     deps = ["//tensorflow/core:framework"],
 )
 
@@ -2189,6 +2227,7 @@ tf_cuda_cc_test(
 
 cc_library(
     name = "io",
+    copts = tf_copts(),
     deps = [
         ":fixed_length_record_reader_op",
         ":identity_reader_op",
@@ -2323,6 +2362,7 @@ tf_cc_tests(
 
 cc_library(
     name = "linalg",
+    copts = tf_copts(),
     deps = [
         ":cholesky_grad",
         ":cholesky_op",
@@ -2461,6 +2501,7 @@ cc_library(
     name = "linalg_ops_common",
     srcs = ["linalg_ops_common.cc"],
     hdrs = ["linalg_ops_common.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:private"],
     deps = [
         "//tensorflow/core:framework",
@@ -2471,6 +2512,7 @@ cc_library(
 
 cc_library(
     name = "logging",
+    copts = tf_copts(),
     deps = [
         ":logging_ops",
         ":summary_audio_op",
@@ -2555,6 +2597,7 @@ MATH_DEPS = [
 
 cc_library(
     name = "math_not_windows",
+    copts = tf_copts(),
     deps = [
         ":sparse_matmul_op",
     ],
@@ -2577,6 +2620,7 @@ tf_kernel_library(
 
 cc_library(
     name = "math",
+    copts = tf_copts(),
     deps = [
         ":aggregate_ops",
         ":argmax_op",
@@ -3116,6 +3160,7 @@ tf_kernel_library(
 
 cc_library(
     name = "nn",
+    copts = tf_copts(),
     deps = [
         ":batch_norm_op",
         ":bias_op",
@@ -3411,6 +3456,7 @@ cc_library(
         "maxpooling_op.h",
         "pooling_ops_common.h",
     ],
+    copts = tf_copts(),
     deps = [
         ":eigen_helpers",
         ":ops_util_hdrs",
@@ -3494,6 +3540,7 @@ tf_kernel_library(
 
 cc_library(
     name = "parsing",
+    copts = tf_copts(),
     deps = [
         ":decode_csv_op",
         ":decode_raw_op",
@@ -3556,6 +3603,7 @@ tf_kernel_library(
 
 cc_library(
     name = "random_ops",
+    copts = tf_copts(),
     deps = [
         ":random_op",
         ":random_shuffle_op",
@@ -3611,6 +3659,7 @@ tf_kernel_library(
 
 cc_library(
     name = "required",
+    copts = tf_copts(),
     deps = [
         ":no_op",
         ":sendrecv_ops",
@@ -3653,6 +3702,7 @@ tf_cc_test(
 
 cc_library(
     name = "sparse",
+    copts = tf_copts(),
     deps = [
         ":serialize_sparse_op",
         ":sparse_add_grad_op",
@@ -3838,6 +3888,7 @@ cc_library(
         "smooth-hinge-loss.h",
         "squared-loss.h",
     ],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//tensorflow/core:lib",
@@ -3893,6 +3944,7 @@ cc_library(
     name = "sdca_internal",
     srcs = ["sdca_internal.cc"],
     hdrs = ["sdca_internal.h"],
+    copts = tf_copts(),
     deps = [
         ":loss_updaters",
         "//tensorflow/core:framework",
@@ -3904,6 +3956,7 @@ cc_library(
 
 cc_library(
     name = "state",
+    copts = tf_copts(),
     deps = [
         ":count_up_to_op",
         ":dense_update_ops",
@@ -4015,6 +4068,7 @@ tf_cuda_cc_test(
 
 cc_library(
     name = "string",
+    copts = tf_copts(),
     deps = [
         ":as_string_op",
         ":base64_ops",
@@ -4422,6 +4476,7 @@ tf_cuda_cc_test(
 
 cc_library(
     name = "audio",
+    copts = tf_copts(),
     deps = [
         ":decode_wav_op",
         ":encode_wav_op",
@@ -5580,6 +5635,7 @@ cc_library(
         "i_remote_fused_graph_ops_definitions.h",
         "remote_fused_graph_execute_utils.h",
     ],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
@@ -5594,6 +5650,7 @@ cc_library(
     testonly = 1,
     srcs = ["remote_fused_graph_execute_op_test_utils.cc"],
     hdrs = ["remote_fused_graph_execute_op_test_utils.h"],
+    copts = tf_copts(),
     deps = [
         ":remote_fused_graph_execute_utils",
         "//tensorflow/cc:cc_ops",
@@ -5664,6 +5721,7 @@ cc_library(
     srcs = [
         "remote_fused_graph_rewriter_transform.cc",
     ],
+    copts = tf_copts(),
     deps = [
         ":remote_fused_graph_execute_utils",
         "//tensorflow/cc:cc_ops",
@@ -5849,6 +5907,7 @@ tf_mkl_kernel_library(
 cc_library(
     name = "stats_aggregator",
     hdrs = ["stats_aggregator.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -5870,6 +5929,7 @@ cc_library(
     name = "batch_util",
     srcs = ["batch_util.cc"],
     hdrs = ["batch_util.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -5880,6 +5940,7 @@ cc_library(
     name = "dataset",
     srcs = ["dataset.cc"],
     hdrs = ["dataset.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:graph",
@@ -5893,6 +5954,7 @@ cc_library(
     name = "dataset_utils",
     srcs = ["dataset_utils.cc"],
     hdrs = ["dataset_utils.h"],
+    copts = tf_copts(),
     deps = [
         ":captured_function",
         ":dataset",
@@ -5906,6 +5968,7 @@ cc_library(
     name = "captured_function",
     srcs = ["captured_function.cc"],
     hdrs = ["captured_function.h"],
+    copts = tf_copts(),
     deps = [
         ":dataset",
         "//tensorflow/core:core_cpu_internal",
@@ -5923,6 +5986,7 @@ cc_library(
     name = "window_dataset",
     srcs = ["window_dataset.cc"],
     hdrs = ["window_dataset.h"],
+    copts = tf_copts(),
     deps = [
         ":dataset",
         "//tensorflow/core:framework",
@@ -6374,6 +6438,7 @@ cc_library(
     name = "summary_interface",
     srcs = ["summary_interface.cc"],
     hdrs = ["summary_interface.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -6444,6 +6509,7 @@ cc_library(
         "meta_support.h",
         "quantization_utils.h",
     ],
+    copts = tf_copts(),
     deps = [
         ":bounds_check",
         "//tensorflow/core:framework",

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -4,6 +4,7 @@ load("@protobuf_archive//:protobuf.bzl", "proto_gen")
 load("@protobuf_archive//:protobuf.bzl", "py_proto_library")
 load("//tensorflow:tensorflow.bzl", "if_not_mobile")
 load("//tensorflow:tensorflow.bzl", "if_not_windows")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 load("//tensorflow/core:platform/default/build_config_root.bzl", "if_static")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load(
@@ -84,6 +85,7 @@ def pyx_library(
     native.cc_binary(
         name=shared_object_name,
         srcs=[stem + ".cpp"],
+        copts = tf_copts(),
         deps=deps + ["//util/python:python_headers"],
         linkshared = 1,
     )
@@ -244,7 +246,7 @@ def tf_proto_library_cc(name, srcs = [], has_services = None,
           ["@protobuf_archive//:protobuf"],
           ["@protobuf_archive//:protobuf_headers"]
       ),
-      copts = if_not_windows([
+      copts = tf_copts() + if_not_windows([
           "-Wno-unknown-warning-option",
           "-Wno-unused-but-set-variable",
           "-Wno-sign-compare",

--- a/tensorflow/core/profiler/BUILD
+++ b/tensorflow/core/profiler/BUILD
@@ -20,12 +20,15 @@ filegroup(
 )
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
+load("//tensorflow:tensorflow.bzl", "if_not_windows")
 load("//tensorflow/core:platform/default/build_config.bzl", "tf_proto_library")
 load("//tensorflow/core:platform/default/build_config.bzl", "tf_additional_all_protos")
 
 tf_cc_binary(
     name = "profiler",
     srcs = ["profiler.cc"],
+    copts = tf_copts() + if_not_windows(["-DHAVE_LINENOISE"]),
     deps = [
         ":protos_all_cc",
         "//tensorflow/c:c_api",
@@ -38,8 +41,7 @@ tf_cc_binary(
         "//tensorflow/core/profiler/internal:tfprof_stats",
         "//tensorflow/core/profiler/internal:tfprof_utils",
         "//tensorflow/core/profiler/internal/advisor:tfprof_advisor",
-        "@linenoise//:linenoise",
-    ],
+    ] + if_not_windows(["@linenoise//:linenoise"]),
 )
 
 tf_proto_library(

--- a/tensorflow/core/profiler/internal/BUILD
+++ b/tensorflow/core/profiler/internal/BUILD
@@ -5,12 +5,14 @@ package(
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 load("//tensorflow:tensorflow.bzl", "if_not_windows")
 
 cc_library(
     name = "tfprof_stats",
     srcs = ["tfprof_stats.cc"],
     hdrs = ["tfprof_stats.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_code",
         ":tfprof_graph",
@@ -33,6 +35,7 @@ cc_library(
     name = "tfprof_timeline",
     srcs = ["tfprof_timeline.cc"],
     hdrs = ["tfprof_timeline.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_node_show",
         ":tfprof_utils",
@@ -46,6 +49,7 @@ cc_library(
     name = "tfprof_node",
     srcs = ["tfprof_node.cc"],
     hdrs = ["tfprof_node.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_options",
         ":tfprof_utils",
@@ -60,6 +64,7 @@ cc_library(
     name = "tfprof_scope",
     srcs = ["tfprof_scope.cc"],
     hdrs = ["tfprof_scope.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_constants",
         ":tfprof_node",
@@ -81,6 +86,7 @@ cc_library(
     name = "tfprof_op",
     srcs = ["tfprof_op.cc"],
     hdrs = ["tfprof_op.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_constants",
         ":tfprof_node",
@@ -101,6 +107,7 @@ cc_library(
     name = "tfprof_code",
     srcs = ["tfprof_code.cc"],
     hdrs = ["tfprof_code.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_constants",
         ":tfprof_node",
@@ -123,6 +130,7 @@ cc_library(
     name = "tfprof_graph",
     srcs = ["tfprof_graph.cc"],
     hdrs = ["tfprof_graph.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_constants",
         ":tfprof_node",
@@ -142,6 +150,7 @@ cc_library(
     name = "tfprof_node_show",
     srcs = ["tfprof_node_show.cc"],
     hdrs = ["tfprof_node_show.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_constants",
         ":tfprof_node",
@@ -157,6 +166,7 @@ cc_library(
     name = "tfprof_show",
     srcs = ["tfprof_show.cc"],
     hdrs = ["tfprof_show.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_constants",
         ":tfprof_node",
@@ -177,6 +187,7 @@ cc_library(
     name = "tfprof_show_multi",
     srcs = ["tfprof_show_multi.cc"],
     hdrs = ["tfprof_show_multi.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_constants",
         ":tfprof_node",
@@ -248,7 +259,7 @@ cc_library(
     name = "tfprof_utils",
     srcs = ["tfprof_utils.cc"],
     hdrs = ["tfprof_utils.h"],
-    copts = if_not_windows(["-Wno-sign-compare"]),
+    copts = tf_copts() + if_not_windows(["-Wno-sign-compare"]),
     deps = [
         ":tfprof_options",
         "//tensorflow/core:lib",
@@ -261,6 +272,7 @@ cc_library(
     name = "tfprof_options",
     srcs = ["tfprof_options.cc"],
     hdrs = ["tfprof_options.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//tensorflow/core:lib",
@@ -271,6 +283,7 @@ cc_library(
 cc_library(
     name = "print_model_analysis_hdr",
     hdrs = ["print_model_analysis.h"],
+    copts = tf_copts(),
     deps = ["//tensorflow/core:framework"],
 )
 
@@ -278,6 +291,7 @@ cc_library(
     name = "print_model_analysis",
     srcs = ["print_model_analysis.cc"],
     hdrs = ["print_model_analysis.h"],
+    copts = tf_copts(),
     deps = [
         ":tfprof_options",
         ":tfprof_stats",
@@ -321,7 +335,7 @@ cc_library(
     name = "tfprof_tensor",
     srcs = ["tfprof_tensor.cc"],
     hdrs = ["tfprof_tensor.h"],
-    copts = if_not_windows(["-Wno-sign-compare"]),
+    copts = tf_copts() + if_not_windows(["-Wno-sign-compare"]),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -355,11 +369,13 @@ tf_cc_test(
 cc_library(
     name = "tfprof_constants",
     hdrs = ["tfprof_constants.h"],
+    copts = tf_copts(),
 )
 
 cc_library(
     name = "tfprof_tf_testlib",
     testonly = 1,
+    copts = tf_copts(),
     deps = [
         ":tfprof_tf_lib",
         "//tensorflow/core:test",
@@ -370,6 +386,7 @@ cc_library(
 
 cc_library(
     name = "tfprof_tf_lib",
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:lib",
         "//tensorflow/core:protos_all_cc",

--- a/tensorflow/core/util/ctc/BUILD
+++ b/tensorflow/core/util/ctc/BUILD
@@ -9,6 +9,7 @@ package(
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_cc_tests")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 
 filegroup(
     name = "mobile_srcs",
@@ -40,6 +41,7 @@ filegroup(
 
 cc_library(
     name = "ctc",
+    copts = tf_copts(),
     deps = [
         ":ctc_beam_search_lib",
         ":ctc_loss_calculator_lib",
@@ -60,6 +62,7 @@ cc_library(
         "ctc_beam_search.h",
         "ctc_decoder.h",
     ],
+    copts = tf_copts(),
     deps = [
         ":ctc_loss_util_lib",
         "//tensorflow/core:lib",
@@ -90,6 +93,7 @@ cc_library(
     hdrs = [
         "ctc_loss_calculator.h",
     ],
+    copts = tf_copts(),
     deps = [
         ":ctc_loss_util_lib",
         "//tensorflow/core:framework",
@@ -103,4 +107,5 @@ cc_library(
     hdrs = [
         "ctc_loss_util.h",
     ],
+    copts = tf_copts(),
 )

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -17,6 +17,7 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "if_not_windows")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_library")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
 load("//tensorflow:tensorflow.bzl", "py_test")
@@ -27,6 +28,7 @@ load("//tensorflow:tensorflow.bzl", "tf_py_wrap_cc")
 load("//tensorflow:tensorflow.bzl", "tf_cc_shared_object")
 load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
+load("//tensorflow:tensorflow.bzl", "py_test")
 load("//tensorflow/core:platform/default/build_config.bzl", "pyx_library")
 load("//tensorflow/core:platform/default/build_config.bzl", "tf_proto_library")
 load("//tensorflow/core:platform/default/build_config.bzl", "tf_proto_library_py")
@@ -186,6 +188,7 @@ cc_library(
     name = "cost_analyzer_lib",
     srcs = ["grappler/cost_analyzer.cc"],
     hdrs = ["grappler/cost_analyzer.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:lib",
         "//tensorflow/core:protos_all_cc",
@@ -203,6 +206,7 @@ cc_library(
     name = "model_analyzer_lib",
     srcs = ["grappler/model_analyzer.cc"],
     hdrs = ["grappler/model_analyzer.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -216,6 +220,7 @@ cc_library(
     name = "numpy_lib",
     srcs = ["lib/core/numpy.cc"],
     hdrs = ["lib/core/numpy.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -228,6 +233,7 @@ cc_library(
     name = "bfloat16_lib",
     srcs = ["lib/core/bfloat16.cc"],
     hdrs = ["lib/core/bfloat16.h"],
+    copts = tf_copts(),
     deps = [
         ":numpy_lib",
         ":safe_ptr",
@@ -241,6 +247,7 @@ cc_library(
     name = "ndarray_tensor_bridge",
     srcs = ["lib/core/ndarray_tensor_bridge.cc"],
     hdrs = ["lib/core/ndarray_tensor_bridge.h"],
+    copts = tf_copts(),
     deps = [
         ":bfloat16_lib",
         ":numpy_lib",
@@ -254,6 +261,7 @@ cc_library(
     name = "kernel_registry",
     srcs = ["util/kernel_registry.cc"],
     hdrs = ["util/kernel_registry.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -265,6 +273,7 @@ cc_library(
     name = "cpp_python_util",
     srcs = ["util/util.cc"],
     hdrs = ["util/util.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -276,6 +285,7 @@ cc_library(
     name = "py_func_lib",
     srcs = ["lib/core/py_func.cc"],
     hdrs = ["lib/core/py_func.h"],
+    copts = tf_copts(),
     deps = [
         ":ndarray_tensor_bridge",
         ":numpy_lib",
@@ -297,6 +307,7 @@ cc_library(
     name = "safe_ptr",
     srcs = ["lib/core/safe_ptr.cc"],
     hdrs = ["lib/core/safe_ptr.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/c:c_api",
         "//tensorflow/c/eager:c_api",
@@ -308,6 +319,7 @@ cc_library(
     name = "ndarray_tensor",
     srcs = ["lib/core/ndarray_tensor.cc"],
     hdrs = ["lib/core/ndarray_tensor.h"],
+    copts = tf_copts(),
     deps = [
         ":bfloat16_lib",
         ":ndarray_tensor_bridge",
@@ -324,6 +336,7 @@ cc_library(
     name = "py_seq_tensor",
     srcs = ["lib/core/py_seq_tensor.cc"],
     hdrs = ["lib/core/py_seq_tensor.h"],
+    copts = tf_copts(),
     deps = [
         ":numpy_lib",
         ":py_util",
@@ -338,6 +351,7 @@ cc_library(
     name = "py_util",
     srcs = ["lib/core/py_util.cc"],
     hdrs = ["lib/core/py_util.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/core:lib",
         "//tensorflow/core:script_ops_op_lib",
@@ -349,6 +363,7 @@ cc_library(
     name = "py_record_reader_lib",
     srcs = ["lib/io/py_record_reader.cc"],
     hdrs = ["lib/io/py_record_reader.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/c:c_api",
         "//tensorflow/c:tf_status_helper",
@@ -361,6 +376,7 @@ cc_library(
     name = "py_record_writer_lib",
     srcs = ["lib/io/py_record_writer.cc"],
     hdrs = ["lib/io/py_record_writer.h"],
+    copts = tf_copts(),
     deps = [
         "//tensorflow/c:c_api",
         "//tensorflow/c:tf_status_helper",
@@ -457,6 +473,7 @@ cc_library(
         "framework/python_op_gen.h",
         "framework/python_op_gen_internal.h",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",
@@ -472,6 +489,7 @@ cc_library(
 cc_library(
     name = "python_op_gen_main",
     srcs = ["framework/python_op_gen_main.cc"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",
@@ -1043,6 +1061,7 @@ tf_gen_op_wrapper_py(
 cc_library(
     name = "test_ops_kernels",
     srcs = ["framework/test_ops.cc"],
+    copts = tf_copts(),
     linkstatic = 1,
     deps = [
         "//tensorflow/core:framework",
@@ -1061,6 +1080,7 @@ tf_gen_op_wrapper_py(
 cc_library(
     name = "test_ops_2_kernels",
     srcs = ["framework/test_ops_2.cc"],
+    copts = tf_copts(),
     linkstatic = 1,
     deps = ["//tensorflow/core:framework"],
     alwayslink = 1,
@@ -2973,7 +2993,7 @@ cc_library(
     name = "cpp_shape_inference",
     srcs = ["framework/cpp_shape_inference.cc"],
     hdrs = ["framework/cpp_shape_inference.h"],
-    copts = if_not_windows(["-Wno-sign-compare"]),
+    copts = tf_copts() + if_not_windows(["-Wno-sign-compare"]),
     visibility = ["//visibility:public"],
     deps = [
         ":cpp_shape_inference_proto_cc",
@@ -3042,6 +3062,7 @@ py_library(
 tf_py_wrap_cc(
     name = "pywrap_tensorflow_internal",
     srcs = ["tensorflow.i"],
+    copts = tf_copts(),
     swig_includes = [
         "client/device_lib.i",
         "client/events_writer.i",

--- a/tensorflow/python/eager/BUILD
+++ b/tensorflow/python/eager/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2.0
 load("//tensorflow:tensorflow.bzl", "py_test")
 load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 load(
     "//tensorflow/tools/test:performance.bzl",
     "tf_py_logged_benchmark",
@@ -18,6 +19,7 @@ cc_library(
         "pywrap_tensor.h",
         "pywrap_tfe.h",
     ],
+    copts = tf_copts(),
     visibility = ["//tensorflow:internal"],
     deps = [
         "//tensorflow/c:c_api",
@@ -195,6 +197,7 @@ cc_library(
     name = "python_eager_op_gen",
     srcs = ["python_eager_op_gen.cc"],
     hdrs = ["python_eager_op_gen.h"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:framework",
@@ -212,6 +215,7 @@ cc_library(
     srcs = [
         "python_eager_op_gen_main.cc",
     ],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":python_eager_op_gen",


### PR DESCRIPTION
To eliminate warnings like:
libarithmetic_optimizer.a(arithmetic_optimizer.o) : warning LNK4049: locally defined symbol ?DEVICE_CPU@tensorflow@@3QEBDEB (char const * const tensorflow::DEVICE_CPU) imported

This PR depends on #15439. Please merge that first.