### PR TITLE
Add `tf.unravel_index` as an equivalent of `np.unravel_index`

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_UnravelIndex.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_UnravelIndex.pbtxt
@@ -1,0 +1,32 @@
+op {
+  graph_op_name: "UnravelIndex"
+  in_arg {
+    name: "indices"
+    description: <<END
+An 0-D or 1-D `int` Tensor whose elements are indices into the
+flattened version of an array of dimensions dims.
+END
+  }
+  in_arg {
+    name: "dims"
+    description: <<END
+An 1-D `int` Tensor. The shape of the array to use for unraveling
+indices.
+END
+  }
+  out_arg {
+    name: "output"
+    description: <<END
+An 2-D (or 1-D if indices is 0-D) tensor where each row has the
+same shape as the indices array.
+END
+  }
+  summary: "Converts a flat index or array of flat indices into a tuple of"
+  description: <<END
+coordinate arrays.
+
+@compatibility(numpy)
+Equivalent to np.unravel_index
+@end_compatibility
+END
+}

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -629,6 +629,7 @@ cc_library(
         ":transpose_op",
         ":unique_op",
         ":unpack_op",
+        ":unravel_index_op",
         ":where_op",
     ],
 )
@@ -881,6 +882,12 @@ tf_kernel_library(
     name = "unpack_op",
     prefix = "unpack_op",
     deps = ARRAY_DEPS + [":split_lib"],
+)
+
+tf_kernel_library(
+    name = "unravel_index_op",
+    prefix = "unravel_index_op",
+    deps = ARRAY_DEPS,
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/unravel_index_op.cc
+++ b/tensorflow/core/kernels/unravel_index_op.cc
@@ -1,0 +1,90 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+namespace tensorflow {
+
+namespace {
+template <typename T>
+struct mod_op {
+  const T operator()(const T& a, const T& b) const {
+    return a % b;
+  }
+};
+}
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+class UnravelIndexOp : public OpKernel {
+ public:
+  explicit UnravelIndexOp(OpKernelConstruction* ctx) : OpKernel(ctx) { }
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& indices_tensor = ctx->input(0);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsVector(indices_tensor.shape()) || TensorShapeUtils::IsScalar(indices_tensor.shape()), errors::InvalidArgument("The indices can only be scalar or vector, got \"", indices_tensor.shape().DebugString(), "\""));
+
+    const Tensor& dims_tensor = ctx->input(1);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsVector(dims_tensor.shape()), errors::InvalidArgument("The indices can only be 1-D, got \"", dims_tensor.shape().DebugString(), "\""));
+
+    auto dims = dims_tensor.vec<int32>();
+
+    Eigen::array<bool, 1> reverse({true});
+
+    Tensor strides_tensor;
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_INT32, TensorShape({dims_tensor.NumElements()}), &strides_tensor));
+
+    auto strides = strides_tensor.vec<int32>();
+    strides = dims.reverse(reverse).scan(0, Eigen::internal::ProdReducer<int32>(), false).reverse(reverse);
+
+    Tensor strides_shifted_tensor;
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_INT32, TensorShape({dims_tensor.NumElements()}), &strides_shifted_tensor));
+
+    auto strides_shifted = strides_shifted_tensor.vec<int32>();
+    strides_shifted = dims.reverse(reverse).scan(0, Eigen::internal::ProdReducer<int32>(), true).reverse(reverse);
+
+    Tensor* output_tensor = nullptr;
+    if (TensorShapeUtils::IsScalar(indices_tensor.shape())) {
+      OP_REQUIRES_OK(ctx, ctx->allocate_output(0, TensorShape({dims_tensor.NumElements()}), &output_tensor));
+
+      auto output = output_tensor->vec<int32>();
+
+      output = output.constant(indices_tensor.scalar<int32>()());
+      output = output.binaryExpr(strides, mod_op<int32>()) / strides_shifted;
+    } else {
+      OP_REQUIRES_OK(ctx, ctx->allocate_output(0, TensorShape({dims_tensor.NumElements(), indices_tensor.NumElements()}), &output_tensor));
+
+      auto output = output_tensor->matrix<int32>();
+
+      Eigen::array<int64, 2> reshape{{dims_tensor.NumElements(), 1}};
+      Eigen::array<int64, 2> bcast({1, indices_tensor.NumElements()});
+      Eigen::array<int64, 2> indices_reshape{{1, indices_tensor.NumElements()}};
+      Eigen::array<int64, 2> indices_bcast({dims_tensor.NumElements(), 1});
+
+      output = indices_tensor.vec<int32>().reshape(indices_reshape).broadcast(indices_bcast);
+      output = output.binaryExpr(strides.reshape(reshape).broadcast(bcast), mod_op<int32>()) / strides_shifted.reshape(reshape).broadcast(bcast);
+    }
+  }
+};
+
+REGISTER_KERNEL_BUILDER(Name("UnravelIndex").Device(DEVICE_CPU), UnravelIndexOp);
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/unravel_index_op.cc
+++ b/tensorflow/core/kernels/unravel_index_op.cc
@@ -32,15 +32,15 @@ struct mod_op {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 
+template <typename Tidx>
 class UnravelIndexOp : public OpKernel {
  public:
   explicit UnravelIndexOp(OpKernelConstruction* ctx) : OpKernel(ctx) {}
 
   void Compute(OpKernelContext* ctx) override {
     const Tensor& indices_tensor = ctx->input(0);
-    OP_REQUIRES(ctx,
-                TensorShapeUtils::IsVector(indices_tensor.shape()) ||
-                    TensorShapeUtils::IsScalar(indices_tensor.shape()),
+    OP_REQUIRES(ctx, TensorShapeUtils::IsVector(indices_tensor.shape()) ||
+                         TensorShapeUtils::IsScalar(indices_tensor.shape()),
                 errors::InvalidArgument(
                     "The indices can only be scalar or vector, got \"",
                     indices_tensor.shape().DebugString(), "\""));
@@ -51,28 +51,30 @@ class UnravelIndexOp : public OpKernel {
         errors::InvalidArgument("The indices can only be 1-D, got \"",
                                 dims_tensor.shape().DebugString(), "\""));
 
-    auto dims = dims_tensor.vec<int32>();
+    auto dims = dims_tensor.vec<Tidx>();
 
     Eigen::array<bool, 1> reverse({true});
 
     Tensor strides_tensor;
-    OP_REQUIRES_OK(ctx, ctx->allocate_temp(
-                            DT_INT32, TensorShape({dims_tensor.NumElements()}),
-                            &strides_tensor));
+    OP_REQUIRES_OK(ctx,
+                   ctx->allocate_temp(DataTypeToEnum<Tidx>::value,
+                                      TensorShape({dims_tensor.NumElements()}),
+                                      &strides_tensor));
 
-    auto strides = strides_tensor.vec<int32>();
+    auto strides = strides_tensor.vec<Tidx>();
     strides = dims.reverse(reverse)
-                  .scan(0, Eigen::internal::ProdReducer<int32>(), false)
+                  .scan(0, Eigen::internal::ProdReducer<Tidx>(), false)
                   .reverse(reverse);
 
     Tensor strides_shifted_tensor;
-    OP_REQUIRES_OK(ctx, ctx->allocate_temp(
-                            DT_INT32, TensorShape({dims_tensor.NumElements()}),
-                            &strides_shifted_tensor));
+    OP_REQUIRES_OK(ctx,
+                   ctx->allocate_temp(DataTypeToEnum<Tidx>::value,
+                                      TensorShape({dims_tensor.NumElements()}),
+                                      &strides_shifted_tensor));
 
-    auto strides_shifted = strides_shifted_tensor.vec<int32>();
+    auto strides_shifted = strides_shifted_tensor.vec<Tidx>();
     strides_shifted = dims.reverse(reverse)
-                          .scan(0, Eigen::internal::ProdReducer<int32>(), true)
+                          .scan(0, Eigen::internal::ProdReducer<Tidx>(), true)
                           .reverse(reverse);
 
     Tensor* output_tensor = nullptr;
@@ -81,35 +83,38 @@ class UnravelIndexOp : public OpKernel {
           ctx, ctx->allocate_output(0, TensorShape({dims_tensor.NumElements()}),
                                     &output_tensor));
 
-      auto output = output_tensor->vec<int32>();
+      auto output = output_tensor->vec<Tidx>();
 
-      output = output.constant(indices_tensor.scalar<int32>()());
-      output = output.binaryExpr(strides, mod_op<int32>()) / strides_shifted;
+      output = output.constant(indices_tensor.scalar<Tidx>()());
+      output = output.binaryExpr(strides, mod_op<Tidx>()) / strides_shifted;
     } else {
-      OP_REQUIRES_OK(
-          ctx, ctx->allocate_output(0,
-                                    TensorShape({dims_tensor.NumElements(),
-                                                 indices_tensor.NumElements()}),
-                                    &output_tensor));
+      OP_REQUIRES_OK(ctx, ctx->allocate_output(
+                              0, TensorShape({dims_tensor.NumElements(),
+                                              indices_tensor.NumElements()}),
+                              &output_tensor));
 
-      auto output = output_tensor->matrix<int32>();
+      auto output = output_tensor->matrix<Tidx>();
 
       Eigen::array<int64, 2> reshape{{dims_tensor.NumElements(), 1}};
       Eigen::array<int64, 2> bcast({1, indices_tensor.NumElements()});
       Eigen::array<int64, 2> indices_reshape{{1, indices_tensor.NumElements()}};
       Eigen::array<int64, 2> indices_bcast({dims_tensor.NumElements(), 1});
 
-      output = indices_tensor.vec<int32>()
+      output = indices_tensor.vec<Tidx>()
                    .reshape(indices_reshape)
                    .broadcast(indices_bcast);
       output = output.binaryExpr(strides.reshape(reshape).broadcast(bcast),
-                                 mod_op<int32>()) /
+                                 mod_op<Tidx>()) /
                strides_shifted.reshape(reshape).broadcast(bcast);
     }
   }
 };
 
