### PR TITLE
make applications using TFLite work on ARM64 Linux (non-Android) platforms

### DIFF
--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -64,6 +64,13 @@ cc_library(
 )
 
 config_setting(
+    name = "aarch64",
+    values = {
+        "cpu": "aarch64",
+    },
+)
+
+config_setting(
     name = "arm",
     values = {
         "cpu": "arm",
@@ -497,6 +504,9 @@ cc_library(
         "//tensorflow/lite/kernels:op_macros",
         "@gemmlowp",
     ] + select({
+        ":aarch64": [
+            ":neon_tensor_utils",
+        ],
         ":arm": [
             ":neon_tensor_utils",
         ],

--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -19,6 +19,10 @@ HARD_FP_FLAGS_IF_APPLICABLE = select({
 })
 
 NEON_FLAGS_IF_APPLICABLE = select({
+    ":arm": [
+        "-O3",
+        "-mfpu=neon",
+    ],
     ":armeabi-v7a": [
         "-O3",
         "-mfpu=neon",

--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -19,10 +19,6 @@ HARD_FP_FLAGS_IF_APPLICABLE = select({
 })
 
 NEON_FLAGS_IF_APPLICABLE = select({
-    ":arm": [
-        "-O3",
-        "-mfpu=neon",
-    ],
     ":armeabi-v7a": [
         "-O3",
         "-mfpu=neon",


### PR DESCRIPTION
When build TF Lite related stuff such as lable_image for tflite on ARMv64 non-Android environment (I am running Debian on an internal development board). I saw something like:

 ```
 /home/freedom/work/tensorflow/tensorflow/contrib/lite/kernels/internal/BUILD:264:1: C++ compilation of rule '//tensorflow/contrib/lite/kernels/internal:neon_tensor_utils' failed (Exit 1)
  gcc: error: unrecognized command line option '-mfpu=neon'
  gcc: error: unrecognized command line option '-mfloat-abi=softfp'
```

It seems ARM64 falls into the ":arm" category. After removing it, I can build my tflite-based command line programs without problems.