### PR TITLE
updating tf.Variable call in sample to execute with eager

### DIFF
--- a/tensorflow/contrib/eager/python/examples/notebooks/custom_training.ipynb
+++ b/tensorflow/contrib/eager/python/examples/notebooks/custom_training.ipynb
@@ -167,7 +167,9 @@
       "source": [
         "TensorFlow, however, has stateful operations built in, and these are often more pleasant to use than low-level Python representations of your state. To represent weights in a model, for example, it's often convenient and efficient to use TensorFlow variables.\n",
         "\n",
-        "A Variable is an object which stores a value and, when used in a TensorFlow computation, will implicitly read from this stored value. There are operations (`tf.assign_sub`, `tf.scatter_update`, etc) which manipulate the value stored in a TensorFlow variable."
+        "A Variable is an object which stores a value and, when used in a TensorFlow computation, will implicitly read from this stored value. There are operations (`tf.assign_sub`, `tf.scatter_update`, etc) which manipulate the value stored in a TensorFlow variable.",
+        "\n",
+        "Note tf.Variable is not currently supported when eager execution is enabled. We'll use `tf.contrib.eager.Variable` instead.\n"
       ]
     },
     {
@@ -183,7 +185,7 @@
       },
       "cell_type": "code",
       "source": [
-        "v = tf.Variable(1.0)\n",
+        "v = tf.contrib.eager.Variable(1.0)\n",
         "assert v.numpy() == 1.0\n",
         "\n",
         "# Re-assign the value\n",
@@ -257,8 +259,8 @@
         "  def __init__(self):\n",
         "    # Initialize variable to (5.0, 0.0)\n",
         "    # In practice, these should be initialized to random values.\n",
-        "    self.W = tf.Variable(5.0)\n",
-        "    self.b = tf.Variable(0.0)\n",
+        "    self.W = tf.contrib.eager.Variable(5.0)\n",
+        "    self.b = tf.contrib.eager.Variable(0.0)\n",
         "    \n",
         "  def __call__(self, x):\n",
         "    return self.W * x + self.b\n",


### PR DESCRIPTION
the current colab code errors out when it calls tf.Variable:

RuntimeError: tf.Variable not supported when eager execution is enabled. Please use tf.contrib.eager.Variable instead

Not sure why this is needed -- I thought eager would allow this syntax to work as is, but the error was pretty clear.