### PR TITLE
RGB<->YIQ colorspace conversion

### DIFF
--- a/tensorflow/python/ops/image_ops.py
+++ b/tensorflow/python/ops/image_ops.py
@@ -49,6 +49,10 @@ See the @{$python/image} guide.
 @@grayscale_to_rgb
 @@hsv_to_rgb
 @@rgb_to_hsv
+@@rgb_to_yiq
+@@yiq_to_rgb
+@@rgb_to_yuv
+@@yuv_to_rgb
 @@convert_image_dtype
 @@adjust_brightness
 @@random_brightness

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1636,7 +1636,7 @@ def yiq_to_rgb(images):
   images = ops.convert_to_tensor(images, name='images')
   kernel = ops.convert_to_tensor(_yiq_to_rgb_kernel, dtype=images.dtype, name='kernel')
   ndims = images.get_shape().ndims
-  return math_ops.tensordot(images, _yiq_to_rgb_kernel, axes=[[ndims-1], [0]])
+  return math_ops.tensordot(images, kernel, axes=[[ndims-1], [0]])
 
 
 _rgb_to_yuv_kernel = [[0.299, -0.14714119, 0.61497538],
@@ -1660,7 +1660,7 @@ def rgb_to_yuv(images):
   """
   images = ops.convert_to_tensor(images, name='images')
   ndims = images.get_shape().ndims
-  return math_ops.tensordot(images, _rgb_to_yuv_kernel, axes=[[ndims-1], [0]])
+  return math_ops.tensordot(images, kernel, axes=[[ndims-1], [0]])
 
 
 _yuv_to_rgb_kernel = [[1, 1, 1],
@@ -1685,5 +1685,5 @@ def yuv_to_rgb(images):
   """
   images = ops.convert_to_tensor(images, name='images')
   ndims = images.get_shape().ndims
-  return math_ops.tensordot(images, _yuv_to_rgb_kernel, axes=[[ndims-1], [0]])
+  return math_ops.tensordot(images, kernel, axes=[[ndims-1], [0]])
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1659,6 +1659,7 @@ def rgb_to_yuv(images):
     images: tensor with the same shape as `images`.
   """
   images = ops.convert_to_tensor(images, name='images')
+  kernel = ops.convert_to_tensor(_rgb_to_yuv_kernel, dtype=images.dtype, name='kernel')
   ndims = images.get_shape().ndims
   return math_ops.tensordot(images, kernel, axes=[[ndims-1], [0]])
 
@@ -1684,6 +1685,7 @@ def yuv_to_rgb(images):
     images: tensor with the same shape as `images`.
   """
   images = ops.convert_to_tensor(images, name='images')
+  kernel = ops.convert_to_tensor(_yuv_to_rgb_kernel, dtype=images.dtype, name='kernel')
   ndims = images.get_shape().ndims
   return math_ops.tensordot(images, kernel, axes=[[ndims-1], [0]])
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1607,7 +1607,10 @@ def rgb_to_yiq(images):
   Returns:
     images: tensor with the same shape as `images`.
   """
-  return math_ops.tensordot(images, _rgb_to_yiq_kernel, axes=[[3], [0]])
+  images = ops.convert_to_tensor(images, name='images')
+  kernel = ops.convert_to_tensor(_rgb_to_yiq_kernel, dtype=images.dtype, name='kernel')
+  ndims = images.get_shape().ndims
+  return math_ops.tensordot(images, kernel, axes=[[ndims-1], [0]])
 
 
 _yiq_to_rgb_kernel = [[1, 1, 1],
@@ -1630,7 +1633,10 @@ def yiq_to_rgb(images):
   Returns:
     images: tensor with the same shape as `images`.
   """
-  return math_ops.tensordot(images, _yiq_to_rgb_kernel, axes=[[3], [0]])
+  images = ops.convert_to_tensor(images, name='images')
+  kernel = ops.convert_to_tensor(_yiq_to_rgb_kernel, dtype=images.dtype, name='kernel')
+  ndims = images.get_shape().ndims
+  return math_ops.tensordot(images, _yiq_to_rgb_kernel, axes=[[ndims-1], [0]])
 
 
 _rgb_to_yuv_kernel = [[0.299, -0.14714119, 0.61497538],
@@ -1652,7 +1658,9 @@ def rgb_to_yuv(images):
   Returns:
     images: tensor with the same shape as `images`.
   """
-  return math_ops.tensordot(images, _rgb_to_yuv_kernel, axes=[[3], [0]])
+  images = ops.convert_to_tensor(images, name='images')
+  ndims = images.get_shape().ndims
+  return math_ops.tensordot(images, _rgb_to_yuv_kernel, axes=[[ndims-1], [0]])
 
 
 _yuv_to_rgb_kernel = [[1, 1, 1],
@@ -1675,5 +1683,7 @@ def yuv_to_rgb(images):
   Returns:
     images: tensor with the same shape as `images`.
   """
-  return math_ops.tensordot(images, _yuv_to_rgb_kernel, axes=[[3], [0]])
+  images = ops.convert_to_tensor(images, name='images')
+  ndims = images.get_shape().ndims
+  return math_ops.tensordot(images, _yuv_to_rgb_kernel, axes=[[ndims-1], [0]])
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1586,3 +1586,94 @@ def non_max_suppression(boxes,
     return gen_image_ops._non_max_suppression_v2(boxes, scores, max_output_size,
                                                  iou_threshold)
     # pylint: enable=protected-access
+
+
+_rgb_to_yiq_kernel = [[0.299, 0.59590059, 0.2115],
+                      [0.587, -0.27455667, -0.52273617],
+                      [0.114, -0.32134392, 0.31119955]]
+
+
+def rgb_to_yiq(images):
+  """Converts one or more images from RGB to YIQ.
+
+  Outputs a tensor of the same shape as the `images` tensor, containing the YIQ
+  value of the pixels.
+  The output is only well defined if the value in images are in [0,1].
+
+  Args:
+    images: 2-D or higher rank. Image data to convert. Last dimension must be
+    size 3.
+
+  Returns:
+    images: tensor with the same shape as `images`.
+  """
+  return math_ops.tensordot(images, _rgb_to_yiq_kernel, axes=[[3], [0]])
+
+
+_yiq_to_rgb_kernel = [[1, 1, 1],
+                      [0.95598634, -0.27201283, -1.10674021],
+                      [0.6208248, -0.64720424, 1.70423049]]
+
+
+def yiq_to_rgb(images):
+  """Converts one or more images from YIQ to RGB.
+
+  Outputs a tensor of the same shape as the `images` tensor, containing the RGB
+  value of the pixels.
+  The output is only well defined if the Y value in images are in [0,1],
+  I value are in [-0.5957,0.5957] and Q value are in [-0.5226,0.5226].
+
+  Args:
+    images: 2-D or higher rank. Image data to convert. Last dimension must be
+    size 3.
+
+  Returns:
+    images: tensor with the same shape as `images`.
+  """
+  return math_ops.tensordot(images, _yiq_to_rgb_kernel, axes=[[3], [0]])
+
+
+_rgb_to_yuv_kernel = [[0.299, -0.14714119, 0.61497538],
+                      [0.587, -0.28886916, -0.51496512],
+                      [0.114, 0.43601035, -0.10001026]]
+
+
+def rgb_to_yuv(images):
+  """Converts one or more images from RGB to YUV.
+
+  Outputs a tensor of the same shape as the `images` tensor, containing the YUV
+  value of the pixels.
+  The output is only well defined if the value in images are in [0,1].
+
+  Args:
+    images: 2-D or higher rank. Image data to convert. Last dimension must be
+    size 3.
+
+  Returns:
+    images: tensor with the same shape as `images`.
+  """
+  return math_ops.tensordot(images, _rgb_to_yuv_kernel, axes=[[3], [0]])
+
+
+_yuv_to_rgb_kernel = [[1, 1, 1],
+                      [0, -0.394642334, 2.03206185],
+                      [1.13988303, -0.58062185, 0]]
+
+
+def yuv_to_rgb(images):
+  """Converts one or more images from YUV to RGB.
+
+  Outputs a tensor of the same shape as the `images` tensor, containing the RGB
+  value of the pixels.
+  The output is only well defined if the Y value in images are in [0,1],
+  U and V value are in [-0.5,0.5].
+
+  Args:
+    images: 2-D or higher rank. Image data to convert. Last dimension must be
+    size 3.
+
+  Returns:
+    images: tensor with the same shape as `images`.
+  """
+  return math_ops.tensordot(images, _yuv_to_rgb_kernel, axes=[[3], [0]])
+

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -94,7 +94,7 @@ class RGBToYIQTest(test_util.TensorFlowTestCase):
     shape = (batch_size, 2, 7, 3)
 
     for nptype in [np.float32, np.float64]:
-      inp = np.random.randint(0, 255, *shape).astype(nptype) / 255
+      inp = np.random.rand(*shape).astype(nptype)
 
       # Convert to YIQ and back, as a batch and individually
       with self.test_session(use_gpu=True) as sess:
@@ -109,9 +109,9 @@ class RGBToYIQTest(test_util.TensorFlowTestCase):
         batch1, batch2, join1, join2 = sess.run([batch1, batch2, join1, join2])
 
       # Verify that processing batch elements together is the same as separate
-      self.assertAllClose(batch1, join1)
-      self.assertAllClose(batch2, join2)
-      self.assertAllClose(batch2, inp)
+      self.assertAllClose(batch1, join1, rtol=1e-4, atol=1e-4)
+      self.assertAllClose(batch2, join2, rtol=1e-4, atol=1e-4)
+      self.assertAllClose(batch2, inp, rtol=1e-4, atol=1e-4)
 
 
 class RGBToYUVTest(test_util.TensorFlowTestCase):
@@ -123,7 +123,7 @@ class RGBToYUVTest(test_util.TensorFlowTestCase):
     shape = (batch_size, 2, 7, 3)
 
     for nptype in [np.float32, np.float64]:
-      inp = np.random.randint(0, 255, *shape).astype(nptype) / 255
+      inp = np.random.rand(shape).astype(nptype)
 
       # Convert to YUV and back, as a batch and individually
       with self.test_session(use_gpu=True) as sess:
@@ -138,9 +138,9 @@ class RGBToYUVTest(test_util.TensorFlowTestCase):
         batch1, batch2, join1, join2 = sess.run([batch1, batch2, join1, join2])
 
       # Verify that processing batch elements together is the same as separate
-      self.assertAllClose(batch1, join1)
-      self.assertAllClose(batch2, join2)
-      self.assertAllClose(batch2, inp)
+      self.assertAllClose(batch1, join1, rtol=1e-4, atol=1e-4)
+      self.assertAllClose(batch2, join2, rtol=1e-4, atol=1e-4)
+      self.assertAllClose(batch2, inp, rtol=1e-4, atol=1e-4)
 
 
 class GrayscaleToRGBTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -123,7 +123,7 @@ class RGBToYUVTest(test_util.TensorFlowTestCase):
     shape = (batch_size, 2, 7, 3)
 
     for nptype in [np.float32, np.float64]:
-      inp = np.random.rand(shape).astype(nptype)
+      inp = np.random.rand(*shape).astype(nptype)
 
       # Convert to YUV and back, as a batch and individually
       with self.test_session(use_gpu=True) as sess:

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -85,6 +85,64 @@ class RGBToHSVTest(test_util.TensorFlowTestCase):
       self.assertAllClose(rgb_tf, rgb_np)
 
 
+class RGBToYIQTest(test_util.TensorFlowTestCase):
+
+  def testBatch(self):
+    # Build an arbitrary RGB image
+    np.random.seed(7)
+    batch_size = 5
+    shape = (batch_size, 2, 7, 3)
+
+    for nptype in [np.float32, np.float64]:
+      inp = np.random.randint(0, 255, *shape).astype(nptype) / 255
+
+      # Convert to YIQ and back, as a batch and individually
+      with self.test_session(use_gpu=True) as sess:
+        batch0 = constant_op.constant(inp)
+        batch1 = image_ops.rgb_to_yiq(batch0)
+        batch2 = image_ops.yiq_to_rgb(batch1)
+        split0 = array_ops.unstack(batch0)
+        split1 = list(map(image_ops.rgb_to_yiq, split0))
+        split2 = list(map(image_ops.yiq_to_rgb, split1))
+        join1 = array_ops.stack(split1)
+        join2 = array_ops.stack(split2)
+        batch1, batch2, join1, join2 = sess.run([batch1, batch2, join1, join2])
+
+      # Verify that processing batch elements together is the same as separate
+      self.assertAllClose(batch1, join1)
+      self.assertAllClose(batch2, join2)
+      self.assertAllClose(batch2, inp)
+
+
+class RGBToYUVTest(test_util.TensorFlowTestCase):
+
+  def testBatch(self):
+    # Build an arbitrary RGB image
+    np.random.seed(7)
+    batch_size = 5
+    shape = (batch_size, 2, 7, 3)
+
+    for nptype in [np.float32, np.float64]:
+      inp = np.random.randint(0, 255, *shape).astype(nptype) / 255
+
+      # Convert to YUV and back, as a batch and individually
+      with self.test_session(use_gpu=True) as sess:
+        batch0 = constant_op.constant(inp)
+        batch1 = image_ops.rgb_to_yuv(batch0)
+        batch2 = image_ops.yuv_to_rgb(batch1)
+        split0 = array_ops.unstack(batch0)
+        split1 = list(map(image_ops.rgb_to_yuv, split0))
+        split2 = list(map(image_ops.yuv_to_rgb, split1))
+        join1 = array_ops.stack(split1)
+        join2 = array_ops.stack(split2)
+        batch1, batch2, join1, join2 = sess.run([batch1, batch2, join1, join2])
+
+      # Verify that processing batch elements together is the same as separate
+      self.assertAllClose(batch1, join1)
+      self.assertAllClose(batch2, join2)
+      self.assertAllClose(batch2, inp)
+
+
 class GrayscaleToRGBTest(test_util.TensorFlowTestCase):
 
   def _RGBToGrayscale(self, images):

--- a/tensorflow/tools/api/golden/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.image.pbtxt
@@ -169,6 +169,14 @@ tf_module {
     argspec: "args=[\'images\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "rgb_to_yiq"
+    argspec: "args=[\'images\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "rgb_to_yuv"
+    argspec: "args=[\'images\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "rot90"
     argspec: "args=[\'image\', \'k\', \'name\'], varargs=None, keywords=None, defaults=[\'1\', \'None\'], "
   }
@@ -183,5 +191,13 @@ tf_module {
   member_method {
     name: "transpose_image"
     argspec: "args=[\'image\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "yiq_to_rgb"
+    argspec: "args=[\'images\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "yuv_to_rgb"
+    argspec: "args=[\'images\'], varargs=None, keywords=None, defaults=None"
   }
 }


### PR DESCRIPTION
Implementation of functions for colorspace conversion RGB <-> YIQ, according to [https://en.wikipedia.org/wiki/YIQ#Formulas](Wikipedia).
This PR adds CPP functions and python wrappers in tf.image namespace