### PR TITLE
Fix build error

### DIFF
--- a/tensorflow/python/util/util.cc
+++ b/tensorflow/python/util/util.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/python/util/util.h"
 
+#include <functional>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
Fix build error: 'function' in namespace 'std' does not name a template type.

When build tensorflow from source on ubuntu 18.04 with g++-7.3, the error messages below appears.
Add `<functional>` header solves this error.

```
ERROR: /home/guo/Github/tensorflow/tensorflow/python/BUILD:310:1: C++ compilation of rule '//tensorflow/python:cpp_python_util' failed (Exit 1)
tensorflow/python/util/util.cc:276:16: error: 'function' in namespace 'std' does not name a template type
     const std::function<int(PyObject*)>& is_sequence_helper,
                ^~~~~~~~
tensorflow/python/util/util.cc:276:24: error: expected ',' or '...' before '<' token
     const std::function<int(PyObject*)>& is_sequence_helper,
                        ^
tensorflow/python/util/util.cc: In function 'bool tensorflow::swig::{anonymous}::FlattenHelper(PyObject*, PyObject*, int)':
tensorflow/python/util/util.cc:280:16: error: 'is_sequence_helper' was not declared in this scope
   int is_seq = is_sequence_helper(nested);
                ^~~~~~~~~~~~~~~~~~
tensorflow/python/util/util.cc:280:16: note: suggested alternative: 'IsSequenceHelper'
   int is_seq = is_sequence_helper(nested);
                ^~~~~~~~~~~~~~~~~~
                IsSequenceHelper
tensorflow/python/util/util.cc:288:8: error: 'next_values_getter' was not declared in this scope
   if (!next_values_getter(nested, &next_values)) return false;
        ^~~~~~~~~~~~~~~~~~
tensorflow/python/util/util.cc:288:8: note: suggested alternative: 'next_values'
   if (!next_values_getter(nested, &next_values)) return false;
        ^~~~~~~~~~~~~~~~~~
        next_values
tensorflow/python/util/util.cc:295:61: error: 'next_values_getter' was not declared in this scope
         FlattenHelper(item.get(), list, is_sequence_helper, next_values_getter);
                                                             ^~~~~~~~~~~~~~~~~~
tensorflow/python/util/util.cc:295:61: note: suggested alternative: 'next_values'
         FlattenHelper(item.get(), list, is_sequence_helper, next_values_getter);
                                                             ^~~~~~~~~~~~~~~~~~
                                                             next_values
tensorflow/python/util/util.cc:297:10: error: in argument to unary !
     if (!success) {
          ^~~~~~~
tensorflow/python/util/util.cc: In function 'PyObject* tensorflow::swig::Flatten(PyObject*)':
tensorflow/python/util/util.cc:472:66: error: invalid conversion from 'int (*)(PyObject*) {aka int (*)(_object*)}' to 'int' [-fpermissive]
   if (FlattenHelper(nested, list, IsSequenceHelper, GetNextValues)) {
                                                                  ^
tensorflow/python/util/util.cc:472:66: error: too many arguments to function 'bool tensorflow::swig::{anonymous}::FlattenHelper(PyObject*, PyObject*, int)'
tensorflow/python/util/util.cc:274:6: note: declared here
 bool FlattenHelper(
      ^~~~~~~~~~~~~
tensorflow/python/util/util.cc: In function 'PyObject* tensorflow::swig::FlattenForData(PyObject*)':
tensorflow/python/util/util.cc:485:41: error: invalid conversion from 'int (*)(PyObject*) {aka int (*)(_object*)}' to 'int' [-fpermissive]
                     GetNextValuesForData)) {
                                         ^
tensorflow/python/util/util.cc:485:41: error: too many arguments to function 'bool tensorflow::swig::{anonymous}::FlattenHelper(PyObject*, PyObject*, int)'
tensorflow/python/util/util.cc:274:6: note: declared here
 bool FlattenHelper(
      ^~~~~~~~~~~~~
Target //tensorflow/tools/pip_package:build_pip_package failed to build

```