### PR TITLE
Add Apache Arrow Support to TensorFlow Dataset

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1677,6 +1677,7 @@ def main():
   config_info_line('nohdfs', 'Disable HDFS support.')
   config_info_line('noignite', 'Disable Apacha Ignite support.')
   config_info_line('nokafka', 'Disable Apache Kafka support.')
+  config_info_line('noarrow', 'Disable Apache Arrow support.')
 
 
 if __name__ == '__main__':

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -241,6 +241,12 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "no_arrow_support",
+    define_values = {"no_arrow_support": "false"},
+    visibility = ["//visibility:public"],
+)
+
 # Crosses between platforms and file system libraries not supported on those
 # platforms due to limitations in nested select() statements.
 config_setting(

--- a/tensorflow/contrib/BUILD
+++ b/tensorflow/contrib/BUILD
@@ -126,6 +126,15 @@ py_library(
         "//tensorflow:ios": [],
         "//tensorflow:linux_s390x": [],
         "//tensorflow:windows": [],
+        "//tensorflow:no_arrow_support": [],
+        "//conditions:default": [
+            "//tensorflow/contrib/arrow",
+        ],
+    }) + select({
+        "//tensorflow:android": [],
+        "//tensorflow:ios": [],
+        "//tensorflow:linux_s390x": [],
+        "//tensorflow:windows": [],
         "//tensorflow:no_aws_support": [],
         "//conditions:default": [
             "//tensorflow/contrib/kinesis",
@@ -189,6 +198,15 @@ cc_library(
         "//tensorflow:no_kafka_support": [],
         "//conditions:default": [
             "//tensorflow/contrib/kafka:dataset_kernels",
+        ],
+    }) + select({
+        "//tensorflow:android": [],
+        "//tensorflow:ios": [],
+        "//tensorflow:linux_s390x": [],
+        "//tensorflow:windows": [],
+        "//tensorflow:no_arrow_support": [],
+        "//conditions:default": [
+            "//tensorflow/contrib/arrow:dataset_kernels",
         ],
     }) + select({
         "//tensorflow:android": [],

--- a/tensorflow/contrib/arrow/BUILD
+++ b/tensorflow/contrib/arrow/BUILD
@@ -1,0 +1,110 @@
+package(default_visibility = ["//tensorflow:internal"])
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+load(
+    "//tensorflow:tensorflow.bzl",
+    "tf_gen_op_wrapper_py",
+    "tf_kernel_library",
+    "tf_custom_op_library",
+    "tf_custom_op_py_library",
+    "tf_gen_op_libs",
+    "tf_py_test",
+)
+
+py_library(
+    name = "arrow",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":dataset_ops",
+    ],
+)
+
+tf_custom_op_library(
+    name = "_dataset_ops.so",
+    srcs = ["ops/dataset_ops.cc"],
+    deps = [":dataset_kernels"],
+)
+
+tf_gen_op_libs(
+    op_lib_names = ["dataset_ops"],
+)
+
+cc_library(
+    name = "dataset_kernels",
+    srcs = ["kernels/arrow_dataset_ops.cc"],
+    deps = [
+        "//tensorflow/core:framework_headers_lib",
+        "//third_party/eigen3",
+        "@arrow",
+        "@protobuf_archive//:protobuf_headers",
+    ],
+    alwayslink = 1,
+)
+
+py_library(
+    name = "dataset_ops",
+    srcs = [
+        "python/ops/arrow_dataset_ops.py",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":arrow_op_loader",
+        "//tensorflow/python:dataset_ops_gen",
+        "//tensorflow/python:util",
+        "//tensorflow/python/data/ops:dataset_ops",
+        "//tensorflow/python/data/util:nest",
+    ],
+)
+
+tf_gen_op_wrapper_py(
+    name = "gen_dataset_ops",
+    out = "python/ops/gen_dataset_ops.py",
+    deps = ["//tensorflow/contrib/arrow:dataset_ops_op_lib"],
+)
+
+tf_kernel_library(
+    name = "dataset_ops_kernels",
+    deps = [
+        ":dataset_kernels",
+        "//tensorflow/core:framework",
+    ],
+    alwayslink = 1,
+)
+
+tf_custom_op_py_library(
+    name = "arrow_op_loader",
+    srcs = ["python/ops/arrow_op_loader.py"],
+    dso = ["//tensorflow/contrib/arrow:_dataset_ops.so"],
+    kernels = [
+        ":dataset_ops_kernels",
+        "//tensorflow/contrib/arrow:dataset_ops_op_lib",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":gen_dataset_ops",
+        "//tensorflow/contrib/util:util_py",
+        "//tensorflow/python:platform",
+    ],
+)
+
+tf_py_test(
+    name = "arrow_test",
+    srcs = ["python/kernel_tests/arrow_test.py"],
+    additional_deps = [
+        ":arrow",
+        "//third_party/py/numpy",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:framework",
+        "//tensorflow/python:framework_test_lib",
+        "//tensorflow/python:platform_test",
+    ],
+    tags = [
+        "manual",
+        "no_windows",
+        "notap",
+    ],
+)

--- a/tensorflow/contrib/arrow/__init__.py
+++ b/tensorflow/contrib/arrow/__init__.py
@@ -1,0 +1,36 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Arrow Dataset.
+
+@@ArrowDataset
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib.arrow.python.ops.arrow_dataset_ops import ArrowDataset
+from tensorflow.contrib.arrow.python.ops.arrow_dataset_ops import ArrowFeatherDataset
+from tensorflow.contrib.arrow.python.ops.arrow_dataset_ops import ArrowStreamDataset
+
+from tensorflow.python.util.all_util import remove_undocumented
+
+_allowed_symbols = [
+    "ArrowDataset",
+    "ArrowFeatherDataset",
+    "ArrowStreamDataset",
+]
+
+remove_undocumented(__name__)

--- a/tensorflow/contrib/arrow/kernels/arrow_dataset_ops.cc
+++ b/tensorflow/contrib/arrow/kernels/arrow_dataset_ops.cc
@@ -1,0 +1,649 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// TODO posix specific
+#include <arpa/inet.h>
+#include <sys/socket.h>
+
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+#include "arrow/ipc/api.h"
+#include "arrow/util/io-util.h"
+#include "tensorflow/core/framework/dataset.h"
+
+#define CHECK_ARROW(arrow_status)             \
+  do {                                        \
+    arrow::Status _s = (arrow_status);        \
+    if (!_s.ok()) {                           \
+      return errors::Internal(_s.ToString()); \
+    }                                         \
+  } while (false)
+
+namespace tensorflow {
+
+// Class to wrap a socket as a readable Arrow InputStream
+class SocketStream : public arrow::io::InputStream {
+ public:
+  SocketStream(int sock) : sock_(sock), pos_(0) {}
+  ~SocketStream() override {}
+
+  arrow::Status Close() override {
+    close(sock_);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Tell(int64_t* position) const override {
+    *position = pos_;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override {
+    int status = recv(sock_, out, nbytes, MSG_WAITALL);
+    // if (status == 0) socket closed
+    if (status == -1) {
+      return arrow::Status::IOError("error reading from socket");
+    }
+    *bytes_read = nbytes;
+    pos_ += *bytes_read;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Read(int64_t nbytes,
+                     std::shared_ptr<arrow::Buffer>* out) override {
+    std::shared_ptr<arrow::ResizableBuffer> buffer;
+    ARROW_RETURN_NOT_OK(arrow::AllocateResizableBuffer(nbytes, &buffer));
+    int64_t bytes_read;
+    ARROW_RETURN_NOT_OK(Read(nbytes, &bytes_read, buffer->mutable_data()));
+    ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read, false));
+    buffer->ZeroPadding();
+    *out = buffer;
+    return arrow::Status::OK();
+  }
+
+ private:
+  int sock_;
+  int64_t pos_;
+};
+
+// Convert an element of an Arrow Array to a Tensor
+class ArrowConvertTensor : public arrow::ArrayVisitor {
+ public:
+  ArrowConvertTensor(int64_t row_idx, IteratorContext* ctx)
+      : curr_row_idx_(row_idx), curr_ctx_(ctx), curr_array_values_(-1) {}
+
+  // Convert to a Tensor and append to the output vector
+  Status AppendTensor(std::shared_ptr<arrow::Array> array, DataType output_type,
+                      std::vector<Tensor>* out_tensors) {
+    curr_type_ = output_type;
+    out_tensors_ = out_tensors;
+    // TODO: make sure null count is 0
+    CHECK_ARROW(array->Accept(this));
+    return Status::OK();
+  }
+
+ protected:
+  template <typename ArrayType>
+  arrow::Status VisitFixedWidth(const ArrayType& array) {
+    // TODO check type is correct
+    // Create a Tensor of required size, curr_array_values_ < 0 indicates scalar
+    Tensor tensor(curr_ctx_->allocator({}), curr_type_,
+                  curr_array_values_ < 0 ? TensorShape({})
+                                         : TensorShape({curr_array_values_}));
+
+    const auto& fw_type =
+        static_cast<const arrow::FixedWidthType&>(*array.type());
+    const int64_t type_width = fw_type.bit_width() / 8;
+
+    auto values = array.data()->buffers[1];
+    if (values != NULLPTR) {
+      const void* src = (values->data() + array.data()->offset * type_width) +
+                        curr_row_idx_ * type_width;
+      void* dst = const_cast<char*>(tensor.tensor_data().data());
+      int32_t num_values = curr_array_values_ < 0 ? 1 : curr_array_values_;
+      std::memcpy(dst, src, num_values * type_width);
+    }
+
+    out_tensors_->emplace_back(std::move(tensor));
+    return arrow::Status::OK();
+  }
+
+#define VISIT_FIXED_WIDTH(TYPE)                             \
+  virtual arrow::Status Visit(const TYPE& array) override { \
+    return VisitFixedWidth(array);                          \
+  }
+
+  VISIT_FIXED_WIDTH(arrow::Int8Array)
+  VISIT_FIXED_WIDTH(arrow::Int16Array)
+  VISIT_FIXED_WIDTH(arrow::Int32Array)
+  VISIT_FIXED_WIDTH(arrow::Int64Array)
+  VISIT_FIXED_WIDTH(arrow::UInt8Array)
+  VISIT_FIXED_WIDTH(arrow::UInt16Array)
+  VISIT_FIXED_WIDTH(arrow::UInt32Array)
+  VISIT_FIXED_WIDTH(arrow::UInt64Array)
+  VISIT_FIXED_WIDTH(arrow::HalfFloatArray)
+  VISIT_FIXED_WIDTH(arrow::FloatArray)
+  VISIT_FIXED_WIDTH(arrow::DoubleArray)
+#undef VISIT_FIXED_WITH
+
+  virtual arrow::Status Visit(const arrow::ListArray& array) override {
+    // TODO check if another array
+    int32 values_offset = array.value_offset(curr_row_idx_);
+    curr_array_values_ = array.value_length(curr_row_idx_);
+    int32 tmp_row_idx = curr_row_idx_;
+    curr_row_idx_ = 0;
+
+    std::shared_ptr<arrow::Array> values = array.values();
+    std::shared_ptr<arrow::Array> element_values =
+        values->Slice(values_offset, curr_array_values_);
+    auto result = element_values->Accept(this);
+    curr_row_idx_ = tmp_row_idx;
+    curr_array_values_ = -1;
+    return result;
+  }
+
+ private:
+  int64_t curr_row_idx_;
+  DataType curr_type_;
+  IteratorContext* curr_ctx_;
+  int32_t curr_array_values_;
+  std::vector<Tensor>* out_tensors_;
+};
+
+// Base class for defining a Dataset over Arrow record batches with an
+// iterator that iterates over rows of the batch to get Tensors
+class ArrowDatasetBase : public DatasetBase {
+ public:
+  ArrowDatasetBase(OpKernelContext* ctx, const std::vector<int32>& columns,
+                   const DataTypeVector& output_types,
+                   const std::vector<PartialTensorShape>& output_shapes)
+      : DatasetBase(DatasetContext(ctx)),
+        columns_(columns),
+        output_types_(output_types),
+        output_shapes_(output_shapes) {}
+
+  const DataTypeVector& output_dtypes() const override { return output_types_; }
+
+  const std::vector<PartialTensorShape>& output_shapes() const override {
+    return output_shapes_;
+  }
+
+ protected:
+  Status AsGraphDefInternal(SerializationContext* ctx,
+                            DatasetGraphDefBuilder* b,
+                            Node** output) const override {
+    return Status::OK();
+  }
+
+  // Abstract base class for iterating over rows of Arrow record
+  // batches. Implementations will define how record batches are
+  // initialized and consumed.
+  template <typename DatasetType>
+  class ArrowBaseIterator : public DatasetIterator<DatasetType> {
+   public:
+    ArrowBaseIterator(
+        const typename DatasetIterator<DatasetType>::Params& params)
+        : DatasetIterator<DatasetType>(params) {}
+
+    Status GetNextInternal(IteratorContext* ctx,
+                           std::vector<Tensor>* out_tensors,
+                           bool* end_of_sequence) override {
+      mutex_lock l(mu_);
+
+      // Intialize and read first batch
+      if (current_batch_ == nullptr) {
+        TF_RETURN_IF_ERROR(SetupStreamsLocked(ctx->env()));
+      }
+
+      // Try to go to next batch if consumed all rows
+      if (current_row_idx_ >= current_batch_->num_rows()) {
+        TF_RETURN_IF_ERROR(NextStreamLocked());
+      }
+
+      // Check if reached end of stream
+      if (current_batch_ == nullptr) {
+        ResetStreamsLocked();
+        *end_of_sequence = true;
+      }
+
+      // Assign Tensors for each column in the current row
+      ArrowConvertTensor arrow_converter(current_row_idx_, ctx);
+      for (size_t i = 0; i < this->dataset()->columns_.size(); ++i) {
+        int32 col = this->dataset()->columns_[i];
+        DataType dt = this->dataset()->output_types_[i];
+        std::shared_ptr<arrow::Array> arr = current_batch_->column(col);
+        TF_RETURN_IF_ERROR(arrow_converter.AppendTensor(arr, dt, out_tensors));
+      }
+
+      // Increment to next row
+      ++current_row_idx_;
+      *end_of_sequence = false;
+
+      return Status::OK();
+    }
+
+   protected:
+    Status SaveInternal(IteratorStateWriter* writer) override {
+      return errors::Unimplemented("SaveInternal is currently not supported");
+    }
+
+    Status RestoreInternal(IteratorContext* ctx,
+                           IteratorStateReader* reader) override {
+      return errors::Unimplemented(
+          "RestoreInternal is currently not supported");
+    }
+
+    // Setup Arrow record batch consumer and initialze current_batch_
+    virtual Status SetupStreamsLocked(Env* env)
+        EXCLUSIVE_LOCKS_REQUIRED(mu_) = 0;
+
+    // Get the next Arrow record batch, if available. If not then
+    // current_batch_ will be set to nullptr to indicate no further batches.
+    virtual Status NextStreamLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+      current_batch_ = nullptr;
+      current_row_idx_ = 0;
+      return Status::OK();
+    }
+
+    // Reset the Arrow record batch consumer when done with batches.
+    virtual void ResetStreamsLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+      current_batch_ = nullptr;
+      current_row_idx_ = 0;
+    }
+
+    mutex mu_;
+    std::shared_ptr<arrow::RecordBatch> current_batch_ GUARDED_BY(mu_) =
+        nullptr;
+    int64_t current_row_idx_ GUARDED_BY(mu_) = 0;
+  };
+
+  const std::vector<int32> columns_;
+  const DataTypeVector output_types_;
+  const std::vector<PartialTensorShape> output_shapes_;
+};
+
+// Abstract base class to define an Arrow OpKernel with output_types and
+// output_shapes attributes, and list of column indices. Implementations
+// will define how to create the Arrow Dataset.
+class ArrowOpKernelBase : public DatasetOpKernel {
+ public:
+  using DatasetOpKernel::DatasetOpKernel;
+
+  ArrowOpKernelBase(OpKernelConstruction* ctx) : DatasetOpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_types", &output_types_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_shapes", &output_shapes_));
+    // TODO: check types and shapes
+  }
+
+ private:
+  void MakeDataset(OpKernelContext* ctx, DatasetBase** output) override {
+    const Tensor* columns_tensor;
+    OP_REQUIRES_OK(ctx, ctx->input("columns", &columns_tensor));
+    OP_REQUIRES(
+        ctx, columns_tensor->dims() <= 1,
+        errors::InvalidArgument("`columns` must be a scalar or a vector."));
+
+    std::vector<int32> columns;
+    columns.reserve(columns_tensor->NumElements());
+    for (int32 i = 0; i < static_cast<int32>(columns_tensor->NumElements());
+         ++i) {
+      columns.push_back(columns_tensor->flat<int32>()(i));
+    }
+
+    ArrowDatasetBase* arrow_output;
+    MakeArrowDataset(ctx, columns, output_types_, output_shapes_,
+                     &arrow_output);
+    *output = arrow_output;
+  }
+
+ protected:
+  // Define to construct an implementation of ArrowDatasetBase
+  virtual void MakeArrowDataset(
+      OpKernelContext* ctx, const std::vector<int32>& columns,
+      const DataTypeVector& output_types,
+      const std::vector<PartialTensorShape>& output_shapes,
+      ArrowDatasetBase** output) = 0;
+
+  DataTypeVector output_types_;
+  std::vector<PartialTensorShape> output_shapes_;
+};
+
+// Op to create an ArrowDataset that consumes Arrow record batches from
+// memory in a Python process, or a Pandas DataFrame.
+class ArrowDatasetOp : public ArrowOpKernelBase {
+ public:
+  using DatasetOpKernel::DatasetOpKernel;
+
+  explicit ArrowDatasetOp(OpKernelConstruction* ctx) : ArrowOpKernelBase(ctx) {}
+
+  virtual void MakeArrowDataset(
+      OpKernelContext* ctx, const std::vector<int32>& columns,
+      const DataTypeVector& output_types,
+      const std::vector<PartialTensorShape>& output_shapes,
+      ArrowDatasetBase** output) override {
+    const Tensor* batches_tensor;
+    OP_REQUIRES_OK(ctx, ctx->input("serialized_batches", &batches_tensor));
+    OP_REQUIRES(
+        ctx, batches_tensor->dims() <= 0,
+        errors::InvalidArgument("`serialized_batches` must be a scalar."));
+    string batches = batches_tensor->flat<string>()(0);
+
+    *output = new Dataset(ctx, batches, columns, output_types_, output_shapes_);
+  }
+
+ private:
+  class Dataset : public ArrowDatasetBase {
+   public:
+    // Construct a Dataset that consumed Arrow batches from serialized bytes
+    // in a string. Record batches should be serialized in Arrow File format.
+    Dataset(OpKernelContext* ctx, const string& serialized_batches,
+            const std::vector<int32>& columns,
+            const DataTypeVector& output_types,
+            const std::vector<PartialTensorShape>& output_shapes)
+        : ArrowDatasetBase(ctx, columns, output_types, output_shapes),
+          batches_(serialized_batches) {}
+
+   protected:
+    std::unique_ptr<IteratorBase> MakeIteratorInternal(
+        const string& prefix) const override {
+      return std::unique_ptr<IteratorBase>(
+          new Iterator({this, strings::StrCat(prefix, "::Arrow")}));
+    }
+
+    string DebugString() const override { return "ArrowDatasetOp::Dataset"; }
+
+   private:
+    class Iterator : public ArrowBaseIterator<Dataset> {
+     public:
+      explicit Iterator(const Params& params)
+          : ArrowBaseIterator<Dataset>(params) {}
+
+     private:
+      Status SetupStreamsLocked(Env* env)
+          EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+        std::shared_ptr<arrow::Buffer> buffer;
+        CHECK_ARROW(arrow::Buffer::FromString(dataset()->batches_, &buffer));
+        auto buffer_reader = std::make_shared<arrow::io::BufferReader>(buffer);
+        CHECK_ARROW(
+            arrow::ipc::RecordBatchFileReader::Open(buffer_reader, &reader_));
+        num_batches_ = reader_->num_record_batches();
+        if (num_batches_ > 0) {
+          CHECK_ARROW(
+              reader_->ReadRecordBatch(current_batch_idx_, &current_batch_));
+        }
+        return Status::OK();
+      }
+
+      Status NextStreamLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+        ArrowBaseIterator<Dataset>::NextStreamLocked();
+        if (++current_batch_idx_ < num_batches_) {
+          CHECK_ARROW(
+              reader_->ReadRecordBatch(current_batch_idx_, &current_batch_));
+        }
+        return Status::OK();
+      }
+
+      void ResetStreamsLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+        ArrowBaseIterator<Dataset>::ResetStreamsLocked();
+        reader_.reset();
+        current_batch_idx_ = 0;
+        num_batches_ = 0;
+      }
+
+      std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader_
+          GUARDED_BY(mu_);
+      int current_batch_idx_ GUARDED_BY(mu_) = 0;
+      int num_batches_ GUARDED_BY(mu_) = 0;
+    };
+
+    const string batches_;
+  };
+};
+
+// Op to create an Arrow Dataset that consumes record batches from a list of
+// files in Arrow Feather format. Feather is a light-weight columnar format
+// ideal for simple writing of Pandas DataFrames.
+class ArrowFeatherDatasetOp : public ArrowOpKernelBase {
+ public:
+  using DatasetOpKernel::DatasetOpKernel;
+
+  explicit ArrowFeatherDatasetOp(OpKernelConstruction* ctx)
+      : ArrowOpKernelBase(ctx) {}
+
+  virtual void MakeArrowDataset(
+      OpKernelContext* ctx, const std::vector<int32>& columns,
+      const DataTypeVector& output_types,
+      const std::vector<PartialTensorShape>& output_shapes,
+      ArrowDatasetBase** output) override {
+    const Tensor* filenames_tensor;
+    OP_REQUIRES_OK(ctx, ctx->input("filenames", &filenames_tensor));
+    OP_REQUIRES(
+        ctx, filenames_tensor->dims() <= 1,
+        errors::InvalidArgument("`filename` must be a scalar or vector."));
+    std::vector<string> filenames;
+    filenames.reserve(filenames_tensor->NumElements());
+    for (int i = 0; i < filenames_tensor->NumElements(); ++i) {
+      filenames.push_back(filenames_tensor->flat<string>()(i));
+    }
+
+    *output =
+        new Dataset(ctx, filenames, columns, output_types_, output_shapes_);
+  }
+
+ private:
+  class Dataset : public ArrowDatasetBase {
+   public:
+    Dataset(OpKernelContext* ctx, const std::vector<string>& filenames,
+            const std::vector<int32>& columns,
+            const DataTypeVector& output_types,
+            const std::vector<PartialTensorShape>& output_shapes)
+        : ArrowDatasetBase(ctx, columns, output_types, output_shapes),
+          filenames_(filenames) {}
+
+   protected:
+    std::unique_ptr<IteratorBase> MakeIteratorInternal(
+        const string& prefix) const override {
+      return std::unique_ptr<IteratorBase>(
+          new Iterator({this, strings::StrCat(prefix, "::ArrowFeather")}));
+    }
+
+    string DebugString() const override {
+      return "ArrowFeatherDatasetOp::Dataset";
+    }
+
+   private:
+    class Iterator : public ArrowBaseIterator<Dataset> {
+     public:
+      explicit Iterator(const Params& params)
+          : ArrowBaseIterator<Dataset>(params) {}
+
+     private:
+      Status SetupStreamsLocked(Env* env)
+          EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+        return SetupStreamsLocked();
+      }
+
+      Status SetupStreamsLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+        const string& filename = dataset()->filenames_[current_file_idx_];
+        std::shared_ptr<arrow::io::ReadableFile> in_file;
+        CHECK_ARROW(arrow::io::ReadableFile::Open(filename, &in_file));
+        std::unique_ptr<arrow::ipc::feather::TableReader> reader;
+        CHECK_ARROW(arrow::ipc::feather::TableReader::Open(in_file, &reader));
+
+        // Read file columns and build a table
+        int64_t num_columns = reader->num_columns();
+        std::vector<std::shared_ptr<arrow::Field>> fields(num_columns);
+        std::vector<std::shared_ptr<arrow::Column>> columns(num_columns);
+        for (int64_t i = 0; i < num_columns; ++i) {
+          CHECK_ARROW(reader->GetColumn(i, &columns[i]));
+          fields[i] = columns[i]->field();
+        }
+        auto schema = std::make_shared<arrow::Schema>(fields);
+        auto table = arrow::Table::Make(schema, columns);
+
+        // Convert the table to a sequence of batches
+        arrow::TableBatchReader tr(*table.get());
+        std::shared_ptr<arrow::RecordBatch> batch;
+        CHECK_ARROW(tr.ReadNext(&batch));
+        current_batch_ = batch;
+        while (batch != nullptr) {
+          record_batches_.push_back(batch);
+          CHECK_ARROW(tr.ReadNext(&batch));
+        }
+        return Status::OK();
+      }
+
+      Status NextStreamLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+        ArrowBaseIterator<Dataset>::NextStreamLocked();
+        if (++current_batch_idx_ < record_batches_.size()) {
+          current_batch_ = record_batches_[current_batch_idx_];
+        } else if (++current_file_idx_ < dataset()->filenames_.size()) {
+          size_t temp_file_idx = current_file_idx_;
+          ResetStreamsLocked();
+          current_file_idx_ = temp_file_idx;
+          SetupStreamsLocked();
+        }
+        return Status::OK();
+      }
+
+      void ResetStreamsLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+        ArrowBaseIterator<Dataset>::ResetStreamsLocked();
+        current_file_idx_ = 0;
+        current_batch_idx_ = 0;
+        record_batches_.clear();
+      }
+
+      size_t current_file_idx_ GUARDED_BY(mu_) = 0;
+      size_t current_batch_idx_ GUARDED_BY(mu_) = 0;
+      std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches_
+          GUARDED_BY(mu_);
+    };
+
+    const std::vector<string> filenames_;
+  };
+};
+
+// Op to create an Arrow Dataset that consumes record batches from an input
+// stream. Currently supported input streams are a POSIX socket client, with
+// host given as "<IP>:<PORT>", or from STDIN if host is "STDIN".
+class ArrowStreamDatasetOp : public ArrowOpKernelBase {
+ public:
+  using DatasetOpKernel::DatasetOpKernel;
+
+  explicit ArrowStreamDatasetOp(OpKernelConstruction* ctx)
+      : ArrowOpKernelBase(ctx) {}
+
+  virtual void MakeArrowDataset(
+      OpKernelContext* ctx, const std::vector<int32>& columns,
+      const DataTypeVector& output_types,
+      const std::vector<PartialTensorShape>& output_shapes,
+      ArrowDatasetBase** output) override {
+    const Tensor* host_tensor;
+    OP_REQUIRES_OK(ctx, ctx->input("host", &host_tensor));
+    OP_REQUIRES(ctx, host_tensor->dims() == 0,
+                errors::InvalidArgument("`host` must be a scalar."));
+    string host = host_tensor->flat<string>()(0);
+
+    *output = new Dataset(ctx, host, columns, output_types_, output_shapes_);
+  }
+
+ private:
+  class Dataset : public ArrowDatasetBase {
+   public:
+    Dataset(OpKernelContext* ctx, const string& host,
+            const std::vector<int32>& columns,
+            const DataTypeVector& output_types,
+            const std::vector<PartialTensorShape>& output_shapes)
+        : ArrowDatasetBase(ctx, columns, output_types, output_shapes),
+          host_(host) {}
+
+   protected:
+    std::unique_ptr<IteratorBase> MakeIteratorInternal(
+        const string& prefix) const override {
+      return std::unique_ptr<IteratorBase>(
+          new Iterator({this, strings::StrCat(prefix, "::ArrowStream")}));
+    }
+
+    string DebugString() const override {
+      return "ArrowStreamDatasetOp::Dataset";
+    }
+
+   private:
+    class Iterator : public ArrowBaseIterator<Dataset> {
+     public:
+      explicit Iterator(const Params& params)
+          : ArrowBaseIterator<Dataset>(params) {}
+
+     private:
+      Status SetupStreamsLocked(Env* env)
+          EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+        if (dataset()->host_ == "STDIN") {
+          in_stream_ = std::make_shared<arrow::io::StdinStream>();
+        } else {
+          int sock = 0;
+          struct sockaddr_in serv_addr;
+          if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+            return errors::InvalidArgument("Socket creation error");
+          }
+          bzero((char*)&serv_addr, sizeof(serv_addr));
+          serv_addr.sin_addr.s_addr = inet_addr(dataset()->host_.c_str());
+          serv_addr.sin_family = AF_INET;
+          // TODO parse port with hostname
+          serv_addr.sin_port = htons(8080);
+          // if(inet_pton(AF_INET, "127.0.0.1", &serv_addr.sin_addr)<=0)
+          // printf("\nInvalid address/ Address not supported \n");
+          if (connect(sock, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) <
+              0) {
+            return errors::InvalidArgument("Connection failed to host: " +
+                                           dataset()->host_);
+          }
+          in_stream_ = std::make_shared<SocketStream>(sock);
+        }
+
+        CHECK_ARROW(arrow::ipc::RecordBatchStreamReader::Open(in_stream_.get(),
+                                                              &reader_));
+        CHECK_ARROW(reader_->ReadNext(&current_batch_));
+        return Status::OK();
+      }
+
+      Status NextStreamLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+        ArrowBaseIterator<Dataset>::NextStreamLocked();
+        CHECK_ARROW(reader_->ReadNext(&current_batch_));
+        return Status::OK();
+      }
+
+      void ResetStreamsLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+        ArrowBaseIterator<Dataset>::ResetStreamsLocked();
+        reader_.reset();
+        in_stream_.reset();
+      }
+
+      std::shared_ptr<arrow::io::InputStream> in_stream_ GUARDED_BY(mu_);
+      std::shared_ptr<arrow::ipc::RecordBatchReader> reader_ GUARDED_BY(mu_);
+    };
+
+    const string host_;
+  };
+};
+
+REGISTER_KERNEL_BUILDER(Name("ArrowDataset").Device(DEVICE_CPU),
+                        ArrowDatasetOp);
+
+REGISTER_KERNEL_BUILDER(Name("ArrowFeatherDataset").Device(DEVICE_CPU),
+                        ArrowFeatherDatasetOp);
+
+REGISTER_KERNEL_BUILDER(Name("ArrowStreamDataset").Device(DEVICE_CPU),
+                        ArrowStreamDatasetOp);
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/arrow/kernels/arrow_dataset_ops.cc
+++ b/tensorflow/contrib/arrow/kernels/arrow_dataset_ops.cc
@@ -215,20 +215,21 @@ class ArrowDatasetBase : public DatasetBase {
       if (current_batch_ == nullptr) {
         ResetStreamsLocked();
         *end_of_sequence = true;
-      }
+      } else {
 
-      // Assign Tensors for each column in the current row
-      ArrowConvertTensor arrow_converter(current_row_idx_, ctx);
-      for (size_t i = 0; i < this->dataset()->columns_.size(); ++i) {
-        int32 col = this->dataset()->columns_[i];
-        DataType dt = this->dataset()->output_types_[i];
-        std::shared_ptr<arrow::Array> arr = current_batch_->column(col);
-        TF_RETURN_IF_ERROR(arrow_converter.AppendTensor(arr, dt, out_tensors));
-      }
+        // Assign Tensors for each column in the current row
+        ArrowConvertTensor arrow_converter(current_row_idx_, ctx);
+        for (size_t i = 0; i < this->dataset()->columns_.size(); ++i) {
+          int32 col = this->dataset()->columns_[i];
+          DataType dt = this->dataset()->output_types_[i];
+          std::shared_ptr<arrow::Array> arr = current_batch_->column(col);
+          TF_RETURN_IF_ERROR(arrow_converter.AppendTensor(arr, dt, out_tensors));
+        }
 
-      // Increment to next row
-      ++current_row_idx_;
-      *end_of_sequence = false;
+        // Increment to next row
+        ++current_row_idx_;
+        *end_of_sequence = false;
+      }
 
       return Status::OK();
     }

