### PR TITLE
[Features] Enable Variable Partitioning in ParameterServerStrategy graph mode

### DIFF
--- a/tensorflow/contrib/distribute/python/parameter_server_strategy.py
+++ b/tensorflow/contrib/distribute/python/parameter_server_strategy.py
@@ -232,7 +232,7 @@ class ParameterServerStrategy(distribute_lib.DistributionStrategy):
     return self._cross_tower_ops.broadcast(tensor, destinations)
 
   def _allow_variable_partition(self):
-    return True if not context.executing_eagerly() else False
+    return not context.executing_eagerly()
 
   # TODO(yuefengz): not all ops in device_setter.STANDARD_PS_OPS will go through
   # this creator, such as "MutableHashTable".

--- a/tensorflow/contrib/distribute/python/parameter_server_strategy.py
+++ b/tensorflow/contrib/distribute/python/parameter_server_strategy.py
@@ -231,6 +231,9 @@ class ParameterServerStrategy(distribute_lib.DistributionStrategy):
       destinations = self._compute_devices
     return self._cross_tower_ops.broadcast(tensor, destinations)
 
+  def _allow_variable_partition(self):
+    return True if not context.executing_eagerly() else False
+
   # TODO(yuefengz): not all ops in device_setter.STANDARD_PS_OPS will go through
   # this creator, such as "MutableHashTable".
   def _create_variable(self, next_creator, *args, **kwargs):

