### PR TITLE
Fix kCall comparison

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -1493,6 +1493,7 @@ bool HloInstruction::IdenticalSlowPath(
       return protobuf_util::ProtobufEquals(padding_config(),
                                            other.padding_config());
     case HloOpcode::kCall:
+      return eq_computations(to_apply(), other.to_apply());
     case HloOpcode::kCrossReplicaSum:
       return replica_group_ids() == other.replica_group_ids() &&
              cross_replica_sum_barrier() == other.cross_replica_sum_barrier() &&


### PR DESCRIPTION
The HloInstruction::Identical is broken for kCall instructions.  It is possible that this API isn't used by anything but the subcomputation unification pipeline stage, which I guess isn't in use by any backends but the GC one.

The call_test in the xla/tests was showing up a Casting error.  The kCall was using the same tests as the cross replica sum, as you can see.  However, the replica_group_ids() function was trying to cast the op to a cross replica sum subclass, and failing.

