### PR TITLE
Add (init) symbol names prefixed with an underscore

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1568,7 +1568,7 @@ def _append_init_to_versionscript_impl(ctx):
             template = ctx.file.template_file,
             output = ctx.outputs.versionscript,
             substitutions = {
-                "global:": "global:\n     init_%s;\n     PyInit_*;" % (mod_name),
+                "global:": "global:\n     init_%s;\n     _init_%s;\n     PyInit_*;\n     _PyInit_*;"%(mod_name, mod_name),
             },
             is_executable = False,
         )
@@ -1577,7 +1577,7 @@ def _append_init_to_versionscript_impl(ctx):
             template = ctx.file.template_file,
             output = ctx.outputs.versionscript,
             substitutions = {
-                "*tensorflow*": "*tensorflow*\ninit_%s\nPyInit_*\n" % (mod_name),
+                "*tensorflow*": "*tensorflow*\ninit_%s\n_init_%s\nPyInit_*\n_PyInit_*\n"%(mod_name, mod_name),
             },
             is_executable = False,
         )


### PR DESCRIPTION
The command: `python -c 'from tensorflow.contrib import tensorrt as trt'` fails
with:
```
File "/xxx/lib/python2.7/site-packages/tensorflow/contrib/tensorrt/wrap_conversion.py", line 24, in swig_import_helper
    _mod = imp.load_module('_wrap_conversion', fp, pathname, description)
ImportError: dynamic module does not define init function (init_wrap_conversion)

➜  1534993632 nm /xxx/lib/python2.7/site-packages/tensorflow/contrib/tensorrt/_wrap_conversion.so  | grep wrap_conversion
0000000000003670 t _init_wrap_conversion <---------- symbol defined, but local, not exposed
                 U init_wrap_conversion
                 I init_wrap_conversion (indirect for init_wrap_conversion)
```
Happens because the linker version script has: `init_wrap_conversion` instead of `_init_wrap_conversion`

xref: https://github.com/tensorflow/tensorflow/issues/21818
xref: https://stackoverflow.com/a/37534357