### PR TITLE
[CMake] Don't build tests for RE2

### DIFF
--- a/tensorflow/contrib/cmake/external/re2.cmake
+++ b/tensorflow/contrib/cmake/external/re2.cmake
@@ -45,4 +45,5 @@ ExternalProject_Add(re2
 		endif()
         -DCMAKE_BUILD_TYPE:STRING=Release
         -DCMAKE_INSTALL_PREFIX:STRING=${re2_INSTALL}
+	-DRE2_BUILD_TESTING:BOOL=OFF
 )

--- a/tensorflow/contrib/cmake/external/re2.cmake
+++ b/tensorflow/contrib/cmake/external/re2.cmake
@@ -45,5 +45,5 @@ ExternalProject_Add(re2
 		endif()
         -DCMAKE_BUILD_TYPE:STRING=Release
         -DCMAKE_INSTALL_PREFIX:STRING=${re2_INSTALL}
-	-DRE2_BUILD_TESTING:BOOL=OFF
+        -DRE2_BUILD_TESTING:BOOL=OFF
 )


### PR DESCRIPTION
Issue #14691 shows a build error on Windows in the RE2 tests. Since we do not run these tests, and they seem to be causing problems on some platforms, do not build them as part of the TensorFlow build.