### PR TITLE
fix random_distributions_test

### DIFF
--- a/tensorflow/core/lib/random/random_distributions_test.cc
+++ b/tensorflow/core/lib/random/random_distributions_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <math.h>
 #include <algorithm>
 #include <functional>
+#include <numeric>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
[iota](http://en.cppreference.com/w/cpp/algorithm/iota) is declared in \<numeric\>
