### PR TITLE
Fix the calculation of the histogram buckets and writing to the tensor in summary_db_writer

### DIFF
--- a/tensorflow/contrib/tensorboard/db/summary_db_writer.cc
+++ b/tensorflow/contrib/tensorboard/db/summary_db_writer.cc
@@ -1182,14 +1182,19 @@ class SummaryDbWriter : public SummaryWriterInterface {
     // See tensorboard/plugins/histogram/summary.py and data_compat.py
     Tensor t{DT_DOUBLE, {k, 3}};
     auto data = t.flat<double>();
-    for (int i = 0; i < k; ++i) {
-      double left_edge = ((i - 1 >= 0) ? histo.bucket_limit(i - 1)
-                                       : std::numeric_limits<double>::min());
-      double right_edge = ((i + 1 < k) ? histo.bucket_limit(i + 1)
-                                       : std::numeric_limits<double>::max());
-      data(i + 0) = left_edge;
-      data(i + 1) = right_edge;
-      data(i + 2) = histo.bucket(i);
+    for (int i = 0, j = 0; i < k; ++i) {
+      // From summary.proto
+      // Parallel arrays encoding the bucket boundaries and the bucket values.
+      // bucket(i) is the count for the bucket i.  The range for
+      // a bucket is:
+      //   i == 0:  -DBL_MAX .. bucket_limit(0)
+      //   i != 0:  bucket_limit(i-1) .. bucket_limit(i)
+      double left_edge = (i == 0) ? std::numeric_limits<double>::min()
+                                  : histo.bucket_limit(i - 1);
+
+      data(j++) = left_edge;
+      data(j++) = histo.bucket_limit(i);
+      data(j++) = histo.bucket(i);
     }
     int64 tag_id;
     PatchPluginName(s->mutable_metadata(), kHistogramPluginName);

--- a/tensorflow/contrib/tensorboard/db/summary_db_writer.cc
+++ b/tensorflow/contrib/tensorboard/db/summary_db_writer.cc
@@ -1183,6 +1183,7 @@ class SummaryDbWriter : public SummaryWriterInterface {
     Tensor t{DT_DOUBLE, {k, 3}};
     auto data = t.flat<double>();
     for (int i = 0, j = 0; i < k; ++i) {
+      // TODO(nickfelt): reconcile with TensorBoard's data_compat.py
       // From summary.proto
       // Parallel arrays encoding the bucket boundaries and the bucket values.
       // bucket(i) is the count for the bucket i.  The range for

--- a/tensorflow/contrib/tensorboard/db/summary_db_writer_test.cc
+++ b/tensorflow/contrib/tensorboard/db/summary_db_writer_test.cc
@@ -131,6 +131,7 @@ TEST_F(SummaryDbWriterTest, WriteHistogram_VerifyTensorValues) {
   writer_->Unref();
   writer_ = nullptr;
 
+  // TODO(nickfelt): implement QueryTensor() to encapsulate this
   // Verify the data
   string result = QueryString("SELECT data FROM Tensors");
   const double* val = reinterpret_cast<const double*>(result.data());


### PR DESCRIPTION
[Issue: 1141](https://github.com/tensorflow/tensorboard/issues/1141): Incorrect data being written out for the histogram in the db

- The calculation of the histogram buckets is incorrect per the histogramProto defined in 	[summary.proto](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/summary.proto)
- The data is getting clobbered in MigrateHistogram when writing it to a Tensor. This results in incorrect data being stored in the db

The pr provides a fix for this.

Testing: 
- Added a unit test