### PR TITLE
Add broadcasting for rank 6 Tensors

### DIFF
--- a/tensorflow/core/kernels/cwise_ops_common.h
+++ b/tensorflow/core/kernels/cwise_ops_common.h
@@ -146,6 +146,13 @@ class BinaryOp : public BinaryOpShared {
           BCast::ToIndexArray<5>(bcast->x_bcast()),
           in1.template shaped<Tin, 5>(bcast->y_reshape()),
           BCast::ToIndexArray<5>(bcast->y_bcast()), error_ptr);
+    } else if (ndims == 6) {
+      functor::BinaryFunctor<Device, Functor, 6>().BCast(
+          eigen_device, out->shaped<Tout, 6>(bcast->result_shape()),
+          in0.template shaped<Tin, 6>(bcast->x_reshape()),
+          BCast::ToIndexArray<6>(bcast->x_bcast()),
+          in1.template shaped<Tin, 6>(bcast->y_reshape()),
+          BCast::ToIndexArray<6>(bcast->y_bcast()), error_ptr);
     } else {
       SetUnimplementedError(ctx);
     }


### PR DESCRIPTION
As per @aselle's comment in #14924, this bumps up the broadcasting dimension limit of Tensors from 5 to 6.

I'm making this pull request to make it easy to merge this change if it is wanted; perhaps it is not wanted.