### PR TITLE
Add SQLITE_OPEN_URI flag to sqlite open to fix create_db_writer failure to open the db

### DIFF
--- a/tensorflow/contrib/summary/summary_ops_test.py
+++ b/tensorflow/contrib/summary/summary_ops_test.py
@@ -17,7 +17,6 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import pathlib
 import tempfile
 import time
 
@@ -280,7 +279,7 @@ class EagerDbTest(summary_test_util.SummaryDbTest):
 
   def testDbURIOpen(self):
     tmpdb_path = os.path.join(self.get_temp_dir(), 'tmpDbURITest.sqlite')
-    tmpdb_uri = pathlib.Path(tmpdb_path).as_uri()
+    tmpdb_uri = six.moves.urllib_parse.urljoin("file:", tmpdb_path)
     tmpdb_writer = summary_ops.create_db_writer(
         tmpdb_uri,
         "experimentA",

--- a/tensorflow/contrib/summary/summary_ops_test.py
+++ b/tensorflow/contrib/summary/summary_ops_test.py
@@ -17,8 +17,11 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import pathlib
 import tempfile
 import time
+
+import sqlite3
 
 import numpy as np
 import six
@@ -274,6 +277,22 @@ class EagerFileTest(test_util.TensorFlowTestCase):
 
 
 class EagerDbTest(summary_test_util.SummaryDbTest):
+
+  def testDbURIOpen(self):
+    tmpdb_path = os.path.join(self.get_temp_dir(), 'tmpDbURITest.sqlite')
+    tmpdb_uri = pathlib.Path(tmpdb_path).as_uri()
+    tmpdb_writer = summary_ops.create_db_writer(
+        tmpdb_uri,
+        "experimentA",
+        "run1",
+        "user1")
+    with summary_ops.always_record_summaries():
+      with tmpdb_writer.as_default():
+        summary_ops.scalar('t1', 2.0)
+    tmpdb = sqlite3.connect(tmpdb_path)
+    num = get_one(tmpdb, 'SELECT count(*) FROM Tags WHERE tag_name = "t1"')
+    self.assertEqual(num, 1)
+    tmpdb.close()
 
   def testIntegerSummaries(self):
     step = training_util.create_global_step()

--- a/tensorflow/core/lib/db/sqlite.cc
+++ b/tensorflow/core/lib/db/sqlite.cc
@@ -112,6 +112,7 @@ Status EnvPragma(Sqlite* db, const char* pragma, const char* var) {
 /* static */
 Status Sqlite::Open(const string& path, int flags, Sqlite** db) {
   flags |= SQLITE_OPEN_PRIVATECACHE;
+  flags |= SQLITE_OPEN_URI;
   sqlite3* sqlite = nullptr;
   int rc = sqlite3_open_v2(path.c_str(), &sqlite, flags, nullptr);
   if (rc != SQLITE_OK) {


### PR DESCRIPTION
**Repro:** 
- Create a summary_ops.create_db_writer with the db_uri as a uri fails. 
- [API](https://www.tensorflow.org/api_docs/python/tf/contrib/summary/create_db_writer) Example: db_uri: For example "file:/tmp/foo.sqlite" 

`2018-07-17 11:53:26.760581: W tensorflow/core/framework/op_kernel.cc:1275] OP_REQUIRES failed at summary_kernels.cc:91 : Invalid argument: Sqlite::Open(file:/tmp/foo.sqlite) **failed: unable to open database file**`

**Workaround:**
One workaround is to remove the uri, and just give the path for the db_uri parameter 

**Fix:**  
- This PR adds the SQLITE_OPEN_URI flag to enable its URI filename capability.  
- Reference: https://sqlite.org/uri.html

**Testing:**
 - A new unit test has been added.