### PR TITLE
Fix minor typo and math rendering format in linear operator related apis

### DIFF
--- a/tensorflow/python/ops/linalg/linear_operator.py
+++ b/tensorflow/python/ops/linalg/linear_operator.py
@@ -282,7 +282,7 @@ class LinearOperator(object):
     `[B1,...,Bb, M, N]`, equivalent to `tf.shape(A)`.
 
     Args:
-      name:  A name for this `Op.
+      name:  A name for this `Op`.
 
     Returns:
       `int32` `Tensor`
@@ -316,7 +316,7 @@ class LinearOperator(object):
     `[B1,...,Bb]`.
 
     Args:
-      name:  A name for this `Op.
+      name:  A name for this `Op`.
 
     Returns:
       `int32` `Tensor`
@@ -338,7 +338,7 @@ class LinearOperator(object):
     `A.shape = [B1,...,Bb, M, N]`, then this returns `b + 2`.
 
     Args:
-      name:  A name for this `Op.
+      name:  A name for this `Op`.
 
     Returns:
       Python integer, or None if the tensor rank is undefined.
@@ -354,7 +354,7 @@ class LinearOperator(object):
     `A.shape = [B1,...,Bb, M, N]`, then this returns `b + 2`.
 
     Args:
-      name:  A name for this `Op.
+      name:  A name for this `Op`.
 
     Returns:
       `int32` `Tensor`, determined at runtime.
@@ -579,7 +579,7 @@ class LinearOperator(object):
       adjoint: Python `bool`.  If `True`, left multiply by the adjoint: `A^H x`.
       adjoint_arg:  Python `bool`.  If `True`, compute `A x^H` where `x^H` is
         the hermitian transpose (transposition and complex conjugation).
-      name:  A name for this `Op.
+      name:  A name for this `Op`.
 
     Returns:
       A `Tensor` with shape `[..., M, R]` and same `dtype` as `self`.
@@ -621,7 +621,7 @@ class LinearOperator(object):
         dimensions, the last dimension defines a vector.
         See class docstring for definition of compatibility.
       adjoint: Python `bool`.  If `True`, left multiply by the adjoint: `A^H x`.
-      name:  A name for this `Op.
+      name:  A name for this `Op`.
 
     Returns:
       A `Tensor` with shape `[..., M]` and same `dtype` as `self`.
@@ -645,7 +645,7 @@ class LinearOperator(object):
     """Determinant for every batch member.
 
     Args:
-      name:  A name for this `Op.
+      name:  A name for this `Op`.
 
     Returns:
       `Tensor` with shape `self.batch_shape` and same `dtype` as `self`.
@@ -674,7 +674,7 @@ class LinearOperator(object):
     """Log absolute value of determinant for every batch member.
 
     Args:
-      name:  A name for this `Op.
+      name:  A name for this `Op`.
 
     Returns:
       `Tensor` with shape `self.batch_shape` and same `dtype` as `self`.

--- a/tensorflow/python/ops/linalg/linear_operator_composition.py
+++ b/tensorflow/python/ops/linalg/linear_operator_composition.py
@@ -45,7 +45,7 @@ class LinearOperatorComposition(linear_operator.LinearOperator):
   [batch] matrix formed with the multiplication `A1 A2...AJ`.
 
   If `opj` has shape `batch_shape_j + [M_j, N_j]`, then we must have
-  `N_j = M_{j+1}`, in which case the composed operator has shape equal to
+  \\(N_j = M_{j+1}\\), in which case the composed operator has shape equal to
   `broadcast_batch_shape + [M_1, N_J]`, where `broadcast_batch_shape` is the
   mutual broadcast of `batch_shape_j`, `j = 1,...,J`, assuming the intermediate
   batch shapes broadcast.  Even if the composed shape is well defined, the
@@ -120,8 +120,8 @@ class LinearOperatorComposition(linear_operator.LinearOperator):
     r"""Initialize a `LinearOperatorComposition`.
 
     `LinearOperatorComposition` is initialized with a list of operators
-    `[\\(op_1,...,op_J\\)]`.  For the `matmul` method to be well defined, the
-    composition `op_i.matmul(\\(op_{i+1}(x)\\))` must be defined.  Other methods have
+    [\\(op_1,...,op_J\\)].  For the `matmul` method to be well defined, the
+    composition op_i.matmul(\\(op_{i+1}(x)\\)) must be defined.  Other methods have
     similar constraints.
 
     Args:

--- a/tensorflow/python/ops/linalg/linear_operator_composition.py
+++ b/tensorflow/python/ops/linalg/linear_operator_composition.py
@@ -120,8 +120,8 @@ class LinearOperatorComposition(linear_operator.LinearOperator):
     r"""Initialize a `LinearOperatorComposition`.
 
     `LinearOperatorComposition` is initialized with a list of operators
-    `[op_1,...,op_J]`.  For the `matmul` method to be well defined, the
-    composition `op_i.matmul(op_{i+1}(x))` must be defined.  Other methods have
+    `[\\(op_1,...,op_J\\)]`.  For the `matmul` method to be well defined, the
+    composition `op_i.matmul(\\(op_{i+1}(x)\\))` must be defined.  Other methods have
     similar constraints.
 
     Args:

--- a/tensorflow/python/ops/linalg/linear_operator_low_rank_update.py
+++ b/tensorflow/python/ops/linalg/linear_operator_low_rank_update.py
@@ -43,7 +43,7 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
   batch member.  For every batch index `(i1,...,ib)`, `A[i1,...,ib, : :]` is
   an `M x N` matrix.
 
-  `LinearOperatorLowRankUpdate` represents `A = L + U D V^H`, where
+  `LinearOperatorLowRankUpdate` represents `\\(A = L + U D V^H\\)`, where
 
   ```
   L, is a LinearOperator representing [batch] M x N matrices
