### PR TITLE
Add PATCH_COMMAND to eigen.cmake (fix #19198)

### DIFF
--- a/tensorflow/contrib/cmake/external/eigen.cmake
+++ b/tensorflow/contrib/cmake/external/eigen.cmake
@@ -19,6 +19,12 @@
 #  build_file = "eigen.BUILD",
 #)
 
+option(eigen_PATCH_FILE "Patch file to apply to eigen" OFF)
+set(eigen_PATCH_COMMAND "")
+if(eigen_PATCH_FILE)
+    set(eigen_PATCH_COMMAND PATCH_COMMAND patch -p0 -i "${eigen_PATCH_FILE}")
+endif(eigen_PATCH_FILE)
+
 include (ExternalProject)
 
 # We parse the current Eigen version and archive hash from the bazel configuration
@@ -45,6 +51,7 @@ ExternalProject_Add(eigen
     URL ${eigen_URL}
     DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
     INSTALL_DIR "${eigen_INSTALL}"
+    ${eigen_PATCH_COMMAND}
     CMAKE_CACHE_ARGS
         -DCMAKE_BUILD_TYPE:STRING=Release
         -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF


### PR DESCRIPTION
This PR adds the ability to apply a patch file to eigen as part of the build. Currently, Eigen has at least one issue under certain configurations. This PR is not to address any specific issue but to make the build more flexible. I linked a patch file below to fix the specific issue in #19198.

Just add `-Deigen_PATCH_FILE=path/to/patch.txt` to cmake and it will run the patch file after downloading eigen. Defaults to `OFF` (no patch file).

Bug I was getting:
- http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1526
- https://github.com/tensorflow/tensorflow/issues/19198

Patch file in gist below. Based on the bug above with some path and line number changes.
- https://gist.github.com/bstriner/a7fb0a8da1f830900fa932652439ed44

This way no one is waiting on a third-party to make a new release. Should be easy enough to make other patches as necessary.

This does assume that `patch` command is on `PATH`. An alternative would be to let the user specify the entire patch command instead of just the patch file but that might unnecessarily complicate things.

Cheers