### PR TITLE
Enable `axis` support for `tf.unique`

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_UniqueV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_UniqueV2.pbtxt
@@ -65,7 +65,7 @@ For an `2-D` tensor `x` with `axis = 1`:
 # tensor 'x' is [[1, 0, 0],
 #                [1, 0, 0],
 #                [2, 0, 0]]
-y, idx = unique(x, axis=0)
+y, idx = unique(x, axis=1)
 y ==> [[1, 0],
        [1, 0],
        [2, 0]]

--- a/tensorflow/core/api_def/base_api/api_def_UniqueV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_UniqueV2.pbtxt
@@ -9,7 +9,7 @@ END
   in_arg {
     name: "axis"
     description: <<END
-A `Tensor` of type `int64` (default: 0). The axis of the Tensor to
+A `Tensor` of type `int32` (default: None). The axis of the Tensor to
 find the unique elements.
 END
   }
@@ -26,12 +26,15 @@ A 1-D Tensor. Has the same type as x that contains the index of each
 value of x in the output y.
 END
   }
-  summary: "Finds unique elements in a 1-D tensor."
+  summary: "Finds unique elements along an axis of a tensor."
   description: <<END
-This operation returns a tensor `y` containing all of the unique elements of `x`
-sorted in the same order that they occur in `x`. This operation also returns a
-tensor `idx` the same size as `x` that contains the index of each value of `x`
-in the unique output `y`. In other words:
+This operation either returns a tensor `y` containing unique elements
+along the `axis` of a tensor. The returned unique elements is sorted
+in the same order as they occur along `axis` in `x`.
+This operation also returns a tensor `idx` that is the same size as
+the number of the elements in `x` along the `axis` dimension. It
+contains the index in the unique output `y`.
+In other words, for an `1-D` tensor `x` with `axis = None:
 
 `y[idx[i]] = x[i] for i in [0, 1,...,rank(x) - 1]`
 
@@ -42,6 +45,31 @@ For example:
 y, idx = unique(x)
 y ==> [1, 2, 4, 7, 8]
 idx ==> [0, 0, 1, 2, 2, 2, 3, 4, 4]
+```
+
+For an `2-D` tensor `x` with `axis = 0`:
+
+```
+# tensor 'x' is [[1, 0, 0],
+#                [1, 0, 0],
+#                [2, 0, 0]]
+y, idx = unique(x, axis=0)
+y ==> [[1, 0, 0],
+       [2, 0, 0]]
+idx ==> [0, 0, 1]
+```
+
+For an `2-D` tensor `x` with `axis = 1`:
+
+```
+# tensor 'x' is [[1, 0, 0],
+#                [1, 0, 0],
+#                [2, 0, 0]]
+y, idx = unique(x, axis=0)
+y ==> [[1, 0],
+       [1, 0],
+       [2, 0]]
+idx ==> [0, 1, 1]
 ```
 END
 }

--- a/tensorflow/core/api_def/python_api/api_def_Unique.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_Unique.pbtxt
@@ -1,0 +1,4 @@
+op {
+  graph_op_name: "Unique"
+  visibility: HIDDEN
+}

--- a/tensorflow/core/api_def/python_api/api_def_UniqueV2.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_UniqueV2.pbtxt
@@ -1,0 +1,4 @@
+op {
+  graph_op_name: "UniqueV2"
+  visibility: HIDDEN
+}

