### PR TITLE
1.10.0-rc1 cherry-pick request: Update tensorboard dependency to 1.10.x

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -55,7 +55,7 @@ REQUIRED_PACKAGES = [
     'six >= 1.10.0',
     'protobuf >= 3.6.0',
     'setuptools <= 39.1.0',
-    'tensorboard >= 1.8.0, < 1.9.0',
+    'tensorboard >= 1.10.0, < 1.11.0',
     'termcolor >= 1.1.0',
 ]
 


### PR DESCRIPTION
TensorBoard 1.10.0 has been released to PyPI: https://pypi.org/project/tensorboard/1.10.0/

PiperOrigin-RevId: 205895470