### PR TITLE
MKL: Fixed 3 bugs picked up by the unit tests

### DIFF
--- a/tensorflow/core/framework/function_testlib.cc
+++ b/tensorflow/core/framework/function_testlib.cc
@@ -165,11 +165,9 @@ FunctionDef WXPlusB(){return FDH::Define(
        {"w", "x"},
        {
            {"T", "$T"}, {"transpose_a", false}, {"transpose_b", false},
-#ifdef INTEL_MKL
-       }},
-#else
-         {"_kernel", "eigen"}}},
-#endif
+           {"_kernel", "eigen"}
+       }
+      },
       {
         {"y"}, "Add", {"mm", "b"}, {
           { "T", "$T" }

--- a/tensorflow/python/tools/selective_registration_header_lib.py
+++ b/tensorflow/python/tools/selective_registration_header_lib.py
@@ -54,7 +54,7 @@ def get_ops_and_kernels(proto_fileformat, proto_files, default_ops_str):
       kernel_class = pywrap_tensorflow.TryFindKernelClass(
           node_def.SerializeToString())
       if kernel_class:
-        op_and_kernel = (str(node_def.op), kernel_class.decode('utf-8'))
+        op_and_kernel = (str(node_def.op), str(kernel_class.decode('utf-8')))
         if op_and_kernel not in ops:
           ops.add(op_and_kernel)
       else:


### PR DESCRIPTION
- There were 2 kinds of registrations for MatMul - with and without the 'eigen' label. Re-added the registrations with the 'eigen' label when MKL is used. 
- Removed the ifdef that removed the check for the label when MKL was used. The eigen op should be called when the eigen label is used.
- In the selective registration header test, unicode strings aren't handled correctly, so there's a "u" before the kernel class string that is compared to the hardcoded string. This has been fixed.
```
- [('BiasAdd', 'BiasOp<CPUDevice, float>'), 
+ [('BiasAdd', u'BiasOp<CPUDevice, float>'), 
```