### PR TITLE
Change `int` to `uint` or `size_t` where applicable

### DIFF
--- a/tensorflow/cc/framework/gradients.cc
+++ b/tensorflow/cc/framework/gradients.cc
@@ -424,7 +424,7 @@ Status SymbolicGradientBuilder::ProcessWhileLoop(Node* exit_node,
   // Backprop along the in edges to the while loop (i.e. the inputs to the enter
   // nodes)
   DCHECK_EQ(dx.size(), while_ctx->enter_nodes().size());
-  for (int i = 0; i < dx.size(); ++i) {
+  for (uint i = 0; i < dx.size(); ++i) {
     Node* enter_node = while_ctx->enter_nodes()[i];
     for (const Edge* e : enter_node->in_edges()) {
       if (e->IsControlEdge()) continue;
@@ -450,7 +450,7 @@ Status SymbolicGradientBuilder::AddGradients() {
     dy.clear();
     dy.resize(num_y, {nullptr, 0});
     std::vector<int> no_grad_dy_indices;
-    for (int i = 0; i < num_y; ++i) {
+    for (uint i = 0; i < num_y; ++i) {
       TF_RETURN_IF_ERROR(SumGradients({n, i}, &dy[i]));
       if (dy[i] == NoGradient()) {
         no_grad_dy_indices.push_back(i);

--- a/tensorflow/cc/framework/while_gradients.cc
+++ b/tensorflow/cc/framework/while_gradients.cc
@@ -37,7 +37,7 @@ std::vector<Output> ToOutputVector(
   size_t n = output_tensors.size();
   std::vector<Output> result;
   result.reserve(n);
-  for (int i = 0; i < n; ++i) result.push_back(ToOutput(output_tensors[i]));
+  for (uint i = 0; i < n; ++i) result.push_back(ToOutput(output_tensors[i]));
   return result;
 }
 

--- a/tensorflow/core/distributed_runtime/eager/eager_service_impl.h
+++ b/tensorflow/core/distributed_runtime/eager/eager_service_impl.h
@@ -123,7 +123,7 @@ class EagerServiceImpl {
         const gtl::ArraySlice<tensorflow::TensorHandle*>& handles,
         int64 operation_id) {
       mutex_lock l(tensors_mu_);
-      for (int i = 0; i < handles.size(); i++) {
+      for (uint i = 0; i < handles.size(); i++) {
         // TODO(nareshmodi): Correctly handle operation_id not being unique.
         tensors_.emplace(RemoteTensorHandleInternal(operation_id, i),
                          handles[i]);

--- a/tensorflow/core/framework/node_def_util.cc
+++ b/tensorflow/core/framework/node_def_util.cc
@@ -411,7 +411,7 @@ Status InOutTypesForNode(const NodeDef& node_def, const OpDef& op_def,
 }
 
 Status NumOutputsForNode(const NodeDef& node_def, const OpDef& op_def,
-                         int* num_outputs) {
+                         size_t* num_outputs) {
   DataTypeVector outputs;
   TF_RETURN_IF_ERROR(OutputTypesForNode(node_def, op_def, &outputs));
   *num_outputs = outputs.size();

--- a/tensorflow/core/util/tensor_format.h
+++ b/tensorflow/core/util/tensor_format.h
@@ -413,7 +413,7 @@ inline int32 GetTensorDimIndex(TensorFormat format, char dimension) {
 template <typename T>
 T GetTensorDim(gtl::ArraySlice<T> dimension_attributes,
                TensorFormat tensor_format, char dimension) {
-  int index =
+  uint index =
       (GetTensorSpatialDims(dimension_attributes.size(), tensor_format) == 3)
           ? GetTensorDimIndex<3>(tensor_format, dimension)
           : GetTensorDimIndex<2>(tensor_format, dimension);
@@ -428,7 +428,7 @@ T GetTensorDim(gtl::ArraySlice<T> dimension_attributes,
 template <typename T>
 T GetFilterDim(gtl::ArraySlice<T> dimension_attribute,
                FilterTensorFormat filter_tensor_format, char dimension) {
-  int index = (GetFilterTensorSpatialDims(dimension_attribute.size(),
+  uint index = (GetFilterTensorSpatialDims(dimension_attribute.size(),
                                           filter_tensor_format) == 3)
                   ? GetFilterDimIndex<3>(filter_tensor_format, dimension)
                   : GetFilterDimIndex<2>(filter_tensor_format, dimension);
@@ -496,7 +496,7 @@ inline TensorShape ShapeFromFormat(TensorFormat format, int64 N,
   const int dims = GetTensorDimsFromSpatialDims(spatial.size(), format);
   gtl::InlinedVector<int64, 6> dim_sizes(dims);
   dim_sizes[GetTensorBatchDimIndex(dims, format)] = N;
-  for (int dim = 0; static_cast<size_t>(dim) < spatial.size(); dim++) {
+  for (uint dim = 0; static_cast<size_t>(dim) < spatial.size(); dim++) {
     auto dim_size = spatial[dim];
     if (format == FORMAT_NHWC_VECT_W && dim == spatial.size() - 1) {
       CHECK_EQ(0, dim_size % 4)


### PR DESCRIPTION
Change `int` to `uint` or `size_t` where applicable. 
Based on compiler warnings & common sense. 

Note: there is **a lot** more to be done on this subject. 