### PR TITLE
[XLA] Use the specific float list rather than a hard coded list

### DIFF
--- a/tensorflow/compiler/tests/categorical_op_test.py
+++ b/tensorflow/compiler/tests/categorical_op_test.py
@@ -99,7 +99,7 @@ class CategoricalTest(XLATestCase):
     self._testRngIsNotConstant(rng, dtype)
 
   def testCategoricalIsInRange(self):
-    for dtype in [dtypes.float32, dtypes.float64]:
+    for dtype in self.float_types:
       with self.test_session() as sess:
         with self.test_scope():
           x = random_ops.multinomial(


### PR DESCRIPTION
This change makes the test use the list of supported types for the backend under test, rather than a hard coded list.

