### PR TITLE
Fix incorrect doc in tf.nn.convolution 

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -711,12 +711,12 @@ def convolution(
   It is required that 1 <= N <= 3.
 
   Args:
-    input: An N-D `Tensor` of type `T`, of shape
+    input: An (N+2)-D `Tensor` of type `T`, of shape
       `[batch_size] + input_spatial_shape + [in_channels]` if data_format does
       not start with "NC" (default), or
       `[batch_size, in_channels] + input_spatial_shape` if data_format starts
       with "NC".
-    filter: An N-D `Tensor` with the same type as `input` and shape
+    filter: An (N+2)-D `Tensor` with the same type as `input` and shape
       `spatial_filter_shape + [in_channels, out_channels]`.
     padding: A string, either `"VALID"` or `"SAME"`. The padding algorithm.
     strides: Optional.  Sequence of N ints >= 1.  Specifies the output stride.


### PR DESCRIPTION
The ranks of input and filter should be N+2 instead of N.
Since the function computes N-D convolution, the input's rank should be N+2 with additional batch and input_channel dimensions, and the filter's rank should be N+2 with additional input_channel and output_channel dimensions.
The function actually requires the length of dilation_rate/stides to be rank(input)-2. Otherwise, it will raise ValueError.