### PR TITLE
[XLA] Explicitly include <numeric>

### DIFF
--- a/tensorflow/compiler/xla/array.h
+++ b/tensorflow/compiler/xla/array.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <initializer_list>
 #include <iterator>
 #include <memory>
+#include <numeric>
 #include <random>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
`std::accumulate` comes from `<numeric>`, but `<numeric>` is not implicitly included by `<algorithm>` in MSVC.

Split from #15310.

#15213