### PR TITLE
DOC: Fix documentation for dataset.md

### DIFF
--- a/tensorflow/docs_src/programmers_guide/datasets.md
+++ b/tensorflow/docs_src/programmers_guide/datasets.md
@@ -735,7 +735,7 @@ def dataset_input_fn():
     parsed = tf.parse_single_example(record, keys_to_features)
 
     # Perform additional preprocessing on the parsed data.
-    image = tf.decode_jpeg(parsed["image_data"])
+    image = tf.image.decode_jpeg(parsed["image_data"])
     image = tf.reshape(image, [299, 299, 1])
     label = tf.cast(parsed["label"], tf.int32)
 


### PR DESCRIPTION
The code `image = tf.decode_jpeg(parsed["image_data"])` in 738 lines is incorrect. It should be `tf.image.decode_jpeg` instead of `tf.decode_jpeg`.