### PR TITLE
Fix batch normalization in canned DNN Estimators

### DIFF
--- a/tensorflow/python/estimator/canned/dnn.py
+++ b/tensorflow/python/estimator/canned/dnn.py
@@ -104,7 +104,7 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
               units=num_hidden_units,
               activation=None,
               kernel_initializer=init_ops.glorot_uniform_initializer(),
-              name=hidden_layer_scope + "_input")
+              name='hiddenlayer_%d_input' % layer_id)
           net = normalization.batch_normalization(
               net,
               # The default momentum 0.99 actually crashes on certain

--- a/tensorflow/python/estimator/canned/dnn.py
+++ b/tensorflow/python/estimator/canned/dnn.py
@@ -104,7 +104,7 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
               units=num_hidden_units,
               activation=None,
               kernel_initializer=init_ops.glorot_uniform_initializer(),
-              name='hiddenlayer_%d_input' % layer_id)
+              name=hidden_layer_scope)
           net = normalization.batch_normalization(
               net,
               # The default momentum 0.99 actually crashes on certain
@@ -114,7 +114,7 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
               training=is_training,
               name='batchnorm_%d' % layer_id)
           if activation_fn is not None:
-            net = activation_fn(net, name=hidden_layer_scope)
+            net = activation_fn(net, name='hiddenlayer_%d_output' % layer_id)
         else:
           net = core_layers.dense(
               net,

--- a/tensorflow/python/estimator/canned/dnn.py
+++ b/tensorflow/python/estimator/canned/dnn.py
@@ -42,7 +42,7 @@ _LEARNING_RATE = 0.05
 
 
 _BatchNormOptions = collections.namedtuple(
-    'BatchNormOptions', ['apply_before_activation', 'momentum']))
+    'BatchNormOptions', ['apply_before_activation', 'momentum'])
 
 
 def experimental_batch_norm_options(

--- a/tensorflow/python/estimator/canned/dnn.py
+++ b/tensorflow/python/estimator/canned/dnn.py
@@ -82,8 +82,9 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
       coordinate.
     input_layer_partitioner: Partitioner for input layer.
     batch_norm: A boolean indicating whether to to use batch normalization
-      after each hidden layer with default options, or a `_BatchNormOptions`
-      object that configures batch normalization after each hidden layer.
+      after each hidden layer with default options, or an
+      experimental_batch_norm_options object that configures batch
+      normalization after each hidden layer.
 
   Returns:
     A logit_fn (see below).
@@ -205,8 +206,9 @@ def _dnn_model_fn(features,
     tpu_estimator_spec: Whether to return a `_TPUEstimatorSpec` or
       or `model_fn.EstimatorSpec` instance.
     batch_norm: A boolean indicating whether to to use batch normalization
-      after each hidden layer with default options, or a `_BatchNormOptions`
-      object that configures batch normalization after each hidden layer.
+      after each hidden layer with default options, or an
+      experimental_batch_norm_options object that configures batch
+      normalization after each hidden layer.
 
   Returns:
     An `EstimatorSpec` instance.
@@ -405,8 +407,9 @@ class DNNClassifier(estimator.Estimator):
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
       batch_norm: A boolean indicating whether to to use batch normalization
-        after each hidden layer with default options, or a `_BatchNormOptions`
-        object that configures batch normalization after each hidden layer.
+        after each hidden layer with default options, or an
+        experimental_batch_norm_options object that configures batch
+        normalization after each hidden layer.
     """
     head = head_lib._binary_logistic_or_multi_class_head(  # pylint: disable=protected-access
         n_classes, weight_column, label_vocabulary, loss_reduction)
@@ -570,8 +573,9 @@ class DNNRegressor(estimator.Estimator):
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
       batch_norm: A boolean indicating whether to to use batch normalization
-        after each hidden layer with default options, or a `_BatchNormOptions`
-        object that configures batch normalization after each hidden layer.
+        after each hidden layer with default options, or an
+        experimental_batch_norm_options object that configures batch
+        normalization after each hidden layer.
     """
 
     def _model_fn(features, labels, mode, config):

--- a/tensorflow/python/estimator/canned/dnn.py
+++ b/tensorflow/python/estimator/canned/dnn.py
@@ -123,14 +123,14 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
               units=num_hidden_units,
               activation=None,
               kernel_initializer=init_ops.glorot_uniform_initializer(),
-              name=hidden_layer_scope + "_input")
+              name=hidden_layer_scope)
           net = normalization.batch_normalization(
               net,
               momentum=batch_norm.momentum,
               training=is_training,
               name='batchnorm_%d' % layer_id)
           if activation_fn is not None:
