### PR TITLE
Disable sdca test on all GPU builds.

### DIFF
--- a/tensorflow/contrib/linear_optimizer/BUILD
+++ b/tensorflow/contrib/linear_optimizer/BUILD
@@ -41,7 +41,10 @@ py_test(
     size = "medium",
     srcs = ["python/kernel_tests/sdca_ops_test.py"],
     srcs_version = "PY2AND3",
-    tags = ["no_windows_gpu"],
+    tags = [
+        "no_gpu",
+        "no_pip_gpu",
+    ],
     deps = [
         ":sdca_ops_py",
         ":sparse_feature_column_py",


### PR DESCRIPTION
This test uses ops that don't have GPU implementations.