### PR TITLE
Try to fix windows libtensorflow

### DIFF
--- a/tensorflow/c/c_api_experimental.cc
+++ b/tensorflow/c/c_api_experimental.cc
@@ -8306,15 +8306,9 @@ TF_Operation* TF_MakeFileBasedIteratorGetNextWithDatasets(
     unsigned char is_mnist, TF_Status* status) {
 #if defined(PLATFORM_WINDOWS)
   // TODO(ashankar): get these functions working on Windows.
-  if (is_mnist) {
-    status->status = tensorflow::errors::Unimplemented(
-        "TF_MakeFileBasedIteratorGetNextWithDatasets in the experimental C API "
-        "is not implemented for Windows");
-  } else {
-    status->status = tensorflow::errors::Unimplemented(
-        "TF_MakeFileBasedIteratorGetNextWithDatasets in the experimental C API "
-        "is not implemented for Windows");
-  }
+  status->status = tensorflow::errors::Unimplemented(
+      "TF_MakeFileBasedIteratorGetNextWithDatasets in the experimental C API "
+      "is not implemented for Windows");
   return nullptr
 #else
   tensorflow::Status s;

--- a/tensorflow/c/c_api_experimental.cc
+++ b/tensorflow/c/c_api_experimental.cc
@@ -190,12 +190,6 @@ library {
 //  be deleted by calling TF_DeleteFunction.
 static std::vector<UniqueFuncPtr> CreateImagenetDatasetFunctions(
     const char* file_path, std::string* dataset_name, TF_Status* status) {
-#if defined(PLATFORM_WINDOWS)
-  status->status = tensorflow::errors::Unimplemented(
-      "TF_MakeFileBasedIteratorGetNextWithDatasets in the experimental C API "
-      "is not implemented for Windows");
-  return std::vector<UniqueFuncPtr>();
-#else
   const char* func_def = R"PREFIX(
 library {
   function {
@@ -7074,7 +7068,6 @@ library {
         DCHECK(found);
       };
   return CreateFunctionsFromTextProto(func_def, &mutate_proto_func, status);
-#endif
 }
 
 //  On success, returns a set of TF_Function instances encoding a dataset
@@ -7084,13 +7077,6 @@ library {
 static std::vector<UniqueFuncPtr> CreateMNISTDatasetFunctions(
     const char* file_path, int batch_size, std::string* dataset_name,
     TF_Status* status) {
-#if defined(PLATFORM_WINDOWS)
-  // TODO(ashankar): cover CreateMNISTDatasetFunctions in Windows tests.
-  status->status = tensorflow::errors::Unimplemented(
-      "TF_MakeFileBasedIteratorGetNextWithDatasets in the experimental C API "
-      "is not implemented for Windows");
-  return std::vector<UniqueFuncPtr>();
-#else
   const char* func_def = R"PREFIX(
 library {
   function {
@@ -8220,7 +8206,6 @@ library {
         DCHECK(found_batch_size);
       };
   return CreateFunctionsFromTextProto(func_def, &mutate_proto_func, status);
-#endif
 }
 
 // Adds the input functions to `graph`.  On success, returns the created
@@ -8315,6 +8300,19 @@ TF_Operation* TF_MakeFakeIteratorGetNextWithDatasets(TF_Graph* graph,
 TF_Operation* TF_MakeFileBasedIteratorGetNextWithDatasets(
     TF_Graph* graph, const char* file_path, int batch_size,
     unsigned char is_mnist, TF_Status* status) {
+#if defined(PLATFORM_WINDOWS)
+  // TODO(ashankar): get these functions working on Windows.
+  if (is_mnist) {
+    status->status = tensorflow::errors::Unimplemented(
+        "TF_MakeFileBasedIteratorGetNextWithDatasets in the experimental C API "
+        "is not implemented for Windows");
+  } else {
+    status->status = tensorflow::errors::Unimplemented(
+        "TF_MakeFileBasedIteratorGetNextWithDatasets in the experimental C API "
+        "is not implemented for Windows");
+  }
+  return nullptr
+#else
   tensorflow::Status s;
 
   std::string dataset_name;
@@ -8356,4 +8354,5 @@ TF_Operation* TF_MakeFileBasedIteratorGetNextWithDatasets(
           << graph->graph.ToGraphDefDebug().DebugString();
 
   return getnext_node;
+#endif
 }

--- a/tensorflow/c/c_api_experimental.cc
+++ b/tensorflow/c/c_api_experimental.cc
@@ -184,6 +184,7 @@ library {
   return std::move(functions[0]);
 }
 
+#if not defined(PLATFORM_WINDOWS)
 //  On success, returns a set of TF_Function instances encoding a dataset
 //  node stack that reads a Imagenet TFRecordFile dataset from `file_path`, and
 //  sets `dataset_name` to the created dataset name. The returned functions must
@@ -7069,6 +7070,7 @@ library {
       };
   return CreateFunctionsFromTextProto(func_def, &mutate_proto_func, status);
 }
+#endif
 
 #if not defined(PLATFORM_WINDOWS)
 //  On success, returns a set of TF_Function instances encoding a dataset
@@ -8210,7 +8212,6 @@ library {
 }
 #endif
 
-#if not defined(PLATFORM_WINDOWS)
 // Adds the input functions to `graph`.  On success, returns the created
 // IteratorGetNext node.
 static TF_Operation* AddDatasetFunctionAndIteratorNodesToGraph(
@@ -8275,7 +8276,6 @@ static TF_Operation* AddDatasetFunctionAndIteratorNodesToGraph(
   VLOG(1) << "Output graph: " << graph->graph.ToGraphDefDebug().DebugString();
   return ToTF_Operation(getnext_node);
 }
-#endif
 
 TF_Operation* TF_MakeFakeIteratorGetNextWithDatasets(TF_Graph* graph,
                                                      TF_Status* status) {

--- a/tensorflow/c/c_api_experimental.cc
+++ b/tensorflow/c/c_api_experimental.cc
@@ -7070,6 +7070,7 @@ library {
   return CreateFunctionsFromTextProto(func_def, &mutate_proto_func, status);
 }
 
+#if not defined(PLATFORM_WINDOWS)
 //  On success, returns a set of TF_Function instances encoding a dataset
 //  node stack that reads an MNIST file dataset from `file_path`, and
 //  sets `dataset_name` to the created dataset name. The returned functions must
@@ -8207,7 +8208,9 @@ library {
       };
   return CreateFunctionsFromTextProto(func_def, &mutate_proto_func, status);
 }
+#endif
 
+#if not defined(PLATFORM_WINDOWS)
 // Adds the input functions to `graph`.  On success, returns the created
 // IteratorGetNext node.
 static TF_Operation* AddDatasetFunctionAndIteratorNodesToGraph(
@@ -8272,6 +8275,7 @@ static TF_Operation* AddDatasetFunctionAndIteratorNodesToGraph(
   VLOG(1) << "Output graph: " << graph->graph.ToGraphDefDebug().DebugString();
   return ToTF_Operation(getnext_node);
 }
+#endif
 
 TF_Operation* TF_MakeFakeIteratorGetNextWithDatasets(TF_Graph* graph,
                                                      TF_Status* status) {


### PR DESCRIPTION
One more attempt to fix Windows libtensorflow build. Current error:
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\xmemory0(737): error C2280: 'std::unique_ptr<TF_Function,void (__cdecl *)(TF_Function *)>::unique_ptr(const std::unique_ptr<TF_Function,void (__cdecl *)(TF_Function *)> &)': attempting to reference a deleted function

Previous commits trying to fix this build:
https://github.com/tensorflow/tensorflow/pull/18432#pullrequestreview-111414452
https://github.com/tensorflow/tensorflow/pull/18442#pullrequestreview-111466504

