### PR TITLE
Modify: fix name problem when export and import graph def of boosted_…

### DIFF
--- a/tensorflow/contrib/boosted_trees/python/ops/stats_accumulator_ops.py
+++ b/tensorflow/contrib/boosted_trees/python/ops/stats_accumulator_ops.py
@@ -106,6 +106,11 @@ class StatsAccumulator(saver.BaseSaverBuilder.SaveableObject):
                                         saver_name + "hessians"),
     ]
 
+    if name.endswith('/'):
+        # tensorflow.python.framework.importer.import_graph_def
+        # will fix name when the name indicates a name scope, it will cause error when restoring
+        # saveable collections
+        name = name[:-1]
     super(StatsAccumulator, self).__init__(self._resource_handle, specs, name)
     resources.register_resource(self._resource_handle, create_op,
                                 is_initialized_op)


### PR DESCRIPTION
**tensorflow/python/framework/importer.py**

```python
  with ops.name_scope(name, 'import', input_map.values()) as scope:
    # Save unique prefix generated by name_scope
    if scope:
      assert scope.endswith('/')
      prefix = scope[:-1]
    else:
      prefix = ''
```

When a variable or saveable objects endswith '/', it will fix it. This will cause a restoring error. Variable or tensor not found.

> "The name 'HzfHomepageWnd/StatsAccumulatorfeature0/' refers to an Operation not in the graph."