### PR TITLE
Fix incorrect data type registration of reduce_min/reduce_max in math_ops.cc

### DIFF
--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -764,7 +764,7 @@ REGISTER_OP("Min")
     .Input("reduction_indices: Tidx")
     .Output("output: T")
     .Attr("keep_dims: bool = false")
-    .Attr("T: numbertype")
+    .Attr("T: realnumbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .SetShapeFn(shape_inference::ReductionShape);
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -773,7 +773,7 @@ REGISTER_OP("Max")
     .Input("reduction_indices: Tidx")
     .Output("output: T")
     .Attr("keep_dims: bool = false")
-    .Attr("T: numbertype")
+    .Attr("T: realnumbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .SetShapeFn(shape_inference::ReductionShape);
 


### PR DESCRIPTION
The ops tf.reduce_min/reduce_max should only support real number types. However, `numbertype` was incorrect used in math_ops.cc. (The kernel parts in reduction_ops_min.cc and reduction_ops_max.cc use TF_CALL_REAL_NUMBER_TYPES correctly).

This fix fixes the issue by replacing numbertype to realnumbertype in math_ops.cc.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>