### PR TITLE
Update cwise_op_mul_2.cc

### DIFF
--- a/tensorflow/core/kernels/cwise_op_mul_2.cc
+++ b/tensorflow/core/kernels/cwise_op_mul_2.cc
@@ -22,10 +22,10 @@ namespace tensorflow {
 // sharded files, only make its register calls when not __ANDROID_TYPES_SLIM__.
 #if !defined(__ANDROID_TYPES_SLIM__)
 
-REGISTER6(BinaryOp, CPU, "Mul", functor::mul, int8, uint16, int16, int64,
+REGISTER6(BinaryOp, CPU, "Mul", functor::mul, int8, uint16, int32, int64,
           complex64, complex128);
 #if GOOGLE_CUDA
-REGISTER6(BinaryOp, GPU, "Mul", functor::mul, int8, uint16, int16, int64,
+REGISTER6(BinaryOp, GPU, "Mul", functor::mul, int8, uint16, int32, int64,
           complex64, complex128);
 
 #endif  // GOOGLE_CUDA


### PR DESCRIPTION
Building for tf 1.9 for iOS and running custom network. Building with ANDROID_TYPES_FULL.
Solve issue:
No OpKernel was registered to support Op 'Mul' with these attrs. Registered devices: [CPU], Registered kernels:
device='CPU'; T in [DT_INT32]