### PR TITLE
[tflite] make benchmark_model tflite build

### DIFF
--- a/tensorflow/contrib/lite/tools/command_line_flags.h
+++ b/tensorflow/contrib/lite/tools/command_line_flags.h
@@ -20,6 +20,25 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include <cstring> // for strcmp()
+
+#ifdef __ANDROID__
+// there is no std::to_string() in libstdc++ used by NDK,
+// which is used by bazel android_{arm,arm64} targets
+#include <sstream>
+namespace std {
+
+template <typename T>
+std::string to_string(T value)
+{
+    std::ostringstream os ;
+    os << value ;
+    return os.str() ;
+}
+
+}
+#endif
+
 namespace tflite {
 // A simple command-line argument parsing module.
 // Dependency free simplified port of core/util/command_line_flags.

--- a/tensorflow/contrib/lite/tools/logging.h
+++ b/tensorflow/contrib/lite/tools/logging.h
@@ -21,6 +21,8 @@ limitations under the License.
 #include <iostream>
 #include <sstream>
 
+#include <cstdlib> // for std::abort() on Android
+
 namespace tflite {
 namespace logging {
 // A wrapper that logs to stderr.


### PR DESCRIPTION
//tensorflow/contrib/lite/tools:benchmark_model doesn't build
for either x86 or android targets. With this, something like

```
bazel build --config opt \
//tensorflow/contrib/lite/tools:benchmark_model
```
or
```
bazel build --config android_arm64 --config monolithic \
--cxxopt=-std=c++11 --linkopt=-llog \
//tensorflow/contrib/lite/tools:benchmark_model
```
works