### PR TITLE
LSTMCell base article at rnn_cell_impl.py

### DIFF
--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -654,10 +654,10 @@ class LSTMCell(LayerRNNCell):
 
   The default non-peephole implementation is based on:
 
-    http://www.bioinf.jku.at/publications/older/2604.pdf
+    https://pdfs.semanticscholar.org/1154/0131eae85b2e11d53df7f1360eeb6476e7f4.pdf
 
-  S. Hochreiter and J. Schmidhuber.
-  "Long Short-Term Memory". Neural Computation, 9(8):1735-1780, 1997.
+  Felix Gers, Jürgen Schmidhuber, and Fred Cummins. 
+  "Learning to forget: Continual prediction with LSTM." IET, 850-855, 1999.
 
   The peephole implementation is based on:
 


### PR DESCRIPTION
The implemented LSTMCell makes use of the "forget gate". The base article pointed out in both comments (lines 650 ~ 661) and tensorflow's documentation does not cover the concept of "forget gate".
This concept was introduced by Gers et al. only in 1999 with "Learning to forget: Continual prediction with LSTM".