### PR TITLE
Enable validate_args for all distributions based on a global parameter

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -2775,6 +2775,8 @@ class Graph(object):
     else:
       self._scoped_c_graph = None
     self._variable_creator_stack = []
+    # Global flag to enable checking of validity of inputs to distributions
+    self._validate_args_default = False
 
   # TODO(apassos) remove once the C API is used by default.
   def _use_c_api_hack(self):
@@ -2955,6 +2957,14 @@ class Graph(object):
   @seed.setter
   def seed(self, seed):
     self._seed = seed
+
+  @property
+  def validate_args_default(self):
+    return self._validate_args_default
+
+  @validate_args_default.setter
+  def validate_args_default(self, validate_args_default):
+    self._validate_args_default = validate_args_default
 
   @property
   def finalized(self):

--- a/tensorflow/python/ops/distributions/distribution.py
+++ b/tensorflow/python/ops/distributions/distribution.py
@@ -35,7 +35,7 @@ from tensorflow.python.ops.distributions import kullback_leibler
 from tensorflow.python.ops.distributions import util
 from tensorflow.python.util import tf_inspect
 from tensorflow.python.util.tf_export import tf_export
-
+import tensorflow as tf
 
 __all__ = [
     "ReparameterizationType",
@@ -410,13 +410,15 @@ class Distribution(_BaseDistribution):
       ValueError: if any member of graph_parents is `None` or not a `Tensor`.
     """
     graph_parents = [] if graph_parents is None else graph_parents
+    validate_args_default = tf.get_default_graph().validate_args_default
+
     for i, t in enumerate(graph_parents):
       if t is None or not tensor_util.is_tensor(t):
         raise ValueError("Graph parent item %d is not a Tensor; %s." % (i, t))
     self._dtype = dtype
     self._reparameterization_type = reparameterization_type
     self._allow_nan_stats = allow_nan_stats
-    self._validate_args = validate_args
+    self._validate_args = validate_args_default or validate_args
     self._parameters = parameters or {}
     self._graph_parents = graph_parents
     self._name = name or type(self).__name__


### PR DESCRIPTION
The probability distributions in Tensorflow have a `validate_args` argument that is initially set to `False`. This PR adds a feature that initializes the value of `validate_args` to the value of a global flag `validate_args_default`, which can be set from the user program

Rationale: Currently, when the user sets up the model incorrectly e.g. wrong parameter values are provided for the distributions, or data values don't match the support for the distribution, the program silently fails and produces nans in the output (or worse, wrong values). The user has no way to debug this easily because `validate_args` is `False` by default, and manually adding `validate_args=True` while initializing each distribution can be tedious for the user.

Resolving: #16839 