### PR TITLE
New features: tf.alphas and tf.alphas_like - Related to #16128

### DIFF
--- a/tensorflow/compiler/tests/unary_ops_test.py
+++ b/tensorflow/compiler/tests/unary_ops_test.py
@@ -475,6 +475,17 @@ class UnaryOpsTest(XLATestCase):
           np.array([[-4j, 3 + 2j], [2, -1j]], dtype=dtype),
           expected=np.array([[1, 1], [1, 1]], dtype=dtype))
 
+      for fill_value in [0, 1, 0.7, -5.2]:
+          target_value = np.array(fill_value).astype(dtype)
+
+          self._assertOpOutputMatchesExpected(
+              lambda x: array_ops.alphas_like(x, alpha_value=target_value),
+              np.array([[-4j, 3 + 2j], [2, -1j]], dtype=dtype),
+              expected=np.array(
+                  [[target_value, target_value], [target_value, target_value]],
+                  dtype=dtype
+              ))
+
       self._assertOpOutputMatchesExpected(
           math_ops.angle,
           np.array([1 + 3j, -4 + 7j, 2.7, -3j], dtype=dtype),
@@ -528,6 +539,17 @@ class UnaryOpsTest(XLATestCase):
           array_ops.ones_like,
           np.array([[4, 3], [2, 1]], dtype=dtype),
           expected=np.array([[1, 1], [1, 1]], dtype=dtype))
+
+      for fill_value in [0, 1, 0.7, -5.2]:
+          target_value = np.array(fill_value).astype(dtype)
+
+          self._assertOpOutputMatchesExpected(
+              lambda x: array_ops.alphas_like(x, alpha_value=target_value),
+              np.array([[4, 3], [2, 1]], dtype=dtype),
+              expected=np.array(
+                  [[target_value, target_value], [target_value, target_value]],
+                  dtype=dtype
+              ))
 
   # TODO(phawkins): these tests fail unless fastmath optimizations
   # are disabled. Use more robust IsInf/IsNaN detection and enable these

--- a/tensorflow/contrib/labeled_tensor/__init__.py
+++ b/tensorflow/contrib/labeled_tensor/__init__.py
@@ -116,6 +116,7 @@ pad = _ops.pad
 constant = _ops.constant
 zeros_like = _ops.zeros_like
 ones_like = _ops.ones_like
+alphas_like = _ops.alphas_like
 cast = _ops.cast
 verify_tensor_all_finite = _ops.verify_tensor_all_finite
 boolean_mask = _ops.boolean_mask

--- a/tensorflow/docs_src/api_guides/python/constant_op.md
+++ b/tensorflow/docs_src/api_guides/python/constant_op.md
@@ -13,6 +13,8 @@ TensorFlow provides several operations that you can use to generate constants.
 *   @{tf.zeros_like}
 *   @{tf.ones}
 *   @{tf.ones_like}
+*   @{tf.alphas}
+*   @{tf.alphas_like}
 *   @{tf.fill}
 *   @{tf.constant}
 

--- a/tensorflow/python/framework/constant_op.py
+++ b/tensorflow/python/framework/constant_op.py
@@ -20,6 +20,8 @@ See the @{$python/constant_op$constants guide}.
 @@zeros_like
 @@ones
 @@ones_like
