### PR TITLE
fix C2678 error on VS2017 15.5

### DIFF
--- a/tensorflow/contrib/boosted_trees/lib/utils/sparse_column_iterable.cc
+++ b/tensorflow/contrib/boosted_trees/lib/utils/sparse_column_iterable.cc
@@ -51,7 +51,7 @@ class IndicesRowIterator
     return tmp;
   }
 
-  reference operator*() { return iter_->ix()(row_idx_, 0); }
+  reference operator*() const { return iter_->ix()(row_idx_, 0); }
 
   pointer operator->() { return &iter_->ix()(row_idx_, 0); }
 


### PR DESCRIPTION
fix build fail on Visual Studio 2017 15.5

error log

    1>------ 已開始建置: 專案: tf_core_kernels, 組態: Debug x64 ------
    1>sparse_column_iterable.cc
    1>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.12.25827\include\algorithm(2417): error C2678: 二元運算子 '*': 找不到使用左方運算元類型 'const tensorflow::boosted_trees::utils::`anonymous-namespace'::IndicesRowIterator' 的運算子 (或是沒有可接受的轉換)
    1>C:\Users\User\tensorflow\tensorflow\contrib\boosted_trees\lib\utils\sparse_column_iterable.cc(54): note: 可能是 'const __int64 &tensorflow::boosted_trees::utils::`anonymous-namespace'::IndicesRowIterator::operator *(void)'
    1>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.12.25827\include\algorithm(2417): note: 當嘗試符合引數清單 '(const tensorflow::boosted_trees::utils::`anonymous-namespace'::IndicesRowIterator)' 時
    1>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.12.25827\include\algorithm(2439): note: 請參閱所要編譯的函式 樣板 具現化 '_FwdIt std::_Lower_bound_unchecked<_Iter,_Ty,_Fn>(_FwdIt,_FwdIt,const _Ty &,_Pr)' 之參考
    1>        with
    1>        [
    1>            _FwdIt=tensorflow::boosted_trees::utils::`anonymous-namespace'::IndicesRowIterator,
    1>            _Iter=tensorflow::boosted_trees::utils::`anonymous-namespace'::IndicesRowIterator,
    1>            _Ty=tensorflow::int64,
    1>            _Fn=std::less<void>,
    1>            _Pr=std::less<void>
    1>        ]
    1>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.12.25827\include\algorithm(2447): note: 請參閱所要編譯的函式 樣板 具現化 '_FwdIt std::lower_bound<_FwdIt,_Ty,std::less<void>>(_FwdIt,_FwdIt,const _Ty &,_Pr)' 之參考
    1>        with
    1>        [
    1>            _FwdIt=tensorflow::boosted_trees::utils::`anonymous-namespace'::IndicesRowIterator,
    1>            _Ty=tensorflow::int64,
    1>            _Pr=std::less<void>
    1>        ]
    1>C:\Users\User\tensorflow\tensorflow\contrib\boosted_trees\lib\utils\sparse_column_iterable.cc(119): note: 請參閱所要編譯的函式 樣板 具現化 '_FwdIt std::lower_bound<tensorflow::boosted_trees::utils::`anonymous-namespace'::IndicesRowIterator,tensorflow::int64>(_FwdIt,_FwdIt,const _Ty &)' 之參考
    1>        with
    1>        [
    1>            _FwdIt=tensorflow::boosted_trees::utils::`anonymous-namespace'::IndicesRowIterator,
    1>            _Ty=tensorflow::int64
    1>        ]
    1>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.12.25827\include\algorithm(2417): error C2100: 不合法的間接取值
    1>專案 "tf_core_kernels.vcxproj" 建置完成 -- 失敗。
    ========== 建置: 0 成功、1 失敗、0 最新、0 略過 ==========