### PR TITLE
Make tensorflow/python:framework_importer_test large

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1048,7 +1048,7 @@ py_test(
 
 py_test(
     name = "framework_importer_test",
-    size = "medium",
+    size = "large",
     srcs = ["framework/importer_test.py"],
     main = "framework/importer_test.py",
     srcs_version = "PY2AND3",


### PR DESCRIPTION
tensorflow/python:framework_importer_test sometime times out during release builds