### PR TITLE
Moving code using new in the linear algebra kernels to absl::make_unique. This should make cleaning…

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2402,6 +2402,7 @@ LINALG_DEPS = [
     "//tensorflow/core:framework",
     "//tensorflow/core:lib",
     "//tensorflow/core:linalg_ops_op_lib",
+    "@com_google_absl//absl/memory"
 ] + if_cuda([
     ":cuda_solvers",
     ":transpose_functor",

--- a/tensorflow/core/kernels/cholesky_op.cc
+++ b/tensorflow/core/kernels/cholesky_op.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #define EIGEN_USE_GPU
 #endif  // GOOGLE_CUDA
 
+#include "absl/memory/memory.h"
 #include "third_party/eigen3/Eigen/Cholesky"
 #include "third_party/eigen3/Eigen/Core"
 #include "tensorflow/core/framework/kernel_def_builder.h"
@@ -121,8 +122,7 @@ class CholeskyOpGpu : public AsyncOpKernel {
     }
 
     // Allocate output.
-    // TODO(rmlarsen): Convert to std::make_unique when available.
-    std::unique_ptr<CudaSolver> solver(new CudaSolver(context));
+    auto solver = absl::make_unique<CudaSolver>(context);
     Tensor* output;
     OP_REQUIRES_OK_ASYNC(context,
                          context->forward_input_or_allocate_output(

--- a/tensorflow/core/kernels/determinant_op.cc
+++ b/tensorflow/core/kernels/determinant_op.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/determinant_op.h"
 #endif
 
+#include "absl/memory/memory.h"
 #include "third_party/eigen3/Eigen/LU"
 #include "tensorflow/core/framework/kernel_def_builder.h"
 #include "tensorflow/core/framework/numeric_types.h"
@@ -164,8 +165,7 @@ class DeterminantOpGpu : public AsyncOpKernel {
       return;
     }
 
-    // TODO(rmlarsen): Convert to absl::make_unique when available.
-    std::unique_ptr<CudaSolver> solver(new CudaSolver(context));
+    auto solver = absl::make_unique<CudaSolver>(context);
 
     // Reuse the input buffer or make a copy for the factorization step,
     // depending on whether this ops owns it exclusively.
@@ -309,8 +309,7 @@ class LogDeterminantOpGpu : public AsyncOpKernel {
       return;
     }
 
-    // TODO(rmlarsen): Convert to absl::make_unique when available.
-    std::unique_ptr<CudaSolver> solver(new CudaSolver(context));
+    auto solver = absl::make_unique<CudaSolver>(context);
 
     // Reuse the input buffer or make a copy for the factorization step,
     // depending on whether this ops owns it exclusively.

--- a/tensorflow/core/kernels/matrix_inverse_op.cc
+++ b/tensorflow/core/kernels/matrix_inverse_op.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #define EIGEN_USE_GPU
 #endif
 
+#include "absl/memory/memory.h"
 #include "third_party/eigen3/Eigen/Core"
 #include "third_party/eigen3/Eigen/LU"
 #include "tensorflow/core/framework/kernel_def_builder.h"
@@ -124,8 +125,7 @@ class MatrixInverseOpGpu : public AsyncOpKernel {
                              {0}, 0, input.shape(), &output),
                          done);
 
-    // TODO(rmlarsen): Convert to std::make_unique when available.
-    std::unique_ptr<CudaSolver> solver(new CudaSolver(context));
+    auto solver = absl::make_unique<CudaSolver>(context);
 
     // Make a copy of the (possible adjointed) input that we will use for the
     // factorization step.

--- a/tensorflow/core/kernels/matrix_solve_op.cc
+++ b/tensorflow/core/kernels/matrix_solve_op.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <numeric>
 
+#include "absl/memory/memory.h"
 #include "third_party/eigen3/Eigen/Core"
 #include "third_party/eigen3/Eigen/LU"
 #include "tensorflow/core/framework/kernel_def_builder.h"
@@ -167,8 +168,7 @@ class MatrixSolveOpGpu : public AsyncOpKernel {
       return;
     }
 
-    // TODO(rmlarsen): Convert to std::make_unique when available.
-    std::unique_ptr<CudaSolver> solver(new CudaSolver(context));
+    auto solver = absl::make_unique<CudaSolver>(context);
 
     // Make a copy of the input for the factorization step, or, if adjoint_ is
     // false, try to reuse the input buffer if this op owns it exclusively.

--- a/tensorflow/core/kernels/qr_op_impl.h
+++ b/tensorflow/core/kernels/qr_op_impl.h
@@ -25,6 +25,7 @@ limitations under the License.
 #define EIGEN_USE_GPU
 #endif
 
+#include "absl/memory/memory.h"
 #include "third_party/eigen3/Eigen/QR"
 #include "tensorflow/core/framework/kernel_def_builder.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -167,8 +168,7 @@ class QrOpGpu : public AsyncOpKernel {
       return;
     }
 
-    // TODO(rmlarsen): Convert to std::make_unique when available.
-    std::unique_ptr<CudaSolver> solver(new CudaSolver(context));
+    auto solver = absl::make_unique<CudaSolver>(context);
 
     // Allocate temporaries.
     Tensor input_transposed;

--- a/tensorflow/core/kernels/self_adjoint_eig_v2_op_gpu.cc
+++ b/tensorflow/core/kernels/self_adjoint_eig_v2_op_gpu.cc
@@ -21,6 +21,8 @@ limitations under the License.
 #include <type_traits>
 
 #define EIGEN_USE_GPU
+
+#include "absl/memory/memory.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/kernel_def_builder.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -81,8 +83,7 @@ class SelfAdjointEigV2OpGpu : public AsyncOpKernel {
     }
 
     // Allocate workspace.
-    // TODO(rmlarsen): Convert to std::make_unique when available.
-    std::unique_ptr<CudaSolver> solver(new CudaSolver(context));
+    auto solver = absl::make_unique<CudaSolver>(context);
     Tensor eigenvalues_real;
     using RealScalar = typename Eigen::NumTraits<Scalar>::Real;
     if (std::is_same<Scalar, RealScalar>::value) {

--- a/tensorflow/core/kernels/svd_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/svd_op_gpu.cu.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include <algorithm>
 #include <vector>
 
+#include "absl/memory/memory.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/kernel_def_builder.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -200,8 +201,7 @@ class SvdOpGpu : public AsyncOpKernel {
     input_shape.AddDim(n);
     input_shape.AddDim(m);
     Tensor input_copy;
-    // TODO(rmlarsen): Convert to std::make_unique when available.
-    std::unique_ptr<CudaSolver> solver(new CudaSolver(context));
+    auto solver = absl::make_unique<CudaSolver>(context);
     OP_REQUIRES_OK_ASYNC(
         context,
         solver->allocate_scoped_tensor(M.dtype(), input_shape, &input_copy),
@@ -266,8 +266,7 @@ class SvdOpGpu : public AsyncOpKernel {
     // Reuse the input buffer or make a copy for the SVD depending on whether
     // this op owns the input buffer exclusively. This is needed because the
     // SVD modifies the input
-    // TODO(rmlarsen): Convert to std::make_unique when available.
-    std::unique_ptr<CudaSolver> solver(new CudaSolver(context));
+    auto solver = absl::make_unique<CudaSolver>(context);
     Tensor input_copy;
     OP_REQUIRES_OK_ASYNC(
         context,


### PR DESCRIPTION
Moving code using new in the linear algebra kernels to absl::make_unique. This should make cleaning this up when std::make_unique is available with automatic tooling easier, and remove references to new.