### PR TITLE
Update zlib version for cmake build

### DIFF
--- a/tensorflow/contrib/cmake/external/zlib.cmake
+++ b/tensorflow/contrib/cmake/external/zlib.cmake
@@ -31,7 +31,8 @@ else (systemlib_ZLIB)
   set(ZLIB_URL https://github.com/madler/zlib)
   set(ZLIB_BUILD ${CMAKE_CURRENT_BINARY_DIR}/zlib/src/zlib)
   set(ZLIB_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/zlib/install)
-  set(ZLIB_TAG 50893291621658f355bc5b4d450a8d06a563053d)
+  # Match zlib version in tensorflow/workspace.bzl
+  set(ZLIB_TAG v1.2.11)
 
   if(WIN32)
     if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")


### PR DESCRIPTION
In cmake build, the zlib version was `50893291621658f355bc5b4d450a8d06a563053d`
which is equal to v1.2.8. This creates a discrepancy between cmake and bazel build.

This fix updates the zlib version to v1.2.11 that syncs with bazel build.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>