### PR TITLE
Use scatter operations to speed up adam optimizer

### DIFF
--- a/tensorflow/contrib/opt/python/training/adamax.py
+++ b/tensorflow/contrib/opt/python/training/adamax.py
@@ -134,8 +134,7 @@ class AdaMaxOptimizer(adam.AdamOptimizer):
         math_ops.cast(self._epsilon_t, grad.dtype.base_dtype),
         grad, use_locking=self._use_locking)
 
-  def _apply_sparse_shared(self, grad, var, indices,
-                           scatter_add, scatter_update):
+  def _apply_sparse_shared(self, grad, var, indices, scatter_op_wrapper):
     beta1_power = self._get_beta_accumulators()
     beta1_power = math_ops.cast(beta1_power, var.dtype.base_dtype)
     lr_t = math_ops.cast(self._lr_t, var.dtype.base_dtype)
@@ -147,38 +146,29 @@ class AdaMaxOptimizer(adam.AdamOptimizer):
     m_slice = array_ops.gather(m, indices)
     m_t_slice = m_slice * beta1_t + grad * (1 - beta1_t)
     with ops.control_dependencies([m_t_slice]):
-      m_t = scatter_update(m, indices, m_t_slice)
+      m_t = scatter_op_wrapper.update(m, indices, m_t_slice)
     # u_t = max(beta2 * u, abs(g_t))
     v = self.get_slot(var, "v")
     v_slice = array_ops.gather(v, indices)
     v_t_slice = math_ops.maximum(v_slice * beta2_t, math_ops.abs(grad))
     with ops.control_dependencies([v_t_slice]):
-      v_t = scatter_update(v, indices, v_t_slice)
+      v_t = scatter_op_wrapper.update(v, indices, v_t_slice)
     # theta_t = theta - lr / (1 - beta1^t) * m_t / u_t
     var_slice = -lr_t / (1 - beta1_power) * (m_t_slice /
                                              (v_t_slice + epsilon_t))
     with ops.control_dependencies([var_slice]):
-      var_update = scatter_add(var, indices, var_slice)
+      var_update = scatter_op_wrapper.add(var, indices, var_slice)
     return control_flow_ops.group(*[var_update, m_t, v_t])
 
   def _apply_sparse(self, grad, var):
     return self._apply_sparse_shared(
         grad.values, var, grad.indices,
-        lambda x, i, v: state_ops.scatter_add(  # pylint: disable=g-long-lambda
-            x, i, v, use_locking=self._use_locking),
-        lambda x, i, v: state_ops.scatter_update(  # pylint: disable=g-long-lambda
-            x, i, v, use_locking=self._use_locking))
-
-  def _resource_scatter_update(self, x, i, v):
-    with ops.control_dependencies(
-        [resource_variable_ops.resource_scatter_update(
-            x.handle, i, v)]):
-      return x.value()
+        adam.AdamOptimizer._ScatterOpWrapper(self._use_locking))
 
   def _resource_apply_sparse(self, grad, var, indices):
     return self._apply_sparse_shared(
         grad, var, indices,
-        self._resource_scatter_add, self._resource_scatter_update)
+        adam.AdamOptimizer._ResourceScatterOpWrapper())
 
   def _finish(self, update_ops, name_scope):
     # Update the power accumulators.

--- a/tensorflow/contrib/opt/python/training/adamax.py
+++ b/tensorflow/contrib/opt/python/training/adamax.py
@@ -23,8 +23,6 @@ from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import resource_variable_ops
-from tensorflow.python.ops import state_ops
 from tensorflow.python.training import adam
 from tensorflow.python.training import training_ops
 

--- a/tensorflow/contrib/opt/python/training/nadam_optimizer.py
+++ b/tensorflow/contrib/opt/python/training/nadam_optimizer.py
@@ -67,7 +67,7 @@ class NadamOptimizer(adam.AdamOptimizer):
         use_locking=self._use_locking,
         use_nesterov=True)
 
