### PR TITLE
[Intel MKL] Reverting changes from 495d511 that break install_pip_packages.sh in …

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -17,14 +17,9 @@
 set -e
 
 # We don't apt-get install so that we can install a newer version of pip.
-# Only needed for Ubuntu 14.04 ,and not needed for Ubuntu 16.04 / Debian 8,9
-if $(cat /etc/*-release | grep -q 14.04); then
-  easy_install -U pip==9.0.3
-  easy_install3 -U pip==9.0.3
-else
-  pip2 install --upgrade pip==9.0.3
-  pip3 install --upgrade pip==9.0.3
-fi
+# Only needed for Ubuntu 14.04 and 16.04; not needed for 18.04 and Debian 8,9?
+easy_install -U pip==9.0.3
+easy_install3 -U pip==9.0.3
 
 # Install pip packages from whl files to avoid the time-consuming process of
 # building from source.


### PR DESCRIPTION
…Ubuntu 16.04 containers, causing nightly mkl ci builds to fail. The comments indicate that easy_install is not required in Ubuntu 16.04, but `pip2 install --upgrade pip==9.0.3` fails in nightly mkl CI builds:

> 22:19:04 Step 7/13 : RUN /install/install_pip_packages.sh
> 22:19:04  ---> Running in c508335088ed
> 22:19:05 /install/install_pip_packages.sh: line 25: pip2: command not found
> 22:19:05 The command '/bin/sh -c /install/install_pip_packages.sh' returned a non-zero code: 127

See http://ci.tensorflow.org/view/Nightly/job/nightly-mkl/198/console