### PR TITLE
[Closed] Fix concat primitive descriptor creation error

### DIFF
--- a/tensorflow/core/kernels/mkl_concat_op.cc
+++ b/tensorflow/core/kernels/mkl_concat_op.cc
@@ -776,7 +776,8 @@ class MklConcatOp : public OpKernel {
       if (are_all_mkl_inputs)
          concat_dim = mkl_input_shapes[0].TfDimIdx(concat_dim);
 
-      auto concat_pd = concat::primitive_desc(dst_md, concat_dim, srcs_pd);
+      auto concat_pd = concat::primitive_desc(concat_dim, srcs_pd);
+      auto dst_pd = concat_pd.dst_primitive_desc();
 
       MklDnnShape dnn_shape_dst;
       TensorShape tf_shape_dst;


### PR DESCRIPTION
This fix allows MKL concat op to decide what tensor format to use automatically. It first creates concat w/o dst_md, then queries dst_pd from concat.