### PR TITLE
update embedding combiner default from mean to sqrtn

### DIFF
--- a/tensorflow/python/ops/embedding_ops.py
+++ b/tensorflow/python/ops/embedding_ops.py
@@ -390,9 +390,7 @@ def embedding_lookup_sparse(params,
     ValueError: If `combiner` is not one of {"mean", "sqrtn", "sum"}.
   """
   if combiner is None:
-    logging.warn("The default value of combiner will change from \"mean\" "
-                 "to \"sqrtn\" after 2016/11/01.")
-    combiner = "mean"
+    combiner = "sqrtn"
   if combiner not in ("mean", "sqrtn", "sum"):
     raise ValueError("combiner must be one of 'mean', 'sqrtn' or 'sum'")
   if isinstance(params, variables.PartitionedVariable):


### PR DESCRIPTION
according to the warning this should be the default since 2016/11/01