-  def _apply_sparse_shared(self, grad, var, indices, scatter_op_wrapper):
+  def _apply_sparse_shared(self, grad, var, indices):
     beta1_power, beta2_power = self._get_beta_accumulators()
     beta1_power = math_ops.cast(beta1_power, var.dtype.base_dtype)
     beta2_power = math_ops.cast(beta2_power, var.dtype.base_dtype)
@@ -81,7 +81,8 @@ class NadamOptimizer(adam.AdamOptimizer):
     m_scaled_g_values = grad * (1 - beta1_t)
     m_t = state_ops.assign(m, m * beta1_t, use_locking=self._use_locking)
     with ops.control_dependencies([m_t]):
-      m_t = scatter_op_wrapper.add(m, indices, m_scaled_g_values)
+      m_t = m.scatter_add(ops.IndexedSlices(m_scaled_g_values, indices),
+                          use_locking=self._use_locking)
       # m_bar = (1 - beta1) * g_t + beta1 * m_t
       m_bar = m_scaled_g_values + beta1_t * m_t
     # v_t = beta2 * v + (1 - beta2) * (g_t * g_t)
@@ -89,7 +90,8 @@ class NadamOptimizer(adam.AdamOptimizer):
     v_scaled_g_values = (grad * grad) * (1 - beta2_t)
     v_t = state_ops.assign(v, v * beta2_t, use_locking=self._use_locking)
     with ops.control_dependencies([v_t]):
-      v_t = scatter_op_wrapper.add(v, indices, v_scaled_g_values)
+      v_t = v.scatter_add(ops.IndexedSlices(v_scaled_g_values, indices),
+                          use_locking=self._use_locking)
     v_sqrt = math_ops.sqrt(v_t)
     var_update = state_ops.assign_sub(
         var, lr * m_bar / (v_sqrt + epsilon_t), use_locking=self._use_locking)

--- a/tensorflow/contrib/opt/python/training/nadam_optimizer.py
+++ b/tensorflow/contrib/opt/python/training/nadam_optimizer.py
@@ -67,7 +67,7 @@ class NadamOptimizer(adam.AdamOptimizer):
         use_locking=self._use_locking,
         use_nesterov=True)
 
-  def _apply_sparse_shared(self, grad, var, indices, scatter_add):
+  def _apply_sparse_shared(self, grad, var, indices, scatter_op_wrapper):
     beta1_power, beta2_power = self._get_beta_accumulators()
     beta1_power = math_ops.cast(beta1_power, var.dtype.base_dtype)
     beta2_power = math_ops.cast(beta2_power, var.dtype.base_dtype)
@@ -81,7 +81,7 @@ class NadamOptimizer(adam.AdamOptimizer):
     m_scaled_g_values = grad * (1 - beta1_t)
     m_t = state_ops.assign(m, m * beta1_t, use_locking=self._use_locking)
     with ops.control_dependencies([m_t]):
-      m_t = scatter_add(m, indices, m_scaled_g_values)
+      m_t = scatter_op_wrapper.add(m, indices, m_scaled_g_values)
       # m_bar = (1 - beta1) * g_t + beta1 * m_t
       m_bar = m_scaled_g_values + beta1_t * m_t
     # v_t = beta2 * v + (1 - beta2) * (g_t * g_t)
@@ -89,7 +89,7 @@ class NadamOptimizer(adam.AdamOptimizer):
     v_scaled_g_values = (grad * grad) * (1 - beta2_t)
     v_t = state_ops.assign(v, v * beta2_t, use_locking=self._use_locking)
     with ops.control_dependencies([v_t]):
-      v_t = scatter_add(v, indices, v_scaled_g_values)
+      v_t = scatter_op_wrapper.add(v, indices, v_scaled_g_values)
     v_sqrt = math_ops.sqrt(v_t)
     var_update = state_ops.assign_sub(
         var, lr * m_bar / (v_sqrt + epsilon_t), use_locking=self._use_locking)

