### PR TITLE
contrib/lite: Avoid building benchmark_model for RPi

### DIFF
--- a/tensorflow/contrib/lite/build_rpi_lib.sh
+++ b/tensorflow/contrib/lite/build_rpi_lib.sh
@@ -19,4 +19,5 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/../../.."
 
-CC_PREFIX=arm-linux-gnueabihf- make -j 3 -f tensorflow/contrib/lite/Makefile TARGET=RPI TARGET_ARCH=armv7
+CC_PREFIX=arm-linux-gnueabihf- make -j 3 -f tensorflow/contrib/lite/Makefile TARGET=RPI TARGET_ARCH=armv7 \
+$SCRIPT_DIR/gen/lib/rpi_armv7/libtensorflow-lite.a


### PR DESCRIPTION
Now benchmark_model depends on //tensorflow/core library.