### PR TITLE
jpeg.BUILD: Use --cpu instead of --android_cpu

### DIFF
--- a/third_party/jpeg/jpeg.BUILD
+++ b/third_party/jpeg/jpeg.BUILD
@@ -526,12 +526,12 @@ config_setting(
 
 config_setting(
     name = "armeabi-v7a",
-    values = {"android_cpu": "armeabi-v7a"},
+    values = {"cpu": "armeabi-v7a"},
 )
 
 config_setting(
     name = "arm64-v8a",
-    values = {"android_cpu": "arm64-v8a"},
+    values = {"cpu": "arm64-v8a"},
 )
 
 config_setting(


### PR DESCRIPTION
```
ERROR: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/70f524e03685b9df645342d13a051faa/external/jpeg/BUILD:126:12: Illegal ambiguous match on configurable attribute "deps" in @jpeg//:jpeg:
--
  | @jpeg//:k8
  | @jpeg//:armeabi-v7a
```
TF build is broken with Bazel@HEAD, see https://buildkite.com/bazel/bazel-with-downstream-projects-bazel/builds/141#ca77fce7-7ea1-4427-a49b-1ab1305f6bfb

Issue https://github.com/bazelbuild/bazel/issues/4652

The reason is, we recently change default value of --android_cpu to `armeabi-v7a`. https://github.com/bazelbuild/bazel/commit/fc30733995afd1a104051a73218b7a40a0428eb9

That results two config_setting enabled at the same time in jpeg.BUILD.

We should better use --cpu instead of --android_cpu to select for architecture.
@jart @gregestren
FYI, @buchgr 