### PR TITLE
Fix documentation for deprecated args

### DIFF
--- a/tensorflow/python/util/deprecation.py
+++ b/tensorflow/python/util/deprecation.py
@@ -54,14 +54,29 @@ def _add_deprecated_function_notice_to_docstring(doc, date, instructions):
       '(deprecated)', main_text)
 
 
-def _add_deprecated_arg_notice_to_docstring(doc, date, instructions):
+def _add_deprecated_arg_notice_to_docstring(doc, date, arg_names, instructions):
   """Adds a deprecation notice to a docstring for deprecated arguments."""
+  arg_names = list(arg_names) # Input can be dict_keys object
+  if 0 == len(arg_names):
+    arg_names_str = 'SOME ARGUMENTS ARE DEPRECATED.'
+  elif 1 == len(arg_names):
+    arg_names_str = 'THE `%s` ARGUMENT IS DEPRECATED.' % arg_names[0]
+  elif 2 == len(arg_names):
+    arg_names_str = 'THE `%s` AND `%s` ARGUMENTS ARE DEPRECATED.' % (
+        arg_names[0], arg_names[1])
+  else:
+    arg_names_copy = ['`%s`' % n for n in arg_names]
+    arg_names_copy[-1] = 'and ' + arg_names_copy[-1]
+    arg_names_str = 'THE %s ARGUMENTS ARE DEPRECATED.' % (
+        ', '.join(arg_names_copy))
+   
   return decorator_utils.add_notice_to_docstring(
       doc, instructions,
       'DEPRECATED FUNCTION ARGUMENTS',
       '(deprecated arguments)', [
-          'SOME ARGUMENTS ARE DEPRECATED. '
-          'They will be removed %s.' % (
+          '%s %s will be removed %s.' % (
+              arg_names_str,
+              'It' if 1 == len(arg_names) else 'They',
               'in a future version' if date is None else ('after %s' % date)),
           'Instructions for updating:'])
 
@@ -488,7 +503,9 @@ def deprecated_args(date, instructions, *deprecated_arg_names_or_tuples,
       return func(*args, **kwargs)
     return tf_decorator.make_decorator(func, new_func, 'deprecated',
                                        _add_deprecated_arg_notice_to_docstring(
-                                           func.__doc__, date, instructions))
+                                           func.__doc__, date, 
+                                           deprecated_arg_names.keys(), 
+                                           instructions))
   return deprecated_wrapper
 
 
@@ -553,7 +570,8 @@ def deprecated_arg_values(date, instructions, warn_once=True,
       return func(*args, **kwargs)
     return tf_decorator.make_decorator(func, new_func, 'deprecated',
                                        _add_deprecated_arg_notice_to_docstring(
-                                           func.__doc__, date, instructions))
+                                           func.__doc__, date, [], 
+                                           instructions))
   return deprecated_wrapper
 
 

