### PR TITLE
[Intel-Mkl] Redundant transpose removal: transpose(to "NHWC")+ conv2d(NHWC) + transpose(back to "NCHW") -> conv2d.

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -949,7 +949,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
             e->dst_input() == kPermTensorIndex) {
           // we find the "perm" node, now try to retrieve its value.
           const TensorProto* proto = nullptr;
-          CHECK_EQ(GetNodeAttr(perm_node->def(), "value", &proto).ok(), true);
+          DCHECK(GetNodeAttr(perm_node->def(), "value", &proto).ok());
 
           DataType type;
           GetNodeAttr(perm_node->def(), "dtype", &type);

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2700,7 +2700,7 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   for (const Edge* e : transpose_to_nchw->out_edges()) {
     if (!e->IsControlEdge()) {
       const int kTransposeWithMklOpOutputSlot = 0;
-      CHECK_NOTNULL((*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot,
+      DCHECK((*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot,
                                   e->dst(), e->dst_input()));
     }
   }

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2700,8 +2700,8 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   for (const Edge* e : transpose_to_nchw->out_edges()) {
     if (!e->IsControlEdge()) {
       const int kTransposeWithMklOpOutputSlot = 0;
-      DCHECK((*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot,
-                                  e->dst(), e->dst_input()));
+      DCHECK((*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot, e->dst(),
+                           e->dst_input()));
     }
   }
 

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2694,7 +2694,7 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   // Create node.
   Node* new_node;
   TF_CHECK_OK(nb.Finalize(&**g, &new_node));
-  CHECK_NOTNULL(new_node);
+  DCHECK(new_node);
 
   // Fill outputs.
   for (const Edge* e : transpose_to_nchw->out_edges()) {

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -592,7 +592,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     std::function<Node*(const Node*)> get_node_to_be_merged;
   } MergeInfo;
 
-  // structure to specify information used in node fusion of 2+ operators
+  // structure to specify information used in node fusion of 3+ operators
   typedef struct {
     std::string pattern_name;  // name to describe this pattern, such as
                                // "Transpose_Mklop_Transpose".

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2669,7 +2669,7 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
              &transpose_nchw_in);
 
   // We use same name as original node, but change the op
-  // name.
+  // type.
   NodeBuilder nb(mklop->name(), mklop->type_string());
 
   for (int i = 0; i < mklop_num_inputs; i++) {

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -22,12 +22,12 @@ limitations under the License.
 #include <memory>
 #include <queue>
 #include <set>
+#include <set>
+#include <stack>
 #include <tuple>
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <stack>
-#include <set>
 
 #include "tensorflow/core/common_runtime/function.h"
 #include "tensorflow/core/common_runtime/optimization_registry.h"
@@ -514,8 +514,10 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
                       csinfo_.conv2d_grad_filter_with_bias,
                       GetConv2DBackpropFilterOrBiasAddGrad});
 
-    // The fusion patterns in "finfo_" that show up first will get applied first,
-    // for example, graph "A->B->C-D" and finfo_ is {A->B->C to ABC, A->B->C->D to ABCD},
+    // The fusion patterns in "finfo_" that show up first will get applied
+    // first,
+    // for example, graph "A->B->C-D" and finfo_ is {A->B->C to ABC, A->B->C->D
+    // to ABCD},
     // since the first gets applied first, the final graph will be ABC->D.
 
     //
@@ -903,7 +905,8 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
   Status FuseNode(std::unique_ptr<Graph>* g, std::vector<Node*>& nodes,
                   const MklLayoutRewritePass::FusionInfo fi);
 
-  // Fuse tranpose(to "NHWC") + mklop("NHWC") + transpose(to "NCHW") into mklop("NCHW").
+  // Fuse tranpose(to "NHWC") + mklop("NHWC") + transpose(to "NCHW") into
+  // mklop("NCHW").
   // Here "mklop" can be any MKL-DNN supported op, such as Conv2D.
   static Status FuseTransposeMklOpTranspose(
       std::unique_ptr<Graph>* g, std::vector<Node*>& nodes,
@@ -919,8 +922,9 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
 
     // Check if has out control edge. If true, this is a training graph.
     // Currently we focus on inference and do no fusion in training.
-    // Note: this constraint will eventually be removed, if we enabled this fusion for training
-    // in the future. 
+    // Note: this constraint will eventually be removed, if we enabled this
+    // fusion for training
+    // in the future.
     for (const Edge* e : node->out_edges()) {
       if (e->IsControlEdge()) {
         return false;
@@ -1835,7 +1839,6 @@ void MklLayoutRewritePass::CopyAttrsConv(const Node* orig_node, NodeBuilder* nb,
 
       new_strides = {strides[NHWC::dim::N], strides[NHWC::dim::C],
                      strides[NHWC::dim::H], strides[NHWC::dim::W]};
-      
 
       new_dilations = {dilations[NHWC::dim::N], dilations[NHWC::dim::C],
                        dilations[NHWC::dim::H], dilations[NHWC::dim::W]};
@@ -2698,8 +2701,8 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   for (const Edge* e : transpose_to_nchw->out_edges()) {
     if (!e->IsControlEdge()) {
       const int kTransposeWithMklOpOutputSlot = 0;
-      CHECK_NOTNULL((*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot, e->dst(),
-                                  e->dst_input()));
+      CHECK_NOTNULL((*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot,
+                                  e->dst(), e->dst_input()));
     }
   }
 
@@ -2726,7 +2729,7 @@ Status MklLayoutRewritePass::FuseNode(
 std::tuple<bool, std::vector<Node*>, const MklLayoutRewritePass::FusionInfo>
 MklLayoutRewritePass::CheckForNodeFusion(Node* a) const {
   // Stores matched nodes, in the same order as node_checkers.
-  std::vector<Node *> nodes;
+  std::vector<Node*> nodes;
 
   for (auto fi = finfo_.begin(); fi != finfo_.end(); ++fi) {
     //
@@ -2743,7 +2746,7 @@ MklLayoutRewritePass::CheckForNodeFusion(Node* a) const {
     if (a != nullptr && (*node_checker)(a)) {
       nodes.push_back(a);
       current_neighbor_stack.push(a->out_edges().begin());
-      ++ node_checker;
+      ++node_checker;
     }
 
     while (!nodes.empty()) {
@@ -2772,7 +2775,7 @@ MklLayoutRewritePass::CheckForNodeFusion(Node* a) const {
     }
   }
 
-  return make_tuple(false, std::vector<Node *>(), FusionInfo());
+  return make_tuple(false, std::vector<Node*>(), FusionInfo());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2698,6 +2698,10 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   // Copy device assigned to old node to new node.
   new_node->set_assigned_device_name(mklop->assigned_device_name());
 
+  // Copy requested_device and assigned_device_name_index
+  new_node->set_requested_device(mklop->requested_device());
+  new_node->set_assigned_device_name_index(mklop->assigned_device_name_index());
+
   (*g)->RemoveNode(transpose_to_nhwc);
   (*g)->RemoveNode(mklop);
   (*g)->RemoveNode(transpose_to_nchw);

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -515,8 +515,9 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
                       GetConv2DBackpropFilterOrBiasAddGrad});
 
     // The fusion patterns in "finfo_" that show up first will get applied
-    // first, for example, graph "A->B->C-D" and finfo_ is {A->B->C to ABC, A->B->C->D
-    // to ABCD}, since the first gets applied first, the final graph will be ABC->D.
+    // first, for example, graph "A->B->C-D" and finfo_ is {A->B->C to ABC,
+    // A->B->C->D to ABCD}, since the first gets applied first, the final
+    // graph will be ABC->D.
 
     //
     // Add rules to fuse sequences such as "Transpose (NCHW -> NHWC) + Conv2D

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -514,6 +514,10 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
                       csinfo_.conv2d_grad_filter_with_bias,
                       GetConv2DBackpropFilterOrBiasAddGrad});
 
+    // The fusion patterns in "finfo_" that show up first will get applied first,
+    // for example, graph "A->B->C-D" and finfo_ is {A->B->C to ABC, A->B->C->D to ABCD},
+    // since the first gets applied first, the final graph will be ABC->D.
+
     //
     // Add rules to fuse sequences such as "Transpose (NCHW -> NHWC) + Conv2D
     // (NHWC) + Transpose (NHWC->

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -1821,8 +1821,6 @@ void MklLayoutRewritePass::CopyAttrsConv(const Node* orig_node, NodeBuilder* nb,
       new_dilations = {dilations[NDHWC::dim::N], dilations[NDHWC::dim::C],
                        dilations[NDHWC::dim::D], dilations[NDHWC::dim::H],
                        dilations[NDHWC::dim::W]};
-      nb->Attr("dilations", new_dilations);
-
     } else {
       // "strides" and "dilations" also need to be changed according to
       // "data_format",
@@ -1834,8 +1832,8 @@ void MklLayoutRewritePass::CopyAttrsConv(const Node* orig_node, NodeBuilder* nb,
 
       new_dilations = {dilations[NHWC::dim::N], dilations[NHWC::dim::C],
                        dilations[NHWC::dim::H], dilations[NHWC::dim::W]};
-      nb->Attr("dilations", new_dilations);
     }
+    nb->Attr("dilations", new_dilations);
   }
 }
 

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2735,7 +2735,7 @@ MklLayoutRewritePass::CheckForNodeFusion(Node* a) const {
     //
 
     std::stack<Node *, std::vector<Node *>> work_stack;
-    std::set<Node *> visited_nodes;
+    std::unordered_set<Node *> visited_nodes;
     auto node_checker = fi->node_checkers.begin();
 
     Node *current_node = nullptr;

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -1810,12 +1810,9 @@ void MklLayoutRewritePass::CopyAttrsConv(const Node* orig_node, NodeBuilder* nb,
     std::vector<int32> new_strides;
     std::vector<int32> new_dilations;
     if (strides.size() == 5) {
-      //
       // "strides" and "dilations" also need to be changed according to
       // "data_format",
       // in this case, is "NDHWC" to "NCDHW".
-      //
-
       new_strides = {strides[NDHWC::dim::N], strides[NDHWC::dim::C],
                      strides[NDHWC::dim::D], strides[NDHWC::dim::H],
                      strides[NDHWC::dim::W]};
@@ -1827,11 +1824,9 @@ void MklLayoutRewritePass::CopyAttrsConv(const Node* orig_node, NodeBuilder* nb,
       nb->Attr("dilations", new_dilations);
 
     } else {
-      //
       // "strides" and "dilations" also need to be changed according to
       // "data_format",
       // in this case, is "NHWC" to "NCHW".
-      //
 
       new_strides = {strides[NHWC::dim::N], strides[NHWC::dim::C],
                      strides[NHWC::dim::H], strides[NHWC::dim::W]};

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -955,7 +955,6 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
                                         tensor_content + tensor_content_size);
 
             return perm_value == perm;
-
           } else if (type == DT_INT64) {
             const int type_size = 8;
             const long* tensor_content =
@@ -969,12 +968,10 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
 
             return perm_value == long_perm;
           }
-
           return false;
         }
       }
     }
-
     return false;
   }
 

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -1820,7 +1820,6 @@ void MklLayoutRewritePass::CopyAttrsConv(const Node* orig_node, NodeBuilder* nb,
       new_strides = {strides[NDHWC::dim::N], strides[NDHWC::dim::C],
                      strides[NDHWC::dim::D], strides[NDHWC::dim::H],
                      strides[NDHWC::dim::W]};
-      nb->Attr("strides", new_strides);
 
       new_dilations = {dilations[NDHWC::dim::N], dilations[NDHWC::dim::C],
                        dilations[NDHWC::dim::D], dilations[NDHWC::dim::H],
@@ -1832,11 +1831,12 @@ void MklLayoutRewritePass::CopyAttrsConv(const Node* orig_node, NodeBuilder* nb,
 
       new_strides = {strides[NHWC::dim::N], strides[NHWC::dim::C],
                      strides[NHWC::dim::H], strides[NHWC::dim::W]};
-      nb->Attr("strides", new_strides);
+      
 
       new_dilations = {dilations[NHWC::dim::N], dilations[NHWC::dim::C],
                        dilations[NHWC::dim::H], dilations[NHWC::dim::W]};
     }
+    nb->Attr("strides", new_strides);
     nb->Attr("dilations", new_dilations);
   }
 }

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2664,8 +2664,7 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   FillInputs(transpose_to_nchw, &transpose_nchw_control_edges,
              &transpose_nchw_in);
 
-  // We will use the node name of Conv2d as the name of new node
-  // Build new node. We use same name as original node, but change the op
+  // We use same name as original node, but change the op
   // name.
   NodeBuilder nb(mklop->name(), mklop->type_string());
 

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2672,6 +2672,7 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   // type.
   NodeBuilder nb(mklop->name(), mklop->type_string());
 
+  // Storing the output slots of the input nodes.
   for (int i = 0; i < mklop_num_inputs; i++) {
     if (mklop_in[i].first == transpose_to_nhwc) {
       // Fill "x":

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -912,6 +912,8 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
 
     // Check if has out control edge. If true, this is a training graph.
     // Currently we focus on inference and do no fusion in training.
+    // Note: this constraint will eventually be removed, if we enabled this fusion for training
+    // in the future. 
     for (const Edge* e : node->out_edges()) {
       if (e->IsControlEdge()) {
         return false;

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2657,7 +2657,7 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   gtl::InlinedVector<Node*, 4> transpose_nchw_control_edges;
   gtl::InlinedVector<std::pair<Node*, int>, 4> transpose_nchw_in(
       transpose_nchw_num_inputs);
-  FillInputs(transpose_to_nchw, &transpose_nchw_control_edges,
+  FillInputs(transpose_to_nhwc, &transpose_nchw_control_edges,
              &transpose_nchw_in);
 
   // We will use the node name of Conv2d as the name of new node
@@ -2689,8 +2689,8 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   // Fill outputs.
   for (const Edge* e : transpose_to_nchw->out_edges()) {
     if (!e->IsControlEdge()) {
-      const int kConv2DWithBiasOutputSlot = 0;
-      CHECK_NOTNULL((*g)->AddEdge(new_node, kConv2DWithBiasOutputSlot, e->dst(),
+      const int kTransposeWithMklOpOutputSlot = 0;
+      CHECK_NOTNULL((*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot, e->dst(),
                                   e->dst_input()));
     }
   }

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2657,7 +2657,7 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   gtl::InlinedVector<Node*, 4> transpose_nchw_control_edges;
   gtl::InlinedVector<std::pair<Node*, int>, 4> transpose_nchw_in(
       transpose_nchw_num_inputs);
-  FillInputs(transpose_to_nhwc, &transpose_nchw_control_edges,
+  FillInputs(transpose_to_nchw, &transpose_nchw_control_edges,
              &transpose_nchw_in);
 
   // We will use the node name of Conv2d as the name of new node

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -515,7 +515,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     //
     // Add rules to fuse sequences such as "Transpose (NCHW -> NHWC) + Conv2D
     // (NHWC) + Transpose (NHWC->
-    // NCHW) " => "Conv2D (NCHW). Such patterns occur frequently in Keras.
+    // NCHW)" into "Conv2D (NCHW)". Such patterns occur frequently in Keras.
     // Note: we use the term "merge" is to combine (exactly) 2 nodes into one,
     // while "fusion" is
     // for 3+ nodes situation.

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -934,7 +934,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
             e->dst_input() == kPermTensorIndex) {
           // we find the "perm" node, now try to retrieve its value.
           const TensorProto* proto = nullptr;
-          CHECK_EQ(GetNodeAttr(perm_node->def(), "value", &proto).ok(), true);
+          CHECK(GetNodeAttr(perm_node->def(), "value", &proto).ok());
 
           DataType type;
           GetNodeAttr(perm_node->def(), "dtype", &type);

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -515,10 +515,8 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
                       GetConv2DBackpropFilterOrBiasAddGrad});
 
     // The fusion patterns in "finfo_" that show up first will get applied
-    // first,
-    // for example, graph "A->B->C-D" and finfo_ is {A->B->C to ABC, A->B->C->D
-    // to ABCD},
-    // since the first gets applied first, the final graph will be ABC->D.
+    // first, for example, graph "A->B->C-D" and finfo_ is {A->B->C to ABC, A->B->C->D
+    // to ABCD}, since the first gets applied first, the final graph will be ABC->D.
 
     //
     // Add rules to fuse sequences such as "Transpose (NCHW -> NHWC) + Conv2D

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -592,12 +592,12 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     std::function<Node*(const Node*)> get_node_to_be_merged;
   } MergeInfo;
 
-  // structure to specify information used in node fusion of 3+ operators
+  // Structure to specify information used in node fusion of 3+ operators
   typedef struct {
-    std::string pattern_name;  // name to describe this pattern, such as
+    std::string pattern_name;  // Name to describe this pattern, such as
                                // "Transpose_Mklop_Transpose".
     std::vector<std::function<bool(const Node*)> >
-        node_checkers;  // extra restriction checker for these ops
+        node_checkers;  // Extra restriction checker for these ops
     std::function<Status(
         std::unique_ptr<Graph>*, std::vector<Node*>&,
         std::function<void(const Node*, NodeBuilder* nb, bool)>)>
@@ -606,7 +606,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
   } FusionInfo;
 
   //
-  // dimension indices for 2D tensor.
+  // Dimension indices for 2D tensor.
   //
   struct NCHW {
     enum dim { N = 0, C = 1, H = 2, W = 3 };

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -910,6 +910,9 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     // Check if node's type is "Transpose"
     if (node->type_string() != "Transpose") return false;
 
+    // If "Transpose" has multiple output data edges, also don't fuse it.
+    if (node->num_outputs() > 1 || node->out_edges().size() > 1) return false;
+
     // Check if has out control edge. If true, this is a training graph.
     // Currently we focus on inference and do no fusion in training.
     // Note: this constraint will eventually be removed, if we enabled this fusion for training
@@ -926,9 +929,6 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
         return false;
       }
     }
-
-    // If "Transpose" has multiple output data edges, also don't fuse it.
-    if (node->num_outputs() > 1 || node->out_edges().size() > 1) return false;
 
     // We compared the tensor containing the permutation order ("perm_node")
     // with our desired order ("perm"). If they're exactly match, this check

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -903,7 +903,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
       string data_format);
 
   static bool CheckForTranspose(const Node* node, std::vector<int> perm) {
-    // Check node node, to see if it's "Transpose"
+    // Check if node's type is "Transpose"
     if (node->type_string() != "Transpose") return false;
 
     // Check if has out control edge. If true, this is a training graph.

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -976,6 +976,8 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
   }
 
   static bool CheckForMklOp(const Node* node, string name = "") {
+    if (node == nullptr) return false;
+    
     if (!name.empty() && node->type_string() != name) {
       return false;
     }

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -903,37 +903,28 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
       string data_format);
 
   static bool CheckForTranspose(const Node* node, std::vector<int> perm) {
-    //
     // Check node node, to see if it's "Transpose"
-    //
     if (node->type_string() != "Transpose") return false;
 
-    //
     // Check if has out control edge. If true, this is a training graph.
     // Currently we focus on inference and do no fusion in training.
-    //
     for (const Edge* e : node->out_edges()) {
       if (e->IsControlEdge()) {
         return false;
       }
     }
 
-    //
     // If "Transpose" has input control edges, don't fuse on it.
-    //
     for (const Edge* e : node->in_edges()) {
       if (e->IsControlEdge()) {
         return false;
       }
     }
 
-    //
     // If "Transpose" has multiple output data edges, also don't fuse it.
-    //
     if (node->num_outputs() > 1 || node->out_edges().size() > 1) return false;
 
     // Check "perm" attribute, make sure it's what we want.
-    //
     for (const Edge* e : node->in_edges()) {
       if (!e->IsControlEdge()) {
         const Node* perm_node = e->src();
@@ -948,11 +939,9 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
           DataType type;
           GetNodeAttr(perm_node->def(), "dtype", &type);
 
-          //
           // Here we directly access to the "tensor_context", rather than
           // "int_val". This is because we find "int_val" is
           // not set properly under some circumstances.
-          //
           if (type == DT_INT32) {
             const int type_size = 4;
             const int* tensor_content =

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2722,7 +2722,6 @@ MklLayoutRewritePass::CheckForNodeFusion(Node* a) const {
   const FusionInfo* fi_ptr = nullptr;
 
   for (auto fi = finfo_.begin(); fi != finfo_.end(); ++fi) {
-    assert(fi->ops.size() == fi->node_checkers.size());
     nodes.clear();
     fi_ptr = &*fi;
     //

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -517,8 +517,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     // (NHWC) + Transpose (NHWC->
     // NCHW)" into "Conv2D (NCHW)". Such patterns occur frequently in Keras.
     // Note: we use the term "merge" to combine (exactly) 2 nodes into one,
-    // while "fusion" is
-    // for 3+ nodes situation.
+    // while "fusion" is for 3+ nodes situation.
     //
 
     // Transpose + Conv2d + Transpose:

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -941,7 +941,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
           DataType type;
           GetNodeAttr(perm_node->def(), "dtype", &type);
 
-          // Here we directly access to the "tensor_context", rather than
+          // Here we directly access to the "tensor_content", rather than
           // "int_val". This is because we find "int_val" is
           // not set properly under some circumstances.
           if (type == DT_INT32) {

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -516,7 +516,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     // Add rules to fuse sequences such as "Transpose (NCHW -> NHWC) + Conv2D
     // (NHWC) + Transpose (NHWC->
     // NCHW)" into "Conv2D (NCHW)". Such patterns occur frequently in Keras.
-    // Note: we use the term "merge" is to combine (exactly) 2 nodes into one,
+    // Note: we use the term "merge" to combine (exactly) 2 nodes into one,
     // while "fusion" is
     // for 3+ nodes situation.
     //

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -897,6 +897,8 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
   Status FuseNode(std::unique_ptr<Graph>* g, std::vector<Node*>& nodes,
                   const MklLayoutRewritePass::FusionInfo fi);
 
+  // Fuse tranpose(to "NHWC") + mklop("NHWC") + transpose(to "NCHW") into mklop("NCHW").
+  // Here "mklop" can be any MKL-DNN supported op, such as Conv2D.
   static Status FuseTransposeMklOpTranspose(
       std::unique_ptr<Graph>* g, std::vector<Node*>& nodes,
       std::function<void(const Node*, NodeBuilder* nb, bool)> copy_attrs,
@@ -977,7 +979,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
 
   static bool CheckForMklOp(const Node* node, string name = "") {
     if (node == nullptr) return false;
-    
+
     if (!name.empty() && node->type_string() != name) {
       return false;
     }

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -2770,19 +2770,22 @@ MklLayoutRewritePass::CheckForNodeFusion(Node* a) const {
               all_succ_has_been_visited = false;
               break;
             }
-
-            // All successor nodes of current node has been visited (no match found),
-            // pop the stack and mark current node as "visited".
-            if (all_succ_has_been_visited) {
-              visited_nodes.insert(current_node);
-              work_stack.pop();
-              -- node_checker;
-            }
           }
         }
+
+        // All successor nodes of current node has been visited (no match found),
+        // pop the stack and mark current node as "visited".
+        if (all_succ_has_been_visited) {
+          visited_nodes.insert(current_node);
+          work_stack.pop();
+          -- node_checker;
+        }
+
       } else {
-        // current node doesn't match, just break and stack will help us roll back.
-        break;
+        // current node doesn't match, pop stack to roll back.
+        visited_nodes.insert(current_node);
+        work_stack.pop();
+        -- node_checker;
       }
     }
   }

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -915,17 +915,17 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     if (node->type_string() != "Transpose") return false;
 
     // If "Transpose" has multiple output data edges, also don't fuse it.
-    // if (node->num_outputs() > 1 || node->out_edges().size() > 1) return false;
+    if (node->num_outputs() > 1 || node->out_edges().size() > 1) return false;
 
     // Check if has out control edge. If true, this is a training graph.
     // Currently we focus on inference and do no fusion in training.
     // Note: this constraint will eventually be removed, if we enabled this fusion for training
     // in the future. 
-    // for (const Edge* e : node->out_edges()) {
-    //   if (e->IsControlEdge()) {
-    //     return false;
-    //   }
-    // }
+    for (const Edge* e : node->out_edges()) {
+      if (e->IsControlEdge()) {
+        return false;
+      }
+    }
 
     // If "Transpose" has input control edges, don't fuse on it.
     for (const Edge* e : node->in_edges()) {

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -924,7 +924,9 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     // If "Transpose" has multiple output data edges, also don't fuse it.
     if (node->num_outputs() > 1 || node->out_edges().size() > 1) return false;
 
-    // Check "perm" attribute, make sure it's what we want.
+    // We compared the tensor containing the permutation order ("perm_node")
+    // with our desired order ("perm"). If they're exactly match, this check
+    // succeed and returns true.
     for (const Edge* e : node->in_edges()) {
       if (!e->IsControlEdge()) {
         const Node* perm_node = e->src();
@@ -934,7 +936,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
             e->dst_input() == kPermTensorIndex) {
           // we find the "perm" node, now try to retrieve its value.
           const TensorProto* proto = nullptr;
-          CHECK(GetNodeAttr(perm_node->def(), "value", &proto).ok());
+          CHECK_EQ(GetNodeAttr(perm_node->def(), "value", &proto).ok(), true);
 
           DataType type;
           GetNodeAttr(perm_node->def(), "dtype", &type);

--- a/tensorflow/core/graph/mkl_layout_pass_test.cc
+++ b/tensorflow/core/graph/mkl_layout_pass_test.cc
@@ -457,53 +457,57 @@ TEST_F(MklLayoutPassTest, NodeMerge_Conv2DWithBias_ConvBpropInput_FilterFwd) {
 
 TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Positive) {
   InitGraph(
-    "node { name: 'Input0' op: 'Input'}"
-    "node { name: 'Input1' op: 'Input'}"
-    "node { name: 'Const0' op: 'Const'"
-    "  attr {"
-    "   key: 'dtype'"
-    "   value {"
-    "     type: DT_INT32"
-    "   }"
-    "  }"
-    " attr {"
-    "   key: 'value'"
-    "   value {"
-    "     tensor {"
-    "       dtype: DT_INT32"
-    "       tensor_shape {"
-    "         dim {"
-    "           size: 4"
-    "         }"
-    "       }"
-    "       tensor_content: '\\000\\000\\000\\000\\002\\000\\000\\000\\003\\000\\000\\000\\001\\000\\000\\000'"
-    "     }"
-    "   }"
-    " }"
-    "}"
-    "node { name: 'Const1' op: 'Const'"
-    "  attr {"
-    "   key: 'dtype'"
-    "   value {"
-    "     type: DT_INT32"
-    "   }"
-    "  }"
-    " attr {"
-    "   key: 'value'"
-    "   value {"
-    "     tensor {"
-    "       dtype: DT_INT32"
-    "       tensor_shape {"
-    "         dim {"
-    "           size: 4"
-    "         }"
-    "       }"
-    "       tensor_content: '\\000\\000\\000\\000\\003\\000\\000\\000\\001\\000\\000\\000\\002\\000\\000\\000'"
-    "     }"
-    "   }"
-    " }"
-    "}"
-    "node {              \
+      "node { name: 'Input0' op: 'Input'}"
+      "node { name: 'Input1' op: 'Input'}"
+      "node { name: 'Const0' op: 'Const'"
+      "  attr {"
+      "   key: 'dtype'"
+      "   value {"
+      "     type: DT_INT32"
+      "   }"
+      "  }"
+      " attr {"
+      "   key: 'value'"
+      "   value {"
+      "     tensor {"
+      "       dtype: DT_INT32"
+      "       tensor_shape {"
+      "         dim {"
+      "           size: 4"
+      "         }"
+      "       }"
+      "       tensor_content: "
+      "'\\000\\000\\000\\000\\002\\000\\000\\000\\003\\000\\000\\000\\001\\000"
+      "\\000\\000'"
+      "     }"
+      "   }"
+      " }"
+      "}"
+      "node { name: 'Const1' op: 'Const'"
+      "  attr {"
+      "   key: 'dtype'"
+      "   value {"
+      "     type: DT_INT32"
+      "   }"
+      "  }"
+      " attr {"
+      "   key: 'value'"
+      "   value {"
+      "     tensor {"
+      "       dtype: DT_INT32"
+      "       tensor_shape {"
+      "         dim {"
+      "           size: 4"
+      "         }"
+      "       }"
+      "       tensor_content: "
+      "'\\000\\000\\000\\000\\003\\000\\000\\000\\001\\000\\000\\000\\002\\000"
+      "\\000\\000'"
+      "     }"
+      "   }"
+      " }"
+      "}"
+      "node {              \
       name: 'Transpose0' \
       op: 'Transpose'    \
       input: 'Input0'    \
@@ -520,8 +524,8 @@ TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Positive) {
           type: DT_INT32 \
         }                \
       }                  \
-    }"                   
-    "node {                 \
+    }"
+      "node {                 \
       name: 'Conv2D'        \
       op: 'Conv2D'          \
       input: 'Transpose0'   \
@@ -573,7 +577,7 @@ TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Positive) {
         }                       \
       }                         \
     }"
-    "node {              \
+      "node {              \
       name: 'Transpose1' \
       op: 'Transpose'    \
       input: 'Conv2D'    \
@@ -591,65 +595,71 @@ TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Positive) {
         }                \
       }                  \
     }"
-    "node { name: 'Relu' op: 'Relu'"
+      "node { name: 'Relu' op: 'Relu'"
       " attr { key: 'T'                value { type: DT_FLOAT } }"
       " input: ['Transpose1'] }");
   EXPECT_EQ(DoMklLayoutOptimizationPass(),
             "Const0(Const);Const1(Const);"
             "Conv2D(_MklConv2D);DMT/_0(Const);DMT/_1(Const);Input0(Input);"
-            "Input1(Input);Relu(_MklRelu)|Conv2D->Relu;Conv2D:2->Relu:1;DMT/_0->Conv2D:2;DMT/_1->Conv2D:3;Input0->Conv2D;"
-            "Input0:control->DMT/_0:control;Input0:control->DMT/_1:control;Input1->Conv2D:1");
+            "Input1(Input);Relu(_MklRelu)|Conv2D->Relu;Conv2D:2->Relu:1;DMT/"
+            "_0->Conv2D:2;DMT/_1->Conv2D:3;Input0->Conv2D;"
+            "Input0:control->DMT/_0:control;Input0:control->DMT/"
+            "_1:control;Input1->Conv2D:1");
 }
 
 TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Negative) {
   InitGraph(
-    "node { name: 'Input0' op: 'Input'}"
-    "node { name: 'Input1' op: 'Input'}"
-    "node { name: 'Const0' op: 'Const'"
-    "  attr {"
-    "   key: 'dtype'"
-    "   value {"
-    "     type: DT_INT32"
-    "   }"
-    "  }"
-    " attr {"
-    "   key: 'value'"
-    "   value {"
-    "     tensor {"
-    "       dtype: DT_INT32"
-    "       tensor_shape {"
-    "         dim {"
-    "           size: 4"
-    "         }"
-    "       }"
-    "       tensor_content: '\\000\\000\\000\\000\\002\\000\\000\\000\\003\\000\\000\\000\\001\\000\\000\\000'"
-    "     }"
-    "   }"
-    " }"
-    "}"
-    "node { name: 'Const1' op: 'Const'"
-    "  attr {"
-    "   key: 'dtype'"
-    "   value {"
-    "     type: DT_INT32"
-    "   }"
-    "  }"
-    " attr {"
-    "   key: 'value'"
-    "   value {"
-    "     tensor {"
-    "       dtype: DT_INT32"
-    "       tensor_shape {"
-    "         dim {"
-    "           size: 4"
-    "         }"
-    "       }"
-    "       tensor_content: '\\000\\000\\000\\000\\002\\000\\000\\000\\003\\000\\000\\000\\001\\000\\000\\000'"
-    "     }"
-    "   }"
-    " }"
-    "}"
-    "node {              \
+      "node { name: 'Input0' op: 'Input'}"
+      "node { name: 'Input1' op: 'Input'}"
+      "node { name: 'Const0' op: 'Const'"
+      "  attr {"
+      "   key: 'dtype'"
+      "   value {"
+      "     type: DT_INT32"
+      "   }"
+      "  }"
+      " attr {"
+      "   key: 'value'"
+      "   value {"
+      "     tensor {"
+      "       dtype: DT_INT32"
+      "       tensor_shape {"
+      "         dim {"
+      "           size: 4"
+      "         }"
+      "       }"
+      "       tensor_content: "
+      "'\\000\\000\\000\\000\\002\\000\\000\\000\\003\\000\\000\\000\\001\\000"
+      "\\000\\000'"
+      "     }"
+      "   }"
+      " }"
+      "}"
+      "node { name: 'Const1' op: 'Const'"
+      "  attr {"
+      "   key: 'dtype'"
+      "   value {"
+      "     type: DT_INT32"
+      "   }"
+      "  }"
+      " attr {"
+      "   key: 'value'"
+      "   value {"
+      "     tensor {"
+      "       dtype: DT_INT32"
+      "       tensor_shape {"
+      "         dim {"
+      "           size: 4"
+      "         }"
+      "       }"
+      "       tensor_content: "
+      "'\\000\\000\\000\\000\\002\\000\\000\\000\\003\\000\\000\\000\\001\\000"
+      "\\000\\000'"
+      "     }"
+      "   }"
+      " }"
+      "}"
+      "node {              \
       name: 'Transpose0' \
       op: 'Transpose'    \
       input: 'Input0'    \
@@ -666,8 +676,8 @@ TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Negative) {
           type: DT_INT32 \
         }                \
       }                  \
-    }"                   
-    "node {                 \
+    }"
+      "node {                 \
       name: 'Conv2D'        \
       op: 'Conv2D'          \
       input: 'Transpose0'   \
@@ -719,7 +729,7 @@ TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Negative) {
         }                       \
       }                         \
     }"
