### PR TITLE
Update C API test data comparison for s390x

### DIFF
--- a/tensorflow/c/c_api_function_test.cc
+++ b/tensorflow/c/c_api_function_test.cc
@@ -1462,7 +1462,7 @@ TEST_F(CApiFunctionTest, AppendHash) {
                  /*append_hash=*/true);
   tensorflow::FunctionDef fdef;
   ASSERT_TRUE(GetFunctionDef(func_, &fdef));
-#if ( __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ )
+#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
   ASSERT_EQ(string("func_name_base_ZpgUD4x8oqk"), fdef.signature().name());
 #else
   ASSERT_EQ(string("func_name_base_qaJ8jA8UmGY"), fdef.signature().name());

--- a/tensorflow/c/c_api_function_test.cc
+++ b/tensorflow/c/c_api_function_test.cc
@@ -1462,7 +1462,11 @@ TEST_F(CApiFunctionTest, AppendHash) {
                  /*append_hash=*/true);
   tensorflow::FunctionDef fdef;
   ASSERT_TRUE(GetFunctionDef(func_, &fdef));
+  #if ((__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) && defined(__s390x__))
+  ASSERT_EQ(string("func_name_base_ZpgUD4x8oqk"), fdef.signature().name());
+  #else
   ASSERT_EQ(string("func_name_base_qaJ8jA8UmGY"), fdef.signature().name());
+  #endif
 }
 
 TEST_F(CApiFunctionTest, GetOpDef) {

--- a/tensorflow/c/c_api_function_test.cc
+++ b/tensorflow/c/c_api_function_test.cc
@@ -1462,7 +1462,7 @@ TEST_F(CApiFunctionTest, AppendHash) {
                  /*append_hash=*/true);
   tensorflow::FunctionDef fdef;
   ASSERT_TRUE(GetFunctionDef(func_, &fdef));
-#if ((__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) && defined(__s390x__))
+#if ( __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ )
   ASSERT_EQ(string("func_name_base_ZpgUD4x8oqk"), fdef.signature().name());
 #else
   ASSERT_EQ(string("func_name_base_qaJ8jA8UmGY"), fdef.signature().name());

--- a/tensorflow/c/c_api_function_test.cc
+++ b/tensorflow/c/c_api_function_test.cc
@@ -1462,11 +1462,11 @@ TEST_F(CApiFunctionTest, AppendHash) {
                  /*append_hash=*/true);
   tensorflow::FunctionDef fdef;
   ASSERT_TRUE(GetFunctionDef(func_, &fdef));
-  #if ((__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) && defined(__s390x__))
+#if ((__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) && defined(__s390x__))
   ASSERT_EQ(string("func_name_base_ZpgUD4x8oqk"), fdef.signature().name());
-  #else
+#else
   ASSERT_EQ(string("func_name_base_qaJ8jA8UmGY"), fdef.signature().name());
-  #endif
+#endif
 }
 
 TEST_F(CApiFunctionTest, GetOpDef) {

--- a/tensorflow/python/framework/function_test.py
+++ b/tensorflow/python/framework/function_test.py
@@ -20,9 +20,9 @@ from __future__ import print_function
 
 import re
 import time
+import platform
 
 import numpy as np
-import platform
 
 from tensorflow.core.framework import function_pb2
 from tensorflow.core.protobuf import config_pb2

--- a/tensorflow/python/framework/function_test.py
+++ b/tensorflow/python/framework/function_test.py
@@ -22,6 +22,7 @@ import re
 import time
 
 import numpy as np
+import platform
 
 from tensorflow.core.framework import function_pb2
 from tensorflow.core.protobuf import config_pb2
@@ -765,8 +766,12 @@ class FunctionTest(test.TestCase):
     # We added more randomness to function names in C API.
     # TODO(iga): Remove this if statement when we switch to C API.
     if ops._USE_C_API:  # pylint: disable=protected-access
-      self.assertEqual("Foo_aCYSbwBkR5A",
-                       Foo.instantiate([dtypes.float32] * 3).name)
+      if platform.machine() == "s390x":
+        self.assertEqual("Foo_kEdkAG8SJvg",
+                         Foo.instantiate([dtypes.float32] * 3).name)
+      else:
+        self.assertEqual("Foo_aCYSbwBkR5A",
+                         Foo.instantiate([dtypes.float32] * 3).name)
     else:
       self.assertEqual("Foo_d643acf7",
                        Foo.instantiate([dtypes.float32] * 3).name)

--- a/tensorflow/python/framework/function_test.py
+++ b/tensorflow/python/framework/function_test.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 import re
 import time
-import platform
+import sys
 
 import numpy as np
 
@@ -766,7 +766,7 @@ class FunctionTest(test.TestCase):
     # We added more randomness to function names in C API.
     # TODO(iga): Remove this if statement when we switch to C API.
     if ops._USE_C_API:  # pylint: disable=protected-access
-      if platform.machine() == "s390x":
+      if sys.byteorder == 'big':
         self.assertEqual("Foo_kEdkAG8SJvg",
                          Foo.instantiate([dtypes.float32] * 3).name)
       else:


### PR DESCRIPTION
Base64 encode/decode is not endian-dependent. The hash passed to Base64 will generate different string on big-endian platform. Correcting the test data comparison for s390x architecture. 