### PR TITLE
Multiplicative LSTM Cell

### DIFF
--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -1702,7 +1702,39 @@ class MLSTMCellTest(test.TestCase):
     return actual_state_c, actual_state_h
 
   def testMLSTMCellWithoutNorm(self):
-    """"""
+    """Check the states of the MLSTMCell with weight_normalization=False
+
+    The following code calculates a forward pass of the MLSTM Cell with
+    weight_normalization=False in numpy, this is equivalent to a forward
+    pass using the MLSTM Cell:
+
+    def sigmoid(x):
+        return 1.0/(1.0 + np.exp(-x))
+
+    x = np.array([[1., 1.]])
+    c0 = 0.1 * np.asarray([[0, 1]])
+    h0 = 0.1 * np.asarray([[2, 3]])
+
+    # all weights and biases are 0.5
+    b = 0.5
+    w = np.asarray([[0.5,0.5],[0.5,0.5]])
+
+    m = x.dot(w) * h0.dot(w)
+
+    h = x.dot(w) + m.dot(w)+ b
+    i = x.dot(w) + m.dot(w)+ b
+    o = x.dot(w) + m.dot(w)+ b
+    f = x.dot(w) + m.dot(w)+ b
+
+    h = np.tanh(h)
+    i = sigmoid(i)
+    o = sigmoid(o)
+    f = sigmoid(f)
+
+    c_new = (f*c0) + (i*h)
+    h_new = np.tanh(c_new) * o
+
+    """
 
     def cell():
       return contrib_rnn_cell.MLSTMCell(2,weight_normalization=False)
@@ -1717,10 +1749,47 @@ class MLSTMCellTest(test.TestCase):
 
 
   def testMLSTMCellWithNorm(self):
-    """"""
+    """Check the states of the MLSTMCell with weight_normalization=True
+
+      The following code calculates a forward pass of the MLSTM Cell with
+      weight_normalization=True in numpy, this is equivalent to a forward
+      pass using the MLSTM Cell:
+
+      def sigmoid(x):
+          return 1.0/(1.0 + np.exp(-x))
+
+      x = np.array([[1., 1.]])
+      c0 = 0.1 * np.asarray([[0, 1]])
+      h0 = 0.1 * np.asarray([[2, 3]])
+
+      weight_normalization=True
+      w = np.asarray([[0.5,0.5],[0.5,0.5]])
+      b = 0.5
+
+      if weight_normalization is True:
+        g = np.asarray([0.5,0.5])
+        n = np.linalg.norm(w, axis=0)
+        w = (w/n) * g
+
+      m = x.dot(w) * h0.dot(w)
+
+      h = x.dot(w) + m.dot(w)+ b
+      i = x.dot(w) + m.dot(w)+ b
+      o = x.dot(w) + m.dot(w)+ b
+      f = x.dot(w) + m.dot(w)+ b
+
+      h = np.tanh(h)
+      i = sigmoid(i)
+      o = sigmoid(o)
+      f = sigmoid(f)
+
+      c_new = (f*c0) + (i*h)
+      h_new = np.tanh(c_new) * o
+
+    """
 
     def cell():
-      return contrib_rnn_cell.MLSTMCell(2,weight_normalization=True)
+      return contrib_rnn_cell.MLSTMCell(2, weight_normalization=True)
 
     actual_c, actual_h = self._cell_output(cell)
 

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -42,6 +42,7 @@ from tensorflow.python.ops import rnn_cell_impl
 from tensorflow.python.ops import variable_scope as vs
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import nest
+from tensorflow.python.keras.utils import tf_utils
 
 
 def _get_concat_variable(name, shape, dtype, num_shards):
@@ -3462,6 +3463,7 @@ class MLSTMCell(rnn_cell_impl.LayerRNNCell):
   def output_size(self):
     return self._num_units
 
+  @tf_utils.shape_type_conversion
   def build(self, inputs_shape):
     if inputs_shape[1].value is None:
       raise ValueError("Expected inputs.shape[1] to be known, saw shape: %s"

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -3465,11 +3465,11 @@ class MLSTMCell(rnn_cell_impl.LayerRNNCell):
 
   @tf_utils.shape_type_conversion
   def build(self, inputs_shape):
-    if inputs_shape[1].value is None:
+    if inputs_shape[1] is None:
       raise ValueError("Expected inputs.shape[1] to be known, saw shape: %s"
                        % inputs_shape)
 
-    input_depth = inputs_shape[1].value
+    input_depth = inputs_shape[1]
     h_depth = self._num_units
     self._wx_kernel = self.add_variable(
         "wx/%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -3435,7 +3435,7 @@ class MLSTMCell(rnn_cell_impl.LayerRNNCell):
         cases.
       kernel_initializer: (optional) The initializer to use for the weights,
       default is glorot_uniform_initializer().
-      bias_initializer: (optional) The initializer to use for the bias, default 
+      bias_initializer: (optional) The initializer to use for the bias, default
       is glorot_uniform_initializer().
       weight_normalization: When set to True, weight normalization is applied to
       the model weights (but not the biases). Default: True
@@ -3464,7 +3464,7 @@ class MLSTMCell(rnn_cell_impl.LayerRNNCell):
 
   def build(self, inputs_shape):
     if inputs_shape[1].value is None:
-      raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
+      raise ValueError("Expected inputs.shape[1] to be known, saw shape: %s"
                        % inputs_shape)
 
     input_depth = inputs_shape[1].value

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -3417,7 +3417,8 @@ class MLSTMCell(rnn_cell_impl.LayerRNNCell):
                bias_initializer=None,
                weight_normalization=True,
                reuse=None,
-               name=None):
+               name=None
+               **kwargs):
 
     """Initialize the Mulitiplicative LSTM (MLSTM) cell.
 

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -3393,8 +3393,6 @@ class IndyLSTMCell(rnn_cell_impl.LayerRNNCell):
     new_state = rnn_cell_impl.LSTMStateTuple(new_c, new_h)
     return new_h, new_state
 
-_BIAS_VARIABLE_NAME = "bias"
-_WEIGHTS_VARIABLE_NAME = "kernel"
 
 class MLSTMCell(rnn_cell_impl.LayerRNNCell):
   """Mulitiplicative LSTM Cell (MLSTM)
