### PR TITLE
Fix issue of branch switching not working with bazel

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import datetime
 import errno
 import os
 import platform
@@ -1234,7 +1233,6 @@ def main():
 
   reset_tf_configure_bazelrc()
   cleanup_makefile()
-  write_action_env_to_bazelrc("TF_CONFIG_TIME", str(datetime.datetime.now()))
   setup_python(environ_cp)
 
   if is_windows():

--- a/configure.py
+++ b/configure.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import datetime
 import errno
 import os
 import platform
@@ -1233,6 +1234,7 @@ def main():
 
   reset_tf_configure_bazelrc()
   cleanup_makefile()
+  write_action_env_to_bazelrc("TF_CONFIG_TIME", str(datetime.datetime.now()))
   setup_python(environ_cp)
 
   if is_windows():

--- a/third_party/git/git_configure.bzl
+++ b/third_party/git/git_configure.bzl
@@ -5,7 +5,6 @@
   * `PYTHON_BIN_PATH`: location of python binary.
 """
 
-_TF_CONFIG_TIME = "TF_CONFIG_TIME"
 _PYTHON_BIN_PATH = "PYTHON_BIN_PATH"
 
 def _fail(msg):
@@ -39,6 +38,11 @@ def _git_conf_impl(repository_ctx):
       Label("@org_tensorflow//tensorflow/tools/git:gen_git_source.py"))
   generated_files_path = repository_ctx.path("gen")
 
+  r = repository_ctx.execute(
+      ["test", "-f", "%s/.git/logs/HEAD" % tensorflow_root_path])
+  if r.return_code == 0:
+    unused_var = repository_ctx.path(Label("//:.git/HEAD")) # pylint: disable=unused-variable
+
   result = repository_ctx.execute([
       _get_python_bin(repository_ctx),
       python_script_path, "--configure", tensorflow_root_path,
@@ -51,7 +55,6 @@ def _git_conf_impl(repository_ctx):
 git_configure = repository_rule(
     implementation = _git_conf_impl,
     environ = [
-        _TF_CONFIG_TIME,
         _PYTHON_BIN_PATH,
     ],
 )

--- a/third_party/git/git_configure.bzl
+++ b/third_party/git/git_configure.bzl
@@ -5,6 +5,7 @@
   * `PYTHON_BIN_PATH`: location of python binary.
 """
 
+_TF_CONFIG_TIME = "TF_CONFIG_TIME"
 _PYTHON_BIN_PATH = "PYTHON_BIN_PATH"
 
 def _fail(msg):
@@ -50,6 +51,7 @@ def _git_conf_impl(repository_ctx):
 git_configure = repository_rule(
     implementation = _git_conf_impl,
     environ = [
+        _TF_CONFIG_TIME,
         _PYTHON_BIN_PATH,
     ],
 )


### PR DESCRIPTION
This fix tries to address the issue raised in #15957 where bazel stops working after switching git branch, and reconfigure with `./configure` will not work as well.

This fix adds a quick fix as was suggested, by having `export TF_CONFIG_TIME="$(date)" `in configure.py and add it to the environ list in git_configure.bzl.

This fix fixes #15957.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>