### PR TITLE
Repair compilation error of tensorflow built with MKL-DNN

### DIFF
--- a/tensorflow/core/kernels/mkl_lrn_op.cc
+++ b/tensorflow/core/kernels/mkl_lrn_op.cc
@@ -43,7 +43,7 @@ limitations under the License.
 using mkldnn::lrn_forward;
 using mkldnn::lrn_backward;
 using mkldnn::prop_kind;
-using mkldnn::algorithm::lrn_across_channels;
+using mkldnn::lrn_across_channels;
 using mkldnn::stream;
 #endif
 


### PR DESCRIPTION
When we compile tensorflow with Intel **MKL-DNN**, it will meet a failure:

`bazel build --copt -O3 --copt=-DINTEL_MKL_DNN --config=mkl -c opt //tensorflow/tools/pip_package:build_pip_package`

**error: 'mkldnn::algorithm' is not a namespace
  using mkldnn::algorithm::lrn_across_channels;**

 Removing the 'algorithm' field in _tensorflow/core/kernels/mkl_lrn_op.cc_ can solve this problem and lead to successful compilation.