### PR TITLE
[Intel MKL] Fix docker ffmpeg issue

### DIFF
--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -43,9 +43,9 @@ apt-get install -y --no-install-recommends \
     automake \
     build-essential \
     clang-format-3.8 \
-    curl \
+    curl
     ## TODO(yifeif) remove once ffmpeg is removed from contrib
-    ffmpeg \
+apt-get install -y --no-install-recommends ffmpeg \
     git \
     libcurl4-openssl-dev \
     libtool \


### PR DESCRIPTION
Comment in the "apt-get install" broke the command stream: https://github.com/NervanaSystems/private-tensorflow/blob/master/tensorflow/tools/ci_build/install/install_deb_packages.sh#L47 

Restart the apt-get install ffmpeg after comment. 

@yifeif  FYI. 