### PR TITLE
Fix cmake library path for libpng16.a

### DIFF
--- a/tensorflow/contrib/cmake/external/png.cmake
+++ b/tensorflow/contrib/cmake/external/png.cmake
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 include (ExternalProject)
+include (GNUInstallDirs)
 
 set(png_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/png_archive)
 set(png_URL https://mirror.bazel.build/github.com/glennrp/libpng/archive/v1.6.34.tar.gz)
@@ -35,7 +36,7 @@ if(WIN32)
     endif()
   endif()
 else()
-  set(png_STATIC_LIBRARIES ${CMAKE_BINARY_DIR}/png/install/lib/libpng16.a)
+  set(png_STATIC_LIBRARIES ${CMAKE_BINARY_DIR}/png/install/${CMAKE_INSTALL_LIBDIR}/libpng16.a)
 endif()
 
 set(png_HEADERS


### PR DESCRIPTION
### System information

- OS: Linux Fedora 26
- Tensorflow: installed from source (master branch)
- GCC 7.3.1
- CMake 3.11
- No GPU

### Problem
The CMake build fails on Fedora in normal build. libpng16 is using 

> CMAKE_INSTALL_LIBDIR

 as the library destination for non-WIN32 systems. In some linux distribution like fedora this path corresponds to **_lib64_**

### Steps to reproduce
```
$ git clone https://github.com/tensorflow/tensorflow
$ cd tensorflow/tensorflow/contrib/cmake
$ mkdir build && cd build
$ cmake  ..
$ make
```

### Logs
```
[...]
make[3]: *** No rule to make target 'png/install/lib/libpng16.a', needed by 'proto_text'.
Stop.
make[2]: *** [CMakeFiles/Makefile2:8959: CMakeFiles/proto_text.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:5441: CMakeFiles/tf_core_framework.dir/rule] Error 2
make: *** [Makefile:1919: tf_core_framework] Error 2
```