### PR TITLE
Fix crash when invalid dtype was passed

### DIFF
--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -696,11 +696,13 @@ def as_dtype(type_value):
     if type_value.type == np.string_ or type_value.type == np.unicode_:
       return string
 
-  for key, val in _NP_TO_TF:
-    try:
-      if key == type_value:
-        return val
-    except TypeError as e:
-      raise TypeError("Cannot convert {} to a dtype. {}".format(type_value, e))
+  if isinstance(type_value, (type, np.dtype)):
+    for key, val in _NP_TO_TF:
+      try:
+        if key == type_value:
+          return val
+      except TypeError as e:
+        raise TypeError("Cannot convert {} to a dtype. {}".format(
+            type_value, e))
 
   raise TypeError("Cannot convert value %r to a TensorFlow DType." % type_value)

--- a/tensorflow/python/kernel_tests/constant_op_test.py
+++ b/tensorflow/python/kernel_tests/constant_op_test.py
@@ -65,6 +65,11 @@ class ConstantTest(test.TestCase):
     self._testCpu(x)
     self._testGpu(x)
 
+  def testInvalidDType(self):
+    # Test case for GitHub issue 18474
+    with self.assertRaises(TypeError):
+      constant_op.constant(dtypes_lib.string, "[,]")
+
   def testBFloat16(self):
     bfloat16 = dtypes_lib.bfloat16.as_numpy_dtype
     self._testAll(np.arange(-15, 15).reshape([2, 3, 5]).astype(bfloat16))


### PR DESCRIPTION
This fix tries to address the issue raised in #18474 where crash may happen if invalid dtype (e.g., `"[,]"`) is passed to `tf.constant(tf.string, "[,]")`. The crash happens during the comparision of `"[,]"` and numpy dtype candidate (e.g., `np.dtype([("qint8", np.int8, 1)])`:
```
>>> import numpy as np
>>> np.dtype([("qint8", np.int8, 1)]) == "[,]"
Segmentation fault: 11
```

This fix adds a type check to make sure the type of the passed dtype is either numpy.dtype or type.

This fix fixes #18474.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>