### PR TITLE
Delete confusing comment related to missing output Variable

### DIFF
--- a/tensorflow/contrib/factorization/python/ops/kmeans.py
+++ b/tensorflow/contrib/factorization/python/ops/kmeans.py
@@ -188,7 +188,6 @@ class _ModelFn(object):
     #   center.
     # is_initialized: scalar indicating whether the initial cluster centers
     #   have been chosen; see init_op.
-    # cluster_centers_var: a Variable containing the cluster centers.
     # init_op: an op to choose the initial cluster centers. A single worker
     #   repeatedly executes init_op until is_initialized becomes True.
     # training_op: an op that runs an iteration of training, either an entire


### PR DESCRIPTION
The method `KMeans().training_graph()` does not return anymore the
output Variable `cluster_centers_var`. Thus the related comment
is outdated and should be deleted.
See related [commit](https://github.com/tensorflow/tensorflow/commit/3110185270e93e0b6a3e82be9199febed1239602).