### PR TITLE
Fix link

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -699,7 +699,7 @@ def convolution(
   `padded_input` is obtained by zero padding the input using an effective
   spatial filter shape of `(spatial_filter_shape-1) * dilation_rate + 1` and
   output striding `strides` as described in the
-  @{python.nn#Convolution$comment here}.
+  @{$python/nn#Convolution$comment here}.
 
   In the case that `data_format` does start with `"NC"`, the `input` and output
   (but not the `filter`) are simply transposed as follows:

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -699,7 +699,7 @@ def convolution(
   `padded_input` is obtained by zero padding the input using an effective
   spatial filter shape of `(spatial_filter_shape-1) * dilation_rate + 1` and
   output striding `strides` as described in the
-  @{tf.nn.convolution$comment here}.
+  @{python.nn#Convolution$comment here}.
 
   In the case that `data_format` does start with `"NC"`, the `input` and output
   (but not the `filter`) are simply transposed as follows:


### PR DESCRIPTION
Fix wrong link

from
https://www.tensorflow.org/api_docs/python/tf/nn/convolution
to 
https://www.tensorflow.org/api_guides/python/nn#Convolution

without the fix the link is kinda dangling:
>as described in the [comment here](https://www.tensorflow.org/api_docs/python/tf/nn/convolution).

in
https://www.tensorflow.org/api_docs/python/tf/nn/convolution
