### PR TITLE
Support "causal" padding in tf.layers.convolutional.Conv1D

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3980,7 +3980,10 @@ py_test(
     main = "layers/convolutional_test.py",
     srcs_version = "PY2AND3",
     deps = [
+        ":array_ops",
         ":client_testlib",
+        ":constant_op",
+        ":dtypes",
         ":framework_for_generated_wrappers",
         ":framework_test_lib",
         ":layers",

--- a/tensorflow/python/keras/_impl/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/_impl/keras/layers/convolutional.py
@@ -136,7 +136,8 @@ class Conv1D(tf_convolutional_layers.Conv1D, Layer):
         'filters': self.filters,
         'kernel_size': self.kernel_size,
         'strides': self.strides,
-        'padding': self.padding,
+        # Hack for causal padding
+        'padding': "causal" if self._causal_padding else self.padding,
         'dilation_rate': self.dilation_rate,
         'activation': activations.serialize(self.activation),
         'use_bias': self.use_bias,

--- a/tensorflow/python/keras/_impl/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/_impl/keras/layers/convolutional.py
@@ -137,7 +137,7 @@ class Conv1D(tf_convolutional_layers.Conv1D, Layer):
         'kernel_size': self.kernel_size,
         'strides': self.strides,
         # Hack for causal padding
-        'padding': "causal" if self._causal_padding else self.padding,
+        'padding': 'causal' if self._causal_padding else self.padding,
         'dilation_rate': self.dilation_rate,
         'activation': activations.serialize(self.activation),
         'use_bias': self.use_bias,

--- a/tensorflow/python/keras/_impl/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/_impl/keras/layers/convolutional.py
@@ -136,8 +136,7 @@ class Conv1D(tf_convolutional_layers.Conv1D, Layer):
         'filters': self.filters,
         'kernel_size': self.kernel_size,
         'strides': self.strides,
-        # Hack for causal padding
-        'padding': 'causal' if self._causal_padding else self.padding,
+        'padding': self.padding,
         'dilation_rate': self.dilation_rate,
         'activation': activations.serialize(self.activation),
         'use_bias': self.use_bias,

--- a/tensorflow/python/keras/_impl/keras/layers/convolutional_test.py
+++ b/tensorflow/python/keras/_impl/keras/layers/convolutional_test.py
@@ -42,6 +42,21 @@ class Convolution1DTest(test.TestCase):
           },
           expected_output=[[[1], [3], [5]]])
 
+  def test_conv1d_with_causal_padding(self):
+    with self.test_session(use_gpu=test.is_gpu_available()):
+      testing_utils.layer_test(
+        keras.layers.Conv1D,
+        input_data=np.reshape(np.arange(4, dtype='float32'), (1, 4, 1)),
+        kwargs={
+          'filters': 1,
+          'kernel_size': 2,
+          'dilation_rate': 2,
+          'padding': 'causal',
+          'kernel_initializer': 'ones',
+          'use_bias': False,
+        },
+        expected_output=[[[0], [1], [2], [4]]])
+
   def test_conv_1d(self):
     batch_size = 2
     steps = 8

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -376,17 +376,17 @@ class Conv1D(_Conv):
         name=name, **kwargs)
     # TODO(fchollet): Remove it when nn_ops.convolution supports causal padding.
     if self.padding == 'causal':
-        if self.data_format != 'channels_last':
-          raise ValueError('causal padding only supports channels_last (NTC) format.')
-        # Left pad for `causal` padding.
-        self._inputs_fn, self._shape_fn, self._padding_fn = _helper_for_causal_padding(
-            self.dilation_rate[0], self.kernel_size[0])
+      if self.data_format != 'channels_last':
+        raise ValueError('causal padding only supports channels_last (NTC) format.')
+      # Left pad for `causal` padding.
+      self._inputs_fn, self._shape_fn, self._padding_fn = _helper_for_causal_padding(
+          self.dilation_rate[0], self.kernel_size[0])
     else:
-        # Keep original value for `same` and `valid` padding.
-        identity_fn = lambda x: x
-        self._inputs_fn = identity_fn
-        self._shape_fn = identity_fn
-        self._padding_fn = identity_fn
+      # Keep original value for `same` and `valid` padding.
+      identity_fn = lambda x: x
+      self._inputs_fn = identity_fn
+      self._shape_fn = identity_fn
+      self._padding_fn = identity_fn
 
   # TODO(fchollet): Remove those methods when nn_ops.convolution supports causal padding.
   def _get_padding(self):

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -240,7 +240,8 @@ class Conv1D(_Conv):
       specifying the stride length of the convolution.
       Specifying any stride value != 1 is incompatible with specifying
       any `dilation_rate` value != 1.
