### PR TITLE
Optimize FusedBatchNorm (and fix a bug).

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -1118,7 +1118,7 @@ tf_cc_test(
     ],
 )
 
-tf_cc_test(
+tf_cuda_cc_test(
     name = "fused_batch_norm_op_test",
     size = "small",
     srcs = ["fused_batch_norm_op_test.cc"],

--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -22,13 +22,13 @@ limitations under the License.
 #include "tensorflow/core/util/stream_executor_util.h"
 #endif
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/kernels/fused_batch_norm_op.h"
 #include "tensorflow/core/util/tensor_format.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 using CPUDevice = Eigen::ThreadPoolDevice;
@@ -241,7 +241,6 @@ struct FusedBatchNorm<GPUDevice, T, U> {
 
     Tensor x_maybe_transformed = x;
     Tensor x_transformed;
-    Tensor y_transformed;
     perftools::gputools::DeviceMemory<T> y_ptr;
 
     if (tensor_format == FORMAT_NCHW) {
@@ -257,13 +256,13 @@ struct FusedBatchNorm<GPUDevice, T, U> {
           const_cast<const Tensor&>(x_maybe_transformed).tensor<T, 4>(),
           x_transformed.tensor<T, 4>());
       x_maybe_transformed = x_transformed;
-
-      OP_REQUIRES_OK(context, context->allocate_temp(
-                                  DataTypeToEnum<T>::value,
-                                  ShapeFromFormat(FORMAT_NCHW, batch_size,
-                                                  height, width, channels),
-                                  &y_transformed));
-      y_ptr = StreamExecutorUtil::AsDeviceMemory<T>(y_transformed);
+      // We do not allocate additional memory for y, because
+      // cudnnBatchNormalizationForwardTraining and
+      // cudnnBatchNormalizationForwardInference can perform the
+      // computation in place.
+      // NOTE: this property is not mentioned by the NVIDIA documentation,
+      // and may change in the future.
+      y_ptr = StreamExecutorUtil::AsDeviceMemory<T>(x_transformed);
     } else {
       context->SetStatus(
           errors::Internal("Unsupported tensor format: ", tensor_format));
@@ -344,7 +343,7 @@ struct FusedBatchNorm<GPUDevice, T, U> {
     if (tensor_format == FORMAT_NHWC) {
       functor::NCHWToNHWC<GPUDevice, T, 4>()(
           context->eigen_device<GPUDevice>(),
-          const_cast<const Tensor&>(y_transformed).tensor<T, 4>(),
+          const_cast<const Tensor&>(x_transformed).tensor<T, 4>(),
           y->tensor<T, 4>());
     }
   }

--- a/tensorflow/core/kernels/fused_batch_norm_op_test.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op_test.cc
@@ -13,6 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+// The current implementation of fused batch norm assumes that several
+// cudnn routines can perform the computation in place. This is not
+// mentioned by the NVIDIA documentation. If any of the large tests below
+// fails, this might mean the assumption is no longer true.
+
+#include <cmath>
 #include <vector>
 #include "tensorflow/core/framework/allocator.h"
 #include "tensorflow/core/framework/fake_input.h"
@@ -63,6 +69,150 @@ TEST_F(FusedBatchNormOpTest, Training) {
   test::ExpectTensorNear<float>(expected_variance, *GetOutput(2), 0.01);
 }
 
+TEST_F(FusedBatchNormOpTest, TrainingLargeFormatNHWC) {
+#if GOOGLE_CUDA
+  std::unique_ptr<Device> device(
+      DeviceFactory::NewDevice("GPU", {}, "/job:b/replica:0/task:0"));
+  SetDevice(DEVICE_GPU, std::move(device));
+#endif
+  TF_EXPECT_OK(NodeDefBuilder("batch_norm_op", "FusedBatchNorm")
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("epsilon", 0.001)
+                   .Attr("data_format", "NHWC")
+                   .Attr("is_training", true)
+                   .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  int N = 2, C = 4, H = 100, W = 100;
+  std::vector<float> input;
+  std::vector<float> scale;
+  std::vector<float> offset;
+
+  input.reserve(N * H * W * C);
+  for (int batch = 0; batch < N; ++batch)
+    for (int i = 0; i < H * W; ++i)
+      for (int feature = 0; feature < C; ++feature) input.push_back(2 * i + 1);
+  AddInputFromArray<float>(TensorShape({N, H, W, C}), input);
+  for (int feature = 0; feature < C; ++feature) {
+    scale.push_back(2.5);
+    offset.push_back(1.5);
+  }
+  AddInputFromArray<float>(TensorShape({C}), scale);
+  AddInputFromArray<float>(TensorShape({C}), offset);
+  AddInputFromArray<float>(TensorShape({0}), {});
+  AddInputFromArray<float>(TensorShape({0}), {});
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  float mean = H * W;
+  float variance = (2 * H * W - 1) * (2 * H * W + 1) / 3.0 - mean * mean;
+  std::vector<float> result;
+  result.reserve(N * H * W * C);
+  for (int batch = 0; batch < N; ++batch)
+    for (int i = 0; i < H * W; ++i)
+      for (int feature = 0; feature < C; ++feature)
+        result.push_back(2.5 * (2 * i + 1 - mean) / sqrt(variance + 0.001) +
+                         1.5);
+
+  Tensor expected(allocator(), DT_FLOAT, TensorShape({N, H, W, C}));
+  test::FillValues<float>(&expected, result);
+  test::ExpectTensorNear<float>(expected, *GetOutput(0), 0.01);
+
+  std::vector<float> mean_res, variance_res;
+  for (int feature = 0; feature < C; ++feature) {
+    mean_res.push_back(mean);
+    variance_res.push_back(variance * N * H * W / (N * H * W - 1.0));
+  }
+  Tensor expected_mean(allocator(), DT_FLOAT, TensorShape({C}));
+  test::FillValues<float>(&expected_mean, mean_res);
+  test::ExpectTensorNear<float>(expected_mean, *GetOutput(1), 0.01);
+  // For large tests such as this, the accumulated error in the
+  // variance computation is higher than 1. This is not surprising,
+  // because the variance ~ 10^7.
+  Tensor expected_variance(allocator(), DT_FLOAT, TensorShape({C}));
+  test::FillValues<float>(&expected_variance, variance_res);
+  test::ExpectTensorNear<float>(expected_variance, *GetOutput(2), 25.0);
+}
+
+TEST_F(FusedBatchNormOpTest, TrainingLargeFormatNCHW) {
+#if GOOGLE_CUDA
+  std::unique_ptr<Device> device(
+      DeviceFactory::NewDevice("GPU", {}, "/job:b/replica:0/task:0"));
+  SetDevice(DEVICE_GPU, std::move(device));
+#endif
+  TF_EXPECT_OK(NodeDefBuilder("batch_norm_op", "FusedBatchNorm")
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("epsilon", 0.001)
+                   .Attr("data_format", "NCHW")
+                   .Attr("is_training", true)
+                   .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  int N = 2, C = 4, H = 100, W = 100;
+  std::vector<float> input;
+  std::vector<float> scale;
+  std::vector<float> offset;
+
+  input.reserve(N * C * H * W);
+  for (int batch = 0; batch < N; ++batch)
+    for (int feature = 0; feature < C; ++feature)
+      for (int i = 0; i < H * W; ++i) input.push_back(2 * i + 1);
+  AddInputFromArray<float>(TensorShape({N, C, H, W}), input);
+  for (int feature = 0; feature < C; ++feature) {
+    scale.push_back(2.5);
+    offset.push_back(1.5);
+  }
+  AddInputFromArray<float>(TensorShape({C}), scale);
+  AddInputFromArray<float>(TensorShape({C}), offset);
+  AddInputFromArray<float>(TensorShape({0}), {});
+  AddInputFromArray<float>(TensorShape({0}), {});
+
+  Status status = RunOpKernel();
+#if GOOGLE_CUDA
+  TF_EXPECT_OK(status);
+
+  float mean = H * W;
+  float variance = (2 * H * W - 1) * (2 * H * W + 1) / 3.0 - mean * mean;
+  std::vector<float> result;
+  result.reserve(N * C * H * W);
+  for (int batch = 0; batch < N; ++batch)
+    for (int feature = 0; feature < C; ++feature)
+      for (int i = 0; i < H * W; ++i)
+        result.push_back(2.5 * (2 * i + 1 - mean) / sqrt(variance + 0.001) +
+                         1.5);
+
+  Tensor expected(allocator(), DT_FLOAT, TensorShape({N, C, H, W}));
+  test::FillValues<float>(&expected, result);
+  test::ExpectTensorNear<float>(expected, *GetOutput(0), 0.01);
+
+  std::vector<float> mean_res, variance_res;
+  for (int feature = 0; feature < C; ++feature) {
+    mean_res.push_back(mean);
+    variance_res.push_back(variance * N * H * W / (N * H * W - 1));
+  }
+  Tensor expected_mean(allocator(), DT_FLOAT, TensorShape({C}));
+  test::FillValues<float>(&expected_mean, mean_res);
+  test::ExpectTensorNear<float>(expected_mean, *GetOutput(1), 0.01);
+
+  Tensor expected_variance(allocator(), DT_FLOAT, TensorShape({C}));
+  test::FillValues<float>(&expected_variance, variance_res);
+  test::ExpectTensorNear<float>(expected_variance, *GetOutput(2), 10.0);
+#else  // The CPU version does not support format NCHW.
+  EXPECT_TRUE(StringPiece(status.ToString())
+                  .contains("The CPU implementation of FusedBatchNorm "
+                            "only supports NHWC tensor format for now."))
+      << status;
+#endif
+}
+
 TEST_F(FusedBatchNormOpTest, Inference) {
   TF_EXPECT_OK(NodeDefBuilder("batch_norm_op", "FusedBatchNorm")
                    .Input(FakeInput(DT_FLOAT))
@@ -86,6 +236,62 @@ TEST_F(FusedBatchNormOpTest, Inference) {
   Tensor expected(allocator(), DT_FLOAT, TensorShape({1, 1, 6, 2}));
   test::FillValues<float>(&expected, {-3.86, -3.86, -1.51, -1.51, 0.83, 0.83,
                                       3.17, 3.17, 5.51, 5.51, 7.86, 7.86});
+  test::ExpectTensorNear<float>(expected, *GetOutput(0), 0.01);
+}
+
+TEST_F(FusedBatchNormOpTest, InferenceLargeFormatNHWC) {
+#if GOOGLE_CUDA
+  std::unique_ptr<Device> device(
+      DeviceFactory::NewDevice("GPU", {}, "/job:b/replica:0/task:0"));
+  SetDevice(DEVICE_GPU, std::move(device));
+#endif
+  TF_EXPECT_OK(NodeDefBuilder("batch_norm_op", "FusedBatchNorm")
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("epsilon", 0.001)
+                   .Attr("data_format", "NHWC")
+                   .Attr("is_training", false)
+                   .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  int N = 2, C = 4, H = 100, W = 100;
+  std::vector<float> input;
+  std::vector<float> scale;
+  std::vector<float> offset;
+  std::vector<float> estimated_mean;
+  std::vector<float> estimated_variance;
+
+  input.reserve(N * H * W * C);
+  for (int batch = 0; batch < N; ++batch)
+    for (int i = 0; i < H * W; ++i)
+      for (int feature = 0; feature < C; ++feature)
+        input.push_back(1.7 * i + 1);
+  AddInputFromArray<float>(TensorShape({N, H, W, C}), input);
+  for (int feature = 0; feature < C; ++feature) {
+    scale.push_back(3.0);
+    offset.push_back(2.0);
+    estimated_mean.push_back(2 * feature + 1);
+    estimated_variance.push_back(13.0);
+  }
+  AddInputFromArray<float>(TensorShape({C}), scale);
+  AddInputFromArray<float>(TensorShape({C}), offset);
+  AddInputFromArray<float>(TensorShape({C}), estimated_mean);
+  AddInputFromArray<float>(TensorShape({C}), estimated_variance);
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  std::vector<float> result;
+  result.reserve(N * H * W * C);
+  for (int batch = 0; batch < N; ++batch)
+    for (int i = 0; i < H * W; ++i)
+      for (int feature = 0; feature < C; ++feature)
+        result.push_back(3 * (1.7 * i - 2 * feature) / sqrt(13.001) + 2.0);
+
+  Tensor expected(allocator(), DT_FLOAT, TensorShape({N, H, W, C}));
+  test::FillValues<float>(&expected, result);
   test::ExpectTensorNear<float>(expected, *GetOutput(0), 0.01);
 }
 

--- a/tensorflow/core/kernels/ops_testutil.cc
+++ b/tensorflow/core/kernels/ops_testutil.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #ifdef GOOGLE_CUDA
 #define EIGEN_USE_GPU
 #include "tensorflow/core/common_runtime/gpu/gpu_managed_allocator.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_util.h"
 #endif
 
 #include "tensorflow/core/kernels/ops_testutil.h"
@@ -55,7 +56,7 @@ Tensor* OpsTestBase::GetOutput(int output_index) {
       auto dst = managed_output->tensor_data();
       context_->eigen_gpu_device().memcpy(const_cast<char*>(dst.data()),
                                           src.data(), src.size());
-      context_->eigen_gpu_device().synchronize();
+      GPUUtil::Sync(device_.get());
       managed_outputs_[output_index] = managed_output;
     }
     output = managed_outputs_[output_index];


### PR DESCRIPTION
I discovered experimentally that `cudnn` computations can be performed in place. Therefore there is no need to allocate two temporary tensors in `FusedBatchNorm` for GPU and data format NHWC. One is enough. This lowers memory consumption, and hence increases the maximum possible batch size.

This might seem risky (because NVIDIA doesn't mention the property), but in fact the current implementation already uses it: by doing forward_input_or_allocate_output in `FusedBatchNormOp`.
If data format is NCHW, and the input is forwarded, then `cudnn` would be forced
to do the computation in place (see line 247). This is how I discovered that the whole approach works:
I was trying to see if forwarding the input is a bug or not.

I added several tests to ensure that the change is correct.

While doing this, I discovered that ops_testutil does not properly synchronize at the end.
The reason seems to be the call `context_->eigen_gpu_device().synchronize()`. Somehow
it does nothing. I think the problem is that Eigen is not compiled with the flag `EIGEN_CUDACC`.
So I changed it to `GPUUtil::Sync(device_.get())`.