### PR TITLE
r1.5 cherry-pick request: Fixes issue when linking of rule '//tensorflow/contrib/lite/toco:toco…

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1320,6 +1320,8 @@ def main():
     set_tf_cuda_version(environ_cp)
     set_tf_cudnn_version(environ_cp)
     set_tf_cuda_compute_capabilities(environ_cp)
+    if 'LD_LIBRARY_PATH' in environ_cp and environ_cp.get('LD_LIBRARY_PATH') != '1':
+      write_action_env_to_bazelrc('LD_LIBRARY_PATH', environ_cp.get('LD_LIBRARY_PATH'))
 
     set_tf_cuda_clang(environ_cp)
     if environ_cp.get('TF_CUDA_CLANG') == '1':


### PR DESCRIPTION
…… (#16838)

* Fixes issue when linking of rule '//tensorflow/contrib/lite/toco:toco' fails because LD_LIBRARY_PATH is not configured

* Check if LD_LIBRARY_PATH is in environ_cp