### PR TITLE
conv1d doc string misnames first argument

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2380,7 +2380,7 @@ def conv1d(value,
 
   Args:
     value: A 3D `Tensor`.  Must be of type `float16` or `float32`.
-    filters: A 3D `Tensor`.  Must have the same type as `input`.
+    filters: A 3D `Tensor`.  Must have the same type as `value`.
     stride: An `integer`.  The number of entries by which
       the filter is moved right at each step.
     padding: 'SAME' or 'VALID'


### PR DESCRIPTION
The docs say `conv2d()`'s first argument is `input` which is maybe how the docstring for `conv1d()` ended up saying `input` instead of `value` when describing the `filters` argument.