### PR TITLE
Fix typo of tf.abs docstring

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -252,7 +252,7 @@ def abs(x, name=None):
   Returns:
     A `Tensor` or `SparseTensor` the same size and type as `x` with absolute
       values.
-    Note, for `complex64` or `complex128' input, the returned `Tensor` will be
+    Note, for `complex64` or `complex128` input, the returned `Tensor` will be
       of type `float32` or `float64`, respectively.
   """
   with ops.name_scope(name, "Abs", [x]) as name:


### PR DESCRIPTION
Change "'", which causes incorrect highlight, to "`"

And by the way, this is a typo I found when checking whether #9827 was resolved. The answer seems to be yes and we can close #9827 now.