### PR TITLE
[INTEL MKL] Fix build error for //tensorflow/core:platform_port unit test.

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -383,6 +383,7 @@ cc_library(
         ":lib_platform",
         ":platform_base",
         "//tensorflow/core/platform/default/build_config:port",
+        "@com_google_absl//absl/base",
         "@snappy",
     ],
 )


### PR DESCRIPTION
This PR fixes the build error (shown below) that occurs when running `//tensorflow/core:platform_port` unit test.
```
tensorflow/core/platform/posix/port.cc:16:40: fatal error: absl/base/internal/sysinfo.h: No such file or directory
 #include "absl/base/internal/sysinfo.h"
```