### PR TITLE
Pass custom_objects as args in TocoConverter.from_keras_model_file

### DIFF
--- a/tensorflow/contrib/lite/python/lite.py
+++ b/tensorflow/contrib/lite/python/lite.py
@@ -346,7 +346,8 @@ class TFLiteConverter(object):
                             model_file,
                             input_arrays=None,
                             input_shapes=None,
-                            output_arrays=None):
+                            output_arrays=None,
+                            custom_objects=None):
     """Creates a TFLiteConverter class from a tf.keras model file.
 
     Args:
@@ -359,13 +360,15 @@ class TFLiteConverter(object):
           None}). (default None)
       output_arrays: List of output tensors to freeze graph with. Uses output
         arrays from SignatureDef when none are provided. (default None)
+      custom_objects: Optional dictionary mapping string names to custom classes
+      or functions (e.g. custom loss functions).
 
     Returns:
       TFLiteConverter class.
     """
     _keras.backend.clear_session()
     _keras.backend.set_learning_phase(False)
-    keras_model = _keras.models.load_model(model_file)
+    keras_model = _keras.models.load_model(model_file, custom_objects=custom_objects)
     sess = _keras.backend.get_session()
 
     # Get input and output tensors.


### PR DESCRIPTION
Pass `custom_objects` as an argument to `TocoConverter.from_keras_model_file()` to allow for things like custom Keras layers.