### PR TITLE
Fix WARNING in BatchNormalization

### DIFF
--- a/tensorflow/python/keras/_impl/keras/layers/normalization.py
+++ b/tensorflow/python/keras/_impl/keras/layers/normalization.py
@@ -592,9 +592,9 @@ class BatchNormalization(Layer):
         # used during evaluation, it is more efficient to just update in one
         # step and should not make a significant difference in the result.
         new_mean = math_ops.reduce_mean(new_mean,
-                                        axis=1, keep_dims=True)
+                                        axis=1, keepdims=True)
         new_variance = math_ops.reduce_mean(new_variance,
-                                            axis=1, keep_dims=True)
+                                            axis=1, keepdims=True)
 
       def _do_update(var, value):
         if in_eager_mode and not self.trainable:


### PR DESCRIPTION
The keep_dims for reduce_mean has been deprecated and replaced
with keepdims. This casues the following WARNING in BatchNormalization:
```
normalization.py:584: calling reduce_mean (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.
Instructions for updating:
keep_dims is deprecated, use keepdims instead
```

This fix fixes the warning in BatchNormalization.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>