### PR TITLE
Improve correctness of auto_parallel

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -196,6 +196,7 @@ COMMON_PROTO_SRCS = [
     "protobuf/cluster.proto",
     "protobuf/debug.proto",
     "protobuf/device_properties.proto",
+    "protobuf/gradients_info.proto",
     "protobuf/queue_runner.proto",
     "protobuf/rewriter_config.proto",
     "protobuf/tensor_bundle.proto",

--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/variable.pb.h"
+#include "tensorflow/core/protobuf/gradients_info.pb.h"
 #include "tensorflow/core/protobuf/queue_runner.pb.h"
 
 namespace tensorflow {
@@ -60,6 +61,17 @@ struct GrapplerItem {
 
   // Queue runner(s) required to run the queue(s) of this model.
   std::vector<QueueRunnerDef> queue_runners;
+
+  // Trainable variable(s) of this model.
+  std::vector<string> trainable_variables;
+
+  // Pairs of a target tensor and its gradient tensor of this model.
+  std::vector<
+      std::pair<GradientsInfoDef_TensorInfoDef, GradientsInfoDef_TensorInfoDef>>
+      gradients_info;
+
+  // Map of an operator name to its OpDef in metagraph.
+  std::map<std::string, OpDef> op_def;
 
   // List of op names to keep in the graph. This includes nodes that are
   // referenced in various collections, and therefore must be preserved to

--- a/tensorflow/core/grappler/grappler_item_builder_test.cc
+++ b/tensorflow/core/grappler/grappler_item_builder_test.cc
@@ -198,6 +198,29 @@ TEST_F(GrapplerItemBuilderTest, GraphWithCustomOps) {
        test::function::NDef("y", "CustomOp", {"x"}, {{"T", DT_FLOAT}}, device)},
       {});
 
+  const string op_def_text = R"(
+name: "CustomOp"
+input_arg {
+  name: "a"
+  description: "Description for a."
+}
+output_arg {
+  name: "output"
+  description: "Description for output."
+}
+attr {
+  name: "b"
+  description: "Description for b."
+}
+summary: "Summary for Op1."
+description: "Description\nfor Op1."
+)";
+  meta_graph.mutable_meta_info_def()->mutable_stripped_op_list()->add_op();
+  protobuf::TextFormat::ParseFromString(op_def_text,
+                                        meta_graph.mutable_meta_info_def()
+                                            ->mutable_stripped_op_list()
+                                            ->mutable_op(0));
+
   CollectionDef train_op;
   train_op.mutable_node_list()->add_value("y");
   (*meta_graph.mutable_collection_def())["train_op"] = train_op;
@@ -207,6 +230,7 @@ TEST_F(GrapplerItemBuilderTest, GraphWithCustomOps) {
   std::unique_ptr<GrapplerItem> item =
       GrapplerItemFromMetaGraphDef("0", meta_graph, cfg);
   ASSERT_TRUE(item != nullptr);
+  ASSERT_TRUE(item->op_def.find("CustomOp") != item->op_def.end());
 }
 
 TEST_F(GrapplerItemBuilderTest, FromGraphWithSignatureDef) {

--- a/tensorflow/core/grappler/optimizers/auto_parallel.cc
+++ b/tensorflow/core/grappler/optimizers/auto_parallel.cc
@@ -31,26 +31,56 @@ namespace tensorflow {
 namespace grappler {
 const char kAutoParallelPrefix[] = "AutoParallel";
 
-NodeDef* AutoParallel::AddNodeDivConst() {
-  NodeDef* node = graph_.add_node();
-  node->set_name(strings::StrCat(kAutoParallelPrefix, "-Div-Const"));
+NodeDef* AutoParallel::AddNodeNumReplicasConst(bool is_float, GraphDef* graph) {
+  NodeDef* node = graph->add_node();
   node->set_op("Const");
 
   AttrValue attr_data_type;
-  attr_data_type.set_type(DT_FLOAT);
+  if (is_float) {
+    attr_data_type.set_type(DT_FLOAT);
+    node->set_name(
+        strings::StrCat(kAutoParallelPrefix, "-NumReplicas-Float-Const"));
+  } else {
+    attr_data_type.set_type(DT_INT32);
+    node->set_name(
+        strings::StrCat(kAutoParallelPrefix, "-NumReplicas-Int-Const"));
+  }
   node->mutable_attr()->insert({"dtype", attr_data_type});
 
   AttrValue attr_tensor;
   auto tensor = attr_tensor.mutable_tensor();
-  tensor->add_float_val(static_cast<float>(num_replicas_));
-  tensor->set_dtype(DT_FLOAT);
+  if (is_float) {
+    tensor->add_float_val(static_cast<float>(num_replicas_));
+    tensor->set_dtype(DT_FLOAT);
+  } else {
+    tensor->add_int_val(num_replicas_);
+    tensor->set_dtype(DT_INT32);
+  }
+  node->mutable_attr()->insert({"value", attr_tensor});
+  return node;
+}
+
+NodeDef* AutoParallel::AddNodeMaxLongConst(const string& name,
+                                           GraphDef* graph) {
+  NodeDef* node = graph->add_node();
+  node->set_name(name);
+  node->set_op("Const");
+
+  AttrValue attr_data_type;
+  attr_data_type.set_type(DT_INT64);
+  node->mutable_attr()->insert({"dtype", attr_data_type});
+
+  AttrValue attr_tensor;
+  auto tensor = attr_tensor.mutable_tensor();
+  tensor->add_int64_val(std::numeric_limits<long>::max());
+  tensor->set_dtype(DT_INT64);
   node->mutable_attr()->insert({"value", attr_tensor});
   return node;
 }
 
 NodeDef* AutoParallel::AddNodeDiv(const string& name, const string& input_a,
-                                  const string& input_b) {
-  NodeDef* node = graph_.add_node();
+                                  const string& input_b, GraphDef* graph) {
+  NodeDef* node = graph->add_node();
   node->set_name(strings::StrCat(kAutoParallelPrefix, "-Div-", name));
   node->set_op("RealDiv");
   node->add_input(input_a);
@@ -59,6 +89,91 @@ NodeDef* AutoParallel::AddNodeDiv(const string& name, const string& input_a,
   attr_type.set_type(DT_FLOAT);
   node->mutable_attr()->insert({"T", attr_type});
   return node;
+}
+
+NodeDef* AutoParallel::AddNodeAdd(const string& name,
+                                  const std::set<string>& inps,
+                                  GraphDef* graph) {
+  NodeDef* add_node = graph->add_node();
+  add_node->set_name(strings::StrCat(kAutoParallelPrefix, "-Add-", name));
+  add_node->set_op("AddN");
+
+  for (auto input_name : inps) {
+    add_node->add_input(input_name);
+  }
+
+  AttrValue attr_type;
+  attr_type.set_type(DT_FLOAT);
+  add_node->mutable_attr()->insert({"T", attr_type});
+  AttrValue attr_numbers;
+  attr_numbers.set_i(inps.size());
+  add_node->mutable_attr()->insert({"N", attr_numbers});
+  return add_node;
+}
+
+NodeDef* AutoParallel::AddNodeSparseAccumulator(const string& name,
+                                                GraphDef* graph) {
+  NodeDef* accumulator = graph->add_node();
+  accumulator->set_name(strings::StrCat(kAutoParallelPrefix, "-Accum-", name));
+  accumulator->set_op("SparseConditionalAccumulator");
+  AttrValue attr_type;
+  attr_type.set_type(DT_FLOAT);
+  accumulator->mutable_attr()->insert({"dtype", attr_type});
+  return accumulator;
+}
+
+NodeDef* AutoParallel::AddNodeCast(const string& name, const string& input,
+                                   const DataType& src_dtype,
+                                   const DataType& dst_dtype, GraphDef* graph) {
+  NodeDef* cast_node = graph->add_node();
+  cast_node->set_name(name);
+  cast_node->set_op("Cast");
+  cast_node->add_input(input);
+  AttrValue attr_src_type;
+  attr_src_type.set_type(src_dtype);
+  AttrValue attr_dst_type;
+  attr_dst_type.set_type(dst_dtype);
+  cast_node->mutable_attr()->insert({"SrcT", attr_src_type});
+  cast_node->mutable_attr()->insert({"DstT", attr_dst_type});
+  return cast_node;
+}
+
+NodeDef* AutoParallel::AddNodeSparseAccumApply(
+    const string& name, const string& accumulator, const string& max_long,
+    const string& indices, const string& values, GraphDef* graph) {
+  NodeDef* sparse_accum_apply_node = graph->add_node();
+  sparse_accum_apply_node->set_op("SparseAccumulatorApplyGradient");
+  sparse_accum_apply_node->set_name(name);
+  sparse_accum_apply_node->add_input(accumulator);
+  sparse_accum_apply_node->add_input(max_long);
+  sparse_accum_apply_node->add_input(indices);
+  sparse_accum_apply_node->add_input(values);
+  sparse_accum_apply_node->add_input(values);  // dummy shape node
+  AttrValue attr_type;
+  attr_type.set_type(DT_FLOAT);
+  sparse_accum_apply_node->mutable_attr()->insert({"dtype", attr_type});
+  AttrValue attr_bool;
+  attr_bool.set_b(false);
+  sparse_accum_apply_node->mutable_attr()->insert(
+      {"has_known_shape", attr_bool});
+  return sparse_accum_apply_node;
+}
+
+NodeDef* AutoParallel::AddNodeSparseAccumTakeGrad(const string& name,
+                                                  const string& accumulator,
+                                                  const string& num_replicas,
+                                                  const string& control,
+                                                  GraphDef* graph) {
+  NodeDef* take_grad = graph->add_node();
+  take_grad->set_name(strings::StrCat(kAutoParallelPrefix, "-TakeGrad-", name));
+  take_grad->set_op("SparseAccumulatorTakeGradient");
+  take_grad->add_input(accumulator);
+  take_grad->add_input(num_replicas);
+  take_grad->add_input(strings::StrCat("^", control));
+  AttrValue attr_type;
+  attr_type.set_type(DT_FLOAT);
+  take_grad->mutable_attr()->insert({"dtype", attr_type});
+  return take_grad;
 }
 
 NodeDef* AutoParallel::AddNodeControl(const string& name,
@@ -99,55 +214,33 @@ Status AutoParallel::Initialize(const GrapplerItem& item) {
     VLOG(2) << "Variable: " << var->name();
   }
 
-  const std::set<string> apply_gradients_ops = {"ApplyGradientDescent",
-                                                "ApplyProximalGradientDescent",
-                                                "ApplyAdadelta",
-                                                "ApplyAdagrad",
-                                                "ApplyProximalAdagrad",
-                                                "ApplyAdagradDA",
-                                                "ApplyFtrl",
-                                                "ApplyMomentum",
-                                                "ApplyAdam",
-                                                "ApplyRMSProp",
-                                                "ApplyCenteredRMSProp"};
   for (int i = 0; i < graph_.node_size(); i++) {
     all_nodes_.insert(
         std::make_pair(graph_.node(i).name(), graph_.mutable_node(i)));
-    if (apply_gradients_ops.find(graph_.node(i).op()) !=
-        apply_gradients_ops.end()) {
-      apply_gradients_nodes_.insert(graph_.node(i).name());
-      VLOG(2) << "Apply gradients node: " << graph_.node(i).name();
+  }
+
+  // Replicate operations that are necessary for computing gradients
+  // of trainable variables.
+  std::vector<std::string> gradient_nodes;
+  for (const auto& grad_info : item.gradients_info) {
+    auto target_tensor_info = grad_info.first;
+    if (std::find(item.trainable_variables.begin(),
+                  item.trainable_variables.end(),
+                  NodeName(target_tensor_info.values_tensor_name())) !=
+        item.trainable_variables.end()) {
+      auto grad_tensor_info = grad_info.second;
+      auto indices = grad_tensor_info.indices_tensor_name();
+      auto values = grad_tensor_info.values_tensor_name();
+
+      gradients_.insert(std::make_pair(indices, values));
+      if (!indices.empty()) {
+        gradient_nodes.push_back(NodeName(indices));
+      }
+      gradient_nodes.push_back(NodeName(values));
     }
   }
 
-  auto div_const_node = AddNodeDivConst();
-  all_nodes_.insert(std::make_pair(div_const_node->name(), div_const_node));
-  std::map<string, int> gradient_pos = {{"ApplyGradientDescent", 2},
-                                        {"ApplyProximalGradientDescent", 4},
-                                        {"ApplyAdadelta", 6},
-                                        {"ApplyAdagrad", 3},
-                                        {"ApplyProximalAdagrad", 5},
-                                        {"ApplyAdagradDA", 3},
-                                        {"ApplyFtrl", 3},
-                                        {"ApplyMomentum", 3},
-                                        {"ApplyAdam", 9},
-                                        {"ApplyRMSProp", 7},
-                                        {"ApplyCenteredRMSProp", 8}};
-  for (const auto& apply_gradient_node_name : apply_gradients_nodes_) {
-    auto apply_gradients_op = all_nodes_[apply_gradient_node_name]->op();
-    auto apply_gradients_node = all_nodes_[apply_gradient_node_name];
-
-    auto div_node = AddNodeDiv(
-        apply_gradient_node_name,
-        apply_gradients_node->input(gradient_pos[apply_gradients_op]),
-        div_const_node->name());
-    all_nodes_.insert(std::make_pair(div_node->name(), div_node));
-    *apply_gradients_node->mutable_input(gradient_pos[apply_gradients_op]) =
-        div_node->name();
-  }
-  LOG(INFO) << "Graph size after adding div nodes: " << all_nodes_.size();
-
-  auto train_nodes = ComputeTransitiveFanin(graph_, item.fetch);
+  auto train_nodes = ComputeTransitiveFanin(graph_, gradient_nodes);
   LOG(INFO) << "Number of training nodes: " << train_nodes.size();
 
   const NodeDef* dequeue_node;
@@ -235,26 +328,175 @@ void AutoParallel::AddOneReplica(GraphDef* graph, int number) {
   }
 }
 
+void AutoParallel::AddDenseAggregatedGrad(GraphDef* graph,
+                                          NodeDef* num_replicas,
+                                          const std::string& grad_name,
+                                          std::string* new_grad_name) {
+  // make unique grad name
+  const auto& unique_grad_name =
+      str_util::StringReplace(grad_name, ":", "_", false);
+
+  std::set<std::string> inputs;
+  for (int i = 0; i < num_replicas_; i++) {
+    auto prefix = strings::StrCat(kAutoParallelPrefix, "-Replica-", i);
+    inputs.insert(AddPrefixToNodeName(grad_name, prefix));
+  }
+
+  auto add_node = AddNodeAdd(unique_grad_name, inputs, graph);
+
+  // divide the aggregated grad by num_replicas
+  auto div_node = AddNodeDiv(unique_grad_name, add_node->name(),
+                             num_replicas->name(), graph);
+
+  *new_grad_name = div_node->name();
+}
+
+void AutoParallel::AddSparseAggregatedGrad(GraphDef* graph,
+                                           NodeDef* num_replicas_node,
+                                           const std::string& indices_name,
+                                           const std::string& values_name,
+                                           std::string* new_indices_name,
+                                           std::string* new_grad_name) {
+  const auto& unique_indices_name =
+      str_util::StringReplace(indices_name, ":", "_", false);
+  const auto& unique_values_name =
+      str_util::StringReplace(values_name, ":", "_", false);
+
+  auto sparse_accum_node = AddNodeSparseAccumulator(unique_values_name, graph);
+
+  int indices_index = 0;
+  if (str_util::StrContains(indices_name, ":")) {
+    auto str_splits = str_util::Split(indices_name, ":");
+    strings::safe_strto32(str_splits.back(), &indices_index);
+  }
+  auto indices_node = all_nodes_[NodeName(indices_name)];
+  const auto& indices_op_def = item_->op_def.at(indices_node->op());
+  auto type_name = indices_op_def.output_arg(indices_index).type_attr();
+  auto indices_dtype = indices_node->attr().at(type_name).type();
+
+  // Create SparseAccumulatorApplyGradientOp per replica
+  std::set<std::string> sparse_accum_apply_nodes;
+  for (int i = 0; i < num_replicas_; i++) {
+    auto prefix = strings::StrCat(kAutoParallelPrefix, "-Replica-", i);
+    auto indices_replica_name = AddPrefixToNodeName(indices_name, prefix);
+    if (indices_dtype != DT_INT64) {
+      assert(indices_dtype == DT_INT32);
+      auto indices_cast_node = AddNodeCast(
+          AddPrefixToNodeName(strings::StrCat("Cast-", unique_indices_name),
+                              prefix),
+          indices_replica_name, DT_INT32, DT_INT64, graph);
+      indices_replica_name = indices_cast_node->name();
+    }
+
+    auto values_replica_name = AddPrefixToNodeName(values_name, prefix);
+    auto max_long_node = AddNodeMaxLongConst(
+        AddPrefixToNodeName("MaxLong-Const", prefix), graph);
+    auto sparse_accum_apply_node = AddNodeSparseAccumApply(
+        AddPrefixToNodeName(strings::StrCat("AccumApply-", unique_values_name),
+                            prefix),
+        sparse_accum_node->name(), max_long_node->name(), indices_replica_name,
+        values_replica_name, graph);
+    sparse_accum_apply_nodes.insert(sparse_accum_apply_node->name());
+  }
+
+  auto control_node =
+      AddNodeControl(strings::StrCat(kAutoParallelPrefix, "-AccumApplyControl-",
+                                     unique_values_name),
+                     sparse_accum_apply_nodes, graph);
+
+  auto take_grad = AddNodeSparseAccumTakeGrad(
+      unique_values_name, sparse_accum_node->name(), num_replicas_node->name(),
+      control_node->name(), graph);
+
+  *new_indices_name = strings::StrCat(take_grad->name(), ":0");
+  *new_grad_name = strings::StrCat(take_grad->name(), ":1");
+
+  if (indices_dtype != DT_INT64) {
+    assert(indices_dtype == DT_INT32);
+    auto indices_cast_node =
+        AddNodeCast(strings::StrCat(take_grad->name(), "-Cast"),
+                    *new_indices_name, DT_INT64, DT_INT32, graph);
+    *new_indices_name = indices_cast_node->name();
+  }
+}
+
+void AutoParallel::UpdateConsumers(
+    const std::vector<std::pair<NodeDef*, int>>& grad_consumers,
+    const std::string& new_grad_name) {
+  for (const auto& consumer : grad_consumers) {
+    auto consumer_node = consumer.first;
+    int input_index = consumer.second;
+    if (str_util::StartsWith(consumer_node->input(input_index), "^")) {
+      consumer_node->set_input(input_index,
+                               strings::StrCat("^", new_grad_name));
+    } else {
+      consumer_node->set_input(input_index, new_grad_name);
+    }
+  }
+}
+
+void AutoParallel::AddGradientAggregation(GraphDef* graph) {
+  // Find gradient consumers.
+  // Gradient name -> list of (consumer node, index of the gradient in the
+  // conumser inputs).
+  std::map<std::string, std::vector<std::pair<NodeDef*, int>>> grad_consumers;
+  string prefix = strings::StrCat(kAutoParallelPrefix, "-Replica-");
+  for (int i = 0; i < graph->node_size(); i++) {
+    auto node = graph->mutable_node(i);
+    for (int j = 0; j < node->input_size(); j++) {
+      auto input = node->input(j);
+      if (str_util::StartsWith(input, prefix)) {
+        // Remove prefix(e.g'AutoParallel-Replica-15/')
+        input = input.substr(input.find("/") + 1);
+      }
+      for (auto gradient : gradients_) {
+        auto indices_name = gradient.first;
+        auto values_name = gradient.second;
+        if (!indices_name.empty() &&
+            (!input.compare(indices_name) ||
+             !input.compare(strings::StrCat("^", indices_name)))) {
+          grad_consumers[indices_name].push_back(std::make_pair(node, j));
+        }
+        if (!input.compare(values_name) ||
+            !input.compare(strings::StrCat("^", values_name))) {
+          grad_consumers[values_name].push_back(std::make_pair(node, j));
+        }
+      }
+    }
+  }
+
+  NodeDef* num_replicas_node_f = AddNodeNumReplicasConst(true, graph);
+  NodeDef* num_replicas_node_i = NULL;
+  for (const auto& gradient : gradients_) {
+    const auto& indices_name = gradient.first;
+    const auto& values_name = gradient.second;
+    bool is_sparse_values = !indices_name.empty();
+    std::string new_indices_name;
+    std::string new_values_name;
+    if (!is_sparse_values) {
+      AddDenseAggregatedGrad(graph, num_replicas_node_f, values_name,
+                             &new_values_name);
+      UpdateConsumers(grad_consumers[values_name], new_values_name);
+    } else {
+      if (num_replicas_node_i == NULL) {
+        num_replicas_node_i = AddNodeNumReplicasConst(false, graph);
+      }
+      AddSparseAggregatedGrad(graph, num_replicas_node_i, indices_name,
+                              values_name, &new_indices_name, &new_values_name);
+      UpdateConsumers(grad_consumers[indices_name], new_indices_name);
+      UpdateConsumers(grad_consumers[values_name], new_values_name);
+    }
+  }
+}
+
 void AutoParallel::BuildGraph(GraphDef* graph) {
   AddSharedNodes(graph);
   for (int i = 0; i < num_replicas_; i++) {
     AddOneReplica(graph, i);
   }
-  std::set<string> fetches;
-  for (size_t i = 0; i < item_->fetch.size(); i++) {
-    for (int j = 0; j < num_replicas_; j++) {
-      string prefix = strings::StrCat(kAutoParallelPrefix, "-Replica-", j);
-      string fetch = AddPrefixToNodeName(item_->fetch[i], prefix);
-      fetches.insert(fetch);
-    }
-  }
-  string name_control =
-      strings::StrCat(kAutoParallelPrefix, "-Control-", "Fetch");
-  auto control = AddNodeControl(name_control, fetches, graph);
 
-  for (const auto& fetch : item_->fetch) {
-    AddNodeControl(fetch, {control->name()}, graph);
-  }
+  AddGradientAggregation(graph);
+
   *graph->mutable_library() = item_->graph.library();
   *graph->mutable_versions() = item_->graph.versions();
   LOG(INFO) << "Parallelized graph size: " << graph->node_size();

--- a/tensorflow/core/grappler/optimizers/auto_parallel_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_parallel_test.cc
@@ -31,99 +31,168 @@ TEST_F(AutoParallelTest, SimpleParallel) {
   tensorflow::Scope s = tensorflow::Scope::DisabledShapeInferenceScope();
   Output constant_a = ops::Const(s.WithOpName("constant_a"), 1.0f, {1});
   Output constant_b = ops::Const(s.WithOpName("constant_b"), 1, {1});
+  Output constant_c =
+      ops::Const(s.WithOpName("constant_c"), {1.0f, 2.0f, 3.0f}, {3});
+  Output constant_d = ops::Const(s.WithOpName("constant_d"), 2.0f, {1});
   Output var = ops::Variable(s.WithOpName("var"), {1}, DT_FLOAT);
   Output assign = ops::Assign(s.WithOpName("assign"), {var}, {constant_a});
   Output identity = ops::Identity(s.WithOpName("identity"), {var});
+  Output embedding = ops::Variable(s.WithOpName("embedding"), {3}, DT_FLOAT);
+  Output emb_assign =
+      ops::Assign(s.WithOpName("emb_assign"), {embedding}, {constant_c});
   Output fifo_queue = ops::FIFOQueue(s.WithOpName("fifo_queue"), {DT_FLOAT});
   auto dequeue = ops::QueueDequeueMany(s.WithOpName("dequeue"), {fifo_queue},
                                        {constant_b}, {DT_FLOAT});
   Output add = ops::AddN(s.WithOpName("add"), {constant_a, dequeue[0]});
+  Output clip =
+      ops::ClipByValue(s.WithOpName("clip"), {add}, {constant_a}, {constant_d});
+  Output indices = ops::Const(s.WithOpName("indices"), 1, {1});
+  Output values = ops::Const(s.WithOpName("values"), 2.0f, {1});
   Output learning_rate = ops::Const(s.WithOpName("learning_rate"), 0.01f, {1});
   Output apply_gradient = ops::ApplyGradientDescent(
-      s.WithOpName("apply_gradient"), {var}, {learning_rate}, {add});
+      s.WithOpName("apply_gradient"), {var}, {learning_rate}, {clip});
+  Output update_sparse = ops::ScatterAdd(s.WithOpName("scatter_add"),
+                                         {embedding}, {indices}, {values});
 
   GrapplerItem item;
   item.init_ops.push_back("assign");
+  item.init_ops.push_back("emb_assign");
   item.fetch.push_back("apply_gradient");
-  item.init_ops.push_back("assign");
+  item.fetch.push_back("scatter_add");
+  // add trainable variables.
+  item.trainable_variables.push_back("var");
+  item.trainable_variables.push_back("embedding");
+  // add gradients information.
+  GradientsInfoDef_TensorInfoDef var_tensor;
+  var_tensor.set_tensor_type(GradientsInfoDef_TensorInfoDef::TENSOR);
+  var_tensor.set_values_tensor_name("var");
+  GradientsInfoDef_TensorInfoDef var_grad_tensor;
+  var_grad_tensor.set_tensor_type(GradientsInfoDef_TensorInfoDef::TENSOR);
+  var_grad_tensor.set_values_tensor_name("add");
+  item.gradients_info.push_back(std::make_pair(var_tensor, var_grad_tensor));
+  GradientsInfoDef_TensorInfoDef embedding_tensor;
+  embedding_tensor.set_tensor_type(GradientsInfoDef_TensorInfoDef::TENSOR);
+  embedding_tensor.set_values_tensor_name("embedding");
+  GradientsInfoDef_TensorInfoDef embedding_grad_tensor;
+  embedding_grad_tensor.set_tensor_type(
+      GradientsInfoDef_TensorInfoDef::INDEXED_SLICES);
+  embedding_grad_tensor.set_indices_tensor_name("indices");
+  embedding_grad_tensor.set_values_tensor_name("values");
+  item.gradients_info.push_back(
+      std::make_pair(embedding_tensor, embedding_grad_tensor));
+  // add op_def information.
+  OpDef const_op_def;
+  const_op_def.set_name("Const");
+  const_op_def.add_output_arg();
+  const_op_def.mutable_output_arg(0)->set_name("output");
+  const_op_def.mutable_output_arg(0)->set_type_attr("dtype");
+  const_op_def.add_attr();
+  const_op_def.mutable_attr(0)->set_name("dtype");
+  const_op_def.mutable_attr(0)->set_type("type");
+  item.op_def.insert(std::make_pair("Const", const_op_def));
   TF_CHECK_OK(s.ToGraphDef(&item.graph));
+
+  std::vector<std::string> shared_nodes = {
+      "constant_b",    "constant_c",     "constant_d", "var",        "assign",
+      "identity",      "embedding",      "emb_assign", "fifo_queue", "clip",
+      "learning_rate", "apply_gradient", "scatter_add"};
+  std::vector<std::string> replica_nodes = {"constant_a", "dequeue", "add",
+                                            "indices", "values"};
+  std::vector<std::string> aggregation_shared_nodes = {
+      "AutoParallel-NumReplicas-Int-Const",
+      "AutoParallel-NumReplicas-Float-Const",
+      "AutoParallel-Add-add",
+      "AutoParallel-Div-add",
+      "AutoParallel-Accum-values",
+      "AutoParallel-TakeGrad-values",
+      "AutoParallel-AccumApplyControl-values",
+      "AutoParallel-TakeGrad-values-Cast"};
+  std::vector<std::string> aggregation_replica_nodes = {
+      "MaxLong-Const", "AccumApply-values", "Cast-indices"};
 
   AutoParallel parallel(2);
   GraphDef output;
   Status status = parallel.Optimize(nullptr, item, &output);
   TF_EXPECT_OK(status);
-  EXPECT_EQ(21, output.node_size());
+  int expected_node_size =
+      shared_nodes.size() + aggregation_shared_nodes.size() +
+      (replica_nodes.size() + aggregation_replica_nodes.size()) * 2;
+  EXPECT_EQ(expected_node_size, output.node_size());
 
-  const NodeDef& node_assign = output.node(0);
-  EXPECT_EQ("assign", node_assign.name());
-  EXPECT_EQ("AutoParallel-Replica-0/constant_a", node_assign.input(1));
+  std::map<std::string, NodeDef> all_nodes;
+  for (int i = 0; i < output.node_size(); i++) {
+    all_nodes.insert(std::make_pair(output.node(i).name(), output.node(i)));
+  }
 
-  const NodeDef& node_constant_b = output.node(1);
-  EXPECT_EQ("constant_b", node_constant_b.name());
+  shared_nodes.insert(shared_nodes.end(), aggregation_shared_nodes.begin(),
+                      aggregation_shared_nodes.end());
+  for (const auto& shared_node : shared_nodes) {
+    EXPECT_TRUE(all_nodes.find(shared_node) != all_nodes.end());
+  }
 
-  const NodeDef& node_fifo_queue = output.node(2);
-  EXPECT_EQ("fifo_queue", node_fifo_queue.name());
+  replica_nodes.insert(replica_nodes.end(), aggregation_replica_nodes.begin(),
+                       aggregation_replica_nodes.end());
+  auto prefix_0 = "AutoParallel-Replica-0";
+  auto prefix_1 = "AutoParallel-Replica-1";
+  for (const auto& replica_node : replica_nodes) {
+    EXPECT_TRUE(all_nodes.find(replica_node) == all_nodes.end());
+    EXPECT_TRUE(all_nodes.find(AddPrefixToNodeName(replica_node, prefix_0)) !=
+                all_nodes.end());
+    EXPECT_TRUE(all_nodes.find(AddPrefixToNodeName(replica_node, prefix_1)) !=
+                all_nodes.end());
+  }
 
-  const NodeDef& node_identity = output.node(3);
-  EXPECT_EQ("identity", node_identity.name());
-  EXPECT_EQ("var", node_identity.input(0));
+  const NodeDef& node_apply = all_nodes.find("apply_gradient")->second;
+  EXPECT_EQ("clip", node_apply.input(2));
 
-  const NodeDef& node_var = output.node(4);
-  EXPECT_EQ("var", node_var.name());
+  const NodeDef& node_clip = all_nodes.find("clip")->second;
+  EXPECT_EQ("AutoParallel-Div-add", node_clip.input(0));
 
-  const NodeDef& node_div_const0 = output.node(5);
-  EXPECT_EQ("AutoParallel-Replica-0/AutoParallel-Div-Const",
-            node_div_const0.name());
+  const NodeDef& node_div = all_nodes.find("AutoParallel-Div-add")->second;
+  EXPECT_EQ("AutoParallel-Add-add", node_div.input(0));
+  EXPECT_EQ("AutoParallel-NumReplicas-Float-Const", node_div.input(1));
 
-  const NodeDef& node_div0 = output.node(6);
-  EXPECT_EQ("AutoParallel-Replica-0/AutoParallel-Div-apply_gradient",
-            node_div0.name());
-  const NodeDef& node_add0 = output.node(7);
-  EXPECT_EQ("AutoParallel-Replica-0/add", node_add0.name());
+  const NodeDef& node_add_n = all_nodes.find("AutoParallel-Add-add")->second;
+  EXPECT_EQ(AddPrefixToNodeName("add", prefix_0), node_add_n.input(0));
+  EXPECT_EQ(AddPrefixToNodeName("add", prefix_1), node_add_n.input(1));
 
-  const NodeDef& node_gradient0 = output.node(8);
-  EXPECT_EQ("AutoParallel-Replica-0/apply_gradient", node_gradient0.name());
+  const NodeDef& node_scatter_add = all_nodes.find("scatter_add")->second;
+  EXPECT_EQ("AutoParallel-TakeGrad-values-Cast", node_scatter_add.input(1));
+  EXPECT_EQ("AutoParallel-TakeGrad-values:1", node_scatter_add.input(2));
 
-  const NodeDef& node_constant_a0 = output.node(9);
-  EXPECT_EQ("AutoParallel-Replica-0/constant_a", node_constant_a0.name());
+  const NodeDef& node_take_grad =
+      all_nodes.find("AutoParallel-TakeGrad-values")->second;
+  EXPECT_EQ("AutoParallel-Accum-values", node_take_grad.input(0));
+  EXPECT_EQ("AutoParallel-NumReplicas-Int-Const", node_take_grad.input(1));
+  EXPECT_EQ("^AutoParallel-AccumApplyControl-values", node_take_grad.input(2));
 
-  const NodeDef& node_dequeue0 = output.node(10);
-  EXPECT_EQ("AutoParallel-Replica-0/dequeue", node_dequeue0.name());
+  const NodeDef& node_apply_control =
+      all_nodes.find("AutoParallel-AccumApplyControl-values")->second;
+  EXPECT_EQ(
+      strings::StrCat("^", AddPrefixToNodeName("AccumApply-values", prefix_0)),
+      node_apply_control.input(0));
+  EXPECT_EQ(
+      strings::StrCat("^", AddPrefixToNodeName("AccumApply-values", prefix_1)),
+      node_apply_control.input(1));
 
-  const NodeDef& node_learning_rate0 = output.node(11);
-  EXPECT_EQ("AutoParallel-Replica-0/learning_rate", node_learning_rate0.name());
+  for (int i = 0; i < 2; i++) {
+    auto prefix = strings::StrCat("AutoParallel-Replica-", i);
+    const NodeDef& node_accum_apply =
+        all_nodes.find(AddPrefixToNodeName("AccumApply-values", prefix))
+            ->second;
+    EXPECT_EQ("AutoParallel-Accum-values", node_accum_apply.input(0));
+    EXPECT_EQ(AddPrefixToNodeName("MaxLong-Const", prefix),
+              node_accum_apply.input(1));
+    EXPECT_EQ(AddPrefixToNodeName("Cast-indices", prefix),
+              node_accum_apply.input(2));
+    EXPECT_EQ(AddPrefixToNodeName("values", prefix), node_accum_apply.input(3));
+    EXPECT_EQ(false, node_accum_apply.attr().at("has_known_shape").b());
 
-  const NodeDef& node_div_const1 = output.node(12);
-  EXPECT_EQ("AutoParallel-Replica-1/AutoParallel-Div-Const",
-            node_div_const1.name());
-
-  const NodeDef& node_div1 = output.node(13);
-  EXPECT_EQ("AutoParallel-Replica-1/AutoParallel-Div-apply_gradient",
-            node_div1.name());
-
-  const NodeDef& node_add1 = output.node(14);
-  EXPECT_EQ("AutoParallel-Replica-1/add", node_add1.name());
-
-  const NodeDef& node_gradient1 = output.node(15);
-  EXPECT_EQ("AutoParallel-Replica-1/apply_gradient", node_gradient1.name());
-
-  const NodeDef& node_constant_a1 = output.node(16);
-  EXPECT_EQ("AutoParallel-Replica-1/constant_a", node_constant_a1.name());
-
-  const NodeDef& node_dequeue1 = output.node(17);
-  EXPECT_EQ("AutoParallel-Replica-1/dequeue", node_dequeue1.name());
-
-  const NodeDef& node_learning_rate1 = output.node(18);
-  EXPECT_EQ("AutoParallel-Replica-1/learning_rate", node_learning_rate1.name());
-
-  const NodeDef& node_fetch = output.node(19);
-  EXPECT_EQ("AutoParallel-Control-Fetch", node_fetch.name());
-  EXPECT_EQ("^AutoParallel-Replica-0/apply_gradient", node_fetch.input(0));
-  EXPECT_EQ("^AutoParallel-Replica-1/apply_gradient", node_fetch.input(1));
-
-  const NodeDef& node_gradient = output.node(20);
-  EXPECT_EQ("apply_gradient", node_gradient.name());
-  EXPECT_EQ("^AutoParallel-Control-Fetch", node_gradient.input(0));
+    const NodeDef& node_cast_indices =
+        all_nodes.find(AddPrefixToNodeName("Cast-indices", prefix))->second;
+    EXPECT_EQ(AddPrefixToNodeName("indices", prefix),
+              node_cast_indices.input(0));
+  }
 }
 
 }  // namespace

--- a/tensorflow/core/protobuf/gradients_info.proto
+++ b/tensorflow/core/protobuf/gradients_info.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package tensorflow;
+option cc_enable_arenas = true;
+option java_outer_classname = "GradientsInfoProtos";
+option java_multiple_files = true;
+option java_package = "org.tensorflow.framework";
+
+// Protocol buffer representing a GradientsInfo.
+message GradientsInfoDef {
+    
+  // Protocol buffer representing a tensor.
+  message TensorInfoDef {
+    
+    enum TensorType {
+      // Tensor
+      TENSOR = 0;
+    
+      // IndexedSlices
+      INDEXED_SLICES = 1;
+
+      // SparseTensor
+      SPARSE_TENSOR = 2;
+    }
+
+    // Tensor type(TENSOR, INDEXED_SLICES, SPARSE_TENSOR)
+    TensorType tensor_type = 1;
+    
+    // Indices of tensor for INDEXED_SLICES and SPARSE_TENSOR
+    string indices_tensor_name = 2;
+
+    // Values of tensor for all of the tensor types
+    string values_tensor_name = 3;
+    
+    // Dense shape of tensor for INDEXED_SLICES and SPARSE_TENSOR
+    string dense_shape_tensor_name = 4;
+  }
+
+  // A target tensor information which is used for differentiation
+  TensorInfoDef target_tensor_info = 1;
+  
+  // The gradient tensor information of the target tensor
+  TensorInfoDef grad_tensor_info = 2;
+}

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -5777,6 +5777,9 @@ class GraphKeys(object):
   # Key for streaming model ports.
   # NOTE(yuanbyu): internal and experimental.
   _STREAMING_MODEL_PORTS = "streaming_model_ports"
+  
+  #Key for gradients information.
+  GRADIENTS_INFO = "gradients_info"  
 
   @decorator_utils.classproperty
   def VARIABLES(cls):  # pylint: disable=no-self-argument

--- a/tensorflow/python/ops/gradients_impl.py
+++ b/tensorflow/python/ops/gradients_impl.py
@@ -28,6 +28,7 @@ import six
 from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from tensorflow.core.framework import attr_value_pb2
+from tensorflow.core.protobuf import gradients_info_pb2
 from tensorflow.python.eager import context
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
@@ -64,6 +65,151 @@ cond_v2_impl._gradients_impl = sys.modules[__name__]  # pylint: disable=protecte
 # Warn the user if we convert a sparse representation to dense with at
 # least this number of elements.
 _LARGE_SPARSE_NUM_ELEMENTS = 100000000
+
+class GradientsInfo(object):
+  """Gradients Information.
+  """
+  def __init__(self, target=None, grad=None,
+               gradients_info_def=None, import_scope=None):
+    """Create a GradientsInfo.
+    Args:
+      target: Optional `Tensor` which is used for differentiation.
+      grad : Optional `Tensor`(or `IndexedSlices`). gradient tensor of target.
+      gradients_info_def: Optional `GradientsInfoDef` protocol buffer.
+        If specified, recreates the GradientsInfo from its contents.
+        `gradients_info_def` and the other arguments are mutually exclusive.
+      import_scope: Optional `string`. Name scope to add. Only used when
+        initializing from protocol buffer.
+    Raises:
+      ValueError: If both `gradients_info_def` and `target` are both specified.
+    """
+    if gradients_info_def and target is not None:
+      raise ValueError("gradients_info_def and target are "
+                       "mutually exclusive.")
+    if gradients_info_def:
+      self._init_from_proto(gradients_info_def, import_scope=import_scope)
+    else:
+      self._init_from_args(target, grad)
+
+  def _get_tensor_from_proto(self, tensor_info_def, import_scope):
+    """Return a `Tensor`(or `IndexedSlices`) of 'GradientsInfoDef.TensorInfoDef'
+       from current default graph.
+    Args:
+      tensor_info_def: `GradientsInfoDef.TensorInfoDef` protocol buffer.
+      import_scope: Optional `string`. Name scope to add. Only used when
+        initializing from protocol buffer.
+    Returns:
+      `Tensor` or `IndexedSlices`.
+    """
+    g = ops.get_default_graph()
+    tensor_type = tensor_info_def.tensor_type
+    values = g.as_graph_element(
+        ops.prepend_name_scope(tensor_info_def.values_tensor_name,
+                               import_scope))
+    if tensor_type == gradients_info_pb2.GradientsInfoDef.TensorInfoDef.TENSOR:
+      return values
+    else:
+      indices = g.as_graph_element(
+          ops.prepend_name_scope(tensor_info_def.indices_tensor_name,
+                                 import_scope))
+      dense_shape = None
+      if tensor_info_def.dense_shape_tensor_name:
+        dense_shape = g.as_graph_element(
+            ops.prepend_name_scope(tensor_info_def.dense_shape_tensor_name,
+                                   import_scope))
+      assert (tensor_type ==
+              gradients_info_pb2.GradientsInfoDef.TensorInfoDef.INDEXED_SLICES)
+      return ops.IndexedSlices(values=values, indices=indices,
+                               dense_shape=dense_shape)
+
+  def _init_from_proto(self, gradients_info_def, import_scope=None):
+    """Creates a GradientsInfo from 'GradientsInfoDef'.
+    Args:
+      gradients_info_def: Optional `GradientsInfoDef` protocol buffer.
+        If specified, recreates the GradientsInfo from its contents.
+        `gradients_info_def` and the other arguments are mutually exclusive.
+      import_scope: Optional `string`. Name scope to add. Only used when
+        initializing from protocol buffer.
+    """
+    assert isinstance(
+        gradients_info_def, gradients_info_pb2.GradientsInfoDef)
+
+    # Create from gradients_info_def.
+    self._target = self._get_tensor_from_proto(
+        gradients_info_def.target_tensor_info, import_scope)
+    self._grad = self._get_tensor_from_proto(
+        gradients_info_def.grad_tensor_info, import_scope)
+
+  def _init_from_args(self, target, grad):
+    """Create a `GradientsInfo` from arguments.
+    Args:
+      target: Optional tensor which is used for differentiation.
+      grad : Optional gradient tensor of target.
+    """
+    self._target = target
+    self._grad = grad
+
+  def _set_tensor_info_from_tensor(self, tensor_info_def, tensor, export_scope):
+    """Set 'GradientsInfoDef.TensorInfoDef' using `tensor`.
+    Args:
+      tensor_info_def: `GradientsInfoDef.TensorInfoDef` protocol buffer to set.
+      tensor: `Tensor` or `IndexedSlices` to store the information.
+      export_scope: Optional `string`. Name scope to remove.
+    Returns:
+      `Tensor` or `IndexedSlices`.
+    """
+
+    if isinstance(tensor, ops.Tensor):
+      tensor_info_def.tensor_type = \
+          gradients_info_pb2.GradientsInfoDef.TensorInfoDef.TENSOR
+      tensor_info_def.values_tensor_name = \
+          ops.strip_name_scope(tensor.name, export_scope)
+    else:
+      assert isinstance(tensor, ops.IndexedSlices)
+      tensor_info_def.tensor_type = \
+          gradients_info_pb2.GradientsInfoDef.TensorInfoDef.INDEXED_SLICES
+      tensor_info_def.indices_tensor_name = \
+          ops.strip_name_scope(tensor.indices.name, export_scope)
+      tensor_info_def.values_tensor_name = \
+          ops.strip_name_scope(tensor.values.name, export_scope)
+      if tensor.dense_shape != None:
+        tensor_info_def.dense_shape_tensor_name = \
+            ops.strip_name_scope(tensor.dense_shape.name, export_scope)
+
+  def to_proto(self, export_scope=None):
+    """Converts this `GradientsInfo` to a `GradientsInfoDef` protocol buffer.
+    Args:
+      export_scope: Optional `string`. Name scope to remove.
+    Returns:
+      A `GradientsInfoDef` protocol buffer, or `None` if the `Variable` is not
+      in the specified name scope.
+    """
+
+    gradients_info_def = gradients_info_pb2.GradientsInfoDef()
+    target = self._target
+    grad = self._grad
+    if (export_scope is not None and
+        (not target.name.startswith(export_scope) or
+         not grad.name.startswith(export_scope))):
+      return None
+    target_tensor_info_def = gradients_info_def.target_tensor_info
+    self._set_tensor_info_from_tensor(target_tensor_info_def, target,
+                                      export_scope)
+    grad_tensor_info_def = gradients_info_def.grad_tensor_info
+    self._set_tensor_info_from_tensor(grad_tensor_info_def, grad, export_scope)
+    return gradients_info_def
+
+  @staticmethod
+  def from_proto(gradients_info_def, import_scope=None):
+    """Returns a `GradientsInfo` object created from `gradients_info_def`."""
+    return GradientsInfo(gradients_info_def=gradients_info_def,
+                         import_scope=import_scope)
+
+ops.register_proto_function(
+    ops.GraphKeys.GRADIENTS_INFO,
+    proto_type=gradients_info_pb2.GradientsInfoDef,
+    to_proto=GradientsInfo.to_proto,
+    from_proto=GradientsInfo.from_proto)
 
 
 def _IndexedSlicesToTensor(value, dtype=None, name=None, as_ref=False):
@@ -817,7 +963,14 @@ def _GradientsHelper(ys,
 
   if loop_state:
     loop_state.PostProcessing()
-  return [_GetGrad(grads, x) for x in xs]
+
+  res_grads = []
+  for x in xs:
+    grad = _GetGrad(grads, x)
+    gi = GradientsInfo(target=x, grad=grad)
+    ops.add_to_collection(ops.GraphKeys.GRADIENTS_INFO, gi)
+    res_grads.append(grad)
+  return res_grads
 
 
 def _HasAnyNotNoneGrads(grads, op):


### PR DESCRIPTION
This PR improves the correctness of current auto_parallel in grappler.

The problem of current auto_parallel can be summarized as below.
**First, each replica updates a variable independently.** This computation result could be different with a single device, which computes gradients for large batch size and updates a variable once if you use complex optimizers like momentum optimizer.  
**Second, the result of gradient clipping is changed.** In the current version, auto_parallel aggregates the input of variable update operators(e.g., ApplyGradientDescent) so "clipping->aggregation" is the current order if clipping is used. However, “aggregation->clipping” is the right order to make the same result as a single-device job.

This PR changes to aggregate gradients from auto differentiation of trainable variables.
The aggregations are defined explicitly instead of implicit aggregation through update operators. 

**[Current auto_parallel]**
![current_auto_parallel](https://user-images.githubusercontent.com/2465713/40906054-a946024c-681a-11e8-85af-b3d2db7803e5.jpg)

**[auto_parallel in this PR]**
![auto_parallel_after_pr](https://user-images.githubusercontent.com/2465713/40886079-ac008a9c-676c-11e8-9397-bcf7f96513f0.jpg)

**Changes in this PR**
1. Assumptions
Current: variables are updated by optimizer operations
This PR : all the gradients are made by tf.gradients, the gradients of trainable variables are the target of aggregation in synchronous training

2. Correct gradient clipping(e.g. tf.clip_by_global_norm, tf.clip_by_value)
Refer figures above.

3. The number of updates
Current : as many as the number of replicas(refer above)
This PR : one (it can also improve performance on multi-machine environment)