### PR TITLE
Fix misleading cupti.h error message

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -604,7 +604,7 @@ def _find_cupti_header_dir(repository_ctx, cuda_config):
   for relative_path in CUPTI_HEADER_PATHS:
     if repository_ctx.path("%s/%scupti.h" % (cuda_toolkit_path, relative_path)).exists:
         return ("%s/%s" % (cuda_toolkit_path, relative_path))[:-1]
-  auto_configure_fail("Cannot find cupti.h under %s" % cuda_toolkit_path)
+  auto_configure_fail("Cannot find cupti.h under %s" % ", ".join([cuda_toolkit_path + "/" + s for s in CUPTI_HEADER_PATHS]))
 
 
 def _find_cupti_lib(repository_ctx, cuda_config):


### PR DESCRIPTION
This fix tries to address the issue raised in #19223 where the cupti.h eror message was misleading. The following error:
```
Cuda Configuration Error: Cannot find cupti.h under /usr/local/cuda-9.0
```
is not the true path searched.

This fix updates the bzl file to print out the complete searched paths when error occurs. Below is the new output:
```
Cuda Configuration Error: Cannot find cupti.h under /usr/local/cuda-9.0/extras/CUPTI/include/, /usr/local/cuda-9.0/include/cuda/CUPTI/
```

This fix fixes #19223.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>