### PR TITLE
[XLA] Don't do int64 tests for devices which do not support int64

### DIFF
--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -687,11 +687,12 @@ class BinaryOpsTest(XLATestCase):
           np.float32(7),
           expected=np.array([[False], [False], [True]], dtype=np.bool))
       if np.int64 in self.numeric_types:
-          self._testBinary(
-              less_op,
-              np.array([[10], [7], [2], [-1]], dtype=np.int64),
-              np.int64(7),
-              expected=np.array([[False], [False], [True], [True]], dtype=np.bool))
+        self._testBinary(
+            less_op,
+            np.array([[10], [7], [2], [-1]], dtype=np.int64),
+            np.int64(7),
+            expected=np.array(
+                [[False], [False], [True], [True]], dtype=np.bool))
 
     for less_equal_op in [math_ops.less_equal, (lambda x, y: x <= y)]:
       self._testBinary(

--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -686,11 +686,12 @@ class BinaryOpsTest(XLATestCase):
           np.array([[10], [7], [2]], dtype=np.float32),
           np.float32(7),
           expected=np.array([[False], [False], [True]], dtype=np.bool))
-      self._testBinary(
-          less_op,
-          np.array([[10], [7], [2], [-1]], dtype=np.int64),
-          np.int64(7),
-          expected=np.array([[False], [False], [True], [True]], dtype=np.bool))
+      if np.int64 in self.numeric_types:
+          self._testBinary(
+              less_op,
+              np.array([[10], [7], [2], [-1]], dtype=np.int64),
+              np.int64(7),
+              expected=np.array([[False], [False], [True], [True]], dtype=np.bool))
 
     for less_equal_op in [math_ops.less_equal, (lambda x, y: x <= y)]:
       self._testBinary(


### PR DESCRIPTION
If a device does not specify that it supports int64, then do not run tests which hard-code int64 types into themselves.

