### PR TITLE
Add nsync lib dep. to cc_library rule android_tensorflow_lib_selective_registration

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1139,6 +1139,7 @@ cc_library(
     deps = [
         ":protos_all_cc_impl",
         "//third_party/eigen3",
+        "@nsync//:nsync_cpp",
         "@protobuf_archive//:protobuf",
     ],
     alwayslink = 1,


### PR DESCRIPTION
The nsync lib dep is missed in rule "android_tensorflow_lib_selective_registration"

This pr adds it.