### PR TITLE
Fix folding unfused batchnorm bug

### DIFF
--- a/tensorflow/contrib/quantize/python/fold_batch_norms.py
+++ b/tensorflow/contrib/quantize/python/fold_batch_norms.py
@@ -544,7 +544,7 @@ def _GetBatchNormParams(graph, context, has_scaling):
         gamma_tensor = graph.get_tensor_by_name(op.name + ':0')
 
   if not has_scaling:
-    gamma_tensor = array_ops.ones(batch_mean_tensor.shape)
+    gamma_tensor = array_ops.ones(moving_mean_tensor.shape)
 
   return _BatchNormMatch(
       layer_op=None,


### PR DESCRIPTION
Folding batch normalization which has parameters like `is_training=False, fuse=False, scale=False` raises an error because its `batch_mean_tensor` is `None`. I suggest using `moving_mean_tensor` instead.