### PR TITLE
Fix bug in add_n's handling of IndexedSlices

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2135,6 +2135,8 @@ def _as_indexed_slices_list(inputs, optimize=True):
 def add_n(inputs, name=None):
   """Adds all input tensors element-wise.
 
+  Converts `IndexedSlices` objects into dense tensors prior to adding.
+
   Args:
     inputs: A list of `Tensor` or `IndexedSlices` objects, each with same shape
       and type.
@@ -2157,7 +2159,7 @@ def add_n(inputs, name=None):
 
   if len(inputs) == 1:
     if isinstance(inputs[0], ops.IndexedSlices):
-      values = inputs[0].values
+      values = ops.convert_to_tensor(inputs[0])
     else:
       values = inputs[0]
     if name:

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -359,6 +359,17 @@ class AddNTest(test_util.TensorFlowTestCase):
                             [g.eval() for g in add_n_grad])
 
 
+  def testIndexedSlices(self):
+    slc = tf.IndexedSlices(array_ops.constant([1, 2], shape=[1, 2]), 
+        array_ops.constant([2]), array_ops.constant([2,2])
+    slc_as_dense = np.array([[0, 0], [1, 2]])
+    with self.test_session(use_gpu=True):
+      # add_n currently always converts IndexedSlices to dense
+      self.assertAllEqual(slc_as_dense, math_ops.add_n([slc]).eval())
+      self.assertAllEqual(2 * slc_as_dense, math_ops.add_n([slc, slc]).eval())
+
+
+
 class DivAndModTest(test_util.TensorFlowTestCase):
   # TODO(aselle): Test more types before exposing new division operators.
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -361,7 +361,7 @@ class AddNTest(test_util.TensorFlowTestCase):
 
   def testIndexedSlices(self):
     slc = ops.IndexedSlices(array_ops.constant([1, 2], shape=[1, 2]), 
-        array_ops.constant([1]), array_ops.constant([2,2]))
+                            array_ops.constant([1]), array_ops.constant([2, 2]))
     slc_as_dense = np.array([[0, 0], [1, 2]])
     with self.test_session(use_gpu=True):
       # add_n currently always converts IndexedSlices to dense

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -360,8 +360,8 @@ class AddNTest(test_util.TensorFlowTestCase):
 
 
   def testIndexedSlices(self):
-    slc = tf.IndexedSlices(array_ops.constant([1, 2], shape=[1, 2]), 
-        array_ops.constant([2]), array_ops.constant([2,2])
+    slc = ops.IndexedSlices(array_ops.constant([1, 2], shape=[1, 2]), 
+        array_ops.constant([1]), array_ops.constant([2,2]))
     slc_as_dense = np.array([[0, 0], [1, 2]])
     with self.test_session(use_gpu=True):
       # add_n currently always converts IndexedSlices to dense

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -369,7 +369,6 @@ class AddNTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(2 * slc_as_dense, math_ops.add_n([slc, slc]).eval())
 
 
-
 class DivAndModTest(test_util.TensorFlowTestCase):
   # TODO(aselle): Test more types before exposing new division operators.
 


### PR DESCRIPTION
The fix for #15943 (https://github.com/tensorflow/tensorflow/pull/21494) modified the Python `add_n` op to allow `IndexedSlices` in its arguments. This fix introduced a bug in how `add_n` handles an input consisting of a single `IndexedSlices` object. Specifically, `add_n` returns the `values` field of the `IndexedSlices` object, when it should return the tensor representation of the object.

This PR fixes the bug and adds a regression test.