### PR TITLE
BUILD: dont force stripping

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1427,6 +1427,10 @@ def set_grpc_build_flags():
   write_to_bazelrc('build --define grpc_no_ares=true')
 
 
+def set_build_strip_flag():
+  write_to_bazelrc('build --strip=always')
+
+
 def set_windows_build_flags():
   if is_windows():
     # The non-monolithic build is not supported yet
@@ -1549,6 +1553,7 @@ def main():
 
   set_grpc_build_flags()
   set_cc_opt_flags(environ_cp)
+  set_build_strip_flag()
   set_windows_build_flags()
 
   if workspace_has_any_android_rule():

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -471,7 +471,7 @@ tf_cc_shared_object(
 # excludes all but a subset of function names.
 # On MacOS, the linker does not support version_script, but has an
 # an "-exported_symbols_list" command.  -z defs disallows undefined
-# symbols in object files and -s strips the output.
+# symbols in object files.
 
 tf_cc_shared_object(
     name = "libtensorflow.so",
@@ -485,7 +485,6 @@ tf_cc_shared_object(
         "//tensorflow:windows_msvc": [],
         "//conditions:default": [
             "-z defs",
-            "-s",
             "-Wl,--version-script",  #  This line must be directly followed by the version_script.lds file
             "$(location //tensorflow/c:version_script.lds)",
         ],
@@ -511,7 +510,6 @@ tf_cc_shared_object(
         "//tensorflow:windows_msvc": [],
         "//conditions:default": [
             "-z defs",
-            "-s",
             "-Wl,--version-script",  #  This line must be directly followed by the version_script.lds file
             "$(location //tensorflow:tf_version_script.lds)",
         ],


### PR DESCRIPTION
Build systems must not strip binaries, it makes it impossible for
distros to ship debugging symbols for packages.

bazel build has a --strip option to allow the user to generate stripped
binaries in a configurable way, that should be used instead.

https://fedoraproject.org/wiki/Packaging:Debuginfo
https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Backtraces#Stripping

Signed-off-by: Jason Zaman <jason@perfinion.com>