### PR TITLE
Fix broken python3 build

### DIFF
--- a/third_party/astor.BUILD
+++ b/third_party/astor.BUILD
@@ -19,5 +19,6 @@ py_library(
         "astor/string_repr.py",
         "astor/tree_walk.py",
     ],
+    srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )

--- a/third_party/gast.BUILD
+++ b/third_party/gast.BUILD
@@ -14,5 +14,6 @@ py_library(
         "gast/astn.py",
         "gast/gast.py",
     ],
+    srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )

--- a/third_party/termcolor.BUILD
+++ b/third_party/termcolor.BUILD
@@ -10,5 +10,6 @@ py_library(
     srcs = [
         "termcolor.py",
     ],
+    srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Currently building tensorflow master branch with python3 fails with following error message.
```
ERROR: ${BAZEL_CACHE}/external/astor_archive/BUILD:8:1: Converting to Python 3: external/astor_archive/astor/code_gen.py failed (Exit 1).
```
It seems that the 3 newly added `third_party/*.BUILD` scripts from https://github.com/tensorflow/tensorflow/pull/15955/commits/4080654c8f03ec34f2822c14db5fd8b75f63d569 are missing `srcs_version = "PY2AND3"` part, which all the other py_library modules have.

I'm using bazel 0.5.4 on linux ubuntu 16.04 to build the current master branch.