--- a/tensorflow/python/training/adam.py
+++ b/tensorflow/python/training/adam.py
@@ -183,15 +183,15 @@ class AdamOptimizer(optimizer.Optimizer):
 
     def add(self, sparse_tensor, index, delta):
       return state_ops.scatter_add(sparse_tensor, index, delta,
-                                   use_locking = self._use_locking)
+                                   use_locking=self._use_locking)
 
     def sub(self, sparse_tensor, index, delta):
       return state_ops.scatter_sub(sparse_tensor, index, delta,
-                                   use_locking = self._use_locking)
+                                   use_locking=self._use_locking)
 
     def update(self, sparse_tensor, index, value):
       return state_ops.scatter_update(sparse_tensor, index, value,
-                                      use_locking = self._use_locking)
+                                      use_locking=self._use_locking)
 
 
   class ResourceScatterOpWrapper(ScatterOpWrapper):
@@ -246,14 +246,15 @@ class AdamOptimizer(optimizer.Optimizer):
         var, indices, lr * m_t_gathered / (v_sqrt_gathered + epsilon_t))
     return control_flow_ops.group(*[var_update, m_t, v_t])
 
-
   def _apply_sparse(self, grad, var):
     return self._apply_sparse_shared(
-        grad.values, var, grad.indices, AdamOptimizer.ScatterOpWrapper(self._use_locking))
+        grad.values, var, grad.indices,
+        AdamOptimizer.ScatterOpWrapper(self._use_locking))
 
   def _resource_apply_sparse(self, grad, var, indices):
     return self._apply_sparse_shared(
-       grad, var, indices, AdamOptimizer.ResourceScatterOpWrapper(self._use_locking))
+        grad, var, indices,
+        AdamOptimizer.ResourceScatterOpWrapper(self._use_locking))
 
   def _finish(self, update_ops, name_scope):
     # Update the power accumulators.

--- a/tensorflow/python/training/adam.py
+++ b/tensorflow/python/training/adam.py
@@ -175,7 +175,7 @@ class AdamOptimizer(optimizer.Optimizer):
         math_ops.cast(self._epsilon_t, grad.dtype.base_dtype),
         grad, use_locking=self._use_locking)
 
-  class ScatterOpWrapper(object):
+  class _ScatterOpWrapper(object):
     """Wraps necessary scatter ops for sparse tensors."""
 
     def __init__(self, use_locking=False):
@@ -194,11 +194,11 @@ class AdamOptimizer(optimizer.Optimizer):
                                       use_locking=self._use_locking)
 
 
-  class ResourceScatterOpWrapper(ScatterOpWrapper):
+  class _ResourceScatterOpWrapper(_ScatterOpWrapper):
     """Wraps necessay scatter ops for sparse resource variables."""
 
-    def __init__(self, use_locking=False):
-      super(AdamOptimizer.ResourceScatterOpWrapper, self).__init__(use_locking)
+    def __init__(self):
+      pass
 
     def add(self, sparse_tensor, index, delta):
       with ops.control_dependencies(
@@ -249,12 +249,12 @@ class AdamOptimizer(optimizer.Optimizer):
   def _apply_sparse(self, grad, var):
     return self._apply_sparse_shared(
         grad.values, var, grad.indices,
-        AdamOptimizer.ScatterOpWrapper(self._use_locking))
+        AdamOptimizer._ScatterOpWrapper(self._use_locking))
 
   def _resource_apply_sparse(self, grad, var, indices):
     return self._apply_sparse_shared(
         grad, var, indices,
-        AdamOptimizer.ResourceScatterOpWrapper(self._use_locking))
+        AdamOptimizer._ResourceScatterOpWrapper())
 
   def _finish(self, update_ops, name_scope):
     # Update the power accumulators.

--- a/tensorflow/python/training/adam.py
+++ b/tensorflow/python/training/adam.py
@@ -23,8 +23,6 @@ from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import resource_variable_ops
-from tensorflow.python.ops import state_ops
 from tensorflow.python.training import optimizer
 from tensorflow.python.training import training_ops
 from tensorflow.python.util.tf_export import tf_export


### PR DESCRIPTION
Original implement uses the whole m and t tensor to do computation, which is not efficient for sparse tensors.
My job speed up by 40x (3500ms -> 90ms for a single step) with this patch