### PR TITLE
Add compression support for FixedLengthRecordDataset

### DIFF
--- a/tensorflow/contrib/distribute/python/input_ops.py
+++ b/tensorflow/contrib/distribute/python/input_ops.py
@@ -29,7 +29,8 @@ from tensorflow.python.platform import tf_logging
 _READER_DATASET_OPS = [
     "TextLineDataset",
     "TFRecordDataset",
-    "FixedLengthRecordDataset"
+    "FixedLengthRecordDataset",
+    "FixedLengthRecordDatasetV2"
 ]
 
 

--- a/tensorflow/core/api_def/base_api/api_def_FixedLengthRecordDatasetV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_FixedLengthRecordDatasetV2.pbtxt
@@ -1,0 +1,3 @@
+op {
+  graph_op_name: "FixedLengthRecordDatasetV2"
+}

--- a/tensorflow/core/kernels/data/reader_dataset_ops.cc
+++ b/tensorflow/core/kernels/data/reader_dataset_ops.cc
@@ -343,11 +343,11 @@ class FixedLengthRecordDatasetOp : public DatasetOpKernel {
     std::unique_ptr<IteratorBase> MakeIteratorInternal(
         const string& prefix) const override {
       if (compression_type_ == "") {
-      return std::unique_ptr<IteratorBase>(
-          new UncompressedIterator({this, strings::StrCat(prefix, "::FixedLengthRecord")}));
+        return std::unique_ptr<IteratorBase>(new UncompressedIterator(
+            {this, strings::StrCat(prefix, "::FixedLengthRecord")}));
       } else {
-      return std::unique_ptr<IteratorBase>(
-          new CompressedIterator({this, strings::StrCat(prefix, "::FixedLengthRecord")}));
+        return std::unique_ptr<IteratorBase>(new CompressedIterator(
+            {this, strings::StrCat(prefix, "::FixedLengthRecord")}));
       }
     }
 

--- a/tensorflow/core/kernels/data/reader_dataset_ops.cc
+++ b/tensorflow/core/kernels/data/reader_dataset_ops.cc
@@ -406,7 +406,7 @@ class FixedLengthRecordDatasetOp : public DatasetOpKernel {
                     dataset()->record_bytes_, &record));
                 // Produce the record as output.
                 Tensor record_tensor(ctx->allocator({}), DT_STRING, {});
-                record_tensor.scalar<string>()() = record;
+                record_tensor.scalar<string>()() = std::move(record);
                 out_tensors->emplace_back(std::move(record_tensor));
                 *end_of_sequence = false;
                 return Status::OK();
@@ -580,7 +580,7 @@ class FixedLengthRecordDatasetOp : public DatasetOpKernel {
       std::unique_ptr<RandomAccessFile> file_
           GUARDED_BY(mu_);  // must outlive buffered_input_stream_
       std::unique_ptr<io::RandomAccessInputStream>
-          file_stream_;  // must outlive buffered_inputstream_
+          file_stream_;  // must outlive buffered_input_stream_
       std::unique_ptr<io::InputStreamInterface> buffered_input_stream_
           GUARDED_BY(mu_);
       int64 file_pos_limit_ GUARDED_BY(mu_) = -1;

--- a/tensorflow/core/ops/dataset_ops.cc
+++ b/tensorflow/core/ops/dataset_ops.cc
@@ -674,6 +674,29 @@ REGISTER_OP("FixedLengthRecordDataset")
       return shape_inference::ScalarShape(c);
     });
 
+REGISTER_OP("FixedLengthRecordDatasetV2")
+    .Input("filenames: string")
+    .Input("header_bytes: int64")
+    .Input("record_bytes: int64")
+    .Input("footer_bytes: int64")
+    .Input("buffer_size: int64")
+    .Input("compression_type: string")
+    .Output("handle: variant")
+    .SetIsStateful()  // TODO(b/65524810): Source dataset ops must be marked
+                      // stateful to inhibit constant folding.
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      shape_inference::ShapeHandle unused;
+      // `filenames` must be a scalar or a vector.
+      TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(0), 1, &unused));
+      // header_bytes, record_bytes, footer_bytes, buffer_size should be
+      // scalars.
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused));
+      return shape_inference::ScalarShape(c);
+    });
+
 REGISTER_OP("TFRecordDataset")
     .Input("filenames: string")
     .Input("compression_type: string")

