### PR TITLE
Add uint16 support for py_func

### DIFF
--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -62,6 +62,15 @@ class PyFuncTest(test.TestCase):
         y = constant_op.constant(2, dtype=dtype)
         z = self.evaluate(script_ops.py_func(sum_func, [x, y], dtype))
         self.assertEqual(z, dtype(3))
+  def testComplexDataTypes(self):
+    def sum_func(x, y):
+      return x + y
+    for dtype in [np.complex64, np.complex128]:
+      with self.test_session():
+        x = constant_op.constant(1 + 1j, dtype=dtype)
+        y = constant_op.constant(2 + 2j, dtype=dtype)
+        z = self.evaluate(script_ops.py_func(sum_func, [x, y], dtype))
+        self.assertEqual(z, dtype(3 + 3j))
 
   def testSingleType(self):
     with self.test_session():

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -64,14 +64,14 @@ class PyFuncTest(test.TestCase):
         self.assertEqual(z, dtype(3))
 
   def testComplexDataTypes(self):
-    def sum_func(x, y):
-      return x + y
+    def sub_func(x, y):
+      return x - y
     for dtype in [np.complex64, np.complex128]:
       with self.test_session():
         x = constant_op.constant(1 + 1j, dtype=dtype)
-        y = constant_op.constant(2 + 2j, dtype=dtype)
-        z = self.evaluate(script_ops.py_func(sum_func, [x, y], dtype))
-        self.assertEqual(z, dtype(3 + 3j))
+        y = constant_op.constant(2 - 2j, dtype=dtype)
+        z = self.evaluate(script_ops.py_func(sub_func, [x, y], dtype))
+        self.assertEqual(z, dtype(-1 + 3j))
 
   def testSingleType(self):
     with self.test_session():

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -73,6 +73,16 @@ class PyFuncTest(test.TestCase):
         z = self.evaluate(script_ops.py_func(sub_func, [x, y], dtype))
         self.assertEqual(z, dtype(-1 + 3j))
 
+  def testBoolDataTypes(self):
+    def and_func(x, y):
+      return x and y
+    for dtype in [np.bool]:
+      with self.test_session():
+        x = constant_op.constant(True, dtype=dtype)
+        y = constant_op.constant(False, dtype=dtype)
+        z = self.evaluate(script_ops.py_func(and_func, [x, y], dtype))
+        self.assertEqual(z, dtype(False))
+
   def testSingleType(self):
     with self.test_session():
       x = constant_op.constant(1.0, dtypes.float32)

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -76,12 +76,12 @@ class PyFuncTest(test.TestCase):
   def testBoolDataTypes(self):
     def and_func(x, y):
       return x and y
-    for dtype in [np.bool]:
-      with self.test_session():
-        x = constant_op.constant(True, dtype=dtype)
-        y = constant_op.constant(False, dtype=dtype)
-        z = self.evaluate(script_ops.py_func(and_func, [x, y], dtype))
-        self.assertEqual(z, dtype(False))
+    dtype = dtypes.bool
+    with self.test_session():
+      x = constant_op.constant(True, dtype=dtype)
+      y = constant_op.constant(False, dtype=dtype)
+      z = self.evaluate(script_ops.py_func(and_func, [x, y], dtype))
+      self.assertEqual(z, False)
 
   def testSingleType(self):
     with self.test_session():

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -62,6 +62,7 @@ class PyFuncTest(test.TestCase):
         y = constant_op.constant(2, dtype=dtype)
         z = self.evaluate(script_ops.py_func(sum_func, [x, y], dtype))
         self.assertEqual(z, dtype(3))
+
   def testComplexDataTypes(self):
     def sum_func(x, y):
       return x + y

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -55,23 +55,24 @@ class PyFuncTest(test.TestCase):
   def testRealDataTypes(self):
     def sum_func(x, y):
       return x + y
