### PR TITLE
GDR contrib- Suballocators fixes

### DIFF
--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -82,9 +82,8 @@ int TryToReadNumaNode(ibv_device* device) {
   if (strings::safe_strto32(content, &value)) {
     if (value < 0) {
       LOG(INFO) << "Successful NUMA node read from SysFS had negative value ("
-                << value
-                << "), but there must be at least one NUMA node"
-                   ", so returning NUMA node zero";
+                << value << "), but there must be at least one NUMA node"
+                            ", so returning NUMA node zero";
       return port::kNUMANoAffinity;
     }
     LOG(INFO) << "NUMA node for device: " << device->name << " is " << value;
@@ -276,8 +275,8 @@ Status GdrMemoryManager::Init() {
     };
     GPUProcessState::singleton()->AddGPUAllocVisitor(bus_id,
                                                      cuda_alloc_visitor);
-    GPUProcessState::singleton()->AddCUDAHostAllocVisitor(bus_id,
-                                                          alloc_visitor);
+    GPUProcessState::singleton()->AddCUDAHostAllocVisitor(0, alloc_visitor);
+    GPUProcessState::singleton()->AddCUDAHostAllocVisitor(1, alloc_visitor);
     GPUProcessState::singleton()->AddCUDAHostFreeVisitor(bus_id, free_visitor);
     LOG(INFO) << "Instrumenting GPU allocator(s) with bus_id " << bus_id;
   }
@@ -640,8 +639,8 @@ void GdrMemoryManager::TensorFromTransportOptions(
     } else {
       checksum = GPUUtil::Checksum(*tensor);
     }
-    CHECK(checksum == remote_mr.checksum())
-        << "Checksum mismatch: " << checksum << "!=" << remote_mr.checksum();
+    CHECK(checksum == remote_mr.checksum()) << "Checksum mismatch: " << checksum
+                                            << "!=" << remote_mr.checksum();
 #endif
   }
   done(Status::OK());

--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -282,7 +282,7 @@ Status GdrMemoryManager::Init() {
       GPUProcessState::singleton()->AddGPUAllocVisitor(numa_idx,
                                                        cuda_alloc_visitor);
     }
-    VLOG(INFO) << "Instrumenting GPU allocator(s) for all Numas";
+    VLOG(1) << "Instrumenting GPU allocator(s) for all Numas";
   }
 #endif  // GOOGLE_CUDA
   return Status::OK();

--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -267,7 +267,7 @@ Status GdrMemoryManager::Init() {
 #if GOOGLE_CUDA
   for (int numa_idx = 0; numa_idx < port::NUMANumNodes(); ++numa_idx) {
     GPUProcessState::singleton()->AddCUDAHostAllocVisitor(numa_idx,
-                                                            alloc_visitor);
+                                                          alloc_visitor);
   }
   if (IsGDRAvailable()) {
     SubAllocator::Visitor cuda_alloc_visitor = [this](void* ptr, int gpu_id,
@@ -278,7 +278,8 @@ Status GdrMemoryManager::Init() {
     for (int numa_idx = 0; numa_idx < port::NUMANumNodes(); ++numa_idx) {
       GPUProcessState::singleton()->AddGPUAllocVisitor(numa_idx,
                                                        cuda_alloc_visitor);
-      GPUProcessState::singleton()->AddCUDAHostFreeVisitor(numa_idx, free_visitor);
+      GPUProcessState::singleton()->AddCUDAHostFreeVisitor(numa_idx,
+                                                           free_visitor);
     }
     LOG(INFO) << "Instrumenting GPU allocator(s) for all numas ";
   }

--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -275,8 +275,13 @@ Status GdrMemoryManager::Init() {
     };
     GPUProcessState::singleton()->AddGPUAllocVisitor(bus_id,
                                                      cuda_alloc_visitor);
-    GPUProcessState::singleton()->AddCUDAHostAllocVisitor(0, alloc_visitor);
-    GPUProcessState::singleton()->AddCUDAHostAllocVisitor(1, alloc_visitor);
+
+    for (int numa_idx = 0; numa_idx < port::NUMANumNodes(); ++numa_idx) {
+      GPUProcessState::singleton()->AddCUDAHostAllocVisitor(numa_idx,
+                                                            alloc_visitor);
+      LOG(INFO) << "Instrumenting Cuda host allocator on numa " << numa_idx;
+    }
+
     GPUProcessState::singleton()->AddCUDAHostFreeVisitor(bus_id, free_visitor);
     LOG(INFO) << "Instrumenting GPU allocator(s) with bus_id " << bus_id;
   }

--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -82,8 +82,9 @@ int TryToReadNumaNode(ibv_device* device) {
   if (strings::safe_strto32(content, &value)) {
     if (value < 0) {
       LOG(INFO) << "Successful NUMA node read from SysFS had negative value ("
-                << value << "), but there must be at least one NUMA node"
-                            ", so returning NUMA node zero";
+                << value
+                << "), but there must be at least one NUMA node"
+                   ", so returning NUMA node zero";
       return port::kNUMANoAffinity;
     }
     LOG(INFO) << "NUMA node for device: " << device->name << " is " << value;
@@ -281,10 +282,9 @@ Status GdrMemoryManager::Init() {
       GPUProcessState::singleton()->AddGPUAllocVisitor(numa_idx,
                                                        cuda_alloc_visitor);
     }
-    LOG(INFO) << "Instrumenting GPU allocator(s) for all numas ";
+    VLOG(INFO) << "Instrumenting GPU allocator(s) for all Numas";
   }
 #endif  // GOOGLE_CUDA
-
   return Status::OK();
 }
 
@@ -642,8 +642,8 @@ void GdrMemoryManager::TensorFromTransportOptions(
     } else {
       checksum = GPUUtil::Checksum(*tensor);
     }
-    CHECK(checksum == remote_mr.checksum()) << "Checksum mismatch: " << checksum
-                                            << "!=" << remote_mr.checksum();
+    CHECK(checksum == remote_mr.checksum())
+        << "Checksum mismatch: " << checksum << "!=" << remote_mr.checksum();
 #endif
   }
   done(Status::OK());

