### PR TITLE
[XLA] Skip float16 adam_tests.

### DIFF
--- a/tensorflow/compiler/tests/adam_test.py
+++ b/tensorflow/compiler/tests/adam_test.py
@@ -52,6 +52,7 @@ class AdamOptimizerTest(XLATestCase):
 
   def testBasic(self):
     for dtype in self.float_types:
+      # TODO: test fails for float16 due to excessive precision requirements.
       if dtype == np.float16:
         continue
       with self.test_session(), self.test_scope():
@@ -93,6 +94,7 @@ class AdamOptimizerTest(XLATestCase):
 
   def testTensorLearningRate(self):
     for dtype in self.float_types:
+      # TODO: test fails for float16 due to excessive precision requirements.
       if dtype == np.float16:
         continue
       with self.test_session(), self.test_scope():
@@ -134,6 +136,7 @@ class AdamOptimizerTest(XLATestCase):
 
   def testSharing(self):
     for dtype in self.float_types:
+      # TODO: test fails for float16 due to excessive precision requirements.
       if dtype == np.float16:
         continue
       with self.test_session(), self.test_scope():

--- a/tensorflow/compiler/tests/adam_test.py
+++ b/tensorflow/compiler/tests/adam_test.py
@@ -52,6 +52,8 @@ class AdamOptimizerTest(XLATestCase):
 
   def testBasic(self):
     for dtype in self.float_types:
+      if dtype == np.float16:
+        continue
       with self.test_session(), self.test_scope():
         variable_scope.get_variable_scope().set_use_resource(True)
 
@@ -91,6 +93,8 @@ class AdamOptimizerTest(XLATestCase):
 
   def testTensorLearningRate(self):
     for dtype in self.float_types:
+      if dtype == np.float16:
+        continue
       with self.test_session(), self.test_scope():
         variable_scope.get_variable_scope().set_use_resource(True)
 
@@ -130,6 +134,8 @@ class AdamOptimizerTest(XLATestCase):
 
   def testSharing(self):
     for dtype in self.float_types:
+      if dtype == np.float16:
+        continue
       with self.test_session(), self.test_scope():
         variable_scope.get_variable_scope().set_use_resource(True)
 


### PR DESCRIPTION
Adam tests compare the output of the computation against a hand wirtten numpy
solution which does not take into account the precision and hence these tests fail for
float16.