### PR TITLE
Update tensorboard dependency to 1.6.0+ and new name

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,6 +59,10 @@ newcomers.
 
   TensorFlow will print a warning if you use XLA:GPU with a known-bad version of
   CUDA; see e00ba24c4038e7644da417ddc639169b6ea59122.
+* The `tensorboard` command or module may appear to be missing after certain
+  upgrade flows. This is due to pip package conflicts as a result of changing
+  the TensorBoard package name.  See the [TensorBoard 1.6.0 release notes](
+  https://github.com/tensorflow/tensorboard/releases/tag/1.6.0) for a fix.
 
 ## Thanks to our Contributors
 

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -39,7 +39,7 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.13.3',
     'six >= 1.10.0',
     'protobuf >= 3.4.0',
-    'tensorflow-tensorboard >= 1.5.0, < 1.6.0',
+    'tensorboard >= 1.6.0, < 1.7.0',
     'termcolor >= 1.1.0',
 ]
 


### PR DESCRIPTION
TensorBoard for versions 1.6.0+ will use the `tensorboard` name on PyPI rather than the previous `tensorflow-tensorboard` name.  Unfortunately PyPI/pip have no notion of package "renames" so it will look like an unrelated dependency, i.e. users doing an upgrade will wind up with both names installed, although the new `tensorboard` package will overwrite the old one functionally speaking.

Let me know if you think it's worth mentioning this in the release notes.

Note that the new name currently just has [TB 1.6.0-rc0 on PyPI](https://pypi.python.org/pypi/tensorboard/1.6.0rc0) but we should have the 1.6.0 final release out in a couple days, before TF 1.6.0 is published.

cc @jhseu 
