### PR TITLE
Fix ValueError by image.transform in eager mode

### DIFF
--- a/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
+++ b/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
@@ -286,8 +286,7 @@ class ImageOpsTest(test_util.TensorFlowTestCase):
     image = constant_op.constant([[1., 2.], [3., 4.]])
     value = image_ops.transform(image, [1] * 8)
     with self.test_session(use_gpu=True):
-      self.assertAllEqual(
-        self.evaluate(value), np.array([[4, 4], [4, 4]]))
+      self.assertAllEqual(self.evaluate(value), np.array([[4, 4], [4, 4]]))
 
 
 class BipartiteMatchTest(test_util.TensorFlowTestCase):

--- a/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
+++ b/tensorflow/contrib/image/python/kernel_tests/image_ops_test.py
@@ -281,6 +281,14 @@ class ImageOpsTest(test_util.TensorFlowTestCase):
             value.eval(),
             np.array([[4, 4], [4, 4]]).astype(dtype.as_numpy_dtype()))
 
+  @test_util.run_in_graph_and_eager_modes
+  def test_transform_eager(self):
+    image = constant_op.constant([[1., 2.], [3., 4.]])
+    value = image_ops.transform(image, [1] * 8)
+    with self.test_session(use_gpu=True):
+      self.assertAllEqual(
+        self.evaluate(value), np.array([[4, 4], [4, 4]]))
+
 
 class BipartiteMatchTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/contrib/image/python/ops/image_ops.py
+++ b/tensorflow/contrib/image/python/ops/image_ops.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorflow.python.eager import context
 from tensorflow.contrib.image.ops import gen_image_ops
 from tensorflow.contrib.util import loader
 from tensorflow.python.framework import common_shapes
@@ -271,8 +272,11 @@ def transform(images,
       raise TypeError("Images should have rank between 2 and 4.")
 
     if output_shape is None:
-      output_shape = tensor_util.constant_value(
-          array_ops.shape(images)[1:3]) or array_ops.shape(images)[1:3]
+      output_shape = array_ops.shape(images)[1:3]
+      if not context.executing_eagerly():
+        output_shape_value = tensor_util.constant_value(output_shape)
+        if output_shape_value is not None:
+          output_shape = output_shape_value
 
     output_shape = ops.convert_to_tensor(
         output_shape, dtypes.int32, name="output_shape")


### PR DESCRIPTION
This fix tries to address the issue raised in #23654 where in eager mode tf.contrib.image.transform will throw out
```
ValueError: The truth value of an array with more than one
    element is ambiguous. Use a.any() or a.all()
```

This fix addresses the issue. This fix fixes #23654.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>