### PR TITLE
BUG: fix name scope collision in `tf.layers`

### DIFF
--- a/tensorflow/python/layers/base.py
+++ b/tensorflow/python/layers/base.py
@@ -493,7 +493,8 @@ class Layer(object):
 
     self._set_scope(None)
     with vs.variable_scope(
-        self._scope, reuse=(self.built or self._reuse)) as scope:
+        self._scope, reuse=(self.built or self._reuse),
+        auxiliary_name_scope=False) as scope:
       with ops.name_scope(self._name_scope_name(scope)):
         variable = vs.get_variable(name,
                                    shape=shape,
@@ -602,11 +603,11 @@ class Layer(object):
         # variable scope with this setting. We avoid re-creating variable scopes
         # after this point as an optimization.
         self._always_reuse_variable_scope = vs.variable_scope(
-            self._scope, reuse=True)
+            self._scope, reuse=True, auxiliary_name_scope=False)
         scope_context_manager = self._always_reuse_variable_scope
     else:
       scope_context_manager = vs.variable_scope(
-          self._scope, reuse=self._reuse)
+          self._scope, reuse=self._reuse, auxiliary_name_scope=False)
     with scope_context_manager as scope:
       with ops.name_scope(self._name_scope_name(scope)):
         if not self.built:

--- a/tensorflow/python/layers/base_test.py
+++ b/tensorflow/python/layers/base_test.py
@@ -474,6 +474,66 @@ class BaseLayerTest(test.TestCase):
     layer.apply(x)
     self.assertEqual(len(layer.get_losses_for(x)), 1)
 
+  def testNameScopeIsConsistentWithVariableScope(self):
+    # Github issue 13429.
+
+    class MyLayer(base_layers.Layer):
+
+      def build(self, input_shape):
+        self.my_var = self.add_variable('my_var', (), dtypes.float32)
+        self.built = True
+
+      def call(self, inputs):
+        return math_ops.multiply(inputs, self.my_var, name='my_op')
+
+    def _gen_layer(x, name=None):
+      layer = MyLayer(name=name)
+      out = layer.apply(x)
+      return layer, out
+
+    # unnamed layer
+    with ops.Graph().as_default():
+      x = array_ops.placeholder(dtypes.float32, (), 'x')
+
+      layer, op = _gen_layer(x)
+      layer1, op1 = _gen_layer(op)
+      layer2, op2 = _gen_layer(op1)
+
+      self.assertEqual(layer.my_var.name, 'my_layer/my_var:0')
+      self.assertEqual(op.name, 'my_layer/my_op:0')
+      self.assertEqual(layer1.my_var.name, 'my_layer_1/my_var:0')
+      self.assertEqual(op1.name, 'my_layer_1/my_op:0')
+      self.assertEqual(layer2.my_var.name, 'my_layer_2/my_var:0')
+      self.assertEqual(op2.name, 'my_layer_2/my_op:0')
+    # name starts from zero
+    with ops.Graph().as_default():
+      x = array_ops.placeholder(dtypes.float32, (), 'x')
+
+      layer, op = _gen_layer(x, name='name')
+      layer1, op1 = _gen_layer(op, name='name_1')
+      layer2, op2 = _gen_layer(op1, name='name_2')
+
+      self.assertEqual(layer.my_var.name, 'name/my_var:0')
+      self.assertEqual(op.name, 'name/my_op:0')
+      self.assertEqual(layer1.my_var.name, 'name_1/my_var:0')
+      self.assertEqual(op1.name, 'name_1/my_op:0')
+      self.assertEqual(layer2.my_var.name, 'name_2/my_var:0')
+      self.assertEqual(op2.name, 'name_2/my_op:0')
+    # name starts from one
+    with ops.Graph().as_default():
+      x = array_ops.placeholder(dtypes.float32, (), 'x')
+
+      layer, op = _gen_layer(x, name='name_1')
+      layer1, op1 = _gen_layer(op, name='name_2')
+      layer2, op2 = _gen_layer(op1, name='name_3')
+
+      self.assertEqual(layer.my_var.name, 'name_1/my_var:0')
+      self.assertEqual(op.name, 'name_1/my_op:0')
+      self.assertEqual(layer1.my_var.name, 'name_2/my_var:0')
+      self.assertEqual(op1.name, 'name_2/my_op:0')
+      self.assertEqual(layer2.my_var.name, 'name_3/my_var:0')
+      self.assertEqual(op2.name, 'name_3/my_op:0')
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/layers/base_test.py
+++ b/tensorflow/python/layers/base_test.py
@@ -476,7 +476,6 @@ class BaseLayerTest(test.TestCase):
 
   def testNameScopeIsConsistentWithVariableScope(self):
     # Github issue 13429.
-
     class MyLayer(base_layers.Layer):
 
       def build(self, input_shape):
@@ -494,7 +493,6 @@ class BaseLayerTest(test.TestCase):
     # unnamed layer
     with ops.Graph().as_default():
       x = array_ops.placeholder(dtypes.float32, (), 'x')
-
       layer, op = _gen_layer(x)
       layer1, op1 = _gen_layer(op)
       layer2, op2 = _gen_layer(op1)
@@ -508,7 +506,6 @@ class BaseLayerTest(test.TestCase):
     # name starts from zero
     with ops.Graph().as_default():
       x = array_ops.placeholder(dtypes.float32, (), 'x')
-
       layer, op = _gen_layer(x, name='name')
       layer1, op1 = _gen_layer(op, name='name_1')
       layer2, op2 = _gen_layer(op1, name='name_2')
@@ -522,7 +519,6 @@ class BaseLayerTest(test.TestCase):
     # name starts from one
     with ops.Graph().as_default():
       x = array_ops.placeholder(dtypes.float32, (), 'x')
-
       layer, op = _gen_layer(x, name='name_1')
       layer1, op1 = _gen_layer(op, name='name_2')
       layer2, op2 = _gen_layer(op1, name='name_3')


### PR DESCRIPTION
Fix  #13429.

Since  #14390 has been merged into master branch, we can easily solve the problem with `auxiliary_name_scope=False`.

### How to test

+ [x] add test case.
+ [x] pass all tests.
