### PR TITLE
Fix cmake build errors for Linux

### DIFF
--- a/tensorflow/contrib/cmake/external/grpc.cmake
+++ b/tensorflow/contrib/cmake/external/grpc.cmake
@@ -35,6 +35,7 @@ else()
   set(grpc_STATIC_LIBRARIES
       ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc++_unsecure.a
       ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc_unsecure.a
+      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/third_party/cares/cares/lib/libcares.a
       ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgpr.a)
 endif()
 


### PR DESCRIPTION
When trying to build TensorFlow with cmake for Linux, as was specified:
```
tensorflow/tools/ci_build/ci_build.sh CMAKE tensorflow/tools/ci_build/builds/cmake.sh
```

The following error encountered:
```
grpc/src/grpc/libgrpc_unsecure.a(grpc_ares_wrapper.cc.o): In function `on_txt_done_cb(void*, int, int, unsigned char*, int)':
grpc_ares_wrapper.cc:(.text+0x256): undefined reference to `ares_parse_txt_reply_ext'
grpc_ares_wrapper.cc:(.text+0x267): undefined reference to `ares_strerror'
grpc_ares_wrapper.cc:(.text+0x363): undefined reference to `ares_free_data'
```

This fix fixes the above issue with libcares.a in cmake file.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>