### PR TITLE
Fix undefined name: import as_str_any for line 35

### DIFF
--- a/tensorflow/python/util/compat_internal.py
+++ b/tensorflow/python/util/compat_internal.py
@@ -19,6 +19,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorflow.python.util.compat import as_str_any
+
 
 def path_to_str(path):
   """Returns the file system path representation of a `PathLike` object, else as it is.


### PR DESCRIPTION
flake8 testing of https://github.com/tensorflow/tensorflow on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tensorflow/python/util/compat_internal.py:33:12: F821 undefined name 'as_str_any'
    path = as_str_any(path.__fspath__())
           ^
```