### PR TITLE
Replace raw_input/input with six.moves.input for python 2/3

### DIFF
--- a/tensorflow/python/debug/cli/readline_ui.py
+++ b/tensorflow/python/debug/cli/readline_ui.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 
 import readline
 
+import six
+
 from tensorflow.python.debug.cli import base_ui
 from tensorflow.python.debug.cli import debugger_cli_common
 
@@ -39,11 +41,7 @@ class ReadlineUI(base_ui.BaseUI):
     readline.set_completer(self._readline_complete)
     readline.parse_and_bind("tab: complete")
 
-    # For Python 2-3 compatibility.
-    try:
-      self._input = raw_input
-    except NameError:
-      self._input = input
+    self._input = six.moves.input
 
   def _readline_complete(self, text, state):
     context, prefix, except_last_word = self._analyze_tab_complete_input(text)


### PR DESCRIPTION
This fix is an enhancement to replace raw_input/input in python 2 and 3 with six.moves.input, which works in both python 2 and python 3.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>