### PR TITLE
cluster resolver for slurm workload manager

### DIFF
--- a/tensorflow/contrib/cluster_resolver/BUILD
+++ b/tensorflow/contrib/cluster_resolver/BUILD
@@ -30,8 +30,8 @@ py_library(
     deps = [
         ":base_cluster_resolver_py",
         ":gce_cluster_resolver_py",
-        ":tpu_cluster_resolver_py",
         ":slurm_cluster_resolver_py",
+        ":tpu_cluster_resolver_py",
         "//tensorflow/python:util",
     ],
 )

--- a/tensorflow/contrib/cluster_resolver/BUILD
+++ b/tensorflow/contrib/cluster_resolver/BUILD
@@ -31,6 +31,7 @@ py_library(
         ":base_cluster_resolver_py",
         ":gce_cluster_resolver_py",
         ":tpu_cluster_resolver_py",
+        ":slurm_cluster_resolver_py",
         "//tensorflow/python:util",
     ],
 )
@@ -57,6 +58,16 @@ py_library(
 py_library(
     name = "tpu_cluster_resolver_py",
     srcs = ["python/training/tpu_cluster_resolver.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":base_cluster_resolver_py",
+        "//tensorflow/python:training",
+    ],
+)
+
+py_library(
+    name = "slurm_cluster_resolver_py",
+    srcs = ["python/training/slurm_cluster_resolver.py"],
     srcs_version = "PY2AND3",
     deps = [
         ":base_cluster_resolver_py",
@@ -108,4 +119,20 @@ tf_py_test(
     ],
     grpc_enabled = True,
     main = "python/training/tpu_cluster_resolver_test.py",
+)
+
+tf_py_test(
+    name = "slurm_cluster_resolver_py_test",
+    size = "small",
+    srcs = ["python/training/slurm_cluster_resolver_test.py"],
+    additional_deps = [
+        ":cluster_resolver_py",
+        ":slurm_cluster_resolver_py",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:framework_test_lib",
+        "//tensorflow/python:platform_test",
+        "//tensorflow/python:training",
+    ],
+    main = "python/training/slurm_cluster_resolver_test.py",
 )

--- a/tensorflow/contrib/cluster_resolver/__init__.py
+++ b/tensorflow/contrib/cluster_resolver/__init__.py
@@ -25,6 +25,7 @@ from tensorflow.contrib.cluster_resolver.python.training.cluster_resolver import
 from tensorflow.contrib.cluster_resolver.python.training.cluster_resolver import UnionClusterResolver
 from tensorflow.contrib.cluster_resolver.python.training.gce_cluster_resolver import GceClusterResolver
 from tensorflow.contrib.cluster_resolver.python.training.tpu_cluster_resolver import TPUClusterResolver
+from tensorflow.contrib.cluster_resolver.python.training.slurm_cluster_resolver import SlurmClusterResolver
 # pylint: enable=wildcard-import,unused-import
 
 from tensorflow.python.util.all_util import remove_undocumented
@@ -35,6 +36,7 @@ _allowed_symbols = [
     'UnionClusterResolver',
     'GceClusterResolver',
     'TPUClusterResolver',
+    'SlurmClusterResolver',
 ]
 
 remove_undocumented(__name__, _allowed_symbols)

--- a/tensorflow/contrib/cluster_resolver/python/training/README.slurm
+++ b/tensorflow/contrib/cluster_resolver/python/training/README.slurm
@@ -1,0 +1,50 @@
+# Slurm Cluster Resolver
+
+The Slurm Cluster Resolver resolves cluster specification for distribution TensorFlow work launched on HPC system running on Slurm. This implementation is able to handle homogeneous task allocation on computing nodes with default task distribution plane. The resolution is done by determining job configuration through a number of Slurm output variables and user input. The resolver requires the specification of total number of tasks launched, process ID/rank of the running process, number of tasks launched per node, number of GPUs present on each node and the number of GPUs to allocate for each task.
+
+The process ID/rank is extracted from environment variable ```SLURM_PROCID``` and the total number of tasks launched is extract from ```SLURM_NTASKS```. The number of tasks per node is extracted from ```SLURM_NTASKS_PER_NODE```, unless a value is specified by user. The number of GPUs present on each node and number of GPUs for each task have to be specified by the user. A base port can be specified by user and in case there are more than one task launched per node the port number will be incremented for each additional tasks on that node. The hostnames are resolved by running command ```scontrol show hostname``` through a subprocess and a list of hostnames will be returned. The distribution of rank/process ID by default follows that order. By default allocated GPUs will be automatically exposed to processes according to specification by setting ```CUDA_VISIBLE_DEVICE```.
+
+## Example
+- Slurm allocation in shell  ```salloc --nodes=2 -t 01:30:00 -A <project ID> --ntasks-per-node=2 --gres=gpu:k80:2 --exclusive```
+- Creating cluster in Python
+```
+cluster_resolver = tf.contrib.cluster_resolver.SlurmClusterResolver(
+    {'ps': 1, 'worker': 3},
+    port_base=8888,
+    tasks_per_node=2,
+    gpus_per_node=2,
+    gpus_per_task=1,
+    auto_set_gpu=True)
+
+cluster = cluster_resolver.cluster_spec()
+job_name, task_index = cluster_resolver.get_task_info()
+```
+The above example resolves a cluster specification for a Slurm job allocation with two computing nodes each having two GPUs and two tasks will be launched on each node. The jobs are specified in form of a dictionary where the key is a string representing job name and value is an integer that specifies the number of tasks in that job. ```cluster_resolver.cluster_spec()``` will return a cluster specificaiton object and the cluster specification will have the following specification as protobuf.
+
+```
+job {
+  name: "ps"
+  tasks {
+    value: "t02n13:8888"
+  }
+}
+job {
+  name: "worker"
+  tasks {
+    value: "t02n13:8889"
+  }
+  tasks {
+    key: 1
+    value: "t02n41:8888"
+  }
+  tasks {
+    key: 2
+    value: "t02n41:8889"
+  }
+}
+```
+
+After calling ```cluster_resolver.cluster_spec()``` internal data structions of the resolver will be populated. By looking at the process ID/rank and comparing with cluster specification the task can 'realize' which task it belongs to. This can be retrieved by calling ```cluster_resolver.get_task_info()``` and a string specifying job name and an integer specifying the task index will be returned.
+
+GPUs will be automatically allocated to the processes. For example in the above example ```
+t02n41:8888``` will see GPU 0 and ```t02n41:8889``` will see GPU 1.

--- a/tensorflow/contrib/cluster_resolver/python/training/__init__.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/__init__.py
@@ -23,3 +23,4 @@ from tensorflow.contrib.cluster_resolver.python.training.cluster_resolver import
 from tensorflow.contrib.cluster_resolver.python.training.cluster_resolver import UnionClusterResolver
 from tensorflow.contrib.cluster_resolver.python.training.gce_cluster_resolver import GceClusterResolver
 from tensorflow.contrib.cluster_resolver.python.training.tpu_cluster_resolver import TPUClusterResolver
+from tensorflow.contrib.cluster_resolver.python.training.slurm_cluster_resolver import SlurmClusterResolver

--- a/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver.py
@@ -70,7 +70,7 @@ class SlurmClusterResolver(ClusterResolver):
       tasks_per_node: Number of tasks to run on each node, if not set defaults
         to Slurm's output environment variable SLURM_NTASKS_PER_NODE.
       auto_set_gpu: Set the visible CUDA devices automatically while resolving
-        the cluster by setting CUDA_VISIBLE_DEVICE environment variable.
+        the cluster by setting CUDA_VISIBLE_DEVICES environment variable.
         Defaults to True.
 
     Returns:
@@ -126,7 +126,7 @@ class SlurmClusterResolver(ClusterResolver):
     resolver extract hostnames of nodes by scontrol and pack tasks in that
     order until a node a has number of tasks that is equal to specification.
     GPUs on nodes are allocated to tasks by specification through setting
-    CUDA_VISIBLE_DEVICE environment variable.
+    CUDA_VISIBLE_DEVICES environment variable.
 
     Returns:
       A ClusterSpec containing host information retrieved from Slurm's
@@ -170,7 +170,7 @@ class SlurmClusterResolver(ClusterResolver):
       cluster_rank_offset_start = cluster_rank_offset_end
 
     if self._auto_set_gpu is True:
-      os.environ['CUDA_VISIBLE_DEVICE'] = self._gpu_allocation[self._rank]
+      os.environ['CUDA_VISIBLE_DEVICES'] = self._gpu_allocation[self._rank]
 
     return ClusterSpec(self._cluster_allocation)
 

--- a/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver.py
@@ -162,7 +162,7 @@ class SlurmClusterResolver(ClusterResolver):
 
     return ClusterSpec(self._cluster_allocation)
 
-  def own_task(self):
+  def get_task_info(self):
     """Returns job name and task_index for the process which calls this function
 
     This returns the job name and task index for the process which calls this

--- a/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver.py
@@ -1,0 +1,180 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Implementation of Cluster Resolvers for Slurm workload manager."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import subprocess
+
+from tensorflow.contrib.cluster_resolver.python.training.cluster_resolver import ClusterResolver
+from tensorflow.python.training.server_lib import ClusterSpec
+
+class SlurmClusterResolver(ClusterResolver):
+  """Cluster Resolver for system with Slurm workload manager.
+
+  This is an implementation of cluster resolvers for Slurm clusters. This allows
+  the specification of jobs and task counts, number of tasks per node, number of
+  GPUs on each node and number of GPUs for each task, It retrieves system
+  attributes by Slurm environment variables, resolve allocated computing node
+  names, construct a cluster and return a Cluster Resolver object which an be
+  use for distributed TensorFlow.
+  """
+
+  def __init__(self,
+               jobs,
+               port_base=8888,
+               gpus_per_node=1,
+               gpus_per_task=1,
+               tasks_per_node=None,
+               auto_set_gpu=True):
+    """Creates a new SlurmClusterResolver object.
+
+    This takes in parameters and creates a SlurmClusterResolver object. It uses
+    those parameters to determine which nodes will processes reside and resolve
+    their hostnames. With the number of the GPUs on each node and number of GPUs
+    for each task it offsets the port number for each processes and allocate
+    GPUs to tasks by setting environment variables. The resolver currently
+    supports homogeneous tasks and default Slurm process allocation.
+
+    Args:
+      jobs: Dictionary with job names as key and number of tasks in the job as
+        value
+      port_base: The first port number to start with for processes on a node.
+      gpus_per_node: Number of GPUs avaliable on each node.
+      gpus_per_task: Number of GPUs to be used for each task.
+      tasks_per_node: Number of tasks to run on each node, if not set defaults
+        to Slurm's output environment variable SLURM_NTASKS_PER_NODE.
+      auto_set_gpu: Set the visible CUDA devices automatically while resolving
+        the cluster by setting CUDA_VISIBLE_DEVICE environment variable.
+        Defaults to True.
+
+    Raises:
+      RuntimeError: If requested more GPUs per node then avaliable or requested
+      more tasks then assigned tasks.
+    """
+
+    # check if launched by mpirun
+    if 'OMPI_COMM_WORLD_RANK' in os.environ:
+      self._rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
+      num_tasks = int(os.environ['OMPI_COMM_WORLD_SIZE'])
+    else:
+      self._rank = int(os.environ['SLURM_PROCID'])
+      num_tasks = int(os.environ['SLURM_NTASKS'])
+
+    self._jobs = jobs
+    self._port_base = port_base
+
+    # user specification overrides SLURM specification
+    if tasks_per_node is not None:
+      self._tasks_per_node = tasks_per_node
+    elif tasks_per_node is None and 'SLURM_NTASKS_PER_NODE' in os.environ:
+      self._tasks_per_node = int(os.environ['SLURM_NTASKS_PER_NODE'])
+    else:
+      raise RuntimeError('Neither `tasks_per_node` or \
+                          SLURM_NTASKS_PER_NODE is set')
+
+    self._gpus_per_node = gpus_per_node
+    self._gpus_per_task = gpus_per_task
+
+    self._auto_set_gpu = auto_set_gpu
+    self._job_name = None
+    self._task_index = None
+
+    self._gpu_allocation = []
+    self._cluster_allocation = {}
+
+    if self._tasks_per_node * self._gpus_per_task > self._gpus_per_node:
+      raise RuntimeError('Requested more GPUs per node then avaliable')
+
+    if sum(self._jobs.values()) != num_tasks:
+      raise RuntimeError('Requested more tasks then assigned tasks')
+
+  def cluster_spec(self):
+    """Returns a ClusterSpec object based on the latest instance group info.
+
+    This returns a ClusterSpec object for use based on information from the
+    specified initialization parameters and Slurm environment variables. The
+    cluster specification is resolved each time this function is called. The
+    resolver extract hostnames of nodes by scontrol and pack tasks in that
+    order until a node a has number of tasks that is equal to specification.
+    GPUs on nodes are allocated to tasks by specification through setting
+    CUDA_VISIBLE_DEVICE environment variable.
+
+    Returns:
+      A ClusterSpec containing host information retrieved from Slurm's
+        environment variables.
+    """
+    hostlist = subprocess.check_output(['scontrol', 'show', 'hostname']).\
+               decode("utf-8").strip().split('\n')
+
+    task_list = []
+    self._gpu_allocation = []
+    self._cluster_allocation = {}
+
+    for host in hostlist:
+      for port_offset, gpu_offset in zip(range(self._tasks_per_node),
+                                         range(0, self._gpus_per_node,
+                                               self._gpus_per_task)):
+
+        host_addr = "%s:%d" % (host, self._port_base+port_offset)
+        task_list.append(host_addr)
+        gpu_id_list = []
+
+        for gpu_id in range(gpu_offset, gpu_offset+self._gpus_per_task):
+          gpu_id_list.append(str(gpu_id))
+
+        self._gpu_allocation.append(",".join(gpu_id_list))
+
+    cluster_rank_offset_start = 0
+    cluster_rank_offset_end = 0
+
+    for job_name, num_tasks in self._jobs.items():
+      cluster_rank_offset_end = cluster_rank_offset_start + num_tasks
+
+      self._cluster_allocation[job_name] = \
+        task_list[cluster_rank_offset_start:cluster_rank_offset_end]
+
+      if self._rank >= cluster_rank_offset_start and \
+          self._rank < cluster_rank_offset_end:
+
+        self._job_name = job_name
+        self._task_index = self._rank - cluster_rank_offset_start
+
+      cluster_rank_offset_start = cluster_rank_offset_end
+
+    if self._auto_set_gpu is True:
+      os.environ['CUDA_VISIBLE_DEVICE'] = self._gpu_allocation[self._rank]
+
+    return ClusterSpec(self._cluster_allocation)
+
+  def own_task(self):
+    """Returns job name and task_index for the process which calls this function
+
+    This returns the job name and task index for the process which calls this
+    function according to its rank and cluster specification. The job name and
+    task index are set after a cluster is constructed by cluster_spec otherwise
+    defaults to None.
+
+    Returns:
+      A string specifying job name the process belongs to and an integner
+        specifying the task index the process belongs to in that job.
+    """
+    return self._job_name, self._task_index
+
+  def master(self):
+    return self._cluster_allocation[str(self._job_name)][self._task_index]

--- a/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
@@ -113,7 +113,7 @@ class SlurmClusterResolverTest(test.TestCase):
   @mock.patch.dict(os.environ, {'SLURM_PROCID': '1',
                                 'SLURM_NTASKS': '5',
                                 'SLURM_NTASKS_PER_NODE': '2',
-                                'CUDA_VISIBLE_DEVICE': ''})
+                                'CUDA_VISIBLE_DEVICES': ''})
   @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
                      mock_resolve_hostnames_output)
   def testMultiTaskPerNodeRetrieval(self):
@@ -152,12 +152,12 @@ class SlurmClusterResolverTest(test.TestCase):
       }
     """
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
-    assert os.environ['CUDA_VISIBLE_DEVICE'] == '1'
+    assert os.environ['CUDA_VISIBLE_DEVICES'] == '1'
 
   @mock.patch.dict(os.environ, {'SLURM_PROCID': '1',
                                 'SLURM_NTASKS': '5',
                                 'SLURM_NTASKS_PER_NODE': '2',
-                                'CUDA_VISIBLE_DEVICE': ''})
+                                'CUDA_VISIBLE_DEVICES': ''})
   @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
                      mock_resolve_hostnames_output)
   def testMultipleGpusPerTaskRetrieval(self):
