### PR TITLE
make build_pip_package work again on rpi3

### DIFF
--- a/tensorflow/core/kernels/concat_lib_cpu.cc
+++ b/tensorflow/core/kernels/concat_lib_cpu.cc
@@ -73,6 +73,7 @@ REGISTER(qint8)
 REGISTER(quint16)
 REGISTER(qint16)
 REGISTER(qint32)
+REGISTER(bfloat16)
 
 #if defined(IS_MOBILE_PLATFORM) && !defined(SUPPORT_SELECTIVE_REGISTRATION) && \
     !defined(__ANDROID_TYPES_FULL__)


### PR DESCRIPTION
make something like
```
bazel build --config opt --local_resources 1024.0,0.5,0.5 --cxxopt=-mfpu=neon-vfpv4 --cxxopt=-ftree-vectorize --cxxopt=-funsafe-math-optimizations --cxxopt=-ftree-loop-vectorize --cxxopt=-fomit-frame-pointer //tensorflow/tools/pip_package:build_pip_package
```
work.

When building tensorflow pip package natively on RPI 3 (yes, I know it's slow, not recommended), I saw error message like
```
ERROR: /home/pi/work/tensorflow/tensorflow/BUILD:589:1: Executing genrule //tensorflow:tensorflow_python_api_gen failed (Exit 1)
Traceback (most recent call last):
  File "/home/pi/.cache/bazel/_bazel_pi/fab1708ba000bf373adf42719f003e8e/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.python_api.runfiles/org_tensorflow/tensorflow/python/tools/api/generator/create_python_api.py", line 27, in <module>
    from tensorflow.python.tools.api.generator import doc_srcs
  File "/home/pi/.cache/bazel/_bazel_pi/fab1708ba000bf373adf42719f003e8e/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.python_api.runfiles/org_tensorflow/tensorflow/python/__init__.py", line 49, in <module>
    from tensorflow.python import pywrap_tensorflow
  File "/home/pi/.cache/bazel/_bazel_pi/fab1708ba000bf373adf42719f003e8e/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.python_api.runfiles/org_tensorflow/tensorflow/python/pywrap_tensorflow.py", line 74, in <module>
    raise ImportError(msg)
ImportError: Traceback (most recent call last):
  File "/home/pi/.cache/bazel/_bazel_pi/fab1708ba000bf373adf42719f003e8e/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.python_api.runfiles/org_tensorflow/tensorflow/python/pywrap_tensorflow.py", line 58, in <module>
    from tensorflow.python.pywrap_tensorflow_internal import *
  File "/home/pi/.cache/bazel/_bazel_pi/fab1708ba000bf373adf42719f003e8e/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.python_api.runfiles/org_tensorflow/tensorflow/python/pywrap_tensorflow_internal.py", line 28, in <module>
    _pywrap_tensorflow_internal = swig_import_helper()
  File "/home/pi/.cache/bazel/_bazel_pi/fab1708ba000bf373adf42719f003e8e/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.python_api.runfiles/org_tensorflow/tensorflow/python/pywrap_tensorflow_internal.py", line 24, in swig_import_helper
    _mod = imp.load_module('_pywrap_tensorflow_internal', fp, pathname, description)
ImportError: /home/pi/.cache/bazel/_bazel_pi/fab1708ba000bf373adf42719f003e8e/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.python_api.runfiles/org_tensorflow/tensorflow/python/_pywrap_tensorflow_internal.so: undefined symbol: _ZN10tensorflow9ConcatCPUINS_8bfloat16EEEvPNS_10DeviceBaseERKSt6vectorISt10unique_ptrINS_6TTypesIT_Li2EiE11ConstMatrixESt14default_deleteIS9_EESaISC_EEPNS8_6MatrixE

```

Demangling with `c++filt`
```
$ c++filt _ZN10tensorflow9ConcatCPUINS_8bfloat16EEEvPNS_10DeviceBaseERKSt6vectorISt10unique_ptrINS_6TTypesIT_Li2EiE11ConstMatrixESt14default_deleteIS9_EESaISC_EEPNS8_6MatrixE 
void tensorflow::ConcatCPU<tensorflow::bfloat16>(tensorflow::DeviceBase*, std::vector<std::unique_ptr<tensorflow::TTypes<tensorflow::bfloat16, 2, int>::ConstMatrix, std::default_delete<tensorflow::TTypes<tensorflow::bfloat16, 2, int>::ConstMatrix> >, std::allocator<std::unique_ptr<tensorflow::TTypes<tensorflow::bfloat16, 2, int>::ConstMatrix, std::default_delete<tensorflow::TTypes<tensorflow::bfloat16, 2, int>::ConstMatrix> > > > const&, tensorflow::TTypes<tensorflow::bfloat16, 2, int>::Matrix*)
```
we can see that we need instantiation for `ConcatCPU<bfloat16>(.....)`.

Tested on Raspbian Jun-2018.