### PR TITLE
Fix build failure in verbs

### DIFF
--- a/tensorflow/contrib/verbs/verbs_server_lib.cc
+++ b/tensorflow/contrib/verbs/verbs_server_lib.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #ifdef TENSORFLOW_USE_VERBS
 
-#include <mutex>
-
 #include "tensorflow/contrib/verbs/verbs_server_lib.h"
 
 #include "grpc/support/alloc.h"

--- a/tensorflow/contrib/verbs/verbs_server_lib.cc
+++ b/tensorflow/contrib/verbs/verbs_server_lib.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #ifdef TENSORFLOW_USE_VERBS
 
+#include <mutex>
+
 #include "tensorflow/contrib/verbs/verbs_server_lib.h"
 
 #include "grpc/support/alloc.h"
@@ -77,7 +79,7 @@ Status VerbsServer::ChannelCacheFactory(const ServerDef& server_def,
 }
 
 namespace {
-std::once_call reg_mem_visitors_call;
+std::once_flag reg_mem_visitors_call;
 }  // namespace
 
 Status VerbsServer::Init(ServiceInitFunction service_func,


### PR DESCRIPTION
While looking into #22372, the verbs build fails with the following error:
```
tensorflow/contrib/verbs/verbs_server_lib.cc:80:6: error: 'once_call' in namespace 'std' does not name a type
 std::once_call reg_mem_visitors_call;
      ^
tensorflow/contrib/verbs/verbs_server_lib.cc: In member function 'tensorflow::Status tensorflow::VerbsServer::Init(tensorflow::ServiceInitFunction, tensorflow::RendezvousMgrCreationFunction)':
tensorflow/contrib/verbs/verbs_server_lib.cc:85:18: error: 'reg_mem_visitors_call' was not declared in this scope
   std::call_once(reg_mem_visitors_call, []() { RdmaMgr::RegMemVisitors(); });
```

This fix fixes the build failures with `once_call` -> `once_flag`.

This fix fixes #22372.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>