### PR TITLE
Add float16 support for tf.qr

### DIFF
--- a/tensorflow/core/kernels/linalg_ops_common.cc
+++ b/tensorflow/core/kernels/linalg_ops_common.cc
@@ -247,6 +247,7 @@ void LinearAlgebraOp<Scalar>::ComputeTensorSlice(
 }
 
 // Explicitly instantiate LinearAlgebraOp for the scalar types we expect to use.
+template class LinearAlgebraOp<Eigen::half>;
 template class LinearAlgebraOp<float>;
 template class LinearAlgebraOp<double>;
 template class LinearAlgebraOp<complex64>;

--- a/tensorflow/core/kernels/qr_op_half.cc
+++ b/tensorflow/core/kernels/qr_op_half.cc
@@ -1,0 +1,36 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/qr_op_impl.h"
+
+namespace tensorflow {
+
+REGISTER_LINALG_OP("Qr", (QrOp<Eigen::half>), Eigen::half);
+
+#if GOOGLE_CUDA
+// We temporarily disable QR on GPU due to a bug in the QR implementation in
+// cuSolver affecting older hardware. The cuSolver team is tracking the issue
+// (https://partners.nvidia.com/bug/viewbug/2171459) and we will re-enable
+// this feature when a fix is available.
+REGISTER_KERNEL_BUILDER(Name("Qr")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<Eigen::half>("T")
+                            .HostMemory("input")
+                            .HostMemory("q")
+                            .HostMemory("r"),
+                        QrOp<Eigen::half>);
+#endif
+
+}  // namespace tensorflow

--- a/tensorflow/core/ops/linalg_ops.cc
+++ b/tensorflow/core/ops/linalg_ops.cc
@@ -334,7 +334,7 @@ REGISTER_OP("Qr")
     .Output("q: T")
     .Output("r: T")
     .Attr("full_matrices: bool = False")
-    .Attr("T: {double, float, complex64, complex128}")
+    .Attr("T: {double, float, half, complex64, complex128}")
     .SetShapeFn(QrShapeFn);
 
 REGISTER_OP("Svd")

--- a/tensorflow/core/ops/linalg_ops_test.cc
+++ b/tensorflow/core/ops/linalg_ops_test.cc
@@ -179,12 +179,10 @@ TEST(LinalgOpsTest, Qr_ShapeFn) {
                      .Attr("full_matrices", full_matrices)
                      .Finalize(&op.node_def));
 
-
     TF_ASSERT_OK(NodeDefBuilder("test", "Qr")
                      .Input({"input", 0, DT_FLOAT})
                      .Attr("full_matrices", full_matrices)
                      .Finalize(&op.node_def));
-
 
     TF_ASSERT_OK(NodeDefBuilder("test", "Qr")
                      .Input({"input", 0, DT_DOUBLE})

--- a/tensorflow/core/ops/linalg_ops_test.cc
+++ b/tensorflow/core/ops/linalg_ops_test.cc
@@ -184,6 +184,12 @@ TEST(LinalgOpsTest, Qr_ShapeFn) {
                      .Input({"input", 0, DT_FLOAT})
                      .Attr("full_matrices", full_matrices)
                      .Finalize(&op.node_def));
+
+
+    TF_ASSERT_OK(NodeDefBuilder("test", "Qr")
+                     .Input({"input", 0, DT_DOUBLE})
+                     .Attr("full_matrices", full_matrices)
+                     .Finalize(&op.node_def));
   };
 
   // Defining `P` = min(`M`, `N`), if full_matrices = False, then Q should be

--- a/tensorflow/core/ops/linalg_ops_test.cc
+++ b/tensorflow/core/ops/linalg_ops_test.cc
@@ -175,6 +175,12 @@ TEST(LinalgOpsTest, Qr_ShapeFn) {
   ShapeInferenceTestOp op("Qr");
   auto set_attrs = [&op](bool full_matrices) {
     TF_ASSERT_OK(NodeDefBuilder("test", "Qr")
+                     .Input({"input", 0, DT_HALF})
+                     .Attr("full_matrices", full_matrices)
+                     .Finalize(&op.node_def));
+
+
+    TF_ASSERT_OK(NodeDefBuilder("test", "Qr")
                      .Input({"input", 0, DT_FLOAT})
                      .Attr("full_matrices", full_matrices)
                      .Finalize(&op.node_def));


### PR DESCRIPTION
This fix tries to address the issue raised in #23830 where tf.qr does not support float16 data types.
This fix adds the float16 support for tf.qr.

This fix fixes #23830.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>