### PR TITLE
add extra document to parameter:num_epochs

### DIFF
--- a/tensorflow/contrib/slim/python/slim/data/dataset_data_provider.py
+++ b/tensorflow/contrib/slim/python/slim/data/dataset_data_provider.py
@@ -62,7 +62,9 @@ class DatasetDataProvider(data_provider.DataProvider):
                seed=None,
                scope=None):
     """Creates a DatasetDataProvider.
-
+    Note: if `num_epochs` is not `None`,  local counter `epochs` will be created
+    by relevant function. Use `local_variables_initializer()` to initialize
+    local variables.
     Args:
       dataset: An instance of the Dataset class.
       num_readers: The number of parallel readers to use.


### PR DESCRIPTION
Add extra documents to DatasetDataProvider. I forget to call  `tf.local_variables_initializer` when I set num_epochs to 1. I trace source code to find out that I need to do that.  I think put some extra documentation will help others to avoid this mistake.