### PR TITLE
Fix error that bugs Keras during multi-gpu with batch normalization

### DIFF
--- a/tensorflow/python/framework/device.py
+++ b/tensorflow/python/framework/device.py
@@ -283,7 +283,8 @@ def merge_device(spec):
   if not isinstance(spec, DeviceSpec):
     spec = DeviceSpec.from_string(spec or "")
   def _device_function(node_def):
-    current_device = DeviceSpec.from_string(node_def.device or "")
+    current_device = node_def.device if isinstance(node_def.device, DeviceSpec) \
+                        else DeviceSpec.from_string(node_def.device or "")
     copy_spec = copy.copy(spec)
     copy_spec.merge_from(current_device)  # current_device takes precedence.
     return copy_spec


### PR DESCRIPTION
Here are the issues that lead to this bug:
https://github.com/keras-team/keras/issues/10008
https://github.com/keras-team/keras/issues/10490

If you use `multi_gpu_model` in Keras, it causes an error.  I tracked this to the following stack:

```
  File "/home/sean/env3/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py", line 1858, in normalize_batch_in_training
    if not _has_nchw_support() and list(reduction_axes) == [0, 2, 3]:
  File "/home/sean/env3/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py", line 291, in _has_nchw_support
    explicitly_on_cpu = _is_current_explicit_device('CPU')
  File "/home/sean/env3/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py", line 266, in _is_current_explicit_device
    device = _get_current_tf_device()
  File "/home/sean/env3/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py", line 247, in _get_current_tf_device
    g._apply_device_functions(op)
  File "/home/sean/env3/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 4259, in _apply_device_functions
    op._set_device(device_spec.function(op))
  File "/home/sean/env3/lib/python3.6/site-packages/tensorflow/python/framework/device.py", line 306, in _device_function
    current_device = DeviceSpec.from_string(node_def.device or "")
  File "/home/sean/env3/lib/python3.6/site-packages/tensorflow/python/framework/device.py", line 231, in from_string
    return DeviceSpec().parse_from_string(spec)
  File "/home/sean/env3/lib/python3.6/site-packages/tensorflow/python/framework/device.py", line 149, in parse_from_string
    splits = [x.split(":") for x in spec.split("/")]
AttributeError: 'DeviceSpec' object has no attribute 'split'
```

The fix is that for some reason, the node_def.device from `device.py` is being passed in as a `DeviceSpec` instance, not a string as expected.  However, I noticed a couple of lines above that, there is a check to see if `spec` is a `DeviceSpec` instance.  I went ahead and added this check to this line as well, and it fixes the issue.