### PR TITLE
Add a new Batched NMS OP

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_CombinedNonMaxSuppression.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_CombinedNonMaxSuppression.pbtxt
@@ -3,7 +3,9 @@ op {
   in_arg {
     name: "boxes"
     description: <<END
-A 4-D float tensor of shape `[batch_size, num_boxes, q, 4]`.
+A 4-D float tensor of shape `[batch_size, num_boxes, q, 4]`. If `q` is 1 then 
+same boxes are used for all classes otherwise, if `q` is equal to number of 
+classes, class-specific boxes are used.
 END
   }
   in_arg {

--- a/tensorflow/core/api_def/base_api/api_def_CombinedNonMaxSuppression.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_CombinedNonMaxSuppression.pbtxt
@@ -1,0 +1,106 @@
+op {
+  graph_op_name: "CombinedNonMaxSuppression"
+  in_arg {
+    name: "boxes"
+    description: <<END
+A 4-D float tensor of shape `[batch_size, num_boxes, q, 4]`.
+END
+  }
+  in_arg {
+    name: "scores"
+    description: <<END
+A 3-D float tensor of shape `[batch_size, num_boxes, num_classes]`
+representing a single score corresponding to each box (each row of boxes).
+END
+  }
+  in_arg {
+    name: "max_output_size_per_class"
+    description: <<END
+A scalar integer tensor representing the maximum number of 
+boxes to be selected by non max suppression per class
+END
+  }
+  in_arg {
+    name: "max_total_size"
+    description: <<END
+A scalar representing maximum number of boxes retained over all classes.
+END
+  }
+  in_arg {
+    name: "iou_threshold"
+    description: <<END
+A 0-D float tensor representing the threshold for deciding whether
+boxes overlap too much with respect to IOU.
+END
+  }
+  in_arg {
+    name: "score_threshold"
+    description: <<END
+A 0-D float tensor representing the threshold for deciding when to remove
+boxes based on score.
+END
+  }
+  attr {
+    name: "pad_per_class"
+    description: <<END
+If false, the output nmsed boxes, scores, classes and
+selected_indices are padded/clipped to `max_total_size`. If true, the
+output nmsed boxes, scores, classes and selected_indices are
+padded/clipped to be of length `max_size_per_class` or `max_total_size`
+(smaller of the two). Defaults to false.
+END
+  }
+  out_arg {
+    name: "nmsed_boxes"
+    description: <<END
+A [batch_size, max_detections, 4] float32 tensor 
+containing the non-max suppressed boxes.
+END
+  }
+  out_arg {
+    name: "nmsed_scores"
+    description: <<END
+A [batch_size, max_detections] float32 tensor 
+containing the scores for the boxes.
+END
+  }
+  out_arg {
+    name: "nmsed_classes"
+    description: <<END
+A [batch_size, max_detections] float32 tensor 
+containing the classes for the boxes.
+END
+  }
+  out_arg {
+    name: "valid_detections"
+    description: <<END
+A [batch_size] int32 tensor indicating the number of
+valid detections per batch item. Only the top num_detections[i] entries in
+nms_boxes[i], nms_scores[i] and nms_class[i] are valid. The rest of the
+entries are zero paddings.
+END
+  }
+  out_arg {
+    name: "selected_indices"
+    description: <<END
+A [batch_size, max_detections] int32 tensor
+containing the indices of the selected boxes
+END
+  }
+  summary: "Greedily selects a subset of bounding boxes in descending order of score,"
+  description: <<END
+This operation performs non_max_suppression on the inputs per batch, across
+all classes.
+Prunes away boxes that have high intersection-over-union (IOU) overlap
+with previously selected boxes.  Bounding boxes are supplied as
+[y1, x1, y2, x2], where (y1, x1) and (y2, x2) are the coordinates of any
+diagonal pair of box corners and the coordinates can be provided as normalized
+(i.e., lying in the interval [0, 1]) or absolute.  Note that this algorithm
+is agnostic to where the origin is in the coordinate system. Also note that
+this algorithm is invariant to orthogonal transformations and translations
+of the coordinate system; thus translating or reflections of the coordinate
+system result in the same boxes being selected by the algorithm.
+The output of this operation is the final boxes, scores and classes tensor
+returned after performing non_max_suppression.
+END
+}

--- a/tensorflow/core/api_def/base_api/api_def_CombinedNonMaxSuppression.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_CombinedNonMaxSuppression.pbtxt
@@ -47,9 +47,9 @@ END
     description: <<END
 If false, the output nmsed boxes, scores and classes
 are padded/clipped to `max_total_size`. If true, the
-output nmsed boxes, scores and classes are
-padded/clipped to be of length `max_size_per_class` or `max_total_size`
-(smaller of the two). Defaults to false.
+output nmsed boxes, scores and classes are padded to be of length
+`max_size_per_class`*`num_classes`, unless it exceeds `max_total_size` in
+which case it is clipped to `max_total_size`. Defaults to false.
 END
   }
   out_arg {

--- a/tensorflow/core/api_def/base_api/api_def_CombinedNonMaxSuppression.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_CombinedNonMaxSuppression.pbtxt
@@ -45,9 +45,9 @@ END
   attr {
     name: "pad_per_class"
     description: <<END
-If false, the output nmsed boxes, scores, classes and
-selected_indices are padded/clipped to `max_total_size`. If true, the
-output nmsed boxes, scores, classes and selected_indices are
+If false, the output nmsed boxes, scores and classes
+are padded/clipped to `max_total_size`. If true, the
+output nmsed boxes, scores and classes are
 padded/clipped to be of length `max_size_per_class` or `max_total_size`
 (smaller of the two). Defaults to false.
 END
@@ -80,13 +80,6 @@ A [batch_size] int32 tensor indicating the number of
 valid detections per batch item. Only the top num_detections[i] entries in
 nms_boxes[i], nms_scores[i] and nms_class[i] are valid. The rest of the
 entries are zero paddings.
-END
-  }
-  out_arg {
-    name: "selected_indices"
-    description: <<END
-A [batch_size, max_detections] int32 tensor
-containing the indices of the selected boxes
 END
   }
   summary: "Greedily selects a subset of bounding boxes in descending order of score,"

--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -74,7 +74,7 @@ static inline void ParseAndCheckBoxSizes(OpKernelContext* context,
               errors::InvalidArgument("boxes must have 4 columns"));
 }
 
-static inline void CheckNMSLiteScoreSizes(OpKernelContext* context, 
+static inline void CheckCombinedNMSScoreSizes(OpKernelContext* context, 
                                           int num_boxes,
                                           const Tensor& scores) {
   // The shape of 'scores' is [batch_size, num_boxes, num_classes]
@@ -85,7 +85,7 @@ static inline void CheckNMSLiteScoreSizes(OpKernelContext* context,
               errors::InvalidArgument("scores has incompatible shape"));
 }
 
-static inline void ParseAndCheckNMSLiteBoxSizes(OpKernelContext* context,
+static inline void ParseAndCheckCombinedNMSBoxSizes(OpKernelContext* context,
                                          const Tensor& boxes, int* num_boxes, 
                                          const int num_classes) {
   // The shape of 'boxes' is [batch_size, num_boxes, q, 4]
@@ -686,9 +686,9 @@ class NonMaxSuppressionWithOverlapsOp : public OpKernel {
 };
 
 template <typename Device>
-class NonMaxSuppressionLiteOp : public OpKernel {
+class CombinedNonMaxSuppressionOp : public OpKernel {
  public:
-  explicit NonMaxSuppressionLiteOp(OpKernelConstruction* context)
+  explicit CombinedNonMaxSuppressionOp(OpKernelConstruction* context)
       : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr("pad_per_class",
                                              &pad_per_class_));
@@ -738,8 +738,8 @@ class NonMaxSuppressionLiteOp : public OpKernel {
                 errors::InvalidArgument("iou_threshold must be in [0, 1]"));
     int num_boxes = 0;
     const int num_classes = scores.dim_size(2);
-    ParseAndCheckNMSLiteBoxSizes(context, boxes, &num_boxes, num_classes);
-    CheckNMSLiteScoreSizes(context, num_boxes, scores);
+    ParseAndCheckCombinedNMSBoxSizes(context, boxes, &num_boxes, num_classes);
+    CheckCombinedNMSScoreSizes(context, num_boxes, scores);
 
     if (!context->status().ok()) {
       return;
@@ -785,7 +785,7 @@ REGISTER_KERNEL_BUILDER(
     Name("NonMaxSuppressionWithOverlaps").Device(DEVICE_CPU),
     NonMaxSuppressionWithOverlapsOp<CPUDevice>);
 
-REGISTER_KERNEL_BUILDER(Name("NonMaxSuppressionLite").Device(DEVICE_CPU),
-        NonMaxSuppressionLiteOp<CPUDevice>);
+REGISTER_KERNEL_BUILDER(Name("CombinedNonMaxSuppression").Device(DEVICE_CPU),
+        CombinedNonMaxSuppressionOp<CPUDevice>);
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -376,8 +376,7 @@ void BatchedNonMaxSuppressionOp(OpKernelContext* context,
     int curr_total_size = max_detections;
     int result_idx = 0;
     // Pick the top max_detections values 
-    while (curr_total_size > 0 && result_idx < result_candidate_vec.size())
-    {
+    while (curr_total_size > 0 && result_idx < result_candidate_vec.size()) {
       ResultCandidate next_candidate = result_candidate_vec[result_idx++];
       // Add to final output vectors
       nmsed_boxes[batch].push_back(

--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -268,7 +268,9 @@ void BatchedNonMaxSuppressionOp(
     // Iterate through all classes
     for (int class_idx = 0; class_idx < num_classes; ++class_idx) {
       std::vector<float> class_scores_data;
+      class_scores_data.reserve(num_boxes);
       std::vector<float> class_boxes_data;
+      class_boxes_data.reserve(num_boxes * 4);
 
       for (int box = 0; box < num_boxes; ++box) {
         // Get the scores per class

--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -230,7 +230,7 @@ void BatchedNonMaxSuppressionOp(OpKernelContext* context,
                                 const int total_size_per_batch,
                                 const float score_threshold,
                                 const float iou_threshold,
-                                bool use_static_shapes = false) {
+                                bool pad_per_class = false) {
 
   int q = inp_boxes.dim_size(2);
   int num_classes = inp_scores.dim_size(2);
@@ -358,8 +358,8 @@ void BatchedNonMaxSuppressionOp(OpKernelContext* context,
 
     }
     int max_detections = 0;
-    // If use_static_shapes is false, we always pad to max_total_size
-    if (!use_static_shapes) {
+    // If pad_per_class is false, we always pad to max_total_size
+    if (!pad_per_class) {
       max_detections = std::min((int) result_candidate_pq.size(), 
         total_size_per_batch);
       per_batch_size = total_size_per_batch;
@@ -690,8 +690,8 @@ class NonMaxSuppressionLiteOp : public OpKernel {
  public:
   explicit NonMaxSuppressionLiteOp(OpKernelConstruction* context)
       : OpKernel(context) {
-    OP_REQUIRES_OK(context, context->GetAttr("use_static_shapes",
-                                             &use_static_shapes_));
+    OP_REQUIRES_OK(context, context->GetAttr("pad_per_class",
+                                             &pad_per_class_));
   }
 
   void Compute(OpKernelContext* context) override {
@@ -747,10 +747,10 @@ class NonMaxSuppressionLiteOp : public OpKernel {
     BatchedNonMaxSuppressionOp(context, boxes, scores, num_boxes, 
                                max_size_per_class, max_total_size_per_batch, 
                                score_threshold_val, iou_threshold_val, 
-                               use_static_shapes_);
+                               pad_per_class_);
   }
  private:
-  bool use_static_shapes_;
+  bool pad_per_class_;
 };
 
 

--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -222,14 +222,15 @@ void DoNonMaxSuppressionOp(
   std::copy_n(selected.begin(), selected.size(), output_indices_data.data());
 }
 
-void BatchedNonMaxSuppressionOp(OpKernelContext* context, 
-                           const Tensor& inp_boxes, const Tensor& inp_scores, 
-                           int num_boxes, 
-                           const int max_size_per_class, 
-                           const int total_size_per_batch, 
-                           const float score_threshold, 
-                           const float iou_threshold,
-                           bool use_static_shapes = false) {
+void BatchedNonMaxSuppressionOp(OpKernelContext* context,
+                                const Tensor& inp_boxes,
+                                const Tensor& inp_scores,
+                                int num_boxes,
+                                const int max_size_per_class,
+                                const int total_size_per_batch,
+                                const float score_threshold,
+                                const float iou_threshold,
+                                bool use_static_shapes = false) {
 
   int q = inp_boxes.dim_size(2);
   int num_classes = inp_scores.dim_size(2);
@@ -242,9 +243,9 @@ void BatchedNonMaxSuppressionOp(OpKernelContext* context,
   // [num_batches, per_batch_size, 4]
   std::vector <std::vector<float>> nmsed_boxes(num_batches);
   // [num_batches, per_batch_size]
-  std::vector <std::vector<float>> nmsed_scores(num_batches); 
+  std::vector <std::vector<float>> nmsed_scores(num_batches);
   // [num_batches, per_batch_size]
-  std::vector <std::vector<float>> nmsed_classes(num_batches); 
+  std::vector <std::vector<float>> nmsed_classes(num_batches);
   // [num_batches]
   std::vector <int> final_valid_detections;
   // [num_batches, per_batch_size]

--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -363,10 +363,10 @@ void BatchedNonMaxSuppressionOp(OpKernelContext* context,
       per_batch_size = total_size_per_batch;
     }
     else {
-      // max_detections will be <= max_size_per_class * num_classes
-      max_detections = (int) result_candidate_pq.size();
       per_batch_size = std::min(total_size_per_batch, 
                             max_size_per_class * num_classes);
+      max_detections = std::min(per_batch_size, 
+                            (int) result_candidate_pq.size());
     }
 
     final_valid_detections.push_back(max_detections);

--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -74,6 +74,35 @@ static inline void ParseAndCheckBoxSizes(OpKernelContext* context,
               errors::InvalidArgument("boxes must have 4 columns"));
 }
 
+static inline void CheckNMSLiteScoreSizes(OpKernelContext* context, 
+                                          int num_boxes,
+                                          const Tensor& scores) {
+  // The shape of 'scores' is [batch_size, num_boxes, num_classes]
+  OP_REQUIRES(context, scores.dims() == 3,
+              errors::InvalidArgument("scores must be 3-D",
+                                      scores.shape().DebugString()));
+  OP_REQUIRES(context, scores.dim_size(1) == num_boxes,
+              errors::InvalidArgument("scores has incompatible shape"));
+}
+
+static inline void ParseAndCheckNMSLiteBoxSizes(OpKernelContext* context,
+                                         const Tensor& boxes, int* num_boxes, 
+                                         const int num_classes) {
+  // The shape of 'boxes' is [batch_size, num_boxes, q, 4]
+  OP_REQUIRES(context, boxes.dims() == 4,
+              errors::InvalidArgument("boxes must be 4-D",
+                                      boxes.shape().DebugString()));
+
+  bool box_check = boxes.dim_size(2) == 1 || boxes.dim_size(2) == num_classes;
+  OP_REQUIRES(context, box_check,
+              errors::InvalidArgument(
+                  "third dimension of boxes must be either 1 or num classes"));
+  // Num_boxes * q where q is either 1 or num_classes
+  // TODO check if this should take num_classes into account
+  *num_boxes = boxes.dim_size(1); //*boxes.dim_size(2);
+  OP_REQUIRES(context, boxes.dim_size(3) == 4,
+              errors::InvalidArgument("boxes must have 4 columns"));
+}
 // Return intersection-over-union overlap between boxes i and j
 template <typename T>
 static inline bool IOUGreaterThanThreshold(
@@ -193,6 +222,215 @@ void DoNonMaxSuppressionOp(
                  context->allocate_output(0, output_shape, &output_indices));
   TTypes<int, 1>::Tensor output_indices_data = output_indices->tensor<int, 1>();
   std::copy_n(selected.begin(), selected.size(), output_indices_data.data());
+}
+
+void BatchedNonMaxSuppressionOp(OpKernelContext* context, 
+                           const Tensor& inp_boxes, const Tensor& inp_scores, 
+                           int num_boxes, 
+                           const Tensor& max_size_per_class, 
+                           const Tensor& max_total_size, 
+                           const float score_threshold, 
+                           const float iou_threshold) {
+
+  int q = inp_boxes.dim_size(2);
+  int num_classes = inp_scores.dim_size(2);
+  //unpack along batch dimension
+  const int num_batches = inp_boxes.dim_size(0);
+
+  // [num_batches, max_detections, 4]
+  std::vector <std::vector<float>> nmsed_boxes(num_batches);
+  // [num_batches, max_detections]
+  std::vector <std::vector<float>> nmsed_scores(num_batches); 
+  // [num_batches, max_detections]
+  std::vector <std::vector<float>> nmsed_classes(num_batches); 
+  // [num_batches]
+  std::vector <int> final_valid_detections;
+  // [num_batches, max_detections]
+  std::vector <std::vector<int>> selected_indices(num_batches);
+
+  int max_detections = 0;
+  //perform non_max_suppression operation for each batch independently
+  for (int batch = 0; batch < num_batches; ++batch) {
+    std::cout << " iteration " << batch <<std::endl;
+    // dims of per_batch_boxes [num_boxes, q, 4]
+    //Tensor per_batch_boxes = inp_boxes.SubSlice(batch);
+    Tensor per_batch_boxes = inp_boxes.Slice(batch, batch+1);
+    // dims of per_batch_scores [num_boxes, num_classes]
+    Tensor per_batch_scores = inp_scores.Slice(batch, batch+1);
+
+    struct ResultCandidate {
+          int box_index;
+          float score;
+          int class_idx;
+          float box_coord[4];
+    };
+
+    auto rc_cmp = [](const ResultCandidate rc_i, const ResultCandidate rc_j) {
+        return rc_i.score < rc_j.score;
+    };
+    std::priority_queue<ResultCandidate, std::vector<ResultCandidate>, 
+      decltype(rc_cmp)> result_candidate_pq(rc_cmp);
+
+    float * scoresData = per_batch_scores.unaligned_flat<float>().data();
+    float * boxesData = per_batch_boxes.unaligned_flat<float>().data();
+
+    //Iterate through all classes
+    for (int class_idx = 0; class_idx < num_classes; ++class_idx) {
+      std::vector<float> scores_data;
+      std::vector<float> boxes_data_vec;
+
+      for (int box = 0; box < num_boxes; ++box) {
+        //Get the scores per class 
+        //scores_data dim is [num_boxes].
+        scores_data.push_back(scoresData[box * num_classes + class_idx]);
+        for(int cid = 0; cid < 4; ++cid){
+          if(q > 1){
+            //Get the boxes per class. boxes_data_vec dims is [num_boxes, 4]
+            boxes_data_vec.push_back(boxesData[box * q * 4 + 
+                  class_idx * 4 + cid]);
+            //std::cout << " Pushing box_data " << boxes_data_vec[boxes_data_vec.size()-1] << std::endl;
+          }
+          else 
+              boxes_data_vec.push_back(boxesData[box * 4 + cid]);
+        }
+      }
+        
+      //Copy boxes_data_vec to a tensor
+      TensorShape boxesShape({num_boxes, 4});
+      Tensor boxes(per_batch_boxes.dtype(), boxesShape);
+      std::copy_n(boxes_data_vec.begin(), boxes_data_vec.size(), 
+          boxes.unaligned_flat<float>().data());
+
+      const int output_size = std::min(max_size_per_class.scalar<int>()(), 
+                                   num_boxes);
+      // Do NMS, get the candidate indices of form vector<int>
+      // Data structure for selection candidate in NMS.
+      struct Candidate {
+        int box_index;
+        float score;
+      };
+      auto cmp = [](const Candidate bs_i, const Candidate bs_j) {
+        return bs_i.score < bs_j.score;
+      };
+      std::priority_queue<Candidate, std::deque<Candidate>, decltype(cmp)>
+        candidate_priority_queue(cmp);
+      for (int i = 0; i < scores_data.size(); ++i) {
+          //std::cout << "scores_data "<< scores_data[i] << std::endl;
+        if (scores_data[i] > score_threshold) {
+          candidate_priority_queue.emplace(Candidate({i, scores_data[i]}));
+        }
+      }
+
+      std::vector<int> selected;
+      std::vector<float> selected_boxes;
+      Candidate next_candidate;
+
+      const Tensor const_boxes = boxes;
+      typename TTypes<float, 2>::ConstTensor boxes_data = 
+        const_boxes.tensor<float, 2>();
+      LOG(ERROR) << " boxes data " << boxes.DebugString();
+      while (selected.size() < output_size && !candidate_priority_queue.empty())
+      {
+        next_candidate = candidate_priority_queue.top();
+        //std::cout << " next_candidate " << next_candidate.box_index << std::endl;
+        candidate_priority_queue.pop();
+
+        // Overlapping boxes are likely to have similar scores,
+        // therefore we iterate through the previously selected boxes backwards
+        // in order to see if `next_candidate` should be suppressed.
+        bool should_select = true;
+        for (int j = selected.size() - 1; j >= 0; --j) {
+          if (IOUGreaterThanThreshold(boxes_data, next_candidate.box_index, 
+              selected[j], iou_threshold)) {
+              //std::cout << " Dont select. box id is " << selected[j] << " idx " << j <<std::endl;  
+            should_select = false;
+            break;
+          }
+        }
+
+        if (should_select) {
+          selected.push_back(next_candidate.box_index);
+          //std::cout << " select box_index " << next_candidate.box_index << std::endl;
+          //Add the selected box to the result candidate. Sorted by score
+          int id = next_candidate.box_index;
+          ResultCandidate rc = {next_candidate.box_index, next_candidate.score,
+            class_idx, {boxes_data(id, 0), boxes_data(id, 1), boxes_data(id, 2),
+            boxes_data(id, 3)}}; 
+          result_candidate_pq.push(rc);
+        }
+      }
+
+    }
+    int total_size_per_batch = max_total_size.scalar<int>()();
+    std::cout << " pq size " << result_candidate_pq.size() << std::endl;
+
+    if (total_size_per_batch > 0)
+      max_detections = std::min((int) result_candidate_pq.size(), 
+        total_size_per_batch);
+    else max_detections = (int) result_candidate_pq.size();
+
+    std::cout << " max_detections " << max_detections << std::endl;
+    final_valid_detections.push_back(max_detections);
+    // Pick the top max_total_size values 
+    while(total_size_per_batch > 0 && !result_candidate_pq.empty())
+    {
+      ResultCandidate next_candidate = result_candidate_pq.top();
+      result_candidate_pq.pop();
+      // Add to final output vectors
+      nmsed_boxes[batch].push_back(next_candidate.box_coord[0]);
+      nmsed_boxes[batch].push_back(next_candidate.box_coord[1]);
+      nmsed_boxes[batch].push_back(next_candidate.box_coord[2]);
+      nmsed_boxes[batch].push_back(next_candidate.box_coord[3]);
+      nmsed_scores[batch].push_back(next_candidate.score);
+      nmsed_classes[batch].push_back(next_candidate.class_idx);
+      selected_indices[batch].push_back(next_candidate.box_index);
+      total_size_per_batch--;
+    }
+            
+  }
+
+  Tensor* nmsed_boxes_t = nullptr;
+  TensorShape boxes_shape({num_batches, max_detections, 4});
+  OP_REQUIRES_OK(context,
+                 context->allocate_output(0, boxes_shape, &nmsed_boxes_t));
+  auto nmsed_boxes_flat = nmsed_boxes_t->template flat<float>();
+
+  Tensor* nmsed_scores_t = nullptr;
+  TensorShape scores_shape({num_batches, max_detections});
+  OP_REQUIRES_OK(context,
+                 context->allocate_output(1, scores_shape, &nmsed_scores_t));
+  auto nmsed_scores_flat = nmsed_scores_t->template flat<float>();
+
+  Tensor* nmsed_classes_t = nullptr;
+  OP_REQUIRES_OK(context,
+                 context->allocate_output(2, scores_shape, &nmsed_classes_t));
+  auto nmsed_classes_flat = nmsed_classes_t->template flat<float>();
+
+  Tensor* valid_detections_t = nullptr;
+  TensorShape valid_detections_shape({num_batches});
+  OP_REQUIRES_OK(context, context->allocate_output(3, valid_detections_shape, 
+                 &valid_detections_t));
+  auto valid_detections_flat = valid_detections_t->template flat<int>();
+
+  Tensor* selected_indices_t = nullptr;
+  OP_REQUIRES_OK(context,
+                 context->allocate_output(4, scores_shape, &selected_indices_t));
+  auto selected_indices_flat = selected_indices_t->template flat<int>();
+  for (int i = 0; i < num_batches; ++i) {
+    valid_detections_flat(i) = final_valid_detections[i];
+    for (int j = 0; j < max_detections; ++j) {
+      nmsed_scores_flat(i * max_detections + j) = nmsed_scores[i][j];
+      nmsed_classes_flat(i * max_detections + j) = nmsed_classes[i][j];
+      selected_indices_flat(i * max_detections + j) = selected_indices[i][j];
+      for (int k = 0; k < 4; ++k) {
+        nmsed_boxes_flat(i * max_detections * 4 + j * 4 + k) = 
+          nmsed_boxes[i][j * 4 + k]; 
+      }
+    }
+  }
+  LOG(ERROR) << " boxes " << nmsed_boxes_t->DebugString();
+  LOG(ERROR) << " Scores " << nmsed_scores_t->DebugString();
+  LOG(ERROR) << " classes " << nmsed_classes_t->DebugString();
 }
 
 }  // namespace
@@ -435,6 +673,65 @@ class NonMaxSuppressionWithOverlapsOp : public OpKernel {
   }
 };
 
+template <typename Device>
+class NonMaxSuppressionLiteOp : public OpKernel {
+ public:
+  explicit NonMaxSuppressionLiteOp(OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    // boxes: [batch_size, num_anchors, q, 4]
+    const Tensor& boxes = context->input(0);
+    LOG(ERROR) << " inp_boxes " << boxes.DebugString();
+    // scores: [batch_size, num_anchors, num_classes]
+    const Tensor& scores = context->input(1);
+    OP_REQUIRES(context, (boxes.dim_size(0) == scores.dim_size(0)),
+              errors::InvalidArgument(
+                "boxes and scores must have same batch size"));
+
+    // max_output_size: scalar
+    const Tensor& max_output_size = context->input(2);
+    OP_REQUIRES(
+        context, TensorShapeUtils::IsScalar(max_output_size.shape()),
+        errors::InvalidArgument("max_size_per_class must be 0-D, got shape ",
+                                max_output_size.shape().DebugString()));
+    // max_total_size: scalar
+    const Tensor& max_total_size = context->input(3);
+    OP_REQUIRES(
+        context, TensorShapeUtils::IsScalar(max_total_size.shape()),
+        errors::InvalidArgument("max_total_size must be 0-D, got shape ",
+                                max_total_size.shape().DebugString()));
+    // iou_threshold: scalar
+    const Tensor& iou_threshold = context->input(4);
+    OP_REQUIRES(context, TensorShapeUtils::IsScalar(iou_threshold.shape()),
+                errors::InvalidArgument("iou_threshold must be 0-D, got shape ",
+                                        iou_threshold.shape().DebugString()));
+    const float iou_threshold_val = iou_threshold.scalar<float>()();
+
+    // score_threshold: scalar
+    const Tensor& score_threshold = context->input(5);
+    OP_REQUIRES(
+        context, TensorShapeUtils::IsScalar(score_threshold.shape()),
+        errors::InvalidArgument("score_threshold must be 0-D, got shape ",
+                                score_threshold.shape().DebugString()));
+    const float score_threshold_val = score_threshold.scalar<float>()();
+
+    OP_REQUIRES(context, iou_threshold_val >= 0 && iou_threshold_val <= 1,
+                errors::InvalidArgument("iou_threshold must be in [0, 1]"));
+    int num_boxes = 0;
+    const int num_classes = scores.dim_size(2);
+    ParseAndCheckNMSLiteBoxSizes(context, boxes, &num_boxes, num_classes);
+    CheckNMSLiteScoreSizes(context, num_boxes, scores);
+    if (!context->status().ok()) {
+      return;
+    }
+    BatchedNonMaxSuppressionOp(context, boxes, scores, num_boxes, 
+                               max_output_size, max_total_size, 
+                               score_threshold_val, iou_threshold_val);
+  }
+};
+
+
 REGISTER_KERNEL_BUILDER(Name("NonMaxSuppression").Device(DEVICE_CPU),
                         NonMaxSuppressionOp<CPUDevice>);
 
@@ -465,5 +762,8 @@ REGISTER_KERNEL_BUILDER(Name("NonMaxSuppressionV4")
 REGISTER_KERNEL_BUILDER(
     Name("NonMaxSuppressionWithOverlaps").Device(DEVICE_CPU),
     NonMaxSuppressionWithOverlapsOp<CPUDevice>);
+
+REGISTER_KERNEL_BUILDER(Name("NonMaxSuppressionLite").Device(DEVICE_CPU),
+        NonMaxSuppressionLiteOp<CPUDevice>);
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/non_max_suppression_op_test.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op_test.cc
@@ -892,22 +892,22 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestEmptyInput) {
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({0, 10, 4}));
   test::FillValues<float>(&expected_boxes, {});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  
+
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({0, 10}));
   test::FillValues<float>(&expected_scores, {});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  
+
   // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({0, 10}));
   test::FillValues<float>(&expected_classes, {});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
-  
+
   // valid
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({0}));
   test::FillValues<int>(&expected_valid_d, {});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  
+
   // indices
   Tensor expected_indices(allocator(), DT_INT32, TensorShape({0, 10}));
   test::FillValues<int>(&expected_indices, {});
@@ -919,19 +919,19 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectFromThreeClusters) {
   AddInputFromArray<float>(
       TensorShape({1, 6, 1, 4}),
       {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
-       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3, 1,   0.4});
-  AddInputFromArray<float>(TensorShape({1, 6, 1}), 
-       {.9f, .75f, .6f, .95f, .5f, .3f});
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.3,   1,   0.4});
+  AddInputFromArray<float>(TensorShape({1, 6, 1}),
+                           {.9f, .75f, .6f, .95f, .5f, .3f});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
-          0, 0.3, 1, 0.4});
+  test::FillValues<float>(&expected_boxes,
+                          {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 0, 0.3, 1, 0.4});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 3}));
@@ -952,24 +952,24 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectFromThreeClusters) {
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromThreeClustersWithScoreThreshold) {
+       TestSelectFromThreeClustersWithScoreThreshold) {
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({1, 6, 1, 4}),
       {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
-       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3, 1,   0.4});
-  AddInputFromArray<float>(TensorShape({1, 6, 1}), 
-       {.9f, .75f, .6f, .95f, .5f, .3f});
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.3,   1,   0.4});
+  AddInputFromArray<float>(TensorShape({1, 6, 1}),
+                           {.9f, .75f, .6f, .95f, .5f, .3f});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.4f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1,
-      0, 0, 0, 0});
+  test::FillValues<float>(&expected_boxes,
+                          {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 3}));
@@ -990,14 +990,14 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromThreeClustersWithScoreThresholdZeroScores) {
+       TestSelectFromThreeClustersWithScoreThresholdZeroScores) {
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({1, 6, 1, 4}),
       {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
-       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3, 1,   0.4});
-  AddInputFromArray<float>(TensorShape({1, 6, 1}), 
-       {.1f, 0, 0, .3f, .2f, -5.0f});
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.3,   1,   0.4});
+  AddInputFromArray<float>(TensorShape({1, 6, 1}),
+                           {.1f, 0, 0, .3f, .2f, -5.0f});
   // If we ask for more boxes than we actually expect to get back;
   // should still only get 2 boxes back.
   AddInputFromArray<int>(TensorShape({}), {4});
