### PR TITLE
Add clean_dep to a bazel macro.

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -190,7 +190,7 @@ def tf_copts(android_optimization_level_override="-O2", is_external=False):
       + if_android_arm(["-mfpu=neon"])
       + if_linux_x86_64(["-msse3"])
       + select({
-            "//tensorflow:framework_shared_object": [],
+            clean_dep("//tensorflow:framework_shared_object"): [],
             "//conditions:default": ["-DTENSORFLOW_MONOLITHIC_BUILD"],
       })
       + select({


### PR DESCRIPTION
Currently, copts macro has select statement with //tensorflow/...
This resulted in bazel error when any supermodule that uses tensorflow as a submoudle and uses copts macro.
