### PR TITLE
Added implementation of an absolute_name_scope and a unit test.

### DIFF
--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -1081,6 +1081,19 @@ class NameTest(test_util.TensorFlowTestCase):
 
     g = ops.Graph()
     with g.as_default():
+      # abs_scope>abs_scope with `as abs_inner`
+      with g.absolute_name_scope('abs_outer'):
+        with g.absolute_name_scope('abs_inner') as abs_inner:
+          self.assertEqual(
+              'abs_outer/abs_inner/FloatOutput',
+              g.create_op("FloatOutput", [], [dtypes.float32]).name)
+      with g.absolute_name_scope(abs_inner):
+        self.assertEqual(
+            'abs_outer/abs_inner/FloatOutput_1',
+            g.create_op("FloatOutput", [], [dtypes.float32]).name)
+
+    g = ops.Graph()
+    with g.as_default():
       # name_scope>abs_scope
       with g.name_scope('name_outer'):
         with g.absolute_name_scope('abs_inner'):

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -1064,6 +1064,87 @@ class NameTest(test_util.TensorFlowTestCase):
       self.assertEqual("bar/FloatOutput_2",
                        g.create_op("FloatOutput", [], [dtypes.float32]).name)
 
+  def testAbsoluteNameScope(self):
+    g = ops.Graph()
+    with g.as_default():
+      # abs_scope>abs_scope
+      with g.absolute_name_scope('abs_outer'):
+        with g.absolute_name_scope('abs_inner'):
+          self.assertEqual(
+              'abs_outer/abs_inner/FloatOutput',
+              g.create_op("FloatOutput", [], [dtypes.float32]).name)
+      with g.absolute_name_scope('abs_outer'):
+        with g.absolute_name_scope('abs_inner'):
+          self.assertEqual(
+              'abs_outer/abs_inner/FloatOutput_1',
+              g.create_op("FloatOutput", [], [dtypes.float32]).name)
+
+    g = ops.Graph()
+    with g.as_default():
+      # name_scope>abs_scope
+      with g.name_scope('name_outer'):
+        with g.absolute_name_scope('abs_inner'):
+          self.assertEqual(
+              'name_outer/abs_inner/FloatOutput',
+              g.create_op("FloatOutput", [], [dtypes.float32]).name)
+      with g.name_scope('name_outer'):
+        with g.absolute_name_scope('abs_inner'):
+          self.assertEqual(
+              'name_outer_1/abs_inner/FloatOutput',
+              g.create_op("FloatOutput", [], [dtypes.float32]).name)
+
+    g = ops.Graph()
+    with g.as_default():
+      # abs_scope>name_scope
+      with g.absolute_name_scope('abs_outer'):
+        with g.name_scope('name_inner'):
+          self.assertEqual(
+              'abs_outer/name_inner/FloatOutput',
+              g.create_op("FloatOutput", [], [dtypes.float32]).name)
+      with g.absolute_name_scope('abs_outer'):
+        with g.name_scope('name_inner'):
+          self.assertEqual(
+              'abs_outer/name_inner_1/FloatOutput',
+              g.create_op("FloatOutput", [], [dtypes.float32]).name)
+
+    g = ops.Graph()
+    with g.as_default():
+      # abs_scope>abs_scope>abs_scope
+      with g.absolute_name_scope('abs_outer'):
+        with g.absolute_name_scope('abs_middle'):
+          with g.absolute_name_scope('abs_inner'):
+            self.assertEqual(
+                'abs_outer/abs_middle/abs_inner/FloatOutput',
+                g.create_op("FloatOutput", [], [dtypes.float32]).name)
+      with g.absolute_name_scope('abs_outer'):
+        with g.absolute_name_scope('abs_middle'):
+          with g.absolute_name_scope('abs_inner'):
+            self.assertEqual(
+                'abs_outer/abs_middle/abs_inner/FloatOutput_1',
+                g.create_op("FloatOutput", [], [dtypes.float32]).name)
+
+    g = ops.Graph()
+    with g.as_default():
+      # abs_scope>name_scope>abs_scope
+      with g.absolute_name_scope('abs_outer'):
+        with g.name_scope('name_inner'):
+          with g.absolute_name_scope('abs_inner'):
+            self.assertEqual(
+                'abs_outer/name_inner/abs_inner/FloatOutput',
+                g.create_op("FloatOutput", [], [dtypes.float32]).name)
+      with g.absolute_name_scope('abs_outer'):
+        with g.name_scope('name_inner'):
+          with g.absolute_name_scope('abs_inner'):
+            self.assertEqual(
+                'abs_outer/name_inner_1/abs_inner/FloatOutput',
+                g.create_op("FloatOutput", [], [dtypes.float32]).name)
+      with g.absolute_name_scope('abs_outer'):
+        with g.name_scope('name_inner'):
+          with g.absolute_name_scope('abs_inner'):
+            self.assertEqual(
+                'abs_outer/name_inner_2/abs_inner/FloatOutput',
+                g.create_op("FloatOutput", [], [dtypes.float32]).name)
+
 
 class DeviceTest(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
This PR adds a new `name_scope` called `absolute_name_scope` which builds on `name_scope` but allows reusing `name_scope`s without creating a new `name_scope` which is normally uniquified by adding a `_N`.
Based on the discussion in https://github.com/tensorflow/tensorflow/issues/9545