### PR TITLE
Make unused variable warning an error during TF builds.

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -23,6 +23,7 @@ build:sycl_trisycl --define=using_sycl=true --define=using_trisycl=true
 build --define=use_fast_cpp_protos=true
 build --define=allow_oversize_protos=true
 build --define=grpc_no_ares=true
+build --copt=-Werror=unused-variable
 
 build --spawn_strategy=standalone
 build --genrule_strategy=standalone


### PR DESCRIPTION
We will need to eyeball build logs and see if this is really working as intended