### PR TITLE
Add LICENSES to gitignore for iOS example

### DIFF
--- a/tensorflow/examples/ios/.gitignore
+++ b/tensorflow/examples/ios/.gitignore
@@ -2,3 +2,6 @@ project.xcworkspace
 xcuserdata
 imagenet_comp_graph_label_strings.txt
 tensorflow_inception_graph.pb
+simple/data/LICENSE
+camera/data/LICENSE
+benchmark/data/LICENSE


### PR DESCRIPTION
Update gitignore file for ios to cover the license files that get
installed following the install instructions.