### PR TITLE
[INTEL MKL] Skip special nodes inserted by TF and MKL

### DIFF
--- a/tensorflow/core/grappler/clusters/single_machine_test.cc
+++ b/tensorflow/core/grappler/clusters/single_machine_test.cc
@@ -196,8 +196,8 @@ TEST_F(SingleMachineTest, GraphOptimizations) {
   TF_CHECK_OK(cluster_->Run(item.graph, item.feed, item.fetch, &metadata));
   std::set<string> cost_nodes;
   for (const auto& node : metadata.cost_graph().node()) {
-    // Skip the special nodes inserted by TF: these are prefixed with an
-    // underscore.
+    // Skip the special nodes inserted by TF (and MKL): these are either 
+    // prefixed with an underscore or contain "/_".
     if (node.name()[0] == '_' || node.name().find("/_") != string::npos) {
       continue;
     }

--- a/tensorflow/core/grappler/clusters/single_machine_test.cc
+++ b/tensorflow/core/grappler/clusters/single_machine_test.cc
@@ -196,10 +196,12 @@ TEST_F(SingleMachineTest, GraphOptimizations) {
   TF_CHECK_OK(cluster_->Run(item.graph, item.feed, item.fetch, &metadata));
   std::set<string> cost_nodes;
   for (const auto& node : metadata.cost_graph().node()) {
-    // Skip nodes added by TF internally.
-    if (node.name()[0] != '_') {
-      cost_nodes.insert(node.name());
+    // Skip the special nodes inserted by TF: these are prefixed with an
+    // underscore.
+    if (node.name()[0] == '_' || node.name().find("/_") != string::npos) {
+      continue;
     }
+    cost_nodes.insert(node.name());
   }
   const std::set<string> expected_cost_nodes = {
       "zero",      "one",      "add",         "square",

--- a/tensorflow/core/grappler/clusters/single_machine_test.cc
+++ b/tensorflow/core/grappler/clusters/single_machine_test.cc
@@ -196,12 +196,19 @@ TEST_F(SingleMachineTest, GraphOptimizations) {
   TF_CHECK_OK(cluster_->Run(item.graph, item.feed, item.fetch, &metadata));
   std::set<string> cost_nodes;
   for (const auto& node : metadata.cost_graph().node()) {
+#ifdef INTEL_MKL
     // Skip the special nodes inserted by TF (and MKL): these are either
     // prefixed with an underscore or contain "/_".
     if (node.name()[0] == '_' || node.name().find("/_") != string::npos) {
       continue;
     }
     cost_nodes.insert(node.name());
+#else
+    // Skip nodes added by TF internally.
+    if (node.name()[0] != '_') {
+      cost_nodes.insert(node.name());
+    }
+#endif
   }
   const std::set<string> expected_cost_nodes = {
       "zero",      "one",      "add",         "square",

--- a/tensorflow/core/grappler/clusters/single_machine_test.cc
+++ b/tensorflow/core/grappler/clusters/single_machine_test.cc
@@ -196,7 +196,7 @@ TEST_F(SingleMachineTest, GraphOptimizations) {
   TF_CHECK_OK(cluster_->Run(item.graph, item.feed, item.fetch, &metadata));
   std::set<string> cost_nodes;
   for (const auto& node : metadata.cost_graph().node()) {
-    // Skip the special nodes inserted by TF (and MKL): these are either 
+    // Skip the special nodes inserted by TF (and MKL): these are either
     // prefixed with an underscore or contain "/_".
     if (node.name()[0] == '_' || node.name().find("/_") != string::npos) {
       continue;


### PR DESCRIPTION
This patch fixes SingleMachineTest.GraphOptimizations (//tensorflow/core/grappler/clusters:single_machine_test) unit test failure when MKL is enabled.