### PR TITLE
Fix nn_test.py on AVX512 builds

### DIFF
--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -220,7 +220,7 @@ class L2LossTest(test_lib.TestCase):
       output = nn_ops.l2_loss(x)
       err = gradient_checker.compute_gradient_error(x, x_shape, output, [1])
     print("L2Loss gradient err = %g " % err)
-    err_tolerance = 1e-11
+    err_tolerance = 1e-10
     self.assertLess(err, err_tolerance)
 
 


### PR DESCRIPTION
This patch modifies the nn_test test case L2LossTest.testGradient
so that it passes on AVX512 builds.  The test case is failing
as the error tolerance used in the test case is too strict.
The test case compares the difference of pairs of tensor reductions
to an expected result.  If the comparison is out by more than 1e-11
the test case fails.  The problem here is that the results of a
summation reduction of doubles of the same tensor can differ slightly
on different builds.  AVX2, AVX512 and non vectorized versions of the
tensor contraction algorithm add the tensor's contents together in
different orders and this different ordering can produce slightly
different results due to rounding errors.

The accuracy of AVX512 tensor reduction is no worse than the AVX2
implementation.  In fact, it's only luck that this test case passes
on AVX2 builds and fails on AVX512 builds.  If the seed at the start of
the test is changed from 1 to 3, the test passes on AVX512 builds and
fails on AVX2 builds.  Rather than trying to find a seed that allows
the test case to pass on all CPU architectures, it is better to relax
the test criteria a little bit.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>