--- a/tensorflow/python/util/deprecation_test.py
+++ b/tensorflow/python/util/deprecation_test.py
@@ -507,7 +507,8 @@ class DeprecatedArgsTest(test.TestCase):
     self.assertEqual(
         "fn doc. (deprecated arguments)"
         "\n"
-        "\nSOME ARGUMENTS ARE DEPRECATED. They will be removed after %s."
+        "\nTHE `deprecated` ARGUMENT IS DEPRECATED. It will be removed "
+        "after %s."
         "\nInstructions for updating:\n%s"
         "\n"
         "\nArgs:"
@@ -544,7 +545,8 @@ class DeprecatedArgsTest(test.TestCase):
     self.assertEqual(
         "fn doc. (deprecated arguments)"
         "\n"
-        "\nSOME ARGUMENTS ARE DEPRECATED. They will be removed after %s."
+        "\nTHE `deprecated` ARGUMENT IS DEPRECATED. It will be removed "
+        "after %s."
         "\nInstructions for updating:\n%s" % (date, instructions), _fn.__doc__)
 
     # Assert calls without the deprecated argument log nothing.
@@ -572,7 +574,8 @@ class DeprecatedArgsTest(test.TestCase):
     self.assertEqual(
         "DEPRECATED FUNCTION ARGUMENTS"
         "\n"
-        "\nSOME ARGUMENTS ARE DEPRECATED. They will be removed after %s."
+        "\nTHE `deprecated` ARGUMENT IS DEPRECATED. It will be removed "
+        "after %s."
         "\nInstructions for updating:"
         "\n%s" % (date, instructions), _fn.__doc__)
 
@@ -586,6 +589,90 @@ class DeprecatedArgsTest(test.TestCase):
     (args, _) = mock_warning.call_args
     self.assertRegexpMatches(args[0], r"deprecated and will be removed")
     self._assert_subset(set(["after " + date, instructions]), set(args[1:]))
+
+  @test.mock.patch.object(logging, "warning", autospec=True)
+  def test_docs_multiple_deprecated_args(self, mock_warning):
+    date = "2016-07-04"
+    instructions = "This is how you update..."
+
+    @deprecation.deprecated_args(date, instructions, "deprecated1", 
+                                 "deprecated2")
+    def _fn2(arg0, arg1, deprecated1=False, deprecated2=False):
+      """fn2 doc.
+
+      Args:
+        arg0: Arg 0.
+        arg1: Arg 1.
+        deprecated1: Deprecated!
+        deprecated2: Deprecated!
+
+      Returns:
+        Sum of args.
+      """
+      if deprecated1:
+        return 1 + arg0 + arg1
+      elif deprecated2:
+        return 2 + arg0 + arg1
+      else:
+        return arg0 + arg1
+
+    @deprecation.deprecated_args(date, instructions, "deprecated1", 
+                                 "deprecated2", "deprecated3")
+    def _fn3(arg0, arg1, deprecated1=False, deprecated2=False, 
+             deprecated3=False):
+      """fn3 doc.
+
+      Args:
+        arg0: Arg 0.
+        arg1: Arg 1.
+        deprecated1: Deprecated!
+        deprecated2: Deprecated!
+        deprecated3: Deprecated!
+
+      Returns:
+        Sum of args.
+      """
+      if deprecated1:
+        return 1 + arg0 + arg1
+      elif deprecated2:
+        return 2 + arg0 + arg1
+      elif deprecated3:
+        return 3 + arg0 + arg1
+      else:
+        return arg0 + arg1
+
+    self.assertEqual(
+        "fn2 doc. (deprecated arguments)"
+        "\n"
+        "\nTHE `deprecated1` AND `deprecated2` ARGUMENTS ARE DEPRECATED. "
+        "They will be removed after %s."
+        "\nInstructions for updating:\n%s"
+        "\n"
+        "\nArgs:"
+        "\n  arg0: Arg 0."
+        "\n  arg1: Arg 1."
+        "\n  deprecated1: Deprecated!"
+        "\n  deprecated2: Deprecated!"
+        "\n"
+        "\nReturns:"
+        "\n  Sum of args." % (date, instructions), _fn2.__doc__)
+    self.assertEqual(
+        "fn3 doc. (deprecated arguments)"
+        "\n"
+        "\nTHE `deprecated1`, `deprecated2`, and `deprecated3` ARGUMENTS ARE "
+        "DEPRECATED. They will be removed after %s."
+        "\nInstructions for updating:\n%s"
+        "\n"
+        "\nArgs:"
+        "\n  arg0: Arg 0."
+        "\n  arg1: Arg 1."
+        "\n  deprecated1: Deprecated!"
+        "\n  deprecated2: Deprecated!"
+        "\n  deprecated3: Deprecated!"
+        "\n"
+        "\nReturns:"
+        "\n  Sum of args." % (date, instructions), _fn3.__doc__)
+
 
   @test.mock.patch.object(logging, "warning", autospec=True)
   def test_varargs(self, mock_warning):


### PR DESCRIPTION
While reading the API docs, I noticed that some of the deprecation notices seem to have missing pieces. For example, this notice in `tf.math.argmax`:
<img width="712" alt="screen shot 2018-10-22 at 10 16 08 am" src="https://user-images.githubusercontent.com/12436991/47307300-8f1af080-d5e3-11e8-81c6-f04beb7b257f.png">

I traced the problem to a bug in the `@deprecated_args` decorator. The message that the decorator generates for docstrings is different from the message it generates for runtime warnings. Instructions that make sense in the context of the runtime warning message don't make sense in the context of the API docs.

This PR makes the deprecation message for docstrings more like the one for warnings. After the changes in this PR, the deprecation notice for `tf.math.argmax` looks like this:
![screen shot 2018-10-22 at 5 02 30 pm](https://user-images.githubusercontent.com/12436991/47326191-6fec8500-d61c-11e8-9f8b-5f8037c8917e.png)

Overall, this change fixes problems with the deprecation warnings for the following functions:
* `tf.graph_util.import_graph_def`
* `tf.expand_dims`
* `tf.squeeze`
* `tf.math.argmax`
* `tf.math.argmin`

I regenerated the docs on my local copy and checked each of these functions by hand. I also ran regression tests and pylint.

I updated the expected results in `deprecation_test.py` and added a new test to cover docstrings for functions with 2 or more deprecated arguments.