### PR TITLE
Fix MPI build issue with bazel

### DIFF
--- a/tensorflow/contrib/mpi_collectives/BUILD
+++ b/tensorflow/contrib/mpi_collectives/BUILD
@@ -52,6 +52,7 @@ tf_custom_op_library(
     deps = [
         ":mpi_defines",
         ":mpi_message_proto_cc",
+        "//tensorflow/compiler/xla:xla_headers_lib",
         "//third_party/mpi",
     ],
 )

--- a/tensorflow/contrib/mpi_collectives/BUILD
+++ b/tensorflow/contrib/mpi_collectives/BUILD
@@ -52,7 +52,7 @@ tf_custom_op_library(
     deps = [
         ":mpi_defines",
         ":mpi_message_proto_cc",
-        "//tensorflow/compiler/xla:xla_headers_lib",
+        "//tensorflow/stream_executor:stream_executor_headers_lib",
         "//third_party/mpi",
     ],
 )

--- a/tensorflow/contrib/mpi_collectives/kernels/mpi_ops.cc
+++ b/tensorflow/contrib/mpi_collectives/kernels/mpi_ops.cc
@@ -73,7 +73,7 @@ limitations under the License.
  */
 
 template <class T>
-using StatusOr = se::port::StatusOr<T>;
+using StatusOr = stream_executor::port::StatusOr<T>;
 
 using CPUDevice = Eigen::ThreadPoolDevice;
 using GPUDevice = Eigen::GpuDevice;

--- a/tensorflow/stream_executor/BUILD
+++ b/tensorflow/stream_executor/BUILD
@@ -2,6 +2,7 @@ licenses(["restricted"])
 
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda_is_configured")
 load("//tensorflow/core:platform/default/build_config_root.bzl", "if_static")
+load("//tensorflow:tensorflow.bzl", "cc_header_only_library")
 
 STREAM_EXECUTOR_HEADERS = glob([
     "*.h",
@@ -49,6 +50,14 @@ cc_library(
         "//tensorflow/core:ptr_util",
         "@local_config_cuda//cuda:cuda_headers",
     ] + if_static([":stream_executor_impl"]),
+)
+
+cc_header_only_library(
+    name = "stream_executor_headers_lib",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":stream_executor",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION

While trying to build tensorflow with MPI through:
```
Do you wish to build TensorFlow with MPI support [y/N] y
...
$ bazel build -s --verbose_failures --config=opt //tensorflow/tools/pip_package:build_pip_package
```
, the following failure happens:
```
tensorflow/contrib/mpi_collectives/kernels/mpi_ops.cc:76:18: error: 'se' does not name a type
 using StatusOr = se::port::StatusOr<T>;
                  ^
tensorflow/contrib/mpi_collectives/kernels/mpi_ops.cc:139:28: error: 'StatusOr' was not declared in this scope
 typedef std::function<void(StatusOr<Tensor>)> CommunicationDoneCallback;
...
```

This fix addresses the build failures for MPI build.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>