### PR TITLE
Fix 2 typos in documents

### DIFF
--- a/tensorflow/docs_src/programmers_guide/variables.md
+++ b/tensorflow/docs_src/programmers_guide/variables.md
@@ -237,7 +237,7 @@ TensorFlow supports two ways of sharing variables:
 While code which explicitly passes variables around is very clear, it is
 sometimes convenient to write TensorFlow functions that implicitly use
 variables in their implementations. Most of the functional layers from
-`tf.layer` use this approach, as well as all `tf.metrics`, and a few other
+`tf.layers` use this approach, as well as all `tf.metrics`, and a few other
 library utilities.
 
 Variable scopes allow you to control variable reuse when calling functions which

--- a/tensorflow/docs_src/tutorials/layers.md
+++ b/tensorflow/docs_src/tutorials/layers.md
@@ -209,7 +209,6 @@ for two-dimensional image data expect input tensors to have a shape of
 *   _`channels`_. Number of color channels in the example images. For color
     images, the number of channels is 3 (red, green, blue). For monochrome
     images, there is just 1 channel (black).
-*   _`image_height`_. Height of the example images.
 *   _`data_format`_. A string, one of `channels_last` (default) or `channels_first`.
       `channels_last` corresponds to inputs with shape
       `(batch, ..., channels)` while `channels_first` corresponds to


### PR DESCRIPTION
1. In the line 240 of the [programmer_guide/variables.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/programmers_guide/variables.md), the name of API `tf.layer` is wrong, should be `tf.layers`;
2. The line 212 of the [tutorials/layers.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/docs_src/tutorials/layers.md) is duplicated, which already apears in the line 207.