### PR TITLE
Fix the inconsistency in the accepted shape/data_format in layers doc

### DIFF
--- a/tensorflow/docs_src/tutorials/layers.md
+++ b/tensorflow/docs_src/tutorials/layers.md
@@ -198,9 +198,9 @@ Classifier"](#training_and_evaluating_the_cnn_mnist_classifier).
 ### Input Layer
 
 The methods in the `layers` module for creating convolutional and pooling layers
-for two-dimensional image data expect input tensors to have a shape of
-<code>[<em>batch_size</em>, <em>image_width</em>, <em>image_height</em>,
-<em>channels</em>]</code>, defined as follows:
+for two-dimensional image data expect input tensors to have a `channels_last` shape of
+<code>[<em>batch_size</em>, <em>image_height</em>, <em>image_width</em>, <em>channels</em>]</code>
+or a `channels_first` shape of <code>[<em>batch_size</em>, <em>channels</em>, <em>image_height</em>, <em>image_width</em>]</code>, defined as follows:
 
 *   _`batch_size`_. Size of the subset of examples to use when performing
     gradient descent during training.


### PR DESCRIPTION
This PR is to fix #17892 on the the inconsistency in the accepted shape/data_format of layers doc.

As described in the above issue, the [Tensorflow Layers Guide](https://www.tensorflow.org/tutorials/layers) at specifies:
> The methods in the layers module for creating convolutional and pooling layers for two-dimensional image data expect input tensors to have a shape of [batch_size, image_width, image_height, channels]

While, the inline documentation specified for [conv2D](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/layers/convolutional.py#L444) mentions the following valid data_formats:
> data_format: A string, one of channels_last (default) or channels_first.
> The ordering of the dimensions in the inputs.
> channels_last corresponds to inputs with shape
> (batch, height, width, channels) while channels_first corresponds to
> inputs with shape (batch, channels, height, width)

Moreover, [nn.bias_add, avg_pool2d etc. ](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/layers/python/layers/layers.py#L99) also accept [...,height, width...] but using different strings/methodology.
> inputs: A 4-D tensor of shape [batch_size, height, width, channels] if
> data_format is NHWC, and [batch_size, channels, height, width] if
> data_format is NCHW.

This PR is to fix #17892.