### PR TITLE
Fix tf.matching_files issue with access denied subdirectory.

### DIFF
--- a/tensorflow/core/platform/file_system_helper.cc
+++ b/tensorflow/core/platform/file_system_helper.cc
@@ -82,7 +82,10 @@ Status GetMatchingPaths(FileSystem* fs, Env* env, const string& pattern,
     dir_q.pop_front();
     std::vector<string> children;
     Status s = fs->GetChildren(current_dir, &children);
-    ret.Update(s);
+    // We will ignore permission denied error, and update status otherwise.
+    if (s.code() != tensorflow::error::PERMISSION_DENIED) {
+      ret.Update(s);
+    }
     if (children.empty()) continue;
     // This IsDirectory call can be expensive for some FS. Parallelizing it.
     children_dir_status.resize(children.size());

--- a/tensorflow/core/platform/file_system_helper.cc
+++ b/tensorflow/core/platform/file_system_helper.cc
@@ -82,10 +82,11 @@ Status GetMatchingPaths(FileSystem* fs, Env* env, const string& pattern,
     dir_q.pop_front();
     std::vector<string> children;
     Status s = fs->GetChildren(current_dir, &children);
-    // We will ignore permission denied error, and update status otherwise.
-    if (s.code() != tensorflow::error::PERMISSION_DENIED) {
-      ret.Update(s);
+    // In case PERMISSION_DENIED is encountered, we bail here.
+    if (s.code() == tensorflow::error::PERMISSION_DENIED) {
+      continue;
     }
+    ret.Update(s);
     if (children.empty()) continue;
     // This IsDirectory call can be expensive for some FS. Parallelizing it.
     children_dir_status.resize(children.size());

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -24,7 +24,6 @@ import os.path
 from tensorflow.python.framework import errors
 from tensorflow.python.lib.io import file_io
 from tensorflow.python.platform import test
-from tensorflow.python.util import compat
 
 
 class FileIoTest(test.TestCase):

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -23,7 +23,6 @@ import os.path
 
 from tensorflow.python.framework import errors
 from tensorflow.python.lib.io import file_io
-from tensorflow.python.ops import gen_io_ops
 from tensorflow.python.platform import test
 from tensorflow.python.util import compat
 
@@ -585,7 +584,6 @@ class FileIoTest(test.TestCase):
     self.assertEqual(crc2, crc3)
 
   def testMatchingFilesPermission(self):
-    # Test case for GitHub issue 19274.
     # Create top level directory test_dir.
     dir_path = os.path.join(self._base_dir, "test_dir")
     file_io.create_dir(dir_path)
@@ -602,10 +600,11 @@ class FileIoTest(test.TestCase):
     file_io.FileIO(file_path, mode="w").write("testing")
     # Change noread to noread access.
     os.chmod(noread_path, 0)
-    expected_match = [compat.as_bytes(dir_path)]
-    with self.test_session() as sess:
-      self.assertItemsEqual(
-          gen_io_ops.matching_files(dir_path).eval(), expected_match)
+    expected_match = [
+        compat.as_bytes(os.path.join(any_path, name)) for name in files]
+    self.assertItemsEqual(
+        file_io.get_matching_files(os.path.join(dir_path, "*", "file*.txt")),
+        expected_match)
     # Change noread back so that it could be cleaned during tearDown.
     os.chmod(noread_path, 0o777)
 

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -601,7 +601,7 @@ class FileIoTest(test.TestCase):
     # Change noread to noread access.
     os.chmod(noread_path, 0)
     expected_match = [
-        compat.as_bytes(os.path.join(any_path, name)) for name in files]
+        os.path.join(any_path, name) for name in files]
     self.assertItemsEqual(
         file_io.get_matching_files(os.path.join(dir_path, "*", "file*.txt")),
         expected_match)

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -23,7 +23,9 @@ import os.path
 
 from tensorflow.python.framework import errors
 from tensorflow.python.lib.io import file_io
+from tensorflow.python.ops import gen_io_ops
 from tensorflow.python.platform import test
+from tensorflow.python.util import compat
 
 
 class FileIoTest(test.TestCase):
@@ -581,6 +583,32 @@ class FileIoTest(test.TestCase):
 
     self.assertTrue(crc1 != crc2)
     self.assertEqual(crc2, crc3)
+
+  def testMatchingFilesPermission(self):
+    # Test case for GitHub issue 19274.
+    # Create top level directory test_dir.
+    dir_path = os.path.join(self._base_dir, "test_dir")
+    file_io.create_dir(dir_path)
+    # Create second level directories `noread` and `any`.
+    noread_path = os.path.join(dir_path, "noread")
+    file_io.create_dir(noread_path)
+    any_path = os.path.join(dir_path, "any")
+    file_io.create_dir(any_path)
+    files = ["file1.txt", "file2.txt", "file3.txt"]
+    for name in files:
+      file_path = os.path.join(any_path, name)
+      file_io.FileIO(file_path, mode="w").write("testing")
+    file_path = os.path.join(noread_path, "file4.txt")
+    file_io.FileIO(file_path, mode="w").write("testing")
+    # Change noread to noread access.
+    os.chmod(noread_path, 0)
+    expected_match = [compat.as_bytes(dir_path)]
+    with self.test_session() as sess:
+      self.assertItemsEqual(
+          gen_io_ops.matching_files(dir_path).eval(), expected_match)
+    # Change noread back so that it could be cleaned during tearDown.
+    os.chmod(noread_path, 0o777)
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
This fix tries to address the issue raised in #19274 where
tf.matching_files will return an error if no permission for
subdirectories (Even if the subdirectories does not match).

This fix addresses the issue by ignore the case for `permisson denied`
during the directory traversal.

This fix fixes #19274.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>