### PR TITLE
Fix the C2678 MSVC compilation error

### DIFF
--- a/tensorflow/core/framework/op_kernel.h
+++ b/tensorflow/core/framework/op_kernel.h
@@ -376,7 +376,9 @@ class OpArgIterator {
   using iterator_category = std::forward_iterator_tag;
   using value_type = ElementType;
   using pointer = ElementType*;
+  using const_pointer = const ElementType*;
   using reference = ElementType&;
+  using const_reference = const ElementType&;
   using difference_type = ptrdiff_t;
 
   OpArgIterator(const ListType* list, int i) : list_(list), i_(i) {}
@@ -404,6 +406,9 @@ class OpArgIterator {
 
   reference operator*() { return (*list_)[i_]; }
   pointer operator->() { return &(*list_)[i_]; }
+
+  const_reference operator*() const { return (*list_)[i_]; }
+  const_pointer operator->() const { return &(*list_)[i_]; }
 
  private:
   const ListType* const list_;


### PR DESCRIPTION
MSVC 14.15 returns the C2678 error during a compilation of the
'tensorflow/core/kernels/data/scan_dataset_op.cc' unit:

C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.15.26726\include\xmemory(217):
error C2678: binary '*': no operator found which takes a left-hand
operand of type 'const _Iter' (or there is no acceptable conversion)
with
[
    _Iter=tensorflow::OpInputList::Iterator
]

.\tensorflow/core/framework/op_kernel.h(405):
note: could be 'const tensorflow::Tensor &tensorflow::OpArgIterator<tensorflow::OpInputList,
    const tensorflow::Tensor>::operator *(void)'

Two const operator functions: 'operator*() const' and 'operator->()
const', returning a const pointer or const reference respectively,
have been added to the 'OpArgIterator' template class.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>