### PR TITLE
Make graph transform tool accessible via command line for pip install.

### DIFF
--- a/tensorflow/tools/graph_transforms/BUILD
+++ b/tensorflow/tools/graph_transforms/BUILD
@@ -317,6 +317,16 @@ tf_py_test(
     main = "python/transform_graph_test.py",
 )
 
+
+py_binary(
+    name = "graph_transforms_wrapper",
+    srcs = ["graph_transforms_wrapper.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorflow:tensorflow_py",
+    ],
+)
+
 filegroup(
     name = "all_files",
     srcs = glob(

--- a/tensorflow/tools/graph_transforms/BUILD
+++ b/tensorflow/tools/graph_transforms/BUILD
@@ -321,6 +321,9 @@ py_binary(
     name = "graph_transforms_wrapper",
     srcs = ["graph_transforms_wrapper.py"],
     srcs_version = "PY2AND3",
+    data = [
+        ":transform_graph",
+    ],
     deps = [
         "//tensorflow:tensorflow_py",
     ],

--- a/tensorflow/tools/graph_transforms/BUILD
+++ b/tensorflow/tools/graph_transforms/BUILD
@@ -317,7 +317,6 @@ tf_py_test(
     main = "python/transform_graph_test.py",
 )
 
-
 py_binary(
     name = "graph_transforms_wrapper",
     srcs = ["graph_transforms_wrapper.py"],

--- a/tensorflow/tools/graph_transforms/graph_transforms_wrapper.py
+++ b/tensorflow/tools/graph_transforms/graph_transforms_wrapper.py
@@ -1,0 +1,33 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Wrapper for runninmg graph_transform binary embedded in pip site-package.
+NOTE: this mainly exists since PIP setup.py cannot install binaries to bin/.
+It can only install Python "console-scripts." This will work as a console
+script. See tools/pip_package/setup.py (search for CONSOLE_SCRIPTS).
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import sys
+import tensorflow as tf
+
+
+def main():
+  # Pip installs the binary in aux-bin off of main site-package install.
+  # Just find it and exec, passing all arguments in the process.
+  binary = os.path.join(tf.__path__[0], 'aux-bin/transform_graph')
+  os.execvp(binary, sys.argv)

--- a/tensorflow/tools/graph_transforms/graph_transforms_wrapper.py
+++ b/tensorflow/tools/graph_transforms/graph_transforms_wrapper.py
@@ -29,5 +29,11 @@ import tensorflow as tf
 def main():
   # Pip installs the binary in aux-bin off of main site-package install.
   # Just find it and exec, passing all arguments in the process.
-  binary = os.path.join(tf.__path__[0], 'aux-bin/transform_graph')
+  pip_binary = os.path.join(tf.__path__[0], 'aux-bin/transform_graph')
+  bazel_binary = os.path.join(
+      tf.resource_loader.get_root_dir_with_all_resources(),
+      'bazel-bin/tensorflow/tools/graph_transforms/transform_graph')
+  binary = bazel_binary if os.path.isfile(bazel_binary) else pip_binary
   os.execvp(binary, sys.argv)
+
+main()

--- a/tensorflow/tools/graph_transforms/graph_transforms_wrapper.py
+++ b/tensorflow/tools/graph_transforms/graph_transforms_wrapper.py
@@ -30,9 +30,9 @@ def main():
   # Pip installs the binary in aux-bin off of main site-package install.
   # Just find it and exec, passing all arguments in the process.
   pip_binary = os.path.join(tf.__path__[0], 'aux-bin/transform_graph')
-  bazel_binary = os.path.join(
-      tf.resource_loader.get_root_dir_with_all_resources(),
-      'bazel-bin/tensorflow/tools/graph_transforms/transform_graph')
+  bazel_binary = ('bazel-bin/tensorflow/tools/graph_transforms/'
+                  'graph_transforms_wrapper.runfiles/org_tensorflow/'
+                  'tensorflow/tools/graph_transforms/transform_graph')
   binary = bazel_binary if os.path.isfile(bazel_binary) else pip_binary
   os.execvp(binary, sys.argv)
 

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -195,6 +195,8 @@ sh_binary(
             "//tensorflow/python/tools:tools_pip",
             "//tensorflow/python:test_ops",
             "//tensorflow/tools/dist_test/server:grpc_tensorflow_server",
+            "//tensorflow/tools/graph_transforms:graph_transforms_wrapper",
+            "//tensorflow/tools/graph_transforms:transform_graph",
         ],
     }) + if_mkl(["//third_party/mkl:intel_binary_blob"]),
 )

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -135,9 +135,11 @@ function main() {
         fi
       fi
     fi
-    # Install toco as a binary in aux-bin.
     mkdir "${TMPDIR}/tensorflow/aux-bin"
+    # Install toco as a binary in aux-bin.
     cp bazel-bin/tensorflow/contrib/lite/toco/toco ${TMPDIR}/tensorflow/aux-bin/
+    # Install graph transform tool as a bianry in aux-bin
+    cp bazel-bin/tensorflow/tools/graph_transforms/transform_graph ${TMPDIR}/tensorflow/aux-bin/
   fi
 
   # protobuf pip package doesn't ship with header files. Copy the headers

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -74,6 +74,7 @@ CONSOLE_SCRIPTS = [
     'freeze_graph = tensorflow.python.tools.freeze_graph:main',
     'toco_from_protos = tensorflow.contrib.lite.toco.python.toco_from_protos:main',
     'toco = tensorflow.contrib.lite.toco.python.toco_wrapper:main',
+    'transform_graph = tensorflow.tools.graph_transforms.graph_transforms_wrapper:main',
     'saved_model_cli = tensorflow.python.tools.saved_model_cli:main',
     # We need to keep the TensorBoard command, even though the console script
     # is now declared by the tensorboard pip package. If we remove the


### PR DESCRIPTION
RELNOTE: Make graph transform tool available from command line as
`transform_graph` for pip package.
Fix  #13287.