### PR TITLE
[INTEL MKL] Using MKL DNN sgemm

### DIFF
--- a/tensorflow/core/kernels/matmul_op.cc
+++ b/tensorflow/core/kernels/matmul_op.cc
@@ -591,6 +591,19 @@ TF_CALL_bfloat16(REGISTER_CPU);
 TF_CALL_int32(REGISTER_CPU);
 TF_CALL_complex64(REGISTER_CPU_EIGEN);
 TF_CALL_complex128(REGISTER_CPU_EIGEN);
+
+#elif defined(INTEL_MKL) && defined(DO_NOT_USE_ML)
+
+// MKL opensource supports only float for matrix-multiplication
+TF_CALL_float(REGISTER_CPU_EIGEN);
+TF_CALL_double(REGISTER_CPU);
+TF_CALL_half(REGISTER_CPU);
+TF_CALL_bfloat16(REGISTER_CPU);
+
+TF_CALL_int32(REGISTER_CPU);
+TF_CALL_complex64(REGISTER_CPU);
+TF_CALL_complex128(REGISTER_CPU);
+
 #else
 TF_CALL_float(REGISTER_CPU);
 TF_CALL_double(REGISTER_CPU);

--- a/tensorflow/core/kernels/matmul_op.cc
+++ b/tensorflow/core/kernels/matmul_op.cc
@@ -578,38 +578,39 @@ struct MatMulFunctor<SYCLDevice, T> {
                               .Label("cublas"),                    \
                           MatMulOp<GPUDevice, T, true /* cublas */>)
 
-#if defined(INTEL_MKL) && !defined(DO_NOT_USE_ML)
+#if defined(INTEL_MKL) 
 
-// MKL does not support half and int32 types for matrix-multiplication, so
+// MKL does not support half, bfloat16 and int32 types for matrix-multiplication, so
 // register the kernel to use default Eigen based implementations for these
-// types. Registration for NO-LABEL version is in mkl_matmul_op.cc
-TF_CALL_float(REGISTER_CPU_EIGEN);
-TF_CALL_double(REGISTER_CPU_EIGEN);
+// types. REGISTER_CPU defines two versions - Eigen label and NO-LABEL
 TF_CALL_half(REGISTER_CPU);
 TF_CALL_bfloat16(REGISTER_CPU);
-
 TF_CALL_int32(REGISTER_CPU);
-TF_CALL_complex64(REGISTER_CPU_EIGEN);
-TF_CALL_complex128(REGISTER_CPU_EIGEN);
 
-#elif defined(INTEL_MKL) && defined(DO_NOT_USE_ML)
-
-// MKL opensource supports only float for matrix-multiplication
+// Float is supported in both MKL DNN as well as in MKL ML 
+// Registration for NO-LABEL version is in mkl_matmul_op.cc for types supported by 
+// MKL. However we define Eigen label version here just to pass a few unit tests
 TF_CALL_float(REGISTER_CPU_EIGEN);
-TF_CALL_double(REGISTER_CPU);
-TF_CALL_half(REGISTER_CPU);
-TF_CALL_bfloat16(REGISTER_CPU);
 
-TF_CALL_int32(REGISTER_CPU);
+// MKL DNN does not support complex64/complex128/double, if user specifies
+// to use only opensource MKL DNN then use default implementation for these types
+// otherwise use GEMM from MKL ML binary
+
+#if defined(DO_NOT_USE_ML)
 TF_CALL_complex64(REGISTER_CPU);
 TF_CALL_complex128(REGISTER_CPU);
+TF_CALL_double(REGISTER_CPU);
+#else // DO_NOT_USE_ML
+TF_CALL_complex64(REGISTER_CPU_EIGEN);
+TF_CALL_complex128(REGISTER_CPU_EIGEN);
+TF_CALL_double(REGISTER_CPU_EIGEN);
+#endif
 
-#else
+#else // INTEL MKL 
 TF_CALL_float(REGISTER_CPU);
 TF_CALL_double(REGISTER_CPU);
 TF_CALL_half(REGISTER_CPU);
 TF_CALL_bfloat16(REGISTER_CPU);
-
 TF_CALL_int32(REGISTER_CPU);
 TF_CALL_complex64(REGISTER_CPU);
 TF_CALL_complex128(REGISTER_CPU);

--- a/tensorflow/core/kernels/mkl_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl_matmul_op.cc
@@ -31,7 +31,6 @@ limitations under the License.
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/fill_functor.h"
 
-//This header file is part of MKL ML, need equivalent file in MKL DNN
 #ifndef DO_NOT_USE_ML
 #include "mkl_cblas.h"
 #else

--- a/tensorflow/core/kernels/mkl_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl_matmul_op.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/fill_functor.h"
 
+//This header file is part of MKL ML, need equivalent file in MKL DNN
 #ifndef DO_NOT_USE_ML
 #include "mkl_cblas.h"
 #else
@@ -160,11 +161,12 @@ class MklMatMulOp : public OpKernel {
     int index_transa = transa? 1 : 0 ;
     int index_transb = transb? 1 : 0 ;
     VLOG(2) << "MKL DNN SGEMM called";
-    //Using the fortran api of mkldnn
-    //Since TF is in row major layout,reversing the order of A and B
+    // MKL DNN only supports the Fortran api and requires column major while Tensorflow
+    // uses row major so we reverse the order A and B
     mkldnn_sgemm(ftrans[index_transb], ftrans[index_transa],
                 &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc);
 #else
+    // MKL ML binary uses CBLAS API
     cblas_sgemm(CblasRowMajor, transa ? CblasTrans : CblasNoTrans,
                 transb ? CblasTrans : CblasNoTrans, m, n, k, alpha, a, lda, b,
                 ldb, beta, c, ldc);


### PR DESCRIPTION
Added code to call MKL DNN sgemm when building from MKL DNN opensources only.  This PR depends on https://github.com/tensorflow/tensorflow/pull/21011, so it should be merged only after 21011 is merged