### PR TITLE
Update docstring of sparse_softmax_cross_entropy

### DIFF
--- a/tensorflow/python/ops/losses/losses_impl.py
+++ b/tensorflow/python/ops/losses/losses_impl.py
@@ -878,7 +878,8 @@ def sparse_softmax_cross_entropy(
       exception when this op is run on CPU, and return `NaN` for corresponding
       loss and gradient rows on GPU.
     logits: Unscaled log probabilities of shape
-      `[d_0, d_1, ..., d_{r-1}, num_classes]` and dtype `float32` or `float64`.
+      `[d_0, d_1, ..., d_{r-1}, num_classes]` and dtype `float16`, `float32` or
+      `float64`.
     weights: Coefficients for the loss. This must be scalar or broadcastable to
       `labels` (i.e. same rank and each dimension is either 1 or the same).
     scope: the scope for the operations performed in computing the loss.

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2009,7 +2009,8 @@ def sparse_softmax_cross_entropy_with_logits(
       exception when this op is run on CPU, and return `NaN` for corresponding
       loss and gradient rows on GPU.
     logits: Unscaled log probabilities of shape
-      `[d_0, d_1, ..., d_{r-1}, num_classes]` and dtype `float32` or `float64`.
+      `[d_0, d_1, ..., d_{r-1}, num_classes]` and dtype `float16`, `float32`, or
+      `float64`.
     name: A name for the operation (optional).
 
   Returns:


### PR DESCRIPTION
This fix tries to address the discrepancy between the docstring and the actual implementation of sparse_softmax_cross_entropy.

The implementation of sparse_softmax_cross_entropy supports float16, float32, and float64, though the docstring only specified float32 and float64. This fix addresses the discrepancy.

NOTE: The `sparse_softmax_cross_entropy` calls `nn.sparse_softmax_cross_entropy_with_logits`:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/losses/losses_impl.py#L912
, which converts `float16` to `float32`, so `float16` is supported:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/nn_ops.py#L2035-L2036


This fix fixes #20231.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
