### PR TITLE
[XLA/tfcompile] Add Env::CreateUniqueFileName and use it in SaveGraph

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_graph_dumper.cc
+++ b/tensorflow/compiler/xla/service/hlo_graph_dumper.cc
@@ -1357,7 +1357,7 @@ string SaveGraph(const string& graph,
       dest_path, StrCat("hlo_graph_", output_num++, "."));
   auto status = Status::OK();
   auto env = tensorflow::Env::Default();
-  if (!env->CreateNewFileWithUniqueName(&path, file_extension)) {
+  if (!env->CreateUniqueFileName(&path, file_extension)) {
     status =
         Status(tensorflow::error::Code::UNKNOWN,
                StrCat("Failed to create temporary file to dump HLO graph: ",

--- a/tensorflow/compiler/xla/service/hlo_graph_dumper.cc
+++ b/tensorflow/compiler/xla/service/hlo_graph_dumper.cc
@@ -1357,7 +1357,7 @@ string SaveGraph(const string& graph,
       dest_path, StrCat("hlo_graph_", output_num++, "."));
   auto status = Status::OK();
   auto env = tensorflow::Env::Default();
-  if (!env->CreateTempFilename(&path, file_extension)) {
+  if (!env->CreateLocalFilename(&path, file_extension)) {
     status =
         Status(tensorflow::error::Code::UNKNOWN,
                StrCat("Failed to create temporary file to dump HLO graph: ",

--- a/tensorflow/compiler/xla/service/hlo_graph_dumper.cc
+++ b/tensorflow/compiler/xla/service/hlo_graph_dumper.cc
@@ -1354,18 +1354,17 @@ string SaveGraph(const string& graph,
       break;
   }
   string path = JoinPath(
-      dest_path, StrCat("hlo_graph_", output_num++, ".XXXXXX", file_extension));
+      dest_path, StrCat("hlo_graph_", output_num++, "."));
   auto status = Status::OK();
-  int fd = mkstemps(&path[0], file_extension.length());
-  if (fd < 0) {
+  auto env = tensorflow::Env::Default();
+  if (!env->CreateTempFilename(&path, file_extension)) {
     status =
         Status(tensorflow::error::Code::UNKNOWN,
                StrCat("Failed to create temporary file to dump HLO graph: ",
                       strerror(errno)));
   } else {
     status =
-        tensorflow::WriteStringToFile(tensorflow::Env::Default(), path, graph);
-    close(fd);
+        tensorflow::WriteStringToFile(env, path, graph);
   }
   if (!status.ok()) {
     LOG(WARNING) << "Saving HLO graph failed: " << status;

--- a/tensorflow/compiler/xla/service/hlo_graph_dumper.cc
+++ b/tensorflow/compiler/xla/service/hlo_graph_dumper.cc
@@ -1357,7 +1357,7 @@ string SaveGraph(const string& graph,
       dest_path, StrCat("hlo_graph_", output_num++, "."));
   auto status = Status::OK();
   auto env = tensorflow::Env::Default();
-  if (!env->CreateLocalFilename(&path, file_extension)) {
+  if (!env->CreateNewFileWithUniqueName(&path, file_extension)) {
     status =
         Status(tensorflow::error::Code::UNKNOWN,
                StrCat("Failed to create temporary file to dump HLO graph: ",

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -301,14 +301,14 @@ bool Env::LocalTempFilename(string* filename) {
   // permissions or have different problems at times.
   for (const string& dir : dirs) {
     *filename = io::JoinPath(dir, "tempfile-");
-    if (CreateNewFileWithUniqueName(filename, "")) {
+    if (CreateUniqueFileName(filename, "")) {
       return true;
     }
   }
   return false;
 }
 
-bool Env::CreateNewFileWithUniqueName(string* prefix, const string& suffix) {
+bool Env::CreateUniqueFileName(string* prefix, const string& suffix) {
 #ifdef __APPLE__
   uint64_t tid64;
   pthread_threadid_np(nullptr, &tid64);

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -301,14 +301,14 @@ bool Env::LocalTempFilename(string* filename) {
   // permissions or have different problems at times.
   for (const string& dir : dirs) {
     *filename = io::JoinPath(dir, "tempfile-");
-    if (CreateTempFilename(filename, "")) {
+    if (CreateLocalFilename(filename, "")) {
       return true;
     }
   }
   return false;
 }
 
-bool Env::CreateTempFilename(string* prefix, const string& suffix) {
+bool Env::CreateLocalFilename(string* prefix, const string& suffix) {
 #ifdef __APPLE__
   uint64_t tid64;
   pthread_threadid_np(nullptr, &tid64);

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -300,36 +300,47 @@ bool Env::LocalTempFilename(string* filename) {
   // Try each directory, as they might be full, have inappropriate
   // permissions or have different problems at times.
   for (const string& dir : dirs) {
-#ifdef __APPLE__
-    uint64_t tid64;
-    pthread_threadid_np(nullptr, &tid64);
-    int32 tid = static_cast<int32>(tid64);
-    int32 pid = static_cast<int32>(getpid());
-#elif defined(__FreeBSD__)
-    // Has to be casted to long first, else this error appears:
-    // static_cast from 'pthread_t' (aka 'pthread *') to 'int32' (aka 'int')
-    // is not allowed
-    int32 tid = static_cast<int32>((long) pthread_self());
-    int32 pid = static_cast<int32>(getpid());
-#elif defined(PLATFORM_WINDOWS)
-    int32 tid = static_cast<int32>(GetCurrentThreadId());
-    int32 pid = static_cast<int32>(GetCurrentProcessId());
-#else
-    int32 tid = static_cast<int32>(pthread_self());
-    int32 pid = static_cast<int32>(getpid());
-#endif
-    uint64 now_microsec = NowMicros();
-
-    *filename = io::JoinPath(
-        dir, strings::Printf("tempfile-%s-%x-%d-%llx", port::Hostname().c_str(),
-                             tid, pid, now_microsec));
-    if (FileExists(*filename).ok()) {
-      filename->clear();
-    } else {
+    *filename = io::JoinPath(dir, "tempfile-");
+    if (CreateTempFilename(filename, "")) {
       return true;
     }
   }
   return false;
+}
+
+bool Env::CreateTempFilename(string* prefix, const string& suffix) {
+#ifdef __APPLE__
+  uint64_t tid64;
+  pthread_threadid_np(nullptr, &tid64);
+  int32 tid = static_cast<int32>(tid64);
+  int32 pid = static_cast<int32>(getpid());
+#elif defined(__FreeBSD__)
+  // Has to be casted to long first, else this error appears:
+  // static_cast from 'pthread_t' (aka 'pthread *') to 'int32' (aka 'int')
+  // is not allowed
+  int32 tid = static_cast<int32>((long) pthread_self());
+  int32 pid = static_cast<int32>(getpid());
+#elif defined(PLATFORM_WINDOWS)
+  int32 tid = static_cast<int32>(GetCurrentThreadId());
+  int32 pid = static_cast<int32>(GetCurrentProcessId());
+#else
+  int32 tid = static_cast<int32>(pthread_self());
+  int32 pid = static_cast<int32>(getpid());
+#endif
+  uint64 now_microsec = NowMicros();
+
+  *prefix += strings::Printf("%s-%x-%d-%llx", port::Hostname().c_str(),
+                           tid, pid, now_microsec);
+
+  if (suffix.size()) {
+    *prefix += suffix;
+  }
+  if (FileExists(*prefix).ok()) {
+    prefix->clear();
+    return false;
+  } else {
+    return true;
+  }
 }
 
 Thread::~Thread() {}

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -301,14 +301,14 @@ bool Env::LocalTempFilename(string* filename) {
   // permissions or have different problems at times.
   for (const string& dir : dirs) {
     *filename = io::JoinPath(dir, "tempfile-");
-    if (CreateLocalFilename(filename, "")) {
+    if (CreateNewFileWithUniqueName(filename, "")) {
       return true;
     }
   }
   return false;
 }
 
-bool Env::CreateLocalFilename(string* prefix, const string& suffix) {
+bool Env::CreateNewFileWithUniqueName(string* prefix, const string& suffix) {
 #ifdef __APPLE__
   uint64_t tid64;
   pthread_threadid_np(nullptr, &tid64);

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -220,7 +220,7 @@ class Env {
 
   /// Creates a local unique file name that starts with |prefix| and ends with
   /// |suffix|. Returns true if success.
-  bool CreateLocalFilename(string* prefix, const string& suffix);
+  bool CreateNewFileWithUniqueName(string* prefix, const string& suffix);
 
   // TODO(jeff,sanjay): Add back thread/thread-pool support if needed.
   // TODO(jeff,sanjay): if needed, tighten spec so relative to epoch, or

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -220,7 +220,7 @@ class Env {
 
   /// Creates a local unique file name that starts with |prefix| and ends with
   /// |suffix|. Returns true if success.
-  bool CreateNewFileWithUniqueName(string* prefix, const string& suffix);
+  bool CreateUniqueFileName(string* prefix, const string& suffix);
 
   // TODO(jeff,sanjay): Add back thread/thread-pool support if needed.
   // TODO(jeff,sanjay): if needed, tighten spec so relative to epoch, or

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -283,7 +283,7 @@ class Env {
   // "version" should be the version of the library or NULL
   // returns the name that LoadLibrary() can use
   virtual string FormatLibraryFileName(const string& name,
-                                       const string& version) = 0;
+      const string& version) = 0;
 
  private:
   // Returns a possible list of local temporary directories.
@@ -350,7 +350,6 @@ class EnvWrapper : public Env {
                                const string& version) override {
     return target_->FormatLibraryFileName(name, version);
   }
-
  private:
   Env* target_;
 };

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -218,6 +218,10 @@ class Env {
   /// Creates a local unique temporary file name. Returns true if success.
   bool LocalTempFilename(string* filename);
 
+  /// Create a unique file name starts with |prefix| and ends with |suffix|.
+  /// Returns true if success.
+  bool CreateTempFilename(string* prefix, const string& suffix);
+
   // TODO(jeff,sanjay): Add back thread/thread-pool support if needed.
   // TODO(jeff,sanjay): if needed, tighten spec so relative to epoch, or
   // provide a routine to get the absolute time.
@@ -279,7 +283,7 @@ class Env {
   // "version" should be the version of the library or NULL
   // returns the name that LoadLibrary() can use
   virtual string FormatLibraryFileName(const string& name,
-      const string& version) = 0;
+                                       const string& version) = 0;
 
  private:
   // Returns a possible list of local temporary directories.
@@ -346,6 +350,7 @@ class EnvWrapper : public Env {
                                const string& version) override {
     return target_->FormatLibraryFileName(name, version);
   }
+
  private:
   Env* target_;
 };

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -218,9 +218,9 @@ class Env {
   /// Creates a local unique temporary file name. Returns true if success.
   bool LocalTempFilename(string* filename);
 
-  /// Create a unique file name starts with |prefix| and ends with |suffix|.
-  /// Returns true if success.
-  bool CreateTempFilename(string* prefix, const string& suffix);
+  /// Creates a local unique file name that starts with |prefix| and ends with
+  /// |suffix|. Returns true if success.
+  bool CreateLocalFilename(string* prefix, const string& suffix);
 
   // TODO(jeff,sanjay): Add back thread/thread-pool support if needed.
   // TODO(jeff,sanjay): if needed, tighten spec so relative to epoch, or

--- a/tensorflow/core/platform/env_test.cc
+++ b/tensorflow/core/platform/env_test.cc
@@ -341,14 +341,14 @@ TEST_F(DefaultEnvTest, LocalTempFilename) {
   EXPECT_FALSE(env->FileExists(filename).ok());
 }
 
-TEST_F(DefaultEnvTest, CreateTempFilename) {
+TEST_F(DefaultEnvTest, CreateLocalFilename) {
   Env* env = Env::Default();
 
   string prefix = "tempfile-prefix-";
   string suffix = ".tmp";
   string filename = prefix;
 
-  EXPECT_TRUE(env->CreateTempFilename(&filename, suffix));
+  EXPECT_TRUE(env->CreateLocalFilename(&filename, suffix));
 
   StringPiece str(filename);
   EXPECT_TRUE(str.starts_with(prefix));

--- a/tensorflow/core/platform/env_test.cc
+++ b/tensorflow/core/platform/env_test.cc
@@ -341,14 +341,14 @@ TEST_F(DefaultEnvTest, LocalTempFilename) {
   EXPECT_FALSE(env->FileExists(filename).ok());
 }
 
-TEST_F(DefaultEnvTest, CreateNewFileWithUniqueName) {
+TEST_F(DefaultEnvTest, CreateUniqueFileName) {
   Env* env = Env::Default();
 
   string prefix = "tempfile-prefix-";
   string suffix = ".tmp";
   string filename = prefix;
 
-  EXPECT_TRUE(env->CreateNewFileWithUniqueName(&filename, suffix));
+  EXPECT_TRUE(env->CreateUniqueFileName(&filename, suffix));
 
   StringPiece str(filename);
   EXPECT_TRUE(str.starts_with(prefix));

--- a/tensorflow/core/platform/env_test.cc
+++ b/tensorflow/core/platform/env_test.cc
@@ -341,14 +341,14 @@ TEST_F(DefaultEnvTest, LocalTempFilename) {
   EXPECT_FALSE(env->FileExists(filename).ok());
 }
 
-TEST_F(DefaultEnvTest, CreateLocalFilename) {
+TEST_F(DefaultEnvTest, CreateNewFileWithUniqueName) {
   Env* env = Env::Default();
 
   string prefix = "tempfile-prefix-";
   string suffix = ".tmp";
   string filename = prefix;
 
-  EXPECT_TRUE(env->CreateLocalFilename(&filename, suffix));
+  EXPECT_TRUE(env->CreateNewFileWithUniqueName(&filename, suffix));
 
   StringPiece str(filename);
   EXPECT_TRUE(str.starts_with(prefix));

--- a/tensorflow/core/platform/env_test.cc
+++ b/tensorflow/core/platform/env_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/framework/node_def.pb.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/lib/core/stringpiece.h"
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/lib/strings/strcat.h"
@@ -338,6 +339,20 @@ TEST_F(DefaultEnvTest, LocalTempFilename) {
   // Delete the temporary file.
   TF_CHECK_OK(env->DeleteFile(filename));
   EXPECT_FALSE(env->FileExists(filename).ok());
+}
+
+TEST_F(DefaultEnvTest, CreateTempFilename) {
+  Env* env = Env::Default();
+
+  string prefix = "tempfile-prefix-";
+  string suffix = ".tmp";
+  string filename = prefix;
+
+  EXPECT_TRUE(env->CreateTempFilename(&filename, suffix));
+
+  StringPiece str(filename);
+  EXPECT_TRUE(str.starts_with(prefix));
+  EXPECT_TRUE(str.ends_with(suffix));
 }
 
 }  // namespace tensorflow


### PR DESCRIPTION
Split part of `tensorflow::Env::LocalTempFilename` into `tensorflow::Env::CreateTempFilename` so that it can be used in `SaveGraph`.

This PR is to replace #15335.

I am terrible in creating descriptive function name, better name suggestion for `CreateTempFilename` is welcomed.

/cc @jlebar.

 #15213