### PR TITLE
Check input dimension for contrib.layers.conv2d/conv3d

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -933,7 +933,7 @@ def convolution(inputs,
                 outputs_collections=None,
                 trainable=True,
                 scope=None,
-                dims=None):
+                conv_dims=None):
   """Adds an N-D convolution followed by an optional batch_norm layer.
 
   It is required that 1 <= N <= 3.
@@ -994,8 +994,10 @@ def convolution(inputs,
     trainable: If `True` also add variables to the graph collection
       `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
     scope: Optional scope for `variable_scope`.
-    dims: Optional dims (e.g., 2 for Conv 2D) for convolution. Default is None
-      which will select the dimension based on the input rank.
+    conv_dims: Optional convolution dimensionality, when set it would use the
+      corresponding convolution (e.g. 2 for Conv 2D, 3 for Conv 3D, ..). When
+      leaved to None it would select the convolution dimensionality based on
+      the input rank (i.e. Conv ND, with N = input_rank - 2).
 
   Returns:
     A tensor representing the output of the operation.
@@ -1018,9 +1020,9 @@ def convolution(inputs,
     inputs = ops.convert_to_tensor(inputs)
     input_rank = inputs.get_shape().ndims
 
-    if dims is not None and dims + 2 != input_rank:
+    if conv_dims is not None and conv_dims + 2 != input_rank:
       raise ValueError('Convolution expects input with rank %d, got %d' %
-                       (dims + 2, input_rank))
+                       (conv_dims + 2, input_rank))
     if input_rank == 3:
       layer_class = convolutional_layers.Convolution1D
     elif input_rank == 4:
@@ -1068,6 +1070,49 @@ def convolution(inputs,
     return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
 
 @add_arg_scope
+def convolution1d(inputs,
+                  num_outputs,
+                  kernel_size,
+                  stride=1,
+                  padding='SAME',
+                  data_format=None,
+                  rate=1,
+                  activation_fn=nn.relu,
+                  normalizer_fn=None,
+                  normalizer_params=None,
+                  weights_initializer=initializers.xavier_initializer(),
+                  weights_regularizer=None,
+                  biases_initializer=init_ops.zeros_initializer(),
+                  biases_regularizer=None,
+                  reuse=None,
+                  variables_collections=None,
+                  outputs_collections=None,
+                  trainable=True,
+                  scope=None):
+  return convolution(inputs,
+                     num_outputs,
+                     kernel_size,
+                     stride,
+                     padding,
+                     data_format,
+                     rate,
+                     activation_fn,
+                     normalizer_fn,
+                     normalizer_params,
+                     weights_initializer,
+                     weights_regularizer,
+                     biases_initializer,
+                     biases_regularizer,
+                     reuse,
+                     variables_collections,
+                     outputs_collections,
+                     trainable,
+                     scope,
+                     conv_dims=1)
+
+convolution1d.__doc__ = convolution.__doc__
+
+@add_arg_scope
 def convolution2d(inputs,
                   num_outputs,
                   kernel_size,
@@ -1106,7 +1151,7 @@ def convolution2d(inputs,
                      outputs_collections,
                      trainable,
                      scope,
-                     dims=2)
+                     conv_dims=2)
 
 convolution2d.__doc__ = convolution.__doc__
 
@@ -1149,7 +1194,7 @@ def convolution3d(inputs,
                      outputs_collections,
                      trainable,
                      scope,
-                     dims=3)
+                     conv_dims=3)
 
 convolution3d.__doc__ = convolution.__doc__
 

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -911,26 +911,99 @@ def bias_add(inputs,
     return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
 
 
-def _convolution(inputs,
-                 num_outputs,
-                 kernel_size,
-                 stride=1,
-                 padding='SAME',
-                 data_format=None,
-                 rate=1,
-                 activation_fn=nn.relu,
-                 normalizer_fn=None,
-                 normalizer_params=None,
-                 weights_initializer=initializers.xavier_initializer(),
-                 weights_regularizer=None,
-                 biases_initializer=init_ops.zeros_initializer(),
-                 biases_regularizer=None,
-                 reuse=None,
-                 variables_collections=None,
-                 outputs_collections=None,
-                 trainable=True,
-                 scope=None,
-                 dims=None):
+# TODO(jbms): change `rate` parameter to `dilation_rate` for consistency with
+# underlying op.
+@add_arg_scope
+def convolution(inputs,
+                num_outputs,
+                kernel_size,
+                stride=1,
+                padding='SAME',
+                data_format=None,
+                rate=1,
+                activation_fn=nn.relu,
+                normalizer_fn=None,
+                normalizer_params=None,
+                weights_initializer=initializers.xavier_initializer(),
+                weights_regularizer=None,
+                biases_initializer=init_ops.zeros_initializer(),
+                biases_regularizer=None,
+                reuse=None,
+                variables_collections=None,
+                outputs_collections=None,
+                trainable=True,
+                scope=None,
+                dims=None):
+  """Adds an N-D convolution followed by an optional batch_norm layer.
+
+  It is required that 1 <= N <= 3.
+
+  `convolution` creates a variable called `weights`, representing the
+  convolutional kernel, that is convolved (actually cross-correlated) with the
+  `inputs` to produce a `Tensor` of activations. If a `normalizer_fn` is
+  provided (such as `batch_norm`), it is then applied. Otherwise, if
+  `normalizer_fn` is None and a `biases_initializer` is provided then a `biases`
+  variable would be created and added the activations. Finally, if
+  `activation_fn` is not `None`, it is applied to the activations as well.
+
+  Performs atrous convolution with input stride/dilation rate equal to `rate`
+  if a value > 1 for any dimension of `rate` is specified.  In this case
+  `stride` values != 1 are not supported.
+
+  Args:
+    inputs: A Tensor of rank N+2 of shape
+      `[batch_size] + input_spatial_shape + [in_channels]` if data_format does
+      not start with "NC" (default), or
+      `[batch_size, in_channels] + input_spatial_shape` if data_format starts
+      with "NC".
+    num_outputs: Integer, the number of output filters.
+    kernel_size: A sequence of N positive integers specifying the spatial
+      dimensions of the filters.  Can be a single integer to specify the same
+      value for all spatial dimensions.
+    stride: A sequence of N positive integers specifying the stride at which to
+      compute output.  Can be a single integer to specify the same value for all
+      spatial dimensions.  Specifying any `stride` value != 1 is incompatible
+      with specifying any `rate` value != 1.
+    padding: One of `"VALID"` or `"SAME"`.
+    data_format: A string or None.  Specifies whether the channel dimension of
+      the `input` and output is the last dimension (default, or if `data_format`
+      does not start with "NC"), or the second dimension (if `data_format`
+      starts with "NC").  For N=1, the valid values are "NWC" (default) and
+      "NCW".  For N=2, the valid values are "NHWC" (default) and "NCHW".
+      For N=3, the valid values are "NDHWC" (default) and "NCDHW".
+    rate: A sequence of N positive integers specifying the dilation rate to use
+      for atrous convolution.  Can be a single integer to specify the same
+      value for all spatial dimensions.  Specifying any `rate` value != 1 is
+      incompatible with specifying any `stride` value != 1.
+    activation_fn: Activation function. The default value is a ReLU function.
+      Explicitly set it to None to skip it and maintain a linear activation.
+    normalizer_fn: Normalization function to use instead of `biases`. If
+      `normalizer_fn` is provided then `biases_initializer` and
+      `biases_regularizer` are ignored and `biases` are not created nor added.
+      default set to None for no normalizer function
+    normalizer_params: Normalization function parameters.
+    weights_initializer: An initializer for the weights.
+    weights_regularizer: Optional regularizer for the weights.
+    biases_initializer: An initializer for the biases. If None skip biases.
+    biases_regularizer: Optional regularizer for the biases.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional list of collections for all the variables or
+      a dictionary containing a different list of collection per variable.
+    outputs_collections: Collection to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+    scope: Optional scope for `variable_scope`.
+    dims: Optional dims (e.g., 2 for Conv 2D) for convolution. Default is None
+      which will select the dimension based on the input rank.
+
+  Returns:
+    A tensor representing the output of the operation.
+
+  Raises:
+    ValueError: If `data_format` is invalid.
+    ValueError: Both 'rate' and `stride` are not uniformly 1.
+  """
   if data_format not in [None, 'NWC', 'NCW', 'NHWC', 'NCHW', 'NDHWC', 'NCDHW']:
     raise ValueError('Invalid data_format: %r' % (data_format,))
 
@@ -994,117 +1067,6 @@ def _convolution(inputs,
       outputs = activation_fn(outputs)
     return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
 
-
-# TODO(jbms): change `rate` parameter to `dilation_rate` for consistency with
-# underlying op.
-@add_arg_scope
-def convolution(inputs,
-                num_outputs,
-                kernel_size,
-                stride=1,
-                padding='SAME',
-                data_format=None,
-                rate=1,
-                activation_fn=nn.relu,
-                normalizer_fn=None,
-                normalizer_params=None,
-                weights_initializer=initializers.xavier_initializer(),
-                weights_regularizer=None,
-                biases_initializer=init_ops.zeros_initializer(),
-                biases_regularizer=None,
-                reuse=None,
-                variables_collections=None,
-                outputs_collections=None,
-                trainable=True,
-                scope=None):
-  """Adds an N-D convolution followed by an optional batch_norm layer.
-
-  It is required that 1 <= N <= 3.
-
-  `convolution` creates a variable called `weights`, representing the
-  convolutional kernel, that is convolved (actually cross-correlated) with the
-  `inputs` to produce a `Tensor` of activations. If a `normalizer_fn` is
-  provided (such as `batch_norm`), it is then applied. Otherwise, if
-  `normalizer_fn` is None and a `biases_initializer` is provided then a `biases`
-  variable would be created and added the activations. Finally, if
-  `activation_fn` is not `None`, it is applied to the activations as well.
-
-  Performs atrous convolution with input stride/dilation rate equal to `rate`
-  if a value > 1 for any dimension of `rate` is specified.  In this case
-  `stride` values != 1 are not supported.
-
-  Args:
-    inputs: A Tensor of rank N+2 of shape
-      `[batch_size] + input_spatial_shape + [in_channels]` if data_format does
-      not start with "NC" (default), or
-      `[batch_size, in_channels] + input_spatial_shape` if data_format starts
-      with "NC".
-    num_outputs: Integer, the number of output filters.
-    kernel_size: A sequence of N positive integers specifying the spatial
-      dimensions of the filters.  Can be a single integer to specify the same
-      value for all spatial dimensions.
-    stride: A sequence of N positive integers specifying the stride at which to
-      compute output.  Can be a single integer to specify the same value for all
-      spatial dimensions.  Specifying any `stride` value != 1 is incompatible
-      with specifying any `rate` value != 1.
-    padding: One of `"VALID"` or `"SAME"`.
-    data_format: A string or None.  Specifies whether the channel dimension of
-      the `input` and output is the last dimension (default, or if `data_format`
-      does not start with "NC"), or the second dimension (if `data_format`
-      starts with "NC").  For N=1, the valid values are "NWC" (default) and
-      "NCW".  For N=2, the valid values are "NHWC" (default) and "NCHW".
-      For N=3, the valid values are "NDHWC" (default) and "NCDHW".
-    rate: A sequence of N positive integers specifying the dilation rate to use
-      for atrous convolution.  Can be a single integer to specify the same
-      value for all spatial dimensions.  Specifying any `rate` value != 1 is
-      incompatible with specifying any `stride` value != 1.
-    activation_fn: Activation function. The default value is a ReLU function.
-      Explicitly set it to None to skip it and maintain a linear activation.
-    normalizer_fn: Normalization function to use instead of `biases`. If
-      `normalizer_fn` is provided then `biases_initializer` and
-      `biases_regularizer` are ignored and `biases` are not created nor added.
-      default set to None for no normalizer function
-    normalizer_params: Normalization function parameters.
-    weights_initializer: An initializer for the weights.
-    weights_regularizer: Optional regularizer for the weights.
-    biases_initializer: An initializer for the biases. If None skip biases.
-    biases_regularizer: Optional regularizer for the biases.
-    reuse: Whether or not the layer and its variables should be reused. To be
-      able to reuse the layer scope must be given.
-    variables_collections: Optional list of collections for all the variables or
-      a dictionary containing a different list of collection per variable.
-    outputs_collections: Collection to add the outputs.
-    trainable: If `True` also add variables to the graph collection
-      `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
-    scope: Optional scope for `variable_scope`.
-
-  Returns:
-    A tensor representing the output of the operation.
-
-  Raises:
-    ValueError: If `data_format` is invalid.
-    ValueError: Both 'rate' and `stride` are not uniformly 1.
-  """
-  return _convolution(inputs,
-                      num_outputs,
-                      kernel_size,
-                      stride,
-                      padding,
-                      data_format,
-                      rate,
-                      activation_fn,
-                      normalizer_fn,
-                      normalizer_params,
-                      weights_initializer,
-                      weights_regularizer,
-                      biases_initializer,
-                      biases_regularizer,
-                      reuse,
-                      variables_collections,
-                      outputs_collections,
-                      trainable,
-                      scope)
-
 @add_arg_scope
 def convolution2d(inputs,
                   num_outputs,
@@ -1125,26 +1087,26 @@ def convolution2d(inputs,
                   outputs_collections=None,
                   trainable=True,
                   scope=None):
-  return _convolution(inputs,
-                      num_outputs,
-                      kernel_size,
-                      stride,
-                      padding,
-                      data_format,
-                      rate,
-                      activation_fn,
-                      normalizer_fn,
-                      normalizer_params,
-                      weights_initializer,
-                      weights_regularizer,
-                      biases_initializer,
-                      biases_regularizer,
-                      reuse,
-                      variables_collections,
-                      outputs_collections,
-                      trainable,
-                      scope,
-                      dims=2)
+  return convolution(inputs,
+                     num_outputs,
+                     kernel_size,
+                     stride,
+                     padding,
+                     data_format,
+                     rate,
+                     activation_fn,
+                     normalizer_fn,
+                     normalizer_params,
+                     weights_initializer,
+                     weights_regularizer,
+                     biases_initializer,
+                     biases_regularizer,
+                     reuse,
+                     variables_collections,
+                     outputs_collections,
+                     trainable,
+                     scope,
+                     dims=2)
 
 convolution2d.__doc__ = convolution.__doc__
 
@@ -1168,26 +1130,26 @@ def convolution3d(inputs,
                   outputs_collections=None,
                   trainable=True,
                   scope=None):
-  return _convolution(inputs,
-                      num_outputs,
-                      kernel_size,
-                      stride,
-                      padding,
-                      data_format,
-                      rate,
-                      activation_fn,
-                      normalizer_fn,
-                      normalizer_params,
-                      weights_initializer,
-                      weights_regularizer,
-                      biases_initializer,
-                      biases_regularizer,
-                      reuse,
-                      variables_collections,
-                      outputs_collections,
-                      trainable,
-                      scope,
-                      dims=3)
+  return convolution(inputs,
+                     num_outputs,
+                     kernel_size,
+                     stride,
+                     padding,
+                     data_format,
+                     rate,
+                     activation_fn,
+                     normalizer_fn,
+                     normalizer_params,
+                     weights_initializer,
+                     weights_regularizer,
+                     biases_initializer,
+                     biases_regularizer,
+                     reuse,
+                     variables_collections,
+                     outputs_collections,
+                     trainable,
+                     scope,
+                     dims=3)
 
 convolution3d.__doc__ = convolution.__doc__
 

--- a/tensorflow/contrib/layers/python/layers/layers_test.py
+++ b/tensorflow/contrib/layers/python/layers/layers_test.py
@@ -3166,7 +3166,7 @@ class RepeatTests(test.TestCase):
     with self.test_session():
       images = np.random.uniform(size=(5, height, width, 3)).astype(np.float32)
       output = _layers.repeat(images, 3, layers_lib.conv2d, 32, [3, 3])
-      self.assertEqual(output.op.name, 'Repeat/convolution_3/Relu')
+      self.assertEqual(output.op.name, 'Repeat/convolution2d_3/Relu')
       self.assertListEqual(output.get_shape().as_list(), [5, 3, 3, 32])
 
   def testRepeatWithScope(self):
@@ -3760,7 +3760,7 @@ class StackTests(test.TestCase):
           layers_lib.convolution2d, [10, 20, 30],
           kernel_size=[3, 3],
           padding='SAME')
-      self.assertEqual(output.op.name, 'Stack/convolution_3/Relu')
+      self.assertEqual(output.op.name, 'Stack/convolution2d_3/Relu')
       self.assertListEqual(output.get_shape().as_list(), [5, 3, 3, 30])
 
   def testStackWithScope(self):

--- a/tensorflow/contrib/layers/python/layers/layers_test.py
+++ b/tensorflow/contrib/layers/python/layers/layers_test.py
@@ -310,6 +310,17 @@ class BiasAddTest(test.TestCase):
 
 class ConvolutionTest(test.TestCase):
 
+  def testInvalidShape(self):
+    with self.test_session():
+      images_2d = random_ops.random_uniform((5, 7, 9, 3), seed=1)
+      with self.assertRaisesRegexp(
+          ValueError, 'Convolution expects input with rank 5, got 4'):
+        layers_lib.convolution3d(images_2d, 32, 3)
+      images_3d = random_ops.random_uniform((5, 6, 7, 9, 3), seed=1)
+      with self.assertRaisesRegexp(
+          ValueError, 'Convolution expects input with rank 4, got 5'):
+        layers_lib.convolution2d(images_3d, 32, 3)
+
   def testInvalidDataFormat(self):
     height, width = 7, 9
     with self.test_session():


### PR DESCRIPTION
This fix tries to fix the issue raised in #14583 where the input dimension was not checked for contrib.layers.conv2d/conv3d and contrib.slim.conv2d/conv3d.

The issue was that conv2d/conv3d were just aliases of convolution. This fix wrap the conv2d/conv3d with the input dimension check so that incorrect usage will return ValueError.

This fix fixes #14583.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>