### PR TITLE
Fix the naming of _any_variable_initialized

### DIFF
--- a/tensorflow/python/estimator/keras.py
+++ b/tensorflow/python/estimator/keras.py
@@ -68,7 +68,7 @@ def _convert_tensor(x):
   return x
 
 
-def _any_variable_initalized():
+def _any_variable_initialized():
   """Check if any variable has been initialized in the Keras model.
 
   Returns:
@@ -493,7 +493,7 @@ def model_to_estimator(keras_model=None,
       keras_model_fn, model_dir=model_dir, config=config)
 
   # Check if we need to call get_weights:
-  if _any_variable_initalized():
+  if _any_variable_initialized():
     keras_weights = keras_model.get_weights()
     # Warn if config passed to estimator tries to update GPUOptions. If a
     # session has already been created, the GPUOptions passed to the first


### PR DESCRIPTION
This might be a very small issue, though the naming `_any_variable_initalized` seems to be a typo (`initalized` -> `initialized`).

As this is an interanl function so renaming should be safe. This fix
change the naming to `_any_variable_initialized`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>