### PR TITLE
Fix the gradient update in the word2vec example

### DIFF
--- a/tensorflow/core/kernels/word2vec_kernels.cc
+++ b/tensorflow/core/kernels/word2vec_kernels.cc
@@ -320,7 +320,7 @@ class NegTrainOp : public OpKernel {
         auto dot = (v_in * v_out).sum();
         g = (dot.exp() + 1.f).inverse();
         Tbuf = v_out * (g() * lr);
-        v_out += v_in * (g() * lr);
+        v_out -= v_in * (g() * lr);
       }
 
       // Negative samples:
@@ -336,11 +336,11 @@ class NegTrainOp : public OpKernel {
         auto dot = (v_in * v_sample).sum();
         g = -((-dot).exp() + 1.f).inverse();
         Tbuf += v_sample * (g() * lr);
-        v_sample += v_in * (g() * lr);
+        v_sample -= v_in * (g() * lr);
       }
 
       // Applies the gradient on v_in.
-      v_in += Tbuf;
+      v_in -= Tbuf;
     }
   }
 


### PR DESCRIPTION
The gradient update should be `x <- x - alpha * gradient`, not `x <- x + alpha * gradient`.