### PR TITLE
Disable the logging for OutofRangeError in test

### DIFF
--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -877,7 +877,11 @@ class ErrorLoggingSession(session.Session):
     try:
       return super(ErrorLoggingSession, self).run(*args, **kwargs)
     except Exception as e:  # pylint: disable=broad-except
-      logging.error(str(e))
+      # Note: disable the logging for OutOfRangeError, which makes the output
+      # of tf.data tests hard to read, because OutOfRangeError is used as the
+      # signal completion
+      if not isinstance(e, errors.OutOfRangeError):
+        logging.error(str(e))
       raise
 
 


### PR DESCRIPTION
`tensorflow.python.framework.test_util.ErrorLoggingSession` logs the errors from the tests. However, `OutOfRangeError` is used in many `tf.data` Ops as the signal completion,  which makes the ouput of `tf.data` tests hard to read. This PR disables the loging for `OutOfRnageError` to make the test log easy to read.