### PR TITLE
Add the optional param to base64 encode estimator inputs

### DIFF
--- a/tensorflow/contrib/learn/python/learn/utils/input_fn_utils.py
+++ b/tensorflow/contrib/learn/python/learn/utils/input_fn_utils.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 
 import collections
 
+import tensorflow
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import array_ops
@@ -66,7 +67,8 @@ class InputFnOps(collections.namedtuple('InputFnOps',
 
 @deprecated(None, 'Please use '
             'tf.estimator.export.build_parsing_serving_input_receiver_fn.')
-def build_parsing_serving_input_fn(feature_spec, default_batch_size=None):
+def build_parsing_serving_input_fn(feature_spec, default_batch_size=None,
+                                   base64_encode_example=False):
   """Build an input_fn appropriate for serving, expecting fed tf.Examples.
 
   Creates an input_fn that expects a serialized tf.Example fed into a string
@@ -78,16 +80,26 @@ def build_parsing_serving_input_fn(feature_spec, default_batch_size=None):
     feature_spec: a dict of string to `VarLenFeature`/`FixedLenFeature`.
     default_batch_size: the number of query examples expected per batch.
         Leave unset for variable batch size (recommended).
+    base64_encode_example: use base64 to encode serialized examples or not.
 
   Returns:
     An input_fn suitable for use in serving.
   """
   def input_fn():
     """An input_fn that expects a serialized tf.Example."""
-    serialized_tf_example = array_ops.placeholder(dtype=dtypes.string,
-                                                  shape=[default_batch_size],
-                                                  name='input_example_tensor')
-    inputs = {'examples': serialized_tf_example}
+    if base64_encode_example:
+      new_base64_placeholder = tensorflow.placeholder(dtype=tensorflow.string,
+                                                      shape=[default_batch_size],
+                                                      name='input_example_tensor')
+      serialized_tf_example = tensorflow.map_fn(tensorflow.decode_base64,
+                                                new_base64_placeholder)
+      inputs = {'examples': new_base64_placeholder}
+    else:
+      serialized_tf_example = array_ops.placeholder(dtype=dtypes.string,
+                                                    shape=[default_batch_size],
+                                                    name='input_example_tensor')
+      inputs = {'examples': serialized_tf_example}
+
     features = parsing_ops.parse_example(serialized_tf_example, feature_spec)
     labels = None  # these are not known in serving!
     return InputFnOps(features, labels, inputs)

--- a/tensorflow/contrib/learn/python/learn/utils/input_fn_utils.py
+++ b/tensorflow/contrib/learn/python/learn/utils/input_fn_utils.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 
 import collections
 
-import tensorflow
+import tensorflow as tf
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import array_ops
@@ -88,11 +88,11 @@ def build_parsing_serving_input_fn(feature_spec, default_batch_size=None,
   def input_fn():
     """An input_fn that expects a serialized tf.Example."""
     if base64_encode_example:
-      new_base64_placeholder = tensorflow.placeholder(dtype=tensorflow.string,
-                                                      shape=[default_batch_size],
-                                                      name='input_example_tensor')
-      serialized_tf_example = tensorflow.map_fn(tensorflow.decode_base64,
-                                                new_base64_placeholder)
+      new_base64_placeholder = tf.placeholder(dtype=tf.string,
+                                              shape=[default_batch_size],
+                                              name='input_example_tensor')
+      serialized_tf_example = tf.map_fn(tf.decode_base64,
+                                        new_base64_placeholder)
       inputs = {'examples': new_base64_placeholder}
     else:
       serialized_tf_example = array_ops.placeholder(dtype=dtypes.string,

--- a/tensorflow/contrib/learn/python/learn/utils/input_fn_utils.py
+++ b/tensorflow/contrib/learn/python/learn/utils/input_fn_utils.py
@@ -32,11 +32,12 @@ from __future__ import print_function
 
 import collections
 
-import tensorflow as tf
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import parsing_ops
+from tensorflow.python.ops import string_ops
+from tensorflow.python.ops import functional_ops
 from tensorflow.python.util.deprecation import deprecated
 
 
@@ -88,10 +89,10 @@ def build_parsing_serving_input_fn(feature_spec, default_batch_size=None,
   def input_fn():
     """An input_fn that expects a serialized tf.Example."""
     if base64_encode_example:
-      new_base64_placeholder = tf.placeholder(dtype=tf.string,
+      new_base64_placeholder = array_ops.placeholder(dtype=dtypes.string,
                                               shape=[default_batch_size],
                                               name='input_example_tensor')
-      serialized_tf_example = tf.map_fn(tf.decode_base64,
+      serialized_tf_example = functional_ops.map_fn(string_ops.decode_base64,
                                         new_base64_placeholder)
       inputs = {'examples': new_base64_placeholder}
     else:

--- a/tensorflow/python/estimator/export/export.py
+++ b/tensorflow/python/estimator/export/export.py
@@ -23,7 +23,6 @@ import os
 
 import six
 
-import tensorflow as tf
 from tensorflow.python.estimator import util
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -31,6 +30,8 @@ from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import parsing_ops
+from tensorflow.python.ops import string_ops
+from tensorflow.python.ops import functional_ops
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.saved_model import signature_constants
 from tensorflow.python.saved_model import signature_def_utils
@@ -287,10 +288,10 @@ def build_parsing_serving_input_receiver_fn(feature_spec,
   def serving_input_receiver_fn():
     """An input_fn that expects a serialized tf.Example."""
     if base64_encode_example:
-      new_base64_placeholder = tf.placeholder(dtype=tf.string,
+      new_base64_placeholder = array_ops.placeholder(dtype=dtypes.string,
                                               shape=[default_batch_size],
                                               name='input_example_tensor')
-      serialized_tf_example = tf.map_fn(tf.decode_base64,
+      serialized_tf_example = functional_ops.map_fn(string_ops.decode_base64,
                                         new_base64_placeholder)
       receiver_tensors = {'examples': new_base64_placeholder}
     else:

--- a/tensorflow/python/estimator/export/export.py
+++ b/tensorflow/python/estimator/export/export.py
@@ -23,6 +23,7 @@ import os
 
 import six
 
+import tensorflow as tf
 from tensorflow.python.estimator import util
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -265,7 +266,8 @@ class SupervisedInputReceiver(
 
 @estimator_export('estimator.export.build_parsing_serving_input_receiver_fn')
 def build_parsing_serving_input_receiver_fn(feature_spec,
-                                            default_batch_size=None):
+                                            default_batch_size=None,
+                                            base64_encode_example=False):
   """Build a serving_input_receiver_fn expecting fed tf.Examples.
 
   Creates a serving_input_receiver_fn that expects a serialized tf.Example fed
@@ -276,6 +278,7 @@ def build_parsing_serving_input_receiver_fn(feature_spec,
     feature_spec: a dict of string to `VarLenFeature`/`FixedLenFeature`.
     default_batch_size: the number of query examples expected per batch.
         Leave unset for variable batch size (recommended).
+    base64_encode_example: use base64 to encode serialized examples or not.
 
   Returns:
     A serving_input_receiver_fn suitable for use in serving.
@@ -283,11 +286,19 @@ def build_parsing_serving_input_receiver_fn(feature_spec,
 
   def serving_input_receiver_fn():
     """An input_fn that expects a serialized tf.Example."""
-    serialized_tf_example = array_ops.placeholder(
-        dtype=dtypes.string,
-        shape=[default_batch_size],
-        name='input_example_tensor')
-    receiver_tensors = {'examples': serialized_tf_example}
+    if base64_encode_example:
+      new_base64_placeholder = tf.placeholder(dtype=tf.string,
+                                              shape=[default_batch_size],
+                                              name='input_example_tensor')
+      serialized_tf_example = tf.map_fn(tf.decode_base64,
+                                        new_base64_placeholder)
+      receiver_tensors = {'examples': new_base64_placeholder}
+    else:
+      serialized_tf_example = array_ops.placeholder(dtype=dtypes.string,
+                                                    shape=[default_batch_size],
+                                                    name='input_example_tensor')
+      receiver_tensors = {'examples': serialized_tf_example}
+
     features = parsing_ops.parse_example(serialized_tf_example, feature_spec)
     return ServingInputReceiver(features, receiver_tensors)
 


### PR DESCRIPTION
This may resolved https://github.com/tensorflow/tensorflow/issues/21234 .

Using base64 to encode TensorFlow serialized example byte arrays makes it possible to serve the estimator models with RESTful servers.