### PR TITLE
Fix control edge issue while constructing TRTEngineOp nodes

### DIFF
--- a/tensorflow/contrib/tensorrt/convert/convert_graph.cc
+++ b/tensorflow/contrib/tensorrt/convert/convert_graph.cc
@@ -591,10 +591,11 @@ tensorflow::Status CreateTRTNode(const std::vector<EngineInfo>& infos, int pos,
     }
     VLOG(1) << ins;
   }
-  node_builder.Input(inputs);
+  // Add control inputs first, just in case.
   for (const string& c : control_input_names) {
     node_builder.ControlInput(c);
   }
+  node_builder.Input(inputs);
 
   if (info.engine_type == EngineInfo::EngineType::TRTStatic &&
       info.cached_engine_batches.size()) {
@@ -633,11 +634,6 @@ tensorflow::Status CreateTRTNode(const std::vector<EngineInfo>& infos, int pos,
     return status;
   }
   // Add control input and input edges to the engine node.
-  for (const auto in : control_input_nodes) {
-    VLOG(1) << "Connecting control edge from " << in->name() << " to "
-            << engine_node->name();
-    graph->AddControlEdge(in, engine_node);
-  }
   VLOG(1) << "input_nodes size = " << input_nodes.size();
   for (int i = 0; i < input_nodes.size(); ++i) {
     Node* n = CHECK_NOTNULL(input_nodes[i]);

--- a/tensorflow/contrib/tensorrt/convert/convert_graph.cc
+++ b/tensorflow/contrib/tensorrt/convert/convert_graph.cc
@@ -633,7 +633,7 @@ tensorflow::Status CreateTRTNode(const std::vector<EngineInfo>& infos, int pos,
     LOG(ERROR) << "Adding node failed " << status;
     return status;
   }
-  // Add control input and input edges to the engine node.
+  // Add input edges to the engine node.
   VLOG(1) << "input_nodes size = " << input_nodes.size();
   for (int i = 0; i < input_nodes.size(); ++i) {
     Node* n = CHECK_NOTNULL(input_nodes[i]);

--- a/tensorflow/contrib/tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/contrib/tensorrt/convert/convert_nodes.cc
@@ -2882,7 +2882,7 @@ tensorflow::Status ConvertSegmentToGraphDef(
       marker_nodes.insert(node_name);
       auto seg_node = segment_def->add_node();
       tensorflow::NodeDefBuilder builder(node_name, "Identity");
-      auto status = builder.Input(connection.inside_node_name, 0, dtype)
+      auto status = builder.Input(connection.inside_node_name, connection.inside_port, dtype)
                         .Finalize(seg_node);
       VLOG(1) << "Constructing output " << node_name << " for the edge "
               << connection.inside_node_name << ":" << connection.inside_port

--- a/tensorflow/contrib/tensorrt/convert/trt_optimization_pass.h
+++ b/tensorflow/contrib/tensorrt/convert/trt_optimization_pass.h
@@ -38,7 +38,14 @@ class TRTOptimizationPass : public tensorflow::grappler::CustomGraphOptimizer {
         maximum_batch_size_(-1),
         is_dynamic_op_(false),
         max_cached_batches_(1),
-        max_workspace_size_bytes_(256LL << 20) {
+        max_workspace_size_bytes_(256LL << 20),
+        print_input_graph_(false),
+        print_output_graph_(false),
+        print_engines_(false),
+        print_subgraphs_(false),
+        save_input_graph_(false),
+        save_output_graph_(false),
+        converted_graph_count(0) {
     VLOG(1) << "Constructing " << name_;
   }
 
@@ -67,6 +74,16 @@ class TRTOptimizationPass : public tensorflow::grappler::CustomGraphOptimizer {
   std::vector<int> batches_;
   int max_cached_batches_;
   int64_t max_workspace_size_bytes_;
+  bool print_input_graph_;
+  bool print_output_graph_;
+  bool print_engines_;
+  bool print_subgraphs_;
+  bool save_input_graph_;
+  bool save_output_graph_;
+  bool per_engine_workspace_size_;
+  int converted_graph_count;
+  string saved_output_graph_prefix_;
+  string saved_input_graph_prefix_;
 };
 
 }  // namespace convert


### PR DESCRIPTION
This PR fixes an issue with control edges when constructing TRTEngineOp nodes. Duplicate addition of control edges both to the NodeDef and to the graph was breaking schema.

Additionally extra configuration parameters are added to the TRTOptimization pass to help better understanding the conversion process and help with similar issues in the future.