### PR TITLE
Add batch support for various image_ops

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -390,16 +390,17 @@ def rot90(image, k=1, name=None):
              (math_ops.equal(k, 2), _rot180),
              (math_ops.equal(k, 3), _rot270)]
 
-    ret = control_flow_ops.case(cases, default=lambda: image, exclusive=True,
+    result = control_flow_ops.case(cases, default=lambda: image, exclusive=True,
                                 name=scope)
 
     shape = image.get_shape()
-    ret.set_shape([shape[0], None, None, shape[3]])
+    result.set_shape([shape[0], None, None, shape[3]])
 
-    if is_batch != True:
-      ret = array_ops.squeeze(ret, squeeze_dims=[0])
+    if is_batch == True:
+      return result
 
-    return ret
+    result = array_ops.squeeze(result, squeeze_dims=[0])
+    return result
 
 
 def transpose_image(image):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -234,19 +234,20 @@ def fix_image_flip_shape_v2(original_shape, result, rank=3):
   return result
 
 def random_flip_up_down(image, seed=None):
-  """Randomly flips an image vertically (upside down).
+  """Randomly flips image(s) vertically (upside down).
 
-  With a 1 in 2 chance, outputs the contents of `image` flipped along the first
-  dimension, which is `height`.  Otherwise output the image as-is.
+  With a 1 in 2 chance, outputs the contents of `image` flipped along the height
+  dimension. Otherwise output the image as-is.
 
   Args:
-    image: A 3-D tensor of shape `[height, width, channels].`
+    image: 4-D Tensor of shape `[batch, height, width, channels]` or
+           3-D Tensor of shape `[height, width, channels]`.
     seed: A Python integer. Used to create a random seed. See
       @{tf.set_random_seed}
       for behavior.
 
   Returns:
-    A 3-D tensor of the same type and shape as `image`.
+    A tensor of the same type and shape as `image`.
 
   Raises:
     ValueError: if the shape of `image` not supported.
@@ -271,19 +272,20 @@ def random_flip_up_down(image, seed=None):
 
 
 def random_flip_left_right(image, seed=None):
-  """Randomly flip an image horizontally (left to right).
+  """Randomly flip image(s) horizontally (left to right).
 
   With a 1 in 2 chance, outputs the contents of `image` flipped along the
-  second dimension, which is `width`.  Otherwise output the image as-is.
+  width dimension. Otherwise output the image as-is.
 
   Args:
-    image: A 3-D tensor of shape `[height, width, channels].`
+    image: 4-D Tensor of shape `[batch, height, width, channels]` or
+           3-D Tensor of shape `[height, width, channels]`.
     seed: A Python integer. Used to create a random seed. See
       @{tf.set_random_seed}
       for behavior.
 
   Returns:
-    A 3-D tensor of the same type and shape as `image`.
+    A tensor of the same type and shape as `image`.
 
   Raises:
     ValueError: if the shape of `image` not supported.
@@ -310,16 +312,16 @@ def random_flip_left_right(image, seed=None):
 def flip_left_right(image):
   """Flip an image horizontally (left to right).
 
-  Outputs the contents of `image` flipped along the second dimension, which is
-  `width`.
+  Outputs the contents of `image` flipped along the width dimension.
 
   See also `reverse()`.
 
   Args:
-    image: A 3-D tensor of shape `[height, width, channels].`
+    image: 4-D Tensor of shape `[batch, height, width, channels]` or
+           3-D Tensor of shape `[height, width, channels]`.
 
   Returns:
-    A 3-D tensor of the same type and shape as `image`.
+    A tensor of the same type and shape as `image`.
 
   Raises:
     ValueError: if the shape of `image` not supported.
@@ -342,16 +344,16 @@ def flip_left_right(image):
 def flip_up_down(image):
   """Flip an image vertically (upside down).
 
-  Outputs the contents of `image` flipped along the first dimension, which is
-  `height`.
+  Outputs the contents of `image` flipped along the height dimension.
 
   See also `reverse()`.
 
   Args:
-    image: A 3-D tensor of shape `[height, width, channels].`
+    image: 4-D Tensor of shape `[batch, height, width, channels]` or
+           3-D Tensor of shape `[height, width, channels]`.
 
   Returns:
-    A 3-D tensor of the same type and shape as `image`.
+    A tensor of the same type and shape as `image`.
 
   Raises:
     ValueError: if the shape of `image` not supported.
@@ -372,15 +374,19 @@ def flip_up_down(image):
 
 
 def rot90(image, k=1, name=None):
-  """Rotate an image counter-clockwise by 90 degrees.
+  """Rotate image(s) counter-clockwise by 90 degrees.
 
   Args:
-    image: A 3-D tensor of shape `[height, width, channels]`.
+    image: 4-D Tensor of shape `[batch, height, width, channels]` or
+           3-D Tensor of shape `[height, width, channels]`.
     k: A scalar integer. The number of times the image is rotated by 90 degrees.
     name: A name for this operation (optional).
 
   Returns:
-    A rotated 3-D tensor of the same type and shape as `image`.
+    A rotated of the same type and shape as `image`.
+
+  Raises:
+    ValueError: if the shape of `image` not supported.
   """
   with ops.name_scope(name, 'rot90', [image, k]) as scope:
     image = ops.convert_to_tensor(image, name='image')
@@ -416,15 +422,19 @@ def rot90(image, k=1, name=None):
 
 
 def transpose_image(image):
-  """Transpose an image by swapping the first and second dimension.
+  """Transpose an image by swapping the height and width dimension.
 
   See also `transpose()`.
 
   Args:
-    image: 3-D tensor of shape `[height, width, channels]`
+    image: 4-D Tensor of shape `[batch, height, width, channels]` or
+           3-D Tensor of shape `[height, width, channels]`.
 
   Returns:
-    A 3-D tensor of shape `[width, height, channels]`
+    If `image` was 4-D, a 4-D float Tensor of shape
+    `[batch, width, height, channels]`
+    If `image` was 3-D, a 3-D float Tensor of shape
+    `[width, height, channels]`
 
   Raises:
     ValueError: if the shape of `image` not supported.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -225,7 +225,6 @@ def _flip_image(image, axis, random=False, seed=None):
 
   Raises:
     ValueError: if image is not a 3-D or 4-D Tensor.
-    ValueError: if image is not a 3-D or 4-D Tensor.
 
   Returns:
     A tensor of the same type and shape as `image`

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -183,19 +183,33 @@ def _CheckAtLeast3DImage(image, require_static=True):
 
 
 def _EnsureTensorIs4D(image):
-    original_shape = image.get_shape()
-    is_batch = True
-    if original_shape.ndims == 3:
-      is_batch = False
-      image = array_ops.expand_dims(image, 0)
-    elif original_shape.ndims is None:
-      is_batch = False
-      image = array_ops.expand_dims(image, 0)
-      image.set_shape([None] * 4)
-    elif original_shape.ndims != 4:
-        raise ValueError('\'image\' must have either 3 or 4 dimensions.')
+  """Converts `image` to a 4-D Tensor if it is not already one
 
-    return (image, is_batch)
+  Args:
+    image: 4-D Tensor of shape `[batch, height, width, channels]` or
+           3-D Tensor of shape `[height, width, channels]`.
+  Raises:
+    ValueError: if image is not a 3-D or 4-D Tensor.
+
+  Returns:
+    If `image` was 4-D, a 4-D float Tensor of shape
+    `[batch, width, height, channels]`
+    If `image` was 3-D, a 4-D float Tensor of shape
+    `[1, width, height, channels]`
+  """
+  original_shape = image.get_shape()
+  is_batch = True
+  if original_shape.ndims == 3:
+    is_batch = False
+    image = array_ops.expand_dims(image, 0)
+  elif original_shape.ndims is None:
+    is_batch = False
+    image = array_ops.expand_dims(image, 0)
+    image.set_shape([None] * 4)
+  elif original_shape.ndims != 4:
+    raise ValueError('\'image\' must have either 3 or 4 dimensions.')
+
+  return (image, is_batch)
 
 
 def fix_image_flip_shape(image, result, rank=3):
@@ -242,17 +256,18 @@ def random_flip_up_down(image, seed=None):
   image = control_flow_ops.with_dependencies(
       _CheckAtLeast3DImage(image, require_static=False), image)
 
-  batch, height, width, depth = _ImageDimensions(image, rank=4)
+  batch, _, _, _ = _ImageDimensions(image, rank=4)
 
   uniform_random = random_ops.random_uniform([batch], 0, 1.0, seed=seed)
   mirror_cond = math_ops.less(uniform_random, .5)
-  result = array_ops.where(mirror_cond, x=image, y=array_ops.reverse(image, [1]))
+  result = array_ops.where(mirror_cond, x=image,
+                           y=array_ops.reverse(image, [1]))
 
   if is_batch:
     return fix_image_flip_shape(original_image, result, rank=4)
-  else:
-    result = array_ops.squeeze(result, squeeze_dims=[0])
-    return fix_image_flip_shape(original_image, result, rank=3)
+
+  result = array_ops.squeeze(result, squeeze_dims=[0])
+  return fix_image_flip_shape(original_image, result, rank=3)
 
 
 def random_flip_left_right(image, seed=None):
@@ -280,17 +295,18 @@ def random_flip_left_right(image, seed=None):
   image = control_flow_ops.with_dependencies(
       _CheckAtLeast3DImage(image, require_static=False), image)
 
-  batch, height, width, depth = _ImageDimensions(image, rank=4)
+  batch, _, _, _ = _ImageDimensions(image, rank=4)
 
   uniform_random = random_ops.random_uniform([batch], 0, 1.0, seed=seed)
   mirror_cond = math_ops.less(uniform_random, .5)
 
-  result = array_ops.where(mirror_cond, x=image, y=array_ops.reverse(image, [2]))
+  result = array_ops.where(mirror_cond, x=image,
+                           y=array_ops.reverse(image, [2]))
   if is_batch:
     return fix_image_flip_shape(original_image, result, rank=4)
-  else:
-    result = array_ops.squeeze(result, squeeze_dims=[0])
-    return fix_image_flip_shape(original_image, result, rank=3)
+
+  result = array_ops.squeeze(result, squeeze_dims=[0])
+  return fix_image_flip_shape(original_image, result, rank=3)
 
 
 def flip_left_right(image):
@@ -320,9 +336,9 @@ def flip_left_right(image):
 
   if is_batch:
     return fix_image_flip_shape(original_image, result, rank=4)
-  else:
-    result = array_ops.squeeze(result, squeeze_dims=[0])
-    return fix_image_flip_shape(original_image, result, rank=3)
+
+  result = array_ops.squeeze(result, squeeze_dims=[0])
+  return fix_image_flip_shape(original_image, result, rank=3)
 
 
 def flip_up_down(image):
@@ -352,9 +368,9 @@ def flip_up_down(image):
 
   if is_batch:
     return fix_image_flip_shape(original_image, result, rank=4)
-  else:
-    result = array_ops.squeeze(result, squeeze_dims=[0])
-    return fix_image_flip_shape(original_image, result, rank=3)
+
+  result = array_ops.squeeze(result, squeeze_dims=[0])
+  return fix_image_flip_shape(original_image, result, rank=3)
 
 
 def rot90(image, k=1, name=None):
@@ -432,9 +448,9 @@ def transpose_image(image):
 
   if is_batch:
     return result
-  else:
-    result = array_ops.squeeze(result, squeeze_dims=[0])
-    return result
+
+  result = array_ops.squeeze(result, squeeze_dims=[0])
+  return result
 
 
 def central_crop(image, central_fraction):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -182,8 +182,8 @@ def _CheckAtLeast3DImage(image, require_static=True):
     return []
 
 
-def fix_image_flip_shape(image, result):
-  """Set the shape to 3 dimensional if we don't know anything else.
+def fix_image_flip_shape(image, result, rank=3):
+  """Set the shape to original dimensional if we don't know anything else.
 
   Args:
     image: original image size
@@ -195,7 +195,7 @@ def fix_image_flip_shape(image, result):
 
   image_shape = image.get_shape()
   if image_shape == tensor_shape.unknown_shape():
-    result.set_shape([None, None, None])
+    result.set_shape([None] * rank)
   else:
     result.set_shape(image_shape)
   return result

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -220,7 +220,7 @@ def _flip_image(image, axis, random=False, seed=None):
             3-D Tensor of shape `[height, width, channels]`.
     axis:   A Python integer representing the axis on which the image(s)
             will be flipped. Note: The provided axis must be specified relative
-            to the shape `[batch, height, width, channels]` as .3-D images will
+            to the shape `[batch, height, width, channels]` as 3-D images will
             be expanded to fit this shape before being flipped.
     random: A boolean representing whether or not we should flip the
             image(s) at random.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -259,6 +259,7 @@ def random_flip_up_down(image, seed=None):
   result = control_flow_ops.cond(mirror_cond,
                                  lambda: array_ops.reverse(image, [0]),
                                  lambda: image)
+
   return fix_image_flip_shape(image, result)
 
 
@@ -281,14 +282,23 @@ def random_flip_left_right(image, seed=None):
     ValueError: if the shape of `image` not supported.
   """
   image = ops.convert_to_tensor(image, name='image')
+  original_shape = image.get_shape()
+  image, is_batch = _EnsureTensorIs4D(image)
   image = control_flow_ops.with_dependencies(
-      _Check3DImage(image, require_static=False), image)
-  uniform_random = random_ops.random_uniform([], 0, 1.0, seed=seed)
+      _CheckAtLeast3DImage(image, require_static=False), image)
+
+  batch, height, width, depth = _ImageDimensions(image, rank=4)
+
+  uniform_random = random_ops.random_uniform([batch], 0, 1.0, seed=seed)
   mirror_cond = math_ops.less(uniform_random, .5)
