### PR TITLE
[tf.keras] Add custom scalar tensorboard summary for metrics

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -848,7 +848,7 @@ class TensorBoard(Callback):
                       layout_pb2.Chart(
                           title=metric,
                           multiline=layout_pb2.MultilineChartContent(
-                              tag=[r'(val_{0}|{0})'.format(metric)])
+                              tag=[r'(epoch_val_{0}|epoch_{0})'.format(metric)])
                       ) for metric in self.model.metrics_names])
               ]))
 

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -836,6 +836,27 @@ class TensorBoard(Callback):
       self._make_histogram_ops(model)
       self.merged = tf_summary.merge_all()
 
+    try:
+      from tensorboard import summary as summary_lib
+      from tensorboard.plugins.custom_scalar import layout_pb2
+
+      layout_summary = summary_lib.custom_scalar_pb(
+          layout_pb2.Layout(category=[
+              layout_pb2.Category(
+                  title='metrics',
+                  chart=[
+                      layout_pb2.Chart(
+                          title=metric,
+                          multiline=layout_pb2.MultilineChartContent(
+                              tag=[r'(val_{0}|{0})'.format(metric)])
+                      ) for metric in self.model.metrics_names])
+              ]))
+
+      self.writer.add_summary(layout_summary)
+    except ImportError:
+      logging.warning('Failed to import TensorBoard. '
+                      'Skipping custom scalar plugin.')
+
     # If both embedding_freq and embeddings_data are available, we will
     # visualize embeddings.
     if self.embeddings_freq and self.embeddings_data is not None:


### PR DESCRIPTION
It can be very useful to view training and validation loss in a single chart inside tensorboard.

Currently this is only easily possible by using two different summary writers that write to different tags: https://stackoverflow.com/questions/47877475/keras-tensorboard-plot-train-and-validation-scalars-in-a-same-figure/48393723

This PR extends the keras callback to display trainings and validation metrics in a single chart using the [custom scalar plugin](https://github.com/tensorflow/tensorboard/tree/master/tensorboard/plugins/custom_scalar):

![tb_custom](https://user-images.githubusercontent.com/13285808/42854540-9758f9e2-8a3c-11e8-963b-813c2a33291b.png)

Note: https://github.com/tensorflow/tensorboard/pull/1294 is required to properly display multiple runs.