### PR TITLE
Optimize FusedBatchNormGrad.

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -1118,7 +1118,7 @@ tf_cc_test(
     ],
 )
 
-tf_cc_test(
+tf_cuda_cc_test(
     name = "fused_batch_norm_op_test",
     size = "small",
     srcs = ["fused_batch_norm_op_test.cc"],

--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -22,13 +22,13 @@ limitations under the License.
 #include "tensorflow/core/util/stream_executor_util.h"
 #endif
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/kernels/fused_batch_norm_op.h"
 #include "tensorflow/core/util/tensor_format.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 using CPUDevice = Eigen::ThreadPoolDevice;
@@ -380,18 +380,17 @@ struct FusedBatchNormGrad<GPUDevice, T, U> {
     Tensor x_transformed;
 
     // Outputs
-    Tensor x_backprop_transformed;
     perftools::gputools::DeviceMemory<T> x_backprop_ptr;
 
     if (tensor_format == FORMAT_NCHW) {
       x_backprop_ptr = StreamExecutorUtil::AsDeviceMemory<T>(*x_backprop);
     } else if (tensor_format == FORMAT_NHWC) {
       // Transform inputs from 'NHWC' to 'NCHW'
-      OP_REQUIRES_OK(context, context->allocate_temp(
-                                  DataTypeToEnum<T>::value,
-                                  ShapeFromFormat(FORMAT_NCHW, batch_size,
-                                                  height, width, channels),
-                                  &y_backprop_transformed));
+      // We temporary use the output buffer. Note that here we assume
+      // that x_backprop is not one of the inputs forwarded.
+      y_backprop_transformed.UnsafeCopyFromInternal(
+          *x_backprop, DataTypeToEnum<T>::value,
+          ShapeFromFormat(FORMAT_NCHW, batch_size, height, width, channels));
       functor::NHWCToNCHW<GPUDevice, T, 4>()(
           context->eigen_device<GPUDevice>(),
           const_cast<const Tensor&>(y_backprop_maybe_transformed)
@@ -410,14 +409,12 @@ struct FusedBatchNormGrad<GPUDevice, T, U> {
           x_transformed.tensor<T, 4>());
       x_maybe_transformed = x_transformed;
 
-      // Allocate memory for transformed outputs in 'NCHW'
-      OP_REQUIRES_OK(context, context->allocate_temp(
-                                  DataTypeToEnum<T>::value,
-                                  ShapeFromFormat(FORMAT_NCHW, batch_size,
-                                                  height, width, channels),
-                                  &x_backprop_transformed));
-      x_backprop_ptr =
-          StreamExecutorUtil::AsDeviceMemory<T>(x_backprop_transformed);
+      // We do not allocate additional memory for x_backprop transformed,
+      // because cudnnBatchNormalizationBackward can perform the
+      // computation in place.
+      // NOTE: this property is not mentioned by the NVIDIA documentation,
+      // and may change in the future.
+      x_backprop_ptr = StreamExecutorUtil::AsDeviceMemory<T>(x_transformed);
     } else {
       context->SetStatus(
           errors::Internal("Unsupported tensor format: ", tensor_format));
@@ -467,7 +464,7 @@ struct FusedBatchNormGrad<GPUDevice, T, U> {
     if (tensor_format == FORMAT_NHWC) {
       functor::NCHWToNHWC<GPUDevice, T, 4>()(
           context->eigen_device<GPUDevice>(),
-          const_cast<const Tensor&>(x_backprop_transformed).tensor<T, 4>(),
+          const_cast<const Tensor&>(x_transformed).tensor<T, 4>(),
           x_backprop->tensor<T, 4>());
     }
   }
@@ -612,6 +609,8 @@ class FusedBatchNormGradOp : public OpKernel {
                     "saved variance must be 1-dimensional",
                     saved_maybe_inv_var_or_pop_var.shape().DebugString()));
 
+    // Note that the NHWC computation path relies on the output being
+    // allocated, rather than forwarded.
     Tensor* x_backprop = nullptr;
     OP_REQUIRES_OK(context,
                    context->allocate_output(0, x.shape(), &x_backprop));

--- a/tensorflow/core/kernels/fused_batch_norm_op_test.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op_test.cc
@@ -92,6 +92,11 @@ TEST_F(FusedBatchNormOpTest, Inference) {
 class FusedBatchNormGradOpTest : public OpsTestBase {};
 
 TEST_F(FusedBatchNormGradOpTest, Simple) {
+#if GOOGLE_CUDA
+  std::unique_ptr<Device> device(
+      DeviceFactory::NewDevice("GPU", {}, "/job:b/replica:0/task:0"));
+  SetDevice(DEVICE_GPU, std::move(device));
+#endif
   TF_EXPECT_OK(NodeDefBuilder("batch_norm_grad_op", "FusedBatchNormGrad")
                    .Input(FakeInput(DT_FLOAT))
                    .Input(FakeInput(DT_FLOAT))
@@ -107,7 +112,11 @@ TEST_F(FusedBatchNormGradOpTest, Simple) {
                            {1, 1, 7, 7, 4, 4, -3, -3, -11, -11, 13, 13});
   AddInputFromArray<float>(TensorShape({2}), {4, 4});
   AddInputFromArray<float>(TensorShape({2}), {1.833f, 1.833f});
+#if GOOGLE_CUDA
+  AddInputFromArray<float>(TensorShape({2}), {0.1319f, 0.1319f});
+#else
   AddInputFromArray<float>(TensorShape({2}), {57.472f, 57.472f});
+#endif
 
   TF_ASSERT_OK(RunOpKernel());
 
@@ -122,6 +131,94 @@ TEST_F(FusedBatchNormGradOpTest, Simple) {
 
   Tensor expected_offset(allocator(), DT_FLOAT, TensorShape({2}));
   test::FillValues<float>(&expected_offset, {27, 27});
+  test::ExpectTensorNear<float>(expected_offset, *GetOutput(2), 0.01);
+}
+
+TEST_F(FusedBatchNormGradOpTest, LargeFormatNHWC) {
+#if GOOGLE_CUDA
+  std::unique_ptr<Device> device(
+      DeviceFactory::NewDevice("GPU", {}, "/job:b/replica:0/task:0"));
+  SetDevice(DEVICE_GPU, std::move(device));
+#endif
+  TF_EXPECT_OK(NodeDefBuilder("batch_norm_grad_op", "FusedBatchNormGrad")
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("epsilon", 0.001)
+                   .Attr("data_format", "NHWC")
+                   .Finalize(node_def()));
+  TF_EXPECT_OK(InitOp());
+
+  int N = 2, C = 3, H = 100, W = 100;
+  std::vector<float> y_backprop;
+  std::vector<float> x;
+  std::vector<float> scale;
+  std::vector<float> saved_mean;
+  std::vector<float> saved_variance;
+  float variance;
+#if GOOGLE_CUDA  // cudnn saves the inverted variance in the forward pass
+  variance = 1.0 / sqrt(13.001);
+#else
+  variance = 13.0;
+#endif
+
+  y_backprop.reserve(N * H * W * C);
+  x.reserve(N * H * W * C);
+  for (int batch = 0; batch < N; ++batch)
+    for (int i = 0; i < H * W; ++i)
+      for (int feature = 0; feature < C; ++feature) {
+        y_backprop.push_back((i % 7) + 1);
+        x.push_back(i % 13);
+      }
+  for (int feature = 0; feature < C; ++feature) {
+    scale.push_back(1.5);
+    saved_mean.push_back(6.0 + feature);
+    saved_variance.push_back(variance);
+  }
+  AddInputFromArray<float>(TensorShape({N, H, W, C}), y_backprop);
+  AddInputFromArray<float>(TensorShape({N, H, W, C}), x);
+  AddInputFromArray<float>(TensorShape({C}), scale);
+  AddInputFromArray<float>(TensorShape({C}), saved_mean);
+  AddInputFromArray<float>(TensorShape({C}), saved_variance);
+
+  TF_ASSERT_OK(RunOpKernel());
+
+  std::vector<float> x_backprop;
+  std::vector<float> res_scale;
+  std::vector<float> res_offset;
+
+  float offset = 0.0;
+  for (int i = 0; i < H * W; ++i) offset += ((i % 7) + 1) * N;
+  for (int feature = 0; feature < C; ++feature) {
+    float feat_scale = 0.0;
+    for (int i = 0; i < H * W; ++i)
+      feat_scale += ((i % 7) + 1) * ((i % 13) - 6.0 - feature) / sqrt(13.001);
+    res_scale.push_back(feat_scale * N);
+    res_offset.push_back(offset);
+  }
+  for (int batch = 0; batch < N; ++batch)
+    for (int i = 0; i < H * W; ++i)
+      for (int feature = 0; feature < C; ++feature) {
+        float coef0 = 1.5 / sqrt(13.001);
+        float coef1 = res_scale[feature] / (N * H * W * sqrt(13.001));
+        float y_mean = offset / (N * H * W);
+        float y_centered = (i % 7) + 1 - y_mean;
+        x_backprop.push_back(coef0 *
+                             (y_centered - ((i % 13) - 6.0 - feature) * coef1));
+      }
+
+  Tensor expected_x(allocator(), DT_FLOAT, TensorShape({N, H, W, C}));
+  test::FillValues<float>(&expected_x, x_backprop);
+  test::ExpectTensorNear<float>(expected_x, *GetOutput(0), 0.01);
+
+  Tensor expected_scale(allocator(), DT_FLOAT, TensorShape({C}));
+  test::FillValues<float>(&expected_scale, res_scale);
+  test::ExpectTensorNear<float>(expected_scale, *GetOutput(1), 1.0);
+
+  Tensor expected_offset(allocator(), DT_FLOAT, TensorShape({C}));
+  test::FillValues<float>(&expected_offset, res_offset);
   test::ExpectTensorNear<float>(expected_offset, *GetOutput(2), 0.01);
 }
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/ops_testutil.cc
+++ b/tensorflow/core/kernels/ops_testutil.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #ifdef GOOGLE_CUDA
 #define EIGEN_USE_GPU
 #include "tensorflow/core/common_runtime/gpu/gpu_managed_allocator.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_util.h"
 #endif
 
 #include "tensorflow/core/kernels/ops_testutil.h"
@@ -55,7 +56,7 @@ Tensor* OpsTestBase::GetOutput(int output_index) {
       auto dst = managed_output->tensor_data();
       context_->eigen_gpu_device().memcpy(const_cast<char*>(dst.data()),
                                           src.data(), src.size());
-      context_->eigen_gpu_device().synchronize();
+      GPUUtil::Sync(device_.get());
       managed_outputs_[output_index] = managed_output;
     }
     output = managed_outputs_[output_index];


### PR DESCRIPTION
Reuse the output buffer and allocate only one temporary tensor, when data format is NHWC and
GPU is used. This is based on the observation that cudnn can perform the backward computation
in place. The same idea is used in PR #15601 . 

This lowers GPU memory consumption and may improve performance, because fewer distinct memory addresses are accessed. It also permits a higher batch size.

I've also added a new test for the gradient computation.