### PR TITLE
Rot90ND for rotating image tensors with general shapes

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -484,7 +484,7 @@ def _rot90_4D(images, k, name_scope):
   """Rotate batch of images counter-clockwise by 90 degrees `k` times.
 
   Args:
-    images: 4-D Tensor of shape `[height, width, channels]`.
+    images: 4-D Tensor of shape `[batch, height, width, channels]`.
     k: A scalar integer. The number of times the images are rotated by 90
       degrees.
     name_scope: A valid TensorFlow name scope.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -540,16 +540,15 @@ def rot90ND(image, rot_dims, k=1, name=None):
   else:
     ndims = shape.ndims
 
-  def _swap(mylist, dims):
-    assert len(dims) == 2
-    tmp = mylist[dims[0]]
-    mylist[dims[0]] = mylist[dims[1]]
-    mylist[dims[1]] = tmp
+  def _swap(mylist, dim0, dim1):
+    tmp = mylist[dim0]
+    mylist[dim0] = mylist[dim1]
+    mylist[dim1] = tmp
     return mylist
 
   def _rot90():
     t_pos = list(range(ndims))
-    t_pos = _swap(t_pos, rot_dims)
+    t_pos = _swap(t_pos, rot_dims[0], rot_dims[1])
     return array_ops.transpose(array_ops.reverse_v2(image, [rot_dims[1]]), t_pos)
 
   def _rot180():
@@ -557,7 +556,7 @@ def rot90ND(image, rot_dims, k=1, name=None):
 
   def _rot270():
     t_pos = list(range(ndims))
-    t_pos = _swap(t_pos, rot_dims)
+    t_pos = _swap(t_pos, rot_dims[0], rot_dims[1])
     return array_ops.reverse_v2(array_ops.transpose(image, t_pos), [rot_dims[1]])
 
   with ops.name_scope(name, 'rot90', [image, k]) as scope:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -520,11 +520,12 @@ def rot90ND(image, dim0, dim1, k=1, name=None):
     image: N-D Tensor where N >= 3 
     k: A scalar integer. The number of times the image is rotated by 90 degrees.
     dim0: The first dimension to be rotated. 
-    dim1: The second dimension to be rotated.
+    dim1: The second dimension to be rotated. 
     name: A name for this operation (optional).
 
   Returns:
-    A rotated tensor of the same type and shape as `image`.
+    A tensor of the same type and shape as `image`, rotated about the axis 
+      perpendicular to `dim0` and `dim1`.
 
   Raises:
     ValueError: if the shape of `image` not supported.
@@ -538,6 +539,11 @@ def rot90ND(image, dim0, dim1, k=1, name=None):
     ndims = 3
   else:
     ndims = shape.ndims
+
+  if dim0 >= ndims:
+    raise ValueError('\'dim0\' must be less than the number of dims in \'image\'')
+  if dim1 >= ndims:
+    raise ValueError('\'dim1\' must be less than the number of dims in \'image\'')
 
   def _swap(mylist, dim0, dim1):
     mylist[dim0], mylist[dim1] = mylist[dim1], mylist[dim0]

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1331,6 +1331,30 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
         y_np = np.rot90(image, k=k, axes=(1, 2))
         self.assertAllEqual(y_np, y_tf.eval({k_placeholder: k}))
 
+  def testRot90ND4Dims(self):
+    image = np.arange(48, dtype=np.uint8).reshape([2, 2, 4, 3])
+    with self.test_session(use_gpu=True):
+      rotated = image
+      for _ in xrange(4):
+        rotated = image_ops.rot90ND(rotated, 0, 1)
+      self.assertAllEqual(image, rotated.eval())
+
+  def testRot90ND4DimsWithBatch(self):
+    image = np.arange(96, dtype=np.uint8).reshape([2, 2, 2, 4, 3])
+    with self.test_session(use_gpu=True):
+      rotated = image
+      for _ in xrange(4):
+        rotated = image_ops.rot90ND(rotated, 1, 2)
+      self.assertAllEqual(image, rotated.eval())
+
+  def testRot90ND4DimsReverseIndexes(self):
+    image = np.arange(48, dtype=np.uint8).reshape([2, 2, 4, 3])
+    with self.test_session(use_gpu=True):
+      rotated = image
+      for _ in xrange(4):
+        rotated = image_ops.rot90ND(rotated, 1, 0)
+      self.assertAllEqual(image, rotated.eval())
+
 class AdjustContrastTest(test_util.TensorFlowTestCase):
 
   def _testContrast(self, x_np, y_np, contrast_factor):


### PR DESCRIPTION
This request addresses the feature request raised in [#21104](https://github.com/tensorflow/tensorflow/issues/21104)

The original feature request suggested "a 5D [batch, height, width, depth, channels] version of tf.image.rot90." Rather than modify the existing rot90 function, I opted to create a more general rot90ND function which can handle image tensors with the following shapes:

-   [height, width, channels]
-   [height, width, depth, channels]
-   [batch, height, width, channels]
-   [batch, height, width, depth, channels]