### PR TITLE
Update docs of reduce_max/reduce_min for real numeric type

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1632,7 +1632,7 @@ def reduce_min(input_tensor,
   tensor with a single element is returned.
 
   Args:
-    input_tensor: The tensor to reduce. Should have numeric type.
+    input_tensor: The tensor to reduce. Should have real numeric type.
     axis: The dimensions to reduce. If `None` (the default),
       reduces all dimensions. Must be in the range
       `[-rank(input_tensor), rank(input_tensor))`.
@@ -1681,7 +1681,7 @@ def reduce_max(input_tensor,
   tensor with a single element is returned.
 
   Args:
-    input_tensor: The tensor to reduce. Should have numeric type.
+    input_tensor: The tensor to reduce. Should have real numeric type.
     axis: The dimensions to reduce. If `None` (the default),
       reduces all dimensions. Must be in the range
       `[-rank(input_tensor), rank(input_tensor))`.


### PR DESCRIPTION
Both reduce_max and reduce_min only work for real numeric types as complex numbers do not apply. This fix update the docs with `numeric type` -> `real numeric type`.

Note that the current kernel registration in `reduction_ops_max.cc` and `reduction_ops_min.cc`
use `TF_CALL_REAL_NUMBER_TYPES` so no change needed. The op registraton for Max and Min inside math_ops.cc should be `.Attr("T: realnumbertype")` instead of `numbertype`. However, such a change will break API compatibility so leave it alone.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>