### PR TITLE
Replace tuple<int,int,int> for version info with a class in DnnSupportr::GetVersion()

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/cudnn_convolution_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_convolution_algorithm_picker.cc
@@ -99,9 +99,9 @@ bool ShouldIncludeWinogradNonfusedAlgo(const Shape& input_shape,
                                        const ConvolutionDimensionNumbers& dnums,
                                        se::StreamExecutor* stream_exec) {
   // Skip this check for cudnn7 and newer.
-  se::port::StatusOr<std::tuple<int, int, int>> version =
+  auto version =
       stream_exec->AsDnn()->GetVersion();
-  if (version.ok() && std::get<0>(version.ValueOrDie()) >= 7) {
+  if (version.ok() && version.ValueOrDie().maj() >= 7) {
     return true;
   }
 

--- a/tensorflow/compiler/xla/service/gpu/cudnn_convolution_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_convolution_algorithm_picker.cc
@@ -101,7 +101,7 @@ bool ShouldIncludeWinogradNonfusedAlgo(const Shape& input_shape,
   // Skip this check for cudnn7 and newer.
   auto version =
       stream_exec->AsDnn()->GetVersion();
-  if (version.ok() && version.ValueOrDie().maj() >= 7) {
+  if (version.ok() && version.ValueOrDie().major_version() >= 7) {
     return true;
   }
 

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 
+#include "third_party/eigen3/Eigen/Core"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/env_var.h"
 #include "tensorflow/stream_executor/cuda/cuda_activation.h"
@@ -40,7 +41,6 @@ limitations under the License.
 #include "tensorflow/stream_executor/scratch_allocator.h"
 #include "tensorflow/stream_executor/stream.h"
 #include "tensorflow/stream_executor/stream_executor_pimpl.h"
-#include "third_party/eigen3/Eigen/Core"
 // clang-format off
 #include "cuda/include/cudnn.h"
 // clang-format on
@@ -63,10 +63,10 @@ namespace perftools {
 namespace gputools {
 
 using dnn::BatchDescriptor;
-using dnn::ConvolutionDescriptor;
 using dnn::FilterDescriptor;
-using dnn::NormalizeDescriptor;
+using dnn::ConvolutionDescriptor;
 using dnn::PoolingDescriptor;
+using dnn::NormalizeDescriptor;
 
 namespace cuda {
 
@@ -215,9 +215,9 @@ CUDNN_DNN_ROUTINE_EACH(PERFTOOLS_GPUTOOLS_CUDNN_WRAP)
 #if CUDNN_VERSION >= 3000
 #define CUDNN_DNN_ROUTINE_EACH_AFTER_R3(__macro)              \
   __macro(cudnnGetConvolutionBackwardFilterWorkspaceSize)     \
-      __macro(cudnnGetConvolutionBackwardDataAlgorithm)       \
-          __macro(cudnnGetConvolutionBackwardFilterAlgorithm) \
-              __macro(cudnnGetConvolutionBackwardDataWorkspaceSize)
+  __macro(cudnnGetConvolutionBackwardDataAlgorithm)           \
+  __macro(cudnnGetConvolutionBackwardFilterAlgorithm)         \
+  __macro(cudnnGetConvolutionBackwardDataWorkspaceSize)
 CUDNN_DNN_ROUTINE_EACH_AFTER_R3(PERFTOOLS_GPUTOOLS_CUDNN_WRAP)
 #undef CUDNN_DNN_ROUTINE_EACH_AFTER_R3
 #endif
@@ -1220,7 +1220,8 @@ class CudnnRnnDescriptor : public CudnnDescriptorCommon<dnn::RnnDescriptor> {
       cudnnStatus_t status =
           wrap::cudnnSetRNNMatrixMathType(parent_, rnn_desc_, math_type);
       if (status != CUDNN_STATUS_SUCCESS) {
-        LOG(FATAL) << "could not set cudnn RNN math type: " << ToString(status);
+        LOG(FATAL) << "could not set cudnn RNN math type: "
+                   << ToString(status);
       }
     }
 #endif
@@ -2542,32 +2543,33 @@ bool CudnnSupport::DoConvolveImpl(
   //   GetCudnnConvolutionForwardAlgorithm().
   if (algorithm_config.algorithm().is_default()) {
     // With the default algorithm, use Cudnn's heuristics.
-    auto get_algorithm = [&](bool specify_limit) SHARED_LOCKS_REQUIRED(
-                             dnn_handle_mutex_) {
-      cudnnConvolutionFwdPreference_t preference =
-          specify_limit ? CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT
-                        : CUDNN_CONVOLUTION_FWD_NO_WORKSPACE;
+    auto get_algorithm =
+        [&](bool specify_limit) SHARED_LOCKS_REQUIRED(dnn_handle_mutex_) {
+          cudnnConvolutionFwdPreference_t preference =
+              specify_limit ? CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT
+                            : CUDNN_CONVOLUTION_FWD_NO_WORKSPACE;
 
-      auto memory_limit_bytes =
-          scratch_allocator == nullptr
-              ? 0
-              : scratch_allocator->GetMemoryLimitInBytes(stream);
-      if (memory_limit_bytes < 0) {
-        memory_limit_bytes = 0;
-      }
+          auto memory_limit_bytes =
+              scratch_allocator == nullptr
+                  ? 0
+                  : scratch_allocator->GetMemoryLimitInBytes(stream);
+          if (memory_limit_bytes < 0) {
+            memory_limit_bytes = 0;
+          }
 
-      cudnnConvolutionFwdAlgo_t algo_to_use;
-      status = wrap::cudnnGetConvolutionForwardAlgorithm(
-          parent_, ToHandle(dnn_handle_), input_nd.handle(), filter.handle(),
-          conv.handle(), output_nd.handle(),
-          /*preference=*/preference,
-          /*memoryLimitInBytes=*/memory_limit_bytes,
-          /*algo=*/&algo_to_use);
-      CHECK_EQ(status, CUDNN_STATUS_SUCCESS) << "Unable to find a suitable "
-                                                "algorithm for doing forward "
-                                                "convolution";
-      return algo_to_use;
-    };
+          cudnnConvolutionFwdAlgo_t algo_to_use;
+          status = wrap::cudnnGetConvolutionForwardAlgorithm(
+              parent_, ToHandle(dnn_handle_), input_nd.handle(),
+              filter.handle(), conv.handle(), output_nd.handle(),
+              /*preference=*/preference,
+              /*memoryLimitInBytes=*/memory_limit_bytes,
+              /*algo=*/&algo_to_use);
+          CHECK_EQ(status, CUDNN_STATUS_SUCCESS)
+              << "Unable to find a suitable "
+                 "algorithm for doing forward "
+                 "convolution";
+          return algo_to_use;
+        };
 
     algo = get_algorithm(/*specify_limit=*/scratch_allocator != nullptr);
     use_tensor_ops = true;
@@ -3300,9 +3302,10 @@ bool CudnnSupport::DoFusedConvolve(
 #endif
 }
 
-template <class T>
+template<class T>
 DeviceMemory<T> CudnnSupport::MaybeTransformLayout(
-    Stream* stream, BatchDescriptor* output_descriptor,
+    Stream* stream,
+    BatchDescriptor* output_descriptor,
     DeviceMemory<T> backward_output_data,
     std::unique_ptr<TemporaryDeviceMemory<T>>* transform_scratch) {
   if (output_descriptor->layout() == dnn::DataLayout::kBatchDepthYX) {
@@ -3371,7 +3374,8 @@ bool CudnnSupport::DoTransformTensor(Stream* stream,
 
 template <class T>
 bool CudnnSupport::DoConvolveBackwardDataImpl(
-    Stream* stream, const FilterDescriptor& filter_descriptor,
+    Stream* stream,
+    const FilterDescriptor& filter_descriptor,
     const DeviceMemory<T>& filter_data,
     const BatchDescriptor& output_descriptor_in,
     DeviceMemory<T> backward_output_data,
@@ -3419,9 +3423,8 @@ bool CudnnSupport::DoConvolveBackwardDataImpl(
 
   if (algorithm_config.algorithm().is_default()) {
     // With the default algorithm, use Cudnn's heuristics.
-    auto get_algorithm =
-        [&](bool specify_limit) SHARED_LOCKS_REQUIRED(
-            dnn_handle_mutex_) -> cudnnConvolutionBwdDataAlgo_t {
+    auto get_algorithm = [&](bool specify_limit) SHARED_LOCKS_REQUIRED(
+        dnn_handle_mutex_) -> cudnnConvolutionBwdDataAlgo_t {
       cudnnConvolutionBwdDataPreference_t preference =
           specify_limit ? CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT
                         : CUDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE;
@@ -3696,7 +3699,7 @@ bool CudnnSupport::DoConvolveBackwardFilterImpl(
     // specify_limit will occur when we have a scratch allocator and it succeeds
     // in allocating; otherwise, we'll fall back to the "no workspace" version.
     auto get_algorithm = [&](bool specify_limit) SHARED_LOCKS_REQUIRED(
-                             dnn_handle_mutex_) {
+        dnn_handle_mutex_) {
       cudnnConvolutionBwdFilterPreference_t preference =
           specify_limit ? CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT
                         : CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE;
@@ -4689,8 +4692,8 @@ void initialize_cudnn() {
       gpu::PluginRegistry::Instance()
           ->RegisterFactory<gpu::PluginRegistry::DnnFactory>(
               gpu::cuda::kCudaPlatformId, gpu::cuda::kCuDnnPlugin, "cuDNN",
-              [](gpu::internal::StreamExecutorInterface* parent)
-                  -> gpu::dnn::DnnSupport* {
+              [](gpu::internal::StreamExecutorInterface*
+                     parent) -> gpu::dnn::DnnSupport* {
                 gpu::cuda::CUDAExecutor* cuda_executor =
                     dynamic_cast<gpu::cuda::CUDAExecutor*>(parent);
                 if (cuda_executor == nullptr) {

--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -46,7 +46,7 @@ class CudnnSupport : public dnn::DnnSupport {
   ~CudnnSupport() override;
 
   port::Status Init() override;
-  port::StatusOr<std::tuple<int, int, int>> GetVersion() override;
+  port::StatusOr<perftools::gputools::dnn::VersionInfo> GetVersion() override;
 
   port::StatusOr<std::unique_ptr<dnn::RnnDescriptor>> createRnnDescriptor(
       int num_layers, int hidden_size, int input_size,

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -876,9 +876,9 @@ enum class ElementwiseOperation { kAdd, kMultiply };
 
 string ElementwiseOperationString(ElementwiseOperation op);
 
-// A simple class to workaround the too perfect forwarding issue at
-// gcc6+ compilers. See PR#16309 and issue #18402 for links discussing
-// the issue
+// A simple class representing the version of the backing library, to 
+// workaround the "too perfect forwarding" issue in gcc6+ compilers. 
+// See PR#16309 and issue #18402 for links discussing the issue.
 class VersionInfo {
  public:
   VersionInfo(int major = 0, int minor = 0, int patch = 0)

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -876,15 +876,15 @@ enum class ElementwiseOperation { kAdd, kMultiply };
 
 string ElementwiseOperationString(ElementwiseOperation op);
 
-// Suite of operations typically used for implementing Deep/Convolutional Neural
-// Nets. Note: A false return value of an operation indicates the
-// implementation is not available.
+// A simple class to workaround the too perfect forwarding issue at
+// gcc6+ compilers. See PR#16309 and issue #18402 for links discussing
+// the issue
 class VersionInfo {
  public:
   VersionInfo(int major = 0, int minor = 0, int patch = 0)
       : major_(major), minor_(minor), patch_(patch) {}
-  int maj() { return major_; }
-  int min() { return minor_; }
+  int major_version() { return major_; }
+  int minor_version() { return minor_; }
   int patch() { return patch_; }
  private:
   int major_;
@@ -892,6 +892,9 @@ class VersionInfo {
   int patch_;
 };
 
+// Suite of operations typically used for implementing Deep/Convolutional Neural
+// Nets. Note: A false return value of an operation indicates the
+// implementation is not available.
 class DnnSupport {
  public:
   DnnSupport() {}
@@ -899,7 +902,7 @@ class DnnSupport {
 
   virtual port::Status Init() = 0;
 
-  // Gets the version of the backing library, as a {major, minor, patch} tuple.
+  // Gets the version of the backing library, as a VersionInfo object.
   virtual port::StatusOr<VersionInfo> GetVersion() {
     return port::UnimplementedError(
         "DnnSupport::GetVersion not implemented on this platform.");
@@ -1878,10 +1881,10 @@ class DnnSupport {
   //  bottom_pad: Amount to pad the input at the bottom (high Y).
   //  output_data: un-owned device memory region in which to place the
   //    padded result.
-  virtual bool DoXYPad(Stream* stream, const dnn::BatchDescriptor& dimensions,
-                       const DeviceMemory<float>& input_data, int64 left_pad,
-                       int64 right_pad, int64 top_pad, int64 bottom_pad,
-                       DeviceMemory<float>* output_data) = 0;
+  virtual bool DoXYPad(Stream* stream, const dnn::BatchDescriptor &dimensions,
+                       const DeviceMemory<float> &input_data,
+                       int64 left_pad, int64 right_pad, int64 top_pad,
+                       int64 bottom_pad, DeviceMemory<float> *output_data) = 0;
 
   // Extracts a slice of the input in the X and Y dimensions. The feature_map
   // dimension is unchanged.
@@ -1898,10 +1901,10 @@ class DnnSupport {
   //  bottom_trim: Amount to cut off the input at the bottom (high Y).
   //  output_data: un-owned device memory region in which to place the
   //    padded result.
-  virtual bool DoXYSlice(Stream* stream, const dnn::BatchDescriptor& dimensions,
-                         const DeviceMemory<float>& input_data, int64 left_trim,
-                         int64 right_trim, int64 top_trim, int64 bottom_trim,
-                         DeviceMemory<float>* output_data) = 0;
+  virtual bool DoXYSlice(Stream* stream, const dnn::BatchDescriptor &dimensions,
+                    const DeviceMemory<float> &input_data,
+                    int64 left_trim, int64 right_trim, int64 top_trim,
+                    int64 bottom_trim, DeviceMemory<float> *output_data) = 0;
 
   // Grows the input tensor by replicating the X and Y dimensions. The batch and
   // depth/feature_map dimensions are unchanged. Currently, the input tensor is

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -879,6 +879,19 @@ string ElementwiseOperationString(ElementwiseOperation op);
 // Suite of operations typically used for implementing Deep/Convolutional Neural
 // Nets. Note: A false return value of an operation indicates the
 // implementation is not available.
+class VersionInfo {
+ public:
+  VersionInfo(int major = 0, int minor = 0, int patch = 0)
+      : major_(major), minor_(minor), patch_(patch) {}
+  int maj() { return major_; }
+  int min() { return minor_; }
+  int patch() { return patch_; }
+ private:
+  int major_;
+  int minor_;
+  int patch_;
+};
+
 class DnnSupport {
  public:
   DnnSupport() {}
@@ -887,7 +900,7 @@ class DnnSupport {
   virtual port::Status Init() = 0;
 
   // Gets the version of the backing library, as a {major, minor, patch} tuple.
-  virtual port::StatusOr<std::tuple<int, int, int>> GetVersion() {
+  virtual port::StatusOr<VersionInfo> GetVersion() {
     return port::UnimplementedError(
         "DnnSupport::GetVersion not implemented on this platform.");
   }
@@ -1865,10 +1878,10 @@ class DnnSupport {
   //  bottom_pad: Amount to pad the input at the bottom (high Y).
   //  output_data: un-owned device memory region in which to place the
   //    padded result.
-  virtual bool DoXYPad(Stream* stream, const dnn::BatchDescriptor &dimensions,
-                       const DeviceMemory<float> &input_data,
-                       int64 left_pad, int64 right_pad, int64 top_pad,
-                       int64 bottom_pad, DeviceMemory<float> *output_data) = 0;
+  virtual bool DoXYPad(Stream* stream, const dnn::BatchDescriptor& dimensions,
+                       const DeviceMemory<float>& input_data, int64 left_pad,
+                       int64 right_pad, int64 top_pad, int64 bottom_pad,
+                       DeviceMemory<float>* output_data) = 0;
 
   // Extracts a slice of the input in the X and Y dimensions. The feature_map
   // dimension is unchanged.
@@ -1885,10 +1898,10 @@ class DnnSupport {
   //  bottom_trim: Amount to cut off the input at the bottom (high Y).
   //  output_data: un-owned device memory region in which to place the
   //    padded result.
-  virtual bool DoXYSlice(Stream* stream, const dnn::BatchDescriptor &dimensions,
-                    const DeviceMemory<float> &input_data,
-                    int64 left_trim, int64 right_trim, int64 top_trim,
-                    int64 bottom_trim, DeviceMemory<float> *output_data) = 0;
+  virtual bool DoXYSlice(Stream* stream, const dnn::BatchDescriptor& dimensions,
+                         const DeviceMemory<float>& input_data, int64 left_trim,
+                         int64 right_trim, int64 top_trim, int64 bottom_trim,
+                         DeviceMemory<float>* output_data) = 0;
 
   // Grows the input tensor by replicating the X and Y dimensions. The batch and
   // depth/feature_map dimensions are unchanged. Currently, the input tensor is


### PR DESCRIPTION
tuple<int,int,int> is falling into too perfect forwarding issue with gcc-6. This PR replaces tuple with a class until a more permanent solution can be found.