### PR TITLE
[tf.data] Make `tf.contrib.data.reduce_dataset` work when the internal state is a tuple

### DIFF
--- a/tensorflow/contrib/data/python/kernel_tests/get_single_element_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/get_single_element_test.py
@@ -121,9 +121,9 @@ class GetSingleElementTest(test.TestCase, parameterized.TestCase):
     with self.cached_session() as sess:
       value = sess.run(element, feed_dict={stop_t: stop})
       if stop == 0:
-          self.assertEqual(0.0, value)
+        self.assertEqual(0.0, value)
       else:
-          self.assertEqual(stop * (stop - 1) / (2 * stop), value)
+        self.assertEqual(stop * (stop - 1) / (2 * stop), value)
 
 
 if __name__ == "__main__":

--- a/tensorflow/contrib/data/python/ops/get_single_element.py
+++ b/tensorflow/contrib/data/python/ops/get_single_element.py
@@ -91,8 +91,11 @@ def reduce_dataset(dataset, reducer):
     raise TypeError("`dataset` must be a `tf.data.Dataset` object.")
 
   # The sentinel dataset is used in case the reduced dataset is empty.
+  initial_state = reducer.init_func(np.int64(0))
+  if not isinstance(initial_state, tuple):
+      initial_state = (initial_state,)
   sentinel_dataset = dataset_ops.Dataset.from_tensors(
-      reducer.finalize_func(reducer.init_func(np.int64(0))))
+      reducer.finalize_func(*initial_state))
   reduced_dataset = dataset.apply(
       grouping.group_by_reducer(lambda x: np.int64(0), reducer))
 

--- a/tensorflow/contrib/data/python/ops/get_single_element.py
+++ b/tensorflow/contrib/data/python/ops/get_single_element.py
@@ -93,7 +93,7 @@ def reduce_dataset(dataset, reducer):
   # The sentinel dataset is used in case the reduced dataset is empty.
   initial_state = reducer.init_func(np.int64(0))
   if not isinstance(initial_state, tuple):
-      initial_state = (initial_state,)
+    initial_state = (initial_state,)
   sentinel_dataset = dataset_ops.Dataset.from_tensors(
       reducer.finalize_func(*initial_state))
   reduced_dataset = dataset.apply(


### PR DESCRIPTION
## Issue

One issue with the new [`tf.contrib.data.reduce_dataset`][doc] is that the internal state can only have one element.

This is because of [this line][line] in the code to create the `sentinel_dataset`:

```python
sentinel_dataset = dataset_ops.Dataset.from_tensors(
          reducer.finalize_func(reducer.init_func(np.int64(0))))
```

Usually the `finalize_func` can have multiple input arguments (as many as the number of elements in the state).

For instance if we want to compute the average over a dataset:
```python
dataset = tf.data.Dataset.range(5)

def init_fn(_):
    return 0.0, 0.0

def reduce_fn(state, value):
    average, count = state
    value = tf.cast(value, tf.float32)
    average = (average * count + value) / (count + 1)
    count = count + 1
    return average, count

def finalize_fn(average, count):
    return average

reducer = tf.contrib.data.Reducer(init_fn, reduce_fn, finalize_fn)

mean = tf.contrib.data.reduce_dataset(dataset, reducer)
```

This will return an error:
>TypeError: finalize_fn() missing 1 required positional argument: 'count'

---

## Proposed workaround

A way to pass a tuple as multiple arguments to `finalize_func` is to use `*`:

```python
initial_state = reducer.init_func(np.int64(0))
if not isinstance(initial_state, tuple):
    initial_state = (initial_state,)
sentinel_dataset = dataset_ops.Dataset.from_tensors(
        reducer.finalize_func(*initial_state))
```

where I convert the initial state to a tuple if it is not already a tuple.


## Test

I added a `testReduceDatasetAverage` which has a state with two elements.


## Comments

Let me know if this makes sense and if my workaround is correct.

It would also be great to have this in release `1.11`.





[doc]: https://www.tensorflow.org/versions/r1.11/api_docs/python/tf/contrib/data/reduce_dataset
[line]: https://github.com/tensorflow/tensorflow/blob/da3357ecbdd6772413e8bbceeab8238971be11ce/tensorflow/contrib/data/python/ops/get_single_element.py#L94-L95