### PR TITLE
[keras] fix: ReLU had dict argument when load model from ckeck point file

### DIFF
--- a/tensorflow/python/keras/layers/advanced_activations.py
+++ b/tensorflow/python/keras/layers/advanced_activations.py
@@ -306,6 +306,13 @@ class ReLU(Layer):
 
   def __init__(self, max_value=None, negative_slope=0, threshold=0, **kwargs):
     super(ReLU, self).__init__(**kwargs)
+    if isinstance(max_value, dict):
+      max_value = max_value['value']
+    if isinstance(negative_slope, dict):
+      negative_slope = negative_slope['value']
+    if isinstance(threshold, dict):
+      threshold = threshold['value']
+          
     if max_value is not None and max_value < 0.:
       raise ValueError('max_value of Relu layer '
                        'cannot be negative value: ' + str(max_value))


### PR DESCRIPTION
ReLU had dict argument when load model from ckeck point file

When keras model had tf.keras.layers.ReLU layer and load the model from file, the arguments of ReLU layer had type dict. The dict argument make trouble when they are cast to float.

What i added is the code to change the dict to number.
I thinks this is a kind of hot fix.. maybe someone can fix the module for save or load keras model.
so. there is no fundamental different between the type of inputs.

I refered to this issue:
keras-team/keras#7107


