### PR TITLE
Upgrade gradle to fix a resolution error

### DIFF
--- a/tensorflow/contrib/lite/java/demo/app/build.gradle
+++ b/tensorflow/contrib/lite/java/demo/app/build.gradle
@@ -11,11 +11,6 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        // Remove this block.
-        jackOptions {
-            enabled true
-        }
     }
     lintOptions {
         abortOnError false
@@ -37,6 +32,7 @@ android {
 }
 
 repositories {
+    google()
     maven {
         url 'https://google.bintray.com/tensorflow'
     }

--- a/tensorflow/contrib/lite/java/demo/build.gradle
+++ b/tensorflow/contrib/lite/java/demo/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tensorflow/contrib/lite/java/demo/gradle/wrapper/gradle-wrapper.properties
+++ b/tensorflow/contrib/lite/java/demo/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 28 09:01:41 PDT 2017
+#Thu Aug 02 11:46:34 CDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
I am never an expert of gradle, but I needed these changes to avoid `Failed to resolve: androidx.test.espresso:espresso-core:3.1.0-alpha3` when building the demo app.  See #20828.