### PR TITLE
Fix warning for format specifier

### DIFF
--- a/tensorflow/core/lib/strings/numbers.cc
+++ b/tensorflow/core/lib/strings/numbers.cc
@@ -391,7 +391,7 @@ string FpToString(Fprint fp) {
 bool StringToFp(const string& s, Fprint* fp) {
   char junk;
   uint64_t result;
-  if (sscanf(s.c_str(), "%lx%c", &result, &junk) == 1) {
+  if (sscanf(s.c_str(), "%llx%c", &result, &junk) == 1) {
     *fp = result;
     return true;
   } else {

--- a/tensorflow/core/util/command_line_flags.cc
+++ b/tensorflow/core/util/command_line_flags.cc
@@ -70,7 +70,7 @@ bool ParseInt64Flag(tensorflow::StringPiece arg, tensorflow::StringPiece flag,
       str_util::ConsumePrefix(&arg, "=")) {
     char extra;
     int64_t parsed_int64;
-    if (sscanf(arg.data(), "%ld%c", &parsed_int64, &extra) != 1) {
+    if (sscanf(arg.data(), "%lld%c", &parsed_int64, &extra) != 1) {
       LOG(ERROR) << "Couldn't interpret value " << arg << " for flag " << flag
                  << ".";
       *value_parsing_ok = false;


### PR DESCRIPTION
tensorflow/core/util/command_line_flags.cc:73:37: warning:
format specifies type 'long *' but the argument has type 'int64_t *' (aka 'long long *') [-Wformat]
    if (sscanf(arg.data(), "%ld%c", &parsed_int64, &extra) != 1) {
                            ~~~     ^~~~~~~~~~~~~
                            %lld
1 warning generated.