### PR TITLE
dataset_ops.py batch() checks type immediately

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -741,6 +741,12 @@ class Dataset(object):
     Returns:
       Dataset: A `Dataset`.
     """
+    if isinstance(batch_size, ops.Tensor):
+      if not batch_size.shape.is_compatible_with(tensor_shape.scalar()):
+        raise ValueError("batch_size value should be a scalar, but is not: %s" % value)
+    elif not isinstance(batch_size, (int)):
+      raise ValueError('Unexpectedly found a batch_size of type `' + str(type(batch_size)) + '`. '
+                       'Expected an integer or a scalar symbolic Tensor instance.')
     return BatchDataset(self, batch_size)
 
   def padded_batch(self, batch_size, padded_shapes, padding_values=None):


### PR DESCRIPTION
Currently if you inadvertently pass a non integer value for batch_size you get a strangely cryptic error with a long trace:
```
  File "/home/ahundt/.local/lib/python2.7/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 734, in batch
    return BatchDataset(self, batch_size)
  File "/home/ahundt/.local/lib/python2.7/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 1392, in __init__
    batch_size, dtype=dtypes.int64, name="batch_size")
  File "/home/ahundt/.local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 932, in convert_to_tensor
    as_ref=False)
  File "/home/ahundt/.local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 1022, in internal_convert_to_tensor
    ret = conversion_func(value, dtype=dtype, name=name, as_ref=as_ref)
  File "/home/ahundt/.local/lib/python2.7/site-packages/tensorflow/python/framework/constant_op.py", line 233, in _constant_tensor_conversion_function
    return constant(v, dtype=dtype, name=name)
  File "/home/ahundt/.local/lib/python2.7/site-packages/tensorflow/python/framework/constant_op.py", line 212, in constant
    value, dtype=dtype, shape=shape, verify_shape=verify_shape))
  File "/home/ahundt/.local/lib/python2.7/site-packages/tensorflow/python/framework/tensor_util.py", line 413, in make_tensor_proto
    _AssertCompatible(values, dtype)
  File "/home/ahundt/.local/lib/python2.7/site-packages/tensorflow/python/framework/tensor_util.py", line 328, in _AssertCompatible
    (dtype.name, repr(mismatch), type(mismatch).__name__))
TypeError: Expected int64, got 'dataset_reader.py' of type 'str' instead.
```

This PR hopes to clear that up by checking the type right at the call site.

If I made a mistake in the preferred approach to such a check I'd appreciate advice, I did some searching and I couldn't find obvious examples that can accept both integers and scalar tensors, there are always slight variations and acceptable imports depend on the code location. 