### PR TITLE
Fix adam optimizer related math equation rendering format

### DIFF
--- a/tensorflow/contrib/opt/python/training/lazy_adam_optimizer.py
+++ b/tensorflow/contrib/opt/python/training/lazy_adam_optimizer.py
@@ -56,21 +56,21 @@ class LazyAdamOptimizer(adam.AdamOptimizer):
     epsilon_t = math_ops.cast(self._epsilon_t, var.dtype.base_dtype)
     lr = (lr_t * math_ops.sqrt(1 - beta2_power) / (1 - beta1_power))
 
-    # m := beta1 * m + (1 - beta1) * g_t
+    # \\(m := beta1 * m + (1 - beta1) * g_t\\)
     m = self.get_slot(var, "m")
     m_t = state_ops.scatter_update(m, grad.indices,
                                    beta1_t * array_ops.gather(m, grad.indices) +
                                    (1 - beta1_t) * grad.values,
                                    use_locking=self._use_locking)
 
-    # v := beta2 * v + (1 - beta2) * (g_t * g_t)
+    # \\(v := beta2 * v + (1 - beta2) * (g_t * g_t)\\)
     v = self.get_slot(var, "v")
     v_t = state_ops.scatter_update(v, grad.indices,
                                    beta2_t * array_ops.gather(v, grad.indices) +
                                    (1 - beta2_t) * math_ops.square(grad.values),
                                    use_locking=self._use_locking)
 
-    # variable -= learning_rate * m_t / (epsilon_t + sqrt(v_t))
+    # \\(variable -= learning_rate * m_t / (epsilon_t + sqrt(v_t))\\)
     m_t_slice = array_ops.gather(m_t, grad.indices)
     v_t_slice = array_ops.gather(v_t, grad.indices)
     denominator_slice = math_ops.sqrt(v_t_slice) + epsilon_t

--- a/tensorflow/contrib/optimizer_v2/adam.py
+++ b/tensorflow/contrib/optimizer_v2/adam.py
@@ -40,19 +40,19 @@ class AdamOptimizer(optimizer_v2.OptimizerV2):
 
     Initialization:
 
-    \\(m_0 <- 0\\) (Initialize initial 1st moment vector)
-    \\(v_0 <- 0\\) (Initialize initial 2nd moment vector)
-    \\(t <- 0\\) (Initialize timestep)
+    $$m_0 \Leftarrow 0 (Initialize initial 1st moment vector)$$
+    $$v_0 \Leftarrow 0 (Initialize initial 2nd moment vector)$$
+    $$t \Leftarrow 0 (Initialize timestep)$$
 
     The update rule for `variable` with gradient `g` uses an optimization
     described at the end of section2 of the paper:
 
-    $$t <- t + 1$$
-    $$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+    $$t \Leftarrow t + 1$$
+    $$lr_t \Leftarrow \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
 
-    $$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
-    $$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-    $$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+    $$m_t \Leftarrow beta_1 * m_{t-1} + (1 - beta_1) * g$$
+    $$v_t \Leftarrow beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+    $$variable \Leftarrow variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 
     The default value of 1e-8 for epsilon might not be a good default in
     general. For example, when training an Inception network on ImageNet a

--- a/tensorflow/contrib/optimizer_v2/adam.py
+++ b/tensorflow/contrib/optimizer_v2/adam.py
@@ -40,19 +40,19 @@ class AdamOptimizer(optimizer_v2.OptimizerV2):
 
     Initialization:
 
-    $$m_0 \Leftarrow 0 (Initialize initial 1st moment vector)$$
-    $$v_0 \Leftarrow 0 (Initialize initial 2nd moment vector)$$
-    $$t \Leftarrow 0 (Initialize timestep)$$
+    $$m_0 := 0 (Initialize initial 1st moment vector)$$
+    $$v_0 := 0 (Initialize initial 2nd moment vector)$$
+    $$t := 0 (Initialize timestep)$$
 
     The update rule for `variable` with gradient `g` uses an optimization
     described at the end of section2 of the paper:
 
-    $$t \Leftarrow t + 1$$
-    $$lr_t \Leftarrow \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+    $$t := t + 1$$
+    $$lr_t := \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
 
