### PR TITLE
Suppress AWS curl init warning

### DIFF
--- a/tensorflow/core/platform/s3/aws_logging.cc
+++ b/tensorflow/core/platform/s3/aws_logging.cc
@@ -48,6 +48,7 @@ void AWSLogSystem::LogStream(Aws::Utils::Logging::LogLevel log_level,
 
 void AWSLogSystem::LogMessage(Aws::Utils::Logging::LogLevel log_level,
                               const std::string& message) {
+  if (message == "Initializing Curl library") return;
   switch (log_level) {
     case Aws::Utils::Logging::LogLevel::Info:
       LOG(INFO) << message;


### PR DESCRIPTION
This shows up each time we run the TensorBoard command, even if we're
not using anything AWS related.

```sh
jart@compy:~/tmp/aws-sdk-cpp-1.3.15$ grep -R "Initializing Curl library" .
./aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp:        AWS_LOGSTREAM_INFO(CURL_HTTP_CLIENT_TAG, "Initializing Curl library");
```