### PR TITLE
Fix a BUILD file bug in `tensorflow/contrib/cloud/BUILD`

### DIFF
--- a/tensorflow/contrib/cloud/BUILD
+++ b/tensorflow/contrib/cloud/BUILD
@@ -60,9 +60,7 @@ tf_py_test(
     size = "small",
     srcs = ["python/ops/bigquery_reader_ops_test.py"],
     additional_deps = [
-        ":bigquery_reader_ops_op_lib",
         ":cloud_py",
-        "//tensorflow/contrib/cloud/kernels:bigquery_reader_ops",
         "//tensorflow/core:protos_all_py",
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client_testlib",


### PR DESCRIPTION
In `tensorflow/contrib/cloud`, invoking `bigquery_reader_ops_test` will fail.

The error is caused by the the fact that `bigquery_reader_ops_test` depends on `:bigquery_reader_ops_op_lib` and `:bigquery_reader_ops`.

However, bigquery_reader_ops_test is in python, `:bigquery_reader_ops_op_lib` and `:bigquery_reader_ops` are cc libraries. So they shouldn't be the dependencies of bigquery_reader_ops_test.

This fix removes the above two dependencies so that `bigquery_reader_ops_test` could run successfully.

Below is the full error message before this PR.

```
ubuntu@ubuntu:~/tensorflow$ bazel test -s --config=opt //tensorflow/contrib/cloud:bigquery_reader_ops_test
..........
WARNING: /home/ubuntu/tensorflow/tensorflow/core/BUILD:1815:1: in includes attribute of cc_library rule //tensorflow/core:framework_headers_lib: '../../external/nsync/public' resolves to 'external/nsync/public' not below the relative path of its package 'tensorflow/core'. This will be an error in the future. Since this rule was created by the macro 'cc_header_only_library', the error might have been caused by the macro implementation in /home/ubuntu/tensorflow/tensorflow/tensorflow.bzl:1127:30
ERROR: /home/ubuntu/tensorflow/tensorflow/contrib/cloud/BUILD:58:1: in deps attribute of py_test rule //tensorflow/contrib/cloud:bigquery_reader_ops_test: '//tensorflow/contrib/cloud:bigquery_reader_ops_op_lib' does not have mandatory providers: 'py'. Since this rule was created by the macro 'tf_py_test', the error might have been caused by the macro implementation in /home/ubuntu/tensorflow/tensorflow/tensorflow.bzl:1368:12
ERROR: /home/ubuntu/tensorflow/tensorflow/contrib/cloud/BUILD:58:1: in deps attribute of py_test rule //tensorflow/contrib/cloud:bigquery_reader_ops_test: '//tensorflow/contrib/cloud/kernels:bigquery_reader_ops' does not have mandatory providers: 'py'. Since this rule was created by the macro 'tf_py_test', the error might have been caused by the macro implementation in /home/ubuntu/tensorflow/tensorflow/tensorflow.bzl:1368:12
ERROR: Analysis of target '//tensorflow/contrib/cloud:bigquery_reader_ops_test' failed; build aborted: Analysis of target '//tensorflow/contrib/cloud:bigquery_reader_ops_test' failed; build aborted
INFO: Elapsed time: 10.083s
FAILED: Build did NOT complete successfully (105 packages loaded)
ERROR: Couldn't start the build. Unable to run tests
ubuntu@ubuntu:~/tensorflow$
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>