### PR TITLE
Fix related doc clarification request on tf.contrib.lookup.MutableHas…

### DIFF
--- a/tensorflow/contrib/lookup/lookup_ops.py
+++ b/tensorflow/contrib/lookup/lookup_ops.py
@@ -494,7 +494,7 @@ class MutableDenseHashTable(LookupInterface):
                                                   value_dtype=tf.int64,
                                                   default_value=-1,
                                                   empty_key=0)
-  table.insert(keys, values)
+  sess.run(table.insert(keys, values))
   out = table.lookup(query_keys)
   print(out.eval())
   ```


### PR DESCRIPTION
…hTable insert operation #17835

Make the doc example executable, and explicitly suggests that MutableDenseHashTable.insert is an operation rather than in-place computation.