@@ -1005,11 +1005,14 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {-3.0f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 5, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,});
+  test::FillValues<float>(
+      &expected_boxes,
+      {
+          0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      });
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 5}));
@@ -1031,14 +1034,14 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
 
 TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectSingleBox) {
   MakeOp();
-  AddInputFromArray<float>(TensorShape({1, 1, 1, 4}), {0, 0, 1, 1});  
+  AddInputFromArray<float>(TensorShape({1, 1, 1, 4}), {0, 0, 1, 1});
   AddInputFromArray<float>(TensorShape({1, 1, 1}), {.9f});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<int>(TensorShape({}), {1});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 1, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0, 1, 1});
@@ -1062,27 +1065,28 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectSingleBox) {
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromTwoBatchesWithScoreThreshold) {
+       TestSelectFromTwoBatchesWithScoreThreshold) {
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
       {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
-       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.3,   1,   0.4,
        0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
-       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
-       });
-  AddInputFromArray<float>(TensorShape({2, 6, 1}), 
-       {.9f, .75f, .6f, .95f, .5f, .3f, .9f, .75f, .6f, .95f, .5f, .3f});
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0, 0.4,   1,   0.5});
+  AddInputFromArray<float>(
+      TensorShape({2, 6, 1}),
+      {.9f, .75f, .6f, .95f, .5f, .3f, .9f, .75f, .6f, .95f, .5f, .3f});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.4f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
-          0, 0, 0, 0, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
+  test::FillValues<float>(&expected_boxes,
+                          {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 0, 0, 0, 0,
+                           0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
@@ -1102,30 +1106,30 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromTwoBatchesTwoClasses) {
+TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectFromTwoBatchesTwoClasses) {
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
       {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
-       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.3,   1,   0.4,
        0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
-       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
-       });
-  AddInputFromArray<float>(TensorShape({2, 6, 2}), 
-       {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
-       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f}); 
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0, 0.4,   1,   0.5});
+  AddInputFromArray<float>(TensorShape({2, 6, 2}),
+                           {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f,
+                            0.5f, 0.5f, 0.3f,  0.1f, 0.1f, 0.9f, 0.75f, 0.8f,
+                            0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f,  0.1f});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
-          0, 0.01f, 0.1, 0.11f, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 
-          0, 0.02f, 0.2, 0.22f});
+  test::FillValues<float>(
+      &expected_boxes,
+      {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 0, 0.01f, 0.1, 0.11f,
+       0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0.02f, 0.2, 0.22f});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
@@ -1146,29 +1150,29 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromTwoBatchesTwoClassesWithScoreThreshold) {
+       TestSelectFromTwoBatchesTwoClassesWithScoreThreshold) {
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
       {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
-       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.3,   1,   0.4,
        0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
-       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
-       });
-  AddInputFromArray<float>(TensorShape({2, 6, 2}), 
-      {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
-       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f
-       }); 
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0, 0.4,   1,   0.5});
+  AddInputFromArray<float>(TensorShape({2, 6, 2}),
+                           {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f,
+                            0.5f, 0.5f, 0.3f,  0.1f, 0.1f, 0.9f, 0.75f, 0.8f,
+                            0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f,  0.1f});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.8f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
-          0, 0, 0, 0, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
+  test::FillValues<float>(&expected_boxes,
+                          {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 0, 0, 0, 0,
+                           0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
@@ -1189,29 +1193,29 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromTwoBatchesTwoClassesWithScoreThresholdPaddedTotalSize) {
+       TestSelectFromTwoBatchesTwoClassesWithScoreThresholdPaddedTotalSize) {
   MakeOp(true);
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
       {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
-       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.3,   1,   0.4,
        0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
-       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
-       });
-  AddInputFromArray<float>(TensorShape({2, 6, 2}), 
-      {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
-       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f
-       }); 
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0, 0.4,   1,   0.5});
+  AddInputFromArray<float>(TensorShape({2, 6, 2}),
+                           {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f,
+                            0.5f, 0.5f, 0.3f,  0.1f, 0.1f, 0.9f, 0.75f, 0.8f,
+                            0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f,  0.1f});
   AddInputFromArray<int>(TensorShape({}), {10});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.8f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
