### PR TITLE
1.12.0-rc2 cherry-pick request: Upgrade setuptools before clean pip install pulls in absl-py.

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip.sh
+++ b/tensorflow/tools/ci_build/builds/pip.sh
@@ -321,6 +321,12 @@ create_activate_virtualenv_and_install_tensorflow() {
   # some versions in python
   curl https://bootstrap.pypa.io/get-pip.py | python
 
+  # Force upgrade of setuptools. This must happen before the pip install of the
+  # WHL_PATH, which pulls in absl-py, which uses install_requires notation
+  # introduced in setuptools >=20.5. The default version of setuptools is 5.5.1,
+  # which is too old for absl-py.
+  pip install --upgrade setuptools==39.1.0
+
   # Force tensorflow reinstallation. Otherwise it may not get installed from
   # last build if it had the same version number as previous build.
   PIP_FLAGS="--upgrade --force-reinstall"
@@ -328,9 +334,11 @@ create_activate_virtualenv_and_install_tensorflow() {
     die "pip install (forcing to reinstall tensorflow) FAILED"
   echo "Successfully installed pip package ${TF_WHEEL_PATH}"
 
-  # Force downgrade setuptools.
+  # Force downgrade of setuptools. This must happen after the pip install of the
+  # WHL_PATH, which ends up upgrading to the latest version of setuptools.
+  # Versions of setuptools >= 39.1.0 will cause tests to fail like this:
+  #   ImportError: cannot import name py31compat
   pip install --upgrade setuptools==39.1.0
-
 }
 
 ################################################################################


### PR DESCRIPTION
absl-py recently added a version dependency to the package, causing
install to fail on the old setuptools

PiperOrigin-RevId: 218783878