### PR TITLE
change libcudnn7 version to 7.0.5.15

### DIFF
--- a/tensorflow/tools/docker/Dockerfile.gpu
+++ b/tensorflow/tools/docker/Dockerfile.gpu
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         cuda-cusolver-9-0 \
         cuda-cusparse-9-0 \
         curl \
-        libcudnn7=7.2.1.38-1+cuda9.0 \
+        libcudnn7=7.0.5.15-1+cuda9.0 \
         libnccl2=2.2.13-1+cuda9.0 \
         libfreetype6-dev \
         libhdf5-serial-dev \


### PR DESCRIPTION
Founded incompatibilities with my laptop GPU in ubuntu 18. "cuda_dnn.cc:360] Possibly insufficient driver version: 390.48.0". It was solved downgrading CuDNN