### PR TITLE
Avijit/fix license files

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -396,7 +396,7 @@ def tf_cc_binary(
         srcs = srcs + tf_binary_additional_srcs(),
         deps = deps + tf_binary_dynamic_kernel_deps(kernels) + if_mkl_ml(
             [
-                "//third_party/mkl:intel_binary_blob",
+                clean_dep("//third_party/mkl:intel_binary_blob"),
             ],
         ),
         data = data + tf_binary_dynamic_kernel_dsos(kernels),
@@ -734,7 +734,7 @@ def tf_cc_test(
         }) + linkopts + _rpath_linkopts(name),
         deps = deps + tf_binary_dynamic_kernel_deps(kernels) + if_mkl_ml(
             [
-                "//third_party/mkl:intel_binary_blob",
+                clean_dep("//third_party/mkl:intel_binary_blob"),
             ],
         ),
         data = data + tf_binary_dynamic_kernel_dsos(kernels),

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -209,7 +209,7 @@ filegroup(
     ) + if_ngraph([
         "@ngraph//:LICENSE",
         "@ngraph_tf//:LICENSE",
-        "@nlohmann_json_lib//:LICENSE",
+        "@nlohmann_json_lib//:LICENSE.MIT",
     ]) + tf_additional_license_deps(),
 )
 

--- a/third_party/mkl/build_defs.bzl
+++ b/third_party/mkl/build_defs.bzl
@@ -26,7 +26,7 @@ def if_mkl(if_true, if_false = []):
       a select evaluating to either if_true or if_false as appropriate.
     """
     return select({
-        "//third_party/mkl:using_mkl": if_true,
+        str(Label("//third_party/mkl:using_mkl")): if_true,
         "//conditions:default": if_false,
     })
 
@@ -42,9 +42,8 @@ def if_mkl_ml(if_true, if_false = []):
       a select evaluating to either if_true or if_false as appropriate.
     """
     return select({
-        "//third_party/mkl_dnn:using_mkl_dnn_only":
-        if_false,
-        "//third_party/mkl:using_mkl": if_true,
+        str(Label("//third_party/mkl_dnn:using_mkl_dnn_only")): if_false,
+        str(Label("//third_party/mkl:using_mkl")): if_true,
         "//conditions:default": if_false,
         })
 
@@ -59,7 +58,7 @@ def if_mkl_ml_only(if_true, if_false = []):
       a select evaluating to either if_true or if_false as appropriate.
     """
     return select({
-        "//third_party/mkl:using_mkl_ml_only": if_true,
+        str(Label("//third_party/mkl:using_mkl_ml_only")): if_true,
         "//conditions:default": if_false,
     })
 
@@ -76,7 +75,7 @@ def if_mkl_lnx_x64(if_true, if_false = []):
       a select evaluating to either if_true or if_false as appropriate.
     """
     return select({
-        "//third_party/mkl:using_mkl_lnx_x64": if_true,
+        str(Label("//third_party/mkl:using_mkl_lnx_x64")): if_true,
         "//conditions:default": if_false,
     })
 
@@ -90,16 +89,13 @@ def mkl_deps():
       inclusion in the deps attribute of rules.
     """
     return select({
-        "//third_party/mkl_dnn:using_mkl_dnn_only":
-        ["@mkl_dnn"],
-        "//third_party/mkl:using_mkl_ml_only":
-        ["//third_party/mkl:intel_binary_blob"],
-        "//third_party/mkl:using_mkl":
-        [
+        str(Label("//third_party/mkl_dnn:using_mkl_dnn_only")): ["@mkl_dnn"],
+        str(Label("//third_party/mkl:using_mkl_ml_only")): ["//third_party/mkl:intel_binary_blob"],
+        str(Label("//third_party/mkl:using_mkl")): [
             "//third_party/mkl:intel_binary_blob",
-            "@mkl_dnn"
+            "@mkl_dnn",
         ],
-        "//conditions:default": []
+        "//conditions:default": [],
         })
 
 def _enable_local_mkl(repository_ctx):

--- a/third_party/ngraph/ngraph.BUILD
+++ b/third_party/ngraph/ngraph.BUILD
@@ -1,14 +1,6 @@
 licenses(["notice"])  # 3-Clause BSD
 
-exports_files(["license.txt"])
-
-filegroup(
-    name = "LICENSE",
-    srcs = [
-        "license.txt",
-    ],
-    visibility = ["//visibility:public"],
-)
+exports_files(["LICENSE"])
 
 cc_library(
     name = "ngraph_core",

--- a/third_party/ngraph/ngraph_tf.BUILD
+++ b/third_party/ngraph/ngraph_tf.BUILD
@@ -1,14 +1,6 @@
 licenses(["notice"])  # 3-Clause BSD
 
-exports_files(["license.txt"])
-
-filegroup(
-    name = "LICENSE",
-    srcs = [
-        "license.txt",
-    ],
-    visibility = ["//visibility:public"],
-)
+exports_files(["LICENSE"])
 
 load(
     "@org_tensorflow//tensorflow:tensorflow.bzl",

--- a/third_party/ngraph/nlohmann_json.BUILD
+++ b/third_party/ngraph/nlohmann_json.BUILD
@@ -1,14 +1,6 @@
 licenses(["notice"])  # 3-Clause BSD
 
-exports_files(["license.txt"])
-
-filegroup(
-    name = "LICENSE",
-    srcs = [
-        "license.txt",
-    ],
-    visibility = ["//visibility:public"],
-)
+exports_files(["LICENSE.MIT"])
 
 cc_library(
     name = "nlohmann_json_lib",


### PR DESCRIPTION
We discovered that the license file names are wrong when nGraph build is selected. This PR fixes these file names so that nGraph is built with TensorFlow when requested. This PR also fixes nGraph unit tests due to recent changes in the MKL bazel files.