### PR TITLE
Fix to 'Model' object has no attribute '_container_nodes' error when using tf.keras.utils.plot_model().

### DIFF
--- a/tensorflow/python/keras/_impl/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/_impl/keras/utils/vis_utils.py
@@ -120,7 +120,7 @@ def model_to_dot(model, show_shapes=False, show_layer_names=True, rankdir='TB'):
     layer_id = str(id(layer))
     for i, node in enumerate(layer._inbound_nodes):
       node_key = layer.name + '_ib-' + str(i)
-      if node_key in model._container_nodes:
+      if node_key in model._network_nodes:  # pylint: disable=protected-access
         for inbound_layer in node.inbound_layers:
           inbound_layer_id = str(id(inbound_layer))
           layer_id = str(id(layer))


### PR DESCRIPTION
Fix to #17633. Duplicate of #17658
'Model' object has no attribute '_container_nodes' error when using tf.keras.utils.plot_model().
Replaced
if node_key in model._container_nodes:
with
if node_key in model._network_nodes: # pylint: disable=protected-access

in tensorflow\python\keras_impl\keras\utils\vis_utils.py.