### PR TITLE
[RFC] Added support for sequence_numeric_column to bucketized_column

### DIFF
--- a/tensorflow/contrib/feature_column/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/contrib/feature_column/python/feature_column/sequence_feature_column_test.py
@@ -577,6 +577,84 @@ class SequenceEmbeddingColumnTest(test.TestCase):
           expected_sequence_length, sequence_length.eval(session=sess))
 
 
+class SequenceBucketizedColumnTest(test.TestCase):
+
+  def test_get_sequence_dense_tensor(self):
+    sparse_input = sparse_tensor.SparseTensorValue(
+        # example 0, ids [42]
+        # example 1, ids [2.5, 10]
+        # example 2, ids []
+        # example 3, ids [1]
+        indices=((0, 0), (1, 0), (1, 1), (3, 0)),
+        values=(42.0, 2.5, 10.0, 1.0),
+        dense_shape=(4, 2))
+
+    zero = [[1.0, 0.0, 0.0, 0.0]]
+    expected_lookups = [
+        # example 0, ids [42]
+        [[[0.0, 0.0, 0.0, 1.0]], zero],
+        # example 1, ids [0, 10]
+        [[[0.0, 0.0, 1.0, 0.0]], [[0.0, 0.0, 0.0, 1.0]]],
+        # example 2, ids []
+        [zero, zero],
+        # example 3, ids [1]
+        [[[0.0, 1.0, 0.0, 0.0]], zero]
+    ]
+
+    numeric_column = sfc.sequence_numeric_column('aaa')
+    bucketized_column = fc.bucketized_column(numeric_column, [1.0, 2.0, 3.0])
+
+    bucketized, _ = bucketized_column._get_sequence_dense_tensor(
+        _LazyBuilder({'aaa': sparse_input}))
+
+    with monitored_session.MonitoredSession() as sess:
+      self.assertAllEqual(expected_lookups, bucketized.eval(session=sess))
+
+  def _test_sequence_length(self):
+    sparse_input = sparse_tensor.SparseTensorValue(
+        # example 0, ids [2]
+        # example 1, ids [0, 1]
+        indices=((0, 0), (1, 0), (1, 1)),
+        values=(2.0, 0.0, 1.0),
+        dense_shape=(2, 2))
+    expected_sequence_length = [1, 2]
+
+    numeric_column = sfc.sequence_numeric_column(key='aaa')
+    bucketized_column = fc.bucketized_column(numeric_column, [1.0, 2.0, 3.0])
+
+    _, sequence_length = bucketized_column._get_sequence_dense_tensor(
+        _LazyBuilder({'aaa': sparse_input}))
+
+    with monitored_session.MonitoredSession() as sess:
+      sequence_length = sess.run(sequence_length)
+      self.assertAllEqual(expected_sequence_length, sequence_length)
+      self.assertEqual(np.int64, sequence_length.dtype)
+
+  def _test_sequence_length_with_empty_rows(self):
+    """Tests _sequence_length when some examples do not have ids."""
+    sparse_input = sparse_tensor.SparseTensorValue(
+        # example 0, ids []
+        # example 1, ids [2]
+        # example 2, ids [0, 1]
+        # example 3, ids []
+        # example 4, ids [1]
+        # example 5, ids []
+        indices=((1, 0), (2, 0), (2, 1), (4, 0)),
+        values=(2.0, 0.0, 1.0, 1.0),
+        dense_shape=(6, 2))
+    expected_sequence_length = [0, 1, 2, 0, 1, 0]
+
+    numeric_column = sfc.sequence_numeric_column(key='aaa')
+    bucketized_column = fc.bucketized_column(numeric_column, [1.0, 2.0, 3.0])
+
+    _, sequence_length = bucketized_column._get_sequence_dense_tensor(
+        _LazyBuilder({'aaa': sparse_input}))
+
+    with monitored_session.MonitoredSession() as sess:
+      self.assertAllEqual(
+          expected_sequence_length, sequence_length.eval(session=sess))
+
+
 class SequenceIndicatorColumnTest(test.TestCase):
 
   def test_get_sequence_dense_tensor(self):