--- a/tensorflow/contrib/arrow/ops/dataset_ops.cc
+++ b/tensorflow/contrib/arrow/ops/dataset_ops.cc
@@ -1,0 +1,64 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+
+REGISTER_OP("ArrowDataset")
+    .Input("serialized_batches: string")
+    .Input("columns: int32")
+    .Output("handle: variant")
+    .Attr("output_types: list(type) >= 1")
+    .Attr("output_shapes: list(shape) >= 1")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::ScalarShape)
+    .Doc(R"doc(
+Creates a dataset that reads serialized Arrow RecordBatches in file format.
+
+serialized_batches: Serialized Arrow RecordBatches.
+)doc");
+
+REGISTER_OP("ArrowFeatherDataset")
+    .Input("filenames: string")
+    .Input("columns: int32")
+    .Output("handle: variant")
+    .Attr("output_types: list(type) >= 1")
+    .Attr("output_shapes: list(shape) >= 1")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::ScalarShape)
+    .Doc(R"doc(
+Creates a dataset that reads files in Arrow Feather format.
+
+filenames: One or more file paths.
+)doc");
+
+REGISTER_OP("ArrowStreamDataset")
+    .Input("host: string")
+    .Input("columns: int32")
+    .Output("handle: variant")
+    .Attr("output_types: list(type) >= 1")
+    .Attr("output_shapes: list(shape) >= 1")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::ScalarShape)
+    .Doc(R"doc(
+Creates a dataset that connects to a host serving Arrow RecordBatches in stream format.
+
+host: A host address that is serving an Arrow stream.
+)doc");
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/arrow/python/kernel_tests/arrow_test.py
+++ b/tensorflow/contrib/arrow/python/kernel_tests/arrow_test.py
@@ -1,0 +1,184 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for ArrowDataset."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import socket
+import tempfile
+import threading
+
+import pyarrow as pa
+from pyarrow.feather import write_feather
+
+from tensorflow.contrib.arrow.python.ops import arrow_dataset_ops
+from tensorflow.python.framework import dtypes
+from tensorflow.python.platform import test
+
+
+class ArrowDatasetTest(test.TestCase):
+
+  def testArrowDataset(self):
+
+    data = [
+        [1, 2, 3, 4],
+        [1.1, 2.2, 3.3, 4.4],
+        [[1, 1], [2, 2], [3, 3], [4, 4]],
+        [[1], [2, 2], [3, 3, 3], [4, 4, 4]],
+    ]
+
+    arrays = [
+        pa.array(data[0], type=pa.int32()),
+        pa.array(data[1], type=pa.float32()),
+        pa.array(data[2], type=pa.list_(pa.int32())),
+        pa.array(data[3], type=pa.list_(pa.int32())),
+    ]
+
+    names = ["%s_[%s]" % (i, a.type) for i, a in enumerate(arrays)]
+    batch = pa.RecordBatch.from_arrays(arrays, names)
+
+    columns = tuple(range(len(arrays)))
+    output_types = (dtypes.int32, dtypes.float32, dtypes.int32, dtypes.int32)
+
+    dataset = arrow_dataset_ops.ArrowDataset(
+        batch, columns, output_types)
+
+    iterator = dataset.make_one_shot_iterator()
+    next_element = iterator.get_next()
+
+    with self.test_session() as sess:
+      for row_num in range(len(data[0])):
+        value = sess.run(next_element)
+        self.assertEqual(value[0], data[0][row_num])
+        self.assertAlmostEqual(value[1], data[1][row_num], 2)
+        self.assertListEqual(value[2].tolist(), data[2][row_num])
+        self.assertListEqual(value[3].tolist(), data[3][row_num])
+
+    df = batch.to_pandas()
+
+    dataset = arrow_dataset_ops.ArrowDataset.from_pandas(
+        df, preserve_index=False)
+
+    iterator = dataset.make_one_shot_iterator()
+    next_element = iterator.get_next()
+
+    with self.test_session() as sess:
+      for row_num in range(len(data[0])):
+        value = sess.run(next_element)
+        self.assertEqual(value[0], data[0][row_num])
+        self.assertAlmostEqual(value[1], data[1][row_num], 2)
+        self.assertListEqual(value[2].tolist(), data[2][row_num])
+        self.assertListEqual(value[3].tolist(), data[3][row_num])
+
+  def testArrowFeatherDataset(self):
+    f = tempfile.NamedTemporaryFile(delete=False)
+
+    names = ["int32", "float32"]
+
+    data = [
+        [1, 2, 3, 4],
+        [1.1, 2.2, 3.3, 4.4],
+    ]
+
+    arrays = [
+        pa.array(data[0], type=pa.int32()),
+        pa.array(data[1], type=pa.float32()),
+    ]
+
+    batch = pa.RecordBatch.from_arrays(arrays, names)
+    df = batch.to_pandas()
+    write_feather(df, f)
+    f.close()
+
+    columns = (0, 1)
+    output_types = (dtypes.int32, dtypes.float32)
+
+    dataset = arrow_dataset_ops.ArrowFeatherDataset(
+        f.name, columns, output_types)
+
+    iterator = dataset.make_one_shot_iterator()
+    next_element = iterator.get_next()
+
+    with self.test_session() as sess:
+      for row_num in range(len(data[0])):
+        value = sess.run(next_element)
+        self.assertEqual(value[0], data[0][row_num])
+        self.assertAlmostEqual(value[1], data[1][row_num], 2)
+
+    os.unlink(f.name)
+
+  def testArrowSocketDataset(self):
+
+    data = [
+        [1, 2, 3, 4],
+        [1.1, 2.2, 3.3, 4.4],
+        [[1, 1], [2, 2], [3, 3], [4, 4]],
+        [[1], [2, 2], [3, 3, 3], [4, 4, 4]],
+    ]
+
+    arrays = [
+        pa.array(data[0], type=pa.int32()),
+        pa.array(data[1], type=pa.float32()),
+        pa.array(data[2], type=pa.list_(pa.int32())),
+        pa.array(data[3], type=pa.list_(pa.int32())),
+    ]
+
+    names = ["%s_[%s]" % (i, a.type) for i, a in enumerate(arrays)]
+    batch = pa.RecordBatch.from_arrays(arrays, names)
+
+    columns = tuple(range(len(arrays)))
+    output_types = (dtypes.int32, dtypes.float32, dtypes.int32, dtypes.int32)
+
+    host = '127.0.0.1'
+    port_num = 8080
+
+    def run_server():
+      s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+      s.bind((host, port_num))
+      s.listen(1)
+      conn, _ = s.accept()
+      outfile = conn.makefile(mode='wb')
+      writer = pa.RecordBatchStreamWriter(outfile, batch.schema)
+      writer.write_batch(batch)
+      writer.close()
+      outfile.flush()
+      outfile.close()
+      conn.close()
+      s.close()
+
+    server = threading.Thread(target=run_server)
+    server.start()
+
+    host_wport = host  # TODO + ':%' % port_num
+
+    dataset = arrow_dataset_ops.ArrowStreamDataset(
+        host_wport, columns, output_types)
+
+    iterator = dataset.make_one_shot_iterator()
+    next_element = iterator.get_next()
+
+    with self.test_session() as sess:
+      for row_num in range(len(data[0])):
+        value = sess.run(next_element)
+        self.assertEqual(value[0], data[0][row_num])
+        self.assertAlmostEqual(value[1], data[1][row_num], 2)
+
+    server.join()
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/contrib/arrow/python/ops/arrow_dataset_ops.py
+++ b/tensorflow/contrib/arrow/python/ops/arrow_dataset_ops.py
@@ -31,7 +31,7 @@ from tensorflow.python.framework import tensor_shape
 
 # TODO expose arrow-cpp to tensor type
 def arrow_to_tensor_type(pa_t):
