### PR TITLE
Cleanup usage of the protobuf workspace.

### DIFF
--- a/tensorflow/compiler/xla/service/interpreter/BUILD
+++ b/tensorflow/compiler/xla/service/interpreter/BUILD
@@ -61,8 +61,8 @@ cc_library(
     srcs = ["platform_id.cc"],
     hdrs = ["platform_id.h"],
     deps = ["//tensorflow/core:stream_executor_headers_lib"] + if_static(
-        ["@protobuf_archive//:protobuf"],
-        ["@protobuf_archive//:protobuf_headers"],
+        ["@com_google_protobuf//:protobuf"],
+        ["@com_google_protobuf//:protobuf_headers"],
     ),
 )
 

--- a/tensorflow/compiler/xla/xla.bzl
+++ b/tensorflow/compiler/xla/xla.bzl
@@ -13,10 +13,10 @@ def xla_proto_library(name, srcs=[], deps=[], visibility=None, testonly=0, **kwa
                    srcs=srcs,
                    deps=deps,
                    cc_libs = if_static(
-                       ["@protobuf_archive//:protobuf"],
-                       otherwise=["@protobuf_archive//:protobuf_headers"],
+                       ["@com_google_protobuf//:protobuf"],
+                       otherwise=["@com_google_protobuf//:protobuf_headers"],
                    ),
-                   protoc="@protobuf_archive//:protoc",
+                   protoc="@com_google_protobuf//:protoc",
                    testonly=testonly,
                    visibility=visibility,
                    **kwargs)

--- a/tensorflow/contrib/factorization/kernels/BUILD
+++ b/tensorflow/contrib/factorization/kernels/BUILD
@@ -14,7 +14,7 @@ cc_library(
         ":clustering_ops",
         ":masked_matmul_ops",
         ":wals_solver_ops",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
 )
 
@@ -24,7 +24,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
     alwayslink = 1,
 )
@@ -35,7 +35,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
     alwayslink = 1,
 )
@@ -47,7 +47,7 @@ cc_library(
         "//tensorflow/core:framework_headers_lib",
         "//tensorflow/core/kernels:bounds_check",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/contrib/ffmpeg/default/BUILD
+++ b/tensorflow/contrib/ffmpeg/default/BUILD
@@ -20,7 +20,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
 )
 

--- a/tensorflow/contrib/hadoop/BUILD
+++ b/tensorflow/contrib/hadoop/BUILD
@@ -46,7 +46,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/contrib/ignite/BUILD
+++ b/tensorflow/contrib/ignite/BUILD
@@ -67,7 +67,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "@boringssl//:ssl",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
 )
 
