### PR TITLE
GAN model: move generated and real operations under discriminator namespace

### DIFF
--- a/tensorflow/contrib/gan/python/train.py
+++ b/tensorflow/contrib/gan/python/train.py
@@ -277,14 +277,16 @@ def acgan_model(
     generator_inputs = _convert_tensor_or_l_or_d(generator_inputs)
     generated_data = generator_fn(generator_inputs)
   with variable_scope.variable_scope(discriminator_scope) as dis_scope:
-    (discriminator_gen_outputs, discriminator_gen_classification_logits
-    ) = _validate_acgan_discriminator_outputs(
-        discriminator_fn(generated_data, generator_inputs))
+    with ops.name_scope(dis_scope.name+'/generated/'):
+      (discriminator_gen_outputs, discriminator_gen_classification_logits
+      ) = _validate_acgan_discriminator_outputs(
+          discriminator_fn(generated_data, generator_inputs))
   with variable_scope.variable_scope(dis_scope, reuse=True):
-    real_data = ops.convert_to_tensor(real_data)
-    (discriminator_real_outputs, discriminator_real_classification_logits
-    ) = _validate_acgan_discriminator_outputs(
-        discriminator_fn(real_data, generator_inputs))
+    with ops.name_scope(dis_scope.name+'/real/'):
+      real_data = ops.convert_to_tensor(real_data)
+      (discriminator_real_outputs, discriminator_real_classification_logits
+      ) = _validate_acgan_discriminator_outputs(
+          discriminator_fn(real_data, generator_inputs))
   if check_shapes:
     if not generated_data.shape.is_compatible_with(real_data.shape):
       raise ValueError(


### PR DESCRIPTION
Hi everybody,

`gan_model` runs the discriminator on both the generated and real data. This PR changes/fixes the namespace of the generated graph.

* Current: The network variables and operations on generated data are in the `Discriminator` namespace but the operations on real data are in the `Discriminator_1` namespace.
* PR: The network variables stay in the `Discriminator` namespace. Operations on generated data are in `Discriminator/generated` and operations on real data are in `Discriminator/real`.

`gan_model` only searches the `Discriminator` namespace for regularization. Presumably, if you were running activity regularization in your discriminator, only the part on generated data would be picked up. Plus, the graph looks much better visually this way and you can tell which discriminator is which.

Cheers