### PR TITLE
Move bazel.rc to workspace root to support bazel-0.18.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,7 +29,7 @@ build:mkl -c opt
 
 # This config option is used to enable MKL-DNN open source library only,
 # without depending on MKL binary version.
-build:mkl_open_source_only --define=build_with_mkl_dnn_only=true 
+build:mkl_open_source_only --define=build_with_mkl_dnn_only=true
 build:mkl_open_source_only --define=build_with_mkl=true --define=enable_mkl=true
 
 build:download_clang --crosstool_top=@local_config_download_clang//:toolchain
@@ -84,3 +84,5 @@ build:dynamic_kernels --define=dynamic_loaded_kernels=true
 build --define=PREFIX=/usr
 build --define=LIBDIR=$(PREFIX)/lib
 build --define=INCLUDEDIR=$(PREFIX)/include
+
+# Do not commit the tf_configure.bazelrc line

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 .ipynb_checkpoints
 node_modules
-/.bazelrc
 /.tf_configure.bazelrc
 /bazel-*
 /bazel_pip

--- a/configure.py
+++ b/configure.py
@@ -257,11 +257,7 @@ def reset_tf_configure_bazelrc(workspace_path):
       if _TF_BAZELRC_FILENAME in l:
         continue
       f.write('%s\n' % l)
-    if is_windows():
-      tf_bazelrc_path = _TF_BAZELRC.replace('\\', '/')
-    else:
-      tf_bazelrc_path = _TF_BAZELRC
-    f.write('import %s\n' % tf_bazelrc_path)
+    f.write('import %%workspace%%/%s\n' % _TF_BAZELRC_FILENAME)
 
 
 def cleanup_makefile():


### PR DESCRIPTION
Bazel 0.17.0 will contain a change for which rc files it accepts.
https://github.com/bazelbuild/bazel/commit/ec83598cb6ee4136166bb562a24dc5dfa58921db
https://github.com/bazelbuild/bazel/issues/4502

Old bazel used to read %workspace%/tools/bazel.rc. New bazel will not
read that and instead will only read %workspace%/.bazelrc.

Signed-off-by: Jason Zaman <jason@perfinion.com>

Also updates bazel rules_closure to the latest and changes ./configure to echo a workspace relative path instead of full path in case the .bazelrc accidentally gets committed.
