### PR TITLE
Fix typo in eager value_and_gradients docstring

### DIFF
--- a/tensorflow/python/eager/backprop.py
+++ b/tensorflow/python/eager/backprop.py
@@ -550,7 +550,7 @@ def _ensure_unique_tensor_objects(parameter_positions, args):
 
 
 def val_and_grad_function(f, params=None):
-  """Returns a function that computes f and is derivative w.r.t. params.
+  """Returns a function that computes f and its derivative w.r.t. params.
 
   Example:
   ```python


### PR DESCRIPTION
The function is computing gradients with respect to `f`, so this is possessive of the function if I'm reading this properly.