### PR TITLE
[XLA] Allow components in the plugins directory to create devices

### DIFF
--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -7,6 +7,7 @@ package_group(
     packages = [
         "//tensorflow/compiler/aot/...",
         "//tensorflow/compiler/jit/...",
+        "//tensorflow/compiler/plugin/...",
         "//tensorflow/compiler/tests/...",
         "//tensorflow/compiler/tf2xla/...",
     ],


### PR DESCRIPTION
Due to a change in the visibility of sub-components of the XLA JIT, the Graphcore device was unable to use the target needed for creating devices.

This change adds the plugin directory to the set of directories allowed to use the JIT.



