### PR TITLE
Update BAZEL_VERSION to 0.17.1

### DIFF
--- a/tensorflow/tools/ci_build/install/install_bazel.sh
+++ b/tensorflow/tools/ci_build/install/install_bazel.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 # Select bazel version.
-BAZEL_VERSION="0.15.0"
+BAZEL_VERSION="0.17.1"
 
 set +e
 local_bazel_ver=$(bazel version 2>&1 | grep -i label | awk '{print $3}')

--- a/tensorflow/tools/ci_build/install/install_bazel_from_source.sh
+++ b/tensorflow/tools/ci_build/install/install_bazel_from_source.sh
@@ -18,7 +18,7 @@
 # It will compile bazel from source and install it in /usr/local/bin
 
 # Select bazel version.
-BAZEL_VERSION="0.15.0"
+BAZEL_VERSION="0.17.1"
 
 set +e
 local_bazel_ver=$(bazel version 2>&1 | grep -i label | awk '{print $3}')


### PR DESCRIPTION
This fix tries to update BAZEL_VERSION from previous 0.15.0 to 0.17.1. The reason for the update was that PR #19461 depends on a Bazel issue https://github.com/bazelbuild/bazel/issues/5932 which has only been fixed in 0.17.1.

This fix updates the BAZEL_VERSION so that test builds could succeed for #19461.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>