### PR TITLE
add a function to add extra logging handler

### DIFF
--- a/tensorflow/python/platform/tf_logging.py
+++ b/tensorflow/python/platform/tf_logging.py
@@ -261,6 +261,14 @@ def set_verbosity(v):
   _get_logger().setLevel(v)
 
 
+def add_log_handler(handler):
+  """Add extra log handler for logging messages."""
+  if not isinstance(handler, _logging.Handler):
+    warn("log handler is not valid. It is ignored")
+  else:
+    _get_logger().addHandler(handler)
+
+
 def _get_thread_id():
   """Get id of current thread, suitable for logging as an unsigned quantity."""
   # pylint: disable=protected-access
@@ -291,9 +299,11 @@ _allowed_symbols = [
     'log_every_n',
     'log_first_n',
     'set_verbosity',
+    'add_log_handler',
     'vlog',
     'warn',
     'warning',
 ]
+
 
 remove_undocumented(__name__, _allowed_symbols)


### PR DESCRIPTION
I want to separate different level of logs. So error message will not be buried by info/debug logs. In r1.4.  I use following code to do the job.

```
  file_hanlder = logging.FileHandler("running_error.log", mode='w', encoding=None, delay=False)
  file_hanlder.setLevel(logging.WARNING)
  tf.logging._logger.addHandler(file_hanlder)
```
but, when I change to r1.5, it don't work any more. because tensorflow rewrite tf_logging.py and _logger  is not exposed.  So I think add a function to add extra handler should be useful.