### PR TITLE
Update tensorboard dependency to 1.7.0+

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -39,7 +39,7 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.13.3',
     'six >= 1.10.0',
     'protobuf >= 3.4.0',
-    'tensorboard >= 1.6.0, < 1.7.0',
+    'tensorboard >= 1.7.0, < 1.8.0',
     'termcolor >= 1.1.0',
 ]
 


### PR DESCRIPTION
TensorBoard 1.7.0 has been released to PyPI: https://pypi.python.org/pypi/tensorboard/1.7.0