### PR TITLE
Update tensorboard dep to >= 1.5.0, < 1.6.0

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -36,7 +36,7 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.12.1',
     'six >= 1.10.0',
     'protobuf >= 3.4.0',
-    'tensorflow-tensorboard >= 0.4.0',
+    'tensorflow-tensorboard >= 1.5.0, < 1.6.0',
 ]
 
 project_name = 'tensorflow'


### PR DESCRIPTION
This change fixes the `tensorflow-tensorboard` dep now that TensorBoard 1.5.0 has been pushed to PyPI, and ensures that TensorBoard releases installed as dependencies of TF stay in sync with their corresponding TF releases even once newer (potentially backwards-incompatible) versions of TensorBoard are released by adding `< 1.6.0` as an upper bound.

cc @jart 