### PR TITLE
Add extra log for failing to load variables

### DIFF
--- a/tensorflow/cc/saved_model/loader.cc
+++ b/tensorflow/cc/saved_model/loader.cc
@@ -169,6 +169,7 @@ Status RunRestore(const RunOptions& run_options, const string& export_dir,
   const string variables_index_path = io::JoinPath(
       variables_directory, MetaFilename(kSavedModelVariablesFilename));
   if (!Env::Default()->FileExists(variables_index_path).ok()) {
+    LOG(INFO) << "Falied to restore variables from " << variables_index_path;
     LOG(INFO) << "The specified SavedModel has no variables; no checkpoints "
                  "were restored.";
     return Status::OK();

--- a/tensorflow/cc/saved_model/loader.cc
+++ b/tensorflow/cc/saved_model/loader.cc
@@ -170,7 +170,7 @@ Status RunRestore(const RunOptions& run_options, const string& export_dir,
       variables_directory, MetaFilename(kSavedModelVariablesFilename));
   if (!Env::Default()->FileExists(variables_index_path).ok()) {
     LOG(INFO) << "The specified SavedModel has no variables; no checkpoints "
-                 "were restored. Failed to restore from " << variables_index_path;
+                 "were restored. File does not exist: " << variables_index_path;
     return Status::OK();
   }
   const string variables_path =

--- a/tensorflow/cc/saved_model/loader.cc
+++ b/tensorflow/cc/saved_model/loader.cc
@@ -170,7 +170,8 @@ Status RunRestore(const RunOptions& run_options, const string& export_dir,
       variables_directory, MetaFilename(kSavedModelVariablesFilename));
   if (!Env::Default()->FileExists(variables_index_path).ok()) {
     LOG(INFO) << "The specified SavedModel has no variables; no checkpoints "
-                 "were restored. File does not exist: " << variables_index_path;
+                 "were restored. File does not exist: "
+              << variables_index_path;
     return Status::OK();
   }
   const string variables_path =

--- a/tensorflow/cc/saved_model/loader.cc
+++ b/tensorflow/cc/saved_model/loader.cc
@@ -169,9 +169,8 @@ Status RunRestore(const RunOptions& run_options, const string& export_dir,
   const string variables_index_path = io::JoinPath(
       variables_directory, MetaFilename(kSavedModelVariablesFilename));
   if (!Env::Default()->FileExists(variables_index_path).ok()) {
-    LOG(INFO) << "Falied to restore variables from " << variables_index_path;
     LOG(INFO) << "The specified SavedModel has no variables; no checkpoints "
-                 "were restored.";
+                 "were restored. Failed to restore from " << variables_index_path;
     return Status::OK();
   }
   const string variables_path =


### PR DESCRIPTION
There is a flaky in tensorflow/serving. There is a chance for loading a new model version to fail and then following version would all fail with the `The specified SavedModel has no variables; no checkpoints were restored` 
related to this https://github.com/tensorflow/serving/issues/1027

Which would cause the serving model have non-initialized weights error.

Adding this extra log would help us understand more on why it's failing 