### PR TITLE
Fix missing __sincos in XLA on macOS

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
+++ b/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
@@ -41,6 +41,11 @@ limitations under the License.
 #include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/core/platform/logging.h"
 
+#if defined(__APPLE__)
+static void sincos(double, double*, double*)  __attribute__((weakref ("__sincos")));
+static void sincosf(float, float*, float*)    __attribute__((weakref ("__sincosf")));
+#endif
+
 namespace xla {
 namespace cpu {
 namespace {


### PR DESCRIPTION
Building XLA on macOS failed due to missing `__sincos` and `__sincosf`. 

```
tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc:285:3: error: use of undeclared identifier 'sincosf'; did you mean '__sincosf'?
tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc:285:24: error: use of undeclared identifier 'sincos'; did you mean '__sincos'?
```

https://github.com/tensorflow/tensorflow/pull/14288 tried to fix the issue but still needs https://github.com/tensorflow/tensorflow/pull/14137 too.