### PR TITLE
MKL: Reverting PR #14478, which breaks Inception v3 with MKL.

### DIFF
--- a/tensorflow/core/kernels/slice_op.cc
+++ b/tensorflow/core/kernels/slice_op.cc
@@ -273,6 +273,7 @@ class MklSliceOp : public OpKernel {
       HANDLE_DIM(1);
       HANDLE_DIM(2);
       HANDLE_DIM(3);
+      HANDLE_DIM(4);
       HANDLE_DIM(5);
       HANDLE_DIM(6);
       HANDLE_DIM(7);


### PR DESCRIPTION
PR #14478 https://github.com/tensorflow/tensorflow/pull/14478 (based on commit e7b69e4) removed line 276 from  #ifdef INTEL_MKL section and breaks Inception v3 with MKL. Perhaps someone meant to remove line 202?