### PR TITLE
update _DECORATED_OPS for each latest call

### DIFF
--- a/tensorflow/contrib/framework/python/ops/arg_scope.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope.py
@@ -103,9 +103,8 @@ def _kwarg_names(func):
 
 
 def _add_op(op):
-  key = arg_scope_func_key(op)
-  if key not in _DECORATED_OPS:
-    _DECORATED_OPS[key] = _kwarg_names(op)
+  key_op = _key_op(op)
+  _DECORATED_OPS[key_op] = _kwarg_names(op)
 
 
 @tf_contextlib.contextmanager

--- a/tensorflow/contrib/framework/python/ops/arg_scope.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope.py
@@ -103,7 +103,7 @@ def _kwarg_names(func):
 
 
 def _add_op(op):
-  key_op = _key_op(op)
+  key_op = arg_scope_func_key(op)
   _DECORATED_OPS[key_op] = _kwarg_names(op)
 
 

--- a/tensorflow/contrib/framework/python/ops/arg_scope_test.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope_test.py
@@ -40,10 +40,10 @@ def func3(args, a=None, b=1, c=2):
 
 @add_arg_scope
 def func4(x='x', y='y'):
-    if x:
-        pass
-    if y:
-        pass
+  if x:
+    pass
+  if y:
+    pass
 
 def _key_op(op):
   return getattr(op, '_key_op', str(op))
@@ -241,10 +241,10 @@ class ArgScopeTest(test.TestCase):
     func4_kwargs = ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h')
     for i in range(4):
         # redefine the function with different args
-        @add_arg_scope
-        def func4(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8):
-            pass
-        self.assertTupleEqual(arg_scoped_arguments(func4), func4_kwargs)
+      @add_arg_scope
+      def func4(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8):
+        pass
+      self.assertTupleEqual(arg_scoped_arguments(func4), func4_kwargs)
 
   def testDocString(self):
     self.assertEqual(func3.__doc__, 'Some cool doc string.')

--- a/tensorflow/contrib/framework/python/ops/arg_scope_test.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope_test.py
@@ -38,6 +38,12 @@ def func3(args, a=None, b=1, c=2):
   """Some cool doc string."""
   return (args, a, b, c)
 
+@add_arg_scope
+def func4(x='x', y='y'):
+    if x:
+        pass
+    if y:
+        pass
 
 def _key_op(op):
   return getattr(op, '_key_op', str(op))
@@ -230,6 +236,15 @@ class ArgScopeTest(test.TestCase):
           args, kwargs = func2(1)
           self.assertTupleEqual(args, func2_args)
           self.assertDictEqual(kwargs, func2_kwargs)
+
+  def testAddArgScopeRaceCondition(self):
+    func4_kwargs = ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h')
+    for i in range(4):
+        # redefine the function with different args
+        @add_arg_scope
+        def func4(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8):
+            pass
+        self.assertTupleEqual(arg_scoped_arguments(func4), func4_kwargs)
 
   def testDocString(self):
     self.assertEqual(func3.__doc__, 'Some cool doc string.')


### PR DESCRIPTION
This fixes a race condition where the arg list is not being reliably extracted during `add_arg_scope` .
The simple solution is to always update `_DECORATED_OPS` on each latest call to `_add_op`.

fixes #11923