### PR TITLE
lib / pip_package: only include licenses if option is enabled

### DIFF
--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -4,7 +4,9 @@
 package(default_visibility = ["//visibility:private"])
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@local_config_syslibs//:build_defs.bzl", "if_not_system_lib")
 load("//tensorflow:tensorflow.bzl", "tf_binary_additional_srcs")
+load("//tensorflow:tensorflow.bzl", "if_cuda")
 load("//third_party/mkl:build_defs.bzl", "if_mkl")
 
 genrule(
@@ -113,11 +115,8 @@ genrule(
         "//third_party/hadoop:LICENSE.txt",
         "//third_party/eigen3:LICENSE",
         "//third_party/fft2d:LICENSE",
-        "@aws//:LICENSE",
         "@boringssl//:LICENSE",
-        "@com_github_googlecloudplatform_google_cloud_cpp//:LICENSE",
         "@com_googlesource_code_re2//:LICENSE",
-        "@cub_archive//:LICENSE.TXT",
         "@curl//:COPYING",
         "@double_conversion//:LICENSE",
         "@eigen_archive//:COPYING.MPL2",
@@ -125,13 +124,8 @@ genrule(
         "@fft2d//:fft/readme.txt",
         "@gemmlowp//:LICENSE",
         "@gif_archive//:COPYING",
-        "@grpc//:LICENSE",
-        "@grpc//third_party/address_sorting:LICENSE",
-        "@grpc//third_party/nanopb:LICENSE.txt",
         "@highwayhash//:LICENSE",
-        "@jemalloc//:COPYING",
         "@jpeg//:LICENSE.md",
-        "@libxsmm_archive//:LICENSE.md",
         "@llvm//:LICENSE.TXT",
         "@lmdb//:LICENSE",
         "@local_config_sycl//sycl:LICENSE.text",
@@ -141,10 +135,42 @@ genrule(
         "@protobuf_archive//:LICENSE",
         "@snappy//:COPYING",
         "@zlib_archive//:zlib.h",
-    ] + if_mkl([
+    ] + select({
+        "//tensorflow:with_aws_support": [
+            "@aws//:LICENSE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow:with_gcp_support": [
+            "@com_github_googlecloudplatform_google_cloud_cpp//:LICENSE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow:with_jemalloc_linux_x86_64": [
+            "@jemalloc//:COPYING",
+        ],
+        "//tensorflow:with_jemalloc_linux_ppc64le": [
+            "@jemalloc//:COPYING",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow/core/kernels:xsmm": [
+            "@libxsmm_archive//:LICENSE.md",
+        ],
+        "//conditions:default": [],
+    }) + if_cuda([
+        "@cub_archive//:LICENSE.TXT",
+    ]) + if_mkl([
         "//third_party/mkl:LICENSE",
         "//third_party/mkl_dnn:LICENSE",
-    ]),
+    ]) + if_not_system_lib(
+        "grpc",
+        [
+            "@grpc//:LICENSE",
+            "@grpc//third_party/nanopb:LICENSE.txt",
+            "@grpc//third_party/address_sorting:LICENSE",
+        ],
+    ),
     outs = ["include/tensorflow/c/LICENSE"],
     cmd = "$(location :concat_licenses.sh) $(SRCS) >$@",
     tools = [":concat_licenses.sh"],
@@ -156,11 +182,8 @@ genrule(
         "//third_party/hadoop:LICENSE.txt",
         "//third_party/eigen3:LICENSE",
         "//third_party/fft2d:LICENSE",
-        "@aws//:LICENSE",
         "@boringssl//:LICENSE",
-        "@com_github_googlecloudplatform_google_cloud_cpp//:LICENSE",
         "@com_googlesource_code_re2//:LICENSE",
-        "@cub_archive//:LICENSE.TXT",
         "@curl//:COPYING",
         "@double_conversion//:LICENSE",
         "@eigen_archive//:COPYING.MPL2",
@@ -169,9 +192,7 @@ genrule(
         "@gemmlowp//:LICENSE",
         "@gif_archive//:COPYING",
         "@highwayhash//:LICENSE",
-        "@jemalloc//:COPYING",
         "@jpeg//:LICENSE.md",
-        "@libxsmm_archive//:LICENSE.md",
         "@llvm//:LICENSE.TXT",
         "@lmdb//:LICENSE",
         "@local_config_sycl//sycl:LICENSE.text",
@@ -181,7 +202,32 @@ genrule(
         "@protobuf_archive//:LICENSE",
         "@snappy//:COPYING",
         "@zlib_archive//:zlib.h",
-    ] + if_mkl([
+    ] + select({
+        "//tensorflow:with_aws_support": [
+            "@aws//:LICENSE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow:with_gcp_support": [
+            "@com_github_googlecloudplatform_google_cloud_cpp//:LICENSE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow:with_jemalloc_linux_x86_64": [
+            "@jemalloc//:COPYING",
+        ],
+        "//tensorflow:with_jemalloc_linux_ppc64le": [
+            "@jemalloc//:COPYING",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow/core/kernels:xsmm": [
+            "@libxsmm_archive//:LICENSE.md",
+        ],
+        "//conditions:default": [],
+    }) + if_cuda([
+        "@cub_archive//:LICENSE.TXT",
+    ]) + if_mkl([
         "//third_party/mkl:LICENSE",
         "//third_party/mkl_dnn:LICENSE",
     ]),

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -131,13 +131,9 @@ filegroup(
         "@absl_py//absl/flags:LICENSE",
         "@arm_neon_2_x86_sse//:LICENSE",
         "@astor_archive//:LICENSE",
-        "@aws//:LICENSE",
         "@boringssl//:LICENSE",
-        "@com_github_googleapis_googleapis//:LICENSE",
-        "@com_github_googlecloudplatform_google_cloud_cpp//:LICENSE",
         "@com_google_absl//:LICENSE",
         "@com_googlesource_code_re2//:LICENSE",
-        "@cub_archive//:LICENSE.TXT",
         "@curl//:COPYING",
         "@double_conversion//:LICENSE",
         "@eigen_archive//:COPYING.MPL2",
@@ -148,12 +144,8 @@ filegroup(
         "@gemmlowp//:LICENSE",
         "@gif_archive//:COPYING",
         "@highwayhash//:LICENSE",
-        "@jemalloc//:COPYING",
         "@jpeg//:LICENSE.md",
-        "@kafka//:LICENSE",
-        "@libxsmm_archive//:LICENSE.md",
         "@lmdb//:LICENSE",
-        "@local_config_nccl//:LICENSE",
         "@local_config_sycl//sycl:LICENSE.text",
         "@nasm//:LICENSE",
         "@nsync//:LICENSE",
@@ -166,7 +158,39 @@ filegroup(
         "@termcolor_archive//:COPYING.txt",
         "@zlib_archive//:zlib.h",
         "@org_python_pypi_backports_weakref//:LICENSE",
-    ] + if_mkl([
+    ] + select({
+        "//tensorflow:with_aws_support": [
+            "@aws//:LICENSE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow:with_gcp_support": [
+            "@com_github_googleapis_googleapis//:LICENSE",
+            "@com_github_googlecloudplatform_google_cloud_cpp//:LICENSE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow:with_jemalloc_linux_x86_64": [
+            "@jemalloc//:COPYING",
+        ],
+        "//tensorflow:with_jemalloc_linux_ppc64le": [
+            "@jemalloc//:COPYING",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow:with_kafka_support": [
+            "@kafka//:LICENSE",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//tensorflow/core/kernels:xsmm": [
+            "@libxsmm_archive//:LICENSE.md",
+        ],
+        "//conditions:default": [],
+    }) + if_cuda([
+        "@cub_archive//:LICENSE.TXT",
+        "@local_config_nccl//:LICENSE",
+    ]) + if_mkl([
         "//third_party/mkl:LICENSE",
         "//third_party/mkl_dnn:LICENSE",
     ]) + if_not_system_lib(


### PR DESCRIPTION
The license files were included unconditionally so the whole dependency
needs to be downloaded even if disabled and not used. This puts them
behind in a select() so they are only included when the feature is
enabled for the build and significantly reduces the dependencies when
configured without all the cloud options.

Signed-off-by: Jason Zaman <jason@perfinion.com>