### PR TITLE
Add command line option to specify the version of the tensorflow wheel

### DIFF
--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -149,7 +149,8 @@ function build_wheel() {
 
   TMPDIR="$1"
   DEST="$2"
-  PKG_NAME_FLAG="$3"
+  shift
+  shift
 
   # Before we leave the top-level directory, make sure we know how to
   # call python.
@@ -160,7 +161,7 @@ function build_wheel() {
   pushd ${TMPDIR} > /dev/null
   rm -f MANIFEST
   echo $(date) : "=== Building wheel"
-  "${PYTHON_BIN_PATH:-python}" setup.py bdist_wheel ${PKG_NAME_FLAG} >/dev/null
+  "${PYTHON_BIN_PATH:-python}" setup.py bdist_wheel ${@} >/dev/null
   mkdir -p ${DEST}
   cp dist/* ${DEST}
   popd > /dev/null
@@ -183,6 +184,7 @@ function usage() {
   echo "    --gpu                 build tensorflow_gpu"
   echo "    --gpudirect           build tensorflow_gpudirect"
   echo "    --nightly_flag        build tensorflow nightly"
+  echo "    --version <semver>    set version number"
   echo ""
   exit 1
 }
@@ -211,6 +213,9 @@ function main() {
         break
       fi
       PROJECT_NAME="$1"
+    elif [[ "$1" == "--version" ]]; then
+      shift
+      VERSION_FLAG="--version $1"
     elif [[ "$1" == "--src" ]]; then
       shift
       SRCDIR="$(real_path $1)"
@@ -256,7 +261,7 @@ function main() {
     PKG_NAME_FLAG="--project_name tensorflow_gpu"
   fi
 
-  build_wheel "$SRCDIR" "$DSTDIR" "$PKG_NAME_FLAG"
+  build_wheel "$SRCDIR" "$DSTDIR" "$PKG_NAME_FLAG" "$VERSION_FLAG"
 
   if [[ $CLEANSRC -ne 0 ]]; then
     rm -rf "${TMPDIR}"

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -47,6 +47,13 @@ DOCLINES = __doc__.split('\n')
 # result for pip.
 _VERSION = '1.9.0'
 
+if '--version' in sys.argv:
+  version_idx = sys.argv.index('--version')
+  _VERSION = sys.argv[version_idx + 1]
+  print("version specified is " + _VERSION)
+  sys.argv.remove('--version')
+  sys.argv.pop(version_idx)
+
 REQUIRED_PACKAGES = [
     'absl-py >= 0.1.6',
     'astor >= 0.6.0',


### PR DESCRIPTION
There is a command line option to build_pip_package.sh (with support in setup.py) for setting the name of the pip package which is created.  This is so that Tensorflow can be called things like `tensorflow_gpu`. 

This adds the same scaffolding for altering the version number of the PIP wheel file.

While it seems less useful, possibly even confusing, to alter the version number, this is so that a 3rd party (Graphcore) can release versions of Tensorflow which are targeted at their hardware.  It would be difficult to manage that release process without being able to change the versioning of the releases independently of the versions of Tensorflow.

The version reported by Tensorflow in python (tensorflow.__version__) is still the tensorflow release.  This only affects the versioning of the pip package, just like the package name does.

