### PR TITLE
Fix compilation of split with SYCL enabled

### DIFF
--- a/tensorflow/core/kernels/split_lib.h
+++ b/tensorflow/core/kernels/split_lib.h
@@ -50,7 +50,7 @@ struct Split<Eigen::ThreadPoolDevice, T, NDims> {
 
 #ifdef TENSORFLOW_USE_SYCL
 template <typename T, int NDims>
-struct Split<Eigen::SyclDevice, T> {
+struct Split<Eigen::SyclDevice, T, NDims> {
   void operator()(const Eigen::SyclDevice& d,
                   typename TTypes<T, NDims>::Tensor output,
                   typename TTypes<T, NDims>::ConstTensor input,


### PR DESCRIPTION
ERROR: /home/tomeu/opencl-prefix/source/tensorflow/tensorflow/core/kernels/BUILD:436:1: C++ compilation of rule '//tensorflow/core/kernels:split_lib' failed (Exit 1)
In file included from tensorflow/core/kernels/split_lib_cpu.cc:18:0:
./tensorflow/core/kernels/split_lib.h:53:34: error: wrong number of template arguments (2, should be 3)
 struct Split<Eigen::SyclDevice, T> {
                                  ^
./tensorflow/core/kernels/split_lib.h:35:8: note: provided for ‘template<class Device, class T, int NDims> struct tensorflow::functor::Split’
 struct Split {
        ^~~~~

Signed-off-by: Tomeu Vizoso <tomeu.vizoso@collabora.com>
Fixes: 93f5dd54dab1 ("Optimized non-aligned case of split and split_v on the first input dimension.")