### PR TITLE
Fallback to dynamic loader even if HADOOP_HDFS_HOME is not defined

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -115,18 +115,16 @@ class LibHDFS {
     const char* kLibHdfsDso = "libhdfs.so";
 #endif
     char* hdfs_home = getenv("HADOOP_HDFS_HOME");
-    if (hdfs_home == nullptr) {
-      status_ = errors::FailedPrecondition(
-          "Environment variable HADOOP_HDFS_HOME not set");
-      return;
+    if (hdfs_home != nullptr) {
+      status_ = TryLoadAndBind(path.c_str(), &handle_);
+      if (status_.ok()) {
+        return;
+      }
     }
-    string path = io::JoinPath(hdfs_home, "lib", "native", kLibHdfsDso);
-    status_ = TryLoadAndBind(path.c_str(), &handle_);
-    if (!status_.ok()) {
-      // try load libhdfs.so using dynamic loader's search path in case
-      // libhdfs.so is installed in non-standard location
-      status_ = TryLoadAndBind(kLibHdfsDso, &handle_);
-    }
+
+    // try load libhdfs.so using dynamic loader's search path in case
+    // libhdfs.so is installed in non-standard location
+    status_ = TryLoadAndBind(kLibHdfsDso, &handle_);
   }
 
   Status status_;

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -116,14 +116,15 @@ class LibHDFS {
 #endif
     char* hdfs_home = getenv("HADOOP_HDFS_HOME");
     if (hdfs_home != nullptr) {
+      string path = io::JoinPath(hdfs_home, "lib", "native", kLibHdfsDso);
       status_ = TryLoadAndBind(path.c_str(), &handle_);
       if (status_.ok()) {
         return;
       }
     }
 
-    // try load libhdfs.so using dynamic loader's search path in case
-    // libhdfs.so is installed in non-standard location
+    // Try to load the library dynamically in case it has been installed
+    // to a in non-standard location.
     status_ = TryLoadAndBind(kLibHdfsDso, &handle_);
   }
 


### PR DESCRIPTION
Prior to this commit HadoopFileSystem required HADOOP_HDFS_HOME to be
defined to initialize the filesystem, even if libhdfs.so is located
outside of the standard location. This limitation is unnecessary and
can be safely removed.

As a nice side-effect, the error message is now more informative.

Before:

    Environment variable HADOOP_HDFS_HOME not set

After:

    libhdfs.so: cannot open shared object file: No such file or directory

Change-Id: Ief6a8679d7ef353003aa387f7767ebaa8ef290ce