### PR TITLE
Unify learning rate as normal Tensor for tf.contrib.layers.optimize_loss

### DIFF
--- a/tensorflow/contrib/layers/python/layers/optimizers.py
+++ b/tensorflow/contrib/layers/python/layers/optimizers.py
@@ -176,10 +176,7 @@ def optimize_loss(loss,
       elif isinstance(learning_rate, float):
         if learning_rate < 0.0:
           raise ValueError("Invalid learning_rate %s.", learning_rate)
-        lr = vs.get_variable(
-            "learning_rate", [],
-            trainable=False,
-            initializer=init_ops.constant_initializer(learning_rate))
+        lr = constant_op.constant(learning_rate)
       else:
         raise ValueError("Learning rate should be 0d Tensor or float. "
                          "Got %s of type %s" % (str(learning_rate),


### PR DESCRIPTION
In ```tf.contrib.layers.optimize_loss```, we handle ```learning_rate``` differently. 
* If it's a Tensor, then keep intact.
* If it's a float, then we wrap it as TF Variable, thus be stored in checkpoint.

It will throw exception if we train a model with constant learning rate(for example ```0.2```), save to checkpoint, and then continue train with a Tensor learning rate(for example ```tf.constant(0.2)```). This exceptions was reported at (here](https://github.com/tensorflow/tensor2tensor/issues/809)

Meanwhile, I think we don't need to store ```learning rate``` in checkpoint. If the checkpoint is used for inference only, no learning rate is needed. If the checkpoint is used for further training, we specify constant learning rate, or learning rate decay function(which takes constant ```learning_rate``` and ```global_step``` variable as input).

Further more, if we export ```learning rate``` as variable, when continuing training a model with constant ```learning rate```, we can't change it to different value. But there is need to use a new ```learning rate``` to continue training.

To sum up, I would suggest to unify ```learning rate``` as normal Tensor regardless of it's Tensor or float input. I'm glad to hear TF core developers' opinion. Thanks.

