### PR TITLE
Bugfix: remove first arg instead of `self`

### DIFF
--- a/tensorflow/python/util/function_utils.py
+++ b/tensorflow/python/util/function_utils.py
@@ -55,7 +55,7 @@ def fn_args(fn):
       fn = fn.__call__
     args = tf_inspect.getfullargspec(fn).args
     if _is_bounded_method(fn):
-      args.remove('self')
+      args.pop(0)  # remove `self` or `cls`
   return tuple(args)
 
 


### PR DESCRIPTION
Bugfix: remove first arg instead of `self` to make the function more robust and works for classmethod