### PR TITLE
INTEL MKL: Fix concat related issues

### DIFF
--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -712,33 +712,41 @@ template <typename T> class MklDnnData;
 template <typename T>
 inline Tensor ConvertMklToTF(OpKernelContext* context, const Tensor& mkl_tensor,
                              const MklDnnShape& mkl_shape) {
-  if (!mkl_shape.IsMklTensor())
-    return mkl_tensor;  // return input since it is already TF tensor
-
   Tensor output_tensor;
-  TensorShape output_shape = mkl_shape.GetTfShape();;
+  try {
+    if (!mkl_shape.IsMklTensor())
+      return mkl_tensor;  // return input since it is already TF tensor
 
-  // Allocate output tensor.
-  context->allocate_temp(DataTypeToEnum<T>::v(), output_shape, &output_tensor);
+    TensorShape output_shape = mkl_shape.GetTfShape();;
 
-  auto cpu_engine = engine(engine::cpu, 0);
-  MklDnnData<T> input(&cpu_engine);
+    // Allocate output tensor.
+    context->allocate_temp(DataTypeToEnum<T>::v(),
+        output_shape, &output_tensor);
 
-  // Get Mkl layout of input tensor.
-  auto input_mkl_md = mkl_shape.GetMklLayout();
-  auto output_tf_md = mkl_shape.GetTfLayout();
-  auto output_tf_pd = memory::primitive_desc(output_tf_md, cpu_engine);
-  input.SetUsrMem(input_mkl_md, &mkl_tensor);
+    auto cpu_engine = engine(engine::cpu, 0);
+    MklDnnData<T> input(&cpu_engine);
 
-  // reorder
-  if (input.IsReorderNeeded(output_tf_pd)) {
-    std::vector<primitive> net;
-    CHECK_EQ(input.CheckReorderToOpMem(output_tf_pd, &output_tensor, &net),
+    // Get Mkl layout of input tensor.
+    auto input_mkl_md = mkl_shape.GetMklLayout();
+    auto output_tf_md = mkl_shape.GetTfLayout();
+    auto output_tf_pd = memory::primitive_desc(output_tf_md, cpu_engine);
+    input.SetUsrMem(input_mkl_md, &mkl_tensor);
+
+    // reorder
+    if (input.IsReorderNeeded(output_tf_pd)) {
+      std::vector<primitive> net;
+      CHECK_EQ(input.CheckReorderToOpMem(output_tf_pd, &output_tensor, &net),
              true);
-    stream(stream::kind::eager).submit(net).wait();
-  } else {
-    // If not, just forward input tensor to output tensor.
-    CHECK(output_tensor.CopyFrom(mkl_tensor, output_shape));
+      stream(stream::kind::eager).submit(net).wait();
+    } else {
+      // If not, just forward input tensor to output tensor.
+      CHECK(output_tensor.CopyFrom(mkl_tensor, output_shape));
+    }
+  } catch (mkldnn::error& e) {
+    string error_msg = "Status: " + std::to_string(e.status) +
+                       ", message: " + string(e.message) + ", in file " +
+                       string(__FILE__) + ":" + std::to_string(__LINE__);
+    LOG(FATAL) << "Operation received an exception: " << error_msg;
   }
   return output_tensor;
 }


### PR DESCRIPTION
Fix the following concat related issue (Mkl_Concat Op)
 •	Inputs with both TF and MKL layouts  (ref public escalation tensorflow/tensorflow#17494)
•	Inputs with one or more EMPTY tensor(s), that is tensors with ndims==0
•	In case of ALL tensors are in MKL layout but with different data formats, , “reorder” to 
        the most common format for better performance.
