### PR TITLE
Add IndRNN implementation

### DIFF
--- a/tensorflow/contrib/rnn/__init__.py
+++ b/tensorflow/contrib/rnn/__init__.py
@@ -58,6 +58,7 @@ See @{$python/contrib.rnn} guide.
 @@Conv3DLSTMCell
 @@HighwayWrapper
 @@GLSTMCell
+@@IndRNNCell
 
 <!--RNNCell wrappers-->
 @@AttentionCellWrapper

--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -1671,5 +1671,54 @@ class WeightNormLSTMCellTest(test.TestCase):
     self.assertAllClose(expected_c, actual_c, 1e-5)
     self.assertAllClose(expected_h, actual_h, 1e-5)
 
+
+class IndRNNCellTest(test.TestCase):
+  def testIndRNNCell(self):
+    """Tests basic cell functionality"""
+    with self.test_session() as sess:
+      init = init_ops.constant_initializer(1.)
+      with variable_scope.variable_scope("root", initializer=init):
+        x = array_ops.zeros([1, 4])
+        m = array_ops.zeros([1, 4])
+
+        # Create the cell with input weights = 1 and constant recurrent weights
+        recurrent_init = init_ops.constant_initializer([-3., -2., 1., 3.])
+        cell = contrib_rnn_cell.IndRNNCell(4,
+                                           recurrent_initializer=recurrent_init,
+                                           activation=array_ops.identity)
+        output, _ = cell(x, m)
+
+        sess.run([variables.global_variables_initializer()])
+        res = sess.run([output],
+                       {x.name: np.array([[1., 0., 0., 0.]]),
+                         m.name: np.array([[2., 2., 2., 2.]])})
+        # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
+        self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])
+
+  def testIndRNNCellBounds(self):
+    """Tests cell with recurrent weights exceeding the bounds."""
+    with self.test_session() as sess:
+      init = init_ops.constant_initializer(1.)
+      with variable_scope.variable_scope("root", initializer=init):
+        x = array_ops.zeros([1, 4])
+        m = array_ops.zeros([1, 4])
+
+        # Create the cell with input weights = 1 and constant recurrent weights
+        recurrent_init = init_ops.constant_initializer([-5., -2., 0.1, 5.])
+        cell = contrib_rnn_cell.IndRNNCell(4,
+                                           recurrent_min_abs=1.,
+                                           recurrent_max_abs=3.,
+                                           recurrent_initializer=recurrent_init,
+                                           activation=array_ops.identity)
+        output, _ = cell(x, m)
+
+        sess.run([variables.global_variables_initializer()])
+        res = sess.run([output],
+                       {x.name: np.array([[1., 0., 0., 0.]]),
+                         m.name: np.array([[2., 2., 2., 2.]])})
+        # Recurrent weights should be clipped to -3, -2, 1, 3
+        # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
+        self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -1676,49 +1676,51 @@ class IndRNNCellTest(test.TestCase):
   def testIndRNNCell(self):
     """Tests basic cell functionality"""
     with self.test_session() as sess:
-      init = init_ops.constant_initializer(1.)
-      with variable_scope.variable_scope("root", initializer=init):
-        x = array_ops.zeros([1, 4])
-        m = array_ops.zeros([1, 4])
+      x = array_ops.zeros([1, 4])
+      m = array_ops.zeros([1, 4])
 
-        # Create the cell with input weights = 1 and constant recurrent weights
-        recurrent_init = init_ops.constant_initializer([-3., -2., 1., 3.])
-        cell = contrib_rnn_cell.IndRNNCell(4,
-                                           recurrent_initializer=recurrent_init,
-                                           activation=array_ops.identity)
-        output, _ = cell(x, m)
+      # Create the cell with input weights = 1 and constant recurrent weights
+      recurrent_init = init_ops.constant_initializer([-3., -2., 1., 3.])
+      input_init = init_ops.constant_initializer(1.)
+      cell = contrib_rnn_cell.IndRNNCell(
+          num_units=4,
+          recurrent_kernel_initializer=recurrent_init,
+          input_kernel_initializer=input_init,
+          activation=array_ops.identity)
+      output, _ = cell(x, m)
 
-        sess.run([variables.global_variables_initializer()])
-        res = sess.run([output],
-                       {x.name: np.array([[1., 0., 0., 0.]]),
-                         m.name: np.array([[2., 2., 2., 2.]])})
-        # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
-        self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])
+      sess.run([variables.global_variables_initializer()])
+      res = sess.run([output],
+                     {x.name: np.array([[1., 0., 0., 0.]]),
+                       m.name: np.array([[2., 2., 2., 2.]])})
+      # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
+      self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])
 
   def testIndRNNCellBounds(self):
     """Tests cell with recurrent weights exceeding the bounds."""
     with self.test_session() as sess:
-      init = init_ops.constant_initializer(1.)
-      with variable_scope.variable_scope("root", initializer=init):
-        x = array_ops.zeros([1, 4])
-        m = array_ops.zeros([1, 4])
+      x = array_ops.zeros([1, 4])
+      m = array_ops.zeros([1, 4])
 
