### PR TITLE
Add no_pip_gpu to the sdca test.

### DIFF
--- a/tensorflow/contrib/linear_optimizer/BUILD
+++ b/tensorflow/contrib/linear_optimizer/BUILD
@@ -43,6 +43,7 @@ py_test(
     srcs_version = "PY2AND3",
     tags = [
         "no_gpu",
+        "no_pip_gpu",
         "no_windows_gpu",
     ],
     deps = [


### PR DESCRIPTION
Second attempt to disable on GPU release build.