### PR TITLE
Build sqlite3 with json1 extension

### DIFF
--- a/tensorflow/core/lib/db/sqlite_test.cc
+++ b/tensorflow/core/lib/db/sqlite_test.cc
@@ -73,6 +73,19 @@ TEST_F(SqliteTest, InsertAndSelectDouble) {
   EXPECT_EQ(1, stmt.ColumnInt(1));
 }
 
+TEST_F(SqliteTest, Json1Extension) {
+  string s1 = "{\"key\": 42}";
+  string s2 = "{\"key\": \"value\"}";
+  auto stmt = db_->PrepareOrDie("INSERT INTO T (a, b) VALUES (?, ?)");
+  stmt.BindText(1, s1);
+  stmt.BindText(2, s2);
+  TF_ASSERT_OK(stmt.StepAndReset());
+  stmt = db_->PrepareOrDie("SELECT json_extract(a, '$.key'), json_extract(b, '$.key') FROM T");
+  TF_ASSERT_OK(stmt.Step(&is_done_));
+  EXPECT_EQ(42, stmt.ColumnInt(0));
+  EXPECT_EQ("value", stmt.ColumnString(1));
+}
+
 TEST_F(SqliteTest, NulCharsInString) {
   string s;  // XXX: Want to write {2, '\0'} but not sure why not.
   s.append(static_cast<size_t>(2), '\0');

--- a/third_party/sqlite.BUILD
+++ b/third_party/sqlite.BUILD
@@ -5,6 +5,7 @@ licenses(["unencumbered"])  # Public Domain
 
 SQLITE_COPTS = [
     "-Os",
+    "-DSQLITE_ENABLE_JSON1",
     "-DHAVE_DECL_STRERROR_R=1",
     "-DHAVE_STDINT_H=1",
     "-DHAVE_INTTYPES_H=1",


### PR DESCRIPTION
Builds of SQLite by default often with with the [builtin json1 Extension enabled](https://www.sqlite.org/json1.html).

E.g. the `libsqlite3-dev` enables this (as used in TF's CI!) or sqlite3 that comes with Python has this enabled.

For TF, this impacts TF's [SqlDataset reader](https://www.tensorflow.org/api_docs/python/tf/contrib/data/SqlDataset):

For example, if you have a field that contains a json-encoded list `[1,2,3]` or dictionary `{ 'foo': 'bar'}`, you can simply extract those f.e. in your SQL Query:
```sql
json_extract(data, '$.foo')
```

I think this is very useful for cases where you have f.e. a variable list of classes `['car', 'boat']` or (a variable number of) coordinates (e.g. polygons, bounding boxes) and you want to save them in one encoded field: e.g. `"[[0.0, 1.0, 2.0, 2.0], ..]"`

The added code simply adds the flag to enable json1, and a test to make sure it works.