### PR TITLE
Fix broken link in tfmobile documentation

### DIFF
--- a/tensorflow/docs_src/mobile/linking_libs.md
+++ b/tensorflow/docs_src/mobile/linking_libs.md
@@ -27,7 +27,7 @@ called `libandroid_tensorflow_inference_java.jar`. There are three ways to
 include this functionality in your program:
 
 1. Include the jcenter AAR which contains it, as in this
- [example app](https://github.com/googlecodelabs/tensorflow-for-poets-2/blob/master/android/build.gradle#L59-L65)
+ [example app](https://github.com/googlecodelabs/tensorflow-for-poets-2/blob/master/android/tfmobile/build.gradle#L59-L65)
 
 2. Download the nightly precompiled version from
 [ci.tensorflow.org](http://ci.tensorflow.org/view/Nightly/job/nightly-android/lastSuccessfulBuild/artifact/out/).


### PR DESCRIPTION
This fix fixes the broken link in tfmobile documentation as
`android/` had been moved to `android/tfmobile/` in the repo
`googlecodelabs/tensorflow-for-poets-2`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>