### PR TITLE
Deprecation of the LXD PPAs

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.cmake
+++ b/tensorflow/tools/ci_build/Dockerfile.cmake
@@ -29,5 +29,5 @@ RUN pip install --upgrade numpy
 RUN pip install --upgrade termcolor
 
 # Install golang
-RUN add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
+RUN apt-get install -y --no-install-recommends -t xenial-backports lxd lxd-client
 RUN apt-get install -y golang


### PR DESCRIPTION
LXD PPAs are deprecated at the end of 2017 and need to use
the official backports in the Ubuntu archive.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>