### PR TITLE
fix doc bug for per_image_standardization (unit norm vs. variance)

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1176,7 +1176,7 @@ def resize_image_with_pad(image,
 
 @tf_export('image.per_image_standardization')
 def per_image_standardization(image):
-  """Linearly scales `image` to have zero mean and unit norm.
+  """Linearly scales `image` to have zero mean and unit variance.
 
   This op computes `(x - mean) / adjusted_stddev`, where `mean` is the average
   of all values in image, and


### PR DESCRIPTION
The first line of the doc states "Linearly scales `image` to have zero mean and **unit norm.**"  This is incorrect - "unit norm" is calculated by dividing the vector by its L2 norm, and by definition, when you take the L2 norm of the result, it should evaluate to 1.  The result being calculated here is referred to as "unit variance".  Reference: https://en.wikipedia.org/wiki/Feature_scaling
