### PR TITLE
Skip record reader for cloud file system

### DIFF
--- a/tensorflow/contrib/data/python/kernel_tests/writer_ops_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/writer_ops_test.py
@@ -18,7 +18,6 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import sys
 
 from tensorflow.contrib.data.python.ops import writers
 from tensorflow.python.data.ops import dataset_ops
@@ -53,7 +52,6 @@ class TFRecordWriterTest(test.TestCase):
     for i in range(self._num_records):
       writer.write(self._record(i))
     writer.close()
-    sys.stdout.flush()
     return filename
 
   def _inputFilename(self):

--- a/tensorflow/contrib/data/python/kernel_tests/writer_ops_test.py
+++ b/tensorflow/contrib/data/python/kernel_tests/writer_ops_test.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import sys
 
 from tensorflow.contrib.data.python.ops import writers
 from tensorflow.python.data.ops import dataset_ops
@@ -52,6 +53,7 @@ class TFRecordWriterTest(test.TestCase):
     for i in range(self._num_records):
       writer.write(self._record(i))
     writer.close()
+    sys.stdout.flush()
     return filename
 
   def _inputFilename(self):

--- a/tensorflow/python/lib/io/py_record_reader.cc
+++ b/tensorflow/python/lib/io/py_record_reader.cc
@@ -41,6 +41,14 @@ PyRecordReader* PyRecordReader::New(const string& filename, uint64 start_offset,
     Set_TF_Status_from_Status(out_status, s);
     return nullptr;
   }
+  uint64 file_size;
+  // for some cloud file system (gcs). For empty files, we can still get error
+  // messages form read, we use file size to hijack the actual reader.
+  Status s = Env::Default()->GetFileSize(filename, &file_size);
+  if (file_size == 0) {
+    Set_TF_Status_from_Status(out_status, errors::OutOfRange("eof"));
+    return nullptr;
+  }
   PyRecordReader* reader = new PyRecordReader;
   reader->offset_ = start_offset;
   reader->file_ = file.release();

--- a/tensorflow/python/lib/io/py_record_reader.cc
+++ b/tensorflow/python/lib/io/py_record_reader.cc
@@ -44,10 +44,15 @@ PyRecordReader* PyRecordReader::New(const string& filename, uint64 start_offset,
   uint64 file_size;
   // for some cloud file system (gcs). For empty files, we can still get error
   // messages form read, we use file size to hijack the actual reader.
-  Status s = Env::Default()->GetFileSize(filename, &file_size);
-  if (file_size == 0) {
-    Set_TF_Status_from_Status(out_status, errors::OutOfRange("eof"));
+  Status s1 = Env::Default()->GetFileSize(filename, &file_size);
+  if (!s1.ok()) {
+    Set_TF_Status_from_Status(out_status, s1);
     return nullptr;
+  } else {
+    if (file_size == 0) {
+      Set_TF_Status_from_Status(out_status, errors::OutOfRange("eof"));
+      return nullptr;
+    }
   }
   PyRecordReader* reader = new PyRecordReader;
   reader->offset_ = start_offset;


### PR DESCRIPTION
Addressing this https://github.com/tensorflow/tensorflow/issues/22598

The behaviour of gcs(google cloud file storage) file system is different than local file system.

as
```
 tf.gfile.Open('local_empty.tfrecord').read(100000000) == ''
```
while 
```
tf.gfile.Open('gcs_empty_file.tfrecord').read(1000000)=='Out[11]: "<?xml version='1.0'
 encoding='UTF-8'?><Error>
<Code>InvalidRange</Code>
<Message>The requested range cannot be satisfied. 
</Message>
<Details>bytes=some number</Details></Error>"'
```
so when we use tf.data.TFRecordDataset to process the tfrecord in the gcs, there would be
DataLossError
