### PR TITLE
Remove warnings for tf.contrib.copy_graph.copy_op_to_graph.

### DIFF
--- a/tensorflow/contrib/copy_graph/python/util/copy_elements.py
+++ b/tensorflow/contrib/copy_graph/python/util/copy_elements.py
@@ -201,7 +201,7 @@ def copy_op_to_graph(org_instance, to_graph, variables, scope=''):
     #An instance of tensorflow.core.framework.node_def_pb2.NodeDef, it
     #stores String-based info such as name, device and type of the op.
     #Unique to every Operation instance.
-    new_node_def = deepcopy(op._node_def)
+    new_node_def = deepcopy(op.node_def)
     #Change the name
     new_node_def.name = new_name
 
@@ -211,7 +211,7 @@ def copy_op_to_graph(org_instance, to_graph, variables, scope=''):
 
     #Make a copy of the op_def too.
     #Its unique to every _type_ of Operation.
-    op_def = deepcopy(op._op_def)
+    op_def = deepcopy(op.op_def)
 
     #Initialize a new Operation instance
     new_op = ops.Operation(new_node_def, to_graph, new_inputs, output_types,


### PR DESCRIPTION
When I run the test for tf.contrib.copy_graph, there were the warnings as shown below.

```
WARNING:tensorflow:Operation._node_def is private, use Operation.node_def instead. Operation._node_def will eventually be removed.
WARNING:tensorflow:Operation._op_def is private, use Operation.op_def instead. Operation._op_def will eventually be removed.
WARNING:tensorflow:Operation._node_def is private, use Operation.node_def instead. Operation._node_def will eventually be removed.
WARNING:tensorflow:Operation._op_def is private, use Operation.op_def instead. Operation._op_def will eventually be removed.
WARNING:tensorflow:Operation._node_def is private, use Operation.node_def instead. Operation._node_def will eventually be removed.
WARNING:tensorflow:Operation._op_def is private, use Operation.op_def instead. Operation._op_def will eventually be removed.
WARNING:tensorflow:Operation._node_def is private, use Operation.node_def instead. Operation._node_def will eventually be removed.
WARNING:tensorflow:Operation._op_def is private, use Operation.op_def instead. Operation._op_def will eventually be removed.
```

I made a patch to follow the instruction in warning messages :)
