### PR TITLE
Improve S3 filesystem read performance

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -187,9 +187,7 @@ class S3RandomAccessFile : public RandomAccessFile {
       return Status(error::OUT_OF_RANGE, "Read less bytes than requested");
     }
     n = getObjectOutcome.GetResult().GetContentLength();
-    std::stringstream ss;
-    ss << getObjectOutcome.GetResult().GetBody().rdbuf();
-    ss.read(scratch, n);
+    getObjectOutcome.GetResult().GetBody().read(scratch, n);
 
     *result = StringPiece(scratch, n);
     return Status::OK();


### PR DESCRIPTION
Avoid creating a new std::stringstream and copying data into it every time S3RandomAccessFile::Read() is called. Fixes #14572.

I was seeing the same issue in #14572 when using an S3 path for my Tensorboard logdir and when reading datasets from S3. Looking at the S3 code, I noticed that S3RandomAccessFile was copying data read from an Aws::IOStream into a temporary std::stringstream, and then copying it back into the final buffer (`scratch`).

Based on the comments for `RandomAccessFile::Read()`, it seems that the data from S3 could be directly written into `scratch` without a copy. I also think the stringstream was allocating lots of small chunks of memory to store the data read from the S3 files, which was probably the bigger performance hit.

I updated the code and rebuilt Tensorflow, and now Tensorboard loads tfevent files from S3 much more quickly.

