### PR TITLE
DOC: Fix python code in for invalid code

### DIFF
--- a/tensorflow/docs_src/programmers_guide/estimators.md
+++ b/tensorflow/docs_src/programmers_guide/estimators.md
@@ -102,7 +102,7 @@ of the following four steps:
     a sample instantiation of a pre-made Estimator named `LinearClassifier`:
 
         # Instantiate an estimator, passing the feature columns.
-        estimator = tf.estimator.Estimator.LinearClassifier(
+        estimator = tf.estimator.LinearClassifier(
             feature_columns=[population, crime_rate, median_education],
             )
 


### PR DESCRIPTION
There is an error in python code in the documentation. There is no class called `tf.estimator.Estimator.LinearClassifier` I think it was a typo and the author meant `tf.estimator.LinearClassifier`.