### PR TITLE
Removes redundant variable assignment

### DIFF
--- a/tensorflow/python/framework/constant_op.py
+++ b/tensorflow/python/framework/constant_op.py
@@ -59,7 +59,6 @@ def _eager_reshape(tensor, shape, ctx):
   attr_t = tensor._datatype_enum()  # pylint: disable=protected-access
   attr_tshape, (shape,) = execute.args_to_matching_eager(
       [shape], ctx, dtypes.int32)
-  attr_tshape = attr_tshape
   inputs_flat = [tensor, shape]
   attrs = ("T", attr_t, "Tshape", attr_tshape)
   result, = execute.execute(


### PR DESCRIPTION
Addresses alert raised by lgtm.com:
https://lgtm.com/projects/g/tensorflow/tensorflow/snapshot/e6183fbeecf069148371be83988e8e5db2b14185/files/tensorflow/python/framework/constant_op.py#xb77a2f6647d782be:1

It doesn't seem like assigning `attr_tshape = attr_tshape` does anything, so there's no need to keep it in.