### PR TITLE
Silence warning of graph_replace

### DIFF
--- a/tensorflow/contrib/graph_editor/tests/util_test.py
+++ b/tensorflow/contrib/graph_editor/tests/util_test.py
@@ -155,5 +155,6 @@ class UtilTest(test.TestCase):
     names = ge.util.get_predefined_collection_names()
     self.assertEqual(1, names.count('variables'))
 
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/contrib/graph_editor/tests/util_test.py
+++ b/tensorflow/contrib/graph_editor/tests/util_test.py
@@ -150,6 +150,10 @@ class UtilTest(test.TestCase):
       self.assertEqual(c0.op.inputs[0].op.name, "geph__a0_0")
       self.assertEqual(c0.op.inputs[1].op.name, "geph")
 
+  def test_get_predefined_collection_names(self):
+    """Test ge.util.get_predefined_collection_names"""
+    names = ge.util.get_predefined_collection_names()
+    self.assertEqual(1, names.count('variables'))
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/contrib/graph_editor/util.py
+++ b/tensorflow/contrib/graph_editor/util.py
@@ -485,9 +485,9 @@ _INTERNAL_VARIABLE_RE = re.compile(r"^__\w+__$")
 
 
 def get_predefined_collection_names():
-  """Return all the predefined collection names."""
+  """Return all the predefined collection names except the deprecated."""
   return [getattr(tf_ops.GraphKeys, key) for key in dir(tf_ops.GraphKeys)
-          if not _INTERNAL_VARIABLE_RE.match(key)]
+          if not _INTERNAL_VARIABLE_RE.match(key) and key != 'VARIABLES']
 
 
 def find_corresponding_elem(target, dst_graph, dst_scope="", src_scope=""):


### PR DESCRIPTION
This PR fixes #8661 
The warning is caused by access to deprecated graph key `VARIABLES`.

Update:
Because it is hard to distinguish the deprecated from other graph keys, this fix is somewhat ad-hoc and should be removed after graph key `VARIABLES` is removed.