### PR TITLE
Fixed false error triggering in ps distribution strategy for local run

### DIFF
--- a/tensorflow/contrib/distribute/python/parameter_server_strategy.py
+++ b/tensorflow/contrib/distribute/python/parameter_server_strategy.py
@@ -296,7 +296,7 @@ class ParameterServerStrategy(distribute_lib.DistributionStrategy):
       return
     for d in cross_tower_ops_lib.get_devices_from(destinations):
       d_spec = tf_device.DeviceSpec.from_string(d)
-      if d_spec.job == self._task_type and d_spec.task != self._task_id:
+      if d_spec.job == self._task_type and d_spec.task != (self._task_id or 0):
         raise ValueError(
             "Cannot reduce to another worker: %r, current worker is %r" %
             (d, self._worker_device))


### PR DESCRIPTION
# Problem description

The `ParameterServerStrategy` throws an error from `_verify_destinations_not_different_worker` when applied locally, where only one worker is available. The cause seems to be the line 

```python
if d_spec.job == self._task_type and d_spec.task != self._task_id:
```

where the `d_spec` obtained from `"'/device:CPU:0"` gives a 0 to `d_spec.task`, while the `self._task_id` is still `None` as it is not set anywhere after its definition in `_initialize_local`.

# Actions taken

I'm not sure if `self._task_id` being `None` has any semantics in other contexts, so I have added a default value in the check to minimize the impact.

Please kindly review 