### PR TITLE
Fix pylint issue in the master branch

### DIFF
--- a/tensorflow/contrib/cmake/tools/create_def_file.py
+++ b/tensorflow/contrib/cmake/tools/create_def_file.py
@@ -44,7 +44,8 @@ UNDNAME = "undname.exe"
 DUMPBIN = "dumpbin.exe"
 
 # Exclude if matched
-EXCLUDE_RE = re.compile(r"RTTI|deleting destructor|::internal::|Internal|python_op_gen_internal|grappler")
+EXCLUDE_RE = re.compile(r"RTTI|deleting destructor|::internal::|Internal|"
+                        r"python_op_gen_internal|grappler")
 
 # Include if matched before exclude
 INCLUDEPRE_RE = re.compile(r"google::protobuf::internal::ExplicitlyConstructed|"

--- a/tensorflow/contrib/cmake/tools/create_def_file.py
+++ b/tensorflow/contrib/cmake/tools/create_def_file.py
@@ -59,7 +59,8 @@ INCLUDEPRE_RE = re.compile(r"google::protobuf::internal::ExplicitlyConstructed|"
                            r"tensorflow::strings::internal::CatPieces|"
                            r"tensorflow::errors::Internal|"
                            r"tensorflow::Tensor::CopyFromInternal|"
-                           r"tensorflow::kernel_factory::OpKernelRegistrar::InitInternal|"
+                           r"tensorflow::kernel_factory::"
+                           r"OpKernelRegistrar::InitInternal|"
                            r"tensorflow::io::internal::JoinPathImpl")
 
 # Include if matched after exclude


### PR DESCRIPTION

The latest master branch has the following pylint failure that caused:

`Ubuntu Sanity — Internal CI build failed`:
```
53 FAIL: Found 2 non-whitelited pylint errors:
54 tensorflow/contrib/cmake/tools/create_def_file.py:47: [C0301(line-too-long), ] Line too long (106/80)
55
56 tensorflow/contrib/cmake/tools/create_def_file.py:61: [C0301(line-too-long), ] Line too long (90/80)
```

This PR addresses the above issues.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>