### PR TITLE
Switched optimization mode for Pi builds to avoid internal compiler error

### DIFF
--- a/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
+++ b/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
@@ -82,6 +82,7 @@ if [[ $1 == "PI_ONE" ]]; then
 else
   PI_COPTS='--copt=-march=armv7-a --copt=-mfpu=neon-vfpv4
   --copt=-std=gnu11 --copt=-DS_IREAD=S_IRUSR --copt=-DS_IWRITE=S_IWUSR
+  --copt=-O3
   --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1
   --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2
   --copt=-U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8'


### PR DESCRIPTION
The nightly Pi3 builds have been failing with:

```
In file included from external/eigen_archive/unsupported/Eigen/MatrixFunctions:57:0,
                 from ./third_party/eigen3/unsupported/Eigen/MatrixFunctions:1,
                 from tensorflow/core/kernels/matrix_exponential_op.cc:19:
external/eigen_archive/unsupported/Eigen/src/MatrixFunctions/MatrixFunction.h: In member function 'MatrixType Eigen::internal::MatrixFunctionAtomic<MatrixType>::compute(const MatrixType&) [with MatrixType = Eigen::Matrix<std::complex<float>, -1, -1>]':
external/eigen_archive/unsupported/Eigen/src/MatrixFunctions/MatrixFunction.h:101:1: internal compiler error: in decompose_normal_address, at rtlanal.c:5799
 }
 ^
Please submit a full bug report,
with preprocessed source if appropriate.
See <http://gcc.gnu.org/bugs.html> for instructions.
```

It appears to be the same problem that Chrome hit with gcc here:

https://bugs.chromium.org/p/chromium/issues/detail?id=675648

Their solution was to change the optimization flags to avoid this, so I've followed their lead and switched to -O3. I hope this won'tl make a big latency or size difference, but it does solve the compiler crash at least.