### PR TITLE
Input node name correction

### DIFF
--- a/tensorflow/contrib/lite/tools/benchmark/README.md
+++ b/tensorflow/contrib/lite/tools/benchmark/README.md
@@ -75,7 +75,7 @@ adb push mobilenet_quant_v1_224.tflite /data/local/tmp
 ```
 adb shell /data/local/tmp/benchmark_model \
   --graph=/data/local/tmp/mobilenet_quant_v1_224.tflite \
-  --input_layer="input" \
+  --input_layer="Placeholder" \
   --input_layer_shape="1,224,224,3" \
   --num_threads=4
 ```


### PR DESCRIPTION
Correct for the error
```
STARTING!
Num runs: [20]
Inter-run delay (seconds): [-1]
Num threads: [-1]
Benchmark name: []
Output prefix: []
Warmup runs: [1]
Graph: [/data/local/tmp/mobilenet.tflite]
Input layers: [input]
Input shapes: [1,224,224,3]
Use nnapi : [0]
Loaded model /data/local/tmp/mobilenet.tflite
resolved reporter
Tensor # 88 is named Placeholder but flags call it input
Aborted
```