### PR TITLE
Include <algorithm> in .pb_text.cc generated files

### DIFF
--- a/tensorflow/tools/proto_text/gen_proto_text_functions_lib.cc
+++ b/tensorflow/tools/proto_text/gen_proto_text_functions_lib.cc
@@ -803,6 +803,9 @@ void Generator::Generate(const FileDescriptor& fd) {
   // Add header to cc file.
   SetOutput(&cc_);
   Print("// GENERATED FILE - DO NOT MODIFY");
+  Print();
+  Print("#include <algorithm>");  // for `std::stable_sort()`
+  Print();
   headers = {GetProtoTextHeaderName(fd, true /* impl */)};
   AddHeadersToCurrentSection(headers);
   Print();


### PR DESCRIPTION
The generated code depends on this header for `std::stable_sort()`. Until now we've been lucky that this header is included indirectly on the platforms for which we build. Fixes #19323.