### PR TITLE
Relaxing float comparison and removing unneeded include

### DIFF
--- a/tensorflow/contrib/layers/python/layers/rev_block_lib_test.py
+++ b/tensorflow/contrib/layers/python/layers/rev_block_lib_test.py
@@ -60,8 +60,8 @@ class RevBlockTest(test.TestCase):
       sess.run(variables.global_variables_initializer())
       x1, x2, x1_inv, x2_inv = sess.run([x1, x2, x1_inv, x2_inv])
 
-      self.assertAllClose(x1, x1_inv)
-      self.assertAllClose(x2, x2_inv)
+      self.assertAllClose(x1, x1_inv, atol=1e-5)
+      self.assertAllClose(x2, x2_inv, atol=1e-5)
 
   def testBackwardForward(self):
 

--- a/tensorflow/stream_executor/cuda/cudnn_version_test.cc
+++ b/tensorflow/stream_executor/cuda/cudnn_version_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/stream_executor/cuda/cudnn_version.h"
 
-#include "testing/base/public/gunit.h"
 #include "tensorflow/core/platform/test.h"
 
 namespace perftools {


### PR DESCRIPTION
Fixing two build failures:
1. contrib/layers/python/layers/rev_block_lib_test.py failure in testForwardBackward:
AssertionError: 
Not equal to tolerance rtol=1e-06, atol=1e-06
Mismatched value: a is different from b.
(mismatch 1.5625%)
 x: array([[0.386929, 0.360026, 0.97688 , 0.086516],
       [0.424401, 0.507681, 0.344677, 0.482503],
       [0.260149, 0.651255, 0.529058, 0.537508],...
 y: array([[0.386929, 0.360026, 0.976879, 0.086516],
       [0.424401, 0.507682, 0.344677, 0.482503],
       [0.26015 , 0.651255, 0.529058, 0.537508],...

2. Removing unneeded include.