### PR TITLE
TF Lite: from six.moves import xrange for Python 3

### DIFF
--- a/tensorflow/contrib/lite/testing/generate_examples.py
+++ b/tensorflow/contrib/lite/testing/generate_examples.py
@@ -36,6 +36,7 @@ import traceback
 import zipfile
 import numpy as np
 from six import StringIO
+from six.moves import xrange
 
 # TODO(aselle): Disable GPU for now
 os.environ["CUDA_VISIBLE_DEVICES"] = "-1"


### PR DESCRIPTION
Lines 1785 and 1818 contain calls to the Python 2-only builtin function __xrange()__ which was removed in Python 3 in favor of __range()__.  This PR adds the line [__from six.moves import xrange__](http://six.readthedocs.io/#module-six.moves) for compatibility with both Python 2 and Python 3.