### PR TITLE
Added some missing int32 GPU kernel registrations.

### DIFF
--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -124,6 +124,7 @@ REGISTER_KERNEL_BUILDER(
                           ResourceHandleOp<Var>)
 
 TF_CALL_GPU_ALL_TYPES(REGISTER_GPU_KERNELS);
+TF_CALL_int32(REGISTER_GPU_KERNELS);
 TF_CALL_int64(REGISTER_GPU_KERNELS);
 TF_CALL_variant(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS
@@ -347,6 +348,17 @@ TF_CALL_GPU_ALL_TYPES(REGISTER_GPU_KERNELS);
 TF_CALL_int64(REGISTER_GPU_KERNELS);
 TF_CALL_variant(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS
+
+// A special GPU kernel for int32.
+// TODO(b/25387198): Also enable int32 in device memory. This kernel
+// registration requires the int32 value to be in host memory.
+REGISTER_KERNEL_BUILDER(Name("AssignVariableOp")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<int32>("dtype")
+                            .HostMemory("resource")
+                            .HostMemory("value"),
+                        AssignVariableOp<Eigen::ThreadPoolDevice, int32>);
+
 #endif  // GOOGLE_CUDA
 
 template <typename Device, typename T, DenseUpdateType Op>
@@ -405,6 +417,23 @@ TF_CALL_NUMBER_TYPES(REGISTER_KERNELS);
 TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNELS);
 TF_CALL_int64(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS
+
+// Special GPU kernels for int32.
+// TODO(b/25387198): Also enable int32 in device memory. This kernel
+// registration requires the int32 value to be in host memory.
+REGISTER_KERNEL_BUILDER(Name("AssignAddVariableOp")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<int32>("dtype")
+                            .HostMemory("resource")
+                            .HostMemory("value"),
+                        AssignUpdateVariableOp<Eigen::ThreadPoolDevice, int32, ADD>);
+REGISTER_KERNEL_BUILDER(Name("AssignSubVariableOp")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<int32>("dtype")
+                            .HostMemory("resource")
+                            .HostMemory("value"),
+                        AssignUpdateVariableOp<Eigen::ThreadPoolDevice, int32, SUB>);
+
 #endif  // GOOGLE_CUDA
 
 class VarIsInitializedOp : public OpKernel {

--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -105,11 +105,11 @@ REGISTER_KERNEL_BUILDER(Name("ReadVariableOp").Device(DEVICE_CPU),
                         ReadVariableOp);
 
 #if GOOGLE_CUDA
-#define REGISTER_READ_GPU_KERNELS(type)                        \
-  REGISTER_KERNEL_BUILDER(Name("ReadVariableOp")               \
-                              .Device(DEVICE_GPU)              \
-                              .HostMemory("resource")          \
-                              .TypeConstraint<type>("dtype"),  \
+#define REGISTER_READ_GPU_KERNELS(type)                       \
+  REGISTER_KERNEL_BUILDER(Name("ReadVariableOp")              \
+                              .Device(DEVICE_GPU)             \
+                              .HostMemory("resource")         \
+                              .TypeConstraint<type>("dtype"), \
                           ReadVariableOp)
 
 TF_CALL_GPU_ALL_TYPES(REGISTER_READ_GPU_KERNELS);
@@ -439,18 +439,20 @@ TF_CALL_int64(REGISTER_GPU_KERNELS);
 // Special GPU kernels for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel
 // registration requires the int32 value to be in host memory.
-REGISTER_KERNEL_BUILDER(Name("AssignAddVariableOp")
-                            .Device(DEVICE_GPU)
-                            .TypeConstraint<int32>("dtype")
-                            .HostMemory("resource")
-                            .HostMemory("value"),
-                        AssignUpdateVariableOp<Eigen::ThreadPoolDevice, int32, ADD>);
-REGISTER_KERNEL_BUILDER(Name("AssignSubVariableOp")
-                            .Device(DEVICE_GPU)
-                            .TypeConstraint<int32>("dtype")
-                            .HostMemory("resource")
-                            .HostMemory("value"),
-                        AssignUpdateVariableOp<Eigen::ThreadPoolDevice, int32, SUB>);
+REGISTER_KERNEL_BUILDER(
+    Name("AssignAddVariableOp")
+        .Device(DEVICE_GPU)
+        .TypeConstraint<int32>("dtype")
+        .HostMemory("resource")
+        .HostMemory("value"),
+    AssignUpdateVariableOp<Eigen::ThreadPoolDevice, int32, ADD>);
+REGISTER_KERNEL_BUILDER(
+    Name("AssignSubVariableOp")
+        .Device(DEVICE_GPU)
+        .TypeConstraint<int32>("dtype")
+        .HostMemory("resource")
+        .HostMemory("value"),
+    AssignUpdateVariableOp<Eigen::ThreadPoolDevice, int32, SUB>);
 
 #endif  // GOOGLE_CUDA
 


### PR DESCRIPTION
@alextp This helps prevent some performance degradation when allowing soft placement. The issue is that gradient updates are often colocated with the variables they are applied to. When using resource variables, the missing int32 kernel registrations can cause the whole colocation group to be placed on the CPU incurring a big performance penalty. The added int32 kernel registrations follow the same "fake" GPU kernel pattern used in various places (such as the "Concat" and "ConcatV2" ops, for example).