-    for dtype in [np.float16, np.float32, np.float64,
-                  np.uint8, np.int8, np.uint16, np.int16, np.int32, np.int64]:
+    for dtype in [dtypes.float16, dtypes.float32, dtypes.float64,
+                  dtypes.uint8, dtypes.int8, dtypes.uint16, dtypes.int16,
+                  dtypes.int32, dtypes.int64]:
       with self.test_session():
         x = constant_op.constant(1, dtype=dtype)
         y = constant_op.constant(2, dtype=dtype)
         z = self.evaluate(script_ops.py_func(sum_func, [x, y], dtype))
-        self.assertEqual(z, dtype(3))
+        self.assertEqual(z, 3)
 
   def testComplexDataTypes(self):
     def sub_func(x, y):
       return x - y
-    for dtype in [np.complex64, np.complex128]:
+    for dtype in [dtypes.complex64, dtypes.complex128]:
       with self.test_session():
         x = constant_op.constant(1 + 1j, dtype=dtype)
         y = constant_op.constant(2 - 2j, dtype=dtype)
         z = self.evaluate(script_ops.py_func(sub_func, [x, y], dtype))
-        self.assertEqual(z, dtype(-1 + 3j))
+        self.assertEqual(z, -1 + 3j)
 
   def testBoolDataTypes(self):
     def and_func(x, y):

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -52,6 +52,16 @@ class PyFuncTest(test.TestCase):
   """Encapsulates tests for py_func and eager_py_func."""
 
   # ----- Tests for py_func -----
+  def testRealDataTypes(self):
+    def sum_func(x, y):
+      return x + y
+    for dtype in [np.float16, np.float32, np.float64, np.uint8, np.int8, np.uint16, np.int16, np.int32, np.int64]:
+      with self.test_session():
+        x = constant_op.constant(1, dtype=dtype)
+        y = constant_op.constant(2, dtype=dtype)
+        z = self.evaluate(script_ops.py_func(sum_func, [x, y], dtype))
+        self.assertEqual(z, dtype(3))
+
   def testSingleType(self):
     with self.test_session():
       x = constant_op.constant(1.0, dtypes.float32)

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -55,7 +55,8 @@ class PyFuncTest(test.TestCase):
   def testRealDataTypes(self):
     def sum_func(x, y):
       return x + y
-    for dtype in [np.float16, np.float32, np.float64, np.uint8, np.int8, np.uint16, np.int16, np.int32, np.int64]:
+    for dtype in [np.float16, np.float32, np.float64,
+                  np.uint8, np.int8, np.uint16, np.int16, np.int32, np.int64]:
       with self.test_session():
         x = constant_op.constant(1, dtype=dtype)
         y = constant_op.constant(2, dtype=dtype)

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -126,6 +126,9 @@ Status NumericNpDTypeToTfDType(const int np, DataType* tf) {
     case NPY_INT8:
       *tf = DT_INT8;
       break;
+    case NPY_UINT16:
+      *tf = DT_UINT16;
+      break;
     case NPY_INT16:
       *tf = DT_INT16;
       break;


### PR DESCRIPTION
When using`py_func` in tf I noticed that uint16 support is not available (all other numeric types have already been supported):
```
$ python
>>> import tensorflow as tf
>>> def sum_func(x, y):
...   return x + y
...
>>> x = tf.constant(1, dtype=tf.uint16)
>>> y = tf.constant(2, dtype=tf.uint16)
>>> z = tf.py_func(sum_func, [x, y], tf.uint16)
>>> tf.Session().run(z)
...
...
tensorflow.python.framework.errors_impl.UnimplementedError: Unsupported numpy type 4
	 [[Node: PyFunc = PyFunc[Tin=[DT_UINT16, DT_UINT16], Tout=[DT_UINT16], token="pyfunc_0", _device="/job:localhost/replica:0/task:0/device:CPU:0"](Const, Const_1)]]
...
```

The reason is that there is no conversion between numpy uint16 and tf.uint16.

This fix adds the support so that py_func could process tf.uint16 data types.

This fix also adds test cases for different data types with py_func to increase the test coverage.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>