### PR TITLE
C++ gradient for Select

### DIFF
--- a/tensorflow/cc/gradients/math_grad.cc
+++ b/tensorflow/cc/gradients/math_grad.cc
@@ -728,6 +728,26 @@ Status LgammaGrad(const Scope& scope, const Operation& op,
 }
 REGISTER_GRADIENT_OP("Lgamma", LgammaGrad);
 
+Status SelectGrad(const Scope& scope, const Operation& op,
+                  const std::vector<Output>& grad_inputs,
+                  std::vector<Output>* grad_outputs) {
+  auto comparator = op.input(0);
+  auto x = op.input(1);
+  auto zeros = ZerosLike(scope, x);
+  auto grad = grad_inputs[0];
+
+  Scope grad_scope = scope.WithControlDependencies(grad);
+  auto gx_1 = Where3(grad_scope, comparator, grad, zeros);
+  auto gx_2 = Where3(grad_scope, comparator, zeros, grad);
+
+  grad_outputs->push_back(NoGradient());
+  grad_outputs->push_back(gx_1);
+  grad_outputs->push_back(gx_2);
+
+  return grad_scope.status();
+}
+REGISTER_GRADIENT_OP("Select", SelectGrad);
+
 Status MinOrMaxGrad(const Scope& scope, const Operation& op,
                     const std::vector<Output>& grad_inputs,
                     std::vector<Output>* grad_outputs) {

--- a/tensorflow/cc/gradients/math_grad.cc
+++ b/tensorflow/cc/gradients/math_grad.cc
@@ -736,15 +736,13 @@ Status SelectGrad(const Scope& scope, const Operation& op,
   auto zeros = ZerosLike(scope, x);
   auto grad = grad_inputs[0];
 
-  Scope grad_scope = scope.WithControlDependencies(grad);
-  auto gx_1 = Where3(grad_scope, comparator, grad, zeros);
-  auto gx_2 = Where3(grad_scope, comparator, zeros, grad);
+  auto gx_1 = Where3(scope, comparator, grad, zeros);
+  auto gx_2 = Where3(scope, comparator, zeros, grad);
 
   grad_outputs->push_back(NoGradient());
   grad_outputs->push_back(gx_1);
   grad_outputs->push_back(gx_2);
-
-  return grad_scope.status();
+  return scope.status();
 }
 REGISTER_GRADIENT_OP("Select", SelectGrad);
 

--- a/tensorflow/cc/gradients/math_grad_test.cc
+++ b/tensorflow/cc/gradients/math_grad_test.cc
@@ -865,5 +865,15 @@ TEST_F(NaryGradTest, Minimum) {
   RunTest(x, x_init_value, y, shape);
 }
 
+TEST_F(NaryGradTest, Select) {
+  TensorShape x_shape({3, 4});
+  TensorShape y_shape({3, 4});
+  auto x1 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x_shape));
+  auto x2 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x_shape));
+  auto condition = Greater(scope_, x1, Const(scope_, 0.f));
+  auto y = Where3(scope_, condition, x1, x2);
+  RunTest({x1, x2}, {x_shape, x_shape}, {y}, {y_shape});
+}
+
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/cc/gradients/math_grad_test.cc
+++ b/tensorflow/cc/gradients/math_grad_test.cc
@@ -870,8 +870,7 @@ TEST_F(NaryGradTest, Select) {
   TensorShape y_shape({3, 4});
   auto x1 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x_shape));
   auto x2 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x_shape));
-  auto condition = Greater(scope_, x1, Const(scope_, 0.f));
-  auto y = Where3(scope_, condition, x1, x2);
+  auto y = Where3(scope_, Greater(scope_, x1, x2), x1, x2);
   RunTest({x1, x2}, {x_shape, x_shape}, {y}, {y_shape});
 }
 

--- a/tensorflow/cc/gradients/math_grad_test.cc
+++ b/tensorflow/cc/gradients/math_grad_test.cc
@@ -866,12 +866,11 @@ TEST_F(NaryGradTest, Minimum) {
 }
 
 TEST_F(NaryGradTest, Select) {
-  TensorShape x_shape({3, 4});
-  TensorShape y_shape({3, 4});
-  auto x1 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x_shape));
-  auto x2 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x_shape));
+  TensorShape shape({3, 4});
+  auto x1 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(shape));
+  auto x2 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(shape));
   auto y = Where3(scope_, Greater(scope_, x1, x2), x1, x2);
-  RunTest({x1, x2}, {x_shape, x_shape}, {y}, {y_shape});
+  RunTest({x1, x2}, {shape, shape}, {y}, {shape});
 }
 
 }  // namespace


### PR DESCRIPTION
Fix #14845 

migrate python implementation to c++ side, source: https://github.com/tensorflow/tensorflow/blob/27767d8e9c1325979cf32ff5b81c10df9006fd57/tensorflow/python/ops/math_grad.py#L919

### How to test

+ [x] add test case
+ [ ] pass all tests