### PR TITLE
[BugFix] Fixes #20983 - Store py_func dtypes for correct conversion

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -428,7 +428,7 @@ class Dataset(object):
         ret_arrays = []
         for ret, dtype in zip(flattened_values, flattened_types):
           try:
-            ret_arrays.append(script_ops.FuncRegistry._convert(  # pylint: disable=protected-access
+            ret_arrays.append(script_ops.PythonFunc._convert(  # pylint: disable=protected-access
                 ret, dtype=dtype.as_numpy_dtype))
           except (TypeError, ValueError):
             raise TypeError(

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -148,6 +148,17 @@ class PyFuncTest(test.TestCase):
           script_ops.py_func(list_func, [x], [dtypes.float64] * 2))
       self.assertAllClose(y, [0.0, 1.0])
 
+  def testConvertEmptyList(self):
+    with self.test_session():
+
+      def empty_list_func(args):
+        return [],
+
+      x = constant_op.constant(0, dtypes.int64)
+      y = self.evaluate(
+          script_ops.py_func(empty_list_func, [x], dtypes.int64))
+      self.assertAllClose(y, [])
+
   def testTuple(self):
     # returns a tuple
     with self.test_session():
@@ -452,7 +463,7 @@ class PyFuncTest(test.TestCase):
           # (see #18292)
           _ = script_ops.py_func(lambda x: x + c.shape[0], [c], [dtypes.float32])
           _ = script_ops.eager_py_func(lambda x: x + c.shape[0], [c], [dtypes.float32])
- 
+
     # Call garbage collector to enforce deletion.
     make_graphs()
     ops.reset_default_graph()

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -283,21 +283,6 @@ class PyFuncTest(test.TestCase):
       z, = script_ops.py_func(unicode_string, [], [dtypes.string])
       self.assertEqual(z.eval(), correct.encode("utf8"))
 
-  # TODO: This will no longer raise an exception since the byte-array
-  #       will be converted into a float32 type.  Is this not as desired?
-  # def testBadNumpyReturnType(self):
-  #   with self.test_session():
-  #
-  #     def bad():
-  #       # Structured numpy arrays aren't supported.
-  #       return np.array([], dtype=[("foo", np.float32)])
-  #
-  #     y, = script_ops.py_func(bad, [], [dtypes.float32])
-  #
-  #     with self.assertRaisesRegexp(errors.UnimplementedError,
-  #                                  "Unsupported numpy type"):
-  #       y.eval()
-
   def testBadReturnType(self):
     with self.test_session():
 

--- a/tensorflow/python/ops/script_ops.py
+++ b/tensorflow/python/ops/script_ops.py
@@ -175,7 +175,11 @@ class PythonFunc(object):
           self._convert(x, dtype=dtype.as_numpy_dtype)
           for (x, dtype) in zip(ret, self._out_dtypes)
       ]
-    return self._convert(ret)  # TODO: pass self._out_dtypes?
+
+    dtype = None
+    if isinstance(self._out_dtypes, (tuple, list)) and self._out_dtypes:
+      dtype = self._out_dtypes[0].as_numpy_dtype
+    return self._convert(ret, dtype)
 
 
 class FuncRegistry(object):


### PR DESCRIPTION
1.  Implement wrapper class `PythonFunc` to store Tout list
    for appropriate dtype conversion from tensorflow types to
    numpy types using the `dtype.as_numpy_dtype` member.
2.  Add py_func_test to illustrate broken behavior (see
    `testConvertEmptyList`). 