### PR TITLE
Templates DataTypeToEnum and associated structs on type properties

### DIFF
--- a/tensorflow/core/framework/types.h
+++ b/tensorflow/core/framework/types.h
@@ -346,68 +346,397 @@ inline DataTypeSet RealAndQuantizedTypes() { return kRealAndQuantizedTypes; }
 #endif  // defined(IS_MOBILE_PLATFORM)
 
 // Validates type T for whether it is a supported DataType.
+template <class T, typename T2 = void>
+struct IsValidDataType {
+  static constexpr bool value = false;
+};
+
+template <>
+struct IsValidDataType<string> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<complex64> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<complex128> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<bool> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<Eigen::half> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<bfloat16> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<ResourceHandle> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<Variant> {
+  static constexpr bool value = true;
+};
+
 template <class T>
-struct IsValidDataType;
+struct IsValidDataType<
+    T, typename std::enable_if<std::is_floating_point<T>::value &&
+                               (sizeof(T) == 4)>::type> {
+  static constexpr bool value = true;
+};
+template <class T>
+struct IsValidDataType<
+    T, typename std::enable_if<std::is_floating_point<T>::value &&
+                               (sizeof(T) == 8)>::type> {
+  static constexpr bool value = true;
+};
+
+template <class T>
+struct IsValidDataType<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                  std::is_signed<T>::value &&
+                                                  (sizeof(T) == 1)>::type> {
+  static constexpr bool value = true;
+};
+template <class T>
+struct IsValidDataType<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                  std::is_signed<T>::value &&
+                                                  (sizeof(T) == 2)>::type> {
+  static constexpr bool value = true;
+};
+template <class T>
+struct IsValidDataType<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                  std::is_signed<T>::value &&
+                                                  (sizeof(T) == 4)>::type> {
+  static constexpr bool value = true;
+};
+template <class T>
+struct IsValidDataType<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                  std::is_signed<T>::value &&
+                                                  (sizeof(T) == 8)>::type> {
+  static constexpr bool value = true;
+};
+
+template <class T>
+struct IsValidDataType<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                  !std::is_signed<T>::value &&
+                                                  (sizeof(T) == 1)>::type> {
+  static constexpr bool value = true;
+};
+template <class T>
+struct IsValidDataType<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                  !std::is_signed<T>::value &&
+                                                  (sizeof(T) == 2)>::type> {
+  static constexpr bool value = true;
+};
+template <class T>
+struct IsValidDataType<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                  !std::is_signed<T>::value &&
+                                                  (sizeof(T) == 4)>::type> {
+  static constexpr bool value = true;
+};
+template <class T>
+struct IsValidDataType<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                  !std::is_signed<T>::value &&
+                                                  (sizeof(T) == 8)>::type> {
+  static constexpr bool value = true;
+};
+
+template <>
+struct IsValidDataType<qint8> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<qint16> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<qint32> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<quint8> {
+  static constexpr bool value = true;
+};
+template <>
+struct IsValidDataType<quint16> {
+  static constexpr bool value = true;
+};
 
 // DataTypeToEnum<T>::v() and DataTypeToEnum<T>::value are the DataType
 // constants for T, e.g. DataTypeToEnum<float>::v() is DT_FLOAT.
-template <class T>
+template <class T, typename T2 = void>
 struct DataTypeToEnum {
   static_assert(IsValidDataType<T>::value, "Specified Data Type not supported");
 };  // Specializations below
 
