### PR TITLE
[Intel MKL] Fixes for unit test failures

### DIFF
--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -277,6 +277,9 @@ class MklCPUAllocator : public VisitableAllocator {
     // max_alloc_size from large_size_allocator would be the maximum
     // size allocated by MklCPUAllocator.
     stats->max_alloc_size = l_stats.max_alloc_size;
+
+    stats->bytes_limit =
+        std::max(s_stats.bytes_limit, l_stats.bytes_limit);
   }
 
   void ClearStats() override {

--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -277,9 +277,7 @@ class MklCPUAllocator : public VisitableAllocator {
     // max_alloc_size from large_size_allocator would be the maximum
     // size allocated by MklCPUAllocator.
     stats->max_alloc_size = l_stats.max_alloc_size;
-
-    stats->bytes_limit =
-        std::max(s_stats.bytes_limit, l_stats.bytes_limit);
+    stats->bytes_limit = std::max(s_stats.bytes_limit, l_stats.bytes_limit);
   }
 
   void ClearStats() override {

--- a/tensorflow/core/kernels/partitioned_function_ops.cc
+++ b/tensorflow/core/kernels/partitioned_function_ops.cc
@@ -102,7 +102,8 @@ class PartitionedCallOp : public AsyncOpKernel {
         // by name.
         auto graph = tensorflow::MakeUnique<Graph>(fbody->graph->flib_def());
         FunctionLibraryDefinition global_flib(OpRegistry::Global(), {});
-        graph.get()->AddFunctionLibrary(global_flib.ToProto());
+        TF_CHECK_OK(
+                    graph.get()->AddFunctionLibrary(global_flib.ToProto()));
         CopyGraph(*fbody->graph, graph.get());
         OP_REQUIRES_OK_ASYNC(ctx, PinResourceArgs(graph.get(), args), done);
 
@@ -258,7 +259,8 @@ class PartitionedCallOp : public AsyncOpKernel {
     for (const auto& partition : partitions) {
       std::unique_ptr<Graph> subgraph(new Graph(graph->flib_def()));
       FunctionLibraryDefinition global_flib(OpRegistry::Global(), {});
-      subgraph.get()->AddFunctionLibrary(global_flib.ToProto());
+      TF_CHECK_OK(
+                subgraph.get()->AddFunctionLibrary(global_flib.ToProto()));
       GraphConstructorOptions opts;
       opts.allow_internal_ops = true;
       opts.expect_device_spec = true;

--- a/tensorflow/core/kernels/partitioned_function_ops.cc
+++ b/tensorflow/core/kernels/partitioned_function_ops.cc
@@ -97,7 +97,12 @@ class PartitionedCallOp : public AsyncOpKernel {
         OP_REQUIRES_ASYNC(ctx, fbody != nullptr,
                           errors::Internal("Could not find handle ", handle),
                           done);
-        auto graph = tensorflow::MakeUnique<Graph>(fbody->graph->flib_def());
+        // We need to pass global op_registry as default_registry when creating
+        // graph. So that graph optimization passes can lookup all possible ops
+        // by name.
+        FunctionLibraryDefinition func_lib_def(OpRegistry::Global(),
+                                            fbody->graph->flib_def().ToProto());
+        auto graph = tensorflow::MakeUnique<Graph>(func_lib_def);
         CopyGraph(*fbody->graph, graph.get());
         OP_REQUIRES_OK_ASYNC(ctx, PinResourceArgs(graph.get(), args), done);
 
@@ -250,9 +255,10 @@ class PartitionedCallOp : public AsyncOpKernel {
     VLOG(3) << "Partitioned function '" << func_.name() << "', yielding "
             << partitions.size() << " shards.";
 
-    const FunctionLibraryDefinition* flib_def = &graph->flib_def();
+    FunctionLibraryDefinition func_lib_def(OpRegistry::Global(),
+                                          graph->flib_def().ToProto());
     for (const auto& partition : partitions) {
-      std::unique_ptr<Graph> subgraph(new Graph(flib_def));
+      std::unique_ptr<Graph> subgraph(new Graph(func_lib_def));
       GraphConstructorOptions opts;
       opts.allow_internal_ops = true;
       opts.expect_device_spec = true;

--- a/tensorflow/core/kernels/partitioned_function_ops.cc
+++ b/tensorflow/core/kernels/partitioned_function_ops.cc
@@ -100,8 +100,8 @@ class PartitionedCallOp : public AsyncOpKernel {
         // We need to pass global op_registry as default_registry when creating
         // graph. So that graph optimization passes can lookup all possible ops
         // by name.
-        FunctionLibraryDefinition func_lib_def(OpRegistry::Global(),
-                                            fbody->graph->flib_def().ToProto());
+        FunctionLibraryDefinition func_lib_def(
+            OpRegistry::Global(), fbody->graph->flib_def().ToProto());
         auto graph = tensorflow::MakeUnique<Graph>(func_lib_def);
         CopyGraph(*fbody->graph, graph.get());
         OP_REQUIRES_OK_ASYNC(ctx, PinResourceArgs(graph.get(), args), done);
@@ -256,7 +256,7 @@ class PartitionedCallOp : public AsyncOpKernel {
             << partitions.size() << " shards.";
 
     FunctionLibraryDefinition func_lib_def(OpRegistry::Global(),
-                                          graph->flib_def().ToProto());
+                                           graph->flib_def().ToProto());
     for (const auto& partition : partitions) {
       std::unique_ptr<Graph> subgraph(new Graph(func_lib_def));
       GraphConstructorOptions opts;


### PR DESCRIPTION
1) Changes in partitioned_function_ops.cc are for passing
   Global OpRegistry as default_registry in PartitionedFunction op

   This fix addresses failure in MKL layout pass when PartitionedFunction
   op calls graph optimization passes. The problem was that the function
   library definition that is used to create function graph and corresponding
   subgraphs after partitioning did not use global OpRegistry as the
   default OpRegistry used for look of operator names. Because of that,
   standard operators such as "Const" were not available to graph passes.

2) Changes in mkl_cpu_allocator.h are to address failure in
   mkl_cpu_allocator_test which was expecting that max_bytes_limits is returned
   via GetStats() in MKLCPUAllocator.