### PR TITLE
Support a single Tensor in StagingArea.put()

### DIFF
--- a/tensorflow/python/ops/data_flow_ops.py
+++ b/tensorflow/python/ops/data_flow_ops.py
@@ -1769,9 +1769,9 @@ class StagingArea(BaseStagingArea):
     its capacity.
 
     Args:
-      values: A single tensor, a tuple or list of Tensors. The number of 
-        elements must match the length of the list provided to the dtypes
-        argument when creating the StagingArea.
+      values: A single tensor, a list or tuple of tensors, or a dictionary with
+        tensor values. The number of elements must match the length of the
+        list provided to the dtypes argument when creating the StagingArea.
       name: A name for the operation (optional).
 
     Returns:
@@ -1783,7 +1783,7 @@ class StagingArea(BaseStagingArea):
     with ops.name_scope(name, "%s_put" % self._name,
                         self._scope_vals(values)) as scope:
       
-      if not isinstance(values, (list, tuple)):
+      if not isinstance(values, (list, tuple, dict)):
         values = [values]
 
       # Hard-code indices for this staging area

--- a/tensorflow/python/ops/data_flow_ops.py
+++ b/tensorflow/python/ops/data_flow_ops.py
@@ -1769,7 +1769,9 @@ class StagingArea(BaseStagingArea):
     its capacity.
 
     Args:
-      values: Tensor (or a tuple of Tensors) to place into the staging area.
+      values: A single tensor, a tuple or list of Tensors. The number of 
+        elements must match the length of the list provided to the dtypes
+        argument when creating the StagingArea.
       name: A name for the operation (optional).
 
     Returns:
@@ -1780,11 +1782,12 @@ class StagingArea(BaseStagingArea):
     """
     with ops.name_scope(name, "%s_put" % self._name,
                         self._scope_vals(values)) as scope:
+      
+      if not isinstance(values, (list, tuple)):
+        values = [values]
 
       # Hard-code indices for this staging area
-      indices = (
-          list(six.moves.range(len(values)))
-          if isinstance(values, (list, tuple)) else None)
+      indices = list(six.moves.range(len(values)))
       vals, _ = self._check_put_dtypes(values, indices)
 
       with ops.colocate_with(self._coloc_op):


### PR DESCRIPTION
This PR is to fix #13288 as a follow-up of #17862 to support a single Tensor in StagingArea.put().
As described in the above issue, considering the following two pieces of codes:
**Snippet 1**
> import tensorflow as tf
> from tensorflow.contrib import staging
> staging.StagingArea(dtypes=[tf.int32]).put(tf.constant(1))

**Snippet 2**
> import tensorflow as tf
> from tensorflow.contrib import staging
> staging.StagingArea(dtypes=[tf.int32]).put((tf.constant(1),))

The Snippet 1 won't work while the Snippet 2 works. It obviously currently can only support a tuple or a list of tensors instead of single tensor.

This PR is to support a single Tensor in StagingArea.put().