### PR TITLE
Raspberry Pi install command not properly formatted.

### DIFF
--- a/tensorflow/docs_src/install/install_raspbian.md
+++ b/tensorflow/docs_src/install/install_raspbian.md
@@ -78,8 +78,8 @@ your system, run the following command:
 Assuming the prerequisite software is installed on your Pi, install TensorFlow
 by invoking **one** of the following commands:
 
-     <pre> $ <b>pip3 install tensorflow</b>     # Python 3.n
-     $ <b>pip install tensorflow</b>      # Python 2.7</pre>
+<pre>$ <b>pip3 install tensorflow</b>     # Python 3.n
+$ <b>pip install tensorflow</b>      # Python 2.7</pre>
 
 This can take some time on certain platforms like the Pi Zero, where some Python
 packages like scipy that TensorFlow depends on need to be compiled before the


### PR DESCRIPTION
Added proper formatting to the install commands.

Please refer to this documentation website page: https://www.tensorflow.org/install/install_raspbian

![image](https://user-images.githubusercontent.com/1383831/43673722-69c097a4-977c-11e8-9489-4766aa4d8b8c.png)

I have fixed this improper formatting so that the shell commands are properly rendered.