### PR TITLE
Revert "Fix a bug: bfloat16 is unsigned on Windows (#15302)"

### DIFF
--- a/tensorflow/core/framework/numeric_types.h
+++ b/tensorflow/core/framework/numeric_types.h
@@ -25,7 +25,6 @@ limitations under the License.
 #include "third_party/eigen3/unsupported/Eigen/CXX11/FixedPoint"
 // clang-format on
 
-#include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/types.h"
 
 namespace tensorflow {


### PR DESCRIPTION
This reverts commit fdf34a88bec9645473f10ba2d52df4cfcb80d582.

Since the fix for #15302 is not getting merged soon, I'll revert it to fix the Windows build.
@gunan 
FYI, @snnn 