### PR TITLE
the correct argument is "--output_image"

### DIFF
--- a/tensorflow/docs_src/tutorials/audio_recognition.md
+++ b/tensorflow/docs_src/tutorials/audio_recognition.md
@@ -280,7 +280,7 @@ tool:
 ```
 bazel run tensorflow/examples/wav_to_spectrogram:wav_to_spectrogram -- \
 --input_wav=/tmp/speech_dataset/happy/ab00c4b2_nohash_0.wav \
---output_png=/tmp/spectrogram.png
+--output_image=/tmp/spectrogram.png
 ```
 
 If you open up `/tmp/spectrogram.png` you should see something like this:


### PR DESCRIPTION
It looks like the correct argument name is "--output_image".  I got the following error when I ran it with "--output_png":
```
INFO: Running command line: bazel-bin/tensorflow/examples/wav_to_spectrogram/wav_to_spectrogram '--input_wav=/tmp/speech_dataset/happy/ab00c4b2_nohash_0.wav' '--output_png=/tmp/spectrogram.png'
2018-03-04 23:47:22.532841: E tensorflow/examples/wav_to_spectrogram/main.cc:54] Unknown argument --output_png=/tmp/spectrogram.png
usage: /private/var/tmp/_bazel_hakaydin/12fe9c53feea8848ab5cfab4ea3dcd47/execroot/org_tensorflow/bazel-out/darwin-py3-opt/bin/tensorflow/examples/wav_to_spectrogram/wav_to_spectrogram
Flags:
	--input_wav="tensorflow/core/kernels/spectrogram_test_data/short_test_segment.wav"	string	audio file to load
	--window_size=256                	int32	frequency sample window width
	--stride=128                     	int32	how far apart to place frequency windows
	--brightness=64.000000           	float	controls how bright the output image is
	--output_image="spectrogram.png" 	string	where to save the spectrogram image to

ERROR: Non-zero return code '255' from command: Process exited with status 255
```