-            net = activation_fn(net, name=hidden_layer_scope)
+            net = activation_fn(net, name='hiddenlayer_%d_output' % layer_id)
         else:
           net = core_layers.dense(
               net,

--- a/tensorflow/python/estimator/canned/dnn.py
+++ b/tensorflow/python/estimator/canned/dnn.py
@@ -58,7 +58,8 @@ def experimental_batch_norm_options(
       problems, so here we use 0.999, which is the default of
       tf.contrib.layers.batch_norm.
   """
-  return _BatchNormOptions(apply_before_activation=apply_before_activation, momentum=momentum)
+  return _BatchNormOptions(
+      apply_before_activation=apply_before_activation, momentum=momentum)
 
 
 def _add_hidden_layer_summary(value, tag):
@@ -80,8 +81,9 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
     dropout: When not `None`, the probability we will drop out a given
       coordinate.
     input_layer_partitioner: Partitioner for input layer.
-    batch_norm: When not `None`, a `_BatchNormOptions` object that
-      configures batch normalization after each hidden layer.
+    batch_norm: A boolean indicating whether to to use batch normalization
+      after each hidden layer with default options, or a `_BatchNormOptions`
+      object that configures batch normalization after each hidden layer.
 
   Returns:
     A logit_fn (see below).
@@ -92,6 +94,11 @@ def _dnn_logit_fn_builder(units, hidden_units, feature_columns, activation_fn,
   if not isinstance(units, int):
     raise ValueError('units must be an int.  Given type: {}'.format(
         type(units)))
+
+  if isinstance(batch_norm, bool) and batch_norm:
+    batch_norm = experimental_batch_norm_options()
+  elif isinstance(batch_norm, bool):
+    batch_norm = None
 
   def dnn_logit_fn(features, mode):
     """Deep Neural Network logit_fn.
@@ -174,7 +181,7 @@ def _dnn_model_fn(features,
                   input_layer_partitioner=None,
                   config=None,
                   tpu_estimator_spec=False,
-                  batch_norm=None):
+                  batch_norm=False):
   """Deep Neural Net model_fn.
 
   Args:
@@ -197,8 +204,9 @@ def _dnn_model_fn(features,
     config: `RunConfig` object to configure the runtime settings.
     tpu_estimator_spec: Whether to return a `_TPUEstimatorSpec` or
       or `model_fn.EstimatorSpec` instance.
-    batch_norm: When not `None`, a `_BatchNormOptions` object that
-      configures batch normalization after each hidden layer.
+    batch_norm: A boolean indicating whether to to use batch normalization
+      after each hidden layer with default options, or a `_BatchNormOptions`
+      object that configures batch normalization after each hidden layer.
 
   Returns:
     An `EstimatorSpec` instance.
@@ -349,7 +357,7 @@ class DNNClassifier(estimator.Estimator):
       config=None,
       warm_start_from=None,
       loss_reduction=losses.Reduction.SUM,
-      batch_norm=None,
+      batch_norm=False,
   ):
     """Initializes a `DNNClassifier` instance.
 
@@ -396,8 +404,9 @@ class DNNClassifier(estimator.Estimator):
         names are unchanged.
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
-      batch_norm: When not `None`, a `_BatchNormOptions` object that
-        configures batch normalization after each hidden layer.
+      batch_norm: A boolean indicating whether to to use batch normalization
+        after each hidden layer with default options, or a `_BatchNormOptions`
+        object that configures batch normalization after each hidden layer.
     """
     head = head_lib._binary_logistic_or_multi_class_head(  # pylint: disable=protected-access
         n_classes, weight_column, label_vocabulary, loss_reduction)
@@ -519,7 +528,7 @@ class DNNRegressor(estimator.Estimator):
       config=None,
       warm_start_from=None,
       loss_reduction=losses.Reduction.SUM,
-      batch_norm=None,
+      batch_norm=False,
   ):
     """Initializes a `DNNRegressor` instance.
 
@@ -560,8 +569,9 @@ class DNNRegressor(estimator.Estimator):
         names are unchanged.
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
-      batch_norm: When not `None`, a `_BatchNormOptions` object that
-        configures batch normalization after each hidden layer.
+      batch_norm: A boolean indicating whether to to use batch normalization
+        after each hidden layer with default options, or a `_BatchNormOptions`
+        object that configures batch normalization after each hidden layer.
     """
 
     def _model_fn(features, labels, mode, config):

--- a/tensorflow/python/estimator/canned/dnn_linear_combined.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined.py
@@ -118,8 +118,9 @@ def _dnn_linear_combined_model_fn(features,
     input_layer_partitioner: Partitioner for input layer.
     config: `RunConfig` object to configure the runtime settings.
     batch_norm: A boolean indicating whether to to use batch normalization
-      after each hidden layer with default options, or a `_BatchNormOptions`
-      object that configures batch normalization after each hidden layer.
+      after each hidden layer with default options, or an
+      experimental_batch_norm_options object that configures batch
+      normalization after each hidden layer.
     linear_sparse_combiner: A string specifying how to reduce the linear model
       if a categorical column is multivalent.  One of "mean", "sqrtn", and
       "sum".
@@ -386,8 +387,9 @@ class DNNLinearCombinedClassifier(estimator.Estimator):
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
       batch_norm: A boolean indicating whether to to use batch normalization
-        after each hidden layer with default options, or a `_BatchNormOptions`
-        object that configures batch normalization after each hidden layer.
+        after each hidden layer with default options, or an
+        experimental_batch_norm_options object that configures batch
+        normalization after each hidden layer.
       linear_sparse_combiner: A string specifying how to reduce the linear model
         if a categorical column is multivalent.  One of "mean", "sqrtn", and
         "sum" -- these are effectively different ways to do example-level
@@ -586,8 +588,9 @@ class DNNLinearCombinedRegressor(estimator.Estimator):
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
       batch_norm: A boolean indicating whether to to use batch normalization
-        after each hidden layer with default options, or a `_BatchNormOptions`
-        object that configures batch normalization after each hidden layer.
+        after each hidden layer with default options, or an
+        experimental_batch_norm_options object that configures batch
+        normalization after each hidden layer.
       linear_sparse_combiner: A string specifying how to reduce the linear model
         if a categorical column is multivalent.  One of "mean", "sqrtn", and
         "sum" -- these are effectively different ways to do example-level

--- a/tensorflow/python/estimator/canned/dnn_linear_combined.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined.py
@@ -89,7 +89,7 @@ def _dnn_linear_combined_model_fn(features,
                                   dnn_dropout=None,
                                   input_layer_partitioner=None,
                                   config=None,
-                                  batch_norm=None,
+                                  batch_norm=False,
                                   linear_sparse_combiner='sum'):
   """Deep Neural Net and Linear combined model_fn.
 
@@ -117,8 +117,9 @@ def _dnn_linear_combined_model_fn(features,
       coordinate.
     input_layer_partitioner: Partitioner for input layer.
     config: `RunConfig` object to configure the runtime settings.
-    batch_norm: When not `None`, a `_BatchNormOptions` object that
-      configures batch normalization after each hidden layer.
+    batch_norm: A boolean indicating whether to to use batch normalization
+      after each hidden layer with default options, or a `_BatchNormOptions`
+      object that configures batch normalization after each hidden layer.
     linear_sparse_combiner: A string specifying how to reduce the linear model
       if a categorical column is multivalent.  One of "mean", "sqrtn", and
       "sum".
@@ -330,7 +331,7 @@ class DNNLinearCombinedClassifier(estimator.Estimator):
                config=None,
                warm_start_from=None,
                loss_reduction=losses.Reduction.SUM,
-               batch_norm=None,
+               batch_norm=False,
                linear_sparse_combiner='sum'):
     """Initializes a DNNLinearCombinedClassifier instance.
 
@@ -384,8 +385,9 @@ class DNNLinearCombinedClassifier(estimator.Estimator):
         names are unchanged.
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
-      batch_norm: When not `None`, a `_BatchNormOptions` object that
-        configures batch normalization after each hidden layer.
+      batch_norm: A boolean indicating whether to to use batch normalization
+        after each hidden layer with default options, or a `_BatchNormOptions`
+        object that configures batch normalization after each hidden layer.
       linear_sparse_combiner: A string specifying how to reduce the linear model
         if a categorical column is multivalent.  One of "mean", "sqrtn", and
         "sum" -- these are effectively different ways to do example-level
@@ -535,7 +537,7 @@ class DNNLinearCombinedRegressor(estimator.Estimator):
                config=None,
                warm_start_from=None,
                loss_reduction=losses.Reduction.SUM,
-               batch_norm=None,
+               batch_norm=False,
                linear_sparse_combiner='sum'):
     """Initializes a DNNLinearCombinedRegressor instance.
 
@@ -583,8 +585,9 @@ class DNNLinearCombinedRegressor(estimator.Estimator):
         names are unchanged.
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
-      batch_norm: When not `None`, a `_BatchNormOptions` object that
-        configures batch normalization after each hidden layer.
+      batch_norm: A boolean indicating whether to to use batch normalization
+        after each hidden layer with default options, or a `_BatchNormOptions`
+        object that configures batch normalization after each hidden layer.
       linear_sparse_combiner: A string specifying how to reduce the linear model
         if a categorical column is multivalent.  One of "mean", "sqrtn", and
         "sum" -- these are effectively different ways to do example-level

--- a/tensorflow/python/estimator/canned/dnn_linear_combined.py
+++ b/tensorflow/python/estimator/canned/dnn_linear_combined.py
@@ -89,7 +89,7 @@ def _dnn_linear_combined_model_fn(features,
                                   dnn_dropout=None,
                                   input_layer_partitioner=None,
                                   config=None,
-                                  batch_norm=False,
+                                  batch_norm=None,
                                   linear_sparse_combiner='sum'):
   """Deep Neural Net and Linear combined model_fn.
 
@@ -117,7 +117,8 @@ def _dnn_linear_combined_model_fn(features,
       coordinate.
     input_layer_partitioner: Partitioner for input layer.
     config: `RunConfig` object to configure the runtime settings.
-    batch_norm: Whether to use batch normalization after each hidden layer.
+    batch_norm: When not `None`, a `_BatchNormOptions` object that
+      configures batch normalization after each hidden layer.
     linear_sparse_combiner: A string specifying how to reduce the linear model
       if a categorical column is multivalent.  One of "mean", "sqrtn", and
       "sum".
@@ -329,7 +330,7 @@ class DNNLinearCombinedClassifier(estimator.Estimator):
                config=None,
                warm_start_from=None,
                loss_reduction=losses.Reduction.SUM,
-               batch_norm=False,
+               batch_norm=None,
                linear_sparse_combiner='sum'):
     """Initializes a DNNLinearCombinedClassifier instance.
 
@@ -383,7 +384,8 @@ class DNNLinearCombinedClassifier(estimator.Estimator):
         names are unchanged.
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
-      batch_norm: Whether to use batch normalization after each hidden layer.
+      batch_norm: When not `None`, a `_BatchNormOptions` object that
+        configures batch normalization after each hidden layer.
       linear_sparse_combiner: A string specifying how to reduce the linear model
         if a categorical column is multivalent.  One of "mean", "sqrtn", and
         "sum" -- these are effectively different ways to do example-level
@@ -533,7 +535,7 @@ class DNNLinearCombinedRegressor(estimator.Estimator):
                config=None,
                warm_start_from=None,
                loss_reduction=losses.Reduction.SUM,
-               batch_norm=False,
+               batch_norm=None,
                linear_sparse_combiner='sum'):
     """Initializes a DNNLinearCombinedRegressor instance.
 
@@ -581,7 +583,8 @@ class DNNLinearCombinedRegressor(estimator.Estimator):
         names are unchanged.
       loss_reduction: One of `tf.losses.Reduction` except `NONE`. Describes how
         to reduce training loss over batch. Defaults to `SUM`.
-      batch_norm: Whether to use batch normalization after each hidden layer.
+      batch_norm: When not `None`, a `_BatchNormOptions` object that
+        configures batch normalization after each hidden layer.
       linear_sparse_combiner: A string specifying how to reduce the linear model
         if a categorical column is multivalent.  One of "mean", "sqrtn", and
         "sum" -- these are effectively different ways to do example-level

--- a/tensorflow/python/estimator/canned/dnn_testing_utils.py
+++ b/tensorflow/python/estimator/canned/dnn_testing_utils.py
@@ -591,13 +591,12 @@ class BaseDNNLogitFnTest(object):
       x11 = (7-(-2))/sqrt(81+0.001) = 0.99999383
       x21 = (-11-(-2))/sqrt(81+0.001) = -0.99999383
 
-    hidden_layer_0 = [[relu(0.99999383), relu(-0.99999383)]] = [[0.99999383, 0]]
-
       mean2 = 1/2*(4+(-11)) = -3.5,
       variance2 = 1/2*(7.5^2+7.5^2) = 56.25
       x12 = (4-(-3.5))/sqrt(56.25+0.001) = 0.99999111,
       x22 = (-11-(-3.5))/sqrt(56.25+0.001) = -0.99999111,
 
+    hidden_layer_0 = [[relu(0.99999383), relu(-0.99999383)]] = [[0.99999383, 0]]
     hidden_layer_0 = [[relu(0.99999111), relu(-0.99999111)]] = [[0.99999111, 0]]
 
     logits = [[-1*0.99999383 + 2*0.99999111 + 0.3],
@@ -606,15 +605,15 @@ class BaseDNNLogitFnTest(object):
 
     batch_norm_0, not training (epsilon = 0.001):
       moving_mean1 = 0, moving_variance1 = 1
-      x11 = (0.99999383-0)/sqrt(1+0.001) = 0.99949420777,
-      x21 = (0.99999111-0)/sqrt(1+0.001) = 0.99949148913,
+      x11 = (0.99999383-0)/sqrt(1+0.001) = 0.999494208,
+      x21 = (0.99999111-0)/sqrt(1+0.001) = 0.999491489,
       moving_mean2 = 0, moving_variance2 = 1
       x12 = (0-0)/sqrt(1+0.001) = 0,
       x22 = (0-0)/sqrt(1+0.001) = 0,
 
-    logits = [[-1*6.996502623 + 2*3.998001499 + 0.3],
+    logits = [[-1*0.999494208 + 2*0.999491489 + 0.3],
               [-1*(0) + 2*(0) + 0.3]]
-           = [[1.299500375],[0.3]]
+           = [[1.2995],[0.3]]
     """
     base_global_step = 100
     create_checkpoint(
@@ -634,7 +633,7 @@ class BaseDNNLogitFnTest(object):
         hidden_units=[2],
         logits_dimension=1,
         inputs=[[10.], [-20.]],
-        expected_logits=[[1.29998839], [-0.69998839]],
+        expected_logits=[[1.29998839], [0.3]],
         batch_norm=True)
     for mode in [model_fn.ModeKeys.EVAL, model_fn.ModeKeys.PREDICT]:
       self._test_logits(
@@ -642,7 +641,7 @@ class BaseDNNLogitFnTest(object):
           hidden_units=[2],
           logits_dimension=1,
           inputs=[[10.], [-20.]],
-          expected_logits=[[1.299500375], [-10.694504121]],
+          expected_logits=[[1.2995], [0.3]],
           batch_norm=True)
 
   def test_multi_dim_logits(self):

