### PR TITLE
Change dso_loader to look for libcupti.so instead of libcupti.so.8.0

### DIFF
--- a/tensorflow/stream_executor/dso_loader.cc
+++ b/tensorflow/stream_executor/dso_loader.cc
@@ -97,7 +97,7 @@ string GetCudnnVersion() { return TF_CUDNN_VERSION; }
 
 /* static */ port::Status DsoLoader::GetLibcuptiDsoHandle(void** dso_handle) {
   return GetDsoHandle(FindDsoPath(port::Env::Default()->FormatLibraryFileName(
-                                      "cupti", GetCudaVersion()),
+                                      "cupti", ""),
                                   GetCudaCuptiLibraryPath()),
                       dso_handle);
 }


### PR DESCRIPTION
On Android, it is hard to package libcupti.so.8.0 with bazel to generate CUDA-enabled apk
The cc_library macro in bazel only looks for *.so, not *.so.*