### PR TITLE
Memory allocation improvement for `decode_libsvm`

### DIFF
--- a/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
+++ b/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
@@ -48,8 +48,8 @@ class DecodeLibsvmOp : public OpKernel {
     for (int i = 0; i < input_flat.size(); ++i) {
       StringPiece line(input_flat(i));
       str_util::RemoveWhitespaceContext(&line);
+
       StringPiece piece;
-      ;
       OP_REQUIRES(ctx, str_util::ConsumeNonWhitespace(&line, &piece),
                   errors::InvalidArgument("No label found for input[", i,
                                           "]: \"", input_flat(i), "\""));

--- a/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
+++ b/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
@@ -46,34 +46,30 @@ class DecodeLibsvmOp : public OpKernel {
     std::vector<T> out_values;
     std::vector<std::pair<int64, int64>> out_indices;
     for (int i = 0; i < input_flat.size(); ++i) {
-      std::vector<string> entries =
-          str_util::Split(input_flat(i), " ", str_util::SkipEmpty());
-      OP_REQUIRES(ctx, !entries.empty(),
-                  errors::InvalidArgument("No entries found for input[", i,
-                                          "]: \"", input_flat(i), "\""));
+      StringPiece line(input_flat(i));
+      str_util::RemoveWhitespaceContext(&line);
+      StringPiece piece;;
+      OP_REQUIRES(ctx, str_util::ConsumeNonWhitespace(&line, &piece), errors::InvalidArgument("No label found for input[", i, "]: \"", input_flat(i), "\""));
+
       Tlabel label_value;
-      OP_REQUIRES(
-          ctx, strings::SafeStringToNumeric<Tlabel>(entries[0], &label_value),
-          errors::InvalidArgument("Label format incorrect: ", entries[0]));
+      OP_REQUIRES(ctx, strings::SafeStringToNumeric<Tlabel>(piece, &label_value), errors::InvalidArgument("Label format incorrect: ", piece));
       label(i) = label_value;
-      for (int j = 1; j < entries.size(); j++) {
-        std::vector<string> pair = str_util::Split(entries[j], ":");
-        OP_REQUIRES(
-            ctx, (pair.size() == 2),
-            errors::InvalidArgument("Invalid feature \"", entries[j], "\""));
+
+      str_util::RemoveLeadingWhitespace(&line);
+      while (str_util::ConsumeNonWhitespace(&line, &piece)) {
+        size_t p = piece.find(':');
+        OP_REQUIRES(ctx, (p != StringPiece::npos), errors::InvalidArgument("Invalid feature \"", piece, "\""));
+
         int64 feature_index;
-        OP_REQUIRES(
-            ctx, strings::safe_strto64(pair[0].c_str(), &feature_index),
-            errors::InvalidArgument("Feature format incorrect: ", entries[j]));
-        OP_REQUIRES(ctx, (feature_index >= 0),
-                    errors::InvalidArgument(
-                        "Feature index should be >= 0, got ", feature_index));
+        OP_REQUIRES(ctx, strings::safe_strto64(piece.substr(0, p), &feature_index), errors::InvalidArgument("Feature format incorrect: ", piece));
+        OP_REQUIRES(ctx, (feature_index >= 0), errors::InvalidArgument("Feature index should be >= 0, got ", feature_index));
+
         T feature_value;
-        OP_REQUIRES(
-            ctx, strings::SafeStringToNumeric<T>(pair[1], &feature_value),
-            errors::InvalidArgument("Feature format incorrect: ", entries[j]));
+        OP_REQUIRES(ctx, strings::SafeStringToNumeric<T>(piece.substr(p + 1), &feature_value), errors::InvalidArgument("Feature format incorrect: ", piece));
         out_values.emplace_back(feature_value);
         out_indices.emplace_back(std::pair<int64, int64>(i, feature_index));
+
+        str_util::RemoveLeadingWhitespace(&line);
       }
     }
 

--- a/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
+++ b/tensorflow/contrib/libsvm/kernels/decode_libsvm_op.cc
@@ -48,24 +48,38 @@ class DecodeLibsvmOp : public OpKernel {
     for (int i = 0; i < input_flat.size(); ++i) {
       StringPiece line(input_flat(i));
       str_util::RemoveWhitespaceContext(&line);
-      StringPiece piece;;
-      OP_REQUIRES(ctx, str_util::ConsumeNonWhitespace(&line, &piece), errors::InvalidArgument("No label found for input[", i, "]: \"", input_flat(i), "\""));
+      StringPiece piece;
+      ;
+      OP_REQUIRES(ctx, str_util::ConsumeNonWhitespace(&line, &piece),
+                  errors::InvalidArgument("No label found for input[", i,
+                                          "]: \"", input_flat(i), "\""));
 
       Tlabel label_value;
-      OP_REQUIRES(ctx, strings::SafeStringToNumeric<Tlabel>(piece, &label_value), errors::InvalidArgument("Label format incorrect: ", piece));
+      OP_REQUIRES(ctx,
+                  strings::SafeStringToNumeric<Tlabel>(piece, &label_value),
+                  errors::InvalidArgument("Label format incorrect: ", piece));
       label(i) = label_value;
 
       str_util::RemoveLeadingWhitespace(&line);
       while (str_util::ConsumeNonWhitespace(&line, &piece)) {
         size_t p = piece.find(':');
-        OP_REQUIRES(ctx, (p != StringPiece::npos), errors::InvalidArgument("Invalid feature \"", piece, "\""));
+        OP_REQUIRES(ctx, (p != StringPiece::npos),
+                    errors::InvalidArgument("Invalid feature \"", piece, "\""));
 
         int64 feature_index;
-        OP_REQUIRES(ctx, strings::safe_strto64(piece.substr(0, p), &feature_index), errors::InvalidArgument("Feature format incorrect: ", piece));
-        OP_REQUIRES(ctx, (feature_index >= 0), errors::InvalidArgument("Feature index should be >= 0, got ", feature_index));
+        OP_REQUIRES(
+            ctx, strings::safe_strto64(piece.substr(0, p), &feature_index),
+            errors::InvalidArgument("Feature format incorrect: ", piece));
+        OP_REQUIRES(ctx, (feature_index >= 0),
+                    errors::InvalidArgument(
+                        "Feature index should be >= 0, got ", feature_index));
 
         T feature_value;
-        OP_REQUIRES(ctx, strings::SafeStringToNumeric<T>(piece.substr(p + 1), &feature_value), errors::InvalidArgument("Feature format incorrect: ", piece));
+        OP_REQUIRES(
+            ctx,
+            strings::SafeStringToNumeric<T>(piece.substr(p + 1),
+                                            &feature_value),
+            errors::InvalidArgument("Feature format incorrect: ", piece));
         out_values.emplace_back(feature_value);
         out_indices.emplace_back(std::pair<int64, int64>(i, feature_index));
 


### PR DESCRIPTION
This fix is an improvement to #14330. Previously, string split was handled through `str_util::Split`, which may incur unnecessary memory allocations. This fix uses StringPiece instead.

See comment https://github.com/tensorflow/tensorflow/pull/14330#pullrequestreview-79877956 for reference.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>