### PR TITLE
Fix incorrect link of checkpoint files in CNN tutorials

### DIFF
--- a/tensorflow/docs_src/tutorials/deep_cnn.md
+++ b/tensorflow/docs_src/tutorials/deep_cnn.md
@@ -268,7 +268,7 @@ in `cifar10_input.py`.
 
 `cifar10_train.py` periodically @{tf.train.Saver$saves}
 all model parameters in
-@{$variables#saving-and-restoring$checkpoint files}
+@{$programmers_guide/saved_model$checkpoint files}
 but it does *not* evaluate the model. The checkpoint file
 will be used by `cifar10_eval.py` to measure the predictive
 performance (see [Evaluating a Model](#evaluating-a-model) below).


### PR DESCRIPTION
This PR is to fix the incorrect link of checkpoint files in CNN tutorials.

As we can see in [CNN tutorials](https://www.tensorflow.org/tutorials/deep_cnn#launching_and_training_the_model), below checkpoint files links to https://www.tensorflow.org/programmers_guide/variables#saving-and-restoring which is not correct. 
> cifar10_train.py periodically saves all model parameters in **checkpoint files** but it does not evaluate the model. 

The correct intended link should be https://www.tensorflow.org/programmers_guide/saved_model instead.
