### PR TITLE
MKL: Dockerfile Locked to Broadwell/AVX2 arch to work around Eigen Issues with AVX512

### DIFF
--- a/tensorflow/tools/docker/Dockerfile.devel-cpu-mkl
+++ b/tensorflow/tools/docker/Dockerfile.devel-cpu-mkl
@@ -54,7 +54,7 @@ RUN ./configure
 RUN LD_LIBRARY_PATH=${LD_LIBRARY_PATH} \
     bazel build --config=mkl \
                 --config="opt" \
-                --copt="-march=native" \
+                --copt="-march=broadwell" \
                 --copt="-O3" \
                 //tensorflow/tools/pip_package:build_pip_package && \
     mkdir ${WHL_DIR} && \
@@ -81,5 +81,3 @@ RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/issue && cat /etc/motd' \
 ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||\n\
 \n "\
 	> /etc/motd
-
-CMD ["/bin/bash"]


### PR DESCRIPTION
Eigen currently has issues when Tensorflow is compiled with -march=skylake, or the container is build on a skylake system with -march=native. The container is now compiled with -march=broadwell, which adds AVX2 instructions, which are supported on Skylake, Haswell, Broadwell, KNL and KNM architectures.