### PR TITLE
Fix set_difference doc

### DIFF
--- a/tensorflow/python/ops/sets_impl.py
+++ b/tensorflow/python/ops/sets_impl.py
@@ -247,7 +247,7 @@ def set_difference(a, b, aminusb=True, validate_indices=True):
     #
     # collections.OrderedDict([
     #     ((0, 0, 0), 2),
-    #     ((0, 0, 1), 3),
+    #     ((0, 1, 0), 3),
     # ])
   ```
 


### PR DESCRIPTION
The example in [tf.sets.set_difference](https://www.tensorflow.org/api_docs/python/tf/sets/set_difference) has a mistake. The result of `tf.sets.set_difference(a, b)` should be 

```python
  # collections.OrderedDict([
  #     ((0, 0, 0), 2),
  #     ((0, 1, 0), 3),
  # ])
```

instead of 

```python
  # collections.OrderedDict([
  #     ((0, 0, 0), 2),
  #     ((0, 0, 1), 3),
  # ])
```

Additionally the following is the result of running the code on my machine:

```python
SparseTensorValue(indices=array([[0, 0, 0], [0, 1, 0]], dtype=int64), values=array([2, 3]), dense_shape=array([2, 2, 1], dtype=int64))
```