### PR TITLE
The method of open addressing is not quadratic probing

### DIFF
--- a/tensorflow/core/lib/gtl/flatrep.h
+++ b/tensorflow/core/lib/gtl/flatrep.h
@@ -339,7 +339,7 @@ class FlatRep {
 
   inline size_t NextIndex(size_t i, uint32 num_probes) const {
     // Quadratic probing.
-    return (i + num_probes) & mask_;
+    return (i + num_probes + 3 * num_probes * num_probes) & mask_;
   }
 };
 


### PR DESCRIPTION
There are three method in open addressing: linear probing, quadratic probing and double hashing, they have such functions:
linear probing: h(k, i) = (h'(k) + i) mod m   (eq.1)
quadratic probing: h(k, i) = (h'(k) + c1 * i + c2 * i^2) mod m  (eq.2)
linear probing: h(k, i) = (h1(k) + i * h2(k)) mod m  (eq.3)
The difference between linear probing and quadratic probing is that there are quadratic component in quadratic probing, c2 * i^2.
But I can't see it in NextIndex():
```
inline size_t NextIndex(size_t i, uint32 num_probes) const {
    // Quadratic probing.
    return (i + num_probes) & mask_;
  }
```
The num_probes is the number of probe, like i in eq.1, so I think NextIndex() is the implement of eq.1. But all the comments said this is quadratic probing, so I add quadratic component in NextIndex().

Besides, the coefficient of quadratic component I choose is random, c1 and c2 is set manually, maybe other numbers are better.