### PR TITLE
Fix for Raspberry Pi build breakage

### DIFF
--- a/tensorflow/contrib/lite/toco/toco_port.cc
+++ b/tensorflow/contrib/lite/toco/toco_port.cc
@@ -18,12 +18,10 @@ limitations under the License.
 #include "tensorflow/contrib/lite/toco/toco_types.h"
 #include "tensorflow/core/platform/logging.h"
 
-#ifdef __ARM_ARCH_7A__
+#if defined(__ANDROID__) && defined(__ARM_ARCH_7A__)
 namespace std {
-double round(double x) {
-  return ::round(x);
-}
-}
+double round(double x) { return ::round(x); }
+}  // namespace std
 #endif
 
 namespace toco {


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/17885 was missing a guard for the definition of `double()`, so it was being defined even on non-Android ARM platforms like the Pi.