### PR TITLE
Update docs for tf.unstack with respect to numpy compatibility

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1057,9 +1057,7 @@ def unstack(value, num=None, axis=0, name="unstack"):
     `value[:, i, :, :]` and each tensor in `output` will have shape `(A, C, D)`.
   Etc.
 
-  This is the opposite of stack.  The numpy equivalent is
-
-      tf.unstack(x, n) = np.unstack(x)
+  This is the opposite of stack.
 
   Args:
     value: A rank `R > 0` `Tensor` to be unstacked.


### PR DESCRIPTION
In #18692 an issue was raised over whether `tf.unstack` is compatible with `numpy.unstack `(specified in existing docs) or `numpy.split`.

It looks like there is no `numpy.unstack`. And for `numpy.split`, it is not compatible with `tf.unstack`.

The `tf.split` is indeed very close to `numpy.split`. However, the second arg `num_or_size_splits` in `tf.split` requires the number of the splits, while the second arg `indices_or_sections` in `numpy.split` requires the index of the splits. For that reason the `tf.split` is not compatible with `numpy.split` as well.

According to the above this fix simply removes `The numpy equivalent` part in the docs of `tf.unstack`.

This fix fixes #18692.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>