### PR TITLE
fix a mistake in the doc str of class GradientTape

### DIFF
--- a/tensorflow/python/eager/backprop.py
+++ b/tensorflow/python/eager/backprop.py
@@ -681,8 +681,8 @@ class GradientTape(object):
     g.watch(x)
     y = x * x
     z = y * y
-  dz_dx = g.gradient(z, x)  # 108.0 (4*x^3 at x = 3)
-  dy_dx = g.gradient(y, x)  # 6.0
+  dz_dx = g.gradient(z, x)  # 6.0
+  dy_dx = g.gradient(y, x)  # 108.0 (4*x^3 at x = 3)
   del g  # Drop the reference to the tape
   ```
 


### PR DESCRIPTION
There is a mistake in the original help (or doc) string under class GradientTape in version 1.8.0,  The expected value for two of the example output is interchanged, which could lead to user misunderstanding if not fixed. 