### PR TITLE
Support Negativo17 Fedora Packaging

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -948,6 +948,33 @@ def set_tf_cudnn_version(environ_cp):
   write_action_env_to_bazelrc('TF_CUDNN_VERSION', tf_cudnn_version)
 
 
+def set_tf_nvvm_location(environ_cp):
+  """Set NVVMIR_LIBRARY_DIR."""
+
+  for _ in range(_DEFAULT_PROMPT_ASK_ATTEMPTS):
+    default_nvvm_path = os.path.join(environ_cp.get('CUDA_TOOLKIT_PATH'), 'nvvm')
+    ask_nvvm_path = (r'Please specify the location where NVVM IR library is '
+                      'installed. [Default is %s]:') % (default_nvvm_path)
+    nvvm_install_path = get_from_env_or_user_or_default(
+        environ_cp, 'NVVMIR_LIBRARY_DIR', ask_nvvm_path, default_nvvm_path)
+
+    if os.path.exists(nvvm_install_path):
+      break
+
+    # Reset and Retry
+    print(
+        'Invalid path to NVVM IR library. %s does not exist:' % nvvm_install_path)
+
+  else:
+    raise UserInputError('Invalid NVVMIR_LIBRARY_DIR setting was provided %d '
+                         'times in a row. Assuming to be a scripting mistake.' %
+                         _DEFAULT_PROMPT_ASK_ATTEMPTS)
+
+  environ_cp['NVVMIR_LIBRARY_DIR'] = nvvm_install_path
+  write_action_env_to_bazelrc('NVVMIR_LIBRARY_DIR', nvvm_install_path)
+
+
+
 def get_native_cuda_compute_capabilities(environ_cp):
   """Get native cuda compute capabilities.
 
@@ -1296,6 +1323,7 @@ def main():
       'TF_CUDA_CONFIG_REPO' not in environ_cp):
     set_tf_cuda_version(environ_cp)
     set_tf_cudnn_version(environ_cp)
+    set_tf_nvvm_location(environ_cp)
     set_tf_cuda_compute_capabilities(environ_cp)
 
     set_tf_cuda_clang(environ_cp)

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -28,6 +28,7 @@ _CUDA_TOOLKIT_PATH = "CUDA_TOOLKIT_PATH"
 _TF_CUDA_VERSION = "TF_CUDA_VERSION"
 _TF_CUDNN_VERSION = "TF_CUDNN_VERSION"
 _CUDNN_INSTALL_PATH = "CUDNN_INSTALL_PATH"
+_NVVM_INSTALL_PATH = "NVVMIR_LIBRARY_DIR"
 _TF_CUDA_COMPUTE_CAPABILITIES = "TF_CUDA_COMPUTE_CAPABILITIES"
 _TF_CUDA_CONFIG_REPO = "TF_CUDA_CONFIG_REPO"
 _TF_DOWNLOAD_CLANG = "TF_DOWNLOAD_CLANG"
@@ -238,6 +239,16 @@ def _cudnn_install_basedir(repository_ctx):
   if not repository_ctx.path(cudnn_install_path).exists:
     auto_configure_fail("Cannot find cudnn install path.")
   return cudnn_install_path
+
+
+def _nvvm_install_basedir(repository_ctx, cuda_toolkit_path):
+  """Finds the cudnn install directory."""
+  nvvm_install_path = cuda_toolkit_path + '/nvvm/libdevice'
+  if _NVVM_INSTALL_PATH in repository_ctx.os.environ:
+    nvvm_install_path = repository_ctx.os.environ[_NVVM_INSTALL_PATH].strip()
+  if not repository_ctx.path(nvvm_install_path).exists:
+    auto_configure_fail("Cannot find NVVM install path.")
+  return nvvm_install_path
 
 
 def _matches_version(environ_version, detected_version):
@@ -576,6 +587,11 @@ def _find_cupti_lib(repository_ctx, cuda_config):
   if path.exists:
     return struct(file_name=file_name, path=str(path.realpath))
 
+  path = repository_ctx.path(
+      "%s/lib64/%s" % (cuda_config.cuda_toolkit_path, file_name))
+  if path.exists:
+    return struct(file_name=file_name, path=str(path.realpath))
+
   auto_configure_fail("Cannot find cupti library %s" % file_name)
 
 def _find_libs(repository_ctx, cuda_config):
@@ -619,6 +635,23 @@ def _find_libs(repository_ctx, cuda_config):
   }
 
 
+def _find_cupti_header_dir(repository_ctx, cuda_toolkit_path):
+  """Returns the path to the directory containing the CUPTI headers
+
+  Args:
+    repository_ctx: The repository context.
+    cuda_toolkit_path: The CUDA toolkit path.
+
+  Returns:
+    The path of the directory containing the CUPTI headers.
+  """
+  if repository_ctx.path(cuda_toolkit_path + "/extras/CUPTI/include").exists:
+    return cuda_toolkit_path + "/extras/CUPTI/include"
+  if repository_ctx.path(cuda_toolkit_path + "/include/cuda/CUPTI").exists:
+    return cuda_toolkit_path + "/include/cuda/CUPTI"
+  auto_configure_fail("Cannot find CUPTI headers under %s" % cuda_toolkit_path)
+
+
 def _find_cudnn_header_dir(repository_ctx, cudnn_install_basedir):
   """Returns the path to the directory containing cudnn.h
 