-  result = control_flow_ops.cond(mirror_cond,
-                                 lambda: array_ops.reverse(image, [1]),
-                                 lambda: image)
-  return fix_image_flip_shape(image, result)
+
+  result = array_ops.where(mirror_cond, x=image, y=array_ops.reverse(image, [2]))
+  if is_batch:
+    return fix_image_flip_shape_v2(original_shape, result, rank=4)
+  else:
+    result = array_ops.squeeze(result, squeeze_dims=[0])
+    return fix_image_flip_shape_v2(original_shape, result, rank=3)
+
 
 
 def flip_left_right(image):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -216,12 +216,16 @@ def _flip_image(image, axis, random=False, seed=None):
   Flips image(s) around a given axis.
 
   Args:
-    image: 4-D Tensor of shape `[batch, height, width, channels]` or
-           3-D Tensor of shape `[height, width, channels]`.
-
-    axis:  A Tensor. Must be one of the following types: int32, int64. 1-D.
-           The indices of the dimensions to reverse. Must be in the range
-           [-rank(tensor), rank(tensor))
+    image:  4-D Tensor of shape `[batch, height, width, channels]` or
+            3-D Tensor of shape `[height, width, channels]`.
+    axis:   A Python integer representing the axis on which the image(s)
+            will be flipped. Note: The provided axis must be specified relative
+            to the shape `[batch, height, width, channels]` as .3-D images will
+            be expanded to fit this shape before being flipped.
+    random: A boolean representing whether or not we should flip the
+            image(s) at random.
+    seed:   Python integer. Used to create a random seed. See
+            tf.set_random_seed for behavior.
 
   Raises:
     ValueError: if image is not a 3-D or 4-D Tensor.
