### PR TITLE
long was removed in Python 3

### DIFF
--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -31,6 +31,7 @@ import warnings
 
 import numpy as np
 
+from six import integer_types
 from tensorflow.contrib.saved_model.python.saved_model import reader
 from tensorflow.contrib.saved_model.python.saved_model import signature_def_utils
 from tensorflow.core.example import example_pb2
@@ -440,7 +441,7 @@ def _create_example_string(example_dict):
     elif isinstance(feature_list[0], str):
       example.features.feature[feature_name].bytes_list.value.extend(
           feature_list)
-    elif isinstance(feature_list[0], (int, long)):
+    elif isinstance(feature_list[0], integer_types):
       example.features.feature[feature_name].int64_list.value.extend(
           feature_list)
     else:


### PR DESCRIPTION
__long__ was [removed](https://docs.python.org/3/whatsnew/3.0.html#integers) from Python 3 in favor of __int__.  Here we have replaced the tuple __(int, long)__ with [six.integer_types](https://pythonhosted.org/six/#six.integer_types) which does the right thing in both Python 2 and Python 3.