### PR TITLE
fix SRU call return type

### DIFF
--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -2771,7 +2771,9 @@ class SRUCell(rnn_cell_impl._LayerRNNCell):
     c = f * state + (1.0 - f) * x_bar
     h = r * self._activation(c) + (1.0 - r) * inputs
 
-    return h, c
+    new_state = (rnn_cell_impl.LSTMStateTuple(c, h))
+
+    return h, new_state
 
 
 class WeightNormLSTMCell(rnn_cell_impl.RNNCell):


### PR DESCRIPTION
Because many other cells , such as BasicLSTMCell 、 LSTMCell 、NASCell 、 LayerNormBasicLSTMCell , return h and stateTuple with c and h when call . I think sru should return the same type as lstm .