### PR TITLE
Load region from `~/.aws/config` if possible in S3

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -66,7 +66,8 @@ Aws::Client::ClientConfiguration& GetDefaultClientConfig() {
       // Load config file (e.g., ~/.aws/config) only if AWS_SDK_LOAD_CONFIG
       // is set with a truthy value.
       const char* load_config_env = getenv("AWS_SDK_LOAD_CONFIG");
-      string load_config = load_config_env ? str_util::Lowercase(load_config_env) : "";
+      string load_config =
+          load_config_env ? str_util::Lowercase(load_config_env) : "";
       if (load_config == "true" || load_config == "1") {
         Aws::String config_file;
         // If AWS_CONFIG_FILE is set then use it, otherwise use ~/.aws/config.

--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/core/platform/s3/s3_file_system.h"
 #include "tensorflow/core/lib/io/path.h"
+#include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/s3/aws_logging.h"
 #include "tensorflow/core/platform/s3/s3_crypto.h"
@@ -55,26 +56,36 @@ Aws::Client::ClientConfiguration& GetDefaultClientConfig() {
       cfg.endpointOverride = Aws::String(endpoint);
     }
     const char* region = getenv("AWS_REGION");
+    if (!region) {
+      // TODO (yongtang): `S3_REGION` should be deprecated after 2.0.
+      region = getenv("S3_REGION");
+    }
     if (region) {
       cfg.region = Aws::String(region);
     } else {
-      // TODO (yongtang): `S3_REGION` should be deprecated after 2.0.
-      const char* region = getenv("S3_REGION");
-      if (region) {
-        cfg.region = Aws::String(region);
-      } else {
-      // If no AWS_REGION or S3_REGION, se ~/.aws/config if possible
-      const char* home = getenv("HOME");
-      if (home) {
-      Aws::String config_file(home);
-      config_file += "/.aws/config";
-      Aws::Config::AWSConfigFileProfileConfigLoader loader(config_file);
-      loader.Load();
-      auto profiles = loader.GetProfiles();
-      if (!profiles["default"].GetRegion().empty()) {
-        cfg.region = profiles["default"].GetRegion();
-      }
-      }
+      // Load config file (e.g., ~/.aws/config) only if AWS_SDK_LOAD_CONFIG
+      // is set with a truthy value.
+      const char* load_config_env = getenv("AWS_SDK_LOAD_CONFIG");
+      string load_config = load_config_env ? str_util::Lowercase(load_config_env) : "";
+      if (load_config == "true" || load_config == "1") {
+        Aws::String config_file;
+        // If AWS_CONFIG_FILE is set then use it, otherwise use ~/.aws/config.
+        const char* config_file_env = getenv("AWS_CONFIG_FILE");
+        if (config_file_env) {
+          config_file = config_file_env;
+        } else {
+          const char* home_env = getenv("HOME");
+          if (home_env) {
+            config_file = home_env;
+            config_file += "/.aws/config";
+          }
+        }
+        Aws::Config::AWSConfigFileProfileConfigLoader loader(config_file);
+        loader.Load();
+        auto profiles = loader.GetProfiles();
+        if (!profiles["default"].GetRegion().empty()) {
+          cfg.region = profiles["default"].GetRegion();
+        }
       }
     }
     const char* use_https = getenv("S3_USE_HTTPS");


### PR DESCRIPTION
This fix tries to address the issue raised in https://github.com/tensorflow/tensorflow/issues/15662#issuecomment-354272697 where TensorFlow does not load region from `~/.aws/config` if exists. The reason was that AWS C++ SDK does not use the config file by default.

This fix adds the loading of config file (`~/.aws/config`) explicitly, if either AWS_REGION or S3_REGION is not available. In case none of the `AWS_REGION`, `S3_REGION`, `~/.aws/config` is available, then the default `use-east-1` is used (by AWS C++ SDK).

This fix is related to #15562.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>