### PR TITLE
Add missing <stdio.h> include

### DIFF
--- a/tensorflow/contrib/lite/kernels/op_macros.h
+++ b/tensorflow/contrib/lite/kernels/op_macros.h
@@ -15,6 +15,8 @@ limitations under the License.
 #ifndef THIRD_PARTY_TENSORFLOW_CONTRIB_LITE_KERNELS_OP_UTIL_H_
 #define THIRD_PARTY_TENSORFLOW_CONTRIB_LITE_KERNELS_OP_UTIL_H_
 
+#include <stdio.h>
+
 #define TF_LITE_FATAL(msg)          \
   do {                              \
     fprintf(stderr, "%s\n", (msg)); \


### PR DESCRIPTION
Add missing <stdio.h> include in `tensorflow/contrib/lite/kernels/op_macros.h`. Otherwise, it fails to find `stderr`.

To reproduce it:

```shell
bazel build //tensorflow/contrib/lite/java:tflite_runtime
```