### PR TITLE
Fix np.float -> np.floating change

### DIFF
--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -1655,7 +1655,7 @@ class TensorFlowTestCase(googletest.TestCase):
         if any of the elements do not fall in the specified range.
     """
     target = self._GetNdArray(target)
-    if not (np.issubdtype(target.dtype, np.float) or
+    if not (np.issubdtype(target.dtype, np.floating) or
             np.issubdtype(target.dtype, np.integer)):
       raise AssertionError(
           "The value of %s does not have an ordered numeric type, instead it "


### PR DESCRIPTION
While running core_rnn_cell_test:
```
bazel test -s --verbose_failures --config=opt //tensorflow/contrib/rnn:core_rnn_cell_test
```
Noticed the following warning:
```
FutureWarning: Conversion of the second argument of issubdtype from
`float` to `np.floating` is deprecated. In future, it will be treated
as `np.float64 == np.dtype(float).type`.
```

This fix fixes the above warning.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>