### PR TITLE
Fix wrong api name in apis.md

### DIFF
--- a/tensorflow/contrib/lite/g3doc/apis.md
+++ b/tensorflow/contrib/lite/g3doc/apis.md
@@ -29,7 +29,7 @@ interpreter->AllocateTensors();
 float* input = interpreter->typed_input_tensor<float>(0);
 // Fill `input`.
 interpreter->Invoke();
-float* output = interpreter->type_output_tensor<float>(0);
+float* output = interpreter->typed_output_tensor<float>(0);
 ```
 ### Data Alignment
 


### PR DESCRIPTION
typed_output_tensor is the correct api name.
It is implemented in the interpreter class.

Signed-off-by: MyungSung Kwak <yesmung@gmail.com>