### PR TITLE
Accepts `PathLike` objects for dataset readers

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3182,6 +3182,23 @@ py_test(
 )
 
 py_test(
+    name = "compat_test",
+    size = "small",
+    srcs = ["util/compat_test.py"],
+    main = "util/compat_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":array_ops",
+        ":client_testlib",
+        ":framework",
+        ":framework_for_generated_wrappers",
+        ":math_ops",
+        ":util",
+        "//third_party/py/numpy"
+    ]
+)
+
+py_test(
     name = "future_api_test",
     size = "small",
     srcs = ["util/future_api_test.py"],

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.util import compat
 from tensorflow.python.data.util import convert
 from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import sparse
@@ -41,7 +42,7 @@ class TextLineDataset(dataset_ops.Dataset):
     """Creates a `TextLineDataset`.
 
     Args:
-      filenames: A `tf.string` tensor containing one or more filenames.
+      filenames: A `tf.string` tensor containing one or more filenames or `PathLike` objects.
       compression_type: (Optional.) A `tf.string` scalar evaluating to one of
         `""` (no compression), `"ZLIB"`, or `"GZIP"`.
       buffer_size: (Optional.) A `tf.int64` scalar denoting the number of bytes
@@ -49,6 +50,7 @@ class TextLineDataset(dataset_ops.Dataset):
         based on the compression type.
     """
     super(TextLineDataset, self).__init__()
+    filenames = compat.path_to_str(filenames)
     self._filenames = ops.convert_to_tensor(
         filenames, dtype=dtypes.string, name="filenames")
     self._compression_type = convert.optional_param_to_tensor(
@@ -83,7 +85,7 @@ class _TFRecordDataset(dataset_ops.Dataset):
     """Creates a `TFRecordDataset`.
 
     Args:
-      filenames: A `tf.string` tensor containing one or more filenames.
+      filenames: A `tf.string` tensor containing one or more filenames or `PathLike` objects.
       compression_type: (Optional.) A `tf.string` scalar evaluating to one of
         `""` (no compression), `"ZLIB"`, or `"GZIP"`.
       buffer_size: (Optional.) A `tf.int64` scalar representing the number of
@@ -91,6 +93,7 @@ class _TFRecordDataset(dataset_ops.Dataset):
     """
     super(_TFRecordDataset, self).__init__()
     # Force the type to string even if filenames is an empty list.
+    filenames = compat.path_to_str(filenames)
     self._filenames = ops.convert_to_tensor(
         filenames, dtypes.string, name="filenames")
     self._compression_type = convert.optional_param_to_tensor(
@@ -252,7 +255,7 @@ class FixedLengthRecordDataset(dataset_ops.Dataset):
     """Creates a `FixedLengthRecordDataset`.
 
     Args:
-      filenames: A `tf.string` tensor containing one or more filenames.
+      filenames: A `tf.string` tensor containing one or more filenames or `PathLike` objects.
       record_bytes: A `tf.int64` scalar representing the number of bytes in
         each record.
       header_bytes: (Optional.) A `tf.int64` scalar representing the number of
@@ -263,6 +266,7 @@ class FixedLengthRecordDataset(dataset_ops.Dataset):
         bytes to buffer when reading.
     """
     super(FixedLengthRecordDataset, self).__init__()
+    filenames = compat.path_to_str(filenames)
     self._filenames = ops.convert_to_tensor(
         filenames, dtype=dtypes.string, name="filenames")
     self._record_bytes = ops.convert_to_tensor(

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -35,9 +35,13 @@ import numbers as _numbers
 
 import numpy as _np
 import six as _six
+try:
+  from collections.abc import Iterable as _Iterable
+except ImportError:
+  from collections import Iterable as _Iterable
 
 from tensorflow.python.util.tf_export import tf_export
-
+from tensorflow.python.framework import ops
 
 def as_bytes(bytes_or_text, encoding='utf-8'):
   """Converts either bytes or unicode to `bytes`, using utf-8 encoding for text.
@@ -114,12 +118,14 @@ def path_to_str(path):
   """Returns the file system path representation of a `PathLike` object, else as it is.
 
   Args:
-    path: An object that can be converted to path representation.
+    path: One or more objects that can be converted to path representation.
 
   Returns:
-    A `str` object.
+    One or more `str` object.
   """
-  if hasattr(path, '__fspath__'):
+  if isinstance(path, _Iterable) and not isinstance(path, (str, bytes, bytearray, ops.Tensor)):
+    path = [path_to_str(p) for p in path]
+  elif hasattr(path, '__fspath__'):
     path = as_str_any(path.__fspath__())
   return path
 

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -115,13 +115,15 @@ def as_str_any(value):
 
 @tf_export('compat.path_to_str')
 def path_to_str(path):
-  """Returns the file system path representation of a `PathLike` object, else as it is.
+  """Returns the file system path representation of one or more `PathLike` objects, otherwise 
+  `path` is passed through unchanged.
 
   Args:
-    path: One or more objects that can be converted to path representation.
+    path: One or more objects to be conditionally converted to path representation.
 
   Returns:
-    One or more `str` object.
+    If `path` is a `PathLike` object, then the return value is one or more `str` objects.
+    Otherwise `path` is returned unchanged
   """
   if isinstance(path, _Iterable) and not isinstance(path, (str, bytes, bytearray, ops.Tensor)):
     path = [path_to_str(p) for p in path]

--- a/tensorflow/python/util/compat_test.py
+++ b/tensorflow/python/util/compat_test.py
@@ -1,0 +1,79 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for compat."""
+
+# pylint: disable=unused-import
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    from pathlib import Path
+except ImportError:
+    Path = None
+
+try:
+  from collections.abc import Iterable as _Iterable
+except ImportError:
+  from collections import Iterable as _Iterable
+
+import inspect
+
+from tensorflow.python.platform import test
+from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.util import compat
+from tensorflow.python.ops import array_ops
+from tensorflow.python import dtypes
+
+class CompatPathToStrTest(test.TestCase):
+
+    def testTransformsPathlibPath(self):
+        if Path is None:
+            return # Skip test if pathlib not available.
+        
+        path_input = Path('/tmp/folder')
+        transformed = compat.path_to_str(path_input)
+
+        self.assertTrue(isinstance(transformed, str))
+        self.assertEqual('/tmp/folder', transformed)
+
+    def testTransformsIterablePathlibPath(self):
+        if Path is None:
+            return # Skip test if pathlib not available.
+        
+        path_input = [Path('/tmp/folder'), Path('/tmp/folder2')]
+        transformed = compat.path_to_str(path_input)
+
+        self.assertEqual(['/tmp/folder', '/tmp/folder2'], transformed)
+
+    def testReturnsStrUnchanged(self):
+        str_input = '/tmp/folder'
+
+        transformed = compat.path_to_str(str_input)
+        self.assertEqual(str_input, transformed)
+
+    def testTransformsIterableStrUnchanged(self):   
+        str_input = ['/tmp/folder', '/tmp/folder2']
+        transformed = compat.path_to_str(str_input)
+
+        self.assertEqual(['/tmp/folder', '/tmp/folder2'], transformed)
+
+    def testReturnsTensorUnchanged(self):
+        tensor_input = array_ops.constant('/tmp/folder/', dtype=dtypes.string)
+
+        transformed = compat.path_to_str(tensor_input)
+        self.assertEqual(tensor_input, transformed)
+
+    


### PR DESCRIPTION
* Dataset operations convert `PathLike` objects to string
* `compat.path_to_str` now accepts one or more objects to convert

Further work to #15784 to allow `PathLike` objects to be passed to Dataset readers as well. 