### PR TITLE
Expose `tf.broadcast_to` op

### DIFF
--- a/tensorflow/contrib/framework/__init__.py
+++ b/tensorflow/contrib/framework/__init__.py
@@ -119,14 +119,13 @@ from tensorflow.python.framework.smart_cond import smart_cond
 from tensorflow.python.framework.smart_cond import smart_constant_value
 from tensorflow.python.framework.tensor_spec import BoundedTensorSpec
 from tensorflow.python.framework.tensor_spec import TensorSpec
-from tensorflow.python.ops.array_ops import broadcast_to
 from tensorflow.python.ops.init_ops import convolutional_delta_orthogonal
 from tensorflow.python.ops.init_ops import convolutional_orthogonal_1d
 from tensorflow.python.ops.init_ops import convolutional_orthogonal_2d
 from tensorflow.python.ops.init_ops import convolutional_orthogonal_3d
 from tensorflow.python.util.all_util import remove_undocumented
 
-_allowed_symbols = ['nest', 'broadcast_to']
+_allowed_symbols = ['nest']
 _nest_allowed_symbols = [
     'assert_same_structure',
     'is_sequence',

--- a/tensorflow/core/api_def/python_api/api_def_BroadcastTo.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_BroadcastTo.pbtxt
@@ -1,4 +1,0 @@
-op {
-  graph_op_name: "BroadcastTo"
-  visibility: HIDDEN
-}

--- a/tensorflow/tools/api/golden/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/tensorflow.pbtxt
@@ -793,6 +793,10 @@ tf_module {
     argspec: "args=[\'shape_x\', \'shape_y\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "broadcast_to"
+    argspec: "args=[\'input\', \'shape\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "case"
     argspec: "args=[\'pred_fn_pairs\', \'default\', \'exclusive\', \'strict\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'False\', \'False\', \'case\'], "
   }


### PR DESCRIPTION
This fix is a follow up of #15243 to expose `tf.broadcast_to`. Previously the op was exposed as `tf.contrib.framework.broadcast_to`.

This fix unhides the BroadcastTo so that it is exposed in `tf.broadcast_to`, and also removes `tf.contrib.framework.broadcast_to`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>