### PR TITLE
Omit some operations if only one para is kLogZero

### DIFF
--- a/tensorflow/core/util/ctc/ctc_loss_util.h
+++ b/tensorflow/core/util/ctc/ctc_loss_util.h
@@ -33,8 +33,8 @@ inline float LogSumExp(float log_prob_1, float log_prob_2) {
   // blowing up.
   if (log_prob_1 == kLogZero) {
     return log_prob_2;
-  } else if (log_prob_2 == kLogZero){
-      return log_prob_1;
+  } else if (log_prob_2 == kLogZero) {
+    return log_prob_1;
   } else {
     return (log_prob_1 > log_prob_2)
                ? log_prob_1 + log1pf(expf(log_prob_2 - log_prob_1))

--- a/tensorflow/core/util/ctc/ctc_loss_util.h
+++ b/tensorflow/core/util/ctc/ctc_loss_util.h
@@ -31,8 +31,10 @@ const float kLogZero = -std::numeric_limits<float>::infinity();
 inline float LogSumExp(float log_prob_1, float log_prob_2) {
   // Always have 'b' be the smaller number to avoid the exponential from
   // blowing up.
-  if (log_prob_1 == kLogZero && log_prob_2 == kLogZero) {
-    return kLogZero;
+  if (log_prob_1 == kLogZero) {
+    return log_prob_2;
+  } else if (log_prob_2 == kLogZero){
+      return log_prob_1;
   } else {
     return (log_prob_1 > log_prob_2)
                ? log_prob_1 + log1pf(expf(log_prob_2 - log_prob_1))


### PR DESCRIPTION
If log_prob_1 is kLogZero and log_prob_2 is not kLogZero or log_prob_2 is kLogZero and log_prob_1 is not kLogZero, just return another parameters, this judge can omit some operations(log1pf() and expf()).
The mathematical equation is:
ln(e^(-inf)+e^(x))=ln(0+e^(x))=x