### PR TITLE
API documentation updates for tf.b*

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_BroadcastTo.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_BroadcastTo.pbtxt
@@ -27,6 +27,7 @@ to broadcast a Tensor to a shape, this op starts with the trailing dimensions
 and works its way forward.
 
 For example,
+
 ```
 >>> x = tf.constant([1, 2, 3], shape=[1, 3])
 >>> y = tf.broadcast_to(x, [3, 3])
@@ -35,8 +36,9 @@ array([[1, 2, 3],
        [1, 2, 3],
        [1, 2, 3]], dtype=int32)
 ```
+
 In the above example, the input Tensor with the shape of `[1, 3]`
-is broadcasted to output Tensor with shape of `[3, 3]`.
+is broadcasted to an output Tensor with shape of `[3, 3]`.
 
 See [the "Broadcasting semantics" section of the TensorFlow XLA guide](
 https://www.tensorflow.org/performance/xla/broadcasting)

--- a/tensorflow/core/api_def/base_api/api_def_BroadcastTo.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_BroadcastTo.pbtxt
@@ -18,17 +18,17 @@ END
 A Tensor.
 END
   }
-  summary: "Broadcast an array for a compatible shape."
+  summary: "Broadcast an array to a compatible shape."
   description: <<END
 Broadcasting is the process of making arrays to have compatible shapes
 for arithmetic operations. Two shapes are compatible if for each
 dimension pair they are either equal or one of them is one. When trying
-to broadcast a Tensor to a shape, it starts with the trailing dimensions,
+to broadcast a Tensor to a shape, this op starts with the trailing dimensions
 and works its way forward.
 
 For example,
 ```
->>> x = tf.constant([1, 2, 3])
+>>> x = tf.constant([1, 2, 3], shape=[1, 3])
 >>> y = tf.broadcast_to(x, [3, 3])
 >>> sess.run(y)
 array([[1, 2, 3],
@@ -37,5 +37,9 @@ array([[1, 2, 3],
 ```
 In the above example, the input Tensor with the shape of `[1, 3]`
 is broadcasted to output Tensor with shape of `[3, 3]`.
+
+See [the "Broadcasting semantics" section of the TensorFlow XLA guide](
+https://www.tensorflow.org/performance/xla/broadcasting)
+for a detailed description of TensorFlow's broadcasting semantics. 
 END
 }

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -474,7 +474,7 @@ REGISTER_OP("BroadcastTo")
       }
       if (c->Rank(out) < c->Rank(in)) {
         return errors::InvalidArgument("Cannot broadcast a tensor with shape ",
-                                       c->DebugString(in), " shape ",
+                                       c->DebugString(in), " to shape ",
                                        c->DebugString(out));
       }
 
@@ -490,7 +490,7 @@ REGISTER_OP("BroadcastTo")
               if (c->Value(dim) % c->Value(in_dim) != 0) {
                 return errors::InvalidArgument(
                     "Cannot broadcast a tensor with shape ", c->DebugString(in),
-                    " shape ", c->DebugString(out));
+                    " to shape ", c->DebugString(out));
               }
             }
           }

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1160,7 +1160,7 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
   """Apply boolean mask to tensor.  Numpy equivalent is `tensor[mask]`.
 
   ```python
-  # 1-D example
+  # 1-D example (Run this code in eager mode)
   tensor = [0, 1, 2, 3]
   mask = np.array([True, False, True, False])
   tf.boolean_mask(tensor, mask).numpy()  
@@ -1174,7 +1174,7 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
   For example:
 
   ```python
-  # 3-D tensor and 2-D mask
+  # 3-D tensor and 2-D mask (Run this code in eager mode)
   tensor = [[[1, 2],
              [3, 4]],
             [[5, 6],

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2352,7 +2352,7 @@ def batch_to_space(input, crops, block_size, name=None):  # pylint: disable=rede
 
 batch_to_space.__doc__ = gen_array_ops.batch_to_space.__doc__.replace(
     "BatchToSpaceND", "`tf.batch_to_space_nd`").replace(
-    "SpaceToBatch", "`tf.nn.space_to_batch`")
+        "SpaceToBatch", "`tf.nn.space_to_batch`")
 
 
 @tf_export("one_hot")

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -200,10 +200,11 @@ def broadcast_static_shape(shape_x, shape_y):
   If some dimensions of the input shapes are unknown, this function
   will infer as much information as possible about the broadcasted shape.
   For example:
+
   ```python
   tf.broadcast_static_shape(
-    tf.TensorShape([None,2,3]),
-    tf.TensorShape([2,None])
+    tf.TensorShape([None, 2, 3]),
+    tf.TensorShape([2, None])
   )
   # ==> TensorShape([Dimension(None), Dimension(2), Dimension(3)])
   ```

--- a/tensorflow/python/ops/state_ops.py
+++ b/tensorflow/python/ops/state_ops.py
@@ -622,13 +622,13 @@ def batch_scatter_update(ref, indices, updates, use_locking=True, name=None):
   `tf.scatter_update`.
 
   To avoid this operation there would be 2 alternatives:
-  1) Reshaping the variable by merging the first `ndims` dimensions. However,
-     this is not possible because `tf.reshape` returns a Tensor, which we
-     cannot use `tf.scatter_update` on.
-  2) Looping over the first `ndims` of the variable and using
+  1) Reshaping the variable by merging the first `indices.ndims` dimensions. 
+     However, this is not possible because `tf.reshape` returns a Tensor, which 
+     we cannot use `tf.scatter_update` on.
+  2) Looping over the first `indices.ndims` of the variable and using
      `tf.scatter_update` on the subtensors that result of slicing the first
-     dimension. This is a valid option for `ndims = 1`, but less efficient than
-     this implementation.
+     dimension. This is a valid option for `indices.ndims = 1`, but less 
+     efficient than this implementation.
 
   See also `tf.scatter_update` and `tf.scatter_nd_update`.
 
@@ -637,14 +637,17 @@ def batch_scatter_update(ref, indices, updates, use_locking=True, name=None):
     indices: Tensor containing indices as described above.
     updates: Tensor of updates to apply to `ref`.
     use_locking: Boolean indicating whether to lock the writing operation.
+      If True, no other updates to the variable will happen at the same time.
+      Otherwise the write behavior is undefined, but may exhibit less 
+      contention.
     name: Optional scope name string.
 
   Returns:
     Ref to `variable` after it has been modified.
 
   Raises:
-    ValueError: If the initial `ndims` of `ref`, `indices`, and `updates` are
-        not the same.
+    ValueError: If the initial `indices.ndims` of `ref`, `indices`, and 
+      `updates` are not the same.
   """
   with ops.name_scope(name):
     indices = ops.convert_to_tensor(indices, name="indices")


### PR DESCRIPTION
This PR contains miscellaneous API documentation updates that cover the API functions whose names start with "tf.b". Some of the changes correct typos, while others document aspects of these functions that weren't obvious to me without reading the source code.

I've generated and reviewed the Markdown files for the documentation after these changes.