### PR TITLE
New metric: Cohen's kappa

### DIFF
--- a/tensorflow/contrib/metrics/__init__.py
+++ b/tensorflow/contrib/metrics/__init__.py
@@ -66,6 +66,7 @@ See the @{$python/contrib.metrics} guide.
 @@set_intersection
 @@set_size
 @@set_union
+@@cohen_kappa
 @@count
 @@precision_recall_at_equal_thresholds
 @@recall_at_precision
@@ -82,6 +83,7 @@ from tensorflow.contrib.metrics.python.ops.confusion_matrix_ops import confusion
 from tensorflow.contrib.metrics.python.ops.histogram_ops import auc_using_histogram
 from tensorflow.contrib.metrics.python.ops.metric_ops import aggregate_metric_map
 from tensorflow.contrib.metrics.python.ops.metric_ops import aggregate_metrics
+from tensorflow.contrib.metrics.python.ops.metric_ops import cohen_kappa
 from tensorflow.contrib.metrics.python.ops.metric_ops import count
 from tensorflow.contrib.metrics.python.ops.metric_ops import precision_recall_at_equal_thresholds
 from tensorflow.contrib.metrics.python.ops.metric_ops import recall_at_precision

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3301,13 +3301,16 @@ def count(values,
 
 def cohen_kappa(labels, predictions, num_classes, weights=None,
                 metrics_collections=None, updates_collections=None, name=None):
-  """Calculates [Cohen's kappa](https://en.wikipedia.org/wiki/Cohen's_kappa)
-  which is a statistic that measures inter-annotator agreement.
+  """Calculates Cohen's kappa.
 
-  The `cohen_kappa` function creates three local variables: `total_po`,
-  `total_pe_row`, and `total_pe_col`, that are used to compute the
-  Cohen's kappa. This value is ultimately returned as `kappa`, an idempotent
-  operation that is calculate by
+  [Cohen's kappa](https://en.wikipedia.org/wiki/Cohen's_kappa) is a statistic
+  that measures inter-annotator agreement.
+
+  The `cohen_kappa` function calculates the confusion matrix, and creates three
+  local variables to compute the Cohen's kappa: `total_po`, `total_pe_row`, and
+  `total_pe_col` refer to the diagonal part, rows and columns totals of the
+  confusion matrix, respectively. This value is ultimately returned as `kappa`,
+  an idempotent operation that is calculated by
 
       pe = (pe_row * pe_col) / N
       k = (sum(po) - sum(pe)) / (N - sum(pe))
@@ -3326,8 +3329,10 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
   doesn't support weighted matrix yet.
 
   Args:
-    labels: 1-D `Tensor` of the ground truth values.
-    predictions: 1-D `Tensor` of the predicted values.
+    labels: 1-D `Tensor` of real labels for the classification task. Must be
+      one of the following types: int16, int32, int64.
+    predictions: 1-D `Tensor` of predictions for a given classification.
+      Must have the same type as `labels`.
     num_classes: The possible number of labels.
     weights: Optional `Tensor` whose shape matches `predictions`.
     metrics_collections: An optional list of collections that `kappa` should

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3299,7 +3299,7 @@ def count(values,
     return count_, update_op
 
 
-def cohen_kappa(labels, predictions, num_classes, weights=None,
+def cohen_kappa(labels, predictions_idx, num_classes, weights=None,
                 metrics_collections=None, updates_collections=None, name=None):
   """Calculates Cohen's kappa.
 
@@ -3331,8 +3331,8 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
   Args:
     labels: 1-D `Tensor` of real labels for the classification task. Must be
       one of the following types: int16, int32, int64.
-    predictions: 1-D `Tensor` of predictions for a given classification.
-      Must have the same type as `labels`.
+    predictions_idx: 1-D `Tensor` of predicted class indices for a given
+      classification. Must have the same type as `labels`.
     num_classes: The possible number of labels.
     weights: Optional `Tensor` whose shape matches `predictions`.
     metrics_collections: An optional list of collections that `kappa` should
@@ -3360,15 +3360,15 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
     raise ValueError('`num_classes` must be greater than 1.'
                      'Found: {}'.format(num_classes))
   with variable_scope.variable_scope(name, 'cohen_kappa',
-                                     (labels, predictions, weights)):
+                                     (labels, predictions_idx, weights)):
     # Convert 2-dim (num, 1) to 1-dim (num,)
     labels.get_shape().with_rank_at_most(2)
     if labels.get_shape().ndims == 2:
       labels = array_ops.squeeze(labels, axis=[-1])
     predictions_idx, labels, weights = (
         metrics_impl._remove_squeezable_dimensions(  # pylint: disable=protected-access
-            predictions=predictions, labels=labels, weights=weights))
-    predictions.get_shape().assert_is_compatible_with(labels.get_shape())
+            predictions=predictions_idx, labels=labels, weights=weights))
+    predictions_idx.get_shape().assert_is_compatible_with(labels.get_shape())
 
     stat_dtype = (dtypes.int64
                   if weights is None or weights.dtype.is_integer
@@ -3382,7 +3382,7 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
 
     # Table of the counts of agreement:
     counts_in_table = confusion_matrix.confusion_matrix(
-      labels, predictions,
+      labels, predictions_idx,
       num_classes=num_classes, weights=weights,
       dtype=stat_dtype, name="counts_in_table")
 

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3330,7 +3330,7 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
 
   Args:
     labels: 1-D `Tensor` of real labels for the classification task. Must be
-      one of the following types: int16, int32, int64, float32, float64.
+      one of the following types: int16, int32, int64.
     predictions: 1-D `Tensor` of predictions for a given classification.
       Must have the same type as `labels`.
     num_classes: The possible number of labels.

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3307,10 +3307,10 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
   that measures inter-annotator agreement.
 
   The `cohen_kappa` function calculates the confusion matrix, and creates three
-  local variables to compute the Cohen's kappa: `total_po`, `total_pe_row`, and
-  `total_pe_col` refer to the diagonal part, rows and columns totals of the
-  confusion matrix, respectively. This value is ultimately returned as `kappa`,
-  an idempotent operation that is calculated by
+  local variables to compute the Cohen's kappa: `po`, `pe_row`, and `pe_col`
+  refer to the diagonal part, rows and columns totals of the confusion matrix,
+  respectively. This value is ultimately returned as `kappa`, an idempotent
+  operation that is calculated by
 
       pe = (pe_row * pe_col) / N
       k = (sum(po) - sum(pe)) / (N - sum(pe))
@@ -3371,9 +3371,12 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
     stat_dtype = (dtypes.int64
                   if weights is None or weights.dtype.is_integer
                   else dtypes.float32)
-    total_po = metrics_impl.metric_variable((num_classes,), stat_dtype, name='total_po')
-    total_pe_row = metrics_impl.metric_variable((num_classes,), stat_dtype, name='total_pe_row')
-    total_pe_col = metrics_impl.metric_variable((num_classes,), stat_dtype, name='total_pe_col')
+    po = metrics_impl.metric_variable(
+        (num_classes,), stat_dtype, name='po')
+    pe_row = metrics_impl.metric_variable(
+        (num_classes,), stat_dtype, name='pe_row')
+    pe_col = metrics_impl.metric_variable(
+        (num_classes,), stat_dtype, name='pe_col')
 
     # Table of the counts of agreement:
     counts_in_table = confusion_matrix.confusion_matrix(
@@ -3402,7 +3405,7 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
           po_sum - pe_sum, total - pe_sum, name=name)
       return k
 
-    kappa = _calculate_k(total_po, total_pe_row, total_pe_col, name='value')
+    kappa = _calculate_k(po, pe_row, pe_col, name='value')
     update_op = _calculate_k(update_po, update_pe_row, update_pe_col, 'update_op')
 
     if metrics_collections:

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3363,8 +3363,9 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
                                      (labels, predictions, weights)):
     # Convert 2-dim (num, 1) to 1-dim (num,)
     labels.get_shape().with_rank_at_most(2)
-    labels = array_ops.squeeze(labels)
-    predictions, labels, weights = (
+    if labels.get_shape().ndims == 2:
+      labels = array_ops.squeeze(labels, axis=[-1])
+    predictions_idx, labels, weights = (
         metrics_impl._remove_squeezable_dimensions(  # pylint: disable=protected-access
             predictions=predictions, labels=labels, weights=weights))
     predictions.get_shape().assert_is_compatible_with(labels.get_shape())

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3357,7 +3357,7 @@ def cohen_kappa(labels, predictions_idx, num_classes, weights=None,
     raise RuntimeError('tf.contrib.metrics.cohen_kappa is not supported'
                        'when eager execution is enabled.')
   if num_classes < 2:
-    raise ValueError('`num_classes` must be greater than 1.'
+    raise ValueError('`num_classes` must be >= 2.'
                      'Found: {}'.format(num_classes))
   with variable_scope.variable_scope(name, 'cohen_kappa',
                                      (labels, predictions_idx, weights)):

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3343,8 +3343,8 @@ def cohen_kappa(labels, predictions_idx, num_classes, weights=None,
 
   Returns:
     kappa: Scalar float `Tensor` representing the current Cohen's kappa.
-    update_op: `Operation` that increments `total_po`, `total_pe_row` and
-      `total_pe_col` variables appropriately and whose value matches `kappa`.
+    update_op: `Operation` that increments `po`, `pe_row` and `pe_col`
+      variables appropriately and whose value matches `kappa`.
 
   Raises:
     ValueError: If `num_classes` is less than 2, or `predictions` and `labels`

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3330,7 +3330,7 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
 
   Args:
     labels: 1-D `Tensor` of real labels for the classification task. Must be
-      one of the following types: int16, int32, int64.
+      one of the following types: int16, int32, int64, float32, float64.
     predictions: 1-D `Tensor` of predictions for a given classification.
       Must have the same type as `labels`.
     num_classes: The possible number of labels.

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3309,6 +3309,7 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
                      'Found: {}'.format(num_classes))
   with variable_scope.variable_scope(name, 'cohen_kappa',
                                      (labels, predictions, weights)):
+    # Convert 2-dim (num, 1) to 1-dim (num,)
     labels.get_shape().with_rank_at_most(2)
     labels = array_ops.squeeze(labels)
     predictions, labels, weights = metrics_impl._remove_squeezable_dimensions(  # pylint: disable=protected-access

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3307,10 +3307,10 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
   that measures inter-annotator agreement.
 
   The `cohen_kappa` function calculates the confusion matrix, and creates three
-  local variables to compute the Cohen's kappa: `po`, `pe_row`, and `pe_col`
-  refer to the diagonal part, rows and columns totals of the confusion matrix,
-  respectively. This value is ultimately returned as `kappa`, an idempotent
-  operation that is calculated by
+  local variables to compute the Cohen's kappa: `po`, `pe_row`, and `pe_col`,
+  which refer to the diagonal part, rows and columns totals of the confusion
+  matrix, respectively. This value is ultimately returned as `kappa`, an
+  idempotent operation that is calculated by
 
       pe = (pe_row * pe_col) / N
       k = (sum(po) - sum(pe)) / (N - sum(pe))

--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3388,10 +3388,9 @@ def cohen_kappa(labels, predictions, num_classes, weights=None,
     po_t = array_ops.diag_part(counts_in_table)
     pe_row_t = math_ops.reduce_sum(counts_in_table, axis=0)
     pe_col_t = math_ops.reduce_sum(counts_in_table, axis=1)
-    with ops.control_dependencies([po_t, pe_row_t, pe_col_t]):
-      update_po = state_ops.assign_add(po, po_t)
-      update_pe_row = state_ops.assign_add(pe_row, pe_row_t)
-      update_pe_col = state_ops.assign_add(pe_col, pe_col_t)
+    update_po = state_ops.assign_add(po, po_t)
+    update_pe_row = state_ops.assign_add(pe_row, pe_row_t)
+    update_pe_col = state_ops.assign_add(pe_col, pe_col_t)
 
     def _calculate_k(po, pe_row, pe_col, name):
       po_sum = math_ops.reduce_sum(po)

--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -6856,6 +6856,17 @@ class CohenKappaTest(test.TestCase):
     with self.assertRaisesRegexp(ValueError, 'num_classes'):
       metrics.cohen_kappa(labels, predictions, 1)
 
+  def testInvalidDimension(self):
+    predictions = array_ops.placeholder(dtypes_lib.float32, shape=(4, 1))
+    invalid_labels = array_ops.placeholder(dtypes_lib.int32, shape=(4, 2))
+    with self.assertRaises(ValueError):
+      metrics.cohen_kappa(invalid_labels, predictions, 3)
+
+    invalid_predictions = array_ops.placeholder(dtypes_lib.float32, shape=(4, 2))
+    labels = array_ops.placeholder(dtypes_lib.int32, shape=(4, 1))
+    with self.assertRaises(ValueError):
+      metrics.cohen_kappa(labels, invalid_predictions, 3)
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -6737,8 +6737,7 @@ class CohenKappaTest(test.TestCase):
     expect = 0.45
     labels, predictions = self._confusion_matrix_to_samples(confusion_matrix)
 
-    dtypes = [dtypes_lib.int16, dtypes_lib.int32, dtypes_lib.int64,
-              dtypes_lib.float32, dtypes_lib.float64]
+    dtypes = [dtypes_lib.int16, dtypes_lib.int32, dtypes_lib.int64]
     shapes = [(len(labels,)),  # 1-dim
               (len(labels), 1)]  # 2-dim
     weights = [None, np.ones_like(labels)]

--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -6728,6 +6728,14 @@ class CohenKappaTest(test.TestCase):
       [9, 3, 1],
       [4, 8, 2],
       [2, 1, 6]])
+    # overall total = 36
+    # po = [9, 8, 6], sum(po) = 23
+    # pe_row = [15, 12, 9], pe_col = [13, 14, 9], so pe = [5.42, 4.67, 2.25]
+    # finally, kappa = (sum(po) - sum(pe)) / (N - sum(pe))
+    #                = (23 - 12.34) / (36 - 12.34)
+    #                = 0.45
+    # see: http://psych.unl.edu/psycrs/handcomp/hckappa.PDF
+    expect = 0.45
     labels, predictions = self._confuse_matrix_to_samples(confuse_matrix)
 
     dtypes = [dtypes_lib.int16, dtypes_lib.int32, dtypes_lib.int64,
@@ -6748,8 +6756,8 @@ class CohenKappaTest(test.TestCase):
                 labels_tensor, predictions_tensor, 3, weights=weight)
 
             sess.run(variables.local_variables_initializer())
-            self.assertAlmostEqual(0.45, sess.run(update_op), 2)
-            self.assertAlmostEqual(0.45, kappa.eval(), 2)
+            self.assertAlmostEqual(expect, sess.run(update_op), 2)
+            self.assertAlmostEqual(expect, kappa.eval(), 2)
 
   def testBasic2(self):
     labels = np.random.randint(0, 4, size=(100, 1))

--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -6759,20 +6759,6 @@ class CohenKappaTest(test.TestCase):
             self.assertAlmostEqual(expect, sess.run(update_op), 2)
             self.assertAlmostEqual(expect, kappa.eval(), 2)
 
-  def testBasic2(self):
-    labels = np.random.randint(0, 4, size=(100, 1))
-    predictions = np.random.randint(0, 4, size=(100, 1))
-    expect = sk_metrics.cohen_kappa_score(labels, predictions)
-
-    with self.test_session() as sess:
-      predictions = constant_op.constant(predictions, dtype=dtypes_lib.float32)
-      labels = constant_op.constant(labels)
-      kappa, update_op = metrics.cohen_kappa(labels, predictions, 4)
-
-      sess.run(variables.local_variables_initializer())
-      self.assertAlmostEqual(expect, sess.run(update_op), 5)
-      self.assertAlmostEqual(expect, kappa.eval(), 5)
-
   def testAllCorrect(self):
     inputs = np.random.randint(0, 4, size=(100, 1))
     expect = sk_metrics.cohen_kappa_score(inputs, inputs)

--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -6677,7 +6677,7 @@ class CohenKappaTest(test.TestCase):
 
   def testVars(self):
     metrics.cohen_kappa(
-        predictions=array_ops.ones((10, 1)),
+        predictions_idx=array_ops.ones((10, 1)),
         labels=array_ops.ones((10, 1)),
         num_classes=2)
     _assert_metric_variables(self, (
@@ -6688,7 +6688,7 @@ class CohenKappaTest(test.TestCase):
   def testMetricsCollection(self):
     my_collection_name = '__metrics__'
     kappa, _ = metrics.cohen_kappa(
-        predictions=array_ops.ones((10, 1)),
+        predictions_idx=array_ops.ones((10, 1)),
         labels=array_ops.ones((10, 1)),
         num_classes=2,
         metrics_collections=[my_collection_name])
@@ -6697,7 +6697,7 @@ class CohenKappaTest(test.TestCase):
   def testUpdatesCollection(self):
     my_collection_name = '__updates__'
     _, update_op = metrics.cohen_kappa(
-        predictions=array_ops.ones((10, 1)),
+        predictions_idx=array_ops.ones((10, 1)),
         labels=array_ops.ones((10, 1)),
         num_classes=2,
         updates_collections=[my_collection_name])

--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -6730,7 +6730,7 @@ class CohenKappaTest(test.TestCase):
       [2, 1, 6]])
     labels, predictions = self._confuse_matrix_to_samples(confuse_matrix)
 
-    dtypes = [dtypes_lib.int32, dtypes_lib.int64,
+    dtypes = [dtypes_lib.int16, dtypes_lib.int32, dtypes_lib.int64,
               dtypes_lib.float32, dtypes_lib.float64]
     shapes = [(len(labels,)),  # 1-dim
               (len(labels), 1)]  # 2-dim

--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -6682,9 +6682,9 @@ class CohenKappaTest(test.TestCase):
         labels=array_ops.ones((10, 1)),
         num_classes=2)
     _assert_metric_variables(self, (
-        'cohen_kappa/total_po:0',
-        'cohen_kappa/total_pe_row:0',
-        'cohen_kappa/total_pe_col:0',))
+        'cohen_kappa/po:0',
+        'cohen_kappa/pe_row:0',
+        'cohen_kappa/pe_col:0',))
 
   def testMetricsCollection(self):
     my_collection_name = '__metrics__'

--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -6823,26 +6823,29 @@ class CohenKappaTest(test.TestCase):
       [40, 80, 20, 30],
       [20, 10, 60, 35],
       [15, 25, 30, 25]])
-    labels_np, predictions_np = self._confusion_matrix_to_samples(confusion_matrix)
+    labels, predictions = self._confusion_matrix_to_samples(confusion_matrix)
     num_samples = np.sum(confusion_matrix, dtype=np.int32)
-    weights_np = (np.arange(0, num_samples) % 5) / 5.0
+    weights = (np.arange(0, num_samples) % 5) / 5.0
     num_classes = confusion_matrix.shape[0]
 
     batch_size = num_samples // 10
-    predictions = array_ops.placeholder(dtypes_lib.float32, shape=(batch_size,))
-    labels = array_ops.placeholder(dtypes_lib.int32, shape=(batch_size,))
-    weights = array_ops.placeholder(dtypes_lib.float32, shape=(batch_size,))
-    kappa, update_op = metrics.cohen_kappa(labels, predictions, num_classes,
-                                           weights=weights)
+    predictions_t = array_ops.placeholder(dtypes_lib.float32,
+                                          shape=(batch_size,))
+    labels_t = array_ops.placeholder(dtypes_lib.int32,
+                                     shape=(batch_size,))
+    weights_t = array_ops.placeholder(dtypes_lib.float32,
+                                      shape=(batch_size,))
+    kappa, update_op = metrics.cohen_kappa(
+        labels_t, predictions_t, num_classes, weights=weights_t)
     with self.test_session() as sess:
       sess.run(variables.local_variables_initializer())
 
       for idx in range(0, num_samples, batch_size):
         batch_start, batch_end = idx, idx + batch_size
         sess.run(update_op,
-                 feed_dict={labels: labels_np[batch_start:batch_end],
-                            predictions: predictions_np[batch_start:batch_end],
-                            weights: weights_np[batch_start:batch_end]})
+                 feed_dict={labels_t: labels[batch_start:batch_end],
+                            predictions_t: predictions[batch_start:batch_end],
+                            weights_t: weights[batch_start:batch_end]})
       # Calculated by v0.19: sklearn.metrics.cohen_kappa_score(
       #                          labels_np, predictions_np, sample_weight=weights_np)
       expect = 0.289965397924

--- a/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops_test.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import math
 
 import numpy as np
-from sklearn import metrics as sk_metrics
 from six.moves import xrange  # pylint: disable=redefined-builtin
 from tensorflow.contrib import metrics as metrics_lib
 from tensorflow.contrib.metrics.python.ops import metric_ops
@@ -6765,7 +6764,8 @@ class CohenKappaTest(test.TestCase):
     # [[25, 0, 0],
     #  [0, 25, 0],
     #  [0, 0, 25]]
-    expect = sk_metrics.cohen_kappa_score(inputs, inputs)
+    # Calculated by v0.19: sklearn.metrics.cohen_kappa_score(inputs, inputs)
+    expect = 1.0
 
     with self.test_session() as sess:
       predictions = constant_op.constant(inputs, dtype=dtypes_lib.float32)
@@ -6783,7 +6783,8 @@ class CohenKappaTest(test.TestCase):
     # [[0, 25, 0],
     #  [0, 0, 25],
     #  [25, 0, 0]]
-    expect = sk_metrics.cohen_kappa_score(labels, predictions)
+    # Calculated by v0.19: sklearn.metrics.cohen_kappa_score(labels, predictions)
+    expect = -0.333333333333
 
     with self.test_session() as sess:
       predictions = constant_op.constant(predictions, dtype=dtypes_lib.float32)
@@ -6802,9 +6803,9 @@ class CohenKappaTest(test.TestCase):
     labels, predictions = self._confusion_matrix_to_samples(confusion_matrix)
     num_samples = np.sum(confusion_matrix, dtype=np.int32)
     weights = (np.arange(0, num_samples) % 5) / 5.0
-
-    expect = sk_metrics.cohen_kappa_score(labels, predictions,
-                                          sample_weight=weights)
+    # Calculated by v0.19: sklearn.metrics.cohen_kappa_score(
+    #                          labels, predictions, sample_weight=weights)
+    expect = 0.453466583385
 
     with self.test_session() as sess:
       predictions = constant_op.constant(predictions, dtype=dtypes_lib.float32)
@@ -6842,10 +6843,10 @@ class CohenKappaTest(test.TestCase):
                  feed_dict={labels: labels_np[batch_start:batch_end],
                             predictions: predictions_np[batch_start:batch_end],
                             weights: weights_np[batch_start:batch_end]})
-
-      final_expect = sk_metrics.cohen_kappa_score(
-          labels_np, predictions_np, sample_weight=weights_np)
-      self.assertAlmostEqual(final_expect, kappa.eval(), 5)
+      # Calculated by v0.19: sklearn.metrics.cohen_kappa_score(
+      #                          labels_np, predictions_np, sample_weight=weights_np)
+      expect = 0.289965397924
+      self.assertAlmostEqual(expect, kappa.eval(), 5)
 
   def testInvalidNumClasses(self):
     predictions = array_ops.placeholder(dtypes_lib.float32, shape=(4, 1))

--- a/tensorflow/python/ops/metrics_impl.py
+++ b/tensorflow/python/ops/metrics_impl.py
@@ -185,11 +185,11 @@ def _safe_div(numerator, denominator, name):
   Returns:
     0 if `denominator` <= 0, else `numerator` / `denominator`
   """
-  return array_ops.where(
-      math_ops.greater(denominator, 0),
-      math_ops.truediv(numerator, denominator),
-      0,
-      name=name)
+  t = math_ops.truediv(numerator, denominator)
+  zero = array_ops.zeros_like(t, dtype=denominator.dtype)
+  contion = math_ops.greater(denominator, zero)
+  zero = math_ops.cast(zero, t.dtype)
+  return array_ops.where(contion, t, zero, name=name)
 
 
 def _safe_scalar_div(numerator, denominator, name):

--- a/tensorflow/python/ops/metrics_impl.py
+++ b/tensorflow/python/ops/metrics_impl.py
@@ -175,7 +175,7 @@ def _maybe_expand_labels(labels, predictions):
 
 
 def _safe_div(numerator, denominator, name):
-  """Divides two values, returning 0 if the denominator is <= 0.
+  """Divides two tensors element-wise, returning 0 if the denominator is <= 0.
 
   Args:
     numerator: A real `Tensor`.

--- a/tensorflow/python/ops/metrics_impl.py
+++ b/tensorflow/python/ops/metrics_impl.py
@@ -187,9 +187,9 @@ def _safe_div(numerator, denominator, name):
   """
   t = math_ops.truediv(numerator, denominator)
   zero = array_ops.zeros_like(t, dtype=denominator.dtype)
-  contion = math_ops.greater(denominator, zero)
+  condition = math_ops.greater(denominator, zero)
   zero = math_ops.cast(zero, t.dtype)
-  return array_ops.where(contion, t, zero, name=name)
+  return array_ops.where(condition, t, zero, name=name)
 
 
 def _safe_scalar_div(numerator, denominator, name):


### PR DESCRIPTION
resolve #15285.

Add new metric: `cohen_kappa`, which is equivalent to `sklearn.metrics.cohen_kappa_score`(>=0.19), but the implementation doesn't support weighted matrix yet.

Ref:
+ [Cohen's kappa - Wiki](https://en.wikipedia.org/wiki/Cohen's_kappa)
+ [Cohen's kappa: Index of Inter-rater Reliability](http://psych.unl.edu/psycrs/handcomp/hckappa.PDF)
+ [sklearn.metrics.cohen_kappa_score](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html)

### How to test

+ [x] add test cases.
+ [ ] pass all tests.