### PR TITLE
Improve shape function check for `tf.roll`

### DIFF
--- a/tensorflow/core/ops/manip_ops.cc
+++ b/tensorflow/core/ops/manip_ops.cc
@@ -32,6 +32,8 @@ REGISTER_OP("Roll")
       shape_inference::ShapeHandle unused;
       // The `input` must be 1-D or higher
       TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &unused));
+      // The `shift` must be scalar or 1-D.
+      TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(1), 1, &unused));
       // The `axis` must be scalar or 1-D.
       TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(2), 1, &unused));
 

--- a/tensorflow/core/ops/manip_ops.cc
+++ b/tensorflow/core/ops/manip_ops.cc
@@ -28,6 +28,12 @@ REGISTER_OP("Roll")
     .Attr("T: type")
     .Attr("Tshift: {int32,int64}")
     .Attr("Taxis: {int32,int64}")
-    .SetShapeFn(shape_inference::UnchangedShape);
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      shape_inference::ShapeHandle unused;
+      // The `input` must be 1-D or higher
+      TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &unused));
+
+      return shape_inference::UnchangedShape(c);
+    });
 
 }  // namespace tensorflow

--- a/tensorflow/core/ops/manip_ops.cc
+++ b/tensorflow/core/ops/manip_ops.cc
@@ -37,7 +37,7 @@ REGISTER_OP("Roll")
       // The `axis` must be scalar or 1-D.
       TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(2), 1, &unused));
       // Validate 'shift' is the same shape as axis'.
-      TF_RETURN_IF_ERROR(c->Merge(c->input(1), c->input(2), &unused) );
+      TF_RETURN_IF_ERROR(c->Merge(c->input(1), c->input(2), &unused));
       return shape_inference::UnchangedShape(c);
     });
 

--- a/tensorflow/core/ops/manip_ops.cc
+++ b/tensorflow/core/ops/manip_ops.cc
@@ -32,6 +32,8 @@ REGISTER_OP("Roll")
       shape_inference::ShapeHandle unused;
       // The `input` must be 1-D or higher
       TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &unused));
+      // The `axis` must be scalar or 1-D.
+      TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(2), 1, &unused));
 
       return shape_inference::UnchangedShape(c);
     });

--- a/tensorflow/core/ops/manip_ops.cc
+++ b/tensorflow/core/ops/manip_ops.cc
@@ -36,7 +36,8 @@ REGISTER_OP("Roll")
       TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(1), 1, &unused));
       // The `axis` must be scalar or 1-D.
       TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(2), 1, &unused));
-
+      // Validate 'shift' is the same shape as axis'.
+      TF_RETURN_IF_ERROR(c->Merge(c->input(1), c->input(2), &unused) );
       return shape_inference::UnchangedShape(c);
     });
 

--- a/tensorflow/python/kernel_tests/manip_ops_test.py
+++ b/tensorflow/python/kernel_tests/manip_ops_test.py
@@ -115,14 +115,20 @@ class RollTest(test_util.TensorFlowTestCase):
                                    "input must be 1-D or higher"):
         manip_ops.roll(tensor, shift, axis).eval(feed_dict={tensor: 7})
 
+  def testInvalidAxisShape(self):
+    # The axis should be a scalar or 1-D, checked in shape function.
+    with self.assertRaisesRegexp(ValueError, "Shape must be at most rank 1 but is rank 2"):
+      roll = manip_ops.roll([[1, 2], [3, 4]], 1, [[0, 1]])
+
   def testRollAxisMustBeScalarOrVectorRaises(self):
+    # The axis should be a scalar or 1-D, checked in kernel.
     tensor = [[1, 2], [3, 4]]
     shift = 1
-    axis = [[0, 1]]
+    axis = array_ops.placeholder(dtype=dtypes.int32)
     with self.test_session():
       with self.assertRaisesRegexp(errors_impl.InvalidArgumentError,
                                    "axis must be a scalar or a 1-D vector"):
-        manip_ops.roll(tensor, shift, axis).eval()
+        manip_ops.roll(tensor, shift, axis).eval(feed_dict={axis: [[0, 1]]})
 
   def testRollShiftMustBeScalarOrVectorRaises(self):
     tensor = [[1, 2], [3, 4]]