-          0, 0, 0, 0, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
+  test::FillValues<float>(&expected_boxes,
+                          {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 0, 0, 0, 0,
+                           0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
@@ -1232,19 +1236,18 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromTwoBatchesTwoClassesWithScoreThresholdPaddedPerClass) {
+       TestSelectFromTwoBatchesTwoClassesWithScoreThresholdPaddedPerClass) {
   MakeOp(true);
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
       {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
-       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.3,   1,   0.4,
        0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
-       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
-       });
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0, 0.4,   1,   0.5});
   AddInputFromArray<float>(TensorShape({2, 6, 2}),
-      {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f,
-       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f
-       });
+                           {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f,
+                            0.5f, 0.5f, 0.3f,  0.1f, 0.1f, 0.9f, 0.75f, 0.8f,
+                            0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f,  0.1f});
   AddInputFromArray<int>(TensorShape({}), {2});
   AddInputFromArray<int>(TensorShape({}), {50});
   AddInputFromArray<float>(TensorShape({}), {.5f});
@@ -1253,9 +1256,10 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
 
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 4, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1,
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0,
-          0, 0, 0, 0});
+  test::FillValues<float>(
+      &expected_boxes,
+      {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 4}));
@@ -1276,37 +1280,37 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromTwoBatchesTwoClassesTotalSize) {
+       TestSelectFromTwoBatchesTwoClassesTotalSize) {
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
       {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
-       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.3,   1,   0.4,
        0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
-       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
-       });
-  AddInputFromArray<float>(TensorShape({2, 6, 2}), 
-      {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
-       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f
-       }); 
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0, 0.4,   1,   0.5});
+  AddInputFromArray<float>(TensorShape({2, 6, 2}),
+                           {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f,
+                            0.5f, 0.5f, 0.3f,  0.1f, 0.1f, 0.9f, 0.75f, 0.8f,
+                            0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f,  0.1f});
   AddInputFromArray<int>(TensorShape({}), {3});
   // Total size per batch is more than size per class
   AddInputFromArray<int>(TensorShape({}), {5});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.1f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 5, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
-          0, 0.01f, 0.1, 0.11f, 0, 0.12f, 0.1, 0.21f, 0,  0.3, 1, 0.4,
-          0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0.02f, 0.2, 0.22f,
-          0, 0.22f, 0.2, 0.31f, 0, 0.4, 1, 0.5});
+  test::FillValues<float>(
+      &expected_boxes, {0,   0.11,  0.1, 0.2,   0,   0,     0.1, 0.1, 0, 0.01f,
+                        0.1, 0.11f, 0,   0.12f, 0.1, 0.21f, 0,   0.3, 1, 0.4,
+                        0,   0.21,  0.2, 0.3,   0,   0,     0.2, 0.2, 0, 0.02f,
+                        0.2, 0.22f, 0,   0.22f, 0.2, 0.31f, 0,   0.4, 1, 0.5});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 5}));
-  test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.75, 0.5, 0.3, 
-          0.95, 0.9, 0.75, 0.5, 0.3});
+  test::FillValues<float>(
+      &expected_scores, {0.95, 0.9, 0.75, 0.5, 0.3, 0.95, 0.9, 0.75, 0.5, 0.3});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
   // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 5}));
@@ -1323,39 +1327,37 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromTwoBatchesTwoClassesForBoxesAndScores) {
+       TestSelectFromTwoBatchesTwoClassesForBoxesAndScores) {
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 2, 4}),
       // batch 0, box1 of class 1 should get selected
-      {0, 0,     0.1, 0.1,   0, 0,     0.1, 0.1, 
-       0, 0.01f, 0.1, 0.11f, 0, 0.6f,  0.1, 0.7f,
-       0, -0.01, 0.1, 0.09f, 0, -0.01, 0.1, 0.09f, 
-       0, 0.11,  0.1, 0.2,   0, 0.11,  0.1, 0.2, 
-       0, 0.12f, 0.1, 0.21f, 0, 0.12f, 0.1, 0.21f, 
-       0, 0.3,   1,   0.4,   0, 0.3,   1,   0.4, 
-      // batch 1, box1 of class 0 should get selected
-       0, 0,     0.2, 0.2,   0, 0,     0.2, 0.2, 
-       0, 0.02f, 0.2, 0.22f, 0, 0.02f, 0.2, 0.22f,
-       0, -0.02, 0.2, 0.19f, 0, -0.02, 0.2, 0.19f,
-       0, 0.21,  0.2, 0.3,   0, 0.21,  0.2, 0.3, 
-       0, 0.22f, 0.2, 0.31f, 0, 0.22f, 0.2, 0.31f,
-       0,  0.4,  1,   0.5,   0, 0.4,   1,   0.5});
+      {0, 0, 0.1, 0.1, 0, 0, 0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, 0.6f, 0.1, 0.7f,
+       0, -0.01, 0.1, 0.09f, 0, -0.01, 0.1, 0.09f, 0, 0.11, 0.1, 0.2, 0, 0.11,
+       0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0, 0.12f, 0.1, 0.21f, 0, 0.3, 1, 0.4, 0,
+       0.3, 1, 0.4,
+       // batch 1, box1 of class 0 should get selected
+       0, 0, 0.2, 0.2, 0, 0, 0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, 0.02f, 0.2,
+       0.22f, 0, -0.02, 0.2, 0.19f, 0, -0.02, 0.2, 0.19f, 0, 0.21, 0.2, 0.3, 0,
+       0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0, 0.22f, 0.2, 0.31f, 0, 0.4, 1,
+       0.5, 0, 0.4, 1, 0.5});
 
-  AddInputFromArray<float>(TensorShape({2, 6, 2}), 
-      {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
-       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f
-       }); 
+  AddInputFromArray<float>(TensorShape({2, 6, 2}),
+                           {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f,
+                            0.5f, 0.5f, 0.3f,  0.1f, 0.1f, 0.9f, 0.75f, 0.8f,
+                            0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f,  0.1f});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());
-  
+
   // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
-           0, 0.6f, 0.1, 0.7f, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0.02f, 0.2, 0.22f});
+  test::FillValues<float>(
+      &expected_boxes,
+      {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 0, 0.6f,  0.1, 0.7f,
+       0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0.02f, 0.2, 0.22f});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));

--- a/tensorflow/core/kernels/non_max_suppression_op_test.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op_test.cc
@@ -861,11 +861,11 @@ TEST_F(NonMaxSuppressionWithOverlapsOpTest, TestEmptyInput) {
   test::ExpectTensorEqual<int>(expected, *GetOutput(0));
 }
 
