### PR TITLE
tf.Print supports Variable

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1763,6 +1763,8 @@ py_library(
     srcs = ["ops/logging_ops.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":array_ops_gen",
+        ":constant_op",
         ":framework_for_generated_wrappers",
         ":logging_ops_gen",
         ":util",

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -466,6 +466,7 @@ tf_py_test(
         "//tensorflow/python:gradients",
         "//tensorflow/python:logging_ops",
         "//tensorflow/python:math_ops",
+        "//tensorflow/python:variables",
     ],
 )
 

--- a/tensorflow/python/kernel_tests/logging_ops_test.py
+++ b/tensorflow/python/kernel_tests/logging_ops_test.py
@@ -25,6 +25,7 @@ from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import logging_ops
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
 
@@ -76,6 +77,15 @@ class PrintGradientTest(test.TestCase):
       wxg = wx_grad.eval()
       wxpg = wx_print_grad.eval()
     self.assertAllEqual(wxg, wxpg)
+
+  def testPrintVariable(self):
+    v = variables.Variable([[99], [22]])
+    p = logging_ops.Print(v, [v])
+    self.assertTrue(isinstance(p, type(v)))
+    self.assertEqual(p.dtype, v.dtype)
+    with self.test_session() as sess:
+      sess.run(variables.global_variables_initializer())
+      self.assertAllEqual(p.eval(), v.eval())
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/logging_ops_test.py
+++ b/tensorflow/python/kernel_tests/logging_ops_test.py
@@ -79,13 +79,24 @@ class PrintGradientTest(test.TestCase):
     self.assertAllEqual(wxg, wxpg)
 
   def testPrintVariable(self):
+    # Variable
     v = variables.Variable([[99], [22]])
-    p = logging_ops.Print(v, [v])
-    self.assertTrue(isinstance(p, type(v)))
-    self.assertEqual(p.dtype, v.dtype)
+    pv = logging_ops.Print(v, [v])
+    self.assertTrue(isinstance(pv, type(v)))
+    self.assertEqual(pv.dtype, v.dtype)
     with self.test_session() as sess:
-      sess.run(variables.global_variables_initializer())
-      self.assertAllEqual(p.eval(), v.eval())
+      sess.run(v.initializer)
+      self.assertAllEqual(pv.eval(), v.eval())
+
+    # mutable tensor
+    v = variables.Variable([17])
+    m = v.op.outputs[0]
+    pm = logging_ops.Print(m, [m])
+    self.assertTrue(isinstance(pm, type(m)))
+    self.assertEqual(pm.dtype, m.dtype)
+    with self.test_session() as sess:
+      sess.run(v.initializer)
+      self.assertAllEqual(sess.run(pm), sess.run(m))
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/ops/logging_ops.py
+++ b/tensorflow/python/ops/logging_ops.py
@@ -24,6 +24,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import gen_logging_ops
+from tensorflow.python.ops import variables
 # go/tf-wildcard-import
 # pylint: disable=wildcard-import
 from tensorflow.python.ops.gen_logging_ops import *
@@ -65,7 +66,10 @@ def Print(input_, data, message=None, first_n=None, summarize=None,
     helper_op = gen_logging_ops._print(constant_op.constant([]),
                                        data, message, first_n, summarize, name)
     with ops.control_dependencies([helper_op]):
-      return gen_array_ops._ref_identity(input_, name=name)
+      if isinstance(input_, variables.Variable):
+        return variables.Variable(variable_def=input_.to_proto())
+      else:
+        return gen_array_ops._ref_identity(input_, name=name)
   else:
     return gen_logging_ops._print(input_, data, message, first_n, summarize, name)
 


### PR DESCRIPTION
CF #14788, #14874

I agree that it might be not a good idea to pass Variable as `input_` for `tf.Print`, and the implementation might be incomplete, incorrect or even potentially dangerous.  So feel free to close the pr.

As we knwon, `tf.Print` is consistent with `tf.identity`, which always return a Tensor with the same type. However, the pr changes `tf.Print`'s behavior as:
+ return Tensor for Tensor.
+ return mutable Tensor for mutable Tensor.
+ return Variable for Variable.

The pr is opposed to #15069.