### PR TITLE
Improve shape function of tf.sparse_reduce_sum

### DIFF
--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -1549,6 +1549,51 @@ Status ExplicitShapes(InferenceContext* c) {
   return Status::OK();
 }
 
+Status SparseReduceShapeFn(InferenceContext* c) {
+  // Input 0: input_indices
+  // Input 1: input_values
+  // Input 2: input_shape
+  // Input 3: reduction_axes
+  // Attr: keep_dims
+  bool keep_dims = false;
+  TF_RETURN_IF_ERROR(c->GetAttr("keep_dims", &keep_dims));
+
+  const Tensor* shape_tensor = c->input_tensor(2);
+  const Tensor* axes_tensor = c->input_tensor(3);
+  if (shape_tensor != nullptr && axes_tensor != nullptr) {
+    auto shape_vec = shape_tensor->flat<int64>();
+    auto axes_vec = axes_tensor->flat<int32>();
+
+    int64 ndims = shape_vec.size();
+    std::unordered_set<int64> axes;
+    for (int i = 0; i < axes_vec.size(); i++) {
+      axes.insert((axes_vec(i) + ndims) % ndims);
+    }
+
+    std::vector<DimensionHandle> dims;
+    if (keep_dims) {
+      dims.reserve(ndims);
+      for (int d = 0; d < ndims; ++d) {
+        if (axes.find(d) == axes.end()) {
+          dims.push_back(c->MakeDim(shape_vec(d)));
+        } else {
+          dims.push_back(c->MakeDim(1));
+        }
+      }
+    } else {
+      for (int d = 0; d < ndims; ++d) {
+        if (axes.find(d) == axes.end()) {
+          dims.push_back(c->MakeDim(shape_vec(d)));
+        }
+      }
+    }
+
+    c->set_output(0, c->MakeShape(dims));
+    return Status::OK();
+  }
+  return UnknownShape(c);
+}
+
 }  // namespace shape_inference
 
 }  // namespace tensorflow

--- a/tensorflow/core/framework/common_shape_fns.h
+++ b/tensorflow/core/framework/common_shape_fns.h
@@ -310,6 +310,9 @@ Status ExplicitShape(InferenceContext* c);
 // Shape function for multiple-output ops with an explicit "shapes" attribute.
 Status ExplicitShapes(InferenceContext* c);
 
+// Shape function for SparseReduceMax and SparseReduceSum.
+Status SparseReduceShapeFn(InferenceContext* c);
+
 }  // namespace shape_inference
 
 }  // namespace tensorflow

--- a/tensorflow/core/ops/sparse_ops.cc
+++ b/tensorflow/core/ops/sparse_ops.cc
@@ -39,6 +39,51 @@ Status SparseSparseMinOrMaxShapeFn(InferenceContext* c) {
   return Status::OK();
 }
 
+Status SparseReduceShapeFn(InferenceContext* c) {
+  // Input 0: input_indices
+  // Input 1: input_values
+  // Input 2: input_shape
+  // Input 3: reduction_axes
+  // Attr: keep_dims
+  bool keep_dims = false;
+  TF_RETURN_IF_ERROR(c->GetAttr("keep_dims", &keep_dims));
+
+  const Tensor* shape_tensor = c->input_tensor(2);
+  const Tensor* axes_tensor = c->input_tensor(3);
+  if (shape_tensor != nullptr && axes_tensor != nullptr) {
+    auto shape_vec = shape_tensor->flat<int64>();
+    auto axes_vec = axes_tensor->flat<int32>();
+
+    int64 ndims = shape_vec.size();
+    std::unordered_set<int64> axes;
+    for (int i = 0; i < axes_vec.size(); i++) {
+      axes.insert((axes_vec(i) + ndims) % ndims);
+    }
+
+    std::vector<DimensionHandle> dims;
+    if (keep_dims) {
+      dims.reserve(ndims);
+      for (int d = 0; d < ndims; ++d) {
+        if (axes.find(d) == axes.end()) {
+          dims.push_back(c->MakeDim(shape_vec(d)));
+        } else {
+          dims.push_back(c->MakeDim(1));
+        }
+      }
+    } else {
+      for (int d = 0; d < ndims; ++d) {
+        if (axes.find(d) == axes.end()) {
+          dims.push_back(c->MakeDim(shape_vec(d)));
+        }
+      }
+    }
+
+    c->set_output(0, c->MakeShape(dims));
+    return Status::OK();
+  }
+  return shape_inference::UnknownShape(c);
+}
+
 }  // namespace
 
 REGISTER_OP("SparseAddGrad")
@@ -401,7 +446,7 @@ REGISTER_OP("SparseReduceMax")
     .Attr("keep_dims: bool = False")
     .Output("output: T")
     .Attr("T: realnumbertype")
