### PR TITLE
Fix an lib error while building with CUDA9.1

### DIFF
--- a/third_party/gpus/cuda/BUILD.tpl
+++ b/third_party/gpus/cuda/BUILD.tpl
@@ -46,6 +46,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     visibility = ["//visibility:public"],
 )
@@ -56,6 +57,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     linkopts = select({
         ":freebsd": [],
@@ -73,6 +75,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     visibility = ["//visibility:public"],
 )
@@ -84,6 +87,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     linkstatic = 1,
     visibility = ["//visibility:public"],
@@ -96,6 +100,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     linkstatic = 1,
     visibility = ["//visibility:public"],
@@ -108,6 +113,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     linkopts = ["-lgomp"],
     linkstatic = 1,
@@ -121,6 +127,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     linkstatic = 1,
     visibility = ["//visibility:public"],
@@ -133,6 +140,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     linkstatic = 1,
     visibility = ["//visibility:public"],
@@ -145,6 +153,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     linkstatic = 1,
     visibility = ["//visibility:public"],
@@ -182,6 +191,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Some header files in CUDA9.1 was moved into dir cuda/include/crt causing when building with CUDA9.1 headers like math_functions.hpp could no long be loaded.  Adding the directory into BUILD file fixs the issue. 