@@ -237,7 +241,7 @@ def _flip_image(image, axis, random=False, seed=None):
     _CheckAtLeast3DImage(image, require_static=False), image)
 
   batch, _, _, _ = _ImageDimensions(image, rank=4)
-  flipped = array_ops.reverse(image, axis)
+  flipped = array_ops.reverse(image, [axis])
 
   if random == True:
     uniform_random = random_ops.random_uniform([batch], 0, 1.0, seed=seed)
@@ -289,7 +293,7 @@ def random_flip_up_down(image, seed=None):
   Raises:
     ValueError: if the shape of `image` not supported.
   """
-  return _flip_image(image, [1], random=True, seed=seed)
+  return _flip_image(image, axis=1, random=True, seed=seed)
 
 
 def random_flip_left_right(image, seed=None):
@@ -311,7 +315,7 @@ def random_flip_left_right(image, seed=None):
   Raises:
     ValueError: if the shape of `image` not supported.
   """
-  return _flip_image(image, [2], random=True, seed=seed)
+  return _flip_image(image, axis=2, random=True, seed=seed)
 
 
 def flip_left_right(image):
@@ -331,7 +335,7 @@ def flip_left_right(image):
   Raises:
     ValueError: if the shape of `image` not supported.
   """
-  return _flip_image(image, [2], random=False)
+  return _flip_image(image, axis=2, random=False)
 
 def flip_up_down(image):
   """Flip an image vertically (upside down).
