### PR TITLE
Go: Don't require -std=c99 for the cgo code.

### DIFF
--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -28,7 +28,8 @@ package tensorflow
 //                                 int num_shapes) {
 //  const int64_t** dims =
 //    (const int64_t**)malloc(sizeof(const int64_t*) * num_shapes);
-//  for (int i = 0; i < num_shapes; i++) {
+//  int i = 0;
+//  for (i = 0; i < num_shapes; i++) {
 //    dims[i] = flat_dims;
 //    if (num_dims[i] > 0) {
 //      // flat_dims will be NULL iff num_shapes is 0 or all elements in num_dims are <= 0.


### PR DESCRIPTION
This should fix the error:
github.com/tensorflow/tensorflow/tensorflow/go/graph.go:31:3: error:
'for' loop initial declarations are only allowed in C99 mode
 //  for (int i = 0; i < num_shapes; i++) {
    ^

in some continuous builds like:
https://ci.tensorflow.org/job/tensorflow-master-cpu/3297/consoleFull

Alternative to #15169