### PR TITLE
Clean up image_retraining example

### DIFF
--- a/tensorflow/examples/image_retraining/BUILD
+++ b/tensorflow/examples/image_retraining/BUILD
@@ -32,10 +32,6 @@ py_test(
         "retrain.py",
         "retrain_test.py",
     ],
-    data = [
-        ":data/labels.txt",
-        "//tensorflow/examples/label_image:data/grace_hopper.jpg",
-    ],
     srcs_version = "PY2AND3",
     deps = [
         ":retrain",

--- a/tensorflow/examples/image_retraining/data/labels.txt
+++ b/tensorflow/examples/image_retraining/data/labels.txt
@@ -1,3 +1,0 @@
-Runner-up
-Winner
-Loser

--- a/tensorflow/examples/image_retraining/retrain.py
+++ b/tensorflow/examples/image_retraining/retrain.py
@@ -1299,7 +1299,7 @@ if __name__ == '__main__':
   parser.add_argument(
       '--image_dir',
       type=str,
-      default='',
+      required=True,
       help='Path to folders of labeled images.'
   )
   parser.add_argument(


### PR DESCRIPTION
The data files are remnants from when label_image.py used to be located
in the image_retraining directory and are no longer used.

Also made image_dir a required argument in retrain.py to make it clearer
that the user has to pass in a path.