### PR TITLE
Remove :0 in final result argument

### DIFF
--- a/tensorflow/docs_src/tutorials/image_retraining.md
+++ b/tensorflow/docs_src/tutorials/image_retraining.md
@@ -390,7 +390,7 @@ image size that your model expects, as follows:
 python tensorflow/examples/label_image/label_image.py \
 --graph=/tmp/output_graph.pb --labels=/tmp/output_labels.txt \
 --input_layer=input \
---output_layer=final_result:0 \
+--output_layer=final_result \
 --input_height=224 --input_width=224 \
 --input_mean=128 --input_std=128 \
 --image=$HOME/flower_photos/daisy/21652746_cc379e0eea_m.jpg


### PR DESCRIPTION
Small change to line 393 - in my recent testing of retrain and the label_image workflow as of today (TF master @  136697e) I had to remove :0 from the label_image output_layer argument.

Thank you.