### PR TITLE
Fix numerical warning of np.float with explicitly specifying np.float32

### DIFF
--- a/tensorflow/contrib/learn/python/learn/datasets/base.py
+++ b/tensorflow/contrib/learn/python/learn/datasets/base.py
@@ -109,7 +109,7 @@ def load_iris(data_path=None):
     module_path = path.dirname(__file__)
     data_path = path.join(module_path, 'data', 'iris.csv')
   return load_csv_with_header(
-      data_path, target_dtype=np.int, features_dtype=np.float)
+      data_path, target_dtype=np.int, features_dtype=np.float32)
 
 
 @deprecated(None, 'Use scikits.learn.datasets.')
@@ -126,7 +126,7 @@ def load_boston(data_path=None):
     module_path = path.dirname(__file__)
     data_path = path.join(module_path, 'data', 'boston_house_prices.csv')
   return load_csv_with_header(
-      data_path, target_dtype=np.float, features_dtype=np.float)
+      data_path, target_dtype=np.float32, features_dtype=np.float32)
 
 
 @deprecated(None, 'Use the retry module or similar alternatives.')

--- a/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
+++ b/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
@@ -311,7 +311,7 @@ class NpairsLossMultiLabelTest(test.TestCase):
 
       similarity_matrix = np.matmul(embeddings_anchor, embeddings_positive.T)
 
-      labels_remapped = np.dot(labels, labels.T).astype(np.float)
+      labels_remapped = np.dot(labels, labels.T).astype(np.float32)
       labels_remapped /= np.sum(labels_remapped, 1, keepdims=True)
 
       xent_loss = math_ops.reduce_mean(nn.softmax_cross_entropy_with_logits(

--- a/tensorflow/contrib/timeseries/python/timeseries/ar_model_test.py
+++ b/tensorflow/contrib/timeseries/python/timeseries/ar_model_test.py
@@ -51,12 +51,12 @@ class ARModelTest(test.TestCase):
     self.period = 25
     num_samples = 200
     time = 1 + 3 * np.arange(num_samples).astype(np.int64)
-    time_offset = (2 * np.pi * (time % self.period).astype(np.float) /
+    time_offset = (2 * np.pi * (time % self.period).astype(np.float32) /
                    self.period).reshape([-1, 1])
     if multiple_periods:
       period2 = 55
       self.period = [self.period, period2]
-      time_offset2 = ((time % period2).astype(np.float) / period2).reshape(
+      time_offset2 = ((time % period2).astype(np.float32) / period2).reshape(
           [-1, 1])
       data1 = np.sin(time_offset / 2.0) ** 2 * (1 + time_offset2)
     else:

--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -114,7 +114,7 @@ class UnaryOpTest(test.TestCase):
         s = list(np.shape(x))
         jacob_t, _ = gradient_checker.compute_gradient(
             inx, s, y, s, x_init_value=x)
-        xf = x.astype(np.float)
+        xf = x.astype(np.float32)
         inxf = ops.convert_to_tensor(xf)
         yf = tf_func(inxf)
         _, jacob_n = gradient_checker.compute_gradient(
@@ -880,8 +880,8 @@ class BinaryOpTest(test.TestCase):
           # care is taken with choosing the inputs and the delta. This is
           # a weaker check (in particular, it does not test the op itself,
           # only its gradient), but it's much better than nothing.
-          self._compareGradientX(x, y, np_func, tf_func, np.float)
-          self._compareGradientY(x, y, np_func, tf_func, np.float)
+          self._compareGradientX(x, y, np_func, tf_func, np.float32)
+          self._compareGradientY(x, y, np_func, tf_func, np.float32)
         else:
           self._compareGradientX(x, y, np_func, tf_func)
           self._compareGradientY(x, y, np_func, tf_func)
@@ -1528,8 +1528,8 @@ class SelectOpTest(test.TestCase):
         # care is taken with choosing the inputs and the delta. This is
         # a weaker check (in particular, it does not test the op itself,
         # only its gradient), but it's much better than nothing.
-        self._compareGradientX(c, xt, yt, np.float)
-        self._compareGradientY(c, xt, yt, np.float)
+        self._compareGradientX(c, xt, yt, np.float32)
+        self._compareGradientY(c, xt, yt, np.float32)
       else:
         self._compareGradientX(c, xt, yt)
         self._compareGradientY(c, xt, yt)
@@ -1657,8 +1657,8 @@ class BatchSelectOpTest(test.TestCase):
         # care is taken with choosing the inputs and the delta. This is
         # a weaker check (in particular, it does not test the op itself,
         # only its gradient), but it's much better than nothing.
-        self._compareGradientX(c, xt, yt, np.float)
-        self._compareGradientY(c, xt, yt, np.float)
+        self._compareGradientX(c, xt, yt, np.float32)
+        self._compareGradientY(c, xt, yt, np.float32)
       else:
         self._compareGradientX(c, xt, yt)
         self._compareGradientY(c, xt, yt)

--- a/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
+++ b/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
@@ -114,7 +114,7 @@ class DynamicPartitionTest(test.TestCase):
     self.assertEqual(num_partitions, len(partition_vals))
     for i in range(num_partitions):
       # reshape because of empty parts
-      parts_np = np.array(parts[i], dtype=np.float).reshape(-1, cols)
+      parts_np = np.array(parts[i], dtype=np.float32).reshape(-1, cols)
       self.assertAllEqual(parts_np, partition_vals[i])
 
   def testSimpleComplex(self):
@@ -204,7 +204,7 @@ class DynamicPartitionTest(test.TestCase):
     self.assertEqual(3, len(partition_vals))
     self.assertAllEqual([[]], partition_vals[0])
     self.assertAllEqual([[]], partition_vals[1])
-    self.assertAllEqual(np.array([], dtype=np.float).reshape(0, 0),
+    self.assertAllEqual(np.array([], dtype=np.float32).reshape(0, 0),
                         partition_vals[2])
 
   def testEmptyPartitions(self):

--- a/tensorflow/python/kernel_tests/relu_op_test.py
+++ b/tensorflow/python/kernel_tests/relu_op_test.py
@@ -210,7 +210,7 @@ class Relu6Test(test.TestCase):
       self._testRelu6(
           np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t),
           use_gpu=False)
-      if t in [np.float16, np.float, np.double]:
+      if t in [np.float16, np.float32, np.double]:
         self._testRelu6(
             np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t),
             use_gpu=True)

--- a/tensorflow/python/kernel_tests/reverse_sequence_op_test.py
+++ b/tensorflow/python/kernel_tests/reverse_sequence_op_test.py
@@ -111,7 +111,7 @@ class ReverseSequenceTest(test.TestCase):
     x = np.asarray(
         [[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]],
          [[17, 18, 19, 20], [21, 22, 23, 24]]],
-        dtype=np.float)
+        dtype=np.float32)
     x = x.reshape(3, 2, 4, 1, 1)
     x = x.transpose([2, 1, 0, 3, 4])  # transpose axes 0 <=> 2
 

--- a/tensorflow/python/kernel_tests/softsign_op_test.py
+++ b/tensorflow/python/kernel_tests/softsign_op_test.py
@@ -41,7 +41,7 @@ class SoftsignTest(test.TestCase):
     self.assertShapeEqual(np_softsign, softsign)
 
   def testNumbers(self):
-    for t in [np.float, np.double]:
+    for t in [np.float32, np.double]:
       self._testSoftsign(
           np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t),
           use_gpu=False)

--- a/tensorflow/python/ops/gradient_checker_test.py
+++ b/tensorflow/python/ops/gradient_checker_test.py
@@ -100,7 +100,7 @@ class GradientCheckerTest(test.TestCase):
       index_values = [1, 3]
       y_shape = [2, 2]
       params = constant_op.constant(
-          np.arange(p_size).astype(np.float), shape=p_shape, name="p")
+          np.arange(p_size).astype(np.float32), shape=p_shape, name="p")
       indices = constant_op.constant(index_values, name="i")
       y = array_ops.gather(params, indices, name="y")
 
