### PR TITLE
Added 64 bit toolchain flag to CMake build instructions

### DIFF
--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -1,5 +1,9 @@
 # Minimum CMake required
-cmake_minimum_required(VERSION 3.5)
+if(WIN32)
+  cmake_minimum_required(VERSION 3.8)
+else()
+  cmake_minimum_required(VERSION 3.5)
+endif()
 
 # Project
 project(tensorflow C CXX)

--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -1,8 +1,14 @@
 # Minimum CMake required
+cmake_minimum_required(VERSION 3.5)
+
 if(WIN32)
-  cmake_minimum_required(VERSION 3.8)
-else()
-  cmake_minimum_required(VERSION 3.5)
+	if(${CMAKE_VERSION} VERSION_LESS "3.8")
+		message(WARNING "Your current cmake version is ${CMAKE_VERSION} which does not support setting the toolset architecture to x64. This may cause \"compiler out of heap space\" errors when building. Consider upgrading your cmake to > 3.8 and using the flag -Thost=x64 when running cmake.")
+	else()
+		if(NOT CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE OR NOT "${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}" STREQUAL "x64")
+			message(WARNING "Your current cmake generator is set to use 32 bit toolset architecture. This may cause \"compiler out of heap space\" errors when building. Consider using the flag -Thost=x64 when running cmake.")
+		endif()
+	endif()
 endif()
 
 # Project

--- a/tensorflow/contrib/cmake/README.md
+++ b/tensorflow/contrib/cmake/README.md
@@ -106,17 +106,6 @@ Step-by-step Windows build
 
 1. Install the prerequisites detailed above, and set up your environment.
 
-   * The following commands assume that you are using the Windows Command
-     Prompt (`cmd.exe`). You will need to set up your environment to use the
-     appropriate toolchain, i.e. the 64-bit tools. (Some of the binary targets
-     we will build are too large for the 32-bit tools, and they will fail with
-     out-of-memory errors.) The typical command to do set up your
-     environment is:
-
-     ```
-     D:\temp> "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvarsall.bat"
-     ```
-
    * When building with GPU support after installing the CUDNN zip file from NVidia, append its
      bin directory to your PATH environment variable.
      In case TensorFlow fails to find the CUDA dll's during initialization, check your PATH environment variable.
@@ -168,7 +157,7 @@ Step-by-step Windows build
    and must be the last character on each line.
 
    ```
-   D:\...\build> cmake .. -A x64 -DCMAKE_BUILD_TYPE=Release ^
+   D:\...\build> cmake .. -A x64 -Thost=x64 -DCMAKE_BUILD_TYPE=Release ^
    More? -DSWIG_EXECUTABLE=C:/tools/swigwin-3.0.10/swig.exe ^
    More? -DPYTHON_EXECUTABLE=C:/Users/%USERNAME%/AppData/Local/Continuum/Anaconda3/python.exe ^
    More? -DPYTHON_LIBRARIES=C:/Users/%USERNAME%/AppData/Local/Continuum/Anaconda3/libs/python35.lib
@@ -196,6 +185,10 @@ Step-by-step Windows build
    values are `Release` and `RelWithDebInfo`. The `Debug` build type is
    not currently supported, because it relies on a `Debug` library for
    Python (`python35d.lib`) that is not distributed by default.
+
+   The `-Thost=x64` flag will ensure that the 64 bit compiler and linker
+   is used when building. Without this flag, MSBuild will use the 32 bit
+   toolchain which is prone to compile errors such as "compiler out of heap space".
 
    There are various options that can be specified when generating the
    solution and project files:
@@ -262,6 +255,11 @@ Step-by-step Windows build
 
 
 4. Invoke MSBuild to build TensorFlow.
+
+   Set up the path to find MSbuild:
+   ```
+   D:\temp> "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvarsall.bat"
+   ```
 
    To build the C++ example program, which will be created as a `.exe`
    executable in the subdirectory `.\Release`:


### PR DESCRIPTION
When building tensorflow on windows with CMake, using the 64 bit toolchain (compiler (cl.exe) and linker (link.exe)) is needed. Using the 32 bit toolchain often result in errors such as C1060 "compiler out of heap space" and C1002: "compiler is out of heap space in pass 2". There are several issues reported on this: https://github.com/tensorflow/tensorflow/issues?utf8=%E2%9C%93&q=is%3Aissue+compiler+is+out+of+heap+space

The current README for CMake in tensorflow states that you can fix this by setting up a bunch of environment variables using the visual studio bat script: "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvarsall.bat".

However, I have discovered that this has no effect. If you look in task manager while you are compiling when using this bat script, you can see the task: "Microsoft Compiler Driver **(32 bit)**" running. 
The reason why this has no effect, is that CMake select which compiler and linker is used. It will output this to the console the first time you run configure with cmake. You will then see that CMAKE_CXX_COMPILER is set to "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/**x86**_amd64/cl.exe". The x86 part I assume means the 32 bit compiler is used, while the amd64 part means you are building an 64 bit application, two very different things. The fact that some people report that using the bat script actually helps, is most likely due to chance. I have observed several times that sometimes this error occurs, while other times it doesn't. I think this is due to multi-threading during compilation.

Newer versions of CMake (>= 3.8) allow you to specify the toolset host architecture to 64 bit using the flag:
`-Thost=x64`. This is documented here: https://cmake.org/cmake/help/v3.8/generator/Visual%20Studio%2014%202015.html

By adding this flag, I observe that CMAKE_CXX_COMPILER is set to "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/**amd64**/cl.exe" instead. Also, while compiling, the task manager now shows the task "Microsoft Compiler Driver", which is the 64 bit version of cl.exe, instead of "Microsoft Compiler Driver **(32 bit)**".

Using this flag, I have not experienced "compiler out of heap space" issues anymore on neither Visual studio 2015 and 2017 on windows 10. I hope others can test this and, hopefully, verify this solution.

I also updated the minimum cmake version required for windows to 3.8, which supports this host toolset flag.