### PR TITLE
Use np.frombuffer instead of np.fromstring to avoid DeprecationWarning. r1.6

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -557,7 +557,7 @@ def MakeNdarray(tensor):
   dtype = tensor_dtype.as_numpy_dtype
 
   if tensor.tensor_content:
-    return np.fromstring(tensor.tensor_content, dtype=dtype).reshape(shape)
+    return np.frombuffer(tensor.tensor_content, dtype=dtype).reshape(shape)
   elif tensor_dtype == dtypes.float16:
     # the half_val field of the TensorProto stores the binary representation
     # of the fp16: we need to reinterpret this as a proper float16


### PR DESCRIPTION
Resolves #17020

PiperOrigin-RevId: 185927310