-    "node {              \
+      "node {              \
       name: 'Transpose1' \
       op: 'Transpose'    \
       input: 'Conv2D'    \
@@ -737,17 +747,21 @@ TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Negative) {
         }                \
       }                  \
     }"
-    "node { name: 'Relu' op: 'Relu'"
+      "node { name: 'Relu' op: 'Relu'"
       " attr { key: 'T'                value { type: DT_FLOAT } }"
       " input: ['Transpose1'] }");
-  EXPECT_EQ(DoMklLayoutOptimizationPass(),
-            "Const0(Const);Const1(Const);"
-            "Conv2D(_MklConv2D);DMT/_0(Const);DMT/_1(Const);DMT/_2(Const);"
-            "Input0(Input);Input1(Input);Relu(_MklRelu);"
-            "Transpose0(Transpose);Transpose1(Transpose)|Const0->Transpose0:1;Const1->Transpose1:1;"
-            "Conv2D->Transpose1;DMT/_0->Conv2D:2;DMT/_1->Conv2D:3;DMT/_2->Relu:1;Input0->Transpose0;"
-            "Input1->Conv2D:1;Transpose0->Conv2D;Transpose0:control->DMT/_0:control;"
-            "Transpose0:control->DMT/_1:control;Transpose1->Relu;Transpose1:control->DMT/_2:control");
+  EXPECT_EQ(
+      DoMklLayoutOptimizationPass(),
+      "Const0(Const);Const1(Const);"
+      "Conv2D(_MklConv2D);DMT/_0(Const);DMT/_1(Const);DMT/_2(Const);"
+      "Input0(Input);Input1(Input);Relu(_MklRelu);"
+      "Transpose0(Transpose);Transpose1(Transpose)|Const0->Transpose0:1;Const1-"
+      ">Transpose1:1;"
+      "Conv2D->Transpose1;DMT/_0->Conv2D:2;DMT/_1->Conv2D:3;DMT/"
+      "_2->Relu:1;Input0->Transpose0;"
+      "Input1->Conv2D:1;Transpose0->Conv2D;Transpose0:control->DMT/_0:control;"
+      "Transpose0:control->DMT/"
+      "_1:control;Transpose1->Relu;Transpose1:control->DMT/_2:control");
 }
 
 /////////////////////////////////////////////////////////////////////

