### PR TITLE
[lite]revised a parameter error

### DIFF
--- a/tensorflow/contrib/lite/tutorials/post_training_quant.ipynb
+++ b/tensorflow/contrib/lite/tutorials/post_training_quant.ipynb
@@ -542,7 +542,7 @@
       },
       "outputs": [],
       "source": [
-        "print(eval_model(interpreter_quant, mnist_ds))"
+        "print(eval_model(interpreter, mnist_ds))"
       ]
     },
     {


### PR DESCRIPTION
Hi @MarkDaoust , i found that when firstly use `interpreter `as a parameter pass into `eval_model` function, pass `interpreter_quant` two times to `eval_model` may be make some people confused.