### PR TITLE
Try importing TRTOps to import_pb_to_tensorboard.py

### DIFF
--- a/tensorflow/python/tools/BUILD
+++ b/tensorflow/python/tools/BUILD
@@ -63,6 +63,7 @@ py_binary(
     srcs = ["import_pb_to_tensorboard.py"],
     srcs_version = "PY2AND3",
     deps = [
+        "//tensorflow/contrib/tensorrt:init_py",
         "//tensorflow/core:protos_all_py",
         "//tensorflow/python:client",
         "//tensorflow/python:framework",

--- a/tensorflow/python/tools/BUILD
+++ b/tensorflow/python/tools/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "py_test")
+load("//tensorflow:tensorflow.bzl", "if_not_windows")
 
 # Transitive dependencies of this target will be included in the pip package.
 py_library(
@@ -63,14 +64,15 @@ py_binary(
     srcs = ["import_pb_to_tensorboard.py"],
     srcs_version = "PY2AND3",
     deps = [
-        "//tensorflow/contrib/tensorrt:init_py",
         "//tensorflow/core:protos_all_py",
         "//tensorflow/python:client",
         "//tensorflow/python:framework",
         "//tensorflow/python:framework_ops",
         "//tensorflow/python:platform",
         "//tensorflow/python:summary",
-    ],
+    ] + if_not_windows([
+        "//tensorflow/contrib/tensorrt:init_py",
+    ]),
 )
 
 py_test(

--- a/tensorflow/python/tools/import_pb_to_tensorboard.py
+++ b/tensorflow/python/tools/import_pb_to_tensorboard.py
@@ -29,6 +29,13 @@ from tensorflow.python.platform import app
 from tensorflow.python.platform import gfile
 from tensorflow.python.summary import summary
 
+# Try importing TensorRT ops if available
+# pylint: disable=unused-import,trailing-whitespace,g-import-not-at-top,wildcard-import
+try:
+  from tensorflow.contrib.tensorrt.ops.gen_trt_engine_op import *
+except ImportError:
+  pass
+# pylint: enable=unused-import,trailing-whitespace,g-import-not-at-top,wildcard-import
 
 def import_to_tensorboard(model_dir, log_dir):
   """View an imported protobuf model (`.pb` file) as a graph in Tensorboard.

--- a/tensorflow/python/tools/import_pb_to_tensorboard.py
+++ b/tensorflow/python/tools/import_pb_to_tensorboard.py
@@ -30,12 +30,15 @@ from tensorflow.python.platform import gfile
 from tensorflow.python.summary import summary
 
 # Try importing TensorRT ops if available
-# pylint: disable=unused-import,trailing-whitespace,g-import-not-at-top,wildcard-import
+# TODO(aaroey): ideally we should import everything from tensorflow.contrib but
+# currently tensorrt module would cause build errors when being imported in
+# tensorflow/contrib/__init__.py. Fix it.
+# pylint: disable=unused-import,g-import-not-at-top,wildcard-import
 try:
   from tensorflow.contrib.tensorrt.ops.gen_trt_engine_op import *
 except ImportError:
   pass
-# pylint: enable=unused-import,trailing-whitespace,g-import-not-at-top,wildcard-import
+# pylint: enable=unused-import,g-import-not-at-top,wildcard-import
 
 def import_to_tensorboard(model_dir, log_dir):
   """View an imported protobuf model (`.pb` file) as a graph in Tensorboard.


### PR DESCRIPTION
This PR tries to import TRTEngine ops to import_pb_to_tensorboard.py script to ease up of construction of tensorboard visualizations of TFTRT optimized graphs.