### PR TITLE
WIP: Support "causal" padding in tf.layers.convolutional.Conv1D

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3980,7 +3980,10 @@ py_test(
     main = "layers/convolutional_test.py",
     srcs_version = "PY2AND3",
     deps = [
+        ":array_ops",
         ":client_testlib",
+        ":constant_op",
+        ":dtypes",
         ":framework_for_generated_wrappers",
         ":framework_test_lib",
         ":layers",

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -240,7 +240,8 @@ class Conv1D(_Conv):
       specifying the stride length of the convolution.
       Specifying any stride value != 1 is incompatible with specifying
       any `dilation_rate` value != 1.
-    padding: One of `"valid"` or `"same"` (case-insensitive).
+    padding: One of `"valid"`, `"same"` or `"causal"` (case-insensitive).
+      Currently, causal padding only supports channels_last (NTC) format.
     data_format: A string, one of `channels_last` (default) or `channels_first`.
       The ordering of the dimensions in the inputs.
       `channels_last` corresponds to inputs with shape
@@ -270,6 +271,9 @@ class Conv1D(_Conv):
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+
+  Raises:
+    ValueError: If data format is incompatible with causal padding.
   """
 
   def __init__(self, filters,
@@ -291,7 +295,8 @@ class Conv1D(_Conv):
                name=None,
                **kwargs):
     if padding == "causal":
-      assert data_format == "channels_last", "causal padding only supports NTC format."
+      if data_format != "channels_last":
+        raise ValueError("causal padding only supports channels_last (NTC) format.")
       self._causal_padding = True
       padding = "valid"
     else:

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -206,7 +206,7 @@ class ConvTest(test.TestCase):
                           [2 * 0 + 1 * 1, 2 * 0 + 1 * 2, 2 * 1 + 1 * 3, 2 * 2 + 1 * 4])
 
     with self.assertRaisesRegexp(ValueError, "causal padding"):
-      conv_layers.Conv1D(x, filters, padding="causal", data_format="channels_first")
+      conv_layers.Conv1D(1, 2, padding="causal", data_format="channels_first")
 
   def testUnknownInputChannelsConv1D(self):
     data = random_ops.random_uniform((5, 4, 7))


### PR DESCRIPTION
Fix #14933.

Because we don't see causal padding in other use cases expect of NTC, we choose to modify code at Conv1D, instead of `tf.nn.convolution`.
For simplicity, we hack the Conv1D's `__call__` method, instead of `build`, `call` and `_compute_output_shape`.

### How to test

+ [x] add test case.
+ [ ]  pass all tests.