### PR TITLE
[XLA] Add in a plugin tf2xla dependency for backend registration

### DIFF
--- a/tensorflow/compiler/plugin/BUILD
+++ b/tensorflow/compiler/plugin/BUILD
@@ -34,10 +34,29 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+# This target is for plugins/extensions to add their TF device, and XLA backend
+# into the system. The depenency comes via the jit module.  The target should
+# include the creation of a XlaDevice, and a factory registered with
+# REGISTER_LOCAL_DEVICE_FACTORY.  It should also include the XLA compiler and
+# associated platform, registered with xla::Compiler::RegisterCompilerFactory.
+# See tensorflow/compiler/jit/xla_cpu_device.cc,
+# tensorflow/compiler/xla/service/cpu/cpu_compiler.cc and
+# tensorflow/stream_executor/host/host_platform.cc for examples.
 cc_library(
     name = "plugin",
     deps = [
         #"//tensorflow/compiler/plugin/example:example_lib",
+    ],
+)
+
+# This target is for plugins/extensions to add their backend registration files.
+# The dependency comes via the tf2xla module, and should register the backend
+# using the REGISTER_XLA_BACKEND macro.  See tf2xla/xla_cpu_backend.cc for an
+# example.
+cc_library(
+    name = "plugin_backend",
+    deps = [
+        #"//tensorflow/compiler/plugin/example:example_backend",
     ],
 )
 

--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -31,9 +31,7 @@ cc_library(
     hdrs = ["tf2xla_supported_ops.h"],
     visibility = ["//visibility:public"],
     deps = [
-        ":xla_compiler",
-        "//tensorflow/compiler/tf2xla/kernels:xla_cpu_only_ops",
-        "//tensorflow/compiler/tf2xla/kernels:xla_ops",
+        ":tf2xla",
         "//tensorflow/core:framework",
         "//tensorflow/core:framework_internal",
         "//tensorflow/core:lib",
@@ -78,6 +76,7 @@ cc_library(
         ":tf2xla_proto",
         ":tf2xla_util",
         ":xla_compiler",
+        "//tensorflow/compiler/plugin:plugin_backend",
         "//tensorflow/compiler/tf2xla/kernels:xla_cpu_only_ops",
         "//tensorflow/compiler/tf2xla/kernels:xla_ops",
         "//tensorflow/compiler/xla/client",


### PR DESCRIPTION
tf2xla backends are slightly separate to the XlaDevices and platform/compiler framework.

This change allows a tf2xla backend to be registered separately to the rest of the framework, which enables targets that bind to tf2xla and not the core of XLA to work. specifically this will allow this target to work with plugin extensions:

tensorflow/compiler/tf2xla:tf2xla_supported_ops