### PR TITLE
added CMake options to provide external zlib, GRPC, Eigen

### DIFF
--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -47,6 +47,31 @@ else()
 endif()
 
 
+# Provider options
+set(PROVIDER_DESCRIPTION "Library provider: use 'module' to download package internally,\
+ use 'package' if you want to provide package externally")
+
+set(tensorflow_EIGEN_PROVIDER "module" CACHE STRING ${PROVIDER_DESCRIPTION})
+set_property(CACHE tensorflow_EIGEN_PROVIDER PROPERTY STRINGS "module" "package")
+
+set(tensorflow_GIF_PROVIDER "module" CACHE STRING ${PROVIDER_DESCRIPTION})
+set_property(CACHE tensorflow_GIF_PROVIDER PROPERTY STRINGS "module" "package")
+
+set(tensorflow_GRPC_PROVIDER "module" CACHE STRING ${PROVIDER_DESCRIPTION})
+set_property(CACHE tensorflow_GRPC_PROVIDER PROPERTY STRINGS "module" "package")
+
+set(tensorflow_JPEG_PROVIDER "module" CACHE STRING ${PROVIDER_DESCRIPTION})
+set_property(CACHE tensorflow_JPEG_PROVIDER PROPERTY STRINGS "module" "package")
+
+set(tensorflow_PNG_PROVIDER "module" CACHE STRING ${PROVIDER_DESCRIPTION})
+set_property(CACHE tensorflow_PNG_PROVIDER PROPERTY STRINGS "module" "package")
+
+set(tensorflow_PROTOBUF_PROVIDER "module" CACHE STRING ${PROVIDER_DESCRIPTION})
+set_property(CACHE tensorflow_PROTOBUF_PROVIDER PROPERTY STRINGS "module" "package")
+
+set(tensorflow_ZLIB_PROVIDER "module" CACHE STRING ${PROVIDER_DESCRIPTION})
+set_property(CACHE tensorflow_ZLIB_PROVIDER PROPERTY STRINGS "module" "package")
+
 if (NOT WIN32)
   # Threads: defines CMAKE_THREAD_LIBS_INIT and adds -pthread compile option
   # for targets that link ${CMAKE_THREAD_LIBS_INIT}.
@@ -181,37 +206,35 @@ include(protobuf)
 include(re2)
 include(cub)
 include(sqlite)
+# if need GRPC or using protobuf from external GRPC package
+if(tensorflow_ENABLE_GRPC_SUPPORT OR (tensorflow_GRPC_PROVIDER STREQUAL "package" AND tensorflow_PROTOBUF_PROVIDER STREQUAL "package"))
+  include(grpc)
+endif()
 if (tensorflow_BUILD_CC_TESTS)
   include(googletest)
 endif()
 
 set(tensorflow_EXTERNAL_LIBRARIES
-    ${zlib_STATIC_LIBRARIES}
-    ${gif_STATIC_LIBRARIES}
-    ${png_STATIC_LIBRARIES}
-    ${jpeg_STATIC_LIBRARIES}
+    ${ZLIB_LIBRARIES}
+    ${GIF_LIBRARIES}
+    ${PNG_LIBRARIES}
+    ${JPEG_LIBRARIES}
     ${lmdb_STATIC_LIBRARIES}
     ${jsoncpp_STATIC_LIBRARIES}
     ${farmhash_STATIC_LIBRARIES}
     ${fft2d_STATIC_LIBRARIES}
     ${highwayhash_STATIC_LIBRARIES}
     ${nsync_STATIC_LIBRARIES}
-    ${protobuf_STATIC_LIBRARIES}
+    ${PROTOBUF_LIBRARIES}
     ${re2_STATIC_LIBRARIES}
     ${sqlite_STATIC_LIBRARIES}
 )
 set(tensorflow_EXTERNAL_DEPENDENCIES
-    zlib_copy_headers_to_destination
-    gif_copy_headers_to_destination
-    png_copy_headers_to_destination
-    jpeg_copy_headers_to_destination
     lmdb_copy_headers_to_destination
     jsoncpp
     farmhash_copy_headers_to_destination
     highwayhash_copy_headers_to_destination
     nsync_copy_headers_to_destination
-    protobuf
-    eigen
     gemmlowp
     cub
     fft2d
@@ -224,10 +247,10 @@ include_directories(
     ${tensorflow_source_dir}
     ${CMAKE_CURRENT_BINARY_DIR}
     # External dependencies.
-    ${zlib_INCLUDE_DIR}
-    ${gif_INCLUDE_DIR}
-    ${png_INCLUDE_DIR}
-    ${jpeg_INCLUDE_DIR}
+    ${ZLIB_INCLUDE_DIRS}
+    ${GIF_INCLUDE_DIR}
+    ${PNG_INCLUDE_DIRS}
+    ${JPEG_INCLUDE_DIR}
     ${lmdb_INCLUDE_DIR}
     ${eigen_INCLUDE_DIRS}
     ${gemmlowp_INCLUDE_DIR}
@@ -241,6 +264,24 @@ include_directories(
     ${sqlite_INCLUDE_DIR}
 )
 
+if(tensorflow_EIGEN_PROVIDER STREQUAL module)
+    list(APPEND tensorflow_EXTERNAL_DEPENDENCIES eigen)
+endif()
+if(tensorflow_GIF_PROVIDER STREQUAL module)
+  list(APPEND tensorflow_EXTERNAL_DEPENDENCIES gif gif_copy_headers_to_destination)
+endif()
+if(tensorflow_JPEG_PROVIDER STREQUAL module)
+  list(APPEND tensorflow_EXTERNAL_DEPENDENCIES jpeg jpeg_copy_headers_to_destination)
+endif()
+if(tensorflow_PNG_PROVIDER STREQUAL module)
+  list(APPEND tensorflow_EXTERNAL_DEPENDENCIES png png_copy_headers_to_destination)
+endif()
+if(tensorflow_PROTOBUF_PROVIDER STREQUAL module)
+  list(APPEND tensorflow_EXTERNAL_DEPENDENCIES protobuf)
+endif()
+if(tensorflow_ZLIB_PROVIDER STREQUAL module)
+  list(APPEND tensorflow_EXTERNAL_DEPENDENCIES zlib_copy_headers_to_destination)
+endif()
 if(tensorflow_ENABLE_SSL_SUPPORT)
   include(boringssl)
   list(APPEND tensorflow_EXTERNAL_LIBRARIES ${boringssl_STATIC_LIBRARIES})
@@ -248,9 +289,10 @@ if(tensorflow_ENABLE_SSL_SUPPORT)
   include_directories(${boringssl_INCLUDE_DIR})
 endif()
 if(tensorflow_ENABLE_GRPC_SUPPORT)
-  include(grpc)
-  list(APPEND tensorflow_EXTERNAL_LIBRARIES ${grpc_STATIC_LIBRARIES})
-  list(APPEND tensorflow_EXTERNAL_DEPENDENCIES grpc)
+  list(APPEND tensorflow_EXTERNAL_LIBRARIES ${GRPC_LIBRARIES})
+  if(tensorflow_GRPC_PROVIDER STREQUAL module)
+    list(APPEND tensorflow_EXTERNAL_DEPENDENCIES grpc)
+  endif()
   include_directories(${GRPC_INCLUDE_DIRS})
 endif()
 if(tensorflow_ENABLE_JEMALLOC_SUPPORT)

--- a/tensorflow/contrib/cmake/external/FindGRPC.cmake
+++ b/tensorflow/contrib/cmake/external/FindGRPC.cmake
@@ -1,0 +1,67 @@
+find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin) # Get full path to plugin
+
+find_library(GRPC_LIBRARY NAMES grpc)
+find_library(GRPCPP_LIBRARY NAMES grpc++)
+find_library(GPR_LIBRARY NAMES gpr)
+set(GRPC_LIBRARIES ${GRPCPP_LIBRARY} ${GRPC_LIBRARY} ${GPR_LIBRARY})
+if(GRPC_LIBRARIES)
+    message(STATUS "Found GRPC: ${GRPC_LIBRARIES}; plugin - ${GRPC_CPP_PLUGIN}")
+endif()
+
+
+function(PROTOBUF_GENERATE_GRPC_CPP SRCS HDRS)
+  if(NOT ARGN)
+    message(SEND_ERROR "Error: PROTOBUF_GENERATE_GRPC_CPP() called without any proto files")
+    return()
+  endif()
+
+  if(PROTOBUF_GENERATE_CPP_APPEND_PATH) # This variable is common for all types of output.
+    # Create an include path for each file specified
+    foreach(FIL ${ARGN})
+      get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
+      get_filename_component(ABS_PATH ${ABS_FIL} PATH)
+      list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
+      if(${_contains_already} EQUAL -1)
+          list(APPEND _protobuf_include_path -I ${ABS_PATH})
+      endif()
+    endforeach()
+  else()
+    set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  if(DEFINED PROTOBUF_IMPORT_DIRS)
+    foreach(DIR ${PROTOBUF_IMPORT_DIRS})
+      get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
+      list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
+      if(${_contains_already} EQUAL -1)
+          list(APPEND _protobuf_include_path -I ${ABS_PATH})
+      endif()
+    endforeach()
+  endif()
+
+  set(${SRCS})
+  set(${HDRS})
+  foreach(FIL ${ARGN})
+    get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
+    get_filename_component(FIL_WE ${FIL} NAME_WE)
+
+    list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.grpc.pb.cc")
+    list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.grpc.pb.h")
+
+    add_custom_command(
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.grpc.pb.cc"
+             "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.grpc.pb.h"
+      COMMAND  ${PROTOBUF_PROTOC_EXECUTABLE}
+      ARGS --grpc_out=${CMAKE_CURRENT_BINARY_DIR}
+           --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}
+           ${_protobuf_include_path} ${ABS_FIL}
+      DEPENDS ${ABS_FIL} ${PROTOBUF_PROTOC_EXECUTABLE}
+      COMMENT "Running gRPC C++ protocol buffer compiler on ${FIL}"
+      VERBATIM)
+  endforeach()
+
+  set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
+  set(${SRCS} ${${SRCS}} PARENT_SCOPE)
+  set(${HDRS} ${${HDRS}} PARENT_SCOPE)
+endfunction()
+

