### PR TITLE
Make api_compatibility_test pass in Python 3

### DIFF
--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.Dataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.FixedLengthRecordDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.TFRecordDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.TextLineDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.experimental.CsvDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.experimental.RandomDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.experimental.SqlDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.pbtxt
@@ -10,7 +10,7 @@ tf_module {
   }
   member {
     name: "CsvDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "Optional"
@@ -18,7 +18,7 @@ tf_module {
   }
   member {
     name: "RandomDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "Reducer"
@@ -26,7 +26,7 @@ tf_module {
   }
   member {
     name: "SqlDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "StatsAggregator"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
@@ -2,11 +2,11 @@ path: "tensorflow.data"
 tf_module {
   member {
     name: "Dataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "FixedLengthRecordDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "Iterator"
@@ -18,11 +18,11 @@ tf_module {
   }
   member {
     name: "TFRecordDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "TextLineDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "experimental"

--- a/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.-classification-output.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.-classification-output.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.estimator.export.ClassificationOutput.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.-export-output.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.-export-output.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.estimator.export.ExportOutput.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.-predict-output.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.-predict-output.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.estimator.export.PredictOutput.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.-regression-output.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.-regression-output.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.estimator.export.RegressionOutput.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.estimator.export.pbtxt
@@ -2,19 +2,19 @@ path: "tensorflow.estimator.export"
 tf_module {
   member {
     name: "ClassificationOutput"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "ExportOutput"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "PredictOutput"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "RegressionOutput"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "ServingInputReceiver"

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-block-diag.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-block-diag.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorBlockDiag.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-circulant.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-circulant.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorCirculant.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-circulant2-d.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-circulant2-d.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorCirculant2D.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-circulant3-d.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-circulant3-d.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorCirculant3D.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-composition.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-composition.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorComposition.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-diag.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-diag.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorDiag.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-full-matrix.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-full-matrix.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorFullMatrix.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-identity.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-identity.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorIdentity.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-kronecker.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-kronecker.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorKronecker.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-low-rank-update.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-low-rank-update.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorLowRankUpdate.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-lower-triangular.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-lower-triangular.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorLowerTriangular.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-scaled-identity.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-scaled-identity.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorScaledIdentity.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-zeros.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator-zeros.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorZeros.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.-linear-operator.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperator.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.pbtxt
@@ -2,59 +2,59 @@ path: "tensorflow.linalg"
 tf_module {
   member {
     name: "LinearOperator"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorBlockDiag"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorCirculant"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorCirculant2D"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorCirculant3D"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorComposition"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorDiag"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorFullMatrix"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorIdentity"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorKronecker"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorLowRankUpdate"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorLowerTriangular"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorScaledIdentity"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorZeros"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member_method {
     name: "adjoint"

--- a/tensorflow/tools/api/golden/v1/tensorflow.train.-nan-loss-during-training-error.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.train.-nan-loss-during-training-error.pbtxt
@@ -6,10 +6,6 @@ tf_class {
     name: "args"
     mtype: "<type \'getset_descriptor\'>"
   }
-  member {
-    name: "message"
-    mtype: "<type \'getset_descriptor\'>"
-  }
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.Dataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.FixedLengthRecordDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.TFRecordDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.TextLineDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.experimental.CsvDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.experimental.RandomDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.data.experimental.SqlDataset.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.pbtxt
@@ -10,7 +10,7 @@ tf_module {
   }
   member {
     name: "CsvDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "Optional"
@@ -18,7 +18,7 @@ tf_module {
   }
   member {
     name: "RandomDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "Reducer"
@@ -26,7 +26,7 @@ tf_module {
   }
   member {
     name: "SqlDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "StatsAggregator"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
@@ -2,11 +2,11 @@ path: "tensorflow.data"
 tf_module {
   member {
     name: "Dataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "FixedLengthRecordDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "Iterator"
@@ -18,11 +18,11 @@ tf_module {
   }
   member {
     name: "TFRecordDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "TextLineDataset"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "experimental"

--- a/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.-classification-output.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.-classification-output.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.estimator.export.ClassificationOutput.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.-export-output.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.-export-output.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.estimator.export.ExportOutput.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.-predict-output.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.-predict-output.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.estimator.export.PredictOutput.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.-regression-output.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.-regression-output.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.estimator.export.RegressionOutput.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.estimator.export.pbtxt
@@ -2,19 +2,19 @@ path: "tensorflow.estimator.export"
 tf_module {
   member {
     name: "ClassificationOutput"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "ExportOutput"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "PredictOutput"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "RegressionOutput"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "ServingInputReceiver"

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-block-diag.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-block-diag.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorBlockDiag.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-circulant.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-circulant.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorCirculant.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-circulant2-d.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-circulant2-d.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorCirculant2D.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-circulant3-d.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-circulant3-d.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorCirculant3D.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-composition.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-composition.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorComposition.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-diag.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-diag.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorDiag.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-full-matrix.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-full-matrix.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorFullMatrix.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-identity.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-identity.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorIdentity.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-kronecker.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-kronecker.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorKronecker.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-low-rank-update.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-low-rank-update.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorLowRankUpdate.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-lower-triangular.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-lower-triangular.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorLowerTriangular.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-scaled-identity.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-scaled-identity.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorScaledIdentity.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-zeros.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator-zeros.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperatorZeros.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator.__metaclass__.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.-linear-operator.__metaclass__.pbtxt
@@ -1,6 +1,6 @@
 path: "tensorflow.linalg.LinearOperator.__metaclass__"
 tf_class {
-  is_instance: "<class \'abc.ABCMeta\'>"
+  is_instance: "<type \'type\'>"
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.pbtxt
@@ -2,59 +2,59 @@ path: "tensorflow.linalg"
 tf_module {
   member {
     name: "LinearOperator"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorBlockDiag"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorCirculant"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorCirculant2D"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorCirculant3D"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorComposition"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorDiag"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorFullMatrix"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorIdentity"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorKronecker"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorLowRankUpdate"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorLowerTriangular"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorScaledIdentity"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member {
     name: "LinearOperatorZeros"
-    mtype: "<class \'abc.ABCMeta\'>"
+    mtype: "<type \'type\'>"
   }
   member_method {
     name: "adjoint"

--- a/tensorflow/tools/api/golden/v2/tensorflow.train.-nan-loss-during-training-error.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.train.-nan-loss-during-training-error.pbtxt
@@ -6,10 +6,6 @@ tf_class {
     name: "args"
     mtype: "<type \'getset_descriptor\'>"
   }
-  member {
-    name: "message"
-    mtype: "<type \'getset_descriptor\'>"
-  }
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/lib/python_object_to_proto_visitor.py
+++ b/tensorflow/tools/api/lib/python_object_to_proto_visitor.py
@@ -19,6 +19,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import re
+import sys
 from google.protobuf import message
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import tf_decorator
@@ -31,6 +33,59 @@ _CORNER_CASES = {
     'test.TestCase': {},
     'test.TestCase.failureException': {},
 }
+
+
+# Python 2 vs. 3 differences
+if sys.version_info.major == 3:
+  _CODE_ATTR = '__code__'
+  _CLASS_TO_TYPE = {}
+  for t in ('property', 'object', 'getset_descriptor', 'int', 'str', 'type',
+            'tuple', 'module', 'collections.defaultdict', 'set', 'dict',
+            'NoneType', 'frozenset'):
+    _CLASS_TO_TYPE["<class '%s'>" % t] = "<type '%s'>" % t
+  for e in 'Exception', 'RuntimeError':
+    _CLASS_TO_TYPE["<class '%s'>" % e] = "<type 'exceptions.%s'>" % e
+  _NORMALIZE_ISINSTANCE = {
+      "<class 'tensorflow.python.training.monitored_session._MonitoredSession.StepContext'>":
+          "<class 'tensorflow.python.training.monitored_session.StepContext'>",
+      "<class 'tensorflow.python.ops.variables.Variable.SaveSliceInfo'>":
+          "<class 'tensorflow.python.ops.variables.SaveSliceInfo'>"}
+
+  def _normalize_type(ty):
+    return _CLASS_TO_TYPE.get(ty, ty)
+
+  def _normalize_isinstance(ty):
+    return _NORMALIZE_ISINSTANCE.get(ty, ty)
+
+  def _skip_member(cls, member):
+    if member == 'with_traceback':
+      return True
+    if (cls in ('VariableSynchronization', 'UnconnectedGradients', 'VariableAggregation') and
+        member in ('name', 'value')):
+      return True
+
+  def normalize_proto(proto):
+    for kind in 'tf_module', 'tf_class':
+      if proto.HasField(kind):
+        for member in getattr(proto, kind).member:
+          if member.mtype == "<class 'abc.ABCMeta'>":
+            member.mtype = "<type 'type'>"
+        if proto.path == 'tensorflow.train.NanLossDuringTrainingError':
+          del proto.tf_class.member[1]
+else:
+  _CODE_ATTR = 'func_code'
+
+  def _normalize_type(ty):
+    return ty
+
+  def _normalize_isinstance(ty):
+    return ty
+
+  def _skip_member(cls, member):
+    return False
+
+  def normalize_proto(proto):
+    pass
 
 
 def _SanitizedArgSpec(obj):
@@ -91,7 +146,7 @@ def _SanitizedMRO(obj):
     if cls.__name__ == '_NewClass':
       # Ignore class created by @deprecated_alias decorator.
       continue
-    str_repr = str(cls)
+    str_repr = _normalize_type(str(cls))
     return_list.append(str_repr)
     if 'tensorflow' not in str_repr:
       break
@@ -130,6 +185,8 @@ class PythonObjectToProtoVisitor(object):
     def _AddMember(member_name, member_obj, proto):
       """Add the child object to the object being constructed."""
       _, member_obj = tf_decorator.unwrap(member_obj)
+      if _skip_member(parent.__name__, member_name):
+        return
       if member_name == '__init__' or not member_name.startswith('_'):
         if tf_inspect.isroutine(member_obj):
           new_method = proto.member_method.add()
@@ -137,12 +194,12 @@ class PythonObjectToProtoVisitor(object):
           # If member_obj is a python builtin, there is no way to get its
           # argspec, because it is implemented on the C side. It also has no
           # func_code.
-          if getattr(member_obj, 'func_code', None):
+          if hasattr(member_obj, _CODE_ATTR):
             new_method.argspec = _SanitizedArgSpec(member_obj)
         else:
           new_member = proto.member.add()
           new_member.name = member_name
-          new_member.mtype = str(type(member_obj))
+          new_member.mtype = _normalize_type(str(type(member_obj)))
 
     parent_corner_cases = _CORNER_CASES.get(path, {})
 
@@ -172,7 +229,7 @@ class PythonObjectToProtoVisitor(object):
       elif tf_inspect.isclass(parent):
         # Construct a class.
         class_obj = api_objects_pb2.TFAPIClass()
-        class_obj.is_instance.extend(_SanitizedMRO(parent))
+        class_obj.is_instance.extend(_normalize_isinstance(i) for i in _SanitizedMRO(parent))
         for name, child in children:
           if name in parent_corner_cases:
             # If we have an empty entry, skip this object.

--- a/tensorflow/tools/api/lib/python_object_to_proto_visitor.py
+++ b/tensorflow/tools/api/lib/python_object_to_proto_visitor.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import re
+import enum
 import sys
 from google.protobuf import message
 from tensorflow.python.platform import tf_logging as logging
@@ -32,60 +32,44 @@ _CORNER_CASES = {
     '': {'tools': {}},
     'test.TestCase': {},
     'test.TestCase.failureException': {},
+    'train.NanLossDuringTrainingError': {'message': {}},
 }
 
 
 # Python 2 vs. 3 differences
 if sys.version_info.major == 3:
-  _CODE_ATTR = '__code__'
-  _CLASS_TO_TYPE = {}
+  _NORMALIZE_TYPE = {}
   for t in ('property', 'object', 'getset_descriptor', 'int', 'str', 'type',
             'tuple', 'module', 'collections.defaultdict', 'set', 'dict',
             'NoneType', 'frozenset'):
-    _CLASS_TO_TYPE["<class '%s'>" % t] = "<type '%s'>" % t
+    _NORMALIZE_TYPE["<class '%s'>" % t] = "<type '%s'>" % t
   for e in 'Exception', 'RuntimeError':
-    _CLASS_TO_TYPE["<class '%s'>" % e] = "<type 'exceptions.%s'>" % e
+    _NORMALIZE_TYPE["<class '%s'>" % e] = "<type 'exceptions.%s'>" % e
+  _NORMALIZE_TYPE["<class 'abc.ABCMeta'>"] = "<type 'type'>"
   _NORMALIZE_ISINSTANCE = {
-      "<class 'tensorflow.python.training.monitored_session._MonitoredSession.StepContext'>":
+      "<class 'tensorflow.python.training.monitored_session._MonitoredSession.StepContext'>":  # pylint: disable=line-too-long
           "<class 'tensorflow.python.training.monitored_session.StepContext'>",
       "<class 'tensorflow.python.ops.variables.Variable.SaveSliceInfo'>":
           "<class 'tensorflow.python.ops.variables.SaveSliceInfo'>"}
 
-  def _normalize_type(ty):
-    return _CLASS_TO_TYPE.get(ty, ty)
-
-  def _normalize_isinstance(ty):
-    return _NORMALIZE_ISINSTANCE.get(ty, ty)
-
   def _skip_member(cls, member):
-    if member == 'with_traceback':
-      return True
-    if (cls in ('VariableSynchronization', 'UnconnectedGradients', 'VariableAggregation') and
-        member in ('name', 'value')):
-      return True
-
-  def normalize_proto(proto):
-    for kind in 'tf_module', 'tf_class':
-      if proto.HasField(kind):
-        for member in getattr(proto, kind).member:
-          if member.mtype == "<class 'abc.ABCMeta'>":
-            member.mtype = "<type 'type'>"
-        if proto.path == 'tensorflow.train.NanLossDuringTrainingError':
-          del proto.tf_class.member[1]
+    return (member == 'with_traceback' or
+            member in ('name', 'value') and isinstance(cls, type) and
+            issubclass(cls, enum.Enum))
 else:
-  _CODE_ATTR = 'func_code'
-
-  def _normalize_type(ty):
-    return ty
-
-  def _normalize_isinstance(ty):
-    return ty
+  _NORMALIZE_TYPE = {"<class 'abc.ABCMeta'>": "<type 'type'>"}
+  _NORMALIZE_ISINSTANCE = {}
 
   def _skip_member(cls, member):
     return False
 
-  def normalize_proto(proto):
-    pass
+
+def _normalize_type(ty):
+  return _NORMALIZE_TYPE.get(ty, ty)
+
+
+def _normalize_isinstance(ty):
+  return _NORMALIZE_ISINSTANCE.get(ty, ty)
 
 
 def _SanitizedArgSpec(obj):
@@ -185,7 +169,7 @@ class PythonObjectToProtoVisitor(object):
     def _AddMember(member_name, member_obj, proto):
       """Add the child object to the object being constructed."""
       _, member_obj = tf_decorator.unwrap(member_obj)
-      if _skip_member(parent.__name__, member_name):
+      if _skip_member(parent, member_name):
         return
       if member_name == '__init__' or not member_name.startswith('_'):
         if tf_inspect.isroutine(member_obj):
@@ -194,7 +178,7 @@ class PythonObjectToProtoVisitor(object):
           # If member_obj is a python builtin, there is no way to get its
           # argspec, because it is implemented on the C side. It also has no
           # func_code.
-          if hasattr(member_obj, _CODE_ATTR):
+          if hasattr(member_obj, '__code__'):
             new_method.argspec = _SanitizedArgSpec(member_obj)
         else:
           new_member = proto.member.add()
@@ -229,7 +213,8 @@ class PythonObjectToProtoVisitor(object):
       elif tf_inspect.isclass(parent):
         # Construct a class.
         class_obj = api_objects_pb2.TFAPIClass()
-        class_obj.is_instance.extend(_normalize_isinstance(i) for i in _SanitizedMRO(parent))
+        class_obj.is_instance.extend(
+            _normalize_isinstance(i) for i in _SanitizedMRO(parent))
         for name, child in children:
           if name in parent_corner_cases:
             # If we have an empty entry, skip this object.

--- a/tensorflow/tools/api/tests/api_compatibility_test.py
+++ b/tensorflow/tools/api/tests/api_compatibility_test.py
@@ -31,7 +31,6 @@ import argparse
 import os
 import re
 import sys
-import unittest
 
 import tensorflow as tf
 from tensorflow._api import v2 as tf_v2
@@ -299,7 +298,6 @@ class ApiCompatibilityTest(test.TestCase):
       """Read a filename, create a protobuf from its contents."""
       ret_val = api_objects_pb2.TFAPIObject()
       text_format.Merge(file_io.read_file_to_string(filename), ret_val)
-      python_object_to_proto_visitor.normalize_proto(ret_val)
       return ret_val
 
     golden_proto_dict = {

--- a/tensorflow/tools/api/tests/api_compatibility_test.py
+++ b/tensorflow/tools/api/tests/api_compatibility_test.py
@@ -299,6 +299,7 @@ class ApiCompatibilityTest(test.TestCase):
       """Read a filename, create a protobuf from its contents."""
       ret_val = api_objects_pb2.TFAPIObject()
       text_format.Merge(file_io.read_file_to_string(filename), ret_val)
+      python_object_to_proto_visitor.normalize_proto(ret_val)
       return ret_val
 
     golden_proto_dict = {
@@ -315,9 +316,6 @@ class ApiCompatibilityTest(test.TestCase):
         update_goldens=FLAGS.update_goldens,
         api_version=api_version)
 
-  @unittest.skipUnless(
-      sys.version_info.major == 2,
-      'API compabitility test goldens are generated using python2.')
   def testAPIBackwardsCompatibility(self):
     api_version = 1
     golden_file_pattern = os.path.join(
@@ -331,9 +329,6 @@ class ApiCompatibilityTest(test.TestCase):
         # in separate tests.
         additional_private_map={'tf.compat': ['v1', 'v2']})
 
-  @unittest.skipUnless(
-      sys.version_info.major == 2,
-      'API compabitility test goldens are generated using python2.')
   def testAPIBackwardsCompatibilityV1(self):
     api_version = 1
     golden_file_pattern = os.path.join(
@@ -342,9 +337,6 @@ class ApiCompatibilityTest(test.TestCase):
     self._checkBackwardsCompatibility(
         tf_v2.compat.v1, golden_file_pattern, api_version)
 
-  @unittest.skipUnless(
-      sys.version_info.major == 2,
-      'API compabitility test goldens are generated using python2.')
   def testAPIBackwardsCompatibilityV2(self):
     api_version = 2
     golden_file_pattern = os.path.join(


### PR DESCRIPTION
I was (perhaps masochistically) curious what it would take.

This is a bunch of hacks, but it isn't that much overall code.  I leave it up to others whether it's worth ignoring, cleaning up, or adopting with minimal changes.  Main plus: nearly everyone outside Google uses Python 3, and this would make it easier for people to contribute.