### PR TITLE
Update embedding.md

### DIFF
--- a/tensorflow/docs_src/programmers_guide/embedding.md
+++ b/tensorflow/docs_src/programmers_guide/embedding.md
@@ -120,7 +120,7 @@ data set.
   text patterns.
 
 Further useful articles are
-[How to Use t-SNE Effectively](distill.pub/2016/misread-tsne/) and
+[How to Use t-SNE Effectively](https://distill.pub/2016/misread-tsne/) and
 [Principal Component Analysis Explained Visually](http://setosa.io/ev/principal-component-analysis/).
 
 ### Exploration


### PR DESCRIPTION
When I reference embedding projector, I found the string of https:// was removed. So I added it to help other people get a correct reference about How to Use t-SNE Effectively from Embedding of Programmer's guides.