-    .SetShapeFn(shape_inference::UnknownShape);
+    .SetShapeFn(SparseReduceShapeFn);
 
 REGISTER_OP("SparseReduceMaxSparse")
     .Input("input_indices: int64")
@@ -423,45 +468,7 @@ REGISTER_OP("SparseReduceSum")
     .Attr("keep_dims: bool = False")
     .Output("output: T")
     .Attr("T: numbertype")
-    .SetShapeFn([](InferenceContext* c) {
-      bool keep_dims = false;
-      TF_RETURN_IF_ERROR(c->GetAttr("keep_dims", &keep_dims));
-
-      const Tensor* shape_tensor = c->input_tensor(2);
-      const Tensor* axes_tensor = c->input_tensor(3);
-      if (shape_tensor != nullptr && axes_tensor != nullptr) {
-        auto shape_vec = shape_tensor->flat<int64>();
-        auto axes_vec = axes_tensor->flat<int32>();
-
-        int64 ndims = shape_vec.size();
-        std::unordered_set<int64> axes;
-        for (int i = 0; i < axes_vec.size(); i++) {
-          axes.insert((axes_vec(i) + ndims) % ndims);
-        }
-
-        std::vector<DimensionHandle> dims;
-        if (keep_dims) {
-          dims.reserve(ndims);
-          for (int d = 0; d < ndims; ++d) {
-            if (axes.find(d) == axes.end()) {
-              dims.push_back(c->MakeDim(shape_vec(d)));
-            } else {
-              dims.push_back(c->MakeDim(1));
-            }
-          }
-        } else {
-          for (int d = 0; d < ndims; ++d) {
-            if (axes.find(d) == axes.end()) {
-              dims.push_back(c->MakeDim(shape_vec(d)));
-            }
-          }
-        }
-
-        c->set_output(0, c->MakeShape(dims));
-        return Status::OK();
-      }
-      return shape_inference::UnknownShape(c);
-    });
+    .SetShapeFn(SparseReduceShapeFn);
 
 REGISTER_OP("SparseReduceSumSparse")
     .Input("input_indices: int64")

--- a/tensorflow/core/ops/sparse_ops.cc
+++ b/tensorflow/core/ops/sparse_ops.cc
@@ -423,7 +423,46 @@ REGISTER_OP("SparseReduceSum")
     .Attr("keep_dims: bool = False")
     .Output("output: T")
     .Attr("T: numbertype")
-    .SetShapeFn(shape_inference::UnknownShape);
+    .SetShapeFn([](InferenceContext* c) {
+      bool keep_dims = false;
+      TF_RETURN_IF_ERROR(c->GetAttr("keep_dims", &keep_dims));
+
+      const Tensor* shape_tensor = c->input_tensor(2);
+      const Tensor* axes_tensor = c->input_tensor(3);
+      if (shape_tensor != nullptr && axes_tensor != nullptr) {
+        auto shape_vec = shape_tensor->flat<int64>();
+        auto axes_vec = axes_tensor->flat<int32>();
+
+        int64 ndims = shape_vec.size();
+        std::unordered_set<int64> axes;
+        for (int i = 0; i < axes_vec.size(); i++) {
+          axes.insert((axes_vec(i) + ndims) % ndims);
+        }
+
+        std::vector<DimensionHandle> dims;
+        if (keep_dims) {
+          dims.reserve(ndims);
+          for (int d = 0; d < ndims; ++d) {
+            if (axes.find(d) == axes.end()) {
+              dims.push_back(c->MakeDim(shape_vec(d)));
+            } else {
+              dims.push_back(c->MakeDim(1));
+            }
+          }
+        } else {
+          for (int d = 0; d < ndims; ++d) {
+            if (axes.find(d) == axes.end()) {
+              dims.push_back(c->MakeDim(shape_vec(d)));
+            }
+          }
+
+        }
+
+        c->set_output(0, c->MakeShape(dims));
+        return Status::OK();
+      }
+      return shape_inference::UnknownShape(c);
+    });
 
 REGISTER_OP("SparseReduceSumSparse")
     .Input("input_indices: int64")

--- a/tensorflow/core/ops/sparse_ops.cc
+++ b/tensorflow/core/ops/sparse_ops.cc
@@ -39,51 +39,6 @@ Status SparseSparseMinOrMaxShapeFn(InferenceContext* c) {
   return Status::OK();
 }
 
