### PR TITLE
Implemented cosine distance metric

### DIFF
--- a/tensorflow/contrib/losses/python/metric_learning/__init__.py
+++ b/tensorflow/contrib/losses/python/metric_learning/__init__.py
@@ -33,7 +33,6 @@ _allowed_symbols = [
     'npairs_loss',
     'npairs_loss_multilabel',
     'triplet_semihard_loss',
+    'pairwise_distance_cosine',
 ]
 remove_undocumented(__name__, _allowed_symbols)
-
-

--- a/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops.py
+++ b/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops.py
@@ -83,7 +83,8 @@ def pairwise_distance(feature, squared=False):
 def pairwise_distance_cosine(feature, squared=True):
   """Computes the pairwise distance matrix using the cosine distance.
 
-  output[i, j] = 1 - tf.matmul(feature[i, :], feature[j, :]) / (tf.norm(feature[i, :]) * tf.norm(feature[j, :]))
+  output[i, j] = 1 - tf.matmul(feature[i, :], feature[j, :]) /
+                        (tf.norm(feature[i, :]) * tf.norm(feature[j, :]))
 
   Args:
     feature: 2-D Tensor of size [number of data, feature dimension].
@@ -94,7 +95,7 @@ def pairwise_distance_cosine(feature, squared=True):
   """
 
   # normalize feature tensor
-  epsilon=1e-12
+  epsilon = 1e-12
   square_sum = math_ops.reduce_sum(math_ops.square(feature), 1, keepdims=True)
   feature_inv_norm = math_ops.rsqrt(math_ops.maximum(square_sum, epsilon))
   normalized = math_ops.multiply(feature, feature_inv_norm)
@@ -183,7 +184,8 @@ def masked_minimum(data, mask, dim=1):
   return masked_minimums
 
 
-def triplet_semihard_loss(labels, embeddings, margin=1.0, pairwise_dist_fn=pairwise_distance):
+def triplet_semihard_loss(labels, embeddings, margin=1.0,
+                          pairwise_dist_fn=pairwise_distance):
   """Computes the triplet loss with semi-hard negative mining.
 
   The loss encourages the positive distances (between a pair of embeddings with

--- a/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops.py
+++ b/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops.py
@@ -87,6 +87,7 @@ def pairwise_distance_cosine(feature, squared=True):
 
   Args:
     feature: 2-D Tensor of size [number of data, feature dimension].
+    squared: Unused argument - only for compatibility with pairwise_distance
 
   Returns:
     pairwise_distances: 2-D Tensor of size [number of data, number of data].
@@ -198,6 +199,8 @@ def triplet_semihard_loss(labels, embeddings, margin=1.0, pairwise_dist_fn=pairw
     embeddings: 2-D float `Tensor` of embedding vectors. Embeddings should
       be l2 normalized.
     margin: Float, margin term in the loss definition.
+    pairwise_dist_fn: Function to use to compute the pairwise distance.
+      Default is Euclidean pairwise distance.
 
   Returns:
     triplet_loss: tf.float32 scalar.
@@ -447,6 +450,8 @@ def lifted_struct_loss(labels, embeddings, margin=1.0, pairwise_dist_fn=pairwise
     embeddings: 2-D float `Tensor` of embedding vectors. Embeddings should not
       be l2 normalized.
     margin: Float, margin term in the loss definition.
+    pairwise_dist_fn: Function to use to compute the pairwise distance.
+      Default is Euclidean pairwise distance.
 
   Returns:
     lifted_loss: tf.float32 scalar.
@@ -988,6 +993,8 @@ def cluster_loss(labels,
       [batch size, embedding dimension]. Embeddings should be l2 normalized.
     margin_multiplier: float32 scalar. multiplier on the structured margin term
       See section 3.2 of paper for discussion.
+    pairwise_dist_fn: Function to use to compute the pairwise distance.
+      Default is Euclidean pairwise distance.
     enable_pam_finetuning: Boolean, Whether to run local pam refinement.
       See section 3.4 of paper for discussion.
     margin_type: Type of structured margin to use. See section 3.2 of
@@ -1004,7 +1011,7 @@ def cluster_loss(labels,
   if not HAS_SKLEARN:
     raise ImportError('Cluster loss depends on sklearn.')
   pairwise_distances = pairwise_dist_fn(embeddings)
-  
+
   labels = array_ops.squeeze(labels)
   all_ids = math_ops.range(array_ops.shape(embeddings)[0])
 

--- a/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
+++ b/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
@@ -57,6 +57,18 @@ def pairwise_distance_np(feature, squared=False):
       pairwise_distances.diagonal())
   return pairwise_distances
 
+class PairwiseCosineTest(tf.test.TestCase):
+
+  def testPairwiseCosine(self):
+    with self.test_session():
+      num_data = 10
+      feat_dim = 6
+
+      embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
+      sklearn_result = 1 - metric.pairwise.cosine_similarity(embedding)
+      dist_matrix = metric_loss_ops.pairwise_distances_cosine(embedding)
+      self.assertAllClose(dist_matrix.eval(), sklearn_result, rtol=1e-06)
+
 
 class ContrastiveLossTest(test.TestCase):
 

--- a/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
+++ b/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
@@ -57,7 +57,7 @@ def pairwise_distance_np(feature, squared=False):
       pairwise_distances.diagonal())
   return pairwise_distances
 
-class PairwiseCosineTest(tf.test.TestCase):
+class PairwiseCosineTest(test.TestCase):
 
   def testPairwiseCosine(self):
     with self.test_session():

--- a/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
+++ b/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
@@ -212,7 +212,7 @@ class TripletSemiHardLossCosineTest(test.TestCase):
           labels=ops.convert_to_tensor(labels),
           embeddings=ops.convert_to_tensor(embedding),
           margin=margin,
-          pairwise_dist_fn=metric_loss_ops.pairwise_distances_cosine))
+          pairwise_dist_fn=metric_loss_ops.pairwise_distances_cosine)
       loss_tf = loss_tf.eval()
       self.assertAllClose(loss_np, loss_tf)
 

--- a/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
+++ b/tensorflow/contrib/losses/python/metric_learning/metric_loss_ops_test.py
@@ -212,7 +212,7 @@ class TripletSemiHardLossCosineTest(test.TestCase):
           labels=ops.convert_to_tensor(labels),
           embeddings=ops.convert_to_tensor(embedding),
           margin=margin,
-          pairwise_dist_fn=pairwise_distance_cosine))
+          pairwise_dist_fn=metric_loss_ops.pairwise_distances_cosine))
       loss_tf = loss_tf.eval()
       self.assertAllClose(loss_np, loss_tf)
 


### PR DESCRIPTION
Losses in `tf.contrib.losses.metric_learning` rely only on euclidean distance.
I implemented the cosine distance that can be used to calculate the losses for:

- `lifted_struct_loss`
- `cluster_loss`
- `triplet_semihard_loss`

I added an extra argument `metric` with default value `euclidean`, in order to make the API backward compatible.