### PR TITLE
Fix LSTM Layer Normalization implementation to match original paper

### DIFF
--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_cell_test.py
@@ -522,39 +522,40 @@ class RNNCellTest(test.TestCase):
       num_proj = 3
       batch_size = 1
       input_size = 4
-      with variable_scope.variable_scope(
-          "root", initializer=init_ops.constant_initializer(0.5)):
-        x = array_ops.zeros([batch_size, input_size])
-        c = array_ops.zeros([batch_size, num_units])
-        h = array_ops.zeros([batch_size, num_proj])
-        state = rnn_cell_impl.LSTMStateTuple(c, h)
-        cell = contrib_rnn_cell.LayerNormLSTMCell(
-            num_units=num_units,
-            num_proj=num_proj,
-            forget_bias=1.0,
-            layer_norm=True,
-            norm_gain=1.0,
-            norm_shift=0.0)
-        g, out_m = cell(x, state)
-        sess.run([variables_lib.global_variables_initializer()])
-        res = sess.run(
-            [g, out_m], {
-                x.name: np.ones((batch_size, input_size)),
-                c.name: 0.1 * np.ones((batch_size, num_units)),
-                h.name: 0.1 * np.ones((batch_size, num_proj))
-            })
-        self.assertEqual(len(res), 2)
-        # The numbers in results were not calculated, this is mostly just a
-        # smoke test.
-        self.assertEqual(res[0].shape, (batch_size, num_proj))
-        self.assertEqual(res[1][0].shape, (batch_size, num_units))
-        self.assertEqual(res[1][1].shape, (batch_size, num_proj))
-        # Different inputs so different outputs and states
-        for i in range(1, batch_size):
-          self.assertTrue(
-              float(np.linalg.norm((res[0][0, :] - res[0][i, :]))) < 1e-6)
-          self.assertTrue(
-              float(np.linalg.norm((res[1][0, :] - res[1][i, :]))) < 1e-6)
+      for i, layer_norm_columns in enumerate({False, True}):
+        with variable_scope.variable_scope(
+            "root" + str(i), initializer=init_ops.constant_initializer(0.5)):
+          x = array_ops.zeros([batch_size, input_size])
+          c = array_ops.zeros([batch_size, num_units])
+          h = array_ops.zeros([batch_size, num_proj])
+          state = rnn_cell_impl.LSTMStateTuple(c, h)
+          cell = contrib_rnn_cell.LayerNormLSTMCell(
+              num_units=num_units,
+              num_proj=num_proj,
+              forget_bias=1.0,
+              layer_norm_columns=layer_norm_columns,
+              norm_gain=1.0,
+              norm_shift=0.0)
+          g, out_m = cell(x, state)
+          sess.run([variables_lib.global_variables_initializer()])
+          res = sess.run(
+              [g, out_m], {
+                  x.name: np.ones((batch_size, input_size)),
+                  c.name: 0.1 * np.ones((batch_size, num_units)),
+                  h.name: 0.1 * np.ones((batch_size, num_proj))
+              })
+          self.assertEqual(len(res), 2)
+          # The numbers in results were not calculated, this is mostly just a
+          # smoke test.
+          self.assertEqual(res[0].shape, (batch_size, num_proj))
+          self.assertEqual(res[1][0].shape, (batch_size, num_units))
+          self.assertEqual(res[1][1].shape, (batch_size, num_proj))
+          # Different inputs so different outputs and states
+          for i in range(1, batch_size):
+            self.assertTrue(
+                float(np.linalg.norm((res[0][0, :] - res[0][i, :]))) < 1e-6)
+            self.assertTrue(
+                float(np.linalg.norm((res[1][0, :] - res[1][i, :]))) < 1e-6)
 
   @test_util.run_in_graph_and_eager_modes
   def testWrapperCheckpointing(self):

--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -1213,11 +1213,11 @@ class LayerNormBasicLSTMCellTest(test.TestCase):
                 h1.name: 0.1 * np.asarray([[6, 7]]),
             })
 
