### PR TITLE
Pretty print the dtype in error message with eager

### DIFF
--- a/tensorflow/python/eager/pywrap_tensor.cc
+++ b/tensorflow/python/eager/pywrap_tensor.cc
@@ -435,7 +435,7 @@ int EagerTensor_init(EagerTensor* self, PyObject* args, PyObject* kwds) {
           PyExc_TypeError,
           tensorflow::strings::StrCat(
               "Cannot convert value ", TFE_GetPythonString(value_str.get()),
-              " to EagerTensor with requested dtype: ", desired_dtype)
+              " to EagerTensor with requested dtype: ", tensorflow::DataTypeString(static_cast<tensorflow::DataType>(desired_dtype)))
               .c_str());
       return -1;
     }

--- a/tensorflow/python/eager/pywrap_tensor.cc
+++ b/tensorflow/python/eager/pywrap_tensor.cc
@@ -420,12 +420,13 @@ int EagerTensor_init(EagerTensor* self, PyObject* args, PyObject* kwds) {
       if (TF_GetCode(self->status) != TF_OK) {
         PyErr_SetString(
             PyExc_TypeError,
-            tensorflow::strings::StrCat("Error while casting from DataType ",
-                                        tensorflow::DataTypeString(static_cast<tensorflow::DataType>(handle_dtype)),
-                                        " to ",
-                                        tensorflow::DataTypeString(static_cast<tensorflow::DataType>(desired_dtype)),
-                                        ". ",
-                                        TF_Message(self->status))
+            tensorflow::strings::StrCat(
+                "Error while casting from DataType ",
+                tensorflow::DataTypeString(
+                    static_cast<tensorflow::DataType>(handle_dtype)),
+                " to ", tensorflow::DataTypeString(
+                            static_cast<tensorflow::DataType>(desired_dtype)),
+                ". ", TF_Message(self->status))
                 .c_str());
         // Cleanup self->status before returning.
         TF_SetStatus(self->status, TF_OK, "");

--- a/tensorflow/python/eager/pywrap_tensor.cc
+++ b/tensorflow/python/eager/pywrap_tensor.cc
@@ -435,7 +435,9 @@ int EagerTensor_init(EagerTensor* self, PyObject* args, PyObject* kwds) {
           PyExc_TypeError,
           tensorflow::strings::StrCat(
               "Cannot convert value ", TFE_GetPythonString(value_str.get()),
-              " to EagerTensor with requested dtype: ", tensorflow::DataTypeString(static_cast<tensorflow::DataType>(desired_dtype)))
+              " to EagerTensor with requested dtype: ",
+              tensorflow::DataTypeString(
+                  static_cast<tensorflow::DataType>(desired_dtype)))
               .c_str());
       return -1;
     }

--- a/tensorflow/python/eager/pywrap_tensor.cc
+++ b/tensorflow/python/eager/pywrap_tensor.cc
@@ -421,8 +421,11 @@ int EagerTensor_init(EagerTensor* self, PyObject* args, PyObject* kwds) {
         PyErr_SetString(
             PyExc_TypeError,
             tensorflow::strings::StrCat("Error while casting from DataType ",
-                                        handle_dtype, " to ", desired_dtype,
-                                        ". ", TF_Message(self->status))
+                                        tensorflow::DataTypeString(static_cast<tensorflow::DataType>(handle_dtype)),
+                                        " to ",
+                                        tensorflow::DataTypeString(static_cast<tensorflow::DataType>(desired_dtype)),
+                                        ". ",
+                                        TF_Message(self->status))
                 .c_str());
         // Cleanup self->status before returning.
         TF_SetStatus(self->status, TF_OK, "");


### PR DESCRIPTION
This fix is related to #23452 where the dtype in the error message is a non-descriptive integer:
```
>>> import tensorflow as tf
>>> tf.enable_eager_execution()
>>> print(1.2*tf.constant(2))
Traceback (most recent call last):
...
...
TypeError: Cannot convert value 1.2 to EagerTensor with requested dtype: 3
>>>
```

This fix converts the integer (e.g., `3`) to a descriptive string:
```
TypeError: Cannot convert value 1.2 to EagerTensor with requested dtype: int32
```

This fix fixes #23452.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
