### PR TITLE
Fix mismatch of shape restriction in DrawBoundingBoxes

### DIFF
--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -454,7 +454,9 @@ REGISTER_OP("DrawBoundingBoxes")
       DimensionHandle unused;
       TF_RETURN_IF_ERROR(c->WithValue(c->Dim(boxes, 2), 4, &unused));
 
-      return shape_inference::UnchangedShapeWithRankAtLeast(c, 3);
+      // The rank of the input image (rank = 4) has already been restricted
+      // above, and the output is of the same shape as the input.
+      return shape_inference::UnchangedShape(c);
     });
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
In the kernel of DrawBoundingBoxes, the shape of the input
images should be 4-D. Though in the shape function,
at the end `UnchangedShapeWithRankAtLeast(c, 3)` was used instead
(at the beginning of the shape function the validation is
`WithRank(c->input(0), 4, &images)` which is correct).

This fix address the discrepancy by changing to `UnchangedShape`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>