### PR TITLE
Fix typo in docstring of is_tensor

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -942,7 +942,7 @@ def is_tensor(x):  # pylint: disable=invalid-name
   """Check whether `x` is of tensor type.
 
   Check whether an object is a tensor. This check is equivalent to calling
-  `isinstance(x, [tf.Tensor, tf.SparseTensor, tf.Variable])` and also checks
+  `isinstance(x, (tf.Tensor, tf.SparseTensor, tf.Variable))` and also checks
   if all the component variables of a MirroredVariable or a TowerLocalVariable
   are tensors.
 


### PR DESCRIPTION
The isinstance builtin expects a tuple of types, not list.