### PR TITLE
Added controlled logging to estimator.py

### DIFF
--- a/tensorflow/python/estimator/estimator.py
+++ b/tensorflow/python/estimator/estimator.py
@@ -288,7 +288,7 @@ class Estimator(object):
             hooks=None,
             steps=None,
             max_steps=None,
-            saving_listeners=None
+            saving_listeners=None,
             logging_every_n_iter=100):
     """Trains a model given training data input_fn.
 


### PR DESCRIPTION
Added `logging_every_n_iter` argument to Estimator.fit and _train_model to control the display of metrics (e.g. loss and accuracy) during training.