### PR TITLE
Fix a minor tuple plus operation

### DIFF
--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -876,7 +876,7 @@ class RNNCellTest(test.TestCase):
   def testConv1DLSTMCell(self):
     with self.test_session() as sess:
       shape = [2, 1]
-      filter_size = [3]
+      filter_size = tuple([3])
       num_features = 1
       expected_state_c = np.array(
           [[[1.4375670191], [1.4375670191]], [[2.7542609292], [2.7542609292]]],

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -2109,7 +2109,7 @@ class ConvLSTMCell(rnn_cell_impl.RNNCell):
 
   def call(self, inputs, state, scope=None):
     cell, hidden = state
-    new_hidden = _conv([inputs, hidden], self._kernel_shape,
+    new_hidden = _conv((inputs, hidden), self._kernel_shape,
                        4 * self._output_channels, self._use_bias)
     gates = array_ops.split(
         value=new_hidden, num_or_size_splits=4, axis=self._conv_ndims + 1)

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -2204,7 +2204,7 @@ def _conv(args, filter_size, num_features, bias, bias_start=0.0):
 
   # Now the computation.
   kernel = vs.get_variable(
-      "kernel", filter_size + [total_arg_size_depth, num_features], dtype=dtype)
+      "kernel", filter_size + (total_arg_size_depth, num_features), dtype=dtype)
   if len(args) == 1:
     res = conv_op(args[0], kernel, strides, padding="SAME")
   else:

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -2109,7 +2109,7 @@ class ConvLSTMCell(rnn_cell_impl.RNNCell):
 
   def call(self, inputs, state, scope=None):
     cell, hidden = state
-    new_hidden = _conv((inputs, hidden), self._kernel_shape,
+    new_hidden = _conv([inputs, hidden], self._kernel_shape,
                        4 * self._output_channels, self._use_bias)
     gates = array_ops.split(
         value=new_hidden, num_or_size_splits=4, axis=self._conv_ndims + 1)


### PR DESCRIPTION
This PR is to fix a minor bracket format for tuple plus operation.

As we can see [_conv definition](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/rnn/python/ops/rnn_cell.py#L2167), the input arg "filter_size" is an int tuple.
>   #Now the computation.
>   kernel = vs.get_variable(
>       "kernel", filter_size + (total_arg_size_depth, num_features), dtype=dtype)

Thus this PR is to fix above "[]" with "()" since plus operation should be on same data type tuple instead of list.