### PR TITLE
Change --output_png to --output_image

### DIFF
--- a/tensorflow/docs_src/tutorials/audio_recognition.md
+++ b/tensorflow/docs_src/tutorials/audio_recognition.md
@@ -280,7 +280,7 @@ tool:
 ```
 bazel run tensorflow/examples/wav_to_spectrogram:wav_to_spectrogram -- \
 --input_wav=/tmp/speech_dataset/happy/ab00c4b2_nohash_0.wav \
---output_png=/tmp/spectrogram.png
+--output_image=/tmp/spectrogram.png
 ```
 
 If you open up `/tmp/spectrogram.png` you should see something like this:


### PR DESCRIPTION
The argument is incorrect.

When running the given command, we get
```
E tensorflow/examples/wav_to_spectrogram/main.cc:54] Unknown argument
--output_png=/tmp/spectrogram.png
```

TESTED:Rerun the updated command and verify that the flag is correct.
```
bazel run tensorflow/examples/wav_to_spectrogram:wav_to_spectrogram --
--input_wav=/tmp/speech_dataset/happy/ab00c4b2_nohash_0.wav
--output_image=/tmp/spectrogram.png
```