### PR TITLE
Compute test accuracy in batches to avoid OOM on GPUs

### DIFF
--- a/tensorflow/examples/tutorials/mnist/mnist_deep.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_deep.py
@@ -170,7 +170,9 @@ def main(_):
     accuracy_l = []
     for _ in range(20):
       batch = mnist.test.next_batch(500, shuffle=False)
-      accuracy_l.append(accuracy.eval(feed_dict={x: batch[0], y_: batch[1], keep_prob: 1.0}))
+      accuracy_l.append(accuracy.eval(feed_dict={x: batch[0], 
+                                                 y_: batch[1], 
+                                                 keep_prob: 1.0}))
     print('test accuracy %g' % numpy.mean(accuracy_l))
 
 

--- a/tensorflow/examples/tutorials/mnist/mnist_deep.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_deep.py
@@ -168,7 +168,7 @@ def main(_):
 
     # compute in batches to avoid OOM on GPUs 
     accuracy_l = []
-    for i in range(50):
+    for _ in range(20):
       batch = mnist.test.next_batch(500, shuffle=False)
       accuracy_l.append(accuracy.eval(feed_dict={x: batch[0], y_: batch[1], keep_prob: 1.0}))
     print('test accuracy %g' % numpy.mean(accuracy_l))

--- a/tensorflow/examples/tutorials/mnist/mnist_deep.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_deep.py
@@ -34,6 +34,8 @@ from tensorflow.examples.tutorials.mnist import input_data
 
 import tensorflow as tf
 
+import numpy
+
 FLAGS = None
 
 
@@ -164,8 +166,13 @@ def main(_):
         print('step %d, training accuracy %g' % (i, train_accuracy))
       train_step.run(feed_dict={x: batch[0], y_: batch[1], keep_prob: 0.5})
 
-    print('test accuracy %g' % accuracy.eval(feed_dict={
-        x: mnist.test.images, y_: mnist.test.labels, keep_prob: 1.0}))
+    # compute in batches to avoid OOM on GPUs 
+    accuracy_l = []
+    for i in range(50):
+      batch = mnist.test.next_batch(500, shuffle=False)
+      accuracy_l.append(accuracy.eval(feed_dict={x: batch[0], y_: batch[1], keep_prob: 1.0}))
+    print('test accuracy %g' % numpy.mean(accuracy_l))
+
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()


### PR DESCRIPTION
Reported here: https://github.com/tensorflow/tensorflow/issues/136
Alternative to this for mnist_deep.py: https://github.com/tensorflow/tensorflow/pull/157

Note that some reports in https://github.com/tensorflow/tensorflow/issues/136 claim that BFC solves the problem and that it would be included in the next binary release, but as this writing is two years after those comments, it stands to reason that the example still doesn't work out of the box for "low" memory GPUs.

Also noting for completeness that I am running on a GeForce GTX 670 (2GB) and that avg(avg(x_i)) = avg(x_i) when |x_i| for all i is equal. 