### PR TITLE
Removing unused variable "b" in EventsWriter from events_writer_test.py

### DIFF
--- a/tensorflow/python/client/events_writer_test.py
+++ b/tensorflow/python/client/events_writer_test.py
@@ -74,7 +74,7 @@ class PywrapeventsWriterTest(test_util.TensorFlowTestCase):
         return "Invalid"
 
     with self.assertRaisesRegexp(TypeError, "Invalid"):
-      pywrap_tensorflow.EventsWriter(b"foo").WriteEvent(_Invalid())
+      pywrap_tensorflow.EventsWriter("foo").WriteEvent(_Invalid())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There was no use of "b" I have found so far in codebase. However, "foo" was a proper tag.