### PR TITLE
[Performance Optimization] Improve the performance of tf.clip_by_norm when the input is IndexedSlices

### DIFF
--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -131,7 +131,7 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
   an optimizer.
 
   Args:
-    t: A `Tensor`.
+    t: A `Tensor` or `IndexedSlices`.
     clip_norm: A 0-D (scalar) `Tensor` > 0. A maximum clipping value.
     axes: A 1-D (vector) `Tensor` of type int32 containing the dimensions
       to use for computing the L2-norm. If `None` (the default), uses all
@@ -139,26 +139,29 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     name: A name for the operation (optional).
 
   Returns:
-    A clipped `Tensor`.
+    A clipped `Tensor` or `IndexedSlices`.
   """
   with ops.name_scope(name, "clip_by_norm", [t, clip_norm]) as name:
-    t = ops.convert_to_tensor(t, name="t")
+    values = ops.convert_to_tensor(
+        t.values if isinstance(t, ops.IndexedSlices) else t, name="t")
 
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
-    l2sum = math_ops.reduce_sum(t * t, axes, keepdims=True)
+    l2sum = math_ops.reduce_sum(values * values, axes, keepdims=True)
     pred = l2sum > 0
     # Two-tap tf.where trick to bypass NaN gradients
     l2sum_safe = array_ops.where(pred, l2sum, array_ops.ones_like(l2sum))
     l2norm = array_ops.where(pred, math_ops.sqrt(l2sum_safe), l2sum)
-    intermediate = t * clip_norm
+    intermediate = values * clip_norm
     # Assert that the shape is compatible with the initial shape,
     # to prevent unintentional broadcasting.
-    _ = t.shape.merge_with(intermediate.shape)
-    tclip = array_ops.identity(
+    _ = values.shape.merge_with(intermediate.shape)
+    values_clip = array_ops.identity(
         intermediate / math_ops.maximum(l2norm, clip_norm), name=name)
 
-  return tclip
+    if isinstance(t, ops.IndexedSlices):
+      return ops.IndexedSlices(values_clip, t.indices, t.dense_shape)
 
+    return values_clip     
 
 @tf_export("linalg.global_norm", "global_norm")
 @deprecation.deprecated_endpoints("global_norm")

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -161,7 +161,7 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     if isinstance(t, ops.IndexedSlices):
       return ops.IndexedSlices(values_clip, t.indices, t.dense_shape)
 
-    return values_clip     
+    return values_clip
 
 @tf_export("linalg.global_norm", "global_norm")
 @deprecation.deprecated_endpoints("global_norm")

--- a/tensorflow/python/ops/clip_ops_test.py
+++ b/tensorflow/python/ops/clip_ops_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import ops
 from tensorflow.python.ops import clip_ops
 from tensorflow.python.ops import numerics
 from tensorflow.python.platform import test
@@ -29,7 +30,7 @@ class ClipOpsTest(test.TestCase):
   def __init__(self, method_name="runTest"):
     super(ClipOpsTest, self).__init__(method_name)
 
-  def _testClipByNorm(self, inputs, max_norm, expected):
+  def _testClipTensorByNorm(self, inputs, max_norm, expected):
     with self.cached_session() as sess:
       input_op = constant_op.constant(inputs)
       clipped = clip_ops.clip_by_norm(input_op, max_norm)
@@ -37,13 +38,75 @@ class ClipOpsTest(test.TestCase):
       result, _ = sess.run([clipped, check_op])
     self.assertAllClose(result, expected)
 
-  def testClipByNorm(self):
+  def _testClipIndexedSlicesByNorm(self,
+                                   values,
+                                   indices,
+                                   shape,
+                                   max_norm,
+                                   axes):
+     with self.cached_session() as sess:
+       values = constant_op.constant(values)
+       indices = constant_op.constant(indices)
+       shape = constant_op.constant(shape)
+       # IndexedSlices mode
+       indixed_slices = ops.IndexedSlices(values, indices, shape)
+       clipped = clip_ops.clip_by_norm(indixed_slices, max_norm, axes)
+       # clipped should be IndexedSlices
+       self.assertIsInstance(clipped, ops.IndexedSlices)
+       clipped = ops.convert_to_tensor(clipped)
+       
+       # Tensor mode
+       dense_tensor = ops.convert_to_tensor(indixed_slices)
+       dense_clipped = clip_ops.clip_by_norm(dense_tensor, max_norm, axes)
+       result, expected = sess.run([clipped, dense_clipped])
+     self.assertAllClose(result, expected)
+      
+  def testClipTensorByNorm(self):
     # Simple example
-    self._testClipByNorm([[-3.0, 0.0, 0.0], [4.0, 0.0, 0.0]], 4.0,
-                         [[-2.4, 0.0, 0.0], [3.2, 0.0, 0.0]])
+    self._testClipTensorByNorm(
+        [[-3.0, 0.0, 0.0], [4.0, 0.0, 0.0]], 4.0,
+        [[-2.4, 0.0, 0.0], [3.2, 0.0, 0.0]])
     # Zero norm
-    self._testClipByNorm([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], 4.0,
-                         [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    self._testClipTensorByNorm(
+        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], 4.0,
+        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+
+  def testClipIndexedSlicesByNorm(self):
+    values = [[[-3.0, 0.0, 0.0], [4.0, 0.0, 0.0]],
+              [[0.0, 2.0, 0.0], [0.0, 0.0, -1.0]]]
+    indices = [2, 6]
+    shape = [10, 2, 3]
+    # Axes == None
+    self._testClipIndexedSlicesByNorm(
+        values, indices, shape, 4.0, None)
+
+    # Axes == 0
+    self._testClipIndexedSlicesByNorm(
+        values, indices, shape, 4.0, 0)
+
+    # Axes == 1
+    self._testClipIndexedSlicesByNorm(
+        values, indices, shape, 4.0, 1)
+
+    # Axes == 2
+    self._testClipIndexedSlicesByNorm(
+        values, indices, shape, 4.0, 1)
+
+    # Axes == [0, 1]
+    self._testClipIndexedSlicesByNorm(
+        values, indices, shape, 4.0, [0, 1])
+
+    # Axes == [0, 1]
+    self._testClipIndexedSlicesByNorm(
+        values, indices, shape, 4.0, [0, 2])
+
+    # Axes == [0, 1]
+    self._testClipIndexedSlicesByNorm(
+        values, indices, shape, 4.0, [1, 2])
+
+    # Axes == [0, 1]
+    self._testClipIndexedSlicesByNorm(
+        values, indices, shape, 4.0, [0, 1, 2])
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/ops/clip_ops_test.py
+++ b/tensorflow/python/ops/clip_ops_test.py
@@ -44,23 +44,23 @@ class ClipOpsTest(test.TestCase):
                                    shape,
                                    max_norm,
                                    axes):
-     with self.cached_session() as sess:
-       values = constant_op.constant(values)
-       indices = constant_op.constant(indices)
-       shape = constant_op.constant(shape)
-       # IndexedSlices mode
-       indixed_slices = ops.IndexedSlices(values, indices, shape)
-       clipped = clip_ops.clip_by_norm(indixed_slices, max_norm, axes)
-       # clipped should be IndexedSlices
-       self.assertIsInstance(clipped, ops.IndexedSlices)
-       clipped = ops.convert_to_tensor(clipped)
-       
-       # Tensor mode
-       dense_tensor = ops.convert_to_tensor(indixed_slices)
-       dense_clipped = clip_ops.clip_by_norm(dense_tensor, max_norm, axes)
-       result, expected = sess.run([clipped, dense_clipped])
-     self.assertAllClose(result, expected)
-      
+    with self.cached_session() as sess:
+      values = constant_op.constant(values)
+      indices = constant_op.constant(indices)
+      shape = constant_op.constant(shape)
+      # IndexedSlices mode
+      indixed_slices = ops.IndexedSlices(values, indices, shape)
+      clipped = clip_ops.clip_by_norm(indixed_slices, max_norm, axes)
+      # clipped should be IndexedSlices
+      self.assertIsInstance(clipped, ops.IndexedSlices)
+      clipped = ops.convert_to_tensor(clipped)
+
+      # Tensor mode
+      dense_tensor = ops.convert_to_tensor(indixed_slices)
+      dense_clipped = clip_ops.clip_by_norm(dense_tensor, max_norm, axes)
+      result, expected = sess.run([clipped, dense_clipped])
+    self.assertAllClose(result, expected)
+
   def testClipTensorByNorm(self):
     # Simple example
     self._testClipTensorByNorm(


### PR DESCRIPTION
Currently, the `tf.clip_by_norm` will convert the input to dense tensor and do the clipping. However, the gradients may be `IndexedSlices` type when encounters with `tf.nn.embedding_lookup` in forward pass. It may both consume large memory and make computation performance worse.

In this pull request, the clipping function will deal with `IndexedSlices` directly instead of converting to dense tensor.