@@ -350,7 +354,7 @@ def flip_up_down(image):
   Raises:
     ValueError: if the shape of `image` not supported.
   """
-  return _flip_image(image, [1], random=False)
+  return _flip_image(image, axis=1, random=False)
 
 
 def rot90(image, k=1, name=None):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -216,22 +216,6 @@ def fix_image_flip_shape(image, result, rank=3):
     result.set_shape(image_shape)
   return result
 
-def fix_image_flip_shape_v2(original_shape, result, rank=3):
-  """Set the shape to original dimensional if we don't know anything else.
-
-  Args:
-    image: original image size
-    result: flipped or transformed image
-
-  Returns:
-    An image whose shape is at least None,None,None.
-  """
-
-  if original_shape == tensor_shape.unknown_shape():
-    result.set_shape([None] * rank)
-  else:
-    result.set_shape(original_shape)
-  return result
 
 def random_flip_up_down(image, seed=None):
   """Randomly flips image(s) vertically (upside down).
@@ -253,7 +237,7 @@ def random_flip_up_down(image, seed=None):
     ValueError: if the shape of `image` not supported.
   """
   image = ops.convert_to_tensor(image, name='image')
-  original_shape = image.get_shape()
+  original_image = image
   image, is_batch = _EnsureTensorIs4D(image)
   image = control_flow_ops.with_dependencies(
       _CheckAtLeast3DImage(image, require_static=False), image)
@@ -265,10 +249,10 @@ def random_flip_up_down(image, seed=None):
   result = array_ops.where(mirror_cond, x=image, y=array_ops.reverse(image, [1]))
 
   if is_batch:
-    return fix_image_flip_shape_v2(original_shape, result, rank=4)
+    return fix_image_flip_shape(original_image, result, rank=4)
   else:
     result = array_ops.squeeze(result, squeeze_dims=[0])
-    return fix_image_flip_shape_v2(original_shape, result, rank=3)
+    return fix_image_flip_shape(original_image, result, rank=3)
 
 
 def random_flip_left_right(image, seed=None):
@@ -291,7 +275,7 @@ def random_flip_left_right(image, seed=None):
     ValueError: if the shape of `image` not supported.
   """
   image = ops.convert_to_tensor(image, name='image')
-  original_shape = image.get_shape()
+  original_image = image
   image, is_batch = _EnsureTensorIs4D(image)
   image = control_flow_ops.with_dependencies(
       _CheckAtLeast3DImage(image, require_static=False), image)
@@ -303,10 +287,10 @@ def random_flip_left_right(image, seed=None):
 
   result = array_ops.where(mirror_cond, x=image, y=array_ops.reverse(image, [2]))
   if is_batch:
-    return fix_image_flip_shape_v2(original_shape, result, rank=4)
+    return fix_image_flip_shape(original_image, result, rank=4)
   else:
     result = array_ops.squeeze(result, squeeze_dims=[0])
-    return fix_image_flip_shape_v2(original_shape, result, rank=3)
+    return fix_image_flip_shape(original_image, result, rank=3)
 
 
 def flip_left_right(image):
@@ -327,7 +311,7 @@ def flip_left_right(image):
     ValueError: if the shape of `image` not supported.
   """
   image = ops.convert_to_tensor(image, name='image')
-  original_shape = image.get_shape()
+  original_image = image
   image, is_batch = _EnsureTensorIs4D(image)
   image = control_flow_ops.with_dependencies(
       _CheckAtLeast3DImage(image, require_static=False), image)
@@ -335,10 +319,10 @@ def flip_left_right(image):
   result = array_ops.reverse(image, [2])
 
   if is_batch:
-    return fix_image_flip_shape_v2(original_shape, result, rank=4)
+    return fix_image_flip_shape(original_image, result, rank=4)
   else:
     result = array_ops.squeeze(result, squeeze_dims=[0])
-    return fix_image_flip_shape_v2(original_shape, result, rank=3)
+    return fix_image_flip_shape(original_image, result, rank=3)
 
 
 def flip_up_down(image):
@@ -359,7 +343,7 @@ def flip_up_down(image):
     ValueError: if the shape of `image` not supported.
   """
   image = ops.convert_to_tensor(image, name='image')
-  original_shape = image.get_shape()
+  original_image = image
   image, is_batch = _EnsureTensorIs4D(image)
   image = control_flow_ops.with_dependencies(
       _CheckAtLeast3DImage(image, require_static=False), image)
@@ -367,10 +351,10 @@ def flip_up_down(image):
   result = array_ops.reverse(image, [1])
 
   if is_batch:
-    return fix_image_flip_shape_v2(original_shape, result, rank=4)
+    return fix_image_flip_shape(original_image, result, rank=4)
   else:
     result = array_ops.squeeze(result, squeeze_dims=[0])
-    return fix_image_flip_shape_v2(original_shape, result, rank=3)
+    return fix_image_flip_shape(original_image, result, rank=3)
 
 
 def rot90(image, k=1, name=None):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -423,9 +423,18 @@ def transpose_image(image):
     ValueError: if the shape of `image` not supported.
   """
   image = ops.convert_to_tensor(image, name='image')
+  original_shape = image.get_shape()
+  image, is_batch = _EnsureTensorIs4D(image)
   image = control_flow_ops.with_dependencies(
-      _Check3DImage(image, require_static=False), image)
-  return array_ops.transpose(image, [1, 0, 2], name='transpose_image')
+      _CheckAtLeast3DImage(image, require_static=False), image)
+
+  result = array_ops.transpose(image, [0, 2, 1, 3], name='transpose_image')
+
+  if is_batch:
+    return result
+  else:
+    result = array_ops.squeeze(result, squeeze_dims=[0])
+    return result
 
 
 def central_crop(image, central_fraction):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -309,9 +309,18 @@ def flip_left_right(image):
     ValueError: if the shape of `image` not supported.
   """
   image = ops.convert_to_tensor(image, name='image')
