### PR TITLE
Python 3.7 fixes

### DIFF
--- a/tensorflow/c/eager/c_api.h
+++ b/tensorflow/c/eager/c_api.h
@@ -76,7 +76,7 @@ typedef enum TFE_ContextDevicePlacementPolicy {
 // Sets the default execution mode (sync/async). Note that this can be
 // overridden per thread using TFE_ContextSetAsyncForThread.
 TF_CAPI_EXPORT extern void TFE_ContextOptionsSetAsync(TFE_ContextOptions*,
-                                                      unsigned char async);
+                                                      unsigned char is_async);
 
 TF_CAPI_EXPORT extern void TFE_ContextOptionsSetDevicePlacementPolicy(
     TFE_ContextOptions*, TFE_ContextDevicePlacementPolicy);
@@ -125,7 +125,7 @@ TFE_ContextGetDevicePlacementPolicy(TFE_Context*);
 
 // Overrides the execution mode (sync/async) for the current thread.
 TF_CAPI_EXPORT extern void TFE_ContextSetAsyncForThread(TFE_Context*,
-                                                        unsigned char async,
+                                                        unsigned char is_async,
                                                         TF_Status* status);
 
 // Causes the calling thread to block till all ops dispatched in async mode
@@ -184,7 +184,7 @@ TF_CAPI_EXPORT extern TF_Tensor* TFE_TensorHandleResolve(TFE_TensorHandle* h,
 // that shares the underlying buffer. Otherwise, it currently requires at least
 // one of the source or destination devices to be CPU (i.e., for the source or
 // destination tensor to be placed in host memory).
-// If async execution is enabled, the copy may be enqueued and the call will
+// If asynchronous execution is enabled, the copy may be enqueued and the call will
 // return "non-ready" handle. Else, this function returns after the copy has
 // been done.
 TF_CAPI_EXPORT extern TFE_TensorHandle* TFE_TensorHandleCopyToDevice(
@@ -341,7 +341,7 @@ TF_CAPI_EXPORT extern void TFE_OpSetAttrFunctionList(TFE_Op* op,
 // the size of 'retvals' is less than the number of outputs. This call sets
 // *num_retvals to the number of outputs.
 //
-// If async execution is enabled, the call may simply enqueue the execution
+// If asynchronous execution is enabled, the call may simply enqueue the execution
 // and return "non-ready" handles in `retvals`. Note that any handles contained
 // in 'op' should not be mutated till the kernel execution actually finishes.
 //
@@ -374,7 +374,7 @@ TF_CAPI_EXPORT extern void TFE_ContextDisableRunMetadata(TFE_Context* ctx);
 // Populates the passed-in buffer with a serialized RunMetadata protocol buffer
 // containing any run metadata information accumulated so far and clears this
 // information.
-// If async mode is enabled, this call blocks till all currently pending ops are
+// If asynchronous mode is enabled, this call blocks till all currently pending ops are
 // done.
 TF_CAPI_EXPORT extern void TFE_ContextExportRunMetadata(TFE_Context* ctx,
                                                         TF_Buffer* buf,

--- a/tensorflow/c/eager/c_api_internal.h
+++ b/tensorflow/c/eager/c_api_internal.h
@@ -56,8 +56,7 @@ limitations under the License.
 
 struct TFE_ContextOptions {
   TF_SessionOptions session_options;
-  // true if async execution is enabled.
-  bool async = false;
+  bool is_async = false;
   TFE_ContextDevicePlacementPolicy policy{TFE_DEVICE_PLACEMENT_SILENT};
   tensorflow::ServerDef server_def;
 };
@@ -65,17 +64,17 @@ struct TFE_ContextOptions {
 struct TFE_Context {
   explicit TFE_Context(const tensorflow::SessionOptions& opts,
                        TFE_ContextDevicePlacementPolicy default_policy,
-                       bool async,
+                       bool is_async,
                        std::unique_ptr<tensorflow::DeviceMgr> device_mgr,
                        tensorflow::Rendezvous* rendezvous)
       : context(opts,
                 static_cast<tensorflow::ContextDevicePlacementPolicy>(
                     default_policy),
-                async, std::move(device_mgr), rendezvous) {}
+                is_async, std::move(device_mgr), rendezvous) {}
 
   explicit TFE_Context(
       const tensorflow::SessionOptions& opts,
-      TFE_ContextDevicePlacementPolicy default_policy, bool async,
+      TFE_ContextDevicePlacementPolicy default_policy, bool is_async,
       tensorflow::DeviceMgr* local_device_mgr,
       tensorflow::Rendezvous* rendezvous,
       std::unique_ptr<tensorflow::ServerInterface> server,
@@ -86,7 +85,7 @@ struct TFE_Context {
       : context(opts,
                 static_cast<tensorflow::ContextDevicePlacementPolicy>(
                     default_policy),
-                async, local_device_mgr, rendezvous, std::move(server),
+                is_async, local_device_mgr, rendezvous, std::move(server),
                 std::move(remote_eager_workers), std::move(remote_device_mgr),
                 remote_contexts) {}
 

--- a/tensorflow/contrib/distribute/python/mirrored_strategy.py
+++ b/tensorflow/contrib/distribute/python/mirrored_strategy.py
@@ -193,7 +193,7 @@ class MirroredStrategy(distribute_lib.DistributionStrategy):
         self._prefetch_on_device)
 
   def _broadcast(self, tensor, destinations):
-    # TODO(josh11b): In eager mode, use one thread per device, or async mode.
+    # TODO(josh11b): In eager mode, use one thread per device, or asynchronous mode.
     return self._get_cross_tower_ops().broadcast(tensor, destinations or
                                                  self._devices)
 

--- a/tensorflow/core/common_runtime/eager/context.h
+++ b/tensorflow/core/common_runtime/eager/context.h
@@ -65,7 +65,7 @@ enum ContextDevicePlacementPolicy {
 class EagerContext {
  public:
   explicit EagerContext(const SessionOptions& opts,
-                        ContextDevicePlacementPolicy default_policy, bool async,
+                        ContextDevicePlacementPolicy default_policy, bool is_async,
                         std::unique_ptr<DeviceMgr> device_mgr,
                         Rendezvous* rendezvous);
 
@@ -87,7 +87,7 @@ class EagerContext {
 #ifndef __ANDROID__
   explicit EagerContext(
       const SessionOptions& opts, ContextDevicePlacementPolicy default_policy,
-      bool async, DeviceMgr* local_device_mgr, Rendezvous* rendezvous,
+      bool is_async, DeviceMgr* local_device_mgr, Rendezvous* rendezvous,
       std::unique_ptr<ServerInterface> server,
       std::unique_ptr<eager::EagerClientCache> remote_eager_workers,
       std::unique_ptr<DeviceMgr> remote_device_manager,
@@ -106,7 +106,7 @@ class EagerContext {
   EagerExecutor* Executor() { return &executor_; }
 
   // Sets whether this thread should run in synchronous or asynchronous mode.
-  Status SetAsyncForThread(bool async);
+  Status SetAsyncForThread(bool is_async);
 
   // TODO(apassos) make this return a constant reference
   gtl::FlatMap<string, Device*, StringPieceHasher>* device_map() {

--- a/tensorflow/core/common_runtime/eager/kernel_and_device.cc
+++ b/tensorflow/core/common_runtime/eager/kernel_and_device.cc
@@ -99,9 +99,9 @@ Status KernelAndDevice::Run(std::vector<Tensor>* input_tensors,
     // TODO(apassos) do not special-case _Recv. Currently the GPU device fails
     // if trying to run _Recv->Compute(), specifically checking for _Recv. To go
     // around this we call _Recv->ComputeAsync, to mimic graph mode behavior.
-    AsyncOpKernel* async = kernel_->AsAsync();
+    AsyncOpKernel* is_async = kernel_->AsAsync();
     Notification done;
-    device_->ComputeAsync(async, &context, [&done]() { done.Notify(); });
+    device_->ComputeAsync(is_async, &context, [&done]() { done.Notify(); });
     done.WaitForNotification();
   } else {
     device_->Compute(kernel_.get(), &context);

--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -1729,8 +1729,8 @@ void ExecutorState::Process(TaggedNode tagged_node, int64 scheduled_usec) {
 
       if (item.kernel_is_async) {
         // Asynchronous computes.
-        AsyncOpKernel* async = item.kernel->AsAsync();
-        DCHECK(async != nullptr);
+        AsyncOpKernel* is_async = item.kernel->AsAsync();
+        DCHECK(is_async != nullptr);
         launched_asynchronously = true;
         AsyncState* state =
             new AsyncState(params, tagged_node, &item, first_input, stats);
@@ -1781,7 +1781,7 @@ void ExecutorState::Process(TaggedNode tagged_node, int64 scheduled_usec) {
           if (completed) Finish();
         };
         nodestats::SetOpStart(stats);
-        device->ComputeAsync(async, &state->ctx, done);
+        device->ComputeAsync(is_async, &state->ctx, done);
       } else {
         // Synchronous computes.
         OpKernelContext ctx(&params, item.num_outputs);

--- a/tensorflow/python/eager/pywrap_tfe_src.cc
+++ b/tensorflow/python/eager/pywrap_tfe_src.cc
@@ -216,7 +216,7 @@ bool ParseStringValue(const string& key, PyObject* py_value, TF_Status* status,
 #if PY_MAJOR_VERSION >= 3
   if (PyUnicode_Check(py_value)) {
     Py_ssize_t size = 0;
-    char* buf = PyUnicode_AsUTF8AndSize(py_value, &size);
+    char* buf = const_cast<char*>(PyUnicode_AsUTF8AndSize(py_value, &size));
     if (buf == nullptr) return false;
     *value = tensorflow::StringPiece(buf, size);
     return true;
@@ -831,7 +831,7 @@ char* TFE_GetPythonString(PyObject* o) {
   }
 #if PY_MAJOR_VERSION >= 3
   if (PyUnicode_Check(o)) {
-    return PyUnicode_AsUTF8(o);
+    return const_cast<char*>(PyUnicode_AsUTF8(o));
   }
 #endif
   return nullptr;

--- a/tensorflow/python/lib/core/ndarray_tensor.cc
+++ b/tensorflow/python/lib/core/ndarray_tensor.cc
@@ -154,7 +154,7 @@ Status PyBytesArrayMap(PyArrayObject* array, F f) {
     if (PyUnicode_Check(item.get())) {
 #if PY_VERSION_HEX >= 0x03030000
       // Accept unicode by converting to UTF-8 bytes.
-      ptr = PyUnicode_AsUTF8AndSize(item.get(), &len);
+      ptr = const_cast<char*>(PyUnicode_AsUTF8AndSize(item.get(), &len));
       if (!ptr) {
         return errors::Internal("Unable to get element as UTF-8.");
       }

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -352,7 +352,7 @@ Status ConvertNdarrayToTensor(PyObject* obj, Tensor* ret) {
         Py_ssize_t el_size;
         if (PyBytes_AsStringAndSize(input_data[i], &el, &el_size) == -1) {
 #if PY_MAJOR_VERSION >= 3
-          el = PyUnicode_AsUTF8AndSize(input_data[i], &el_size);
+          el = const_cast<char*>(PyUnicode_AsUTF8AndSize(input_data[i], &el_size));
 #else
           el = nullptr;
           if (PyUnicode_Check(input_data[i])) {


### PR DESCRIPTION
### Reserved word: ```async```
"async" became a reserved word in Python 3.7. I replaced with "is_async", which was already used for such flags in other places. An alternative suggestion, if the ```is_``` construct is deemed too ugly, might be to use the full term, "asynchronous".

### Python C API changes

Python C API now returns ```const``` types for `PyUnicode_AsUTF8AndSize``` and similar. Fixed analogous to https://github.com/google/protobuf/commit/0a59054c30e4f0ba10f10acfc1d7f3814c63e1a7.

Fixes #20690