### PR TITLE
Fix compiler error mentioned in #16960 introduced by commit 1baac78627

### DIFF
--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -161,7 +161,7 @@ class MklCPUAllocator : public VisitableAllocator {
   /// The alignment that we need for the allocations
   static const size_t kAlignment = 64;
 
-  Allocator* allocator_;  // owned by this class
+  BFCAllocator* allocator_;  // owned by this class
 };
 
 }  // namespace tensorflow


### PR DESCRIPTION
Addressing #16960.
The commit https://github.com/tensorflow/tensorflow/commit/1baac7862739525351d25202800dc04e8ec3868b introduced member functions `MklSubAllocator::AddAllocVisitor` and `MklSubAllocator::AddFreeVisitor` which respectively use `allocator_->AddAllocVisitor` and `allocator_->AddFreeVisitor` but `allocator_` is of type `Allocator *` which doesn't have these member functions. 

I am guessing the intention was to change the type of `allocator_` to `BFCAllocator*` to make this work.