### PR TITLE
Fix build issue while creating Python API

### DIFF
--- a/tensorflow/tools/api/generator/create_python_api.py
+++ b/tensorflow/tools/api/generator/create_python_api.py
@@ -180,7 +180,7 @@ def get_api_init_text(package, api_name):
   for module in list(sys.modules.values()):
     # Only look at tensorflow modules.
     if (not module or not hasattr(module, '__name__') or
-        package not in module.__name__):
+        module.__name__ is None or package not in module.__name__):
       continue
     # Do not generate __init__.py files for contrib modules for now.
     if '.contrib.' in module.__name__ or module.__name__.endswith('.contrib'):


### PR DESCRIPTION
This fix tries to address the issue raised in #20233 where build could fail with the following error:
```
"/var/tmp/portage/sci-libs/tensorflow-1.9.0_rc1/work/bazel-base-python3_6/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/tools/api/generator/create_python_api.runfiles/org_tensorflow/tensorflow/tools/api/generator/create_python_api.py", line 182, in get_api_init_text
    package not in module.__name__):
TypeError: argument of type 'NoneType' is not iterable
Target //tensorflow/tools/pip_package:build_pip_package failed to build
INFO: Elapsed time: 3202.457s, Critical Path: 83.98s
INFO: 4901 processes, local.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
```

This fix addresses the issue.

This fix fixes #20233.

NOTE: The patch is provided by @cjmayo (👍 )

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>