### PR TITLE
1.9.0rc2 cherry-pick request: [tf.data] Properly export `choose_from_datasets()`

### DIFF
--- a/tensorflow/contrib/data/__init__.py
+++ b/tensorflow/contrib/data/__init__.py
@@ -72,6 +72,7 @@ from tensorflow.contrib.data.python.ops.error_ops import ignore_errors
 from tensorflow.contrib.data.python.ops.get_single_element import get_single_element
 from tensorflow.contrib.data.python.ops.grouping import bucket_by_sequence_length
 from tensorflow.contrib.data.python.ops.grouping import group_by_window
+from tensorflow.contrib.data.python.ops.interleave_ops import choose_from_datasets
 from tensorflow.contrib.data.python.ops.interleave_ops import parallel_interleave
 from tensorflow.contrib.data.python.ops.interleave_ops import sample_from_datasets
 from tensorflow.contrib.data.python.ops.interleave_ops import sloppy_interleave


### PR DESCRIPTION
This change adds a missing import statement in the `tf.contrib.data` library. The `tf.contrib.data.choose_from_datasets()` is already mentioned in the release notes, and its implementation is there, but I neglected to check that it was accessible via the public API. Not including it in the release would make the release notes incorrect.