### PR TITLE
Floating point type issue when computing extract images patches gradient

### DIFF
--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -790,7 +790,7 @@ def _ExtractImagePatchesGrad(op, grad):
 
   sp_mat = sparse_tensor.SparseTensor(
       array_ops.constant(idx, dtype=ops.dtypes.int64),
-      array_ops.ones((len(idx),), dtype=ops.dtypes.float32), sp_shape)
+      array_ops.ones((len(idx),), dtype=grad.dtype), sp_shape)
 
   jac = sparse_ops.sparse_tensor_dense_matmul(sp_mat, grad_flat)
 


### PR DESCRIPTION
I was using `tf.extract_image_patches` when I ran into this issue. 

It seems `sp_mat` here becomes a 32 bit floating point number as the sparse tensor inherits the floating point type from the values argument. If one is using float64 and the gradient is float64 computing the jacobian on the next line will result in the error "TypeError: Input 'b' of 'SparseTensorDenseMatMul' Op has type float64 that does not match type float32 of argument 'a_values'".

Inheriting the floating point type from the gradient should fix the issue.