### PR TITLE
1.12-rc0 cherry-pick request: Disable XLA from raspberry pi builds.

### DIFF
--- a/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
+++ b/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
@@ -34,6 +34,8 @@ set -e
 #
 # Make sure you have an up to date version of the Bazel build tool installed too.
 
+export TF_ENABLE_XLA=0
+
 yes '' | ./configure
 
 # Fix for curl build problem in 32-bit, see https://stackoverflow.com/questions/35181744/size-of-array-curl-rule-01-is-negative


### PR DESCRIPTION
There is no known conceptual reason we can't use XLA, but in practice
we have some build issues that will need to be fixed.

PiperOrigin-RevId: 215484942