### PR TITLE
Fixes issue when linking of rule '//tensorflow/contrib/lite/toco:toco…

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1400,7 +1400,7 @@ def main():
     if is_linux():
       set_tf_tensorrt_install_path(environ_cp)
     set_tf_cuda_compute_capabilities(environ_cp)
-    if environ_cp.get('LD_LIBRARY_PATH') != '1':
+    if 'LD_LIBRARY_PATH' in environ_cp and environ_cp.get('LD_LIBRARY_PATH') != '1':
       write_action_env_to_bazelrc('LD_LIBRARY_PATH', environ_cp.get('LD_LIBRARY_PATH'))
 
     set_tf_cuda_clang(environ_cp)

--- a/configure.py
+++ b/configure.py
@@ -1400,6 +1400,8 @@ def main():
     if is_linux():
       set_tf_tensorrt_install_path(environ_cp)
     set_tf_cuda_compute_capabilities(environ_cp)
+    if environ_cp.get('LD_LIBRARY_PATH') != '1':
+      write_action_env_to_bazelrc('LD_LIBRARY_PATH', environ_cp.get('LD_LIBRARY_PATH'))
 
     set_tf_cuda_clang(environ_cp)
     if environ_cp.get('TF_CUDA_CLANG') == '1':


### PR DESCRIPTION
Fixes issue when linking of rule '//tensorflow/contrib/lite/toco:toco' fails because LD_LIBRARY_PATH is not configured. The workaround is to add `--action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"` to `bazel build` as described here https://stackoverflow.com/questions/47080760/tensorflow-fails-to-compile/47295278#47295278.

Related to issue: https://github.com/tensorflow/tensorflow/issues/15142#issuecomment-352562394