### PR TITLE
Adam docu: learning rate formula

### DIFF
--- a/tensorflow/python/training/adam.py
+++ b/tensorflow/python/training/adam.py
@@ -51,7 +51,7 @@ class AdamOptimizer(optimizer.Optimizer):
     described at the end of section2 of the paper:
 
     $$t := t + 1$$
-    $$lr_t := \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}$$
+    $$lr_t := \text{learning_rate} * \sqrt{(1 - beta_2^t)} / (1 - beta_1^t)$$
 
     $$m_t := beta_1 * m_{t-1} + (1 - beta_1) * g$$
     $$v_t := beta_2 * v_{t-1} + (1 - beta_2) * g * g$$


### PR DESCRIPTION
Fixed formula for the learning rate in the documentation of class AdamOptimizer.

Before, it read

    \text{learning_rate} * \sqrt{(1 - beta_2^t) / (1 - beta_1^t)}

(i.e. the sqrt applied to both numerator and denominator). The new version

    \text{learning_rate} * \sqrt{(1 - beta_2^t)} / (1 - beta_1^t)

(sqrt applied to numerator only) is consistent with the Adam paper and how it
is actually implemented (currently l. 185).