### PR TITLE
fix a bug in built nsync android library

### DIFF
--- a/tensorflow/contrib/makefile/compile_nsync.sh
+++ b/tensorflow/contrib/makefile/compile_nsync.sh
@@ -270,7 +270,7 @@ for arch in $archs; do
                         PLATFORM_LDFLAGS=-pthread
                         MKDEP=${CC} -M -std=c++11
                         PLATFORM_C=../../platform/c++11/src/nsync_semaphore_mutex.cc \
-                                   ../../platform/c++11/src/per_thread_waiter.cc \
+                                   ../../platform/posix/src/per_thread_waiter.c \
                                    ../../platform/c++11/src/yield.cc \
                                    ../../platform/c++11/src/time_rep_timespec.cc \
                                    ../../platform/c++11/src/nsync_panic.cc


### PR DESCRIPTION
Edited: NDK doesn't support thread_local variables which own destructors, so on Android it should use __thread instead.

Google Protocol Buffer and other libraries have kept away from thread_local on Android.

In Tensorflow, there's a "thread_local" in code about CUDA, which should be safe enough.

More discussions are on https://github.com/android-ndk/ndk/issues/360 . Although in my tests, `gnustl_static` also caused bugs when there're `thread_local` class instances, I still agree with most of those opinions.