### PR TITLE
[Windows] Copy NominalCPUFrequency from Abseil

### DIFF
--- a/tensorflow/core/platform/windows/port.cc
+++ b/tensorflow/core/platform/windows/port.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #endif
 
 #include <Windows.h>
+#include <shlwapi.h>
 
 #include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/demangle.h"

--- a/tensorflow/core/platform/windows/port.cc
+++ b/tensorflow/core/platform/windows/port.cc
@@ -149,11 +149,16 @@ bool Snappy_Uncompress(const char* input, size_t length, char* output) {
 string Demangle(const char* mangled) { return mangled; }
 
 double NominalCPUFrequency() {
-#ifdef TENSORFLOW_USE_ABSL
-  return absl::base_internal::NominalCPUFrequency();
-#else
+  DWORD data;
+  DWORD data_size = sizeof(data);
+  #pragma comment(lib, "shlwapi.lib")  // For SHGetValue().
+  if (SUCCEEDED(
+          SHGetValueA(HKEY_LOCAL_MACHINE,
+                      "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+                      "~MHz", nullptr, &data, &data_size))) {
+    return data * 1e6;  // Value is MHz.
+  }
   return 1.0;
-#endif
 }
 
 int64 AvailableRam() {


### PR DESCRIPTION
Attempt to fix Bazel build on Windows. https://ci.tensorflow.org/job/tf-master-win-bzl/ is all red since https://github.com/tensorflow/tensorflow/commit/09138338ed81b56aeaff88b9ee5a11c3f6d77b70

Copy from https://github.com/abseil/abseil-cpp/blob/4972c72c5cf2f27e2a0846ce9ff5d377d3f2b7af/absl/base/internal/sysinfo.cc#L74

Do not ever use anything from `absl::*_internal` as it violates Abseil's compatibility contract.

/cc @meteorcloudy @benoitsteiner 