+template <>
+struct DataTypeToEnum<string> {
+  static DataType v() { return DT_STRING; }
+  static DataType ref() { return MakeRefType(DT_STRING); }
+  static constexpr DataType value = DT_STRING;
+};
+template <>
+struct DataTypeToEnum<complex64> {
+  static DataType v() { return DT_COMPLEX64; }
+  static DataType ref() { return MakeRefType(DT_COMPLEX64); }
+  static constexpr DataType value = DT_COMPLEX64;
+};
+template <>
+struct DataTypeToEnum<complex128> {
+  static DataType v() { return DT_COMPLEX128; }
+  static DataType ref() { return MakeRefType(DT_COMPLEX128); }
+  static constexpr DataType value = DT_COMPLEX128;
+};
+template <>
+struct DataTypeToEnum<bool> {
+  static DataType v() { return DT_BOOL; }
+  static DataType ref() { return MakeRefType(DT_BOOL); }
+  static constexpr DataType value = DT_BOOL;
+};
+template <>
+struct DataTypeToEnum<Eigen::half> {
+  static DataType v() { return DT_HALF; }
+  static DataType ref() { return MakeRefType(DT_HALF); }
+  static constexpr DataType value = DT_HALF;
+};
+template <>
+struct DataTypeToEnum<bfloat16> {
+  static DataType v() { return DT_BFLOAT16; }
+  static DataType ref() { return MakeRefType(DT_BFLOAT16); }
+  static constexpr DataType value = DT_BFLOAT16;
+};
+template <>
+struct DataTypeToEnum<ResourceHandle> {
+  static DataType v() { return DT_RESOURCE; }
+  static DataType ref() { return MakeRefType(DT_RESOURCE); }
+  static constexpr DataType value = DT_RESOURCE;
+};
+template <>
+struct DataTypeToEnum<Variant> {
+  static DataType v() { return DT_VARIANT; }
+  static DataType ref() { return MakeRefType(DT_VARIANT); }
+  static constexpr DataType value = DT_VARIANT;
+};
+
+template <class T>
+struct DataTypeToEnum<
+    T, typename std::enable_if<std::is_floating_point<T>::value &&
+                               (sizeof(T) == 4)>::type> {
+  static DataType v() { return DT_FLOAT; }
+  static DataType ref() { return MakeRefType(DT_FLOAT); }
+  static constexpr DataType value = DT_FLOAT;
+};
+template <class T>
+struct DataTypeToEnum<
+    T, typename std::enable_if<std::is_floating_point<T>::value &&
+                               (sizeof(T) == 8)>::type> {
+  static DataType v() { return DT_DOUBLE; }
+  static DataType ref() { return MakeRefType(DT_DOUBLE); }
+  static constexpr DataType value = DT_DOUBLE;
+};
+
+template <class T>
+struct DataTypeToEnum<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                 std::is_signed<T>::value &&
+                                                 (sizeof(T) == 1)>::type> {
+  static DataType v() { return DT_INT8; }
+  static DataType ref() { return MakeRefType(DT_INT8); }
+  static constexpr DataType value = DT_INT8;
+};
+template <class T>
+struct DataTypeToEnum<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                 std::is_signed<T>::value &&
+                                                 (sizeof(T) == 2)>::type> {
+  static DataType v() { return DT_INT16; }
+  static DataType ref() { return MakeRefType(DT_INT16); }
+  static constexpr DataType value = DT_INT16;
+};
+template <class T>
+struct DataTypeToEnum<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                 std::is_signed<T>::value &&
+                                                 (sizeof(T) == 4)>::type> {
+  static DataType v() { return DT_INT32; }
+  static DataType ref() { return MakeRefType(DT_INT32); }
+  static constexpr DataType value = DT_INT32;
+};
+template <class T>
+struct DataTypeToEnum<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                 std::is_signed<T>::value &&
+                                                 (sizeof(T) == 8)>::type> {
+  static DataType v() { return DT_INT64; }
+  static DataType ref() { return MakeRefType(DT_INT64); }
+  static constexpr DataType value = DT_INT64;
+};
+
+template <class T>
+struct DataTypeToEnum<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                 !std::is_signed<T>::value &&
+                                                 (sizeof(T) == 1)>::type> {
+  static DataType v() { return DT_UINT8; }
+  static DataType ref() { return MakeRefType(DT_UINT8); }
+  static constexpr DataType value = DT_UINT8;
+};
+template <class T>
+struct DataTypeToEnum<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                 !std::is_signed<T>::value &&
+                                                 (sizeof(T) == 2)>::type> {
+  static DataType v() { return DT_UINT16; }
+  static DataType ref() { return MakeRefType(DT_UINT16); }
+  static constexpr DataType value = DT_UINT16;
+};
+template <class T>
+struct DataTypeToEnum<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                 !std::is_signed<T>::value &&
+                                                 (sizeof(T) == 4)>::type> {
+  static DataType v() { return DT_UINT32; }
+  static DataType ref() { return MakeRefType(DT_UINT32); }
+  static constexpr DataType value = DT_UINT32;
+};
+template <class T>
+struct DataTypeToEnum<T, typename std::enable_if<std::is_integral<T>::value &&
+                                                 !std::is_signed<T>::value &&
+                                                 (sizeof(T) == 8)>::type> {
+  static DataType v() { return DT_UINT64; }
+  static DataType ref() { return MakeRefType(DT_UINT64); }
+  static constexpr DataType value = DT_UINT64;
+};
+
+template <>
+struct DataTypeToEnum<qint8> {
+  static DataType v() { return DT_QINT8; }
+  static DataType ref() { return MakeRefType(DT_QINT8); }
+  static constexpr DataType value = DT_QINT8;
+};
+template <>
+struct DataTypeToEnum<qint16> {
+  static DataType v() { return DT_QINT16; }
+  static DataType ref() { return MakeRefType(DT_QINT16); }
+  static constexpr DataType value = DT_QINT16;
+};
+template <>
+struct DataTypeToEnum<qint32> {
+  static DataType v() { return DT_QINT32; }
+  static DataType ref() { return MakeRefType(DT_QINT32); }
+  static constexpr DataType value = DT_QINT32;
+};
+template <>
+struct DataTypeToEnum<quint8> {
+  static DataType v() { return DT_QUINT8; }
+  static DataType ref() { return MakeRefType(DT_QUINT8); }
+  static constexpr DataType value = DT_QUINT8;
+};
+template <>
+struct DataTypeToEnum<quint16> {
+  static DataType v() { return DT_QUINT16; }
+  static DataType ref() { return MakeRefType(DT_QUINT16); }
+  static constexpr DataType value = DT_QUINT16;
+};
+
 // EnumToDataType<VALUE>::Type is the type for DataType constant VALUE, e.g.
 // EnumToDataType<DT_FLOAT>::Type is float.
 template <DataType VALUE>
