### PR TITLE
Fix for LNK2019 error when compiling tf1.9 with CMake on Windows due to missing definition.

### DIFF
--- a/tensorflow/core/platform/windows/port.cc
+++ b/tensorflow/core/platform/windows/port.cc
@@ -57,6 +57,11 @@ int NumSchedulableCPUs() {
   return system_info.dwNumberOfProcessors;
 }
 
+int NumHyperthreadsPerCore() {
+  static const int ht_per_core = tensorflow::port::CPUIDNumSMT();
+  return (ht_per_core > 0) ? ht_per_core : 1;
+}
+
 void* AlignedMalloc(size_t size, int minimum_alignment) {
 #ifdef TENSORFLOW_USE_JEMALLOC
   void* ptr = NULL;


### PR DESCRIPTION
This is the suggested fix for the missing NumHyperthreadsPerCore definition #19761 which is still present in release 1.9.