### PR TITLE
Add missing deps for simd_armv8a in jpeg.BUILD

### DIFF
--- a/third_party/jpeg/jpeg.BUILD
+++ b/third_party/jpeg/jpeg.BUILD
@@ -291,8 +291,10 @@ cc_library(
         "jchuff.h",
         "jconfig.h",
         "jdct.h",
+        "jerror.h",
         "jinclude.h",
         "jmorecfg.h",
+        "jpegint.h"
         "jpeglib.h",
         "jsimd.h",
         "jsimddct.h",


### PR DESCRIPTION
Building for armv8 fails with error:

ERROR: .../bazel/external/jpeg/BUILD:288:1: undeclared inclusion(s) in rule '@jpeg//:simd_armv8a':
this rule is missing dependency declarations for the following files included by 'external/jpeg/simd/jsimd_arm64.c':
'.../bazel/external/jpeg/jpegint.h'
'.../bazel/external/jpeg/jerror.h'