### PR TITLE
Fix shape validation error with tf.nn.conv3d_transpose

### DIFF
--- a/tensorflow/python/kernel_tests/conv3d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/conv3d_transpose_test.py
@@ -119,6 +119,17 @@ class Conv3DTransposeTest(test.TestCase):
                   target = 3.0
                 self.assertAllClose(target, value[n, d, h, w, k])
 
+  def testConv3DTransposeShapeMismatch(self):
+    # Test case for GitHub issue 18460
+    x_shape = [2, 2, 3, 4, 3]
+    f_shape = [3, 3, 3, 2, 2]
+    y_shape = [2, 2, 6, 8, 6]
+    strides = [1, 1, 2, 2, 2]
+    np.random.seed(1)  # Make it reproducible.
+    x_value = np.random.random_sample(x_shape).astype(np.float64)
+    f_value = np.random.random_sample(f_shape).astype(np.float64)
+    output = nn_ops.conv3d_transpose(x_value, f_value, y_shape, strides, data_format='NCDHW')
+
   def testConv3DTransposeValid(self):
     with self.test_session():
       strides = [1, 2, 2, 2, 1]

--- a/tensorflow/python/kernel_tests/conv3d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/conv3d_transpose_test.py
@@ -125,10 +125,11 @@ class Conv3DTransposeTest(test.TestCase):
     f_shape = [3, 3, 3, 2, 2]
     y_shape = [2, 2, 6, 8, 6]
     strides = [1, 1, 2, 2, 2]
-    np.random.seed(1)  # Make it reproducible.
+    np.random.seed(1)
     x_value = np.random.random_sample(x_shape).astype(np.float64)
     f_value = np.random.random_sample(f_shape).astype(np.float64)
-    output = nn_ops.conv3d_transpose(x_value, f_value, y_shape, strides, data_format='NCDHW')
+    nn_ops.conv3d_transpose(
+        x_value, f_value, y_shape, strides, data_format='NCDHW')
 
   def testConv3DTransposeValid(self):
     with self.test_session():

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1461,7 +1461,7 @@ def conv3d_transpose(
       if not filter.get_shape()[3].is_compatible_with(output_shape[axis]):
         raise ValueError(
             "output_shape does not match filter's output channels, "
-            "{} != {}".format(output_shape[4],
+            "{} != {}".format(output_shape[axis],
                               filter.get_shape()[3]))
 
     if padding != "VALID" and padding != "SAME":

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1458,7 +1458,7 @@ def conv3d_transpose(
 
     if isinstance(output_shape, (list, np.ndarray)):
       # output_shape's shape should be == [5] if reached this point.
-      if not filter.get_shape()[3].is_compatible_with(output_shape[4]):
+      if not filter.get_shape()[3].is_compatible_with(output_shape[axis]):
         raise ValueError(
             "output_shape does not match filter's output channels, "
             "{} != {}".format(output_shape[4],


### PR DESCRIPTION
This fix tries to address the issue raised in #18460. In `tf.nn.conv3d_transpose` when list or np array is passed, the validate of the output shape with filter shape uses `output_shape[4]` (channel). This will not work with `data_format='NCDHW'`.

This fix fixes the issue by replace `output_shape[4]` with `output_shape[axis]`.

This fix also adds a test case. Before this fix, the test case will fail.

This fix fixes #18460.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>