### PR TITLE
Add #define guards for get_xxx_tensorrt_version() to fix an internal ci build error.

### DIFF
--- a/tensorflow/contrib/tensorrt/trt_conversion.i
+++ b/tensorflow/contrib/tensorrt/trt_conversion.i
@@ -221,22 +221,26 @@ std::pair<string, string> calib_convert(
 #endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
 }
 
-version_struct get_linked_tensorrt_version(){
+version_struct get_linked_tensorrt_version() {
   // Return the version at the link time.
-  const auto &lv = tensorflow::tensorrt::convert::GetLinkedTensorRTVersion();
   version_struct s;
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+  const auto &lv = tensorflow::tensorrt::convert::GetLinkedTensorRTVersion();
   s.vmajor = lv[0];
   s.vminor = lv[1];
   s.vpatch = lv[2];
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
   return s;
 }
 version_struct get_loaded_tensorrt_version(){
   // Return the version from the loaded library.
-  const auto &lv = tensorflow::tensorrt::convert::GetLoadedTensorRTVersion();
   version_struct s;
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+  const auto &lv = tensorflow::tensorrt::convert::GetLoadedTensorRTVersion();
   s.vmajor = lv[0];
   s.vminor = lv[1];
   s.vpatch = lv[2];
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
   return s;
 }
 


### PR DESCRIPTION
I verified the fix by running:
```
bazel build --verbose_failures --jobs=32 -c opt --copt=-mavx --output_filter=DONT_MATCH_ANYTHING tensorflow/contrib/tensorrt:init_py
```
on a local repository where trt is not enabled.