### PR TITLE
Enable while_loop to support timeout

### DIFF
--- a/tensorflow/core/kernels/control_flow_ops.cc
+++ b/tensorflow/core/kernels/control_flow_ops.cc
@@ -601,9 +601,11 @@ LoopCondOp::~LoopCondOp() = default;
 
 void LoopCondOp::Compute(OpKernelContext* context) {
   CancellationManager* cm = context->cancellation_manager();
-  bool already_cancelled = cm->IsCancelled();
-  OP_REQUIRES(context, !already_cancelled,
-              errors::Cancelled("Loop execution was cancelled."));
+  if (cm != nullptr) {
+    bool already_cancelled = cm->IsCancelled();
+    OP_REQUIRES(context, !already_cancelled,
+                errors::Cancelled("Loop execution was cancelled."));
+  }
 
   context->set_output(0, context->input(0));
 }

--- a/tensorflow/core/kernels/control_flow_ops.cc
+++ b/tensorflow/core/kernels/control_flow_ops.cc
@@ -602,12 +602,8 @@ LoopCondOp::~LoopCondOp() = default;
 void LoopCondOp::Compute(OpKernelContext* context) {
   CancellationManager* cm = context->cancellation_manager();
   bool already_cancelled = cm->IsCancelled();
-
-  if (already_cancelled) {
-    Tensor continue_running(false);
-    context->set_output(0, continue_running);
-    return;
-  }
+  OP_REQUIRES(context, !already_cancelled,
+              errors::Cancelled("Loop execution was cancelled."));
 
   context->set_output(0, context->input(0));
 }

--- a/tensorflow/core/kernels/control_flow_ops.cc
+++ b/tensorflow/core/kernels/control_flow_ops.cc
@@ -600,6 +600,15 @@ LoopCondOp::LoopCondOp(OpKernelConstruction* context) : OpKernel(context) {}
 LoopCondOp::~LoopCondOp() = default;
 
 void LoopCondOp::Compute(OpKernelContext* context) {
+  CancellationManager* cm = context->cancellation_manager();
+  bool already_cancelled = cm->IsCancelled();
+
+  if (already_cancelled) {
+    Tensor continue_running(false);
+    context->set_output(0, continue_running);
+    return;
+  }
+
   context->set_output(0, context->input(0));
 }
 

--- a/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
+++ b/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
@@ -1988,6 +1988,16 @@ class ControlFlowTest(test.TestCase):
       for i in xrange(10):
         self.assertEqual([i], q.dequeue().eval())
 
+  def testWhileTimeOut(self):
+    run_options = config_pb2.RunOptions(timeout_in_ms=1)
+    with self.cached_session() as sess:
+      n = constant_op.constant(0)
+      c = lambda x: True
+      b = lambda x: math_ops.add(x, 1)
+      r = control_flow_ops.while_loop(c, b, [n])
+      with self.assertRaises(errors_impl.DeadlineExceededError):
+        sess.run(r, options=run_options)
+
   @test_util.disable_control_flow_v2("b/117119329 (stack)")
   def testWhileStack_1(self):
     with self.cached_session():


### PR DESCRIPTION
This PR fixes #22217. 

The current implementation of `WhileLoop` does not support `Timeout` yet. As a result, even when setting a timeout for a session, the infinite while_loop could not stop as expected. This PR solves this issue by adding `CancellationManager` to `LoopCondOp` to check if the current session is cancelled. If cancelled, then stop the while_loop.   