### PR TITLE
Fix broken link in kernel method tutorial

### DIFF
--- a/tensorflow/docs_src/tutorials/kernel_methods.md
+++ b/tensorflow/docs_src/tutorials/kernel_methods.md
@@ -1,9 +1,9 @@
 # Improving Linear Models Using Explicit Kernel Methods
 
-Note: This document uses a deprecated version of ${tf.estimator},
-which has a ${tf.contrib.learn.estimator$different interface}.
+Note: This document uses a deprecated version of @{tf.estimator},
+which has a @{tf.contrib.learn.estimator$different interface}.
 It also uses other `contrib` methods whose
-${$version_compat#not_covered$API may not be stable}.
+@{$version_compat#not_covered$API may not be stable}.
 
 In this tutorial, we demonstrate how combining (explicit) kernel methods with
 linear models can drastically increase the latters' quality of predictions


### PR DESCRIPTION
As we can see in [Kernel Methods tutorial](https://www.tensorflow.org/tutorials/kernel_methods), the reference links in Note section haven't generated valid links.
> Note: This document uses a deprecated version of ${tf.estimator}, which has a ${tf.contrib.learn.estimator$different interface}. It also uses other contrib methods whose ${$version_compat#not_covered$API may not be stable}.

This PR is a simple fix just replace the begining "$" to "@" to fix above broken links.
