### PR TITLE
Fix incorrect documentation for `tf.reduce_any`/`tf.reduce_all`

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1617,7 +1617,7 @@ def reduce_all(input_tensor,
   entry in `axis`. If `keepdims` is true, the reduced dimensions
   are retained with length 1.
 
-  If `axis` has no entries, all dimensions are reduced, and a
+  If `axis` is None, all dimensions are reduced, and a
   tensor with a single element is returned.
 
   For example:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1675,7 +1675,7 @@ def reduce_any(input_tensor,
   entry in `axis`. If `keepdims` is true, the reduced dimensions
   are retained with length 1.
 
-  If `axis` has no entries, all dimensions are reduced, and a
+  If `axis` is None, all dimensions are reduced, and a
   tensor with a single element is returned.
 
   For example:


### PR DESCRIPTION
This fix fixes the incorrect documentation for `tf.reduce_any`/`tf.reduce_all`. The previous description:
```
   If `axis` has no entries, all dimensions are reduced, and a
   tensor with a single element is returned.
```

is not correct. See below:
```
Python 2.7.12 (default, Dec  4 2017, 14:50:18)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import tensorflow as tf
>>> x = tf.constant([[True,  True], [False, False]])
>>> v1 = tf.reduce_any(x, [])
>>> tf.Session().run(v1)
array([[ True,  True],
       [False, False]])
>>> v2 = tf.reduce_any(x, None)
>>> tf.Session().run(v2)
True
>>>
```

Instead, the correct description should be:
```
   If `axis` is None, all dimensions are reduced, and a
   tensor with a single element is returned.
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>