### PR TITLE
Fix warnings in `nn.sampled_softmax_loss`

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1341,6 +1341,7 @@ def sampled_softmax_loss(weights,
       name=name,
       seed=seed)
   labels = array_ops.stop_gradient(labels, name="labels_stop_gradient")
-  sampled_losses = nn_ops.softmax_cross_entropy_with_logits_v2(labels=labels, logits=logits)
+  sampled_losses = nn_ops.softmax_cross_entropy_with_logits_v2(
+      labels=labels, logits=logits)
   # sampled_losses is a [batch_size] tensor.
   return sampled_losses

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1340,7 +1340,7 @@ def sampled_softmax_loss(weights,
       partition_strategy=partition_strategy,
       name=name,
       seed=seed)
-  sampled_losses = nn_ops.softmax_cross_entropy_with_logits(
-      labels=labels, logits=logits)
+  labels = array_ops.stop_gradient(labels, name="labels_stop_gradient")
+  sampled_losses = nn_ops.softmax_cross_entropy_with_logits_v2(labels=labels, logits=logits)
   # sampled_losses is a [batch_size] tensor.
   return sampled_losses


### PR DESCRIPTION
The `softmax_cross_entropy_with_logits` has been deprecated and replaced with `softmax_cross_entropy_with_logits_v2`.

This causes `nn.sampled_softmax_loss` to always generate a WANRING whenever called. This fix replaces `softmax_cross_entropy_with_logits` with `softmax_cross_entropy_with_logits_v2` and maintains the existing behavior to fix the warning.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>