### PR TITLE
Remove duplicate import in linear_equations.py

### DIFF
--- a/tensorflow/contrib/solvers/python/ops/linear_equations.py
+++ b/tensorflow/contrib/solvers/python/ops/linear_equations.py
@@ -28,7 +28,6 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import linalg_ops
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import linalg_ops
 
 
 def conjugate_gradient(operator,


### PR DESCRIPTION
The line `from tensorflow.python.ops import linalg_ops`
in linear_equations.py is a duplicate from the previous
line. This fix removes the duplicate import.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>