### PR TITLE
Make build rule for //tensorflow/contrib/lite/tools:benchmark_model

### DIFF
--- a/tensorflow/contrib/lite/tools/BUILD
+++ b/tensorflow/contrib/lite/tools/BUILD
@@ -20,8 +20,8 @@ tf_cc_binary(
     name = "benchmark_model",
     srcs = ["benchmark_model.cc"],
     deps = [
-        "//tensorflow/contrib/lite/kernels:builtin_ops",
         ":mutable_op_resolver",
+        "//tensorflow/contrib/lite/kernels:builtin_ops",
     ],
     linkopts = select({
         "//tensorflow:android": [

--- a/tensorflow/contrib/lite/tools/BUILD
+++ b/tensorflow/contrib/lite/tools/BUILD
@@ -16,6 +16,25 @@ tf_cc_binary(
     ],
 )
 
+tf_cc_binary(
+    name = "benchmark_model",
+    srcs = ["benchmark_model.cc"],
+    deps = [
+        "//tensorflow/contrib/lite/kernels:builtin_ops",
+        ":mutable_op_resolver",
+    ],
+    linkopts = select({
+        "//tensorflow:android": [
+            "-pie",
+            "-landroid",
+            "-lm",
+            "-z defs",
+            "-Wl,--exclude-libs,ALL",  # Exclude syms in all libs from auto export
+        ],
+        "//conditions:default": [],
+    }),
+)
+
 cc_library(
     name = "gen_op_registration",
     srcs = ["gen_op_registration.cc"],

--- a/tensorflow/contrib/lite/tools/BUILD
+++ b/tensorflow/contrib/lite/tools/BUILD
@@ -19,10 +19,6 @@ tf_cc_binary(
 tf_cc_binary(
     name = "benchmark_model",
     srcs = ["benchmark_model.cc"],
-    deps = [
-        ":mutable_op_resolver",
-        "//tensorflow/contrib/lite/kernels:builtin_ops",
-    ],
     linkopts = select({
         "//tensorflow:android": [
             "-pie",
@@ -33,6 +29,10 @@ tf_cc_binary(
         ],
         "//conditions:default": [],
     }),
+    deps = [
+        ":mutable_op_resolver",
+        "//tensorflow/contrib/lite/kernels:builtin_ops",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
Resolve issue https://github.com/tensorflow/tensorflow/issues/14581
Note that this benchmark_model.cc is not completed yet. It doesn't
load and models.

1. With proper Android SDK and NDK settings in WORKSPACE, we can
   build armeabi-v7a or arm64-v8a binary, e.g.,

   > bazel build --cxxopt='--std=c++11' \
     --crosstool_top=//external:android/crosstool \
     --cpu=arm64-v8a \
     --host_crosstool_top=@bazel_tools//tools/cpp:toolchain \
    //tensorflow/contrib/lite/tools:benchmark_model

2. It's also possible to build this for Linux or OS X, e.g.,

   >  bazel --config opt --cxxopt='--std=c++11' \
     //tensorflow/contrib/lite/tools:benchmark_model