### PR TITLE
fix the comparison error when building a CPP API application

### DIFF
--- a/tensorflow/cc/framework/ops.h
+++ b/tensorflow/cc/framework/ops.h
@@ -150,7 +150,7 @@ class Input {
     Initializer(const std::initializer_list<T>& v, const TensorShape& shape) {
       typedef typename RealType<T>::type RealT;
       Tensor t(DataTypeToEnum<RealT>::v(), shape);
-      if (t.NumElements() != v.size()) {
+      if (t.NumElements() != static_cast<int64>(v.size())) {
         status = errors::InvalidArgument(
             "Cannot construct a tensor with ", t.NumElements(),
             " from an initializer list with ", v.size(), " elements");


### PR DESCRIPTION
### Summary

When building a CPP API application with "-Wall -Werror" option, `error: comparison between signed and unsigned integer expressions' occurs since return type of num_elements() is 'int64' instead of 'size_t' in ops.h to express -1. This patch fixes this bug by explicit type casting.

### related issue
* https://github.com/tensorflow/tensorflow/issues/20428

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>