### PR TITLE
Fix the doc of tf.contrib.lookup.MutableHashTable insert operation

### DIFF
--- a/tensorflow/contrib/lookup/lookup_ops.py
+++ b/tensorflow/contrib/lookup/lookup_ops.py
@@ -298,7 +298,7 @@ class MutableHashTable(LookupInterface):
   table = tf.contrib.lookup.MutableHashTable(key_dtype=tf.string,
                                              value_dtype=tf.int64,
                                              default_value=-1)
-  table.insert(keys, values)
+  sess.run(table.insert(keys, values))
   out = table.lookup(query_keys)
   print(out.eval())
   ```
@@ -494,7 +494,7 @@ class MutableDenseHashTable(LookupInterface):
                                                   value_dtype=tf.int64,
                                                   default_value=-1,
                                                   empty_key=0)
-  table.insert(keys, values)
+  sess.run(table.insert(keys, values))
   out = table.lookup(query_keys)
   print(out.eval())
   ```


### PR DESCRIPTION
This PR is to fix #17835.
Document on [MutableHashTable](https://www.tensorflow.org/api_docs/python/tf/contrib/lookup/MutableDenseHashTable) is confusing, especially in this line:
> table.insert(keys, values)

This code is unexecutable and misleading, it suggests insert is done inplace rather than an operation that need to be executed afterwards.
> sess.run(table.insert(keys, values))

Reference: [tensorflow-mutablehashtable-not-updating](https://stackoverflow.com/questions/43373170/tensorflow-mutablehashtable-not-updating)