### PR TITLE
fix tests in lite/kernels/internal

### DIFF
--- a/tensorflow/contrib/lite/kernels/internal/BUILD
+++ b/tensorflow/contrib/lite/kernels/internal/BUILD
@@ -491,6 +491,7 @@ cc_library(
     hdrs = ["test_util.h"],
     deps = [
         ":types",
+        "//tensorflow/contrib/lite:string",
     ],
 )
 
@@ -588,6 +589,7 @@ cc_test(
     deps = [
         ":optimized_base",
         ":reference_base",
+        "//tensorflow/contrib/lite:string",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tensorflow/contrib/lite/kernels/internal/log_quantized_test.cc
+++ b/tensorflow/contrib/lite/kernels/internal/log_quantized_test.cc
@@ -29,8 +29,9 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "tensorflow/contrib/lite/kernels/internal/optimized/optimized_ops.h"
 #include "tensorflow/contrib/lite/kernels/internal/reference/reference_ops.h"
+#include "tensorflow/contrib/lite/string.h"
 
-namespace {
+namespace tflite {
 
 class NumberGenerator {
  public:
@@ -69,7 +70,7 @@ inline int32 LogPositiveValuesViaFloat(int32 input_val, int input_integer_bits,
 void CheckOutputData(const std::vector<int32>& test_output,
                      const std::vector<int32>& reference_output,
                      const std::vector<int32>& test_input,
-                     const std::string& check_label, int input_integer_bits,
+                     const string& check_label, int input_integer_bits,
                      int output_integer_bits, int tolerance) {
   // In the special case of small input, specifically raw value of 5, a rounding
   // up leads to difference in the output.  We do not aim to be accurate for
@@ -117,7 +118,7 @@ void RightShiftVector(const std::vector<int32>& shifts,
 
 template <int OutputIntegerBits, int InputIntegerBits>
 void RunSingleTest(const std::vector<int32>& test_input,
-                   const std::string& check_label, int tolerance) {
+                   const string& check_label, int tolerance) {
   const int n = test_input.size();
   std::vector<int32> float_gen_output(n, 0);
   std::vector<int32> reference_output(n, 0);
@@ -175,7 +176,7 @@ void RunSingleTest(const std::vector<int32>& test_input,
 
 template <int OutputIntegerBits>
 void RunSingleTest(const std::vector<int32>& test_input, int input_integer_bits,
-                   const std::string& check_label, int tolerance) {
+                   const string& check_label, int tolerance) {
 #define INPUT_CASE(K)                                                   \
   case K:                                                               \
     return RunSingleTest<OutputIntegerBits, K>(test_input, check_label, \
@@ -219,7 +220,7 @@ void RunSingleTest(const std::vector<int32>& test_input, int input_integer_bits,
 }
 
 void RunSingleTest(const std::vector<int32>& test_input, int input_integer_bits,
-                   int output_integer_bits, const std::string& check_label,
+                   int output_integer_bits, const string& check_label,
                    int tolerance) {
 #define OUTPUT_CASE(K)                                                   \
   case K:                                                                \
@@ -264,7 +265,7 @@ void RunSingleTest(const std::vector<int32>& test_input, int input_integer_bits,
 }
 
 void RunUniformTest(int test_size, int input_integer_bits,
-                    int output_integer_bits, const std::string& check_label,
+                    int output_integer_bits, const string& check_label,
                     int tolerance, NumberGenerator* generator) {
   std::vector<int> test_data = generator->RandomIntVector(
       test_size, 2, std::numeric_limits<int>::max() - 1);
@@ -281,7 +282,7 @@ void RunUniformTest(int test_size, int input_integer_bits,
 
 void RunUniformShiftUniformTest(int test_size, int input_integer_bits,
                                 int output_integer_bits,
-                                const std::string& check_label, int tolerance,
+                                const string& check_label, int tolerance,
                                 NumberGenerator* generator) {
   std::vector<int> test_data = generator->RandomIntVector(
       test_size, 2, std::numeric_limits<int>::max() - 1);

--- a/tensorflow/contrib/lite/kernels/internal/log_quantized_test.cc
+++ b/tensorflow/contrib/lite/kernels/internal/log_quantized_test.cc
@@ -69,7 +69,7 @@ inline int32 LogPositiveValuesViaFloat(int32 input_val, int input_integer_bits,
 void CheckOutputData(const std::vector<int32>& test_output,
                      const std::vector<int32>& reference_output,
                      const std::vector<int32>& test_input,
-                     const string& check_label, int input_integer_bits,
+                     const std::string& check_label, int input_integer_bits,
                      int output_integer_bits, int tolerance) {
   // In the special case of small input, specifically raw value of 5, a rounding
   // up leads to difference in the output.  We do not aim to be accurate for
@@ -117,7 +117,7 @@ void RightShiftVector(const std::vector<int32>& shifts,
 
 template <int OutputIntegerBits, int InputIntegerBits>
 void RunSingleTest(const std::vector<int32>& test_input,
-                   const string& check_label, int tolerance) {
+                   const std::string& check_label, int tolerance) {
   const int n = test_input.size();
   std::vector<int32> float_gen_output(n, 0);
   std::vector<int32> reference_output(n, 0);
@@ -175,7 +175,7 @@ void RunSingleTest(const std::vector<int32>& test_input,
 
 template <int OutputIntegerBits>
 void RunSingleTest(const std::vector<int32>& test_input, int input_integer_bits,
-                   const string& check_label, int tolerance) {
+                   const std::string& check_label, int tolerance) {
 #define INPUT_CASE(K)                                                   \
   case K:                                                               \
     return RunSingleTest<OutputIntegerBits, K>(test_input, check_label, \
@@ -219,7 +219,7 @@ void RunSingleTest(const std::vector<int32>& test_input, int input_integer_bits,
 }
 
 void RunSingleTest(const std::vector<int32>& test_input, int input_integer_bits,
-                   int output_integer_bits, const string& check_label,
+                   int output_integer_bits, const std::string& check_label,
                    int tolerance) {
 #define OUTPUT_CASE(K)                                                   \
   case K:                                                                \
@@ -264,7 +264,7 @@ void RunSingleTest(const std::vector<int32>& test_input, int input_integer_bits,
 }
 
 void RunUniformTest(int test_size, int input_integer_bits,
-                    int output_integer_bits, const string& check_label,
+                    int output_integer_bits, const std::string& check_label,
                     int tolerance, NumberGenerator* generator) {
   std::vector<int> test_data = generator->RandomIntVector(
       test_size, 2, std::numeric_limits<int>::max() - 1);
@@ -281,7 +281,7 @@ void RunUniformTest(int test_size, int input_integer_bits,
 
 void RunUniformShiftUniformTest(int test_size, int input_integer_bits,
                                 int output_integer_bits,
-                                const string& check_label, int tolerance,
+                                const std::string& check_label, int tolerance,
                                 NumberGenerator* generator) {
   std::vector<int> test_data = generator->RandomIntVector(
       test_size, 2, std::numeric_limits<int>::max() - 1);

--- a/tensorflow/contrib/lite/kernels/internal/logsoftmax_quantized_test.cc
+++ b/tensorflow/contrib/lite/kernels/internal/logsoftmax_quantized_test.cc
@@ -58,7 +58,7 @@ void RunLogSoftmaxFloatReference(const uint8* input_data,
 
 void CheckOutputData(const uint8* test_output, const uint8* reference_output,
                      const RuntimeShape& shape_common,
-                     const string& check_label, bool be_exacting) {
+                     const std::string& check_label, bool be_exacting) {
   const int buffer_size = shape_common.FlatSize();
   // While calculating some metrics in floating point, we work with quantized
   // scaling.

--- a/tensorflow/contrib/lite/kernels/internal/logsoftmax_quantized_test.cc
+++ b/tensorflow/contrib/lite/kernels/internal/logsoftmax_quantized_test.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/contrib/lite/kernels/internal/quantization_util.h"
 #include "tensorflow/contrib/lite/kernels/internal/reference/reference_ops.h"
 #include "tensorflow/contrib/lite/kernels/internal/test_util.h"
+#include "tensorflow/contrib/lite/string.h"
 
 namespace tflite {
 namespace {
@@ -58,7 +59,7 @@ void RunLogSoftmaxFloatReference(const uint8* input_data,
 
 void CheckOutputData(const uint8* test_output, const uint8* reference_output,
                      const RuntimeShape& shape_common,
-                     const std::string& check_label, bool be_exacting) {
+                     const string& check_label, bool be_exacting) {
   const int buffer_size = shape_common.FlatSize();
   // While calculating some metrics in floating point, we work with quantized
   // scaling.

--- a/tensorflow/contrib/lite/kernels/internal/quantization_util_test.cc
+++ b/tensorflow/contrib/lite/kernels/internal/quantization_util_test.cc
@@ -130,22 +130,22 @@ void RunSafeCastTests() {
 }
 
 TEST(QuantizationUtilTest, SafeCast) {
-  RunSafeCastTests<float, int8>();
-  RunSafeCastTests<double, int8>();
-  RunSafeCastTests<float, int16>();
-  RunSafeCastTests<double, int16>();
-  RunSafeCastTests<float, int32>();
-  RunSafeCastTests<double, int32>();
-  RunSafeCastTests<float, int64>();
-  RunSafeCastTests<double, int64>();
-  RunSafeCastTests<float, uint8>();
-  RunSafeCastTests<double, uint8>();
-  RunSafeCastTests<float, uint16>();
-  RunSafeCastTests<double, uint16>();
-  RunSafeCastTests<float, uint32>();
-  RunSafeCastTests<double, uint32>();
-  RunSafeCastTests<float, uint64>();
-  RunSafeCastTests<double, uint64>();
+  RunSafeCastTests<float, int8_t>();
+  RunSafeCastTests<double, int8_t>();
+  RunSafeCastTests<float, int16_t>();
+  RunSafeCastTests<double, int16_t>();
+  RunSafeCastTests<float, int32_t>();
+  RunSafeCastTests<double, int32_t>();
+  RunSafeCastTests<float, int64_t>();
+  RunSafeCastTests<double, int64_t>();
+  RunSafeCastTests<float, uint8_t>();
+  RunSafeCastTests<double, uint8_t>();
+  RunSafeCastTests<float, uint16_t>();
+  RunSafeCastTests<double, uint16_t>();
+  RunSafeCastTests<float, uint32_t>();
+  RunSafeCastTests<double, uint32_t>();
+  RunSafeCastTests<float, uint64_t>();
+  RunSafeCastTests<double, uint64_t>();
 }
 
 // Example taken from http://www.tensorflow.org/performance/quantization

--- a/tensorflow/contrib/lite/kernels/internal/softmax_quantized_test.cc
+++ b/tensorflow/contrib/lite/kernels/internal/softmax_quantized_test.cc
@@ -58,7 +58,7 @@ void RunSoftmaxFloatReference(const uint8* input_data,
 
 void CheckOutputData(const uint8* test_output, const uint8* reference_output,
                      const RuntimeShape& shape_common,
-                     const string& check_label, bool be_exacting) {
+                     const std::string& check_label, bool be_exacting) {
   const int buffer_size = shape_common.FlatSize();
   // While calculating some metrics in floating point, we work with quantized
   // scaling.

--- a/tensorflow/contrib/lite/kernels/internal/softmax_quantized_test.cc
+++ b/tensorflow/contrib/lite/kernels/internal/softmax_quantized_test.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/contrib/lite/kernels/internal/quantization_util.h"
 #include "tensorflow/contrib/lite/kernels/internal/reference/reference_ops.h"
 #include "tensorflow/contrib/lite/kernels/internal/test_util.h"
+#include "tensorflow/contrib/lite/string.h"
 
 namespace tflite {
 namespace {
@@ -58,7 +59,7 @@ void RunSoftmaxFloatReference(const uint8* input_data,
 
 void CheckOutputData(const uint8* test_output, const uint8* reference_output,
                      const RuntimeShape& shape_common,
-                     const std::string& check_label, bool be_exacting) {
+                     const string& check_label, bool be_exacting) {
   const int buffer_size = shape_common.FlatSize();
   // While calculating some metrics in floating point, we work with quantized
   // scaling.

--- a/tensorflow/contrib/lite/kernels/internal/tensor_utils_test.cc
+++ b/tensorflow/contrib/lite/kernels/internal/tensor_utils_test.cc
@@ -56,7 +56,7 @@ TEST(uKernels, SymmetricQuantizeFloatsTest) {
   static float input[kVectorSize] = {-640, -635.0, -630, 10.0,  2.0,
                                      -5.0, -10.0,  0.0,  1000.0};
 
-  int8 output[kVectorSize];
+  int8_t output[kVectorSize];
   float min, max, scaling_factor;
   SymmetricQuantizeFloats(input, kVectorSize, output, &min, &max,
                           &scaling_factor);
@@ -72,7 +72,7 @@ TEST(uKernels, SymmetricQuantizeFloatsAllZerosTest) {
   constexpr int kVectorSize = 9;
   static float input[kVectorSize] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-  int8 output[kVectorSize];
+  int8_t output[kVectorSize];
   float min, max, scaling_factor;
   SymmetricQuantizeFloats(input, kVectorSize, output, &min, &max,
                           &scaling_factor);
@@ -88,7 +88,7 @@ TEST(uKernels, SymmetricQuantizeFloatsAllAlmostZeroTest) {
   static float input[kVectorSize] = {-1e-5, 3e-5, -7e-6, -9e-5, 1e-6,
                                      4e-5,  9e-6, 2e-4,  0};
 
-  int8 output[kVectorSize];
+  int8_t output[kVectorSize];
   float min, max, scaling_factor;
   SymmetricQuantizeFloats(input, kVectorSize, output, &min, &max,
                           &scaling_factor);
@@ -126,6 +126,7 @@ TEST(uKernels, MatrixBatchVectorMultiplyAccumulateTest) {
                                                -1., 3., 7., 3., 23., 3.})));
 }
 
+#ifdef __ANDROID__
 TEST(uKernels, MatrixBatchVectorMultiplyAccumulateSymmetricQuantizedTest) {
   // Note we use 29 columns as this exercises all the neon kernel: the
   // 16-block SIMD code, the 8-block postamble, and the leftover postamble.
@@ -149,13 +150,13 @@ TEST(uKernels, MatrixBatchVectorMultiplyAccumulateSymmetricQuantizedTest) {
       -13.13, 14.14, -15.15, 16.16, -17.17, 18.18, -19.19, 20.2, -21.21, 22.22,
       -23.23, 24.24, -25.25, 26.26, -27.27, 28.28, 0};
 
-  int8* a_int8_data = reinterpret_cast<int8*>(
+  int8_t* a_int8_data = reinterpret_cast<int8_t*>(
       aligned_malloc(a_rows * a_cols, kWeightsPerUint32));
   float a_min, a_max;
   float scaling_factor_a;
   SymmetricQuantizeFloats(a_float_data, a_rows * a_cols, a_int8_data, &a_min,
                           &a_max, &scaling_factor_a);
-  const int8 expected_a_int8_data[] = {
+  const int8_t expected_a_int8_data[] = {
       /* 1st row */
       5,
       10,
@@ -346,7 +347,7 @@ TEST(uKernels, MatrixBatchVectorMultiplyAccumulateSymmetricQuantizedTest) {
   };
 
   // Quantized values of B:
-  int8 b_int8_data[b_rows * b_cols * batches];
+  int8_t b_int8_data[b_rows * b_cols * batches];
   float b_min, b_max;
   float scaling_factor_b[batches];
   SymmetricQuantizeFloats(b_float_data, b_rows * b_cols, b_int8_data, &b_min,
@@ -355,7 +356,7 @@ TEST(uKernels, MatrixBatchVectorMultiplyAccumulateSymmetricQuantizedTest) {
                           &b_int8_data[b_rows * b_cols], &b_min, &b_max,
                           &scaling_factor_b[1]);
 
-  const int8 expected_b_int8_data[] = {
+  const int8_t expected_b_int8_data[] = {
       /* batch 1 */
       127,
       -127,
@@ -448,6 +449,7 @@ TEST(uKernels, MatrixBatchVectorMultiplyAccumulateSymmetricQuantizedTest) {
 
   aligned_free(a_int8_data);
 }
+#endif // __ANDROID__
 
 TEST(uKernels, VectorVectorCwiseProductTest) {
   constexpr int kVectorSize = 10;


### PR DESCRIPTION
make
```
bazel test --config opt //tensorflow/contrib/lite/kernels/internal:all
```
work. So that
```
bazel test --config opt //tensorflow/contrib/lite/kernels/...
```
works.


This is a sequel to https://github.com/tensorflow/tensorflow/pull/17700