### PR TITLE
Add a setter method variable_scope.auto_reuse_variables() to enable AUTO_REUSE

### DIFF
--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -982,6 +982,10 @@ class VariableScope(object):
     """Reuse variables in this scope."""
     self._reuse = True
 
+  def auto_reuse_variables(self):
+    """Auto reuse variables in this scope."""
+    self._reuse = AUTO_REUSE
+
   def set_initializer(self, initializer):
     """Set initializer for this scope."""
     self._initializer = initializer


### PR DESCRIPTION
Currently we can enable variable reuse in a scope with variable_scope.reuse_variables(). However, there is no handy method to enable auto reuse yet. This PR adds this functionality.