### PR TITLE
Improvement of shape function in HistogramFixedWidth

### DIFF
--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1380,6 +1380,14 @@ REGISTER_OP("HistogramFixedWidth")
     .Attr("T: {int32, int64, float32, float64}")
     .Attr("dtype: {int32, int64} = DT_INT32")
     .SetShapeFn([](InferenceContext* c) {
+      // value_range should be a vector.
+      ShapeHandle value_range_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &value_range_shape));
+      // value_range should have two elements.
+      DimensionHandle unused;
+      TF_RETURN_IF_ERROR(c->WithValue(c->Dim(value_range_shape, 0), 2, &unused));
+
+      // If nbins is available, set the shape from nbins.
       const Tensor* nbins_input = c->input_tensor(2);
       if (nbins_input != nullptr) {
         int64 nbins;

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1387,6 +1387,9 @@ REGISTER_OP("HistogramFixedWidth")
       DimensionHandle unused;
       TF_RETURN_IF_ERROR(
           c->WithValue(c->Dim(value_range_shape, 0), 2, &unused));
+      // nbins should be a scalar.
+      ShapeHandle nbins_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &nbins_shape));
 
       // If nbins is available, set the shape from nbins.
       const Tensor* nbins_input = c->input_tensor(2);

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1393,6 +1393,10 @@ REGISTER_OP("HistogramFixedWidth")
       if (nbins_input != nullptr) {
         int64 nbins;
         TF_RETURN_IF_ERROR(c->GetScalarFromTensor(nbins_input, &nbins));
+        // nbins has to be positive.
+        if (nbins <= 0) {
+          return errors::InvalidArgument("Requires nbins > 0: ", nbins);
+        }
         c->set_output(0, c->Vector(nbins));
       } else {
         c->set_output(0, c->UnknownShapeOfRank(1));

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1385,7 +1385,8 @@ REGISTER_OP("HistogramFixedWidth")
       TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &value_range_shape));
       // value_range should have two elements.
       DimensionHandle unused;
-      TF_RETURN_IF_ERROR(c->WithValue(c->Dim(value_range_shape, 0), 2, &unused));
+      TF_RETURN_IF_ERROR(
+          c->WithValue(c->Dim(value_range_shape, 0), 2, &unused));
 
       // If nbins is available, set the shape from nbins.
       const Tensor* nbins_input = c->input_tensor(2);

--- a/tensorflow/core/ops/math_ops_test.cc
+++ b/tensorflow/core/ops/math_ops_test.cc
@@ -528,4 +528,15 @@ TEST(MathOpsTest, Cross_ShapeFn) {
   INFER_OK(op, "[?];[?]", "in0");
   INFER_OK(op, "[1,?,3];[?,?,?]", "in0");
 }
+
+TEST(MathOpsTest, HistogramFixedWidth_ShapeFn) {
+  ShapeInferenceTestOp op("HistogramFixedWidth");
+
+  INFER_ERROR("Shape must be rank 1 but is rank 0", op, "[];[];[]");
+  INFER_ERROR("Dimension must be 2 but is 3", op, "[];[3];[]");
+
+  INFER_OK(op, "?;?;?", "[?]");
+  INFER_OK(op, "[?];[2];[]", "[?]");
+  INFER_OK(op, "[?];[2];?", "[?]");
+}
 }  // end namespace tensorflow

--- a/tensorflow/core/ops/math_ops_test.cc
+++ b/tensorflow/core/ops/math_ops_test.cc
@@ -532,8 +532,12 @@ TEST(MathOpsTest, Cross_ShapeFn) {
 TEST(MathOpsTest, HistogramFixedWidth_ShapeFn) {
   ShapeInferenceTestOp op("HistogramFixedWidth");
 
+  // value_range should be vector.
   INFER_ERROR("Shape must be rank 1 but is rank 0", op, "[];[];[]");
+  // value_range should have 2 elements.
   INFER_ERROR("Dimension must be 2 but is 3", op, "[];[3];[]");
+  // nbins should be scalar.
+  INFER_ERROR("Shape must be rank 0 but is rank 1", op, "[];[2];[2]");
 
   INFER_OK(op, "?;?;?", "[?]");
   INFER_OK(op, "[?];[2];[]", "[?]");

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -86,14 +86,16 @@ class HistogramFixedWidthTest(test.TestCase):
 
   def test_with_invalid_value_range(self):
     values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
-    with self.assertRaisesRegexp(ValueError, "Shape must be rank 1 but is rank 0"):
+    with self.assertRaisesRegexp(
+        ValueError, "Shape must be rank 1 but is rank 0"):
       histogram_ops.histogram_fixed_width(values, 1.0)
     with self.assertRaisesRegexp(ValueError, "Dimension must be 2 but is 3"):
       histogram_ops.histogram_fixed_width(values, [1.0, 2.0, 3.0])
 
   def test_with_invalid_nbins(self):
     values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
-    with self.assertRaisesRegexp(ValueError, "Input must be scalar but has rank 1"):
+    with self.assertRaisesRegexp(
+        ValueError, "Input must be scalar but has rank 1"):
       histogram_ops.histogram_fixed_width(values, [1.0, 5.0], nbins=[1, 2])
 
   def test_empty_input_gives_all_zero_counts(self):

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -97,6 +97,9 @@ class HistogramFixedWidthTest(test.TestCase):
     with self.assertRaisesRegexp(
         ValueError, "Input must be scalar but has rank 1"):
       histogram_ops.histogram_fixed_width(values, [1.0, 5.0], nbins=[1, 2])
+    with self.assertRaisesRegexp(
+        ValueError, "Requires nbins > 0"):
+      histogram_ops.histogram_fixed_width(values, [1.0, 5.0], nbins=-5)
 
   def test_empty_input_gives_all_zero_counts(self):
     # Bins will be:

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -95,7 +95,7 @@ class HistogramFixedWidthTest(test.TestCase):
   def test_with_invalid_nbins(self):
     values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
     with self.assertRaisesRegexp(
-        ValueError, "Input must be scalar but has rank 1"):
+        ValueError, "Shape must be rank 0 but is rank 1"):
       histogram_ops.histogram_fixed_width(values, [1.0, 5.0], nbins=[1, 2])
     with self.assertRaisesRegexp(
         ValueError, "Requires nbins > 0"):

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -84,6 +84,18 @@ class HistogramFixedWidthTest(test.TestCase):
   def setUp(self):
     self.rng = np.random.RandomState(0)
 
+  def test_with_invalid_value_range(self):
+    values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
+    with self.assertRaisesRegexp(ValueError, "Shape must be rank 1 but is rank 0"):
+      histogram_ops.histogram_fixed_width(values, 1.0)
+    with self.assertRaisesRegexp(ValueError, "Dimension must be 2 but is 3"):
+      histogram_ops.histogram_fixed_width(values, [1.0, 2.0, 3.0])
+
+  def test_with_invalid_nbins(self):
+    values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
+    with self.assertRaisesRegexp(ValueError, "Input must be scalar but has rank 1"):
+      histogram_ops.histogram_fixed_width(values, [1.0, 5.0], nbins=[1, 2])
+
   def test_empty_input_gives_all_zero_counts(self):
     # Bins will be:
     #   (-inf, 1), [1, 2), [2, 3), [3, 4), [4, inf)


### PR DESCRIPTION
In the HistogramFixedWidth op, there are restrictions over the shape of range_value and nbins. The range_value should be a vector of 2 elements and nbins should be a scalar.

This fix adds the restriction to shape function of HistogramFixedWidth.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>