### PR TITLE
Fix issues in maxout layer

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -3109,7 +3109,7 @@ def maxout(inputs, num_units, axis=-1, scope=None):
     inputs: Tensor input
     num_units: Specifies how many features will remain after maxout
       in the `axis` dimension (usually channel).
-      This must be multiple of number of `axis`.
+      This must be a factor of number of features.
     axis: The dimension where max pooling will be performed. Default is the
     last dimension.
     scope: Optional scope for variable_scope.
@@ -3128,7 +3128,7 @@ def maxout(inputs, num_units, axis=-1, scope=None):
       raise ValueError('number of features({}) is not '
                        'a multiple of num_units({})'.format(
                            num_channels, num_units))
-    shape[axis] = -1
+    shape[axis] = num_units
     shape += [num_channels // num_units]
 
     # Dealing with batches with arbitrary sizes


### PR DESCRIPTION
Originally pointed out by @ilblackdragon in [this pull request](https://github.com/tensorflow/tensorflow/pull/5528#discussion_r92219222):
shape[axis] should = num_units instead of = -1.

The original implementation causes some trouble. For example, if I am to maxout a tensor x = (?, 32, 32, 256) and reduce it into a tensor of shape (?, 32, 32, 128), by using `x = tf.contrib.layers.maxout(x, 128)`, I get a tensor of shape (?, 32, 32, ?) instead of (?, 32, 32, 128).

The shape of the tensor after the maxout can be inferred with num_units, so there is no need to use -1 here. This also causes inconvenience and raises errors when using a dense layer afterwards (or any layer that needs the value of the last dimension).

In addition, the original documentation is problematic in saying that "num_units should be a multiple of 'axis'", and this PR fixes the description.