### PR TITLE
[tf.keras] Fix input shape for 1D output using tf.data.Dataset

### DIFF
--- a/tensorflow/contrib/distribute/python/keras_test.py
+++ b/tensorflow/contrib/distribute/python/keras_test.py
@@ -447,7 +447,7 @@ class TestWithDistributionStrategy(test.TestCase):
       dataset = dataset.repeat(100)
 
       with self.assertRaisesRegexp(ValueError,
-                                   'expected input to have 2 dimensions'):
+                                   'expected input to have shape'):
         model.fit(dataset, epochs=1, steps_per_epoch=2, verbose=0)
 
       # Wrong input shape

--- a/tensorflow/python/keras/engine/training_utils.py
+++ b/tensorflow/python/keras/engine/training_utils.py
@@ -211,6 +211,8 @@ def standardize_single_array(x):
   if x is None:
     return None
   elif tensor_util.is_tensor(x):
+    if K.ndim(x) == 1:
+      return array_ops.expand_dims(x, 1)
     return x
   elif x.ndim == 1:
     x = np.expand_dims(x, 1)


### PR DESCRIPTION
Using keras models with one dimensional output together with the `tf.data.Dataset` API will fail due to the shape validation introduced in 677b4cf7539af0cf5741d12dfe7e142c586d4567 since the dataset will have output shape `(None,)` but keras expects shape `(None, 1)`.

Here is a small notebook describing the problem: https://colab.research.google.com/drive/1h3FUGBhVsXnj6oEE3JDnC0WRFF-Zu__c

This PR fixes the bug by expanding the last dimension of the data tensors the same way it is done with numpy arrays. Alternatively we could loosen the input validation to account for this case.

/cc @rohan100jain @fchollet 

Fixes #20698

<details>
 <summary><b>Traceback</b></summary>
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-11-d79ea2a94b4d> in <module>()
      3 
      4 history = model.fit(dataset, epochs=300,
----> 5                     verbose=0, steps_per_epoch=len(train_data) // 32)

/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/engine/training.py in fit(self, x, y, batch_size, epochs, verbose, callbacks, validation_split, validation_data, shuffle, class_weight, sample_weight, initial_epoch, steps_per_epoch, validation_steps, **kwargs)
   1261         steps_name='steps_per_epoch',
   1262         steps=steps_per_epoch,
-> 1263         validation_split=validation_split)
   1264 
   1265     # Prepare validation data.

/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/engine/training.py in _standardize_user_data(self, x, y, sample_weight, class_weight, batch_size, check_steps, steps_name, steps, validation_split)
    905           feed_output_shapes,
    906           check_batch_axis=False,  # Don't enforce the batch size.
--> 907           exception_prefix='target')
    908 
    909       # Generate sample-wise weight values given the `sample_weight` and

/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/engine/training_utils.py in standardize_input_data(data, names, shapes, check_batch_axis, exception_prefix)
    180                            ': expected ' + names[i] + ' to have ' +
    181                            str(len(shape)) + ' dimensions, but got array '
--> 182                            'with shape ' + str(data_shape))
    183         if not check_batch_axis:
    184           data_shape = data_shape[1:]

ValueError: Error when checking target: expected dense_5 to have 2 dimensions, but got array with shape (None,)
</details>