### PR TITLE
Ensure bash is invoked as a login shell on windows otherwise fixups fail.

### DIFF
--- a/third_party/repo.bzl
+++ b/third_party/repo.bzl
@@ -27,7 +27,7 @@ def _wrap_bash_cmd(ctx, cmd):
     bazel_sh = _get_env_var(ctx, "BAZEL_SH")
     if not bazel_sh:
       fail("BAZEL_SH environment variable is not set")
-    cmd = [bazel_sh, "-c", " ".join(cmd)]
+    cmd = [bazel_sh, "-l", "-c", " ".join(cmd)]
   return cmd
 
 def _get_env_var(ctx, name):


### PR DESCRIPTION
Hi,

This PR contains a small fix to `repo.bzl` to ensure that bash is invoked as a login shell on Windows. Otherwise, depending on the `tf_http_archive` execution, bash fails to find `rm` and/or `patch`. Note this issue only manifests itself when Bazel is invoked from a Windows command prompt.

**E.g.**
```
ERROR: Skipping '//tensorflow:libtensorflow.so': error loading package 'tensorflow': Encountered error while reading extension file 'protobuf.bzl': no such package '@protobuf_archive//': Traceback (most recent call last):
        File "<redacted>/third_party/repo.bzl", line 88
                _apply_patch(ctx, ctx.attr.patch_file)
        File "<redacted>/third_party/repo.bzl", line 59, in _apply_patch
                _execute_and_check_ret_code(ctx, cmd)
        File "<redacted>/third_party/repo.bzl", line 44, in _execute_and_check_ret_code
                fail("Non-zero return code({1}) when ...))
Non-zero return code(127) when executing 'C:\tools\msys64\usr\bin\bash.exe -c patch -p1 -d <redacted>/4bwywwqm/external/protobuf_archive -i <redacted>/third_party/protobuf/add_noinlines.patch':
Stdout:
Stderr: /usr/bin/bash: patch: command not found
```
**Environment**

||Version|
|--|--|
|OS|Win10-Ent|
|Bazel|0.8.1|
|msys2|msys2-x86_64-20161025|

Cheers,

Andy