### PR TITLE
Add remove_control_dependencies() graph_transform.

### DIFF
--- a/tensorflow/tools/graph_transforms/BUILD
+++ b/tensorflow/tools/graph_transforms/BUILD
@@ -102,6 +102,7 @@ cc_library(
         "remove_ema.cc",
         "obfuscate_names.cc",
         "remove_attribute.cc",
+        "remove_control_dependencies.cc",
         "remove_device.cc",
         "remove_nodes.cc",
         "rename_attribute.cc",

--- a/tensorflow/tools/graph_transforms/README.md
+++ b/tensorflow/tools/graph_transforms/README.md
@@ -639,6 +639,13 @@ specified devices may not be available. In order to work with graphs like these,
 you can run this transform to wipe the slate clean and delete the device
 specifier from all ops.
 
+### remove_control_dependencies
+
+Args: None \
+Prerequisites: None
+
+Removes all control dependencies from the graph.
+
 ### remove_nodes
 
 Args:

--- a/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
+++ b/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
@@ -1,0 +1,34 @@
+#include <tensorflow/core/common_runtime/constant_folding.h>
+#include <tensorflow/core/graph/graph_constructor.h>
+#include <tensorflow/core/graph/node_builder.h>
+#include <tensorflow/core/graph/subgraph.h>
+#include <tensorflow/core/platform/init_main.h>
+#include <tensorflow/core/public/session.h>
+#include <tensorflow/core/util/command_line_flags.h>
+#include <tensorflow/tools/graph_transforms/transform_utils.h>
+
+namespace tensorflow {
+namespace graph_transforms {
+
+// Changes the op type of a specified op.
+Status RemoveControlDependencies(const GraphDef& input_graph_def,
+                const TransformFuncContext& context,
+                GraphDef* output_graph_def) {
+    output_graph_def->Clear();
+    for (const NodeDef& node : input_graph_def.node()) {
+        NodeDef* new_node = output_graph_def->mutable_node()->Add();
+        *new_node = node;
+        new_node->clear_input();
+        for (const auto& input : node.input()) {
+            if (input[0] != '^') {
+                new_node->add_input(input);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+REGISTER_GRAPH_TRANSFORM("remove_control_dependencies", RemoveControlDependencies);
+
+}  // namespace graph_transforms
+}  // namespace tensorflow

--- a/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
+++ b/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
@@ -1,3 +1,17 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 #include <tensorflow/core/graph/graph_constructor.h>
 #include <tensorflow/core/graph/node_builder.h>
 #include <tensorflow/tools/graph_transforms/transform_utils.h>

--- a/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
+++ b/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
@@ -1,10 +1,5 @@
-#include <tensorflow/core/common_runtime/constant_folding.h>
 #include <tensorflow/core/graph/graph_constructor.h>
 #include <tensorflow/core/graph/node_builder.h>
-#include <tensorflow/core/graph/subgraph.h>
-#include <tensorflow/core/platform/init_main.h>
-#include <tensorflow/core/public/session.h>
-#include <tensorflow/core/util/command_line_flags.h>
 #include <tensorflow/tools/graph_transforms/transform_utils.h>
 
 namespace tensorflow {

--- a/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
+++ b/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
@@ -12,9 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <tensorflow/core/graph/graph_constructor.h>
-#include <tensorflow/core/graph/node_builder.h>
-#include <tensorflow/tools/graph_transforms/transform_utils.h>
+#include "tensorflow/core/graph/graph_constructor.h"
+#include "tensorflow/core/graph/node_builder.h"
+#include "tensorflow/tools/graph_transforms/transform_utils.h"
 
 namespace tensorflow {
 namespace graph_transforms {

--- a/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
+++ b/tensorflow/tools/graph_transforms/remove_control_dependencies.cc
@@ -10,7 +10,10 @@
 namespace tensorflow {
 namespace graph_transforms {
 
-// Changes the op type of a specified op.
+// Remove control depdencies in preparation for inference.
+// In the tensorflow graph, control dependencies are represented as extra
+// inputs which are referenced with "^tensor_name".
+// See node_def.proto for more details.
 Status RemoveControlDependencies(const GraphDef& input_graph_def,
                 const TransformFuncContext& context,
                 GraphDef* output_graph_def) {


### PR DESCRIPTION
Add a graph_transform that can be used to remove control dependencies from the tensorflow graph. This can allow later passes such as strip_unused_nodes to do a better job.  