### PR TITLE
Add complex64 and complex128 support for ApplyAdadelta kernel

### DIFF
--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -649,6 +649,8 @@ class ApplyAdadeltaOp : public OpKernel {
 TF_CALL_half(REGISTER_CPU_KERNELS);
 TF_CALL_float(REGISTER_CPU_KERNELS);
 TF_CALL_double(REGISTER_CPU_KERNELS);
+TF_CALL_complex64(REGISTER_CPU_KERNELS);
+TF_CALL_complex128(REGISTER_CPU_KERNELS);
 
 #if GOOGLE_CUDA
 // Forward declarations of the functor specializations for GPU.

--- a/tensorflow/python/training/adadelta_test.py
+++ b/tensorflow/python/training/adadelta_test.py
@@ -34,7 +34,8 @@ class AdadeltaOptimizerTest(test.TestCase):
 
   def doTestBasic(self, use_resource=False):
     num_updates = 4  # number of ADADELTA steps to perform
-    for dtype in [dtypes.half, dtypes.float32]:
+    for dtype in [dtypes.half, dtypes.float32, dtypes.float64,
+                  dtypes.complex64, dtypes.complex128]:
       for grad in [0.2, 0.1, 0.01]:
         for lr in [1.0, 0.5, 0.1]:
           with self.test_session():


### PR DESCRIPTION
This fix tries to address the issue raised in #13521 where the complex64 and complex128 support for ApplyAdadelta is missing. The test cases have also been updated.

This fix fixes #13521.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>