### PR TITLE
Fix the tfcompile_tests

### DIFF
--- a/tensorflow/python/platform/test.py
+++ b/tensorflow/python/platform/test.py
@@ -57,10 +57,6 @@ from tensorflow.python.ops.gradient_checker import compute_gradient
 
 import sys
 from tensorflow.python.util.tf_export import tf_export
-if sys.version_info.major == 2:
-  import mock                # pylint: disable=g-import-not-at-top,unused-import
-else:
-  from unittest import mock  # pylint: disable=g-import-not-at-top
 
 # Import Benchmark class
 Benchmark = _googletest.Benchmark  # pylint: disable=invalid-name

--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -1750,7 +1750,8 @@ class Saver(object):
     if save_path is None:
       raise ValueError("Can't load save_path when it is None.")
     if (os.path.isfile(save_path) and
-        self._write_version != saver_pb2.SaverDef.V1):
+        self._write_version != saver_pb2.SaverDef.V1 and
+        self._write_version != saver_pb2.SaverDef.V2):
       raise ValueError("The specified path: %s is a file."
                        " Please specify only the path prefix"
                        " to the checkpoint files." % save_path)


### PR DESCRIPTION

We can remove the mock import as its not being used. Also some of the
checkpoints are V1 and V2 versions and we need to handle both the scenarios

BUILD: bazel build //tensorflow/compiler/aot/tests:tfcompile_test
TEST: ./bazel-bin/tensorflow/compiler/aot/tests/tfcompile_test

Signed-off-by: Subash Patel <subash@nod-labs.com>