### PR TITLE
Fixes the formatting issue pointed out at #21762

### DIFF
--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -421,7 +421,7 @@ class BasicRNNCell(LayerRNNCell):
   def build(self, inputs_shape):
     if inputs_shape[-1] is None:
       raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
-                       % inputs_shape)
+                       % (inputs_shape,))
 
     input_depth = inputs_shape[-1]
     self._kernel = self.add_variable(
@@ -510,7 +510,7 @@ class GRUCell(LayerRNNCell):
   def build(self, inputs_shape):
     if inputs_shape[-1] is None:
       raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
-                       % inputs_shape)
+                       % (inputs_shape,))
 
     input_depth = inputs_shape[-1]
     self._gate_kernel = self.add_variable(
@@ -681,7 +681,7 @@ class BasicLSTMCell(LayerRNNCell):
   def build(self, inputs_shape):
     if inputs_shape[-1] is None:
       raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
-                       % inputs_shape)
+                       % (inputs_shape,))
 
     input_depth = inputs_shape[-1]
     h_depth = self._num_units
@@ -875,7 +875,7 @@ class LSTMCell(LayerRNNCell):
   def build(self, inputs_shape):
     if inputs_shape[-1] is None:
       raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
-                       % inputs_shape)
+                       % (inputs_shape,))
 
     input_depth = inputs_shape[-1]
     h_depth = self._num_units if self._num_proj is None else self._num_proj

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -421,7 +421,7 @@ class BasicRNNCell(LayerRNNCell):
   def build(self, inputs_shape):
     if inputs_shape[-1] is None:
       raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
-                       % (inputs_shape,))
+                       % str(input_shape))
 
     input_depth = inputs_shape[-1]
     self._kernel = self.add_variable(
@@ -510,7 +510,7 @@ class GRUCell(LayerRNNCell):
   def build(self, inputs_shape):
     if inputs_shape[-1] is None:
       raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
-                       % (inputs_shape,))
+                       % str(input_shape))
 
     input_depth = inputs_shape[-1]
     self._gate_kernel = self.add_variable(
@@ -681,7 +681,7 @@ class BasicLSTMCell(LayerRNNCell):
   def build(self, inputs_shape):
     if inputs_shape[-1] is None:
       raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
-                       % (inputs_shape,))
+                       % str(input_shape))
 
     input_depth = inputs_shape[-1]
     h_depth = self._num_units
@@ -875,7 +875,7 @@ class LSTMCell(LayerRNNCell):
   def build(self, inputs_shape):
     if inputs_shape[-1] is None:
       raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
-                       % (inputs_shape,))
+                       % str(input_shape))
 
     input_depth = inputs_shape[-1]
     h_depth = self._num_units if self._num_proj is None else self._num_proj


### PR DESCRIPTION
This fixes #21762
`TypeError: not all arguments converted during string formatting`

> I believe there's a mistake in the BasicLSTMCell.build method:
> 
> ```
> raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
>                        % inputs_shape)
> ```
> will be called with inputs_shape being a tuple and % formatting will interpret this tuple as multiple formatting arguments. Can we change it to
> 
> ```
> raise ValueError("Expected inputs.shape[-1] to be known, saw shape: %s"
>                        % (inputs_shape,))
> ```
> ?