-class NonMaxSuppressionLiteOpTest : public OpsTestBase {
+class CombinedNonMaxSuppressionOpTest : public OpsTestBase {
  protected:
   void MakeOp(bool pad_per_class = false) {
-    TF_EXPECT_OK(NodeDefBuilder("non_max_suppression_lite_op", 
-                                "NonMaxSuppressionLite")
+    TF_EXPECT_OK(NodeDefBuilder("combined_non_max_suppression_op",
+                                "CombinedNonMaxSuppression")
                      .Input(FakeInput(DT_FLOAT))
                      .Input(FakeInput(DT_FLOAT))
                      .Input(FakeInput(DT_INT32))
@@ -878,7 +878,7 @@ class NonMaxSuppressionLiteOpTest : public OpsTestBase {
   }
 };
 
-TEST_F(NonMaxSuppressionLiteOpTest, TestEmptyInput) {
+TEST_F(CombinedNonMaxSuppressionOpTest, TestEmptyInput) {
   MakeOp();
   AddInputFromArray<float>(TensorShape({0, 0, 0, 4}), {});
   AddInputFromArray<float>(TensorShape({0, 0, 0}), {});
@@ -914,7 +914,7 @@ TEST_F(NonMaxSuppressionLiteOpTest, TestEmptyInput) {
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, TestSelectFromThreeClusters) {
+TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectFromThreeClusters) {
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({1, 6, 1, 4}),
@@ -951,7 +951,7 @@ TEST_F(NonMaxSuppressionLiteOpTest, TestSelectFromThreeClusters) {
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, 
+TEST_F(CombinedNonMaxSuppressionOpTest,
         TestSelectFromThreeClustersWithScoreThreshold) {
   MakeOp();
   AddInputFromArray<float>(
@@ -989,7 +989,7 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, 
+TEST_F(CombinedNonMaxSuppressionOpTest,
         TestSelectFromThreeClustersWithScoreThresholdZeroScores) {
   MakeOp();
   AddInputFromArray<float>(
@@ -1029,7 +1029,7 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, TestSelectSingleBox) {
+TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectSingleBox) {
   MakeOp();
   AddInputFromArray<float>(TensorShape({1, 1, 1, 4}), {0, 0, 1, 1});  
   AddInputFromArray<float>(TensorShape({1, 1, 1}), {.9f});
@@ -1061,7 +1061,7 @@ TEST_F(NonMaxSuppressionLiteOpTest, TestSelectSingleBox) {
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, 
+TEST_F(CombinedNonMaxSuppressionOpTest,
         TestSelectFromTwoBatchesWithScoreThreshold) {
   MakeOp();
   AddInputFromArray<float>(
@@ -1102,7 +1102,7 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, 
+TEST_F(CombinedNonMaxSuppressionOpTest,
         TestSelectFromTwoBatchesTwoClasses) {
   MakeOp();
   AddInputFromArray<float>(
@@ -1145,7 +1145,7 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, 
+TEST_F(CombinedNonMaxSuppressionOpTest,
         TestSelectFromTwoBatchesTwoClassesWithScoreThreshold) {
   MakeOp();
   AddInputFromArray<float>(
@@ -1188,7 +1188,7 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, 
+TEST_F(CombinedNonMaxSuppressionOpTest,
         TestSelectFromTwoBatchesTwoClassesWithScoreThresholdPadded) {
   MakeOp(true);
   AddInputFromArray<float>(
@@ -1231,7 +1231,7 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, 
+TEST_F(CombinedNonMaxSuppressionOpTest,
         TestSelectFromTwoBatchesTwoClassesTotalSize) {
   MakeOp();
   AddInputFromArray<float>(
@@ -1278,7 +1278,7 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
-TEST_F(NonMaxSuppressionLiteOpTest, 
+TEST_F(CombinedNonMaxSuppressionOpTest,
         TestSelectFromTwoBatchesTwoClassesForBoxesAndScores) {
   MakeOp();
   AddInputFromArray<float>(

--- a/tensorflow/core/kernels/non_max_suppression_op_test.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op_test.cc
@@ -888,17 +888,17 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestEmptyInput) {
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());
 
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({0, 10, 4}));
   test::FillValues<float>(&expected_boxes, {});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({0, 10}));
   test::FillValues<float>(&expected_scores, {});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
   
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({0, 10}));
   test::FillValues<float>(&expected_classes, {});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -928,16 +928,16 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectFromThreeClusters) {
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 3, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
           0, 0.3, 1, 0.4});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 3}));
   test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.3});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({1, 3}));
   test::FillValues<float>(&expected_classes, {0, 0, 0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -966,16 +966,16 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   AddInputFromArray<float>(TensorShape({}), {0.4f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 3, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1,
       0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 3}));
   test::FillValues<float>(&expected_scores, {0.95, 0.9, 0});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({1, 3}));
   test::FillValues<float>(&expected_classes, {0, 0, 0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -1006,16 +1006,16 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   AddInputFromArray<float>(TensorShape({}), {-3.0f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 5, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 5}));
   test::FillValues<float>(&expected_scores, {0.3, 0.1, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({1, 5}));
   test::FillValues<float>(&expected_classes, {0, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -1039,15 +1039,15 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectSingleBox) {
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 1, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0, 1, 1});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 1}));
   test::FillValues<float>(&expected_scores, {0.9});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({1, 1}));
   test::FillValues<float>(&expected_classes, {0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -1079,16 +1079,16 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   AddInputFromArray<float>(TensorShape({}), {0.4f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
           0, 0, 0, 0, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_scores, {0.95, 0.9, 0, 0.95, 0.9, 0});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_classes, {0, 0, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -1121,17 +1121,17 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
           0, 0.01f, 0.1, 0.11f, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 
           0, 0.02f, 0.2, 0.22f});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.75, 0.95, 0.9, 0.75});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_classes, {0, 1, 0, 0, 1, 0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -1165,16 +1165,16 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   AddInputFromArray<float>(TensorShape({}), {0.8f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
           0, 0, 0, 0, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_scores, {0.95, 0.9, 0, 0.95, 0.9, 0});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_classes, {0, 1, 0, 0, 1, 0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -1189,7 +1189,7 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
-        TestSelectFromTwoBatchesTwoClassesWithScoreThresholdPadded) {
+        TestSelectFromTwoBatchesTwoClassesWithScoreThresholdPaddedTotalSize) {
   MakeOp(true);
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
@@ -1202,22 +1202,22 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
       {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
        0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f
        }); 
-  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<int>(TensorShape({}), {10});
   AddInputFromArray<int>(TensorShape({}), {3});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.8f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
           0, 0, 0, 0, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_scores, {0.95, 0.9, 0, 0.95, 0.9, 0});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_classes, {0, 1, 0, 0, 1, 0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -1228,6 +1228,50 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   // indices
   Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 3}));
   test::FillValues<int>(&expected_indices, {3, 0, 0, 3, 0, 0});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(CombinedNonMaxSuppressionOpTest,
+        TestSelectFromTwoBatchesTwoClassesWithScoreThresholdPaddedPerClass) {
+  MakeOp(true);
+  AddInputFromArray<float>(
+      TensorShape({2, 6, 1, 4}),
+      {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
+       });
+  AddInputFromArray<float>(TensorShape({2, 6, 2}),
+      {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f,
+       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f
+       });
+  AddInputFromArray<int>(TensorShape({}), {2});
+  AddInputFromArray<int>(TensorShape({}), {50});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.8f});
+  TF_ASSERT_OK(RunOpKernel());
+
+  // boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 4, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0,
+          0, 0, 0, 0});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  // scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 4}));
+  test::FillValues<float>(&expected_scores, {0.95, 0.9, 0, 0, 0.95, 0.9, 0, 0});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  // classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 4}));
+  test::FillValues<float>(&expected_classes, {0, 1, 0, 0, 0, 1, 0, 0});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
+  test::FillValues<int>(&expected_valid_d, {2, 2});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 4}));
+  test::FillValues<int>(&expected_indices, {3, 0, 0, 0, 3, 0, 0, 0});
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
@@ -1246,25 +1290,25 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
        0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f
        }); 
   AddInputFromArray<int>(TensorShape({}), {3});
-  //Total size per batch is more than size per class
+  // Total size per batch is more than size per class
   AddInputFromArray<int>(TensorShape({}), {5});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.1f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 5, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
           0, 0.01f, 0.1, 0.11f, 0, 0.12f, 0.1, 0.21f, 0,  0.3, 1, 0.4,
           0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0.02f, 0.2, 0.22f,
           0, 0.22f, 0.2, 0.31f, 0, 0.4, 1, 0.5});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 5}));
   test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.75, 0.5, 0.3, 
           0.95, 0.9, 0.75, 0.5, 0.3});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 5}));
   test::FillValues<float>(&expected_classes, {0, 1, 0, 1, 0, 0, 1, 0, 1, 0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
@@ -1283,14 +1327,14 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 2, 4}),
-      //batch 0, box1 of class 1 should get selected
+      // batch 0, box1 of class 1 should get selected
       {0, 0,     0.1, 0.1,   0, 0,     0.1, 0.1, 
        0, 0.01f, 0.1, 0.11f, 0, 0.6f,  0.1, 0.7f,
        0, -0.01, 0.1, 0.09f, 0, -0.01, 0.1, 0.09f, 
        0, 0.11,  0.1, 0.2,   0, 0.11,  0.1, 0.2, 
        0, 0.12f, 0.1, 0.21f, 0, 0.12f, 0.1, 0.21f, 
        0, 0.3,   1,   0.4,   0, 0.3,   1,   0.4, 
-      //batch 1, box1 of class 0 should get selected
+      // batch 1, box1 of class 0 should get selected
        0, 0,     0.2, 0.2,   0, 0,     0.2, 0.2, 
        0, 0.02f, 0.2, 0.22f, 0, 0.02f, 0.2, 0.22f,
        0, -0.02, 0.2, 0.19f, 0, -0.02, 0.2, 0.19f,
@@ -1308,16 +1352,16 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());
   
-  //boxes
+  // boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
   test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
            0, 0.6f, 0.1, 0.7f, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0.02f, 0.2, 0.22f});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
-  //scores
+  // scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.8, 0.95, 0.9, 0.75});
   test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
-  //classes
+  // classes
   Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 3}));
   test::FillValues<float>(&expected_classes, {0, 1, 1, 0, 1, 0});
   test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));

--- a/tensorflow/core/kernels/non_max_suppression_op_test.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op_test.cc
@@ -907,11 +907,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestEmptyInput) {
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({0}));
   test::FillValues<int>(&expected_valid_d, {});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({0, 10}));
-  test::FillValues<int>(&expected_indices, {});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectFromThreeClusters) {
@@ -945,10 +940,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectFromThreeClusters) {
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({1}));
   test::FillValues<int>(&expected_valid_d, {3});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({1, 3}));
-  test::FillValues<int>(&expected_indices, {3, 0, 5});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
@@ -983,10 +974,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({1}));
   test::FillValues<int>(&expected_valid_d, {2});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({1, 3}));
-  test::FillValues<int>(&expected_indices, {3, 0, 0});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
@@ -1026,10 +1013,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({1}));
   test::FillValues<int>(&expected_valid_d, {2});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({1, 5}));
-  test::FillValues<int>(&expected_indices, {3, 0, 0, 0, 0});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectSingleBox) {
@@ -1058,10 +1041,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectSingleBox) {
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({1}));
   test::FillValues<int>(&expected_valid_d, {1});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({1, 1}));
-  test::FillValues<int>(&expected_indices, {0});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
@@ -1100,10 +1079,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
   test::FillValues<int>(&expected_valid_d, {2, 2});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 3}));
-  test::FillValues<int>(&expected_indices, {3, 0, 0, 3, 0, 0});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectFromTwoBatchesTwoClasses) {
@@ -1143,10 +1118,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest, TestSelectFromTwoBatchesTwoClasses) {
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
   test::FillValues<int>(&expected_valid_d, {3, 3});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 3}));
-  test::FillValues<int>(&expected_indices, {3, 0, 1, 3, 0, 1});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
@@ -1186,10 +1157,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
   test::FillValues<int>(&expected_valid_d, {2, 2});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 3}));
-  test::FillValues<int>(&expected_indices, {3, 0, 0, 3, 0, 0});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
@@ -1229,10 +1196,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
   test::FillValues<int>(&expected_valid_d, {2, 2});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 3}));
-  test::FillValues<int>(&expected_indices, {3, 0, 0, 3, 0, 0});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
@@ -1273,10 +1236,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
   test::FillValues<int>(&expected_valid_d, {2, 2});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 4}));
-  test::FillValues<int>(&expected_indices, {3, 0, 0, 0, 3, 0, 0, 0});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
@@ -1320,10 +1279,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
   test::FillValues<int>(&expected_valid_d, {5, 5});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 5}));
-  test::FillValues<int>(&expected_indices, {3, 0, 1, 4, 5, 3, 0, 1, 4, 5});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 TEST_F(CombinedNonMaxSuppressionOpTest,
@@ -1371,10 +1326,6 @@ TEST_F(CombinedNonMaxSuppressionOpTest,
   Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
   test::FillValues<int>(&expected_valid_d, {3, 3});
   test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
-  // indices
-  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 3}));
-  test::FillValues<int>(&expected_indices, {3, 0, 1, 3, 0, 1});
-  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/non_max_suppression_op_test.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op_test.cc
@@ -883,7 +883,7 @@ TEST_F(NonMaxSuppressionLiteOpTest, TestEmptyInput) {
   AddInputFromArray<float>(TensorShape({0, 0, 0, 4}), {});
   AddInputFromArray<float>(TensorShape({0, 0, 0}), {});
   AddInputFromArray<int>(TensorShape({}), {30});
-  AddInputFromArray<int>(TensorShape({}), {30});
+  AddInputFromArray<int>(TensorShape({}), {10});
   AddInputFromArray<float>(TensorShape({}), {.5f});
   AddInputFromArray<float>(TensorShape({}), {0.0f});
   TF_ASSERT_OK(RunOpKernel());

--- a/tensorflow/core/kernels/non_max_suppression_op_test.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op_test.cc
@@ -863,7 +863,7 @@ TEST_F(NonMaxSuppressionWithOverlapsOpTest, TestEmptyInput) {
 
 class NonMaxSuppressionLiteOpTest : public OpsTestBase {
  protected:
-  void MakeOp(bool use_static_shapes = false) {
+  void MakeOp(bool pad_per_class = false) {
     TF_EXPECT_OK(NodeDefBuilder("non_max_suppression_lite_op", 
                                 "NonMaxSuppressionLite")
                      .Input(FakeInput(DT_FLOAT))
@@ -872,7 +872,7 @@ class NonMaxSuppressionLiteOpTest : public OpsTestBase {
                      .Input(FakeInput(DT_INT32))
                      .Input(FakeInput(DT_FLOAT))
                      .Input(FakeInput(DT_FLOAT))
-                     .Attr("use_static_shapes", use_static_shapes)
+                     .Attr("pad_per_class", pad_per_class)
                      .Finalize(node_def()));
     TF_EXPECT_OK(InitOp());
   }

--- a/tensorflow/core/kernels/non_max_suppression_op_test.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op_test.cc
@@ -918,8 +918,8 @@ TEST_F(NonMaxSuppressionLiteOpTest, TestSelectFromThreeClusters) {
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({1, 6, 1, 4}),
-      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
-       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101});
+      {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3, 1,   0.4});
   AddInputFromArray<float>(TensorShape({1, 6, 1}), 
        {.9f, .75f, .6f, .95f, .5f, .3f});
   AddInputFromArray<int>(TensorShape({}), {3});
@@ -930,8 +930,8 @@ TEST_F(NonMaxSuppressionLiteOpTest, TestSelectFromThreeClusters) {
   
   //boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11 ,0, 0, 1, 1, 
-          0, 100, 1, 101});
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
+          0, 0.3, 1, 0.4});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   //scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 3}));
@@ -956,8 +956,8 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({1, 6, 1, 4}),
-      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
-       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101});
+      {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3, 1,   0.4});
   AddInputFromArray<float>(TensorShape({1, 6, 1}), 
        {.9f, .75f, .6f, .95f, .5f, .3f});
   AddInputFromArray<int>(TensorShape({}), {3});
