### PR TITLE
Add ability to start TensorFlow server from Java API

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -94,6 +94,7 @@ tf_cuda_library(
             "//tensorflow/core:protos_all_cc",
             "//tensorflow/core:lib",
             "//tensorflow/core:lib_internal",
+            "//tensorflow/core/distributed_runtime:server_lib",
         ],
     }) + select({
         "//tensorflow:with_xla_support": [

--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -2809,9 +2809,15 @@ TF_Buffer* TF_GetRegisteredKernelsForOp(const char* name, TF_Status* status) {
 #ifndef __ANDROID__
 TF_Server::TF_Server(std::unique_ptr<tensorflow::ServerInterface> server)
     : server(std::move(server)) {}
+#endif  // __ANDROID__
 
 TF_Server* TF_NewServer(const void* proto, size_t proto_len,
                         TF_Status* status) {
+#ifdef __ANDROID__
+  status->status = tensorflow::errors::Unimplemented(
+      "Server functionality is not supported in Android");
+  return nullptr;
+#else
   tensorflow::ServerDef server_def;
   if (!server_def.ParseFromArray(proto, static_cast<int>(proto_len))) {
     status->status = InvalidArgument(
@@ -2824,21 +2830,39 @@ TF_Server* TF_NewServer(const void* proto, size_t proto_len,
   if (!status->status.ok()) return nullptr;
 
   return new TF_Server(std::move(out_server));
+#endif
 }
 
 void TF_ServerStart(TF_Server* server, TF_Status* status) {
+#ifdef __ANDROID__
+  status->status = tensorflow::errors::Unimplemented(
+      "Server functionality is not supported in Android");
+  return nullptr;
+#else
   status->status = server->server->Start();
+#endif
 }
 
 void TF_ServerStop(TF_Server* server, TF_Status* status) {
+#ifdef __ANDROID__
+  status->status = tensorflow::errors::Unimplemented(
+      "Server functionality is not supported in Android");
+  return nullptr;
+#else
   status->status = server->server->Stop();
+#endif
 }
 
 void TF_ServerJoin(TF_Server* server, TF_Status* status) {
+#ifdef __ANDROID__
+  status->status = tensorflow::errors::Unimplemented(
+      "Server functionality is not supported in Android");
+  return nullptr;
+#else
   status->status = server->server->Join();
+#endif
 }
 
 void TF_DeleteServer(TF_Server* server) { delete server; }
-#endif  // __ANDROID__
 
 }  // end extern "C"

--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -2837,7 +2837,6 @@ void TF_ServerStart(TF_Server* server, TF_Status* status) {
 #ifdef __ANDROID__
   status->status = tensorflow::errors::Unimplemented(
       "Server functionality is not supported in Android");
-  return nullptr;
 #else
   status->status = server->server->Start();
 #endif
@@ -2847,7 +2846,6 @@ void TF_ServerStop(TF_Server* server, TF_Status* status) {
 #ifdef __ANDROID__
   status->status = tensorflow::errors::Unimplemented(
       "Server functionality is not supported in Android");
-  return nullptr;
 #else
   status->status = server->server->Stop();
 #endif
@@ -2857,7 +2855,6 @@ void TF_ServerJoin(TF_Server* server, TF_Status* status) {
 #ifdef __ANDROID__
   status->status = tensorflow::errors::Unimplemented(
       "Server functionality is not supported in Android");
-  return nullptr;
 #else
   status->status = server->server->Join();
 #endif

--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -2806,6 +2806,7 @@ TF_Buffer* TF_GetRegisteredKernelsForOp(const char* name, TF_Status* status) {
 
 // TF_Server functions ----------------------------------------------
 
+#ifndef __ANDROID__
 TF_Server::TF_Server(std::unique_ptr<tensorflow::ServerInterface> server)
     : server(std::move(server)) {}
 
@@ -2838,5 +2839,6 @@ void TF_ServerJoin(TF_Server* server, TF_Status* status) {
 }
 
 void TF_DeleteServer(TF_Server* server) { delete server; }
+#endif  // __ANDROID__
 
 }  // end extern "C"

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -1673,43 +1673,28 @@ TF_CAPI_EXPORT extern TF_Buffer* TF_GetRegisteredKernelsForOp(
 // In-process TensorFlow server.
 typedef struct TF_Server TF_Server;
 
-// Creates a new server. The returned TF_Server object can be started, stopped
-// and joined using correspondent commands. After using TF_Server object should
-// be deleted using the TF_DeleteServer command to free correspondent resources.
+// Creates a new in-process TensorFlow server configured using a serialized
+// ServerDef protocol buffer provided via `proto` and `proto_len`.
 //
-// Params:
-//  proto - Serialized ServerDef protocol buffer.
-//  proto_len - Length of the proto.
-//  status - Set to OK on success and an appropriate error on failure.
+// The server will not serve any requests until TF_ServerStart is invoked.
+// The server will stop serving requests once TF_ServerStop or
+// TF_DeleteServer is invoked.
 TF_CAPI_EXPORT extern TF_Server* TF_NewServer(const void* proto,
                                               size_t proto_len,
                                               TF_Status* status);
 
-// Starts a server.
-//
-// Params:
-//  server - TF_Server object to be started.
-//  status - Set to OK on success and an appropriate error on failure.
+// Starts an in-process TensorFlow server.
 TF_CAPI_EXPORT extern void TF_ServerStart(TF_Server* server, TF_Status* status);
 
-// Stops a server.
-//
-// Params:
-//  server - TF_Server object to be stopped.
-//  status - Set to OK on success and an appropriate error on failure.
+// Stops an in-process TensorFlow server.
 TF_CAPI_EXPORT extern void TF_ServerStop(TF_Server* server, TF_Status* status);
 
-// Blocks until the server has shut down (currently blocks forever).
-//
-// Params:
-//  server - TF_Server object to be joined.
-//  status - Set to OK on success and an appropriate error on failure.
+// Blocks until the server has been successfully stopped (via TF_ServerStop or
+// TF_ServerClose).
 TF_CAPI_EXPORT extern void TF_ServerJoin(TF_Server* server, TF_Status* status);
 
-// Destroy a server, frees memory. Server is expected to be stopped before.
-//
-// Params:
-//  server - TF_Server object to be deleted.
+// Destroy an in-process TensorFlow server, frees memory. If server is running
+// it will be stopped and joined.
 TF_CAPI_EXPORT extern void TF_DeleteServer(TF_Server* server);
 
 #ifdef __cplusplus

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -1663,26 +1663,53 @@ TF_CAPI_EXPORT extern TF_Buffer* TF_GetRegisteredKernelsForOp(
     const char* name, TF_Status* status);
 
 // --------------------------------------------------------------------------
-// Server functionality.
+// In-process TensorFlow server functionality, for use in distributed training.
+// A Server instance encapsulates a set of devices and a Session target that
+// can participate in distributed training. A server belongs to a cluster
+// (specified by a ClusterSpec), and corresponds to a particular task in a
+// named job. The server can communicate with any other server in the same
+// cluster.
 
-// Server.
+// In-process TensorFlow server.
 typedef struct TF_Server TF_Server;
 
-// Creates new server.
+// Creates a new server. The returned TF_Server object can be started, stopped
+// and joined using correspondent commands. After using TF_Server object should
+// be deleted using the TF_DeleteServer command to free correspondent resources.
+//
+// Params:
+//  proto - Serialized ServerDef protocol buffer.
+//  proto_len - Length of the proto.
+//  status - Set to OK on success and an appropriate error on failure.
 TF_CAPI_EXPORT extern TF_Server* TF_NewServer(const void* proto,
                                               size_t proto_len,
                                               TF_Status* status);
 
 // Starts a server.
-TF_CAPI_EXPORT extern void TF_StartServer(TF_Server* server, TF_Status* status);
+//
+// Params:
+//  server - TF_Server object to be started.
+//  status - Set to OK on success and an appropriate error on failure.
+TF_CAPI_EXPORT extern void TF_ServerStart(TF_Server* server, TF_Status* status);
 
 // Stops a server.
-TF_CAPI_EXPORT extern void TF_StopServer(TF_Server* server, TF_Status* status);
+//
+// Params:
+//  server - TF_Server object to be stopped.
+//  status - Set to OK on success and an appropriate error on failure.
+TF_CAPI_EXPORT extern void TF_ServerStop(TF_Server* server, TF_Status* status);
 
 // Blocks until the server has shut down (currently blocks forever).
-TF_CAPI_EXPORT extern void TF_JoinServer(TF_Server* server, TF_Status* status);
+//
+// Params:
+//  server - TF_Server object to be joined.
+//  status - Set to OK on success and an appropriate error on failure.
+TF_CAPI_EXPORT extern void TF_ServerJoin(TF_Server* server, TF_Status* status);
 
-// Destroy a server, frees memory.
+// Destroy a server, frees memory. Server is expected to be stopped before.
+//
+// Params:
+//  server - TF_Server object to be deleted.
 TF_CAPI_EXPORT extern void TF_DeleteServer(TF_Server* server);
 
 #ifdef __cplusplus

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -1662,6 +1662,29 @@ TF_CAPI_EXPORT extern TF_Buffer* TF_GetAllRegisteredKernels(TF_Status* status);
 TF_CAPI_EXPORT extern TF_Buffer* TF_GetRegisteredKernelsForOp(
     const char* name, TF_Status* status);
 
+// --------------------------------------------------------------------------
+// Server functionality.
+
+// Server.
+typedef struct TF_Server TF_Server;
+
+// Creates new server.
+TF_CAPI_EXPORT extern TF_Server* TF_NewServer(const void* proto,
+                                              size_t proto_len,
+                                              TF_Status* status);
+
+// Starts a server.
+TF_CAPI_EXPORT extern void TF_StartServer(TF_Server* server, TF_Status* status);
+
+// Stops a server.
+TF_CAPI_EXPORT extern void TF_StopServer(TF_Server* server, TF_Status* status);
+
+// Blocks until the server has shut down (currently blocks forever).
+TF_CAPI_EXPORT extern void TF_JoinServer(TF_Server* server, TF_Status* status);
+
+// Destroy a server, frees memory.
+TF_CAPI_EXPORT extern void TF_DeleteServer(TF_Server* server);
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/tensorflow/c/c_api_internal.h
+++ b/tensorflow/c/c_api_internal.h
@@ -25,8 +25,8 @@ limitations under the License.
 #include <vector>
 
 #ifndef __ANDROID__
-#include "tensorflow/core/framework/op_gen_lib.h"
 #include "tensorflow/core/distributed_runtime/server_lib.h"
+#include "tensorflow/core/framework/op_gen_lib.h"
 #endif
 #include "tensorflow/core/common_runtime/shape_refiner.h"
 #include "tensorflow/core/framework/tensor.h"

--- a/tensorflow/c/c_api_internal.h
+++ b/tensorflow/c/c_api_internal.h
@@ -26,9 +26,9 @@ limitations under the License.
 
 #ifndef __ANDROID__
 #include "tensorflow/core/framework/op_gen_lib.h"
+#include "tensorflow/core/distributed_runtime/server_lib.h"
 #endif
 #include "tensorflow/core/common_runtime/shape_refiner.h"
-#include "tensorflow/core/distributed_runtime/server_lib.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/graph/graph.h"
@@ -180,11 +180,13 @@ struct TF_ApiDefMap {
   tensorflow::mutex lock;
 };
 
+#ifndef __ANDROID__
 struct TF_Server {
   TF_Server(std::unique_ptr<tensorflow::ServerInterface> server);
 
   std::unique_ptr<tensorflow::ServerInterface> server;
 };
+#endif
 
 namespace tensorflow {
 

--- a/tensorflow/c/c_api_internal.h
+++ b/tensorflow/c/c_api_internal.h
@@ -37,6 +37,7 @@ limitations under the License.
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/public/session.h"
+#include "tensorflow/core/distributed_runtime/server_lib.h"
 
 namespace tensorflow {
 class Device;
@@ -177,6 +178,12 @@ struct TF_ApiDefMap {
 #endif
   bool update_docs_called GUARDED_BY(lock);
   tensorflow::mutex lock;
+};
+
+struct TF_Server {
+  TF_Server(tensorflow::ServerInterface* server);
+
+  tensorflow::ServerInterface* server;
 };
 
 namespace tensorflow {

--- a/tensorflow/c/c_api_internal.h
+++ b/tensorflow/c/c_api_internal.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op_gen_lib.h"
 #endif
 #include "tensorflow/core/common_runtime/shape_refiner.h"
+#include "tensorflow/core/distributed_runtime/server_lib.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/graph/graph.h"
@@ -37,7 +38,6 @@ limitations under the License.
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/public/session.h"
-#include "tensorflow/core/distributed_runtime/server_lib.h"
 
 namespace tensorflow {
 class Device;
@@ -181,9 +181,9 @@ struct TF_ApiDefMap {
 };
 
 struct TF_Server {
-  TF_Server(tensorflow::ServerInterface* server);
+  TF_Server(std::unique_ptr<tensorflow::ServerInterface> server);
 
-  tensorflow::ServerInterface* server;
+  std::unique_ptr<tensorflow::ServerInterface> server;
 };
 
 namespace tensorflow {

--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -382,6 +382,7 @@ tf_cc_binary(
     linkstatic = 1,
     deps = [
         "//tensorflow/java/src/main/native",
+        "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib",
         LINKER_VERSION_SCRIPT,
         LINKER_EXPORTED_SYMBOLS,
     ],

--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -381,8 +381,8 @@ tf_cc_binary(
     linkshared = 1,
     linkstatic = 1,
     deps = [
-        "//tensorflow/java/src/main/native",
         "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib",
+        "//tensorflow/java/src/main/native",
         LINKER_VERSION_SCRIPT,
         LINKER_EXPORTED_SYMBOLS,
     ],

--- a/tensorflow/java/src/main/java/org/tensorflow/Server.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Server.java
@@ -23,7 +23,7 @@ package org.tensorflow;
  * training. A server belongs to a cluster (specified by a
  * {@code ClusterSpec}), and corresponds to a particular task in a named job.
  * The server can communicate with any other server in the same cluster.
- * The server will not serve any requests until {@link #start()} is invoked. 
+ * The server will not serve any requests until {@link #start()} is invoked.
  * The server will stop serving requests once {@link #stop()} or {@link #close()} is invoked.
  * Be aware that {@link #close()} method stops the server if it is running.
  *
@@ -60,12 +60,12 @@ package org.tensorflow;
  * }</pre>
  */
 public final class Server implements AutoCloseable {
-
-  /** 
-   * Constructs a new instance of server. 
+  /**
+   * Constructs a new instance of server.
    *
    * @param serverDef Server definition specified as a serialized
-   *        <a href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/protobuf/tensorflow_server.proto">ServerDef</a>
+   *        <a
+   * href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/protobuf/tensorflow_server.proto">ServerDef</a>
    *        protocol buffer.
    */
   public Server(byte[] serverDef) {
@@ -85,7 +85,7 @@ public final class Server implements AutoCloseable {
   /** Blocks until the server has been successfully stopped. */
   public void join() {
     long handle = 0;
-    synchronized(this) {
+    synchronized (this) {
       handle = nativeHandle;
       if (handle != 0) {
         numJoining++;
@@ -94,10 +94,10 @@ public final class Server implements AutoCloseable {
     try {
       join(handle);
     } finally {
-      synchronized(this) {
+      synchronized (this) {
         if (handle != 0) {
           numJoining--;
-        } 
+        }
         notifyAll();
       }
     }

--- a/tensorflow/java/src/main/java/org/tensorflow/Server.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Server.java
@@ -1,0 +1,82 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package org.tensorflow;
+
+/**
+ * An in-process TensorFlow server, for use in distributed training.
+ *
+ * A {@code tf.train.Server} instance encapsulates a set of devices and a
+ * {@code tf.Session} target that can participate in distributed training. A
+ * server belongs to a cluster (specified by a {@code tf.train.ClusterSpec}),
+ * and corresponds to a particular task in a named job. The server can
+ * communicate with any other server in the same cluster.
+ *
+ * <p><b>WARNING:</b>A {@code Server} owns resources that <b>must</b> be
+ * explicitly freed by invoking {@link #close()}.
+ *
+ * <p>Instances of a {@code Server} are thread-safe.
+ */
+public final class Server implements AutoCloseable {
+
+  /** 
+   * Constructs a new instance of server. 
+   *
+   * @param config Server definition specified as a serialized
+   *        <a href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/protobuf/tensorflow_server.proto">ServerDef</a>
+   *        protocol buffer.
+   */
+  public Server(byte[] serverDef) {
+    nativeHandle = allocate(serverDef);
+  }
+
+  /** Starts this server. */
+  public synchronized void start() {
+    start(nativeHandle);
+  }
+
+  /** Stops this server. */
+  public synchronized void stop() {
+    stop(nativeHandle);
+  }
+
+  /** Blocks until the server has shut down (currently blocks forever). */
+  public synchronized void join() {
+    join(nativeHandle);
+  }
+
+  @Override
+  public void close() {
+    delete(nativeHandle);
+
+    nativeHandle = 0;
+  }
+
+  private static native long allocate(byte[] serverDef);
+
+  private static native void start(long nativeHandle);
+
+  private static native void stop(long nativeHandle);
+
+  private static native void join(long nativeHandle);
+
+  private static native void delete(long nativeHandle);
+
+  private long nativeHandle;
+
+  static {
+    TensorFlow.init();
+  }
+}

--- a/tensorflow/java/src/main/java/org/tensorflow/Server.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Server.java
@@ -15,26 +15,52 @@ limitations under the License.
 
 package org.tensorflow;
 
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 /**
  * An in-process TensorFlow server, for use in distributed training.
  *
- * A {@code tf.train.Server} instance encapsulates a set of devices and a
- * {@code tf.Session} target that can participate in distributed training. A
- * server belongs to a cluster (specified by a {@code tf.train.ClusterSpec}),
- * and corresponds to a particular task in a named job. The server can
- * communicate with any other server in the same cluster.
+ * A {@code Server} instance encapsulates a set of devices and a
+ * {@link org.tensorflow.Session} target that can participate in distributed
+ * training. A server belongs to a cluster (specified by a
+ * {@code ClusterSpec}), and corresponds to a particular task in a named job.
+ * The server can communicate with any other server in the same cluster.
  *
- * <p><b>WARNING:</b>A {@code Server} owns resources that <b>must</b> be
+ * <p><b>WARNING:</b> A {@code Server} owns resources that <b>must</b> be
  * explicitly freed by invoking {@link #close()}.
  *
  * <p>Instances of a {@code Server} are thread-safe.
+ *
+ * <p>Using example:
+ * <pre>
+ * {@code
+ * ClusterDef clusterDef = ClusterDef.newBuilder()
+ *   .addJob(JobDef.newBuilder()
+ *   .setName("worker")
+ *   .putTasks(0, "localhost:4321")
+ *   .build()
+ * ).build();
+ *
+ * ServerDef serverDef = ServerDef.newBuilder()
+ *   .setCluster(clusterDef)
+ *   .setJobName("worker")
+ *   .setTaskIndex(0)
+ *   .setProtocol("grpc")
+ * .build();
+ *
+ * try (Server srv = new Server(serverDef.toByteArray())) {
+ *   srv.start();
+ *   srv.join();
+ * }
+ * }
+ * </pre>
  */
 public final class Server implements AutoCloseable {
 
   /** 
    * Constructs a new instance of server. 
    *
-   * @param config Server definition specified as a serialized
+   * @param serverDef Server definition specified as a serialized
    *        <a href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/protobuf/tensorflow_server.proto">ServerDef</a>
    *        protocol buffer.
    */
@@ -43,25 +69,49 @@ public final class Server implements AutoCloseable {
   }
 
   /** Starts this server. */
-  public synchronized void start() {
-    start(nativeHandle);
+  public void start() {
+    lock.readLock().lock();
+    try {
+      start(nativeHandle);
+    }
+    finally {
+      lock.readLock().unlock();
+    }
   }
 
   /** Stops this server. */
-  public synchronized void stop() {
-    stop(nativeHandle);
+  public void stop() {
+    lock.readLock().lock();
+    try {
+      stop(nativeHandle);
+    }
+    finally {
+      lock.readLock().unlock();
+    }
   }
 
   /** Blocks until the server has shut down (currently blocks forever). */
-  public synchronized void join() {
-    join(nativeHandle);
+  public void join() {
+    lock.readLock().lock();
+    try {
+      join(nativeHandle);
+    }
+    finally {
+      lock.readLock().unlock();
+    }
   }
 
+  /** Stops server and frees resources. Server is expected to be stopped before. */
   @Override
   public void close() {
-    delete(nativeHandle);
-
-    nativeHandle = 0;
+    lock.writeLock().lock();
+    try {
+      delete(nativeHandle);
+      nativeHandle = 0;
+    }
+    finally {
+      lock.writeLock().unlock();
+    }
   }
 
   private static native long allocate(byte[] serverDef);
@@ -73,6 +123,8 @@ public final class Server implements AutoCloseable {
   private static native void join(long nativeHandle);
 
   private static native void delete(long nativeHandle);
+
+  private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
   private long nativeHandle;
 

--- a/tensorflow/java/src/main/java/org/tensorflow/Server.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Server.java
@@ -25,6 +25,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * training. A server belongs to a cluster (specified by a
  * {@code ClusterSpec}), and corresponds to a particular task in a named job.
  * The server can communicate with any other server in the same cluster.
+ * The server will not serve any requests until {@link #start()} is invoked. 
+ * The server will stop serving requests once {@link #stop()} or {@link #close()} is invoked.
+ * Be aware that {@link #close()} method stops the server if it is running.
  *
  * <p><b>WARNING:</b> A {@code Server} owns resources that <b>must</b> be
  * explicitly freed by invoking {@link #close()}.
@@ -32,8 +35,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * <p>Instances of a {@code Server} are thread-safe.
  *
  * <p>Using example:
- * <pre>
- * {@code
+ * <pre>{@code
  * ClusterDef clusterDef = ClusterDef.newBuilder()
  *   .addJob(JobDef.newBuilder()
  *   .setName("worker")
@@ -52,8 +54,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *   srv.start();
  *   srv.join();
  * }
- * }
- * </pre>
+ * }</pre>
  */
 public final class Server implements AutoCloseable {
 
@@ -68,7 +69,7 @@ public final class Server implements AutoCloseable {
     nativeHandle = allocate(serverDef);
   }
 
-  /** Starts this server. */
+  /** Starts an in-process TensorFlow server. */
   public void start() {
     lock.readLock().lock();
     try {
@@ -79,7 +80,7 @@ public final class Server implements AutoCloseable {
     }
   }
 
-  /** Stops this server. */
+  /**  Stops an in-process TensorFlow server. */
   public void stop() {
     lock.readLock().lock();
     try {
@@ -90,7 +91,7 @@ public final class Server implements AutoCloseable {
     }
   }
 
-  /** Blocks until the server has shut down (currently blocks forever). */
+  /** Blocks until the server has been successfully stopped. */
   public void join() {
     lock.readLock().lock();
     try {
@@ -101,7 +102,7 @@ public final class Server implements AutoCloseable {
     }
   }
 
-  /** Stops server and frees resources. Server is expected to be stopped before. */
+  /** Destroy an in-process TensorFlow server, frees memory. */
   @Override
   public void close() {
     lock.writeLock().lock();

--- a/tensorflow/java/src/main/native/BUILD
+++ b/tensorflow/java/src/main/native/BUILD
@@ -43,7 +43,6 @@ tf_cuda_library(
             "//tensorflow/core:all_kernels",
             "//tensorflow/core:direct_session",
             "//tensorflow/core:ops",
-            "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib",
         ],
     }),
     alwayslink = 1,

--- a/tensorflow/java/src/main/native/BUILD
+++ b/tensorflow/java/src/main/native/BUILD
@@ -43,6 +43,7 @@ tf_cuda_library(
             "//tensorflow/core:all_kernels",
             "//tensorflow/core:direct_session",
             "//tensorflow/core:ops",
+            "//tensorflow/core/distributed_runtime/rpc:grpc_server_lib",
         ],
     }),
     alwayslink = 1,

--- a/tensorflow/java/src/main/native/server_jni.cc
+++ b/tensorflow/java/src/main/native/server_jni.cc
@@ -29,44 +29,76 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Server_allocate(
       status);
 
   env->ReleaseByteArrayElements(server_def, server_def_ptr, JNI_ABORT);
-  throwExceptionIfNotOK(env, status);
+  bool ok = throwExceptionIfNotOK(env, status);
 
-  return reinterpret_cast<jlong>(server);
+  TF_DeleteStatus(status);
+
+  return ok ? reinterpret_cast<jlong>(server) : 0;
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
                                                         jclass clazz,
                                                         jlong handle) {
+  if (handle == 0) {
+    throwException(env, kIllegalStateException,
+                   "close() has been called on the Server");
+    return;
+  }
+
   TF_Status* status = TF_NewStatus();
   TF_Server* server = reinterpret_cast<TF_Server*>(handle);
 
-  TF_StartServer(server, status);
+  TF_ServerStart(server, status);
   throwExceptionIfNotOK(env, status);
+
+  TF_DeleteStatus(status);
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
+  if (handle == 0) {
+    throwException(env, kIllegalStateException,
+                   "close() has been called on the Server");
+    return;
+  }
+
   TF_Status* status = TF_NewStatus();
   TF_Server* server = reinterpret_cast<TF_Server*>(handle);
 
-  TF_StopServer(server, status);
+  TF_ServerStop(server, status);
   throwExceptionIfNotOK(env, status);
+
+  TF_DeleteStatus(status);
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
+  if (handle == 0) {
+    throwException(env, kIllegalStateException,
+                   "close() has been called on the Server");
+    return;
+  }
+
   TF_Status* status = TF_NewStatus();
   TF_Server* server = reinterpret_cast<TF_Server*>(handle);
 
-  TF_JoinServer(server, status);
+  TF_ServerJoin(server, status);
   throwExceptionIfNotOK(env, status);
+
+  TF_DeleteStatus(status);
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_delete(JNIEnv* env,
                                                          jclass clazz,
                                                          jlong handle) {
+  if (handle == 0) {
+    throwException(env, kIllegalStateException,
+                   "close() has been called on the Server");
+    return;
+  }
+  
   TF_Server* server = reinterpret_cast<TF_Server*>(handle);
 
   TF_DeleteServer(server);

--- a/tensorflow/java/src/main/native/server_jni.cc
+++ b/tensorflow/java/src/main/native/server_jni.cc
@@ -63,9 +63,8 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
                                                         jclass clazz,
                                                         jlong handle) {
 #ifdef __ANDROID__
-    throwException(env, kUnsupportedOperationException,
-                   "Server is not supported on Android");
-  return 0;
+  throwException(env, kUnsupportedOperationException,
+                 "Server is not supported on Android");
 #else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
@@ -85,7 +84,6 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
 #ifdef __ANDROID__
   throwException(env, kUnsupportedOperationException,
                  "Server is not supported on Android");
-  return 0;
 #else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
@@ -105,7 +103,6 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
 #ifdef __ANDROID__
   throwException(env, kUnsupportedOperationException,
                  "Server is not supported on Android");
-  return 0;
 #else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
@@ -122,8 +119,13 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_delete(JNIEnv* env,
                                                          jclass clazz,
                                                          jlong handle) {
+#ifdef __ANDROID__
+  throwException(env, kUnsupportedOperationException,
+                 "Server is not supported on Android");
+#else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
 
   TF_DeleteServer(server);
+#endif  // __ANDROID__
 }

--- a/tensorflow/java/src/main/native/server_jni.cc
+++ b/tensorflow/java/src/main/native/server_jni.cc
@@ -18,6 +18,21 @@ limitations under the License.
 #include "tensorflow/java/src/main/native/exception_jni.h"
 #include "tensorflow/java/src/main/native/utils_jni.h"
 
+namespace {
+TF_Server* requireHandle(JNIEnv* env, jlong handle) {
+  static_assert(sizeof(jlong) >= sizeof(TF_Server*),
+                "Cannot package C object pointers as a Java long");
+  if (handle == 0) {
+    throwException(env, kIllegalStateException,
+                   "close() has been called on the Server");
+    return nullptr;
+  }
+
+  return reinterpret_cast<TF_Server*>(handle);
+}
+
+}  // namespace
+
 JNIEXPORT jlong JNICALL Java_org_tensorflow_Server_allocate(
     JNIEnv* env, jclass clazz, jbyteArray server_def) {
   TF_Status* status = TF_NewStatus();
@@ -39,14 +54,9 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Server_allocate(
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
                                                         jclass clazz,
                                                         jlong handle) {
-  if (handle == 0) {
-    throwException(env, kIllegalStateException,
-                   "close() has been called on the Server");
-    return;
-  }
-
   TF_Status* status = TF_NewStatus();
-  TF_Server* server = reinterpret_cast<TF_Server*>(handle);
+  TF_Server* server = requireHandle(env, handle);
+  if (server == nullptr) return;
 
   TF_ServerStart(server, status);
   throwExceptionIfNotOK(env, status);
@@ -57,14 +67,9 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
-  if (handle == 0) {
-    throwException(env, kIllegalStateException,
-                   "close() has been called on the Server");
-    return;
-  }
-
   TF_Status* status = TF_NewStatus();
-  TF_Server* server = reinterpret_cast<TF_Server*>(handle);
+  TF_Server* server = requireHandle(env, handle);
+  if (server == nullptr) return;
 
   TF_ServerStop(server, status);
   throwExceptionIfNotOK(env, status);
@@ -75,14 +80,9 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
-  if (handle == 0) {
-    throwException(env, kIllegalStateException,
-                   "close() has been called on the Server");
-    return;
-  }
-
   TF_Status* status = TF_NewStatus();
-  TF_Server* server = reinterpret_cast<TF_Server*>(handle);
+  TF_Server* server = requireHandle(env, handle);
+  if (server == nullptr) return;
 
   TF_ServerJoin(server, status);
   throwExceptionIfNotOK(env, status);
@@ -93,13 +93,8 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_delete(JNIEnv* env,
                                                          jclass clazz,
                                                          jlong handle) {
-  if (handle == 0) {
-    throwException(env, kIllegalStateException,
-                   "close() has been called on the Server");
-    return;
-  }
-  
-  TF_Server* server = reinterpret_cast<TF_Server*>(handle);
+  TF_Server* server = requireHandle(env, handle);
+  if (server == nullptr) return;
 
   TF_DeleteServer(server);
 }

--- a/tensorflow/java/src/main/native/server_jni.cc
+++ b/tensorflow/java/src/main/native/server_jni.cc
@@ -1,0 +1,73 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/java/src/main/native/server_jni.h"
+#include "tensorflow/c/c_api.h"
+#include "tensorflow/java/src/main/native/exception_jni.h"
+#include "tensorflow/java/src/main/native/utils_jni.h"
+
+JNIEXPORT jlong JNICALL Java_org_tensorflow_Server_allocate(
+    JNIEnv* env, jclass clazz, jbyteArray server_def) {
+  TF_Status* status = TF_NewStatus();
+
+  jbyte* server_def_ptr = env->GetByteArrayElements(server_def, nullptr);
+
+  TF_Server* server = TF_NewServer(
+      server_def_ptr, static_cast<size_t>(env->GetArrayLength(server_def)),
+      status);
+
+  env->ReleaseByteArrayElements(server_def, server_def_ptr, JNI_ABORT);
+  throwExceptionIfNotOK(env, status);
+
+  return reinterpret_cast<jlong>(server);
+}
+
+JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
+                                                        jclass clazz,
+                                                        jlong handle) {
+  TF_Status* status = TF_NewStatus();
+  TF_Server* server = reinterpret_cast<TF_Server*>(handle);
+
+  TF_StartServer(server, status);
+  throwExceptionIfNotOK(env, status);
+}
+
+JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
+                                                       jclass clazz,
+                                                       jlong handle) {
+  TF_Status* status = TF_NewStatus();
+  TF_Server* server = reinterpret_cast<TF_Server*>(handle);
+
+  TF_StopServer(server, status);
+  throwExceptionIfNotOK(env, status);
+}
+
+JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
+                                                       jclass clazz,
+                                                       jlong handle) {
+  TF_Status* status = TF_NewStatus();
+  TF_Server* server = reinterpret_cast<TF_Server*>(handle);
+
+  TF_JoinServer(server, status);
+  throwExceptionIfNotOK(env, status);
+}
+
+JNIEXPORT void JNICALL Java_org_tensorflow_Server_delete(JNIEnv* env,
+                                                         jclass clazz,
+                                                         jlong handle) {
+  TF_Server* server = reinterpret_cast<TF_Server*>(handle);
+
+  TF_DeleteServer(server);
+}

--- a/tensorflow/java/src/main/native/server_jni.cc
+++ b/tensorflow/java/src/main/native/server_jni.cc
@@ -19,7 +19,7 @@ limitations under the License.
 #include "tensorflow/java/src/main/native/utils_jni.h"
 
 namespace {
-#ifndef __ANDROID__
+
 TF_Server* requireHandle(JNIEnv* env, jlong handle) {
   static_assert(sizeof(jlong) >= sizeof(TF_Server*),
                 "Cannot package C object pointers as a Java long");
@@ -31,17 +31,11 @@ TF_Server* requireHandle(JNIEnv* env, jlong handle) {
 
   return reinterpret_cast<TF_Server*>(handle);
 }
-#endif  // __ANDROID__
 
 }  // namespace
 
 JNIEXPORT jlong JNICALL Java_org_tensorflow_Server_allocate(
     JNIEnv* env, jclass clazz, jbyteArray server_def) {
-#ifdef __ANDROID__
-  throwException(env, kUnsupportedOperationException,
-                 "Server is not supported on Android");
-  return 0;
-#else
   TF_Status* status = TF_NewStatus();
 
   jbyte* server_def_ptr = env->GetByteArrayElements(server_def, nullptr);
@@ -56,16 +50,11 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Server_allocate(
   TF_DeleteStatus(status);
 
   return ok ? reinterpret_cast<jlong>(server) : 0;
-#endif  // __ANDROID__
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
                                                         jclass clazz,
                                                         jlong handle) {
-#ifdef __ANDROID__
-  throwException(env, kUnsupportedOperationException,
-                 "Server is not supported on Android");
-#else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
 
@@ -75,16 +64,11 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
   throwExceptionIfNotOK(env, status);
 
   TF_DeleteStatus(status);
-#endif  // __ANDROID__
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
-#ifdef __ANDROID__
-  throwException(env, kUnsupportedOperationException,
-                 "Server is not supported on Android");
-#else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
 
@@ -94,16 +78,11 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
   throwExceptionIfNotOK(env, status);
 
   TF_DeleteStatus(status);
-#endif  // __ANDROID__
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
-#ifdef __ANDROID__
-  throwException(env, kUnsupportedOperationException,
-                 "Server is not supported on Android");
-#else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
 
@@ -113,19 +92,13 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
   throwExceptionIfNotOK(env, status);
 
   TF_DeleteStatus(status);
-#endif  // __ANDROID__
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_delete(JNIEnv* env,
                                                          jclass clazz,
                                                          jlong handle) {
-#ifdef __ANDROID__
-  throwException(env, kUnsupportedOperationException,
-                 "Server is not supported on Android");
-#else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
 
   TF_DeleteServer(server);
-#endif  // __ANDROID__
 }

--- a/tensorflow/java/src/main/native/server_jni.cc
+++ b/tensorflow/java/src/main/native/server_jni.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/java/src/main/native/utils_jni.h"
 
 namespace {
+#ifndef __ANDROID__
 TF_Server* requireHandle(JNIEnv* env, jlong handle) {
   static_assert(sizeof(jlong) >= sizeof(TF_Server*),
                 "Cannot package C object pointers as a Java long");
@@ -30,11 +31,17 @@ TF_Server* requireHandle(JNIEnv* env, jlong handle) {
 
   return reinterpret_cast<TF_Server*>(handle);
 }
+#endif  // __ANDROID__
 
 }  // namespace
 
 JNIEXPORT jlong JNICALL Java_org_tensorflow_Server_allocate(
     JNIEnv* env, jclass clazz, jbyteArray server_def) {
+#ifdef __ANDROID__
+  throwException(env, kUnsupportedOperationException,
+                 "Server is not supported on Android");
+  return 0;
+#else
   TF_Status* status = TF_NewStatus();
 
   jbyte* server_def_ptr = env->GetByteArrayElements(server_def, nullptr);
@@ -49,11 +56,17 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Server_allocate(
   TF_DeleteStatus(status);
 
   return ok ? reinterpret_cast<jlong>(server) : 0;
+#endif  // __ANDROID__
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
                                                         jclass clazz,
                                                         jlong handle) {
+#ifdef __ANDROID__
+    throwException(env, kUnsupportedOperationException,
+                   "Server is not supported on Android");
+  return 0;
+#else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
 
@@ -63,11 +76,17 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
   throwExceptionIfNotOK(env, status);
 
   TF_DeleteStatus(status);
+#endif  // __ANDROID__
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
+#ifdef __ANDROID__
+  throwException(env, kUnsupportedOperationException,
+                 "Server is not supported on Android");
+  return 0;
+#else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
 
@@ -77,11 +96,17 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
   throwExceptionIfNotOK(env, status);
 
   TF_DeleteStatus(status);
+#endif  // __ANDROID__
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
+#ifdef __ANDROID__
+  throwException(env, kUnsupportedOperationException,
+                 "Server is not supported on Android");
+  return 0;
+#else
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
 
@@ -91,6 +116,7 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
   throwExceptionIfNotOK(env, status);
 
   TF_DeleteStatus(status);
+#endif  // __ANDROID__
 }
 
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_delete(JNIEnv* env,

--- a/tensorflow/java/src/main/native/server_jni.cc
+++ b/tensorflow/java/src/main/native/server_jni.cc
@@ -54,9 +54,10 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Server_allocate(
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
                                                         jclass clazz,
                                                         jlong handle) {
-  TF_Status* status = TF_NewStatus();
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
+
+  TF_Status* status = TF_NewStatus();
 
   TF_ServerStart(server, status);
   throwExceptionIfNotOK(env, status);
@@ -67,9 +68,10 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv* env,
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
-  TF_Status* status = TF_NewStatus();
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
+
+  TF_Status* status = TF_NewStatus();
 
   TF_ServerStop(server, status);
   throwExceptionIfNotOK(env, status);
@@ -80,9 +82,10 @@ JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv* env,
 JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv* env,
                                                        jclass clazz,
                                                        jlong handle) {
-  TF_Status* status = TF_NewStatus();
   TF_Server* server = requireHandle(env, handle);
   if (server == nullptr) return;
+
+  TF_Status* status = TF_NewStatus();
 
   TF_ServerJoin(server, status);
   throwExceptionIfNotOK(env, status);

--- a/tensorflow/java/src/main/native/server_jni.h
+++ b/tensorflow/java/src/main/native/server_jni.h
@@ -1,0 +1,66 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_JAVA_SRC_MAIN_NATIVE_SERVER_JNI_H_
+#define TENSORFLOW_JAVA_SRC_MAIN_NATIVE_SERVER_JNI_H_
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Class:     org_tensorflow_Server
+ * Method:    allocate
+ * Signature: ([B)J
+ */
+JNIEXPORT jlong JNICALL
+Java_org_tensorflow_Server_allocate(JNIEnv *, jclass, jbyteArray server_def);
+
+/*
+ * Class:     org_tensorflow_Server
+ * Method:    start
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_tensorflow_Server_start(JNIEnv *, jclass,
+                                                        jlong);
+
+/*
+ * Class:     org_tensorflow_Server
+ * Method:    stop
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_tensorflow_Server_stop(JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_tensorflow_Session
+ * Method:    join
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_tensorflow_Server_join(JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_tensorflow_Session
+ * Method:    delete
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_tensorflow_Server_delete(JNIEnv *, jclass,
+                                                         jlong);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  // TENSORFLOW_JAVA_SRC_MAIN_NATIVE_SERVER_JNI_H_

--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -193,6 +193,9 @@ genrule(
         "@protobuf_archive//:LICENSE",
         "@snappy//:COPYING",
         "@zlib_archive//:zlib.h",
+        "@grpc//:LICENSE",
+        "@grpc//third_party/address_sorting:LICENSE",
+        "@grpc//third_party/nanopb:LICENSE.txt",
     ] + select({
         "//tensorflow/core/kernels:xsmm": [
             "@libxsmm_archive//:LICENSE.md",


### PR DESCRIPTION
[Standalone Client Mode](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/distribute/README.md#standalone-client-mode) allows to easily train model utilizing distributed resources. Only one thing we need to do that is to start TensorFlow server on every cluster node we'd like to participate in training. Because of that it's very important to have an ability to start TensorFlow server in different ways and from any environment. I prepared this request as result of [discussion on Development List](https://groups.google.com/a/tensorflow.org/forum/#!topic/developers/TVtFC94bC8k).

The following example demonstrates how to use TensorFlow server in Java:
```java
ClusterDef clusterDef = ClusterDef.newBuilder()
  .addJob(JobDef.newBuilder()
  .setName("worker")
  .putTasks(0, "localhost:4321")
  .build()
).build();

ServerDef serverDef = ServerDef.newBuilder()
  .setCluster(clusterDef)
  .setJobName("worker")
  .setTaskIndex(0)
  .setProtocol("grpc")
  .build();

Server server = new Server(serverDef.toByteArray());
server.start();
server.join();
```

Please, feel free to comment and suggest changes.