### PR TITLE
Hide MSVC workaround from Clang on Windows

### DIFF
--- a/tensorflow/core/framework/numeric_types.h
+++ b/tensorflow/core/framework/numeric_types.h
@@ -217,7 +217,7 @@ using ::tensorflow::operator==;
 using ::tensorflow::operator!=;
 }  // namespace Eigen
 
-#ifdef COMPILER_MSVC
+#if defined(COMPILER_MSVC) && !defined(__clang__)
 namespace std {
 template <>
 struct hash<Eigen::half> {


### PR DESCRIPTION
#15990