### PR TITLE
[XLA] Define TF_COMPILE_LIBRARY for two libraries

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/BUILD
+++ b/tensorflow/compiler/tf2xla/kernels/BUILD
@@ -4,6 +4,7 @@ package(
     default_visibility = ["//tensorflow/compiler/tf2xla:internal"],
 )
 
+load("//tensorflow:tensorflow.bzl", "tf_copts")
 load("//tensorflow:tensorflow.bzl", "tf_kernel_library")
 
 tf_kernel_library(
@@ -165,6 +166,7 @@ tf_kernel_library(
 cc_library(
     name = "index_ops_kernel_argmax_float_1d",
     srcs = ["index_ops_kernel_argmax_float_1d.cc"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/compiler/xla/service/cpu:custom_call_target_registry",
@@ -177,6 +179,7 @@ cc_library(
 cc_library(
     name = "index_ops_kernel_argmax_float_2d",
     srcs = ["index_ops_kernel_argmax_float_2d.cc"],
+    copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/compiler/xla/service/cpu:custom_call_target_registry",


### PR DESCRIPTION
Both [`index_ops_kernel_argmax_float_1d.cc`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/tf2xla/kernels/index_ops_kernel_argmax_float_1d.cc#L48) and [`index_ops_kernel_argmax_float_2d.cc`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/tf2xla/kernels/index_ops_kernel_argmax_float_2d.cc#L50) use `TF_EXPORT` macro. We need to define `TF_COMPILE_LIBRARY` (comes from [`tf_copts`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tensorflow.bzl#L170)) to make sure `TF_EXPORT` is expanded into `__declspec(dllexport)`.

#15213