### PR TITLE
Fix typo in bounding box example

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_DrawBoundingBoxes.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DrawBoundingBoxes.pbtxt
@@ -30,7 +30,7 @@ height of the underlying image.
 
 For example, if an image is 100 x 200 pixels (height x width) and the bounding
 box is `[0.1, 0.2, 0.5, 0.9]`, the upper-left and bottom-right coordinates of
-the bounding box will be `(40, 10)` to `(100, 50)` (in (x,y) coordinates).
+the bounding box will be `(40, 10)` to `(180, 50)` (in (x,y) coordinates).
 
 Parts of the bounding box may fall outside the image.
 END


### PR DESCRIPTION
The example in the [tf.image.draw_bounding_boxes documentation](https://www.tensorflow.org/api_docs/python/tf/image/draw_bounding_boxes) has a typo that makes it really confusing. The relative values for `[y_min, x_min, y_max, x_max]` are computed by:

```python
y_min = y_min_px / height
y_max = y_max_px / height
x_min = x_min_px / width
x_max = x_max_px / width
```

Since the example doesn't explicitly describe this simple formula, the fact that the absolute pixel value for `x_max` is wrong can make the reader wonder if there is in fact another formula for computing `x_max`.