### PR TITLE
Update docstring of tf.linespace for 0-D inputs

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_LinSpace.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_LinSpace.pbtxt
@@ -15,7 +15,7 @@ END
   in_arg {
     name: "num"
     description: <<END
-Number of values to generate.
+0-D tensor. Number of values to generate.
 END
   }
   out_arg {

--- a/tensorflow/core/api_def/base_api/api_def_LinSpace.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_LinSpace.pbtxt
@@ -3,13 +3,13 @@ op {
   in_arg {
     name: "start"
     description: <<END
-First entry in the range.
+0-D tensor. First entry in the range.
 END
   }
   in_arg {
     name: "stop"
     description: <<END
-Last entry in the range.
+0-D tensor. Last entry in the range.
 END
   }
   in_arg {


### PR DESCRIPTION
In #20258 the question was raised as tf.linespace only supports 0-D inputs of start/stop, but the docstring did not mention the 0-D restriction.

This fix updates the docstring to address the discrepancy.

This fix fixes #20258.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>