### PR TITLE
Fix incorrect link to version compatibility

### DIFF
--- a/tensorflow/java/README.md
+++ b/tensorflow/java/README.md
@@ -1,7 +1,7 @@
 # TensorFlow for Java
 
 > *WARNING*: The TensorFlow Java API is not currently covered by the TensorFlow
-> [API stability guarantees](https://www.tensorflow.org/guide/version_semantics).
+> [API stability guarantees](https://www.tensorflow.org/guide/version_compat).
 >
 > For using TensorFlow on Android refer instead to
 > [contrib/android](https://www.tensorflow.org/code/tensorflow/contrib/android),


### PR DESCRIPTION
While looking into `tensorflow/java/README.md`,
the `API stability guarantees` retured 404. This
fix made the change
`version_semantics` -> `version_compat` to fix the issue.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>