### PR TITLE
Setting proper sonames on Linux

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -694,14 +694,6 @@ tf_cc_shared_object(
     framework_so = [],
     linkstatic = 1,
     visibility = ["//visibility:public"],
-    linkopts = select({
-        "//tensorflow:darwin": [],
-        "//tensorflow:windows": [],
-        "//tensorflow:windows_msvc": [],
-        "//conditions:default": [
-            "-Wl,-soname,libtensorflow_framework.so"
-        ]
-    }),
     deps = [
         "//tensorflow/core:framework_internal_impl",
         "//tensorflow/core:lib_internal_impl",
@@ -738,7 +730,6 @@ tf_cc_shared_object(
         "//conditions:default": [
             "-z defs",
             "-s",
-            "-Wl,-soname,libtensorflow_cc.so",
             "-Wl,--version-script",  #  This line must be directly followed by the version_script.lds file
             "//tensorflow/c:version_script.lds",
         ],

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -694,6 +694,14 @@ tf_cc_shared_object(
     framework_so = [],
     linkstatic = 1,
     visibility = ["//visibility:public"],
+    linkopts = select({
+        "//tensorflow:darwin": [],
+        "//tensorflow:windows": [],
+        "//tensorflow:windows_msvc": [],
+        "//conditions:default": [
+            "-Wl,-soname,libtensorflow_framework.so"
+        ]
+    }),
     deps = [
         "//tensorflow/core:framework_internal_impl",
         "//tensorflow/core:lib_internal_impl",
@@ -730,6 +738,7 @@ tf_cc_shared_object(
         "//conditions:default": [
             "-z defs",
             "-s",
+            "-Wl,-soname,libtensorflow_cc.so",
             "-Wl,--version-script",  #  This line must be directly followed by the version_script.lds file
             "//tensorflow/c:version_script.lds",
         ],

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -268,6 +268,7 @@ def tf_cc_shared_object(
               "-Wl,-install_name,@rpath/" + name.split("/")[-1],
           ],
           "//conditions:default": [
+              "-Wl,-soname," + name.split("/")[-1],
           ],
       }),
       **kwargs)


### PR DESCRIPTION
Setting proper soname prevents from linking with absolute path when using `cmake`.

The reference below contains long conversation about the issue with linking, but the general idea is when a library has no `DT_SONAME` field, executable is linked with absolute path and can't be used in a different environment, setting `LD_LIBRARY_PATH` doesn't help.

http://cmake.3232098.n2.nabble.com/How-to-avoid-the-explicit-library-location-when-linking-with-imported-library-targets-td5542269.html