### PR TITLE
Adds missing protobuf dep to tf.contrib.data ops.

### DIFF
--- a/tensorflow/contrib/data/BUILD
+++ b/tensorflow/contrib/data/BUILD
@@ -30,8 +30,8 @@ tf_custom_op_library(
     name = "_dataset_ops.so",
     srcs = ["ops/dataset_ops.cc"],
     deps = [
-        "//third_party/tensorflow/contrib/data/kernels:dataset_kernels",
-        "//third_party/tensorflow/core:lib_proto_parsing",
+        "//tensorflow/contrib/data/kernels:dataset_kernels",
+        "//tensorflow/core:lib_proto_parsing",
     ],
 )
 

--- a/tensorflow/contrib/data/BUILD
+++ b/tensorflow/contrib/data/BUILD
@@ -29,7 +29,10 @@ py_library(
 tf_custom_op_library(
     name = "_dataset_ops.so",
     srcs = ["ops/dataset_ops.cc"],
-    deps = ["//tensorflow/contrib/data/kernels:dataset_kernels"],
+    deps = [
+        "//third_party/tensorflow/contrib/data/kernels:dataset_kernels",
+        "//third_party/tensorflow/core:lib_proto_parsing",
+    ],
 )
 
 tf_gen_op_libs(


### PR DESCRIPTION
I think this will help resolve the following:
https://github.com/tensorflow/serving/issues/421
https://github.com/tensorflow/serving/issues/684
https://github.com/tensorflow/tensorflow/issues/17619

Or at least I was experiencing a similar issue and this change resolved it for me in my local repo.  (See also cl/189580464).