### PR TITLE
Pass dtype to constructor in LSTMCell

### DIFF
--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
@@ -307,6 +307,14 @@ class LSTMTest(test.TestCase):
     self._seed = 23489
     np.random.seed(self._seed)
 
+  def testDType(self):
+    # Test case for GitHub issue 16228
+    # Not passing dtype in constructor results in default float32
+    lstm = rnn_cell.LSTMCell(10)
+    input_tensor = array_ops.ones([10, 50])
+    lstm.build(input_tensor.get_shape())
+    self.assertEqual(lstm._bias.dtype, dtypes.float32_ref)
+
   def testNoProjNoSharding(self):
     num_units = 3
     input_size = 5

--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
@@ -315,6 +315,13 @@ class LSTMTest(test.TestCase):
     lstm.build(input_tensor.get_shape())
     self.assertEqual(lstm._bias.dtype, dtypes.float32_ref)
 
+    # Explicitly pass dtype in constructor
+    for dtype in ['float16', 'float32', 'float64']:
+      lstm = rnn_cell.LSTMCell(10, dtype=dtypes.as_dtype(dtype))
+      input_tensor = array_ops.ones([10, 50])
+      lstm.build(input_tensor.get_shape())
+      self.assertEqual(lstm._bias.dtype, dtypes.as_dtype(dtype+'_ref'))
+
   def testNoProjNoSharding(self):
     num_units = 3
     input_size = 5

--- a/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/core_rnn_test.py
@@ -316,11 +316,11 @@ class LSTMTest(test.TestCase):
     self.assertEqual(lstm._bias.dtype, dtypes.float32_ref)
 
     # Explicitly pass dtype in constructor
-    for dtype in ['float16', 'float32', 'float64']:
-      lstm = rnn_cell.LSTMCell(10, dtype=dtypes.as_dtype(dtype))
+    for dtype in [dtypes.float16, dtypes.float32, dtypes.float64]:
+      lstm = rnn_cell.LSTMCell(10, dtype=dtype)
       input_tensor = array_ops.ones([10, 50])
       lstm.build(input_tensor.get_shape())
-      self.assertEqual(lstm._bias.dtype, dtypes.as_dtype(dtype+'_ref'))
+      self.assertEqual(lstm._bias.dtype, dtype._as_ref)
 
   def testNoProjNoSharding(self):
     num_units = 3

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -785,10 +785,14 @@ class LSTMCell(LayerRNNCell):
         shape=[input_depth + h_depth, 4 * self._num_units],
         initializer=self._initializer,
         partitioner=maybe_partitioner)
+    if self.dtype is None:
+      initializer=init_ops.zeros_initializer
+    else:
+      initializer=init_ops.zeros_initializer(dtype=self.dtype)
     self._bias = self.add_variable(
         _BIAS_VARIABLE_NAME,
         shape=[4 * self._num_units],
-        initializer=init_ops.zeros_initializer(dtype=self.dtype))
+        initializer=initializer)
     if self._use_peepholes:
       self._w_f_diag = self.add_variable("w_f_diag", shape=[self._num_units],
                                          initializer=self._initializer)

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -786,9 +786,9 @@ class LSTMCell(LayerRNNCell):
         initializer=self._initializer,
         partitioner=maybe_partitioner)
     if self.dtype is None:
-      initializer=init_ops.zeros_initializer
+      initializer = init_ops.zeros_initializer
     else:
-      initializer=init_ops.zeros_initializer(dtype=self.dtype)
+      initializer = init_ops.zeros_initializer(dtype=self.dtype)
     self._bias = self.add_variable(
         _BIAS_VARIABLE_NAME,
         shape=[4 * self._num_units],


### PR DESCRIPTION
This fix tries to address the issue raised in #16228 where the dtype is not passed to LSTMCell and causes a TypeError when build() is called.

This fix pass the dtype to constructor in LSTMCell so that the initializer in build could be invoked. In case None is passed for dtype, float32 is used for initializer.

This fix fixes #16228.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>