@@ -968,7 +968,7 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   
   //boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 2, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11, 0, 0, 1, 1});
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   //scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 2}));
@@ -993,8 +993,8 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({1, 6, 1, 4}),
-      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
-       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101});
+      {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3, 1,   0.4});
   AddInputFromArray<float>(TensorShape({1, 6, 1}), 
        {.1f, 0, 0, .3f, .2f, -5.0f});
   // If we ask for more boxes than we actually expect to get back;
@@ -1007,7 +1007,7 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   
   //boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 2, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11, 0, 0, 1, 1});
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   //scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 2}));
@@ -1064,10 +1064,10 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
-      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
-       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101,
-       0, 0,  2, 2,  0, 0.2f,  2, 2.2f,  0, -0.2f, 2, 1.9f,
-       0, 20, 2, 22, 0, 20.2f, 2, 22.2f, 0, 200,   2, 202
+      {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
        });
   AddInputFromArray<float>(TensorShape({2, 6, 1}), 
        {.9f, .75f, .6f, .95f, .5f, .3f, .9f, .75f, .6f, .95f, .5f, .3f});
@@ -1079,8 +1079,8 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   
   //boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 2, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11 ,0, 0, 1, 1, 
-          0, 20, 2, 22 ,0, 0, 2, 2});
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
+          0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   //scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 2}));
@@ -1105,10 +1105,10 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
-      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
-       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101,
-       0, 0,  2, 2,  0, 0.2f,  2, 2.2f,  0, -0.2f, 2, 1.9f,
-       0, 20, 2, 22, 0, 20.2f, 2, 22.2f, 0, 200,   2, 202
+      {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
        });
   AddInputFromArray<float>(TensorShape({2, 6, 2}), 
        {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
@@ -1121,8 +1121,9 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   
   //boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11 ,0, 0, 1, 1, 
-          0, 0.1f, 1, 1.1f, 0, 20, 2, 22 ,0, 0, 2, 2, 0, 0.2f, 2, 2.2f});
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
+          0, 0.01f, 0.1, 0.11f, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 
+          0, 0.02f, 0.2, 0.22f});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   //scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
@@ -1147,10 +1148,10 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
-      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
-       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101,
-       0, 0,  2, 2,  0, 0.2f,  2, 2.2f,  0, -0.2f, 2, 1.9f,
-       0, 20, 2, 22, 0, 20.2f, 2, 22.2f, 0, 200,   2, 202
+      {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
        });
   AddInputFromArray<float>(TensorShape({2, 6, 2}), 
       {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
@@ -1164,8 +1165,8 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   
   //boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 2, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11 ,0, 0, 1, 1, 
-          0, 20, 2, 22, 0, 0, 2, 2});
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
+          0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   //scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 2}));
@@ -1190,10 +1191,10 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   MakeOp(true);
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
-      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
-       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101,
-       0, 0,  2, 2,  0, 0.2f,  2, 2.2f,  0, -0.2f, 2, 1.9f,
-       0, 20, 2, 22, 0, 20.2f, 2, 22.2f, 0, 200,   2, 202
+      {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
        });
   AddInputFromArray<float>(TensorShape({2, 6, 2}), 
       {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
@@ -1207,8 +1208,8 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   
   //boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11 ,0, 0, 1, 1, 
-          0, 0, 0, 0, 0, 20, 2, 22, 0, 0, 2, 2, 0, 0, 0, 0});
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
+          0, 0, 0, 0, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0, 0, 0});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   //scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
@@ -1233,10 +1234,10 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   MakeOp();
   AddInputFromArray<float>(
       TensorShape({2, 6, 1, 4}),
-      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
-       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101,
-       0, 0,  2, 2,  0, 0.2f,  2, 2.2f,  0, -0.2f, 2, 1.9f,
-       0, 20, 2, 22, 0, 20.2f, 2, 22.2f, 0, 200,   2, 202
+      {0, 0,    0.1, 0.1, 0, 0.01f, 0.1, 0.11f, 0, -0.01, 0.1, 0.09f,
+       0, 0.11, 0.1, 0.2, 0, 0.12f, 0.1, 0.21f, 0,  0.3,  1,   0.4,
+       0, 0,    0.2, 0.2, 0, 0.02f, 0.2, 0.22f, 0, -0.02, 0.2, 0.19f,
+       0, 0.21, 0.2, 0.3, 0, 0.22f, 0.2, 0.31f, 0,  0.4,  1,   0.5
        });
   AddInputFromArray<float>(TensorShape({2, 6, 2}), 
       {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
@@ -1251,10 +1252,10 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   
   //boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 5, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11, 0, 0, 1, 1, 
-          0, 0.1f, 1, 1.1f, 0, 10.1f, 1, 11.1f, 0, 100, 1, 101,
-          0, 20, 2, 22, 0, 0, 2, 2, 0, 0.2f, 2, 2.2f, 
-          0, 20.2f, 2, 22.2f, 0, 200, 2, 202});
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
+          0, 0.01f, 0.1, 0.11f, 0, 0.12f, 0.1, 0.21f, 0,  0.3, 1, 0.4,
+          0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0.02f, 0.2, 0.22f,
+          0, 0.22f, 0.2, 0.31f, 0, 0.4, 1, 0.5});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   //scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 5}));
@@ -1281,13 +1282,19 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   AddInputFromArray<float>(
       TensorShape({2, 6, 2, 4}),
       //batch 0, box1 of class 1 should get selected
-      {0, 0, 1, 1, 0, 0,  1, 1, 0, 0.1f, 1, 1.1f, 0, 0.1f, 4, 4.1f, 
-      0, -0.1f, 1, 0.9f, 0, -0.1f, 1, 0.9f, 0, 10, 1, 11, 0, 10, 1, 11, 
-      0, 10.1f, 1, 11.1f, 0, 10.1f, 1, 11.1f, 0, 100, 1, 101, 0, 100, 1, 101, 
+      {0, 0,     0.1, 0.1,   0, 0,     0.1, 0.1, 
+       0, 0.01f, 0.1, 0.11f, 0, 0.6f,  0.1, 0.7f,
+       0, -0.01, 0.1, 0.09f, 0, -0.01, 0.1, 0.09f, 
+       0, 0.11,  0.1, 0.2,   0, 0.11,  0.1, 0.2, 
+       0, 0.12f, 0.1, 0.21f, 0, 0.12f, 0.1, 0.21f, 
+       0, 0.3,   1,   0.4,   0, 0.3,   1,   0.4, 
       //batch 1, box1 of class 0 should get selected
-      0, 0, 2, 2, 0, 0, 2, 2, 0, 0.2f, 2, 2.2f, 0, 0.2f, 2, 2.2f, 
-      0, -0.2f, 2, 1.9f, 0, -0.2f, 2, 1.9f, 0, 20, 2, 22, 0, 20, 2, 22, 
-      0, 20.2f, 2, 22.2f, 0, 20.2f, 2, 22.2f, 0, 200, 2, 202, 0, 200, 2, 202});
+       0, 0,     0.2, 0.2,   0, 0,     0.2, 0.2, 
+       0, 0.02f, 0.2, 0.22f, 0, 0.02f, 0.2, 0.22f,
+       0, -0.02, 0.2, 0.19f, 0, -0.02, 0.2, 0.19f,
+       0, 0.21,  0.2, 0.3,   0, 0.21,  0.2, 0.3, 
+       0, 0.22f, 0.2, 0.31f, 0, 0.22f, 0.2, 0.31f,
+       0,  0.4,  1,   0.5,   0, 0.4,   1,   0.5});
 
   AddInputFromArray<float>(TensorShape({2, 6, 2}), 
       {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
@@ -1301,8 +1308,8 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   
   //boxes
   Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
-  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11, 0, 0, 1, 1, 
-          0, 0.1f, 4, 4.1f, 0, 20, 2, 22 ,0, 0, 2, 2, 0, 0.2f, 2, 2.2f});
+  test::FillValues<float>(&expected_boxes, {0, 0.11, 0.1, 0.2, 0, 0, 0.1, 0.1, 
+           0, 0.6f, 0.1, 0.7f, 0, 0.21, 0.2, 0.3, 0, 0, 0.2, 0.2, 0, 0.02f, 0.2, 0.22f});
   test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
   //scores
   Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
@@ -1321,4 +1328,5 @@ TEST_F(NonMaxSuppressionLiteOpTest,
   test::FillValues<int>(&expected_indices, {3, 0, 1, 3, 0, 1});
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
 }
+
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/non_max_suppression_op_test.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op_test.cc
@@ -861,4 +861,417 @@ TEST_F(NonMaxSuppressionWithOverlapsOpTest, TestEmptyInput) {
   test::ExpectTensorEqual<int>(expected, *GetOutput(0));
 }
 
