### PR TITLE
[XLA] Remove dependency on having a GPU to run jit tests

### DIFF
--- a/tensorflow/compiler/jit/BUILD
+++ b/tensorflow/compiler/jit/BUILD
@@ -586,7 +586,6 @@ tf_cc_test(
         ":node_matchers",
         ":xla_cluster_util",
         ":xla_cpu_device",
-        ":xla_gpu_device",
         "//tensorflow/cc:cc_ops",
         "//tensorflow/cc:cc_ops_internal",
         "//tensorflow/cc:function_ops",
@@ -600,6 +599,7 @@ tf_cc_test(
         "//tensorflow/compiler/tf2xla/cc:xla_jit_ops",
         "//tensorflow/compiler/tf2xla/cc:xla_ops",
         "//tensorflow/compiler/tf2xla/kernels:xla_ops",
+        "//tensorflow/compiler/xla/service:platform_util",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
         "//tensorflow/core:framework_internal",
@@ -612,7 +612,9 @@ tf_cc_test(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
-    ],
+    ] + if_cuda_is_configured([
+        ":xla_gpu_device",
+    ]),
 )
 
 tf_cc_test(

--- a/tensorflow/compiler/jit/mark_for_compilation_pass_test.cc
+++ b/tensorflow/compiler/jit/mark_for_compilation_pass_test.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/compiler/jit/defs.h"
 #include "tensorflow/compiler/tf2xla/xla_op_kernel.h"
 #include "tensorflow/compiler/tf2xla/xla_op_registry.h"
+#include "tensorflow/compiler/xla/service/platform_util.h"
 #include "tensorflow/core/framework/node_def_util.h"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/graph/algorithm.h"
@@ -896,6 +897,11 @@ TEST(XlaCompilationTest, RandomShapeWithFunc) {
 }
 
 TEST(XlaCompilationTest, RandomShapeOnXlaDevice) {
+  auto plat = xla::PlatformUtil::GetPlatform("gpu");
+  if (!plat.ok()) {
+    return;
+  }
+
   absl::string_view xla_gpu_device =
       "/job:worker/replica:0/task:0/device:XLA_GPU:0";
 
@@ -929,6 +935,11 @@ TEST(XlaCompilationTest, RandomShapeOnXlaDevice) {
 }
 
 TEST(XlaCompilationTest, TensorArrayShapeOnXlaDevice) {
+  auto plat = xla::PlatformUtil::GetPlatform("gpu");
+  if (!plat.ok()) {
+    return;
+  }
+
   absl::string_view xla_gpu_device =
       "/job:worker/replica:0/task:0/device:XLA_GPU:0";
   Scope root = Scope::NewRootScope().ExitOnError();


### PR DESCRIPTION
This test is set up to require the GPU device, but not all systems have a GPU device in them.

This change removes the need for a GPU device to be present, both at compile time (where the xla_gpu_device was compiled in and therefore required CUDA support to be compiled in), and also at run time, where the GPU device was being targeted in a test, when it might not have been registered.