--- a/tensorflow/python/estimator/canned/dnn_testing_utils.py
+++ b/tensorflow/python/estimator/canned/dnn_testing_utils.py
@@ -32,6 +32,7 @@ from tensorflow.python.estimator import model_fn
 from tensorflow.python.estimator.canned import head as head_lib
 from tensorflow.python.estimator.canned import metric_keys
 from tensorflow.python.estimator.canned import prediction_keys
+from tensorflow.python.estimator.canned.dnn import experimental_batch_norm_options
 from tensorflow.python.estimator.inputs import numpy_io
 from tensorflow.python.feature_column import feature_column
 from tensorflow.python.framework import constant_op
@@ -525,7 +526,7 @@ class BaseDNNLogitFnTest(object):
                    logits_dimension,
                    inputs,
                    expected_logits,
-                   batch_norm=False):
+                   batch_norm=None):
     """Tests that the expected logits are calculated."""
     with ops.Graph().as_default():
       # Global step needed for MonitoredSession, which is in turn used to
@@ -631,7 +632,7 @@ class BaseDNNLogitFnTest(object):
         logits_dimension=1,
         inputs=[[10.], [20.]],
         expected_logits=[[-0.699895571], [1.299895571]],
-        batch_norm=True)
+        batch_norm=experimental_batch_norm_options())
     for mode in [model_fn.ModeKeys.EVAL, model_fn.ModeKeys.PREDICT]:
       self._test_logits(
           mode,
@@ -639,7 +640,7 @@ class BaseDNNLogitFnTest(object):
           logits_dimension=1,
           inputs=[[10.], [20.]],
           expected_logits=[[1.299500375], [5.297501873]],
-          batch_norm=True)
+          batch_norm=experimental_batch_norm_options())
 
   def test_multi_dim_logits(self):
     """Tests multi-dimensional logits.
@@ -792,7 +793,7 @@ class BaseDNNLogitFnTest(object):
               activation_fn=nn.relu,
               dropout=None,
               input_layer_partitioner=input_layer_partitioner,
-              batch_norm=False)
+              batch_norm=None)
           logits = logit_fn(
               features={
                   'age': constant_op.constant(inputs[0]),

--- a/tensorflow/python/estimator/canned/dnn_testing_utils.py
+++ b/tensorflow/python/estimator/canned/dnn_testing_utils.py
@@ -581,39 +581,36 @@ class BaseDNNLogitFnTest(object):
   def test_one_dim_logits_with_batch_norm(self):
     """Tests one-dimensional logits.
 