@@ -86,7 +86,7 @@ cc_library(
         ":ignite_client",
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/contrib/image/BUILD
+++ b/tensorflow/contrib/image/BUILD
@@ -353,7 +353,7 @@ tf_custom_op_library(
         "ops/single_image_random_dot_stereograms_ops.cc",
     ],
     deps = [
-        "@protobuf_archive//:protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/tensorflow/contrib/input_pipeline/kernels/BUILD
+++ b/tensorflow/contrib/input_pipeline/kernels/BUILD
@@ -13,7 +13,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/contrib/kafka/BUILD
+++ b/tensorflow/contrib/kafka/BUILD
@@ -39,8 +39,8 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
+        "@com_google_protobuf//:protobuf_headers",
         "@kafka",
-        "@protobuf_archive//:protobuf_headers",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/contrib/kinesis/BUILD
+++ b/tensorflow/contrib/kinesis/BUILD
@@ -43,7 +43,7 @@ cc_library(
         "//tensorflow/core/platform/s3:aws_crypto",
         "//third_party/eigen3",
         "@aws",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/contrib/layers/kernels/BUILD
+++ b/tensorflow/contrib/layers/kernels/BUILD
@@ -13,8 +13,8 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
+        "@com_google_protobuf//:protobuf_headers",
         "@farmhash_archive//:farmhash",
-        "@protobuf_archive//:protobuf_headers",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/contrib/periodic_resample/BUILD
+++ b/tensorflow/contrib/periodic_resample/BUILD
@@ -21,7 +21,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/contrib/proto/python/kernel_tests/BUILD
+++ b/tensorflow/contrib/proto/python/kernel_tests/BUILD
@@ -109,7 +109,7 @@ py_library(
         ":proto_op_test_base",
         "//third_party/py/numpy",
         "@absl_py//absl/testing:parameterized",
-        "@protobuf_archive//:protobuf_python",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/tensorflow/contrib/tensor_forest/BUILD
+++ b/tensorflow/contrib/tensor_forest/BUILD
@@ -42,7 +42,7 @@ cc_library(
         ":tree_utils",
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
     alwayslink = 1,
 )
@@ -387,7 +387,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
 )
 
@@ -411,7 +411,7 @@ tf_cc_shared_object(
     deps = [
         ":forest_proto_impl",
         "//tensorflow/contrib/tensor_forest/kernels/v4:decision-tree-resource_impl",
-        "@protobuf_archive//:protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/tensorflow/contrib/tensor_forest/hybrid/BUILD
+++ b/tensorflow/contrib/tensor_forest/hybrid/BUILD
@@ -76,7 +76,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
 )
 

--- a/tensorflow/contrib/tensorrt/BUILD
+++ b/tensorflow/contrib/tensorrt/BUILD
@@ -375,7 +375,7 @@ cc_library(
         "//tensorflow/core:graph",
         "//tensorflow/core:lib_proto_parsing",
         "//tensorflow/core:protos_all_cc",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
 )
 

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -426,7 +426,7 @@ cc_library(
         ":platform_base",
         ":platform_port",
         "//tensorflow/core/platform/default/build_config:protobuf",
-        "@protobuf_archive//:protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -1661,9 +1661,9 @@ cc_library(
         ":protos_all_cc_impl",
         ":stats_calculator_portable",
         "//third_party/eigen3",
+        "@com_google_protobuf//:protobuf",
         "@double_conversion//:double-conversion",
         "@nsync//:nsync_cpp",
-        "@protobuf_archive//:protobuf",
     ],
     alwayslink = 1,
 )
@@ -1694,9 +1694,9 @@ cc_library(
         ":protos_all_cc_impl",
         "//third_party/eigen3",
         "//third_party/fft2d:fft2d_headers",
+        "@com_google_protobuf//:protobuf",
         "@fft2d",
         "@gemmlowp",
-        "@protobuf_archive//:protobuf",
     ],
     alwayslink = 1,
 )
@@ -1711,9 +1711,9 @@ cc_library(
         ":protos_all_cc_impl",
         ":stats_calculator_portable",
         "//third_party/eigen3",
+        "@com_google_protobuf//:protobuf",
         "@double_conversion//:double-conversion",
         "@nsync//:nsync_cpp",
-        "@protobuf_archive//:protobuf",
     ],
     alwayslink = 1,
 )
@@ -1752,7 +1752,7 @@ cc_library(
         ":protos_all_cc_impl",
         "//tensorflow/core/kernels:android_tensorflow_kernels",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
     alwayslink = 1,
 )
@@ -1776,9 +1776,9 @@ cc_library(
     deps = [
         ":protos_all_cc_impl",
         "//third_party/eigen3",
+        "@com_google_protobuf//:protobuf",
         "@double_conversion//:double-conversion",
         "@nsync//:nsync_cpp",
-        "@protobuf_archive//:protobuf",
     ],
     alwayslink = 1,
 )
@@ -1800,9 +1800,9 @@ cc_library(
     deps = [
         ":protos_all_cc_impl",
         "//third_party/eigen3",
+        "@com_google_protobuf//:protobuf",
         "@double_conversion//:double-conversion",
         "@nsync//:nsync_cpp",
-        "@protobuf_archive//:protobuf",
     ],
     alwayslink = 1,
 )
@@ -2217,10 +2217,10 @@ cc_library(
         ":core_stringpiece",
         "//third_party/eigen3",
         "//tensorflow/core/platform/default/build_config:platformlib",
+        "@com_google_protobuf//:protobuf",
         "@snappy",
         "@zlib_archive//:zlib",
         "@double_conversion//:double-conversion",
-        "@protobuf_archive//:protobuf",
     ] + tf_protos_all_impl() + tf_protos_grappler_impl(),
 )
 
