### PR TITLE
Update tensorboard dep to 1.8.x

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -38,7 +38,7 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.13.3',
     'six >= 1.10.0',
     'protobuf >= 3.4.0',
-    'tensorboard >= 1.7.0, < 1.8.0',
+    'tensorboard >= 1.8.0, < 1.9.0',
     'termcolor >= 1.1.0',
 ]
 


### PR DESCRIPTION
TensorBoard 1.8.0 has been released to PyPI: https://pypi.org/project/tensorboard/1.8.0/