-Status SparseReduceShapeFn(InferenceContext* c) {
-  // Input 0: input_indices
-  // Input 1: input_values
-  // Input 2: input_shape
-  // Input 3: reduction_axes
-  // Attr: keep_dims
-  bool keep_dims = false;
-  TF_RETURN_IF_ERROR(c->GetAttr("keep_dims", &keep_dims));
-
-  const Tensor* shape_tensor = c->input_tensor(2);
-  const Tensor* axes_tensor = c->input_tensor(3);
-  if (shape_tensor != nullptr && axes_tensor != nullptr) {
-    auto shape_vec = shape_tensor->flat<int64>();
-    auto axes_vec = axes_tensor->flat<int32>();
-
-    int64 ndims = shape_vec.size();
-    std::unordered_set<int64> axes;
-    for (int i = 0; i < axes_vec.size(); i++) {
-      axes.insert((axes_vec(i) + ndims) % ndims);
-    }
-
-    std::vector<DimensionHandle> dims;
-    if (keep_dims) {
-      dims.reserve(ndims);
-      for (int d = 0; d < ndims; ++d) {
-        if (axes.find(d) == axes.end()) {
-          dims.push_back(c->MakeDim(shape_vec(d)));
-        } else {
-          dims.push_back(c->MakeDim(1));
-        }
-      }
-    } else {
-      for (int d = 0; d < ndims; ++d) {
-        if (axes.find(d) == axes.end()) {
-          dims.push_back(c->MakeDim(shape_vec(d)));
-        }
-      }
-    }
-
-    c->set_output(0, c->MakeShape(dims));
-    return Status::OK();
-  }
-  return shape_inference::UnknownShape(c);
-}
-
 }  // namespace
 
 REGISTER_OP("SparseAddGrad")
@@ -446,7 +401,7 @@ REGISTER_OP("SparseReduceMax")
     .Attr("keep_dims: bool = False")
     .Output("output: T")
     .Attr("T: realnumbertype")
-    .SetShapeFn(SparseReduceShapeFn);
+    .SetShapeFn(shape_inference::SparseReduceShapeFn);
 
 REGISTER_OP("SparseReduceMaxSparse")
     .Input("input_indices: int64")
@@ -468,7 +423,7 @@ REGISTER_OP("SparseReduceSum")
     .Attr("keep_dims: bool = False")
     .Output("output: T")
     .Attr("T: numbertype")
-    .SetShapeFn(SparseReduceShapeFn);
+    .SetShapeFn(shape_inference::SparseReduceShapeFn);
 
 REGISTER_OP("SparseReduceSumSparse")
     .Input("input_indices: int64")

--- a/tensorflow/core/ops/sparse_ops.cc
+++ b/tensorflow/core/ops/sparse_ops.cc
@@ -455,7 +455,6 @@ REGISTER_OP("SparseReduceSum")
               dims.push_back(c->MakeDim(shape_vec(d)));
             }
           }
-
         }
 
         c->set_output(0, c->MakeShape(dims));

--- a/tensorflow/core/ops/sparse_ops_test.cc
+++ b/tensorflow/core/ops/sparse_ops_test.cc
@@ -133,6 +133,13 @@ TEST(SparseOpsTest, SparseToDense_ShapeFn) {
 
 TEST(SparseOpsTest, SparseReduceSum_ShapeFn) {
   ShapeInferenceTestOp op("SparseReduceSum");
+  TF_ASSERT_OK(NodeDefBuilder("test", "SparseReduceSum")
+                   .Input({"input_indices", 0, DT_INT64})
+                   .Input({"input_values", 1, DT_INT64})
+                   .Input({"input_shape", 2, DT_INT64})
+                   .Input({"reduction_axes", 3, DT_INT32})
+                   .Attr("keep_dims", false)
+                   .Finalize(&op.node_def));
 
   // Shape fn always yields unknown.
   INFER_OK(op, "?;?;?;?", "?");

--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -747,20 +747,14 @@ class SparseReduceTest(test_util.TensorFlowTestCase):
     sp_t = sparse_tensor.SparseTensor(self.ind, self.vals, self.dense_shape)
 
     with self.session(use_gpu=False):
-      self._testSparseReduceSumShape(sp_t, None, ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, None, ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, 0, ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, 0, ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [1], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [1], ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [0, 1], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [0, 1], ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [1, 0], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [1, 0], ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [-1], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [-1], ndims=2, keep_dims=True)
-      self._testSparseReduceSumShape(sp_t, [1, -2], ndims=2, keep_dims=False)
-      self._testSparseReduceSumShape(sp_t, [1, -2], ndims=2, keep_dims=True)
+      for keep_dims in [True, False]:
+        self._testSparseReduceSumShape(sp_t, None, ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, 0, ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [0, 1], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1, 0], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [-1], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1, -2], ndims=2, keep_dims=keep_dims)
 
 
 class SparseMathOpsTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -657,7 +657,6 @@ class SparseReduceTest(test_util.TensorFlowTestCase):
     self._compare(sp_t, reduction_axes, ndims, True, False)
     self._compare(sp_t, reduction_axes, ndims, True, True)
 
