### PR TITLE
Add decode_compressed support

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_DecodeCompressed.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DecodeCompressed.pbtxt
@@ -20,5 +20,13 @@ A scalar containing either (i) the empty string (no
 compression), (ii) "ZLIB", or (iii) "GZIP".
 END
   }
-  summary: "Decompress the bytes of a string to the output string."
+  summary: "Decompress strings."
+  description: <<END
+This op decompresses each element of the `bytes` input `Tensor`, which
+is assumed to be compressed using the given `compression_type`.
+
+The `output` is a string `Tensor` of the same shape as `bytes`,
+each element containing the decompressed data from the corresponding
+element in `bytes`.
+END
 }

--- a/tensorflow/core/api_def/base_api/api_def_DecodeCompressed.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DecodeCompressed.pbtxt
@@ -1,0 +1,24 @@
+op {
+  graph_op_name: "DecodeCompressed"
+  in_arg {
+    name: "bytes"
+    description: <<END
+A Tensor of string which is compressed.
+END
+  }
+  out_arg {
+    name: "output"
+    description: <<END
+A Tensor with the same shape as input `bytes`, uncompressed
+from bytes.
+END
+  }
+  attr {
+    name: "compression_type"
+    description: <<END
+A scalar containing either (i) the empty string (no
+compression), (ii) "ZLIB", or (iii) "GZIP".
+END
+  }
+  summary: "Decompress the bytes of a string to the output string."
+}

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3495,9 +3495,9 @@ tf_kernel_library(
 cc_library(
     name = "parsing",
     deps = [
+        ":decode_compressed_op",
         ":decode_csv_op",
         ":decode_raw_op",
-        ":decode_compressed_op",
         ":example_parsing_ops",
         ":parse_tensor_op",
         ":string_to_number_op",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3497,6 +3497,7 @@ cc_library(
     deps = [
         ":decode_csv_op",
         ":decode_raw_op",
+        ":decode_compressed_op",
         ":example_parsing_ops",
         ":parse_tensor_op",
         ":string_to_number_op",
@@ -3521,6 +3522,14 @@ tf_kernel_library(
     name = "decode_raw_op",
     prefix = "decode_raw_op",
     deps = PARSING_DEPS,
+)
+
+tf_kernel_library(
+    name = "decode_compressed_op",
+    prefix = "decode_compressed_op",
+    deps = [
+        "//tensorflow/core:lib_internal",
+    ] + PARSING_DEPS,
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/decode_compressed_op.cc
+++ b/tensorflow/core/kernels/decode_compressed_op.cc
@@ -1,0 +1,113 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/parse_ops.cc.
+
+#include <algorithm>
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/io/zlib_compression_options.h"
+#include "tensorflow/core/lib/io/zlib_inputstream.h"
+
+namespace tensorflow {
+namespace {
+// Wrap memory buffer into InputStreamInterface
+class MemoryInputStream : public io::InputStreamInterface {
+ public:
+  explicit MemoryInputStream(const char* buffer, size_t length)
+      : buf_(buffer), len_(length), pos_(0) {}
+
+  ~MemoryInputStream(){};
+
+  Status ReadNBytes(int64 bytes_to_read, string* result) override {
+    result->clear();
+    if (bytes_to_read < 0) {
+      return errors::InvalidArgument("Can't read a negative number of bytes: ",
+                                     bytes_to_read);
+    }
+    int64 bytes = bytes_to_read;
+    Status s = Status::OK();
+    if (pos_ + bytes_to_read > len_) {
+      bytes = len_ - pos_;
+      s = errors::OutOfRange("reached end of file");
+    }
+    if (bytes > 0) {
+      result->resize(bytes);
+      memcpy(&(*result)[0], &buf_[pos_], bytes);
+      pos_ += bytes;
+    }
+    return s;
+  }
+
+  int64 Tell() const override { return pos_; }
+
+  Status Reset() override {
+    pos_ = 0;
+    return Status::OK();
+  }
+
+ private:
+  const char* buf_;  // Not owned.
+  int64 len_;
+  int64 pos_ = 0;  // Tracks where we are in the file.
+};
+}  // namespace
+
+class DecodeCompressedOp : public OpKernel {
+ public:
+  explicit DecodeCompressedOp(OpKernelConstruction* context)
+      : OpKernel(context) {
+    OP_REQUIRES_OK(context,
+                   context->GetAttr("compression_type", &compression_type_));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* bytes_tensor;
+    OP_REQUIRES_OK(context, context->input("bytes", &bytes_tensor));
+    const auto& bytes_flat = bytes_tensor->flat<string>();
+
+    Tensor* output_tensor = nullptr;
+    OP_REQUIRES_OK(context,
+                   context->allocate_output("output", bytes_tensor->shape(),
+                                            &output_tensor));
+    auto output_flat = output_tensor->flat<string>();
+    const io::ZlibCompressionOptions zlib_options =
+        compression_type_ == "ZLIB" ? io::ZlibCompressionOptions::DEFAULT()
+                                    : io::ZlibCompressionOptions::GZIP();
+    for (int64 i = 0; i < bytes_flat.size(); i++) {
+      std::unique_ptr<MemoryInputStream> input_stream(
+          new MemoryInputStream(bytes_flat(i).data(), bytes_flat(i).size()));
+      std::unique_ptr<io::ZlibInputStream> zlib_stream(new io::ZlibInputStream(
+          input_stream.get(), static_cast<size_t>(kBufferSize),
+          static_cast<size_t>(kBufferSize), zlib_options));
+      std::string output_string;
+      Status s = zlib_stream->ReadNBytes(INT_MAX, &output_string);
+      OP_REQUIRES(context, (s.ok() || errors::IsOutOfRange(s)), s);
+      output_flat(i) = output_string;
+    }
+  }
+
+ private:
+  enum { kBufferSize = 256 << 10 /* 256 kB */ };
+  std::string compression_type_;
+};
+
+REGISTER_KERNEL_BUILDER(Name("DecodeCompressed").Device(DEVICE_CPU),
+                        DecodeCompressedOp)
+
+}  // namespace tensorflow

--- a/tensorflow/core/ops/parsing_ops.cc
+++ b/tensorflow/core/ops/parsing_ops.cc
@@ -48,6 +48,20 @@ output: A Tensor with one more dimension than the input `bytes`.  The
   of `bytes` divided by the number of bytes to represent `out_type`.
 )doc");
 
+REGISTER_OP("DecodeCompressed")
+    .Input("bytes: string")
+    .Output("output: string")
+    .Attr("compression_type: string = ''")
+    .SetShapeFn(shape_inference::UnchangedShape)
+    .Doc(R"doc(
+Reinterpret the bytes of a string as a vector of numbers.
+
+bytes: All the elements must have the same length.
+compression_type: A scalar containing either (i) the empty string (no
+  compression), (ii) "ZLIB", or (iii) "GZIP".
+output: A Tensor with the same shape as input `bytes`.
+)doc");
+
 REGISTER_OP("ParseExample")
     .Input("serialized: string")
     .Input("names: string")

--- a/tensorflow/core/ops/parsing_ops.cc
+++ b/tensorflow/core/ops/parsing_ops.cc
@@ -54,12 +54,13 @@ REGISTER_OP("DecodeCompressed")
     .Attr("compression_type: string = ''")
     .SetShapeFn(shape_inference::UnchangedShape)
     .Doc(R"doc(
-Reinterpret the bytes of a string as a vector of numbers.
+Decompress the bytes of a string to the output string.
 
-bytes: All the elements must have the same length.
+bytes: A Tensor of string which is compressed.
 compression_type: A scalar containing either (i) the empty string (no
   compression), (ii) "ZLIB", or (iii) "GZIP".
-output: A Tensor with the same shape as input `bytes`.
+output: A Tensor with the same shape as input `bytes`, uncompressed
+  from bytes.
 )doc");
 
 REGISTER_OP("ParseExample")

--- a/tensorflow/core/ops/parsing_ops.cc
+++ b/tensorflow/core/ops/parsing_ops.cc
@@ -54,13 +54,20 @@ REGISTER_OP("DecodeCompressed")
     .Attr("compression_type: string = ''")
     .SetShapeFn(shape_inference::UnchangedShape)
     .Doc(R"doc(
-Decompress the bytes of a string to the output string.
+Decompress strings. 
+
+This op decompresses each element of the `bytes` input `Tensor`, which
+is assumed to be compressed using the given `compression_type`. 
+
+The `output` is a string `Tensor` of the same shape as `bytes`, 
+each element containing the decompressed data from the corresponding
+element in `bytes`.
 
 bytes: A Tensor of string which is compressed.
-compression_type: A scalar containing either (i) the empty string (no
-  compression), (ii) "ZLIB", or (iii) "GZIP".
 output: A Tensor with the same shape as input `bytes`, uncompressed
   from bytes.
+compression_type: A scalar containing either (i) the empty string (no
+  compression), (ii) "ZLIB", or (iii) "GZIP".
 )doc");
 
 REGISTER_OP("ParseExample")

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -294,6 +294,19 @@ tf_py_test(
     ],
 )
 
+tf_py_test(
+    name = "decode_compressed_op_test",
+    size = "small",
+    srcs = ["decode_compressed_op_test.py"],
+    additional_deps = [
+        "//third_party/py/numpy",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:parsing_ops",
+    ],
+)
+
 cuda_py_test(
     name = "determinant_op_test",
     size = "small",

--- a/tensorflow/python/kernel_tests/decode_compressed_op_test.py
+++ b/tensorflow/python/kernel_tests/decode_compressed_op_test.py
@@ -1,0 +1,60 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for DecodeRaw op from parsing_ops."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import gzip
+import sys
+import zlib
+
+from six import StringIO
+
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import parsing_ops
+from tensorflow.python.platform import test
+
+
+class DecodeCompressedOpTest(test.TestCase):
+
+  def _compress(self, bytes, compression_type):
+    if compression_type == "ZLIB":
+      return zlib.compress(bytes)
+    else:
+      out = StringIO()
+      with gzip.GzipFile(fileobj=out, mode="w") as f:
+        f.write(bytes)
+      return out.getvalue()
+
+  def testDecompress(self):
+    for compression_type in ["ZLIB", "GZIP"]:
+      with self.test_session():
+        in_bytes = array_ops.placeholder(dtypes.string, shape=[2])
+        decompressed = parsing_ops.decode_compressed(
+            in_bytes, compression_type=compression_type)
+        self.assertEqual([2], decompressed.get_shape().as_list())
+
+        result = decompressed.eval(
+            feed_dict={in_bytes: [self._compress("AaAA", compression_type),
+                                  self._compress("bBbb", compression_type)]})
+        self.assertAllEqual(["AaAA", "bBbb"], result)
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/kernel_tests/decode_compressed_op_test.py
+++ b/tensorflow/python/kernel_tests/decode_compressed_op_test.py
@@ -34,7 +34,9 @@ from tensorflow.python.platform import test
 class DecodeCompressedOpTest(test.TestCase):
 
   def _compress(self, bytes, compression_type):
-    if compression_type == "ZLIB":
+    if compression_type == "":
+      return bytes
+    elif compression_type == "ZLIB":
       return zlib.compress(bytes)
     else:
       out = StringIO()
@@ -43,7 +45,7 @@ class DecodeCompressedOpTest(test.TestCase):
       return out.getvalue()
 
   def testDecompress(self):
-    for compression_type in ["ZLIB", "GZIP"]:
+    for compression_type in ["ZLIB", "GZIP", ""]:
       with self.test_session():
         in_bytes = array_ops.placeholder(dtypes.string, shape=[2])
         decompressed = parsing_ops.decode_compressed(
@@ -56,7 +58,7 @@ class DecodeCompressedOpTest(test.TestCase):
         self.assertAllEqual(["AaAA", "bBbb"], result)
 
   def testDecompressWithRaw(self):
-    for compression_type in ["ZLIB", "GZIP"]:
+    for compression_type in ["ZLIB", "GZIP", ""]:
       with self.test_session():
         in_bytes = array_ops.placeholder(dtypes.string, shape=[None])
         decompressed = parsing_ops.decode_compressed(

--- a/tensorflow/python/kernel_tests/decode_compressed_op_test.py
+++ b/tensorflow/python/kernel_tests/decode_compressed_op_test.py
@@ -55,6 +55,19 @@ class DecodeCompressedOpTest(test.TestCase):
                                   self._compress("bBbb", compression_type)]})
         self.assertAllEqual(["AaAA", "bBbb"], result)
 
+  def testDecompressWithRaw(self):
+    for compression_type in ["ZLIB", "GZIP"]:
+      with self.test_session():
+        in_bytes = array_ops.placeholder(dtypes.string, shape=[None])
+        decompressed = parsing_ops.decode_compressed(
+            in_bytes, compression_type=compression_type)
+        decode = parsing_ops.decode_raw(decompressed, out_type=dtypes.int16)
+
+        result = decode.eval(
+            feed_dict={in_bytes: [self._compress("AaBC", compression_type)]})
+        self.assertAllEqual(
+            [[ord("A") + ord("a") * 256, ord("B") + ord("C") * 256]], result)
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/decode_compressed_op_test.py
+++ b/tensorflow/python/kernel_tests/decode_compressed_op_test.py
@@ -23,7 +23,7 @@ import gzip
 import sys
 import zlib
 
-from six import StringIO
+from six import BytesIO
 
 from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import array_ops
@@ -39,8 +39,8 @@ class DecodeCompressedOpTest(test.TestCase):
     elif compression_type == "ZLIB":
       return zlib.compress(bytes)
     else:
-      out = StringIO()
-      with gzip.GzipFile(fileobj=out, mode="w") as f:
+      out = BytesIO()
+      with gzip.GzipFile(fileobj=out, mode="wb") as f:
         f.write(bytes)
       return out.getvalue()
 
@@ -53,9 +53,9 @@ class DecodeCompressedOpTest(test.TestCase):
         self.assertEqual([2], decompressed.get_shape().as_list())
 
         result = decompressed.eval(
-            feed_dict={in_bytes: [self._compress("AaAA", compression_type),
-                                  self._compress("bBbb", compression_type)]})
-        self.assertAllEqual(["AaAA", "bBbb"], result)
+            feed_dict={in_bytes: [self._compress(b"AaAA", compression_type),
+                                  self._compress(b"bBbb", compression_type)]})
+        self.assertAllEqual([b"AaAA", b"bBbb"], result)
 
   def testDecompressWithRaw(self):
     for compression_type in ["ZLIB", "GZIP", ""]:
@@ -66,7 +66,7 @@ class DecodeCompressedOpTest(test.TestCase):
         decode = parsing_ops.decode_raw(decompressed, out_type=dtypes.int16)
 
         result = decode.eval(
-            feed_dict={in_bytes: [self._compress("AaBC", compression_type)]})
+            feed_dict={in_bytes: [self._compress(b"AaBC", compression_type)]})
         self.assertAllEqual(
             [[ord("A") + ord("a") * 256, ord("B") + ord("C") * 256]], result)
 


### PR DESCRIPTION
This fix tries to address the issue raised in #14887 to add decode_compressed support.

The API will take a string Tensor (compressed with either ZLIB or GZIP) and output a string Tensor of the same shape with content uncompressed.

This fix fixes #14887.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>