### PR TITLE
Replace loop iteration with `chip`

### DIFF
--- a/tensorflow/core/kernels/unique_op.cc
+++ b/tensorflow/core/kernels/unique_op.cc
@@ -133,11 +133,7 @@ class UniqueOp : public OpKernel {
     auto Tout = output->shaped<T, 3>(new_sizes);
 
     for (auto it : uniq) {
-      for (int64 i = 0; i < Tin.dimension(0); i++) {
-        for (int64 j = 0; j < Tin.dimension(2); j++) {
-          Tout(i, it.second, j) = Tin(i, it.first, j);
-        }
-      }
+      Tout.chip(it.second, 1) = Tin.chip(it.first, 1);
     }
 
     if (num_outputs() > 2) {


### PR DESCRIPTION
In unique_op.cc, the ouput tensor was generated through loop iteration. It seems that this could be improved through Eigen's `chip`.

The fix addresses this improvement.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>