### PR TITLE
[XLA/tfcompile] Various fixes for MSVC Part 1

### DIFF
--- a/tensorflow/compiler/aot/tests/make_test_graphs.py
+++ b/tensorflow/compiler/aot/tests/make_test_graphs.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
+import os
 import sys
 
 from tensorflow.core.protobuf import saver_pb2
@@ -53,7 +54,7 @@ def tfadd_with_ckpt(out_dir):
     sess.run(init_op)
     sess.run(y.assign(y + 42))
     # Without the checkpoint, the variable won't be set to 42.
-    ckpt = '%s/test_graph_tfadd_with_ckpt.ckpt' % out_dir
+    ckpt = os.path.join(out_dir, 'test_graph_tfadd_with_ckpt.ckpt')
     saver.save(sess, ckpt)
 
 
@@ -68,10 +69,10 @@ def tfadd_with_ckpt_saver(out_dir):
     sess.run(init_op)
     sess.run(y.assign(y + 42))
     # Without the checkpoint, the variable won't be set to 42.
-    ckpt_file = '%s/test_graph_tfadd_with_ckpt_saver.ckpt' % out_dir
+    ckpt_file = os.path.join(out_dir, 'test_graph_tfadd_with_ckpt_saver.ckpt')
     saver.save(sess, ckpt_file)
     # Without the SaverDef, the restore op won't be named correctly.
-    saver_file = '%s/test_graph_tfadd_with_ckpt_saver.saver' % out_dir
+    saver_file = os.path.join(out_dir, 'test_graph_tfadd_with_ckpt_saver.saver')
     with open(saver_file, 'wb') as f:
       f.write(saver.as_saver_def().SerializeToString())
 
@@ -129,7 +130,7 @@ def write_graph(build_graph, out_dir):
   g = ops.Graph()
   with g.as_default():
     build_graph(out_dir)
-    filename = '%s/test_graph_%s.pb' % (out_dir, build_graph.__name__)
+    filename = os.path.join(out_dir, 'test_graph_%s.pb' % build_graph.__name__)
     with open(filename, 'wb') as f:
       f.write(g.as_graph_def().SerializeToString())
 

--- a/tensorflow/compiler/xla/array.h
+++ b/tensorflow/compiler/xla/array.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <initializer_list>
 #include <iterator>
 #include <memory>
+#include <numeric>
 #include <random>
 #include <type_traits>
 #include <vector>

