### PR TITLE
Docs: Fix 'Unable to find source java class'

### DIFF
--- a/tensorflow/docs_src/mobile/android_build.md
+++ b/tensorflow/docs_src/mobile/android_build.md
@@ -51,8 +51,8 @@ If you haven't already, do the following two things:
         // set to 'bazel', 'cmake', 'makefile', 'none'
         def nativeBuildSystem = 'none'
 
-4. Running "Build -> Rebuild Project" from Android Studio menu and click the 
-    Run button (the green arrow) or use **Run -> Run 'android'** from the top menu.
+4. Click the *Run* button (the green arrow) or select *Run > Run 'android'* from the
+    top menu. You may need to rebuild the project using *Build > Rebuild Project*.
 
     If it asks you to use Instant Run, click **Proceed Without Instant Run**.
 

--- a/tensorflow/docs_src/mobile/android_build.md
+++ b/tensorflow/docs_src/mobile/android_build.md
@@ -51,7 +51,8 @@ If you haven't already, do the following two things:
         // set to 'bazel', 'cmake', 'makefile', 'none'
         def nativeBuildSystem = 'none'
 
-4. Click the Run button (the green arrow) or use **Run -> Run 'android'** from the top menu.
+4. Running "Build -> Rebuild Project" from Android Studio menu and click the 
+    Run button (the green arrow) or use **Run -> Run 'android'** from the top menu.
 
     If it asks you to use Instant Run, click **Proceed Without Instant Run**.
 


### PR DESCRIPTION
Fix error:
>  Error:Execution failed for task ':compileDebugJavaWithJavac'.
>  because it does not belong to any of the source dirs