### PR TITLE
Add int64 support for output_shape of tf.nn.conv3d_transpose

### DIFF
--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -195,8 +195,8 @@ class Conv3DBackpropInputOp : public OpKernel {
     TensorShape input_shape;
     if (takes_shape_) {
       const Tensor& input_sizes = context->input(0);
-      OP_REQUIRES_OK(context, TensorShapeUtils::MakeShape(
-                                  input_sizes.vec<int32>(), &input_shape));
+      // MakeShape is able to handle both DT_INT32 and DT_INT64 for input_sizes.
+      OP_REQUIRES_OK(context, MakeShape(input_sizes, &input_shape));
     } else {
       input_shape = context->input(0).shape();
     }

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -547,7 +547,7 @@ REGISTER_OP("Conv3DBackpropFilter")
     });
 
 REGISTER_OP("Conv3DBackpropInputV2")
-    .Input("input_sizes: int32")
+    .Input("input_sizes: Tshape")
     .Input("filter: T")
     .Input("out_backprop: T")
     .Output("output: T")
@@ -556,6 +556,7 @@ REGISTER_OP("Conv3DBackpropInputV2")
     .Attr(GetPaddingAttrString())
     .Attr(GetConvnet3dDataFormatAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1, 1]")
+    .Attr("Tshape: {int32, int64} = DT_INT32")
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle s;
       TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(0, &s));

--- a/tensorflow/python/kernel_tests/conv3d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/conv3d_transpose_test.py
@@ -144,8 +144,9 @@ class Conv3DTransposeTest(test.TestCase):
         f_value = constant_op.constant(
             1.0, shape=f_shape, name="filter", dtype=dtypes.float32)
         output = nn_ops.conv3d_transpose(
-            x_value, f_value, constant_op.constant(y_shape, dtype=dtype), strides=strides, padding="SAME")
-        value = output.eval()
+            x_value, f_value, constant_op.constant(y_shape, dtype=dtype),
+            strides=strides, padding="SAME")
+        output.eval()
 
   def testConv3DTransposeValid(self):
     with self.test_session():

--- a/tensorflow/python/kernel_tests/conv3d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/conv3d_transpose_test.py
@@ -131,6 +131,21 @@ class Conv3DTransposeTest(test.TestCase):
     nn_ops.conv3d_transpose(
         x_value, f_value, y_shape, strides, data_format='NCDHW')
 
+  def testConv3DTransposeOutputShapeType(self):
+    # Test case for GitHub issue 18887
+    with self.test_session():
+      x_shape = [2, 5, 6, 4, 3]
+      y_shape = [2, 5, 6, 4, 2]
+      f_shape = [3, 3, 3, 2, 3]
+      strides = [1, 1, 1, 1, 1]
+      x_value = constant_op.constant(
+          1.0, shape=x_shape, name="x", dtype=dtypes.float32)
+      f_value = constant_op.constant(
+          1.0, shape=f_shape, name="filter", dtype=dtypes.float32)
+      output = nn_ops.conv3d_transpose(
+          x_value, f_value, constant_op.constant(y_shape, dtype=dtypes.int64), strides=strides, padding="SAME")
+      value = output.eval()
+
   def testConv3DTransposeValid(self):
     with self.test_session():
       strides = [1, 2, 2, 2, 1]

--- a/tensorflow/python/kernel_tests/conv3d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/conv3d_transpose_test.py
@@ -133,18 +133,19 @@ class Conv3DTransposeTest(test.TestCase):
 
   def testConv3DTransposeOutputShapeType(self):
     # Test case for GitHub issue 18887
-    with self.test_session():
-      x_shape = [2, 5, 6, 4, 3]
-      y_shape = [2, 5, 6, 4, 2]
-      f_shape = [3, 3, 3, 2, 3]
-      strides = [1, 1, 1, 1, 1]
-      x_value = constant_op.constant(
-          1.0, shape=x_shape, name="x", dtype=dtypes.float32)
-      f_value = constant_op.constant(
-          1.0, shape=f_shape, name="filter", dtype=dtypes.float32)
-      output = nn_ops.conv3d_transpose(
-          x_value, f_value, constant_op.constant(y_shape, dtype=dtypes.int64), strides=strides, padding="SAME")
-      value = output.eval()
+    for dtype in [dtypes.int32, dtypes.int64]:
+      with self.test_session():
+        x_shape = [2, 5, 6, 4, 3]
+        y_shape = [2, 5, 6, 4, 2]
+        f_shape = [3, 3, 3, 2, 3]
+        strides = [1, 1, 1, 1, 1]
+        x_value = constant_op.constant(
+            1.0, shape=x_shape, name="x", dtype=dtypes.float32)
+        f_value = constant_op.constant(
+            1.0, shape=f_shape, name="filter", dtype=dtypes.float32)
+        output = nn_ops.conv3d_transpose(
+            x_value, f_value, constant_op.constant(y_shape, dtype=dtype), strides=strides, padding="SAME")
+        value = output.eval()
 
   def testConv3DTransposeValid(self):
     with self.test_session():


### PR DESCRIPTION
This fix tries to address the issue raised in #18887 where the output_shape of tf.nn.conv3d_transpose only support int32 data types. The support of int64 has been added in this PR with test case covered.

This fix fixes #18887.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>