### PR TITLE
Fixes the bug in model.save

### DIFF
--- a/tensorflow/python/keras/engine/saving.py
+++ b/tensorflow/python/keras/engine/saving.py
@@ -33,13 +33,6 @@ from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import serialization
 from tensorflow.python.util.tf_export import tf_export
 
-# pylint: disable=g-import-not-at-top
-try:
-  import h5py
-  HDF5_OBJECT_HEADER_LIMIT = 64512
-except ImportError:
-  h5py = None
-
 try:
   import yaml
 except ImportError:
@@ -73,8 +66,11 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
   Raises:
       ImportError: if h5py is not available.
   """
-
-  if h5py is None:
+  # pylint: disable=g-import-not-at-top
+  try:
+    import h5py
+    HDF5_OBJECT_HEADER_LIMIT = 64512
+  except ImportError:
     raise ImportError('`save_model` requires h5py.')
 
   from tensorflow.python.keras import __version__ as keras_version  # pylint: disable=g-import-not-at-top

--- a/tensorflow/python/keras/engine/saving.py
+++ b/tensorflow/python/keras/engine/saving.py
@@ -33,6 +33,8 @@ from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import serialization
 from tensorflow.python.util.tf_export import tf_export
 
+HDF5_OBJECT_HEADER_LIMIT = 64512
+
 try:
   import yaml
 except ImportError:
@@ -69,7 +71,6 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
   # pylint: disable=g-import-not-at-top
   try:
     import h5py
-    HDF5_OBJECT_HEADER_LIMIT = 64512
   except ImportError:
     raise ImportError('`save_model` requires h5py.')
 
@@ -178,7 +179,9 @@ def load_model(filepath, custom_objects=None, compile=True):  # pylint: disable=
       ImportError: if h5py is not available.
       ValueError: In case of an invalid savefile.
   """
-  if h5py is None:
+  try:
+    import h5py
+  except ImportError:
     raise ImportError('`load_model` requires h5py.')
 
   if not custom_objects:


### PR DESCRIPTION
Fixes the bug where if you get the h5py error, and install it in Jupyter, you still can't use save because keras never tries to reimport.