### PR TITLE
Use FastBoundsCheck in ArgMax kernel op

### DIFF
--- a/tensorflow/core/kernels/argmax_op.cc
+++ b/tensorflow/core/kernels/argmax_op.cc
@@ -59,7 +59,7 @@ class ArgOp : public OpKernel {
 
     int axis = dim < 0 ? dim + input_dims : dim;
 
-    OP_REQUIRES(context, axis >= 0 && axis < input_dims,
+    OP_REQUIRES(context, FastBoundsCheck(axis, input_dims),
                 errors::InvalidArgument("Expected dimension in the range [",
                                         -input_dims, ", ", input_dims,
                                         "), but got ", dim));


### PR DESCRIPTION
This fix updates ArgMax kernel implementation to
use FastBoundsCheck for improved performance, and
keep consistency with other places in tf.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>