### PR TITLE
Fix tensorflow::CurrentStackTrace when TF_GENERATE_BACKTRACE isn't defined

### DIFF
--- a/tensorflow/core/platform/default/stacktrace.h
+++ b/tensorflow/core/platform/default/stacktrace.h
@@ -66,6 +66,8 @@ inline std::string CurrentStackTrace() {
 
   ss << "*** End stack trace ***" << std::endl;
   return ss.str();
+#else
+  return std::string();
 #endif  // defined(TF_GENERATE_BACKTRACE)
 }
 


### PR DESCRIPTION
Fix http://ci.tensorflow.org/job/tf-master-win-bzl/2227/console
culprit: https://github.com/tensorflow/tensorflow/commit/05386f42f18d66bf9ff1d69edf5c47591e60f804