### PR TITLE
Add support for unknown batch sizes in group_norm.

### DIFF
--- a/tensorflow/contrib/layers/python/layers/normalization.py
+++ b/tensorflow/contrib/layers/python/layers/normalization.py
@@ -235,7 +235,7 @@ def group_norm(inputs,
   """
   # TODO(shlens): Support partially defined shapes for the inputs.
   inputs = ops.convert_to_tensor(inputs)
-  original_shape = inputs.shape
+  original_shape = array_ops.shape(inputs)
 
   if inputs.shape.ndims is None:
     raise ValueError('Inputs %s has undefined rank.' % inputs.name)
@@ -286,6 +286,7 @@ def group_norm(inputs,
   # Reshape the input by the group within the channel dimension.
   inputs_shape = (axes_before_channels + [groups, channels // groups] +
                   axes_after_channels)
+  inputs_shape = list(map(lambda d: -1 if d is None else d, inputs_shape))
   inputs = array_ops.reshape(inputs, inputs_shape)
 
   # Determine the dimensions across which moments are calculated.

--- a/tensorflow/contrib/layers/python/layers/normalization.py
+++ b/tensorflow/contrib/layers/python/layers/normalization.py
@@ -274,10 +274,9 @@ def group_norm(inputs,
   # Determine axes before channels. Some examples of common image formats:
   #  'NCHW': before = [N], after = [HW]
   #  'NHWC': before = [NHW], after = []
-  axes_before_channels = [array_ops.shape(inputs)[i]
-                          for i in range(0,channels_axis)]
-  axes_after_channels = [array_ops.shape(inputs)[i]
-                         for i in range(channels_axis+1,len(inputs.shape))]
+  axes_before_channels = [original_shape[i] for i in range(0, channels_axis)]
+  axes_after_channels = [original_shape[i]
+                         for i in range(channels_axis+1, inputs.shape.ndims)]
 
   # Manually broadcast the parameters to conform to the number of groups.
   params_shape_broadcast = ([1] * len(axes_before_channels) +

--- a/tensorflow/contrib/layers/python/layers/normalization_test.py
+++ b/tensorflow/contrib/layers/python/layers/normalization_test.py
@@ -221,6 +221,18 @@ class GroupNormTest(test.TestCase):
       normalization.group_norm(inputs, channels_axis=-1,
                                reduction_axes=[-3, -2])
 
+  def testParamsShapeNotFullyDefinedBatchAxes(self):
+    inputs = array_ops.placeholder(dtypes.float32, shape=(None, 3, 4, 32))
+    actual_inputs = np.ones(shape=(2, 3, 4, 32))
+    output_op = normalization.group_norm(inputs, channels_axis=-1,
+                                         reduction_axes=[-3, -2])
+
+    with self.test_session() as sess:
+      sess.run(variables.global_variables_initializer())
+      outputs = sess.run(output_op, feed_dict={inputs: actual_inputs})
+      # Make sure that there are no NaNs
+      self.assertFalse(np.isnan(outputs).any())
+
   def testParamsShapeNotFullyDefinedBatchAndSequenceAxes(self):
     inputs = array_ops.placeholder(dtypes.float32, shape=(None, None, 4, 5, 32))
     actual_inputs = np.ones(shape=(2, 3, 4, 5, 32))

--- a/tensorflow/contrib/layers/python/layers/normalization_test.py
+++ b/tensorflow/contrib/layers/python/layers/normalization_test.py
@@ -221,11 +221,11 @@ class GroupNormTest(test.TestCase):
       normalization.group_norm(inputs, channels_axis=-1,
                                reduction_axes=[-3, -2])
 
-  def testParamsShapeNotFullyDefinedOtherAxes(self):
-    inputs = array_ops.placeholder(dtypes.float32, shape=(None, 3, 4, None, 32))
+  def testParamsShapeNotFullyDefinedBatchAndSequenceAxes(self):
+    inputs = array_ops.placeholder(dtypes.float32, shape=(None, None, 4, 5, 32))
     actual_inputs = np.ones(shape=(2, 3, 4, 5, 32))
     output_op = normalization.group_norm(inputs, channels_axis=-1,
-                                         reduction_axes=[-4, -3])
+                                         reduction_axes=[-3, -2])
 
     with self.test_session() as sess:
       sess.run(variables.global_variables_initializer())

--- a/tensorflow/contrib/layers/python/layers/normalization_test.py
+++ b/tensorflow/contrib/layers/python/layers/normalization_test.py
@@ -221,6 +221,18 @@ class GroupNormTest(test.TestCase):
       normalization.group_norm(inputs, channels_axis=-1,
                                reduction_axes=[-3, -2])
 
+  def testParamsShapeNotFullyDefinedOtherAxes(self):
+    inputs = array_ops.placeholder(dtypes.float32, shape=(None, 3, 4, None, 32))
+    actual_inputs = np.ones(shape=(2, 3, 4, 5, 32))
+    output_op = normalization.group_norm(inputs, channels_axis=-1,
+                                         reduction_axes=[-4, -3])
+
+    with self.test_session() as sess:
+      sess.run(variables.global_variables_initializer())
+      outputs = sess.run(output_op, feed_dict={inputs: actual_inputs})
+      # Make sure that there are no NaNs
+      self.assertFalse(np.isnan(outputs).any())
+
   def testCreateOp(self):
     height, width, groups = 3, 3, 4
     images = random_ops.random_uniform((5, height, width, 2*groups), seed=1)


### PR DESCRIPTION
Previously, the `group_norm` layer did not work when the batch size was not known (as is the case when using e.g. `tf.data.Dataset.batch`). 

The change directly addresses this case by replacing a call to `Tensor.shape` with a call to `array_ops.shape`, as well as replacing `None` with `-1` when calling `array_ops.reshape`.