### PR TITLE
Revert changes in TrainingHelper that cause "no gradient" error

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/helper.py
+++ b/tensorflow/contrib/seq2seq/python/ops/helper.py
@@ -223,7 +223,8 @@ class TrainingHelper(Helper):
 
   def sample(self, time, outputs, name=None, **unused_kwargs):
     with ops.name_scope(name, "TrainingHelperSample", [time, outputs]):
-      sample_ids = math_ops.argmax(outputs, axis=-1, output_type=dtypes.int32)
+      sample_ids = math_ops.cast(
+          math_ops.argmax(outputs, axis=-1), dtypes.int32)
       return sample_ids
 
   def next_inputs(self, time, outputs, state, name=None, **unused_kwargs):


### PR DESCRIPTION
Change occured in https://github.com/tensorflow/tensorflow/commit/69c324591ba4dfeafb403ee59de56ffe063c1e94

Discussed in https://github.com/tensorflow/tensorflow/issues/15278