### PR TITLE
Swtich to use axis instead of squeeze_dims in tf.squeeze

### DIFF
--- a/tensorflow/examples/learn/text_classification_character_cnn.py
+++ b/tensorflow/examples/learn/text_classification_character_cnn.py
@@ -74,7 +74,7 @@ def char_cnn_model(features, labels, mode):
         kernel_size=FILTER_SHAPE2,
         padding='VALID')
     # Max across each filter to get useful features for classification.
-    pool2 = tf.squeeze(tf.reduce_max(conv2, 1), squeeze_dims=[1])
+    pool2 = tf.squeeze(tf.reduce_max(conv2, 1), axis=[1])
 
   # Apply regular WX + B and classification.
   logits = tf.layers.dense(pool2, MAX_LABEL, activation=None)

--- a/tensorflow/examples/learn/text_classification_cnn.py
+++ b/tensorflow/examples/learn/text_classification_cnn.py
@@ -73,7 +73,7 @@ def cnn_model(features, labels, mode):
         kernel_size=FILTER_SHAPE2,
         padding='VALID')
     # Max across each filter to get useful features for classification.
-    pool2 = tf.squeeze(tf.reduce_max(conv2, 1), squeeze_dims=[1])
+    pool2 = tf.squeeze(tf.reduce_max(conv2, 1), axis=[1])
 
   # Apply regular WX + B and classification.
   logits = tf.layers.dense(pool2, MAX_LABEL, activation=None)

--- a/tensorflow/tools/compatibility/testdata/test_file_v0_11.py
+++ b/tensorflow/tools/compatibility/testdata/test_file_v0_11.py
@@ -125,18 +125,18 @@ class TestUpgrade(test_util.TensorFlowTestCase):
       self.assertAllEqual(
           tf.expand_dims(
               tf.squeeze(
-                  [[1, 2, 3]], squeeze_dims=[0]), dim=0).eval(),
+                  [[1, 2, 3]], axis=[0]), dim=0).eval(),
           a)
       self.assertAllEqual(
           tf.squeeze(
               tf.expand_dims(
-                  [[1, 2, 3]], dim=1), squeeze_dims=[1]).eval(),
+                  [[1, 2, 3]], dim=1), axis=[1]).eval(),
           a)
 
       self.assertAllEqual(
           tf.squeeze(
               tf.expand_dims(
-                  [[1, 2, 3]], dim=1), squeeze_dims=[1]).eval(),
+                  [[1, 2, 3]], dim=1), axis=[1]).eval(),
           a)
 
   def testArithmeticRenames(self):


### PR DESCRIPTION
This PR is to change `squeeze_dims` to `axis` in `tf.squeeze` since the former one is deprecated now.

This fix switches from squeeze_dims to axis to remove below warnings according to [array_ops.py#L2579](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/array_ops.py#L2579).
> @deprecation.deprecated_args(None, "Use the `axis` argument instead",
>                              "squeeze_dims")