### PR TITLE
TensorRT support for ARM architectures

### DIFF
--- a/third_party/tensorrt/tensorrt_configure.bzl
+++ b/third_party/tensorrt/tensorrt_configure.bzl
@@ -57,6 +57,10 @@ def _find_trt_header_dir(repository_ctx, trt_install_path):
     path = "/usr/include/x86_64-linux-gnu"
     if _headers_exist(repository_ctx, path):
       return path
+  if trt_install_path == "/usr/lib/aarch64-linux-gnu":
+    path = "/usr/include/aarch64-linux-gnu"
+    if _headers_exist(repository_ctx, path):
+      return path
   path = str(repository_ctx.path("%s/../include" % trt_install_path).realpath)
   if _headers_exist(repository_ctx, path):
     return path


### PR DESCRIPTION
i.e. without this modification Tensorflow under Nvidia Jetpack 3.2 is not compiling. Else condition in if-then-else block generates a path "%s/../include" which results in "/usr/lib/include" but it must be "/usr/include/aarch64-linux-gnu"... So this fix targets ARM architectures and with this fix, Tensorflow 1.6rc compiles fine with TensorRT support.