### PR TITLE
Fix incorrect doc in tf.layers.dense

### DIFF
--- a/tensorflow/python/layers/core.py
+++ b/tensorflow/python/layers/core.py
@@ -127,8 +127,8 @@ def dense(
   """Functional interface for the densely-connected layer.
 
   This layer implements the operation:
-  `outputs = activation(inputs.kernel + bias)`
-  Where `activation` is the activation function passed as the `activation`
+  `outputs = activation(inputs * kernel + bias)`
+  where `activation` is the activation function passed as the `activation`
   argument (if not `None`), `kernel` is a weights matrix created by the layer,
   and `bias` is a bias vector created by the layer
   (only if `use_bias` is `True`).


### PR DESCRIPTION
This fix tries to address the issue raised in #21525 where
the doc in tf.layers.dense is not correct. Specifically
`outputs = activation(inputs.kernel + bias) Where`
should be:
`outputs = activation(inputs * kernel + bias) where`

This fix fixes #21525.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>