### PR TITLE
summary_image_op_test_fixed_on_ppc64le

### DIFF
--- a/tensorflow/python/kernel_tests/summary_image_op_test.py
+++ b/tensorflow/python/kernel_tests/summary_image_op_test.py
@@ -50,7 +50,6 @@ class SummaryImageOpTest(test.TestCase):
     self.assertProtoEquals(expected, image_summ)
 
   def testImageSummary(self):
-    np.random.seed(7)
     for depth in (1, 3, 4):
       for positive in False, True:
         with self.test_session(graph=ops.Graph()) as sess:


### PR DESCRIPTION
Hi @gunan , 
As we discussed here https://github.com/tensorflow/tensorflow/issues/12325 , I have created this PR to fix summary_image_op_test on ppc64le.

Thanks!