### PR TITLE
Sync package version of double-conversion between bazel and cmake

### DIFF
--- a/tensorflow/contrib/cmake/external/double_conversion.cmake
+++ b/tensorflow/contrib/cmake/external/double_conversion.cmake
@@ -16,7 +16,7 @@ include (ExternalProject)
 
 set(double_conversion_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/double_conversion/src/double_conversion)
 set(double_conversion_URL https://github.com/google/double-conversion.git)
-set(double_conversion_TAG 5664746)
+set(double_conversion_TAG 3992066a95b823efc8ccc1baf82a1cfc73f6e9b8)
 set(double_conversion_BUILD ${double_conversion_INCLUDE_DIR})
 set(double_conversion_LIBRARIES ${double_conversion_BUILD}/double-conversion/libdouble-conversion.so)
 set(double_conversion_INCLUDES ${double_conversion_BUILD})

--- a/tensorflow/contrib/cmake/external/double_conversion.cmake
+++ b/tensorflow/contrib/cmake/external/double_conversion.cmake
@@ -22,9 +22,9 @@ set(double_conversion_LIBRARIES ${double_conversion_BUILD}/double-conversion/lib
 set(double_conversion_INCLUDES ${double_conversion_BUILD})
 
 if(WIN32)
-  set(double_conversion_STATIC_LIBRARIES ${double_conversion_BUILD}/double-conversion/$(Configuration)/double-conversion.lib)
+  set(double_conversion_STATIC_LIBRARIES ${double_conversion_BUILD}/$(Configuration)/double-conversion.lib)
 else()
-  set(double_conversion_STATIC_LIBRARIES ${double_conversion_BUILD}/double-conversion/libdouble-conversion.a)
+  set(double_conversion_STATIC_LIBRARIES ${double_conversion_BUILD}/libdouble-conversion.a)
 endif()
 
 set(double_conversion_HEADERS


### PR DESCRIPTION
This fix tries to sync package version of double-conversion between bazel and cmake.

The double-conversion package was added in #12102 and was reverted in PR #15133. At that time the package version was 5664746 for both bazel and cmake.

Later on, the double-conversion was re-introduced in PR #18746. The package version of double-conversion in bazel has been advanced to `3992066a95b823efc8ccc1baf82a1cfc73f6e9b8` but the version in cmake remains the old `5664746`.

This fix updates the double-conversion version in cmake so that it is synced with the version (`3992066a95b823efc8ccc1baf82a1cfc73f6e9b8`) used in bazel.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>