### PR TITLE
Improve shape function of tf.sparse_reduce_sum

### DIFF
--- a/tensorflow/core/ops/sparse_ops.cc
+++ b/tensorflow/core/ops/sparse_ops.cc
@@ -423,7 +423,46 @@ REGISTER_OP("SparseReduceSum")
     .Attr("keep_dims: bool = False")
     .Output("output: T")
     .Attr("T: numbertype")
-    .SetShapeFn(shape_inference::UnknownShape);
+    .SetShapeFn([](InferenceContext* c) {
+      bool keep_dims = false;
+      TF_RETURN_IF_ERROR(c->GetAttr("keep_dims", &keep_dims));
+
+      const Tensor* shape_tensor = c->input_tensor(2);
+      const Tensor* axes_tensor = c->input_tensor(3);
+      if (shape_tensor != nullptr && axes_tensor != nullptr) {
+        auto shape_vec = shape_tensor->flat<int64>();
+        auto axes_vec = axes_tensor->flat<int32>();
+
+        int64 ndims = shape_vec.size();
+        std::unordered_set<int64> axes;
+        for (int i = 0; i < axes_vec.size(); i++) {
+          axes.insert((axes_vec(i) + ndims) % ndims);
+        }
+
+        std::vector<DimensionHandle> dims;
+        if (keep_dims) {
+          dims.reserve(ndims);
+          for (int d = 0; d < ndims; ++d) {
+            if (axes.find(d) == axes.end()) {
+              dims.push_back(c->MakeDim(shape_vec(d)));
+            } else {
+              dims.push_back(c->MakeDim(1));
+            }
+          }
+        } else {
+          for (int d = 0; d < ndims; ++d) {
+            if (axes.find(d) == axes.end()) {
+              dims.push_back(c->MakeDim(shape_vec(d)));
+            }
+          }
+
+        }
+
+        c->set_output(0, c->MakeShape(dims));
+        return Status::OK();
+      }
+      return shape_inference::UnknownShape(c);
+    });
 
 REGISTER_OP("SparseReduceSumSparse")
     .Input("input_indices: int64")

--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -747,20 +747,14 @@ class SparseReduceTest(test_util.TensorFlowTestCase):
     sp_t = sparse_tensor.SparseTensor(self.ind, self.vals, self.dense_shape)
 
     with self.session(use_gpu=False):
-      self._testSparseReduceSumShape(sp_t, None, ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, None, ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, 0, ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, 0, ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [1], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [1], ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [0, 1], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [0, 1], ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [1, 0], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [1, 0], ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [-1], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [-1], ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [1, -2], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [1, -2], ndims=2, keep_dims=True)
+      for keep_dims in [True, False]:
+        self._testSparseReduceSumShape(sp_t, None, ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, 0, ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [0, 1], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1, 0], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [-1], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1, -2], ndims=2, keep_dims=keep_dims)
 
 
 class SparseMathOpsTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -748,13 +748,13 @@ class SparseReduceTest(test_util.TensorFlowTestCase):
 
     with self.session(use_gpu=False):
       for keep_dims in [True, False]:
-        self._testSparseReduceSumShape(sp_t, None, ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, 0, ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [1], ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [0, 1], ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [1, 0], ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [-1], ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [1, -2], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, None, 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, 0, 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1], 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [0, 1], 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1, 0], 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [-1], 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1, -2], 2, keep_dims)
 
 
 class SparseMathOpsTest(test_util.TensorFlowTestCase):


### PR DESCRIPTION
This fix tries to address the issue raised in #23114 where the shape function of tf.sparse_reduce_sum did not infer the shape even if the input shape were known. This fix improves the shape function.

This fix fixes #23114.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>