### PR TITLE
Fix the Windows GPU build

### DIFF
--- a/tensorflow/core/util/cuda_device_functions.h
+++ b/tensorflow/core/util/cuda_device_functions.h
@@ -29,7 +29,6 @@ limitations under the License.
 #include <algorithm>
 #include <complex>
 #include "cuda/include/cuda.h"
-#include "cuda/include/device_functions.h"
 #include "tensorflow/core/platform/types.h"
 
 #if CUDA_VERSION >= 7050


### PR DESCRIPTION
device_functions.h moved in CUDA 9.1, which breaks the Windows GPU build. It's not needed here.