### PR TITLE
Update or-tools to v6.7.2

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -143,9 +143,7 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
       name = "ortools_archive",
       urls = [
           "https://mirror.bazel.build/github.com/google/or-tools/archive/v6.7.2.tar.gz",
-          # Please uncomment me, when the next upgrade happens. Then
-          # remove the whitelist entry in third_party/repo.bzl.
-          # "https://github.com/google/or-tools/archive/v6.7.2.tar.gz",
+          "https://github.com/google/or-tools/archive/v6.7.2.tar.gz",
       ],
       sha256 = "d025a95f78b5fc5eaa4da5f395f23d11c23cf7dbd5069f1f627f002de87b86b9",
       strip_prefix = "or-tools-6.7.2/src",

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -142,13 +142,13 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "ortools_archive",
       urls = [
-          "https://mirror.bazel.build/github.com/google/or-tools/archive/253f7955c6a1fd805408fba2e42ac6d45b312d15.tar.gz",
+          "https://mirror.bazel.build/github.com/google/or-tools/archive/v6.7.2.tar.gz",
           # Please uncomment me, when the next upgrade happens. Then
           # remove the whitelist entry in third_party/repo.bzl.
-          # "https://github.com/google/or-tools/archive/253f7955c6a1fd805408fba2e42ac6d45b312d15.tar.gz",
+          # "https://github.com/google/or-tools/archive/v6.7.2.tar.gz",
       ],
-      sha256 = "932075525642b04ac6f1b50589f1df5cd72ec2f448b721fd32234cf183f0e755",
-      strip_prefix = "or-tools-253f7955c6a1fd805408fba2e42ac6d45b312d15/src",
+      sha256 = "d025a95f78b5fc5eaa4da5f395f23d11c23cf7dbd5069f1f627f002de87b86b9",
+      strip_prefix = "or-tools-6.7.2/src",
       build_file = clean_dep("//third_party:ortools.BUILD"),
   )
 

--- a/third_party/repo.bzl
+++ b/third_party/repo.bzl
@@ -16,7 +16,6 @@
 
 _SINGLE_URL_WHITELIST = depset([
     "arm_compiler",
-    "ortools_archive",
 ])
 
 def _is_windows(ctx):


### PR DESCRIPTION
This fix updates or-tools from 253f795 (dated 03/21/2017) to the latest versioned release version of v6.7.2

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>