### PR TITLE
Fix link to original LSTM paper

### DIFF
--- a/tensorflow/contrib/lite/nnapi/NeuralNetworksShim.h
+++ b/tensorflow/contrib/lite/nnapi/NeuralNetworksShim.h
@@ -609,7 +609,7 @@ enum {
    * Long short-term memory unit (LSTM) recurrent network layer.
    *
    * The default non-peephole implementation is based on:
-   * http://deeplearning.cs.cmu.edu/pdfs/Hochreiter97_lstm.pdf
+   * http://www.bioinf.jku.at/publications/older/2604.pdf
    * S. Hochreiter and J. Schmidhuber. "Long Short-Term Memory". Neural
    * Computation, 9(8):1735-1780, 1997.
    *


### PR DESCRIPTION
Hi,

the url to the original LSTM paper in `tensorflow/contrib/lite/nnapi/NeuralNetworksShim.h` is no longer available (404 is returned), so this PR fixes it.