### PR TITLE
fix docstring

### DIFF
--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -1227,7 +1227,7 @@ class EagerVariableStore(object):
     for input in dataset_iterator:
       with container.as_default():
         x = tf.layers.dense(input, name="l1")
-    print(container.variables)  # Should print the variables used in the layer.
+    print(container.variables())  # Should print the variables used in the layer.
   ```
   """
 


### PR DESCRIPTION
Confusing, since container.variables is a method. Looks similar to tf.keras.Sequential().variables, which returns the list of all layer variables/weights.

Compare with 
https://github.com/tensorflow/models/blob/master/official/mnist/mnist_eager.py#L73