### PR TITLE
Fix incorrect math equation renderings in random_fourier_features.py

### DIFF
--- a/tensorflow/contrib/kernel_methods/python/mappers/random_fourier_features.py
+++ b/tensorflow/contrib/kernel_methods/python/mappers/random_fourier_features.py
@@ -40,11 +40,11 @@ class RandomFourierFeatureMapper(dkm.DenseKernelMapper):
   "Random Features for Large-Scale Kernel Machines" by Ali Rahimi and Ben Recht.
   (link: https://people.eecs.berkeley.edu/~brecht/papers/07.rah.rec.nips.pdf)
 
-  The mapping uses a matrix `\\(Omega \in R^{d x D}\\)` and a bias vector
-  `\\(b \in R^D\\)` where `d` is the input dimension (number of dense input
-  features) and `D` is the output dimension (i.e., dimension of the feature
-  space the input is mapped to). Each entry of `Omega` is sampled i.i.d. from a
-  (scaled) Gaussian distribution and each entry of `b` is sampled independently
+  The mapping uses a matrix \\(\Omega \in R^{d x D}\\) and a bias vector
+  \\(b \in R^D\\) where \\(d\\) is the input dimension (number of dense input
+  features) and \\(D\\) is the output dimension (i.e., dimension of the feature
+  space the input is mapped to). Each entry of \\(\Omega\\) is sampled i.i.d. from a
+  (scaled) Gaussian distribution and each entry of \\(b\\) is sampled independently
   and uniformly from [0, \\(2 * pi\\)].
 
   For a single input feature vector x in R^d, its RFFM is defined as:

--- a/tensorflow/contrib/kernel_methods/python/mappers/random_fourier_features.py
+++ b/tensorflow/contrib/kernel_methods/python/mappers/random_fourier_features.py
@@ -43,21 +43,22 @@ class RandomFourierFeatureMapper(dkm.DenseKernelMapper):
   The mapping uses a matrix \\(\Omega \in R^{d x D}\\) and a bias vector
   \\(b \in R^D\\) where \\(d\\) is the input dimension (number of dense input
   features) and \\(D\\) is the output dimension (i.e., dimension of the feature
-  space the input is mapped to). Each entry of \\(\Omega\\) is sampled i.i.d. from a
-  (scaled) Gaussian distribution and each entry of \\(b\\) is sampled independently
-  and uniformly from [0, \\(2 * \pi\\)].
+  space the input is mapped to). Each entry of \\(\Omega\\) is sampled i.i.d.
+  from a (scaled) Gaussian distribution and each entry of \\(b\\) is sampled
+  independently and uniformly from [0, \\(2 * \pi\\)].
 
   For a single input feature vector \\(x \in R^d\\), its RFFM is defined as:
   $$\sqrt(2/D) * cos(x * \Omega + b)$$
 
-  where \\(cos\\) is the element-wise cosine function and \\(x, b\\) are represented as
-  row vectors. The aforementioned paper shows that the linear kernel of
-  RFFM-mapped vectors approximates the Gaussian kernel of the initial vectors.
+  where \\(cos\\) is the element-wise cosine function and \\(x, b\\) are
+  represented as row vectors. The aforementioned paper shows that the linear
+  kernel of RFFM-mapped vectors approximates the Gaussian kernel of the initial
+  vectors.
 
   """
 
   def __init__(self, input_dim, output_dim, stddev=1.0, seed=1, name=None):
-    """Constructs a RandomFourierFeatureMapper instance.
+    r"""Constructs a RandomFourierFeatureMapper instance.
 
     Args:
       input_dim: The dimension (number of features) of the tensors to be mapped.
@@ -65,11 +66,11 @@ class RandomFourierFeatureMapper(dkm.DenseKernelMapper):
       stddev: The standard deviation of the Gaussian kernel to be approximated.
         The error of the classifier trained using this approximation is very
         sensitive to this parameter.
-      seed: An integer used to initialize the parameters (\\(\Omega\\) and \\(b\\)) of
-        the mapper. For repeatable sequences across different invocations of the
-        mapper object (for instance, to ensure consistent mapping both at
-        training and eval/inference if these happen in different invocations),
-        set this to the same integer.
+      seed: An integer used to initialize the parameters (\\(\Omega\\) and
+        \\(b\\)) of the mapper. For repeatable sequences across different
+        invocations of the mapper object (for instance, to ensure consistent
+        mapping both at training and eval/inference if these happen in
+        different invocations), set this to the same integer.
       name: name for the mapper object.
     """
     # TODO(sibyl-vie3Poto): Maybe infer input_dim and/or output_dim (if not explicitly

--- a/tensorflow/contrib/kernel_methods/python/mappers/random_fourier_features.py
+++ b/tensorflow/contrib/kernel_methods/python/mappers/random_fourier_features.py
@@ -45,13 +45,12 @@ class RandomFourierFeatureMapper(dkm.DenseKernelMapper):
   features) and \\(D\\) is the output dimension (i.e., dimension of the feature
   space the input is mapped to). Each entry of \\(\Omega\\) is sampled i.i.d. from a
   (scaled) Gaussian distribution and each entry of \\(b\\) is sampled independently
-  and uniformly from [0, \\(2 * pi\\)].
+  and uniformly from [0, \\(2 * \pi\\)].
 
-  For a single input feature vector x in R^d, its RFFM is defined as:
-  ```
-      $$sqrt(2/D) * cos(x * Omega + b)$$
-  ```
-  where `cos` is the element-wise cosine function and `x, b` are represented as
+  For a single input feature vector \\(x \in R^d\\), its RFFM is defined as:
+  $$\sqrt(2/D) * cos(x * \Omega + b)$$
+
+  where \\(cos\\) is the element-wise cosine function and \\(x, b\\) are represented as
   row vectors. The aforementioned paper shows that the linear kernel of
   RFFM-mapped vectors approximates the Gaussian kernel of the initial vectors.
 
@@ -66,7 +65,7 @@ class RandomFourierFeatureMapper(dkm.DenseKernelMapper):
       stddev: The standard deviation of the Gaussian kernel to be approximated.
         The error of the classifier trained using this approximation is very
         sensitive to this parameter.
-      seed: An integer used to initialize the parameters (`Omega` and `b`) of
+      seed: An integer used to initialize the parameters (\\(\Omega\\) and \\(b\\)) of
         the mapper. For repeatable sequences across different invocations of the
         mapper object (for instance, to ensure consistent mapping both at
         training and eval/inference if these happen in different invocations),

--- a/tensorflow/contrib/kernel_methods/python/mappers/random_fourier_features.py
+++ b/tensorflow/contrib/kernel_methods/python/mappers/random_fourier_features.py
@@ -34,9 +34,7 @@ class RandomFourierFeatureMapper(dkm.DenseKernelMapper):
   r"""Class that implements Random Fourier Feature Mapping (RFFM) in TensorFlow.
 
   The RFFM mapping is used to approximate the Gaussian (RBF) kernel:
-  ```
   $$(exp(-||x-y||_2^2 / (2 * \sigma^2))$$
-  ```
 
   The implementation of RFFM is based on the following paper:
   "Random Features for Large-Scale Kernel Machines" by Ali Rahimi and Ben Recht.


### PR DESCRIPTION
This fix fixes incorrect math equation renderings for markdown in random_fourier_features.py. The issue is that "```" backtick should not be added when mathjax quote is used ("\\(" or "$$").

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>