### PR TITLE
improve tf.saved_model.loader.load exception

### DIFF
--- a/tensorflow/python/saved_model/loader_impl.py
+++ b/tensorflow/python/saved_model/loader_impl.py
@@ -311,7 +311,9 @@ class SavedModelLoader(object):
       RuntimeError: if no metagraphs were found with the associated tags.
     """
     found_match = False
+    available_tags = []
     for meta_graph_def in self._saved_model.meta_graphs:
+      available_tags.append(set(meta_graph_def.meta_info_def.tags))
       if set(meta_graph_def.meta_info_def.tags) == set(tags):
         meta_graph_def_to_load = meta_graph_def
         found_match = True
@@ -322,6 +324,7 @@ class SavedModelLoader(object):
           "MetaGraphDef associated with tags " + str(tags).strip("[]") +
           " could not be found in SavedModel. To inspect available tag-sets in"
           " the SavedModel, please use the SavedModel CLI: `saved_model_cli`"
+          "\navailable_tags: " + str(available_tags)
       )
     return meta_graph_def_to_load
 


### PR DESCRIPTION
If the `tags` argument to `tf.saved_model.loader.load` is wrong, the exception does not help.
First: It says use saved_model_cli, but it take a while to figure out that this is a executable and not a python function.
Second: The required information (allowed tags) is known inside `tf.saved_model.loader.load` and now it prints this error
```python
>>> with tf.Session(graph=tf.Graph()) as sess:
>>>    tf.saved_model.loader.load(sess, ['wrong tag'], 'path/to/model')
RuntimeError: MetaGraphDef associated with tags 'wrong tag' could not be found in SavedModel. To inspect available tag-sets in the SavedModel, please use the SavedModel CLI: `saved_model_cli`available_tags: [{'serve'}]
```