### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ There are two ways to run TensorFlow unit tests.
    bazel test ${flags} //tensorflow/python/...
    ```
 
-2. Using [Docker](www.docker.com) and TensorFlow's CI scripts.
+2. Using [Docker](https://www.docker.com) and TensorFlow's CI scripts.
 
    ```bash
    # Install Docker first, then this will build and run cpu tests


### PR DESCRIPTION
This fix fixes the broken link in CONTRIBUTING.md.

Without `https://`, the markdown will render the link incorrectly to (404):
https://github.com/tensorflow/tensorflow/blob/master/www.docker.com

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>