### PR TITLE
[CMake]Exclude duplicate tests from ${tf_test_src_simple}

### DIFF
--- a/tensorflow/contrib/cmake/tf_tests.cmake
+++ b/tensorflow/contrib/cmake/tf_tests.cmake
@@ -475,6 +475,10 @@ if (tensorflow_BUILD_CC_TESTS)
     "${tensorflow_source_dir}/tensorflow/core/profiler/internal/advisor/*_test.cc"
   )
 
+  list(REMOVE_ITEM tf_test_src_simple
+    ${tf_core_profiler_test_srcs}
+  )
+
   set(tf_test_lib tf_test_lib)
   add_library(${tf_test_lib} STATIC ${tf_src_testlib})
 


### PR DESCRIPTION
This fixes errors caused by adding executable targets twice.

To reproduce:
(tf-venv) tedchang@teds-mbp:~/tfws/tensorflow/tensorflow/contrib/cmake/build$ cmake -DCMAKE_BUILD_TYPE=Release -Dtensorflow_BUILD_CC_TESTS=ON ..
CMake Error at tf_tests.cmake:73 (add_executable):
  add_executable cannot create target
  "tensorflow_core_profiler_internal_tfprof_show_test" because another target
  with the same name already exists.  The existing target is an executable
  created in source directory
  "/Users/tedchang/tfws/tensorflow/tensorflow/contrib/cmake".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  tf_tests.cmake:46 (AddTest)
  tf_tests.cmake:527 (AddTests)
  CMakeLists.txt:469 (include)


CMake Error at tf_tests.cmake:73 (add_executable):
  add_executable cannot create target
  "tensorflow_core_profiler_internal_tfprof_stats_test" because another
  target with the same name already exists.  The existing target is an
  executable created in source directory
  "/Users/tedchang/tfws/tensorflow/tensorflow/contrib/cmake".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  tf_tests.cmake:46 (AddTest)
  tf_tests.cmake:527 (AddTests)
  CMakeLists.txt:469 (include)


CMake Error at tf_tests.cmake:73 (add_executable):
  add_executable cannot create target
  "tensorflow_core_profiler_internal_tfprof_tensor_test" because another
  target with the same name already exists.  The existing target is an
  executable created in source directory
  "/Users/tedchang/tfws/tensorflow/tensorflow/contrib/cmake".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  tf_tests.cmake:46 (AddTest)
  tf_tests.cmake:527 (AddTests)
  CMakeLists.txt:469 (include)


CMake Error at tf_tests.cmake:73 (add_executable):
  add_executable cannot create target
  "tensorflow_core_profiler_internal_tfprof_timeline_test" because another
  target with the same name already exists.  The existing target is an
  executable created in source directory
  "/Users/tedchang/tfws/tensorflow/tensorflow/contrib/cmake".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  tf_tests.cmake:46 (AddTest)
  tf_tests.cmake:527 (AddTests)
  CMakeLists.txt:469 (include)


CMake Error at tf_tests.cmake:73 (add_executable):
  add_executable cannot create target
  "tensorflow_core_profiler_internal_advisor_tfprof_advisor_test" because
  another target with the same name already exists.  The existing target is
  an executable created in source directory
  "/Users/tedchang/tfws/tensorflow/tensorflow/contrib/cmake".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  tf_tests.cmake:46 (AddTest)
  tf_tests.cmake:527 (AddTests)
  CMakeLists.txt:469 (include)


-- Configuring incomplete, errors occurred!

