### PR TITLE
Support complex type for tf.Print (Fix issue #21250)

### DIFF
--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -904,6 +904,10 @@ inline const strings::AlphaNum& PrintOneElement(const strings::AlphaNum& a) {
 inline float PrintOneElement(const Eigen::half& h) {
   return static_cast<float>(h);
 }
+template <typename T>
+inline const std::complex<T>& PrintOneElement(const std::complex<T>& a) {
+  return a;
+}
 
 // Print from left dim to right dim recursively.
 template <typename T>
@@ -1013,6 +1017,13 @@ string Tensor::SummarizeValue(int64 max_entries) const {
       // will emit "1 0..." which is more compact.
       return SummarizeArray<bool>(limit, num_elts, shape_, data);
       break;
+    case DT_COMPLEX64:
+      return SummarizeArray<std::complex<float>>(limit, num_elts, shape_, data);
+      break;
+    case DT_COMPLEX128:
+      return SummarizeArray<std::complex<double>>(limit, num_elts, shape_,
+                                                  data);
+      break;
     default: {
       // All irregular cases
       string ret;
@@ -1030,7 +1041,7 @@ string Tensor::SummarizeValue(int64 max_entries) const {
           } break;
           default:
             // TODO(zhifengc, josh11b): Pretty-print other types (bool,
-            // complex64, quantized).
+            // quantized).
             strings::StrAppend(&ret, "?");
         }
       }

--- a/tensorflow/core/framework/tensor_test.cc
+++ b/tensorflow/core/framework/tensor_test.cc
@@ -1278,6 +1278,20 @@ TEST(SummarizeValue, BOOL) {
   EXPECT_EQ("0 1 1...", x.SummarizeValue(3));
 }
 
+TEST(SummarizeValue, COMPLEX64) {
+  Tensor x =
+      MkTensor<complex64>(DT_COMPLEX64, TensorShape({5}), {1, 2, 3, 4, 0});
+  EXPECT_EQ("1+0j 2+0j 3+0j 4+0j 0+0j", x.SummarizeValue(16));
+  x = MkTensor<complex64>(DT_COMPLEX64, TensorShape({2, 2}), {1, 2, 3, 4, 0});
+  EXPECT_EQ("[1+0j 2+0j][3+0j 4+0j]", x.SummarizeValue(16));
+  x = MkTensor<complex64>(DT_COMPLEX64, TensorShape({2, 2, 1, 1}),
+                          {1, 2, 3, 4, 0});
+  EXPECT_EQ("[[[1+0j]][[2+0j]]][[[3+0j]][[4+0j]]]", x.SummarizeValue(16));
+  EXPECT_EQ("[[[1+0j]][[2+0j]]][[[3+0j]]]...", x.SummarizeValue(3));
+  x = MkTensor<complex64>(DT_COMPLEX64, TensorShape({0}), {});
+  EXPECT_EQ("", x.SummarizeValue(16));
+}
+
 TEST(SummarizeValue, STRING) {
   Tensor x = MkTensor<string>(DT_STRING, TensorShape({5}),
                               {"one", "two", "three", "four", "five"});

--- a/tensorflow/core/lib/strings/strcat.h
+++ b/tensorflow/core/lib/strings/strcat.h
@@ -20,6 +20,7 @@ limitations under the License.
 #ifndef TENSORFLOW_LIB_STRINGS_STRCAT_H_
 #define TENSORFLOW_LIB_STRINGS_STRCAT_H_
 
+#include <complex>
 #include <string>
 
 #include "tensorflow/core/lib/core/stringpiece.h"
@@ -228,6 +229,10 @@ inline void StrAppend(string *dest, const AlphaNum &a, const AlphaNum &b,
   internal::AppendPieces(dest,
                          {a.Piece(), b.Piece(), c.Piece(), d.Piece(), e.Piece(),
                           static_cast<const AlphaNum &>(args).Piece()...});
+}
+template <class T>
+inline void StrAppend(string *dest, const std::complex<T> &a) {
+  StrAppend(dest, a.real(), "+", a.imag(), "j");
 }
 
 }  // namespace strings

--- a/tensorflow/core/lib/strings/strcat_test.cc
+++ b/tensorflow/core/lib/strings/strcat_test.cc
@@ -281,6 +281,11 @@ TEST(StrAppend, Basics) {
   EXPECT_EQ(result.substr(old_size),
             "A hundred K and a half squared is 10000100000.25");
 
+  std::complex<float> c(0.5, 1);
+  old_size = result.size();
+  tensorflow::strings::StrAppend(&result, c);
+  EXPECT_EQ(result.substr(old_size), "0.5+1j");
+
   // Test 9 arguments, the old maximum
   old_size = result.size();
   tensorflow::strings::StrAppend(&result, 1, 22, 333, 4444, 55555, 666666,


### PR DESCRIPTION
Fix issue #21250 

The following tests passed:
- On mac, rebuilding the python package and executing the test case from the issue above
- With Docker and TensorFlow's CI scripts: `//tensorflow/core:framework_tensor_test` & `//tensorflow/core:lib_strings_strcat_test`

Clang-format was used to verify the C++ coding style.

Note that it is my first pull request in this project, so let me know if anything is missing.
