### PR TITLE
added note about weights gradient in compute_weighted_loss

### DIFF
--- a/tensorflow/python/ops/losses/losses_impl.py
+++ b/tensorflow/python/ops/losses/losses_impl.py
@@ -157,6 +157,13 @@ def compute_weighted_loss(
     ValueError: If `weights` is `None` or the shape is not compatible with
       `losses`, or if the number of dimensions (rank) of either `losses` or
       `weights` is missing.
+
+  Note:
+    When calculating the gradient of a weighted loss contributions from
+    both `losses` and `weights` are considered. If your `weights` depend
+    on some model parameters but you do not want this to affect the loss
+    gradient, you need to apply @{tf.stop_gradient} to `weights` before
+    passing them to `compute_weighted_loss`.
   """
   Reduction.validate(reduction)
   with ops.name_scope(scope, "weighted_loss", (losses, weights)):


### PR DESCRIPTION
Added a note concerning the gradient computation w.r.t. weights in `losses.compute_weighted_loss`, 
see #15046.

I have only added it to this function, and not the other losses (like mean_squared_error) because it is a rare cornercase that should be documented somewhere, but is of no relevance to most users. 