### PR TITLE
tflite label_image: add -llog and update doc

### DIFF
--- a/tensorflow/contrib/lite/examples/label_image/BUILD
+++ b/tensorflow/contrib/lite/examples/label_image/BUILD
@@ -21,6 +21,7 @@ tf_cc_binary(
     ],
     linkopts = tflite_linkopts() + select({
         "//tensorflow:android": [
+            "-llog", # for Android logcat
             "-pie",  # Android 5.0 and later supports only PIE
             "-lm",  # some builtin ops, e.g., tanh, need -lm
         ],

--- a/tensorflow/contrib/lite/examples/label_image/label_image.md
+++ b/tensorflow/contrib/lite/examples/label_image/label_image.md
@@ -1,10 +1,9 @@
 label_image for TensorFlow Lite inspired by TensorFlow's label_image.
 
 To build label_image for Android, run $TENSORFLOW_ROOT/configure 
-and set Android NDK or configure NDK setting in 
-$TENSORFLOW_ROOT/WORKSPACE first.
+and set Android NDK or add them to `$TENSORFLOW_ROOT/.tf_configure.bazelrc`.
  
-To build it for android ARMv8:
+To build it for Android ARMv8:
 ```
 > bazel build --config monolithic --cxxopt=-std=c++11 \
   --crosstool_top=//external:android/crosstool \
@@ -18,7 +17,7 @@ or
   //tensorflow/contrib/lite/examples/label_image:label_image
 ```
 
-To build it for android arm-v7a:
+To build it for Android arm-v7a:
 ```
 > bazel build --config monolithic --cxxopt=-std=c++11 \
   --crosstool_top=//external:android/crosstool \
@@ -38,9 +37,20 @@ Build it for desktop machines (tested on Ubuntu and OS X)
 ```
 To run it. Prepare `./mobilenet_quant_v1_224.tflite`, `./grace_hopper.bmp`, and `./labels.txt`.
 
+```
+curl https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/contrib/lite/examples/label_image/testdata/grace_hopper.bmp > grace_hopper.bmp
+
+curl  https://storage.googleapis.com/download.tensorflow.org/models/mobilenet_v1_1.0_224_frozen.tgz  | tar xzv mobilenet_v1_1.0_224/labels.txt
+mv mobilenet_v1_1.0_224/labels.txt .
+
+curl http://download.tensorflow.org/models/mobilenet_v1_2018_02_22/mobilenet_v1_1.0_224_quant.tgz | tar xzv ./mobilenet_v1_1.0_224_quant.tflite
+mv mobilenet_v1_1.0_224_quant.tflite mobilenet_quant_v1_224.tflite
+```
+
+
 Run it:
 ```
-> ./label_image                                        
+> ./label_image
 Loaded model ./mobilenet_quant_v1_224.tflite
 resolved reporter
 invoked
@@ -53,7 +63,7 @@ average time: 100.986 ms
 ```
 Run `interpreter->Invoker()` 100 times:
 ```
-> ./label_image   -c 100                               
+> ./label_image -c 100
 Loaded model ./mobilenet_quant_v1_224.tflite
 resolved reporter
 invoked
@@ -63,7 +73,7 @@ average time: 33.4694 ms
 
 Run a floating point (`mobilenet_v1_1.0_224.tflite`) model,
 ```
-> ./label_image -f 1 -m mobilenet_v1_1.0_224.tflite
+> ./label_image -m mobilenet_v1_1.0_224.tflite
 Loaded model mobilenet_v1_1.0_224.tflite
 resolved reporter
 invoked
@@ -73,6 +83,65 @@ average time: 263.493 ms
 0.0109948: 466 bulletproof vest
 0.0105327: 401 academic gown
 0.00947104: 723 ping-pong bal
+```
+
+To run profiling with TF Lite profiling mechanism, build with
+`--cxxopt=-DTFLITE_PROFILING_ENABLED`
+e.g.,
+
+```
+bazel build --config opt \
+--cxxopt=-std=c++11 \
+--cxxopt=-DTFLITE_PROFILING_ENABLED \
+--config monolithic \
+//tensorflow/contrib/lite/examples/label_image:label_image
+
+```
+
+Run it with `-p`
+
+```
+> ./label_image  -p 1
+Loaded model ./mobilenet_quant_v1_224.tflite
+resolved reporter
+invoked
+average time: 55.522 ms
+     4.702, Node   0, OpCode   3, CONV_2D
+     9.158, Node   1, OpCode   4, DEPTHWISE_CONV_2D
+     3.295, Node   2, OpCode   3, CONV_2D
+     3.431, Node   3, OpCode   4, DEPTHWISE_CONV_2D
+     1.708, Node   4, OpCode   3, CONV_2D
+     5.836, Node   5, OpCode   4, DEPTHWISE_CONV_2D
+     2.263, Node   6, OpCode   3, CONV_2D
+     1.408, Node   7, OpCode   4, DEPTHWISE_CONV_2D
+     1.105, Node   8, OpCode   3, CONV_2D
+     2.678, Node   9, OpCode   4, DEPTHWISE_CONV_2D
+     1.784, Node  10, OpCode   3, CONV_2D
+     0.665, Node  11, OpCode   4, DEPTHWISE_CONV_2D
+     0.836, Node  12, OpCode   3, CONV_2D
+     1.198, Node  13, OpCode   4, DEPTHWISE_CONV_2D
+     1.494, Node  14, OpCode   3, CONV_2D
+     1.208, Node  15, OpCode   4, DEPTHWISE_CONV_2D
+     1.429, Node  16, OpCode   3, CONV_2D
+     1.202, Node  17, OpCode   4, DEPTHWISE_CONV_2D
+     1.477, Node  18, OpCode   3, CONV_2D
+     1.193, Node  19, OpCode   4, DEPTHWISE_CONV_2D
+     1.415, Node  20, OpCode   3, CONV_2D
+     1.209, Node  21, OpCode   4, DEPTHWISE_CONV_2D
+     1.394, Node  22, OpCode   3, CONV_2D
+     0.288, Node  23, OpCode   4, DEPTHWISE_CONV_2D
+     0.770, Node  24, OpCode   3, CONV_2D
+     0.542, Node  25, OpCode   4, DEPTHWISE_CONV_2D
+     1.453, Node  26, OpCode   3, CONV_2D
+     0.020, Node  27, OpCode   1, AVERAGE_POOL_2D
+     0.303, Node  28, OpCode   3, CONV_2D
+     0.000, Node  29, OpCode  43, SQUEEZE
+     0.052, Node  30, OpCode  25, SOFTMAX
+0.365: 907 907:Windsor tie
+0.365: 653 653:military uniform
+0.043: 668 668:mortarboard
+0.035: 458 458:bow tie, bow-tie, bowtie
+0.027: 543 543:drumstick
 ```
 
 See the source code for other command line options.


### PR DESCRIPTION
1. -llog needed for Android after 2c623eaa
2. update label_image.md
   a. reflect changes
   b. where to get test model and data
   c. describe --cxxopt=-DTFLITE_PROFILING_ENABLED