### PR TITLE
Add index to plugin_name of Tags table

### DIFF
--- a/tensorflow/contrib/tensorboard/db/schema.cc
+++ b/tensorflow/contrib/tensorboard/db/schema.cc
@@ -193,6 +193,12 @@ Status SetupTensorboardSqliteDb(Sqlite* db) {
       AND tag_name IS NOT NULL
   )sql"));
 
+  s.Update(Run(db, R"sql(
+    CREATE UNIQUE INDEX IF NOT EXISTS PluginNameIndex
+    ON Tags (plugin_name)
+    WHERE plugin_name IS NOT NULL
+  )sql"));
+
   // Runs are groups of Tags.
   //
   // Each Run usually represents a single attempt at training or testing


### PR DESCRIPTION
Added index to plugin_name of Tags table in TensorBoard DB schema to potentially help query performance (e.g.,  `SELECT 1 FROM Tags WHERE Tags.plugin_name = ?`) in histograms_plugin.