### PR TITLE
Reapplying #20254

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -107,11 +107,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "eigen_archive",
       urls = [
-          "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/e5e305a158a0.tar.gz",
-          "https://bitbucket.org/eigen/eigen/get/e5e305a158a0.tar.gz",
+          "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/fd6845384b86.tar.gz",
+          "https://bitbucket.org/eigen/eigen/get/fd6845384b86.tar.gz",
       ],
-      sha256 = "8bbe676d69e7f59070c83a949454b8b6344034e0ebbf686b337528e5dc04c7de",
-      strip_prefix = "eigen-eigen-e5e305a158a0",
+      sha256 = "d956415d784fa4e42b6a2a45c32556d6aec9d0a3d8ef48baee2522ab762556a9",
+      strip_prefix = "eigen-eigen-fd6845384b86",
       build_file = clean_dep("//third_party:eigen.BUILD"),
   )
 


### PR DESCRIPTION
PR #20430 contained 151 commits, one of which backleveled PR #20254.

This PR is to re-apply that change. Text of 20254:
PR #20229 included a change to the Eigen version that failed to
compile on ppc64le. rmlarsen created a pull request in Eigen to
fix the compile failure:
https://bitbucket.org/eigen/eigen/pull-requests/410

This patch is to pick up the Eigen version of that patch.