### PR TITLE
User defined optimization list

### DIFF
--- a/tensorflow/core/grappler/optimizers/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.cc
@@ -272,7 +272,7 @@ Status MetaOptimizer::OptimizeGraph(Cluster* cluster, const GrapplerItem& item,
   }
 
   std::vector<std::unique_ptr<GraphOptimizer>> optimizers;
-  if (cfg_.optimizers().empty()) {
+  if (cfg_.optimizers().empty() && cfg_.custom_optimizers().empty()) {
     TF_RETURN_IF_ERROR(InitializeOptimizers(&optimizers));
   } else {
     TF_RETURN_IF_ERROR(InitializeOptimizersByName(&optimizers));


### PR DESCRIPTION
Currently if user adds an optimizer to rewrite_config.optimizer list, default optimizers are disabled and user defined optimizers run. However if user modifies custom_optimizers list, optimizers in the list is appended to the default optimizers list. This PR makes the behavior for optimizers and custom_optimizers list identical in this respect.