### PR TITLE
Fix the default value doc string of global_step in contrib.slim

### DIFF
--- a/tensorflow/contrib/slim/python/slim/learning.py
+++ b/tensorflow/contrib/slim/python/slim/learning.py
@@ -389,7 +389,7 @@ def create_train_op(total_loss,
     total_loss: A `Tensor` representing the total loss.
     optimizer: A tf.Optimizer to use for computing the gradients.
     global_step: A `Tensor` representing the global step variable. If left as
-      `_USE_GLOBAL_STEP`, then slim.variables.global_step() is used.
+      `_USE_GLOBAL_STEP`, then tf.contrib.framework.global_step() is used.
     update_ops: An optional list of updates to execute. If `update_ops` is
       `None`, then the update ops are set to the contents of the
       `tf.GraphKeys.UPDATE_OPS` collection. If `update_ops` is not `None`, but
@@ -578,7 +578,8 @@ def train(train_op,
     is_chief: Specifies whether or not the training is being run by the primary
       replica during replica training.
     global_step: The `Tensor` representing the global step. If left as `None`,
-      then slim.variables.get_or_create_global_step() is used.
+      then training_util.get_or_create_global_step(), that is,
+      tf.contrib.framework.global_step() is used.
     number_of_steps: The max number of gradient steps to take during training,
       as measured by 'global_step': training will stop if global_step is
       greater than 'number_of_steps'. If the value is left as None, training


### PR DESCRIPTION
This PR is to fix the default value doc string of global_step in contrib.slim.
- As [contrib.slim.learning.L428](https://github.com/imsheridan/tensorflow/blob/master/tensorflow/contrib/slim/python/slim/learning.py#L428) shown, If global_step was left as `_USE_GLOBAL_STEP`, then `tf.contrib.framework.global_step()` is used instead of `slim.variables.global_step()` according to [contrib.training.training.L386](https://github.com/imsheridan/tensorflow/blob/master/tensorflow/contrib/training/python/training/training.py#L386)
![image](https://user-images.githubusercontent.com/1680977/38458125-e6e9aae8-3acc-11e8-9a69-077d776a8fa6.png)

- As [contrib.slim.learning.L657](https://github.com/imsheridan/tensorflow/blob/master/tensorflow/contrib/slim/python/slim/learning.py#L657) shown, If global_step was left as `None`, then `training_util.get_or_create_global_step()` is used instead of `slim.variables.get_or_create_global_step()`;
![image](https://user-images.githubusercontent.com/1680977/38458102-91faaee2-3acc-11e8-8640-ec4ba1f6c14c.png)



