### PR TITLE
fix a_ to allocator_

### DIFF
--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -117,7 +117,7 @@ class MklCPUAllocator : public Allocator {
 
   void GetStats(AllocatorStats* stats) override { allocator_->GetStats(stats); }
 
-  void ClearStats() override { a_->ClearStats(); }
+  void ClearStats() override { allocator_->ClearStats(); }
 
  private:
   // Hooks provided by this allocator for memory allocation routines from MKL


### PR DESCRIPTION
```bash
[07:05:58]	[Step 1/1] In file included from tensorflow/core/common_runtime/threadpool_device.cc:32:0:
[07:05:58]	[Step 1/1] ./tensorflow/core/common_runtime/mkl_cpu_allocator.h: In member function 'virtual void tensorflow::MklCPUAllocator::ClearStats()':
[07:05:58]	[Step 1/1] ./tensorflow/core/common_runtime/mkl_cpu_allocator.h:120:32: error: 'a_' was not declared in this scope
[07:05:58]	[Step 1/1]    void ClearStats() override { a_->ClearStats(); }
[07:05:58]	[Step 1/1]                                 ^
```

Please review this PR ASAP... @yuefengz 