### PR TITLE
Utility classes for writing Java source code from a C++ process (part 2)

### DIFF
--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -14,6 +14,7 @@ load(
     "tf_copts",
     "tf_custom_op_library",
     "tf_java_test",
+    "tf_cc_test",
 )
 
 java_library(
@@ -103,9 +104,6 @@ cc_library(
     copts = tf_copts(),
     deps = [
         ":java_op_gen_lib",
-        "//tensorflow/core:framework",
-        "//tensorflow/core:framework_internal",
-        "//tensorflow/core:lib",
     ],
 )
 
@@ -113,10 +111,12 @@ cc_library(
     name = "java_op_gen_lib",
     srcs = [
         "src/gen/cc/op_generator.cc",
+        "src/gen/cc/source_writer.cc",
     ],
     hdrs = [
         "src/gen/cc/java_defs.h",
         "src/gen/cc/op_generator.h",
+        "src/gen/cc/source_writer.h",
     ],
     copts = tf_copts(),
     deps = [
@@ -303,6 +303,19 @@ filegroup(
         "src/test/resources/org/tensorflow/**/*.java",
         "src/main/java/org/tensorflow/op/annotation/Operator.java",
     ]),
+)
+
+tf_cc_test(
+    name = "source_writer_test",
+    size = "small",
+    srcs = [
+        "src/gen/cc/source_writer_test.cc",
+    ],
+    deps = [
+        ":java_op_gen_lib",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+    ],
 )
 
 filegroup(

--- a/tensorflow/java/src/gen/cc/source_writer.cc
+++ b/tensorflow/java/src/gen/cc/source_writer.cc
@@ -1,0 +1,72 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <string>
+
+#include "tensorflow/java/src/gen/cc/source_writer.h"
+
+namespace tensorflow {
+
+SourceWriter& SourceWriter::Append(const StringPiece& str) {
+  if (!str.empty()) {
+    if (newline_) {
+      DoAppend(left_margin_ + line_prefix_);
+      newline_ = false;
+    }
+    DoAppend(str);
+  }
+  return *this;
+}
+
+SourceWriter& SourceWriter::Write(const string& str) {
+  size_t line_pos = 0;
+  do {
+    size_t start_pos = line_pos;
+    line_pos = str.find('\n', start_pos);
+    if (line_pos != string::npos) {
+      ++line_pos;
+      Append(StringPiece(str.data() + start_pos, line_pos - start_pos));
+      newline_ = true;
+    } else {
+      Append(StringPiece(str.data() + start_pos, str.size() - start_pos));
+    }
+  } while (line_pos != string::npos && line_pos < str.size());
+
+  return *this;
+}
+
+SourceWriter& SourceWriter::EndLine() {
+  Append("\n");
+  newline_ = true;
+  return *this;
+}
+
+SourceWriter& SourceWriter::Indent(int tab) {
+  left_margin_.resize(
+      std::max(static_cast<int>(left_margin_.size() + tab), 0), ' ');
+  return *this;
+}
+
+SourceWriter& SourceWriter::SetLinePrefix(const char* line_prefix) {
+  line_prefix_ = line_prefix;
+  return *this;
+}
+
+SourceWriter& SourceWriter::UnsetLinePrefix() {
+  line_prefix_.clear();
+  return *this;
+}
+
+}  // namespace tensorflow

--- a/tensorflow/java/src/gen/cc/source_writer.cc
+++ b/tensorflow/java/src/gen/cc/source_writer.cc
@@ -59,14 +59,4 @@ SourceWriter& SourceWriter::Indent(int tab) {
   return *this;
 }
 
-SourceWriter& SourceWriter::SetLinePrefix(const char* line_prefix) {
-  line_prefix_ = line_prefix;
-  return *this;
-}
-
-SourceWriter& SourceWriter::UnsetLinePrefix() {
-  line_prefix_.clear();
-  return *this;
-}
-
 }  // namespace tensorflow

--- a/tensorflow/java/src/gen/cc/source_writer.h
+++ b/tensorflow/java/src/gen/cc/source_writer.h
@@ -72,11 +72,13 @@ class SourceWriter {
   // A common use case of a prefix is for commenting or documenting the code.
   //
   // The prefix is written after the indentation, For example, invoking
-  // Indent(2)->SetLinePrefix("//") will result in prefixing lines with "  //".
-  SourceWriter& SetLinePrefix(const char* line_prefix);
-
-  // Removes the actual line prefix, if any.
-  SourceWriter& UnsetLinePrefix();
+  // Indent(2)->Prefix("//") will result in prefixing lines with "  //".
+  //
+  // An empty value ("") will remove any line prefix that was previously set.
+  SourceWriter& Prefix(const char* line_prefix) {
+    line_prefix_ = line_prefix;
+    return *this;
+  }
 
  protected:
   virtual void DoAppend(const StringPiece& str) = 0;

--- a/tensorflow/java/src/gen/cc/source_writer.h
+++ b/tensorflow/java/src/gen/cc/source_writer.h
@@ -1,0 +1,131 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_JAVA_SRC_GEN_CC_SOURCE_WRITER_H_
+#define TENSORFLOW_JAVA_SRC_GEN_CC_SOURCE_WRITER_H_
+
+#include <string>
+
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/lib/core/stringpiece.h"
+
+namespace tensorflow {
+
+// A utility class for writing source code, normally generated at
+// compile-time.
+//
+// Source writers are language-agnostic and therefore only expose generic
+// methods common to most languages. Extend or wrap this class to implement
+// language-specific features.
+//
+// Note: if you are looking to reuse this class for generating code in another
+// language than Java, please do by moving it at the '//tensorflow/core/lib/io'
+// level.
+class SourceWriter {
+ public:
+  virtual ~SourceWriter() = default;
+
+  // Returns true if the writer is at the beginnig of a new line
+  bool newline() const { return newline_; }
+
+  // Appends a piece of code or text.
+  //
+  // It is expected that no newline character is present in the data provided,
+  // otherwise Write() must be used.
+  SourceWriter& Append(const StringPiece& str);
+
+  // Writes a block of code or text.
+  //
+  // The data might potentially contain newline characters, therefore it will
+  // be scanned to ensure that each line is indented and prefixed properly,
+  // making it a bit slower than Append().
+  SourceWriter& Write(const string& text);
+
+  // Appends a newline character and start writing on a new line.
+  SourceWriter& EndLine();
+
+  // Indents following lines with white spaces.
+  //
+  // Indentation is cumulative, i.e. the provided tabulation is added to the
+  // current indentation value. If the tabulation is negative, the operation
+  // will outdent the source code, until the indentation reaches 0 again.
+  //
+  // For example, calling Indent(2) twice will indent code with 4 white
+  // spaces. Then calling Indent(-2) will outdent the code back to 2 white
+  // spaces.
+  SourceWriter& Indent(int tab);
+
+  // Prefixes following lines with provided character(s).
+  //
+  // A common use case of a prefix is for commenting or documenting the code.
+  //
+  // The prefix is written after the indentation, For example, invoking
+  // Indent(2)->SetLinePrefix("//") will result in prefixing lines with "  //".
+  SourceWriter& SetLinePrefix(const char* line_prefix);
+
+  // Removes the actual line prefix, if any.
+  SourceWriter& UnsetLinePrefix();
+
+ protected:
+  virtual void DoAppend(const StringPiece& str) = 0;
+
+ private:
+  string left_margin_;
+  string line_prefix_;
+  bool newline_ = true;
+};
+
+// A writer that outputs source code into a file.
+//
+// Note: the writer does not acquire the ownership of the file being passed in
+// parameter.
+class SourceFileWriter : public SourceWriter {
+ public:
+  explicit SourceFileWriter(WritableFile* file) : file_(file) {}
+  virtual ~SourceFileWriter() = default;
+
+ protected:
+  void DoAppend(const StringPiece& str) override {
+    TF_CHECK_OK(file_->Append(str));
+  }
+ private:
+  WritableFile* file_;
+};
+
+// A writer that outputs source code into a string buffer.
+class SourceBufferWriter : public SourceWriter {
+ public:
+  SourceBufferWriter()
+    : owns_buffer_(true), buffer_(new string()) {}
+  explicit SourceBufferWriter(string* buffer)
+    : owns_buffer_(false), buffer_(buffer) {}
+  virtual ~SourceBufferWriter() {
+    if (owns_buffer_) delete buffer_;
+  }
+  const string& str() {
+    return *buffer_;
+  }
+ protected:
+  void DoAppend(const StringPiece& str) override {
+    buffer_->append(str.begin(), str.end());
+  }
+ private:
+  bool owns_buffer_;
+  string* buffer_;
+};
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_JAVA_SRC_GEN_CC_SOURCE_WRITER_H_

--- a/tensorflow/java/src/gen/cc/source_writer_test.cc
+++ b/tensorflow/java/src/gen/cc/source_writer_test.cc
@@ -1,0 +1,219 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/lib/io/path.h"
+#include "tensorflow/java/src/gen/cc/source_writer.h"
+
+namespace tensorflow {
+namespace {
+
+TEST(AppendTest, SingleLineText) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye and I say hello!");
+
+  const char* expected = "You say goodbye and I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(AppendTest, MultiLineText) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye\nand I say hello!");
+
+  const char* expected = "You say goodbye\nand I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(AppendTest, MultiLineTextWithIndent) {
+  SourceBufferWriter writer;
+  writer.Indent(2).Append("You say goodbye\nand I say hello!");
+
+  const char* expected = "  You say goodbye\nand I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(AppendTest, MultiLineTextWithPrefix) {
+  SourceBufferWriter writer;
+  writer.SetLinePrefix("--").Append("You say goodbye\nand I say hello!");
+
+  const char* expected = "--You say goodbye\nand I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(AppendTest, MultiLineTextWithIndentAndPrefix) {
+  SourceBufferWriter writer;
+  writer.Indent(2)
+        .SetLinePrefix("--")
+        .Append("You say goodbye\nand I say hello!");
+
+  const char* expected = "  --You say goodbye\nand I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(WriteTest, SingleLineText) {
+  SourceBufferWriter writer;
+  writer.Write("You say goodbye and I say hello!");
+
+  const char* expected = "You say goodbye and I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(WriteTest, MultiLineText) {
+  SourceBufferWriter writer;
+  writer.Write("You say goodbye\nand I say hello!");
+
+  const char* expected = "You say goodbye\nand I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(WriteTest, MultiLineTextWithIndent) {
+  SourceBufferWriter writer;
+  writer.Indent(2).Write("You say goodbye\nand I say hello!");
+
+  const char* expected = "  You say goodbye\n  and I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(WriteTest, MultiLineTextWithPrefix) {
+  SourceBufferWriter writer;
+  writer.SetLinePrefix("--").Write("You say goodbye\nand I say hello!");
+
+  const char* expected = "--You say goodbye\n--and I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(WriteTest, MultiLineTextWithIndentAndPrefix) {
+  SourceBufferWriter writer;
+  writer.Indent(2)
+        .SetLinePrefix("--")
+        .Write("You say goodbye\nand I say hello!");
+
+  const char* expected = "  --You say goodbye\n  --and I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(MarginTest, Basic) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye").EndLine().Append("and I say hello!");
+
+  const char* expected = "You say goodbye\nand I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(MarginTest, Indent) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye")
+        .EndLine()
+        .Indent(2)
+        .Append("and I say hello!");
+
+  const char* expected = "You say goodbye\n  and I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(MarginTest, IndentAndOutdent) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye")
+        .EndLine()
+        .Indent(2)
+        .Append("and I say hello!")
+        .EndLine()
+        .Indent(-2)
+        .Append("Hello, hello!");
+
+  const char* expected = "You say goodbye\n  and I say hello!\nHello, hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(MarginTest, SetLinePrefix) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye")
+        .EndLine()
+        .SetLinePrefix("--")
+        .Append("and I say hello!");
+
+  const char* expected = "You say goodbye\n--and I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(MarginTest, PrefixAndRemovePrefix) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye")
+        .EndLine()
+        .SetLinePrefix("--")
+        .Append("and I say hello!")
+        .EndLine()
+        .UnsetLinePrefix()
+        .Append("Hello, hello!");
+
+  const char* expected = "You say goodbye\n--and I say hello!\nHello, hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(MarginTest, IndentAndPrefixAndOutdentAndRemovePrefix) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye")
+        .EndLine()
+        .Indent(2)
+        .SetLinePrefix("--")
+        .Append("and I say hello!")
+        .EndLine()
+        .Indent(-2)
+        .UnsetLinePrefix()
+        .Append("Hello, hello!");
+
+  const char* expected = "You say goodbye\n  --and I say hello!\nHello, hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(MarginTest, NegativeIndent) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye")
+        .EndLine()
+        .Indent(-10)
+        .Append("and I say hello!");
+
+  const char* expected = "You say goodbye\nand I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(MarginTest, CumulativeIndent) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye")
+        .EndLine()
+        .Indent(2)
+        .Append("and I say hello!")
+        .EndLine()
+        .Indent(2)
+        .Append("Hello, hello!");
+
+  const char* expected =
+      "You say goodbye\n  and I say hello!\n    Hello, hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+TEST(MarginTest, EmptyPrefix) {
+  SourceBufferWriter writer;
+  writer.Append("You say goodbye")
+        .EndLine()
+        .SetLinePrefix("")
+        .Append("and I say hello!");
+
+  const char* expected = "You say goodbye\nand I say hello!";
+  ASSERT_STREQ(expected, writer.str().data());
+}
+
+}  // namespace
+}  // namespace tensorflow

