### PR TITLE
Fix build error with MPI support

### DIFF
--- a/tensorflow/contrib/mpi/mpi_utils.h
+++ b/tensorflow/contrib/mpi/mpi_utils.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/lib/strings/str_util.h"
 
 // Skip MPI C++ bindings support, this matches the usage in other places


### PR DESCRIPTION
This fix tries to fix the issue raised in #18363 where the bazel build with MPI support fails as a header is missing in the include.

This fix fixes the issue. The fix is verified locally with MPI+CUDA on Ubuntu 16.04.

This fix fixes #18363.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>