### PR TITLE
Fix: Typo in the release note

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,7 @@
 * The [distributions.Bijector](https://www.tensorflow.org/versions/r1.9/api_docs/python/tf/contrib/distributions/bijectors/Bijector)
   API supports broadcasting for Bijectors with new API changes.
   
-## Breaking Chances
+## Breaking Changes
   * If you're opening empty variable scopes; replace `variable_scope('', ...)` by
     `variable_scope(tf.get_variable_scope(), ...)`.
   * Headers used for building custom ops have been moved from site-packages/external into site-packages/tensorflow/include/external.


### PR DESCRIPTION
There is a small typo in the release note (RELEASE.md).
This patch fixes it.