### PR TITLE
add model restore support for tree and forest variables

### DIFF
--- a/tensorflow/contrib/tensor_forest/python/tensor_forest.py
+++ b/tensorflow/contrib/tensor_forest/python/tensor_forest.py
@@ -354,7 +354,7 @@ class ForestVariables(object):
         if tree_stats is not None:
           kwargs.update(dict(tree_stat=tree_stats[i]))
         self.variables.append(tree_variables_class(
-                params, i, training, **kwargs))
+            params, i, training, **kwargs))
 
   def __setitem__(self, t, val):
     self.variables[t] = val

--- a/tensorflow/contrib/tensor_forest/python/tensor_forest.py
+++ b/tensorflow/contrib/tensor_forest/python/tensor_forest.py
@@ -335,7 +335,8 @@ class ForestVariables(object):
   """
 
   def __init__(self, params, device_assigner, training=True,
-               tree_variables_class=TreeVariables, tree_configs=None, tree_stats=None):
+               tree_variables_class=TreeVariables,
+               tree_configs=None, tree_stats=None):
     self.variables = []
     # Set up some scalar variables to run through the device assigner, then
     # we can use those to colocate everything related to a tree.
@@ -349,10 +350,11 @@ class ForestVariables(object):
       with ops.device(self.device_dummies[i].device):
         kwargs = {}
         if tree_configs is not None:
-            kwargs.update(dict(tree_config=tree_configs[i]))
+          kwargs.update(dict(tree_config=tree_configs[i]))
         if tree_stats is not None:
-            kwargs.update(dict(tree_stat=tree_stats[i]))
-        self.variables.append(tree_variables_class(params, i, training, **kwargs))
+          kwargs.update(dict(tree_stat=tree_stats[i]))
+        self.variables.append(tree_variables_class(
+                params, i, training, **kwargs))
 
   def __setitem__(self, t, val):
     self.variables[t] = val
@@ -380,7 +382,8 @@ class RandomForestGraphs(object):
     logging.info(self.params.__dict__)
     self.variables = variables or ForestVariables(
         self.params, device_assigner=self.device_assigner, training=training,
-        tree_variables_class=tree_variables_class, tree_configs=tree_configs, tree_stats=tree_stats)
+        tree_variables_class=tree_variables_class,
+        tree_configs=tree_configs, tree_stats=tree_stats)
     tree_graph_class = tree_graphs or RandomTreeGraphs
     self.trees = [
         tree_graph_class(self.variables[i], self.params, i)

--- a/tensorflow/contrib/tensor_forest/python/tensor_forest_test.py
+++ b/tensorflow/contrib/tensor_forest/python/tensor_forest_test.py
@@ -114,7 +114,7 @@ class TensorForestTest(test_util.TensorFlowTestCase):
     self.assertTrue(isinstance(paths, ops.Tensor))
     self.assertTrue(isinstance(var, ops.Tensor))
 
-  def testInfrenceWithPreTrainedParams(self):
+  def testInfrenceFromRestoredModel(self):
     input_data = [[-1., 0.], [-1., 2.],  # node 1
                   [1., 0.], [1., -2.]]  # node 2
     expected_prediction = [[0.0, 1.0], [0.0, 1.0],
@@ -126,8 +126,8 @@ class TensorForestTest(test_util.TensorFlowTestCase):
         max_nodes=1000,
         split_after_samples=25).fill()
     tree_weight = {'decisionTree': {'nodes': [{'binaryNode': {'rightChildId': 2, 'leftChildId': 1, 'inequalityLeftChildTest': {'featureId': {'id': '0'}, 'threshold': {'floatValue': 0}}}}, {'leaf': {'vector': {'value': [{'floatValue': 0.0}, {'floatValue': 1.0}]}}, 'nodeId': 1}, {'leaf': {'vector': {'value': [{'floatValue': 0.0}, {'floatValue': 1.0}]}}, 'nodeId': 2}]}}
-    tree_param = ParseDict(tree_weight, _tree_proto.Model()).SerializeToString()
-    graph_builder = tensor_forest.RandomForestGraphs(hparams, [tree_param])
+    restored_tree_param = ParseDict(tree_weight, _tree_proto.Model()).SerializeToString()
+    graph_builder = tensor_forest.RandomForestGraphs(hparams, [restored_tree_param])
     probs, paths, var = graph_builder.inference_graph(input_data)
     self.assertTrue(isinstance(probs, ops.Tensor))
     self.assertTrue(isinstance(paths, ops.Tensor))

--- a/tensorflow/contrib/tensor_forest/python/tensor_forest_test.py
+++ b/tensorflow/contrib/tensor_forest/python/tensor_forest_test.py
@@ -18,10 +18,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from google.protobuf.json_format import ParseDict
+from tensorflow.contrib.decision_trees.proto import generic_tree_model_pb2 as _tree_proto
 from tensorflow.contrib.tensor_forest.python import tensor_forest
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import test_util
+from tensorflow.python.ops import resources
+from tensorflow.python.ops import variables
 from tensorflow.python.platform import googletest
 
 
@@ -109,6 +113,30 @@ class TensorForestTest(test_util.TensorFlowTestCase):
     self.assertTrue(isinstance(probs, ops.Tensor))
     self.assertTrue(isinstance(paths, ops.Tensor))
     self.assertTrue(isinstance(var, ops.Tensor))
+
+  def testInfrenceWithPreTrainedParams(self):
+    input_data = [[-1., 0.], [-1., 2.],  # node 1
+                  [1., 0.], [1., -2.]]  # node 2
+    expected_prediction = [[0.0, 1.0], [0.0, 1.0],
+                           [0.0, 1.0], [0.0, 1.0]]
+    hparams = tensor_forest.ForestHParams(
+        num_classes=2,
+        num_features=2,
+        num_trees=1,
+        max_nodes=1000,
+        split_after_samples=25).fill()
+    tree_weight = {'decisionTree': {'nodes': [{'binaryNode': {'rightChildId': 2, 'leftChildId': 1, 'inequalityLeftChildTest': {'featureId': {'id': '0'}, 'threshold': {'floatValue': 0}}}}, {'leaf': {'vector': {'value': [{'floatValue': 0.0}, {'floatValue': 1.0}]}}, 'nodeId': 1}, {'leaf': {'vector': {'value': [{'floatValue': 0.0}, {'floatValue': 1.0}]}}, 'nodeId': 2}]}}
+    tree_param = ParseDict(tree_weight, _tree_proto.Model()).SerializeToString()
+    graph_builder = tensor_forest.RandomForestGraphs(hparams, [tree_param])
+    probs, paths, var = graph_builder.inference_graph(input_data)
+    self.assertTrue(isinstance(probs, ops.Tensor))
+    self.assertTrue(isinstance(paths, ops.Tensor))
+    self.assertTrue(isinstance(var, ops.Tensor))
+    with self.test_session():
+      variables.global_variables_initializer().run()
+      resources.initialize_resources(resources.shared_resources()).run()
+      self.assertEquals(probs.eval().shape, (4, 2))
+      self.assertEquals(probs.eval().tolist(), expected_prediction)
 
   def testTrainingConstructionClassificationSparse(self):
     input_data = sparse_tensor.SparseTensor(

--- a/tensorflow/contrib/tensor_forest/python/tensor_forest_test.py
+++ b/tensorflow/contrib/tensor_forest/python/tensor_forest_test.py
@@ -126,23 +126,25 @@ class TensorForestTest(test_util.TensorFlowTestCase):
         max_nodes=1000,
         split_after_samples=25).fill()
     tree_weight = {'decisionTree':
-                    {'nodes':
+                       {'nodes':
                         [{'binaryNode':
-                            {'rightChildId': 2,
-                             'leftChildId': 1,
-                             'inequalityLeftChildTest':
-                             {'featureId': {'id': '0'},
-                             'threshold': {'floatValue': 0}}}},
+                          {'rightChildId': 2,
+                           'leftChildId': 1,
+                           'inequalityLeftChildTest':
+                           {'featureId': {'id': '0'},
+                            'threshold': {'floatValue': 0}}}},
                          {'leaf': {'vector':
-                            {'value': [{'floatValue': 0.0},
-                                       {'floatValue': 1.0}]}},
-                            'nodeId': 1},
-                        {'leaf': {'vector':
-                            {'value': [{'floatValue': 0.0},
-                                       {'floatValue': 1.0}]}},
-                            'nodeId': 2}]}}
-    restored_tree_param = ParseDict(tree_weight, _tree_proto.Model()).SerializeToString()
-    graph_builder = tensor_forest.RandomForestGraphs(hparams, [restored_tree_param])
+                                   {'value': [{'floatValue': 0.0},
+                                              {'floatValue': 1.0}]}},
+                          'nodeId': 1},
+                         {'leaf': {'vector':
+                                   {'value': [{'floatValue': 0.0},
+                                              {'floatValue': 1.0}]}},
+                          'nodeId': 2}]}}
+    restored_tree_param = ParseDict(tree_weight,
+                                    _tree_proto.Model()).SerializeToString()
+    graph_builder = tensor_forest.RandomForestGraphs(hparams,
+                                                     [restored_tree_param])
     probs, paths, var = graph_builder.inference_graph(input_data)
     self.assertTrue(isinstance(probs, ops.Tensor))
     self.assertTrue(isinstance(paths, ops.Tensor))

--- a/tensorflow/contrib/tensor_forest/python/tensor_forest_test.py
+++ b/tensorflow/contrib/tensor_forest/python/tensor_forest_test.py
@@ -125,7 +125,22 @@ class TensorForestTest(test_util.TensorFlowTestCase):
         num_trees=1,
         max_nodes=1000,
         split_after_samples=25).fill()
-    tree_weight = {'decisionTree': {'nodes': [{'binaryNode': {'rightChildId': 2, 'leftChildId': 1, 'inequalityLeftChildTest': {'featureId': {'id': '0'}, 'threshold': {'floatValue': 0}}}}, {'leaf': {'vector': {'value': [{'floatValue': 0.0}, {'floatValue': 1.0}]}}, 'nodeId': 1}, {'leaf': {'vector': {'value': [{'floatValue': 0.0}, {'floatValue': 1.0}]}}, 'nodeId': 2}]}}
+    tree_weight = {'decisionTree':
+                    {'nodes':
+                        [{'binaryNode':
+                            {'rightChildId': 2,
+                             'leftChildId': 1,
+                             'inequalityLeftChildTest':
+                             {'featureId': {'id': '0'},
+                             'threshold': {'floatValue': 0}}}},
+                         {'leaf': {'vector':
+                            {'value': [{'floatValue': 0.0},
+                                       {'floatValue': 1.0}]}},
+                            'nodeId': 1},
+                        {'leaf': {'vector':
+                            {'value': [{'floatValue': 0.0},
+                                       {'floatValue': 1.0}]}},
+                            'nodeId': 2}]}}
     restored_tree_param = ParseDict(tree_weight, _tree_proto.Model()).SerializeToString()
     graph_builder = tensor_forest.RandomForestGraphs(hparams, [restored_tree_param])
     probs, paths, var = graph_builder.inference_graph(input_data)


### PR DESCRIPTION
Right now both tree variables and forest variables only support training.

This pr makes it possible for supporting  restore a tensor forest model from a serialized string