### PR TITLE
Add `ENV LANG C.UTF-8` to dockerfiles for Python

### DIFF
--- a/tensorflow/tools/dockerfiles/dockerfiles/cpu-devel-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/cpu-devel-jupyter.Dockerfile
@@ -65,6 +65,9 @@ ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
 ARG PIP=pip${_PY_SUFFIX}
 
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y \
     ${PYTHON} \
     ${PYTHON}-pip

--- a/tensorflow/tools/dockerfiles/dockerfiles/cpu-devel.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/cpu-devel.Dockerfile
@@ -63,6 +63,9 @@ ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
 ARG PIP=pip${_PY_SUFFIX}
 
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y \
     ${PYTHON} \
     ${PYTHON}-pip

--- a/tensorflow/tools/dockerfiles/dockerfiles/cpu-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/cpu-jupyter.Dockerfile
@@ -45,6 +45,9 @@ ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
 ARG PIP=pip${_PY_SUFFIX}
 
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y \
     ${PYTHON} \
     ${PYTHON}-pip

--- a/tensorflow/tools/dockerfiles/dockerfiles/cpu.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/cpu.Dockerfile
@@ -43,6 +43,9 @@ ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
 ARG PIP=pip${_PY_SUFFIX}
 
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y \
     ${PYTHON} \
     ${PYTHON}-pip

--- a/tensorflow/tools/dockerfiles/dockerfiles/nvidia-devel-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/nvidia-devel-jupyter.Dockerfile
@@ -85,6 +85,9 @@ ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
 ARG PIP=pip${_PY_SUFFIX}
 
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y \
     ${PYTHON} \
     ${PYTHON}-pip

--- a/tensorflow/tools/dockerfiles/dockerfiles/nvidia-devel.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/nvidia-devel.Dockerfile
@@ -83,6 +83,9 @@ ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
 ARG PIP=pip${_PY_SUFFIX}
 
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y \
     ${PYTHON} \
     ${PYTHON}-pip

--- a/tensorflow/tools/dockerfiles/dockerfiles/nvidia-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/nvidia-jupyter.Dockerfile
@@ -66,6 +66,9 @@ ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
 ARG PIP=pip${_PY_SUFFIX}
 
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y \
     ${PYTHON} \
     ${PYTHON}-pip

--- a/tensorflow/tools/dockerfiles/dockerfiles/nvidia.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/nvidia.Dockerfile
@@ -64,6 +64,9 @@ ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
 ARG PIP=pip${_PY_SUFFIX}
 
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y \
     ${PYTHON} \
     ${PYTHON}-pip

--- a/tensorflow/tools/dockerfiles/partials/python.partial.Dockerfile
+++ b/tensorflow/tools/dockerfiles/partials/python.partial.Dockerfile
@@ -3,6 +3,9 @@ ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
 ARG PIP=pip${_PY_SUFFIX}
 
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y \
     ${PYTHON} \
     ${PYTHON}-pip


### PR DESCRIPTION
This fix tries to address the issue raised in #20380 where `LANG` env was not set in Docker images, and was causing issues with python 3 (see related bug https://bugs.python.org/issue19846).

This fix adds `ENV LANG C.UTF-8` to Dockerfiles which matches the official python images.

This fix fixes #20380.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>