### PR TITLE
Include _solib_local for MKL-DNN libs

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -176,7 +176,8 @@ def find_files(pattern, root):
 
 
 matches = ['../' + x for x in find_files('*', 'external') if '.py' not in x]
-matches += ['../' + x for x in find_files('*', '_solib_*') if '.py' not in x]
+matches += ['../' + x for x in find_files('*', '_solib_k8') if '.py' not in x]
+matches += ['../' + x for x in find_files('*', '_solib_local') if '.py' not in x]
 
 if os.name == 'nt':
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.pyd'

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -176,7 +176,7 @@ def find_files(pattern, root):
 
 
 matches = ['../' + x for x in find_files('*', 'external') if '.py' not in x]
-matches += ['../' + x for x in find_files('*', '_solib_k8') if '.py' not in x]
+matches += ['../' + x for x in find_files('*', '_solib_*') if '.py' not in x]
 
 if os.name == 'nt':
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.pyd'


### PR DESCRIPTION
`_solib_local/libmklml_intel.so` is not getting included in the package.
`build_pip_package.sh` has been updated to copy `*solib*` instead of just `_solib_k8`, so just update `setup.py` to include it.
See https://github.com/tensorflow/tensorflow/issues/13711 for details.