### PR TITLE
[configure] eagerly determine the truthfulness of environment variables

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -319,6 +319,15 @@ def get_var(environ_cp,
     question += ' [y/N]: '
 
   var = environ_cp.get(var_name)
+  if var is not None:
+    _var_content = var.strip().lower()
+    if _var_content in ['1', 'y', 'true']:
+      var = True
+    elif _var_content in ['0', 'n', 'false']:
+      var = False
+    else:
+      var = None
+
   while var is None:
     user_input_origin = get_input(question)
     user_input = user_input_origin.strip().lower()

--- a/configure.py
+++ b/configure.py
@@ -327,11 +327,9 @@ def get_var(environ_cp,
   var = environ_cp.get(var_name)
   if var is not None:
     var_content = var.strip().lower()
-    true_contents = ('1', 'y', 'yes', 'true')
-    false_contents = ('0', 'n', 'no', 'false')
-    if var_content in true_contents:
+    if var_content in ('1', 't', 'true', 'y', 'yes'):
       var = True
-    elif var_content in false_contents:
+    elif var_content in ('0', 'f', 'false', 'n', 'no'):
       var = False
     else:
       raise UserInputError('Environment variable %s must be set as a boolean indicator.\n'

--- a/configure.py
+++ b/configure.py
@@ -305,9 +305,9 @@ def get_var(environ_cp,
 
   Raises:
     UserInputError: if an environment variable is set, but it cannot be
-    interpreted as a boolean indicator, assume that the user has made a
-    scripting error, and will continue to provide invalid input.
-    Raise the error to avoid infinitely looping.
+      interpreted as a boolean indicator, assume that the user has made a
+      scripting error, and will continue to provide invalid input.
+      Raise the error to avoid infinitely looping.
   """
   if not question:
     question = 'Do you wish to build TensorFlow with %s support?' % query_item
@@ -326,21 +326,21 @@ def get_var(environ_cp,
 
   var = environ_cp.get(var_name)
   if var is not None:
-    _var_content = var.strip().lower()
-    _true_contents = ('1', 'y', 'yes', 'true')
-    _false_contents = ('0', 'n', 'no', 'false')
-    if _var_content in _true_contents:
+    var_content = var.strip().lower()
+    true_contents = ('1', 'y', 'yes', 'true')
+    false_contents = ('0', 'n', 'no', 'false')
+    if var_content in true_contents:
       var = True
-    elif _var_content in _false_contents:
+    elif var_content in false_contents:
       var = False
     else:
-      raise UserInputError('environment variable %s must be set as a boolean indicator\n'
-                           'the followings are accepted as TRUE : %s\n'
-                           'the followings are accepted as FALSE: %s\n'
-                           'current value is %s' %
+      raise UserInputError('Environment variable %s must be set as a boolean indicator.\n'
+                           'The followings are accepted as TRUE : %s.\n'
+                           'The followings are accepted as FALSE: %s.\n'
+                           'Current value is %s' %
                            (var_name,
-                            ','.join(_true_contents),
-                            ','.join(_false_contents),
+                            ','.join(true_contents),
+                            ','.join(false_contents),
                             var))
 
   while var is None:
@@ -629,8 +629,8 @@ def prompt_loop_or_load_from_env(
 
   Raises:
     UserInputError: if a query has been attempted n_ask_attempts times without
-    success, assume that the user has made a scripting error, and will continue
-    to provide invalid input. Raise the error to avoid infinitely looping.
+      success, assume that the user has made a scripting error, and will continue
+      to provide invalid input. Raise the error to avoid infinitely looping.
   """
   default = environ_cp.get(var_name) or var_default
   full_query = '%s [Default is %s]: ' % (

--- a/configure.py
+++ b/configure.py
@@ -302,6 +302,12 @@ def get_var(environ_cp,
 
   Returns:
     boolean value of the variable.
+
+  Raises:
+    UserInputError: if an environment variable is set, but it cannot be
+    interpreted as a boolean indicator, assume that the user has made a
+    scripting error, and will continue to provide invalid input.
+    Raise the error to avoid infinitely looping.
   """
   if not question:
     question = 'Do you wish to build TensorFlow with %s support?' % query_item
@@ -321,12 +327,21 @@ def get_var(environ_cp,
   var = environ_cp.get(var_name)
   if var is not None:
     _var_content = var.strip().lower()
-    if _var_content in ['1', 'y', 'true']:
+    _true_contents = ['1', 'y', 'yes', 'true']
+    _false_contents = ['0', 'n', 'no', 'false']
+    if _var_content in _true_contents:
       var = True
-    elif _var_content in ['0', 'n', 'false']:
+    elif _var_content in _false_contents:
       var = False
     else:
-      var = None
+      raise UserInputError('environment variable %s must be set as a boolean indicator\n'
+                           'the followings are accepted as TRUE : %s\n'
+                           'the followings are accepted as FALSE: %s\n'
+                           'current value is %s' %
+                           (var_name,
+                            ','.join(_true_contents),
+                            ','.join(_false_contents),
+                            var))
 
   while var is None:
     user_input_origin = get_input(question)

--- a/configure.py
+++ b/configure.py
@@ -327,8 +327,8 @@ def get_var(environ_cp,
   var = environ_cp.get(var_name)
   if var is not None:
     _var_content = var.strip().lower()
-    _true_contents = ['1', 'y', 'yes', 'true']
-    _false_contents = ['0', 'n', 'no', 'false']
+    _true_contents = ('1', 'y', 'yes', 'true')
+    _false_contents = ('0', 'n', 'no', 'false')
     if _var_content in _true_contents:
       var = True
     elif _var_content in _false_contents:


### PR DESCRIPTION
Eagerly determine the truthfulness of environment variables in `get_var` function.

This way we can skip checking, e.g. Android workspace setup if the user sets `TF_SET_ANDROID_WORKSPACE=0`

Tested manually. 
