### PR TITLE
Fix op_scope warning in adjust_gamma

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1377,7 +1377,7 @@ def adjust_gamma(image, gamma=1, gain=1):
     [1] http://en.wikipedia.org/wiki/Gamma_correction
   """
 
-  with ops.op_scope([image, gamma, gain], None, 'adjust_gamma'):
+  with ops.name_scope(None, 'adjust_gamma', [image, gamma, gain]) as name:
     # Convert pixel value to DT_FLOAT for computing adjusted image.
     img = ops.convert_to_tensor(image, name='img', dtype=dtypes.float32)
     # Keep image dtype for computing the scale of corresponding dtype.


### PR DESCRIPTION
While running the following op_scope causes the warning:
```
Python 3.5.2 (default, Nov 23 2017, 16:37:01)
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tensorflow as tf
i>>> import numpy as np
>>> tf.image.adjust_gamma(np.random.uniform(0.0, 255.0, (8, 8)), gamma=1)
WARNING:tensorflow:tf.op_scope(values, name, default_name) is deprecated, use tf.name_scope(name, default_name, values)
<tf.Tensor 'adjust_gamma/mul_1:0' shape=(8, 8) dtype=float32>
>>>
```

This fix fixes the warning by switching op_scope to name_scope.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>