### PR TITLE
Allow access to keras.utils.model_to_dot API

### DIFF
--- a/tensorflow/python/keras/_impl/keras/utils/__init__.py
+++ b/tensorflow/python/keras/_impl/keras/utils/__init__.py
@@ -35,4 +35,5 @@ from tensorflow.python.keras._impl.keras.utils.multi_gpu_utils import multi_gpu_
 from tensorflow.python.keras._impl.keras.utils.np_utils import normalize
 from tensorflow.python.keras._impl.keras.utils.np_utils import to_categorical
 from tensorflow.python.keras._impl.keras.utils.vis_utils import plot_model
+from tensorflow.python.keras._impl.keras.utils.vis_utils import model_to_dot
 

--- a/tensorflow/python/keras/_impl/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/_impl/keras/utils/vis_utils.py
@@ -50,6 +50,7 @@ def _check_pydot():
                       ' and graphviz for `pydotprint` to work.')
 
 
+@tf_export('keras.utils.model_to_dot')
 def model_to_dot(model, show_shapes=False, show_layer_names=True, rankdir='TB'):
   """Convert a Keras model to dot format.
 

--- a/tensorflow/python/keras/utils/__init__.py
+++ b/tensorflow/python/keras/utils/__init__.py
@@ -34,6 +34,7 @@ from tensorflow.python.keras._impl.keras.utils.multi_gpu_utils import multi_gpu_
 from tensorflow.python.keras._impl.keras.utils.np_utils import normalize
 from tensorflow.python.keras._impl.keras.utils.np_utils import to_categorical
 from tensorflow.python.keras._impl.keras.utils.vis_utils import plot_model
+from tensorflow.python.keras._impl.keras.utils.vis_utils import model_to_dot
 
 del absolute_import
 del division


### PR DESCRIPTION

`model_to_dot` is not currently accessible from TensorFlow Keras. So visualizing the graph directly using commands  like` SVG(model_to_dot(model).create(prog='dot', format='svg'))` is not possible. 

Add `@tf_export('keras.utils.model_to_dot')` in  vis_utils.py

Add `from tensorflow.python.keras._impl.keras.utils.vis_utils import model_to_dot` in 
'tensorflow/python/keras/_impl/keras/utils/__init__.py'

Add `from tensorflow.python.keras._impl.keras.utils.vis_utils import model_to_dot` in 
'tensorflow/python/keras/utils//__init__.py'