### PR TITLE
tf.Print converts Variable to mutable Tensor

### DIFF
--- a/tensorflow/core/kernels/logging_ops.cc
+++ b/tensorflow/core/kernels/logging_ops.cc
@@ -88,5 +88,6 @@ class PrintOp : public OpKernel {
 };
 
 REGISTER_KERNEL_BUILDER(Name("Print").Device(DEVICE_CPU), PrintOp);
+REGISTER_KERNEL_BUILDER(Name("PrintRef").Device(DEVICE_CPU), PrintOp);
 
 }  // end namespace tensorflow

--- a/tensorflow/core/ops/logging_ops.cc
+++ b/tensorflow/core/ops/logging_ops.cc
@@ -37,29 +37,32 @@ data: The tensors to print out when condition is false.
 summarize: Print this many entries of each tensor.
 )doc");
 
-REGISTER_OP("Print")
-    .Input("input: T")
-    .Input("data: U")
-    .Output("output: T")
-    .SetIsStateful()
-    .Attr("T: type")
-    .Attr("U: list(type) >= 0")
-    .Attr("message: string = ''")
-    .Attr("first_n: int = -1")
-    .Attr("summarize: int = 3")
-    .SetShapeFn(shape_inference::UnchangedShape)
-    .Doc(R"doc(
-Prints a list of tensors.
-
-Passes `input` through to `output` and prints `data` when evaluating.
-
-input: The tensor passed to `output`
-data: A list of tensors to print out when op is evaluated.
-output:= The unmodified `input` tensor
-message: A string, prefix of the error message.
-first_n: Only log `first_n` number of times. -1 disables logging.
-summarize: Only print this many entries of each tensor.
-)doc");
+#define REGISTER_PRINT_OP(NAME, DTYPE)  \
+REGISTER_OP(NAME) \
+    .Input("input: " DTYPE) \
+    .Input("data: U") \
+    .Output("output: " DTYPE) \
+    .SetIsStateful() \
+    .Attr("T: type") \
+    .Attr("U: list(type) >= 0") \
+    .Attr("message: string = ''") \
+    .Attr("first_n: int = -1") \
+    .Attr("summarize: int = 3") \
+    .SetShapeFn(shape_inference::UnchangedShape) \
+    .Doc("doc(\n\
+Prints a list of tensors.\n\
+\n\
+Passes `input` through to `output` and prints `data` when evaluating.\n\
+\n\
+input: The tensor passed to `output`\n\
+data: A list of tensors to print out when op is evaluated.\n\
+output:= The unmodified `input` tensor\n\
+message: A string, prefix of the error message.\n\
+first_n: Only log `first_n` number of times. -1 disables logging.\n\
+summarize: Only print this many entries of each tensor.\n\
+)doc")
+REGISTER_PRINT_OP("Print", "T");
+#undef REGISTER_PRINT_OP
 
 // ----------------------------------------------------------------------------
 // Operators that deal with SummaryProtos (encoded as DT_STRING tensors) as

--- a/tensorflow/core/ops/logging_ops.cc
+++ b/tensorflow/core/ops/logging_ops.cc
@@ -62,6 +62,7 @@ first_n: Only log `first_n` number of times. -1 disables logging.\n\
 summarize: Only print this many entries of each tensor.\n\
 )doc")
 REGISTER_PRINT_OP("Print", "T");
+REGISTER_PRINT_OP("PrintRef", "Ref(T)");
 #undef REGISTER_PRINT_OP
 
 // ----------------------------------------------------------------------------

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1763,9 +1763,11 @@ py_library(
     srcs = ["ops/logging_ops.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":dtypes",
         ":framework_for_generated_wrappers",
         ":logging_ops_gen",
         ":util",
+        ":variables",
     ],
 )
 

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -466,6 +466,7 @@ tf_py_test(
         "//tensorflow/python:gradients",
         "//tensorflow/python:logging_ops",
         "//tensorflow/python:math_ops",
+        "//tensorflow/python:variables",
     ],
 )
 

--- a/tensorflow/python/kernel_tests/logging_ops_test.py
+++ b/tensorflow/python/kernel_tests/logging_ops_test.py
@@ -85,7 +85,7 @@ class PrintGradientTest(test.TestCase):
     self.assertEqual(p.dtype, v.dtype)
     with self.test_session() as sess:
       sess.run(variables.global_variables_initializer())
-      self.assertAllEqual(v.eval(), p.eval())
+      self.assertAllEqual(p.eval(), v.eval())
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/logging_ops_test.py
+++ b/tensorflow/python/kernel_tests/logging_ops_test.py
@@ -25,6 +25,7 @@ from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import logging_ops
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
 
@@ -76,6 +77,15 @@ class PrintGradientTest(test.TestCase):
       wxg = wx_grad.eval()
       wxpg = wx_print_grad.eval()
     self.assertAllEqual(wxg, wxpg)
+
+  def testPrintVariable(self):
+    v = variables.Variable([99])
+    p = logging_ops.Print(v, [v])
+    self.assertTrue(isinstance(p, ops.Tensor))
+    self.assertEqual(p.dtype, v.dtype)
+    with self.test_session() as sess:
+      sess.run(variables.global_variables_initializer())
+      self.assertAllEqual(v.eval(), p.eval())
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/ops/hidden_ops.txt
+++ b/tensorflow/python/ops/hidden_ops.txt
@@ -237,6 +237,7 @@ HistogramSummary
 ImageSummary
 MergeSummary
 Print
+PrintRef
 ScalarSummary
 TensorSummary
 TensorSummaryV2


### PR DESCRIPTION
The PR is proposed to resolve #14788.

tf.Print converts Variable to mutable Tensor, instead of constant.

```python
v = tf.Variable([99])
# <tf.Variable 'Variable:0' shape=(1,) dtype=int32_ref>

p = tf.Print(v, [v])
# Tensor("PrintRef:0", shape=(1,), dtype=int32_ref)
```

### How to test

+ [x] add test case
+ [ ] pass all tests