### PR TITLE
Remove warnings for initialize_variables

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -890,7 +890,7 @@ class StridedSliceAssignChecker(object):
         var = resource_variable_ops.ResourceVariable(self.x)
       else:
         var = variables.Variable(self.x)
-      sess.run(variables.initialize_variables([var]))
+      sess.run(variables.variables_initializer([var]))
       val = sess.run(var[index].assign(value))
       # val_copy is used to check that tf.assign works equivalently to the
       # assign method above.


### PR DESCRIPTION
The `initialize_variables` has been deprecated and replaced with
`tf.variables_initializer`.

This fix makes the change and fixes the following warning in array_ops_test.py:
```
WARNING:tensorflow:From /private/var/tmp/_bazel_ytang/48f7de64c479bcefe5e55c65866b55a6/execroot/org_tensorflow/bazel-out/darwin-opt/bin/tensorflow/python/kernel_tests/array_ops_test.runfiles/org_tensorflow/tensorflow/python/util/tf_should_use.py:118: initialize_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
Instructions for updating:
Use `tf.variables_initializer` instead.
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>