### PR TITLE
Fix issue caused by None in batch dimension for tf.layers.conv3d

### DIFF
--- a/tensorflow/python/layers/convolutional.py
+++ b/tensorflow/python/layers/convolutional.py
@@ -180,6 +180,8 @@ class _Conv(base.Layer):
           # bias_add when computing gradients. To use bias_add, we collapse Z
           # and Y into a single dimension to obtain a 4D input tensor.
           outputs_shape = outputs.shape.as_list()
+          if outputs_shape[0] is None:
+            outputs_shape[0] = -1
           outputs_4d = array_ops.reshape(outputs,
                                          [outputs_shape[0], outputs_shape[1],
                                           outputs_shape[2] * outputs_shape[3],

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -326,7 +326,7 @@ class ConvTest(test.TestCase):
     self.assertEqual(conv3d.bias_constraint, b_constraint)
 
   def testConv3DChannelsFirst(self):
-    # Test case for GitHub 15655
+    # Test case for GitHub issue 15655
     images = array_ops.placeholder(
         dtype=dtypes.float32, shape=[None, 1, 32, 32, 32])
     conv_layers.conv3d(images, 32, 9, data_format='channels_first')

--- a/tensorflow/python/layers/convolutional_test.py
+++ b/tensorflow/python/layers/convolutional_test.py
@@ -325,6 +325,12 @@ class ConvTest(test.TestCase):
     self.assertEqual(conv3d.kernel_constraint, k_constraint)
     self.assertEqual(conv3d.bias_constraint, b_constraint)
 
+  def testConv3DChannelsFirst(self):
+    # Test case for GitHub 15655
+    images = array_ops.placeholder(
+        dtype=dtypes.float32, shape=[None, 1, 32, 32, 32])
+    conv_layers.conv3d(images, 32, 9, data_format='channels_first')
+
 
 @test_util.with_c_api
 class SeparableConv1DTest(test.TestCase):


### PR DESCRIPTION
This fix tries to address the issue raised in #15655 where error returns when the batch dimension for tf.layers.conv3d is None with "channels_first" format.

This fix cast None to `-1` to address the issue

This fix fixes #15655.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>