### PR TITLE
Disambiguate documentation in `multi_class_labels` of `losses.sigmoid_cross_entropy`

### DIFF
--- a/tensorflow/python/ops/losses/losses_impl.py
+++ b/tensorflow/python/ops/losses/losses_impl.py
@@ -654,7 +654,7 @@ def sigmoid_cross_entropy(
 
   Args:
     multi_class_labels: `[batch_size, num_classes]` target integer labels in
-      `(0, 1)`.
+      `{0, 1}`.
     logits: Float `[batch_size, num_classes]` logits outputs of the network.
     weights: Optional `Tensor` whose rank is either 0, or the same rank as
       `labels`, and must be broadcastable to `labels` (i.e., all dimensions must


### PR DESCRIPTION
from continuous (0, 1) to categorical set {0, 1} according to @drpngx 
in https://github.com/tensorflow/tensorflow/issues/17021