### PR TITLE
Fix broken graphviz download link and change to https

### DIFF
--- a/tensorflow/docs_src/performance/xla/jit.md
+++ b/tensorflow/docs_src/performance/xla/jit.md
@@ -157,7 +157,7 @@ to fuse Ops is visible by starting at `hlo_graph_0.dot` and viewing each diagram
 in succession.
 
 To Render the .dot file into a png, install
-[GraphViz](http://www.graphviz.org/Download..php) and run:
+[GraphViz](https://www.graphviz.org/download/) and run:
 
 ```shell
 dot -Tpng hlo_graph_80.dot -o hlo_graph_80.png


### PR DESCRIPTION
The graphviz download link has been changed to
https://www.graphviz.org/download/

This fix fixes the broken link in jit.md.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>