### PR TITLE
1.12-rc1 cherry-pick request: Fix use-of-uninitialized-value bug for bfloat16 in MatrixBandPart.

### DIFF
--- a/tensorflow/core/framework/bfloat16_test.cc
+++ b/tensorflow/core/framework/bfloat16_test.cc
@@ -23,6 +23,20 @@ limitations under the License.
 namespace tensorflow {
 namespace {
 
+TEST(Bfloat16Test, DefaultValueIsZero) {
+  EXPECT_EQ(0.0f, static_cast<float>(bfloat16()));
+}
+
+TEST(Bfloat16Test, RepresentableFloatsRoundTripViaBfloat16) {
+  const std::vector<float> values = {
+      -std::numeric_limits<float>::infinity(), -1.0, -0.5, -0.0, 0.0, 0.5, 1.0,
+      std::numeric_limits<float>::infinity(),
+  };
+  for (float v : values) {
+    EXPECT_EQ(v, static_cast<float>(static_cast<bfloat16>(v)));
+  }
+}
+
 TEST(Bfloat16Test, Simple) {
   bfloat16 a(12);
   // Floating point representation of 12: 0x41400000

--- a/tensorflow/core/lib/bfloat16/bfloat16.h
+++ b/tensorflow/core/lib/bfloat16/bfloat16.h
@@ -43,7 +43,9 @@ typedef std::complex<double> complex128;
 
 // see framework/bfloat16.h for description.
 struct bfloat16 {
-  B16_DEVICE_FUNC bfloat16() {}
+  // The default constructor must yield a zero value, not an uninitialized
+  // value; some TF kernels use T() as a zero value.
+  B16_DEVICE_FUNC bfloat16() : value(ZERO_VALUE) {}
 
   B16_DEVICE_FUNC static bfloat16 truncate_to_bfloat16(const float v) {
     bfloat16 output;
@@ -376,6 +378,9 @@ struct bfloat16 {
   static const uint16_t NAN_VALUE = 0x7FC0;
 
  private:
+  // A value that represents "zero".
+  static const uint16_t ZERO_VALUE = 0;
+
   B16_DEVICE_FUNC static bool float_isnan(const float& x) {
 #ifdef __CUDA_ARCH__
     return ::isnan(x);

--- a/tensorflow/python/kernel_tests/matrix_band_part_op_test.py
+++ b/tensorflow/python/kernel_tests/matrix_band_part_op_test.py
@@ -137,12 +137,13 @@ class MatrixBandPartBenchmark(test_lib.Benchmark):
 
 
 if __name__ == "__main__":
-  dtypes = (np.bool, np.int32, np.int64, np.float32, np.float64, np.complex64,
-            np.complex128)
+  dtypes = (np.bool, np.int32, np.int64, np.float16,
+            dtypes_lib.bfloat16.as_numpy_dtype, np.float32, np.float64,
+            np.complex64, np.complex128)
   for dtype in dtypes:
     for batch_shape in ((), (2,), (1, 3, 2)):
-      for rows in 1, 2, 7:
-        for cols in 1, 2, 7:
+      for rows in 1, 2, 7, 23:
+        for cols in 1, 2, 7, 23:
           shape = (rows, cols)
           name = "%s_%s" % (dtype.__name__,
                             "_".join(map(str, batch_shape + shape)))


### PR DESCRIPTION
MatrixBandPart ends up calling bfloat16() to create a zero value, but the implementation of bfloat16::bfloat16() returned an uninitialized value, not zero.

PiperOrigin-RevId: 216761660