### PR TITLE
 Remove whitespace characters from tf_cuda_compute_capabilities user …

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1226,6 +1226,9 @@ def set_tf_cuda_compute_capabilities(environ_cp):
         ask_cuda_compute_capabilities, default_cuda_compute_capabilities)
     # Check whether all capabilities from the input is valid
     all_valid = True
+    # Remove all whitespace characters before splitting the string
+    # that users may insert by accident, as this will result in error 
+    tf_cuda_compute_capabilities = ''.join(tf_cuda_compute_capabilities.split())
     for compute_capability in tf_cuda_compute_capabilities.split(','):
       m = re.match('[0-9]+.[0-9]+', compute_capability)
       if not m:


### PR DESCRIPTION
…string

Remove all whitespace characters from the user specified tf_cuda_compute_capabilities string as this can results in errors during the split operation, and is easy for users to do as it is natural to insert a space after a comma