### PR TITLE
[XLA] Remove unused dlfcn.h and implement sincos[f] for MSVC

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -15,7 +15,6 @@ package_group(
 )
 
 load(":build_defs.bzl", "runtime_copts")
-load("//tensorflow:tensorflow.bzl", "if_windows")
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
 load("//tensorflow/compiler/xla:xla.bzl", "ORC_JIT_MEMORY_MAPPER_TARGETS")
@@ -150,7 +149,11 @@ cc_library(
 
 cc_library(
     name = "simple_orc_jit",
-    srcs = ["simple_orc_jit.cc"] + if_windows(["windows_compatibility.h"]),
+    srcs = [
+        "simple_orc_jit.cc",
+        "windows_compatibility.h",
+        "windows_compatibility.cc",
+    ],
     hdrs = ["simple_orc_jit.h"],
     deps = [
         ":compiler_functor",

--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -15,6 +15,7 @@ package_group(
 )
 
 load(":build_defs.bzl", "runtime_copts")
+load("//tensorflow:tensorflow.bzl", "if_windows")
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
 load("//tensorflow/compiler/xla:xla.bzl", "ORC_JIT_MEMORY_MAPPER_TARGETS")
@@ -149,7 +150,7 @@ cc_library(
 
 cc_library(
     name = "simple_orc_jit",
-    srcs = ["simple_orc_jit.cc"],
+    srcs = ["simple_orc_jit.cc"] + if_windows(["windows_compatibility.h"]),
     hdrs = ["simple_orc_jit.h"],
     deps = [
         ":compiler_functor",

--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -151,8 +151,8 @@ cc_library(
     name = "simple_orc_jit",
     srcs = [
         "simple_orc_jit.cc",
-        "windows_compatibility.h",
         "windows_compatibility.cc",
+        "windows_compatibility.h",
     ],
     hdrs = ["simple_orc_jit.h"],
     deps = [

--- a/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
+++ b/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
@@ -37,12 +37,9 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/cpu/runtime_matmul.h"
 #include "tensorflow/compiler/xla/service/cpu/runtime_single_threaded_conv2d.h"
 #include "tensorflow/compiler/xla/service/cpu/runtime_single_threaded_matmul.h"
+#include "tensorflow/compiler/xla/service/cpu/windows_compatibility.h"
 #include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/core/platform/logging.h"
-
-#ifdef _MSC_VER
-#include "tensorflow/compiler/xla/service/cpu/windows_compatibility.h"
-#endif
 
 namespace xla {
 namespace cpu {

--- a/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
+++ b/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/compiler/xla/service/cpu/simple_orc_jit.h"
 
-#include <dlfcn.h>
 #include <stdint.h>
 #include <algorithm>
 #include <list>
@@ -40,6 +39,19 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/cpu/runtime_single_threaded_matmul.h"
 #include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/core/platform/logging.h"
+
+#ifdef _MSC_VER
+extern "C" {
+void sincos(double x, double *sin, double *cos) {
+  *sin = std::sin(x);
+  *cos = std::cos(x);
+}
+void sincosf(float x, float *sin, float *cos) {
+  *sin = std::sinf(x);
+  *cos = std::cosf(x);
+}
+}
+#endif
 
 namespace xla {
 namespace cpu {

--- a/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
+++ b/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
@@ -41,16 +41,7 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 
 #ifdef _MSC_VER
-extern "C" {
-void sincos(double x, double *sin, double *cos) {
-  *sin = std::sin(x);
-  *cos = std::cos(x);
-}
-void sincosf(float x, float *sin, float *cos) {
-  *sin = std::sinf(x);
-  *cos = std::cosf(x);
-}
-}
+#include "tensorflow/compiler/xla/service/cpu/windows_compatibility.h"
 #endif
 
 namespace xla {

--- a/tensorflow/compiler/xla/service/cpu/windows_compatibility.cc
+++ b/tensorflow/compiler/xla/service/cpu/windows_compatibility.cc
@@ -13,18 +13,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_CPU_WINDOWS_COMPATIBILITY_H_
-#define TENSORFLOW_COMPILER_XLA_SERVICE_CPU_WINDOWS_COMPATIBILITY_H_
+#include "tensorflow/compiler/xla/service/cpu/windows_compatibility.h"
 
 #ifdef _MSC_VER
 
-extern "C" {
+#include <math.h>
 
-void sincos(double x, double *sinv, double *cosv);
-void sincosf(float x, float *sinv, float *cosv);
+void sincos(double x, double *sinv, double *cosv) {
+  *sinv = sin(x);
+  *cosv = cos(x);
+}
 
+void sincosf(float x, float *sinv, float *cosv) {
+  *sinv = sinf(x);
+  *cosv = cosf(x);
 }
 
 #endif  // _MSC_VER
-
-#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_CPU_WINDOWS_COMPATIBILITY_H_

--- a/tensorflow/compiler/xla/service/cpu/windows_compatibility.h
+++ b/tensorflow/compiler/xla/service/cpu/windows_compatibility.h
@@ -1,0 +1,35 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_CPU_WINDOWS_COMPATIBILITY_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_CPU_WINDOWS_COMPATIBILITY_H_
+
+#include <math.h>
+
+extern "C" {
+
+void sincos(double x, double *sinv, double *cosv) {
+  *sinv = sin(x);
+  *cosv = cos(x);
+}
+
+void sincosf(float x, float *sinv, float *cosv) {
+  *sinv = sinf(x);
+  *cosv = cosf(x);
+}
+
+}
+
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_CPU_WINDOWS_COMPATIBILITY_H_

--- a/tensorflow/compiler/xla/service/cpu/windows_compatibility.h
+++ b/tensorflow/compiler/xla/service/cpu/windows_compatibility.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 extern "C" {
 
+// MSVC does not have sincos[f].
 void sincos(double x, double *sinv, double *cosv);
 void sincosf(float x, float *sinv, float *cosv);
 


### PR DESCRIPTION
Split from #15310.

#15213