### PR TITLE
decorate sparse_categorical_accuracy with  tf_export decorator

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -582,6 +582,7 @@ def categorical_accuracy(y_true, y_pred):
       K.floatx())
 
 
+@tf_export('keras.metrics.sparse_categorical_accuracy')
 def sparse_categorical_accuracy(y_true, y_pred):
   return math_ops.cast(
       math_ops.equal(


### PR DESCRIPTION
according to [Issue21735](https://github.com/tensorflow/tensorflow/issues/21735#issue-352151121), it may be a mistake that only `sparse_categorical_accuracy` is NOT decorated by `tf_export` and result in explicit import i.e. `from tensorflow.keras.metrics import sparse_categorical_crossentropy`.