### PR TITLE
Fix unicode string conversion issue in Python 2

### DIFF
--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -301,13 +301,22 @@ Status ConvertNdarrayToTensor(PyObject* obj, Tensor* ret) {
         if (PyBytes_AsStringAndSize(input_data[i], &el, &el_size) == -1) {
 #if PY_MAJOR_VERSION >= 3
           el = PyUnicode_AsUTF8AndSize(input_data[i], &el_size);
-          if (!el) {
-#endif
-            return errors::Unimplemented("Unsupported object type ",
-                                         input_data[i]->ob_type->tp_name);
-#if PY_MAJOR_VERSION >= 3
+#else
+          el = NULL;
+          if (PyUnicode_Check(input_data[i])) {
+            PyObject *unicode = PyUnicode_AsUTF8String(input_data[i]);
+            if (unicode) {
+              if (PyString_AsStringAndSize(unicode, &el, &el_size) == -1) {
+                Py_DECREF(unicode);
+                el = NULL;
+              }
+            }
           }
 #endif
+          if (!el) {
+            return errors::Unimplemented("Unsupported object type ",
+                                         input_data[i]->ob_type->tp_name);
+          }
         }
         tflat(i) = string(el, el_size);
       }

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -304,13 +304,13 @@ Status ConvertNdarrayToTensor(PyObject* obj, Tensor* ret) {
 #if PY_MAJOR_VERSION >= 3
           el = PyUnicode_AsUTF8AndSize(input_data[i], &el_size);
 #else
-          el = NULL;
+          el = nullptr;
           if (PyUnicode_Check(input_data[i])) {
             PyObject* unicode = PyUnicode_AsUTF8String(input_data[i]);
             if (unicode) {
               if (PyString_AsStringAndSize(unicode, &el, &el_size) == -1) {
                 Py_DECREF(unicode);
-                el = NULL;
+                el = nullptr;
               }
             }
           }

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "tensorflow/python/lib/core/ndarray_tensor_bridge.h"
 #include "tensorflow/python/lib/core/py_util.h"
 #include "tensorflow/python/lib/core/safe_ptr.h"
+
 #include <Python.h>
 
 namespace tensorflow {
@@ -141,7 +142,8 @@ bool IsSingleNone(PyObject* obj) {
     return false;
   }
   std::array<npy_intp, 0> indices;
-  char* item_ptr = static_cast<char*>(PyArray_GetPtr(array_obj, indices.data()));
+  char* item_ptr =
+      static_cast<char*>(PyArray_GetPtr(array_obj, indices.data()));
   PyObject* item = PyArray_GETITEM(array_obj, item_ptr);
   CHECK(item);
   return item == Py_None;
@@ -304,7 +306,7 @@ Status ConvertNdarrayToTensor(PyObject* obj, Tensor* ret) {
 #else
           el = NULL;
           if (PyUnicode_Check(input_data[i])) {
-            PyObject *unicode = PyUnicode_AsUTF8String(input_data[i]);
+            PyObject* unicode = PyUnicode_AsUTF8String(input_data[i]);
             if (unicode) {
               if (PyString_AsStringAndSize(unicode, &el, &el_size) == -1) {
                 Py_DECREF(unicode);


### PR DESCRIPTION
This fix tries to address the issue raised in #16149 where the unicode string conversion with Python 2 does not match the behavior with Python 3.

The issue was that in Python 3, TensorFlow tries to do a unicode conversion in UTF8 while in Python 2
the default conversion was used.

This fix addresses the issue so that behaviors of TensorFlow with Python 2 and Python 3 match.

This fix fixes #16149.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>