### PR TITLE
Fix internal breakage caused by #16659

### DIFF
--- a/tensorflow/contrib/BUILD
+++ b/tensorflow/contrib/BUILD
@@ -40,6 +40,7 @@ py_library(
         "//tensorflow/contrib/estimator:estimator_py",
         "//tensorflow/contrib/factorization:factorization_py",
         "//tensorflow/contrib/feature_column:feature_column_py",
+        "//tensorflow/contrib/ffmpeg:ffmpeg_ops_py",  # unix dependency, need to fix code for Windows
         "//tensorflow/contrib/framework:framework_py",
         "//tensorflow/contrib/fused_conv:fused_conv_py",
         "//tensorflow/contrib/gan",
@@ -109,7 +110,6 @@ py_library(
     ] + if_mpi(["//tensorflow/contrib/mpi_collectives:mpi_collectives_py"]) + if_tensorrt([
         "//tensorflow/contrib/tensorrt:init_py",
     ]) + if_not_windows([
-        "//tensorflow/contrib/ffmpeg:ffmpeg_ops_py",  # unix dependency, need to fix code
         "//tensorflow/contrib/lite/python:lite",  # unix dependency, need to fix code
         "//tensorflow/contrib/kafka",  # has some linking issue on opensssl.
     ]),

--- a/tensorflow/contrib/ffmpeg/BUILD
+++ b/tensorflow/contrib/ffmpeg/BUILD
@@ -11,6 +11,7 @@ load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
 load("//tensorflow:tensorflow.bzl", "tf_copts")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
+load("//tensorflow:tensorflow.bzl", "if_not_windows")
 
 filegroup(
     name = "test_data",
@@ -63,11 +64,11 @@ cc_library(
 
 tf_custom_op_library(
     name = "ffmpeg.so",
-    deps = [
+    deps = if_not_windows([
         ":decode_audio_op_cc",
         ":decode_video_op_cc",
         ":encode_audio_op_cc",
-    ],
+    ]),
 )
 
 cc_library(


### PR DESCRIPTION
Due to copybara modification, we cannot put
`//tensorflow/contrib/ffmpeg:ffmpeg_ops_py` into if_not_windows()


@gunan This is to address the breakage caused by https://github.com/tensorflow/tensorflow/pull/16659, I believe with this fix, we don't have to rollback it anymore.

Tested internally: cl/189559607 

@gunan 