### PR TITLE
RendezvousMgr & CancellationMgr are already aborted, shouldn't send R…

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/rpc_rendezvous_mgr.cc
+++ b/tensorflow/core/distributed_runtime/rpc/rpc_rendezvous_mgr.cc
@@ -244,6 +244,15 @@ void RpcRemoteRendezvous::RecvFromRemoteAsync(
   // Record "call" in active_ so that it can be aborted cleanly.
   RegisterCall(call);
 
+  // RendezvousMgr already aborted, shouldn't send RPC call any more
+  if (!call->status().ok()) {
+    session()->worker_cache->ReleaseWorker(call->src_worker_, call->wi_);
+    call->done()(call->status(), Args(), Args(), Tensor(), false);
+    call->wi_ = nullptr;
+    get_call_freelist()->Release(call, session()->worker_cache.get());
+    return;
+  }
+
   // Start "call".
   Ref();
   call->Start([this, call]() {


### PR DESCRIPTION
…PC call any more

When RendezvousMgr & CancellationMgr are already aborted, following RPC couldn't handled
by CancellationMgr. At the moment, if remote service is already closed, client would hang here.