--- a/tensorflow/core/graph/mkl_layout_pass_test.cc
+++ b/tensorflow/core/graph/mkl_layout_pass_test.cc
@@ -455,6 +455,301 @@ TEST_F(MklLayoutPassTest, NodeMerge_Conv2DWithBias_ConvBpropInput_FilterFwd) {
             "E:3->G:4;F->G;F:control->DMT/_3:control;G->Z;X->Y:1;X->Z:1");
 }
 
+TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Positive) {
+  InitGraph(
+    "node { name: 'Input0' op: 'Input'}"
+    "node { name: 'Input1' op: 'Input'}"
+    "node { name: 'Const0' op: 'Const'"
+    "  attr {"
+    "   key: 'dtype'"
+    "   value {"
+    "     type: DT_INT32"
+    "   }"
+    "  }"
+    " attr {"
+    "   key: 'value'"
+    "   value {"
+    "     tensor {"
+    "       dtype: DT_INT32"
+    "       tensor_shape {"
+    "         dim {"
+    "           size: 4"
+    "         }"
+    "       }"
+    "       tensor_content: '\\000\\000\\000\\000\\002\\000\\000\\000\\003\\000\\000\\000\\001\\000\\000\\000'"
+    "     }"
+    "   }"
+    " }"
+    "}"
+    "node { name: 'Const1' op: 'Const'"
+    "  attr {"
+    "   key: 'dtype'"
+    "   value {"
+    "     type: DT_INT32"
+    "   }"
+    "  }"
+    " attr {"
+    "   key: 'value'"
+    "   value {"
+    "     tensor {"
+    "       dtype: DT_INT32"
+    "       tensor_shape {"
+    "         dim {"
+    "           size: 4"
+    "         }"
+    "       }"
+    "       tensor_content: '\\000\\000\\000\\000\\003\\000\\000\\000\\001\\000\\000\\000\\002\\000\\000\\000'"
+    "     }"
+    "   }"
+    " }"
+    "}"
+    "node {              \
+      name: 'Transpose0' \
+      op: 'Transpose'    \
+      input: 'Input0'    \
+      input: 'Const0'    \
+      attr {             \
+        key: 'T'         \
+        value {          \
+          type: DT_FLOAT \
+        }                \
+      }                  \
+      attr {             \
+        key: 'Tperm'     \
+        value {          \
+          type: DT_INT32 \
+        }                \
+      }                  \
+    }"                   
+    "node {                 \
+      name: 'Conv2D'        \
+      op: 'Conv2D'          \
+      input: 'Transpose0'   \
+      input: 'Input1'       \
+      attr {                \
+        key: 'T'            \
+        value {             \
+          type: DT_FLOAT    \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'data_format'  \
+        value {             \
+          s: 'NHWC'         \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'dilations'    \
+        value {             \
+          list {            \
+            i: 1            \
+            i: 1            \
+            i: 1            \
+            i: 1            \
+          }                 \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'padding'      \
+        value {             \
+          s: 'SAME'         \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'strides'      \
+        value {             \
+          list {            \
+            i: 1            \
+            i: 1            \
+            i: 1            \
+            i: 1            \
+          }                 \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'use_cudnn_on_gpu' \
+        value {                 \
+          b: true               \
+        }                       \
+      }                         \
+    }"
+    "node {              \
+      name: 'Transpose1' \
+      op: 'Transpose'    \
+      input: 'Conv2D'    \
+      input: 'Const1'    \
+      attr {             \
+        key: 'T'         \
+        value {          \
+          type: DT_FLOAT \
+        }                \
+      }                  \
+      attr {             \
+        key: 'Tperm'     \
+        value {          \
+          type: DT_INT32 \
+        }                \
+      }                  \
+    }"
+    "node { name: 'Relu' op: 'Relu'"
+      " attr { key: 'T'                value { type: DT_FLOAT } }"
+      " input: ['Transpose1'] }");
+  EXPECT_EQ(DoMklLayoutOptimizationPass(),
+            "Const0(Const);Const1(Const);"
+            "Conv2D(_MklConv2D);DMT/_0(Const);DMT/_1(Const);Input0(Input);"
+            "Input1(Input);Relu(_MklRelu)|Conv2D->Relu;Conv2D:2->Relu:1;DMT/_0->Conv2D:2;DMT/_1->Conv2D:3;Input0->Conv2D;"
+            "Input0:control->DMT/_0:control;Input0:control->DMT/_1:control;Input1->Conv2D:1");
+}
+
+TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Negative) {
+  InitGraph(
+    "node { name: 'Input0' op: 'Input'}"
+    "node { name: 'Input1' op: 'Input'}"
+    "node { name: 'Const0' op: 'Const'"
+    "  attr {"
+    "   key: 'dtype'"
+    "   value {"
+    "     type: DT_INT32"
+    "   }"
+    "  }"
+    " attr {"
+    "   key: 'value'"
+    "   value {"
+    "     tensor {"
+    "       dtype: DT_INT32"
+    "       tensor_shape {"
+    "         dim {"
+    "           size: 4"
+    "         }"
+    "       }"
+    "       tensor_content: '\\000\\000\\000\\000\\002\\000\\000\\000\\003\\000\\000\\000\\001\\000\\000\\000'"
+    "     }"
+    "   }"
+    " }"
+    "}"
+    "node { name: 'Const1' op: 'Const'"
+    "  attr {"
+    "   key: 'dtype'"
+    "   value {"
+    "     type: DT_INT32"
+    "   }"
+    "  }"
+    " attr {"
+    "   key: 'value'"
+    "   value {"
+    "     tensor {"
+    "       dtype: DT_INT32"
+    "       tensor_shape {"
+    "         dim {"
+    "           size: 4"
+    "         }"
+    "       }"
+    "       tensor_content: '\\000\\000\\000\\000\\002\\000\\000\\000\\003\\000\\000\\000\\001\\000\\000\\000'"
+    "     }"
+    "   }"
+    " }"
+    "}"
+    "node {              \
+      name: 'Transpose0' \
+      op: 'Transpose'    \
+      input: 'Input0'    \
+      input: 'Const0'    \
+      attr {             \
+        key: 'T'         \
+        value {          \
+          type: DT_FLOAT \
+        }                \
+      }                  \
+      attr {             \
+        key: 'Tperm'     \
+        value {          \
+          type: DT_INT32 \
+        }                \
+      }                  \
+    }"                   
+    "node {                 \
+      name: 'Conv2D'        \
+      op: 'Conv2D'          \
+      input: 'Transpose0'   \
+      input: 'Input1'       \
+      attr {                \
+        key: 'T'            \
+        value {             \
+          type: DT_FLOAT    \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'data_format'  \
+        value {             \
+          s: 'NHWC'         \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'dilations'    \
+        value {             \
+          list {            \
+            i: 1            \
+            i: 1            \
+            i: 1            \
+            i: 1            \
+          }                 \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'padding'      \
+        value {             \
+          s: 'SAME'         \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'strides'      \
+        value {             \
+          list {            \
+            i: 1            \
+            i: 1            \
+            i: 1            \
+            i: 1            \
+          }                 \
+        }                   \
+      }                     \
+      attr {                \
+        key: 'use_cudnn_on_gpu' \
+        value {                 \
+          b: true               \
+        }                       \
+      }                         \
+    }"
+    "node {              \
+      name: 'Transpose1' \
+      op: 'Transpose'    \
+      input: 'Conv2D'    \
+      input: 'Const1'    \
+      attr {             \
+        key: 'T'         \
+        value {          \
+          type: DT_FLOAT \
+        }                \
+      }                  \
+      attr {             \
+        key: 'Tperm'     \
+        value {          \
+          type: DT_INT32 \
+        }                \
+      }                  \
+    }"
+    "node { name: 'Relu' op: 'Relu'"
+      " attr { key: 'T'                value { type: DT_FLOAT } }"
+      " input: ['Transpose1'] }");
+  EXPECT_EQ(DoMklLayoutOptimizationPass(),
+            "Const0(Const);Const1(Const);"
+            "Conv2D(_MklConv2D);DMT/_0(Const);DMT/_1(Const);DMT/_2(Const);"
+            "Input0(Input);Input1(Input);Relu(_MklRelu);"
+            "Transpose0(Transpose);Transpose1(Transpose)|Const0->Transpose0:1;Const1->Transpose1:1;"
+            "Conv2D->Transpose1;DMT/_0->Conv2D:2;DMT/_1->Conv2D:3;DMT/_2->Relu:1;Input0->Transpose0;"
+            "Input1->Conv2D:1;Transpose0->Conv2D;Transpose0:control->DMT/_0:control;"
+            "Transpose0:control->DMT/_1:control;Transpose1->Relu;Transpose1:control->DMT/_2:control");
+}
+
 /////////////////////////////////////////////////////////////////////
 //  Unit tests related to rewriting node to Mkl node
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a pattern found in Keras-based models. When using "NCHW" format dataset, Keras will insert 2 extra "Transpose" ops before/after every CNN ops, because only "NHWC" format is supported in CPU mode. 

These "Transpose" overhead are significant in typical CNN models, we observed it contributes ~35% of total inference time in 3D-UNet. This PR is aimed to remove these overhead completely, by:
1. detect the "transpose + conv2d + transpose" pattern;
2. delete those 2 "transpose" ops, and make "conv2d"'s format "NCHW";
3. replace "conv2d" with "_MklConv2D", which support both "NCHW" and "NHWC" format.

