### PR TITLE
Fix bug of declaring regularization loss multiple times when reusing PartitionedVariables in tf layers

### DIFF
--- a/tensorflow/python/layers/base.py
+++ b/tensorflow/python/layers/base.py
@@ -233,7 +233,7 @@ class Layer(base_layer.Layer):
             getter=vs.get_variable)
 
         if regularizer:
-          if context.executing_eagerly() or variable not in existing_variables:
+          if context.executing_eagerly() or _should_add_regularizer(variable, existing_variables):
             self._handle_weight_regularization(name, variable, regularizer)
 
         if init_graph is not None:
@@ -353,4 +353,13 @@ def _add_elements_to_collection(elements, collection_list):
     for element in elements:
       if element not in collection_set:
         collection.append(element)
+
+def _should_add_regularizer(variable, existing_variable_set):
+  if isinstance(variable, tf_variables.PartitionedVariable):
+    for var in variable._variable_list:
+      if var in existing_variable_set:
+        return False
+    return True
+  else:
+    return variable not in existing_variable_set
 

--- a/tensorflow/python/layers/base.py
+++ b/tensorflow/python/layers/base.py
@@ -233,7 +233,8 @@ class Layer(base_layer.Layer):
             getter=vs.get_variable)
 
         if regularizer:
-          if context.executing_eagerly() or _should_add_regularizer(variable, existing_variables):
+          if context.executing_eagerly() or _should_add_regularizer(
+              variable, existing_variables):
             self._handle_weight_regularization(name, variable, regularizer)
 
         if init_graph is not None:
@@ -355,11 +356,12 @@ def _add_elements_to_collection(elements, collection_list):
         collection.append(element)
 
 def _should_add_regularizer(variable, existing_variable_set):
+  result = True
   if isinstance(variable, tf_variables.PartitionedVariable):
-    for var in variable._variable_list:
+    for var in variable._get_variable_list():
       if var in existing_variable_set:
-        return False
-    return True
+        result = False
+        break
   else:
-    return variable not in existing_variable_set
-
+    result = variable not in existing_variable_set
+  return result

--- a/tensorflow/python/layers/base_test.py
+++ b/tensorflow/python/layers/base_test.py
@@ -30,6 +30,7 @@ from tensorflow.python.layers import core as core_layers
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import partitioned_variables
 from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import state_ops
 from tensorflow.python.ops import variable_scope
@@ -94,6 +95,20 @@ class BaseLayerTest(test.TestCase):
           initializer=init_ops.zeros_initializer(),
           regularizer=regularizer)
       self.assertEqual(len(layer.losses), 1)
+
+  def testReusePartitionedVaraiblesAndRegularizers(self):
+    regularizer = lambda x: math_ops.reduce_sum(x) * 1e-3
+    partitioner = partitioned_variables.fixed_size_partitioner(3)
+    for i in xrange(2):
+      with variable_scope.variable_scope(variable_scope.get_variable_scope(),
+                                         partitioner=partitioner,
+                                         reuse=False if i == 0 else True):
+        layer = base_layers.Layer(name='my_layer')
+        variable = layer.add_variable(
+            'reg_part_var', [4, 4],
+            initializer=init_ops.zeros_initializer(),
+            regularizer=regularizer)
+    self.assertEqual(len(ops.get_collection(ops.GraphKeys.REGULARIZATION_LOSSES)), 3)
 
   def testNoEagerActivityRegularizer(self):
     with context.eager_mode():


### PR DESCRIPTION
When reusing a variable in current variable scope, we should always reuse its regularization loss computation. But it will declare regularization loss multiple times when reusing PartitionedVariables in tf.layers.  For example:
```
import tensorflow as tf
partitioner = tf.fixed_size_partitioner(3)
l2_regularizer = tf.contrib.layers.l2_regularizer(0.001)
for i in xrange(2):
  with tf.variable_scope(tf.get_variable_scope(), partitioner=partitioner, reuse=False if i == 0 else True):
    inputs_tensor = tf.constant(1.0, shape=[100, 100])
    logits = tf.layers.dense(inputs_tensor, 256, use_bias=False, name="fc", kernel_regularizer=l2_regularizer)
print (tf.get_collection(tf.GraphKeys.REGULARIZATION_LOSSES))
```
This short program should get result 3 because the PartitionedVariable has 3 shards. However, it got 6.  To debug the source code, we found that there is no judgement on PartitionedVariables when declaring the regularization loss in /tensorflow/python/layers/base.py