### PR TITLE
Use passed name for leaky relu tensor op

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1601,7 +1601,7 @@ def leaky_relu(features, alpha=0.2, name=None):
     if features.dtype.is_integer:
       features = math_ops.to_float(features)
     alpha = ops.convert_to_tensor(alpha, dtype=features.dtype, name="alpha")
-    return math_ops.maximum(alpha * features, features)
+    return math_ops.maximum(alpha * features, features, name=name)
 
 
 def _flatten_outer_dims(logits):

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1596,7 +1596,7 @@ def leaky_relu(features, alpha=0.2, name=None):
   Returns:
     The activation value.
   """
-  with ops.name_scope(name, "LeakyRelu", [features, alpha]):
+  with ops.name_scope(name, "LeakyRelu", [features, alpha]) as name:
     features = ops.convert_to_tensor(features, name="features")
     if features.dtype.is_integer:
       features = math_ops.to_float(features)

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -964,9 +964,12 @@ class LeakyReluTest(test_lib.TestCase):
 
   def testName(self):
     np_values = np.array([-2, -1, 0, 1, 2], dtype=np.float64)
-    outputs_with_name_set = nn_ops.leaky_relu(constant_op.constant(np_values), name='test_relu_op')
+    outputs_with_name_set = nn_ops.leaky_relu(
+        constant_op.constant(np_values),
+        name='test_relu_op')
     self.assertEqual(outputs_with_name_set.name, 'test_relu_op:0')
-    outputs_without_name_set = nn_ops.leaky_relu(constant_op.constant(np_values))
+    outputs_without_name_set = nn_ops.leaky_relu(
+        constant_op.constant(np_values))
     self.assertEqual(outputs_without_name_set.name, 'LeakyRelu:0')
 
 

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -962,6 +962,13 @@ class LeakyReluTest(test_lib.TestCase):
       self.assertAllClose(
           outputs, [-0.4, -0.2, 0.0, 1.0, 2.0], rtol=tol, atol=tol)
 
+  def testName(self):
+    np_values = np.array([-2, -1, 0, 1, 2], dtype=np.float64)
+    outputs_with_name_set = np.ops.leaky_relu(constant_op.constant(np_values), name='test_relu_op')
+    self.assertEqual(outputs_with_name_set.name, 'test_relu_op:0')
+    outputs_without_name_set = np.ops.leaky_relu(constant_op.constant(np_values))
+    self.assertEqual(outputs_without_name_set.name, 'LeakyRelu:0')
+
 
 class SwishTest(test_lib.TestCase):
 

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -964,9 +964,9 @@ class LeakyReluTest(test_lib.TestCase):
 
   def testName(self):
     np_values = np.array([-2, -1, 0, 1, 2], dtype=np.float64)
-    outputs_with_name_set = np.ops.leaky_relu(constant_op.constant(np_values), name='test_relu_op')
+    outputs_with_name_set = nn_ops.leaky_relu(constant_op.constant(np_values), name='test_relu_op')
     self.assertEqual(outputs_with_name_set.name, 'test_relu_op:0')
-    outputs_without_name_set = np.ops.leaky_relu(constant_op.constant(np_values))
+    outputs_without_name_set = nn_ops.leaky_relu(constant_op.constant(np_values))
     self.assertEqual(outputs_without_name_set.name, 'LeakyRelu:0')
 
 


### PR DESCRIPTION
I was experimenting with different activation functions for the final layer of my graph recently when I noticed that the output graph was failing to save because it couldn't find a tensor by a name I had provided, e.g. (`my_final_tensor_op`).

It worked correctly with an activation function like `tf.nn.sigmoid`:
```
import tensorflow as tf
import numpy as np

sample_values = np.array([1.0, 2.0, 3.0], dtype=np.float64)
sigmoid_tensor = tf.nn.sigmoid(sample_values, name='my_final_tensor_op')
sigmoid_tensor.name
>>> 'my_final_tensor_op:0'
```

But for `tf.nn.leaky_relu` I noticed that a `/Maximum` gets appended to whatever `name` value is passed:
```
import tensorflow as tf
import numpy as np

sample_values = np.array([1.0, 2.0, 3.0], dtype=np.float64)
leaky_relu_tensor = tf.nn.leaky_relu(sample_values, name='my_final_tensor_op')
leaky_relu_tensor.name
>>> 'my_final_tensor_op/Maximum:0'
```

I suspect the reason why is that the `name` parameter [is not passed in the call](https://github.com/tensorflow/tensorflow/blob/f91bd2f8c4b263dd5460e4398b94ad4823ce7a18/tensorflow/python/ops/nn_ops.py#L1604) to the `math_ops.maximum` function:
```
return math_ops.maximum(alpha * features, features)
```

Compare this to the case of `tf.nn.sigmoid`, which [does pass in](https://github.com/tensorflow/tensorflow/blob/f91bd2f8c4b263dd5460e4398b94ad4823ce7a18/tensorflow/python/ops/math_ops.py#L2342) the `name` parameter into the function call that it returns:
```
return gen_math_ops.sigmoid(x, name=name)
```

This PR makes the change to have the `leaky_relu` function pass `name` to the `math_ops.maximum` function so that the desired name for the op carries down. I also added a unit test that addresses this specific functionality.

One potential issue that could come up is if there's a lot of existing code that expects the `/Maximum` string to be appended, such as in the case where no `name` is set and the tensor op's name becomes `LeakyRelu/Maximum:0`. If that's the case, I would at least like to change the method's documentation so that the caller is aware of the `/Maximum` string concatenation side effect.