### PR TITLE
Update .gitignore for cmake generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Podfile.lock
 /tensorflow/contrib/lite/examples/ios/simple/data/*.txt
 /tensorflow/contrib/lite/examples/ios/simple/data/*.tflite
 xcuserdata/**
+/api_init_files_list.txt
 
 # Android
 .gradle


### PR DESCRIPTION
After running cmake on Linux with:
```
tensorflow/tools/ci_build/ci_build.sh CMAKE tensorflow/tools/ci_build/builds/cmake.sh
```

the following file is left:
```
ubuntu@ubuntu:~/tensorflow$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        api_init_files_list.txt

nothing added to commit but untracked files present (use "git add" to track)
ubuntu@ubuntu:~/tensorflow$
```

This fix updates the .gitignore file so that cmake generated files
is not added with git inadvertently.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>