### PR TITLE
Fix ps0 OOM when workers too many.

### DIFF
--- a/tensorflow/python/ops/resources.py
+++ b/tensorflow/python/ops/resources.py
@@ -87,7 +87,7 @@ def report_uninitialized_resources(resource_list=None,
     resource_list = shared_resources() + local_resources()
   with ops.name_scope(name):
     # Run all operations on CPU
-    local_device = os.environ.get("TF_LOCAL_DEVICE", "/cpu:0")
+    local_device = os.environ.get("TF_DEVICE_FOR_UNINITIALIZED_VARIABLE_REPORTING", "/cpu:0")
     with ops.device(local_device):
       if not resource_list:
         # Return an empty tensor so we only need to check for returned tensor

--- a/tensorflow/python/ops/resources.py
+++ b/tensorflow/python/ops/resources.py
@@ -21,6 +21,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import os
 
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -86,7 +87,8 @@ def report_uninitialized_resources(resource_list=None,
     resource_list = shared_resources() + local_resources()
   with ops.name_scope(name):
     # Run all operations on CPU
-    with ops.device("/cpu:0"):
+    local_device = os.environ.get("TF_LOCAL_DEVICE", "/cpu:0")
+    with ops.device(local_device):
       if not resource_list:
         # Return an empty tensor so we only need to check for returned tensor
         # size being 0 as an indication of model ready.

--- a/tensorflow/python/ops/resources.py
+++ b/tensorflow/python/ops/resources.py
@@ -87,7 +87,8 @@ def report_uninitialized_resources(resource_list=None,
     resource_list = shared_resources() + local_resources()
   with ops.name_scope(name):
     # Run all operations on CPU
-    local_device = os.environ.get("TF_DEVICE_FOR_UNINITIALIZED_VARIABLE_REPORTING", "/cpu:0")
+    local_device = os.environ.get(
+      "TF_DEVICE_FOR_UNINITIALIZED_VARIABLE_REPORTING", "/cpu:0")
     with ops.device(local_device):
       if not resource_list:
         # Return an empty tensor so we only need to check for returned tensor

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 import enum  # pylint: disable=g-bad-import-order
 
+import os
 import six
 
 from tensorflow.core.framework import attr_value_pb2
@@ -2283,7 +2284,8 @@ def report_uninitialized_variables(var_list=None,
     # Run all operations on CPU
     if var_list:
       init_vars = [state_ops.is_variable_initialized(v) for v in var_list]
-    with ops.device("/cpu:0"):
+    local_device = os.environ.get("TF_LOCAL_DEVICE", "/cpu:0")
+    with ops.device(local_device):
       if not var_list:
         # Return an empty tensor so we only need to check for returned tensor
         # size being 0 as an indication of model ready.

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -2284,7 +2284,7 @@ def report_uninitialized_variables(var_list=None,
     # Run all operations on CPU
     if var_list:
       init_vars = [state_ops.is_variable_initialized(v) for v in var_list]
-    local_device = os.environ.get("TF_LOCAL_DEVICE", "/cpu:0")
+    local_device = os.environ.get("TF_DEVICE_FOR_UNINITIALIZED_VARIABLE_REPORTING", "/cpu:0")
     with ops.device(local_device):
       if not var_list:
         # Return an empty tensor so we only need to check for returned tensor

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -2284,7 +2284,8 @@ def report_uninitialized_variables(var_list=None,
     # Run all operations on CPU
     if var_list:
       init_vars = [state_ops.is_variable_initialized(v) for v in var_list]
-    local_device = os.environ.get("TF_DEVICE_FOR_UNINITIALIZED_VARIABLE_REPORTING", "/cpu:0")
+    local_device = os.environ.get(
+      "TF_DEVICE_FOR_UNINITIALIZED_VARIABLE_REPORTING", "/cpu:0")
     with ops.device(local_device):
       if not var_list:
         # Return an empty tensor so we only need to check for returned tensor


### PR DESCRIPTION
When training with MonitoredTrainingSession in distributed mode,
all ops related with report_uninitialized_xxx will be placed on ps0,
which may lead to OOM when workers up to thousands.

We use a environment variable to solve it. When OOM happens, users can
set the local device to fix the problem, such as
os.environ['TF_LOCAL_DEVICE'] = '/job:worker/task:index'.

Fixes #22137