### PR TITLE
Updating error handling in normalize_tuple

### DIFF
--- a/tensorflow/python/layers/utils.py
+++ b/tensorflow/python/layers/utils.py
@@ -81,7 +81,7 @@ def normalize_tuple(value, n, name):
     for single_value in value_tuple:
       try:
         int(single_value)
-      except ValueError:
+      except (ValueError, TypeError):
         raise ValueError('The `' + name + '` argument must be a tuple of ' +
                          str(n) + ' integers. Received: ' + str(value) + ' '
                          'including element ' + str(single_value) + ' of type' +


### PR DESCRIPTION
In normalize_tuple we test to see if all values are an int (or able to be cast to an int) using `int()`

`ValueError` is thrown if `int()` is called with an input like 'asdf' - this is caught and gives a helpful error, using the 'name' param to provide more context.

**However**, when given an input other than a string or int, a `TypeError` is thrown. This is **not** caught - making error messages much more esoteric than the helpful one written out here, especially when coming from a very long stack trace.

For example, before this change I was getting an error:
```
TypeError: int() argument must be a string or a number, not 'tuple'
```

With this change, I get the more useful:
```
ValueError: The `kernel_size` argument must be a tuple of 2 integers. 
Received: ((0, 3), 50) including element (0, 3) of type <type 'tuple'>
```
  
  