### PR TITLE
fix the bug that all string fields in protobuf share same memory location in the monolithic build

### DIFF
--- a/tensorflow/tf_version_script.lds
+++ b/tensorflow/tf_version_script.lds
@@ -6,6 +6,7 @@ tensorflow {
     *TFE_*;
     *nsync_*;
     *pywrap_xla*;
+    *protobuf*;
   local:
     *;
 };


### PR DESCRIPTION
All string fields in protobuf share same memory location in the monolithic build. This problem is described in #16291. Export protobuf related symbols in the library to fix it.