### PR TITLE
Windows: Use cc_import to import python lib properly

### DIFF
--- a/third_party/py/BUILD.tpl
+++ b/third_party/py/BUILD.tpl
@@ -2,20 +2,26 @@ licenses(["restricted"])
 
 package(default_visibility = ["//visibility:public"])
 
+# To build Python C/C++ extension on Windows, we need to link to python import library pythonXY.lib
+# See https://docs.python.org/3/extending/windows.html
+cc_import(
+    name = "python_lib",
+    interface_library = select({
+        ":windows": ":python_import_lib",
+        # A placeholder for Unix platforms which makes --no_build happy.
+        "//conditions:default": "not-existing.lib",
+    }),
+    system_provided = 1,
+)
+
 cc_library(
     name = "python_headers",
     hdrs = [":python_include"],
-    data = select({
-        ":windows": [":python_import_lib"],
+    deps = select({
+        ":windows": [":python_lib"],
         "//conditions:default": [],
     }),
     includes = ["python_include"],
-    linkopts = select({
-        # TODO(pcloudy): Ideally, this should just go into deps after resolving
-        # https://github.com/bazelbuild/bazel/issues/3237,
-        ":windows": ["$(locations :python_import_lib)"],
-        "//conditions:default": [],
-    }),
 )
 
 cc_library(


### PR DESCRIPTION
Previously, we put python.lib in data attribute of a cc_library and
manually added the link option. That caused the build to be
non-hermetic. This change fixed the problem.

@gunan @mrry 