### PR TITLE
Fix invalid link in security advisories page

### DIFF
--- a/tensorflow/security/index.md
+++ b/tensorflow/security/index.md
@@ -4,7 +4,7 @@ We regularly publish security advisories about using TensorFlow.
 
 *Note*: In conjunction with these security advisories, we strongly encourage
 TensorFlow users to read and understand TensorFlow's security model as outlined
-in (https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md)[SECURITY.md].
+in [SECURITY.md](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md).
 
 | Advisory Number | Type               | Versions affected | Reported by           | Additional Information      |
 |-----------------|--------------------|:-----------------:|-----------------------|-----------------------------|


### PR DESCRIPTION
The link in security advisories page was invalid and caused incorrect rendering in markdown, should be `[SECURITY.md](https://...)` instead of `(https://...)[SECURITY.md]`. This fix correct the link issue.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>