### PR TITLE
Make colocations be compatible with DistributionStrategy in SyncReplicasOptimizer

### DIFF
--- a/tensorflow/python/training/sync_replicas_optimizer.py
+++ b/tensorflow/python/training/sync_replicas_optimizer.py
@@ -27,6 +27,7 @@ from tensorflow.python.ops import state_ops
 from tensorflow.python.ops import variable_scope
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.training import distribution_strategy_context
 from tensorflow.python.training import optimizer
 from tensorflow.python.training import queue_runner
 from tensorflow.python.training import session_manager
@@ -245,7 +246,9 @@ class SyncReplicasOptimizer(optimizer.Optimizer):
     # local_anchor op will be placed on this worker task by default.
     local_anchor = control_flow_ops.no_op()
     # Colocating local_step variable prevents it being placed on the PS.
-    with ops.colocate_with(local_anchor):
+    distribution_strategy = (
+        distribution_strategy_context.get_distribution_strategy())
+    with distribution_strategy.colocate_vars_with(local_anchor):
       self._local_step = variable_scope.variable(
           initial_value=0,
           trainable=False,


### PR DESCRIPTION
This is a compatibility improvement related to `DistributionStrategy`.  The `ops.colocate_with` in 'SyncReplicasOptimizer' should be replaced with `distribution.colocate_with_vars` to support `DistributionStrategy`. Otherwise, this `colocation` will be ignored and the `self._local_step` will be placed on `PS`.

This feature can be reffered to `parameter_server_strategy_test.py`.

```
# The device scope is ignored for variables but not for normal ops.
with ops.device('/job:worker/task:0'):
  x = variable_scope.get_variable(
        'x', initializer=10.0,
         aggregation=variable_scope.VariableAggregation.SUM)
```

```
# The colocate_vars_with can override the distribution's device.
with d.colocate_vars_with(x):
  y = variable_scope.get_variable(
        'y', initializer=20.0,
        aggregation=variable_scope.VariableAggregation.SUM)
```

