### PR TITLE
Fix ppc64le compile failure libpng

### DIFF
--- a/third_party/png.BUILD
+++ b/third_party/png.BUILD
@@ -28,7 +28,14 @@ cc_library(
         "pngwrite.c",
         "pngwtran.c",
         "pngwutil.c",
-    ],
+    ] + select({
+        "@org_tensorflow//tensorflow:linux_ppc64le": [
+            "powerpc/powerpc_init.c",
+            "powerpc/filter_vsx_intrinsics.c",
+        ],
+        "//conditions:default": [
+        ],
+    }),
     hdrs = [
         "png.h",
         "pngconf.h",


### PR DESCRIPTION
Building Tensorflow on ppc64le fails with the message:
ERROR: /root/tensorflow/tensorflow/cc/BUILD:422:1: Linking of rule
'//tensorflow/cc:ops/control_flow_ops_gen_cc' failed (Exit 1)
bazel-out/host/bin/_solib_local/_U_S_Stensorflow_Scc_Cops_Scontrol_Uflow
_Uops_Ugen_Ucc___Utensorflow/libtensorflow_framework.so:
undefined reference to `png_init_filter_functions_vsx'
collect2: error: ld returned 1 exit status

This is fixed by adding powerpc specific files from the png archive
for @org_tensorflow//tensorflow:linux_ppc64le builds only.