### PR TITLE
contrib/learn: Typo in variable name x_exrta --> x_extra

### DIFF
--- a/tensorflow/contrib/learn/python/learn/datasets/synthetic.py
+++ b/tensorflow/contrib/learn/python/learn/datasets/synthetic.py
@@ -151,7 +151,7 @@ def spirals(n_samples=100,
   # Add more points if n_samples is not divisible by n_classes (unbalanced!)
   extras = n_samples % n_classes
   if extras > 0:
-    x_exrta, y_extra = _modes[mode](np.random.rand(extras) * 2 * np.pi, *args,
+    x_extra, y_extra = _modes[mode](np.random.rand(extras) * 2 * np.pi, *args,
                                     **kwargs)
     spir_x = np.append(spir_x, x_extra)
     spir_y = np.append(spir_y, y_extra)

--- a/tensorflow/contrib/learn/python/learn/datasets/synthetic_test.py
+++ b/tensorflow/contrib/learn/python/learn/datasets/synthetic_test.py
@@ -125,7 +125,7 @@ class SyntheticTest(test.TestCase):
   def test_spirals_typo(self):
     """Test if a typo was made in a variable name such as x_exrta instead of x_extra
 
-       May raise NameError if there is a typo link in pull request ##16500
+       May raise NameError if there is a typo like in pull request ##16500
     """
     synthetic.spirals(3)
 

--- a/tensorflow/contrib/learn/python/learn/datasets/synthetic_test.py
+++ b/tensorflow/contrib/learn/python/learn/datasets/synthetic_test.py
@@ -122,11 +122,7 @@ class SyntheticTest(test.TestCase):
       spir1 = synthetic.spirals(n_samples = 1000, noise = noise/2., seed = seed)
       self.assertRaises(AssertionError, np.testing.assert_array_equal, spir0.data, spir1.data)
 
-  def test_spirals_typo(self):
-    """Test if a typo was made in a variable name such as x_exrta instead of x_extra
-
-       May raise NameError if there is a typo like in pull request ##16500
-    """
+  def test_spirals(self):
     synthetic.spirals(3)
 
 

--- a/tensorflow/contrib/learn/python/learn/datasets/synthetic_test.py
+++ b/tensorflow/contrib/learn/python/learn/datasets/synthetic_test.py
@@ -122,6 +122,13 @@ class SyntheticTest(test.TestCase):
       spir1 = synthetic.spirals(n_samples = 1000, noise = noise/2., seed = seed)
       self.assertRaises(AssertionError, np.testing.assert_array_equal, spir0.data, spir1.data)
 
+  def test_spirals_typo(self):
+    """Test if a typo was made in a variable name such as x_exrta instead of x_extra
+
+       May raise NameError if there is a typo link in pull request ##16500
+    """
+    synthetic.spirals(3)
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
flake8 testing of https://github.com/tensorflow/tensorflow

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tensorflow/contrib/learn/python/learn/datasets/synthetic.py:156:32: F821 undefined name 'x_extra'
    spir_x = np.append(spir_x, x_extra)
                               ^
```