### PR TITLE
Removing duplicate code block that raises exception

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -276,12 +276,6 @@ with tf.Session(graph=graph) as session:
     if step == (num_steps - 1):
       writer.add_run_metadata(run_metadata, 'step%d' % step)
 
-    # Add returned summaries to writer in each step.
-    writer.add_summary(summary, step)
-    # Add metadata to visualize the graph for the last run.
-    if step == (num_steps - 1):
-      writer.add_run_metadata(run_metadata, 'step%d' % step)
-
     if step % 2000 == 0:
       if step > 0:
         average_loss /= 2000


### PR DESCRIPTION
For TensorFlow version 1.5.0-rc1, the code block below raises a `ValueError`. Simply remove the duplication (lines 274 - 277 are exactly the same) and the issue is resolved.

```
# Add returned summaries to writer in each step.
writer.add_summary(summary, step)
# Add metadata to visualize the graph for the last run.
if step == (num_steps - 1):
      writer.add_run_metadata(run_metadata, 'step%d' % step)
```