### PR TITLE
Add option for inferring op attributes from inputs

### DIFF
--- a/tensorflow/c/eager/c_api.h
+++ b/tensorflow/c/eager/c_api.h
@@ -81,18 +81,6 @@ TF_CAPI_EXPORT extern void TFE_ContextOptionsSetAsync(TFE_ContextOptions*,
 TF_CAPI_EXPORT extern void TFE_ContextOptionsSetDevicePlacementPolicy(
     TFE_ContextOptions*, TFE_ContextDevicePlacementPolicy);
 
-// Infer type and number attributes from the operation inputs, disabled by
-// default.
-//
-// Enabling it replicates the inference behaviour present in graph construction.
-// It is assumed that inputs are added to the operaton in the same order as they
-// are declared in its definition.
-//
-// It is also assumed that inferable attributes are not set explicitly when
-// this option is enabled.
-TF_CAPI_EXPORT extern void TFE_ContextOptionsSetInferInputAttributes(
-    TFE_ContextOptions*, unsigned char enable);
-
 // Destroy an options object.
 TF_CAPI_EXPORT extern void TFE_DeleteContextOptions(TFE_ContextOptions*);
 
@@ -378,8 +366,6 @@ TF_CAPI_EXPORT extern void TFE_OpSetAttrFunctionList(TFE_Op* op,
                                                      const char* attr_name,
                                                      const TFE_Op** value,
                                                      int num_values);
-
-TF_CAPI_EXPORT extern void TFE_OpInferSingleInputTypeAttrs(TFE_Op* op);
 
 // Execute the operation defined by 'op' and return handles to computed
 // tensors in `retvals`.

--- a/tensorflow/c/eager/c_api.h
+++ b/tensorflow/c/eager/c_api.h
@@ -81,6 +81,18 @@ TF_CAPI_EXPORT extern void TFE_ContextOptionsSetAsync(TFE_ContextOptions*,
 TF_CAPI_EXPORT extern void TFE_ContextOptionsSetDevicePlacementPolicy(
     TFE_ContextOptions*, TFE_ContextDevicePlacementPolicy);
 
+// Infer type and number attributes from the operation inputs, disabled by
+// default.
+//
+// Enabling it replicates the inference behaviour present in graph construction.
+// It is assumed that inputs are added to the operaton in the same order as they
+// are declared in its definition.
+//
+// It is also assumed that inferable attributes are not set explicitly when
+// this option is enabled.
+TF_CAPI_EXPORT extern void TFE_ContextOptionsSetInferInputAttributes(
+    TFE_ContextOptions*, unsigned char enable);
+
 // Destroy an options object.
 TF_CAPI_EXPORT extern void TFE_DeleteContextOptions(TFE_ContextOptions*);
 
@@ -282,8 +294,14 @@ TF_CAPI_EXPORT extern const char* TFE_OpGetDevice(TFE_Op* op,
 TF_CAPI_EXPORT extern void TFE_OpSetXLACompilation(TFE_Op* op,
                                                    unsigned char enable);
 
-TF_CAPI_EXPORT extern void TFE_OpAddInput(TFE_Op* op, TFE_TensorHandle* h,
+TF_CAPI_EXPORT extern void TFE_OpAddInput(TFE_Op* op,
+                                          TFE_TensorHandle* input,
                                           TF_Status* status);
+
+TF_CAPI_EXPORT extern void TFE_OpAddInputList(TFE_Op* op,
+                                              TFE_TensorHandle** inputs,
+                                              int num_inputs,
+                                              TF_Status* status);
 
 TF_CAPI_EXPORT extern TF_AttrType TFE_OpGetAttrType(TFE_Op* op,
                                                     const char* attr_name,
@@ -360,6 +378,8 @@ TF_CAPI_EXPORT extern void TFE_OpSetAttrFunctionList(TFE_Op* op,
                                                      const char* attr_name,
                                                      const TFE_Op** value,
                                                      int num_values);
+
+TF_CAPI_EXPORT extern void TFE_OpInferSingleInputTypeAttrs(TFE_Op* op);
 
 // Execute the operation defined by 'op' and return handles to computed
 // tensors in `retvals`.

--- a/tensorflow/c/eager/c_api_debug_test.cc
+++ b/tensorflow/c/eager/c_api_debug_test.cc
@@ -21,7 +21,7 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 
 TEST(CApiDebug, ScalarCPU) {
-  TFE_TensorHandle* h = TestScalarTensorHandle();
+  TFE_TensorHandle* h = TestScalarTensorHandle(1.0f);
   TF_Status* status = TF_NewStatus();
   TFE_TensorDebugInfo* debug_info = TFE_TensorHandleTensorDebugInfo(h, status);
   CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);

--- a/tensorflow/c/eager/c_api_internal.h
+++ b/tensorflow/c/eager/c_api_internal.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 #include <vector>
+#include <set>
 
 #include "tensorflow/c/c_api.h"
 #include "tensorflow/c/c_api_internal.h"
@@ -60,19 +61,22 @@ struct TFE_ContextOptions {
   // true if async execution is enabled.
   bool async = false;
   TFE_ContextDevicePlacementPolicy policy{TFE_DEVICE_PLACEMENT_SILENT};
+  bool input_attrs_inference = false;
 };
 
 struct TFE_Context {
   TFE_Context(const tensorflow::SessionOptions& opts,
               TFE_ContextDevicePlacementPolicy default_policy, bool async,
               const tensorflow::DeviceMgr* device_mgr, bool device_mgr_owned,
-              tensorflow::Rendezvous* rendezvous)
+              tensorflow::Rendezvous* rendezvous, bool input_attrs_inference)
       : context(opts,
                 static_cast<tensorflow::ContextDevicePlacementPolicy>(
                     default_policy),
-                async, device_mgr, device_mgr_owned, rendezvous) {}
+                async, device_mgr, device_mgr_owned, rendezvous),
+        input_attrs_inference(input_attrs_inference) {}
 
   tensorflow::EagerContext context;
+  bool input_attrs_inference;
 };
 
 struct TFE_TensorHandle {
@@ -99,12 +103,24 @@ struct TFE_TensorDebugInfo {
   std::vector<tensorflow::int64> dev_dims;
 };
 
+struct TFE_OpInferenceContext {
+  explicit TFE_OpInferenceContext(const tensorflow::OpDef* op_def)
+      : op_def(op_def) {}
+
+  const tensorflow::OpDef* op_def;  // op definition from protobuf
+  int input_idx = 0;                // index of the next input to be added
+  std::set<std::string> attrs;      // attributes inferred so far
+};
+
 struct TFE_Op {
   TFE_Op(TFE_Context* ctx, const char* op, bool is_function,
-         const tensorflow::AttrTypeMap* t)
-      : operation(&ctx->context, op, is_function, t) {}
+         const tensorflow::AttrTypeMap* t,
+         TFE_OpInferenceContext* inference_ctx)
+      : operation(&ctx->context, op, is_function, t),
+        inference_ctx(inference_ctx) {}
 
   tensorflow::EagerOperation operation;
+  TFE_OpInferenceContext* inference_ctx = nullptr;
 };
 
 struct TFE_ProfilerContext {

--- a/tensorflow/c/eager/c_api_test.cc
+++ b/tensorflow/c/eager/c_api_test.cc
@@ -1631,7 +1631,6 @@ TEST(CAPI, TestTFE_TensorHandleCopySharingUnderlyingTensorHandle) {
 TEST(CAPI, TestTFE_OpInferSingleInputAttrs) {
   TF_Status* status = TF_NewStatus();
   TFE_ContextOptions* opts = TFE_NewContextOptions();
-  opts->input_attrs_inference = true;
   TFE_Context* ctx = TFE_NewContext(opts, status);
   CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
   TFE_DeleteContextOptions(opts);
@@ -1647,7 +1646,7 @@ TEST(CAPI, TestTFE_OpInferSingleInputAttrs) {
 
   tensorflow::AttrValueMap attr_values;
   minOp->operation.Attrs().FillAttrValueMap(&attr_values);
-  tensorflow::AttrValueMap::iterator attr_found = attr_values.find("T");
+  tensorflow::AttrValueMap::const_iterator attr_found = attr_values.find("T");
   EXPECT_NE(attr_found, attr_values.cend());
   EXPECT_EQ(attr_found->second.type(), tensorflow::DataType::DT_FLOAT);
   attr_found = attr_values.find("Tidx");
@@ -1668,7 +1667,6 @@ TEST(CAPI, TestTFE_OpInferSingleInputAttrs) {
 TEST(CAPI, TestTFE_OpInferSingleTypeInputListAttrs) {
   TF_Status* status = TF_NewStatus();
   TFE_ContextOptions* opts = TFE_NewContextOptions();
-  opts->input_attrs_inference = true;
   TFE_Context* ctx = TFE_NewContext(opts, status);
   CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
   TFE_DeleteContextOptions(opts);
@@ -1686,7 +1684,7 @@ TEST(CAPI, TestTFE_OpInferSingleTypeInputListAttrs) {
 
   tensorflow::AttrValueMap attr_values;
   concatOp->operation.Attrs().FillAttrValueMap(&attr_values);
-  tensorflow::AttrValueMap::iterator attr_found = attr_values.find("T");
+  tensorflow::AttrValueMap::const_iterator attr_found = attr_values.find("T");
   EXPECT_NE(attr_found, attr_values.cend());
   EXPECT_EQ(attr_found->second.type(), tensorflow::DataType::DT_FLOAT);
   attr_found = attr_values.find("N");
@@ -1708,7 +1706,6 @@ TEST(CAPI, TestTFE_OpInferSingleTypeInputListAttrs) {
 TEST(CAPI, TestTFE_OpInferMixedTypeInputListAttrs) {
   TF_Status* status = TF_NewStatus();
   TFE_ContextOptions* opts = TFE_NewContextOptions();
-  opts->input_attrs_inference = true;
   TFE_Context* ctx = TFE_NewContext(opts, status);
   CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
   TFE_DeleteContextOptions(opts);
@@ -1726,7 +1723,7 @@ TEST(CAPI, TestTFE_OpInferMixedTypeInputListAttrs) {
 
   tensorflow::AttrValueMap attr_values;
   assertOp->operation.Attrs().FillAttrValueMap(&attr_values);
-  tensorflow::AttrValueMap::iterator attr_found = attr_values.find("T");
+  tensorflow::AttrValueMap::const_iterator attr_found = attr_values.find("T");
   EXPECT_NE(attr_found, attr_values.cend());
   EXPECT_EQ(attr_found->second.list().type(0), tensorflow::DataType::DT_BOOL);
   EXPECT_EQ(attr_found->second.list().type(1), tensorflow::DataType::DT_FLOAT);

--- a/tensorflow/c/eager/c_api_test.cc
+++ b/tensorflow/c/eager/c_api_test.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/c/eager/c_api.h"
+#include "tensorflow/c/eager/c_api_internal.h"
 
 #include <string.h>
 #include "absl/strings/match.h"
@@ -1625,5 +1626,121 @@ TEST(CAPI, TestTFE_TensorHandleCopySharingUnderlyingTensorHandle) {
 
   TFE_DeleteTensorHandle(h);
   TFE_DeleteTensorHandle(h_shares_tensor);
+}
+
+TEST(CAPI, TestTFE_OpInferSingleInputAttrs) {
+  TF_Status* status = TF_NewStatus();
+  TFE_ContextOptions* opts = TFE_NewContextOptions();
+  opts->input_attrs_inference = true;
+  TFE_Context* ctx = TFE_NewContext(opts, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_DeleteContextOptions(opts);
+
+  TFE_TensorHandle* input = TestMatrixTensorHandle();
+  TFE_TensorHandle* axis = TestAxisTensorHandle();
+  TFE_Op* minOp = TFE_NewOp(ctx, "Min", status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_OpAddInput(minOp, input, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_OpAddInput(minOp, axis, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  tensorflow::AttrValueMap attr_values;
+  minOp->operation.Attrs().FillAttrValueMap(&attr_values);
+  tensorflow::AttrValueMap::iterator attr_found = attr_values.find("T");
+  EXPECT_NE(attr_found, attr_values.cend());
+  EXPECT_EQ(attr_found->second.type(), tensorflow::DataType::DT_FLOAT);
+  attr_found = attr_values.find("Tidx");
+  EXPECT_NE(attr_found, attr_values.cend());
+  EXPECT_EQ(attr_found->second.type(), tensorflow::DataType::DT_INT32);
+
+  TFE_TensorHandle* retvals[1] = {nullptr};
+  int num_retvals = 1;
+  TFE_Execute(minOp, &retvals[0], &num_retvals, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  TF_DeleteStatus(status);
+  TFE_DeleteOp(minOp);
+  TFE_DeleteTensorHandle(input);
+  TFE_DeleteTensorHandle(axis);
+}
+
+TEST(CAPI, TestTFE_OpInferSingleTypeInputListAttrs) {
+  TF_Status* status = TF_NewStatus();
+  TFE_ContextOptions* opts = TFE_NewContextOptions();
+  opts->input_attrs_inference = true;
+  TFE_Context* ctx = TFE_NewContext(opts, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_DeleteContextOptions(opts);
+
+  TFE_TensorHandle* input1 = TestMatrixTensorHandle();
+  TFE_TensorHandle* input2 = TestMatrixTensorHandle();
+  TFE_TensorHandle* dim = TestScalarTensorHandle(0);
+  TFE_Op* concatOp = TFE_NewOp(ctx, "Concat", status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_TensorHandle* inputs[] = { input1, input2 };
+  TFE_OpAddInput(concatOp, dim, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_OpAddInputList(concatOp, inputs, 2, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  tensorflow::AttrValueMap attr_values;
+  concatOp->operation.Attrs().FillAttrValueMap(&attr_values);
+  tensorflow::AttrValueMap::iterator attr_found = attr_values.find("T");
+  EXPECT_NE(attr_found, attr_values.cend());
+  EXPECT_EQ(attr_found->second.type(), tensorflow::DataType::DT_FLOAT);
+  attr_found = attr_values.find("N");
+  EXPECT_NE(attr_found, attr_values.cend());
+  EXPECT_EQ(attr_found->second.i(), 2);
+
+  TFE_TensorHandle* retvals[1] = {nullptr};
+  int num_retvals = 1;
+  TFE_Execute(concatOp, &retvals[0], &num_retvals, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  TF_DeleteStatus(status);
+  TFE_DeleteOp(concatOp);
+  TFE_DeleteTensorHandle(input1);
+  TFE_DeleteTensorHandle(input2);
+  TFE_DeleteTensorHandle(dim);
+}
+
+TEST(CAPI, TestTFE_OpInferMixedTypeInputListAttrs) {
+  TF_Status* status = TF_NewStatus();
+  TFE_ContextOptions* opts = TFE_NewContextOptions();
+  opts->input_attrs_inference = true;
+  TFE_Context* ctx = TFE_NewContext(opts, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_DeleteContextOptions(opts);
+
+  TFE_TensorHandle* condition = TestScalarTensorHandle(true);
+  TFE_TensorHandle* t1 = TestMatrixTensorHandle();
+  TFE_TensorHandle* t2 = TestAxisTensorHandle();
+  TFE_Op* assertOp = TFE_NewOp(ctx, "Assert", status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_OpAddInput(assertOp, condition, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_TensorHandle* data[] = { condition, t1, t2 };
+  TFE_OpAddInputList(assertOp, data, 3, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  tensorflow::AttrValueMap attr_values;
+  assertOp->operation.Attrs().FillAttrValueMap(&attr_values);
+  tensorflow::AttrValueMap::iterator attr_found = attr_values.find("T");
+  EXPECT_NE(attr_found, attr_values.cend());
+  EXPECT_EQ(attr_found->second.list().type(0), tensorflow::DataType::DT_BOOL);
+  EXPECT_EQ(attr_found->second.list().type(1), tensorflow::DataType::DT_FLOAT);
+  EXPECT_EQ(attr_found->second.list().type(2), tensorflow::DataType::DT_INT32);
+
+  TFE_TensorHandle* retvals[1] = {nullptr};
+  int num_retvals = 1;
+  TFE_Execute(assertOp, &retvals[0], &num_retvals, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  TF_DeleteStatus(status);
+  TFE_DeleteOp(assertOp);
+  TFE_DeleteTensorHandle(condition);
+  TFE_DeleteTensorHandle(t1);
+  TFE_DeleteTensorHandle(t2);
 }
 }  // namespace

--- a/tensorflow/c/eager/c_api_test_util.cc
+++ b/tensorflow/c/eager/c_api_test_util.cc
@@ -21,9 +21,33 @@ limitations under the License.
 
 using tensorflow::string;
 
-TFE_TensorHandle* TestScalarTensorHandle() {
-  float data[] = {1.0f};
+TFE_TensorHandle* TestScalarTensorHandle(float value) {
+  float data[] = {value};
   TF_Tensor* t = TF_AllocateTensor(TF_FLOAT, nullptr, 0, sizeof(float));
+  memcpy(TF_TensorData(t), &data[0], TF_TensorByteSize(t));
+  TF_Status* status = TF_NewStatus();
+  TFE_TensorHandle* th = TFE_NewTensorHandle(t, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TF_DeleteTensor(t);
+  TF_DeleteStatus(status);
+  return th;
+}
+
+TFE_TensorHandle* TestScalarTensorHandle(int value) {
+  int data[] = {value};
+  TF_Tensor* t = TF_AllocateTensor(TF_INT32, nullptr, 0, sizeof(int));
+  memcpy(TF_TensorData(t), &data[0], TF_TensorByteSize(t));
+  TF_Status* status = TF_NewStatus();
+  TFE_TensorHandle* th = TFE_NewTensorHandle(t, status);
+  CHECK_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TF_DeleteTensor(t);
+  TF_DeleteStatus(status);
+  return th;
+}
+
+TFE_TensorHandle* TestScalarTensorHandle(bool value) {
+  bool data[] = {value};
+  TF_Tensor* t = TF_AllocateTensor(TF_BOOL, nullptr, 0, sizeof(bool));
   memcpy(TF_TensorData(t), &data[0], TF_TensorByteSize(t));
   TF_Status* status = TF_NewStatus();
   TFE_TensorHandle* th = TFE_NewTensorHandle(t, status);

--- a/tensorflow/c/eager/c_api_test_util.h
+++ b/tensorflow/c/eager/c_api_test_util.h
@@ -20,7 +20,13 @@ limitations under the License.
 #include "tensorflow/core/platform/types.h"
 
 // Return a tensor handle containing a float scalar
-TFE_TensorHandle* TestScalarTensorHandle();
+TFE_TensorHandle* TestScalarTensorHandle(float value);
+
+// Return a tensor handle containing a int scalar
+TFE_TensorHandle* TestScalarTensorHandle(int value);
+
+// Return a tensor handle containing a bool scalar
+TFE_TensorHandle* TestScalarTensorHandle(bool value);
 
 // Return a tensor handle containing a 2x2 matrix of doubles
 TFE_TensorHandle* DoubleTestMatrixTensorHandle();

--- a/tensorflow/core/common_runtime/eager/attr_builder.h
+++ b/tensorflow/core/common_runtime/eager/attr_builder.h
@@ -129,14 +129,19 @@ class AttrBuilder {
     // Copied from NodeDefBuilder::Attr
     const AttrValue* found = AttrSlice(m).Find(attr_name);
     AttrValue attr_value;
+    SetAttrValue(value, &attr_value);
     if (found == nullptr) {
-      SetAttrValue(value, &attr_value);
       m->insert(AttrValueMap::value_type(attr_name, attr_value));
     } else {
-      // TODO(ashankar): Do what is done in
-      // NodeDefBuilder::CheckInconsistency(attr_name, *found, attr_value);
-      SetAttrValue(std::forward<T>(value), &attr_value);
-      (*m)[attr_name] = attr_value;
+      // TODO(klessard): remove this validation once automatic input attributes
+      // inference of the C API is used by all clients, or at least Python.
+      // We use it only to verify that attributes inferred have the same values
+      // as those currently added manually (see
+      // github.com/tensorflow/tensorflow/pull/23468#issuecomment-438484058).
+      CHECK_EQ(found->i(), attr_value.i()) << " Number attribute \""
+          << attr_name << "\" was set multiple times with different values";
+      CHECK_EQ(found->type(), attr_value.type()) << " Type attribute \""
+          << attr_name << "\" was set multiple times with different values";
     }
   }
 

--- a/tensorflow/core/common_runtime/eager/attr_builder.h
+++ b/tensorflow/core/common_runtime/eager/attr_builder.h
@@ -126,22 +126,11 @@ class AttrBuilder {
                          T&& value) const {
     DCHECK(!node_def_finalized_)
         << "Calling SetInAttrValueMap after BuildNodeDef.";
-    // Copied from NodeDefBuilder::Attr
-    const AttrValue* found = AttrSlice(m).Find(attr_name);
-    AttrValue attr_value;
-    SetAttrValue(value, &attr_value);
-    if (found == nullptr) {
+    // If attribute is set more than once, its first value prevails
+    if (AttrSlice(m).Find(attr_name) == nullptr) {
+      AttrValue attr_value;
+      SetAttrValue(value, &attr_value);
       m->insert(AttrValueMap::value_type(attr_name, attr_value));
-    } else {
-      // TODO(klessard): remove this validation once automatic input attributes
-      // inference of the C API is used by all clients, or at least Python.
-      // We use it only to verify that attributes inferred have the same values
-      // as those currently added manually (see
-      // github.com/tensorflow/tensorflow/pull/23468#issuecomment-438484058).
-      CHECK_EQ(found->i(), attr_value.i()) << " Number attribute \""
-          << attr_name << "\" was set multiple times with different values";
-      CHECK_EQ(found->type(), attr_value.type()) << " Type attribute \""
-          << attr_name << "\" was set multiple times with different values";
     }
   }
 


### PR DESCRIPTION
In graph execution mode, the `NodeDefBuilder` will take care of inferring type and number attributes from operation inputs as they are added. Eager execution does not support for now. Unfortunately, some clients, as in Java, assume this feature to be present in both cases.

This PR is to enhance eager execution mode with input attribute inference to replicate normal (graph) mode. This behaviour is marked as optional and is by default disabled, so current clients that already take care of doing that inference on their own won't be impacted.