### PR TITLE
Fix broken Android demo app download links

### DIFF
--- a/tensorflow/examples/android/README.md
+++ b/tensorflow/examples/android/README.md
@@ -45,11 +45,7 @@ on API >= 14 devices.
 
 ## Prebuilt Components:
 
-If you just want the fastest path to trying the demo, you may download the
-nightly build
-[here](https://ci.tensorflow.org/view/Nightly/job/nightly-android/). Expand the
-"View" and then the "out" folders under "Last Successful Artifacts" to find
-tensorflow_demo.apk.
+The fastest path to trying the demo is to download the [prebuilt demo APK](http://download.tensorflow.org/deps/tflite/TfLiteCameraDemo.apk).
 
 Also available are precompiled native libraries, and a jcenter package that you
 may simply drop into your own applications. See
@@ -113,8 +109,7 @@ protobuf compilation.
 
 NOTE: Bazel does not currently support building for Android on Windows. Full
 support for gradle/cmake builds is coming soon, but in the meantime we suggest
-that Windows users download the [prebuilt
-binaries](https://ci.tensorflow.org/view/Nightly/job/nightly-android/) instead.
+that Windows users download the [prebuilt demo APK](http://download.tensorflow.org/deps/tflite/TfLiteCameraDemo.apk) instead.
 
 ##### Install Bazel and Android Prerequisites
 


### PR DESCRIPTION
The old links didn't work:

![screen shot 2018-06-29 at 4 16 22 pm](https://user-images.githubusercontent.com/739125/42118445-f4b621b6-7bb7-11e8-9d57-0f575c440b5f.png)

It seems like many of the Jenkins jobs in that location are disabled:

![screen shot 2018-06-29 at 4 16 49 pm](https://user-images.githubusercontent.com/739125/42118452-ff22dfcc-7bb7-11e8-8f53-4bb9f81712e8.png)

I got the new working links from https://www.tensorflow.org/mobile/tflite/demo_android.