### PR TITLE
Fix build error with GCC 7.2.1 on AWS Linux 2

### DIFF
--- a/tensorflow/contrib/lite/toco/model.h
+++ b/tensorflow/contrib/lite/toco/model.h
@@ -15,6 +15,7 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_LITE_TOCO_MODEL_H_
 #define TENSORFLOW_CONTRIB_LITE_TOCO_MODEL_H_
 
+#include <functional>
 #include <initializer_list>
 #include <memory>
 #include <string>


### PR DESCRIPTION
This fix fixes a build failure when compiling with GCC 7.2.1 on AWS Linux 2:
```
gcc version 7.2.1 20170915 (Red Hat 7.2.1-2) (GCC)
```

The eror output was:
```
...
./tensorflow/contrib/lite/toco/model.h:1567:25: error: 'std::function' has not been declared
   void EraseArrays(std::function<bool(const string&)> discardable) {
  .....
```

This fix is related to #16046.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>