### PR TITLE
[tfgan] Fix assertion in regularization loss unittest

### DIFF
--- a/tensorflow/contrib/gan/python/train_test.py
+++ b/tensorflow/contrib/gan/python/train_test.py
@@ -447,8 +447,8 @@ class GANLossTest(test.TestCase):
       reg_loss_gen_np = reg_loss.generator_loss.eval()
       reg_loss_dis_np = reg_loss.discriminator_loss.eval()
 
-    self.assertTrue(3.0, reg_loss_gen_np - no_reg_loss_gen_np)
-    self.assertTrue(3.0, reg_loss_dis_np - no_reg_loss_dis_np)
+    self.assertEqual(3.0, reg_loss_gen_np - no_reg_loss_gen_np)
+    self.assertEqual(2.0, reg_loss_dis_np - no_reg_loss_dis_np)
 
   def test_regularization_gan(self):
     self._test_regularization_helper(get_gan_model)


### PR DESCRIPTION
`self.assertTrue(3.0)` always evaluates to `True`.
This PR fixes assertion so it will correctly check the loss values as set [here](https://github.com/lgeiger/tensorflow/blob/006b8faeb79c8b9329bd600390dbda888e9df226/tensorflow/contrib/gan/python/train_test.py#L437-L442).