### PR TITLE
[ROCm] StreamExecutor logic for ROCm platform (PR 20709 continued)

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -329,6 +329,13 @@ config_setting(
 )
 
 config_setting(
+    name = "using_rocm_hipcc",
+    define_values = {
+        "using_rocm_hipcc": "true",
+    },
+)
+
+config_setting(
     name = "with_mpi_support",
     values = {"define": "with_mpi_support=true"},
     visibility = ["//visibility:public"],

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1957,6 +1957,14 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "rocm",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorflow/core/platform/default/build_config:rocm",
+    ],
+)
+
 # -----------------------------------------------------------------------------
 # Clif-related proto libraries.
 

--- a/tensorflow/core/platform/default/build_config/BUILD
+++ b/tensorflow/core/platform/default/build_config/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "if_cuda")
+load("//tensorflow:tensorflow.bzl", "if_rocm")
 load("//tensorflow:tensorflow.bzl", "tf_copts")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_library")
 load("//tensorflow/core:platform/default/build_config_root.bzl", "if_static")
@@ -39,6 +40,7 @@ tf_cuda_library(
         "//tensorflow:using_cuda_nvcc": ["//tensorflow/stream_executor:cuda_platform"],
         "//tensorflow:using_cuda_clang_with_dynamic_build": [],
         "//tensorflow:using_cuda_nvcc_with_dynamic_build": [],
+        "//tensorflow:using_rocm_hipcc": ["//tensorflow/stream_executor:rocm_platform"],
         "//conditions:default": [],
     }) + select({
         "@local_config_cuda//cuda:darwin": ["IOKit"],
@@ -56,6 +58,15 @@ cc_library(
         "@local_config_cuda//cuda:darwin": ["IOKit"],
         "//conditions:default": [],
     }),
+)
+
+cc_library(
+    name = "stream_executor_rocm",
+    deps = [
+        "//tensorflow/stream_executor",
+    ] + if_static(
+        ["//tensorflow/stream_executor:rocm_platform"],
+    ),
 )
 
 cc_library(
@@ -248,6 +259,16 @@ cc_library(
     deps = [
         "@local_config_cuda//cuda:cudart",
     ],
+)
+
+cc_library(
+    name = "rocm",
+    data = [],
+    linkopts = select({
+        "//conditions:default": [
+        ],
+    }),
+    deps = [],
 )
 
 cc_library(

--- a/tensorflow/core/platform/stream_executor.h
+++ b/tensorflow/core/platform/stream_executor.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/stream_executor/dso_loader.h"
 #endif
 #include "tensorflow/stream_executor/cuda/cuda_platform_id.h"
+#include "tensorflow/stream_executor/rocm/rocm_platform_id.h"
 #include "tensorflow/stream_executor/device_memory.h"
 #include "tensorflow/stream_executor/dnn.h"
 #include "tensorflow/stream_executor/event.h"

--- a/tensorflow/core/platform/stream_executor_no_cuda.h
+++ b/tensorflow/core/platform/stream_executor_no_cuda.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/stream_executor/dso_loader.h"
 #endif
 #include "tensorflow/stream_executor/cuda/cuda_platform_id.h"
+#include "tensorflow/stream_executor/rocm/rocm_platform_id.h"
 #include "tensorflow/stream_executor/device_memory.h"
 #include "tensorflow/stream_executor/dnn.h"
 #include "tensorflow/stream_executor/event.h"

--- a/tensorflow/stream_executor/BUILD
+++ b/tensorflow/stream_executor/BUILD
@@ -1,6 +1,7 @@
 licenses(["restricted"])
 
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda_is_configured")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
 load("//tensorflow/core:platform/default/build_config.bzl", "tf_proto_library")
 load("//tensorflow/core:platform/default/build_config.bzl", "tf_additional_all_protos")
 load("//tensorflow/core:platform/default/build_config_root.bzl", "if_static")
@@ -9,6 +10,7 @@ load("//tensorflow:tensorflow.bzl", "cc_header_only_library")
 STREAM_EXECUTOR_HEADERS = glob([
     "*.h",
     "cuda/*.h",
+    "rocm/*.h",
     "host/*.h",
     "lib/*.h",
     "lib/gtl/*.h",
@@ -30,6 +32,7 @@ cc_library(
             "*.cc",
             "host/*.cc",
             "cuda/cuda_platform_id.cc",
+            "rocm/rocm_platform_id.cc",
             "lib/*.cc",
             "platform/default/*.cc",
         ],
@@ -53,6 +56,7 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_rocm//rocm:rocm_headers",
     ],
     alwayslink = 1,
 )
@@ -67,6 +71,7 @@ cc_library(
         "//tensorflow/core:ptr_util",
         "@com_google_absl//absl/strings",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_rocm//rocm:rocm_headers",
     ] + if_static([":stream_executor_impl"]),
 )
 
@@ -110,6 +115,35 @@ cc_library(
         "//tensorflow/core:cuda",
         "@local_config_cuda//cuda:cuda_driver",
         "@local_config_cuda//cuda:cudnn",
+    ]),
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "rocm_platform",
+    srcs = if_rocm_is_configured(
+        glob(
+            [
+                "rocm/*.cc",
+            ],
+            exclude = ["rocm/rocm_platform_id.cc"],
+        ),
+    ),
+    linkopts = select({
+        "//tensorflow:freebsd": [],
+        "//conditions:default": ["-ldl"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":stream_executor",
+        "//tensorflow/core:lib",
+        "@local_config_rocm//rocm:rocm_headers",
+    ] + if_rocm_is_configured([
+        "//tensorflow/core:rocm",
+        "@local_config_rocm//rocm:hiprand",
+        "@local_config_rocm//rocm:rocfft",
+        "@local_config_rocm//rocm:rocblas",
+        "@local_config_rocm//rocm:miopen",
     ]),
     alwayslink = 1,
 )

--- a/tensorflow/stream_executor/device_description.cc
+++ b/tensorflow/stream_executor/device_description.cc
@@ -50,6 +50,7 @@ DeviceDescription::DeviceDescription()
       clock_rate_ghz_(-1.0),
       cuda_compute_capability_major_(-1),
       cuda_compute_capability_minor_(-1),
+      rocm_amdgpu_isa_version_(0),
       numa_node_(-1),
       core_count_(-1),
       ecc_enabled_(false) {}
@@ -112,6 +113,13 @@ bool DeviceDescription::cuda_compute_capability(int *major, int *minor) const {
   return cuda_compute_capability_major_ != 0;
 }
 
+bool DeviceDescription::rocm_amdgpu_isa_version(int *version) const {
+  if (rocm_amdgpu_isa_version_ > 0) { 
+    *version = rocm_amdgpu_isa_version_;
+  }
+  return rocm_amdgpu_isa_version_ > 0;
+}
+  
 bool ThreadDimOk(const DeviceDescription &device_description,
                  const ThreadDim &thread_dim) {
   auto total_threads = thread_dim.x * thread_dim.y * thread_dim.z;

--- a/tensorflow/stream_executor/device_description.h
+++ b/tensorflow/stream_executor/device_description.h
@@ -134,8 +134,8 @@ class DeviceDescription {
   bool cuda_compute_capability(int *major, int *minor) const;
 
   // Returns the AMDGPU ISA version if we're running on the ROCm platform.
-  // If the information is not available, the version will be zero, and the
-  // return value will be false.
+  // If the information is not available, the version will not be modified, 
+  // and the return value will be false.
   bool rocm_amdgpu_isa_version(int *version) const;
 
   // Returns the maximum amount of shared memory present on a single core

--- a/tensorflow/stream_executor/device_description.h
+++ b/tensorflow/stream_executor/device_description.h
@@ -133,6 +133,11 @@ class DeviceDescription {
   // zero, and the return value will be false.
   bool cuda_compute_capability(int *major, int *minor) const;
 
+  // Returns the AMDGPU ISA version if we're running on the ROCm platform.
+  // If the information is not available, the version will be zero, and the
+  // return value will be false.
+  bool rocm_amdgpu_isa_version(int *version) const;
+
   // Returns the maximum amount of shared memory present on a single core
   // (i.e. Streaming Multiprocessor on NVIDIA GPUs; Compute Unit for OpenCL
   // devices). Note that some devices, such as NVIDIA's have a configurable
@@ -194,6 +199,9 @@ class DeviceDescription {
   // CUDA "CC" major value, -1 if not available.
   int cuda_compute_capability_major_;
   int cuda_compute_capability_minor_;
+
+  // ROCM AMDGPU ISA version, 0 if not available.
+  int rocm_amdgpu_isa_version_;
 
   int numa_node_;
   int core_count_;
@@ -278,6 +286,10 @@ class DeviceDescriptionBuilder {
   void set_cuda_compute_capability(int major, int minor) {
     device_description_->cuda_compute_capability_major_ = major;
     device_description_->cuda_compute_capability_minor_ = minor;
+  }
+
+  void set_rocm_amdgpu_isa_version(int version) {
+    device_description_->rocm_amdgpu_isa_version_ = version;
   }
 
   void set_numa_node(int value) { device_description_->numa_node_ = value; }

--- a/tensorflow/stream_executor/platform.cc
+++ b/tensorflow/stream_executor/platform.cc
@@ -28,6 +28,8 @@ string PlatformKindString(PlatformKind kind) {
   switch (kind) {
     case PlatformKind::kCuda:
       return "CUDA";
+    case PlatformKind::kROCm:
+      return "ROCm";
     case PlatformKind::kOpenCL:
       return "OpenCL";
     case PlatformKind::kHost:
@@ -52,6 +54,7 @@ PlatformKind PlatformKindFromString(string kind) {
 bool PlatformIsRunnable(PlatformKind kind) {
   switch (kind) {
     case PlatformKind::kCuda:
+    case PlatformKind::kROCm:
     case PlatformKind::kOpenCL:
     case PlatformKind::kHost:
       return true;
@@ -63,6 +66,7 @@ bool PlatformIsRunnable(PlatformKind kind) {
 bool PlatformIsRunnableOnDevice(PlatformKind kind) {
   switch (kind) {
     case PlatformKind::kCuda:
+    case PlatformKind::kROCm:
     case PlatformKind::kOpenCL:
       return true;
     default:

--- a/tensorflow/stream_executor/platform.h
+++ b/tensorflow/stream_executor/platform.h
@@ -41,6 +41,7 @@ enum class PlatformKind {
   kInvalid,
   kCuda,
   kOpenCL,
+  kROCm,
   kHost,
   kMock,
   kSize,

--- a/tensorflow/stream_executor/rocm/rocm_activation.cc
+++ b/tensorflow/stream_executor/rocm/rocm_activation.cc
@@ -1,0 +1,40 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/stream_executor/rocm/rocm_activation.h"
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+#include "tensorflow/stream_executor/stream_executor.h"
+#include "tensorflow/stream_executor/stream_executor_internal.h"
+
+namespace stream_executor {
+namespace rocm {
+
+int ExtractROCmDeviceOrdinal(ROCMExecutor *rocm_exec);
+ROCMExecutor *ExtractROCmExecutor(StreamExecutor *stream_exec);
+
+ScopedActivateExecutorContext::ScopedActivateExecutorContext(
+    ROCMExecutor *rocm_exec)
+    : driver_scoped_activate_context_(
+          new ScopedActivateContext{ExtractROCmDeviceOrdinal(rocm_exec)}) {}
+
+ScopedActivateExecutorContext::ScopedActivateExecutorContext(
+    StreamExecutor *stream_exec)
+    : ScopedActivateExecutorContext(ExtractROCmExecutor(stream_exec)) {}
+
+ScopedActivateExecutorContext::~ScopedActivateExecutorContext() {
+  delete static_cast<ScopedActivateContext *>(driver_scoped_activate_context_);
+}
+}  // namespace rocm
+}  // namespace stream_executor

--- a/tensorflow/stream_executor/rocm/rocm_activation.h
+++ b/tensorflow/stream_executor/rocm/rocm_activation.h
@@ -1,0 +1,58 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file contains APIs that assume a StreamExecutor is backed by ROCM.
+// It reaches into the ROCM implementation to activate an underlying ROCM
+// context.
+//
+// Having this file separate from rocm_gpu_executor.h means that dependent
+// code does not also have to depend on rocm.h.
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_ACTIVATION_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_ACTIVATION_H_
+
+#include "tensorflow/stream_executor/platform/port.h"
+
+namespace stream_executor {
+
+class StreamExecutor;
+
+namespace rocm {
+
+class ROCMExecutor;
+class ScopedActivateContext;
+
+// Activates a ROCM device within an enclosing scope.
+class ScopedActivateExecutorContext {
+ public:
+  // Form that takes a ROCM executor implementation.
+  explicit ScopedActivateExecutorContext(ROCMExecutor* rocm_exec);
+
+  // Form that takes a pImpl executor and extracts a ROCM implementation --
+  // fatal failure if it is not ROCM inside.
+  explicit ScopedActivateExecutorContext(StreamExecutor* stream_exec);
+
+  ~ScopedActivateExecutorContext();
+
+ private:
+  // The rocm.h-using datatype that we wrap.
+  ScopedActivateContext* driver_scoped_activate_context_;
+
+  SE_DISALLOW_COPY_AND_ASSIGN(ScopedActivateExecutorContext);
+};
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_ACTIVATION_H_

--- a/tensorflow/stream_executor/rocm/rocm_activation.h
+++ b/tensorflow/stream_executor/rocm/rocm_activation.h
@@ -24,10 +24,10 @@ limitations under the License.
 #define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_ACTIVATION_H_
 
 #include "tensorflow/stream_executor/platform/port.h"
+#include "tensorflow/stream_executor/stream_executor.h"
+#include "tensorflow/stream_executor/stream_executor_internal.h"
 
 namespace stream_executor {
-
-class StreamExecutor;
 
 namespace rocm {
 

--- a/tensorflow/stream_executor/rocm/rocm_diagnostics.cc
+++ b/tensorflow/stream_executor/rocm/rocm_diagnostics.cc
@@ -1,0 +1,233 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <dirent.h>
+
+#include <limits.h>
+#include <link.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "tensorflow/stream_executor/lib/error.h"
+#include "tensorflow/stream_executor/lib/inlined_vector.h"
+#include "tensorflow/stream_executor/lib/numbers.h"
+#include "tensorflow/stream_executor/lib/process_state.h"
+#include "tensorflow/stream_executor/lib/status.h"
+#include "tensorflow/stream_executor/lib/str_util.h"
+#include "tensorflow/stream_executor/lib/strcat.h"
+#include "tensorflow/stream_executor/lib/stringpiece.h"
+#include "tensorflow/stream_executor/lib/stringprintf.h"
+#include "tensorflow/stream_executor/platform/logging.h"
+#include "tensorflow/stream_executor/rocm/rocm_diagnostics.h"
+
+namespace stream_executor {
+namespace rocm {
+
+string DriverVersionToString(DriverVersion version) {
+  return port::Printf("%d.%d.%d", std::get<0>(version), std::get<1>(version),
+                      std::get<2>(version));
+}
+
+string DriverVersionStatusToString(port::StatusOr<DriverVersion> version) {
+  if (!version.ok()) {
+    return version.status().ToString();
+  }
+
+  return DriverVersionToString(version.ValueOrDie());
+}
+
+port::StatusOr<DriverVersion> StringToDriverVersion(const string &value) {
+  std::vector<string> pieces = port::Split(value, '.');
+  if (pieces.size() != 2 && pieces.size() != 3) {
+    return port::Status{port::error::INVALID_ARGUMENT,
+                        port::Printf("expected %%d.%%d or %%d.%%d.%%d form for "
+                                     "driver version; got \"%s\"",
+                                     value.c_str())};
+  }
+
+  int major;
+  int minor;
+  int patch = 0;
+  if (!port::safe_strto32(pieces[0], &major)) {
+    return port::Status{
+        port::error::INVALID_ARGUMENT,
+        port::Printf("could not parse major version number \"%s\" as an "
+                     "integer from string \"%s\"",
+                     pieces[0].c_str(), value.c_str())};
+  }
+  if (!port::safe_strto32(pieces[1], &minor)) {
+    return port::Status{
+        port::error::INVALID_ARGUMENT,
+        port::Printf("could not parse minor version number \"%s\" as an "
+                     "integer from string \"%s\"",
+                     pieces[1].c_str(), value.c_str())};
+  }
+  if (pieces.size() == 3 && !port::safe_strto32(pieces[2], &patch)) {
+    return port::Status{
+        port::error::INVALID_ARGUMENT,
+        port::Printf("could not parse patch version number \"%s\" as an "
+                     "integer from string \"%s\"",
+                     pieces[2].c_str(), value.c_str())};
+  }
+
+  DriverVersion result{major, minor, patch};
+  VLOG(2) << "version string \"" << value << "\" made value "
+          << DriverVersionToString(result);
+  return result;
+}
+
+// -- class Diagnostician
+
+string Diagnostician::GetDevNodePath(int dev_node_ordinal) {
+  return port::StrCat("/dev/kfd", dev_node_ordinal);
+}
+
+void Diagnostician::LogDiagnosticInformation() {
+  LOG(INFO) << "retrieving ROCM diagnostic information for host: "
+            << port::Hostname();
+
+  LogDriverVersionInformation();
+}
+
+/* static */ void Diagnostician::LogDriverVersionInformation() {
+  LOG(INFO) << "hostname: " << port::Hostname();
+  if (VLOG_IS_ON(1)) {
+    const char *value = getenv("LD_LIBRARY_PATH");
+    string library_path = value == nullptr ? "" : value;
+    VLOG(1) << "LD_LIBRARY_PATH is: \"" << library_path << "\"";
+
+    std::vector<string> pieces = port::Split(library_path, ':');
+    for (const auto &piece : pieces) {
+      if (piece.empty()) {
+        continue;
+      }
+      DIR *dir = opendir(piece.c_str());
+      if (dir == nullptr) {
+        VLOG(1) << "could not open \"" << piece << "\"";
+        continue;
+      }
+      while (dirent *entity = readdir(dir)) {
+        VLOG(1) << piece << " :: " << entity->d_name;
+      }
+      closedir(dir);
+    }
+  }
+  port::StatusOr<DriverVersion> dso_version = FindDsoVersion();
+  LOG(INFO) << "librocm reported version is: "
+            << DriverVersionStatusToString(dso_version);
+
+  port::StatusOr<DriverVersion> kernel_version = FindKernelDriverVersion();
+  LOG(INFO) << "kernel reported version is: "
+            << DriverVersionStatusToString(kernel_version);
+
+  if (kernel_version.ok() && dso_version.ok()) {
+    WarnOnDsoKernelMismatch(dso_version, kernel_version);
+  }
+}
+
+// Iterates through loaded DSOs with DlIteratePhdrCallback to find the
+// driver-interfacing DSO version number. Returns it as a string.
+port::StatusOr<DriverVersion> Diagnostician::FindDsoVersion() {
+  port::StatusOr<DriverVersion> result{port::Status{
+      port::error::NOT_FOUND,
+      "was unable to find librocm.so DSO loaded into this program"}};
+
+  // Callback used when iterating through DSOs. Looks for the driver-interfacing
+  // DSO and yields its version number into the callback data, when found.
+  auto iterate_phdr = [](struct dl_phdr_info *info, size_t size,
+                         void *data) -> int {
+    if (strstr(info->dlpi_name, "librocm.so.1")) {
+      VLOG(1) << "found DLL info with name: " << info->dlpi_name;
+      char resolved_path[PATH_MAX] = {0};
+      if (realpath(info->dlpi_name, resolved_path) == nullptr) {
+        return 0;
+      }
+      VLOG(1) << "found DLL info with resolved path: " << resolved_path;
+      const char *slash = rindex(resolved_path, '/');
+      if (slash == nullptr) {
+        return 0;
+      }
+      const char *so_suffix = ".so.";
+      const char *dot = strstr(slash, so_suffix);
+      if (dot == nullptr) {
+        return 0;
+      }
+      string dso_version = dot + strlen(so_suffix);
+      // TODO(b/22689637): Eliminate the explicit namespace if possible.
+      auto stripped_dso_version = port::StripSuffixString(dso_version, ".ld64");
+      auto result = static_cast<port::StatusOr<DriverVersion> *>(data);
+      *result = StringToDriverVersion(stripped_dso_version);
+      return 1;
+    }
+    return 0;
+  };
+
+  dl_iterate_phdr(iterate_phdr, &result);
+
+  return result;
+}
+
+port::StatusOr<DriverVersion> Diagnostician::FindKernelModuleVersion(
+    const string &driver_version_file_contents) {
+  static const char *kDriverFilePrelude = "Kernel Module  ";
+  size_t offset = driver_version_file_contents.find(kDriverFilePrelude);
+  if (offset == string::npos) {
+    return port::Status{
+        port::error::NOT_FOUND,
+        port::StrCat("could not find kernel module information in "
+                     "driver version file contents: \"",
+                     driver_version_file_contents, "\"")};
+  }
+
+  string version_and_rest = driver_version_file_contents.substr(
+      offset + strlen(kDriverFilePrelude), string::npos);
+  size_t space_index = version_and_rest.find(" ");
+  auto kernel_version = version_and_rest.substr(0, space_index);
+  // TODO(b/22689637): Eliminate the explicit namespace if possible.
+  auto stripped_kernel_version =
+      port::StripSuffixString(kernel_version, ".ld64");
+  return StringToDriverVersion(stripped_kernel_version);
+}
+
+void Diagnostician::WarnOnDsoKernelMismatch(
+    port::StatusOr<DriverVersion> dso_version,
+    port::StatusOr<DriverVersion> kernel_version) {
+  if (kernel_version.ok() && dso_version.ok() &&
+      dso_version.ValueOrDie() == kernel_version.ValueOrDie()) {
+    LOG(INFO) << "kernel version seems to match DSO: "
+              << DriverVersionToString(kernel_version.ValueOrDie());
+  } else {
+    LOG(ERROR) << "kernel version "
+               << DriverVersionStatusToString(kernel_version)
+               << " does not match DSO version "
+               << DriverVersionStatusToString(dso_version)
+               << " -- cannot find working devices in this configuration";
+  }
+}
+
+port::StatusOr<DriverVersion> Diagnostician::FindKernelDriverVersion() {
+  auto status = port::Status{port::error::UNIMPLEMENTED,
+                             "kernel reported driver version not implemented"};
+  return status;
+}
+}  // namespace rocm
+}  // namespace stream_executor

--- a/tensorflow/stream_executor/rocm/rocm_diagnostics.cc
+++ b/tensorflow/stream_executor/rocm/rocm_diagnostics.cc
@@ -27,14 +27,12 @@ limitations under the License.
 #include <memory>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
 #include "tensorflow/stream_executor/lib/error.h"
-#include "tensorflow/stream_executor/lib/inlined_vector.h"
 #include "tensorflow/stream_executor/lib/numbers.h"
 #include "tensorflow/stream_executor/lib/process_state.h"
 #include "tensorflow/stream_executor/lib/status.h"
 #include "tensorflow/stream_executor/lib/str_util.h"
-#include "tensorflow/stream_executor/lib/strcat.h"
-#include "tensorflow/stream_executor/lib/stringpiece.h"
 #include "tensorflow/stream_executor/lib/stringprintf.h"
 #include "tensorflow/stream_executor/platform/logging.h"
 #include "tensorflow/stream_executor/rocm/rocm_diagnostics.h"
@@ -42,7 +40,7 @@ limitations under the License.
 namespace stream_executor {
 namespace rocm {
 
-string DriverVersionToString(DriverVersion version) {
+static string DriverVersionToString(DriverVersion version) {
   return port::Printf("%d.%d.%d", std::get<0>(version), std::get<1>(version),
                       std::get<2>(version));
 }
@@ -55,7 +53,7 @@ string DriverVersionStatusToString(port::StatusOr<DriverVersion> version) {
   return DriverVersionToString(version.ValueOrDie());
 }
 
-port::StatusOr<DriverVersion> StringToDriverVersion(const string &value) {
+static port::StatusOr<DriverVersion> StringToDriverVersion(const string &value) {
   std::vector<string> pieces = port::Split(value, '.');
   if (pieces.size() != 2 && pieces.size() != 3) {
     return port::Status{port::error::INVALID_ARGUMENT,
@@ -98,7 +96,7 @@ port::StatusOr<DriverVersion> StringToDriverVersion(const string &value) {
 // -- class Diagnostician
 
 string Diagnostician::GetDevNodePath(int dev_node_ordinal) {
-  return port::StrCat("/dev/kfd", dev_node_ordinal);
+  return absl::StrCat("/dev/kfd", dev_node_ordinal);
 }
 
 void Diagnostician::LogDiagnosticInformation() {
@@ -193,7 +191,7 @@ port::StatusOr<DriverVersion> Diagnostician::FindKernelModuleVersion(
   if (offset == string::npos) {
     return port::Status{
         port::error::NOT_FOUND,
-        port::StrCat("could not find kernel module information in "
+        absl::StrCat("could not find kernel module information in "
                      "driver version file contents: \"",
                      driver_version_file_contents, "\"")};
   }

--- a/tensorflow/stream_executor/rocm/rocm_diagnostics.h
+++ b/tensorflow/stream_executor/rocm/rocm_diagnostics.h
@@ -1,0 +1,94 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_DIAGNOSTICS_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_DIAGNOSTICS_H_
+
+#include <tuple>
+#include "tensorflow/stream_executor/platform/port.h"
+
+#include "tensorflow/stream_executor/lib/statusor.h"
+#include "tensorflow/stream_executor/platform/port.h"
+
+namespace stream_executor {
+namespace rocm {
+
+// e.g. DriverVersion{346, 3, 4}
+using DriverVersion = std::tuple<int, int, int>;
+
+// Converts a parsed driver version to string form.
+string DriverVersionToString(DriverVersion version);
+
+// Converts a parsed driver version or status value to natural string form.
+string DriverVersionStatusToString(port::StatusOr<DriverVersion> version);
+
+// Converts a string of a form like "331.79" to a DriverVersion{331, 79}.
+port::StatusOr<DriverVersion> StringToDriverVersion(const string &value);
+
+class Diagnostician {
+ public:
+  // Logs diagnostic information when ROCM appears to be misconfigured (e.g. is
+  // not initializing).
+  //
+  // Note: if we're running on a machine that has no GPUs, we don't want to
+  // produce very much log spew beyond saying, "looks like there's no ROCM
+  // kernel module running".
+  //
+  // Note: we use non-Google-File:: API here because we may be called before
+  // InitGoogle has completed.
+  static void LogDiagnosticInformation();
+
+  // Given the driver version file contents, finds the kernel module version and
+  // returns it as a string.
+  //
+  // This is solely used for more informative log messages when the user is
+  // running on a machine that happens to have a librocm/kernel driver mismatch.
+  static port::StatusOr<DriverVersion> FindKernelModuleVersion(
+      const string &driver_version_file_contents);
+
+  // Extracts the kernel driver version from the current host.
+  static port::StatusOr<DriverVersion> FindKernelDriverVersion();
+
+  // Iterates through loaded DSOs with DlIteratePhdrCallback to find the
+  // driver-interfacing DSO version number. Returns it as a string.
+  static port::StatusOr<DriverVersion> FindDsoVersion();
+
+  // Logs information about the kernel driver version and userspace driver
+  // library version.
+  static void LogDriverVersionInformation();
+
+ private:
+  // Given the DSO version number and the driver version file contents, extracts
+  // the driver version and compares, warning the user in the case of
+  // incompatibility.
+  //
+  // This is solely used for more informative log messages when the user is
+  // running on a machine that happens to have a librocm/kernel driver mismatch.
+  static void WarnOnDsoKernelMismatch(
+      port::StatusOr<DriverVersion> dso_version,
+      port::StatusOr<DriverVersion> kernel_version);
+
+  // Logs information about the dev nodes present on this machine: their
+  // existence, permissions, accessibility from this uid/gid.
+  static void LogDevNodeDiagnosticInformation();
+
+  static string GetDevNodePath(int dev_node_ordinal);
+
+  SE_DISALLOW_COPY_AND_ASSIGN(Diagnostician);
+};
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_DIAGNOSTICS_H_

--- a/tensorflow/stream_executor/rocm/rocm_diagnostics.h
+++ b/tensorflow/stream_executor/rocm/rocm_diagnostics.h
@@ -28,14 +28,8 @@ namespace rocm {
 // e.g. DriverVersion{346, 3, 4}
 using DriverVersion = std::tuple<int, int, int>;
 
-// Converts a parsed driver version to string form.
-string DriverVersionToString(DriverVersion version);
-
 // Converts a parsed driver version or status value to natural string form.
 string DriverVersionStatusToString(port::StatusOr<DriverVersion> version);
-
-// Converts a string of a form like "331.79" to a DriverVersion{331, 79}.
-port::StatusOr<DriverVersion> StringToDriverVersion(const string &value);
 
 class Diagnostician {
  public:

--- a/tensorflow/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/stream_executor/rocm/rocm_driver.cc
@@ -1,0 +1,1280 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <map>
+#include <set>
+#include <utility>
+
+#include "tensorflow/stream_executor/lib/casts.h"
+#include "tensorflow/stream_executor/lib/env.h"
+#include "tensorflow/stream_executor/lib/error.h"
+#include "tensorflow/stream_executor/lib/human_readable.h"
+#include "tensorflow/stream_executor/lib/inlined_vector.h"
+#include "tensorflow/stream_executor/lib/notification.h"
+#include "tensorflow/stream_executor/lib/stacktrace.h"
+#include "tensorflow/stream_executor/lib/static_threadlocal.h"
+#include "tensorflow/stream_executor/lib/strcat.h"
+#include "tensorflow/stream_executor/lib/stringprintf.h"
+#include "tensorflow/stream_executor/lib/threadpool.h"
+#include "tensorflow/stream_executor/platform/logging.h"
+#include "tensorflow/stream_executor/platform/mutex.h"
+#include "tensorflow/stream_executor/platform/port.h"
+#include "tensorflow/stream_executor/rocm/rocm_diagnostics.h"
+
+bool FLAGS_gpuexec_rocm_driver_inject_init_error = false;
+bool FLAGS_gpuexec_rocm_sync_around_driver_calls = false;
+bool FLAGS_gpuexec_rocm_device_0_only = false;
+
+// Debugging: on each push and pop of a rocm context, verify the current device
+// matches the expected one.
+constexpr bool kVerifyROCmDevice = false;
+
+namespace stream_executor {
+namespace rocm {
+
+namespace {
+
+// Formats hipError_t to output prettified values into a log stream.
+// Error summaries taken from:
+//
+// TODO(leary) switch to cuGetErrorName when updated rocm.h is available.
+string ToString(hipError_t result) {
+#define OSTREAM_ROCM_ERROR(__name) \
+  case hipError##__name:           \
+    return "HIP_ERROR_" #__name;
+
+///////////////
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch"
+  switch (result) {
+    OSTREAM_ROCM_ERROR(InvalidValue)
+    OSTREAM_ROCM_ERROR(OutOfMemory)
+    OSTREAM_ROCM_ERROR(NotInitialized)
+    OSTREAM_ROCM_ERROR(Deinitialized)
+    OSTREAM_ROCM_ERROR(NoDevice)
+    OSTREAM_ROCM_ERROR(InvalidDevice)
+    OSTREAM_ROCM_ERROR(InvalidImage)
+    OSTREAM_ROCM_ERROR(InvalidContext)
+    OSTREAM_ROCM_ERROR(InvalidHandle)
+    OSTREAM_ROCM_ERROR(NotFound)
+    OSTREAM_ROCM_ERROR(NotReady)
+    OSTREAM_ROCM_ERROR(NoBinaryForGpu)
+
+    // Encountered an uncorrectable ECC error during execution.
+    OSTREAM_ROCM_ERROR(ECCNotCorrectable)
+
+    // Load/store on an invalid address. Must reboot all context.
+    case 700:
+      return "ROCM_ERROR_ILLEGAL_ADDRESS";
+    // Passed too many / wrong arguments, too many threads for register count.
+    case 701:
+      return "ROCM_ERROR_LAUNCH_OUT_OF_RESOURCES";
+
+      OSTREAM_ROCM_ERROR(ContextAlreadyInUse)
+      OSTREAM_ROCM_ERROR(PeerAccessUnsupported)
+      OSTREAM_ROCM_ERROR(Unknown)  // Unknown internal error to ROCM.
+    default:
+      return port::StrCat("hipError_t(", static_cast<int>(result), ")");
+  }
+#pragma GCC diagnostic pop
+}
+
+// ROCM driver routines may require a large amount of stack (particularly
+// hipModuleLoadDataEx, in our experience). To avoid stack overflow when using
+// stack-limited threads (such as those spawned by a default-argument
+// thread::ThreadPool on some platforms), we run certain routines in this pool
+// and wait for completion.
+static mutex driver_executor_threadpool_mu(LINKER_INITIALIZED);
+static port::ThreadPool *InitializeDriverExecutor() {
+  return new port::ThreadPool(port::Env::Default(), port::ThreadOptions(),
+                              "rocm_driver", 1);
+}
+
+port::ThreadPool *GetDriverExecutor() {
+  mutex_lock lock(driver_executor_threadpool_mu);
+  static port::ThreadPool *thread_pool = InitializeDriverExecutor();
+  return thread_pool;
+}
+}  // namespace
+
+string MemorySpaceString(MemorySpace memory_space) {
+  switch (memory_space) {
+    case MemorySpace::kHost:
+      return "host";
+    case MemorySpace::kDevice:
+      return "device";
+    default:
+      LOG(FATAL) << "impossible memory space";
+  }
+}
+
+namespace {
+
+// Call hipDeviceSynchronize and crash if it doesn't succeed.
+void SynchronizeOrDie() {
+  auto res = hipDeviceSynchronize();
+  if (res != hipSuccess) {
+    LOG(FATAL) << "Synchronize found " << ToString(res)
+               << " :: " << port::CurrentStackTrace();
+  }
+}
+
+struct ThreadLocalData {
+  int current_device_ordinal;
+  int depth;
+};
+
+SE_STATIC_THREAD_LOCAL_POD(ThreadLocalData, tls_data);
+}  // namespace
+
+ScopedActivateContext::ScopedActivateContext(int device_ordinal) {
+  if (FLAGS_gpuexec_rocm_sync_around_driver_calls) {
+    SynchronizeOrDie();
+  }
+
+  auto *tls = &tls_data.get();
+  if (tls->depth == 0) {
+    tls->current_device_ordinal = ROCMDriver::CurrentDeviceOrDie();
+  }
+
+  if (kVerifyROCmDevice) {
+    CHECK_EQ(ROCMDriver::CurrentDeviceOrDie(), tls->current_device_ordinal);
+  }
+
+  tls->depth++;
+
+  to_restore_ = tls->current_device_ordinal;
+
+  if (device_ordinal == tls->current_device_ordinal) {
+    DCHECK_EQ(ROCMDriver::CurrentDeviceOrDie(), device_ordinal);
+    return;
+  }
+
+  VLOG(3) << "ScopedActivateContext switching device from "
+          << tls->current_device_ordinal << " to " << device_ordinal;
+
+  // Set the device and update thread local.
+  CHECK_EQ(hipSuccess, hipSetDevice(device_ordinal));
+  tls->current_device_ordinal = device_ordinal;
+}
+
+ScopedActivateContext::~ScopedActivateContext() {
+  if (FLAGS_gpuexec_rocm_sync_around_driver_calls) {
+    SynchronizeOrDie();
+  }
+
+  auto *tls = &tls_data.get();
+
+  if (kVerifyROCmDevice) {
+    CHECK_EQ(ROCMDriver::CurrentDeviceOrDie(), tls->current_device_ordinal);
+  }
+
+  tls->depth--;
+  DCHECK_GE(tls->depth, 0);
+
+  if (to_restore_ == tls->current_device_ordinal) {
+    DCHECK_EQ(ROCMDriver::CurrentDeviceOrDie(), to_restore_);
+    return;
+  }
+
+  VLOG(3) << "ScopedActivateContext switching device from "
+          << tls->current_device_ordinal << " to " << to_restore_;
+
+  // Set context and update thread local.
+  CHECK_EQ(hipSuccess, hipSetDevice(to_restore_));
+  tls->current_device_ordinal = to_restore_;
+}
+
+namespace {
+
+// Returns a stringified device number associated with pointer, primarily for
+// logging purposes. Returns "?" if the device could not be successfully
+// queried.
+string ROCMPointerToDeviceString(hipDeviceptr_t pointer) {
+  auto value = ROCMDriver::GetPointerDevice(pointer);
+  if (value.ok()) {
+    return port::StrCat(value.ValueOrDie());
+  }
+  LOG(ERROR) << "could not query device: " << value.status();
+  return "?";
+}
+
+// Returns a stringified memory space associated with pointer, primarily for
+// logging purposes. Returns "?" if the memory space could not be successfully
+// queried.
+string ROCMPointerToMemorySpaceString(hipDeviceptr_t pointer) {
+  auto value = ROCMDriver::GetPointerMemorySpace(pointer);
+  if (value.ok()) {
+    return MemorySpaceString(value.ValueOrDie());
+  }
+  LOG(ERROR) << "could not query device: " << value.status();
+  return "?";
+}
+
+// Returns a stringified representation of whether or not peer access is
+// permitted between the "from" and "to" pointers' associated contexts,
+// primarily for logging purposes. Returns "error" if an error is encountered
+// in the process of querying.
+string ROCMPointersToCanAccessString(hipDeviceptr_t from, hipDeviceptr_t to) {
+  hipPointerAttribute_t from_pointerAttributes;
+  hipError_t result = hipPointerGetAttributes(&from_pointerAttributes, from);
+  if (result != hipSuccess) {
+    LOG(ERROR) << "could not retrieve source pointer's device: "
+               << ToString(result);
+    return "error";
+  }
+
+  hipPointerAttribute_t to_pointerAttributes;
+  result = hipPointerGetAttributes(&to_pointerAttributes, to);
+  if (result != hipSuccess) {
+    LOG(ERROR) << "could not retrieve destination pointer's device: "
+               << ToString(result);
+    return "error";
+  }
+
+  return ROCMDriver::CanEnablePeerAccess(from_pointerAttributes.device,
+                                         to_pointerAttributes.device)
+             ? "true"
+             : "false";
+}
+
+// Actually performs the work of ROCM initialization. Wrapped up in one-time
+// execution guard.
+static port::Status InternalInit() {
+  hipError_t res = hipErrorNoDevice;
+  if (FLAGS_gpuexec_rocm_driver_inject_init_error) {
+    LOG(ERROR) << "injecting ROCM init error; initialization will fail";
+  } else {
+    res = hipInit(0 /* = flags */);
+  }
+
+  if (res == hipSuccess) {
+    return port::Status::OK();
+  }
+
+  LOG(ERROR) << "failed call to hipInit: " << ToString(res);
+  Diagnostician::LogDiagnosticInformation();
+  return port::Status{port::error::ABORTED,
+                      port::StrCat("failed call to hipInit: ", ToString(res))};
+}
+}  // namespace
+
+/* static */ port::Status ROCMDriver::Init() {
+  // Cached return value from calling InternalInit(), as hipInit need only be
+  // called once, but ROCMDriver::Init may be called many times.
+  static port::Status init_retval;
+  static bool set = false;
+  static mutex *init_mu = new mutex;
+
+  mutex_lock lock(*init_mu);
+  if (!set) {
+    init_retval = InternalInit();
+    set = true;
+  }
+
+  return init_retval;
+}
+
+/* static */ port::Status ROCMDriver::GetDevice(int device_ordinal,
+                                                hipDevice_t *device) {
+  hipError_t res = hipDeviceGet(device, device_ordinal);
+  if (res == hipSuccess) {
+    return port::Status::OK();
+  }
+
+  return port::Status{
+      port::error::INTERNAL,
+      port::StrCat("failed call to hipDeviceGet: ", ToString(res))};
+}
+
+/* static */ bool ROCMDriver::GetDeviceName(hipDevice_t device,
+                                            string *device_name) {
+  static const size_t kCharLimit = 64;
+  port::InlinedVector<char, 4> chars(kCharLimit);
+  hipError_t res = hipDeviceGetName(chars.begin(), kCharLimit - 1, device);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to get device name for " << device << ": "
+               << ToString(res);
+    return false;
+  }
+  chars[kCharLimit - 1] = '\0';
+  *device_name = chars.begin();
+  return true;
+}
+
+bool DeviceOptionsToContextFlags(const DeviceOptions &device_options,
+                                 int *flags) {
+  static_assert(DeviceOptions::kMask == 0xf,
+                "needs update for new device options");
+  return true;
+}
+
+/* static */ bool ROCMDriver::FuncGetAttribute(hipDeviceAttribute_t attribute,
+                                               hipFunction_t func,
+                                               int *attribute_value) {
+  // ROCM TODO properly implement this feature in HIP
+  hipError_t res = hipSuccess;
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query kernel attribute. kernel: " << func
+               << ", attribute: " << attribute;
+    return false;
+  }
+  return true;
+}
+
+/* static */ bool ROCMDriver::FuncSetCacheConfig(hipFunction_t function,
+                                                 hipFuncCache_t cache_config) {
+  hipError_t res = hipFuncSetCacheConfig(function, cache_config);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to set ROCM kernel cache config. kernel: " << function
+               << ", config: " << cache_config << ", result: " << ToString(res);
+    return false;
+  }
+
+  return true;
+}
+
+/* static */ port::StatusOr<hipSharedMemConfig>
+ROCMDriver::DeviceGetSharedMemConfig(int device_ordinal) {
+  hipSharedMemConfig shared_mem_config;
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t result = hipDeviceGetSharedMemConfig(&shared_mem_config);
+  if (result != hipSuccess) {
+    LOG(ERROR) << "failed to get ROCM device shared memory config. "
+               << "Context device ID: " << device_ordinal
+               << ", result: " << ToString(result);
+    return port::Status{
+        port::error::INTERNAL,
+        port::StrCat("failed to get shared memory config: ", ToString(result))};
+  }
+  return shared_mem_config;
+}
+
+/* static */ port::Status ROCMDriver::DeviceSetSharedMemConfig(
+    int device_ordinal, hipSharedMemConfig shared_mem_config) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t result = hipDeviceSetSharedMemConfig(shared_mem_config);
+  if (result != hipSuccess) {
+    LOG(ERROR) << "failed to set ROCM device shared memory config. "
+               << "Context device ID: " << device_ordinal
+               << ", config: " << shared_mem_config
+               << ", result: " << ToString(result);
+    return port::Status{
+        port::error::INTERNAL,
+        port::StrCat("failed to set shared memory config: ", ToString(result))};
+  }
+  return port::Status::OK();
+}
+
+/* static */ bool ROCMDriver::LaunchKernel(
+    int device_ordinal, hipFunction_t function, unsigned int grid_dim_x,
+    unsigned int grid_dim_y, unsigned int grid_dim_z, unsigned int block_dim_x,
+    unsigned int block_dim_y, unsigned int block_dim_z,
+    unsigned int shared_mem_bytes, hipStream_t stream, void **kernel_params,
+    void **extra) {
+  ScopedActivateContext activation{device_ordinal};
+  VLOG(2) << "launching kernel: " << function << "; gdx: " << grid_dim_x
+          << " gdy: " << grid_dim_y << " gdz: " << grid_dim_z
+          << " bdx: " << block_dim_x << " bdy: " << block_dim_y
+          << " bdz: " << block_dim_z << " smem: " << shared_mem_bytes;
+  hipError_t res = hipModuleLaunchKernel(
+      function, grid_dim_x, grid_dim_y, grid_dim_z, block_dim_x, block_dim_y,
+      block_dim_z, shared_mem_bytes, stream, kernel_params, extra);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to launch ROCM kernel: " << function
+               << "; result: " << ToString(res);
+    return false;
+  }
+  VLOG(2) << "successfully launched kernel";
+  return true;
+}
+
+/* static */ bool ROCMDriver::LoadHsaco(int device_ordinal,
+                                        const char *hsaco_contents,
+                                        hipModule_t *module) {
+  port::Notification notification;
+  bool ret = true;
+  GetDriverExecutor()->Schedule(
+      [device_ordinal, hsaco_contents, module, &ret, &notification]() {
+        ScopedActivateContext activation{device_ordinal};
+        void *hsaco_data = const_cast<char *>(hsaco_contents);
+
+        hipError_t res = hipModuleLoadData(module, hsaco_data);
+
+        if (res != hipSuccess) {
+          LOG(ERROR) << "failed to load HSACO: " << ToString(res);
+          ret = false;
+          notification.Notify();
+        }
+
+        CHECK(module != nullptr);
+        notification.Notify();
+      });
+  notification.WaitForNotification();
+
+  return ret;
+}
+
+/* static */ bool ROCMDriver::SynchronousMemsetUint8(int device_ordinal,
+                                                     hipDeviceptr_t location,
+                                                     uint8 value, size_t size) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipMemset(location, value, size);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to memset memory: " << ToString(res);
+    return false;
+  }
+  return true;
+}
+
+/* static */ bool ROCMDriver::SynchronousMemsetUint32(int device_ordinal,
+                                                      hipDeviceptr_t location,
+                                                      uint32 value,
+                                                      size_t uint32_count) {
+  ScopedActivateContext activation{device_ordinal};
+  void *pointer = port::bit_cast<void *>(location);
+  unsigned char valueC = static_cast<unsigned char>(value);
+  uint32_t value32 = (valueC << 24) | (valueC << 16) | (valueC << 8) | (valueC);
+  assert(value32 == value);  // if mismatch this indicates case where
+                             // hipMemsetAsyc can't emulate hipMemSetD32
+  hipError_t res =
+      hipMemset(pointer, static_cast<int>(value), uint32_count * 4);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to memset memory: " << ToString(res);
+    return false;
+  }
+  return true;
+}
+
+/* static */ bool ROCMDriver::AsynchronousMemsetUint8(int device_ordinal,
+                                                      hipDeviceptr_t location,
+                                                      uint8 value,
+                                                      size_t uint32_count,
+                                                      hipStream_t stream) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipMemsetAsync(location, value, uint32_count, stream);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to enqueue async memset operation: " << ToString(res);
+    return false;
+  }
+  VLOG(2) << "successfully enqueued async memset operation";
+  return true;
+}
+
+/* static */ bool ROCMDriver::AsynchronousMemsetUint32(int device_ordinal,
+                                                       hipDeviceptr_t location,
+                                                       uint32 value,
+                                                       size_t uint32_count,
+                                                       hipStream_t stream) {
+  ScopedActivateContext activation{device_ordinal};
+  void *pointer = port::bit_cast<void *>(location);
+
+  // FIXME - need to set a 32-bit value here
+  unsigned char valueC = static_cast<unsigned char>(value);
+  uint32_t value32 = (valueC << 24) | (valueC << 16) | (valueC << 8) | (valueC);
+  assert(value32 == value);  // if mismatch this indicates case where
+                             // hipMemsetAsyc can't emulate hipMemSetD32
+  hipError_t res = hipMemsetAsync(pointer, value, uint32_count * 4, stream);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to enqueue async memset operation: " << ToString(res);
+    return false;
+  }
+  VLOG(2) << "successfully enqueued async memset operation";
+  return true;
+}
+
+/* static */ bool ROCMDriver::AddStreamCallback(int device_ordinal,
+                                                hipStream_t stream,
+                                                StreamCallback callback,
+                                                void *data) {
+  hipError_t res = hipStreamAddCallback(stream, (hipStreamCallback_t)callback,
+                                        data, 0 /* = flags */);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "unable to add host callback: " << ToString(res);
+    return false;
+  }
+  return true;
+}
+
+/* static */ bool ROCMDriver::GetModuleFunction(int device_ordinal,
+                                                hipModule_t module,
+                                                const char *kernel_name,
+                                                hipFunction_t *function) {
+  ScopedActivateContext activated{device_ordinal};
+  CHECK(module != nullptr && kernel_name != nullptr);
+  hipError_t res = hipModuleGetFunction(function, module, kernel_name);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to get kernel \"" << kernel_name
+               << "\" from module: " << ToString(res);
+    return false;
+  }
+
+  return true;
+}
+
+/* static */ bool ROCMDriver::GetModuleSymbol(int device_ordinal,
+                                              hipModule_t module,
+                                              const char *symbol_name,
+                                              hipDeviceptr_t *dptr,
+                                              size_t *bytes) {
+  ScopedActivateContext activated{device_ordinal};
+  CHECK(module != nullptr && symbol_name != nullptr &&
+        (dptr != nullptr || bytes != nullptr));
+  hipError_t res = hipModuleGetGlobal(dptr, bytes, module, symbol_name);
+  if (res != hipSuccess) {
+    // symbol may not be found in the current module, but it may reside in
+    // another module.
+    VLOG(2) << "failed to get symbol \"" << symbol_name
+            << "\" from module: " << ToString(res);
+    return false;
+  }
+
+  return true;
+}
+
+/* static */ void ROCMDriver::UnloadModule(int device_ordinal,
+                                           hipModule_t module) {
+  ScopedActivateContext activated{device_ordinal};
+  hipError_t res = hipModuleUnload(module);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to unload module " << module
+               << "; leaking: " << ToString(res);
+  }
+}
+
+/* static */ bool ROCMDriver::CreateStream(int device_ordinal,
+                                           hipStream_t *out) {
+  ScopedActivateContext activated{device_ordinal};
+  hipError_t res = hipStreamCreateWithFlags(
+      out, hipStreamDefault);  // switch to hipStreamNonBlocking?
+  if (res != hipSuccess) {
+    LOG(ERROR) << "could not allocate ROCM stream for device " << device_ordinal
+               << ": " << ToString(res);
+    return false;
+  }
+
+  VLOG(2) << "successfully created stream " << *out << " for device "
+          << device_ordinal << " on thread";
+  return true;
+}
+
+/* static */ void ROCMDriver::DestroyStream(int device_ordinal,
+                                            hipStream_t *stream) {
+  if (*stream == nullptr) {
+    return;
+  }
+
+  ScopedActivateContext activated{device_ordinal};
+  hipError_t res = hipStreamDestroy(*stream);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to destroy ROCM stream for device " << device_ordinal
+               << ": " << ToString(res);
+  } else {
+    VLOG(2) << "successfully destroyed stream " << *stream << " for device "
+            << device_ordinal;
+    *stream = nullptr;
+  }
+}
+
+/* static */ void *ROCMDriver::DeviceAllocate(int device_ordinal,
+                                              uint64 bytes) {
+  ScopedActivateContext activated{device_ordinal};
+  hipDeviceptr_t result = 0;
+  hipError_t res = hipMalloc(&result, bytes);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to allocate "
+               << port::HumanReadableNumBytes::ToString(bytes) << " (" << bytes
+               << " bytes) from device: " << ToString(res);
+    return nullptr;
+  }
+  void *ptr = reinterpret_cast<void *>(result);
+  VLOG(2) << "allocated " << ptr << " for device " << device_ordinal << " of "
+          << bytes << " bytes";
+  return ptr;
+}
+
+/* static */ void ROCMDriver::DeviceDeallocate(int device_ordinal,
+                                               void *location) {
+  ScopedActivateContext activation{device_ordinal};
+  hipDeviceptr_t pointer = port::bit_cast<hipDeviceptr_t>(location);
+  hipError_t res = hipFree(pointer);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to free device memory at " << location
+               << "; result: " << ToString(res);
+  } else {
+    VLOG(2) << "deallocated " << location << " for device " << device_ordinal;
+  }
+}
+
+/* static */ void *ROCMDriver::HostAllocate(int device_ordinal, uint64 bytes) {
+  ScopedActivateContext activation{device_ordinal};
+  void *host_mem = nullptr;
+  // "Portable" memory is visible to all ROCM contexts. Safe for our use model.
+  hipError_t res = hipHostMalloc(&host_mem, bytes, hipHostMallocPortable);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to alloc " << bytes
+               << " bytes on host: " << ToString(res);
+  }
+  return host_mem;
+}
+
+/* static */ void ROCMDriver::HostDeallocate(int device_ordinal,
+                                             void *location) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipHostFree(location);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "error deallocating host memory at " << location << ": "
+               << ToString(res);
+  }
+}
+
+/* static */ bool ROCMDriver::HostRegister(int device_ordinal, void *location,
+                                           uint64 bytes) {
+  ScopedActivateContext activation{device_ordinal};
+  // "Portable" memory is visible to all ROCM contexts. Safe for our use model.
+  hipError_t res = hipHostRegister(location, bytes, hipHostRegisterPortable);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "error registering host memory at " << location << ": "
+               << ToString(res);
+    return false;
+  }
+  return true;
+}
+
+/* static */ bool ROCMDriver::HostUnregister(int device_ordinal,
+                                             void *location) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipHostUnregister(location);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "error unregistering host memory at " << location << ": "
+               << ToString(res);
+    return false;
+  }
+  return true;
+}
+
+/* static */ port::Status ROCMDriver::DestroyEvent(int device_ordinal,
+                                                   hipEvent_t *event) {
+  if (*event == nullptr) {
+    return port::Status{port::error::INVALID_ARGUMENT,
+                        "input event cannot be null"};
+  }
+
+  ScopedActivateContext activated{device_ordinal};
+  hipError_t res = hipEventDestroy(*event);
+  *event = nullptr;
+
+  switch (res) {
+    case hipSuccess:
+      return port::Status::OK();
+    case hipErrorDeinitialized:
+    case hipErrorNotInitialized:
+      return port::Status{
+          port::error::FAILED_PRECONDITION,
+          port::Printf("error destroying ROCM event in device %d: %s",
+                       device_ordinal, ToString(res).c_str())};
+    default:
+      return port::Status{
+          port::error::INTERNAL,
+          port::Printf("error destroying ROCM event in device %d: %s",
+                       device_ordinal, ToString(res).c_str())};
+  }
+}
+
+/* static */ port::Status ROCMDriver::RecordEvent(int device_ordinal,
+                                                  hipEvent_t event,
+                                                  hipStream_t stream) {
+  ScopedActivateContext activated{device_ordinal};
+  hipError_t res = hipEventRecord(event, stream);
+  switch (res) {
+    case hipSuccess:
+      return port::Status::OK();
+    case hipErrorDeinitialized:
+    case hipErrorNotInitialized:
+      return port::Status{
+          port::error::FAILED_PRECONDITION,
+          port::Printf("error recording ROCM event on stream %p: %s", stream,
+                       ToString(res).c_str())};
+    default:
+      return port::Status{
+          port::error::INVALID_ARGUMENT,
+          port::Printf("error recording ROCM event on stream %p: %s", stream,
+                       ToString(res).c_str())};
+  }
+}
+
+/* static */ port::StatusOr<hipError_t> ROCMDriver::QueryEvent(
+    int device_ordinal, hipEvent_t event) {
+  ScopedActivateContext activated{device_ordinal};
+  hipError_t res = hipEventQuery(event);
+  if (res != hipSuccess && res != hipErrorNotReady) {
+    return port::Status{
+        port::error::INTERNAL,
+        port::Printf("failed to query event: %s", ToString(res).c_str())};
+  }
+
+  return res;
+}
+
+/* static */ bool ROCMDriver::GetEventElapsedTime(int device_ordinal,
+                                                  float *elapsed_milliseconds,
+                                                  hipEvent_t start,
+                                                  hipEvent_t stop) {
+  ScopedActivateContext activated{device_ordinal};
+  // The stop event must have completed in order for hipEventElapsedTime to
+  // work.
+  hipError_t res = hipEventSynchronize(stop);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to synchronize the stop event: " << ToString(res);
+    return false;
+  }
+  res = hipEventElapsedTime(elapsed_milliseconds, start, stop);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to get elapsed time between events: "
+               << ToString(res);
+    return false;
+  }
+
+  return true;
+}
+
+/* static */ bool ROCMDriver::WaitStreamOnEvent(int device_ordinal,
+                                                hipStream_t stream,
+                                                hipEvent_t event) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipStreamWaitEvent(stream, event, 0 /* = flags */);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "could not wait stream on event: " << ToString(res);
+    return false;
+  }
+
+  return true;
+}
+
+/* static */ bool ROCMDriver::SynchronizeDevice(int device_ordinal) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipDeviceSynchronize();
+  if (res != hipSuccess) {
+    LOG(ERROR) << "could not synchronize on ROCM device: " << ToString(res)
+               << " :: " << port::CurrentStackTrace();
+    return false;
+  }
+
+  return true;
+}
+
+/* static */ port::Status ROCMDriver::SynchronizeStream(int device_ordinal,
+                                                        hipStream_t stream) {
+  ScopedActivateContext activated{device_ordinal};
+  CHECK(stream != nullptr);
+  hipError_t res = hipStreamSynchronize(stream);
+  if (res != hipSuccess) {
+    port::Status status = port::InternalError(
+        port::StrCat("could not synchronize on ROCM stream: ", ToString(res)));
+    LOG(ERROR) << status << " :: " << port::CurrentStackTrace();
+    return status;
+  }
+  VLOG(2) << "successfully synchronized stream " << stream << " on device "
+          << device_ordinal;
+  return port::Status::OK();
+}
+
+/* static */ bool ROCMDriver::IsStreamIdle(int device_ordinal,
+                                           hipStream_t stream) {
+  ScopedActivateContext activated{device_ordinal};
+  CHECK(stream != nullptr);
+  hipError_t res = hipStreamQuery(stream);
+  if (res == hipSuccess) {
+    return true;
+  }
+
+  if (res != hipErrorNotReady) {
+    LOG(ERROR) << "stream in bad state on status query: " << ToString(res);
+  }
+  return false;
+}
+
+/* static */ port::Status ROCMDriver::SynchronousMemcpyD2H(
+    int device_ordinal, void *host_dst, hipDeviceptr_t gpu_src, uint64 size) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipMemcpyDtoH(host_dst, gpu_src, size);
+  if (res != hipSuccess) {
+    return port::InternalError(
+        port::Printf("failed to synchronous memcpy from device to host: %s; "
+                     "host dst: %p; GPU src: %p; size: %llu=0x%llx",
+                     ToString(res).c_str(), host_dst,
+                     port::bit_cast<void *>(gpu_src), size, size));
+  }
+  VLOG(2) << "successfully sync memcpy'd d2h of " << size << " bytes to "
+          << host_dst;
+  return port::Status::OK();
+}
+
+/* static */ port::Status ROCMDriver::SynchronousMemcpyH2D(
+    int device_ordinal, hipDeviceptr_t gpu_dst, const void *host_src,
+    uint64 size) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipMemcpyHtoD(gpu_dst, const_cast<void *>(host_src), size);
+  if (res != hipSuccess) {
+    return port::InternalError(port::Printf(
+        "failed to synchronous memcpy from host to device: %s; GPU dst: %p;"
+        " host src: %p; size: %llu=0x%llx",
+        ToString(res).c_str(), port::bit_cast<void *>(gpu_dst), host_src, size,
+        size));
+  }
+  VLOG(2) << "successfully enqueued sync memcpy h2d of " << size << " bytes";
+  return port::Status::OK();
+}
+
+/* static */ port::Status ROCMDriver::SynchronousMemcpyD2D(
+    int device_ordinal, hipDeviceptr_t gpu_dst, hipDeviceptr_t gpu_src,
+    uint64 size) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipMemcpyDtoD(gpu_dst, gpu_src, size);
+  if (res != hipSuccess) {
+    return port::InternalError(port::Printf(
+        "failed to synchronous memcpy from host to device: %s; GPU dst: %p; "
+        "GPU src: %p; size: %llu=0x%llx",
+        ToString(res).c_str(), port::bit_cast<void *>(gpu_dst),
+        port::bit_cast<void *>(gpu_src), size, size));
+  }
+  VLOG(2) << "successfully sync memcpy'd d2d of " << size << " bytes";
+  return port::Status::OK();
+}
+
+/* static */ bool ROCMDriver::AsynchronousMemcpyD2H(int device_ordinal,
+                                                    void *host_dst,
+                                                    hipDeviceptr_t gpu_src,
+                                                    uint64 size,
+                                                    hipStream_t stream) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipMemcpyDtoHAsync(host_dst, gpu_src, size, stream);
+  if (res != hipSuccess) {
+    LOG(ERROR) << port::Printf(
+        "failed to enqueue async memcpy from device to host: %s; host dst: %p; "
+        "GPU src: %p; size: %llu=0x%llx",
+        ToString(res).c_str(), host_dst, port::bit_cast<void *>(gpu_src), size,
+        size);
+    return false;
+  }
+  VLOG(2) << "successfully enqueued async memcpy d2h of " << size
+          << " bytes from " << port::bit_cast<void *>(gpu_src) << " to "
+          << host_dst << " on stream " << stream;
+  return true;
+}
+
+/* static */ bool ROCMDriver::AsynchronousMemcpyH2D(int device_ordinal,
+                                                    hipDeviceptr_t gpu_dst,
+                                                    const void *host_src,
+                                                    uint64 size,
+                                                    hipStream_t stream) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res =
+      hipMemcpyHtoDAsync(gpu_dst, const_cast<void *>(host_src), size, stream);
+  if (res != hipSuccess) {
+    LOG(ERROR) << port::Printf(
+        "failed to enqueue async memcpy from host to device: %s; GPU dst: %p; "
+        "host src: %p; size: %llu=0x%llx",
+        ToString(res).c_str(), port::bit_cast<void *>(gpu_dst), host_src, size,
+        size);
+    return false;
+  }
+  VLOG(2) << "successfully enqueued async memcpy h2d of " << size << " bytes"
+          << " on stream " << stream;
+  return true;
+}
+
+/* static */ bool ROCMDriver::AsynchronousMemcpyD2D(int device_ordinal,
+                                                    hipDeviceptr_t gpu_dst,
+                                                    hipDeviceptr_t gpu_src,
+                                                    uint64 size,
+                                                    hipStream_t stream) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t result = hipMemcpyDtoDAsync(gpu_dst, gpu_src, size, stream);
+  if (result != hipSuccess) {
+    LOG(ERROR) << port::Printf(
+        "failed to enqueue async memcpy from device to device: %s"
+        "; GPU dst: %p on %s %s"
+        "; GPU src: %p on %s %s"
+        "; can access? %s; size: %llu=0x%llx",
+        ToString(result).c_str(), port::bit_cast<void *>(gpu_dst),
+        ROCMPointerToMemorySpaceString(gpu_dst).c_str(),
+        ROCMPointerToDeviceString(gpu_dst).c_str(),
+        port::bit_cast<void *>(gpu_src),
+        ROCMPointerToMemorySpaceString(gpu_src).c_str(),
+        ROCMPointerToDeviceString(gpu_src).c_str(),
+        ROCMPointersToCanAccessString(gpu_src, gpu_dst).c_str(), size, size);
+
+    return false;
+  }
+  VLOG(2) << "successfully enqueued async memcpy d2d of " << size << " bytes";
+  return true;
+}
+
+/* static */ port::Status ROCMDriver::CreateEvent(int device_ordinal,
+                                                  hipEvent_t *result,
+                                                  EventFlags flags) {
+  int hipflags;
+  switch (flags) {
+    case EventFlags::kDefault:
+      hipflags = hipEventDefault;
+      break;
+    case EventFlags::kDisableTiming:
+      hipflags = hipEventDisableTiming | hipEventReleaseToSystem;
+      break;
+    default:
+      LOG(FATAL) << "impossible event flags: " << int(hipflags);
+  }
+
+  ScopedActivateContext activated{device_ordinal};
+  hipError_t res = hipEventCreateWithFlags(result, hipflags);
+
+  if (res == hipSuccess) {
+    return port::Status::OK();
+  } else if (res == hipErrorMemoryAllocation) {
+    return port::Status{port::error::RESOURCE_EXHAUSTED,
+                        "could not create ROCM event: out of device memory"};
+  } else {
+    return port::Status{
+        port::error::FAILED_PRECONDITION,
+        port::StrCat("could not create ROCM event: ", ToString(res))};
+  }
+}
+
+/* static */ int ROCMDriver::GetDeviceCount() {
+  int device_count = 0;
+  hipError_t res = hipGetDeviceCount(&device_count);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "could not retrieve ROCM device count: " << ToString(res);
+    return 0;
+  }
+
+  if (FLAGS_gpuexec_rocm_device_0_only && device_count > 1) {
+    device_count = 1;
+  }
+  return device_count;
+}
+
+/* static */ port::StatusOr<MemorySpace> ROCMDriver::GetPointerMemorySpace(
+    hipDeviceptr_t pointer) {
+  unsigned int value;
+  hipError_t result = hipSuccess;
+  if (result == hipSuccess) {
+    switch (value) {
+      case hipMemoryTypeDevice:
+        return MemorySpace::kDevice;
+      case hipMemoryTypeHost:
+        return MemorySpace::kHost;
+      default:
+        return port::Status{
+            port::error::INTERNAL,
+            port::StrCat("unknown memory space provided by ROCM API: ", value)};
+    }
+  }
+
+  return port::Status{
+      port::error::INTERNAL,
+      port::StrCat("failed to query device pointer for memory space: ",
+                   ToString(result))};
+}
+
+/* static */ port::Status ROCMDriver::GetPointerAddressRange(
+    hipDeviceptr_t dptr, hipDeviceptr_t *base, size_t *size) {
+  hipError_t result = hipMemGetAddressRange(base, size, dptr);
+  if (result == hipSuccess) {
+    return port::Status::OK();
+  } else if (result == hipErrorNotFound) {
+    // We differentiate between "this pointer is unknown" (return here) and
+    // "there was an internal error while performing this operation" (return
+    // below).
+    return port::Status{
+        port::error::NOT_FOUND,
+        port::Printf("not a device pointer %p; %s",
+                     reinterpret_cast<void *>(dptr), ToString(result).c_str())};
+  }
+
+  return port::Status{
+      port::error::INTERNAL,
+      port::Printf("failed to get pointer into for device pointer %p; %s",
+                   reinterpret_cast<void *>(dptr), ToString(result).c_str())};
+}
+
+/* static */ port::StatusOr<hipDevice_t> ROCMDriver::GetPointerDevice(
+    hipDeviceptr_t pointer) {
+  hipPointerAttribute_t pointerAttributes;
+  hipError_t result = hipPointerGetAttributes(&pointerAttributes, pointer);
+  if (result != hipSuccess) {
+    return port::Status{
+        port::error::INTERNAL,
+        port::StrCat("failed to get device for pointer: ", ToString(result))};
+  }
+
+  hipDevice_t device;
+  result = hipDeviceGet(&device, pointerAttributes.device);
+  if (result != hipSuccess) {
+    return port::Status{
+        port::error::INTERNAL,
+        port::StrCat("failed to get device for pointer: ", ToString(result))};
+  }
+
+  return device;
+}
+
+/* static */ port::Status ROCMDriver::GetAMDGPUISAVersion(int *version,
+                                                          hipDevice_t device) {
+  hipDeviceProp_t props;
+  hipError_t result = hipGetDeviceProperties(&props, device);
+  if (result == hipSuccess) {
+    *version = props.gcnArch;
+    return port::Status::OK();
+  }
+  *version = 0;
+  return port::Status{
+      port::error::INTERNAL,
+      port::Printf("failed to determine AMDGPU ISA version for device %d",
+                   device)};
+}
+
+// Helper function that turns the integer output of hipDeviceGetAttribute to
+// type T and wraps it in a StatusOr.
+template <typename T>
+static port::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
+                                            hipDeviceAttribute_t attribute) {
+  int value = -1;
+  hipError_t result = hipDeviceGetAttribute(&value, attribute, device);
+  if (result != hipSuccess) {
+    return port::Status{
+        port::error::NOT_FOUND,
+        port::StrCat("could not retrieve ROCM device attribute (", attribute,
+                     "): ", ToString(result))};
+  }
+  T converted = value;
+  return converted;
+}
+
+/* static */ port::StatusOr<int> ROCMDriver::GetMultiprocessorCount(
+    hipDevice_t device) {
+  return GetSimpleAttribute<int>(device, hipDeviceAttributeMultiprocessorCount);
+}
+
+/* static */ port::StatusOr<int64> ROCMDriver::GetMaxSharedMemoryPerCore(
+    hipDevice_t device) {
+  return GetSimpleAttribute<int64>(
+      device, hipDeviceAttributeMaxSharedMemoryPerMultiprocessor);
+}
+
+/* static */ port::StatusOr<int64> ROCMDriver::GetMaxSharedMemoryPerBlock(
+    hipDevice_t device) {
+  return GetSimpleAttribute<int64>(device,
+                                   hipDeviceAttributeMaxSharedMemoryPerBlock);
+}
+
+/* static */ port::StatusOr<int64> ROCMDriver::GetMaxThreadsPerMultiprocessor(
+    hipDevice_t device) {
+  return GetSimpleAttribute<int64>(
+      device, hipDeviceAttributeMaxThreadsPerMultiProcessor);
+}
+
+/* static */ port::StatusOr<int64> ROCMDriver::GetMaxThreadsPerBlock(
+    hipDevice_t device) {
+  return GetSimpleAttribute<int64>(device,
+                                   hipDeviceAttributeMaxThreadsPerBlock);
+}
+
+/* static */ port::StatusOr<int64> ROCMDriver::GetMaxRegistersPerBlock(
+    hipDevice_t device) {
+  return GetSimpleAttribute<int64>(device,
+                                   hipDeviceAttributeMaxRegistersPerBlock);
+}
+
+/* static */ port::StatusOr<int64> ROCMDriver::GetThreadsPerWarp(
+    hipDevice_t device) {
+  return GetSimpleAttribute<int64>(device, hipDeviceAttributeWarpSize);
+}
+
+/* static */ bool ROCMDriver::GetGridLimits(int *x, int *y, int *z,
+                                            hipDevice_t device) {
+  int value;
+  hipError_t res =
+      hipDeviceGetAttribute(&value, hipDeviceAttributeMaxGridDimX, device);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query max grid dim x: " << ToString(res);
+    return false;
+  }
+  *x = value;
+
+  res = hipDeviceGetAttribute(&value, hipDeviceAttributeMaxGridDimY, device);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query max grid dim y: " << ToString(res);
+    return false;
+  }
+  *y = value;
+
+  res = hipDeviceGetAttribute(&value, hipDeviceAttributeMaxGridDimZ, device);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query max grid dim z: " << ToString(res);
+    return false;
+  }
+  *z = value;
+  return true;
+}
+
+/* static */ bool ROCMDriver::GetDriverVersion(int *driver_version) {
+  hipError_t res = hipDriverGetVersion(driver_version);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query driver version: " << ToString(res);
+    return false;
+  }
+
+  return true;
+}
+
+/* static */ bool ROCMDriver::GetDeviceProperties(
+    hipDeviceProp_t *device_properties, int device_ordinal) {
+  hipError_t res = hipGetDeviceProperties(device_properties, device_ordinal);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query device properties: " << ToString(res);
+    return false;
+  }
+
+  return true;
+}
+
+/* static */ bool ROCMDriver::IsEccEnabled(hipDevice_t device, bool *result) {
+  int value = -1;
+  hipError_t res = hipSuccess;
+  // ROCM TODO implement this feature in HIP
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query ECC status: " << ToString(res);
+    return false;
+  }
+
+  *result = value;
+  return true;
+}
+
+/* static */ bool ROCMDriver::GetDeviceMemoryInfo(int device_ordinal,
+                                                  int64 *free_out,
+                                                  int64 *total_out) {
+  ScopedActivateContext activation{device_ordinal};
+  size_t free = 0;
+  size_t total = 0;
+  hipError_t res = hipMemGetInfo(&free, &total);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query device memory info: " << ToString(res);
+    return false;
+  }
+
+  *free_out = free;
+  *total_out = total;
+  return true;
+}
+
+/* static */ bool ROCMDriver::GetDeviceTotalMemory(hipDevice_t device,
+                                                   uint64 *result) {
+  size_t value = -1;
+  hipError_t res = hipDeviceTotalMem(&value, device);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query total available memory: " << ToString(res);
+    return false;
+  }
+
+  *result = value;
+  return true;
+}
+
+/* static */ string ROCMDriver::GetPCIBusID(hipDevice_t device) {
+  string pci_bus_id;
+  static const int kBufferSize = 64;
+  port::InlinedVector<char, 4> chars(kBufferSize);
+  chars[kBufferSize - 1] = '\0';
+  hipError_t res = hipDeviceGetPCIBusId(chars.begin(), kBufferSize - 1, device);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to query PCI bus id for device: " << ToString(res);
+    return pci_bus_id;
+  }
+  pci_bus_id = chars.begin();
+  return pci_bus_id;
+}
+
+/* static */ bool ROCMDriver::CanEnablePeerAccess(int from_device_ordinal,
+                                                  int to_device_ordinal) {
+  if (from_device_ordinal == to_device_ordinal) {
+    return true;  // A context can always access its own memory.
+  }
+
+  int can_access_peer = -1;
+  hipError_t res = hipDeviceCanAccessPeer(&can_access_peer, from_device_ordinal,
+                                          to_device_ordinal);
+  if (res != hipSuccess) {
+    LOG(ERROR) << "failed to detect peer access capability: " << ToString(res);
+    return false;
+  }
+
+  return can_access_peer;
+}
+
+/* static */ port::Status ROCMDriver::EnablePeerAccess(int from_device_ordinal,
+                                                       int to_device_ordinal) {
+  if (from_device_ordinal == to_device_ordinal) {
+    return port::Status::OK();  // A context can always access its own memory.
+  }
+
+  ScopedActivateContext activated{from_device_ordinal};
+  hipError_t result =
+      hipDeviceEnablePeerAccess(to_device_ordinal, 0 /* = flags */);
+  if (result != hipSuccess && result != hipErrorPeerAccessAlreadyEnabled) {
+    return port::Status{
+        port::error::INTERNAL,
+        port::Printf("failed to enable peer access from %p to %p: %s",
+                     from_device_ordinal, to_device_ordinal,
+                     ToString(result).c_str())};
+  }
+
+  return port::Status::OK();
+}
+
+/* static */ port::StatusOr<int> ROCMDriver::GetMaxOccupiedBlocksPerCore(
+    int device_ordinal, hipFunction_t kernel, int threads_per_block,
+    size_t dynamic_shared_memory_bytes) {
+  ScopedActivateContext activation{device_ordinal};
+
+  int max_blocks = 0;
+  hipError_t result = hipSuccess;
+  // ROCM TODO implement this feature in HIP
+  if (result != hipSuccess) {
+    return port::Status{
+        port::error::INTERNAL,
+        port::Printf("failed to calculate occupancy of kernel %p: %s", kernel,
+                     ToString(result).c_str())};
+  }
+
+  return max_blocks;
+}
+
+/* static */ int ROCMDriver::CurrentDeviceOrDie() {
+  int current = -1;
+  hipError_t result = hipGetDevice(&current);
+  if (result != hipSuccess) {
+    LOG(FATAL) << "failed to query current device: " << ToString(result);
+  }
+  return current;
+}
+}  // namespace rocm
+}  // namespace stream_executor

