### PR TITLE
golang: ~15x speedup for decodeTensor()

### DIFF
--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -360,6 +360,15 @@ func decodeTensor(r *bytes.Reader, shape []int64, typ reflect.Type, ptr reflect.
 	case reflect.Slice:
 		val := reflect.Indirect(ptr)
 		val.Set(reflect.MakeSlice(typ, int(shape[0]), int(shape[0])))
+
+		// Optimization: if only one dimension is left we can use binary.Read() directly for this slice
+		if len(shape) == 1 && val.Len() > 0 {
+			switch val.Index(0).Kind() {
+			case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
+				return binary.Read(r, nativeEndian, val.Interface())
+			}
+		}
+
 		for i := 0; i < val.Len(); i++ {
 			if err := decodeTensor(r, shape[1:], typ.Elem(), val.Index(i).Addr()); err != nil {
 				return err

--- a/tensorflow/go/tensor_test.go
+++ b/tensorflow/go/tensor_test.go
@@ -243,3 +243,23 @@ func BenchmarkNewTensor(b *testing.B) {
 	)
 	b.Run("[150528]", func(b *testing.B) { benchmarkNewTensor(b, vector) })
 }
+
+func benchmarkDecodeTensor(b *testing.B, t *Tensor) {
+	for i := 0; i < b.N; i++ {
+		_ = t.Value()
+	}
+}
+
+func BenchmarkDecodeTensor(b *testing.B) {
+	var (
+		// Some sample sizes from the Inception image labeling model.
+		// Where input tensors correspond to a 224x224 RGB image
+		// flattened into a vector.
+		vector [224 * 224 * 3]int32
+	)
+	t, err := NewTensor(vector)
+	if err != nil {
+		b.Fatalf("(%v, %v)", t, err)
+	}
+	b.Run("[150528]", func(b *testing.B) { benchmarkDecodeTensor(b, t) })
+}


### PR DESCRIPTION
Make decodeTensor() faster by running binary.Read() for the whole slice in last dimension.

Similar to https://github.com/tensorflow/tensorflow/pull/14427

before:

$ go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/tensorflow/tensorflow/tensorflow/go
BenchmarkNewTensor/[150528]-8                200           7459717 ns/op
BenchmarkDecodeTensor/[150528]-8             100          11205557 ns/op
PASS
ok      github.com/tensorflow/tensorflow/tensorflow/go  3.447s


after:

$ go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/tensorflow/tensorflow/tensorflow/go
BenchmarkNewTensor/[150528]-8                200           7009254 ns/op
BenchmarkDecodeTensor/[150528]-8            2000            747224 ns/op
PASS
ok      github.com/tensorflow/tensorflow/tensorflow/go  3.793s
