### PR TITLE
Fix invalid Markdown in docstring

### DIFF
--- a/tensorflow/contrib/gan/python/estimator/python/gan_estimator_impl.py
+++ b/tensorflow/contrib/gan/python/estimator/python/gan_estimator_impl.py
@@ -96,7 +96,7 @@ class GANEstimator(estimator.Estimator):
       # Generate samples from generator.
       predictions = np.array([
           x for x in gan_estimator.predict(predict_input_fn)])
-    ```
+  ```
   """
 
   def __init__(self,


### PR DESCRIPTION
There is currently invalid markdown in the docstring, which is causing the docs site to render incorrectly.

https://www.tensorflow.org/api_docs/python/tf/contrib/gan/estimator/GANEstimator

<img width="902" alt="screen shot 2018-01-01 at 10 17 59 am" src="https://user-images.githubusercontent.com/279498/34469987-1d2fbce6-eedd-11e7-896b-a43f65326fd0.png">

This patch fixes the indentation on the MD code block, which should fix the issue.