### PR TITLE
Transpose for high dimensional tensors using eigen

### DIFF
--- a/tensorflow/core/kernels/transpose_functor_cpu.cc
+++ b/tensorflow/core/kernels/transpose_functor_cpu.cc
@@ -88,6 +88,18 @@ struct Transpose<CPUDevice, T, conjugate> {
         internal::TransposeUsingEigen<CPUDevice, T, 5>(d, in, perm, conjugate,
                                                        out);
         break;
+      case 6:
+	internal::TransposeUsingEigen<CPUDevice, T, 6>(d, in, perm, conjugate,
+						       out);
+	break;
+      case 7:
+	internal::TransposeUsingEigen<CPUDevice, T, 7>(d, in, perm, conjugate,
+						       out);
+	break;
+      case 8:
+        internal::TransposeUsingEigen<CPUDevice, T, 8>(d, in, perm, conjugate,
+						       out);
+	break;
       default:
         TransposeSimple<T, conjugate>(d, in, perm, out);
         break;

--- a/tensorflow/core/kernels/transpose_functor_gpu.cu.cc
+++ b/tensorflow/core/kernels/transpose_functor_gpu.cu.cc
@@ -201,6 +201,27 @@ struct Transpose<GPUDevice, T, conjugate> {
                                                          out);
         }
         break;
+      case 6:
+        if (!internal::TransposeUsingTile<T, conjugate>::run(d, in, perm,
+                                                             out)) {
+          internal::TransposeUsingEigen<GPUDevice, T, 6>(d, in, perm, conjugate,
+                                                         out);
+        }
+        break;
+      case 7:
+        if (!internal::TransposeUsingTile<T, conjugate>::run(d, in, perm,
+                                                             out)) {
+          internal::TransposeUsingEigen<GPUDevice, T, 7>(d, in, perm, conjugate,
+                                                         out);
+        }
+        break;
+      case 8:
+        if (!internal::TransposeUsingTile<T, conjugate>::run(d, in, perm,
+                                                             out)) {
+          internal::TransposeUsingEigen<GPUDevice, T, 8>(d, in, perm, conjugate,
+                                                         out);
+        }
+        break;
       default:
         internal::TransposeSimple<T, conjugate>(d, in, perm, out);
         break;


### PR DESCRIPTION
In our [library](https://github.com/Bihaqo/t3f) we rely heavily on fast transposes of high dimensional tensors, so we have added few extra cases to the CPU and GPU transpose functors. Previously it was done up to dimension 5 and we included dimensions 6, 7, 8 (similarly to the TENSORFLOW_USE_SYCL case).