### PR TITLE
Add axis support for `tf.nn.crelu`

### DIFF
--- a/tensorflow/python/kernel_tests/relu_op_test.py
+++ b/tensorflow/python/kernel_tests/relu_op_test.py
@@ -452,7 +452,6 @@ class CreluTest(test.TestCase):
                            [9, 0, 5, 0, 1],
                            [0, 3, 0, 7, 0]])
       self.assertAllEqual(np_crelu, tf_relu)
-      self.assertShapeEqual(np_crelu, crelu)
 
   def testNumbersWithAxis1(self):
     with self.test_session():
@@ -463,7 +462,6 @@ class CreluTest(test.TestCase):
       np_crelu = np.array([[0, 7, 0, 3, 0, 9, 0, 5, 0, 1],
                            [1, 0, 5, 0, 9, 0, 3, 0, 7, 0]])
       self.assertAllEqual(np_crelu, tf_relu)
-      self.assertShapeEqual(np_crelu, crelu)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/relu_op_test.py
+++ b/tensorflow/python/kernel_tests/relu_op_test.py
@@ -441,6 +441,30 @@ class CreluTest(test.TestCase):
             np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t),
             use_gpu=True)
 
+  def testNumbersWithAxis0(self):
+    with self.test_session():
+      crelu = nn_ops.crelu(
+          np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]),
+          axis=0)
+      tf_relu = crelu.eval()
+      np_crelu = np.array([[0, 7, 0, 3, 0],
+                           [1, 0, 5, 0, 9],
+                           [9, 0, 5, 0, 1],
+                           [0, 3, 0, 7, 0]])
+      self.assertAllEqual(np_crelu, tf_relu)
+      self.assertShapeEqual(np_crelu, crelu)
+
+  def testNumbersWithAxis1(self):
+    with self.test_session():
+      crelu = nn_ops.crelu(
+          np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]),
+          axis=1)
+      tf_relu = crelu.eval()
+      np_crelu = np.array([[0, 7, 0, 3, 0, 9, 0, 5, 0, 1],
+                           [1, 0, 5, 0, 9, 0, 3, 0, 7, 0]])
+      self.assertAllEqual(np_crelu, tf_relu)
+      self.assertShapeEqual(np_crelu, crelu)
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1498,7 +1498,7 @@ def bias_add_v1(value, bias, name=None):
     return gen_nn_ops._bias_add_v1(value, bias, name=name)
 
 
-def crelu(features, name=None):
+def crelu(features, name=None, axis=-1):
   """Computes Concatenated ReLU.
 
   Concatenates a ReLU which selects only the positive part of the activation
@@ -1510,13 +1510,14 @@ def crelu(features, name=None):
     features: A `Tensor` with type `float`, `double`, `int32`, `int64`, `uint8`,
       `int16`, or `int8`.
     name: A name for the operation (optional).
+    axis: The axis that the output values are concatenated along. Default is -1.
 
   Returns:
     A `Tensor` with the same type as `features`.
   """
   with ops.name_scope(name, "CRelu", [features]) as name:
     features = ops.convert_to_tensor(features, name="features")
-    c = array_ops.concat([features, -features], -1, name=name)
+    c = array_ops.concat([features, -features], axis, name=name)
     return gen_nn_ops.relu(c)
 
 

--- a/tensorflow/tools/api/golden/tensorflow.nn.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.nn.pbtxt
@@ -86,7 +86,7 @@ tf_module {
   }
   member_method {
     name: "crelu"
-    argspec: "args=[\'features\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'features\', \'name\', \'axis\'], varargs=None, keywords=None, defaults=[\'None\', \'-1\'], "
   }
   member_method {
     name: "ctc_beam_search_decoder"


### PR DESCRIPTION
This fix tries to address the issue raised in #15619 where it was not possible to specify an `axis` for
`tf.nn.crelu`. By default, `axis=-1` was used for concatenation implicitly.

This fix adds the support of `axis` for `tf.nn.crelu`, and adds test cases for it.

This fix fixes #15619.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>