### PR TITLE
MKL DNN: Fix allocation ID for MKL

### DIFF
--- a/tensorflow/core/common_runtime/direct_session_with_tracking_alloc_test.cc
+++ b/tensorflow/core/common_runtime/direct_session_with_tracking_alloc_test.cc
@@ -109,15 +109,15 @@ TEST(DirectSessionWithTrackingAllocTest, CostModelTest) {
           // and deallocated. Each allocation calls the
           // (FindChunkPtr of BFCAllocator),
           // which increments the value of AllocationId. 
-          // Thus AllocationId becomes more than 3 and 4 if 
-          // MKL is used. Now they are 9 and 10 for MKL. 
-          EXPECT_EQ(19, cm->AllocationId(node, 0));
+          // Thus AllocationId becomes more than TF if MKL 
+          // is used. Now IDs for MKL are 8 more than TF. 
+          EXPECT_EQ(29, cm->AllocationId(node, 0));
 #else
           EXPECT_EQ(21, cm->AllocationId(node, 0));
 #endif 
         } else {
 #ifdef INTEL_MKL
-          EXPECT_EQ(20, cm->AllocationId(node, 0));
+          EXPECT_EQ(30, cm->AllocationId(node, 0));
 #else
           EXPECT_EQ(22, cm->AllocationId(node, 0));
 #endif 


### PR DESCRIPTION
The allocation in the graph pass has been changed recently in non MKL version (original TF version) of code. Since MKL related code does more allocation in graph pass, thus allocation ID in MKL is also have been changed. Now it is fixed.
It would be nice, if someone changes allocation ID in non MKL version (TF only version), they can also change the MKL version of allocation ID. Both the allocation IDs (non MKL and MKL) are in the same location of the function. That way, both tests (MKL version and non MKL version) will be passed.
 Otherwise, we have to create a PR for MKL unit test every time someone changes the allocation ID in the non MKL version of code.