--- a/tensorflow/contrib/cmake/external/eigen.cmake
+++ b/tensorflow/contrib/cmake/external/eigen.cmake
@@ -21,34 +21,39 @@
 
 include (ExternalProject)
 
-# We parse the current Eigen version and archive hash from the bazel configuration
-file(STRINGS ${PROJECT_SOURCE_DIR}/../../workspace.bzl workspace_contents)
-foreach(line ${workspace_contents})
-    string(REGEX MATCH ".*\"(https://bitbucket.org/eigen/eigen/get/[^\"]*tar.gz)\"" has_url ${line})
-    if(has_url)
-        set(eigen_url ${CMAKE_MATCH_1})
-        break()
-    endif()
-endforeach()
+if (tensorflow_EIGEN_PROVIDER STREQUAL module)
+  # We parse the current Eigen version and archive hash from the bazel configuration
+  file(STRINGS ${PROJECT_SOURCE_DIR}/../../workspace.bzl workspace_contents)
+  foreach(line ${workspace_contents})
+      string(REGEX MATCH ".*\"(https://bitbucket.org/eigen/eigen/get/[^\"]*tar.gz)\"" has_url ${line})
+      if(has_url)
+          set(eigen_url ${CMAKE_MATCH_1})
+          break()
+      endif()
+  endforeach()
 
-set(eigen_INCLUDE_DIRS
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/external/eigen_archive
-    ${tensorflow_source_dir}/third_party/eigen3
-)
-set(eigen_URL ${eigen_url})
-set(eigen_BUILD ${CMAKE_CURRENT_BINARY_DIR}/eigen/src/eigen)
-set(eigen_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/eigen/install)
+  set(eigen_INCLUDE_DIRS
+      ${CMAKE_CURRENT_BINARY_DIR}
+      ${CMAKE_CURRENT_BINARY_DIR}/external/eigen_archive
+      ${tensorflow_source_dir}/third_party/eigen3
+  )
+  set(eigen_URL ${eigen_url})
+  set(eigen_BUILD ${CMAKE_CURRENT_BINARY_DIR}/eigen/src/eigen)
+  set(eigen_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/eigen/install)
 
