### PR TITLE
Fix batch input in TFLite multithreaded 1x1 conv

### DIFF
--- a/tensorflow/contrib/lite/kernels/internal/optimized/multithreaded_conv.h
+++ b/tensorflow/contrib/lite/kernels/internal/optimized/multithreaded_conv.h
@@ -126,7 +126,7 @@ class EigenTensorConvFunctor {
     if (is_1x1_kernel) {
       // For 1x1 kernel, the 2D convolution is reduced to matrix
       // multiplication.
-      const int conv_width = output_height * output_width;
+      const int conv_width = output_height * output_width * input_batches;
       Eigen::array<Eigen::IndexPair<Eigen::DenseIndex>, 1> dim_pair;
       dim_pair[0] = Eigen::IndexPair<Eigen::DenseIndex>(1, 0);
       EigenMatrix output(output_data, conv_width, filter_count);
@@ -142,8 +142,8 @@ class EigenTensorConvFunctor {
           filter_width * filter_height * input_depth;
       Eigen::array<Eigen::IndexPair<Eigen::DenseIndex>, 1> dim_pair;
       dim_pair[0] = Eigen::IndexPair<Eigen::DenseIndex>(1, 0);
-      EigenMatrix output(output_data, 1, filter_count);
-      ConstEigenMatrix input(input_data, 1, k);
+      EigenMatrix output(output_data, input_batches, filter_count);
+      ConstEigenMatrix input(input_data, input_batches, k);
       ConstEigenMatrix filter(filter_data, k, filter_count);
       MatMulConvFunctor<Eigen::ThreadPoolDevice, T>()(device, output, input,
                                                       filter, dim_pair);


### PR DESCRIPTION
Fix the issue that batch size is hard-coded as 1 in TFLite
multithreaded_ops::Conv() when filter size is 1x1 or filter and
input have the same size.