### PR TITLE
Update tensorflow/contrib/lite/BUILD

### DIFF
--- a/tensorflow/contrib/lite/BUILD
+++ b/tensorflow/contrib/lite/BUILD
@@ -6,8 +6,6 @@ licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow/contrib/lite:build_def.bzl", "tflite_copts", "gen_selected_ops")
 
-exports_files(["LICENSE"])
-
 exports_files(glob([
     "testdata/*.bin",
     "testdata/*.pb",


### PR DESCRIPTION
exports_files(["LICENSE"]) gives error while building on Mac and Ubuntu