### PR TITLE
parallel_for: use absl wrapper and add converter for SoftplusGrad

### DIFF
--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -2010,6 +2010,7 @@ def _convert_biasaddgrad(pfor_input):
 @RegisterPForWithArgs("ReluGrad")
 @RegisterPForWithArgs("TanhGrad")
 @RegisterPForWithArgs("SigmoidGrad")
+@RegisterPForWithArgs("SoftplusGrad")
 def _convert_grads(pfor_input, op_type, *args, **kw_args):
   del args
   del kw_args

--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -21,8 +21,6 @@ from __future__ import print_function
 
 import collections
 
-from absl import flags
-
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -41,6 +39,7 @@ from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import parsing_ops
 from tensorflow.python.ops import sparse_ops
 from tensorflow.python.ops import tensor_array_ops
+from tensorflow.python.platform import flags
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import nest
 


### PR DESCRIPTION
Consider the following snippet

```python
import tensorflow as tf
from tensorflow.python.ops.parallel_for import gradients

x = tf.placeholder(tf.float32, (None,))
y = tf.nn.softplus(x)

print(gradients.jacobian(y, x))
```

On the current master it fails with

```
Traceback (most recent call last):
  File "test.py", line 7, in <module>
    print(gradients.jacobian(y, x))
  File "/Users/asobolev/dev/tensorflow/pfor_test/venv/lib/python3.6/site-packages/tensorflow/python/ops/parallel_for/gradients.py", line 58, in jacobian
    pfor_outputs = control_flow_ops.pfor(loop_fn, output_size)
  File "/Users/asobolev/dev/tensorflow/pfor_test/venv/lib/python3.6/site-packages/tensorflow/python/ops/parallel_for/control_flow_ops.py", line 122, in pfor
    outputs.append(converter.convert(loop_fn_output))
  File "/Users/asobolev/dev/tensorflow/pfor_test/venv/lib/python3.6/site-packages/tensorflow/python/ops/parallel_for/pfor.py", line 1075, in convert
    output = self._convert_helper(y)
  File "/Users/asobolev/dev/tensorflow/pfor_test/venv/lib/python3.6/site-packages/tensorflow/python/ops/parallel_for/pfor.py", line 1214, in _convert_helper
    if flags.FLAGS.op_conversion_fallback_to_while_loop:
  File "/Users/asobolev/dev/tensorflow/pfor_test/venv/lib/python3.6/site-packages/absl/flags/_flagvalues.py", line 488, in __getattr__
    raise _exceptions.UnparsedFlagAccessError(error_message)
absl.flags._exceptions.UnparsedFlagAccessError: Trying to access flag --op_conversion_fallback_to_while_loop before flags were parsed.
```

This is caused by the fact that no converter is registered for the `SoftplusGrad` op, and when parallel_for sees no converter defined, it tries to fall back to a while loop, if this is allowed with a special CLI flag. The problem, though, is that it uses raw `absl` call which requires one to first explicitly parse command line arguments. To mitigate that, one should use a flags wrapper from the `tensorflow.platform`, which is what I did.

Also, this pull introduces a converter for `SoftplusGrad` in the same way as, say, `SigmoidGrad`.