@@ -141,7 +141,7 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
                name="LinearOperatorLowRankUpdate"):
     """Initialize a `LinearOperatorLowRankUpdate`.
 
-    This creates a `LinearOperator` of the form `A = L + U D V^H`, with
+    This creates a `LinearOperator` of the form `\\(A = L + U D V^H\\)`, with
     `L` a `LinearOperator`, `U, V` both [batch] matrices, and `D` a [batch]
     diagonal matrix.
 
@@ -315,32 +315,32 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
 
   @property
   def u(self):
-    """If this operator is `A = L + U D V^H`, this is the `U`."""
+    """If this operator is `\\(A = L + U D V^H\\)`, this is the `U`."""
     return self._u
 
   @property
   def v(self):
-    """If this operator is `A = L + U D V^H`, this is the `V`."""
+    """If this operator is `\\(A = L + U D V^H\\)`, this is the `V`."""
     return self._v
 
   @property
   def is_diag_update_positive(self):
-    """If this operator is `A = L + U D V^H`, this hints `D > 0` elementwise."""
+    """If this operator is `\\(A = L + U D V^H\\)`, this hints `D > 0` elementwise."""
     return self._is_diag_update_positive
 
   @property
   def diag_update(self):
-    """If this operator is `A = L + U D V^H`, this is the diagonal of `D`."""
+    """If this operator is `\\(A = L + U D V^H\\)`, this is the diagonal of `D`."""
     return self._diag_update
 
   @property
   def diag_operator(self):
-    """If this operator is `A = L + U D V^H`, this is `D`."""
+    """If this operator is `\\(A = L + U D V^H\\)`, this is `D`."""
     return self._diag_operator
 
   @property
   def base_operator(self):
-    """If this operator is `A = L + U D V^H`, this is the `L`."""
+    """If this operator is `\\(A = L + U D V^H\\)`, this is the `L`."""
     return self._base_operator
 
   def _shape(self):

--- a/tensorflow/python/ops/linalg/linear_operator_low_rank_update.py
+++ b/tensorflow/python/ops/linalg/linear_operator_low_rank_update.py
@@ -275,7 +275,7 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
       self._check_shapes()
 
       # Pre-compute the so-called "capacitance" matrix
-      #   C := D^{-1} + V^H L^{-1} U
+      #   \\(C := D^{-1} + V^H L^{-1} U\\)
       self._capacitance = self._make_capacitance()
       if self._use_cholesky:
         self._chol_capacitance = linalg_ops.cholesky(self._capacitance)
@@ -380,10 +380,10 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
       return math_ops.exp(self.log_abs_determinant())
     # The matrix determinant lemma gives
     # https://en.wikipedia.org/wiki/Matrix_determinant_lemma
-    #   det(L + UDV^H) = det(D^{-1} + V^H L^{-1} U) det(D) det(L)
-    #                  = det(C) det(D) det(L)
+    #   \\(det(L + UDV^H) = det(D^{-1} + V^H L^{-1} U) det(D) det(L)\\)
+    #                  \\(= det(C) det(D) det(L)\\)
     # where C is sometimes known as the capacitance matrix,
-    #   C := D^{-1} + V^H L^{-1} U
+    #   \\(C := D^{-1} + V^H L^{-1} U\\)
     det_c = linalg_ops.matrix_determinant(self._capacitance)
     det_d = self.diag_operator.determinant()
     det_l = self.base_operator.determinant()
@@ -391,8 +391,8 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
 
   def _log_abs_determinant(self):
     # Recall
-    #   det(L + UDV^H) = det(D^{-1} + V^H L^{-1} U) det(D) det(L)
-    #                  = det(C) det(D) det(L)
+    #   \\(det(L + UDV^H) = det(D^{-1} + V^H L^{-1} U) det(D) det(L)\\)
+    #                  \\(= det(C) det(D) det(L)\\)
     log_abs_det_d = self.diag_operator.log_abs_determinant()
     log_abs_det_l = self.base_operator.log_abs_determinant()
 
@@ -413,13 +413,13 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
           "non-singular LinearOperator.")
     # The Woodbury formula gives:
     # https://en.wikipedia.org/wiki/Woodbury_matrix_identity
-    #   (L + UDV^H)^{-1}
-    #   = L^{-1} - L^{-1} U (D^{-1} + V^H L^{-1} U)^{-1} V^H L^{-1}
-    #   = L^{-1} - L^{-1} U C^{-1} V^H L^{-1}
-    # where C is the capacitance matrix, C := D^{-1} + V^H L^{-1} U
+    #   \\((L + UDV^H)^{-1}\\)
+    #   \\(= L^{-1} - L^{-1} U (D^{-1} + V^H L^{-1} U)^{-1} V^H L^{-1}\\)
+    #   \\(= L^{-1} - L^{-1} U C^{-1} V^H L^{-1}\\)
+    # where C is the capacitance matrix, \\(C := D^{-1} + V^H L^{-1} U\\)
     # Note also that, with ^{-H} being the inverse of the adjoint,
-    #   (L + UDV^H)^{-H}
-    #   = L^{-H} - L^{-H} V C^{-H} U^H L^{-H}
+    #   \\((L + UDV^H)^{-H}\\)
+    #  \\( = L^{-H} - L^{-H} V C^{-H} U^H L^{-H}\\)
     l = self.base_operator
     if adjoint:
       v = self.u
@@ -428,34 +428,34 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
       v = self.v
       u = self.u
 
-    # L^{-1} rhs
+    # \\(L^{-1} rhs\\)
     linv_rhs = l.solve(rhs, adjoint=adjoint, adjoint_arg=adjoint_arg)
-    # V^H L^{-1} rhs
+    # \\(V^H L^{-1} rhs
     vh_linv_rhs = math_ops.matmul(v, linv_rhs, adjoint_a=True)
-    # C^{-1} V^H L^{-1} rhs
+    # \\(C^{-1} V^H L^{-1} rhs\\)
     if self._use_cholesky:
       capinv_vh_linv_rhs = linalg_ops.cholesky_solve(
           self._chol_capacitance, vh_linv_rhs)
     else:
       capinv_vh_linv_rhs = linalg_ops.matrix_solve(
           self._capacitance, vh_linv_rhs, adjoint=adjoint)
-    # U C^{-1} V^H M^{-1} rhs
+    # \\(U C^{-1} V^H M^{-1} rhs\\)
     u_capinv_vh_linv_rhs = math_ops.matmul(u, capinv_vh_linv_rhs)
-    # L^{-1} U C^{-1} V^H L^{-1} rhs
+    # \\(L^{-1} U C^{-1} V^H L^{-1} rhs\\)
     linv_u_capinv_vh_linv_rhs = l.solve(u_capinv_vh_linv_rhs, adjoint=adjoint)
 
-    # L^{-1} - L^{-1} U C^{-1} V^H L^{-1}
+    # \\(L^{-1} - L^{-1} U C^{-1} V^H L^{-1}\\)
     return linv_rhs - linv_u_capinv_vh_linv_rhs
 
   def _make_capacitance(self):
-    # C := D^{-1} + V^H L^{-1} U
+    # \\(C := D^{-1} + V^H L^{-1} U\\)
     # which is sometimes known as the "capacitance" matrix.
 
-    # L^{-1} U
+    # \\(L^{-1} U\\)
     linv_u = self.base_operator.solve(self.u)
-    # V^H L^{-1} U
+    # \\(V^H L^{-1} U\\)
     vh_linv_u = math_ops.matmul(self.v, linv_u, adjoint_a=True)
 
-    # D^{-1} + V^H L^{-1} V
+    # \\(D^{-1} + V^H L^{-1} V\\)
     capacitance = self._diag_inv_operator.add_to_tensor(vh_linv_u)
     return capacitance

--- a/tensorflow/python/ops/linalg/linear_operator_low_rank_update.py
+++ b/tensorflow/python/ops/linalg/linear_operator_low_rank_update.py
@@ -43,7 +43,7 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
   batch member.  For every batch index `(i1,...,ib)`, `A[i1,...,ib, : :]` is
   an `M x N` matrix.
 
-  `LinearOperatorLowRankUpdate` represents `\\(A = L + U D V^H\\)`, where
+  `LinearOperatorLowRankUpdate` represents \\(A = L + U D V^H\\), where
 
   ```
   L, is a LinearOperator representing [batch] M x N matrices
@@ -141,7 +141,7 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
                name="LinearOperatorLowRankUpdate"):
     """Initialize a `LinearOperatorLowRankUpdate`.
 
