### PR TITLE
Typo in variable name: BETA --> self.BETA

### DIFF
--- a/tensorflow/contrib/opt/python/training/elastic_average_optimizer.py
+++ b/tensorflow/contrib/opt/python/training/elastic_average_optimizer.py
@@ -150,7 +150,7 @@ class ElasticAverageOptimizer(optimizer.Optimizer):
     self._global_map = ea_custom_getter._global_map
 
     if moving_rate is None:
-      self._moving_rate = BETA / communication_period / num_worker
+      self._moving_rate = self.BETA / communication_period / num_worker
     else:
       self._moving_rate = moving_rate
     if rho is None:


### PR DESCRIPTION
__BETA__ is defined on line 118 as a class member so it can only be accessed via __self__ or via the class name, __ElasticAverageOptimizer__.

flake8 testing of https://github.com/tensorflow/tensorflow

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tensorflow/contrib/opt/python/training/elastic_average_optimizer.py:153:27: F821 undefined name 'BETA'
      self._moving_rate = BETA / communication_period / num_worker
                          ^
```