### PR TITLE
Fix MacOSX build failure

### DIFF
--- a/tensorflow/python/eager/pywrap_tfe.h
+++ b/tensorflow/python/eager/pywrap_tfe.h
@@ -16,6 +16,11 @@ limitations under the License.
 #ifndef TENSORFLOW_PYTHON_EAGER_PYWRAP_TFE_H_
 #define TENSORFLOW_PYTHON_EAGER_PYWRAP_TFE_H_
 
+// Place `<locale>` before <Python.h> to avoid build failure in macOS.
+#include <locale>
+
+// The empty line above is on purpose as otherwise clang-format will
+// automatically move <Python.h> before <locale>.
 #include <Python.h>
 
 #include "tensorflow/c/eager/c_api.h"


### PR DESCRIPTION
While building tensorflow on MaxOSX
(`Apple LLVM version 10.0.0 (clang-1000.11.45.2)`, `Python 2.7.10`)
the following build failure surfaced:
```
In file included from tensorflow/python/eager/pywrap_tfe_src.cc:18:
In file included from ./tensorflow/python/eager/pywrap_tfe.h:22:
In file included from ./tensorflow/core/lib/core/status.h:23:
In file included from bazel-out/host/genfiles/tensorflow/core/lib/core/error_codes.pb.h:9:
In file included from external/protobuf_archive/src/google/protobuf/stubs/common.h:39:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ios:216:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__locale:518:15: error: C++ requires a type specifier for all declarations
    char_type toupper(char_type __c) const
              ^
bazel-out/host/genfiles/external/local_config_python/python_include/pyport.h:731:29: note: expanded from macro 'toupper'
```

This fix fixes the build failure.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>