### PR TITLE
Fix broken link

### DIFF
--- a/tensorflow/docs_src/get_started/premade_estimators.md
+++ b/tensorflow/docs_src/get_started/premade_estimators.md
@@ -177,7 +177,7 @@ other features so you can concentrate on your model. For more details see
 
 An Estimator is any class derived from @{tf.estimator.Estimator}. TensorFlow
 provides a collection of
-[pre-made Estimators](https://developers.google.com/machine-learning/glossary/#pre-made_Estimator)
+[pre-made Estimators](https://developers.google.com/machine-learning/glossary/#premade_Estimator)
 (for example, `LinearRegressor`) to implement common ML algorithms. Beyond
 those, you may write your own
 [custom Estimators](https://developers.google.com/machine-learning/glossary/#custom_Estimator).


### PR DESCRIPTION
Also, as a side note, I found this link confusing. I was expecting it to take me to a list of pre-made estimators. Not a definition of what a pre-made estimator is. (maybe the glossary definition should link to a list of pre-made estimators?)