### PR TITLE
Improve shape function for CudnnRNNParamsSize

### DIFF
--- a/tensorflow/contrib/cudnn_rnn/python/kernel_tests/cudnn_rnn_ops_test.py
+++ b/tensorflow/contrib/cudnn_rnn/python/kernel_tests/cudnn_rnn_ops_test.py
@@ -416,24 +416,27 @@ class CudnnRNNTestParamsSize(TensorFlowTestCase):
   @unittest.skipUnless(test.is_built_with_cuda(),
                        "Test only applicable when running on GPUs")
   def testLSTMParamsSizeShape(self):
-      with self.assertRaisesRegexp(ValueError, "Shape must be rank 0 but is rank 1"):
-        model = _CreateModel(
-            cudnn_rnn_ops.CUDNN_LSTM,
-            constant_op.constant([4]), 200, 200,
-            direction=cudnn_rnn_ops.CUDNN_RNN_UNIDIRECTION)
-        params_size = model.params_size()
-      with self.assertRaisesRegexp(ValueError, "Shape must be rank 0 but is rank 1"):
-        model = _CreateModel(
-            cudnn_rnn_ops.CUDNN_LSTM,
-            4, constant_op.constant([200]), 200,
-            direction=cudnn_rnn_ops.CUDNN_RNN_UNIDIRECTION)
-        params_size = model.params_size()
-      with self.assertRaisesRegexp(ValueError, "Shape must be rank 0 but is rank 1"):
-        model = _CreateModel(
-            cudnn_rnn_ops.CUDNN_LSTM,
-            4, 200, constant_op.constant([200]),
-            direction=cudnn_rnn_ops.CUDNN_RNN_UNIDIRECTION)
-        params_size = model.params_size()
+    with self.assertRaisesRegexp(
+        ValueError, "Shape must be rank 0 but is rank 1"):
+      model = _CreateModel(
+          cudnn_rnn_ops.CUDNN_LSTM,
+          constant_op.constant([4]), 200, 200,
+          direction=cudnn_rnn_ops.CUDNN_RNN_UNIDIRECTION)
+      params_size = model.params_size()
+    with self.assertRaisesRegexp(
+        ValueError, "Shape must be rank 0 but is rank 1"):
+      model = _CreateModel(
+          cudnn_rnn_ops.CUDNN_LSTM,
+          4, constant_op.constant([200]), 200,
+          direction=cudnn_rnn_ops.CUDNN_RNN_UNIDIRECTION)
+      params_size = model.params_size()
+    with self.assertRaisesRegexp(
+        ValueError, "Shape must be rank 0 but is rank 1"):
+      model = _CreateModel(
+          cudnn_rnn_ops.CUDNN_LSTM,
+          4, 200, constant_op.constant([200]),
+          direction=cudnn_rnn_ops.CUDNN_RNN_UNIDIRECTION)
+      params_size = model.params_size()
 
 
 class CudnnRNNTestInference(TensorFlowTestCase):

--- a/tensorflow/contrib/cudnn_rnn/python/kernel_tests/cudnn_rnn_ops_test.py
+++ b/tensorflow/contrib/cudnn_rnn/python/kernel_tests/cudnn_rnn_ops_test.py
@@ -413,6 +413,28 @@ class CudnnRNNTestParamsSize(TensorFlowTestCase):
         self._testOneLSTMParamsSize(num_layers, num_units, input_size,
                                     direction)
 
+  @unittest.skipUnless(test.is_built_with_cuda(),
+                       "Test only applicable when running on GPUs")
+  def testLSTMParamsSizeShape(self):
+      with self.assertRaisesRegexp(ValueError, "Shape must be rank 0 but is rank 1"):
+        model = _CreateModel(
+            cudnn_rnn_ops.CUDNN_LSTM,
+            constant_op.constant([4]), 200, 200,
+            direction=cudnn_rnn_ops.CUDNN_RNN_UNIDIRECTION)
+        params_size = model.params_size()
+      with self.assertRaisesRegexp(ValueError, "Shape must be rank 0 but is rank 1"):
+        model = _CreateModel(
+            cudnn_rnn_ops.CUDNN_LSTM,
+            4, constant_op.constant([200]), 200,
+            direction=cudnn_rnn_ops.CUDNN_RNN_UNIDIRECTION)
+        params_size = model.params_size()
+      with self.assertRaisesRegexp(ValueError, "Shape must be rank 0 but is rank 1"):
+        model = _CreateModel(
+            cudnn_rnn_ops.CUDNN_LSTM,
+            4, 200, constant_op.constant([200]),
+            direction=cudnn_rnn_ops.CUDNN_RNN_UNIDIRECTION)
+        params_size = model.params_size()
+
 
 class CudnnRNNTestInference(TensorFlowTestCase):
 

