### PR TITLE
fix training_hook and training_chief_hook processing of distributed training

### DIFF
--- a/tensorflow/python/estimator/estimator.py
+++ b/tensorflow/python/estimator/estimator.py
@@ -957,18 +957,17 @@ class Estimator(object):
             init_fn=init_fn)
 
         def get_hooks_from_the_first_device(per_device_hooks):
-          hooks_list = self._distribution.unwrap(per_device_hooks)
-          assert hooks_list
-          return hooks_list[0]
+          hooks_list = []
+          for per_device_hook in per_device_hooks:
+            hooks = self._distribution.unwrap(per_device_hook)
+            assert hooks
+            hooks_list.append(hooks[0])
+          return hooks_list
 
-        training_hooks = [
-            get_hooks_from_the_first_device(per_device_hook)
-            for per_device_hook in grouped_estimator_spec.training_hooks
-        ]
-        training_chief_hooks = [
-            get_hooks_from_the_first_device(per_device_chief_hook)
-            for per_device_chief_hook in grouped_estimator_spec.training_chief_hooks
-        ]
+        training_hooks = get_hooks_from_the_first_device(
+            grouped_estimator_spec.training_hooks)
+        training_chief_hooks = get_hooks_from_the_first_device(
+            grouped_estimator_spec.training_chief_hooks)
 
         estimator_spec = model_fn_lib.EstimatorSpec(
             mode=grouped_estimator_spec.mode,

--- a/tensorflow/python/estimator/estimator.py
+++ b/tensorflow/python/estimator/estimator.py
@@ -961,10 +961,14 @@ class Estimator(object):
           assert hooks_list
           return hooks_list[0]
 
-        training_hooks = get_hooks_from_the_first_device(
-            grouped_estimator_spec.training_hooks)
-        training_chief_hooks = get_hooks_from_the_first_device(
-            grouped_estimator_spec.training_chief_hooks)
+        training_hooks = [
+            get_hooks_from_the_first_device(per_device_hook)
+            for per_device_hook in grouped_estimator_spec.training_hooks
+        ]
+        training_chief_hooks = [
+            get_hooks_from_the_first_device(per_device_chief_hook)
+            for per_device_chief_hook in grouped_estimator_spec.training_chief_hooks
+        ]
 
         estimator_spec = model_fn_lib.EstimatorSpec(
             mode=grouped_estimator_spec.mode,


### PR DESCRIPTION
The changes are listed as followed.
```python3
"""
training_hooks = get_hooks_from_the_first_device(
    grouped_estimator_spec.training_hooks)
training_chief_hooks = get_hooks_from_the_first_device(
    grouped_estimator_spec.training_chief_hooks)
"""
training_hooks = [
    get_hooks_from_the_first_device(per_device_hook)
    for per_device_hook in grouped_estimator_spec.training_hooks
]
training_chief_hooks = [
    get_hooks_from_the_first_device(per_device_chief_hook)
    for per_device_chief_hook in grouped_estimator_spec.training_chief_hooks
]
```
`grouped_estimator_spec.training_hooks` is a `list` of `PerDevice`, and function `get_hooks_from_the_first_device` is only able to pick head item of *one* `PerDevice`, thus the old version doesn't work and keeps the PerDevice, leading to such errors:
```
TypeError: All hooks must be SessionRunHook instances, given: PerDevice:{'/job:localhost/replica:0/task:0/device:GPU:2': <XXXXXHook object at 0x7fc6f43f3080>, '/job:localhost/replica:0/task:0/device:GPU:0': <XXXXXHook object at 0x7fc71430bf60>, /job:localhost/replica:0/task:0/device:GPU:3': <XXXXXHook object at 0x7fc6b467e080>, '/job:localhost/replica:0/task:0/device:GPU:1': <XXXXXHook object at 0x7fc70430d048>}
```
(XXXXXHook inherits from SessionRunHook, and is hidden for some reason.)