-    This creates a `LinearOperator` of the form `\\(A = L + U D V^H\\)`, with
+    This creates a `LinearOperator` of the form \\(A = L + U D V^H\\), with
     `L` a `LinearOperator`, `U, V` both [batch] matrices, and `D` a [batch]
     diagonal matrix.
 
@@ -315,12 +315,12 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
 
   @property
   def u(self):
-    """If this operator is `\\(A = L + U D V^H\\)`, this is the `U`."""
+    """If this operator is \\(A = L + U D V^H\\), this is the `U`."""
     return self._u
 
   @property
   def v(self):
-    """If this operator is `\\(A = L + U D V^H\\)`, this is the `V`."""
+    """If this operator is \\(A = L + U D V^H\\), this is the `V`."""
     return self._v
 
   @property
@@ -330,17 +330,17 @@ class LinearOperatorLowRankUpdate(linear_operator.LinearOperator):
 
   @property
   def diag_update(self):
-    """If this operator is `\\(A = L + U D V^H\\)`, this is the diagonal of `D`."""
+    """If this operator is \\(A = L + U D V^H\\), this is the diagonal of `D`."""
     return self._diag_update
 
   @property
   def diag_operator(self):
-    """If this operator is `\\(A = L + U D V^H\\)`, this is `D`."""
+    """If this operator is \\(A = L + U D V^H\\), this is `D`."""
     return self._diag_operator
 
   @property
   def base_operator(self):