@@ -196,7 +196,7 @@ class SlurmClusterResolverTest(test.TestCase):
       }
     """
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
-    assert os.environ['CUDA_VISIBLE_DEVICE'] == '2,3'
+    assert os.environ['CUDA_VISIBLE_DEVICES'] == '2,3'
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
@@ -101,8 +101,8 @@ class SlurmClusterResolverTest(test.TestCase):
     expected_proto = """
     job { name: 'ps' tasks { value: 't02n13:8888' } }
     job { name: 'worker' tasks { key: 0 value: 't02n13:8889' }
-                         tasks { key: 1 value: 't02n41:8888' } }
-                         tasks { key: 2 value: 't02n41:8889' } }
+                         tasks { key: 1 value: 't02n41:8888' }
+                         tasks { key: 2 value: 't02n41:8889' }
                          tasks { key: 3 value: 't02n43:8888' } }
     """
 
@@ -127,8 +127,8 @@ class SlurmClusterResolverTest(test.TestCase):
     expected_proto = """
     job { name: 'ps' tasks { value: 't02n13:8888' } }
     job { name: 'worker' tasks { key: 0 value: 't02n13:8889' }
-                         tasks { key: 1 value: 't02n41:8888' } }
-                         tasks { key: 2 value: 't02n41:8889' } }
+                         tasks { key: 1 value: 't02n41:8888' }
+                         tasks { key: 2 value: 't02n41:8889' }
                          tasks { key: 3 value: 't02n43:8888' } }
     """
 

--- a/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import subprocess
 import os
 
 from tensorflow.contrib.cluster_resolver.python.training.slurm_cluster_resolver import SlurmClusterResolver
@@ -57,22 +56,9 @@ class SlurmClusterResolverTest(test.TestCase):
 
     actual_cluster_spec = slurm_cluster_resolver.cluster_spec()
     expected_proto = """
