### PR TITLE
Updating highwayhash library to fix kernel_tests:lookup_ops_test, lookup:lookup_ops_test and string_to_hash_bucket_op_test tests on ppc

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -188,11 +188,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "highwayhash",
       urls = [
-          "https://mirror.bazel.build/github.com/google/highwayhash/archive/dfcb97ca4fe9277bf9dc1802dd979b071896453b.tar.gz",
-          "https://github.com/google/highwayhash/archive/dfcb97ca4fe9277bf9dc1802dd979b071896453b.tar.gz",
+          "http://mirror.bazel.build/github.com/google/highwayhash/archive/e2098bc92a8540e133b11207ed1f1abfca57724c.tar.gz",
+          "https://github.com/google/highwayhash/archive/e2098bc92a8540e133b11207ed1f1abfca57724c.tar.gz",
       ],
-      sha256 = "0f30a15b1566d93f146c8d149878a06e91d9bb7ec2cfd76906df62a82be4aac9",
-      strip_prefix = "highwayhash-dfcb97ca4fe9277bf9dc1802dd979b071896453b",
+      sha256 = "67e5cdbe8a31ee80d21082a861641cb84fc8fddc10388e47ff358db048a21b67",
+      strip_prefix = "highwayhash-e2098bc92a8540e133b11207ed1f1abfca57724c",
       build_file = clean_dep("//third_party:highwayhash.BUILD"),
   )
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -188,11 +188,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "highwayhash",
       urls = [
-          "http://mirror.bazel.build/github.com/google/highwayhash/archive/e2098bc92a8540e133b11207ed1f1abfca57724c.tar.gz",
-          "https://github.com/google/highwayhash/archive/e2098bc92a8540e133b11207ed1f1abfca57724c.tar.gz",
+          "http://mirror.bazel.build/github.com/google/highwayhash/archive/fd3d9af80465e4383162e4a7c5e2f406e82dd968.tar.gz",
+          "https://github.com/google/highwayhash/archive/fd3d9af80465e4383162e4a7c5e2f406e82dd968.tar.gz",
       ],
-      sha256 = "67e5cdbe8a31ee80d21082a861641cb84fc8fddc10388e47ff358db048a21b67",
-      strip_prefix = "highwayhash-e2098bc92a8540e133b11207ed1f1abfca57724c",
+      sha256 = "9c3e0e87d581feeb0c18d814d98f170ff23e62967a2bd6855847f0b2fe598a37",
+      strip_prefix = "highwayhash-fd3d9af80465e4383162e4a7c5e2f406e82dd968",
       build_file = clean_dep("//third_party:highwayhash.BUILD"),
   )
 

--- a/third_party/highwayhash.BUILD
+++ b/third_party/highwayhash.BUILD
@@ -10,6 +10,7 @@ cc_library(
     srcs = ["highwayhash/sip_hash.cc"],
     hdrs = [
         "highwayhash/sip_hash.h",
+        "highwayhash/endianess.h",
         "highwayhash/state_helpers.h",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
All three of these tests were failing on ppc64le ,because the build was using a version of the highwayhash library which did not properly support the power architecture. Updating the library to include commit e2098b (google/highwayhash@e2098bc) seems to fix the issue.

Thanks !