### PR TITLE
[tflite] fixed label_image resize bilinear problems

### DIFF
--- a/tensorflow/contrib/lite/examples/label_image/bitmap_helpers_impl.h
+++ b/tensorflow/contrib/lite/examples/label_image/bitmap_helpers_impl.h
@@ -56,10 +56,12 @@ void resize(T* out, uint8_t* in, int image_height, int image_width,
       2, kTfLiteFloat32, "output",
       {1, wanted_height, wanted_width, wanted_channels}, quant);
 
+  TfLiteResizeBilinearParams p = {false};
+
   ops::builtin::BuiltinOpResolver resolver;
   TfLiteRegistration* resize_op =
       resolver.FindOp(BuiltinOperator_RESIZE_BILINEAR);
-  interpreter->AddNodeWithParameters({0, 1}, {2}, nullptr, 0, nullptr,
+  interpreter->AddNodeWithParameters({0, 1}, {2}, nullptr, 0, &p,
                                      resize_op, nullptr);
 
   interpreter->AllocateTensors();

--- a/tensorflow/contrib/lite/examples/label_image/bitmap_helpers_impl.h
+++ b/tensorflow/contrib/lite/examples/label_image/bitmap_helpers_impl.h
@@ -33,7 +33,9 @@ void resize(T* out, uint8_t* in, int image_height, int image_width,
             int wanted_channels, Settings* s) {
 
   int number_of_pixels = image_height * image_width * image_channels;
-  std::unique_ptr<Interpreter> interpreter(new Interpreter);
+  // Interpreter will won't need delete anymore, so cannot use
+  // std::unique_ptr<>, otherwise there will be double free
+  Interpreter *interpreter = new Interpreter();
 
   int base_index = 0;
 


### PR DESCRIPTION
1. Interpreter does not need delete anymore, so cannot use `std::unique_ptr<>`, otherwise there will be double free
2. ResizeBilinear need the `align_corners` parameter after https://github.com/tensorflow/tensorflow/commit/1a0b637df8d082301118dd0f85ec63704f862aeb