### PR TITLE
cmake: add systemlib_GRPC option.

### DIFF
--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -90,10 +90,12 @@ if (NOT WIN32)
 
   # Options for linking other libraries
   option(systemlib_ZLIB "Use the system installed library as shared objects instead of downloading ZLIB and statically linking to it: ZLIB" OFF)
+  option(systemlin_GRPC "Use the system installed library as shared objects instead of downloading GRPC and statically linking to it: GRPC" OFF)
 
   option(systemlib_ALL "Turn on every possible systemlib_* options" OFF)
   if (systemlib_ALL)
     set (systemlib_ZLIB ON)
+    set (systemlib_GRPC ON)
   endif (systemlib_ALL)
 endif()
 
@@ -322,7 +324,11 @@ if(tensorflow_ENABLE_GRPC_SUPPORT)
   include(grpc)
   include_directories(${GRPC_INCLUDE_DIRS})
   # Place boringssl after grpc as grpc depends on boringssl.
-  list(APPEND tensorflow_EXTERNAL_LIBRARIES ${grpc_STATIC_LIBRARIES})
+  if (systemlib_GRPC)
+    list(APPEND tensorflow_EXTERNAL_LIBRARIES ${grpc_STATIC_LIBRARIES})
+  else (systemlib_GRPC)
+    list(APPEND tensorflow_EXTERNAL_LIBRARIES ${grpc_LIBRARIES})
+  endif (systemlib_GRPC)
   list(APPEND tensorflow_EXTERNAL_DEPENDENCIES grpc)
   if(tensorflow_ENABLE_SSL_SUPPORT)
     list(APPEND tensorflow_EXTERNAL_LIBRARIES ${boringssl_STATIC_LIBRARIES})

--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -90,7 +90,7 @@ if (NOT WIN32)
 
   # Options for linking other libraries
   option(systemlib_ZLIB "Use the system installed library as shared objects instead of downloading ZLIB and statically linking to it: ZLIB" OFF)
-  option(systemlin_GRPC "Use the system installed library as shared objects instead of downloading GRPC and statically linking to it: GRPC" OFF)
+  option(systemlib_GRPC "Use the system installed library as shared objects instead of downloading GRPC and statically linking to it: GRPC" OFF)
 
   option(systemlib_ALL "Turn on every possible systemlib_* options" OFF)
   if (systemlib_ALL)

--- a/tensorflow/contrib/cmake/external/grpc.cmake
+++ b/tensorflow/contrib/cmake/external/grpc.cmake
@@ -12,67 +12,77 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-include (ExternalProject)
+if (systemlib_GRPC)
+  find_package(PkgConfig)
+  pkg_search_module(GRPC REQUIRED grpc++)
+  set(grpc_INCLUDE_DIRS ${GRPC_INCLUDE_DIRS})
+  set(grpc_STATIC_LIBRARIES "-lgrpc++ -lgrpc")
+  set(GRPC_BUILD /usr/bin)
+  add_custom_target(grpc)
 
