### PR TITLE
OS X ld does not have icf

### DIFF
--- a/tensorflow/contrib/lite/build_def.bzl
+++ b/tensorflow/contrib/lite/build_def.bzl
@@ -47,6 +47,7 @@ def tflite_linkopts_unstripped():
           "-Wl,--gc-sections", # Eliminate unused code and data.
           "-Wl,--as-needed", # Don't link unused libs.
       ],
+      "//tensorflow:darwin": [],
       "//tensorflow/contrib/lite:mips": [],
       "//tensorflow/contrib/lite:mips64": [],
       "//conditions:default": [


### PR DESCRIPTION
when using tflite_linkopts_unstripped() or tflite_linkopts() to build stuff, such as https://github.com/tensorflow/tensorflow/pull/15095, on OS X, identical code folding flag is not supported.