+  original_shape = image.get_shape()
+  image, is_batch = _EnsureTensorIs4D(image)
   image = control_flow_ops.with_dependencies(
-      _Check3DImage(image, require_static=False), image)
-  return fix_image_flip_shape(image, array_ops.reverse(image, [1]))
+      _CheckAtLeast3DImage(image, require_static=False), image)
+
+  result = array_ops.reverse(image, [2])
+
+  if is_batch:
+    return fix_image_flip_shape_v2(original_shape, result, rank=4)
+  else:
+    result = array_ops.squeeze(result, squeeze_dims=[0])
+    return fix_image_flip_shape_v2(original_shape, result, rank=3)
 
 
 def flip_up_down(image):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -739,7 +739,7 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
 
   def testIdempotentLeftRightWithBatch(self):
     x_np = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
       y = image_ops.flip_left_right(image_ops.flip_left_right(x_tf))
@@ -758,9 +758,9 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
 
   def testLeftRightWithBatch(self):
     x_np = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
     y_np = np.array([[[3, 2, 1], [3, 2, 1]], [[3, 2, 1], [3, 2, 1]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -791,9 +791,9 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
 
   def testRandomFlipLeftRightWithBatch(self):
     x_np = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
     y_np = np.array([[[3, 2, 1], [3, 2, 1]], [[3, 2, 1], [3, 2, 1]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape).eval()
@@ -803,16 +803,16 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       for _ in range(50):
         y_tf = y.eval()
         for index in range(0, x_tf.shape[0]):
-            current_x_tf = x_tf[index]
-            current_y_tf = y_tf[index]
-            current_y_np = y_np[index]
+          current_x_tf = x_tf[index]
+          current_y_tf = y_tf[index]
+          current_y_np = y_np[index]
 
-            if current_y_tf[0][0] == 1:
-              self.assertAllEqual(current_y_tf, current_x_tf)
-              count_unflipped += 1
-            else:
-              self.assertAllEqual(current_y_tf, current_y_np)
-              count_flipped += 1
+          if current_y_tf[0][0] == 1:
+            self.assertAllEqual(current_y_tf, current_x_tf)
+            count_unflipped += 1
+          else:
+            self.assertAllEqual(current_y_tf, current_y_np)
+            count_flipped += 1
       self.assertGreaterEqual(count_flipped, 1)
       self.assertGreaterEqual(count_unflipped, 1)
 
@@ -827,7 +827,7 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
 
   def testIdempotentUpDownWithBatch(self):
     x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -847,9 +847,9 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
 
   def testUpDownWithBatch(self):
     x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
     y_np = np.array([[[4, 5, 6], [1, 2, 3]], [[10, 11, 12], [7, 8, 9]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -879,9 +879,9 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
 
   def testRandomFlipUpDownWithBatch(self):
     x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
     y_np = np.array([[[4, 5, 6], [1, 2, 3]], [[4, 5, 6], [1, 2, 3]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape).eval()
@@ -891,9 +891,9 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       for _ in range(50):
         y_tf = y.eval()
         for index in range(0, x_tf.shape[0]):
-            current_x_tf = x_tf[index]
-            current_y_tf = y_tf[index]
-            current_y_np = y_np[index]
+          current_x_tf = x_tf[index]
+          current_y_tf = y_tf[index]
+          current_y_np = y_np[index]
         if current_y_tf[0][0] == 1:
           self.assertAllEqual(current_y_tf, current_x_tf)
           count_unflipped += 1
@@ -914,7 +914,7 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
 
   def testIdempotentTransposeWithBatch(self):
     x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -934,10 +934,10 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
 
   def testTransposeWithBatch(self):
     x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
-            dtype=np.uint8).reshape([2, 2, 3, 1])
+                    dtype=np.uint8).reshape([2, 2, 3, 1])
 
     y_np = np.array([[[1, 4], [2, 5], [3, 6]], [[7, 10], [8, 11], [9, 12]]],
-        dtype=np.uint8).reshape([2, 3, 2, 1])
+                    dtype=np.uint8).reshape([2, 3, 2, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -952,7 +952,8 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
     p_unknown_dims_4 = array_ops.placeholder(
         dtypes.uint8, shape=[None, None, None, None])
     p_unknown_width = array_ops.placeholder(dtypes.uint8, shape=[64, None, 3])
-    p_unknown_batch = array_ops.placeholder(dtypes.uint8, shape=[None, 64, 64, 3])
+    p_unknown_batch = array_ops.placeholder(dtypes.uint8,
+                                            shape=[None, 64, 64, 3])
 
     p_wrong_rank = array_ops.placeholder(dtypes.uint8, shape=[None, None])
     p_zero_dim = array_ops.placeholder(dtypes.uint8, shape=[64, 0, 3])
@@ -973,7 +974,8 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       transformed_unknown_batch = op(p_unknown_batch)
       self.assertEqual(4, transformed_unknown_batch.get_shape().ndims)
 
-      with self.assertRaisesRegexp(ValueError, "must have either 3 or 4 dimensions."):
+      with self.assertRaisesRegexp(ValueError,
+                                   "must have either 3 or 4 dimensions."):
         op(p_wrong_rank)
       with self.assertRaisesRegexp(ValueError, "must be > 0"):
         op(p_zero_dim)
@@ -1009,7 +1011,7 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       k_placeholder = array_ops.placeholder(dtypes.int32, shape=[])
       y_tf = image_ops.rot90(image, k_placeholder)
       for k in xrange(4):
-        y_np = np.rot90(image, k=k, axes=(1,2))
+        y_np = np.rot90(image, k=k, axes=(1, 2))
         self.assertAllEqual(y_np, y_tf.eval({k_placeholder: k}))
 
 class RandomFlipTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -729,7 +729,7 @@ class AdjustSaturationTest(test_util.TensorFlowTestCase):
 
 class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
 
-  def testIdempotentLeftRight(self):
+  def testInvolutionLeftRight(self):
     x_np = np.array([[1, 2, 3], [1, 2, 3]], dtype=np.uint8).reshape([2, 3, 1])
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -737,7 +737,7 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       y_tf = y.eval()
       self.assertAllEqual(y_tf, x_np)
 
-  def testIdempotentLeftRightWithBatch(self):
+  def testInvolutionLeftRightWithBatch(self):
     x_np = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]],
                     dtype=np.uint8).reshape([2, 2, 3, 1])
     with self.test_session(use_gpu=True):
@@ -816,7 +816,7 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       self.assertGreaterEqual(count_flipped, 1)
       self.assertGreaterEqual(count_unflipped, 1)
 
-  def testIdempotentUpDown(self):
+  def testInvolutionUpDown(self):
     x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8).reshape([2, 3, 1])
 
     with self.test_session(use_gpu=True):
@@ -825,7 +825,7 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       y_tf = y.eval()
       self.assertAllEqual(y_tf, x_np)
 
-  def testIdempotentUpDownWithBatch(self):
+  def testInvolutionUpDownWithBatch(self):
     x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
                     dtype=np.uint8).reshape([2, 2, 3, 1])
 
@@ -903,7 +903,7 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       self.assertGreaterEqual(count_flipped, 1)
       self.assertGreaterEqual(count_unflipped, 1)
 
-  def testIdempotentTranspose(self):
+  def testInvolutionTranspose(self):
     x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8).reshape([2, 3, 1])
 
     with self.test_session(use_gpu=True):
@@ -912,7 +912,7 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       y_tf = y.eval()
       self.assertAllEqual(y_tf, x_np)
 
-  def testIdempotentTransposeWithBatch(self):
+  def testInvolutionTransposeWithBatch(self):
     x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
                     dtype=np.uint8).reshape([2, 2, 3, 1])
 

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -771,14 +771,15 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
   def testRandomFlipLeftRight(self):
     x_np = np.array([[1, 2, 3], [1, 2, 3]], dtype=np.uint8).reshape([2, 3, 1])
     y_np = np.array([[3, 2, 1], [3, 2, 1]], dtype=np.uint8).reshape([2, 3, 1])
+    seed = 42
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
-      y = image_ops.random_flip_left_right(x_tf)
+      y = image_ops.random_flip_left_right(x_tf, seed=seed)
 
       count_flipped = 0
       count_unflipped = 0
-      for _ in range(50):
+      for _ in range(100):
         y_tf = y.eval()
         if y_tf[0][0] == 1:
           self.assertAllEqual(y_tf, x_np)
@@ -786,18 +787,23 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
         else:
           self.assertAllEqual(y_tf, y_np)
           count_flipped += 1
-      self.assertGreaterEqual(count_flipped, 1)
-      self.assertGreaterEqual(count_unflipped, 1)
+      # 100 trials
+      # Mean: 50
+      # Std Dev: ~5
+      # Six Sigma: 50 - (5 * 6) = 20
+      self.assertGreaterEqual(count_flipped, 20)
+      self.assertGreaterEqual(count_unflipped, 20)
 
   def testRandomFlipLeftRightWithBatch(self):
     x_np = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]],
                     dtype=np.uint8).reshape([2, 2, 3, 1])
     y_np = np.array([[[3, 2, 1], [3, 2, 1]], [[3, 2, 1], [3, 2, 1]]],
                     dtype=np.uint8).reshape([2, 2, 3, 1])