@@ -2548,10 +2548,10 @@ tf_cuda_library(
     ] + if_static(
         extra_deps = [
             ":framework_internal_impl",
-            "@protobuf_archive//:protobuf",
+            "@com_google_protobuf//:protobuf",
         ],
         otherwise = [
-            "@protobuf_archive//:protobuf_headers",
+            "@com_google_protobuf//:protobuf_headers",
         ],
     ),
     alwayslink = 1,
@@ -2645,8 +2645,8 @@ tf_cuda_library(
         "//tensorflow/core/kernels:bounds_check",
         "//third_party/eigen3",
     ] + if_static(
-        extra_deps = ["@protobuf_archive//:protobuf"],
-        otherwise = ["@protobuf_archive//:protobuf_headers"],
+        extra_deps = ["@com_google_protobuf//:protobuf"],
+        otherwise = ["@com_google_protobuf//:protobuf_headers"],
     ) + mkl_deps(),
     alwayslink = 1,
 )

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -5727,9 +5727,9 @@ cc_library(
         "//tensorflow/core:protos_all_cc_impl",
         "//third_party/eigen3",
         "//third_party/fft2d:fft2d_headers",
+        "@com_google_protobuf//:protobuf",
         "@fft2d",
         "@gemmlowp",
-        "@protobuf_archive//:protobuf",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -1,6 +1,6 @@
 # Platform-specific build configurations.
 
-load("@protobuf_archive//:protobuf.bzl", "proto_gen")
+load("@com_google_protobuf//:protobuf.bzl", "proto_gen")
 load("//tensorflow:tensorflow.bzl", "if_not_mobile")
 load("//tensorflow:tensorflow.bzl", "if_windows")
 load("//tensorflow:tensorflow.bzl", "if_not_windows")
@@ -127,7 +127,7 @@ def cc_proto_library(
         deps = [],
         cc_libs = [],
         include = None,
-        protoc = "@protobuf_archive//:protoc",
+        protoc = "@com_google_protobuf//:protoc",
         internal_bootstrap_hack = False,
         use_grpc_plugin = False,
         use_grpc_namespace = False,
@@ -227,7 +227,7 @@ def cc_proto_library(
     )
     native.cc_library(
         name = header_only_name,
-        deps = ["@protobuf_archive//:protobuf_headers"] + if_static([impl_name]),
+        deps = ["@com_google_protobuf//:protobuf_headers"] + if_static([impl_name]),
         hdrs = gen_hdrs,
         **kargs
     )
@@ -244,8 +244,8 @@ def py_proto_library(
         py_libs = [],
         py_extra_srcs = [],
         include = None,
-        default_runtime = "@protobuf_archive//:protobuf_python",
-        protoc = "@protobuf_archive//:protoc",
+        default_runtime = "@com_google_protobuf//:protobuf_python",
+        protoc = "@com_google_protobuf//:protoc",
         use_grpc_plugin = False,
         **kargs):
     """Bazel rule to create a Python protobuf library from proto source files
@@ -340,19 +340,19 @@ def tf_proto_library_cc(
         # libraries containing all the sources.
         proto_gen(
             name = cc_name + "_genproto",
-            protoc = "@protobuf_archive//:protoc",
+            protoc = "@com_google_protobuf//:protoc",
             visibility = ["//visibility:public"],
             deps = [s + "_genproto" for s in cc_deps],
         )
         native.cc_library(
             name = cc_name,
-            deps = cc_deps + ["@protobuf_archive//:protobuf_headers"] + if_static([name + "_cc_impl"]),
+            deps = cc_deps + ["@com_google_protobuf//:protobuf_headers"] + if_static([name + "_cc_impl"]),
             testonly = testonly,
             visibility = visibility,
         )
         native.cc_library(
             name = cc_name + "_impl",
-            deps = [s + "_impl" for s in cc_deps] + ["@protobuf_archive//:cc_wkt_protos"],
+            deps = [s + "_impl" for s in cc_deps] + ["@com_google_protobuf//:cc_wkt_protos"],
         )
 
         return
@@ -362,8 +362,8 @@ def tf_proto_library_cc(
         testonly = testonly,
         srcs = srcs,
         cc_libs = cc_libs + if_static(
-            ["@protobuf_archive//:protobuf"],
-            ["@protobuf_archive//:protobuf_headers"],
+            ["@com_google_protobuf//:protobuf"],
+            ["@com_google_protobuf//:protobuf_headers"],
         ),
         copts = if_not_windows([
             "-Wno-unknown-warning-option",
@@ -371,10 +371,10 @@ def tf_proto_library_cc(
             "-Wno-sign-compare",
         ]),
         default_header = default_header,
-        protoc = "@protobuf_archive//:protoc",
+        protoc = "@com_google_protobuf//:protoc",
         use_grpc_plugin = use_grpc_plugin,
         visibility = visibility,
-        deps = cc_deps + ["@protobuf_archive//:cc_wkt_protos"],
+        deps = cc_deps + ["@com_google_protobuf//:cc_wkt_protos"],
     )
 
 def tf_proto_library_py(
@@ -393,13 +393,13 @@ def tf_proto_library_py(
         # libraries containing all the sources.
         proto_gen(
             name = py_name + "_genproto",
-            protoc = "@protobuf_archive//:protoc",
+            protoc = "@com_google_protobuf//:protoc",
             visibility = ["//visibility:public"],
             deps = [s + "_genproto" for s in py_deps],
         )
         native.py_library(
             name = py_name,
-            deps = py_deps + ["@protobuf_archive//:protobuf_python"],
+            deps = py_deps + ["@com_google_protobuf//:protobuf_python"],
             testonly = testonly,
             visibility = visibility,
         )
@@ -409,12 +409,12 @@ def tf_proto_library_py(
         name = py_name,
         testonly = testonly,
         srcs = srcs,
-        default_runtime = "@protobuf_archive//:protobuf_python",
-        protoc = "@protobuf_archive//:protoc",
+        default_runtime = "@com_google_protobuf//:protobuf_python",
+        protoc = "@com_google_protobuf//:protoc",
         srcs_version = srcs_version,
         use_grpc_plugin = use_grpc_plugin,
         visibility = visibility,
-        deps = deps + py_deps + ["@protobuf_archive//:protobuf_python"],
+        deps = deps + py_deps + ["@com_google_protobuf//:protobuf_python"],
     )
 
 def tf_jspb_proto_library(**kwargs):
@@ -689,7 +689,7 @@ def tf_lib_proto_parsing_deps():
 
 def tf_lib_proto_compiler_deps():
     return [
-        "@protobuf_archive//:protoc_lib",
+        "@com_google_protobuf//:protoc_lib",
     ]
 
 def tf_additional_verbs_lib_defines():

--- a/tensorflow/core/platform/s3/BUILD
+++ b/tensorflow/core/platform/s3/BUILD
@@ -34,8 +34,8 @@ tf_cc_binary(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "@aws",
+        "@com_google_protobuf//:protobuf_headers",
         "@curl",
-        "@protobuf_archive//:protobuf_headers",
     ],
 )
 

--- a/tensorflow/go/genop/generate.sh
+++ b/tensorflow/go/genop/generate.sh
@@ -41,7 +41,7 @@ then
   then
     echo "Protocol buffer compiler protoc not found in PATH or in ${PROTOC}"
     echo "Perhaps build it using:"
-    echo "bazel build --config opt @protobuf_archive//:protoc"
+    echo "bazel build --config opt @com_google_protobuf//:protoc"
     exit 1
   fi
   PROTOC=$PATH_PROTOC

--- a/tensorflow/lite/toco/BUILD
+++ b/tensorflow/lite/toco/BUILD
@@ -163,7 +163,7 @@ cc_library(
     ],
     deps = [
         # Placeholder for internal file dependency.
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
         "//tensorflow/core:framework_lite",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
@@ -322,7 +322,7 @@ cc_library(
         ":toco_flags_proto_cc",
         ":toco_port",
         ":tooling_util",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "//tensorflow/core:core_cpu_lib",
@@ -376,8 +376,8 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/lite/kernels/internal:types",
         "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf_headers",
         "@com_googlesource_code_re2//:re2",
-        "@protobuf_archive//:protobuf_headers",
     ],
 )
 

--- a/tensorflow/lite/toco/tensorflow_graph_matching/BUILD
+++ b/tensorflow/lite/toco/tensorflow_graph_matching/BUILD
@@ -53,7 +53,7 @@ cc_library(
         "//tensorflow/lite/toco:model",
         "//tensorflow/lite/toco:toco_port",
         "//tensorflow/lite/toco:tooling_util",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
 )
 

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -464,7 +464,7 @@ tf_cc_shared_object(
     deps = [
         "//tensorflow/core:framework_headers_lib",
         "//third_party/eigen3",
-        "@protobuf_archive//:protobuf_headers",
+        "@com_google_protobuf//:protobuf_headers",
     ],
 )
 
@@ -3673,8 +3673,8 @@ py_library(
     ],
     deps = [
         "//third_party/py/numpy",
+        "@com_google_protobuf//:protobuf_python",
         "@org_python_pypi_backports_weakref",
-        "@protobuf_archive//:protobuf_python",
         "@six_archive//:six",
     ],
 )

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1419,7 +1419,7 @@ def cc_header_only_library(name, deps = [], includes = [], extra_deps = [], **kw
 
 def tf_custom_op_library_additional_deps():
     return [
-      "@protobuf_archive//:protobuf_headers",
+      "@com_google_protobuf//:protobuf_headers",
         clean_dep("//third_party/eigen3"),
         clean_dep("//tensorflow/core:framework_headers_lib"),
     ] + if_windows(["//tensorflow/python:pywrap_tensorflow_import_lib"])
@@ -1429,7 +1429,7 @@ def tf_custom_op_library_additional_deps():
 # exporting symbols from _pywrap_tensorflow.dll on Windows.
 def tf_custom_op_library_additional_deps_impl():
     return [
-      "@protobuf_archive//:protobuf",
+      "@com_google_protobuf//:protobuf",
       "@nsync//:nsync_cpp",
         # for //third_party/eigen3
         clean_dep("//third_party/eigen3"),

--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -133,7 +133,7 @@ genrule(
         "@nasm//:LICENSE",
         "@nsync//:LICENSE",
         "@png_archive//:LICENSE",
-        "@protobuf_archive//:LICENSE",
+        "@com_google_protobuf//:LICENSE",
         "@snappy//:COPYING",
         "@zlib_archive//:zlib.h",
     ] + select({
@@ -201,7 +201,7 @@ genrule(
         "@nasm//:LICENSE",
         "@nsync//:LICENSE",
         "@png_archive//:LICENSE",
-        "@protobuf_archive//:LICENSE",
+        "@com_google_protobuf//:LICENSE",
         "@snappy//:COPYING",
         "@zlib_archive//:zlib.h",
         "@grpc//:LICENSE",

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -160,7 +160,7 @@ filegroup(
         "@nsync//:LICENSE",
         "@pcre//:LICENCE",
         "@png_archive//:LICENSE",
-        "@protobuf_archive//:LICENSE",
+        "@com_google_protobuf//:LICENSE",
         "@six_archive//:LICENSE",
         "@snappy//:COPYING",
         "@swig//:LICENSE",

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -128,7 +128,7 @@ function prepare_src() {
   mkdir -p ${TMPDIR}/google
   mkdir -p ${TMPDIR}/third_party
   pushd ${RUNFILES%org_tensorflow} > /dev/null
-  for header in $(find protobuf_archive -name \*.h); do
+  for header in $(find com_google_protobuf -name \*.h); do
     mkdir -p "${TMPDIR}/google/$(dirname ${header})"
     cp "$header" "${TMPDIR}/google/$(dirname ${header})/"
   done

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -165,7 +165,7 @@ class InstallHeaders(Command):
     install_dir = os.path.join(self.install_dir, os.path.dirname(header))
     # Get rid of some extra intervening directories so we can have fewer
     # directories for -I
-    install_dir = re.sub('/google/protobuf_archive/src', '', install_dir)
+    install_dir = re.sub('/google/com_google_protobuf/src', '', install_dir)
 
     # Copy external code headers into tensorflow/include.
     # A symlink would do, but the wheel file that gets created ignores
@@ -230,7 +230,7 @@ else:
 headers = (
     list(find_files('*.h', 'tensorflow/core')) + list(
         find_files('*.h', 'tensorflow/stream_executor')) +
-    list(find_files('*.h', 'google/protobuf_archive/src')) + list(
+    list(find_files('*.h', 'google/com_google_protobuf/src')) + list(
         find_files('*', 'third_party/eigen3')) + list(
             find_files('*.h', 'tensorflow/include/external/com_google_absl')) +
     list(find_files('*.inc', 'tensorflow/include/external/com_google_absl')) +

--- a/tensorflow/tools/proto_text/BUILD
+++ b/tensorflow/tools/proto_text/BUILD
@@ -37,7 +37,7 @@ cc_binary(
     visibility = ["//tensorflow:internal"],
     deps = [
         ":gen_proto_text_functions_lib",
-        "@protobuf_archive//:protobuf",
+        "@com_google_protobuf//:protobuf",
         "//tensorflow/core:lib_proto_parsing",
         "//tensorflow/core:lib_proto_compiler",
     ] + if_ios(["//tensorflow/core/platform/default/build_config:logging"]),

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -355,24 +355,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
     PROTOBUF_STRIP_PREFIX = "protobuf-3.6.1"
 
     tf_http_archive(
-        name = "protobuf_archive",
-        sha256 = PROTOBUF_SHA256,
-        strip_prefix = PROTOBUF_STRIP_PREFIX,
-        urls = PROTOBUF_URLS,
-    )
-
-    # We need to import the protobuf library under the names com_google_protobuf
-    # and com_google_protobuf_cc to enable proto_library support in bazel.
-    # Unfortunately there is no way to alias http_archives at the moment.
-    tf_http_archive(
         name = "com_google_protobuf",
-        sha256 = PROTOBUF_SHA256,
-        strip_prefix = PROTOBUF_STRIP_PREFIX,
-        urls = PROTOBUF_URLS,
-    )
-
-    tf_http_archive(
-        name = "com_google_protobuf_cc",
         sha256 = PROTOBUF_SHA256,
         strip_prefix = PROTOBUF_STRIP_PREFIX,
         urls = PROTOBUF_URLS,
@@ -885,20 +868,20 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
     # Needed by gRPC
     native.bind(
         name = "protobuf",
-        actual = "@protobuf_archive//:protobuf",
+        actual = "@com_google_protobuf//:protobuf",
     )
 
     # gRPC expects //external:protobuf_clib and //external:protobuf_compiler
     # to point to Protobuf's compiler library.
     native.bind(
         name = "protobuf_clib",
-        actual = "@protobuf_archive//:protoc_lib",
+        actual = "@com_google_protobuf//:protoc_lib",
     )
 
     # Needed by gRPC
     native.bind(
         name = "protobuf_headers",
-        actual = "@protobuf_archive//:protobuf_headers",
+        actual = "@com_google_protobuf//:protobuf_headers",
     )
 
     # Needed by Protobuf

--- a/third_party/googleapis.BUILD
+++ b/third_party/googleapis.BUILD
@@ -16,7 +16,7 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
-load("@protobuf_archive//:protobuf.bzl", "cc_proto_library")
+load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library")
 
 cc_proto_library(
     name = "bigtable_protos",
@@ -38,8 +38,8 @@ cc_proto_library(
         "google/api/http.proto",
     ],
     include = ".",
-    protoc = "@protobuf_archive//:protoc",
-    default_runtime = "@protobuf_archive//:protobuf",
-    deps = ["@protobuf_archive//:cc_wkt_protos"],
+    protoc = "@com_google_protobuf//:protoc",
+    default_runtime = "@com_google_protobuf//:protobuf",
+    deps = ["@com_google_protobuf//:cc_wkt_protos"],
     use_grpc_plugin = True,
 )

--- a/third_party/pprof.BUILD
+++ b/third_party/pprof.BUILD
@@ -4,15 +4,15 @@ package(
 
 licenses(["notice"])  # MIT
 
-load("@protobuf_archive//:protobuf.bzl", "py_proto_library")
+load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 
 exports_files(["pprof/LICENSE"])
 
 py_proto_library(
     name = "pprof_proto_py",
     srcs = ["proto/profile.proto"],
-    default_runtime = "@protobuf_archive//:protobuf_python",
-    protoc = "@protobuf_archive//:protoc",
+    default_runtime = "@com_google_protobuf//:protobuf_python",
+    protoc = "@com_google_protobuf//:protoc",
     srcs_version = "PY2AND3",
-    deps = ["@protobuf_archive//:protobuf_python"],
+    deps = ["@com_google_protobuf//:protobuf_python"],
 )


### PR DESCRIPTION
- Always refer to protobuf as @com_google_protobuf rather than @protobuf_archive.
- Remove com_google_protobuf_cc, which is not required by modern Bazel versions.