### PR TITLE
Raise warning once only if trainable_weights and _collected_trainable_weights are inconsistent

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -677,9 +677,9 @@ class Model(Network):
 
     if len(self.trainable_weights) != len(self._collected_trainable_weights):
       logging.log_first_n(logging.WARN,
-                          'Discrepancy between trainable weights and collected trainable'
-                          ' weights, did you set `model.trainable` without calling'
-                          ' `model.compile` after ?', 1)
+                          'Discrepancy between trainable weights and collected'
+                          ' trainable weights, did you set `model.trainable`'
+                          ' without calling `model.compile` after ?', 1)
 
   def _make_train_function(self):
     if not hasattr(self, 'train_function'):

--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -676,11 +676,10 @@ class Model(Network):
       return
 
     if len(self.trainable_weights) != len(self._collected_trainable_weights):
-      logging.warning(
-          UserWarning(
-              'Discrepancy between trainable weights and collected trainable'
-              ' weights, did you set `model.trainable` without calling'
-              ' `model.compile` after ?'))
+      logging.log_first_n(logging.WARN,
+                          'Discrepancy between trainable weights and collected trainable'
+                          ' weights, did you set `model.trainable` without calling'
+                          ' `model.compile` after ?', 1)
 
   def _make_train_function(self):
     if not hasattr(self, 'train_function'):


### PR DESCRIPTION
Fix #22012
If ```trainable_weights``` and ```_collected_trainable_weights``` are inconsistent, raise warning only once, not every batch(```train_on_batch```) which would flood the screen. ```train_on_batch``` inside loop is not efficient as each batch would rebuild the ```train_function```, but it's the most simple way to train model like GAN in #22012 . This may not a perfect fix, but at least, don't flood my screen. The updated behavior would be the same as ```keras-team/keras```.