### PR TITLE
Simplify the dense_to_one_hot method

### DIFF
--- a/tensorflow/contrib/learn/python/learn/datasets/mnist.py
+++ b/tensorflow/contrib/learn/python/learn/datasets/mnist.py
@@ -68,11 +68,7 @@ def extract_images(f):
 
 def dense_to_one_hot(labels_dense, num_classes):
   """Convert class labels from scalars to one-hot vectors."""
-  num_labels = labels_dense.shape[0]
-  index_offset = numpy.arange(num_labels) * num_classes
-  labels_one_hot = numpy.zeros((num_labels, num_classes))
-  labels_one_hot.flat[index_offset + labels_dense.ravel()] = 1
-  return labels_one_hot
+  return numpy.identity(num_classes)[labels_dense]
 
 
 def extract_labels(f, one_hot=False, num_classes=10):


### PR DESCRIPTION
Simplified the `dense_to_one_hot` method.
The updated method behaves exactly like the old one, but is more concise.