@@ -119,7 +119,7 @@ class GradientCheckerTest(test.TestCase):
       y2_shape = [2, 2]
 
       params = constant_op.constant(
-          np.arange(p_size).astype(np.float), shape=p_shape, name="p")
+          np.arange(p_size).astype(np.float32), shape=p_shape, name="p")
       indices = constant_op.constant(index_values, name="i")
       y = array_ops.gather(params, indices, name="y")
       indices2 = constant_op.constant(index_values2, name="i2")

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1265,13 +1265,13 @@ class AdjustContrastTest(test_util.TensorFlowTestCase):
   def testDoubleContrastFloat(self):
     x_shape = [1, 2, 2, 3]
     x_data = [0, 5, 13, 54, 135, 226, 37, 8, 234, 90, 255, 1]
-    x_np = np.array(x_data, dtype=np.float).reshape(x_shape) / 255.
+    x_np = np.array(x_data, dtype=np.float32).reshape(x_shape) / 255.
 
     y_data = [
         -45.25, -90.75, -92.5, 62.75, 169.25, 333.5, 28.75, -84.75, 349.5,
         134.75, 409.25, -116.5
     ]
-    y_np = np.array(y_data, dtype=np.float).reshape(x_shape) / 255.
+    y_np = np.array(y_data, dtype=np.float32).reshape(x_shape) / 255.
 
     self._testContrast(x_np, y_np, contrast_factor=2.0)
 


### PR DESCRIPTION
This PR is to fix numerical warning of type np.float.
> WARNING:tensorflow:float64 is not supported by many models, consider casting to float32

The [numpy](https://docs.scipy.org/doc/numpy-1.14.0/user/basics.types.html) data type `np.float` is shorthand for `np.float64`. So, `np.float32` is explicitly specified as solution.