-      job {
-        name: "ps"
-        tasks {
-          value: "t02n13:8888"
-        }
-      }
-      job {
-        name: "worker"
-        tasks {
-          value: "t02n41:8888"
-        }
-        tasks {
-          key: 1
-          value: "t02n43:8888"
-        }
-      }
+    job { name: 'ps' tasks { value: 't02n13:8888' } }
+    job { name: 'worker' tasks { key: 0 value: 't02n41:8888' }
+                         tasks { key: 1 value: 't02n43:8888' } }
     """
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
 
@@ -91,22 +77,9 @@ class SlurmClusterResolverTest(test.TestCase):
 
     actual_cluster_spec = slurm_cluster_resolver.cluster_spec()
     expected_proto = """
-      job {
-        name: "ps"
-        tasks {
-          value: "t02n13:8888"
-        }
-      }
-      job {
-        name: "worker"
-        tasks {
-          value: "t02n41:8888"
-        }
-        tasks {
-          key: 1
-          value: "t02n43:8888"
-        }
-      }
+    job { name: 'ps' tasks { value: 't02n13:8888' } }
+    job { name: 'worker' tasks { key: 0 value: 't02n41:8888' }
+                         tasks { key: 1 value: 't02n43:8888' } }
     """
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
 
@@ -126,31 +99,13 @@ class SlurmClusterResolverTest(test.TestCase):
 
     actual_cluster_spec = slurm_cluster_resolver.cluster_spec()
     expected_proto = """
