### PR TITLE
Fix unaligned access on Android 4 or 5

### DIFF
--- a/tensorflow/contrib/lite/kernels/internal/optimized/neon_tensor_utils.cc
+++ b/tensorflow/contrib/lite/kernels/internal/optimized/neon_tensor_utils.cc
@@ -24,12 +24,26 @@ limitations under the License.
 
 #define kFloatWeightsPerNeonLane 4
 
-namespace tflite {
-namespace tensor_utils {
+#ifndef __ANDROID__
+#include <stdlib.h>
 
+namespace {
+float32x4_t* AlignedAlloc(unsigned count) {
+  void *ptr = nullptr;
+  int err = posix_memalign(&ptr, sizeof(float32x4_t), count * sizeof(float32x4_t));
+  return err == 0 ? (float32x4_t*)ptr : nullptr;
+}
+}
+#else
+namespace {
 float32x4_t* AlignedAlloc(unsigned count) {
   return (float32x4_t*)memalign(sizeof(float32x4_t), count * sizeof(float32x4_t));
 }
+}
+#endif
+
+namespace tflite {
+namespace tensor_utils {
 
 void NeonMatrixBatchVectorMultiplyAccumulate(const float* matrix, int m_rows,
                                              int m_cols, const float* vector,


### PR DESCRIPTION
This issue is caused by a breaking change in NDK clang (r13+). In those
recent NDKs, clang assumes NEON vectors are aligned to 128-bit boundary,
and thus generates 128-bit address hints. However, on old Android
versions, heap-allocated memory are not always aligned to 128-bit.

After consulting NDK maintainers [(here)](https://github.com/android-ndk/ndk/issues/640), the breaking change of compiler will not be fixed - so TensorFlow should fix it instead.

P.S: it also seems to be responsible for #16317 .

Secondly, it looks to me that existing code [(here)](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/lite/kernels/internal/optimized/neon_tensor_utils.cc#L42-L43) allocates more than it actually needs. The element count should not be multiplied by `sizeof(float32x4_t)` again. **Please help verify this part.**