-    $$m_t \Leftarrow beta_1 * m_{t-1} + (1 - beta_1) * g$$
-    $$v_t \Leftarrow beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-    $$variable \Leftarrow variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+    $$m_t := beta_1 * m_{t-1} + (1 - beta_1) * g$$
+    $$v_t := beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+    $$variable := variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 
     The default value of 1e-8 for epsilon might not be a good default in
     general. For example, when training an Inception network on ImageNet a

--- a/tensorflow/contrib/optimizer_v2/adam.py
+++ b/tensorflow/contrib/optimizer_v2/adam.py
@@ -40,23 +40,19 @@ class AdamOptimizer(optimizer_v2.OptimizerV2):
 
     Initialization:
 
-    ```
     \\(m_0 <- 0\\) (Initialize initial 1st moment vector)
     \\(v_0 <- 0\\) (Initialize initial 2nd moment vector)
     \\(t <- 0\\) (Initialize timestep)
-    ```
 
     The update rule for `variable` with gradient `g` uses an optimization
     described at the end of section2 of the paper:
 
-    ```
     $$t <- t + 1$$
     $$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
 
     $$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
     $$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
     $$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
-    ```
 
     The default value of 1e-8 for epsilon might not be a good default in
     general. For example, when training an Inception network on ImageNet a

--- a/tensorflow/contrib/optimizer_v2/adam.py
+++ b/tensorflow/contrib/optimizer_v2/adam.py
@@ -51,11 +51,11 @@ class AdamOptimizer(optimizer_v2.OptimizerV2):
 
     ```
     $$t <- t + 1$$
-    $$lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)$$
+    $$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
 
-    $$m_t <- beta1 * m_{t-1} + (1 - beta1) * g$$
-    $$v_t <- beta2 * v_{t-1} + (1 - beta2) * g * g$$
-    $$variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)$$
+    $$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
+    $$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+    $$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
     ```
 
     The default value of 1e-8 for epsilon might not be a good default in

--- a/tensorflow/contrib/optimizer_v2/adam.py
+++ b/tensorflow/contrib/optimizer_v2/adam.py
@@ -41,21 +41,21 @@ class AdamOptimizer(optimizer_v2.OptimizerV2):
     Initialization:
 
     ```
-    m_0 <- 0 (Initialize initial 1st moment vector)
-    v_0 <- 0 (Initialize initial 2nd moment vector)
-    t <- 0 (Initialize timestep)
+    \\(m_0 <- 0\\) (Initialize initial 1st moment vector)
+    \\(v_0 <- 0\\) (Initialize initial 2nd moment vector)
+    \\(t <- 0\\) (Initialize timestep)
     ```
 
     The update rule for `variable` with gradient `g` uses an optimization
     described at the end of section2 of the paper:
 
     ```
-    t <- t + 1
-    lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)
+    $$t <- t + 1$$
+    $$lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)$$
 
-    m_t <- beta1 * m_{t-1} + (1 - beta1) * g
-    v_t <- beta2 * v_{t-1} + (1 - beta2) * g * g
-    variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)
+    $$m_t <- beta1 * m_{t-1} + (1 - beta1) * g$$
+    $$v_t <- beta2 * v_{t-1} + (1 - beta2) * g * g$$
+    $$variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)$$
     ```
 
     The default value of 1e-8 for epsilon might not be a good default in

--- a/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
@@ -82,9 +82,9 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-$$lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)$$
-$$m_t <- beta1 * m_{t-1} + (1 - beta1) * g_t$$
-$$v_t <- beta2 * v_{t-1} + (1 - beta2) * g_t * g_t$$
-$$variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)$$
+$$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+$$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
+$$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+$$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
@@ -82,9 +82,9 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)
-m_t <- beta1 * m_{t-1} + (1 - beta1) * g_t
-v_t <- beta2 * v_{t-1} + (1 - beta2) * g_t * g_t
-variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)
+$$lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)$$
+$$m_t <- beta1 * m_{t-1} + (1 - beta1) * g_t$$
+$$v_t <- beta2 * v_{t-1} + (1 - beta2) * g_t * g_t$$
+$$variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)$$
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
@@ -82,9 +82,9 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-$$lr_t \Leftarrow \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
-$$m_t \Leftarrow beta_1 * m_{t-1} + (1 - beta_1) * g$$
-$$v_t \Leftarrow beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-$$variable \Leftarrow variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+$$lr_t := \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+$$m_t := beta_1 * m_{t-1} + (1 - beta_1) * g$$
+$$v_t := beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+$$variable := variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
@@ -82,9 +82,9 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-$$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
-$$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
-$$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-$$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+$$lr_t \Leftarrow \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+$$m_t \Leftarrow beta_1 * m_{t-1} + (1 - beta_1) * g$$
+$$v_t \Leftarrow beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+$$variable \Leftarrow variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
@@ -76,9 +76,8 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-$$lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)$$
-$$m_t <- beta1 * m_{t-1} + (1 - beta1) * g_t$$
-$$v_t <- beta2 * v_{t-1} + (1 - beta2) * g_t * g_t$$
-$$variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)$$
-END
+$$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+$$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
+$$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+$$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 }

