### PR TITLE
Fix typo in attention_wrapper.py

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
+++ b/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
@@ -331,7 +331,7 @@ def _luong_score(query, keys, scale):
   # batched matmul on:
   #   [batch_size, 1, depth] . [batch_size, depth, max_time]
   # resulting in an output shape of:
-  #   [batch_time, 1, max_time].
+  #   [batch_size, 1, max_time].
   # we then squeeze out the center singleton dimension.
   score = math_ops.matmul(query, keys, transpose_b=True)
   score = array_ops.squeeze(score, [1])


### PR DESCRIPTION
This is to fix [#14629](https://github.com/tensorflow/tensorflow/issues/14629).

As said in the discussion, the description of the output shape should be "[batch_size, 1, max_time]" instead of the current "[batch_time, 1, max_time]" (which doesn't make sense because batch_time doesn't occur elsewhere).