### PR TITLE
1.12-rc0 cherry-pick request: Mark tensorflow/contrib/tpu:datasets_test flaky

### DIFF
--- a/tensorflow/contrib/tpu/BUILD
+++ b/tensorflow/contrib/tpu/BUILD
@@ -299,6 +299,7 @@ tf_py_test(
         "//tensorflow/python:client_testlib",
         ":datasets",
     ],
+    flaky = 1,  # TODO(b/117363808): fails 1/1000 OSS runs
     grpc_enabled = True,
 )
 


### PR DESCRIPTION
It fails 1/1000 runs in OSS builds.

PiperOrigin-RevId: 216050192