### PR TITLE
Add correlation cost layer from FlowNet

### DIFF
--- a/tensorflow/contrib/BUILD
+++ b/tensorflow/contrib/BUILD
@@ -32,6 +32,7 @@ py_library(
         "//tensorflow/contrib/autograph",
         "//tensorflow/contrib/constrained_optimization",
         "//tensorflow/contrib/copy_graph:copy_graph_py",
+        "//tensorflow/contrib/correlation_cost:correlation_cost_py",
         "//tensorflow/contrib/crf:crf_py",
         "//tensorflow/contrib/cudnn_rnn:cudnn_rnn_py",
         "//tensorflow/contrib/data",
@@ -158,6 +159,7 @@ cc_library(
         "//tensorflow/contrib/text:all_kernels",
     ] + if_mpi(["//tensorflow/contrib/mpi_collectives:mpi_collectives_py"]) + if_cuda([
         "//tensorflow/contrib/nccl:nccl_kernels",
+        "//tensorflow/contrib/correlation_cost:correlation_cost_op_kernels"
     ]) + select({
         "//tensorflow:with_kafka_support_windows_override": [],
         "//tensorflow:with_kafka_support": [

--- a/tensorflow/contrib/correlation_cost/BUILD
+++ b/tensorflow/contrib/correlation_cost/BUILD
@@ -1,0 +1,116 @@
+# Description:
+#   An implementation of the correlation layer computing a cost volume
+
+package(
+    default_visibility = ["//visibility:private"],
+)
+
+package_group(
+    name = "friends",
+    packages = [
+        "//tensorflow/...",
+    ],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+load("//tensorflow:tensorflow.bzl", "tf_kernel_library")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
+load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
+load("//tensorflow:tensorflow.bzl", "tf_gen_op_libs")
+load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
+load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
+
+tf_custom_op_py_library(
+    name = "correlation_cost_py",
+    srcs = ["__init__.py"] + glob(["python/ops/*.py"]),
+    dso = [":python/ops/_correlation_cost_op.so"],
+    kernels = [
+        ":correlation_cost_op_kernels",
+        ":correlation_cost_op_op_lib",
+    ],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":correlation_cost_op",
+        "//tensorflow/contrib/util:util_py",
+        "//tensorflow/python:framework_ops",
+        "//tensorflow/python:platform",
+        "//tensorflow/python:util",
+    ]
+)
+
+tf_kernel_library(
+    name = "correlation_cost_op_kernels",
+    srcs = [
+        "kernels/correlation_cost_op.cc",
+        "kernels/correlation_cost_op.h",
+        "ops/correlation_cost_op.cc",
+    ],
+    gpu_srcs = [
+        "kernels/correlation_cost_op_gpu.cu.cc",
+    ],
+    prefix = "correlation_cost_op",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_proto_parsing",
+        "//tensorflow/core:stream_executor",
+        "//tensorflow/core/kernels:gpu_util_hdrs",
+        "//tensorflow/core/kernels:ops_util_hdrs",
+        "//third_party/eigen3"
+    ] + if_cuda([
+        "@cub_archive//:cub",
+        "//tensorflow/core:gpu_runtime",
+    ]),
+    alwayslink = 1,
+)
+
+tf_custom_op_library(
+    name = "python/ops/_correlation_cost_op.so",
+    srcs = [
+        "kernels/correlation_cost_op.cc",
+        "kernels/correlation_cost_op.h",
+        "ops/correlation_cost_op.cc",
+    ],
+    gpu_srcs = [
+        "kernels/correlation_cost_op_gpu.cu.cc",
+    ],
+    deps = [
+        "//tensorflow/core:lib_proto_parsing",
+        "//tensorflow/core/kernels:gpu_util_hdrs",
+        "//tensorflow/core/kernels:ops_util_hdrs"
+    ] + if_cuda([
+        "@cub_archive//:cub"
+    ])
+)
+
+tf_gen_op_libs(
+    op_lib_names = ["correlation_cost_op"],
+    deps = ["//tensorflow/core:lib_proto_parsing"],
+)
+
+tf_gen_op_wrapper_py(
+    name = "correlation_cost_op",
+    deps = [":correlation_cost_op_op_lib"],
+)
+
+cuda_py_test(
+    name = "correlation_cost_op_test",
+    size = "medium",
+    srcs = ["python/kernel_tests/correlation_cost_op_test.py"],
+    additional_deps = [
+        ":correlation_cost_py",
+        "//third_party/py/numpy",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:dtypes",
+        "//tensorflow/python:platform",
+        "//tensorflow/python:constant_op",
+    ],
+)

--- a/tensorflow/contrib/correlation_cost/__init__.py
+++ b/tensorflow/contrib/correlation_cost/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Ops and modules related to correlation_cost."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# pylint: disable=wildcard-import
+from tensorflow.contrib.correlation_cost.python.ops.correlation_cost_op import *
+from tensorflow.python.util.all_util import remove_undocumented
+
+remove_undocumented(__name__, ['correlation_cost'])

--- a/tensorflow/contrib/correlation_cost/kernels/correlation_cost_op.cc
+++ b/tensorflow/contrib/correlation_cost/kernels/correlation_cost_op.cc
@@ -1,0 +1,344 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/contrib/correlation_cost/kernels/correlation_cost_op.h"
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/util/tensor_format.h"
+
+namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+typedef Eigen::GpuDevice GPUDevice;
+
+namespace functor {
+
+template <typename Dtype>
+struct CorrelationCostFunctor<CPUDevice, Dtype> {
+  Status operator()(OpKernelContext* context, const Tensor& input_a_t,
+                    const Tensor& input_b_t, Tensor* output_t,
+                    /* params */
+                    int kernel_size, int max_displacement, int stride_1,
+                    int stride_2, int pad, TensorFormat data_format) {
+    const int32 oN = GetTensorDim(*output_t, FORMAT_NCHW, 'N');
+    const int32 oH = GetTensorDim(*output_t, FORMAT_NCHW, 'H');
+    const int32 oW = GetTensorDim(*output_t, FORMAT_NCHW, 'W');
+    const int32 iH = GetTensorDim(input_a_t, data_format, 'H');
+    const int32 iW = GetTensorDim(input_a_t, data_format, 'W');
+    const int32 iC = GetTensorDim(input_a_t, data_format, 'C');
+
+    const int K = kernel_size * kernel_size * iC;
+
+    const auto input_a = input_a_t.tensor<Dtype, 4>();
+    const auto input_b = input_b_t.tensor<Dtype, 4>();
+    auto output = output_t->tensor<Dtype, 4>();
+    output.setZero();
+
+    const int kernel_rad = (kernel_size - 1) / 2;
+    const int displacement_rad = max_displacement / stride_2;
+    const int displacement_size = 2 * displacement_rad + 1;
+
+    const bool is_NCHW = (data_format == FORMAT_NCHW);
+
+    for (int n = 0; n < oN; ++n) {
+      for (int h = 0; h < oH; ++h) {
+        const int h1 = (h - pad) * stride_1 + max_displacement + kernel_rad;
+        for (int w = 0; w < oW; ++w) {
+          const int w1 = (w - pad) * stride_1 + max_displacement + kernel_rad;
+
+          for (int tj = -displacement_rad; tj <= displacement_rad; ++tj) {
+            for (int ti = -displacement_rad; ti <= displacement_rad; ++ti) {
+              const int tc = (tj + displacement_rad) * displacement_size +
+                             (ti + displacement_rad);
+
+              const int w2 = w1 + ti * stride_2;
+              const int h2 = h1 + tj * stride_2;
+
+              for (int j = -kernel_rad; j <= kernel_rad; ++j) {
+                // out-of-bound tests
+                if ((h1 + j < 0) || (h1 + j >= iH)) continue;
+                if ((h2 + j < 0) || (h2 + j >= iH)) continue;
+                for (int i = -kernel_rad; i <= kernel_rad; ++i) {
+                  if ((w1 + i < 0) || (w1 + i >= iW)) continue;
+                  if ((w2 + i < 0) || (w2 + i >= iW)) continue;
+                  for (int c = 0; c < iC; ++c) {
+                    // eq. (1) in FlowNet: Learning Optical Flow with
+                    // Convolutional Networks
+                    if (is_NCHW) {
+                      output(n, tc, h, w) += input_a(n, c, h1 + j, w1 + i) *
+                                             input_b(n, c, h2 + j, w2 + i);
+                    } else {
+                      output(n, tc, h, w) += input_a(n, h1 + j, w1 + i, c) *
+                                             input_b(n, h2 + j, w2 + i, c);
+                    }
+                  }
+                }
+              }
+              output(n, tc, h, w) /= K;
+            }
+          }
+        }
+      }
+    }
+    return Status::OK();
+  }
+};
+
+template <typename Dtype>
+struct CorrelationCostGradFunctor<CPUDevice, Dtype> {
+  Status operator()(OpKernelContext* context, const Tensor& input_a_t,
+                    const Tensor& input_b_t, const Tensor& topdiff_t,
+                    Tensor* output_a_gradient_t, Tensor* output_b_gradient_t,
+                    /* params */
+                    int kernel_size, int max_displacement, int stride_1,
+                    int stride_2, int pad, TensorFormat data_format) {
+    const int32 iN = GetTensorDim(input_a_t, data_format, 'N');
+    const int32 iC = GetTensorDim(input_a_t, data_format, 'C');
+    const int32 iH = GetTensorDim(input_a_t, data_format, 'H');
+    const int32 iW = GetTensorDim(input_a_t, data_format, 'W');
+
+    // topdiff is NCHW
+    const int32 oH = GetTensorDim(topdiff_t, FORMAT_NCHW, 'H');
+    const int32 oW = GetTensorDim(topdiff_t, FORMAT_NCHW, 'W');
+
+    const auto topdiff = topdiff_t.tensor<Dtype, 4>();
+    const auto input_a = input_a_t.tensor<Dtype, 4>();
+    const auto input_b = input_b_t.tensor<Dtype, 4>();
+    auto output_a_gradient = output_a_gradient_t->tensor<Dtype, 4>();
+    auto output_b_gradient = output_b_gradient_t->tensor<Dtype, 4>();
+    output_a_gradient.setZero();
+    output_b_gradient.setZero();
+
+    const int kernel_rad = (kernel_size - 1) / 2;
+    const int displacement_rad = max_displacement / stride_2;
+    const int displacement_size = 2 * displacement_rad + 1;
+    const int K = kernel_size * kernel_size * iC;
+
+    const bool is_NCHW = (data_format == FORMAT_NCHW);
+
+    for (int n = 0; n < iN; ++n) {
+      for (int h = 0; h < oH; ++h) {
+        const int h1 = (h - pad) * stride_1 + max_displacement + kernel_rad;
+        for (int w = 0; w < oW; ++w) {
+          const int w1 = (w - pad) * stride_1 + max_displacement + kernel_rad;
+
+          for (int tj = -displacement_rad; tj <= displacement_rad; ++tj) {
+            for (int ti = -displacement_rad; ti <= displacement_rad; ++ti) {
+              const int tc = (tj + displacement_rad) * displacement_size +
+                             (ti + displacement_rad);
+
+              const int w2 = w1 + ti * stride_2;
+              const int h2 = h1 + tj * stride_2;
+
+              for (int j = -kernel_rad; j <= kernel_rad; ++j) {
+                // out-of-bound test
+                if ((h1 + j < 0) || (h1 + j >= iH)) continue;
+                if ((h2 + j < 0) || (h2 + j >= iH)) continue;
+                for (int i = -kernel_rad; i <= kernel_rad; ++i) {
+                  if ((w1 + i < 0) || (w1 + i >= iW)) continue;
+                  if ((w2 + i < 0) || (w2 + i >= iW)) continue;
+                  for (int c = 0; c < iC; ++c) {
+                    // derivative of eq. (1) in FlowNet
+                    if (is_NCHW) {
+                      output_a_gradient(n, c, h1 + j, w1 + i) +=
+                          topdiff(n, tc, h, w) * input_b(n, c, h2 + j, w2 + i) /
+                          K;
+                      output_b_gradient(n, c, h2 + j, w2 + i) +=
+                          topdiff(n, tc, h, w) * input_a(n, c, h1 + j, w1 + i) /
+                          K;
+                    } else {
+                      output_a_gradient(n, h1 + j, w1 + i, c) +=
+                          topdiff(n, tc, h, w) * input_b(n, h2 + j, w2 + i, c) /
+                          K;
+                      output_b_gradient(n, h2 + j, w2 + i, c) +=
+                          topdiff(n, tc, h, w) * input_a(n, h1 + j, w1 + i, c) /
+                          K;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return Status::OK();
+  }
+};
+
+}  // namespace functor
+
+template <typename Device, typename T>
+class CorrelationCostOp : public OpKernel {
+ public:
+  explicit CorrelationCostOp(OpKernelConstruction* context)
+      : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("kernel_size", &kernel_size));
+    OP_REQUIRES_OK(context,
+                   context->GetAttr("max_displacement", &max_displacement));
+    OP_REQUIRES_OK(context, context->GetAttr("stride_1", &stride_1));
+    OP_REQUIRES_OK(context, context->GetAttr("stride_2", &stride_2));
+    OP_REQUIRES_OK(context, context->GetAttr("pad", &pad));
+    string data_format;
+    OP_REQUIRES_OK(context, context->GetAttr("data_format", &data_format));
+    OP_REQUIRES(context, FormatFromString(data_format, &data_format_),
+                errors::InvalidArgument("Invalid data format"));
+    OP_REQUIRES(context, kernel_size % 2 != 0,
+                errors::InvalidArgument("kernel_size must be odd"));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor& input_a_t = context->input(0);
+    const Tensor& input_b_t = context->input(1);
+
+    // we didn't check the batch-dimension during "SetShapeFn"
+    OP_REQUIRES(context, input_a_t.shape() == input_b_t.shape(),
+                errors::InvalidArgument("Input shapes have to be the same"));
+
+    const int32 N = GetTensorDim(input_a_t, data_format_, 'N');
+    const int32 H = GetTensorDim(input_a_t, data_format_, 'H');
+    const int32 W = GetTensorDim(input_a_t, data_format_, 'W');
+
+    // output channels are d**2 where, d = 2r + 1
+    const int32 r = max_displacement / stride_2;
+    const int32 d = 2 * r + 1;
+    const int32 border = max_displacement + (kernel_size - 1) / 2;
+
+    const int32 Cout = d * d;
+    const int32 Hout =
+        static_cast<int>(ceil(static_cast<float>(((H + 2 * pad) - border * 2)) /
+                              static_cast<float>(stride_1)));
+    const int32 Wout =
+        static_cast<int>(ceil(static_cast<float>(((W + 2 * pad) - border * 2)) /
+                              static_cast<float>(stride_1)));
+
+    OP_REQUIRES(context, Hout >= 1,
+                errors::InvalidArgument(
+                    "Neighborhood and kernel don't fit in input height."));
+    OP_REQUIRES(context, Wout >= 1,
+                errors::InvalidArgument(
+                    "Neighborhood and kernel don't fit in input width."));
+
+    Tensor* output_t;
+    OP_REQUIRES_OK(
+        context, context->allocate_output(0, TensorShape({N, Cout, Hout, Wout}),
+                                          &output_t));
+
+
+    functor::CorrelationCostFunctor<Device, T> correlationCostFunc;
+    Status s = correlationCostFunc(
+        context, input_a_t, input_b_t, output_t,
+        /* params */
+        kernel_size, max_displacement, stride_1, stride_2, pad, data_format_);
+
+    OP_REQUIRES_OK(context, s);
+  }
+
+ private:
+  int kernel_size;
+  int max_displacement;
+  int stride_1;
+  int stride_2;
+  int pad;
+  TensorFormat data_format_;
+};
+
+template <typename Device, typename T>
+class CorrelationCostGradOp : public OpKernel {
+ public:
+  explicit CorrelationCostGradOp(OpKernelConstruction* context)
+      : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("kernel_size", &kernel_size));
+    OP_REQUIRES_OK(context,
+                   context->GetAttr("max_displacement", &max_displacement));
+    OP_REQUIRES_OK(context, context->GetAttr("stride_1", &stride_1));
+    OP_REQUIRES_OK(context, context->GetAttr("stride_2", &stride_2));
+    OP_REQUIRES_OK(context, context->GetAttr("pad", &pad));
+    string data_format;
+    OP_REQUIRES_OK(context, context->GetAttr("data_format", &data_format));
+    OP_REQUIRES(context, FormatFromString(data_format, &data_format_),
+                errors::InvalidArgument("Invalid data format"));
+    OP_REQUIRES(context, kernel_size % 2 != 0,
+                errors::InvalidArgument("kernel_size must be odd"));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor& input_a_t = context->input(0);
+    const Tensor& input_b_t = context->input(1);
+    const Tensor& topdiff_t = context->input(2);
+
+    OP_REQUIRES(context, input_a_t.shape() == input_b_t.shape(),
+                errors::InvalidArgument("Input shapes have to be the same"));
+
+    // Allocate the memory for the bottom diffs
+    Tensor* output_a_gradient_t;
+    OP_REQUIRES_OK(context, context->allocate_output(0, input_a_t.shape(),
+                                                     &output_a_gradient_t));
+    Tensor* output_b_gradient_t;
+    OP_REQUIRES_OK(context, context->allocate_output(1, input_b_t.shape(),
+                                                     &output_b_gradient_t));
+
+    functor::CorrelationCostGradFunctor<Device, T> correlationCostGrad;
+    Status s = correlationCostGrad(
+        context, input_a_t, input_b_t, topdiff_t,
+        output_a_gradient_t, output_b_gradient_t,
+        /* params */
+        kernel_size, max_displacement, stride_1, stride_2, pad, data_format_);
+
+    OP_REQUIRES_OK(context, s);
+  }
+
+ private:
+  int kernel_size;
+  int max_displacement;
+  int stride_1;
+  int stride_2;
+  int pad;
+  TensorFormat data_format_;
+};
+
+// Register the CPU kernels.
+#define REGISTER_CORRELATIONCOST_OP_CPU(T)                                   \
+  REGISTER_KERNEL_BUILDER(                                                   \
+      Name("CorrelationCost").Device(DEVICE_CPU).TypeConstraint<T>("T"),     \
+      CorrelationCostOp<CPUDevice, T>)                                       \
+  REGISTER_KERNEL_BUILDER(                                                   \
+      Name("CorrelationCostGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
+      CorrelationCostGradOp<CPUDevice, T>)
+
+TF_CALL_float(REGISTER_CORRELATIONCOST_OP_CPU);
+TF_CALL_double(REGISTER_CORRELATIONCOST_OP_CPU);
+#undef REGISTER_CORRELATIONCOST_OP_CPU
+
+// Register the GPU kernels.
+#ifdef GOOGLE_CUDA
+
+#define REGISTER_CORRELATIONCOST_OP_GPU(T)                                   \
+  REGISTER_KERNEL_BUILDER(                                                   \
+      Name("CorrelationCost").Device(DEVICE_GPU).TypeConstraint<T>("T"),     \
+      CorrelationCostOp<GPUDevice, T>)                                       \
+  REGISTER_KERNEL_BUILDER(                                                   \
+      Name("CorrelationCostGrad").Device(DEVICE_GPU).TypeConstraint<T>("T"), \
+      CorrelationCostGradOp<GPUDevice, T>)
+
+TF_CALL_float(REGISTER_CORRELATIONCOST_OP_GPU);
+TF_CALL_double(REGISTER_CORRELATIONCOST_OP_GPU);
+#undef REGISTER_CORRELATIONCOST_OP_GPU
+
+#endif  // GOOGLE_CUDA
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/correlation_cost/kernels/correlation_cost_op.h
+++ b/tensorflow/contrib/correlation_cost/kernels/correlation_cost_op.h
@@ -1,0 +1,47 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORRELATION_COST_OP_H_
+#define TENSORFLOW_CORRELATION_COST_OP_H_
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/util/tensor_format.h"
+
+namespace tensorflow {
+namespace functor {
+
+template <typename Device, typename T>
+struct CorrelationCostFunctor {
+  Status operator()(OpKernelContext* context, const Tensor& input_a_t,
+                    const Tensor& input_b_t, Tensor* output_t,
+                    /* params */
+                    int kernel_size, int max_displacement, int stride_1,
+                    int stride_2, int pad, TensorFormat data_format);
+};
+
+template <typename Device, typename T>
+struct CorrelationCostGradFunctor {
+  Status operator()(OpKernelContext* context, const Tensor& input_a_t,
+                    const Tensor& input_b_t, const Tensor& topdiff_t,
+                    Tensor* output_a_gradient_t, Tensor* output_b_gradient_t,
+                    /* params */
+                    int kernel_size, int max_displacement, int stride_1,
+                    int stride_2, int pad, TensorFormat data_format);
+};
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORRELATION_COST_OP_H_

--- a/tensorflow/contrib/correlation_cost/kernels/correlation_cost_op_gpu.cu.cc
+++ b/tensorflow/contrib/correlation_cost/kernels/correlation_cost_op_gpu.cu.cc
@@ -1,0 +1,493 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA
+
+#define EIGEN_USE_GPU
+
+#include "tensorflow/contrib/correlation_cost/kernels/correlation_cost_op.h"
+
+#include "external/cub_archive/cub/device/device_reduce.cuh"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/util/cuda_kernel_helper.h"
+#include "tensorflow/core/util/tensor_format.h"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+namespace functor {
+
+/*
+This implementation is based on the implementations:
+- https://github.com/lmb-freiburg/flownet2
+- https://github.com/NVIDIA/flownet2-pytorch
+*/
+
+namespace {
+
+template <typename Dtype, unsigned int THREADS_PER_BLOCK>
+__global__ void pad_and_transpose(const Dtype *input, Dtype *output, int C,
+                                  int H, int W, int P) {
+  // NCHW -> pad(NHWC)
+  const int n = blockIdx.x;
+  const int h = blockIdx.y;
+  const int w = blockIdx.z;
+  const int c0 = threadIdx.x;
+  const int pW = (W + 2 * P);
+  const int pH = (H + 2 * P);
+
+  Dtype value;
+  for (int c = c0; c < C; c += THREADS_PER_BLOCK) {
+    value = input[n * (C * H * W) + c * (H * W) + h * W + w];
+    output[n * (C * pH * pW) + (h + P) * (pW * C) + (w + P) * C + c] = value;
+  }
+}
+
+template <typename Dtype, unsigned int THREADS_PER_BLOCK>
+__global__ void pad_and_no_transpose(const Dtype *input, Dtype *output, int C,
+                                     int H, int W, int P) {
+  // NHWC -> pad(NHWC)
+  const int n = blockIdx.x;
+  const int h = blockIdx.y;
+  const int w = blockIdx.z;
+  const int c0 = threadIdx.x;
+  const int pW = (W + 2 * P);
+  const int pH = (H + 2 * P);
+
+  Dtype value;
+  for (int c = c0; c < C; c += THREADS_PER_BLOCK) {
+    value = input[n * (C * H * W) + h * (W * C) + w * C + c];
+    output[n * (C * pH * pW) + (h + P) * (pW * C) + (w + P) * C + c] = value;
+  }
+}
+
+template <typename Dtype, unsigned int THREADS_PER_BLOCK>
+__global__ void Correlation_forward(Dtype *output, int Cout, int Hout, int Wout,
+                                    Dtype *pInput1, int Cin, int Hin, int Win,
+                                    Dtype *pInput2, int pad, int kernel_size,
+                                    int max_displacement, int stride1,
+                                    int stride2) {
+  const int pWin = Win + 2 * pad;
+  const int pHin = Hin + 2 * pad;
+
+  const int kernel_rad = (kernel_size - 1) / 2;
+  const int displacement_rad = max_displacement / stride2;
+  const int displacement_size = 2 * displacement_rad + 1;
+
+  const int n = blockIdx.x;
+  const int h1 = blockIdx.y * stride1 + max_displacement + kernel_rad;
+  const int w1 = blockIdx.z * stride1 + max_displacement + kernel_rad;
+  const int c = threadIdx.x;
+  const int K = kernel_size * kernel_size * Cin;
+
+  typedef cub::WarpReduce<Dtype> WarpReduce;
+  __shared__ typename WarpReduce::TempStorage temp_sum_storage;
+  Dtype thread_accumulation = 0;
+
+  for (int tj = -displacement_rad; tj <= displacement_rad; ++tj) {
+    for (int ti = -displacement_rad; ti <= displacement_rad; ++ti) {
+      thread_accumulation = 0;
+      int w2 = w1 + ti * stride2;
+      int h2 = h1 + tj * stride2;
+
+      for (int j = -kernel_rad; j <= kernel_rad; ++j) {
+        for (int i = -kernel_rad; i <= kernel_rad; ++i) {
+          for (int ch = c; ch < Cin; ch += THREADS_PER_BLOCK) {
+            const int indx1 = n * (pHin * pWin * Cin) +
+                              (h1 + j) * (pWin * Cin) + (w1 + i) * Cin + ch;
+            const int indx2 = n * (pHin * pWin * Cin) +
+                              (h2 + j) * (pWin * Cin) + (w2 + i) * Cin + ch;
+            // pre-loading pInput1[indx1] into shared memory
+            // of size (2*kernel_rad-1)**2 * Cin
+            // yields no speed up
+            thread_accumulation += pInput1[indx1] * pInput2[indx2];
+          }
+        }
+      }
+      __syncthreads();
+
+      // THREADS_PER_BLOCK==32, hence there is only one warp per block
+      const Dtype reduce_sum =
+          WarpReduce(temp_sum_storage).Sum(thread_accumulation);
+      if (c == 0) {
+        const int tc = (tj + displacement_rad) * displacement_size +
+                       (ti + displacement_rad);
+        const int tindx = n * (Cout * Hout * Wout) + tc * (Hout * Wout) +
+                          blockIdx.y * Wout + blockIdx.z;
+        output[tindx] = reduce_sum / K;
+      }
+    }
+  }
+} // namespace
+
+template <typename Dtype, unsigned int THREADS_PER_BLOCK>
+__global__ void Correlation_backward_input1(
+    int item, Dtype *gradInput1, int Cin, int Hin, int Win,
+    const Dtype *gradOutput, int Cout, int Hout, int Wout, const Dtype *rInput2,
+    int pad_size, int kernel_size, int max_displacement, int stride1,
+    int stride2, bool is_NCHW) {
+  const int n = item;
+  const int h = blockIdx.x * stride1 + pad_size;
+  const int w = blockIdx.y * stride1 + pad_size;
+  const int c = blockIdx.z;
+  const int t0 = threadIdx.x;
+
+  const int kernel_rad = (kernel_size - 1) / 2;
+  const int displacement_rad = max_displacement / stride2;
+  const int displacement_size = 2 * displacement_rad + 1;
+
+  int Wmin = (w - kernel_rad - max_displacement) / stride1;
+  int Hmin = (h - kernel_rad - max_displacement) / stride1;
+
+  int Wmax = (w + kernel_rad - max_displacement) / stride1;
+  int Hmax = (h + kernel_rad - max_displacement) / stride1;
+
+  if (Wmax < 0 || Hmax < 0 || Wmin >= Wout || Hmin >= Hout) {
+    // assumes gradInput1 is pre-allocated and zero filled
+    return;
+  }
+
+  if (Wmin > Wmax || Hmin > Hmax) {
+    // assumes gradInput1 is pre-allocated and zero filled
+    return;
+  }
+
+  Wmin = max(0, Wmin);
+  Wmax = min(Wout - 1, Wmax);
+
+  Hmin = max(0, Hmin);
+  Hmax = min(Hout - 1, Hmax);
+
+  const int pWin = Win + 2 * pad_size;
+  const int pHin = Hin + 2 * pad_size;
+  const Dtype nelems = kernel_size * kernel_size * Cin;
+
+  typedef cub::WarpReduce<Dtype> WarpReduce;
+  __shared__ typename WarpReduce::TempStorage temp_sum_storage;
+  Dtype thread_accumulation = 0;
+
+  for (int tc = t0; tc < Cout; tc += THREADS_PER_BLOCK) {
+    int i2 = (tc % displacement_size - displacement_rad) * stride2;
+    int j2 = (tc / displacement_size - displacement_rad) * stride2;
+
+    int indx2 =
+        n * (pHin * pWin * Cin) + (h + j2) * (pWin * Cin) + (w + i2) * Cin + c;
+
+    Dtype val2 = rInput2[indx2];
+
+    for (int j = Hmin; j <= Hmax; ++j) {
+      for (int i = Wmin; i <= Wmax; ++i) {
+        const int tindx =
+            n * (Cout * Hout * Wout) + tc * (Hout * Wout) + j * Wout + i;
+        thread_accumulation += gradOutput[tindx] * val2;
+      }
+    }
+  }
+  __syncthreads();
+
+  // THREADS_PER_BLOCK==32, hence there is only one warp per block
+  const Dtype reduce_sum =
+      WarpReduce(temp_sum_storage).Sum(thread_accumulation);
+  if (t0 == 0) {
+    if (is_NCHW) {
+      const int indx1 = n * (Cin * Hin * Win) + c * (Hin * Win) +
+                        (h - pad_size) * Win + (w - pad_size);
+      gradInput1[indx1] = reduce_sum / nelems;
+    } else {
+      const int indx1 = n * (Cin * Hin * Win) + (h - pad_size) * (Win * Cin) +
+                        (w - pad_size) * Cin + c;
+      gradInput1[indx1] = reduce_sum / nelems;
+    }
+  }
+}
+
+template <typename Dtype, unsigned int THREADS_PER_BLOCK>
+__global__ void Correlation_backward_input2(
+    int item, Dtype *gradInput2, int Cin, int Hin, int Win,
+    const Dtype *gradOutput, int Cout, int Hout, int Wout, const Dtype *rInput1,
+    int pad_size, int kernel_size, int max_displacement, int stride1,
+    int stride2, bool is_NCHW) {
+  const int n = item;
+  const int h = blockIdx.x * stride1 + pad_size;
+  const int w = blockIdx.y * stride1 + pad_size;
+  const int c = blockIdx.z;
+  const int t0 = threadIdx.x;
+
+  const int kernel_rad = (kernel_size - 1) / 2;
+  const int displacement_rad = max_displacement / stride2;
+  const int displacement_size = 2 * displacement_rad + 1;
+
+  const int pWin = Win + 2 * pad_size;
+  const int pHin = Hin + 2 * pad_size;
+  const Dtype nelems = kernel_size * kernel_size * Cin;
+
+  typedef cub::WarpReduce<Dtype> WarpReduce;
+  __shared__ typename WarpReduce::TempStorage temp_sum_storage;
+  Dtype thread_accumulation = 0;
+
+  for (int tc = t0; tc < Cout; tc += THREADS_PER_BLOCK) {
+    const int i2 = (tc % displacement_size - displacement_rad) * stride2;
+    const int j2 = (tc / displacement_size - displacement_rad) * stride2;
+
+    int Wmin = (w - kernel_rad - max_displacement - i2) / stride1;
+    int Hmin = (h - kernel_rad - max_displacement - j2) / stride1;
+
+    int Wmax = (w + kernel_rad - max_displacement - i2) / stride1;
+    int Hmax = (h + kernel_rad - max_displacement - j2) / stride1;
+
+    if (Wmax < 0 || Hmax < 0 || Wmin >= Wout || Hmin >= Hout) {
+      // assumes gradInput2 is pre-allocated and zero filled
+      continue;
+    }
+
+    if (Wmin > Wmax || Hmin > Hmax) {
+      // assumes gradInput2 is pre-allocated and zero filled
+      continue;
+    }
+
+    Wmin = max(0, Wmin);
+    Wmax = min(Wout - 1, Wmax);
+
+    Hmin = max(0, Hmin);
+    Hmax = min(Hout - 1, Hmax);
+
+    const int indx1 =
+        n * (pHin * pWin * Cin) + (h - j2) * (pWin * Cin) + (w - i2) * Cin + c;
+    const Dtype val1 = rInput1[indx1];
+
+    for (int j = Hmin; j <= Hmax; ++j) {
+      for (int i = Wmin; i <= Wmax; ++i) {
+        const int tindx =
+            n * (Cout * Hout * Wout) + tc * (Hout * Wout) + j * Wout + i;
+        thread_accumulation += gradOutput[tindx] * val1;
+      }
+    }
+  }
+  __syncthreads();
+
+  const Dtype reduce_sum =
+      WarpReduce(temp_sum_storage).Sum(thread_accumulation);
+  if (t0 == 0) {
+    if (is_NCHW) {
+      const int indx2 = n * (Cin * Hin * Win) + c * (Hin * Win) +
+                        (h - pad_size) * (Win) + (w - pad_size);
+      gradInput2[indx2] = reduce_sum / nelems;
+    } else {
+      const int indx2 = n * (Cin * Hin * Win) + (h - pad_size) * (Win * Cin) +
+                        (w - pad_size) * Cin + c;
+      gradInput2[indx2] = reduce_sum / nelems;
+    }
+  }
+}
+
+};  // namespace
+
+template <typename Dtype>
+struct CorrelationCostFunctor<GPUDevice, Dtype> {
+  Status operator()(OpKernelContext *context, const Tensor &input_a_t,
+                    const Tensor &input_b_t, Tensor *output_t,
+                    /* params */
+                    int kernel_size, int max_displacement, int stride_1,
+                    int stride_2, int pad, TensorFormat data_format) {
+    // theoretical occupancy of each multiprocessor == 1
+    const int PAD_THREADS_PER_BLOCK = 64;
+    // the overhead of using more than 1 warp/block requires
+    // a sum from >= two warps neglecting the speedup
+    const int CORR_THREADS_PER_BLOCK = 32;
+
+    const int32 N = GetTensorDim(input_a_t, data_format, 'N');
+    const int32 iC = GetTensorDim(input_a_t, data_format, 'C');
+    const int32 iH = GetTensorDim(input_a_t, data_format, 'H');
+    const int32 iW = GetTensorDim(input_a_t, data_format, 'W');
+
+    Tensor padded_a_t;
+    Tensor padded_b_t;
+    TensorShape padded_shape({N, iH + 2 * pad, iW + 2 * pad, iC});
+    Status s;
+    s = context->allocate_temp(DataTypeToEnum<Dtype>::value,
+                               padded_shape, &padded_a_t);
+    if(!TF_PREDICT_TRUE(s.ok())){
+      return s;
+    }
+    s = context->allocate_temp(DataTypeToEnum<Dtype>::value,
+                               padded_shape, &padded_b_t);
+    if(!TF_PREDICT_TRUE(s.ok())){
+      return s;
+    }
+
+    dim3 pad_grid(N, iH, iW);
+    dim3 pad_block(PAD_THREADS_PER_BLOCK);
+
+    const GPUDevice &d = context->eigen_gpu_device();
+
+    // the output is always NCHW (python transposes it to NHWC)
+    const int32 oC = GetTensorDim(*output_t, FORMAT_NCHW, 'C');
+    const int32 oH = GetTensorDim(*output_t, FORMAT_NCHW, 'H');
+    const int32 oW = GetTensorDim(*output_t, FORMAT_NCHW, 'W');
+
+    // set everything to zero (we zero-pad)
+    cudaMemset(padded_a_t.flat<Dtype>().data(), 0,
+               padded_a_t.NumElements() * sizeof(Dtype));
+    cudaMemset(padded_b_t.flat<Dtype>().data(), 0,
+               padded_b_t.NumElements() * sizeof(Dtype));
+    cudaMemset(output_t->flat<Dtype>().data(), 0,
+               output_t->NumElements() * sizeof(Dtype));
+
+    const bool is_NCHW = (data_format == FORMAT_NCHW);
+    if (is_NCHW) {
+      pad_and_transpose<Dtype, PAD_THREADS_PER_BLOCK>
+      <<<pad_grid, pad_block, 0, d.stream()>>>(
+          input_a_t.flat<Dtype>().data(), padded_a_t.flat<Dtype>().data(), iC,
+          iH, iW, pad);
+      pad_and_transpose<Dtype, PAD_THREADS_PER_BLOCK>
+      <<<pad_grid, pad_block, 0, d.stream()>>>(
+          input_b_t.flat<Dtype>().data(), padded_b_t.flat<Dtype>().data(), iC,
+          iH, iW, pad);
+    } else {
+      pad_and_no_transpose<Dtype, PAD_THREADS_PER_BLOCK>
+      <<<pad_grid, pad_block, 0, d.stream()>>>(
+          input_a_t.flat<Dtype>().data(), padded_a_t.flat<Dtype>().data(), iC,
+          iH, iW, pad);
+      pad_and_no_transpose<Dtype, PAD_THREADS_PER_BLOCK>
+      <<<pad_grid, pad_block, 0, d.stream()>>>(
+          input_b_t.flat<Dtype>().data(), padded_b_t.flat<Dtype>().data(), iC,
+          iH, iW, pad);
+    }
+
+    dim3 corr_grid(CORR_THREADS_PER_BLOCK);
+    dim3 corr_block(N, oH, oW);
+
+    Correlation_forward<Dtype, CORR_THREADS_PER_BLOCK>
+        <<<corr_block, corr_grid, 0, d.stream()>>>(
+        output_t->flat<Dtype>().data(), oC, oH, oW,
+        padded_a_t.flat<Dtype>().data(), iC, iH, iW,
+        padded_b_t.flat<Dtype>().data(), pad, kernel_size, max_displacement,
+        stride_1, stride_2);
+
+    return Status::OK();
+  }
+};
+
+template <typename Dtype>
+struct CorrelationCostGradFunctor<GPUDevice, Dtype> {
+  Status operator()(OpKernelContext *context, const Tensor &input_a_t,
+                    const Tensor &input_b_t, const Tensor &topdiff_t,
+                    Tensor *output_a_gradient_t, Tensor *output_b_gradient_t,
+                    /* params */
+                    int kernel_size, int max_displacement, int stride_1,
+                    int stride_2, int pad, TensorFormat data_format) {
+    // theoretical occupancy of each multiprocessor == 1
+    const int PAD_THREADS_PER_BLOCK = 64;
+    // the overhead of using more than 1 warp/block requires
+    // a sum from >= two warps neglecting the speedup
+    const int CORR_THREADS_PER_BLOCK = 32;
+
+    const int32 N = GetTensorDim(input_a_t, data_format, 'N');
+    const int32 iC = GetTensorDim(input_a_t, data_format, 'C');
+    const int32 iH = GetTensorDim(input_a_t, data_format, 'H');
+    const int32 iW = GetTensorDim(input_a_t, data_format, 'W');
+
+    Tensor padded_a_t;
+    Tensor padded_b_t;
+    TensorShape padded_shape({N, iH + 2 * pad, iW + 2 * pad, iC});
+    Status s;
+    s = context->allocate_temp(DataTypeToEnum<Dtype>::value,
+                               padded_shape, &padded_a_t);
+    if(!TF_PREDICT_TRUE(s.ok())){
+      return s;
+    }
+    s = context->allocate_temp(DataTypeToEnum<Dtype>::value,
+                               padded_shape, &padded_b_t);
+    if(!TF_PREDICT_TRUE(s.ok())){
+      return s;
+    }
+
+    const GPUDevice &d = context->eigen_gpu_device();
+
+    dim3 pad_grid(N, iH, iW);
+    dim3 pad_block(PAD_THREADS_PER_BLOCK);
+
+    // topdiff is NCHW
+    const int32 oC = GetTensorDim(topdiff_t, FORMAT_NCHW, 'C');
+    const int32 oH = GetTensorDim(topdiff_t, FORMAT_NCHW, 'H');
+    const int32 oW = GetTensorDim(topdiff_t, FORMAT_NCHW, 'W');
+
+    // set everything to zero (we zero-pad)
+    cudaMemset(padded_a_t.flat<Dtype>().data(), 0,
+               padded_a_t.NumElements() * sizeof(Dtype));
+    cudaMemset(padded_b_t.flat<Dtype>().data(), 0,
+               padded_b_t.NumElements() * sizeof(Dtype));
+    cudaMemset(output_a_gradient_t->flat<Dtype>().data(), 0,
+               output_a_gradient_t->NumElements() * sizeof(Dtype));
+    cudaMemset(output_b_gradient_t->flat<Dtype>().data(), 0,
+               output_b_gradient_t->NumElements() * sizeof(Dtype));
+
+    const bool is_NCHW = (data_format == FORMAT_NCHW);
+    if (is_NCHW) {
+      pad_and_transpose<Dtype, PAD_THREADS_PER_BLOCK>
+      <<<pad_grid, pad_block, 0, d.stream()>>>(
+          input_a_t.flat<Dtype>().data(), padded_a_t.flat<Dtype>().data(), iC,
+          iH, iW, pad);
+      pad_and_transpose<Dtype, PAD_THREADS_PER_BLOCK>
+      <<<pad_grid, pad_block, 0, d.stream()>>>(
+          input_b_t.flat<Dtype>().data(), padded_b_t.flat<Dtype>().data(), iC,
+          iH, iW, pad);
+    } else {
+      pad_and_no_transpose<Dtype, PAD_THREADS_PER_BLOCK>
+      <<<pad_grid, pad_block, 0, d.stream()>>>(
+          input_a_t.flat<Dtype>().data(), padded_a_t.flat<Dtype>().data(), iC,
+          iH, iW, pad);
+      pad_and_no_transpose<Dtype, PAD_THREADS_PER_BLOCK>
+      <<<pad_grid, pad_block, 0, d.stream()>>>(
+          input_b_t.flat<Dtype>().data(), padded_b_t.flat<Dtype>().data(), iC,
+          iH, iW, pad);
+    }
+
+    dim3 corr_grid(CORR_THREADS_PER_BLOCK);
+    dim3 corr_block(iH, iW, iC);
+
+    for (int n = 0; n < N; ++n) {
+      Correlation_backward_input1<Dtype, CORR_THREADS_PER_BLOCK>
+          <<<corr_block, corr_grid, 0, d.stream()>>>(
+          n, output_a_gradient_t->flat<Dtype>().data(), iC, iH, iW,
+          topdiff_t.flat<Dtype>().data(), oC, oH, oW,
+          padded_b_t.flat<Dtype>().data(), pad, kernel_size, max_displacement,
+          stride_1, stride_2, is_NCHW);
+    }
+
+    for (int n = 0; n < N; n++) {
+      Correlation_backward_input2<Dtype, CORR_THREADS_PER_BLOCK>
+          <<<corr_block, corr_grid, 0, d.stream()>>>(
+          n, output_b_gradient_t->flat<Dtype>().data(), iC, iH, iW,
+          topdiff_t.flat<Dtype>().data(), oC, oH, oW,
+          padded_a_t.flat<Dtype>().data(), pad, kernel_size, max_displacement,
+          stride_1, stride_2, is_NCHW);
+    }
+
+    return Status::OK();
+  }
+};
+
+template struct CorrelationCostFunctor<GPUDevice, float>;
+template struct CorrelationCostFunctor<GPUDevice, double>;
+template struct CorrelationCostGradFunctor<GPUDevice, float>;
+template struct CorrelationCostGradFunctor<GPUDevice, double>;
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA

--- a/tensorflow/contrib/correlation_cost/ops/correlation_cost_op.cc
+++ b/tensorflow/contrib/correlation_cost/ops/correlation_cost_op.cc
@@ -1,0 +1,113 @@
+// Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or  implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+
+using ::tensorflow::shape_inference::InferenceContext;
+using ::tensorflow::shape_inference::ShapeHandle;
+
+// --------------------------------------------------------------------------
+
+REGISTER_OP("CorrelationCost")
+    .Input("input_a: T")
+    .Input("input_b: T")
+    .Output("output: T")
+    .Attr("kernel_size: int")
+    .Attr("max_displacement: int")
+    .Attr("stride_1: int")
+    .Attr("stride_2: int")
+    .Attr("pad: int")
+    .Attr("data_format: {'NHWC', 'NCHW'} = 'NHWC'")
+    .Attr("T: realnumbertype")
+    .SetShapeFn([](InferenceContext* c) {
+      ShapeHandle input_a, input_b, input;
+
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &input_a));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 4, &input_b));
+      TF_RETURN_IF_ERROR(c->Merge(input_a, input_b, &input));
+
+      // get input shapes
+      int32 B, H, W;
+      B = c->Value(c->Dim(input, 0));
+      string data_format;
+      Status s = c->GetAttr("data_format", &data_format);
+      if (s.ok() && data_format == "NCHW") {
+        H = c->Value(c->Dim(input, 2));
+        W = c->Value(c->Dim(input, 3));
+      } else {
+        H = c->Value(c->Dim(input, 1));
+        W = c->Value(c->Dim(input, 2));
+      }
+
+      int32 kernel_size;
+      int32 max_displacement;
+      int32 stride_1;
+      int32 stride_2;
+      int32 pad;
+
+      TF_RETURN_IF_ERROR(c->GetAttr("kernel_size", &kernel_size));
+      TF_RETURN_IF_ERROR(c->GetAttr("max_displacement", &max_displacement));
+      // stride in input
+      TF_RETURN_IF_ERROR(c->GetAttr("stride_1", &stride_1));
+      // stride in patch
+      TF_RETURN_IF_ERROR(c->GetAttr("stride_2", &stride_2));
+      TF_RETURN_IF_ERROR(c->GetAttr("pad", &pad));
+
+      // output channels are d**2 where, d = 2r + 1
+      const int32 r = max_displacement / stride_2;
+      const int32 d = 2 * r + 1;
+      const int32 border = max_displacement + (kernel_size - 1) / 2;
+
+      const int32 Cout = d * d;
+      // for spatial dimensions, we pad the inputs
+      const int32 Hout = static_cast<int>(
+          ceil(static_cast<float>(((H + 2 * pad) - border * 2)) /
+               static_cast<float>(stride_1)));
+      const int32 Wout = static_cast<int>(
+          ceil(static_cast<float>(((W + 2 * pad) - border * 2)) /
+               static_cast<float>(stride_1)));
+
+      // Note, the output is always NCHW (even when input is NHWC)
+      c->set_output(0, c->MakeShape({B, Cout, Hout, Wout}));
+      return Status::OK();
+    })
+    .Doc(R"doc(CorrelationCost op.)doc");
+
+REGISTER_OP("CorrelationCostGrad")
+    .Input("orig_input_a: T")
+    .Input("orig_input_b: T")
+    .Input("top_diff: T")
+    .Output("bottom_diff_a: T")
+    .Output("bottom_diff_b: T")
+    .Attr("T: realnumbertype")
+    .Attr("kernel_size: int")
+    .Attr("max_displacement: int")
+    .Attr("stride_1: int")
+    .Attr("stride_2: int")
+    .Attr("pad: int")
+    .Attr("data_format: {'NHWC', 'NCHW'} = 'NHWC'")
+    .SetShapeFn([](InferenceContext* c) {
+      ShapeHandle shp_hnd;
+      TF_RETURN_IF_ERROR(c->Merge(c->input(0), c->input(1), &shp_hnd));
+      c->set_output(0, shp_hnd);
+      c->set_output(1, shp_hnd);
+      return Status::OK();
+    })
+    .Doc(R"doc(CorrelationCost op.)doc");
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/correlation_cost/python/__init__.py
+++ b/tensorflow/contrib/correlation_cost/python/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""ops module."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function

--- a/tensorflow/contrib/correlation_cost/python/kernel_tests/correlation_cost_op_test.py
+++ b/tensorflow/contrib/correlation_cost/python/kernel_tests/correlation_cost_op_test.py
@@ -1,0 +1,169 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+
+from tensorflow.contrib.correlation_cost.python.ops import correlation_cost_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.framework import ops
+from tensorflow.python.platform import test
+from tensorflow.python.framework import constant_op
+
+
+class CorrelationCostTest(test.TestCase):
+
+  def _forward(self, input_a, input_b,
+               kernel_size,
+               max_displacement,
+               stride_1,
+               stride_2,
+               pad,
+               data_format,
+               use_gpu=False):
+    with self.test_session(use_gpu=use_gpu, force_gpu=use_gpu) as sess:
+
+      input_a_op = ops.convert_to_tensor(input_a)
+      input_b_op = ops.convert_to_tensor(input_b)
+
+      kernel_size = 1
+      max_displacement = 2
+      stride_1 = 1
+      stride_2 = 2
+      pad = 4
+
+      call_op = correlation_cost_op.correlation_cost
+      actual_op = call_op(input_a_op, input_b_op,
+                          kernel_size=kernel_size,
+                          max_displacement=max_displacement,
+                          stride_1=stride_1,
+                          stride_2=stride_2,
+                          pad=pad,
+                          data_format=data_format)
+
+      return sess.run(actual_op)
+
+  def _forward_both(self, shape, data_format='NCHW', dtype=dtypes.float32):
+    # some shape to test uneven number of channels
+    input_a = np.random.randn(*shape)
+    input_b = np.random.randn(*shape)
+
+    input_a = constant_op.constant(input_a, dtype=dtype)
+    input_b = constant_op.constant(input_b, dtype=dtype)
+
+    kernel_size = 1
+    max_displacement = 2
+    stride_1 = 1
+    stride_2 = 2
+    pad = 4
+
+    if data_format == 'NHWC':
+      input_a = array_ops.transpose(input_a, [0, 2, 3, 1])
+      input_b = array_ops.transpose(input_b, [0, 2, 3, 1])
+
+    actual_cpu = self._forward(input_a, input_b,
+                               kernel_size=kernel_size,
+                               max_displacement=max_displacement,
+                               stride_1=stride_1,
+                               stride_2=stride_2,
+                               pad=pad,
+                               data_format=data_format,
+                               use_gpu=False)
+
+    actual_gpu = self._forward(input_a, input_b,
+                               kernel_size=kernel_size,
+                               max_displacement=max_displacement,
+                               stride_1=stride_1,
+                               stride_2=stride_2,
+                               pad=pad,
+                               data_format=data_format,
+                               use_gpu=True)
+
+    self.assertEqual(actual_cpu.shape, actual_gpu.shape)
+    self.assertAllClose(actual_cpu, actual_gpu)
+
+  def _gradients(self, data_format='NCHW', use_gpu=False):
+
+    batch, channels, height, width = 2, 3, 5, 6
+    input_a = np.random.randn(batch, channels, height, width)
+    input_b = np.random.randn(batch, channels, height, width)
+
+    kernel_size = 1
+    max_displacement = 2
+    stride_1 = 1
+    stride_2 = 2
+    pad = 4
+
+    if data_format == 'NHWC':
+      input_a = input_a.transpose(0, 2, 3, 1)
+      input_b = input_b.transpose(0, 2, 3, 1)
+
+    with self.test_session(use_gpu=use_gpu, force_gpu=use_gpu):
+
+      input_a_op = ops.convert_to_tensor(input_a, dtype=dtypes.float32)
+      input_b_op = ops.convert_to_tensor(input_b, dtype=dtypes.float32)
+
+      call_op = correlation_cost_op.correlation_cost
+      actual_op = call_op(input_a_op, input_b_op,
+                          kernel_size=kernel_size,
+                          max_displacement=max_displacement,
+                          stride_1=stride_1,
+                          stride_2=stride_2,
+                          pad=pad,
+                          data_format=data_format)
+
+      err_a = test.compute_gradient_error(
+          [input_a_op, input_b_op],
+          [input_a.shape, input_b.shape],
+          actual_op, actual_op.shape.as_list())
+
+      self.assertLess(err_a, 1e-4)
+
+  def testForwardSameFloatLarge(self):
+    # to test channel_num larger than 1 warp
+    self._forward_both((1, 65, 3, 4), data_format='NCHW', dtype=dtypes.float32)
+    self._forward_both((1, 65, 3, 4), data_format='NHWC', dtype=dtypes.float32)
+
+  def testForwardSameDoubleLarge(self):
+    # to test channel_num larger than 1 warp
+    self._forward_both((1, 65, 3, 4), data_format='NCHW', dtype=dtypes.float64)
+    self._forward_both((1, 65, 3, 4), data_format='NHWC', dtype=dtypes.float64)
+
+  def testForwardSameFloatSmall(self):
+    # to test channel_num smaller than 1 warp
+    self._forward_both((1, 15, 3, 4), data_format='NCHW', dtype=dtypes.float32)
+    self._forward_both((1, 15, 3, 4), data_format='NHWC', dtype=dtypes.float32)
+
+  def testForwardSameDoubleSmall(self):
+    # to test channel_num smaller than 1 warp
+    self._forward_both((1, 15, 3, 4), data_format='NCHW', dtype=dtypes.float64)
+    self._forward_both((1, 15, 3, 4), data_format='NHWC', dtype=dtypes.float64)
+
+  def testBackwardNCHW(self):
+    self._gradients(data_format='NCHW', use_gpu=False)
+    self._gradients(data_format='NCHW', use_gpu=True)
+
+  def testBackwardNHWC(self):
+    self._gradients(data_format='NHWC', use_gpu=False)
+    self._gradients(data_format='NHWC', use_gpu=True)
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/contrib/correlation_cost/python/ops/correlation_cost_op.py
+++ b/tensorflow/contrib/correlation_cost/python/ops/correlation_cost_op.py
@@ -1,0 +1,124 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tensorflow op performing correlation cost operation."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib.correlation_cost.ops import gen_correlation_cost_op
+from tensorflow.contrib.util import loader
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.platform import resource_loader
+
+_correlation_cost_op_so = loader.load_op_library(
+    resource_loader.get_path_to_datafile("_correlation_cost_op.so"))
+
+# pylint: disable=redefined-builtin
+def correlation_cost(input_a,
+                     input_b,
+                     kernel_size,
+                     max_displacement,
+                     stride_1,
+                     stride_2,
+                     pad,
+                     data_format='NHWC',
+                     name=None):
+  """Correlation Cost Volume computation.
+
+  Computes a cost volume using correlation for two inputs. For feature
+  maps A, B with spatial dimensions w, h, c it computes
+
+    output(a, b) = sum_{l in [-k,k]**2}  < I(a+l), J(b+l) >
+
+  where the patches of size K=2d + 1 are centered in position a resp. b.
+
+  The output shape is [B, C', H', W'], where
+
+    r = max_displacement / stride_2;
+    bd = max_displacement + (kernel_size - 1) / 2
+    C' = (2 * r + 1) ** 2
+    H' = H + 2 * (pad - bd) / stride_1
+    W' = W + 2 * (pad - bd) / stride_1
+
+  Note: When the data_format requests "NHWC", an additional explicit
+    transpose operation is executed.
+
+  Args:
+    input_a: A `Tensor` of the format specified by `data_format`.
+    input_b: A `Tensor` of the format specified by `data_format`.
+    kernel_size: An integer specifying the height and width of the
+        patch used to compute the per-patch costs.
+    max_displacement: An integer specifying the maximum search radius
+        for each position.
+    stride_1: An integer specifying the stride length in the input.
+    stride_2: An integer specifying the stride length in the patch.
+    pad: An integer specifying the paddings in height and width.
+    data_format: Specifies the data format.
+        Possible values are:
+        "NHWC" float [batch, height, width, channels]
+        "NCHW" float [batch, channels, height, width]
+        Defaults to `"NHWC"`.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of the format specified by `data_format`.
+  """
+
+  with ops.name_scope(name, "correlation_cost"):
+    op_call = gen_correlation_cost_op.correlation_cost
+    ret = op_call(input_a, input_b,
+                  kernel_size=kernel_size,
+                  max_displacement=max_displacement,
+                  stride_1=stride_1,
+                  stride_2=stride_2,
+                  pad=pad,
+                  data_format=data_format)
+    if data_format == 'NHWC':
+      # this is easier to maintain without
+      # specializing an additional cuda kernel
+      return array_ops.transpose(ret, [0, 2, 3, 1])
+    return ret
+
+
+correlation_cost_grad = gen_correlation_cost_op.correlation_cost_grad
+
+@ops.RegisterGradient("CorrelationCost")
+def _correlation_cost_grad(op, grad_output):
+  kernel_size = op.get_attr("kernel_size")
+  max_displacement = op.get_attr("max_displacement")
+  stride_1 = op.get_attr("stride_1")
+  stride_2 = op.get_attr("stride_2")
+  pad = op.get_attr("pad")
+  data_format = op.get_attr("data_format")
+
+  input_a = ops.convert_to_tensor(op.inputs[0], name="input_a")
+  input_b = ops.convert_to_tensor(op.inputs[1], name="input_b")
+  grad_output_tensor = ops.convert_to_tensor(grad_output, name="grad_output")
+
+  op_call = gen_correlation_cost_op.correlation_cost_grad
+  grads = op_call(input_a, input_b, grad_output_tensor,
+                  kernel_size=kernel_size,
+                  max_displacement=max_displacement,
+                  stride_1=stride_1,
+                  stride_2=stride_2,
+                  pad=pad,
+                  data_format=data_format)
+
+
+  grad_input_a = ops.convert_to_tensor(grads[0], name="grad_input_a")
+  grad_input_b = ops.convert_to_tensor(grads[1], name="grad_input_b")
+  return [grad_input_a, grad_input_b]

--- a/tensorflow/contrib/nn/__init__.py
+++ b/tensorflow/contrib/nn/__init__.py
@@ -34,6 +34,7 @@ from tensorflow.contrib.nn.python.ops.alpha_dropout import *
 from tensorflow.contrib.nn.python.ops.cross_entropy import *
 from tensorflow.contrib.nn.python.ops.sampling_ops import *
 from tensorflow.contrib.nn.python.ops.scaled_softplus import *
+from tensorflow.contrib.nn.python.ops.correlation_cost import *
 from tensorflow.python.ops.nn_ops import conv1d_transpose
 from tensorflow.python.ops.nn_ops import nth_element
 # pylint: enable=unused-import,wildcard-import


### PR DESCRIPTION
This adds a new operation to compute the correlation layer used in
FlowNet: Learning Optical Flow with Convolutional Networks by
Dosovitskiy et al.

It is a refactored version of the open-source implementation
"https://github.com/NVIDIA/flownet2-pytorch"
resp. [original implementation](
https://github.com/lmb-freiburg/flownet2/blob/master/src/caffe/layers/correlation_layer.cu)
adapted to use CUB and support both data_formats NCHW, NHWC.