### PR TITLE
Update custom_training with tf.contrib.eager.Variable

### DIFF
--- a/tensorflow/contrib/eager/python/examples/notebooks/custom_training.ipynb
+++ b/tensorflow/contrib/eager/python/examples/notebooks/custom_training.ipynb
@@ -119,7 +119,8 @@
       "source": [
         "import tensorflow as tf\n",
         "\n",
-        "tf.enable_eager_execution()"
+        "tf.enable_eager_execution()",
+        "tfe = tf.contrib.eager"
       ],
       "execution_count": 0,
       "outputs": []
@@ -183,7 +184,7 @@
       },
       "cell_type": "code",
       "source": [
-        "v = tf.Variable(1.0)\n",
+        "v = tfe.Variable(1.0)\n",
         "assert v.numpy() == 1.0\n",
         "\n",
         "# Re-assign the value\n",
@@ -257,8 +258,8 @@
         "  def __init__(self):\n",
         "    # Initialize variable to (5.0, 0.0)\n",
         "    # In practice, these should be initialized to random values.\n",
-        "    self.W = tf.Variable(5.0)\n",
-        "    self.b = tf.Variable(0.0)\n",
+        "    self.W = tfe.Variable(5.0)\n",
+        "    self.b = tfe.Variable(0.0)\n",
         "    \n",
         "  def __call__(self, x):\n",
         "    return self.W * x + self.b\n",


### PR DESCRIPTION
Replacing tf.Variable with tf.contrib.eager.Variable to avoid error: RuntimeError: tf.Variable not supported when eager execution is enabled. Please use tf.contrib.eager.Variable instead. As a result, the notebook can run without error.

 "tf.contrib.eager.Variable" is needed under eager execution is enabled.