### PR TITLE
Fix compilation failure with RDMA+GDR

### DIFF
--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -190,7 +190,7 @@ class BFCGdrAllocator : public BFCAllocator {
  public:
   BFCGdrAllocator()
       : BFCAllocator(new BasicCPUAllocator(port::kNUMANoAffinity), 1LL << 36,
-                     true, "cpu_rdma_bfc") {}
+                     true, "cpu_gdr_bfc") {}
 };
 class BFCGdrAllocatorFactory : public AllocatorFactory {
  public:

--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -186,22 +186,22 @@ class GdrMemoryManager : public RemoteMemoryManager {
 // TODO(byronyi): remove this class and its registration when the default
 // cpu_allocator() returns visitable allocator, or cpu_allocator() is no
 // longer in use.
-class BFCRdmaAllocator : public BFCAllocator {
+class BFCGdrAllocator : public BFCAllocator {
  public:
-  BFCRdmaAllocator()
+  BFCGdrAllocator()
       : BFCAllocator(new BasicCPUAllocator(port::kNUMANoAffinity), 1LL << 36,
                      true, "cpu_rdma_bfc") {}
 };
-class BFCRdmaAllocatorFactory : public AllocatorFactory {
+class BFCGdrAllocatorFactory : public AllocatorFactory {
  public:
-  Allocator* CreateAllocator() override { return new BFCRdmaAllocator; }
+  Allocator* CreateAllocator() override { return new BFCGdrAllocator; }
 
   virtual SubAllocator* CreateSubAllocator(int numa_node) {
     return new BasicCPUAllocator(numa_node);
   }
 };
 
-REGISTER_MEM_ALLOCATOR("BFCRdmaAllocator", 101, BFCRdmaAllocatorFactory);
+REGISTER_MEM_ALLOCATOR("BFCGdrAllocator", 101, BFCGdrAllocatorFactory);
 
 GdrMemoryManager::GdrMemoryManager(const string& host, const string& port)
     : host_(host),

--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -201,7 +201,7 @@ class BFCGdrAllocatorFactory : public AllocatorFactory {
   }
 };
 
-REGISTER_MEM_ALLOCATOR("BFCGdrAllocator", 101, BFCGdrAllocatorFactory);
+REGISTER_MEM_ALLOCATOR("BFCGdrAllocator", 102, BFCGdrAllocatorFactory);
 
 GdrMemoryManager::GdrMemoryManager(const string& host, const string& port)
     : host_(host),


### PR DESCRIPTION

This fix tries to address the issue raised in #21696 where
tensorflow failed to compile when both RDMA and GDR are on.
The issue is that the memory allocator of GDR used the same
name as RDMA.

This fix fixes #21696.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>