### PR TITLE
Update README.md

### DIFF
--- a/tensorflow/core/profiler/README.md
+++ b/tensorflow/core/profiler/README.md
@@ -240,7 +240,8 @@ Open a Chrome browser, enter URL chrome://tracing and load the timeline file.
 # can also generate memory profile using `-select bytes`
 tfprof> code -select accelerator_micros -max_depth 100000 -output pprof:outfile=<filename>  -trim_name_regexes .*apply_op.*
 
-# Use pprof to visualize the generated file.
+# Use google-pprof, from the google-perftools package to visualize the generated file.
+# On Ubuntu you can install it with `apt-get install it google-perftools`.
 google-pprof --pdf --nodecount=100 <filename>
 ```
 

--- a/tensorflow/core/profiler/README.md
+++ b/tensorflow/core/profiler/README.md
@@ -241,7 +241,7 @@ Open a Chrome browser, enter URL chrome://tracing and load the timeline file.
 tfprof> code -select accelerator_micros -max_depth 100000 -output pprof:outfile=<filename>  -trim_name_regexes .*apply_op.*
 
 # Use pprof to visualize the generated file.
-pprof -png --nodecount=100 --sample_index=1 <filename>
+google-pprof --pdf --nodecount=100 <filename>
 ```
 
 ![PprofGraph](g3doc/pprof.jpg)


### PR DESCRIPTION
-png, --sample_index options are not available in google-perftools (2.4-0ubuntu5.16.04.1). 
Also, since Ubuntu 16.04 wrongly recommends to install pprof from 'tau' package

> The program 'pprof' is currently not installed. You can install it by typing:
> sudo apt install tau

the typical user command should probably be 

`google-pprof --pdf --nodecount=100 <filename>`