### PR TITLE
[INTEL MKL] Memory control to avoid caching large buffer for MKL primitives

### DIFF
--- a/tensorflow/core/kernels/mkl_conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_grad_filter_ops.cc
@@ -854,9 +854,9 @@ class MklConvCustomBackpropFilterOp
       // MKL DNN allocates large buffers when a conv gradient filter primtive is
       // created. So we don't cache conv backward primitives when the env
       // variable TF_MKL_OPTIMIZE_PRIMITVE_MEMUSE is set to true.
-      do_not_cache_ = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled();
+      bool do_not_cache = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled();
       conv_bwd_filter = MklConvBwdFilterPrimitiveFactory<T>::Get(
-          convBwdFilterDims, do_not_cache_);
+          convBwdFilterDims, do_not_cache);
       auto bwd_filter_pd = conv_bwd_filter->GetPrimitiveDesc();
 
       // allocate output tensors: diff_fitler and diff_bias (w bias)
@@ -950,7 +950,7 @@ class MklConvCustomBackpropFilterOp
       }
 
       // delete primitive since it is not cached.
-      if (do_not_cache_) delete conv_bwd_filter;
+      if (do_not_cache) delete conv_bwd_filter;
     } catch (mkldnn::error& e) {
       string error_msg = "Status: " + std::to_string(e.status) +
                          ", message: " + string(e.message) + ", in file " +
@@ -966,7 +966,6 @@ class MklConvCustomBackpropFilterOp
   const int kInputIndex_InputSizes = 0;
   const int kDilationH = 0, kDilationW = 1;
   engine cpu_engine_ = engine(engine::cpu, 0);
-  bool do_not_cache_;
 
   // Validate input shapes.
   // Function asserts that input shapes are valid.

--- a/tensorflow/core/kernels/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_grad_input_ops.cc
@@ -241,10 +241,10 @@ class MklConvBwdInputPrimitiveFactory : public MklPrimitiveFactory<T> {
 
  public:
   static MklConvBwdInputPrimitive<T>* Get(
-      const MklConvBwdInputParams& convBwdInputDims, bool not_cache) {
+      const MklConvBwdInputParams& convBwdInputDims, bool do_not_cache) {
     MklConvBwdInputPrimitive<T>* conv_bwd_input = nullptr;
 
-    if (not_cache) { /* Always allocate primitive */
+    if (do_not_cache) { /* Always allocate primitive */
       conv_bwd_input = new MklConvBwdInputPrimitive<T>(convBwdInputDims);
     } else {
       // look into the pool for reusable primitive
@@ -718,11 +718,11 @@ class MklConvCustomBackpropInputOp : public MklConvBackpropCommonOp<Device, T> {
       // in the following cases
       //   1. Legacy CPU without AVX512/AVX2, or
       //   2. 1x1 convolution with stride != 1
-      not_cache_ = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled() &&
+      do_not_cache_ = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled() &&
                    (MklPrimitiveFactory<T>::IsLegacyPlatform() ||
                     IsConv1x1StrideNot1(fwd_filter_dims, strides));
       conv_bwd_input = MklConvBwdInputPrimitiveFactory<T>::Get(convBwdInputDims,
-                                                               not_cache_);
+                                                               do_not_cache_);
       auto bwd_input_pd = conv_bwd_input->GetPrimitiveDesc();
 
       // allocate output tensor
@@ -770,7 +770,7 @@ class MklConvCustomBackpropInputOp : public MklConvBackpropCommonOp<Device, T> {
       conv_bwd_input->Execute(diff_src_data, filter_data, diff_dst_data);
 
       // delete primitive since it is not cached.
-      if (not_cache_) {
+      if (do_not_cache_) {
         delete conv_bwd_input;
       }
     } catch (mkldnn::error& e) {
@@ -787,7 +787,7 @@ class MklConvCustomBackpropInputOp : public MklConvBackpropCommonOp<Device, T> {
   const int kInputIndex_Filter = 1, kInputIndex_InputSizes = 0;
   const int kDilationH = 0, kDilationW = 1;
   engine cpu_engine = engine(engine::cpu, 0);
-  bool not_cache_;
+  bool do_not_cache_;
 
   // Validate input shapes.
   // Function asserts that input shapes are valid.

--- a/tensorflow/core/kernels/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_grad_input_ops.cc
@@ -174,7 +174,6 @@ class MklConvBwdInputPrimitive : public MklPrimitive {
     }
   };
 
-
   void Setup(const MklConvBwdInputParams& convBwdInputDims) {
     // create memory descriptors for convolution data w/ no specified format
     context_.diff_src_md.reset(new memory::desc(
@@ -242,19 +241,23 @@ class MklConvBwdInputPrimitiveFactory : public MklPrimitiveFactory<T> {
 
  public:
   static MklConvBwdInputPrimitive<T>* Get(
-      const MklConvBwdInputParams& convBwdInputDims) {
+      const MklConvBwdInputParams& convBwdInputDims, bool not_cache) {
     MklConvBwdInputPrimitive<T>* conv_bwd_input = nullptr;
 
-    // look into the pool for reusable primitive
-    conv_bwd_input = dynamic_cast<MklConvBwdInputPrimitive<T>*>(
-        MklConvBwdInputPrimitiveFactory<T>::GetInstance().GetConvBwdInput(
-            convBwdInputDims));
-
-    if (conv_bwd_input == nullptr) {
+    if (not_cache) { /* Always allocate primitive */
       conv_bwd_input = new MklConvBwdInputPrimitive<T>(convBwdInputDims);
-      MklConvBwdInputPrimitiveFactory<T>::GetInstance().SetConvBwdInput(
-          convBwdInputDims, conv_bwd_input);
+    } else {
+      // look into the pool for reusable primitive
+      conv_bwd_input = dynamic_cast<MklConvBwdInputPrimitive<T>*>(
+          MklConvBwdInputPrimitiveFactory<T>::GetInstance().GetConvBwdInput(
+              convBwdInputDims));
+      if (conv_bwd_input == nullptr) {
+        conv_bwd_input = new MklConvBwdInputPrimitive<T>(convBwdInputDims);
+        MklConvBwdInputPrimitiveFactory<T>::GetInstance().SetConvBwdInput(
+            convBwdInputDims, conv_bwd_input);
+      }
     }
+
     return conv_bwd_input;
   }
 
@@ -708,8 +711,18 @@ class MklConvCustomBackpropInputOp : public MklConvBackpropCommonOp<Device, T> {
       MklConvBwdInputParams convBwdInputDims(fwd_src_dims, fwd_filter_dims,
           diff_dst_dims, strides, dilations, padding_left, padding_right,
           TFPaddingToMklDnnPadding(this->padding_));
-      conv_bwd_input =
-          MklConvBwdInputPrimitiveFactory<T>::Get(convBwdInputDims);
+
+      // We don't cache those primitves if the env variable
+      // TF_MKL_OPTIMIZE_PRIMITVE_MEMUSE is true and if primitve descriptor
+      // includes potentialy large buffers. MKL DNN allocates buffers
+      // in the following cases
+      //   1. Legacy CPU without AVX512/AVX2, or
+      //   2. 1x1 convolution with stride != 1
+      not_cache_ = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled() &&
+                   (MklPrimitiveFactory<T>::IsLegacyPlatform() ||
+                    IsConv1x1StrideNot1(fwd_filter_dims, strides));
+      conv_bwd_input = MklConvBwdInputPrimitiveFactory<T>::Get(convBwdInputDims,
+                                                               not_cache_);
       auto bwd_input_pd = conv_bwd_input->GetPrimitiveDesc();
 
       // allocate output tensor
@@ -755,6 +768,11 @@ class MklConvCustomBackpropInputOp : public MklConvBackpropCommonOp<Device, T> {
 
       // execute convolution input bwd
       conv_bwd_input->Execute(diff_src_data, filter_data, diff_dst_data);
+
+      // delete primitive since it is not cached.
+      if (not_cache_) {
+        delete conv_bwd_input;
+      }
     } catch (mkldnn::error& e) {
       string error_msg = "Status: " + std::to_string(e.status) +
                          ", message: " + string(e.message) + ", in file " +
@@ -769,6 +787,7 @@ class MklConvCustomBackpropInputOp : public MklConvBackpropCommonOp<Device, T> {
   const int kInputIndex_Filter = 1, kInputIndex_InputSizes = 0;
   const int kDilationH = 0, kDilationW = 1;
   engine cpu_engine = engine(engine::cpu, 0);
+  bool not_cache_;
 
   // Validate input shapes.
   // Function asserts that input shapes are valid.

--- a/tensorflow/core/kernels/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_grad_input_ops.cc
@@ -718,11 +718,11 @@ class MklConvCustomBackpropInputOp : public MklConvBackpropCommonOp<Device, T> {
       // in the following cases
       //   1. Legacy CPU without AVX512/AVX2, or
       //   2. 1x1 convolution with stride != 1
-      do_not_cache_ = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled() &&
+      bool do_not_cache = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled() &&
                    (MklPrimitiveFactory<T>::IsLegacyPlatform() ||
                     IsConv1x1StrideNot1(fwd_filter_dims, strides));
       conv_bwd_input = MklConvBwdInputPrimitiveFactory<T>::Get(convBwdInputDims,
-                                                               do_not_cache_);
+                                                               do_not_cache);
       auto bwd_input_pd = conv_bwd_input->GetPrimitiveDesc();
 
       // allocate output tensor
@@ -770,7 +770,7 @@ class MklConvCustomBackpropInputOp : public MklConvBackpropCommonOp<Device, T> {
       conv_bwd_input->Execute(diff_src_data, filter_data, diff_dst_data);
 
       // delete primitive since it is not cached.
-      if (do_not_cache_) {
+      if (do_not_cache) {
         delete conv_bwd_input;
       }
     } catch (mkldnn::error& e) {
@@ -787,7 +787,6 @@ class MklConvCustomBackpropInputOp : public MklConvBackpropCommonOp<Device, T> {
   const int kInputIndex_Filter = 1, kInputIndex_InputSizes = 0;
   const int kDilationH = 0, kDilationW = 1;
   engine cpu_engine = engine(engine::cpu, 0);
-  bool do_not_cache_;
 
   // Validate input shapes.
   // Function asserts that input shapes are valid.

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -906,6 +906,7 @@ class MklConvOp : public OpKernel {
       //   1. Legacy CPU without AVX512/AVX2, or
       //   2. 1x1 convolution with stride != 1
       not_cache_ = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled() &&
+                    (src_dims[MklDnnDims::Dim_N] > kSmallBatchSize) &&
                     (MklPrimitiveFactory<T>::IsLegacyPlatform() ||
                      IsConv1x1StrideNot1(filter_dims, strides));
 

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -272,10 +272,10 @@ template <typename T>
 class MklConvFwdPrimitiveFactory : public MklPrimitiveFactory<T> {
  public:
   static MklConvFwdPrimitive<T>* Get(const MklConvFwdParams& convFwdDims,
-                                     bool not_cache) {
+                                     bool do_not_cache) {
     MklConvFwdPrimitive<T>* conv_fwd = nullptr;
 
-    if (not_cache) { /* Always create new primitive */
+    if (do_not_cache) { /* Always create new primitive */
       conv_fwd = new MklConvFwdPrimitive<T>(convFwdDims);
     } else {
       // try to find a suitable one in pool
@@ -905,7 +905,7 @@ class MklConvOp : public OpKernel {
       // in the following cases
       //   1. Legacy CPU without AVX512/AVX2, or
       //   2. 1x1 convolution with stride != 1
-      not_cache_ = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled() &&
+      do_not_cache_ = MklPrimitiveFactory<T>::IsPrimitiveMemOptEnabled() &&
                     (src_dims[MklDnnDims::Dim_N] > kSmallBatchSize) &&
                     (MklPrimitiveFactory<T>::IsLegacyPlatform() ||
                      IsConv1x1StrideNot1(filter_dims, strides));
@@ -919,13 +919,13 @@ class MklConvOp : public OpKernel {
                                      dst_dims_mkl_order, strides, dilations,
                                      padding_left, padding_right);
         conv_fwd = MklConvFwdPrimitiveFactory<T>::Get(
-            convFwdDims, not_cache_);
+            convFwdDims, do_not_cache_);
       } else {
         MklConvFwdParams convFwdDims(src_dims, filter_dims, NONE_DIMS,
                                      dst_dims_mkl_order, strides, dilations,
                                      padding_left, padding_right);
         conv_fwd = MklConvFwdPrimitiveFactory<T>::Get(
-            convFwdDims, not_cache_);
+            convFwdDims, do_not_cache_);
       }
 
       // allocate output tensors output_tensor and filter_out_tensor
@@ -972,7 +972,7 @@ class MklConvOp : public OpKernel {
       }
 
       // delete primitive since it is not cached.
-      if (not_cache_) delete conv_fwd;
+      if (do_not_cache_) delete conv_fwd;
     } catch (mkldnn::error &e) {
       string error_msg = tensorflow::strings::StrCat(
           "Status: ", e.status, ", message: ", string(e.message), ", in file ",
@@ -991,7 +991,7 @@ class MklConvOp : public OpKernel {
   const int kOutputIndex_Dst = 0, kOutputIndex_Filter = 1;
   const int kDilationH = 0, kDilationW = 1;
   engine cpu_engine = engine(engine::cpu, 0);
-  bool not_cache_;
+  bool do_not_cache_;
 
   // Allocate output tensor.
   void AllocateOutputTensor(

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_CORE_UTIL_MKL_UTIL_H_
 #ifdef INTEL_MKL
 
+#include <string>
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -30,6 +31,12 @@ limitations under the License.
 
 #if defined(INTEL_MKL_ML_ONLY) && defined(INTEL_MKL_DNN_ONLY)
 #error "at most one of INTEL_MKL_ML_ONLY and INTEL_MKL_DNN_ONLY may be defined"
+#endif
+
+#ifdef INTEL_MKL_ML_ONLY
+// Using pragma message since #warning doesn't work with all compilers
+#pragma message("Compiling for INTEL MKL ML only will be deprecated soon.")
+#pragma message("Please use MKL DNN (the default option for --config=mkl)")
 #endif
 
 #ifdef INTEL_MKL_ML_ONLY
@@ -50,6 +57,7 @@ limitations under the License.
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/util/padding.h"
 #include "tensorflow/core/util/tensor_format.h"
+#include "tensorflow/core/util/env_var.h"
 
 #ifndef INTEL_MKL_ML_ONLY
 #include "mkldnn.hpp"
@@ -1994,7 +2002,9 @@ const mkldnn::memory::dims NONE_DIMS = {};
 template <typename T>
 class MklPrimitiveFactory {
  public:
-  MklPrimitiveFactory() {}
+  MklPrimitiveFactory() {
+  }
+
   ~MklPrimitiveFactory() {}
 
   MklPrimitive* GetOp(const string& key) {
@@ -2015,6 +2025,22 @@ class MklPrimitiveFactory {
     CHECK(stream_iter == map.end());
 
     map[key] = op;
+  }
+
+  /// Function to decide whether HW has AVX512 or AVX2
+  /// For those legacy device(w/o AVX512 and AVX2),
+  /// MKL-DNN GEMM will be used.
+  static inline bool IsLegacyPlatform() {
+    return (!port::TestCPUFeature(port::CPUFeature::AVX512F)
+                   && !port::TestCPUFeature(port::CPUFeature::AVX2));
+  }
+
+  /// Fuction to check whether primitive memory optimization is enabled
+  static inline bool IsPrimitiveMemOptEnabled() {
+    bool is_primitive_mem_opt_enabled = true;
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_MKL_OPTIMIZE_PRIMITVE_MEMUSE", true,
+          &is_primitive_mem_opt_enabled));
+    return is_primitive_mem_opt_enabled;
   }
 
  private:
@@ -2089,7 +2115,7 @@ class MklReorderPrimitive : public MklPrimitive {
       context_.dst_mem->set_data_handle(to->get_data_handle());
     }
 
-   private:
+ private:
     struct ReorderContext {
       std::shared_ptr<mkldnn::memory> src_mem;
       std::shared_ptr<mkldnn::memory> dst_mem;
@@ -2131,7 +2157,7 @@ class MklReorderPrimitiveFactory : public MklPrimitiveFactory<T> {
       return instance_;
     }
 
-   private:
+ private:
     MklReorderPrimitiveFactory() {}
     ~MklReorderPrimitiveFactory() {}
 
@@ -2174,6 +2200,15 @@ inline primitive FindOrCreateReorder(const memory* from, const memory* to) {
   MklReorderPrimitive* reorder_prim =
       MklReorderPrimitiveFactory<T>::Get(from, to);
   return *reorder_prim->GetPrimitive();
+}
+
+// utility function to determine if it is conv 1x1 and stride != 1
+// for purpose of temporarily disabling primitive reuse
+inline bool IsConv1x1StrideNot1(memory::dims filter_dims, memory::dims strides) {
+  if (filter_dims.size() != 4 || strides.size() != 2) return false;
+
+  return ((filter_dims[2] == 1) && (filter_dims[3] == 1) &&
+          ((strides[0] != 1) || (strides[1] != 1)));
 }
 
 #endif  // INTEL_MKL_DNN

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -105,6 +105,8 @@ typedef enum {
   Dim3d_I = 1
 } MklDnnDims3D;
 
+static const int kSmallBatchSize = 32;
+
 #ifdef INTEL_MKL_ML_ONLY
 class MklShape {
  public:


### PR DESCRIPTION
This PR enables memory usage control: 
To avoid caching large buffer for MKL primitives, "caching" MKL primitives in the following scenarios is prevented:
1. conv2d backward - always by default (see bottom comment on the environment variable)
2. conv2d forward: large batch size (> 32) and for old systems which do not support 
                               AVX2 or AVX512 (e.g. Ivebridge). 
3. conv2d forward: large batch size (>32) and for 1x1 kernel and stride != 1

Environment variable TF_MKL_OPTIMIZE_PRIMITVE_MEMUSE is "true" by default or not set. 
To enable primitive reuse for all ops and all cases, set it to "false". 