### PR TITLE
execute command properly in bash.exe on windows

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -107,7 +107,7 @@ def _apply_patch(repo_ctx, patch_file):
     bazel_sh = _get_env_var(repo_ctx, "BAZEL_SH")
     if not bazel_sh:
       fail("BAZEL_SH environment variable is not set")
-    cmd = [bazel_sh, "-c", " ".join(cmd)]
+    cmd = [bazel_sh, "-l", "-c", " ".join(cmd)]
   _execute_and_check_ret_code(repo_ctx, cmd)
 
 # Download the repository and apply a patch to its root


### PR DESCRIPTION
On windows using bazel:

```
# doesn't work
C:\Windows\system32>C:\msys64\usr\bin\bash.exe -c "patch --help"
/usr/bin/bash: patch: command not found

# works properly
C:\Windows\system32>C:\msys64\usr\bin\bash.exe -l -c "patch --help"
```

After adding `-l`, it works. 

```
...

E:\>cd tensorflow_dev

E:\tensorflow_dev>cd tensorflow

E:\tensorflow_dev\tensorflow>cd test_bazel

E:\tensorflow_dev\tensorflow\test_bazel>bazel build :test_bazel
...............
____Loading package: tensorflow/test_bazel
____Loading package: @bazel_tools//tools/cpp
____Loading package: @bazel_tools//tools/jdk
____Loading package: @local_config_xcode//
____Loading package: @local_jdk//
DEBUG: C:/users/win7-vm/appdata/local/temp/_bazel_win7-vm/9apswmfr/external/baze
l_tools/tools/cpp/lib_cc_configure.bzl:37:3:
Auto-Configuration Warning: 'BAZEL_VC' is not set, start looking for the latest
Visual C++ installed.

____Loading package: @local_config_cc//
DEBUG: C:/users/win7-vm/appdata/local/temp/_bazel_win7-vm/9apswmfr/external/baze
l_tools/tools/cpp/lib_cc_configure.bzl:37:3:
Auto-Configuration Warning: Looking for VS%VERSION%COMNTOOLS environment variabl
es,eg. VS140COMNTOOLS

DEBUG: C:/users/win7-vm/appdata/local/temp/_bazel_win7-vm/9apswmfr/external/baze
l_tools/tools/cpp/lib_cc_configure.bzl:37:3:
Auto-Configuration Warning: Visual C++ build tools found at C:\Program Files (x8
6)\Microsoft Visual Studio 14.0\VC\

____Loading complete.  Analyzing...
____Downloading https://mirror.bazel.build/github.com/google/protobuf/archive/b0
4e5cba356212e4e8c66c61bbe0c3a20537c5b9.tar.gz: 713,130 bytes
...
ERROR: E:/tensorflow_dev/tensorflow/test_bazel/BUILD:3:1: error loading package
'tensorflow': Encountered error while reading extension file 'protobuf.bzl': no
such package '@protobuf_archive//': Traceback (most recent call last):
        File "E:/tensorflow_dev/tensorflow/workspace.bzl", line 119
                _apply_patch(repo_ctx, repo_ctx.attr.patch_file)
        File "E:/tensorflow_dev/tensorflow/workspace.bzl", line 111, in _apply_p
atch
                _execute_and_check_ret_code(repo_ctx, cmd)
        File "E:/tensorflow_dev/tensorflow/workspace.bzl", line 92, in _execute_
and_check_ret_code
                fail("Non-zero return code({1}) when ...))
Non-zero return code(127) when executing 'C:\msys64\usr\bin\bash.exe -c patch -p
1 -d C:/users/win7-vm/appdata/local/temp/_bazel_win7-vm/9apswmfr/external/protob
uf_archive -i E:/tensorflow_dev/third_party/protobuf/add_noinlines.patch':
Stdout:
Stderr: /usr/bin/bash: patch: command not found
 and referenced by '//tensorflow/test_bazel:test_bazel'.
ERROR: E:/tensorflow_dev/tensorflow/test_bazel/BUILD:3:1: error loading package
'tensorflow': Encountered error while reading extension file 'protobuf.bzl': no
such package '@protobuf_archive//': Traceback (most recent call last):
        File "E:/tensorflow_dev/tensorflow/workspace.bzl", line 119
                _apply_patch(repo_ctx, repo_ctx.attr.patch_file)
        File "E:/tensorflow_dev/tensorflow/workspace.bzl", line 111, in _apply_p
atch
                _execute_and_check_ret_code(repo_ctx, cmd)
        File "E:/tensorflow_dev/tensorflow/workspace.bzl", line 92, in _execute_
and_check_ret_code
                fail("Non-zero return code({1}) when ...))
Non-zero return code(127) when executing 'C:\msys64\usr\bin\bash.exe -c patch -p
1 -d C:/users/win7-vm/appdata/local/temp/_bazel_win7-vm/9apswmfr/external/protob
uf_archive -i E:/tensorflow_dev/third_party/protobuf/add_noinlines.patch':
Stdout:
Stderr: /usr/bin/bash: patch: command not found
 and referenced by '//tensorflow/test_bazel:test_bazel'.
ERROR: Analysis of target '//tensorflow/test_bazel:test_bazel' failed; build abo
rted: error loading package 'tensorflow': Encountered error while reading extens
ion file 'protobuf.bzl': no such package '@protobuf_archive//': Traceback (most
recent call last):
        File "E:/tensorflow_dev/tensorflow/workspace.bzl", line 119
                _apply_patch(repo_ctx, repo_ctx.attr.patch_file)
        File "E:/tensorflow_dev/tensorflow/workspace.bzl", line 111, in _apply_p
atch
                _execute_and_check_ret_code(repo_ctx, cmd)
        File "E:/tensorflow_dev/tensorflow/workspace.bzl", line 92, in _execute_
and_check_ret_code
                fail("Non-zero return code({1}) when ...))
Non-zero return code(127) when executing 'C:\msys64\usr\bin\bash.exe -c patch -p
1 -d C:/users/win7-vm/appdata/local/temp/_bazel_win7-vm/9apswmfr/external/protob
uf_archive -i E:/tensorflow_dev/third_party/protobuf/add_noinlines.patch':
Stdout:
Stderr: /usr/bin/bash: patch: command not found
.
____Elapsed time: 20.658s

E:\tensorflow_dev\tensorflow\test_bazel>
```