### PR TITLE
MPI enabled builds fail for r1.8

### DIFF
--- a/tensorflow/contrib/mpi/mpi_utils.cc
+++ b/tensorflow/contrib/mpi/mpi_utils.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #ifdef TENSORFLOW_USE_MPI
 
+#include <iostream>
 #include "tensorflow/contrib/mpi/mpi_utils.h"
 namespace tensorflow {
 

--- a/tensorflow/contrib/mpi/mpi_utils.h
+++ b/tensorflow/contrib/mpi/mpi_utils.h
@@ -21,8 +21,10 @@ limitations under the License.
 #include <map>
 #include <string>
 #include <vector>
+#include <iostream>
 
 #include "tensorflow/core/lib/strings/str_util.h"
+#include "tensorflow/core/platform/default/logging.h"
 
 // Skip MPI C++ bindings support, this matches the usage in other places
 #define OMPI_SKIP_MPICXX


### PR DESCRIPTION
There are two problems: "endl" not being part of std, and undefined logging macros.