### PR TITLE
Add back whitespace

### DIFF
--- a/tensorflow/compiler/aot/tfcompile.bzl
+++ b/tensorflow/compiler/aot/tfcompile.bzl
@@ -152,7 +152,7 @@ def tf_library(name, graph, config,
            " --target_triple=" + target_llvm_triple() +
            " --out_header=$(@D)/" + header_file +
            " --out_object=$(@D)/" + object_file +
-           flags),
+           " " + flags),
       tools=[tfcompile_tool],
       visibility=visibility,
       testonly=testonly,


### PR DESCRIPTION
When `tfcompile_flags` was changed so it could be not just a string but also a list of strings, the initial white space was erroneously removed (probably a misunderstanding of str.join) meaning `--out_object=` would consume the first flag.

E.g. this would no longer work:
```
tf_library(
  tfcompile_flags = "--target_cpu='core-avx2'"
)
```

While this would work:
```
tf_library(
  tfcompile_flags = " --target_cpu='core-avx2'"
)
```