### PR TITLE
Disable sdca_ops test on GPU.

### DIFF
--- a/tensorflow/contrib/linear_optimizer/BUILD
+++ b/tensorflow/contrib/linear_optimizer/BUILD
@@ -43,7 +43,7 @@ py_test(
     srcs_version = "PY2AND3",
     tags = [
         "no_gpu",
-        "no_windows_gpu"
+        "no_windows_gpu",
     ],
     deps = [
         ":sdca_ops_py",

--- a/tensorflow/contrib/linear_optimizer/BUILD
+++ b/tensorflow/contrib/linear_optimizer/BUILD
@@ -41,7 +41,10 @@ py_test(
     size = "medium",
     srcs = ["python/kernel_tests/sdca_ops_test.py"],
     srcs_version = "PY2AND3",
-    tags = ["no_windows_gpu"],
+    tags = [
+        "no_gpu",
+        "no_windows_gpu"
+    ],
     deps = [
         ":sdca_ops_py",
         ":sparse_feature_column_py",


### PR DESCRIPTION
This test is failing on GPU. Some of the ops don't have GPU
implementations so this test might not even be meant to be
run on GPU.