### PR TITLE
added crucial documentation on SELU activation

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_Selu.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Selu.pbtxt
@@ -4,10 +4,9 @@ op {
   description: <<END
 if < 0, `scale * features` otherwise.
 
-To be used together with:
-`initializer = layers.variance_scaling_initializer(factor=1.0, mode='FAN_IN')`
-and
-'tf.contrib.nn.alpha_dropout'
+To be used together with
+`initializer = tf.variance_scaling_initializer(factor=1.0, mode='FAN_IN')`.
+For correct dropout, use `tf.contrib.nn.alpha_dropout`.
 
 See [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
 END

--- a/tensorflow/core/api_def/base_api/api_def_Selu.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Selu.pbtxt
@@ -4,6 +4,11 @@ op {
   description: <<END
 if < 0, `scale * features` otherwise.
 
+To be used together with:
+`initializer = layers.variance_scaling_initializer(factor=1.0, mode='FAN_IN')`
+and
+'tf.contrib.nn.alpha_dropout'
+
 See [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
 END
 }

--- a/tensorflow/go/op/wrappers.go
+++ b/tensorflow/go/op/wrappers.go
@@ -18104,6 +18104,9 @@ func SparseFillEmptyRowsGrad(scope *Scope, reverse_index_map tf.Output, grad_val
 //
 // if < 0, `scale * features` otherwise.
 //
+// To be used together with initialization
+// `initializer = layers.variance_scaling_initializer(factor=1.0, mode='FAN_IN')`
+//
 // See [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
 func Selu(scope *Scope, features tf.Output) (activations tf.Output) {
 	if scope.Err() != nil {
@@ -24359,8 +24362,7 @@ type DecodeProtoV2Attr func(optionalAttr)
 // If not specified, defaults to "local://"
 func DecodeProtoV2DescriptorSource(value string) DecodeProtoV2Attr {
 	return func(m optionalAttr) {
-		m["descriptor_source"] = value
-	}
+		m["descriptor_source"] = value	}
 }
 
 // DecodeProtoV2MessageFormat sets the optional message_format attribute to value.

--- a/tensorflow/go/op/wrappers.go
+++ b/tensorflow/go/op/wrappers.go
@@ -18101,11 +18101,9 @@ func SparseFillEmptyRowsGrad(scope *Scope, reverse_index_map tf.Output, grad_val
 }
 
 // Computes scaled exponential linear: `scale * alpha * (exp(features) - 1)`
-//
 // if < 0, `scale * features` otherwise.
 //
-// To be used together with initialization
-// `initializer = layers.variance_scaling_initializer(factor=1.0, mode='FAN_IN')`
+// Assumes weights to have zero mean and variance 1.0 / fan_in.
 //
 // See [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
 func Selu(scope *Scope, features tf.Output) (activations tf.Output) {

--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -71,6 +71,8 @@ def selu(x):
       - To be used together with the initialization "lecun_normal".
       - To be used together with the dropout variant "AlphaDropout".
 
+  References:
+      - [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515)
   """
   alpha = 1.6732632423543772848170429916717
   scale = 1.0507009873554804934193349852946


### PR DESCRIPTION
Users extrememly frequently forget to use the correct initialization with SELUs. Added notes to documentation to use correct initialization wherever possible.