### PR TITLE
import contextmanager in side_effect_guards.py

### DIFF
--- a/tensorflow/contrib/py2tf/converters/side_effect_guards.py
+++ b/tensorflow/contrib/py2tf/converters/side_effect_guards.py
@@ -34,6 +34,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from contextlib import contextmanager
+
 import gast
 
 from tensorflow.contrib.py2tf.pyct import anno
@@ -123,7 +125,7 @@ class SideEffectGuardTransformer(gast.NodeTransformer):
             temp_result = (temp_result,)
           ctx = tf.control_dependencies(temp_result)  # pylint:disable=undefined-variable
         else:
-          ctx = contextmanager(lambda: (yield))()  # pylint:disable=undefined-variable
+          ctx = contextmanager(lambda: (yield))()
         with ctx:
           # TODO(mdan): Also insert ops to re-fetch if variables are involved.
           pass  # Will be removed below.


### PR DESCRIPTION
Resolve the undefined name '__contextmanager__' in __side_effect_guards.py__ via __from contextlib import contextmanager__ and remove the associated pylint directive.

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
tensorflow/contrib/py2tf/converters/side_effect_guards.py:126:17: F821 undefined name 'contextmanager'
          ctx = contextmanager(lambda: (yield))()  # pylint:disable=undefined-variable
                ^
```