### PR TITLE
Avoid index out of range in traceable_stack

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -4250,7 +4250,8 @@ class Graph(object):
       A context manager that specifies the default device to use for newly
       created ops.
     """
-    self._add_device_to_stack(device_name_or_function, offset=2)
+    offset = 2 if (len(tf_stack.extract_stack()) > 2) else 1
+    self._add_device_to_stack(device_name_or_function, offset=offset)
     try:
       yield
     finally:

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -4250,8 +4250,7 @@ class Graph(object):
       A context manager that specifies the default device to use for newly
       created ops.
     """
-    offset = 2 if (len(tf_stack.extract_stack()) > 2) else 1
-    self._add_device_to_stack(device_name_or_function, offset=offset)
+    self._add_device_to_stack(device_name_or_function, offset=2)
     try:
       yield
     finally:

--- a/tensorflow/python/framework/traceable_stack.py
+++ b/tensorflow/python/framework/traceable_stack.py
@@ -61,8 +61,11 @@ class TraceableObject(object):
     if len(frame_records) >= local_offset:
       # Negative indexing is one-indexed instead of zero-indexed.
       negative_offset = -(local_offset + 1)
-      self.filename, self.lineno = frame_records[negative_offset][:2]
-      return self.SUCCESS
+      if len(frame_records) > local_offset:
+        self.filename, self.lineno = frame_records[negative_offset][:2]
+        return self.SUCCESS
+      else:
+        return self.FAILURE
     else:
       # If the offset is too large then we use the largest offset possible,
       # meaning we use the outermost stack frame at index 0.

--- a/tensorflow/python/framework/traceable_stack.py
+++ b/tensorflow/python/framework/traceable_stack.py
@@ -58,14 +58,11 @@ class TraceableObject(object):
     frame_records = tf_stack.extract_stack()
     if not frame_records:
       return self.FAILURE
-    if len(frame_records) >= local_offset:
+    if len(frame_records) > local_offset:
       # Negative indexing is one-indexed instead of zero-indexed.
       negative_offset = -(local_offset + 1)
-      if len(frame_records) > local_offset:
-        self.filename, self.lineno = frame_records[negative_offset][:2]
-        return self.SUCCESS
-      else:
-        return self.FAILURE
+      self.filename, self.lineno = frame_records[negative_offset][:2]
+      return self.SUCCESS
     else:
       # If the offset is too large then we use the largest offset possible,
       # meaning we use the outermost stack frame at index 0.


### PR DESCRIPTION
Fix for https://github.com/rstudio/tensorflow/issues/272 which blocks use of devices in TensorFlow 1.11.

An `list index out of range` exception triggers in [traceable_stack.py#L64](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/traceable_stack.py#L64) which is initialized in [ops.py#L4253](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/ops.py#L4253) when running from R:

```
library(tensorflow)
data <- tf$device("/cpu:0")
context <- data$`__enter__`()
```

The frame records from `tf_stack.extract_stack()` at [ops.py#L4253](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/ops.py#L4253) looks like:

```
<stdin>
/…/r-tensorflow/lib/python3.6/contextlib.py
/…/r-tensorflow/lib/python3.6/site-packages/tensorflow/python/framework/ops.py
```

However, while used from R and other tools that embed Python directly, looks like:

```
/…/r-tensorflow/lib/python3.6/contextlib.py
/…/r-tensorflow/lib/python3.6/site-packages/tensorflow/python/framework/ops.py
```

Since the Python interpreter is not available when called from R (which embeds Python as a library), `<stdin>` is missing. One fix is to protect against this be reducing the call stack offset when shorter than expected.

Please let us know if you have additional feedback or suggestions to get them implemented, thanks!

Change of behavior originally introduced with https://github.com/tensorflow/tensorflow/commit/e5cc33df74ec4f761da26c87bb785edfa3fb8280.