### PR TITLE
Add required compilation options to build libtensorflow-lite.a

### DIFF
--- a/tensorflow/contrib/lite/tools/make/targets/linux_makefile.inc
+++ b/tensorflow/contrib/lite/tools/make/targets/linux_makefile.inc
@@ -4,6 +4,10 @@ ifeq ($(TARGET), linux)
     -fPIC \
     -DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK \
     -pthread
+  CCFLAGS += \
+    -fPIC \
+    -DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK \
+    -pthread
   # TODO(petewarden): In the future we may want to add architecture-specific
   # flags like -msse4.2
 	LIBS += -ldl


### PR DESCRIPTION
This PR fixes generating some object files for libtensorflow-lite.a without -fPIC for linux.
I think makefiles for other systems are likely to have the same problem.