### PR TITLE
Remove extra param of concatenation in nnapi/NeuralNetworksShim.h

### DIFF
--- a/tensorflow/contrib/lite/nnapi/NeuralNetworksShim.h
+++ b/tensorflow/contrib/lite/nnapi/NeuralNetworksShim.h
@@ -196,9 +196,7 @@ enum {
    *
    * Inputs:
    * 0 ~ n: The list on n input tensors, of shape [D0, D1, ..., Daxis(i), ...,
-   * Dm] n+1: An INT32 value, specifying the concatenation axis. n+2: An INT32
-   * value, and has to be one of the {@link FuseCode} values. Specifies the
-   * activation to invoke on the result of each addition.
+   * Dm] n+1: An INT32 value, specifying the concatenation axis.
    *
    * Outputs:
    * * 0: The output, a tensor of the same type as the input tensors.


### PR DESCRIPTION
The param specifying activation is not documented in [this](https://developer.android.com/ndk/reference/group___neural_networks.html#ggaabbe492c60331b13038e39d4207940e0a44cbea825c4b224dd3ea757e9b1f65ed). It is actually needed in 8.1 Preview MR1, but not needed anymore in MR2.