### PR TITLE
fix default parameters for TimeFreqLSTMCell, fixes #16100

### DIFF
--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -328,7 +328,7 @@ class TimeFreqLSTMCell(rnn_cell_impl.RNNCell):
   def __init__(self, num_units, use_peepholes=False,
                cell_clip=None, initializer=None,
                num_unit_shards=1, forget_bias=1.0,
-               feature_size=None, frequency_skip=None,
+               feature_size=None, frequency_skip=1,
                reuse=None):
     """Initialize the parameters for an LSTM cell.
 


### PR DESCRIPTION
Resolve #16100 

The default parameters for TimeFreqLSTMCell lead to a division by `None`, which throws an exception.