+class NonMaxSuppressionLiteOpTest : public OpsTestBase {
+ protected:
+  void MakeOp() {
+    TF_EXPECT_OK(NodeDefBuilder("non_max_suppression_lite_op", 
+                                "NonMaxSuppressionLite")
+                     .Input(FakeInput(DT_FLOAT))
+                     .Input(FakeInput(DT_FLOAT))
+                     .Input(FakeInput(DT_INT32))
+                     .Input(FakeInput(DT_INT32))
+                     .Input(FakeInput(DT_FLOAT))
+                     .Input(FakeInput(DT_FLOAT))
+                     .Finalize(node_def()));
+    TF_EXPECT_OK(InitOp());
+  }
+};
+
+TEST_F(NonMaxSuppressionLiteOpTest, TestEmptyInput) {
+  MakeOp();
+  AddInputFromArray<float>(TensorShape({0, 0, 0, 4}), {});
+  AddInputFromArray<float>(TensorShape({0, 0, 0}), {});
+  AddInputFromArray<int>(TensorShape({}), {30});
+  AddInputFromArray<int>(TensorShape({}), {30});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+  TF_ASSERT_OK(RunOpKernel());
+
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({0, 0, 4}));
+  test::FillValues<float>(&expected_boxes, {});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({0, 0}));
+  test::FillValues<float>(&expected_scores, {});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({0, 0}));
+  test::FillValues<float>(&expected_classes, {});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({0}));
+  test::FillValues<int>(&expected_valid_d, {});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({0, 0}));
+  test::FillValues<int>(&expected_indices, {});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(NonMaxSuppressionLiteOpTest, TestSelectFromThreeClusters) {
+  MakeOp();
+  AddInputFromArray<float>(
+      TensorShape({1, 6, 1, 4}),
+      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
+       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101});
+  AddInputFromArray<float>(TensorShape({1, 6, 1}), 
+       {.9f, .75f, .6f, .95f, .5f, .3f});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+  TF_ASSERT_OK(RunOpKernel());
+  
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 3, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11 ,0, 0, 1, 1, 
+          0, 100, 1, 101});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 3}));
+  test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.3});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({1, 3}));
+  test::FillValues<float>(&expected_classes, {0, 0, 0});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({1}));
+  test::FillValues<int>(&expected_valid_d, {3});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({1, 3}));
+  test::FillValues<int>(&expected_indices, {3, 0, 5});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(NonMaxSuppressionLiteOpTest, 
+        TestSelectFromThreeClustersWithScoreThreshold) {
+  MakeOp();
+  AddInputFromArray<float>(
+      TensorShape({1, 6, 1, 4}),
+      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
+       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101});
+  AddInputFromArray<float>(TensorShape({1, 6, 1}), 
+       {.9f, .75f, .6f, .95f, .5f, .3f});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.4f});
+  TF_ASSERT_OK(RunOpKernel());
+  
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 2, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11, 0, 0, 1, 1});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 2}));
+  test::FillValues<float>(&expected_scores, {0.95, 0.9});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({1, 2}));
+  test::FillValues<float>(&expected_classes, {0, 0});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({1}));
+  test::FillValues<int>(&expected_valid_d, {2});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({1, 2}));
+  test::FillValues<int>(&expected_indices, {3, 0});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(NonMaxSuppressionLiteOpTest, 
+        TestSelectFromThreeClustersWithScoreThresholdZeroScores) {
+  MakeOp();
+  AddInputFromArray<float>(
+      TensorShape({1, 6, 1, 4}),
+      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
+       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101});
+  AddInputFromArray<float>(TensorShape({1, 6, 1}), 
+       {.1f, 0, 0, .3f, .2f, -5.0f});
+  // If we ask for more boxes than we actually expect to get back;
+  // should still only get 2 boxes back.
+  AddInputFromArray<int>(TensorShape({}), {6});
+  AddInputFromArray<int>(TensorShape({}), {7});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {-3.0f});
+  TF_ASSERT_OK(RunOpKernel());
+  
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 2, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11, 0, 0, 1, 1});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 2}));
+  test::FillValues<float>(&expected_scores, {0.3, 0.1});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({1, 2}));
+  test::FillValues<float>(&expected_classes, {0, 0});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({1}));
+  test::FillValues<int>(&expected_valid_d, {2});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({1, 2}));
+  test::FillValues<int>(&expected_indices, {3, 0});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(NonMaxSuppressionLiteOpTest, TestSelectSingleBox) {
+  MakeOp();
+  AddInputFromArray<float>(TensorShape({1, 1, 1, 4}), {0, 0, 1, 1});  
+  AddInputFromArray<float>(TensorShape({1, 1, 1}), {.9f});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+  TF_ASSERT_OK(RunOpKernel());
+  
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({1, 1, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 0, 1, 1});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({1, 1}));
+  test::FillValues<float>(&expected_scores, {0.9});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({1, 1}));
+  test::FillValues<float>(&expected_classes, {0});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({1}));
+  test::FillValues<int>(&expected_valid_d, {1});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({1, 1}));
+  test::FillValues<int>(&expected_indices, {0});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(NonMaxSuppressionLiteOpTest, 
+        TestSelectFromTwoBatchesWithScoreThreshold) {
+  MakeOp();
+  AddInputFromArray<float>(
+      TensorShape({2, 6, 1, 4}),
+      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
+       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101,
+       0, 0,  2, 2,  0, 0.2f,  2, 2.2f,  0, -0.2f, 2, 1.9f,
+       0, 20, 2, 22, 0, 20.2f, 2, 22.2f, 0, 200,   2, 202
+       });
+  AddInputFromArray<float>(TensorShape({2, 6, 1}), 
+       {.9f, .75f, .6f, .95f, .5f, .3f, .9f, .75f, .6f, .95f, .5f, .3f});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<int>(TensorShape({}), {9});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.4f});
+  TF_ASSERT_OK(RunOpKernel());
+  
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 2, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11 ,0, 0, 1, 1, 
+          0, 20, 2, 22 ,0, 0, 2, 2});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 2}));
+  test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.95, 0.9});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 2}));
+  test::FillValues<float>(&expected_classes, {0, 0, 0, 0});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
+  test::FillValues<int>(&expected_valid_d, {2, 2});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 2}));
+  test::FillValues<int>(&expected_indices, {3, 0, 3, 0});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(NonMaxSuppressionLiteOpTest, 
+        TestSelectFromTwoBatchesTwoClasses) {
+  MakeOp();
+  AddInputFromArray<float>(
+      TensorShape({2, 6, 1, 4}),
+      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
+       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101,
+       0, 0,  2, 2,  0, 0.2f,  2, 2.2f,  0, -0.2f, 2, 1.9f,
+       0, 20, 2, 22, 0, 20.2f, 2, 22.2f, 0, 200,   2, 202
+       });
+  AddInputFromArray<float>(TensorShape({2, 6, 2}), 
+       {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
+       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f}); 
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+  TF_ASSERT_OK(RunOpKernel());
+  
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11 ,0, 0, 1, 1, 
+          0, 0.1f, 1, 1.1f, 0, 20, 2, 22 ,0, 0, 2, 2, 0, 0.2f, 2, 2.2f});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
+  test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.75, 0.95, 0.9, 0.75});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 3}));
+  test::FillValues<float>(&expected_classes, {0, 1, 0, 0, 1, 0});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
+  test::FillValues<int>(&expected_valid_d, {3, 3});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 3}));
+  test::FillValues<int>(&expected_indices, {3, 0, 1, 3, 0, 1});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(NonMaxSuppressionLiteOpTest, 
+        TestSelectFromTwoBatchesTwoClassesWithScoreThreshold) {
+  MakeOp();
+  AddInputFromArray<float>(
+      TensorShape({2, 6, 1, 4}),
+      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
+       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101,
+       0, 0,  2, 2,  0, 0.2f,  2, 2.2f,  0, -0.2f, 2, 1.9f,
+       0, 20, 2, 22, 0, 20.2f, 2, 22.2f, 0, 200,   2, 202
+       });
+  AddInputFromArray<float>(TensorShape({2, 6, 2}), 
+       {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
+       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f}); 
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.8f});
+  TF_ASSERT_OK(RunOpKernel());
+  
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 2, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11 ,0, 0, 1, 1, 
+          0, 20, 2, 22, 0, 0, 2, 2});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 2}));
+  test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.95, 0.9});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 2}));
+  test::FillValues<float>(&expected_classes, {0, 1, 0, 1});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
+  test::FillValues<int>(&expected_valid_d, {2, 2});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 2}));
+  test::FillValues<int>(&expected_indices, {3, 0, 3, 0});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(NonMaxSuppressionLiteOpTest, 
+        TestSelectFromTwoBatchesTwoClassesTotalSize) {
+  MakeOp();
+  AddInputFromArray<float>(
+      TensorShape({2, 6, 1, 4}),
+      {0, 0,  1, 1,  0, 0.1f,  1, 1.1f,  0, -0.1f, 1, 0.9f,
+       0, 10, 1, 11, 0, 10.1f, 1, 11.1f, 0, 100,   1, 101,
+       0, 0,  2, 2,  0, 0.2f,  2, 2.2f,  0, -0.2f, 2, 1.9f,
+       0, 20, 2, 22, 0, 20.2f, 2, 22.2f, 0, 200,   2, 202
+       });
+  AddInputFromArray<float>(TensorShape({2, 6, 2}), 
+      {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
+      0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f}); 
+  AddInputFromArray<int>(TensorShape({}), {3});
+  //Total size per batch is more than size per class
+  AddInputFromArray<int>(TensorShape({}), {5});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.1f});
+  TF_ASSERT_OK(RunOpKernel());
+  
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 5, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11, 0, 0, 1, 1, 
+          0, 0.1f, 1, 1.1f, 0, 10.1f, 1, 11.1f, 0, 100, 1, 101,
+          0, 20, 2, 22, 0, 0, 2, 2, 0, 0.2f, 2, 2.2f, 
+          0, 20.2f, 2, 22.2f, 0, 200, 2, 202});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 5}));
+  test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.75, 0.5, 0.3, 
+          0.95, 0.9, 0.75, 0.5, 0.3});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 5}));
+  test::FillValues<float>(&expected_classes, {0, 1, 0, 1, 0, 0, 1, 0, 1, 0});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
+  test::FillValues<int>(&expected_valid_d, {5, 5});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 5}));
+  test::FillValues<int>(&expected_indices, {3, 0, 1, 4, 5, 3, 0, 1, 4, 5});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
+
+TEST_F(NonMaxSuppressionLiteOpTest, 
+        TestSelectFromTwoBatchesTwoClassesForBoxesAndScores) {
+  MakeOp();
+  AddInputFromArray<float>(
+      TensorShape({2, 6, 2, 4}),
+      //batch 0, box1 of class 1 should get selected
+      {0, 0, 1, 1, 0, 0,  1, 1, 0, 0.1f, 1, 1.1f, 0, 0.1f, 4, 4.1f, 
+      0, -0.1f, 1, 0.9f, 0, -0.1f, 1, 0.9f, 0, 10, 1, 11, 0, 10, 1, 11, 
+      0, 10.1f, 1, 11.1f, 0, 10.1f, 1, 11.1f, 0, 100, 1, 101, 0, 100, 1, 101, 
+      //batch 1, box1 of class 0 should get selected
+      0, 0, 2, 2, 0, 0, 2, 2, 0, 0.2f, 2, 2.2f, 0, 0.2f, 2, 2.2f, 
+      0, -0.2f, 2, 1.9f, 0, -0.2f, 2, 1.9f, 0, 20, 2, 22, 0, 20, 2, 22, 
+      0, 20.2f, 2, 22.2f, 0, 20.2f, 2, 22.2f, 0, 200, 2, 202, 0, 200, 2, 202});
+
+  AddInputFromArray<float>(TensorShape({2, 6, 2}), 
+       {0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f, 
+       0.1f, 0.9f, 0.75f, 0.8f, 0.6f, 0.3f, 0.95f, 0.1f, 0.5f, 0.5f, 0.3f, 0.1f}); 
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<int>(TensorShape({}), {3});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+  TF_ASSERT_OK(RunOpKernel());
+  
+  //boxes
+  Tensor expected_boxes(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
+  test::FillValues<float>(&expected_boxes, {0, 10, 1, 11, 0, 0, 1, 1, 
+          0, 0.1f, 4, 4.1f, 0, 20, 2, 22 ,0, 0, 2, 2, 0, 0.2f, 2, 2.2f});
+  test::ExpectTensorEqual<float>(expected_boxes, *GetOutput(0));
+  //scores
+  Tensor expected_scores(allocator(), DT_FLOAT, TensorShape({2, 3}));
+  test::FillValues<float>(&expected_scores, {0.95, 0.9, 0.8, 0.95, 0.9, 0.75});
+  test::ExpectTensorEqual<float>(expected_scores, *GetOutput(1));
+  //classes
+  Tensor expected_classes(allocator(), DT_FLOAT, TensorShape({2, 3}));
+  test::FillValues<float>(&expected_classes, {0, 1, 1, 0, 1, 0});
+  test::ExpectTensorEqual<float>(expected_classes, *GetOutput(2));
+  // valid
+  Tensor expected_valid_d(allocator(), DT_INT32, TensorShape({2}));
+  test::FillValues<int>(&expected_valid_d, {3, 3});
+  test::ExpectTensorEqual<int>(expected_valid_d, *GetOutput(3));
+  // indices
+  Tensor expected_indices(allocator(), DT_INT32, TensorShape({2, 3}));
+  test::FillValues<int>(&expected_indices, {3, 0, 1, 3, 0, 1});
+  test::ExpectTensorEqual<int>(expected_indices, *GetOutput(4));
+}
 }  // namespace tensorflow

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -132,12 +132,12 @@ Status NMSShapeFn(InferenceContext* c) {
 }
 
 Status CombinedNMSShapeFn(InferenceContext* c) {
-  //Get inputs and validate ranks
+  // Get inputs and validate ranks
   ShapeHandle boxes;
-  //boxes is a tensor of Dimensions [batch_size, num_anchors, q, 4]
+  // boxes is a tensor of Dimensions [batch_size, num_anchors, q, 4]
   TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &boxes));
   ShapeHandle scores;
-  //scores is a tensor of Dimensions [batch_size, num_anchors, num_classes]
+  // scores is a tensor of Dimensions [batch_size, num_anchors, num_classes]
   TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 3, &scores));
   ShapeHandle max_output_size_per_class;
   TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &max_output_size_per_class));
@@ -148,9 +148,9 @@ Status CombinedNMSShapeFn(InferenceContext* c) {
   TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused_shape));
 
   DimensionHandle unused;
-  //boxes[0] and scores[0] are both batch_size
+  // boxes[0] and scores[0] are both batch_size
   TF_RETURN_IF_ERROR(c->Merge(c->Dim(boxes, 0), c->Dim(scores, 0), &unused));
-  //boxes[1] and scores[1] are both num_anchors
+  // boxes[1] and scores[1] are both num_anchors
   TF_RETURN_IF_ERROR(c->Merge(c->Dim(boxes, 1), c->Dim(scores, 1), &unused));
   // The boxes[3] is 4.
   TF_RETURN_IF_ERROR(c->WithValue(c->Dim(boxes, 3), 4, &unused));
@@ -159,8 +159,9 @@ Status CombinedNMSShapeFn(InferenceContext* c) {
   DimensionHandle class_dim = c->Dim(scores, 2);
   if (c->ValueKnown(d) && c->ValueKnown(class_dim)) {
     if (c->Value(d) != 1 && c->Value(d) != c->Value(class_dim)) {
-       return errors::InvalidArgument("third dimension of boxes must be either "
-           "1 or equal to the third dimension of scores");
+      return errors::InvalidArgument(
+          "third dimension of boxes must be either "
+          "1 or equal to the third dimension of scores");
     }
   }
   DimensionHandle output_dim;
@@ -177,15 +178,15 @@ Status CombinedNMSShapeFn(InferenceContext* c) {
   bool pad_per_class;
   TF_RETURN_IF_ERROR(c->GetAttr("pad_per_class", &pad_per_class));
   if (!pad_per_class) {
-    output_size =  c->Value(output_dim);
-  }
-  else {
+    output_size = c->Value(output_dim);
+  } else {
     if (c->ValueKnown(size_per_class) && c->Value(size_per_class) <= 0) {
-      return errors::InvalidArgument("max_output_size_per_class must be > 0 "
-             "if pad_per_class is set to true ");
+      return errors::InvalidArgument(
+          "max_output_size_per_class must be > 0 "
+          "if pad_per_class is set to true ");
     }
     output_size = std::min(c->Value(output_dim),
-        c->Value(size_per_class) * c->Value(class_dim));
+                           c->Value(size_per_class) * c->Value(class_dim));
   }
   c->set_output(0, c->MakeShape({batch_dim, output_size, 4}));
   c->set_output(1, c->MakeShape({batch_dim, output_size}));
@@ -194,7 +195,6 @@ Status CombinedNMSShapeFn(InferenceContext* c) {
   c->set_output(4, c->MakeShape({batch_dim, output_size}));
   return Status::OK();
 }
-
 
 }  // namespace
 

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -131,7 +131,7 @@ Status NMSShapeFn(InferenceContext* c) {
   return Status::OK();
 }
 
-Status NMSLiteShapeFn(InferenceContext* c) {
+Status CombinedNMSShapeFn(InferenceContext* c) {
   //Get inputs and validate ranks
   ShapeHandle boxes;
   //boxes is a tensor of Dimensions [batch_size, num_anchors, q, 4]
@@ -143,40 +143,55 @@ Status NMSLiteShapeFn(InferenceContext* c) {
   TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &max_output_size_per_class));
   ShapeHandle max_total_size;
   TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &max_total_size));
-  ShapeHandle iou_threshold;
-  TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &iou_threshold));
-  ShapeHandle score_threshold;
-  TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &score_threshold));
+  ShapeHandle unused_shape;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused_shape));
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused_shape));
 
   DimensionHandle unused;
+  //boxes[0] and scores[0] are both batch_size
+  TF_RETURN_IF_ERROR(c->Merge(c->Dim(boxes, 0), c->Dim(scores, 0), &unused));
   //boxes[1] and scores[1] are both num_anchors
   TF_RETURN_IF_ERROR(c->Merge(c->Dim(boxes, 1), c->Dim(scores, 1), &unused));
   // The boxes[3] is 4.
   TF_RETURN_IF_ERROR(c->WithValue(c->Dim(boxes, 3), 4, &unused));
 
+  DimensionHandle d = c->Dim(boxes, 2);
+  auto num_classes = c->Value(c->Dim(scores, 2));
+  if (c->ValueKnown(d)) {
+    if (c->Value(d) != 1 && c->Value(d) != num_classes) {
+       return errors::InvalidArgument("third dimension of boxes must be either "
+           "1 or equal to the third dimension of scores");
+    }
+  }
+  DimensionHandle output_dim;
+  DimensionHandle batch_dim = c->Dim(boxes, 0);
+
+  TF_RETURN_IF_ERROR(c->MakeDimForScalarInput(3, &output_dim));
+  if (c->ValueKnown(output_dim) && c->Value(output_dim) <= 0) {
+    return errors::InvalidArgument("max_total_size should be > 0 ");
+  }
+  DimensionHandle size_per_class;
+  TF_RETURN_IF_ERROR(c->MakeDimForScalarInput(2, &size_per_class));
+
+  int64 output_size;
   bool pad_per_class;
   TF_RETURN_IF_ERROR(c->GetAttr("pad_per_class", &pad_per_class));
-  if(!pad_per_class) {
-    DimensionHandle output_dim;
-    DimensionHandle batch_dim = c->Dim(boxes, 0);
-    
-    TF_RETURN_IF_ERROR(c->MakeDimForScalarInput(3, &output_dim));
-    if(c->ValueKnown(output_dim) && c->Value(output_dim) <= 0) {
-      return errors::InvalidArgument("max_total_size should be > 0 ");
-    }
-    c->set_output(0, c->MakeShape({batch_dim, output_dim, 4}));
-    c->set_output(1, c->MakeShape({batch_dim, output_dim}));
-    c->set_output(2, c->MakeShape({batch_dim, output_dim}));
-    c->set_output(4, c->MakeShape({batch_dim, output_dim}));
+  if (!pad_per_class) {
+    output_size =  c->Value(output_dim);
   }
   else {
-    //TODO SR Can all the outputs be unknowndim?
-    c->set_output(0, c->Vector(c->UnknownDim()));
-    c->set_output(1, c->Vector(c->UnknownDim()));
-    c->set_output(2, c->Vector(c->UnknownDim()));
-    c->set_output(3, c->Vector(c->UnknownDim()));
-    c->set_output(4, c->Vector(c->UnknownDim()));
+    if (c->ValueKnown(size_per_class) && c->Value(size_per_class) <= 0) {
+      return errors::InvalidArgument("max_output_size_per_class must be > 0 "
+             "if pad_per_class is set to true ");
+    }
+    output_size = std::min(c->Value(output_dim),
+        c->Value(size_per_class) * num_classes);
   }
+  c->set_output(0, c->MakeShape({batch_dim, output_size, 4}));
+  c->set_output(1, c->MakeShape({batch_dim, output_size}));
+  c->set_output(2, c->MakeShape({batch_dim, output_size}));
+  c->set_output(3, c->Vector(batch_dim));
+  c->set_output(4, c->MakeShape({batch_dim, output_size}));
   return Status::OK();
 }
 
