### PR TITLE
Fix documentation issue with `tf.nn.conv1d`

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2454,7 +2454,7 @@ def conv1d(value,
   returned to the caller.
 
   Args:
-    value: A 3D `Tensor`.  Must be of type `float16` or `float32`.
+    value: A 3D `Tensor`.  Must be of type `float16`, `float32`, or `float64`.
     filters: A 3D `Tensor`.  Must have the same type as `value`.
     stride: An `integer`.  The number of entries by which
       the filter is moved right at each step.


### PR DESCRIPTION
The `tf.nn.conv1d` supports float16, float32, and float64
though in `tf.nn.conv1d.__doc__` only float16 and float32
are mentioned. This fix updates the doc string to add
float64 as the supported data type.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>