### PR TITLE
MKL: Reverting the switch to max_pool_v2 in python

### DIFF
--- a/tensorflow/contrib/specs/python/specs_test.py
+++ b/tensorflow/contrib/specs/python/specs_test.py
@@ -87,7 +87,7 @@ class SpecsTest(test.TestCase):
       self.assertEqual(tuple(result.shape), (1, 8, 8, 5))
       self.assertEqual(
           summaries.tf_spec_structure(spec, inputs),
-          "_ _ _ maxpoolv2 _ _ maxpoolv2 _ _ maxpoolv2")
+          "_ maxpool maxpool maxpool")
 
   def testAbbrevPower(self):
     with self.test_session():
@@ -100,10 +100,10 @@ class SpecsTest(test.TestCase):
       self.assertEqual(tuple(result.shape), (1, 8, 8, 5))
       self.assertEqual(
           summaries.tf_spec_structure(spec, inputs),
-          "_ variablev2 conv variablev2 biasadd relu _ _ maxpoolv2"
+          "_ variablev2 conv variablev2 biasadd relu maxpool"
           " variablev2 conv variablev2"
-          " biasadd relu _ _ maxpoolv2 variablev2 conv variablev2"
-          " biasadd relu _ _ maxpoolv2")
+          " biasadd relu maxpool variablev2 conv variablev2"
+          " biasadd relu maxpool")
 
   def testAbbrevPower2(self):
     with self.test_session():
@@ -117,10 +117,10 @@ class SpecsTest(test.TestCase):
       self.assertEqual(tuple(result.shape), (1, 8, 8, 5))
       self.assertEqual(
           summaries.tf_spec_structure(spec, inputs),
-          "_ variablev2 conv variablev2 biasadd relu _ _ maxpoolv2"
+          "_ variablev2 conv variablev2 biasadd relu maxpool"
           " variablev2 conv variablev2 biasadd relu"
-          " _ _ maxpoolv2 variablev2 conv variablev2 biasadd relu"
-          " _ _ maxpoolv2")
+          " maxpool variablev2 conv variablev2 biasadd relu"
+          " maxpool")
 
   def testConc(self):
     with self.test_session():

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2070,7 +2070,7 @@ def max_pool(value, ksize, strides, padding, data_format="NHWC", name=None):
   """
   with ops.name_scope(name, "MaxPool", [value]) as name:
     value = ops.convert_to_tensor(value, name="input")
-    return gen_nn_ops._max_pool_v2(value,
+    return gen_nn_ops._max_pool(value,
                                   ksize=ksize,
                                   strides=strides,
                                   padding=padding,


### PR DESCRIPTION
A prior commit https://github.com/tensorflow/tensorflow/pull/14983 changed python interface to call max_pool_v2 causing failure in MKL build. Currently MKL doesn't support max_pool_v2. Reverting  the commit  for now, will change it back when MKL implementation is complete.