### PR TITLE
Fix cmake Dockerfile issue on Linux

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.cmake
+++ b/tensorflow/tools/ci_build/Dockerfile.cmake
@@ -23,6 +23,7 @@ RUN /install/install_deb_packages.sh
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends python-pip
+RUN pip install --upgrade wheel
 RUN pip install --upgrade astor
 RUN pip install --upgrade gast
 RUN pip install --upgrade numpy

--- a/tensorflow/tools/ci_build/Dockerfile.cmake
+++ b/tensorflow/tools/ci_build/Dockerfile.cmake
@@ -30,5 +30,5 @@ RUN pip install --upgrade numpy
 RUN pip install --upgrade termcolor
 
 # Install golang
-RUN add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
-RUN apt-get install -y golang
+RUN apt-get install -t xenial-backports -y golang-1.9
+ENV PATH=${PATH}:/usr/lib/go-1.9/bin


### PR DESCRIPTION
When running cmake on Linux with (clean build with no cached docker images):
```
tensorflow/tools/ci_build/ci_build.sh CMAKE tensorflow/tools/ci_build/builds/cmake.sh
```

The following two issues were encountered:
```
Step 13/14 : RUN add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
 ---> Running in 09301ba43a33
Cannot add PPA: 'ppa:~ubuntu-lxc/ubuntu/lxd-stable'.
The team named '~ubuntu-lxc' has no PPA named 'ubuntu/lxd-stable'
Please choose from the following available PPAs:
 * 'buildd-backports':  linuxcontainers.org: buildd backports
 * 'daily':  linuxcontainers.org: development builds
 ......
 ......
```

The issue is that `ppa:ubuntu-lxc/lxd-stable` was used but it has been deprecated, see:
http://lxc-users.linuxcontainers.narkive.com/IlHLLHqN/lxd-official-ppa-deprecation

Another issue is the missing wheel install:
```
Step 11/13 : RUN pip install --upgrade termcolor
 ---> Running in 838167596eb6
Collecting termcolor
  Downloading termcolor-1.1.0.tar.gz
  ......
  ......
  ......
  error: invalid command 'bdist_wheel'

  ----------------------------------------
  Failed building wheel for termcolor
```
This fix updates the golang installation and use backported xenial (16.04), as was suggested in the link:
http://lxc-users.linuxcontainers.narkive.com/IlHLLHqN/lxd-official-ppa-deprecation

This fix also adds the missing `pip install wheel`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>