### PR TITLE
Update grpc to v1.13.0

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -449,11 +449,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "grpc",
       urls = [
-          "https://mirror.bazel.build/github.com/grpc/grpc/archive/d184fa229d75d336aedea0041bd59cb93e7e267f.tar.gz",
-          "https://github.com/grpc/grpc/archive/d184fa229d75d336aedea0041bd59cb93e7e267f.tar.gz",
+          "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.12.1.tar.gz",
+          "https://github.com/grpc/grpc/archive/v1.12.1.tar.gz",
       ],
-      sha256 = "895b31310e718a61f7335759a778c068a6edde1c089883598a0830cbb7075673",
-      strip_prefix = "grpc-d184fa229d75d336aedea0041bd59cb93e7e267f",
+      sha256 = "f6afbfafa8e7b524727d1ff37ff22fe9c3dcca07bd864e7a9d1efabf1d15d13c",
+      strip_prefix = "grpc-1.12.1",
   )
 
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -449,11 +449,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "grpc",
       urls = [
-          "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.12.1.tar.gz",
-          "https://github.com/grpc/grpc/archive/v1.12.1.tar.gz",
+          "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.13.0.tar.gz",
+          "https://github.com/grpc/grpc/archive/v1.13.0.tar.gz",
       ],
-      sha256 = "f6afbfafa8e7b524727d1ff37ff22fe9c3dcca07bd864e7a9d1efabf1d15d13c",
-      strip_prefix = "grpc-1.12.1",
+      sha256 = "50db9cf2221354485eb7c3bd55a4c27190caef7048a2a1a15fbe60a498f98b44",
+      strip_prefix = "grpc-1.13.0",
   )
 
 


### PR DESCRIPTION
~~This fix is an update to grpc v1.12.1.~~

The updates of v1.12.1 was in #20245 but was not picked up (See https://github.com/tensorflow/tensorflow/pull/20245#issuecomment-402054059)

This fix updates grpc to v1.13.0 directly.

/cc @gunan @perfinion 
Signed-off-by: Yong Tang <yong.tang.github@outlook.com>