### PR TITLE
Update find_cuda_define to handle tabs.

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -368,9 +368,10 @@ def find_cuda_define(repository_ctx, header_dir, header_file, define):
     auto_configure_fail("Cannot find line containing '%s' in %s" %
                         (define, h_path))
   version = result.stdout
-  # Remove the new line and '\' character if any.
+  # Remove the new line, tab, and '\' character if any.
   version = version.replace("\\", " ")
   version = version.replace("\n", " ")
+  version = version.replace("\t", " ")
   version = version.replace(define, "").lstrip()
   # Remove the code after the version number.
   version_end = version.find(" ")


### PR DESCRIPTION
The 4.0.4 release of NvInfer.h  uses tabs between the version number and the comments, this causes find_cuda_define to fail.