### PR TITLE
Include cstring in logging.cc for use of strrchr()

### DIFF
--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <android/log.h>
 #include <iostream>
 #include <sstream>
+#include <cstring>
 #endif
 
 #include <stdlib.h>


### PR DESCRIPTION
I'm working on Bazel's NDK support for r15 and r16. While building `//tensorflow/examples/android:tensorflow_demo` at v1.5.0 and v1.6.0rc1 with NDK r16, I ran into the following error:

```
/usr/local/google/home/jingwen/code/tensorflow/tensorflow/core/BUILD:1019:1: C++ compilation of rule '//tensorflow/core:android_tensorflow_lib_lite' failed (Exit 1)
tensorflow/core/platform/default/logging.cc:61:36: error: use of undeclared identifier 'strrchr'
  const char* const partial_name = strrchr(fname_, '/');
                                   ^
1 error generated.
```

I added an include for `<cstring>` and that fixed the build. Please let me know if this is incorrect or if there's a better way to do this.