### PR TITLE
Update replicate_model_fn.py

### DIFF
--- a/tensorflow/contrib/estimator/python/estimator/replicate_model_fn.py
+++ b/tensorflow/contrib/estimator/python/estimator/replicate_model_fn.py
@@ -376,7 +376,7 @@ class TowerOptimizer(optimizer_lib.Optimizer):
   class _PerGraphState(object):
     """Gradient reduction related state of a Tensorflow graph."""
 
-    def __init__(self):
+    def __init__(self, name="gradient_reduction"):
       self._collected_grads_and_vars = defaultdict(list)
       self._current_tower_index = 0
       self._number_of_towers = 1
@@ -386,6 +386,7 @@ class TowerOptimizer(optimizer_lib.Optimizer):
       self._name_scope = None
       # If needed, alert that TowerOptimizer needs to be used with model_fn.
       self._has_tower_optimizer_been_used = False
+      self.name= name
 
     def collect_gradients(self, grads_and_vars):
       self._collected_grads_and_vars[self._current_tower_index].append(


### PR DESCRIPTION
Added a name attribute to _PerGraphState. Using the TowerOptimizer throws this warning without it:

```
WARNING:tensorflow:Error encountered when serializing replicate_model_fn_graph_states.
Type is unsupported, or the types of the items don't match field type in CollectionDef.
'_PerGraphState' object has no attribute 'name'
```