### PR TITLE
Adding back abi and stacktrace dependencies to stacktrace_handler

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -462,7 +462,9 @@ cc_library(
     srcs = ["platform/stacktrace_handler.cc"],
     hdrs = ["platform/stacktrace_handler.h"],
     deps = [
+        ":abi",
         ":lib_platform",
+        ":stacktrace",
     ],
 )
 


### PR DESCRIPTION
Corresponding headers are referenced in:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/platform/stacktrace_handler.cc