### PR TITLE
Accepts `PathLike` objects for dataset readers

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3801,16 +3801,11 @@ tf_py_test(
     name = "compat_test",
     size = "small",
     srcs = ["util/compat_test.py"],
-    main = "util/compat_test.py",
     srcs_version = "PY2AND3",
     deps = [
-        ":array_ops",
         ":client_testlib",
-        ":framework",
-        ":framework_for_generated_wrappers",
-        ":math_ops",
-        ":util",
-        "//third_party/py/numpy"
+        ":array_ops",
+        ":util"
     ]
 )
 

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3801,8 +3801,7 @@ tf_py_test(
     name = "compat_test",
     size = "small",
     srcs = ["util/compat_test.py"],
-    srcs_version = "PY2AND3",
-    deps = [
+    additional_deps = [
         ":client_testlib",
         ":array_ops",
         ":util",

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3805,8 +3805,8 @@ tf_py_test(
     deps = [
         ":client_testlib",
         ":array_ops",
-        ":util"
-    ]
+        ":util",
+    ],
 )
 
 tf_py_test(

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3798,6 +3798,23 @@ tf_py_test(
 )
 
 tf_py_test(
+    name = "compat_test",
+    size = "small",
+    srcs = ["util/compat_test.py"],
+    main = "util/compat_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":array_ops",
+        ":client_testlib",
+        ":framework",
+        ":framework_for_generated_wrappers",
+        ":math_ops",
+        ":util",
+        "//third_party/py/numpy"
+    ]
+)
+
+tf_py_test(
     name = "future_api_test",
     size = "small",
     srcs = ["util/future_api_test.py"],

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -43,7 +43,8 @@ class TextLineDatasetV2(dataset_ops.DatasetSource):
     """Creates a `TextLineDataset`.
 
     Args:
-      filenames: A `tf.string` tensor containing one or more filenames or `PathLike` objects.
+      filenames: A `tf.string` tensor containing one or more filenames
+        or `PathLike` objects.
       compression_type: (Optional.) A `tf.string` scalar evaluating to one of
         `""` (no compression), `"ZLIB"`, or `"GZIP"`.
       buffer_size: (Optional.) A `tf.int64` scalar denoting the number of bytes
@@ -94,7 +95,8 @@ class _TFRecordDataset(dataset_ops.DatasetSource):
     """Creates a `TFRecordDataset`.
 
     Args:
-      filenames: A `tf.string` tensor containing one or more filenames or `PathLike` objects.
+      filenames: A `tf.string` tensor containing one or more filenames
+        or `PathLike` objects.
       compression_type: (Optional.) A `tf.string` scalar evaluating to one of
         `""` (no compression), `"ZLIB"`, or `"GZIP"`.
       buffer_size: (Optional.) A `tf.int64` scalar representing the number of
@@ -294,7 +296,8 @@ class FixedLengthRecordDatasetV2(dataset_ops.DatasetSource):
     """Creates a `FixedLengthRecordDataset`.
 
     Args:
-      filenames: A `tf.string` tensor containing one or more filenames or `PathLike` objects.
+      filenames: A `tf.string` tensor containing one or more filenames
+        or `PathLike` objects.
       record_bytes: A `tf.int64` scalar representing the number of bytes in
         each record.
       header_bytes: (Optional.) A `tf.int64` scalar representing the number of

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 from tensorflow.python.compat import compat
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.util import compat
 from tensorflow.python.data.util import convert
 from tensorflow.python.data.util import structure
 from tensorflow.python.framework import dtypes
@@ -42,13 +43,14 @@ class TextLineDatasetV2(dataset_ops.DatasetSource):
     """Creates a `TextLineDataset`.
 
     Args:
-      filenames: A `tf.string` tensor containing one or more filenames.
+      filenames: A `tf.string` tensor containing one or more filenames or `PathLike` objects.
       compression_type: (Optional.) A `tf.string` scalar evaluating to one of
         `""` (no compression), `"ZLIB"`, or `"GZIP"`.
       buffer_size: (Optional.) A `tf.int64` scalar denoting the number of bytes
         to buffer. A value of 0 results in the default buffering values chosen
         based on the compression type.
     """
+    filenames = compat.path_to_str(filenames)
     self._filenames = ops.convert_to_tensor(
         filenames, dtype=dtypes.string, name="filenames")
     self._compression_type = convert.optional_param_to_tensor(
@@ -92,13 +94,14 @@ class _TFRecordDataset(dataset_ops.DatasetSource):
     """Creates a `TFRecordDataset`.
 
     Args:
-      filenames: A `tf.string` tensor containing one or more filenames.
+      filenames: A `tf.string` tensor containing one or more filenames or `PathLike` objects.
       compression_type: (Optional.) A `tf.string` scalar evaluating to one of
         `""` (no compression), `"ZLIB"`, or `"GZIP"`.
       buffer_size: (Optional.) A `tf.int64` scalar representing the number of
         bytes in the read buffer. 0 means no buffering.
     """
     # Force the type to string even if filenames is an empty list.
+    filenames = compat.path_to_str(filenames)
     self._filenames = ops.convert_to_tensor(
         filenames, dtypes.string, name="filenames")
     self._compression_type = convert.optional_param_to_tensor(
@@ -291,7 +294,7 @@ class FixedLengthRecordDatasetV2(dataset_ops.DatasetSource):
     """Creates a `FixedLengthRecordDataset`.
 
     Args:
-      filenames: A `tf.string` tensor containing one or more filenames.
+      filenames: A `tf.string` tensor containing one or more filenames or `PathLike` objects.
       record_bytes: A `tf.int64` scalar representing the number of bytes in
         each record.
       header_bytes: (Optional.) A `tf.int64` scalar representing the number of
@@ -303,6 +306,7 @@ class FixedLengthRecordDatasetV2(dataset_ops.DatasetSource):
       compression_type: (Optional.) A `tf.string` scalar evaluating to one of
         `""` (no compression), `"ZLIB"`, or `"GZIP"`.
     """
+    filenames = compat.path_to_str(filenames)
     self._filenames = ops.convert_to_tensor(
         filenames, dtype=dtypes.string, name="filenames")
     self._record_bytes = ops.convert_to_tensor(

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -35,9 +35,13 @@ import numbers as _numbers
 
 import numpy as _np
 import six as _six
+try:
+  from collections.abc import Iterable as _Iterable
+except ImportError:
+  from collections import Iterable as _Iterable
 
 from tensorflow.python.util.tf_export import tf_export
-
+from tensorflow.python.framework import ops
 
 def as_bytes(bytes_or_text, encoding='utf-8'):
   """Converts either bytes or unicode to `bytes`, using utf-8 encoding for text.
@@ -114,12 +118,14 @@ def path_to_str(path):
   """Returns the file system path representation of a `PathLike` object, else as it is.
 
   Args:
-    path: An object that can be converted to path representation.
+    path: One or more objects that can be converted to path representation.
 
   Returns:
-    A `str` object.
+    One or more `str` object.
   """
-  if hasattr(path, '__fspath__'):
+  if isinstance(path, _Iterable) and not isinstance(path, (str, bytes, bytearray, ops.Tensor)):
+    path = [path_to_str(p) for p in path]
+  elif hasattr(path, '__fspath__'):
     path = as_str_any(path.__fspath__())
   return path
 

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -41,7 +41,6 @@ except ImportError:
   from collections import Iterable as _Iterable
 
 from tensorflow.python.util.tf_export import tf_export
-from tensorflow.python.framework import ops
 
 def as_bytes(bytes_or_text, encoding='utf-8'):
   """Converts either bytes or unicode to `bytes`, using utf-8 encoding for text.
@@ -125,7 +124,8 @@ def path_to_str(path):
     If `path` is a `PathLike` object, then the return value is one or more `str` objects.
     Otherwise `path` is returned unchanged
   """
-  if isinstance(path, _Iterable) and not isinstance(path, (str, bytes, bytearray, ops.Tensor)):
+  from tensorflow.python.framework.ops import _TensorLike
+  if isinstance(path, _Iterable) and not isinstance(path, (str, bytes, bytearray, _TensorLike)):
     path = [path_to_str(p) for p in path]
   elif hasattr(path, '__fspath__'):
     path = as_str_any(path.__fspath__())

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -114,18 +114,20 @@ def as_str_any(value):
 
 @tf_export('compat.path_to_str')
 def path_to_str(path):
-  """Returns the file system path representation of one or more `PathLike` objects, otherwise 
-  `path` is passed through unchanged.
+  """Returns the file system path representation of one or more `PathLike`
+  objects, otherwise `path` is passed through unchanged.
 
   Args:
-    path: One or more objects to be conditionally converted to path representation.
+    path: One or more objects to be conditionally converted to
+      path representation.
 
   Returns:
-    If `path` is a `PathLike` object, then the return value is one or more `str` objects.
-    Otherwise `path` is returned unchanged
+    If `path` is a `PathLike` object, then the return value is one
+    or more `str` objects. Otherwise `path` is returned unchanged
   """
   from tensorflow.python.framework.ops import _TensorLike
-  if isinstance(path, _Iterable) and not isinstance(path, (str, bytes, bytearray, _TensorLike)):
+  if (isinstance(path, _Iterable) and
+      not isinstance(path, (str, bytes, bytearray, _TensorLike))):
     path = [path_to_str(p) for p in path]
   elif hasattr(path, '__fspath__'):
     path = as_str_any(path.__fspath__())

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -115,13 +115,15 @@ def as_str_any(value):
 
 @tf_export('compat.path_to_str')
 def path_to_str(path):
-  """Returns the file system path representation of a `PathLike` object, else as it is.
+  """Returns the file system path representation of one or more `PathLike` objects, otherwise 
+  `path` is passed through unchanged.
 
   Args:
-    path: One or more objects that can be converted to path representation.
+    path: One or more objects to be conditionally converted to path representation.
 
   Returns:
-    One or more `str` object.
+    If `path` is a `PathLike` object, then the return value is one or more `str` objects.
+    Otherwise `path` is returned unchanged
   """
   if isinstance(path, _Iterable) and not isinstance(path, (str, bytes, bytearray, ops.Tensor)):
     path = [path_to_str(p) for p in path]

--- a/tensorflow/python/util/compat_test.py
+++ b/tensorflow/python/util/compat_test.py
@@ -1,0 +1,79 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for compat."""
+
+# pylint: disable=unused-import
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    from pathlib import Path
+except ImportError:
+    Path = None
+
+try:
+  from collections.abc import Iterable as _Iterable
+except ImportError:
+  from collections import Iterable as _Iterable
+
+import inspect
+
+from tensorflow.python.platform import test
+from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.util import compat
+from tensorflow.python.ops import array_ops
+from tensorflow.python import dtypes
+
+class CompatPathToStrTest(test.TestCase):
+
+    def testTransformsPathlibPath(self):
+        if Path is None:
+            return # Skip test if pathlib not available.
+        
+        path_input = Path('/tmp/folder')
+        transformed = compat.path_to_str(path_input)
+
+        self.assertTrue(isinstance(transformed, str))
+        self.assertEqual('/tmp/folder', transformed)
+
+    def testTransformsIterablePathlibPath(self):
+        if Path is None:
+            return # Skip test if pathlib not available.
+        
+        path_input = [Path('/tmp/folder'), Path('/tmp/folder2')]
+        transformed = compat.path_to_str(path_input)
+
+        self.assertEqual(['/tmp/folder', '/tmp/folder2'], transformed)
+
+    def testReturnsStrUnchanged(self):
+        str_input = '/tmp/folder'
+
+        transformed = compat.path_to_str(str_input)
+        self.assertEqual(str_input, transformed)
+
+    def testTransformsIterableStrUnchanged(self):   
+        str_input = ['/tmp/folder', '/tmp/folder2']
+        transformed = compat.path_to_str(str_input)
+
+        self.assertEqual(['/tmp/folder', '/tmp/folder2'], transformed)
+
+    def testReturnsTensorUnchanged(self):
+        tensor_input = array_ops.constant('/tmp/folder/', dtype=dtypes.string)
+
+        transformed = compat.path_to_str(tensor_input)
+        self.assertEqual(tensor_input, transformed)
+
+    

--- a/tensorflow/python/util/compat_test.py
+++ b/tensorflow/python/util/compat_test.py
@@ -35,7 +35,6 @@ from tensorflow.python.platform import test
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import compat
 from tensorflow.python.ops import array_ops
-from tensorflow.python import dtypes
 
 class CompatPathToStrTest(test.TestCase):
 
@@ -71,7 +70,7 @@ class CompatPathToStrTest(test.TestCase):
         self.assertEqual(['/tmp/folder', '/tmp/folder2'], transformed)
 
     def testReturnsTensorUnchanged(self):
-        tensor_input = array_ops.constant('/tmp/folder/', dtype=dtypes.string)
+        tensor_input = array_ops.constant('/tmp/folder/')
 
         transformed = compat.path_to_str(tensor_input)
         self.assertEqual(tensor_input, transformed)

--- a/tensorflow/python/util/compat_test.py
+++ b/tensorflow/python/util/compat_test.py
@@ -24,15 +24,7 @@ try:
 except ImportError:
   Path = None
 
-try:
-  from collections.abc import Iterable as _Iterable
-except ImportError:
-  from collections import Iterable as _Iterable
-
-import inspect
-
 from tensorflow.python.platform import test
-from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import compat
 from tensorflow.python.ops import array_ops
 

--- a/tensorflow/python/util/compat_test.py
+++ b/tensorflow/python/util/compat_test.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class CompatPathToStrTest(test.TestCase):
 
   def test_transforms_pathlib_path(self):
     if Path is None:
-      return # Skip test if pathlib not available.
+      self.skipTest("Test requires Python 3.6 or greater.")
 
     path_input = Path('/tmp/folder')
     transformed = compat.path_to_str(path_input)
@@ -51,7 +51,7 @@ class CompatPathToStrTest(test.TestCase):
 
   def test_transforms_iterable_pathlib_path(self):
     if Path is None:
-      return # Skip test if pathlib not available.
+      self.skipTest("Test requires Python 3.6 or greater.")
 
     path_input = [Path('/tmp/folder'), Path('/tmp/folder2')]
     transformed = compat.path_to_str(path_input)

--- a/tensorflow/python/util/compat_test.py
+++ b/tensorflow/python/util/compat_test.py
@@ -75,4 +75,3 @@ class CompatPathToStrTest(test.TestCase):
         transformed = compat.path_to_str(tensor_input)
         self.assertEqual(tensor_input, transformed)
 
-    

--- a/tensorflow/python/util/compat_test.py
+++ b/tensorflow/python/util/compat_test.py
@@ -20,9 +20,9 @@ from __future__ import division
 from __future__ import print_function
 
 try:
-    from pathlib import Path
+  from pathlib import Path
 except ImportError:
-    Path = None
+  Path = None
 
 try:
   from collections.abc import Iterable as _Iterable
@@ -37,41 +37,41 @@ from tensorflow.python.util import compat
 from tensorflow.python.ops import array_ops
 
 class CompatPathToStrTest(test.TestCase):
+  """Tests for compat path to string utilities"""
 
-    def testTransformsPathlibPath(self):
-        if Path is None:
-            return # Skip test if pathlib not available.
-        
-        path_input = Path('/tmp/folder')
-        transformed = compat.path_to_str(path_input)
+  def test_transforms_pathlib_path(self):
+    if Path is None:
+      return # Skip test if pathlib not available.
 
-        self.assertTrue(isinstance(transformed, str))
-        self.assertEqual('/tmp/folder', transformed)
+    path_input = Path('/tmp/folder')
+    transformed = compat.path_to_str(path_input)
 
-    def testTransformsIterablePathlibPath(self):
-        if Path is None:
-            return # Skip test if pathlib not available.
-        
-        path_input = [Path('/tmp/folder'), Path('/tmp/folder2')]
-        transformed = compat.path_to_str(path_input)
+    self.assertTrue(isinstance(transformed, str))
+    self.assertEqual('/tmp/folder', transformed)
 
-        self.assertEqual(['/tmp/folder', '/tmp/folder2'], transformed)
+  def test_transforms_iterable_pathlib_path(self):
+    if Path is None:
+      return # Skip test if pathlib not available.
 
-    def testReturnsStrUnchanged(self):
-        str_input = '/tmp/folder'
+    path_input = [Path('/tmp/folder'), Path('/tmp/folder2')]
+    transformed = compat.path_to_str(path_input)
 
-        transformed = compat.path_to_str(str_input)
-        self.assertEqual(str_input, transformed)
+    self.assertEqual(['/tmp/folder', '/tmp/folder2'], transformed)
 
-    def testTransformsIterableStrUnchanged(self):   
-        str_input = ['/tmp/folder', '/tmp/folder2']
-        transformed = compat.path_to_str(str_input)
+  def test_returns_str_unchanged(self):
+    str_input = '/tmp/folder'
 
-        self.assertEqual(['/tmp/folder', '/tmp/folder2'], transformed)
+    transformed = compat.path_to_str(str_input)
+    self.assertEqual(str_input, transformed)
 
-    def testReturnsTensorUnchanged(self):
-        tensor_input = array_ops.constant('/tmp/folder/')
+  def test_transforms_iterable_str_unchanged(self):
+    str_input = ['/tmp/folder', '/tmp/folder2']
+    transformed = compat.path_to_str(str_input)
 
-        transformed = compat.path_to_str(tensor_input)
-        self.assertEqual(tensor_input, transformed)
+    self.assertEqual(['/tmp/folder', '/tmp/folder2'], transformed)
 
+  def test_returns_tensor_unchanged(self):
+    tensor_input = array_ops.constant('/tmp/folder/')
+
+    transformed = compat.path_to_str(tensor_input)
+    self.assertEqual(tensor_input, transformed)


### PR DESCRIPTION
Continuation from #17465
* Dataset operations convert `PathLike` objects to string
* `compat.path_to_str` now accepts one or more objects to convert
* Unit tests

Further work to #15784 to allow `PathLike` objects to be passed to Dataset readers as well. 