### PR TITLE
Fix build for Tensorflow Lite

### DIFF
--- a/tensorflow/contrib/lite/profiling/profile_summarizer.cc
+++ b/tensorflow/contrib/lite/profiling/profile_summarizer.cc
@@ -83,7 +83,7 @@ OperatorDetails GetOperatorDetails(const tflite::Interpreter& interpreter,
   OperatorDetails details;
   details.name = op_name;
   if (profiling_string) {
-    details.name += ":" + string(profiling_string);
+    details.name += ":" + std::string(profiling_string);
   }
   details.inputs = GetTensorNames(interpreter, inputs);
   details.outputs = GetTensorNames(interpreter, outputs);

--- a/tensorflow/contrib/lite/tools/benchmark/benchmark_params.h
+++ b/tensorflow/contrib/lite/tools/benchmark/benchmark_params.h
@@ -47,10 +47,12 @@ class BenchmarkParam {
   virtual ~BenchmarkParam() {}
   BenchmarkParam(ParamType type) : type_(type) {}
 
- private:
-  static void AssertHasSameType(ParamType a, ParamType b);
+ protected:
   template <typename T>
   static ParamType GetValueType();
+
+ private:
+  static void AssertHasSameType(ParamType a, ParamType b);
 
   const ParamType type_;
 };


### PR DESCRIPTION
- tensorflow/contrib/lite/tools/benchmark/benchmark_params.h:
Move `GetValueType()` to protected because it's called by
`TypedBenchmarkParam`.

- tensorflow/contrib/lite/profiling/profile_summarizer.cc:
`string` => `std::string`