### PR TITLE
Shape validation of `max_features` in `QuantizedReluX`

### DIFF
--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -1452,6 +1452,7 @@ REGISTER_OP("QuantizedReluX")
       ShapeHandle unused;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 0, &unused));
       TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));
       c->set_output(1, c->Scalar());
       c->set_output(2, c->Scalar());
       return Status::OK();


### PR DESCRIPTION
In shape function of QuantizedReluX, shapes of `max_value` and
`min_features` have been validated  but not `max_features`.
This fix add restriction to `max_features` as well.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>