### PR TITLE
Fix broken link of tf.train.Example in recurrent_quickdraw.md

### DIFF
--- a/tensorflow/docs_src/tutorials/recurrent_quickdraw.md
+++ b/tensorflow/docs_src/tutorials/recurrent_quickdraw.md
@@ -109,7 +109,8 @@ This download will take a while and download a bit more than 23GB of data.
 
 To convert the `ndjson` files to
 @{$python/python_io#tfrecords_format_details$TFRecord} files containing
-${tf.train.Example} protos run the following command.
+[`tf.train.Example`](https://www.tensorflow.org/code/tensorflow/core/example/example.proto)
+protos run the following command.
 
 ```shell
    python create_dataset.py --ndjson_path rnn_tutorial_data \


### PR DESCRIPTION
In recurrent_quickdraw.md, the link `${tf.train.Example}` is not rendered correctly. This fix fixes the broken link with correct rendering. Now the link is rendered the same way as tf.train.Example in api_guides/python/reading_data.md and extend/new_data_formats.md

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>