### PR TITLE
Add complex64 and complex128 support for `tf.angle` on GPU

### DIFF
--- a/tensorflow/core/kernels/cwise_op_arg.cc
+++ b/tensorflow/core/kernels/cwise_op_arg.cc
@@ -26,9 +26,7 @@ namespace tensorflow {
 REGISTER_COMPLEX(CPU, float, complex64);
 REGISTER_COMPLEX(CPU, double, complex128);
 
-// TODO: Enable GPU support for angle op after resolving
-// build failures on GPU (See #10643 for context).
-#if 0 && GOOGLE_CUDA
+#if GOOGLE_CUDA
 REGISTER_COMPLEX(GPU, float, complex64);
 REGISTER_COMPLEX(GPU, double, complex128);
 #endif

--- a/tensorflow/core/kernels/cwise_op_gpu_arg.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_arg.cu.cc
@@ -13,9 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// TODO: Enable GPU support for angle op after resolving
-// build failures on GPU (See #10643 for context).
-#if 0 && GOOGLE_CUDA
+#if GOOGLE_CUDA
 
 #include "tensorflow/core/kernels/cwise_ops_gpu_common.cu.h"
 

--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -51,23 +51,6 @@ struct scalar_arg_op<std::complex<double>> {
 };
 #endif
 
-// TODO(rmlarsen): Get rid of fmod2 once fmod is upstreamed to Eigen.
-template <typename T>
-struct scalar_fmod2_op {
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_fmod2_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& a,
-                                                           const T& b) const {
-    return std::fmod(a, b);
-  }
-};
-template <typename T>
-struct functor_traits<scalar_fmod2_op<T>> {
-  enum {
-    Cost = 13,  // Reciprocal throughput of FPREM on Haswell.
-    PacketAccess = false,
-  };
-};
-
 template <typename T>
 struct scalar_asinh_op {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_asinh_op)

--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -1023,8 +1023,8 @@ template <>
 struct scalar_get_angle_op<complex64> {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_get_angle_op)
   typedef typename Eigen::NumTraits<complex64>::Real result_type;
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const float
-  operator()(const complex64& a) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const float operator()(
+      const complex64& a) const {
     return ::atan2f(a.imag(), a.real());
   }
 };
@@ -1033,15 +1033,16 @@ template <>
 struct scalar_get_angle_op<complex128> {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_get_angle_op)
   typedef typename Eigen::NumTraits<complex128>::Real result_type;
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const double
-  operator()(const complex128& a) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const double operator()(
+      const complex128& a) const {
     return ::atan2(a.imag(), a.real());
   }
 };
 #endif
 
 template <typename T>
-struct get_angle : base<T, scalar_get_angle_op<T>, typename scalar_get_angle_op<T>::result_type> {};
+struct get_angle : base<T, scalar_get_angle_op<T>,
+                        typename scalar_get_angle_op<T>::result_type> {};
 
 template <typename T>
 struct conj : base<T, Eigen::internal::scalar_conjugate_op<T>> {};

--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -1008,9 +1008,40 @@ template <typename T>
 struct get_imag
     : base<T, Eigen::internal::scalar_imag_op<T>, typename T::value_type> {};
 
+template <typename Scalar>
+struct scalar_get_angle_op {
+  EIGEN_EMPTY_STRUCT_CTOR(scalar_get_angle_op)
+  typedef typename Eigen::NumTraits<Scalar>::Real result_type;
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type
+  operator()(const Scalar& a) const {
+    return Eigen::numext::arg(a);
+  }
+};
+
+#if GOOGLE_CUDA
+template <>
+struct scalar_get_angle_op<complex64> {
+  EIGEN_EMPTY_STRUCT_CTOR(scalar_get_angle_op)
+  typedef typename Eigen::NumTraits<complex64>::Real result_type;
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const float
+  operator()(const complex64& a) const {
+    return ::atan2f(a.imag(), a.real());
+  }
+};
+
+template <>
+struct scalar_get_angle_op<complex128> {
+  EIGEN_EMPTY_STRUCT_CTOR(scalar_get_angle_op)
+  typedef typename Eigen::NumTraits<complex128>::Real result_type;
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const double
+  operator()(const complex128& a) const {
+    return ::atan2(a.imag(), a.real());
+  }
+};
+#endif
+
 template <typename T>
-struct get_angle
-    : base<T, Eigen::internal::scalar_arg_op<T>, typename T::value_type> {};
+struct get_angle : base<T, scalar_get_angle_op<T>, typename scalar_get_angle_op<T>::result_type> {};
 
 template <typename T>
 struct conj : base<T, Eigen::internal::scalar_conjugate_op<T>> {};

--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -887,7 +887,7 @@ class ComplexMakeRealImagTest(test.TestCase):
       tf_angle = math_ops.angle(inx)
       tf_angle_val = self.evaluate(tf_angle)
 
-    self.assertAllEqual(np_angle, tf_angle_val)
+    self.assertAllClose(np_angle, tf_angle_val)
     self.assertShapeEqual(np_angle, tf_angle)
 
   def testAngle64(self):
@@ -895,18 +895,14 @@ class ComplexMakeRealImagTest(test.TestCase):
     imag = (np.arange(-3, 3) / 5.).reshape([1, 3, 2]).astype(np.float32)
     cplx = real + 1j * imag
     self._compareAngle(cplx, use_gpu=False)
-    # TODO: Enable GPU tests for angle op after resolving
-    # build failures on GPU (See #10643 for context).
-    # self._compareAngle(cplx, use_gpu=True)
+    self._compareAngle(cplx, use_gpu=True)
 
   def testAngle(self):
     real = (np.arange(-3, 3) / 4.).reshape([1, 3, 2]).astype(np.float64)
     imag = (np.arange(-3, 3) / 5.).reshape([1, 3, 2]).astype(np.float64)
     cplx = real + 1j * imag
     self._compareAngle(cplx, use_gpu=False)
-    # TODO: Enable GPU tests for angle op after resolving
-    # build failures on GPU (See #10643 for context).
-    # self._compareAngle(cplx, use_gpu=True)
+    self._compareAngle(cplx, use_gpu=True)
 
   @test_util.run_deprecated_v1
   def testRealReal(self):


### PR DESCRIPTION
In PR #10643, complex64 and complex128 support have been added for `tf.angle` on CPU. However, because of the compiling errors, the complex support on GPU is not enabled yet.

The issue was that, std::arg is not available on nvidia device for GPU. This fix changes to used atan2 instead, which is available in CUDA.

The relevant test cases have bee enabled.

This fix is related to #10643.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>