### PR TITLE
add alternative relative paths for cupti and nvvm

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -59,6 +59,7 @@ CUDA_LIB_PATHS = [
 CUPTI_HEADER_PATHS = [
   "extras/CUPTI/include/",
   "include/cuda/CUPTI/",
+  "include/",
 ]
 
 # Lookup paths for the cupti library, relative to the
@@ -94,6 +95,7 @@ CUDNN_INCLUDE_PATHS = [
 NVVM_LIBDEVICE_PATHS = [
   "nvvm/libdevice/",
   "share/cuda/",
+  "lib/nvidia-cuda-toolkit/libdevice/",
 ]
 
 load("//third_party/clang_toolchain:download_clang.bzl", "download_clang")


### PR DESCRIPTION
On Ubuntu 18.04, _libcupti-dev_ and _nvidia-cuda-toolkit_ both install under /usr (instead of Nvidia's default /usr/local/cuda). This fixes the ensuing bazel configuration errors when building for CUDA:
```Cuda Configuration Error: Cannot find cupti.h under /usr```
and
```Cuda Configuration Error: Cannot find libdevice.10.bc under /usr```