### PR TITLE
Add `colors` support for `tf.image.draw_bounding_boxes`

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_DrawBoundingBoxesV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DrawBoundingBoxesV2.pbtxt
@@ -1,0 +1,43 @@
+op {
+  graph_op_name: "DrawBoundingBoxesV2"
+  in_arg {
+    name: "images"
+    description: <<END
+4-D with shape `[batch, height, width, depth]`. A batch of images.
+END
+  }
+  in_arg {
+    name: "boxes"
+    description: <<END
+3-D with shape `[batch, num_bounding_boxes, 4]` containing bounding
+boxes.
+END
+  }
+  in_arg {
+    name: "colors"
+    description: <<END
+2-D. A list of RGBA colors to cycle through for the boxes.
+END
+  }
+  out_arg {
+    name: "output"
+    description: <<END
+4-D with the same shape as `images`. The batch of input images with
+bounding boxes drawn on the images.
+END
+  }
+  summary: "Draw bounding boxes on a batch of images."
+  description: <<END
+Outputs a copy of `images` but draws on top of the pixels zero or more bounding
+boxes specified by the locations in `boxes`. The coordinates of the each
+bounding box in `boxes` are encoded as `[y_min, x_min, y_max, x_max]`. The
+bounding box coordinates are floats in `[0.0, 1.0]` relative to the width and
+height of the underlying image.
+
+For example, if an image is 100 x 200 pixels (height x width) and the bounding
+box is `[0.1, 0.2, 0.5, 0.9]`, the upper-left and bottom-right coordinates of
+the bounding box will be `(40, 10)` to `(100, 50)` (in (x,y) coordinates).
+
+Parts of the bounding box may fall outside the image.
+END
+}

--- a/tensorflow/core/api_def/python_api/api_def_DrawBoundingBoxesV2.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_DrawBoundingBoxesV2.pbtxt
@@ -1,0 +1,4 @@
+op {
+  graph_op_name: "DrawBoundingBoxesV2"
+  visibility: HIDDEN
+}

--- a/tensorflow/core/kernels/draw_bounding_box_op.cc
+++ b/tensorflow/core/kernels/draw_bounding_box_op.cc
@@ -78,14 +78,19 @@ class DrawBoundingBoxesOp : public OpKernel {
     }
     if (context->num_inputs() == 3) {
       const Tensor& colors_tensor = context->input(2);
-      OP_REQUIRES(context, colors_tensor.shape().dims() == 2, errors::InvalidArgument("colors must be a 2-D matrix", colors_tensor.shape().DebugString()));
-      OP_REQUIRES(context, colors_tensor.shape().dim_size(1) == 4, errors::InvalidArgument("colors must be n x 4 (RGBA)", colors_tensor.shape().DebugString()));
+      OP_REQUIRES(context, colors_tensor.shape().dims() == 2,
+                  errors::InvalidArgument("colors must be a 2-D matrix",
+                                          colors_tensor.shape().DebugString()));
+      OP_REQUIRES(context, colors_tensor.shape().dim_size(1) == 4,
+                  errors::InvalidArgument("colors must be n x 4 (RGBA)",
+                                          colors_tensor.shape().DebugString()));
       if (colors_tensor.NumElements() != 0) {
         color_table.clear();
 
         auto colors = colors_tensor.matrix<float>();
         for (int64 i = 0; i < colors.dimension(0); i++) {
-            color_table.emplace_back(std::array<float, 4>{colors(i, 0), colors(i, 1), colors(i, 2), colors(i, 3)});
+          color_table.emplace_back(std::array<float, 4>{
+              colors(i, 0), colors(i, 1), colors(i, 2), colors(i, 3)});
         }
       }
     }
@@ -188,11 +193,11 @@ class DrawBoundingBoxesOp : public OpKernel {
   }
 };
 
