### PR TITLE
Add S3 to the list of implemented file systems in doc

### DIFF
--- a/tensorflow/docs_src/extend/add_filesys.md
+++ b/tensorflow/docs_src/extend/add_filesys.md
@@ -35,6 +35,7 @@ Note that TensorFlow already includes many filesystem implementations, such as:
 
 *   HDFS - the Hadoop File System
 *   GCS - Google Cloud Storage filesystem
+*   S3 - Amazon Simple Storage Service filesystem
 *   A "memory-mapped-file" filesystem
 
 The rest of this guide describes how to implement a custom filesystem.


### PR DESCRIPTION
This fix adds S3 to the list of implemented file systems in doc.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>