### PR TITLE
[INTEL MKL] Fix memory leak issue in MklFusedBatchNorm

### DIFF
--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1616,6 +1616,9 @@ class MklDnnData {
         cpu_engine_(e) {}
 
   ~MklDnnData() {
+    if (allocated_buffer_ != nullptr) {
+      cpu_allocator()->DeallocateRaw(allocated_buffer_);
+    }
     cpu_engine_ = nullptr;  // We don't own this.
     delete (user_memory_);
     delete (reorder_memory_);


### PR DESCRIPTION
fix the memory leak bug in mkl batch norm, free the temp weight buffer used for MKL-DNN weight memory primitive.