### PR TITLE
Add a line break when logging the graph definition

### DIFF
--- a/tensorflow/core/common_runtime/graph_execution_state.cc
+++ b/tensorflow/core/common_runtime/graph_execution_state.cc
@@ -76,7 +76,7 @@ GraphExecutionState::~GraphExecutionState() {
     GraphDef* graph_def, const GraphExecutionStateOptions& options,
     std::unique_ptr<GraphExecutionState>* out_state) {
 #ifndef __ANDROID__
-  VLOG(4) << "Graph proto is " << graph_def->DebugString();
+  VLOG(4) << "Graph proto is \n" << graph_def->DebugString();
 #endif  // __ANDROID__
 
   std::unique_ptr<GraphExecutionState> ret(


### PR DESCRIPTION
This PR adds a line break to make the log of the graph proto easier to read. 

Without the line break, the log info will be like this:
```
2018-10-26 22:09:38.402045: I tensorflow/core/common_runtime/graph_execution_state.cc:79] Graph proto is node {
  name: "start"
  op: "Const"
  attr {
    key: "dtype"
    value {
      type: DT_INT64
    }
  }
.......
```

This PR makes it as below:
```
2018-10-26 22:09:38.402045: I tensorflow/core/common_runtime/graph_execution_state.cc:79] Graph proto is 
node {
  name: "start"
  op: "Const"
  attr {
    key: "dtype"
    value {
      type: DT_INT64
    }
  }
.......
```



