### PR TITLE
Edit mnist data read in to match tutorial

### DIFF
--- a/tensorflow/examples/tutorials/mnist/mnist_softmax.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_softmax.py
@@ -29,12 +29,10 @@ from tensorflow.examples.tutorials.mnist import input_data
 
 import tensorflow as tf
 
-FLAGS = None
-
 
 def main(_):
   # Import data
-  mnist = input_data.read_data_sets(FLAGS.data_dir, one_hot=True)
+  mnist = input_data.read_data_sets("MNIST_data/", one_hot=True)
 
   # Create the model
   x = tf.placeholder(tf.float32, [None, 784])
@@ -72,8 +70,4 @@ def main(_):
                                       y_: mnist.test.labels}))
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--data_dir', type=str, default='/tmp/tensorflow/mnist/input_data',
-                      help='Directory for storing input data')
-  FLAGS, unparsed = parser.parse_known_args()
-  tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
+  tf.app.run(main=main)


### PR DESCRIPTION
The accompanying tutorial (https://www.tensorflow.org/get_started/mnist/beginners) and this file did not match. The proposed code change was copied from the tutorial and confirmed to run correctly.

Note that this removes the ability to pass a custom data directory as an argument. However, since this is aimed at absolute beginners I believe clarity is more important than flexibility.