### PR TITLE
Windows: Add missing dependencies in lib_proto_parsing

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -277,6 +277,7 @@ cc_library(
         "platform/platform.h",
         "platform/protobuf.h",
         "platform/types.h",
+        "platform/windows/cpu_info.h",
         "lib/bfloat16/bfloat16.h",
     ] + tf_additional_proto_hdrs() + glob(tf_env_time_hdrs()),
     copts = tf_copts(),


### PR DESCRIPTION
Fix http://ci.tensorflow.org/job/tf-master-win-bzl/2275/console
Culprit: https://github.com/tensorflow/tensorflow/commit/ccbd14b741e6efbe51769f0f1b9cb3719c42c23b
@gunan @panyx0718 