@@ -3469,41 +3467,41 @@ class MLSTMCell(rnn_cell_impl.LayerRNNCell):
     input_depth = inputs_shape[1].value
     h_depth = self._num_units
     self._wx_kernel = self.add_variable(
-        "wx/%s" % _WEIGHTS_VARIABLE_NAME,
+        "wx/%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
         shape=[input_depth, 4 * h_depth],
         initializer=self._kernel_initializer)
     self._wh_kernel = self.add_variable(
-        "wh/%s" % _WEIGHTS_VARIABLE_NAME,
+        "wh/%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
         shape=[h_depth, 4 * h_depth],
         initializer=self._kernel_initializer)
     self._wmx_kernel = self.add_variable(
-        "wmx/%s" % _WEIGHTS_VARIABLE_NAME,
+        "wmx/%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
         shape=[input_depth, h_depth],
         initializer=self._kernel_initializer)
     self._wmh_kernel = self.add_variable(
-        "wmh/%s" % _WEIGHTS_VARIABLE_NAME,
+        "wmh/%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
         shape=[h_depth, h_depth],
         initializer=self._kernel_initializer)
     self.bias = self.add_variable(
-        "b/%s" % _BIAS_VARIABLE_NAME,
+        "b/%s" % rnn_cell_impl._BIAS_VARIABLE_NAME,
         shape=[4 * h_depth],
         initializer=self._bias_initializer)
 
     if self._weight_normalization is True:
       self._gx_kernel = self.add_variable(
-          "gx/%s" % _WEIGHTS_VARIABLE_NAME,
+          "gx/%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
           shape=[4 * h_depth],
           initializer=self._kernel_initializer)
       self._gh_kernel = self.add_variable(
-          "gh/%s" % _WEIGHTS_VARIABLE_NAME,
+          "gh/%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
           shape=[4 * h_depth],
           initializer=self._kernel_initializer)
       self._gmx_kernel = self.add_variable(
-          "gmx/%s" % _WEIGHTS_VARIABLE_NAME,
+          "gmx/%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
           shape=[h_depth],
           initializer=self._kernel_initializer)
       self._gmh_kernel = self.add_variable(
-          "gmh/%s" % _WEIGHTS_VARIABLE_NAME,
+          "gmh/%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
           shape=[h_depth],
           initializer=self._kernel_initializer)
       self._wx_kernel = (nn_impl.l2_normalize(self._wx_kernel, axis=0)

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -3418,7 +3418,7 @@ class MLSTMCell(rnn_cell_impl.LayerRNNCell):
                bias_initializer=None,
                weight_normalization=True,
                reuse=None,
-               name=None
+               name=None,
                **kwargs):
 
     """Initialize the Mulitiplicative LSTM (MLSTM) cell.

--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -3433,8 +3433,10 @@ class MLSTMCell(rnn_cell_impl.LayerRNNCell):
       name: String, the name of the layer. Layers with the same name will
         share weights, but to avoid mistakes we require reuse=True in such
         cases.
-      kernel_initializer: (optional) The initializer to use for the weights
-      bias_initializer: (optional) The initializer to use for the bias.
+      kernel_initializer: (optional) The initializer to use for the weights,
+      default is glorot_uniform_initializer().
+      bias_initializer: (optional) The initializer to use for the bias, default 
+      is glorot_uniform_initializer().
       weight_normalization: When set to True, weight normalization is applied to
       the model weights (but not the biases). Default: True
     """


### PR DESCRIPTION
Added Multiplicative LSTM cell based on:
https://arxiv.org/pdf/1609.07959.pdf

The cell also has the option to implement weight normalization, based on:
https://arxiv.org/abs/1602.07868

The Multiplicative LSTM with weight normalization is used is this paper by OpenAI:
https://arxiv.org/pdf/1704.01444.pdf

I have also tested the MLSTMCell as a drop in replacement for the BasicLSTMCell in models/tutorials/rnn/ptb/ptb_word_lm.py, and achieved comparable results. 