### PR TITLE
Switch to v2 version of tf.unique to enable axis support

### DIFF
--- a/tensorflow/python/kernel_tests/unique_op_test.py
+++ b/tensorflow/python/kernel_tests/unique_op_test.py
@@ -66,9 +66,9 @@ class UniqueTest(test.TestCase):
     for dtype in [np.int32, np.int64]:
       x = np.array([[1, 0, 0], [1, 0, 0], [2, 0, 0]])
       with self.test_session() as sess:
-        y0, idx0 = gen_array_ops.unique_v2(x, axis=np.array([0], dtype))
+        y0, idx0 = array_ops.unique(x, axis=dtype(0))
         tf_y0, tf_idx0 = sess.run([y0, idx0])
-        y1, idx1 = gen_array_ops.unique_v2(x, axis=np.array([1], dtype))
+        y1, idx1 = array_ops.unique(x, axis=dtype(1))
         tf_y1, tf_idx1 = sess.run([y1, idx1])
       self.assertAllEqual(tf_y0, np.array([[1, 0, 0], [2, 0, 0]]))
       self.assertAllEqual(tf_idx0, np.array([0, 0, 1]))
@@ -76,8 +76,7 @@ class UniqueTest(test.TestCase):
       self.assertAllEqual(tf_idx1, np.array([0, 1, 1]))
 
   def testInt32V2(self):
-    # This test is only temporary, once V2 is used
-    # by default, the axis will be wrapped to allow `axis=None`.
+    # This test invokes unique_v2 with axis=None
     x = np.random.randint(2, high=10, size=7000)
     with self.test_session() as sess:
       y, idx = gen_array_ops.unique_v2(x, axis=np.array([], np.int32))

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1237,15 +1237,15 @@ def sparse_mask(a, mask_indices, name=None):
 
 
 @tf_export("unique")
-def unique(x, out_idx=dtypes.int32, name=None):
-  # TODO(yongtang): switch to v2 once API deprecation
-  # period (3 weeks) pass.
-  # TODO(yongtang): The documentation should also
-  # be updated when switch  to v2.
-  return gen_array_ops.unique(x, out_idx, name)
+def unique(x, out_idx=dtypes.int32, name=None, axis=None):
+  if axis is None:
+    axis = []
+  else:
+    axis = [axis]
+  return gen_array_ops.unique_v2(x, axis, out_idx, name)
 
 
-unique.__doc__ = gen_array_ops.unique.__doc__
+unique.__doc__ = gen_array_ops.unique_v2.__doc__
 
 
 @tf_export("unique_with_counts")

--- a/tensorflow/tools/api/golden/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.pbtxt
@@ -2098,7 +2098,7 @@ tf_module {
   }
   member_method {
     name: "unique"
-    argspec: "args=[\'x\', \'out_idx\', \'name\'], varargs=None, keywords=None, defaults=[\"<dtype: \'int32\'>\", \'None\'], "
+    argspec: "args=[\'x\', \'out_idx\', \'name\', \'axis\'], varargs=None, keywords=None, defaults=[\"<dtype: \'int32\'>\", \'None\', \'None\'], "
   }
   member_method {
     name: "unique_with_counts"


### PR DESCRIPTION
This fix is a follow up to #15654 to switch to unique_v2 for tf.unique so that axis support could be enabled.

This follows the compatibility workflow as PR 15654 has been merged 3+ weeks ago.

This fix is part of the effort for #15644.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>