-    input_layer = [[10], [-20]]
-    hidden_layer_0_input = [[0.6*10 +1, 0.5*10 -1]] = [[7, 4]]
-    hidden_layer_0_input = [[0.6*(-20) +1, 0.5*(-20) -1]] = [[-11, -11]]
+    input_layer = [[10]]
+    hidden_layer_0 = [[relu(0.6*10 +1), relu(0.5*10 -1)]] = [[7, 4]]
+    hidden_layer_0 = [[relu(0.6*20 +1), relu(0.5*20 -1)]] = [[13, 9]]
 
     batch_norm_0, training (epsilon = 0.001):
-      mean1 = 1/2*(7+(-11)) = -2,
-      variance1 = 1/2*(9^2+9^2) = 81
-      x11 = (7-(-2))/sqrt(81+0.001) = 0.99999383
-      x21 = (-11-(-2))/sqrt(81+0.001) = -0.99999383
+      mean1 = 1/2*(7+13) = 10,
+      variance1 = 1/2*(3^2+3^2) = 9
+      x11 = (7-10)/sqrt(9+0.001) = -0.999944449,
+      x21 = (13-10)/sqrt(9+0.001) = 0.999944449,
 
-      mean2 = 1/2*(4+(-11)) = -3.5,
-      variance2 = 1/2*(7.5^2+7.5^2) = 56.25
-      x12 = (4-(-3.5))/sqrt(56.25+0.001) = 0.99999111,
-      x22 = (-11-(-3.5))/sqrt(56.25+0.001) = -0.99999111,
+      mean2 = 1/2*(4+9) = 6.5,
+      variance2 = 1/2*(2.5^2+.2.5^2) = 6.25
+      x12 = (4-6.5)/sqrt(6.25+0.001) = -0.99992001,
+      x22 = (9-6.5)/sqrt(6.25+0.001) = 0.99992001,
 
