### PR TITLE
Fix crash on closing the app when classifier failed to initialize

### DIFF
--- a/tensorflow/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/Camera2BasicFragment.java
+++ b/tensorflow/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/Camera2BasicFragment.java
@@ -476,7 +476,9 @@ public class Camera2BasicFragment extends Fragment
 
   @Override
   public void onDestroy() {
-    classifier.close();
+    if (classifier != null) {
+      classifier.close();
+    }
     super.onDestroy();
   }
 


### PR DESCRIPTION
When testing on an API 21 emulator, the classifier fails to initialize.
`E/TfLiteCameraDemo: Failed to initialize an image classifier.`

In this situation, the app crashes when pressing Back to exit.  Here's the cause:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.example.android.tflitecamerademo.ImageClassifier.close()' on a null object reference
                                                                                        at com.example.android.tflitecamerademo.Camera2BasicFragment.onDestroy(Camera2BasicFragment.java:331)
                                                                                        at android.app.Fragment.performDestroy(Fragment.java:2266)
```
The fix is to check for null before calling `.close()`.

I'll investigate why the classifier is failing to initialize separately. :-)  FTR, the UI does report the error nicely:
![screen shot 2017-11-23 at 12 58 23 pm](https://user-images.githubusercontent.com/739125/33185236-3e6cbb68-d04f-11e7-9deb-c1bf90a46e50.png)
