### PR TITLE
New rolling window batch operation for tf.data.Dataset #15044

### DIFF
--- a/tensorflow/contrib/data/__init__.py
+++ b/tensorflow/contrib/data/__init__.py
@@ -27,6 +27,7 @@ See the @{$datasets$Importing Data} Programmer's Guide for an overview.
 @@padded_batch_and_drop_remainder
 @@dense_to_sparse_batch
 @@enumerate_dataset
+@@rolling_window
 @@group_by_window
 @@ignore_errors
 @@make_saveable_from_iterator
@@ -54,6 +55,7 @@ from tensorflow.contrib.data.python.ops.counter import Counter
 from tensorflow.contrib.data.python.ops.dataset_ops import Dataset
 from tensorflow.contrib.data.python.ops.dataset_ops import get_single_element
 from tensorflow.contrib.data.python.ops.enumerate_ops import enumerate_dataset
+from tensorflow.contrib.data.python.ops.rolling_ops import rolling_window
 from tensorflow.contrib.data.python.ops.error_ops import ignore_errors
 from tensorflow.contrib.data.python.ops.grouping import group_by_window
 from tensorflow.contrib.data.python.ops.interleave_ops import parallel_interleave

--- a/tensorflow/contrib/data/python/kernel_tests/rolling_window_op_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/rolling_window_op_test.py
@@ -27,30 +27,30 @@ from tensorflow.contrib.data.python.ops import rolling_ops
 
 class RollingWindowTest(test.TestCase):
 
-    def test_rolling_window(self):
-        input_data = dataset_ops.Dataset.from_tensor_slices([
-            [[0], [1], [2], [3], [4], [5], [6], [7], [8]]])
-        rolled_data = input_data.apply(rolling_ops.rolling_window(window_size=3,
-                                                                  stride=2))
+  def test_rolling_window(self):
+    input_data = dataset_ops.Dataset.from_tensor_slices([
+        [[0], [1], [2], [3], [4], [5], [6], [7], [8]]])
+    rolled_data = input_data.apply(rolling_ops.rolling_window(window_size=3,
+                                                              stride=2))
 
-        self.assertEqual(rolled_data.output_shapes.as_list(), [None, 1])
-        iterator = rolled_data.make_initializable_iterator()
-        init_op = iterator.initializer
-        get_next = iterator.get_next()
+    self.assertEqual(rolled_data.output_shapes.as_list(), [None, 1])
+    iterator = rolled_data.make_initializable_iterator()
+    init_op = iterator.initializer
+    get_next = iterator.get_next()
 
-        with self.test_session() as sess:
-            sess.run(init_op)
-            for i in range(4):
-                result = sess.run(get_next)
-                self.assertAllEqual(np.array([[x] for x in range(i*2, i*2+3)]), result)
-            with self.assertRaises(errors.OutOfRangeError):
-                sess.run(get_next)
+    with self.test_session() as sess:
+      sess.run(init_op)
+      for i in range(4):
+        result = sess.run(get_next)
+        self.assertAllEqual(np.array([[x] for x in range(i*2, i*2+3)]), result)
+      with self.assertRaises(errors.OutOfRangeError):
+        sess.run(get_next)
 
-    def test_rolling_window_empty(self):
-        input_data = dataset_ops.Dataset.from_tensor_slices([[]])
-        rolled_data = input_data.apply(rolling_ops.rolling_window(window_size=7,
-                                                                  stride=1))
-        self.assertEqual(rolled_data.output_shapes.as_list(), [None,])
+  def test_rolling_window_empty(self):
+    input_data = dataset_ops.Dataset.from_tensor_slices([[]])
+    rolled_data = input_data.apply(rolling_ops.rolling_window(window_size=7,
+                                                              stride=1))
+    self.assertEqual(rolled_data.output_shapes.as_list(), [None,])
 
 if __name__ == "__main__":
-    test.main()
+  test.main()

