### PR TITLE
Fix a compile error in file_block_cache_test.cc

### DIFF
--- a/tensorflow/core/platform/cloud/file_block_cache_test.cc
+++ b/tensorflow/core/platform/cloud/file_block_cache_test.cc
@@ -456,7 +456,7 @@ TEST(FileBlockCacheTest, CoalesceConcurrentReads) {
   FileBlockCache cache(block_size, block_size, 0, fetcher);
   // Fork off thread for parallel read.
   std::unique_ptr<Thread> concurrent(
-      Env::Default()->StartThread({}, "concurrent", [&cache] {
+      Env::Default()->StartThread({}, "concurrent", [&cache, block_size] {
         std::vector<char> out;
         TF_EXPECT_OK(cache.Read("", 0, block_size / 2, &out));
         EXPECT_EQ(out.size(), block_size / 2);


### PR DESCRIPTION
tensorflow/core/platform/cloud/file_block_cache_test.cc(461): error C3493: 'block_size' cannot be implicitly captured because no default capture mode has been specified

Compiler: Visual Studio 2017 v15.4.4