### PR TITLE
Canned estimators use 'careful_interpolation' rule to compute PR-AUCs

### DIFF
--- a/tensorflow/python/estimator/canned/head.py
+++ b/tensorflow/python/estimator/canned/head.py
@@ -494,7 +494,12 @@ def _auc(labels, predictions, weights=None, curve='ROC', name=None):
     predictions = math_ops.to_float(predictions, name='predictions')
     if weights is not None:
       weights = weights_broadcast_ops.broadcast_weights(weights, predictions)
-    return metrics_lib.auc(
+    if curve == 'PR':
+      return metrics_lib.auc(
+        labels=labels, predictions=predictions, weights=weights, curve=curve,
+        name=scope, summation_method='careful_interpolation')
+    else:
+      return metrics_lib.auc(
         labels=labels, predictions=predictions, weights=weights, curve=curve,
         name=scope)
 


### PR DESCRIPTION
Fix https://github.com/tensorflow/tensorflow/issues/19080