### PR TITLE
Cast return value that caused warning

### DIFF
--- a/tensorflow/core/util/stat_summarizer.h
+++ b/tensorflow/core/util/stat_summarizer.h
@@ -186,7 +186,7 @@ class StatSummarizer {
   void Reset();
 
   // Returns number of runs.
-  int num_runs() const { return run_total_us_.count(); }
+  int num_runs() const { return static_cast<int>(run_total_us_.count()); }
 
   // Returns stats of total microseconds spent by all nodes in each run.
   const Stat<int64>& run_total_us() const { return run_total_us_; }


### PR DESCRIPTION
The member function `num_runs()` returns an `int`, however the return value from `run_total_us_.count()` is an `int64`. Casting the value to an `int` allows for the compiler to know that the intended return value should be an `int`.