### PR TITLE
Include ThenBlasGemm

### DIFF
--- a/tensorflow/contrib/cmake/tools/create_def_file.py
+++ b/tensorflow/contrib/cmake/tools/create_def_file.py
@@ -56,7 +56,8 @@ INCLUDEPRE_RE = re.compile(r"google::protobuf::internal::ExplicitlyConstructed|"
                            r"tensorflow::ops::internal::Enter|"
                            r"tensorflow::strings::internal::AppendPieces|"
                            r"tensorflow::strings::internal::CatPieces|"
-                           r"tensorflow::io::internal::JoinPathImpl")
+                           r"tensorflow::io::internal::JoinPathImpl|"
+						   r"stream_executor::Stream::ThenBlasGemm")
 
 # Include if matched after exclude
 INCLUDE_RE = re.compile(r"^(TF_\w*)$|"
@@ -64,7 +65,8 @@ INCLUDE_RE = re.compile(r"^(TF_\w*)$|"
                         r"tensorflow::|"
                         r"functor::|"
                         r"\?nsync_|"
-                        r"perftools::gputools")
+                        r"perftools::gputools|"
+						r"stream_executor::Stream::ThenBlasGemm")
 
 # We want to identify data members explicitly in the DEF file, so that no one
 # can implicitly link against the DLL if they use one of the variables exported

--- a/tensorflow/contrib/cmake/tools/create_def_file.py
+++ b/tensorflow/contrib/cmake/tools/create_def_file.py
@@ -57,7 +57,7 @@ INCLUDEPRE_RE = re.compile(r"google::protobuf::internal::ExplicitlyConstructed|"
                            r"tensorflow::strings::internal::AppendPieces|"
                            r"tensorflow::strings::internal::CatPieces|"
                            r"tensorflow::io::internal::JoinPathImpl|"
-						   r"stream_executor::Stream::ThenBlasGemm")
+                           r"stream_executor::Stream::ThenBlasGemm")
 
 # Include if matched after exclude
 INCLUDE_RE = re.compile(r"^(TF_\w*)$|"
@@ -66,7 +66,7 @@ INCLUDE_RE = re.compile(r"^(TF_\w*)$|"
                         r"functor::|"
                         r"\?nsync_|"
                         r"perftools::gputools|"
-						r"stream_executor::Stream::ThenBlasGemm")
+                        r"stream_executor::Stream::ThenBlasGemm")
 
 # We want to identify data members explicitly in the DEF file, so that no one
 # can implicitly link against the DLL if they use one of the variables exported


### PR DESCRIPTION
Hi everybody,

I'm getting an unresolved external symbol `ThenBlasGemm` when compiling for GPU with CMake using MSVC 2015. This function isn't picked up by the script to create the def file for the DLL, so it isn't being exported. This PR just adds that function to the regex so the build works. Linker error below.

Does Windows CMake GPU not go through CI? I'm curious why this hasn't come up before.

Cheers

```
[D:\Projects\tensorflow\tensorflow\contrib\cmake\buildout\_gru_ops.vcxproj]
   199>blas_gemm.obj : error LNK2019: unresolved external symbol "public: class stream_executor::Stream & __cdecl stream_executor::Stream::ThenBlasGemm(enum stream_executor::blas::Transpose,enum stream_executor::blas::Transpose,unsigned __int64,unsigned __int64,unsigned __int64,double,class stream_executor::DeviceMemory<double> const &,int,class stream_executor::DeviceMemory<double> const &,int,double,class stream_executor::DeviceMemory<double> *,int)" (?ThenBlasGemm@Stream@stream_executor@@QEAAAEAV12@W4Transpose@blas@2@0_K11NAEBV?$DeviceMemory@N@2@H2HNPEAV52@H@Z) referenced in function "public: void __cdecl tensorflow::functor::TensorCuBlasGemm<double>::operator()(class tensorflow::OpKernelContext *,bool,bool,unsigned __int64,unsigned __int64,unsigned __int64,double,double const *,int,double const *,int,double,double *,int)" (??R?$TensorCuBlasGemm@N@functor@tensorflow@@QEAAXPEAVOpKernelContext@2@_N1_K22NPEBNH3HNPEANH@Z) 
```