### PR TITLE
MKLDNN: conv2d forward DNN primitive reuse enhancement

### DIFF
--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -60,7 +60,7 @@ namespace tensorflow {
 #ifndef INTEL_MKL_ML
 
 template <typename T>
-class Conv2DFwd: public DnnOp {
+class Conv2DFwd : public DnnOp {
  public:
   Conv2DFwd(memory::dims src_dims,
             memory::dims filter_dims,
@@ -139,7 +139,7 @@ class Conv2DFwd: public DnnOp {
     // create convolution primitive and add it to net
     if (!bias_dims.empty()) {
         bias_mem_.reset(new memory({{{bias_dims}, MklDnnType<T>(),
-                                   memory::format::x}, cpu_engine_}, DummyData));
+                             memory::format::x}, cpu_engine_}, DummyData));
         conv_fwd_.reset(new convolution_forward(*fwd_pd_, *src_mem_,
                         *filter_mem_, *bias_mem_, *dst_mem_));
     } else {
@@ -223,10 +223,6 @@ class Conv2DFwd: public DnnOp {
 
 template <typename T>
 class Conv2DFwdFactory : public DnnOpFactory<T> {
- private:
-    Conv2DFwdFactory() {}
-    ~Conv2DFwdFactory() {}
-
  public:
   static Conv2DFwd<T>* Get(
                          memory::dims src_dims,
@@ -259,6 +255,9 @@ class Conv2DFwdFactory : public DnnOpFactory<T> {
   }
 
  private:
+  Conv2DFwdFactory() {}
+  ~Conv2DFwdFactory() {}
+
   static const int kDilationH = 0, kDilationW = 1;
 
   static Conv2DFwdFactory& GetInstance() {
@@ -877,7 +876,6 @@ class MklConv2DOp : public OpKernel {
                         bias_dims, dst_dims_mkl_order,
                         strides, dilations, padding_l, padding_r);
       } else {
-        conv_utl.GetBiasSizeInMklOrder(kInputIndex_Bias, &bias_dims);
         conv2d_fwd = Conv2DFwdFactory<T>::Get(src_dims, filter_dims,
                         NONE_DIMS, dst_dims_mkl_order,
                         strides, dilations, padding_l, padding_r);

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -92,6 +92,48 @@ class Conv2DFwd : public DnnOp {
 
   ~Conv2DFwd() {}
 
+  void Execute() {}
+
+  // Convolution forward execute with bias
+  void Execute(T* src, T* w, T* b, T* dst) {
+    src_mem_->set_data_handle(static_cast<void*>(src));
+    filter_mem_->set_data_handle(static_cast<void*>(w));
+    bias_mem_->set_data_handle(static_cast<void*>(b));
+    dst_mem_->set_data_handle(static_cast<void*>(dst));
+    fwd_stream_->submit(fwd_primitives_);
+
+    // after exec, set data handle back
+    src_mem_->set_data_handle(DummyData);
+    filter_mem_->set_data_handle(DummyData);
+    bias_mem_->set_data_handle(DummyData);
+    dst_mem_->set_data_handle(DummyData);
+
+    return;
+  }
+
+  // Convolution forward execute without bias
+  void Execute(T* src, T* w, T* dst) {
+    src_mem_->set_data_handle(static_cast<void*>(src));
+    filter_mem_->set_data_handle(static_cast<void*>(w));
+    dst_mem_->set_data_handle(static_cast<void*>(dst));
+    fwd_stream_->submit(fwd_primitives_);
+
+    // after exec, set data handle back
+    src_mem_->set_data_handle(DummyData);
+    filter_mem_->set_data_handle(DummyData);
+    dst_mem_->set_data_handle(DummyData);
+
+    return;
+  }
+
+  // expected memory format for this primitive instance
+  memory::format src_fmt_;
+  memory::format filter_fmt_;
+
+  // convolution primitive
+  std::shared_ptr<mkldnn::convolution_forward::primitive_desc> fwd_pd_;
+  std::shared_ptr<mkldnn::primitive> conv_fwd_;
+
  private:
   void Setup(const ConvFwdDimensions& convFwdDims) {
     // create memory descriptors for convolution data w/ no specified format
@@ -152,48 +194,6 @@ class Conv2DFwd : public DnnOp {
     return;
   }
 
- public:
-  // Convolution forward execute with bias
-  void Execute(T* src, T* w, T* b, T* dst) {
-    src_mem_->set_data_handle(static_cast<void*>(src));
-    filter_mem_->set_data_handle(static_cast<void*>(w));
-    bias_mem_->set_data_handle(static_cast<void*>(b));
-    dst_mem_->set_data_handle(static_cast<void*>(dst));
-    fwd_stream_->submit(fwd_primitives_);
-
-    // after exec, set data handle back
-    src_mem_->set_data_handle(DummyData);
-    filter_mem_->set_data_handle(DummyData);
-    bias_mem_->set_data_handle(DummyData);
-    dst_mem_->set_data_handle(DummyData);
-
-    return;
-  }
-
-  // Convolution forward execute without bias
-  void Execute(T* src, T* w, T* dst) {
-    src_mem_->set_data_handle(static_cast<void*>(src));
-    filter_mem_->set_data_handle(static_cast<void*>(w));
-    dst_mem_->set_data_handle(static_cast<void*>(dst));
-    fwd_stream_->submit(fwd_primitives_);
-
-    // after exec, set data handle back
-    src_mem_->set_data_handle(DummyData);
-    filter_mem_->set_data_handle(DummyData);
-    dst_mem_->set_data_handle(DummyData);
-
-    return;
-  }
-
-  // expected memory format for this primitive instance
-  memory::format src_fmt_;
-  memory::format filter_fmt_;
-
-  // convolution primitive
-  std::shared_ptr<mkldnn::convolution_forward::primitive_desc> fwd_pd_;
-  std::shared_ptr<mkldnn::primitive> conv_fwd_;
-
- private:
   // MKLDNN memory
   std::shared_ptr<mkldnn::memory> src_mem_;
   std::shared_ptr<mkldnn::memory> filter_mem_;

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -66,16 +66,18 @@ struct ConvFwdDimensions {
   memory::dims dst_dims;
   memory::dims strides;
   memory::dims dilations;
-  memory::dims padding_l;
-  memory::dims padding_r;
+  memory::dims padding_left;
+  memory::dims padding_right;
 
-  ConvFwdDimensions(memory::dims src_d,
-      memory::dims filter_d, memory::dims bias_d,
-      memory::dims dst_d, memory::dims strides,
-      memory::dims dilations, memory::dims pl,
-      memory::dims pr) : src_dims(src_d), filter_dims(filter_d),
-          bias_dims(bias_d), dst_dims(dst_d), strides(strides),
-          dilations(dilations), padding_l(pl), padding_r(pr) {
+  ConvFwdDimensions(memory::dims src_dims,
+    memory::dims filter_dims, memory::dims bias_dims,
+    memory::dims dst_dims, memory::dims strides,
+    memory::dims dilations, memory::dims padding_left,
+    memory::dims padding_right) :
+      src_dims(src_dims), filter_dims(filter_dims),
+      bias_dims(bias_dims), dst_dims(dst_dims),
+      strides(strides), dilations(dilations),
+      padding_left(padding_left), padding_right(padding_right) {
   }
 };
 
@@ -152,13 +154,13 @@ class Conv2DFwd : public DnnOp {
     if (!convFwdDims.bias_dims.empty()) {
       fwd_desc_.reset(new convolution_forward::desc(prop_kind::forward,
           convolution_direct, *src_md_, *filter_md_, *bias_md_, *dst_md_,
-          convFwdDims.strides, convFwdDims.dilations, convFwdDims.padding_l,
-          convFwdDims.padding_r, padding_kind::zero));
+          convFwdDims.strides, convFwdDims.dilations, convFwdDims.padding_left,
+          convFwdDims.padding_right, padding_kind::zero));
     } else {
       fwd_desc_.reset(new convolution_forward::desc(prop_kind::forward,
           convolution_direct, *src_md_, *filter_md_, *dst_md_,
-          convFwdDims.strides, convFwdDims.dilations, convFwdDims.padding_l,
-          convFwdDims.padding_r, padding_kind::zero));
+          convFwdDims.strides, convFwdDims.dilations, convFwdDims.padding_left,
+          convFwdDims.padding_right, padding_kind::zero));
     }
 
     fwd_pd_.reset(new convolution_forward::primitive_desc(
@@ -252,8 +254,8 @@ class Conv2DFwdFactory : public DnnOpFactory<T> {
     key_creator.AddAsKey(convFwdDims.dst_dims);
     key_creator.AddAsKey(convFwdDims.strides);
     key_creator.AddAsKey(convFwdDims.dilations);
-    key_creator.AddAsKey(convFwdDims.padding_l);
-    key_creator.AddAsKey(convFwdDims.padding_r);
+    key_creator.AddAsKey(convFwdDims.padding_left);
+    key_creator.AddAsKey(convFwdDims.padding_right);
     return key_creator.GetKey();
   }
 

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -869,8 +869,8 @@ class MklConv2DOp : public OpKernel {
 
       // get a conv2d fwd from primitive pool
       Conv2DFwd<T> *conv2d_fwd = nullptr;
-      memory::dims bias_dims = {};
       if (biasEnabled) {
+        memory::dims bias_dims = {};
         conv_utl.GetBiasSizeInMklOrder(kInputIndex_Bias, &bias_dims);
         conv2d_fwd = Conv2DFwdFactory<T>::Get(src_dims, filter_dims,
                         bias_dims, dst_dims_mkl_order,

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -92,8 +92,6 @@ class Conv2DFwd : public DnnOp {
 
   ~Conv2DFwd() {}
 
-  void Execute() {}
-
   // Convolution forward execute with bias
   void Execute(T* src, T* w, T* b, T* dst) {
     src_mem_->set_data_handle(static_cast<void*>(src));

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <map>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -42,14 +43,13 @@ limitations under the License.
 #include "tensorflow/core/util/mkl_util.h"
 
 #ifndef INTEL_MKL_ML
-
 #include "mkldnn.hpp"
 
 using mkldnn::prop_kind;
 using mkldnn::stream;
-
-using mkldnn::convolution_direct;
 using mkldnn::convolution_forward;
+using mkldnn::convolution_direct;
+
 #else
 #include "mkl_dnn.h"
 #include "mkl_dnn_types.h"
@@ -57,11 +57,274 @@ using mkldnn::convolution_forward;
 
 namespace tensorflow {
 
+#ifndef INTEL_MKL_ML
+
+template <typename T>
+class Conv2DFwd: public DnnOp {
+ public:
+  Conv2DFwd(memory::dims src_dims,
+            memory::dims filter_dims,
+            memory::dims bias_dims,
+            memory::dims dst_dims,
+            memory::dims strides,
+            memory::dims dilations,
+            memory::dims padding_l,
+            memory::dims padding_r) {
+    fwd_stream_.reset(new stream(stream::kind::eager));
+    // create conv primitive
+    if (conv_fwd_ == nullptr) {
+      Setup(src_dims, filter_dims, bias_dims, dst_dims,
+          strides, dilations, padding_l, padding_r);
+    }
+  }
+
+  ~Conv2DFwd() {}
+
+ private:
+  void Setup(memory::dims src_dims,
+             memory::dims filter_dims,
+             memory::dims bias_dims,
+             memory::dims dst_dims,
+             memory::dims strides,
+             memory::dims dilations,
+             memory::dims padding_l,
+             memory::dims padding_r) {
+    strides_ = strides;
+    padding_l_ = padding_l;
+    padding_r_ = padding_r;
+
+    // create memory descriptors for convolution data w/ no specified format
+    src_md_.reset(new memory::desc({src_dims}, MklDnnType<T>(),
+                                   memory::format::any));
+
+    filter_md_.reset(new memory::desc({filter_dims},
+                  MklDnnType<T>(), memory::format::any));
+
+    dst_md_.reset(new memory::desc({dst_dims}, MklDnnType<T>(),
+                                   memory::format::any));
+    if (!bias_dims.empty())
+        bias_md_.reset(new memory::desc({bias_dims}, MklDnnType<T>(),
+                                   memory::format::any));
+    // create a convolution
+    if (!bias_dims.empty()) {
+      fwd_desc_.reset(new convolution_forward::desc(prop_kind::forward,
+                      convolution_direct, *src_md_, *filter_md_,
+                      *bias_md_, *dst_md_, strides_, dilations,
+                      padding_l_, padding_r_, padding_kind::zero));
+    } else {
+      fwd_desc_.reset(new convolution_forward::desc(prop_kind::forward,
+                      convolution_direct, *src_md_, *filter_md_,
+                      *dst_md_, strides_, dilations,
+                      padding_l_, padding_r_, padding_kind::zero));
+    }
+
+    fwd_pd_.reset(new convolution_forward::primitive_desc(
+                  *fwd_desc_, cpu_engine_));
+
+    // store the expected memory format
+    src_fmt_ = static_cast<mkldnn::memory::format>(
+                 fwd_pd_.get()->src_primitive_desc().desc().data.format);
+
+    filter_fmt_ = static_cast<mkldnn::memory::format>(
+                 fwd_pd_.get()->weights_primitive_desc().desc().data.format);
+    dst_fmt_ = static_cast<mkldnn::memory::format>(
+                 fwd_pd_.get()->dst_primitive_desc().desc().data.format);
+
+    // create memory primitive based on dummy data
+    src_mem_.reset(new memory(fwd_pd_.get()->src_primitive_desc(), DummyData));
+    filter_mem_.reset(new memory(fwd_pd_.get()->weights_primitive_desc(),
+                      DummyData));
+    dst_mem_.reset(new memory(fwd_pd_.get()->dst_primitive_desc(), DummyData));
+
+    // create convolution primitive and add it to net
+    if (!bias_dims.empty()) {
+        bias_mem_.reset(new memory({{{bias_dims}, MklDnnType<T>(),
+                                   memory::format::x}, cpu_engine_}, DummyData));
+        conv_fwd_.reset(new convolution_forward(*fwd_pd_, *src_mem_,
+                        *filter_mem_, *bias_mem_, *dst_mem_));
+    } else {
+        conv_fwd_.reset(new convolution_forward(*fwd_pd_, *src_mem_,
+                        *filter_mem_, *dst_mem_));
+    }
+
+    fwd_primitives_.push_back(*conv_fwd_);
+    return;
+  }
+
+ public:
+  // Convolution forward execute with bias
+  void Execute(void* src, void* w, void* b, void* dst) {
+    src_mem_->set_data_handle(src);
+    filter_mem_->set_data_handle(w);
+    bias_mem_->set_data_handle(b);
+    dst_mem_->set_data_handle(dst);
+    fwd_stream_->submit(fwd_primitives_);
+
+    // after exec, set data handle back
+    src_mem_->set_data_handle(DummyData);
+    filter_mem_->set_data_handle(DummyData);
+    bias_mem_->set_data_handle(DummyData);
+    dst_mem_->set_data_handle(DummyData);
+
+    return;
+  }
+
+  // Convolution forward execute without bias
+  void Execute(void* src, void* w, void* dst) {
+    src_mem_->set_data_handle(src);
+    filter_mem_->set_data_handle(w);
+    dst_mem_->set_data_handle(dst);
+    fwd_stream_->submit(fwd_primitives_);
+
+    // after exec, set data handle back
+    src_mem_->set_data_handle(DummyData);
+    filter_mem_->set_data_handle(DummyData);
+    dst_mem_->set_data_handle(DummyData);
+
+    return;
+  }
+
+  // expected memory format for this primitive instance
+  memory::format src_fmt_;
+  memory::format filter_fmt_;
+  memory::format dst_fmt_;
+
+  // convolution primitive
+  std::shared_ptr<mkldnn::convolution_forward::primitive_desc> fwd_pd_;
+  std::shared_ptr<mkldnn::primitive> conv_fwd_;
+
+ private:
+  // MKLDNN memory
+  std::shared_ptr<mkldnn::memory> src_mem_;
+  std::shared_ptr<mkldnn::memory> filter_mem_;
+  std::shared_ptr<mkldnn::memory> bias_mem_;
+  std::shared_ptr<mkldnn::memory> dst_mem_;
+
+  std::shared_ptr<mkldnn::stream> fwd_stream_;
+  std::vector<mkldnn::primitive> fwd_primitives_;
+
+  // desc & prmitive desc
+  std::shared_ptr<mkldnn::convolution_forward::desc> fwd_desc_;
+
+  // memory dims
+  mkldnn::memory::dims dilates_;
+  mkldnn::memory::dims strides_;
+  mkldnn::memory::dims padding_l_;
+  mkldnn::memory::dims padding_r_;
+
+  // memory desc
+  std::shared_ptr<mkldnn::memory::desc> src_md_;
+  std::shared_ptr<mkldnn::memory::desc> filter_md_;
+  std::shared_ptr<mkldnn::memory::desc> bias_md_;
+  std::shared_ptr<mkldnn::memory::desc> dst_md_;
+
+  engine cpu_engine_ = engine(engine::cpu, 0);
+};
+
+template <typename T>
+class Conv2DFwdFactory : public DnnOpFactory<T> {
+ private:
+    Conv2DFwdFactory() {}
+    ~Conv2DFwdFactory() {}
+
+ public:
+  static Conv2DFwd<T>* Get(
+                         memory::dims src_dims,
+                         memory::dims filter_dims,
+                         memory::dims bias_dims,
+                         memory::dims dst_dims,
+                         memory::dims strides,
+                         memory::dims dilations,
+                         memory::dims padding_l,
+                         memory::dims padding_r) {
+     Conv2DFwd<T>* conv2d_fwd = nullptr;
+
+     // try to find a suitable one in pool
+     conv2d_fwd = dynamic_cast<Conv2DFwd<T>*> (
+       Conv2DFwdFactory<T>::GetInstance().GetConv2DFwd(
+           src_dims, filter_dims, bias_dims, dst_dims,
+           strides, dilations, padding_l, padding_r));
+
+     if (conv2d_fwd == nullptr) {
+       conv2d_fwd = new Conv2DFwd<T>(
+           src_dims, filter_dims, bias_dims, dst_dims,
+           strides, dilations, padding_l, padding_r);
+       Conv2DFwdFactory<T>::GetInstance().SetConv2DFwd(
+           src_dims, filter_dims, bias_dims, dst_dims,
+           strides, dilations, padding_l, padding_r, conv2d_fwd);
+     } else {
+       // reuse
+     }
+     return conv2d_fwd;
+  }
+
+ private:
+  static const int kDilationH = 0, kDilationW = 1;
+
+  static Conv2DFwdFactory& GetInstance() {
+    static Conv2DFwdFactory instance_;
+    return instance_;
+  }
+
+  static std::string CreateKey(memory::dims src_dims,
+             memory::dims filter_dims,
+             memory::dims bias_dims,
+             memory::dims dst_dims,
+             memory::dims strides,
+             memory::dims dilations,
+             memory::dims padding_l,
+             memory::dims padding_r) {
+    std::string key = "conv2d_fwd_";
+
+    key += DimsToString(src_dims);
+    key += DimsToString(filter_dims);
+    key += DimsToString(bias_dims);
+    key += DimsToString(dst_dims);
+    key += IntToString(dilations[kDilationH]);
+    key += IntToString(dilations[kDilationW]);
+    key += IntToString(strides[0]);
+    key += IntToString(strides[1]);
+    key += IntToString(padding_l[0]);
+    key += IntToString(padding_l[1]);
+    key += IntToString(padding_r[0]);
+    key += IntToString(padding_r[1]);
+    return key;
+  }
+
+  DnnOp* GetConv2DFwd(memory::dims src_dims,
+             memory::dims filter_dims,
+             memory::dims bias_dims,
+             memory::dims dst_dims,
+             memory::dims strides,
+             memory::dims dilations,
+             memory::dims padding_l,
+             memory::dims padding_r) {
+    std::string key = CreateKey(src_dims, filter_dims, bias_dims,
+             dst_dims, strides, dilations, padding_l, padding_r);
+    return this->GetOp(key);
+  }
+
+  void SetConv2DFwd(memory::dims src_dims,
+             memory::dims filter_dims,
+             memory::dims bias_dims,
+             memory::dims dst_dims,
+             memory::dims strides,
+             memory::dims dilations,
+             memory::dims padding_l,
+             memory::dims padding_r,
+             DnnOp *op) {
+    std::string key = CreateKey(src_dims, filter_dims, bias_dims,
+             dst_dims, strides, dilations, padding_l, padding_r);
+    this->SetOp(key, op);
+  }
+};
+
+#endif
+
 typedef Eigen::ThreadPoolDevice CPUDevice;
 
-// MKL-DNN is now default. MKL-ML must be specified explicitly.
+// For now, MKL-ML is default. So making MKL-DNN not a default choice.
 #ifdef INTEL_MKL_ML
-
 template <typename Device, typename T, bool biasEnabled>
 class MklConv2DOp : public OpKernel {
  public:
@@ -528,8 +791,6 @@ class MklConv2DOp : public OpKernel {
 
   void Compute(OpKernelContext* context) override {
     try {
-      auto cpu_engine = engine(engine::cpu, 0);
-
       // Input tensors
       const Tensor& src_tensor = MklGetInput(context, kInputIndex_Src);
       const Tensor& filter_tensor = MklGetInput(context, kInputIndex_Filter);
@@ -538,16 +799,16 @@ class MklConv2DOp : public OpKernel {
       GetMklShape(context, kInputIndex_Src, &src_mkl_shape);
       GetMklShape(context, kInputIndex_Filter, &filter_mkl_shape);
       OP_REQUIRES(context, filter_mkl_shape.IsMklTensor() == false,
-                  errors::InvalidArgument("Filter should not be in "
-                                          "Mkl Layout"));
+            errors::InvalidArgument("Filter should not be in "
+            "Mkl Layout"));
 
       MklDnnData<T> src(&cpu_engine);
       MklDnnData<T> filter(&cpu_engine);
-      MklDnnData<T> output(&cpu_engine);
+      MklDnnData<T> dst(&cpu_engine);  // output
 
       memory::dims src_dims, filter_dims, padding_l, padding_r,
                    dilations, strides;
-      memory::dims output_dims_tf_order, output_dims_mkl_order;
+      memory::dims dst_dims_tf_order, dst_dims_mkl_order;
 
       // Get shapes of input tensors in MKL-DNN order
       MklDnnConvUtil conv_utl(context, strides_, padding_, data_format_,
@@ -555,31 +816,29 @@ class MklConv2DOp : public OpKernel {
       auto src_tf_shape = GetTfShape(context, kInputIndex_Src);
       auto filter_tf_shape = GetTfShape(context, kInputIndex_Filter);
       conv_utl.GetConvFwdSizesInMklOrder(
-          src_tf_shape, filter_tf_shape, &src_dims, &filter_dims, &strides,
-          &dilations, &output_dims_tf_order, &output_dims_mkl_order,
+          src_tf_shape, filter_tf_shape, &src_dims, &filter_dims,
+          &strides, &dilations, &dst_dims_tf_order, &dst_dims_mkl_order,
           &padding_l, &padding_r);
       if (!context->status().ok()) return;
 
       // Check for corner case - if there is nothing to compute, return.
-      TensorShape output_tf_shape = MklDnnDimsToTFShape(output_dims_tf_order);
+      TensorShape dst_tf_shape = MklDnnDimsToTFShape(dst_dims_tf_order);
 
       // Corner cases: output with 0 elements and 0 batch size.
-      Tensor* output_tensor = nullptr;
-      if (output_tf_shape.num_elements() == 0 || output_dims_tf_order[0] == 0) {
-        // TODO(jbobba): Verify correctness here
-        //               Need semantics for Null MKL tensor
-        MklDnnShape output_mkl_shape;
-        output_mkl_shape.SetMklTensor(false);
-
-        AllocateOutputSetMklShape(context, kOutputIndex_Dst, &output_tensor,
-                                  src_tf_shape, output_mkl_shape);
+      Tensor* dst_tensor = nullptr;
+      if (dst_tf_shape.num_elements() == 0 ||
+          dst_dims_tf_order[0] == 0) {
+        MklDnnShape dst_mkl_shape;
+        dst_mkl_shape.SetMklTensor(false);
+        AllocateOutputSetMklShape(context, kOutputIndex_Dst,
+                    &dst_tensor, src_tf_shape, dst_mkl_shape);
 
         // MklConv2D also outputs converted filter as 2nd output of Conv2D.
         filter_mkl_shape.SetMklTensor(false);
         Tensor* output_filter_tensor = nullptr;
         AllocateOutputSetMklShape(context, kOutputIndex_Filter,
-                                  &output_filter_tensor, filter_tf_shape,
-                                  filter_mkl_shape);
+                                  &output_filter_tensor,
+                                  filter_tf_shape, filter_mkl_shape);
         return;
       }
 
@@ -587,6 +846,7 @@ class MklConv2DOp : public OpKernel {
       // Describe how the inputs and outputs of Convolution look like. Also
       // specify buffers containing actual input and output data.
       auto tf_fmt = TFDataFormatToMklDnnDataFormat(data_format_);
+
       // If input is in MKL layout, then simply grab input layout; otherwise,
       // construct input Tf layout. For TF layout, although input shape
       // (src_dims) required is in MKL-DNN order, the layout is Tensorflow's
@@ -595,6 +855,7 @@ class MklConv2DOp : public OpKernel {
                         ? src_mkl_shape.GetMklLayout()
                         : memory::desc(src_dims, MklDnnType<T>(), tf_fmt);
       src.SetUsrMem(src_md, &src_tensor);
+
       // Although filter shape (filter_dims) required is in MKL-DNN order,
       // the layout is Tensorflow's layout (HWIO).
       auto filter_md = filter_mkl_shape.IsMklTensor()  // Should NEVER be true
@@ -603,98 +864,72 @@ class MklConv2DOp : public OpKernel {
                                           memory::format::hwio);
       filter.SetUsrMem(filter_md, &filter_tensor);
 
-      // Set output shape (output_dims) required in MKL-DNN order.
-      // Currently, we set output layout as Tensorflow's layout (NHWC or NCHW
-      // depending on data format). But later we propagate Mkl layout of the
-      // output to the next op directly.
-      output.SetUsrMem(output_dims_mkl_order, tf_fmt);
-
-      // Create memory descriptors for convolution data w/ no specified format.
-      src.SetOpMemDesc(src_dims, memory::format::any);
-      filter.SetOpMemDesc(filter_dims, memory::format::any);
-      output.SetOpMemDesc(output_dims_mkl_order, memory::format::any);
-
       // MKLDNN dilation starts from 0.
       dilations[kDilationH] -= 1;
       dilations[kDilationW] -= 1;
 
+      // get a conv2d fwd from primitive pool
+      Conv2DFwd<T> *conv2d_fwd = nullptr;
+      memory::dims bias_dims = {};
       if (biasEnabled) {
-          // Create convolution primitive with Bias.
-          MklDnnData<T> bias(&cpu_engine);
-          memory::dims bias_size;
-          conv_utl.GetBiasSizeInMklOrder(kInputIndex_Bias, &bias_size);
-          const Tensor& bias_tensor = MklGetInput(context, kInputIndex_Bias);
-          bias.SetUsrMem(bias_size, memory::format::x, &bias_tensor);
-          bias.SetOpMemDesc(bias_size, memory::format::any);
-
-          // Create convolution primitive with Bias.
-          // Use MKLDNN dilated convolution in case of dilated rate (>0).
-          auto conv_desc = (dilations[kDilationH] > 0 ||
-              dilations[kDilationW] > 0) ?
-              convolution_forward::desc(prop_kind::forward,
-                      convolution_direct, src.GetOpMemDesc(),
-                      filter.GetOpMemDesc(), bias.GetOpMemDesc(),
-                      output.GetOpMemDesc(), strides, dilations,
-                      padding_l, padding_r,
-                      TFPaddingToMklDnnPadding(padding_)):
-              convolution_forward::desc(prop_kind::forward,
-                      convolution_direct, src.GetOpMemDesc(),
-                      filter.GetOpMemDesc(), bias.GetOpMemDesc(),
-                      output.GetOpMemDesc(), strides,
-                      padding_l, padding_r,
-                      TFPaddingToMklDnnPadding(padding_));
-
-          auto conv_prim_desc = convolution_forward::primitive_desc(conv_desc,
-                                                                  cpu_engine);
-          AllocateOutputTensor(context, conv_prim_desc,
-                               output_dims_mkl_order, tf_fmt, &output_tensor);
-          // Set data handle for output.
-          output.SetUsrMemDataHandle(output_tensor);
-
-          Tensor* filter_out_tensor = nullptr;
-          AllocateFilterOutputTensor(context, conv_prim_desc,
-                TFShapeToMklDnnDims(filter_tf_shape),
-                &filter_out_tensor);
-
-          PrepareAndExecuteNet(conv_prim_desc, &src, &filter, &bias, &output,
-                               filter_out_tensor);
+        conv_utl.GetBiasSizeInMklOrder(kInputIndex_Bias, &bias_dims);
+        conv2d_fwd = Conv2DFwdFactory<T>::Get(src_dims, filter_dims,
+                        bias_dims, dst_dims_mkl_order,
+                        strides, dilations, padding_l, padding_r);
       } else {
-          // Create convolution primitive without Bias.
-          // Use MKLDNN dilated convolution in case of dilated rate (>0).
-          auto conv_desc = (dilations[kDilationH] > 0 ||
-            dilations[kDilationW] > 0) ?
-            convolution_forward::desc(prop_kind::forward,
-              convolution_direct, src.GetOpMemDesc(),
-              filter.GetOpMemDesc(), output.GetOpMemDesc(),
-              strides, dilations, padding_l, padding_r,
-              TFPaddingToMklDnnPadding(padding_)):
-          convolution_forward::desc(prop_kind::forward,
-              convolution_direct, src.GetOpMemDesc(),
-              filter.GetOpMemDesc(), output.GetOpMemDesc(),
-              strides, padding_l, padding_r,
-              TFPaddingToMklDnnPadding(padding_));
-
-          auto conv_prim_desc = convolution_forward::primitive_desc(conv_desc,
-                                                                  cpu_engine);
-          AllocateOutputTensor(context, conv_prim_desc, output_dims_mkl_order,
-                               tf_fmt, &output_tensor);
-          // Set data handle for output.
-          output.SetUsrMemDataHandle(output_tensor);
-
-          Tensor* filter_out_tensor = nullptr;
-          AllocateFilterOutputTensor(context, conv_prim_desc,
-                TFShapeToMklDnnDims(filter_tf_shape),
-                &filter_out_tensor);
-          PrepareAndExecuteNet(conv_prim_desc, &src, &filter,
-                              nullptr, &output, filter_out_tensor);
+        conv_utl.GetBiasSizeInMklOrder(kInputIndex_Bias, &bias_dims);
+        conv2d_fwd = Conv2DFwdFactory<T>::Get(src_dims, filter_dims,
+                        NONE_DIMS, dst_dims_mkl_order,
+                        strides, dilations, padding_l, padding_r);
       }
-    } catch (mkldnn::error& e) {
+
+      // allocate output tensors output_tensor and filter_out_tensor
+      std::shared_ptr<mkldnn::convolution_forward::primitive_desc>
+      conv_fwd_pd = conv2d_fwd->fwd_pd_;
+      AllocateOutputTensor(context, *conv_fwd_pd,
+                       dst_dims_mkl_order, tf_fmt, &dst_tensor);
+      Tensor* filter_out_tensor = nullptr;
+      AllocateFilterOutputTensor(context, *conv_fwd_pd,
+                                 TFShapeToMklDnnDims(filter_tf_shape),
+                                 &filter_out_tensor);
+
+      void* dst_data = static_cast<void*>(const_cast<T*>(
+                         dst_tensor->flat<T>().data()));
+
+      // check whether src/filter need reorder
+      std::vector<primitive> net;
+      if (src_md.data.format != conv2d_fwd->src_fmt_)
+          src.CheckReorderToOpMem(
+              conv_fwd_pd.get()->src_primitive_desc(), &net);
+
+      if (filter_md.data.format != conv2d_fwd->filter_fmt_)
+          filter.CheckReorderToOpMem(
+              conv_fwd_pd.get()->weights_primitive_desc(),
+              filter.GetTensorBuffer(filter_out_tensor), &net);
+      stream(stream::kind::eager).submit(net).wait();
+
+      void* src_data = static_cast<void*>(
+                src.GetOpMem().get_data_handle());
+      void* filter_data = static_cast<void*>(
+                filter.GetOpMem().get_data_handle());
+
+      // execute convolution
+      if (biasEnabled) {
+        const Tensor& bias_tensor = MklGetInput(context, kInputIndex_Bias);
+        void* bias_data =  static_cast<void*>(const_cast<T*>(
+                             bias_tensor.flat<T>().data()));
+
+        conv2d_fwd->Execute(src_data, filter_data, bias_data, dst_data);
+      } else {
+        conv2d_fwd->Execute(src_data, filter_data, dst_data);
+      }
+    } catch (mkldnn::error &e) {
       string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + std::string(e.message) + ", in file " +
-                         std::string(__FILE__) + ":" + std::to_string(__LINE__);
-      OP_REQUIRES_OK(
-          context,
-          errors::Aborted("Operation received an exception:", error_msg));
+                       ", message: " + std::string(e.message) +
+                       ", in file " + std::string(__FILE__) + ":" +
+                       std::to_string(__LINE__);
+      OP_REQUIRES_OK(context,
+        errors::Aborted("Operation received an exception:", error_msg));
     }
   }
 
@@ -706,6 +941,7 @@ class MklConv2DOp : public OpKernel {
   const int kInputIndex_Src = 0, kInputIndex_Filter = 1, kInputIndex_Bias = 2;
   const int kOutputIndex_Dst = 0, kOutputIndex_Filter = 1;
   const int kDilationH = 0, kDilationW = 1;
+  engine cpu_engine = engine(engine::cpu, 0);
 
   // Allocate output tensor.
   void AllocateOutputTensor(

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1762,7 +1762,6 @@ class MklDnnData {
 class DnnOp {
  public:
   virtual ~DnnOp() {}
-  virtual void Execute() = 0;
 
   // Dummy data. Its size, hard-coded as 256 here, does
   // not matter since MKL should never operate on this buffer.
@@ -1817,24 +1816,14 @@ class FactoryKeyCreator {
 
   void AddAsKey(const mkldnn::memory::dims &dims) {
     for (unsigned int i = 0; i < dims.size(); i++) {
-      AddAsKey(dims[i]);
+      AddAsKey<int>(dims[i]);
     }
   }
 
-  void AddAsKey(const float data) {
+  template <typename T>
+  void AddAsKey(const T data) {
     auto buffer = reinterpret_cast<const char *>(&data);
-    Append(buffer, sizeof(float));
-  }
-
-  void AddAsKey(const int data) {
-    auto buffer = reinterpret_cast<const char*>(&data);
-    auto len = sizeof(data) - (__builtin_clz(data)/8);
-    Append(buffer, len);
-  }
-
-  void AddAsKey(const bool data) {
-    auto buffer = reinterpret_cast<const char*>(&data);
-    Append(buffer, sizeof(bool));
+    Append(buffer, sizeof(T));
   }
 
   std::string GetKey() {

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1765,7 +1765,8 @@ class DnnOp {
   virtual void Setup() {return;}
   virtual void Execute() {return;}
 
-  // dummy data
+  // Dummy data. Its size, hard-coded as 256 here, does
+  // not matter since MKL should never operate on this buffer.
   unsigned char DummyData[256];
 };
 
@@ -1777,7 +1778,7 @@ class DnnOpFactory {
   DnnOpFactory() {}
   ~DnnOpFactory() {}
 
-  DnnOp* GetOp(std::string key) {
+  DnnOp* GetOp(const std::string& key) {
     auto stream_iter = DnnOpFactory<T>::GetHashMap().find(key);
     if (stream_iter == DnnOpFactory<T>::GetHashMap().end()) {
       return nullptr;
@@ -1786,7 +1787,7 @@ class DnnOpFactory {
     }
   }
 
-  void SetOp(std::string key, DnnOp* op) {
+  void SetOp(const std::string& key, DnnOp* op) {
     auto stream_iter = DnnOpFactory<T>::GetHashMap().find(key);
 
     CHECK(stream_iter == DnnOpFactory<T>::GetHashMap().end());
@@ -1803,26 +1804,40 @@ class DnnOpFactory {
 
 // utility functions which convert int, double, bool or dims to string
 static inline std::string IntToString(int value) {
-  return "I" + std::to_string(value) + "_";
+  std::string strInt = "I";
+  strInt.append(std::to_string(value));
+  strInt.append("_");
+  return strInt;
 }
 
 static inline std::string DoubleToString(double value) {
-  return "D" + std::to_string(value) + "_";
+  std::string strDouble = "D";
+  strDouble.append(std::to_string(value));
+  strDouble.append("_");
+  return strDouble;
 }
 
 static inline std::string FloatToString(float value) {
-  return "F" + std::to_string(value) + "_";
+  std::string strFloat = "F";
+  strFloat.append(std::to_string(value));
+  strFloat.append("_");
+  return strFloat;
 }
 
 static inline std::string BoolToString(bool value) {
-  return "B" + std::to_string(value) + "_";
+  std::string strBool = "B";
+  strBool.append(std::to_string(value));
+  strBool.append("_");
+  return strBool;
 }
 
 static inline std::string DimsToString(mkldnn::memory::dims dims) {
   std::string strDims = "DIMS:";
-  for (unsigned int i = 0; i < dims.size(); i++)
-    strDims += std::to_string(dims[i]) + ",";
-  strDims += ";";
+  for (unsigned int i = 0; i < dims.size(); i++) {
+    strDims.append(std::to_string(dims[i]));
+    strDims.append(",");
+  }
+  strDims.append(";");
   return strDims;
 }
 

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1762,8 +1762,7 @@ class MklDnnData {
 class DnnOp {
  public:
   virtual ~DnnOp() {}
-  virtual void Setup() {return;}
-  virtual void Execute() {return;}
+  virtual void Execute() = 0;
 
   // Dummy data. Its size, hard-coded as 256 here, does
   // not matter since MKL should never operate on this buffer.


### PR DESCRIPTION
This enhancement enables MKL primitive reuse for conv2d forward operation to reduce the overload of 
repetitive creations of primitives. It 

- Improves MKL op based training performance 
- Improves MKL op based inference performance, especially for small batch size including BS=1 case