### PR TITLE
Correcting the number of flop for MatMul

### DIFF
--- a/tensorflow/python/kernel_tests/matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/matmul_op_test.py
@@ -142,7 +142,7 @@ class MatMulStatsTest(test_lib.TestCase):
       for op in g.get_operations():
         flops = ops.get_stats_for_node_def(g, op.node_def, "flops").value
         if op.name == "MatMul":
-          self.assertEqual(7200, flops)
+          self.assertEqual(6975, flops)
 
   def testTransposedStatistics(self):
     g = ops.Graph()
@@ -153,7 +153,7 @@ class MatMulStatsTest(test_lib.TestCase):
       for op in g.get_operations():
         flops = ops.get_stats_for_node_def(g, op.node_def, "flops").value
         if op.name == "MatMul":
-          self.assertEqual(7200, flops)
+          self.assertEqual(6975, flops)
 
 
 try:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2033,7 +2033,7 @@ def _calc_mat_mul_flops(graph, node):
   output_shape = graph_util.tensor_shape_from_node_def_name(graph, node.name)
   output_shape.assert_is_fully_defined()
   output_count = np.prod(output_shape.as_list())
-  return ops.OpStats("flops", (k * output_count * 2))
+  return ops.OpStats("flops", ((2 * k - 1) * output_count))
 
 
 def _as_indexed_slices(x, optimize=True):


### PR DESCRIPTION
Cf https://github.com/tensorflow/tensorflow/issues/19746

Given two matrices A of shape (m, p) and B of shape (p, q), the number of floating point operations (FLOP) should be mq(2p-1).

Calculating the number of FLOP using tensorflow's profiler gives 2mqp instead of mq(2p-1).


```
import tensorflow as tf
g = tf.Graph()
with g.as_default():
    m, p, q = 25, 16, 9
    A = tf.Variable(tf.zeros([m, p]))
    B = tf.Variable(tf.zeros([p, q]))
    C = tf.matmul(A,B)

    flops = tf.profiler.profile(g, options = tf.profiler.ProfileOptionBuilder.float_operation())
    if flops is not None:
        print('FLOP should be', m * q * (2 * p - 1))
        print('Calculated FLOP', flops.total_float_ops)
```