### PR TITLE
Make raw_rnn accept scalar or TensorArray values for state.

### DIFF
--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -1122,6 +1122,12 @@ def raw_rnn(cell, loop_fn,
       def _copy_some_through(current, candidate):
         """Copy some tensors through via array_ops.where."""
         def copy_fn(cur_i, cand_i):
+          # TensorArray and scalar get passed through.
+          if isinstance(cur_i, tensor_array_ops.TensorArray):
+            return cand_i
+          if cur_i.shape.ndims == 0:
+            return cand_i
+          # Otherwise propagate the old or the new value.
           with ops.colocate_with(cand_i):
             return array_ops.where(elements_finished, cur_i, cand_i)
         return nest.map_structure(copy_fn, current, candidate)


### PR DESCRIPTION
`tf.contrib.seq2seq.AttentionWrapper` rnn cell cannot be passed to `raw_rnn`, the problem is related
#11988, and the same problem in `dynamic_rnn`  been solved. However, in `raw_rnn`, it still exists as 
https://github.com/tensorflow/tensorflow/issues/11988#issuecomment-326887212 pointed.

When state is a tuple which contains a nested scalar state (i.e. `time` state in `tf.contrib.seq2seq.AttentionWrapperState`), the codes `tf.where` for scalars fail.

Current code in `raw_rnn`:
```python
      def _copy_some_through(current, candidate):
        """Copy some tensors through via array_ops.where."""
          with ops.colocate_with(cand_i):
            return array_ops.where(elements_finished, cur_i, cand_i)
        return nest.map_structure(copy_fn, current, candidate)

      emit_output = _copy_some_through(zero_emit, emit_output)
      next_state = _copy_some_through(state, next_state)
```

Similar codes in `dynamic_rnn` have been amended, as follows:
```python
  def _copy_one_through(output, new_output):
    # TensorArray and scalar get passed through.
    if isinstance(output, tensor_array_ops.TensorArray):
      return new_output
    if output.shape.ndims == 0:
      return new_output
    # Otherwise propagate the old or the new value.
    copy_cond = (time >= sequence_length)
    with ops.colocate_with(new_output):
      return array_ops.where(copy_cond, output, new_output)
```

This PR solves the problem, add judgement as with `dynamic_rnn`.