### PR TITLE
Fix TensorBoard tutorial links to the wrong MNIST tutorial example code

### DIFF
--- a/tensorflow/docs_src/programmers_guide/summaries_and_tensorboard.md
+++ b/tensorflow/docs_src/programmers_guide/summaries_and_tensorboard.md
@@ -76,7 +76,7 @@ data than you need, though. Instead, consider running the merged summary op
 every `n` steps.
 
 The code example below is a modification of the
-@{$layers$simple MNIST tutorial},
+[simple MNIST tutorial](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/mnist/mnist.py),
 in which we have added some summary ops, and run them every ten steps. If you
 run this and then launch `tensorboard --logdir=/tmp/tensorflow/mnist`, you'll be able
 to visualize statistics, such as how the weights or accuracy varied during


### PR DESCRIPTION
This PR is to fix #17600.

The [TensorBoard guide](https://www.tensorflow.org/programmers_guide/summaries_and_tensorboard) contains example code that it says "is a modification of the simple MNIST tutorial, in which we have added some summary ops." But the tutorial it links to, https://www.tensorflow.org/tutorials/layers, is very different from the example code it gives -- that tutorial uses the tf.layers module to create a CNN, while the example code manually defines a one-hidden-layer fully-connected network. 