### PR TITLE
Fix #15297: bfloat16 is unsigned on Windows

### DIFF
--- a/tensorflow/core/framework/numeric_types.h
+++ b/tensorflow/core/framework/numeric_types.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "third_party/eigen3/unsupported/Eigen/CXX11/FixedPoint"
 // clang-format on
 
+#include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/types.h"
 
 namespace tensorflow {


### PR DESCRIPTION
#15297 

__BYTE_ORDER__ is not a builtin macro in VC++.  Need to include "tensorflow/core/platform/cpu_info.h" before using it. 