### PR TITLE
Support 3/4/5 dimensional input for bias_add with NCHW data format

### DIFF
--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -266,7 +266,7 @@ Status BiasAddGradShape(shape_inference::InferenceContext* c) {
 
   if (s.ok() && data_format == "NCHW") {
     TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 3, &input_shape));
-    c->set_output(0, c->Vector(c->Dim(input_shape, -3)));
+    c->set_output(0, c->Vector(c->Dim(input_shape, 1)));
   } else {
     TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 2, &input_shape));
     c->set_output(0, c->Vector(c->Dim(input_shape, -1)));

--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -228,12 +228,12 @@ Status BiasAddShape(shape_inference::InferenceContext* c) {
   if (s.ok() && data_format == "NCHW") {
     // Merge the length of bias_shape into the third to last dimension
     ShapeHandle first;
-    TF_RETURN_IF_ERROR(c->Subshape(input_shape, 0, -3, &first));
+    TF_RETURN_IF_ERROR(c->Subshape(input_shape, 0, 1, &first));
 
     ShapeHandle last;
-    TF_RETURN_IF_ERROR(c->Subshape(input_shape, -2, &last));
+    TF_RETURN_IF_ERROR(c->Subshape(input_shape, 2, &last));
 
-    DimensionHandle input_bias_dim = c->Dim(input_shape, -3);
+    DimensionHandle input_bias_dim = c->Dim(input_shape, 1);
     DimensionHandle merged_bias_dim;
     TF_RETURN_IF_ERROR(c->Merge(input_bias_dim, bias_dim, &merged_bias_dim));
     ShapeHandle merged_bias = c->Vector(merged_bias_dim);

--- a/tensorflow/core/framework/common_shape_fns_test.cc
+++ b/tensorflow/core/framework/common_shape_fns_test.cc
@@ -278,9 +278,7 @@ TEST(CommonShapeFnsTest, BiasAddShapeTest) {
                     .Finalize(&def));
     InferenceContext c(TF_GRAPH_DEF_VERSION, &def, op_def,
                        {S({8, 6, 4, 2, 3, 4, 5}), S({3})}, {}, {}, {});
-    TF_EXPECT_OK(BiasAddShape(&c));
-    ShapeHandle output = c.output(0);
-    EXPECT_EQ("[8,6,4,2,3,4,5]", c.DebugString(output));
+    EXPECT_FALSE(BiasAddShape(&c).ok());
   }
 
   {

--- a/tensorflow/core/framework/common_shape_fns_test.cc
+++ b/tensorflow/core/framework/common_shape_fns_test.cc
@@ -289,7 +289,7 @@ TEST(CommonShapeFnsTest, BiasAddShapeTest) {
                     .Attr("data_format", "NCHW")
                     .Finalize(&def));
     InferenceContext c(TF_GRAPH_DEF_VERSION, &def, op_def,
-                       {S({10, 11, 12}), S({10})}, {}, {}, {});
+                       {S({10, 11, 12}), S({11})}, {}, {}, {});
     TF_EXPECT_OK(BiasAddShape(&c));
     ShapeHandle output = c.output(0);
     EXPECT_EQ("[10,11,12]", c.DebugString(output));
@@ -369,7 +369,7 @@ TEST(CommonShapeFnsTest, BiasAddGradShapeTest) {
                        {S({8, 6, 4, 2, 3, 4, 5})}, {}, {}, {});
     TF_EXPECT_OK(BiasAddGradShape(&c));
     ShapeHandle output = c.output(0);
-    EXPECT_EQ(3, c.Value(c.Dim(output, 0)));
+    EXPECT_EQ(6, c.Value(c.Dim(output, 0)));
   }
 
   {
@@ -382,7 +382,7 @@ TEST(CommonShapeFnsTest, BiasAddGradShapeTest) {
                        {}, {}, {});
     TF_EXPECT_OK(BiasAddGradShape(&c));
     ShapeHandle output = c.output(0);
-    EXPECT_EQ(10, c.Value(c.Dim(output, 0)));
+    EXPECT_EQ(11, c.Value(c.Dim(output, 0)));
   }
 
   {

--- a/tensorflow/core/kernels/bias_op.cc
+++ b/tensorflow/core/kernels/bias_op.cc
@@ -357,8 +357,8 @@ class BiasOp<GPUDevice, T> : public BinaryOp<T> {
     OP_REQUIRES(context, TensorShapeUtils::IsVector(bias.shape()),
                 errors::InvalidArgument("Biases must be 1D: ",
                                         bias.shape().DebugString()));
-    int32 batch, height, width, channel;
-    GetBiasValueDims(input, data_format_, &batch, &height, &width, &channel);
+    int32 batch, height, width, depth, channel;
+    GetBiasValueDims(input, data_format_, &batch, &height, &width, &depth, &channel);
     OP_REQUIRES(context, bias.shape().dim_size(0) == channel,
                 errors::InvalidArgument(
                     "Must provide as many biases as the channel dimension "
@@ -371,7 +371,7 @@ class BiasOp<GPUDevice, T> : public BinaryOp<T> {
     if (input.NumElements() > 0) {
       BiasGPU<T>::compute(context->template eigen_device<Device>(),
                           input.flat<T>().data(), bias.flat<T>().data(),
-                          output->flat<T>().data(), batch, width, height,
+                          output->flat<T>().data(), batch, width, height, depth,
                           channel, data_format_);
     }
   }
@@ -543,8 +543,8 @@ class BiasGradOp<GPUDevice, T> : public OpKernel {
                 TensorShapeUtils::IsMatrixOrHigher(output_backprop.shape()),
                 errors::InvalidArgument("Input tensor must be at least 2D: ",
                                         output_backprop.shape().DebugString()));
-    int32 batch, height, width, channel;
-    GetBiasValueDims(output_backprop, data_format_, &batch, &height, &width,
+    int32 batch, height, width, depth, channel;
+    GetBiasValueDims(output_backprop, data_format_, &batch, &height, &width, &depth,
                      &channel);
     Tensor* output = nullptr;
     TensorShape output_shape{channel};

--- a/tensorflow/core/kernels/bias_op.cc
+++ b/tensorflow/core/kernels/bias_op.cc
@@ -250,9 +250,8 @@ class BiasGradOp : public OpKernel {
                                         output_backprop.shape().DebugString()));
 
     OP_REQUIRES(
-        context,
-        FastBoundsCheck(output_backprop.NumElements(),
-                        std::numeric_limits<int32>::max()),
+        context, FastBoundsCheck(output_backprop.NumElements(),
+                                 std::numeric_limits<int32>::max()),
         errors::InvalidArgument("BiasGrad requires tensor size <= int32 max"));
 
     int32 batch, height, width, depth, channel;
@@ -358,7 +357,8 @@ class BiasOp<GPUDevice, T> : public BinaryOp<T> {
                 errors::InvalidArgument("Biases must be 1D: ",
                                         bias.shape().DebugString()));
     int32 batch, height, width, depth, channel;
-    GetBiasValueDims(input, data_format_, &batch, &height, &width, &depth, &channel);
+    GetBiasValueDims(input, data_format_, &batch, &height, &width, &depth,
+                     &channel);
     OP_REQUIRES(context, bias.shape().dim_size(0) == channel,
                 errors::InvalidArgument(
                     "Must provide as many biases as the channel dimension "
@@ -544,8 +544,8 @@ class BiasGradOp<GPUDevice, T> : public OpKernel {
                 errors::InvalidArgument("Input tensor must be at least 2D: ",
                                         output_backprop.shape().DebugString()));
     int32 batch, height, width, depth, channel;
-    GetBiasValueDims(output_backprop, data_format_, &batch, &height, &width, &depth,
-                     &channel);
+    GetBiasValueDims(output_backprop, data_format_, &batch, &height, &width,
+                     &depth, &channel);
     Tensor* output = nullptr;
     TensorShape output_shape{channel};
     OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
@@ -560,10 +560,7 @@ class BiasGradOp<GPUDevice, T> : public OpKernel {
     int device_id = stream->parent()->device_ordinal();
     DataType dtype = output_backprop.dtype();
     BiasAddParams bias_parameters = {
-        {batch, height * width, channel},
-        data_format_,
-        dtype,
-        device_id,
+        {batch, height * width, channel}, data_format_, dtype, device_id,
     };
 
     // Autotune two algorithm: customized

--- a/tensorflow/core/kernels/bias_op.cc
+++ b/tensorflow/core/kernels/bias_op.cc
@@ -43,11 +43,12 @@ typedef Eigen::SyclDevice SYCLDevice;
 namespace {
 
 void GetBiasValueDims(const Tensor& value_tensor, TensorFormat data_format,
-                      int32* batch, int32* height, int32* width,
+                      int32* batch, int32* height, int32* width, int32* depth,
                       int32* channel) {
   *batch = 1;
-  *width = 1;
   *height = 1;
+  *width = 1;
+  *depth = 1;
   *channel = 1;
   if (data_format == FORMAT_NHWC) {
     int32 channel_dim = value_tensor.dims() - 1;
@@ -56,14 +57,14 @@ void GetBiasValueDims(const Tensor& value_tensor, TensorFormat data_format,
       *batch *= static_cast<int32>(value_tensor.dim_size(i));
     }
   } else if (data_format == FORMAT_NCHW) {
-    int32 channel_dim = value_tensor.dims() - 3;
-    int32 height_dim = value_tensor.dims() - 2;
-    int32 width_dim = value_tensor.dims() - 1;
-    *channel = static_cast<int32>(value_tensor.dim_size(channel_dim));
-    *height = static_cast<int32>(value_tensor.dim_size(height_dim));
-    *width = static_cast<int32>(value_tensor.dim_size(width_dim));
-    for (int32 i = 0; i < channel_dim; i++) {
-      *batch *= static_cast<int32>(value_tensor.dim_size(i));
+    *batch = static_cast<int32>(value_tensor.dim_size(0));
+    *channel = static_cast<int32>(value_tensor.dim_size(1));
+    *height = static_cast<int32>(value_tensor.dim_size(2));
+    if (value_tensor.dims() > 3) {
+      *width = static_cast<int32>(value_tensor.dim_size(3));
+    }
+    if (value_tensor.dims() > 4) {
+      *depth = static_cast<int32>(value_tensor.dim_size(4));
     }
   }
 }
@@ -109,10 +110,7 @@ class BiasOp : public BinaryOp<T> {
     // Added by intel_tf to support NCHW on CPU regardless of MKL used or not.
     size_t channel_dim;
     if (data_format_ == FORMAT_NCHW) {
-      OP_REQUIRES(context, input.dims() == 4,
-                  errors::InvalidArgument(
-                      "NCHW format supports only 4D input tensor."));
-      channel_dim = 1;
+      channel_dim = 1; // NCHW always have channel dim in 1 (with 3, 4, 5 dimensions data).
     } else {
       channel_dim = input.shape().dims() - 1;  // End of code by intel_tf.
     }
@@ -132,14 +130,41 @@ class BiasOp : public BinaryOp<T> {
 
     // Added by intel_tf to support NCHW on CPU regardless of MKL used or not.
     if (data_format_ == FORMAT_NCHW) {
-      int32 batch, height, width, channel;
-      GetBiasValueDims(input, data_format_, &batch, &height, &width, &channel);
-      Eigen::DSizes<Eigen::Index, 4> four_dims(1, channel, 1, 1);
-      Eigen::DSizes<Eigen::Index, 4> broad_cast_dims(batch, 1, height, width);
-      const Device& d = context->eigen_device<Device>();
-      output->tensor<T, 4>().device(d) =
-          input.tensor<T, 4>() +
-          bias.tensor<T, 1>().reshape(four_dims).broadcast(broad_cast_dims);
+      int32 batch, height, width, depth, channel;
+      GetBiasValueDims(input, data_format_, &batch, &height, &width, &depth, &channel);
+      switch (input.shape().dims()) {
+        case 3: {
+          Eigen::DSizes<int32, 3> three_dims(1, channel, 1);
+          Eigen::DSizes<int32, 3> broad_cast_dims(batch, 1, height);
+          const Device& d = context->eigen_device<Device>();
+          output->tensor<T, 3>().device(d) =
+              input.tensor<T, 3>() +
+              bias.tensor<T, 1>().reshape(three_dims).broadcast(broad_cast_dims);
+          }
+          break;
+      case 4: {
+          Eigen::DSizes<int32, 4> four_dims(1, channel, 1, 1);
+          Eigen::DSizes<int32, 4> broad_cast_dims(batch, 1, height, width);
+          const Device& d = context->eigen_device<Device>();
+          output->tensor<T, 4>().device(d) =
+              input.tensor<T, 4>() +
+              bias.tensor<T, 1>().reshape(four_dims).broadcast(broad_cast_dims);
+        }
+        break;
+      case 5: {
+          Eigen::DSizes<int32, 5> four_dims(1, channel, 1, 1, 1);
+          Eigen::DSizes<int32, 5> broad_cast_dims(batch, 1, height, width, depth);
+          const Device& d = context->eigen_device<Device>();
+          output->tensor<T, 5>().device(d) =
+              input.tensor<T, 5>() +
+              bias.tensor<T, 1>().reshape(four_dims).broadcast(broad_cast_dims);
+        }
+        break;
+      default:
+        OP_REQUIRES(context, false,
+                    errors::InvalidArgument("Only ranks up to 5 supported: ",
+                                            input.shape().DebugString()));
+      }
       return;
     }  // End of code by intel_tf.
 
@@ -229,8 +254,8 @@ class BiasGradOp : public OpKernel {
                         std::numeric_limits<int32>::max()),
         errors::InvalidArgument("BiasGrad requires tensor size <= int32 max"));
 
-    int32 batch, height, width, channel;
-    GetBiasValueDims(output_backprop, data_format_, &batch, &height, &width,
+    int32 batch, height, width, depth, channel;
+    GetBiasValueDims(output_backprop, data_format_, &batch, &height, &width, &depth,
                      &channel);
     Tensor* output = nullptr;
     TensorShape output_shape{channel};
@@ -243,6 +268,7 @@ class BiasGradOp : public OpKernel {
       output->template flat<T>().setZero();
     } else {
       // Added by intel_tf to support NCHW on CPU regardless of MKL used or not.
+      // TODO (yongtang): Add 3/4/5 dimensional data support for NCHW format.
       if (data_format_ == FORMAT_NCHW) {
         OP_REQUIRES(context, output_backprop.dims() == 4,
                     errors::InvalidArgument(

--- a/tensorflow/core/kernels/bias_op.cc
+++ b/tensorflow/core/kernels/bias_op.cc
@@ -110,7 +110,8 @@ class BiasOp : public BinaryOp<T> {
     // Added by intel_tf to support NCHW on CPU regardless of MKL used or not.
     size_t channel_dim;
     if (data_format_ == FORMAT_NCHW) {
-      channel_dim = 1; // NCHW always have channel dim in 1 (with 3, 4, 5 dimensions data).
+      channel_dim = 1;  // NCHW always have channel dim in 1 (with 3, 4, 5
+                        // dimensions data).
     } else {
       channel_dim = input.shape().dims() - 1;  // End of code by intel_tf.
     }
@@ -131,39 +132,39 @@ class BiasOp : public BinaryOp<T> {
     // Added by intel_tf to support NCHW on CPU regardless of MKL used or not.
     if (data_format_ == FORMAT_NCHW) {
       int32 batch, height, width, depth, channel;
-      GetBiasValueDims(input, data_format_, &batch, &height, &width, &depth, &channel);
+      GetBiasValueDims(input, data_format_, &batch, &height, &width, &depth,
+                       &channel);
       switch (input.shape().dims()) {
         case 3: {
           Eigen::DSizes<int32, 3> three_dims(1, channel, 1);
           Eigen::DSizes<int32, 3> broad_cast_dims(batch, 1, height);
           const Device& d = context->eigen_device<Device>();
-          output->tensor<T, 3>().device(d) =
-              input.tensor<T, 3>() +
-              bias.tensor<T, 1>().reshape(three_dims).broadcast(broad_cast_dims);
-          }
-          break;
-      case 4: {
+          output->tensor<T, 3>().device(d) = input.tensor<T, 3>() +
+                                             bias.tensor<T, 1>()
+                                                 .reshape(three_dims)
+                                                 .broadcast(broad_cast_dims);
+        } break;
+        case 4: {
           Eigen::DSizes<int32, 4> four_dims(1, channel, 1, 1);
           Eigen::DSizes<int32, 4> broad_cast_dims(batch, 1, height, width);
           const Device& d = context->eigen_device<Device>();
           output->tensor<T, 4>().device(d) =
               input.tensor<T, 4>() +
               bias.tensor<T, 1>().reshape(four_dims).broadcast(broad_cast_dims);
-        }
-        break;
-      case 5: {
+        } break;
+        case 5: {
           Eigen::DSizes<int32, 5> four_dims(1, channel, 1, 1, 1);
-          Eigen::DSizes<int32, 5> broad_cast_dims(batch, 1, height, width, depth);
+          Eigen::DSizes<int32, 5> broad_cast_dims(batch, 1, height, width,
+                                                  depth);
           const Device& d = context->eigen_device<Device>();
           output->tensor<T, 5>().device(d) =
               input.tensor<T, 5>() +
               bias.tensor<T, 1>().reshape(four_dims).broadcast(broad_cast_dims);
-        }
-        break;
-      default:
-        OP_REQUIRES(context, false,
-                    errors::InvalidArgument("Only ranks up to 5 supported: ",
-                                            input.shape().DebugString()));
+        } break;
+        default:
+          OP_REQUIRES(context, false,
+                      errors::InvalidArgument("Only ranks up to 5 supported: ",
+                                              input.shape().DebugString()));
       }
       return;
     }  // End of code by intel_tf.
@@ -255,8 +256,8 @@ class BiasGradOp : public OpKernel {
         errors::InvalidArgument("BiasGrad requires tensor size <= int32 max"));
 
     int32 batch, height, width, depth, channel;
-    GetBiasValueDims(output_backprop, data_format_, &batch, &height, &width, &depth,
-                     &channel);
+    GetBiasValueDims(output_backprop, data_format_, &batch, &height, &width,
+                     &depth, &channel);
     Tensor* output = nullptr;
     TensorShape output_shape{channel};
     OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));

--- a/tensorflow/core/kernels/bias_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bias_op_gpu.cu.cc
@@ -75,10 +75,10 @@ __global__ void BiasNCHWKernel(int32 nthreads, const T* input, const T* bias,
 // dimension.
 template <typename T>
 void BiasGPU<T>::compute(const GPUDevice& d, const T* input, const T* bias,
-                         T* output, int32 batch, int32 height, int32 width,
+                         T* output, int32 batch, int32 height, int32 width, int depth,
                          int32 channel, TensorFormat data_format) {
   const int32 bias_size = channel;
-  const int32 image_size = height * width;
+  const int32 image_size = height * width * depth;
   const int32 total_count = batch * bias_size * image_size;
   if (total_count == 0) {
     return;

--- a/tensorflow/core/kernels/bias_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bias_op_gpu.cu.cc
@@ -75,8 +75,8 @@ __global__ void BiasNCHWKernel(int32 nthreads, const T* input, const T* bias,
 // dimension.
 template <typename T>
 void BiasGPU<T>::compute(const GPUDevice& d, const T* input, const T* bias,
-                         T* output, int32 batch, int32 height, int32 width, int depth,
-                         int32 channel, TensorFormat data_format) {
+                         T* output, int32 batch, int32 height, int32 width,
+                         int depth, int32 channel, TensorFormat data_format) {
   const int32 bias_size = channel;
   const int32 image_size = height * width * depth;
   const int32 total_count = batch * bias_size * image_size;
@@ -85,14 +85,14 @@ void BiasGPU<T>::compute(const GPUDevice& d, const T* input, const T* bias,
   }
   CudaLaunchConfig config = GetCudaLaunchConfig(total_count, d);
   if (data_format == FORMAT_NHWC) {
-    BiasNHWCKernel<T>
-        <<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
-            config.virtual_thread_count, input, bias, output, bias_size);
+    BiasNHWCKernel<
+        T><<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
+        config.virtual_thread_count, input, bias, output, bias_size);
   } else {
-    BiasNCHWKernel<T>
-        <<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
-            config.virtual_thread_count, input, bias, output, bias_size,
-            image_size);
+    BiasNCHWKernel<
+        T><<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
+        config.virtual_thread_count, input, bias, output, bias_size,
+        image_size);
   }
 }
 
@@ -214,10 +214,10 @@ void BiasGradGPU<T>::compute(const GPUDevice& d, const T* output_backprop,
   // Check if we have enough shared memory.
   if (shared_memory_size <= max_shared_memory_size) {
     if (data_format == FORMAT_NHWC) {
-      BiasGradNHWC_SharedAtomics<T>
-          <<<config.block_count, config.thread_per_block, shared_memory_size,
-             d.stream()>>>(total_count, output_backprop, bias_backprop,
-                           bias_size);
+      BiasGradNHWC_SharedAtomics<
+          T><<<config.block_count, config.thread_per_block, shared_memory_size,
+               d.stream()>>>(total_count, output_backprop, bias_backprop,
+                             bias_size);
     } else {
       // Round up the block count to multiple of bias_size.
       int group_size = (config.block_count + bias_size - 1) / bias_size;
@@ -225,24 +225,23 @@ void BiasGradGPU<T>::compute(const GPUDevice& d, const T* output_backprop,
       if (config.thread_per_block < kWarpSize) {
         config.thread_per_block = kWarpSize;
       }
-      BiasGradNCHW_SharedAtomics<T>
-          <<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
-              output_backprop, bias_backprop, batch, bias_size, image_size,
-              group_size);
+      BiasGradNCHW_SharedAtomics<
+          T><<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
+          output_backprop, bias_backprop, batch, bias_size, image_size,
+          group_size);
     }
   } else {
     // Note that even if we don't have enough shared memory to fit the entire
     // output block, it is possible to process one group of elements at a time.
     // But for now, we simply fall back to the naive implementation.
     if (data_format == FORMAT_NHWC) {
-      BiasGradNHWC_Naive<T>
-          <<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
-              total_count, output_backprop, bias_backprop, bias_size);
+      BiasGradNHWC_Naive<
+          T><<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
+          total_count, output_backprop, bias_backprop, bias_size);
     } else {
-      BiasGradNCHW_Naive<T>
-          <<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
-              total_count, output_backprop, bias_backprop, bias_size,
-              image_size);
+      BiasGradNCHW_Naive<
+          T><<<config.block_count, config.thread_per_block, 0, d.stream()>>>(
+          total_count, output_backprop, bias_backprop, bias_size, image_size);
     }
   }
 }

--- a/tensorflow/core/kernels/bias_op_gpu.h
+++ b/tensorflow/core/kernels/bias_op_gpu.h
@@ -31,7 +31,7 @@ typedef Eigen::GpuDevice GPUDevice;
 template <typename T>
 struct BiasGPU {
   static void compute(const GPUDevice& d, const T* input, const T* bias,
-                      T* output, int32 batch, int32 height, int32 width,
+                      T* output, int32 batch, int32 height, int32 width, int32 depth,
                       int32 channel, TensorFormat data_format);
 };
 

--- a/tensorflow/core/kernels/bias_op_gpu.h
+++ b/tensorflow/core/kernels/bias_op_gpu.h
@@ -31,8 +31,8 @@ typedef Eigen::GpuDevice GPUDevice;
 template <typename T>
 struct BiasGPU {
   static void compute(const GPUDevice& d, const T* input, const T* bias,
-                      T* output, int32 batch, int32 height, int32 width, int32 depth,
-                      int32 channel, TensorFormat data_format);
+                      T* output, int32 batch, int32 height, int32 width,
+                      int32 depth, int32 channel, TensorFormat data_format);
 };
 
 template <typename T>

--- a/tensorflow/python/kernel_tests/bias_op_test.py
+++ b/tensorflow/python/kernel_tests/bias_op_test.py
@@ -74,16 +74,16 @@ class BiasAddTest(test.TestCase):
   def _NHWCToNCHW(self, np_value):
     # fill the input value to at least 3-dimension
     np_value = self._AtLeast3d(np_value)
-    # move the last dimension to third-to-last
+    # move the last dimension to second
     np_dim = list(range(np_value.ndim))
-    np_dim_new = list(np_dim[0:-3]) + list(np_dim[-1:]) + list(np_dim[-3:-1])
+    np_dim_new = list(np_dim[0:1]) + list(np_dim[-1:]) + list(np_dim[1:-1])
     return np.transpose(np_value, np_dim_new)
 
   def _NCHWToNHWC(self, np_value):
     assert len(np_value.shape) >= 3
     np_dim = list(range(np_value.ndim))
-    # move the third-to-last dimension to the last
-    np_dim_new = list(np_dim[0:-3]) + list(np_dim[-2:]) + list(np_dim[-3:-2])
+    # move the second dimension to the last
+    np_dim_new = list(np_dim[0:1]) + list(np_dim[2:]) + list(np_dim[1:2])
     return np.transpose(np_value, np_dim_new)
 
   def _testBiasNCHW(self, np_inputs, np_bias, use_gpu):

--- a/tensorflow/python/kernel_tests/bias_op_test.py
+++ b/tensorflow/python/kernel_tests/bias_op_test.py
@@ -96,10 +96,11 @@ class BiasAddTest(test.TestCase):
 
   def _testAll(self, np_inputs, np_bias):
     self._testBias(np_inputs, np_bias, use_gpu=False)
+    self._testBiasNCHW(np_inputs, np_bias, use_gpu=False)
     if np_inputs.dtype in [np.float16, np.float32, np.float64]:
       self._testBias(np_inputs, np_bias, use_gpu=True)
-      if test.is_gpu_available(cuda_only=True):
-        self._testBiasNCHW(np_inputs, np_bias, use_gpu=True)
+      self._testBiasNCHW(np_inputs, np_bias, use_gpu=True)
+
 
   def testInputDims(self):
     with self.assertRaises(ValueError):
@@ -131,6 +132,16 @@ class BiasAddTest(test.TestCase):
     for t in [np.float16, np.float32, np.float64]:
       self._testAll(
           np.random.rand(4, 3, 3).astype(t), np.random.rand(3).astype(t))
+
+  def test4DFloatTypes(self):
+    for t in [np.float16, np.float32, np.float64]:
+      self._testAll(
+          np.random.rand(4, 3, 2, 3).astype(t), np.random.rand(3).astype(t))
+
+  def test5DFloatTypes(self):
+    for t in [np.float16, np.float32, np.float64]:
+      self._testAll(
+          np.random.rand(4, 3, 2, 3, 4).astype(t), np.random.rand(4).astype(t))
 
   def _testGradient(self, np_input, bias, dtype, data_format, use_gpu):
     with self.test_session(use_gpu=use_gpu):


### PR DESCRIPTION
This fix tries to address part of the issue raised in #20527 where biad_add only support 4 dimensional input with NCHW data format, and is causing tf.layers.conv3d to not suppport dynamic shapes with `channel_first` data format.

This fix add the 3/4/5 dimensional input for bias_add with NCHW data format as the first step to address the issue. Follow up PR will be added to fix tf.layers.conv3d issue.

This fix also only adds bias_add support. BiasGradOp still only works with 4D+NCHW. The 3D/5D+NCHW+BiadGradOp will be worked on later (TODO).

This fix is part of the effort for #20527.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>