-  """Conert Arrow to Tensor dtype."""
+  """Convert Arrow to Tensor dtype."""
   if pa.types.is_int8(pa_t):
     tf_t = dtypes.int8
   elif pa.types.is_int16(pa_t):
@@ -80,8 +80,8 @@ class ArrowBaseDataset(dataset_ops.DatasetSource):
 
   @property
   def output_shapes(self):
-    # TODO what about array types?
-    return nest.map_structure(lambda _: tensor_shape.TensorShape([]), self._output_types)
+    # TODO alllow for known shapes
+    return nest.map_structure(lambda _: tensor_shape.TensorShape(None), self._output_types)
 
   @property
   def output_types(self):

--- a/tensorflow/contrib/arrow/python/ops/arrow_dataset_ops.py
+++ b/tensorflow/contrib/arrow/python/ops/arrow_dataset_ops.py
@@ -1,0 +1,193 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Arrow Dataset."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import io
+import pyarrow as pa
+
+from tensorflow.contrib.arrow.python.ops import arrow_op_loader  # pylint: disable=unused-import
+from tensorflow.contrib.arrow.python.ops import gen_dataset_ops
+from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.data.util import nest
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
+
+
+# TODO expose arrow-cpp to tensor type
+def arrow_to_tensor_type(pa_t):
+  """Conert Arrow to Tensor dtype."""
+  if pa.types.is_int8(pa_t):
+    tf_t = dtypes.int8
+  elif pa.types.is_int16(pa_t):
+    tf_t = dtypes.int16
+  elif pa.types.is_int32(pa_t):
+    tf_t = dtypes.int32
+  elif pa.types.is_int64(pa_t):
+    tf_t = dtypes.int64
+  elif pa.types.is_uint8(pa_t):
+    tf_t = dtypes.uint8
+  elif pa.types.is_uint16(pa_t):
+    tf_t = dtypes.uint16
+  elif pa.types.is_uint32(pa_t):
+    tf_t = dtypes.uint32
+  elif pa.types.is_uint64(pa_t):
+    tf_t = dtypes.uint64
+  elif pa.types.is_float16(pa_t):
+    tf_t = dtypes.float16
+  elif pa.types.is_float32(pa_t):
+    tf_t = dtypes.float32
+  elif pa.types.is_float64(pa_t):
+    tf_t = dtypes.float64
+  elif pa.types.is_list(pa_t):
+    if pa.types.is_list(pa_t.value_type):
+      raise TypeError("Nested arrays are not supported: " + str(pa_t))
+    tf_t = arrow_to_tensor_type(pa_t.value_type)
+  else:
+    raise TypeError("Unsupported type in conversion from Arrow: " + str(pa_t))
+  return tf_t
+
+
+def arrow_schema_to_tensor_types(schema):
+  """Convert an Arrow schema to list of Tensor dtypes."""
+  return tuple([arrow_to_tensor_type(field.type) for field in schema])
+
+
+class ArrowBaseDataset(dataset_ops.DatasetSource):
+
+  def __init__(self, columns, output_types):
+    self._columns = columns
+    self._output_types = output_types
+
+  @property
+  def output_classes(self):
+    return nest.map_structure(lambda _: ops.Tensor, self._output_types)
+
+  @property
+  def output_shapes(self):
+    # TODO what about array types?
+    return nest.map_structure(lambda _: tensor_shape.TensorShape([]), self._output_types)
+
+  @property
+  def output_types(self):
+    return self._output_types
+
+
+class ArrowDataset(ArrowBaseDataset):
+  """An Arrow Dataset from record batches in memory, or a Pandas DataFrame.
+  """
+
+  def __init__(self,
+               record_batches,
+               columns,
+               output_types):
+    """Create an ArrowDataset directly from Arrow record batches.
+
+    Args:
+      record_batches: An Arrow record batch or sequence of record batches
+    """
+    super(ArrowDataset, self).__init__(columns, output_types)
+    if isinstance(record_batches, pa.RecordBatch):
+      record_batches = [record_batches]
+    assert record_batches
+    buf = io.BytesIO()
+    writer = pa.RecordBatchFileWriter(buf, record_batches[0].schema)
+    for batch in record_batches:
+      writer.write_batch(batch)
+    writer.close()
+
+    self._serialized_batches = ops.convert_to_tensor(
+        buf.getvalue(), dtype=dtypes.string, name="serialized_batches")
+
+  def _as_variant_tensor(self):
+    return gen_dataset_ops.arrow_dataset(self._serialized_batches,
+                                         self._columns,
+                                         nest.flatten(self.output_types),
+                                         nest.flatten(self.output_shapes))
+
+  @classmethod
+  def from_pandas(cls, df, columns=None, preserve_index=True):
+    """Create an ArrowDataset from a given Pandas DataFrame.
+
+    Args:
+      df: a Pandas DataFrame
+      columns: Optional column indices to use, if None all are used
+      preserve_index: Flag to include the DataFrame index as a column
+    """
+    if columns is not None:
+      df = df[columns]
+    batch = pa.RecordBatch.from_pandas(df, preserve_index=preserve_index)
+    columns = tuple(range(len(df.columns)))
+    output_types = arrow_schema_to_tensor_types(batch.schema)
+    return cls(batch, columns, output_types)
+
+
+class ArrowFeatherDataset(ArrowBaseDataset):
+  """An Arrow Dataset for reading record batches from Arrow feather files.
+  Feather is a light-weight columnar format ideal for simple writing of
+  Pandas DataFrames. Pyarrow can be used for reading/writing Feather files,
+  see https://arrow.apache.org/docs/python/ipc.html#feather-format
+  """
+
+  def __init__(self,
+               filenames,
+               columns,
+               output_types):
+    """Create an ArrowDataset from one or more Feather file names.
+
+    Args:
+      filenames: A `tf.string` tensor, Python list or scalar containing files
+      in Arrow Feather format
+    """
+    super(ArrowFeatherDataset, self).__init__(columns, output_types)
+    self._filenames = ops.convert_to_tensor(
+        filenames, dtype=dtypes.string, name="filenames")
+
+  def _as_variant_tensor(self):
+    return gen_dataset_ops.\
+        arrow_feather_dataset(self._filenames,
+                              self._columns,
+                              nest.flatten(self.output_types),
+                              nest.flatten(self.output_shapes))
+
+
+class ArrowStreamDataset(ArrowBaseDataset):
+  """An Arrow Dataset for reading record batches from an input stream.
+  Currently supported input streams are a socket client or stdin.
+  """
+
+  def __init__(self,
+               host,
+               columns,
+               output_types):
+    """Create an ArrowDataset from an input stream.
+
+    Args:
+      host: A `tf.string` tensor or Python string defining the input stream
+      type. For a socket client, use "<HOST_IP>:<PORT>". For stdin use "STDIN".
+    """
+    super(ArrowStreamDataset, self).__init__(columns, output_types)
+    self._host = ops.convert_to_tensor(
+        host, dtype=dtypes.string, name="host")
+
+  def _as_variant_tensor(self):
+    return gen_dataset_ops.\
+        arrow_stream_dataset(self._host,
+                             self._columns,
+                             nest.flatten(self.output_types),
+                             nest.flatten(self.output_shapes))

