### PR TITLE
Add complex numbers to the supported data types for UnsortedSegmentProd

### DIFF
--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1080,7 +1080,7 @@ REGISTER_OP("UnsortedSegmentProd")
     .Input("segment_ids: Tindices")
     .Input("num_segments: Tnumsegments")
     .Output("output: T")
-    .Attr("T: realnumbertype")
+    .Attr("T: numbertype")
     .Attr("Tindices: {int32,int64}")
     .Attr("Tnumsegments: {int32,int64} = DT_INT32")
     .SetShapeFn(UnsortedSegmentReductionShapeFn);

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
@@ -263,8 +263,7 @@ class UnsortedSegmentTest(SegmentReductionHelper):
                       math_ops.unsorted_segment_max, lambda t: t.min)]
 
     # A subset of ops has been enabled for complex numbers
-    self.complex_ops_list = [(np.add, None,
-                              math_ops.unsorted_segment_sum, lambda t: 0)]
+    self.complex_ops_list = [(np.add, None, math_ops.unsorted_segment_sum, lambda t: 0), (np.ndarray.__mul__, None, math_ops.unsorted_segment_prod, lambda t: 1)]
     self.differentiable_dtypes = [dtypes_lib.float16, dtypes_lib.float32,
                                   dtypes_lib.float64]
     self.all_dtypes = (self.differentiable_dtypes +

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
@@ -263,7 +263,10 @@ class UnsortedSegmentTest(SegmentReductionHelper):
                       math_ops.unsorted_segment_max, lambda t: t.min)]
 
     # A subset of ops has been enabled for complex numbers
-    self.complex_ops_list = [(np.add, None, math_ops.unsorted_segment_sum, lambda t: 0), (np.ndarray.__mul__, None, math_ops.unsorted_segment_prod, lambda t: 1)]
+    self.complex_ops_list = [(np.add, None,
+                              math_ops.unsorted_segment_sum, lambda t: 0),
+                             (np.ndarray.__mul__, None,
+                              math_ops.unsorted_segment_prod, lambda t: 1)]
     self.differentiable_dtypes = [dtypes_lib.float16, dtypes_lib.float32,
                                   dtypes_lib.float64]
     self.all_dtypes = (self.differentiable_dtypes +


### PR DESCRIPTION
In the kernel implementation both UnsortedSegmentProd and UnsortedSegmentSum supports complex numbers. However, unlike UnsortedSegmentSum, the op of UnsortedSegmentProd does not register complex number types in math_ops.cc.

This fix adds the supported complex number types to math_ops.cc, and enables test cases for it.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>