### PR TITLE
Fix floating point exception when loading from a small events log file using the loader

### DIFF
--- a/tensorflow/contrib/tensorboard/db/loader.cc
+++ b/tensorflow/contrib/tensorboard/db/loader.cc
@@ -111,11 +111,10 @@ int main(int argc, char* argv[]) {
     ++records;
   }
   uint64 elapsed = env->NowMicros() - start;
+  uint64 bps = (elapsed == 0 ? offset : static_cast<uint64>(
+                                            offset / (elapsed / 1000000.0)));
   LOG(INFO) << "Loaded " << AddCommas(offset) << " bytes with "
-            << AddCommas(records) << " records at "
-            << (elapsed == 0 ? offset : static_cast<uint64>(
-                                            offset / (elapsed / 1000000.0)))
-            << " bps";
+            << AddCommas(records) << " records at " << AddCommas(bps) << " bps";
   return 0;
 }
 

--- a/tensorflow/contrib/tensorboard/db/loader.cc
+++ b/tensorflow/contrib/tensorboard/db/loader.cc
@@ -112,11 +112,10 @@ int main(int argc, char* argv[]) {
   }
   uint64 elapsed = env->NowMicros() - start;
   LOG(INFO) << "Loaded " << AddCommas(offset) << " bytes with "
-            << AddCommas(records) << " records";
-  if (elapsed > 0) {
-    LOG(INFO) << "bps=" << (uint64)(offset / (elapsed / 1000000.0));
-  }
-
+            << AddCommas(records) << " records at "
+            << (elapsed == 0 ? offset : static_cast<uint64>(
+                                            offset / (elapsed / 1000000.0)))
+            << " bps";
   return 0;
 }
 

--- a/tensorflow/contrib/tensorboard/db/loader.cc
+++ b/tensorflow/contrib/tensorboard/db/loader.cc
@@ -112,8 +112,10 @@ int main(int argc, char* argv[]) {
   }
   uint64 elapsed = env->NowMicros() - start;
   LOG(INFO) << "Loaded " << AddCommas(offset) << " bytes with "
-            << AddCommas(records) << " records at "
-            << AddCommas(offset / (elapsed / 1000000)) << " bps";
+            << AddCommas(records) << " records";
+  if (elapsed > 0) {
+    LOG(INFO) << "bps=" << (uint64)(offset / (elapsed / 1000000.0));
+  }
 
   return 0;
 }


### PR DESCRIPTION
Issue:  Floating point exception when using the loader to load some data from a small events log file

- Fixed the bps calculation to guard against div by 0
- Tested this manually with the different size logs we have from our experiment.

If you have suggestions or a recommended way to add a unit test for the loader, I'd be glad to look into it.  Please let me know. Thanks.

TESTING:
For now, I have tested this manually with the logs we have from our experiment.

**With Fix:**
 ```
./loader --events=/data_location/experiments/mitoses/jan/events.out.tfevents.xyz.com --db=/db_location/tb/db/test14db --experiment_name=test --run_name=run1 --user_name=s
<snipped>
2018-03-29 10:58:59.092540: I tensorflow/contrib/tensorboard/db/loader.cc:116] Loaded 624,975 bytes with 31 records at 2,130,206 bps
```

Empty events file: 
```
./loader --events=test --db=/db_location/tb/db/test14db --experiment_name=test --run_name=run1 --user_name=s
<snipped>
2018-03-29 12:20:03.849826: I tensorflow/contrib/tensorboard/db/loader.cc:116] Loaded 0 bytes with 0 records at 0 bps
```

**Without Fix:**
```
./loader --events=/data_location/experiments/mitoses/jan/events.out.tfevents.xyz.com --db=/db_location/tb/db/test14db --experiment_name=test --run_name=run1 --user_name=s
2018-03-13 11:53:35.910348: I tensorflow/contrib/tensorboard/db/loader.cc:75] Opening SQLite file: /db_location/tb/db/test14db
2018-03-13 11:53:35.911059: I tensorflow/contrib/tensorboard/db/loader.cc:82] Initializing TensorBoard schema
2018-03-13 11:53:35.914771: I tensorflow/contrib/tensorboard/db/loader.cc:85] Creating SummaryDbWriter
2018-03-13 11:53:35.914792: I tensorflow/contrib/tensorboard/db/loader.cc:91] Loading TF event log: /data_location/experiments/mitoses/jan/events.out.tfevents.xyz.com
Floating point exception: 8
```