### PR TITLE
Disable GPU test for scatter_add_ndim_op_test

### DIFF
--- a/tensorflow/contrib/tensor_forest/BUILD
+++ b/tensorflow/contrib/tensor_forest/BUILD
@@ -462,7 +462,10 @@ py_test(
     size = "small",
     srcs = ["python/kernel_tests/scatter_add_ndim_op_test.py"],
     srcs_version = "PY2AND3",
-    tags = ["no_pip_gpu"],
+    tags = [
+        "no_pip_gpu",
+        "no_gpu",
+    ],
     deps = [
         ":tensor_forest_ops_py",
         "//tensorflow/python:framework_test_lib",


### PR DESCRIPTION
As scatter_add_ndim doesn't have implementation for GPU, the
test needs to be excluded from GPU test to prevent it from failing.
Currently fails on both x86_64 and ppc64le.
Fixes #21833