### PR TITLE
Fix build issue on mac with python-2.7.10 and clang-9.1.0

### DIFF
--- a/tensorflow/contrib/lite/python/interpreter_wrapper/interpreter_wrapper.h
+++ b/tensorflow/contrib/lite/python/interpreter_wrapper/interpreter_wrapper.h
@@ -19,6 +19,8 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+// Place `<locale>` before <Python.h> to avoid build failures in macOS.
+#include <locale>
 #include <Python.h>
 
 // We forward declare TFLite classes here to avoid exposing them to SWIG.

--- a/tensorflow/python/lib/core/numpy.h
+++ b/tensorflow/python/lib/core/numpy.h
@@ -29,6 +29,8 @@ limitations under the License.
 #define NO_IMPORT_ARRAY
 #endif
 
+// Place `<locale>` before <Python.h> to avoid build failure in macOS.
+#include <locale>
 #include <Python.h>
 
 #include "numpy/arrayobject.h"

--- a/tensorflow/python/lib/core/py_util.cc
+++ b/tensorflow/python/lib/core/py_util.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "tensorflow/python/lib/core/py_util.h"
 
+// Place `<locale>` before <Python.h> to avoid build failure in macOS.
+#include <locale>
 #include <Python.h>
 
 #include "tensorflow/core/lib/core/errors.h"


### PR DESCRIPTION
While building tensorflow on mac with `python 2.7.10` and `llvm 9.1.0` (`macOS High Sierra 10.15.5`), the following compilation errors surface:
```
In file included from tensorflow/python/lib/core/py_util.cc:20:
In file included from ./tensorflow/core/lib/core/errors.h:19:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/sstream:174:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:138:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ios:216:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__locale:492:15: error: C++ requires a type specifier for all declarations
    char_type toupper(char_type __c) const
              ^
bazel-out/host/genfiles/external/local_config_python/python_include/pyport.h:731:29: note: expanded from macro 'toupper'
...
...
```

The error is related to the issue in `pyport.h`.
The build error could be fixed by including `#include <locale>`
before including `#include <Python.h>`.

The changes in this PR allows the build to succeed.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>