### PR TITLE
einsum: allow capital letter indices

### DIFF
--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -163,7 +163,7 @@ def einsum(equation, *inputs, **kwargs):
     if '...' in equation:
       raise ValueError('Subscripts with ellipses are not yet supported.')
 
-    match = re.match('([a-z,]+)(->[a-z]*)?', equation)
+    match = re.match('([a-zA-Z,]+)(->[a-zA-Z]*)?', equation)
     if not match:
       raise ValueError('Indices have incorrect format: %s' % equation)
 

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -192,6 +192,8 @@ class EinsumTest(test.TestCase):
       'abc,cba',
       'dba,ead,cad->bce',
       'aef,fbc,dca->bde',
+      'iJ,Jk->ik',
+      'IJ,JK->IK',
   ]
 
   long_cases = [


### PR DESCRIPTION
Small tweak to allow capital letters in ``einsum``, as in ``numpy``. This is occasionally a problem when more than 26 indices are needed.