### PR TITLE
Add scanr support for tensorflow

### DIFF
--- a/tensorflow/python/kernel_tests/functional_ops_test.py
+++ b/tensorflow/python/kernel_tests/functional_ops_test.py
@@ -392,6 +392,85 @@ class FunctionalOpsTest(test.TestCase):
         self.assertAllEqual(results, self.evaluate(r))
 
   @test_util.run_in_graph_and_eager_modes()
+  def testScanR_Simple(self):
+    with self.test_session():
+      elems = constant_op.constant([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], name="data")
+      v = constant_op.constant(2.0, name="v")
+
+      # pylint: disable=unnecessary-lambda
+      r = functional_ops.scanr(lambda a, x: math_ops.multiply(a, x), elems)
+      self.assertAllEqual([720., 720., 360., 120., 30., 6.], self.evaluate(r))
+
+      r = functional_ops.scanr(
+          lambda a, x: math_ops.multiply(a, x), elems, initializer=v)
+      self.assertAllEqual([1440., 1440., 720., 240., 60., 12.], self.evaluate(r))
+      # pylint: enable=unnecessary-lambda
+
+  @test_util.run_in_graph_and_eager_modes()
+  def testScanR_SingleInputMultiOutput(self):
+    with self.test_session():
+      elems = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+      initializer = (np.array(1.0), np.array(-1.0))
+      r = functional_ops.scanr(lambda a, x: (a[0] * x, -a[1] * x), elems,
+                              initializer)
+      r_value = self.evaluate(r)
+
+      self.assertAllEqual([720., 720., 360., 120., 30., 6.], r_value[0])
+      self.assertAllEqual([-720., 720., -360., 120., -30., 6.], r_value[1])
+
+  @test_util.run_in_graph_and_eager_modes()
+  def testScanR_MultiInputSingleOutput(self):
+    with self.test_session():
+      elems = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+      initializer = np.array(1.0)
+      # Multiply a * 1 each time
+      r = functional_ops.scanr(lambda a, x: a * (x[0] + x[1]),
+                              (elems + 1, -elems), initializer)
+      self.assertAllEqual([1.0, 1.0, 1.0, 1.0, 1.0, 1.0], self.evaluate(r))
+
+  @test_util.run_in_graph_and_eager_modes()
+  def testScanR_MultiInputSameTypeOutput(self):
+    with self.test_session():
+      elems = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+      r = functional_ops.scanr(lambda a, x: (a[0] + x[0], a[1] + x[1]),
+                              (elems, -elems))
+      r_value = self.evaluate(r)
+      # Use [::-1] to flip the elems
+      self.assertAllEqual(np.cumsum(elems[::-1])[::-1], r_value[0])
+      self.assertAllEqual(np.cumsum(-elems[::-1])[::-1], r_value[1])
+
+  @test_util.run_in_graph_and_eager_modes()
+  def testScanR_MultiOutputMismatchedInitializer(self):
+    with self.test_session():
+      elems = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+      initializer = np.array(1.0)
+      # Multiply a * 1 each time
+      with self.assertRaisesRegexp(
+          ValueError, "two structures don't have the same nested structure"):
+        functional_ops.scanr(lambda a, x: (a, -a), elems, initializer)
+
+  def testScanR_Scoped(self):
+    with self.test_session() as sess:
+      with variable_scope.variable_scope("root") as varscope:
+        elems = constant_op.constant([1, 2, 3, 4, 5, 6], name="data")
+
+        r = functional_ops.scanr(simple_scoped_fn, elems)
+        # Check that we have the one variable we asked for here.
+        self.assertEqual(len(variables.trainable_variables()), 1)
+        self.assertEqual(variables.trainable_variables()[0].name,
+                         "root/body/two:0")
+        sess.run([variables.global_variables_initializer()])
+        results = np.array([450, 224, 110, 52, 22, 6])
+        self.assertAllEqual(results, self.evaluate(r))
+
+        # Now let's reuse our single variable.
+        varscope.reuse_variables()
+        r = functional_ops.scanr(simple_scoped_fn, elems, initializer=2)
+        self.assertEqual(len(variables.trainable_variables()), 1)
+        results = np.array([770, 384, 190, 92, 42, 16])
+        self.assertAllEqual(results, self.evaluate(r))
+
+  @test_util.run_in_graph_and_eager_modes()
   def testScanFoldl_Nested(self):
     with self.test_session():
       elems = constant_op.constant([1.0, 2.0, 3.0, 4.0], name="data")

