### PR TITLE
Define Cr, Fr, Shared, Var to resolved undefined names

### DIFF
--- a/tensorflow/contrib/specs/python/specs_test.py
+++ b/tensorflow/contrib/specs/python/specs_test.py
@@ -22,14 +22,14 @@ import numpy as np
 
 from tensorflow.contrib.specs import python
 from tensorflow.contrib.specs.python import summaries
+from tensorflow.contrib.specs.python.specs_ops import Cr
+from tensorflow.contrib.specs.python.specs_ops import Fr
+from tensorflow.contrib.specs.python.specs_ops import Shared
+from tensorflow.contrib.specs.python.specs_ops import Var
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import variables
 import tensorflow.python.ops.math_ops  # pylint: disable=unused-import
-from tensorflow.python.ops.spec_ops import Cr
-from tensorflow.python.ops.spec_ops import Fr
-from tensorflow.python.ops.spec_ops import Shared
-from tensorflow.python.ops.spec_ops import Var
 from tensorflow.python.platform import test
 
 specs = python

--- a/tensorflow/contrib/specs/python/specs_test.py
+++ b/tensorflow/contrib/specs/python/specs_test.py
@@ -20,20 +20,20 @@ from __future__ import print_function
 
 import numpy as np
 
-from tensorflow.contrib.layers.python.layers import layers
 from tensorflow.contrib.specs import python
-from tensorflow.contrib.specs.python import specs_lib
 from tensorflow.contrib.specs.python import summaries
+
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import init_ops
-from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import variables
 import tensorflow.python.ops.math_ops  # pylint: disable=unused-import
+from tensorflow.python.ops.spec_ops import Cr
+from tensorflow.python.ops.spec_ops import Fr
+from tensorflow.python.ops.spec_ops import Shared
+from tensorflow.python.ops.spec_ops import Var
 from tensorflow.python.platform import test
 
 specs = python
-Fun = specs_lib.Function
-Cr = Fun(layers.conv2d, activation_fn=nn_ops.relu)
 
 
 def _rand(*size):

--- a/tensorflow/contrib/specs/python/specs_test.py
+++ b/tensorflow/contrib/specs/python/specs_test.py
@@ -20,15 +20,20 @@ from __future__ import print_function
 
 import numpy as np
 
+from tensorflow.contrib.layers.python.layers import layers
 from tensorflow.contrib.specs import python
+from tensorflow.contrib.specs.python import specs_lib
 from tensorflow.contrib.specs.python import summaries
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import variables
 import tensorflow.python.ops.math_ops  # pylint: disable=unused-import
 from tensorflow.python.platform import test
 
 specs = python
+Fun = specs_lib.Function
+Cr = Fun(layers.conv2d, activation_fn=nn_ops.relu)
 
 
 def _rand(*size):

--- a/tensorflow/contrib/specs/python/specs_test.py
+++ b/tensorflow/contrib/specs/python/specs_test.py
@@ -198,10 +198,7 @@ class SpecsTest(test.TestCase):
     self.assertTrue("z" in bindings)
     self.assertTrue("q" in bindings)
 
-  # XXX: the cleverness of this code is over 9000
-  # TODO: original author please fix
-  def DISABLED_testSpecsOps(self):
-    # pylint: disable=undefined-variable
+  def testSpecsOps(self):
     with self.assertRaises(NameError):
       _ = Cr
     with specs.ops:
@@ -210,12 +207,9 @@ class SpecsTest(test.TestCase):
     with self.assertRaises(NameError):
       _ = Cr
 
-  # XXX: the cleverness of this code is over 9000
-  # TODO: original author please fix
-  def DISABLED_testVar(self):
+  def testVar(self):
     with self.test_session() as sess:
       with specs.ops:
-        # pylint: disable=undefined-variable
         v = Var("test_var",
                 shape=[2, 2],
                 initializer=init_ops.constant_initializer(42.0))
@@ -227,12 +221,9 @@ class SpecsTest(test.TestCase):
       self.assertEqual(outputs_value.shape, (2, 2))
       self.assertEqual(outputs_value[1, 1], 42.0)
 
-  # XXX: the cleverness of this code is over 9000
-  # TODO: original author please fix
-  def DISABLED_testShared(self):
+  def testShared(self):
     with self.test_session():
       with specs.ops:
-        # pylint: disable=undefined-variable
         f = Shared(Fr(100))
         g = f | f | f | f
       inputs = constant_op.constant(_rand(10, 100))

--- a/tensorflow/contrib/specs/python/specs_test.py
+++ b/tensorflow/contrib/specs/python/specs_test.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from tensorflow.contrib.specs import python
 from tensorflow.contrib.specs.python import summaries
-
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import variables


### PR DESCRIPTION
flake8 testing of https://github.com/tensorflow/tensorflow

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tensorflow/contrib/specs/python/specs_test.py:202:11: F821 undefined name 'Cr'
      _ = Cr
          ^
./tensorflow/contrib/specs/python/specs_test.py:204:28: F821 undefined name 'Cr'
      self.assertIsNotNone(Cr)
                           ^
./tensorflow/contrib/specs/python/specs_test.py:205:32: F821 undefined name 'Cr'
      self.assertTrue(callable(Cr(64, [3, 3])))
                               ^
./tensorflow/contrib/specs/python/specs_test.py:207:11: F821 undefined name 'Cr'
      _ = Cr
          ^
./tensorflow/contrib/specs/python/specs_test.py:215:13: F821 undefined name 'Var'
        v = Var("test_var",
            ^
./tensorflow/contrib/specs/python/specs_test.py:232:13: F821 undefined name 'Shared'
        f = Shared(Fr(100))
            ^
./tensorflow/contrib/specs/python/specs_test.py:232:20: F821 undefined name 'Fr'
        f = Shared(Fr(100))
                   ^
```