### PR TITLE
Allow deletion of multiple checkpoints at once

### DIFF
--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -1422,14 +1422,14 @@ class Saver(object):
     if not self.saver_def.max_to_keep:
       return
     # Remove first from list if the same name was used before.
-    for p in self._last_checkpoints:
+    for p in list(self._last_checkpoints):
       if latest_save_path == self._CheckpointFilename(p):
         self._last_checkpoints.remove(p)
     # Append new path to list
     self._last_checkpoints.append((latest_save_path, time.time()))
 
     # If more than max_to_keep, remove oldest.
-    if len(self._last_checkpoints) > self.saver_def.max_to_keep:
+    while len(self._last_checkpoints) > self.saver_def.max_to_keep:
       self._checkpoints_to_be_deleted.append(self._last_checkpoints.pop(0))
 
   def _MaybeDeleteOldCheckpoints(self, meta_graph_suffix="meta"):
@@ -1445,7 +1445,7 @@ class Saver(object):
     Args:
       meta_graph_suffix: Suffix for `MetaGraphDef` file. Defaults to 'meta'.
     """
-    if self._checkpoints_to_be_deleted:
+    while self._checkpoints_to_be_deleted:
       p = self._checkpoints_to_be_deleted.pop(0)
       # Do not delete the file if we keep_checkpoint_every_n_hours is set and we
       # have reached N hours of training.
@@ -1453,7 +1453,7 @@ class Saver(object):
       if should_keep:
         self._next_checkpoint_time += (
             self.saver_def.keep_checkpoint_every_n_hours * 3600)
-        return
+        continue
 
       # Otherwise delete the files.
       try:

--- a/tensorflow/python/training/saver_test.py
+++ b/tensorflow/python/training/saver_test.py
@@ -1289,6 +1289,19 @@ class MaxToKeepTest(test.TestCase):
           all_model_checkpoint_paths=[s2, s1],
           save_dir=save_dir)
 
+      # Create a new saver with a smaller value of max_to_keep.
+      save4 = saver_module.Saver({"v": v}, max_to_keep=1)
+      checkpoint_state = saver_module.get_checkpoint_state(save_dir)
+      s4 = save4.save(sess, os.path.join(save_dir, "s4"))
+      checkpoint_state = saver_module.get_checkpoint_state(save_dir)
+      self.assertCheckpointState(
+          model_checkpoint_path=s4,
+          all_model_checkpoint_paths=[s4],
+          save_dir=save_dir)
+
+ 
+
+
   def testSharded(self):
     save_dir = self._get_test_dir("max_to_keep_sharded")
 


### PR DESCRIPTION
The code in `saver.py` that enforces the `max_to_keep` parameter (AKA `keep_checkpoint_max`) is written in such a way that it deletes at most one checkpoint when saving a new checkpoint. If a Saver gets into a state where the number of checkpoints in the checkpoints file is greater than `max_to_keep`, the Saver will never delete enough checkpoints to bring the number down to `max_to_keep`.

I ran into this issue when my VM ran low disk space due to a large number of checkpoints. I killed my running training job, set `max_to_keep` to a smaller number, and restarted. Nothing happened.

This PR adjusts the deletion logic so that the Saver will delete multiple checkpoints if necessary to bring the number of checkpoints down to the current value of `max_to_keep`.