-    """If this operator is `\\(A = L + U D V^H\\)`, this is the `L`."""
+    """If this operator is \\(A = L + U D V^H\\), this is the `L`."""
     return self._base_operator
 
   def _shape(self):

--- a/tensorflow/python/training/ftrl.py
+++ b/tensorflow/python/training/ftrl.py
@@ -69,13 +69,13 @@ class FtrlOptimizer(optimizer.Optimizer):
         or equal to zero. This differs from L2 above in that the L2 above is a
         stabilization penalty, whereas this L2 shrinkage is a magnitude penalty.
         The FTRL formulation can be written as:
-        w_{t+1} = argmin_w(\hat{g}_{1:t}w + L1*||w||_1 + L2*||w||_2^2), where
-        \hat{g} = g + (2*L2_shrinkage*w), and g is the gradient of the loss
+        \\(w_{t+1} = argmin_w(\hat{g}_{1:t}w + L1*||w||_1 + L2*||w||_2^2)\\), where
+        \\(\hat{g} = g + (2*L2_{shrinkage}*w)\\), and g is the gradient of the loss
         function w.r.t. the weights w.
         Specifically, in the absence of L1 regularization, it is equivalent to
         the following update rule:
-        w_{t+1} = w_t - lr_t / (1 + 2*L2*lr_t) * g_t -
-                  2*L2_shrinkage*lr_t / (1 + 2*L2*lr_t) * w_t
+        $$w_{t+1} = w_t - lr_t / (1 + 2*L2*lr_t) * g_t -$$
+                  $$2*L2_{shrinkage}*lr_t / (1 + 2*L2*lr_t) * w_t$$
         where lr_t is the learning rate at t.
         When input is sparse shrinkage will only happen on the active weights.
 


### PR DESCRIPTION
This PR is to fix some minor typo and mathe rendering format in linear operator related doc strings.
- Fix a minor typo format for below line in [tensor_rank](https://www.tensorflow.org/api_docs/python/tf/linalg/LinearOperator#tensor_rank);
![image](https://user-images.githubusercontent.com/1680977/38263160-e696ea3e-37a1-11e8-9f63-9a27c847d05a.png)

- Fix some math equation rendering format in linear operator related api doc strings, like the one example [LinearOperatorLowRankUpdate](https://www.tensorflow.org/api_docs/python/tf/linalg/LinearOperatorLowRankUpdate#base_operator) as below;
![image](https://user-images.githubusercontent.com/1680977/38263690-54ee4a08-37a3-11e8-99fb-7a27676075eb.png)


