### PR TITLE
Add compression support for TextLineReader

### DIFF
--- a/tensorflow/core/ops/io_ops.cc
+++ b/tensorflow/core/ops/io_ops.cc
@@ -460,6 +460,7 @@ REGISTER_OP("TextLineReader")
     .Attr("skip_header_lines: int = 0")
     .Attr("container: string = ''")
     .Attr("shared_name: string = ''")
+    .Attr("compression_type: string = ''")
     .SetIsStateful()
     .SetShapeFn(TwoElementOutput)
     .Doc(R"doc(
@@ -471,6 +472,8 @@ container: If non-empty, this reader is placed in the given container.
         Otherwise, a default container is used.
 shared_name: If non-empty, this reader is named in the given bucket
              with this shared_name. Otherwise, the node name is used instead.
+compression_type: The type of compression for the file. Currently ZLIB and GZIP
+        are supported. Defaults to none.
 )doc");
 
 REGISTER_OP("TextLineReaderV2")
@@ -478,6 +481,7 @@ REGISTER_OP("TextLineReaderV2")
     .Attr("skip_header_lines: int = 0")
     .Attr("container: string = ''")
     .Attr("shared_name: string = ''")
+    .Attr("compression_type: string = ''")
     .SetIsStateful()
     .SetShapeFn(shape_inference::ScalarShape)
     .Doc(R"doc(
@@ -489,6 +493,8 @@ container: If non-empty, this reader is placed in the given container.
         Otherwise, a default container is used.
 shared_name: If non-empty, this reader is named in the given bucket
              with this shared_name. Otherwise, the node name is used instead.
+compression_type: The type of compression for the file. Currently ZLIB and GZIP
+        are supported. Defaults to none.
 )doc");
 
 // TODO(cwhipkey): mark this deprecated in favor of V2.

--- a/tensorflow/python/ops/io_ops.py
+++ b/tensorflow/python/ops/io_ops.py
@@ -394,15 +394,17 @@ class TextLineReader(ReaderBase):
   """
   # TODO(josh11b): Support serializing and restoring state.
 
-  def __init__(self, skip_header_lines=None, name=None):
+  def __init__(self, skip_header_lines=None, name=None, compression_type=None):
     """Create a TextLineReader.
 
     Args:
       skip_header_lines: An optional int. Defaults to 0.  Number of lines
         to skip from the beginning of every file.
       name: A name for the operation (optional).
+      compression_type: The type of compression for the file. Defaults to none.
     """
     rr = gen_io_ops._text_line_reader_v2(skip_header_lines=skip_header_lines,
+                                         compression_type=compression_type,
                                          name=name)
     super(TextLineReader, self).__init__(rr)
 


### PR DESCRIPTION
This fix tries to address the issue raised in #14593 where it was not possible to process compressed TextLineReader.

This fix add compression support for TextLineReader, similar to TFRecordReader.

Additional tests have been added.

This fix fixes #14593.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