--- a/tensorflow/python/feature_column/feature_column.py
+++ b/tensorflow/python/feature_column/feature_column.py
@@ -1132,26 +1132,24 @@ def bucketized_column(source_column, boundaries):
   ```
 
   Args:
-    source_column: A one-dimensional dense column which is generated with
-      `numeric_column`.
+    source_column: A dense column which is generated with `numeric_column`
+      or `sequence_numeric_column`.
     boundaries: A sorted list or tuple of floats specifying the boundaries.
 
   Returns:
     A `_BucketizedColumn`.
 
   Raises:
-    ValueError: If `source_column` is not a numeric column, or if it is not
-      one-dimensional.
+    ValueError: If `source_column` is not a numeric column.
     ValueError: If `boundaries` is not a sorted list or tuple.
   """
-  if not isinstance(source_column, _NumericColumn):
+  # TODO: remove this check? the implementation of the column would
+  #       fail anyway if the input is not a `_NumericColumn`.
+  # TODO: write a test for ndims == 2?
+  if not isinstance(source_column, (_NumericColumn, _SequenceDenseColumn)):
     raise ValueError(
-        'source_column must be a column generated with numeric_column(). '
-        'Given: {}'.format(source_column))
-  if len(source_column.shape) > 1:
-    raise ValueError(
-        'source_column must be one-dimensional column. '
-        'Given: {}'.format(source_column))
+        'source_column must be a column generated with numeric_column() or '
+        'sequence_numeric_column(). Given: {}'.format(source_column))
   if (not boundaries or
       not (isinstance(boundaries, list) or isinstance(boundaries, tuple))):
     raise ValueError('boundaries must be a sorted list.')
@@ -2372,9 +2370,11 @@ class _NumericColumn(_DenseColumn,
     return inputs.get(self)
 
 
-class _BucketizedColumn(_DenseColumn, _CategoricalColumn,
-                        collections.namedtuple('_BucketizedColumn', [
-                            'source_column', 'boundaries'])):
+class _BucketizedColumn(
+    _DenseColumn,
+    _CategoricalColumn,
+    _SequenceDenseColumn,
+    collections.namedtuple('_BucketizedColumn', ['source_column', 'boundaries'])):
   """See `bucketized_column`."""
 
   @property
@@ -2397,6 +2397,20 @@ class _BucketizedColumn(_DenseColumn, _CategoricalColumn,
         tuple(self.source_column.shape) + (len(self.boundaries) + 1,))
 
   def _get_dense_tensor(self, inputs, weight_collections=None, trainable=None):
+    if isinstance(self.source_column, _SequenceDenseColumn):
+      # TODO: generalize the message and extract from here as well
+      #       as from  _EmbeddingColumn?
+      raise ValueError(
+        'In bucketized_column: {}. '
+        'source_column must not be of type _SequenceDenseColumn. '
+        'Suggested fix A: If you wish to use input_layer, use a '
+        'non-sequence numeric_column. '
+        'Suggested fix B: If you wish to create sequence input, use '
+        'sequence_input_layer instead of input_layer. '
+        'Given (type {}): {}'.format(
+          self.name, type(self.source_column),
+          self.source_column))
+
     del weight_collections
     del trainable
     input_tensor = inputs.get(self)
@@ -2405,6 +2419,38 @@ class _BucketizedColumn(_DenseColumn, _CategoricalColumn,
         depth=len(self.boundaries) + 1,
         on_value=1.,
         off_value=0.)
+
+  def _get_sequence_dense_tensor(
+      self, inputs, weight_collections=None, trainable=None):
+    # TODO: generalize the message and extract from here as well
+    #       as from  _EmbeddingColumn?
+    if not isinstance(self.source_column, _SequenceDenseColumn):
+      raise ValueError(
+        'In bucketized_column: {}. '
+        'sequence_column must be of type _SequenceDenseColumn '
+        'to use sequence_input_layer. '
+        'Suggested fix: Use sequence_numeric_column. '
+        'Given (type {}): {}'.format(
+          self.name, type(self.source_column),
+          self.source_column))
+
+    input_tensor, sequence_length = \
+      self.source_column._get_sequence_dense_tensor(
+        # pylint: disable=protected-access
+        inputs=inputs,
+        weight_collections=weight_collections,
+        trainable=trainable)
+
+    input_tensor = math_ops._bucketize( # pylint: disable=protected-access
+      input_tensor,
+      self.boundaries)
+    dense_tensor = array_ops.one_hot(
+        indices=math_ops.to_int64(input_tensor),
+        depth=len(self.boundaries) + 1,
+        on_value=1.,
+        off_value=0.)
+    return _SequenceDenseColumn.TensorSequenceLengthPair(
+        dense_tensor=dense_tensor, sequence_length=sequence_length)
 
   @property
   def _num_buckets(self):

--- a/tensorflow/python/feature_column/feature_column_test.py
+++ b/tensorflow/python/feature_column/feature_column_test.py
@@ -370,12 +370,6 @@ class BucketizedColumnTest(test.TestCase):
         'source_column must be a column generated with numeric_column'):
       fc.bucketized_column(a, boundaries=[0, 1])
 
-  def test_invalid_source_column_shape(self):
-    a = fc.numeric_column('aaa', shape=[2, 3])
-    with self.assertRaisesRegexp(
-        ValueError, 'source_column must be one-dimensional column'):
-      fc.bucketized_column(a, boundaries=[0, 1])
-
   def test_invalid_boundaries(self):
     a = fc.numeric_column('aaa')
     with self.assertRaisesRegexp(


### PR DESCRIPTION
This is a work in progress.

Caveats:
* the current implementation only works when the bucketized_column is used in the dense context;
* sequence columns are >=2 dimensional, so I had to drop the 1-D constraint from `bucketized_column`.

Closes #18975