-struct EnumToDataType {};  // Specializations below
+struct EnumToDataType;  // Specializations below
 
-// Template specialization for both DataTypeToEnum and EnumToDataType.
-#define MATCH_TYPE_AND_ENUM(TYPE, ENUM)                 \
-  template <>                                           \
-  struct DataTypeToEnum<TYPE> {                         \
-    static DataType v() { return ENUM; }                \
-    static DataType ref() { return MakeRefType(ENUM); } \
-    static constexpr DataType value = ENUM;             \
-  };                                                    \
-  template <>                                           \
-  struct IsValidDataType<TYPE> {                        \
-    static constexpr bool value = true;                 \
-  };                                                    \
-  template <>                                           \
-  struct EnumToDataType<ENUM> {                         \
-    typedef TYPE Type;                                  \
-  }
+template <>
+struct EnumToDataType<DT_STRING> {
+  typedef string Type;
+};
+template <>
+struct EnumToDataType<DT_COMPLEX64> {
+  typedef complex64 Type;
+};
+template <>
+struct EnumToDataType<DT_COMPLEX128> {
+  typedef complex128 Type;
+};
+template <>
+struct EnumToDataType<DT_BOOL> {
+  typedef bool Type;
+};
+template <>
+struct EnumToDataType<DT_HALF> {
+  typedef Eigen::half Type;
+};
+template <>
+struct EnumToDataType<DT_BFLOAT16> {
+  typedef bfloat16 Type;
+};
+template <>
+struct EnumToDataType<DT_RESOURCE> {
+  typedef ResourceHandle Type;
+};
+template <>
+struct EnumToDataType<DT_VARIANT> {
+  typedef Variant Type;
+};
 
