### PR TITLE
Fix incorrect reference DOI number/link for GDR

### DIFF
--- a/tensorflow/contrib/gdr/README.md
+++ b/tensorflow/contrib/gdr/README.md
@@ -119,4 +119,4 @@ In the original design (as in the reference), tensor buffers are only registered
 Reference
 ===
 
-Bairen Yi, Jiacheng Xia, Li Chen, and Kai Chen. 2017. Towards Zero Copy Dataflows using RDMA. In Proceedings of SIGCOMM Posters and Demos'17, Los Angeles, CA, USA, August 22-24, 2017, 3 pages. https://doi.org/10.1145/3123878.3123907
+Bairen Yi, Jiacheng Xia, Li Chen, and Kai Chen. 2017. Towards Zero Copy Dataflows using RDMA. In Proceedings of SIGCOMM Posters and Demos'17, Los Angeles, CA, USA, August 22-24, 2017, 3 pages. https://doi.org/10.1145/3123878.3131975


### PR DESCRIPTION
This fix fixes the incorrect reference DOI number/link for GDR:
`https://doi.org/10.1145/3123878.3123907` -> `https://doi.org/10.1145/3123878.3131975`.

The previous link (https://doi.org/10.1145/3123878.3123907) in the README.md does not work and returns 404. The new link (https://doi.org/10.1145/3123878.3131975) should be the correct one.


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>