### PR TITLE
Fix issue in tf.nn.softmax where negative dims could only be -1

### DIFF
--- a/tensorflow/python/kernel_tests/softmax_op_test.py
+++ b/tensorflow/python/kernel_tests/softmax_op_test.py
@@ -200,6 +200,15 @@ class SoftmaxTest(test.TestCase):
         use_gpu=False)
     self._testOverflow(use_gpu=False)
 
+  def testAlongNegativeDimension(self):
+    self._testSoftmax(
+        np.array([[[1., 1., 1., 1.], [1., 2., 3., 4.]],
+                  [[2., 3., 4., 5.], [6., 7., 8., 9.]],
+                  [[5., 4., 3., 2.], [1., 2., 3., 4.]]]).astype(np.float32),
+        dim=-2,
+        use_gpu=False)
+    self._testOverflow(use_gpu=False)
+
   def testShapeInference(self):
     op = nn_ops.softmax([[[1., 1., 1., 1.], [1., 2., 3., 4.]],
                          [[2., 3., 4., 5.], [6., 7., 8., 9.]],

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1699,11 +1699,12 @@ def _softmax(logits, compute_op, dim=-1, name=None):
   # still perform softmax on its last dimension.
 
   # In case dim is negative (and is not last dimension -1), add shape.ndims
+  ndims = array_ops.rank(logits)
   if not isinstance(dim, ops.Tensor):
     if dim < 0:
-      dim += shape.ndims
+      dim += ndims
   else:
-    dim = array_ops.where(math_ops.less(dim, 0), dim + shape.ndims, dim)
+    dim = array_ops.where(math_ops.less(dim, 0), dim + ndims, dim)
 
   # Swap logits' dimension of dim and its last dimension.
   input_rank = array_ops.rank(logits)

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1699,8 +1699,11 @@ def _softmax(logits, compute_op, dim=-1, name=None):
   # still perform softmax on its last dimension.
 
   # In case dim is negative (and is not last dimension -1), add shape.ndims
-  if not isinstance(dim, ops.Tensor) and dim < 0:
-    dim += shape.ndims
+  if not isinstance(dim, ops.Tensor):
+    if dim < 0:
+      dim += shape.ndims
+  else:
+    dim = array_ops.where(math_ops.less(dim, 0), dim + shape.ndims, dim)
 
   # Swap logits' dimension of dim and its last dimension.
   input_rank = array_ops.rank(logits)

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1699,7 +1699,7 @@ def _softmax(logits, compute_op, dim=-1, name=None):
   # still perform softmax on its last dimension.
 
   # In case dim is negative (and is not last dimension -1), add shape.ndims
-  if dim < 0:
+  if not isinstance(dim, ops.Tensor) and dim < 0:
     dim += shape.ndims
 
   # Swap logits' dimension of dim and its last dimension.

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1698,6 +1698,10 @@ def _softmax(logits, compute_op, dim=-1, name=None):
   # If dim is not the last dimension, we have to do a transpose so that we can
   # still perform softmax on its last dimension.
 
+  # In case dim is negative (and is not last dimension -1), add shape.ndims
+  if dim < 0:
+    dim += shape.ndims
+
   # Swap logits' dimension of dim and its last dimension.
   input_rank = array_ops.rank(logits)
   dim_axis = dim % shape.ndims


### PR DESCRIPTION
This fix tries to address the issue raised in #14916 where negative dims could only be -1 in tf.nn.softmax.

The issue was that dims=-1 was handled as a case of "last dim" with `is_last_dim = (dim is -1) or (dim == shape.ndims - 1)`, but the generic negative dims were never processed.

This fix adds `dim += shape.ndims` for generic negative dims, and add additional test cases.

This fix fixes #14916.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
