### PR TITLE
Support NUMA aware CPU device

### DIFF
--- a/NonBlockingThreadPool.h
+++ b/NonBlockingThreadPool.h
@@ -1,0 +1,387 @@
+// This file is part of Eigen, a lightweight C++ template library
+// for linear algebra.
+//
+// Copyright (C) 2016 Dmitry Vyukov <dvyukov@google.com>
+//
+// This Source Code Form is subject to the terms of the Mozilla
+// Public License v. 2.0. If a copy of the MPL was not distributed
+// with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef EIGEN_CXX11_THREADPOOL_NONBLOCKING_THREAD_POOL_H
+#define EIGEN_CXX11_THREADPOOL_NONBLOCKING_THREAD_POOL_H
+
+#include <iostream>
+
+namespace Eigen {
+
+template <typename Environment>
+class NonBlockingThreadPoolTempl : public Eigen::ThreadPoolInterface {
+ public:
+  typedef typename Environment::Task Task;
+  typedef RunQueue<Task, 1024> Queue;
+
+  NonBlockingThreadPoolTempl(int num_threads, std::vector<int> &proc_set, Environment env = Environment())
+      : NonBlockingThreadPoolTempl(num_threads, proc_set, true, env) {}
+
+  NonBlockingThreadPoolTempl(int num_threads, std::vector<int> &proc_set, bool allow_spinning,
+                             Environment env = Environment())
+      : env_(env),
+        num_threads_(num_threads),
+        allow_spinning_(allow_spinning),
+        threads_(num_threads),
+        queues_(num_threads),
+        coprimes_(num_threads),
+        waiters_(num_threads),
+        blocked_(0),
+        spinning_(0),
+        done_(false),
+        cancelled_(false),
+        ec_(waiters_) {
+    if(proc_set.size() != 0) {
+        proc_set_.insert(proc_set_.begin(), proc_set.begin(), proc_set.end());
+    }
+ 
+    thread_bound_.resize(num_threads);
+    waiters_.resize(num_threads_);
+
+    // Calculate coprimes of num_threads_.
+    // Coprimes are used for a random walk over all threads in Steal
+    // and NonEmptyQueueIndex. Iteration is based on the fact that if we take
+    // a walk starting thread index t and calculate num_threads - 1 subsequent
+    // indices as (t + coprime) % num_threads, we will cover all threads without
+    // repetitions (effectively getting a presudo-random permutation of thread
+    // indices).
+    for (int i = 1; i <= num_threads_; i++) {
+      unsigned a = i;
+      unsigned b = num_threads_;
+      // If GCD(a, b) == 1, then a and b are coprimes.
+      while (b != 0) {
+        unsigned tmp = a;
+        a = b;
+        b = tmp % b;
+      }
+      if (a == 1) {
+        coprimes_.push_back(i);
+      }
+    }
+    for (int i = 0; i < num_threads_; i++) {
+      queues_.push_back(new Queue());
+    }
+    for (int i = 0; i < num_threads_; i++) {
+      threads_.push_back(env_.CreateThread([this, i]() { WorkerLoop(i); }));
+    }
+  }
+
+  ~NonBlockingThreadPoolTempl() {
+    if(proc_set_.size() != 0){
+      std::cout << "NonBlockingThreadPool: " << (long) this << " bound to: ";
+      for(int i=0; i<thread_bound_.size(); i++) 
+        std::cout << thread_bound_[i] << " ";
+      std::cout << "\n";
+    }
+
+    done_ = true;
+
+    // Now if all threads block without work, they will start exiting.
+    // But note that threads can continue to work arbitrary long,
+    // block, submit new work, unblock and otherwise live full life.
+    if (!cancelled_) {
+      ec_.Notify(true);
+    } else {
+      // Since we were cancelled, there might be entries in the queues.
+      // Empty them to prevent their destructor from asserting.
+      for (size_t i = 0; i < queues_.size(); i++) {
+        queues_[i]->Flush();
+      }
+    }
+
+    // Join threads explicitly to avoid destruction order issues.
+    for (size_t i = 0; i < num_threads_; i++) delete threads_[i];
+    for (size_t i = 0; i < num_threads_; i++) delete queues_[i];
+  }
+
+  void Schedule(std::function<void()> fn) {
+    Task t = env_.CreateTask(std::move(fn));
+    PerThread* pt = GetPerThread();
+    if (pt->pool == this) {
+      // Worker thread of this pool, push onto the thread's queue.
+      Queue* q = queues_[pt->thread_id];
+      t = q->PushFront(std::move(t));
+    } else {
+      // A free-standing thread (or worker of another pool), push onto a random
+      // queue.
+      Queue* q = queues_[Rand(&pt->rand) % queues_.size()];
+      t = q->PushBack(std::move(t));
+    }
+    // Note: below we touch this after making w available to worker threads.
+    // Strictly speaking, this can lead to a racy-use-after-free. Consider that
+    // Schedule is called from a thread that is neither main thread nor a worker
+    // thread of this pool. Then, execution of w directly or indirectly
+    // completes overall computations, which in turn leads to destruction of
+    // this. We expect that such scenario is prevented by program, that is,
+    // this is kept alive while any threads can potentially be in Schedule.
+    if (!t.f) {
+      ec_.Notify(false);
+    }
+    else {
+      env_.ExecuteTask(t);  // Push failed, execute directly.
+    }
+  }
+
+  void Cancel() {
+    cancelled_ = true;
+    done_ = true;
+
+    // Let each thread know it's been cancelled.
+#ifdef EIGEN_THREAD_ENV_SUPPORTS_CANCELLATION
+    for (size_t i = 0; i < threads_.size(); i++) {
+      threads_[i]->OnCancel();
+    }
+#endif
+
+    // Wake up the threads without work to let them exit on their own.
+    ec_.Notify(true);
+  }
+
+  int NumThreads() const final {
+    return num_threads_;
+  }
+
+  int CurrentThreadId() const final {
+    const PerThread* pt =
+        const_cast<NonBlockingThreadPoolTempl*>(this)->GetPerThread();
+    if (pt->pool == this) {
+      return pt->thread_id;
+    } else {
+      return -1;
+    }
+  }
+
+ private:
+  typedef typename Environment::EnvThread Thread;
+
+  struct PerThread {
+    constexpr PerThread() : pool(NULL), rand(0), thread_id(-1) { }
+    NonBlockingThreadPoolTempl* pool;  // Parent pool, or null for normal threads.
+    uint64_t rand;  // Random generator state.
+    int thread_id;  // Worker thread index in pool.
+  };
+
+  Environment env_;
+  const int num_threads_;
+  const bool allow_spinning_;
+  MaxSizeVector<Thread*> threads_;
+  MaxSizeVector<Queue*> queues_;
+  MaxSizeVector<unsigned> coprimes_;
+  MaxSizeVector<EventCount::Waiter> waiters_;
+  std::atomic<unsigned> blocked_;
+  std::atomic<bool> spinning_;
+  std::atomic<bool> done_;
+  std::atomic<bool> cancelled_;
+  EventCount ec_;
+  std::vector<int> proc_set_;
+  std::vector<int> thread_bound_;
+
+  // Main worker thread loop.
+  void WorkerLoop(int thread_id) {
+    if(proc_set_.size() != 0) {
+      //set the thread affinity
+      cpu_set_t cpuset;
+      CPU_ZERO(&cpuset);
+      CPU_SET(proc_set_[thread_id], &cpuset);
+      pthread_t thread = pthread_self();
+
+      int s = pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
+      if (s != 0) {
+        std::cout << "NonBlockingThreadPool: Failed to set thread affinity\n";
+        return;
+      }
+
+      /* Check the actual affinity mask assigned to the thread */
+      s = pthread_getaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
+      if (s != 0)
+        std::cout << "NonBlockingThreadPool: Failed to call pthread_getaffinity_np\n";
+      else {
+        for (int j = 0; j < CPU_SETSIZE; j++)
+          if (CPU_ISSET(j, &cpuset))
+            thread_bound_[thread_id] = j;
+      }
+
+      char buf[1024];
+      sprintf(buf, "eigen worker %d", thread_id);
+      pthread_setname_np(thread, buf);
+    }
+
+    PerThread* pt = GetPerThread();
+    pt->pool = this;
+    pt->rand = std::hash<std::thread::id>()(std::this_thread::get_id());
+    pt->thread_id = thread_id;
+    Queue* q = queues_[thread_id];
+    EventCount::Waiter* waiter = &waiters_[thread_id];
+    // TODO(dvyukov,rmlarsen): The time spent in Steal() is proportional
+    // to num_threads_ and we assume that new work is scheduled at a
+    // constant rate, so we set spin_count to 5000 / num_threads_. The
+    // constant was picked based on a fair dice roll, tune it.
+    const int spin_count =
+        allow_spinning_ && num_threads_ > 0 ? 5000 / num_threads_ : 0;
+    if (num_threads_ == 1) {
+      // For num_threads_ == 1 there is no point in going through the expensive
+      // steal loop. Moreover, since Steal() calls PopBack() on the victim
+      // queues it might reverse the order in which ops are executed compared to
+      // the order in which they are scheduled, which tends to be
+      // counter-productive for the types of I/O workloads the single thread
+      // pools tend to be used for.
+      while (!cancelled_) {
+        Task t = q->PopFront();
+        for (int i = 0; i < spin_count && !t.f; i++) {
+          if (!cancelled_.load(std::memory_order_relaxed)) {
+            t = q->PopFront();
+          }
+        }
+        if (!t.f) {
+          if (!WaitForWork(waiter, &t)) {
+            return;
+          }
+        }
+        if (t.f) {
+          env_.ExecuteTask(t);
+        }
+      }
+    } else {
+      while (!cancelled_) {
+        Task t = q->PopFront();
+        if (!t.f) {
+          t = Steal();
+          if (!t.f) {
+            // Leave one thread spinning. This reduces latency.
+            if (allow_spinning_ && !spinning_ && !spinning_.exchange(true)) {
+              for (int i = 0; i < spin_count && !t.f; i++) {
+                if (!cancelled_.load(std::memory_order_relaxed)) {
+                  t = Steal();
+                } else {
+                  return;
+                }
+              }
+              spinning_ = false;
+            }
+            if (!t.f) {
+              if (!WaitForWork(waiter, &t)) {
+                return;
+              }
+            }
+          }
+        }
+        if (t.f) {
+          env_.ExecuteTask(t);
+        }
+      }
+    }
+  }
+
+  // Steal tries to steal work from other worker threads in best-effort manner.
+  Task Steal() {
+    PerThread* pt = GetPerThread();
+    const size_t size = queues_.size();
+    unsigned r = Rand(&pt->rand);
+    unsigned inc = coprimes_[r % coprimes_.size()];
+    unsigned victim = r % size;
+    for (unsigned i = 0; i < size; i++) {
+      Task t = queues_[victim]->PopBack();
+      if (t.f) {
+        return t;
+      }
+      victim += inc;
+      if (victim >= size) {
+        victim -= size;
+      }
+    }
+    return Task();
+  }
+
+  // WaitForWork blocks until new work is available (returns true), or if it is
+  // time to exit (returns false). Can optionally return a task to execute in t
+  // (in such case t.f != nullptr on return).
+  bool WaitForWork(EventCount::Waiter* waiter, Task* t) {
+    eigen_assert(!t->f);
+    // We already did best-effort emptiness check in Steal, so prepare for
+    // blocking.
+    ec_.Prewait(waiter);
+    // Now do a reliable emptiness check.
+    int victim = NonEmptyQueueIndex();
+    if (victim != -1) {
+      ec_.CancelWait(waiter);
+      if (cancelled_) {
+        return false;
+      } else {
+        *t = queues_[victim]->PopBack();
+        return true;
+      }
+    }
+    // Number of blocked threads is used as termination condition.
+    // If we are shutting down and all worker threads blocked without work,
+    // that's we are done.
+    blocked_++;
+    if (done_ && blocked_ == num_threads_) {
+      ec_.CancelWait(waiter);
+      // Almost done, but need to re-check queues.
+      // Consider that all queues are empty and all worker threads are preempted
+      // right after incrementing blocked_ above. Now a free-standing thread
+      // submits work and calls destructor (which sets done_). If we don't
+      // re-check queues, we will exit leaving the work unexecuted.
+      if (NonEmptyQueueIndex() != -1) {
+        // Note: we must not pop from queues before we decrement blocked_,
+        // otherwise the following scenario is possible. Consider that instead
+        // of checking for emptiness we popped the only element from queues.
+        // Now other worker threads can start exiting, which is bad if the
+        // work item submits other work. So we just check emptiness here,
+        // which ensures that all worker threads exit at the same time.
+        blocked_--;
+        return true;
+      }
+      // Reached stable termination state.
+      ec_.Notify(true);
+      return false;
+    }
+    ec_.CommitWait(waiter);
+    blocked_--;
+    return true;
+  }
+
+  int NonEmptyQueueIndex() {
+    PerThread* pt = GetPerThread();
+    const size_t size = queues_.size();
+    unsigned r = Rand(&pt->rand);
+    unsigned inc = coprimes_[r % coprimes_.size()];
+    unsigned victim = r % size;
+    for (unsigned i = 0; i < size; i++) {
+      if (!queues_[victim]->Empty()) {
+        return victim;
+      }
+      victim += inc;
+      if (victim >= size) {
+        victim -= size;
+      }
+    }
+    return -1;
+  }
+
+  static EIGEN_STRONG_INLINE PerThread* GetPerThread() {
+    EIGEN_THREAD_LOCAL PerThread per_thread_;
+    PerThread* pt = &per_thread_;
+    return pt;
+  }
+
+  static EIGEN_STRONG_INLINE unsigned Rand(uint64_t* state) {
+    uint64_t current = *state;
+    // Update the internal state
+    *state = current * 6364136223846793005ULL + 0xda3e39cb94b95bdbULL;
+    // Generate the random output (using the PCG-XSH-RS scheme)
+    return static_cast<unsigned>((current ^ (current >> 22)) >> (22 + (current >> 61)));
+  }
+};
+
+typedef NonBlockingThreadPoolTempl<StlThreadEnvironment> NonBlockingThreadPool;
+
+}  // namespace Eigen
+
+#endif  // EIGEN_CXX11_THREADPOOL_NONBLOCKING_THREAD_POOL_H

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -2138,6 +2138,7 @@ CORE_CPU_LIB_HEADERS = CORE_CPU_BASE_HDRS + [
     "common_runtime/stats_publisher_interface.h",
     "common_runtime/step_stats_collector.h",
     "common_runtime/threadpool_device.h",
+    "common_runtime/numa_device.h",
     "graph/gradients.h",
     "graph/quantize_training.h",
 ] + if_mkl(["graph/mkl_graph_util.h"])
