### PR TITLE
Exclude the log_dir from the metadata path

### DIFF
--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -309,7 +309,8 @@ with tf.Session(graph=graph) as session:
   config = projector.ProjectorConfig()
   embedding_conf = config.embeddings.add()
   embedding_conf.tensor_name = embeddings.name
-  embedding_conf.metadata_path = os.path.join(FLAGS.log_dir, 'metadata.tsv')
+  # This path is relative to the LOG_DIR.
+  embedding_conf.metadata_path = 'metadata.tsv'
   projector.visualize_embeddings(writer, config)
 
 writer.close()


### PR DESCRIPTION
The metadata path should exclude the log directory. See https://github.com/tensorflow/tensorboard/issues/247.