### PR TITLE
Fix pylint sanity error for CI build

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2619,8 +2619,10 @@ reverse.__doc__ = gen_array_ops.reverse_v2.__doc__
 
 # pylint: disable=redefined-builtin
 @tf_export("reverse_sequence")
-@deprecation.deprecated_args(None, "seq_dim is deprecated, use seq_axis instead", "seq_dim")
-@deprecation.deprecated_args(None, "batch_dim is deprecated, use batch_axis instead", "batch_dim")
+@deprecation.deprecated_args(
+    None, "seq_dim is deprecated, use seq_axis instead", "seq_dim")
+@deprecation.deprecated_args(
+    None, "batch_dim is deprecated, use batch_axis instead", "batch_dim")
 def reverse_sequence(input,
                      seq_lengths,
                      seq_axis=None,

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -84,7 +84,8 @@ def _convert_to_sparse_tensors(sp_inputs):
 
 # pylint: disable=protected-access
 @tf_export("sparse_concat")
-@deprecation.deprecated_args(None, "concat_dim is deprecated, use axis instead", "concat_dim")
+@deprecation.deprecated_args(
+    None, "concat_dim is deprecated, use axis instead", "concat_dim")
 def sparse_concat(axis,
                   sp_inputs,
                   name=None,
@@ -591,7 +592,8 @@ class KeywordRequired(object):
 
 
 @tf_export("sparse_split")
-@deprecation.deprecated_args(None, "split_dim is deprecated, use axis instead", "split_dim")
+@deprecation.deprecated_args(
+    None, "split_dim is deprecated, use axis instead", "split_dim")
 def sparse_split(keyword_required=KeywordRequired(),
                  sp_input=None,
                  num_split=None,


### PR DESCRIPTION

The CI build is failing, caused by:
```
53 FAIL: Found 4 non-whitelited pylint errors:
54 tensorflow/python/ops/sparse_ops.py:87: [C0301(line-too-long), ] Line too long (94/80)
55
56 tensorflow/python/ops/sparse_ops.py:594: [C0301(line-too-long), ] Line too long (92/80)
57
58 tensorflow/python/ops/array_ops.py:2622: [C0301(line-too-long), ] Line too long (92/80)
59
60 tensorflow/python/ops/array_ops.py:2623: [C0301(line-too-long), ] Line too long (98/80)
```

This fix fixes the sanity pylint error.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>