### PR TITLE
Fix missing header in aarch64 Nvidia Jetson

### DIFF
--- a/tensorflow/contrib/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h
+++ b/tensorflow/contrib/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h
@@ -26,7 +26,7 @@ namespace optimized_ops {
 // Enable for arm64 except for the Nvidia Linux 4 Tegra (L4T) running on
 // Jetson TX-2. This compiler does not support the offsetof() macro.
 #if defined(__aarch64__) && !defined(GOOGLE_L4T)
-
+#include <stddef.h>
 // clang-format gets confused with this file and ends up formatting lines to
 // be larger than 80 characters. Turn off here and back on at the end of the
 // file.


### PR DESCRIPTION
fix missing header in aarch64 Nvidia Jetson

This issue is GOOGLE_L4T Marco is 'not defined' on Jetson(build on Jetson) or config file. It will compile these section, then error happened.

See https://github.com/tensorflow/tensorflow/issues/19956