### PR TITLE
Fix adding elements to collections.deque.

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -120,7 +120,7 @@ def generate_batch(batch_size, num_skips, skip_window):
       batch[i * num_skips + j] = buffer[skip_window]
       labels[i * num_skips + j, 0] = buffer[context_word]
     if data_index == len(data):
-      buffer[:] = data[:span]
+      buffer.extend(data[0:span])
       data_index = span
     else:
       buffer.append(data[data_index])


### PR DESCRIPTION
In some cases, [word2vec_basic.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/word2vec/word2vec_basic.py#L123) will fail at L123 and throw the following error:
```
TypeError: sequence index must be integer, not 'slice'
```
It seams the ```text8``` dataset and parameters will not touch that line code, but I hit this issue when I run this script against my own dataset. This is caused by Python ```collections.deque``` doesn't support index by slice:
```
>>> from collections import deque
>>> d = deque('tensorflow')
>>> d[:]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: sequence index must be integer, not 'slice'
```
This PR fix this issue by using ```deque.extend```, and this is consistent with L114.