### PR TITLE
Improve doc of TFRecordDataset, shuffle ahead of map

### DIFF
--- a/tensorflow/docs_src/programmers_guide/datasets.md
+++ b/tensorflow/docs_src/programmers_guide/datasets.md
@@ -679,8 +679,8 @@ buffer and chooses the next element uniformly at random from that buffer.
 ```python
 filenames = ["/var/data/file1.tfrecord", "/var/data/file2.tfrecord"]
 dataset = tf.data.TFRecordDataset(filenames)
-dataset = dataset.map(...)
 dataset = dataset.shuffle(buffer_size=10000)
+dataset = dataset.map(...)
 dataset = dataset.batch(32)
 dataset = dataset.repeat()
 ```
@@ -696,8 +696,8 @@ with the `tf.data` API, we recommend using
 ```python
 filenames = ["/var/data/file1.tfrecord", "/var/data/file2.tfrecord"]
 dataset = tf.data.TFRecordDataset(filenames)
-dataset = dataset.map(...)
 dataset = dataset.shuffle(buffer_size=10000)
+dataset = dataset.map(...)
 dataset = dataset.batch(32)
 dataset = dataset.repeat(num_epochs)
 iterator = dataset.make_one_shot_iterator()
@@ -740,8 +740,8 @@ def dataset_input_fn():
 
   # Use `Dataset.map()` to build a pair of a feature dictionary and a label
   # tensor for each example.
-  dataset = dataset.map(parser)
   dataset = dataset.shuffle(buffer_size=10000)
+  dataset = dataset.map(parser)
   dataset = dataset.batch(32)
   dataset = dataset.repeat(num_epochs)
   iterator = dataset.make_one_shot_iterator()


### PR DESCRIPTION
In the origin document, the code to demonstrate TFRecordDataset do `dataset.map(parser)` then do `dataset.shuffle(10000)`.
This code use a high number of buffer size (10000), and since `map` do ahead of `shuffle`, means when the first time this dataset yield one result it will need to run `map` over 10000 items and this can take a lot of time.
So, instead we can do `shuffle` ahead of `map`, since the item of `TFRecordDataset` is one `Example` raw data, `shuffle` ahead will not compromise the randomness and then the `map(parser)` only need to process one batch of items at a time. Which results much faster startup.