--- a/tensorflow/contrib/distribute/python/parameter_server_strategy_test.py
+++ b/tensorflow/contrib/distribute/python/parameter_server_strategy_test.py
@@ -37,6 +37,7 @@ from tensorflow.python.layers import core
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gradients
+from tensorflow.python.ops import partitioned_variables
 from tensorflow.python.ops import variable_scope
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
@@ -177,6 +178,108 @@ class ParameterServerStrategyTestBase(
         self.assertEqual(y_val, 33.0)
         self.assertEqual(z_val, 43.0)
         self.assertEqual(f_val, 46.0)
+
+  def _test_device_assignment_distributed_enable_partitioner(self,
+                                                             task_type,
+                                                             task_id,
+                                                             num_gpus):
+    worker_device = '/job:%s/replica:0/task:%d' % (task_type, task_id)
+    d, _, sess_config = self._get_test_objects(task_type, task_id, num_gpus)
+    num_shards = len(d.parameter_devices)
+    partitioner = partitioned_variables.fixed_size_partitioner(num_shards)
+    with ops.Graph().as_default(), \
+         self.cached_session(target=self._default_target,
+                             config=sess_config) as sess, \
+         d.scope():
+
+      # Define a variable outside the call_for_each_tower scope. This is not
+      # recommended.
+      n = variable_scope.get_variable(
+          'n',
+          initializer=constant_op.constant([10.0, 20.0]),
+          aggregation=variable_scope.VariableAggregation.SUM,
+          partitioner=partitioner)
+
+      for part_id, var in enumerate(n):
+        self.assertEqual(var.device, '/job:ps/task:%d' % part_id)
+
+      def model_fn():
+        if num_gpus == 0:
+          last_part_device = 'device:CPU:0'
+        else:
+          last_part_device = (
+              'device:GPU:%d' %
+              distribution_strategy_context.get_tower_context().tower_id)
+
+        a = constant_op.constant([1.0, 2.0])
+        b = constant_op.constant([2.0, 3.0])
+        c = a + b
+        self.assertEqual(a.device, worker_device + '/' + last_part_device)
+        self.assertEqual(b.device, worker_device + '/' + last_part_device)
+        self.assertEqual(c.device, worker_device + '/' + last_part_device)
+
+        # The device scope is ignored for variables but not for normal ops.
+        with ops.device('/job:worker/task:0'):
+          x = variable_scope.get_variable(
+              'x',
+              initializer=constant_op.constant([10.0, 20.0]),
+              aggregation=variable_scope.VariableAggregation.SUM,
+              partitioner=partitioner)
+          x_add = x.assign_add(c, name="x_Add")
+          e = a + c
+        # The variable x is on the task 1 since the device_function has been
+        # called once before the model_fn.
+        for part_id, var in enumerate(x):
+          self.assertEqual(var.device, '/job:ps/task:%d' % part_id)
+          self.assertEqual(var.device, x_add[part_id].device)
+
+        self.assertEqual(e.device,
+                         '/job:worker/replica:0/task:0/%s' % last_part_device)
+
+        # The colocate_vars_with can override the distribution's device.
+        with d.colocate_vars_with(x_add[0]):
+          y = variable_scope.get_variable(
+              'y',
+              initializer=constant_op.constant([20.0, 10.0]),
+              aggregation=variable_scope.VariableAggregation.SUM,
+              partitioner=partitioner)
+        y_add = y.assign_add([array_ops.identity(x_add[0]),
+                              array_ops.identity(x_add[1])])
+
+        for part_id, var in enumerate(y):
+          self.assertEqual(var.device, '/job:ps/task:0')
+          self.assertEqual(y_add[part_id].device, var.device)
+          self.assertEqual(var.device, x_add[0].device)
+
+        z = variable_scope.get_variable(
+            'z',
+            initializer=constant_op.constant([10.0, 30.0]),
+            aggregation=variable_scope.VariableAggregation.SUM,
+            partitioner=partitioner)
+
+        for task_id, var in enumerate(z):
+          self.assertEqual(var.device, '/job:ps/task:%d' % task_id)
+
+        with ops.control_dependencies(y_add):
+          y_list = [var for var in y]
+          y_tensor = array_ops.concat(y_list, 0)
+          z_add = z.assign_add(array_ops.identity(y_tensor))
+        with ops.control_dependencies(z_add):
+          z_list = [var for var in z]
+          z_tensor = array_ops.concat(z_list, 0)
+          f = z_tensor + c
+        self.assertEqual(f.device, worker_device + '/' + last_part_device)
+
+        return y_add, z_add, f
+
+      y, z, f = d.call_for_each_tower(model_fn)
+
+      if context.num_gpus() >= 1 and num_gpus <= 1:
+        variables.global_variables_initializer().run()
+        y_val, z_val, f_val = sess.run([y, z, f])
+        self.assertEqual(y_val, [33.0, 35.0])
+        self.assertEqual(z_val, [43.0, 65.0])
+        self.assertEqual(tuple(f_val), (46.0, 70.0))
 
   def _test_device_assignment_local(self,
                                     d,
@@ -472,6 +575,12 @@ class ParameterServerStrategyTest(ParameterServerStrategyTestBase,
       combinations.combine(mode=['graph'], num_gpus=[0, 1, 2]))
   def testDeviceAssignmentDistributed(self, num_gpus):
     self._test_device_assignment_distributed('worker', 1, num_gpus)
+
+  @combinations.generate(
+      combinations.combine(mode=['graph'], num_gpus=[0, 1, 2]))
+  def testDeviceAssignmentDistributedEnablePartitioner(self, num_gpus):
+    self._test_device_assignment_distributed_enable_partitioner(
+        'worker', 1, num_gpus)
 
   def testSimpleBetweenGraph(self):
     self._run_between_graph_clients(self._test_simple_increment,

--- a/tensorflow/contrib/distribute/python/parameter_server_strategy_test.py
+++ b/tensorflow/contrib/distribute/python/parameter_server_strategy_test.py
@@ -191,8 +191,6 @@ class ParameterServerStrategyTestBase(
                              config=sess_config) as sess, \
          d.scope():
 
-      # Define a variable outside the call_for_each_tower scope. This is not
-      # recommended.
       n = variable_scope.get_variable(
           'n',
           initializer=constant_op.constant([10.0, 20.0]),

--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -625,6 +625,15 @@ class _VariableStore(object):
         variable and return the Tensor for the projected value
         (which must have the same shape). Constraints are not safe to
         use when doing asynchronous distributed training.
+      synchronization: Indicates when a distributed a variable will be
+        aggregated. Accepted values are constants defined in the class
+        `tf.VariableSynchronization`. By default the synchronization is set to
+        `AUTO` and the current `DistributionStrategy` chooses
+        when to synchronize. If `synchronization` is set to `ON_READ`,
+        `trainable` must not be set to `True`.
+      aggregation: Indicates how a distributed variable will be aggregated.
+        Accepted values are constants defined in the class
+        `tf.VariableAggregation`.
 
     Returns:
       A `PartitionedVariable` object.
@@ -1732,6 +1741,15 @@ def _get_partitioned_variable(name,
       variable and return the Tensor for the projected value
       (which must have the same shape). Constraints are not safe to
       use when doing asynchronous distributed training.
+    synchronization: Indicates when a distributed a variable will be
+      aggregated. Accepted values are constants defined in the class
+      `tf.VariableSynchronization`. By default the synchronization is set to
+      `AUTO` and the current `DistributionStrategy` chooses
+      when to synchronize. If `synchronization` is set to `ON_READ`,
+      `trainable` must not be set to `True`.
+    aggregation: Indicates how a distributed variable will be aggregated.
+      Accepted values are constants defined in the class
+      `tf.VariableAggregation`.
 
   Returns:
     A tuple `(shards, partitions)` where `shards` is the list of `Variable`

--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -449,7 +449,9 @@ class _VariableStore(object):
                                                 partitioner=partitioner,
                                                 validate_shape=validate_shape,
                                                 use_resource=use_resource,
-                                                constraint=constraint)
+                                                constraint=constraint,
+                                                synchronization=synchronization,
+                                                aggregation=aggregation)
 
       # Special case for partitioned variable to allow reuse without having to
       # specify partitioner.
@@ -467,7 +469,9 @@ class _VariableStore(object):
                                               partitioner=None,
                                               validate_shape=validate_shape,
                                               use_resource=use_resource,
-                                              constraint=constraint)
+                                              constraint=constraint,
+                                              synchronization=synchronization,
+                                              aggregation=aggregation)
 
       # Single variable case
       if "%s/part_0" % name in self._vars:
@@ -553,7 +557,9 @@ class _VariableStore(object):
                                 caching_device=None,
                                 validate_shape=True,
                                 use_resource=None,
-                                constraint=None):
+                                constraint=None,
+                                synchronization=VariableSynchronization.AUTO,
+                                aggregation=VariableAggregation.NONE):
     """Gets or creates a sharded variable list with these parameters.
 
     The `partitioner` must be a callable that accepts a fully defined
@@ -776,7 +782,9 @@ class _VariableStore(object):
             caching_device=caching_device,
             validate_shape=validate_shape,
             use_resource=use_resource,
-            constraint=constraint)
+            constraint=constraint,
+            synchronization=synchronization,
+            aggregation=aggregation)
 
       # pylint: disable=protected-access
       var._set_save_slice_info(variables.Variable.SaveSliceInfo(
@@ -1254,7 +1262,9 @@ class VariableScope(object):
                                 partitioner=None,
                                 validate_shape=True,
                                 use_resource=None,
-                                constraint=None):
+                                constraint=None,
+                                synchronization=VariableSynchronization.AUTO,
+                                aggregation=VariableAggregation.NONE):
     """Gets an existing variable with this name or create a new one."""
     if context.executing_eagerly():
       raise NotImplementedError("Partitioned variables are not yet supported "
@@ -1304,7 +1314,8 @@ class VariableScope(object):
           regularizer=regularizer, reuse=self.reuse, trainable=trainable,
           collections=collections, caching_device=caching_device,
           partitioner=partitioner, validate_shape=validate_shape,
-          use_resource=use_resource, constraint=constraint)
+          use_resource=use_resource, constraint=constraint,
+          synchronization=synchronization, aggregation=aggregation)
       # pylint: enable=protected-access
 
 
@@ -1661,7 +1672,9 @@ def _get_partitioned_variable(name,
                               partitioner=None,
                               validate_shape=True,
                               use_resource=None,
-                              constraint=None):
+                              constraint=None,
+                              synchronization=VariableSynchronization.AUTO,
+                              aggregation=VariableAggregation.NONE):
   """Gets or creates a sharded variable list with these parameters.
 
   The `partitioner` must be a callable that accepts a fully defined
