### PR TITLE
remove the misleading n_class information

### DIFF
--- a/tensorflow/python/estimator/canned/head.py
+++ b/tensorflow/python/estimator/canned/head.py
@@ -263,7 +263,7 @@ def _check_dense_labels_match_logits_and_reshape(
         if (dim1 is not None) and (dim1 != expected_labels_dimension):
           raise ValueError(
               'Mismatched label shape. '
-              'Classifier configured with n_classes=%s.  Received %s. '
+              'Expected labels dimension=%s.  Received %s. '
               'Suggested Fix: check your n_classes argument to the estimator '
               'and/or the shape of your label.' %
               (expected_labels_dimension, dim1))

--- a/tensorflow/python/estimator/canned/head.py
+++ b/tensorflow/python/estimator/canned/head.py
@@ -264,8 +264,11 @@ def _check_dense_labels_match_logits_and_reshape(
           raise ValueError(
               'Mismatched label shape. '
               'Expected labels dimension=%s.  Received %s. '
-              'Suggested Fix: check your n_classes argument to the estimator '
-              'and/or the shape of your label.' %
+              'Suggested Fix:'
+              'If your classifier expects one-hot encoding label,'
+              'check your n_classes argument to the estimator'
+              'and/or the shape of your label.'
+              'Otherwise, check the shape of your label.' %
               (expected_labels_dimension, dim1))
       expected_labels_shape = array_ops.concat(
           [logits_shape[:-1], [expected_labels_dimension]], axis=0)


### PR DESCRIPTION
Fix #15800 

`tf.estimator.DNNClassifier` expects a `[D0]` or `[D0, 1]` labels, where `expected_labels_dimension` is not equal to `n_classes`.  Hence the error information below is totally misleading.
> Classifier configured with n_classes=1. Received 4.