### PR TITLE
[MSVC] Use explicit func pointer to static method instead of lambda func

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_instruction.h
+++ b/tensorflow/compiler/xla/service/hlo_instruction.h
@@ -571,12 +571,9 @@ class HloInstruction {
     if (opcode() != other.opcode()) {
       return false;
     }
-    auto eq_shapes = layout_sensitive
-                         ? [](const Shape& a,
-                              const Shape& b) { return ShapeUtil::Equal(a, b); }
-                         : [](const Shape& a, const Shape& b) {
-                             return ShapeUtil::Compatible(a, b);
-                           };
+    using EqShapeFuncType = bool (*)(const Shape&, const Shape&);
+    EqShapeFuncType eq_shapes =
+        layout_sensitive ? ShapeUtil::Equal : ShapeUtil::Compatible;
     if (!eq_shapes(shape(), other.shape())) {
       return false;
     }


### PR DESCRIPTION
MSVC cannot decide the common type to accept two lambda functions even though they are non-capturing and have the same function signatures.

Since they just pass parameters to static methods, just use function pointers to these static methods.

`using EqShapeFuncType = bool (*)(const Shape&, const Shape&)` is really just for readability. I just thought that reader might not be able to figure out the function signature if I just use `auto eq_shapes = layout_sensitive ? ShapeUtil::Equal : ShapeUtil::Compatible`.

/cc @thefiddler

#16911