### PR TITLE
Fix out of memory issue on Tegra devices

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -762,6 +762,10 @@ int64 MinSystemMemory(int64 available_memory) {
   // is necessary.
   min_system_memory *= 2;
 #endif
+#if defined(NVIDIA_TEGRA)
+  // 1GB system mem for NVIDIA Tegra devices since they use the same mem for RAM and Video RAM
+  min_system_memory = 1<<30;
+#endif
   return min_system_memory;
 }
 


### PR DESCRIPTION
TF used to allocate (available memory - 300MB) or (available memory - 225MB)
for TF to use. This is fine for graphic cards, but will cause out of memory
issue on Tegra.
Modify to allocate (available memory - 1GB) for Tegra.
1GB should be enough for OS and other apps
(available memory - 1GB) should be 0.8-1.5GB which is enough for most graph for TF.