### PR TITLE
Fix issue in get_temp_export_dir under python 3

### DIFF
--- a/tensorflow/python/estimator/export/export.py
+++ b/tensorflow/python/estimator/export/export.py
@@ -590,5 +590,5 @@ def get_temp_export_dir(timestamped_export_dir):
   (dirname, basename) = os.path.split(timestamped_export_dir)
   temp_export_dir = os.path.join(
       compat.as_bytes(dirname),
-      compat.as_bytes('temp-') + compat.as_bytes(basename))
+      b"temp-" + compat.as_bytes(basename))
   return temp_export_dir

--- a/tensorflow/python/estimator/export/export.py
+++ b/tensorflow/python/estimator/export/export.py
@@ -589,5 +589,6 @@ def get_temp_export_dir(timestamped_export_dir):
   """
   (dirname, basename) = os.path.split(timestamped_export_dir)
   temp_export_dir = os.path.join(
-      compat.as_bytes(dirname), compat.as_bytes('temp-{}'.format(basename)))
+      compat.as_bytes(dirname),
+      compat.as_bytes('temp-') + compat.as_bytes(basename))
   return temp_export_dir

--- a/tensorflow/python/estimator/export/export_test.py
+++ b/tensorflow/python/estimator/export/export_test.py
@@ -38,6 +38,7 @@ from tensorflow.python.ops import parsing_ops
 from tensorflow.python.platform import test
 from tensorflow.python.saved_model import signature_constants
 from tensorflow.python.saved_model import signature_def_utils
+from tensorflow.python.util import compat
 
 
 class LabeledTensorMock(object):
@@ -704,6 +705,14 @@ class ExportTest(test_util.TensorFlowTestCase):
     })
 
     self.assertDictEqual(expected_signature_defs, signature_defs)
+
+  def test_get_temp_export_dir(self):
+    # Test case for GitHub issue 21403.
+    export_dir = compat.as_bytes(os.path.join("a", "b", "1533609814"))
+    temp_export_dir = export.get_temp_export_dir(export_dir)
+    self.assertEqual(
+        temp_export_dir,
+        compat.as_bytes(os.path.join("a", "b", "temp-1533609814")))
 
 
 class TensorServingReceiverTest(test_util.TensorFlowTestCase):


### PR DESCRIPTION
This fix tries to address the issue raised in #21403 where
tensorflow.python.estimator.export.get_temp_export_dir
does not work correctly under python 3 due to the combination
of bytes vs non-bytes concatenation:
```
Python 3.5.2 (default, Nov 23 2017, 16:37:01)
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from tensorflow.python.estimator.export import export as export_helpers
>>> export_dir = export_helpers.get_timestamped_export_dir(b"/a/b/")
>>> export_dir
b'/a/b/1533609814'
>>> export_helpers.get_temp_export_dir(export_dir)
b"/a/b/temp-b'1533609814'"
>>>
```
This fix address the issue by adding compat.as_bytes to 'temp-'
before concatenation.

This fix fixes #21403.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>