### PR TITLE
Fixing download_dependencies.sh bugs for generating TFLite iOS exmaples

### DIFF
--- a/tensorflow/contrib/lite/BUILD
+++ b/tensorflow/contrib/lite/BUILD
@@ -191,6 +191,9 @@ filegroup(
         exclude = [
             "**/METADATA",
             "**/OWNERS",
+            "downloads",
+            "examples",
+            "gen",
         ],
     ),
     visibility = ["//tensorflow:__subpackages__"],

--- a/tensorflow/contrib/lite/download_dependencies.sh
+++ b/tensorflow/contrib/lite/download_dependencies.sh
@@ -56,11 +56,19 @@ download_and_extract() {
   elif [[ "${url}" == *zip ]]; then
     tempdir=$(mktemp -d)
     tempdir2=$(mktemp -d)
-    wget -P ${tempdir} ${url}
-    unzip ${tempdir}/* -d ${tempdir2}
-    # unzip has no strip components, so unzip to a temp dir, and move the files
-    # we want from the tempdir to destination.
-    echo cp `find ${tempdir2} -type f` ${dir}/
+
+    curl -L ${url} > ${tempdir}/zipped.zip
+    unzip ${tempdir}/zipped.zip -d ${tempdir2}
+
+    # If the zip file contains nested directories, extract the files from the
+    # inner directory.
+    if ls ${tempdir2}/*/* 1> /dev/null 2>&1; then
+      # unzip has no strip components, so unzip to a temp dir, and move the
+      # files we want from the tempdir to destination.
+      cp -R ${tempdir2}/*/* ${dir}/
+    else
+      cp -R ${tempdir2}/* ${dir}/
+    fi
     rm -rf ${tempdir2} ${tempdir}
   fi
 


### PR DESCRIPTION
This is the 2nd try for #14631

To verify this:
* `git clean -fdx` to clean all local files. 
* run `tensorflow/contrib/lite/download_dependencies.sh`
* Verify that you see "download_dependencies.sh completed successfully", so the script is completed. 
* Verify these files are downloaded to correct location. 
 * tensorflow/contrib/lite/examples/ios/camera/data/labels.txt
 * tensorflow/contrib/lite/examples/ios/camera/data/mobilenet_quant_v1_224.tflite
 * tensorflow/contrib/lite/examples/ios/simple/data/labels.txt
 * tensorflow/contrib/lite/examples/ios/simple/data/mobilenet_v1_1.0_224.tflite
* Run `tensorflow/contrib/lite/build_ios_universal_lib.sh` to verify the library can be built. 