--- a/tensorflow/python/kernel_tests/functional_ops_test.py
+++ b/tensorflow/python/kernel_tests/functional_ops_test.py
@@ -403,7 +403,8 @@ class FunctionalOpsTest(test.TestCase):
 
       r = functional_ops.scanr(
           lambda a, x: math_ops.multiply(a, x), elems, initializer=v)
-      self.assertAllEqual([1440., 1440., 720., 240., 60., 12.], self.evaluate(r))
+      self.assertAllEqual([1440., 1440., 720., 240., 60., 12.],
+                          self.evaluate(r))
       # pylint: enable=unnecessary-lambda
 
   @test_util.run_in_graph_and_eager_modes()
@@ -412,7 +413,7 @@ class FunctionalOpsTest(test.TestCase):
       elems = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
       initializer = (np.array(1.0), np.array(-1.0))
       r = functional_ops.scanr(lambda a, x: (a[0] * x, -a[1] * x), elems,
-                              initializer)
+                               initializer)
       r_value = self.evaluate(r)
 
       self.assertAllEqual([720., 720., 360., 120., 30., 6.], r_value[0])
@@ -425,7 +426,7 @@ class FunctionalOpsTest(test.TestCase):
       initializer = np.array(1.0)
       # Multiply a * 1 each time
       r = functional_ops.scanr(lambda a, x: a * (x[0] + x[1]),
-                              (elems + 1, -elems), initializer)
+                               (elems + 1, -elems), initializer)
       self.assertAllEqual([1.0, 1.0, 1.0, 1.0, 1.0, 1.0], self.evaluate(r))
 
   @test_util.run_in_graph_and_eager_modes()
@@ -433,7 +434,7 @@ class FunctionalOpsTest(test.TestCase):
     with self.test_session():
       elems = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
       r = functional_ops.scanr(lambda a, x: (a[0] + x[0], a[1] + x[1]),
-                              (elems, -elems))
+                               (elems, -elems))
       r_value = self.evaluate(r)
       # Use [::-1] to flip the elems
       self.assertAllEqual(np.cumsum(elems[::-1])[::-1], r_value[0])

--- a/tensorflow/python/ops/functional_ops.py
+++ b/tensorflow/python/ops/functional_ops.py
@@ -383,7 +383,7 @@ def map_fn(fn, elems, dtype=None, parallel_iterations=10, back_prop=True,
   in_graph_mode = not context.executing_eagerly()
   with ops.name_scope(name, "map", elems_flat):
     # TODO(akshayka): Remove the in_graph_mode check once caching devices are
-    # supported in Eager.
+    # supported in Eager
     if in_graph_mode:
       # Any get_variable calls in fn will cache the first call locally
       # and not issue repeated network I/O requests for each iteration.
@@ -412,13 +412,13 @@ def map_fn(fn, elems, dtype=None, parallel_iterations=10, back_prop=True,
         )
     n = static_shape[0].value or array_ops.shape(elems_flat[0])[0]
 
-    # TensorArrays are always flat.
+    # TensorArrays are always flat
     elems_ta = [
         tensor_array_ops.TensorArray(dtype=elem.dtype, size=n,
                                      dynamic_size=False,
                                      infer_shape=True)
         for elem in elems_flat]
-    # Unpack elements.
+    # Unpack elements
     elems_ta = [
         elem_ta.unstack(elem) for elem_ta, elem in zip(elems_ta, elems_flat)]
 
@@ -466,7 +466,7 @@ def map_fn(fn, elems, dtype=None, parallel_iterations=10, back_prop=True,
           r.get_shape()[1:]))
 
     # TODO(akshayka): Remove the in_graph_mode check once caching devices are
-    # supported in Eager.
+    # supported in Eager
     if in_graph_mode and varscope_caching_device_was_none:
       varscope.set_caching_device(None)
 
