### PR TITLE
Add python built-in types support for `tf.as_dtype`

### DIFF
--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -18,7 +18,6 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import types
 
 from tensorflow.core.framework import types_pb2
 from tensorflow.python import pywrap_tensorflow
@@ -650,11 +649,10 @@ QUANTIZED_DTYPES = frozenset([
 tf_export("QUANTIZED_DTYPES").export_constant(__name__, "QUANTIZED_DTYPES")
 
 _PYTHON_TO_TF = {
-    types.IntType: int32,
-    types.LongType: int64,
-    types.FloatType: float64,
-    types.ComplexType: complex128,
-    types.BooleanType: bool,
+    int: int64,
+    float: float64,
+    complex: complex128,
+    bool: bool,
 }
 
 @tf_export("as_dtype")

--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import types
 
 from tensorflow.core.framework import types_pb2
 from tensorflow.python import pywrap_tensorflow
@@ -648,6 +649,13 @@ QUANTIZED_DTYPES = frozenset([
 ])
 tf_export("QUANTIZED_DTYPES").export_constant(__name__, "QUANTIZED_DTYPES")
 
+_PYTHON_TO_TF = {
+    types.IntType: int32,
+    types.LongType: int64,
+    types.FloatType: float64,
+    types.ComplexType: complex128,
+    types.BooleanType: bool,
+}
 
 @tf_export("as_dtype")
 def as_dtype(type_value):
@@ -676,6 +684,11 @@ def as_dtype(type_value):
 
   try:
     return _STRING_TO_TF[type_value]
+  except KeyError:
+    pass
+
+  try:
+    return _PYTHON_TO_TF[type_value]
   except KeyError:
     pass
 

--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -649,9 +649,7 @@ QUANTIZED_DTYPES = frozenset([
 tf_export("QUANTIZED_DTYPES").export_constant(__name__, "QUANTIZED_DTYPES")
 
 _PYTHON_TO_TF = {
-    int: int64,
-    float: float64,
-    complex: complex128,
+    float: float32,
     bool: bool,
 }
 

--- a/tensorflow/python/framework/dtypes_test.py
+++ b/tensorflow/python/framework/dtypes_test.py
@@ -296,9 +296,7 @@ class TypesTest(test_util.TensorFlowTestCase):
     self.assertNotEqual(dtypes.float64, 2.1)
 
   def testPythonTypesConversion(self):
-    self.assertIs(dtypes.float64, dtypes.as_dtype(float))
-    self.assertIs(dtypes.int64, dtypes.as_dtype(int))
-    self.assertIs(dtypes.complex128, dtypes.as_dtype(complex))
+    self.assertIs(dtypes.float32, dtypes.as_dtype(float))
     self.assertIs(dtypes.bool, dtypes.as_dtype(bool))
 
 if __name__ == "__main__":

--- a/tensorflow/python/framework/dtypes_test.py
+++ b/tensorflow/python/framework/dtypes_test.py
@@ -292,7 +292,8 @@ class TypesTest(test_util.TensorFlowTestCase):
       self.assertEquals(dtype, dtype2)
 
   def testEqWithNonTFTypes(self):
-    self.assertNotEqual(dtypes.int32, int)
+    self.assertNotEqual(dtypes.int32, long)
+    self.assertNotEqual(dtypes.int64, int)
     self.assertNotEqual(dtypes.float64, 2.1)
 
   def testPythonTypesConversion(self):

--- a/tensorflow/python/framework/dtypes_test.py
+++ b/tensorflow/python/framework/dtypes_test.py
@@ -295,6 +295,12 @@ class TypesTest(test_util.TensorFlowTestCase):
     self.assertNotEqual(dtypes.int32, int)
     self.assertNotEqual(dtypes.float64, 2.1)
 
+  def testPythonTypesConversion(self):
+    self.assertIs(dtypes.float64, dtypes.as_dtype(float))
+    self.assertIs(dtypes.int32, dtypes.as_dtype(int))
+    self.assertIs(dtypes.int64, dtypes.as_dtype(long))
+    self.assertIs(dtypes.complex128, dtypes.as_dtype(complex))
+    self.assertIs(dtypes.bool, dtypes.as_dtype(bool))
 
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/python/framework/dtypes_test.py
+++ b/tensorflow/python/framework/dtypes_test.py
@@ -292,14 +292,12 @@ class TypesTest(test_util.TensorFlowTestCase):
       self.assertEquals(dtype, dtype2)
 
   def testEqWithNonTFTypes(self):
-    self.assertNotEqual(dtypes.int32, long)
-    self.assertNotEqual(dtypes.int64, int)
+    self.assertNotEqual(dtypes.int32, int)
     self.assertNotEqual(dtypes.float64, 2.1)
 
   def testPythonTypesConversion(self):
     self.assertIs(dtypes.float64, dtypes.as_dtype(float))
-    self.assertIs(dtypes.int32, dtypes.as_dtype(int))
-    self.assertIs(dtypes.int64, dtypes.as_dtype(long))
+    self.assertIs(dtypes.int64, dtypes.as_dtype(int))
     self.assertIs(dtypes.complex128, dtypes.as_dtype(complex))
     self.assertIs(dtypes.bool, dtypes.as_dtype(bool))
 


### PR DESCRIPTION
This fix tries to address the issue raised in #17641 where it was not possible to use `tf.as_dtype(float)` the same way as numpy `np.dtype(float)`.
This fix adds the built-in types support for `tf.as_dtype`, so that it is possible to specify:
```
dtypes.as_dtype(float)   # dtypes.float64
dtypes.as_dtype(int)     # dtypes.int64
dtypes.as_dtype(complex) # dtypes.complex128
dtypes.as_dtype(bool)    # dtypes.bool
```

This fix fixes #17641.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>