### PR TITLE
Fix the messed up list format in using_tpu.md

### DIFF
--- a/tensorflow/docs_src/programmers_guide/using_tpu.md
+++ b/tensorflow/docs_src/programmers_guide/using_tpu.md
@@ -130,8 +130,7 @@ Typically the `FLAGS` would be set by command line arguments. To switch from
 training locally to training on a cloud TPU you would need to:
 
 * Set `FLAGS.use_tpu` to `True`
-* Set `FLAGS.tpu_name` so the
-     `tf.contrib.cluster_resolver.TPUClusterResolver` can find it
+* Set `FLAGS.tpu_name` so the `tf.contrib.cluster_resolver.TPUClusterResolver` can find it
 * Set `FLAGS.model_dir` to a Google Cloud Storage bucket url (`gs://`).
 
 

--- a/tensorflow/docs_src/programmers_guide/using_tpu.md
+++ b/tensorflow/docs_src/programmers_guide/using_tpu.md
@@ -129,10 +129,10 @@ my_tpu_estimator = tf.contrib.tpu.TPUEstimator(
 Typically the `FLAGS` would be set by command line arguments. To switch from
 training locally to training on a cloud TPU you would need to:
 
-  1) Set `FLAGS.use_tpu` to `True`
-  1) Set `FLAGS.tpu_name` so the
+* Set `FLAGS.use_tpu` to `True`
+* Set `FLAGS.tpu_name` so the
      `tf.contrib.cluster_resolver.TPUClusterResolver` can find it
-  1) Set `FLAGS.model_dir` to a Google Cloud Storage bucket url (`gs://`).
+* Set `FLAGS.model_dir` to a Google Cloud Storage bucket url (`gs://`).
 
 
 ## Optimizer


### PR DESCRIPTION
As you can see in [using_tpu.md](https://www.tensorflow.org/programmers_guide/using_tpu), this PR is to fix below messed up format:

> 1) Set FLAGS.use_tpu to True 1) Set FLAGS.tpu_name so the tf.contrib.cluster_resolver.TPUClusterResolver can find it 1) Set FLAGS.model_dir to a Google Cloud Storage bucket url (gs://).