### PR TITLE
Fix bug inside boston.py in boosted_trees with python 3

### DIFF
--- a/tensorflow/contrib/boosted_trees/estimator_batch/custom_export_strategy.py
+++ b/tensorflow/contrib/boosted_trees/estimator_batch/custom_export_strategy.py
@@ -32,6 +32,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.platform import gfile
 from tensorflow.python.saved_model import loader as saved_model_loader
 from tensorflow.python.saved_model import tag_constants
+from tensorflow.python.util import compat
 
 _SPARSE_FLOAT_FEATURE_NAME_TEMPLATE = "%s_%d"
 
@@ -88,9 +89,9 @@ def make_custom_export_strategy(name,
             len(sparse_float_indices), len(sparse_int_indices))
         sorted_by_importance = sorted(
             feature_importances.items(), key=lambda x: -x[1])
-        assets_dir = os.path.join(result_dir, "assets.extra")
+        assets_dir = os.path.join(compat.as_bytes(result_dir), compat.as_bytes("assets.extra"))
         gfile.MakeDirs(assets_dir)
-        with gfile.GFile(os.path.join(assets_dir, "feature_importances"),
+        with gfile.GFile(os.path.join(compat.as_bytes(assets_dir), compat.as_bytes("feature_importances")),
                          "w") as f:
           f.write("\n".join("%s, %f" % (k, v) for k, v in sorted_by_importance))
     return result_dir

--- a/tensorflow/contrib/boosted_trees/estimator_batch/custom_export_strategy.py
+++ b/tensorflow/contrib/boosted_trees/estimator_batch/custom_export_strategy.py
@@ -89,10 +89,12 @@ def make_custom_export_strategy(name,
             len(sparse_float_indices), len(sparse_int_indices))
         sorted_by_importance = sorted(
             feature_importances.items(), key=lambda x: -x[1])
-        assets_dir = os.path.join(compat.as_bytes(result_dir), compat.as_bytes("assets.extra"))
+        assets_dir = os.path.join(
+            compat.as_bytes(result_dir), compat.as_bytes("assets.extra"))
         gfile.MakeDirs(assets_dir)
-        with gfile.GFile(os.path.join(compat.as_bytes(assets_dir), compat.as_bytes("feature_importances")),
-                         "w") as f:
+        with gfile.GFile(os.path.join(
+            compat.as_bytes(assets_dir),
+            compat.as_bytes("feature_importances")), "w") as f:
           f.write("\n".join("%s, %f" % (k, v) for k, v in sorted_by_importance))
     return result_dir
 

--- a/tensorflow/contrib/boosted_trees/examples/boston.py
+++ b/tensorflow/contrib/boosted_trees/examples/boston.py
@@ -45,6 +45,7 @@ from tensorflow.contrib.boosted_trees.estimator_batch.estimator import GradientB
 from tensorflow.contrib.boosted_trees.proto import learner_pb2
 from tensorflow.contrib.layers.python.layers import feature_column
 from tensorflow.contrib.learn import learn_runner
+from tensorflow.python.util import compat
 
 _BOSTON_NUM_FEATURES = 13
 
@@ -79,7 +80,7 @@ def _convert_fn(dtec, sorted_feature_names, num_dense, num_sparse_float,
                 num_sparse_int, export_dir, unused_eval_result):
   universal_format = custom_export_strategy.convert_to_universal_format(
       dtec, sorted_feature_names, num_dense, num_sparse_float, num_sparse_int)
-  with tf.gfile.GFile(os.path.join(export_dir, "tree_proto"), "w") as f:
+  with tf.gfile.GFile(os.path.join(compat.as_bytes(export_dir), compat.as_bytes("tree_proto")), "w") as f:
     f.write(str(universal_format))
 
 

--- a/tensorflow/contrib/boosted_trees/examples/boston.py
+++ b/tensorflow/contrib/boosted_trees/examples/boston.py
@@ -80,7 +80,8 @@ def _convert_fn(dtec, sorted_feature_names, num_dense, num_sparse_float,
                 num_sparse_int, export_dir, unused_eval_result):
   universal_format = custom_export_strategy.convert_to_universal_format(
       dtec, sorted_feature_names, num_dense, num_sparse_float, num_sparse_int)
-  with tf.gfile.GFile(os.path.join(compat.as_bytes(export_dir), compat.as_bytes("tree_proto")), "w") as f:
+  with tf.gfile.GFile(os.path.join(
+      compat.as_bytes(export_dir), compat.as_bytes("tree_proto")), "w") as f:
     f.write(str(universal_format))
 
 


### PR DESCRIPTION
This fix tries to address the issue raised in #20776 where run the sample with boston.py in boosted_trees throws out error with python 3:
```
$ python3 boston.py \
>   --batch_size=404 --output_dir="/tmp/boston" --depth=4 --learning_rate=0.1 \
>   --num_eval_steps=1 --num_trees=500 --l2=0.001 \
>   --vmodule=training_ops=1
......
......
Traceback (most recent call last):
  File "boston.py", line 169, in <module>
    tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
......
......
  File "/usr/lib/python3.5/genericpath.py", line 145, in _check_arg_types
    raise TypeError("Can't mix strings and bytes in path components") from None
TypeError: Can't mix strings and bytes in path components
```
The reason for the error was because in python 3, the export_dir was returned as bytes.

This fix as the `compat.as_bytes` which is consistent with other places in tensorflow.

This fix fixes #20776

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>