### PR TITLE
Fixed the paper reference for AttentionCellWrapper.

### DIFF
--- a/tensorflow/contrib/rnn/python/ops/rnn_cell.py
+++ b/tensorflow/contrib/rnn/python/ops/rnn_cell.py
@@ -1110,7 +1110,7 @@ _Linear = core_rnn_cell._Linear  # pylint: disable=invalid-name
 class AttentionCellWrapper(rnn_cell_impl.RNNCell):
   """Basic attention cell wrapper.
 
-  Implementation based on https://arxiv.org/abs/1409.0473.
+  Implementation based on https://arxiv.org/abs/1601.06733.
   """
 
   def __init__(self,


### PR DESCRIPTION
Fixed the paper reference for AttentionCellWrapper to a more appropriate one. Because the original reference is wrong, there are various options  (e.g. attn_length, attn_size, attn_vec_size, etc) are not clearly defined, which always brings some confusion. 
In fact, it should be AttentionWrapper corresponding to https://arxiv.org/abs/1409.0473 and AttentionCellWrapper corresponding to https://arxiv.org/abs/1601.06733.