### PR TITLE
Fix the headers error due to recent CUDA9.1 change

### DIFF
--- a/third_party/gpus/cuda/BUILD.tpl
+++ b/third_party/gpus/cuda/BUILD.tpl
@@ -46,6 +46,7 @@ cc_library(
     includes = [
         ".",
         "cuda/include",
+        "cuda/include/crt",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Some headers in CUDA 9.1 has been move to cuda/include/crt directory. 