### PR TITLE
add URLEncode for the CopyObjectRequest of S3 Rename function

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include <aws/core/utils/FileSystemUtils.h>
 #include <aws/core/utils/logging/AWSLogging.h>
 #include <aws/core/utils/logging/LogSystemInterface.h>
+#include <aws/core/utils/StringUtils.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/S3Errors.h>
 #include <aws/s3/model/CopyObjectRequest.h>
@@ -607,7 +608,8 @@ Status S3FileSystem::RenameFile(const string& src, const string& target) {
       Aws::String src_key = object.GetKey();
       Aws::String target_key = src_key;
       target_key.replace(0, src_object.length(), target_object.c_str());
-      Aws::String source = Aws::String(src_bucket.c_str()) + "/" + src_key;
+      Aws::String source = Aws::String(src_bucket.c_str()) + "/"
+          + Aws::Utils::StringUtils::URLEncode(src_key.c_str());
 
       copyObjectRequest.SetBucket(target_bucket.c_str());
       copyObjectRequest.SetKey(target_key);


### PR DESCRIPTION
I found that `tf.gfile.Rename` did not work for S3 objects with UTF-8 names. A "NoSuchKey" error will be reported in this case:

```
>>> tf.gfile.Rename('s3://xxxxxxxx/上海', 's3://xxxxxxxx/北京')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/xxxxxxxx/Software/Linux/anaconda2/envs/tfdev/lib/python2.7/site-packages/tensorflow/python/lib/io/file_io.py", line 402, in rename
    compat.as_bytes(oldname), compat.as_bytes(newname), overwrite, status)
  File "/home/xxxxxxxx/Software/Linux/anaconda2/envs/tfdev/lib/python2.7/site-packages/tensorflow/python/framework/errors_impl.py", line 473, in __exit__
    c_api.TF_GetCode(self.status.status))
tensorflow.python.framework.errors_impl.InternalError: NoSuchKey: The specified key does not exist.
```

After debugging, I believed the error should be related to the usage of `CopyObjectRequest`. It is described that the "CopySource" must be URL-encoded (as in the [AWS document](http://sdk.amazonaws.com/cpp/api/LATEST/class_aws_1_1_s3_1_1_model_1_1_copy_object_request.html#ab3fd89c8e77ffa12d053925efbb099ae) ). Thus, I made a patch. It worked well in my environment, and now objects with UTF-8 names can be renamed by `tf.gfile.Rename`. Also, `bazel test //tensorflow/core/platform/s3:s3_file_system_test` passed.

Please take a look. Thanks!