### PR TITLE
Use a trailing period to define floating point constant.

### DIFF
--- a/tensorflow/docs_src/get_started/get_started.md
+++ b/tensorflow/docs_src/get_started/get_started.md
@@ -375,7 +375,7 @@ estimator = tf.estimator.LinearRegressor(feature_columns=feature_columns)
 x_train = np.array([1., 2., 3., 4.])
 y_train = np.array([0., -1., -2., -3.])
 x_eval = np.array([2., 5., 8., 1.])
-y_eval = np.array([-1.01, -4.1, -7, 0.])
+y_eval = np.array([-1.01, -4.1, -7., 0.])
 input_fn = tf.estimator.inputs.numpy_input_fn(
     {"x": x_train}, y_train, batch_size=4, num_epochs=None, shuffle=True)
 train_input_fn = tf.estimator.inputs.numpy_input_fn(


### PR DESCRIPTION
In the example code for basic usage of tf.estimator, the array y_eval uses the constant "-7", when the rest of surrounding constants use trailing periods.  The corresponding code for a custom estimator has the trailing period.  (compare line 378 to line 450)