### PR TITLE
make build_rpi_lib.sh work

### DIFF
--- a/tensorflow/contrib/lite/tools/make/Makefile
+++ b/tensorflow/contrib/lite/tools/make/Makefile
@@ -65,6 +65,7 @@ INCLUDES := \
 -I$(MAKEFILE_DIR)/downloads/gemmlowp \
 -I$(MAKEFILE_DIR)/downloads/neon_2_sse \
 -I$(MAKEFILE_DIR)/downloads/farmhash/src \
+-I$(MAKEFILE_DIR)/downloads/flatbuffers/ \
 -I$(MAKEFILE_DIR)/downloads/flatbuffers/include \
 -I$(OBJDIR)
 # This is at the end so any globally-installed frameworks like protobuf don't


### PR DESCRIPTION
running `./tensorflow/contrib/lite/tools/make/build_rpi_lib.sh` showed something like

```
/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/bin/benchmark_model
arm-linux-gnueabihf-g++ -O3 -DNDEBUG --std=c++11 -march=armv7-a -mfpu=neon-vfpv4 -funsafe-math-optimizations -ftree-vectorize -fPIC -I. -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/../../../../../ -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/../../../../../../ -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/ -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/eigen -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/gemmlowp -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/neon_2_sse -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/farmhash/src -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/flatbuffers/include -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/ -I/usr/local/include -c tensorflow/contrib/lite/kernels/audio_spectrogram.cc -o /hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/tensorflow/contrib/lite/kernels/audio_spectrogram.o
arm-linux-gnueabihf-g++ -O3 -DNDEBUG --std=c++11 -march=armv7-a -mfpu=neon-vfpv4 -funsafe-math-optimizations -ftree-vectorize -fPIC -I. -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/../../../../../ -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/../../../../../../ -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/ -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/eigen -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/gemmlowp -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/neon_2_sse -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/farmhash/src -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/flatbuffers/include -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/ -I/usr/local/include -c tensorflow/contrib/lite/kernels/detection_postprocess.cc -o /hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/tensorflow/contrib/lite/kernels/detection_postprocess.o
arm-linux-gnueabihf-g++ -O3 -DNDEBUG --std=c++11 -march=armv7-a -mfpu=neon-vfpv4 -funsafe-math-optimizations -ftree-vectorize -fPIC -I. -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/../../../../../ -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/../../../../../../ -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/ -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/eigen -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/gemmlowp -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/neon_2_sse -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/farmhash/src -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/downloads/flatbuffers/include -I/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/ -I/usr/local/include -c tensorflow/contrib/lite/kernels/mfcc.cc -o /hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/tensorflow/contrib/lite/kernels/mfcc.o
tensorflow/contrib/lite/kernels/mfcc.cc:16:61: fatal error: include/flatbuffers/flexbuffers.h: No such file or directory
compilation terminated.
tensorflow/contrib/lite/tools/make/Makefile:159: recipe for target '/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/tensorflow/contrib/lite/kernels/mfcc.o' failed
make: *** [/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/tensorflow/contrib/lite/kernels/mfcc.o] Error 1
make: *** Waiting for unfinished jobs....
tensorflow/contrib/lite/kernels/detection_postprocess.cc:18:61: fatal error: include/flatbuffers/flexbuffers.h: No such file or directory
compilation terminated.
tensorflow/contrib/lite/tools/make/Makefile:159: recipe for target '/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/tensorflow/contrib/lite/kernels/detection_postprocess.o' failed
make: *** [/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/tensorflow/contrib/lite/kernels/detection_postprocess.o] Error 1
tensorflow/contrib/lite/kernels/audio_spectrogram.cc:25:61: fatal error: include/flatbuffers/flexbuffers.h: No such file or directory
compilation terminated.
tensorflow/contrib/lite/tools/make/Makefile:159: recipe for target '/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/tensorflow/contrib/lite/kernels/audio_spectrogram.o' failed
make: *** [/hack/freedom/tensorflow/tensorflow/tensorflow/contrib/lite/tools/make/gen/rpi_armv7l/obj/tensorflow/contrib/lite/kernels/audio_spectrogram.o] Error 1

```

Some kernels use `flatbuffers/flexbuffers.h`, others use `include/flatbuffers/flexbuffers.h`