-REGISTER_KERNEL_BUILDER(Name("UnravelIndex").Device(DEVICE_CPU),
-                        UnravelIndexOp);
+#define REGISTER_KERNEL(type)                                               \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("UnravelIndex").Device(DEVICE_CPU).TypeConstraint<type>("Tidx"), \
+      UnravelIndexOp<type>);
+TF_CALL_int32(REGISTER_KERNEL) TF_CALL_int64(REGISTER_KERNEL)
+#undef REGISTER_KERNEL
 
 }  // namespace tensorflow

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -335,6 +335,27 @@ REGISTER_OP("Unpack")
       return Status::OK();
     });
 
+REGISTER_OP("UnravelIndex")
+    .Input("indices: int32")
+    .Input("dims: int32")
+    .Output("output: int32")
+    .SetShapeFn([](InferenceContext* c) {
+      return Status::OK();
+    })
+    .Doc(R"doc(
+Converts a flat index or array of flat indices into a tuple of coordinate
+arrays.
+
+This is equivalent to numpy.unravel_index
+
+indices: An 0-D or 1-D `int` Tensor whose elements are indices into the
+  flattened version of an array of dimensions dims.
+dims: An 1-D `int` Tensor. The shape of the array to use for unraveling
+  indices.
+output: An 2-D (or 1-D if indices is 0-D) tensor where each row has the
+  same shape as the indices array.
+)doc");
+
 // --------------------------------------------------------------------------
 // TODO(josh11b): Remove the >= 2 constraint, once we can rewrite the graph
 // in the N == 1 case to remove the node.

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -342,8 +342,12 @@ REGISTER_OP("UnravelIndex")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .SetShapeFn([](InferenceContext* c) { return Status::OK(); })
     .Doc(R"doc(
-Converts a flat index or array of flat indices into a tuple of coordinate
-arrays.
+Converts a flat index or array of flat indices into a tuple of
+coordinate arrays.
+
+@compatibility(numpy)
+Equivalent to np.unravel_index
+@end_compatibility
 
 indices: An 0-D or 1-D `int` Tensor whose elements are indices into the
   flattened version of an array of dimensions dims.
@@ -351,10 +355,6 @@ dims: An 1-D `int` Tensor. The shape of the array to use for unraveling
   indices.
 output: An 2-D (or 1-D if indices is 0-D) tensor where each row has the
   same shape as the indices array.
-
-@compatibility(numpy)
-Equivalent to np.unravel_index
-@end_compatibility
 )doc");
 
 // --------------------------------------------------------------------------

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -340,22 +340,7 @@ REGISTER_OP("UnravelIndex")
     .Input("dims: Tidx")
     .Output("output: Tidx")
     .Attr("Tidx: {int32, int64} = DT_INT32")
