### PR TITLE
Update gemmlowp version for cmake build

### DIFF
--- a/tensorflow/contrib/cmake/external/gemmlowp.cmake
+++ b/tensorflow/contrib/cmake/external/gemmlowp.cmake
@@ -14,8 +14,8 @@
 # ==============================================================================
 include (ExternalProject)
 
-set(gemmlowp_URL https://github.com/google/gemmlowp/archive/6a2a90822e8546fc2bfa7044de0faf1c1cb4862f.zip)
-set(gemmlowp_HASH SHA256=3447948d219f3270383766bbe08942888c0eb4e0ca6663c0e0548502ec5bb77d)
+set(gemmlowp_URL https://github.com/google/gemmlowp/archive/7c7c744640ddc3d0af18fb245b4d23228813a71b.zip)
+set(gemmlowp_HASH SHA256=b852cc90259a7357c8a323f108f2cec6e85979fc3b18b5590b99e0130044b2cf)
 set(gemmlowp_BUILD ${CMAKE_CURRENT_BINARY_DIR}/gemmlowp/src/gemmlowp)
 set(gemmlowp_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/gemmlowp/src/gemmlowp)
 


### PR DESCRIPTION
The gemmlowp has been updated in bazel, though
cmake version was not updated. This fix updates
gemmlowp in cmake so that cmake and bazel versions
are synced.

The fix has been tested on Linux:
```
tensorflow/tools/ci_build/ci_build.sh CMAKE tensorflow/tools/ci_build/builds/cmake.sh
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>