### PR TITLE
Add test case for empty tensor with clip ops

### DIFF
--- a/tensorflow/python/kernel_tests/clip_ops_test.py
+++ b/tensorflow/python/kernel_tests/clip_ops_test.py
@@ -419,11 +419,13 @@ class ClipTest(test.TestCase):
 
   def testClipByValueEmptyTensor(self):
     # Test case for GitHub issue 19337
-    z = array_ops.placeholder(dtype=dtypes.float32, shape=None)
-    x = clip_ops.clip_by_value(z, z, 1)
-    y = clip_ops.clip_by_value(z, 1, z)
+    zero = array_ops.placeholder(dtype=dtypes.float32, shape=None)
+    x = clip_ops.clip_by_value(zero, zero, zero)
+    y = clip_ops.clip_by_value(zero, 1.0, 1.0)
+    z = clip_ops.clip_by_value(zero, zero, 1.0)
+    w = clip_ops.clip_by_value(zero, 1.0, zero)
     with self.test_session(use_gpu=True) as sess:
-      sess.run([x, y], feed_dict={z: np.zeros((7, 0))})
+      sess.run([x, y, z, w], feed_dict={zero: np.zeros((7, 0))})
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/kernel_tests/clip_ops_test.py
+++ b/tensorflow/python/kernel_tests/clip_ops_test.py
@@ -18,9 +18,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as np
+
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import clip_ops
 from tensorflow.python.ops import gradient_checker
 from tensorflow.python.platform import test
@@ -413,6 +416,13 @@ class ClipTest(test.TestCase):
       tf_ans = ans.eval()
 
     self.assertAllClose(np_ans, tf_ans)
+
+  def testClipByValueEmptyTensor(self):
+    # Test case for GitHub issue 19337
+    z = array_ops.placeholder(dtype=dtypes.float32, shape=None)
+    x = clip_ops.clip_by_value(z, z, 1)
+    with self.test_session(use_gpu=True) as sess:
+      sess.run(x, feed_dict={z: np.zeros((7, 0))})
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/kernel_tests/clip_ops_test.py
+++ b/tensorflow/python/kernel_tests/clip_ops_test.py
@@ -421,8 +421,9 @@ class ClipTest(test.TestCase):
     # Test case for GitHub issue 19337
     z = array_ops.placeholder(dtype=dtypes.float32, shape=None)
     x = clip_ops.clip_by_value(z, z, 1)
+    y = clip_ops.clip_by_value(z, 1, z)
     with self.test_session(use_gpu=True) as sess:
-      sess.run(x, feed_dict={z: np.zeros((7, 0))})
+      sess.run([x, y], feed_dict={z: np.zeros((7, 0))})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fix is based on #19337 and #19338. The issue was that previously an empty tensor for `tf.clip_by_value` on GPU triggers a crash. The issue should have been fixed by #19338 and
the recent master. It makes sense to adds the test case for this issue.

This fix adds the test case.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>