### PR TITLE
RNN.call should get initial state from full input spec

### DIFF
--- a/tensorflow/python/keras/layers/recurrent.py
+++ b/tensorflow/python/keras/layers/recurrent.py
@@ -583,6 +583,14 @@ class RNN(Layer):
     # note that the .build() method of subclasses MUST define
     # self.input_spec and self.state_spec with complete input shapes.
     if isinstance(inputs, list):
+      # get initial_state from full input spec
+      # as they could be copied to multiple GPU.
+      if self._num_constants is None:
+        initial_state = inputs[1:]
+      else:
+        initial_state = inputs[1:-self._num_constants]
+      if len(initial_state) == 0:
+        initial_state = None
       inputs = inputs[0]
     if initial_state is not None:
       pass


### PR DESCRIPTION
Pick the fix at https://github.com/keras-team/keras/pull/10845 to ```tf.keras```, to fix a critical bug when running ```RNN``` with ```multi_gpu_model```.