### PR TITLE
include <cstring> in a few places that use it

### DIFF
--- a/tensorflow/core/lib/strings/str_util.cc
+++ b/tensorflow/core/lib/strings/str_util.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow/core/lib/strings/str_util.h"
 
 #include <ctype.h>
+#include <cstring>
 #include <algorithm>
 #include <vector>
 #include "tensorflow/core/lib/strings/numbers.h"

--- a/tensorflow/core/platform/posix/net.cc
+++ b/tensorflow/core/platform/posix/net.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <unordered_set>
 
 #include <netinet/in.h>

--- a/tensorflow/core/util/command_line_flags.cc
+++ b/tensorflow/core/util/command_line_flags.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include <string>
+#include <cstring>
 #include <vector>
 
 #include "tensorflow/core/lib/core/stringpiece.h"


### PR DESCRIPTION
This is a bit of a drive-by, but I was doing some builds with c++17 and triSYCL, but fell across these 3 errors with gcc version 8.1.1 20180712 (Red Hat 8.1.1-5) (GCC)  on Fedora 28.

These must be getting via another header somehow in normal builds.

I work for Red Hat so should be covered under a CLA already.