### PR TITLE
Fix the issue for class_weight used with tf.dataset

### DIFF
--- a/tensorflow/python/keras/engine/training_utils_test.py
+++ b/tensorflow/python/keras/engine/training_utils_test.py
@@ -27,6 +27,7 @@ from tensorflow.python.data.ops import readers
 from tensorflow.python.eager import context
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
 from tensorflow.python.keras.engine import training_utils
 from tensorflow.python.keras.utils import tf_utils
 from tensorflow.python.platform import test
@@ -225,13 +226,9 @@ class StandardizeWeightsTest(keras_parameterized.TestCase):
     expected = sample_weights * np.array([0.5, 1., 0.5, 0.5, 1.5])
     self.assertAllClose(weights, expected)
 
-  @tf_test_util.run_in_graph_and_eager_modes
   def test_dataset_with_class_weight(self):
     model = testing_utils.get_small_functional_mlp(1, 4, input_dim=3)
-    optimizer = RMSPropOptimizer(learning_rate=0.001)
-    loss = 'mse'
-    metrics = ['mae', metrics_module.CategoricalAccuracy()]
-    model.compile(optimizer, loss, metrics=metrics)
+    model.compile('rmsprop', 'mse')
 
     inputs = np.zeros((10, 3), np.float32)
     targets = np.zeros((10, 4), np.float32)


### PR DESCRIPTION

This fix tries to address the issue raised in #22275 where class_weight used with tf.dataset will result in:
```
AxisError: axis 1 is out of bounds for array of dimension 1
```

This fix fixes the issue by taking into account that y
could be tensor.

This fix fixes #22275.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>