### PR TITLE
Fix inconsistency of eq for TensorShape

### DIFF
--- a/tensorflow/python/framework/tensor_shape.py
+++ b/tensorflow/python/framework/tensor_shape.py
@@ -394,7 +394,7 @@ def as_dimension(value):
     A Dimension corresponding to the given value.
   """
   if isinstance(value, Dimension):
-    return value
+    return Dimension(value.value)
   else:
     return Dimension(value)
 

--- a/tensorflow/python/framework/tensor_shape_test.py
+++ b/tensorflow/python/framework/tensor_shape_test.py
@@ -393,6 +393,21 @@ class ShapeTest(test_util.TensorFlowTestCase):
     with self.assertRaises(ValueError):
       unk1 != unk0  # pylint: disable=pointless-statement
 
+    # Test case for GitHub issue 17593
+    v1 = tensor_shape.TensorShape([None])
+    v2 = tensor_shape.TensorShape([None])
+    self.assertFalse(v1 == v2)
+
+    dim = tensor_shape.Dimension(None)
+
+    v3 = tensor_shape.TensorShape([dim])
+    v4 = tensor_shape.TensorShape([tensor_shape.Dimension(None)])
+    self.assertFalse(v3 == v4)
+
+    v5 = tensor_shape.TensorShape([dim])
+    v6 = tensor_shape.TensorShape([dim])
+    self.assertFalse(v5 == v6)
+
   def testAsList(self):
     with self.assertRaisesRegexp(ValueError,
                                  "not defined on an unknown TensorShape"):


### PR DESCRIPTION

This fix tries to address the inconsistency of eq for TensorShape.

For TensorShape, the dimension of Dimension(None) should be considered not equal to Dimension(None). However, if the same Dimension(None) is reused, the behavior changes. For example,
```
$ python
Python 2.7.12 (default, Dec  4 2017, 14:50:18)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import tensorflow as tf
>>> tf.TensorShape([None]) == tf.TensorShape([None])
False
>>> tf.TensorShape([tf.Dimension(None)]) == tf.TensorShape([tf.Dimension(None)])
False
>>> dim = tf.Dimension(None)
>>> tf.TensorShape([dim]) == tf.TensorShape([dim])
True
>>>
```

The issue was that when dims is passed to the constructor of TensorShape through `as_dimension`, the dimension is directly assigned. This fix changes the implementaion of `as_dimension` so that a copy is always performs. In this way, Dimensions in TensorShape will always have the differnet id so an `__eq__` op will always be performed.

This fix fixes #17593.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>