### PR TITLE
sys/sendfile.h is actually only defined for Linux.

### DIFF
--- a/tensorflow/core/platform/posix/posix_file_system.cc
+++ b/tensorflow/core/platform/posix/posix_file_system.cc
@@ -18,7 +18,7 @@ limitations under the License.
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/mman.h>
-#if !defined(__APPLE__)
+#if defined(__linux__)
 #include <sys/sendfile.h>
 #endif
 #include <sys/stat.h>


### PR DESCRIPTION
For other systems (OS X/FreeBSD) header is missing.