--- a/tensorflow/contrib/data/python/kernel_tests/rolling_window_op_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/rolling_window_op_test.py
@@ -1,0 +1,63 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the experimental rolling_window ops."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import numpy as np
+
+from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.data.util import nest
+from tensorflow.python.framework import errors
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.platform import test
+from tensorflow.python.training import saver as saver_lib
+from tensorflow.contrib.data.python.ops import rolling_ops
+
+class RollingWindowTest(test.TestCase):
+
+    def test_rolling_window(self):
+        input_data = dataset_ops.Dataset.from_tensor_slices([
+            [[0], [1], [2], [3], [4], [5], [6],
+            [7], [8]]])
+        rolled_data = input_data.apply(rolling_ops.rolling_window(window_size=3,
+                                                                  stride=2))
+        self.assertEqual(rolled_data.output_shapes.as_list(), [None,1])
+
+        iterator = rolled_data.make_initializable_iterator()
+        init_op = iterator.initializer
+        get_next = iterator.get_next()
+
+        with self.test_session() as sess:
+            sess.run(init_op)
+            for i in range(4):
+                result = sess.run(get_next)
+                self.assertAllEqual(np.array([[x] for x in range(i*2,i*2+3)]),
+                                    result)
+        with self.assertRaises(errors.OutOfRangeError):
+            sess.run(get_next)
+
+    def test_rolling_window_empty(self):
+        input_data = dataset_ops.Dataset.from_tensor_slices([[]])
+        rolled_data = input_data.apply(rolling_ops.rolling_window(window_size=7,
+                                                                  stride=1))
+        self.assertEqual(rolled_data.output_shapes.as_list(), [None,])
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/contrib/data/python/kernel_tests/rolling_window_op_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/rolling_window_op_test.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import errors
-from tensorflow.python.framework import tensor_shape
 from tensorflow.python.platform import test
 from tensorflow.contrib.data.python.ops import rolling_ops
 
@@ -30,12 +29,11 @@ class RollingWindowTest(test.TestCase):
 
     def test_rolling_window(self):
         input_data = dataset_ops.Dataset.from_tensor_slices([
-            [[0], [1], [2], [3], [4], [5], [6],
-            [7], [8]]])
+            [[0], [1], [2], [3], [4], [5], [6], [7], [8]]])
         rolled_data = input_data.apply(rolling_ops.rolling_window(window_size=3,
                                                                   stride=2))
-        self.assertEqual(rolled_data.output_shapes.as_list(), [None,1])
 
+        self.assertEqual(rolled_data.output_shapes.as_list(), [None, 1])
         iterator = rolled_data.make_initializable_iterator()
         init_op = iterator.initializer
         get_next = iterator.get_next()
@@ -44,10 +42,9 @@ class RollingWindowTest(test.TestCase):
             sess.run(init_op)
             for i in range(4):
                 result = sess.run(get_next)
-                self.assertAllEqual(np.array([[x] for x in range(i*2,i*2+3)]),
-                                    result)
-        with self.assertRaises(errors.OutOfRangeError):
-            sess.run(get_next)
+                self.assertAllEqual(np.array([[x] for x in range(i*2, i*2+3)]), result)
+            with self.assertRaises(errors.OutOfRangeError):
+                sess.run(get_next)
 
     def test_rolling_window_empty(self):
         input_data = dataset_ops.Dataset.from_tensor_slices([[]])
@@ -56,4 +53,4 @@ class RollingWindowTest(test.TestCase):
         self.assertEqual(rolled_data.output_shapes.as_list(), [None,])
 
 if __name__ == "__main__":
-  test.main()
+    test.main()

--- a/tensorflow/contrib/data/python/kernel_tests/rolling_window_op_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/rolling_window_op_test.py
@@ -18,16 +18,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
 import numpy as np
 
 from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.data.util import nest
 from tensorflow.python.framework import errors
-from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.platform import test
-from tensorflow.python.training import saver as saver_lib
 from tensorflow.contrib.data.python.ops import rolling_ops
 
 class RollingWindowTest(test.TestCase):

--- a/tensorflow/contrib/data/python/ops/rolling_ops.py
+++ b/tensorflow/contrib/data/python/ops/rolling_ops.py
@@ -22,35 +22,36 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.ops.array_ops import shape
 
 def rolling_window(window_size=1, stride=1):
-   """A transformation that batches the given dataset using a rolling window.
+  """A transformation that batches the given dataset using a rolling window.
 
-   For example:
+  For example:
 
-   ```python
-   # NOTE: The following example uses `{ ... }` to represent the
-   # contents of a dataset.
-   a = { 1, 2, 3, 4, 5, 6, 7 }
+  ```python
+  # NOTE: The following example uses `{ ... }` to represent the
+  # contents of a dataset.
+  a = { 1, 2, 3, 4, 5, 6, 7 }
 
-   a.apply(tf.contrib.data.rolling_window(window_size=3, stride=2))
-     == { ( 1, 2, 3 ), ( 3, 4, 5 ), ( 5, 6, 7 ) }
-   ```
+  a.apply(tf.contrib.data.rolling_window(window_size=3, stride=2))
+    == { ( 1, 2, 3 ), ( 3, 4, 5 ), ( 5, 6, 7 ) }
+  ```
 
-   Args:
-     window_size: A `tf.int64` scalar `tf.Tensor`, representing the size
-       of the rolling window to be applied.
-     stride: A `tf.int64` scalar `tf.Tensor`, representing the number of
-       elements the window moves over each iteration.
+  Args:
+    window_size: A `tf.int64` scalar `tf.Tensor`, representing the size
+      of the rolling window to be applied.
+    stride: A `tf.int64` scalar `tf.Tensor`, representing the number of
+      elements the window moves over each iteration.
 