--- a/tensorflow/core/kernels/unique_op.cc
+++ b/tensorflow/core/kernels/unique_op.cc
@@ -63,7 +63,7 @@ class UniqueOp : public OpKernel {
         OP_REQUIRES(context, TensorShapeUtils::IsVector(input.shape()),
                     errors::InvalidArgument("unique expects a 1D vector."));
       } else {
-        auto axis_vec = axis_tensor.vec<int64>();
+        auto axis_vec = axis_tensor.vec<int32>();
         axis = axis_vec(0);
         axis = axis < 0 ? axis + input.dims() : axis;
         OP_REQUIRES(context, 0 <= axis && axis < input.dims(),

--- a/tensorflow/core/kernels/unique_op.cc
+++ b/tensorflow/core/kernels/unique_op.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/kernels/bounds_check.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/lib/hash/hash.h"
 
@@ -63,8 +64,16 @@ class UniqueOp : public OpKernel {
         OP_REQUIRES(context, TensorShapeUtils::IsVector(input.shape()),
                     errors::InvalidArgument("unique expects a 1D vector."));
       } else {
-        auto axis_vec = axis_tensor.vec<int32>();
-        axis = axis_vec(0);
+        OP_REQUIRES(context, (axis_tensor.dtype() == DT_INT32 ||
+                              axis_tensor.dtype() == DT_INT64),
+                    errors::InvalidArgument(
+                        "axis tensor should be int32 or int64, but got ",
+                        axis_tensor.dtype()));
+        if (axis_tensor.dtype() == DT_INT32) {
+          axis = internal::SubtleMustCopy(axis_tensor.scalar<int32>()());
+        } else {
+          axis = internal::SubtleMustCopy(axis_tensor.scalar<int64>()());
+        }
         axis = axis < 0 ? axis + input.dims() : axis;
         OP_REQUIRES(context, 0 <= axis && axis < input.dims(),
                     errors::InvalidArgument("axis has to be between [0, ",

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -1169,7 +1169,7 @@ REGISTER_OP("UniqueV2")
     .Output("y: T")
     .Output("idx: out_idx")
     .Attr("T: type")
-    .Attr("Taxis: {int32,int64}")
+    .Attr("Taxis: {int32,int64} = DT_INT64")
     .Attr("out_idx: {int32, int64} = DT_INT32")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->Vector(InferenceContext::kUnknownDim));
@@ -1198,9 +1198,34 @@ y ==> [1, 2, 4, 7, 8]
 idx ==> [0, 0, 1, 2, 2, 2, 3, 4, 4]
 ```
 
+For an `2-D` tensor `x` with `axis = 0`:
+
+```
+# tensor 'x' is [[1, 0, 0],
+#                [1, 0, 0],
+#                [2, 0, 0]]
+y, idx = unique(x, axis=0)
+y ==> [[1, 0, 0],
+       [2, 0, 0]]
+idx ==> [0, 0, 1]
+```
+
+For an `2-D` tensor `x` with `axis = 1`:
+
+```
+# tensor 'x' is [[1, 0, 0],
+#                [1, 0, 0],
+#                [2, 0, 0]]
+y, idx = unique(x, axis=0)
+y ==> [[1, 0],
+       [1, 0],
+       [2, 0]]
+idx ==> [0, 1, 1]
+```
+
 
 x: A `Tensor`.
-axis: A `Tensor` of type `int32` (default: 0). The axis of the Tensor to
+axis: A `Tensor` of type `int32` (default: None). The axis of the Tensor to
   find the unique elements.
 y: A `Tensor`. Unique elements along the `axis` of `Tensor` x.
 idx: A 1-D Tensor. Has the same type as x that contains the index of each

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -1165,7 +1165,7 @@ REGISTER_OP("Unique")
 
 REGISTER_OP("UniqueV2")
     .Input("x: T")
-    .Input("axis: int64")
+    .Input("axis: int32")
     .Output("y: T")
     .Output("idx: out_idx")
     .Attr("T: type")
@@ -1174,7 +1174,37 @@ REGISTER_OP("UniqueV2")
       c->set_output(0, c->Vector(InferenceContext::kUnknownDim));
       c->set_output(1, c->input(0));
       return Status::OK();
-    });
+    })
+    .Doc(R"doc(
+Finds unique elements along an axis of a tensor.
+
+This operation either returns a tensor `y` containing unique elements
+along the `axis` of a tensor. The returned unique elements is sorted
+in the same order as they occur along `axis` in `x`.
+This operation also returns a tensor `idx` that is the same size as
+the number of the elements in `x` along the `axis` dimension. It
+contains the index in the unique output `y`.
+In other words, for an `1-D` tensor `x` with `axis = None:
+
+`y[idx[i]] = x[i] for i in [0, 1,...,rank(x) - 1]`
+
+For example:
+
+```
+# tensor 'x' is [1, 1, 2, 4, 4, 4, 7, 8, 8]
+y, idx = unique(x)
+y ==> [1, 2, 4, 7, 8]
+idx ==> [0, 0, 1, 2, 2, 2, 3, 4, 4]
+```
+
+
+x: A `Tensor`.
+axis: A `Tensor` of type `int32` (default: 0). The axis of the Tensor to
+  find the unique elements.
+y: A `Tensor`. Unique elements along the `axis` of `Tensor` x.
+idx: A 1-D Tensor. Has the same type as x that contains the index of each
+  value of x in the output y.
+)doc");
 
 // --------------------------------------------------------------------------
 REGISTER_OP("UniqueWithCounts")

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -1165,10 +1165,11 @@ REGISTER_OP("Unique")
 
 REGISTER_OP("UniqueV2")
     .Input("x: T")
-    .Input("axis: int32")
+    .Input("axis: Taxis")
     .Output("y: T")
     .Output("idx: out_idx")
     .Attr("T: type")
+    .Attr("Taxis: {int32,int64}")
     .Attr("out_idx: {int32, int64} = DT_INT32")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->Vector(InferenceContext::kUnknownDim));

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -1175,62 +1175,7 @@ REGISTER_OP("UniqueV2")
       c->set_output(0, c->Vector(InferenceContext::kUnknownDim));
       c->set_output(1, c->input(0));
       return Status::OK();
-    })
-    .Doc(R"doc(
-Finds unique elements along an axis of a tensor.
-
-This operation either returns a tensor `y` containing unique elements
-along the `axis` of a tensor. The returned unique elements is sorted
-in the same order as they occur along `axis` in `x`.
-This operation also returns a tensor `idx` that is the same size as
-the number of the elements in `x` along the `axis` dimension. It
-contains the index in the unique output `y`.
-In other words, for an `1-D` tensor `x` with `axis = None:
-
-`y[idx[i]] = x[i] for i in [0, 1,...,rank(x) - 1]`
-
-For example:
-
-```
-# tensor 'x' is [1, 1, 2, 4, 4, 4, 7, 8, 8]
-y, idx = unique(x)
-y ==> [1, 2, 4, 7, 8]
-idx ==> [0, 0, 1, 2, 2, 2, 3, 4, 4]
-```
-
-For an `2-D` tensor `x` with `axis = 0`:
-
-```
-# tensor 'x' is [[1, 0, 0],
-#                [1, 0, 0],
-#                [2, 0, 0]]
-y, idx = unique(x, axis=0)
-y ==> [[1, 0, 0],
-       [2, 0, 0]]
-idx ==> [0, 0, 1]
-```
-
-For an `2-D` tensor `x` with `axis = 1`:
-
-```
-# tensor 'x' is [[1, 0, 0],
-#                [1, 0, 0],
-#                [2, 0, 0]]
-y, idx = unique(x, axis=0)
-y ==> [[1, 0],
-       [1, 0],
-       [2, 0]]
-idx ==> [0, 1, 1]
-```
-
-
-x: A `Tensor`.
-axis: A `Tensor` of type `int32` (default: None). The axis of the Tensor to
-  find the unique elements.
-y: A `Tensor`. Unique elements along the `axis` of `Tensor` x.
-idx: A 1-D Tensor. Has the same type as x that contains the index of each
-  value of x in the output y.
-)doc");
+    });
 
 // --------------------------------------------------------------------------
 REGISTER_OP("UniqueWithCounts")

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -2667,7 +2667,7 @@ class OutputTypesTest(test_util.TensorFlowTestCase):
     with g.as_default():
       x = constant_op.constant([1, 1, 2, 4, 4, 4, 7, 8, 8],
                                dtype=dtypes.double)
-      y, _ = gen_array_ops.unique(x)
+      y, _ = gen_array_ops._unique(x)
       self.assertEqual([types_pb2.DT_DOUBLE, types_pb2.DT_INT32],
                        y.op._output_types)  # pylint: disable=protected-access
 

--- a/tensorflow/python/kernel_tests/unique_op_test.py
+++ b/tensorflow/python/kernel_tests/unique_op_test.py
@@ -65,9 +65,9 @@ class UniqueTest(test.TestCase):
   def testInt32Axis(self):
     x = np.array([[1, 0, 0], [1, 0, 0], [2, 0, 0]])
     with self.test_session() as sess:
-      y0, idx0 = gen_array_ops.unique_v2(x, axis=[0])
+      y0, idx0 = gen_array_ops._unique_v2(x, axis=[0])
       tf_y0, tf_idx0 = sess.run([y0, idx0])
-      y1, idx1 = gen_array_ops.unique_v2(x, axis=[1])
+      y1, idx1 = gen_array_ops._unique_v2(x, axis=[1])
       tf_y1, tf_idx1 = sess.run([y1, idx1])
     self.assertAllEqual(tf_y0, np.array([[1, 0, 0], [2, 0, 0]]))
     self.assertAllEqual(tf_idx0, np.array([0, 0, 1]))
@@ -79,7 +79,7 @@ class UniqueTest(test.TestCase):
     # by default, the axis will be wrapped to allow `axis=None`.
     x = np.random.randint(2, high=10, size=7000)
     with self.test_session() as sess:
-      y, idx = gen_array_ops.unique_v2(x, axis=[])
+      y, idx = gen_array_ops._unique_v2(x, axis=[])
       tf_y, tf_idx = sess.run([y, idx])
 
     self.assertEqual(len(x), len(tf_idx))

--- a/tensorflow/python/kernel_tests/unique_op_test.py
+++ b/tensorflow/python/kernel_tests/unique_op_test.py
@@ -63,23 +63,24 @@ class UniqueTest(test.TestCase):
       self.assertEqual(x[i], tf_y[tf_idx[i]].decode('ascii'))
 
   def testInt32Axis(self):
-    x = np.array([[1, 0, 0], [1, 0, 0], [2, 0, 0]])
-    with self.test_session() as sess:
-      y0, idx0 = gen_array_ops._unique_v2(x, axis=[0])
-      tf_y0, tf_idx0 = sess.run([y0, idx0])
-      y1, idx1 = gen_array_ops._unique_v2(x, axis=[1])
-      tf_y1, tf_idx1 = sess.run([y1, idx1])
-    self.assertAllEqual(tf_y0, np.array([[1, 0, 0], [2, 0, 0]]))
-    self.assertAllEqual(tf_idx0, np.array([0, 0, 1]))
-    self.assertAllEqual(tf_y1, np.array([[1, 0], [1, 0], [2, 0]]))
-    self.assertAllEqual(tf_idx1, np.array([0, 1, 1]))
+    for dtype in [np.int32, np.int64]:
+      x = np.array([[1, 0, 0], [1, 0, 0], [2, 0, 0]])
+      with self.test_session() as sess:
+        y0, idx0 = gen_array_ops._unique_v2(x, axis=np.array([0], dtype))
+        tf_y0, tf_idx0 = sess.run([y0, idx0])
+        y1, idx1 = gen_array_ops._unique_v2(x, axis=np.array([1], dtype))
+        tf_y1, tf_idx1 = sess.run([y1, idx1])
+      self.assertAllEqual(tf_y0, np.array([[1, 0, 0], [2, 0, 0]]))
+      self.assertAllEqual(tf_idx0, np.array([0, 0, 1]))
+      self.assertAllEqual(tf_y1, np.array([[1, 0], [1, 0], [2, 0]]))
+      self.assertAllEqual(tf_idx1, np.array([0, 1, 1]))
 
   def testInt32V2(self):
     # This test is only temporary, once V2 is used
     # by default, the axis will be wrapped to allow `axis=None`.
     x = np.random.randint(2, high=10, size=7000)
     with self.test_session() as sess:
-      y, idx = gen_array_ops._unique_v2(x, axis=[])
+      y, idx = gen_array_ops._unique_v2(x, axis=np.array([], np.int32))
       tf_y, tf_idx = sess.run([y, idx])
 
     self.assertEqual(len(x), len(tf_idx))

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1276,6 +1276,16 @@ def sparse_mask(a, mask_indices, name=None):
     return ops.IndexedSlices(out_values, out_indices, a.dense_shape)
 
 
+def unique(x, out_idx=dtypes.int32, name=None):
+  # TODO (yongtang): switch to v2 once API deprecation
+  # period (3 weeks) pass.
+  # TODO (yongtang): The documentation should also
+  # be updated when switch  to v2.
+  return gen_array_ops._unique(x, out_idx, name)
+
+unique.__doc__ = gen_array_ops._unique.__doc__
+
+
 def split(value, num_or_size_splits, axis=0, num=None, name="split"):
   """Splits a tensor into sub tensors.
 

--- a/tensorflow/python/ops/hidden_ops.txt
+++ b/tensorflow/python/ops/hidden_ops.txt
@@ -30,6 +30,8 @@ Squeeze
 Slice
 TileGrad  # Exported through array_grad instead of array_ops.
 ZerosLike  # TODO(josh11b): Use this instead of the Python version.
+Unique
+UniqueV2
 Unpack
 
 # candidate_sampling_ops


### PR DESCRIPTION
The `axis` support for `Unique` has been Added in PR #12952 (defined in `UniqueV2` ops). The support for `axis` in python version of the `tf.unique` was not enabled yet, due to the API workflow porcess (3 weeks). This fix adds the support for `axis` with `tf.unique` by adds `Unique` to `hidden.txt`, and adds a python wrapper of `tf.unique` to pointing to `UniqueV2`.

This fix addresses part of the issue #15644.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>