### PR TITLE
[tfgan] Remove outdated estimator TODO

### DIFF
--- a/tensorflow/contrib/gan/python/estimator/python/gan_estimator_impl.py
+++ b/tensorflow/contrib/gan/python/estimator/python/gan_estimator_impl.py
@@ -53,9 +53,6 @@ _summary_type_map = {
 }
 
 
-# TODO(joelshor): For now, this only supports 1:1 generator:discriminator
-# training sequentially. Find a nice way to expose options to the user without
-# exposing internals.
 class GANEstimator(estimator.Estimator):
   """An estimator for Generative Adversarial Networks (GANs).
 


### PR DESCRIPTION
Training discriminator and generator with different ratios can already be done using `get_hooks_fn`.

This was resolved in #14723