### PR TITLE
Fix BZL_FILE_PATH detection in building tensorflow lite

### DIFF
--- a/tensorflow/lite/tools/make/download_dependencies.sh
+++ b/tensorflow/lite/tools/make/download_dependencies.sh
@@ -17,7 +17,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR/../../../../.."
+cd "$SCRIPT_DIR/../../../.."
 
 DOWNLOADS_DIR=tensorflow/lite/tools/make/downloads
 BZL_FILE_PATH=tensorflow/workspace.bzl


### PR DESCRIPTION
Currently it will cause an error.
`Could not find tensorflow/workspace.bzl:
Likely you are not running this from the root directory of the repository.`