### PR TITLE
fix some compilation errors on MSVC if IS_SLIM_BUILD

### DIFF
--- a/tensorflow/core/lib/io/record_reader.cc
+++ b/tensorflow/core/lib/io/record_reader.cc
@@ -205,7 +205,9 @@ Status RecordReader::SkipNBytes(uint64 offset) {
     if (options_.buffer_size > 0) {
       TF_RETURN_IF_ERROR(input_stream_->SkipNBytes(offset));
     }
+#if !defined(IS_SLIM_BUILD)
   }
+#endif
   return Status::OK();
 }  // namespace io
 

--- a/tensorflow/core/lib/io/record_reader.h
+++ b/tensorflow/core/lib/io/record_reader.h
@@ -16,10 +16,10 @@ limitations under the License.
 #ifndef TENSORFLOW_LIB_IO_RECORD_READER_H_
 #define TENSORFLOW_LIB_IO_RECORD_READER_H_
 
-#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/stringpiece.h"
-#if !defined(IS_SLIM_BUILD)
 #include "tensorflow/core/lib/io/inputstream_interface.h"
+#if !defined(IS_SLIM_BUILD)
 #include "tensorflow/core/lib/io/zlib_compression_options.h"
 #include "tensorflow/core/lib/io/zlib_inputstream.h"
 #endif  // IS_SLIM_BUILD


### PR DESCRIPTION
Using MSVC (2017), the record_reader.cc can not be compiled successfully if `IS_SLIM_BUILD` is defined, so this PR fixes it.