### PR TITLE
Update ops.h -- Eliminating a Warning Message of Type Inconsistency

### DIFF
--- a/tensorflow/cc/framework/ops.h
+++ b/tensorflow/cc/framework/ops.h
@@ -150,7 +150,7 @@ class Input {
     Initializer(const std::initializer_list<T>& v, const TensorShape& shape) {
       typedef typename RealType<T>::type RealT;
       Tensor t(DataTypeToEnum<RealT>::v(), shape);
-      if (t.NumElements() != v.size()) {
+      if (t.NumElements() != (int64)(v.size())) {
         status = errors::InvalidArgument(
             "Cannot construct a tensor with ", t.NumElements(),
             " from an initializer list with ", v.size(), " elements");


### PR DESCRIPTION
In this source code file, the type of t.NumElements() is a signed integer, while the type of v.size() is unsigned. For the "!=" operator between them, a warning message appears when TensorFlow is compiled with a C++ application.