@@ -634,9 +667,28 @@ def _find_cudnn_header_dir(repository_ctx, cudnn_install_basedir):
     return cudnn_install_basedir
   if repository_ctx.path(cudnn_install_basedir + "/include/cudnn.h").exists:
     return cudnn_install_basedir + "/include"
+  if repository_ctx.path(cudnn_install_basedir + "/include/cuda/cudnn.h").exists:
+    return cudnn_install_basedir + "/include/cuda"
   if repository_ctx.path("/usr/include/cudnn.h").exists:
     return "/usr/include"
   auto_configure_fail("Cannot find cudnn.h under %s" % cudnn_install_basedir)
+
+
+def _find_cuda_header_dir(repository_ctx, cuda_toolkit_path):
+  """Returns the path to the directory containing cuda_runtime.h
+
+  Args:
+    repository_ctx: The repository context.
+    cuda_toolkit_path: The CUDA toolkit path.
+
+  Returns:
+    The path of the directory containing the CUDA runtime headers.
+  """
+  if repository_ctx.path(cuda_toolkit_path + "/include/cuda_runtime.h").exists:
+    return cuda_toolkit_path + "/include"
+  if repository_ctx.path(cuda_toolkit_path + "/include/cuda/cuda_runtime.h").exists:
+    return cuda_toolkit_path + "/include/cuda"
+  auto_configure_fail("Cannot find cuda_runtime.h under %s" % cuda_toolkit_path)
 
 
 def _find_cudnn_lib_path(repository_ctx, cudnn_install_basedir, symlink_files):
@@ -686,10 +738,12 @@ def _get_cuda_config(repository_ctx):
   cuda_toolkit_path = _cuda_toolkit_path(repository_ctx)
   cuda_version = _cuda_version(repository_ctx, cuda_toolkit_path, cpu_value)
   cudnn_install_basedir = _cudnn_install_basedir(repository_ctx)
+  nvvm_install_basedir = _nvvm_install_basedir(repository_ctx, cuda_toolkit_path)
   cudnn_version = _cudnn_version(repository_ctx, cudnn_install_basedir, cpu_value)
   return struct(
       cuda_toolkit_path = cuda_toolkit_path,
       cudnn_install_basedir = cudnn_install_basedir,
+      nvvm_install_basedir = nvvm_install_basedir,
       cuda_version = cuda_version,
       cudnn_version = cudnn_version,
       compute_capabilities = _compute_capabilities(repository_ctx),
@@ -935,18 +989,21 @@ def _create_local_cuda_repository(repository_ctx):
 
   cudnn_header_dir = _find_cudnn_header_dir(repository_ctx,
                                             cuda_config.cudnn_install_basedir)
+  cupti_header_dir = _find_cupti_header_dir(repository_ctx,
+                                            cuda_config.cuda_toolkit_path)
+  cuda_include_path = _find_cuda_header_dir(repository_ctx,
+                                            cuda_config.cuda_toolkit_path)
 
   # Set up symbolic links for the cuda toolkit by creating genrules to do
   # symlinking. We create one genrule for each directory we want to track under
   # cuda_toolkit_path
   cuda_toolkit_path = cuda_config.cuda_toolkit_path
-  cuda_include_path = cuda_toolkit_path + "/include"
   genrules = [_symlink_genrule_for_dir(repository_ctx,
       cuda_include_path, "cuda/include", "cuda-include")]
   genrules.append(_symlink_genrule_for_dir(repository_ctx,
-      cuda_toolkit_path + "/nvvm", "cuda/nvvm", "cuda-nvvm"))
+      cuda_config.nvvm_install_basedir, "cuda/nvvm/libdevice", "cuda-nvvm"))
   genrules.append(_symlink_genrule_for_dir(repository_ctx,
-      cuda_toolkit_path + "/extras/CUPTI/include",
+      cupti_header_dir,
       "cuda/extras/CUPTI/include", "cuda-extras"))
 
   cuda_libs = _find_libs(repository_ctx, cuda_config)
