### PR TITLE
Support constant value tensor shape for tf.constant

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -404,6 +404,14 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False):
   if dtype:
     dtype = dtypes.as_dtype(dtype)
 
+  if shape is not None:
+    if isinstance(shape, ops.Tensor):
+      shape_value = constant_value(shape)
+      shape = shape_value if shape_value is not None else shape
+    shape = [
+        int(dim if not isinstance(dim, ops.Tensor) else constant_value(dim))
+        for dim in shape]
+
   is_quantized = (
       dtype in [
           dtypes.qint8, dtypes.quint8, dtypes.qint16, dtypes.quint16,
@@ -482,7 +490,6 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False):
     is_same_size = True
     shape_size = nparray.size
   else:
-    shape = [int(dim) for dim in shape]
     shape_size = np.prod(shape, dtype=np.int64)
     is_same_size = shape_size == nparray.size
 

--- a/tensorflow/python/kernel_tests/constant_op_test.py
+++ b/tensorflow/python/kernel_tests/constant_op_test.py
@@ -186,6 +186,15 @@ class ConstantTest(test.TestCase):
           shape=[2, 3, 5])
     self.assertEqual(c.get_shape(), [2, 3, 5])
 
+  def testExplicitShapeTensor(self):
+    with ops.Graph().as_default():
+      c = constant_op.constant(
+          np.arange(-15, 15).reshape([2, 3, 5]).astype(np.float32),
+          shape=constant_op.constant([2, 3, 5]))
+      d = constant_op.constant(3, shape=(2, 3, constant_op.constant(5)))
+    self.assertEqual(c.get_shape(), [2, 3, 5])
+    self.assertEqual(d.get_shape(), [2, 3, 5])
+
   @test_util.assert_no_new_pyobjects_executing_eagerly
   def testEagerMemory(self):
     """Tests PyObject refs are managed correctly when executing eagerly."""


### PR DESCRIPTION

This fix tries to address the issue raised in #21267 where
it was not possible to provide a tensor to the shape argument
of tf.constant:
```
tf.constant(3, shape=(3, 1, tf.constant(3)))
```
will throw out ValueError.

This fix is an attempt to address the issue so that at least
the constant value tensor shape like `shape=(3, 1, tf.constant(3))`
or `shape=tf.constant([3, 1, 3])` is supported.
It may not be a complete fix but an improvement.

This fix fixes #21267.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
