### PR TITLE
Fix two external anchor link in kernel method tutorial

### DIFF
--- a/tensorflow/docs_src/tutorials/kernel_methods.md
+++ b/tensorflow/docs_src/tutorials/kernel_methods.md
@@ -1,7 +1,7 @@
 # Improving Linear Models Using Explicit Kernel Methods
 
 Note: This document uses a deprecated version of @{tf.estimator},
-which has a different interface (see `tf.contrib.learn Estimator`).
+which has a @{tf.contrib.learn.Estimator$different interface}.
 It also uses other `contrib` methods whose
 @{$version_compat#not_covered$API may not be stable}.
 

--- a/tensorflow/docs_src/tutorials/kernel_methods.md
+++ b/tensorflow/docs_src/tutorials/kernel_methods.md
@@ -1,11 +1,7 @@
 # Improving Linear Models Using Explicit Kernel Methods
 
 Note: This document uses a deprecated version of @{tf.estimator},
-<<<<<<< HEAD
 which has a different interface (see `tf.contrib.learn Estimator`).
-=======
-which has a @{tf.contrib.learn.estimator$different interface}.
->>>>>>> Fix several broken links in kernel method tutorials
 It also uses other `contrib` methods whose
 @{$version_compat#not_covered$API may not be stable}.
 

--- a/tensorflow/docs_src/tutorials/kernel_methods.md
+++ b/tensorflow/docs_src/tutorials/kernel_methods.md
@@ -1,7 +1,11 @@
 # Improving Linear Models Using Explicit Kernel Methods
 
 Note: This document uses a deprecated version of @{tf.estimator},
+<<<<<<< HEAD
 which has a different interface (see `tf.contrib.learn Estimator`).
+=======
+which has a @{tf.contrib.learn.estimator$different interface}.
+>>>>>>> Fix several broken links in kernel method tutorials
 It also uses other `contrib` methods whose
 @{$version_compat#not_covered$API may not be stable}.
 
@@ -53,7 +57,7 @@ In order to feed data to a `tf.contrib.learn Estimator`, it is helpful to conver
 it to Tensors. For this, we will use an `input function` which adds Ops to the
 TensorFlow graph that, when executed, create mini-batches of Tensors to be used
 downstream. For more background on input functions, check
-@{$get_started/premade_estimators#input_fn$this section on input functions}.
+@{$get_started/premade_estimators#create_input_functions$this section on input functions}.
 In this example, we will use the `tf.train.shuffle_batch` Op which, besides
 converting numpy arrays to Tensors, allows us to specify the batch_size and
 whether to randomize the input every time the input_fn Ops are executed


### PR DESCRIPTION
This PR is to fix:
 - The link of tf.contrib.learn.Estimator. As we can see in the note section of [kernel method tutorial](https://www.tensorflow.org/tutorials/kernel_methods), the two below highlighted link was broken and I can see from the latest source code the second one was fixed while the first one wasn't pointed to the correct place;
    > Note: This document uses a deprecated version of ${tf.estimator}, which has a **${tf.contrib.learn.estimator$different interface}**. It also uses other contrib methods whose **${$version_compat#not_covered$API may not be stable}**.

- The accurate link of input function section. It should be @{$get_started/premade_estimators#create_input_functions$this section on input functions} instead of #input_fn.