@@ -869,7 +884,7 @@ REGISTER_OP("NonMaxSuppressionWithOverlaps")
       return Status::OK();
     });
 
-REGISTER_OP("NonMaxSuppressionLite")
+REGISTER_OP("CombinedNonMaxSuppression")
     .Input("boxes: float")
     .Input("scores: float")
     .Input("max_output_size_per_class: int32")
@@ -882,6 +897,6 @@ REGISTER_OP("NonMaxSuppressionLite")
     .Output("valid_detections: int32")
     .Output("selected_indices: int32")
     .Attr("pad_per_class: bool = false")
-    .SetShapeFn(NMSLiteShapeFn);   
+    .SetShapeFn(CombinedNMSShapeFn);
 
 }  // namespace tensorflow

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -192,7 +192,6 @@ Status CombinedNMSShapeFn(InferenceContext* c) {
   c->set_output(1, c->MakeShape({batch_dim, output_size}));
   c->set_output(2, c->MakeShape({batch_dim, output_size}));
   c->set_output(3, c->Vector(batch_dim));
-  c->set_output(4, c->MakeShape({batch_dim, output_size}));
   return Status::OK();
 }
 

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -156,9 +156,9 @@ Status CombinedNMSShapeFn(InferenceContext* c) {
   TF_RETURN_IF_ERROR(c->WithValue(c->Dim(boxes, 3), 4, &unused));
 
   DimensionHandle d = c->Dim(boxes, 2);
-  auto num_classes = c->Value(c->Dim(scores, 2));
-  if (c->ValueKnown(d)) {
-    if (c->Value(d) != 1 && c->Value(d) != num_classes) {
+  DimensionHandle class_dim = c->Dim(scores, 2);
+  if (c->ValueKnown(d) && c->ValueKnown(class_dim)) {
+    if (c->Value(d) != 1 && c->Value(d) != c->Value(class_dim)) {
        return errors::InvalidArgument("third dimension of boxes must be either "
            "1 or equal to the third dimension of scores");
     }
@@ -185,7 +185,7 @@ Status CombinedNMSShapeFn(InferenceContext* c) {
              "if pad_per_class is set to true ");
     }
     output_size = std::min(c->Value(output_dim),
-        c->Value(size_per_class) * num_classes);
+        c->Value(size_per_class) * c->Value(class_dim));
   }
   c->set_output(0, c->MakeShape({batch_dim, output_size, 4}));
   c->set_output(1, c->MakeShape({batch_dim, output_size}));

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -895,7 +895,6 @@ REGISTER_OP("CombinedNonMaxSuppression")
     .Output("nmsed_scores: float")
     .Output("nmsed_classes: float")
     .Output("valid_detections: int32")
-    .Output("selected_indices: int32")
     .Attr("pad_per_class: bool = false")
     .SetShapeFn(CombinedNMSShapeFn);
 

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -131,6 +131,35 @@ Status NMSShapeFn(InferenceContext* c) {
   return Status::OK();
 }
 
+Status NMSLiteShapeFn(InferenceContext* c) {
+  //Get inputs and validate ranks
+  ShapeHandle boxes;
+  //boxes is a tensor of Dimensions [batch_size, num_anchors, q, 4]
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &boxes));
+  ShapeHandle scores;
+  //scores is a tensor of Dimensions [batch_size, num_anchors, num_classes]
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 3, &scores));
+  ShapeHandle max_output_size_per_class;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &max_output_size_per_class));
+  ShapeHandle iou_threshold;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &iou_threshold));
+  ShapeHandle score_threshold;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &score_threshold));
+  DimensionHandle unused;
+  //boxes[3] is unused
+  TF_RETURN_IF_ERROR(c->WithValue(c->Dim(boxes, 3), 4, &unused));
+
+  //TODO SR Check dims of outputs here
+  c->set_output(0, c->Vector(c->UnknownDim()));
+  c->set_output(1, c->Vector(c->UnknownDim()));
+  c->set_output(2, c->Vector(c->UnknownDim()));
+  c->set_output(3, c->Vector(c->UnknownDim()));
+  c->set_output(4, c->Vector(c->UnknownDim()));
+
+  return Status::OK();
+}
+
+
 }  // namespace
 
 // --------------------------------------------------------------------------

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -819,4 +819,18 @@ REGISTER_OP("NonMaxSuppressionWithOverlaps")
       return Status::OK();
     });
 
