### PR TITLE
Update the doc of StagingArea.put() to a tuple or list of Tensors

### DIFF
--- a/tensorflow/python/ops/data_flow_ops.py
+++ b/tensorflow/python/ops/data_flow_ops.py
@@ -1769,7 +1769,9 @@ class StagingArea(BaseStagingArea):
     its capacity.
 
     Args:
-      values: Tensor (or a tuple of Tensors) to place into the staging area.
+      values: A tuple or list of Tensors. The number of elements must match 
+        the length of the list provided to the dtypes argument when creating 
+        the StagingArea.
       name: A name for the operation (optional).
 
     Returns:


### PR DESCRIPTION
This PR is to fix #13288.

As described in the above issue, considering the following two pieces of codes:
**Snippet 1**
> import tensorflow as tf
> from tensorflow.contrib import staging
> staging.StagingArea(dtypes=[tf.int32]).put(tf.constant(1))

**Snippet 2**
> import tensorflow as tf
> from tensorflow.contrib import staging
> staging.StagingArea(dtypes=[tf.int32]).put((tf.constant(1),))

The **Snippet 1** won't work while the **Snippet 2** works. It obviously currently can only support a tuple or a list of tensors instead of single tensor. 

Thus this PR is firstly to fix the doc of StagingArea.put(). Next step, I'll try to continue working on how to support a single Tensor in a StagingArea.put().