### PR TITLE
Update docs for tf.matching_files to mention non-deterministic

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_MatchingFiles.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_MatchingFiles.pbtxt
@@ -16,5 +16,6 @@ END
   description: <<END
 Note that this routine only supports wildcard characters in the
 basename portion of the pattern, not in the directory portion.
+Note also that the order of filenames returned can be non-deterministic.
 END
 }

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -556,6 +556,8 @@ class Dataset(object):
         - /path/to/dir/b.py
         - /path/to/dir/c.py
 
+    NOTE: The order of the file names returned can be non-deterministic.
+
     Args:
       file_pattern: A string or scalar string `tf.Tensor`, representing
         the filename pattern that will be matched.

--- a/tensorflow/python/training/input.py
+++ b/tensorflow/python/training/input.py
@@ -56,6 +56,8 @@ _restore_sparse = sparse_ops._take_many_sparse_from_tensors_map
 def match_filenames_once(pattern, name=None):
   """Save the list of files matching pattern, so it is only computed once.
 
+  NOTE: The order of the files returned can be non-deterministic.
+
   Args:
     pattern: A file pattern (glob), or 1D tensor of file patterns.
     name: A name for the operations (optional).


### PR DESCRIPTION
This fix tries to close the issue of #15374 by updating the
docs of `tf.matching_files` (as well as `Dataset.list_files`
and `train.match_filenames_once`), to mention that the file names
returned could be non-deterministic.

This fix fixes #15374.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>