### PR TITLE
Add zero padding option to `tf.image.extract_glimpse`

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_ExtractGlimpse.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ExtractGlimpse.pbtxt
@@ -54,7 +54,7 @@ END
     name: "noise"
     description: <<END
 indicates if the noise should `uniform`, `gaussian`, or
-`zero`. The default is `` which means the the noise type
+`zero`. The default is `uniform` which means the the noise type
 will be decided by `uniform_noise`.
 END
   }

--- a/tensorflow/core/api_def/base_api/api_def_ExtractGlimpse.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ExtractGlimpse.pbtxt
@@ -50,6 +50,14 @@ indicates if the noise should be generated using a
 uniform distribution or a Gaussian distribution.
 END
   }
+  attr {
+    name: "noise"
+    description: <<END
+indicates if the noise should `uniform`, `gaussian`, or
+`zero`. The default is `` which means the the noise type
+will be decided by `uniform_noise`.
+END
+  }
   summary: "Extracts a glimpse from the input tensor."
   description: <<END
 Returns a set of windows called glimpses extracted at location

--- a/tensorflow/core/api_def/python_api/api_def_ExtractGlimpse.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_ExtractGlimpse.pbtxt
@@ -1,6 +1,4 @@
 op {
   graph_op_name: "ExtractGlimpse"
-  endpoint {
-    name: "image.extract_glimpse"
-  }
+  visibility: HIDDEN
 }

