### PR TITLE
Refactor methods for path calculation

### DIFF
--- a/tensorflow/tools/api/golden/tensorflow.resource_loader.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.resource_loader.pbtxt
@@ -1,8 +1,16 @@
 path: "tensorflow.resource_loader"
 tf_module {
   member_method {
+    name: "get_abs_data_path"
+    argspec: "args=[\'path\', \'depth\', \'frame\'], varargs=None, keywords=None, defaults=[\'0\'], "
+  }
+  member_method {
     name: "get_data_files_path"
-    argspec: "args=[], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'frame\'], varargs=None, keywords=None, defaults=[\'0\'], "
+  }
+  member_method {
+    name: "get_grandparent"
+    argspec: "args=[\'path\', \'degree\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "get_path_to_datafile"


### PR DESCRIPTION
@jart I really appreciate your advice. I've rewritten #15315 to be more "boring":
* `get_grandparent(path, degree)` -> a files grandparent of the given degree
* `get_abs_data_path(path, depth, frame=0)` -> path relative to a file upwards the callstack
* `get_data_files_path(frame=0)` -> no change in behavior, but now shared with other methods

They should be about boring enough to be useful and to be shared.

* This should resolve the issues with `get_data_files_path` by making it less brittle...
* And I think `get_abs_data_path` is how `get_path_to_datafile` should really look like?

Further thoughts on this are appreciated!