### PR TITLE
Fix warning in image_ops_test

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1167,7 +1167,7 @@ def resize_image_with_pad(image,
     _ImageDimensions(padded, rank=4)
 
     if not is_batch:
-      padded = array_ops.squeeze(padded, squeeze_dims=[0])
+      padded = array_ops.squeeze(padded, axis=[0])
 
     return padded
 


### PR DESCRIPTION
While running test:
```
bazel test -s --verbose_failures --config=opt --cache_test_results=no //tensorflow/python:image_ops_test
```

The following warning showed up:
```
WARNING:tensorflow:From /home/ubuntu/.cache/bazel/_bazel_ubuntu/ad1e09741bb4109fbc70ef8216b59ee2/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/image_ops_test.runfiles/org_tensorflow/tensorflow/python/ops/image_ops_impl.py:1170: calling squeeze (from tensorflow.python.ops.array_ops) with squeeze_dims is deprecated and will be removed in a future version.
Instructions for updating:
Use the `axis` argument instead
```

This fix fixes the above warning.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>