### PR TITLE
Fix tf.variable_scope unique name after entering root scope

### DIFF
--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -1175,7 +1175,7 @@ class _VariableScopeStore(threading.local):
 
   def close_variable_subscopes(self, scope_name):
     for k in list(self.variable_scopes_count.keys()):
-      if not scope_name or k.startswith(scope_name + "/"):
+      if scope_name is None or k.startswith(scope_name + "/"):
         self.variable_scopes_count[k] = 0
 
   def variable_scope_count(self, scope_name):


### PR DESCRIPTION
This PR fixes a bug in creating unique scope name after entering and closing the root scope.

The following snippet exploits the bug
```python
import tensorflow as tf

with tf.variable_scope(None, "Block") as scope:
    print("SCOPE:" + scope.name)
with tf.variable_scope('') as scope:
    print("SCOPE:" + scope.name)
with tf.variable_scope(None, "Block") as scope:
    print("SCOPE:" + scope.name)
```

Executing it produces
```
    SCOPE:Block
    SCOPE:
    SCOPE:Block
```
While the expected behavior should be
```
    SCOPE:Block
    SCOPE:
    SCOPE:Block_1
```
As it turns out, closing the root scope ('') results in resetting the dict `self.variable_scopes_count` to `0`,
since `not ''` evaluates to `True`, which is unlikely the required behavior.