### PR TITLE
[tflite] make calling NNAPI work again

### DIFF
--- a/tensorflow/contrib/lite/interpreter.cc
+++ b/tensorflow/contrib/lite/interpreter.cc
@@ -291,7 +291,6 @@ TfLiteStatus Interpreter::Invoke() {
 
   TfLiteStatus status = kTfLiteOk;
   if (nnapi_delegate_) {
-    TF_LITE_ENSURE_STATUS(PrepareOpsAndTensors());
     if (next_node_to_prepare_ == nodes_and_registration_.size()) {
       TF_LITE_ENSURE_OK(&context_, nnapi_delegate_->Invoke(this));
       return kTfLiteOk;


### PR DESCRIPTION
calling PrepareOpsAndTensors() before using NN API looks
1. unnecessary
2. will decrease `next_node_to_prepare_ so` that the next
```
   next_node_to_prepare_ == nodes_and_registration_.size()
```
will fail