### PR TITLE
[tfgan] Add one sided wasserstein gradient penalty

### DIFF
--- a/tensorflow/contrib/gan/python/losses/python/losses_impl.py
+++ b/tensorflow/contrib/gan/python/losses/python/losses_impl.py
@@ -381,12 +381,12 @@ def wasserstein_gradient_penalty(
     # root. Note tf.norm does not add epsilon.
     slopes = math_ops.sqrt(gradient_squares + epsilon)
     penalties = slopes / target - 1.0
-    if one_sided is True:
-        penalties = math_ops.maximum(0., penalties)
+    if one_sided:
+      penalties = math_ops.maximum(0., penalties)
     penalties_squared = math_ops.square(penalties)
     penalty = losses.compute_weighted_loss(
-        penalties_squared, weights, scope=scope, loss_collection=loss_collection,
-        reduction=reduction)
+        penalties_squared, weights, scope=scope,
+        loss_collection=loss_collection, reduction=reduction)
 
     if add_summaries:
       summary.scalar('gradient_penalty_loss', penalty)

--- a/tensorflow/contrib/gan/python/losses/python/losses_impl.py
+++ b/tensorflow/contrib/gan/python/losses/python/losses_impl.py
@@ -306,7 +306,7 @@ def wasserstein_gradient_penalty(
     discriminator_scope,
     epsilon=1e-10,
     target=1.0,
-    mode='two_sided',
+    one_sided=False,
     weights=1.0,
     scope=None,
     loss_collection=ops.GraphKeys.LOSSES,
@@ -328,8 +328,8 @@ def wasserstein_gradient_penalty(
       computing the gradient norm.
     target: Optional Python number or `Tensor` indicating the target value of
       gradient norm. Defaults to 1.0.
-    mode: One of `"two_sided"` or `"one_sided"`. If `"one_sided"`, penalty
-      proposed in https://arxiv.org/abs/1709.08894 is used. Defaults to `"two_sided"`.
+    one_sided: If `True`, penalty proposed in https://arxiv.org/abs/1709.08894
+      is used. Defaults to `False`.
     weights: Optional `Tensor` whose rank is either 0, or the same rank as
       `real_data` and `generated_data`, and must be broadcastable to
       them (i.e., all dimensions must be either `1`, or the same as the
@@ -345,9 +345,6 @@ def wasserstein_gradient_penalty(
   Raises:
     ValueError: If the rank of data Tensors is unknown.
   """
-  if mode not in {'two_sided', 'one_sided'}:
-      raise ValueError('The `mode` argument must be one of '
-                       '"two_sided", "one_sided". Received: ' + str(mode))
   with ops.name_scope(scope, 'wasserstein_gradient_penalty',
                       (real_data, generated_data)) as scope:
     real_data = ops.convert_to_tensor(real_data)
@@ -384,7 +381,7 @@ def wasserstein_gradient_penalty(
     # root. Note tf.norm does not add epsilon.
     slopes = math_ops.sqrt(gradient_squares + epsilon)
     penalties = slopes / target - 1.0
-    if mode == 'one_sided':
+    if one_sided is True:
         penalties = math_ops.maximum(0., penalties)
     penalties_squared = math_ops.square(penalties)
     penalty = losses.compute_weighted_loss(

--- a/tensorflow/contrib/gan/python/losses/python/losses_impl.py
+++ b/tensorflow/contrib/gan/python/losses/python/losses_impl.py
@@ -306,6 +306,7 @@ def wasserstein_gradient_penalty(
     discriminator_scope,
     epsilon=1e-10,
     target=1.0,
+    mode='two_sided',
     weights=1.0,
     scope=None,
     loss_collection=ops.GraphKeys.LOSSES,
@@ -327,6 +328,8 @@ def wasserstein_gradient_penalty(
       computing the gradient norm.
     target: Optional Python number or `Tensor` indicating the target value of
       gradient norm. Defaults to 1.0.
+    mode: One of `"two_sided"` or `"one_sided"`. If `"one_sided"`, penalty
+      proposed in https://arxiv.org/abs/1709.08894 is used. Defaults to `"two_sided"`.
     weights: Optional `Tensor` whose rank is either 0, or the same rank as
       `real_data` and `generated_data`, and must be broadcastable to
       them (i.e., all dimensions must be either `1`, or the same as the
@@ -342,6 +345,9 @@ def wasserstein_gradient_penalty(
   Raises:
     ValueError: If the rank of data Tensors is unknown.
   """
+  if mode not in {'two_sided', 'one_sided'}:
+      raise ValueError('The `mode` argument must be one of '
+                       '"two_sided", "one_sided". Received: ' + str(mode))
   with ops.name_scope(scope, 'wasserstein_gradient_penalty',
                       (real_data, generated_data)) as scope:
     real_data = ops.convert_to_tensor(real_data)
@@ -377,9 +383,12 @@ def wasserstein_gradient_penalty(
     # For numerical stability, add epsilon to the sum before taking the square
     # root. Note tf.norm does not add epsilon.
     slopes = math_ops.sqrt(gradient_squares + epsilon)
-    penalties = math_ops.square(slopes / target - 1.0)
+    penalties = slopes / target - 1.0
+    if mode == 'one_sided':
+        penalties = math_ops.maximum(0., penalties)
+    penalties_squared = math_ops.square(penalties)
     penalty = losses.compute_weighted_loss(
-        penalties, weights, scope=scope, loss_collection=loss_collection,
+        penalties_squared, weights, scope=scope, loss_collection=loss_collection,
         reduction=reduction)
 
     if add_summaries:

--- a/tensorflow/contrib/gan/python/losses/python/losses_impl_test.py
+++ b/tensorflow/contrib/gan/python/losses/python/losses_impl_test.py
@@ -481,27 +481,27 @@ class GradientPenaltyTest(test.TestCase, _PenaltyTest):
                       })
       self.assertAlmostEqual(self._expected_loss, loss, 5)
 
-      def test_loss_using_one_sided_mode(self):
-        generated_data = array_ops.placeholder(dtypes.float32, shape=(None, None))
-        real_data = array_ops.placeholder(dtypes.float32, shape=(None, None))
+  def test_loss_using_one_sided_mode(self):
+    generated_data = array_ops.placeholder(dtypes.float32, shape=(None, None))
+    real_data = array_ops.placeholder(dtypes.float32, shape=(None, None))
 
-        loss = tfgan_losses.wasserstein_gradient_penalty(
-            generated_data,
-            real_data,
-            self._kwargs['generator_inputs'],
-            self._kwargs['discriminator_fn'],
-            self._kwargs['discriminator_scope'],
-            one_sided=True)
-        self.assertEqual(generated_data.dtype, loss.dtype)
+    loss = tfgan_losses.wasserstein_gradient_penalty(
+        generated_data,
+        real_data,
+        self._kwargs['generator_inputs'],
+        self._kwargs['discriminator_fn'],
+        self._kwargs['discriminator_scope'],
+        one_sided=True)
+    self.assertEqual(generated_data.dtype, loss.dtype)
 
-        with self.test_session() as sess:
-          variables.global_variables_initializer().run()
-          loss = sess.run(loss,
-                          feed_dict={
-                              generated_data: self._generated_data_np,
-                              real_data: self._real_data_np,
-                          })
-          self.assertAlmostEqual(self._expected_loss, loss, 5)
+    with self.test_session() as sess:
+      variables.global_variables_initializer().run()
+      loss = sess.run(loss,
+                      feed_dict={
+                          generated_data: self._generated_data_np,
+                          real_data: self._real_data_np,
+                      })
+      self.assertAlmostEqual(self._expected_loss, loss, 5)
 
   def test_loss_with_gradient_norm_target(self):
     """Test loss value with non default gradient norm target."""

--- a/tensorflow/contrib/gan/python/losses/python/losses_impl_test.py
+++ b/tensorflow/contrib/gan/python/losses/python/losses_impl_test.py
@@ -481,6 +481,28 @@ class GradientPenaltyTest(test.TestCase, _PenaltyTest):
                       })
       self.assertAlmostEqual(self._expected_loss, loss, 5)
 
+      def test_loss_using_one_sided_mode(self):
+        generated_data = array_ops.placeholder(dtypes.float32, shape=(None, None))
+        real_data = array_ops.placeholder(dtypes.float32, shape=(None, None))
+
+        loss = tfgan_losses.wasserstein_gradient_penalty(
+            generated_data,
+            real_data,
+            self._kwargs['generator_inputs'],
+            self._kwargs['discriminator_fn'],
+            self._kwargs['discriminator_scope'],
+            mode='one_sided')
+        self.assertEqual(generated_data.dtype, loss.dtype)
+
+        with self.test_session() as sess:
+          variables.global_variables_initializer().run()
+          loss = sess.run(loss,
+                          feed_dict={
+                              generated_data: self._generated_data_np,
+                              real_data: self._real_data_np,
+                          })
+          self.assertAlmostEqual(self._expected_loss, loss, 5)
+
   def test_loss_with_gradient_norm_target(self):
     """Test loss value with non default gradient norm target."""
     generated_data = array_ops.placeholder(dtypes.float32, shape=(None, None))

--- a/tensorflow/contrib/gan/python/losses/python/losses_impl_test.py
+++ b/tensorflow/contrib/gan/python/losses/python/losses_impl_test.py
@@ -491,7 +491,7 @@ class GradientPenaltyTest(test.TestCase, _PenaltyTest):
             self._kwargs['generator_inputs'],
             self._kwargs['discriminator_fn'],
             self._kwargs['discriminator_scope'],
-            mode='one_sided')
+            one_sided=True)
         self.assertEqual(generated_data.dtype, loss.dtype)
 
         with self.test_session() as sess:

--- a/tensorflow/contrib/gan/python/train.py
+++ b/tensorflow/contrib/gan/python/train.py
@@ -461,6 +461,7 @@ def gan_loss(
     gradient_penalty_weight=None,
     gradient_penalty_epsilon=1e-10,
     gradient_penalty_target=1.0,
+    gradient_penalty_mode='two_sided',
     mutual_information_penalty_weight=None,
     aux_cond_generator_weight=None,
     aux_cond_discriminator_weight=None,
@@ -485,6 +486,9 @@ def gan_loss(
     gradient_penalty_target: If `gradient_penalty_weight` is not None, a Python
       number or `Tensor` indicating the target value of gradient norm. See the
       CIFAR10 section of https://arxiv.org/abs/1710.10196. Defaults to 1.0.
+    gradient_penalty_mode: One of `"two_sided"` or `"one_sided"`. If `"one_sided"`,
+      gradient penalty proposed in https://arxiv.org/abs/1709.08894 is used.
+      Defaults to `"two_sided"`.
     mutual_information_penalty_weight: If not `None`, must be a non-negative
       Python number or Tensor indicating how much to weight the mutual
       information penalty. See https://arxiv.org/abs/1606.03657 for more
@@ -546,6 +550,7 @@ def gan_loss(
         model,
         epsilon=gradient_penalty_epsilon,
         target=gradient_penalty_target,
+        mode=gradient_penalty_mode,
         add_summaries=add_summaries)
     dis_loss += gradient_penalty_weight * gp_loss
   if _use_aux_loss(mutual_information_penalty_weight):

--- a/tensorflow/contrib/gan/python/train.py
+++ b/tensorflow/contrib/gan/python/train.py
@@ -461,7 +461,7 @@ def gan_loss(
     gradient_penalty_weight=None,
     gradient_penalty_epsilon=1e-10,
     gradient_penalty_target=1.0,
-    gradient_penalty_mode='two_sided',
+    gradient_penalty_one_sided=False,
     mutual_information_penalty_weight=None,
     aux_cond_generator_weight=None,
     aux_cond_discriminator_weight=None,
@@ -486,9 +486,8 @@ def gan_loss(
     gradient_penalty_target: If `gradient_penalty_weight` is not None, a Python
       number or `Tensor` indicating the target value of gradient norm. See the
       CIFAR10 section of https://arxiv.org/abs/1710.10196. Defaults to 1.0.
-    gradient_penalty_mode: One of `"two_sided"` or `"one_sided"`. If `"one_sided"`,
-      gradient penalty proposed in https://arxiv.org/abs/1709.08894 is used.
-      Defaults to `"two_sided"`.
+    gradient_penalty_one_sided: If `True`, penalty proposed in
+      https://arxiv.org/abs/1709.08894 is used. Defaults to `False`.
     mutual_information_penalty_weight: If not `None`, must be a non-negative
       Python number or Tensor indicating how much to weight the mutual
       information penalty. See https://arxiv.org/abs/1606.03657 for more
@@ -550,7 +549,7 @@ def gan_loss(
         model,
         epsilon=gradient_penalty_epsilon,
         target=gradient_penalty_target,
-        mode=gradient_penalty_mode,
+        one_sided=gradient_penalty_one_sided,
         add_summaries=add_summaries)
     dis_loss += gradient_penalty_weight * gp_loss
   if _use_aux_loss(mutual_information_penalty_weight):

--- a/tensorflow/contrib/gan/python/train_test.py
+++ b/tensorflow/contrib/gan/python/train_test.py
@@ -359,10 +359,11 @@ class GANLossTest(test.TestCase):
     self.assertGreater(len(ops.get_collection(ops.GraphKeys.SUMMARIES)), 0)
 
   # Test gradient penalty option.
-  def _test_grad_penalty_helper(self, create_gan_model_fn):
+  def _test_grad_penalty_helper(self, create_gan_model_fn, mode='two_sided'):
     model = create_gan_model_fn()
     loss = train.gan_loss(model)
-    loss_gp = train.gan_loss(model, gradient_penalty_weight=1.0)
+    loss_gp = train.gan_loss(model,
+        gradient_penalty_weight=1.0, gradient_penalty_mode=mode)
     self.assertTrue(isinstance(loss_gp, namedtuples.GANLoss))
 
     # Check values.
@@ -393,6 +394,24 @@ class GANLossTest(test.TestCase):
 
   def test_grad_penalty_callable_acgan(self):
     self._test_grad_penalty_helper(create_callable_acgan_model)
+
+  def test_grad_penalty_one_sided_gan(self):
+    self._test_grad_penalty_helper(create_gan_model, mode='one_sided')
+
+  def test_grad_penalty_one_sided_callable_gan(self):
+    self._test_grad_penalty_helper(create_callable_gan_model, mode='one_sided')
+
+  def test_grad_penalty_one_sided_infogan(self):
+    self._test_grad_penalty_helper(create_infogan_model, mode='one_sided')
+
+  def test_grad_penalty_one_sided_callable_infogan(self):
+    self._test_grad_penalty_helper(create_callable_infogan_model, mode='one_sided')
+
+  def test_grad_penalty_one_sided_acgan(self):
+    self._test_grad_penalty_helper(create_acgan_model, mode='one_sided')
+
+  def test_grad_penalty_one_sided_callable_acgan(self):
+    self._test_grad_penalty_helper(create_callable_acgan_model, mode='one_sided')
 
   # Test mutual information penalty option.
   def _test_mutual_info_penalty_helper(self, create_gan_model_fn):

--- a/tensorflow/contrib/gan/python/train_test.py
+++ b/tensorflow/contrib/gan/python/train_test.py
@@ -363,7 +363,8 @@ class GANLossTest(test.TestCase):
     model = create_gan_model_fn()
     loss = train.gan_loss(model)
     loss_gp = train.gan_loss(model,
-        gradient_penalty_weight=1.0, gradient_penalty_one_sided=one_sided)
+                             gradient_penalty_weight=1.0,
+                             gradient_penalty_one_sided=one_sided)
     self.assertTrue(isinstance(loss_gp, namedtuples.GANLoss))
 
     # Check values.
@@ -405,7 +406,8 @@ class GANLossTest(test.TestCase):
     self._test_grad_penalty_helper(create_infogan_model, one_sided=True)
 
   def test_grad_penalty_one_sided_callable_infogan(self):
-    self._test_grad_penalty_helper(create_callable_infogan_model, one_sided=True)
+    self._test_grad_penalty_helper(
+        create_callable_infogan_model, one_sided=True)
 
   def test_grad_penalty_one_sided_acgan(self):
     self._test_grad_penalty_helper(create_acgan_model, one_sided=True)

--- a/tensorflow/contrib/gan/python/train_test.py
+++ b/tensorflow/contrib/gan/python/train_test.py
@@ -359,11 +359,11 @@ class GANLossTest(test.TestCase):
     self.assertGreater(len(ops.get_collection(ops.GraphKeys.SUMMARIES)), 0)
 
   # Test gradient penalty option.
-  def _test_grad_penalty_helper(self, create_gan_model_fn, mode='two_sided'):
+  def _test_grad_penalty_helper(self, create_gan_model_fn, one_sided=False):
     model = create_gan_model_fn()
     loss = train.gan_loss(model)
     loss_gp = train.gan_loss(model,
-        gradient_penalty_weight=1.0, gradient_penalty_mode=mode)
+        gradient_penalty_weight=1.0, gradient_penalty_one_sided=one_sided)
     self.assertTrue(isinstance(loss_gp, namedtuples.GANLoss))
 
     # Check values.
@@ -396,22 +396,22 @@ class GANLossTest(test.TestCase):
     self._test_grad_penalty_helper(create_callable_acgan_model)
 
   def test_grad_penalty_one_sided_gan(self):
-    self._test_grad_penalty_helper(create_gan_model, mode='one_sided')
+    self._test_grad_penalty_helper(create_gan_model, one_sided=True)
 
   def test_grad_penalty_one_sided_callable_gan(self):
-    self._test_grad_penalty_helper(create_callable_gan_model, mode='one_sided')
+    self._test_grad_penalty_helper(create_callable_gan_model, one_sided=True)
 
   def test_grad_penalty_one_sided_infogan(self):
-    self._test_grad_penalty_helper(create_infogan_model, mode='one_sided')
+    self._test_grad_penalty_helper(create_infogan_model, one_sided=True)
 
   def test_grad_penalty_one_sided_callable_infogan(self):
-    self._test_grad_penalty_helper(create_callable_infogan_model, mode='one_sided')
+    self._test_grad_penalty_helper(create_callable_infogan_model, one_sided=True)
 
   def test_grad_penalty_one_sided_acgan(self):
-    self._test_grad_penalty_helper(create_acgan_model, mode='one_sided')
+    self._test_grad_penalty_helper(create_acgan_model, one_sided=True)
 
   def test_grad_penalty_one_sided_callable_acgan(self):
-    self._test_grad_penalty_helper(create_callable_acgan_model, mode='one_sided')
+    self._test_grad_penalty_helper(create_callable_acgan_model, one_sided=True)
 
   # Test mutual information penalty option.
   def _test_mutual_info_penalty_helper(self, create_gan_model_fn):


### PR DESCRIPTION
This PR adds an optional argument to `tf.contrib.gan.losses.wasserstein_gradient_penalty` which allows for a one sided wasserstein gradient penalty.

The paper [On the regularization of Wasserstein GANs](https://arxiv.org/abs/1709.08894) presents theoretical arguments why using a weaker regularization term is preferable over the [two sided gradient penalty](https://arxiv.org/abs/1704.00028) and shows experimental results supporting these arguments.

For reference, [here is the code used in the paper](https://github.com/lukovnikov/improved_wgan_training/blob/master/gan_cifar.py#L144).

/cc @joel-shor @sguada