--- a/tensorflow/core/kernels/attention_ops.cc
+++ b/tensorflow/core/kernels/attention_ops.cc
@@ -38,7 +38,7 @@ class ExtractGlimpseOp : public OpKernel {
     string noise;
     OP_REQUIRES_OK(context, context->GetAttr("uniform_noise", &uniform_noise));
     OP_REQUIRES_OK(context, context->GetAttr("noise", &noise));
-    OP_REQUIRES(context, !uniform_noise || noise == "",
+    OP_REQUIRES(context, !(uniform_noise && (noise != "" && noise != "uniform")),
                 errors::InvalidArgument("The uniform_noise and noise could not "
                                         "be specified at the same time"));
     if (noise == "") {

--- a/tensorflow/core/kernels/attention_ops.cc
+++ b/tensorflow/core/kernels/attention_ops.cc
@@ -38,7 +38,8 @@ class ExtractGlimpseOp : public OpKernel {
     string noise;
     OP_REQUIRES_OK(context, context->GetAttr("uniform_noise", &uniform_noise));
     OP_REQUIRES_OK(context, context->GetAttr("noise", &noise));
-    OP_REQUIRES(context, !(uniform_noise && (noise != "" && noise != "uniform")),
+    OP_REQUIRES(context,
+                !(uniform_noise && (noise != "" && noise != "uniform")),
                 errors::InvalidArgument("The uniform_noise and noise could not "
                                         "be specified at the same time"));
     if (noise == "") {

--- a/tensorflow/core/kernels/eigen_attention.h
+++ b/tensorflow/core/kernels/eigen_attention.h
@@ -145,8 +145,9 @@ struct GlimpseExtractionOp {
 
       if (partial_overlap) {
         if (noise_ == "zero") {
-           // Initialize the glimpse with zero noise.
-          output.template chip<3>(i).setZero();
+          // Initialize the glimpse with zero noise.
+          output.template chip<3>(i).device(device) =
+              output.template chip<3>(i).constant(0);
         } else if (noise_ == "uniform") {
            // Initialize the glimpse with uniform noise.
           typedef typename internal::remove_const<

--- a/tensorflow/core/kernels/eigen_attention.h
+++ b/tensorflow/core/kernels/eigen_attention.h
@@ -20,6 +20,13 @@ limitations under the License.
 
 namespace Eigen {
 
+// Noise mode used when padding.
+enum ExtractGlimpsesNoiseMode {
+  UNIFORM = 0,
+  GAUSSIAN = 1,
+  ZERO = 2,
+};
+
 /** ExtractGlimpses
  * \ingroup CXX11_NeuralNetworks_Module
  *
@@ -43,12 +50,13 @@ namespace Eigen {
  * for width and height which will be equal to the requested glimpse size.
  */
 namespace {
+
 template <typename Index>
 struct GlimpseExtractionOp {
   GlimpseExtractionOp(const Index width, const Index height,
                       const std::vector<IndexPair<float> >& offsets,
                       const bool normalized, const bool centered,
-                      const std::string &noise)
+                      const ExtractGlimpsesNoiseMode noise)
       : width_(width),
         height_(height),
         offsets_(offsets),
@@ -144,68 +152,73 @@ struct GlimpseExtractionOp {
       slice_extent[2] = std::min<Index>(input_height, slice_extent[2]);
 
       if (partial_overlap) {
-        if (noise_ == "zero") {
-          // Initialize the glimpse with zero noise.
-          output.template chip<3>(i).device(device) =
-              output.template chip<3>(i).constant(0);
-        } else if (noise_ == "uniform") {
-           // Initialize the glimpse with uniform noise.
-          typedef typename internal::remove_const<
-              typename internal::traits<Input>::Scalar>::type Scalar;
-          TensorFixedSize<Scalar, Sizes<> > mini;
-          mini.device(device) = input.template chip<3>(i).minimum();
-          TensorFixedSize<float, Sizes<> > range;
-          range.device(device) = (input.template chip<3>(i).maximum() - mini)
-                                     .template cast<float>();
-
-          DSizes<Index, 3> glimpse_size(num_channels, width_, height_);
-          TensorMap<Tensor<float, 3> > tmp(NULL, glimpse_size);
-          output.template chip<3>(i).device(device) =
-              mini.reshape(Sizes<1, 1, 1>()).broadcast(glimpse_size) +
-              (tmp.random(unigen) *
-               range.reshape(Sizes<1, 1, 1>()).broadcast(glimpse_size))
-                  .template cast<Scalar>();
-        } else {
-          // Initialize the glimpse with white noise: compute the mean and sigma
-          // of each channel, and use them to shape the gaussian.
-          DSizes<Index, 2> glimpse_size(width_, height_);
-          DSizes<Index, 2> input_size(input_width, input_height);
-          typedef typename internal::remove_const<
-              typename internal::traits<Input>::Scalar>::type Scalar;
-
-          for (int j = 0; j < num_channels; ++j) {
-            TensorFixedSize<Scalar, Sizes<> > mean;
-            mean.device(device) = input.template chip<3>(i)
-                                      .template chip<0>(j)
-                                      .template cast<float>()
-                                      .mean();
-            TensorFixedSize<float, Sizes<> > sigma;
-            sigma.device(device) =
-                (input.template chip<3>(i)
-                     .template chip<0>(j)
-                     .template cast<float>() -
-                 mean.reshape(Sizes<1, 1>()).broadcast(input_size))
-                    .square()
-                    .mean()
-                    .sqrt();
+        switch (noise_) {
+          case ZERO: {
+            // Initialize the glimpse with zero noise.
+            output.template chip<3>(i).device(device) =
+                output.template chip<3>(i).constant(0);
+          } break;
+          case UNIFORM: {
+            // Initialize the glimpse with uniform noise.
+            typedef typename internal::remove_const<
+                typename internal::traits<Input>::Scalar>::type Scalar;
             TensorFixedSize<Scalar, Sizes<> > mini;
-            mini.device(device) =
-                input.template chip<3>(i).template chip<0>(j).minimum();
-            TensorFixedSize<float, Sizes<> > maxi;
-            maxi.device(device) =
-                input.template chip<3>(i).template chip<0>(j).maximum();
+            mini.device(device) = input.template chip<3>(i).minimum();
+            TensorFixedSize<float, Sizes<> > range;
+            range.device(device) = (input.template chip<3>(i).maximum() - mini)
+                                       .template cast<float>();
 
-            TensorMap<Tensor<float, 2> > tmp(NULL, glimpse_size);
-            output.template chip<3>(i).template chip<0>(j).device(device) =
-                (mean.reshape(Sizes<1, 1>()).broadcast(glimpse_size) +
-                 (tmp.random(gen) *
-                  sigma.reshape(Sizes<1, 1>()).broadcast(glimpse_size))
-                     .template cast<Scalar>())
-                    .cwiseMin(
-                        maxi.reshape(Sizes<1, 1>()).broadcast(glimpse_size))
-                    .cwiseMax(
-                        mini.reshape(Sizes<1, 1>()).broadcast(glimpse_size));
-          }
+            DSizes<Index, 3> glimpse_size(num_channels, width_, height_);
+            TensorMap<Tensor<float, 3> > tmp(NULL, glimpse_size);
+            output.template chip<3>(i).device(device) =
+                mini.reshape(Sizes<1, 1, 1>()).broadcast(glimpse_size) +
+                (tmp.random(unigen) *
+                 range.reshape(Sizes<1, 1, 1>()).broadcast(glimpse_size))
+                    .template cast<Scalar>();
+          } break;
+          case GAUSSIAN: {
+            // Initialize the glimpse with white noise: compute the mean and
+            // sigma
+            // of each channel, and use them to shape the gaussian.
+            DSizes<Index, 2> glimpse_size(width_, height_);
+            DSizes<Index, 2> input_size(input_width, input_height);
+            typedef typename internal::remove_const<
+                typename internal::traits<Input>::Scalar>::type Scalar;
+
+            for (int j = 0; j < num_channels; ++j) {
+              TensorFixedSize<Scalar, Sizes<> > mean;
+              mean.device(device) = input.template chip<3>(i)
+                                        .template chip<0>(j)
+                                        .template cast<float>()
+                                        .mean();
+              TensorFixedSize<float, Sizes<> > sigma;
+              sigma.device(device) =
+                  (input.template chip<3>(i)
+                       .template chip<0>(j)
+                       .template cast<float>() -
+                   mean.reshape(Sizes<1, 1>()).broadcast(input_size))
+                      .square()
+                      .mean()
+                      .sqrt();
+              TensorFixedSize<Scalar, Sizes<> > mini;
+              mini.device(device) =
+                  input.template chip<3>(i).template chip<0>(j).minimum();
+              TensorFixedSize<float, Sizes<> > maxi;
+              maxi.device(device) =
+                  input.template chip<3>(i).template chip<0>(j).maximum();
+
+              TensorMap<Tensor<float, 2> > tmp(NULL, glimpse_size);
+              output.template chip<3>(i).template chip<0>(j).device(device) =
+                  (mean.reshape(Sizes<1, 1>()).broadcast(glimpse_size) +
+                   (tmp.random(gen) *
+                    sigma.reshape(Sizes<1, 1>()).broadcast(glimpse_size))
+                       .template cast<Scalar>())
+                      .cwiseMin(
+                          maxi.reshape(Sizes<1, 1>()).broadcast(glimpse_size))
+                      .cwiseMax(
+                          mini.reshape(Sizes<1, 1>()).broadcast(glimpse_size));
+            }
+          } break;
         }
 
         // Copy the part of the glimpse that cover the input image if any.
@@ -229,7 +242,7 @@ struct GlimpseExtractionOp {
   const std::vector<IndexPair<float> > offsets_;
   const bool normalized_;
   const bool centered_;
-  const std::string noise_;
+  const ExtractGlimpsesNoiseMode noise_;
 };
 }  // namespace
 
@@ -237,12 +250,12 @@ template <typename Input>
 EIGEN_ALWAYS_INLINE static const TensorCustomUnaryOp<
     const GlimpseExtractionOp<typename internal::traits<Input>::Index>,
     const Input>
-ExtractGlimpses(const Input& input,
-                const typename internal::traits<Input>::Index width,
-                const typename internal::traits<Input>::Index height,
-                const std::vector<IndexPair<float> >& offsets,
-                const bool normalized = true, const bool centered = true,
-                const std::string &noise = "uniform") {
+ExtractGlimpses(
+    const Input& input, const typename internal::traits<Input>::Index width,
+    const typename internal::traits<Input>::Index height,
+    const std::vector<IndexPair<float> >& offsets, const bool normalized = true,
+    const bool centered = true,
+    const ExtractGlimpsesNoiseMode noise = ExtractGlimpsesNoiseMode::UNIFORM) {
   EIGEN_STATIC_ASSERT(internal::traits<Input>::Layout == ColMajor,
                       YOU_MADE_A_PROGRAMMING_MISTAKE);
   EIGEN_STATIC_ASSERT(internal::traits<Input>::NumDimensions == 4,

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -606,7 +606,7 @@ REGISTER_OP("ExtractGlimpse")
     .Attr("centered: bool = true")
     .Attr("normalized: bool = true")
     .Attr("uniform_noise: bool = true")
-    .Attr("noise: string = ''")
+    .Attr("noise: string = 'uniform'")
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle input;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &input));
@@ -623,7 +623,7 @@ REGISTER_OP("ExtractGlimpse")
       TF_RETURN_IF_ERROR(c->GetAttr("uniform_noise", &uniform_noise));
       string noise;
       TF_RETURN_IF_ERROR(c->GetAttr("noise", &noise));
-      if (uniform_noise && noise != "") {
+      if (uniform_noise && (noise != "" && noise != "uniform")) {
         return errors::InvalidArgument(
             "The uniform_noise and noise should not be specified at the same "
             "time");

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -624,7 +624,9 @@ REGISTER_OP("ExtractGlimpse")
       string noise;
       TF_RETURN_IF_ERROR(c->GetAttr("noise", &noise));
       if (uniform_noise && noise != "") {
-        return errors::InvalidArgument("The uniform_noise and noise should not be specified at the same time");
+        return errors::InvalidArgument(
+            "The uniform_noise and noise should not be specified at the same "
+            "time");
       }
 
       return SetOutputToSizedImage(c, batch_dim, 1 /* size_input_idx */,

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -624,7 +624,7 @@ REGISTER_OP("ExtractGlimpse")
       string noise;
       TF_RETURN_IF_ERROR(c->GetAttr("noise", &noise));
       if (uniform_noise && noise != "") {
-        return errors::InvalidArgument("The uniform_noise and noise could not be specified at the same time");
+        return errors::InvalidArgument("The uniform_noise and noise should not be specified at the same time");
       }
 
       return SetOutputToSizedImage(c, batch_dim, 1 /* size_input_idx */,

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -606,6 +606,7 @@ REGISTER_OP("ExtractGlimpse")
     .Attr("centered: bool = true")
     .Attr("normalized: bool = true")
     .Attr("uniform_noise: bool = true")
+    .Attr("noise: string = ''")
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle input;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &input));
@@ -617,6 +618,14 @@ REGISTER_OP("ExtractGlimpse")
           c->Merge(c->Dim(input, 0), c->Dim(offsets, 0), &batch_dim));
       DimensionHandle unused;
       TF_RETURN_IF_ERROR(c->WithValue(c->Dim(offsets, 1), 2, &unused));
+
+      bool uniform_noise = false;
+      TF_RETURN_IF_ERROR(c->GetAttr("uniform_noise", &uniform_noise));
+      string noise;
+      TF_RETURN_IF_ERROR(c->GetAttr("noise", &noise));
+      if (uniform_noise && noise != "") {
+        return errors::InvalidArgument("The uniform_noise and noise could not be specified at the same time");
+      }
 
       return SetOutputToSizedImage(c, batch_dim, 1 /* size_input_idx */,
                                    c->Dim(input, 3));

--- a/tensorflow/core/ops/image_ops_test.cc
+++ b/tensorflow/core/ops/image_ops_test.cc
@@ -183,6 +183,13 @@ TEST(ImageOpsTest, ExtractGlimpse_ShapeFn) {
   op.input_tensors.resize(2);
 
   // Inputs are input, size, offsets.
+  TF_ASSERT_OK(NodeDefBuilder("test", "ExtractGlimpse")
+                   .Input({"input", 0, DT_FLOAT})
+                   .Input({"size", 1, DT_INT32})
+                   .Input({"offsets", 2, DT_FLOAT})
+                   .Attr("uniform_noise", true)
+                   .Attr("noise", "")
+                   .Finalize(&op.node_def));
 
   // Rank and size checks.
   INFER_ERROR("Shape must be rank 4 but is rank 5", op, "[1,2,3,4,5];?;?");

--- a/tensorflow/python/kernel_tests/attention_ops_test.py
+++ b/tensorflow/python/kernel_tests/attention_ops_test.py
@@ -210,9 +210,9 @@ class ExtractGlimpseTest(test.TestCase):
       # [ 0.  0.  0.]
       # [ 0.  0.  0.]
       # [ 0.  0.  0.]
-      result1 = image_ops.extract_glimpse(img, [3, 3], [[-2, 2]],
-                                          centered=False, normalized=False,
-                                          uniform_noise=False, noise="zero")
+      result1 = image_ops.extract_glimpse_v2(img, [3, 3], [[-2, 2]],
+                                             centered=False, normalized=False,
+                                             noise="zero")
       self.assertAllEqual(np.asarray([[0, 0, 0],
                                       [0, 0, 0],
                                       [0, 0, 0]]),
@@ -226,9 +226,9 @@ class ExtractGlimpseTest(test.TestCase):
       # [  0.  15.  16.  17.  18.  19.   0.]
       # [  0.  20.  21.  22.  23.  24.   0.]
       # [  0.   0.   0.   0.   0.   0.   0.]]
-      result2 = image_ops.extract_glimpse(img, [7, 7], [[0, 0]],
-                                          normalized=False,
-                                          uniform_noise=False, noise="zero")
+      result2 = image_ops.extract_glimpse_v2(img, [7, 7], [[0, 0]],
+                                             normalized=False,
+                                             noise="zero")
       self.assertAllEqual(np.asarray([[0, 0, 0, 0, 0, 0, 0],
                                       [0, 0, 1, 2, 3, 4, 0],
                                       [0, 5, 6, 7, 8, 9, 0],

--- a/tensorflow/python/kernel_tests/attention_ops_test.py
+++ b/tensorflow/python/kernel_tests/attention_ops_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import image_ops
 from tensorflow.python.platform import test
@@ -194,6 +195,16 @@ class ExtractGlimpseTest(test.TestCase):
         offsets=[-1, 0.9],
         expected_rows=[None, None, None, 1, 2, 3, 4],
         expected_cols=[56, 57, 58, 59, 60])
+
+  def testGlimpseNoOverlapZero(self):
+    img = constant_op.constant(np.arange(25).reshape((1, 5, 5, 1)),
+                               dtype=dtypes.float32)
+    with self.test_session():
+      result = image_ops.extract_glimpse(img, [3, 3], [[-2, 2]],
+                                         centered=False, normalized=False,
+                                         uniform_noise=False, noise="zero")
+      self.assertAllEqual(np.asarray([[0, 0, 0], [0, 0, 0], [0, 0, 0]]),
+                          result.eval()[0, :, :, 0])
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/kernel_tests/attention_ops_test.py
+++ b/tensorflow/python/kernel_tests/attention_ops_test.py
@@ -196,15 +196,47 @@ class ExtractGlimpseTest(test.TestCase):
         expected_rows=[None, None, None, 1, 2, 3, 4],
         expected_cols=[56, 57, 58, 59, 60])
 
-  def testGlimpseNoOverlapZero(self):
+  def testGlimpseNoiseZero(self):
+    # Image:
+    # [  0.   1.   2.   3.   4.]
+    # [  5.   6.   7.   8.   9.]
+    # [ 10.  11.  12.  13.  14.]
+    # [ 15.  16.  17.  18.  19.]
+    # [ 20.  21.  22.  23.  24.]
     img = constant_op.constant(np.arange(25).reshape((1, 5, 5, 1)),
                                dtype=dtypes.float32)
     with self.test_session():
-      result = image_ops.extract_glimpse(img, [3, 3], [[-2, 2]],
-                                         centered=False, normalized=False,
-                                         uniform_noise=False, noise="zero")
-      self.assertAllEqual(np.asarray([[0, 0, 0], [0, 0, 0], [0, 0, 0]]),
-                          result.eval()[0, :, :, 0])
+      # Result 1:
+      # [ 0.  0.  0.]
+      # [ 0.  0.  0.]
+      # [ 0.  0.  0.]
+      result1 = image_ops.extract_glimpse(img, [3, 3], [[-2, 2]],
+                                          centered=False, normalized=False,
+                                          uniform_noise=False, noise="zero")
+      self.assertAllEqual(np.asarray([[0, 0, 0],
+                                      [0, 0, 0],
+                                      [0, 0, 0]]),
+                          result1.eval()[0, :, :, 0])
+
+      # Result 2:
+      # [  0.   0.   0.   0.   0.   0.   0.]
+      # [  0.   0.   1.   2.   3.   4.   0.]
+      # [  0.   5.   6.   7.   8.   9.   0.]
+      # [  0.  10.  11.  12.  13.  14.   0.]
+      # [  0.  15.  16.  17.  18.  19.   0.]
+      # [  0.  20.  21.  22.  23.  24.   0.]
+      # [  0.   0.   0.   0.   0.   0.   0.]]
+      result2 = image_ops.extract_glimpse(img, [7, 7], [[0, 0]],
+                                          normalized=False,
+                                          uniform_noise=False, noise="zero")
+      self.assertAllEqual(np.asarray([[0, 0, 0, 0, 0, 0, 0],
+                                      [0, 0, 1, 2, 3, 4, 0],
+                                      [0, 5, 6, 7, 8, 9, 0],
+                                      [0, 10, 11, 12, 13, 14, 0],
+                                      [0, 15, 16, 17, 18, 19, 0],
+                                      [0, 20, 21, 22, 23, 24, 0],
+                                      [0, 0, 0, 0, 0, 0, 0]]),
+                          result2.eval()[0, :, :, 0])
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3079,8 +3079,56 @@ def extract_glimpse(
     centered=True,
     normalized=True,
     uniform_noise=True,
-    name=None,
-    noise=""):
+    name=None):
+  """Extracts a glimpse from the input tensor.
+
+  Returns a set of windows called glimpses extracted at location
+  `offsets` from the input tensor. If the windows only partially
+  overlaps the inputs, the non overlapping areas will be filled with
+  random noise.
+
+  The result is a 4-D tensor of shape `[batch_size, glimpse_height,
+  glimpse_width, channels]`. The channels and batch dimensions are the
+  same as that of the input tensor. The height and width of the output
+  windows are specified in the `size` parameter.
+
+  The argument `normalized` and `centered` controls how the windows are built:
+
+  * If the coordinates are normalized but not centered, 0.0 and 1.0
+    correspond to the minimum and maximum of each height and width
+    dimension.
+  * If the coordinates are both normalized and centered, they range from
+    -1.0 to 1.0. The coordinates (-1.0, -1.0) correspond to the upper
+    left corner, the lower right corner is located at (1.0, 1.0) and the
+    center is at (0, 0).
+  * If the coordinates are not normalized they are interpreted as
+    numbers of pixels.
+
+  Args:
+    input: A `Tensor` of type `float32`.
+      A 4-D float tensor of shape `[batch_size, height, width, channels]`.
+    size: A `Tensor` of type `int32`.
+      A 1-D tensor of 2 elements containing the size of the glimpses
+      to extract.  The glimpse height must be specified first, following
+      by the glimpse width.
+    offsets: A `Tensor` of type `float32`.
+      A 2-D integer tensor of shape `[batch_size, 2]` containing
+      the y, x locations of the center of each window.
+    centered: An optional `bool`. Defaults to `True`.
+      indicates if the offset coordinates are centered relative to
+      the image, in which case the (0, 0) offset is relative to the center
+      of the input images. If false, the (0,0) offset corresponds to the
+      upper left corner of the input images.
+    normalized: An optional `bool`. Defaults to `True`.
+      indicates if the offset coordinates are normalized.
+    uniform_noise: An optional `bool`. Defaults to `True`.
+      indicates if the noise should be generated using a
+      uniform distribution or a Gaussian distribution.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of type `float32`.
+  """
   return gen_image_ops.extract_glimpse(
       input=input,
       size=size,
@@ -3088,10 +3136,72 @@ def extract_glimpse(
       centered=centered,
       normalized=normalized,
       uniform_noise=uniform_noise,
-      noise=noise,
       name=name)
 
-extract_glimpse.__doc__ = gen_image_ops.extract_glimpse.__doc__
+@tf_export("image.extract_glimpse", v1=[])
+def extract_glimpse_v2(
+    input, # pylint: disable=redefined-builtin
+    size,
+    offsets,
+    centered=True,
+    normalized=True,
+    noise="uniform",
+    name=None):
+  """Extracts a glimpse from the input tensor.
 
-extract_glimpse_v2 = gen_image_ops.extract_glimpse
-tf_export('image.extract_glimpse', v1=[])(extract_glimpse_v2)
+  Returns a set of windows called glimpses extracted at location
+  `offsets` from the input tensor. If the windows only partially
+  overlaps the inputs, the non overlapping areas will be filled with
+  random noise.
+
+  The result is a 4-D tensor of shape `[batch_size, glimpse_height,
+  glimpse_width, channels]`. The channels and batch dimensions are the
+  same as that of the input tensor. The height and width of the output
+  windows are specified in the `size` parameter.
+
+  The argument `normalized` and `centered` controls how the windows are built:
+
+  * If the coordinates are normalized but not centered, 0.0 and 1.0
+    correspond to the minimum and maximum of each height and width
+    dimension.
+  * If the coordinates are both normalized and centered, they range from
+    -1.0 to 1.0. The coordinates (-1.0, -1.0) correspond to the upper
+    left corner, the lower right corner is located at (1.0, 1.0) and the
+    center is at (0, 0).
+  * If the coordinates are not normalized they are interpreted as
+    numbers of pixels.
+
+  Args:
+    input: A `Tensor` of type `float32`.
+      A 4-D float tensor of shape `[batch_size, height, width, channels]`.
+    size: A `Tensor` of type `int32`.
+      A 1-D tensor of 2 elements containing the size of the glimpses
+      to extract.  The glimpse height must be specified first, following
+      by the glimpse width.
+    offsets: A `Tensor` of type `float32`.
+      A 2-D integer tensor of shape `[batch_size, 2]` containing
+      the y, x locations of the center of each window.
+    centered: An optional `bool`. Defaults to `True`.
+      indicates if the offset coordinates are centered relative to
+      the image, in which case the (0, 0) offset is relative to the center
+      of the input images. If false, the (0,0) offset corresponds to the
+      upper left corner of the input images.
+    normalized: An optional `bool`. Defaults to `True`.
+      indicates if the offset coordinates are normalized.
+    noise: An optional `string`. Defaults to `uniform`.
+      indicates if the noise should be `uniform` (uniform distribution),
+      `gaussian` (gaussian distribution), or `zero` (zero padding).
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of type `float32`.
+  """
+  return gen_image_ops.extract_glimpse(
+      input=input,
+      size=size,
+      offsets=offsets,
+      centered=centered,
+      normalized=normalized,
+      noise=noise,
+      uniform_noise=False,
+      name=name)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3093,5 +3093,5 @@ def extract_glimpse(
 
 extract_glimpse.__doc__ = gen_image_ops.extract_glimpse.__doc__
 
-extract_glimpse_v2=gen_image_ops.extract_glimpse
+extract_glimpse_v2 = gen_image_ops.extract_glimpse
 tf_export(v2=['image.extract_glimpse'])(extract_glimpse_v2)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3094,4 +3094,4 @@ def extract_glimpse(
 extract_glimpse.__doc__ = gen_image_ops.extract_glimpse.__doc__
 
 extract_glimpse_v2 = gen_image_ops.extract_glimpse
-tf_export(v2=['image.extract_glimpse'])(extract_glimpse_v2)
+tf_export('image.extract_glimpse', v1=[])(extract_glimpse_v2)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3070,3 +3070,25 @@ crop_and_resize_deprecation = deprecation.deprecated_args(
     None, 'box_ind is deprecated, use box_indices instead', 'box_ind')
 tf_export(v1=['image.crop_and_resize'])(
     crop_and_resize_deprecation(gen_image_ops.crop_and_resize))
+
+@tf_export('image.extract_glimpse')
+def extract_glimpse(
+    input,
+    size,
+    offsets,
+    centered=True,
+    normalized=True,
+    uniform_noise=True,
+    name=None,
+    noise=""):
+  return gen_image_ops.extract_glimpse(
+      input=input,
+      size=size,
+      offsets=offsets,
+      centered=centered,
+      normalized=normalized,
+      uniform_noise=uniform_noise,
+      noise=noise,
+      name=name)
+
+extract_glimpse.__doc__ = gen_image_ops.extract_glimpse.__doc__

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3071,9 +3071,9 @@ crop_and_resize_deprecation = deprecation.deprecated_args(
 tf_export(v1=['image.crop_and_resize'])(
     crop_and_resize_deprecation(gen_image_ops.crop_and_resize))
 
-@tf_export('image.extract_glimpse')
+@tf_export(v1=['image.extract_glimpse'])
 def extract_glimpse(
-    input,
+    input, # pylint: disable=redefined-builtin
     size,
     offsets,
     centered=True,
@@ -3092,3 +3092,6 @@ def extract_glimpse(
       name=name)
 
 extract_glimpse.__doc__ = gen_image_ops.extract_glimpse.__doc__
+
+extract_glimpse_v2=gen_image_ops.extract_glimpse
+tf_export(v2=['image.extract_glimpse'])(extract_glimpse_v2)

--- a/tensorflow/tools/api/golden/v1/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.image.pbtxt
@@ -82,7 +82,7 @@ tf_module {
   }
   member_method {
     name: "extract_glimpse"
-    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'name\', \'noise\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'None\', \'\'], "
+    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'None\'], "
   }
   member_method {
     name: "extract_image_patches"

--- a/tensorflow/tools/api/golden/v1/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.image.pbtxt
@@ -82,7 +82,7 @@ tf_module {
   }
   member_method {
     name: "extract_glimpse"
-    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'None\'], "
+    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'\', \'None\'], "
   }
   member_method {
     name: "extract_image_patches"

--- a/tensorflow/tools/api/golden/v1/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.image.pbtxt
@@ -82,7 +82,7 @@ tf_module {
   }
   member_method {
     name: "extract_glimpse"
-    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'\', \'None\'], "
+    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'name\', \'noise\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'None\', \'\'], "
   }
   member_method {
     name: "extract_image_patches"

--- a/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
@@ -82,7 +82,7 @@ tf_module {
   }
   member_method {
     name: "extract_glimpse"
-    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'\', \'None\'], "
+    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'uniform\', \'None\'], "
   }
   member_method {
     name: "extract_image_patches"

--- a/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
@@ -82,7 +82,7 @@ tf_module {
   }
   member_method {
     name: "extract_glimpse"
-    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'None\'], "
+    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'\', \'None\'], "
   }
   member_method {
     name: "extract_image_patches"

--- a/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
@@ -81,6 +81,10 @@ tf_module {
     argspec: "args=[\'image\', \'compression\', \'name\'], varargs=None, keywords=None, defaults=[\'-1\', \'None\'], "
   }
   member_method {
+    name: "extract_glimpse"
+    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'\', \'None\'], "
+  }
+  member_method {
     name: "extract_image_patches"
     argspec: "args=[\'images\', \'sizes\', \'strides\', \'rates\', \'padding\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
@@ -81,10 +81,6 @@ tf_module {
     argspec: "args=[\'image\', \'compression\', \'name\'], varargs=None, keywords=None, defaults=[\'-1\', \'None\'], "
   }
   member_method {
-    name: "extract_glimpse"
-    argspec: "args=[\'input\', \'size\', \'offsets\', \'centered\', \'normalized\', \'uniform_noise\', \'noise\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'True\', \'True\', \'\', \'None\'], "
-  }
-  member_method {
     name: "extract_image_patches"
     argspec: "args=[\'images\', \'sizes\', \'strides\', \'rates\', \'padding\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/compatibility/tf_upgrade_v2.py
+++ b/tensorflow/tools/compatibility/tf_upgrade_v2.py
@@ -794,7 +794,7 @@ class TFAPIChangeSpec(ast_edits.APIChangeSpec):
         "tf.image.resize_bicubic": self._image_resize_transformer,
         "tf.image.resize_bilinear": self._image_resize_transformer,
         "tf.image.resize_nearest_neighbor": self._image_resize_transformer,
-
+        "tf.image.extract_glimpse": self._extract_glimpse_transformer,
     }
 
     decay_function_comment = (
@@ -1265,6 +1265,48 @@ class TFAPIChangeSpec(ast_edits.APIChangeSpec):
                  "Please check this transformation.\n" % (name, name)))
 
     return node
+
+  @staticmethod
+  def _extract_glimpse_transformer(parent, node, full_name, name, logs):
+    def _replace_uniform_noise_node(parent, old_value):
+      """Replaces old_value with 'uniform' or 'guassian'."""
+      uniform = ast.Str(s="uniform")
+      gaussian = ast.Str(s="gaussian")
+      new_value = ast.IfExp(body=uniform, test=old_value,
+                            orelse=gaussian)
+      # This copies the prefix and suffix on old_value to new_value.
+      pasta.ast_utils.replace_child(parent, old_value, new_value)
+      ast.copy_location(new_value, old_value)
+      # Put parentheses around noise.value (and remove the old prefix/
+      # suffix, they should only be around new_value).
+      pasta.base.formatting.set(new_value, "prefix", "(")
+      pasta.base.formatting.set(new_value, "suffix", ")")
+
+    # Check if we have a uniform_noise keyword arg
+    for uniform_noise in node.keywords:
+      if uniform_noise.arg == "uniform_noise":
+        logs.append((ast_edits.INFO, node.lineno, node.col_offset,
+                     "Changing uniform_noise arg of tf.image.extract_glimpse "
+                     "to noise, and recomputing value. Please check this "
+                     "transformation.\n"))
+        uniform_noise.arg = "noise"
+        value = "uniform" if uniform_noise.value else "gaussian"
+        _replace_uniform_noise_node(uniform_noise, uniform_noise.value)
+        return node
+
+    # Maybe it was a positional arg
+    if len(node.args) < 5:
+      logs.append((ast_edits.ERROR, node.lineno, node.col_offset,
+                   "tf.image.extract_glimpse called without "
+                   "arguments, so automatic fix was disabled. "
+                   "tf.image.extract_glimpse has changed the semantics "
+                   "of the sxth argument."))
+    else:
+      _replace_uniform_noise_node(node, node.args[5])
+      logs.append((ast_edits.INFO, node.lineno, node.col_offset,
+                   "Changing uniform_noise arg of tf.image.extract_glimpse to "
+                   "noise, and recomputing value.\n"))
+      return node
 
   @staticmethod
   def _dropout_transformer(parent, node, full_name, name, logs):

--- a/tensorflow/tools/compatibility/tf_upgrade_v2.py
+++ b/tensorflow/tools/compatibility/tf_upgrade_v2.py
@@ -1277,10 +1277,11 @@ class TFAPIChangeSpec(ast_edits.APIChangeSpec):
       # This copies the prefix and suffix on old_value to new_value.
       pasta.ast_utils.replace_child(parent, old_value, new_value)
       ast.copy_location(new_value, old_value)
-      # Put parentheses around noise.value (and remove the old prefix/
-      # suffix, they should only be around new_value).
-      pasta.base.formatting.set(new_value, "prefix", "(")
-      pasta.base.formatting.set(new_value, "suffix", ")")
+      # Put parentheses around noise.value.test (and remove the old prefix/
+      # suffix, they should only be around new_value.test), so that:
+      # "uniform" if (a if b else c) else "gaussian" is valid.
+      pasta.base.formatting.set(new_value.test, "prefix", "(")
+      pasta.base.formatting.set(new_value.test, "suffix", ")")
 
     # Check if we have a uniform_noise keyword arg
     for uniform_noise in node.keywords:
@@ -1294,14 +1295,9 @@ class TFAPIChangeSpec(ast_edits.APIChangeSpec):
         _replace_uniform_noise_node(uniform_noise, uniform_noise.value)
         return node
 
-    # Maybe it was a positional arg
-    if len(node.args) < 5:
-      logs.append((ast_edits.ERROR, node.lineno, node.col_offset,
-                   "tf.image.extract_glimpse called without "
-                   "arguments, so automatic fix was disabled. "
-                   "tf.image.extract_glimpse has changed the semantics "
-                   "of the sxth argument."))
-    else:
+    # Since `noise`/`uniform_noise` is optional arg, nothing needs to be
+    # done if len(node.args) < 5.
+    if len(node.args) >= 5:
       _replace_uniform_noise_node(node, node.args[5])
       logs.append((ast_edits.INFO, node.lineno, node.col_offset,
                    "Changing uniform_noise arg of tf.image.extract_glimpse to "


### PR DESCRIPTION
There has been several feature request in #16663 and https://github.com/tensorflow/tensorflow/issues/2134#issuecomment-326071624 asking for zero padding option to `tf.image.extract_glimpse`.

This fix is an attempt to address the issue through:
1. Add an additional args of `noise` so that it is possible to specify `uniform`, `gaussian`, or `zero`.
2. In case `zero` is specified, extract_glimpse will fill padding with zeros.

Note this PR keeps the original arg `uniform_noise` intact (unless it conflict with `noise`), though it is possible to deprecate the `uniform_noise` if desired.

This fix fixes #16663.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>