### PR TITLE
Fix broken link pointing to vulnerability reporting/SECURITY.md

### DIFF
--- a/tensorflow/docs_src/community/welcome.md
+++ b/tensorflow/docs_src/community/welcome.md
@@ -65,5 +65,5 @@ please read the following list carefully:
     on GitHub.  For example, use the issue tracker to request a
     new operation in TensorFlow.
   * To report vulnerabilities, please follow our
-    [vulnerability disclosure guidelines](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/SECURITY.md).
+    [vulnerability disclosure guidelines](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md).
 


### PR DESCRIPTION
The vulnerability reporting (SECURITY.md) has been moved to top level
directory, this fix fixes the broken link inside tensorflow/docs_src/community/welcome.md

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>