-    .SetShapeFn([](InferenceContext* c) { return Status::OK(); })
-    .Doc(R"doc(
-Converts a flat index or array of flat indices into a tuple of
-coordinate arrays.
-
-@compatibility(numpy)
-Equivalent to np.unravel_index
-@end_compatibility
-
-indices: An 0-D or 1-D `int` Tensor whose elements are indices into the
-  flattened version of an array of dimensions dims.
-dims: An 1-D `int` Tensor. The shape of the array to use for unraveling
-  indices.
-output: An 2-D (or 1-D if indices is 0-D) tensor where each row has the
-  same shape as the indices array.
-)doc");
+    .SetShapeFn([](InferenceContext* c) { return Status::OK(); });
 
 // --------------------------------------------------------------------------
 // TODO(josh11b): Remove the >= 2 constraint, once we can rewrite the graph

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -336,17 +336,14 @@ REGISTER_OP("Unpack")
     });
 
 REGISTER_OP("UnravelIndex")
-    .Input("indices: int32")
-    .Input("dims: int32")
-    .Output("output: int32")
-    .SetShapeFn([](InferenceContext* c) {
-      return Status::OK();
-    })
+    .Input("indices: Tidx")
+    .Input("dims: Tidx")
+    .Output("output: Tidx")
+    .Attr("Tidx: {int32, int64} = DT_INT32")
+    .SetShapeFn([](InferenceContext* c) { return Status::OK(); })
     .Doc(R"doc(
 Converts a flat index or array of flat indices into a tuple of coordinate
 arrays.
-
-This is equivalent to numpy.unravel_index
 
 indices: An 0-D or 1-D `int` Tensor whose elements are indices into the
   flattened version of an array of dimensions dims.
@@ -354,6 +351,10 @@ dims: An 1-D `int` Tensor. The shape of the array to use for unraveling
   indices.
 output: An 2-D (or 1-D if indices is 0-D) tensor where each row has the
   same shape as the indices array.
+
+@compatibility(numpy)
+Equivalent to np.unravel_index
+@end_compatibility
 )doc");
 
 // --------------------------------------------------------------------------

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -1118,16 +1118,21 @@ class UnravelIndexTest(test_util.TensorFlowTestCase):
 
   def testUnravelIndex(self):
     with self.test_session():
