### PR TITLE
Add feature get_placeholders()

### DIFF
--- a/tensorflow/contrib/framework/python/framework/graph_util.py
+++ b/tensorflow/contrib/framework/python/framework/graph_util.py
@@ -24,11 +24,11 @@ import six
 # pylint: disable=unused-import
 from tensorflow.core.framework import graph_pb2
 from tensorflow.core.framework import node_def_pb2
+from tensorflow.python.framework import ops
 from tensorflow.python.framework.graph_util_impl import _assert_nodes_are_present
 from tensorflow.python.framework.graph_util_impl import _bfs_for_reachable_nodes
 from tensorflow.python.framework.graph_util_impl import _extract_graph_summary
 from tensorflow.python.framework.graph_util_impl import _node_name
-from tensorflow.python.framework import ops
 
 
 __all__ = ["fuse_op", "get_placeholders"]
@@ -139,19 +139,16 @@ def get_placeholders(graph):
     A list contains all placeholders of given graph.
 
   Raises:
-    TypeError: If 'graph' is not a tensorflow graph.
+    TypeError: If `graph` is not a tensorflow graph.
   """
 
-  if graph and not isinstance(graph, ops.Graph):
+  if not isinstance(graph, ops.Graph):
     raise TypeError("Input graph needs to be a Graph: %s" % graph)
 
-  # For each placeholder() call, there is a coresponding
+  # For each placeholder() call, there is a corresponding
   # operation of type 'Placeholder' registered to the graph.
   # The return value (a Tensor) of placeholder() is the
   # first output of this operation in fact.
   operations = graph.get_operations()
-  result = []
-  for i in operations:
-    if i.type == 'Placeholder':
-      result.append(i.outputs[0])
+  result = [i.outputs[0] for i in operations if i.type == 'Placeholder']
   return result

--- a/tensorflow/contrib/framework/python/framework/graph_util.py
+++ b/tensorflow/contrib/framework/python/framework/graph_util.py
@@ -28,8 +28,10 @@ from tensorflow.python.framework.graph_util_impl import _assert_nodes_are_presen
 from tensorflow.python.framework.graph_util_impl import _bfs_for_reachable_nodes
 from tensorflow.python.framework.graph_util_impl import _extract_graph_summary
 from tensorflow.python.framework.graph_util_impl import _node_name
+from tensorflow.python.framework import ops
 
-__all__ = ["fuse_op"]
+
+__all__ = ["fuse_op", "get_placeholders"]
 
 
 def fuse_op(graph_def, input_nodes, output_nodes, output_dtypes,
@@ -126,3 +128,30 @@ def fuse_op(graph_def, input_nodes, output_nodes, output_dtypes,
   out.library.CopyFrom(graph_def.library)
   out.versions.CopyFrom(graph_def.versions)
   return out
+
+
+def get_placeholders(graph):
+  """Get placeholders of a graph.
+
+  Args:
+    graph: A tf.Graph.
+  Returns:
+    A list contains all placeholders of given graph.
+
+  Raises:
+    TypeError: If 'graph' is not a tensorflow graph.
+  """
+
+  if graph and not isinstance(graph, ops.Graph):
+    raise TypeError("Input graph needs to be a Graph: %s" % graph)
+
+  # For each placeholder() call, there is a coresponding
+  # operation of type 'Placeholder' registered to the graph.
+  # The return value (a Tensor) of placeholder() is the
+  # first output of this operation in fact.
+  operations = graph.get_operations()
+  result = []
+  for i in operations:
+    if i.type == 'Placeholder':
+      result.append(i.outputs[0])
+  return result

--- a/tensorflow/contrib/framework/python/framework/graph_util_test.py
+++ b/tensorflow/contrib/framework/python/framework/graph_util_test.py
@@ -69,8 +69,8 @@ class GetPlaceholdersTest(test.TestCase):
         x = array_ops.placeholder(dtypes.float32)
         ids.append(x._id)
       result = graph_util.get_placeholders(g)
-      result_ids = { i._id for i in result }
-      self.assertEqual(result_ids, set(ids))
+      result_ids = [ i._id for i in result ]
+      self.assertEqual(sorted(result_ids), sorted(ids))
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/contrib/framework/python/framework/graph_util_test.py
+++ b/tensorflow/contrib/framework/python/framework/graph_util_test.py
@@ -21,10 +21,10 @@ from tensorflow.contrib.framework.python.framework import graph_util
 from tensorflow.core.framework import graph_pb2
 from tensorflow.core.framework import node_def_pb2
 from tensorflow.core.framework import types_pb2
-from tensorflow.python.platform import test
-from tensorflow.python.framework import ops
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
+from tensorflow.python.platform import test
 
 
 def GetNewNode(name, op, input_nodes):
@@ -64,13 +64,11 @@ class GetPlaceholdersTest(test.TestCase):
 
   def test_get_placeholders(self):
     with ops.Graph().as_default() as g:
-      ids = []
-      for i in range(5):
-        x = array_ops.placeholder(dtypes.float32)
-        ids.append(x._id)
-      result = graph_util.get_placeholders(g)
-      result_ids = [ i._id for i in result ]
-      self.assertEqual(sorted(result_ids), sorted(ids))
+      placeholders = [array_ops.placeholder(dtypes.float32) for _ in range(5)]
+      results = graph_util.get_placeholders(g)
+      self.assertEqual(sorted(placeholders, key=lambda x: x._id),  # pylint: disable=protected-access
+                       sorted(results, key=lambda x: x._id))  # pylint: disable=protected-access
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/contrib/framework/python/framework/graph_util_test.py
+++ b/tensorflow/contrib/framework/python/framework/graph_util_test.py
@@ -22,6 +22,9 @@ from tensorflow.core.framework import graph_pb2
 from tensorflow.core.framework import node_def_pb2
 from tensorflow.core.framework import types_pb2
 from tensorflow.python.platform import test
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
 
 
 def GetNewNode(name, op, input_nodes):
@@ -56,6 +59,18 @@ class GraphUtilTest(test.TestCase):
     self.assertEqual(fused_graph_def.node[2].name, 'D')
     self.assertEqual(fused_graph_def.node[3].name, 'E')
 
+
+class GetPlaceholdersTest(test.TestCase):
+
+  def test_get_placeholders(self):
+    with ops.Graph().as_default() as g:
+      ids = []
+      for i in range(5):
+        x = array_ops.placeholder(dtypes.float32)
+        ids.append(x._id)
+      result = graph_util.get_placeholders(g)
+      result_ids = { i._id for i in result }
+      self.assertEqual(result_ids, set(ids))
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Add a new API that can get all placeholders of a graph easily as #14374 requires.