### PR TITLE
Enable crc32c acceleration for MSVC

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -2112,6 +2112,7 @@ cc_library(
     srcs = ["lib/hash/crc32c_accelerate.cc"],
     # -msse4.2 enables the use of crc32c compiler builtins.
     copts = tf_copts() + if_linux_x86_64(["-msse4.2"]),
+    deps = [":platform_port"],
 )
 
 cc_library(

--- a/tensorflow/core/lib/hash/crc32c_accelerate.cc
+++ b/tensorflow/core/lib/hash/crc32c_accelerate.cc
@@ -29,8 +29,9 @@ limitations under the License.
 #endif
 #endif /* __SSE4_2__ */
 
-// MSVC does not have __SSE4_2__ macro, but does support sse4.2 for x64
-#ifdef _M_X64
+// MSVC does not have __SSE4_2__ macro, but will enable SSE 4.2 when AVX
+// is turned on.
+#if defined(_MSC_VER) && defined(__AVX__)
 #define USE_SEE_CRC32C 1
 #endif
 

--- a/tensorflow/core/lib/hash/crc32c_accelerate.cc
+++ b/tensorflow/core/lib/hash/crc32c_accelerate.cc
@@ -39,7 +39,7 @@ limitations under the License.
 #include <nmmintrin.h>
 #endif
 
-#include <tensorflow/core/platform/cpu_info.h>
+#include "tensorflow/core/platform/cpu_info.h"
 
 namespace tensorflow {
 namespace crc32c {


### PR DESCRIPTION
Use `TestCPUFeature` instead of `__builtin_cpu_supports` to dynamically detect SSE4.2 support.
This will allow us to enable crc32c acceleration for MSVC and old Apple clang.