### PR TITLE
Add abseil_cpp cmake dependence.

### DIFF
--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -90,10 +90,12 @@ if (NOT WIN32)
 
   # Options for linking other libraries
   option(systemlib_ZLIB "Use the system installed library as shared objects instead of downloading ZLIB and statically linking to it: ZLIB" OFF)
+  option(systemlib_ABSEIL_CPP "Use the system installed library as shared objects instead of downloading ABSEIL_CPP and statically linking to it: ABSEIL_CPP" OFF)
 
   option(systemlib_ALL "Turn on every possible systemlib_* options" OFF)
   if (systemlib_ALL)
     set (systemlib_ZLIB ON)
+    set (systemlib_ABSEIL_CPP ON)
   endif (systemlib_ALL)
 endif()
 
@@ -115,7 +117,7 @@ function(SHOW_VARIABLES)
 endfunction()
 
 # External dependencies
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/external)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/external ${PROJECT_SOURCE_DIR}/modules)
 
 # Location where external projects will be downloaded
 set (DOWNLOAD_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/downloads"
@@ -240,6 +242,7 @@ include(re2)
 include(cub)
 include(sqlite)
 include(double_conversion)
+include(abseil_cpp)
 if (tensorflow_BUILD_CC_TESTS)
   include(googletest)
 endif()
@@ -248,6 +251,7 @@ add_definitions(${ADD_CFLAGS})
 link_directories(${ADD_LINK_DIRECTORY})
 
 set(tensorflow_EXTERNAL_LIBRARIES
+    ${tensorflow_EXTERNAL_LIBRARIES}
     ${gif_STATIC_LIBRARIES}
     ${png_STATIC_LIBRARIES}
     ${jpeg_STATIC_LIBRARIES}

--- a/tensorflow/contrib/cmake/external/abseil_cpp.cmake
+++ b/tensorflow/contrib/cmake/external/abseil_cpp.cmake
@@ -1,0 +1,100 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+if (systemlib_ABSEIL_CPP)
+
+  find_package(AbseilCpp REQUIRED
+               absl_base
+               absl_spinlock_wait
+               absl_dynamic_annotations
+               absl_malloc_internal
+               absl_throw_delegate
+               absl_strings
+               str_format_internal
+               absl_bad_optional_access)
+
+  include_directories(${ABSEIL_CPP_INCLUDE_DIR})
+  list(APPEND tensorflow_EXTERNAL_LIBRARIES ${ABSEIL_CPP_LIBRARIES})
+
+  message(STATUS "  abseil_cpp includes: ${ABSEIL_CPP_INCLUDE_DIR}")
+  message(STATUS "  abseil_cpp libraries: ${ABSEIL_CPP_LIBRARIES}")
+
+  add_custom_target(abseil_cpp_build)
+  list(APPEND tensorflow_EXTERNAL_DEPENDENCIES abseil_cpp_build)
+
+else (systemlib_ABSEIL_CPP)
+
+  include (ExternalProject)
+
+  set(abseil_cpp_INCLUDE_DIR ${CMAKE_BINARY_DIR}/abseil_cpp/src/abseil_cpp_build)
+  set(abseil_cpp_URL https://github.com/abseil/abseil-cpp/archive/e01d95528ea2137a4a27a88d1f57c6cb260aafed.tar.gz)
+  set(abseil_cpp_HASH SHA256=84043ed402d2a2a6ba4cdddb7e85118b1158fd81fe4ac3a14adc343d054c1e2e)
+  set(abseil_cpp_BUILD ${CMAKE_BINARY_DIR}/abseil_cpp/src/abseil_cpp_build)
+
+  if(WIN32)
+    if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
+      set(abseil_cpp_STATIC_LIBRARIES
+          ${abseil_cpp_BUILD}/absl/base/Release/absl_base.lib
+          ${abseil_cpp_BUILD}/absl/base/Release/absl_spinlock_wait.lib
+          ${abseil_cpp_BUILD}/absl/base/Release/absl_dynamic_annotations.lib
+          ${abseil_cpp_BUILD}/absl/base/Release/absl_malloc_internal.lib
+          ${abseil_cpp_BUILD}/absl/base/Release/absl_throw_delegate.lib
+          ${abseil_cpp_BUILD}/absl/strings/Release/absl_strings.lib
+          ${abseil_cpp_BUILD}/absl/strings/Release/str_format_internal.lib
+          ${abseil_cpp_BUILD}/absl/types/Release/absl_bad_optional_access.lib)
+    else()
+      set(abseil_cpp_STATIC_LIBRARIES
+          ${abseil_cpp_BUILD}/absl/base/absl_base.lib
+          ${abseil_cpp_BUILD}/absl/base/absl_spinlock_wait.lib
+          ${abseil_cpp_BUILD}/absl/base/absl_dynamic_annotations.lib
+          ${abseil_cpp_BUILD}/absl/base/absl_malloc_internal.lib
+          ${abseil_cpp_BUILD}/absl/base/absl_throw_delegate.lib
+          ${abseil_cpp_BUILD}/absl/strings/absl_strings.lib
+          ${abseil_cpp_BUILD}/absl/strings/str_format_internal.lib
+          ${abseil_cpp_BUILD}/absl/types/absl_bad_optional_access.lib)
+    endif()
+  else()
+    set(abseil_cpp_STATIC_LIBRARIES
+        ${abseil_cpp_BUILD}/absl/base/libabsl_base.a
+        ${abseil_cpp_BUILD}/absl/base/libabsl_spinlock_wait.a
+        ${abseil_cpp_BUILD}/absl/base/libabsl_dynamic_annotations.a
+        ${abseil_cpp_BUILD}/absl/base/libabsl_malloc_internal.a
+        ${abseil_cpp_BUILD}/absl/base/libabsl_throw_delegate.a
+        ${abseil_cpp_BUILD}/absl/strings/libabsl_strings.a
+        ${abseil_cpp_BUILD}/absl/strings/libstr_format_internal.a
+        ${abseil_cpp_BUILD}/absl/types/libabsl_bad_optional_access.a)
+  endif()
+
+  ExternalProject_Add(abseil_cpp_build
+      PREFIX abseil_cpp
+      URL ${abseil_cpp_URL}
+      URL_HASH ${abseil_cpp_HASH}
+      DOWNLOAD_DIR "${DOWNLOAD_LOCATION}"
+      BUILD_IN_SOURCE 1
+      BUILD_BYPRODUCTS ${abseil_cpp_STATIC_LIBRARIES}
+      BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release
+      COMMAND ${CMAKE_COMMAND} --build . --config Release
+      INSTALL_COMMAND ""
+      CMAKE_CACHE_ARGS
+          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=${tensorflow_ENABLE_POSITION_INDEPENDENT_CODE}
+          -DCMAKE_BUILD_TYPE:STRING=Release
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+  )
+
+  include_directories(${abseil_cpp_INCLUDE_DIR})
+  list(APPEND tensorflow_EXTERNAL_LIBRARIES ${abseil_cpp_STATIC_LIBRARIES})
+
+  list(APPEND tensorflow_EXTERNAL_DEPENDENCIES abseil_cpp_build)
+
+endif (systemlib_ABSEIL_CPP)

--- a/tensorflow/contrib/cmake/modules/FindAbseilCpp.cmake
+++ b/tensorflow/contrib/cmake/modules/FindAbseilCpp.cmake
@@ -1,0 +1,72 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+find_path(ABSEIL_CPP_INCLUDE_DIR absl/base/config.h
+  HINTS "${ABSEIL_CPP_INCLUDE_DIR_HINTS}"
+  PATHS "$ENV{PROGRAMFILES}"
+        "$ENV{PROGRAMW6432}"
+  PATH_SUFFIXES "")
+
+if(EXISTS "${ABSEIL_CPP_INCLUDE_DIR}" AND NOT "${ABSEIL_CPP_INCLUDE_DIR}" STREQUAL "")
+
+  if(NOT AbseilCpp_FIND_COMPONENTS)
+    # search all libraries if no COMPONENTS was requested
+    set(AbseilCpp_FIND_COMPONENTS
+        "absl_algorithm;absl_any;absl_bad_any_cast"
+        "absl_bad_optional_access;absl_base absl_container;absl_debugging"
+        "absl_dynamic_annotations;absl_examine_stack;absl_failure_signal_handler"
+        "absl_int128;absl_leak_check;absl_malloc_internal;absl_memory;absl_meta"
+        "absl_numeric;absl_optional;absl_span;absl_spinlock_wait;absl_stack_consumption"
+        "absl_stacktrace;absl_str_format;absl_strings;absl_symbolize;absl_synchronization"
+        "absl_throw_delegate;absl_time;absl_utility;str_format_extension_internal"
+        "str_format_internal;test_instance_tracker_lib")
+  endif()
+
+  foreach(LIBNAME ${AbseilCpp_FIND_COMPONENTS})
+
+    unset(ABSEIL_CPP_LIBRARY CACHE)
+
+    find_library(ABSEIL_CPP_LIBRARY
+                 NAMES ${LIBNAME}
+                 HINTS ${ABSEIL_CPP_LIBRARIES_DIR_HINTS})
+
+    if(ABSEIL_CPP_LIBRARY)
+      list(APPEND ABSEIL_CPP_LIBRARIES ${ABSEIL_CPP_LIBRARY})
+    else()
+      message(FATAL_ERROR "\n"
+        "abseil_cpp library \"${LIBNAME}\" not found in system path.\n"
+        "Please provide locations using: -DABSEIL_CPP_LIBRARIES_DIR_HINTS:STRING=\"PATH\"\n")
+    endif()
+
+  endforeach()
+
+  unset(LIBNAME CACHE)
+  unset(ABSEIL_CPP_LIBRARY CACHE)
+
+  set(ABSEIL_CPP_FOUND TRUE)
+  message(STATUS "Found abseil_cpp libraries")
+
+  set(ABSEIL_CPP_INCLUDE_DIR "${ABSEIL_CPP_INCLUDE_DIR}" CACHE PATH "" FORCE)
+  mark_as_advanced(ABSEIL_CPP_INCLUDE_DIR)
+
+  set(ABSEIL_CPP_LIBRARIES "${ABSEIL_CPP_LIBRARIES}" CACHE PATH "" FORCE)
+  mark_as_advanced(ABSEIL_CPP_LIBRARIES)
+
+else()
+
+  message(FATAL_ERROR "\n"
+    "abseil_cpp headers not found in system path.\n"
+    "Please provide locations using: -DABSEIL_CPP_INCLUDE_DIR_HINTS:STRING=\"PATH\"\n")
+
+endif()


### PR DESCRIPTION
This patch enhance cmake build and add proper dependency to both **external** path (by fetching and compiling from scratch) and **system** path (existing library on the system).


  **Abseil_CPP** is required and referenced in tensorflow code:

```
tensorflow]$ find . -name '*.h' -exec grep -H '#include "absl/' {} \; | wc -l
214
```

---

Few outlines:

***New module***

*  **1** New specialized ```modules/FindAbseilCpp.cmake``` module was added in new folder. The ```abseil_cpp``` upstream project doesn't expose cmake or pkgconfig helpers so a custom module capable of searching it system wide was added. More modules like this for all existing packages (that have poor/buggy/lacks support in its cmake exposure) will be proposed. The module is reliable on mswin and linux too. It has minimal lines of code that can be maintained.

* **2** ```-DABSEIL_CPP_INCLUDE_DIR_HINTS``` and ```-DABSEIL_CPP_LIBRARIES_DIR_HINTS``` can be used as extra path hints for the search task (e.g. in case of very obscure places). These two VARS will be default feature for any future modules like this.

* **3** The proposed module can search through specified list of COMPONENTS, otherwise will export all available components from **system**. It happens that in the case of abseil_cpp we have more libraries as components (quite a lot).

***Rule change proposal***

* **4** ```ExternalProject_Add(abseil_cpp_build)``` notice the **_build** suffix of label. More changes (appending **_build**) for all existing module will be proposed. The reason is that in the case of **system** libraries, the very project name e.g. **re2** will conflict inside cmake with the library name **re2** appended into ```tensorflow_EXTERNAL_DEPENDENCIES```. Thus extra discrimination e.g. **_build** tag is required otherwise cmake will throw error on it (it will appear only in **system** scenario).

* **5** ```tensorflow_EXTERNAL_LIBRARIES``` and ```tensorflow_EXTERNAL_DEPENDENCIES``` plus  ```include_directories()```  are updated right in this related module ```external/abseil_cpp.cmake``` and not from very main ```CMakeLists.txt```. More changes like this will come for all rest of packages.

@perfinion ,

  If this is passed and rule changes agreed, very next PR will update the rest of existing modules. Then will continue with PR series relating other issues.


Thank you !