### PR TITLE
Replace tf.Variable with tfe.Variable in eager guide

### DIFF
--- a/tensorflow/docs_src/guide/eager.md
+++ b/tensorflow/docs_src/guide/eager.md
@@ -225,7 +225,7 @@ the tape backwards and then discard. A particular `tf.GradientTape` can only
 compute one gradient; subsequent calls throw a runtime error.
 
 ```py
-w = tf.Variable([[1.0]])
+w = tfe.Variable([[1.0]])
 with tf.GradientTape() as tape:
   loss = w * w
 
@@ -260,8 +260,8 @@ def grad(weights, biases):
 train_steps = 200
 learning_rate = 0.01
 # Start with arbitrary values for W and B on the same batch of data
-W = tf.Variable(5.)
-B = tf.Variable(10.)
+W = tfe.Variable(5.)
+B = tfe.Variable(10.)
 
 print("Initial loss: {:.3f}".format(loss(W, B)))
 
@@ -407,11 +407,11 @@ with tf.device("/gpu:0"):
 
 ### Variables and optimizers
 
-`tf.Variable` objects store mutable `tf.Tensor` values accessed during
+`tfe.Variable` objects store mutable `tf.Tensor` values accessed during
 training to make automatic differentiation easier. The parameters of a model can
 be encapsulated in classes as variables.
 
-Better encapsulate model parameters by using `tf.Variable` with
+Better encapsulate model parameters by using `tfe.Variable` with
 `tf.GradientTape`. For example, the automatic differentiation example above
 can be rewritten:
 
@@ -419,8 +419,8 @@ can be rewritten:
 class Model(tf.keras.Model):
   def __init__(self):
     super(Model, self).__init__()
-    self.W = tf.Variable(5., name='weight')
-    self.B = tf.Variable(10., name='bias')
+    self.W = tfe.Variable(5., name='weight')
+    self.B = tfe.Variable(10., name='bias')
   def call(self, inputs):
     return inputs * self.W + self.B
 
@@ -447,7 +447,8 @@ def grad(model, inputs, targets):
 model = Model()
 optimizer = tf.train.GradientDescentOptimizer(learning_rate=0.01)
 
-print("Initial loss: {:.3f}".format(loss(model, training_inputs, training_outputs)))
+print("Initial loss: {:.3f}".format(loss(model, training_inputs, 
+                                         training_outputs)))
 
 # Training loop
 for i in range(300):
@@ -455,9 +456,11 @@ for i in range(300):
   optimizer.apply_gradients(zip(grads, [model.W, model.B]),
                             global_step=tf.train.get_or_create_global_step())
   if i % 20 == 0:
-    print("Loss at step {:03d}: {:.3f}".format(i, loss(model, training_inputs, training_outputs)))
+    print("Loss at step {:03d}: {:.3f}".format(i, loss(model, training_inputs,
+                                                       training_outputs)))
 
-print("Final loss: {:.3f}".format(loss(model, training_inputs, training_outputs)))
+print("Final loss: {:.3f}".format(loss(model, training_inputs,
+                                       training_outputs)))
 print("W = {}, B = {}".format(model.W.numpy(), model.B.numpy()))
 ```
 
@@ -498,17 +501,17 @@ is removed, and is then deleted.
 
 ```py
 with tf.device("gpu:0"):
-  v = tf.Variable(tf.random_normal([1000, 1000]))
+  v = tfe.Variable(tf.random_normal([1000, 1000]))
   v = None  # v no longer takes up GPU memory
 ```
 
 ### Object-based saving
 
-`tf.train.Checkpoint` can save and restore `tf.Variable`s to and from
+`tf.train.Checkpoint` can save and restore `tfe.Variable`s to and from
 checkpoints:
 
 ```py
-x = tf.Variable(10.)
+x = tfe.Variable(10.)
 
 checkpoint = tf.train.Checkpoint(x=x)  # save as "x"
 
@@ -611,7 +614,7 @@ def line_search_step(fn, init_x, rate=1.0):
 `tf.GradientTape` is a powerful interface for computing gradients, but there
 is another [Autograd](https://github.com/HIPS/autograd)-style API available for
 automatic differentiation. These functions are useful if writing math code with
-only tensors and gradient functions, and without `tf.Variables`:
+only tensors and gradient functions, and without `tfe.Variables`:
 
 * `tfe.gradients_function` —Returns a function that computes the derivatives
   of its input function parameter with respect to its arguments. The input


### PR DESCRIPTION
The current code produces this error:
`RuntimeError: tf.Variable not supported when eager execution is enabled. Please use tf.contrib.eager.Variable instead`

`tf.contrib.eager` is defined as `tfe` early here, so this replaces `tf.Variable` with `tfe.Variable`. Here's a [colab notebook](https://colab.research.google.com/drive/1tC8ykDqzcWhVLfMnCXk9i9XOvoNwX5Xg) showing that it works (a lot of it doesn't work since the code isn't fully reproducible).

This also fixes a couple of >80char lines.