+@@alphas
+@@alphas_like
 @@fill
 @@constant
 @@linspace

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1654,32 +1654,32 @@ def alphas_like(tensor, alpha_value, name=None, optimize=True):
   A `Tensor` with all elements set to `alpha_value`.
   """
   with ops.name_scope(name, "alphas_like", [tensor]) as name:
-  tensor = ops.convert_to_tensor(tensor, name="tensor")
+    tensor = ops.convert_to_tensor(tensor, name="tensor")
 
-  if context.in_eager_mode():
-    ret = alphas(
-      shape_internal(tensor, optimize=optimize),
-      alpha_value=alpha_value,
-      name=name
-    )
-
-  else: # if context.in_graph_mode():
-
-    if (optimize and tensor.shape.is_fully_defined()):
-      # We can produce a tensor independent of the value of 'tensor',
-      # since the shape is known statically.
-      ret = alphas(tensor.shape, alpha_value=alpha_value, name=name)
-
-    else:
+    if context.in_eager_mode():
       ret = alphas(
         shape_internal(tensor, optimize=optimize),
         alpha_value=alpha_value,
         name=name
       )
 
-    ret.set_shape(tensor.get_shape())
+    else: # if context.in_graph_mode():
 
-  return ret
+      if (optimize and tensor.shape.is_fully_defined()):
+        # We can produce a tensor independent of the value of 'tensor',
+        # since the shape is known statically.
+        ret = alphas(tensor.shape, alpha_value=alpha_value, name=name)
+
+      else:
+        ret = alphas(
+          shape_internal(tensor, optimize=optimize),
+          alpha_value=alpha_value,
+          name=name
+        )
+
+      ret.set_shape(tensor.get_shape())
+
+    return ret
 
 
 def alphas(shape, alpha_value, name=None):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1633,7 +1633,97 @@ def ones_like(tensor, dtype=None, name=None, optimize=True):
     if context.in_graph_mode():
       ret.set_shape(tensor.get_shape())
     return ret
+    
+def alphas_like(tensor, alpha_value, name=None, optimize=True):
+  """Creates a tensor with all elements set to the value contained in `alpha_value`.
+  Given a single tensor (`tensor`), this operation returns a tensor of the same
+  shape as `tensor` with all elements set to `alpha_value`.
+  
+  For example:
+  ```python
+  tensor = tf.constant([[1, 2, 3], [4, 5, 6]])
+  tf.alphas_like(tensor, 0.123456)  # [[0.123456, 0.123456, 0.123456], [0.123456, 0.123456, 0.123456]]
+  ```
+  Args:
+  tensor: A `Tensor`.
+  alpha_value: A custom value to be set in the new tensor. Must be `float32`, `float64`,
+    `int8`, `uint8`, `int16`, `uint16`, int32`, `int64`, `complex64`, `complex128` or `bool`.
+  name: A name for the operation (optional).
+  optimize: if true, attempt to statically determine the shape of 'tensor' and encode it as a constant.
+  Returns:
+  A `Tensor` with all elements set to `alpha_value`.
+  """
+  with ops.name_scope(name, "alphas_like", [tensor]) as name:
+  tensor = ops.convert_to_tensor(tensor, name="tensor")
 
+  if context.in_eager_mode():
+    ret = alphas(
+      shape_internal(tensor, optimize=optimize),
+      alpha_value=alpha_value,
+      name=name
+    )
+
+  else: # if context.in_graph_mode():
+
+    if (optimize and tensor.shape.is_fully_defined()):
+      # We can produce a tensor independent of the value of 'tensor',
+      # since the shape is known statically.
+      ret = alphas(tensor.shape, alpha_value=alpha_value, name=name)
+
+    else:
+      ret = alphas(
+        shape_internal(tensor, optimize=optimize),
+        alpha_value=alpha_value,
+        name=name
+      )
+
+    ret.set_shape(tensor.get_shape())
+
+  return ret
+
+
+def alphas(shape, alpha_value, name=None):
+  """Creates a tensor with all elements set to `alpha_value`.
+  This operation returns a tensor with shape `shape` and all elements set to `alpha_value`.
+  For example:
+  ```python
+  tf.alphas([2, 3], alpha_value=0.123456)  # [[0.123456, 0.123456, 0.123456], [0.123456, 0.123456, 0.123456]]
+  ```
+  Args:
+  shape: A list of integers, a tuple of integers, or a 1-D `Tensor` of type
+    `int32`.  
+  alpha_value: A custom value to be set in the new tensor. Must be `float32`, `float64`,
+    `int8`, `uint8`, `int16`, `uint16`, int32`, `int64`, `complex64`, `complex128` or `bool`.
+  name: A name for the operation (optional).
+  Returns:
+  A `Tensor` with all elements set to `alpha_value`.
+  """
+
+  with ops.name_scope(name, "alphas", [shape]) as name:
+
+    alpha_tensor = convert_to_tensor(alpha_value)
+    alpha_dtype = dtypes.as_dtype(alpha_tensor.dtype).base_dtype
+
+    if not isinstance(shape, ops.Tensor):
+      try:
+        shape = constant_op._tensor_shape_tensor_conversion_function(tensor_shape.TensorShape(shape))
+      except (TypeError, ValueError):
+        shape = ops.convert_to_tensor(shape, dtype=dtypes.int32)
+
+    if not shape._shape_tuple():
+      shape = reshape(shape, [-1])  # Ensure it's a vector
+
+
+    try:
+      output = constant(alpha_value, shape=shape, dtype=alpha_dtype, name=name)
+
+    except (TypeError, ValueError) as e:
+      output = fill(shape, constant(alpha_value, dtype=alpha_dtype), name=name)
+
+    assert output.dtype.base_dtype == alpha_dtype
+
+    return output
+    
 
 def ones(shape, dtype=dtypes.float32, name=None):
   """Creates a tensor with all elements set to 1.

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1701,7 +1701,7 @@ def alphas(shape, alpha_value, name=None):
 
   with ops.name_scope(name, "alphas", [shape]) as name:
 
