### PR TITLE
fix pooling1D dimension bug

### DIFF
--- a/tensorflow/python/layers/pooling_test.py
+++ b/tensorflow/python/layers/pooling_test.py
@@ -110,19 +110,19 @@ class PoolingTest(test.TestCase):
 
   def testCreateMaxPooling1DChannelsFirst(self):
     width = 7
-    images = random_ops.random_uniform((5, width, 4))
+    images = random_ops.random_uniform((5, 4, width))
     layer = pooling_layers.MaxPooling1D(
         2, strides=2, data_format='channels_first')
     output = layer.apply(images)
-    self.assertListEqual(output.get_shape().as_list(), [5, 3, 4])
+    self.assertListEqual(output.get_shape().as_list(), [5, 4, 3])
 
   def testCreateAveragePooling1DChannelsFirst(self):
     width = 7
-    images = random_ops.random_uniform((5, width, 4))
+    images = random_ops.random_uniform((5, 4, width))
     layer = pooling_layers.AveragePooling1D(
         2, strides=2, data_format='channels_first')
     output = layer.apply(images)
-    self.assertListEqual(output.get_shape().as_list(), [5, 3, 4])
+    self.assertListEqual(output.get_shape().as_list(), [5, 4, 3])
 
   def testCreateMaxPooling3D(self):
     depth, height, width = 6, 7, 9


### PR DESCRIPTION
When `data_format` is `channels_last`, input is `NWC`, so we have to `expand_dim(1)` to make it become `NHWC`. Then we apply pooling on `W` which is the 3rd dimention.

When `data_format` is `channels_first`, input is `NCW`, so we have to `expand_dim(2)` to make it become `NCHW`. Then we apply pooling on `W`, which is the 4th dimention.

RELNOTES: Fixed wrong handling of 1D pooling (pooling was not happening on the correct dimension).