### PR TITLE
Add un-fed placeholder warning to negative-dimension error

### DIFF
--- a/tensorflow/core/framework/tensor_shape_test.cc
+++ b/tensorflow/core/framework/tensor_shape_test.cc
@@ -359,7 +359,8 @@ Status TensorShapeOld::IsValidShape(const TensorShapeProto& proto) {
   for (const auto& d : proto.dim()) {
     if (d.size() < 0) {
       return errors::InvalidArgument("Shape ", DebugString(proto),
-                                     " has negative dimensions");
+                                     " has negative dimensions; ",
+                                     "perhaps an uninitialized placeholder?");
     }
     num_elements *= d.size();
     if (num_elements > kMaxElements) {

--- a/tensorflow/core/framework/tensor_shape_test.cc
+++ b/tensorflow/core/framework/tensor_shape_test.cc
@@ -360,7 +360,7 @@ Status TensorShapeOld::IsValidShape(const TensorShapeProto& proto) {
     if (d.size() < 0) {
       return errors::InvalidArgument("Shape ", DebugString(proto),
                                      " has negative dimensions; ",
-                                     "perhaps an uninitialized placeholder?");
+                                     "perhaps an un-fed placeholder?");
     }
     num_elements *= d.size();
     if (num_elements > kMaxElements) {


### PR DESCRIPTION
Sometimes a user runs a tensor and forgets to initialize one of its placeholders in `feed_dict`. If that placeholder has a shape that includes `None`, the `None` gets converted to -1 and rejected at the C++ level, resulting in [confusing](https://stackoverflow.com/q/45059428/1979005) [error](https://stackoverflow.com/a/45480003/1979005) [messages](https://stackoverflow.com/q/44706840/1979005) (each word a separate link). This problem also appears in #11371.

This PR is a two-line change that briefly mentions this issue in the exception string. The hope is that it will help developers find the problem more quickly.