### PR TITLE
Remove duplicate `from six import text_type` in upload_test_benchmarks.py

### DIFF
--- a/tensorflow/tools/test/upload_test_benchmarks.py
+++ b/tensorflow/tools/test/upload_test_benchmarks.py
@@ -89,7 +89,6 @@ import shutil
 
 from six import text_type
 from google.cloud import datastore
-from six import text_type
 
 
 def is_real_file(dirpath, fname):


### PR DESCRIPTION
The `from six import text_type` was imported twice in upload_test_benchmarks.py, this fix removes the duplication.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>