### PR TITLE
[Closed] Fix concat primitive descriptor creation bug

### DIFF
--- a/tensorflow/core/kernels/mkl_concat_op.cc
+++ b/tensorflow/core/kernels/mkl_concat_op.cc
@@ -776,7 +776,8 @@ class MklConcatOp : public OpKernel {
       if (are_all_mkl_inputs)
          concat_dim = mkl_input_shapes[0].TfDimIdx(concat_dim);
 
-      auto concat_pd = concat::primitive_desc(dst_md, concat_dim, srcs_pd);
+      auto concat_pd = concat::primitive_desc(concat_dim, srcs_pd);
+      auto dst_pd = concat_pd.dst_primitive_desc();
 
       MklDnnShape dnn_shape_dst;
       TensorShape tf_shape_dst;


### PR DESCRIPTION
When there is tensor format mismatch between tf tensor and mkl tensor, the primitive descriptor creation will error out. This fix allows MKL concat op to decide what format to use on its own. 
It first creates concat w/o dst_md, then queries dst_pd from concat.