### PR TITLE
Fix tf.svd docs issue

### DIFF
--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -429,7 +429,7 @@ def svd(tensor, full_matrices=False, compute_uv=True, name=None):
   u, s, v_adj = np.linalg.svd(a, full_matrices=False)
   np_a_approx = np.dot(u, np.dot(np.diag(s), v_adj))
   # tf_a_approx and np_a_approx should be numerically close.
-  ````
+  ```
   @end_compatibility
   """
   s, u, v = gen_linalg_ops.svd(


### PR DESCRIPTION
This fix tries to fix tf.svd docs issue where "````" (four backticks)
were used instead of three backticks (See previous "```python" with three backpacks). That caused the docs to render incorrectly.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>