### PR TITLE
Replace raw_input/input with six.moves.input

### DIFF
--- a/tensorflow/python/debug/wrappers/grpc_wrapper.py
+++ b/tensorflow/python/debug/wrappers/grpc_wrapper.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import signal
 import sys
 import traceback
+import six
 
 # Google-internal import(s).
 from tensorflow.python.debug.lib import common
@@ -140,11 +141,7 @@ class GrpcDebugWrapperSession(framework.NonInteractiveDebugWrapperSession):
 
 
 def _signal_handler(unused_signal, unused_frame):
-  try:
-    input_func = raw_input
-  except NameError:
-    # Python 3 does not have raw_input.
-    input_func = input
+  input_func = six.moves.input
 
   while True:
     response = input_func("\nSIGINT received. Quit program? (Y/n): ").strip()

--- a/tensorflow/python/debug/wrappers/grpc_wrapper.py
+++ b/tensorflow/python/debug/wrappers/grpc_wrapper.py
@@ -143,7 +143,8 @@ class GrpcDebugWrapperSession(framework.NonInteractiveDebugWrapperSession):
 
 def _signal_handler(unused_signal, unused_frame):
   while True:
-    response = six.moves.input("\nSIGINT received. Quit program? (Y/n): ").strip()
+    response = six.moves.input(
+        "\nSIGINT received. Quit program? (Y/n): ").strip()
     if response in ("", "Y", "y"):
       sys.exit(0)
     elif response in ("N", "n"):

--- a/tensorflow/python/debug/wrappers/grpc_wrapper.py
+++ b/tensorflow/python/debug/wrappers/grpc_wrapper.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import signal
 import sys
 import traceback
+
 import six
 
 # Google-internal import(s).

--- a/tensorflow/python/debug/wrappers/grpc_wrapper.py
+++ b/tensorflow/python/debug/wrappers/grpc_wrapper.py
@@ -142,10 +142,8 @@ class GrpcDebugWrapperSession(framework.NonInteractiveDebugWrapperSession):
 
 
 def _signal_handler(unused_signal, unused_frame):
-  input_func = six.moves.input
-
   while True:
-    response = input_func("\nSIGINT received. Quit program? (Y/n): ").strip()
+    response = six.moves.input("\nSIGINT received. Quit program? (Y/n): ").strip()
     if response in ("", "Y", "y"):
       sys.exit(0)
     elif response in ("N", "n"):


### PR DESCRIPTION
This fix is an enhancement to replace raw_input/input in python 2 and 3 with six.moves.input.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
