### PR TITLE
removed inline function

### DIFF
--- a/tensorflow/core/lib/core/coding.cc
+++ b/tensorflow/core/lib/core/coding.cc
@@ -133,6 +133,17 @@ int VarintLength(uint64_t v) {
   return len;
 }
 
+const char* GetVarint32Ptr(const char* p, const char* limit, uint32* value) {
+  if (p < limit) {
+    uint32 result = *(reinterpret_cast<const unsigned char*>(p));
+    if ((result & 128) == 0) {
+      *value = result;
+      return p + 1;
+    }
+  }
+  return GetVarint32PtrFallback(p, limit, value);
+}
+
 const char* GetVarint32PtrFallback(const char* p, const char* limit,
                                    uint32* value) {
   uint32 result = 0;

--- a/tensorflow/core/lib/core/coding.h
+++ b/tensorflow/core/lib/core/coding.h
@@ -53,20 +53,8 @@ extern const char* GetVarint32Ptr(const char* p, const char* limit, uint32* v);
 extern const char* GetVarint64Ptr(const char* p, const char* limit, uint64* v);
 
 // Internal routine for use by fallback path of GetVarint32Ptr
-extern const char* GetVarint32PtrFallback(const char* p, const char* limit,
-                                          uint32* value);
-inline const char* GetVarint32Ptr(const char* p, const char* limit,
-                                  uint32* value) {
-  if (p < limit) {
-    uint32 result = *(reinterpret_cast<const unsigned char*>(p));
-    if ((result & 128) == 0) {
-      *value = result;
-      return p + 1;
-    }
-  }
-  return GetVarint32PtrFallback(p, limit, value);
-}
-
+extern const char* GetVarint32PtrFallback(const char* p, const char* limit, uint32* value);
+extern const char* GetVarint32Ptr(const char* p, const char* limit, uint32* value);
 extern char* EncodeVarint32(char* dst, uint32 v);
 extern char* EncodeVarint64(char* dst, uint64 v);
 


### PR DESCRIPTION
if one includes the header and does not link with coding.cc gets unresolved error. not the case when you just include extern functions and do not use them, more over this function does not seem to save so much being inlined.