### PR TITLE
Add shape function SingleImageRandomDotStereograms

### DIFF
--- a/tensorflow/contrib/image/BUILD
+++ b/tensorflow/contrib/image/BUILD
@@ -233,6 +233,23 @@ py_library(
     ],
 )
 
+cuda_py_test(
+    name = "single_image_random_dot_stereograms_ops_test",
+    size = "medium",
+    srcs = ["python/kernel_tests/single_image_random_dot_stereograms_ops_test.py"],
+    additional_deps = [
+        ":distort_image_py",
+        ":image_py",
+        ":single_image_random_dot_stereograms_py",
+        "//third_party/py/numpy",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:framework_test_lib",
+        "//tensorflow/python:math_ops",
+        "//tensorflow/python:platform_test",
+    ],
+)
+
 filegroup(
     name = "all_files",
     srcs = glob(

--- a/tensorflow/contrib/image/ops/single_image_random_dot_stereograms_ops.cc
+++ b/tensorflow/contrib/image/ops/single_image_random_dot_stereograms_ops.cc
@@ -19,6 +19,10 @@ limitations under the License.
 
 namespace tensorflow {
 
+using shape_inference::DimensionHandle;
+using shape_inference::InferenceContext;
+using shape_inference::ShapeHandle;
+
 REGISTER_OP("SingleImageRandomDotStereograms")
     .Attr("T: {double,float,int64,int32}")
     .Input("depth_values: T")
@@ -37,6 +41,31 @@ REGISTER_OP("SingleImageRandomDotStereograms")
         "output_image_shape: shape = { dim {size:1024} dim {size: 768} dim "
         "{size: 1}}")
     .Attr("output_data_window: shape = { dim {size:1022} dim {size: 757}}")
+    .SetShapeFn([](InferenceContext* c) {
+      // Validate that the output_image_shape attr is correct.
+      // NOTE: The output_image_shape is [X, Y, C]
+      // while the output data is [Y, X, C] (or [H, W, C])
+      // so by default the output_image_shape has the value
+      // of [1024, 768, 1] but the output data will be [768, 1024, 1]
+      PartialTensorShape shape;
+      TF_RETURN_IF_ERROR(c->GetAttr("output_image_shape", &shape));
+      ShapeHandle output_image_shape;
+      TF_RETURN_IF_ERROR(
+          c->MakeShapeFromPartialTensorShape(shape, &output_image_shape));
+      DimensionHandle x_dim = c->Dim(output_image_shape, 0);
+      DimensionHandle y_dim = c->Dim(output_image_shape, 1);
+      DimensionHandle c_dim = c->Dim(output_image_shape, 2);
+
+      int colors;
+      TF_RETURN_IF_ERROR(c->GetAttr("number_colors", &colors));
+
+      std::vector<DimensionHandle> dims(3);
+      dims[0] = y_dim;
+      dims[1] = x_dim;
+      dims[2] = colors > 256 ? c->MakeDim(3) : c->MakeDim(1);
+      c->set_output(0, c->MakeShape(dims));
+      return Status::OK();
+    })
     .Doc(R"doc(
 Outputs a single image random dot stereogram for export via encode_PNG/JPG OP.
 

--- a/tensorflow/contrib/image/ops/single_image_random_dot_stereograms_ops.cc
+++ b/tensorflow/contrib/image/ops/single_image_random_dot_stereograms_ops.cc
@@ -44,9 +44,9 @@ REGISTER_OP("SingleImageRandomDotStereograms")
     .SetShapeFn([](InferenceContext* c) {
       // Validate that the output_image_shape attr is correct.
       // NOTE: The output_image_shape is [X, Y, C]
-      // while the output data is [Y, X, C] (or [H, W, C])
-      // so by default the output_image_shape has the value
-      // of [1024, 768, 1] but the output data will be [768, 1024, 1]
+      // while the output data is [Y, X, C] (or [H, W, C]).
+      // As a result, by default the output_image_shape has the value
+      // of [1024, 768, 1] but the output data will be [768, 1024, 1].
       PartialTensorShape shape;
       TF_RETURN_IF_ERROR(c->GetAttr("output_image_shape", &shape));
       ShapeHandle output_image_shape;
@@ -59,11 +59,7 @@ REGISTER_OP("SingleImageRandomDotStereograms")
       int colors;
       TF_RETURN_IF_ERROR(c->GetAttr("number_colors", &colors));
 
-      std::vector<DimensionHandle> dims(3);
-      dims[0] = y_dim;
-      dims[1] = x_dim;
-      dims[2] = colors > 256 ? c->MakeDim(3) : c->MakeDim(1);
-      c->set_output(0, c->MakeShape(dims));
+      c->set_output(0, c->MakeShape({y_dim, x_dim, colors > 256? c->MakeDim(3) : c->MakeDim(1)}));
       return Status::OK();
     })
     .Doc(R"doc(

--- a/tensorflow/contrib/image/python/kernel_tests/single_image_random_dot_stereograms_ops_test.py
+++ b/tensorflow/contrib/image/python/kernel_tests/single_image_random_dot_stereograms_ops_test.py
@@ -34,9 +34,9 @@ class SingleImageRandomDotStereogramsTest(test_util.TensorFlowTestCase):
   def test_shape_function_default(self):
     """
     NOTE: The output_image_shape is [X, Y, C]
-    while the output data is [Y, X, C] (or [H, W, C])
-    so by default the output_image_shape has the value
-    of [1024, 768, 1], but the output data will be [768, 1024, 1]
+    while the output data is [Y, X, C] (or [H, W, C]).
+    As a result, by default the output_image_shape has the value
+    of [1024, 768, 1], but the output data will be [768, 1024, 1].
     """
     x_np = [[1, 2, 3, 3, 2, 1],
             [1, 2, 3, 4, 5, 2],
@@ -44,7 +44,7 @@ class SingleImageRandomDotStereogramsTest(test_util.TensorFlowTestCase):
             [1, 2, 3, 4, 5, 4],
             [6, 5, 4, 4, 5, 5]]
     x_tf = constant_op.constant(x_np)
-    # By default [1024, 768, 1] => [768, 1024, 1]
+    # By default [1024, 768, 1] => [768, 1024, 1].
     sirds_1 = single_image_random_dot_stereograms(
         x_tf,
         convergence_dots_size=8,
@@ -56,7 +56,7 @@ class SingleImageRandomDotStereogramsTest(test_util.TensorFlowTestCase):
       r_tf_1 = sirds_1.eval()
       self.assertAllEqual(shape_1, r_tf_1.shape)
 
-    # If color > 256 then [1024, 768, 3] => [768, 1024, 3]
+    # If color > 256 then [1024, 768, 3] => [768, 1024, 3].
     sirds_2 = single_image_random_dot_stereograms(
         x_tf,
         convergence_dots_size=8,
@@ -69,7 +69,7 @@ class SingleImageRandomDotStereogramsTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(shape_2, r_tf_2.shape)
 
     # If explicitly set output_image_shape to [1200, 800, 1],
-    # then the output data should be [800, 1200, 1]
+    # then the output data should be [800, 1200, 1].
     sirds_3 = single_image_random_dot_stereograms(
         x_tf,
         convergence_dots_size=8,

--- a/tensorflow/contrib/image/python/kernel_tests/single_image_random_dot_stereograms_ops_test.py
+++ b/tensorflow/contrib/image/python/kernel_tests/single_image_random_dot_stereograms_ops_test.py
@@ -1,0 +1,87 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for python single_image_random_dot_stereograms_ops."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from six.moves import xrange  # pylint: disable=redefined-builtin
+
+from tensorflow.contrib.image.python.ops.single_image_random_dot_stereograms \
+    import single_image_random_dot_stereograms
+from tensorflow.python.client import session
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import test_util
+from tensorflow.python.platform import googletest
+
+class SingleImageRandomDotStereogramsTest(test_util.TensorFlowTestCase):
+
+  def test_shape_function_default(self):
+    """
+    NOTE: The output_image_shape is [X, Y, C]
+    while the output data is [Y, X, C] (or [H, W, C])
+    so by default the output_image_shape has the value
+    of [1024, 768, 1], but the output data will be [768, 1024, 1]
+    """
+    x_np = [[1, 2, 3, 3, 2, 1],
+            [1, 2, 3, 4, 5, 2],
+            [1, 2, 3, 4, 5, 3],
+            [1, 2, 3, 4, 5, 4],
+            [6, 5, 4, 4, 5, 5]]
+    x_tf = constant_op.constant(x_np)
+    # By default [1024, 768, 1] => [768, 1024, 1]
+    sirds_1 = single_image_random_dot_stereograms(
+        x_tf,
+        convergence_dots_size=8,
+        number_colors=256,
+        normalize=True)
+    shape_1 = sirds_1.get_shape().as_list()
+    self.assertEqual(shape_1, [768, 1024, 1])
+    with self.test_session():
+      r_tf_1 = sirds_1.eval()
+      self.assertAllEqual(shape_1, r_tf_1.shape)
+
+    # If color > 256 then [1024, 768, 3] => [768, 1024, 3]
+    sirds_2 = single_image_random_dot_stereograms(
+        x_tf,
+        convergence_dots_size=8,
+        number_colors=512,
+        normalize=True)
+    shape_2 = sirds_2.get_shape().as_list()
+    self.assertEqual(shape_2, [768, 1024, 3])
+    with self.test_session():
+      r_tf_2 = sirds_2.eval()
+      self.assertAllEqual(shape_2, r_tf_2.shape)
+
+    # If explicitly set output_image_shape to [1200, 800, 1],
+    # then the output data should be [800, 1200, 1]
+    sirds_3 = single_image_random_dot_stereograms(
+        x_tf,
+        convergence_dots_size=8,
+        number_colors=256,
+        normalize=True,
+        output_image_shape=[1200, 800, 1])
+    shape_3 = sirds_3.get_shape().as_list()
+    self.assertEqual(shape_3, [800, 1200, 1])
+    with self.test_session():
+      r_tf_3 = sirds_3.eval()
+      self.assertAllEqual(shape_3, r_tf_3.shape)
+
+
+if __name__ == '__main__':
+  googletest.main()


### PR DESCRIPTION
This fix tries to address the issue raised in #15429 where there is no shape function for SingleImageRandomDotStereograms.

This fix adds the shape function for `SingleImageRandomDotStereograms`.

NOTE: `SingleImageRandomDotStereograms` takes an attribute of `output_image_shape` which is in the format of `[X, Y, C]` (`[ImageX, ImageY, Channel]`. However, the actual
data output is in the format of `[ImageY, ImageX, Channel]` (`[h, w, c]`). So by default the output_image_shape has the value of [1024, 768, 1] but the output data will be [768, 1024, 1].
And if `[1200, 800, 1]` is used explicitly then the output data shape will be `[800, 1200, 1]`.

This fix does not change the behavior for now.

This fix fixes #15429.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>