### PR TITLE
Add a note that stop_gradient in moments does not change the gradient

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -689,6 +689,9 @@ def moments(
     # Compute true mean while keeping the dims for proper broadcasting.
     mean = math_ops.reduce_mean(y, axes, keepdims=True, name="mean")
     # sample variance, not unbiased variance
+    # Note: stop_gradient does not change the gradient that gets 
+    #       backpropagated to the mean from the variance calculation,
+    #       because that gradient is zero
     variance = math_ops.reduce_mean(
         math_ops.squared_difference(y, array_ops.stop_gradient(mean)),
         axes,


### PR DESCRIPTION
In https://github.com/tensorflow/tensorflow/commit/eccd162119675d0bf5bc6f8e6a93dcda7ab6db4a#diff-ef8609a43751227afcaacc838670a96f @sguada added support for sample mean in `moments`. He added a `stop_gradient` to the mean in the variance calculation. Since it took me some time to figure out that this `stop_gradient` has no effect (except a reduced computation time), I think a note to the `stop_gradient` could be usefull.

PS: This PR is a suggestion for such a note.