### PR TITLE
Fix OdeIntTest

### DIFF
--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -974,6 +974,8 @@ class TensorFlowTestCase(googletest.TestCase):
       config.graph_options.optimizer_options.opt_level = -1
       config.graph_options.rewrite_options.constant_folding = (
           rewriter_config_pb2.RewriterConfig.OFF)
+      config.graph_options.rewrite_options.arithmetic_optimization = (
+          rewriter_config_pb2.RewriterConfig.OFF)
       return config
 
     if graph is None:


### PR DESCRIPTION
Fix OdeIntTest in GPU pip build. This effectively reverts https://github.com/tensorflow/tensorflow/commit/23d6c55ba22596f903696e0dba8037ad81470a39#diff-f541c00fcae53468339272b7c92a67a4.

The test is currently failing with:
tensorflow/core/common_runtime/executor.cc:660] Executor failed to create kernel. Not found: No registered 'Square' OpKernel for GPU devices compatible with node ArithmeticOptimizer/odeint_4/interpolate_loop/interpolate/interp_evaluate/mul_square = Square[T=DT_COMPLEX64, _device="/job:localhost/replica:0/task:0/device:GPU:0"](odeint_4/interpolate_loop/interpolate/interp_evaluate/Cast)
	 (OpKernel was found, but attributes didn't match)
	.  Registered:  device='CPU'; T in [DT_BFLOAT16]
  device='CPU'; T in [DT_COMPLEX128]
  device='CPU'; T in [DT_COMPLEX64]
  device='CPU'; T in [DT_INT64]
  device='CPU'; T in [DT_INT32]
  device='CPU'; T in [DT_DOUBLE]
  device='CPU'; T in [DT_HALF]
  device='CPU'; T in [DT_FLOAT]
  device='GPU'; T in [DT_INT32]
  device='GPU'; T in [DT_INT64]
  device='GPU'; T in [DT_DOUBLE]
  device='GPU'; T in [DT_HALF]
  device='GPU'; T in [DT_FLOAT]