### PR TITLE
Fix: DepthwiseConv2D fails when bias is enabled

### DIFF
--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -1729,7 +1729,7 @@ class DepthwiseConv2D(Conv2D):
         dilation_rate=self.dilation_rate,
         data_format=self.data_format)
 
-    if self.bias:
+    if self.use_bias:
       outputs = backend.bias_add(
           outputs,
           self.bias,

--- a/tensorflow/python/keras/layers/convolutional_test.py
+++ b/tensorflow/python/keras/layers/convolutional_test.py
@@ -995,6 +995,7 @@ class DepthwiseConv2DTest(test.TestCase):
               'bias_regularizer': 'l2',
               'activity_regularizer': 'l2',
               'depthwise_constraint': 'unit_norm',
+              'use_bias': True,
               'strides': (2, 2),
              }
     self._run_test(kwargs, 'depth_multiplier', [1])


### PR DESCRIPTION
Replaced `if self.bias` with `if self.use_bias`. bias is a tensor and using it as a bool will result in error.
Fixes #20023 