### PR TITLE
Fix incorrect doc in sparse_softmax_cross_entropy_with_logits

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2003,8 +2003,8 @@ def sparse_softmax_cross_entropy_with_logits(
   A common use case is to have logits and labels of shape
   `[batch_size, num_classes]`, but higher dimensions are supported, in which
   case the `dim`-th dimension is assumed to be of size `num_classes`.
-  `logits` and `labels` must have the same dtype (either `float16`, `float32`,
-  or `float64`).
+  `logits` must have the dtype of `float16`, `float32`, or `float64`, and
+  `labels` must have the dtype of `int32` or `int64`.
 
   **Note that to avoid confusion, it is required to pass only named arguments to
   this function.**


### PR DESCRIPTION
This fix fixes the incorrect doc in sparse_softmax_cross_entropy_with_logits.
In sparse_softmax_cross_entropy_with_logits, `labels` must be `int32` or `int64` (not the same as `logits` in existing docs), as is seen in:
https://github.com/tensorflow/tensorflow/blob/46cf73f0214bc6208295e36650f1a8ffde4abdd7/tensorflow/core/ops/nn_ops.cc#L1092-L1099

This fix fixes #21435.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>