### PR TITLE
[tf.keras] Enable tf.keras.callbacks.CallbackList API for tf.keras

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -157,6 +157,7 @@ def make_logs(model, logs, outputs, mode, prefix=''):
   return logs
 
 
+@tf_export('keras.callbacks.CallbackList')
 class CallbackList(object):
   """Container abstracting a list of callbacks.
 


### PR DESCRIPTION
In keras I'm used to use `keras.callbacks.CallbackList` I'd like to be able to use it also in the tf.keras this PR should enable the API `tf.keras.callbacks.CallbackList`.