### PR TITLE
WIP: Remove invalid merge_repeated option from CTC beam decoder

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_CTCBeamSearchDecoder.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_CTCBeamSearchDecoder.pbtxt
@@ -55,12 +55,6 @@ END
 A scalar >= 0, <= beam_width (controls output size).
 END
   }
-  attr {
-    name: "merge_repeated"
-    description: <<END
-If true, merge repeated classes in output.
-END
-  }
   summary: "Performs beam search decoding on the logits given in input."
   description: <<END
 A note about the attribute merge_repeated: For the beam search decoder,

--- a/tensorflow/core/ops/ctc_ops.cc
+++ b/tensorflow/core/ops/ctc_ops.cc
@@ -142,7 +142,6 @@ REGISTER_OP("CTCBeamSearchDecoder")
     .Input("sequence_length: int32")
     .Attr("beam_width: int >= 1")
     .Attr("top_paths: int >= 1")
-    .Attr("merge_repeated: bool = true")
     .Output("decoded_indices: top_paths * int64")
     .Output("decoded_values: top_paths * int64")
     .Output("decoded_shape: top_paths * int64")
@@ -180,17 +179,14 @@ REGISTER_OP("CTCBeamSearchDecoder")
     .Doc(R"doc(
 Performs beam search decoding on the logits given in input.
 
-A note about the attribute merge_repeated: For the beam search decoder,
-this means that if consecutive entries in a beam are the same, only
-the first of these is emitted.  That is, when the top path is "A B B B B",
-"A B" is returned if merge_repeated = True but "A B B B B" is
-returned if merge_repeated = False.
+For the beam search decoder, if consecutive entries in a beam are the same,
+only the first of these is emitted.  That is, when the top path is "A B B B B",
+"A B" is returned.
 
 inputs: 3-D, shape: `(max_time x batch_size x num_classes)`, the logits.
 sequence_length: A vector containing sequence lengths, size `(batch)`.
 beam_width: A scalar >= 0 (beam search beam width).
 top_paths: A scalar >= 0, <= beam_width (controls output size).
-merge_repeated: If true, merge repeated classes in output.
 decoded_indices: A list (length: top_paths) of indices matrices.  Matrix j,
   size `(total_decoded_outputs[j] x 2)`, has indices of a
   `SparseTensor<int64, 2>`.  The rows store: [batch, time].

--- a/tensorflow/core/util/ctc/ctc_beam_search.h
+++ b/tensorflow/core/util/ctc/ctc_beam_search.h
@@ -81,9 +81,8 @@ class CTCBeamSearchDecoder : public CTCDecoder {
   // implementation, CTCBeamSearchDecoder<>::DefaultBeamScorer, generates the
   // standard beam search.
   CTCBeamSearchDecoder(int num_classes, int beam_width,
-                       BaseBeamScorer<CTCBeamState>* scorer, int batch_size = 1,
-                       bool merge_repeated = false)
-      : CTCDecoder(num_classes, batch_size, merge_repeated),
+                       BaseBeamScorer<CTCBeamState>* scorer, int batch_size = 1)
+      : CTCDecoder(num_classes, batch_size, false),
         beam_width_(beam_width),
         leaves_(beam_width),
         beam_scorer_(CHECK_NOTNULL(scorer)) {

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -229,20 +229,17 @@ def ctc_greedy_decoder(inputs, sequence_length, merge_repeated=True):
 
 
 def ctc_beam_search_decoder(inputs, sequence_length, beam_width=100,
-                            top_paths=1, merge_repeated=True):
+                            top_paths=1):
   """Performs beam search decoding on the logits given in input.
 
   **Note** The `ctc_greedy_decoder` is a special case of the
-  `ctc_beam_search_decoder` with `top_paths=1` and `beam_width=1` (but
-  that decoder is faster for this special case).
+  `ctc_beam_search_decoder` with `top_paths=1`, `beam_width=1`, and
+  `merge_repeated=True` (but that decoder is faster for this special case).
 
-  If `merge_repeated` is `True`, merge repeated classes in the output beams.
+  Repeated classes are merged in the output beam.s
   This means that if consecutive entries in a beam are the same,
   only the first of these is emitted.  That is, when the top path
-  is `A B B B B`, the return value is:
-
-    * `A B` if `merge_repeated = True`.
-    * `A B B B B` if `merge_repeated = False`.
+  is `A B B B B`, the return value is `A B`.
 
   Args:
     inputs: 3-D `float` `Tensor`, size
@@ -251,7 +248,6 @@ def ctc_beam_search_decoder(inputs, sequence_length, beam_width=100,
       having size `[batch_size]`.
     beam_width: An int scalar >= 0 (beam search beam width).
     top_paths: An int scalar >= 0, <= beam_width (controls output size).
-    merge_repeated: Boolean.  Default: True.
 
   Returns:
     A tuple `(decoded, log_probabilities)` where
@@ -269,8 +265,7 @@ def ctc_beam_search_decoder(inputs, sequence_length, beam_width=100,
 
   decoded_ixs, decoded_vals, decoded_shapes, log_probabilities = (
       gen_ctc_ops._ctc_beam_search_decoder(
-          inputs, sequence_length, beam_width=beam_width, top_paths=top_paths,
-          merge_repeated=merge_repeated))
+          inputs, sequence_length, beam_width=beam_width, top_paths=top_paths))
 
   return (
       [sparse_tensor.SparseTensor(ix, val, shape) for (ix, val, shape)


### PR DESCRIPTION
The CTC beam decoding implicitly collapses repeated characters as part of calculating the optimal path (i.e. 'AAA' will contribute probability mass through the path 'A').

So the correct CTC decoding behavior occurs when merge_repeated=False. In this case, it DOES merge repeated characters. The merge_repeated flag, when true, will merge repeated characters after characters have already been merged/blank symbols removed. As it stands now, the behavior is extremely misleading.

This PR removes the misleading parameter from the ctc beam search op.

Closes #9550.