### PR TITLE
SYCL with ComputeCpp: local_config_sycl has multiple matches

### DIFF
--- a/third_party/sycl/sycl/BUILD.tpl
+++ b/third_party/sycl/sycl/BUILD.tpl
@@ -21,7 +21,7 @@ config_setting(
     name = "using_sycl_trisycl",
     define_values = {
         "using_sycl": "true",
-        "using_trisycl": "false",
+        "using_trisycl": "true",
     },
 )
 


### PR DESCRIPTION
This patch fixes issue reported https://github.com/lukeiwanski/tensorflow/issues/197