--- a/tensorflow/contrib/arrow/python/ops/arrow_op_loader.py
+++ b/tensorflow/contrib/arrow/python/ops/arrow_op_loader.py
@@ -1,0 +1,24 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Python helper for loading arrow ops and kernels."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib.util import loader
+from tensorflow.python.platform import resource_loader
+
+_dataset_ops = loader.load_op_library(
+    resource_loader.get_path_to_datafile("../../_dataset_ops.so"))

--- a/tensorflow/contrib/cmake/python_modules.txt
+++ b/tensorflow/contrib/cmake/python_modules.txt
@@ -84,6 +84,8 @@ tensorflow/contrib/android/java/org/tensorflow
 tensorflow/contrib/android/java/org/tensorflow/contrib
 tensorflow/contrib/android/java/org/tensorflow/contrib/android
 tensorflow/contrib/android/jni
+tensorflow/contrib/arrow/python
+tensorflow/contrib/arrow/python/ops
 tensorflow/contrib/batching
 tensorflow/contrib/batching/python
 tensorflow/contrib/batching/python/ops

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -137,6 +137,7 @@ filegroup(
         "//third_party/hadoop:LICENSE.txt",
         "@absl_py//absl/flags:LICENSE",
         "@arm_neon_2_x86_sse//:LICENSE",
+        "@arrow//:LICENSE.txt",
         "@astor_archive//:LICENSE",
         "@boringssl//:LICENSE",
         "@com_google_absl//:LICENSE",

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -595,6 +595,17 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
         testonly_ = True,
     )
 
