### PR TITLE
Fix the mac builds on r1.6

### DIFF
--- a/tensorflow/contrib/py2tf/converters/BUILD
+++ b/tensorflow/contrib/py2tf/converters/BUILD
@@ -131,6 +131,7 @@ py_test(
 py_test(
     name = "for_canonicalization_test",
     srcs = ["for_canonicalization_test.py"],
+    srcs_version = "PY2AND3",
     deps = [
         ":test_lib",
         "//tensorflow/contrib/py2tf/pyct",


### PR DESCRIPTION
Without this setting, it runs 2to3 on the python files. In master, it's set to PY2 which is also wrong.

Tested that the builds pass with this change:
http://ci.tensorflow.org/view/Experimental/job/jhseu-mac-test/