--- a/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
@@ -76,9 +76,9 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)
-m_t <- beta1 * m_{t-1} + (1 - beta1) * g_t
-v_t <- beta2 * v_{t-1} + (1 - beta2) * g_t * g_t
-variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)
+$$lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)$$
+$$m_t <- beta1 * m_{t-1} + (1 - beta1) * g_t$$
+$$v_t <- beta2 * v_{t-1} + (1 - beta2) * g_t * g_t$$
+$$variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)$$
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
@@ -76,8 +76,8 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-$$lr_t \Leftarrow \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
-$$m_t \Leftarrow beta_1 * m_{t-1} + (1 - beta_1) * g$$
-$$v_t \Leftarrow beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-$$variable \Leftarrow variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+$$lr_t := \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+$$m_t := beta_1 * m_{t-1} + (1 - beta_1) * g$$
+$$v_t := beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+$$variable := variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 }

--- a/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
@@ -76,8 +76,8 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-$$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
-$$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
-$$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-$$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+$$lr_t \Leftarrow \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+$$m_t \Leftarrow beta_1 * m_{t-1} + (1 - beta_1) * g$$
+$$v_t \Leftarrow beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+$$variable \Leftarrow variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 }

--- a/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
@@ -80,4 +80,5 @@ $$lr_t := \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
 $$m_t := beta_1 * m_{t-1} + (1 - beta_1) * g$$
 $$v_t := beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
 $$variable := variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+END
 }

--- a/tensorflow/python/training/adam.py
+++ b/tensorflow/python/training/adam.py
@@ -44,21 +44,21 @@ class AdamOptimizer(optimizer.Optimizer):
     Initialization:
 
     ```
-    m_0 <- 0 (Initialize initial 1st moment vector)
-    v_0 <- 0 (Initialize initial 2nd moment vector)
-    t <- 0 (Initialize timestep)
+    \\(m_0 <- 0\\) (Initialize initial 1st moment vector)
+    \\(v_0 <- 0\\) (Initialize initial 2nd moment vector)
+    \\(t <- 0\\) (Initialize timestep)
     ```
 
     The update rule for `variable` with gradient `g` uses an optimization
     described at the end of section2 of the paper:
 
     ```
-    t <- t + 1
-    lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)
+    $$t <- t + 1$$
+    $$lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)$$
 
-    m_t <- beta1 * m_{t-1} + (1 - beta1) * g
-    v_t <- beta2 * v_{t-1} + (1 - beta2) * g * g
-    variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)
+    $$m_t <- beta1 * m_{t-1} + (1 - beta1) * g$$
+    $$v_t <- beta2 * v_{t-1} + (1 - beta2) * g * g$$
+    $$variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)$$
     ```
 
     The default value of 1e-8 for epsilon might not be a good default in

--- a/tensorflow/python/training/adam.py
+++ b/tensorflow/python/training/adam.py
@@ -43,23 +43,19 @@ class AdamOptimizer(optimizer.Optimizer):
 
     Initialization:
 
-    ```
     \\(m_0 <- 0\\) (Initialize initial 1st moment vector)
     \\(v_0 <- 0\\) (Initialize initial 2nd moment vector)
     \\(t <- 0\\) (Initialize timestep)
-    ```
 
     The update rule for `variable` with gradient `g` uses an optimization
     described at the end of section2 of the paper:
 
-    ```
     $$t <- t + 1$$
     $$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
 
     $$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
     $$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
     $$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
-    ```
 
     The default value of 1e-8 for epsilon might not be a good default in
     general. For example, when training an Inception network on ImageNet a

