### PR TITLE
Fix the feature shape of maxout output

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -2984,6 +2984,12 @@ def maxout(inputs, num_units, axis=-1, scope=None):
         shape[i] = array_ops.shape(inputs)[i]
     outputs = math_ops.reduce_max(
         array_ops.reshape(inputs, shape), -1, keepdims=False)
+
+    # Specify the final number of features in the maxout axis
+    shape = inputs.get_shape().as_list()
+    shape[self.axis] = self.num_units
+    outputs.set_shape(shape)
+
     return outputs
 
 


### PR DESCRIPTION
This PR is to fix the feature shape of maxout.

In tf.contrib.layers.maxout(), when the shape of "inputs" is not completely specified, the shape of its output will be completely unknown, such as [None, None, None] in the 3D case.

Since "num_units" has specified the final number of features in the maxout axis, the output can leverage it to set its shape accordingly.