### PR TITLE
Implement server Stop method

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/eager/grpc_eager_service_impl.cc
+++ b/tensorflow/core/distributed_runtime/rpc/eager/grpc_eager_service_impl.cc
@@ -54,11 +54,7 @@ void GrpcEagerServiceImpl::HandleRPCsLoop() {
   void* tag;  // Matches the operation started against this cq_.
   bool ok;
 
-  while (true) {
-    if (!cq_->Next(&tag, &ok)) {
-      // The queue is shutting down.
-      break;
-    }
+  while (cq_->Next(&tag, &ok)) {
     UntypedCall<GrpcEagerServiceImpl>::Tag* callback_tag =
         static_cast<UntypedCall<GrpcEagerServiceImpl>::Tag*>(tag);
 
@@ -66,7 +62,6 @@ void GrpcEagerServiceImpl::HandleRPCsLoop() {
       callback_tag->OnCompleted(this, ok);
     } else {
       cq_->Shutdown();
-      break;
     }
   }
 }

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -398,8 +398,13 @@ Status GrpcServer::Stop() {
       state_ = STOPPED;
       return Status::OK();
     case STARTED:
-      return errors::Unimplemented(
-          "Clean shutdown is not currently implemented");
+      server_->Shutdown();
+      master_service_->Shutdown();
+      worker_service_->Shutdown();
+      eager_service_->Shutdown();
+      state_ = STOPPED;
+      LOG(INFO) << "Server stopped (target: " << target() << ")";
+      return Status::OK();
     case STOPPED:
       LOG(INFO) << "Server already stopped (target: " << target() << ")";
       return Status::OK();


### PR DESCRIPTION
Currently "Stop" function is not implemented in `GrpcServer`. It leads to the fact, that `GrpcServer` can't be used inside other processes (like in #23022). I've implemented stop method so that server stops and doesn't abort the process during destructor execution.

@mrry, could you please have a look as the author of this functionality?