-        expected_h = np.array([[0.70230919, 0.72581059]])
-        expected_state0_c = np.array([[0.8020075, 0.89599884]])
-        expected_state0_h = np.array([[0.56668288, 0.60858738]])
-        expected_state1_c = np.array([[1.17500675, 1.26892781]])
-        expected_state1_h = np.array([[0.70230919, 0.72581059]])
+        expected_h = np.array([[ 0.56360819, 0.59142343]])
+        expected_state0_c = np.array([[ 0.65937076, 0.74983581]])
+        expected_state0_h = np.array([[ 0.44923618, 0.49362504]])
+        expected_state1_c = np.array([[ 0.96667446, 1.05597134]])
+        expected_state1_h = np.array([[ 0.56360819, 0.59142343]])
 
         actual_h = res[0]
         actual_state0_c = res[1][0].c
@@ -1241,15 +1241,14 @@ class LayerNormBasicLSTMCellTest(test.TestCase):
         cell = contrib_rnn_cell.LayerNormBasicLSTMCell(2, layer_norm=False)
         g, out_m = cell(x, state)
         sess.run([variables.global_variables_initializer()])
-        res = sess.run(
-            [g, out_m], {
-                x.name: np.array([[1., 1., 1.]]),
-                c.name: 0.1 * np.asarray([[0, 1]]),
-                h.name: 0.1 * np.asarray([[2, 3]]),
-            })
+        res = sess.run([g, out_m], {
+          x.name: np.array([[1., 1., 1.]]),
+          c.name: 0.1 * np.asarray([[0, 1]]),
+          h.name: 0.1 * np.asarray([[2, 3]]),
+        })
 
-        expected_h = np.array([[0.64121795, 0.68166804]])
-        expected_c = np.array([[0.88477188, 0.98103917]])
+        expected_h = np.array([[ 0.56668288, 0.60858742]])
+        expected_c = np.array([[ 0.80200753, 0.89599886]])
         self.assertEqual(len(res), 2)
         self.assertAllClose(res[0], expected_h, 1e-5)
         self.assertAllClose(res[1].c, expected_c, 1e-5)

--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -1312,9 +1312,9 @@ class LayerNormBasicLSTMCellTest(test.TestCase):
         sess.run([variables.global_variables_initializer()])
         res = sess.run(
           [g, out_m], {
-            x.name: np.array([[1., 1., 1.]]),
-            c.name: 0.1 * np.asarray([[0, 1]]),
-            h.name: 0.1 * np.asarray([[2, 3]]),
+              x.name: np.array([[1., 1., 1.]]),
+              c.name: 0.1 * np.asarray([[0, 1]]),
+              h.name: 0.1 * np.asarray([[2, 3]]),
           })
 
         expected_h = np.array([[0.56668288, 0.60858742]])

--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -1269,8 +1269,7 @@ class LayerNormBasicLSTMCellTest(test.TestCase):
         h1 = array_ops.zeros([1, 2])
         state1 = rnn_cell.LSTMStateTuple(c1, h1)
         state = (state0, state1)
-        single_cell = lambda: contrib_rnn_cell.LayerNormBasicLSTMCell(2,
-          layer_norm=False)
+        single_cell = lambda: contrib_rnn_cell.LayerNormBasicLSTMCell(2, layer_norm=False)  # pylint: disable=line-too-long
         cell = rnn_cell.MultiRNNCell([single_cell() for _ in range(2)])
         g, out_m = cell(x, state)
         sess.run([variables.global_variables_initializer()])
@@ -1283,11 +1282,11 @@ class LayerNormBasicLSTMCellTest(test.TestCase):
                 h1.name: 0.1 * np.asarray([[6, 7]]),
             })
 
-        expected_h = np.array([[ 0.56360819, 0.59142343]])
-        expected_state0_c = np.array([[ 0.65937076, 0.74983581]])
-        expected_state0_h = np.array([[ 0.44923618, 0.49362504]])
-        expected_state1_c = np.array([[ 0.96667446, 1.05597134]])
-        expected_state1_h = np.array([[ 0.56360819, 0.59142343]])
+        expected_h = np.array([[0.56360819, 0.59142343]])
+        expected_state0_c = np.array([[0.65937076, 0.74983581]])
+        expected_state0_h = np.array([[0.44923618, 0.49362504]])
+        expected_state1_c = np.array([[0.96667446, 1.05597134]])
+        expected_state1_h = np.array([[0.56360819, 0.59142343]])
 
         actual_h = res[0]
         actual_state0_c = res[1][0].c
