### PR TITLE
Fixed bytes/str issue in get_temp_export_dir

### DIFF
--- a/tensorflow/python/estimator/export/export.py
+++ b/tensorflow/python/estimator/export/export.py
@@ -589,5 +589,5 @@ def get_temp_export_dir(timestamped_export_dir):
   """
   (dirname, basename) = os.path.split(timestamped_export_dir)
   temp_export_dir = os.path.join(
-      compat.as_bytes(dirname), compat.as_bytes('temp-{}'.format(basename)))
+      compat.as_bytes(dirname), b'temp-' + compat.as_bytes(basename))
   return temp_export_dir

--- a/tensorflow/python/estimator/export/export_test.py
+++ b/tensorflow/python/estimator/export/export_test.py
@@ -676,6 +676,12 @@ class ExportTest(test_util.TensorFlowTestCase):
     self.assertTrue(int(time_1) < int(time_2))
     self.assertTrue(int(time_2) < int(time_3))
 
+  def test_get_temp_export_dir_bytes(self):
+    temp_export_dir = export.get_temp_export_dir(
+        b"/foo/bar/1534435836")
+    self.assertNotIn(b"b'", temp_export_dir)
+    self.assertEquals(b"/foo/bar/temp-1534435836", temp_export_dir)
+
   def test_build_all_signature_defs_serving_only(self):
     receiver_tensor = {"input": array_ops.placeholder(dtypes.string)}
     output_1 = constant_op.constant([1.])


### PR DESCRIPTION
Prior to this commit on Python 3 get_temp_export_dir produced directories
of the form

    /foo/bar/temp-b'1534435836'

because basename is bytes and str(bytes) is b'...'.