### PR TITLE
Update .gitignore for cmake generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Podfile.lock
 /tensorflow/contrib/lite/examples/ios/simple/data/*.tflite
 xcuserdata/**
 /api_init_files_list.txt
+/estimator_api_init_files_list.txt
 
 # Android
 .gradle


### PR DESCRIPTION
While running cmake in Linux:
```
tensorflow/tools/ci_build/ci_build.sh CMAKE tensorflow/tools/ci_build/builds/cmake.sh
```

the following file is generated and left out:
```
ubuntu@ubuntu:~/tensorflow$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        estimator_api_init_files_list.txt

nothing added to commit but untracked files present (use "git add" to track)
```

This fix add `/estimator_api_init_files_list.txt`
in gitignore so that it will not be picked by `git add -A`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>