-MATCH_TYPE_AND_ENUM(float, DT_FLOAT);
-MATCH_TYPE_AND_ENUM(double, DT_DOUBLE);
-MATCH_TYPE_AND_ENUM(int32, DT_INT32);
-MATCH_TYPE_AND_ENUM(uint32, DT_UINT32);
-MATCH_TYPE_AND_ENUM(uint16, DT_UINT16);
-MATCH_TYPE_AND_ENUM(uint8, DT_UINT8);
-MATCH_TYPE_AND_ENUM(int16, DT_INT16);
-MATCH_TYPE_AND_ENUM(int8, DT_INT8);
-MATCH_TYPE_AND_ENUM(string, DT_STRING);
-MATCH_TYPE_AND_ENUM(complex64, DT_COMPLEX64);
-MATCH_TYPE_AND_ENUM(complex128, DT_COMPLEX128);
-MATCH_TYPE_AND_ENUM(int64, DT_INT64);
-MATCH_TYPE_AND_ENUM(uint64, DT_UINT64);
-MATCH_TYPE_AND_ENUM(bool, DT_BOOL);
-MATCH_TYPE_AND_ENUM(qint8, DT_QINT8);
-MATCH_TYPE_AND_ENUM(quint8, DT_QUINT8);
-MATCH_TYPE_AND_ENUM(qint16, DT_QINT16);
-MATCH_TYPE_AND_ENUM(quint16, DT_QUINT16);
-MATCH_TYPE_AND_ENUM(qint32, DT_QINT32);
-MATCH_TYPE_AND_ENUM(bfloat16, DT_BFLOAT16);
-MATCH_TYPE_AND_ENUM(Eigen::half, DT_HALF);
-MATCH_TYPE_AND_ENUM(ResourceHandle, DT_RESOURCE);
-MATCH_TYPE_AND_ENUM(Variant, DT_VARIANT);
+template <>
+struct EnumToDataType<DT_FLOAT> {
+  typedef float Type;
+};
+template <>
+struct EnumToDataType<DT_DOUBLE> {
+  typedef double Type;
+};
 
-#undef MATCH_TYPE_AND_ENUM
+template <>
+struct EnumToDataType<DT_INT8> {
+  typedef int8 Type;
+};
+template <>
+struct EnumToDataType<DT_INT16> {
+  typedef int16 Type;
+};
+template <>
+struct EnumToDataType<DT_INT32> {
+  typedef int32 Type;
+};
+template <>
+struct EnumToDataType<DT_INT64> {
+  typedef int64 Type;
+};
+template <>
+struct EnumToDataType<DT_UINT8> {
+  typedef uint8 Type;
+};
+template <>
+struct EnumToDataType<DT_UINT16> {
+  typedef uint16 Type;
+};
+template <>
+struct EnumToDataType<DT_UINT32> {
+  typedef uint32 Type;
+};
+template <>
+struct EnumToDataType<DT_UINT64> {
+  typedef uint64 Type;
+};
 
