### PR TITLE
TFTS: Enhancements to timeseries head

### DIFF
--- a/tensorflow/contrib/timeseries/python/timeseries/BUILD
+++ b/tensorflow/contrib/timeseries/python/timeseries/BUILD
@@ -146,7 +146,7 @@ py_library(
         "//tensorflow/python/estimator:estimator_py",
         "//tensorflow/python/estimator:export",
         "//tensorflow/python/estimator:head",
-        "//tensorflow/python/estimator:metric_keys"
+        "//tensorflow/python/estimator:metric_keys",
     ],
 )
 

--- a/tensorflow/contrib/timeseries/python/timeseries/BUILD
+++ b/tensorflow/contrib/timeseries/python/timeseries/BUILD
@@ -140,6 +140,7 @@ py_library(
         "//tensorflow/python:framework_ops",
         "//tensorflow/python:math_ops",
         "//tensorflow/python:state_ops",
+        "//tensorflow/python:summary",
         "//tensorflow/python:util",
         "//tensorflow/python:variable_scope",
         "//tensorflow/python/estimator:estimator_py",

--- a/tensorflow/contrib/timeseries/python/timeseries/BUILD
+++ b/tensorflow/contrib/timeseries/python/timeseries/BUILD
@@ -145,6 +145,7 @@ py_library(
         "//tensorflow/python/estimator:estimator_py",
         "//tensorflow/python/estimator:export",
         "//tensorflow/python/estimator:head",
+        "//tensorflow/python/estimator:metric_keys"
     ],
 )
 

--- a/tensorflow/contrib/timeseries/python/timeseries/head.py
+++ b/tensorflow/contrib/timeseries/python/timeseries/head.py
@@ -36,6 +36,7 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import state_ops
 from tensorflow.python.ops import variable_scope
 from tensorflow.python.util import nest
+from tensorflow.python.summary import summary
 
 
 def time_series_regression_head(model,
@@ -84,7 +85,7 @@ class _TimeSeriesRegressionHead(head_lib._Head):  # pylint:disable=protected-acc
       model_outputs = self.state_manager.define_loss(
           self.model, features, mode)
       summary.scalar(
-        head_lib._summary_key(self._name, metric_keys.LOSS),
+        head_lib._summary_key(self._name, metric_keys.MetricKeys.LOSS),
         model_outputs.loss)
     return model_outputs
 

--- a/tensorflow/contrib/timeseries/python/timeseries/head.py
+++ b/tensorflow/contrib/timeseries/python/timeseries/head.py
@@ -144,7 +144,8 @@ class _TimeSeriesRegressionHead(head_lib._Head):  # pylint:disable=protected-acc
     with variable_scope.variable_scope("model"):
       prediction_outputs = self.model.predict(features=features)
     with variable_scope.variable_scope("model", reuse=True):
-      filtering_outputs = self.create_loss(features, estimator_lib.ModeKeys.EVAL)
+      filtering_outputs = self.create_loss(
+          features, estimator_lib.ModeKeys.EVAL)
     return estimator_lib.EstimatorSpec(
         mode=estimator_lib.ModeKeys.PREDICT,
         export_outputs={

--- a/tensorflow/contrib/timeseries/python/timeseries/head.py
+++ b/tensorflow/contrib/timeseries/python/timeseries/head.py
@@ -26,6 +26,7 @@ from tensorflow.contrib.timeseries.python.timeseries import feature_keys
 
 from tensorflow.python.estimator import estimator_lib
 from tensorflow.python.estimator.canned import head as head_lib
+from tensorflow.python.estimator.canned import metric_keys
 from tensorflow.python.estimator.export import export_lib
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -75,11 +76,16 @@ class _TimeSeriesRegressionHead(head_lib._Head):  # pylint:disable=protected-acc
   def name(self):
     return self._name
 
+  # TODO(terrytangyuan): consolidate model_outputs and _Head.LossSpec once _Head.create_loss
+  # becomes extendable
   def create_loss(self, features, mode, logits=None, labels=None):
     """See `_Head`."""
     with variable_scope.variable_scope("model", reuse=variable_scope.AUTO_REUSE):
       model_outputs = self.state_manager.define_loss(
           self.model, features, mode)
+      summary.scalar(
+        head_lib._summary_key(self._name, metric_keys.LOSS),
+        model_outputs.loss)
     return model_outputs
 
   @property

--- a/tensorflow/contrib/timeseries/python/timeseries/head.py
+++ b/tensorflow/contrib/timeseries/python/timeseries/head.py
@@ -77,16 +77,17 @@ class _TimeSeriesRegressionHead(head_lib._Head):  # pylint:disable=protected-acc
   def name(self):
     return self._name
 
-  # TODO(terrytangyuan): consolidate model_outputs and _Head.LossSpec once _Head.create_loss
-  # becomes extendable
+  # TODO(terrytangyuan): consolidate `model_outputs` and `_Head.LossSpec`
+  # once `_Head.create_loss` becomes extendable
   def create_loss(self, features, mode, logits=None, labels=None):
     """See `_Head`."""
-    with variable_scope.variable_scope("model", reuse=variable_scope.AUTO_REUSE):
+    with variable_scope.variable_scope(
+        "model", reuse=variable_scope.AUTO_REUSE):
       model_outputs = self.state_manager.define_loss(
           self.model, features, mode)
       summary.scalar(
-        head_lib._summary_key(self._name, metric_keys.MetricKeys.LOSS),
-        model_outputs.loss)
+          head_lib._summary_key(self._name, metric_keys.MetricKeys.LOSS),
+          model_outputs.loss)
     return model_outputs
 
   @property


### PR DESCRIPTION
* Moved loss creation to `create_loss` that satisfies `_Head`
* Added namescope using `self._name`
* Added loss summary identifiable reusing `head_lib._summary_key`
* Made `logits_dimension` always be 1 (not used anyways) just to satisfy `_Head`