### PR TITLE
Fix unstable test case for Select op

### DIFF
--- a/tensorflow/cc/gradients/math_grad.cc
+++ b/tensorflow/cc/gradients/math_grad.cc
@@ -763,6 +763,24 @@ Status LgammaGrad(const Scope& scope, const Operation& op,
 }
 REGISTER_GRADIENT_OP("Lgamma", LgammaGrad);
 
+Status SelectGrad(const Scope& scope, const Operation& op,
+                  const std::vector<Output>& grad_inputs,
+                  std::vector<Output>* grad_outputs) {
+  auto comparator = op.input(0);
+  auto x = op.input(1);
+  auto zeros = ZerosLike(scope, x);
+  auto grad = grad_inputs[0];
+
+  auto gx_1 = Where3(scope, comparator, grad, zeros);
+  auto gx_2 = Where3(scope, comparator, zeros, grad);
+
+  grad_outputs->push_back(NoGradient());
+  grad_outputs->push_back(gx_1);
+  grad_outputs->push_back(gx_2);
+  return scope.status();
+}
+REGISTER_GRADIENT_OP("Select", SelectGrad);
+
 Status MinOrMaxGrad(const Scope& scope, const Operation& op,
                     const std::vector<Output>& grad_inputs,
                     std::vector<Output>* grad_outputs) {

--- a/tensorflow/cc/gradients/math_grad_test.cc
+++ b/tensorflow/cc/gradients/math_grad_test.cc
@@ -882,5 +882,13 @@ TEST_F(NaryGradTest, Prod) {
   RunTest({x}, {x_shape}, {y}, {y_shape});
 }
 
+TEST_F(NaryGradTest, Select) {
+  TensorShape shape({3, 4});
+  auto x1 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(shape));
+  auto x2 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(shape));
+  auto y = Where3(scope_, Greater(scope_, x1, x2), x1, x2);
+  RunTest({x1, x2}, {shape, shape}, {y}, {shape});
+}
+
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/cc/gradients/math_grad_test.cc
+++ b/tensorflow/cc/gradients/math_grad_test.cc
@@ -883,10 +883,14 @@ TEST_F(NaryGradTest, Prod) {
 }
 
 TEST_F(NaryGradTest, Select) {
-  TensorShape shape({3, 4});
+  TensorShape shape({3, 2});
   auto x1 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(shape));
   auto x2 = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(shape));
-  auto y = Where3(scope_, Greater(scope_, x1, x2), x1, x2);
+  // Use constant values to avoid instability when computing
+  Tensor c =
+      test::AsTensor<float>({-3.5f, 1.5f, -1.2f, 3.0f, -2.5f, 2.8f}, {3, 2});
+  auto zero = Cast(scope_, Const(scope_, 0.0), c.dtype());
+  auto y = Where3(scope_, Greater(scope_, c, zero), x1, x2);
   RunTest({x1, x2}, {shape, shape}, {y}, {shape});
 }
 


### PR DESCRIPTION
Fix #14862. CF: #15764

In the test case for Select op, the condition might switch to another value when `x1` is close to `x2`.  The PR is opened to resolve the unstable condition.

Test passed for 100 times.
```bash
[facai@h1077922 tensorflow]$ bazel test --runs_per_test=100 -c opt //tensorflow/cc:gradients_math_grad_test
HEAD is now at c642574... TST: modify unstable test case
INFO: Found 1 test target...
Target //tensorflow/cc:gradients_math_grad_test up-to-date:
  bazel-bin/tensorflow/cc/gradients_math_grad_test
INFO: Elapsed time: 49.959s, Critical Path: 21.29s
//tensorflow/cc:gradients_math_grad_test                                 PASSED in 21.3s
  Stats over 100 runs: max = 21.3s, min = 0.7s, avg = 11.2s, dev = 4.4s

Executed 1 out of 1 test: 1 test passes.
```

cc @gunan @drpngx 
  