### PR TITLE
Change repository command to valid value

### DIFF
--- a/tensorflow/docs_src/install/install_mac.md
+++ b/tensorflow/docs_src/install/install_mac.md
@@ -279,7 +279,7 @@ The remainder of this section explains how to launch a Docker container.
 To launch a Docker container that holds the TensorFlow binary image,
 enter a command of the following format:
 
-<pre> $ <b>docker run -it <i>-p hostPort:containerPort</i> TensorFlowImage</b> </pre>
+<pre> $ <b>docker run -it <i>-p hostPort:containerPort</i> gcr.io/tensorflow/tensorflow</b> </pre>
 
 where:
 


### PR DESCRIPTION
When running the example command I got an error from docker saying: `docker: invalid reference format: repository name must be lowercase.` 

It seems that the repository name is written with capital letters. This confused me and might confuse others. By replacing `TensorFlowImage` with a valid repository the first command can also be run.