### PR TITLE
tf.keras: Warn user when they mix up `sparse_categorical_crossentropy` and `categorical_crossentropy`

### DIFF
--- a/tensorflow/python/keras/_impl/keras/backend.py
+++ b/tensorflow/python/keras/_impl/keras/backend.py
@@ -3451,6 +3451,15 @@ def categorical_crossentropy(target, output, from_logits=False):
   # Note: nn.softmax_cross_entropy_with_logits_v2
   # expects logits, Keras expects probabilities.
   if not from_logits:
+    if (target.shape[-1] == 1 and output.shape[-1]
+        and target.shape[-1] != output.shape[-1]):
+      raise ValueError('Expected target dimension = {}, Received: {}'
+                       'Suggested Fix:'
+                       'Your label is integer,'
+                       'to use `sparse_categorical_crossentropy` instead'
+                       'or convert your label to one-hot format.'.format(
+                           output.shape[-1], target.shape[-1]))
+
     # scale preds so that the class probas of each sample sum to 1
     output = output / math_ops.reduce_sum(  # pylint: disable=g-no-augmented-assignment
         output, len(output.get_shape()) - 1, True)

--- a/tensorflow/python/keras/_impl/keras/losses_test.py
+++ b/tensorflow/python/keras/_impl/keras/losses_test.py
@@ -137,6 +137,14 @@ class KerasLossesTest(test.TestCase):
         loaded_model = keras.models.load_model(model_filename)
         loaded_model.predict(np.random.rand(128, 2))
 
+  def test_categorical_crossentropy_with_integer_targets(self):
+    y_pred = keras.backend.variable(np.array([[0.3, 0.2, 0.1],
+                                              [0.1, 0.2, 0.7]]))
+    y_true = keras.backend.variable(np.array([[1], [0]]))
+    with self.assertRaisesRegexp(ValueError,
+                                 'sparse_categorical_crossentropy'):
+      keras.losses.categorical_crossentropy(y_true, y_pred)
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Sometimes we convert one-hot labels to integer labels, and forget to change the loss function `categorical_crossentropy` to `sparse_categorical_crossentropy`.

Because `categorical_crossentropy` doesn't check the shape of `target` and `output`, tf.keras works well except a totally wrong result.

The PR only checks the last dimension of static shape for efficient, perhaps we'd better to check whole shape with help of `tf.contrib.framework.with_same_shape`?