### PR TITLE
include _solib_* in pip package

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -176,10 +176,15 @@ def find_files(pattern, root):
 
 
 matches = ['../' + x for x in find_files('*', 'external') if '.py' not in x]
-matches += ['../' + x for x in find_files('*', '_solib_k8') if '.py' not in x]
-matches += [
-    '../' + x for x in find_files('*', '_solib_local') if '.py' not in x
-]
+
+so_lib_paths = [i for i in os.listdir('.')
+                if os.path.isdir(i) 
+                and fnmatch.fnmatch(i, '_solib_*')]
+
+for path in so_lib_paths:
+  matches.extend(
+      ['../' + x for x in find_files('*', path) if '.py' not in x]
+  )
 
 if os.name == 'nt':
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.pyd'


### PR DESCRIPTION
See issue #15252 for detail, also should fixes issue #13711.
The problem is that when compile tensorflow with --config=mkl on virtual machines, mkl libraries won't be included because they locate under _solib_local, however, setup.py only includes _solib_k8.