--- a/tensorflow/python/training/adam.py
+++ b/tensorflow/python/training/adam.py
@@ -54,11 +54,11 @@ class AdamOptimizer(optimizer.Optimizer):
 
     ```
     $$t <- t + 1$$
-    $$lr_t <- learning_rate * sqrt(1 - beta2^t) / (1 - beta1^t)$$
+    $$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
 
-    $$m_t <- beta1 * m_{t-1} + (1 - beta1) * g$$
-    $$v_t <- beta2 * v_{t-1} + (1 - beta2) * g * g$$
-    $$variable <- variable - lr_t * m_t / (sqrt(v_t) + epsilon)$$
+    $$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
+    $$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+    $$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
     ```
 
     The default value of 1e-8 for epsilon might not be a good default in

--- a/tensorflow/python/training/adam.py
+++ b/tensorflow/python/training/adam.py
@@ -43,19 +43,19 @@ class AdamOptimizer(optimizer.Optimizer):
 
     Initialization:
 
-    $$m_0 \Leftarrow 0 (Initialize initial 1st moment vector)$$
-    $$v_0 \Leftarrow 0 (Initialize initial 2nd moment vector)$$
-    $$t \Leftarrow 0 (Initialize timestep)$$
+    $$m_0 := 0 (Initialize initial 1st moment vector)$$
+    $$v_0 := 0 (Initialize initial 2nd moment vector)$$
+    $$t := 0 (Initialize timestep)$$
 
     The update rule for `variable` with gradient `g` uses an optimization
     described at the end of section2 of the paper:
 
-    $$t \Leftarrow t + 1$$
-    $$lr_t \Leftarrow \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+    $$t := t + 1$$
+    $$lr_t := \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
 
-    $$m_t \Leftarrow beta_1 * m_{t-1} + (1 - beta_1) * g$$
-    $$v_t \Leftarrow beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-    $$variable \Leftarrow variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+    $$m_t := beta_1 * m_{t-1} + (1 - beta_1) * g$$
+    $$v_t := beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+    $$variable := variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 
     The default value of 1e-8 for epsilon might not be a good default in
     general. For example, when training an Inception network on ImageNet a

--- a/tensorflow/python/training/adam.py
+++ b/tensorflow/python/training/adam.py
@@ -43,19 +43,19 @@ class AdamOptimizer(optimizer.Optimizer):
 
     Initialization:
 
-    \\(m_0 <- 0\\) (Initialize initial 1st moment vector)
-    \\(v_0 <- 0\\) (Initialize initial 2nd moment vector)
-    \\(t <- 0\\) (Initialize timestep)
+    $$m_0 \Leftarrow 0 (Initialize initial 1st moment vector)$$
+    $$v_0 \Leftarrow 0 (Initialize initial 2nd moment vector)$$
+    $$t \Leftarrow 0 (Initialize timestep)$$
 
     The update rule for `variable` with gradient `g` uses an optimization
     described at the end of section2 of the paper:
 
-    $$t <- t + 1$$
-    $$lr_t <- \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+    $$t \Leftarrow t + 1$$
+    $$lr_t \Leftarrow \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
 
-    $$m_t <- beta_1 * m_{t-1} + (1 - beta_1) * g$$
-    $$v_t <- beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-    $$variable <- variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+    $$m_t \Leftarrow beta_1 * m_{t-1} + (1 - beta_1) * g$$
+    $$v_t \Leftarrow beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
+    $$variable \Leftarrow variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
 
     The default value of 1e-8 for epsilon might not be a good default in
     general. For example, when training an Inception network on ImageNet a


### PR DESCRIPTION
This PR is to fix mess-up math equation format in below Adam optimizer related docstrings.

This PR is to fix this math equation issue according to the [Math in markdown guideline](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/community/documentation.md#math-in-markdown).

Take [LazyAdamOptimizer](https://www.tensorflow.org/api_docs/python/tf/contrib/opt/LazyAdamOptimizer#methods) as an example below:
Before:
![image](https://user-images.githubusercontent.com/1680977/38183933-b681b03a-3676-11e8-8099-b53e2f55d0cc.png)

After:
![image](https://user-images.githubusercontent.com/1680977/38184016-476ff1e2-3677-11e8-8d48-b68d2f257f41.png)
