### PR TITLE
Fix the issue where distributions.percentile does not support eager mode

### DIFF
--- a/tensorflow/contrib/distributions/python/kernel_tests/sample_stats_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/sample_stats_test.py
@@ -471,7 +471,7 @@ class PercentileTestWithNearestInterpolation(test.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def test_percentile_in_eager_mode(self):
     # Test case for GitHub issue 23619
-    x = constant_op.constant([1,2,3,4], dtype=dtypes.float64)
+    x = constant_op.constant([1, 2, 3, 4], dtype=dtypes.float64)
     with self.cached_session():
       y = sample_stats.percentile(x, q=30, validate_args=True)
       self.assertAllEqual(2.0, self.evaluate(y))

--- a/tensorflow/contrib/distributions/python/kernel_tests/sample_stats_test.py
+++ b/tensorflow/contrib/distributions/python/kernel_tests/sample_stats_test.py
@@ -21,7 +21,9 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.contrib.distributions.python.ops import sample_stats
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import spectral_ops_test_util
@@ -466,6 +468,13 @@ class PercentileTestWithNearestInterpolation(test.TestCase):
       minval = sample_stats.percentile(x, q=0, validate_args=True)
       self.assertAllEqual(0, minval.eval())
 
+  @test_util.run_in_graph_and_eager_modes
+  def test_percentile_in_eager_mode(self):
+    # Test case for GitHub issue 23619
+    x = constant_op.constant([1,2,3,4], dtype=dtypes.float64)
+    with self.cached_session():
+      y = sample_stats.percentile(x, q=30, validate_args=True)
+      self.assertAllEqual(2.0, self.evaluate(y))
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/contrib/distributions/python/ops/sample_stats.py
+++ b/tensorflow/contrib/distributions/python/ops/sample_stats.py
@@ -300,7 +300,7 @@ def percentile(x,
       raise ValueError("Argument 'interpolation' must be in %s.  Found %s" %
                        (allowed_interpolations, interpolation))
 
-  with ops.name_scope(name, [x, q]):
+  with ops.name_scope(name, values=[x, q]):
     x = ops.convert_to_tensor(x, name="x")
     # Double is needed here and below, else we get the wrong index if the array
     # is huge along axis.


### PR DESCRIPTION
This fix tries to address the issue in #23619 where distributions.percentile in eager mode throws:
```
TypeError: unhashable type: 'list'
```
The issue is that ` [x, q]` should be passed as `values`, not name default. This fix fixed the issue.

This fix fixes #23619

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>