--- a/tensorflow/python/data/kernel_tests/reader_dataset_ops_test.py
+++ b/tensorflow/python/data/kernel_tests/reader_dataset_ops_test.py
@@ -213,26 +213,43 @@ class FixedLengthRecordReaderTest(test_base.DatasetTestBase):
   def _record(self, f, r):
     return compat.as_bytes(str(f * 2 + r) * self._record_bytes)
 
-  def _createFiles(self):
+  def _createFiles(self, compression_type=None):
     filenames = []
     for i in range(self._num_files):
       fn = os.path.join(self.get_temp_dir(), "fixed_length_record.%d.txt" % i)
       filenames.append(fn)
-      with open(fn, "wb") as f:
-        f.write(b"H" * self._header_bytes)
-        for j in range(self._num_records):
-          f.write(self._record(i, j))
-        f.write(b"F" * self._footer_bytes)
+
+      contents = []
+      contents.append(b"H" * self._header_bytes)
+      for j in range(self._num_records):
+        contents.append(self._record(i, j))
+      contents.append(b"F" * self._footer_bytes)
+      contents = b"".join(contents)
+
+      if not compression_type:
+        with open(fn, "wb") as f:
+          f.write(contents)
+      elif compression_type == "GZIP":
+        with gzip.GzipFile(fn, "wb") as f:
+          f.write(contents)
+      elif compression_type == "ZLIB":
+        contents = zlib.compress(contents)
+        with open(fn, "wb") as f:
+          f.write(contents)
+      else:
+        raise ValueError("Unsupported compression_type", compression_type)
+
     return filenames
 
-  def testFixedLengthRecordDataset(self):
-    test_filenames = self._createFiles()
+  def _testFixedLengthRecordDataset(self, compression_type=None):
+    test_filenames = self._createFiles(compression_type=compression_type)
     filenames = array_ops.placeholder(dtypes.string, shape=[None])
     num_epochs = array_ops.placeholder(dtypes.int64, shape=[])
     batch_size = array_ops.placeholder(dtypes.int64, shape=[])
 
     repeat_dataset = (readers.FixedLengthRecordDataset(
-        filenames, self._record_bytes, self._header_bytes, self._footer_bytes)
+        filenames, self._record_bytes, self._header_bytes, self._footer_bytes,
+        compression_type=compression_type)
                       .repeat(num_epochs))
     batch_dataset = repeat_dataset.batch(batch_size)
 
@@ -292,6 +309,15 @@ class FixedLengthRecordReaderTest(test_base.DatasetTestBase):
               sess.run(get_next))
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
+
+  def testFixedLengthRecordDatasetNoCompression(self):
+    self._testFixedLengthRecordDataset()
+
+  def testFixedLengthRecordDatasetGzipCompression(self):
+    self._testFixedLengthRecordDataset(compression_type="GZIP")
+
+  def testFixedLengthRecordDatasetZlibCompression(self):
+    self._testFixedLengthRecordDataset(compression_type="ZLIB")
 
   def testFixedLengthRecordDatasetBuffering(self):
     test_filenames = self._createFiles()

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -292,7 +292,8 @@ class FixedLengthRecordDataset(dataset_ops.Dataset):
         argument_dtype=dtypes.string)
 
   def _as_variant_tensor(self):
-    if self._compression_type is not None or compat.forward_compatible(2018, 9, 30):
+    if (self._compression_type is not None or
+        compat.forward_compatible(2018, 9, 30)):
       return gen_dataset_ops.fixed_length_record_dataset_v2(
           self._filenames, self._header_bytes, self._record_bytes,
           self._footer_bytes, self._buffer_size, self._compression_type)

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -293,7 +293,7 @@ class FixedLengthRecordDataset(dataset_ops.Dataset):
 
   def _as_variant_tensor(self):
     if (self._compression_type is not None or
-        compat.forward_compatible(2018, 9, 30)):
+        compat.forward_compatible(2018, 11, 30)):
       return gen_dataset_ops.fixed_length_record_dataset_v2(
           self._filenames, self._header_bytes, self._record_bytes,
           self._footer_bytes, self._buffer_size, self._compression_type)

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorflow.python.compat import compat
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.util import convert
 from tensorflow.python.framework import dtypes
@@ -291,9 +292,15 @@ class FixedLengthRecordDataset(dataset_ops.Dataset):
         argument_dtype=dtypes.string)
 
   def _as_variant_tensor(self):
