### PR TITLE
fix missing type conversion

### DIFF
--- a/tensorflow/docs_src/get_started/get_started_for_beginners.md
+++ b/tensorflow/docs_src/get_started/get_started_for_beginners.md
@@ -611,7 +611,7 @@ def eval_input_fn(features, labels=None, batch_size=None):
         # No labels, use only features.
         inputs = features
     else:
-        inputs = (features, labels)
+        inputs = (dict(features), labels)
 
     # Convert inputs to a tf.dataset object.
     dataset = tf.data.Dataset.from_tensor_slices(inputs)


### PR DESCRIPTION
Hi,

I was following the getting started and noticed that the else case of `eval_input_fn` needs an extra dict(features). Without it I get:

```
(tensorflow) rodrigo@rodrigo-XPS-13-9360:~/dev/tensorflow$ python python/iris_graph.py
Traceback (most recent call last):
  File "python/iris_graph.py", line 52, in <module>
    eval_result = classifier.evaluate(input_fn=lambda:eval_input_fn(test_features, test_labels, batch_size))
  File "/home/rodrigo/dev/tensorflow/local/lib/python2.7/site-packages/tensorflow/python/estimator/estimator.py", line 425, in evaluate
    name=name)
  File "/home/rodrigo/dev/tensorflow/local/lib/python2.7/site-packages/tensorflow/python/estimator/estimator.py", line 1087, in _evaluate_model
    features, labels, model_fn_lib.ModeKeys.EVAL, self.config)
  File "/home/rodrigo/dev/tensorflow/local/lib/python2.7/site-packages/tensorflow/python/estimator/estimator.py", line 831, in _call_model_fn
    model_fn_results = self._model_fn(features=features, **kwargs)
  File "/home/rodrigo/dev/tensorflow/local/lib/python2.7/site-packages/tensorflow/python/estimator/canned/dnn.py", line 347, in _model_fn
    config=config)
  File "/home/rodrigo/dev/tensorflow/local/lib/python2.7/site-packages/tensorflow/python/estimator/canned/dnn.py", line 159, in _dnn_model_fn
    'Given type: {}'.format(type(features)))
ValueError: features should be a dictionary of `Tensor`s. Given type: <class 'tensorflow.python.framework.ops.Tensor'>
(tensorflow) rodrigo@rodrigo-XPS-13-9360:~/dev/tensorflow$
```

After adding the extra type conversion (line 39) as following everything works fine:

```
 35 def eval_input_fn(features, labels, batch_size):
 36     if labels is None:
 37         input = features
 38     else:
 39         input = (dict(features), labels)
 40     dataset = tf.data.Dataset.from_tensor_slices(input)
 41     dataset = dataset.batch(batch_size)
 42     return dataset.make_one_shot_iterator().get_next()
```

Note that this is also consistent with `train_input_fn`