### PR TITLE
fix _Pooling1D data format bug

### DIFF
--- a/tensorflow/python/layers/pooling.py
+++ b/tensorflow/python/layers/pooling.py
@@ -62,14 +62,14 @@ class _Pooling1D(base.Layer):
   def call(self, inputs):
     # There is no TF op for 1D pooling, hence we make the inputs 4D.
     if self.data_format == 'channels_last':
-      inputs = array_ops.expand_dims(inputs, 2)
-      pool_shape = (1,) + self.pool_size + (1, 1)
-      strides = (1,) + self.strides + (1, 1)
-      data_format = 'NHWC'
-    else:
       inputs = array_ops.expand_dims(inputs, 1)
       pool_shape = (1, 1) + self.pool_size + (1,)
       strides = (1, 1) + self.strides + (1,)
+      data_format = 'NHWC'
+    else:
+      inputs = array_ops.expand_dims(inputs, 2)
+      pool_shape = (1, 1, 1) + self.pool_size
+      strides = (1, 1, 1) + self.strides
       data_format = 'NCHW'
 
     outputs = self.pool_function(
@@ -80,9 +80,9 @@ class _Pooling1D(base.Layer):
         data_format=data_format)
 
     if self.data_format == 'channels_last':
-      return array_ops.squeeze(outputs, 2)
-    else:
       return array_ops.squeeze(outputs, 1)
+    else:
+      return array_ops.squeeze(outputs, 2)
 
   def _compute_output_shape(self, input_shape):
     input_shape = tensor_shape.TensorShape(input_shape).as_list()


### PR DESCRIPTION
When `data_format` is `channels_last`, input is `NWC`, so we have to `expand_dim(1)` to make it become `NHWC`. Then we apply pooling on `W` which is the 3rd dimention.

When `data_format` is `channels_first`, input is `NCW`, so we have to `expand_dim(2)` to make it become `NCHW`. Then we apply pooling on `W`, which is the 4th dimention.