### PR TITLE
Update mobile prepare models documentation

### DIFF
--- a/tensorflow/docs_src/mobile/prepare_models.md
+++ b/tensorflow/docs_src/mobile/prepare_models.md
@@ -105,8 +105,8 @@ inline constants so everything’s in one file.  To handle the conversion, you�
 need the `freeze_graph.py` script, that’s held in
 [`tensorflow/python/tools/freeze_graph.py`](https://www.tensorflow.org/code/tensorflow/python/tools/freeze_graph.py). You’ll run it like this:
 
-    bazel build tensorflow/tools:freeze_graph
-    bazel-bin/tensorflow/tools/freeze_graph \
+    bazel build tensorflow/python/tools:freeze_graph
+    bazel-bin/tensorflow/python/tools/freeze_graph \
     --input_graph=/tmp/model/my_graph.pb \
     --input_checkpoint=/tmp/model/model.ckpt-1000 \
     --output_graph=/tmp/frozen_graph.pb \


### PR DESCRIPTION
Correct the command line examples to match the actual location of freeze_graph.
- Old command line example showed freeze_graph in `tensorflow/tools`
- freeze_graph is actually located in `tensorflow/python/tools`. The documentation immediately above the command line example states this.
- Modify the command line example to run using the `tensorflow/python/tools` location.
- The command line for graph_transforms does not need to be updated.