### PR TITLE
Fix small typo in docstring which causes the API doc to render incorr…

### DIFF
--- a/tensorflow/python/training/learning_rate_decay.py
+++ b/tensorflow/python/training/learning_rate_decay.py
@@ -120,7 +120,7 @@ def piecewise_constant(x, boundaries, values, name=None):
       `float64`, `uint8`, `int8`, `int16`, `int32`, `int64`.
     boundaries: A list of `Tensor`s or `int`s or `float`s with strictly
       increasing entries, and with all elements having the same type as `x`.
-    values: A list of `Tensor`s or float`s or `int`s that specifies the values
+    values: A list of `Tensor`s or `float`s or `int`s that specifies the values
       for the intervals defined by `boundaries`. It should have one more element
       than `boundaries`, and all elements should have the same type.
     name: A string. Optional name of the operation. Defaults to


### PR DESCRIPTION
…ectly
See
![screen shot 2017-12-27 at 19 53 06](https://user-images.githubusercontent.com/11613312/34390366-adc111e8-eb3f-11e7-8d31-bdb0c24c32a9.png)
on https://www.tensorflow.org/api_docs/python/tf/train/piecewise_constant