### PR TITLE
Remove the extra clip_by_value created by keras.layers.ReLU

### DIFF
--- a/tensorflow/python/keras/layers/advanced_activations.py
+++ b/tensorflow/python/keras/layers/advanced_activations.py
@@ -315,7 +315,7 @@ class ReLU(Layer):
                        'cannot be negative value: ' + str(negative_slope))
 
     self.support_masking = True
-    self.max_value = K.cast_to_floatx(max_value)
+    self.max_value = None if max_value is None else K.cast_to_floatx(max_value)
     self.negative_slope = K.cast_to_floatx(negative_slope)
     self.threshold = K.cast_to_floatx(threshold)
 


### PR DESCRIPTION
When `max_value` of `tf.keras.layers.ReLU.__init__` is None, [`self.max_value = cast_to_floatx(max_value)` will set `self.max_value` to `nan`](https://github.com/tensorflow/tensorflow/blob/0cf2c612e5e6ff8c5026011e8186056801def747/tensorflow/python/keras/layers/advanced_activations.py#L318). This `nan self.max_value` results in an extra `tf.clip_by_value(..., clip_value_max=nan)` following `tf.nn.relu`.
