### PR TITLE
batch_normalization layers docs (issue #21229)

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -197,7 +197,7 @@ def _fused_batch_norm(inputs,
 
   Can be used as a normalizer function for conv2d and fully_connected.
 
-  Note: when training, the moving_mean and moving_variance need to be updated.
+  Caution: when training, the moving_mean and moving_variance need to be updated.
   By default the update ops are placed in `tf.GraphKeys.UPDATE_OPS`, so they
   need to be added as a dependency to the `train_op`. For example:
 
@@ -463,7 +463,7 @@ def batch_norm(inputs,
   this
   corresponds to the batch and space dimensions.
 
-  Note: when training, the moving_mean and moving_variance need to be updated.
+  Caution: when training, the moving_mean and moving_variance need to be updated.
   By default the update ops are placed in `tf.GraphKeys.UPDATE_OPS`, so they
   need to be added as a dependency to the `train_op`. For example:
 

--- a/tensorflow/python/layers/normalization.py
+++ b/tensorflow/python/layers/normalization.py
@@ -188,7 +188,7 @@ def batch_normalization(inputs,
 
   Sergey Ioffe, Christian Szegedy
 
-  Note: when training, the moving_mean and moving_variance need to be updated.
+  Caution: when training, the moving_mean and moving_variance need to be updated.
   By default the update ops are placed in `tf.GraphKeys.UPDATE_OPS`, so they
   need to be added as a dependency to the `train_op`. Also, be sure to add
   any batch_normalization ops before getting the update_ops collection.


### PR DESCRIPTION
Addresses issue #21229. Changes Notes to Cautions as batch normalization layers do not work properly without taking into account the caution in the Note.