### PR TITLE
Add string_strip to remove leading and trailing whitespaces

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_StringStrip.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_StringStrip.pbtxt
@@ -1,0 +1,16 @@
+op {
+  graph_op_name: "StringStrip"
+  in_arg {
+    name: "input"
+    description: <<END
+A string `Tensor` of any shape.
+END
+  }
+  out_arg {
+    name: "output"
+    description: <<END
+A string `Tensor` of the same shape as the input.
+END
+  }
+  summary: "Strip leading and trailing whitespaces from the Tensor."
+}

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4225,6 +4225,7 @@ cc_library(
         ":regex_replace_op",
         ":string_join_op",
         ":string_split_op",
+        ":string_strip_op",
         ":string_to_hash_bucket_op",
         ":substr_op",
     ],
@@ -4266,6 +4267,12 @@ tf_kernel_library(
 tf_kernel_library(
     name = "string_split_op",
     prefix = "string_split_op",
+    deps = STRING_DEPS,
+)
+
+tf_kernel_library(
+    name = "string_strip_op",
+    prefix = "string_strip_op",
     deps = STRING_DEPS,
 )
 

--- a/tensorflow/core/kernels/string_strip_op.cc
+++ b/tensorflow/core/kernels/string_strip_op.cc
@@ -28,13 +28,14 @@ namespace tensorflow {
 
 class StringStripOp : public OpKernel {
  public:
-  explicit StringStripOp(OpKernelConstruction* context) : OpKernel(context) { }
+  explicit StringStripOp(OpKernelConstruction* context) : OpKernel(context) {}
 
   void Compute(OpKernelContext* ctx) override {
     const Tensor* input_tensor;
     OP_REQUIRES_OK(ctx, ctx->input("input", &input_tensor));
     Tensor* output_tensor;
-    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, input_tensor->shape(), &output_tensor));
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_output(0, input_tensor->shape(), &output_tensor));
 
     const auto input = input_tensor->flat<string>();
     auto output = output_tensor->flat<string>();

--- a/tensorflow/core/kernels/string_strip_op.cc
+++ b/tensorflow/core/kernels/string_strip_op.cc
@@ -1,0 +1,52 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/string_ops.cc.
+
+#include <string>
+
+#include "tensorflow/core/framework/kernel_def_builder.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/strings/str_util.h"
+
+namespace tensorflow {
+
+class StringStripOp : public OpKernel {
+ public:
+  explicit StringStripOp(OpKernelConstruction* context) : OpKernel(context) { }
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(ctx, ctx->input("input", &input_tensor));
+    Tensor* output_tensor;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, input_tensor->shape(), &output_tensor));
+
+    const auto input = input_tensor->flat<string>();
+    auto output = output_tensor->flat<string>();
+
+    for (int64 i = 0; i < input.size(); ++i) {
+      StringPiece entry(input(i));
+      str_util::RemoveWhitespaceContext(&entry);
+      output(i) = entry.ToString();
+    }
+  }
+};
+
+REGISTER_KERNEL_BUILDER(Name("StringStrip").Device(DEVICE_CPU), StringStripOp);
+
+}  // namespace tensorflow

--- a/tensorflow/core/ops/string_ops.cc
+++ b/tensorflow/core/ops/string_ops.cc
@@ -123,6 +123,17 @@ REGISTER_OP("StringSplit")
       return Status::OK();
     });
 
+REGISTER_OP("StringStrip")
+    .Input("input: string")
+    .Output("output: string")
+    .SetShapeFn(shape_inference::UnchangedShape)
+    .Doc(R"doc(
+Strip leading and trailing whitespaces from the Tensor.
+
+input: A string `Tensor` of any shape.
+output: A string `Tensor` of the same shape as the input.
+)doc");
+
 REGISTER_OP("EncodeBase64")
     .Input("input: string")
     .Output("output: string")

--- a/tensorflow/core/ops/string_ops.cc
+++ b/tensorflow/core/ops/string_ops.cc
@@ -126,13 +126,7 @@ REGISTER_OP("StringSplit")
 REGISTER_OP("StringStrip")
     .Input("input: string")
     .Output("output: string")
