### PR TITLE
Surface the number of threads used by ctx->runner() for ParallelMapIteratorBase

### DIFF
--- a/tensorflow/core/framework/dataset.h
+++ b/tensorflow/core/framework/dataset.h
@@ -279,12 +279,15 @@ class IteratorContext {
           lib(ctx->lib()),
           model(ctx->model()),
           runner(*(ctx->runner())),
+          runner_threadpool_size(ctx->runner_threadpool_size()),
           stats_aggregator(ctx->stats_aggregator()) {}
 
     explicit Params(OpKernelContext* ctx)
         : env(ctx->env()),
           lib(ctx->function_library()),
-          runner(*(ctx->runner())) {
+          runner(*(ctx->runner())),
+          runner_threadpool_size(
+              ctx->device()->tensorflow_cpu_worker_threads()->num_threads) {
       // NOTE: need reinterpret_cast because function.h forward-declares Device.
       DeviceBase* device =
           reinterpret_cast<DeviceBase*>(ctx->function_library()->device());
@@ -310,6 +313,9 @@ class IteratorContext {
 
     // Function call support.
     std::function<void(std::function<void()>)> runner = nullptr;
+
+    // Number of threads used for executing user-defined functions.
+    int32 runner_threadpool_size = 0;
 
     // The `StatsAggregator` object to record statistics about the iterator.
     std::shared_ptr<StatsAggregator> stats_aggregator = nullptr;
@@ -342,6 +348,8 @@ class IteratorContext {
   std::function<void(std::function<void()>)>* runner() {
     return &params_.runner;
   }
+
+  int32 runner_threadpool_size() { return params_.runner_threadpool_size; }
 
   std::shared_ptr<StatsAggregator> stats_aggregator() {
     return params_.stats_aggregator;

--- a/tensorflow/core/kernels/data/experimental/numa_map_and_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/numa_map_and_batch_dataset_op.cc
@@ -201,7 +201,7 @@ class NumaMapAndBatchDatasetOp : public UnaryDatasetOpKernel {
       Status Initialize(IteratorContext* ctx) override {
         mutex_lock l(*mu_);
         if (num_parallel_calls_->value == kAutoTune) {
-          num_parallel_calls_->value = port::NumSchedulableCPUs();
+          num_parallel_calls_->value = ctx->runner_threadpool_size();
           num_parallel_calls_->tunable = true;
         }
         TF_RETURN_IF_ERROR(

--- a/tensorflow/core/kernels/data/experimental/numa_map_and_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/numa_map_and_batch_dataset_op.cc
@@ -244,7 +244,7 @@ class NumaMapAndBatchDatasetOp : public UnaryDatasetOpKernel {
         return model::MakeAsyncKnownRatioNode(
             std::move(args), dataset()->batch_size_,
             {model::MakeParameter("parallelism", num_parallel_calls_, /*min=*/1,
-                                  /*max=*/port::NumSchedulableCPUs())});
+                                  /*max=*/ctx->runner_threadpool_size())});
       }
 
       Status SaveInternal(IteratorStateWriter* writer) override {

--- a/tensorflow/core/kernels/data/experimental/threadpool_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/threadpool_dataset_op.cc
@@ -47,6 +47,8 @@ class ThreadPoolResource : public ResourceBase {
     }
   }
 
+  int32 NumThreads() { return thread_pool_.NumThreads(); }
+
   string DebugString() override { return "ThreadPoolResource"; }
 
  private:
@@ -196,6 +198,7 @@ class ThreadPoolDatasetOp : public UnaryDatasetOpKernel {
         params.runner = [pool](std::function<void()> c) {
           pool->Schedule(std::move(c));
         };
+        params.runner_threadpool_size = pool->NumThreads();
         IteratorContext iter_ctx(params);
         return input_impl_->GetNext(&iter_ctx, out_tensors, end_of_sequence);
       }

--- a/tensorflow/core/kernels/data/iterator_ops.cc
+++ b/tensorflow/core/kernels/data/iterator_ops.cc
@@ -145,8 +145,6 @@ class IteratorResource : public ResourceBase {
       params.allocator_getter = [device](AllocatorAttributes attrs) {
         return device->GetAllocator(attrs);
       };
-      params.runner_threadpool_size =
-          ctx->device()->tensorflow_cpu_worker_threads()->num_threads;
       IteratorContext iter_ctx(std::move(params));
       TF_RETURN_IF_ERROR(captured_iterator->Restore(&iter_ctx, reader));
       mutex_lock l(mu_);
@@ -1009,7 +1007,6 @@ void IteratorGetNextSyncOp::Compute(OpKernelContext* ctx) {
   bool end_of_sequence = false;
   IteratorContext::Params params(ctx);
   params.function_library = iterator->function_library();
-
   OP_REQUIRES_OK(ctx, iterator->GetNext(IteratorContext(std::move(params)),
                                         &components, &end_of_sequence));
   OP_REQUIRES(ctx, !end_of_sequence, errors::OutOfRange("End of sequence"));
@@ -1211,6 +1208,7 @@ class DeserializeIteratorOp : public OpKernel {
     OP_REQUIRES_OK(ctx, iterator_resource->Restore(ctx, wrapper->get()));
   }
 };
+
 
 REGISTER_KERNEL_BUILDER(Name("Iterator").Device(DEVICE_CPU), IteratorHandleOp);
 REGISTER_KERNEL_BUILDER(Name("IteratorV2").Device(DEVICE_CPU),

--- a/tensorflow/core/kernels/data/iterator_ops.cc
+++ b/tensorflow/core/kernels/data/iterator_ops.cc
@@ -980,20 +980,8 @@ void IteratorGetNextOp::ComputeAsync(OpKernelContext* ctx, DoneCallback done) {
 
         IteratorContext::Params params(ctx);
         params.function_library = iterator->function_library();
-<<<<<<< HEAD
         Status s = iterator->GetNext(IteratorContext(std::move(params)),
                                      &components, &end_of_sequence);
-=======
-        DeviceBase* device = ctx->function_library()->device();
-        params.allocator_getter = [device](AllocatorAttributes attrs) {
-          return device->GetAllocator(attrs);
-        };
-        params.runner_threadpool_size =
-            ctx->device()->tensorflow_cpu_worker_threads()->num_threads;
-        IteratorContext iter_ctx(std::move(params));
-
-        Status s = iterator->GetNext(&iter_ctx, &components, &end_of_sequence);
->>>>>>> Add runner_threadpool_size into IteratorContext
         // NOTE(mrry): We must unref the iterator before calling `done()`, to
         // avoid destruction races.
         iterator->Unref();
@@ -1021,21 +1009,9 @@ void IteratorGetNextSyncOp::Compute(OpKernelContext* ctx) {
   bool end_of_sequence = false;
   IteratorContext::Params params(ctx);
   params.function_library = iterator->function_library();
-<<<<<<< HEAD
+
   OP_REQUIRES_OK(ctx, iterator->GetNext(IteratorContext(std::move(params)),
                                         &components, &end_of_sequence));
-=======
-  DeviceBase* device = ctx->function_library()->device();
-  params.allocator_getter = [device](AllocatorAttributes attrs) {
-    return device->GetAllocator(attrs);
-  };
-  params.runner_threadpool_size =
-      ctx->device()->tensorflow_cpu_worker_threads()->num_threads;
-  IteratorContext iter_ctx(std::move(params));
-
-  OP_REQUIRES_OK(ctx,
-                 iterator->GetNext(&iter_ctx, &components, &end_of_sequence));
->>>>>>> Add runner_threadpool_size into IteratorContext
   OP_REQUIRES(ctx, !end_of_sequence, errors::OutOfRange("End of sequence"));
 
   for (int i = 0; i < components.size(); ++i) {
@@ -1235,7 +1211,6 @@ class DeserializeIteratorOp : public OpKernel {
     OP_REQUIRES_OK(ctx, iterator_resource->Restore(ctx, wrapper->get()));
   }
 };
-
 
 REGISTER_KERNEL_BUILDER(Name("Iterator").Device(DEVICE_CPU), IteratorHandleOp);
 REGISTER_KERNEL_BUILDER(Name("IteratorV2").Device(DEVICE_CPU),

--- a/tensorflow/core/kernels/data/iterator_ops.cc
+++ b/tensorflow/core/kernels/data/iterator_ops.cc
@@ -145,6 +145,8 @@ class IteratorResource : public ResourceBase {
       params.allocator_getter = [device](AllocatorAttributes attrs) {
         return device->GetAllocator(attrs);
       };
+      params.runner_threadpool_size =
+          ctx->device()->tensorflow_cpu_worker_threads()->num_threads;
       IteratorContext iter_ctx(std::move(params));
       TF_RETURN_IF_ERROR(captured_iterator->Restore(&iter_ctx, reader));
       mutex_lock l(mu_);
@@ -978,8 +980,20 @@ void IteratorGetNextOp::ComputeAsync(OpKernelContext* ctx, DoneCallback done) {
 
         IteratorContext::Params params(ctx);
         params.function_library = iterator->function_library();
+<<<<<<< HEAD
         Status s = iterator->GetNext(IteratorContext(std::move(params)),
                                      &components, &end_of_sequence);
+=======
+        DeviceBase* device = ctx->function_library()->device();
+        params.allocator_getter = [device](AllocatorAttributes attrs) {
+          return device->GetAllocator(attrs);
+        };
+        params.runner_threadpool_size =
+            ctx->device()->tensorflow_cpu_worker_threads()->num_threads;
+        IteratorContext iter_ctx(std::move(params));
+
+        Status s = iterator->GetNext(&iter_ctx, &components, &end_of_sequence);
+>>>>>>> Add runner_threadpool_size into IteratorContext
         // NOTE(mrry): We must unref the iterator before calling `done()`, to
         // avoid destruction races.
         iterator->Unref();
@@ -1007,8 +1021,21 @@ void IteratorGetNextSyncOp::Compute(OpKernelContext* ctx) {
   bool end_of_sequence = false;
   IteratorContext::Params params(ctx);
   params.function_library = iterator->function_library();
+<<<<<<< HEAD
   OP_REQUIRES_OK(ctx, iterator->GetNext(IteratorContext(std::move(params)),
                                         &components, &end_of_sequence));
+=======
+  DeviceBase* device = ctx->function_library()->device();
+  params.allocator_getter = [device](AllocatorAttributes attrs) {
+    return device->GetAllocator(attrs);
+  };
+  params.runner_threadpool_size =
+      ctx->device()->tensorflow_cpu_worker_threads()->num_threads;
+  IteratorContext iter_ctx(std::move(params));
+
+  OP_REQUIRES_OK(ctx,
+                 iterator->GetNext(&iter_ctx, &components, &end_of_sequence));
+>>>>>>> Add runner_threadpool_size into IteratorContext
   OP_REQUIRES(ctx, !end_of_sequence, errors::OutOfRange("End of sequence"));
 
   for (int i = 0; i < components.size(); ++i) {

--- a/tensorflow/core/kernels/data/map_and_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/map_and_batch_dataset_op.cc
@@ -296,7 +296,7 @@ class MapAndBatchDatasetOp : public UnaryDatasetOpKernel {
         return model::MakeAsyncKnownRatioNode(
             std::move(args), dataset()->batch_size_,
             {model::MakeParameter("parallelism", num_parallel_calls_, /*min=*/1,
-                                  /*max=*/port::NumSchedulableCPUs())});
+                                  /*max=*/ctx->runner_threadpool_size())});
       }
 
       Status SaveInternal(IteratorStateWriter* writer) override {

--- a/tensorflow/core/kernels/data/map_and_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/map_and_batch_dataset_op.cc
@@ -262,9 +262,7 @@ class MapAndBatchDatasetOp : public UnaryDatasetOpKernel {
       Status Initialize(IteratorContext* ctx) override {
         mutex_lock l(*mu_);
         if (num_parallel_calls_->value == kAutoTune) {
-          // TODO(jsimsa): Surface the number of threads used by `ctx->runner()`
-          // and use it here for the default.
-          num_parallel_calls_->value = port::NumSchedulableCPUs();
+          num_parallel_calls_->value = ctx->runner_threadpool_size();
           num_parallel_calls_->tunable = true;
         }
         TF_RETURN_IF_ERROR(

--- a/tensorflow/core/kernels/data/parallel_map_iterator.cc
+++ b/tensorflow/core/kernels/data/parallel_map_iterator.cc
@@ -65,9 +65,7 @@ class ParallelMapIterator : public DatasetBaseIterator {
   Status Initialize(IteratorContext* ctx) override {
     mutex_lock l(*mu_);
     if (num_parallel_calls_->value == kAutoTune) {
-      // TODO(jsimsa): Surface the number of threads used by `ctx->runner()` and
-      // use it here for the default.
-      num_parallel_calls_->value = port::NumSchedulableCPUs();
+      num_parallel_calls_->value = ctx->runner_threadpool_size();
       num_parallel_calls_->tunable = true;
     }
     TF_RETURN_IF_ERROR(

--- a/tensorflow/core/kernels/data/parallel_map_iterator.cc
+++ b/tensorflow/core/kernels/data/parallel_map_iterator.cc
@@ -101,7 +101,7 @@ class ParallelMapIterator : public DatasetBaseIterator {
         std::move(args),
         /*ratio=*/1,
         {model::MakeParameter("parallelism", num_parallel_calls_, /*min=*/1,
-                              /*max=*/port::NumSchedulableCPUs())});
+                              /*max=*/ctx->runner_threadpool_size())});
   }
 
   Status SaveInternal(IteratorStateWriter* writer) override {


### PR DESCRIPTION
This PR surfaces the number of threads used by `ctx->runner()` for [ParallelMapIteratorBase::AddTunableParameter()](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/data/parallel_map_iterator.cc#L63-L66). 