### PR TITLE
Rename the artifact IDs for TensorFlow ecosystem jars

### DIFF
--- a/tensorflow/java/maven/pom.xml
+++ b/tensorflow/java/maven/pom.xml
@@ -32,8 +32,8 @@
     <module>libtensorflow_jni_gpu</module>
     <module>tensorflow</module>
     <module>proto</module>
-    <module>hadoop</module>
-    <module>spark-connector</module>
+    <module>tensorflow-hadoop</module>
+    <module>spark-tensorflow-connector</module>
   </modules>
 
   <!-- Two profiles are used:

--- a/tensorflow/java/maven/run_inside_container.sh
+++ b/tensorflow/java/maven/run_inside_container.sh
@@ -41,7 +41,7 @@ clean() {
   mvn -q clean
   rm -rf libtensorflow_jni/src libtensorflow_jni/target libtensorflow_jni_gpu/src libtensorflow_jni_gpu/target \
     libtensorflow/src libtensorflow/target tensorflow-android/target proto/src proto/target \
-    hadoop/src hadoop/target spark-connector/src spark-connector/target
+    tensorflow-hadoop/src tensorflow-hadoop/target spark-tensorflow-connector/src spark-tensorflow-connector/target
 }
 
 update_version_in_pom() {
@@ -170,8 +170,8 @@ generate_java_protos() {
 # is updated for each module.
 download_tf_ecosystem() {
   ECOSYSTEM_DIR="/tmp/tensorflow-ecosystem"
-  HADOOP_DIR="${DIR}/hadoop"
-  SPARK_DIR="${DIR}/spark-connector"
+  HADOOP_DIR="${DIR}/tensorflow-hadoop"
+  SPARK_DIR="${DIR}/spark-tensorflow-connector"
 
   # Clean any previous attempts
   rm -rf "${ECOSYSTEM_DIR}"

--- a/tensorflow/java/maven/spark-tensorflow-connector/pom.xml
+++ b/tensorflow/java/maven/spark-tensorflow-connector/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tensorflow</groupId>
-    <artifactId>spark-connector_2.11</artifactId>
+    <artifactId>spark-tensorflow-connector_2.11</artifactId>
     <packaging>jar</packaging>
     <version>1.10.0</version>
     <name>spark-tensorflow-connector</name>
@@ -120,7 +120,7 @@
                                 <artifactSet>
                                     <includes>
                                         <include>com.google.protobuf:protobuf-java</include>
-                                        <include>org.tensorflow:hadoop</include>
+                                        <include>org.tensorflow:tensorflow-hadoop</include>
                                         <include>org.tensorflow:proto</include>
                                     </includes>
                                 </artifactSet>
@@ -305,7 +305,7 @@
     <dependencies>
         <dependency>
             <groupId>org.tensorflow</groupId>
-            <artifactId>hadoop</artifactId>
+            <artifactId>tensorflow-hadoop</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/tensorflow/java/maven/tensorflow-hadoop/pom.xml
+++ b/tensorflow/java/maven/tensorflow-hadoop/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tensorflow</groupId>
-    <artifactId>hadoop</artifactId>
+    <artifactId>tensorflow-hadoop</artifactId>
     <packaging>jar</packaging>
     <version>1.10.0</version>
     <name>tensorflow-hadoop</name>
@@ -15,7 +15,7 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <hadoop.version>2.6.0</hadoop.version>
-        <protobuf.version>3.3.1</protobuf.version>
+        <protobuf.version>3.5.1</protobuf.version>
         <junit.version>4.11</junit.version>
     </properties>
 


### PR DESCRIPTION
Rename the artifact IDs for the TensorFlow ecosystem jars to tensorflow-hadoop and tensorflow-spark-connector in response to discussion in https://github.com/tensorflow/ecosystem/pull/87

@asimshankar Please let me if you would like me to make any changes.