### PR TITLE
Replace PLATFORM_WINDOWS to _MSC_VER as it only applies to MSVC

### DIFF
--- a/tensorflow/core/platform/cpu_info.h
+++ b/tensorflow/core/platform/cpu_info.h
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include <string>
 
-#if defined(PLATFORM_WINDOWS)
+#if defined(_MSC_VER)
 #include "tensorflow/core/platform/windows/cpu_info.h"
 #endif
 


### PR DESCRIPTION
Attempt to fix Bazel Windows build.

/cc @meteorcloudy 