### PR TITLE
Update Release.md to remove duplicate release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -409,14 +409,6 @@ answered questions, and were part of inspiring discussions.
 * [`tf.data`](http://tensorflow.org/programmers_guide/datasets) is now part of
   the core TensorFlow API.
   * The API is now subject to backwards compatibility guarantees.
-
-# Release 1.4.0
-
-## Major Features And Improvements
-* `tf.keras` is now part of the core TensorFlow API.
-* [`tf.data`](http://tensorflow.org/programmers_guide/datasets) is now part of
-  the core TensorFlow API.
-  * The API is now subject to backwards compatibility guarantees.
   * For a guide to migrating from the `tf.contrib.data` API, see the
     [README](https://github.com/tensorflow/tensorflow/blob/r1.4/tensorflow/contrib/data/README.md).
   * Major new features include `Dataset.from_generator()` (for building an input


### PR DESCRIPTION
The beginning of the release note for 1.4.0 seems to have been duplicated,
remove the duplication.