### PR TITLE
[tflite] label_image for tflite in Python

### DIFF
--- a/tensorflow/contrib/lite/examples/python/BUILD
+++ b/tensorflow/contrib/lite/examples/python/BUILD
@@ -1,0 +1,13 @@
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//tensorflow:internal"])
+
+py_binary(
+    name = "label_image",
+    srcs = ["label_image.py"],
+    main = "label_image.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorflow/contrib/lite/python:lite",
+    ],
+)

--- a/tensorflow/contrib/lite/examples/python/label_image.md
+++ b/tensorflow/contrib/lite/examples/python/label_image.md
@@ -1,0 +1,35 @@
+With model (mobilenet_v1_1.0_224_quant.tflite), input image
+(grace_hooper.bmp), and labels file (labels.txt) in /tmp.
+Run
+
+```
+bazel run --config opt //tensorflow/contrib/lite/examples/python:label_image
+```
+
+We can get results like
+
+```
+0.470588: military uniform
+0.337255: Windsor tie
+0.047059: bow tie
+0.031373: mortarboard
+0.019608: suit
+```
+
+Run
+
+```
+bazel run --config opt //tensorflow/contrib/lite/examples/python:label_image \
+-- --graph /tmp/mobilenet_v1_1.0_224.tflite
+```
+
+We can get results like
+```
+0.728693: military uniform
+0.116163: Windsor tie
+0.035517: bow tie
+0.014874: mortarboard
+0.011758: bolo tie
+```
+
+Check [models](../../g3doc/models.md) hosted by Google.

--- a/tensorflow/contrib/lite/examples/python/label_image.md
+++ b/tensorflow/contrib/lite/examples/python/label_image.md
@@ -1,8 +1,22 @@
-With model (mobilenet_v1_1.0_224_quant.tflite), input image
-(grace_hooper.bmp), and labels file (labels.txt) in /tmp.
+
+With model, input image (grace_hopper.bmp), and labels file (labels.txt)
+in /tmp.
+
+The example input image and labels file are from TensorFlow repo and
+MobileNet V1 model files.
+
+```
+curl https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/contrib/lite/examples/label_image/testdata/grace_hopper.bmp > /tmp/grace_hopper.bmp
+
+curl  https://storage.googleapis.com/download.tensorflow.org/models/mobilenet_v1_1.0_224_frozen.tgz  | tar xzv -C /tmp  mobilenet_v1_1.0_224/labels.txt
+mv /tmp/mobilenet_v1_1.0_224/labels.txt /tmp/
+
+```
+
 Run
 
 ```
+curl http://download.tensorflow.org/models/mobilenet_v1_2018_02_22/mobilenet_v1_1.0_224_quant.tgz | tar xzv -C /tmp
 bazel run --config opt //tensorflow/contrib/lite/examples/python:label_image
 ```
 
@@ -19,8 +33,9 @@ We can get results like
 Run
 
 ```
+curl http://download.tensorflow.org/models/mobilenet_v1_2018_02_22/mobilenet_v1_1.0_224.tgz | tar xzv -C /tmp
 bazel run --config opt //tensorflow/contrib/lite/examples/python:label_image \
--- --graph /tmp/mobilenet_v1_1.0_224.tflite
+-- --model_file /tmp/mobilenet_v1_1.0_224.tflite
 ```
 
 We can get results like
