### PR TITLE
Fix incorrect python version in installation doc for Mac

### DIFF
--- a/tensorflow/docs_src/install/install_mac.md
+++ b/tensorflow/docs_src/install/install_mac.md
@@ -115,7 +115,7 @@ Take the following steps to install TensorFlow with Virtualenv:
      <i>tfBinaryURL</i> for your system
      [here](#the_url_of_the_tensorflow_python_package).
      For example, if you are installing TensorFlow for macOS,
-     Python 2.7, the command to install
+     Python 3.6, the command to install
      TensorFlow in the active Virtualenv is as follows:
 
      <pre> $ <b>pip3 install --upgrade \


### PR DESCRIPTION
This fix fixes the incorrect python version (2 vs 3) in the installation documentation for Mac.

This fix fixes #17614.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>