### PR TITLE
[Intel MKL] MKL allocator fix

### DIFF
--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -50,7 +50,7 @@ class MklCPUAllocator : public VisitableAllocator {
   // Constructor and other standard functions
 
   /// Environment variable that user can set to upper bound on memory allocation
-  static inline constexpr const char* kMaxLimitStr = "TF_MKL_ALLOC_MAX_BYTES";
+  static constexpr const char* kMaxLimitStr = "TF_MKL_ALLOC_MAX_BYTES";
 
   /// Default upper limit on allocator size - 64GB
   static constexpr size_t kDefaultMaxLimit = 64LL << 30;


### PR DESCRIPTION
reverting mkl allocator inline modifier from #17396. leads to build failures with older compilers (e.g., gcc6.3). 