### PR TITLE
Fix typo: host_src -> gpu_src for inter-gpu copy

### DIFF
--- a/tensorflow/stream_executor/stream_executor_internal.h
+++ b/tensorflow/stream_executor/stream_executor_internal.h
@@ -236,7 +236,7 @@ class StreamExecutorInterface {
   virtual bool Memcpy(Stream *stream, DeviceMemoryBase *gpu_dst,
                       const void *host_src, uint64 size) = 0;
   virtual bool MemcpyDeviceToDevice(Stream *stream, DeviceMemoryBase *gpu_dst,
-                                    const DeviceMemoryBase &host_src,
+                                    const DeviceMemoryBase &gpu_src,
                                     uint64 size) = 0;
   virtual bool HostCallback(Stream *stream, std::function<void()> callback) = 0;
   virtual port::Status AllocateEvent(Event *event) = 0;


### PR DESCRIPTION
Fix typo: `host_src` -> `gpu_src`
