### PR TITLE
Fix nccl.BUILD on Windows

### DIFF
--- a/third_party/nccl.BUILD
+++ b/third_party/nccl.BUILD
@@ -55,7 +55,7 @@ cc_library(
         ],
         "@%ws%//tensorflow:ios": [],
         "@%ws%//tensorflow:windows": [
-            "ws2_32.lib",
+            "-DEFAULTLIB:ws2_32.lib",
         ],
         "//conditions:default": [
             "-lrt",


### PR DESCRIPTION
Bazel doesn't allow a random file name in `linkopts` attribute, so use `-DEFAULTLIB:` option to specify `ws2_32.lib`