### PR TITLE
Fix an issue in api_compatibility_test

### DIFF
--- a/tensorflow/tools/api/generator/create_python_api.py
+++ b/tensorflow/tools/api/generator/create_python_api.py
@@ -122,7 +122,8 @@ def get_api_imports():
   # we want to traverse over TensorFlow Python modules.
   for module in sys.modules.values():
     # Only look at tensorflow modules.
-    if not module or 'tensorflow.' not in module.__name__:
+    if (not module or not hasattr(module, "__name__") or
+        'tensorflow.' not in module.__name__):
       continue
     # Do not generate __init__.py files for contrib modules for now.
     if '.contrib.' in module.__name__ or module.__name__.endswith('.contrib'):


### PR DESCRIPTION
While trying to run on my machine (Ubuntu 16.04 Python 2.7) the api_compatibility_test:
```
bazel test -s --config=opt --cache_test_results=no //tensorflow/tools/api/tests:api_compatibility_test
```

The following error was encountered:
```
  ......
  File "/home/ubuntu/.cache/bazel/_bazel_ubuntu/ad1e09741bb4109fbc70ef8216b59ee2/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/tools/api/generator/create_python_api.runfiles/org_tensorflow/tensorflow/tools/api/generator/create_python_api.py", line 125, in get_api_imports
    if not module or 'tensorflow.' not in module.__name__:
  File "/usr/lib/python2.7/dist-packages/py/_apipkg.py", line 171, in __getattribute__
    return getattr(getmod(), name)
  File "/usr/lib/python2.7/dist-packages/py/_error.py", line 43, in __getattr__
    raise AttributeError(name)
AttributeError: __name__
```

The issue is that `<AliasModule 'py.error' for 'py._error.error'>` does not have a `__name__` attribute (See similiar issue in https://github.com/pytest-dev/py/issues/73).

This fix tries to address the issue by adding an `hasattr()` check so that AttributeError is not thrown.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>