### PR TITLE
Add RCCL package and ops.

### DIFF
--- a/tensorflow/contrib/BUILD
+++ b/tensorflow/contrib/BUILD
@@ -7,6 +7,7 @@ package(default_visibility = ["//tensorflow:__subpackages__"])
 
 load("//third_party/mpi:mpi.bzl", "if_mpi")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("//tensorflow:tensorflow.bzl", "if_not_windows")
 load("//tensorflow:tensorflow.bzl", "if_not_windows_cuda")
 
@@ -81,6 +82,7 @@ py_library(
         "//tensorflow/contrib/proto",
         "//tensorflow/contrib/quantization:quantization_py",
         "//tensorflow/contrib/quantize:quantize_graph",
+        "//tensorflow/contrib/rccl:rccl_py",
         "//tensorflow/contrib/receptive_field:receptive_field_py",
         "//tensorflow/contrib/recurrent:recurrent_py",
         "//tensorflow/contrib/reduce_slice_ops:reduce_slice_ops_py",
@@ -178,7 +180,11 @@ cc_library(
         "//tensorflow/contrib/tensor_forest:stats_ops_kernels",
         "//tensorflow/contrib/tensor_forest:tensor_forest_kernels",
         "//tensorflow/contrib/text:all_kernels",
-    ] + if_mpi(["//tensorflow/contrib/mpi_collectives:mpi_collectives_py"]) + select({
+    ] + if_mpi([
+        "//tensorflow/contrib/mpi_collectives:mpi_collectives_py"
+    ]) + if_rocm([
+        "//tensorflow/contrib/rccl:rccl_kernels"
+    ]) + select({
         "//tensorflow:android": [],
         "//tensorflow:ios": [],
         "//tensorflow:linux_s390x": [],
@@ -213,6 +219,7 @@ cc_library(
         "//tensorflow/contrib/input_pipeline:input_pipeline_ops_op_lib",
         "//tensorflow/contrib/layers:sparse_feature_cross_op_op_lib",
         "//tensorflow/contrib/nearest_neighbor:nearest_neighbor_ops_op_lib",
+        "//tensorflow/contrib/rccl:rccl_ops_op_lib",
         "//tensorflow/contrib/rnn:all_ops",
         "//tensorflow/contrib/seq2seq:beam_search_ops_op_lib",
         "//tensorflow/contrib/tensor_forest:model_ops_op_lib",

--- a/tensorflow/contrib/rccl/BUILD
+++ b/tensorflow/contrib/rccl/BUILD
@@ -1,0 +1,129 @@
+# Description:
+#   Wrap AMD (https://github.com/ROCmSoftwarePlatform/rccl) RCCL with tensorflow ops.
+#   APIs are meant to change over time.
+
+package(default_visibility = ["//tensorflow:__subpackages__"])
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+load(
+    "//tensorflow:tensorflow.bzl",
+    "cuda_py_test",
+    "tf_custom_op_library",
+    "tf_custom_op_py_library",
+    "tf_gen_op_libs",
+    "tf_gen_op_wrapper_py",
+    "tf_cuda_cc_test",
+    "tf_kernel_library",
+)
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
+
+tf_custom_op_py_library(
+    name = "rccl_py",
+    srcs = [
+        "__init__.py",
+        "python/ops/rccl_ops.py",
+    ],
+    dso = [
+        ":python/ops/_rccl_ops.so" ,
+    ],
+    kernels = [
+        ":rccl_kernels",
+        ":rccl_ops_op_lib",
+    ],
+    deps = [
+        ":gen_rccl_ops",
+    ],
+)
+
+tf_kernel_library(
+    name = "rccl_kernels",
+    srcs = if_rocm_is_configured([
+        "kernels/rccl_manager.cc",
+        "kernels/rccl_manager.h",
+        "kernels/rccl_ops.cc",
+        "kernels/rccl_rewrite.cc",
+    ]),
+    deps = if_rocm_is_configured([
+        "//tensorflow/core:gpu_headers_lib",
+        "//tensorflow/core:core_cpu_lib",
+        "@rccl_archive//:rccl",
+    ]),
+    alwayslink = 1,
+)
+
+tf_custom_op_library(
+    name = "python/ops/_rccl_ops.so",
+    srcs = if_rocm_is_configured([
+        "kernels/rccl_manager.cc",
+        "kernels/rccl_manager.h",
+        "kernels/rccl_ops.cc",
+        "kernels/rccl_rewrite.cc",
+        "ops/rccl_ops.cc",
+    ]),
+    deps = if_rocm_is_configured([
+        "//tensorflow/core:gpu_headers_lib",
+        "//tensorflow/core:core_cpu_lib",
+        "@rccl_archive//:rccl",
+    ]),
+)
+
+tf_gen_op_libs(
+    op_lib_names = ["rccl_ops"],
+)
+
+tf_gen_op_wrapper_py(
+    name = "gen_rccl_ops",
+    out = "python/ops/gen_rccl_ops.py",
+    deps = [":rccl_ops_op_lib"],
+)
+
+cuda_py_test(
+    name = "rccl_ops_test",
+    size = "small",
+    srcs = ["python/ops/rccl_ops_test.py"],
+    additional_deps = [
+        ":rccl_py",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:framework_test_lib",
+        "//tensorflow/python:platform_test",
+        "//tensorflow/contrib/util:util_py",
+    ],
+    # Disabled on jenkins until errors finding nvmlShutdown are found.
+    tags = [
+        "manual",
+        "multi_gpu",
+        "no_oss",
+        "noguitar",
+        "notap",
+    ],
+)
+
+tf_cuda_cc_test(
+    name = "rccl_manager_test",
+    size = "medium",
+    srcs = if_rocm_is_configured([
+        "kernels/rccl_manager.cc",
+        "kernels/rccl_manager.h",
+        "kernels/rccl_manager_test.cc",
+    ]),
+    # Disabled on jenkins until errors finding nvmlShutdown are found.
+    tags = [
+        "manual",
+        "multi_gpu",
+        "no_oss",
+        "noguitar",
+        "notap",
+    ],
+    deps = if_rocm_is_configured([
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+        "@rccl_archive//:rccl",
+    ]),
+)
+

--- a/tensorflow/contrib/rccl/__init__.py
+++ b/tensorflow/contrib/rccl/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Functions for using AMD rccl collective ops.
+
+@@all_max
+@@all_min
+@@all_prod
+@@all_sum
+@@reduce_sum
+@@broadcast
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib.rccl.python.ops.rccl_ops import all_max
+from tensorflow.contrib.rccl.python.ops.rccl_ops import all_min
+from tensorflow.contrib.rccl.python.ops.rccl_ops import all_prod
+from tensorflow.contrib.rccl.python.ops.rccl_ops import all_sum
+from tensorflow.contrib.rccl.python.ops.rccl_ops import broadcast
+from tensorflow.contrib.rccl.python.ops.rccl_ops import reduce_sum
+
+from tensorflow.python.util.all_util import remove_undocumented
+remove_undocumented(__name__)

--- a/tensorflow/contrib/rccl/kernels/rccl_manager.cc
+++ b/tensorflow/contrib/rccl/kernels/rccl_manager.cc
@@ -262,10 +262,10 @@ RcclManager::Communicator* RcclManager::GetCommunicator(
   int currDevice;
   auto status = hipGetDevice(&currDevice);
 
-  for(int i = 0; i < num_devices; i++) {
+  for (int i = 0; i < num_devices; i++) {
     hipSetDevice(devices[i]);
-    for(int j = 0; j < num_devices; j++) {
-      if(devices[i] != devices[j]) {
+    for (int j = 0; j < num_devices; j++) {
+      if (devices[i] != devices[j]) {
         hipDeviceEnablePeerAccess(devices[j], 0);
       }
     }

--- a/tensorflow/contrib/rccl/kernels/rccl_manager.cc
+++ b/tensorflow/contrib/rccl/kernels/rccl_manager.cc
@@ -1,0 +1,543 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/contrib/rccl/kernels/rccl_manager.h"
+
+#include <utility>
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#include "tensorflow/core/lib/core/threadpool.h"
+#include "tensorflow/core/platform/cuda.h"
+#include "tensorflow/core/platform/env.h"
+
+namespace tensorflow {
+
+using se::cuda::ScopedActivateExecutorContext;
+
+// Contains data for a single stream used for rccl communication; this includes
+// a background thread that calls RcclManager::LoopKernelLaunches.
+struct RcclManager::RcclStream {
+ public:
+  RcclStream() {}
+  ~RcclStream() {
+    mutex_lock l(mu);
+    shutdown_requested = true;
+    cv.notify_all();
+  }
+
+  se::StreamExecutor* executor = nullptr;
+
+  // The stream on which to run the rccl collective.
+  // This is a different stream than the tensorflow compute stream.
+  std::unique_ptr<se::Stream> stream;
+
+  // See RcclManager::LoopKernelLaunches for information on these.
+  std::unique_ptr<Thread> thread;
+  mutex mu;
+  condition_variable cv;
+  // Has collective,rank pairs.
+  std::deque<std::pair<Collective*, int>> pending_launches_ GUARDED_BY(mu);
+  bool shutdown_requested GUARDED_BY(mu) = false;
+};
+
+struct RcclManager::CommunicatorMember {
+ public:
+  CommunicatorMember() {}
+  ~CommunicatorMember() {
+    if (rccl_comm != nullptr) rcclCommDestroy(rccl_comm);
+  }
+  rcclComm_t rccl_comm;
+
+  // Owned by RcclManager::device_to_comm_streams_.
+  RcclStream* rccl_stream = nullptr;
+};
+
+struct RcclManager::Communicator {
+ public:
+  explicit Communicator(std::vector<CommunicatorMember> members)
+      : num_devices(members.size()), members(std::move(members)) {}
+
+  const int num_devices;
+  const std::vector<CommunicatorMember> members;  // indexed by rank.
+};
+
+namespace {
+rcclDataType_t ToRcclType(DataType t) {
+  switch (t) {
+    case DT_HALF:
+      return rcclHalf;
+    case DT_FLOAT:
+      return rcclFloat;
+    case DT_DOUBLE:
+      return rcclDouble;
+    case DT_INT32:
+      return rcclInt;
+    case DT_INT64:
+      return rcclInt64;
+    default:
+      return rcclFloat;
+  }
+}
+}  // namespace
+
+// A participant in a Collective.  See <Collective> below.
+struct RcclManager::Participant {
+  Participant(const Tensor* in_t, Tensor* out_t, EventMgr* event_mgr,
+              se::Stream* tensor_stream, se::StreamExecutor* executor,
+              int gpu_device_id, RcclManager::DoneCallback done_callback)
+      : in_t(in_t),
+        out_t(out_t),
+        event_mgr(event_mgr),
+        tensor_stream(tensor_stream),
+        executor(executor),
+        gpu_device_id(gpu_device_id),
+        done_callback(std::move(done_callback)) {
+    DCHECK(executor != nullptr);
+    DCHECK(event_mgr != nullptr);
+    DCHECK(tensor_stream != nullptr);
+  }
+  // Owned by the caller, who must keep it live until <done_callback> is called.
+  // Is NULL for participants that only receive data.
+  const Tensor* in_t;
+
+  // Owned by the caller, who must keep it live until <done_callback> is called.
+  // Is NULL for participants that only send data.
+  Tensor* out_t;
+
+  // Owned by the caller, who must keep it live until <done_callback> is called.
+  EventMgr* const event_mgr;
+
+  // Owned by the caller, who must keep it live until <done_callback> is called.
+  se::Stream* const tensor_stream;
+
+  // Matches the executor in CommunicatorMember::stream. Expected to be live for
+  // process lifetime.
+  se::StreamExecutor* const executor = nullptr;
+
+  const int gpu_device_id;
+
+  RcclManager::DoneCallback done_callback;
+
+  bool root = false;
+};
+
+// A Collective tracks a single communicator operation (e.g., a single
+// AllReduce call).
+struct RcclManager::Collective {
+  Collective(DataType data_type_in, CollectiveType type_in,
+             rcclRedOp_t reduction_op_in, int num_devices)
+      : data_type(data_type_in),
+        type(type_in),
+        reduction_op(reduction_op_in),
+        remaining_participants(num_devices) {
+    participants.reserve(num_devices);
+  }
+
+  const DataType data_type;
+  const CollectiveType type;
+  const rcclRedOp_t reduction_op;  // applies when <type> is a reduction.
+
+  Communicator* communicator = nullptr;
+
+  // All collective participants.
+  //
+  // Adding values in this vector is guarded by the mutex of the containing
+  // RcclManager.
+  std::vector<std::unique_ptr<Participant>> participants;
+
+  // For collective types that have a root (e.g. the root of broadcast is the
+  // sender), this is the rank of the root.
+  int root_rank = -1;
+
+  // How many participants have been registered so far. The Collective is
+  // eligible for running with <available_participants> == participants.size().
+  //
+  // Guarded by the mutex of the containing Communicator.
+  int available_participants = 0;
+
+  mutable std::atomic_int_fast32_t remaining_participants;
+};
+
+RcclManager::RcclManager() {}
+RcclManager::~RcclManager() {}
+RcclManager* RcclManager::instance() {
+  static RcclManager* instance = new RcclManager();
+  return instance;
+}
+
+RcclManager::Communicator* RcclManager::GetCommunicator(
+    RcclManager::Collective* collective) {
+  // Sort by executor to make ordering of executors deterministic.
+  std::sort(collective->participants.begin(), collective->participants.end(),
+            [](const std::unique_ptr<Participant>& a,
+               const std::unique_ptr<Participant>& b) {
+              return a->executor < b->executor;
+            });
+  const int num_devices = collective->participants.size();
+
+  mutex_lock l(mu_);
+
+  // Scan to find an existing communicator that provides rccl communication
+  // between the executors used by the participants in the collective. For
+  // example, if a collective is for GPUs 0, 1, and 2 then this will scan
+  // to find the communicator for GPUs 0, 1, and 2.
+  //
+  // Note that each executor identifies a context on one device, so this is the
+  // same as getting the communicator connecting the devices in the collective.
+  // A device can be in different communicators as well - for example, a
+  // communicator for GPUs 0 and 1 is separate from one for GPUs 0, 1, and 2.
+  //
+  // Since it's expected that a small number of distinct communicators will
+  // be needed, communicators_ is not garbage collected currently.
+  //
+  // Launching of kernels must be serialized so that, given collectives A and B,
+  // and an order of them (e.g., A before B), then for each comm_stream
+  // involved, the kernel for A is launched before the kernel for B. This is
+  // guaranteed currently be a global mutex controlling additions of the kernels
+  // to per-stream launch queues.  The launch queues are processed by
+  // LoopKernelLaunches.
+  for (auto& comm : communicators_) {
+    if (comm->num_devices == num_devices) {
+      int i;
+      for (i = 0; i < num_devices; ++i) {
+        if (comm->members[i].rccl_stream->executor !=
+            collective->participants[i]->executor) {
+          break;
+        }
+      }
+      if (i == num_devices) return comm.get();
+    }
+  }
+
+  auto* env = Env::Default();
+  std::set<RcclStream*> used_streams;
+
+  // Create and initialize a new communicator.
+  // Note that this is done under the lock; performance is not expected to
+  // matter as this happens a very small number of times.
+  std::vector<CommunicatorMember> members(num_devices);
+  std::vector<int> devices(num_devices);
+  for (int i = 0; i < num_devices; ++i) {
+    auto* executor = collective->participants[i]->executor;
+
+    // Find a communication stream to use for the device.
+    auto& streams = device_to_comm_streams_[executor];
+    RcclStream* rccl_stream = nullptr;
+    for (const auto& s : streams) {
+      if (used_streams.insert(s.get()).second) {
+        rccl_stream = s.get();
+        break;
+      }
+    }
+    if (rccl_stream == nullptr) {
+      rccl_stream = new RcclStream();
+      rccl_stream->executor = executor;
+      rccl_stream->stream.reset(new se::Stream(executor));
+      rccl_stream->stream->Init();
+
+      streams.emplace_back(rccl_stream);
+      used_streams.insert(rccl_stream);
+
+      rccl_stream->thread.reset(env->StartThread(
+          ThreadOptions(), "rccl_kernel_launch",
+          [this, rccl_stream] { LoopKernelLaunches(rccl_stream); }));
+    }
+
+    members[i].rccl_stream = rccl_stream;
+    devices[i] = collective->participants[i]->gpu_device_id;
+  }
+
+  int currDevice;
+  auto status = hipGetDevice(&currDevice);
+
+  for(int i = 0; i < num_devices; i++) {
+    hipSetDevice(devices[i]);
+    for(int j = 0; j < num_devices; j++) {
+      if(devices[i] != devices[j]) {
+        hipDeviceEnablePeerAccess(devices[j], 0);
+      }
+    }
+  }
+
+  hipSetDevice(currDevice);
+
+  int device_count = num_devices;
+#if RCCL_MAJOR >= 2
+  // RCCL2 prevents InitAll for more communicators than devices (but doesn't
+  // check that device ids are unique). Work around it by initializing each
+  // rank individually.
+  hipGetDeviceCount(&device_count);
+#endif
+  std::vector<rcclComm_t> rccl_comms(num_devices);
+  if (num_devices <= device_count) {
+    auto result =
+        rcclCommInitAll(rccl_comms.data(), num_devices, devices.data());
+    CHECK_EQ(result, rcclSuccess) << rcclGetErrorString(result);
+  } else {
+    int savedDevice = 0;
+    CHECK_EQ(hipGetDevice(&savedDevice), hipSuccess);
+    rcclUniqueId commId;
+    rcclGetUniqueId(&commId);
+#if RCCL_MAJOR >= 2
+    CHECK_EQ(rcclGroupStart(), rcclSuccess);
+#endif
+    for (int rank = 0; rank < num_devices; ++rank) {
+      hipSetDevice(devices[rank]);
+      auto result =
+          rcclCommInitRank(rccl_comms.data() + rank, num_devices, commId, rank);
+      CHECK_EQ(result, rcclSuccess) << rcclGetErrorString(result);
+    }
+#if RCCL_MAJOR >= 2
+    CHECK_EQ(rcclGroupEnd(), rcclSuccess);
+#endif
+    hipSetDevice(savedDevice);
+  }
+  for (int rank = 0; rank < num_devices; ++rank) {
+    members[rank].rccl_comm = rccl_comms[rank];
+  }
+  communicators_.emplace_back(new Communicator(std::move(members)));
+  return communicators_.back().get();
+}
+
+void RcclManager::AddToAllReduce(int num_devices, const string& key,
+                                 rcclRedOp_t reduction_op,
+                                 se::StreamExecutor* executor,
+                                 int gpu_device_id, EventMgr* event_mgr,
+                                 se::Stream* tensor_stream, const Tensor* in_t,
+                                 Tensor* out_t,
+                                 const DoneCallback& done_callback) {
+  std::unique_ptr<Participant> participant(
+      new Participant(in_t, out_t, event_mgr, tensor_stream, executor,
+                      gpu_device_id, done_callback));
+  AddParticipant(num_devices, key, std::move(participant), in_t->dtype(),
+                 kAllReduce, reduction_op);
+}
+
+void RcclManager::AddBroadcastSend(int num_devices, const string& key,
+                                   se::StreamExecutor* executor,
+                                   int gpu_device_id, EventMgr* event_mgr,
+                                   se::Stream* tensor_stream,
+                                   const Tensor* in_t,
+                                   DoneCallback done_callback) {
+  std::unique_ptr<Participant> participant(
+      new Participant(in_t, nullptr /* out_t */, event_mgr, tensor_stream,
+                      executor, gpu_device_id, std::move(done_callback)));
+  participant->root = true;
+  AddParticipant(num_devices, key, std::move(participant), in_t->dtype(),
+                 kBroadcast, rcclSum /* unused */);
+}
+
+void RcclManager::AddBroadcastRecv(int num_devices, const string& key,
+                                   se::StreamExecutor* executor,
+                                   int gpu_device_id, EventMgr* event_mgr,
+                                   se::Stream* tensor_stream, Tensor* out_t,
+                                   DoneCallback done_callback) {
+  std::unique_ptr<Participant> participant(
+      new Participant(nullptr /* in_t */, out_t, event_mgr, tensor_stream,
+                      executor, gpu_device_id, std::move(done_callback)));
+  AddParticipant(num_devices, key, std::move(participant), out_t->dtype(),
+                 kBroadcast, rcclSum /* unused */);
+}
+
+void RcclManager::AddReduceSend(int num_devices, const string& key,
+                                rcclRedOp_t reduction_op,
+                                se::StreamExecutor* executor, int gpu_device_id,
+                                EventMgr* event_mgr, se::Stream* tensor_stream,
+                                const Tensor* in_t,
+                                DoneCallback done_callback) {
+  std::unique_ptr<Participant> participant(
+      new Participant(in_t, nullptr /* out_t */, event_mgr, tensor_stream,
+                      executor, gpu_device_id, std::move(done_callback)));
+  AddParticipant(num_devices, key, std::move(participant), in_t->dtype(),
+                 kReduce, reduction_op);
+}
+
+void RcclManager::AddReduceRecv(int num_devices, const string& key,
+                                rcclRedOp_t reduction_op,
+                                se::StreamExecutor* executor, int gpu_device_id,
+                                EventMgr* event_mgr, se::Stream* tensor_stream,
+                                const Tensor* in_t, Tensor* out_t,
+                                DoneCallback done_callback) {
+  std::unique_ptr<Participant> participant(
+      new Participant(in_t, out_t, event_mgr, tensor_stream, executor,
+                      gpu_device_id, std::move(done_callback)));
+  participant->root = true;
+  AddParticipant(num_devices, key, std::move(participant), in_t->dtype(),
+                 kReduce, reduction_op);
+}
+
+void RcclManager::AddParticipant(int num_devices, const string& key,
+                                 std::unique_ptr<Participant> participant,
+                                 DataType data_type,
+                                 CollectiveType collective_type,
+                                 rcclRedOp_t reduction_op) {
+  Collective* to_run = nullptr;
+  {
+    mutex_lock l(mu_);
+    auto& collective_ptr = collectives_[key];
+    if (collective_ptr == nullptr) {
+      collective_ptr.reset(new Collective(data_type, collective_type,
+                                          reduction_op, num_devices));
+    }
+    Collective* collective = collective_ptr.get();
+    DCHECK_EQ(collective->type, collective_type);
+    DCHECK_LT(collective->participants.size(), num_devices);
+    collective->participants.emplace_back(std::move(participant));
+    ++collective->available_participants;
+
+    if (collective->available_participants == num_devices) {
+      to_run = collective;
+
+      // Ownership is going to be transferred to RunCollective.
+      collective_ptr.release();
+      collectives_.erase(key);
+    }
+  }
+
+  if (to_run != nullptr) {
+    RunCollective(key, to_run);
+  }
+}
+
+void RcclManager::RunCollective(const string& key, Collective* collective) {
+  static mutex collective_mu(LINKER_INITIALIZED);
+
+  auto* communicator = GetCommunicator(collective);
+  collective->communicator = communicator;
+  const int size = communicator->num_devices;
+
+  for (int rank = 0; rank < size; ++rank) {
+    Participant* p = collective->participants[rank].get();
+    RcclStream* rccl_stream = communicator->members[rank].rccl_stream;
+    CHECK(rccl_stream != nullptr);
+
+    if (p->in_t != nullptr) {
+      // Wait to ensure that the kernel that produces the data in the input
+      // tensor has finished running before the rccl kernel runs on the
+      // communication stream.
+      rccl_stream->stream->ThenWaitFor(p->tensor_stream);
+    }
+    if (p->root) {
+      CHECK_EQ(collective->root_rank, -1);
+      collective->root_rank = rank;
+    }
+  }
+
+  if (collective->type == kBroadcast) {
+    CHECK_NE(collective->root_rank, -1);
+  }
+
+  {
+    // Allow only one collective at a time to queue kernels for launching. This
+    // is to prevent collectives from deadlocking each other.
+    // Note that it would be possible to run multiple collectives at once, if
+    // they have non-intersecting sets of devices.
+    mutex_lock l(collective_mu);
+    for (int rank = 0; rank < size; ++rank) {
+      RcclStream* rccl_stream = communicator->members[rank].rccl_stream;
+      mutex_lock l(rccl_stream->mu);
+      rccl_stream->pending_launches_.push_front(
+          std::make_pair(collective, rank));
+      rccl_stream->cv.notify_all();
+    }
+  }
+}
+
+void RcclManager::LoopKernelLaunches(RcclStream* rccl_stream) {
+  se::Stream* comm_stream = rccl_stream->stream.get();
+  ScopedActivateExecutorContext scoped_context(rccl_stream->executor);
+  const hipStream_t* cu_stream = reinterpret_cast<const hipStream_t*>(
+      comm_stream->implementation()->GpuStreamMemberHack());
+
+  while (true) {
+    // Find collective to run.
+    std::pair<Collective*, int> next_launch;
+    {
+      mutex_lock l(rccl_stream->mu);
+      while (rccl_stream->pending_launches_.empty()) {
+        if (rccl_stream->shutdown_requested) {
+          // No work and shutdown requested, exit.
+          return;
+        }
+        rccl_stream->cv.wait(l);
+      }
+      next_launch = rccl_stream->pending_launches_.back();
+      rccl_stream->pending_launches_.pop_back();
+    }
+    Collective* collective = next_launch.first;
+    int rank = next_launch.second;
+
+    // Launch the rccl kernel.
+    rcclDataType_t data_type = ToRcclType(collective->data_type);
+    Participant* p = collective->participants[rank].get();
+
+    auto rccl_comm = collective->communicator->members[rank].rccl_comm;
+    rcclResult_t rccl_result = rcclSuccess;
+    switch (collective->type) {
+      case kAllReduce: {
+        const void* sendbuff = p->in_t->tensor_data().data();
+        void* recvbuff = const_cast<char*>(p->out_t->tensor_data().data());
+
+        rccl_result =
+            rcclAllReduce(sendbuff, recvbuff, p->in_t->NumElements(), data_type,
+                          collective->reduction_op, rccl_comm, *cu_stream);
+        break;
+      }
+      case kBroadcast: {
+        const Tensor* buf_t = p->in_t ? p->in_t : p->out_t;
+        void* buf = const_cast<char*>(buf_t->tensor_data().data());
+        rccl_result = rcclBcast(buf, buf_t->NumElements(), data_type,
+                                collective->root_rank, rccl_comm, *cu_stream);
+        break;
+      }
+      case kReduce: {
+        const void* sendbuff = p->in_t->tensor_data().data();
+        void* recvbuff = p->out_t
+                             ? const_cast<char*>(p->out_t->tensor_data().data())
+                             : nullptr;
+        rccl_result = rcclReduce(sendbuff, recvbuff, p->in_t->NumElements(),
+                                 data_type, collective->reduction_op,
+                                 collective->root_rank, rccl_comm, *cu_stream);
+        break;
+      }
+    }
+
+    // Run the done_callback when the rccl kernel finishes running.
+    auto done_callback = [collective, rank, rccl_result]() {
+      if (rccl_result == rcclSuccess) {
+        collective->participants[rank]->done_callback(Status::OK());
+      } else {
+        // Propagate the error, but note that if other members of the collective
+        // did launch their kernels, then they are hanging.
+        collective->participants[rank]->done_callback(errors::Unknown(
+            "Error invoking RCCL: ", rcclGetErrorString(rccl_result)));
+      }
+
+      // TODO(cwhipkey): use RefCounted after figuring out how to use in a
+      // custom op library.
+      // See tensorflow/core/lib/core/refcount.h for details on this locking.
+      if (collective->remaining_participants.load(std::memory_order_acquire) ==
+              1 ||
+          collective->remaining_participants.fetch_sub(1) == 1) {
+        delete collective;
+      }
+    };
+    p->event_mgr->ThenExecute(comm_stream, done_callback);
+  }
+}
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/contrib/rccl/kernels/rccl_manager.h
+++ b/tensorflow/contrib/rccl/kernels/rccl_manager.h
@@ -1,0 +1,138 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_CONTRIB_RCCL_KERNELS_RCCL_MANAGER_H_
+#define TENSORFLOW_CONTRIB_RCCL_KERNELS_RCCL_MANAGER_H_
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#include <unordered_map>
+#include <vector>
+
+// TODO(rmlarsen): Get rid of this workaround. "gpu_assert" is defined when
+// setting EIGEN_USE_THREADS. But when defining EIGEN_USE_THREADS here,
+// incAtomic and other CUDA specific symbols are no longer recognized.
+#ifndef gpu_assert
+#define gpu_assert(x)
+#endif
+
+#include "rccl.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/stream_executor.h"
+
+namespace tensorflow {
+
+// The communicator is used to make the asynchronous communicator calls and to
+// manage the per-device streams used for communication.
+//
+// See rccl_ops.cc for example usage, including description of memory
+// management and stream synchronization.
+class RcclManager {
+ public:
+  typedef std::function<void(Status)> DoneCallback;
+  RcclManager();
+  ~RcclManager();
+
+  static RcclManager* instance();
+
+  // Add one participant to an all-reduce, sending in data from <in_t> and
+  // receiving the result of the all-reduce in <out_t>.  The device for this
+  // participant is managed by <executor>, and its events are polled by
+  // <event_mgr>.
+  //
+  // This is an asynchronous call. When <done_callback> is called, <out_t> has
+  // been set to the all-reduce result (note: the stream may not yet have been
+  // synced).
+  //
+  // <tensor_stream> is the stream that should be waited on to ensure <in_t>'s
+  // data is available on the GPU for the communication stream to access. It
+  // is also the stream that will use the produced data; <done_callback> is
+  // not called until the next kernel launched on <stream> would see the data.
+  void AddToAllReduce(int num_devices, const string& key,
+                      rcclRedOp_t reduction_op, se::StreamExecutor* executor,
+                      int gpu_device_id, EventMgr* event_mgr,
+                      se::Stream* tensor_stream, const Tensor* in_t,
+                      Tensor* out_t, const DoneCallback& done_callback);
+
+  // AddBroadcastSend and AddBroadcastRecv combine to sent data from one sender
+  // to all receivers.
+  void AddBroadcastSend(int num_devices, const string& key,
+                        se::StreamExecutor* executor, int gpu_device_id,
+                        EventMgr* event_mgr, se::Stream* tensor_stream,
+                        const Tensor* in_t, DoneCallback done_callback);
+  void AddBroadcastRecv(int num_devices, const string& key,
+                        se::StreamExecutor* executor, int gpu_device_id,
+                        EventMgr* event_mgr, se::Stream* tensor_stream,
+                        Tensor* out_t, DoneCallback done_callback);
+
+  // AddReduceSend and AddReduceRecv combine to sent data from all senders
+  // to one receiver.
+  void AddReduceSend(int num_devices, const string& key,
+                     rcclRedOp_t reduction_op, se::StreamExecutor* executor,
+                     int gpu_device_id, EventMgr* event_mgr,
+                     se::Stream* tensor_stream, const Tensor* in_t,
+                     DoneCallback done_callback);
+  void AddReduceRecv(int num_devices, const string& key,
+                     rcclRedOp_t reduction_op, se::StreamExecutor* executor,
+                     int gpu_device_id, EventMgr* event_mgr,
+                     se::Stream* tensor_stream, const Tensor* in_t,
+                     Tensor* out_t, DoneCallback done_callback);
+
+ private:
+  enum CollectiveType {
+    kAllReduce = 1,
+    kBroadcast = 2,
+    kReduce = 3,
+  };
+  struct Collective;
+  struct Communicator;
+  struct CommunicatorMember;
+  struct RcclStream;
+  struct Participant;
+
+  Communicator* GetCommunicator(Collective* collective);
+
+  void AddParticipant(int num_devices, const string& key,
+                      std::unique_ptr<Participant> participant,
+                      DataType data_type, CollectiveType collective_type,
+                      rcclRedOp_t reduction_op);
+
+  // Run <collective>.  This calls takes ownership of <collective>.
+  void RunCollective(const string& key, Collective* collective);
+  void LoopKernelLaunches(RcclStream* stream);
+
+  mutex mu_;
+
+  // Maps key to collectives currently being assembled or run.
+  std::unordered_map<string, std::unique_ptr<Collective>> collectives_
+      GUARDED_BY(mu_);
+
+  // Maps a device to the communication streams that make up its collective.
+  // This is used to share the stream across different communicators that
+  // include the same device.
+  std::map<se::StreamExecutor*, std::vector<std::unique_ptr<RcclStream>>>
+      device_to_comm_streams_ GUARDED_BY(mu_);
+
+  std::vector<std::unique_ptr<Communicator>> communicators_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(RcclManager);
+};
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#endif  // TENSORFLOW_CONTRIB_RCCL_KERNELS_RCCL_MANAGER_H_

--- a/tensorflow/contrib/rccl/kernels/rccl_manager_test.cc
+++ b/tensorflow/contrib/rccl/kernels/rccl_manager_test.cc
@@ -1,0 +1,307 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+#include "tensorflow/core/common_runtime/device_factory.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_device.h"
+#include "tensorflow/core/framework/tensor_testutil.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/contrib/rccl/kernels/rccl_manager.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+
+static std::vector<BaseGPUDevice*> GetGPUDevices() {
+  std::vector<Device*> devices;
+  SessionOptions session_options;
+  session_options.config.mutable_gpu_options()
+      ->set_per_process_gpu_memory_fraction(0.1);
+  session_options.env = Env::Default();
+  Status s = DeviceFactory::GetFactory(DEVICE_GPU)
+                 ->AddDevices(session_options, "", &devices);
+  TF_CHECK_OK(s);
+  std::vector<BaseGPUDevice*> gpus;
+  for (Device* d : devices) {
+    if (d->device_type() == "GPU") {
+      gpus.push_back(static_cast<BaseGPUDevice*>(d));
+    } else {
+      delete d;
+    }
+  }
+  return gpus;
+}
+
+template <typename Scalar>
+class RcclManagerTest : public ::testing::Test {
+ public:
+  // A single all-reduce to apply.
+  struct TestCase {
+    string key;
+    std::vector<Tensor> ins;
+    std::vector<Tensor> outs;
+    Tensor expected;
+
+    mutex mu;
+    Status final_status;
+    int num_completed = 0;
+  };
+
+  static void SetUpTestCase() {
+    setenv("RCCL_DEBUG", "INFO", 1 /* replace */);
+    devices_ = new std::vector<BaseGPUDevice*>(GetGPUDevices());
+    CHECK(!devices_->empty());
+    LOG(ERROR) << "Running test with " << devices_->size() << " gpus";
+  }
+
+  static void TearDownTestCase() {
+    for (auto device : *devices_) delete device;
+    delete devices_;
+  }
+
+  TestCase* MakeTestCase(int num_ranks, rcclRedOp_t reduction_op,
+                         TensorShape shape, float value_offset) {
+    TestCase* test_case = new TestCase();
+    test_case->expected = Tensor(data_type_, shape);
+    if (reduction_op == rcclProd) {
+      test::FillFn<Scalar>(&test_case->expected,
+                           [](int) { return static_cast<Scalar>(1); });
+    } else if (reduction_op == rcclSum) {
+      test::FillFn<Scalar>(&test_case->expected,
+                           [](int) { return static_cast<Scalar>(0); });
+    } else if (reduction_op == rcclMax) {
+      test::FillFn<Scalar>(&test_case->expected, [](int) { return -max_; });
+    } else if (reduction_op == rcclMin) {
+      test::FillFn<Scalar>(&test_case->expected, [](int) { return max_; });
+    } else {
+      LOG(FATAL) << "Invalid reduction_op " << reduction_op;
+    }
+
+    float value_scale = 0.01;  // Small scale to avoid fp16 overflow.
+    for (int rank = 0; rank < num_ranks; ++rank) {
+      auto* device = GetDevice(rank);
+      auto* stream = device->tensorflow_gpu_device_info()->stream;
+
+      Tensor in_cpu(data_type_, shape);
+      test::FillFn<Scalar>(&in_cpu, [&](int index) {
+        return static_cast<Scalar>((index + 1) * value_scale + value_offset);
+      });
+      for (int j = 0; j < shape.num_elements(); ++j) {
+        auto in_val = in_cpu.flat<Scalar>()(j);
+        auto out_expr = test_case->expected.template flat<Scalar>();
+        if (reduction_op == rcclProd) {
+          out_expr(j) = out_expr(j) * in_val;
+        } else if (reduction_op == rcclSum) {
+          out_expr(j) = out_expr(j) + in_val;
+        } else if (reduction_op == rcclMax) {
+          if (in_val > out_expr(j)) {
+            out_expr(j) = in_val;
+          }
+        } else if (reduction_op == rcclMin) {
+          if (in_val < out_expr(j)) {
+            out_expr(j) = in_val;
+          }
+        }
+      }
+
+      value_scale *= 10;
+      test_case->ins.emplace_back(GpuAllocator(device), data_type_, shape);
+      test_case->outs.emplace_back(GpuAllocator(device), data_type_, shape);
+
+      const Tensor& in_gpu = test_case->ins.back();
+      auto in_gpu_mem = AsDeviceMemory(in_gpu.flat<Scalar>().data());
+      stream->ThenMemcpy(&in_gpu_mem, in_cpu.flat<Scalar>().data(),
+                         in_cpu.TotalBytes());
+    }
+    return test_case;
+  }
+
+  void VerifyResults(const string& case_label, TestCase* test_case) {
+    // Wait for the done callback to be called.
+    {
+      test_case->mu.lock();
+      while (test_case->num_completed != test_case->outs.size()) {
+        test_case->mu.unlock();
+        Env::Default()->SleepForMicroseconds(10);
+        test_case->mu.lock();
+      }
+      test_case->mu.unlock();
+    }
+    // Copy memory to host and verify.
+    for (int rank = 0; rank < test_case->outs.size(); ++rank) {
+      auto* device = GetDevice(rank);
+      auto* stream = device->tensorflow_gpu_device_info()->stream;
+      const Tensor& out_gpu = test_case->outs[rank];
+      Tensor out_cpu(data_type_, out_gpu.shape());
+      auto out_gpu_mem = AsDeviceMemory(out_gpu.flat<Scalar>().data());
+      stream->ThenMemcpy(out_cpu.flat<Scalar>().data(), out_gpu_mem,
+                         out_cpu.TotalBytes());
+      SE_ASSERT_OK(stream->BlockHostUntilDone());
+      test::ExpectTensorNear<Scalar>(test_case->expected, out_cpu, 0.01);
+    }
+  }
+
+  RcclManager::DoneCallback CreateDoneCallback(TestCase* test_case) {
+    return [this, test_case](Status s) {
+      mutex_lock l(test_case->mu);
+      ++test_case->num_completed;
+      test_case->final_status.Update(s);
+    };
+  }
+
+  static BaseGPUDevice* GetDevice(size_t rank) {
+    return devices_->at(rank % devices_->size());
+  }
+
+ private:
+  static Allocator* GpuAllocator(BaseGPUDevice* device) {
+    return device->GetAllocator(AllocatorAttributes());
+  }
+
+  static se::DeviceMemory<Scalar> AsDeviceMemory(const Scalar* gpu_memory) {
+    se::DeviceMemoryBase wrapped(const_cast<Scalar*>(gpu_memory));
+    se::DeviceMemory<Scalar> typed(wrapped);
+    return typed;
+  }
+
+ private:
+  static std::vector<BaseGPUDevice*>* devices_;
+  static const DataType data_type_;
+  static const Scalar max_;
+};
+
+template <typename Scalar>
+std::vector<BaseGPUDevice*>* RcclManagerTest<Scalar>::devices_ = nullptr;
+template <typename Scalar>
+const DataType RcclManagerTest<Scalar>::data_type_ =
+    DataTypeToEnum<Scalar>::value;
+template <typename Scalar>
+const Scalar RcclManagerTest<Scalar>::max_ =
+    Eigen::NumTraits<Scalar>::highest();
+
+// Instantiate tests for float and half.
+using TypeList = ::testing::Types<float, Eigen::half>;
+TYPED_TEST_CASE(RcclManagerTest, TypeList);
+
+// Test basic sum reduction.
+TYPED_TEST(RcclManagerTest, BasicSumReduction) {
+  const int num_ranks = 3;
+
+  for (int op = 0; op < 4; ++op) {
+    rcclRedOp_t reduction_op = static_cast<rcclRedOp_t>(op);
+    std::unique_ptr<typename TestFixture::TestCase> test_case(
+        this->MakeTestCase(num_ranks, reduction_op, TensorShape({2, 3}), 0.0f));
+    for (int rank = 0; rank < num_ranks; ++rank) {
+      auto* device = this->GetDevice(rank);
+      auto* event_mgr = device->tensorflow_gpu_device_info()->event_mgr;
+      auto* stream = device->tensorflow_gpu_device_info()->stream;
+      RcclManager::instance()->AddToAllReduce(
+          num_ranks, "allreduce", reduction_op, device->executor(),
+          device->gpu_id(), event_mgr, stream, &test_case->ins[rank],
+          &test_case->outs[rank], this->CreateDoneCallback(test_case.get()));
+    }
+
+    LOG(ERROR) << "Verifying results";
+    this->VerifyResults("test_case", test_case.get());
+  }
+}
+
+// Same as the Basic test, but with multiple threads launching parts of many
+// reductions.
+//
+// Testing the multi-rank execution is currently reduced as it can hang when run
+// with num_ranks > devices->size(), for some GPUs (e.g. K20m).
+// To test the higher settings, increase num_ranks,
+// num_collectives_per_iteration and time_limit_micros.
+TYPED_TEST(RcclManagerTest, MultipleCallers) {
+  const int num_ranks = 1;                      // 2;
+  const int num_collectives_per_iteration = 1;  // 1000;
+  const int num_threads = 3;
+  const int time_limit_micros = 1;  // 60 * 30 * 1000 * 1000;
+
+  int64 start = Env::Default()->NowMicros();
+  srand(Env::Default()->NowMicros());
+
+  for (;;) {
+    std::vector<std::pair<int, int>> case_and_rank;
+    std::vector<std::unique_ptr<typename TestFixture::TestCase>> test_cases;
+    for (int i = 0; i < num_collectives_per_iteration; ++i) {
+      test_cases.emplace_back(this->MakeTestCase(
+          num_ranks, rcclSum, TensorShape({100, i % 5 + 1, i % 3 + 1}),
+          1.1f * i));
+      for (int j = 0; j < num_ranks; ++j) {
+        case_and_rank.emplace_back(i, j);
+      }
+    }
+
+    for (int rank = 0; rank < num_ranks; ++rank) {
+      auto* device = this->GetDevice(rank);
+      auto* stream = device->tensorflow_gpu_device_info()->stream;
+      SE_ASSERT_OK(stream->BlockHostUntilDone());
+    }
+
+    std::shuffle(case_and_rank.begin(), case_and_rank.end(),
+                 std::mt19937(std::random_device()()));
+
+    mutex mu;  // guards case_and_rank.
+    std::unique_ptr<thread::ThreadPool> pool(
+        new thread::ThreadPool(Env::Default(), "test", num_threads));
+    const int to_schedule = case_and_rank.size();
+    for (int i = 0; i < to_schedule; ++i) {
+      auto fn = [&]() {
+        int rank;
+        int test_num;
+        {
+          mutex_lock l(mu);
+          test_num = case_and_rank.back().first;
+          rank = case_and_rank.back().second;
+          case_and_rank.pop_back();
+        }
+        auto* device = this->GetDevice(rank);
+        auto* event_mgr = device->tensorflow_gpu_device_info()->event_mgr;
+        auto* stream = device->tensorflow_gpu_device_info()->stream;
+        typename TestFixture::TestCase* test_case = test_cases[test_num].get();
+        RcclManager::instance()->AddToAllReduce(
+            num_ranks, strings::StrCat("allreduce", test_num), rcclSum,
+            device->executor(), device->gpu_id(), event_mgr, stream,
+            &test_case->ins[rank], &test_case->outs[rank],
+            this->CreateDoneCallback(test_case));
+      };
+      pool->Schedule(fn);
+    }
+    pool.reset();  // wait for all work to be scheduled.
+
+    LOG(ERROR) << "Verifying results for " << num_collectives_per_iteration
+               << " collectives";
+    for (int i = 0; i < test_cases.size(); ++i) {
+      this->VerifyResults(strings::StrCat("collective", i),
+                          test_cases[i].get());
+    }
+
+    int64 delta = Env::Default()->NowMicros() - start;
+    if (delta > time_limit_micros) {
+      LOG(ERROR) << "Ran for " << delta << " quitting";
+      break;
+    }
+  }
+}
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/contrib/rccl/kernels/rccl_manager_test.cc
+++ b/tensorflow/contrib/rccl/kernels/rccl_manager_test.cc
@@ -19,11 +19,11 @@ limitations under the License.
 #include <random>
 #include <vector>
 
+#include "tensorflow/contrib/rccl/kernels/rccl_manager.h"
 #include "tensorflow/core/common_runtime/device_factory.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_device.h"
 #include "tensorflow/core/framework/tensor_testutil.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
-#include "tensorflow/contrib/rccl/kernels/rccl_manager.h"
 #include "tensorflow/core/platform/test.h"
 
 namespace tensorflow {

--- a/tensorflow/contrib/rccl/kernels/rccl_ops.cc
+++ b/tensorflow/contrib/rccl/kernels/rccl_ops.cc
@@ -1,0 +1,246 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#include <vector>
+
+#include "rccl.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/contrib/rccl/kernels/rccl_manager.h"
+
+namespace tensorflow {
+namespace {
+
+// Base class for all communicator ops that use rccl.
+//
+// About memory management and stream syncing:
+// 1. The rccl communicator has a stream for each rank.
+// 2. For input tensors to the communicator, the compute stream is passed to the
+//    RcclManager which will do a needed
+//    communicator_stream.ThenWaitFor(input_tensor_stream).
+// 3. The done_callback of the async kernel is not called by the
+//    RcclManager until after the communicator kernel is complete. This
+//    is enough to a) keep the input tensor data valid for the lifetime of the
+//    collective; and b) ensure the data in the output tensor is available
+//    when the async op kernel's done callback is called.
+class RcclAsyncOpBase : public AsyncOpKernel {
+ public:
+  explicit RcclAsyncOpBase(OpKernelConstruction* c) : AsyncOpKernel(c) {
+    OP_REQUIRES_OK(c, c->GetAttr("num_devices", &num_devices_));
+    OP_REQUIRES_OK(c, c->GetAttr("shared_name", &collective_prefix_));
+  }
+
+  string GetCollectiveKey(OpKernelContext* c) {
+    return strings::StrCat(collective_prefix_, ";", c->step_id(), ";",
+                           c->frame_iter().frame_id, ":",
+                           c->frame_iter().iter_id);
+  }
+
+  int num_devices() const { return num_devices_; }
+
+ private:
+  int num_devices_;
+  string collective_prefix_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(RcclAsyncOpBase);
+};
+
+class RcclReduceOpBase : public RcclAsyncOpBase {
+ public:
+  explicit RcclReduceOpBase(OpKernelConstruction* c) : RcclAsyncOpBase(c) {
+    string reduction;
+    OP_REQUIRES_OK(c, c->GetAttr("reduction", &reduction));
+    if (reduction == "min") {
+      reduction_op_ = rcclMin;
+    } else if (reduction == "max") {
+      reduction_op_ = rcclMax;
+    } else if (reduction == "sum") {
+      reduction_op_ = rcclSum;
+    } else if (reduction == "prod") {
+      reduction_op_ = rcclProd;
+    } else {
+      OP_REQUIRES_OK(c,
+                     errors::InvalidArgument("Invalid reduction: ", reduction));
+    }
+  }
+
+  rcclRedOp_t reduction_op() const { return reduction_op_; }
+
+ private:
+  rcclRedOp_t reduction_op_;
+};
+
+// To execute a single all-reduce, this kernel is called once for each of the
+// <k> devices in the communicator.
+class RcclAllReduceOpKernel : public RcclReduceOpBase {
+ public:
+  explicit RcclAllReduceOpKernel(OpKernelConstruction* c)
+      : RcclReduceOpBase(c) {}
+
+  void ComputeAsync(OpKernelContext* c, DoneCallback done) override {
+    const Tensor* in_t = &c->input(0);
+    Tensor* out_t;
+    OP_REQUIRES_OK_ASYNC(c, c->allocate_output(0, in_t->shape(), &out_t), done);
+
+    auto actual_done = [c, done](Status s) {
+      OP_REQUIRES_OK_ASYNC(c, s, done);
+      done();
+    };
+
+    auto* compute_stream = c->op_device_context()->stream();
+    auto* gpu_info = c->device()->tensorflow_gpu_device_info();
+    RcclManager::instance()->AddToAllReduce(
+        num_devices(), GetCollectiveKey(c), reduction_op(),
+        compute_stream->parent(), gpu_info->gpu_id, gpu_info->event_mgr,
+        compute_stream, in_t, out_t, std::move(actual_done));
+  }
+};
+REGISTER_KERNEL_BUILDER(Name("RcclAllReduce").Device(DEVICE_GPU),
+                        RcclAllReduceOpKernel);
+
+// To execute a single reduce, this kernel is called once for all but one of the
+// <k> devices in the communicator, and RcclReduceRecvKernel is called once for
+// the remaining device.
+class RcclReduceSendKernel : public RcclReduceOpBase {
+ public:
+  explicit RcclReduceSendKernel(OpKernelConstruction* c)
+      : RcclReduceOpBase(c) {}
+
+  void ComputeAsync(OpKernelContext* c, DoneCallback done) override {
+    auto actual_done = [c, done](Status s) {
+      OP_REQUIRES_OK_ASYNC(c, s, done);
+      done();
+    };
+
+    auto* compute_stream = c->op_device_context()->stream();
+    auto* gpu_info = c->device()->tensorflow_gpu_device_info();
+    RcclManager::instance()->AddReduceSend(
+        num_devices(), GetCollectiveKey(c), reduction_op(),
+        compute_stream->parent(), gpu_info->gpu_id, gpu_info->event_mgr,
+        compute_stream, &c->input(0), std::move(actual_done));
+  }
+};
+REGISTER_KERNEL_BUILDER(Name("_RcclReduceSend").Device(DEVICE_GPU),
+                        RcclReduceSendKernel);
+
+// To execute a single reduce, this kernel is called once for one devices, and
+// RcclReduceSendKernel is called for all other <k-1> devices in the
+// communicator.
+class RcclReduceRecvKernel : public RcclReduceOpBase {
+ public:
+  explicit RcclReduceRecvKernel(OpKernelConstruction* c)
+      : RcclReduceOpBase(c) {}
+
+  void ComputeAsync(OpKernelContext* c, DoneCallback done) override {
+    const Tensor& in_t = c->input(0);
+    Tensor* out_t;
+    OP_REQUIRES_OK_ASYNC(c, c->allocate_output(0, in_t.shape(), &out_t), done);
+
+    auto actual_done = [c, done](Status s) {
+      OP_REQUIRES_OK_ASYNC(c, s, done);
+      done();
+    };
+
+    auto* compute_stream = c->op_device_context()->stream();
+    auto* gpu_info = c->device()->tensorflow_gpu_device_info();
+    RcclManager::instance()->AddReduceRecv(
+        num_devices(), GetCollectiveKey(c), reduction_op(),
+        compute_stream->parent(), gpu_info->gpu_id, gpu_info->event_mgr,
+        compute_stream, &in_t, out_t, std::move(actual_done));
+  }
+
+ private:
+  rcclRedOp_t reduction_op_;
+};
+REGISTER_KERNEL_BUILDER(Name("_RcclReduceRecv").Device(DEVICE_GPU),
+                        RcclReduceRecvKernel);
+
+// To execute a single broadcast, this kernel is called once for one device, and
+// RcclBroadcastRecvKernel is called for all other <k-1> devices in the
+// communicator.
+class RcclBroadcastSendKernel : public RcclAsyncOpBase {
+ public:
+  explicit RcclBroadcastSendKernel(OpKernelConstruction* c)
+      : RcclAsyncOpBase(c) {}
+
+  void ComputeAsync(OpKernelContext* c, DoneCallback done) override {
+    auto actual_done = [c, done](Status s) {
+      OP_REQUIRES_OK_ASYNC(c, s, done);
+      done();
+    };
+
+    auto* compute_stream = c->op_device_context()->stream();
+    auto* gpu_info = c->device()->tensorflow_gpu_device_info();
+    RcclManager::instance()->AddBroadcastSend(
+        num_devices(), GetCollectiveKey(c), compute_stream->parent(),
+        gpu_info->gpu_id, gpu_info->event_mgr, compute_stream, &c->input(0),
+        std::move(actual_done));
+  }
+};
+REGISTER_KERNEL_BUILDER(Name("_RcclBroadcastSend").Device(DEVICE_GPU),
+                        RcclBroadcastSendKernel);
+
+// To execute a single broadcast, this kernel is called once for all but one of
+// the <k> devices in the communicator, and RcclBroadcastSendKernel is called
+// once for the remaining device.
+class RcclBroadcastRecvKernel : public RcclAsyncOpBase {
+ public:
+  explicit RcclBroadcastRecvKernel(OpKernelConstruction* c)
+      : RcclAsyncOpBase(c) {}
+
+  void ComputeAsync(OpKernelContext* c, DoneCallback done) override {
+    const Tensor& shape_t = c->input(0);
+    TensorShape shape;
+    OP_REQUIRES_OK_ASYNC(
+        c, TensorShapeUtils::MakeShape(shape_t.vec<int32>(), &shape), done);
+    Tensor* out_t;
+    OP_REQUIRES_OK_ASYNC(c, c->allocate_output(0, shape, &out_t), done);
+
+    auto actual_done = [c, done](Status s) {
+      OP_REQUIRES_OK_ASYNC(c, s, done);
+      done();
+    };
+
+    auto* compute_stream = c->op_device_context()->stream();
+    auto* gpu_info = c->device()->tensorflow_gpu_device_info();
+    RcclManager::instance()->AddBroadcastRecv(
+        num_devices(), GetCollectiveKey(c), compute_stream->parent(),
+        gpu_info->gpu_id, gpu_info->event_mgr, compute_stream, out_t,
+        std::move(actual_done));
+  }
+};
+REGISTER_KERNEL_BUILDER(
+    Name("_RcclBroadcastRecv").Device(DEVICE_GPU).HostMemory("shape"),
+    RcclBroadcastRecvKernel);
+
+// Define stub kernels for the ops that get replaced post placement.
+class RcclStubKernel : public AsyncOpKernel {
+ public:
+  explicit RcclStubKernel(OpKernelConstruction* c) : AsyncOpKernel(c) {}
+  void ComputeAsync(OpKernelContext* c, DoneCallback done) override {
+    c->SetStatus(errors::Unimplemented(
+        "This op should be replaced during graph optimization."));
+    done();
+  }
+};
+REGISTER_KERNEL_BUILDER(Name("RcclBroadcast").Device(DEVICE_GPU),
+                        RcclStubKernel);
+REGISTER_KERNEL_BUILDER(Name("RcclReduce").Device(DEVICE_GPU), RcclStubKernel);
+
+}  // namespace
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/contrib/rccl/kernels/rccl_ops.cc
+++ b/tensorflow/contrib/rccl/kernels/rccl_ops.cc
@@ -18,8 +18,8 @@ limitations under the License.
 #include <vector>
 
 #include "rccl.h"
-#include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/contrib/rccl/kernels/rccl_manager.h"
+#include "tensorflow/core/framework/op_kernel.h"
 
 namespace tensorflow {
 namespace {

--- a/tensorflow/contrib/rccl/kernels/rccl_rewrite.cc
+++ b/tensorflow/contrib/rccl/kernels/rccl_rewrite.cc
@@ -1,0 +1,277 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/lib/strings/str_util.h"
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#include <forward_list>
+#include <vector>
+
+#include "tensorflow/core/common_runtime/optimization_registry.h"
+#include "tensorflow/core/graph/node_builder.h"
+
+namespace tensorflow {
+namespace {
+
+// Replaces RcclReduce node with _RcclReduceRecv reusing one input of same
+// device, adds one _RcclReduceSend for each other input.
+Status ReplaceReduce(Graph* graph, Node* node) {
+  string reduction;
+  TF_RETURN_IF_ERROR(GetNodeAttr(node->attrs(), "reduction", &reduction));
+  DataType dtype;
+  TF_RETURN_IF_ERROR(GetNodeAttr(node->attrs(), "T", &dtype));
+  int num_devices = node->num_inputs();
+  string shared_name = node->name();
+  auto make_builder = [&](StringPiece op_name, StringPiece suffix) {
+    return NodeBuilder(strings::StrCat(shared_name, suffix), op_name)
+        .Attr("reduction", reduction)
+        .Attr("num_devices", num_devices)
+        .Attr("shared_name", shared_name)
+        .Attr("T", dtype);
+  };
+  std::vector<Node*> control_inputs;
+  for (const auto& edge : node->in_edges()) {
+    if (edge->IsControlEdge()) {
+      control_inputs.push_back(edge->src());
+    }
+  }
+  std::vector<NodeBuilder::NodeOut> out_nodes;
+  for (const auto& edge : node->out_edges()) {
+    out_nodes.emplace_back(edge->dst(), edge->dst_input());
+  }
+  int recv_dev = node->assigned_device_name_index();
+  NodeBuilder recv_builder =
+      make_builder("_RcclReduceRecv", "Recv").ControlInputs(control_inputs);
+  bool recv_input_set = false;
+  int send_counter = 0;
+  for (const auto& edge : node->in_edges()) {
+    Node* src_node = edge->src();
+    if (edge->IsControlEdge()) {
+      continue;
+    }
+    int send_dev = src_node->assigned_device_name_index();
+    if (!recv_input_set && send_dev == recv_dev) {
+      recv_builder.Input(src_node);
+      recv_input_set = true;
+      continue;
+    }
+    auto send_builder = make_builder("_RcclReduceSend",
+                                     strings::StrCat("Send_", ++send_counter))
+                            .Input(src_node)
+                            .ControlInputs(control_inputs);
+    Node* send_node = nullptr;
+    TF_RETURN_IF_ERROR(send_builder.Finalize(graph, &send_node));
+    send_node->set_assigned_device_name_index(send_dev);
+    // Send nodes don't have any outputs and therefore have no data dependencies
+    // to the outputs of the graph. We add a control dependency to the receive
+    // node so that those 'dangling' nodes are run.
+    // TODO(b/67027412): Avoid these cross-device control edges.
+    for (const auto& out_node : out_nodes) {
+      graph->AddControlEdge(send_node, out_node.node);
+    }
+  }
+  if (!recv_input_set) {
+    return errors::InvalidArgument(
+        "No input tensor uses the same device as the RcclReduce op");
+  }
+  Node* recv_node = nullptr;
+  TF_RETURN_IF_ERROR(recv_builder.Finalize(graph, &recv_node));
+  recv_node->set_assigned_device_name_index(recv_dev);
+  graph->RemoveNode(node);
+  for (const auto& out_node : out_nodes) {
+    if (out_node.index == Graph::kControlSlot) {
+      graph->AddControlEdge(recv_node, out_node.node);
+    } else {
+      graph->AddEdge(recv_node, 0, out_node.node, out_node.index);
+    }
+  }
+  return Status::OK();
+}
+
+TensorProto TensorFromShape(const TensorShapeProto& shape) {
+  TensorProto result;
+  result.set_dtype(DT_INT32);
+  for (const auto& dim : shape.dim()) {
+    result.add_int_val(dim.size());
+  }
+  result.mutable_tensor_shape()->add_dim()->set_size(shape.dim_size());
+  return result;
+}
+
+// Replaces RcclBroadcast node with _RcclBroadcastSend, connects the input to
+// all outputs of same device, adds one _RcclBroadcastRecv for each other output
+// device.
+Status ReplaceBroadcast(Graph* graph, Node* node) {
+  DataType dtype;
+  TF_RETURN_IF_ERROR(GetNodeAttr(node->attrs(), "T", &dtype));
+  int send_dev = node->assigned_device_name_index();
+  int num_devices = 0;  // Number of distinct devices, incremented below.
+  std::vector<int> recv_index_map;  // Map device name index to stable index.
+
+  // Map device name index to nodes that take the broadcast as input.
+  std::vector<std::forward_list<NodeBuilder::NodeOut>> out_nodes_map;
+  for (const auto& edge : node->out_edges()) {
+    int dst_dev = edge->IsControlEdge()
+                      ? send_dev
+                      : edge->dst()->assigned_device_name_index();
+    if (out_nodes_map.size() <= dst_dev) {
+      out_nodes_map.resize(dst_dev + 1);
+      recv_index_map.resize(dst_dev + 1);
+    }
+    auto it = out_nodes_map.begin() + dst_dev;
+    if (it->empty()) {
+      recv_index_map[dst_dev] = num_devices;
+      ++num_devices;
+    }
+    it->emplace_front(NodeBuilder::NodeOut(edge->dst(), edge->dst_input()));
+  }
+
+  if (num_devices <= 1) {
+    // Only one participating device, skip RCCL op.
+    const Edge* in_edge = nullptr;
+    TF_RETURN_IF_ERROR(node->input_edge(0, &in_edge));
+    Node* in_node = in_edge->src();
+    int in_index = in_edge->src_output();
+    graph->RemoveNode(node);
+    for (const auto& out_nodes : out_nodes_map) {
+      for (const auto& out_node : out_nodes) {
+        if (out_node.index == Graph::kControlSlot) {
+          graph->AddControlEdge(in_node, out_node.node);
+        } else {
+          graph->AddEdge(in_node, in_index, out_node.node, out_node.index);
+        }
+      }
+    }
+    return Status::OK();
+  }
+
+  string shared_name = node->name();
+  auto make_builder = [&](StringPiece op_name, StringPiece suffix) {
+    return NodeBuilder(strings::StrCat(shared_name, suffix), op_name)
+        .Attr("num_devices", num_devices)
+        .Attr("shared_name", shared_name)
+        .Attr("T", dtype);
+  };
+
+  // Create broadcast send node and replace the original broadcast node.
+  NodeBuilder::NodeOut in_node;
+  NodeBuilder send_builder = make_builder("_RcclBroadcastSend", "Send");
+  for (const auto& edge : node->in_edges()) {
+    if (edge->IsControlEdge()) {
+      send_builder.ControlInput(edge->src());
+    } else {
+      in_node = NodeBuilder::NodeOut(edge->src(), edge->src_output());
+      send_builder.Input(in_node);
+    }
+  }
+  Node* send_node = nullptr;
+  TF_RETURN_IF_ERROR(send_builder.Finalize(graph, &send_node));
+  send_node->set_assigned_device_name_index(send_dev);
+
+  TensorShapeProto shape_proto;
+  TF_RETURN_IF_ERROR(GetNodeAttr(node->attrs(), "shape", &shape_proto));
+
+  // Delete the original node before reconnecting to outputs.
+  graph->RemoveNode(node);
+
+  // Connect all outputs on the device of broadcast send.
+  for (const auto& out_node : out_nodes_map[send_dev]) {
+    if (out_node.index == Graph::kControlSlot) {
+      graph->AddControlEdge(send_node, out_node.node);
+    } else {
+      graph->AddEdge(in_node.node, in_node.index, out_node.node,
+                     out_node.index);
+      // Add control edge so send node is run.
+      graph->AddControlEdge(send_node, out_node.node);
+    }
+  }
+  out_nodes_map[send_dev].clear();
+
+  TensorProto tensor_proto = TensorFromShape(shape_proto);
+  bool is_fully_defined = TensorShape(shape_proto).IsFullyDefined();
+  string shape_name = strings::StrCat(in_node.node->name(), "/Shape");
+  Node* shape_node = nullptr;
+  if (!is_fully_defined) {
+    NodeBuilder shape_builder(shape_name, "Shape");
+    shape_builder.Input(in_node).Attr("out_type", DT_INT32).Attr("T", dtype);
+    TF_RETURN_IF_ERROR(shape_builder.Finalize(graph, &shape_node));
+    shape_node->set_assigned_device_name_index(send_dev);
+  }
+
+  // For all other devices, create a broadcast receive and connect outputs.
+  for (int recv_dev = 0; recv_dev < out_nodes_map.size(); ++recv_dev) {
+    if (out_nodes_map[recv_dev].empty()) {
+      continue;
+    }
+    int recv_index = recv_index_map[recv_dev];
+    if (is_fully_defined) {
+      // If the shape is fully defined, define one const node per device.
+      NodeBuilder shape_builder(strings::StrCat(shape_name, recv_index),
+                                "Const");
+      shape_builder.Attr("value", tensor_proto).Attr("dtype", DT_INT32);
+      TF_RETURN_IF_ERROR(shape_builder.Finalize(graph, &shape_node));
+      shape_node->set_assigned_device_name_index(recv_dev);
+    }
+    Node* recv_node;
+    TF_RETURN_IF_ERROR(
+        make_builder("_RcclBroadcastRecv", strings::StrCat("Recv_", recv_index))
+            .Input(shape_node)
+            .Finalize(graph, &recv_node));
+    recv_node->set_assigned_device_name_index(recv_dev);
+    for (const auto& out_node : out_nodes_map[recv_dev]) {
+      graph->AddEdge(recv_node, 0, out_node.node, out_node.index);
+    }
+  }
+
+  return Status::OK();
+}
+
+// Replaces occurrences of Rccl{Reduce, Broadcast}Input/Output with their
+// _Rccl...Send/Recv counterparts and removes data dependencies between them.
+class RcclReplacePass : public GraphOptimizationPass {
+ public:
+  Status Run(const GraphOptimizationPassOptions& options) override {
+    if (options.graph == nullptr) {
+      return Status::OK();
+    }
+    Graph* graph = options.graph->get();
+    if (graph == nullptr) {
+      return errors::Internal(
+          "RCCL replacement should happen before partitioning and a "
+          "graph should be available.");
+    }
+    // Find reduction and broadcast ops and replace them with Send/Recv ops.
+    for (Node* node : graph->op_nodes()) {
+      StringPiece type = node->type_string();
+      if (!str_util::StartsWith(type, "Rccl")) {
+        continue;
+      }
+      if (type == "RcclReduce") {
+        TF_RETURN_IF_ERROR(ReplaceReduce(graph, node));
+      }
+      if (type == "RcclBroadcast") {
+        TF_RETURN_IF_ERROR(ReplaceBroadcast(graph, node));
+      }
+    }
+    return Status::OK();
+  }
+};
+REGISTER_OPTIMIZATION(OptimizationPassRegistry::POST_PLACEMENT, 0,
+                      RcclReplacePass);
+
+}  // namespace
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/contrib/rccl/ops/rccl_ops.cc
+++ b/tensorflow/contrib/rccl/ops/rccl_ops.cc
@@ -1,0 +1,185 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+
+namespace tensorflow {
+
+using shape_inference::InferenceContext;
+using shape_inference::ShapeHandle;
+
+REGISTER_OP("RcclAllReduce")
+    .Input("input: T")
+    .Output("data: T")
+    .Attr("reduction: {'min', 'max', 'prod', 'sum'}")
+    .Attr("T: {half, float, float64, int32, int64}")
+    .Attr("num_devices: int")
+    .Attr("shared_name: string")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::UnchangedShape)
+    .Doc(R"doc(
+Outputs a tensor containing the reduction across all input tensors passed to ops
+within the same `shared_name.
+
+The graph should be constructed so if one op runs with shared_name value `c`,
+then `num_devices` ops will run with shared_name value `c`.  Failure to do so
+will cause the graph execution to fail to complete.
+
+input: the input to the reduction
+data: the value of the reduction across all `num_devices` devices.
+reduction: the reduction operation to perform.
+num_devices: The number of devices participating in this reduction.
+shared_name: Identifier that shared between ops of the same reduction.
+)doc");
+
+// Note: This op has no kernel implementation, but is replaced by
+// _RcclReduceSend and _RcclReduceRecv during graph optimization stage.
+REGISTER_OP("RcclReduce")
+    .Input("input: num_devices * T")
+    .Output("data: T")
+    .Attr("reduction: {'min', 'max', 'prod', 'sum'}")
+    .Attr("T: {half, float, float64, int32, int64}")
+    .Attr("num_devices: int")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::UnchangedShape)
+    .Doc(R"doc(
+Reduces `input` from `num_devices` using `reduction` to a single device.
+
+The graph should be constructed so that all inputs have a valid device
+assignment, and the op itself is assigned one of these devices.
+
+input: The input to the reduction.
+data: the value of the reduction across all `num_devices` devices.
+reduction: the reduction operation to perform.
+    )doc");
+
+REGISTER_OP("_RcclReduceSend")
+    .Input("input: T")
+    .Attr("reduction: {'min', 'max', 'prod', 'sum'}")
+    .Attr("T: {half, float, float64, int32, int64}")
+    .Attr("num_devices: int")
+    .Attr("shared_name: string")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::NoOutputs)
+    .Doc(R"doc(
+Replacement node for RcclReduce.
+
+Reduces `input` to the RcclReduceRecv op registered in the same `shared_name`.
+The graph should be constructed so that 'num_devices-1' devices run
+`_RcclReduceSend` and one device runs _RcclReduceRecv op with shared_name value
+`c`. Failure to do so will cause the graph execution to fail to complete.
+
+input: The input to the reduction.
+reduction: the reduction operation to perform.
+num_devices: The number of devices participating in this reduction.
+shared_name: Identifier that is shared between ops of the same reduce.
+    )doc");
+
+REGISTER_OP("_RcclReduceRecv")
+    .Input("input: T")
+    .Output("data: T")
+    .Attr("reduction: {'min', 'max', 'prod', 'sum'}")
+    .Attr("T: {half, float, float64, int32, int64}")
+    .Attr("num_devices: int")
+    .Attr("shared_name: string")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::UnchangedShape)
+    .Doc(R"doc(
+Replacement node for RcclReduce.
+
+Reduces 'input' from this op and the RcclReduceSend ops registered in the same
+`shared_name`.
+The graph should be constructed so that 'num_devices-1' devices run
+`_RcclReduceSend` and one device runs _RcclReduceRecv op with shared_name value
+`c`. Failure to do so will cause the graph execution to fail to complete.
+
+input: The input to the reduction.
+data: The reduced data received from this op and the RcclReduceSend op.
+reduction: the reduction operation to perform.
+num_devices: The number of devices participating in this reduction.
+shared_name: Identifier that is shared between ops of the same reduce.
+    )doc");
+
+// Note: This op has no kernel implementation, but is replaced by
+// _RcclBroadcastSend and _RcclBroadcastRecv during graph optimization stage.
+REGISTER_OP("RcclBroadcast")
+    .Input("input: T")
+    .Output("output: T")
+    .Attr("T: {half, float, float64, int32, int64}")
+    .Attr("shape: shape")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::UnchangedShape)
+    .Doc(R"doc(
+Sends `input` to all devices that are connected to the output.
+
+The graph should be constructed so that all ops connected to the output have a
+valid device assignment, and the op itself is assigned one of these devices.
+
+input: The input to the broadcast.
+output: The same as input.
+shape: The shape of the input tensor.
+    )doc");
+
+REGISTER_OP("_RcclBroadcastSend")
+    .Input("input: T")
+    .Attr("T: {half, float, float64, int32, int64}")
+    .Attr("num_devices: int")
+    .Attr("shared_name: string")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::NoOutputs)
+    .Doc(R"doc(
+Replacement node for RcclBroadcast.
+
+Sends `input` to the _RcclBroadcastRecv ops registered in the same
+`shared_name`.
+The graph should be constructed so that one device runs `_RcclBroadcastSend` and
+`num_devices-1` devices run _RcclBroadcastRecv ops with shared_name value `c`.
+Failure to do so will cause the graph execution to fail to complete.
+
+input: The input to the broadcast.
+num_devices: The number of devices participating in this reduction.
+shared_name: Identifier that is shared between ops of the same broadcast.
+    )doc");
+
+REGISTER_OP("_RcclBroadcastRecv")
+    .Input("shape: int32")
+    .Output("output: T")
+    .Attr("T: {half, float, float64, int32, int64}")
+    .Attr("num_devices: int")
+    .Attr("shared_name: string")
+    .SetIsStateful()
+    .SetShapeFn([](InferenceContext* c) {
+      ShapeHandle out;
+      TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(0, &out));
+      c->set_output(0, out);
+      return Status::OK();
+    })
+    .Doc(R"doc(
+Replacement node for RcclBroadcast.
+
+Sends data of shape `shape` from the _RcclBroadcastSend op registered in the
+same `shared_name`.
+The graph should be constructed so that one device runs `_RcclBroadcastSend` and
+`num_devices-1` devices run _RcclBroadcastRecv ops with shared_name value `c`.
+Failure to do so will cause the graph execution to fail to complete.
+
+shape: The shape of the output.
+output: The broadcast data received from the RcclBroadcastSend op.
+num_devices: The number of devices participating in this reduction.
+shared_name: Identifier that is shared between ops of the same broadcast.
+    )doc");
+
+}  // namespace tensorflow

--- a/tensorflow/contrib/rccl/python/ops/rccl_dependency_test.py
+++ b/tensorflow/contrib/rccl/python/ops/rccl_dependency_test.py
@@ -1,0 +1,59 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dependency test for rccl to test behavior when RCCL is not installed."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib import rccl
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import errors_impl
+from tensorflow.python.framework import ops
+from tensorflow.python.platform import test
+from tensorflow.python.util import tf_inspect
+
+
+class RcclDependencyTest(test.TestCase):
+  """Verifies that importing rccl ops lib does not fail even if RCCL is not
+  installed but rccl ops throws an exception on use if RCCL is not installed.
+  """
+
+  def test_rccl_ops(self):
+    """Tests behavior of rccl ops when RCCL is not installed."""
+
+    public_methods = [
+        m[0]
+        for m in tf_inspect.getmembers(rccl, tf_inspect.isfunction)
+        if not m[0].startswith('_')
+    ]
+    for method_name in public_methods:
+      with ops.device('/device:CPU:0'):
+        tensor = constant_op.constant(1)
+
+      if method_name == 'broadcast':
+        arg = tensor
+      else:
+        arg = [tensor]
+
+      rccl_op = getattr(rccl, method_name)
+      with ops.device('/device:CPU:0'):
+        with self.assertRaisesRegexp(errors_impl.NotFoundError,
+                                     r'cannot open shared object file'):
+          rccl_op(arg)
+
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow/contrib/rccl/python/ops/rccl_ops.py
+++ b/tensorflow/contrib/rccl/python/ops/rccl_ops.py
@@ -1,0 +1,288 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Ops for GPU collective operations implemented using AMD rccl."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import threading
+
+from tensorflow.contrib.rccl.python.ops import gen_rccl_ops
+from tensorflow.contrib.util import loader
+from tensorflow.python.eager import context
+from tensorflow.python.framework import device
+from tensorflow.python.framework import ops
+from tensorflow.python.platform import resource_loader
+
+
+_rccl_ops_so = None
+_module_lock = threading.Lock()
+_shared_name_counter = 0
+
+
+def all_sum(tensors):
+  """Returns a list of tensors with the all-reduce sum across `tensors`.
+
+  The computation is done with an all-reduce operation, so if only some of the
+  returned tensors are evaluated then the computation will hang.
+
+  Args:
+    tensors: The input tensors across which to sum; must be assigned
+      to GPU devices.
+
+  Returns:
+    List of tensors, each with the sum of the input tensors, where tensor i has
+    the same device as `tensors[i]`.
+  """
+  return _apply_all_reduce('sum', tensors)
+
+
+@ops.RegisterGradient('RcclAllReduce')
+def _all_sum_grad(op, grad):
+  """The gradients for `all_sum`.
+
+  Args:
+    op: The `all_sum` `Operation` that we are differentiating.
+    grad: Gradient with respect to the output of the `all_sum` op.
+
+  Returns:
+    The gradient with respect to the output of `all_sum`.
+
+  Raises:
+    LookupError: If `reduction` is not `sum`.
+  """
+  if op.get_attr('reduction') != b'sum':
+    raise LookupError('No gradient defined for RcclAllReduce except sum.')
+
+  _check_device(grad, expected=op.device)
+  num_devices = op.get_attr('num_devices')
+  shared_name = op.get_attr('shared_name') + b'_grad'
+
+  with ops.device(op.device):
+    return gen_rccl_ops.rccl_all_reduce(
+        input=grad,
+        reduction='sum',
+        num_devices=num_devices,
+        shared_name=shared_name)
+
+
+def all_prod(tensors):
+  """Returns a list of tensors with the all-reduce product across `tensors`.
+
+  The computation is done with an all-reduce operation, so if only some of the
+  returned tensors are evaluated then the computation will hang.
+
+  Args:
+    tensors: The input tensors across which to multiply; must be assigned
+      to GPU devices.
+
+  Returns:
+    List of tensors, each with the product of the input tensors, where tensor i
+    has the same device as `tensors[i]`.
+  """
+  return _apply_all_reduce('prod', tensors)
+
+
+def all_min(tensors):
+  """Returns a list of tensors with the all-reduce min across `tensors`.
+
+  The computation is done with an all-reduce operation, so if only some of the
+  returned tensors are evaluated then the computation will hang.
+
+  Args:
+    tensors: The input tensors across which to reduce; must be assigned
+      to GPU devices.
+
+  Returns:
+    List of tensors, each with the minimum of the input tensors, where tensor i
+    has the same device as `tensors[i]`.
+  """
+  return _apply_all_reduce('min', tensors)
+
+
+def all_max(tensors):
+  """Returns a list of tensors with the all-reduce max across `tensors`.
+
+  The computation is done with an all-reduce operation, so if only some of the
+  returned tensors are evaluated then the computation will hang.
+
+  Args:
+    tensors: The input tensors across which to reduce; must be assigned
+      to GPU devices.
+
+  Returns:
+    List of tensors, each with the maximum of the input tensors, where tensor i
+    has the same device as `tensors[i]`.
+  """
+  return _apply_all_reduce('max', tensors)
+
+
+def reduce_sum(tensors):
+  """Returns a tensor with the reduce sum across `tensors`.
+
+  The computation is done with a reduce operation, so only one tensor is
+  returned.
+
+  Args:
+    tensors: The input tensors across which to sum; must be assigned
+      to GPU devices.
+
+  Returns:
+    A tensor containing the sum of the input tensors.
+
+  Raises:
+    LookupError: If context is not currently using a GPU device.
+  """
+  return _apply_reduce('sum', tensors)
+
+
+@ops.RegisterGradient('RcclReduce')
+def _reduce_sum_grad(op, grad):
+  """The gradients for input `Operation` of `reduce_sum`.
+
+  Args:
+    op: The `sum send` `Operation` that we are differentiating.
+    grad: Gradient with respect to the output of the `reduce_sum` op.
+
+  Returns:
+    The gradient with respect to the input of `reduce_sum` op.
+
+  Raises:
+    LookupError: If the reduction attribute of op is not `sum`.
+  """
+  if op.get_attr('reduction') != b'sum':
+    raise LookupError('No gradient defined for RcclReduce except sum.')
+  _check_device(grad, expected=op.device)
+
+  with ops.device(op.device):
+    result = gen_rccl_ops.rccl_broadcast(input=grad, shape=grad.shape)
+
+  return [result] * len(op.inputs)
+
+
+def broadcast(tensor):
+  """Returns a tensor that can be efficiently transferred to other devices.
+
+  Args:
+    tensor: The tensor to send; must be assigned to a GPU device.
+
+  Returns:
+    A tensor with the value of `src_tensor`, which can be used as input to
+    ops on other GPU devices.
+  """
+  _validate_and_load_rccl_so()
+  _check_device(tensor)
+
+  with ops.device(tensor.device):
+    return gen_rccl_ops.rccl_broadcast(input=tensor, shape=tensor.shape)
+
+
+@ops.RegisterGradient('RcclBroadcast')
+def _broadcast_grad(op, accumulated_grad):
+  """The gradients for input `Operation` of `broadcast`.
+
+  Args:
+    op: The `broadcast send` `Operation` that we are differentiating.
+    accumulated_grad: Accumulated gradients with respect to the output of the
+      `broadcast` op.
+
+  Returns:
+    Gradients with respect to the input of `broadcast`.
+  """
+  # Grab inputs of accumulated_grad and replace accumulation with reduce_sum.
+  grads = [t for t in accumulated_grad.op.inputs]
+  for t in grads:
+    _check_device(t)
+
+  with ops.device(op.device):
+    return gen_rccl_ops.rccl_reduce(input=grads, reduction='sum')
+
+
+def _apply_all_reduce(reduction, tensors):
+  """Helper function for all_* functions."""
+  if not tensors:
+    raise ValueError('Must pass >0 tensors to all reduce operations')
+  _validate_and_load_rccl_so()
+
+  shared_name = _get_shared_name()
+  res = []
+
+  for t in tensors:
+    _check_device(t)
+    with ops.device(t.device):
+      res.append(
+          gen_rccl_ops.rccl_all_reduce(
+              input=t,
+              reduction=reduction,
+              num_devices=len(tensors),
+              shared_name=shared_name))
+
+  return res
+
+
+def _apply_reduce(reduction, tensors):
+  """Helper function for reduce_* functions."""
+  if not tensors:
+    raise ValueError('Must pass >0 tensors to reduce operations')
+  _validate_and_load_rccl_so()
+
+  for t in tensors:
+    _check_device(t)
+  result = gen_rccl_ops.rccl_reduce(input=tensors, reduction=reduction)
+  try:
+    next(t for t in tensors if t.device == result.device)
+  except StopIteration:
+    raise ValueError('One input tensor must be assigned to current device')
+  return result
+
+
+def _get_shared_name():
+  global _shared_name_counter
+
+  with _module_lock:
+    val = _shared_name_counter
+    _shared_name_counter += 1
+  return 'c%s' % val
+
+
+def _check_device(tensor, expected=None):
+  if not device.canonical_name(tensor.device):
+    raise ValueError('Device assignment required for rccl collective ops')
+  if expected and expected != tensor.device:
+    raise ValueError('Expected device %s, got %s' % (expected, tensor.device))
+
+
+def _maybe_load_rccl_ops_so():
+  """Loads rccl ops so if it hasn't been loaded already."""
+
+  with _module_lock:
+    global _rccl_ops_so
+    if not _rccl_ops_so:
+      _rccl_ops_so = loader.load_op_library(
+          resource_loader.get_path_to_datafile('_rccl_ops.so'))
+
+
+def _validate_and_load_rccl_so():
+  """Validates calling context and loads rccl ops so file.
+
+  Raises:
+    ValueError: Ops are not supported.
+    errors_impl.NotFoundError: rccl library is not installed.
+  """
+
+  if context.executing_eagerly():
+    raise ValueError('Rccl ops are not supported in eager mode')
+
+  _maybe_load_rccl_ops_so()

--- a/tensorflow/contrib/rccl/python/ops/rccl_ops_test.py
+++ b/tensorflow/contrib/rccl/python/ops/rccl_ops_test.py
@@ -1,0 +1,201 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for rccl ops. See also the cc test for rccl_communicator."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from functools import partial
+import numpy as np
+
+from tensorflow.contrib import rccl
+from tensorflow.python.framework import errors
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gradients
+from tensorflow.python.platform import test
+
+
+def _DeviceTensors(tensors, devices):
+  res = []
+  for t, d in zip(tensors, devices):
+    with ops.device(d):
+      res.append(array_ops.identity(t))
+  return res
+
+
+def _RcclAllReduce(rccl_fun, tensors, devices):
+  return rccl_fun(_DeviceTensors(tensors, devices))
+
+
+def _RcclReduce(rccl_fun, tensors, devices):
+  receiver = np.random.randint(0, len(devices))
+  with ops.device(devices[receiver]):
+    return [rccl_fun(_DeviceTensors(tensors, devices))]
+
+
+def _RcclBroadcast(tensors, devices):
+  sender = np.random.randint(0, len(devices))
+  with ops.device(devices[sender]):
+    tensor = array_ops.identity(tensors[0])
+    broadcast = rccl.broadcast(tensor)
+  return _DeviceTensors([broadcast] * len(devices), devices)
+
+
+class RcclTestCase(test.TestCase):
+
+  def assertNotEmpty(self, obj):
+    self.assertTrue(obj)
+
+  def _Test(self,
+            rccl_reduce,
+            numpy_fn,
+            dtypes=[np.float16, np.float32, np.int32, np.int64, np.float64],
+            device_sets=(['/device:GPU:1', '/device:GPU:2', '/device:GPU:0'],
+                         ['/device:GPU:1', '/device:GPU:0'])):
+    """Tests that rccl_reduce does the same as reduction with numpy_fn.
+
+    Args:
+      rccl_reduce: A function taking a list of tensors and a list of devices,
+          and returns a list of reduced tensors and a list of ops to perform the
+          reduction.
+      numpy_fn: A function taking two tensors and returning the reduction of the
+          two.
+      dtypes: Tuple of dtypes to run test on.
+      device_sets: Tuple of virtual devices to run test on.
+    """
+    for dtype in dtypes:
+      # Create session inside outer loop to test use of
+      # same communicator across multiple sessions.
+      with self.test_session(use_gpu=True) as sess:
+
+        for devices in device_sets:
+          shape = (3, 4)
+          random = (np.random.random_sample(shape) - .5) * 1024
+          tensors = []
+          for _ in devices:
+            tensors.append(random.astype(dtype))
+          np_ans = tensors[0]
+          for t in tensors[1:]:
+            np_ans = numpy_fn(np_ans, t)
+
+          reduce_tensors = rccl_reduce(tensors, devices)
+          self.assertNotEmpty(reduce_tensors)
+
+          # Test shape inference.
+          for r in reduce_tensors:
+            self.assertEqual(shape, r.get_shape())
+
+          result_tensors = [array_ops.identity(t) for t in reduce_tensors]
+
+          # Check GPU availability *after* creating session, see b/68975239.
+          if not test.is_gpu_available():
+            # If no GPU is available, only test graph construction.
+            continue
+
+          # Test execution and results.
+          for t in sess.run(result_tensors):
+            self.assertAllClose(t, np_ans)
+
+  def _TestGradient(self, rccl_reduce, numpy_fn):
+    """Tests the gradient of rccl_reduce.
+
+    Args:
+      rccl_reduce: A function taking a list of tensors and a list of devices,
+          and returns a list of reduced tensors and a list of ops to perform the
+          reduction.
+      numpy_fn: A function taking two tensors and returning the gradient of the
+          reduction of the two.
+    """
+
+    def _Gradient(tensors, devices):
+      inputs = [array_ops.placeholder(t.dtype, t.shape) for t in tensors]
+      reduce_tensors = rccl_reduce(inputs, devices)
+      losses = _DeviceTensors(tensors, [t.device for t in reduce_tensors])
+      grads = gradients.gradients(
+          reduce_tensors, inputs, losses, colocate_gradients_with_ops=True)
+      return [g for g in grads if g is not None]
+
+    self._Test(_Gradient, numpy_fn, dtypes=[np.float16, np.float32, np.float64])
+
+
+class AllReduceTest(RcclTestCase):
+
+  def testAllReduce(self):
+    self._Test(partial(_RcclAllReduce, rccl.all_sum), lambda x, y: x + y)
+    self._Test(partial(_RcclAllReduce, rccl.all_prod), lambda x, y: x * y)
+    self._Test(partial(_RcclAllReduce, rccl.all_min), np.minimum)
+    self._Test(partial(_RcclAllReduce, rccl.all_max), np.maximum)
+
+  def testAllSumGrad(self):
+    self._TestGradient(
+        partial(_RcclAllReduce, rccl.all_sum), lambda x, y: x + y)
+
+  def testErrors(self):
+    with self.assertRaisesRegexp(ValueError, 'Device assignment required'):
+      rccl.all_sum([array_ops.identity(np.random.random_sample((3, 4)))])
+    with self.assertRaisesRegexp(ValueError, 'Must pass >0 tensors'):
+      rccl.all_sum([])
+
+
+class SingleReduceTest(RcclTestCase):
+
+  def testSum(self):
+    self._Test(partial(_RcclReduce, rccl.reduce_sum), lambda x, y: x + y)
+
+  def testSumGrad(self):
+    self._TestGradient(partial(_RcclReduce, rccl.reduce_sum), lambda x, y: x)
+
+
+class BroadcastTest(RcclTestCase):
+
+  def testBroadcast(self):
+    self._Test(_RcclBroadcast, lambda x, y: x)
+
+  def testBroadcastSingleDevice(self):
+    # Broadcasts on a single device are removed completely during rewrite.
+    self._Test(_RcclBroadcast, lambda x, y: x,
+               device_sets=(['/device:GPU:0', '/device:GPU:0'],))
+
+  def testBroadcastToCpuError(self):
+    try:
+      # Broadcasts to CPU is not supported.
+      self._Test(_RcclBroadcast, lambda x, y: x,
+                 device_sets=(['/device:GPU:0', '/device:CPU:0'],))
+    except errors.NotFoundError as e:
+      self.assertRegexpMatches(
+          str(e), "No registered '_RcclBroadcastRecv' OpKernel for CPU devices")
+    else:
+      # Session isn't executed when no GPU is available.
+      if test.is_gpu_available():
+        self.fail("Didn't raise NotFoundError trying to broadcast to CPU")
+
+
+class CombinedTest(RcclTestCase):
+  """Test all-reduce vs. single-reduce plus broadcast in one session.run."""
+
+  def _Combined(self, tensors, devices):
+    all_reduce_tensors = _RcclAllReduce(rccl.all_sum, tensors, devices)
+    single_reduce_tensors = _RcclReduce(rccl.reduce_sum, tensors, devices)
+    broadcast_tensors = _RcclBroadcast(single_reduce_tensors, devices)
+    return all_reduce_tensors + broadcast_tensors
+
+  def testCombined(self):
+    self._Test(self._Combined, lambda x, y: x + y)
+
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow/core/util/port.cc
+++ b/tensorflow/core/util/port.cc
@@ -29,6 +29,14 @@ bool IsGoogleCudaEnabled() {
 #endif
 }
 
+bool IsBuiltWithROCm() {
+#if TENSORFLOW_USE_ROCM
+  return true;
+#else
+  return false;
+#endif
+}
+
 bool CudaSupportsHalfMatMulAndConv() {
 #if GOOGLE_CUDA
   return true;

--- a/tensorflow/core/util/port.h
+++ b/tensorflow/core/util/port.h
@@ -21,6 +21,9 @@ namespace tensorflow {
 // Returns true if GOOGLE_CUDA is defined.
 bool IsGoogleCudaEnabled();
 
+// Returns true if TENSORFLOW_USE_ROCM is defined. (i.e. TF is built with ROCm)
+bool IsBuiltWithROCm();
+
 // Returns true if GOOGLE_CUDA is defined, and the given CUDA version supports
 // half-precision matrix multiplications and convolution operations.
 bool CudaSupportsHalfMatMulAndConv();

--- a/tensorflow/python/distribute/BUILD
+++ b/tensorflow/python/distribute/BUILD
@@ -21,6 +21,7 @@ py_library(
         "//tensorflow/python:framework_ops",
         "//tensorflow/python:math_ops",
         "//tensorflow/python:nccl_ops",
+        "//tensorflow/contrib/rccl:rccl_py",
     ],
 )
 

--- a/tensorflow/python/distribute/all_reduce.py
+++ b/tensorflow/python/distribute/all_reduce.py
@@ -21,11 +21,15 @@ from __future__ import print_function
 import collections
 import math
 
+from tensorflow.python import pywrap_tensorflow
 from tensorflow.python.framework import device as device_lib
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import nccl_ops
+if pywrap_tensorflow.IsBuiltWithROCm():
+  from tensorflow.contrib import rccl as nccl_ops
+else:
+  from tensorflow.python.ops import nccl_ops
 
 
 def _flatten_tensors(tensors):

--- a/tensorflow/python/distribute/cross_device_utils.py
+++ b/tensorflow/python/distribute/cross_device_utils.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import collections as pycoll
 import threading
 
+from tensorflow.python import pywrap_tensorflow
 from tensorflow.python.distribute import all_reduce
 from tensorflow.python.distribute import values as value_lib
 from tensorflow.python.framework import device as pydev
@@ -30,7 +31,10 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import collective_ops
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import nccl_ops
+if pywrap_tensorflow.IsBuiltWithROCm():
+  from tensorflow.contrib import rccl as nccl_ops
+else:
+  from tensorflow.python.ops import nccl_ops
 
 
 def aggregate_gradients_using_nccl(replica_grads):

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -236,6 +236,10 @@ def IsGoogleCudaEnabled():
   return pywrap_tensorflow.IsGoogleCudaEnabled()
 
 
+def IsBuiltWithROCm():
+  return pywrap_tensorflow.IsBuiltWithROCm()
+
+
 def CudaSupportsHalfMatMulAndConv():
   return pywrap_tensorflow.CudaSupportsHalfMatMulAndConv()
 

--- a/tensorflow/python/framework/test_util_test.py
+++ b/tensorflow/python/framework/test_util_test.py
@@ -111,6 +111,14 @@ class TestUtilTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     else:
       print("GoogleCuda is disabled")
 
+  def testIsBuiltWithROCm(self):
+    # The test doesn't assert anything. It ensures the py wrapper
+    # function is generated correctly.
+    if test_util.IsBuiltWithROCm():
+      print("Tensorflow build has ROCm support")
+    else:
+      print("Tensorflow build does not have ROCm support")
+
   def testIsMklEnabled(self):
     # This test doesn't assert anything.
     # It ensures the py wrapper function is generated correctly.

--- a/tensorflow/python/platform/test.py
+++ b/tensorflow/python/platform/test.py
@@ -94,3 +94,9 @@ def test_src_dir_path(relative_path):
 def is_built_with_cuda():
   """Returns whether TensorFlow was built with CUDA (GPU) support."""
   return _test_util.IsGoogleCudaEnabled()
+
+
+@tf_export('test.is_built_with_rocm')
+def is_built_with_rocm():
+  """Returns whether TensorFlow was built with ROCm (GPU) support."""
+  return _test_util.IsBuiltWithROCm()

--- a/tensorflow/python/platform/test.py
+++ b/tensorflow/python/platform/test.py
@@ -95,8 +95,12 @@ def is_built_with_cuda():
   """Returns whether TensorFlow was built with CUDA (GPU) support."""
   return _test_util.IsGoogleCudaEnabled()
 
-
 @tf_export('test.is_built_with_rocm')
 def is_built_with_rocm():
   """Returns whether TensorFlow was built with ROCm (GPU) support."""
   return _test_util.IsBuiltWithROCm()
+
+@tf_export('test.is_built_with_gpu_support')
+def is_built_with_gpu_support():
+  """Returns whether TensorFlow was built with ROCm (GPU) support."""
+  return is_built_with_cuda() or is_built_with_rocm()

--- a/tensorflow/python/util/port.i
+++ b/tensorflow/python/util/port.i
@@ -22,6 +22,7 @@ limitations under the License.
 %ignoreall
 %unignore tensorflow;
 %unignore tensorflow::IsGoogleCudaEnabled;
+%unignore tensorflow::IsBuiltWithROCm;
 %unignore tensorflow::CudaSupportsHalfMatMulAndConv;
 %unignore tensorflow::IsMklEnabled;
 %include "tensorflow/core/util/port.h"

--- a/tensorflow/tools/api/golden/v1/tensorflow.test.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.test.pbtxt
@@ -49,6 +49,14 @@ tf_module {
     argspec: "args=[], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "is_built_with_gpu_support"
+    argspec: "args=[], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "is_built_with_rocm"
+    argspec: "args=[], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "is_gpu_available"
     argspec: "args=[\'cuda_only\', \'min_cuda_compute_capability\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.test.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.test.pbtxt
@@ -33,6 +33,14 @@ tf_module {
     argspec: "args=[], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "is_built_with_gpu_support"
+    argspec: "args=[], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "is_built_with_rocm"
+    argspec: "args=[], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "is_gpu_available"
     argspec: "args=[\'cuda_only\', \'min_cuda_compute_capability\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -835,6 +835,17 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
         ],
     )
 
+    tf_http_archive(
+        name = "rccl_archive",
+        build_file = clean_dep("//third_party:rccl.BUILD"),
+        sha256 = "a933ffbe8a7bea816e790723cf4c4406e0899feaaa49b180432989106152a117",
+        strip_prefix = "rccl-0.7.2",
+        urls = [
+            "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/rccl/archive/0.7.2.tar.gz",
+            "https://github.com/ROCmSoftwarePlatform/rccl/archive/0.7.2.tar.gz",
+        ],
+    )
+
     ##############################################################################
     # BIND DEFINITIONS
     #

--- a/third_party/rccl.BUILD
+++ b/third_party/rccl.BUILD
@@ -34,7 +34,7 @@ genrule(
     cmd = ("sed " +
            "-e 's/@rccl_VERSION_MAJOR@/0/g' " +
            "-e 's/@rccl_VERSION_MINOR@/7/g' " +
-           "-e 's/@rccl_VERSION_PATCH@/1/g' " +
+           "-e 's/@rccl_VERSION_PATCH@/2/g' " +
            "-e 's/@rccl_VERSION_TWEAK@//g' " +
            "$< >$@"),
 )

--- a/third_party/rccl.BUILD
+++ b/third_party/rccl.BUILD
@@ -1,0 +1,40 @@
+# AMD rccl
+# A package of optimized primitives for collective multi-GPU communication.
+
+licenses(["notice"])  # BSD
+
+exports_files(["LICENSE"])
+
+load("@local_config_rocm//rocm:build_defs.bzl", "rocm_default_copts", "if_rocm")
+
+cc_library(
+    name = "rccl",
+    srcs = if_rocm(glob(["src/*.cpp"]) + glob(["src/*.h"])),
+    hdrs = if_rocm(["inc/rccl.h", "inc/rccl-version.h"]),
+    copts = [
+        "-Iexternal/rccl_archive/src",
+        "-Iexternal/rccl_archive/inc",
+        "-O3",
+    ] + rocm_default_copts(),
+    linkopts = select({
+        "//conditions:default": [
+            "-lrt",
+        ],
+    }),
+    strip_include_prefix = "inc",
+    visibility = ["//visibility:public"],
+    deps = ["@local_config_rocm//rocm:rocm_headers"],
+)
+
+genrule(
+    name = "rccl_version",
+    message = "Creating RCCL version header...",
+    srcs = ["inc/rccl-version.h.in"],
+    outs = ["inc/rccl-version.h"],
+    cmd = ("sed " +
+           "-e 's/@rccl_VERSION_MAJOR@/0/g' " +
+           "-e 's/@rccl_VERSION_MINOR@/7/g' " +
+           "-e 's/@rccl_VERSION_PATCH@/1/g' " +
+           "-e 's/@rccl_VERSION_TWEAK@//g' " +
+           "$< >$@"),
+)


### PR DESCRIPTION
These contributed RCCL ops are based on the NCCL ops. Due to the intentional similarities of the RCCL API to the NCCL1 API, in most cases, these can be used as a drop-in replacement for NCCL when compiling with ROCm.