### PR TITLE
Add str(Label(...)) to bazel macros

### DIFF
--- a/tensorflow/core/platform/default/build_config_root.bzl
+++ b/tensorflow/core/platform/default/build_config_root.bzl
@@ -10,7 +10,9 @@ def tf_sycl_tests_tags():
 
 def tf_additional_plugin_deps():
   return select({
-      "//tensorflow:with_xla_support": ["//tensorflow/compiler/jit"],
+      str(Label("//tensorflow:with_xla_support")): [
+          str(Label("//tensorflow/compiler/jit"))
+      ],
       "//conditions:default": [],
   })
 
@@ -19,37 +21,37 @@ def tf_additional_xla_deps_py():
 
 def tf_additional_license_deps():
   return select({
-      "//tensorflow:with_xla_support": ["@llvm//:LICENSE.TXT"],
+      str(Label("//tensorflow:with_xla_support")): ["@llvm//:LICENSE.TXT"],
       "//conditions:default": [],
   })
 
 def tf_additional_verbs_deps():
   return select({
-      "//tensorflow:with_verbs_support": [
-          "//tensorflow/contrib/verbs:verbs_server_lib",
-          "//tensorflow/contrib/verbs:grpc_verbs_client",
-      ], 
+      str(Label("//tensorflow:with_verbs_support")): [
+          str(Label("//tensorflow/contrib/verbs:verbs_server_lib")),
+          str(Label("//tensorflow/contrib/verbs:grpc_verbs_client")),
+      ],
       "//conditions:default": [],
   })
 
 def tf_additional_mpi_deps():
   return select({
-      "//tensorflow:with_mpi_support": [
-          "//tensorflow/contrib/mpi:mpi_server_lib",
+      str(Label("//tensorflow:with_mpi_support")): [
+          str(Label("//tensorflow/contrib/mpi:mpi_server_lib")),
       ],
       "//conditions:default": [],
   })
 
 def tf_additional_gdr_deps():
   return select({
-      "//tensorflow:with_gdr_support": [
-          "//tensorflow/contrib/gdr:gdr_server_lib",
+      str(Label("//tensorflow:with_gdr_support")): [
+          str(Label("//tensorflow/contrib/gdr:gdr_server_lib")),
       ],
       "//conditions:default": [],
   })
 
 def if_static(extra_deps, otherwise=[]):
   return select({
-      "//tensorflow:framework_shared_object": otherwise,
+      str(Label("//tensorflow:framework_shared_object")): otherwise,
       "//conditions:default": extra_deps,
   })

--- a/third_party/mkl/build_defs.bzl
+++ b/third_party/mkl/build_defs.bzl
@@ -8,9 +8,7 @@ mkl_repository depends on the following environment variables:
   * `TF_MKL_ROOT`: The root folder where a copy of libmkl is located.
 """
 
-
 _TF_MKL_ROOT = "TF_MKL_ROOT"
-
 
 def if_mkl(if_true, if_false = []):
     """Shorthand for select()'ing on whether we're building with MKL.
@@ -20,14 +18,12 @@ def if_mkl(if_true, if_false = []):
 
     """
     return select({
-        "//third_party/mkl:using_mkl": if_true,
+        str(Label("//third_party/mkl:using_mkl")): if_true,
         "//conditions:default": if_false
     })
 
-
 def _enable_local_mkl(repository_ctx):
   return _TF_MKL_ROOT in repository_ctx.os.environ
-
 
 def _mkl_autoconf_impl(repository_ctx):
   """Implementation of the local_mkl_autoconf repository rule."""
@@ -52,12 +48,7 @@ def _mkl_autoconf_impl(repository_ctx):
   # Also setup BUILD file.
   repository_ctx.symlink(repository_ctx.attr.build_file, "BUILD")
 
-
 mkl_repository = repository_rule(
-    implementation = _mkl_autoconf_impl,
-    environ = [
-        _TF_MKL_ROOT,
-    ],
     attrs = {
         "build_file": attr.label(),
         "repository": attr.string(),
@@ -65,4 +56,8 @@ mkl_repository = repository_rule(
         "sha256": attr.string(default = ""),
         "strip_prefix": attr.string(default = ""),
     },
+    environ = [
+        _TF_MKL_ROOT,
+    ],
+    implementation = _mkl_autoconf_impl,
 )

--- a/third_party/mkl/build_defs.bzl
+++ b/third_party/mkl/build_defs.bzl
@@ -8,7 +8,9 @@ mkl_repository depends on the following environment variables:
   * `TF_MKL_ROOT`: The root folder where a copy of libmkl is located.
 """
 
+
 _TF_MKL_ROOT = "TF_MKL_ROOT"
+
 
 def if_mkl(if_true, if_false = []):
     """Shorthand for select()'ing on whether we're building with MKL.
@@ -22,8 +24,10 @@ def if_mkl(if_true, if_false = []):
         "//conditions:default": if_false
     })
 
+
 def _enable_local_mkl(repository_ctx):
   return _TF_MKL_ROOT in repository_ctx.os.environ
+
 
 def _mkl_autoconf_impl(repository_ctx):
   """Implementation of the local_mkl_autoconf repository rule."""
@@ -48,7 +52,12 @@ def _mkl_autoconf_impl(repository_ctx):
   # Also setup BUILD file.
   repository_ctx.symlink(repository_ctx.attr.build_file, "BUILD")
 
+
 mkl_repository = repository_rule(
+    implementation = _mkl_autoconf_impl,
+    environ = [
+        _TF_MKL_ROOT,
+    ],
     attrs = {
         "build_file": attr.label(),
         "repository": attr.string(),
@@ -56,8 +65,4 @@ mkl_repository = repository_rule(
         "sha256": attr.string(default = ""),
         "strip_prefix": attr.string(default = ""),
     },
-    environ = [
-        _TF_MKL_ROOT,
-    ],
-    implementation = _mkl_autoconf_impl,
 )


### PR DESCRIPTION
When using tensorflow as a submodule in bazel, importing bazel rules from tensorflow.bzl is not working.
The main reason is that some of the dependencies are hard coded instead of using str(Label(...)) and this makes bazel to generate dependencies like

//tensorflow

instead of

@org_tensorflow//tensorflow.

Most of bzl files under tensorflow use Label mechanism to allow supermodule to import tensorflow bazel rules like tf_cc_test, etc, but there were two files that did not use the Label mechanism and these two files block supermodule to import tensorflow bazel rules. This change updates those files to unblock bazel rule importing.