### PR TITLE
Exclude importing tensorflow.contrib.cloud on Windows

### DIFF
--- a/tensorflow/contrib/__init__.py
+++ b/tensorflow/contrib/__init__.py
@@ -25,7 +25,8 @@ import os
 from tensorflow.contrib import batching
 from tensorflow.contrib import bayesflow
 from tensorflow.contrib import checkpoint
-from tensorflow.contrib import cloud
+if os.name != "nt":
+  from tensorflow.contrib import cloud
 from tensorflow.contrib import cluster_resolver
 from tensorflow.contrib import coder
 from tensorflow.contrib import compiler


### PR DESCRIPTION
This is a follow up to fix import error in tensorflow/contrib/__init__.py on Windows, which is caused by https://github.com/tensorflow/tensorflow/commit/654eb3dd779107eb919af1093e2a72f0ab6ba922

@gunan @case540