### PR TITLE
 r1.9-rc2 cherry-pick request: Fix for RPi OpenBLAS compile issues, by pinning to known good version

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pi_python3_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3_toolchain.sh
@@ -27,3 +27,11 @@ curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 apt-get update
 rm -rf /usr/local/bin/bazel
 apt-get install -y bazel python3 python3-numpy python3-dev python3-pip
+
+# We're using Ubuntu 14.04 as our base image because that's needed by the Pi
+# cross-compilation chain, but that doesn't have built-in Python 3.5 support, so
+# install from a separate repository.
+apt-get install -y software-properties-common
+add-apt-repository ppa:fkrull/deadsnakes
+apt-get update
+apt-get install -y python3.5 python3.5-dev

--- a/tensorflow/tools/ci_build/install/install_pi_python3_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3_toolchain.sh
@@ -27,11 +27,3 @@ curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 apt-get update
 rm -rf /usr/local/bin/bazel
 apt-get install -y bazel python3 python3-numpy python3-dev python3-pip
-
-# We're using Ubuntu 14.04 as our base image because that's needed by the Pi
-# cross-compilation chain, but that doesn't have built-in Python 3.5 support, so
-# install from a separate repository.
-apt-get install -y software-properties-common
-add-apt-repository ppa:fkrull/deadsnakes
-apt-get update
-apt-get install -y python3.5 python3.5-dev

--- a/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
+++ b/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
@@ -65,6 +65,10 @@ OPENBLAS_SRC_PATH=/tmp/openblas_src/
 sudo rm -rf ${OPENBLAS_SRC_PATH}
 git clone https://github.com/xianyi/OpenBLAS ${OPENBLAS_SRC_PATH}
 cd ${OPENBLAS_SRC_PATH}
+# The commit after this introduced Fortran compile issues. In theory they should
+# be solvable using NOFORTRAN=1 on the make command, but my initial tries didn't
+# work, so pinning to the last know good version.
+git checkout 5a6a2bed9aff0ba8a18651d5514d029c8cae336a
 # If this path is changed, you'll also need to update
 # cxx_builtin_include_directory in third_party/toolchains/cpus/arm/CROSSTOOL.tpl
 OPENBLAS_INSTALL_PATH=/tmp/openblas_install/


### PR DESCRIPTION
OpenBLAS broke the Raspberry Pi build, and I wasn't pinning to a particular version before this, so it broke even the 'frozen' 1.9 branch.