### PR TITLE
Add int32/string k/v support for tf.contrib.lookup.HashTable

### DIFF
--- a/tensorflow/contrib/lookup/lookup_ops_test.py
+++ b/tensorflow/contrib/lookup/lookup_ops_test.py
@@ -280,6 +280,21 @@ class HashTableOpTest(test.TestCase):
       table.init.run()
       self.assertAllEqual(3, table.size().eval())
 
+  def testHashTableInt32String(self):
+    with self.test_session():
+      default_val = "n/a"
+      keys = constant_op.constant([0, 1, 2], dtypes.int32)
+      values = constant_op.constant(["brain", "salad", "surgery"])
+      table = lookup.HashTable(
+          lookup.KeyValueTensorInitializer(keys, values), default_val)
+      table.init.run()
+
+      input_tensor = constant_op.constant([0, 1, -1])
+      output = table.lookup(input_tensor)
+
+      result = output.eval()
+      self.assertAllEqual(["brain", "salad", "n/a"], result)
+
 
 class MutableHashTableOpTest(test.TestCase):
 

--- a/tensorflow/contrib/lookup/lookup_ops_test.py
+++ b/tensorflow/contrib/lookup/lookup_ops_test.py
@@ -293,7 +293,7 @@ class HashTableOpTest(test.TestCase):
       output = table.lookup(input_tensor)
 
       result = output.eval()
-      self.assertAllEqual(["brain", "salad", "n/a"], result)
+      self.assertAllEqual([b"brain", b"salad", b"n/a"], result)
 
 
 class MutableHashTableOpTest(test.TestCase):

--- a/tensorflow/core/kernels/lookup_table_op.cc
+++ b/tensorflow/core/kernels/lookup_table_op.cc
@@ -822,6 +822,7 @@ REGISTER_KERNEL(int64, float);
 REGISTER_KERNEL(string, string);
 REGISTER_KERNEL(string, bool);
 REGISTER_KERNEL(int32, int32);
+REGISTER_KERNEL(int32, string);
 
 #undef REGISTER_KERNEL
 


### PR DESCRIPTION
This fix tries to address the issue raised in #20869 where there were no int32/string k/v support for tf.contrib.lookup.HashTable. This fix adds the int32/string for the kernel.

This fix fixes #20869.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>