### PR TITLE
Use relative and correct paths to get flatc and schema file.

### DIFF
--- a/tensorflow/contrib/lite/tools/visualize.py
+++ b/tensorflow/contrib/lite/tools/visualize.py
@@ -29,10 +29,10 @@ import os
 import sys
 
 # Schema to use for flatbuffers
-_SCHEMA = "third_party/tensorflow/contrib/lite/schema/schema.fbs"
+_SCHEMA = os.path.abspath(os.path.dirname(__file__) + "/../schema/schema.fbs")
 
 # Where the binary will be once built in for the flatc converter
-_BINARY = "third_party/flatbuffers/flatc"
+_BINARY = os.path.abspath(os.path.dirname(__file__) + "/../../../../third_party/flatbuffers/flatc")
 
 # A CSS description for making the visualizer
 _CSS = """


### PR DESCRIPTION
Current visualize.py file uses wrong path for schema file.  In addition, it assume current directory is the top directory of tensorflow, which is inflexible.

This patch uses paths relative to the script itself, which makes it possible to invoke the script from anywhere in the file system.