### PR TITLE
We must also trim everything after TAB, in order to correctly parse version from TensorRT-3.0.2

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -380,6 +380,13 @@ def find_cuda_define(repository_ctx, header_dir, header_file, define):
           "Cannot extract the version from line containing '%s' in %s" %
           (define, str(h_path)))
     version = version[:version_end].strip()
+  version_end = version.find("\t")
+  if version_end != -1:
+    if version_end == 0:
+      auto_configure_fail(
+          "Cannot extract the version from line containing '%s' in %s" %
+          (define, str(h_path)))
+    version = version[:version_end].strip()
   return version
 
 


### PR DESCRIPTION
Note TABS after version numbers:

```
dmikushin@tesla-cmc:/opt/TensorRT-3.0.2/include$ cat NvInfer.h | grep SONAME
#define NV_TENSORRT_SONAME_MAJOR 4		//!< shared object library major version number
#define NV_TENSORRT_SONAME_MINOR 0		//!< shared object library minor version number
#define NV_TENSORRT_SONAME_PATCH 2		//!< shared object library patch version number
```

I'm not a Python expert, please feel free to rework this in a better way.

This pull requests fixes the following build error:

```
Cuda Configuration Error: TensorRT library version detected from /opt/TensorRT-3.0.2/include/NvInfer.h (4		//!<.0		//!<.2	//!<) does not match TF_TENSORRT_VERSION (4.0.2). To fix this rerun configure again.
WARNING: Target pattern parsing failed.
```