### PR TITLE
Update Eigen hash for fix of fp16 predux bug

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -188,11 +188,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   native.new_http_archive(
       name = "eigen_archive",
       urls = [
-          "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/429aa5254200.tar.gz",
-          "https://bitbucket.org/eigen/eigen/get/429aa5254200.tar.gz",
+          "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/b6e6d0cf6a77.tar.gz",
+          "https://bitbucket.org/eigen/eigen/get/b6e6d0cf6a77.tar.gz",
       ],
-      sha256 = "61d8b6fc4279dd1dda986fb1677d15e3d641c07a3ea5abe255790b1f0c0c14e9",
-      strip_prefix = "eigen-eigen-429aa5254200",
+      sha256 = "0840c497f2749b5e90bda666aab96be6da90dc75b4e21ca9843cae69b7fed52a",
+      strip_prefix = "eigen-eigen-b6e6d0cf6a77",
       build_file = str(Label("//third_party:eigen.BUILD")),
   )
 


### PR DESCRIPTION
Attention: @benoitsteiner and @zheng-xq 

For Maxwell and earlier GPUs, Eigen was incorrectly casting fp16 values to
unsigned int during some reductions. This causes incorrect results in
Tensorflow's xent and sparse_xent ops when applied to fp16 data.