### PR TITLE
[XLA/AOT] Add check for --help command line option.

### DIFF
--- a/tensorflow/compiler/aot/tfcompile_main.cc
+++ b/tensorflow/compiler/aot/tfcompile_main.cc
@@ -136,6 +136,10 @@ int main(int argc, char** argv) {
 
   tensorflow::string usage = tensorflow::tfcompile::kUsageHeader;
   usage += tensorflow::Flags::Usage(argv[0], flag_list);
+  if (argc > 1 && !strcmp(argv[1], "--help")) {
+    std::cerr << usage << "\n\n";
+    return 0;
+  }
   bool parsed_flags_ok = tensorflow::Flags::Parse(&argc, argv, flag_list);
   QCHECK(parsed_flags_ok) << "\n" << usage;
 


### PR DESCRIPTION
By default Flags::Parse from tensorflow util returns false
if argv[1] == "--help" and in this case tfcompile fails with
SIGABRT.

Example:
tfcompile --help

Output:
Aborted (core dumped)
