### PR TITLE
Bump the rtol in hmc_test

### DIFF
--- a/tensorflow/contrib/bayesflow/python/kernel_tests/hmc_test.py
+++ b/tensorflow/contrib/bayesflow/python/kernel_tests/hmc_test.py
@@ -617,7 +617,7 @@ class _HMCHandlesLists(object):
           expected_vars,
       ])
       self.assertAllClose(expected_means_, actual_means_, atol=0.05, rtol=0.16)
-      self.assertAllClose(expected_vars_, actual_vars_, atol=0., rtol=0.30)
+      self.assertAllClose(expected_vars_, actual_vars_, atol=0., rtol=0.40)
 
 
 class HMCHandlesLists16(_HMCHandlesLists, test.TestCase):


### PR DESCRIPTION
This test is flaky due to the rtol:
https://source.cloud.google.com/results/invocations/e381cb7e-272e-41ac-b0da-931f6cf293bb/log