@@ -1091,6 +1148,7 @@ cuda_configure = repository_rule(
         _TF_DOWNLOAD_CLANG,
         _CUDA_TOOLKIT_PATH,
         _CUDNN_INSTALL_PATH,
+        _NVVM_INSTALL_PATH,
         _TF_CUDA_VERSION,
         _TF_CUDNN_VERSION,
         _TF_CUDA_COMPUTE_CAPABILITIES,


### PR DESCRIPTION
Support the [Negativo17](https://negativo17.org/nvidia-driver/) Nvidia driver packaging for Fedora. `libdevice` libraries are under `/usr/share/cuda`, includes are under `/usr/include/cuda` and libraries are under `/usr/lib64`. This PR should help #8264 too.

In addition, the gcc 5.3 in the Negativo17 repository (installed as `/usr/bin/gcc53`) only has a static non-PIC version of `libgomp.a`, so I have this local patch to force Tensorflow to link to the global (`/usr/lib64`) shared version:

````diff
diff --git a/tensorflow/contrib/cmake/tf_stream_executor.cmake b/tensorflow/contrib/cmake/tf_stream_executor.cmake
index 91ca33f4c4..7719ee096d 100644
--- a/tensorflow/contrib/cmake/tf_stream_executor.cmake
+++ b/tensorflow/contrib/cmake/tf_stream_executor.cmake
@@ -75,7 +75,7 @@ endif()
 #list(REMOVE_ITEM tf_stream_executor_srcs ${tf_stream_executor_test_srcs})
 
 if (NOT WIN32)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lgomp")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -l:libgomp.so.1")
 endif (NOT WIN32)
 add_library(tf_stream_executor OBJECT ${tf_stream_executor_srcs})
 
diff --git a/third_party/gpus/cuda/BUILD.tpl b/third_party/gpus/cuda/BUILD.tpl
index b752734a08..0ce972291e 100644
--- a/third_party/gpus/cuda/BUILD.tpl
+++ b/third_party/gpus/cuda/BUILD.tpl
@@ -109,7 +109,7 @@ cc_library(
         ".",
         "cuda/include",
     ],
-    linkopts = ["-lgomp"],
+    linkopts = ["-l:libgomp.so.1"],
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )
diff --git a/third_party/toolchains/gpus/cuda/BUILD b/third_party/toolchains/gpus/cuda/BUILD
index 39136de99c..6f697919fd 100644
--- a/third_party/toolchains/gpus/cuda/BUILD
+++ b/third_party/toolchains/gpus/cuda/BUILD
@@ -114,7 +114,7 @@ cc_library(
         ".",
         "cuda/include",
     ],
-    linkopts = ["-lgomp"],
+    linkopts = ["-l:libgomp.so.1"],
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )
````

Building with clang is a lot more difficult, as it'd require making Tensorflow's CUDA symlink repo look enough like the unpacked tarball to pass [this detection logic](https://github.com/jyknight/llvm-monorepo/blob/6a6c3cae76a0839429c0b552572c46af9b194b86/clang/lib/Driver/ToolChains/Cuda.cpp)!

My `.tf_configure.bazelrc` (for FC 26) looks like:

````
build --action_env PYTHON_BIN_PATH="/home/nicholas/miniconda3/bin/python"
build --action_env PYTHON_LIB_PATH="/home/nicholas/miniconda3/lib/python3.6/site-packages"
build --force_python=py3
build --host_force_python=py3
build --python_path="/home/nicholas/miniconda3/bin/python"
build --define with_jemalloc=true
build:gcp --define with_gcp_support=true
build:hdfs --define with_hdfs_support=true
build:s3 --define with_s3_support=true
build:xla --define with_xla_support=true
build:gdr --define with_gdr_support=true
build:verbs --define with_verbs_support=true
build --action_env TF_NEED_OPENCL_SYCL="0"
build --action_env TF_NEED_CUDA="1"
build --action_env CUDA_TOOLKIT_PATH="/usr"
build --action_env TF_CUDA_VERSION="8.0"
build --action_env CUDNN_INSTALL_PATH="/usr"
build --action_env TF_CUDNN_VERSION="7"
build --action_env NVVMIR_LIBRARY_DIR="/usr/share/cuda"
build --action_env TF_CUDA_COMPUTE_CAPABILITIES="6.1"
build --action_env TF_CUDA_CLANG="0"
build --action_env GCC_HOST_COMPILER_PATH="/usr/bin/gcc53"
build --config=cuda
test --config=cuda
build --define grpc_no_ares=true
build:opt --copt=-march=native
build:opt --host_copt=-march=native
build:opt --define with_default_optimizations=true
build --copt=-DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK
build --host_copt=-DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK
build:mkl --define using_mkl=true
build:mkl -c opt
build:monolithic --define framework_shared_object=false
build --define framework_shared_object=true
build:android --crosstool_top=//external:android/crosstool
build:android --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
build:android_arm --config=android
build:android_arm --cpu=armeabi-v7a
build:android_arm64 --config=android
build:android_arm64 --cpu=arm64-v8a
````