### PR TITLE
Update get_started_for_beginners.md

### DIFF
--- a/tensorflow/docs_src/get_started/get_started_for_beginners.md
+++ b/tensorflow/docs_src/get_started/get_started_for_beginners.md
@@ -303,7 +303,7 @@ and test sets respectively:
 
 ```python
     # Call load_data() to parse the CSV file.
-    (train_feature, train_label), (test_feature, test_label) = load_data()
+    (train_x, train_y), (test_x, test_y) = load_data()
 ```
 
 Pandas is an open-source Python library leveraged by several
@@ -466,7 +466,7 @@ method. For example:
 
 ```python
     classifier.train(
-        input_fn=lambda:train_input_fn(train_feature, train_label, args.batch_size),
+        input_fn=lambda:train_input_fn(train_x, train_y, args.batch_size),
         steps=args.train_steps)
 ```
 


### PR DESCRIPTION
Older versions used "_feature" and "_label" instead of "_x" and "_y" as in the newest versions of the get_started model in the code base.  This documentation was inconsistent, using the former for loading the training and test data, but the latter when calling eval().  This commit makes the notation consistent.