### PR TITLE
Placate pylint on jupyter_notebook_config.py

### DIFF
--- a/tensorflow/tools/docker/jupyter_notebook_config.py
+++ b/tensorflow/tools/docker/jupyter_notebook_config.py
@@ -15,6 +15,7 @@
 import os
 from IPython.lib import passwd
 
+c = c  # pylint:disable=undefined-variable
 c.NotebookApp.ip = '*'
 c.NotebookApp.port = int(os.getenv('PORT', 8888))
 c.NotebookApp.open_browser = False


### PR DESCRIPTION
Eliminate the following pylint issues:
```
E: 18, 0: Undefined variable 'c' (undefined-variable)
E: 19, 0: Undefined variable 'c' (undefined-variable)
E: 20, 0: Undefined variable 'c' (undefined-variable)
E: 26, 4: Undefined variable 'c' (undefined-variable)
E: 28, 4: Undefined variable 'c' (undefined-variable)
E: 29, 4: Undefined variable 'c' (undefined-variable)
```