### PR TITLE
Make TensorFlow Lite library for Android target

### DIFF
--- a/tensorflow/contrib/lite/Makefile
+++ b/tensorflow/contrib/lite/Makefile
@@ -1,4 +1,6 @@
 
+SHELL := /bin/bash
+
 # Find where we're running from, so we can store generated files here.
 ifeq ($(origin MAKEFILE_DIR), undefined)
 	MAKEFILE_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
@@ -45,6 +47,12 @@ INCLUDES := \
 -I$(MAKEFILE_DIR)/downloads/farmhash/src \
 -I$(MAKEFILE_DIR)/downloads/flatbuffers/include \
 -I$(GENDIR)
+
+ifeq ($(TARGET), ANDROID)
+INCLUDE += \
+-I$(MAKEFILE_DIR)/downloads/abel
+endif
+
 # This is at the end so any globally-installed frameworks like protobuf don't
 # override local versions in the source tree.
 INCLUDES += -I/usr/local/include
@@ -61,6 +69,7 @@ ifeq ($(OS),LINUX)
 endif
 
 include $(MAKEFILE_DIR)/ios_makefile.inc
+include $(MAKEFILE_DIR)/android_makefile.inc
 
 # This library is the main target for this makefile. It will contain a minimal
 # runtime that can be linked in to other programs.
@@ -145,3 +154,8 @@ $(DEPDIR)/%.d: ;
 .PRECIOUS: $(DEPDIR)/%.d
 
 -include $(patsubst %,$(DEPDIR)/%.d,$(basename $(TF_CC_SRCS)))
+
+ifdef SUB_MAKEFILES
+$(warning "include sub makefiles, must not contain white spaces in the path:" $(SUB_MAKEFILES))
+include $(SUB_MAKEFILES)
+endif

