### PR TITLE
fixed build error on gcc-7

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/xfeed_queue.h
+++ b/tensorflow/compiler/xla/service/gpu/xfeed_queue.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_XFEED_QUEUE_H_
 
 #include <deque>
+#include <functional>
 #include <vector>
 
 #include "tensorflow/core/platform/mutex.h"


### PR DESCRIPTION
fixed build error 

```sh
ERROR: /home/msca8h/Projects/tensorflow/tensorflow/compiler/xla/service/gpu/BUILD:650:1: C++ compilation of rule '//tensorflow/compiler/xla/service/gpu:infeed_manager' failed (Exit 1)
In file included from ./tensorflow/compiler/xla/service/gpu/infeed_manager.h:23:0,
                 from tensorflow/compiler/xla/service/gpu/infeed_manager.cc:16:
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:68:37: error: 'std::function' has not been declared
   void RegisterOnEmptyCallback(std::function<void()> callback) {
                                     ^~~~~~~~
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:68:45: error: expected ',' or '...' before '<' token
   void RegisterOnEmptyCallback(std::function<void()> callback) {
                                             ^
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:83:20: error: 'function' is not a member of 'std'
   std::vector<std::function<void()>> on_empty_callbacks_;
                    ^~~~~~~~
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:83:20: note: suggested alternative: 'is_function'
   std::vector<std::function<void()>> on_empty_callbacks_;
                    ^~~~~~~~
                    is_function
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:83:20: error: 'function' is not a member of 'std'
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:83:20: note: suggested alternative: 'is_function'
   std::vector<std::function<void()>> on_empty_callbacks_;
                    ^~~~~~~~
                    is_function
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:83:34: error: template argument 1 is invalid
   std::vector<std::function<void()>> on_empty_callbacks_;
                                  ^
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:83:34: error: template argument 2 is invalid
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:83:35: error: expected unqualified-id before '>' token
   std::vector<std::function<void()>> on_empty_callbacks_;
                                   ^~
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h: In member function 'BufferType xla::gpu::XfeedQueue<BufferType>::BlockingGetNextDestination()':
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:61:35: error: 'on_empty_callbacks_' was not declared in this scope
       for (const auto& callback : on_empty_callbacks_) {
                                   ^~~~~~~~~~~~~~~~~~~
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h: In member function 'void xla::gpu::XfeedQueue<BufferType>::RegisterOnEmptyCallback(int)':
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:69:5: error: 'on_empty_callbacks_' was not declared in this scope
     on_empty_callbacks_.push_back(std::move(callback));
     ^~~~~~~~~~~~~~~~~~~
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:69:45: error: 'callback' was not declared in this scope
     on_empty_callbacks_.push_back(std::move(callback));
                                             ^~~~~~~~
./tensorflow/compiler/xla/service/gpu/xfeed_queue.h:69:45: note: suggested alternative: 'calloc'
     on_empty_callbacks_.push_back(std::move(callback));
                                             ^~~~~~~~
                                             calloc
In file included from ./tensorflow/core/platform/default/logging.h:24:0,
                 from ./tensorflow/core/platform/logging.h:25,
                 from ./tensorflow/core/lib/core/status.h:25,
                 from ./tensorflow/compiler/xla/status.h:19,
                 from ./tensorflow/compiler/xla/layout_util.h:23,
                 from ./tensorflow/compiler/xla/shape_tree.h:24,
                 from ./tensorflow/compiler/xla/service/gpu/infeed_manager.h:24,
                 from tensorflow/compiler/xla/service/gpu/infeed_manager.cc:16:
./tensorflow/core/platform/default/logging.h: In instantiation of 'std::__cxx11::string* tensorflow::internal::Check_LEImpl(const T1&, const T2&, const char*) [with T1 = long long int; T2 = long unsigned int; std::__cxx11::string = std::__cxx11::basic_string<char>]':
./tensorflow/compiler/xla/shape_util.h:117:5:   required from here
./tensorflow/core/platform/default/logging.h:232:35: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
 TF_DEFINE_CHECK_OP_IMPL(Check_LE, <=)
./tensorflow/core/platform/macros.h:88:49: note: in definition of macro 'TF_PREDICT_TRUE'
 #define TF_PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
                                                 ^
./tensorflow/core/platform/default/logging.h:232:1: note: in expansion of macro 'TF_DEFINE_CHECK_OP_IMPL'
 TF_DEFINE_CHECK_OP_IMPL(Check_LE, <=)
 ^~~~~~~~~~~~~~~~~~~~~~~
Target //tensorflow/tools/pip_package:build_pip_package failed to build
Use --verbose_failures to see the command lines of failed build steps.
```

The compiler couldn't find std::function
including ```<functional>``` fixed the problem