### PR TITLE
[tflite] fix number of gemmlowp threads problem

### DIFF
--- a/tensorflow/contrib/lite/kernels/conv.cc
+++ b/tensorflow/contrib/lite/kernels/conv.cc
@@ -333,6 +333,12 @@ void EvalQuantized(TfLiteContext* context, TfLiteNode* node,
                    TfLiteTensor* output) {
   gemmlowp::GemmContext* gemm_context = gemm_support::GetFromContext(context);
 
+  // checkout the number of threads again here, so that we can change the
+  // numberof threads dynamically (after the graph constructed)
+  if (context->recommended_num_threads != -1) {
+      gemm_context->set_max_num_threads(context->recommended_num_threads);
+  }
+
   auto input_offset = -input->params.zero_point;
   auto filter_offset = -filter->params.zero_point;
   auto output_offset = output->params.zero_point;


### PR DESCRIPTION
Recent changes moved setting of the number of gemmlowp threads to
Init() of conv operation so that invoking `Interpreter::SetNumThreads()`
after nodes created doesn't change of number of threads.

Note that the number of Eigen threads is also problematic, but I don't have an easy fix yet. In current [`tflite::eigen_support::IncrementUsageCounter()` ](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/lite/kernels/eigen_support.cc#L27), it assumes that `Eigen::setNbThreads()` changes the number of Eigen thread. But current [multithreaded conv](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/lite/kernels/internal/optimized/multithreaded_conv.h) actually has its own Eigen threadpool.