### PR TITLE
Add gradient for tensorflow::ops::Fill

### DIFF
--- a/tensorflow/cc/gradients/array_grad_test.cc
+++ b/tensorflow/cc/gradients/array_grad_test.cc
@@ -108,6 +108,14 @@ TEST_F(ArrayGradTest, SplitGrad) {
   RunTest({x}, {x_shape}, y.output, {y_shape, y_shape});
 }
 
+TEST_F(ArrayGradTest, FillGrad) {
+  TensorShape x_shape({});
+  auto x = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x_shape));
+  TensorShape y_shape({2, 5, 3});
+  auto y = Fill(scope_, {2, 5, 3}, x);
+  RunTest(x, x_shape, y, y_shape);
+}
+
 TEST_F(ArrayGradTest, DiagGrad) {
   TensorShape x_shape({5, 2});
   auto x = Placeholder(scope_, DT_FLOAT, Placeholder::Shape(x_shape));


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/issues/20926

Also tested for any flakes with this:
```
bazel test --runs_per_test=100 tensorflow/cc:gradients_array_grad_test
...
//tensorflow/cc:gradients_array_grad_test                                PASSED in 0.8s
  Stats over 100 runs: max = 0.8s, min = 0.5s, avg = 0.6s, dev = 0.0s
```

