### PR TITLE
Fix ReLU layer serialization bug

### DIFF
--- a/tensorflow/python/keras/layers/advanced_activations.py
+++ b/tensorflow/python/keras/layers/advanced_activations.py
@@ -330,9 +330,9 @@ class ReLU(Layer):
 
   def get_config(self):
     config = {
-        'max_value': self.max_value,
-        'negative_slope': self.negative_slope,
-        'threshold': self.threshold
+        'max_value': float(self.max_value),
+        'negative_slope': float(self.negative_slope),
+        'threshold': float(self.threshold)
     }
     base_config = super(ReLU, self).get_config()
     return dict(list(base_config.items()) + list(config.items()))


### PR DESCRIPTION
This bug is reported at https://github.com/keras-team/keras/issues/11023, but actually ```keras-team/keras``` handles this correctly, ```tf.keras``` has the bug. You can also use the following code snippet to reproduce:
```
from tensorflow.python.keras.layers import Input, ReLU
from tensorflow.python.keras.models import Model, save_model, load_model
import numpy as np

input = Input(shape=(5, 6, 3))
output = ReLU(6)(input)
model = Model(inputs=input, outputs=output)
model.summary()
model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])

save_model(model, "/tmp/test1")
load_model("/tmp/test1")
```
This is the exception:
```
Traceback (most recent call last):
  File "test.py", line 13, in <module>
    load_model("/tmp/test1")
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/engine/saving.py", line 229, in load_model
    model = model_from_config(model_config, custom_objects=custom_objects)
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/engine/saving.py", line 306, in model_from_config
    return deserialize(config, custom_objects=custom_objects)
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/layers/serialization.py", line 64, in deserialize
    printable_module_name='layer')
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/utils/generic_utils.py", line 173, in deserialize_keras_object
    list(custom_objects.items())))
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/engine/network.py", line 1209, in from_config
    process_layer(layer_data)
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/engine/network.py", line 1195, in process_layer
    layer = deserialize_layer(layer_data, custom_objects=custom_objects)
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/layers/serialization.py", line 64, in deserialize
    printable_module_name='layer')
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/utils/generic_utils.py", line 175, in deserialize_keras_object
    return cls.from_config(config['config'])
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/engine/base_layer.py", line 1553, in from_config
    return cls(**config)
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/layers/advanced_activations.py", line 302, in __init__
    self.max_value = K.cast_to_floatx(max_value)
  File "/Library/Python/2.7/site-packages/tensorflow/python/keras/backend.py", line 216, in cast_to_floatx
    return np.asarray(x, dtype=_FLOATX)
  File "/Library/Python/2.7/site-packages/numpy/core/numeric.py", line 492, in asarray
    return array(a, dtype, copy=False, order=order)
TypeError: float() argument must be a string or a number
```
The bug is caused by the type of ```self.max_value``` is ```np.ndarray``` after ```K.cast_to_floatx```, so we should force to convert it to float when serializing it, otherwise, it would be serialized as ```np.ndarray``` and throws exception when loading back. This fix is following other layers in ```advanced_activations.py```, such as [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/layers/advanced_activations.py#L63), they handle similar issue correctly.