@@ -1744,7 +1757,8 @@ def _get_partitioned_variable(name,
       initializer=initializer, regularizer=regularizer, trainable=trainable,
       collections=collections, caching_device=caching_device,
       partitioner=partitioner, validate_shape=validate_shape,
-      use_resource=use_resource, constraint=constraint)
+      use_resource=use_resource, constraint=constraint,
+      synchronization=synchronization, aggregation=aggregation)
   # pylint: enable=protected-access
 
 

--- a/tensorflow/python/training/distribute.py
+++ b/tensorflow/python/training/distribute.py
@@ -458,19 +458,23 @@ class DistributionStrategy(object):
       kwargs["use_resource"] = True
       return self._create_variable(*args, **kwargs)
 
-    def disable_partitioned_variables(getter, *args, **kwargs):
-      if kwargs.pop("partitioner", None) is not None:
-        tf_logging.log_first_n(
-            tf_logging.WARN, "Partitioned variables are disabled when using "
-            "DistributionStrategy.", 1)
+    def distributed_getter(getter, *args, **kwargs):
+      if not self._allow_variable_partition():
+        if kwargs.pop("partitioner", None) is not None:
+          tf_logging.log_first_n(
+              tf_logging.WARN, "Partitioned variables are disabled when using "
+              "current DistributionStrategy.", 1)
       return getter(*args, **kwargs)
 
     return _CurrentDistributionContext(
         self, variable_scope.variable_creator_scope(creator_with_resource_vars),
         variable_scope.variable_scope(
             variable_scope.get_variable_scope(),
-            custom_getter=disable_partitioned_variables),
+            custom_getter=distributed_getter),
         self._default_device)
+
+  def _allow_variable_partition(self):
+    return False
 
   def _create_variable(self, next_creator, *args, **kwargs):
     # Note: should support "colocate_with" argument.


### PR DESCRIPTION
Hi @yuefengz ,

Variable Partitioning is very important in Parameter Server architecture for loading balancing. It has been widely used in Recommendation systems for distributing the large embedding variables. 

In `DistributionStrategy` architecture, the variable partitioner is ignored to all cases. I understand it will be complicated if we enable variables partitioner to all cases such as  `Eager`. It may be even involved with the `PartitionVariableScope` in TF 2.0 which will influence `tf.Variable` declaration with `tf.variable_creator_scope`.  However, it is easy and suitable to support partitioning on `ParameterServerStrategy` in graph mode. Every subclasses of  `DistributionStrategy` can override `_allow_variable_partition` method to decide whether to enable it or not. Currently, only `ParameterServerStrategy` has override it.

It would be appreciated to have a discussion  if there is another solutions to support variable partitioner.

Thanks.