### PR TITLE
1.7.0rc2 cherry-pick request: Fixes a bug in `tf.contrib.data.map_and_batch()` shape inference

### DIFF
--- a/tensorflow/contrib/data/python/ops/batching.py
+++ b/tensorflow/contrib/data/python/ops/batching.py
@@ -374,8 +374,7 @@ class _MapAndBatchDataset(dataset_ops.MapDataset):
   @property
   def output_shapes(self):
     return nest.pack_sequence_as(self._output_shapes, [
-        tensor_shape.vector(tensor_util.constant_value(
-            self._batch_size)).concatenate(s)
+        tensor_shape.vector(None).concatenate(s)
         for s in nest.flatten(self._output_shapes)
     ])
 


### PR DESCRIPTION
This backports a fix for issue #17720 to the release branch. (It would not be the end of the world if this change wasn't cherry picked, but I'm sending it opportunistically in case it's be possible to fix the bug in the new release.)