### PR TITLE
[tflite] Extract NEON check function for aarch64

### DIFF
--- a/tensorflow/contrib/lite/kernels/internal/optimized/cpu_check.h
+++ b/tensorflow/contrib/lite/kernels/internal/optimized/cpu_check.h
@@ -18,21 +18,26 @@ limitations under the License.
 namespace tflite {
 
 #ifdef __ANDROID__
+
+#ifdef __aarch64__
+
+// ARM-64 always has NEON support.
+inline bool TestCPUFeatureNeon() { return true; }
+
+#else
+
 #include "ndk/sources/android/cpufeatures/cpu-features.h"
 
 // Runtime check for Neon support on Android.
 inline bool TestCPUFeatureNeon() {
-#ifdef __aarch64__
-  // ARM-64 always has NEON support.
-  return true;
-#else
   static bool kUseAndroidNeon =
       (android_getCpuFamily() == ANDROID_CPU_FAMILY_ARM &&
        android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_ARMv7 &&
        android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_NEON);
   return kUseAndroidNeon;
-#endif  // __aarch64__
 }
+
+#endif  // __aarch64__
 
 #elif defined USE_NEON || defined __ARM_NEON
 


### PR DESCRIPTION
For aarch64, we do not have to include `cpu-features.h`.