### PR TITLE
Add OpKernel of QuantizedReluX

### DIFF
--- a/tensorflow/core/kernels/quantized_activation_ops.cc
+++ b/tensorflow/core/kernels/quantized_activation_ops.cc
@@ -110,7 +110,8 @@ class QuantizedReluXOp : public OpKernel {
     OP_REQUIRES_OK(context,
                    context->allocate_output(0, input.shape(), &output));
     const T min_as_quantized = FloatToQuantized<T>(0.0f, min_input, max_input);
-    const T max_as_quantized = FloatToQuantized<T>(max_value, min_input, max_input);
+    const T max_as_quantized =
+        FloatToQuantized<T>(max_value, min_input, max_input);
 
     if (meta::IsSupportedAndEnabled() && std::is_same<T, quint8>()) {
       auto input_ui8_array = input.flat<quint8>();

--- a/tensorflow/core/kernels/quantized_activation_ops.cc
+++ b/tensorflow/core/kernels/quantized_activation_ops.cc
@@ -95,6 +95,45 @@ class QuantizedRelu6Op : public OpKernel {
   }
 };
 
+template <typename T>
+class QuantizedReluXOp : public OpKernel {
+ public:
+  explicit QuantizedReluXOp(OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor& input = context->input(0);
+    const float max_value = context->input(1).flat<float>()(0);
+    const float min_input = context->input(2).flat<float>()(0);
+    const float max_input = context->input(3).flat<float>()(0);
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(context,
+                   context->allocate_output(0, input.shape(), &output));
+    const T min_as_quantized = FloatToQuantized<T>(0.0f, min_input, max_input);
+    const T max_as_quantized = FloatToQuantized<T>(max_value, min_input, max_input);
+
+    if (meta::IsSupportedAndEnabled() && std::is_same<T, quint8>()) {
+      auto input_ui8_array = input.flat<quint8>();
+      meta::Clamp(context, input_ui8_array.data(), input_ui8_array.size(),
+                  min_as_quantized, max_as_quantized,
+                  output->flat<quint8>().data());
+    } else {
+      output->flat<T>().device(context->eigen_cpu_device()) =
+          input.flat<T>()
+              .cwiseMax(min_as_quantized)
+              .cwiseMin(max_as_quantized)
+              .template cast<T>();
+    }
+
+    Tensor* output_min = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(1, {}, &output_min));
+    output_min->flat<float>()(0) = min_input;
+    Tensor* output_max = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(2, {}, &output_max));
+    output_max->flat<float>()(0) = max_input;
+  }
+};
+
 REGISTER_KERNEL_BUILDER(Name("QuantizedRelu")
                             .Device(DEVICE_CPU)
                             .TypeConstraint<qint32>("Tinput")
@@ -116,4 +155,15 @@ REGISTER_KERNEL_BUILDER(Name("QuantizedRelu6")
                             .TypeConstraint<quint8>("Tinput")
                             .TypeConstraint<quint8>("out_type"),
                         QuantizedRelu6Op<quint8>);
+
+REGISTER_KERNEL_BUILDER(Name("QuantizedReluX")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<qint32>("Tinput")
+                            .TypeConstraint<qint32>("out_type"),
+                        QuantizedReluXOp<qint32>);
+REGISTER_KERNEL_BUILDER(Name("QuantizedReluX")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<quint8>("Tinput")
+                            .TypeConstraint<quint8>("out_type"),
+                        QuantizedReluXOp<quint8>);
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/quantized_activation_ops_test.cc
+++ b/tensorflow/core/kernels/quantized_activation_ops_test.cc
@@ -97,4 +97,38 @@ TEST_F(QuantizedActivationsTest, TestRelu6) {
   test::ExpectTensorNear<float>(expected_float, output_float, 0.2);
 }
 
+TEST_F(QuantizedActivationsTest, TestReluX) {
+  TF_ASSERT_OK(NodeDefBuilder("quantized_relux_op", "QuantizedReluX")
+                   .Input(FakeInput(DT_QUINT8))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+  const float input_max_value = 5.0f;
+  const float input_min = -128.0f;
+  const float input_max = 127.0f;
+  const int input_width = 2;
+  const int input_height = 4;
+  Tensor input_float(DT_FLOAT, {input_height, input_width});
+  test::FillValues<float>(&input_float, {-100, -1, 0, 1, 3, 6, 7, 100});
+  Tensor input_quantized =
+      FloatTensorToQuantized<quint8>(input_float, input_min, input_max);
+  Tensor expected_float(DT_FLOAT, {input_height, input_width});
+  test::FillValues<float>(&expected_float, {0, 0, 0, 1, 3, 5, 5, 5});
+
+  AddInputFromArray<quint8>(input_quantized.shape(),
+                            input_quantized.flat<quint8>());
+  AddInputFromArray<float>(TensorShape({1}), {input_max_value});
+  AddInputFromArray<float>(TensorShape({1}), {input_min});
+  AddInputFromArray<float>(TensorShape({1}), {input_max});
+  TF_ASSERT_OK(RunOpKernel());
+  const Tensor& output_quantized = *GetOutput(0);
+  const float output_min = GetOutput(1)->flat<float>()(0);
+  const float output_max = GetOutput(2)->flat<float>()(0);
+  Tensor output_float =
+      QuantizedTensorToFloat<quint8>(output_quantized, output_min, output_max);
+  test::ExpectTensorNear<float>(expected_float, output_float, 0.2);
+}
+
 }  // namespace tensorflow


### PR DESCRIPTION
This fix tries to address the issue raised in #20514 where no OpKernel was registered to support Op `QuantizedReluX`.

This fix add the OpKernel for `QuantizedReluX`.

This fix fixes #20514.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>