### PR TITLE
[r1.8] Fix tf.compat.as_str returns bytes issue in Python 3

### DIFF
--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -45,7 +45,6 @@ from tensorflow.python.util.tf_export import tf_export
 from tensorflow.python.util.tf_export import tf_export
 
 
-@tf_export('compat.as_bytes', 'compat.as_str')
 def as_bytes(bytes_or_text, encoding='utf-8'):
   """Converts either bytes or unicode to `bytes`, using utf-8 encoding for text.
 
@@ -68,7 +67,6 @@ def as_bytes(bytes_or_text, encoding='utf-8'):
                     (bytes_or_text,))
 
 
-@tf_export('compat.as_text')
 def as_text(bytes_or_text, encoding='utf-8'):
   """Returns the given argument as a unicode string.
 
@@ -93,8 +91,12 @@ def as_text(bytes_or_text, encoding='utf-8'):
 # Convert an object to a `str` in both Python 2 and 3.
 if _six.PY2:
   as_str = as_bytes
+  tf_export('compat.as_bytes', 'compat.as_str')(as_bytes)
+  tf_export('compat.as_text')(as_text)
 else:
   as_str = as_text
+  tf_export('compat.as_bytes')(as_bytes)
+  tf_export('compat.as_text', 'compat.as_str')(as_text)
 
 
 @tf_export('compat.as_str_any')


### PR DESCRIPTION
**NOTE: This PR is against r1.8.** Please feel free to close the PR if this is not appropriate.

This PR is to carry the fix of #18601 `Fix tf.compat.as_str returns bytes issue in Python 3` to r1.8. 

@martinwicke @annarev I feel it might make sense to apply this patch to 1.8 release if time permits.

Not sure about the overall release work flow though, so please feel free to close the PR if not appropriate.