### PR TITLE
Use bash in makefile to avoid unknown [[ error 

### DIFF
--- a/tensorflow/contrib/lite/tools/make/Makefile
+++ b/tensorflow/contrib/lite/tools/make/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 # Find where we're running from, so we can store generated files here.
 ifeq ($(origin MAKEFILE_DIR), undefined)
 	MAKEFILE_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
When building `tflite` with makefile using this command, 
```
make -f tensorflow/contrib/lite/tools/make/Makefile
```
we observed this error for determining host architecture
```
/bin/sh: 1: [[: not found
```