+    seed = 42
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape).eval()
-      y = image_ops.random_flip_left_right(x_tf)
+      y = image_ops.random_flip_left_right(x_tf, seed=seed)
       count_flipped = 0
       count_unflipped = 0
       for _ in range(50):
@@ -813,8 +819,12 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
           else:
             self.assertAllEqual(current_y_tf, current_y_np)
             count_flipped += 1
-      self.assertGreaterEqual(count_flipped, 1)
-      self.assertGreaterEqual(count_unflipped, 1)
+      # Batch size 2 * 50 trials = 100
+      # Mean: 50
+      # Std Dev: ~5
+      # Six Sigma: 50 - (5 * 6) = 20
+      self.assertGreaterEqual(count_flipped, 20)
+      self.assertGreaterEqual(count_unflipped, 20)
 
   def testInvolutionUpDown(self):
     x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8).reshape([2, 3, 1])
@@ -860,13 +870,14 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
   def testRandomFlipUpDown(self):
     x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8).reshape([2, 3, 1])
     y_np = np.array([[4, 5, 6], [1, 2, 3]], dtype=np.uint8).reshape([2, 3, 1])
+    seed = 42
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
-      y = image_ops.random_flip_up_down(x_tf)
+      y = image_ops.random_flip_up_down(x_tf, seed=42)
       count_flipped = 0
       count_unflipped = 0
-      for _ in range(50):
+      for _ in range(100):
         y_tf = y.eval()
         if y_tf[0][0] == 1:
           self.assertAllEqual(y_tf, x_np)
@@ -874,18 +885,23 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
         else:
           self.assertAllEqual(y_tf, y_np)
           count_flipped += 1
-      self.assertGreaterEqual(count_flipped, 1)
-      self.assertGreaterEqual(count_unflipped, 1)
+      # 100 trials
+      # Mean: 50
+      # Std Dev: ~5
+      # Six Sigma: 50 - (5 * 6) = 20
+      self.assertGreaterEqual(count_flipped, 20)
+      self.assertGreaterEqual(count_unflipped, 20)
 
   def testRandomFlipUpDownWithBatch(self):
     x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]],
                     dtype=np.uint8).reshape([2, 2, 3, 1])
     y_np = np.array([[[4, 5, 6], [1, 2, 3]], [[4, 5, 6], [1, 2, 3]]],
                     dtype=np.uint8).reshape([2, 2, 3, 1])
+    seed = 42
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape).eval()
-      y = image_ops.random_flip_up_down(x_tf)
+      y = image_ops.random_flip_up_down(x_tf, seed=42)
       count_flipped = 0
       count_unflipped = 0
       for _ in range(50):
@@ -900,8 +916,12 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
         else:
           self.assertAllEqual(current_y_tf, current_y_np)
           count_flipped += 1
