### PR TITLE
Add deprecated_args decoration to array_ops/ sparse_ops

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2690,6 +2690,8 @@ reverse.__doc__ = gen_array_ops.reverse_v2.__doc__
 
 # pylint: disable=redefined-builtin
 @tf_export("reverse_sequence")
+@deprecation.deprecated_args(None, "Use the `seq_axis` argument instead", "seq_dim")
+@deprecation.deprecated_args(None, "Use the `batch_axis` argument instead", "batch_dim")
 def reverse_sequence(input,
                      seq_lengths,
                      seq_axis=None,

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2690,8 +2690,8 @@ reverse.__doc__ = gen_array_ops.reverse_v2.__doc__
 
 # pylint: disable=redefined-builtin
 @tf_export("reverse_sequence")
-@deprecation.deprecated_args(None, "Use the `seq_axis` argument instead", "seq_dim")
-@deprecation.deprecated_args(None, "Use the `batch_axis` argument instead", "batch_dim")
+@deprecation.deprecated_args(None, "seq_dim is deprecated, use seq_axis instead", "seq_dim")
+@deprecation.deprecated_args(None, "batch_dim is deprecated, use batch_axis instead", "batch_dim")
 def reverse_sequence(input,
                      seq_lengths,
                      seq_axis=None,

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -110,6 +110,7 @@ def _convert_to_sparse_tensors(sp_inputs):
 
 # pylint: disable=protected-access
 @tf_export("sparse_concat")
+@deprecation.deprecated_args(None, "concat_dim is deprecated, use axis instead", "concat_dim")
 def sparse_concat(axis,
                   sp_inputs,
                   name=None,
@@ -616,6 +617,7 @@ class KeywordRequired(object):
 
 
 @tf_export("sparse_split")
+@deprecation.deprecated_args(None, "split_dim is deprecated, use axis instead", "split_dim")
 def sparse_split(keyword_required=KeywordRequired(),
                  sp_input=None,
                  num_split=None,


### PR DESCRIPTION
This PR is to add deprecated_args decoration to several ops in array_ops/ sparse_ops as below:
- [tf.reverse_sequence](https://www.tensorflow.org/api_docs/python/tf/reverse_sequence)
- [tf.sparse_concat](https://www.tensorflow.org/api_docs/python/tf/sparse_concat)
- [sparse_split](https://www.tensorflow.org/api_docs/python/tf/sparse_split)
