### PR TITLE
Add libtensorflow_cc.so to pip_package BUILD

### DIFF
--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -59,6 +59,7 @@ COMMON_PIP_DEPS = [
     "setup.py",
     ":included_headers",
     "//tensorflow:tensorflow_py",
+    "//tensorflow:libtensorflow_cc.so",
     "//tensorflow/contrib/autograph:autograph",
     "//tensorflow/contrib/autograph/converters:converters",
     "//tensorflow/contrib/autograph/core:core",


### PR DESCRIPTION
This allows to run inference from C++ code if we link against the `libtensorflow_cc.so` library that will get installed under `/usr/local/lib/python2.7/dist-packages/tensorflow` by default. Otherwise, this library doesn't get installed there and there's no other way to run inference from C++ using Tensorflow AFAIK.

I've seen some issues related with this topic, but it's not clear to me what are the drawbacks of doing this, other than increasing the compile time for the additional target.

Sorry if I missed something and there's actually another way.