--- a/tensorflow/contrib/lite/README.md
+++ b/tensorflow/contrib/lite/README.md
@@ -220,3 +220,44 @@ Follow the documentation [here](https://github.com/tensorflow/tensorflow/tree/ma
 ## Core ML support
 
 Core ML is a machine learning framework used across Apple products. In addition to using Tensorflow Lite models directly in their applications, developers have the option to convert their trained Tensorflow models to the [CoreML](https://developer.apple.com/machine-learning/) format for use on Apple devices. For information on how to use the converter please refer to the [Tensorflow-CoreML converter documentation](https://github.com/tf-coreml/tf-coreml).
+
+
+# TensorFlow Lite Makefile
+
+Basically, the environment to be prepared is the same as TensorFlow. See the README.md in tensorflow/contrib/makefile/
+
+
+## Android
+
+You can compile a TensorFlow Lite library for Android target. It can then be compiled into static or shared library as required.
+
+First, you will need to download and unzip the [Native Development Kit (NDK)](https://developer.android.com/ndk/).
+You will not need to install the standalone toolchain, however.
+
+Assign your NDK location to $NDK_ROOT:
+
+```bash
+export NDK_ROOT=/absolute/path/to/NDK/android-ndk-rxxx/
+```
+
+To compile TensorFlow Lite library using the Makefile, you need the cpufeatures library in NDK.
+
+```bash
+mkdir -p $NDK_ROOT/sources/android/cpufeatures/jni
+cp $NDK_ROOT/sources/android/cpufeatures/cpu-features.* $NDK_ROOT/sources/android/cpufeatures/jni
+cp $NDK_ROOT/sources/android/cpufeatures/Android.mk $NDK_ROOT/sources/android/cpufeatures/jni
+ndk-build NDK_PROJECT_PATH="$NDK_ROOT/sources/android/cpufeatures" NDK_APPLICATION_MK="$NDK_ROOT/sources/android/cpufeatures/Android.mk"
+```
+
+Then, you will have complied a static library in 'gen/lib/' and the [benchmark app](./tools/) compiled for Android as execute the following:
+
+```bash
+tensorflow/contrib/makefile/download_dependencies.sh
+make -f tensorflow/contrib/makefile/Makefile TARGET=ANDROID
+```
+
+If you need a shared library, execute the following command.
+
+```bash
+make -f tensorflow/contrib/lite/Makefile TARGET=ANDROID SUB_MAKEFILES=tensorflow/contrib/lite/sub_makefiles/android/Makefile.in libtensorflow-lite.so
+```

--- a/tensorflow/contrib/lite/android_makefile.inc
+++ b/tensorflow/contrib/lite/android_makefile.inc
@@ -1,0 +1,127 @@
+# Settings for Android.
+ifeq ($(TARGET), ANDROID)
+	HOST_ARCH = $(ARCH)
+
+	#If ANDROID_TYPES is not set assume __ANDROID_TYPES_SLIM__
+	ifeq ($(ANDROID_TYPES), )
+		ANDROID_TYPES := -D__ANDROID_TYPES_SLIM__
+	endif
+
+	ANDROID_HOST_OS_ARCH :=
+	ifeq ($(HOST_OS),LINUX)
+		ANDROID_HOST_OS_ARCH=linux
+	endif
+	ifeq ($(HOST_OS),OSX)
+		ANDROID_HOST_OS_ARCH=darwin
+	endif
+	ifeq ($(HOST_OS),WINDOWS)
+    $(error "windows is not supported.")
+	endif
+
+	ifeq ($(HOST_ARCH),x86_32)
+		ANDROID_HOST_OS_ARCH := $(ANDROID_HOST_OS_ARCH)-x86
+	else
+		ANDROID_HOST_OS_ARCH := $(ANDROID_HOST_OS_ARCH)-$(HOST_ARCH)
+	endif
+
+	ifndef ANDROID_ARCH
+		ANDROID_ARCH := armeabi-v7a
+	endif
+
+	ifeq ($(ANDROID_ARCH),arm64-v8a)
+		TOOLCHAIN := aarch64-linux-android-4.9
+		SYSROOT_ARCH := arm64
+		BIN_PREFIX := aarch64-linux-android
+		MARCH_OPTION :=
+	endif
+	ifeq ($(ANDROID_ARCH),armeabi)
+		TOOLCHAIN := arm-linux-androideabi-4.9
+		SYSROOT_ARCH := arm
+		BIN_PREFIX := arm-linux-androideabi
+		MARCH_OPTION :=
+	endif
+	ifeq ($(ANDROID_ARCH),armeabi-v7a)
+		TOOLCHAIN := arm-linux-androideabi-4.9
+		SYSROOT_ARCH := arm
+		BIN_PREFIX := arm-linux-androideabi
+		MARCH_OPTION := -march=armv7-a -mfloat-abi=softfp -mfpu=neon
+	endif
+	ifeq ($(ANDROID_ARCH),mips)
+		TOOLCHAIN := mipsel-linux-android-4.9
+		SYSROOT_ARCH := mips
+		BIN_PREFIX := mipsel-linux-android
+		MARCH_OPTION :=
+	endif
+	ifeq ($(ANDROID_ARCH),mips64)
+		TOOLCHAIN := mips64el-linux-android-4.9
+		SYSROOT_ARCH := mips64
+		BIN_PREFIX := mips64el-linux-android
+		MARCH_OPTION :=
+	endif
+	ifeq ($(ANDROID_ARCH),x86)
+		TOOLCHAIN := x86-4.9
+		SYSROOT_ARCH := x86
+		BIN_PREFIX := i686-linux-android
+		MARCH_OPTION :=
+	endif
+	ifeq ($(ANDROID_ARCH),x86_64)
+		TOOLCHAIN := x86_64-4.9
+		SYSROOT_ARCH := x86_64
+		BIN_PREFIX := x86_64-linux-android
+		MARCH_OPTION :=
+	endif
+
+	ifndef NDK_ROOT
+    $(error "NDK_ROOT is not defined.")
+	endif
+
+	CXX := $(CC_PREFIX) $(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(ANDROID_HOST_OS_ARCH)/bin/$(BIN_PREFIX)-g++
+
+	CC := $(CC_PREFIX) $(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(ANDROID_HOST_OS_ARCH)/bin/$(BIN_PREFIX)-gcc
+
+	CXXFLAGS +=\
+	--sysroot $(NDK_ROOT)/platforms/android-21/arch-$(SYSROOT_ARCH) \
+	-Wno-narrowing \
+	-fomit-frame-pointer \
+	$(MARCH_OPTION) \
+	-fPIE \
+	-fPIC \
+	-D__USE_MAKE__
+
+	INCLUDES += \
+	-I. \
+	-I$(NDK_ROOT)/sources/android/support/include \
+	-I$(NDK_ROOT)/sources/android/cpufeatures \
+	-I$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.9/include \
+	-I$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.9/libs/$(ANDROID_ARCH)/include \
+	-I$(NDK_ROOT)/platforms/android-21/arch-arm/usr/include \
+	-I$(NDK_ROOT)/platforms/android-21/arch-arm/usr/include/machine
+
+	LIBS := \
+	-lgnustl_static \
+	-llog \
+	-lz \
+	-lm \
+	-ldl \
+	-latomic \
+	-lcpufeatures
+
+	LD := $(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(ANDROID_HOST_OS_ARCH)/$(BIN_PREFIX)/bin/ld
+
+	LDFLAGS := \
+	$(MARCH_OPTION) \
+	-L$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.9/libs/$(ANDROID_ARCH) \
+	-L$(NDK_ROOT)/sources/android/cpufeatures/obj/local/$(ANDROID_ARCH) \
+	-fPIE \
+	-pie \
+	-v
+
+	AR := $(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(ANDROID_HOST_OS_ARCH)/bin/$(BIN_PREFIX)-ar
+	ARFLAGS := r
+	LIBFLAGS += -Wl,--allow-multiple-definition -Wl,--whole-archive
+
+	OBJDIR := $(OBJDIR)android_$(ANDROID_ARCH)/
+	LIBDIR := $(LIBDIR)android_$(ANDROID_ARCH)/
+	BINDIR := $(BINDIR)android_$(ANDROID_ARCH)/
+	GENDIR := $(GENDIR)android_$(ANDROID_ARCH)/
+endif

--- a/tensorflow/contrib/lite/kernels/internal/optimized/cpu_check.h
+++ b/tensorflow/contrib/lite/kernels/internal/optimized/cpu_check.h
@@ -18,7 +18,11 @@ limitations under the License.
 namespace tflite {
 
 #ifdef __ANDROID__
+#ifdef __USE_MAKE__
+#include "cpu-features.h"
+#else
 #include "ndk/sources/android/cpufeatures/cpu-features.h"
+#endif
 
 // Runtime check for Neon support on Android.
 inline bool TestCPUFeatureNeon() {

--- a/tensorflow/contrib/lite/sub_makefiles/android/Makefile.in
+++ b/tensorflow/contrib/lite/sub_makefiles/android/Makefile.in
@@ -1,0 +1,14 @@
+# libtensorflow-lite.so
+
+LITE_SO_NAME:= libtensorflow-lite.so
+LITE_SO_PATH  := $(LIBDIR)$(LITE_SO_NAME)
+
+$(LITE_SO_PATH): $(LIB_OBJS)
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) \
+	-o $@ $(LIB_OBJS) \
+	$(LIBFLAGS) $(LDFLAGS) \
+	-shared -Wl,-soname,$(LITE_SO_NAME) \
+	$(LIBS)
+
+$(LITE_SO_NAME): $(LITE_SO_PATH)


### PR DESCRIPTION
You can compile Tensorflow Lite library using Makefile.
It is possible to compile both static and shared library
including benchmark tools.

For more details, see TensorFlow Lite Makefile section
of the README.md file.

Signed-off-by: MyungSung Kwak <yesmung@gmail.com>