-      self.assertGreaterEqual(count_flipped, 1)
-      self.assertGreaterEqual(count_unflipped, 1)
+      # Batch size 2 * 50 trials = 100
+      # Mean: 50
+      # Std Dev: ~5
+      # Six Sigma: 50 - (5 * 6) = 20
+      self.assertGreaterEqual(count_flipped, 20)
+      self.assertGreaterEqual(count_unflipped, 20)
 
   def testInvolutionTranspose(self):
     x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8).reshape([2, 3, 1])

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -737,9 +737,30 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       y_tf = y.eval()
       self.assertAllEqual(y_tf, x_np)
 
+  def testIdempotentLeftRightWithBatch(self):
+    x_np = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
+    with self.test_session(use_gpu=True):
+      x_tf = constant_op.constant(x_np, shape=x_np.shape)
+      y = image_ops.flip_left_right(image_ops.flip_left_right(x_tf))
+      y_tf = y.eval()
+      self.assertAllEqual(y_tf, x_np)
+
   def testLeftRight(self):
     x_np = np.array([[1, 2, 3], [1, 2, 3]], dtype=np.uint8).reshape([2, 3, 1])
     y_np = np.array([[3, 2, 1], [3, 2, 1]], dtype=np.uint8).reshape([2, 3, 1])
