### PR TITLE
Add complex128 support for tf.as_string

### DIFF
--- a/tensorflow/core/kernels/as_string_op.cc
+++ b/tensorflow/core/kernels/as_string_op.cc
@@ -47,6 +47,7 @@ class AsStringOp : public OpKernel {
       case DT_FLOAT:
       case DT_DOUBLE:
       case DT_COMPLEX64:
+      case DT_COMPLEX128:
         break;
       default:
         OP_REQUIRES(ctx, !(scientific || shortest),
@@ -83,6 +84,7 @@ class AsStringOp : public OpKernel {
       case DT_FLOAT:
       case DT_DOUBLE:
       case DT_COMPLEX64:
+      case DT_COMPLEX128:
         if (shortest) {
           strings::Appendf(&format_, "g");
         } else if (scientific) {
@@ -100,7 +102,7 @@ class AsStringOp : public OpKernel {
                                             DataTypeString(dtype)));
     }
 
-    if (dtype == DT_COMPLEX64) {
+    if (dtype == DT_COMPLEX64 || dtype == DT_COMPLEX128) {
       format_ = strings::Printf("(%s,%s)", format_.c_str(), format_.c_str());
     }
   }
@@ -139,6 +141,13 @@ class AsStringOp : public OpKernel {
       } break;
       case (DT_COMPLEX64): {
         const auto& input_flat = input_tensor->flat<complex64>();
+        for (int i = 0; i < input_flat.size(); ++i) {
+          output_flat(i) = strings::Printf(
+              format_.c_str(), input_flat(i).real(), input_flat(i).imag());
+        }
+      } break;
+      case (DT_COMPLEX128): {
+        const auto& input_flat = input_tensor->flat<complex128>();
         for (int i = 0; i < input_flat.size(); ++i) {
           output_flat(i) = strings::Printf(
               format_.c_str(), input_flat(i).real(), input_flat(i).imag());

--- a/tensorflow/core/ops/string_ops.cc
+++ b/tensorflow/core/ops/string_ops.cc
@@ -78,7 +78,9 @@ REGISTER_OP("ReduceJoin")
 REGISTER_OP("AsString")
     .Input("input: T")
     .Output("output: string")
-    .Attr("T: {int8, int16, int32, int64, complex64, float, double, bool}")
+    .Attr(
+        "T: {int8, int16, int32, int64, complex64, complex128, float, double, "
+        "bool}")
     .Attr("precision: int = -1")
     .Attr("scientific: bool = false")
     .Attr("shortest: bool = false")

--- a/tensorflow/python/kernel_tests/as_string_op_test.py
+++ b/tensorflow/python/kernel_tests/as_string_op_test.py
@@ -160,7 +160,7 @@ class AsStringOpTest(test.TestCase):
     complex_inputs_ = [(x + (x + 1) * 1j) for x in float_inputs_]
 
     with self.test_session():
-      for dtype in (dtypes.complex64,):
+      for dtype in (dtypes.complex64, dtypes.complex128):
         input_ = array_ops.placeholder(dtype)
 
         def clean_nans(s_l):


### PR DESCRIPTION
The tf.as_string supports most of the data types (including `complex64`) but not `complex128`.

This fix add `complex128` support for tf.as_string.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>