### PR TITLE
[tflite] make calling NNAPI work again (resend)

### DIFF
--- a/tensorflow/contrib/lite/interpreter.cc
+++ b/tensorflow/contrib/lite/interpreter.cc
@@ -303,7 +303,6 @@ TfLiteStatus Interpreter::Invoke() {
 
   TfLiteStatus status = kTfLiteOk;
   if (nnapi_delegate_) {
-    TF_LITE_ENSURE_STATUS(PrepareOpsAndTensors());
     if (next_execution_plan_index_to_prepare_ == execution_plan_.size()) {
       TF_LITE_ENSURE_OK(&context_, nnapi_delegate_->Invoke(this));
       return kTfLiteOk;


### PR DESCRIPTION
for the previous one (https://github.com/tensorflow/tensorflow/pull/16256) somehow reverted/overwritten

calling PrepareOpsAndTensors() before using NN API looks
  1. unnecessary
  2. decrease next_execution_plan_index_to_prepare_ so that
     the logic check in the next line
     `next_execution_plan_index_to_prepare_ == execution_plan_.size`
     will fail