### PR TITLE
Explicitly import tools/bazel.rc

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1555,6 +1555,9 @@ def main():
   check_bazel_version('0.15.0')
 
   reset_tf_configure_bazelrc()
+  # Explicitly import tools/bazel.rc, this is needed for Bazel 0.19.0 or later
+  write_to_bazelrc('import %workspace%/tools/bazel.rc')
+
   cleanup_makefile()
   setup_python(environ_cp)
 


### PR DESCRIPTION
To fix build with Bazel 0.19.0 or later and it won't break build with old version of Bazel
Fixes https://github.com/tensorflow/tensorflow/issues/23398