### PR TITLE
_create_c_op: copy over device placement

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -1606,7 +1606,7 @@ def _create_c_op(graph, node_def, inputs, control_inputs):
                                   compat.as_str(node_def.op),
                                   compat.as_str(node_def.name))
   if node_def.device:
-    c_api.TF_SetDevice(op_desc, node_def.device)
+    c_api.TF_SetDevice(op_desc, compat.as_str(node_def.device))
   # Add inputs
   for op_input in inputs:
     if isinstance(op_input, (list, tuple)):

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -1605,6 +1605,8 @@ def _create_c_op(graph, node_def, inputs, control_inputs):
   op_desc = c_api.TF_NewOperation(graph._c_graph,
                                   compat.as_str(node_def.op),
                                   compat.as_str(node_def.name))
+  if node_def.device:
+    c_api.TF_SetDevice(op_desc, node_def.device)
   # Add inputs
   for op_input in inputs:
     if isinstance(op_input, (list, tuple)):

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -256,8 +256,8 @@ class OperationTest(test_util.TensorFlowTestCase):
 
   def testDevicePresent(self):
     op = ops.Operation(
-      ops._NodeDef("None", "myop", device='/job:goo/device:GPU:0'), ops.Graph(),
-      [], [])
+        ops._NodeDef("None", "myop", device='/job:goo/device:GPU:0'),
+        ops.Graph(), [], [])
     self.assertEqual('/job:goo/device:GPU:0', op.device)
 
   def testDeviceObject(self):

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -254,7 +254,7 @@ class OperationTest(test_util.TensorFlowTestCase):
     input:'myop1' input:'myop2:1' input:'myop2:1'
     """, op3.node_def)
 
-  def testDevicePresent(self):
+  def testDeviceFromNodeDef(self):
     op = ops.Operation(
         ops._NodeDef("None", "myop", device='/job:goo/device:GPU:0'),
         ops.Graph(), [], [])

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -254,6 +254,10 @@ class OperationTest(test_util.TensorFlowTestCase):
     input:'myop1' input:'myop2:1' input:'myop2:1'
     """, op3.node_def)
 
+  def testDevicePresent(self):
+    op = ops.Operation(ops._NodeDef("None", "myop", device='/job:goo/device:GPU:0'), ops.Graph(), [], [])
+    self.assertEqual('/job:goo/device:GPU:0', op.device)
+
   def testDeviceObject(self):
     op = ops.Operation(ops._NodeDef("None", "myop"), ops.Graph(), [], [])
     op._set_device("/job:goo/device:GPU:0")

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -255,7 +255,9 @@ class OperationTest(test_util.TensorFlowTestCase):
     """, op3.node_def)
 
   def testDevicePresent(self):
-    op = ops.Operation(ops._NodeDef("None", "myop", device='/job:goo/device:GPU:0'), ops.Graph(), [], [])
+    op = ops.Operation(
+      ops._NodeDef("None", "myop", device='/job:goo/device:GPU:0'), ops.Graph(),
+      [], [])
     self.assertEqual('/job:goo/device:GPU:0', op.device)
 
   def testDeviceObject(self):


### PR DESCRIPTION
Fixes the following problem 
```
node_def = tf._NodeDef(..., device='/device:GPU:0')
op = tf.Operation(node_def, ...)
op.device  # no device
```