+
+    with self.test_session(use_gpu=True):
+      x_tf = constant_op.constant(x_np, shape=x_np.shape)
+      y = image_ops.flip_left_right(x_tf)
+      y_tf = y.eval()
+      self.assertAllEqual(y_tf, y_np)
+
+  def testLeftRightWithBatch(self):
+    x_np = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
+    y_np = np.array([[[3, 2, 1], [3, 2, 1]], [[3, 2, 1], [3, 2, 1]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -768,8 +789,45 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       self.assertGreaterEqual(count_flipped, 1)
       self.assertGreaterEqual(count_unflipped, 1)
 
+  def testRandomFlipLeftRightWithBatch(self):
+    x_np = np.array([[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
+    y_np = np.array([[[3, 2, 1], [3, 2, 1]], [[3, 2, 1], [3, 2, 1]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
+
+    with self.test_session(use_gpu=True):
+      x_tf = constant_op.constant(x_np, shape=x_np.shape).eval()
+      y = image_ops.random_flip_left_right(x_tf)
+      count_flipped = 0
+      count_unflipped = 0
+      for _ in range(50):
+        y_tf = y.eval()
+        for index in range(0, x_tf.shape[0]):
+            current_x_tf = x_tf[index]
+            current_y_tf = y_tf[index]
+            current_y_np = y_np[index]
+
+            if current_y_tf[0][0] == 1:
+              self.assertAllEqual(current_y_tf, current_x_tf)
+              count_unflipped += 1
+            else:
+              self.assertAllEqual(current_y_tf, current_y_np)
+              count_flipped += 1
+      self.assertGreaterEqual(count_flipped, 1)
+      self.assertGreaterEqual(count_unflipped, 1)
+
   def testIdempotentUpDown(self):
     x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8).reshape([2, 3, 1])
+
+    with self.test_session(use_gpu=True):
+      x_tf = constant_op.constant(x_np, shape=x_np.shape)
+      y = image_ops.flip_up_down(image_ops.flip_up_down(x_tf))
+      y_tf = y.eval()
+      self.assertAllEqual(y_tf, x_np)
+
+  def testIdempotentUpDownWithBatch(self):
+    x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -780,6 +838,18 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
   def testUpDown(self):
     x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8).reshape([2, 3, 1])
     y_np = np.array([[4, 5, 6], [1, 2, 3]], dtype=np.uint8).reshape([2, 3, 1])
+
+    with self.test_session(use_gpu=True):
+      x_tf = constant_op.constant(x_np, shape=x_np.shape)
+      y = image_ops.flip_up_down(x_tf)
+      y_tf = y.eval()
+      self.assertAllEqual(y_tf, y_np)
+
+  def testUpDownWithBatch(self):
+    x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
+    y_np = np.array([[[4, 5, 6], [1, 2, 3]], [[10, 11, 12], [7, 8, 9]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -807,8 +877,44 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       self.assertGreaterEqual(count_flipped, 1)
       self.assertGreaterEqual(count_unflipped, 1)
 
+  def testRandomFlipUpDownWithBatch(self):
+    x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
+    y_np = np.array([[[4, 5, 6], [1, 2, 3]], [[4, 5, 6], [1, 2, 3]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
+
+    with self.test_session(use_gpu=True):
+      x_tf = constant_op.constant(x_np, shape=x_np.shape).eval()
+      y = image_ops.random_flip_up_down(x_tf)
+      count_flipped = 0
+      count_unflipped = 0
+      for _ in range(50):
+        y_tf = y.eval()
+        for index in range(0, x_tf.shape[0]):
+            current_x_tf = x_tf[index]
+            current_y_tf = y_tf[index]
+            current_y_np = y_np[index]
+        if current_y_tf[0][0] == 1:
+          self.assertAllEqual(current_y_tf, current_x_tf)
+          count_unflipped += 1
+        else:
+          self.assertAllEqual(current_y_tf, current_y_np)
+          count_flipped += 1
+      self.assertGreaterEqual(count_flipped, 1)
+      self.assertGreaterEqual(count_unflipped, 1)
+
   def testIdempotentTranspose(self):
     x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8).reshape([2, 3, 1])
+
+    with self.test_session(use_gpu=True):
+      x_tf = constant_op.constant(x_np, shape=x_np.shape)
+      y = image_ops.transpose_image(image_ops.transpose_image(x_tf))
+      y_tf = y.eval()
+      self.assertAllEqual(y_tf, x_np)
+
+  def testIdempotentTransposeWithBatch(self):
+    x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
 
     with self.test_session(use_gpu=True):
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
@@ -826,11 +932,27 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       y_tf = y.eval()
       self.assertAllEqual(y_tf, y_np)
 
+  def testTransposeWithBatch(self):
+    x_np = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
+            dtype=np.uint8).reshape([2, 2, 3, 1])
+
+    y_np = np.array([[[1, 4], [2, 5], [3, 6]], [[7, 10], [8, 11], [9, 12]]],
+        dtype=np.uint8).reshape([2, 3, 2, 1])
+
+    with self.test_session(use_gpu=True):
+      x_tf = constant_op.constant(x_np, shape=x_np.shape)
+      y = image_ops.transpose_image(x_tf)
+      y_tf = y.eval()
+      self.assertAllEqual(y_tf, y_np)
+
   def testPartialShapes(self):
     p_unknown_rank = array_ops.placeholder(dtypes.uint8)
-    p_unknown_dims = array_ops.placeholder(
+    p_unknown_dims_3 = array_ops.placeholder(
         dtypes.uint8, shape=[None, None, None])
+    p_unknown_dims_4 = array_ops.placeholder(
+        dtypes.uint8, shape=[None, None, None, None])
     p_unknown_width = array_ops.placeholder(dtypes.uint8, shape=[64, None, 3])
+    p_unknown_batch = array_ops.placeholder(dtypes.uint8, shape=[None, 64, 64, 3])
 
     p_wrong_rank = array_ops.placeholder(dtypes.uint8, shape=[None, None])
     p_zero_dim = array_ops.placeholder(dtypes.uint8, shape=[64, 0, 3])
@@ -842,10 +964,14 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
     ]:
       transformed_unknown_rank = op(p_unknown_rank)
       self.assertEqual(3, transformed_unknown_rank.get_shape().ndims)
-      transformed_unknown_dims = op(p_unknown_dims)
-      self.assertEqual(3, transformed_unknown_dims.get_shape().ndims)
+      transformed_unknown_dims_3 = op(p_unknown_dims_3)
+      self.assertEqual(3, transformed_unknown_dims_3.get_shape().ndims)
+      transformed_unknown_dims_4 = op(p_unknown_dims_4)
+      self.assertEqual(4, transformed_unknown_dims_4.get_shape().ndims)
       transformed_unknown_width = op(p_unknown_width)
       self.assertEqual(3, transformed_unknown_width.get_shape().ndims)
+      transformed_unknown_batch = op(p_unknown_batch)
+      self.assertEqual(4, transformed_unknown_batch.get_shape().ndims)
 
       #TODO: JoshVarty: Uncomment and fix after all ops are implemented
       #with self.assertRaisesRegexp(ValueError, "must be three-dimensional"):
@@ -861,6 +987,14 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
         rotated = image_ops.rot90(rotated)
       self.assertAllEqual(image, rotated.eval())
 
+  def testRot90GroupOrderWithBatch(self):
+    image = np.arange(48, dtype=np.uint8).reshape([2, 2, 4, 3])
+    with self.test_session(use_gpu=True):
+      rotated = image
+      for _ in xrange(4):
+        rotated = image_ops.rot90(rotated)
+      self.assertAllEqual(image, rotated.eval())
+
   def testRot90NumpyEquivalence(self):
     image = np.arange(24, dtype=np.uint8).reshape([2, 4, 3])
     with self.test_session(use_gpu=True):
@@ -870,6 +1004,14 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
         y_np = np.rot90(image, k=k)
         self.assertAllEqual(y_np, y_tf.eval({k_placeholder: k}))
 
+  def testRot90NumpyEquivalenceWithBatch(self):
+    image = np.arange(48, dtype=np.uint8).reshape([2, 2, 4, 3])
+    with self.test_session(use_gpu=True):
+      k_placeholder = array_ops.placeholder(dtypes.int32, shape=[])
+      y_tf = image_ops.rot90(image, k_placeholder)
+      for k in xrange(4):
+        y_np = np.rot90(image, k=k, axes=(1,2))
+        self.assertAllEqual(y_np, y_tf.eval({k_placeholder: k}))
 
 class RandomFlipTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -973,9 +973,8 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       transformed_unknown_batch = op(p_unknown_batch)
       self.assertEqual(4, transformed_unknown_batch.get_shape().ndims)
 
-      #TODO: JoshVarty: Uncomment and fix after all ops are implemented
-      #with self.assertRaisesRegexp(ValueError, "must be three-dimensional"):
-      #  op(p_wrong_rank)
+      with self.assertRaisesRegexp(ValueError, "must have either 3 or 4 dimensions."):
+        op(p_wrong_rank)
       with self.assertRaisesRegexp(ValueError, "must be > 0"):
         op(p_zero_dim)
 

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -847,8 +847,9 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
       transformed_unknown_width = op(p_unknown_width)
       self.assertEqual(3, transformed_unknown_width.get_shape().ndims)
 
-      with self.assertRaisesRegexp(ValueError, "must be three-dimensional"):
-        op(p_wrong_rank)
+      #TODO: JoshVarty: Uncomment and fix after all ops are implemented
+      #with self.assertRaisesRegexp(ValueError, "must be three-dimensional"):
+      #  op(p_wrong_rank)
       with self.assertRaisesRegexp(ValueError, "must be > 0"):
         op(p_zero_dim)
 


### PR DESCRIPTION
Working on #8926
I used #7369 as a guide for my work here.

I have added batch support for:

- `flip_left_right`
- `flip_up_down`
- `random_flip_left_right`
- `random_flip_up_down`
- `transpose_image`
- `rot90`

I have corrected existing tests in `image_ops_test.py` and introduced a number of new tests based on existing tests for 3D inputs. 

This is my first contribution to this repository and I have tried to follow the [`contributing`](https://github.com/tensorflow/tensorflow/blob/master/CONTRIBUTING.md) guidelines. However, running `pylint` on `image_ops_impl.py` and `image_ops_test.py` revealed a number of pre-existing style violations. I've tried to fix the ones relevant to my work but may have missed some.