### PR TITLE
Fix windows boosted_trees test failure

### DIFF
--- a/tensorflow/python/kernel_tests/boosted_trees/training_ops_test.py
+++ b/tensorflow/python/kernel_tests/boosted_trees/training_ops_test.py
@@ -1331,66 +1331,67 @@ class UpdateTreeEnsembleOpTest(test_util.TensorFlowTestCase):
       res_ensemble = boosted_trees_pb2.TreeEnsemble()
       res_ensemble.ParseFromString(serialized)
 
+      expected_result = """
+        trees {
+          nodes {
+            leaf {
+            }
+          }
+        }
+        trees {
+          nodes {
+            leaf {
+            }
+          }
+        }
+        tree_weights: 1.0
+        tree_weights: 1.0
+        tree_metadata{
+          num_layers_grown: 2
+          is_finalized: true
+          post_pruned_nodes_meta {
+            new_node_id: 0
+            logit_change: 0.0
+          }
+          post_pruned_nodes_meta {
+            new_node_id: 0
+            logit_change: -0.01
+          }
+          post_pruned_nodes_meta {
+            new_node_id: 0
+            logit_change: -0.0143
+          }
+          post_pruned_nodes_meta {
+            new_node_id: 0
+            logit_change: -0.033
+          }
+          post_pruned_nodes_meta {
+            new_node_id: 0
+            logit_change: -0.022343
+          }
+          post_pruned_nodes_meta {
+            new_node_id: 0
+            logit_change: -0.3143
+          }
+          post_pruned_nodes_meta {
+            new_node_id: 0
+            logit_change: -24.014299
+          }
+        }
+        tree_metadata {
+        }
+        growing_metadata {
+          num_trees_attempted: 1
+          num_layers_attempted: 2
+          last_layer_node_start: 0
+          last_layer_node_end: 1
+        }
+      """
+
       # Expect the ensemble to be empty as post-pruning will prune
       # the entire finalized tree.
       self.assertEqual(new_stamp, 2)
-      self.assertProtoEquals(
-          """
-      trees {
-        nodes {
-          leaf {
-          }
-        }
-      }
-      trees {
-        nodes {
-          leaf {
-          }
-        }
-      }
-      tree_weights: 1.0
-      tree_weights: 1.0
-      tree_metadata{
-        num_layers_grown: 2
-        is_finalized: true
-        post_pruned_nodes_meta {
-          new_node_id: 0
-          logit_change: 0.0
-        }
-        post_pruned_nodes_meta {
-          new_node_id: 0
-          logit_change: -0.01
-        }
-        post_pruned_nodes_meta {
-          new_node_id: 0
-          logit_change: -0.0143
-        }
-        post_pruned_nodes_meta {
-          new_node_id: 0
-          logit_change: -0.033
-        }
-        post_pruned_nodes_meta {
-          new_node_id: 0
-          logit_change: -0.022343
-        }
-        post_pruned_nodes_meta {
-          new_node_id: 0
-          logit_change: -0.3143
-        }
-        post_pruned_nodes_meta {
-          new_node_id: 0
-          logit_change: -24.0143
-        }
-      }
-      tree_metadata {
-      }
-      growing_metadata {
-        num_trees_attempted: 1
-        num_layers_attempted: 2
-        last_layer_node_start: 0
-        last_layer_node_end: 1
-      }
-      """, res_ensemble)
+      self.assertProtoEquals(expected_result, res_ensemble)
 
   def testPostPruningChangesNothing(self):
     """Test growing an ensemble with post-pruning with all gains >0."""


### PR DESCRIPTION
In the Windows cmake build, the test "python/kernel_tests/boosted_trees/training_ops_test.py" is failing on a Proto comparison. This commit changes one of the expected values to use
higher decimal precision which should pass on all builds. (-24.0143 to -24.014299)

The windows error of topic:

`13:01:23 Traceback (most recent call last):
13:01:23   File "C:/tf_jenkins/workspace/tensorflow-master-win-cmake-py/tensorflow/python/kernel_tests/boosted_trees/training_ops_test.py", line 1363, in testPostPruningOfAllNodes
13:01:23     """, res_ensemble)
13:01:23   File "C:\Program Files\Anaconda3\lib\site-packages\tensorflow\python\framework\test_util.py", line 840, in assertProtoEquals
13:01:23     self._AssertProtoEquals(expected_message, message, msg=msg)
13:01:23   File "C:\Program Files\Anaconda3\lib\site-packages\tensorflow\python\framework\test_util.py", line 817, in _AssertProtoEquals
13:01:23     compare.assertProtoEqual(self, a, b, normalize_numbers=True, msg=msg)
13:01:23   File "C:\Program Files\Anaconda3\lib\site-packages\tensorflow\python\util\protobuf\compare.py", line 107, in assertProtoEqual
13:01:23     msg=msg)
13:01:23 AssertionError: 'tree[570 chars]4.0143\n  }\n}\ntree_metadata {\n}\ngrowing_me[62 chars]n}\n' != 'tree[570 chars]4.014299\n  }\n}\ntree_metadata {\n}\ngrowing_[64 chars]n}\n'`

This stems from the 32 bit floating point imprecision. For example:

> import numpy as np
> p = np.float32(-24.0143)
> '{:.12f}'.format(p)
**'-24.014299392700'**

This commit also assigns the expected result to a variable to remain consistent with the other tests.
