### PR TITLE
core/framework/op_gen_lib.cc: include <algorithm>

### DIFF
--- a/tensorflow/core/framework/op_gen_lib.cc
+++ b/tensorflow/core/framework/op_gen_lib.cc
@@ -15,8 +15,8 @@ limitations under the License.
 
 #include "tensorflow/core/framework/op_gen_lib.h"
 
-#include <vector>
 #include <algorithm>
+#include <vector>
 #include "tensorflow/core/framework/attr_value.pb.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/gtl/map_util.h"

--- a/tensorflow/core/framework/op_gen_lib.cc
+++ b/tensorflow/core/framework/op_gen_lib.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op_gen_lib.h"
 
 #include <vector>
+#include <algorithm>
 #include "tensorflow/core/framework/attr_value.pb.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/gtl/map_util.h"


### PR DESCRIPTION
In `tensorflow/core/framework/op_gen_lib.cc` Add `#include <algorithm>` or else build with cmake fails at [line 415](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/op_gen_lib.cc#L415) 
```
[ 1098s] /home/abuild/rpmbuild/BUILD/tensorflow-1.8.0/tensorflow/core/framework/op_gen_lib.cc:418:10: error: 'is_permutation' is not a member of 'std'
[ 1098s]      if (!std::is_permutation(new_api_def.arg_order().begin(),

```