### PR TITLE
Adding a callback function to improve flexibility of Keras

### DIFF
--- a/tensorflow/python/keras/preprocessing/image.py
+++ b/tensorflow/python/keras/preprocessing/image.py
@@ -1543,8 +1543,13 @@ class DirectoryIterator(Iterator):
 
     pool.close()
     pool.join()
+    self._batch_x_processor = None
+    self._batch_y_processor = None
     super(DirectoryIterator, self).__init__(self.samples, batch_size, shuffle,
                                             seed)
+  def register_batch_processor(self, batch_x_processor=None, batch_y_processor=None):
+    self._batch_x_processor = batch_x_processor
+    self._batch_y_processor = batch_y_processor
 
   def _get_batches_of_transformed_samples(self, index_array):
     batch_x = np.zeros((len(index_array),) + self.image_shape, dtype=K.floatx())
@@ -1584,6 +1589,10 @@ class DirectoryIterator(Iterator):
         batch_y[i, label] = 1.
     else:
       return batch_x
+    if self._batch_x_processor is not None:
+        batch_x = self._batch_x_processor(batch_x, self.filenames, index_array)
+    if self._batch_y_processor is not None:
+        batch_y = self._batch_y_processor(batch_y, self.filenames, index_array)
     return batch_x, batch_y
 
   def next(self):


### PR DESCRIPTION
Hello everyone, I added one member function in `DirectoryIterator` class allow developer to register callback functions when pumping data by `flow_from_directory` of `ImageDataGenerator` class. It's can improve flexibility when have complex data structure of feature and label. It's very useful to register a customize function to process their own logic to integrate the `batch_x` and `batch_y`. It can make the `DirectoryIterator` pump the data structure what the model required.

> example:

```
def process_train_batch_X(raw_x_batch, filenames, index_array):
    tmp_temperature = []
    tmp_time = []
    for i, j in enumerate(index_array):
        tmp_temperature.append(get_temp_from_str(filenames[j]))
        tmp_time.append(get_time_from_str(filenames[j]))
    # get discretization array from the filename
    x_batch_wet = utils.discretization(tmp_temperature)
    x_batch_time = utils.discretization(tmp_time)
    x_batch = [raw_x_batch, x_batch_wet, x_batch_time]
    return x_batch

def process_batch_Y(raw_x_batch, filenames, index_array):
    .....

train_iterator.register_batch_processor(process_train_batch_X, process_batch_Y)
```