### PR TITLE
Fix Embedding layer to check invalid inputs

### DIFF
--- a/tensorflow/python/keras/layers/embeddings.py
+++ b/tensorflow/python/keras/layers/embeddings.py
@@ -158,19 +158,36 @@ class Embedding(Layer):
         in_lens = list(self.input_length)
       else:
         in_lens = [self.input_length]
-      if len(in_lens) != len(input_shape) - 1:
-        raise ValueError('"input_length" is %s, '
-                         'but received input has shape %s' % (str(
-                             self.input_length), str(input_shape)))
+
+      for i, (s1, s2) in enumerate(zip(in_lens, input_shape[1:])):
+        if s1 is None:
+          in_lens[i] = s2
+
+      return (input_shape[0],) + tuple(in_lens) + (self.output_dim,)
+
+  def _assert_input_compatibility(self, inputs):
+    super(Embedding, self)._assert_input_compatibility(inputs)
+    if self.input_length is not None:
+      if isinstance(inputs, list):
+        input = inputs[0]
+      else:
+        input = inputs
+      input_shape = input.shape
+      # input_length can be tuple if input is 3D or higher
+      if isinstance(self.input_length, (list, tuple)):
+        in_lens = list(self.input_length)
+      else:
+        in_lens = [self.input_length]
+
+      if len(in_lens) != input_shape.ndims - 1:
+        raise ValueError('"input_length" is %s, but received input has shape '
+                         '%s' % (str(self.input_length), str(input_shape)))
       else:
         for i, (s1, s2) in enumerate(zip(in_lens, input_shape[1:])):
           if s1 is not None and s2 is not None and s1 != s2:
-            raise ValueError('"input_length" is %s, '
-                             'but received input has shape %s' % (str(
-                                 self.input_length), str(input_shape)))
-          elif s1 is None:
-            in_lens[i] = s2
-      return (input_shape[0],) + tuple(in_lens) + (self.output_dim,)
+            raise ValueError('"input_length" is %s, but received input has '
+                             'shape %s' % (str(self.input_length),
+                                           str(input_shape)))
 
   def call(self, inputs):
     dtype = K.dtype(inputs)

--- a/tensorflow/python/keras/layers/embeddings.py
+++ b/tensorflow/python/keras/layers/embeddings.py
@@ -168,11 +168,11 @@ class Embedding(Layer):
   def _assert_input_compatibility(self, inputs):
     super(Embedding, self)._assert_input_compatibility(inputs)
     if self.input_length is not None:
-      if isinstance(inputs, list):
-        input = inputs[0]
+      if isinstance(inputs, (list, tuple)):
+        x = list(inputs)[0]
       else:
-        input = inputs
-      input_shape = input.shape
+        x = inputs
+      input_shape = x.shape
       # input_length can be tuple if input is 3D or higher
       if isinstance(self.input_length, (list, tuple)):
         in_lens = list(self.input_length)

--- a/tensorflow/python/keras/layers/embeddings_test.py
+++ b/tensorflow/python/keras/layers/embeddings_test.py
@@ -95,7 +95,9 @@ class EmbeddingTest(test.TestCase):
   @tf_test_util.run_in_graph_and_eager_modes(use_gpu=False)
   def test_embedding_invalid(self):
     # len(input_length) should be equal to len(input_shape) - 1
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegexp(
+        ValueError,
+        '"input_length" is 2, but received input has shape \(\?, 3, 4, 5\)'):
       model = keras.Sequential([keras.layers.Embedding(
           input_dim=10,
           output_dim=4,
@@ -103,7 +105,9 @@ class EmbeddingTest(test.TestCase):
           input_shape=(3, 4, 5))])
 
     # input_length should be equal to input_shape[1:]
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegexp(
+        ValueError,
+        '"input_length" is 2, but received input has shape \(\?, 3, 5\)'):
       model = keras.Sequential([keras.layers.Embedding(
           input_dim=10,
           output_dim=4,

--- a/tensorflow/python/keras/layers/embeddings_test.py
+++ b/tensorflow/python/keras/layers/embeddings_test.py
@@ -92,5 +92,23 @@ class EmbeddingTest(test.TestCase):
     opt.apply_gradients(zip(gs, l.weights))
     self.assertAllEqual(len(gs), 1)
 
+  @tf_test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def test_embedding_invalid(self):
+    # len(input_length) should be equal to len(input_shape) - 1
+    with self.assertRaises(ValueError):
+      model = keras.Sequential([keras.layers.Embedding(
+          input_dim=10,
+          output_dim=4,
+          input_length=2,
+          input_shape=(3, 4, 5))])
+
+    # input_length should be equal to input_shape[1:]
+    with self.assertRaises(ValueError):
+      model = keras.Sequential([keras.layers.Embedding(
+          input_dim=10,
+          output_dim=4,
+          input_length=2,
+          input_shape=(3, 5))])
+
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Bug: If users set ```input_length``` for ```Embedding``` layer incorrectly, it should throw exception(existing not). Otherwise, the downstream layers compute shape incorrect and throw confused exception.
I have fixed this at https://github.com/keras-team/keras/pull/11091, but it's different from ```tf.keras```. ```keras-team/keras``` makes this check in ```compute_output_shape``` which was executed always. But ```tf.keras``` only calls ```compute_output_shape``` in deferred mode, so we need to move this check to other place. Actually it makes more sense to move it to ```_assert_input_compatibility``` which is used to check the inputs legal, and would be run in all mode.
