### PR TITLE
OptimizationPass::POST_REWRITE_FOR_EXEC after Grappler optimization

### DIFF
--- a/tensorflow/core/kernels/partitioned_function_ops.cc
+++ b/tensorflow/core/kernels/partitioned_function_ops.cc
@@ -179,10 +179,9 @@ class PartitionedCallOp : public AsyncOpKernel {
                              done);
 
         OP_REQUIRES_OK_ASYNC(
-            ctx,
-            OptimizationPassRegistry::Global()->RunGrouping(
-                OptimizationPassRegistry::POST_REWRITE_FOR_EXEC,
-                optimization_options),
+            ctx, OptimizationPassRegistry::Global()->RunGrouping(
+                     OptimizationPassRegistry::POST_REWRITE_FOR_EXEC,
+                     optimization_options),
             done);
 
         std::unordered_map<string, std::unique_ptr<Graph>> subgraphs;

--- a/tensorflow/core/kernels/partitioned_function_ops.cc
+++ b/tensorflow/core/kernels/partitioned_function_ops.cc
@@ -166,12 +166,6 @@ class PartitionedCallOp : public AsyncOpKernel {
             OptimizationPassRegistry::Global()->RunGrouping(
                 OptimizationPassRegistry::POST_PLACEMENT, optimization_options),
             done);
-        OP_REQUIRES_OK_ASYNC(
-            ctx,
-            OptimizationPassRegistry::Global()->RunGrouping(
-                OptimizationPassRegistry::POST_REWRITE_FOR_EXEC,
-                optimization_options),
-            done);
 
         Device* cpu_device;
         OP_REQUIRES_OK_ASYNC(
@@ -183,6 +177,13 @@ class PartitionedCallOp : public AsyncOpKernel {
                              OptimizeGraph(ctx, fbody->ret_nodes, overlay_lib,
                                            device_set, cpu_device, &graph),
                              done);
+
+        OP_REQUIRES_OK_ASYNC(
+            ctx,
+            OptimizationPassRegistry::Global()->RunGrouping(
+                OptimizationPassRegistry::POST_REWRITE_FOR_EXEC,
+                optimization_options),
+            done);
 
         std::unordered_map<string, std::unique_ptr<Graph>> subgraphs;
         OP_REQUIRES_OK_ASYNC(


### PR DESCRIPTION
I found there is graph optimization ordering difference between PartitionedCallOp and GraphExecutionState.
I think OptimizationPass::POST_REWRITE_FOR_EXEC should be applied after Grappler optimization because we can not add the graph conversion between Grappler optimization and graph partitioning.

This PR matches the graph optimization ordering.