### PR TITLE
[Intel MKL] Upgrading the the CI install_bazel.sh script to install bazel 0.15.0

### DIFF
--- a/tensorflow/tools/ci_build/install/install_bazel.sh
+++ b/tensorflow/tools/ci_build/install/install_bazel.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 # Select bazel version.
-BAZEL_VERSION="0.14.0"
+BAZEL_VERSION="0.15.0"
 
 set +e
 local_bazel_ver=$(bazel version 2>&1 | grep -i label | awk '{print $3}')

--- a/tensorflow/tools/ci_build/install/install_bazel.sh
+++ b/tensorflow/tools/ci_build/install/install_bazel.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 # Select bazel version.
-BAZEL_VERSION="0.11.0"
+BAZEL_VERSION="0.14.0"
 
 set +e
 local_bazel_ver=$(bazel version 2>&1 | grep -i label | awk '{print $3}')


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/commit/1e2438318dd250132572a23458598f8c4c4d9ce5

Without this, CI builds can't compile because of recent changes to third_party/gpus/cuda_configure.bzl: 

@gunan Can you take a look at this one?