### PR TITLE
Make shared S3 file system lib linkable

### DIFF
--- a/tensorflow/core/platform/s3/BUILD
+++ b/tensorflow/core/platform/s3/BUILD
@@ -14,7 +14,7 @@ load(
 )
 
 tf_cc_binary(
-    name = "s3_file_system.so",
+    name = "libs3_file_system_shared.so",
     srcs = [
         "aws_crypto.cc",
         "aws_crypto.h",


### PR DESCRIPTION
My (and I think most) linkers expect shared object files to start with `lib`, so using the target `s3_file_system.so` resulted in an error along the lines of `error: cannot find -ls3_file_system`, because this target creates a file named `s3_file_system.so` as opposed to `libs3_file_system.so`.

Just prefixing the name with `lib` would have caused the output to collide with the output of `s3_file_system`, so I also appended `_shared` before `.so`.

Adding this line: `cc_binary(name = "test", srcs = [":s3_file_system.so"])` in the same `BUILD` file is enough to demonstrate the linker error for me, although it also complains about an undefined reference to `main`. Adding a trivial main file (`int main() { return 0; }`) gets rid of this but preserves the linker error for a more minimal (in some ways) reproduction