### PR TITLE
[INTEL MKL] Fixes a failure in //tensorflow/python/profiler:model_analyzer_test.

### DIFF
--- a/tensorflow/python/profiler/model_analyzer_test.py
+++ b/tensorflow/python/profiler/model_analyzer_test.py
@@ -232,7 +232,7 @@ class PrintModelAnalysisTest(test.TestCase):
 
         self.assertLess(0, tfprof_node.total_exec_micros)
         self.assertEqual(2844, tfprof_node.total_parameters)
-        self.assertLess(145660, tfprof_node.total_float_ops)
+        self.assertLess(101600, tfprof_node.total_float_ops)
         self.assertEqual(8, len(tfprof_node.children))
         self.assertEqual('_TFProfRoot', tfprof_node.name)
         self.assertEqual(

--- a/tensorflow/python/profiler/model_analyzer_test.py
+++ b/tensorflow/python/profiler/model_analyzer_test.py
@@ -235,9 +235,9 @@ class PrintModelAnalysisTest(test.TestCase):
         #The graph is modifed when MKL is enabled,total_float_ops will
         #be different
         if test_util.IsMklEnabled():
-            self.assertLess(101600, tfprof_node.total_float_ops)
+          self.assertLess(101600, tfprof_node.total_float_ops)
         else:
-            self.assertLess(145660, tfprof_node.total_float_ops)
+          self.assertLess(145660, tfprof_node.total_float_ops)
         self.assertEqual(8, len(tfprof_node.children))
         self.assertEqual('_TFProfRoot', tfprof_node.name)
         self.assertEqual(

--- a/tensorflow/python/profiler/model_analyzer_test.py
+++ b/tensorflow/python/profiler/model_analyzer_test.py
@@ -232,7 +232,12 @@ class PrintModelAnalysisTest(test.TestCase):
 
         self.assertLess(0, tfprof_node.total_exec_micros)
         self.assertEqual(2844, tfprof_node.total_parameters)
-        self.assertLess(101600, tfprof_node.total_float_ops)
+        #The graph is modifed when MKL is enabled,total_float_ops will
+        #be different
+        if test_util.IsMklEnabled():
+            self.assertLess(101600, tfprof_node.total_float_ops)
+        else:
+            self.assertLess(145660, tfprof_node.total_float_ops)
         self.assertEqual(8, len(tfprof_node.children))
         self.assertEqual('_TFProfRoot', tfprof_node.name)
         self.assertEqual(


### PR DESCRIPTION
 Modified  testComplexCodeView to look for lower total_float_ops. The value of total_float_ops is lower when Tensorflow is compiled with Intel MKL.