-    padding: One of `"valid"` or `"same"` (case-insensitive).
+    padding: One of `"valid"`, `"same"` or `"causal"` (case-insensitive).
+      Currently, causal padding only supports channels_last (NTC) format.
     data_format: A string, one of `channels_last` (default) or `channels_first`.
       The ordering of the dimensions in the inputs.
       `channels_last` corresponds to inputs with shape
@@ -270,6 +271,9 @@ class Conv1D(_Conv):
     trainable: Boolean, if `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
     name: A string, the name of the layer.
+
+  Raises:
+    ValueError: If data format is incompatible with causal padding.
   """
 
   def __init__(self, filters,
@@ -291,7 +295,8 @@ class Conv1D(_Conv):
                name=None,
                **kwargs):
     if padding == "causal":
-      assert data_format == "channels_last", "causal padding only supports NTC format."
+      if data_format != "channels_last":
+        raise ValueError("causal padding only supports channels_last (NTC) format.")
       self._causal_padding = True
       padding = "valid"
     else:

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -122,8 +122,14 @@ class _Conv(base.Layer):
     self.bias_constraint = bias_constraint
     self.input_spec = base.InputSpec(ndim=self.rank + 2)
 
+  # TODO(fchollet): Remove it when nn_ops.convolution supports causal padding.
   def _get_padding(self):
-    """The private method is only declared for Conv1D to support causal padding."""
+    """Return correct padding for its low-level implementation.
+
+    Note that the private method is only declared for Conv1D
+    to support causal padding. Don't use it anywhere except in
+    _Conv or Conv1D class.
+    """
     return self.padding
 
   def build(self, input_shape):
@@ -226,6 +232,7 @@ class _Conv(base.Layer):
                                       new_space)
 
 
+# TODO(fchollet): Remove it when nn_ops.convolution supports causal padding.
 def _helper_for_causal_padding(dilation_rate, kernel_size):
   """Generate the functions to preprocess inputs and input_shape for causal padding.
 
@@ -266,7 +273,7 @@ def _helper_for_causal_padding(dilation_rate, kernel_size):
     if padding == 'causal':
       return 'valid'
     else:
-      raise ValueError("padding must be `causal`. Received: {}".format(padding))
+      raise ValueError('padding must be `causal`. Received: {}'.format(padding))
 
   return inputs_fn, shape_fn, padding_fn
 
@@ -363,6 +370,7 @@ class Conv1D(_Conv):
         bias_constraint=bias_constraint,
         trainable=trainable,
         name=name, **kwargs)
+    # TODO(fchollet): Remove it when nn_ops.convolution supports causal padding.
     if self.padding == 'causal':
         if self.data_format != 'channels_last':
           raise ValueError('causal padding only supports channels_last (NTC) format.')
@@ -376,6 +384,7 @@ class Conv1D(_Conv):
         self._shape_fn = identity_fn
         self._padding_fn = identity_fn
 
+  # TODO(fchollet): Remove those methods when nn_ops.convolution supports causal padding.
   def _get_padding(self):
     return self._padding_fn(self.padding)
 

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -323,16 +323,15 @@ class Conv1D(_Conv):
 
   def build(self, input_shape):
     _, shape_fn = self._helper_for_causal_padding()
-    super(Conv1D, self).build(shape_fn(input_shape) or input_shape)
+    super(Conv1D, self).build(shape_fn(input_shape))
 
   def call(self, inputs):
     inputs_fn, _ = self._helper_for_causal_padding()
-    return super(Conv1D, self).call(inputs_fn(inputs) or inputs)
+    return super(Conv1D, self).call(inputs_fn(inputs))
 
   def _compute_output_shape(self, input_shape):
     _, shape_fn = self._helper_for_causal_padding()
-    return super(Conv1D, self)._compute_output_shape(shape_fn(input_shape)
-                                                     or input_shape)
+    return super(Conv1D, self)._compute_output_shape(shape_fn(input_shape))
 
   def _helper_for_causal_padding(self):
     """Generate the functions to handle inputs and input_shape for causal padding."""
@@ -355,8 +354,8 @@ class Conv1D(_Conv):
 
       return inputs_fn, shape_fn
     else:
-      dummy_fn = lambda _: None
-      return dummy_fn, dummy_fn
+      identity_fn = lambda x: x
+      return identity_fn, identity_fn
 
 
 def conv1d(inputs,

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -295,11 +295,11 @@ class Conv1D(_Conv):
                trainable=True,
                name=None,
                **kwargs):
-    if padding == "causal":
-      if data_format != "channels_last":
-        raise ValueError("causal padding only supports channels_last (NTC) format.")
+    if padding == 'causal':
+      if data_format != 'channels_last':
+        raise ValueError('causal padding only supports channels_last (NTC) format.')
       self._causal_padding = True
-      padding = "valid"
+      padding = 'valid'
     else:
       self._causal_padding = False
     super(Conv1D, self).__init__(
@@ -340,8 +340,8 @@ class Conv1D(_Conv):
       # `causal` padding: left pad on time channel.
       left_pad = int(self.dilation_rate[0] * (self.kernel_size[0] - 1))
       if left_pad <= 0:
-        raise ValueError("The left_pad must be positive, "
-                         "while get: {}".format(left_pad))
+        raise ValueError('The left_pad must be positive, '
+                         'while get: {}'.format(left_pad))
 
       def inputs_fn(inputs):
         # left pad for causal (dilated) convolution.
@@ -350,8 +350,8 @@ class Conv1D(_Conv):
       def shape_fn(input_shape):
         input_shape = tensor_shape.TensorShape(input_shape)
         if input_shape.ndims != 3:
-          raise ValueError("The input_shape must be 3 dimensions, "
-                           "while get: {}".format(input_shape))
+          raise ValueError('The input_shape must be 3 dimensions, '
+                           'while get: {}'.format(input_shape))
         input_list = input_shape.as_list()
         # left pad on time channel.
         input_list[1] += left_pad

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -262,11 +262,15 @@ def _helper_for_causal_padding(dilation_rate, kernel_size):
     if input_shape.ndims != 3:
       raise ValueError('The input_shape must be 3 dimensions. '
                        'Received: {}'.format(input_shape))
-    input_list = input_shape.as_list()
-    # Padding on the left side of time channel.
-    input_list[1] += left_pad
-    return tensor_shape.TensorShape([tensor_shape.Dimension(d)
-                                     for d in input_list])
+    if not input_shape[1].value:
+      # Unknown dimension in time channel.
+      return input_shape
+    else:
+      input_list = input_shape.as_list()
+      # Padding on the left side of time channel.
+      input_list[1] += left_pad
+      return tensor_shape.TensorShape([tensor_shape.Dimension(d)
+                                       for d in input_list])
 
   def padding_fn(padding):
     # Use valid convolution after left padding.

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -222,31 +222,6 @@ class _Conv(base.Layer):
                                       new_space)
 
 
-def _convert_input_shape_for_causal_padding(input_shape, left_pad):
-  """Correct the time channel size for causal padding.
-
-  Arguments:
-    input_shape: A 3-D `TensorShape`.
-    left_pad: The increment in the left side of time channel.
-
-  Returns:
-    A TensorShape.
-
-  Raises:
-    AssertionError: If argument is invalid.
-  """
-  input_shape = tensor_shape.TensorShape(input_shape)
-  assert input_shape.ndims == 3, "The rank of input_shape must be 3."
-  input_list = input_shape.as_list()
-
-  left_pad = int(left_pad)
-  assert left_pad > 0, "The left_pad must be positive."
-
-  input_list[1] += int(left_pad)
-  return tensor_shape.TensorShape([tensor_shape.Dimension(d)
-                                   for d in input_list])
-
-
 class Conv1D(_Conv):
   """1D convolution layer (e.g. temporal convolution).
 
@@ -347,29 +322,41 @@ class Conv1D(_Conv):
         name=name, **kwargs)
 
   def build(self, input_shape):
-    if self._causal_padding:
-      input_shape = _convert_input_shape_for_causal_padding(
-        input_shape, self._left_pad_for_causal_padding())
-    super(Conv1D, self).build(input_shape)
+    _, shape_fn = self._helper_for_causal_padding()
+    super(Conv1D, self).build(shape_fn(input_shape) or input_shape)
 
   def call(self, inputs):
-    if self._causal_padding:
-      # causal (dilated) convolution:
-      left_pad = self._left_pad_for_causal_padding()
-      inputs = array_ops.pad(inputs, [[0, 0], [left_pad, 0], [0, 0]])
-    return super(Conv1D, self).call(inputs)
+    inputs_fn, _ = self._helper_for_causal_padding()
+    return super(Conv1D, self).call(inputs_fn(inputs) or inputs)
 
   def _compute_output_shape(self, input_shape):
-    if self._causal_padding:
-      input_shape = _convert_input_shape_for_causal_padding(
-        input_shape, self._left_pad_for_causal_padding())
-    return super(Conv1D, self)._compute_output_shape(input_shape)
+    _, shape_fn = self._helper_for_causal_padding()
+    return super(Conv1D, self)._compute_output_shape(shape_fn(input_shape)
+                                                     or input_shape)
 
-  def _left_pad_for_causal_padding(self):
+  def _helper_for_causal_padding(self):
+    """Generate the functions to handle inputs and input_shape for causal padding."""
     if self._causal_padding:
-      return self.dilation_rate[0] * (self.kernel_size[0] - 1)
+      left_pad = int(self.dilation_rate[0] * (self.kernel_size[0] - 1))
+      if left_pad <= 0:
+        raise ValueError("The left_pad must be positive.")
+
+      def inputs_fn(inputs):
+        # left pad for causal (dilated) convolution
+        return array_ops.pad(inputs, [[0, 0], [left_pad, 0], [0, 0]])
+
+      def shape_fn(input_shape):
+        input_shape = tensor_shape.TensorShape(input_shape)
+        assert input_shape.ndims == 3, "The rank of input_shape must be 3."
+        input_list = input_shape.as_list()
+        input_list[1] += left_pad
+        return tensor_shape.TensorShape([tensor_shape.Dimension(d)
+                                         for d in input_list])
+
+      return inputs_fn, shape_fn
     else:
-      raise NotImplementedError("The method can only be invoked for causal padding")
+      dummy_fn = lambda _: None
+      return dummy_fn, dummy_fn
 
 
 def conv1d(inputs,

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -171,7 +171,7 @@ class ConvTest(test.TestCase):
 
   def testConv1DCausalPadding(self):
     x = np.array([1, 2, 3, 4], dtype=np.float32)
-    # Aad batch and channel dimension: 1x4x1
+    # Add batch and channel dimension: 1x4x1
     x = x[np.newaxis, ..., np.newaxis]
     # Filters is 2x1x1
     filters = np.array([2, 1], dtype=np.float32)
@@ -209,13 +209,13 @@ class ConvTest(test.TestCase):
     x = constant_op.constant([1, 2, 3, 4], dtype=dtypes.float32)
     x = array_ops.expand_dims(x, 0)  # Add batch dimension
     x = array_ops.expand_dims(x, 2)  # And channel dimension
-    # incompatible data_format.
+    # Incompatible data_format.
     with self.assertRaisesRegexp(ValueError, 'NTC'):
       conv_layers.Conv1D(1, 2, padding='causal', data_format='channels_first')
-    # invalid dilation_rate.
+    # Invalid dilation_rate.
     with self.assertRaisesRegexp(ValueError, 'nonnegative'):
       conv_layers.Conv1D(1, 2, padding='causal', dilation_rate=-1).apply(x)
-    # invalid inputs.
+    # Invalid inputs.
     with self.assertRaisesRegexp(ValueError, '3 dimensions'):
       x_4d = array_ops.expand_dims(x, 3)
       conv_layers.Conv1D(1, 2, padding='causal').build(x_4d.shape)

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -209,7 +209,7 @@ class ConvTest(test.TestCase):
     with self.assertRaisesRegexp(ValueError, 'NTC'):
       conv_layers.Conv1D(1, 2, padding='causal', data_format='channels_first')
     # invalid dilation_rate.
-    with self.assertRaisesRegexp(ValueError, 'positive'):
+    with self.assertRaisesRegexp(ValueError, 'nonnegative'):
       conv_layers.Conv1D(1, 2, padding='causal', dilation_rate=-1).apply(x)
     # invalid inputs.
     with self.assertRaisesRegexp(ValueError, '3 dimensions'):

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -178,7 +178,7 @@ class ConvTest(test.TestCase):
     filters = filters[..., np.newaxis, np.newaxis]
     filters = init_ops.constant_initializer(filters)
     with self.test_session(use_gpu=test.is_gpu_available()) as sess:
-      layer = conv_layers.Conv1D(1, 2, padding="causal",
+      layer = conv_layers.Conv1D(1, 2, padding='causal',
                                  kernel_initializer=filters,
                                  activation=None,
                                  use_bias=False)
@@ -192,7 +192,7 @@ class ConvTest(test.TestCase):
                           [2 * 0 + 1 * 1, 2 * 1 + 1 * 2, 2 * 2 + 1 * 3, 2 * 3 + 1 * 4])
     # dilation_rate is 2
     with self.test_session(use_gpu=test.is_gpu_available()) as sess:
-      layer = conv_layers.Conv1D(1, 2, padding="causal", dilation_rate=2,
+      layer = conv_layers.Conv1D(1, 2, padding='causal', dilation_rate=2,
                                  kernel_initializer=filters,
                                  activation=None,
                                  use_bias=False)
@@ -206,15 +206,15 @@ class ConvTest(test.TestCase):
                           [2 * 0 + 1 * 1, 2 * 0 + 1 * 2, 2 * 1 + 1 * 3, 2 * 2 + 1 * 4])
 
     # incompatible data_format.
-    with self.assertRaisesRegexp(ValueError, "NTC"):
-      conv_layers.Conv1D(1, 2, padding="causal", data_format="channels_first")
+    with self.assertRaisesRegexp(ValueError, 'NTC'):
+      conv_layers.Conv1D(1, 2, padding='causal', data_format='channels_first')
     # invalid dilation_rate.
-    with self.assertRaisesRegexp(ValueError, "positive"):
-      conv_layers.Conv1D(1, 2, padding="causal", dilation_rate=-1).apply(x)
+    with self.assertRaisesRegexp(ValueError, 'positive'):
+      conv_layers.Conv1D(1, 2, padding='causal', dilation_rate=-1).apply(x)
     # invalid inputs.
-    with self.assertRaisesRegexp(ValueError, "3 dimensions"):
+    with self.assertRaisesRegexp(ValueError, '3 dimensions'):
       x_4d = array_ops.expand_dims(x, 3)
-      conv_layers.Conv1D(1, 2, padding="causal").build(x_4d.shape)
+      conv_layers.Conv1D(1, 2, padding='causal').build(x_4d.shape)
 
   def testUnknownInputChannelsConv1D(self):
     data = random_ops.random_uniform((5, 4, 7))

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -205,8 +205,16 @@ class ConvTest(test.TestCase):
       self.assertAllClose(output,
                           [2 * 0 + 1 * 1, 2 * 0 + 1 * 2, 2 * 1 + 1 * 3, 2 * 2 + 1 * 4])
 
-    with self.assertRaisesRegexp(ValueError, "causal padding"):
-      conv_layers.Conv1D(x, filters, padding="causal", data_format="channels_first")
+    # incompatible data_format.
+    with self.assertRaisesRegexp(ValueError, "NTC"):
+      conv_layers.Conv1D(1, 2, padding="causal", data_format="channels_first")
+    # invalid dilation_rate.
+    with self.assertRaisesRegexp(ValueError, "positive"):
+      conv_layers.Conv1D(1, 2, padding="causal", dilation_rate=-1).apply(x)
+    # invalid inputs.
+    with self.assertRaisesRegexp(ValueError, "3 dimensions"):
+      x_4d = array_ops.expand_dims(x, 3)
+      conv_layers.Conv1D(1, 2, padding="causal").build(x_4d.shape)
 
   def testUnknownInputChannelsConv1D(self):
     data = random_ops.random_uniform((5, 4, 7))

--- a/tensorflow/python/layers/utils.py
+++ b/tensorflow/python/layers/utils.py
@@ -100,8 +100,8 @@ def normalize_data_format(value):
 
 def normalize_padding(value):
   padding = value.lower()
-  if padding not in {'valid', 'same'}:
-    raise ValueError('The `padding` argument must be one of "valid", "same". '
+  if padding not in {'valid', 'same', 'causal'}:
+    raise ValueError('The `padding` argument must be one of "valid", "same" or "causal". '
                      'Received: ' + str(padding))
   return padding
 


### PR DESCRIPTION
Because #15000 is closed by mistake, hence the PR is reopened to resolve #14933 issue.

Because we don't see causal padding in other use cases expect of NTC, we choose to modify code at Conv1D, instead of tf.nn.convolution.

Ref: [conv1d implementation](https://github.com/fchollet/keras/blob/d956d19fccf6de6344c282218f1b027453785fa9/keras/backend/tensorflow_backend.py#L3141-3145) in keras.

### How to test

+ [x] add test for layers.Conv1D
+ [x] add test for keras.layers.Conv1D
+ [ ] pass all tests.