+REGISTER_OP("NonMaxSuppressionLite")
+    .Input("boxes: float")
+    .Input("scores: float")
+    .Input("max_output_size_per_class: int32")
+    .Input("max_total_size: int32")
+    .Input("iou_threshold: float")
+    .Input("score_threshold: float")
+    .Output("nmsed_boxes: float")
+    .Output("nmsed_scores: float")
+    .Output("nmsed_classes: float")
+    .Output("valid_detections: int32")
+    .Output("selected_indices: int32")
+    .SetShapeFn(NMSLiteShapeFn);   
+
 }  // namespace tensorflow

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -154,14 +154,14 @@ Status NMSLiteShapeFn(InferenceContext* c) {
   // The boxes[3] is 4.
   TF_RETURN_IF_ERROR(c->WithValue(c->Dim(boxes, 3), 4, &unused));
 
-  bool use_static_shapes;
-  TF_RETURN_IF_ERROR(c->GetAttr("use_static_shapes", &use_static_shapes));
-  if(!use_static_shapes) {
+  bool pad_per_class;
+  TF_RETURN_IF_ERROR(c->GetAttr("pad_per_class", &pad_per_class));
+  if(!pad_per_class) {
     DimensionHandle output_dim;
     DimensionHandle batch_dim = c->Dim(boxes, 0);
     
     TF_RETURN_IF_ERROR(c->MakeDimForScalarInput(3, &output_dim));
-    if(c->Value(output_dim) <= 0) {
+    if(c->ValueKnown(output_dim) && c->Value(output_dim) <= 0) {
       return errors::InvalidArgument("max_total_size should be > 0 ");
     }
     c->set_output(0, c->MakeShape({batch_dim, output_dim, 4}));
@@ -881,7 +881,7 @@ REGISTER_OP("NonMaxSuppressionLite")
     .Output("nmsed_classes: float")
     .Output("valid_detections: int32")
     .Output("selected_indices: int32")
-    .Attr("use_static_shapes: bool = false")
+    .Attr("pad_per_class: bool = false")
     .SetShapeFn(NMSLiteShapeFn);   
 
 }  // namespace tensorflow

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -158,9 +158,12 @@ Status NMSLiteShapeFn(InferenceContext* c) {
   TF_RETURN_IF_ERROR(c->GetAttr("use_static_shapes", &use_static_shapes));
   if(!use_static_shapes) {
     DimensionHandle output_dim;
-    DimensionHandle batch_dim = c->UnknownDim();
-
+    DimensionHandle batch_dim = c->Dim(boxes, 0);
+    
     TF_RETURN_IF_ERROR(c->MakeDimForScalarInput(3, &output_dim));
+    if(c->Value(output_dim) <= 0) {
+      return errors::InvalidArgument("max_total_size should be > 0 ");
+    }
     c->set_output(0, c->MakeShape({batch_dim, output_dim, 4}));
     c->set_output(1, c->MakeShape({batch_dim, output_dim}));
     c->set_output(2, c->MakeShape({batch_dim, output_dim}));

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -154,9 +154,9 @@ Status NMSLiteShapeFn(InferenceContext* c) {
   // The boxes[3] is 4.
   TF_RETURN_IF_ERROR(c->WithValue(c->Dim(boxes, 3), 4, &unused));
 
-  bool pad_to_max;
-  TF_RETURN_IF_ERROR(c->GetAttr("pad_to_max_total_size", &pad_to_max));
-  if(pad_to_max) {
+  bool use_static_shapes;
+  TF_RETURN_IF_ERROR(c->GetAttr("use_static_shapes", &use_static_shapes));
+  if(!use_static_shapes) {
     DimensionHandle output_dim;
     DimensionHandle batch_dim = c->UnknownDim();
 
@@ -878,7 +878,7 @@ REGISTER_OP("NonMaxSuppressionLite")
     .Output("nmsed_classes: float")
     .Output("valid_detections: int32")
     .Output("selected_indices: int32")
-    .Attr("pad_to_max_total_size: bool = false")
+    .Attr("use_static_shapes: bool = false")
     .SetShapeFn(NMSLiteShapeFn);   
 
 }  // namespace tensorflow

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3211,8 +3211,8 @@ def extract_glimpse_v2(
       uniform_noise=False,
       name=name)
 
-@tf_export('image.non_max_suppression_lite')
-def non_max_suppression_lite(boxes,
+@tf_export('image.combined_non_max_suppression')
+def combined_non_max_suppression(boxes,
                              scores,
                              max_output_size_per_class,
                              max_total_size,
@@ -3269,10 +3269,10 @@ def non_max_suppression_lite(boxes,
     'selected_indices':  A [batch_size, max_detections] int32 tensor
       containing the indices of the selected boxes
   """
-  with ops.name_scope(name, 'non_max_suppression_lite'):
+  with ops.name_scope(name, 'combined_non_max_suppression'):
     iou_threshold = ops.convert_to_tensor(iou_threshold, name='iou_threshold')
     score_threshold = ops.convert_to_tensor(
         score_threshold, name='score_threshold')
-    return gen_image_ops.non_max_suppression_lite(boxes, scores,
+    return gen_image_ops.combined_non_max_suppression(boxes, scores,
             max_output_size_per_class, max_total_size, iou_threshold,
             score_threshold, pad_per_class)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3262,9 +3262,9 @@ def combined_non_max_suppression(boxes,
       the scores for the boxes.
     'nmsed_classes': A [batch_size, max_detections] float32 tensor
       containing the class for boxes.
-    'num_detections': A [batch_size] int32 tensor indicating the number of
-      valid detections per batch item. Only the top num_detections[i] entries in
-      nms_boxes[i], nms_scores[i] and nms_class[i] are valid. The rest of the
+    'valid_detections': A [batch_size] int32 tensor indicating the number of
+      valid detections per batch item. Only the top valid_detections[i] entries
+      in nms_boxes[i], nms_scores[i] and nms_class[i] are valid. The rest of the
       entries are zero paddings.
     'selected_indices':  A [batch_size, max_detections] int32 tensor
       containing the indices of the selected boxes

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3250,11 +3250,11 @@ def combined_non_max_suppression(boxes,
       overlap too much with respect to IOU.
     score_threshold: A float representing the threshold for deciding when to
       remove boxes based on score.
-    pad_per_class: If false, the output nmsed boxes, scores, classes and
-      selected_indices are padded/clipped to `max_total_size`. If true, the
-      output nmsed boxes, scores, classes and selected_indices are
-      padded/clipped to be of length `max_size_per_class` or `max_total_size`
-      (smaller of the two). Defaults to false.
+    pad_per_class: If false, the output nmsed boxes, scores and classes
+      are padded/clipped to `max_total_size`. If true, the
+      output nmsed boxes, scores and classes are padded/clipped to be of length
+      `max_size_per_class` or `max_total_size` (smaller of the two).
+      Defaults to false.
     name: A name for the operation (optional).
 
   Returns:
@@ -3268,8 +3268,6 @@ def combined_non_max_suppression(boxes,
       valid detections per batch item. Only the top valid_detections[i] entries
       in nms_boxes[i], nms_scores[i] and nms_class[i] are valid. The rest of the
       entries are zero paddings.
-    'selected_indices':  A [batch_size, max_detections] int32 tensor
-      containing the indices of the selected boxes
   """
   with ops.name_scope(name, 'combined_non_max_suppression'):
     iou_threshold = ops.convert_to_tensor(

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3223,7 +3223,7 @@ def combined_non_max_suppression(boxes,
   """Greedily selects a subset of bounding boxes in descending order of score.
 
   This operation performs non_max_suppression on the inputs per batch, across
-  all classes. 
+  all classes.
   Prunes away boxes that have high intersection-over-union (IOU) overlap
   with previously selected boxes.  Bounding boxes are supplied as
   [y1, x1, y2, x2], where (y1, x1) and (y2, x2) are the coordinates of any
@@ -3233,14 +3233,14 @@ def combined_non_max_suppression(boxes,
   this algorithm is invariant to orthogonal transformations and translations
   of the coordinate system; thus translating or reflections of the coordinate
   system result in the same boxes being selected by the algorithm.
-  The output of this operation is the final boxes, scores and classes tensor 
+  The output of this operation is the final boxes, scores and classes tensor
   returned after performing non_max_suppression.
 
   Args:
     boxes: A 4-D float `Tensor` of shape `[batch_size, num_boxes, q, 4]`.
-    scores: A 3-D float `Tensor` of shape `[batch_size, num_boxes, num_classes]` 
+    scores: A 3-D float `Tensor` of shape `[batch_size, num_boxes, num_classes]`
     representing a single score corresponding to each box (each row of boxes).
-    max_output_size_per_class: A scalar integer `Tensor` representing the 
+    max_output_size_per_class: A scalar integer `Tensor` representing the
     maximum number of boxes to be selected by non max suppression per class
     max_total_size: A scalar representing maximum number of boxes retained over
     all classes.
@@ -3274,5 +3274,8 @@ def combined_non_max_suppression(boxes,
     score_threshold = ops.convert_to_tensor(
         score_threshold, name='score_threshold')
     return gen_image_ops.combined_non_max_suppression(boxes, scores,
-            max_output_size_per_class, max_total_size, iou_threshold,
-            score_threshold, pad_per_class)
+                                                      max_output_size_per_class,
+                                                      max_total_size,
+                                                      iou_threshold,
+                                                      score_threshold,
+                                                      pad_per_class)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3237,7 +3237,9 @@ def combined_non_max_suppression(boxes,
   returned after performing non_max_suppression.
 
   Args:
-    boxes: A 4-D float `Tensor` of shape `[batch_size, num_boxes, q, 4]`.
+    boxes: A 4-D float `Tensor` of shape `[batch_size, num_boxes, q, 4]`. If `q`
+    is 1 then same boxes are used for all classes otherwise, if `q` is equal to
+    number of classes, class-specific boxes are used.
     scores: A 3-D float `Tensor` of shape `[batch_size, num_boxes, num_classes]`
     representing a single score corresponding to each box (each row of boxes).
     max_output_size_per_class: A scalar integer `Tensor` representing the

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3272,9 +3272,10 @@ def combined_non_max_suppression(boxes,
       containing the indices of the selected boxes
   """
   with ops.name_scope(name, 'combined_non_max_suppression'):
-    iou_threshold = ops.convert_to_tensor(iou_threshold, name='iou_threshold')
+    iou_threshold = ops.convert_to_tensor(
+        iou_threshold, dtype=dtypes.float32, name='iou_threshold')
     score_threshold = ops.convert_to_tensor(
-        score_threshold, name='score_threshold')
+        score_threshold, dtype=dtypes.float32, name='score_threshold')
     return gen_image_ops.combined_non_max_suppression(boxes, scores,
                                                       max_output_size_per_class,
                                                       max_total_size,

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3252,8 +3252,9 @@ def combined_non_max_suppression(boxes,
       remove boxes based on score.
     pad_per_class: If false, the output nmsed boxes, scores and classes
       are padded/clipped to `max_total_size`. If true, the
-      output nmsed boxes, scores and classes are padded/clipped to be of length
-      `max_size_per_class` or `max_total_size` (smaller of the two).
+      output nmsed boxes, scores and classes are padded to be of length
+      `max_size_per_class`*`num_classes`, unless it exceeds `max_total_size` in
+      which case it is clipped to `max_total_size`.
       Defaults to false.
     name: A name for the operation (optional).
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3213,13 +3213,13 @@ def extract_glimpse_v2(
 
 @tf_export('image.combined_non_max_suppression')
 def combined_non_max_suppression(boxes,
-                             scores,
-                             max_output_size_per_class,
-                             max_total_size,
-                             iou_threshold=0.5,
-                             score_threshold=float('-inf'),
-                             pad_per_class=False,
-                             name=None):
+                                 scores,
+                                 max_output_size_per_class,
+                                 max_total_size,
+                                 iou_threshold=0.5,
+                                 score_threshold=float('-inf'),
+                                 pad_per_class=False,
+                                 name=None):
   """Greedily selects a subset of bounding boxes in descending order of score.
 
   This operation performs non_max_suppression on the inputs per batch, across
@@ -3229,8 +3229,8 @@ def combined_non_max_suppression(boxes,
   [y1, x1, y2, x2], where (y1, x1) and (y2, x2) are the coordinates of any
   diagonal pair of box corners and the coordinates can be provided as normalized
   (i.e., lying in the interval [0, 1]) or absolute.  Note that this algorithm
-  is agnostic to where the origin is in the coordinate system.  Note that this
-  algorithm is invariant to orthogonal transformations and translations
+  is agnostic to where the origin is in the coordinate system. Also note that
+  this algorithm is invariant to orthogonal transformations and translations
   of the coordinate system; thus translating or reflections of the coordinate
   system result in the same boxes being selected by the algorithm.
   The output of this operation is the final boxes, scores and classes tensor 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3250,7 +3250,8 @@ def non_max_suppression_lite(boxes,
       remove boxes based on score.
     use_static_shapes: If true, the output nmsed boxes, scores, classes and 
       selected_indices are padded to be of length `max_size_per_class` and 
-      it doesn't clip boxes to max_total_size. Defaults to false.
+      it doesn't clip boxes to max_total_size. If false, the outputs are
+      padded/clipped to max_total_size. Defaults to false.
     name: A name for the operation (optional).
 
   Returns:
@@ -3271,6 +3272,6 @@ def non_max_suppression_lite(boxes,
     iou_threshold = ops.convert_to_tensor(iou_threshold, name='iou_threshold')
     score_threshold = ops.convert_to_tensor(
         score_threshold, name='score_threshold')
-    return gen_image_ops.non_max_suppression_lite(boxes, scores, 
-            max_output_size_per_class, max_total_size, iou_threshold, 
+    return gen_image_ops.non_max_suppression_lite(boxes, scores,
+            max_output_size_per_class, max_total_size, iou_threshold,
             score_threshold, use_static_shapes)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3218,7 +3218,7 @@ def non_max_suppression_lite(boxes,
                              max_total_size,
                              iou_threshold=0.5,
                              score_threshold=float('-inf'),
-                             pad_to_max_total_size=False,
+                             use_static_shapes=False,
                              name=None):
   """Greedily selects a subset of bounding boxes in descending order of score.
 
@@ -3248,8 +3248,9 @@ def non_max_suppression_lite(boxes,
       overlap too much with respect to IOU.
     score_threshold: A float representing the threshold for deciding when to
       remove boxes based on score.
-    pad_to_max_total_size: If true the size of outputs is padded to
-    max_total_size per batch.
+    use_static_shapes: If true, the output nmsed boxes, scores, classes and 
+      selected_indices are padded to be of length `max_size_per_class` and 
+      it doesn't clip boxes to max_total_size. Defaults to false.
     name: A name for the operation (optional).
 
   Returns:
@@ -3272,4 +3273,4 @@ def non_max_suppression_lite(boxes,
         score_threshold, name='score_threshold')
     return gen_image_ops.non_max_suppression_lite(boxes, scores, 
             max_output_size_per_class, max_total_size, iou_threshold, 
-            score_threshold, pad_to_max_total_size)
+            score_threshold, use_static_shapes)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3267,7 +3267,6 @@ def non_max_suppression_lite(boxes,
       containing the indices of the selected boxes
   """
   with ops.name_scope(name, 'non_max_suppression_lite'):
-    print(" *** calling actual non_max_suppression_lite *** ")
     iou_threshold = ops.convert_to_tensor(iou_threshold, name='iou_threshold')
     score_threshold = ops.convert_to_tensor(
         score_threshold, name='score_threshold')

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3218,7 +3218,7 @@ def non_max_suppression_lite(boxes,
                              max_total_size,
                              iou_threshold=0.5,
                              score_threshold=float('-inf'),
-                             use_static_shapes=False,
+                             pad_per_class=False,
                              name=None):
   """Greedily selects a subset of bounding boxes in descending order of score.
 
@@ -3248,11 +3248,11 @@ def non_max_suppression_lite(boxes,
       overlap too much with respect to IOU.
     score_threshold: A float representing the threshold for deciding when to
       remove boxes based on score.
-    use_static_shapes: If false, the output nmsed boxes, scores, classes and
+    pad_per_class: If false, the output nmsed boxes, scores, classes and
       selected_indices are padded/clipped to `max_total_size`. If true, the
       output nmsed boxes, scores, classes and selected_indices are
-      padded/clipped to be of length `max_size_per_class` or `max_total_size`.
-      Defaults to false.
+      padded/clipped to be of length `max_size_per_class` or `max_total_size`
+      (smaller of the two). Defaults to false.
     name: A name for the operation (optional).
 
   Returns:
@@ -3275,4 +3275,4 @@ def non_max_suppression_lite(boxes,
         score_threshold, name='score_threshold')
     return gen_image_ops.non_max_suppression_lite(boxes, scores,
             max_output_size_per_class, max_total_size, iou_threshold,
-            score_threshold, use_static_shapes)
+            score_threshold, pad_per_class)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3210,3 +3210,68 @@ def extract_glimpse_v2(
       noise=noise,
       uniform_noise=False,
       name=name)
+
+@tf_export('image.non_max_suppression_lite')
+def non_max_suppression_lite(boxes,
+                             scores,
+                             max_output_size_per_class,
+                             max_total_size,
+                             iou_threshold=0.5,
+                             score_threshold=float('-inf'),
+                             pad_to_max_total_size=False,
+                             name=None):
+  """Greedily selects a subset of bounding boxes in descending order of score.
+
+  This operation performs non_max_suppression on the inputs per batch, across
+  all classes. 
+  Prunes away boxes that have high intersection-over-union (IOU) overlap
+  with previously selected boxes.  Bounding boxes are supplied as
+  [y1, x1, y2, x2], where (y1, x1) and (y2, x2) are the coordinates of any
+  diagonal pair of box corners and the coordinates can be provided as normalized
+  (i.e., lying in the interval [0, 1]) or absolute.  Note that this algorithm
+  is agnostic to where the origin is in the coordinate system.  Note that this
+  algorithm is invariant to orthogonal transformations and translations
+  of the coordinate system; thus translating or reflections of the coordinate
+  system result in the same boxes being selected by the algorithm.
+  The output of this operation is the final boxes, scores and classes tensor 
+  returned after performing non_max_suppression.
+
+  Args:
+    boxes: A 4-D float `Tensor` of shape `[batch_size, num_boxes, q, 4]`.
+    scores: A 3-D float `Tensor` of shape `[batch_size, num_boxes, num_classes]` 
+    representing a single score corresponding to each box (each row of boxes).
+    max_output_size_per_class: A scalar integer `Tensor` representing the 
+    maximum number of boxes to be selected by non max suppression per class
+    max_total_size: A scalar representing maximum number of boxes retained over
+    all classes.
+    iou_threshold: A float representing the threshold for deciding whether boxes
+      overlap too much with respect to IOU.
+    score_threshold: A float representing the threshold for deciding when to
+      remove boxes based on score.
+    pad_to_max_total_size: If true the size of outputs is padded to
+    max_total_size per batch.
+    name: A name for the operation (optional).
+
+  Returns:
+    'nmsed_boxes': A [batch_size, max_detections, 4] float32 tensor
+      containing the non-max suppressed boxes.
+    'nmsed_scores': A [batch_size, max_detections] float32 tensor containing
+      the scores for the boxes.
+    'nmsed_classes': A [batch_size, max_detections] float32 tensor
+      containing the class for boxes.
+    'num_detections': A [batch_size] int32 tensor indicating the number of
+      valid detections per batch item. Only the top num_detections[i] entries in
+      nms_boxes[i], nms_scores[i] and nms_class[i] are valid. The rest of the
+      entries are zero paddings.
+    'selected_indices':  A [batch_size, max_detections] int32 tensor
+      containing the indices of the selected boxes
+  """
+  with ops.name_scope(name, 'non_max_suppression_lite'):
+    print(" *** calling actual non_max_suppression_lite *** ")
+    iou_threshold = ops.convert_to_tensor(iou_threshold, name='iou_threshold')
+    score_threshold = ops.convert_to_tensor(
+        score_threshold, name='score_threshold')
+    return gen_image_ops.non_max_suppression_lite(boxes, scores,
+            max_output_size_per_class, max_total_size, iou_threshold, 
+            score_threshold, pad_to_max_total_size);
+

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3248,10 +3248,11 @@ def non_max_suppression_lite(boxes,
       overlap too much with respect to IOU.
     score_threshold: A float representing the threshold for deciding when to
       remove boxes based on score.
-    use_static_shapes: If true, the output nmsed boxes, scores, classes and 
-      selected_indices are padded to be of length `max_size_per_class` and 
-      it doesn't clip boxes to max_total_size. If false, the outputs are
-      padded/clipped to max_total_size. Defaults to false.
+    use_static_shapes: If false, the output nmsed boxes, scores, classes and
+      selected_indices are padded/clipped to `max_total_size`. If true, the
+      output nmsed boxes, scores, classes and selected_indices are
+      padded/clipped to be of length `max_size_per_class` or `max_total_size`.
+      Defaults to false.
     name: A name for the operation (optional).
 
   Returns:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3270,7 +3270,6 @@ def non_max_suppression_lite(boxes,
     iou_threshold = ops.convert_to_tensor(iou_threshold, name='iou_threshold')
     score_threshold = ops.convert_to_tensor(
         score_threshold, name='score_threshold')
-    return gen_image_ops.non_max_suppression_lite(boxes, scores,
+    return gen_image_ops.non_max_suppression_lite(boxes, scores, 
             max_output_size_per_class, max_total_size, iou_threshold, 
-            score_threshold, pad_to_max_total_size);
-
+            score_threshold, pad_to_max_total_size)

--- a/tensorflow/tools/api/golden/v1/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.image.pbtxt
@@ -33,6 +33,10 @@ tf_module {
     argspec: "args=[\'image\', \'central_fraction\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "combined_non_max_suppression"
+    argspec: "args=[\'boxes\', \'scores\', \'max_output_size_per_class\', \'max_total_size\', \'iou_threshold\', \'score_threshold\', \'pad_per_class\', \'name\'], varargs=None, keywords=None, defaults=[\'0.5\', \'-inf\', \'False\', \'None\'], "
+  }
+  member_method {
     name: "convert_image_dtype"
     argspec: "args=[\'image\', \'dtype\', \'saturate\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -933,12 +933,12 @@ tf_module {
     argspec: "args=[\'t\', \'clip_value_min\', \'clip_value_max\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
-    name: "combined_non_max_suppression"
-    argspec: "args=[\'boxes\', \'scores\', \'max_output_size_per_class\', \'max_total_size\', \'iou_threshold\', \'score_threshold\', \'pad_per_class\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
-  }
-  member_method {
     name: "colocate_with"
     argspec: "args=[\'op\', \'ignore_existing\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
+    name: "combined_non_max_suppression"
+    argspec: "args=[\'boxes\', \'scores\', \'max_output_size_per_class\', \'max_total_size\', \'iou_threshold\', \'score_threshold\', \'pad_per_class\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }
   member_method {
     name: "complex"

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -933,6 +933,10 @@ tf_module {
     argspec: "args=[\'t\', \'clip_value_min\', \'clip_value_max\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "combined_non_max_suppression"
+    argspec: "args=[\'boxes\', \'scores\', \'max_output_size_per_class\', \'max_total_size\', \'iou_threshold\', \'score_threshold\', \'pad_per_class\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
+  }
+  member_method {
     name: "colocate_with"
     argspec: "args=[\'op\', \'ignore_existing\'], varargs=None, keywords=None, defaults=[\'False\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.image.pbtxt
@@ -33,6 +33,10 @@ tf_module {
     argspec: "args=[\'image\', \'central_fraction\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "combined_non_max_suppression"
+    argspec: "args=[\'boxes\', \'scores\', \'max_output_size_per_class\', \'max_total_size\', \'iou_threshold\', \'score_threshold\', \'pad_per_class\', \'name\'], varargs=None, keywords=None, defaults=[\'0.5\', \'-inf\', \'False\', \'None\'], "
+  }
+  member_method {
     name: "convert_image_dtype"
     argspec: "args=[\'image\', \'dtype\', \'saturate\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -469,6 +469,10 @@ tf_module {
     argspec: "args=[\'t\', \'clip_value_min\', \'clip_value_max\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "combined_non_max_suppression"
+    argspec: "args=[\'boxes\', \'scores\', \'max_output_size_per_class\', \'max_total_size\', \'iou_threshold\', \'score_threshold\', \'pad_per_class\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
+  }
+  member_method {
     name: "complex"
     argspec: "args=[\'real\', \'imag\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }


### PR DESCRIPTION
This change adds a new Batched NMS operation (called NonMaxSuppressionLite). The entire NMS operation for all batches and across all classes is performed in one kernel operation.
The change also adds unit tests for the new kernel operation.