--- a/tensorflow/java/src/gen/cc/source_writer_test.cc
+++ b/tensorflow/java/src/gen/cc/source_writer_test.cc
@@ -46,7 +46,7 @@ TEST(AppendTest, MultiLineTextWithIndent) {
 
 TEST(AppendTest, MultiLineTextWithPrefix) {
   SourceBufferWriter writer;
-  writer.SetLinePrefix("--").Append("You say goodbye\nand I say hello!");
+  writer.Prefix("--").Append("You say goodbye\nand I say hello!");
 
   const char* expected = "--You say goodbye\nand I say hello!";
   ASSERT_STREQ(expected, writer.str().data());
@@ -55,7 +55,7 @@ TEST(AppendTest, MultiLineTextWithPrefix) {
 TEST(AppendTest, MultiLineTextWithIndentAndPrefix) {
   SourceBufferWriter writer;
   writer.Indent(2)
-        .SetLinePrefix("--")
+        .Prefix("--")
         .Append("You say goodbye\nand I say hello!");
 
   const char* expected = "  --You say goodbye\nand I say hello!";
@@ -88,7 +88,7 @@ TEST(WriteTest, MultiLineTextWithIndent) {
 
 TEST(WriteTest, MultiLineTextWithPrefix) {
   SourceBufferWriter writer;
-  writer.SetLinePrefix("--").Write("You say goodbye\nand I say hello!");
+  writer.Prefix("--").Write("You say goodbye\nand I say hello!");
 
   const char* expected = "--You say goodbye\n--and I say hello!";
   ASSERT_STREQ(expected, writer.str().data());
@@ -97,7 +97,7 @@ TEST(WriteTest, MultiLineTextWithPrefix) {
 TEST(WriteTest, MultiLineTextWithIndentAndPrefix) {
   SourceBufferWriter writer;
   writer.Indent(2)
-        .SetLinePrefix("--")
+        .Prefix("--")
         .Write("You say goodbye\nand I say hello!");
 
   const char* expected = "  --You say goodbye\n  --and I say hello!";
@@ -137,11 +137,11 @@ TEST(MarginTest, IndentAndOutdent) {
   ASSERT_STREQ(expected, writer.str().data());
 }
 
-TEST(MarginTest, SetLinePrefix) {
+TEST(MarginTest, Prefix) {
   SourceBufferWriter writer;
   writer.Append("You say goodbye")
         .EndLine()
-        .SetLinePrefix("--")
+        .Prefix("--")
         .Append("and I say hello!");
 
   const char* expected = "You say goodbye\n--and I say hello!";
@@ -152,10 +152,10 @@ TEST(MarginTest, PrefixAndRemovePrefix) {
   SourceBufferWriter writer;
   writer.Append("You say goodbye")
         .EndLine()
-        .SetLinePrefix("--")
+        .Prefix("--")
         .Append("and I say hello!")
         .EndLine()
-        .UnsetLinePrefix()
+        .Prefix("")
         .Append("Hello, hello!");
 
   const char* expected = "You say goodbye\n--and I say hello!\nHello, hello!";
@@ -167,11 +167,11 @@ TEST(MarginTest, IndentAndPrefixAndOutdentAndRemovePrefix) {
   writer.Append("You say goodbye")
         .EndLine()
         .Indent(2)
-        .SetLinePrefix("--")
+        .Prefix("--")
         .Append("and I say hello!")
         .EndLine()
         .Indent(-2)
-        .UnsetLinePrefix()
+        .Prefix("")
         .Append("Hello, hello!");
 
   const char* expected = "You say goodbye\n  --and I say hello!\nHello, hello!";
@@ -208,7 +208,7 @@ TEST(MarginTest, EmptyPrefix) {
   SourceBufferWriter writer;
   writer.Append("You say goodbye")
         .EndLine()
-        .SetLinePrefix("")
+        .Prefix("")
         .Append("and I say hello!");
 
   const char* expected = "You say goodbye\nand I say hello!";


### PR DESCRIPTION
Part 2 of pull request #14094 that has been splitted into several commits.

This part features only a language-agnostic writer that outputs generated source code into a file or in memory. Note that this class is being kept apart from the Java-specific code generators since it could be a good candidate to be moved in the core io library in the future (ref #13748).

cc: @asimshankar 