### PR TITLE
Fix Windows GPU Build failure caused by nccl

### DIFF
--- a/tensorflow/contrib/nccl/BUILD
+++ b/tensorflow/contrib/nccl/BUILD
@@ -27,10 +27,10 @@ tf_custom_op_library(
         "ops/nccl_ops.cc",
     ],
     gpu_srcs = if_not_windows_cuda([
-        "kernels/nccl_rewrite.cc",
         "kernels/nccl_manager.cc",
         "kernels/nccl_manager.h",
         "kernels/nccl_ops.cc",
+        "kernels/nccl_rewrite.cc",
     ]),
     deps = [] + if_cuda([
         "@local_config_nccl//:nccl",

--- a/tensorflow/contrib/nccl/BUILD
+++ b/tensorflow/contrib/nccl/BUILD
@@ -25,8 +25,9 @@ tf_custom_op_library(
     name = "python/ops/_nccl_ops.so",
     srcs = [
         "ops/nccl_ops.cc",
-    ] + if_cuda(["kernels/nccl_rewrite.cc"]),
+    ],
     gpu_srcs = if_not_windows_cuda([
+        "kernels/nccl_rewrite.cc",
         "kernels/nccl_manager.cc",
         "kernels/nccl_manager.h",
         "kernels/nccl_ops.cc",


### PR DESCRIPTION
This fix is an attempt to fix Window GPU build which was broken:
https://source.cloud.google.com/results/invocations/18ee81e7-f798-4ecc-9926-046d82993d80/log


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>