### PR TITLE
install libnccl-dev in Dockerfile.gpu to fix missing nccl.h

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.gpu
+++ b/tensorflow/tools/ci_build/Dockerfile.gpu
@@ -17,7 +17,8 @@ RUN /install/install_deb_packages.sh
 
 # Install NCCL
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libnccl2=2.2.13-1+cuda9.0
+        libnccl2=2.2.13-1+cuda9.0 \
+        libnccl-dev=2.2.13-1+cuda9.0
 
 RUN /install/install_pip_packages.sh
 RUN /install/install_bazel.sh


### PR DESCRIPTION
fix https://github.com/tensorflow/tensorflow/issues/21094 for ci_build.