### PR TITLE
Fix the wrong ValurError formatting in convolutional.py

### DIFF
--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -1231,9 +1231,7 @@ class Conv2DTranspose(Conv2D):
 
   def build(self, input_shape):
     if len(input_shape) != 4:
-      raise ValueError('Inputs should have rank ' +
-                       str(4) +
-                       'Received input shape:', str(input_shape))
+      raise ValueError('Inputs should have rank 4. Received input shape: ' + str(input_shape))
     if self.data_format == 'channels_first':
       channel_axis = 1
     else:


### PR DESCRIPTION
This commit makes the error message of the build function of Conv2DTranspose a complete string, which is more human-readable.