### PR TITLE
[WIP] fix: InMemoryEvaluatorHook timer

### DIFF
--- a/tensorflow/contrib/estimator/python/estimator/hooks.py
+++ b/tensorflow/contrib/estimator/python/estimator/hooks.py
@@ -189,7 +189,7 @@ class InMemoryEvaluatorHook(training.SessionRunHook):
         init_fn=feed_variables, copy_from_scaffold=self._scaffold)
 
     with self._graph.as_default():
-      return self._estimator._evaluate_run(
+      self._estimator._evaluate_run(
           checkpoint_path=None,
           scaffold=scaffold,
           update_op=self._update_op,


### PR DESCRIPTION
There is an extraneous return statement inside `_evaluate` that prevents `update_last_triggered_step` from being called. This causes the hook trigger at every iteration.

Besides this minor bug I am grateful for this new hook, it has sped up our training / evaluation loop tremendously. Thank you!

TODO:
- [ ] Add a test to prevent future regression (will do later today)