### PR TITLE
sys/sendfile.h does not exist for FreeBSD.

### DIFF
--- a/tensorflow/core/platform/posix/posix_file_system.cc
+++ b/tensorflow/core/platform/posix/posix_file_system.cc
@@ -18,7 +18,7 @@ limitations under the License.
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/mman.h>
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 #include <sys/sendfile.h>
 #endif
 #include <sys/stat.h>


### PR DESCRIPTION
sys/sendfile.h should be ignored for FreeBSD as it is ignored for Mac OS X.