### PR TITLE
[XLA] Sink constants into the conditional computation in while loops

### DIFF
--- a/tensorflow/compiler/xla/service/while_loop_constant_sinking.cc
+++ b/tensorflow/compiler/xla/service/while_loop_constant_sinking.cc
@@ -68,12 +68,12 @@ StatusOr<bool> WhileLoopConstantSinking::TrySinkingConstantsIntoWhileLoop(
     int64 index = invariant_body_gte->tuple_index();
     const HloInstruction& invariant_value = *init_value.operand(index);
 
-    // Original value should be a constant
+    // Original value should be a constant.
     if (invariant_value.opcode() != HloOpcode::kConstant) {
       continue;
     }
 
-    // Sink into the while_body
+    // Sink into the while_body.
     // Should have at least one user that's not while_body_root.
     if (invariant_body_gte->user_count() > 1) {
       HloInstruction* constant_instr =

--- a/tensorflow/compiler/xla/service/while_loop_constant_sinking.cc
+++ b/tensorflow/compiler/xla/service/while_loop_constant_sinking.cc
@@ -85,9 +85,7 @@ StatusOr<bool> WhileLoopConstantSinking::TrySinkingConstantsIntoWhileLoop(
     }
 
     // Check if there is a corresponding GTE in while_conditional.
-    absl::flat_hash_map<int64,
-                        absl::InlinedVector<HloInstruction*, 1>>::iterator it =
-        invariant_conditional_gte_index_to_inst.find(index);
+    auto it = invariant_conditional_gte_index_to_inst.find(index);
     if (it == invariant_conditional_gte_index_to_inst.end()) {
       continue;
     }

--- a/tensorflow/compiler/xla/service/while_loop_constant_sinking.cc
+++ b/tensorflow/compiler/xla/service/while_loop_constant_sinking.cc
@@ -58,9 +58,10 @@ StatusOr<bool> WhileLoopConstantSinking::TrySinkingConstantsIntoWhileLoop(
 
   bool changed = false;
 
-  auto invariant_conditional_gte_index_to_inst =
-      WhileUtil::GetGTEsMapForWhileConditional(*while_cond);
-  auto invariant_body_gtes =
+  absl::flat_hash_map<int64, absl::InlinedVector<HloInstruction*, 1>>
+      invariant_conditional_gte_index_to_inst =
+          WhileUtil::GetGTEsMapForWhileConditional(*while_cond);
+  std::vector<HloInstruction*> invariant_body_gtes =
       WhileUtil::GetInvariantGTEsForWhileBody(*while_body);
 
   for (HloInstruction* invariant_body_gte : invariant_body_gtes) {
@@ -68,12 +69,14 @@ StatusOr<bool> WhileLoopConstantSinking::TrySinkingConstantsIntoWhileLoop(
     const HloInstruction& invariant_value = *init_value.operand(index);
 
     // Original value should be a constant
-    if (invariant_value.opcode() != HloOpcode::kConstant) continue;
+    if (invariant_value.opcode() != HloOpcode::kConstant) {
+      continue;
+    }
 
     // Sink into the while_body
     // Should have at least one user that's not while_body_root.
     if (invariant_body_gte->user_count() > 1) {
-      auto* constant_instr =
+      HloInstruction* constant_instr =
           while_body->AddInstruction(invariant_value.Clone(/*suffix=*/".sunk"));
       TF_RETURN_IF_ERROR(ReplaceUsesWhileKeepingLoopInvariance(
           invariant_body_gte, constant_instr, while_body->root_instruction(),
@@ -81,20 +84,23 @@ StatusOr<bool> WhileLoopConstantSinking::TrySinkingConstantsIntoWhileLoop(
       changed = true;
     }
 
-    // Check if there is a corresponding GTE in while_conditional
-    auto it = invariant_conditional_gte_index_to_inst.find(index);
+    // Check if there is a corresponding GTE in while_conditional.
+    absl::flat_hash_map<int64,
+                        absl::InlinedVector<HloInstruction*, 1>>::iterator it =
+        invariant_conditional_gte_index_to_inst.find(index);
     if (it == invariant_conditional_gte_index_to_inst.end()) {
       continue;
     }
 
-    auto* invariant_cond_gte = it->second;
-    // Should have at least one user
-    if (invariant_cond_gte->user_count() > 0) {
-      auto* constant_instr =
-          while_cond->AddInstruction(invariant_value.Clone(/*suffix=*/".sunk"));
-      TF_RETURN_IF_ERROR(
-          invariant_cond_gte->ReplaceAllUsesWith(constant_instr));
-      changed = true;
+    for (HloInstruction* invariant_cond_gte : it->second) {
+      // Should have at least one user.
+      if (invariant_cond_gte->user_count() > 0) {
+        HloInstruction* constant_instr = while_cond->AddInstruction(
+            invariant_value.Clone(/*suffix=*/".sunk"));
+        TF_RETURN_IF_ERROR(
+            invariant_cond_gte->ReplaceAllUsesWith(constant_instr));
+        changed = true;
+      }
     }
   }
 

--- a/tensorflow/compiler/xla/service/while_loop_constant_sinking.cc
+++ b/tensorflow/compiler/xla/service/while_loop_constant_sinking.cc
@@ -59,7 +59,7 @@ StatusOr<bool> WhileLoopConstantSinking::TrySinkingConstantsIntoWhileLoop(
   bool changed = false;
 
   absl::flat_hash_map<int64, absl::InlinedVector<HloInstruction*, 1>>
-      invariant_conditional_gte_index_to_inst =
+      conditional_gte_index_to_insts =
           WhileUtil::GetGTEsMapForWhileConditional(*while_cond);
   std::vector<HloInstruction*> invariant_body_gtes =
       WhileUtil::GetInvariantGTEsForWhileBody(*while_body);
@@ -85,8 +85,8 @@ StatusOr<bool> WhileLoopConstantSinking::TrySinkingConstantsIntoWhileLoop(
     }
 
     // Check if there is a corresponding GTE in while_conditional.
-    auto it = invariant_conditional_gte_index_to_inst.find(index);
-    if (it == invariant_conditional_gte_index_to_inst.end()) {
+    auto it = conditional_gte_index_to_insts.find(index);
+    if (it == conditional_gte_index_to_insts.end()) {
       continue;
     }
 

--- a/tensorflow/compiler/xla/service/while_loop_constant_sinking.h
+++ b/tensorflow/compiler/xla/service/while_loop_constant_sinking.h
@@ -52,7 +52,7 @@ class WhileLoopConstantSinking : public HloModulePass {
   ~WhileLoopConstantSinking() override = default;
 
   absl::string_view name() const override {
-    return "while-loop-invariant-code-motion";
+    return "while-loop-constant-sinking";
   }
 
   StatusOr<bool> Run(HloModule* module) override;

--- a/tensorflow/compiler/xla/service/while_loop_constant_sinking.h
+++ b/tensorflow/compiler/xla/service/while_loop_constant_sinking.h
@@ -23,8 +23,8 @@ limitations under the License.
 namespace xla {
 
 // Sinks while loop invariant values that happen to be constants into the while
-// loop body.  This is probably not a win in isolation but may unlock further
-// optimizations like constant folding.
+// loop body and conditional. This is probably not a win in isolation but may
+// unlock further optimizations like constant folding.
 //
 //   state = (..., const, ...)
 //   while (pred(state)) {
@@ -46,9 +46,6 @@ namespace xla {
 // tuple trivially loop invariant.  WhileLoopSimplifier will later get rid of
 // `v`.
 //
-// We only sink into while loop bodies, but this can be extended to transform
-// conditions as well.
-//
 // TODO(b/79121449):  We should also sink broadcasts of constants.
 class WhileLoopConstantSinking : public HloModulePass {
  public:
@@ -61,7 +58,7 @@ class WhileLoopConstantSinking : public HloModulePass {
   StatusOr<bool> Run(HloModule* module) override;
 
  private:
-  StatusOr<bool> TrySinkingConstantsIntoWhileBody(HloInstruction* while_instr);
+  StatusOr<bool> TrySinkingConstantsIntoWhileLoop(HloInstruction* while_instr);
 };
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/service/while_loop_constant_sinking_test.cc
+++ b/tensorflow/compiler/xla/service/while_loop_constant_sinking_test.cc
@@ -242,5 +242,132 @@ ENTRY entry {
     }
   }
 }
+
+TEST_F(WhileLoopConstantSinkingTest, ConditionalSinkConstant) {
+  const char* const hlo_string = R"(
+HloModule ModuleWithWhile
+
+body {
+  p_body = (f32[],f32[]) parameter(0)
+  p_body.0 = f32[] get-tuple-element((f32[],f32[]) p_body), index=0
+  const = f32[] constant(1)
+  add = f32[] add(p_body.0, const)
+  p_body.1 = f32[] get-tuple-element((f32[],f32[]) p_body), index=1
+  ROOT root = (f32[],f32[]) tuple(add, p_body.1)
+}
+
+condition {
+  p_cond = (f32[],f32[]) parameter(0)
+  p_cond.0 = f32[] get-tuple-element((f32[],f32[]) p_cond), index=0
+  p_cond.1 = f32[] get-tuple-element((f32[],f32[]) p_cond), index=1
+  ROOT result = pred[] less-than(p_cond.0, p_cond.1)
+}
+
+ENTRY entry {
+  const_0 = f32[] constant(0)
+  const_1 = f32[] constant(10)
+  while_init = (f32[],f32[]) tuple(const_0, const_1)
+  ROOT while = (f32[],f32[]) while(while_init), condition=condition, body=body
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseHloString(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          WhileLoopConstantSinking{}.Run(module.get()));
+  ASSERT_TRUE(changed);
+
+  auto* while_condition = module->GetComputationWithName("condition");
+  EXPECT_THAT(while_condition->root_instruction(), op::Lt(_, op::Constant()));
+}
+
+TEST_F(WhileLoopConstantSinkingTest, ConditionalTupleShapedConstants) {
+  const char* const hlo_string = R"(
+HloModule ModuleWithWhile
+
+body {
+  p_b = (f32[],(f32[],f32[])) parameter(0)
+  p_b.0 = f32[] get-tuple-element((f32[],(f32[],f32[])) p_b), index=0
+  p_b.1 = (f32[],f32[]) get-tuple-element((f32[],(f32[],f32[])) p_b), index=1
+  p_b.1.0 = f32[] get-tuple-element((f32[],f32[]) p_b.1), index=0
+  add = f32[] add(p_b.0, p_b.1.0)
+  ROOT root = (f32[],(f32[],f32[])) tuple(add, p_b.1)
+}
+
+condition {
+  p_c = (f32[],(f32[],f32[])) parameter(0)
+  p_c.0 = f32[] get-tuple-element((f32[],f32[]) p_c), index=0
+  p_c.1 = (f32[],f32[]) get-tuple-element((f32[],f32[]) p_c), index=1
+  p_c.1.1 = f32[] get-tuple-element((f32[],f32[]) p_c.1), index=1
+  ROOT result = pred[] less-than(p_c.0, p_c.1.1)
+}
+
+ENTRY entry {
+  const_0 = f32[] constant(0)
+  const_1 = (f32[], f32[]) constant((f32[], f32[]) (1, 10))
+  while_init = (f32[],(f32[],f32[])) tuple(const_0, const_1)
+  ROOT while = (f32[],(f32[],f32[])) while(while_init), condition=condition, body=body
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseHloString(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          WhileLoopConstantSinking{}.Run(module.get()));
+  ASSERT_TRUE(changed);
+
+  auto* while_condition = module->GetComputationWithName("condition");
+  EXPECT_THAT(while_condition->root_instruction(),
+              op::Lt(_, op::GetTupleElement(op::Constant())));
+}
+
+TEST_F(WhileLoopConstantSinkingTest, ConditionalDontCreateDeadConstant) {
+  const char* const hlo_string = R"(
+HloModule ModuleWithWhile
+
+body {
+  p_body = (f32[],f32[],f32[]) parameter(0)
+  p_body.0 = f32[] get-tuple-element((f32[],f32[],f32[]) p_body), index=0
+  const = f32[] constant(1)
+  add = f32[] add(p_body.0, const)
+  p_body.1 = f32[] get-tuple-element((f32[],f32[],f32[]) p_body), index=1
+  p_body.2 = f32[] get-tuple-element((f32[],f32[],f32[]) p_body), index=2
+  ROOT root = (f32[],f32[],f32[]) tuple(add, p_body.1, p_body.2)
+}
+
+condition {
+  p_cond = (f32[],f32[],f32[]) parameter(0)
+  p_cond.0 = f32[] get-tuple-element((f32[],f32[],f32[]) p_cond), index=0
+  p_cond.1 = f32[] get-tuple-element((f32[],f32[],f32[]) p_cond), index=1
+  p_cond.2 = f32[] get-tuple-element((f32[],f32[],f32[]) p_cond), index=2
+  ROOT result = pred[] less-than(p_cond.0, p_cond.1)
+}
+
+ENTRY entry {
+  const_0 = f32[] constant(0)
+  const_1 = f32[] constant(10)
+  const_2 = f32[] constant(12)
+  while_init = (f32[],f32[],f32[]) tuple(const_0, const_1, const_2)
+  ROOT while = (f32[],f32[],f32[]) while(while_init), condition=condition, body=body
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseHloString(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          WhileLoopConstantSinking{}.Run(module.get()));
+  ASSERT_TRUE(changed);
+
+  auto* while_condition = module->GetComputationWithName("condition");
+  EXPECT_THAT(while_condition->root_instruction(), op::Lt(_, op::Constant()));
+  for (const HloInstruction* inst : while_condition->instructions()) {
+    if (inst->opcode() == HloOpcode::kConstant) {
+      EXPECT_GT(inst->user_count(), 0);
+    }
+  }
+}
 }  // namespace
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/while_util.cc
+++ b/tensorflow/compiler/xla/service/while_util.cc
@@ -268,4 +268,17 @@ static Shape MakeLoopStateShape(const WhileUtil::LoopStateTy& init_values) {
   return result;
 }
 
+/*static*/ std::map<int64, HloInstruction*>
+WhileUtil::GetGTEsMapForWhileConditional(
+    const HloComputation& while_conditional) {
+  std::map<int64, HloInstruction*> result;
+  for (auto* inst : while_conditional.instructions()) {
+    if (inst->opcode() == HloOpcode::kGetTupleElement &&
+        inst->operand(0) == while_conditional.parameter_instruction(0)) {
+      result[inst->tuple_index()] = inst;
+    }
+  }
+  return result;
+}
+
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/while_util.h
+++ b/tensorflow/compiler/xla/service/while_util.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_XLA_SERVICE_WHILE_UTIL_H_
 #define TENSORFLOW_COMPILER_XLA_SERVICE_WHILE_UTIL_H_
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/inlined_vector.h"
 #include "tensorflow/compiler/xla/service/call_inliner.h"
 #include "tensorflow/compiler/xla/service/hlo_instruction.h"
 
@@ -89,8 +91,8 @@ class WhileUtil {
   // `while_conditional` that access elements in the parameter tuple. Assumes
   // `while_conditional` is the conditional computation of the while loop in
   // question.
-  static std::map<int64, HloInstruction*> GetGTEsMapForWhileConditional(
-      const HloComputation& while_conditional);
+  static absl::flat_hash_map<int64, absl::InlinedVector<HloInstruction*, 1>>
+  GetGTEsMapForWhileConditional(const HloComputation& while_conditional);
 };
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/service/while_util.h
+++ b/tensorflow/compiler/xla/service/while_util.h
@@ -84,6 +84,13 @@ class WhileUtil {
   // Assumes `while_body` is the body computation of the while loop in question.
   static std::vector<HloInstruction*> GetInvariantGTEsForWhileBody(
       const HloComputation& while_body);
+
+  // Returns a map of index to GetTupleElement instructions in
+  // `while_conditional` that access elements in the parameter tuple. Assumes
+  // `while_conditional` is the conditional computation of the while loop in
+  // question.
+  static std::map<int64, HloInstruction*> GetGTEsMapForWhileConditional(
+      const HloComputation& while_conditional);
 };
 }  // namespace xla
 


### PR DESCRIPTION
Modify the WhileLoopConstantSinking  pass so that it sinks the constants into the while loop conditional as well. From my (limited) experiments, this helps the `WhileLoopAnalysis::ComputeWhileLoopTripCount` function in being able to evaluate and get the trip count (at least for simple while loops created by `dynamic_rnn`s where the original conditional is `and`ed with the max_iterations) .