### PR TITLE
Comment fix: cudnn output tensor data_format conversion.

### DIFF
--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -851,7 +851,7 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
         ") filter shape(", filter.shape().DebugString(), ")"));
   }
 
-  // Convert the output tensor back from NHWC to NCHW.
+  // Convert the output tensor back from NCHW to NHWC.
   if (data_format == FORMAT_NHWC) {
     functor::NCHWToNHWC<GPUDevice, T, 4>()(
         ctx->eigen_device<GPUDevice>(),


### PR DESCRIPTION
The output tensor data_format conversion in core/kernels/conv_ops.cc should be "from NCHW to NHWC" since the called function is functor::NCHWToNHWC<GPUDevice, T, 4>().