### PR TITLE
fix 'channels_first' conv3d with None shape inputs

### DIFF
--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -197,9 +197,7 @@ class Conv(Layer):
           # As of Mar 2017, direct addition is significantly slower than
           # bias_add when computing gradients. To use bias_add, we collapse Z
           # and Y into a single dimension to obtain a 4D input tensor.
-          outputs_shape = outputs.shape.as_list()
-          if outputs_shape[0] is None:
-            outputs_shape[0] = -1
+          outputs_shape = array_ops.shape(outputs)
           outputs_4d = array_ops.reshape(outputs,
                                          [outputs_shape[0], outputs_shape[1],
                                           outputs_shape[2] * outputs_shape[3],


### PR DESCRIPTION
use array_ops.shape such that 'channels_first' conv3d can support None shape inputs.