### PR TITLE
contrib/eagerpython/datasets: Resource naming workaround.

### DIFF
--- a/tensorflow/contrib/eager/python/datasets.py
+++ b/tensorflow/contrib/eager/python/datasets.py
@@ -106,7 +106,8 @@ class Iterator(iterator_ops.EagerIterator, checkpointable.CheckpointableBase):
             target_device=target,
             buffer_size=10,
             container="",
-            shared_name=_generate_shared_name("function_buffer_resource"))
+            shared_name=_generate_shared_name(
+                "contrib_eager_iterator_function_buffer_resource"))
         self._buffer_resource_deleter = resource_variable_ops.EagerResourceDeleter(  # pylint: disable=line-too-long
             handle=self._buffer_resource_handle,
             handle_device=self._device)


### PR DESCRIPTION
tensorflow/contrib/eager/python/datasets_test.py was failing on GPU
because two tests - testTensorsPlacedOnDevice() and
testTensorsExplicitPrefetchToDevice() we're creating
FunctionBufferResources with the same shared_name, leading to
unintentional interference.

This change will make the tests pass and allow the use of
tf.contrib.eager.Iterator and
tf.data.Dataset.apply(prefetching_ops.prefetch_to_device)
in the same process without interference.

However, a more appropriate fix would probably be to use
anonymous function buffering resources (similar to
AnonymousIteratorHandle) when eager execution is enabled,
doing away with sharing by name.

CC @allenlavoie @rohan100jain @mrry @av8ramit 