-    hidden_layer_0 = [[relu(0.99999383), relu(-0.99999383)]] = [[0.99999383, 0]]
-    hidden_layer_0 = [[relu(0.99999111), relu(-0.99999111)]] = [[0.99999111, 0]]
-
-    logits = [[-1*0.99999383 + 2*0.99999111 + 0.3],
-              [-1*(0) + 2*(0) + 0.3]]
-           = [[1.29998839],[0.3]]
+    logits = [[-1*(-0.999944449) + 2*(-0.99992001) + 0.3],
+              [-1*0.999944449 + 2*0.99992001 + 0.3]]
+           = [[-0.699895571],[1.299895571]]
 
     batch_norm_0, not training (epsilon = 0.001):
       moving_mean1 = 0, moving_variance1 = 1
-      x11 = (0.99999383-0)/sqrt(1+0.001) = 0.999494208,
-      x21 = (0.99999111-0)/sqrt(1+0.001) = 0.999491489,
+      x11 = (7-0)/sqrt(1+0.001) = 6.996502623,
+      x21 = (13-0)/sqrt(1+0.001) = 12.993504871,
       moving_mean2 = 0, moving_variance2 = 1
-      x12 = (0-0)/sqrt(1+0.001) = 0,
-      x22 = (0-0)/sqrt(1+0.001) = 0,
+      x12 = (4-0)/sqrt(1+0.001) = 3.998001499,
+      x22 = (9-0)/sqrt(1+0.001) = 8.995503372,
 
