### PR TITLE
Removes reference to TFProf C++ API

### DIFF
--- a/tensorflow/contrib/tfprof/README.md
+++ b/tensorflow/contrib/tfprof/README.md
@@ -21,4 +21,3 @@
 * Python API
 * Command Line
 * Visualization
-* C++ API (Not public, contact us if needed.)


### PR DESCRIPTION
As mentioned in #16821