-set(GRPC_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/include)
-set(GRPC_URL https://github.com/grpc/grpc.git)
-set(GRPC_BUILD ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc)
-set(GRPC_TAG d184fa229d75d336aedea0041bd59cb93e7e267f)
-
-if(WIN32)
-  # We use unsecure gRPC because boringssl does not build on windows
-  set(grpc_TARGET grpc++_unsecure)
-  set(grpc_DEPENDS protobuf zlib)
-  set(grpc_SSL_PROVIDER NONE)
-  if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
-    set(grpc_STATIC_LIBRARIES
-        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/grpc++_unsecure.lib
-        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/grpc_unsecure.lib
-        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/gpr.lib)
+else (systemlib_GRPC)
+  include (ExternalProject)
+  
+  set(GRPC_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/include)
+  set(GRPC_URL https://github.com/grpc/grpc.git)
+  set(GRPC_BUILD ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc)
+  set(GRPC_TAG d184fa229d75d336aedea0041bd59cb93e7e267f)
+  
+  if(WIN32)
+    # We use unsecure gRPC because boringssl does not build on windows
+    set(grpc_TARGET grpc++_unsecure)
+    set(grpc_DEPENDS protobuf zlib)
+    set(grpc_SSL_PROVIDER NONE)
+    if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
+      set(grpc_STATIC_LIBRARIES
+          ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/grpc++_unsecure.lib
+          ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/grpc_unsecure.lib
+          ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/Release/gpr.lib)
+    else()
+      set(grpc_STATIC_LIBRARIES
+          ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/grpc++_unsecure.lib
+          ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/grpc_unsecure.lib
+          ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/gpr.lib)
+    endif()
   else()
+    set(grpc_TARGET grpc++)
+    set(grpc_DEPENDS boringssl protobuf zlib)
+    set(grpc_SSL_PROVIDER module)
     set(grpc_STATIC_LIBRARIES
-        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/grpc++_unsecure.lib
-        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/grpc_unsecure.lib
-        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/gpr.lib)
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc++.a
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc.a
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libaddress_sorting.a
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/third_party/cares/cares/lib/libcares.a
+        ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgpr.a)
   endif()
-else()
-  set(grpc_TARGET grpc++)
-  set(grpc_DEPENDS boringssl protobuf zlib)
-  set(grpc_SSL_PROVIDER module)
-  set(grpc_STATIC_LIBRARIES
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc++.a
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgrpc.a
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libaddress_sorting.a
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/third_party/cares/cares/lib/libcares.a
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc/src/grpc/libgpr.a)
-endif()
-
-add_definitions(-DGRPC_ARES=0)
-
-ExternalProject_Add(grpc
-    PREFIX grpc
-    DEPENDS ${grpc_DEPENDS}
-    GIT_REPOSITORY ${GRPC_URL}
-    GIT_TAG ${GRPC_TAG}
-    DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
-    BUILD_IN_SOURCE 1
-    BUILD_BYPRODUCTS ${grpc_STATIC_LIBRARIES}
-    BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release --target ${grpc_TARGET}
-    COMMAND ${CMAKE_COMMAND} --build . --config Release --target grpc_cpp_plugin
-    INSTALL_COMMAND ""
-    CMAKE_CACHE_ARGS
-        -DCMAKE_BUILD_TYPE:STRING=Release
-        -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
-        -DPROTOBUF_INCLUDE_DIRS:STRING=${PROTOBUF_INCLUDE_DIRS}
-        -DPROTOBUF_LIBRARIES:STRING=${protobuf_STATIC_LIBRARIES}
-        -DZLIB_ROOT:STRING=${ZLIB_INSTALL}
-	-DgRPC_SSL_PROVIDER:STRING=${grpc_SSL_PROVIDER}
-)
-
-# grpc/src/core/ext/census/tracing.c depends on the existence of openssl/rand.h.
-ExternalProject_Add_Step(grpc copy_rand
-    COMMAND ${CMAKE_COMMAND} -E copy
-    ${CMAKE_SOURCE_DIR}/patches/grpc/rand.h ${GRPC_BUILD}/include/openssl/rand.h
-    DEPENDEES patch
-    DEPENDERS build
-)
+  
+  add_definitions(-DGRPC_ARES=0)
+  
+  ExternalProject_Add(grpc
+      PREFIX grpc
+      DEPENDS ${grpc_DEPENDS}
+      GIT_REPOSITORY ${GRPC_URL}
+      GIT_TAG ${GRPC_TAG}
+      DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+      BUILD_IN_SOURCE 1
+      BUILD_BYPRODUCTS ${grpc_STATIC_LIBRARIES}
+      BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release --target ${grpc_TARGET}
+      COMMAND ${CMAKE_COMMAND} --build . --config Release --target grpc_cpp_plugin
+      INSTALL_COMMAND ""
+      CMAKE_CACHE_ARGS
+          -DCMAKE_BUILD_TYPE:STRING=Release
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+          -DPROTOBUF_INCLUDE_DIRS:STRING=${PROTOBUF_INCLUDE_DIRS}
+          -DPROTOBUF_LIBRARIES:STRING=${protobuf_STATIC_LIBRARIES}
+          -DZLIB_ROOT:STRING=${ZLIB_INSTALL}
+  	-DgRPC_SSL_PROVIDER:STRING=${grpc_SSL_PROVIDER}
+  )
+  
+  # grpc/src/core/ext/census/tracing.c depends on the existence of openssl/rand.h.
+  ExternalProject_Add_Step(grpc copy_rand
+      COMMAND ${CMAKE_COMMAND} -E copy
+      ${CMAKE_SOURCE_DIR}/patches/grpc/rand.h ${GRPC_BUILD}/include/openssl/rand.h
+      DEPENDEES patch
+      DEPENDERS build
+  )
+endif (systemlib_GRPC)


### PR DESCRIPTION
This is still a work in progress, don't merge.

I'm trying to add a cmake option to build against `libgrpc++-dev` package provided by system, and the final goal of this PR is #720 . However I'm not sure whether it is working since it fails to build.

The build failure looks like this:
```
In file included from /dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:6:
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:105:19: error: 'RpcMethod' in namespace 'grpc' does not name a type
     const ::grpc::RpcMethod rpcmethod_SendEvents_;
                   ^~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:106:19: error: 'RpcMethod' in namespace 'grpc' does not name a type
     const ::grpc::RpcMethod rpcmethod_SendTracebacks_;
                   ^~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:107:19: error: 'RpcMethod' in namespace 'grpc' does not name a type
     const ::grpc::RpcMethod rpcmethod_SendSourceFiles_;
                   ^~~~~~~~~
[ 15%] Building CXX object CMakeFiles/tf_protos_cc.dir/tensorflow/core/protobuf/saver.pb.cc.o
[ 15%] Building CXX object CMakeFiles/tf_protos_cc.dir/tensorflow/core/protobuf/tensor_bundle.pb.cc.o
In file included from /dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:6:
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h: In constructor 'tensorflow::EventListener::WithStreamedUnaryMethod_SendTracebacks<BaseClass>::WithStreamedUnaryMethod_SendTracebacks()':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:247:21: error: 'StreamedUnaryHandler' in namespace 'grpc' does not name a template type
         new ::grpc::StreamedUnaryHandler< ::tensorflow::CallTraceback, ::tensorflow::EventReply>(std::bind(&WithStreamedUnaryMethod_SendTracebacks<BaseClass>::StreamedSendTracebacks, this, std::placeholders::_1, std::placeholders::_2)));
                     ^~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:247:70: error: expected primary-expression before ',' token
         new ::grpc::StreamedUnaryHandler< ::tensorflow::CallTraceback, ::tensorflow::EventReply>(std::bind(&WithStreamedUnaryMethod_SendTracebacks<BaseClass>::StreamedSendTracebacks, this, std::placeholders::_1, std::placeholders::_2)));
                                                                      ^
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:247:96: error: expected primary-expression before '>' token
         new ::grpc::StreamedUnaryHandler< ::tensorflow::CallTraceback, ::tensorflow::EventReply>(std::bind(&WithStreamedUnaryMethod_SendTracebacks<BaseClass>::StreamedSendTracebacks, this, std::placeholders::_1, std::placeholders::_2)));
                                                                                                ^
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h: In constructor 'tensorflow::EventListener::WithStreamedUnaryMethod_SendSourceFiles<BaseClass>::WithStreamedUnaryMethod_SendSourceFiles()':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:267:21: error: 'StreamedUnaryHandler' in namespace 'grpc' does not name a template type
         new ::grpc::StreamedUnaryHandler< ::tensorflow::DebuggedSourceFiles, ::tensorflow::EventReply>(std::bind(&WithStreamedUnaryMethod_SendSourceFiles<BaseClass>::StreamedSendSourceFiles, this, std::placeholders::_1, std::placeholders::_2)));
                     ^~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:267:76: error: expected primary-expression before ',' token
         new ::grpc::StreamedUnaryHandler< ::tensorflow::DebuggedSourceFiles, ::tensorflow::EventReply>(std::bind(&WithStreamedUnaryMethod_SendSourceFiles<BaseClass>::StreamedSendSourceFiles, this, std::placeholders::_1, std::placeholders::_2)));
                                                                            ^
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:267:102: error: expected primary-expression before '>' token
         new ::grpc::StreamedUnaryHandler< ::tensorflow::DebuggedSourceFiles, ::tensorflow::EventReply>(std::bind(&WithStreamedUnaryMethod_SendSourceFiles<BaseClass>::StreamedSendSourceFiles, this, std::placeholders::_1, std::placeholders::_2)));
                                                                                                      ^
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc: In constructor 'tensorflow::EventListener::Stub::Stub(const std::shared_ptr<grpc::ChannelInterface>&)':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:30:24: error: class 'tensorflow::EventListener::Stub' does not have any field named 'rpcmethod_SendEvents_'
   : channel_(channel), rpcmethod_SendEvents_(EventListener_method_names[0], ::grpc::RpcMethod::BIDI_STREAMING, channel)
                        ^~~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:30:85: error: 'grpc::RpcMethod' has not been declared
   : channel_(channel), rpcmethod_SendEvents_(EventListener_method_names[0], ::grpc::RpcMethod::BIDI_STREAMING, channel)
                                                                                     ^~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:31:5: error: class 'tensorflow::EventListener::Stub' does not have any field named 'rpcmethod_SendTracebacks_'
   , rpcmethod_SendTracebacks_(EventListener_method_names[1], ::grpc::RpcMethod::NORMAL_RPC, channel)
     ^~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:31:70: error: 'grpc::RpcMethod' has not been declared
   , rpcmethod_SendTracebacks_(EventListener_method_names[1], ::grpc::RpcMethod::NORMAL_RPC, channel)
                                                                      ^~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:32:5: error: class 'tensorflow::EventListener::Stub' does not have any field named 'rpcmethod_SendSourceFiles_'
   , rpcmethod_SendSourceFiles_(EventListener_method_names[2], ::grpc::RpcMethod::NORMAL_RPC, channel)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:32:71: error: 'grpc::RpcMethod' has not been declared
   , rpcmethod_SendSourceFiles_(EventListener_method_names[2], ::grpc::RpcMethod::NORMAL_RPC, channel)
                                                                       ^~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc: In member function 'virtual grpc::ClientReaderWriter<tensorflow::Event, tensorflow::EventReply>* tensorflow::EventListener::Stub::SendEventsRaw(grpc::ClientContext*)':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:36:105: error: 'rpcmethod_SendEvents_' was not declared in this scope
   return new ::grpc::ClientReaderWriter< ::tensorflow::Event, ::tensorflow::EventReply>(channel_.get(), rpcmethod_SendEvents_, context);
                                                                                                         ^~~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:36:105: note: suggested alternative: 'WithAsyncMethod_SendEvents'
   return new ::grpc::ClientReaderWriter< ::tensorflow::Event, ::tensorflow::EventReply>(channel_.get(), rpcmethod_SendEvents_, context);
                                                                                                         ^~~~~~~~~~~~~~~~~~~~~
                                                                                                         WithAsyncMethod_SendEvents
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc: In member function 'virtual grpc::ClientAsyncReaderWriter<tensorflow::Event, tensorflow::EventReply>* tensorflow::EventListener::Stub::AsyncSendEventsRaw(grpc::ClientContext*, grpc::CompletionQueue*, void*)':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:40:114: error: 'rpcmethod_SendEvents_' was not declared in this scope
   return new ::grpc::ClientAsyncReaderWriter< ::tensorflow::Event, ::tensorflow::EventReply>(channel_.get(), cq, rpcmethod_SendEvents_, context, tag);
                                                                                                                  ^~~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:40:114: note: suggested alternative: 'WithAsyncMethod_SendEvents'
   return new ::grpc::ClientAsyncReaderWriter< ::tensorflow::Event, ::tensorflow::EventReply>(channel_.get(), cq, rpcmethod_SendEvents_, context, tag);
                                                                                                                  ^~~~~~~~~~~~~~~~~~~~~
                                                                                                                  WithAsyncMethod_SendEvents
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc: In member function 'virtual grpc::Status tensorflow::EventListener::Stub::SendTracebacks(grpc::ClientContext*, const tensorflow::CallTraceback&, tensorflow::EventReply*)':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:44:18: error: 'BlockingUnaryCall' is not a member of 'grpc'
   return ::grpc::BlockingUnaryCall(channel_.get(), rpcmethod_SendTracebacks_, context, request, response);
                  ^~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:44:18: note: suggested alternative:
In file included from /usr/include/grpc++/impl/codegen/client_unary_call.h:26,
                 from /dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:11:
/usr/include/grpcpp/impl/codegen/client_unary_call.h:38:8: note:   'grpc::internal::BlockingUnaryCall'
 Status BlockingUnaryCall(ChannelInterface* channel, const RpcMethod& method,
        ^~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:44:52: error: 'rpcmethod_SendTracebacks_' was not declared in this scope
   return ::grpc::BlockingUnaryCall(channel_.get(), rpcmethod_SendTracebacks_, context, request, response);
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:44:52: note: suggested alternative: 'WithAsyncMethod_SendTracebacks'
   return ::grpc::BlockingUnaryCall(channel_.get(), rpcmethod_SendTracebacks_, context, request, response);
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
                                                    WithAsyncMethod_SendTracebacks
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc: In member function 'virtual grpc::ClientAsyncResponseReader<tensorflow::EventReply>* tensorflow::EventListener::Stub::AsyncSendTracebacksRaw(grpc::ClientContext*, const tensorflow::CallTraceback&, grpc::CompletionQueue*)':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:48:95: error: 'rpcmethod_SendTracebacks_' was not declared in this scope
   return new ::grpc::ClientAsyncResponseReader< ::tensorflow::EventReply>(channel_.get(), cq, rpcmethod_SendTracebacks_, context, request);
                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:48:95: note: suggested alternative: 'WithAsyncMethod_SendTracebacks'
   return new ::grpc::ClientAsyncResponseReader< ::tensorflow::EventReply>(channel_.get(), cq, rpcmethod_SendTracebacks_, context, request);
                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                               WithAsyncMethod_SendTracebacks
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:48:138: error: 'static void* grpc::ClientAsyncResponseReader<R>::operator new(std::size_t) [with R = tensorflow::EventReply; std::size_t = long unsigned int]' is private within this context
   return new ::grpc::ClientAsyncResponseReader< ::tensorflow::EventReply>(channel_.get(), cq, rpcmethod_SendTracebacks_, context, request);
                                                                                                                                          ^
In file included from /usr/include/grpc++/impl/codegen/async_unary_call.h:26,
                 from /dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:26,
                 from /dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:6:
/usr/include/grpcpp/impl/codegen/async_unary_call.h:182:16: note: declared private here
   static void* operator new(std::size_t size);
                ^~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc: In member function 'virtual grpc::Status tensorflow::EventListener::Stub::SendSourceFiles(grpc::ClientContext*, const tensorflow::DebuggedSourceFiles&, tensorflow::EventReply*)':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:52:18: error: 'BlockingUnaryCall' is not a member of 'grpc'
   return ::grpc::BlockingUnaryCall(channel_.get(), rpcmethod_SendSourceFiles_, context, request, response);
                  ^~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:52:18: note: suggested alternative:
In file included from /usr/include/grpc++/impl/codegen/client_unary_call.h:26,
                 from /dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:11:
/usr/include/grpcpp/impl/codegen/client_unary_call.h:38:8: note:   'grpc::internal::BlockingUnaryCall'
 Status BlockingUnaryCall(ChannelInterface* channel, const RpcMethod& method,
        ^~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:52:52: error: 'rpcmethod_SendSourceFiles_' was not declared in this scope
   return ::grpc::BlockingUnaryCall(channel_.get(), rpcmethod_SendSourceFiles_, context, request, response);
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:52:52: note: suggested alternative: 'WithAsyncMethod_SendSourceFiles'
   return ::grpc::BlockingUnaryCall(channel_.get(), rpcmethod_SendSourceFiles_, context, request, response);
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
                                                    WithAsyncMethod_SendSourceFiles
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc: In member function 'virtual grpc::ClientAsyncResponseReader<tensorflow::EventReply>* tensorflow::EventListener::Stub::AsyncSendSourceFilesRaw(grpc::ClientContext*, const tensorflow::DebuggedSourceFiles&, grpc::CompletionQueue*)':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:56:95: error: 'rpcmethod_SendSourceFiles_' was not declared in this scope
   return new ::grpc::ClientAsyncResponseReader< ::tensorflow::EventReply>(channel_.get(), cq, rpcmethod_SendSourceFiles_, context, request);
                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:56:95: note: suggested alternative: 'WithAsyncMethod_SendSourceFiles'
   return new ::grpc::ClientAsyncResponseReader< ::tensorflow::EventReply>(channel_.get(), cq, rpcmethod_SendSourceFiles_, context, request);
                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                               WithAsyncMethod_SendSourceFiles
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:56:139: error: 'static void* grpc::ClientAsyncResponseReader<R>::operator new(std::size_t) [with R = tensorflow::EventReply; std::size_t = long unsigned int]' is private within this context
   return new ::grpc::ClientAsyncResponseReader< ::tensorflow::EventReply>(channel_.get(), cq, rpcmethod_SendSourceFiles_, context, request);
                                                                                                                                           ^
In file included from /usr/include/grpc++/impl/codegen/async_unary_call.h:26,
                 from /dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.h:26,
                 from /dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:6:
/usr/include/grpcpp/impl/codegen/async_unary_call.h:182:16: note: declared private here
   static void* operator new(std::size_t size);
                ^~~~~~~~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc: In constructor 'tensorflow::EventListener::Service::Service()':
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:60:17: error: expected type-specifier before '::' token
   AddMethod(new ::grpc::RpcServiceMethod(
                 ^~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:65:17: error: expected type-specifier before '::' token
   AddMethod(new ::grpc::RpcServiceMethod(
                 ^~
/dev/shm/tensorflow.orig/tensorflow/contrib/cmake/build/tensorflow/core/debug/debug_service.grpc.pb.cc:70:17: error: expected type-specifier before '::' token
   AddMethod(new ::grpc::RpcServiceMethod(
                 ^~
```

Building with 88e560d6fadc1cf23519b00a9de5ed7c973536fd on Debian unstable, libgrpc++-dev version is `1.13.0-1`

flags:
```
cmake .. -DCMAKE_BUILD_TYPE=Release \
			 -Dtensorflow_VERBOSE=OFF \
			 -Dtensorflow_ENABLE_SSL_SUPPORT=ON \
			 -Dtensorflow_ENABLE_GRPC_SUPPORT=ON \
			 -Dtensorflow_ENABLE_HDFS_SUPPORT=OFF \
			 -Dtensorflow_ENABLE_JEMALLOC_SUPPORT=OFF \
			 -Dtensorflow_BUILD_CC_EXAMPLE=ON \
			 -Dtensorflow_BUILD_PYTHON_BINDINGS=OFF \
			 -Dtensorflow_BUILD_ALL_KERNELS=ON \
			 -Dtensorflow_BUILD_CONTRIB_KERNELS=ON \
			 -Dtensorflow_BUILD_CC_TESTS=OFF \
			 -Dtensorflow_BUILD_PYTHON_TESTS=OFF \
			 -Dtensorflow_BUILD_MORE_PYTHON_TESTS=OFF \
			 -Dtensorflow_BUILD_SHARED_LIB=ON \
			 -Dtensorflow_OPTIMIZE_FOR_NATIVE_ARCH=OFF \
			 -Dtensorflow_ENABLE_SNAPPY_SUPPORT=ON \
			 -Dtensorflow_DISABLE_EIGEN_FORCEINLINE=OFF \
			 -Dtensorflow_WIN_CPU_SIMD_OPTIONS=OFF \
			 -Dtensorflow_ENABLE_MKL_SUPPORT=OFF \
			 -Dtensorflow_ENABLE_MKLDNN_SUPPORT=OFF \
			 -Dtensorflow_ENABLE_GPU=OFF \
			 -Dtensorflow_ENABLE_POSITION_INDEPENDENT_CODE=ON \
			 -Dsystemlib_ZLIB=ON \
			 -Dsystemlib_GRPC=ON \
			 -DPYTHON_EXECUTABLE=/usr/bin/python3
```