### PR TITLE
Issue #15572, support for unspecified spatial dimensions in layers.Conv3d_transposed

### DIFF
--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -1622,17 +1622,17 @@ class Conv3DTranspose(Conv3D):
       outputs.set_shape(out_shape)
 
     if self.use_bias:
-        if self.data_format == 'channels_first':
-            outputs_shape = outputs.shape.as_list()
-            outputs_4d = array_ops.reshape(outputs,
-                                           [outputs_shape[0], outputs_shape[1],
-                                            outputs_shape[2] * outputs_shape[3],
-                                            outputs_shape[4]])
-            outputs_4d = nn.bias_add(outputs_4d, self.bias, data_format='NCHW')
-            outputs = array_ops.reshape(outputs_4d, outputs_shape)
-        else:
-            outputs = nn.bias_add(outputs, self.bias, data_format='NHWC')
-
+      if self.data_format == 'channels_first':
+        outputs_shape = outputs.shape.as_list()
+        outputs_4d = array_ops.reshape(outputs,
+                                       [outputs_shape[0], outputs_shape[1],
+                                       outputs_shape[2] * outputs_shape[3],
+                                       outputs_shape[4]])
+        outputs_4d = nn.bias_add(outputs_4d, self.bias, data_format='NCHW')
+        outputs = array_ops.reshape(outputs_4d, outputs_shape)
+      else:
+        outputs = nn.bias_add(outputs, self.bias, data_format='NHWC')
+    
     if self.activation is not None:
       return self.activation(outputs)
     return outputs

--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -1622,22 +1622,16 @@ class Conv3DTranspose(Conv3D):
       outputs.set_shape(out_shape)
 
     if self.use_bias:
-      outputs_shape = outputs.shape.as_list()
-      if self.data_format == 'channels_first':
-        outputs_4d = array_ops.reshape(outputs, [
-            outputs_shape[0], outputs_shape[1],
-            outputs_shape[2] * outputs_shape[3], outputs_shape[4]
-        ])
-      else:
-        outputs_4d = array_ops.reshape(outputs, [
-            outputs_shape[0], outputs_shape[1] * outputs_shape[2],
-            outputs_shape[3], outputs_shape[4]
-        ])
-      outputs_4d = nn.bias_add(
-          outputs_4d,
-          self.bias,
-          data_format=utils.convert_data_format(self.data_format, ndim=4))
-      outputs = array_ops.reshape(outputs_4d, outputs_shape)
+        if self.data_format == 'channels_first':
+            outputs_shape = outputs.shape.as_list()
+            outputs_4d = array_ops.reshape(outputs,
+                                           [outputs_shape[0], outputs_shape[1],
+                                            outputs_shape[2] * outputs_shape[3],
+                                            outputs_shape[4]])
+            outputs_4d = nn.bias_add(outputs_4d, self.bias, data_format='NCHW')
+            outputs = array_ops.reshape(outputs_4d, outputs_shape)
+        else:
+            outputs = nn.bias_add(outputs, self.bias, data_format='NHWC')
 
     if self.activation is not None:
       return self.activation(outputs)

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -609,9 +609,9 @@ class Conv2DTransposeTest(test.TestCase):
     self.assertListEqual(layer.bias.get_shape().as_list(), [32])
 
   def testCreateConv2DTransposeUndefinedInputShape(self):
-	layer = conv_layers.Conv2DTranspose(4,3,activation=nn_ops.relu)
-	inputPlaceholder = placeholder(float32,shape=[1,None,None,1],name='input')
-	output = layer.apply(inputPlaceholder)
+    layer = conv_layers.Conv2DTranspose(4,3,activation=nn_ops.relu)
+    inputPlaceholder = placeholder(float32,shape=[1,None,None,1],name='input')
+    output = layer.apply(inputPlaceholder)
 
   def testConv2DTransposeFloat16(self):
     height, width = 7, 9
@@ -799,9 +799,9 @@ class Conv3DTransposeTest(test.TestCase):
     self.assertListEqual(layer.bias.get_shape().as_list(), [4])
 
   def testCreateConv3DTransposeUndefinedInputShape(self):
-	layer = conv_layers.Conv3DTranspose(4,3,activation=nn_ops.relu)
-	inputPlaceholder = placeholder(float32,shape=[1,None,None,None,1],name='input')
-	output = layer.apply(inputPlaceholder)
+    layer = conv_layers.Conv3DTranspose(4,3,activation=nn_ops.relu)
+    inputPlaceholder = placeholder(float32,shape=[1,None,None,None,1],name='input')
+    output = layer.apply(inputPlaceholder)
 
   def testCreateConv3DTransposeIntegerKernelSize(self):
     depth, height, width = 5, 7, 9

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -30,7 +30,7 @@ from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import variable_scope
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
-
+from tensorflow import placeholder, float32
 
 class ConvTest(test.TestCase):
 
@@ -608,6 +608,11 @@ class Conv2DTransposeTest(test.TestCase):
     self.assertListEqual(layer.kernel.get_shape().as_list(), [3, 3, 32, 4])
     self.assertListEqual(layer.bias.get_shape().as_list(), [32])
 
+  def testCreateConv2DTransposeUndefinedInputShape(self):
+	layer = conv_layers.Conv2DTranspose(4,3,activation=nn_ops.relu)
+	inputPlaceholder = placeholder(float32,shape=[1,None,None,1],name='input')
+	output = layer.apply(inputPlaceholder)
+
   def testConv2DTransposeFloat16(self):
     height, width = 7, 9
     images = random_ops.random_uniform((5, height, width, 4), dtype='float16')
@@ -792,6 +797,11 @@ class Conv3DTransposeTest(test.TestCase):
                          [5, depth + 2, height + 2, width + 2, 4])
     self.assertListEqual(layer.kernel.get_shape().as_list(), [3, 3, 3, 4, 32])
     self.assertListEqual(layer.bias.get_shape().as_list(), [4])
+
+  def testCreateConv3DTransposeUndefinedInputShape(self):
+	layer = conv_layers.Conv3DTranspose(4,3,activation=nn_ops.relu)
+	inputPlaceholder = placeholder(float32,shape=[1,None,None,None,1],name='input')
+	output = layer.apply(inputPlaceholder)
 
   def testCreateConv3DTransposeIntegerKernelSize(self):
     depth, height, width = 5, 7, 9


### PR DESCRIPTION
Patch to 3d transposed convolution to use the same code for adding biases that regular 3d conv uses.  This allows transposed convolution to add biases if the spatial dimensions are not specified and the dimension ordering is channel last.  The case with channel first ordering still requires spatial dimensions be specified for both conv3d and conv3d_transposed because add_bias doesn't support 5d dimension ordering specifications.