### PR TITLE
using finally in tf_record_iterator()

### DIFF
--- a/tensorflow/python/lib/io/tf_record.py
+++ b/tensorflow/python/lib/io/tf_record.py
@@ -75,14 +75,16 @@ def tf_record_iterator(path, options=None):
 
   if reader is None:
     raise IOError("Could not open %s." % path)
-  while True:
-    try:
-      with errors.raise_exception_on_not_ok_status() as status:
-        reader.GetNext(status)
-    except errors.OutOfRangeError:
-      break
-    yield reader.record()
-  reader.Close()
+  try:
+    while True:
+      try:
+        with errors.raise_exception_on_not_ok_status() as status:
+          reader.GetNext(status)
+      except errors.OutOfRangeError:
+        break
+      yield reader.record()
+  finally:
+    reader.Close()
 
 
 @tf_export("python_io.TFRecordWriter")


### PR DESCRIPTION
Hi, this is to handle the case when [generator.throw()](https://www.python.org/dev/peps/pep-0342/#new-generator-method-throw-type-value-none-traceback-none) or [generator.close()](https://www.python.org/dev/peps/pep-0342/#new-generator-method-close) is called on a tfrecord iterator.

It will raise an exception like `GeneratorExit` in the generator's stack, and using `finally:` will promptly release the resources in such cases, without relying on garbage collection.

Please let me know if I'm missing something.