### PR TITLE
Remove a unnecessary dependency to accelerate compilation

### DIFF
--- a/tensorflow/cc/saved_model/BUILD
+++ b/tensorflow/cc/saved_model/BUILD
@@ -42,7 +42,6 @@ cc_library(
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:lib",
         "//tensorflow/core:protos_all_cc",
-        "//tensorflow/core:tensorflow",
     ]) + if_android([
         "//tensorflow/core:android_tensorflow_lib",
     ]),


### PR DESCRIPTION
`//tensorflow/contrib/lite/toco:toco` now depends on many kernel implementations when building. It is very annoying on laptops. After some Bazel queries, it looks like they are introduced here and can be safely removed without breaking `toco`.

I did not do a full build , so I am not sure if it breaks other targets. Can CI help verify this?