### PR TITLE
contrib.graph_editor.transform.copy_op_handler: fix for pruning

### DIFF
--- a/tensorflow/contrib/graph_editor/transform.py
+++ b/tensorflow/contrib/graph_editor/transform.py
@@ -129,7 +129,7 @@ def transform_op_if_inside_handler(info, op, keep_if_possible=True):
       return None
 
 
-def copy_op_handler(info, op, new_inputs, copy_shape=True, nodedef_fn=None):
+def copy_op_handler(info, op, new_inputs, copy_shape=False, nodedef_fn=None):
   """Copy a `tf.Operation`.
 
   Args:


### PR DESCRIPTION
tf.contrib.graph_editor.transform.copy_op_handler: change default copy_shape to False so graph_replace can work for network pruning where new weight shape does not match old weight shape