--- a/tensorflow/python/kernel_tests/manip_ops_test.py
+++ b/tensorflow/python/kernel_tests/manip_ops_test.py
@@ -130,14 +130,20 @@ class RollTest(test_util.TensorFlowTestCase):
                                    "axis must be a scalar or a 1-D vector"):
         manip_ops.roll(tensor, shift, axis).eval(feed_dict={axis: [[0, 1]]})
 
+  def testInvalidShiftShape(self):
+    # The shift should be a scalar or 1-D, checked in shape function.
+    with self.assertRaisesRegexp(ValueError, "Shape must be at most rank 1 but is rank 2"):
+      roll = manip_ops.roll([[1, 2], [3, 4]], [[0, 1]], 1)
+
   def testRollShiftMustBeScalarOrVectorRaises(self):
+    # The shift should be a scalar or 1-D, checked in kernel.
     tensor = [[1, 2], [3, 4]]
-    shift = [[0, 1]]
+    shift = array_ops.placeholder(dtype=dtypes.int32)
     axis = 1
     with self.test_session():
       with self.assertRaisesRegexp(errors_impl.InvalidArgumentError,
                                    "shift must be a scalar or a 1-D vector"):
-        manip_ops.roll(tensor, shift, axis).eval()
+        manip_ops.roll(tensor, shift, axis).eval(feed_dict={shift: [[0, 1]]})
 
   def testRollShiftAndAxisMustBeSameSizeRaises(self):
     tensor = [[1, 2], [3, 4]]

--- a/tensorflow/python/kernel_tests/manip_ops_test.py
+++ b/tensorflow/python/kernel_tests/manip_ops_test.py
@@ -145,14 +145,20 @@ class RollTest(test_util.TensorFlowTestCase):
                                    "shift must be a scalar or a 1-D vector"):
         manip_ops.roll(tensor, shift, axis).eval(feed_dict={shift: [[0, 1]]})
 
+  def testInvalidShiftAndAxisNotEqualShape(self):
+    # The shift and axis must be same size, checked in shape function.
+    with self.assertRaisesRegexp(ValueError, "both shapes must be equal"):
+      roll = manip_ops.roll([[1, 2], [3, 4]], [1], [0, 1])
+
   def testRollShiftAndAxisMustBeSameSizeRaises(self):
+    # The shift and axis must be same size, checked in kernel.
     tensor = [[1, 2], [3, 4]]
-    shift = [1]
+    shift = array_ops.placeholder(dtype=dtypes.int32)
     axis = [0, 1]
     with self.test_session():
       with self.assertRaisesRegexp(errors_impl.InvalidArgumentError,
                                    "shift and axis must have the same size"):
-        manip_ops.roll(tensor, shift, axis).eval()
+        manip_ops.roll(tensor, shift, axis).eval(feed_dict={shift: [1]})
 
   def testRollAxisOutOfRangeRaises(self):
     tensor = [1, 2]

--- a/tensorflow/python/kernel_tests/manip_ops_test.py
+++ b/tensorflow/python/kernel_tests/manip_ops_test.py
@@ -102,8 +102,9 @@ class RollTest(test_util.TensorFlowTestCase):
 
   def testInvalidInputShape(self):
     # The input should be 1-D or higher, checked in shape function.
-    with self.assertRaisesRegexp(ValueError, "Shape must be at least rank 1 but is rank 0"):
-      roll = manip_ops.roll(7, 1, 0)
+    with self.assertRaisesRegexp(
+        ValueError, "Shape must be at least rank 1 but is rank 0"):
+      manip_ops.roll(7, 1, 0)
 
   def testRollInputMustVectorHigherRaises(self):
     # The input should be 1-D or higher, checked is done in kernel.
@@ -117,8 +118,9 @@ class RollTest(test_util.TensorFlowTestCase):
 
   def testInvalidAxisShape(self):
     # The axis should be a scalar or 1-D, checked in shape function.
