### PR TITLE
Remove duplicate imports in dynamic_stitch_op_test.py

### DIFF
--- a/tensorflow/python/kernel_tests/dynamic_stitch_op_test.py
+++ b/tensorflow/python/kernel_tests/dynamic_stitch_op_test.py
@@ -27,7 +27,6 @@ from tensorflow.python.ops import data_flow_ops
 from tensorflow.python.ops import gradients_impl
 import tensorflow.python.ops.data_flow_grad  # pylint: disable=unused-import
 from tensorflow.python.platform import test
-from tensorflow.python.framework import dtypes
 
 
 class DynamicStitchTestBase(object):


### PR DESCRIPTION
There is a duplicate `from tensorflow.python.framework import dtypes`
in dynamic_stitch_op_test.py (See Line 24 above).
