### PR TITLE
doc: fix typo in api_guides/cc/guide.md

### DIFF
--- a/tensorflow/docs_src/api_guides/cc/guide.md
+++ b/tensorflow/docs_src/api_guides/cc/guide.md
@@ -270,7 +270,7 @@ the graph need to be executed, and what values need feeding. For example:
 ```c++
 Scope root = Scope::NewRootScope();
 auto c = Const(root, { {1, 1} });
-auto m = MatMul(root, c, { {42}, {1} });
+auto m = MatMul(root, c, { {41}, {1} });
 
 ClientSession session(root);
 std::vector<Tensor> outputs;


### PR DESCRIPTION
When I was learning the cc api from official site, I found the calculation result  and the comment doesn't match, so I send this PR.