### PR TITLE
Fix typo in estimator with distribution strategy using hooks

### DIFF
--- a/tensorflow/python/estimator/estimator.py
+++ b/tensorflow/python/estimator/estimator.py
@@ -1327,7 +1327,7 @@ class Estimator(object):
         # TODO(yuefengz): add a test for unwrapping per_device_hooks.
         def get_hooks_from_the_first_device(per_device_hooks):
           return [
-              self._distribution.unwrap(per_device_hook)[0]
+              self._train_distribution.unwrap(per_device_hook)[0]
               for per_device_hook in per_device_hooks
           ]
 


### PR DESCRIPTION
Fix typo while extracting estimator training hooks using distribution strategy.
CC @yuefengz 