### PR TITLE
Fix incorrect reference to version compatibility

### DIFF
--- a/tensorflow/docs_src/install/install_go.md
+++ b/tensorflow/docs_src/install/install_go.md
@@ -6,7 +6,7 @@ a Go application. This guide explains how to install and set up the
 [TensorFlow Go package](https://godoc.org/github.com/tensorflow/tensorflow/tensorflow/go).
 
 Warning: The TensorFlow Go API is *not* covered by the TensorFlow
-[API stability guarantees](../guide/version_semantics.md).
+[API stability guarantees](../guide/version_compat.md).
 
 
 ## Supported Platforms


### PR DESCRIPTION
This fix tries to address the issue raised in #21434 where
the link to version compatibility is not correct.
The link should be `version_compat.md`, not `version_semantics.md`.

This fix fixes #21434.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>