### PR TITLE
kernel register bug fix

### DIFF
--- a/tensorflow/core/framework/op_kernel.cc
+++ b/tensorflow/core/framework/op_kernel.cc
@@ -1000,8 +1000,11 @@ Status FindKernelRegistration(const DeviceType& device_type,
             ProtoShortDebugString(iter->second.def), "'");
       }
       *reg = &iter->second;
+      *was_attr_mismatch = false;
     } else {
-      *was_attr_mismatch = true;
+      if (*reg == nullptr) {
+        *was_attr_mismatch = true;
+      }
     }
   }
   return Status::OK();


### PR DESCRIPTION
If the right kernel found, don't set `was_attr_mismatch` true.