### PR TITLE
Removed no longer supported call `in_eager_execution()`

### DIFF
--- a/tensorflow/python/profiler/model_analyzer.py
+++ b/tensorflow/python/profiler/model_analyzer.py
@@ -398,7 +398,7 @@ def advise(graph=None, run_meta=None, options=_DEFAULT_ADVISE_OPTIONS):
   Returns:
     Returns AdviceProto proto
   """
-  if not graph and context.in_eager_execution():
+  if not graph and not context.executing_eagerly():
     graph = ops.get_default_graph()
 
   if options == _DEFAULT_ADVISE_OPTIONS:


### PR DESCRIPTION
changes to `model_analyser.analyse(...)`:

- Swapped `context.in_eager_execution()` to the currently supported `context.executing_eagerly()`.
- Added negation to eager check. In all likelihood, the negation was always supposed to be there since getting default graph in eager mode does not make sense. The current `if` condition is likely a bug. The proposed fix is consistent with other functions in this module, e.g., `profile(...)`, line 339.