### PR TITLE
add Kernel Inception Distance to tf.contrib.gan.eval

### DIFF
--- a/tensorflow/contrib/gan/README.md
+++ b/tensorflow/contrib/gan/README.md
@@ -47,7 +47,7 @@ Easily experiment with already-implemented and well-tested losses and penalties,
 such as the Wasserstein loss, gradient penalty, mutual information penalty, etc
 
 * [evaluation](https://www.tensorflow.org/code/tensorflow/contrib/gan/python/eval/python/):
-Use `Inception Score` or `Frechet Distance` with a pretrained Inception
+Use `Inception Score`, `Frechet Distance`, or `Kernel Distance` with a pretrained Inception
 network to evaluate your unconditional generative model. You can also use
 your own pretrained classifier for more specific performance numbers, or use
 other methods for evaluating conditional generative models.

--- a/tensorflow/contrib/gan/python/eval/python/classifier_metrics_impl.py
+++ b/tensorflow/contrib/gan/python/eval/python/classifier_metrics_impl.py
@@ -14,8 +14,8 @@
 # ==============================================================================
 """Model evaluation tools for TFGAN.
 
-These methods come from https://arxiv.org/abs/1606.03498 and
-https://arxiv.org/abs/1706.08500.
+These methods come from https://arxiv.org/abs/1606.03498,
+https://arxiv.org/abs/1706.08500, and https://arxiv.org/abs/1801.01401.
 
 NOTE: This implementation uses the same weights as in
 https://github.com/openai/improved-gan/blob/master/inception_score/model.py,
@@ -40,6 +40,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import importer
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import functional_ops
 from tensorflow.python.ops import image_ops
 from tensorflow.python.ops import linalg_ops
@@ -64,6 +65,12 @@ __all__ = [
     'frechet_classifier_distance_from_activations',
     'mean_only_frechet_classifier_distance_from_activations',
     'diagonal_only_frechet_classifier_distance_from_activations',
+    'kernel_inception_distance',
+    'kernel_inception_distance_and_std',
+    'kernel_classifier_distance',
+    'kernel_classifier_distance_and_std',
+    'kernel_classifier_distance_from_activations',
+    'kernel_classifier_distance_and_std_from_activations',
     'INCEPTION_DEFAULT_IMAGE_SIZE',
 ]
 
@@ -734,3 +741,372 @@ frechet_inception_distance = functools.partial(
     frechet_classifier_distance,
     classifier_fn=functools.partial(
         run_inception, output_tensor=INCEPTION_FINAL_POOL))
+
+
+def kernel_classifier_distance(real_images,
+                               generated_images,
+                               classifier_fn,
+                               num_classifier_batches=1,
+                               max_block_size=1024,
+                               dtype=None):
+  """Kernel "classifier" distance for evaluating a generative model.
+
+  This is based on the Kernel Inception distance, but for an arbitrary
+  embedding.
+
+  This technique is described in detail in https://arxiv.org/abs/1801.01401.
+  Given two distributions P and Q of activations, this function calculates
+
+      E_{X, X' ~ P}[k(X, X')] + E_{Y, Y' ~ Q}[k(Y, Y')]
+        - 2 E_{X ~ P, Y ~ Q}[k(X, Y)]
+
+  where k is the polynomial kernel
+
+      k(x, y) = ( x^T y / dimension + 1 )^3.
+
+  This captures how different the distributions of real and generated images'
+  visual features are. Like the Frechet distance (and unlike the Inception
+  score), this is a true distance and incorporates information about the
+  target images. Unlike the Frechet score, this function computes an
+  *unbiased* and asymptotically normal estimator, which makes comparing
+  estimates across models much more intuitive.
+
+  The estimator used takes time quadratic in max_block_size. Larger values of
+  max_block_size will decrease the variance of the estimator but increase the
+  computational cost. This differs slightly from the estimator used by the
+  original paper; it is the block estimator of https://arxiv.org/abs/1307.1954.
+
+  NOTE: the blocking code assumes that real_activations and
+  generated_activations are both in random order. If either is sorted in a
+  meaningful order, the estimator will behave poorly.
+
+  NOTE: This function consumes images, computes their activations, and then
+  computes the classifier score. If you would like to precompute many
+  activations for real and generated images for large batches, or to compute
+  multiple scores based on the same images, please use
+  kernel_clasifier_distance_from_activations(), which this method also uses.
+
+  Args:
+    real_images: Real images to use to compute Kernel Inception distance.
+    generated_images: Generated images to use to compute Kernel Inception
+      distance.
+    classifier_fn: A function that takes images and produces activations
+      based on a classifier.
+    num_classifier_batches: Number of batches to split images in to in order to
+      efficiently run them through the classifier network.
+    max_estimator_block_size: integer, default 1024. The distance estimator
+      splits samples into blocks for computational efficiency. Larger values
+      are more computationally expensive but decrease the variance of the
+      distance estimate.
+    dtype: if not None, coerce activations to this dtype before computations.
+
+  Returns:
+   The Kernel Inception Distance. A floating-point scalar of the same type
+   as the output of the activations.
+  """
+  return kernel_classifier_distance_and_std(
+      real_images, generated_images, classifier_fn,
+      num_classifier_batches=num_classifier_batches,
+      max_block_size=max_block_size,
+      dtype=dtype)[0]
+
+
+kernel_inception_distance = functools.partial(
+    kernel_classifier_distance,
+    classifier_fn=functools.partial(
+        run_inception, output_tensor=INCEPTION_FINAL_POOL))
+
+
+def kernel_classifier_distance_and_std(real_images,
+                                       generated_images,
+                                       classifier_fn,
+                                       num_classifier_batches=1,
+                                       max_block_size=1024,
+                                       dtype=None):
+  """Kernel "classifier" distance for evaluating a generative model.
+
+  This is based on the Kernel Inception distance, but for an arbitrary
+  embedding. Also returns an estimate of the standard error of the distance
+  estimator.
+
+  This technique is described in detail in https://arxiv.org/abs/1801.01401.
+  Given two distributions P and Q of activations, this function calculates
+
+      E_{X, X' ~ P}[k(X, X')] + E_{Y, Y' ~ Q}[k(Y, Y')]
+        - 2 E_{X ~ P, Y ~ Q}[k(X, Y)]
+
+  where k is the polynomial kernel
+
+      k(x, y) = ( x^T y / dimension + 1 )^3.
+
+  This captures how different the distributions of real and generated images'
+  visual features are. Like the Frechet distance (and unlike the Inception
+  score), this is a true distance and incorporates information about the
+  target images. Unlike the Frechet score, this function computes an
+  *unbiased* and asymptotically normal estimator, which makes comparing
+  estimates across models much more intuitive.
+
+  The estimator used takes time quadratic in max_block_size. Larger values of
+  max_block_size will decrease the variance of the estimator but increase the
+  computational cost. This differs slightly from the estimator used by the
+  original paper; it is the block estimator of https://arxiv.org/abs/1307.1954.
+
+  NOTE: the blocking code assumes that real_activations and
+  generated_activations are both in random order. If either is sorted in a
+  meaningful order, the estimator will behave poorly.
+
+  NOTE: This function consumes images, computes their activations, and then
+  computes the classifier score. If you would like to precompute many
+  activations for real and generated images for large batches, or to compute
+  multiple scores based on the same images, please use
+  kernel_clasifier_distance_from_activations(), which this method also uses.
+
+  Args:
+    real_images: Real images to use to compute Kernel Inception distance.
+    generated_images: Generated images to use to compute Kernel Inception
+      distance.
+    classifier_fn: A function that takes images and produces activations
+      based on a classifier.
+    num_classifier_batches: Number of batches to split images in to in order to
+      efficiently run them through the classifier network.
+    max_estimator_block_size: integer, default 1024. The distance estimator
+      splits samples into blocks for computational efficiency. Larger values
+      are more computationally expensive but decrease the variance of the
+      distance estimate. Having a smaller block size also gives a better
+      estimate of the standard error.
+    dtype: if not None, coerce activations to this dtype before computations.
+
+  Returns:
+   The Kernel Inception Distance. A floating-point scalar of the same type
+     as the output of the activations.
+   An estimate of the standard error of the distance estimator (a scalar of
+     the same type).
+  """
+  real_images_list = array_ops.split(
+      real_images, num_or_size_splits=num_classifier_batches)
+  generated_images_list = array_ops.split(
+      generated_images, num_or_size_splits=num_classifier_batches)
+
+  real_imgs = array_ops.stack(real_images_list)
+  generated_imgs = array_ops.stack(generated_images_list)
+
+  # Compute the activations using the memory-efficient `map_fn`.
+  def compute_activations(elems):
+    return functional_ops.map_fn(fn=classifier_fn,
+                                 elems=elems,
+                                 parallel_iterations=1,
+                                 back_prop=False,
+                                 swap_memory=True,
+                                 name='RunClassifier')
+
+  real_a = compute_activations(real_imgs)
+  gen_a = compute_activations(generated_imgs)
+
+  # Ensure the activations have the right shapes.
+  real_a = array_ops.concat(array_ops.unstack(real_a), 0)
+  gen_a = array_ops.concat(array_ops.unstack(gen_a), 0)
+
+  return kernel_classifier_distance_and_std_from_activations(
+      real_a, gen_a, max_block_size=max_block_size)
+
+
+kernel_inception_distance_and_std = functools.partial(
+    kernel_classifier_distance_and_std,
+    classifier_fn=functools.partial(
+        run_inception, output_tensor=INCEPTION_FINAL_POOL))
+
+
+def kernel_classifier_distance_from_activations(real_activations,
+                                                generated_activations,
+                                                max_block_size=1024,
+                                                dtype=None):
+  '''Kernel "classifier" distance for evaluating a generative model.
+
+  This methods computes the kernel classifier distance from activations of
+  real images and generated images. This can be used independently of the
+  kernel_classifier_distance() method, especially in the case of using large
+  batches during evaluation where we would like to precompute all of the
+  activations before computing the classifier distance, or if we want to
+  compute multiple metrics based on the same images.
+
+  This technique is described in detail in https://arxiv.org/abs/1801.01401.
+  Given two distributions P and Q of activations, this function calculates
+
+      E_{X, X' ~ P}[k(X, X')] + E_{Y, Y' ~ Q}[k(Y, Y')]
+        - 2 E_{X ~ P, Y ~ Q}[k(X, Y)]
+
+  where k is the polynomial kernel
+
+      k(x, y) = ( x^T y / dimension + 1 )^3.
+
+  This captures how different the distributions of real and generated images'
+  visual features are. Like the Frechet distance (and unlike the Inception
+  score), this is a true distance and incorporates information about the
+  target images. Unlike the Frechet score, this function computes an
+  *unbiased* and asymptotically normal estimator, which makes comparing
+  estimates across models much more intuitive.
+
+  The estimator used takes time quadratic in max_block_size. Larger values of
+  max_block_size will decrease the variance of the estimator but increase the
+  computational cost. This differs slightly from the estimator used by the
+  original paper; it is the block estimator of https://arxiv.org/abs/1307.1954.
+
+  NOTE: the blocking code assumes that real_activations and
+  generated_activations are both in random order. If either is sorted in a
+  meaningful order, the estimator will behave poorly.
+
+  Args:
+    real_activations: 2D Tensor containing activations of real data. Shape is
+      [batch_size, activation_size].
+    generated_activations: 2D Tensor containing activations of generated data.
+      Shape is [batch_size, activation_size].
+    max_block_size: integer, default 1024. The distance estimator
+      splits samples into blocks for computational efficiency. Larger values
+      are more computationally expensive but decrease the variance of the
+      distance estimate.
+    dtype: if not None, coerce activations to this dtype before computations.
+
+  Returns:
+   The Kernel Inception Distance. A floating-point scalar of the same type
+   as the output of the activations.
+  '''
+  return kernel_classifier_distance_and_std_from_activations(
+      real_activations, generated_activations,
+      max_block_size=max_block_size)[0]
+
+
+def kernel_classifier_distance_and_std_from_activations(real_activations,
+                                                        generated_activations,
+                                                        max_block_size=1024,
+                                                        dtype=None):
+  '''Kernel "classifier" distance for evaluating a generative model.
+
+  This methods computes the kernel classifier distance from activations of
+  real images and generated images. This can be used independently of the
+  kernel_classifier_distance() method, especially in the case of using large
+  batches during evaluation where we would like to precompute all of the
+  activations before computing the classifier distance, or if we want to
+  compute multiple metrics based on the same images. It also returns a rough
+  estimate of the standard error of the estimator.
+
+  This technique is described in detail in https://arxiv.org/abs/1801.01401.
+  Given two distributions P and Q of activations, this function calculates
+
+      E_{X, X' ~ P}[k(X, X')] + E_{Y, Y' ~ Q}[k(Y, Y')]
+        - 2 E_{X ~ P, Y ~ Q}[k(X, Y)]
+
+  where k is the polynomial kernel
+
+      k(x, y) = ( x^T y / dimension + 1 )^3.
+
+  This captures how different the distributions of real and generated images'
+  visual features are. Like the Frechet distance (and unlike the Inception
+  score), this is a true distance and incorporates information about the
+  target images. Unlike the Frechet score, this function computes an
+  *unbiased* and asymptotically normal estimator, which makes comparing
+  estimates across models much more intuitive.
+
+  The estimator used takes time quadratic in max_block_size. Larger values of
+  max_block_size will decrease the variance of the estimator but increase the
+  computational cost. This differs slightly from the estimator used by the
+  original paper; it is the block estimator of https://arxiv.org/abs/1307.1954.
+  The estimate of the standard error will also be more reliable when there are
+  more blocks, i.e. when max_block_size is smaller.
+
+  NOTE: the blocking code assumes that real_activations and
+  generated_activations are both in random order. If either is sorted in a
+  meaningful order, the estimator will behave poorly.
+
+  Args:
+    real_activations: 2D Tensor containing activations of real data. Shape is
+      [batch_size, activation_size].
+    generated_activations: 2D Tensor containing activations of generated data.
+      Shape is [batch_size, activation_size].
+    max_block_size: integer, default 1024. The distance estimator
+      splits samples into blocks for computational efficiency. Larger values
+      are more computationally expensive but decrease the variance of the
+      distance estimate. Having a smaller block size also gives a better
+      estimate of the standard error.
+    dtype: if not None, coerce activations to this dtype before computations.
+
+  Returns:
+   The Kernel Inception Distance. A floating-point scalar of the same type
+     as the output of the activations.
+   An estimate of the standard error of the distance estimator (a scalar of
+     the same type).
+  '''
+
+  real_activations.shape.assert_has_rank(2)
+  generated_activations.shape.assert_has_rank(2)
+  real_activations.shape[1].assert_is_compatible_with(
+      generated_activations.shape[1])
+
+  if dtype is None:
+    dtype = real_activations.dtype
+    assert generated_activations.dtype == dtype
+  else:
+    real_activations = math_ops.cast(real_activations, dtype)
+    generated_activations = math_ops.cast(generated_activations, dtype)
+
+  # Figure out how to split the activations into blocks of approximately
+  # equal size, with none larger than max_block_size.
+  n_r = array_ops.shape(real_activations)[0]
+  n_g = array_ops.shape(generated_activations)[0]
+
+  n_bigger = math_ops.maximum(n_r, n_g)
+  n_blocks = math_ops.to_int32(math_ops.ceil(n_bigger / max_block_size))
+
+  v_r = n_r // n_blocks
+  v_g = n_g // n_blocks
+
+  n_plusone_r = n_r - v_r * n_blocks
+  n_plusone_g = n_g - v_g * n_blocks
+
+  sizes_r = array_ops.concat([
+      array_ops.fill([n_blocks - n_plusone_r], v_r),
+      array_ops.fill([n_plusone_r], v_r + 1),
+  ], 0)
+  sizes_g = array_ops.concat([
+      array_ops.fill([n_blocks - n_plusone_g], v_g),
+      array_ops.fill([n_plusone_g], v_g + 1),
+  ], 0)
+
+  zero = array_ops.zeros([1], dtype=dtypes.int32)
+  inds_r = array_ops.concat([zero, math_ops.cumsum(sizes_r)], 0)
+  inds_g = array_ops.concat([zero, math_ops.cumsum(sizes_g)], 0)
+
+  dim = math_ops.cast(real_activations.shape[1], dtype)
+
+  def compute_kid_block(i):
+    "Compute the ith block of the KID estimate."
+    r_s = inds_r[i]
+    r_e = inds_r[i + 1]
+    r = real_activations[r_s:r_e]
+    m = math_ops.cast(r_e - r_s, dtype)
+
+    g_s = inds_g[i]
+    g_e = inds_g[i + 1]
+    g = generated_activations[g_s:g_e]
+    n = math_ops.cast(g_e - g_s, dtype)
+
+    k_rr = (math_ops.matmul(r, r, transpose_b=True) / dim + 1) ** 3
+    k_rg = (math_ops.matmul(r, g, transpose_b=True) / dim + 1) ** 3
+    k_gg = (math_ops.matmul(g, g, transpose_b=True) / dim + 1) ** 3
+    return (
+        -2 * math_ops.reduce_mean(k_rg)
+        + (math_ops.reduce_sum(k_rr) - math_ops.trace(k_rr)) / (m * (m - 1))
+        + (math_ops.reduce_sum(k_gg) - math_ops.trace(k_gg)) / (n * (n - 1)))
+
+  ests = functional_ops.map_fn(
+      compute_kid_block, math_ops.range(n_blocks), dtype=dtype, back_prop=False)
+
+  mn = math_ops.reduce_mean(ests)
+
+  # nn_impl.moments doesn't use the Bessel correction, which we want here
+  n_blocks_ = math_ops.cast(n_blocks, dtype)
+  var = control_flow_ops.cond(
+      math_ops.less_equal(n_blocks, 1),
+      lambda: array_ops.constant(float("nan"), dtype=dtype),
+      lambda: math_ops.reduce_sum(math_ops.square(ests - mn)) / (n_blocks_ - 1))
+
+  return mn, math_ops.sqrt(var / n_blocks_)

--- a/tensorflow/contrib/gan/python/eval/python/classifier_metrics_test.py
+++ b/tensorflow/contrib/gan/python/eval/python/classifier_metrics_test.py
@@ -86,6 +86,43 @@ def _expected_fid(real_imgs, gen_imgs):
 def _expected_trace_sqrt_product(sigma, sigma_v):
   return np.trace(scp_linalg.sqrtm(np.dot(sigma, sigma_v)))
 
+
+def _expected_kid_and_std(real_imgs, gen_imgs, max_block_size=1024):
+  n_r, dim = real_imgs.shape
+  n_g = gen_imgs.shape[0]
+
+  n_blocks = int(np.ceil(max(n_r, n_g) / max_block_size))
+
+  sizes_r = np.full(n_blocks, n_r // n_blocks)
+  to_patch = n_r - n_blocks * (n_r // n_blocks)
+  if to_patch > 0:
+    sizes_r[-to_patch:] += 1
+  inds_r = np.r_[0, np.cumsum(sizes_r)]
+  assert inds_r[-1] == n_r
+
+  sizes_g = np.full(n_blocks, n_g // n_blocks)
+  to_patch = n_g - n_blocks * (n_g // n_blocks)
+  if to_patch > 0:
+    sizes_g[-to_patch:] += 1
+  inds_g = np.r_[0, np.cumsum(sizes_g)]
+  assert inds_g[-1] == n_g
+
+  ests = []
+  for i in range(n_blocks):
+    r = real_imgs[inds_r[i]:inds_r[i + 1]]
+    g = gen_imgs[inds_g[i]:inds_g[i + 1]]
+
+    k_rr = (np.dot(r, r.T) / dim + 1) ** 3
+    k_rg = (np.dot(r, g.T) / dim + 1) ** 3
+    k_gg = (np.dot(g, g.T) / dim + 1) ** 3
+    ests.append(
+        -2 * k_rg.mean()
+        + k_rr[np.triu_indices_from(k_rr, k=1)].mean()
+        + k_gg[np.triu_indices_from(k_gg, k=1)].mean())
+
+  var = np.var(ests, ddof=1) if len(ests) > 1 else np.nan
+  return np.mean(ests), np.sqrt(var / len(ests))
+
 # A dummy GraphDef string with the minimum number of Ops.
 graphdef_string = """
 node {
@@ -272,6 +309,18 @@ class ClassifierMetricsTest(test.TestCase, parameterized.TestCase):
     # Check that none of the model variables are trainable.
     self.assertListEqual([], variables.trainable_variables())
 
+  def test_kernel_inception_distance_graph(self):
+    """Test `frechet_inception_distance` graph construction."""
+    img = array_ops.ones([7, 299, 299, 3])
+    distance = _run_with_mock(
+        classifier_metrics.kernel_inception_distance, img, img)
+
+    self.assertTrue(isinstance(distance, ops.Tensor))
+    distance.shape.assert_has_rank(0)
+
+    # Check that none of the model variables are trainable.
+    self.assertListEqual([], variables.trainable_variables())
+
   def test_run_inception_multicall(self):
     """Test that `run_inception` can be called multiple times."""
     for batch_size in (7, 3, 2):
@@ -410,6 +459,54 @@ class ClassifierMetricsTest(test.TestCase, parameterized.TestCase):
 
     # Check that the FIDs increase monotonically.
     self.assertTrue(all(fid_a < fid_b for fid_a, fid_b in zip(fids, fids[1:])))
+
+  def test_kernel_classifier_distance_value(self):
+    """Test that `kernel_classifier_distance` gives the correct value."""
+    np.random.seed(0)
+
+    test_pool_real_a = np.float32(np.random.randn(512, 256))
+    test_pool_gen_a = np.float32(np.random.randn(512, 256) * 1.1 + .05)
+
+    kid_op = _run_with_mock(
+        classifier_metrics.kernel_classifier_distance_and_std,
+        test_pool_real_a,
+        test_pool_gen_a,
+        classifier_fn=lambda x: x,
+        max_block_size=600)
+
+    with self.test_session() as sess:
+      actual_kid, actual_std = sess.run(kid_op)
+
+    expected_kid, expected_std = _expected_kid_and_std(
+        test_pool_real_a, test_pool_gen_a)
+
+    self.assertAllClose(expected_kid, actual_kid, 0.001)
+    self.assertAllClose(expected_std, actual_std, 0.001)
+
+  def test_kernel_classifier_distance_block_sizes(self):
+    """Test that `kernel_classifier_distance` works with unusual max_block_size
+    values.."""
+    np.random.seed(0)
+
+    test_pool_real_a = np.float32(np.random.randn(512, 256))
+    test_pool_gen_a = np.float32(np.random.randn(768, 256) * 1.1 + .05)
+
+    max_block_size = array_ops.placeholder(dtypes.int32, shape=())
+    kid_op = _run_with_mock(
+        classifier_metrics.kernel_classifier_distance_and_std_from_activations,
+        array_ops.constant(test_pool_real_a),
+        array_ops.constant(test_pool_gen_a),
+        max_block_size=max_block_size)
+
+    for block_size in [50, 512, 1000]:
+      with self.test_session() as sess:
+        actual_kid, actual_std = sess.run(kid_op, {max_block_size: block_size})
+
+      expected_kid, expected_std = _expected_kid_and_std(
+          test_pool_real_a, test_pool_gen_a, max_block_size=block_size)
+
+      self.assertAllClose(expected_kid, actual_kid, 0.001)
+      self.assertAllClose(expected_std, actual_std, 0.001)
 
   def test_trace_sqrt_product_value(self):
     """Test that `trace_sqrt_product` gives the correct value."""


### PR DESCRIPTION
The KID is a score similar to the FID, but with an unbiased, asymptotically normal estimator. It was introduced by our paper [_Demystifying MMD GANs_](https://arxiv.org/abs/1801.01401); a very similar metric was also recommended by [_An empirical study on evaluation metrics of generative adversarial networks_](https://arxiv.org/abs/1806.07755).

For comparison to the FID, see section 4 (starting page 7) and appendices D/E (starting page 30) of our paper. As noted in the docstrings for the FID here, the FID estimator is biased and you can absolutely only compare estimates based on the same number of samples. But there's no guarantee that you still won't be very misled by the bias even then; in particular, see our Appendix D.2:

> This example thus gives a case where, for the dimension and sample sizes at which we actually apply the FID and for somewhat-realistic distributions, comparing two models based on their FID estimates will not only not reliably give the right ordering – with relatively close true values and high dimensions, this is not too surprising – but, more distressingly, will _reliably give the wrong answer_, with misleadingly small variance. This emphasizes that unbiased estimators, like the natural KID estimator, are important for model comparison.

Compared to our original code ([here](https://github.com/mbinkowski/MMD-GAN/blob/master/gan/compute_scores.py)), this version uses a slightly different estimator. Both are unbiased, but I think this block variant is more intuitive for general usage; its output is also "more normal" and gives a very simple estimate of the variance of the estimator (unlike the asymptotic one we used before, which is [not a very pretty expression](https://github.com/mbinkowski/MMD-GAN/blob/master/gan/compute_scores.py#L251)).

The functions that estimate the variance currently return an estimate as long as there are at least two blocks. This could be a little misleading; it might make sense to refuse to estimate the std if there are fewer than, say, 10 blocks, but I don't know if that added code complexity is worth it.

xref: https://github.com/google/compare_gan/pull/7