### PR TITLE
Fix broken link of performance guide for the `tf.data` API

### DIFF
--- a/tensorflow/docs_src/performance/performance_guide.md
+++ b/tensorflow/docs_src/performance/performance_guide.md
@@ -78,7 +78,7 @@ training CIFAR-10 illustrates the use of the `tf.data` API along with
 The `tf.data` API utilizes C++ multi-threading and has a much lower overhead
 than the Python-based `queue_runner` that is limited by Python's multi-threading
 performance. A detailed performance guide for the `tf.data` API can be found
-[here](#datasets_performance).
+[here](@{$datasets_performance}).
 
 While feeding data using a `feed_dict` offers a high level of flexibility, in
 general `feed_dict` does not provide a scalable solution. If only a single GPU


### PR DESCRIPTION
As you can see in the [Performance Guide](https://www.tensorflow.org/performance/performance_guide), the below **here** didn't link to the correct place with https://www.tensorflow.org/performance/performance_guide#datasets_performance due to datasets_performance.md is another file instead of an anchor inside current file.
> The tf.data API utilizes C++ multi-threading and has a much lower overhead than the Python-based queue_runner that is limited by Python's multi-threading performance. A detailed performance guide for the tf.data API can be found **here**.

This PR is to fix the above broken link of performance guide for the `tf.data` API.