### PR TITLE
Disable stacktrace_handler_test becase stack trace isn't generated on Windows

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -186,6 +186,7 @@ tf_py_test(
         ":client_testlib",
         ":platform",
     ],
+    tags = ["no_windows"],
 )
 
 tf_py_test(


### PR DESCRIPTION
Fix http://ci.tensorflow.org/job/tf-master-win-bzl/2259/console