### PR TITLE
Fix incorrect rendering in community/documentation.md

### DIFF
--- a/tensorflow/docs_src/community/documentation.md
+++ b/tensorflow/docs_src/community/documentation.md
@@ -477,31 +477,29 @@ should use Markdown in the docstring.
 
 Here's a simple example:
 
-```python
-def foo(x, y, name="bar"):
-  """Computes foo.
+    def foo(x, y, name="bar"):
+      """Computes foo.
 
-  Given two 1-D tensors `x` and `y`, this operation computes the foo.
+      Given two 1-D tensors `x` and `y`, this operation computes the foo.
 
-  Example:
+      Example:
 
-  ```
-  # x is [1, 1]
-  # y is [2, 2]
-  tf.foo(x, y) ==> [3, 3]
-  ```
-  Args:
-    x: A `Tensor` of type `int32`.
-    y: A `Tensor` of type `int32`.
-    name: A name for the operation (optional).
+      ```
+      # x is [1, 1]
+      # y is [2, 2]
+      tf.foo(x, y) ==> [3, 3]
+      ```
+      Args:
+        x: A `Tensor` of type `int32`.
+        y: A `Tensor` of type `int32`.
+        name: A name for the operation (optional).
 
-  Returns:
-    A `Tensor` of type `int32` that is the foo of `x` and `y`.
+      Returns:
+        A `Tensor` of type `int32` that is the foo of `x` and `y`.
 
-  Raises:
-    ValueError: If `x` or `y` are not of type `int32`.
-  """
-```
+      Raises:
+        ValueError: If `x` or `y` are not of type `int32`.
+      """
 
 ## Description of the docstring sections
 


### PR DESCRIPTION
This fix tries to fix the incorrect rendering in community/documentation.md.
The issue was caused by the escaping of "```". As could be seen
in the docs, there are "```" (backticks) inside the code block and
the code block was surrended by "```" (backticks) as well. The
result is that backticks confused the inteprater of markdown and
messed the documentation. See screenshot:

<img width="896" alt="screen shot 2018-03-23 at 3 37 49 pm" src="https://user-images.githubusercontent.com/6932348/37856160-34061ee8-2eb0-11e8-9bd6-863e965c58a7.png">


This fix uses indent four spaces to wrap the code blocks so that
backticks inside could be rendered correctly.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>