### PR TITLE
Static cast size_t to int in arguments 1,2 to forward_input_or_allocate_output()

### DIFF
--- a/tensorflow/core/kernels/mkl_relu_op.cc
+++ b/tensorflow/core/kernels/mkl_relu_op.cc
@@ -1023,7 +1023,8 @@ class MklReluGradOpBase : public OpKernel {
       }
 
       OP_REQUIRES_OK(context, context->forward_input_or_allocate_output(
-                                  {diff_dst_index}, diff_src_index,
+                                  {static_cast<const int>(diff_dst_index)},
+                                  static_cast<const int>(diff_src_index),
                                   tf_shape_diff_src, &diff_src_tensor));
       AllocateOutputSetMklShape(context, diff_src_index, dnn_shape_diff_src);
 


### PR DESCRIPTION
Static cast size_t to int in arguments 1,2 to forward_input_or_allocate_output()

This fix resolves the following compiler error:

tensorflow/core/kernels/mkl_relu_op.cc(1028): error C2398: Element '1':
conversion from 'const std::size_t' to 'int' requires a narrowing conversion