### PR TITLE
Add "python 3 only" support for bazel build

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -71,7 +71,12 @@ def pyx_library(
         name = filename + "_cython_translation",
         srcs = [filename],
         outs = [filename.split(".")[0] + ".cpp"],
-        cmd = "PYTHONHASHSEED=0 $${PYTHON_BIN_PATH} $(location @cython//:cython_binary) --cplus $(SRCS) --output-file $(OUTS)",
+        # Optionally use PYTHON_BIN_PATH on Linux platforms so that python 3
+        # works. Windows has issues with cython_binary so skip PYTHON_BIN_PATH.
+        cmd = "PYTHONHASHSEED=0 " + select({
+            "@bazel_tools//src/conditions:windows": "",
+            "//conditions:default": "$${PYTHON_BIN_PATH} ",
+        }) + "$(location @cython//:cython_binary) --cplus $(SRCS) --output-file $(OUTS)",
         tools = ["@cython//:cython_binary"] + pxd_srcs,
     )
 

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -71,7 +71,7 @@ def pyx_library(
         name = filename + "_cython_translation",
         srcs = [filename],
         outs = [filename.split(".")[0] + ".cpp"],
-        cmd = "PYTHONHASHSEED=0 $(location @cython//:cython_binary) --cplus $(SRCS) --output-file $(OUTS)",
+        cmd = "PYTHONHASHSEED=0 $${PYTHON_BIN_PATH} $(location @cython//:cython_binary) --cplus $(SRCS) --output-file $(OUTS)",
         tools = ["@cython//:cython_binary"] + pxd_srcs,
     )
 

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1716,7 +1716,7 @@ def tf_version_info_genrule():
       ],
       outs=["util/version_info.cc"],
       cmd=
-      "$(location //tensorflow/tools/git:gen_git_source.py) --generate $(SRCS) \"$@\" --git_tag_override=$${GIT_TAG_OVERRIDE:-}",
+      "$${PYTHON_BIN_PATH} $(location //tensorflow/tools/git:gen_git_source.py) --generate $(SRCS) \"$@\" --git_tag_override=$${GIT_TAG_OVERRIDE:-}",
       local=1,
       tools=[clean_dep("//tensorflow/tools/git:gen_git_source.py")],)
 
@@ -1725,7 +1725,7 @@ def tf_py_build_info_genrule():
       name="py_build_info_gen",
       outs=["platform/build_info.py"],
       cmd=
-      "$(location //tensorflow/tools/build_info:gen_build_info.py) --raw_generate \"$@\" --build_config " + if_cuda("cuda", "cpu"),
+      "$${PYTHON_BIN_PATH} $(location //tensorflow/tools/build_info:gen_build_info.py) --raw_generate \"$@\" --build_config " + if_cuda("cuda", "cpu"),
       local=1,
       tools=[clean_dep("//tensorflow/tools/build_info:gen_build_info.py")],)
 

--- a/tensorflow/tools/api/generator/BUILD
+++ b/tensorflow/tools/api/generator/BUILD
@@ -122,7 +122,7 @@ genrule(
         "api/user_ops/__init__.py",
         # END GENERATED FILES
     ],
-    cmd = "$(location create_python_api) $(OUTS)",
+    cmd = "$${PYTHON_BIN_PATH} $(location create_python_api) $(OUTS)",
     tools = ["create_python_api"],
 )
 

--- a/tensorflow/tools/api/generator/BUILD
+++ b/tensorflow/tools/api/generator/BUILD
@@ -122,7 +122,13 @@ genrule(
         "api/user_ops/__init__.py",
         # END GENERATED FILES
     ],
-    cmd = "$${PYTHON_BIN_PATH} $(location create_python_api) $(OUTS)",
+    # Optionally use PYTHON_BIN_PATH on Linux platforms so that python 3
+    # works. Windows has issues with the command so skip PYTHON_BIN_PATH
+    # for now.
+    cmd = select({
+        "@bazel_tools//src/conditions:windows": "",
+        "//conditions:default": "$${PYTHON_BIN_PATH} ",
+    }) + "$(location create_python_api) $(OUTS)",
     tools = ["create_python_api"],
 )
 


### PR DESCRIPTION
When building tensorflow in a python3 system (i.e., only `/usr/bin/python3` and no `/usr/bin/python` in the system), even though `/usr/bin/python3` is specified during the configure the following failure still occur:
```
SUBCOMMAND: # //tensorflow/core:version_info_gen [action 'Executing genrule //tensorflow/core:version_info_gen [for host]']
(cd /home/ubuntu/.cache/bazel/_bazel_ubuntu/ad1e09741bb4109fbc70ef8216b59ee2/execroot/org_tensorflow && \
  exec env - \
    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin \
  /bin/bash -c 'source external/bazel_tools/tools/genrule/genrule-setup.sh; tensorflow/tools/git/gen_git_source.py --generate external/local_config_git/gen/spec.json external/local_config_git/gen/head external/local_config_git/gen/branch_ref "bazel-out/host/genfiles/tensorflow/core/util/version_info.cc" --git_tag_override=${GIT_TAG_OVERRIDE:-}')
ERROR: /home/ubuntu/tensorflow/tensorflow/core/BUILD:2015:1: Executing genrule //tensorflow/core:version_info_gen failed (Exit 127)
/usr/bin/env: 'python': No such file or directory
Target //tensorflow/tools/pip_package:build_pip_package failed to build
Use --verbose_failures to see the command lines of failed build steps.
ERROR: /home/ubuntu/tensorflow/tensorflow/tools/api/generator/BUILD:27:1 Executing genrule //tensorflow/core:version_info_gen failed (Exit 127)
INFO: Elapsed time: 391.217s, Critical Path: 46.74s
INFO: 656 processes, local.
FAILED: Build did NOT complete successfully
```

This fix adds the necessary `${PYTHON_BIN_PATH}` (configured already in `./configure`)
into related commands so that bazel build works even in python 3 only environment.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>