### PR TITLE
Fix T-distribution sampling parameter

### DIFF
--- a/tensorflow/python/ops/distributions/student_t.py
+++ b/tensorflow/python/ops/distributions/student_t.py
@@ -256,7 +256,7 @@ class StudentT(distribution.Distribution):
     gamma_sample = random_ops.random_gamma(
         [n],
         0.5 * df,
-        beta=0.5,
+        beta=2,
         dtype=self.dtype,
         seed=distribution_util.gen_new_seed(seed, salt="student_t"))
     samples = normal_sample * math_ops.rsqrt(gamma_sample / df)


### PR DESCRIPTION
To sample a chi-square (df=n) distribution requires a gamma distribution with shape = df/2 and rate = 2. I believe this is a mistype by the previous contributor. For reference: https://stats.stackexchange.com/questions/118676/relationship-between-gamma-and-chi-squared-distribution