### PR TITLE
Fix: protobuf hardcoded url in contrib/makefile

### DIFF
--- a/tensorflow/contrib/makefile/download_dependencies.sh
+++ b/tensorflow/contrib/makefile/download_dependencies.sh
@@ -34,7 +34,7 @@ NSYNC_URL="$(grep -o 'https://mirror.bazel.build/github.com/google/nsync/.*tar\.
 # 1.10 branch does not work. `make distclean` fails and blocks the build
 # process. For now we're hardcoding to the version which is used by
 # TensorFlow 1.9.
-PROTOBUF_URL="https://mirror.bazel.build/github.com/google/protobuf/archive/v3.6.0.tar.gz"
+PROTOBUF_URL="$(grep -o 'https://github.com/google/protobuf/.*tar\.gz' "${BZL_FILE_PATH}" | head -n1)"
 # TODO (yongtang): Replace the following with 'https://mirror.bazel.build/github.com/google/re2/.*tar\.gz' once
 # the archive has been propagated in mirror.bazel.build.
 RE2_URL="$(grep -o 'https://github.com/google/re2/.*tar\.gz' "${BZL_FILE_PATH}" | head -n1)"


### PR DESCRIPTION
Fixed contrib/makefile/download_dependencies.sh protobuf hardcoded url.

It will now look for the required version in the bazel workspace file instead of downloading an incompatible version whenever there is a change.