### PR TITLE
Revert "Move bazel.rc to workspace root to support bazel-0.18.0"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .ipynb_checkpoints
 node_modules
+/.bazelrc
 /.tf_configure.bazelrc
 /bazel-*
 /bazel_pip

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -91,5 +91,3 @@ build:dynamic_kernels --define=dynamic_loaded_kernels=true
 build --define=PREFIX=/usr
 build --define=LIBDIR=$(PREFIX)/lib
 build --define=INCLUDEDIR=$(PREFIX)/include
-
-# Do not commit the tf_configure.bazelrc line


### PR DESCRIPTION
This reverts commit a74a3217f7ff2dbee2fb618aa658cf666861545c.

Bazel-0.18.0 is changing where it searches for .bazelrc files.
Originally it was removing /tools/bazel.rc and only using /.bazelrc.
This causes issues for gitignoring /.bazelrc and 0.18.0 has temporarily
added tools/bazel.rc back to the list until 0.19. The long term solution
is to use try-import but that statement is new in 0.18 and we are not
going to bump TF's minimum right away. When 0.19 is out things will need
to be changed back and the minimum bumped to 0.18.

Fixes: https://github.com/tensorflow/tensorflow/issues/22762
Fixes: https://github.com/tensorflow/tensorflow/pull/22906
Signed-off-by: Jason Zaman <jason@perfinion.com>