### PR TITLE
Ship TF Eager header with libtensorflow tarballs.

### DIFF
--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -25,9 +25,9 @@ pkg_tar(
     tags = ["manual"],
     deps = [
         ":cheaders",
-        ":eager_cheaders",
         ":clib",
         ":clicenses",
+        ":eager_cheaders",
     ],
 )
 

--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -25,6 +25,7 @@ pkg_tar(
     tags = ["manual"],
     deps = [
         ":cheaders",
+        ":eager_cheaders",
         ":clib",
         ":clicenses",
     ],
@@ -57,9 +58,22 @@ pkg_tar(
     name = "cheaders",
     files = [
         "//tensorflow/c:headers",
-        "//tensorflow/c/eager:headers",
     ],
     package_dir = "include/tensorflow/c",
+    # Mark as "manual" till
+    # https://github.com/bazelbuild/bazel/issues/2352
+    # and https://github.com/bazelbuild/bazel/issues/1580
+    # are resolved, otherwise these rules break when built
+    # with Python 3.
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "eager_cheaders",
+    files = [
+        "//tensorflow/c/eager:headers",
+    ],
+    package_dir = "include/tensorflow/c/eager",
     # Mark as "manual" till
     # https://github.com/bazelbuild/bazel/issues/2352
     # and https://github.com/bazelbuild/bazel/issues/1580


### PR DESCRIPTION
The TF Eager headers are getting excluded from nightly tarballs because they both have the same filename and output destination. Looks like the core TF c header wins. This PR introduces shipping the eager header in the correct location.

Take a look at one of the hosted tarballs here: http://ci.tensorflow.org/view/Nightly/job/nightly-libtensorflow/TYPE=cpu-slave/