### PR TITLE
Add more doc for the dict returned by an estimator's evaluate() method

### DIFF
--- a/tensorflow/docs_src/guide/premade_estimators.md
+++ b/tensorflow/docs_src/guide/premade_estimators.md
@@ -366,6 +366,8 @@ Running this code yields the following output (or something similar):
 Test set accuracy: 0.967
 ```
 
+The `eval_result` dictionary also contains the `average_loss` (mean loss per sample), the `loss` (mean loss per mini-batch) and the value of the estimator's `global_step` (the number of training iterations it underwent).
+
 ### Making predictions (inferring) from the trained model
 
 We now have a trained model that produces good evaluation results.

--- a/tensorflow/python/estimator/estimator.py
+++ b/tensorflow/python/estimator/estimator.py
@@ -431,7 +431,11 @@ class Estimator(object):
     Returns:
       A dict containing the evaluation metrics specified in `model_fn` keyed by
       name, as well as an entry `global_step` which contains the value of the
-      global step for which this evaluation was performed.
+      global step for which this evaluation was performed. For canned
+      estimators, the dict contains the `loss` (mean loss per mini-batch) and
+      the `average_loss` (mean loss per sample). Canned classifiers also return
+      the `accuracy`. Canned regressors also return the `label/mean` and the
+      `prediction/mean`.
 
     Raises:
       ValueError: If `steps <= 0`.


### PR DESCRIPTION
There is currently no information about the difference between the `loss` and the `average_loss`.  It's unclear what the difference is (see #21557).  The other metrics are arguably self-explanatory, but still worth mentioning in the doc.

This PR:
* adds more info about the returned dict in the [API documentation](https://www.tensorflow.org/api_docs/python/tf/estimator/BaselineClassifier#evaluate),
* and adds more info in the [TensorFlow guide](https://www.tensorflow.org/guide/premade_estimators#evaluate_the_trained_model).