### PR TITLE
INTEL-MKL: Fix an issue related to MKL op registration

### DIFF
--- a/tensorflow/core/kernels/mkl_conv_grad_bias_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_grad_bias_ops.cc
@@ -18,6 +18,7 @@ limitations under the License.
 // bias.
 
 #ifdef INTEL_MKL
+#ifdef INTEL_MKL_ML
 
 #define USE_EIGEN_TENSOR
 #define EIGEN_USE_THREADS
@@ -262,4 +263,5 @@ class MklConv2DCustomBackpropBiasOp : public OpKernel {
 TF_CALL_float(REGISTER_CPU_KERNELS);
 #undef REGISTER_CPU_KERNELS
 } /* namespace tensorflow */
+#endif /* INTEL_MKL_ML */
 #endif /* INTEL_MKL */


### PR DESCRIPTION
MklConv2DWithBiasBackpropBias is an MKL op.
If should be registered only when building Tensorflow with original MKL (that is, MKL_ML),
not with the current MKL (that is, open source MKL_DNN).

This fix addresses the problem.