### PR TITLE
Workaround for RefCounted error when using custom ops.

### DIFF
--- a/tensorflow/python/platform/sysconfig.py
+++ b/tensorflow/python/platform/sysconfig.py
@@ -62,6 +62,9 @@ def get_compile_flags():
   flags = []
   flags.append('-I%s' % get_include())
   flags.append('-D_GLIBCXX_USE_CXX11_ABI=%d' % _CXX11_ABI_FLAG)
+  # TODO(mrry): ABI for `tensorflow::core::RefCounted` is error-prone,
+  # see github issue 17316.
+  flags.append('-DNDEBUG')
   return flags
 
 


### PR DESCRIPTION
Fixes #17316.

E.g. as described in #17316 under some circumstances, when adding a custom op, after attempting to use it one gets a:
```
2018-07-23 20:59:22.060710: F external/tf_op_include/tensorflow/core/lib/core/refcount.h:79] Check failed: ref_.load() == 0 (1 vs. 0)
/bin/bash: line 1: 31765 Aborted                 (core dumped) ( /tmp/run_bazel_1532379546 )
```

Relates to issues seen in other repos:
https://github.com/cyberfire/tensorflow-mtcnn/issues/8
https://github.com/cyberfire/tensorflow-mtcnn/issues/5
https://github.com/tensorflow/tensorflow/issues/4640

Solution conform suggestion of @josh11b in #17316.
@mrry Derek, i've taken the liberty to assign you a TODO here.