### PR TITLE
Use GPU_PLATFORM_NAME macro to define GPU platform name

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_init.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_init.cc
@@ -29,13 +29,13 @@ limitations under the License.
 namespace tensorflow {
 
 Status ValidateGPUMachineManager() {
-  return se::MultiPlatformManager::PlatformWithName("CUDA").status();
+  return se::MultiPlatformManager::PlatformWithName(GPU_PLATFORM_NAME).status();
 }
 
 se::Platform* GPUMachineManager() {
-  auto result = se::MultiPlatformManager::PlatformWithName("CUDA");
+  auto result = se::MultiPlatformManager::PlatformWithName(GPU_PLATFORM_NAME);
   if (!result.ok()) {
-    LOG(FATAL) << "Could not find Platform with name CUDA";
+    LOG(FATAL) << "Could not find Platform with name " << GPU_PLATFORM_NAME;
     return nullptr;
   }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_init.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_init.h
@@ -24,8 +24,17 @@ class Platform;
 
 namespace tensorflow {
 
-// Initializes the CUDA platform and returns OK if the CUDA
-// platform could be initialized.
+const char* const kCudaGpuConstant = "CUDA";
+const char* const kNoGpuConstant = "NO_GPU_PLATFORM";
+
+#if GOOGLE_CUDA
+#define GPU_PLATFORM_NAME kCudaGpuConstant
+#else
+#define GPU_PLATFORM_NAME kNoGpuConstant
+#endif
+
+// Initializes the GPU platform and returns OK if the GPU platform could be
+// initialized.
 Status ValidateGPUMachineManager();
 
 // Returns the GPU machine manager singleton, creating it and

--- a/tensorflow/core/common_runtime/gpu/gpu_init.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_init.h
@@ -24,6 +24,11 @@ class Platform;
 
 namespace tensorflow {
 
+// The choice of which kind of gpu that the TF GPU device corresponds to is a
+// compile-time decision, and thus we cannot build a single binary that
+// supports multiple kinds. This is sub-optimal, and a better solution will
+// likely need to be developed in the future. Also see the commentary here:
+// https://github.com/tensorflow/tensorflow/pull/20845
 const char* const kCudaGpuConstant = "CUDA";
 const char* const kNoGpuConstant = "NO_GPU_PLATFORM";
 


### PR DESCRIPTION
Instead of hard-coded "CUDA", use a macro which could be set at configure-time
or compile-time.