### PR TITLE
Faster implementation for constructing gradient of extract_image_patches

### DIFF
--- a/tensorflow/python/kernel_tests/extract_image_patches_grad_test.py
+++ b/tensorflow/python/kernel_tests/extract_image_patches_grad_test.py
@@ -25,6 +25,8 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import random_seed as random_seed_lib
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradient_checker
+from tensorflow.python.ops import gradients_impl
+from tensorflow.python.ops import variable_scope
 from tensorflow.python.platform import test
 
 
@@ -99,6 +101,24 @@ class ExtractImagePatchesGradTest(test.TestCase):
 
           print('extract_image_patches gradient err: %.4e' % err)
           self.assertLess(err, 1e-4)
+
+  def testConstructGradientWithLargeImages(self):
+    batch_size = 4
+    height = 1024
+    width = 1024
+    ksize = 5
+    images = variable_scope.get_variable('inputs',
+                                         (batch_size, height, width, 1))
+    patches = array_ops.extract_image_patches(images,
+                                              ksizes=[1, ksize, ksize, 1],
+                                              strides=[1, 1, 1, 1],
+                                              rates=[1, 1, 1, 1],
+                                              padding='SAME')
+    # Github issue: #20146
+    # tf.extract_image_patches() gradient very slow at graph construction time
+    gradients = gradients_impl.gradients(patches, images)
+    # Won't time out.
+    self.assertIsNotNone(gradients)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -772,7 +772,7 @@ def _ExtractImagePatchesGrad(op, grad):
   sp_shape = (input_indices_num, output_indices_num)
   sp_mat_full = sparse_tensor.SparseTensor(
       idx_map,
-      array_ops.ones_like(idx_map[:, 0], dtype=grad.dtype),
+      array_ops.ones([output_indices_num], dtype=grad.dtype),
       sp_shape)
   # Remove all padding locations [0, :].
   sp_mat = sparse_ops.sparse_slice(sp_mat_full,

--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -741,7 +741,7 @@ def _ExtractImagePatchesGrad(op, grad):
 
   # Create indices matrix for input tensor.
   # Note that 0 is preserved for padding location,
-  # so indice for input starts from 1 to 1 + rows_in * cols_in.
+  # so indices for input start from 1 to 1 + rows_in * cols_in.
   input_indices_num = 1 + rows_in * cols_in
   input_idx = array_ops.reshape(math_ops.range(1, input_indices_num,
                                                dtype=ops.dtypes.int64),
@@ -756,7 +756,7 @@ def _ExtractImagePatchesGrad(op, grad):
   # Create indices matrix for output tensor.
   _, rows_out, cols_out, _ = [dim.value for dim in op.outputs[0].get_shape()]
   _, ksize_r, ksize_c, _ = op.get_attr("ksizes")
-  # Indice for output starts from 0.
+  # Indices for output start from 0.
   output_indices_num = rows_out * cols_out * ksize_r * ksize_c
   output_idx = array_ops.reshape(math_ops.range(output_indices_num,
                                                 dtype=ops.dtypes.int64),

--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -18,9 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from math import ceil
-import numpy as np
-
 from tensorflow.python import pywrap_tensorflow
 from tensorflow.python.eager import context
 from tensorflow.python.framework import constant_op

--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -763,9 +763,10 @@ def _ExtractImagePatchesGrad(op, grad):
                                  (1, rows_out, cols_out, ksize_r * ksize_c))
 
   # Construct mapping table for indices: (input -> output).
-  idx_matrix = array_ops.concat([array_ops.expand_dims(input_idx_patched, axis=-1),
-                                 array_ops.expand_dims(output_idx, axis=-1)],
-                                axis=-1)
+  idx_matrix = array_ops.concat(
+      [array_ops.expand_dims(input_idx_patched, axis=-1),
+       array_ops.expand_dims(output_idx, axis=-1)],
+      axis=-1)
   idx_map = array_ops.reshape(idx_matrix, (-1, 2))
 
   sp_shape = (input_indices_num, output_indices_num)

--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -762,19 +762,19 @@ def _ExtractImagePatchesGrad(op, grad):
                                                 dtype=ops.dtypes.int64),
                                  (1, rows_out, cols_out, ksize_r * ksize_c))
 
-  # Construct mapping table for indices: input -> output.
+  # Construct mapping table for indices: (input -> output).
   idx_matrix = array_ops.concat([array_ops.expand_dims(input_idx_patched, axis=-1),
                                  array_ops.expand_dims(output_idx, axis=-1)],
                                 axis=-1)
   idx_map = array_ops.reshape(idx_matrix, (-1, 2))
 
   sp_shape = (input_indices_num, output_indices_num)
