### PR TITLE
fixup 1baac78627: Underlying allocator must be a VisitableAllocator too

### DIFF
--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -161,7 +161,7 @@ class MklCPUAllocator : public VisitableAllocator {
   /// The alignment that we need for the allocations
   static const size_t kAlignment = 64;
 
-  Allocator* allocator_;  // owned by this class
+  VisitableAllocator* allocator_;  // owned by this class
 };
 
 }  // namespace tensorflow


### PR DESCRIPTION
Signed-off-by: Sylvain Gault <sylvain.gault@road-b-score.com>