### PR TITLE
Adds a check for shuffle=None in numpy_input_fn

### DIFF
--- a/tensorflow/python/estimator/inputs/numpy_io.py
+++ b/tensorflow/python/estimator/inputs/numpy_io.py
@@ -138,6 +138,8 @@ def numpy_input_fn(x,
     ValueError: if x or y is an empty dict.
     TypeError: `x` is not a dict or array, or if `shuffle` is not bool.
   """
+  if shuffle is None:
+    shuffle = False
   if not isinstance(shuffle, bool):
     raise TypeError('shuffle must be explicitly set as boolean; '
                     'got {}'.format(shuffle))


### PR DESCRIPTION
`numpy_input_fn`'s shuffle argument is set to `None` by default. If the argument is not provided, the function raises a `TypeError` since shuffle is of type `NoneType` and not `bool`.

This is fixed by adding a simple check to see if `shuffle` is `None`, and setting it to `False` if so.

From my understanding, this should be the desired behavior. Do let me know if this is not the case! It doesn't seem like additional test code is needed, or any existing test code needs to be changed.

Thanks!