### PR TITLE
Add TensorFlow support for tf.repeat (equivalent to np.repeat)

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -602,6 +602,7 @@ cc_library(
         ":pack_op",
         ":pad_op",
         ":quantize_and_dequantize_op",
+        ":repeat_op",
         ":reshape_op",
         ":reverse_op",
         ":reverse_sequence_op",
@@ -848,6 +849,12 @@ tf_kernel_library(
         "//third_party/mkl:intel_binary_blob",
         "@mkl_dnn//:mkl_dnn",
     ]),
+)
+
+tf_kernel_library(
+    name = "repeat_op",
+    prefix = "repeat_op",
+    deps = ARRAY_DEPS,
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/repeat_op.cc
+++ b/tensorflow/core/kernels/repeat_op.cc
@@ -25,7 +25,7 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 
-template <typename>
+template <typename T>
 class RepeatOp : public OpKernel {
  public:
   explicit RepeatOp(OpKernelConstruction* ctx)
@@ -80,7 +80,7 @@ class RepeatOp : public OpKernel {
           sizes[2] *= output_shape.dim_size(i);
         }
       }
-      auto input = input_tensor.shaped<int32, 3>(sizes);
+      auto input = input_tensor.shaped<T, 3>(sizes);
 
       if (repeats_flat.size() == 1) {
         output_shape.set_dim(
@@ -94,7 +94,7 @@ class RepeatOp : public OpKernel {
 
       OP_REQUIRES_OK(ctx,
                      ctx->allocate_output(0, output_shape, &output_tensor));
-      auto output = output_tensor->shaped<int32, 3>(sizes);
+      auto output = output_tensor->shaped<T, 3>(sizes);
 
       int offset = 0;
       for (int64 i = 0; i < input.dimension(1); i++) {
@@ -107,7 +107,7 @@ class RepeatOp : public OpKernel {
       }
     } else {
       // If axis is not present, treat input as flat
-      auto input_flat = input_tensor.flat<int32>();
+      auto input_flat = input_tensor.flat<T>();
 
       OP_REQUIRES(
           ctx,
@@ -127,7 +127,7 @@ class RepeatOp : public OpKernel {
         Eigen::array<int64, 2> bcast({1, repeats_flat(0)});
         Eigen::array<int64, 2> output_reshape(
             {input_tensor.NumElements() * repeats_flat(0), 1});
-        auto output_vec = output_tensor->vec<int32>();
+        auto output_vec = output_tensor->vec<T>();
         output_vec = input_flat.reshape(input_reshape)
                          .broadcast(bcast)
                          .reshape(output_reshape);
@@ -137,7 +137,7 @@ class RepeatOp : public OpKernel {
         OP_REQUIRES_OK(ctx,
                        ctx->allocate_output(0, TensorShape({output_size()}),
                                             &output_tensor));
-        auto output_vec = output_tensor->vec<int32>();
+        auto output_vec = output_tensor->vec<T>();
         int64 offset = 0;
         for (int64 i = 0; i < repeats_flat.size(); i++) {
           output_vec
@@ -163,7 +163,7 @@ class RepeatOp : public OpKernel {
       Name("RepeatFlat").Device(DEVICE_CPU).TypeConstraint<type>("T"), \
       RepeatOp<type>);
 
-TF_CALL_int32(REGISTER_KERNEL);
+TF_CALL_ALL_TYPES(REGISTER_KERNEL);
 #undef REGISTER_KERNEL
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/repeat_op.cc
+++ b/tensorflow/core/kernels/repeat_op.cc
@@ -1,0 +1,169 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+template <typename>
+class RepeatOp : public OpKernel {
+ public:
+  explicit RepeatOp(OpKernelConstruction* ctx)
+      : OpKernel(ctx), has_axis_(false), axis_(0) {
+    if (ctx->GetAttr("axis", &axis_).ok()) {
+      has_axis_ = true;
+    }
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& input_tensor = ctx->input(0);
+
+    const Tensor& repeats_tensor = ctx->input(1);
+
+    // repeats is either 0-D or 1-D
+    OP_REQUIRES(
+        ctx,
+        TensorShapeUtils::IsScalar(repeats_tensor.shape()) ||
+            TensorShapeUtils::IsVector(repeats_tensor.shape()),
+        errors::InvalidArgument("repeats must be a 0-D or 1-D, but got: ",
+                                repeats_tensor.shape().DebugString()));
+    auto repeats_flat = repeats_tensor.flat<int32>();
+
+    Tensor* output_tensor = nullptr;
+    if (has_axis_) {
+      TensorShape output_shape(input_tensor.shape());
+      if (TensorShapeUtils::IsScalar(input_tensor.shape())) {
+        // If Scalar, then treat as [1]
+        output_shape.AddDim(1);
+      }
+      OP_REQUIRES(ctx, (axis_ < output_shape.dims()),
+                  errors::InvalidArgument(
+                      "axis must be < ", output_shape.dims(), ", got ", axis_));
+
+      OP_REQUIRES(
+          ctx,
+          (repeats_flat.size() == 1 ||
+           repeats_flat.size() == output_shape.dim_size(axis_)),
+          errors::InvalidArgument(
+              "repeats must have the same size as input, or 1, but got input ",
+              output_shape.dim_size(axis_), ", repeats ", repeats_flat.size()));
+
+      // reshape input so that axis is in the middle
+      std::vector<int64> sizes{1, output_shape.dim_size(axis_), 1};
+      if (axis_ > 0) {
+        for (int64 i = 0; i < axis_; i++) {
+          sizes[0] *= output_shape.dim_size(i);
+        }
+      }
+      if (axis_ + 1 < output_shape.dims()) {
+        for (int64 i = axis_ + 1; i < output_shape.dims(); i++) {
+          sizes[2] *= output_shape.dim_size(i);
+        }
+      }
+      auto input = input_tensor.shaped<int32, 3>(sizes);
+
+      if (repeats_flat.size() == 1) {
+        output_shape.set_dim(
+            axis_, input_tensor.shape().dim_size(axis_) * repeats_flat(0));
+      } else {
+        Eigen::Tensor<int32, 0, Eigen::RowMajor> output_size =
+            repeats_flat.sum();
+        output_shape.set_dim(axis_, output_size());
+      }
+      sizes[1] = output_shape.dim_size(axis_);
+
+      OP_REQUIRES_OK(ctx,
+                     ctx->allocate_output(0, output_shape, &output_tensor));
+      auto output = output_tensor->shaped<int32, 3>(sizes);
+
+      int offset = 0;
+      for (int64 i = 0; i < input.dimension(1); i++) {
+        int64 repeats_value =
+            repeats_flat.size() == 1 ? repeats_flat(0) : repeats_flat(i);
+        for (int64 r = 0; r < repeats_value; r++) {
+          output.chip(offset + r, 1) = input.chip(i, 1);
+        }
+        offset += repeats_flat(i);
+      }
+    } else {
+      // If axis is not present, treat input as flat
+      auto input_flat = input_tensor.flat<int32>();
+
+      OP_REQUIRES(
+          ctx,
+          (repeats_flat.size() == 1 ||
+           repeats_flat.size() == input_flat.size()),
+          errors::InvalidArgument(
+              "repeats must have the same size as input, or 1, but got input ",
+              input_flat.size(), ", repeats ", repeats_flat.size()));
+      if (repeats_flat.size() == 1) {
+        // If repeats only have one element, do a broadast
+        OP_REQUIRES_OK(
+            ctx,
+            ctx->allocate_output(
+                0, TensorShape({input_tensor.NumElements() * repeats_flat(0)}),
+                &output_tensor));
+        Eigen::array<int64, 2> input_reshape({input_tensor.NumElements(), 1});
+        Eigen::array<int64, 2> bcast({1, repeats_flat(0)});
+        Eigen::array<int64, 2> output_reshape(
+            {input_tensor.NumElements() * repeats_flat(0), 1});
+        auto output_vec = output_tensor->vec<int32>();
+        output_vec = input_flat.reshape(input_reshape)
+                         .broadcast(bcast)
+                         .reshape(output_reshape);
+      } else {
+        Eigen::Tensor<int32, 0, Eigen::RowMajor> output_size =
+            repeats_flat.sum();
+        OP_REQUIRES_OK(ctx,
+                       ctx->allocate_output(0, TensorShape({output_size()}),
+                                            &output_tensor));
+        auto output_vec = output_tensor->vec<int32>();
+        int64 offset = 0;
+        for (int64 i = 0; i < repeats_flat.size(); i++) {
+          output_vec
+              .slice(Eigen::array<int64, 1>({offset}),
+                     Eigen::array<int64, 1>({repeats_flat(i)}))
+              .setConstant(input_flat(i));
+          offset += repeats_flat(i);
+        }
+      }
+    }
+  }
+
+ private:
+  bool has_axis_;
+  int axis_;
+};
+
+#define REGISTER_KERNEL(type)                                          \
+  REGISTER_KERNEL_BUILDER(                                             \
+      Name("Repeat").Device(DEVICE_CPU).TypeConstraint<type>("T"),     \
+      RepeatOp<type>);                                                 \
+  REGISTER_KERNEL_BUILDER(                                             \
+      Name("RepeatFlat").Device(DEVICE_CPU).TypeConstraint<type>("T"), \
+      RepeatOp<type>);
+
+TF_CALL_int32(REGISTER_KERNEL);
+#undef REGISTER_KERNEL
+
+}  // namespace tensorflow

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -662,6 +662,39 @@ output: Tensors whose shape matches that of `value`
   `size_splits[i]`.
 )doc");
 
+REGISTER_OP("RepeatFlat")
+    .Input("input: T")
+    .Input("repeats: int32")
+    .Output("output: T")
+    .Attr("T: type")
+    .SetShapeFn([](InferenceContext* c) { return Status::OK(); })
+    .Doc(R"doc(
+Repeat elements of an array
+
+input: A Tensor.
+repeats: An 1-D `int` Tensor. The number of repetitions for each element.
+  repeats is broadcasted to fit the shape of the given axis
+output: A Tensor which has the same shape as a, except along the given axis.
+)doc");
+
+REGISTER_OP("Repeat")
+    .Input("input: T")
+    .Input("repeats: int32")
+    .Output("output: T")
+    .Attr("axis: int")
+    .Attr("T: type")
+    .SetShapeFn([](InferenceContext* c) { return Status::OK(); })
+    .Doc(R"doc(
+Repeat elements of an array
+
+input: A Tensor.
+repeats: An 1-D `int` Tensor. The number of repetitions for each element.
+  repeats is broadcasted to fit the shape of the given axis
+axis: An int. The axis along which to repeat values. By default, use the
+  flattened input array, and return a flat output array.
+output: A Tensor which has the same shape as a, except along the given axis.
+)doc");
+
 // --------------------------------------------------------------------------
 REGISTER_OP("Const")
     .Output("output: dtype")

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -1091,6 +1091,41 @@ class InvertPermutationTest(test_util.TensorFlowTestCase):
         self.assertAllEqual(y.get_shape(), [5])
         self.assertAllEqual(y.eval(), [2, 4, 3, 0, 1])
 
+class RepeatTest(test_util.TensorFlowTestCase):
+
+  def testRepeatScalar(self):
+    with self.test_session():
+      v_tf = array_ops.repeat(constant_op.constant(3), 4)
+      v_np = np.repeat(3, 4)
+      self.assertAllEqual(v_tf.eval(), v_np)
+
+  def testRepeatMatrix(self):
+    with self.test_session():
+      x = np.array([[1, 2], [3, 4]], dtype=np.int32)
+      v_tf = array_ops.repeat(constant_op.constant(x), 2)
+      v_np = np.repeat(x, 2)
+      self.assertAllEqual(v_tf.eval(), v_np)
+
+  def testRepeatMatrixAxis0(self):
+    with self.test_session():
+      x = np.array([[1, 2], [3, 4]], dtype=np.int32)
+      v_tf = array_ops.repeat(constant_op.constant(x), constant_op.constant([1, 2]), axis=0)
+      v_np = np.repeat(x, [1, 2], axis=0)
+      self.assertAllEqual(v_tf.eval(), v_np)
+
+  def testRepeatMatrixAxis1(self):
+    with self.test_session():
+      x = np.array([[1, 2], [3, 4]], dtype=np.int32)
+      v_tf = array_ops.repeat(constant_op.constant(x), constant_op.constant(3), axis=1)
+      v_np = np.repeat(x, 3, axis=1)
+      self.assertAllEqual(v_tf.eval(), v_np)
+
+  def testRepeatMatrixRepeatArray(self):
+    with self.test_session():
+      x = np.array([[1, 2], [3, 4]], dtype=np.int32)
+      v_tf = array_ops.repeat(constant_op.constant(x), [1, 2, 3, 4])
+      v_np = np.repeat(x, [1, 2, 3, 4])
+      self.assertAllEqual(v_tf.eval(), v_np)
 
 class GuaranteeConstOpTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -1127,6 +1127,15 @@ class RepeatTest(test_util.TensorFlowTestCase):
       v_np = np.repeat(x, [1, 2, 3, 4])
       self.assertAllEqual(v_tf.eval(), v_np)
 
+  def testRepeatDTypes(self):
+    for dtype in [np.int8, np.int16, np.uint8, np.uint16, np.int32, np.int64]:
+      with self.test_session():
+        x = np.array([[1, 2], [3, 4]], dtype=dtype)
+        v_tf = array_ops.repeat(constant_op.constant(x), 2)
+        v_np = np.repeat(x, 2)
+        self.assertAllEqual(v_tf.eval(), v_np)
+
+
 class GuaranteeConstOpTest(test_util.TensorFlowTestCase):
 
   def testSimple(self):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -44,6 +44,7 @@ See the @{$python/array_ops} guide.
 @@stack
 @@parallel_stack
 @@unstack
+@@repeat
 @@reverse_sequence
 @@reverse
 @@reverse_v2
@@ -2634,3 +2635,17 @@ def quantize(input,  # pylint: disable=redefined-builtin
 
 
 quantize.__doc__ = gen_array_ops.quantize_v2.__doc__
+
+def repeat(input, repeats, axis=None, name=None):
+  if axis is None:
+    return gen_array_ops._repeat_flat(
+        input=input,
+        repeats=repeats,
+        name=name)
+  return gen_array_ops._repeat(
+      input=input,
+      repeats=repeats,
+      axis=axis,
+      name=name)
+
+repeat.__doc__ = gen_array_ops._repeat.__doc__

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2637,6 +2637,19 @@ def quantize(input,  # pylint: disable=redefined-builtin
 quantize.__doc__ = gen_array_ops.quantize_v2.__doc__
 
 def repeat(input, repeats, axis=None, name=None):
+  """Repeat elements of an array
+
+  Args:
+    input: A Tensor.
+    repeats: An 1-D `int` Tensor. The number of repetitions for each element.
+      repeats is broadcasted to fit the shape of the given axis
+    axis: An int. The axis along which to repeat values. By default, use the
+      flattened input array, and return a flat output array.
+    name: name of the op.
+
+  Returns:
+    A Tensor which has the same shape as a, except along the given axis.
+  """
   if axis is None:
     return gen_array_ops._repeat_flat(
         input=input,
@@ -2647,5 +2660,3 @@ def repeat(input, repeats, axis=None, name=None):
       repeats=repeats,
       axis=axis,
       name=name)
-
-repeat.__doc__ = gen_array_ops._repeat.__doc__

--- a/tensorflow/python/ops/hidden_ops.txt
+++ b/tensorflow/python/ops/hidden_ops.txt
@@ -20,6 +20,8 @@ PadV2
 ParallelConcat
 Placeholder
 RefIdentity
+Repeat
+RepeatFlat
 Reverse
 SpaceToBatch
 Split


### PR DESCRIPTION
This fix tries to address the feature request proposed in #8246 where there was no equivalent of numpy.repeat in TensorFlow.

This fix adds the support for tf.repeat that is equivalent to np.repeat.

NOTE: in order to allow optional `axis` parameter, this fix adds `Repeat` and `RepeatFlat`  ops where one takes `axis` and another does not take `axis`.

This fix fixes #8246.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>