### PR TITLE
Make implementation of GrpcServer::Init with Collective Ops compatible with calls in contrib/mpi

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -284,6 +284,14 @@ Status GrpcServer::Init(
               nullptr);
 }
 
+
+Status GrpcServer::Init(
+    ServiceInitFunction service_func,
+    const RendezvousMgrCreationFunction& rendezvous_mgr_func {
+  return Init(std::move(service_func), rendezvous_mgr_func, nullptr,
+              nullptr);
+}
+
 Status GrpcServer::Init() { return Init(nullptr, nullptr, nullptr, nullptr); }
 
 Status GrpcServer::ParseChannelSpec(const WorkerCacheFactoryOptions& options,

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -287,7 +287,7 @@ Status GrpcServer::Init(
 
 Status GrpcServer::Init(
     ServiceInitFunction service_func,
-    const RendezvousMgrCreationFunction& rendezvous_mgr_func {
+    const RendezvousMgrCreationFunction& rendezvous_mgr_func) {
   return Init(std::move(service_func), rendezvous_mgr_func, nullptr,
               nullptr);
 }

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h
@@ -89,6 +89,9 @@ class GrpcServer : public ServerInterface {
   Status Init(ServiceInitFunction service_func,
               const RendezvousMgrCreationFunction& rendezvous_mgr_func,
               const CollectiveMgrCreationFunction& collective_mgr_func);
+    
+  Status Init(ServiceInitFunction service_func,
+              const RendezvousMgrCreationFunction& rendezvous_mgr_func);
 
   Status Init();
 


### PR DESCRIPTION
Fixes compilation errors outlined in #19924.

I haven't tested the actual MPI behavior (just that compilation succeeds). However, an if-clause in `grpc_server_lib.cc` guards the case in which `collective_mgr_func` is not explicitly passed.