### PR TITLE
Enable int8 support for FloorDiv

### DIFF
--- a/tensorflow/core/kernels/cwise_op_floor_div.cc
+++ b/tensorflow/core/kernels/cwise_op_floor_div.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER5(BinaryOp, CPU, "FloorDiv", functor::safe_floor_div, uint8, uint16,
-          int16, int32, int64);
+REGISTER6(BinaryOp, CPU, "FloorDiv", functor::safe_floor_div, uint8, uint16,
+          int8, int16, int32, int64);
 REGISTER3(BinaryOp, CPU, "FloorDiv", functor::floor_div_real, float,
           Eigen::half, double);
 

--- a/tensorflow/python/kernel_tests/division_past_test.py
+++ b/tensorflow/python/kernel_tests/division_past_test.py
@@ -35,7 +35,6 @@ class DivisionTestCase(test.TestCase):
     """Test all the different ways to divide."""
     values = [1, 2, 7, 11]
     functions = (lambda x: x), constant_op.constant
-    # TODO(irving): Test int8, int16 once we support casts for those.
     dtypes = np.int8, np.int16, np.int32, np.int64, np.float32, np.float64
 
     tensors = []

--- a/tensorflow/python/kernel_tests/division_past_test.py
+++ b/tensorflow/python/kernel_tests/division_past_test.py
@@ -36,7 +36,7 @@ class DivisionTestCase(test.TestCase):
     values = [1, 2, 7, 11]
     functions = (lambda x: x), constant_op.constant
     # TODO(irving): Test int8, int16 once we support casts for those.
-    dtypes = np.int32, np.int64, np.float32, np.float64
+    dtypes = np.int8, np.int16, np.int32, np.int64, np.float32, np.float64
 
     tensors = []
     checks = []


### PR DESCRIPTION
int8 is enabled for FloorDiv in math_ops.cc though the kernel was not registered.

This fix register the int8 kernel for FloorDiv, and enables the test case for it.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>