### PR TITLE
document fix: correct code snippets to python3 style

### DIFF
--- a/tensorflow/docs_src/programmers_guide/tensors.md
+++ b/tensorflow/docs_src/programmers_guide/tensors.md
@@ -265,7 +265,7 @@ example:
 ```python
 constant = tf.constant([1, 2, 3])
 tensor = constant * constant
-print tensor.eval()
+print(tensor.eval())
 ```
 
 The `eval` method only works when a default `tf.Session` is active (see
@@ -306,8 +306,8 @@ Note that you rarely want to use the following pattern when printing a
 
 ``` python
 t = <<some tensorflow operation>>
-print t  # This will print the symbolic tensor when the graph is being built.
-         # This tensor does not have a value in this context.
+print(t)  # This will print the symbolic tensor when the graph is being built.
+          # This tensor does not have a value in this context.
 ```
 
 This code prints the `tf.Tensor` object (which represents deferred computation)


### PR DESCRIPTION
python code snippets in this doc [Tensors](https://www.tensorflow.org/programmers_guide/tensors) are still using python2 style print function:

```python
print tensor.eval()
```

while python3 style is used in other docs, such as [Introduction](https://www.tensorflow.org/programmers_guide/low_level_intro) and [Importing Data](https://www.tensorflow.org/programmers_guide/datasets):

```python
print(a)
```