### PR TITLE
Fix the compute_output_shape issue in tf.keras.layers.Bidirectional

### DIFF
--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -441,8 +441,8 @@ class Bidirectional(Wrapper):
 
   @tf_utils.shape_type_conversion
   def compute_output_shape(self, input_shape):
-    forward_layer_output_shape \
-      = self.forward_layer.compute_output_shape(input_shape)
+    forward_layer_output_shape = self.forward_layer.compute_output_shape(
+        input_shape)
     if getattr(forward_layer_output_shape, 'as_list', None) is None:
       output_shape = tuple(forward_layer_output_shape)
     else:

--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -441,10 +441,15 @@ class Bidirectional(Wrapper):
 
   @tf_utils.shape_type_conversion
   def compute_output_shape(self, input_shape):
-    output_shape = tuple(self.forward_layer.compute_output_shape(
-        input_shape).as_list())
+    forward_layer_output_shape \
+      = self.forward_layer.compute_output_shape(input_shape)
+    if getattr(forward_layer_output_shape, 'as_list', None) is None:
+      output_shape = tuple(forward_layer_output_shape)
+    else:
+      output_shape = tuple(forward_layer_output_shape.as_list())
+
     if self.return_state:
-      state_shape = output_shape[1:]
+      state_shape = list(output_shape[1:])
       output_shape = output_shape[0]
 
     if self.merge_mode == 'concat':


### PR DESCRIPTION
This PR fixes #23299, where `tf.keras.layers.Bidirectional` does not work in some cases under eager execution mode because the output shape from the forward layer may not be as expected.