### PR TITLE
Fix tf.compat.as_str returns bytes issue in Python 3

### DIFF
--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -67,7 +67,6 @@ def as_bytes(bytes_or_text, encoding='utf-8'):
                     (bytes_or_text,))
 
 
-@tf_export('compat.as_text')
 def as_text(bytes_or_text, encoding='utf-8'):
   """Returns the given argument as a unicode string.
 

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -93,8 +93,12 @@ def as_text(bytes_or_text, encoding='utf-8'):
 # Convert an object to a `str` in both Python 2 and 3.
 if _six.PY2:
   as_str = as_bytes
+  tf_export('compat.as_bytes', 'compat.as_str')(as_bytes)
+  tf_export('compat.as_text')(as_text)
 else:
   as_str = as_text
+  tf_export('compat.as_bytes')(as_bytes)
+  tf_export('compat.as_text', 'compat.as_str')(as_text)
 
 
 @tf_export('compat.as_str_any')

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -45,7 +45,6 @@ from tensorflow.python.util.tf_export import tf_export
 from tensorflow.python.util.tf_export import tf_export
 
 
-@tf_export('compat.as_bytes', 'compat.as_str')
 def as_bytes(bytes_or_text, encoding='utf-8'):
   """Converts either bytes or unicode to `bytes`, using utf-8 encoding for text.
 


### PR DESCRIPTION
This fix tries to address the issue raised in #18598 where tf.compat.as_str returns bytes (vs. str) in Python 3.

The issue was that `tf_export` decorator:
```
@tf_export('compat.as_bytes', 'compat.as_str')
```
could not be assigned to `as_bytes` or `as_text` based on python 2 or 3.

This fix invokes tf_export explicitly based on `_six.PY2` (for python 2/3) so that `as_str` calls `as_bytes` or `as_text` conditionally.

This fix fixes #18598.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
