### PR TITLE
Fix dataset resampling bug introduced by a bug in datasets itself. fixes #16606

### DIFF
--- a/tensorflow/contrib/data/python/kernel_tests/resample_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/resample_test.py
@@ -21,8 +21,11 @@ import numpy as np
 
 from tensorflow.contrib.data.python.ops import resampling
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
+from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import string_ops
+from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import test
 from tensorflow.python.util import compat
 
@@ -68,6 +71,43 @@ class ResampleTest(test.TestCase):
     returned_dist = class_counts / total_returned
     self.assertAllClose(target_dist, returned_dist, atol=1e-2)
 
+  def testRandomClasses(self):
+    init_dist = [0.25, 0.25, 0.25, 0.25]
+    target_dist = [0.0, 0.0, 0.0, 1.0]
+    num_classes = len(init_dist)
+    num_samples = 100   # We don't need many samples to test a dirac-delta target distribution
+    data_np = np.random.choice(num_classes, num_samples, p=init_dist)
+
+    dataset = dataset_ops.Dataset.from_tensor_slices(data_np)
+
+    # Apply a random mapping that preserves the data distribution.
+    def _remap_fn(_):
+      return math_ops.cast(random_ops.random_uniform([1]) * num_classes,
+                           dtypes.int32)[0]
+    dataset = dataset.map(_remap_fn)
+
+    # Reshape distribution.
+    dataset = dataset.apply(
+        resampling.rejection_resample(
+            class_func=lambda x: x,
+            target_dist=target_dist,
+            initial_dist=init_dist))
+
+    get_next = dataset.make_one_shot_iterator().get_next()
+
+
+    with self.test_session() as sess:
+      returned = []
+      with self.assertRaises(errors.OutOfRangeError):
+        while True:
+          returned.append(sess.run(get_next))
+
+    classes, _ = zip(*returned)
+    bincount = np.bincount(
+        np.array(classes),
+        minlength=num_classes).astype(np.float32) / len(classes)
+
+    self.assertAllClose(target_dist, bincount, atol=1e-2)
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/contrib/data/python/ops/prefetching_ops.py
+++ b/tensorflow/contrib/data/python/ops/prefetching_ops.py
@@ -27,7 +27,7 @@ def function_buffering_resource(string_arg,
                                 target_device,
                                 f,
                                 buffer_size,
-                                thread_pool_size=1,
+                                thread_pool_size=0,
                                 container="",
                                 shared_name=None,
                                 name=None):

--- a/tensorflow/contrib/data/python/ops/prefetching_ops.py
+++ b/tensorflow/contrib/data/python/ops/prefetching_ops.py
@@ -27,7 +27,7 @@ def function_buffering_resource(string_arg,
                                 target_device,
                                 f,
                                 buffer_size,
-                                thread_pool_size=0,
+                                thread_pool_size=1,
                                 container="",
                                 shared_name=None,
                                 name=None):

--- a/tensorflow/contrib/data/python/ops/resampling.py
+++ b/tensorflow/contrib/data/python/ops/resampling.py
@@ -101,13 +101,15 @@ def rejection_resample(class_func, target_dist, initial_dist=None, seed=None):
                                                    initial_dist_ds))
                           .map(maybe_warn_on_large_rejection))
 
-    current_probabilities_ds = dataset_ops.Dataset.zip(
-        (acceptance_dist_ds, class_values_ds)).map(array_ops.gather)
+    def _gather_and_copy(class_val, acceptance_prob, data):
+      return (class_val, array_ops.gather(acceptance_prob, class_val), data)
+    current_probabilities_and_class_and_data_ds = dataset_ops.Dataset.zip(
+          (class_values_ds, acceptance_dist_ds, dataset)).map(_gather_and_copy)
     filtered_ds = (
-        dataset_ops.Dataset.zip((class_values_ds, current_probabilities_ds,
-                                 dataset))
-        .filter(lambda _1, p, _2: random_ops.random_uniform([], seed=seed) < p))
+          current_probabilities_and_class_and_data_ds
+              .filter(lambda _1, p, _2: random_ops.random_uniform([], seed=seed) < p))
     return filtered_ds.map(lambda class_value, _, data: (class_value, data))
+
 
   return _apply_fn
 

--- a/tensorflow/contrib/data/python/ops/resampling.py
+++ b/tensorflow/contrib/data/python/ops/resampling.py
@@ -104,10 +104,10 @@ def rejection_resample(class_func, target_dist, initial_dist=None, seed=None):
     def _gather_and_copy(class_val, acceptance_prob, data):
       return (class_val, array_ops.gather(acceptance_prob, class_val), data)
     current_probabilities_and_class_and_data_ds = dataset_ops.Dataset.zip(
-          (class_values_ds, acceptance_dist_ds, dataset)).map(_gather_and_copy)
+        (class_values_ds, acceptance_dist_ds, dataset)).map(_gather_and_copy)
     filtered_ds = (
-          current_probabilities_and_class_and_data_ds
-              .filter(lambda _1, p, _2: random_ops.random_uniform([], seed=seed) < p))
+        current_probabilities_and_class_and_data_ds
+            .filter(lambda _1, p, _2: random_ops.random_uniform([], seed=seed) < p))
     return filtered_ds.map(lambda class_value, _, data: (class_value, data))
 
 

--- a/tensorflow/contrib/data/python/ops/resampling.py
+++ b/tensorflow/contrib/data/python/ops/resampling.py
@@ -107,7 +107,7 @@ def rejection_resample(class_func, target_dist, initial_dist=None, seed=None):
         (class_values_ds, acceptance_dist_ds, dataset)).map(_gather_and_copy)
     filtered_ds = (
         current_probabilities_and_class_and_data_ds
-            .filter(lambda _1, p, _2: random_ops.random_uniform([], seed=seed) < p))
+        .filter(lambda _1, p, _2: random_ops.random_uniform([], seed=seed) < p))
     return filtered_ds.map(lambda class_value, _, data: (class_value, data))
 
 


### PR DESCRIPTION
Fixes github issue #16606.

This is a correctly-formatted version of PR #17858.

The core issue is that in the case of certain random Tensors, the
following two lines aren't the same:

```
rand_0s_and_1s_ds = ...
gather_ds = rand_0s_and_1s_ds.map(lambda i: tf.gather([0, 1], i))
tup_ds = tf.data.Dataset.zip(gather_ds, rand_0s_and_1s_ds)
```

```
rand_0s_and_1s_ds = ...
tup_ds = rand_0s_and_1s_ds.map(lambda i: (tf.gather([0, 1], i), i))
Note that this does NOT fix the underlying issue of drawing multiple
sampes from the underlying distribution.
```

Tested:
With the new test, bazel test :resample_test fails before and succeeds
after.