### PR TITLE
Bijector mapping  deep tuple fix

### DIFF
--- a/tensorflow/contrib/distributions/python/kernel_tests/bijectors/conditional_bijector_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/bijectors/conditional_bijector_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.contrib.distributions.python.ops.bijectors.conditional_bijector import ConditionalBijector
+from tensorflow.contrib.distributions.python.ops.bijectors.chain import Chain
 from tensorflow.python.framework import dtypes
 from tensorflow.python.platform import test
 
@@ -47,6 +48,32 @@ class _TestBijector(ConditionalBijector):
     raise ValueError("forward_log_det_jacobian", arg1, arg2)
 
 
+class _TestPassthroughBijector(_TestBijector):
+  def __init__(self, *args, **kwargs):
+      super(_TestPassthroughBijector, self).__init__(*args, **kwargs)
+      self._called = {
+          name: False for name in
+          ('forward', 'inverse',
+           'inverse_log_det_jacobian', 'forward_log_det_jacobian')
+      }
+
+  def _forward(self, _, arg1, arg2):
+    self._called['forward'] = True
+    return _
+
+  def _inverse(self, _, arg1, arg2):
+    self._called['inverse'] = True
+    return _
+
+  def _inverse_log_det_jacobian(self, _, arg1, arg2):
+    self._called['inverse_log_det_jacobian'] = True
+    return _
+
+  def _forward_log_det_jacobian(self, _, arg1, arg2):
+    self._called['forward_log_det_jacobian'] = True
+    return _
+
+
 class ConditionalBijectorTest(test.TestCase):
 
   def testConditionalBijector(self):
@@ -60,6 +87,60 @@ class ConditionalBijectorTest(test.TestCase):
       method = getattr(b, name)
       with self.assertRaisesRegexp(ValueError, name + ".*b1.*b2"):
         method(1., event_ndims=0, arg1="b1", arg2="b2")
+
+  def testChainedConditionalBijector(self):
+    class ConditionalChain(ConditionalBijector, Chain):
+      pass
+
+    test_bijector = _TestBijector()
+    passthrough_bijector = _TestPassthroughBijector()
+    chain = ConditionalChain((test_bijector, passthrough_bijector))
+
+    name = "forward"
+    assert not passthrough_bijector._called[name]
+    method = getattr(chain, name)
+    with self.assertRaisesRegexp(ValueError, name + ".*b1.*b2"):
+      method(
+          1.,
+          test_bijector={"arg1": "b1", "arg2": "b2"},
+          test_passthrough_bijector={"arg1": "b1", "arg2": "b2"})
+    assert passthrough_bijector._called[name], name
+
+    name = "forward_log_det_jacobian"
+    assert not passthrough_bijector._called[name]
+    method = getattr(chain, name)
+    with self.assertRaisesRegexp(ValueError, name + ".*b1.*b2"):
+      method(
+          1.,
+          event_ndims=0,
+          test_bijector={"arg1": "b1", "arg2": "b2"},
+          test_passthrough_bijector={"arg1": "b1", "arg2": "b2"})
+    assert passthrough_bijector._called[name], name
+
+    test_bijector = _TestBijector()
+    passthrough_bijector = _TestPassthroughBijector()
+    chain = ConditionalChain((passthrough_bijector, test_bijector))
+
+    name = "inverse"
+    assert not passthrough_bijector._called[name]
+    method = getattr(chain, name)
+    with self.assertRaisesRegexp(ValueError, name + ".*b1.*b2"):
+      method(
+          1.,
+          test_bijector={"arg1": "b1", "arg2": "b2"},
+          test_passthrough_bijector={"arg1": "b1", "arg2": "b2"})
+    assert passthrough_bijector._called[name], name
+
+    name = "inverse_log_det_jacobian"
+    assert not passthrough_bijector._called[name]
+    method = getattr(chain, name)
+    with self.assertRaisesRegexp(ValueError, name + ".*b1.*b2"):
+      method(
+          1.,
+          event_ndims=0,
+          test_bijector={"arg1": "b1", "arg2": "b2"},
+          test_passthrough_bijector={"arg1": "b1", "arg2": "b2"})
+    assert passthrough_bijector._called[name], name
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/ops/distributions/bijector_impl.py
+++ b/tensorflow/python/ops/distributions/bijector_impl.py
@@ -64,12 +64,12 @@ class _Mapping(collections.namedtuple(
   @property
   def x_key(self):
     """Returns key used for caching Y=g(X)."""
-    return (self.x,) + self._deep_tuple(tuple(sorted(self.kwargs.items())))
+    return (self.x,) + self._deep_tuple(self.kwargs)
 
   @property
   def y_key(self):
     """Returns key used for caching X=g^{-1}(Y)."""
-    return (self.y,) + self._deep_tuple(tuple(sorted(self.kwargs.items())))
+    return (self.y,) + self._deep_tuple(self.kwargs)
 
   def merge(self, x=None, y=None, ildj_map=None, kwargs=None, mapping=None):
     """Returns new _Mapping with args merged with self.
@@ -125,8 +125,12 @@ class _Mapping(collections.namedtuple(
 
   def _deep_tuple(self, x):
     """Converts lists of lists to tuples of tuples."""
-    return (tuple(map(self._deep_tuple, x))
-            if isinstance(x, (list, tuple)) else x)
+    if isinstance(x, dict):
+      return self._deep_tuple(tuple(sorted(x.items())))
+    elif isinstance(x, (list, tuple)):
+      return tuple(map(self._deep_tuple, x))
+
+    return x
 
 
 @six.add_metaclass(abc.ABCMeta)


### PR DESCRIPTION
Right now, Bijector _Mapping's _deep_tuple doesn't allow nested dicts. This problem causes some of the conditioning not to work. See:  #21543. This PR is a possible way to fix the issue.