### PR TITLE
Use BUILD.bazel for third_party packages

### DIFF
--- a/third_party/repo.bzl
+++ b/third_party/repo.bzl
@@ -88,7 +88,9 @@ def _tf_http_archive(ctx):
   if ctx.attr.patch_file != None:
     _apply_patch(ctx, ctx.attr.patch_file)
   if ctx.attr.build_file != None:
-    ctx.template("BUILD", ctx.attr.build_file, {
+    # Use BUILD.bazel to avoid conflict with third party projects with
+    # BUILD or build (directory) underneath.
+    ctx.template("BUILD.bazel", ctx.attr.build_file, {
         "%prefix%": ".." if _repos_are_siblings() else "external",
     }, False)
 


### PR DESCRIPTION
Both `BUILD` and `BUILD.bazel` could be used as the bazel project file (see https://github.com/bazelbuild/bazel/issues/552) and `BUILD.bazel` is actually  preferred (see https://github.com/bazelbuild/bazel/issues/4517#issuecomment-360213750)

This fix changes generated BUILD in third_party packages to `BUILD.bazel`.

This will help avoid conflict with `BUILD` or `build` file/directory names in third party packages.

For example, while working on #19461 I noticed that apache thrift package consists of a `build` directory and that causes issues in case-insensitive systems like macOS. This PR should help avoid such conflict issues.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>