### PR TITLE
Fix compilation error due to typo

### DIFF
--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -174,7 +174,7 @@ class GdrMemoryManager : public RemoteMemoryManager {
   // Client side endpoints
   mutex client_mu_;
   std::map<std::pair<string, string>, RdmaEndpointPtr> clients_
-      GUARDED_BY(cient_mu_);
+      GUARDED_BY(client_mu_);
 
   // Managed memory regions
   mutex alloc_mu_;


### PR DESCRIPTION
Fixed compilation error below due to the typo in identifier name 'cient_mu_' -> 'client_mu_'.

ERROR: /home/cos/tensorflow/tensorflow/contrib/gdr/BUILD:40:1: C++ compilation of rule '//tensorflow/contrib/gdr:gdr_memory_manager' failed (Exit 1)
tensorflow/contrib/gdr/gdr_memory_manager.cc:175:18: error: use of undeclared identifier 'cient_mu_'; did you mean 'client_mu_'?
      GUARDED_BY(cient_mu_);
                 ^~~~~~~~~
                 client_mu_
./tensorflow/core/platform/default/thread_annotations.h:52:64: note: expanded from macro 'GUARDED_BY'
#define GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
                                                               ^
./tensorflow/core/platform/default/thread_annotations.h:42:57: note: expanded from macro 'THREAD_ANNOTATION_ATTRIBUTE__'
#define THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
                                                        ^
tensorflow/contrib/gdr/gdr_memory_manager.cc:173:9: note: 'client_mu_' declared here
  mutex client_mu_;
        ^
tensorflow/contrib/gdr/gdr_memory_manager.cc:631:12: warning: unused variable 'checksum' [-Wunused-variable]
  uint64_t checksum = 0;
           ^
1 warning and 1 error generated.
Target //tensorflow/tools/pip_package:build_pip_package failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 24.192s, Critical Path: 11.63s
INFO: 26 processes: 26 local.
FAILED: Build did NOT complete successfully
