### PR TITLE
Exporting tensorflow package for cmake

### DIFF
--- a/tensorflow/contrib/cmake/tf_core_framework.cmake
+++ b/tensorflow/contrib/cmake/tf_core_framework.cmake
@@ -267,7 +267,11 @@ list(REMOVE_ITEM tf_core_lib_srcs ${tf_core_lib_test_srcs})
 
 add_library(tf_core_lib OBJECT ${tf_core_lib_srcs})
 add_dependencies(tf_core_lib ${tensorflow_EXTERNAL_DEPENDENCIES} tf_protos_cc)
-
+target_include_directories(tf_core_lib PUBLIC  
+    $<BUILD_INTERFACE:${nsync_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include/external/nsync/public>
+)
+    
 # Tricky setup to force always rebuilding
 # force_rebuild always runs forcing ${VERSION_INFO_CC} target to run
 # ${VERSION_INFO_CC} would cache, but it depends on a phony never produced

--- a/tensorflow/contrib/cmake/tf_core_framework.cmake
+++ b/tensorflow/contrib/cmake/tf_core_framework.cmake
@@ -267,11 +267,7 @@ list(REMOVE_ITEM tf_core_lib_srcs ${tf_core_lib_test_srcs})
 
 add_library(tf_core_lib OBJECT ${tf_core_lib_srcs})
 add_dependencies(tf_core_lib ${tensorflow_EXTERNAL_DEPENDENCIES} tf_protos_cc)
-target_include_directories(tf_core_lib PUBLIC  
-    $<BUILD_INTERFACE:${nsync_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:include/external/nsync/public>
-)
-    
+
 # Tricky setup to force always rebuilding
 # force_rebuild always runs forcing ${VERSION_INFO_CC} target to run
 # ${VERSION_INFO_CC} would cache, but it depends on a phony never produced

--- a/tensorflow/contrib/cmake/tf_shared_lib.cmake
+++ b/tensorflow/contrib/cmake/tf_shared_lib.cmake
@@ -95,10 +95,18 @@ if(WIN32)
   add_dependencies(tensorflow tensorflow_static)
 endif(WIN32)
 
-install(TARGETS tensorflow
+target_include_directories(tensorflow PUBLIC 
+    $<INSTALL_INTERFACE:include/>
+    $<INSTALL_INTERFACE:include/external/nsync/public>)
+
+install(TARGETS tensorflow EXPORT tensorflow_export
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
+        
+install(EXPORT tensorflow_export
+        FILE TensorflowConfig.cmake
+        DESTINATION lib/cmake)
 
 # install necessary headers
 # tensorflow headers


### PR DESCRIPTION
This PR is based on the PR #13867.

It provides the usage of cmake `find_package()`. Therefore it should be easier to intergrate the prebuilt tensorflow code into existing external projects.

1. What about a version control mechanism? (Cons: Has to be manually changed in every new version)
2. Supplying some examples with the installed version (This examples should not be prebuilt, furthermore they should be built with an installed tensorflow)
