### PR TITLE
Fix build issue on mac with python-2.7.10 and clang 9.1.0

### DIFF
--- a/tensorflow/contrib/lite/python/interpreter_wrapper/interpreter_wrapper.h
+++ b/tensorflow/contrib/lite/python/interpreter_wrapper/interpreter_wrapper.h
@@ -15,8 +15,6 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_LITE_PYTHON_INTERPRETER_WRAPPER_INTERPRETER_WRAPPER_H_
 #define TENSORFLOW_CONTRIB_LITE_PYTHON_INTERPRETER_WRAPPER_INTERPRETER_WRAPPER_H_
 
-// Place `<locale>` before <Python.h> to avoid build failures in macOS.
-#include <locale>
 #include <memory>
 #include <string>
 #include <vector>

--- a/tensorflow/contrib/lite/python/interpreter_wrapper/interpreter_wrapper.h
+++ b/tensorflow/contrib/lite/python/interpreter_wrapper/interpreter_wrapper.h
@@ -21,6 +21,11 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+// Place `<locale>` before <Python.h> to avoid build failures in macOS.
+#include <locale>
+
+// The empty line above is on purpose as otherwise clang-format will
+// automatically move <Python.h> before <locale>.
 #include <Python.h>
 
 // We forward declare TFLite classes here to avoid exposing them to SWIG.

--- a/tensorflow/python/lib/core/py_util.cc
+++ b/tensorflow/python/lib/core/py_util.cc
@@ -18,6 +18,8 @@ limitations under the License.
 // Place `<locale>` before <Python.h> to avoid build failure in macOS.
 #include <locale>
 
+// The empty line above is on purpose as otherwise clang-format will
+// automatically move <Python.h> before <locale>.
 #include <Python.h>
 
 #include "tensorflow/core/lib/core/errors.h"


### PR DESCRIPTION
In PR 19993 the build issues on macOS with python2.7.10 and clang-9.1.0 were fixed. However, later on it looks like the order of `<locale>` and `<Python.h>` has been changed in 1e7b0e4, possibly caused by `clang-format -i --style=`.

This caused the build break of macOS with python-2.7.10 and clang 9.1.0 again.

This fix updates the impacted files, and, adds an empty line in between so that future `clang-format -i --style` will not cuase build breaks.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
