### PR TITLE
Remove python boolean check from adjust_gamma

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1004,12 +1004,13 @@ def adjust_gamma(image, gamma=1, gain=1):
     img = ops.convert_to_tensor(image, name='img', dtype=dtypes.float32)
     # Keep image dtype for computing the scale of corresponding dtype
     image = ops.convert_to_tensor(image, name='image')
-    # Check gamma positive
-    if tf.framework.is_tensor(image):
+    # Check that gamma is not negative. 
+    if tf.framework.is_tensor(gamma):
       tf.assert_non_negative(gamma)
     else:
        if gamma < 0:
-          raise ValueError('Gamma should be a non-negative real number')
+          raise ValueError(
+            'Gamma should be a non-negative real number: %f' % gamma)
    
     # scale = max(dtype) - min(dtype)
     scale = constant_op.constant(image.dtype.limits[1] - image.dtype.limits[0],

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1004,9 +1004,9 @@ def adjust_gamma(image, gamma=1, gain=1):
     img = ops.convert_to_tensor(image, name='img', dtype=dtypes.float32)
     # Keep image dtype for computing the scale of corresponding dtype
     image = ops.convert_to_tensor(image, name='image')
-
-    if gamma < 0:
-      raise ValueError('Gamma should be a non-negative real number')
+    # Check all gamma's positive
+    tf.assert_positive(gamma)
+   
     # scale = max(dtype) - min(dtype)
     scale = constant_op.constant(image.dtype.limits[1] - image.dtype.limits[0],
                                  dtype=dtypes.float32)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1004,7 +1004,7 @@ def adjust_gamma(image, gamma=1, gain=1):
     img = ops.convert_to_tensor(image, name='img', dtype=dtypes.float32)
     # Keep image dtype for computing the scale of corresponding dtype
     image = ops.convert_to_tensor(image, name='image')
-    # Check all gamma's positive
+    # Check gamma positive
     tf.assert_positive(gamma)
    
     # scale = max(dtype) - min(dtype)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1000,19 +1000,20 @@ def adjust_gamma(image, gamma=1, gain=1):
   """
 
   with ops.op_scope([image, gamma, gain], None, 'adjust_gamma'):
-    # Convert pixel value to DT_FLOAT for computing adjusted image
+    # Convert pixel value to DT_FLOAT for computing adjusted image..
     img = ops.convert_to_tensor(image, name='img', dtype=dtypes.float32)
     # Keep image dtype for computing the scale of corresponding dtype
     image = ops.convert_to_tensor(image, name='image')
 
-    assert_op = _assert(gamma >= 0, ValueError,'Gamma should be a non-negative real number.')
+    assert_op = _assert(gamma >= 0, ValueError,
+                        'Gamma should be a non-negative real number.')
     if assert_op:
       gamma = control_flow_ops.with_dependencies(assert_op, gamma)
    
-    # scale = max(dtype) - min(dtype)
+    # scale = max(dtype) - min(dtype).
     scale = constant_op.constant(image.dtype.limits[1] - image.dtype.limits[0],
                                  dtype=dtypes.float32)
-    # According to the definition of gamma correction
+    # According to the definition of gamma correction.
     adjusted_img = (img / scale) ** gamma * scale * gain
 
     return adjusted_img

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -980,8 +980,8 @@ def adjust_gamma(image, gamma=1, gain=1):
 
   Args:
     image : A Tensor.
-    gamma : A scalar. Non negative real number.
-    gain  : A scalar. The constant multiplier.
+    gamma : A scalar or tensor. Non negative real number.
+    gain  : A scalar or tensor. The constant multiplier.
 
   Returns:
     A Tensor. Gamma corrected output image.
@@ -1004,13 +1004,10 @@ def adjust_gamma(image, gamma=1, gain=1):
     img = ops.convert_to_tensor(image, name='img', dtype=dtypes.float32)
     # Keep image dtype for computing the scale of corresponding dtype
     image = ops.convert_to_tensor(image, name='image')
-    # Check that gamma is not negative. 
-    if tf.framework.is_tensor(gamma):
-      tf.assert_non_negative(gamma)
-    else:
-       if gamma < 0:
-          raise ValueError(
-            'Gamma should be a non-negative real number: %f' % gamma)
+
+    assert_op = _assert(gamma >= 0, ValueError,'Gamma should be a non-negative real number.')
+    if assert_op:
+      gamma = control_flow_ops.with_dependencies(assert_op, gamma)
    
     # scale = max(dtype) - min(dtype)
     scale = constant_op.constant(image.dtype.limits[1] - image.dtype.limits[0],

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1000,9 +1000,9 @@ def adjust_gamma(image, gamma=1, gain=1):
   """
 
   with ops.op_scope([image, gamma, gain], None, 'adjust_gamma'):
-    # Convert pixel value to DT_FLOAT for computing adjusted image..
+    # Convert pixel value to DT_FLOAT for computing adjusted image.
     img = ops.convert_to_tensor(image, name='img', dtype=dtypes.float32)
-    # Keep image dtype for computing the scale of corresponding dtype
+    # Keep image dtype for computing the scale of corresponding dtype.
     image = ops.convert_to_tensor(image, name='image')
 
     assert_op = _assert(gamma >= 0, ValueError,

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1005,7 +1005,11 @@ def adjust_gamma(image, gamma=1, gain=1):
     # Keep image dtype for computing the scale of corresponding dtype
     image = ops.convert_to_tensor(image, name='image')
     # Check gamma positive
-    tf.assert_positive(gamma)
+    if tf.framework.is_tensor(image):
+      tf.assert_non_negative(gamma)
+    else:
+       if gamma < 0:
+          raise ValueError('Gamma should be a non-negative real number')
    
     # scale = max(dtype) - min(dtype)
     scale = constant_op.constant(image.dtype.limits[1] - image.dtype.limits[0],

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -214,7 +214,7 @@ class AdjustGamma(test_util.TensorFlowTestCase):
       x_np = np.array(x_data, dtype=np.float32)
     
       x = constant_op.constant(x_np, shape=x_np.shape)
-      y = constant_op.constant(-1.0, dtype=np.float32)
+      y = constant_op.constant(-1.0, dtype=tf.float32)
       
       image = image_ops.adjust_gamma(x, gamma=y)
       

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -189,6 +189,44 @@ class AdjustGamma(test_util.TensorFlowTestCase):
 
       self.assertAllClose(y_tf, y_np, 1e-6)
 
+  def test_adjust_gamma_less_zero(self):
+    """White image should be returned for gamma equal to zero"""
+    with self.test_session():
+      x_data = np.random.uniform(0, 255, (8, 8))
+      x_np = np.array(x_data, dtype=np.float32)
+    
+      x = constant_op.constant(x_np, shape=x_np.shape)
+
+      err_msg = 'Gamma should be a non-negative real number.'
+      
+      try:
+        image_ops.adjust_gamma(x, gamma=-1)
+      except Exception as e:
+        if err_msg not in str(e):
+          raise
+      else:
+        raise AssertionError("Exception not raised: %s" % err_msg)
+
+  def test_adjust_gamma_less_zero_tensor(self):
+    """White image should be returned for gamma equal to zero"""
+    with self.test_session():
+      x_data = np.random.uniform(0, 255, (8, 8))
+      x_np = np.array(x_data, dtype=np.float32)
+    
+      x = constant_op.constant(x_np, shape=x_np.shape)
+      y = constant_op.constant(-1.0, dtype=np.float32)
+      
+      image = image_ops.adjust_gamma(x, gamma=y)
+      
+      err_msg = 'Gamma should be a non-negative real number.'
+      try:
+        image.eval()
+      except Exception as e:
+        if err_msg not in str(e):
+          raise
+      else:
+        raise AssertionError("Exception not raised: %s" % err_msg)
+      
   def test_adjust_gamma_zero(self):
     """White image should be returned for gamma equal to zero"""
     with self.test_session():

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -214,7 +214,7 @@ class AdjustGamma(test_util.TensorFlowTestCase):
       x_np = np.array(x_data, dtype=np.float32)
     
       x = constant_op.constant(x_np, shape=x_np.shape)
-      y = constant_op.constant(-1.0, dtype=tf.float32)
+      y = constant_op.constant(-1.0, dtype=dtypes.float32)
       
       image = image_ops.adjust_gamma(x, gamma=y)
       


### PR DESCRIPTION
The adjust_gamma operation used a python boolean to check if gamma was positive.  This however removes any possibility of using a scalar tensor, which means it can't be used to apply random augmentations during training.

It is fixed by using a tf.assert_positive statement.