-    logits = [[-1*0.999494208 + 2*0.999491489 + 0.3],
-              [-1*(0) + 2*(0) + 0.3]]
-           = [[1.2995],[0.3]]
+    logits = [[-1*6.996502623 + 2*3.998001499 + 0.3],
+              [-1*12.993504871 + 2*8.995503372 + 0.3]]
+           = [[1.299500375],[5.297501873]]
     """
     base_global_step = 100
     create_checkpoint(
@@ -632,16 +629,16 @@ class BaseDNNLogitFnTest(object):
         model_fn.ModeKeys.TRAIN,
         hidden_units=[2],
         logits_dimension=1,
-        inputs=[[10.], [-20.]],
-        expected_logits=[[1.29998839], [0.3]],
+        inputs=[[10.], [20.]],
+        expected_logits=[[-0.699895571], [1.299895571]],
         batch_norm=True)
     for mode in [model_fn.ModeKeys.EVAL, model_fn.ModeKeys.PREDICT]:
       self._test_logits(
           mode,
           hidden_units=[2],
           logits_dimension=1,
-          inputs=[[10.], [-20.]],
-          expected_logits=[[1.2995], [0.3]],
+          inputs=[[10.], [20.]],
+          expected_logits=[[1.299500375], [5.297501873]],
           batch_norm=True)
 
   def test_multi_dim_logits(self):

--- a/tensorflow/python/estimator/canned/dnn_testing_utils.py
+++ b/tensorflow/python/estimator/canned/dnn_testing_utils.py
@@ -526,7 +526,7 @@ class BaseDNNLogitFnTest(object):
                    logits_dimension,
                    inputs,
                    expected_logits,
-                   batch_norm=None):
+                   batch_norm=False):
     """Tests that the expected logits are calculated."""
     with ops.Graph().as_default():
       # Global step needed for MonitoredSession, which is in turn used to
@@ -859,7 +859,7 @@ class BaseDNNLogitFnTest(object):
               activation_fn=nn.relu,
               dropout=None,
               input_layer_partitioner=input_layer_partitioner,
-              batch_norm=None)
+              batch_norm=False)
           logits = logit_fn(
               features={
                   'age': constant_op.constant(inputs[0]),

--- a/tensorflow/python/estimator/canned/dnn_testing_utils.py
+++ b/tensorflow/python/estimator/canned/dnn_testing_utils.py
@@ -632,7 +632,7 @@ class BaseDNNLogitFnTest(object):
         logits_dimension=1,
         inputs=[[10.], [20.]],
         expected_logits=[[-0.699895571], [1.299895571]],
-        batch_norm=experimental_batch_norm_options())
+        batch_norm=True)
     for mode in [model_fn.ModeKeys.EVAL, model_fn.ModeKeys.PREDICT]:
       self._test_logits(
           mode,
@@ -640,7 +640,7 @@ class BaseDNNLogitFnTest(object):
           logits_dimension=1,
           inputs=[[10.], [20.]],
           expected_logits=[[1.299500375], [5.297501873]],
-          batch_norm=experimental_batch_norm_options())
+          batch_norm=True)
 
   def test_one_dim_logits_with_batch_norm_before_activation(self):
     """Tests one-dimensional logits with batch norm before activation.

--- a/tensorflow/python/estimator/canned/dnn_testing_utils.py
+++ b/tensorflow/python/estimator/canned/dnn_testing_utils.py
@@ -698,7 +698,7 @@ class BaseDNNLogitFnTest(object):
         logits_dimension=1,
         inputs=[[10.], [-20.]],
         expected_logits=[[1.29998839], [0.3]],
-        batch_norm=True)
+        batch_norm=experimental_batch_norm_options(apply_before_activation=True))
     for mode in [model_fn.ModeKeys.EVAL, model_fn.ModeKeys.PREDICT]:
       self._test_logits(
           mode,


### PR DESCRIPTION
This PR fixes the implementation of batch normalization in canned DNN estimators.  Batch normalization should be applied after the inputs but before the activation function.