### PR TITLE
modify initial value of scale to zero

### DIFF
--- a/tensorflow/contrib/lite/nnapi_delegate.cc
+++ b/tensorflow/contrib/lite/nnapi_delegate.cc
@@ -76,7 +76,7 @@ uint32_t addTensorOperands(tflite::Interpreter* interpreter,
   uint32_t next_id = 0;
   for (size_t i = 0; i < interpreter->tensors_size(); i++) {
     int32_t nn_type = 0;
-    float scale = 1.0f;
+    float scale = 0.0f;
     int32_t zeroPoint = 0;
     TfLiteTensor* tensor = interpreter->tensor(i);
     switch (tensor->type) {


### PR DESCRIPTION
In Android NN's validation function, it will check operand type and scale
value. Here is sources of validation implementation.
switch (operand.type) {
     case OperandType::FLOAT32:
     case OperandType::INT32:
     case OperandType::UINT32:
     case OperandType::TENSOR_FLOAT32:
         if (operand.scale != 0.f) {
             LOG(ERROR) << "Operand " << index << ": Operand of type "
                        << getOperandTypeName(operand.type) << " with a non-zero scale ("
                        << operand.scale << ")";
             return false;
         }
         break;

Signed-off-by: Tix Lo <tixlo.tw@gmail.com>