### PR TITLE
Disable bfloat16 for sparse_matmul for 1.5.0

### DIFF
--- a/tensorflow/core/kernels/sparse_matmul_op.cc
+++ b/tensorflow/core/kernels/sparse_matmul_op.cc
@@ -1626,11 +1626,10 @@ inline void SparseMatMul<TL, TR>::Compute(
                           SparseMatMulOp<TA, TB, LibxsmmSparseMatMul>);
 #endif
 
-REGISTER_SPARSE_MATMUL(bfloat16, bfloat16);
-
-REGISTER_SPARSE_MATMUL(float, bfloat16);
-
-REGISTER_SPARSE_MATMUL(bfloat16, float);
+// Disabled for TensorFlow 1.5.0. Will be re-enabled in 1.6.0.
+// REGISTER_SPARSE_MATMUL(bfloat16, bfloat16);
+// REGISTER_SPARSE_MATMUL(float, bfloat16);
+// REGISTER_SPARSE_MATMUL(bfloat16, float);
 
 #ifdef TENSORFLOW_USE_LIBXSMM
 REGISTER_SPARSE_MATMUL_LIBXSMM(float, float);

--- a/tensorflow/python/kernel_tests/sparse_matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_matmul_op_test.py
@@ -74,22 +74,22 @@ class SparseMatMulTest(test.TestCase):
   def testBasic(self):
     x = np.arange(0., 4.).reshape([4, 1]).astype(np.float32)
     y = np.arange(-1., 1.).reshape([1, 2]).astype(np.float32)
-    for x_dtype in (dtypes.float32, dtypes.bfloat16):
-      for y_dtype in (dtypes.float32, dtypes.bfloat16):
+    for x_dtype in (dtypes.float32,):
+      for y_dtype in (dtypes.float32,):
         self._testCpuMatmul(x, y, x_dtype=x_dtype, y_dtype=y_dtype)
 
   def testZeroDim(self):
     x = np.ones((4, 0)).astype(np.float32)
     y = np.ones((0, 3)).astype(np.float32)
-    for x_dtype in (dtypes.float32, dtypes.bfloat16):
-      for y_dtype in (dtypes.float32, dtypes.bfloat16):
+    for x_dtype in (dtypes.float32,):
+      for y_dtype in (dtypes.float32,):
         self._testCpuMatmul(x, y, x_dtype=x_dtype, y_dtype=y_dtype)
 
   def testEmpty(self):
     x = np.ones((0, 0)).astype(np.float32)
     y = np.ones((0, 0)).astype(np.float32)
-    for x_dtype in (dtypes.float32, dtypes.bfloat16):
-      for y_dtype in (dtypes.float32, dtypes.bfloat16):
+    for x_dtype in (dtypes.float32,):
+      for y_dtype in (dtypes.float32,):
         self._testCpuMatmul(x, y, x_dtype=x_dtype, y_dtype=y_dtype)
 
   # Tests setting one dimension to be a high value.
@@ -98,8 +98,8 @@ class SparseMatMulTest(test.TestCase):
     r2 = np.random.randint(1, 10)
     r3 = np.random.randint(1, 10)
     for m, k, n in [(r1, r2, r3), (r2, r1, r3), (r2, r3, r1)]:
-      for x_dtype in (dtypes.float32, dtypes.bfloat16):
-        for y_dtype in (dtypes.float32, dtypes.bfloat16):
+      for x_dtype in (dtypes.float32,):
+        for y_dtype in (dtypes.float32,):
           x = RandMatrix(m, k, False)
           y = RandMatrix(k, n, False)
           self._testCpuMatmul(x, y, x_dtype=x_dtype, y_dtype=y_dtype)
@@ -110,8 +110,8 @@ class SparseMatMulTest(test.TestCase):
       for tr_b in [True, False]:
         for sp_a in [True, False]:
           for sp_b in [True, False]:
-            for x_dtype in (dtypes.float32, dtypes.bfloat16):
-              for y_dtype in (dtypes.float32, dtypes.bfloat16):
+            for x_dtype in (dtypes.float32,):
+              for y_dtype in (dtypes.float32,):
                 n, k, m = np.random.randint(1, 100, size=3)
                 x = RandMatrix(n, k, tr_a)
                 y = RandMatrix(k, m, tr_b)
@@ -163,8 +163,8 @@ class MatMulGradientTest(test.TestCase):
       for tr_b in [True, False]:
         for sp_a in [True, False]:
           for sp_b in [True, False]:
-            for a_dtype in (dtypes.float32, dtypes.bfloat16):
-              for b_dtype in (dtypes.float32, dtypes.bfloat16):
+            for a_dtype in (dtypes.float32,):
+              for b_dtype in (dtypes.float32,):
                 name = "sparse_matmul_%s_%s_%s_%s" % (tr_a, tr_b, sp_a, sp_b)
                 self._testGradients(tr_a, tr_b, sp_a, sp_b, a_dtype, b_dtype,
                                     name)


### PR DESCRIPTION
I'm using this PR to test out simple workarounds for the sparse_matmul problem.
It doesn't need a reviewer yet.

Note: it looks like we're going to try to release 1.5.0 with the fix anyway. I will keep this PR available until that's finished.