### PR TITLE
Update libpng to v1.6.35

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -245,11 +245,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "png_archive",
       urls = [
-          "https://mirror.bazel.build/github.com/glennrp/libpng/archive/v1.6.34.tar.gz",
-          "https://github.com/glennrp/libpng/archive/v1.6.34.tar.gz",
+          "https://mirror.bazel.build/github.com/glennrp/libpng/archive/v1.6.35.tar.gz",
+          "https://github.com/glennrp/libpng/archive/v1.6.35.tar.gz",
       ],
-      sha256 = "e45ce5f68b1d80e2cb9a2b601605b374bdf51e1798ef1c2c2bd62131dfcf9eef",
-      strip_prefix = "libpng-1.6.34",
+      sha256 = "6d59d6a154ccbb772ec11772cb8f8beb0d382b61e7ccc62435bf7311c9f4b210",
+      strip_prefix = "libpng-1.6.35",
       build_file = clean_dep("//third_party:png.BUILD"),
       patch_file = clean_dep("//third_party:png_fix_rpi.patch"),
       system_build_file = clean_dep("//third_party/systemlibs:png.BUILD"),


### PR DESCRIPTION
This fix updates libpng to the latest version of v1.6.35 that was released on 07/2018.
(The last version of v1.6.34 was released on 09/2017)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>