-ExternalProject_Add(eigen
-    PREFIX eigen
-    URL ${eigen_URL}
-    DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-    INSTALL_DIR "${eigen_INSTALL}"
-    CMAKE_CACHE_ARGS
-        -DCMAKE_BUILD_TYPE:STRING=Release
-        -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
-        -DCMAKE_INSTALL_PREFIX:STRING=${eigen_INSTALL}
-        -DINCLUDE_INSTALL_DIR:STRING=${CMAKE_CURRENT_BINARY_DIR}/external/eigen_archive
-        -DBUILD_TESTING:BOOL=OFF
-)
+  ExternalProject_Add(eigen
+      PREFIX eigen
+      URL ${eigen_URL}
+      DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+      INSTALL_DIR "${eigen_INSTALL}"
+      CMAKE_CACHE_ARGS
+          -DCMAKE_BUILD_TYPE:STRING=Release
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+          -DCMAKE_INSTALL_PREFIX:STRING=${eigen_INSTALL}
+          -DINCLUDE_INSTALL_DIR:STRING=${CMAKE_CURRENT_BINARY_DIR}/external/eigen_archive
+          -DBUILD_TESTING:BOOL=OFF
+  )
+else()
+  find_package(Eigen3 REQUIRED)
+  set(eigen_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()

--- a/tensorflow/contrib/cmake/external/gif.cmake
+++ b/tensorflow/contrib/cmake/external/gif.cmake
@@ -14,73 +14,77 @@
 # ==============================================================================
 include (ExternalProject)
 
-set(gif_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/gif_archive/giflib-5.1.4/)
-set(gif_URL https://mirror.bazel.build/ufpr.dl.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz)
-set(gif_HASH SHA256=34a7377ba834397db019e8eb122e551a49c98f49df75ec3fcc92b9a794a4f6d1)
-set(gif_INSTALL ${CMAKE_BINARY_DIR}/gif/install)
-set(gif_BUILD ${CMAKE_BINARY_DIR}/gif/src/gif)
+if (tensorflow_GIF_PROVIDER STREQUAL module)
+  set(GIF_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/gif_archive/giflib-5.1.4/)
+  set(gif_URL https://mirror.bazel.build/ufpr.dl.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz)
+  set(gif_HASH SHA256=34a7377ba834397db019e8eb122e551a49c98f49df75ec3fcc92b9a794a4f6d1)
+  set(gif_INSTALL ${CMAKE_BINARY_DIR}/gif/install)
+  set(gif_BUILD ${CMAKE_BINARY_DIR}/gif/src/gif)
 
 
-set(gif_HEADERS
-    "${gif_INSTALL}/include/gif_lib.h"
-)
-
-if(WIN32)
-
-  set(gif_STATIC_LIBRARIES ${gif_INSTALL}/lib/giflib.lib)
-
-  ExternalProject_Add(gif
-      PREFIX gif
-      URL ${gif_URL}
-      URL_HASH ${gif_HASH}
-      PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/patches/gif/CMakeLists.txt ${gif_BUILD}
-      INSTALL_DIR ${gif_INSTALL}
-      DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-      CMAKE_CACHE_ARGS
-          -DCMAKE_BUILD_TYPE:STRING=Release
-          -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
-          -DCMAKE_INSTALL_PREFIX:STRING=${gif_INSTALL}
+  set(gif_HEADERS
+      "${gif_INSTALL}/include/gif_lib.h"
   )
 
-  ExternalProject_Add_Step(gif copy_unistd
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different
-          ${CMAKE_SOURCE_DIR}/patches/gif/unistd.h ${gif_BUILD}/lib/unistd.h
-      DEPENDEES patch
-      DEPENDERS build
-  )
+  if(WIN32)
 
+    set(GIF_LIBRARIES ${gif_INSTALL}/lib/giflib.lib)
+
+    ExternalProject_Add(gif
+        PREFIX gif
+        URL ${gif_URL}
+        URL_HASH ${gif_HASH}
+        PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/patches/gif/CMakeLists.txt ${gif_BUILD}
+        INSTALL_DIR ${gif_INSTALL}
+        DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+        CMAKE_CACHE_ARGS
+            -DCMAKE_BUILD_TYPE:STRING=Release
+            -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+            -DCMAKE_INSTALL_PREFIX:STRING=${gif_INSTALL}
+    )
+
+    ExternalProject_Add_Step(gif copy_unistd
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_SOURCE_DIR}/patches/gif/unistd.h ${gif_BUILD}/lib/unistd.h
+        DEPENDEES patch
+        DEPENDERS build
+    )
+
+  else()
+
+    set(GIF_LIBRARIES ${gif_INSTALL}/lib/libgif.a)
+    set(ENV{CFLAGS} "$ENV{CFLAGS} -fPIC")
+
+    ExternalProject_Add(gif
+        PREFIX gif
+        URL ${gif_URL}
+        URL_HASH ${gif_HASH}
+        INSTALL_DIR ${gif_INSTALL}
+        DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+        BUILD_COMMAND $(MAKE)
+        INSTALL_COMMAND $(MAKE) install
+        CONFIGURE_COMMAND
+            ${CMAKE_CURRENT_BINARY_DIR}/gif/src/gif/configure
+            --with-pic
+            --prefix=${gif_INSTALL}
+            --libdir=${gif_INSTALL}/lib
+           --enable-shared=yes
+    )
+
+  endif()
+
+  # put gif includes in the directory where they are expected
+  add_custom_target(gif_create_destination_dir
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${GIF_INCLUDE_DIR}
+      DEPENDS gif)
+
+  add_custom_target(gif_copy_headers_to_destination
+      DEPENDS gif_create_destination_dir)
+
+  foreach(header_file ${gif_HEADERS})
+      add_custom_command(TARGET gif_copy_headers_to_destination PRE_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${header_file} ${GIF_INCLUDE_DIR}/)
+  endforeach()
 else()
-
-  set(gif_STATIC_LIBRARIES ${gif_INSTALL}/lib/libgif.a)
-  set(ENV{CFLAGS} "$ENV{CFLAGS} -fPIC")
-
-  ExternalProject_Add(gif
-      PREFIX gif
-      URL ${gif_URL}
-      URL_HASH ${gif_HASH}
-      INSTALL_DIR ${gif_INSTALL}
-      DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-      BUILD_COMMAND $(MAKE)
-      INSTALL_COMMAND $(MAKE) install
-      CONFIGURE_COMMAND
-          ${CMAKE_CURRENT_BINARY_DIR}/gif/src/gif/configure
-          --with-pic
-          --prefix=${gif_INSTALL}
-          --libdir=${gif_INSTALL}/lib
-         --enable-shared=yes
-  )
-
+  find_package(GIF REQUIRED)
 endif()
-
-# put gif includes in the directory where they are expected
-add_custom_target(gif_create_destination_dir
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${gif_INCLUDE_DIR}
-    DEPENDS gif)
-
-add_custom_target(gif_copy_headers_to_destination
-    DEPENDS gif_create_destination_dir)
-
-foreach(header_file ${gif_HEADERS})
-    add_custom_command(TARGET gif_copy_headers_to_destination PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${header_file} ${gif_INCLUDE_DIR}/)
-endforeach()

--- a/tensorflow/contrib/cmake/external/grpc.cmake
+++ b/tensorflow/contrib/cmake/external/grpc.cmake
@@ -14,48 +14,61 @@
 # ==============================================================================
 include (ExternalProject)
 
-set(GRPC_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/include)
-set(GRPC_URL https://github.com/grpc/grpc.git)
-set(GRPC_BUILD ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc)
-set(GRPC_TAG 730b778632e79cc3c96ad237f282d687ee325ce7)
+if (tensorflow_GRPC_PROVIDER STREQUAL module)
+  set(GRPC_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/include)
+  set(GRPC_URL https://github.com/grpc/grpc.git)
+  set(GRPC_BUILD ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc)
+  set(GRPC_TAG 730b778632e79cc3c96ad237f282d687ee325ce7)
+  set(GRPC_CPP_PLUGIN ${GRPC_BUILD}/grpc_cpp_plugin)
 
-if(WIN32)
-  set(grpc_STATIC_LIBRARIES
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/grpc++_unsecure.lib
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/grpc_unsecure.lib
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/gpr.lib)
+  if(WIN32)
+    set(GRPC_LIBRARIES
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/grpc++_unsecure.lib
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/grpc_unsecure.lib
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/gpr.lib)
+  else()
+    set(GRPC_LIBRARIES
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc++_unsecure.a
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc_unsecure.a
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgpr.a)
+  endif()
+
+  add_definitions(-DGRPC_ARES=0)
+
+  set(GRPC_DEPENDENCIES)
+  if(tensorflow_PROTOBUF_PROVIDER STREQUAL module)
+    list(APPEND GRPC_DEPENDENCIES protobuf)
+  endif()
+  if(tensorflow_ZLIB_PROVIDER STREQUAL module)
+    list(APPEND GRPC_DEPENDENCIES zlib)
+  endif()
+
+  ExternalProject_Add(grpc
+      PREFIX grpc
+      DEPENDS ${GRPC_DEPENDENCIES}
+      GIT_REPOSITORY ${GRPC_URL}
+      GIT_TAG ${GRPC_TAG}
+      DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+      BUILD_IN_SOURCE 1
+      BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release --target grpc++_unsecure
+      COMMAND ${CMAKE_COMMAND} --build . --config Release --target grpc_cpp_plugin
+      INSTALL_COMMAND ""
+      CMAKE_CACHE_ARGS
+          -DCMAKE_BUILD_TYPE:STRING=Release
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+          -DPROTOBUF_INCLUDE_DIRS:STRING=${PROTOBUF_INCLUDE_DIRS}
+          -DPROTOBUF_LIBRARIES:STRING=${PROTOBUF_LIBRARIES}
+          -DZLIB_ROOT:STRING=${ZLIB_INSTALL}
+          -DgRPC_SSL_PROVIDER:STRING=NONE
+  )
+
+  # grpc/src/core/ext/census/tracing.c depends on the existence of openssl/rand.h.
+  ExternalProject_Add_Step(grpc copy_rand
+      COMMAND ${CMAKE_COMMAND} -E copy
+      ${CMAKE_SOURCE_DIR}/patches/grpc/rand.h ${GRPC_BUILD}/include/openssl/rand.h
+      DEPENDEES patch
+      DEPENDERS build
+  )
 else()
-  set(grpc_STATIC_LIBRARIES
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc++_unsecure.a
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc_unsecure.a
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgpr.a)
+  find_package(GRPC REQUIRED)
 endif()
-
-add_definitions(-DGRPC_ARES=0)
-
-ExternalProject_Add(grpc
-    PREFIX grpc
-    DEPENDS protobuf zlib
-    GIT_REPOSITORY ${GRPC_URL}
-    GIT_TAG ${GRPC_TAG}
-    DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-    BUILD_IN_SOURCE 1
-    BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release --target grpc++_unsecure
-    COMMAND ${CMAKE_COMMAND} --build . --config Release --target grpc_cpp_plugin
-    INSTALL_COMMAND ""
-    CMAKE_CACHE_ARGS
-        -DCMAKE_BUILD_TYPE:STRING=Release
-        -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
-        -DPROTOBUF_INCLUDE_DIRS:STRING=${PROTOBUF_INCLUDE_DIRS}
-        -DPROTOBUF_LIBRARIES:STRING=${protobuf_STATIC_LIBRARIES}
-        -DZLIB_ROOT:STRING=${ZLIB_INSTALL}
-	-DgRPC_SSL_PROVIDER:STRING=NONE
-)
-
-# grpc/src/core/ext/census/tracing.c depends on the existence of openssl/rand.h.
-ExternalProject_Add_Step(grpc copy_rand
-    COMMAND ${CMAKE_COMMAND} -E copy
-    ${CMAKE_SOURCE_DIR}/patches/grpc/rand.h ${GRPC_BUILD}/include/openssl/rand.h
-    DEPENDEES patch
-    DEPENDERS build
-)

--- a/tensorflow/contrib/cmake/external/jpeg.cmake
+++ b/tensorflow/contrib/cmake/external/jpeg.cmake
@@ -14,82 +14,86 @@
 # ==============================================================================
 include (ExternalProject)
 
-set(jpeg_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/jpeg_archive)
-set(jpeg_URL https://mirror.bazel.build/www.ijg.org/files/jpegsrc.v9a.tar.gz)
-set(jpeg_HASH SHA256=3a753ea48d917945dd54a2d97de388aa06ca2eb1066cbfdc6652036349fe05a7)
-set(jpeg_BUILD ${CMAKE_CURRENT_BINARY_DIR}/jpeg/src/jpeg)
-set(jpeg_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/jpeg/install)
+if (tensorflow_JPEG_PROVIDER STREQUAL module)
+    set(JPEG_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/jpeg_archive)
+    set(jpeg_URL https://mirror.bazel.build/www.ijg.org/files/jpegsrc.v9a.tar.gz)
+    set(jpeg_HASH SHA256=3a753ea48d917945dd54a2d97de388aa06ca2eb1066cbfdc6652036349fe05a7)
+    set(jpeg_BUILD ${CMAKE_CURRENT_BINARY_DIR}/jpeg/src/jpeg)
+    set(jpeg_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/jpeg/install)
 
-if(WIN32)
-  set(jpeg_STATIC_LIBRARIES ${jpeg_INSTALL}/lib/libjpeg.lib)
+    if(WIN32)
+      set(JPEG_LIBRARIES ${jpeg_INSTALL}/lib/libjpeg.lib)
+    else()
+      set(JPEG_LIBRARIES ${jpeg_INSTALL}/lib/libjpeg.a)
+    endif()
+
+    set(jpeg_HEADERS
+        "${jpeg_INSTALL}/include/jconfig.h"
+        "${jpeg_INSTALL}/include/jerror.h"
+        "${jpeg_INSTALL}/include/jmorecfg.h"
+        "${jpeg_INSTALL}/include/jpeglib.h"
+        "${jpeg_BUILD}/cderror.h"
+        "${jpeg_BUILD}/cdjpeg.h"
+        "${jpeg_BUILD}/jdct.h"
+        "${jpeg_BUILD}/jinclude.h"
+        "${jpeg_BUILD}/jmemsys.h"
+        "${jpeg_BUILD}/jpegint.h"
+        "${jpeg_BUILD}/jversion.h"
+        "${jpeg_BUILD}/transupp.h"
+    )
+
+    if (WIN32)
+        ExternalProject_Add(jpeg
+            PREFIX jpeg
+            URL ${jpeg_URL}
+            URL_HASH ${jpeg_HASH}
+            PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/patches/jpeg/CMakeLists.txt ${jpeg_BUILD}
+            INSTALL_DIR ${jpeg_INSTALL}
+            DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+            CMAKE_CACHE_ARGS
+                -DCMAKE_BUILD_TYPE:STRING=Release
+                -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+                -DCMAKE_INSTALL_PREFIX:STRING=${jpeg_INSTALL}
+        )
+
+        ExternalProject_Add_Step(jpeg copy_jconfig
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${jpeg_BUILD}/jconfig.vc ${jpeg_BUILD}/jconfig.h
+            DEPENDEES patch
+            DEPENDERS build
+        )
+
+    else()
+        ExternalProject_Add(jpeg
+            PREFIX jpeg
+            URL ${jpeg_URL}
+            URL_HASH ${jpeg_HASH}
+            INSTALL_DIR ${jpeg_INSTALL}
+            DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+            BUILD_COMMAND $(MAKE)
+            INSTALL_COMMAND $(MAKE) install
+            CONFIGURE_COMMAND
+                ${jpeg_BUILD}/configure
+                --prefix=${jpeg_INSTALL}
+                --libdir=${jpeg_INSTALL}/lib
+                --enable-shared=yes
+            CFLAGS=-fPIC
+        )
+
+    endif()
+
+    # put jpeg includes in the directory where they are expected
+    add_custom_target(jpeg_create_destination_dir
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${JPEG_INCLUDE_DIR}
+        DEPENDS jpeg)
+
+    add_custom_target(jpeg_copy_headers_to_destination
+        DEPENDS jpeg_create_destination_dir)
+
+    foreach(header_file ${jpeg_HEADERS})
+        add_custom_command(TARGET jpeg_copy_headers_to_destination PRE_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${header_file} ${JPEG_INCLUDE_DIR})
+    endforeach()
 else()
-  set(jpeg_STATIC_LIBRARIES ${jpeg_INSTALL}/lib/libjpeg.a)
+    find_package(JPEG REQUIRED)
 endif()
-
-set(jpeg_HEADERS
-    "${jpeg_INSTALL}/include/jconfig.h"
-    "${jpeg_INSTALL}/include/jerror.h"
-    "${jpeg_INSTALL}/include/jmorecfg.h"
-    "${jpeg_INSTALL}/include/jpeglib.h"
-    "${jpeg_BUILD}/cderror.h"
-    "${jpeg_BUILD}/cdjpeg.h"
-    "${jpeg_BUILD}/jdct.h"
-    "${jpeg_BUILD}/jinclude.h"
-    "${jpeg_BUILD}/jmemsys.h"
-    "${jpeg_BUILD}/jpegint.h"
-    "${jpeg_BUILD}/jversion.h"
-    "${jpeg_BUILD}/transupp.h"
-)
-
-if (WIN32)
-    ExternalProject_Add(jpeg
-        PREFIX jpeg
-        URL ${jpeg_URL}
-        URL_HASH ${jpeg_HASH}
-        PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/patches/jpeg/CMakeLists.txt ${jpeg_BUILD}
-        INSTALL_DIR ${jpeg_INSTALL}
-        DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-        CMAKE_CACHE_ARGS
-            -DCMAKE_BUILD_TYPE:STRING=Release
-            -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
-            -DCMAKE_INSTALL_PREFIX:STRING=${jpeg_INSTALL}
-    )
-
-    ExternalProject_Add_Step(jpeg copy_jconfig
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${jpeg_BUILD}/jconfig.vc ${jpeg_BUILD}/jconfig.h
-        DEPENDEES patch
-        DEPENDERS build
-    )
-
-else()
-    ExternalProject_Add(jpeg
-        PREFIX jpeg
-        URL ${jpeg_URL}
-        URL_HASH ${jpeg_HASH}
-        INSTALL_DIR ${jpeg_INSTALL}
-        DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-        BUILD_COMMAND $(MAKE)
-        INSTALL_COMMAND $(MAKE) install
-        CONFIGURE_COMMAND
-            ${jpeg_BUILD}/configure
-            --prefix=${jpeg_INSTALL}
-            --libdir=${jpeg_INSTALL}/lib
-            --enable-shared=yes
-	    CFLAGS=-fPIC
-    )
-  
-endif()
-
-# put jpeg includes in the directory where they are expected
-add_custom_target(jpeg_create_destination_dir
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${jpeg_INCLUDE_DIR}
-    DEPENDS jpeg)
-
-add_custom_target(jpeg_copy_headers_to_destination
-    DEPENDS jpeg_create_destination_dir)
-
-foreach(header_file ${jpeg_HEADERS})
-    add_custom_command(TARGET jpeg_copy_headers_to_destination PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${header_file} ${jpeg_INCLUDE_DIR})
-endforeach()

--- a/tensorflow/contrib/cmake/external/png.cmake
+++ b/tensorflow/contrib/cmake/external/png.cmake
@@ -58,7 +58,7 @@ if (tensorflow_PNG_PROVIDER STREQUAL module)
 
 	## put png includes in the directory where they are expected
 	add_custom_target(png_create_destination_dir
-		COMMAND ${CMAKE_COMMAND} -E make_directory ${png_INCLUDE_DIR}
+		COMMAND ${CMAKE_COMMAND} -E make_directory ${png_INCLUDE_DIRS}
 		DEPENDS png)
 
 	add_custom_target(png_copy_headers_to_destination

--- a/tensorflow/contrib/cmake/external/png.cmake
+++ b/tensorflow/contrib/cmake/external/png.cmake
@@ -14,49 +14,60 @@
 # ==============================================================================
 include (ExternalProject)
 
-set(png_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/png_archive)
-set(png_URL https://storage.googleapis.com/libpng-public-archive/libpng-1.2.53.tar.gz)
-set(png_HASH SHA256=e05c9056d7f323088fd7824d8c6acc03a4a758c4b4916715924edc5dd3223a72)
-set(png_BUILD ${CMAKE_BINARY_DIR}/png/src/png)
-set(png_INSTALL ${CMAKE_BINARY_DIR}/png/install)
+if (tensorflow_PNG_PROVIDER STREQUAL module)
+	set(PNG_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/external/png_archive)
+	set(png_URL https://storage.googleapis.com/libpng-public-archive/libpng-1.2.53.tar.gz)
+	set(png_HASH SHA256=e05c9056d7f323088fd7824d8c6acc03a4a758c4b4916715924edc5dd3223a72)
+	set(png_BUILD ${CMAKE_BINARY_DIR}/png/src/png)
+	set(png_INSTALL ${CMAKE_BINARY_DIR}/png/install)
 
-if(WIN32)
-  set(png_STATIC_LIBRARIES 
-    debug ${CMAKE_BINARY_DIR}/png/install/lib/libpng12_staticd.lib
-    optimized ${CMAKE_BINARY_DIR}/png/install/lib/libpng12_static.lib)
+	if(WIN32)
+	  set(PNG_LIBRARIES
+		debug ${CMAKE_BINARY_DIR}/png/install/lib/libpng12_staticd.lib
+		optimized ${CMAKE_BINARY_DIR}/png/install/lib/libpng12_static.lib)
+	else()
+	  set(PNG_LIBRARIES ${CMAKE_BINARY_DIR}/png/install/lib/libpng12.a)
+	endif()
+
+	set(png_HEADERS
+		"${png_INSTALL}/include/libpng12/png.h"
+		"${png_INSTALL}/include/libpng12/pngconf.h"
+	)
+
+	set(PNG_DEPENDENCIES)
+	set(PNG_ADDITIONAL_CACHE_ARGS)
+	if(tensorflow_ZLIB_PROVIDER STREQUAL module)
+	    set(PNG_DEPENDENCIES zlib)
+		set(PNG_ADDITIONAL_CACHE_ARGS -DZLIB_ROOT:STRING=${ZLIB_INSTALL})
+	endif()
+
+	ExternalProject_Add(png
+		PREFIX png
+		DEPENDS ${PNG_DEPENDENCIES}
+		URL ${png_URL}
+		URL_HASH ${png_HASH}
+		INSTALL_DIR ${png_INSTALL}
+		DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+		CMAKE_CACHE_ARGS
+			-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=${tensorflow_ENABLE_POSITION_INDEPENDENT_CODE}
+			-DCMAKE_BUILD_TYPE:STRING=Release
+			-DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+			-DCMAKE_INSTALL_PREFIX:STRING=${png_INSTALL}
+			${PNG_ADDITIONAL_CACHE_ARGS}
+	)
+
+	## put png includes in the directory where they are expected
+	add_custom_target(png_create_destination_dir
+		COMMAND ${CMAKE_COMMAND} -E make_directory ${png_INCLUDE_DIR}
+		DEPENDS png)
+
+	add_custom_target(png_copy_headers_to_destination
+		DEPENDS png_create_destination_dir)
+
+	foreach(header_file ${png_HEADERS})
+	  add_custom_command(TARGET png_copy_headers_to_destination PRE_BUILD
+		  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${header_file} ${PNG_INCLUDE_DIRS}/)
+	endforeach()
 else()
-  set(png_STATIC_LIBRARIES ${CMAKE_BINARY_DIR}/png/install/lib/libpng12.a)
+	find_package(PNG REQUIRED)
 endif()
-
-set(png_HEADERS
-    "${png_INSTALL}/include/libpng12/png.h"
-    "${png_INSTALL}/include/libpng12/pngconf.h"
-)
-
-ExternalProject_Add(png
-    PREFIX png
-    DEPENDS zlib
-    URL ${png_URL}
-    URL_HASH ${png_HASH}
-    INSTALL_DIR ${png_INSTALL}
-    DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-    CMAKE_CACHE_ARGS
-        -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=${tensorflow_ENABLE_POSITION_INDEPENDENT_CODE}
-        -DCMAKE_BUILD_TYPE:STRING=Release
-        -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
-        -DCMAKE_INSTALL_PREFIX:STRING=${png_INSTALL}
-	-DZLIB_ROOT:STRING=${ZLIB_INSTALL}
-)
-
-## put png includes in the directory where they are expected
-add_custom_target(png_create_destination_dir
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${png_INCLUDE_DIR}
-    DEPENDS png)
-
-add_custom_target(png_copy_headers_to_destination
-    DEPENDS png_create_destination_dir)
-
-foreach(header_file ${png_HEADERS})
-  add_custom_command(TARGET png_copy_headers_to_destination PRE_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${header_file} ${png_INCLUDE_DIR}/)
-endforeach()

--- a/tensorflow/contrib/cmake/external/protobuf.cmake
+++ b/tensorflow/contrib/cmake/external/protobuf.cmake
@@ -14,38 +14,46 @@
 # ==============================================================================
 include (ExternalProject)
 
-set(PROTOBUF_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/src)
-set(PROTOBUF_URL https://github.com/google/protobuf.git)
-set(PROTOBUF_TAG b04e5cba356212e4e8c66c61bbe0c3a20537c5b9)
+if (tensorflow_PROTOBUF_PROVIDER STREQUAL module AND tensorflow_GRPC_PROVIDER STREQUAL module)
+  set(PROTOBUF_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/src)
+  set(PROTOBUF_URL https://github.com/google/protobuf.git)
+  set(PROTOBUF_TAG b04e5cba356212e4e8c66c61bbe0c3a20537c5b9)
 
-if(WIN32)
-  set(protobuf_STATIC_LIBRARIES 
-    debug ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/$(Configuration)/libprotobufd.lib
-    optimized ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/$(Configuration)/libprotobuf.lib)
-  set(PROTOBUF_PROTOC_EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/$(Configuration)/protoc.exe)
-  set(PROTOBUF_ADDITIONAL_CMAKE_OPTIONS	-Dprotobuf_MSVC_STATIC_RUNTIME:BOOL=OFF -A x64)
+
+  if(WIN32)
+    set(PROTOBUF_LIBRARIES
+      debug ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/$(Configuration)/libprotobufd.lib
+      optimized ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/$(Configuration)/libprotobuf.lib)
+    set(PROTOBUF_PROTOC_EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/$(Configuration)/protoc.exe)
+    set(PROTOBUF_ADDITIONAL_CMAKE_OPTIONS	-Dprotobuf_MSVC_STATIC_RUNTIME:BOOL=OFF -A x64)
+  else()
+    set(PROTOBUF_LIBRARIES ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/libprotobuf.a)
+    set(PROTOBUF_PROTOC_EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/protoc)
+  endif()
+
+  set(PROTOBUF_DEPENDENCIES)
+  if(tensorflow_ZLIB_PROVIDER STREQUAL module)
+    list(APPEND PROTOBUF_DEPENDENCIES zlib)
+    list(APPEND PROTOBUF_ADDITIONAL_CMAKE_OPTIONS -DZLIB_ROOT=${ZLIB_INSTALL})
+  endif()
+
+  ExternalProject_Add(protobuf
+      PREFIX protobuf
+      DEPENDS ${PROTOBUF_DEPENDENCIES}
+      GIT_REPOSITORY ${PROTOBUF_URL}
+      GIT_TAG ${PROTOBUF_TAG}
+      DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+      BUILD_IN_SOURCE 1
+      SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf
+      CONFIGURE_COMMAND ${CMAKE_COMMAND} cmake/
+          -Dprotobuf_BUILD_TESTS=OFF
+          ${PROTOBUF_ADDITIONAL_CMAKE_OPTIONS}
+      INSTALL_COMMAND ""
+      CMAKE_CACHE_ARGS
+          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=${tensorflow_ENABLE_POSITION_INDEPENDENT_CODE}
+          -DCMAKE_BUILD_TYPE:STRING=Release
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+  )
 else()
-  set(protobuf_STATIC_LIBRARIES ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/libprotobuf.a)
-  set(PROTOBUF_PROTOC_EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf/protoc)
+  find_package(Protobuf REQUIRED)
 endif()
-
-ExternalProject_Add(protobuf
-    PREFIX protobuf
-    DEPENDS zlib
-    GIT_REPOSITORY ${PROTOBUF_URL}
-    GIT_TAG ${PROTOBUF_TAG}
-    DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-    BUILD_IN_SOURCE 1
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf/src/protobuf
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} cmake/
-        -Dprotobuf_BUILD_TESTS=OFF
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-        -DZLIB_ROOT=${ZLIB_INSTALL}
-        ${PROTOBUF_ADDITIONAL_CMAKE_OPTIONS}
-    INSTALL_COMMAND ""
-    CMAKE_CACHE_ARGS
-        -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=${tensorflow_ENABLE_POSITION_INDEPENDENT_CODE}
-        -DCMAKE_BUILD_TYPE:STRING=Release
-        -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
-        -DZLIB_ROOT:STRING=${ZLIB_INSTALL}
-)

--- a/tensorflow/contrib/cmake/external/zlib.cmake
+++ b/tensorflow/contrib/cmake/external/zlib.cmake
@@ -14,48 +14,52 @@
 # ==============================================================================
 include (ExternalProject)
 
-set(zlib_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/zlib_archive)
-set(ZLIB_URL https://github.com/madler/zlib)
-set(ZLIB_BUILD ${CMAKE_CURRENT_BINARY_DIR}/zlib/src/zlib)
-set(ZLIB_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/zlib/install)
-set(ZLIB_TAG 50893291621658f355bc5b4d450a8d06a563053d)
+if (tensorflow_ZLIB_PROVIDER STREQUAL module)
+  set(ZLIB_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/external/zlib_archive)
+  set(ZLIB_URL https://github.com/madler/zlib)
+  set(ZLIB_BUILD ${CMAKE_CURRENT_BINARY_DIR}/zlib/src/zlib)
+  set(ZLIB_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/zlib/install)
+  set(ZLIB_TAG 50893291621658f355bc5b4d450a8d06a563053d)
 
-if(WIN32)
-  set(zlib_STATIC_LIBRARIES
-      debug ${CMAKE_CURRENT_BINARY_DIR}/zlib/install/lib/zlibstaticd.lib
-      optimized ${CMAKE_CURRENT_BINARY_DIR}/zlib/install/lib/zlibstatic.lib)
+  if(WIN32)
+    set(ZLIB_LIBRARIES
+        debug ${CMAKE_CURRENT_BINARY_DIR}/zlib/install/lib/zlibstaticd.lib
+        optimized ${CMAKE_CURRENT_BINARY_DIR}/zlib/install/lib/zlibstatic.lib)
+  else()
+    set(ZLIB_LIBRARIES
+        ${CMAKE_CURRENT_BINARY_DIR}/zlib/install/lib/libz.a)
+  endif()
+
+  set(ZLIB_HEADERS
+      "${ZLIB_INSTALL}/include/zconf.h"
+      "${ZLIB_INSTALL}/include/zlib.h"
+  )
+
+  ExternalProject_Add(zlib
+      PREFIX zlib
+      GIT_REPOSITORY ${ZLIB_URL}
+      GIT_TAG ${ZLIB_TAG}
+      INSTALL_DIR ${ZLIB_INSTALL}
+      BUILD_IN_SOURCE 1
+      DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+      CMAKE_CACHE_ARGS
+          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=${tensorflow_ENABLE_POSITION_INDEPENDENT_CODE}
+          -DCMAKE_BUILD_TYPE:STRING=Release
+          -DCMAKE_INSTALL_PREFIX:STRING=${ZLIB_INSTALL}
+  )
+
+  # put zlib includes in the directory where they are expected
+  add_custom_target(zlib_create_destination_dir
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${ZLIB_INCLUDE_DIRS}
+      DEPENDS zlib)
+
+  add_custom_target(zlib_copy_headers_to_destination
+      DEPENDS zlib_create_destination_dir)
+
+  foreach(header_file ${ZLIB_HEADERS})
+      add_custom_command(TARGET zlib_copy_headers_to_destination PRE_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${header_file} ${ZLIB_INCLUDE_DIRS})
+  endforeach()
 else()
-  set(zlib_STATIC_LIBRARIES
-      ${CMAKE_CURRENT_BINARY_DIR}/zlib/install/lib/libz.a)
+  find_package(ZLIB REQUIRED)
 endif()
-
-set(ZLIB_HEADERS
-    "${ZLIB_INSTALL}/include/zconf.h"
-    "${ZLIB_INSTALL}/include/zlib.h"
-)
-
-ExternalProject_Add(zlib
-    PREFIX zlib
-    GIT_REPOSITORY ${ZLIB_URL}
-    GIT_TAG ${ZLIB_TAG}
-    INSTALL_DIR ${ZLIB_INSTALL}
-    BUILD_IN_SOURCE 1
-    DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-    CMAKE_CACHE_ARGS
-        -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=${tensorflow_ENABLE_POSITION_INDEPENDENT_CODE}
-        -DCMAKE_BUILD_TYPE:STRING=Release
-        -DCMAKE_INSTALL_PREFIX:STRING=${ZLIB_INSTALL}
-)
-
-# put zlib includes in the directory where they are expected
-add_custom_target(zlib_create_destination_dir
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${zlib_INCLUDE_DIR}
-    DEPENDS zlib)
-
-add_custom_target(zlib_copy_headers_to_destination
-    DEPENDS zlib_create_destination_dir)
-
-foreach(header_file ${ZLIB_HEADERS})
-    add_custom_command(TARGET zlib_copy_headers_to_destination PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${header_file} ${zlib_INCLUDE_DIR})
-endforeach()

--- a/tensorflow/contrib/cmake/tf_core_cpu.cmake
+++ b/tensorflow/contrib/cmake/tf_core_cpu.cmake
@@ -59,6 +59,14 @@ file(GLOB_RECURSE tf_core_cpu_exclude_srcs
 )
 list(REMOVE_ITEM tf_core_cpu_srcs ${tf_core_cpu_exclude_srcs})
 
+if (NOT tensorflow_ENABLE_GRPC_SUPPORT)
+  file(GLOB_RECURSE tf_core_debug_srcs
+    "${tensorflow_source_dir}/tensorflow/core/debug/*.h"
+    "${tensorflow_source_dir}/tensorflow/core/debug/*.cc"
+  )
+  list(REMOVE_ITEM tf_core_cpu_srcs ${tf_core_debug_srcs})
+endif()
+
 if (tensorflow_ENABLE_GPU)
   file(GLOB_RECURSE tf_core_gpu_srcs
     "${tensorflow_source_dir}/tensorflow/core/common_runtime/gpu/*.cc"

--- a/tensorflow/contrib/cmake/tf_core_distributed_runtime.cmake
+++ b/tensorflow/contrib/cmake/tf_core_distributed_runtime.cmake
@@ -32,8 +32,11 @@ list(REMOVE_ITEM tf_core_distributed_runtime_srcs ${tf_core_distributed_runtime_
 add_library(tf_core_distributed_runtime OBJECT ${tf_core_distributed_runtime_srcs})
 
 add_dependencies(tf_core_distributed_runtime
-    tf_core_cpu grpc
+    tf_core_cpu
 )
+if(tensorflow_GRPC_PROVIDER STREQUAL module)
+    add_dependencies(tf_core_distributed_runtime grpc)
+endif()
 
 ########################################################
 # grpc_tensorflow_server executable

--- a/tensorflow/contrib/cmake/tf_core_framework.cmake
+++ b/tensorflow/contrib/cmake/tf_core_framework.cmake
@@ -34,12 +34,17 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP SRCS HDRS ROOT_DIR)
     list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.pb.cc")
     list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.pb.h")
 
+    set(DEPENDENCIES)
+    if(tensorflow_PROTOBUF_PROVIDER STREQUAL module)
+      set(DEPENDENCIES protobuf)
+    endif()
+
     add_custom_command(
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.pb.cc"
              "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.pb.h"
       COMMAND  ${PROTOBUF_PROTOC_EXECUTABLE}
       ARGS --cpp_out  ${CMAKE_CURRENT_BINARY_DIR} -I ${ROOT_DIR} ${ABS_FIL} -I ${PROTOBUF_INCLUDE_DIRS}
-      DEPENDS ${ABS_FIL} protobuf
+      DEPENDS ${ABS_FIL} ${DEPENDENCIES}
       COMMENT "Running C++ protocol buffer compiler on ${FIL}"
       VERBATIM )
   endforeach()
@@ -69,14 +74,22 @@ if(NOT WIN32)
       list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.pb.cc")
       list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.pb.h")
 
+      set(DEPENDENCIES)
+      if(tensorflow_PROTOBUF_PROVIDER STREQUAL module)
+        list(APPEND DEPENDENCIES protobuf)
+      endif()
+      if(tensorflow_GRPC_PROVIDER STREQUAL module)
+        list(APPEND DEPENDENCIES grpc)
+      endif()
+
       add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.grpc.pb.cc"
                "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.grpc.pb.h"
                "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.pb.cc"
                "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}/${FIL_WE}.pb.h"
         COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
-        ARGS --grpc_out ${CMAKE_CURRENT_BINARY_DIR} --cpp_out ${CMAKE_CURRENT_BINARY_DIR} --plugin protoc-gen-grpc=${GRPC_BUILD}/grpc_cpp_plugin -I ${ROOT_DIR} ${ABS_FIL} -I ${PROTOBUF_INCLUDE_DIRS}
-        DEPENDS ${ABS_FIL} protobuf grpc
+        ARGS --grpc_out ${CMAKE_CURRENT_BINARY_DIR} --cpp_out ${CMAKE_CURRENT_BINARY_DIR} --plugin protoc-gen-grpc=${GRPC_CPP_PLUGIN} -I ${ROOT_DIR} ${ABS_FIL} -I ${PROTOBUF_INCLUDE_DIRS}
+        DEPENDS ${ABS_FIL} ${DEPENDENCIES}
         COMMENT "Running C++ protocol buffer grpc compiler on ${FIL}"
         VERBATIM )
     endforeach()
@@ -172,7 +185,7 @@ RELATIVE_PROTOBUF_TEXT_GENERATE_CPP(PROTO_TEXT_SRCS PROTO_TEXT_HDRS
     ${tensorflow_source_dir} ${tf_proto_text_srcs}
 )
 
-if(WIN32)
+if(WIN32 OR NOT tensorflow_ENABLE_GRPC_SUPPORT)
   add_library(tf_protos_cc ${PROTO_SRCS} ${PROTO_HDRS})
 else()
   file(GLOB_RECURSE tf_protos_grpc_cc_srcs RELATIVE ${tensorflow_source_dir}

--- a/tensorflow/contrib/cmake/tf_core_kernels.cmake
+++ b/tensorflow/contrib/cmake/tf_core_kernels.cmake
@@ -40,6 +40,13 @@ else(tensorflow_BUILD_ALL_KERNELS)
   )
 endif(tensorflow_BUILD_ALL_KERNELS)
 
+if (NOT tensorflow_ENABLE_GRPC_SUPPORT)
+  list(REMOVE_ITEM tf_core_kernels_srcs
+    "${tensorflow_source_dir}/tensorflow/core/kernels/debug_ops.h"
+    "${tensorflow_source_dir}/tensorflow/core/kernels/debug_ops.cc"
+  )
+endif()
+
 if(tensorflow_BUILD_CONTRIB_KERNELS)
   set(tf_contrib_kernels_srcs
       "${tensorflow_source_dir}/tensorflow/contrib/boosted_trees/kernels/model_ops.cc"

--- a/tensorflow/contrib/cmake/tf_shared_lib.cmake
+++ b/tensorflow/contrib/cmake/tf_shared_lib.cmake
@@ -84,6 +84,11 @@ target_link_libraries(tensorflow PRIVATE
     tf_protos_cc
 )
 
+if(CMAKE_COMPILER_IS_GNUCC)
+  set_target_properties(tensorflow PROPERTIES
+          LINK_FLAGS "-Wl,-version-script,\"${tensorflow_source_dir}/tensorflow/tf_version_script.lds\"")
+endif()
+
 # There is a bug in GCC 5 resulting in undefined reference to a __cpu_model function when
 # linking to the tensorflow library. Adding the following libraries fixes it.
 # See issue on github: https://github.com/tensorflow/tensorflow/issues/9593

--- a/tensorflow/contrib/cmake/tf_tools.cmake
+++ b/tensorflow/contrib/cmake/tf_tools.cmake
@@ -33,9 +33,9 @@ target_link_libraries(${proto_text} PUBLIC
 )
 
 add_dependencies(${proto_text} tf_core_lib)
-if(tensorflow_ENABLE_GRPC_SUPPORT)
+if(tensorflow_ENABLE_GRPC_SUPPORT AND tensorflow_GRPC_PROVIDER STREQUAL module)
     add_dependencies(${proto_text} grpc)
-endif(tensorflow_ENABLE_GRPC_SUPPORT)
+endif()
 
 file(GLOB_RECURSE tf_tools_transform_graph_lib_srcs
     "${tensorflow_source_dir}/tensorflow/tools/graph_transforms/*.h"


### PR DESCRIPTION
Here are changes necessary to build tensorflow with different version of GRPC, Protobuf, Eigen, zlib, etc. It is not possible to compile project using two different versions of protobuf for example. To deal with that I've chosen approach similar to one in GRPC library. Copy of https://github.com/tensorflow/tensorflow/pull/14463#issuecomment-343576192