### PR TITLE
Remove noop python command in pyx_library rule.

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -67,14 +67,14 @@ def pyx_library(
       pxd_srcs.append(src)
 
   # Invoke cython to produce the shared object libraries.
-  cpp_outs = [src.split(".")[0] + ".cpp" for src in pyx_srcs]
-  native.genrule(
-      name = name + "_cython_translation",
-      srcs = pyx_srcs,
-      outs = cpp_outs,
-      cmd = "PYTHONHASHSEED=0 $(location @cython//:cython_binary) --cplus $(SRCS)",
-      tools = ["@cython//:cython_binary"] + pxd_srcs,
-  )
+  for filename in pyx_srcs:
+    native.genrule(
+        name = filename + "_cython_translation",
+        srcs = [filename],
+        outs = [filename.split(".")[0] + ".cpp"],
+        cmd = "PYTHONHASHSEED=0 $(location @cython//:cython_binary) --cplus $(SRCS) --output-file $(OUTS)",
+        tools = ["@cython//:cython_binary"] + pxd_srcs,
+    )
 
   shared_objects = []
   for src in pyx_srcs:

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -72,9 +72,7 @@ def pyx_library(
       name = name + "_cython_translation",
       srcs = pyx_srcs,
       outs = cpp_outs,
-      cmd = ("PYTHONHASHSEED=0 $(location @cython//:cython_binary) --cplus $(SRCS)"
-             # Rename outputs to expected location.
-             + """ && python -c 'import shutil, sys; n = len(sys.argv); [shutil.copyfile(src.split(".")[0] + ".cpp", dst) for src, dst in zip(sys.argv[1:], sys.argv[1+n//2:])]' $(SRCS) $(OUTS)"""),
+      cmd = "PYTHONHASHSEED=0 $(location @cython//:cython_binary) --cplus $(SRCS)",
       tools = ["@cython//:cython_binary"] + pxd_srcs,
   )
 


### PR DESCRIPTION
It looks to me like the command produced should be:
`shutil.copyfile(src.split(".")[0] + ".cpp", src.split(".")[0] + ".cpp")`
based on how `cpp_outs` is constructed a few lines above?
Allen,  could you take a look and comment?

This file,  and the direct call to the python binary is one of the root causes of #15618