### PR TITLE
Make configure script runnable from external workspace.

### DIFF
--- a/configure
+++ b/configure
@@ -8,7 +8,8 @@ if [ -z "$PYTHON_BIN_PATH" ]; then
 fi
 
 # Set all env variables
-"$PYTHON_BIN_PATH" configure.py
+CONFIGURE_DIR=$(dirname "$0")
+"$PYTHON_BIN_PATH" "${CONFIGURE_DIR}/configure.py" "$@"
 
 echo "Configuration finished"
 


### PR DESCRIPTION
To run from external workspace, you should now be able to invoke
script like the following. This will generate some TensorFlow specfic
bazel options and import them into your project's .bazelrc.

$(bazel info output_base)/external/org_tensorflow/configure.py --workspace=$(PWD)