### PR TITLE
[XLA] Use simplified version of TF_ASSIGN_OR_RETURN for MSVC

### DIFF
--- a/tensorflow/compiler/xla/status_macros.h
+++ b/tensorflow/compiler/xla/status_macros.h
@@ -196,34 +196,8 @@ class StatusAdaptorForMacros {
 #define TF_STATUS_MACROS_CONCAT_NAME(x, y) TF_STATUS_MACROS_CONCAT_IMPL(x, y)
 #define TF_STATUS_MACROS_CONCAT_IMPL(x, y) x##y
 
-#ifdef _MSC_VER
-
-#define TF_ASSIGN_OR_RETURN(lhs, rexpr)                                   \
-  TF_ASSIGN_OR_RETURN_IMPL(TF_STATUS_MACROS_CONCAT_NAME(_status_or_value, \
-                                                        __COUNTER__),     \
-                           lhs, rexpr)
-
-#define TF_ASSIGN_OR_RETURN_IMPL(statusor, lhs, rexpr) \
-  auto statusor = (rexpr);                             \
-  if (TF_PREDICT_FALSE(!statusor.ok())) {              \
-    return statusor.status();                          \
-  }                                                    \
-  lhs = std::move(statusor.ValueOrDie())
-
-#else
-
-#define TF_ASSIGN_OR_RETURN(...)                                             \
-  TF_STATUS_MACRO_GET_VARIADIC_IMPL(__VA_ARGS__, TF_ASSIGN_OR_RETURN_IMPL_3, \
-                                    TF_ASSIGN_OR_RETURN_IMPL_2)              \
-  (__VA_ARGS__)
-
-#define TF_STATUS_MACRO_GET_VARIADIC_IMPL(_1, _2, _3, NAME, ...) NAME
-
-#define TF_ASSIGN_OR_RETURN_IMPL_2(lhs, rexpr) \
-  TF_ASSIGN_OR_RETURN_IMPL_3(lhs, rexpr)
-
-#define TF_ASSIGN_OR_RETURN_IMPL_3(lhs, rexpr) \
-  TF_ASSIGN_OR_RETURN_IMPL(                    \
+#define TF_ASSIGN_OR_RETURN(lhs, rexpr) \
+  TF_ASSIGN_OR_RETURN_IMPL(             \
       TF_STATUS_MACROS_CONCAT_NAME(_status_or_value, __COUNTER__), lhs, rexpr)
 
 #define TF_ASSIGN_OR_RETURN_IMPL(statusor, lhs, rexpr) \
@@ -232,7 +206,5 @@ class StatusAdaptorForMacros {
     return statusor.status();                          \
   }                                                    \
   lhs = std::move(statusor.ValueOrDie())
-
-#endif
 
 #endif  // TENSORFLOW_COMPILER_XLA_STATUS_MACROS_H_

--- a/tensorflow/compiler/xla/status_macros.h
+++ b/tensorflow/compiler/xla/status_macros.h
@@ -196,6 +196,22 @@ class StatusAdaptorForMacros {
 #define TF_STATUS_MACROS_CONCAT_NAME(x, y) TF_STATUS_MACROS_CONCAT_IMPL(x, y)
 #define TF_STATUS_MACROS_CONCAT_IMPL(x, y) x##y
 
+#ifdef _MSC_VER
+
+#define TF_ASSIGN_OR_RETURN(lhs, rexpr)                                   \
+  TF_ASSIGN_OR_RETURN_IMPL(TF_STATUS_MACROS_CONCAT_NAME(_status_or_value, \
+                                                        __COUNTER__),     \
+                           lhs, rexpr)
+
+#define TF_ASSIGN_OR_RETURN_IMPL(statusor, lhs, rexpr) \
+  auto statusor = (rexpr);                             \
+  if (TF_PREDICT_FALSE(!statusor.ok())) {              \
+    return statusor.status();                          \
+  }                                                    \
+  lhs = std::move(statusor.ValueOrDie())
+
+#else
+
 #define TF_ASSIGN_OR_RETURN(...)                                             \
   TF_STATUS_MACRO_GET_VARIADIC_IMPL(__VA_ARGS__, TF_ASSIGN_OR_RETURN_IMPL_3, \
                                     TF_ASSIGN_OR_RETURN_IMPL_2)              \
@@ -216,5 +232,7 @@ class StatusAdaptorForMacros {
     return statusor.status();                          \
   }                                                    \
   lhs = std::move(statusor.ValueOrDie())
+
+#endif
 
 #endif  // TENSORFLOW_COMPILER_XLA_STATUS_MACROS_H_


### PR DESCRIPTION
This simplified version also works for GCC as well actually.

Split from #15310.

#15213