### PR TITLE
Fix embedding_ops_test on AVX512 builds

### DIFF
--- a/tensorflow/python/kernel_tests/embedding_ops_test.py
+++ b/tensorflow/python/kernel_tests/embedding_ops_test.py
@@ -563,7 +563,13 @@ class EmbeddingLookupTest(test.TestCase):
           # Compare nonsharded to gather
           simple = embedding_ops.embedding_lookup(
               params, ids, max_norm=1.0).eval()
-          self.assertAllEqual(simple, array_ops.gather(params_norm, ids).eval())
+          # assertAllClose is used here as different implementations of sqrt may
+          # be used to compute each of the values being compared.  For example,
+          # on AVX512 builds the embedding operation makes use of Eigen's fast
+          # vectorized square root algorithm for doubles.  These different
+          # implementations of sqrt are not guaranteed to produce exactly the
+          # same results. Therefore, an exact comparison cannot be made.
+          self.assertAllClose(simple, array_ops.gather(params_norm, ids).eval())
           # Run a few different sharded versions.
           for procs in 1, 2, 3:
             stride = procs * math_ops.range(params.shape[0] // procs)
@@ -608,7 +614,13 @@ class EmbeddingLookupTest(test.TestCase):
           sharded = embedding_ops._embedding_lookup_and_transform(
               split_params, ids, max_norm=l2_norm,
               transform_fn=transform).eval()
-          self.assertAllEqual(simple, sharded)
+          # assertAllClose is used here as different implementations of sqrt may
+          # be used to compute each of the values being compared.  For example,
+          # on AVX512 builds the embedding operation makes use of Eigen's fast
+          # vectorized square root algorithm for doubles.  These different
+          # implementations of sqrt are not guaranteed to produce exactly the
+          # same results. Therefore, an exact comparison cannot be made.
+          self.assertAllClose(simple, sharded)
 
 
 class EmbeddingLookupSparseTest(test.TestCase):


### PR DESCRIPTION
This commit modifies the embedding_ops_test unit test so that it
passes on AVX512 builds.  The test compares the result of an embedding
operation to a precomputed expected result, both of which are computed
using square roots.  The test appears to fail on AVX512 builds as the
embedding operation makes use of Eigen's fast vectorized square root
algorithm for doubles, which can return slightly different results to
those computed using numpy.  As the test expects both results to be
identical it fails on AVX512 builds, even though the difference
between the results is insignificant.  This commit fixes the issue by
modifying the equality tests to use assertAllClose instead of
assertAllEqual.  Note that the test passes in its current form on AVX2
builds as Eigen does not yet implement an AVX2 version of the fast
square root algorithm for doubles.

Fixes: https://github.com/tensorflow/tensorflow/issues/21676

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>