-      out_1 = array_ops.unravel_index(1621, [6, 7, 8, 9])
-      self.assertAllEqual(out_1.eval(), [3, 1, 4, 1])
-      out_2 = array_ops.unravel_index([1621], [6, 7, 8, 9])
-      self.assertAllEqual(out_2.eval(), [[3],
-                                        [1],
-                                        [4],
-                                        [1]])
-      out_3 = array_ops.unravel_index([22, 41, 37], [7, 6])
-      self.assertAllEqual(out_3.eval(), [[3, 6, 6],
-                                        [4, 5, 1]])
+      for dtype in [dtypes.int32, dtypes.int64]:
+        indices_1 = constant_op.constant(1621, dtype=dtype)
+        dims_1 = constant_op.constant([6, 7, 8, 9], dtype=dtype)
+        out_1 = array_ops.unravel_index(indices_1, dims_1)
+        self.assertAllEqual(out_1.eval(), [3, 1, 4, 1])
+
+        indices_2 = constant_op.constant([1621], dtype=dtype)
+        dims_2 = constant_op.constant([6, 7, 8, 9], dtype=dtype)
+        out_2 = array_ops.unravel_index(indices_2, dims_2)
+        self.assertAllEqual(out_2.eval(), [[3], [1], [4], [1]])
+
+        indices_3 = constant_op.constant([22, 41, 37], dtype=dtype)
+        dims_3 = constant_op.constant([7, 6], dtype=dtype)
+        out_3 = array_ops.unravel_index(indices_3, dims_3)
+        self.assertAllEqual(out_3.eval(), [[3, 6, 6], [4, 5, 1]])
 
 
 class GuaranteeConstOpTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -1114,6 +1114,21 @@ class InvertPermutationTest(test_util.TensorFlowTestCase):
         self.assertAllEqual(y.get_shape(), [5])
         self.assertAllEqual(y.eval(), [2, 4, 3, 0, 1])
 
+class UnravelIndexTest(test_util.TensorFlowTestCase):
+
+  def testUnravelIndex(self):
+    with self.test_session():
+      out_1 = array_ops.unravel_index(1621, [6, 7, 8, 9])
+      self.assertAllEqual(out_1.eval(), [3, 1, 4, 1])
+      out_2 = array_ops.unravel_index([1621], [6, 7, 8, 9])
+      self.assertAllEqual(out_2.eval(), [[3],
+                                        [1],
+                                        [4],
+                                        [1]])
+      out_3 = array_ops.unravel_index([22, 41, 37], [7, 6])
+      self.assertAllEqual(out_3.eval(), [[3, 6, 6],
+                                        [4, 5, 1]])
+
 
 class GuaranteeConstOpTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -34,6 +34,7 @@ See the @{$python/array_ops} guide.
 @@reshape
 @@squeeze
 @@expand_dims
+@@unravel_index
 @@meshgrid
 @@slice
 @@strided_slice

--- a/tensorflow/tools/api/golden/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.pbtxt
@@ -2045,6 +2045,10 @@ tf_module {
     argspec: "args=[\'x\', \'out_idx\', \'name\'], varargs=None, keywords=None, defaults=[\"<dtype: \'int32\'>\", \'None\'], "
   }
   member_method {
+    name: "unravel_index"
+    argspec: "args=[\'indices\', \'dims\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "unsorted_segment_max"
     argspec: "args=[\'data\', \'segment_ids\', \'num_segments\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }


### PR DESCRIPTION
This fix tries to address the issue raised in #2075 where there was no implementation of  `tf.unravel_index`.

The `tf.unravel_index` could be quite useful in many places.

This fix adds the `tf.unravel_index` in CPU kernel. Note `order` in `np.unravel_index` has not been added yet.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>