### PR TITLE
CUDNN grouped convolutions + depthwise convolution

### DIFF
--- a/tensorflow/contrib/fused_conv/kernels/fused_conv_ops_gpu.h
+++ b/tensorflow/contrib/fused_conv/kernels/fused_conv_ops_gpu.h
@@ -34,7 +34,7 @@ class FusedConvParameters : public ConvParameters {
                       const SpatialArray& padding, DataType dtype,
                       int device_id, bool has_side_input,
                       ActivationMode activation_mode)
-      : ConvParameters(batch, in_depths, in, out_depths, filter, dilation,
+      : ConvParameters(batch, in_depths, in, out_depths, filter, /* groups */ 1, dilation,
                        stride, padding, dtype, device_id),
         activation_mode_(activation_mode),
         has_side_input_(has_side_input) {

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3279,6 +3279,7 @@ tf_kernel_library(
     deps = [
         ":bounds_check",
         ":ops_util",
+        ":conv_ops",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -898,6 +898,7 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       dims.out_depth,                        // out_depths
       {{dims.spatial_dims[0].filter_size,    // filter_rows
         dims.spatial_dims[1].filter_size}},  // filter_cols
+      1,                                     // groups
       {{dims.spatial_dims[0].dilation,       // dilation_rows
         dims.spatial_dims[1].dilation}},     // dilation_cols
       {{dims.spatial_dims[0].stride,         // stride_rows

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -1046,6 +1046,12 @@ REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropFilter")
                             .TypeConstraint<Eigen::half>("T")
                             .HostMemory("filter_sizes"),
                         Conv2DSlowBackpropFilterOp<GPUDevice, Eigen::half>);
+
+// To be used inside depthwise_conv_grad_op.cc.
+template struct LaunchConv2DBackpropFilterOp<GPUDevice, Eigen::half>;
+template struct LaunchConv2DBackpropFilterOp<GPUDevice, float>;
+template struct LaunchConv2DBackpropFilterOp<GPUDevice, double>;
+
 #endif  // GOOGLE_CUDA
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -807,7 +807,7 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
   perftools::gputools::dnn::FilterDescriptor filter_desc;
   filter_desc.set_input_filter_height(dims.spatial_dims[0].filter_size)
       .set_input_filter_width(dims.spatial_dims[1].filter_size)
-      .set_input_feature_map_count(dims.in_depth)
+      .set_input_feature_map_count(dims.in_depth / groups)
       .set_output_feature_map_count(dims.out_depth);
   perftools::gputools::dnn::ConvolutionDescriptor conv_desc;
   conv_desc.set_vertical_dilation_rate(dims.spatial_dims[0].dilation)
@@ -835,7 +835,7 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
   Tensor pre_transformed_filter_backprop;
   OP_REQUIRES_OK(
       ctx, ctx->allocate_temp(DataTypeToEnum<T>::value,
-                              TensorShape({dims.out_depth, dims.in_depth,
+                              TensorShape({dims.out_depth, dims.in_depth / groups,
                                            dims.spatial_dims[0].filter_size,
                                            dims.spatial_dims[1].filter_size}),
                               &pre_transformed_filter_backprop));
@@ -904,7 +904,7 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       dims.out_depth,                        // out_depths
       {{dims.spatial_dims[0].filter_size,    // filter_rows
         dims.spatial_dims[1].filter_size}},  // filter_cols
-      groups,                                     // groups
+      groups,                                // groups
       {{dims.spatial_dims[0].dilation,       // dilation_rows
         dims.spatial_dims[1].dilation}},     // dilation_cols
       {{dims.spatial_dims[0].stride,         // stride_rows

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -1120,6 +1120,12 @@ REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropInput")
                             .TypeConstraint<Eigen::half>("T")
                             .HostMemory("input_sizes"),
                         Conv2DSlowBackpropInputOp<GPUDevice, Eigen::half>);
+
+// to be used inside depthwise_conv_grad_op.cc
+template struct LaunchConv2DBackpropInputOp<GPUDevice, Eigen::half>;
+template struct LaunchConv2DBackpropInputOp<GPUDevice, float>;
+template struct LaunchConv2DBackpropInputOp<GPUDevice, double>;
+
 #endif  // GOOGLE_CUDA
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -862,7 +862,7 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
   perftools::gputools::dnn::FilterDescriptor filter_desc;
   filter_desc.set_input_filter_height(dims.spatial_dims[0].filter_size)
       .set_input_filter_width(dims.spatial_dims[1].filter_size)
-      .set_input_feature_map_count(dims.in_depth)
+      .set_input_feature_map_count(dims.in_depth / groups)
       .set_output_feature_map_count(dims.out_depth);
   perftools::gputools::dnn::ConvolutionDescriptor conv_desc;
   conv_desc.set_vertical_dilation_rate(dims.spatial_dims[0].dilation)
@@ -889,7 +889,7 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
   Tensor transformed_filter;
   OP_REQUIRES_OK(
       ctx, ctx->allocate_temp(DataTypeToEnum<T>::value,
-                              TensorShape({dims.out_depth, dims.in_depth,
+                              TensorShape({dims.out_depth, dims.in_depth / groups,
                                            dims.spatial_dims[0].filter_size,
                                            dims.spatial_dims[1].filter_size}),
                               &transformed_filter));

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -947,6 +947,7 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
       dims.out_depth,                        // out_depths
       {{dims.spatial_dims[0].filter_size,    // filter_rows
         dims.spatial_dims[1].filter_size}},  // filter_cols
+      1,                                     // groups
       {{dims.spatial_dims[0].dilation,       // dilation_rows
         dims.spatial_dims[1].dilation}},     // dilation_cols
       {{dims.spatial_dims[0].stride,         // stride_rows

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -723,7 +723,7 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
   ConvBackpropDimensions dims;
   OP_REQUIRES_OK(ctx, ConvBackpropComputeDimensionsV2(
                           "Conv2DSlowBackpropInput", /*num_spatial_dims=*/2,
-                          input_shape, filter_shape, out_backprop.shape(),
+                          /*groups=1*/ 1, input_shape, filter_shape, out_backprop.shape(),
                           dilations, strides, padding, data_format, &dims));
 
   // TODO(yangzihao): The padding computations should be done in

--- a/tensorflow/core/kernels/conv_grad_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_ops.cc
@@ -95,7 +95,7 @@ Status ConvBackpropExtractAndVerifyDimension(
 }
 
 Status ConvBackpropComputeDimensionsV2(
-    StringPiece label, int num_spatial_dims, const TensorShape& input_shape,
+    StringPiece label, int num_spatial_dims, int num_groups, const TensorShape& input_shape,
     const TensorShape& filter_shape, const TensorShape& out_backprop_shape,
     const gtl::ArraySlice<int32>& dilations, const std::vector<int32>& strides,
     Padding padding, TensorFormat data_format, ConvBackpropDimensions* dims) {
@@ -131,7 +131,7 @@ Status ConvBackpropComputeDimensionsV2(
     return errors::InvalidArgument(
         label, ": input and filter must have the same depth");
   }
-  dims->out_depth = filter_shape.dim_size(num_dims - 1);
+  dims->out_depth = filter_shape.dim_size(num_dims - 1) * num_groups;
   if (dims->out_depth != out_backprop_shape.dim_size(feature_dim)) {
     return errors::InvalidArgument(
         label, ": filter and out_backprop must have the same out_depth");
@@ -156,7 +156,7 @@ Status ConvBackpropComputeDimensions(StringPiece label, int num_spatial_dims,
                                      ConvBackpropDimensions* dims) {
   static constexpr std::array<int32, 5> one_dilations = {{1, 1, 1, 1, 1}};
   return ConvBackpropComputeDimensionsV2(
-      label, num_spatial_dims, input_shape, filter_shape, out_backprop_shape,
+      label, num_spatial_dims, 1, input_shape, filter_shape, out_backprop_shape,
       one_dilations, strides, padding, data_format, dims);
 }
 

--- a/tensorflow/core/kernels/conv_grad_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_ops.cc
@@ -124,14 +124,18 @@ Status ConvBackpropComputeDimensionsV2(
   }
 
   int feature_dim = GetTensorFeatureDimIndex(num_dims, data_format);
-  dims->in_depth = input_shape.dim_size(feature_dim);
+  int64 in_depth = input_shape.dim_size(feature_dim);
+
+  dims->in_depth = in_depth;
   // The input and output feature dimensions are the second last and last
   // dimensions of the filter Tensor.
-  if (dims->in_depth != filter_shape.dim_size(num_dims - 2)) {
+  // When the number of groups is > 1, the input is divided into that many groups,
+  // and the filter is applied across each group.
+  if (dims->in_depth != filter_shape.dim_size(num_dims - 2) * num_groups) {
     return errors::InvalidArgument(
         label, ": input and filter must have the same depth");
   }
-  dims->out_depth = filter_shape.dim_size(num_dims - 1) * num_groups;
+  dims->out_depth = filter_shape.dim_size(num_dims - 1);
   if (dims->out_depth != out_backprop_shape.dim_size(feature_dim)) {
     return errors::InvalidArgument(
         label, ": filter and out_backprop must have the same out_depth");

--- a/tensorflow/core/kernels/conv_grad_ops.h
+++ b/tensorflow/core/kernels/conv_grad_ops.h
@@ -176,7 +176,7 @@ struct LaunchConv2DBackpropInputOp {
   void operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
                   const Tensor& out_backprop, const Tensor& filter,
                   int row_dilation, int col_dilation, int row_stride,
-                  int col_stride, const Padding& padding, Tensor* in_backprop,
+                  int col_stride, int groups, const Padding& padding, Tensor* in_backprop,
                   TensorFormat data_format);
 };
 
@@ -194,7 +194,7 @@ template <typename T>
 struct LaunchConv2DBackpropInputOp<Eigen::GpuDevice, T> {
   void operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
                   const Tensor& input, const Tensor& filter, int row_dilation,
-                  int col_dilation, int row_stride, int col_stride,
+                  int col_dilation, int row_stride, int col_stride, int groups,
                   const Padding& padding, Tensor* output,
                   TensorFormat data_format);
 };

--- a/tensorflow/core/kernels/conv_grad_ops.h
+++ b/tensorflow/core/kernels/conv_grad_ops.h
@@ -185,7 +185,7 @@ struct LaunchConv2DBackpropFilterOp {
   void operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
                   const Tensor& out_backprop, const Tensor& input,
                   int row_dilation, int col_dilation, int row_stride,
-                  int col_stride, const Padding& padding,
+                  int col_stride, int groups, const Padding& padding,
                   Tensor* filter_backprop, TensorFormat data_format);
 };
 
@@ -204,7 +204,7 @@ struct LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T> {
   void operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
                   const Tensor& out_backprop, const Tensor& input,
                   int row_dilation, int col_dilation, int row_stride,
-                  int col_stride, const Padding& padding,
+                  int col_stride, int groups, const Padding& padding,
                   Tensor* filter_backprop, TensorFormat data_format);
 };
 #endif  // GOOGLE_CUDA
@@ -250,7 +250,7 @@ Status ConvBackpropComputeDimensions(StringPiece label, int num_spatial_dims,
 // The V2 version computes the same outputs with arbitrary dilation rate.
 // TODO(b/67112639): Merge V2 versions and the original versions eventually.
 Status ConvBackpropComputeDimensionsV2(
-    StringPiece label, int num_spatial_dims, const TensorShape& input_shape,
+    StringPiece label, int num_spatial_dims, int num_groups, const TensorShape& input_shape,
     const TensorShape& filter_shape, const TensorShape& out_backprop_shape,
     const gtl::ArraySlice<int32>& dilations, const std::vector<int32>& strides,
     Padding padding, TensorFormat data_format, ConvBackpropDimensions* dims);

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -645,6 +645,7 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
         {{input_size[0], input_size[1], input_size[2]}},
         out_depth,
         {{filter_size[0], filter_size[1], filter_size[2]}},
+        1, // groups
         // TODO(yangzihao): Send in arbitrary dilation rates after the dilated
         // conv is supported.
         /*dilation=*/{{1, 1, 1}},
@@ -1014,6 +1015,7 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
         {{input_size[0], input_size[1], input_size[2]}},
         out_depth,
         {{filter_size[0], filter_size[1], filter_size[2]}},
+        1, // groups
         {{1, 1, 1}},
         {{strides[0], strides[1], strides[2]}},
         {{padding_planes, padding_rows, padding_cols}},

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -696,6 +696,7 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
       out_depths,        // out_depths
       {{patch_rows,      // filter_rows
         patch_cols}},    // filter_cols
+      1,                 // groups
       {{row_dilation,    // dilation_rows
         col_dilation}},  // dilation_cols
       {{row_stride,      // stride_rows

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -840,9 +840,9 @@ REGISTER_KERNEL_BUILDER(
     Conv2DOp<GPUDevice, double>);
 
 // To be used inside depthwise_conv_op.cc.
-// template class LaunchConv2DOp<GPUDevice, Eigen::half>;
-// template class LaunchConv2DOp<GPUDevice, float>;
-// template class LaunchConv2DOp<GPUDevice, double>;
+template struct LaunchConv2DOp<GPUDevice, Eigen::half>;
+template struct LaunchConv2DOp<GPUDevice, float>;
+template struct LaunchConv2DOp<GPUDevice, double>;
 
 #endif  // GOOGLE_CUDA
 

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -706,7 +706,7 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
       out_depths,        // out_depths
       {{patch_rows,      // filter_rows
         patch_cols}},    // filter_cols
-      groups,                 // groups
+      groups,            // groups
       {{row_dilation,    // dilation_rows
         col_dilation}},  // dilation_cols
       {{row_stride,      // stride_rows

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -840,9 +840,9 @@ REGISTER_KERNEL_BUILDER(
     Conv2DOp<GPUDevice, double>);
 
 // To be used inside depthwise_conv_op.cc.
-template class LaunchConv2DOp<GPUDevice, Eigen::half>;
-template class LaunchConv2DOp<GPUDevice, float>;
-template class LaunchConv2DOp<GPUDevice, double>;
+// template class LaunchConv2DOp<GPUDevice, Eigen::half>;
+// template class LaunchConv2DOp<GPUDevice, float>;
+// template class LaunchConv2DOp<GPUDevice, double>;
 
 #endif  // GOOGLE_CUDA
 

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -114,7 +114,7 @@ template <typename T>
 struct LaunchConv2DOp<CPUDevice, T> {
   void operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
                   const Tensor& input, const Tensor& filter, int row_dilation,
-                  int col_dilation, int row_stride, int col_stride,
+                  int col_dilation, int row_stride, int col_stride, int groups,
                   const Padding& padding, Tensor* output,
                   TensorFormat data_format) {
     if (data_format != FORMAT_NHWC) {
@@ -123,6 +123,14 @@ struct LaunchConv2DOp<CPUDevice, T> {
                                 "NHWC tensor format for now."));
       return;
     }
+
+    if (groups != 1) {
+      ctx->SetStatus(
+          errors::Unimplemented("Generic conv implementation only supports "
+                                "groups = 1 for now."));
+      return;
+    }
+
     LaunchGeneric<CPUDevice, T>()(ctx, input, filter, row_stride, col_stride,
                                   row_dilation, col_dilation, padding, output,
                                   data_format);
@@ -420,8 +428,9 @@ class Conv2DOp : public BinaryOp<T> {
     }
 
     launcher_(context, use_cudnn_, cudnn_use_autotune_, input, filter,
-              dilation_rows, dilation_cols, stride_rows, stride_cols, padding_,
-              output, data_format_);
+              dilation_rows, dilation_cols, stride_rows, stride_cols,
+              1, // groups
+              padding_, output, data_format_);
   }
 
  private:
@@ -482,7 +491,7 @@ template <typename T>
 void LaunchConv2DOp<GPUDevice, T>::operator()(
     OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
     const Tensor& input_param, const Tensor& filter, int row_dilation,
-    int col_dilation, int row_stride, int col_stride, const Padding& padding,
+    int col_dilation, int row_stride, int col_stride, int groups, const Padding& padding,
     Tensor* output, TensorFormat data_format) {
   using perftools::gputools::dnn::AlgorithmConfig;
   using perftools::gputools::dnn::AlgorithmDesc;
@@ -500,7 +509,7 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
   Tensor input = input_param;
 
   if (filter.dim_size(0) == 1 && filter.dim_size(1) == 1 && row_dilation == 1 &&
-      col_dilation == 1 && row_stride == 1 && col_stride == 1 &&
+      col_dilation == 1 && row_stride == 1 && col_stride == 1 && groups == 1 &&
       data_format == FORMAT_NHWC) {
     // 1x1 filter, so call cublas directly.
     const uint64 m = input.dim_size(0) * input.dim_size(1) * input.dim_size(2);
@@ -527,7 +536,7 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
     return;
   } else if (filter.dim_size(0) == input.dim_size(1) &&
              filter.dim_size(1) == input.dim_size(2) && row_dilation == 1 &&
-             col_dilation == 1 && padding == VALID &&
+             col_dilation == 1 && padding == VALID && groups == 1 &&
              data_format == FORMAT_NHWC) {
     // The input data and filter have the same height/width, so call cublas
     // directly.
@@ -652,7 +661,8 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
       .set_vertical_filter_stride(row_stride)
       .set_horizontal_filter_stride(col_stride)
       .set_zero_padding_height(padding_rows / 2)
-      .set_zero_padding_width(padding_cols / 2);
+      .set_zero_padding_width(padding_cols / 2)
+      .set_group_count(groups);
 
   Tensor transformed_filter;
   OP_REQUIRES_OK(ctx, ctx->allocate_temp(
@@ -696,7 +706,7 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
       out_depths,        // out_depths
       {{patch_rows,      // filter_rows
         patch_cols}},    // filter_cols
-      1,                 // groups
+      groups,                 // groups
       {{row_dilation,    // dilation_rows
         col_dilation}},  // dilation_cols
       {{row_stride,      // stride_rows
@@ -830,7 +840,9 @@ REGISTER_KERNEL_BUILDER(
     Conv2DOp<GPUDevice, double>);
 
 // To be used inside depthwise_conv_op.cc.
+template class LaunchConv2DOp<GPUDevice, Eigen::half>;
 template class LaunchConv2DOp<GPUDevice, float>;
+template class LaunchConv2DOp<GPUDevice, double>;
 
 #endif  // GOOGLE_CUDA
 

--- a/tensorflow/core/kernels/conv_ops.h
+++ b/tensorflow/core/kernels/conv_ops.h
@@ -35,7 +35,7 @@ template <typename Device, typename T>
 struct LaunchConv2DOp {
   void operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
                   const Tensor& input, const Tensor& filter, int row_dilation,
-                  int col_dilation, int row_stride, int col_stride,
+                  int col_dilation, int row_stride, int col_stride, int groups,
                   const Padding& padding, Tensor* output,
                   TensorFormat data_format);
 };
@@ -45,7 +45,7 @@ template <typename T>
 struct LaunchConv2DOp<Eigen::GpuDevice, T> {
   void operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
                   const Tensor& input, const Tensor& filter, int row_dilation,
-                  int col_dilation, int row_stride, int col_stride,
+                  int col_dilation, int row_stride, int col_stride, int groups,
                   const Padding& padding, Tensor* output,
                   TensorFormat data_format);
 };

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -377,6 +377,7 @@ struct LaunchConvOp<GPUDevice, T> {
         {{in_planes, in_rows, in_cols}},
         out_depth,
         {{filter_planes, filter_rows, filter_cols}},
+        1, // groups
         // TODO(yangzihao): Send in arbitrary dilation rates after the dilated
         // conv is supported.
         /*dilation=*/{{1, 1, 1}},

--- a/tensorflow/core/kernels/conv_ops_gpu.h
+++ b/tensorflow/core/kernels/conv_ops_gpu.h
@@ -89,12 +89,13 @@ class ConvParameters {
  public:
   using SpatialArray = gtl::InlinedVector<int64, 3>;
   ConvParameters(int64 batch, int64 in_depths, const SpatialArray& in,
-                 int64 out_depths, const SpatialArray& filter,
+                 int64 out_depths, const SpatialArray& filter, int64 groups,
                  const SpatialArray& dilation, const SpatialArray& stride,
                  const SpatialArray& padding, DataType dtype, int device_id)
       : batch_(batch),
         in_depths_(in_depths),
         out_depths_(out_depths),
+        groups_(groups),
         in_(in),
         filter_(filter),
         dilation_(dilation),
@@ -107,6 +108,7 @@ class ConvParameters {
     for (int64 val : in) hash_code_ = Hash64Combine(hash_code_, val);
     hash_code_ = Hash64Combine(hash_code_, out_depths);
     for (int64 val : filter) hash_code_ = Hash64Combine(hash_code_, val);
+    hash_code_ = Hash64Combine(hash_code_, groups);
     for (int64 val : dilation) hash_code_ = Hash64Combine(hash_code_, val);
     for (int64 val : stride) hash_code_ = Hash64Combine(hash_code_, val);
     for (int64 val : padding) hash_code_ = Hash64Combine(hash_code_, val);
@@ -155,11 +157,11 @@ class ConvParameters {
 
  protected:
   using ParameterDataType =
-      std::tuple<int64, int64, SpatialArray, int64, SpatialArray, SpatialArray,
+      std::tuple<int64, int64, SpatialArray, int64, SpatialArray, int64, SpatialArray,
                  SpatialArray, SpatialArray, DataType, int>;
 
   ParameterDataType get_data_as_tuple() const {
-    return std::make_tuple(batch_, in_depths_, in_, out_depths_, filter_,
+    return std::make_tuple(batch_, in_depths_, in_, out_depths_, filter_, groups_,
                            dilation_, stride_, padding_, dtype_, device_id_);
   }
 
@@ -169,6 +171,7 @@ class ConvParameters {
   int64 batch_;
   int64 in_depths_;
   int64 out_depths_;
+  int64 groups_;
   SpatialArray in_;
   SpatialArray filter_;
   SpatialArray dilation_;

--- a/tensorflow/core/kernels/conv_ops_gpu_3.cu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu_3.cu.cc
@@ -1009,14 +1009,18 @@ struct NCHWToNHWC<GPUDevice, T, NDIMS> {
 
 template struct functor::ShuffleAndReverse<GPUDevice, float, 4, int>;
 template struct functor::ShuffleAndReverse<GPUDevice, Eigen::half, 4, int>;
+template struct functor::ShuffleAndReverse<GPUDevice, double, 4, int>;
 
 template struct functor::ShuffleAndReverse<GPUDevice, float, 4,
                                            Eigen::DenseIndex>;
 template struct functor::ShuffleAndReverse<GPUDevice, Eigen::half, 4,
                                            Eigen::DenseIndex>;
+template struct functor::ShuffleAndReverse<GPUDevice, double, 4,
+                                           Eigen::DenseIndex>;
 
 template struct functor::TransformDepth<GPUDevice, float, int>;
 template struct functor::TransformDepth<GPUDevice, Eigen::half, int>;
+template struct functor::TransformDepth<GPUDevice, double, int>;
 
 template struct functor::SwapDimension1And2InTensor3<GPUDevice, uint8>;
 template struct functor::SwapDimension1And2InTensor3<GPUDevice, uint16>;

--- a/tensorflow/core/kernels/conv_ops_test.cc
+++ b/tensorflow/core/kernels/conv_ops_test.cc
@@ -43,6 +43,7 @@ TEST(ConvParameters, WinogradNonfusedAlgoSize) {
       128,       // out_depths
       {{3,       // filter_rows
         3}},     // filter_cols
+        1,       // groups
       {{1,       // dilation_rows
         1}},     // dilation_cols
       {{1,       // stride_rows
@@ -62,6 +63,7 @@ TEST(ConvParameters, WinogradNonfusedAlgoSize) {
       768,       // out_depths
       {{3,       // filter_rows
         3}},     // filter_cols
+        1,       // groups
       {{1,       // dilation_rows
         1}},     // dilation_cols
       {{1,       // stride_rows

--- a/tensorflow/core/kernels/depthwise_conv_grad_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_grad_op.cc
@@ -592,7 +592,8 @@ class DepthwiseConv2dNativeBackpropInputOp : public OpKernel {
     #if GOOGLE_CUDA
     // If we have CUDNN group convolutions for conv2d, we can
     // dispatch a standard conv2d with groups = in_depth.
-    if (std::is_same<Device, GPUDevice>::value && use_cudnn_) {
+    if (std::is_same<Device, GPUDevice>::value &&
+        DepthwiseConvUseGroupedConv() && use_cudnn_) {
       // Currently, our filter is arranged as:
       // [rows, cols, in_depth, depth_mul].
       // However, in the grouped convolution, we should have the filter
@@ -1009,7 +1010,8 @@ class DepthwiseConv2dNativeBackpropFilterOp : public OpKernel {
 
     #if GOOGLE_CUDA
     // Use standard conv2d launcher with groups = in_depth.
-    if (std::is_same<Device, GPUDevice>::value && use_cudnn_) {
+    if (std::is_same<Device, GPUDevice>::value &&
+        DepthwiseConvUseGroupedConv() && use_cudnn_) {
       // Currently, our filter backprop is arranged as:
       // [rows, cols, in_depth, depth_mul].
       // However, in the grouped convolution, we should have the filter

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -382,6 +382,18 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
       return;
     }
 
+    #if CUDNN_VERSION >= 7000
+    // CUDNN_VERSION >= 7000 introduces convolution groups for convolutions.
+    // we can thus use the standard conv2d launcher with groups = in_depth
+    // when CUDNN is enabled.
+    if (use_cudnn_) {
+      launcher_(context, us_cudnn_, cudnn_use_autotune_, input, filter,
+                /*row_dilation=*/1, /*col_dilation=*/1, stride_, stride_,
+                /*groups=*/in_depth, padding_, output, data_format_);
+      return;
+    }
+    #endif
+
     DepthwiseArgs args;
     args.batch = batch;
     args.in_rows = input_rows;

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -382,12 +382,12 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
       return;
     }
 
-    #if CUDNN_VERSION >= 7000
-    // CUDNN_VERSION >= 7000 introduces convolution groups for convolutions.
+    #if GOOGLE_CUDA
+    // CUDNN 7 introduces convolution groups for convolutions.
     // we can thus use the standard conv2d launcher with groups = in_depth
     // when CUDNN is enabled.
     if (use_cudnn_) {
-      launcher_(context, us_cudnn_, cudnn_use_autotune_, input, filter,
+      launcher_(context, use_cudnn_, cudnn_use_autotune_, input, filter,
                 /*row_dilation=*/1, /*col_dilation=*/1, stride_, stride_,
                 /*groups=*/in_depth, padding_, output, data_format_);
       return;

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -377,6 +377,7 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
       // conv is supported.
       launcher_(context, use_cudnn_, cudnn_use_autotune_, input, filter,
                 /*row_dilation=*/1, /*col_dilation=*/1, stride_, stride_,
+                /*groups*/1,
                 padding_, output, data_format_);
       return;
     }

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -388,7 +388,8 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // CUDNN 7 introduces convolution groups for convolutions.
     // we can thus use the standard conv2d launcher with groups = in_depth
     // when CUDNN is enabled.
-    if (std::is_same<Device, GPUDevice>::value && use_cudnn_) {
+    if (std::is_same<Device, GPUDevice>::value &&
+        DepthwiseConvUseGroupedConv() && use_cudnn_) {
       // Currently, our filter is arranged as:
       // [rows, cols, in_depth, depth_mul].
       // However, in the grouped convolution, we should have the filter

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -252,6 +252,8 @@ extern template struct LaunchDepthwiseConvOp<GPUDevice, double>;
 
 // Extern template instantiated in conv_ops.cc.
 extern template struct LaunchConv2DOp<GPUDevice, float>;
+extern template struct LaunchConv2DOp<GPUDevice, Eigen::half>;
+extern template struct LaunchConv2DOp<GPUDevice, double>;
 
 #endif
 
@@ -386,7 +388,7 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // CUDNN 7 introduces convolution groups for convolutions.
     // we can thus use the standard conv2d launcher with groups = in_depth
     // when CUDNN is enabled.
-    if (use_cudnn_) {
+    if (std::is_same<Device, GPUDevice>::value && use_cudnn_) {
       launcher_(context, use_cudnn_, cudnn_use_autotune_, input, filter,
                 /*row_dilation=*/1, /*col_dilation=*/1, stride_, stride_,
                 /*groups=*/in_depth, padding_, output, data_format_);

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -389,7 +389,18 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // we can thus use the standard conv2d launcher with groups = in_depth
     // when CUDNN is enabled.
     if (std::is_same<Device, GPUDevice>::value && use_cudnn_) {
-      launcher_(context, use_cudnn_, cudnn_use_autotune_, input, filter,
+      // Currently, our filter is arranged as:
+      // [rows, cols, in_depth, depth_mul].
+      // However, in the grouped convolution, we should have the filter
+      // arranged as:  [rows, cols, 1, in_depth * depth_mul]
+
+      Tensor filter_reshape;
+      TensorShape filter_conv2d_shape = {
+        filter_rows, filter_cols, 1, in_depth * depth_multiplier };
+    
+      CHECK(filter_reshape.CopyFrom(filter, filter_conv2d_shape));
+
+      launcher_(context, use_cudnn_, cudnn_use_autotune_, input, filter_reshape,
                 /*row_dilation=*/1, /*col_dilation=*/1, stride_, stride_,
                 /*groups=*/in_depth, padding_, output, data_format_);
       return;

--- a/tensorflow/core/kernels/depthwise_conv_op.h
+++ b/tensorflow/core/kernels/depthwise_conv_op.h
@@ -40,6 +40,10 @@ struct DepthwiseArgs {
   int out_cols;
   int out_depth;
 
+  // Cudnn configuration
+  bool use_cudnn;
+  bool cudnn_use_autotune;
+
   DepthwiseArgs()
       : batch(0),
         in_rows(0),

--- a/tensorflow/core/util/use_cudnn.cc
+++ b/tensorflow/core/util/use_cudnn.cc
@@ -36,6 +36,7 @@ ADD_CUDNN_FLAG(CanUseCudnn, TF_USE_CUDNN, true);
 ADD_CUDNN_FLAG(CudnnUseAutotune, TF_CUDNN_USE_AUTOTUNE, true);
 ADD_CUDNN_FLAG(CudnnDisableConv1x1Optimization,
                TF_CUDNN_DISABLE_CONV_1X1_OPTIMIZATION, false);
+ADD_CUDNN_FLAG(DepthwiseConvUseGroupedConv, TF_DEPTHWISE_CONV_USE_GROUPED_CONV, false);
 
 #undef ADD_CUDNN_FLAG
 

--- a/tensorflow/core/util/use_cudnn.h
+++ b/tensorflow/core/util/use_cudnn.h
@@ -32,6 +32,10 @@ enum class FP16ConvMode {
 bool CanUseCudnn();
 bool CudnnUseAutotune();
 bool CudnnDisableConv1x1Optimization();
+// Whether to dispatch depthwise convolutions to
+// grouped convolutions with number of groups being
+// number of input features.
+bool DepthwiseConvUseGroupedConv();
 FP16ConvMode CudnnConvComputeMode();
 
 }  // namespace tensorflow

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -275,7 +275,8 @@ CUDNN_DNN_ROUTINE_EACH_R6(PERFTOOLS_GPUTOOLS_CUDNN_WRAP)
 #if CUDNN_VERSION >= 7000
 #define CUDNN_DNN_ROUTINE_EACH_R7(__macro)                    \
   __macro(cudnnSetConvolutionMathType)                        \
-  __macro(cudnnSetRNNMatrixMathType)
+  __macro(cudnnSetRNNMatrixMathType)                          \
+  __macro(cudnnSetConvolutionGroupCount)
 
 // clang-format on
 CUDNN_DNN_ROUTINE_EACH_R7(PERFTOOLS_GPUTOOLS_CUDNN_WRAP)
@@ -666,6 +667,24 @@ class ScopedConvolutionDescriptor {
       LOG(FATAL) << "could not set cudnn convolution descriptor: "
                  << ToString(status);
     }
+
+#if CUDNN_VERSION >= 7000
+    if (convolution_descriptor.group_count() != 1) {
+      status = wrap::cudnnSetConvolutionGroupCount(
+          parent_, handle_, convolution_descriptor.group_count()
+      );
+
+      if (status != CUDNN_STATUS_SUCCESS) {
+        LOG(FATAL) << "could not set cudnn convolution descriptor group count: "
+                  << ToString(status);
+      }
+    }
+#else
+    if (convolution_descriptor.group_count() != 1) {
+      LOG(ERROR) << "Group count > 1 not supported on CUDNN < 7.";
+    }
+#endif
+
     // NOTE(benbarsdell): This only applies if tensor op math is enabled
     //                      and algo selection is set to Default.
     this->set_use_tensor_op_math(true);

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -426,6 +426,7 @@ ConvolutionDescriptor::ConvolutionDescriptor(int ndims)
       filter_strides_(ndims, 1),
       dilation_rates_(ndims, 1),
       pad_alignment_(PadAlignment::kDefault),
+      group_count_(1),
       ndims_(ndims) {}
 
 ConvolutionDescriptor::ConvolutionDescriptor()

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -491,6 +491,7 @@ string PadAlignmentString(PadAlignment alignment);
 //   cells between each filter element in the "y dimension".
 // - horizontal_dilation_rate: there will be (horizontal_dilation_rate - 1)
 //   skipped cells between each filter element in the "x dimension".
+// - group_count: the convolution will be performed in group_count groups of equal size.
 class ConvolutionDescriptor {
  public:
   // By default construction, there is no zero-padding and the filter stride is
@@ -543,6 +544,10 @@ class ConvolutionDescriptor {
     pad_alignment_ = pad_alignment;
     return *this;
   }
+  ConvolutionDescriptor& set_group_count(int64 group_count) {
+    group_count_ = group_count;
+    return *this;
+  }
   int64 zero_padding_height() const {
     return GetDim(zero_padding_, DimIndex::Y);
   }
@@ -565,6 +570,7 @@ class ConvolutionDescriptor {
   int zero_padding(DimIndex dim) const { return GetDim(zero_padding_, dim); }
   int filter_stride(DimIndex dim) const { return GetDim(filter_strides_, dim); }
   int dilation_rate(DimIndex dim) const { return GetDim(dilation_rates_, dim); }
+  int group_count() const { return group_count_; }
   PadAlignment pad_alignment() const { return pad_alignment_; }
   int ndims() const { return ndims_; }
 
@@ -578,6 +584,7 @@ class ConvolutionDescriptor {
   std::vector<int64> filter_strides_;
   std::vector<int64> dilation_rates_;
   PadAlignment pad_alignment_;
+  int group_count_;
   int ndims_;
   // TODO(leary) cudnn provides these fields, but need to characterize what
   // their effect is -- they may be boolean rather than integral.


### PR DESCRIPTION
This pull request implements grouped convolutions backed by the [CUDNN 7](http://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/Chunk1484074616.html#rel_7) convolution groups feature.

The feature is exposed in the DNN support class and the Conv2d ops launchers, but no API / operations are created to instantiate grouped convolutions directly.

This pull request also implements dispatching the DepthwiseNativeConv2d (and the corresponding backpropagation operations) to these new grouped convolution kernels. This feature is gated behind a feature flag TF_DEPTHWISE_CONV_USE_GROUPED_CONV which is disabled by default. This increases performance slightly for training Mobilenet in single precision (about 5% on Volta), but also paves the way for float16 training (which is very slow with the current implementation).

Todo: (need advice / directions):
- add tests for the new DepthwiseNativeConv2d path (probably duplicate existing tests but will also need to set the environment variable - how to do this?)
- the feature flag may not be completely satisfactory at the moment: users compiling on CUDNN 6 and setting the feature flag will face a somewhat cryptic error that "no algorithms are found" as the shapes will be incorrect for the conv2d kernels.