### PR TITLE
[Intel MKL] Adding keras pip packages to MKL container builds.

### DIFF
--- a/tensorflow/tools/docker/Dockerfile.devel-mkl
+++ b/tensorflow/tools/docker/Dockerfile.devel-mkl
@@ -47,6 +47,7 @@ RUN ${PIP} --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        keras_applications \
         && \
     ${PYTHON} -m ipykernel.kernelspec
 


### PR DESCRIPTION
@gunan @av8ramit Adding this package pulls in all of the other dependencies: 

- keras>=2.1.6
- keras-preprocessing==1.0.2
- pyyaml-3.13