### PR TITLE
[aarch64] make aws sdk work on aarch64

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -164,6 +164,12 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_aarch64",
+    values = {"cpu": "aarch64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_x86_64",
     values = {"cpu": "k8"},
     visibility = ["//visibility:public"],

--- a/third_party/aws/BUILD.bazel
+++ b/third_party/aws/BUILD.bazel
@@ -12,6 +12,9 @@ load("@org_tensorflow//third_party:common.bzl", "template_rule")
 cc_library(
     name = "aws",
     srcs = select({
+        "@org_tensorflow//tensorflow:linux_aarch64": glob([
+            "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
+        ]),
         "@org_tensorflow//tensorflow:linux_x86_64": glob([
             "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
         ]),


### PR DESCRIPTION
`bazel build //tensorflow/tools/pip_package:build_pip_package`
requires AWS SDK by default. but platform part was not built
on aarch64