### PR TITLE
Ensure Java Session closes the JNI on finalize

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Session.java
@@ -109,6 +109,14 @@ public final class Session implements AutoCloseable {
   }
 
   /**
+   * Run when the JVM terminates the object.
+   * <p>Ensures that close is called when the JVM deallocates the object.</p>
+   */
+  protected void finalize() {
+    close();
+  }
+
+  /**
    * Run {@link Operation}s and evaluate {@link Tensor}s.
    *
    * <p>A Runner runs the necessary graph fragments to execute every {@link Operation} required to


### PR DESCRIPTION
* Currently the JNI Session object does not close
the native library when the JVM deallocates
* This ensures that when the JVM deallocates this
object from the system it also closes the native
code correctly

Obviously the user should call close explicitly or use try blocks, but this catches the cases where they don't and can prevent massive memory leaks on services.