### PR TITLE
Update tb-nightly dep to >= 1.7.0a0, < 1.8.0a0

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -62,7 +62,7 @@ else:
 if 'tf_nightly' in project_name:
   for i, pkg in enumerate(REQUIRED_PACKAGES):
     if 'tensorboard' in pkg:
-      REQUIRED_PACKAGES[i] = 'tb-nightly >= 1.5.0a0, < 1.6.0a0'
+      REQUIRED_PACKAGES[i] = 'tb-nightly >= 1.7.0a0, < 1.8.0a0'
       break
 
 # weakref.finalize and enum were introduced in Python 3.4


### PR DESCRIPTION
Now that tf-nightly is at 1.7.0+ on PyPI and tb-nightly has been updated to publish at 1.7.0+ as well, synchronize the deps so that current tf-nightly depends on current tb-nightly.