-        # Create the cell with input weights = 1 and constant recurrent weights
-        recurrent_init = init_ops.constant_initializer([-5., -2., 0.1, 5.])
-        cell = contrib_rnn_cell.IndRNNCell(4,
-                                           recurrent_min_abs=1.,
-                                           recurrent_max_abs=3.,
-                                           recurrent_initializer=recurrent_init,
-                                           activation=array_ops.identity)
-        output, _ = cell(x, m)
+      # Create the cell with input weights = 1 and constant recurrent weights
+      recurrent_init = init_ops.constant_initializer([-5., -2., 0.1, 5.])
+      input_init = init_ops.constant_initializer(1.)
+      cell = contrib_rnn_cell.IndRNNCell(
+          num_units=4,
+          recurrent_min_abs=1.,
+          recurrent_max_abs=3.,
+          recurrent_kernel_initializer=recurrent_init,
+          input_kernel_initializer=input_init,
+          activation=array_ops.identity)
+      output, _ = cell(x, m)
 
-        sess.run([variables.global_variables_initializer()])
-        res = sess.run([output],
-                       {x.name: np.array([[1., 0., 0., 0.]]),
-                         m.name: np.array([[2., 2., 2., 2.]])})
-        # Recurrent weights should be clipped to -3, -2, 1, 3
-        # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
-        self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])
+      sess.run([variables.global_variables_initializer()])
+      res = sess.run([output],
+                     {x.name: np.array([[1., 0., 0., 0.]]),
+                       m.name: np.array([[2., 2., 2., 2.]])})
+      # Recurrent weights should be clipped to -3, -2, 1, 3
+      # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
+      self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -1692,7 +1692,7 @@ class IndRNNCellTest(test.TestCase):
       sess.run([variables.global_variables_initializer()])
       res = sess.run([output],
                      {x.name: np.array([[1., 0., 0., 0.]]),
-                       m.name: np.array([[2., 2., 2., 2.]])})
+                      m.name: np.array([[2., 2., 2., 2.]])})
       # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
       self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])
 
@@ -1717,7 +1717,7 @@ class IndRNNCellTest(test.TestCase):
       sess.run([variables.global_variables_initializer()])
       res = sess.run([output],
                      {x.name: np.array([[1., 0., 0., 0.]]),
-                       m.name: np.array([[2., 2., 2., 2.]])})
+                      m.name: np.array([[2., 2., 2., 2.]])})
       # Recurrent weights should be clipped to -3, -2, 1, 3
       # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
       self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -3050,3 +3050,138 @@ class WeightNormLSTMCell(rnn_cell_impl.RNNCell):
 
       new_state = rnn_cell_impl.LSTMStateTuple(new_c, new_h)
       return new_h, new_state
