### PR TITLE
fixed calling Estimator '_distribution' method

### DIFF
--- a/tensorflow/python/estimator/estimator.py
+++ b/tensorflow/python/estimator/estimator.py
@@ -1303,7 +1303,7 @@ class Estimator(object):
         # TODO(yuefengz): add a test for unwrapping per_device_hooks.
         def get_hooks_from_the_first_device(per_device_hooks):
           return [
-              self._distribution.unwrap(per_device_hook)[0]
+              self._train_distribution.unwrap(per_device_hook)[0]
               for per_device_hook in per_device_hooks
           ]
 


### PR DESCRIPTION
The code is calling a '_distribution' method which no longer exists.  It will produce error message <AttributeError: 'Estimator' object has no attribute '_distribution'> when training mirrored strategy with hooks.   

Changing '_distribution' to '_train_distribution' can fix the issue.