### PR TITLE
make the TfLiteCameraDemo.apk built with bazel work again

### DIFF
--- a/tensorflow/contrib/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/ImageClassifierQuantizedMobileNet.java
+++ b/tensorflow/contrib/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/ImageClassifierQuantizedMobileNet.java
@@ -49,7 +49,8 @@ public class ImageClassifierQuantizedMobileNet extends ImageClassifier {
 
   @Override
   protected String getLabelPath() {
-    return "labels_mobilenet_quant_v1_224.txt";
+    // current bazel build rule needs "labels.txt"
+    return "labels.txt";
   }
 
   @Override


### PR DESCRIPTION
Current bazel build rule needs "labels.txt". Build with current head, you get "Uninitialized Classifier or invalid context" as shown in the figure below. ![failed](https://user-images.githubusercontent.com/3395998/36347403-69fb75cc-1491-11e8-81df-822c27e162f9.png)
