### PR TITLE
Copy module list before iterating over it

### DIFF
--- a/tensorflow/tools/api/generator/create_python_api.py
+++ b/tensorflow/tools/api/generator/create_python_api.py
@@ -159,8 +159,7 @@ def get_api_init_text():
 
   # Traverse over everything imported above. Specifically,
   # we want to traverse over TensorFlow Python modules.
-  module_list = list(sys.modules.values())
-  for module in module_list:
+  for module in list(sys.modules.values()):
     # Only look at tensorflow modules.
     if (not module or not hasattr(module, '__name__') or
         'tensorflow.' not in module.__name__):

--- a/tensorflow/tools/api/generator/create_python_api.py
+++ b/tensorflow/tools/api/generator/create_python_api.py
@@ -23,6 +23,7 @@ import collections
 import os
 import sys
 
+from tensorflow import python  # pylint: disable=unused-import
 from tensorflow.python.util import tf_decorator
 
 
@@ -158,7 +159,8 @@ def get_api_init_text():
 
   # Traverse over everything imported above. Specifically,
   # we want to traverse over TensorFlow Python modules.
-  for module in sys.modules.values():
+  module_list = list(sys.modules.values())
+  for module in module_list:
     # Only look at tensorflow modules.
     if (not module or not hasattr(module, '__name__') or
         'tensorflow.' not in module.__name__):


### PR DESCRIPTION
Copying sys.modules.values before iterating over it. Seems like we are seeing errors that dictionary is getting modified during iteration on some plaforms.
Also, I am adding "from tensorflow import python" explicitly since we are iterating over modules under tensorflow.python.