### PR TITLE
Improve tf.constant() for float16 with fast_tensor_util

### DIFF
--- a/tensorflow/python/framework/fast_tensor_util.pyx
+++ b/tensorflow/python/framework/fast_tensor_util.pyx
@@ -5,15 +5,13 @@ import numpy as np
 cimport numpy as np
 
 from tensorflow.python.util import compat
-from libc.stdint cimport uint16_t
 
 def AppendFloat16ArrayToTensorProto(
     tensor_proto, np.ndarray[np.uint16_t, ndim=1, cast=True] nparray):
-  cdef uint16_t[:] nparray_as_uint16 = nparray.view(np.uint16)
   cdef long i, n
   n = nparray.size
   for i in range(n):
-    tensor_proto.half_val.append(nparray_as_uint16[i])
+    tensor_proto.half_val.append(nparray[i])
 
 
 def AppendFloat32ArrayToTensorProto(

--- a/tensorflow/python/framework/fast_tensor_util.pyx
+++ b/tensorflow/python/framework/fast_tensor_util.pyx
@@ -5,6 +5,15 @@ import numpy as np
 cimport numpy as np
 
 from tensorflow.python.util import compat
+from libc.stdint cimport uint16_t
+
+def AppendFloat16ArrayToTensorProto(
+    tensor_proto, np.ndarray[np.uint16_t, ndim=1, cast=True] nparray):
+  cdef uint16_t[:] nparray_as_uint16 = nparray.view(np.uint16)
+  cdef long i, n
+  n = nparray.size
+  for i in range(n):
+    tensor_proto.half_val.append(nparray_as_uint16[i])
 
 
 def AppendFloat32ArrayToTensorProto(

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -68,7 +68,7 @@ if _FAST_TENSOR_UTIL_AVAILABLE:
       # fast_tensor_util.AppendFloat16ArrayToTensorProto,
       # but it seems np.float16_t doesn't exist?
       np.float16:
-          SlowAppendFloat16ArrayToTensorProto,
+          fast_tensor_util.AppendFloat16ArrayToTensorProto,
       np.float32:
           fast_tensor_util.AppendFloat32ArrayToTensorProto,
       np.float64:


### PR DESCRIPTION
This fix tries to fix the issue raised in #19180 where tf.constant() for float16 is too slow as there is no
fast_tensor_util support.

This fix adds fast_tensor_util by casting float16 to uint16. Since numpy natively stores float16 as uint16, the conversion should be ok.

This fix fixes #19180.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>