### PR TITLE
Docker Jupyter: Update deprecated softmax_cross_entropy_with_logits

### DIFF
--- a/tensorflow/tools/docker/notebooks/3_mnist_from_scratch.ipynb
+++ b/tensorflow/tools/docker/notebooks/3_mnist_from_scratch.ipynb
@@ -33,7 +33,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "id": "sbUKaF8_uDI_",
     "outputId": "67a51332-3aea-4c29-8c3d-4752db08ccb3"
    },
@@ -98,7 +97,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 110,
      "status": "ok",
@@ -205,7 +203,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 57,
      "status": "ok",
@@ -290,7 +287,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 887,
      "status": "ok",
@@ -368,7 +364,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 531,
      "status": "ok",
@@ -456,7 +451,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 90,
      "status": "ok",
@@ -533,7 +527,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 734,
      "status": "ok",
@@ -621,7 +614,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 400,
      "status": "ok",
@@ -710,7 +702,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 191,
      "status": "ok",
@@ -789,7 +780,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 127,
      "status": "ok",
@@ -861,7 +851,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 176,
      "status": "ok",
@@ -948,7 +937,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 2081,
      "status": "ok",
@@ -1061,7 +1049,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 772,
      "status": "ok",
@@ -1175,7 +1162,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 269,
      "status": "ok",
@@ -1207,7 +1193,7 @@
    "source": [
     "# Training computation: logits + cross-entropy loss.\n",
     "logits = model(train_data_node, True)\n",
-    "loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(\n",
+    "loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(\n",
     "  labels=train_labels_node, logits=logits))\n",
     "\n",
     "# L2 regularization for the fully connected parameters.\n",
@@ -1325,7 +1311,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 386,
      "status": "ok",
@@ -1405,7 +1390,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 160,
      "status": "ok",
@@ -1471,7 +1455,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 220,
      "status": "ok",
@@ -1545,7 +1528,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 232,
      "status": "ok",
@@ -1613,7 +1595,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 330,
      "status": "ok",
@@ -1700,7 +1681,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 178,
      "status": "ok",
@@ -1777,7 +1757,6 @@
      }
     },
     "colab_type": "code",
-    "collapsed": false,
     "id": "4cgKJrS1_vej"
    },
    "outputs": [
@@ -1881,7 +1860,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 436,
      "status": "ok",
@@ -1971,7 +1949,6 @@
      ]
     },
     "colab_type": "code",
-    "collapsed": false,
     "executionInfo": {
      "elapsed": 352,
      "status": "ok",
@@ -2031,7 +2008,7 @@
    "views": {}
   },
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -2049,5 +2026,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/tensorflow/tools/docker/notebooks/3_mnist_from_scratch.ipynb
+++ b/tensorflow/tools/docker/notebooks/3_mnist_from_scratch.ipynb
@@ -33,6 +33,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "id": "sbUKaF8_uDI_",
     "outputId": "67a51332-3aea-4c29-8c3d-4752db08ccb3"
    },
@@ -97,6 +98,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 110,
      "status": "ok",
@@ -203,6 +205,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 57,
      "status": "ok",
@@ -287,6 +290,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 887,
      "status": "ok",
@@ -364,6 +368,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 531,
      "status": "ok",
@@ -451,6 +456,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 90,
      "status": "ok",
@@ -527,6 +533,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 734,
      "status": "ok",
@@ -614,6 +621,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 400,
      "status": "ok",
@@ -702,6 +710,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 191,
      "status": "ok",
@@ -780,6 +789,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 127,
      "status": "ok",
@@ -851,6 +861,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 176,
      "status": "ok",
@@ -937,6 +948,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 2081,
      "status": "ok",
@@ -1049,6 +1061,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 772,
      "status": "ok",
@@ -1162,6 +1175,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 269,
      "status": "ok",
@@ -1311,6 +1325,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 386,
      "status": "ok",
@@ -1390,6 +1405,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 160,
      "status": "ok",
@@ -1455,6 +1471,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 220,
      "status": "ok",
@@ -1528,6 +1545,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 232,
      "status": "ok",
@@ -1595,6 +1613,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 330,
      "status": "ok",
@@ -1681,6 +1700,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 178,
      "status": "ok",
@@ -1757,6 +1777,7 @@
      }
     },
     "colab_type": "code",
+    "collapsed": false,
     "id": "4cgKJrS1_vej"
    },
    "outputs": [
@@ -1860,6 +1881,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 436,
      "status": "ok",
@@ -1949,6 +1971,7 @@
      ]
     },
     "colab_type": "code",
+    "collapsed": false,
     "executionInfo": {
      "elapsed": 352,
      "status": "ok",


### PR DESCRIPTION
The current Jupyter Notebook included in the Docker image `3_mnist_from_scratch.ipynb` uses the deprecated [`tf.nn.softmax_cross_entropy_with_logits`](https://www.tensorflow.org/api_docs/python/tf/nn/softmax_cross_entropy_with_logits).

This PR updates that Jupyter Notebook to use the new [`tf.nn.softmax_cross_entropy_with_logits_v2`](https://www.tensorflow.org/api_docs/python/tf/nn/softmax_cross_entropy_with_logits_v2).

---

I ran it to make sure everything works, but I didn't commit the changes in the cells because the image style looks a bit different, and that would create changes in the diff of the images in the Notebook. This way it should be easier for you to see the exact change.

If you want me to, I can run the cells and commit the new output (with changes in image style and size, but same content).