-// All types not specialized are marked invalid.
-template <class T>
-struct IsValidDataType {
-  static constexpr bool value = false;
+template <>
+struct EnumToDataType<DT_QINT8> {
+  typedef qint8 Type;
+};
+template <>
+struct EnumToDataType<DT_QINT16> {
+  typedef qint16 Type;
+};
+template <>
+struct EnumToDataType<DT_QINT32> {
+  typedef qint32 Type;
+};
+template <>
+struct EnumToDataType<DT_QUINT8> {
+  typedef quint8 Type;
+};
+template <>
+struct EnumToDataType<DT_QUINT16> {
+  typedef quint16 Type;
 };
 
 // Extra validity checking; not part of public API.


### PR DESCRIPTION
This PR addresses the bug outlined in #20586. Rather than relying on all systems to define the `int64` data type in a manner that is consistent with a `long long`, this PR inspects the properties of the type. For instance, `int64` is a `signed`, `integral` type with a size of `8 bytes`.

This is important as not all systems define the basic integral data types in the same way, but they are all defined to meet the same intrinsic properties. On the test system, `int64_t` is not equivalent to a `long long` (which is how the `int64` type is defined in `tensorflow/core/platform/default/integral_types.h`). However, both `long long` and `int64_t` meet the same intrinsic properties on the test system. The following code and output shows this inconsistency, where `int64_t != long long` from the perspective of gcc (Ubuntu 7.3.0-21ubuntu1~16.04) 7.3.0.

```
#include <cstdint>
#include <iostream>

int main(void) {
    std::cout << "int64_t...............: "
              << "(" << typeid(int64_t).name() << ") " << sizeof(int64_t) << std::endl;
    std::cout << "long..................: "
              << "(" << typeid(long).name() << ") " << sizeof(long) << std::endl;
    std::cout << "long int..............: "
              << "(" << typeid(long int).name() << ") " << sizeof(long int) << std::endl;
    std::cout << "long long int.........: "
              << "(" << typeid(long long int).name() << ") " << sizeof(long long int) << std::endl;
    std::cout << "long long.............: "
              << "(" << typeid(long long).name() << ") " << sizeof(long long) << std::endl;
    std::cout << "uint64_t..............: "
              << "(" << typeid(uint64_t).name() << ") " << sizeof(int64_t) << std::endl;
    std::cout << "unsigned long.........: "
              << "(" << typeid(unsigned long).name() << ") " << sizeof(unsigned long) << std::endl;
    std::cout << "unsigned long int.....: "
              << "(" << typeid(unsigned long int).name() << ") " << sizeof(unsigned long int) << std::endl;
    std::cout << "unsigned long long int: "
              << "(" << typeid(unsigned long long int).name() << ") " << sizeof(unsigned long long int) << std::endl;
    std::cout << "unsigned long long....: "
              << "(" << typeid(unsigned long long).name() << ") " << sizeof(unsigned long long) << std::endl;
    std::cout << "long long == int64_t? " << (std::is_same<long long, int64_t>::value ? "yes" : "no") << std::endl;
    std::cout << "(sizeof(long long) == 8) && std::is_signed<long long>::value? "
              << ((sizeof(long long) == 8) && std::is_signed<long long>::value ? "yes" : "no") << std::endl;
    std::cout << "(sizeof(int64_t) == 8) && std::is_signed<int64_t>::value? "
              << ((sizeof(int64_t) == 8) && std::is_signed<int64_t>::value ? "yes" : "no") << std::endl;
    std::cout << "unsigned long long == uint64_t? "
              << (std::is_same<unsigned long long, uint64_t>::value ? "yes" : "no") << std::endl;
    std::cout << "(sizeof(unsigned long long) == 8) && !std::is_signed<unsigned long long>::value? "
              << ((sizeof(unsigned long long) == 8) && !std::is_signed<unsigned long long>::value ? "yes" : "no")
              << std::endl;
    std::cout << "(sizeof(uint64_t) == 8) && !std::is_signed<uint64_t>::value? "
              << ((sizeof(uint64_t) == 8) && !std::is_signed<uint64_t>::value ? "yes" : "no") << std::endl;
    return 0;
}
```
```
int64_t...............: (l) 8
long..................: (l) 8
long int..............: (l) 8
long long int.........: (x) 8
long long.............: (x) 8
uint64_t..............: (m) 8
unsigned long.........: (m) 8
unsigned long int.....: (m) 8
unsigned long long int: (y) 8
unsigned long long....: (y) 8
long long == int64_t? no
(sizeof(long long) == 8) && std::is_signed<long long>::value? yes
(sizeof(int64_t) == 8) && std::is_signed<int64_t>::value? yes
unsigned long long == uint64_t? no
(sizeof(unsigned long long) == 8) && !std::is_signed<unsigned long long>::value? yes
(sizeof(uint64_t) == 8) && !std::is_signed<uint64_t>::value? yes
```


Note: `int64` is only used as an example here, this bug applies to other types as well, which this PR addresses.