### PR TITLE
Avoid installing newest pip and wheel versions

### DIFF
--- a/tensorflow/tools/docker/Dockerfile.devel
+++ b/tensorflow/tools/docker/Dockerfile.devel
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+RUN curl -fSsL -O https://bootstrap.pypa.io/3.3/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
 


### PR DESCRIPTION
https://bootstrap.pypa.io/get-pip.py  was updated (pip-18.0, setuptools-40.0.0 and wheel-0.31.1) on 22-Jul-2018