@@ -2180,6 +2181,8 @@ tf_cuda_library(
         "common_runtime/step_stats_collector.cc",
         "common_runtime/threadpool_device.cc",
         "common_runtime/threadpool_device_factory.cc",
+        "common_runtime/numa_device.cc",
+        "common_runtime/numa_device_factory.cc",
         "graph/gradients.cc",
         "graph/mkl_layout_pass.cc",
         "graph/mkl_tfconversion_pass.cc",

--- a/tensorflow/core/common_runtime/graph_runner.cc
+++ b/tensorflow/core/common_runtime/graph_runner.cc
@@ -39,6 +39,7 @@ namespace {
 std::unique_ptr<Device> GetCPUDevice(Env* env) {
   std::vector<Device*> devices;
   SessionOptions session_options;
+  session_options.config.set_intra_op_parallelism_threads(1);
   session_options.env = env;
   Status s = DeviceFactory::GetFactory(DEVICE_CPU)
                  ->CreateDevices(session_options, "", &devices);

--- a/tensorflow/core/common_runtime/local_device.cc
+++ b/tensorflow/core/common_runtime/local_device.cc
@@ -31,7 +31,8 @@ namespace tensorflow {
 bool LocalDevice::use_global_threadpool_ = true;
 
 struct LocalDevice::EigenThreadPoolInfo {
-  explicit EigenThreadPoolInfo(const SessionOptions& options) {
+  explicit EigenThreadPoolInfo(const SessionOptions& options, 
+                                     std::vector<int> &proc_set) {
     int32 intra_op_parallelism_threads =
         options.config.intra_op_parallelism_threads();
     if (intra_op_parallelism_threads == 0) {
@@ -41,7 +42,7 @@ struct LocalDevice::EigenThreadPoolInfo {
             << intra_op_parallelism_threads;
     eigen_worker_threads_.num_threads = intra_op_parallelism_threads;
     eigen_worker_threads_.workers = new thread::ThreadPool(
-        options.env, "Eigen", intra_op_parallelism_threads);
+        options.env, "Eigen", intra_op_parallelism_threads, proc_set);
     eigen_threadpool_wrapper_.reset(
         new EigenThreadPoolWrapper(eigen_worker_threads_.workers));
     eigen_device_.reset(new Eigen::ThreadPoolDevice(
@@ -66,18 +67,34 @@ LocalDevice::LocalDevice(const SessionOptions& options,
   // could speed up performance and are available on the current CPU.
   port::InfoAboutUnusedCPUFeatures();
   LocalDevice::EigenThreadPoolInfo* tp_info;
+  std::vector<int> proc_set;
   if (use_global_threadpool_) {
     // All ThreadPoolDevices in the process will use this single fixed
     // sized threadpool for numerical computations.
     static LocalDevice::EigenThreadPoolInfo* global_tp_info =
-        new LocalDevice::EigenThreadPoolInfo(options);
+        new LocalDevice::EigenThreadPoolInfo(options, proc_set);
     tp_info = global_tp_info;
   } else {
     // Each LocalDevice owns a separate ThreadPoolDevice for numerical
     // computations.
-    owned_tp_info_.reset(new LocalDevice::EigenThreadPoolInfo(options));
+    owned_tp_info_.reset(new LocalDevice::EigenThreadPoolInfo(options, proc_set));
     tp_info = owned_tp_info_.get();
   }
+  set_tensorflow_cpu_worker_threads(&tp_info->eigen_worker_threads_);
+  set_eigen_cpu_device(tp_info->eigen_device_.get());
+}
+
+LocalDevice::LocalDevice(const SessionOptions& options,
+                               std::vector<int> &proc_set,
+                         const DeviceAttributes& attributes)
+    : Device(options.env, attributes), owned_tp_info_(nullptr) {
+  // Log info messages if TensorFlow is not compiled with instructions that
+  // could speed up performance and are available on the current CPU.
+  port::InfoAboutUnusedCPUFeatures();
+
+  owned_tp_info_.reset(new LocalDevice::EigenThreadPoolInfo(options, proc_set));
+  LocalDevice::EigenThreadPoolInfo* tp_info = owned_tp_info_.get();
+
   set_tensorflow_cpu_worker_threads(&tp_info->eigen_worker_threads_);
   set_eigen_cpu_device(tp_info->eigen_device_.get());
 }

--- a/tensorflow/core/common_runtime/local_device.h
+++ b/tensorflow/core/common_runtime/local_device.h
@@ -35,6 +35,9 @@ class LocalDevice : public Device {
  public:
   LocalDevice(const SessionOptions& options,
               const DeviceAttributes& attributes);
+  LocalDevice(const SessionOptions& options,
+                    std::vector<int> &proc_set,
+              const DeviceAttributes& attributes);
   ~LocalDevice() override;
 
  private:

--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -143,12 +143,14 @@ class MklCPUAllocator : public VisitableAllocator {
     Status s = Status(error::Code::UNIMPLEMENTED,
                       "Unimplemented case for hooking MKL function.");
     TF_CHECK_OK(s);  // way to assert with an error message
+    return NULL;
   }
 
   static inline void* ReallocHook(void* ptr, size_t size) {
     Status s = Status(error::Code::UNIMPLEMENTED,
                       "Unimplemented case for hooking MKL function.");
     TF_CHECK_OK(s);  // way to assert with an error message
+    return NULL;
   }
 
   /// Do we allow growth in BFC Allocator

--- a/tensorflow/core/common_runtime/numa_device.cc
+++ b/tensorflow/core/common_runtime/numa_device.cc
@@ -1,0 +1,170 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/numa_device.h"
+
+#include "tensorflow/core/common_runtime/local_device.h"
+#include "tensorflow/core/framework/allocator.h"
+#include "tensorflow/core/framework/allocator_registry.h"
+#include "tensorflow/core/framework/device_base.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.pb_text.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/graph/types.h"
+#include "tensorflow/core/lib/hash/hash.h"
+#include "tensorflow/core/platform/tracing.h"
+#include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/public/session_options.h"
+
+#include <sys/syscall.h>
+#include <thread>
+
+#ifdef INTEL_MKL
+#include "tensorflow/core/common_runtime/mkl_cpu_allocator.h"
+#endif
+
+namespace tensorflow {
+
+static void *run_task(void *args) {
+  NumaDevice *device = (NumaDevice *)args;
+
+  // Set thread affinity
+  std::vector<int> &proc_set = device->run_state_.proc_set_;
+  omp_set_num_threads(proc_set.size());
+
+  int    thread_bound[proc_set.size()];
+  pid_t  thread_id   [proc_set.size()];
+
+  #pragma omp parallel num_threads(proc_set.size())
+  {
+    int omp_thread_id = omp_get_thread_num();
+    thread_id[omp_thread_id] = syscall(SYS_gettid);
+
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(proc_set[omp_thread_id], &cpuset);
+    pthread_t thread = pthread_self();
+    int s = pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
+    if (s != 0) {
+      std::cout << "Failed to set thread affinity\n";
+    }
+
+    // Check the actual affinity mask assigned to the thread 
+    s = pthread_getaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
+    if (s != 0){
+      std::cout << "failed to call pthread_getaffinity_np\n";
+    }
+    else {
+      for (int j = 0; j < CPU_SETSIZE; j++)
+        if (CPU_ISSET(j, &cpuset))
+          thread_bound[omp_thread_id] = j;
+    }
+  }
+
+  std::cout << "device = " << device->name() << " thread number = " << (int)proc_set.size() << ", bound to core:\n";
+  for(int i=0; i<(int)proc_set.size(); i++)
+    std::cout << "(" <<thread_bound[i]<<"," << " " << (unsigned long)thread_id[i] << ")\n";
+  std::cout << "\nFinish initialization\n";
+
+  while(device->run_state_.status_ != NumaDevice::Cancel) {
+    //std::cout << "device = " << (long) device << " status = " << device->run_state_.status_ << "\n";
+    if(device->run_state_.status_ == NumaDevice::RunTask) {
+      //std::cout << "NUMA device run task\n";
+      OpKernel* op_kernel      = device->run_state_.op_kernel_;
+      OpKernelContext* context = device->run_state_.context_;
+
+      // When TraceMe profiling is off (which is the default), the
+      // following TraceMe constructor is simply a conditional test of
+      // false value. Measurements show that its overhead is negligible.
+      port::Tracing::TraceMe trace_me(op_kernel->name(), op_kernel->type_string(),
+                                  op_kernel->IsExpensive());
+      if (port::Tracing::IsActive()) {
+        // TODO(pbar) We really need a useful identifier of the graph node.
+        const uint64 id = Hash64(op_kernel->name());
+        port::Tracing::ScopedActivity region(port::Tracing::EventCategory::kCompute,
+                                         id);
+        op_kernel->Compute(context);
+      } else {
+        op_kernel->Compute(context); 
+      }
+
+      device->run_state_.status_ = NumaDevice::NoTask;
+      //std::cout << "NUMA device run task done\n";
+      device->run_state_.notification_->Notify();
+    }
+    //sleep(1);
+    //nanosleep((const struct timespec[]){{0, 1L}}, NULL);
+  }
+
+  return NULL;
+}
+
+NumaDevice::NumaDevice(const SessionOptions& options,
+                                   const string& name, Bytes memory_limit,
+                                   const DeviceLocality& locality,
+                                   Allocator* allocator, std::vector<int> &proc_set)
+    : LocalDevice(options, proc_set, Device::BuildDeviceAttributes(
+                      name, DEVICE_CPU, memory_limit, locality)),
+      allocator_(allocator) {
+  std::cout << "***************In NumaDevice constructor\n";
+
+  run_state_.status_   = NumaDevice::NoTask;
+  run_state_.proc_set_ = proc_set;
+  pthread_create(&task_thread_, NULL, &run_task, this);
+}
+
+NumaDevice::~NumaDevice()
+{
+  run_state_.status_ = Cancel;
+}
+
+void NumaDevice::Compute(OpKernel* op_kernel, OpKernelContext* context) {
+  mutex_lock lock(mutex_);
+
+  //std::cout << "NumaDevice:: " << (long) this << " compute start\n";
+  Notification n;
+
+  run_state_.op_kernel_    = op_kernel;
+  run_state_.context_      = context;
+  run_state_.notification_ = &n;
+  run_state_.status_       = NumaDevice::RunTask;
+  n.WaitForNotification();
+
+  //std::cout << "NumaDevice:: " << (long) this << " compute done\n"; 
+}
+
+Allocator* NumaDevice::GetAllocator(AllocatorAttributes attr) {
+  return allocator_;
+}
+
+Status NumaDevice::MakeTensorFromProto(
+    const TensorProto& tensor_proto, const AllocatorAttributes alloc_attrs,
+    Tensor* tensor) {
+  if (tensor_proto.dtype() > 0 && tensor_proto.dtype() <= DataType_MAX) {
+    Tensor parsed(tensor_proto.dtype());
+    if (parsed.FromProto(cpu_allocator(), tensor_proto)) {
+      *tensor = std::move(parsed);
+      return Status::OK();
+    }
+  }
+  return errors::InvalidArgument("Cannot parse tensor from proto: ",
+                                 ProtoDebugString(tensor_proto));
+}
+
+#ifdef INTEL_MKL
+REGISTER_MEM_ALLOCATOR("MklCPUAllocator", 200, MklCPUAllocator);
+#endif
+
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/numa_device.h
+++ b/tensorflow/core/common_runtime/numa_device.h
@@ -1,0 +1,60 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMMON_RUNTIME_NUMA_DEVICE_H_
+#define TENSORFLOW_COMMON_RUNTIME_NUMA_DEVICE_H_
+
+#include "tensorflow/core/common_runtime/device_factory.h"
+#include "tensorflow/core/common_runtime/local_device.h"
+
+namespace tensorflow {
+
+// NUMA CPU device implementation.
+class NumaDevice : public LocalDevice {
+ public:
+  NumaDevice(const SessionOptions& options, const string& name,
+                   Bytes memory_limit, const DeviceLocality& locality,
+                   Allocator* allocator, std::vector<int> &proc_set);
+  ~NumaDevice() override;
+
+  void Compute(OpKernel* op_kernel, OpKernelContext* context) override;
+  Allocator* GetAllocator(AllocatorAttributes attr) override;
+  Status MakeTensorFromProto(const TensorProto& tensor_proto,
+                             const AllocatorAttributes alloc_attrs,
+                             Tensor* tensor) override;
+
+  Status Sync() override { return Status::OK(); }
+
+  typedef enum {NoTask, RunTask, Cancel} RunStatus;
+
+  struct RunState {
+    std::atomic<RunStatus>         status_;
+    OpKernel         *op_kernel_;
+    OpKernelContext  *context_;
+    Notification     *notification_;
+    std::vector<int>  proc_set_;
+  };
+
+  RunState   run_state_;
+
+ private:
+  Allocator  *allocator_;  // Not owned
+  pthread_t   task_thread_;
+  mutex       mutex_;
+};
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_COMMON_RUNTIME_NUMA_DEVICE_H_

--- a/tensorflow/core/common_runtime/numa_device_factory.cc
+++ b/tensorflow/core/common_runtime/numa_device_factory.cc
@@ -1,0 +1,80 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Register a factory that provides NUMA devices.
+#include "tensorflow/core/common_runtime/numa_device.h"
+
+#include <vector>
+#include "tensorflow/core/common_runtime/device_factory.h"
+#include "tensorflow/core/common_runtime/mkl_cpu_allocator.h"
+#include "tensorflow/core/framework/allocator.h"
+#include "tensorflow/core/public/session_options.h"
+
+namespace tensorflow {
+
+// TODO(zhifengc/tucker): Figure out the bytes of available RAM.
+class NumaDeviceFactory : public DeviceFactory {
+ public:
+  Status CreateDevices(const SessionOptions& options, const string& name_prefix,
+                       std::vector<Device*>* devices) override {
+    // TODO(zhifengc/tucker): Figure out the number of available CPUs
+    // and/or NUMA configuration.
+    int n = 0;
+    auto iter = options.config.device_count().find("NUMA");
+    if (iter != options.config.device_count().end()) {
+      n = iter->second;
+    }
+    int32 intra_op_parallelism_threads =
+        options.config.intra_op_parallelism_threads();
+    std::vector<int>  proc_set[2];
+    if(intra_op_parallelism_threads == 56) {
+     for(int i=0; i<intra_op_parallelism_threads/2; i++){
+        proc_set[0].push_back(i);
+        proc_set[1].push_back(i+28);
+      }
+
+     for(int i=0; i<intra_op_parallelism_threads/2; i++){
+        proc_set[0].push_back(i+56);
+        proc_set[1].push_back(i+84);
+      }
+
+      std::cout << "proc set 1:\n";
+      for(int i=0; i<proc_set[0].size(); i++)
+          std::cout << proc_set[0][i] << " ";
+      std::cout << "\nproc set 2:\n";
+      for(int i=0; i<proc_set[1].size(); i++)
+          std::cout << proc_set[1][i] << " ";
+      std::cout << "\n";
+    }
+    else {
+     for(int i=0; i<intra_op_parallelism_threads; i++){
+        proc_set[0].push_back(i);
+        proc_set[1].push_back(i+28);
+      }
+    }
+
+    for (int i = 0; i < n; i++) {
+      string name = strings::StrCat(name_prefix, "/device:NUMA:", i);
+      devices->push_back(new NumaDevice(
+          options, name, Bytes(256 << 20), DeviceLocality(), new MklCPUAllocator(), proc_set[i]));
+    }
+
+    return Status::OK();
+  }
+};
+
+REGISTER_LOCAL_DEVICE_FACTORY("NUMA", NumaDeviceFactory, 65);
+
+}  // namespace tensorflow

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2683,6 +2683,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
   // Op can run on CPU with MKL if the runtime assigned device or the
   // user requested device contains device CPU, or both are empty.
   bool CanOpRunOnCPUDevice(const Node* n) {
+    return true;
     bool result = true;
     string reason;
 

--- a/tensorflow/core/lib/core/threadpool.cc
+++ b/tensorflow/core/lib/core/threadpool.cc
@@ -87,9 +87,9 @@ struct EigenEnvironment {
 
 struct ThreadPool::Impl : Eigen::ThreadPoolTempl<EigenEnvironment> {
   Impl(Env* env, const ThreadOptions& thread_options, const string& name,
-       int num_threads, bool low_latency_hint)
+       int num_threads, std::vector<int> &proc_set, bool low_latency_hint)
       : Eigen::ThreadPoolTempl<EigenEnvironment>(
-            num_threads, low_latency_hint,
+            num_threads, proc_set, low_latency_hint,
             EigenEnvironment(env, thread_options, name)) {}
 
   void ParallelFor(int64 total, int64 cost_per_unit,
@@ -106,6 +106,15 @@ struct ThreadPool::Impl : Eigen::ThreadPoolTempl<EigenEnvironment> {
 ThreadPool::ThreadPool(Env* env, const string& name, int num_threads)
     : ThreadPool(env, ThreadOptions(), name, num_threads, true) {}
 
+
+ThreadPool::ThreadPool(Env* env, const string& name, 
+                       int num_threads, std::vector<int> &proc_set){
+  CHECK_GE(num_threads, 1);
+  impl_.reset(new ThreadPool::Impl(env, ThreadOptions(), "tf_" + name,
+                                   num_threads, proc_set, true));  
+}
+
+
 ThreadPool::ThreadPool(Env* env, const ThreadOptions& thread_options,
                        const string& name, int num_threads)
     : ThreadPool(env, thread_options, name, num_threads, true) {}
@@ -114,8 +123,9 @@ ThreadPool::ThreadPool(Env* env, const ThreadOptions& thread_options,
                        const string& name, int num_threads,
                        bool low_latency_hint) {
   CHECK_GE(num_threads, 1);
+  std::vector<int> proc_set;
   impl_.reset(new ThreadPool::Impl(env, thread_options, "tf_" + name,
-                                   num_threads, low_latency_hint));
+                                   num_threads, proc_set, low_latency_hint));
 }
 
 ThreadPool::~ThreadPool() {}

--- a/tensorflow/core/lib/core/threadpool.h
+++ b/tensorflow/core/lib/core/threadpool.h
@@ -45,6 +45,8 @@ class ThreadPool {
   // REQUIRES: num_threads > 0
   ThreadPool(Env* env, const string& name, int num_threads);
 
+  ThreadPool(Env* env, const string& name, int num_threads, std::vector<int> &proc_set);
+
   // Constructs a pool for low-latency ops that contains "num_threads" threads
   // with specified "name". env->StartThread() is used to create individual
   // threads with the given ThreadOptions.

--- a/tensorflow/core/util/device_name_utils.cc
+++ b/tensorflow/core/util/device_name_utils.cc
@@ -177,6 +177,17 @@ bool DeviceNameUtils::ParseFullName(StringPiece fullname, ParsedName* p) {
       progress = true;
     }
 
+    if (str_util::ConsumePrefix(&fullname, "/numa:") ||
+        str_util::ConsumePrefix(&fullname, "/NUMA:")) {
+      p->has_type = true;
+      p->type = "NUMA";  // Treat '/numa:..' as uppercase '/device:NUMA:...'
+      p->has_id = !str_util::ConsumePrefix(&fullname, "*");
+      if (p->has_id && !ConsumeNumber(&fullname, &p->id)) {
+        return false;
+      }
+      progress = true;
+    }
+
     if (!progress) {
       return false;
     }

--- a/tensorflow/python/framework/device.py
+++ b/tensorflow/python/framework/device.py
@@ -157,7 +157,7 @@ class DeviceSpec(object):
         elif ly == 2 and y[0] == "task":
           self.task = y[1]
         elif ((ly == 1 or ly == 2) and
-              ((y[0].upper() == "GPU") or (y[0].upper() == "CPU"))):
+              ((y[0].upper() == "GPU") or (y[0].upper() == "CPU") or (y[0].upper() == "NUMA"))):
           if self.device_type is not None:
             raise ValueError("Cannot specify multiple device types: %s" % spec)
           self.device_type = y[0].upper()


### PR DESCRIPTION
We noticed TensorFlow does not scale too much from single CPU socket to multiple CPU sockets. From the performance profiling, we found the memory traffic between NUMA nodes are very high. The latency from the remote memory access prevents TensorFlow from scaling to multiple NUMA nodes.

To fix this performance issue, we did a prototype to use data parallelism to improve the performance. A NumaDevice class has been added, all threads in a NumaDevice are pinned to the cores in one NUMA node, each NumaDevice has its own memory allocator. With the NumaDevice, most of the tensor are created and accessed by the same Numa node, the memory access should be local. 

The input data are evenly distributed to all NUMA nodes, the loss value and the gradient are computed on each Numa node and then the gradients from all Numa nodes are averaged and the variables are updated by these gradients. The variable update is done on all CPU cores.

This pull request contains a prototype to support NUMA aware CPU device. Some code are hacked to make it run. We want to send this pull request to get the comments about what we are doing.

From our initial performance test, ResNet 50 inference got **1.4x** speedup than the master branch on two socket Skylake. ResNet 50 training got **1.14x** speedup, which is lower than what we expected, we will continue working on it.

To make it compile, you need to copy NonBlockingThreadPool.h to compile cache directory/external/eigen_archive/unsupported/Eigen/CXX11/src/ThreadPool/. Also the benchmark script need be modified slightly. I can send you the instructions for changing the benchmark script.