-      job {
-        name: "ps"
-        tasks {
-          value: "t02n13:8888"
-        }
-      }
-      job {
-        name: "worker"
-        tasks {
-          value: "t02n13:8889"
-        }
-        tasks {
-          key: 1
-          value: "t02n41:8888"
-        }
-        tasks {
-          key: 2
-          value: "t02n41:8889"
-        }
-        tasks {
-          key: 3
-          value: "t02n43:8888"
-        }
-      }
+    job { name: 'ps' tasks { value: 't02n13:8888' } }
+    job { name: 'worker' tasks { key: 0 value: 't02n13:8889' }
+                         tasks { key: 1 value: 't02n41:8888' } }
+                         tasks { key: 2 value: 't02n41:8889' } }
+                         tasks { key: 3 value: 't02n43:8888' } }
     """
+
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
     assert os.environ['CUDA_VISIBLE_DEVICES'] == '1'
 
@@ -170,31 +125,13 @@ class SlurmClusterResolverTest(test.TestCase):
 
     actual_cluster_spec = slurm_cluster_resolver.cluster_spec()
     expected_proto = """
-      job {
-        name: "ps"
-        tasks {
-          value: "t02n13:8888"
-        }
-      }
-      job {
-        name: "worker"
-        tasks {
-          value: "t02n13:8889"
-        }
-        tasks {
-          key: 1
-          value: "t02n41:8888"
-        }
-        tasks {
-          key: 2
-          value: "t02n41:8889"
-        }
-        tasks {
-          key: 3
-          value: "t02n43:8888"
-        }
-      }
+    job { name: 'ps' tasks { value: 't02n13:8888' } }
+    job { name: 'worker' tasks { key: 0 value: 't02n13:8889' }
+                         tasks { key: 1 value: 't02n41:8888' } }
+                         tasks { key: 2 value: 't02n41:8889' } }
+                         tasks { key: 3 value: 't02n43:8888' } }
     """
+
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
     assert os.environ['CUDA_VISIBLE_DEVICES'] == '2,3'
 

--- a/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
@@ -29,8 +29,8 @@ mock = test.mock
 
 class SlurmClusterResolverTest(test.TestCase):
 
-  def mock_check_subprocess_output(self):
-    return b't02n13\nt02n41\nt02n43\nt02n44\n'
+  def mock_resolve_hostnames_output(self):
+    return ['t02n13','t02n41','t02n43','t02n44']
 
   def _verifyClusterSpecEquality(self, cluster_spec, expected_proto):
     self.assertProtoEquals(expected_proto, cluster_spec.as_cluster_def())
@@ -44,11 +44,11 @@ class SlurmClusterResolverTest(test.TestCase):
         server_lib.ClusterSpec(cluster_spec.as_dict()).as_cluster_def())
 
   @mock.patch.dict(os.environ, {'SLURM_PROCID': '0', 'SLURM_NTASKS': '3'})
-  @mock.patch.object(subprocess, 'check_output',
-                     mock_check_subprocess_output)
+  @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
+                     mock_resolve_hostnames_output)
   def testSimpleSuccessfulRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
-        jobs={"ps": 1, "worker": 2},
+        jobs={'ps': 1, 'worker': 2},
         port_base=8888,
         tasks_per_node=1,
         gpus_per_node=1,
@@ -79,11 +79,11 @@ class SlurmClusterResolverTest(test.TestCase):
   @mock.patch.dict(os.environ, {'SLURM_PROCID': '0',
                                 'SLURM_NTASKS': '3',
                                 'SLURM_NTASKS_PER_NODE': '1'})
-  @mock.patch.object(subprocess, 'check_output',
-                     mock_check_subprocess_output)
+  @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
+                     mock_resolve_hostnames_output)
   def testTaskPerNodeNotSetRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
-        jobs={"ps": 1, "worker": 2},
+        jobs={'ps': 1, 'worker': 2},
         port_base=8888,
         gpus_per_node=1,
         gpus_per_task=1,
@@ -114,11 +114,11 @@ class SlurmClusterResolverTest(test.TestCase):
                                 'SLURM_NTASKS': '5',
                                 'SLURM_NTASKS_PER_NODE': '2',
                                 'CUDA_VISIBLE_DEVICE': ''})
-  @mock.patch.object(subprocess, 'check_output',
-                     mock_check_subprocess_output)
+  @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
+                     mock_resolve_hostnames_output)
   def testMultiTaskPerNodeRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
-        jobs={"ps": 1, "worker": 4},
+        jobs={'ps': 1, 'worker': 4},
         port_base=8888,
         gpus_per_node=2,
         gpus_per_task=1,
@@ -158,10 +158,11 @@ class SlurmClusterResolverTest(test.TestCase):
                                 'SLURM_NTASKS': '5',
                                 'SLURM_NTASKS_PER_NODE': '2',
                                 'CUDA_VISIBLE_DEVICE': ''})
-  @mock.patch.object(subprocess, 'check_output', mock_check_subprocess_output)
+  @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
+                     mock_resolve_hostnames_output)
   def testMultipleGpusPerTaskRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
-        jobs={"ps": 1, "worker": 4},
+        jobs={'ps': 1, 'worker': 4},
         port_base=8888,
         gpus_per_node=4,
         gpus_per_task=2,

--- a/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
@@ -1,0 +1,201 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for SlurmClusterResolver."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import subprocess
+import os
+
+from tensorflow.contrib.cluster_resolver.python.training.slurm_cluster_resolver import SlurmClusterResolver
+from tensorflow.python.platform import test
+from tensorflow.python.training import server_lib
+
+mock = test.mock
+
+class SlurmClusterResolverTest(test.TestCase):
+
+  def mock_check_subprocess_output(self):
+    return b't02n13\nt02n41\nt02n43\nt02n44\n'
+
+  def _verifyClusterSpecEquality(self, cluster_spec, expected_proto):
+    self.assertProtoEquals(expected_proto, cluster_spec.as_cluster_def())
+    self.assertProtoEquals(
+        expected_proto, server_lib.ClusterSpec(cluster_spec).as_cluster_def())
+    self.assertProtoEquals(
+        expected_proto,
+        server_lib.ClusterSpec(cluster_spec.as_cluster_def()).as_cluster_def())
+    self.assertProtoEquals(
+        expected_proto,
+        server_lib.ClusterSpec(cluster_spec.as_dict()).as_cluster_def())
+
+  @mock.patch.dict(os.environ, {'SLURM_PROCID': '0', 'SLURM_NTASKS': '3'})
+  @mock.patch.object(subprocess, 'check_output',
+                     mock_check_subprocess_output)
+  def testSimpleSuccessfulRetrieval(self):
+    slurm_cluster_resolver = SlurmClusterResolver(
+        jobs={"ps": 1, "worker": 2},
+        port_base=8888,
+        tasks_per_node=1,
+        gpus_per_node=1,
+        gpus_per_task=1,
+        auto_set_gpu=False)
+
+    actual_cluster_spec = slurm_cluster_resolver.cluster_spec()
+    expected_proto = """
+      job {
+        name: "ps"
+        tasks {
+          value: "t02n13:8888"
+        }
+      }
+      job {
+        name: "worker"
+        tasks {
+          value: "t02n41:8888"
+        }
+        tasks {
+          key: 1
+          value: "t02n43:8888"
+        }
+      }
+    """
+    self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
+
+  @mock.patch.dict(os.environ, {'SLURM_PROCID': '0',
+                                'SLURM_NTASKS': '3',
+                                'SLURM_NTASKS_PER_NODE': '1'})
+  @mock.patch.object(subprocess, 'check_output',
+                     mock_check_subprocess_output)
+  def testTaskPerNodeNotSetRetrieval(self):
+    slurm_cluster_resolver = SlurmClusterResolver(
+        jobs={"ps": 1, "worker": 2},
+        port_base=8888,
+        gpus_per_node=1,
+        gpus_per_task=1,
+        auto_set_gpu=False)
+
+    actual_cluster_spec = slurm_cluster_resolver.cluster_spec()
+    expected_proto = """
+      job {
+        name: "ps"
+        tasks {
+          value: "t02n13:8888"
+        }
+      }
+      job {
+        name: "worker"
+        tasks {
+          value: "t02n41:8888"
+        }
+        tasks {
+          key: 1
+          value: "t02n43:8888"
+        }
+      }
+    """
+    self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
+
+  @mock.patch.dict(os.environ, {'SLURM_PROCID': '1',
+                                'SLURM_NTASKS': '5',
+                                'SLURM_NTASKS_PER_NODE': '2',
+                                'CUDA_VISIBLE_DEVICE': ''})
+  @mock.patch.object(subprocess, 'check_output',
+                     mock_check_subprocess_output)
+  def testMultiTaskPerNodeRetrieval(self):
+    slurm_cluster_resolver = SlurmClusterResolver(
+        jobs={"ps": 1, "worker": 4},
+        port_base=8888,
+        gpus_per_node=2,
+        gpus_per_task=1,
+        auto_set_gpu=True)
+
+    actual_cluster_spec = slurm_cluster_resolver.cluster_spec()
+    expected_proto = """
+      job {
+        name: "ps"
+        tasks {
+          value: "t02n13:8888"
+        }
+      }
+      job {
+        name: "worker"
+        tasks {
+          value: "t02n13:8889"
+        }
+        tasks {
+          key: 1
+          value: "t02n41:8888"
+        }
+        tasks {
+          key: 2
+          value: "t02n41:8889"
+        }
+        tasks {
+          key: 3
+          value: "t02n43:8888"
+        }
+      }
+    """
+    self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
+    assert os.environ['CUDA_VISIBLE_DEVICE'] == '1'
+
+  @mock.patch.dict(os.environ, {'SLURM_PROCID': '1',
+                                'SLURM_NTASKS': '5',
+                                'SLURM_NTASKS_PER_NODE': '2',
+                                'CUDA_VISIBLE_DEVICE': ''})
+  @mock.patch.object(subprocess, 'check_output', mock_check_subprocess_output)
+  def testMultipleGpusPerTaskRetrieval(self):
+    slurm_cluster_resolver = SlurmClusterResolver(
+        jobs={"ps": 1, "worker": 4},
+        port_base=8888,
+        gpus_per_node=4,
+        gpus_per_task=2,
+        auto_set_gpu=True)
+
+    actual_cluster_spec = slurm_cluster_resolver.cluster_spec()
+    expected_proto = """
+      job {
+        name: "ps"
+        tasks {
+          value: "t02n13:8888"
+        }
+      }
+      job {
+        name: "worker"
+        tasks {
+          value: "t02n13:8889"
+        }
+        tasks {
+          key: 1
+          value: "t02n41:8888"
+        }
+        tasks {
+          key: 2
+          value: "t02n41:8889"
+        }
+        tasks {
+          key: 3
+          value: "t02n43:8888"
+        }
+      }
+    """
+    self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
+    assert os.environ['CUDA_VISIBLE_DEVICE'] == '2,3'
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
+++ b/tensorflow/contrib/cluster_resolver/python/training/slurm_cluster_resolver_test.py
@@ -30,7 +30,7 @@ mock = test.mock
 class SlurmClusterResolverTest(test.TestCase):
 
   def mock_resolve_hostnames_output(self):
-    return ['t02n13','t02n41','t02n43','t02n44']
+    return ['t02n13', 't02n41', 't02n43', 't02n44']
 
   def _verifyClusterSpecEquality(self, cluster_spec, expected_proto):
     self.assertProtoEquals(expected_proto, cluster_spec.as_cluster_def())


### PR DESCRIPTION
This creates a new cluster resolver which allows launching of distributed TensorFlow on clusters using Slurm workload manager, which is typically used on HPC systems. The resolver for now can handle homogeneous job allocation with default plane distribution. The resolver can also implicitly expose GPUs to a process according to configurations and specifications where one or more GPUs can be can be allocated to a process. A method is also provided to all processes to "realize" which job and task index they are assigned to.