### PR TITLE
add support for other cpu type(aarch64)  for tensorRT

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -40,7 +40,7 @@ _DEFAULT_CUDA_PATH = '/usr/local/cuda'
 _DEFAULT_CUDA_PATH_LINUX = '/opt/cuda'
 _DEFAULT_CUDA_PATH_WIN = ('C:/Program Files/NVIDIA GPU Computing '
                           'Toolkit/CUDA/v%s' % _DEFAULT_CUDA_VERSION)
-_DEFAULT_TENSORRT_PATH_LINUX = '/usr/lib/x86_64-linux-gnu'
+_DEFAULT_TENSORRT_PATH_LINUX = '/usr/lib/%s-linux-gnu' % platform.machine()
 _TF_OPENCL_VERSION = '1.2'
 _DEFAULT_COMPUTECPP_TOOLKIT_PATH = '/usr/local/computecpp'
 _DEFAULT_TRISYCL_INCLUDE_DIR = '/usr/local/triSYCL/include'


### PR DESCRIPTION
add support for other cpu for tensorRT

In Linux 64bit is /usr/lib/x86_64-linux-gnu
In Nvidia Jetson is 'aarch64.' /usr/lib/aarch64-linux-gnu