### PR TITLE
Allow ComplexAbs Op on mobile platforms

### DIFF
--- a/tensorflow/core/kernels/cwise_op_abs.cc
+++ b/tensorflow/core/kernels/cwise_op_abs.cc
@@ -18,9 +18,7 @@ limitations under the License.
 namespace tensorflow {
 REGISTER5(UnaryOp, CPU, "Abs", functor::abs, float, Eigen::half, double, int32,
           int64);
-#if !defined(IS_MOBILE_PLATFORM)
 REGISTER2(UnaryOp, CPU, "ComplexAbs", functor::abs, complex64, complex128);
-#endif
 
 #if GOOGLE_CUDA
 REGISTER4(UnaryOp, GPU, "Abs", functor::abs, float, Eigen::half, double, int64);


### PR DESCRIPTION
Seems like it was disabled long time ago before open-sourcing Tensorflow.
I think disabling it is no longer necessary.
Works now on Android. Could anyone check on iOS?

Somewhat related issue: #11804