-    return gen_dataset_ops.fixed_length_record_dataset_v2(
-        self._filenames, self._header_bytes, self._record_bytes,
-        self._footer_bytes, self._buffer_size, self._compression_type)
+    if self._compression_type is not None or compat.forward_compatible(2018, 9, 30):
+      return gen_dataset_ops.fixed_length_record_dataset_v2(
+          self._filenames, self._header_bytes, self._record_bytes,
+          self._footer_bytes, self._buffer_size, self._compression_type)
+    else:
+      return gen_dataset_ops.fixed_length_record_dataset(
+          self._filenames, self._header_bytes, self._record_bytes,
+          self._footer_bytes, self._buffer_size)
+
 
   def _inputs(self):
     return []

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -255,7 +255,8 @@ class FixedLengthRecordDataset(dataset_ops.Dataset):
                record_bytes,
                header_bytes=None,
                footer_bytes=None,
-               buffer_size=None):
+               buffer_size=None,
+               compression_type=None):
     """Creates a `FixedLengthRecordDataset`.
 
     Args:
@@ -268,6 +269,8 @@ class FixedLengthRecordDataset(dataset_ops.Dataset):
         bytes to ignore at the end of a file.
       buffer_size: (Optional.) A `tf.int64` scalar representing the number of
         bytes to buffer when reading.
+      compression_type: (Optional.) A `tf.string` scalar evaluating to one of
+        `""` (no compression), `"ZLIB"`, or `"GZIP"`.
     """
     super(FixedLengthRecordDataset, self).__init__()
     self._filenames = ops.convert_to_tensor(
@@ -281,11 +284,16 @@ class FixedLengthRecordDataset(dataset_ops.Dataset):
         "footer_bytes", footer_bytes)
     self._buffer_size = convert.optional_param_to_tensor(
         "buffer_size", buffer_size, _DEFAULT_READER_BUFFER_SIZE_BYTES)
+    self._compression_type = convert.optional_param_to_tensor(
+        "compression_type",
+        compression_type,
+        argument_default="",
+        argument_dtype=dtypes.string)
 
   def _as_variant_tensor(self):
-    return gen_dataset_ops.fixed_length_record_dataset(
+    return gen_dataset_ops.fixed_length_record_dataset_v2(
         self._filenames, self._header_bytes, self._record_bytes,
-        self._footer_bytes, self._buffer_size)
+        self._footer_bytes, self._buffer_size, self._compression_type)
 
   def _inputs(self):
     return []

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -17,7 +17,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'filenames\', \'record_bytes\', \'header_bytes\', \'footer_bytes\', \'buffer_size\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+    argspec: "args=[\'self\', \'filenames\', \'record_bytes\', \'header_bytes\', \'footer_bytes\', \'buffer_size\', \'compression_type\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\'], "
   }
   member_method {
     name: "apply"

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -1173,6 +1173,10 @@ tf_module {
     argspec: "args=[\'dims\', \'value\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "fixed_length_record_dataset_v2"
+    argspec: "args=[\'filenames\', \'header_bytes\', \'record_bytes\', \'footer_bytes\', \'buffer_size\', \'compression_type\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "fixed_size_partitioner"
     argspec: "args=[\'num_shards\', \'axis\'], varargs=None, keywords=None, defaults=[\'0\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -17,7 +17,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'filenames\', \'record_bytes\', \'header_bytes\', \'footer_bytes\', \'buffer_size\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+    argspec: "args=[\'self\', \'filenames\', \'record_bytes\', \'header_bytes\', \'footer_bytes\', \'buffer_size\', \'compression_type\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\'], "
   }
   member_method {
     name: "apply"

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -777,6 +777,10 @@ tf_module {
     argspec: "args=[\'dims\', \'value\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "fixed_length_record_dataset_v2"
+    argspec: "args=[\'filenames\', \'header_bytes\', \'record_bytes\', \'footer_bytes\', \'buffer_size\', \'compression_type\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "fixed_size_partitioner"
     argspec: "args=[\'num_shards\', \'axis\'], varargs=None, keywords=None, defaults=[\'0\'], "
   }


### PR DESCRIPTION
This fix tries to address the issue in #21680 where there were no compression type support for FixedLengthRecordDataset. This fix enables the ability to pass a compression type for FixedLengthRecordDataset.

This fix fixes #21680.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>