### PR TITLE
Add unspecified dimensions (-1) support for noise_shape with tf.nn.dropout

### DIFF
--- a/tensorflow/python/layers/core.py
+++ b/tensorflow/python/layers/core.py
@@ -36,6 +36,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn
+from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import standard_ops
 
 
@@ -292,13 +293,7 @@ class Dropout(base.Layer):
     # shapes with dynamically sized inputs.
     if self.noise_shape is None:
       return self.noise_shape
-
-    symbolic_shape = array_ops.shape(inputs)
-    noise_shape = [
-        symbolic_shape[axis] if shape is None else shape
-        for axis, shape in enumerate(self.noise_shape)
-    ]
-    return noise_shape
+    return nn_ops._get_noise_shape(inputs, self.noise_shape)
 
   def call(self, inputs, training=False):
 

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2202,8 +2202,8 @@ def dropout(x, keep_prob, noise_shape=None, seed=None, name=None):  # pylint: di
         # Best effort to figure out the intended shape.
         # If not possible, let the op to handle it.
         noise_shape_ = tensor_shape.as_shape(noise_shape)
-        if (x.shape.dims is not None
-            and len(x.shape.dims) == len(noise_shape_.dims)):
+        if (x.shape.dims is not None and
+            len(x.shape.dims) == len(noise_shape_.dims)):
           new_dims = []
           for i, dim in enumerate(x.shape.dims):
             if noise_shape_.dims[i].value is None and dim.value is not None:

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2211,7 +2211,7 @@ def dropout(x, keep_prob, noise_shape=None, seed=None, name=None):  # pylint: di
             else:
               new_dims.append(noise_shape_.dims[i].value)
           return tensor_shape.TensorShape(new_dims)
-      except TypeError:
+      except Exception:
         return noise_shape
 
       return noise_shape

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2150,18 +2150,20 @@ def _get_noise_shape(x, noise_shape):
   try:
     # Best effort to figure out the intended shape.
     # If not possible, let the op to handle it.
+    # In eager mode exception will show up.
     noise_shape_ = tensor_shape.as_shape(noise_shape)
-    if (x.shape.dims is not None and
-        len(x.shape.dims) == len(noise_shape_.dims)):
-      new_dims = []
-      for i, dim in enumerate(x.shape.dims):
-        if noise_shape_.dims[i].value is None and dim.value is not None:
-          new_dims.append(dim.value)
-        else:
-          new_dims.append(noise_shape_.dims[i].value)
-      return tensor_shape.TensorShape(new_dims)
   except (TypeError, ValueError):
     return noise_shape
+
+  if (x.shape.dims is not None and
+      len(x.shape.dims) == len(noise_shape_.dims)):
+    new_dims = []
+    for i, dim in enumerate(x.shape.dims):
+      if noise_shape_.dims[i].value is None and dim.value is not None:
+        new_dims.append(dim.value)
+      else:
+        new_dims.append(noise_shape_.dims[i].value)
+    return tensor_shape.TensorShape(new_dims)
 
   return noise_shape
 

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2198,31 +2198,23 @@ def dropout(x, keep_prob, noise_shape=None, seed=None, name=None):  # pylint: di
       if noise_shape is None:
         return array_ops.shape(x)
 
-      if isinstance(noise_shape, (tuple, list)) and not noise_shape:
-        dtype = dtypes.int32
-      else:
-        dtype = None
-      noise_shape_ = ops.convert_to_tensor(
-          noise_shape,
-          dtype=dtype,
-          name="noise_shape")
-
-      # Use constant_value (vs. constant_value_as_shape) as we need
-      # the distinction between "unknown" and explicit "not use" (`-1`).
-      # If noise_shape cannot be converted to a const tensor,
-      # then no need to check the value and leave it to rest of the logic.
-      noise_shape_ = tensor_util.constant_value(noise_shape_)
-      if noise_shape_ is None:
+      try:
+        # Best effort to figure out the intended shape.
+        # If not possible, let the op to handle it.
+        noise_shape_ = tensor_shape.as_shape(noise_shape)
+        if (x.shape.dims is not None
+            and len(x.shape.dims) == len(noise_shape_.dims)):
+          new_dims = []
+          for i, dim in enumerate(x.shape.dims):
+            if noise_shape_.dims[i].value is None and dim.value is not None:
+              new_dims.append(dim.value)
+            else:
+              new_dims.append(noise_shape_.dims[i].value)
+          return tensor_shape.TensorShape(new_dims)
+      except TypeError:
         return noise_shape
 
-      # Replace `-1` with shape in x
-      if noise_shape_ is not None and sum(noise_shape_ == -1) > 0:
-        if x.shape.dims is not None and len(x.shape.dims) == len(noise_shape_):
-          for i, dim in enumerate(x.shape.dims):
-            if noise_shape_[i] == -1 and dim.value is not None:
-              noise_shape_[i] = dim.value
-
-      return noise_shape_
+      return noise_shape
 
     noise_shape = noise_shape_func(x, noise_shape)
 

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -368,8 +368,8 @@ class DropoutTest(test_lib.TestCase):
       with self.test_session():
         t = constant_op.constant(
             1.0, shape=[x_dim, y_dim], dtype=dtypes.float32)
-        # Set noise_shape=[-1, 1] which means [x_dim, 1].
-        dropout = nn_ops.dropout(t, keep_prob, noise_shape=[-1, 1])
+        # Set noise_shape=[None, 1] which means [x_dim, 1].
+        dropout = nn_ops.dropout(t, keep_prob, noise_shape=[None, 1])
         self.assertEqual([x_dim, y_dim], dropout.get_shape())
         final_count = 0
         for _ in xrange(0, num_iter):


### PR DESCRIPTION
This fix tries to address the issue raised in #16034 where it was not possible to have unspecified dimensions for `noise_shape` with `tf.nn.dropout`.

This fix adds the support so that it is possible to specify `noise_shape = [-1, 1, 1, -1]` instead of `noise_shape = [k, 1, 1, n]`.

This fix fixes #16034.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>