### PR TITLE
create platform for remote execution

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rbe.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.rbe.cpu
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/rbe-debian8:r327695
+FROM launcher.gcr.io/google/rbe-ubuntu16-04:r327695
 LABEL maintainer="Yu Yi <yiyu@google.com>"
 
 # Copy install scripts
@@ -9,6 +9,6 @@ ENV CC /usr/local/bin/clang
 ENV CXX /usr/local/bin/clang++
 ENV AR /usr/bin/ar
 
-# Run pip install script for RBE Debian8 container.
+# Run pip install script for RBE Ubuntu 16-04 container.
 RUN /install/install_pip_packages_remote.sh
 RUN /install/install_pip_packages.sh

--- a/third_party/toolchains/BUILD
+++ b/third_party/toolchains/BUILD
@@ -1,0 +1,22 @@
+licenses(["restricted"])
+
+package(default_visibility = ["//visibility:public"])
+
+# Platform for use with remote execution with
+# custom container based off RBE Ubuntu16_04 r328903
+# http://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04
+# Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cpu
+platform(
+    name = "rbe_ubuntu16_04-tf",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//tools/cpp:clang",
+        "@bazel_toolchains//constraints:xenial",
+    ],
+    remote_execution_properties = """
+        properties: {
+            name: "container-image"
+            value:"docker://gcr.io/asci-toolchain/nosla-ubuntu16_04-tf@sha256:800a7b68cabef15419695c188ed33ed70adf678c2371b97b236f3ae26c38274d"
+        }""",
+)

--- a/third_party/toolchains/BUILD
+++ b/third_party/toolchains/BUILD
@@ -3,7 +3,7 @@ licenses(["restricted"])
 package(default_visibility = ["//visibility:public"])
 
 # Platform for use with remote execution with
-# custom container based off RBE Ubuntu16_04 r328903
+# custom container based off RBE Ubuntu16_04
 # http://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cpu
 platform(


### PR DESCRIPTION
* Platform target defines container to use for remote builds.
* This PR is part of the process to deprecate use of
experimental_remote_platform_override which will consolidate the
definition of the container to use for remote builds.
* also update dockerfile for rbe to indicate base is Ubuntu 16-04