### PR TITLE
fix var type issue which breaks crf_decode

### DIFF
--- a/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
+++ b/tensorflow/contrib/crf/python/kernel_tests/crf_test.py
@@ -158,7 +158,7 @@ class CrfTest(test.TestCase):
     # Test both the length-1 and regular cases.
     sequence_lengths_list = [
         np.array(3, dtype=np.int32),
-        np.array(1, dtype=np.int32)
+        np.array(1, dtype=np.int64)
     ]
     inputs_list = [
         np.array([[4, 5, -3], [3, -1, 3], [-1, 2, 1], [0, 0, 0]],
@@ -291,7 +291,7 @@ class CrfTest(test.TestCase):
     # Test both the length-1 and regular cases.
     sequence_lengths_list = [
         np.array(3, dtype=np.int32),
-        np.array(1, dtype=np.int32)
+        np.array(1, dtype=np.int64)
     ]
     inputs_list = [
         np.array([[4, 5, -3], [3, -1, 3], [-1, 2, 1], [0, 0, 0]],

--- a/tensorflow/contrib/crf/python/ops/crf.py
+++ b/tensorflow/contrib/crf/python/ops/crf.py
@@ -548,7 +548,9 @@ def crf_decode(potentials, transition_params, sequence_length):
     initial_state = array_ops.squeeze(initial_state, axis=[1])  # [B, O]
     inputs = array_ops.slice(potentials, [0, 1, 0], [-1, -1, -1])  # [B, T-1, O]
     # Sequence length is not allowed to be less than zero.
-    sequence_length_less_one = math_ops.maximum(0, sequence_length - 1)
+    sequence_length_less_one = math_ops.maximum(
+        constant_op.constant(0, dtype=sequence_length.dtype),
+        sequence_length - 1)
     backpointers, last_score = rnn.dynamic_rnn(  # [B, T - 1, O], [B, O]
         crf_fwd_cell,
         inputs=inputs,


### PR DESCRIPTION
CRF decode can fail when default type of "0" (as viewed by math_ops.maximum) does not match the type of sequence_length. 

This change is parallel in motivation and solution to the fix in https://github.com/tensorflow/tensorflow/commit/c0f1080188c5c6955cfa3b3c086ac262b1e5ec02, for crf_log_norm()=>_multi_seq_fn().