### PR TITLE
[XLA] Fix subcomputation unification not adjusting conditionals

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_module.cc
+++ b/tensorflow/compiler/xla/service/hlo_module.cc
@@ -158,6 +158,19 @@ void HloModule::ReplaceComputations(
           }
           break;
         }
+        case HloOpcode::kConditional: {
+          HloComputation* new_true_body = tensorflow::gtl::FindWithDefault(
+              replacements, instruction->true_computation(), nullptr);
+          if (new_true_body != nullptr) {
+            instruction->set_true_computation(new_true_body);
+          }
+          HloComputation* new_false_body = tensorflow::gtl::FindWithDefault(
+              replacements, instruction->false_computation(), nullptr);
+          if (new_false_body != nullptr) {
+            instruction->set_false_computation(new_false_body);
+          }
+          break;
+        }
         default:
           break;
       }


### PR DESCRIPTION
When the subcomputation unification finishes, it calls into the module to adjust any instructions which have had their computation parameters invalidated.

the conditional instruction was missing from this function.
