### PR TITLE
Support GCS URL by tf.estimator.LatestExporter

### DIFF
--- a/tensorflow/python/estimator/exporter_test.py
+++ b/tensorflow/python/estimator/exporter_test.py
@@ -136,6 +136,43 @@ class LatestExporterTest(test.TestCase):
     self.assertTrue(gfile.Exists(export_dir_3))
     self.assertTrue(gfile.Exists(export_dir_4))
 
+  def test_garbage_collect_exports_with_trailing_delimiter(self):
+    export_dir_base = tempfile.mkdtemp() + "export/"
+    gfile.MkDir(export_dir_base)
+    export_dir_1 = _create_test_export_dir(export_dir_base)
+    export_dir_2 = _create_test_export_dir(export_dir_base)
+    export_dir_3 = _create_test_export_dir(export_dir_base)
+    export_dir_4 = _create_test_export_dir(export_dir_base)
+
+    self.assertTrue(gfile.Exists(export_dir_1))
+    self.assertTrue(gfile.Exists(export_dir_2))
+    self.assertTrue(gfile.Exists(export_dir_3))
+    self.assertTrue(gfile.Exists(export_dir_4))
+
+    def _serving_input_receiver_fn():
+      return array_ops.constant([1]), None
+
+    exporter = exporter_lib.LatestExporter(
+        name="latest_exporter",
+        serving_input_receiver_fn=_serving_input_receiver_fn,
+        exports_to_keep=1)
+    estimator = test.mock.Mock(spec=estimator_lib.Estimator)
+    # Garbage collect all but the most recent 2 exports,
+    # where recency is determined based on the timestamp directory names.
+    with test.mock.patch.object(gfile, "ListDirectory") as mock_list_directory:
+      mock_list_directory.return_value = [
+          os.path.basename(export_dir_1) + "/",
+          os.path.basename(export_dir_2) + "/",
+          os.path.basename(export_dir_3) + "/",
+          os.path.basename(export_dir_4) + "/",
+          ]
+      exporter.export(estimator, export_dir_base, None, None, False)
+
+    self.assertFalse(gfile.Exists(export_dir_1))
+    self.assertFalse(gfile.Exists(export_dir_2))
+    self.assertFalse(gfile.Exists(export_dir_3))
+    self.assertTrue(gfile.Exists(export_dir_4))
+
 
 def _create_test_export_dir(export_dir_base):
   export_dir = _get_timestamped_export_dir(export_dir_base)

--- a/tensorflow/python/estimator/gc.py
+++ b/tensorflow/python/estimator/gc.py
@@ -201,6 +201,9 @@ def _get_paths(base_dir, parser):
   raw_paths = gfile.ListDirectory(base_dir)
   paths = []
   for r in raw_paths:
+    # ListDirectory() return paths with "/" at the last if base_dir was GCS URL
+    if r[-1] == "/":
+        r = r[0:len(r)-1]
     p = parser(Path(os.path.join(compat.as_str_any(base_dir),
                                  compat.as_str_any(r)),
                     None))

--- a/tensorflow/python/estimator/gc.py
+++ b/tensorflow/python/estimator/gc.py
@@ -203,7 +203,7 @@ def _get_paths(base_dir, parser):
   for r in raw_paths:
     # ListDirectory() return paths with "/" at the last if base_dir was GCS URL
     if r[-1] == "/":
-        r = r[0:len(r)-1]
+      r = r[0:len(r)-1]
     p = parser(Path(os.path.join(compat.as_str_any(base_dir),
                                  compat.as_str_any(r)),
                     None))

--- a/tensorflow/python/estimator/gc_test.py
+++ b/tensorflow/python/estimator/gc_test.py
@@ -140,6 +140,17 @@ class GcTest(test_util.TensorFlowTestCase):
       gfile.MakeDirs(os.path.join(compat.as_str_any(base_dir), "42"))
       gc._get_paths(base_dir, _create_parser(base_dir))
 
+  def testGcsDirWithSeparator(self):
+    base_dir = "gs://bucket/foo"
+    with test.mock.patch.object(gfile, "ListDirectory") as mockListDirectory:
+      # gfile.ListDirectory returns directory names with separator '/'
+      mockListDirectory.return_value = ["0/", "1/"]
+      self.assertEqual(
+          gc._get_paths(base_dir, _create_parser(base_dir)),
+          [
+              gc.Path(os.path.join(base_dir, "0"), 0),
+              gc.Path(os.path.join(base_dir, "1"), 1)
+          ])
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
I have found that the parameter `exports_to_keep` of `tf.estimator.LatestExporter()` is ignored if export_path is GCS URL (like `gs://bucket/object/`). All exported SavedModel directories are never removed.

The root cause is that the `tf.gfile.ListDirectory` returns basenames with file separator '/' at the end if the path was GCS URL.  The `_export_version_parser` function rejects a path with trailing '/'.

I don't think the behavior of `tf.gfile.ListDirectory` is wrong because the semantics of "path" in GCS is different from usual filesystems. For example, you can place two different objects in the GCS bucket like `gs://bucket/obj` and `gs://bucket/obj/`. So I think `tf.gfile.ListDirectory` should return basename with '/'.

I try to fix the issue by eliminating trailing separator at `tf.estimator.gc._getpaths()`.