### PR TITLE
Use Configuration instead of CMAKE_BUILD_TYPE in MSVC

### DIFF
--- a/tensorflow/contrib/cmake/tf_cc_ops.cmake
+++ b/tensorflow/contrib/cmake/tf_cc_ops.cmake
@@ -150,7 +150,7 @@ add_dependencies(tf_cc tf_cc_framework tf_cc_ops)
 
 if (WIN32)
   if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
-    set (pywrap_tensorflow_lib "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/pywrap_tensorflow_internal.lib")
+    set (pywrap_tensorflow_lib "${CMAKE_CURRENT_BINARY_DIR}/$(Configuration)/pywrap_tensorflow_internal.lib")
   else()
     set (pywrap_tensorflow_lib "${CMAKE_CURRENT_BINARY_DIR}/pywrap_tensorflow_internal.lib")
   endif()

--- a/tensorflow/contrib/cmake/tf_python.cmake
+++ b/tensorflow/contrib/cmake/tf_python.cmake
@@ -549,7 +549,7 @@ if(WIN32)
     )
 
     if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
-        set(pywrap_tensorflow_deffile "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/pywrap_tensorflow.def")
+        set(pywrap_tensorflow_deffile "${CMAKE_CURRENT_BINARY_DIR}/$(Configuration)/pywrap_tensorflow.def")
     else()
         set(pywrap_tensorflow_deffile "${CMAKE_CURRENT_BINARY_DIR}/pywrap_tensorflow.def")
     endif()

--- a/tensorflow/contrib/cmake/tf_shared_lib.cmake
+++ b/tensorflow/contrib/cmake/tf_shared_lib.cmake
@@ -47,7 +47,7 @@ if(WIN32)
   )
 
   if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
-    set(tensorflow_deffile "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/tensorflow.def")
+    set(tensorflow_deffile "${CMAKE_CURRENT_BINARY_DIR}/$(Configuration)/tensorflow.def")
   else()
     set(tensorflow_deffile "${CMAKE_CURRENT_BINARY_DIR}/tensorflow.def")
   endif()


### PR DESCRIPTION
This uses the `Configuration` passed to MSBuild instead of `CMAKE_BUILD_TYPE`. You can actually omit `CMAKE_BUILD_TYPE` during configuration, and the `Configuration` selected during build is used.

Several of the CMake scripts used `Configuration`, several used `CMAKE_BUILD_TYPE`, so this is just making things consistent for MSVC.

One less parameter to worry about during configuration and makes it possible to build debug and release from a single configuration.