### PR TITLE
Change the swap threshold by adding an elastic percentage

### DIFF
--- a/tensorflow/core/grappler/optimizers/memory_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/memory_optimizer.cc
@@ -951,7 +951,7 @@ static bool IdentifySwappingCandidates(
     VLOG(1) << "Failed to infer memory usage: " << s.error_message();
     return false;
   }
-
+  const float elastic_percentage = 0.80;
   bool updated_graph = false;
   for (const auto& device : devices) {
     const string& name = device.first;
@@ -963,12 +963,14 @@ static bool IdentifySwappingCandidates(
       VLOG(1) << "Peak memory usage unknown for device " << name;
       continue;
     }
+
     const GraphMemory::MemoryUsage& mem_usage = memory.GetPeakMemoryUsage(name);
 
-    if (mem_usage.used_memory <= prop.memory_size()) {
+    float swap_threshold = elastic_percentage * prop.memory_size();
+    if (mem_usage.used_memory <= swap_threshold) {
       continue;
     }
-    int64 required_savings = mem_usage.used_memory - prop.memory_size();
+    int64 required_savings = mem_usage.used_memory - swap_threshold;
 
     std::unordered_map<string, Costs::NanoSeconds> op_completion_times;
     {


### PR DESCRIPTION
Originally, heuristic memory swapping feature won't improve much on the batch size, that's because IdentifySwappingCandidates are fully trusting the statically analysis.
Per my experiment, this did not improve the batch size at all. 

While If we make the swapping threshold to be lower,for example, when analyzed memory usage is 0.8 * GPU mem size, then swapping feature is triggered. 

According to my experiments, for my K80 (12G), ResNet50, batch size can be improved from 128 to 150. 