### PR TITLE
[INTEL MKL] Fused quantized Ops for Intel CPU [PR for comment only].

### DIFF
--- a/tensorflow/core/graph/mkl_graph_util.h
+++ b/tensorflow/core/graph/mkl_graph_util.h
@@ -76,6 +76,8 @@ int inline GetTensorMetaDataIndex(int n, int total_tensors) {
 namespace mkl_op_registry {
 static const char* kMklOpLabel = "MklOp";
 static const char* kMklOpLabelPattern = "label='MklOp'";
+static const char* kMklQuantizedOpLabel = "QuantizedMklOp";
+static const char* kMklQuantizedOpLabelPattern = "label='QuantizedMklOp'";
 // Prefix that we add to Tensorflow op name to construct Mkl op name.
 static const char* const kMklOpPrefix = "_Mkl";
 
@@ -90,11 +92,32 @@ inline string GetMklOpName(const string& name) {
 // @input: name of the op
 // @input: T datatype to be used for checking op
 // @return: true if opname is registered as Mkl op; false otherwise
-static inline bool IsMklOp(const string& op_name, DataType T) {
+static inline bool IsMklOp(const std::string& op_name, DataType T) {
   string kernel = KernelsRegisteredForOp(op_name);
-  bool result =
-      kernel.find(kMklOpLabelPattern) != string::npos && (T == DT_FLOAT);
-  return result;
+
+  // Restrict quantized ops to QUINT8 and QINT8 for now
+  if (kernel.find(kMklQuantizedOpLabelPattern) != string::npos) {
+    return (T == DT_QUINT8 || T == DT_QINT8 || T == DT_QINT32);
+  }
+  // Restrict regular ops to FLOAT
+  if (kernel.find(kMklOpLabelPattern) != string::npos) {
+    return (T == DT_FLOAT);
+  }
+  return false;
+}
+
+// TODO(mdfaijul): QuantizedConv2D is registered with input: QUINT8
+// filter:QINT8 for mkldnn integration. First we created a dummy kernel
+// and then it is replaced by actual kernel.
+static inline bool IsMklOp(const std::string& op_name, DataType Tinput,
+                           DataType Tfilter) {
+  string kernel = KernelsRegisteredForOp(op_name);
+
+  // Restrict quantized ops to QUINT8 and QINT8 for now
+  if (kernel.find(kMklQuantizedOpLabelPattern) != string::npos) {
+    return (Tinput == DT_QUINT8 && Tfilter == DT_QINT8);
+  }
+  return false;
 }
 
 // Check whether opname with type T is registered as MKL-compliant and

--- a/tensorflow/core/graph/mkl_tfconversion_pass.cc
+++ b/tensorflow/core/graph/mkl_tfconversion_pass.cc
@@ -147,22 +147,20 @@ Status MklToTfConversionPass::InsertConversionNodeOnEdge(
   CHECK_NOTNULL(dst);
 
   Node* conversion_node = nullptr;
-  DataType src_datatype = DT_INVALID;
-  DataType dst_datatype = DT_INVALID;
+  DataType src_datatype = src->output_type(e->src_output());
+  DataType dst_datatype = dst->input_type(e->dst_input());
   string data_format;
 
-  TF_CHECK_OK(GetNodeAttr(src->def(), "T", &src_datatype));
-  bool dst_dtype_found =
-      GetNodeAttr(dst->def(), "T", &dst_datatype) == Status::OK();
   // We compare source and destination datatypes only when both are found.
-  if (dst_dtype_found && (src_datatype != dst_datatype)) {
-    string err_msg = "T attribute of " + src->name() + " and " + dst->name() +
-                     " do not match. Will not insert" +
-                     " MklToTf node in such case.";
+  if (src_datatype != dst_datatype) {
+    string err_msg = "T attribute of " + src->name() + ":" +
+                     std::to_string(e->src_output()) + " and " + dst->name() +
+                     ":" + std::to_string(e->dst_input()) +
+                     " do not"
+                     " match. Will not insert MklToTf node in such case.";
     return Status(error::Code::INVALID_ARGUMENT, err_msg.c_str());
   }
 
-  // Build the conversion node and specify src as input.
   TF_CHECK_OK(
       NodeBuilder((*g)->NewName("Mkl2Tf"), "_MklToTf")
           .Input(src, e->src_output())

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -5980,6 +5980,7 @@ tf_cc_test(
 tf_mkl_kernel_library(
     name = "mkl_conv_op",
     prefix = "mkl_conv",
+    hdrs = ["mkl_quantized_conv_ops.h"],
     deps = [
         ":bounds_check",
         ":conv_ops",

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -18,9 +18,11 @@ limitations under the License.
 
 #include <string.h>
 #include <map>
-#include <string>
-#include <vector>
 #include <memory>
+#include <string>
+#include <typeinfo>
+#include <vector>
+#include <algorithm>
 
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -30,6 +32,8 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_slice.h"
 #include "tensorflow/core/kernels/bounds_check.h"
 #include "tensorflow/core/kernels/mkl_conv_ops.h"
+#include "tensorflow/core/kernels/mkl_quantized_conv_ops.h"
+#include "tensorflow/core/kernels/no_op.h"
 #include "tensorflow/core/kernels/ops_util.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/gtl/array_slice.h"
@@ -59,7 +63,7 @@ namespace tensorflow {
 
 #ifndef INTEL_MKL_ML
 
-struct ConvFwdDimensions {
+struct ConvFwdParams {
   memory::dims src_dims;
   memory::dims filter_dims;
   memory::dims bias_dims;
@@ -69,26 +73,32 @@ struct ConvFwdDimensions {
   memory::dims padding_left;
   memory::dims padding_right;
 
-  ConvFwdDimensions(memory::dims src_dims,
-    memory::dims filter_dims, memory::dims bias_dims,
-    memory::dims dst_dims, memory::dims strides,
-    memory::dims dilations, memory::dims padding_left,
-    memory::dims padding_right) :
-      src_dims(src_dims), filter_dims(filter_dims),
-      bias_dims(bias_dims), dst_dims(dst_dims),
-      strides(strides), dilations(dilations),
-      padding_left(padding_left), padding_right(padding_right) {
-  }
+  std::string dtypes = std::string("");
+  std::vector<std::string> post_ops = std::vector<std::string>();
+
+  ConvFwdParams(memory::dims src_dims, memory::dims filter_dims,
+                memory::dims bias_dims, memory::dims dst_dims,
+                memory::dims strides, memory::dims dilations,
+                memory::dims padding_left, memory::dims padding_right)
+      : src_dims(src_dims),
+        filter_dims(filter_dims),
+        bias_dims(bias_dims),
+        dst_dims(dst_dims),
+        strides(strides),
+        dilations(dilations),
+        padding_left(padding_left),
+        padding_right(padding_right) {}
 };
 
-template <typename T>
+template <typename T, typename Tinput, typename Tfilter, typename Tbias,
+          typename Toutput>
 class Conv2DFwd : public DnnOp {
  public:
-  explicit Conv2DFwd(const ConvFwdDimensions& convFwdDims) {
+  explicit Conv2DFwd(const ConvFwdParams& conv_fwd_params) {
     fwd_stream_.reset(new stream(stream::kind::eager));
     // create conv primitive
     if (conv_fwd_ == nullptr) {
-      Setup(convFwdDims);
+      Setup(conv_fwd_params);
     }
   }
 
@@ -99,7 +109,8 @@ class Conv2DFwd : public DnnOp {
   //   filter_data: input data buffer of filter (weights)
   //   bias_data:   input data buffer of bias
   //   dst_data:    output data buffer of dst
-  void Execute(T* src_data, T* filter_data, T* bias_data, T* dst_data) {
+  void Execute(Tinput* src_data, Tfilter* filter_data, Tbias* bias_data,
+               Toutput* dst_data) {
     src_mem_->set_data_handle(static_cast<void*>(src_data));
     filter_mem_->set_data_handle(static_cast<void*>(filter_data));
     bias_mem_->set_data_handle(static_cast<void*>(bias_data));
@@ -119,7 +130,7 @@ class Conv2DFwd : public DnnOp {
   //   src_data:    input data buffer of src
   //   filter_data: input data buffer of filter (weights)
   //   dst_data:    output data buffer of dst
-  void Execute(T* src_data, T* filter_data, T* dst_data) {
+  void Execute(Tinput* src_data, Tfilter* filter_data, Toutput* dst_data) {
     src_mem_->set_data_handle(static_cast<void*>(src_data));
     filter_mem_->set_data_handle(static_cast<void*>(filter_data));
     dst_mem_->set_data_handle(static_cast<void*>(dst_data));
@@ -142,36 +153,61 @@ class Conv2DFwd : public DnnOp {
   std::shared_ptr<mkldnn::primitive> conv_fwd_;
 
  private:
-  void Setup(const ConvFwdDimensions& convFwdDims) {
+  void Setup(const ConvFwdParams& conv_fwd_params) {
     // create memory descriptors for convolution data w/ no specified format
-    src_md_.reset(new memory::desc({convFwdDims.src_dims},
-        MklDnnType<T>(), memory::format::any));
+    src_md_.reset(new memory::desc({conv_fwd_params.src_dims},
+                                   MklDnnType<Tinput>(), memory::format::any));
 
-    filter_md_.reset(new memory::desc({convFwdDims.filter_dims},
-        MklDnnType<T>(), memory::format::any));
+    filter_md_.reset(new memory::desc({conv_fwd_params.filter_dims},
+                                      MklDnnType<Tfilter>(),
+                                      memory::format::any));
 
-    dst_md_.reset(new memory::desc({convFwdDims.dst_dims},
-        MklDnnType<T>(), memory::format::any));
+    dst_md_.reset(new memory::desc({conv_fwd_params.dst_dims},
+                                   MklDnnType<Toutput>(), memory::format::any));
 
-    if (!convFwdDims.bias_dims.empty())
-        bias_md_.reset(new memory::desc({convFwdDims.bias_dims},
-            MklDnnType<T>(), memory::format::any));
+    if (!conv_fwd_params.bias_dims.empty())
+      bias_md_.reset(new memory::desc({conv_fwd_params.bias_dims},
+                                      MklDnnType<Tbias>(),
+                                      memory::format::any));
 
     // create a convolution
-    if (!convFwdDims.bias_dims.empty()) {
-      fwd_desc_.reset(new convolution_forward::desc(prop_kind::forward,
-          convolution_direct, *src_md_, *filter_md_, *bias_md_, *dst_md_,
-          convFwdDims.strides, convFwdDims.dilations, convFwdDims.padding_left,
-          convFwdDims.padding_right, padding_kind::zero));
+    if (!conv_fwd_params.bias_dims.empty()) {
+      fwd_desc_.reset(new convolution_forward::desc(
+          prop_kind::forward, convolution_direct, *src_md_, *filter_md_,
+          *bias_md_, *dst_md_, conv_fwd_params.strides,
+          conv_fwd_params.dilations, conv_fwd_params.padding_left,
+          conv_fwd_params.padding_right, padding_kind::zero));
     } else {
-      fwd_desc_.reset(new convolution_forward::desc(prop_kind::forward,
-          convolution_direct, *src_md_, *filter_md_, *dst_md_,
-          convFwdDims.strides, convFwdDims.dilations, convFwdDims.padding_left,
-          convFwdDims.padding_right, padding_kind::zero));
+      fwd_desc_.reset(new convolution_forward::desc(
+          prop_kind::forward, convolution_direct, *src_md_, *filter_md_,
+          *dst_md_, conv_fwd_params.strides, conv_fwd_params.dilations,
+          conv_fwd_params.padding_left, conv_fwd_params.padding_right,
+          padding_kind::zero));
     }
 
-    fwd_pd_.reset(new convolution_forward::primitive_desc(
-        *fwd_desc_, cpu_engine_));
+    // Check if there is any fusions as post-ops
+    if (!conv_fwd_params.post_ops.empty()) {
+      // Add ReLU as post op
+      if (conv_fwd_params.post_ops.at(0) == "relu") {
+        mkldnn::post_ops ops;
+        mkldnn::primitive_attr post_ops_attr;
+        const float ops_scale = 1.f;
+        const float ops_alpha = 0.f;  // relu negative slope
+        const float ops_beta = 0.f;
+        ops.append_eltwise(ops_scale, mkldnn::eltwise_relu, ops_alpha,
+                           ops_beta);
+        post_ops_attr.set_post_ops(ops);
+
+        fwd_pd_.reset(new convolution_forward::primitive_desc(
+            *fwd_desc_, post_ops_attr, cpu_engine_));
+      } else {
+        fwd_pd_.reset(
+            new convolution_forward::primitive_desc(*fwd_desc_, cpu_engine_));
+      }
+    } else {
+      fwd_pd_.reset(
+          new convolution_forward::primitive_desc(*fwd_desc_, cpu_engine_));
+    }
 
     // store the expected memory format
     src_fmt_ = static_cast<mkldnn::memory::format>(
@@ -182,19 +218,21 @@ class Conv2DFwd : public DnnOp {
 
     // create memory primitive based on dummy data
     src_mem_.reset(new memory(fwd_pd_.get()->src_primitive_desc(), DummyData));
-    filter_mem_.reset(new memory(fwd_pd_.get()->weights_primitive_desc(),
-                      DummyData));
+    filter_mem_.reset(
+        new memory(fwd_pd_.get()->weights_primitive_desc(), DummyData));
     dst_mem_.reset(new memory(fwd_pd_.get()->dst_primitive_desc(), DummyData));
 
     // create convolution primitive and add it to net
-    if (!convFwdDims.bias_dims.empty()) {
-        bias_mem_.reset(new memory({{{convFwdDims.bias_dims}, MklDnnType<T>(),
-                        memory::format::x}, cpu_engine_}, DummyData));
-        conv_fwd_.reset(new convolution_forward(*fwd_pd_, *src_mem_,
-                        *filter_mem_, *bias_mem_, *dst_mem_));
+    if (!conv_fwd_params.bias_dims.empty()) {
+      bias_mem_.reset(new memory(
+          {{{conv_fwd_params.bias_dims}, MklDnnType<T>(), memory::format::x},
+           cpu_engine_},
+          DummyData));
+      conv_fwd_.reset(new convolution_forward(*fwd_pd_, *src_mem_, *filter_mem_,
+                                              *bias_mem_, *dst_mem_));
     } else {
-        conv_fwd_.reset(new convolution_forward(*fwd_pd_, *src_mem_,
-                        *filter_mem_, *dst_mem_));
+      conv_fwd_.reset(new convolution_forward(*fwd_pd_, *src_mem_, *filter_mem_,
+                                              *dst_mem_));
     }
 
     fwd_primitives_.push_back(*conv_fwd_);
@@ -222,22 +260,26 @@ class Conv2DFwd : public DnnOp {
   engine cpu_engine_ = engine(engine::cpu, 0);
 };
 
-template <typename T>
+template <typename T, typename Tinput, typename Tfilter, typename Tbias,
+          typename Toutput>
 class Conv2DFwdFactory : public DnnOpFactory<T> {
  public:
-  static Conv2DFwd<T>* Get(const ConvFwdDimensions& convFwdDims) {
-     Conv2DFwd<T>* conv2d_fwd = nullptr;
+  static Conv2DFwd<T, Tinput, Tfilter, Tbias, Toutput>* Get(
+      const ConvFwdParams& conv_fwd_params) {
+    Conv2DFwd<T, Tinput, Tfilter, Tbias, Toutput>* conv2d_fwd = nullptr;
 
-     // try to find a suitable one in pool
-     conv2d_fwd = dynamic_cast<Conv2DFwd<T>*> (
-       Conv2DFwdFactory<T>::GetInstance().GetConv2DFwd(convFwdDims));
+    // try to find a suitable one in pool
+    conv2d_fwd = dynamic_cast<Conv2DFwd<T, Tinput, Tfilter, Tbias, Toutput>*>(
+        Conv2DFwdFactory<T, Tinput, Tfilter, Tbias, Toutput>::GetInstance()
+            .GetConv2DFwd(conv_fwd_params));
 
-     if (conv2d_fwd == nullptr) {
-       conv2d_fwd = new Conv2DFwd<T>(convFwdDims);
-       Conv2DFwdFactory<T>::GetInstance().SetConv2DFwd(
-           convFwdDims, conv2d_fwd);
-     }
-     return conv2d_fwd;
+    if (conv2d_fwd == nullptr) {
+      conv2d_fwd =
+          new Conv2DFwd<T, Tinput, Tfilter, Tbias, Toutput>(conv_fwd_params);
+      Conv2DFwdFactory<T, Tinput, Tfilter, Tbias, Toutput>::GetInstance()
+          .SetConv2DFwd(conv_fwd_params, conv2d_fwd);
+    }
+    return conv2d_fwd;
   }
 
  private:
@@ -251,28 +293,32 @@ class Conv2DFwdFactory : public DnnOpFactory<T> {
     return instance_;
   }
 
-  static std::string CreateKey(const ConvFwdDimensions& convFwdDims) {
+  static std::string CreateKey(const ConvFwdParams& conv_fwd_params) {
     std::string prefix = "conv2d_fwd_";
     FactoryKeyCreator key_creator;
     key_creator.AddAsKey(prefix);
-    key_creator.AddAsKey(convFwdDims.src_dims);
-    key_creator.AddAsKey(convFwdDims.filter_dims);
-    key_creator.AddAsKey(convFwdDims.bias_dims);
-    key_creator.AddAsKey(convFwdDims.dst_dims);
-    key_creator.AddAsKey(convFwdDims.strides);
-    key_creator.AddAsKey(convFwdDims.dilations);
-    key_creator.AddAsKey(convFwdDims.padding_left);
-    key_creator.AddAsKey(convFwdDims.padding_right);
+    key_creator.AddAsKey(conv_fwd_params.src_dims);
+    key_creator.AddAsKey(conv_fwd_params.filter_dims);
+    key_creator.AddAsKey(conv_fwd_params.bias_dims);
+    key_creator.AddAsKey(conv_fwd_params.dst_dims);
+    key_creator.AddAsKey(conv_fwd_params.strides);
+    key_creator.AddAsKey(conv_fwd_params.dilations);
+    key_creator.AddAsKey(conv_fwd_params.padding_left);
+    key_creator.AddAsKey(conv_fwd_params.padding_right);
+    key_creator.AddAsKey(conv_fwd_params.dtypes);
+    for (auto const& post_op : conv_fwd_params.post_ops)
+      key_creator.AddAsKey(post_op);
+
     return key_creator.GetKey();
   }
 
-  DnnOp* GetConv2DFwd(const ConvFwdDimensions& convFwdDims) {
-    std::string key = CreateKey(convFwdDims);
+  DnnOp* GetConv2DFwd(const ConvFwdParams& conv_fwd_params) {
+    std::string key = CreateKey(conv_fwd_params);
     return this->GetOp(key);
   }
 
-  void SetConv2DFwd(const ConvFwdDimensions& convFwdDims, DnnOp *op) {
-    std::string key = CreateKey(convFwdDims);
+  void SetConv2DFwd(const ConvFwdParams& conv_fwd_params, DnnOp* op) {
+    std::string key = CreateKey(conv_fwd_params);
     this->SetOp(key, op);
   }
 };
@@ -337,19 +383,18 @@ class MklConv2DOp : public OpKernel {
                                         filter.shape().DebugString()));
 
     for (int i = 0; i < 3; i++) {
-      OP_REQUIRES(
-          context,
-          FastBoundsCheck(filter.dim_size(i), std::numeric_limits<int>::max()),
-          errors::InvalidArgument("filter too large"));
+      OP_REQUIRES(context, FastBoundsCheck(filter.dim_size(i),
+                                           std::numeric_limits<int>::max()),
+                  errors::InvalidArgument("filter too large"));
     }
 
     const int64 input_depth =
         input_in_mkl_format ? GetMklTensorDim(mkl_context.input_shape, 'C')
                             : GetTensorDim(input, data_format_, 'C');
-    OP_REQUIRES(context, input_depth == filter.dim_size(2),
-                errors::InvalidArgument(
-                    "input and filter must have the same depth: ", input_depth,
-                    " vs ", filter.dim_size(2)));
+    OP_REQUIRES(
+        context, input_depth == filter.dim_size(2),
+        errors::InvalidArgument("input and filter must have the same depth: ",
+                                input_depth, " vs ", filter.dim_size(2)));
     // The last dimension for filter is out_depth.
     const int out_depth = static_cast<int>(filter.dim_size(3));
 
@@ -358,10 +403,9 @@ class MklConv2DOp : public OpKernel {
     const int64 input_rows_raw =
         input_in_mkl_format ? GetMklTensorDim(mkl_context.input_shape, 'H')
                             : GetTensorDim(input, data_format_, 'H');
-    OP_REQUIRES(
-        context,
-        FastBoundsCheck(input_rows_raw, std::numeric_limits<int>::max()),
-        errors::InvalidArgument("Input rows too large"));
+    OP_REQUIRES(context, FastBoundsCheck(input_rows_raw,
+                                         std::numeric_limits<int>::max()),
+                errors::InvalidArgument("Input rows too large"));
     const int input_rows = static_cast<int>(input_rows_raw);
     const int filter_rows = static_cast<int>(filter.dim_size(0));
 
@@ -370,10 +414,9 @@ class MklConv2DOp : public OpKernel {
     const int64 input_cols_raw =
         input_in_mkl_format ? GetMklTensorDim(mkl_context.input_shape, 'W')
                             : GetTensorDim(input, data_format_, 'W');
-    OP_REQUIRES(
-        context,
-        FastBoundsCheck(input_cols_raw, std::numeric_limits<int>::max()),
-        errors::InvalidArgument("Input cols too large"));
+    OP_REQUIRES(context, FastBoundsCheck(input_cols_raw,
+                                         std::numeric_limits<int>::max()),
+                errors::InvalidArgument("Input cols too large"));
     const int input_cols = static_cast<int>(input_cols_raw);
     const int filter_cols = static_cast<int>(filter.dim_size(1));
 
@@ -381,10 +424,9 @@ class MklConv2DOp : public OpKernel {
     const int64 input_batch_raw =
         input_in_mkl_format ? GetMklTensorDim(mkl_context.input_shape, 'N')
                             : GetTensorDim(input, data_format_, 'N');
-    OP_REQUIRES(
-        context,
-        FastBoundsCheck(input_batch_raw, std::numeric_limits<int>::max()),
-        errors::InvalidArgument("batch is too large"));
+    OP_REQUIRES(context, FastBoundsCheck(input_batch_raw,
+                                         std::numeric_limits<int>::max()),
+                errors::InvalidArgument("batch is too large"));
     const int batch = static_cast<int>(input_batch_raw);
 
     // For now we take the stride from the second and third dimensions only (we
@@ -708,7 +750,8 @@ class MklConv2DOp : public OpKernel {
 
 #else
 
-template <typename Device, typename T, bool biasEnabled>
+template <typename Device, typename Tinput, typename Tfilter, typename Tbias,
+          typename Toutput, bool biasEnabled>
 class MklConv2DOp : public OpKernel {
  public:
   ~MklConv2DOp() {}
@@ -757,26 +800,26 @@ class MklConv2DOp : public OpKernel {
       GetMklShape(context, kInputIndex_Src, &src_mkl_shape);
       GetMklShape(context, kInputIndex_Filter, &filter_mkl_shape);
       OP_REQUIRES(context, filter_mkl_shape.IsMklTensor() == false,
-            errors::InvalidArgument("Filter should not be in "
-            "Mkl Layout"));
+                  errors::InvalidArgument("Filter should not be in "
+                                          "Mkl Layout"));
 
-      MklDnnData<T> src(&cpu_engine);
-      MklDnnData<T> filter(&cpu_engine);
-      MklDnnData<T> dst(&cpu_engine);  // output
+      MklDnnData<Tinput> src(&cpu_engine_);
+      MklDnnData<Tfilter> filter(&cpu_engine_);
+      MklDnnData<Toutput> dst(&cpu_engine_);  // output
 
       memory::dims src_dims, filter_dims, padding_left, padding_right,
-                   dilations, strides;
+          dilations, strides;
       memory::dims dst_dims_tf_order, dst_dims_mkl_order;
 
       // Get shapes of input tensors in MKL-DNN order
       MklDnnConvUtil conv_utl(context, strides_, padding_, data_format_,
-                             dilations_);
+                              dilations_);
       auto src_tf_shape = GetTfShape(context, kInputIndex_Src);
       auto filter_tf_shape = GetTfShape(context, kInputIndex_Filter);
       conv_utl.GetConvFwdSizesInMklOrder(
-          src_tf_shape, filter_tf_shape, &src_dims, &filter_dims,
-          &strides, &dilations, &dst_dims_tf_order, &dst_dims_mkl_order,
-          &padding_left, &padding_right);
+          src_tf_shape, filter_tf_shape, &src_dims, &filter_dims, &strides,
+          &dilations, &dst_dims_tf_order, &dst_dims_mkl_order, &padding_left,
+          &padding_right);
       if (!context->status().ok()) return;
 
       // Check for corner case - if there is nothing to compute, return.
@@ -784,19 +827,22 @@ class MklConv2DOp : public OpKernel {
 
       // Corner cases: output with 0 elements and 0 batch size.
       Tensor* dst_tensor = nullptr;
-      if (dst_tf_shape.num_elements() == 0 ||
-          dst_dims_tf_order[0] == 0) {
+      if (dst_tf_shape.num_elements() == 0 || dst_dims_tf_order[0] == 0) {
         MklDnnShape dst_mkl_shape;
         dst_mkl_shape.SetMklTensor(false);
-        AllocateOutputSetMklShape(context, kOutputIndex_Dst,
-                    &dst_tensor, src_tf_shape, dst_mkl_shape);
+        AllocateOutputSetMklShape(context, kOutputIndex_Dst, &dst_tensor,
+                                  src_tf_shape, dst_mkl_shape);
 
-        // MklConv2D also outputs converted filter as 2nd output of Conv2D.
-        filter_mkl_shape.SetMklTensor(false);
         Tensor* output_filter_tensor = nullptr;
-        AllocateOutputSetMklShape(context, kOutputIndex_Filter,
-                                  &output_filter_tensor,
-                                  filter_tf_shape, filter_mkl_shape);
+        // MklConv2D also outputs converted filter as 2nd output of Conv2D.
+        if (typeid(Tinput) == typeid(float) &&
+            typeid(Tfilter) == typeid(float) &&
+            typeid(Toutput) == typeid(float)) {
+          filter_mkl_shape.SetMklTensor(false);
+          AllocateOutputSetMklShape(context, kOutputIndex_Filter,
+                                    &output_filter_tensor, filter_tf_shape,
+                                    filter_mkl_shape);
+        }
         return;
       }
 
@@ -811,14 +857,14 @@ class MklConv2DOp : public OpKernel {
       // layout (NHWC or NCHW depending on data format).
       auto src_md = src_mkl_shape.IsMklTensor()
                         ? src_mkl_shape.GetMklLayout()
-                        : memory::desc(src_dims, MklDnnType<T>(), tf_fmt);
+                        : memory::desc(src_dims, MklDnnType<Tinput>(), tf_fmt);
       src.SetUsrMem(src_md, &src_tensor);
 
       // Although filter shape (filter_dims) required is in MKL-DNN order,
       // the layout is Tensorflow's layout (HWIO).
       auto filter_md = filter_mkl_shape.IsMklTensor()  // Should NEVER be true
                            ? filter_mkl_shape.GetMklLayout()
-                           : memory::desc(filter_dims, MklDnnType<T>(),
+                           : memory::desc(filter_dims, MklDnnType<Tfilter>(),
                                           memory::format::hwio);
       filter.SetUsrMem(filter_md, &filter_tensor);
 
@@ -827,65 +873,111 @@ class MklConv2DOp : public OpKernel {
       dilations[kDilationW] -= 1;
 
       // get a conv2d fwd from primitive pool
-      Conv2DFwd<T> *conv2d_fwd = nullptr;
+      Conv2DFwd<float, Tinput, Tfilter, Tbias, Toutput>* conv2d_fwd = nullptr;
       if (biasEnabled) {
         memory::dims bias_dims = {};
         conv_utl.GetBiasSizeInMklOrder(kInputIndex_Bias, &bias_dims);
-        ConvFwdDimensions convFwdDims(src_dims, filter_dims, bias_dims,
-          dst_dims_mkl_order, strides, dilations, padding_left, padding_right);
-        conv2d_fwd = Conv2DFwdFactory<T>::Get(convFwdDims);
+        ConvFwdParams conv_fwd_params(src_dims, filter_dims, bias_dims,
+                                      dst_dims_mkl_order, strides, dilations,
+                                      padding_left, padding_right);
+
+        // TODO(mdfaijul):  Extend the basic parameters for data types and
+        // fusions
+        this->ExtendConvFwdParams(conv_fwd_params);
+
+        conv2d_fwd =
+            Conv2DFwdFactory<float, Tinput, Tfilter, Tbias, Toutput>::Get(
+                conv_fwd_params);
       } else {
-        ConvFwdDimensions convFwdDims(src_dims, filter_dims, NONE_DIMS,
-          dst_dims_mkl_order, strides, dilations, padding_left, padding_right);
-        conv2d_fwd = Conv2DFwdFactory<T>::Get(convFwdDims);
+        ConvFwdParams conv_fwd_params(src_dims, filter_dims, NONE_DIMS,
+                                      dst_dims_mkl_order, strides, dilations,
+                                      padding_left, padding_right);
+
+        // Extend the basic parameters for data types and fusions
+        this->ExtendConvFwdParams(conv_fwd_params);
+
+        conv2d_fwd =
+            Conv2DFwdFactory<float, Tinput, Tfilter, Tbias, Toutput>::Get(
+                conv_fwd_params);
       }
 
       // allocate output tensors output_tensor and filter_out_tensor
-      std::shared_ptr<mkldnn::convolution_forward::primitive_desc>
-      conv_fwd_pd = conv2d_fwd->fwd_pd_;
-      AllocateOutputTensor(context, *conv_fwd_pd,
-                       dst_dims_mkl_order, tf_fmt, &dst_tensor);
-      Tensor* filter_out_tensor = nullptr;
-      AllocateFilterOutputTensor(context, *conv_fwd_pd,
-                                 TFShapeToMklDnnDims(filter_tf_shape),
-                                 &filter_out_tensor);
+      std::shared_ptr<mkldnn::convolution_forward::primitive_desc> conv_fwd_pd =
+          conv2d_fwd->fwd_pd_;
+      AllocateOutputTensor(context, *conv_fwd_pd, dst_dims_mkl_order, tf_fmt,
+                           &dst_tensor);
 
-      T* dst_data = static_cast<T*>(dst_tensor->flat<T>().data());
+      Tensor* filter_out_tensor = nullptr;
+      if (typeid(Tinput) == typeid(float) && typeid(Tfilter) == typeid(float) &&
+          typeid(Toutput) == typeid(float)) {
+        AllocateFilterOutputTensor(context, *conv_fwd_pd,
+                                   TFShapeToMklDnnDims(filter_tf_shape),
+                                   &filter_out_tensor);
+      }
+
+      Toutput* dst_data =
+          static_cast<Toutput*>(dst_tensor->flat<Toutput>().data());
 
       // check whether src/filter need reorder
       std::vector<primitive> net;
       if (src_md.data.format != conv2d_fwd->src_fmt_)
-          src.CheckReorderToOpMem(
-              conv_fwd_pd.get()->src_primitive_desc(), &net);
+        src.CheckReorderToOpMem(conv_fwd_pd.get()->src_primitive_desc(), &net);
 
-      if (filter_md.data.format != conv2d_fwd->filter_fmt_)
+      if (filter_md.data.format != conv2d_fwd->filter_fmt_) {
+        if (filter_out_tensor == nullptr) {
+          filter.CheckReorderToOpMem(
+              conv_fwd_pd.get()->weights_primitive_desc(), &net);
+        } else {
           filter.CheckReorderToOpMem(
               conv_fwd_pd.get()->weights_primitive_desc(),
               filter.GetTensorBuffer(filter_out_tensor), &net);
+        }
+      }
+
       stream(stream::kind::eager).submit(net).wait();
 
-      T* src_data = static_cast<T*>(
-                src.GetOpMem().get_data_handle());
-      T* filter_data = static_cast<T*>(
-                filter.GetOpMem().get_data_handle());
+      Tinput* src_data = static_cast<Tinput*>(src.GetOpMem().get_data_handle());
+      Tfilter* filter_data =
+          static_cast<Tfilter*>(filter.GetOpMem().get_data_handle());
 
       // execute convolution
       if (biasEnabled) {
         const Tensor& bias_tensor = MklGetInput(context, kInputIndex_Bias);
-        T* bias_data = static_cast<T*>(const_cast<T*>(
-            bias_tensor.flat<T>().data()));
-
+        Tbias* bias_data =
+            this->GetBiasHandle(context, conv_fwd_pd, bias_tensor);
         conv2d_fwd->Execute(src_data, filter_data, bias_data, dst_data);
       } else {
         conv2d_fwd->Execute(src_data, filter_data, dst_data);
       }
-    } catch (mkldnn::error &e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                       ", message: " + std::string(e.message) +
-                       ", in file " + std::string(__FILE__) + ":" +
-                       std::to_string(__LINE__);
-      OP_REQUIRES_OK(context,
-        errors::Aborted("Operation received an exception:", error_msg));
+    } catch (mkldnn::error& e) {
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         std::string(e.message) + ", in file " +
+                         std::string(__FILE__) + ":" + std::to_string(__LINE__);
+      OP_REQUIRES_OK(
+          context,
+          errors::Aborted("Operation received an exception:", error_msg));
+    }
+  }
+
+  virtual void ExtendConvFwdParams(ConvFwdParams& params) {
+    // Create a string from data types of input, filter, bias, and output.
+    params.dtypes.append(typeid(Tinput).name());
+    params.dtypes.append(typeid(Tfilter).name());
+    params.dtypes.append(typeid(Tbias).name());
+    params.dtypes.append(typeid(Toutput).name());
+  }
+
+  virtual Tbias* GetBiasHandle(
+      OpKernelContext* context,
+      std::shared_ptr<mkldnn::convolution_forward::primitive_desc>&
+          conv2d_fwd_pd,
+      const Tensor& bias_tensor) {
+    if (biasEnabled) {
+      Tbias* bias_data = static_cast<Tbias*>(
+          const_cast<Tbias*>(bias_tensor.flat<Tbias>().data()));
+      return bias_data;
+    } else {
+      return nullptr;
     }
   }
 
@@ -897,7 +989,7 @@ class MklConv2DOp : public OpKernel {
   const int kInputIndex_Src = 0, kInputIndex_Filter = 1, kInputIndex_Bias = 2;
   const int kOutputIndex_Dst = 0, kOutputIndex_Filter = 1;
   const int kDilationH = 0, kDilationW = 1;
-  engine cpu_engine = engine(engine::cpu, 0);
+  engine cpu_engine_ = engine(engine::cpu, 0);
 
   // Allocate output tensor.
   void AllocateOutputTensor(
@@ -912,13 +1004,13 @@ class MklConv2DOp : public OpKernel {
     MklDnnShape output_mkl_shape;
     output_mkl_shape.SetMklTensor(true);
     output_mkl_shape.SetMklLayout(&dst_pd);
-    output_mkl_shape.SetElemType(MklDnnType<T>());
+    output_mkl_shape.SetElemType(MklDnnType<Toutput>());
     output_mkl_shape.SetTfLayout(output_dims_mkl_order.size(),
                                  output_dims_mkl_order, output_tf_format);
 
     // Allocate shape of TF tensor.
     TensorShape output_tf_shape;
-    output_tf_shape.AddDim((dst_pd.get_size() / sizeof(T)));
+    output_tf_shape.AddDim((dst_pd.get_size() / sizeof(Toutput)));
 
     AllocateOutputSetMklShape(context, kOutputIndex_Dst, output_tensor,
                               output_tf_shape, output_mkl_shape);
@@ -936,7 +1028,7 @@ class MklConv2DOp : public OpKernel {
     MklDnnShape filter_mkl_shape;
     filter_mkl_shape.SetMklTensor(true);
     filter_mkl_shape.SetMklLayout(&filter_pd);
-    filter_mkl_shape.SetElemType(MklDnnType<T>());
+    filter_mkl_shape.SetElemType(MklDnnType<Tfilter>());
 
     // The format of the filter is actually OIhw8i8o, but TF doesn't support
     // this format. Just use format::blocked for now because the layout
@@ -946,7 +1038,7 @@ class MklConv2DOp : public OpKernel {
 
     // Allocate the data space for the filter to propagate as TF tensor.
     TensorShape filter_tf_shape;
-    filter_tf_shape.AddDim((filter_pd.get_size() / sizeof(T)));
+    filter_tf_shape.AddDim((filter_pd.get_size() / sizeof(Tfilter)));
 
     AllocateOutputSetMklShape(context, kOutputIndex_Filter, filter_tensor,
                               filter_tf_shape, filter_mkl_shape);
@@ -955,8 +1047,9 @@ class MklConv2DOp : public OpKernel {
   // Prepare and execute net - checks for input and output reorders.
   void PrepareAndExecuteNet(
       const convolution_forward::primitive_desc& conv_prim_desc,
-      MklDnnData<T>* src, MklDnnData<T>* filter, MklDnnData<T>* bias,
-      MklDnnData<T>* output, Tensor* filter_out_tensor) {
+      MklDnnData<Tinput>* src, MklDnnData<Tfilter>* filter,
+      MklDnnData<Tbias>* bias, MklDnnData<Toutput>* output,
+      Tensor* filter_out_tensor) {
     CHECK_NOTNULL(filter_out_tensor);
 
     // Create reorders between user layout and MKL layout if it is needed and
@@ -988,23 +1081,219 @@ class MklConv2DOp : public OpKernel {
   }
 };
 
-#endif
+template <typename Device, bool biasEnabled>
+class MklQuantizedConv2DOp
+    : public MklConv2DOp<Device, quint8, qint8, float, qint32, biasEnabled> {
+ public:
+  virtual ~MklQuantizedConv2DOp() {
+    if (this->input_bias_ != nullptr) {
+      delete this->input_bias_;
+    }
 
-#define REGISTER_MKL_CPU(T)                                         \
-  REGISTER_KERNEL_BUILDER(Name("_MklConv2D")                        \
-                              .Device(DEVICE_CPU)                   \
-                              .TypeConstraint<T>("T")               \
-                              .Label(mkl_op_registry::kMklOpLabel), \
-                          MklConv2DOp<CPUDevice, T, false>);        \
-  REGISTER_KERNEL_BUILDER(Name("_MklConv2DWithBias")                \
-                              .Device(DEVICE_CPU)                   \
-                              .TypeConstraint<T>("T")               \
-                              .Label(mkl_op_registry::kMklOpLabel), \
-                          MklConv2DOp<CPUDevice, T, true>);         \
-  REGISTER_KERNEL_BUILDER(Name("__MklDummyConv2DWithBias")          \
-                              .Device(DEVICE_CPU)                   \
-                              .TypeConstraint<T>("T")               \
-                              .Label(mkl_op_registry::kMklOpLabel), \
+    if (this->scaled_bias_ != nullptr) {
+      delete this->scaled_bias_;
+    }
+  }
+
+  explicit MklQuantizedConv2DOp(OpKernelConstruction* context)
+      : MklConv2DOp<Device, quint8, qint8, float, qint32, biasEnabled>(
+            context) {}
+
+  void Compute(OpKernelContext* context) override {
+    // Compute int32 output tensor
+    MklConv2DOp<Device, quint8, qint8, float, qint32, biasEnabled>::Compute(
+        context);
+
+    // Compute additional outputs fp32 min/max sclars.
+    int bias_index_offset;
+    bias_index_offset = biasEnabled ? 1 : 0;
+
+    const float min_input =
+        context->input(2 + bias_index_offset).flat<float>()(0);
+    const float max_input =
+        context->input(3 + bias_index_offset).flat<float>()(0);
+    const float min_filter =
+        context->input(4 + bias_index_offset).flat<float>()(0);
+    const float max_filter =
+        context->input(5 + bias_index_offset).flat<float>()(0);
+
+    float min_output_value;
+    float max_output_value;
+    MklQuantizationRangeForMultiplication<quint8, qint8, qint32>(
+        min_input, max_input, min_filter, max_filter, &min_output_value,
+        &max_output_value);
+    Tensor* output_min = nullptr;
+    Tensor* output_max = nullptr;
+    MklDnnShape output_min_mkl_shape, output_max_mkl_shape;
+    output_min_mkl_shape.SetMklTensor(false);
+    output_max_mkl_shape.SetMklTensor(false);
+    AllocateOutputSetMklShape(context, 1, &output_min, {},
+                              output_min_mkl_shape);
+    AllocateOutputSetMklShape(context, 2, &output_max, {},
+                              output_max_mkl_shape);
+    output_min->flat<float>()(0) = min_output_value;
+    output_max->flat<float>()(0) = max_output_value;
+  }
+
+  void ExtendConvFwdParams(ConvFwdParams& params) override {
+    MklConv2DOp<Device, quint8, qint8, float, qint32,
+                biasEnabled>::ExtendConvFwdParams(params);
+  }
+
+  float* GetBiasHandle(
+      OpKernelContext* context,
+      std::shared_ptr<mkldnn::convolution_forward::primitive_desc>& conv_fwd_pd,
+      const Tensor& bias_tensor) override {
+    int bias_index_offset;
+    bias_index_offset = biasEnabled ? 1 : 0;
+
+    const float min_input =
+        context->input(2 + bias_index_offset).flat<float>()(0);
+    const float max_input =
+        context->input(3 + bias_index_offset).flat<float>()(0);
+    const float min_filter =
+        context->input(4 + bias_index_offset).flat<float>()(0);
+    const float max_filter =
+        context->input(5 + bias_index_offset).flat<float>()(0);
+
+    std::vector<mkldnn::primitive> net;
+    // If bias is enabled, scale the bias to be consistent with quantized-input
+    // and quantized-filter.
+    if (biasEnabled) {
+      float bias_scale = 255.0 * 127.0 /
+                         (std::max(std::abs(max_input), std::abs(min_input)) *
+                          std::max(std::abs(max_filter), std::abs(min_filter)));
+      std::vector<float> scales;
+      scales.push_back(bias_scale);
+      mkldnn::primitive_attr bias_attr;
+      bias_attr.set_output_scales(0, scales);
+
+      void* bias_buf = static_cast<void*>(
+          const_cast<float*>(bias_tensor.flat<float>().data()));
+      input_bias_ = new memory(conv_fwd_pd->bias_primitive_desc(), bias_buf);
+      scaled_bias_ = new memory(conv_fwd_pd->bias_primitive_desc());
+      auto reorder_desc = mkldnn::reorder::primitive_desc(
+          input_bias_->get_primitive_desc(), scaled_bias_->get_primitive_desc(),
+          bias_attr);
+      net.push_back(mkldnn::reorder(reorder_desc, *input_bias_, *scaled_bias_));
+      stream(stream::kind::eager).submit(net).wait();
+      return reinterpret_cast<float*>(scaled_bias_->get_data_handle());
+    } else {
+      return nullptr;
+    }
+  }
+
+ private:
+  memory* input_bias_ = nullptr;
+  memory* scaled_bias_ = nullptr;
+};
+
+template <typename Device, bool biasEnabled>
+class MklQuantizedConv2DReluOp
+    : public MklQuantizedConv2DOp<Device, biasEnabled> {
+ public:
+  virtual ~MklQuantizedConv2DReluOp() {}
+
+  explicit MklQuantizedConv2DReluOp(OpKernelConstruction* context)
+      : MklQuantizedConv2DOp<Device, biasEnabled>(context) {}
+
+  void ExtendConvFwdParams(ConvFwdParams& params) override {
+    MklQuantizedConv2DOp<Device, biasEnabled>::ExtendConvFwdParams(params);
+    params.post_ops.push_back("relu");
+  }
+};
+
+// Register NoOp kernel for QunatizedConv2D since none is registered for
+// filter data type of qint8.
+REGISTER_KERNEL_BUILDER(Name("QuantizedConv2D")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<quint8>("Tinput")
+                            .TypeConstraint<qint8>("Tfilter")
+                            .TypeConstraint<qint32>("out_type"),
+                        NoOp);
+
+// Register a templatized implementation of MklQuntizedConv2D.
+REGISTER_KERNEL_BUILDER(Name("_MklQuantizedConv2D")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<quint8>("Tinput")
+                            .TypeConstraint<qint8>("Tfilter")
+                            .TypeConstraint<qint32>("out_type")
+                            .Label(mkl_op_registry::kMklQuantizedOpLabel),
+                        MklQuantizedConv2DOp<CPUDevice, false>);
+
+// Register NoOp kernel for QuantizedConv2DWithBias to get a python interface.
+// This kernel will be replaced by an MKL kernel during graph
+// optimization pass.
+REGISTER_KERNEL_BUILDER(Name("QuantizedConv2DWithBias")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<quint8>("Tinput")
+                            .TypeConstraint<qint8>("Tfilter")
+                            .TypeConstraint<qint32>("out_type"),
+                        NoOp);
+
+// Register a templatized implementation MklQuantizedConv2DWithBias.
+REGISTER_KERNEL_BUILDER(Name("_MklQuantizedConv2DWithBias")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<quint8>("Tinput")
+                            .TypeConstraint<qint8>("Tfilter")
+                            .TypeConstraint<qint32>("out_type")
+                            .Label(mkl_op_registry::kMklQuantizedOpLabel),
+                        MklQuantizedConv2DOp<CPUDevice, true>);
+
+// Register NoOp kernel for QuantizedConv2DAndRelu to get a python interface.
+// This kernel will be replaced by an MKL kernel during graph-optimization pass.
+REGISTER_KERNEL_BUILDER(Name("QuantizedConv2DAndRelu")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<quint8>("Tinput")
+                            .TypeConstraint<qint8>("Tfilter")
+                            .TypeConstraint<qint32>("out_type"),
+                        NoOp);
+
+// Register a templatized implementation of MklQuantizedConv2DAndRelu.
+REGISTER_KERNEL_BUILDER(Name("_MklQuantizedConv2DAndRelu")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<quint8>("Tinput")
+                            .TypeConstraint<qint8>("Tfilter")
+                            .TypeConstraint<qint32>("out_type")
+                            .Label(mkl_op_registry::kMklQuantizedOpLabel),
+                        MklQuantizedConv2DReluOp<CPUDevice, false>);
+
+// Register NoOp kernel for QuantizedConv2DWithBiasAndRelu to get a python
+// interface.
+// This kernel will be replaced by an MKL kernel during graph-optimization pass.
+REGISTER_KERNEL_BUILDER(Name("QuantizedConv2DWithBiasAndRelu")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<quint8>("Tinput")
+                            .TypeConstraint<qint8>("Tfilter")
+                            .TypeConstraint<qint32>("out_type"),
+                        NoOp);
+
+// Register a templatized implementation of MklQuantizedConv2DWithBiasAndRelu.
+REGISTER_KERNEL_BUILDER(Name("_MklQuantizedConv2DWithBiasAndRelu")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<quint8>("Tinput")
+                            .TypeConstraint<qint8>("Tfilter")
+                            .TypeConstraint<qint32>("out_type")
+                            .Label(mkl_op_registry::kMklQuantizedOpLabel),
+                        MklQuantizedConv2DReluOp<CPUDevice, true>);
+
+#endif  // INTEL_MKL_ML
+
+#define REGISTER_MKL_CPU(T)                                           \
+  REGISTER_KERNEL_BUILDER(Name("_MklConv2D")                          \
+                              .Device(DEVICE_CPU)                     \
+                              .TypeConstraint<T>("T")                 \
+                              .Label(mkl_op_registry::kMklOpLabel),   \
+                          MklConv2DOp<CPUDevice, T, T, T, T, false>); \
+  REGISTER_KERNEL_BUILDER(Name("_MklConv2DWithBias")                  \
+                              .Device(DEVICE_CPU)                     \
+                              .TypeConstraint<T>("T")                 \
+                              .Label(mkl_op_registry::kMklOpLabel),   \
+                          MklConv2DOp<CPUDevice, T, T, T, T, true>);  \
+  REGISTER_KERNEL_BUILDER(Name("__MklDummyConv2DWithBias")            \
+                              .Device(DEVICE_CPU)                     \
+                              .TypeConstraint<T>("T")                 \
+                              .Label(mkl_op_registry::kMklOpLabel),   \
                           MklDummyOp<CPUDevice, T>);
 
 TF_CALL_float(REGISTER_MKL_CPU);

--- a/tensorflow/core/kernels/mkl_tfconv_op.h
+++ b/tensorflow/core/kernels/mkl_tfconv_op.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <vector>
+#include <string>
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -201,6 +202,7 @@ class MklToTfOp : public OpKernel {
                           MklToTfOp<CPUDevice, T>);
 
 TF_CALL_NUMBER_TYPES(REGISTER_CPU);
+TF_CALL_QUANTIZED_TYPES(REGISTER_CPU);
 #undef REGISTER_CPU
 }  // namespace tensorflow
 #endif  // INTEL_MKL

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -2159,7 +2159,7 @@ REGISTER_OP("_MklToTf")
     .Input("input: T")
     .Input("mkl_input: uint8")
     .Output("output: T")
-    .Attr("T: {half, float, double}")
+    .Attr("T: {half, float, double, qint8, quint8, qint32}")
     .Attr(GetConvnetDataFormatAttrString())
     .SetShapeFn(shape_inference::UnknownShape)
     .Doc(R"doc(
@@ -2192,6 +2192,291 @@ element-wise MKL op.
 NOTE Do not invoke this operator directly in Python. Graph rewrite pass is
 expected to invoke these operators.
 )doc");
+
+REGISTER_OP("_MklQuantizedConv2D")
+    .Input("input: Tinput")
+    .Input("filter: Tfilter")
+    .Input("min_input: float")
+    .Input("max_input: float")
+    .Input("min_filter: float")
+    .Input("max_filter: float")
+    .Input("mkl_input: uint8")
+    .Input("mkl_filter: uint8")
+    .Input("mkl_min_input: uint8")
+    .Input("mkl_max_input: uint8")
+    .Input("mkl_min_filter: uint8")
+    .Input("mkl_max_filter: uint8")
+    .Output("output: out_type")
+    .Output("min_output: float")
+    .Output("max_output: float")
+    .Output("mkl_output: uint8")
+    .Output("mkl_min_output: uint8")
+    .Output("mkl_max_output: uint8")
+    .Attr("Tinput: quantizedtype")
+    .Attr("Tfilter: quantizedtype")
+    .Attr("T: quantizedtype")  // Additional attribute "T" for enabling MklToTf
+                               // conversion
+    .Attr("out_type: quantizedtype = DT_QINT32")
+    .Attr("data_format: string = 'NHWC'")
+    .Attr("strides: list(int)")
+    .Attr(GetPaddingAttrString())
+    .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .SetShapeFn([](InferenceContext* c) {
+      TF_RETURN_IF_ERROR(shape_inference::Conv2DShape(c));
+      ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused));
+      c->set_output(1, c->Scalar());
+      c->set_output(2, c->Scalar());
+      return Status::OK();
+    })
+    .Doc(R"doc(
+MKLDNN implementation of QuantizedConv2D OP.
+)doc");
+
+// Fusion of Quantized Conv2D and BiasAdd.
+REGISTER_OP("QuantizedConv2DWithBias")
+    .Input("input: Tinput")
+    .Input("filter: Tfilter")
+    .Input("bias: float")
+    .Input("min_input: float")
+    .Input("max_input: float")
+    .Input("min_filter: float")
+    .Input("max_filter: float")
+    .Output("output: out_type")
+    .Output("min_output: float")
+    .Output("max_output: float")
+    .Attr("Tinput: quantizedtype")
+    .Attr("Tfilter: quantizedtype")
+    .Attr("out_type: quantizedtype = DT_QINT32")
+    .Attr("strides: list(int)")
+    .Attr(GetPaddingAttrString())
+    .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .SetShapeFn([](InferenceContext* c) {
+      TF_RETURN_IF_ERROR(shape_inference::Conv2DShape(c));
+      ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 1, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(6), 0, &unused));
+      c->set_output(1, c->Scalar());
+      c->set_output(2, c->Scalar());
+      return Status::OK();
+    })
+    .Doc(R"doc(
+This Op registration is meant for QuantizedConv2DWithBias operator
+that can be accessed through
+tensorflow.python.ops.gen_nn_ops.quantized_conv2d_with_bias(...).
+)doc");
+
+REGISTER_OP("_MklQuantizedConv2DWithBias")
+    .Input("input: Tinput")
+    .Input("filter: Tfilter")
+    .Input("bias: float")
+    .Input("min_input: float")
+    .Input("max_input: float")
+    .Input("min_filter: float")
+    .Input("max_filter: float")
+    .Input("mkl_input: uint8")
+    .Input("mkl_filter: uint8")
+    .Input("mkl_bias: uint8")
+    .Input("mkl_min_input: uint8")
+    .Input("mkl_max_input: uint8")
+    .Input("mkl_min_filter: uint8")
+    .Input("mkl_max_filter: uint8")
+    .Output("output: out_type")
+    .Output("min_output: float")
+    .Output("max_output: float")
+    .Output("mkl_output: uint8")
+    .Output("mkl_min_output: uint8")
+    .Output("mkl_max_output: uint8")
+    .Attr("Tinput: quantizedtype")
+    .Attr("Tfilter: quantizedtype")
+    .Attr("T: quantizedtype = DT_QINT32")  // Additional attribute "T" for
+                                           // enabling MklToTf conversion
+    .Attr("out_type: quantizedtype = DT_QINT32")
+    .Attr("data_format: string = 'NHWC'")
+    .Attr("strides: list(int)")
+    .Attr(GetPaddingAttrString())
+    .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .SetShapeFn([](InferenceContext* c) {
+      TF_RETURN_IF_ERROR(shape_inference::Conv2DShape(c));
+      ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 1, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(6), 0, &unused));
+      c->set_output(1, c->Scalar());
+      c->set_output(2, c->Scalar());
+      return Status::OK();
+    })
+    .Doc(R"doc(
+MKLDNN implementation of QuantizedConv2DWithBias
+)doc");
+
+// Fusion of Quantized Conv2D and Relu.
+REGISTER_OP("QuantizedConv2DAndRelu")
+    .Input("input: Tinput")
+    .Input("filter: Tfilter")
+    .Input("min_input: float")
+    .Input("max_input: float")
+    .Input("min_filter: float")
+    .Input("max_filter: float")
+    .Output("output: out_type")
+    .Output("min_output: float")
+    .Output("max_output: float")
+    .Attr("Tinput: quantizedtype")
+    .Attr("Tfilter: quantizedtype")
+    .Attr("out_type: quantizedtype = DT_QINT32")
+    .Attr("strides: list(int)")
+    .Attr(GetPaddingAttrString())
+    .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .SetShapeFn([](InferenceContext* c) {
+      TF_RETURN_IF_ERROR(shape_inference::Conv2DShape(c));
+      ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused));
+      c->set_output(1, c->Scalar());
+      c->set_output(2, c->Scalar());
+      return Status::OK();
+    })
+    .Doc(R"doc(
+This Op registration is meant for QuantizedConv2DAndRelu operator
+that can be accessed through
+tensorflow.python.ops.gen_nn_ops.quantized_conv2d_and_relu(...).
+)doc");
+
+REGISTER_OP("_MklQuantizedConv2DAndRelu")
+    .Input("input: Tinput")
+    .Input("filter: Tfilter")
+    .Input("min_input: float")
+    .Input("max_input: float")
+    .Input("min_filter: float")
+    .Input("max_filter: float")
+    .Input("mkl_input: uint8")
+    .Input("mkl_filter: uint8")
+    .Input("mkl_min_input: uint8")
+    .Input("mkl_max_input: uint8")
+    .Input("mkl_min_filter: uint8")
+    .Input("mkl_max_filter: uint8")
+    .Output("output: out_type")
+    .Output("min_output: float")
+    .Output("max_output: float")
+    .Output("mkl_output: uint8")
+    .Output("mkl_min_output: uint8")
+    .Output("mkl_max_output: uint8")
+    .Attr("Tinput: quantizedtype")
+    .Attr("Tfilter: quantizedtype")
+    .Attr("T: quantizedtype")  // Additional attribute "T" for enabling MklToTf
+                               // conversion
+    .Attr("out_type: quantizedtype = DT_QINT32")
+    .Attr("data_format: string = 'NHWC'")
+    .Attr("strides: list(int)")
+    .Attr(GetPaddingAttrString())
+    .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .SetShapeFn([](InferenceContext* c) {
+      TF_RETURN_IF_ERROR(shape_inference::Conv2DShape(c));
+      ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused));
+      c->set_output(1, c->Scalar());
+      c->set_output(2, c->Scalar());
+      return Status::OK();
+    })
+    .Doc(R"doc(
+MKLDNN implementation of QuantizedConv2DAndRelu operator.
+)doc");
+
+// Fusion of Quantized Conv2D, BiasAdd and Relu.
+REGISTER_OP("QuantizedConv2DWithBiasAndRelu")
+    .Input("input: Tinput")
+    .Input("filter: Tfilter")
+    .Input("bias: float")
+    .Input("min_input: float")
+    .Input("max_input: float")
+    .Input("min_filter: float")
+    .Input("max_filter: float")
+    .Output("output: out_type")
+    .Output("min_output: float")
+    .Output("max_output: float")
+    .Attr("Tinput: quantizedtype")
+    .Attr("Tfilter: quantizedtype")
+    .Attr("out_type: quantizedtype = DT_QINT32")
+    .Attr("strides: list(int)")
+    .Attr(GetPaddingAttrString())
+    .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .SetShapeFn([](InferenceContext* c) {
+      TF_RETURN_IF_ERROR(shape_inference::Conv2DShape(c));
+      ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 1, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(6), 0, &unused));
+      c->set_output(1, c->Scalar());
+      c->set_output(2, c->Scalar());
+      return Status::OK();
+    })
+    .Doc(R"doc(
+This Op registration is meant for QuantizedConv2DWithBiasAndRelu operator
+that can be accessed through
+tensorflow.python.ops.gen_nn_ops.quantized_conv2d_with_bias_and_relu(...).
+)doc");
+
+REGISTER_OP("_MklQuantizedConv2DWithBiasAndRelu")
+    .Input("input: Tinput")
+    .Input("filter: Tfilter")
+    .Input("bias: float")
+    .Input("min_input: float")
+    .Input("max_input: float")
+    .Input("min_filter: float")
+    .Input("max_filter: float")
+    .Input("mkl_input: uint8")
+    .Input("mkl_filter: uint8")
+    .Input("mkl_bias: uint8")
+    .Input("mkl_min_input: uint8")
+    .Input("mkl_max_input: uint8")
+    .Input("mkl_min_filter: uint8")
+    .Input("mkl_max_filter: uint8")
+    .Output("output: out_type")
+    .Output("min_output: float")
+    .Output("max_output: float")
+    .Output("mkl_output: uint8")
+    .Output("mkl_min_output: uint8")
+    .Output("mkl_max_output: uint8")
+    .Attr("Tinput: quantizedtype")
+    .Attr("Tfilter: quantizedtype")
+    .Attr("T: quantizedtype = DT_QINT32")  // Additional attribute "T" for
+                                           // enabling MklToTf conversion
+    .Attr("out_type: quantizedtype = DT_QINT32")
+    .Attr("data_format: string = 'NHWC'")
+    .Attr("strides: list(int)")
+    .Attr(GetPaddingAttrString())
+    .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .SetShapeFn([](InferenceContext* c) {
+      TF_RETURN_IF_ERROR(shape_inference::Conv2DShape(c));
+      ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 1, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(6), 0, &unused));
+      c->set_output(1, c->Scalar());
+      c->set_output(2, c->Scalar());
+      return Status::OK();
+    })
+    .Doc(R"doc(
+MKLDNN implementation of QuantizedConv2DWithBiasAndRelu operator.
+)doc");
+
 #endif  // INTEL_MKL
 
 }  // namespace tensorflow

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1299,6 +1299,21 @@ memory::data_type MklDnnType<float>() {
   return memory::data_type::f32;
 }
 
+template <>
+memory::data_type MklDnnType<quint8>() {
+  return memory::data_type::u8;
+}
+
+template <>
+memory::data_type MklDnnType<qint8>() {
+  return memory::data_type::s8;
+}
+
+template <>
+memory::data_type MklDnnType<qint32>() {
+  return memory::data_type::s32;
+}
+
 /// Map TensorFlow's data format into MKL-DNN data format
 ///
 /// @input: TensorFlow data format

--- a/tensorflow/tools/quantization/quantize_graph.py
+++ b/tensorflow/tools/quantization/quantize_graph.py
@@ -350,7 +350,8 @@ def intel_cpu_quantize_weight_eightbit(input_node, quantization_mode="SCALED"):
         min_value,
         max_value,
         dtypes.qint8,
-        mode=quantization_mode)
+        mode=quantization_mode,
+        round_mode="HALF_TO_EVEN")
     qint8_tensor = quantize_op[0].eval()
     # Updated min-max values should be passed to the next feeding node.
     min_value = quantize_op[1].eval()
@@ -914,6 +915,9 @@ class GraphRewriter(object):
     set_attr_dtype(quantize_input_node, "T", dtypes.quint8)
     set_attr_string(quantize_input_node, "mode",
         b"SCALED" if self.intel_cpu_eightbitize else  b"MIN_FIRST")
+    set_attr_string(quantize_input_node, "round_mode",
+        b"HALF_TO_EVEN" if self.intel_cpu_eightbitize 
+        else  b"HALF_AWAY_FROM_ZERO")
     self.add_output_graph_node(quantize_input_node)
     min_output_name = quantize_input_name + ":1"
     max_output_name = quantize_input_name + ":2"

--- a/tensorflow/tools/quantization/quantize_graph.py
+++ b/tensorflow/tools/quantization/quantize_graph.py
@@ -21,6 +21,7 @@ bazel build tensorflow/tools/quantization:quantize_graph \
 --output_node_names="softmax2" --print_nodes --output=/tmp/quantized_graph.pb \
 --mode=eightbit --logtostderr
 
+To quantize for Intel CPU, add --intel_cpu_eightbitize=True.
 """
 
 from __future__ import absolute_import
@@ -46,6 +47,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.platform import app
 from tensorflow.python.platform import flags as flags_lib
 from tensorflow.python.platform import gfile
+from google.protobuf import text_format
 
 flags = flags_lib
 FLAGS = flags.FLAGS
@@ -87,7 +89,14 @@ flags.DEFINE_float(
     "information. Note: this should be considered a coarse tool just good "
     "enough for experimentation purposes, since graphs quantized in this way "
     "would be very inaccurate.")
-
+flags.DEFINE_boolean("input_binary", True,
+                     """Input graph binary or text.""")
+flags.DEFINE_boolean("output_binary", True,
+                     """Output graph binary or text.""")
+flags.DEFINE_boolean(
+    "intel_cpu_eightbitize", False,
+    "If true eightbitized graph will include fused quantized"
+    "nodes in the output_graph for Intel CPU.")
 
 def print_input_nodes(current_node, nodes_map, indent, already_visited):
   print(" " * indent + current_node.op + ":" + current_node.name)
@@ -309,6 +318,56 @@ def quantize_weight_eightbit(input_node, quantization_mode):
   set_attr_string(dequantize_node, "mode", quantization_mode)
   return [quint8_const_node, min_node, max_node, dequantize_node]
 
+# TODO(intel-tf): Current Intel-CPU quantized Conv2D and Matmul supports only
+# signed scaled mode of weight quantization.
+def intel_cpu_quantize_weight_eightbit(input_node, quantization_mode="SCALED"):
+  """Returns replacement of constant weight node.
+
+  This function creates (i) a quantized constant node, (ii) a float min node
+  (iii) a float max node, and (iv) a dequantize node."""
+  base_name = input_node.name + "_"
+  qint8_const_name = base_name + "qint8_const"
+  min_name = base_name + "min"
+  max_name = base_name + "max"
+  float_tensor = tensor_util.MakeNdarray(input_node.attr["value"].tensor)
+  min_value = np.min(float_tensor.flatten())
+  max_value = np.max(float_tensor.flatten())
+  # Same processing of min-max as in quantize_weight_eightbit function.
+  if min_value > 0.0:
+    min_value = 0.0
+  if min_value == max_value:
+    if abs(min_value) < 0.000001:
+      max_value = min_value + 1.0
+    elif min_value > 0:
+      max_value = 2 * min_value
+    else:
+      max_value = min_value / 2.0
+
+  sess = session.Session()
+  with sess.as_default():
+    quantize_op = array_ops.quantize_v2(
+        float_tensor,
+        min_value,
+        max_value,
+        dtypes.qint8,
+        mode=quantization_mode)
+    qint8_tensor = quantize_op[0].eval()
+    # Updated min-max values should be passed to the next feeding node.
+    min_value = quantize_op[1].eval()
+    max_value = quantize_op[2].eval()
+  shape = tensor_util.TensorShapeProtoToList(input_node.attr["value"]
+                                             .tensor.tensor_shape)
+  qint8_const_node = create_constant_node(
+      qint8_const_name, qint8_tensor,
+      dtypes.qint8,
+      shape=shape)
+  min_node = create_constant_node(min_name, min_value, dtypes.float32)
+  max_node = create_constant_node(max_name, max_value, dtypes.float32)
+  dequantize_node = create_node("Dequantize", input_node.name,
+                                [qint8_const_name, min_name, max_name])
+  set_attr_dtype(dequantize_node, "T", dtypes.quint8)
+  set_attr_string(dequantize_node, "mode", b'SCALED')
+  return [qint8_const_node, min_node, max_node, dequantize_node]
 
 EightbitizeRecursionState = collections.namedtuple(
     "EightbitizeRecursionState",
@@ -321,6 +380,7 @@ class GraphRewriter(object):
   def __init__(self,
                input_graph,
                mode,
+               intel_cpu_eightbitize,
                quantized_input_range,
                fallback_quantization_range=None):
     """Sets up the class to rewrite a float graph.
@@ -344,6 +404,7 @@ class GraphRewriter(object):
     self.nodes_map = self.create_nodes_map(input_graph)
     self.output_graph = None
     self.mode = mode
+    self.intel_cpu_eightbitize = intel_cpu_eightbitize
     self.final_node_renames = {}
     if quantized_input_range:
       self.input_range = (quantized_input_range[0], quantized_input_range[1])
@@ -417,8 +478,22 @@ class GraphRewriter(object):
 
       self.state = EightbitizeRecursionState(
           already_visited={}, output_node_stack=[], merged_with_fake_quant={})
-      for output_node in output_nodes:
-        self.eightbitize_nodes_recursively(output_node)
+
+      if self.intel_cpu_eightbitize:
+        # TODO(intel-tf): Enables fused quantized node for intel cpu.
+        for output_node in output_nodes:
+          # Intiailize output_node_stack with output node.
+          # Each element in the stack is a mutable list containing 
+          # [parent_node, index_to_parent, quantization_flag, fusion_flag].
+          # In case of root node, make self as parent.
+          self.state.output_node_stack.append(
+              [output_node, None, False, False])
+          self.intel_cpu_eightbitize_nodes_recursively(output_node)
+          self.state.output_node_stack.pop()
+      else:
+        for output_node in output_nodes:
+          self.eightbitize_nodes_recursively(output_node)
+
       self.state = None
       if self.input_range:
         self.add_output_graph_node(
@@ -653,6 +728,131 @@ class GraphRewriter(object):
           (self.state.output_node_stack[-1][0], current_node.name,
            current_node.op))
 
+  # TODO(intel-tf): Quantized Conv2D could be fused with few other succeeding
+  # ops. Current support is for BiasAdd and Relu. Future implementation will
+  # include:
+  # (i)   Conv2D + {BiasAdd} + Relu + Add + Relu
+  # (ii)  Conv2D + {BiasAdd} + Relu + Add
+  # (ii)  Conv2D + {BiasAdd} + Add + Relu
+  # (iii) Conv2D + {BiasAdd} + Add
+  def intel_cpu_eightbitize_conv_node(self, original_node, bias_node=None,
+                                relu_node_name=None):
+    """Replaces a Conv2D node with the eight bit equivalent sub-graph."""
+    all_input_names = self.add_eightbit_prologue_nodes(original_node)
+
+    if bias_node and relu_node_name:
+      new_node = node_def_pb2.NodeDef()
+      new_node.CopyFrom(bias_node)
+      self.add_output_graph_node(new_node)
+      all_input_names = all_input_names[:2] + [bias_node.name] + \
+          all_input_names[2:]
+      quantized_conv_name = original_node.name + "_eightbit_quantized_conv"
+      quantized_conv_node = create_node("QuantizedConv2DWithBiasAndRelu",
+                              quantized_conv_name, all_input_names)
+    else:
+      quantized_conv_name = original_node.name + "_eightbit_quantized_conv"
+      quantized_conv_node = create_node("QuantizedConv2D", quantized_conv_name,
+                                        all_input_names)
+    copy_attr(quantized_conv_node, "strides", original_node.attr["strides"])
+    copy_attr(quantized_conv_node, "padding", original_node.attr["padding"])
+    set_attr_dtype(quantized_conv_node, "Tinput", dtypes.quint8)
+    set_attr_dtype(quantized_conv_node, "Tfilter", dtypes.qint8)
+    set_attr_dtype(quantized_conv_node, "out_type", dtypes.qint32)
+    self.add_output_graph_node(quantized_conv_node)
+    quantize_down_name = self.add_quantize_down_nodes(original_node,
+                                                      quantized_conv_name)
+    if bias_node and relu_node_name:
+      self.add_dequantize_result_node(quantize_down_name, relu_node_name)
+    else:
+      self.add_dequantize_result_node(quantize_down_name, original_node.name)
+
+  # TODO(intel-tf): To check whether Conv2D is fed by relu directly or via
+  # pooling ops. This is required as intel cpu requires input tensor for Conv2D
+  # to be non-negative.
+  def intel_cpu_find_relu_recursively(self, current_node):
+    """Helper function to check if Conv2D is fed by Relu."""
+    if current_node.op == "Relu":
+      return True
+    else:
+      first_input_node_name = node_name_from_input(current_node.input[0])
+      input_node = self.nodes_map[first_input_node_name]
+      if input_node.op in ("MaxPool", "AvgPool", "Relu"):
+        return self.intel_cpu_find_relu_recursively(input_node)
+      else:
+        return False
+
+  # TODO(intel-tf): We leave the output graph partially quantized for
+  # intel cpu. Current quantization support is for Conv2D and its fusion.
+  # More quantized operations will be included as more implementations are
+  # completed.
+  def intel_cpu_eightbitize_nodes_recursively(self, current_node):
+    """The entry point for transforming a graph into full eight bit."""
+    if current_node.name in self.state.already_visited:
+      if (self.should_merge_with_fake_quant_node() or
+          current_node.name in self.state.merged_with_fake_quant):
+        raise ValueError("Unsupported graph structure: output of node %s "
+                         "is processed by a FakeQuant* node and should have "
+                         "no other outputs.", current_node.name)
+      return
+
+    self.state.already_visited[current_node.name] = True
+
+    quantize_input, should_quantize_conv, \
+        fuse_with_conv = (False, False, False)
+
+    if current_node.op == "Conv2D":
+      should_quantize_conv = self.intel_cpu_find_relu_recursively(current_node)
+
+    for i, input_node_name in enumerate(current_node.input):
+      input_node_name = node_name_from_input(input_node_name)
+      input_node = self.nodes_map[input_node_name]
+
+      if should_quantize_conv and i == 1 and input_node.op == "Const":
+        quantize_input = True
+
+      self.state.output_node_stack.append([current_node, i, quantize_input,
+                                           fuse_with_conv])
+      self.intel_cpu_eightbitize_nodes_recursively(input_node)
+      self.state.output_node_stack.pop()
+
+    if current_node.op == "Conv2D" and should_quantize_conv and quantize_input:
+      # match pattern for fusion with bias and relu
+      grand_parent, parent = self.state.output_node_stack[-2:]
+      if parent[0].op == "BiasAdd" and grand_parent[0].op == "Relu":
+        self.state.output_node_stack[-2][3] = True # BiasAdd to be fused
+        self.state.output_node_stack[-3][3] = True # Relu to be fused
+        bias_node_name = node_name_from_input(parent[0].input[1])
+        bias_node = self.nodes_map[bias_node_name]
+        self.intel_cpu_eightbitize_conv_node(current_node, bias_node, grand_parent[0].name)
+      else:
+        self.intel_cpu_eightbitize_conv_node(current_node)
+    elif current_node.op == "BiasAdd" and self.state.output_node_stack[-1][3] == True:
+      pass # This op is already processed by fused quantization
+    elif current_node.op == "Relu" and self.state.output_node_stack[-1][3] == True:
+      pass # This op is already processed by fused quantization
+    elif current_node.op == "Const":
+      parent = self.state.output_node_stack[-1]
+      if parent[0].op == "Conv2D" and parent[2] == True:
+        for n in intel_cpu_quantize_weight_eightbit(current_node, b"SCALED"):
+          self.add_output_graph_node(n)
+      elif parent[0].op == "BiasAdd" and self.state.output_node_stack[-2][3] == True:
+        pass # This constant is already process by fused quantization
+      else:
+        new_node = node_def_pb2.NodeDef()
+        new_node.CopyFrom(current_node)
+        self.add_output_graph_node(new_node)
+    else:
+      new_node = node_def_pb2.NodeDef()
+      new_node.CopyFrom(current_node)
+      self.add_output_graph_node(new_node)
+
+    if (self.should_merge_with_fake_quant_node() and
+        current_node.name not in self.state.merged_with_fake_quant):
+      raise ValueError(
+          "FakeQuant* node %s failed to merge with node %s of type %s" %
+          (self.state.output_node_stack[-1][0], current_node.name,
+           current_node.op))
+
   def add_eightbit_prologue_nodes(self, original_node):
     """Adds input conversion nodes to handle quantizing the underlying node."""
     namespace_prefix = original_node.name + "_eightbit"
@@ -712,7 +912,8 @@ class GraphRewriter(object):
         "QuantizeV2", quantize_input_name,
         [original_input_name, min_input_name, max_input_name])
     set_attr_dtype(quantize_input_node, "T", dtypes.quint8)
-    set_attr_string(quantize_input_node, "mode", b"MIN_FIRST")
+    set_attr_string(quantize_input_node, "mode",
+        b"SCALED" if self.intel_cpu_eightbitize else  b"MIN_FIRST")
     self.add_output_graph_node(quantize_input_node)
     min_output_name = quantize_input_name + ":1"
     max_output_name = quantize_input_name + ":2"
@@ -1249,7 +1450,6 @@ class GraphRewriter(object):
     self.input_graph = new_input_graph
     self.nodes_map = self.create_nodes_map(self.input_graph)
 
-
 def main(unused_args):
   if not gfile.Exists(FLAGS.input):
     print("Input graph file '" + FLAGS.input + "' does not exist!")
@@ -1264,9 +1464,14 @@ def main(unused_args):
     return -1
 
   tf_graph = graph_pb2.GraphDef()
-  with gfile.Open(FLAGS.input, "rb") as f:
+  # TODO(intel-tf): Enabling user to work with both binary and text format.
+  mode = "rb" if FLAGS.input_binary else "r"
+  with gfile.Open(FLAGS.input, mode) as f:
     data = f.read()
-    tf_graph.ParseFromString(data)
+    if FLAGS.input_binary:
+      tf_graph.ParseFromString(data)
+    else:
+      text_format.Merge(data, tf_graph)
 
   graph = ops.Graph()
   with graph.as_default():
@@ -1287,16 +1492,20 @@ def main(unused_args):
         FLAGS.quantized_fallback_min, FLAGS.quantized_fallback_max
     ]
 
-  rewriter = GraphRewriter(tf_graph, FLAGS.mode, quantized_input_range,
-                           fallback_quantization_range)
+  rewriter = GraphRewriter(tf_graph, FLAGS.mode, FLAGS.intel_cpu_eightbitize,
+      quantized_input_range, fallback_quantization_range)
 
   output_graph = rewriter.rewrite(FLAGS.output_node_names.split(","))
 
-  f = gfile.FastGFile(FLAGS.output, "wb")
-  f.write(output_graph.SerializeToString())
+  # TODO(intel-tf): Enabling user to work with both binary and text format.
+  mode = "wb" if FLAGS.output_binary else "w"
+  f = gfile.FastGFile(FLAGS.output, mode)
+  if FLAGS.output_binary:
+    f.write(output_graph.SerializeToString())
+  else:
+    f.write(str(output_graph))
 
   return 0
-
 
 if __name__ == "__main__":
   app.run()


### PR DESCRIPTION
This PR is intended for comments on eight bit precision inference on Intel CPU. Please do not merge this PR. Here is summary:

1. Introduce quantized Conv2D and its fused operators. (i) Conv2D (ii) Conv2D + BiasAdd (iii) Conv2D + BiasAdd + ReLU (iv) Conv2D + Relu.
2. Adds algorithms for graph quantization [tensorflow/tools/quantization/quantize_graph.py]. The resulting graph is partially quantized, more quantized operators will be added as more implementations are done. We set round_mode to "HALF_TO_EVEN" in QuantizeOp since Intel CPU supports only that rounding mode. Future PR will include an implementation of MklQuantizeOp.
3. QuantizedConv2D and its fusion works with unsigned input and signed filter on Intel CPU.

**Example of fp32 graph:**
![fp_graph](https://user-images.githubusercontent.com/27521767/40284734-69f76140-5c48-11e8-9a8b-46c9d9ecfcaf.png)

**Example of partially quantized graph:** 
![quant_graph](https://user-images.githubusercontent.com/27521767/40284729-5d4af7fe-5c48-11e8-8ab9-b17bd8778982.png)
