### PR TITLE
Correct links to documentation pages

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -127,9 +127,9 @@ class Model(Network):
 
     Arguments:
         optimizer: String (name of optimizer) or optimizer instance.
-            See [optimizers](/optimizers).
+            See [optimizers](/api_docs/python/tf/keras/optimizers).
         loss: String (name of objective function) or objective function.
-            See [losses](/losses).
+            See [losses](/api_docs/python/tf/losses).
             If the model has multiple outputs, you can use a different loss
             on each output by passing a dictionary or a list of losses.
             The loss value that will be minimized by the model
@@ -1168,7 +1168,7 @@ class Model(Network):
             0 = silent, 1 = progress bar, 2 = one line per epoch.
         callbacks: List of `keras.callbacks.Callback` instances.
             List of callbacks to apply during training.
-            See [callbacks](/callbacks).
+            See [callbacks](/api_docs/python/tf/keras/callbacks).
         validation_split: Float between 0 and 1.
             Fraction of the training data to be used as validation data.
             The model will set apart this fraction of the training data,


### PR DESCRIPTION
I'm not 100% sure these are the correct links (like, there might be a secret shorthand I don't know about), but the current links (on [this page](https://www.tensorflow.org/api_docs/python/tf/keras/Model), under `compile` and `fit`) lead to [404s](https://www.tensorflow.org/losses).