### PR TITLE
Fix warning caused by squeeze_dims

### DIFF
--- a/tensorflow/examples/learn/text_classification_cnn.py
+++ b/tensorflow/examples/learn/text_classification_cnn.py
@@ -73,7 +73,7 @@ def cnn_model(features, labels, mode):
         kernel_size=FILTER_SHAPE2,
         padding='VALID')
     # Max across each filter to get useful features for classification.
-    pool2 = tf.squeeze(tf.reduce_max(conv2, 1), squeeze_dims=[1])
+    pool2 = tf.squeeze(tf.reduce_max(conv2, 1), axis=[1])
 
   # Apply regular WX + B and classification.
   logits = tf.layers.dense(pool2, MAX_LABEL, activation=None)


### PR DESCRIPTION
The `squeeze_dims` in `tf.squeeze` has been deprecated in favor of `axis`. This fix fixes the `squeeze_dims` in text_classification_cnn.py so that the warning could be removed.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>