### PR TITLE
Fix the quantized table order by float value for easy reading

### DIFF
--- a/tensorflow/docs_src/performance/quantization.md
+++ b/tensorflow/docs_src/performance/quantization.md
@@ -227,8 +227,8 @@ of 30.0f, and an 8-bit array, the quantized values represent the following:
   <table>
     <tr><th>Quantized</th><th>Float</th></tr>
     <tr><td>0</td><td>-10.0</td></tr>
-    <tr><td>255</td><td>30.0</td></tr>
     <tr><td>128</td><td>10.0</td></tr>
+    <tr><td>255</td><td>30.0</td></tr>
   </table>
   <figcaption>
     <b>Table 2</b>: Example quantized value range


### PR DESCRIPTION
This PR is to fix the quantized table order for better reading and understanding in [How to Quantize Neural Networks with TensorFlow](https://www.tensorflow.org/performance/quantization#what_representation_is_used_for_quantized_tensors).
Before fix:
<figure>
  <table>
    <tr><th>Quantized</th><th>Float</th></tr>
    <tr><td>0</td><td>-10.0</td></tr>
    <tr><td>255</td><td>30.0</td></tr>
    <tr><td>128</td><td>10.0</td></tr>
  </table>
</figure>
After fix:
<figure>
  <table>
    <tr><th>Quantized</th><th>Float</th></tr>
    <tr><td>0</td><td>-10.0</td></tr>
    <tr><td>128</td><td>10.0</td></tr>
    <tr><td>255</td><td>30.0</td></tr>
  </table>
</figure>