### PR TITLE
Raise error on separable convolution and depthwise convolution with strides > 1 and rate > 1

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -20,6 +20,8 @@ from __future__ import print_function
 
 import math
 
+import numpy as np
+
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import function
@@ -440,8 +442,12 @@ def depthwise_conv2d(input,
   with ops.name_scope(name, "depthwise", [input, filter]) as name:
     input = ops.convert_to_tensor(input, name="tensor_in")
     filter = ops.convert_to_tensor(filter, name="filter_in")
+
     if rate is None:
       rate = [1, 1]
+
+    if np.any(strides > 1) and np.any(rate > 1):
+      raise ValueError("strides > 1 not supported in conjunction with rate > 1")
 
     def op(input_converted, _, padding):
       return nn_ops.depthwise_conv2d_native(
@@ -533,6 +539,9 @@ def separable_conv2d(input,
 
     if rate is None:
       rate = [1, 1]
+
+    if np.any(strides > 1) and np.any(rate > 1):
+      raise ValueError("strides > 1 not supported in conjunction with rate > 1")
 
     # The layout of the ops in the graph are expected to be as follows:
     # depthwise_conv2d  // Conv2D op corresponding to native deptwise conv.


### PR DESCRIPTION
In documents, `separable_con2d` and `depthwise_conv2d` should not accept `strides > 1` and `rate > 1` at the same time. But they don't have any code to check these parameters, so it worked in a wrong way.
