### PR TITLE
remove .bazelrc from git tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .ipynb_checkpoints
 node_modules
 /.tf_configure.bazelrc
+/.bazelrc
 /bazel-*
 /bazel_pip
 /tools/python_bin_path.sh

--- a/bazel_defaults
+++ b/bazel_defaults
@@ -74,7 +74,7 @@ build --define=grpc_no_ares=true
 
 #build --spawn_strategy=standalone
 #build --genrule_strategy=standalone
-#build -c opt
+build -c opt
 # Default paths for TF_SYSTEM_LIBS
 #build --define=PREFIX=/usr
 #build --define=LIBDIR=$(PREFIX)/lib

--- a/bazel_defaults
+++ b/bazel_defaults
@@ -66,10 +66,11 @@ build:gdr --define=with_gdr_support=true
 build:ngraph --define=with_ngraph_support=true
 build:verbs --define=with_verbs_support=true
 
-# Don't define defaults behind users back!
-#build --define=use_fast_cpp_protos=true
-#build --define=allow_oversize_protos=true
-#build --define=grpc_no_ares=true
+
+build --define=use_fast_cpp_protos=true
+build --define=allow_oversize_protos=true
+build --define=grpc_no_ares=true
+
 
 #build --spawn_strategy=standalone
 #build --genrule_strategy=standalone
@@ -84,6 +85,3 @@ build:verbs --define=with_verbs_support=true
 
 # Modular TF build options
 build:dynamic_kernels --define=dynamic_loaded_kernels=true
-
-
-# Do not commit the tf_configure.bazelrc line

--- a/bazel_defaults
+++ b/bazel_defaults
@@ -66,23 +66,24 @@ build:gdr --define=with_gdr_support=true
 build:ngraph --define=with_ngraph_support=true
 build:verbs --define=with_verbs_support=true
 
-build --define=use_fast_cpp_protos=true
-build --define=allow_oversize_protos=true
-build --define=grpc_no_ares=true
+# Don't define defaults behind users back!
+#build --define=use_fast_cpp_protos=true
+#build --define=allow_oversize_protos=true
+#build --define=grpc_no_ares=true
 
-build --spawn_strategy=standalone
-build --genrule_strategy=standalone
-build -c opt
+#build --spawn_strategy=standalone
+#build --genrule_strategy=standalone
+#build -c opt
+# Default paths for TF_SYSTEM_LIBS
+#build --define=PREFIX=/usr
+#build --define=LIBDIR=$(PREFIX)/lib
+#build --define=INCLUDEDIR=$(PREFIX)/include
 
 # Other build flags.
-build --define=grpc_no_ares=true
+#build --define=grpc_no_ares=true
 
 # Modular TF build options
 build:dynamic_kernels --define=dynamic_loaded_kernels=true
 
-# Default paths for TF_SYSTEM_LIBS
-build --define=PREFIX=/usr
-build --define=LIBDIR=$(PREFIX)/lib
-build --define=INCLUDEDIR=$(PREFIX)/include
 
 # Do not commit the tf_configure.bazelrc line

--- a/configure.py
+++ b/configure.py
@@ -249,10 +249,10 @@ def reset_tf_configure_bazelrc():
   """Reset file that contains customized config settings."""
   open(_TF_BAZELRC, 'w').close()
   bazelrc_path = os.path.join(_TF_WORKSPACE_ROOT, '.bazelrc')
-
+  bazel_defaults_path = os.path.join(_TF_WORKSPACE_ROOT, 'bazel_defaults')
   data = []
-  if os.path.exists(bazelrc_path):
-    with open(bazelrc_path, 'r') as f:
+  if os.path.exists(bazel_defaults_path):
+    with open(bazel_defaults_path, 'r') as f:
       data = f.read().splitlines()
   with open(bazelrc_path, 'w') as f:
     for l in data:


### PR DESCRIPTION
This PR removes .bazelrc from the git tree. Since it is modified during the configure, in essence it is a generated file and should not have been placed into the tree in the first place. Instead this PR adds a new file bazel_defaults and uses it to generate .bazelrc file. Also certain flags are such as -c opt and some environment variables that are not necessarily valid under all circumstances are disabled with this PR. Since these are mostly platform specific or override user command-line flags, these should be added with configuration prefixes rather than globally.
With this PR .bazelrc is created from template file and removed from git tree.