### PR TITLE
Add missing `#define OMPI_SKIP_MPICXX` 

### DIFF
--- a/tensorflow/contrib/mpi/mpi_utils.h
+++ b/tensorflow/contrib/mpi/mpi_utils.h
@@ -24,6 +24,8 @@ limitations under the License.
 
 #include "tensorflow/core/lib/strings/str_util.h"
 
+// Skip MPI C++ bindings support, this matches the usage in other places
+#define OMPI_SKIP_MPICXX
 #include "third_party/mpi/mpi.h"
 #define MPI_CHECK(cmd)                                                \
   do {                                                                \


### PR DESCRIPTION
This fix adds the missing `#define OMPI_SKIP_MPICXX` in `tensorflow/contrib/mpi/mpi_utils.h` so that it is consistent with other usages of `mpi.h` includes. `OMPI_SKIP_MPICXX` skip the MPI C++ bindings support.

This fix fixes #17388 and #17504.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>