### PR TITLE
Fix #22455.

### DIFF
--- a/tensorflow/contrib/verbs/rdma.h
+++ b/tensorflow/contrib/verbs/rdma.h
@@ -382,6 +382,7 @@ class RdmaAdapter {
   string name() const;
   void StartPolling();
   void Process_CQ();
+  ibv_device* GetDevice() const { return context_->device; }
 
  protected:
   static const int MAX_CONCURRENT_WRITES = 1000;

--- a/tensorflow/contrib/verbs/rdma_mgr.h
+++ b/tensorflow/contrib/verbs/rdma_mgr.h
@@ -33,13 +33,14 @@ class RdmaMgr {
 
  public:
   explicit RdmaMgr(const WorkerEnv* const worker_env,
-                   GrpcChannelCache* const channel_cache);
+                   GrpcChannelCache* const channel_cache,
+                   RdmaAdapter* rdma_adapter);
   ~RdmaMgr();
   RdmaChannel* FindChannel(const string& key);
   void SetupChannels();
   bool ConnectivityCheck();
   void InitAllocators();
-  static void RegMemVisitors();
+  static void RegMemVisitors(ibv_device* device);
   const string& local_worker() { return local_worker_; }
 
  private:

--- a/tensorflow/contrib/verbs/verbs_server_lib.cc
+++ b/tensorflow/contrib/verbs/verbs_server_lib.cc
@@ -82,7 +82,7 @@ std::once_flag reg_mem_visitors_call;
 
 Status VerbsServer::Init(ServiceInitFunction service_func,
                          RendezvousMgrCreationFunction rendezvous_mgr_func) {
-  RdmaAdapter *rdma_adapter = new RdmaAdapter(worker_env());
+  RdmaAdapter* rdma_adapter = new RdmaAdapter(worker_env());
   std::call_once(reg_mem_visitors_call, [rdma_adapter]() {
     RdmaMgr::RegMemVisitors(rdma_adapter->GetDevice());
   });

--- a/tensorflow/contrib/verbs/verbs_server_lib.cc
+++ b/tensorflow/contrib/verbs/verbs_server_lib.cc
@@ -82,13 +82,16 @@ std::once_flag reg_mem_visitors_call;
 
 Status VerbsServer::Init(ServiceInitFunction service_func,
                          RendezvousMgrCreationFunction rendezvous_mgr_func) {
-  std::call_once(reg_mem_visitors_call, []() { RdmaMgr::RegMemVisitors(); });
+  RdmaAdapter *rdma_adapter = new RdmaAdapter(worker_env());
+  std::call_once(reg_mem_visitors_call, [rdma_adapter]() {
+    RdmaMgr::RegMemVisitors(rdma_adapter->GetDevice());
+  });
   Status s = GrpcServer::Init(service_func, rendezvous_mgr_func);
   {
     mutex_lock l(mu_);
     CHECK_EQ(verbs_state_, DISCONNECTED);
     CHECK(ChannelCacheFactory(server_def(), &channel_cache_).ok());
-    rdma_mgr_ = new RdmaMgr(worker_env(), channel_cache_);
+    rdma_mgr_ = new RdmaMgr(worker_env(), channel_cache_, rdma_adapter);
     // set rdma_mgr for verbs_service and rdma_rendezvous_mgr
     verbs_service_->SetRdmaMgr(rdma_mgr_);
     dynamic_cast<RdmaRendezvousMgr*>(worker_env()->rendezvous_mgr)


### PR DESCRIPTION
RdmaAdapter is allocated outside of RdmaMgr so that ibv_device is available to the static visitor registration.