@@ -1311,14 +1310,15 @@ class LayerNormBasicLSTMCellTest(test.TestCase):
         cell = contrib_rnn_cell.LayerNormBasicLSTMCell(2, layer_norm=False)
         g, out_m = cell(x, state)
         sess.run([variables.global_variables_initializer()])
-        res = sess.run([g, out_m], {
-          x.name: np.array([[1., 1., 1.]]),
-          c.name: 0.1 * np.asarray([[0, 1]]),
-          h.name: 0.1 * np.asarray([[2, 3]]),
-        })
+        res = sess.run(
+          [g, out_m], {
+            x.name: np.array([[1., 1., 1.]]),
+            c.name: 0.1 * np.asarray([[0, 1]]),
+            h.name: 0.1 * np.asarray([[2, 3]]),
+          })
 
-        expected_h = np.array([[ 0.56668288, 0.60858742]])
-        expected_c = np.array([[ 0.80200753, 0.89599886]])
+        expected_h = np.array([[0.56668288, 0.60858742]])
+        expected_c = np.array([[0.80200753, 0.89599886]])
         self.assertEqual(len(res), 2)
         self.assertAllClose(res[0], expected_h, 1e-5)
         self.assertAllClose(res[1].c, expected_c, 1e-5)
@@ -1375,7 +1375,7 @@ class LayerNormBasicLSTMCellTest(test.TestCase):
         state1 = rnn_cell_impl.LSTMStateTuple(c1, h1)
         cell = rnn_cell_impl.MultiRNNCell([
             contrib_rnn_cell.LayerNormLSTMCell(
-                2, norm_gain=1.0, norm_shift=0.0)
+                2, layer_norm=True, norm_gain=1.0, norm_shift=0.0)
             for _ in range(2)
         ])
         h, (s0, s1) = cell(x, (state0, state1))

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -2598,8 +2598,8 @@ class LayerNormLSTMCell(rnn_cell_impl.RNNCell):
     Returns:
       A 2D Tensor with shape [batch x output_size] taking value
       sum_i(args[i] * W[i]), where each W[i] is a newly created Variable,
-      and where args[i] * W[i] will be layer normalized if `layer_norm` is
-      "columns"
+      and where args[i] * W[i] will be layer normalized if `layer_norm_columns`
+      is False.
 
     Raises:
       ValueError: if some of the arguments has unspecified or wrong shape.

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -1361,10 +1361,17 @@ class LayerNormBasicLSTMCell(rnn_cell_impl.RNNCell):
   Stanislau Semeniuta, Aliaksei Severyn, Erhardt Barth.
   """
 
-  def __init__(self, num_units, forget_bias=1.0,
-               input_size=None, activation=math_ops.tanh,
-               layer_norm=True, layer_norm_columns=True, norm_gain=1.0,
-               norm_shift=0.0, dropout_keep_prob=1.0, dropout_prob_seed=None,
+  def __init__(self,
+               num_units,
+               forget_bias=1.0,
+               input_size=None,
+               activation=math_ops.tanh,
+               layer_norm=True,
+               layer_norm_columns=True,
+               norm_gain=1.0,
+               norm_shift=0.0,
+               dropout_keep_prob=1.0,
+               dropout_prob_seed=None,
                reuse=None):
     """Initializes the basic LSTM cell.
 


### PR DESCRIPTION
The Layer Norm paper (https://arxiv.org/abs/1607.06450) applies layer norm to LSTMs by separately normalizing the linear transformation of the inputs and the linear transformation of the recurrent cell state. See equation (20) in the Supplementary Material (page 13).

The current contrib LSTM layer norm implementations apply layer norm to LSTMs by separately normalizing each of the gate/cell update preactivations (separate columns of the sum of the linear transformations of the inputs and recurrent cell state). This is very different from the paper (different tensors are being normalized).

This PR changes the two implementations to match the paper. There is one slight difference with the paper: I omit two of the layer norm offset _β_ parameters because there is a bias term already.
  
  
  