### PR TITLE
export symbols in the stream_executor namespace

### DIFF
--- a/tensorflow/tf_exported_symbols.lds
+++ b/tensorflow/tf_exported_symbols.lds
@@ -5,3 +5,4 @@
 *TFE_*
 *nsync_*
 *pywrap_xla*
+*stream_executor*

--- a/tensorflow/tf_version_script.lds
+++ b/tensorflow/tf_version_script.lds
@@ -6,6 +6,7 @@ tensorflow {
     *TFE_*;
     *nsync_*;
     *pywrap_xla*;
+    *stream_executor*;
   local:
     *;
 };


### PR DESCRIPTION
Some of these symbols were previously in the perftools::gputools namespace. Not
having these symbols causes custom ops loading to fail in the monolithic mode.

For example,

bazel test --config monolithic //tensorflow/contrib/rnn:ops/gru_ops_test