### PR TITLE
Make tf.random_uniform([0], maxval=0, dtype=tf.int32) not crash

### DIFF
--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -320,6 +320,15 @@ class RandomUniformTest(RandomOpTestCommon):
       error = np.abs(counts - mean)
       self.assertLess(error.max(), 5 * std)
 
+  # Check that minval = maxval is fine iff we're producing no numbers
+  def testUniformIntsDegenerate(self):
+    for dt in dtypes.int32, dtypes.int64:
+      def sample(n):
+        return self._Sampler(n, minv=0, maxv=0, dtype=dt, use_gpu=True)()
+      self.assertEqual(sample(0).shape, (10, 0))
+      with self.assertRaisesOpError('Need minval < maxval, got 0 >= 0'):
+        sample(1)
+
   # Checks that the CPU and GPU implementation returns the same results,
   # given the same random seed
   def testCPUGPUMatch(self):


### PR DESCRIPTION
For integers, `tf.random_uniform` enforces a nonempty range with `minval < maxval`.  However, an empty range is fine if we're producing no output values, and this degenerate case occurs naturally for some code patterns.

Thus, `tf.random_uniform` now allows empty ranges for integer random numbers if the output shape is empty.