--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -268,6 +268,8 @@ Status GdrMemoryManager::Init() {
   for (int numa_idx = 0; numa_idx < port::NUMANumNodes(); ++numa_idx) {
     GPUProcessState::singleton()->AddCUDAHostAllocVisitor(numa_idx,
                                                           alloc_visitor);
+    GPUProcessState::singleton()->AddCUDAHostFreeVisitor(numa_idx,
+                                                         free_visitor);
   }
   if (IsGDRAvailable()) {
     SubAllocator::Visitor cuda_alloc_visitor = [this](void* ptr, int gpu_id,
@@ -278,8 +280,6 @@ Status GdrMemoryManager::Init() {
     for (int numa_idx = 0; numa_idx < port::NUMANumNodes(); ++numa_idx) {
       GPUProcessState::singleton()->AddGPUAllocVisitor(numa_idx,
                                                        cuda_alloc_visitor);
-      GPUProcessState::singleton()->AddCUDAHostFreeVisitor(numa_idx,
-                                                           free_visitor);
     }
     LOG(INFO) << "Instrumenting GPU allocator(s) for all numas ";
   }

--- a/tensorflow/contrib/gdr/gdr_server_lib.cc
+++ b/tensorflow/contrib/gdr/gdr_server_lib.cc
@@ -59,7 +59,7 @@ Status GdrServer::Init() {
 
   TF_RETURN_IF_ERROR(remote_memory_manager_->Init());
 
-  return GrpcServer::Init(nullptr, rendezvous_mgr_func, nullptr, worker_func));
+  return GrpcServer::Init(nullptr, rendezvous_mgr_func, nullptr, worker_func);
 }
 
 Status GdrServer::Start() {

--- a/tensorflow/contrib/gdr/gdr_server_lib.cc
+++ b/tensorflow/contrib/gdr/gdr_server_lib.cc
@@ -56,10 +56,10 @@ Status GdrServer::Init() {
     return std::unique_ptr<GdrWorker>(
         new GdrWorker(env, remote_memory_manager_.get()));
   };
-  TF_RETURN_IF_ERROR(
-      GrpcServer::Init(nullptr, rendezvous_mgr_func, nullptr, worker_func));
 
-  return remote_memory_manager_->Init();
+  TF_RETURN_IF_ERROR(remote_memory_manager_->Init());
+
+  return GrpcServer::Init(nullptr, rendezvous_mgr_func, nullptr, worker_func));
 }
 
 Status GdrServer::Start() {


### PR DESCRIPTION
This patch includes two fixes, all in the gdr contribution
The 1st one changes the ordering of the calls to gdr memory manager initialization and grpc initialization.

This is necessary because gdr initialization may initiates the GPU device and call GetCPUAllocator (or GetGPUAllocator), which are asserted to never occur before the registration of Suballocators to ProcessState's singleton (which happens on gdr memory manager init)

The 2nd fix is to change the cuda host sub allocators to be registered on both Numas, 0 and 1.
This fixed an error on my servers, and I think it should be fine on different setups too but please comment if you think I missed something.

@byronyi @poxvoculi 