### PR TITLE
[Bug fix]fix bug of reusing MirroredVariables failed in MirroredStrategy

### DIFF
--- a/tensorflow/contrib/distribute/python/values.py
+++ b/tensorflow/contrib/distribute/python/values.py
@@ -395,6 +395,10 @@ class MirroredVariable(DistributedVariable, Mirrored,
     return self._assign_func(f=assign_fn, *args, **kwargs)
 
   @property
+  def op(self):
+    return self._primary_var.op
+
+  @property
   def aggregation(self):
     return self._aggregation
 


### PR DESCRIPTION
The bug will be triggered in the following `else` branch when using `MirroredStrategy`. `create_zeros_slot` will pick up the `VarHandleOp` in current tower to create auxiliary variables. However, in the case of `replica_id > 0`, the `variable_scope` will set `reuse=True` in `MirroredStrategy`. It will use the `replica_id`th of `MirroredVaraible` to create auxiliary variable and this variable cannot be reused  because of its new name(`xxx/replica_1`) .
```
          if isinstance(var, variables.Variable):
            avg = slot_creator.create_slot(var,
                                           var.initialized_value(),
                                           self.name,
                                           colocate_with_primary=True)
            # NOTE(mrry): We only add `tf.Variable` objects to the
            # `MOVING_AVERAGE_VARIABLES` collection.
            ops.add_to_collection(ops.GraphKeys.MOVING_AVERAGE_VARIABLES, var)
          else:
            avg = slot_creator.create_zeros_slot(
                var,
                self.name,
                colocate_with_primary=(var.op.type in ["Variable",
                                                       "VariableV2",
                                                       "VarHandleOp"]))
            if self._zero_debias:
              zero_debias_true.add(avg)
```

Currently, master branch even cannot apply moving average to `MirroredVariable`. The following solves this problem https://github.com/tensorflow/tensorflow/pull/23396  and my bug fix is building on that. 
Please check it. Thanks very much. @yuefengz 