@@ -32,4 +47,4 @@ We can get results like
 0.011758: bolo tie
 ```
 
-Check [models](../../g3doc/models.md) hosted by Google.
+Check [models](../../g3doc/models.md) for models hosted by Google.

--- a/tensorflow/contrib/lite/examples/python/label_image.py
+++ b/tensorflow/contrib/lite/examples/python/label_image.py
@@ -1,0 +1,97 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""label_image for tflite"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import numpy as np
+
+from PIL import Image
+
+from tensorflow.contrib.lite.python import interpreter as interpreter_wrapper
+
+def load_labels(filename):
+  my_labels = []
+  input_file = open(filename, 'r')
+  for l in input_file:
+    my_labels.append(l.strip())
+  return my_labels
+
+if __name__ == "__main__":
+  file_name = "/tmp/grace_hopper.bmp"
+  model_file = "/tmp/mobilenet_v1_1.0_224_quant.tflite"
+  label_file = "/tmp/labels.txt"
+  input_mean = 127.5
+  input_std = 127.5
+  floating_model = False
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--image", help="image to be classified")
+  parser.add_argument("--graph", help=".tflite model to be executed")
+  parser.add_argument("--labels", help="name of file containing labels")
+  parser.add_argument("--input_mean", help="input_mean")
+  parser.add_argument("--input_std", help="input standard deviation")
+  args = parser.parse_args()
+
+  if args.graph:
+    model_file = args.graph
+  if args.image:
+    file_name = args.image
+  if args.labels:
+    label_file = args.labels
+  if args.input_mean:
+    input_mean = args.input_mean
+  if args.input_std:
+    input_std = args.input_std
+
+  interpreter = interpreter_wrapper.Interpreter(model_path=model_file)
+  interpreter.allocate_tensors()
+
+  input_details = interpreter.get_input_details()
+  output_details = interpreter.get_output_details()
+
+  # check the type of the input tensor
+  if input_details[0]['dtype'] == type(np.float32(1.0)):
+    floating_model = True
+
+  # NxHxWxC, H:1, W:2
+  height = input_details[0]['shape'][1]
+  width = input_details[0]['shape'][2]
+  img = Image.open(file_name)
+  img = img.resize((width, height))
+
+  # add N dim
+  input_data = np.expand_dims(img, axis=0)
+
+  if floating_model:
+    input_data = (np.float32(input_data) - input_mean) / input_std
+
+  interpreter.set_tensor(input_details[0]['index'], input_data)
+
+  interpreter.invoke()
+
+  output_data = interpreter.get_tensor(output_details[0]['index'])
+  results = np.squeeze(output_data)
+
+  top_k = results.argsort()[-5:][::-1]
+  labels = load_labels(label_file)
+  for i in top_k:
+    if floating_model:
+      print('{0:08.6f}'.format(float(results[i]))+":", labels[i])
+    else:
+      print('{0:08.6f}'.format(float(results[i]/255.0))+":", labels[i])

--- a/tensorflow/contrib/lite/examples/python/label_image.py
+++ b/tensorflow/contrib/lite/examples/python/label_image.py
@@ -33,53 +33,42 @@ def load_labels(filename):
   return my_labels
 
 if __name__ == "__main__":
-  file_name = "/tmp/grace_hopper.bmp"
-  model_file = "/tmp/mobilenet_v1_1.0_224_quant.tflite"
-  label_file = "/tmp/labels.txt"
-  input_mean = 127.5
-  input_std = 127.5
   floating_model = False
 
   parser = argparse.ArgumentParser()
-  parser.add_argument("--image", help="image to be classified")
-  parser.add_argument("--graph", help=".tflite model to be executed")
-  parser.add_argument("--labels", help="name of file containing labels")
-  parser.add_argument("--input_mean", help="input_mean")
-  parser.add_argument("--input_std", help="input standard deviation")
+  parser.add_argument("-i", "--image", default="/tmp/grace_hopper.bmp", \
+    help="image to be classified")
+  parser.add_argument("-m", "--model_file", \
+    default="/tmp/mobilenet_v1_1.0_224_quant.tflite", \
+    help=".tflite model to be executed")
+  parser.add_argument("-l", "--label_file", default="/tmp/labels.txt", \
+    help="name of file containing labels")
+  parser.add_argument("--input_mean", default=127.5, help="input_mean")
+  parser.add_argument("--input_std", default=127.5, \
+    help="input standard deviation")
   args = parser.parse_args()
 
-  if args.graph:
-    model_file = args.graph
-  if args.image:
-    file_name = args.image
-  if args.labels:
-    label_file = args.labels
-  if args.input_mean:
-    input_mean = args.input_mean
-  if args.input_std:
-    input_std = args.input_std
-
-  interpreter = interpreter_wrapper.Interpreter(model_path=model_file)
+  interpreter = interpreter_wrapper.Interpreter(model_path=args.model_file)
   interpreter.allocate_tensors()
 
   input_details = interpreter.get_input_details()
   output_details = interpreter.get_output_details()
 
   # check the type of the input tensor
-  if input_details[0]['dtype'] == type(np.float32(1.0)):
+  if input_details[0]['dtype'] == np.float32:
     floating_model = True
 
   # NxHxWxC, H:1, W:2
   height = input_details[0]['shape'][1]
   width = input_details[0]['shape'][2]
-  img = Image.open(file_name)
+  img = Image.open(args.image)
   img = img.resize((width, height))
 
   # add N dim
   input_data = np.expand_dims(img, axis=0)
 
   if floating_model:
-    input_data = (np.float32(input_data) - input_mean) / input_std
+    input_data = (np.float32(input_data) - args.input_mean) / args.input_std
 
   interpreter.set_tensor(input_details[0]['index'], input_data)
 
@@ -89,7 +78,7 @@ if __name__ == "__main__":
   results = np.squeeze(output_data)
 
   top_k = results.argsort()[-5:][::-1]
-  labels = load_labels(label_file)
+  labels = load_labels(args.label_file)
   for i in top_k:
     if floating_model:
       print('{0:08.6f}'.format(float(results[i]))+":", labels[i])


### PR DESCRIPTION
With model (mobilenet_v1_1.0_224_quant.tflite), input image
(grace_hooper.bmp), and labels file (labels.txt) in /tmp.
Run

```
bazel run --config opt //tensorflow/contrib/lite/examples/python:label_image
```

We can get results like

```
0.470588: military uniform
0.337255: Windsor tie
0.047059: bow tie
0.031373: mortarboard
0.019608: suit
```