### PR TITLE
[tfgan] Add discriminator and generator losses to estimator eval_metrics

### DIFF
--- a/tensorflow/contrib/gan/python/estimator/python/gan_estimator_test.py
+++ b/tensorflow/contrib/gan/python/estimator/python/gan_estimator_test.py
@@ -213,6 +213,8 @@ class GANEstimatorIntegrationTest(test.TestCase):
     scores = est.evaluate(eval_input_fn)
     self.assertEqual(num_steps, scores[ops.GraphKeys.GLOBAL_STEP])
     self.assertIn('loss', six.iterkeys(scores))
+    self.assertEqual(scores['discriminator_loss'] + scores['generator_loss'],
+                     scores['loss'])
 
     # PREDICT
     predictions = np.array([x for x in est.predict(predict_input_fn)])


### PR DESCRIPTION
This PR adds discriminator and generator losses to estimator `eval_metrics`.

I used the same approach as done for [canned estimators](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/estimator/canned/head.py#L634-L661) though I'm not entirely sure if the `name_scope` is correctly used in this case.