-
   def testSimpleAndRandomInputs(self):
     if np.__version__ == "1.13.0":
       self.skipTest("numpy 1.13.0 bug")
@@ -723,12 +722,19 @@ class SparseReduceTest(test_util.TensorFlowTestCase):
                                                       reduced.eval().shape)
         self.assertLess(err, 1e-3)
 
-  def _testSparseReduceSumShape(self, sp_t, reduction_axes, ndims, keep_dims):
+  def _testSparseReduceShape(self, sp_t, reduction_axes, ndims, keep_dims,
+                             do_sum):
     densified = sparse_ops.sparse_tensor_to_dense(sp_t).eval()
+
+    np_op = np.sum
+    tf_op = sparse_ops.sparse_reduce_sum
+    if not do_sum:
+      np_op = np.max
+      tf_op = sparse_ops.sparse_reduce_max
 
     np_ans = densified
     if reduction_axes is None:
-      np_ans = np.sum(np_ans, keepdims=keep_dims)
+      np_ans = np_op(np_ans, keepdims=keep_dims)
     else:
       if not isinstance(reduction_axes, list):  # Single scalar.
         reduction_axes = [reduction_axes]
@@ -738,23 +744,24 @@ class SparseReduceTest(test_util.TensorFlowTestCase):
       # Loop below depends on sorted.
       reduction_axes.sort()
       for ra in reduction_axes.ravel()[::-1]:
-        np_ans = np.sum(np_ans, axis=ra, keepdims=keep_dims)
+        np_ans = np_op(np_ans, axis=ra, keepdims=keep_dims)
 
-    tf_ans = sparse_ops.sparse_reduce_sum(sp_t, reduction_axes, keep_dims)
+    tf_ans = tf_op(sp_t, reduction_axes, keep_dims)
     self.assertAllEqual(np_ans.shape, tf_ans.get_shape().as_list())
 
-  def testSparseReduceSumShape(self):
+  def testSparseReduceSumOrMaxShape(self):
     sp_t = sparse_tensor.SparseTensor(self.ind, self.vals, self.dense_shape)
 
     with self.session(use_gpu=False):
-      for keep_dims in [True, False]:
-        self._testSparseReduceSumShape(sp_t, None, 2, keep_dims)
-        self._testSparseReduceSumShape(sp_t, 0, 2, keep_dims)
-        self._testSparseReduceSumShape(sp_t, [1], 2, keep_dims)
-        self._testSparseReduceSumShape(sp_t, [0, 1], 2, keep_dims)
-        self._testSparseReduceSumShape(sp_t, [1, 0], 2, keep_dims)
-        self._testSparseReduceSumShape(sp_t, [-1], 2, keep_dims)
-        self._testSparseReduceSumShape(sp_t, [1, -2], 2, keep_dims)
+      for do_sum in [True, False]:
+        for keep_dims in [True, False]:
+          self._testSparseReduceShape(sp_t, None, 2, keep_dims, do_sum)
+          self._testSparseReduceShape(sp_t, 0, 2, keep_dims, do_sum)
+          self._testSparseReduceShape(sp_t, [1], 2, keep_dims, do_sum)
+          self._testSparseReduceShape(sp_t, [0, 1], 2, keep_dims, do_sum)
+          self._testSparseReduceShape(sp_t, [1, 0], 2, keep_dims, do_sum)
+          self._testSparseReduceShape(sp_t, [-1], 2, keep_dims, do_sum)
+          self._testSparseReduceShape(sp_t, [1, -2], 2, keep_dims, do_sum)
 
 
 class SparseMathOpsTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -748,13 +748,13 @@ class SparseReduceTest(test_util.TensorFlowTestCase):
 
     with self.session(use_gpu=False):
       for keep_dims in [True, False]:
-        self._testSparseReduceSumShape(sp_t, None, ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, 0, ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [1], ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [0, 1], ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [1, 0], ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [-1], ndims=2, keep_dims=keep_dims)
-        self._testSparseReduceSumShape(sp_t, [1, -2], ndims=2, keep_dims=keep_dims)
+        self._testSparseReduceSumShape(sp_t, None, 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, 0, 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1], 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [0, 1], 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1, 0], 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [-1], 2, keep_dims)
+        self._testSparseReduceSumShape(sp_t, [1, -2], 2, keep_dims)
 
 
 class SparseMathOpsTest(test_util.TensorFlowTestCase):


### PR DESCRIPTION
This fix tries to address the issue raised in #23114 where
the shape function of tf.sparse_reduce_sum did not
infer the shape even if the input shape were known.

This fix improves the shape function.

This fix fixes #23114.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>