### PR TITLE
Fix tf.Print summarized format bug

### DIFF
--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -967,7 +967,6 @@ string SummarizeArray(int64 limit, int64 num_elts,
   const int shape_size = tensor_shape.dims();
   PrintOneDim(0, shape, limit, shape_size, array, &data_index, &ret);
 
-  if (num_elts > limit) strings::StrAppend(&ret, "...");
   return ret;
 }
 }  // namespace

--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -915,7 +915,11 @@ void PrintOneDim(int dim_index, const gtl::InlinedVector<int64, 4>& shape,
   // We have reached the right-most dimension of the tensor.
   if (dim_index == shape_size - 1) {
     for (int64 i = 0; i < element_count; i++) {
-      if (*data_index >= limit) return;
+      if (*data_index >= limit) {
+        // If not enough elements has been printed, append "...".
+        if (i < element_count) { strings::StrAppend(result, "..."); }
+        return;
+      }
       if (i > 0) strings::StrAppend(result, " ");
       strings::StrAppend(result, PrintOneElement(data[(*data_index)++]));
     }
@@ -933,6 +937,10 @@ void PrintOneDim(int dim_index, const gtl::InlinedVector<int64, 4>& shape,
                 result);
     if (*data_index < limit || flag) {
       strings::StrAppend(result, "]");
+      if (*data_index >= limit) {
+        // If not enough elements has been printed in this dim, append "...".
+        strings::StrAppend(result, "...");
+      }
       flag = false;
     }
   }

--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -917,7 +917,7 @@ void PrintOneDim(int dim_index, const gtl::InlinedVector<int64, 4>& shape,
     for (int64 i = 0; i < element_count; i++) {
       if (*data_index >= limit) {
         // If not enough elements has been printed, append "...".
-        if (i < element_count) {
+        if (dim_index != 0 && i < element_count) {
           strings::StrAppend(result, "...");
         }
         return;
@@ -939,10 +939,6 @@ void PrintOneDim(int dim_index, const gtl::InlinedVector<int64, 4>& shape,
                 result);
     if (*data_index < limit || flag) {
       strings::StrAppend(result, "]");
-      if (*data_index >= limit) {
-        // If not enough elements has been printed in this dim, append "...".
-        strings::StrAppend(result, "...");
-      }
       flag = false;
     }
   }
@@ -967,6 +963,7 @@ string SummarizeArray(int64 limit, int64 num_elts,
   const int shape_size = tensor_shape.dims();
   PrintOneDim(0, shape, limit, shape_size, array, &data_index, &ret);
 
+  if (num_elts > limit) strings::StrAppend(&ret, "...");
   return ret;
 }
 }  // namespace

--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -917,7 +917,9 @@ void PrintOneDim(int dim_index, const gtl::InlinedVector<int64, 4>& shape,
     for (int64 i = 0; i < element_count; i++) {
       if (*data_index >= limit) {
         // If not enough elements has been printed, append "...".
-        if (i < element_count) { strings::StrAppend(result, "..."); }
+        if (i < element_count) {
+          strings::StrAppend(result, "...");
+        }
         return;
       }
       if (i > 0) strings::StrAppend(result, " ");

--- a/tensorflow/core/framework/tensor_test.cc
+++ b/tensorflow/core/framework/tensor_test.cc
@@ -1260,6 +1260,12 @@ TEST(SummarizeValue, INT32) {
   EXPECT_EQ("", x.SummarizeValue(16));
 }
 
+TEST(SummarizeValue, INT32Dims) {
+  Tensor x = MkTensor<int>(DT_INT32, TensorShape({3, 4}), {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  EXPECT_EQ("[1 2 3...]...", x.SummarizeValue(3));
+  EXPECT_EQ("[1 2 3 4][5 6 7 8][9 10...]...", x.SummarizeValue(10));
+}
+
 TEST(SummarizeValue, FLOAT) {
   Tensor x = MkTensor<float>(DT_FLOAT, TensorShape({5}), {1, 2, 3, 4, 0});
   EXPECT_EQ("1 2 3 4 0", x.SummarizeValue(16));

--- a/tensorflow/core/framework/tensor_test.cc
+++ b/tensorflow/core/framework/tensor_test.cc
@@ -1261,7 +1261,8 @@ TEST(SummarizeValue, INT32) {
 }
 
 TEST(SummarizeValue, INT32Dims) {
-  Tensor x = MkTensor<int>(DT_INT32, TensorShape({3, 4}), {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  Tensor x = MkTensor<int>(DT_INT32, TensorShape({3, 4}),
+                           {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
   EXPECT_EQ("[1 2 3...]...", x.SummarizeValue(3));
   EXPECT_EQ("[1 2 3 4][5 6 7 8][9 10...]...", x.SummarizeValue(10));
 }


### PR DESCRIPTION
This fix fixes the issue raised in #20751 where tf.Print may miss `...` at the end with `summarize`.

Below is the output after the fix:
```
$ python
Python 2.7.12 (default, Dec  4 2017, 14:50:18)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import tensorflow as tf
>>> v = tf.constant([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
>>> a = tf.Print(v, [v], message="summarize(3): ")
>>> b = tf.Print(v, [v], message="summarize(10): ", summarize=10)
>>> sess = tf.Session()
>>> sess.run(a)
summarize(3): [[1 2 3...]...]
array([[ 1,  2,  3,  4],
       [ 5,  6,  7,  8],
       [ 9, 10, 11, 12]], dtype=int32)
>>> sess.run(b)
summarize(10): [[1 2 3 4][5 6 7 8][9 10...]...]
array([[ 1,  2,  3,  4],
       [ 5,  6,  7,  8],
       [ 9, 10, 11, 12]], dtype=int32)
```

This fix fixes #20751

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>