### PR TITLE
Fix tflite_convert.py issue in Python 3

### DIFF
--- a/tensorflow/contrib/lite/python/tflite_convert.py
+++ b/tensorflow/contrib/lite/python/tflite_convert.py
@@ -102,7 +102,7 @@ def _convert_model(flags):
     input_arrays = converter.get_input_arrays()
     std_dev_values = _parse_array(flags.std_dev_values, type_fn=int)
     mean_values = _parse_array(flags.mean_values, type_fn=int)
-    quant_stats = zip(mean_values, std_dev_values)
+    quant_stats = list(zip(mean_values, std_dev_values))
     if ((not flags.input_arrays and len(input_arrays) > 1) or
         (len(input_arrays) != len(quant_stats))):
       raise ValueError("Mismatching --input_arrays, --std_dev_values, and "


### PR DESCRIPTION
This fix tries to address the issue raised in #20276 where
in python 3, the following error were thrown with tflite_convert.py:
```
TypeError: object of type 'zip' has no len().
```
This fix converts zip output to list to fix the issue in python 3.

This fix fixes #20276.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>