### PR TITLE
Validate axis in shape function of tf.reverse

### DIFF
--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -752,10 +752,24 @@ REGISTER_OP("ReverseV2")
       ShapeHandle input = c->input(0);
       ShapeHandle axis;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &axis));
-      // TODO(aselle): if input(0)'s dimension is known we could validate axis
       if (c->Rank(input) > 8) {
         return errors::InvalidArgument(
             "reverse does not work on tensors with more than 8 dimensions");
+      }
+      const Tensor* axis_tensor = c->input_tensor(1);
+      if (axis_tensor != nullptr && c->RankKnown(input)) {
+        std::vector<int64> axis_value;
+        if (axis_tensor->dtype() == DT_INT32) {
+          axis_value = AsInt64<int32>(axis_tensor, axis_tensor->NumElements());
+        } else {
+          axis_value = AsInt64<int64>(axis_tensor, axis_tensor->NumElements());
+        }
+        for (int i = 0; i < axis_value.size(); i++) {
+          int64 canonical_axis = axis_value[i] < 0 ? c->Rank(input) + axis_value[i] : axis_value[i];
+          if (canonical_axis < 0 || canonical_axis >= c->Rank(input)) {
+            return errors::InvalidArgument("'axis'[", i, "] = ", axis_value[i], " is out of valid range [", 0, ", ", c->Rank(input) - 1);
+          }
+        }
       }
       c->set_output(0, input);
       return Status::OK();

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -765,6 +765,7 @@ REGISTER_OP("ReverseV2")
         } else {
           axis_value = AsInt64<int64>(axis_tensor, axis_tensor->NumElements());
         }
+        std::vector<bool> axes_dense(c->Rank(input), false);
         for (int i = 0; i < axis_value.size(); i++) {
           int64 canonical_axis =
               axis_value[i] < 0 ? rank + axis_value[i] : axis_value[i];
@@ -773,6 +774,11 @@ REGISTER_OP("ReverseV2")
                                            " is out of valid range [", 0, ", ",
                                            rank - 1);
           }
+          if (axes_dense[canonical_axis]) {
+            return errors::InvalidArgument("axis ", canonical_axis,
+                                            " specified more than once.");
+          }
+          axes_dense[canonical_axis] = true;
         }
       }
       c->set_output(0, input);

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -758,6 +758,7 @@ REGISTER_OP("ReverseV2")
       }
       const Tensor* axis_tensor = c->input_tensor(1);
       if (axis_tensor != nullptr && c->RankKnown(input)) {
+        int32 rank = c->Rank(input);
         std::vector<int64> axis_value;
         if (axis_tensor->dtype() == DT_INT32) {
           axis_value = AsInt64<int32>(axis_tensor, axis_tensor->NumElements());
@@ -765,9 +766,9 @@ REGISTER_OP("ReverseV2")
           axis_value = AsInt64<int64>(axis_tensor, axis_tensor->NumElements());
         }
         for (int i = 0; i < axis_value.size(); i++) {
-          int64 canonical_axis = axis_value[i] < 0 ? c->Rank(input) + axis_value[i] : axis_value[i];
-          if (canonical_axis < 0 || canonical_axis >= c->Rank(input)) {
-            return errors::InvalidArgument("'axis'[", i, "] = ", axis_value[i], " is out of valid range [", 0, ", ", c->Rank(input) - 1);
+          int64 canonical_axis = axis_value[i] < 0 ? rank + axis_value[i] : axis_value[i];
+          if (canonical_axis < 0 || canonical_axis >= rank) {
+            return errors::InvalidArgument("'axis'[", i, "] = ", axis_value[i], " is out of valid range [", 0, ", ", rank - 1);
           }
         }
       }

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -766,9 +766,12 @@ REGISTER_OP("ReverseV2")
           axis_value = AsInt64<int64>(axis_tensor, axis_tensor->NumElements());
         }
         for (int i = 0; i < axis_value.size(); i++) {
-          int64 canonical_axis = axis_value[i] < 0 ? rank + axis_value[i] : axis_value[i];
+          int64 canonical_axis =
+              axis_value[i] < 0 ? rank + axis_value[i] : axis_value[i];
           if (canonical_axis < 0 || canonical_axis >= rank) {
-            return errors::InvalidArgument("'axis'[", i, "] = ", axis_value[i], " is out of valid range [", 0, ", ", rank - 1);
+            return errors::InvalidArgument("'axis'[", i, "] = ", axis_value[i],
+                                           " is out of valid range [", 0, ", ",
+                                           rank - 1);
           }
         }
       }

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -315,6 +315,20 @@ class ReverseV2Test(test_util.TensorFlowTestCase):
             self.assertAllEqual(x_tf_4, np.asarray(x_np)[:, ::-1])
             self.assertAllEqual(x_tf_5, np.asarray(x_np)[::-1, ::-1])
 
+  # This test covers the axis validation in the shape function
+  # (no eval())
+  def testInvalidAxis(self):
+    x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+    with self.assertRaisesRegexp(ValueError,
+                                 "is out of valid range"):
+      array_ops.reverse_v2(x_np, [-30])
+    with self.assertRaisesRegexp(ValueError,
+                                 "is out of valid range"):
+      array_ops.reverse_v2(x_np, [2])
+    with self.assertRaisesRegexp(ValueError,
+                                 "axis 0 specified more than once"):
+      array_ops.reverse_v2(x_np, [0, -2])
+
   # This is the version of reverse that uses axis indices rather than
   # bool tensors
   # TODO(b/32254538): Change this test to use array_ops.reverse

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -332,18 +332,22 @@ class ReverseV2Test(test_util.TensorFlowTestCase):
   # This is the version of reverse that uses axis indices rather than
   # bool tensors
   # TODO(b/32254538): Change this test to use array_ops.reverse
+  #
+  # Note: this test passes placeholder as constant axis is validated
+  # in shape function (see testInvalidAxis)
   def testInvalid(self):
     x_np = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+    axis = array_ops.placeholder(dtypes.int32)
     with self.test_session():
       with self.assertRaisesRegexp(errors_impl.InvalidArgumentError,
                                    "is out of valid range"):
-        array_ops.reverse_v2(x_np, [-30]).eval()
+        array_ops.reverse_v2(x_np, axis).eval(feed_dict={axis: [-30]})
       with self.assertRaisesRegexp(errors_impl.InvalidArgumentError,
                                    "is out of valid range"):
-        array_ops.reverse_v2(x_np, [2]).eval()
+        array_ops.reverse_v2(x_np, axis).eval(feed_dict={axis: [2]})
       with self.assertRaisesRegexp(errors_impl.InvalidArgumentError,
                                    "axis 0 specified more than once"):
-        array_ops.reverse_v2(x_np, [0, -2]).eval()
+        array_ops.reverse_v2(x_np, axis).eval(feed_dict={axis: [0, -2]})
 
   def testReverse1DimAuto(self):
     for dtype in [


### PR DESCRIPTION
tf.reverse requires the axis to be in the range of `[-rank(tensor), rank(tensor))`. Previously the validation is only done in runtime though it is possible to validate axis inside the shape function if the shape of the input tensor is already known.

This fix add the validation in the shape function.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>