### PR TITLE
reshuffle_each_iteration args now default to True

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -591,7 +591,7 @@ class Dataset(object):
     max_value = np.iinfo(dtypes.int64.as_numpy_dtype).max
     return Dataset.zip((Dataset.range(start, max_value), self))
 
-  def shuffle(self, buffer_size, seed=None, reshuffle_each_iteration=None):
+  def shuffle(self, buffer_size, seed=None, reshuffle_each_iteration=True):
     """Randomly shuffles the elements of this dataset.
 
     Args:
@@ -1257,7 +1257,7 @@ class ShuffleDataset(Dataset):
                input_dataset,
                buffer_size,
                seed=None,
-               reshuffle_each_iteration=None):
+               reshuffle_each_iteration=True):
     """Randomly shuffles the elements of this dataset.
 
     Args:
@@ -1292,10 +1292,7 @@ class ShuffleDataset(Dataset):
     else:
       self._seed2 = ops.convert_to_tensor(
           seed2, dtype=dtypes.int64, name="seed2")
-    if reshuffle_each_iteration is None:
-      self._reshuffle_each_iteration = True
-    else:
-      self._reshuffle_each_iteration = reshuffle_each_iteration
+    self._reshuffle_each_iteration = reshuffle_each_iteration
 
   def _as_variant_tensor(self):
     return gen_dataset_ops.shuffle_dataset(


### PR DESCRIPTION
The [documentation for the tf.Dataset.data.shuffle function](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#shuffle) states the following:

> + **reshuffle_each_iteration**: (Optional.) A boolean, which if true indicates that the dataset should be pseudorandomly reshuffled each time it is iterated over. (Defaults to True.)

However, the default value in the function is None:

    def shuffle(self, buffer_size, seed=None, reshuffle_each_iteration=None):

The function calls the ShuffleDataset class, whose `__init__` function also sets the same argument to None by default, and uses the following logic to set the default value of the argument to True:

    if reshuffle_each_iteration is None:
      self._reshuffle_each_iteration = True
    else:
      self._reshuffle_each_iteration = reshuffle_each_iteration

This commit sets the argument to True by default in both the function and the class, making the above code block redundant and replacing it with only `self._reshuffle_each_iteration = reshuffle_each_iteration`.
