### PR TITLE
adding libnsync.a when available.

### DIFF
--- a/tensorflow/contrib/makefile/create_ios_frameworks.sh
+++ b/tensorflow/contrib/makefile/create_ios_frameworks.sh
@@ -45,12 +45,11 @@ cp $SCRIPT_DIR/gen/lib/libtensorflow-core.a \
    $FW_DIR_TFCORE/tensorflow_experimental
 cp $SCRIPT_DIR/gen/protobuf_ios/lib/libprotobuf.a \
    $FW_DIR_TFCORE/libprotobuf_experimental.a
-IOS_ARCH=$(ls $SCRIPT_DIR/gen/bin|grep ios|awk '{print tolower($0)}')
-NSYNC_PATH=./downloads/nsync/builds/${IOS_ARCH:4}.ios.c++11/libnsync.a
+NSYNC_PATH=./downloads/nsync/builds/lipo.ios.c++11/nsync.a
 if [ ! -f $NSYNC_PATH ]; then
   echo "libnsync.a not found!"
 else
-  cp $NSYNC_PATH $FW_DIR_TFCORE/
+  cp $NSYNC_PATH $FW_DIR_TFCORE/libnsync.a
 fi
 
 echo "Headers, populating: tensorflow (core)"

--- a/tensorflow/contrib/makefile/create_ios_frameworks.sh
+++ b/tensorflow/contrib/makefile/create_ios_frameworks.sh
@@ -45,6 +45,13 @@ cp $SCRIPT_DIR/gen/lib/libtensorflow-core.a \
    $FW_DIR_TFCORE/tensorflow_experimental
 cp $SCRIPT_DIR/gen/protobuf_ios/lib/libprotobuf.a \
    $FW_DIR_TFCORE/libprotobuf_experimental.a
+IOS_ARCH=$(ls $SCRIPT_DIR/gen/bin|grep ios|awk '{print tolower($0)}')
+NSYNC_PATH=./downloads/nsync/builds/${IOS_ARCH:4}.ios.c++11/libnsync.a
+if [ ! -f $NSYNC_PATH ]; then
+  echo "libnsync.a not found!"
+else
+  cp $NSYNC_PATH $FW_DIR_TFCORE/
+fi
 
 echo "Headers, populating: tensorflow (core)"
 cd $SCRIPT_DIR/../../..


### PR DESCRIPTION
iOS needs these flags to build:
```
-lprotobuf_experimental
-lnsync
-force_load $(PROJECT_DIR)/tensorflow_experimental.framework/tensorflow_experimental
```

so adding the `libnsync.a` directly into the framework should be a good idea.
if the file doesn't exist, it is still ok to finish the build without conflicts to the document or failure.