--- a/tensorflow/stream_executor/rocm/rocm_driver.h
+++ b/tensorflow/stream_executor/rocm/rocm_driver.h
@@ -1,0 +1,400 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// ROCM userspace driver library wrapper functionality.
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_DRIVER_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_DRIVER_H_
+
+#include <stddef.h>
+#include "tensorflow/stream_executor/platform/port.h"
+
+#include "rocm/include/hip/hip_runtime.h"
+#include "tensorflow/stream_executor/device_options.h"
+#include "tensorflow/stream_executor/lib/status.h"
+#include "tensorflow/stream_executor/lib/statusor.h"
+#include "tensorflow/stream_executor/platform/port.h"
+
+namespace stream_executor {
+namespace rocm {
+
+// Identifies the memory space where an allocation resides. See
+// ROCMDriver::GetPointerMemorySpace().
+enum class MemorySpace { kHost, kDevice };
+
+// Returns a casual string, such as "host" for the provided memory space.
+string MemorySpaceString(MemorySpace memory_space);
+
+// ROCMDriver contains wrappers for calls to the userspace library driver. It's
+// useful to isolate these calls and put basic wrappers around them to separate
+// userspace library driver behaviors from the rest of the program.
+//
+// At the moment it's simply used as a namespace.
+//
+// The calls log any specific errors internally and return whether the operation
+// was successful to the caller.
+//
+// Thread safety: these functions should not be used from signal handlers.
+class ROCMDriver {
+ public:
+  // Wraps a call to hipInit with logging to help indicate what has gone wrong
+  // in the case of failure. Safe to call multiple times; will be fast on all
+  // calls after the first.
+  static port::Status Init();
+
+  // Creates a new ROCM stream associated with the given device via
+  // hipStreamCreate.
+  // stream is an outparam owned by the caller, must not be null.
+  static bool CreateStream(int device_ordinal, hipStream_t *stream);
+
+  // Destroys a ROCM stream associated with the given device.
+  // stream is owned by the caller, must not be null, and *stream is set to null
+  // if the stream is successfully destroyed.
+  static void DestroyStream(int device_ordinal, hipStream_t *stream);
+
+  // ROCM events can explicitly disable event TSC retrieval for some presumed
+  // performance improvement if timing is unnecessary.
+  enum class EventFlags { kDefault, kDisableTiming };
+
+  // Creates a new event associated with the given device.
+  // result is an outparam owned by the caller and must not be null.
+  static port::Status CreateEvent(int device_ordinal, hipEvent_t *result,
+                                  EventFlags flags);
+
+  // Destroys *event and turns it into a nullptr. event may not be null, but
+  // *event may be, via hipEventDestroy
+  static port::Status DestroyEvent(int device_ordinal, hipEvent_t *event);
+
+  // Allocates a GPU memory space of size bytes associated with the given
+  // device via hipMemAlloc.
+  static void *DeviceAllocate(int device_ordinal, uint64 bytes);
+
+  // Deallocates a GPU memory space of size bytes associated with the given
+  // device via hipMemFree.
+  static void DeviceDeallocate(int device_ordinal, void *location);
+
+  // Allocates page-locked and ROCM-registered memory on the host via
+  // hipMemAllocHost.
+  static void *HostAllocate(int device_ordinal, uint64 bytes);
+
+  // Deallocates a location created by HostAllocate, via hipMemFreeHost.
+  static void HostDeallocate(int device_ordinal, void *location);
+
+  // Registers a memory region at location of size bytes via hipMemHostRegister.
+  static bool HostRegister(int device_ordinal, void *location, uint64 bytes);
+
+  // Unregisters a memory region that was previously registered at location via
+  // hipMemHostUnregister.
+  //
+  //
+  // TODO(leary) verify an error will be returned if the location wasn't
+  // previously registered.
+  static bool HostUnregister(int device_ordinal, void *location);
+
+  // Given a device ordinal, returns a device handle into the device outparam,
+  // which must not be null.
+  //
+  // N.B. these device handles do not have a corresponding destroy function in
+  // the ROCM driver API.
+  static port::Status GetDevice(int device_ordinal, hipDevice_t *device);
+
+  // Given a device handle, returns the name reported by the driver for the
+  // device.
+  static bool GetDeviceName(hipDevice_t device, string *name_out);
+
+  // Queries the runtime for the specified attribute of the specified function.
+  static bool FuncGetAttribute(hipDeviceAttribute_t attribute,
+                               hipFunction_t function, int *attribute_value);
+
+  // Sets the preferred cache configuration for the specified function.
+  static bool FuncSetCacheConfig(hipFunction_t function,
+                                 hipFuncCache_t cache_config);
+
+  // Gets the preferred shared memory bank configuration for the specified
+  // DEVICE (not function!), either default or four- or eight-byte bank size.
+  static port::StatusOr<hipSharedMemConfig> DeviceGetSharedMemConfig(
+      int device_ordinal);
+
+  // Sets the preferred shared memory bank configuration for the specified
+  // DEVICE (not function!), either default or four- or eight-byte bank size.
+  static port::Status DeviceSetSharedMemConfig(
+      int device_ordinal, hipSharedMemConfig shared_mem_config);
+
+  // Launches a HIP kernel via hipLaunchKernel.
+  // TODO(leary) describe the structure of kernel_params and extra in a readable
+  // way.
+  static bool LaunchKernel(int device_ordinal, hipFunction_t function,
+                           unsigned int grid_dim_x, unsigned int grid_dim_y,
+                           unsigned int grid_dim_z, unsigned int block_dim_x,
+                           unsigned int block_dim_y, unsigned int block_dim_z,
+                           unsigned int shared_mem_bytes, hipStream_t stream,
+                           void **kernel_params, void **extra);
+
+  // Loads HSACO with the ROCM runtime and stores the resulting handle in
+  // "module". Any error logs that are produced are logged internally.
+  static bool LoadHsaco(int device_ordinal, const char *hsaco_contents,
+                        hipModule_t *module);
+
+  // Retrieves a named kernel from a loaded module, and places the resulting
+  // handle into function (outparam) on success. Neither kernel_name nor
+  // function may be null. No ownership is taken of kernel_name.
+  static bool GetModuleFunction(int device_ordinal, hipModule_t module,
+                                const char *kernel_name,
+                                hipFunction_t *function);
+
+  // Retrieves a named global/constant symbol from a loaded module, and returns
+  // a device pointer and size of the symbol on success. symbol_name may not be
+  // null. At least one of dptr or bytes should not be null. No ownership is
+  // taken of symbol_name.
+  static bool GetModuleSymbol(int device_ordinal, hipModule_t module,
+                              const char *symbol_name, hipDeviceptr_t *dptr,
+                              size_t *bytes);
+
+  // Unloads module from the current device via cuModuleUnload.
+  // TODO(leary) the documentation doesn't say what kind of disasters happen
+  // if you try to unload a module while its hipFunction_ts are in use.
+  static void UnloadModule(int device_ordinal, hipModule_t module);
+
+  // Performs a synchronous memset of the device memory segment via hipMemsetD8.
+  static bool SynchronousMemsetUint8(int device_ordinal,
+                                     hipDeviceptr_t location, uint8 value,
+                                     size_t size);
+
+  // Performs a synchronous memset of the device memory segment via
+  // hipMemsetD32.
+  static bool SynchronousMemsetUint32(int device_ordinal,
+                                      hipDeviceptr_t location, uint32 value,
+                                      size_t uint32_count);
+
+  // Performs an asynchronous memset of the device memory segment via
+  // hipMemsetD8Async.
+  static bool AsynchronousMemsetUint8(int device_ordinal,
+                                      hipDeviceptr_t location, uint8 value,
+                                      size_t uint32_count, hipStream_t stream);
+
+  // Performs an asynchronous memset of the device memory segment via
+  // hipMemsetD32Async.
+  static bool AsynchronousMemsetUint32(int device_ordinal,
+                                       hipDeviceptr_t location, uint32 value,
+                                       size_t uint32_count, hipStream_t stream);
+
+  // -- Synchronous memcopies.
+
+  static port::Status SynchronousMemcpyD2H(int device_ordinal, void *host_dst,
+                                           hipDeviceptr_t gpu_src, uint64 size);
+  static port::Status SynchronousMemcpyH2D(int device_ordinal,
+                                           hipDeviceptr_t gpu_dst,
+                                           const void *host_src, uint64 size);
+  static port::Status SynchronousMemcpyD2D(int device_ordinal,
+                                           hipDeviceptr_t gpu_dst,
+                                           hipDeviceptr_t gpu_src, uint64 size);
+
+  // -- Asynchronous memcopies.
+
+  static bool AsynchronousMemcpyD2H(int device_ordinal, void *host_dst,
+                                    hipDeviceptr_t gpu_src, uint64 size,
+                                    hipStream_t stream);
+  static bool AsynchronousMemcpyH2D(int device_ordinal, hipDeviceptr_t gpu_dst,
+                                    const void *host_src, uint64 size,
+                                    hipStream_t stream);
+  static bool AsynchronousMemcpyD2D(int device_ordinal, hipDeviceptr_t gpu_dst,
+                                    hipDeviceptr_t gpu_src, uint64 size,
+                                    hipStream_t stream);
+
+  // The ROCM stream callback type signature.
+  // The data passed to AddStreamCallback is subsequently passed to this
+  // callback when it fires.
+  //
+  // Some notable things:
+  // * Callbacks must not make any ROCM API calls.
+  // * Callbacks from independent streams execute in an undefined order and may
+  //   be serialized.
+  typedef void (*StreamCallback)(hipStream_t stream, hipError_t status,
+                                 void *data);
+
+  // Enqueues a callback operation into stream.
+  // See StreamCallback above ROCM documentation for additional
+  // details.
+  static bool AddStreamCallback(int device_ordinal, hipStream_t stream,
+                                StreamCallback callback, void *data);
+
+  // Causes stream to wait for event to trigger before proceeding via
+  // hipStreamWaitEvent.
+  static bool WaitStreamOnEvent(int device_ordinal, hipStream_t stream,
+                                hipEvent_t event);
+
+  // Blocks the calling thread until the operations enqueued onto stream have
+  // been completed, via hipStreamSynchronize.
+  //
+  // TODO(leary) if a pathological thread enqueues operations onto the stream
+  // while another thread blocks like this, can you wind up waiting an unbounded
+  // amount of time?
+  //
+  static port::Status SynchronizeStream(int device_ordinal, hipStream_t stream);
+
+  // Blocks the calling thread until the operations associated with the device
+  // have been completed, via hipCtxSynchronize.
+  //
+  static bool SynchronizeDevice(int device_ordinal);
+
+  // Returns true if all stream tasks have completed at time of the call. Note
+  // the potential for races around this call (if another thread adds work to
+  // the stream immediately after this returns).
+  static bool IsStreamIdle(int device_ordinal, hipStream_t stream);
+
+  // Returns whether code in the from device can access memory in the to
+  // device via hipDeviceCanAccessPeer.
+  static bool CanEnablePeerAccess(int from_device_ordinal,
+                                  int to_device_ordinal);
+
+  // Enables peer access per CanEnablePeerAccess, via hipDeviceEnablePeerAccess.
+  static port::Status EnablePeerAccess(int from_device_ordinal,
+                                       int to_device_ordinal);
+
+  // Returns the elapsed milliseconds between start and stop via
+  // hipEventElapsedTime.
+  static bool GetEventElapsedTime(int device_ordinal,
+                                  float *elapsed_milliseconds, hipEvent_t start,
+                                  hipEvent_t stop);
+
+  // Records that an event occurred when execution reaches the current point in
+  // thestream via hipEventRecord.
+  static port::Status RecordEvent(int device_ordinal, hipEvent_t event,
+                                  hipStream_t stream);
+
+  // Polls (without blocking) to determine the status of an event - pending or
+  // complete (or an error status).
+  static port::StatusOr<hipError_t> QueryEvent(int device_ordinal,
+                                               hipEvent_t event);
+
+  // -- Pointer-specific calls.
+
+  // Returns the device associated with the context from GetPointerContext().
+  static port::StatusOr<hipDevice_t> GetPointerDevice(hipDeviceptr_t pointer);
+
+  // Returns the memory space addressed by pointer.
+  static port::StatusOr<MemorySpace> GetPointerMemorySpace(
+      hipDeviceptr_t pointer);
+
+  // Returns the base address and size of the device pointer dptr.
+  static port::Status GetPointerAddressRange(hipDeviceptr_t dptr,
+                                             hipDeviceptr_t *base,
+                                             size_t *size);
+
+  // -- Device-specific calls.
+
+  // Returns AMDGPU ISA version for the device; i.e 803, 900.
+  static port::Status GetAMDGPUISAVersion(int *version, hipDevice_t device);
+
+  // Returns the number of multiprocessors on the device (note that the device
+  // may be multi-GPU-per-board).
+  static port::StatusOr<int> GetMultiprocessorCount(hipDevice_t device);
+
+  // Returns the limit on number of threads that can be resident in a single
+  // multiprocessor.
+  static port::StatusOr<int64> GetMaxThreadsPerMultiprocessor(
+      hipDevice_t device);
+
+  // Returns the limit on number of threads which may be resident for a single
+  // block (cooperative thread array).
+  static port::StatusOr<int64> GetMaxThreadsPerBlock(hipDevice_t device);
+
+  // Returns the amount of shared memory available on a single GPU core (i.e.
+  // CU on ROCM devices).
+  static port::StatusOr<int64> GetMaxSharedMemoryPerCore(hipDevice_t device);
+
+  // Returns the amount of shared memory available for a single block
+  // (cooperative thread array).
+  static port::StatusOr<int64> GetMaxSharedMemoryPerBlock(hipDevice_t device);
+
+  // Returns the maximum supported number of registers per block.
+  static port::StatusOr<int64> GetMaxRegistersPerBlock(hipDevice_t device);
+
+  // Returns the number of threads per warp.
+  static port::StatusOr<int64> GetThreadsPerWarp(hipDevice_t device);
+
+  // Queries the grid limits for device with hipDeviceGetAttribute calls.
+  static bool GetGridLimits(int *x, int *y, int *z, hipDevice_t device);
+
+  // Returns a grab-bag of device properties in a caller-owned device_properties
+  // structure for device_ordinal via hipDeviceGetProperties.
+  static bool GetDeviceProperties(hipDeviceProp_t *device_properties,
+                                  int device_ordinal);
+
+  // Returns whether ECC is enabled for the given hipDevice_t via
+  // hipDeviceGetattribute with CU_DEVICE_ATTRIBUTE_ECC_ENABLED.
+  static bool IsEccEnabled(hipDevice_t device, bool *result);
+
+  // Returns the total amount of memory available for allocation by the ROCM
+  // device, in bytes, via hipDeviceTotalMem.
+  static bool GetDeviceTotalMemory(hipDevice_t device, uint64 *result);
+
+  // Returns the free amount of memory and total amount of memory, as reported
+  // by hipMemGetInfo.
+  static bool GetDeviceMemoryInfo(int device_ordinal, int64 *free,
+                                  int64 *total);
+
+  // Returns a PCI bus id string for the device.
+  // [domain]:[bus]:[device].[function]
+  static string GetPCIBusID(hipDevice_t device);
+
+  // -- Context- and device-independent calls.
+
+  // Returns the number of visible ROCM device via hipDeviceGetCount.
+  // This should correspond to the set of device ordinals available.
+  static int GetDeviceCount();
+
+  // Returns the driver version number via cuDriverGetVersion.
+  // This is, surprisingly, NOT the actual driver version (e.g. 331.79) but,
+  // instead, the ROCM toolkit release number that this driver is compatible
+  // with; e.g. 6000 (for a ROCM 6.0 compatible driver) or 6050 (for a ROCM 6.5
+  // compatible driver).
+  //
+  static bool GetDriverVersion(int *driver_version);
+
+  // -- Other calls
+
+  // Returns the maximum number of blocks (per multiprocessor) occupied by the
+  // specified kernel/hipFunction_t when launched with the specified parameters.
+  static port::StatusOr<int> GetMaxOccupiedBlocksPerCore(
+      int device_ordinal, hipFunction_t kernel, int threads_per_block,
+      size_t dynamic_shared_memory_bytes);
+
+  // Returns the current device ordinal set in HIP. This is done by calling the
+  // HIP driver (e.g., this value is not our cached view of the current device).
+  static int CurrentDeviceOrDie();
+
+  // Seam for injecting an error at CUDA initialization time for testing
+  // purposes.
+  static bool driver_inject_init_error_;
+};
+
+// Ensures the given device is activated within a scope.
+class ScopedActivateContext {
+ public:
+  // Activates the given device , if it is not the currently active device
+  explicit ScopedActivateContext(int device_ordinal);
+
+  // Checks that the device has remained activated for the duration of the
+  // scope.
+  ~ScopedActivateContext();
+
+ private:
+  int to_restore_ = -1;
+};
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_DRIVER_H_

--- a/tensorflow/stream_executor/rocm/rocm_event.cc
+++ b/tensorflow/stream_executor/rocm/rocm_event.cc
@@ -1,0 +1,66 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/stream_executor/rocm/rocm_event.h"
+#include "tensorflow/stream_executor/lib/statusor.h"
+#include "tensorflow/stream_executor/rocm/rocm_gpu_executor.h"
+#include "tensorflow/stream_executor/rocm/rocm_stream.h"
+
+namespace stream_executor {
+namespace rocm {
+
+ROCMEvent::ROCMEvent(ROCMExecutor* parent)
+    : parent_(parent), rocm_event_(nullptr) {}
+
+ROCMEvent::~ROCMEvent() {}
+
+port::Status ROCMEvent::Init() {
+  return ROCMDriver::CreateEvent(parent_->device_ordinal(), &rocm_event_,
+                                 ROCMDriver::EventFlags::kDisableTiming);
+}
+
+port::Status ROCMEvent::Destroy() {
+  return ROCMDriver::DestroyEvent(parent_->device_ordinal(), &rocm_event_);
+}
+
+port::Status ROCMEvent::Record(ROCMStream* stream) {
+  return ROCMDriver::RecordEvent(parent_->device_ordinal(), rocm_event_,
+                                 stream->rocm_stream());
+}
+
+Event::Status ROCMEvent::PollForStatus() {
+  port::StatusOr<hipError_t> status =
+      ROCMDriver::QueryEvent(parent_->device_ordinal(), rocm_event_);
+  if (!status.ok()) {
+    LOG(ERROR) << "Error polling for event status: "
+               << status.status().error_message();
+    return Event::Status::kError;
+  }
+
+  switch (status.ValueOrDie()) {
+    case hipSuccess:
+      return Event::Status::kComplete;
+    case hipErrorNotReady:
+      return Event::Status::kPending;
+    default:
+      LOG(INFO) << "Error condition returned for event status: "
+                << status.ValueOrDie();
+      return Event::Status::kError;
+  }
+}
+
+const hipEvent_t& ROCMEvent::rocm_event() { return rocm_event_; }
+}  // namespace rocm
+}  // namespace stream_executor

--- a/tensorflow/stream_executor/rocm/rocm_event.h
+++ b/tensorflow/stream_executor/rocm/rocm_event.h
@@ -1,0 +1,61 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_EVENT_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_EVENT_H_
+
+#include "tensorflow/stream_executor/event.h"
+#include "tensorflow/stream_executor/lib/status.h"
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+#include "tensorflow/stream_executor/rocm/rocm_stream.h"
+
+namespace stream_executor {
+namespace rocm {
+
+// ROCMEvent wraps a hipEvent_t in the platform-independent EventInterface
+// interface.
+class ROCMEvent : public internal::EventInterface {
+ public:
+  explicit ROCMEvent(ROCMExecutor* parent);
+
+  ~ROCMEvent() override;
+
+  // Populates the ROCM-platform-specific elements of this object.
+  port::Status Init();
+
+  // Deallocates any platform-specific elements of this object. This is broken
+  // out (not part of the destructor) to allow for error reporting.
+  port::Status Destroy();
+
+  // Inserts the event at the current position into the specified stream.
+  port::Status Record(ROCMStream* stream);
+
+  // Polls the ROCM platform for the event's current status.
+  Event::Status PollForStatus();
+
+  // The underlying ROCM event element.
+  const hipEvent_t& rocm_event();
+
+ private:
+  // The Executor used to which this object and hipEvent_t are bound.
+  ROCMExecutor* parent_;
+
+  // The underlying ROCM event element.
+  hipEvent_t rocm_event_;
+};
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_EVENT_H_

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -1,0 +1,872 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/stream_executor/rocm/rocm_gpu_executor.h"
+#include <unistd.h>
+#include "tensorflow/stream_executor/dso_loader.h"
+#include "tensorflow/stream_executor/kernel_cache_config.h"
+#include "tensorflow/stream_executor/lib/casts.h"
+#include "tensorflow/stream_executor/lib/env.h"
+#include "tensorflow/stream_executor/lib/error.h"
+#include "tensorflow/stream_executor/lib/initialize.h"
+#include "tensorflow/stream_executor/lib/mathutil.h"
+#include "tensorflow/stream_executor/lib/numbers.h"
+#include "tensorflow/stream_executor/lib/path.h"
+#include "tensorflow/stream_executor/lib/process_state.h"
+#include "tensorflow/stream_executor/lib/ptr_util.h"
+#include "tensorflow/stream_executor/lib/statusor.h"
+#include "tensorflow/stream_executor/lib/str_util.h"
+#include "tensorflow/stream_executor/lib/strcat.h"
+#include "tensorflow/stream_executor/lib/stringprintf.h"
+#include "tensorflow/stream_executor/platform.h"
+#include "tensorflow/stream_executor/platform/logging.h"
+#include "tensorflow/stream_executor/platform/port.h"
+#include "tensorflow/stream_executor/plugin_registry.h"
+#include "tensorflow/stream_executor/rocm/rocm_diagnostics.h"
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+#include "tensorflow/stream_executor/rocm/rocm_event.h"
+#include "tensorflow/stream_executor/rocm/rocm_platform_id.h"
+#include "tensorflow/stream_executor/rocm/rocm_stream.h"
+#include "tensorflow/stream_executor/rocm/rocm_timer.h"
+#include "tensorflow/stream_executor/stream.h"
+#include "tensorflow/stream_executor/stream_executor_internal.h"
+#include "tensorflow/stream_executor/stream_executor_pimpl.h"
+#include "tensorflow/stream_executor/timer.h"
+
+#ifdef PLATFORMS_GPUS_ROCM_DYNAMIC_LIBROCM_DYNAMIC_LIBROCM_H_
+#error \
+    "No driver calls in this file, wrap driver functionality in rocm_driver.cc."
+#endif
+
+#ifdef __ROCM_RUNTIME_H__
+#error \
+    "ROCM runtime being included into ROCM GPU executor; should be driver only."
+#endif
+
+namespace stream_executor {
+namespace rocm {
+
+static ROCMEvent *AsROCMEvent(Event *event) {
+  DCHECK(event != nullptr);
+  return static_cast<ROCMEvent *>(event->implementation());
+}
+
+// Given a platform-independent timer datatype, returns the internal ROCM
+// platform implementation pointer.
+static ROCMTimer *AsROCMTimer(Timer *timer) {
+  DCHECK(timer != nullptr);
+  return static_cast<ROCMTimer *>(timer->implementation());
+}
+
+// Given const GPU memory, returns a librocm device pointer datatype, suitable
+// for passing directly to librocm APIs.
+//
+// N.B. we must lose constness in order to pass a suitable type to the existing
+// librocm APIs, so the caller should take care to only pass the result of const
+// GPU memory conversions to librocm functions which will honor constness.
+static hipDeviceptr_t AsROCmDevicePtr(const DeviceMemoryBase &gpu_mem) {
+  return const_cast<hipDeviceptr_t>(gpu_mem.opaque());
+}
+
+// See description on const version above.
+static hipDeviceptr_t AsROCmDevicePtr(DeviceMemoryBase *gpu_mem) {
+  return AsROCmDevicePtr(*gpu_mem);
+}
+
+static int GetROCmDeviceOrdinal(Stream *stream) {
+  return static_cast<ROCMExecutor *>(stream->parent()->implementation())
+      ->device_ordinal();
+}
+
+int ExtractROCmDeviceOrdinal(ROCMExecutor *rocm_exec) {
+  CHECK(rocm_exec != nullptr);
+  return rocm_exec->device_ordinal();
+}
+
+ROCMExecutor *ExtractROCmExecutor(StreamExecutor *stream_exec) {
+  return static_cast<ROCMExecutor *>(stream_exec->implementation());
+}
+
+ROCMExecutor::~ROCMExecutor() {
+  for (auto &it : disk_modules_) {
+    ROCMDriver::UnloadModule(device_ordinal_, it.second);
+  }
+  for (auto &it : in_memory_modules_) {
+    ROCMDriver::UnloadModule(device_ordinal_, it.second);
+  }
+}
+
+port::Status ROCMExecutor::Init(int device_ordinal,
+                                DeviceOptions device_options) {
+  device_ordinal_ = device_ordinal;
+
+  auto status = ROCMDriver::Init();
+  if (!status.ok()) {
+    return status;
+  }
+
+  status = ROCMDriver::GetDevice(device_ordinal_, &device_);
+  if (!status.ok()) {
+    return status;
+  }
+
+  return ROCMDriver::GetAMDGPUISAVersion(&version_, device_);
+}
+
+bool ROCMExecutor::FindOnDiskForISAVersion(port::StringPiece filename,
+                                           port::StringPiece canonical_suffix,
+                                           string *found_filename) const {
+  if (version_ == 0) {
+    return false;
+  }
+
+  string cc_specific =
+      port::StrCat(filename, ".cc", version_, canonical_suffix);
+  if (port::FileExists(cc_specific).ok()) {
+    VLOG(2) << "found AMDGPU ISA version-specific file, using that: "
+            << cc_specific;
+    *found_filename = cc_specific;
+    return true;
+  }
+
+  VLOG(2) << "could not find AMDGPU ISA version-specific file at: "
+          << cc_specific;
+  if (port::FileExists(string(filename)).ok()) {
+    *found_filename = string(filename);
+    return true;
+  }
+
+  return false;
+}
+
+// Returns the path to the running executable.
+// N.B. Derived from //knowledge/smalltalk/background_kb.cc
+// Arg: strip_exe: if true, remove the name of the executable itself from the
+//                 returned string. Example: calling this from /usr/bin/foo
+//                 would return /usr/bin.
+static string GetBinaryDir(bool strip_exe) {
+  char exe_path[PATH_MAX] = {0};
+  CHECK_ERR(readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1));
+  // Make sure it's null-terminated:
+  exe_path[sizeof(exe_path) - 1] = 0;
+
+  if (strip_exe) {
+    // The exe is the last component of the path, so remove one component.
+    string ret = exe_path;
+    std::vector<string> components = port::Split(exe_path, '/');
+    components.pop_back();
+    return port::Join(components, "/");
+  }
+  return exe_path;
+}
+
+bool ROCMExecutor::GetKernel(const MultiKernelLoaderSpec &spec,
+                             KernelBase *kernel) {
+  ROCMKernel *rocm_kernel = AsROCMKernel(kernel);
+  hipModule_t module = nullptr;
+  const string *kernelname;
+
+  const OnDiskKernelLoaderSpec *on_disk_spec = nullptr;
+  bool has_ptx = spec.has_cuda_ptx_on_disk();
+  if (has_ptx) {
+    on_disk_spec = &spec.cuda_ptx_on_disk();
+  }
+
+  if (on_disk_spec != nullptr) {
+    LOG(WARNING) << "loading ROCM kernel from disk is not supported";
+    return false;
+  } else if (spec.has_cuda_ptx_in_memory()) {
+    kernelname = &spec.cuda_ptx_in_memory().kernelname();
+
+    const char *hsaco = spec.cuda_ptx_in_memory().original_default_text();
+    mutex_lock lock{in_memory_modules_mu_};
+    module = in_memory_modules_[hsaco];
+
+    if (module == nullptr) {
+      if (!ROCMDriver::LoadHsaco(device_ordinal_, hsaco, &module)) {
+        LOG(ERROR) << "failed to load HSACO\n";
+        return false;
+      }
+      in_memory_modules_[hsaco] = module;
+    }
+  } else {
+    LOG(WARNING) << "no method of loading ROCM kernel provided";
+    return false;
+  }
+
+  VLOG(2) << "getting function " << kernelname << " from module " << module;
+  if (!ROCMDriver::GetModuleFunction(device_ordinal_, module,
+                                     kernelname->c_str(),
+                                     rocm_kernel->rocm_function_ptr())) {
+    return false;
+  }
+
+  // We have to trust the kernel loader spec arity because there doesn't appear
+  // to be a way to reflect on the number of expected arguments w/the ROCM API.
+  rocm_kernel->set_arity(spec.arity());
+
+  KernelMetadata kernel_metadata;
+  if (!GetKernelMetadata(rocm_kernel, &kernel_metadata)) {
+    LOG(WARNING) << "Unable to get metadata for kernel " << kernelname;
+  }
+  kernel->set_metadata(kernel_metadata);
+  kernel->set_name(*kernelname);
+  return true;
+}
+
+bool ROCMExecutor::GetKernelMetadata(ROCMKernel *rocm_kernel,
+                                     KernelMetadata *kernel_metadata) {
+  int value = 0;
+  // ROCM TODO implement this feature in HIP
+  kernel_metadata->set_registers_per_thread(value);
+
+  // ROCM TODO implement this feature in HIP
+  kernel_metadata->set_shared_memory_bytes(value);
+
+  return true;
+}
+
+bool ROCMExecutor::Launch(Stream *stream, const ThreadDim &thread_dims,
+                          const BlockDim &block_dims, const KernelBase &kernel,
+                          const KernelArgsArrayBase &args) {
+  CHECK_EQ(kernel.Arity(), args.number_of_arguments());
+  hipStream_t hipstream = AsROCMStreamValue(stream);
+  const ROCMKernel *rocm_kernel = AsROCMKernel(&kernel);
+  hipFunction_t hipfunc = rocm_kernel->AsROCMFunctionValue();
+
+  // Only perform/print the occupancy check once.  Even just checking to see
+  // whether we've done an occupancy check on this kernel before isn't free
+  // (because we have to synchronize), so we only do this at -v 2+.
+  if (VLOG_IS_ON(2)) {
+    mutex_lock lock(launched_kernels_mu_);
+    if (!launched_kernels_.count(hipfunc)) {
+      VlogOccupancyInfo(kernel, thread_dims, block_dims);
+      // TODO(rspringer): Remove elements from launched_kernels_...if we ever
+      // expose a kernel/module deallocation method.
+      launched_kernels_.insert(hipfunc);
+    }
+  }
+
+  if (rocm_kernel->GetPreferredCacheConfig() !=
+      KernelCacheConfig::kNoPreference) {
+    ROCMDriver::FuncSetCacheConfig(hipfunc, rocm_kernel->GetROCMCacheConfig());
+  }
+
+  // prepare kernargs
+  // KernelArgsArrayBase keeps the pointer of arguments
+  // deference them here
+  std::vector<void *> kernargs;
+  KernelArgIterator iter = args.arg_iterator();
+  while (iter.has_next()) {
+    KernelArg arg = iter.next();
+    VLOG(2) << "*(arg.address): "
+            << reinterpret_cast<void *>(
+                   *static_cast<const uint64_t *>(arg.address));
+    kernargs.push_back(
+        reinterpret_cast<void *>(*static_cast<const uint64_t *>(arg.address)));
+  }
+
+  size_t size = sizeof(void *) * kernargs.size();
+  void *config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, kernargs.data(),
+                    HIP_LAUNCH_PARAM_BUFFER_SIZE, &size, HIP_LAUNCH_PARAM_END};
+
+  if (!ROCMDriver::LaunchKernel(GetROCmDeviceOrdinal(stream), hipfunc,
+                                block_dims.x, block_dims.y, block_dims.z,
+                                thread_dims.x, thread_dims.y, thread_dims.z,
+                                args.number_of_shared_bytes(), hipstream,
+                                nullptr, (void **)&config)) {
+    LOG(ERROR) << "failed to launch ROCM kernel with args: "
+               << args.number_of_arguments()
+               << "; thread dim: " << thread_dims.ToString()
+               << "; block dim: " << block_dims.ToString();
+    return false;
+  }
+
+  return true;
+}
+
+// This is a non-essential operation; if there's a failure, proceed without
+// logging an error. It's nearly certain that in case of failures, we'd never
+// get here in the first place; these are very low-impact routines.
+void ROCMExecutor::VlogOccupancyInfo(const KernelBase &kernel,
+                                     const ThreadDim &thread_dims,
+                                     const BlockDim &block_dims) {
+  // ROCM TODO implement this feature in HIP
+}
+
+void *ROCMExecutor::Allocate(uint64 size) {
+  return ROCMDriver::DeviceAllocate(device_ordinal_, size);
+}
+
+void *ROCMExecutor::AllocateSubBuffer(DeviceMemoryBase *mem,
+                                      uint64 offset_bytes, uint64 size_bytes) {
+  // offset and size are in bytes, so char* works as the pointer type.
+  return reinterpret_cast<char *>(mem->opaque()) + offset_bytes;
+}
+
+void ROCMExecutor::Deallocate(DeviceMemoryBase *mem) {
+  // ROCM "sub-buffers" are just pointer + offset, so no dealloc is necessary.
+  if (!mem->is_sub_buffer()) {
+    ROCMDriver::DeviceDeallocate(device_ordinal_, mem->opaque());
+  }
+}
+
+bool ROCMExecutor::HostMemoryRegister(void *location, uint64 size) {
+  if (location == nullptr || size == 0) {
+    LOG(WARNING) << "attempting to register null or zero-sized memory: "
+                 << location << "; size " << size;
+  }
+  VLOG(2) << "registering " << location << " size " << size;
+  return ROCMDriver::HostRegister(device_ordinal_, location, size);
+}
+
+bool ROCMExecutor::HostMemoryUnregister(void *location) {
+  VLOG(2) << "unregistering " << location;
+  return ROCMDriver::HostUnregister(device_ordinal_, location);
+}
+
+bool ROCMExecutor::SynchronizeAllActivity() {
+  return ROCMDriver::SynchronizeDevice(device_ordinal_);
+}
+
+bool ROCMExecutor::SynchronousMemZero(DeviceMemoryBase *location, uint64 size) {
+  if (reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
+      size % 4 == 0) {
+    return ROCMDriver::SynchronousMemsetUint32(
+        device_ordinal_, AsROCmDevicePtr(location), 0x0, size / 4);
+  }
+  return ROCMDriver::SynchronousMemsetUint8(
+      device_ordinal_, AsROCmDevicePtr(location), 0x0, size);
+}
+
+bool ROCMExecutor::SynchronousMemSet(DeviceMemoryBase *location, int value,
+                                     uint64 size) {
+  if (reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
+      size % 4 == 0) {
+    // hipMemset reinterprets "value" as a uint8.
+    uint8 byte_value = static_cast<uint8>(value);
+    uint32 pattern = (byte_value << 24) | (byte_value << 16) |
+                     (byte_value << 8) | byte_value;
+    return ROCMDriver::SynchronousMemsetUint32(
+        device_ordinal_, AsROCmDevicePtr(location), pattern, size / 4);
+  }
+  return ROCMDriver::SynchronousMemsetUint8(
+      device_ordinal_, AsROCmDevicePtr(location), value, size);
+}
+
+port::Status ROCMExecutor::SynchronousMemcpy(DeviceMemoryBase *gpu_dst,
+                                             const void *host_src,
+                                             uint64 size) {
+  return ROCMDriver::SynchronousMemcpyH2D(
+      device_ordinal_, AsROCmDevicePtr(gpu_dst), host_src, size);
+}
+
+port::Status ROCMExecutor::SynchronousMemcpy(void *host_dst,
+                                             const DeviceMemoryBase &gpu_src,
+                                             uint64 size) {
+  return ROCMDriver::SynchronousMemcpyD2H(device_ordinal_, host_dst,
+                                          AsROCmDevicePtr(gpu_src), size);
+}
+
+port::Status ROCMExecutor::SynchronousMemcpyDeviceToDevice(
+    DeviceMemoryBase *gpu_dst, const DeviceMemoryBase &gpu_src, uint64 size) {
+  return ROCMDriver::SynchronousMemcpyD2D(device_ordinal_,
+                                          AsROCmDevicePtr(gpu_dst),
+                                          AsROCmDevicePtr(gpu_src), size);
+}
+
+bool ROCMExecutor::MemZero(Stream *stream, DeviceMemoryBase *location,
+                           uint64 size) {
+  if (reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
+      size % 4 == 0) {
+    return Memset32(stream, location, 0x0, size);
+  } else {
+    return Memset(stream, location, 0x0, size);
+  }
+}
+
+bool ROCMExecutor::Memset(Stream *stream, DeviceMemoryBase *location,
+                          uint8 pattern, uint64 size) {
+  VLOG(2) << "enqueueing memset8 operation onto stream " << stream
+          << " at location " << location << " with size " << size
+          << " and pattern " << std::hex << pattern;
+  return ROCMDriver::AsynchronousMemsetUint8(device_ordinal_,
+                                             AsROCmDevicePtr(location), pattern,
+                                             size, AsROCMStreamValue(stream));
+}
+
+bool ROCMExecutor::Memset32(Stream *stream, DeviceMemoryBase *location,
+                            uint32 pattern, uint64 size) {
+  VLOG(2) << "enqueueing memset32 operation onto stream " << stream
+          << " at location " << location << " with size " << size
+          << " and pattern " << std::hex << pattern;
+  CHECK(reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
+        size % 4 == 0);
+  return ROCMDriver::AsynchronousMemsetUint32(
+      device_ordinal_, AsROCmDevicePtr(location), pattern, size / 4,
+      AsROCMStreamValue(stream));
+}
+
+bool ROCMExecutor::Memcpy(Stream *stream, void *host_dst,
+                          const DeviceMemoryBase &gpu_src, uint64 size) {
+  return ROCMDriver::AsynchronousMemcpyD2H(device_ordinal_, host_dst,
+                                           AsROCmDevicePtr(gpu_src), size,
+                                           AsROCMStreamValue(stream));
+}
+
+bool ROCMExecutor::Memcpy(Stream *stream, DeviceMemoryBase *gpu_dst,
+                          const void *host_src, uint64 size) {
+  return ROCMDriver::AsynchronousMemcpyH2D(device_ordinal_,
+                                           AsROCmDevicePtr(gpu_dst), host_src,
+                                           size, AsROCMStreamValue(stream));
+}
+
+bool ROCMExecutor::MemcpyDeviceToDevice(Stream *stream,
+                                        DeviceMemoryBase *gpu_dst,
+                                        const DeviceMemoryBase &gpu_src,
+                                        uint64 size) {
+  return ROCMDriver::AsynchronousMemcpyD2D(
+      device_ordinal_, AsROCmDevicePtr(gpu_dst), AsROCmDevicePtr(gpu_src), size,
+      AsROCMStreamValue(stream));
+}
+
+bool ROCMExecutor::HostCallback(Stream *stream,
+                                std::function<void()> callback) {
+  auto callback_ptr = new std::function<void()>(callback);
+  return ROCMDriver::AddStreamCallback(device_ordinal_,
+                                       AsROCMStreamValue(stream),
+                                       InternalHostCallback, callback_ptr);
+}
+
+/* static */ void ROCMExecutor::InternalHostCallback(hipStream_t stream,
+                                                     hipError_t status,
+                                                     void *data) {
+  std::function<void()> *callback =
+      reinterpret_cast<std::function<void()> *>(data);
+  (*callback)();
+  delete callback;
+}
+
+port::Status ROCMExecutor::AllocateEvent(Event *event) {
+  return AsROCMEvent(event)->Init();
+}
+
+port::Status ROCMExecutor::DeallocateEvent(Event *event) {
+  return AsROCMEvent(event)->Destroy();
+}
+
+port::Status ROCMExecutor::RecordEvent(Stream *stream, Event *event) {
+  return AsROCMEvent(event)->Record(AsROCMStream(stream));
+}
+
+port::Status ROCMExecutor::WaitForEvent(Stream *stream, Event *event) {
+  if (ROCMDriver::WaitStreamOnEvent(device_ordinal_,
+                                    AsROCMStream(stream)->rocm_stream(),
+                                    AsROCMEvent(event)->rocm_event())) {
+    return port::Status::OK();
+  } else {
+    return port::Status{
+        port::error::INTERNAL,
+        port::Printf("error recording waiting for ROCM event on stream %p",
+                     stream)};
+  }
+}
+
+Event::Status ROCMExecutor::PollForEventStatus(Event *event) {
+  return AsROCMEvent(event)->PollForStatus();
+}
+
+bool ROCMExecutor::AllocateStream(Stream *stream) {
+  return AsROCMStream(stream)->Init();
+}
+
+void ROCMExecutor::DeallocateStream(Stream *stream) {
+  ROCMStream *rocm_stream = AsROCMStream(stream);
+  if (!rocm_stream->IsIdle()) {
+    LOG(ERROR) << "Deallocating stream with pending work";
+  }
+  rocm_stream->Destroy();
+}
+
+bool ROCMExecutor::AllocateTimer(Timer *timer) {
+  return AsROCMTimer(timer)->Init();
+}
+
+void ROCMExecutor::DeallocateTimer(Timer *timer) {
+  AsROCMTimer(timer)->Destroy();
+}
+
+bool ROCMExecutor::CreateStreamDependency(Stream *dependent, Stream *other) {
+  hipEvent_t other_completed_event = *AsROCMStream(other)->completed_event();
+  bool ok = ROCMDriver::RecordEvent(device_ordinal_, other_completed_event,
+                                    AsROCMStreamValue(other))
+                .ok();
+  if (!ok) {
+    LOG(ERROR) << "failed to record completion event; "
+                  "therefore, failed to create inter-stream dependency";
+    return false;
+  }
+
+  return ROCMDriver::WaitStreamOnEvent(
+      device_ordinal_, AsROCMStreamValue(dependent), other_completed_event);
+}
+
+bool ROCMExecutor::StartTimer(Stream *stream, Timer *timer) {
+  return AsROCMTimer(timer)->Start(AsROCMStream(stream));
+}
+
+bool ROCMExecutor::StopTimer(Stream *stream, Timer *timer) {
+  return AsROCMTimer(timer)->Stop(AsROCMStream(stream));
+}
+
+port::Status ROCMExecutor::BlockHostUntilDone(Stream *stream) {
+  return ROCMDriver::SynchronizeStream(device_ordinal_,
+                                       AsROCMStreamValue(stream));
+}
+
+blas::BlasSupport *ROCMExecutor::CreateBlas() {
+  PluginRegistry *registry = PluginRegistry::Instance();
+  port::StatusOr<PluginRegistry::BlasFactory> status =
+      registry->GetFactory<PluginRegistry::BlasFactory>(kROCmPlatformId,
+                                                        plugin_config_.blas());
+  if (!status.ok()) {
+    LOG(ERROR) << "Unable to retrieve BLAS factory: "
+               << status.status().error_message();
+    return nullptr;
+  }
+
+  return status.ValueOrDie()(this);
+}
+
+dnn::DnnSupport *ROCMExecutor::CreateDnn() {
+  PluginRegistry *registry = PluginRegistry::Instance();
+  port::StatusOr<PluginRegistry::DnnFactory> status =
+      registry->GetFactory<PluginRegistry::DnnFactory>(kROCmPlatformId,
+                                                       plugin_config_.dnn());
+  if (!status.ok()) {
+    LOG(ERROR) << "Unable to retrieve DNN factory: "
+               << status.status().error_message();
+    return nullptr;
+  }
+
+  return status.ValueOrDie()(this);
+}
+
+fft::FftSupport *ROCMExecutor::CreateFft() {
+  PluginRegistry *registry = PluginRegistry::Instance();
+  port::StatusOr<PluginRegistry::FftFactory> status =
+      registry->GetFactory<PluginRegistry::FftFactory>(kROCmPlatformId,
+                                                       plugin_config_.fft());
+  if (!status.ok()) {
+    LOG(ERROR) << "Unable to retrieve FFT factory: "
+               << status.status().error_message();
+    return nullptr;
+  }
+
+  return status.ValueOrDie()(this);
+}
+
+rng::RngSupport *ROCMExecutor::CreateRng() {
+  PluginRegistry *registry = PluginRegistry::Instance();
+  port::StatusOr<PluginRegistry::RngFactory> status =
+      registry->GetFactory<PluginRegistry::RngFactory>(kROCmPlatformId,
+                                                       plugin_config_.rng());
+  if (!status.ok()) {
+    LOG(ERROR) << "Unable to retrieve RNG factory: "
+               << status.status().error_message();
+    return nullptr;
+  }
+
+  return status.ValueOrDie()(this);
+}
+
+// TODO(rspringer): Remove in b/18544742.
+bool ROCMExecutor::SupportsDnn() const { return true; }
+
+bool ROCMExecutor::CanEnablePeerAccessTo(StreamExecutorInterface *other) {
+  ROCMExecutor *rocm_other = static_cast<ROCMExecutor *>(other);
+  return ROCMDriver::CanEnablePeerAccess(device_ordinal_,
+                                         rocm_other->device_ordinal());
+}
+
+port::Status ROCMExecutor::EnablePeerAccessTo(StreamExecutorInterface *other) {
+  ROCMExecutor *rocm_other = static_cast<ROCMExecutor *>(other);
+  return ROCMDriver::EnablePeerAccess(device_ordinal_,
+                                      rocm_other->device_ordinal());
+}
+
+SharedMemoryConfig ROCMExecutor::GetDeviceSharedMemoryConfig() {
+  port::StatusOr<hipSharedMemConfig> rocm_config =
+      ROCMDriver::DeviceGetSharedMemConfig(device_ordinal_);
+  if (!rocm_config.ok()) {
+    // Don't log; the failed call will log necessary output.
+    return SharedMemoryConfig::kDefault;
+  }
+
+  switch (rocm_config.ValueOrDie()) {
+    case hipSharedMemBankSizeDefault:
+      return SharedMemoryConfig::kDefault;
+    case hipSharedMemBankSizeFourByte:
+      return SharedMemoryConfig::kFourByte;
+    case hipSharedMemBankSizeEightByte:
+      return SharedMemoryConfig::kEightByte;
+    default:
+      LOG(FATAL) << "Invalid shared memory configuration returned: "
+                 << rocm_config.ValueOrDie();
+  }
+}
+
+port::Status ROCMExecutor::SetDeviceSharedMemoryConfig(
+    SharedMemoryConfig config) {
+  hipSharedMemConfig rocm_config;
+  switch (config) {
+    case SharedMemoryConfig::kDefault:
+      rocm_config = hipSharedMemBankSizeDefault;
+      break;
+    case SharedMemoryConfig::kFourByte:
+      rocm_config = hipSharedMemBankSizeFourByte;
+      break;
+    case SharedMemoryConfig::kEightByte:
+      rocm_config = hipSharedMemBankSizeEightByte;
+      break;
+    default:
+      LOG(FATAL) << "Invalid shared memory configuration specified: "
+                 << static_cast<int>(config);
+  }
+  return ROCMDriver::DeviceSetSharedMemConfig(device_ordinal_, rocm_config);
+}
+
+bool ROCMExecutor::DeviceMemoryUsage(int64 *free, int64 *total) const {
+  return ROCMDriver::GetDeviceMemoryInfo(device_ordinal_, free, total);
+}
+
+bool ROCMExecutor::GetSymbol(const string &symbol_name,
+			     ModuleHandle module_handle, void **mem,
+                             size_t *bytes) {
+  {  // give limited scope to mutex_lock
+    mutex_lock lock{disk_modules_mu_};
+    for (auto &it : disk_modules_) {
+      if (ROCMDriver::GetModuleSymbol(
+              device_ordinal_, it.second, symbol_name.c_str(),
+              reinterpret_cast<hipDeviceptr_t *>(mem), bytes)) {
+        return true;
+      }
+    }
+  }
+
+  {  // give limited scope to mutex_lock
+    mutex_lock lock{in_memory_modules_mu_};
+    for (auto &it : in_memory_modules_) {
+      if (ROCMDriver::GetModuleSymbol(
+              device_ordinal_, it.second, symbol_name.c_str(),
+              reinterpret_cast<hipDeviceptr_t *>(mem), bytes)) {
+        return true;
+      }
+    }
+  }
+
+  LOG(INFO) << "Falied to find symbol in any modules: " << symbol_name;
+  return false;
+}
+
+bool ROCMExecutor::FillBlockDimLimit(BlockDim *block_dim_limit) const {
+  // The BlockDim name is a mismatch against these GRID_DIM_* queries because
+  // we use BlockDims to express the dimensions of blocks within a grid
+  // (as opposed to ThreadDim which expresses the dimensions of threads
+  // within a block).
+  int x, y, z;
+  if (!ROCMDriver::GetGridLimits(&x, &y, &z, device_)) {
+    return false;
+  }
+
+  block_dim_limit->x = x;
+  block_dim_limit->y = y;
+  block_dim_limit->z = z;
+  return true;
+}
+
+bool ROCMExecutor::SupportsBlas() const { return true; }
+
+bool ROCMExecutor::SupportsFft() const { return true; }
+
+bool ROCMExecutor::SupportsRng() const { return true; }
+
+std::unique_ptr<internal::EventInterface>
+ROCMExecutor::CreateEventImplementation() {
+  return std::unique_ptr<internal::EventInterface>(new ROCMEvent(this));
+}
+
+std::unique_ptr<internal::KernelInterface>
+ROCMExecutor::CreateKernelImplementation() {
+  return std::unique_ptr<internal::KernelInterface>(new ROCMKernel());
+}
+
+std::unique_ptr<internal::StreamInterface>
+ROCMExecutor::GetStreamImplementation() {
+  return std::unique_ptr<internal::StreamInterface>(new ROCMStream(this));
+}
+
+std::unique_ptr<internal::TimerInterface>
+ROCMExecutor::GetTimerImplementation() {
+  return std::unique_ptr<internal::TimerInterface>(new ROCMTimer(this));
+}
+
+void *ROCMExecutor::GpuContextHack() { return nullptr; }
+
+// Attempts to read the NUMA node corresponding to the GPU device's PCI bus out
+// of SysFS. Returns -1 if it cannot.
+//
+// For anything more complicated/prod-focused than this, you'll likely want to
+// turn to gsys' topology modeling.
+static int TryToReadNumaNode(const string &pci_bus_id, int device_ordinal) {
+  // ROCM TODO implement this feature in HIP
+  return 1;
+}
+
+// Set of device-specific parameters that cannot be
+// queried from the driver API.  These values instead are baked into a
+// lookup table indexed by AMDGPU ISA version.
+struct UnqueryableDeviceParams {
+  int version;
+  uint64 blocks_per_core_limit;
+  uint64 registers_per_core_limit;
+  uint64 registers_per_thread_limit;
+  uint64 warp_alloc_granularity;
+  uint64 register_alloc_granularity;
+  uint64 shared_memory_alloc_granularity;
+};
+
+static const UnqueryableDeviceParams kAllUnqueryableDeviceParams[] = {{
+    803,        // AMDGPU ISA version (803)
+    16,         // blocks_per_core_limit
+    64 * 1024,  // registers_per_core_limit
+    255,        // registers_per_thread_limit
+    4,          // warp_alloc_granularity
+    256,        // register_alloc_granularity
+    256         // shared_memory_alloc_granularity
+}};
+
+DeviceDescription *ROCMExecutor::PopulateDeviceDescription() const {
+  internal::DeviceDescriptionBuilder builder;
+
+  {
+    int driver_version = 0;
+    (void)ROCMDriver::GetDriverVersion(&driver_version);
+    string augmented_driver_version = port::Printf(
+        "%d (%s)", driver_version,
+        DriverVersionStatusToString(Diagnostician::FindDsoVersion()).c_str());
+    builder.set_driver_version(augmented_driver_version);
+  }
+
+  {
+    string pci_bus_id = ROCMDriver::GetPCIBusID(device_);
+
+    // Lower the hex characters to match sysfs.
+    pci_bus_id = port::Lowercase(pci_bus_id);
+    builder.set_pci_bus_id(pci_bus_id);
+
+    // Read the NUMA node corresponding to the PCI bus ID out of sysfs.
+    int numa_node = TryToReadNumaNode(pci_bus_id, device_ordinal_);
+    builder.set_numa_node(numa_node);
+  }
+
+  hipDeviceProp_t prop;
+  if (ROCMDriver::GetDeviceProperties(&prop, device_ordinal_)) {
+    builder.set_threads_per_block_limit(prop.maxThreadsPerBlock);
+
+    ThreadDim thread_dim_limit;
+    thread_dim_limit.x = prop.maxThreadsDim[0];
+    thread_dim_limit.y = prop.maxThreadsDim[1];
+    thread_dim_limit.z = prop.maxThreadsDim[2];
+    builder.set_thread_dim_limit(thread_dim_limit);
+
+    float clock_rate_ghz = static_cast<float>(prop.clockRate) / 1e6;
+    builder.set_clock_rate_ghz(clock_rate_ghz);
+  }
+
+  {
+    bool ecc_enabled = false;
+    (void)ROCMDriver::IsEccEnabled(device_, &ecc_enabled);
+    builder.set_ecc_enabled(ecc_enabled);
+  }
+
+  {
+    uint64 device_memory_size = -1;
+    (void)ROCMDriver::GetDeviceTotalMemory(device_, &device_memory_size);
+    builder.set_device_memory_size(device_memory_size);
+  }
+
+  {
+    BlockDim block_dim_limit;
+    FillBlockDimLimit(&block_dim_limit);
+    builder.set_block_dim_limit(block_dim_limit);
+  }
+
+  {
+    string device_name;
+    (void)ROCMDriver::GetDeviceName(device_, &device_name);
+    builder.set_name(device_name);
+  }
+
+  for (size_t i = 0; i < TF_ARRAYSIZE(kAllUnqueryableDeviceParams); i++) {
+    const auto &params = kAllUnqueryableDeviceParams[i];
+    if (params.version == version_) {
+      builder.set_blocks_per_core_limit(params.blocks_per_core_limit);
+      builder.set_registers_per_core_limit(params.registers_per_core_limit);
+      builder.set_registers_per_thread_limit(params.registers_per_thread_limit);
+      builder.set_warp_alloc_granularity(params.warp_alloc_granularity);
+      builder.set_register_alloc_granularity(params.register_alloc_granularity);
+      builder.set_shared_memory_alloc_granularity(
+          params.shared_memory_alloc_granularity);
+    }
+  }
+
+  builder.set_platform_version(
+      port::StrCat("AMDGPU ISA version: gfx", version_));
+
+  // TODO(leary) should be a way to query this from the driver, but this is
+  // unlikely to change for us any time soon.
+  builder.set_device_address_bits(64);
+
+  builder.set_device_vendor("Advanced Micro Devices, Inc");
+  builder.set_rocm_amdgpu_isa_version(version_);
+  builder.set_shared_memory_per_core(
+      ROCMDriver::GetMaxSharedMemoryPerCore(device_).ValueOrDie());
+  builder.set_shared_memory_per_block(
+      ROCMDriver::GetMaxSharedMemoryPerBlock(device_).ValueOrDie());
+  builder.set_core_count(
+      ROCMDriver::GetMultiprocessorCount(device_).ValueOrDie());
+  builder.set_threads_per_core_limit(
+      ROCMDriver::GetMaxThreadsPerMultiprocessor(device_).ValueOrDie());
+  builder.set_registers_per_block_limit(
+      ROCMDriver::GetMaxRegistersPerBlock(device_).ValueOrDie());
+  builder.set_threads_per_warp(
+      ROCMDriver::GetThreadsPerWarp(device_).ValueOrDie());
+
+  auto built = builder.Build();
+  return built.release();
+}
+}  // namespace rocm
+
+void initialize_rocm_gpu_executor() {
+  *internal::MakeROCMExecutorImplementation() = [](const PluginConfig &config) {
+    return new rocm::ROCMExecutor{config};
+  };
+}
+}  // namespace stream_executor
+
+REGISTER_MODULE_INITIALIZER(rocm_gpu_executor, {
+  stream_executor::initialize_rocm_gpu_executor();
+});

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
@@ -1,0 +1,270 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// The ROCM implementation of the StreamExecutorInterface functionality.
+// ROCM inclusions are ideally confined to this implementation file.
+//
+// The notions from the StreamExecutor basically correspond to the ROCM streams
+// programming model provided by the librocm.so driver APIs, so we don't have
+// to do much more than wrap the calls to the libraries appropriately.
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_GPU_EXECUTOR_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_GPU_EXECUTOR_H_
+
+#include <map>
+#include <set>
+
+#include "tensorflow/stream_executor/event.h"
+#include "tensorflow/stream_executor/lib/status.h"
+#include "tensorflow/stream_executor/lib/statusor.h"
+#include "tensorflow/stream_executor/platform.h"
+#include "tensorflow/stream_executor/platform/mutex.h"
+#include "tensorflow/stream_executor/platform/port.h"
+#include "tensorflow/stream_executor/platform/thread_annotations.h"
+#include "tensorflow/stream_executor/rocm/rocm_kernel.h"
+#include "tensorflow/stream_executor/stream_executor_internal.h"
+
+namespace stream_executor {
+namespace rocm {
+
+// ROCM-platform implementation of the platform-agnostic
+// StreamExecutorInferface.
+class ROCMExecutor : public internal::StreamExecutorInterface {
+ public:
+  // sub_platform indicates the subplatform used in this executor; it must
+  // be a ROCM type.
+  explicit ROCMExecutor(const PluginConfig &plugin_config)
+      : device_(0),
+        device_ordinal_(0),
+        version_(0),
+        plugin_config_(plugin_config) {}
+
+  // See the corresponding StreamExecutor methods for method comments on the
+  // following overrides.
+
+  ~ROCMExecutor() override;
+
+  port::Status Init(int device_ordinal, DeviceOptions device_options) override;
+
+  bool GetKernel(const MultiKernelLoaderSpec &spec,
+                 KernelBase *kernel) override;
+
+  bool Launch(Stream *stream, const ThreadDim &thread_dims,
+              const BlockDim &block_dims, const KernelBase &k,
+              const KernelArgsArrayBase &args) override;
+
+  void *Allocate(uint64 size) override;
+
+  void *AllocateSubBuffer(DeviceMemoryBase *mem, uint64 offset_bytes,
+                          uint64 size_bytes) override;
+
+  void Deallocate(DeviceMemoryBase *mem) override;
+
+  // ROCM allocation/registration functions are necessary because the driver
+  // internally sets up buffers for DMA operations (and page locks them).
+  // There's no external interface for us to otherwise control these DMA
+  // settings.
+  void *HostMemoryAllocate(uint64 size) override {
+    return ROCMDriver::HostAllocate(device_ordinal_, size);
+  }
+
+  void HostMemoryDeallocate(void *location) override {
+    return ROCMDriver::HostDeallocate(device_ordinal_, location);
+  }
+
+  bool HostMemoryRegister(void *location, uint64 size) override;
+
+  bool HostMemoryUnregister(void *location) override;
+
+  bool SynchronizeAllActivity() override;
+
+  bool SynchronousMemZero(DeviceMemoryBase *location, uint64 size) override;
+
+  bool SynchronousMemSet(DeviceMemoryBase *location, int value,
+                         uint64 size) override;
+
+  port::Status SynchronousMemcpy(DeviceMemoryBase *gpu_dst,
+                                 const void *host_src, uint64 size) override;
+
+  port::Status SynchronousMemcpy(void *host_dst,
+                                 const DeviceMemoryBase &gpu_src,
+                                 uint64 size) override;
+
+  port::Status SynchronousMemcpyDeviceToDevice(DeviceMemoryBase *gpu_dst,
+                                               const DeviceMemoryBase &gpu_src,
+                                               uint64 size) override;
+
+  bool MemZero(Stream *stream, DeviceMemoryBase *location,
+               uint64 size) override;
+  bool Memset(Stream *stream, DeviceMemoryBase *location, uint8 pattern,
+              uint64 size) override;
+  bool Memset32(Stream *stream, DeviceMemoryBase *location, uint32 pattern,
+                uint64 size) override;
+
+  bool Memcpy(Stream *stream, void *host_dst, const DeviceMemoryBase &gpu_src,
+              uint64 size) override;
+
+  bool Memcpy(Stream *stream, DeviceMemoryBase *gpu_dst, const void *host_src,
+              uint64 size) override;
+
+  bool MemcpyDeviceToDevice(Stream *stream, DeviceMemoryBase *gpu_dst,
+                            const DeviceMemoryBase &gpu_src,
+                            uint64 size) override;
+
+  bool HostCallback(Stream *stream, std::function<void()> callback) override;
+
+  bool AllocateStream(Stream *stream) override;
+
+  void DeallocateStream(Stream *stream) override;
+
+  bool CreateStreamDependency(Stream *dependent, Stream *other) override;
+
+  bool AllocateTimer(Timer *timer) override;
+
+  void DeallocateTimer(Timer *timer) override;
+
+  bool StartTimer(Stream *stream, Timer *timer) override;
+
+  bool StopTimer(Stream *stream, Timer *timer) override;
+
+  port::Status AllocateEvent(Event *event) override;
+
+  port::Status DeallocateEvent(Event *event) override;
+
+  port::Status RecordEvent(Stream *stream, Event *event) override;
+
+  port::Status WaitForEvent(Stream *stream, Event *event) override;
+
+  Event::Status PollForEventStatus(Event *event) override;
+
+  port::Status BlockHostUntilDone(Stream *stream) override;
+
+  int PlatformDeviceCount() override { return ROCMDriver::GetDeviceCount(); }
+
+  port::Status EnablePeerAccessTo(StreamExecutorInterface *other) override;
+
+  bool CanEnablePeerAccessTo(StreamExecutorInterface *other) override;
+
+  SharedMemoryConfig GetDeviceSharedMemoryConfig() override;
+
+  port::Status SetDeviceSharedMemoryConfig(SharedMemoryConfig config) override;
+
+  bool DeviceMemoryUsage(int64 *free, int64 *total) const override;
+
+  // Search for the symbol and returns a device pointer and size.
+  // Returns false if symbol does not exist.
+  bool GetSymbol(const string &symbol_name, ModuleHandle module_handle,
+		 void **mem, size_t *bytes) override;
+
+  DeviceDescription *PopulateDeviceDescription() const override;
+
+  // Populates the block_dim_limit by querying the device driver API. If an
+  // error occurs at any point while asking the driver for block dim limits, it
+  // will be only partially populated as a result, and an error will be logged.
+  bool FillBlockDimLimit(BlockDim *block_dim_limit) const;
+
+  bool SupportsBlas() const override;
+
+  blas::BlasSupport *CreateBlas() override;
+
+  bool SupportsFft() const override;
+
+  fft::FftSupport *CreateFft() override;
+
+  bool SupportsRng() const override;
+
+  rng::RngSupport *CreateRng() override;
+
+  bool SupportsDnn() const override;
+
+  dnn::DnnSupport *CreateDnn() override;
+
+  std::unique_ptr<internal::EventInterface> CreateEventImplementation()
+      override;
+
+  std::unique_ptr<internal::KernelInterface> CreateKernelImplementation()
+      override;
+
+  std::unique_ptr<internal::StreamInterface> GetStreamImplementation() override;
+
+  std::unique_ptr<internal::TimerInterface> GetTimerImplementation() override;
+
+  void *GpuContextHack() override;
+
+  int device_ordinal() const { return device_ordinal_; }
+
+ private:
+  // Attempts to find a more specific version of the file indicated by
+  // filename by looking for AMDGPU ISA-specific suffixed versions.
+  bool FindOnDiskForISAVersion(port::StringPiece filename,
+                               port::StringPiece canonical_suffix,
+                               string *found_filename) const;
+
+  // Host callback landing routine invoked by ROCM.
+  // data: User-provided callback provided to HostCallback() above, captured
+  //       as a std::function<void()>. Allocated/initialized inside
+  //       HostCallback() and owned and deleted by this call.
+  static void InternalHostCallback(hipStream_t stream, hipError_t status,
+                                   void *data);
+
+  // Collects metadata for the specified kernel.
+  bool GetKernelMetadata(ROCMKernel *rocm_kernel,
+                         KernelMetadata *kernel_metadata);
+
+  // Prints to VLOG(2) information about the kernel's occupancy and how it might
+  // be improved.
+  void VlogOccupancyInfo(const KernelBase &kernel, const ThreadDim &thread_dims,
+                         const BlockDim &block_dims);
+
+  // Guards the on-disk-module mapping.
+  mutex disk_modules_mu_;
+
+  // Mapping from filename to hipModule_t, if it was already retrieved.
+  // Multiple hipFunction_t are usually obtained from a single hipModule_t so we
+  // attempt to hit in this mapping first, before retrieving it.
+  std::map<string, hipModule_t> disk_modules_ GUARDED_BY(disk_modules_mu_);
+
+  // Guards the in-memory-module mapping.
+  mutex in_memory_modules_mu_;
+
+  std::map<const char *, hipModule_t> in_memory_modules_
+      GUARDED_BY(in_memory_modules_mu_);
+
+  // Guards the launched kernel set.
+  mutex launched_kernels_mu_;
+
+  // Keeps track of the set of launched kernels. Currently used to suppress the
+  // occupancy check on subsequent launches.
+  std::set<hipFunction_t> launched_kernels_ GUARDED_BY(launched_kernels_mu_);
+
+  // Handle for the ROCM device being operated on. Immutable
+  // post-initialization.
+  hipDevice_t device_;
+
+  // The device ordinal value that this executor was initialized with; recorded
+  // for use in getting device metadata. Immutable post-initialization.
+  int device_ordinal_;
+
+  // AMDGPU ISA version for device_.
+  int version_;
+
+  // The plugin configuration associated with this instance.
+  PluginConfig plugin_config_;
+
+  SE_DISALLOW_COPY_AND_ASSIGN(ROCMExecutor);
+};
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_GPU_EXECUTOR_H_

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <map>
 #include <set>
 
+#include "absl/strings/string_view.h" 
 #include "tensorflow/stream_executor/event.h"
 #include "tensorflow/stream_executor/lib/status.h"
 #include "tensorflow/stream_executor/lib/statusor.h"
@@ -207,8 +208,8 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
  private:
   // Attempts to find a more specific version of the file indicated by
   // filename by looking for AMDGPU ISA-specific suffixed versions.
-  bool FindOnDiskForISAVersion(port::StringPiece filename,
-                               port::StringPiece canonical_suffix,
+  bool FindOnDiskForISAVersion(absl::string_view filename,
+                               absl::string_view canonical_suffix,
                                string *found_filename) const;
 
   // Host callback landing routine invoked by ROCM.

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
@@ -123,7 +123,7 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
                             const DeviceMemoryBase &gpu_src,
                             uint64 size) override;
 
-  bool HostCallback(Stream *stream, std::function<void()> callback) override;
+  bool HostCallback(Stream *stream, std::function<port::Status()> callback) override;
 
   bool AllocateStream(Stream *stream) override;
 

--- a/tensorflow/stream_executor/rocm/rocm_helpers.h
+++ b/tensorflow/stream_executor/rocm/rocm_helpers.h
@@ -1,0 +1,102 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Common helper functions used for dealing with ROCM API datatypes.
+//
+// These are typically placed here for use by multiple source components (for
+// example, BLAS and executor components).
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_HELPERS_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_HELPERS_H_
+
+#include <stddef.h>
+#include <complex>
+
+#include "rocm/include/hip/hip_complex.h"
+
+namespace stream_executor {
+
+template <typename ElemT>
+class DeviceMemory;
+
+namespace rocm {
+
+// Converts a const DeviceMemory reference to its underlying typed pointer in
+// ROCM device memory.
+template <typename T>
+const T *ROCMMemory(const DeviceMemory<T> &mem) {
+  return static_cast<const T *>(mem.opaque());
+}
+
+// Converts a (non-const) DeviceMemory pointer reference to its underlying typed
+// pointer in ROCM device memory.
+template <typename T>
+T *ROCMMemoryMutable(DeviceMemory<T> *mem) {
+  return static_cast<T *>(mem->opaque());
+}
+
+static_assert(sizeof(std::complex<float>) == sizeof(hipComplex),
+              "std::complex<float> and hipComplex should have the same size");
+static_assert(offsetof(hipComplex, x) == 0,
+              "The real part of hipComplex should appear first.");
+static_assert(sizeof(std::complex<double>) == sizeof(hipDoubleComplex),
+              "std::complex<double> and hipDoubleComplex should have the same "
+              "size");
+static_assert(offsetof(hipDoubleComplex, x) == 0,
+              "The real part of hipDoubleComplex should appear first.");
+
+// Type traits to get ROCM complex types from std::complex<>.
+
+template <typename T>
+struct ROCMComplexT {
+  typedef T type;
+};
+
+template <>
+struct ROCMComplexT<std::complex<float>> {
+  typedef hipComplex type;
+};
+
+template <>
+struct ROCMComplexT<std::complex<double>> {
+  typedef hipDoubleComplex type;
+};
+
+// Converts pointers of std::complex<> to pointers of
+// hipComplex/hipDoubleComplex. No type conversion for non-complex types.
+
+template <typename T>
+inline const typename ROCMComplexT<T>::type *ROCMComplex(const T *p) {
+  return reinterpret_cast<const typename ROCMComplexT<T>::type *>(p);
+}
+
+template <typename T>
+inline typename ROCMComplexT<T>::type *ROCMComplex(T *p) {
+  return reinterpret_cast<typename ROCMComplexT<T>::type *>(p);
+}
+
+// Converts values of std::complex<float/double> to values of
+// hipComplex/hipDoubleComplex.
+inline hipComplex ROCMComplexValue(std::complex<float> val) {
+  return {val.real(), val.imag()};
+}
+
+inline hipDoubleComplex ROCMComplexValue(std::complex<double> val) {
+  return {val.real(), val.imag()};
+}
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_HELPERS_H_

--- a/tensorflow/stream_executor/rocm/rocm_kernel.h
+++ b/tensorflow/stream_executor/rocm/rocm_kernel.h
@@ -1,0 +1,130 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// The ROCM implementation of the StreamExecutorInterface functionality.
+// ROCM inclusions are ideally confined to this implementation file.
+//
+// The notions from the StreamExecutor basically correspond to the ROCM streams
+// programming model provided by the librocm.so driver APIs, so we don't have
+// to do much more than wrap the calls to the libraries appropriately.
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_KERNEL_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_KERNEL_H_
+
+#include "tensorflow/stream_executor/kernel_cache_config.h"
+#include "tensorflow/stream_executor/lib/casts.h"
+#include "tensorflow/stream_executor/platform/logging.h"
+#include "tensorflow/stream_executor/platform/port.h"
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+#include "tensorflow/stream_executor/stream_executor_internal.h"
+
+#ifdef PLATFORMS_GPUS_ROCM_DYNAMIC_LIBROCM_DYNAMIC_LIBROCM_H_
+#error \
+    "No driver calls in this file, wrap driver functionality in rocm_driver.cc."
+#endif
+
+#ifdef __ROCM_RUNTIME_H__
+#error \
+    "ROCM runtime being included into ROCM GPU executor; should be driver only."
+#endif
+
+namespace stream_executor {
+namespace rocm {
+
+// Wraps a hipFunction_t to implement the platform-independent KernelInterface.
+class ROCMKernel : public internal::KernelInterface {
+ public:
+  ROCMKernel()
+      : rocm_function_(nullptr),
+        arity_(0),
+        preferred_cache_config_(KernelCacheConfig::kNoPreference) {}
+
+  // Note that the function is unloaded when the module is unloaded, and the
+  // module that the function is contained in is owned by the ROCMExecutor.
+  ~ROCMKernel() override {}
+
+  // As arity cannot be reflected upon using the ROCM API, the arity is
+  // explicitly set during the ROCMExecutor::GetKernel initialization process.
+  void set_arity(unsigned arity) { arity_ = arity; }
+  unsigned Arity() const override { return arity_; }
+
+  // Returns the hipFunction_t value for passing to the ROCM API.
+  hipFunction_t AsROCMFunctionValue() const {
+    DCHECK(rocm_function_ != nullptr);
+    return const_cast<hipFunction_t>(rocm_function_);
+  }
+
+  // Returns the slot that the hipFunction_t is stored within for this object,
+  // for the ROCM API which wants to load into a hipFunction_t*.
+  hipFunction_t *rocm_function_ptr() { return &rocm_function_; }
+
+  // ROCM supports setting the preferred cache configuration of a hipFunction_t
+  // (more-or-less equivalent to a ROCMKernel). We support this via the below
+  // functions; users can set a preference, and that is applied when the kernel
+  // is [lazy-]loaded (in ROCMExecutor::Launch). The alternative would be to
+  // load the kernel & set the preference when the user calls the setter below;
+  // either approach is valid.
+  // Sets the current kernel cache configuration preference.
+  void SetPreferredCacheConfig(KernelCacheConfig config) override {
+    preferred_cache_config_ = config;
+  }
+
+  // Returns the current kernel cache configuration preference.
+  KernelCacheConfig GetPreferredCacheConfig() const override {
+    return preferred_cache_config_;
+  }
+
+  // Returns the current kernel cache configuration preference as a
+  // hipFuncCache_t.
+  hipFuncCache_t GetROCMCacheConfig() const {
+    switch (preferred_cache_config_) {
+      case KernelCacheConfig::kNoPreference:
+        return hipFuncCachePreferNone;
+      case KernelCacheConfig::kPreferShared:
+        return hipFuncCachePreferShared;
+        ;
+      case KernelCacheConfig::kPreferL1:
+        return hipFuncCachePreferL1;
+        ;
+      case KernelCacheConfig::kPreferEqual:
+        return hipFuncCachePreferEqual;
+      default:
+        LOG(FATAL) << "Unknown KernelCacheConfig"
+                   << static_cast<int32>(preferred_cache_config_);
+    }
+  }
+
+ private:
+  hipFunction_t rocm_function_;  // Wrapped ROCM kernel handle.
+  unsigned arity_;  // Number of formal parameters the kernel takes.
+
+  // Preferred (but not required) cache configuration for this kernel.
+  KernelCacheConfig preferred_cache_config_;
+};
+
+// Given a platform-independent kernel datatype, returns the (const) internal
+// ROCM platform implementation pointer.
+inline const ROCMKernel *AsROCMKernel(const KernelBase *kernel) {
+  return static_cast<const ROCMKernel *>(kernel->implementation());
+}
+
+// Given a platform-independent kernel datatype, returns the (non-const)
+// internal ROCM platform implementation pointer.
+inline ROCMKernel *AsROCMKernel(KernelBase *kernel) {
+  return static_cast<ROCMKernel *>(kernel->implementation());
+}
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_KERNEL_H_

--- a/tensorflow/stream_executor/rocm/rocm_kernel.h
+++ b/tensorflow/stream_executor/rocm/rocm_kernel.h
@@ -23,7 +23,6 @@ limitations under the License.
 #define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_KERNEL_H_
 
 #include "tensorflow/stream_executor/kernel_cache_config.h"
-#include "tensorflow/stream_executor/lib/casts.h"
 #include "tensorflow/stream_executor/platform/logging.h"
 #include "tensorflow/stream_executor/platform/port.h"
 #include "tensorflow/stream_executor/rocm/rocm_driver.h"

--- a/tensorflow/stream_executor/rocm/rocm_platform.cc
+++ b/tensorflow/stream_executor/rocm/rocm_platform.cc
@@ -1,0 +1,176 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/stream_executor/rocm/rocm_platform.h"
+#include "tensorflow/stream_executor/lib/error.h"
+#include "tensorflow/stream_executor/lib/initialize.h"
+#include "tensorflow/stream_executor/lib/ptr_util.h"
+#include "tensorflow/stream_executor/lib/status.h"
+#include "tensorflow/stream_executor/lib/stringprintf.h"
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+#include "tensorflow/stream_executor/rocm/rocm_gpu_executor.h"
+#include "tensorflow/stream_executor/rocm/rocm_platform_id.h"
+
+namespace stream_executor {
+namespace rocm {
+
+ROCmPlatform::ROCmPlatform()
+    : name_("ROCM"), min_numa_node_(0), limit_numa_node_(0) {}
+
+ROCmPlatform::~ROCmPlatform() {}
+
+// Due to legacy issues in user code, we can't currently call InpectNumaNodes
+// at module initialization time, because non-GPU programs still include this
+// plugin via various methods, so instead, it has to be init-on-reference.
+void ROCmPlatform::InspectNumaNodes() {
+  // To get NUMA node information, we need to create all executors, so we can
+  // examine their device descriptions to see their bus assignments.
+  static bool initialized = false;
+  static mutex numa_mutex(LINKER_INITIALIZED);
+  mutex_lock lock(numa_mutex);
+  if (initialized) {
+    return;
+  }
+
+  StreamExecutorConfig config;
+  for (int i = 0; i < VisibleDeviceCount(); i++) {
+    config.ordinal = i;
+    StreamExecutor* exec = GetExecutor(config).ValueOrDie();
+    if (i == 0) {
+      // NUMA nodes may not start at 0, so set the minimum node  based on the
+      // first executor we see.
+      min_numa_node_ = exec->GetDeviceDescription().numa_node();
+      limit_numa_node_ = min_numa_node_ + 1;
+    } else {
+      min_numa_node_ =
+          std::min(min_numa_node_, exec->GetDeviceDescription().numa_node());
+      limit_numa_node_ = std::max(limit_numa_node_,
+                                  exec->GetDeviceDescription().numa_node() + 1);
+    }
+  }
+  initialized = true;
+}
+
+int ROCmPlatform::BusCount() {
+  InspectNumaNodes();
+  return limit_numa_node_ - min_numa_node_;
+}
+
+int ROCmPlatform::DeviceToBus(int device_ordinal) {
+  StreamExecutorConfig config;
+  config.ordinal = device_ordinal;
+  StreamExecutor* exec = GetExecutor(config).ValueOrDie();
+  return exec->GetDeviceDescription().numa_node() - min_numa_node_;
+}
+
+port::StatusOr<StreamExecutor*> ROCmPlatform::FirstExecutorForBus(
+    int bus_ordinal) {
+  InspectNumaNodes();
+  CHECK_LT(bus_ordinal, BusCount()) << "bus ordinal out of available range";
+  for (int i = 0; i < VisibleDeviceCount(); i++) {
+    if (DeviceToBus(i) == bus_ordinal) {
+      StreamExecutorConfig config;
+      config.ordinal = i;
+      return GetExecutor(config).ValueOrDie();
+    }
+  }
+
+  return port::Status{
+      port::error::NOT_FOUND,
+      port::Printf("Executor for bus %d not found.", bus_ordinal)};
+}
+
+Platform::Id ROCmPlatform::id() const { return kROCmPlatformId; }
+
+int ROCmPlatform::VisibleDeviceCount() const {
+  // Throw away the result - it logs internally, and this [containing] function
+  // isn't in the path of user control. It's safe to call this > 1x.
+
+  if (!rocm::ROCMDriver::Init().ok()) {
+    return -1;
+  }
+
+  return ROCMDriver::GetDeviceCount();
+}
+
+const string& ROCmPlatform::Name() const { return name_; }
+
+port::StatusOr<StreamExecutor*> ROCmPlatform::ExecutorForDevice(int ordinal) {
+  StreamExecutorConfig config;
+  config.ordinal = ordinal;
+  config.plugin_config = PluginConfig();
+  config.device_options = DeviceOptions::Default();
+  return GetExecutor(config);
+}
+
+port::StatusOr<StreamExecutor*> ROCmPlatform::ExecutorForDeviceWithPluginConfig(
+    int device_ordinal, const PluginConfig& plugin_config) {
+  StreamExecutorConfig config;
+  config.ordinal = device_ordinal;
+  config.plugin_config = plugin_config;
+  config.device_options = DeviceOptions::Default();
+  return GetExecutor(config);
+}
+
+port::StatusOr<StreamExecutor*> ROCmPlatform::GetExecutor(
+    const StreamExecutorConfig& config) {
+  return executor_cache_.GetOrCreate(
+      config, [&]() { return GetUncachedExecutor(config); });
+}
+
+port::StatusOr<std::unique_ptr<StreamExecutor>>
+ROCmPlatform::GetUncachedExecutor(const StreamExecutorConfig& config) {
+  auto executor = MakeUnique<StreamExecutor>(
+      this, MakeUnique<ROCMExecutor>(config.plugin_config));
+  auto init_status = executor->Init(config.ordinal, config.device_options);
+  if (!init_status.ok()) {
+    return port::Status{
+        port::error::INTERNAL,
+        port::Printf(
+            "failed initializing StreamExecutor for ROCM device ordinal %d: %s",
+            config.ordinal, init_status.ToString().c_str())};
+  }
+
+  return std::move(executor);
+}
+
+void ROCmPlatform::RegisterTraceListener(
+    std::unique_ptr<TraceListener> listener) {
+  LOG(FATAL) << "not yet implemented: register ROCM trace listener";
+}
+
+void ROCmPlatform::UnregisterTraceListener(TraceListener* listener) {
+  LOG(FATAL) << "not yet implemented: unregister ROCM trace listener";
+}
+}  // namespace rocm
+
+static void InitializeROCmPlatform() {
+  // Disabling leak checking, MultiPlatformManager does not destroy its
+  // registered platforms.
+  auto status = MultiPlatformManager::PlatformWithName("ROCM");
+  if (!status.ok()) {
+    std::unique_ptr<rocm::ROCmPlatform> platform(new rocm::ROCmPlatform);
+    SE_CHECK_OK(MultiPlatformManager::RegisterPlatform(std::move(platform)));
+  }
+}
+}  // namespace stream_executor
+
+REGISTER_MODULE_INITIALIZER(rocm_platform,
+                            stream_executor::InitializeROCmPlatform());
+
+DECLARE_MODULE_INITIALIZER(multi_platform_manager);
+// Note that module initialization sequencing is not supported in the
+// open-source project, so this will be a no-op there.
+REGISTER_MODULE_INITIALIZER_SEQUENCE(rocm_platform, multi_platform_manager);

--- a/tensorflow/stream_executor/rocm/rocm_platform.cc
+++ b/tensorflow/stream_executor/rocm/rocm_platform.cc
@@ -14,14 +14,15 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/stream_executor/rocm/rocm_platform.h"
+
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+#include "tensorflow/stream_executor/rocm/rocm_gpu_executor.h"
+#include "tensorflow/stream_executor/rocm/rocm_platform_id.h"
 #include "tensorflow/stream_executor/lib/error.h"
 #include "tensorflow/stream_executor/lib/initialize.h"
 #include "tensorflow/stream_executor/lib/ptr_util.h"
 #include "tensorflow/stream_executor/lib/status.h"
 #include "tensorflow/stream_executor/lib/stringprintf.h"
-#include "tensorflow/stream_executor/rocm/rocm_driver.h"
-#include "tensorflow/stream_executor/rocm/rocm_gpu_executor.h"
-#include "tensorflow/stream_executor/rocm/rocm_platform_id.h"
 
 namespace stream_executor {
 namespace rocm {

--- a/tensorflow/stream_executor/rocm/rocm_platform.h
+++ b/tensorflow/stream_executor/rocm/rocm_platform.h
@@ -1,0 +1,110 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_PLATFORM_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_PLATFORM_H_
+
+#include <memory>
+#include <vector>
+#include "tensorflow/stream_executor/platform/port.h"
+
+#include "tensorflow/stream_executor/executor_cache.h"
+#include "tensorflow/stream_executor/lib/statusor.h"
+#include "tensorflow/stream_executor/multi_platform_manager.h"
+#include "tensorflow/stream_executor/platform.h"
+#include "tensorflow/stream_executor/platform/mutex.h"
+#include "tensorflow/stream_executor/platform/port.h"
+#include "tensorflow/stream_executor/platform/thread_annotations.h"
+#include "tensorflow/stream_executor/stream_executor_internal.h"
+#include "tensorflow/stream_executor/stream_executor_pimpl.h"
+#include "tensorflow/stream_executor/trace_listener.h"
+
+namespace stream_executor {
+namespace rocm {
+
+// Opaque and unique identifier for the ROCM platform plugin.
+// This is needed so that plugins can refer to/identify this platform without
+// instantiating a ROCmPlatform object.
+extern const Platform::Id kROCmPlatformId;
+
+// ROCm-specific platform plugin, registered as a singleton value via module
+// initializer.
+class ROCmPlatform : public Platform {
+ public:
+  ROCmPlatform();
+  ~ROCmPlatform() override;
+
+  // ROCmPlatform-specific functionality
+  // Returns the number of distinct buses / NUMA nodes on the machine.
+  int BusCount();
+
+  // Returns the bus/NUMA node for the specified device ordinal.
+  int DeviceToBus(int device_ordinal);
+
+  // Returns the lowest-ordinal-number StreamExecutor on the specified bus.
+  port::StatusOr<StreamExecutor*> FirstExecutorForBus(int bus_ordinal);
+
+  // Platform interface implementation:
+  // Returns the same value as kROCmPlatform above.
+  Platform::Id id() const override;
+
+  // Returns -1 as a sentinel on internal failure (and logs the error).
+  int VisibleDeviceCount() const override;
+
+  const string& Name() const override;
+
+  port::StatusOr<StreamExecutor*> ExecutorForDevice(int ordinal) override;
+
+  port::StatusOr<StreamExecutor*> ExecutorForDeviceWithPluginConfig(
+      int ordinal, const PluginConfig& config) override;
+
+  port::StatusOr<StreamExecutor*> GetExecutor(
+      const StreamExecutorConfig& config) override;
+
+  port::StatusOr<std::unique_ptr<StreamExecutor>> GetUncachedExecutor(
+      const StreamExecutorConfig& config) override;
+
+  void RegisterTraceListener(std::unique_ptr<TraceListener> listener) override;
+
+  void UnregisterTraceListener(TraceListener* listener) override;
+
+ private:
+  // Determines the number of NUMA nodes and the assignment of executor to each.
+  void InspectNumaNodes();
+
+  // This platform's name.
+  string name_;
+
+  // mutex that guards internal state.
+  mutable mutex mu_;
+
+  // Cache of created executors.
+  ExecutorCache executor_cache_;
+
+  // The smallest NUMA node value for any device managed by this machine
+  // manager. Used, along with limit_numa_node_, to convert NUMA nodes into bus
+  // ordinals. The NUMA node space occupied by GPUs is assumed to be dense./
+  int min_numa_node_;
+
+  // Larger than the NUMA node value for any device managed by this machine
+  // manager.
+  int limit_numa_node_;
+
+  SE_DISALLOW_COPY_AND_ASSIGN(ROCmPlatform);
+};
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_PLATFORM_H_

--- a/tensorflow/stream_executor/rocm/rocm_platform_id.cc
+++ b/tensorflow/stream_executor/rocm/rocm_platform_id.cc
@@ -1,0 +1,23 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/stream_executor/rocm/rocm_platform_id.h"
+
+namespace stream_executor {
+namespace rocm {
+
+PLATFORM_DEFINE_ID(kROCmPlatformId);
+}  // namespace rocm
+}  // namespace stream_executor

--- a/tensorflow/stream_executor/rocm/rocm_platform_id.h
+++ b/tensorflow/stream_executor/rocm/rocm_platform_id.h
@@ -1,0 +1,33 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_PLATFORM_ID_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_PLATFORM_ID_H_
+
+#include "tensorflow/stream_executor/platform.h"
+
+namespace stream_executor {
+namespace rocm {
+
+// Opaque and unique identifier for the ROCm platform.
+// This is needed so that plugins can refer to/identify this platform without
+// instantiating a ROCmPlatform object.
+// This is broken out here to avoid a circular dependency between ROCmPlatform
+// and ROCmExecutor.
+extern const Platform::Id kROCmPlatformId;
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_PLATFORM_ID_H_

--- a/tensorflow/stream_executor/rocm/rocm_rng.cc
+++ b/tensorflow/stream_executor/rocm/rocm_rng.cc
@@ -1,0 +1,308 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "rocm/include/hiprand/hiprand.h"
+
+#include "tensorflow/stream_executor/device_memory.h"
+#include "tensorflow/stream_executor/lib/env.h"
+#include "tensorflow/stream_executor/lib/initialize.h"
+#include "tensorflow/stream_executor/lib/status.h"
+#include "tensorflow/stream_executor/platform/logging.h"
+#include "tensorflow/stream_executor/rng.h"
+#include "tensorflow/stream_executor/rocm/rocm_activation.h"
+#include "tensorflow/stream_executor/rocm/rocm_gpu_executor.h"
+#include "tensorflow/stream_executor/rocm/rocm_helpers.h"
+#include "tensorflow/stream_executor/rocm/rocm_platform_id.h"
+#include "tensorflow/stream_executor/rocm/rocm_rng.h"
+#include "tensorflow/stream_executor/rocm/rocm_stream.h"
+
+// Formats hiprandStatus_t to output prettified values into a log stream.
+std::ostream &operator<<(std::ostream &in, const hiprandStatus_t &status) {
+#define OSTREAM_HIPRAND_STATUS(__name) \
+  case HIPRAND_STATUS_##__name:        \
+    in << "HIPRAND_STATUS_" #__name;   \
+    return in;
+
+  switch (status) {
+    OSTREAM_HIPRAND_STATUS(SUCCESS)
+    OSTREAM_HIPRAND_STATUS(VERSION_MISMATCH)
+    OSTREAM_HIPRAND_STATUS(NOT_INITIALIZED)
+    OSTREAM_HIPRAND_STATUS(ALLOCATION_FAILED)
+    OSTREAM_HIPRAND_STATUS(TYPE_ERROR)
+    OSTREAM_HIPRAND_STATUS(OUT_OF_RANGE)
+    OSTREAM_HIPRAND_STATUS(LENGTH_NOT_MULTIPLE)
+    OSTREAM_HIPRAND_STATUS(LAUNCH_FAILURE)
+    OSTREAM_HIPRAND_STATUS(PREEXISTING_FAILURE)
+    OSTREAM_HIPRAND_STATUS(INITIALIZATION_FAILED)
+    OSTREAM_HIPRAND_STATUS(ARCH_MISMATCH)
+    OSTREAM_HIPRAND_STATUS(INTERNAL_ERROR)
+    default:
+      in << "hiprandStatus_t(" << static_cast<int>(status) << ")";
+      return in;
+  }
+}
+
+namespace stream_executor {
+namespace rocm {
+
+PLUGIN_REGISTRY_DEFINE_PLUGIN_ID(kHipRandPlugin);
+
+namespace wrap {
+
+#define PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(__name)                      \
+  struct WrapperShim__##__name {                                     \
+    template <typename... Args>                                      \
+    hiprandStatus_t operator()(ROCMExecutor *parent, Args... args) { \
+      rocm::ScopedActivateExecutorContext sac{parent};               \
+      return ::__name(args...);                                      \
+    }                                                                \
+  } __name;
+
+PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(hiprandCreateGenerator);
+PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(hiprandDestroyGenerator);
+PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(hiprandSetStream);
+PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(hiprandGenerateUniform);
+PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(hiprandGenerateUniformDouble);
+PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(hiprandSetPseudoRandomGeneratorSeed);
+PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(hiprandSetGeneratorOffset);
+PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(hiprandGenerateNormal);
+PERFTOOLS_GPUTOOLS_HIPRAND_WRAP(hiprandGenerateNormalDouble);
+}  // namespace wrap
+
+template <typename T>
+string TypeString();
+
+template <>
+string TypeString<float>() {
+  return "float";
+}
+
+template <>
+string TypeString<double>() {
+  return "double";
+}
+
+template <>
+string TypeString<std::complex<float>>() {
+  return "std::complex<float>";
+}
+
+template <>
+string TypeString<std::complex<double>>() {
+  return "std::complex<double>";
+}
+
+ROCMRng::ROCMRng(ROCMExecutor *parent) : parent_(parent), rng_(nullptr) {}
+
+ROCMRng::~ROCMRng() {
+  if (rng_ != nullptr) {
+    wrap::hiprandDestroyGenerator(parent_, rng_);
+  }
+}
+
+bool ROCMRng::Init() {
+  mutex_lock lock{mu_};
+  CHECK(rng_ == nullptr);
+
+  hiprandStatus_t ret =
+      wrap::hiprandCreateGenerator(parent_, &rng_, HIPRAND_RNG_PSEUDO_DEFAULT);
+  if (ret != HIPRAND_STATUS_SUCCESS) {
+    LOG(ERROR) << "failed to create random number generator: " << ret;
+    return false;
+  }
+
+  CHECK(rng_ != nullptr);
+  return true;
+}
+
+bool ROCMRng::SetStream(Stream *stream) {
+  hiprandStatus_t ret =
+      wrap::hiprandSetStream(parent_, rng_, AsROCMStreamValue(stream));
+  if (ret != HIPRAND_STATUS_SUCCESS) {
+    LOG(ERROR) << "failed to set stream for random generation: " << ret;
+    return false;
+  }
+
+  return true;
+}
+
+// Returns true if std::complex stores its contents as two consecutive
+// elements. Tests int, float and double, as the last two are independent
+// specializations.
+constexpr bool ComplexIsConsecutiveFloats() {
+  return sizeof(std::complex<int>) == 8 && sizeof(std::complex<float>) == 8 &&
+         sizeof(std::complex<double>) == 16;
+}
+
+template <typename T>
+bool ROCMRng::DoPopulateRandUniformInternal(Stream *stream,
+                                            DeviceMemory<T> *v) {
+  mutex_lock lock{mu_};
+  static_assert(ComplexIsConsecutiveFloats(),
+                "std::complex values are not stored as consecutive values");
+
+  if (!SetStream(stream)) {
+    return false;
+  }
+
+  // std::complex<T> is currently implemented as two consecutive T variables.
+  uint64 element_count = v->ElementCount();
+  if (std::is_same<T, std::complex<float>>::value ||
+      std::is_same<T, std::complex<double>>::value) {
+    element_count *= 2;
+  }
+
+  hiprandStatus_t ret;
+  if (std::is_same<T, float>::value ||
+      std::is_same<T, std::complex<float>>::value) {
+    ret = wrap::hiprandGenerateUniform(
+        parent_, rng_, reinterpret_cast<float *>(ROCMMemoryMutable(v)),
+        element_count);
+  } else {
+    ret = wrap::hiprandGenerateUniformDouble(
+        parent_, rng_, reinterpret_cast<double *>(ROCMMemoryMutable(v)),
+        element_count);
+  }
+  if (ret != HIPRAND_STATUS_SUCCESS) {
+    LOG(ERROR) << "failed to do uniform generation of " << v->ElementCount()
+               << " " << TypeString<T>() << "s at " << v->opaque() << ": "
+               << ret;
+    return false;
+  }
+
+  return true;
+}
+
+bool ROCMRng::DoPopulateRandUniform(Stream *stream, DeviceMemory<float> *v) {
+  return DoPopulateRandUniformInternal(stream, v);
+}
+
+bool ROCMRng::DoPopulateRandUniform(Stream *stream, DeviceMemory<double> *v) {
+  return DoPopulateRandUniformInternal(stream, v);
+}
+
+bool ROCMRng::DoPopulateRandUniform(Stream *stream,
+                                    DeviceMemory<std::complex<float>> *v) {
+  return DoPopulateRandUniformInternal(stream, v);
+}
+
+bool ROCMRng::DoPopulateRandUniform(Stream *stream,
+                                    DeviceMemory<std::complex<double>> *v) {
+  return DoPopulateRandUniformInternal(stream, v);
+}
+
+template <typename ElemT, typename FuncT>
+bool ROCMRng::DoPopulateRandGaussianInternal(Stream *stream, ElemT mean,
+                                             ElemT stddev,
+                                             DeviceMemory<ElemT> *v,
+                                             FuncT func) {
+  mutex_lock lock{mu_};
+
+  if (!SetStream(stream)) {
+    return false;
+  }
+
+  uint64 element_count = v->ElementCount();
+  hiprandStatus_t ret =
+      func(parent_, rng_, ROCMMemoryMutable(v), element_count, mean, stddev);
+
+  if (ret != HIPRAND_STATUS_SUCCESS) {
+    LOG(ERROR) << "failed to do gaussian generation of " << v->ElementCount()
+               << " floats at " << v->opaque() << ": " << ret;
+    return false;
+  }
+
+  return true;
+}
+
+bool ROCMRng::DoPopulateRandGaussian(Stream *stream, float mean, float stddev,
+                                     DeviceMemory<float> *v) {
+  return DoPopulateRandGaussianInternal(stream, mean, stddev, v,
+                                        wrap::hiprandGenerateNormal);
+}
+
+bool ROCMRng::DoPopulateRandGaussian(Stream *stream, double mean, double stddev,
+                                     DeviceMemory<double> *v) {
+  return DoPopulateRandGaussianInternal(stream, mean, stddev, v,
+                                        wrap::hiprandGenerateNormalDouble);
+}
+
+bool ROCMRng::SetSeed(Stream *stream, const uint8 *seed, uint64 seed_bytes) {
+  mutex_lock lock{mu_};
+  CHECK(rng_ != nullptr);
+
+  if (!CheckSeed(seed, seed_bytes)) {
+    return false;
+  }
+
+  if (!SetStream(stream)) {
+    return false;
+  }
+
+  // Requires 8 bytes of seed data; checked in RngSupport::CheckSeed (above)
+  // (which itself requires 16 for API consistency with host RNG fallbacks).
+  hiprandStatus_t ret = wrap::hiprandSetPseudoRandomGeneratorSeed(
+      parent_, rng_, *(reinterpret_cast<const uint64 *>(seed)));
+  if (ret != HIPRAND_STATUS_SUCCESS) {
+    LOG(ERROR) << "failed to set rng seed: " << ret;
+    return false;
+  }
+
+  ret = wrap::hiprandSetGeneratorOffset(parent_, rng_, 0);
+  if (ret != HIPRAND_STATUS_SUCCESS) {
+    LOG(ERROR) << "failed to reset rng position: " << ret;
+    return false;
+  }
+  return true;
+}
+}  // namespace rocm
+}  // namespace stream_executor
+
+namespace gpu = ::stream_executor;
+
+REGISTER_MODULE_INITIALIZER(register_hiprand, {
+  gpu::port::Status status =
+      gpu::PluginRegistry::Instance()
+          ->RegisterFactory<gpu::PluginRegistry::RngFactory>(
+              gpu::rocm::kROCmPlatformId, gpu::rocm::kHipRandPlugin, "hipRAND",
+              [](gpu::internal::StreamExecutorInterface *parent)
+                  -> gpu::rng::RngSupport * {
+                gpu::rocm::ROCMExecutor *rocm_executor =
+                    dynamic_cast<gpu::rocm::ROCMExecutor *>(parent);
+                if (rocm_executor == nullptr) {
+                  LOG(ERROR)
+                      << "Attempting to initialize an instance of the hipRAND "
+                      << "support library with a non-ROCM StreamExecutor";
+                  return nullptr;
+                }
+
+                gpu::rocm::ROCMRng *rng = new gpu::rocm::ROCMRng(rocm_executor);
+                if (!rng->Init()) {
+                  // Note: Init() will log a more specific error.
+                  delete rng;
+                  return nullptr;
+                }
+                return rng;
+              });
+
+  if (!status.ok()) {
+    LOG(ERROR) << "Unable to register hipRAND factory: "
+               << status.error_message();
+  }
+
+  gpu::PluginRegistry::Instance()->SetDefaultFactory(gpu::rocm::kROCmPlatformId,
+                                                     gpu::PluginKind::kRng,
+                                                     gpu::rocm::kHipRandPlugin);
+});

--- a/tensorflow/stream_executor/rocm/rocm_rng.h
+++ b/tensorflow/stream_executor/rocm/rocm_rng.h
@@ -1,0 +1,99 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_RNG_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_RNG_H_
+
+#include "tensorflow/stream_executor/platform/mutex.h"
+#include "tensorflow/stream_executor/platform/port.h"
+#include "tensorflow/stream_executor/platform/thread_annotations.h"
+#include "tensorflow/stream_executor/plugin_registry.h"
+#include "tensorflow/stream_executor/rng.h"
+
+namespace stream_executor {
+
+class Stream;
+template <typename ElemT>
+class DeviceMemory;
+
+namespace rocm {
+
+// Opaque and unique identifier for the hipRAND plugin.
+extern const PluginId kHipRandPlugin;
+
+class ROCMExecutor;
+
+// ROCM-platform implementation of the random number generation support
+// interface.
+//
+// Thread-safe post-initialization.
+class ROCMRng : public rng::RngSupport {
+ public:
+  explicit ROCMRng(ROCMExecutor *parent);
+
+  // Retrieves a hiprng library generator handle. This is necessary for
+  // enqueuing random number generation work onto the device.
+  // TODO(leary) provide a way for users to select the RNG algorithm.
+  bool Init();
+
+  // Releases a hiprng library generator handle, if one was acquired.
+  ~ROCMRng() override;
+
+  // See rng::RngSupport for details on the following overrides.
+  bool DoPopulateRandUniform(Stream *stream, DeviceMemory<float> *v) override;
+  bool DoPopulateRandUniform(Stream *stream, DeviceMemory<double> *v) override;
+  bool DoPopulateRandUniform(Stream *stream,
+                             DeviceMemory<std::complex<float>> *v) override;
+  bool DoPopulateRandUniform(Stream *stream,
+                             DeviceMemory<std::complex<double>> *v) override;
+  bool DoPopulateRandGaussian(Stream *stream, float mean, float stddev,
+                              DeviceMemory<float> *v) override;
+  bool DoPopulateRandGaussian(Stream *stream, double mean, double stddev,
+                              DeviceMemory<double> *v) override;
+
+  bool SetSeed(Stream *stream, const uint8 *seed, uint64 seed_bytes) override;
+
+ private:
+  // Actually performs the work of generating random numbers - the public
+  // methods are thin wrappers to this interface.
+  template <typename T>
+  bool DoPopulateRandUniformInternal(Stream *stream, DeviceMemory<T> *v);
+  template <typename ElemT, typename FuncT>
+  bool DoPopulateRandGaussianInternal(Stream *stream, ElemT mean, ElemT stddev,
+                                      DeviceMemory<ElemT> *v, FuncT func);
+
+  // Sets the stream for the internal hiprng generator.
+  //
+  // This is a stateful operation, as the handle can only have one stream set at
+  // a given time, so it is usually performed right before enqueuing work to do
+  // with random number generation.
+  bool SetStream(Stream *stream) EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  // mutex that guards the hipRAND handle for this device.
+  mutex mu_;
+
+  // ROCMExecutor which instantiated this ROCMRng.
+  // Immutable post-initialization.
+  ROCMExecutor *parent_;
+
+  // hipRAND library handle on the device.
+  hiprandGenerator_t rng_ GUARDED_BY(mu_);
+
+  SE_DISALLOW_COPY_AND_ASSIGN(ROCMRng);
+};
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_RNG_H_

--- a/tensorflow/stream_executor/rocm/rocm_stream.cc
+++ b/tensorflow/stream_executor/rocm/rocm_stream.cc
@@ -1,0 +1,59 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/stream_executor/rocm/rocm_stream.h"
+#include "tensorflow/stream_executor/lib/status.h"
+#include "tensorflow/stream_executor/rocm/rocm_gpu_executor.h"
+#include "tensorflow/stream_executor/stream.h"
+
+namespace stream_executor {
+namespace rocm {
+
+bool ROCMStream::Init() {
+  if (!ROCMDriver::CreateStream(parent_->device_ordinal(), &rocm_stream_)) {
+    return false;
+  }
+  return ROCMDriver::CreateEvent(parent_->device_ordinal(), &completed_event_,
+                                 ROCMDriver::EventFlags::kDisableTiming)
+      .ok();
+}
+
+void ROCMStream::Destroy() {
+  if (completed_event_ != nullptr) {
+    port::Status status =
+        ROCMDriver::DestroyEvent(parent_->device_ordinal(), &completed_event_);
+    if (!status.ok()) {
+      LOG(ERROR) << status.error_message();
+    }
+  }
+
+  ROCMDriver::DestroyStream(parent_->device_ordinal(), &rocm_stream_);
+}
+
+bool ROCMStream::IsIdle() const {
+  return ROCMDriver::IsStreamIdle(parent_->device_ordinal(), rocm_stream_);
+}
+
+ROCMStream *AsROCMStream(Stream *stream) {
+  DCHECK(stream != nullptr);
+  return static_cast<ROCMStream *>(stream->implementation());
+}
+
+hipStream_t AsROCMStreamValue(Stream *stream) {
+  DCHECK(stream != nullptr);
+  return AsROCMStream(stream)->rocm_stream();
+}
+}  // namespace rocm
+}  // namespace stream_executor

--- a/tensorflow/stream_executor/rocm/rocm_stream.h
+++ b/tensorflow/stream_executor/rocm/rocm_stream.h
@@ -1,0 +1,92 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Defines the ROCMStream type - the ROCM-specific implementation of the generic
+// StreamExecutor Stream interface.
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_STREAM_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_STREAM_H_
+
+#include "tensorflow/stream_executor/platform/thread_annotations.h"
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+#include "tensorflow/stream_executor/stream_executor_internal.h"
+
+namespace stream_executor {
+namespace rocm {
+
+class ROCMExecutor;
+
+// Wraps a hipStream_t in order to satisfy the platform-independent
+// StreamInterface.
+//
+// Thread-safe post-initialization.
+class ROCMStream : public internal::StreamInterface {
+ public:
+  explicit ROCMStream(ROCMExecutor *parent)
+      : parent_(parent), rocm_stream_(nullptr), completed_event_(nullptr) {}
+
+  // Note: teardown is handled by a parent's call to DeallocateStream.
+  ~ROCMStream() override {}
+
+  void *GpuStreamHack() override { return rocm_stream_; }
+  void **GpuStreamMemberHack() override {
+    return reinterpret_cast<void **>(&rocm_stream_);
+  }
+
+  // Explicitly initialize the ROCM resources associated with this stream, used
+  // by StreamExecutor::AllocateStream().
+  bool Init();
+
+  // Explicitly destroy the ROCM resources associated with this stream, used by
+  // StreamExecutor::DeallocateStream().
+  void Destroy();
+
+  // Returns true if no work is pending or executing on the stream.
+  bool IsIdle() const;
+
+  // Retrieves an event which indicates that all work enqueued into the stream
+  // has completed. Ownership of the event is not transferred to the caller, the
+  // event is owned by this stream.
+  hipEvent_t *completed_event() { return &completed_event_; }
+
+  // Returns the hipStream_t value for passing to the ROCM API.
+  //
+  // Precond: this ROCMStream has been allocated (otherwise passing a nullptr
+  // into ROCM library causes difficult-to-understand faults).
+  hipStream_t rocm_stream() const {
+    DCHECK(rocm_stream_ != nullptr);
+    return const_cast<hipStream_t>(rocm_stream_);
+  }
+
+  ROCMExecutor *parent() const { return parent_; }
+
+ private:
+  ROCMExecutor *parent_;     // Executor that spawned this stream.
+  hipStream_t rocm_stream_;  // Wrapped ROCM stream handle.
+
+  // Event that indicates this stream has completed.
+  hipEvent_t completed_event_ = nullptr;
+};
+
+// Helper functions to simplify extremely common flows.
+// Converts a Stream to the underlying ROCMStream implementation.
+ROCMStream *AsROCMStream(Stream *stream);
+
+// Extracts a hipStream_t from a ROCMStream-backed Stream object.
+hipStream_t AsROCMStreamValue(Stream *stream);
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_STREAM_H_

--- a/tensorflow/stream_executor/rocm/rocm_timer.cc
+++ b/tensorflow/stream_executor/rocm/rocm_timer.cc
@@ -1,0 +1,84 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/stream_executor/rocm/rocm_timer.h"
+#include "tensorflow/stream_executor/lib/status.h"
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+#include "tensorflow/stream_executor/rocm/rocm_gpu_executor.h"
+#include "tensorflow/stream_executor/rocm/rocm_stream.h"
+
+namespace stream_executor {
+namespace rocm {
+
+bool ROCMTimer::Init() {
+  CHECK(start_event_ == nullptr && stop_event_ == nullptr);
+  if (!ROCMDriver::CreateEvent(parent_->device_ordinal(), &start_event_,
+                               ROCMDriver::EventFlags::kDefault)
+           .ok()) {
+    return false;
+  }
+
+  if (!ROCMDriver::CreateEvent(parent_->device_ordinal(), &stop_event_,
+                               ROCMDriver::EventFlags::kDefault)
+           .ok()) {
+    port::Status status =
+        ROCMDriver::DestroyEvent(parent_->device_ordinal(), &start_event_);
+    if (!status.ok()) {
+      LOG(ERROR) << status;
+    }
+    return false;
+  }
+
+  CHECK(start_event_ != nullptr && stop_event_ != nullptr);
+  return true;
+}
+
+void ROCMTimer::Destroy() {
+  port::Status status =
+      ROCMDriver::DestroyEvent(parent_->device_ordinal(), &start_event_);
+  if (!status.ok()) {
+    LOG(ERROR) << status;
+  }
+
+  status = ROCMDriver::DestroyEvent(parent_->device_ordinal(), &stop_event_);
+  if (!status.ok()) {
+    LOG(ERROR) << status;
+  }
+}
+
+float ROCMTimer::GetElapsedMilliseconds() const {
+  CHECK(start_event_ != nullptr && stop_event_ != nullptr);
+  // TODO(leary) provide a way to query timer resolution?
+  // ROCM docs say a resolution of about 0.5us
+  float elapsed_milliseconds = NAN;
+  (void)ROCMDriver::GetEventElapsedTime(parent_->device_ordinal(),
+                                        &elapsed_milliseconds, start_event_,
+                                        stop_event_);
+  return elapsed_milliseconds;
+}
+
+bool ROCMTimer::Start(ROCMStream *stream) {
+  return ROCMDriver::RecordEvent(parent_->device_ordinal(), start_event_,
+                                 stream->rocm_stream())
+      .ok();
+}
+
+bool ROCMTimer::Stop(ROCMStream *stream) {
+  return ROCMDriver::RecordEvent(parent_->device_ordinal(), stop_event_,
+                                 stream->rocm_stream())
+      .ok();
+}
+}  // namespace rocm
+}  // namespace stream_executor

--- a/tensorflow/stream_executor/rocm/rocm_timer.h
+++ b/tensorflow/stream_executor/rocm/rocm_timer.h
@@ -1,0 +1,81 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Defines the ROCMTimer type - the ROCM-specific implementation of the generic
+// StreamExecutor Timer interface.
+
+#ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_TIMER_H_
+#define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_TIMER_H_
+
+#include "tensorflow/stream_executor/rocm/rocm_driver.h"
+#include "tensorflow/stream_executor/rocm/rocm_gpu_executor.h"
+#include "tensorflow/stream_executor/stream_executor_internal.h"
+
+namespace stream_executor {
+namespace rocm {
+
+class ROCMExecutor;
+class ROCMStream;
+
+// Wraps a pair of hipEvent_ts in order to satisfy the platform-independent
+// TimerInferface -- both a start and a stop event are present which may be
+// recorded in a stream.
+class ROCMTimer : public internal::TimerInterface {
+ public:
+  explicit ROCMTimer(ROCMExecutor *parent)
+      : parent_(parent), start_event_(nullptr), stop_event_(nullptr) {}
+
+  // Note: teardown is explicitly handled in this API by a call to
+  // StreamExecutor::DeallocateTimer(), which invokes Destroy().
+  ~ROCMTimer() override {}
+
+  // Allocates the platform-specific pieces of the timer, called as part of
+  // StreamExecutor::AllocateTimer().
+  bool Init();
+
+  // Deallocates the platform-specific pieces of the timer, called as part of
+  // StreamExecutor::DeallocateTimer().
+  void Destroy();
+
+  // Records the "timer start" event at the current point in the stream.
+  bool Start(ROCMStream *stream);
+
+  // Records the "timer stop" event at the current point in the stream.
+  bool Stop(ROCMStream *stream);
+
+  // Returns the elapsed time, in milliseconds, between the start and stop
+  // events.
+  float GetElapsedMilliseconds() const;
+
+  // See Timer::Microseconds().
+  // TODO(leary) make this into an error code interface...
+  uint64 Microseconds() const override {
+    return GetElapsedMilliseconds() * 1e3;
+  }
+
+  // See Timer::Nanoseconds().
+  uint64 Nanoseconds() const override { return GetElapsedMilliseconds() * 1e6; }
+
+ private:
+  ROCMExecutor *parent_;
+  hipEvent_t start_event_;  // Event recorded to indicate the "start" timestamp
+                            // executing in a stream.
+  hipEvent_t stop_event_;   // Event recorded to indicate the "stop" timestamp
+                            // executing in a stream.
+};
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_TIMER_H_

--- a/tensorflow/stream_executor/stream_executor_internal.cc
+++ b/tensorflow/stream_executor/stream_executor_internal.cc
@@ -32,6 +32,13 @@ StreamExecutorFactory* MakeOpenCLExecutorImplementation() {
   return &instance;
 }
 
+// -- ROCm
+
+StreamExecutorFactory* MakeROCMExecutorImplementation() {
+  static StreamExecutorFactory instance;
+  return &instance;
+}
+
 // -- Host
 
 StreamExecutorFactory MakeHostExecutorImplementation;

--- a/tensorflow/stream_executor/stream_executor_internal.h
+++ b/tensorflow/stream_executor/stream_executor_internal.h
@@ -376,6 +376,8 @@ using KernelFactory = std::function<KernelInterface*()>;
 
 StreamExecutorFactory* MakeCUDAExecutorImplementation();
 
+StreamExecutorFactory* MakeROCMExecutorImplementation();
+
 StreamExecutorFactory* MakeOpenCLExecutorImplementation();
 
 extern StreamExecutorFactory MakeHostExecutorImplementation;

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -74,6 +74,9 @@ internal::StreamExecutorInterface *StreamExecutorImplementationFromPlatformKind(
     case PlatformKind::kOpenCL:
       factory = *internal::MakeOpenCLExecutorImplementation();
       break;
+    case PlatformKind::kROCm:
+      factory = *internal::MakeROCMExecutorImplementation();
+      break;
     case PlatformKind::kHost:
       factory = internal::MakeHostExecutorImplementation;
       break;
@@ -188,6 +191,8 @@ StreamExecutor::StreamExecutor(
       memory_limit_bytes_(GetMemoryLimitBytes()) {
   if (port::Lowercase(platform_->Name()) == "cuda") {
     platform_kind_ = PlatformKind::kCuda;
+  } else if (port::Lowercase(platform_->Name()) == "rocm") {
+    platform_kind_ = PlatformKind::kROCm;
   } else if (port::Lowercase(platform_->Name()) == "opencl") {
     platform_kind_ = PlatformKind::kOpenCL;
   } else if (port::Lowercase(platform_->Name()) == "host") {


### PR DESCRIPTION
This is really the continuation of PR 20709. 
Filing this new PR as that one was closed out by the `tensorflowbutler`

Now that PR #20277 has been merged, this PR is ready to be reviewed and merged as well.

Note that this PR includes the change being discussed in PR #22658 to fix the broken. Any further changes made as part of that PR will need to be applied to this one too.

The other PRs that build upon this one (i.e. have this PR getting merged as pre-req) 
1. #20712 
2. #20713
3. #20715
have also been closed out by `tensorflowbutler`, and I will be filing new ones shortly for each of them.


------- Original Description copied from PR #20709 ---------------

The commit contains StreamExecutor logic for ROCm platform. It includes
integration logic with major components on ROCm platform:

- HIP runtime APIs
- rocRAND for RNG

Also included are relevant changes to:

- bazel script to build ROCm StreamExecutor on ROCm platform

Authors:

- Jack Chung: jack.chung@amd.com
- Deven Desai: deven.desai@amd.com
- Johannes M Dieterich: Johannes.Dieterich@amd.com
- Peng Sun: Peng.Sun@amd.com
- Jeffrey Poznanovic: Jeffrey.Poznanovic@amd.com