### PR TITLE
Fix tensor naming for tf.metrics.root_mean_squared_error

### DIFF
--- a/tensorflow/python/ops/metrics_impl.py
+++ b/tensorflow/python/ops/metrics_impl.py
@@ -2635,8 +2635,8 @@ def root_mean_squared_error(labels,
   mse, update_mse_op = mean_squared_error(labels, predictions, weights, None,
                                           None, name='mean_squared_error')
 
-  rmse = math_ops.sqrt(mse, name=name or 'root_mean_squared_error')
-  update_rmse_op = math_ops.sqrt(update_mse_op, name=name or 'root_mean_squared_error')
+  rmse = math_ops.sqrt(mse, name=(name or 'root_mean_squared_error'))
+  update_rmse_op = math_ops.sqrt(update_mse_op, name=(name or 'root_mean_squared_error'))
 
   if metrics_collections:
     ops.add_to_collections(metrics_collections, rmse)

--- a/tensorflow/python/ops/metrics_impl.py
+++ b/tensorflow/python/ops/metrics_impl.py
@@ -2633,11 +2633,10 @@ def root_mean_squared_error(labels,
   predictions, labels, weights = _remove_squeezable_dimensions(
       predictions=predictions, labels=labels, weights=weights)
   mse, update_mse_op = mean_squared_error(labels, predictions, weights, None,
-                                          None, name or
-                                          'root_mean_squared_error')
+                                          None, name='mean_squared_error')
 
-  rmse = math_ops.sqrt(mse)
-  update_rmse_op = math_ops.sqrt(update_mse_op)
+  rmse = math_ops.sqrt(mse, name=name or 'root_mean_squared_error')
+  update_rmse_op = math_ops.sqrt(update_mse_op, name=name or 'root_mean_squared_error')
 
   if metrics_collections:
     ops.add_to_collections(metrics_collections, rmse)


### PR DESCRIPTION
Tensors returned by `tf.metrics.root_mean_squared_error` function do not reflect the name passed in the function parameters. This patch fixes that.