### PR TITLE
Feature: Add reduce_average (weighted reduce_mean)

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1602,6 +1602,7 @@ def reduce_average(input_tensor,
       be x-D (in which case its rank x must equal the length of `axis`.
       And the length of each dimension must be the size of `input_tensor`
       along the corresponding axis) or of the same shape as `input_tensor`.
+      Must have the same type as `input_tensor`.
     keepdims: If true, retains reduced dimensions with length 1.
     name: A name for the operation (optional).
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -71,6 +71,87 @@ class ReduceTest(test_util.TensorFlowTestCase):
 
 
 @test_util.with_c_api
+class ReduceAverageTest(test_util.TensorFlowTestCase):
+
+  @test_util.run_in_graph_and_eager_modes()
+  def testReduceWithoutWeights(self):
+    x = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
+    with test_util.device(use_gpu=True):
+      y_tf = self.evaluate(math_ops.reduce_average(x))
+      self.assertEqual(y_tf, 3)
+
+    x = np.array([[1., 2., 3.], [4., 5., 6.]], dtype=np.float32)
+    with test_util.device(use_gpu=True):
+      y_tf = self.evaluate(math_ops.reduce_average(x))
+      self.assertEqual(y_tf, 3.5)
+
+@test_util.with_c_api
+class ReduceAverageTest(test_util.TensorFlowTestCase):
+
+  @test_util.run_in_graph_and_eager_modes()
+  def testReduceWithoutWeights(self):
+    x = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
+    with test_util.device(use_gpu=True):
+      y_tf = self.evaluate(math_ops.reduce_average(x))
+      self.assertEqual(y_tf, 3)
+
+    x = np.array([[1., 2., 3.], [4., 5., 6.]], dtype=np.float32)
+    with test_util.device(use_gpu=True):
+      y_tf = self.evaluate(math_ops.reduce_average(x))
+      self.assertEqual(y_tf, 3.5)
+
+  @test_util.run_in_graph_and_eager_modes()
+  def testReduceWeights(self):
+    x = np.array([[1., 2., 3.], [4., 5., 6.]], dtype=np.float32)
+    with test_util.device(use_gpu=True):
+      y_tf = self.evaluate(math_ops.reduce_average(
+        x, weights=[1., 2.], axis=0))
+      self.assertAllEqual(y_tf, [3., 4., 5.])
+      y_tf = self.evaluate(math_ops.reduce_average(
+        x, weights=[0., 0., 1.], axis=1))
+      self.assertAllEqual(y_tf, [3., 6.])
+      # 2D weights
+      y_tf = self.evaluate(math_ops.reduce_average(
+        x, weights=[[0., 0., 1.], [0., 0., 2.]], axis=1))
+      self.assertAllEqual(y_tf, [3., 6.])
+      y_tf = self.evaluate(math_ops.reduce_average(
+        x, weights=[[0., 0., 1.], [0., 0., 2.]]))
+      self.assertEqual(y_tf, 5.)
+
+  @test_util.run_in_graph_and_eager_modes()
+  def testReduceWeightswithAxes(self):
+    x = np.arange(6, dtype=np.float32).reshape((1, 3, 2))
+    with test_util.device(use_gpu=True):
+      # 3D input, 2D weights, 2 axes
+      y_tf = self.evaluate(math_ops.reduce_average(
+        x, weights=[[0., 1.]], axis=(0, 2)))
+      self.assertAllEqual(y_tf, [1., 3., 5.])
+      # 3D input, 3D weights, 2 axes
+      w = x.copy()
+      y_tf = self.evaluate(math_ops.reduce_average(
+        x, weights=w, axis=(0, 1)))
+      expected = np.array([3.33333333, 3.88888889], dtype=np.float32)
+      self.assertAllClose(y_tf, expected)
+
+  @test_util.run_in_graph_and_eager_modes()
+  def testReduceInvalidWeightsOrAxes(self):
+    x = np.array([[1., 2., 3.], [4., 5., 6.]], dtype=np.float32)
+    with self.assertRaisesRegexp(ValueError, "Axis must be specified"):
+      math_ops.reduce_average(x, weights=[0., 0., 1.])
+    with self.assertRaisesRegexp(ValueError,
+      "weights not compatible with input_tensor"):
+      math_ops.reduce_average(x, weights=[0., 0., 1.], axis=0)
+    
+    x = np.arange(6, dtype=np.float32).reshape((1, 3, 2))
+    # 1D weights not compatible with 2 axes
+    with self.assertRaisesRegexp(ValueError, "should equal length of"):
+      math_ops.reduce_average(x, weights=[0., 1.], axis=(0, 1))
+    with self.assertRaisesRegexp(ValueError,
+      "weights not compatible with input_tensor"):
+      math_ops.reduce_average(x, weights=[[0., 1.]], axis=(2, 0))
+
+
+@test_util.with_c_api
 class LogSumExpTest(test_util.TensorFlowTestCase):
 
   def testReduceLogSumExp(self):


### PR DESCRIPTION
Add `tf.reduce_average` according to issue #7422

In this issue, some people doubt why this function is needed. I think broadcasting `weights` and corresponding `axis` is complex enough and worth a built-in function.

`np.average` is also contributed by me. Related [Issue](https://github.com/numpy/numpy/issues/10989) and [PR](https://github.com/numpy/numpy/pull/10994).  
I add support for any case where `len(axis) == rank(weights)`,  and it's the same in `tf.reduce_average` to keep compatibility with numpy.

A unit test is attached.