### PR TITLE
Added missing export for `profiler.ProfileContext`

### DIFF
--- a/tensorflow/python/profiler/BUILD
+++ b/tensorflow/python/profiler/BUILD
@@ -12,9 +12,9 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        ":profile_context",
         ":model_analyzer",
         ":option_builder",
+        ":profile_context",
         ":tfprof_logger",
         "//tensorflow/core/profiler:protos_all_py",
         "//tensorflow/python:util",

--- a/tensorflow/python/profiler/BUILD
+++ b/tensorflow/python/profiler/BUILD
@@ -12,6 +12,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":profile_context",
         ":model_analyzer",
         ":option_builder",
         ":tfprof_logger",

--- a/tensorflow/python/profiler/profile_context.py
+++ b/tensorflow/python/profiler/profile_context.py
@@ -32,6 +32,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.platform import gfile
 from tensorflow.python.profiler import model_analyzer
 from tensorflow.python.util import compat
+from tensorflow.python.util.tf_export import tf_export
 
 WARMUP_STEPS = 10
 MAX_TRACED_STEPS = 100
@@ -110,6 +111,7 @@ def _profiled_run(self,
   # pylint: enable=protected-access
 
 
+@tf_export('profiler.ProfileContext')
 class ProfileContext(object):
   """A Context that captures RunMetadata and performs profiling.
 

--- a/tensorflow/python/profiler/profiler.py
+++ b/tensorflow/python/profiler/profiler.py
@@ -28,6 +28,7 @@ from tensorflow.python.profiler.model_analyzer import advise
 from tensorflow.python.profiler.model_analyzer import profile
 from tensorflow.python.profiler.model_analyzer import Profiler
 from tensorflow.python.profiler.option_builder import ProfileOptionBuilder
+from tensorflow.python.profiler.profile_context import ProfileContext
 from tensorflow.python.profiler.tfprof_logger import write_op_log
 
 from tensorflow.python.util.tf_export import tf_export
@@ -36,6 +37,7 @@ from tensorflow.python.util.tf_export import tf_export
 _allowed_symbols = [
     'Profiler',
     'profile',
+    'ProfileContext',
     'ProfileOptionBuilder',
     'advise',
     'write_op_log',

--- a/tensorflow/python/tools/api/generator/api_init_files.bzl
+++ b/tensorflow/python/tools/api/generator/api_init_files.bzl
@@ -67,6 +67,7 @@ TENSORFLOW_API_INIT_FILES = [
     "metrics/__init__.py",
     "nn/__init__.py",
     "nn/rnn_cell/__init__.py",
+    "profiler/__init__.py",
     "quantization/__init__.py",
     "random/__init__.py",
     "saved_model/__init__.py",


### PR DESCRIPTION
 The instruction [here](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/tfprof) says "please use `tf.profiler.xxx` instead of `tf.contrib.tfprof.xxx`". However, this is not exported yet. 