### PR TITLE
Add conditions:default to mkl build

### DIFF
--- a/third_party/mkl/BUILD
+++ b/third_party/mkl/BUILD
@@ -34,6 +34,7 @@ filegroup(
         "@org_tensorflow//tensorflow:windows": [
             "@mkl_windows//:LICENSE",
         ],
+        "//conditions:default": []
     }),
     visibility = ["//visibility:public"],
 )
@@ -54,5 +55,6 @@ cc_library(
             "@mkl_windows//:mkl_headers",
             "@mkl_windows//:mkl_libs_windows",
         ],
+        "//conditions:default": []
     }),
 )


### PR DESCRIPTION
If building on a system that is not darwin, linux_x86_64, or
windows, the select statement in third_party/mkl/BUILD fails to
find a match and fails. Need to use no mkl libraries for non-x86
systems

Fixes #18084