### PR TITLE
Use the known fixed size of the tensor array instead of the dynamic one

### DIFF
--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -810,7 +810,8 @@ def _dynamic_rnn_loop(cell,
 
   # Unpack final output if not using output tuples.
   if in_graph_mode:
-    final_outputs = tuple(ta.stack() for ta in output_final_ta)
+    final_outputs = tuple(
+        ta.gather(range(time_steps)) for ta in output_final_ta)
     # Restore some shape information
     for output, output_size in zip(final_outputs, flat_output_size):
       shape = _concat(


### PR DESCRIPTION
For compatibility with XLA:  The tensorarray.size() operator produces graphs which are not caompatible with XLA.  The size of the tensor array is known explicitly, so by using that size we can avoid the incompatibility.

The other examples of stack() used in this file are not the same, and do not need adjusting.