+    tf_http_archive(
+        name = "arrow",
+        urls = [
+            "https://mirror.bazel.build/github.com/apache/arrow/archive/apache-arrow-0.10.0.tar.gz",
+            "https://github.com/apache/arrow/archive/apache-arrow-0.10.0.tar.gz",
+        ],
+        sha256 = "2094cc6492e77ede19937375769de105603a50440a6257fefd4038f1176a0626",
+        strip_prefix = "arrow-apache-arrow-0.10.0",
+        build_file = clean_dep("//third_party:arrow.BUILD"),
+    )
+
     java_import_external(
         name = "com_google_testing_compile",
         jar_sha256 = "edc180fdcd9f740240da1a7a45673f46f59c5578d8cd3fbc912161f74b5aebb8",

--- a/third_party/arrow.BUILD
+++ b/third_party/arrow.BUILD
@@ -1,0 +1,62 @@
+# Description:
+#   Apache Arrow library
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE.txt"])
+
+load("@flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
+
+flatbuffer_cc_library(
+    name = "arrow_format",
+    srcs = [
+				"format/File.fbs",
+				"format/Message.fbs",
+				"format/Schema.fbs",
+				"format/Tensor.fbs",
+        "cpp/src/arrow/ipc/feather.fbs",
+    ],
+    out_prefix = "cpp/src/arrow/ipc/"
+)
+
+cc_library(
+    name = "arrow",
+    srcs = glob([
+        "cpp/src/arrow/*.cc",
+        "cpp/src/arrow/*.h",
+        "cpp/src/arrow/io/*.cc",
+        "cpp/src/arrow/io/*.h",
+        "cpp/src/arrow/ipc/*.cc",
+        "cpp/src/arrow/ipc/*.h",
+        "cpp/src/arrow/util/*.cc",
+        "cpp/src/arrow/util/*.h",
+    ],
+    exclude=[
+        "cpp/src/arrow/**/*-test.cc",
+        "cpp/src/arrow/**/*benchmark*.cc",
+        "cpp/src/arrow/**/*hdfs*",
+        "cpp/src/arrow/util/compression_zstd.*",
+        "cpp/src/arrow/util/compression_lz4.*",
+        "cpp/src/arrow/util/compression_brotli.*",
+        "cpp/src/arrow/ipc/json*",
+        "cpp/src/arrow/ipc/stream-to-file.cc",
+        "cpp/src/arrow/ipc/file-to-stream.cc",
+    ]),
+    hdrs = [
+    ],
+    defines = [
+        "ARROW_WITH_SNAPPY",
+    ],
+    includes = [
+        "cpp/src",
+    ],
+    copts = [
+    ],
+    deps = [
+        ":arrow_format",
+        "@snappy",
+    ],
+)
+

--- a/third_party/snappy.BUILD
+++ b/third_party/snappy.BUILD
@@ -18,6 +18,7 @@ cc_library(
         "snappy-stubs-public.h",
     ],
     hdrs = ["snappy.h"],
+    includes = ["."],
     copts = ["-DHAVE_CONFIG_H"] + select({
         "@org_tensorflow//tensorflow:windows": [],
         "//conditions:default": [


### PR DESCRIPTION
Apache Arrow is a standard format for in-memory columnar data. It provides a cross-language platform for systems to communicate and operate on data efficiently.

Adding Arrow support in TensorFlow Dataset will allow systems to interface with TensorFlow in a well defined way, without the need to develop custom converters, serialize data, or write to specialized files.

This PR defines an Arrow base layer that will create a TensorFlow Dataset with an iterator over Arrow record batches to produce Tensor values for each column. This base layer is then extended to implement three Dataset Ops that consume Arrow record batches: 1) from Python memory / Pandas DataFrames, 2) Reading Arrow Feather files, 3) Input stream with a socket client to connect to a server streaming Arrow record batches. These are implemented now because they are straightforward and can provide some good initial functionality, but the design here should allow for more Arrow Ops in the future.

fixes #23001 