### PR TITLE
Improve profiler error message when graph_path is not available.

### DIFF
--- a/tensorflow/core/profiler/profiler.cc
+++ b/tensorflow/core/profiler/profiler.cc
@@ -206,8 +206,12 @@ int Run(int argc, char** argv) {
         "graph_path,op_log_path,run_meta_path\n");
     std::unique_ptr<GraphDef> graph(new GraphDef());
     if (!FLAGS_graph_path.empty()) {
-      TF_CHECK_OK(
-          ReadProtoFile(Env::Default(), FLAGS_graph_path, graph.get(), false));
+      s = ReadProtoFile(Env::Default(), FLAGS_graph_path, graph.get(), false);
+      if (!s.ok()) {
+        fprintf(stderr, "Failed to read graph_path: %s\n",
+                s.ToString().c_str());
+        return 1;
+      }
     }
 
     std::unique_ptr<OpLogProto> op_log(new OpLogProto());


### PR DESCRIPTION
This fix tries to address the issue raised in #16451 to provide a better error message when graph_path is not available for profiler.

Previously if graph_path is not available, the process will crash
with not very imformative message and a core dump:
```
2018-01-26 01:43:29.458032: F tensorflow/core/profiler/profiler.cc:206] Non-OK-status: ReadProtoFile(Env::Default(), FLAGS_graph_path, graph.get(), false) status: Not found: ; No such file or directory
Aborted (core dumped)
```

With this fix, the error message is improved to:
```
Failed to read graph_path: Invalid argument: Cannot parse proto file.
```
and the process exit with 1.

This fix fixes #16451.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>