### PR TITLE
Fix logging issue in remapper.cc and Linking issue with scoped_allocator_optimizer

### DIFF
--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -780,7 +780,6 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:protos_all_cc",
-        "//tensorflow/core:scoped_allocator_ops_op_lib",
         "//tensorflow/core/grappler:grappler_item",
         "//tensorflow/core/grappler:op_types",
         "//tensorflow/core/grappler:utils",

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/core/grappler/op_types.h"
 #include "tensorflow/core/grappler/optimizers/constant_folding.h"
 #include "tensorflow/core/grappler/utils.h"
+#include "tensorflow/core/platform/logging.h"
 
 namespace tensorflow {
 namespace grappler {
@@ -200,8 +201,7 @@ Status Remapper::Optimize(Cluster* /*cluster*/, const GrapplerItem& item,
         }
       }
       if (optimizable) {
-        std::cout << "Optimizing fused batch norm node " << node.DebugString()
-                  << std::endl;
+        VLOG(1)<< "Optimizing fused batch norm node " << node.DebugString();
         AddBatchNormNodes(optimized_graph, node);
         continue;
       }


### PR DESCRIPTION
This PR replaces std::cout with VLOG(1) in remapper.cc and removes scoped_allocator_ops_op_lib dependency from ScopedAllocator. This dependency is already satisfied through other libraries in core and causes a fatal for libraries that uses meta_optimizer due to double registration of _ScopedAllocator op due to double inclusion of static objects.