### PR TITLE
Add `AppendFloat16ArrayToTensorProto` to acclerate `tf.constant` for float16

### DIFF
--- a/tensorflow/python/framework/fast_tensor_util.pyx
+++ b/tensorflow/python/framework/fast_tensor_util.pyx
@@ -7,6 +7,18 @@ cimport numpy as np
 from tensorflow.python.util import compat
 
 
+def AppendFloat16ArrayToTensorProto(
+    # For numpy, npy_half is a typedef for npy_uint16,
+    # see: https://github.com/numpy/numpy/blob/master/doc/source/reference/c-api.coremath.rst#half-precision-functions
+    # Because np.float16_t dosen't exist in cython, we use uint16_t here.
+    # TODO: use npy_half typedef?
+    tensor_proto, np.ndarray[np.uint16_t, ndim=1] nparray):
+  cdef long i, n
+  n = nparray.size
+  for i in range(n):
+    tensor_proto.half_val.append(nparray[i])
+
+
 def AppendFloat32ArrayToTensorProto(
     tensor_proto, np.ndarray[np.float32_t, ndim=1] nparray):
   cdef long i, n

--- a/tensorflow/python/framework/fast_tensor_util.pyx
+++ b/tensorflow/python/framework/fast_tensor_util.pyx
@@ -11,7 +11,7 @@ def AppendFloat16ArrayToTensorProto(
     # For numpy, npy_half is a typedef for npy_uint16,
     # see: https://github.com/numpy/numpy/blob/master/doc/source/reference/c-api.coremath.rst#half-precision-functions
     # Because np.float16_t dosen't exist in cython, we use uint16_t here.
-    # TODO: use npy_half typedef?
+    # TODO: Use np.float16_t when cython supports it.
     tensor_proto, np.ndarray[np.uint16_t, ndim=1] nparray):
   cdef long i, n
   n = nparray.size

--- a/tensorflow/python/framework/fast_tensor_util.pyx
+++ b/tensorflow/python/framework/fast_tensor_util.pyx
@@ -13,7 +13,10 @@ def AppendFloat16ArrayToTensorProto(
     # Because np.float16_t dosen't exist in cython, we use uint16_t here.
     # TODO: Use np.float16_t when cython supports it.
     tensor_proto, np.ndarray[np.uint16_t, ndim=1] nparray):
-  tensor_proto.half_val.extend(nparray)
+  cdef long i, n
+  n = nparray.size
+  for i in range(n):
+    tensor_proto.half_val.append(nparray[i])
 
 
 def AppendFloat32ArrayToTensorProto(

--- a/tensorflow/python/framework/fast_tensor_util.pyx
+++ b/tensorflow/python/framework/fast_tensor_util.pyx
@@ -13,10 +13,7 @@ def AppendFloat16ArrayToTensorProto(
     # Because np.float16_t dosen't exist in cython, we use uint16_t here.
     # TODO: Use np.float16_t when cython supports it.
     tensor_proto, np.ndarray[np.uint16_t, ndim=1] nparray):
-  cdef long i, n
-  n = nparray.size
-  for i in range(n):
-    tensor_proto.half_val.append(nparray[i])
+  tensor_proto.half_val.extend(nparray)
 
 
 def AppendFloat32ArrayToTensorProto(

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -64,11 +64,8 @@ if _FAST_TENSOR_UTIL_AVAILABLE:
   _NP_TO_APPEND_FN = {
       dtypes.bfloat16.as_numpy_dtype:
           SlowAppendBFloat16ArrayToTensorProto,
-      # TODO(sesse): We should have a
-      # fast_tensor_util.AppendFloat16ArrayToTensorProto,
-      # but it seems np.float16_t doesn't exist?
       np.float16:
-          SlowAppendFloat16ArrayToTensorProto,
+          fast_tensor_util.AppendFloat16ArrayToTensorProto,
       np.float32:
           fast_tensor_util.AppendFloat32ArrayToTensorProto,
       np.float64:

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -50,6 +50,13 @@ def SlowAppendFloat16ArrayToTensorProto(tensor_proto, proto_values):
       [ExtractBitsFromFloat16(x) for x in proto_values])
 
 
+def _MediumAppendFloat16ArrayToTensorProto(tensor_proto, proto_values):
+  # TODO: Remove the conversion if cython supports np.float16_t
+  fast_tensor_util.AppendFloat16ArrayToTensorProto(
+      tensor_proto,
+      np.asarray(proto_values, dtype=np.float16).view(np.uint16))
+
+
 def ExtractBitsFromBFloat16(x):
   return np.asscalar(
       np.asarray(x, dtype=dtypes.bfloat16.as_numpy_dtype).view(np.uint16))
@@ -65,7 +72,7 @@ if _FAST_TENSOR_UTIL_AVAILABLE:
       dtypes.bfloat16.as_numpy_dtype:
           SlowAppendBFloat16ArrayToTensorProto,
       np.float16:
-          fast_tensor_util.AppendFloat16ArrayToTensorProto,
+          _MediumAppendFloat16ArrayToTensorProto,
       np.float32:
           fast_tensor_util.AppendFloat32ArrayToTensorProto,
       np.float64:


### PR DESCRIPTION
Related with #19180.
It seems that cython doesn't support `np.float16_t` by now, we use `np.uint16` instead. 

The conversion still be time-consuming (25 times slower than float32), however it is better than original slow implementation (260 times slower than float32).

Performance comparison:
```
before:
float32: 0.0535 sec
float16: 13.7567 sec

after:
float32: 0.0496 sec
float16: 1.0815 sec
```

script:
```python
import time
images = np.random.rand(128, 100, 100, 3)
imagesFloat16 = images.astype(np.float16)
imagesFloat32 = images.astype(np.float32)

start = time.time()
constant_op.constant(imagesFloat32)
end = time.time()
print("float32: {0:.4f} sec".format(end - start))

start = time.time()
constant_op.constant(imagesFloat16)
end = time.time()
print("float16: {0:.4f} sec".format(end - start))
```