### PR TITLE
Use CUDA Runtime API instead of Driver API to allow interception using LD_PRELOAD

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_driver.cc
+++ b/tensorflow/stream_executor/cuda/cuda_driver.cc
@@ -897,14 +897,14 @@ CUDADriver::ContextGetSharedMemConfig(CudaContext* context) {
 /* static */ void *CUDADriver::DeviceAllocate(CudaContext *context,
                                               uint64 bytes) {
   ScopedActivateContext activated{context};
-  CUdeviceptr result = 0;
-  CUresult res = cuMemAlloc(&result, bytes);
-  if (res != CUDA_SUCCESS) {
+  void * result;
+  cudaError_t err = cudaMalloc((void**)&result, bytes);
+  if (err != cudaSuccess) {
     LOG(ERROR) << "failed to allocate "
                << port::HumanReadableNumBytes::ToString(bytes) << " (" << bytes
-               << " bytes) from device: " << ToString(res);
-    return nullptr;
+               << " bytes) from device: " << cudaGetErrorString(err);
   }
+
   void *ptr = reinterpret_cast<void *>(result);
   VLOG(2) << "allocated " << ptr << " for context " << context << " of "
           << bytes << " bytes";

--- a/tensorflow/stream_executor/cuda/cuda_driver.h
+++ b/tensorflow/stream_executor/cuda/cuda_driver.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/stream_executor/lib/statusor.h"
 #include "tensorflow/stream_executor/platform/port.h"
 #include "cuda/include/cuda.h"
+#include "cuda/include/cuda_runtime_api.h"
 
 namespace stream_executor {
 namespace cuda {


### PR DESCRIPTION
This pull request is to allow low-level MPI libraries like MVAPICH2-GDR that use LD_PRELOAD style interception of CUDA calls to optimize performance. Currently, a CUDA_INVALID_CONTEXT error appears if cuMemAlloc is used. The change to cudaMalloc will allow interception. There are no known side effects of this patch. 