### PR TITLE
optimize_for_inference script removes dropouts

### DIFF
--- a/tensorflow/python/tools/BUILD
+++ b/tensorflow/python/tools/BUILD
@@ -207,6 +207,7 @@ py_test(
         "//tensorflow/python:math_ops",
         "//tensorflow/python:nn_ops",
         "//tensorflow/python:nn_ops_gen",
+        "//tensorflow/python:layers",
         "//third_party/py/numpy",
     ],
 )


### PR DESCRIPTION
This PR is addressing feature request: 

https://github.com/tensorflow/tensorflow/issues/5867

It enhances optimize_for_inference script with function of removing dropouts. 
Since dropouts are only valuable during training, it makes sense to remove them for inference.

