### PR TITLE
Expose `tf.contrib.layers.conv1d` like conv2d/conv3d

### DIFF
--- a/tensorflow/contrib/layers/__init__.py
+++ b/tensorflow/contrib/layers/__init__.py
@@ -121,6 +121,7 @@ from tensorflow.contrib.layers.python.layers import *
 from tensorflow.python.util.all_util import remove_undocumented
 
 _allowed_symbols = ['bias_add',
+                    'conv1d',
                     'conv2d',
                     'conv3d',
                     'elu',

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -55,9 +55,9 @@ from tensorflow.python.training import moving_averages
 # TODO(b/28426988): Replace legacy_* fns migrated from slim.
 # TODO(b/28426988): Remove legacy_* when all uses have migrated to new API.
 __all__ = [
-    'avg_pool2d', 'avg_pool3d', 'batch_norm', 'bias_add', 'conv2d', 'conv3d',
-    'conv2d_in_plane', 'conv2d_transpose', 'conv3d_transpose', 'convolution',
-    'convolution1d', 'convolution2d', 'convolution2d_in_plane',
+    'avg_pool2d', 'avg_pool3d', 'batch_norm', 'bias_add', 'conv1d', 'conv2d',
+    'conv3d', 'conv2d_in_plane', 'conv2d_transpose', 'conv3d_transpose',
+    'convolution', 'convolution1d', 'convolution2d', 'convolution2d_in_plane',
     'convolution2d_transpose', 'convolution3d', 'convolution3d_transpose',
     'dense_to_sparse', 'dropout', 'elu', 'flatten', 'fully_connected', 'GDN',
     'gdn', 'images_to_sequence', 'layer_norm', 'linear', 'pool', 'max_pool2d',

--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -3315,6 +3315,7 @@ relu6 = functools.partial(fully_connected, activation_fn=nn.relu6)
 linear = functools.partial(fully_connected, activation_fn=None)
 
 # Simple alias.
+conv1d = convolution1d
 conv2d = convolution2d
 conv3d = convolution3d
 conv2d_transpose = convolution2d_transpose


### PR DESCRIPTION
This fix tries to address the issue raised in #20551 where `tf.contrib.layers.conv1d` is not exposed.
In tf.contrib.layers even though conv1d/conv2d/conv3d are all available, the conv1d was not exposed like conv2d/conv3d.

This fix exposed `tf.contrib.layers.conv1d` so that it is consistent with `tf.contrib.layers.conv2d` and `tf.contrib.layers.conv3d`.

This fix fixes #20551.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>