### PR TITLE
Update the tests and benchmark for tf.data.Dataset.list_files

### DIFF
--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -164,6 +164,7 @@ tf_py_test(
     srcs = ["list_files_dataset_op_test.py"],
     additional_deps = [
         ":test_base",
+        "//third_party/py/numpy",
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:dtypes",

--- a/tensorflow/python/data/kernel_tests/list_files_dataset_op_test.py
+++ b/tensorflow/python/data/kernel_tests/list_files_dataset_op_test.py
@@ -19,13 +19,19 @@ from __future__ import division
 from __future__ import print_function
 
 from os import path
+from os import makedirs
 import shutil
 import tempfile
+import time
 
+import numpy as np
+
+from tensorflow.python.client import session
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
+from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.platform import test
 from tensorflow.python.util import compat
@@ -60,13 +66,13 @@ class ListFilesDatasetOpTest(test_base.DatasetTestBase):
       itr = dataset.make_one_shot_iterator()
       next_element = itr.get_next()
 
-      full_filenames = []
-      produced_filenames = []
+      expected_filenames = []
+      actual_filenames = []
       for filename in filenames:
-        full_filenames.append(
+        expected_filenames.append(
             compat.as_bytes(path.join(self.tmp_dir, filename)))
-        produced_filenames.append(compat.as_bytes(sess.run(next_element)))
-      self.assertItemsEqual(full_filenames, produced_filenames)
+        actual_filenames.append(compat.as_bytes(sess.run(next_element)))
+      self.assertItemsEqual(expected_filenames, actual_filenames)
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(itr.get_next())
 
@@ -96,27 +102,27 @@ class ListFilesDatasetOpTest(test_base.DatasetTestBase):
       itr = dataset.make_initializable_iterator()
       next_element = itr.get_next()
 
-      full_filenames = [compat.as_bytes(path.join(self.tmp_dir, filename))
-                        for filename in filenames]
+      expected_filenames = [compat.as_bytes(path.join(self.tmp_dir, filename))
+                            for filename in filenames]
 
-      all_produced_filenames = []
+      all_actual_filenames = []
       for _ in range(3):
-        produced_filenames = []
+        actual_filenames = []
         sess.run(itr.initializer)
         try:
           while True:
-            produced_filenames.append(sess.run(next_element))
+            actual_filenames.append(sess.run(next_element))
         except errors.OutOfRangeError:
           pass
-        all_produced_filenames.append(produced_filenames)
+        all_actual_filenames.append(actual_filenames)
 
       # Each run should produce the same set of filenames, which may be
-      # different from the order of `full_filenames`.
-      self.assertItemsEqual(full_filenames, all_produced_filenames[0])
+      # different from the order of `expected_filenames`.
+      self.assertItemsEqual(expected_filenames, all_actual_filenames[0])
       # However, the different runs should produce filenames in the same order
       # as each other.
-      self.assertEqual(all_produced_filenames[0], all_produced_filenames[1])
-      self.assertEqual(all_produced_filenames[0], all_produced_filenames[2])
+      self.assertEqual(all_actual_filenames[0], all_actual_filenames[1])
+      self.assertEqual(all_actual_filenames[0], all_actual_filenames[2])
 
   def testEmptyDirectoryInitializer(self):
     filename_placeholder = array_ops.placeholder(dtypes.string, shape=[])
@@ -144,14 +150,14 @@ class ListFilesDatasetOpTest(test_base.DatasetTestBase):
           itr.initializer,
           feed_dict={filename_placeholder: path.join(self.tmp_dir, '*')})
 
-      full_filenames = []
-      produced_filenames = []
+      expected_filenames = []
+      actual_filenames = []
       for filename in filenames:
-        full_filenames.append(
+        expected_filenames.append(
             compat.as_bytes(path.join(self.tmp_dir, filename)))
-        produced_filenames.append(compat.as_bytes(sess.run(next_element)))
+        actual_filenames.append(compat.as_bytes(sess.run(next_element)))
 
-      self.assertItemsEqual(full_filenames, produced_filenames)
+      self.assertItemsEqual(expected_filenames, actual_filenames)
 
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(itr.get_next())
@@ -170,13 +176,13 @@ class ListFilesDatasetOpTest(test_base.DatasetTestBase):
           itr.initializer,
           feed_dict={filename_placeholder: path.join(self.tmp_dir, '*.py')})
 
-      full_filenames = []
-      produced_filenames = []
+      expected_filenames = []
+      actual_filenames = []
       for filename in filenames[1:-1]:
-        full_filenames.append(
+        expected_filenames.append(
             compat.as_bytes(path.join(self.tmp_dir, filename)))
-        produced_filenames.append(compat.as_bytes(sess.run(next_element)))
-      self.assertItemsEqual(full_filenames, produced_filenames)
+        actual_filenames.append(compat.as_bytes(sess.run(next_element)))
+      self.assertItemsEqual(expected_filenames, actual_filenames)
 
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(itr.get_next())
@@ -195,14 +201,14 @@ class ListFilesDatasetOpTest(test_base.DatasetTestBase):
           itr.initializer,
           feed_dict={filename_placeholder: path.join(self.tmp_dir, '*.py*')})
 
-      full_filenames = []
-      produced_filenames = []
+      expected_filenames = []
+      actual_filenames = []
       for filename in filenames[1:]:
-        full_filenames.append(
+        expected_filenames.append(
             compat.as_bytes(path.join(self.tmp_dir, filename)))
-        produced_filenames.append(compat.as_bytes(sess.run(next_element)))
+        actual_filenames.append(compat.as_bytes(sess.run(next_element)))
 
-      self.assertItemsEqual(full_filenames, produced_filenames)
+      self.assertItemsEqual(expected_filenames, actual_filenames)
 
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(itr.get_next())
@@ -226,17 +232,81 @@ class ListFilesDatasetOpTest(test_base.DatasetTestBase):
       itr = dataset.make_one_shot_iterator()
       next_element = itr.get_next()
 
-      full_filenames = []
-      produced_filenames = []
+      expected_filenames = []
+      actual_filenames = []
       for filename in filenames * 2:
-        full_filenames.append(
+        expected_filenames.append(
             compat.as_bytes(path.join(self.tmp_dir, filename)))
-        produced_filenames.append(compat.as_bytes(sess.run(next_element)))
+        actual_filenames.append(compat.as_bytes(sess.run(next_element)))
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(itr.get_next())
-      self.assertItemsEqual(full_filenames, produced_filenames)
-      self.assertEqual(produced_filenames[:len(filenames)],
-                       produced_filenames[len(filenames):])
+      self.assertItemsEqual(expected_filenames, actual_filenames)
+      self.assertEqual(actual_filenames[:len(filenames)],
+                       actual_filenames[len(filenames):])
+
+
+class ListFilesDatasetBenchmark(test.Benchmark):
+
+  def benchmarkNestedDirectories(self):
+    tmp_dir = tempfile.mkdtemp()
+    width = 1024
+    depth = 16
+    for i in range(width):
+      for j in range(depth):
+        new_base = path.join(tmp_dir, str(i),
+                             *[str(dir_name) for dir_name in range(j)])
+        makedirs(new_base)
+        child_files = ['a.py', 'b.pyc'] if j < depth - 1 else ['c.txt', 'd.log']
+        for f in child_files:
+          filename = path.join(new_base, f)
+          open(filename, 'w').close()
+
+    patterns = [
+        path.join(tmp_dir, path.join(*['**' for _ in range(depth)]), suffix)
+        for suffix in ['*.txt', '*.log']
+    ]
+
+    deltas = []
+    iters = 3
+    for _ in range(iters):
+      with ops.Graph().as_default():
+        dataset = dataset_ops.Dataset.list_files(patterns)
+        next_element = dataset.make_one_shot_iterator().get_next()
+
+        with session.Session() as sess:
+          sub_deltas = []
+          while True:
+            try:
+              start = time.time()
+              sess.run(next_element)
+              end = time.time()
+              sub_deltas.append(end - start)
+            except errors.OutOfRangeError:
+              break
+          deltas.append(sub_deltas)
+
+    median_deltas = np.median(deltas, axis=0)
+    print('Nested directory size (width*depth): %d*%d Median wall time: '
+          '%fs (read first filename), %fs (read second filename), avg %fs'
+          ' (read %d more filenames)' %
+          (width, depth, median_deltas[0], median_deltas[1],
+           np.average(median_deltas[2:]), len(median_deltas) - 2))
+    self.report_benchmark(
+        iters=iters,
+        wall_time=np.sum(median_deltas),
+        extras={
+            'read first file:':
+                median_deltas[0],
+            'read second file:':
+                median_deltas[1],
+            'avg time for reading %d more filenames:' %
+            (len(median_deltas) - 2):
+                np.average(median_deltas[2:])
+        },
+        name='benchmark_list_files_dataset_nesteddirectory(%d*%d)' %
+        (width, depth))
+
+    shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR uses [MatchingFilesDataset](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/data/ops/dataset_ops.py#L2702) to replace `matching_files` in  `tf.data.Dataset.list_files`. Besides, it adds a benchmarking test and changes some variable names to be more readable in the test file.

Here is the benchmarking results:

`list_files` with `matching_files`:
```
Nested directory size (width*depth): 1024*16 Median wall time: 10.502532s (read first filename), 0.000377s (read second filename), avg 0.000147s (read 2046 more filenames)
entry {
  name: "ListFilesDatasetBenchmark.benchmark_list_files_dataset_nesteddirectory(1024*16)"
  iters: 3
  wall_time: 10.803346157073975
  extras {
    key: "avg time for reading 2046 more filenames:"
    value {
      double_value: 0.00014684125708228565
    }
  }
  extras {
    key: "read first file:"
    value {
      double_value: 10.502532243728638
    }
  }
  extras {
    key: "read second file:"
    value {
      double_value: 0.00037670135498046875
    }
  }
}
```
`list_files` with `MatchingFilesDataset`:
```
Nested directory size (width*depth): 1024*16 Median wall time: 0.039578s (read first filename), 0.001617s (read second filename), avg 0.001562s (read 2046 more filenames)
entry {
  name: "ListFilesDatasetBenchmark.benchmark_list_files_dataset_nesteddirectory(1024*16)"
  iters: 3
  wall_time: 3.2369956970214844
  extras {
    key: "avg time for reading 2046 more filenames:"
    value {
      double_value: 0.0015619748498687297
    }
  }
  extras {
    key: "read first file:"
    value {
      double_value: 0.03957796096801758
    }
  }
  extras {
    key: "read second file:"
    value {
      double_value: 0.0016171932220458984
    }
  }
}
```
 