### PR TITLE
Add alternate clock_gettime() implementation for macOS < 10.12

### DIFF
--- a/tensorflow/core/platform/posix/env_time.cc
+++ b/tensorflow/core/platform/posix/env_time.cc
@@ -18,6 +18,23 @@ limitations under the License.
 
 #include "tensorflow/core/platform/env_time.h"
 
+// Slightly pruned version of https://gist.github.com/alfwatt/3588c5aa1f7a1ef7a3bb
+// Copyright (c) 2015-2018 Alf Watt - Open Source - https://opensource.org/licenses/MIT
+#if defined __APPLE__
+#include <mach/clock.h>
+#include <mach/mach.h>
+int alt_clock_gettime(int clock_id, timespec *ts) {
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), clock_id, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  ts->tv_sec = mts.tv_sec;
+  ts->tv_nsec = mts.tv_nsec;
+  return 0;
+}
+#endif
+
 namespace tensorflow {
 
 namespace {
@@ -28,7 +45,11 @@ class PosixEnvTime : public EnvTime {
 
   uint64 NowNanos() override {
     struct timespec ts;
+#if defined __APPLE__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // less than macOS 10.12
+    alt_clock_gettime(CALENDAR_CLOCK, &ts);
+#else
     clock_gettime(CLOCK_REALTIME, &ts);
+#endif
     return (static_cast<uint64>(ts.tv_sec) * kSecondsToNanos +
             static_cast<uint64>(ts.tv_nsec));
   }


### PR DESCRIPTION
clock_gettime is not available in macOS SDK < 10.12

xref: https://github.com/tensorflow/tensorflow/issues/22636#issuecomment-426488627