### PR TITLE
Fix int64 to int truncation in std::accumulate

### DIFF
--- a/tensorflow/compiler/xla/array.h
+++ b/tensorflow/compiler/xla/array.h
@@ -409,7 +409,7 @@ class Array {
 
   // Returns the total number of elements in the array.
   int64 num_elements() const {
-    return std::accumulate(sizes_.begin(), sizes_.end(), 1,
+    return std::accumulate(sizes_.begin(), sizes_.end(), 1LL,
                            std::multiplies<int64>());
   }
 

--- a/tensorflow/compiler/xla/service/indexed_array_analysis.cc
+++ b/tensorflow/compiler/xla/service/indexed_array_analysis.cc
@@ -441,7 +441,7 @@ int64 FindSourcePositionForPassthroughResultDim(ArraySlice<int64> operand_shape,
 
   int64 indexed_source_subarray_size =
       std::accumulate(operand_shape.begin() + source_passthrough_dim + 1,
-                      operand_shape.end(), 1, std::multiplies<int64>());
+                      operand_shape.end(), 1LL, std::multiplies<int64>());
 
   return FindSuffixWithProduct(result_shape, indexed_source_subarray_size);
 }
@@ -758,7 +758,7 @@ IndexedArrayAnalysis::FoldReshapeOfGatherNoDegenerateDims(
       &new_scalar_indexed_source_shape, source_dim_for_new_scalar_indexed_node,
       scalar_indexed_source_shape.dimensions(scalar_indexed->source_dim()));
 
-  CHECK_EQ(c_accumulate(new_scalar_indexed_source_shape, 1l,
+  CHECK_EQ(c_accumulate(new_scalar_indexed_source_shape, 1LL,
                         std::multiplies<int64>()),
            ShapeUtil::ElementsIn(scalar_indexed_source_shape));
 


### PR DESCRIPTION
From https://en.cppreference.com/w/cpp/algorithm/accumulate

```cpp
template< class InputIt, class T, class BinaryOperation >
T accumulate( InputIt first, InputIt last, T init,
              BinaryOperation op );
```

Return type of `std::accumulate` (and hence `{xla,absl}::c_accumulate`) is determined by the type of third parameter, not the lambda/function or the iterator.

For `std::accumulate(sizes_.begin(), sizes_.end(), /*int*=/1, std::multiplies<int64>())`, compiler will always cast the element of `sizes_` from `int64` to `int`, pass it to `std::multiplies<int64>()` which will cast it to `int64` for multiplication and cast the result back to `int`.

Writing `1LL` instead of `1` will tell compiler the third parameter is 64-bit, making the function works as expected.

Please spread awareness about this to the internal team. `<algorithm>` and `<numeric>` template can be pretty counter-intuitive sometime.