### PR TITLE
1.10.0-rc1 cherry-pick request: Expose proto serialization publicly

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -662,6 +662,7 @@ cc_library(
         "lib/random/random_distributions.h",
         "lib/random/simple_philox.h",
         "lib/strings/numbers.h",
+        "lib/strings/proto_serialization.h",
         "lib/strings/str_util.h",
         "lib/strings/strcat.h",
         "lib/strings/stringprintf.h",


### PR DESCRIPTION
This change is required to ensure TF Serving 1.10.0-rcX builds clean.
TF Serving 1.10.0 is based of TF 1.10.0 release.

More details from the original change is as follows:
===
Expose proto serialization publicly, to avoid code duplication in tensorflow_serving.

PiperOrigin-RevId: 205788702