### PR TITLE
fix opencv imread failure: remove libjpeg symbols from export list of…

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -450,6 +450,15 @@ filegroup(
 # depend on libtensorflow_framework.so unless they opt in.
 tf_cc_shared_object(
     name = "libtensorflow_framework.so",
+    linkopts = select({
+        "//tensorflow:darwin": [],
+        "//tensorflow:windows": [],
+        "//tensorflow:windows_msvc": [],
+        "//conditions:default": [
+            "-Wl,--version-script",  #  This line must be directly followed by the version_script.lds file
+            "$(location //tensorflow:tf_framework_version_script.lds)",
+        ],
+    }),
     framework_so = [],
     linkstatic = 1,
     visibility = ["//visibility:public"],
@@ -460,6 +469,7 @@ tf_cc_shared_object(
         "//tensorflow/core/grappler/optimizers:custom_graph_optimizer_registry_impl",
         "//tensorflow/core:lib_internal_impl",
         "//tensorflow/stream_executor:stream_executor_impl",
+        "//tensorflow:tf_framework_version_script.lds",
     ] + tf_additional_binary_deps(),
 )
 

--- a/tensorflow/tf_framework_version_script.lds
+++ b/tensorflow/tf_framework_version_script.lds
@@ -1,0 +1,11 @@
+VERS_1.0 {
+  # Hide libjpeg symbols to avoid symbol conflict with OpenCV
+  local:
+    jpeg_*;
+    jinit_*;
+    jdiv_round_up;
+    jround_up;
+    jzero_far;
+    jcopy_*;
+    jsimd_*;
+};


### PR DESCRIPTION
… libtensorflow_framework.so to avoid symbol conflicts with opencv