### PR TITLE
Changed ffmpeg verbosity semantics

### DIFF
--- a/tensorflow/contrib/ffmpeg/default/ffmpeg_lib.cc
+++ b/tensorflow/contrib/ffmpeg/default/ffmpeg_lib.cc
@@ -49,7 +49,8 @@ std::vector<string> FfmpegAudioCommandLine(const string& input_filename,
           "-nostdin",             // No interactive commands accepted.
           "-f", input_format_id,  // eg: "mp3"
           "-probesize", StrCat(kDefaultProbeSize), "-i", input_filename,
-          "-loglevel", "info",  // Enable verbose logging to support debugging.
+          "-loglevel", "error",   // Print errors only.
+          "-hide_banner",         // Skip printing build options, version, etc.
           "-map_metadata", "-1",  // Copy global metadata from input to output.
           "-vn",                  // No video recording.
           "-ac:a:0", StrCat(channel_count), "-ar:a:0",
@@ -72,7 +73,8 @@ std::vector<string> FfmpegVideoCommandLine(const string& input_filename,
           "-probesize",
           StrCat(kDefaultProbeSize),
           "-loglevel",
-          "info",  // Enable verbose logging to support debugging.
+          "error",  // Print errors only.
+          "-hide_banner",  // Skip printing build options, version, etc.
           "-vcodec",
           "rawvideo",
           "-pix_fmt",


### PR DESCRIPTION
The `tf.contrib.ffmpeg.decode_*` and `tf.contrib.ffmpeg.encode_*` functions are extremely verbose and make it nearly impossible to see other printed messages.

Corresponding methods for image such as `tf.image.decode_png` produce no output under normal conditions, and it would be nice for audio/video methods to align with this.

### FFmpeg on valid MP3 file with `-loglevel info` and without `-hide_banner` (old semantics)

```sh
$ ffmpeg -loglevel info -nostats -i in.mp3 -acodec pcm_s16le -ar 44100 out.wav
ffmpeg version N-79546-g13406b6 Copyright (c) 2000-2016 the FFmpeg developers
  built with gcc 5.3.0 (GCC)
  configuration: --enable-gpl --enable-version3 --disable-w32threads --enable-avisynth --enable-bzlib --enable-fontconfig --enable-frei0r --enable-gnutls --enable-iconv --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libfreetype --enable-libgme --enable-libgsm --enable-libilbc --enable-libmodplug --enable-libmfx --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libopus --enable-librtmp --enable-libschroedinger --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvo-amrwbenc --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxavs --enable-libxvid --enable-libzimg --enable-lzma --enable-decklink --enable-zlib
  libavutil      55. 22.100 / 55. 22.100
  libavcodec     57. 35.100 / 57. 35.100
  libavformat    57. 34.102 / 57. 34.102
  libavdevice    57.  0.101 / 57.  0.101
  libavfilter     6. 44.100 /  6. 44.100
  libswscale      4.  1.100 /  4.  1.100
  libswresample   2.  0.101 /  2.  0.101
  libpostproc    54.  0.100 / 54.  0.100
[mp3 @ 00000000010771e0] Estimating duration from bitrate, this may be inaccurate
Input #0, mp3, from 'in.mp3':
  Metadata:
    title           : jet-60-low
    artist          : Jon Dattorro
    album           : Tinnitus
    date            : 2003
    comment         : 105 Hz Q 1
    track           : 2
    genre           : Noise
  Duration: 01:00:00.11, start: 0.000000, bitrate: 64 kb/s
    Stream #0:0: Audio: mp3, 22050 Hz, stereo, s16p, 64 kb/s
[wav @ 0000000000edb020] Using AVStream.codec to pass codec parameters to muxers is deprecated, use AVStream.codecpar instead.
Output #0, wav, to 'out.wav':
  Metadata:
    INAM            : jet-60-low
    IART            : Jon Dattorro
    IPRD            : Tinnitus
    ICRD            : 2003
    ICMT            : 105 Hz Q 1
    IPRT            : 2
    IGNR            : Noise
    ISFT            : Lavf57.34.102
    Stream #0:0: Audio: pcm_s16le ([1][0][0][0] / 0x0001), 44100 Hz, stereo, s16, 1411 kb/s
    Metadata:
      encoder         : Lavc57.35.100 pcm_s16le
Stream mapping:
  Stream #0:0 -> #0:0 (mp3 (native) -> pcm_s16le (native))
Press [q] to stop, [?] for help
size=  620172kB time=01:00:00.09 bitrate=1411.2kbits/s speed= 225x
```

### FFmpeg on valid MP3 file with `-loglevel error` and with `-hide_banner` (new semantics)

```sh
$ ffmpeg -loglevel error -nostats -i in.mp3 -acodec pcm_s16le -ar 44100 out.wav -hide_banner
```

### FFmpeg on text file (invalid) with `-loglevel error` and with `-hide_banner` (new semantics)

```sh
$ ffmpeg -loglevel error -nostats -i in.txt -acodec pcm_s16le -ar 44100 out.wav -hide_banner
Output file #0 does not contain any stream
```