### PR TITLE
Added chief to the default device_filters for /job:ps

### DIFF
--- a/tensorflow/python/estimator/run_config.py
+++ b/tensorflow/python/estimator/run_config.py
@@ -566,7 +566,7 @@ class RunConfig(object):
     elif self._task_type == TaskType.WORKER:
       device_filters = ['/job:ps', '/job:worker/task:%d' % self._task_id]
     elif self._task_type == TaskType.PS:
-      device_filters = ['/job:ps', '/job:worker', '/job:master']
+      device_filters = ['/job:ps', '/job:worker', '/job:chief', '/job:master']
     else:
       # If the task_type is `EVALUATOR` or something other than the ones in
       # TaskType then don't set any device filters.

--- a/tensorflow/python/estimator/run_config_test.py
+++ b/tensorflow/python/estimator/run_config_test.py
@@ -1196,8 +1196,9 @@ class RunConfigSessionConfigTest(test.TestCase):
         }
     }
     run_config = _create_run_config_with_cluster_spec(tf_config)
-    self._assert_equal_session_config(run_config.session_config,
-                                      ['/job:ps', '/job:worker', '/job:master'])
+    self._assert_equal_session_config(
+      run_config.session_config,
+      ['/job:ps', '/job:worker', '/job:chief', '/job:master'])
 
   def test_evaluator_session_config(self):
     tf_config = {

--- a/tensorflow/python/estimator/run_config_test.py
+++ b/tensorflow/python/estimator/run_config_test.py
@@ -1197,8 +1197,8 @@ class RunConfigSessionConfigTest(test.TestCase):
     }
     run_config = _create_run_config_with_cluster_spec(tf_config)
     self._assert_equal_session_config(
-      run_config.session_config,
-      ['/job:ps', '/job:worker', '/job:chief', '/job:master'])
+        run_config.session_config,
+        ['/job:ps', '/job:worker', '/job:chief', '/job:master'])
 
   def test_evaluator_session_config(self):
     tf_config = {


### PR DESCRIPTION
This behaviour matches the description in the _get_default_session_config_distributed docstring, and restores the symmetry of the default device_filters.