### PR TITLE
Use base_dtype for self._dtype in tf.layers

### DIFF
--- a/tensorflow/python/layers/base.py
+++ b/tensorflow/python/layers/base.py
@@ -629,7 +629,7 @@ class Layer(object):
           self._assert_input_compatibility(inputs)
           if input_list and self._dtype is None:
             try:
-              self._dtype = input_list[0].dtype.name
+              self._dtype = input_list[0].dtype.base_dtype.name
             except AttributeError:
               pass
           input_shapes = nest.map_structure(lambda x: x.get_shape(), inputs)


### PR DESCRIPTION
This avoids mismatch dtype (ref vs no_ref) when using variables as inputs to a layer.
See #15262