### PR TITLE
Add scaling op and transform to contrib.image

### DIFF
--- a/tensorflow/contrib/image/__init__.py
+++ b/tensorflow/contrib/image/__init__.py
@@ -32,6 +32,8 @@ projective transforms (including rotation) are supported.
 @@transform
 @@translate
 @@translations_to_projective_transforms
+@@scale
+@@scales_to_projective_transforms
 @@dense_image_warp
 @@interpolate_spline
 @@sparse_image_warp
@@ -67,6 +69,8 @@ from tensorflow.contrib.image.python.ops.image_ops import rotate
 from tensorflow.contrib.image.python.ops.image_ops import transform
 from tensorflow.contrib.image.python.ops.image_ops import translate
 from tensorflow.contrib.image.python.ops.image_ops import translations_to_projective_transforms
+from tensorflow.contrib.image.python.ops.image_ops import scale
+from tensorflow.contrib.image.python.ops.image_ops import scales_to_projective_transforms
 from tensorflow.contrib.image.python.ops.interpolate_spline import interpolate_spline
 from tensorflow.contrib.image.python.ops.single_image_random_dot_stereograms import single_image_random_dot_stereograms
 from tensorflow.contrib.image.python.ops.sparse_image_warp import sparse_image_warp

--- a/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
+++ b/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
@@ -106,6 +106,22 @@ class ImageOpsTest(test_util.TensorFlowTestCase):
                              [1, 0, 1, 0],
                              [0, 0, 0, 0]])
 
+  def test_scale(self):
+    for dtype in _DTYPES:
+      with self.cached_session():
+        image = constant_op.constant(
+            [[1, 1, 1, 1],
+             [1, 1, 1, 1],
+             [0, 0, 0, 0],
+             [0, 0, 0, 0]], dtype=dtype)
+        scaler = constant_op.constant([.5], dtypes.float32)
+        image_scaled = image_ops.scale(image, scaler)
+        self.assertAllEqual(image_scaled.eval(),
+                            [[0, 0, 0, 0],
+                             [0, 1, 1, 0],
+                             [0, 0, 0, 0],
+                             [0, 0, 0, 0]])
+
   def test_compose(self):
     for dtype in _DTYPES:
       with self.cached_session():


### PR DESCRIPTION
This add scale and scales_to_projective_transforms ops to contrib.image. This is useful for efficient data augmentation since we can compose transformations.