### PR TITLE
Enable test case for float64 with conv1d

### DIFF
--- a/tensorflow/python/kernel_tests/conv1d_test.py
+++ b/tensorflow/python/kernel_tests/conv1d_test.py
@@ -31,9 +31,7 @@ class Conv1DTest(test.TestCase):
 
   def testBasic(self):
     """Test that argument passing to conv1d is handled properly."""
-    # TODO(yongtang): dtypes.float64 can only be enabled once conv2d support
-    # dtypes.float64, as conv1d implicitly calls conv2d after expand_dims.
-    for dtype in [dtypes.float16, dtypes.float32]:
+    for dtype in [dtypes.float16, dtypes.float32, dtypes.float64]:
       x = constant_op.constant([1, 2, 3, 4], dtype=dtype)
       x = array_ops.expand_dims(x, 0)  # Add batch dimension
       x = array_ops.expand_dims(x, 2)  # And depth dimension


### PR DESCRIPTION
The float64 for conv2d support has been added to tensorflow in e3468b56d323783fdfb79fa2d6c24effc58bcaa9. (Thanks brianwa84!)
Since conv1d implementation invokes conv2d, the float64 support for conv1d is supported now as well.

This fix adds the test case for float64 support of conv1d and removes the TODO.

This fix fixes #19175.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>