-    with self.assertRaisesRegexp(ValueError, "Shape must be at most rank 1 but is rank 2"):
-      roll = manip_ops.roll([[1, 2], [3, 4]], 1, [[0, 1]])
+    with self.assertRaisesRegexp(
+        ValueError, "Shape must be at most rank 1 but is rank 2"):
+      manip_ops.roll([[1, 2], [3, 4]], 1, [[0, 1]])
 
   def testRollAxisMustBeScalarOrVectorRaises(self):
     # The axis should be a scalar or 1-D, checked in kernel.
@@ -132,8 +134,9 @@ class RollTest(test_util.TensorFlowTestCase):
 
   def testInvalidShiftShape(self):
     # The shift should be a scalar or 1-D, checked in shape function.
-    with self.assertRaisesRegexp(ValueError, "Shape must be at most rank 1 but is rank 2"):
-      roll = manip_ops.roll([[1, 2], [3, 4]], [[0, 1]], 1)
+    with self.assertRaisesRegexp(
+        ValueError, "Shape must be at most rank 1 but is rank 2"):
+      manip_ops.roll([[1, 2], [3, 4]], [[0, 1]], 1)
 
   def testRollShiftMustBeScalarOrVectorRaises(self):
     # The shift should be a scalar or 1-D, checked in kernel.
@@ -148,7 +151,7 @@ class RollTest(test_util.TensorFlowTestCase):
   def testInvalidShiftAndAxisNotEqualShape(self):
     # The shift and axis must be same size, checked in shape function.
     with self.assertRaisesRegexp(ValueError, "both shapes must be equal"):
-      roll = manip_ops.roll([[1, 2], [3, 4]], [1], [0, 1])
+      manip_ops.roll([[1, 2], [3, 4]], [1], [0, 1])
 
   def testRollShiftAndAxisMustBeSameSizeRaises(self):
     # The shift and axis must be same size, checked in kernel.

--- a/tensorflow/python/kernel_tests/manip_ops_test.py
+++ b/tensorflow/python/kernel_tests/manip_ops_test.py
@@ -107,7 +107,7 @@ class RollTest(test_util.TensorFlowTestCase):
       manip_ops.roll(7, 1, 0)
 
   def testRollInputMustVectorHigherRaises(self):
-    # The input should be 1-D or higher, checked is done in kernel.
+    # The input should be 1-D or higher, checked in kernel.
     tensor = array_ops.placeholder(dtype=dtypes.int32)
     shift = 1
     axis = 0

--- a/tensorflow/python/kernel_tests/manip_ops_test.py
+++ b/tensorflow/python/kernel_tests/manip_ops_test.py
@@ -20,8 +20,10 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import test_util
+from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import manip_ops
 from tensorflow.python.platform import test as test_lib
@@ -98,14 +100,20 @@ class RollTest(test_util.TensorFlowTestCase):
         manip_ops.roll(np.random.randint(-100, 100, (4, 4)).astype(np.int32),
                        3, -10).eval()
 
+  def testInvalidInputShape(self):
+    # The input should be 1-D or higher, checked in shape function.
+    with self.assertRaisesRegexp(ValueError, "Shape must be at least rank 1 but is rank 0"):
+      roll = manip_ops.roll(7, 1, 0)
+
   def testRollInputMustVectorHigherRaises(self):
-    tensor = 7
+    # The input should be 1-D or higher, checked is done in kernel.
+    tensor = array_ops.placeholder(dtype=dtypes.int32)
     shift = 1
     axis = 0
     with self.test_session():
       with self.assertRaisesRegexp(errors_impl.InvalidArgumentError,
                                    "input must be 1-D or higher"):
-        manip_ops.roll(tensor, shift, axis).eval()
+        manip_ops.roll(tensor, shift, axis).eval(feed_dict={tensor: 7})
 
   def testRollAxisMustBeScalarOrVectorRaises(self):
     tensor = [[1, 2], [3, 4]]


### PR DESCRIPTION
The `tf.roll` op has requirements for the shape of inputs. However, the shape of the inputs are only done at the runtime inside the kernel.

This fix improve the shape function so that the check could be done early if shape is already known in the shape function.

The following validations have been added in the shape function with test cases:
- The `input` must be 1-D or higher
- The `shift` must be scalar or 1-D.
- The `axis` must be scalar or 1-D.
- The  `shift` and `axis` should be the same size.

They matches validations in the kernel.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>