### PR TITLE
contrib/lite: add missing include assert.h (spectrogram.cc)

### DIFF
--- a/tensorflow/contrib/lite/kernels/internal/spectrogram.cc
+++ b/tensorflow/contrib/lite/kernels/internal/spectrogram.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/contrib/lite/kernels/internal/spectrogram.h"
 
+#include <assert.h>
 #include <math.h>
 
 #include "third_party/fft2d/fft.h"


### PR DESCRIPTION
tensorflow/contrib/lite/build_ios_universal_lib.sh fails with:

    error: use of undeclared identifier 'assert'