--- a/tensorflow/core/ops/cudnn_rnn_ops.cc
+++ b/tensorflow/core/ops/cudnn_rnn_ops.cc
@@ -37,7 +37,6 @@ using shape_inference::DimensionHandle;
 using shape_inference::InferenceContext;
 using shape_inference::ShapeHandle;
 
-
 REGISTER_OP("CudnnRNNParamsSize")
     .Input("num_layers: int32")
     .Input("num_units: int32")
@@ -61,7 +60,6 @@ REGISTER_OP("CudnnRNNParamsSize")
       c->set_output(0, c->Vector(1));
       return Status::OK();
     });
-
 
 REGISTER_OP("CudnnRNN")
     .Input("input: T")
@@ -253,7 +251,6 @@ REGISTER_OP("CudnnRNNParamsToCanonical")
       }
       return Status::OK();
     });
-
 
 REGISTER_OP("CudnnRNNCanonicalToParams")
     .Input("num_layers: int32")

--- a/tensorflow/core/ops/cudnn_rnn_ops.cc
+++ b/tensorflow/core/ops/cudnn_rnn_ops.cc
@@ -52,6 +52,12 @@ REGISTER_OP("CudnnRNNParamsSize")
     .Attr("seed2: int = 0")
     .Output("params_size: S")
     .SetShapeFn([](InferenceContext* c) {
+      ShapeHandle unused;
+      // num_layers, num_units, and input_size should be scalars.
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &unused));
+
       c->set_output(0, c->Vector(1));
       return Status::OK();
     });

--- a/tensorflow/core/ops/cudnn_rnn_ops_test.cc
+++ b/tensorflow/core/ops/cudnn_rnn_ops_test.cc
@@ -26,7 +26,19 @@ namespace tensorflow {
 
 TEST(CudnnRNNOpsTest, ParamsSize_ShapeFn) {
   ShapeInferenceTestOp op("CudnnRNNParamsSize");
-  INFER_OK(op, "[1];[1];[1]", "[1]");
+  INFER_OK(op, "[];[];[]", "[1]");
+  INFER_OK(op, "?;[];[]", "[1]");
+  INFER_OK(op, "[];?;[]", "[1]");
+  INFER_OK(op, "[];[];?", "[1]");
+  INFER_OK(op, "[];?;?", "[1]");
+  INFER_OK(op, "?;?;?", "[1]");
+
+  INFER_ERROR("Shape must be rank 0 ", op,
+              "[1,2];?;[]");
+  INFER_ERROR("Shape must be rank 0 ", op,
+              "?;[2];[]");
+  INFER_ERROR("Shape must be rank 0 ", op,
+              "?;?;[1]");
 }
 
 TEST(CudnnRNNOpsTest, ForwardLstm_ShapeFn) {

--- a/tensorflow/core/ops/cudnn_rnn_ops_test.cc
+++ b/tensorflow/core/ops/cudnn_rnn_ops_test.cc
@@ -33,12 +33,9 @@ TEST(CudnnRNNOpsTest, ParamsSize_ShapeFn) {
   INFER_OK(op, "[];?;?", "[1]");
   INFER_OK(op, "?;?;?", "[1]");
 
-  INFER_ERROR("Shape must be rank 0 ", op,
-              "[1,2];?;[]");
-  INFER_ERROR("Shape must be rank 0 ", op,
-              "?;[2];[]");
-  INFER_ERROR("Shape must be rank 0 ", op,
-              "?;?;[1]");
+  INFER_ERROR("Shape must be rank 0 ", op, "[1,2];?;[]");
+  INFER_ERROR("Shape must be rank 0 ", op, "?;[2];[]");
+  INFER_ERROR("Shape must be rank 0 ", op, "?;?;[1]");
 }
 
 TEST(CudnnRNNOpsTest, ForwardLstm_ShapeFn) {


### PR DESCRIPTION
In cudnn_rnn_ops.cc, the CudnnRNNParamsSize does not have restrictions on num_layers, num_units, and input_size, though they all should be scalars.

This fix adds the shape check of num_layers, num_units, and input_size
for CudnnRNNParamsSize.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>