-    alpha_tensor = convert_to_tensor(alpha_value)
+    alpha_tensor = ops.convert_to_tensor(alpha_value)
     alpha_dtype = dtypes.as_dtype(alpha_tensor.dtype).base_dtype
 
     if not isinstance(shape, ops.Tensor):


### PR DESCRIPTION
This PR is related to the issue: #16128

#### I send my work here for peer reviewing and discussion. Please do not merge now.

### A few interrogations before merging

1. Are the names I have chosen fine with everyone or you would like it to be changed to something else ?
2. Do my implementations seem fine ?
3. What kind of tests should I implement ? Where shall I put them ?
4. Is it a good idea to replace the function body of tf.ones/tf.zeros and tf.ones_like/tf.zeros_like by a function call to tf.alphas and tf.alphas_like ? Not doing it would lead to code duplication, however I would understand that you might be reluctant, these functions are at the core of the library.

### Why I created these functions ?

I oftenly need to create similar tensors with a non-zero/one value. A simple example would be cost functions in GANs with *label smoothing* applied. 

As stated by @facaiy in #16128, I could use : 
```python
b1 = tf.ones_like(a, dtype=tf.float32) * 0.9 # Tensor full of 0.9
b2 = tf.ones_like(a, dtype=tf.int32) * 2 # Tensor full of 2
b4 = tf.ones_like(a, dtype=tf.bool) # Tensor full of True
```
 However, as shown in my later comments in the issue, the method implemented in this PR is almost twice as fast.

In a wider view, I think that using a single function more *generic* is always a good thing whenever it is possible.

### How does the function API work ?

In a very similar manner than the existing ones: 

```python
import tensorflow as tf

a = tf.constant([
    [
        [4, 5, 6],
        [1, 2, 3]
    ],
    [
        [4, 5, 6],
        [1, 2, 3]
    ]
])

b1 = tf.alphas_like(a, 0.5431)
b2 = tf.alphas_like(a, 5)
b3 = tf.alphas_like(a, -5)
b4 = tf.alphas_like(a, True)

with tf.Session() as sess:
    _b1, _b2, _b3, _b4 = sess.run([b1, b2, b3, b4])
    
print("b1:", _b1)
print("b2:", _b2)
print("b3:", _b3)
print("b4:", _b4)

############### OUTPUTS ###############

>>> b1: [
  [
    [ 0.5431  0.5431  0.5431]
    [ 0.5431  0.5431  0.5431]
  ]
  [
    [ 0.5431  0.5431  0.5431]
    [ 0.5431  0.5431  0.5431]
  ]
]

>>> b2: [
  [
    [5 5 5]
    [5 5 5]
  ]
  [
    [5 5 5]
    [5 5 5]
  ]
]

>>> b3: [
  [
    [-5 -5 -5]
    [-5 -5 -5]
  ]
  [
    [-5 -5 -5]
    [-5 -5 -5]
  ]
]

>>> b4: [
  [
    [ True  True  True]
    [ True  True  True]
  ]
  [
    [ True  True  True]
    [ True  True  True]
  ]
]
```

---------------------------

I'm of course free for discussion over video-calls. It's the first time I try to make a change at the core of TF, and I'm quite afraid of breaking everything ;) Thanks for your help btw.

All the best,

Jonathan DEKHTIAR