### PR TITLE
[XLA] Add missing win header deps to framework_lite

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -79,6 +79,7 @@ load(
     "if_linux_x86_64",
     "if_mobile",
     "if_not_mobile",
+    "if_windows",
     "if_not_windows",
     "tf_copts",
     "tf_cc_test",
@@ -562,7 +563,7 @@ cc_library(
         "platform/prefetch.h",
         "platform/thread_annotations.h",
         "platform/types.h",
-    ],
+    ] + if_windows(["platform/windows/integral_types.h"]),
     visibility = ["//visibility:public"],
     deps =
         [


### PR DESCRIPTION
Continue from #15579. Most Tensorflow components depend on `framework` rather than `framework_lite`, so I did not notice this until I try to build XLA/tfcompile locally again.

#15213