-   Returns:
-     A `Dataset` transformation function, which can be passed to
-     @{tf.data.Dataset.apply}.
-   """
+  Returns:
+    A `Dataset` transformation function, which can be passed to
+    @{tf.data.Dataset.apply}.
+  """
 
-    def get_slices(x):
-        num_slices = shape(x, out_type=dtypes.int64)[0] - window_size + 1
-        return dataset_ops.Dataset.range(0, num_slices,stride).map(lambda i: x[i:i + window_size])
+  def get_slices(x):
+    num_slices = shape(x, out_type=dtypes.int64)[0] - window_size + 1
+    slices = dataset_ops.Dataset.range(0, num_slices, stride)
+    return slices.map(lambda i: x[i:i + window_size])
 
-    def _apply_fn(dataset):
-        return dataset.flat_map(get_slices)
+  def _apply_fn(dataset):
+    return dataset.flat_map(get_slices)
 
-    return _apply_fn
+  return _apply_fn

--- a/tensorflow/contrib/data/python/ops/rolling_ops.py
+++ b/tensorflow/contrib/data/python/ops/rolling_ops.py
@@ -1,0 +1,52 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Enumerate dataset transformations."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.framework import dtypes
+
+def rolling_window(window_size, stride=1):
+   """A transformation that batches the given dataset using a rolling window.
+
+   For example:
+
+   ```python
+   # NOTE: The following example uses `{ ... }` to represent the
+   # contents of a dataset.
+   a = { 1, 2, 3, 4, 5, 6, 7 }
+
+   a.apply(tf.contrib.data.rolling_window(window_size=3, stride=2))
+     == { ( 1, 2, 3 ), ( 3, 4, 5 ), ( 5, 6, 7 ) }
+   ```
+
+   Args:
+     window_size: A `tf.int64` scalar `tf.Tensor`, representing the size
+       of the rolling window to be applied.
+     stride: A `tf.int64` scalar `tf.Tensor`, representing the number of
+       elements the window moves over each iteration
+
+   Returns:
+     A `Dataset` transformation function, which can be passed to
+     @{tf.data.Dataset.apply}.
+   """
+   def _apply_fn(dataset):
+       pass
+
+   return _apply_fn

--- a/tensorflow/contrib/data/python/ops/rolling_ops.py
+++ b/tensorflow/contrib/data/python/ops/rolling_ops.py
@@ -46,11 +46,11 @@ def rolling_window(window_size=1, stride=1):
      @{tf.data.Dataset.apply}.
    """
 
-   def get_slices(x):
-       num_slices = shape(x, out_type=dtypes.int64)[0] - window_size + 1
-       return dataset_ops.Dataset.range(0, num_slices,stride).map(lambda i: x[i:i + window_size])
+    def get_slices(x):
+        num_slices = shape(x, out_type=dtypes.int64)[0] - window_size + 1
+        return dataset_ops.Dataset.range(0, num_slices,stride).map(lambda i: x[i:i + window_size])
 
-   def _apply_fn(dataset):
-       return dataset.flat_map(get_slices)
+    def _apply_fn(dataset):
+        return dataset.flat_map(get_slices)
 
-   return _apply_fn
+    return _apply_fn

--- a/tensorflow/contrib/data/python/ops/rolling_ops.py
+++ b/tensorflow/contrib/data/python/ops/rolling_ops.py
@@ -12,17 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Enumerate dataset transformations."""
+"""Batch Data Using a Rolling Window"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
-
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import dtypes
+from tensorflow.python.ops.array_ops import shape
 
-def rolling_window(window_size, stride=1):
+def rolling_window(window_size=1, stride=1):
    """A transformation that batches the given dataset using a rolling window.
 
    For example:
@@ -40,13 +39,18 @@ def rolling_window(window_size, stride=1):
      window_size: A `tf.int64` scalar `tf.Tensor`, representing the size
        of the rolling window to be applied.
      stride: A `tf.int64` scalar `tf.Tensor`, representing the number of
-       elements the window moves over each iteration
+       elements the window moves over each iteration.
 
    Returns:
      A `Dataset` transformation function, which can be passed to
      @{tf.data.Dataset.apply}.
    """
+
+   def get_slices(x):
+       num_slices = shape(x, out_type=dtypes.int64)[0] - window_size + 1
+       return dataset_ops.Dataset.range(0, num_slices,stride).map(lambda i: x[i:i + window_size])
+
    def _apply_fn(dataset):
-       pass
+       return dataset.flat_map(get_slices)
 
    return _apply_fn


### PR DESCRIPTION
This is a new feature

For help pre-processing datasets, creates a transformation function that can be applied to a tf.data.Dataset Object to create a new Dataset by rolling a window across the initial Dataset to create the batches for the new Dataset.

*Fails if Dataset is too large to fit in memory (possible future work?)