-  sp_mat = sparse_tensor.SparseTensor(
+  sp_mat_full = sparse_tensor.SparseTensor(
       idx_map,
       array_ops.ones_like(idx_map[:, 0], dtype=grad.dtype),
       sp_shape)
-  # Remove all padding locations: [0, :].
-  sp_mat = sparse_ops.sparse_slice(sp_mat,
+  # Remove all padding locations [0, :].
+  sp_mat = sparse_ops.sparse_slice(sp_mat_full,
                                    (1, 0),
                                    (input_indices_num - 1, output_indices_num))
 

--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -735,7 +735,6 @@ def _QuantizeAndDequantizeV3Grad(_, grad):
 
 @ops.RegisterGradient("ExtractImagePatches")
 def _ExtractImagePatchesGrad(op, grad):
-
   batch_size, rows_in, cols_in, channels = [
       dim.value for dim in op.inputs[0].get_shape()
   ]
@@ -743,63 +742,50 @@ def _ExtractImagePatchesGrad(op, grad):
   batch_size = input_bhwc[0]
   channels = input_bhwc[3]
 
+  # Create indices matrix for input tensor.
+  # Note that 0 is preserved for padding location,
+  # so indice for input starts from 1 to 1 + rows_in * cols_in.
+  input_indices_num = 1 + rows_in * cols_in
+  input_idx = array_ops.reshape(math_ops.range(1, input_indices_num,
+                                               dtype=ops.dtypes.int64),
+                                (1, rows_in, cols_in, 1))
+  input_idx_patched = gen_array_ops.extract_image_patches(
+      input_idx,
+      op.get_attr("ksizes"),
+      op.get_attr("strides"),
+      op.get_attr("rates"),
+      op.get_attr("padding"))
+
+  # Create indices matrix for output tensor.
   _, rows_out, cols_out, _ = [dim.value for dim in op.outputs[0].get_shape()]
   _, ksize_r, ksize_c, _ = op.get_attr("ksizes")
-  _, stride_r, stride_h, _ = op.get_attr("strides")
-  _, rate_r, rate_c, _ = op.get_attr("rates")
-  padding = op.get_attr("padding")
+  # Indice for output starts from 0.
+  output_indices_num = rows_out * cols_out * ksize_r * ksize_c
+  output_idx = array_ops.reshape(math_ops.range(output_indices_num,
+                                                dtype=ops.dtypes.int64),
+                                 (1, rows_out, cols_out, ksize_r * ksize_c))
 
-  ksize_r_eff = ksize_r + (ksize_r - 1) * (rate_r - 1)
-  ksize_c_eff = ksize_c + (ksize_c - 1) * (rate_c - 1)
+  # Construct mapping table for indices: input -> output.
+  idx_matrix = array_ops.concat([array_ops.expand_dims(input_idx_patched, axis=-1),
+                                 array_ops.expand_dims(output_idx, axis=-1)],
+                                axis=-1)
+  idx_map = array_ops.reshape(idx_matrix, (-1, 2))
 
-  if padding == b"SAME":
-    rows_out = int(ceil(rows_in / stride_r))
-    cols_out = int(ceil(cols_in / stride_h))
-    pad_rows = ((rows_out - 1) * stride_r + ksize_r_eff - rows_in) // 2
-    pad_cols = ((cols_out - 1) * stride_h + ksize_c_eff - cols_in) // 2
-
-  elif padding == b"VALID":
-    rows_out = int(ceil((rows_in - ksize_r_eff + 1) / stride_r))
-    cols_out = int(ceil((cols_in - ksize_c_eff + 1) / stride_h))
-    pad_rows = (rows_out - 1) * stride_r + ksize_r_eff - rows_in
-    pad_cols = (cols_out - 1) * stride_h + ksize_c_eff - cols_in
-
-  pad_rows, pad_cols = max(0, pad_rows), max(0, pad_cols)
+  sp_shape = (input_indices_num, output_indices_num)
+  sp_mat = sparse_tensor.SparseTensor(
+      idx_map,
+      array_ops.ones_like(idx_map[:, 0], dtype=grad.dtype),
+      sp_shape)
+  # Remove all padding locations: [0, :].
+  sp_mat = sparse_ops.sparse_slice(sp_mat,
+                                   (1, 0),
+                                   (input_indices_num - 1, output_indices_num))
 
   grad_expanded = array_ops.transpose(
       array_ops.reshape(
           grad, (batch_size, rows_out, cols_out, ksize_r, ksize_c, channels)),
       (1, 2, 3, 4, 0, 5))
   grad_flat = array_ops.reshape(grad_expanded, (-1, batch_size * channels))
-
-  row_steps = range(0, rows_out * stride_r, stride_r)
-  col_steps = range(0, cols_out * stride_h, stride_h)
-
-  idx = np.zeros((rows_out * cols_out * ksize_r * ksize_c, 2),
-                 dtype=np.int64)
-  idx_len = 0
-  for i in range(rows_out):
-    r_low = row_steps[i] - pad_rows
-    r_high = r_low + ksize_r_eff
-
-    for j in range(cols_out):
-      c_low = col_steps[j] - pad_cols
-      c_high = c_low + ksize_c_eff
-
-      for (ri, r) in enumerate(range(r_low, r_high, rate_r)):
-        for (ci, c) in enumerate(range(c_low, c_high, rate_c)):
-          if 0 <= r and r < rows_in and 0 <= c and c < cols_in:
-            idx[idx_len][0] = r * (cols_in) + c
-            idx[idx_len][1] = (i * (cols_out * ksize_r * ksize_c) +
-                               j * (ksize_r * ksize_c) + ri * (ksize_c) + ci)
-            idx_len += 1
-  idx = idx[:idx_len]
-
-  sp_shape = (rows_in * cols_in, rows_out * cols_out * ksize_r * ksize_c)
-
-  sp_mat = sparse_tensor.SparseTensor(
-      array_ops.constant(idx, dtype=ops.dtypes.int64),
-      array_ops.ones((len(idx),), dtype=grad.dtype), sp_shape)
 
   jac = sparse_ops.sparse_tensor_dense_matmul(sp_mat, grad_flat)
 


### PR DESCRIPTION
Fix #20146.

In the PR, we created indices matrix for input tensor, and reuse `extract_image_patches` to calculate `idx` (the mapping table for indices: input -> output). 

The list below is the performance comparison based on the example of @dbbert in #20146.

Before:
+ constructing time: ~138.4s
+ execute time: ~33.7s

After:
+ constructing time: ~3.6s
+ execute time: ~20.3s