### PR TITLE
fix that remove_nodes drops input suffixes

### DIFF
--- a/tensorflow/tools/graph_transforms/remove_nodes.cc
+++ b/tensorflow/tools/graph_transforms/remove_nodes.cc
@@ -81,7 +81,17 @@ Status RemoveNodes(const GraphDef& input_graph_def,
                 return Status::OK();
               }
               const NodeDef& input_node = match.inputs[0].node;
-              inputs_to_rename[replace_node.name()] = input_node.name();
+              string target_name = input_node.name();
+              for (const string& input : replace_node.input()) {
+                if (!input.compare(0, target_name.size(), target_name)) {
+                  if (input.size() == target_name.size() ||
+                      input[target_name.size()] == ':') {
+                    target_name = input;
+                    break;
+                  }
+                }
+              }
+              inputs_to_rename[replace_node.name()] = target_name;
               inputs_to_rename["^" + replace_node.name()] =
                   "^" + input_node.name();
               new_nodes->push_back(input_node);


### PR DESCRIPTION
The transform `remove_nodes` didn't take input suffixes into consideration, and might make mistakes if the removed node used not `:0` but `:1`.

E.g.: For a node of `/a/Identity (Identity): [/a/Switch_1:1]`, the old code will make the pb file generate completely unexpected outputs.

The clang-format checking and tests (`//tensorflow/tools/graph_transforms/...`) have been passed.