### PR TITLE
[XLA] Change the visibility of the graph builder

### DIFF
--- a/tensorflow/compiler/xla/service/BUILD
+++ b/tensorflow/compiler/xla/service/BUILD
@@ -2542,7 +2542,6 @@ cc_library(
     name = "hlo_tfgraph_builder",
     srcs = ["hlo_tfgraph_builder.cc"],
     hdrs = ["hlo_tfgraph_builder.h"],
-    visibility = ["//tensorflow/compiler/xla/tools:__pkg__"],
     deps = [
         ":hlo",
         "//tensorflow/compiler/xla:literal_util",


### PR DESCRIPTION
The hlo_tfgraph_builder isn't directly used by the xla/tools package, so it doesn't seem to need to be limited to only the service module and the tools module.

I have brought it in line with the rest of the service module, which means it can be used by other parts of the XLA system - specifically the Graphcore backend, which resides in the compiler/plugins directory.