@@ -749,7 +749,7 @@ def scanr(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
     ```python
     elems = np.array([1, 2, 3, 4, 5, 6])
     sum = tf.scanr(lambda a, x: a + x, elems)
-    # sum == [720, 720, 360, 120, 30, 6]
+    # sum == [21, 20, 18, 15, 11, 6]
     ```
 
     ```python
@@ -777,7 +777,7 @@ def scanr(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
   in_graph_mode = not context.executing_eagerly()
   with ops.name_scope(name, "scanr", elems_flat):
     # TODO(akshayka): Remove the in_graph_mode check once caching devices are
-    # supported in Eager
+    # supported in Eager.
     if in_graph_mode:
       # Any get_variable calls in fn will cache the first call locally
       # and not issue repeated network I/O requests for each iteration.
@@ -796,13 +796,13 @@ def scanr(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
     # Convert elems to tensor array. n may be known statically.
     n = elems_flat[0].shape[0].value or array_ops.shape(elems_flat[0])[0]
 
-    # TensorArrays are always flat
+    # TensorArrays are always flat.
     elems_ta = [
         tensor_array_ops.TensorArray(dtype=elem.dtype, size=n,
                                      dynamic_size=False,
                                      infer_shape=True)
         for elem in elems_flat]
-    # Unpack elements
+    # Unpack elements.
     elems_ta = [
         elem_ta.unstack(elem) for elem_ta, elem in zip(elems_ta, elems_flat)]
 
@@ -836,11 +836,11 @@ def scanr(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
 
       Returns:
         [i - 1, a_flat, tas]: the updated counter + new accumulator values +
-          updated TensorArrays
+          updated TensorArrays.
 
       Raises:
-        TypeError: if initializer and fn() output structure do not match
-        ValueType: if initializer and fn() output lengths do not match
+        TypeError: if initializer and fn() output structure do not match.
+        ValueType: if initializer and fn() output lengths do not match.
       """
       i -= 1
       packed_elems = input_pack([elem_ta.read(i) for elem_ta in elems_ta])
@@ -868,7 +868,7 @@ def scanr(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
           r.get_shape()[1:]))
 
     # TODO(akshayka): Remove the in_graph_mode check once caching devices are
-    # supported in Eager
+    # supported in Eager.
     if in_graph_mode and varscope_caching_device_was_none:
       varscope.set_caching_device(None)
 

--- a/tensorflow/python/ops/functional_ops.py
+++ b/tensorflow/python/ops/functional_ops.py
@@ -383,7 +383,7 @@ def map_fn(fn, elems, dtype=None, parallel_iterations=10, back_prop=True,
   in_graph_mode = not context.executing_eagerly()
   with ops.name_scope(name, "map", elems_flat):
     # TODO(akshayka): Remove the in_graph_mode check once caching devices are
-    # supported in Eager
+    # supported in Eager.
     if in_graph_mode:
       # Any get_variable calls in fn will cache the first call locally
       # and not issue repeated network I/O requests for each iteration.
@@ -412,13 +412,13 @@ def map_fn(fn, elems, dtype=None, parallel_iterations=10, back_prop=True,
         )
     n = static_shape[0].value or array_ops.shape(elems_flat[0])[0]
 
-    # TensorArrays are always flat
+    # TensorArrays are always flat.
     elems_ta = [
         tensor_array_ops.TensorArray(dtype=elem.dtype, size=n,
                                      dynamic_size=False,
                                      infer_shape=True)
         for elem in elems_flat]
-    # Unpack elements
+    # Unpack elements.
     elems_ta = [
         elem_ta.unstack(elem) for elem_ta, elem in zip(elems_ta, elems_flat)]
 
@@ -466,7 +466,7 @@ def map_fn(fn, elems, dtype=None, parallel_iterations=10, back_prop=True,
           r.get_shape()[1:]))
 
     # TODO(akshayka): Remove the in_graph_mode check once caching devices are
-    # supported in Eager
+    # supported in Eager.
     if in_graph_mode and varscope_caching_device_was_none:
       varscope.set_caching_device(None)
 
@@ -748,14 +748,14 @@ def scanr(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
   Examples:
     ```python
     elems = np.array([1, 2, 3, 4, 5, 6])
-    sum = scanr(lambda a, x: a + x, elems)
+    sum = tf.scanr(lambda a, x: a + x, elems)
     # sum == [720, 720, 360, 120, 30, 6]
     ```
 
     ```python
     elems = np.array([1, 2, 3, 4, 5, 6])
     initializer = np.array(0)
-    sum_one = scan(
+    sum_one = tf.scanr(
         lambda a, x: x[0] - x[1] + a, (elems + 1, elems), initializer)
     # sum_one == [6, 5, 4, 3, 2, 1]
     ```

--- a/tensorflow/python/ops/functional_ops.py
+++ b/tensorflow/python/ops/functional_ops.py
@@ -681,6 +681,130 @@ def scan(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
     return output_pack(results_flat)
 
 
+def scanr(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
+          swap_memory=False, infer_shape=True, name=None):
+  if not callable(fn):
+    raise TypeError("fn must be callable.")
+
+  input_is_sequence = nest.is_sequence(elems)
+  input_flatten = lambda x: nest.flatten(x) if input_is_sequence else [x]
+  def input_pack(x):
+    return nest.pack_sequence_as(elems, x) if input_is_sequence else x[0]
+
+  if initializer is None:
+    output_is_sequence = input_is_sequence
+    output_flatten = input_flatten
+    output_pack = input_pack
+  else:
+    output_is_sequence = nest.is_sequence(initializer)
+    output_flatten = lambda x: nest.flatten(x) if output_is_sequence else [x]
+    def output_pack(x):
+      return (nest.pack_sequence_as(initializer, x)
+              if output_is_sequence else x[0])
+
+  elems_flat = input_flatten(elems)
+
+  in_graph_mode = not context.executing_eagerly()
+  with ops.name_scope(name, "scan", elems_flat):
+    # TODO(akshayka): Remove the in_graph_mode check once caching devices are
+    # supported in Eager
+    if in_graph_mode:
+      # Any get_variable calls in fn will cache the first call locally
+      # and not issue repeated network I/O requests for each iteration.
+      varscope = vs.get_variable_scope()
+      varscope_caching_device_was_none = False
+      if varscope.caching_device is None:
+        # TODO(ebrevdo): Change to using colocate_with here and in other
+        # methods.
+        varscope.set_caching_device(lambda op: op.device)
+        varscope_caching_device_was_none = True
+
+    # Convert elems to tensor array.
+    elems_flat = [
+        ops.convert_to_tensor(elem, name="elem") for elem in elems_flat]
+
+    # Convert elems to tensor array. n may be known statically.
+    n = elems_flat[0].shape[0].value or array_ops.shape(elems_flat[0])[0]
+
+    # TensorArrays are always flat
+    elems_ta = [
+        tensor_array_ops.TensorArray(dtype=elem.dtype, size=n,
+                                     dynamic_size=False,
+                                     infer_shape=True)
+        for elem in elems_flat]
+    # Unpack elements
+    elems_ta = [
+        elem_ta.unstack(elem) for elem_ta, elem in zip(elems_ta, elems_flat)]
+
+    if initializer is None:
+      i = n - 1
+      a_flat = [elem.read(i) for elem in elems_ta]
+    else:
+      i = n
+      initializer_flat = output_flatten(initializer)
+      a_flat = [ops.convert_to_tensor(init) for init in initializer_flat]
+
+    # Create a tensor array to store the intermediate values.
+    accs_ta = [
+        tensor_array_ops.TensorArray(
+            dtype=init.dtype, size=n,
+            element_shape=init.shape if infer_shape else None,
+            dynamic_size=False,
+            infer_shape=infer_shape)
+        for init in a_flat]
+
+    if initializer is None:
+      accs_ta = [acc_ta.write(i, a) for (acc_ta, a) in zip(accs_ta, a_flat)]
+
+    def compute(i, a_flat, tas):
+      """The loop body of scan.
+
+      Args:
+        i: the loop counter.
+        a_flat: the accumulator value(s), flattened.
+        tas: the output accumulator TensorArray(s), flattened.
+
+      Returns:
+        [i - 1, a_flat, tas]: the updated counter + new accumulator values +
+          updated TensorArrays
+
+      Raises:
+        TypeError: if initializer and fn() output structure do not match
+        ValueType: if initializer and fn() output lengths do not match
+      """
+      i -= 1
+      packed_elems = input_pack([elem_ta.read(i) for elem_ta in elems_ta])
+      packed_a = output_pack(a_flat)
+      a_out = fn(packed_a, packed_elems)
+      nest.assert_same_structure(
+          elems if initializer is None else initializer, a_out)
+      flat_a_out = output_flatten(a_out)
+      tas = [ta.write(i, value) for (ta, value) in zip(tas, flat_a_out)]
+      return (i, flat_a_out, tas)
+
+    _, _, r_a = control_flow_ops.while_loop(
+        lambda i, _1, _2: i > 0, compute, (i, a_flat, accs_ta),
+        parallel_iterations=parallel_iterations,
+        back_prop=back_prop, swap_memory=swap_memory,
+        maximum_iterations=n)
+
+    results_flat = [r.stack() for r in r_a]
+
+    n_static = elems_flat[0].get_shape().with_rank_at_least(1)[0]
+    for elem in elems_flat[1:]:
+      n_static.merge_with(elem.get_shape().with_rank_at_least(1)[0])
+    for r in results_flat:
+      r.set_shape(tensor_shape.TensorShape(n_static).concatenate(
+          r.get_shape()[1:]))
+
+    # TODO(akshayka): Remove the in_graph_mode check once caching devices are
+    # supported in Eager
+    if in_graph_mode and varscope_caching_device_was_none:
+      varscope.set_caching_device(None)
+
+    return output_pack(results_flat)
+
+
 # pylint: disable=invalid-name
 def If(cond, inputs, then_branch, else_branch, name=None):
   r"""output = Cond(inputs) ? then_branch(inputs) : else_branch(inputs).

--- a/tensorflow/python/ops/functional_ops.py
+++ b/tensorflow/python/ops/functional_ops.py
@@ -683,6 +683,83 @@ def scan(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
 
 def scanr(fn, elems, initializer=None, parallel_iterations=10, back_prop=True,
           swap_memory=False, infer_shape=True, name=None):
+  """scanr on the list of tensors unpacked from `elems` on dimension 0.
+
+  The simplest version of `scanr` repeatedly applies the callable `fn` to a
+  sequence of elements from last to first. The elements are made of the tensors
+  unpacked from `elems` on dimension 0. The callable fn takes two tensors as
+  arguments. The first argument is the accumulated value computed from the
+  preceding invocation of fn. If `initializer` is None, `elems` must contain
+  at least one element, and its last element is used as the initializer.
+
+  Suppose that `elems` is unpacked into `values`, a list of tensors. The shape
+  of the result tensor is `[len(values)] + fn(initializer, values[0]).shape`.
+
+  This method also allows multi-arity `elems` and accumulator.  If `elems`
+  is a (possibly nested) list or tuple of tensors, then each of these tensors
+  must have a matching first (unpack) dimension.  The second argument of
+  `fn` must match the structure of `elems`.
+
+  If no `initializer` is provided, the output structure and dtypes of `fn`
+  are assumed to be the same as its input; and in this case, the first
+  argument of `fn` must match the structure of `elems`.
+
+  If an `initializer` is provided, then the output of `fn` must have the same
+  structure as `initializer`; and the first argument of `fn` must match
+  this structure.
+
+  For example, if `elems` is `(t1, [t2, t3])` and `initializer` is
+  `[i1, i2]` then an appropriate signature for `fn` in `python2` is:
+  `fn = lambda (acc_p1, acc_p2), (t1, [t2, t3]):` and `fn` must return a list,
+  `[acc_n1, acc_n2]`.  An alternative correct signature for `fn`, and the
+   one that works in `python3`, is:
+  `fn = lambda a, t:`, where `a` and `t` correspond to the input tuples.
+
+  Args:
+    fn: The callable to be performed.  It accepts two arguments.  The first
+      will have the same structure as `initializer` if one is provided,
+      otherwise it will have the same structure as `elems`.  The second
+      will have the same (possibly nested) structure as `elems`.  Its output
+      must have the same structure as `initializer` if one is provided,
+      otherwise it must have the same structure as `elems`.
+    elems: A tensor or (possibly nested) sequence of tensors, each of which
+      will be unpacked along their first dimension.  The nested sequence
+      of the resulting slices will be the first argument to `fn`.
+    initializer: (optional) A tensor or (possibly nested) sequence of tensors,
+      initial value for the accumulator, and the expected output type of `fn`.
+    parallel_iterations: (optional) The number of iterations allowed to run
+      in parallel.
+    back_prop: (optional) True enables support for back propagation.
+    swap_memory: (optional) True enables GPU-CPU memory swapping.
+    infer_shape: (optional) False disables tests for consistent output shapes.
+    name: (optional) Name prefix for the returned tensors.
+
+  Returns:
+    A tensor or (possibly nested) sequence of tensors.  Each tensor packs the
+    results of applying `fn` to tensors unpacked from `elems` along the first
+    dimension, and the previous accumulator value(s), from first to last.
+
+  Raises:
+    TypeError: if `fn` is not callable or the structure of the output of
+      `fn` and `initializer` do not match.
+    ValueError: if the lengths of the output of `fn` and `initializer`
+      do not match.
+
+  Examples:
+    ```python
+    elems = np.array([1, 2, 3, 4, 5, 6])
+    sum = scanr(lambda a, x: a + x, elems)
+    # sum == [720, 720, 360, 120, 30, 6]
+    ```
+
+    ```python
+    elems = np.array([1, 2, 3, 4, 5, 6])
+    initializer = np.array(0)
+    sum_one = scan(
+        lambda a, x: x[0] - x[1] + a, (elems + 1, elems), initializer)
+    # sum_one == [6, 5, 4, 3, 2, 1]
+    ```
+  """
   if not callable(fn):
     raise TypeError("fn must be callable.")
 


### PR DESCRIPTION
This fix tries to address the issue raised in #17387 where unlike `tf.foldl` vs `tf.foldr`, there is no `scanr` support which is the opposite of `tf.scan` (`scanl`).

This fix adds the `scanr` support and add additional test cases.

This fix fixes #17387.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>