-    .SetShapeFn(shape_inference::UnchangedShape)
-    .Doc(R"doc(
-Strip leading and trailing whitespaces from the Tensor.
-
-input: A string `Tensor` of any shape.
-output: A string `Tensor` of the same shape as the input.
-)doc");
+    .SetShapeFn(shape_inference::UnchangedShape);
 
 REGISTER_OP("EncodeBase64")
     .Input("input: string")

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -918,6 +918,20 @@ tf_py_test(
 )
 
 tf_py_test(
+    name = "string_strip_op_test",
+    size = "small",
+    srcs = ["string_strip_op_test.py"],
+    additional_deps = [
+        "//third_party/py/numpy",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:errors",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:string_ops",
+    ],
+)
+
+tf_py_test(
     name = "substr_op_test",
     size = "small",
     srcs = ["substr_op_test.py"],

--- a/tensorflow/python/kernel_tests/string_strip_op_test.py
+++ b/tensorflow/python/kernel_tests/string_strip_op_test.py
@@ -1,0 +1,60 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for string_strip_op."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors_impl
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import string_ops
+from tensorflow.python.platform import test
+
+
+class StringStripOpTest(test.TestCase):
+
+  def testStringStrip(self):
+    strings = ["pigs on the wing", "animals"]
+
+    with self.test_session() as sess:
+      output = string_ops.string_strip(strings)
+      output = sess.run(output)
+      self.assertAllEqual(output, ["pigs on the wing", "animals"])
+
+  def testStringStrip2D(self):
+    strings = [["pigs on the wing", "animals"],
+               [" hello ", "\n\tworld \r \n"]]
+
+    with self.test_session() as sess:
+      output = string_ops.string_strip(strings)
+      output = sess.run(output)
+      self.assertAllEqual(output, [["pigs on the wing", "animals"],
+                                   ["hello", "world"]])
+
+  def testStringStripWithEmptyStrings(self):
+    strings = [" hello ", "", "world ", " \t \r \n "]
+
+    with self.test_session() as sess:
+      output = string_ops.string_strip(strings)
+      output = sess.run(output)
+      self.assertAllEqual(output, ["hello", "", "world", ""])
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/kernel_tests/string_strip_op_test.py
+++ b/tensorflow/python/kernel_tests/string_strip_op_test.py
@@ -18,18 +18,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
-
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import errors_impl
-from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import string_ops
 from tensorflow.python.platform import test
 
 
 class StringStripOpTest(test.TestCase):
+  """ Test cases for tf.string_strip."""
 
-  def testStringStrip(self):
+  def test_string_strip(self):
     strings = ["pigs on the wing", "animals"]
 
     with self.test_session() as sess:
@@ -37,7 +33,7 @@ class StringStripOpTest(test.TestCase):
       output = sess.run(output)
       self.assertAllEqual(output, ["pigs on the wing", "animals"])
 
-  def testStringStrip2D(self):
+  def test_string_strip_2d(self):
     strings = [["pigs on the wing", "animals"],
                [" hello ", "\n\tworld \r \n"]]
 
@@ -47,7 +43,7 @@ class StringStripOpTest(test.TestCase):
       self.assertAllEqual(output, [["pigs on the wing", "animals"],
                                    ["hello", "world"]])
 
-  def testStringStripWithEmptyStrings(self):
+  def test_string_strip_with_empty_strings(self):
     strings = [" hello ", "", "world ", " \t \r \n "]
 
     with self.test_session() as sess:

--- a/tensorflow/python/kernel_tests/string_strip_op_test.py
+++ b/tensorflow/python/kernel_tests/string_strip_op_test.py
@@ -31,7 +31,7 @@ class StringStripOpTest(test.TestCase):
     with self.test_session() as sess:
       output = string_ops.string_strip(strings)
       output = sess.run(output)
-      self.assertAllEqual(output, ["pigs on the wing", "animals"])
+      self.assertAllEqual(output, [b"pigs on the wing", b"animals"])
 
   def test_string_strip_2d(self):
     strings = [["pigs on the wing", "animals"],
@@ -40,8 +40,8 @@ class StringStripOpTest(test.TestCase):
     with self.test_session() as sess:
       output = string_ops.string_strip(strings)
       output = sess.run(output)
-      self.assertAllEqual(output, [["pigs on the wing", "animals"],
-                                   ["hello", "world"]])
+      self.assertAllEqual(output, [[b"pigs on the wing", b"animals"],
+                                   [b"hello", b"world"]])
 
   def test_string_strip_with_empty_strings(self):
     strings = [" hello ", "", "world ", " \t \r \n "]
@@ -49,7 +49,7 @@ class StringStripOpTest(test.TestCase):
     with self.test_session() as sess:
       output = string_ops.string_strip(strings)
       output = sess.run(output)
-      self.assertAllEqual(output, ["hello", "", "world", ""])
+      self.assertAllEqual(output, [b"hello", b"", b"world", b""])
 
 
 if __name__ == "__main__":

--- a/tensorflow/tools/api/golden/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.pbtxt
@@ -1977,6 +1977,10 @@ tf_module {
     argspec: "args=[\'source\', \'delimiter\', \'skip_empty\'], varargs=None, keywords=None, defaults=[\' \', \'True\'], "
   }
   member_method {
+    name: "string_strip"
+    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "string_to_hash_bucket"
     argspec: "args=[\'string_tensor\', \'num_buckets\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }


### PR DESCRIPTION
This fix tries to address the issue raised in #18384 to add an op tf.string_strip so that the leading and trailing whitespaces could be removed.

This fix fixes #18384.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>