### PR TITLE
Fix compilation error and warnings with CUDA=0

### DIFF
--- a/tensorflow/contrib/verbs/rdma.h
+++ b/tensorflow/contrib/verbs/rdma.h
@@ -358,6 +358,7 @@ class RdmaTensorResponse {
 
   RdmaChannel* channel_;
   RdmaMessage rm_;  // The request message
+  Device* src_dev_ = nullptr;
   TensorBuffer* src_buffer_ = nullptr;
   void* src_addr_ = nullptr;
   ibv_mr* mr_ = nullptr;


### PR DESCRIPTION
There is a compilation error when compiling verbs with CUDA=0. This is rarely used, but we still want it to compile of course.
Also there are some compilation warnings that shouldn't exist. Mostly about 'unused functions' when setting/unsetting certain preprocessor defines.