-#define REGISTER_CPU_KERNEL(T)                                             \
-  REGISTER_KERNEL_BUILDER(                                                 \
-      Name("DrawBoundingBoxes").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
-      DrawBoundingBoxesOp<T>);                                             \
-  REGISTER_KERNEL_BUILDER(                                                 \
+#define REGISTER_CPU_KERNEL(T)                                               \
+  REGISTER_KERNEL_BUILDER(                                                   \
+      Name("DrawBoundingBoxes").Device(DEVICE_CPU).TypeConstraint<T>("T"),   \
+      DrawBoundingBoxesOp<T>);                                               \
+  REGISTER_KERNEL_BUILDER(                                                   \
       Name("DrawBoundingBoxesV2").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
       DrawBoundingBoxesOp<T>);
 TF_CALL_half(REGISTER_CPU_KERNEL);

--- a/tensorflow/core/kernels/draw_bounding_box_op.cc
+++ b/tensorflow/core/kernels/draw_bounding_box_op.cc
@@ -52,7 +52,6 @@ class DrawBoundingBoxesOp : public OpKernel {
     const int64 batch_size = images.dim_size(0);
     const int64 height = images.dim_size(1);
     const int64 width = images.dim_size(2);
-    const int64 color_table_length = 10;
 
     // 0: yellow
     // 1: blue
@@ -64,7 +63,7 @@ class DrawBoundingBoxesOp : public OpKernel {
     // 7: navy blue
     // 8: aqua
     // 9: fuchsia
-    float color_table[color_table_length][4] = {
+    std::vector<std::array<float, 4>> color_table = {
         {1, 1, 0, 1},     {0, 0, 1, 1},     {1, 0, 0, 1},   {0, 1, 0, 1},
         {0.5, 0, 0.5, 1}, {0.5, 0.5, 0, 1}, {0.5, 0, 0, 1}, {0, 0, 0.5, 1},
         {0, 1, 1, 1},     {1, 0, 1, 1},
@@ -73,8 +72,21 @@ class DrawBoundingBoxesOp : public OpKernel {
     // Reset first color channel to 1 if image is GRY.
     // For GRY images, this means all bounding boxes will be white.
     if (depth == 1) {
-      for (int64 i = 0; i < color_table_length; i++) {
+      for (int64 i = 0; i < color_table.size(); i++) {
         color_table[i][0] = 1;
+      }
+    }
+    if (context->num_inputs() == 3) {
+      const Tensor& colors_tensor = context->input(2);
+      OP_REQUIRES(context, colors_tensor.shape().dims() == 2, errors::InvalidArgument("colors must be a 2-D matrix", colors_tensor.shape().DebugString()));
+      OP_REQUIRES(context, colors_tensor.shape().dim_size(1) == 4, errors::InvalidArgument("colors must be n x 4 (RGBA)", colors_tensor.shape().DebugString()));
+      if (colors_tensor.NumElements() != 0) {
+        color_table.clear();
+
+        auto colors = colors_tensor.matrix<float>();
+        for (int64 i = 0; i < colors.dimension(0); i++) {
+            color_table.emplace_back(std::array<float, 4>{colors(i, 0), colors(i, 1), colors(i, 2), colors(i, 3)});
+        }
       }
     }
     Tensor* output;
@@ -90,7 +102,7 @@ class DrawBoundingBoxesOp : public OpKernel {
       const int64 num_boxes = boxes.dim_size(1);
       const auto tboxes = boxes.tensor<T, 3>();
       for (int64 bb = 0; bb < num_boxes; ++bb) {
-        int64 color_index = bb % color_table_length;
+        int64 color_index = bb % color_table.size();
         const int64 min_box_row =
             static_cast<float>(tboxes(b, bb, 0)) * (height - 1);
         const int64 min_box_row_clamp = std::max<int64>(min_box_row, int64{0});
@@ -179,6 +191,9 @@ class DrawBoundingBoxesOp : public OpKernel {
 #define REGISTER_CPU_KERNEL(T)                                             \
   REGISTER_KERNEL_BUILDER(                                                 \
       Name("DrawBoundingBoxes").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
+      DrawBoundingBoxesOp<T>);                                             \
+  REGISTER_KERNEL_BUILDER(                                                 \
+      Name("DrawBoundingBoxesV2").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
       DrawBoundingBoxesOp<T>);
 TF_CALL_half(REGISTER_CPU_KERNEL);
 TF_CALL_float(REGISTER_CPU_KERNEL);

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -492,6 +492,39 @@ REGISTER_OP("DrawBoundingBoxes")
     });
 
 // --------------------------------------------------------------------------
+REGISTER_OP("DrawBoundingBoxesV2")
+    .Input("images: T")
+    .Input("boxes: float")
+    .Input("colors: float")
+    .Output("output: T")
+    .Attr("T: {float, half} = DT_FLOAT")
+    .SetShapeFn([](InferenceContext* c) {
+      return shape_inference::UnchangedShapeWithRankAtLeast(c, 3);
+    })
+    .Doc(R"doc(
+Draw bounding boxes on a batch of images.
+
+Outputs a copy of `images` but draws on top of the pixels zero or more bounding
+boxes specified by the locations in `boxes`. The coordinates of the each
+bounding box in `boxes` are encoded as `[y_min, x_min, y_max, x_max]`. The
+bounding box coordinates are floats in `[0.0, 1.0]` relative to the width and
+height of the underlying image.
+
+For example, if an image is 100 x 200 pixels (height x width) and the bounding
+box is `[0.1, 0.2, 0.5, 0.9]`, the upper-left and bottom-right coordinates of
+the bounding box will be `(40, 10)` to `(100, 50)` (in (x,y) coordinates).
+
+Parts of the bounding box may fall outside the image.
+
+images: 4-D with shape `[batch, height, width, depth]`. A batch of images.
+boxes: 3-D with shape `[batch, num_bounding_boxes, 4]` containing bounding
+  boxes.
+colors: 2-D. A list of RGBA colors to cycle through for the boxes.
+output: 4-D with the same shape as `images`. The batch of input images with
+  bounding boxes drawn on the images.
+)doc");
+
+// --------------------------------------------------------------------------
 REGISTER_OP("SampleDistortedBoundingBox")
     .Input("image_size: T")
     .Input("bounding_boxes: float")

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -500,29 +500,7 @@ REGISTER_OP("DrawBoundingBoxesV2")
     .Attr("T: {float, half} = DT_FLOAT")
     .SetShapeFn([](InferenceContext* c) {
       return shape_inference::UnchangedShapeWithRankAtLeast(c, 3);
-    })
-    .Doc(R"doc(
-Draw bounding boxes on a batch of images.
-
-Outputs a copy of `images` but draws on top of the pixels zero or more bounding
-boxes specified by the locations in `boxes`. The coordinates of the each
-bounding box in `boxes` are encoded as `[y_min, x_min, y_max, x_max]`. The
-bounding box coordinates are floats in `[0.0, 1.0]` relative to the width and
-height of the underlying image.
-
-For example, if an image is 100 x 200 pixels (height x width) and the bounding
-box is `[0.1, 0.2, 0.5, 0.9]`, the upper-left and bottom-right coordinates of
-the bounding box will be `(40, 10)` to `(100, 50)` (in (x,y) coordinates).
-
-Parts of the bounding box may fall outside the image.
-
-images: 4-D with shape `[batch, height, width, depth]`. A batch of images.
-boxes: 3-D with shape `[batch, num_bounding_boxes, 4]` containing bounding
-  boxes.
-colors: 2-D. A list of RGBA colors to cycle through for the boxes.
-output: 4-D with the same shape as `images`. The batch of input images with
-  bounding boxes drawn on the images.
-)doc");
+    });
 
 // --------------------------------------------------------------------------
 REGISTER_OP("SampleDistortedBoundingBox")

--- a/tensorflow/python/kernel_tests/draw_bounding_box_op_test.py
+++ b/tensorflow/python/kernel_tests/draw_bounding_box_op_test.py
@@ -23,6 +23,7 @@ import numpy as np
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_image_ops
 from tensorflow.python.ops import image_ops
 from tensorflow.python.ops import image_ops_impl
 from tensorflow.python.ops import math_ops
@@ -54,17 +55,21 @@ class DrawBoundingBoxOpTest(test.TestCase):
     image[height - 1, 0:width, 0:depth] = color
     return image
 
-  def _testDrawBoundingBoxColorCycling(self, img):
+  def _testDrawBoundingBoxColorCycling(self, img, colors=None):
     """Tests if cycling works appropriately.
 
     Args:
       img: 3-D numpy image on which to draw.
     """
     # THIS TABLE MUST MATCH draw_bounding_box_op.cc
-    color_table = np.asarray([[1, 1, 0, 1], [0, 0, 1, 1], [1, 0, 0, 1],
-                              [0, 1, 0, 1], [0.5, 0, 0.5, 1], [0.5, 0.5, 0, 1],
-                              [0.5, 0, 0, 1], [0, 0, 0.5, 1], [0, 1, 1, 1],
-                              [1, 0, 1, 1]])
+    default_color_table = np.asarray([[1, 1, 0, 1], [0, 0, 1, 1],
+                                      [1, 0, 0, 1], [0, 1, 0, 1],
+                                      [0.5, 0, 0.5, 1], [0.5, 0.5, 0, 1],
+                                      [0.5, 0, 0, 1], [0, 0, 0.5, 1],
+                                      [0, 1, 1, 1], [1, 0, 1, 1]])
+    color_table = default_color_table
+    if colors is not None:
+      color_table = colors
     assert len(img.shape) == 3
     depth = img.shape[2]
     assert depth <= color_table.shape[1]
@@ -85,9 +90,12 @@ class DrawBoundingBoxOpTest(test.TestCase):
       image = ops.convert_to_tensor(image)
       image = image_ops_impl.convert_image_dtype(image, dtypes.float32)
       image = array_ops.expand_dims(image, 0)
-      image = image_ops.draw_bounding_boxes(image, bboxes)
+      if colors is None:
+        image = image_ops.draw_bounding_boxes(image, bboxes)
+      else:
+        image = gen_image_ops.draw_bounding_boxes_v2(image, bboxes, colors)
       with self.cached_session(use_gpu=False) as sess:
-        op_drawn_image = np.squeeze(self.evaluate(image), 0)
+        op_drawn_image = np.squeeze(sess.run(image), 0)
         self.assertAllEqual(test_drawn_image, op_drawn_image)
 
   def testDrawBoundingBoxRGBColorCycling(self):
@@ -104,6 +112,21 @@ class DrawBoundingBoxOpTest(test.TestCase):
     """Test if drawing bounding box on a GRY image works."""
     image = np.zeros([4, 4, 1], "float32")
     self._testDrawBoundingBoxColorCycling(image)
+
+  def testDrawBoundingBoxRGBColorCyclingWithColors(self):
+    """Test if RGB color cycling works correctly with provided colors."""
+    image = np.zeros([10, 10, 3], "float32")
+    colors = np.asarray([[1, 1, 0, 1], [0, 0, 1, 1],
+                         [0.5, 0, 0.5, 1], [0.5, 0.5, 0, 1],
+                         [0, 1, 1, 1], [1, 0, 1, 1]])
+    self._testDrawBoundingBoxColorCycling(image, colors=colors)
+
+  def testDrawBoundingBoxRGBAColorCyclingWithColors(self):
+    """Test if RGBA color cycling works correctly with provided colors."""
+    image = np.zeros([10, 10, 4], "float32")
+    colors = np.asarray([[0.5, 0, 0.5, 1], [0.5, 0.5, 0, 1],
+                         [0.5, 0, 0, 1], [0, 0, 0.5, 1]])
+    self._testDrawBoundingBoxColorCycling(image, colors=colors)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fix tries to address the issue raised in #15692 where it was not possible to specify the colors for boxes in `tf.image.draw_bounding_boxes`. Instead, a predefined fixed color table was used to cycle through colors.

This fix adds `colors` Input to `DrawBoundingBoxexV2` so that it is possible to specify the color. In case no color is specified, the default color table will be used.

Since there is an API change, the op is labeled as V2.

This fix fixes #15692.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>