### PR TITLE
Remove redundant header includes in mpi_utils.h

### DIFF
--- a/tensorflow/contrib/mpi/mpi_utils.h
+++ b/tensorflow/contrib/mpi/mpi_utils.h
@@ -24,7 +24,6 @@ limitations under the License.
 
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/lib/strings/str_util.h"
-#include "tensorflow/core/platform/logging.h"
 
 // Skip MPI C++ bindings support, this matches the usage in other places
 #define OMPI_SKIP_MPICXX


### PR DESCRIPTION
In `mpi_utils.h` the header `"tensorflow/core/platform/logging.h"` was included twice.

This fix removes redundant header includes.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>