### PR TITLE
fix keras ReLU layer bug

### DIFF
--- a/tensorflow/python/keras/layers/advanced_activations.py
+++ b/tensorflow/python/keras/layers/advanced_activations.py
@@ -306,6 +306,13 @@ class ReLU(Layer):
 
   def __init__(self, max_value=None, negative_slope=0, threshold=0, **kwargs):
     super(ReLU, self).__init__(**kwargs)
+    if isinstance(max_value, dict):
+        max_value = max_value['value']
+    if isinstance(negative_slope, dict):
+        negative_slope = negative_slope['value']
+    if isinstance(threshold, dict):
+        threshold = threshold['value']
+
     if max_value is not None and max_value < 0.:
       raise ValueError('max_value of Relu layer '
                        'cannot be negative value: ' + str(max_value))


### PR DESCRIPTION
In `tf.keras.layers.ReLU` function, the config of arguments(max_value, negative_slope, threshold) become dict but float is the need while `tf.keras.models.load_model` or `tf.contrib.lite.TocoConverter.from_keras_model_file`

**network structure**
```python3
inputs = Input(shape=(32, 32, 3))
x = Conv2D(32, 3, strides=1, padding='same')(inputs)
x = ReLU()(x)
x = Conv2D(64, 3, strides=2, padding='valid')(x)
x = ReLU()(x)
x = Conv2D(64, 3, strides=2, padding='valid')(x)
x = ReLU()(x)
...
```
**save model** 
`tf.keras.models.save_model(model, 'model.h5')`

**load model** (error occurred)
`tf.keras.models.load_model('model.h5')`

**error message**
TypeError: '<' not supported between instances of 'dict' and 'float' 