--- a/tensorflow/compiler/xla/service/cpu/external_constant_pool.cc
+++ b/tensorflow/compiler/xla/service/cpu/external_constant_pool.cc
@@ -33,13 +33,10 @@ void ExternalConstantPool::Insert(string name, const Literal& literal,
   CHECK(entries_.find(name) == entries_.end());
 
   int64 literal_size = ShapeUtil::ByteSizeOf(literal.shape());
-  void* raw_pointer;
-  CHECK_EQ(
-      posix_memalign(&raw_pointer, std::max<size_t>(alignment, sizeof(void*)),
-                     literal_size),
-      0)
-      << "failed to allocate " << literal_size << " bytes with alignment of "
-      << alignment;
+  void* raw_pointer = tensorflow::port::AlignedMalloc(
+      literal_size, std::max<size_t>(alignment, sizeof(void*)));
+  CHECK(raw_pointer != nullptr) << "failed to allocate " << literal_size
+                                << " bytes with alignment of " << alignment;
 
   std::memcpy(raw_pointer, literal.InternalData(), literal_size);
   entries_.emplace(std::move(name), static_cast<uint8*>(raw_pointer));

--- a/tensorflow/compiler/xla/service/cpu/external_constant_pool.h
+++ b/tensorflow/compiler/xla/service/cpu/external_constant_pool.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "tensorflow/compiler/xla/literal_util.h"
 #include "tensorflow/core/lib/gtl/flatmap.h"
+#include "tensorflow/core/platform/mem.h"
 
 namespace xla {
 namespace cpu {
@@ -52,7 +53,7 @@ class ExternalConstantPool {
   // We need to `free()` pointers allocated into `entries_` since we allocate
   // them with `posix_memalign`.
   struct FreeDeleter {
-    void operator()(void* ptr) { free(ptr); }
+    void operator()(void* ptr) { tensorflow::port::AlignedFree(ptr); }
   };
 
   tensorflow::gtl::FlatMap<string, std::unique_ptr<uint8, FreeDeleter>>

--- a/tensorflow/compiler/xla/service/cpu/llvm_ir_runtime.cc
+++ b/tensorflow/compiler/xla/service/cpu/llvm_ir_runtime.cc
@@ -64,14 +64,14 @@ llvm::Function* EmitVectorF32TanhIfNeeded(llvm::Module* module,
                             &ir_builder),
       llvm::ConstantFP::get(vector_type, 9.0), &ir_builder);
 
-  std::array<float, 7> numerator_coeffs(
-      {{-2.76076847742355e-16f, 2.00018790482477e-13f, -8.60467152213735e-11f,
+  std::array<float, 7> numerator_coeffs
+      {-2.76076847742355e-16f, 2.00018790482477e-13f, -8.60467152213735e-11f,
         5.12229709037114e-08f, 1.48572235717979e-05f, 6.37261928875436e-04f,
-        4.89352455891786e-03f}});
+        4.89352455891786e-03f};
 
-  std::array<float, 4> denominator_coeffs(
-      {{1.19825839466702e-06f, 1.18534705686654e-04f, 2.26843463243900e-03f,
-        4.89352518554385e-03f}});
+  std::array<float, 4> denominator_coeffs
+      {1.19825839466702e-06f, 1.18534705686654e-04f, 2.26843463243900e-03f,
+        4.89352518554385e-03f};
 
   llvm::Value* input_squared =
       ir_builder.CreateFMul(input_clamped, input_clamped);

--- a/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
+++ b/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/compiler/xla/service/cpu/simple_orc_jit.h"
 
-#include <dlfcn.h>
 #include <stdint.h>
 #include <algorithm>
 #include <list>
@@ -40,6 +39,19 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/cpu/runtime_single_threaded_matmul.h"
 #include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/core/platform/logging.h"
+
+#ifdef _MSC_VER
+extern "C" {
+void sincos(double x, double *sin, double *cos) {
+  *sin = std::sin(x);
+  *cos = std::cos(x);
+}
+void sincosf(float x, float *sin, float *cos) {
+  *sin = std::sinf(x);
+  *cos = std::cosf(x);
+}
+}
+#endif
 
 namespace xla {
 namespace cpu {

--- a/tensorflow/compiler/xla/service/heap_simulator.h
+++ b/tensorflow/compiler/xla/service/heap_simulator.h
@@ -264,7 +264,7 @@ class LazyBestFitHeap : public HeapAlgorithm {
   enum { kLazyAllocOffset = -1 };
 
   struct OrderChunkByIncreasingSize {
-    bool operator()(const Chunk& a, const Chunk& b) {
+    bool operator()(const Chunk& a, const Chunk& b) const {
       if (a.size != b.size) return a.size < b.size;
       return a.offset < b.offset;
     }

--- a/tensorflow/compiler/xla/status_macros.h
+++ b/tensorflow/compiler/xla/status_macros.h
@@ -196,6 +196,22 @@ class StatusAdaptorForMacros {
 #define TF_STATUS_MACROS_CONCAT_NAME(x, y) TF_STATUS_MACROS_CONCAT_IMPL(x, y)
 #define TF_STATUS_MACROS_CONCAT_IMPL(x, y) x##y
 
+#ifdef _MSC_VER
+
+#define TF_ASSIGN_OR_RETURN(lhs, rexpr)                                   \
+  TF_ASSIGN_OR_RETURN_IMPL(TF_STATUS_MACROS_CONCAT_NAME(_status_or_value, \
+                                                        __COUNTER__),     \
+                           lhs, rexpr)
+
+#define TF_ASSIGN_OR_RETURN_IMPL(statusor, lhs, rexpr) \
+  auto statusor = (rexpr);                             \
+  if (TF_PREDICT_FALSE(!statusor.ok())) {              \
+    return statusor.status();                          \
+  }                                                    \
+  lhs = std::move(statusor.ValueOrDie())
+
+#else
+
 #define TF_ASSIGN_OR_RETURN(...)                                             \
   TF_STATUS_MACRO_GET_VARIADIC_IMPL(__VA_ARGS__, TF_ASSIGN_OR_RETURN_IMPL_3, \
                                     TF_ASSIGN_OR_RETURN_IMPL_2)              \
@@ -216,5 +232,7 @@ class StatusAdaptorForMacros {
     return statusor.status();                          \
   }                                                    \
   lhs = std::move(statusor.ValueOrDie())
+
+#endif
 
 #endif  // TENSORFLOW_COMPILER_XLA_STATUS_MACROS_H_

--- a/tensorflow/compiler/xla/util.h
+++ b/tensorflow/compiler/xla/util.h
@@ -237,6 +237,7 @@ std::vector<T> Permute(tensorflow::gtl::ArraySlice<int64> permutation,
   return output;
 }
 
+#ifndef _MSC_VER
 // Override of the above that works around compile failures with gcc 7.1.1.
 // For details see https://github.com/tensorflow/tensorflow/issues/10843
 template <typename T>
@@ -244,6 +245,7 @@ std::vector<T> Permute(tensorflow::gtl::ArraySlice<int64> permutation,
                        const std::vector<T>& input) {
   return Permute<std::vector, T>(permutation, input);
 }
+#endif
 
 // Inverts a permutation, i.e., output_permutation[input_permutation[i]] = i.
 std::vector<int64> InversePermutation(

--- a/tensorflow/core/lib/gtl/compactptrset.h
+++ b/tensorflow/core/lib/gtl/compactptrset.h
@@ -19,6 +19,12 @@ limitations under the License.
 #include <type_traits>
 #include "tensorflow/core/lib/gtl/flatset.h"
 
+#ifdef _WIN64
+typedef __int64 ssize_t;
+#elif defined(_WIN32)
+typedef long ssize_t;
+#endif
+
 namespace tensorflow {
 namespace gtl {
 

--- a/tensorflow/core/platform/macros.h
+++ b/tensorflow/core/platform/macros.h
@@ -93,7 +93,8 @@ limitations under the License.
   ((sizeof(a) / sizeof(*(a))) / \
    static_cast<size_t>(!(sizeof(a) % sizeof(*(a)))))
 
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L || \
+    (defined(_MSC_VER) && _MSC_VER >= 1900)
 // Define this to 1 if the code is compiled in C++11 mode; leave it
 // undefined otherwise.  Do NOT define it to 0 -- that causes
 // '#ifdef LANG_CXX11' to behave differently from '#if LANG_CXX11'.


### PR DESCRIPTION
This is the initial work to solve #15213. More changes will come in other PRs.

- `tensorflow/compiler/aot/tests/make_test_graphs.py`: Use `os.path` for path manipulation.

- `tensorflow/compiler/xla/array.h`: Explicitly include `<numeric>` for `std::accumulate`.

- `tensorflow/compiler/xla/service/cpu/external_constant_pool.{cc,h}`: Use `tensorflow::port::Aligned{Malloc,Free}`.

- `tensorflow/compiler/xla/service/cpu/llvm_ir_runtime.cc`: Fix `std::array` initialization.

- `tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc`: Remove unused `<dlfcn.h>` and polyfill `sincos[f]` for MSVC.

- `tensorflow/compiler/xla/service/heap_simulator.h`: Add `const` to custom comparator.

- `tensorflow/compiler/xla/status_macros.h`: Use simplified version of `TF_ASSIGN_OR_RETURN` for MSVC. The simplified version also works for GCC as well actually.

- `tensorflow/compiler/xla/util.h`: Hide the workaround for GCC 7 from MSVC's eyes.

- `tensorflow/core/lib/gtl/compactptrset.h`: Define `ssize_t` for MSVC.

- `tensorflow/core/platform/macros.h`: Define `LANG_CXX11` for >= VS 2015. In MSVC, `__cplusplus == 199711` even when `/std:c++latest` is set because MSVC is still not "fully" C++11 compliant.