### PR TITLE
Remove duplicate import in compat.py

### DIFF
--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -32,7 +32,6 @@ from tensorflow.python.ops import clip_ops
 from tensorflow.python.ops import gen_math_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.util.tf_export import tf_export
-from tensorflow.python.util.tf_export import tf_export
 
 
 @tf_export('histogram_fixed_width_bins')

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -42,7 +42,6 @@ import six as _six
 
 from tensorflow.python.util.all_util import remove_undocumented
 from tensorflow.python.util.tf_export import tf_export
-from tensorflow.python.util.tf_export import tf_export
 
 
 def as_bytes(bytes_or_text, encoding='utf-8'):


### PR DESCRIPTION
Noticed there are a couple of places in compat.py that have duplicate import:
```
from tensorflow.python.util.tf_export import tf_export
from tensorflow.python.util.tf_export import tf_export
```

This fix remove duplicate imports.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>