### PR TITLE
Adapt identity initializer API to other initializers.

### DIFF
--- a/tensorflow/python/ops/state_ops.py
+++ b/tensorflow/python/ops/state_ops.py
@@ -36,6 +36,7 @@
 @@global_variables_initializer
 @@glorot_normal_initializer
 @@glorot_uniform_initializer
+@@identity_initializer
 @@import_meta_graph
 @@initialize_all_tables
 @@initialize_all_variables

--- a/tensorflow/tools/api/golden/tensorflow.identity_initializer.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.identity_initializer.pbtxt
@@ -1,0 +1,18 @@
+path: "tensorflow.identity_initializer"
+tf_class {
+  is_instance: "<class \'tensorflow.python.ops.init_ops.Identity\'>"
+  is_instance: "<class \'tensorflow.python.ops.init_ops.Initializer\'>"
+  is_instance: "<type \'object\'>"
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\', \'gain\', \'dtype\'], varargs=None, keywords=None, defaults=[\'1.0\', \"<dtype: \'float32\'>\"], "
+  }
+  member_method {
+    name: "from_config"
+    argspec: "args=[\'cls\', \'config\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "get_config"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/tensorflow/tools/api/golden/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.pbtxt
@@ -349,6 +349,10 @@ tf_module {
     mtype: "<class \'tensorflow.python.framework.dtypes.DType\'>"
   }
   member {
+    name: "identity_initializer"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "image"
     mtype: "<type \'module\'>"
   }


### PR DESCRIPTION
**This API extension is completely backwards compatible and supports consistency.**

All initializer classes (such as `ZerosInitializer`) have the same API and can either be accessed via the initializer namespace, from Keras initializers or directly from the tensorflow import:
```python
>>> tf.initializers.zeros
<class 'tensorflow.python.ops.init_ops.Zeros'>
>>> tf.keras.initializers.Zeros
<class 'tensorflow.python.ops.init_ops.Zeros'>
>>> tf.zeros_initializer
<class 'tensorflow.python.ops.init_ops.Zeros'>
```

The `IdentityInitializer` class, which was added in d5f1790530db0ee430d223497a59cfc26ab5f4d8, had been missing the last of those options. This is why the following way of access was added to its API:
```python
>>> tf.identity_initializer
<class 'tensorflow.python.ops.init_ops.Identity'>
```
