### PR TITLE
Fix `TypeError: 'dict_keys'` in contrib.distribute with python 3

### DIFF
--- a/tensorflow/contrib/distribute/python/values.py
+++ b/tensorflow/contrib/distribute/python/values.py
@@ -73,7 +73,7 @@ class DistributedValues(object):
 
   @property
   def devices(self):
-    return self._index.keys()
+    return list(self._index.keys())
 
   def __str__(self):
     return "%s:%s" % (self.__class__.__name__, self._index)


### PR DESCRIPTION
This fix tries to fix the issue raised in #18205 where
```
TypeError: 'dict_keys' object does not support indexing
```
was thrown when using contrib.distribute in python 3.

The issue is that DistributedValues.devices returned `self._index.keys()` which is a `dict_keys` and is not a list in python 3.

This fix converts the `dict_keys` to list for python 3 to fix the issue.

This fix fixes #18205.
This fix als fixes #18188.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>