### PR TITLE
Build OpenBLAS 0.3.0 on ppc64le for TF tests

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1465,6 +1465,13 @@ def main():
     environ_cp['TF_NEED_JEMALLOC'] = '0'
     environ_cp['TF_NEED_TENSORRT'] = '0'
 
+  # The numpy package on ppc64le uses OpenBLAS which has multi-threading
+  # issues that lead to incorrect answers.  Set OMP_NUM_THREADS=1 at
+  # runtime to allow the Tensorflow testcases which compare numpy
+  # results to Tensorflow results to succeed.
+  if is_ppc64le():
+    write_action_env_to_bazelrc("OMP_NUM_THREADS", 1)
+
   set_build_var(environ_cp, 'TF_NEED_JEMALLOC', 'jemalloc as malloc',
                 'with_jemalloc', True)
   set_build_var(environ_cp, 'TF_NEED_GCP', 'Google Cloud Platform',

--- a/tensorflow/tools/ci_build/Dockerfile.cpu.ppc64le
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu.ppc64le
@@ -7,7 +7,7 @@ COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa
 RUN /install/install_deb_packages.sh
-RUN apt-get update && apt-get install -y libopenblas-dev
+RUN /install/install_openblas_ppc64le.sh
 RUN /install/install_hdf5_ppc64le.sh
 RUN /install/install_pip_packages.sh
 RUN /install/install_bazel_from_source.sh

--- a/tensorflow/tools/ci_build/Dockerfile.gpu.ppc64le
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu.ppc64le
@@ -13,7 +13,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa
 RUN /install/install_deb_packages.sh
-RUN apt-get update && apt-get install -y libopenblas-dev
+RUN /install/install_openblas_ppc64le.sh 
 RUN /install/install_hdf5_ppc64le.sh
 RUN /install/install_pip_packages.sh
 RUN /install/install_bazel_from_source.sh

--- a/tensorflow/tools/ci_build/install/install_openblas_ppc64le.sh
+++ b/tensorflow/tools/ci_build/install/install_openblas_ppc64le.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+OPENBLAS_SRC_PATH=/tmp/openblas_src/
+POWER="POWER8"
+USE_OPENMP="USE_OPENMP=1"
+OPENBLAS_INSTALL_PATH="/usr"
+apt-get install -y gfortran gfortran-5
+sudo rm -rf ${OPENBLAS_SRC_PATH}
+git clone -b release-0.3.0 https://github.com/xianyi/OpenBLAS ${OPENBLAS_SRC_PATH}
+cd ${OPENBLAS_SRC_PATH}
+# Pick up fix for OpenBLAS issue 1571
+git cherry-pick -X theirs 961d25e9c7e4a1758adb1dbeaa15187de69dd052
+make TARGET=${POWER} ${USE_OPENMP} FC=gfortran
+make PREFIX=${OPENBLAS_INSTALL_PATH} install

--- a/tensorflow/tools/ci_build/install/install_openblas_ppc64le.sh
+++ b/tensorflow/tools/ci_build/install/install_openblas_ppc64le.sh
@@ -18,6 +18,7 @@ OPENBLAS_SRC_PATH=/tmp/openblas_src/
 POWER="POWER8"
 USE_OPENMP="USE_OPENMP=1"
 OPENBLAS_INSTALL_PATH="/usr"
+apt-get update
 apt-get install -y gfortran gfortran-5
 sudo rm -rf ${OPENBLAS_SRC_PATH}
 git clone -b release-0.3.0 https://github.com/xianyi/OpenBLAS ${OPENBLAS_SRC_PATH}

--- a/tensorflow/tools/ci_build/install/install_openblas_ppc64le.sh
+++ b/tensorflow/tools/ci_build/install/install_openblas_ppc64le.sh
@@ -20,7 +20,7 @@ USE_OPENMP="USE_OPENMP=1"
 OPENBLAS_INSTALL_PATH="/usr"
 apt-get update
 apt-get install -y gfortran gfortran-5
-sudo rm -rf ${OPENBLAS_SRC_PATH}
+rm -rf ${OPENBLAS_SRC_PATH}
 git clone -b release-0.3.0 https://github.com/xianyi/OpenBLAS ${OPENBLAS_SRC_PATH}
 cd ${OPENBLAS_SRC_PATH}
 # Pick up fix for OpenBLAS issue 1571


### PR DESCRIPTION
Updates for TF tests on ppc64le.  Update to OpenBLAS 0.3.0 for ppc64le TF testing.  Also set OMP_NUM_THREADS=1 at runtime due to multi-threading issues.