### PR TITLE
Fix tensorflow master build failure with verbs

### DIFF
--- a/tensorflow/contrib/verbs/rdma_rendezvous_mgr.cc
+++ b/tensorflow/contrib/verbs/rdma_rendezvous_mgr.cc
@@ -63,7 +63,7 @@ void RdmaRemoteRendezvous::RecvFromRemoteAsync(
   }
   CHECK(dst_name.compare(rdma_mgr_->local_worker()) == 0);
   RdmaChannel* rc = rdma_mgr_->FindChannel(src_name);
-  string key(std::move(parsed.FullKey().ToString()));
+  string key(parsed.FullKey());
   string key_with_step_id = VerbsUtil::AppendStepidToKey(key, step_id_);
 
   Device* dst_dev;


### PR DESCRIPTION
This fix tries to address the issue in #21999 where
tensorflow master build failed with verbs. The issue was caused
by StringPiece replaced with `absl::string_view`

This fix fixes #21999

This fix fixes #22113

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>