+
+
+class IndRNNCell(rnn_cell_impl._LayerRNNCell):
+  """Independently RNN Cell. Adapted from `rnn_cell_impl.BasicRNNCell`.
+
+  The implementation is based on:
+
+    https://arxiv.org/abs/1803.04831
+
+  Shuai Li, Wanqing Li, Chris Cook, Ce Zhu, Yanbo Gao
+  "Independently Recurrent Neural Network (IndRNN): Building A Longer and
+  Deeper RNN"
+
+  Each unit has a single recurrent weight connected to its last hidden state.
+
+  Args:
+    num_units: int, The number of units in the RNN cell.
+    recurrent_min_abs: float, minimum absolute value of each recurrent weight.
+    recurrent_max_abs: (optional) float, maximum absolute value of each
+      recurrent weight. For `relu` activation, `pow(2, 1/timesteps)` is
+      recommended. If None, recurrent weights will not be clipped.
+      Default: None.
+    recurrent_initializer: (optional) The initializer to use for the recurrent
+      weights. The default is a uniform distribution in the range `[-1, 1]` if
+      `recurrent_max_abs` is not set or in
+      `[-recurrent_max_abs, recurrent_max_abs]` if it is and
+      `recurrent_max_abs < 1`.
+    activation: Nonlinearity to use.  Default: `relu`.
+    reuse: (optional) Python boolean describing whether to reuse variables
+      in an existing scope.  If not `True`, and the existing scope already has
+      the given variables, an error is raised.
+    name: String, the name of the layer. Layers with the same name will
+      share weights, but to avoid mistakes we require reuse=True in such
+      cases.
+  """
+
+  def __init__(self,
+               num_units,
+               recurrent_min_abs=0,
+               recurrent_max_abs=None,
+               recurrent_initializer=None,
+               activation=None,
+               reuse=None,
+               name=None):
+    super(IndRNNCell, self).__init__(_reuse=reuse, name=name)
+
+    # Inputs must be 2-dimensional.
+    self.input_spec = base_layer.InputSpec(ndim=2)
+
+    self._num_units = num_units
+    self._recurrent_min_abs = recurrent_min_abs
+    self._recurrent_max_abs = recurrent_max_abs
+    self._recurrent_initializer = recurrent_initializer
+    self._activation = activation or nn_ops.relu
+
+  @property
+  def state_size(self):
+    return self._num_units
+
+  @property
+  def output_size(self):
+    return self._num_units
+
+  def build(self, inputs_shape):
+    if inputs_shape[1].value is None:
+      raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
+                       % inputs_shape)
+
+    input_depth = inputs_shape[1].value
+    self._input_kernel = self.add_variable(
+        "input_kernel",
+        shape=[input_depth, self._num_units])
+
+    if self._recurrent_initializer is None:
+      # Initialize the recurrent weights uniformly in [-max_abs, max_abs] or
+      # [-1, 1] if max_abs exceeds 1
+      init_bound = 1.0
+      if self._recurrent_max_abs and self._recurrent_max_abs < init_bound:
+        init_bound = self._recurrent_max_abs
+
+      self._recurrent_initializer = init_ops.random_uniform_initializer(
+          minval=-init_bound,
+          maxval=init_bound
+      )
+
+    self._recurrent_kernel = self.add_variable(
+        "recurrent_kernel",
+        shape=[self._num_units], initializer=self._recurrent_initializer)
+
+    # Clip the absolute values of the recurrent weights to the specified minimum
+    if self._recurrent_min_abs:
+      abs_kernel = math_ops.abs(self._recurrent_kernel)
+      min_abs_kernel = math_ops.maximum(abs_kernel, self._recurrent_min_abs)
+      self._recurrent_kernel = math_ops.multiply(
+          math_ops.sign(self._recurrent_kernel),
+          min_abs_kernel
+      )
+
+    # Clip the absolute values of the recurrent weights to the specified maximum
+    if self._recurrent_max_abs:
+      self._recurrent_kernel = clip_ops.clip_by_value(self._recurrent_kernel,
+                                                      -self._recurrent_max_abs,
+                                                      self._recurrent_max_abs)
+
+    self._bias = self.add_variable(
+        "bias",
+        shape=[self._num_units],
+        initializer=init_ops.zeros_initializer(dtype=self.dtype))
+
+    self.built = True
+
+  def call(self, inputs, state):
+    """Run one time step of the IndRNN.
+
+    Calculates the output and new hidden state using the IndRNN equation
+
+      `output = new_state = act(W * input + u (*) state + b)`
+
+    where `*` is the matrix multiplication and `(*)` is the Hadamard product.
+
+    Args:
+      inputs: Tensor, 2-D tensor of shape `[batch, num_units]`.
+      state: Tensor, 2-D tensor of shape `[batch, num_units]` containing the
+        previous hidden state.
+
+    Returns:
+      A tuple containing the output and new hidden state. Both are the same
+        2-D tensor of shape `[batch, num_units]`.
+    """
+    gate_inputs = math_ops.matmul(inputs, self._input_kernel)
+    recurrent_update = math_ops.multiply(state, self._recurrent_kernel)
+    gate_inputs = math_ops.add(gate_inputs, recurrent_update)
+    gate_inputs = nn_ops.bias_add(gate_inputs, self._bias)
+    output = self._activation(gate_inputs)
+    return output, output

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -3052,7 +3052,7 @@ class WeightNormLSTMCell(rnn_cell_impl.RNNCell):
       return new_h, new_state
 
 
-class IndRNNCell(rnn_cell_impl._LayerRNNCell):
+class IndRNNCell(rnn_cell_impl.LayerRNNCell):
   """Independently RNN Cell. Adapted from `rnn_cell_impl.BasicRNNCell`.
 
   Each unit has a single recurrent weight connected to its last hidden state.


### PR DESCRIPTION
This PR adds the cell implementation of Independently Recurrent Neural Networks
to contrib together with unit tests. 

The implementation is based on [Independently Recurrent Neural Network (IndRNN): Building A Longer and Deeper RNN](https://arxiv.org/abs/1803.04831) (Shuai Li et al., 2018).

The difference to the `BasicRNNCell` is that each unit only has one recurrent weight connected to its own last hidden state. This makes it independent from other units in the same layer. To prevent vanishing / exploding gradients over time steps, the paper recommends bounds on the absolute value of that recurrent weight. These can be specified via the `recurrent_min_abs` and `recurrent_max_abs` constructor arguments.

Additional arguments of the `IndRNNCell` are `recurrent_kernel_initializer` and `input_kernel_initializer`. The paper does not recommend default values for the recurrent and input weights, so the default values for these were taken from [
A Simple Way to Initialize Recurrent Networks of Rectified Linear Units](https://arxiv.org/abs/1504.00941) (Quoc V. Le et al., 2015):

- Recurrent weights are set to 1 initially
- Input weights are initialized using a Gaussian with `mean=0` and `stddev=0.001`

The code is originally from [batzner/indrnn](https://github.com/batzner/indrnn/).