### PR TITLE
Make sparse_to_dense differentiable by wrapping scatter_nd_add.

### DIFF
--- a/tensorflow/python/ops/sparse_grad.py
+++ b/tensorflow/python/ops/sparse_grad.py
@@ -30,7 +30,6 @@ from tensorflow.python.ops import sparse_ops
 # latent bugs here.
 ops.NotDifferentiable("SparseAddGrad")
 ops.NotDifferentiable("SparseConcat")
-ops.NotDifferentiable("SparseToDense")
 
 
 @ops.RegisterGradient("SparseReorder")


### PR DESCRIPTION
Make `sparse_to_dense` a wrapper of `scatter_nd_add`, as the two have very similar functionality and the latter is differentiable while the former is not. Ran into this because there apparently is no warning when trying to differentiate not differentiable ops.

Related: https://github.com/tensorflow/tensorflow/issues/6391#issuecomment-268392143

If this has potential to be merged and further changes are required, I am happy to work on those.

edit: Misleading commit message, wrapping `scatter_nd_add` in order to allow a default value.