### PR TITLE
Use https for `https://github.com/tensorflow/serving`

### DIFF
--- a/tensorflow/docs_src/programmers_guide/saved_model.md
+++ b/tensorflow/docs_src/programmers_guide/saved_model.md
@@ -479,10 +479,10 @@ does not specify one.
 ### Serving the exported model locally
 
 For local deployment, you can serve your model using
-[TensorFlow Serving](http://github.com/tensorflow/serving), an open-source project that loads a
+[TensorFlow Serving](https://github.com/tensorflow/serving), an open-source project that loads a
 SavedModel and exposes it as a [gRPC](http://www.grpc.io/) service.
 
-First, [install TensorFlow Serving](http://github.com/tensorflow/serving).
+First, [install TensorFlow Serving](https://github.com/tensorflow/serving).
 
 Then build and run the local model server, substituting `$export_dir_base` with
 the path to the SavedModel you exported above:

--- a/tensorflow/docs_src/programmers_guide/saved_model.md
+++ b/tensorflow/docs_src/programmers_guide/saved_model.md
@@ -480,7 +480,7 @@ does not specify one.
 
 For local deployment, you can serve your model using
 [TensorFlow Serving](https://github.com/tensorflow/serving), an open-source project that loads a
-SavedModel and exposes it as a [gRPC](http://www.grpc.io/) service.
+SavedModel and exposes it as a [gRPC](https://www.grpc.io/) service.
 
 First, [install TensorFlow Serving](https://github.com/tensorflow/serving).
 


### PR DESCRIPTION
It looks like there are a couple of links in saved_model.md using http to point to serving, and the rest are using https to point to serving, This fix updates to `https` for consistency and security.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>