### PR TITLE
Fixed compilation error (undefined reference to LLVMInitializePowerPC…

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -151,7 +151,14 @@ cc_library(
         "@llvm//:target",  # fixdeps: keep
         "@llvm//:x86_code_gen",  # fixdeps: keep
         "@llvm//:x86_disassembler",  # fixdeps: keep
-    ],
+    ] + select({
+        "@org_tensorflow//tensorflow:linux_ppc64le": [
+            "@llvm//:powerpc_disassembler",
+            "@llvm//:powerpc_code_gen",
+        ],
+        "//conditions:default": [
+        ],
+    }),
     alwayslink = True,  # Contains compiler registration
 )
 


### PR DESCRIPTION
…TargetMC) on ppc64le when XLA is enabled

Building master branch tensorflow on ppc64le with XLA enabled gives compilation error - undefined reference to LLVMInitializePowerPCTargetMC. Fixed the error by adding powerpc related code generator and disassembler targets.