### PR TITLE
Don't include -lpthread for android

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -2037,6 +2037,7 @@ cc_library(
         "//tensorflow:freebsd": [],
         "//tensorflow:windows": [],
         "//tensorflow:windows_msvc": [],
+        "//tensorflow:android": [],
         "//conditions:default": [
             "-ldl",
             "-lpthread",


### PR DESCRIPTION
Created to fix https://github.com/tensorflow/tensorflow/issues/21421. 

I'm not sure this is a good idea, this might break something else?