### PR TITLE
Fix for the broken "--config=rocm" build (followup to PR 20277)

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1098,7 +1098,7 @@ def tf_cuda_library(deps = None, cuda_deps = None, copts = tf_copts(), **kwargs)
 
     kwargs["features"] = kwargs.get("features", []) + ["-use_header_modules"]
     native.cc_library(
-        deps = deps + if_cuda(cuda_deps + [
+        deps = deps + if_cuda_is_configured(cuda_deps + [
             clean_dep("//tensorflow/core:cuda"),
             "@local_config_cuda//cuda:cuda_headers",
         ]) + if_rocm_is_configured(cuda_deps + [


### PR DESCRIPTION
This is more of a followup to PR #20277 

As per the following comment by @yifeif 
https://github.com/tensorflow/tensorflow/pull/20277#issuecomment-425178770

`if_cuda_is_configured` was changed to `if_cuda` in the merge to make some internal targets pass. Unfortunately it seems that doing so break the `ROCm` build.

When I try to do a `ROCm` build on a clean repo (post PR 20277 `master` branch), I get the following errors
```
  Successfully uninstalled tensorflow-1.10.0
ERROR: /root/tensorflow/tensorflow/contrib/tensor_forest/BUILD:110:1: Label '//tensorflow/core:gpu_lib' is duplicated in the 'deps' attribute of rule 'tensor_forest_kernels'
ERROR: /root/tensorflow/tensorflow/contrib/tensor_forest/BUILD:220:1: Label '//tensorflow/core:gpu_lib' is duplicated in the 'deps' attribute of rule 'model_ops_kernels'
ERROR: /root/tensorflow/tensorflow/contrib/tensor_forest/BUILD:315:1: Label '//tensorflow/core:gpu_lib' is duplicated in the 'deps' attribute of rule 'stats_ops_kernels'
ERROR: /root/tensorflow/tensorflow/contrib/boosted_trees/BUILD:324:1: Label '//tensorflow/core:gpu_lib' is duplicated in the 'deps' attribute of rule 'model_ops_kernels'
ERROR: /root/tensorflow/tensorflow/contrib/boosted_trees/BUILD:395:1: Label '//tensorflow/core:gpu_lib' is duplicated in the 'deps' attribute of rule 'split_handler_ops_kernels'
ERROR: /root/tensorflow/tensorflow/contrib/boosted_trees/BUILD:439:1: Label '//tensorflow/core:gpu_lib' is duplicated in the 'deps' attribute of rule 'training_ops_kernels'
ERROR: /root/tensorflow/tensorflow/contrib/boosted_trees/BUILD:486:1: Label '//tensorflow/core:gpu_lib' is duplicated in the 'deps' attribute of rule 'prediction_ops_kernels'
ERROR: /root/tensorflow/tensorflow/contrib/boosted_trees/BUILD:534:1: Label '//tensorflow/core:gpu_lib' is duplicated in the 'deps' attribute of rule 'quantile_ops_kernels'
ERROR: /root/tensorflow/tensorflow/contrib/boosted_trees/BUILD:578:1: Label '//tensorflow/core:gpu_lib' is duplicated in the 'deps' attribute of rule 'stats_accumulator_ops_kernels'
```

The following commands can be used to do the `ROCm` build
```
<run configure.py to enable the ROCm support>
bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package 
```

This build does complete without any errors with the commit in this PR.
I realize that this commit will most likely cause regressions in the internal targets/builds that @yifeif eluded to in the comment. So we need to come up with a solution that makes everything work, and we will need your help in that matter.