### PR TITLE
Fix AWS, GCP, HDFS, Kafka and Ignite disable config options

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -213,31 +213,31 @@ config_setting(
 #
 config_setting(
     name = "no_aws_support",
-    define_values = {"no_aws_support": "false"},
+    define_values = {"no_aws_support": "true"},
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "no_gcp_support",
-    define_values = {"no_gcp_support": "false"},
+    define_values = {"no_gcp_support": "true"},
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "no_hdfs_support",
-    define_values = {"no_hdfs_support": "false"},
+    define_values = {"no_hdfs_support": "true"},
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "no_ignite_support",
-    define_values = {"no_ignite_support": "false"},
+    define_values = {"no_ignite_support": "true"},
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "no_kafka_support",
-    define_values = {"no_kafka_support": "false"},
+    define_values = {"no_kafka_support": "true"},
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
The logic implemented in commit 3437098ba5b111817ef6ac5906d86934168704b7 sets `no_<package>_support=true` if the `no<package>` config option is provided, but checks for a false value (in the tensorflow/BUILD file) to disable the package.

This should fully fix Issue https://github.com/tensorflow/tensorflow/issues/22819