### PR TITLE
[Slim] Fix default value for parameter in tfexample_decoder.BoundingBox

### DIFF
--- a/tensorflow/contrib/slim/python/slim/data/tfexample_decoder.py
+++ b/tensorflow/contrib/slim/python/slim/data/tfexample_decoder.py
@@ -102,7 +102,7 @@ class BoundingBox(ItemHandler):
   """An ItemHandler that concatenates a set of parsed Tensors to Bounding Boxes.
   """
 
-  def __init__(self, keys=None, prefix=None):
+  def __init__(self, keys=None, prefix=''):
     """Initialize the bounding box handler.
 
     Args:


### PR DESCRIPTION
When not providing any prefix to [`slim.tfexample_decoder.BoundingBox.__init__`,](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/slim/python/slim/data/tfexample_decoder.py) the default value of `None` for the prefix would raise the error 

> TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

, because of the line `self._full_keys = [prefix + k for k in keys]`. By changing the default parameter to an empty string, this error is resolved.