### PR TITLE
Add stream selection support for `tf.contrib.ffmpeg.decode_video`

### DIFF
--- a/tensorflow/contrib/ffmpeg/decode_video_op.cc
+++ b/tensorflow/contrib/ffmpeg/decode_video_op.cc
@@ -34,7 +34,7 @@ namespace ffmpeg {
 class DecodeVideoOp : public OpKernel {
  public:
   explicit DecodeVideoOp(OpKernelConstruction* context) : OpKernel(context) {
-   string stream;
+    string stream;
     if (context->GetAttr("stream", &stream).ok()) {
       stream_ = stream;
     }
@@ -64,8 +64,8 @@ class DecodeVideoOp : public OpKernel {
 
     // Run FFmpeg on the data and verify results.
     std::vector<uint8> output_data;
-    const Status result = ffmpeg::ReadVideoFile(temp_filename, stream_, &output_data,
-                                                &width, &height, &frames);
+    const Status result = ffmpeg::ReadVideoFile(
+        temp_filename, stream_, &output_data, &width, &height, &frames);
     if (result.code() == error::Code::NOT_FOUND) {
       OP_REQUIRES(
           context, result.ok(),
@@ -75,8 +75,8 @@ class DecodeVideoOp : public OpKernel {
       LOG(ERROR) << "Ffmpeg failed with error '" << result.error_message()
                  << "'. Returning empty tensor.";
       Tensor* output = nullptr;
-      OP_REQUIRES_OK(context,
-                     context->allocate_output(0, TensorShape({0, 0, 0, 0}), &output));
+      OP_REQUIRES_OK(context, context->allocate_output(
+                                  0, TensorShape({0, 0, 0, 0}), &output));
       return;
     } else {
       OP_REQUIRES_OK(context, result);
@@ -95,7 +95,8 @@ class DecodeVideoOp : public OpKernel {
     auto output_flat = output->flat<uint8>();
     std::copy_n(output_data.begin(), output_data.size(), &output_flat(0));
   }
-private:
+
+ private:
   string stream_;
 };
 

--- a/tensorflow/contrib/ffmpeg/ffmpeg_lib.h
+++ b/tensorflow/contrib/ffmpeg/ffmpeg_lib.h
@@ -55,7 +55,8 @@ Status CreateAudioFile(const string& audio_format_id, int32 bits_per_second,
 
 // Reads an video file using ffmpeg and converts it into a RGB24 in uint8
 // [frames, height, width, 3]. The w, h, and frames are obtained from ffmpeg.
-Status ReadVideoFile(const string& filename, std::vector<uint8>* output_data,
+Status ReadVideoFile(const string& filename, const string& stream,
+                     std::vector<uint8>* output_data,
                      uint32* width, uint32* height, uint32* frames);
 
 }  // namespace ffmpeg

--- a/tensorflow/contrib/ffmpeg/ffmpeg_ops.py
+++ b/tensorflow/contrib/ffmpeg/ffmpeg_ops.py
@@ -99,17 +99,20 @@ ops.NotDifferentiable('EncodeAudio')
 
 
 @deprecated('2018-09-04', 'This will be deleted and should not be used.')
-def decode_video(contents):
+def decode_video(contents, stream=None):
   """Create an op that decodes the contents of a video file.
 
   Args:
     contents: The binary contents of the video file to decode. This is a
       scalar.
+    stream: A string specifying which stream from the content file
+      should be decoded, e.g., '0' means the 0-th stream.
+      The default value is '' which leaves the decision to ffmpeg.
 
   Returns:
     A rank-4 `Tensor` that has `[frames, height, width, 3]` RGB as output.
   """
-  return gen_decode_video_op_py.decode_video(contents)
+  return gen_decode_video_op_py.decode_video(contents, stream=stream)
 
 
 ops.NotDifferentiable('DecodeVideo')


### PR DESCRIPTION
This fix is a follow up to #16101. In #16101, stream selection support has been added for `tf.contrib.ffmpeg.decode_audio`.
However, it was still not possible to selectively decode a perticular stream with `tf.contrib.ffmpeg.decode_vidio`.

This fix adds an additional attribute `stream` which could be used to specify the stream of the video to decode. By default `stream=''` which leaves the decision to ffmpeg.

This fix is related to comment https://github.com/tensorflow/tensorflow/pull/16101#issuecomment-357448137

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>