### PR TITLE
[WIP] Add tensor forest classification train in core 

### DIFF
--- a/tensorflow/core/kernels/tensor_forest/BUILD
+++ b/tensorflow/core/kernels/tensor_forest/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core/kernels/boosted_trees:boosted_trees_proto_cc",
+        "//tensorflow/core/kernels/tensor_forest:tensor_forest_proto_cc",
     ],
 )
 
@@ -43,6 +44,7 @@ tf_kernel_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:tensor_forest_ops_op_lib",
         "//tensorflow/core/kernels/boosted_trees:boosted_trees_proto_cc",
+        "//tensorflow/core/kernels/tensor_forest:tensor_forest_proto_cc",
     ],
 )
 

--- a/tensorflow/core/kernels/tensor_forest/BUILD
+++ b/tensorflow/core/kernels/tensor_forest/BUILD
@@ -8,6 +8,20 @@ package(
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_kernel_library")
+load(
+    "//tensorflow/core:platform/default/build_config.bzl",
+    "tf_proto_library",
+)
+
+tf_proto_library(
+    name = "tensor_forest_proto",
+    srcs = ["tensor_forest.proto"],
+    cc_api_version = 2,
+    protodeps = [
+        "//tensorflow/core/kernels/boosted_trees:boosted_trees_proto",
+	],
+    visibility = ["//visibility:public"],
+)
 
 cc_library(
     name = "resources",
@@ -45,9 +59,23 @@ tf_kernel_library(
 )
 
 tf_kernel_library(
+    name = "train_ops",
+    srcs = ["train_ops.cc"],
+    deps = [
+        ":resources",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:tensor_forest_ops_op_lib",
+        "//tensorflow/core/kernels/boosted_trees:boosted_trees_proto_cc",
+        "//tensorflow/core/kernels/tensor_forest:tensor_forest_proto_cc",
+    ],
+)
+
+tf_kernel_library(
     name = "tensor_forest_ops",
     deps = [
         ":prediction_ops",
         ":resource_ops",
+	":train_ops",
     ],
 )

--- a/tensorflow/core/kernels/tensor_forest/resource_ops.cc
+++ b/tensorflow/core/kernels/tensor_forest/resource_ops.cc
@@ -25,7 +25,7 @@ namespace tensorflow {
 class TensorForestCreateTreeVariableOp : public OpKernel {
  public:
   explicit TensorForestCreateTreeVariableOp(OpKernelConstruction* context)
-      : OpKernel(context) {}
+      : OpKernel(context){};
 
   void Compute(OpKernelContext* context) override {
     const Tensor* tree_config_t;
@@ -114,21 +114,113 @@ class TensorForestTreeSizeOp : public OpKernel {
   }
 };
 
+class TensorForestCreateFertileStatsVariableOp : public OpKernel {
+ public:
+  explicit TensorForestCreateFertileStatsVariableOp(
+      OpKernelConstruction* context)
+      : OpKernel(context){};
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* stats_config_t;
+    OP_REQUIRES_OK(context, context->input("stats_config", &stats_config_t));
+    auto* result = new TensorForestFertileStatsResource();
+
+    if (!result->InitFromSerialized(stats_config_t->scalar<string>()())) {
+      result->Unref();
+      OP_REQUIRES(context, false,
+                  errors::InvalidArgument("Unable to parse stats config."));
+    }
+
+    // Only create one, if one does not exist already. Report status for all
+    // other exceptions.
+    auto status = CreateResource(context, HandleFromInput(context, 0), result);
+    if (!status.ok() && status.code() != tensorflow::error::ALREADY_EXISTS) {
+      OP_REQUIRES(context, false, status);
+    }
+  }
+};
+
+// Op for serializing a model.
+class TensorForestFertileStatsSerializeOp : public OpKernel {
+ public:
+  explicit TensorForestFertileStatsSerializeOp(OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    TensorForestFertileStatsResource* fertile_stats_resource;
+    OP_REQUIRES_OK(context, LookupResource(context, HandleFromInput(context, 0),
+                                           &fertile_stats_resource));
+    mutex_lock l(*fertile_stats_resource->get_mutex());
+    core::ScopedUnref unref_me(fertile_stats_resource);
+
+    Tensor* output_config_t = nullptr;
+    OP_REQUIRES_OK(
+        context, context->allocate_output(0, TensorShape(), &output_config_t));
+    output_config_t->scalar<string>()() =
+        fertile_stats_resource->fertile_stats().SerializeAsString();
+  }
+};
+
+// Op for deserializing a stats variable from a checkpoint.
+class TensorForestFertileStatsDeserializeOp : public OpKernel {
+ public:
+  explicit TensorForestFertileStatsDeserializeOp(OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    TensorForestFertileStatsResource* fertile_stats_resource;
+    OP_REQUIRES_OK(context, LookupResource(context, HandleFromInput(context, 0),
+                                           &fertile_stats_resource));
+    mutex_lock l(*fertile_stats_resource->get_mutex());
+    core::ScopedUnref unref_me(fertile_stats_resource);
+
+    const Tensor* stats_config_t;
+    OP_REQUIRES_OK(context, context->input("stats_config", &stats_config_t));
+
+    // Deallocate all the previous objects on the resource.
+    fertile_stats_resource->Reset();
+
+    if (!fertile_stats_resource->InitFromSerialized(
+            stats_config_t->scalar<string>()())) {
+      OP_REQUIRES(context, false,
+                  errors::InvalidArgument("Unable to parse stats config."));
+    }
+  }
+};
+
 REGISTER_RESOURCE_HANDLE_KERNEL(TensorForestTreeResource);
+
+REGISTER_RESOURCE_HANDLE_KERNEL(TensorForestFertileStatsResource);
 
 REGISTER_KERNEL_BUILDER(
     Name("TensorForestTreeIsInitializedOp").Device(DEVICE_CPU),
     IsResourceInitialized<TensorForestTreeResource>);
 
 REGISTER_KERNEL_BUILDER(
+    Name("TensorForestFertileStatsIsInitializedOp").Device(DEVICE_CPU),
+    IsResourceInitialized<TensorForestFertileStatsResource>);
+
+REGISTER_KERNEL_BUILDER(
     Name("TensorForestCreateTreeVariable").Device(DEVICE_CPU),
     TensorForestCreateTreeVariableOp);
+
+REGISTER_KERNEL_BUILDER(
+    Name("TensorForestCreateFertileStatsVariable").Device(DEVICE_CPU),
+    TensorForestCreateFertileStatsVariableOp);
 
 REGISTER_KERNEL_BUILDER(Name("TensorForestTreeSerialize").Device(DEVICE_CPU),
                         TensorForestTreeSerializeOp);
 
 REGISTER_KERNEL_BUILDER(Name("TensorForestTreeDeserialize").Device(DEVICE_CPU),
                         TensorForestTreeDeserializeOp);
+
+REGISTER_KERNEL_BUILDER(
+    Name("TensorForestFertileStatsSerialize").Device(DEVICE_CPU),
+    TensorForestFertileStatsSerializeOp);
+
+REGISTER_KERNEL_BUILDER(
+    Name("TensorForestFertileStatsDeserialize").Device(DEVICE_CPU),
+    TensorForestFertileStatsDeserializeOp);
 
 REGISTER_KERNEL_BUILDER(Name("TensorForestTreeSize").Device(DEVICE_CPU),
                         TensorForestTreeSizeOp);

--- a/tensorflow/core/kernels/tensor_forest/resources.cc
+++ b/tensorflow/core/kernels/tensor_forest/resources.cc
@@ -67,5 +67,165 @@ void TensorForestTreeResource::Reset() {
   DCHECK_EQ(0, arena_.SpaceAllocated());
   decision_tree_ = protobuf::Arena::CreateMessage<boosted_trees::Tree>(&arena_);
 }
+void TensorForestTreeResource::SplitNode(const int32 node,
+                                         tensor_forest::FertileSlot* slot,
+                                         tensor_forest::SplitCandidate* best,
+                                         std::vector<int32>* new_children) {
+  using boosted_trees::Leaf;
+  using boosted_trees::Node;
+  auto current_split =
+      decision_tree_->mutable_nodes(node)->mutable_dense_split();
+  current_split->Swap(best->mutable_split());
+  // add left leaf
+  auto* new_left = decision_tree_->add_nodes();
+  new_left->mutable_leaf()->mutable_vector()->Swap(
+      best->mutable_left_leaf_stats()->mutable_counts_or_sums());
+  new_children->push_back(decision_tree_->nodes_size());
+  // add right leaf
+  auto* new_right = decision_tree_->add_nodes();
+  for (int i = 0; i <= slot->leaf_stats().counts_or_sums().value_size(); i++) {
+    new_right->mutable_leaf()->mutable_vector()->add_value(
+        slot->leaf_stats().counts_or_sums().value(i) -
+        best->left_leaf_stats().counts_or_sums().value(i));
+  }
+  new_children->push_back(decision_tree_->nodes_size());
+};
+
+bool TensorForestFertileStatsResource::InitFromSerialized(
+    const string& serialized) {
+  return ParseProtoUnlimited(fertile_stats_, serialized);
+};
+
+void TensorForestFertileStatsResource::Reset() {
+  arena_.Reset();
+  CHECK_EQ(0, arena_.SpaceAllocated());
+  fertile_stats_ =
+      protobuf::Arena::CreateMessage<tensor_forest::FertileStats>(&arena_);
+};
+
+const bool TensorForestFertileStatsResource::IsSlotInitialized(
+    const int32 node_id, const int32 splits_to_consider) const {
+  if (fertile_stats_->node_to_slot().count(node_id) > 0) {
+    auto slot = fertile_stats_->node_to_slot().at(node_id);
+    return slot.leaf_stats().weight_sum() > 0 &&
+           slot.candidate_size() > splits_to_consider;
+  } else {
+    return false;
+  }
+};
+
+const bool TensorForestFertileStatsResource::IsSlotFinished(
+    const int32 node_id, const int32 split_nodes_after_samples,
+    const int32 splits_to_consider) const {
+  if (IsSlotInitialized(node_id, splits_to_consider)) {
+    auto slot = fertile_stats_->node_to_slot().at(node_id);
+    return slot.leaf_stats().weight_sum() > split_nodes_after_samples;
+  }
+  return false;
+};
+
+void TensorForestFertileStatsResource::UpdateSlotStats(
+    const bool is_regression, const int32 node_id, const int32 example_id,
+    const int32 num_targets, const TTypes<float>::ConstMatrix* dense_feature,
+    const TTypes<float>::ConstMatrix* labels) {
+  float incoming_weight = 1.0;
+  auto slot = fertile_stats_->node_to_slot().at(node_id);
+
+  auto label = (*labels)(example_id, 0);
+  float old_total_weight = slot.leaf_stats().counts_or_sums().value(label);
+
+  slot.mutable_leaf_stats()->set_weight_sum(incoming_weight +
+                                            slot->leaf_stats()->weight_sum());
+  slot.mutable_leaf_stats()->mutable_counts_or_sums()->set_value(
+      label, old_total_weight + incoming_weight);
+
+  for (auto candidate : slot.candidates()) {
+    float old_left_weight =
+        candidate.left_leaf_stats().counts_or_sums().value(label);
+
+    if ((*dense_feature)(example_id, candidate.split().feature_id()) >=
+        candidate.split().threshold()) {
+      candidate.mutable_left_split_stats()->mutable_sum()->set_value(
+          label,
+          candidate.left_split_stats().sum().value(label) + incoming_weight);
+
+      float new_weight = old_left_weight + incoming_weight;
+
+      candidate.mutable_left_split_stats()->mutable_sum_of_square()->set_value(
+          0, candidate.left_split_stats().sum_of_square().value(0) -
+                 old_left_weight * old_left_weight + new_weight * new_weight);
+
+      candidate.mutable_left_leaf_stats()->set_weight_sum(
+          incoming_weight + candidate.left_leaf_stats().weight_sum());
+
+      candidate.mutable_left_leaf_stats()->mutable_counts_or_sums()->set_value(
+          label, new_weight);
+
+    } else {
+      float old_right_weight = old_total_weight - old_left_weight;
+
+      candidate.mutable_right_split_stats()->mutable_sum()->set_value(
+          label,
+          candidate.right_split_stats().sum().value(label) + incoming_weight);
+
+      float new_weight = old_right_weight + incoming_weight;
+
+      candidate.mutable_right_split_stats()->mutable_sum_of_square()->set_value(
+          0, candidate.right_split_stats().sum_of_square().value(0) -
+                 old_right_weight * old_right_weight + new_weight * new_weight);
+    }
+  }
+};
+
+const bool TensorForestFertileStatsResource::BestSplitFromSlot(
+    const int32 node_id, tensor_forest::FertileSlot* slot,
+    tensor_forest::SplitCandidate* best) {
+  auto slot = fertile_stats_->node_to_slot().at(node_id);
+  float min_score = FLT_MAX;
+  for (auto candidate : slot.candidates()) {
+    float left_gini =
+        1 - candidate.left_split_stats().sum_of_square().value(0) /
+                (candidate.left_split_stats().sum() *
+                 candidate.left_split_stats().sum());
+    float right_gini =
+        1 - candidate.right_split_stats().sum_of_square().value(0) /
+                (candidate.right_split_stats().sum() *
+                 candidate.right_split_stats().sum());
+
+    if (left_sum > 0 && right_sum > 0 && left_gini + right_gini < min_score) {
+      min_score = left_gini + right_gini;
+      best = &candidate;
+    }
+  }
+  return min_score != FLT_MAX;
+}
+
+const bool TensorForestFertileStatsResource::AddSplitToSlot(
+    const int32 node_id, const int32 feature_id, const float threshold,
+    const int32 example_id, const int32 num_targets,
+    const TTypes<float>::ConstMatrix* dense_feature,
+    const TTypes<float>::ConstMatrix* labels) {
+  auto slot = fertile_stats_->node_to_slot().at(node_id);
+  slot.mutable_leaf_stats()->set_weight_sum(slot.leaf_stats().weight_sum() + 1);
+  auto candidate = slot.add_candidates();
+  auto split = candidate->mutable_split();
+  split->set_threshold(threshold);
+  split->set_feature_id(feature_id);
+  float incoming_weight = 1.0;
+  for (int i = 0; i < num_targets; i++) {
+    auto label = (*labels)(example_id, i);
+
+    slot.mutable_leaf_stats()->mutable_counts_or_sums()->set_value(
+        label,
+        slot.leaf_stats().counts_or_sums().value(label) + incoming_weight);
+
+    auto* mutable_left_split_stats = candidate->mutable_left_split_stats();
+    mutable_left_split_stats->mutable_sum()->set_value(
+        label,
+        candidate->left_split_stats().sum().value(label) + incoming_weight);
+    mutable_left_split_stats->mutable_sum_of_square()->set_value(
+        0, incoming_weight * incoming_weight);
+  }
+};
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/tensor_forest/resources.h
+++ b/tensorflow/core/kernels/tensor_forest/resources.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "tensorflow/core/framework/resource_mgr.h"
 #include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/kernels/tensor_forest/tensor_forest.pb.h"
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/protobuf.h"
@@ -55,7 +56,7 @@ class TensorForestTreeResource : public ResourceBase {
   const int32 TraverseTree(const int32 example_id,
                            const TTypes<float>::ConstMatrix* dense_data) const;
 
-  void SplitNode(const int32 node, tensor_forest::FertileSlot* slot,
+  void SplitNode(const int32 node, tensor_forest::FertileSlot& slot,
                  tensor_forest::SplitCandidate* best,
                  std::vector<int32>* new_children);
 
@@ -106,9 +107,12 @@ class TensorForestFertileStatsResource : public ResourceBase {
                             const TTypes<float>::ConstMatrix* dense_feature,
                             const TTypes<float>::ConstMatrix* labels);
 
-  const bool BestSplitFromSlot(const int32 node_id,
-                               tensor_forest::FertileSlot* slot,
-                               tensor_forest::SplitCandidate* best);
+  bool BestSplitFromSlot(tensor_forest::FertileSlot& slot,
+                         tensor_forest::SplitCandidate* best);
+
+  const tensor_forest::FertileSlot& get_slot(const int32 node_id) {
+    return fertile_stats_->node_to_slot().at(node_id);
+  }
 
   void Allocate(const int32 node_id);
 

--- a/tensorflow/core/kernels/tensor_forest/tensor_forest.proto
+++ b/tensorflow/core/kernels/tensor_forest/tensor_forest.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package tensorflow.tensor_forest;
+option cc_enable_arenas = true;
+option java_outer_classname = "TensorForestProtos";
+option java_multiple_files = true;
+option java_package = "org.tensorflow.framework";
+
+import "tensorflow/core/kernels/boosted_trees/boosted_trees.proto";
+
+message SplitStats {
+  // For classification,
+  // we store the sum of example weights and the sum of the squares of
+  // example weights.  Gini(X) = 1 - \sum_i{(X_i/n)^2}
+  // = 1 - \sum_i{(x_i/n)^2} /n^2 = 1 - sum_of_square/square_of_sum
+  // = 1 - sum_of_square/sum*sum
+
+  // X_i\weight = LeafStat->counts_or_sums(label) using as counts
+  // new_weight = weight + incoming_weight
+  // sum -> sum + incoming_weight
+  // sum_of_square -> sum_of_square - (weight ^ 2) + (new_weight ^ 2)
+  // since classification only need 1 d of statics, we use the first dimension
+  // of the vector
+
+  // For regression,
+  // we store sum of example weights and sum of square of
+  // example weights. Var(X_i) = E(X_i^2)-E(X_i)^2 We can use
+  // left\right_variance = sum_of_square/n - (sum/n)^2
+
+  // X_i\sum_i = LeafStat->counts_or_sums(label) using as sums
+  // sum_i -> sum_i + incoming_weight
+  // sum_of_square_i -> sum_of_square_i + incoming_weight*incoming_weight
+  boosted_trees.Vector sum = 1;
+  boosted_trees.Vector sum_of_square = 2;
+}
+
+message LeafStat {
+  // The sum of the weights of the training examples that we have seen.
+  float weight_sum = 1;
+  boosted_trees.Vector counts_or_sums = 2;
+}
+
+message SplitCandidate {
+  // proto representing the potential node.
+  boosted_trees.DenseSplit split = 1;
+
+  // Left gini stats.
+  SplitStats left_split_stats = 2;
+
+  // Right gini stats.
+  SplitStats right_split_stats = 3;
+
+  // Right counts are inferred from FertileSlot.post_init_leaf_stats and
+  // left_stats.
+  LeafStat left_leaf_stats = 4;
+
+  // Right stats (not full counts) are kept here.
+  // LeafStat right_stats = 5;
+}
+
+message FertileSlot {
+  repeated SplitCandidate candidates = 1;
+
+  // The statistics for *all* the examples seen at this leaf after
+  // initialization.
+  LeafStat leaf_stats = 4;
+}
+
+message FertileStats {
+  // Tracks stats for each node.  node_to_slot[i] is the FertileSlot for node i.
+  // This grow dynamically as needed.
+  map<int32, FertileSlot> node_to_slot = 1;
+}

--- a/tensorflow/core/kernels/tensor_forest/train_ops.cc
+++ b/tensorflow/core/kernels/tensor_forest/train_ops.cc
@@ -1,0 +1,301 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <queue>
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/resource_mgr.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/kernels/tensor_forest/resources.h"
+#include "tensorflow/core/lib/random/philox_random.h"
+#include "tensorflow/core/lib/random/random.h"
+#include "tensorflow/core/lib/random/simple_philox.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/thread_annotations.h"
+#include "tensorflow/core/util/work_sharder.h"
+
+namespace tensorflow {
+
+class TensorForestTraverseTreeOp : public OpKernel {
+ public:
+  explicit TensorForestTraverseTreeOp(OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    TensorForestTreeResource* decision_tree_resource;
+    OP_REQUIRES_OK(context, LookupResource(context, HandleFromInput(context, 0),
+                                           &decision_tree_resource));
+    mutex_lock l(*decision_tree_resource->get_mutex());
+    core::ScopedUnref unref_me(decision_tree_resource);
+
+    const Tensor* dense_features = nullptr;
+    OP_REQUIRES_OK(context, context->input("dense_features", &dense_features));
+
+    auto data_set = dense_features->matrix<float>();
+    const int32 batch_size = dense_features->dim_size(0);
+
+    Tensor* output_predictions = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, {batch_size},
+                                                     &output_predictions));
+    auto out = output_predictions->matrix<int32>();
+
+    if (decision_tree_resource->GetSize() <= 1) {
+      out.setZero();
+      return;
+    }
+
+    auto* worker_threads = context->device()->tensorflow_cpu_worker_threads();
+    const int32 num_threads = worker_threads->num_threads;
+    const int64 cost_per_traverse = 500;
+    auto traverse = [&out, &data_set, decision_tree_resource](int64 start,
+                                                              int64 end) {
+      for (int example_id = start; example_id < end; ++example_id) {
+        out(example_id) =
+            decision_tree_resource->TraverseTree(example_id, &data_set);
+      };
+    };
+    Shard(num_threads, worker_threads->workers, batch_size, cost_per_traverse,
+          traverse);
+  }
+};
+
+// Op for traversing the tree with each example, accumulating statistics, and
+// outputting node ids that are ready to split.
+class TensorForestProcessInputOp : public OpKernel {
+ public:
+  explicit TensorForestProcessInputOp(OpKernelConstruction* context)
+      : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("random_seed", &random_seed_));
+    OP_REQUIRES_OK(context, context->GetAttr("is_regression", &is_regression_));
+    OP_REQUIRES_OK(context, context->GetAttr("split_node_after_samples",
+                                             &split_node_after_samples_));
+    OP_REQUIRES_OK(context, context->GetAttr("num_splits_to_consider",
+                                             &num_splits_to_consider_));
+    // Set up the random number generator.
+    if (random_seed_ == 0) {
+      single_rand_ = std::unique_ptr<random::PhiloxRandom>(
+          new random::PhiloxRandom(random::New64()));
+    } else {
+      single_rand_ = std::unique_ptr<random::PhiloxRandom>(
+          new random::PhiloxRandom(random_seed_));
+    }
+
+    rng_ = std::unique_ptr<random::SimplePhilox>(
+        new random::SimplePhilox(single_rand_.get()));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* dense_features_t = nullptr;
+    OP_REQUIRES_OK(context,
+                   context->input("dense_features", &dense_features_t));
+    const Tensor* labels_t = nullptr;
+    OP_REQUIRES_OK(context, context->input("labels", &labels_t));
+    const Tensor* leaf_ids_t = nullptr;
+    OP_REQUIRES_OK(context, context->input("leaf_ids", &leaf_ids_t));
+
+    TensorForestFertileStatsResource* fertile_stats_resource;
+    OP_REQUIRES_OK(context, LookupResource(context, HandleFromInput(context, 0),
+                                           &fertile_stats_resource));
+
+    mutex_lock l(*fertile_stats_resource->get_mutex());
+    core::ScopedUnref unref_me(fertile_stats_resource);
+
+    const auto dense_features = dense_features_t->matrix<float>();
+    const auto labels = labels_t->matrix<float>();
+    const auto leaf_ids = leaf_ids_t->matrix<float>();
+    const int32 batch_size = dense_features_t->dim_size(0);
+    number_of_total_feature_ = dense_features_t->dim_size(1);
+
+    // Create one mutex per leaf. We need to protect access to leaf pointers,
+    // so instead of grouping examples by leaf, we spread examples out among
+    // threads to provide uniform work for each of them and protect access
+    // with mutexes.
+    std::unordered_map<int, std::unique_ptr<mutex>> locks;
+    for (int i = 0; i < batch_size; ++i) {
+      const int32 leaf_id = leaf_ids(i);
+      if (locks.find(leaf_id) == locks.end()) {
+        // TODO(gilberth): Consider using a memory pool for these.
+        locks[leaf_id] = std::unique_ptr<mutex>(new mutex);
+      }
+    }
+
+    const int32 label_dim =
+        labels_t->shape().dims() <= 1
+            ? 0
+            : static_cast<int>(labels_t->shape().dim_size(1));
+    const int32 num_targets = is_regression_ ? (std::max(1, label_dim)) : 1;
+
+    // Ids of leaves that can split.
+    std::unordered_set<int32> ready_to_split;
+    mutex set_lock;
+
+    auto worker_threads = context->device()->tensorflow_cpu_worker_threads();
+    int num_threads = worker_threads->num_threads;
+
+    // TODO(gilberth): This is a rough approximation based on measurements
+    // from a digits run on local desktop.  Heuristics might be necessary
+    // if it really matters that much.
+    const int64 costPerUpdate = 1000;
+    auto update = [this, &labels, &leaf_ids, &num_targets, &dense_features,
+                   fertile_stats_resource, &locks, &set_lock,
+                   &ready_to_split](int64 start, int64 end) {
+      // Stores leaf_id, example_id for examples that are waiting
+      // on another to finish.
+      std::queue<std::tuple<int32, int32>> waiting;
+
+      for (int example_id = start; example_id < end; example_id++) {
+        const int32 leaf_id = leaf_ids(example_id);
+        AddExample(num_targets, leaf_id, example_id, &dense_features, &labels,
+                   &locks, &waiting, fertile_stats_resource);
+      }
+
+      while (!waiting.empty()) {
+        int32 leaf_id, example_id;
+        std::tie(leaf_id, example_id) = waiting.front();
+        waiting.pop();
+        AddExample(num_targets, leaf_id, example_id, &dense_features, &labels,
+                   &locks, &waiting, fertile_stats_resource);
+      }
+
+      for (int example_id = start; example_id < end; example_id++) {
+        const int32 leaf_id = leaf_ids(example_id);
+        if (fertile_stats_resource->IsSlotFinished(
+                leaf_id, split_node_after_samples_, num_splits_to_consider_)) {
+          set_lock.lock();
+          ready_to_split.insert(leaf_id);
+          set_lock.unlock();
+        }
+      }
+    };
+
+    Shard(num_threads, worker_threads->workers, batch_size, costPerUpdate,
+          update);
+
+    Tensor* output_finished_t = nullptr;
+    TensorShape output_shape;
+    output_shape.AddDim(ready_to_split.size());
+    OP_REQUIRES_OK(
+        context, context->allocate_output(0, output_shape, &output_finished_t));
+    auto output = output_finished_t->unaligned_flat<int32>();
+    std::copy(ready_to_split.begin(), ready_to_split.end(), output.data());
+  };
+
+  void AddExample(const int32 num_targets, const int32 leaf_id,
+                  const int32 example_id,
+                  const TTypes<float>::ConstMatrix* dense_features,
+                  const TTypes<float>::ConstMatrix* labels,
+                  std::unordered_map<int, std::unique_ptr<mutex>>* locks,
+                  std::queue<std::tuple<int32, int32>>* waiting,
+                  TensorForestFertileStatsResource* fertile_stats_resource) {
+    // Try to update a leaf's stats by acquiring its lock.  If it can't be
+    // acquired, put it in a waiting queue to come back to later and try the
+    // next one.  Once all leaf_ids have been visited, cycle through the waiting
+    // ids until they're gone.
+    const std::unique_ptr<mutex>& leaf_lock = (*locks)[leaf_id];
+    if (leaf_lock->try_lock()) {
+      if (fertile_stats_resource->IsSlotInitialized(leaf_id,
+                                                    num_splits_to_consider_)) {
+        fertile_stats_resource->UpdateSlotStats(is_regression_, leaf_id,
+                                                num_targets, example_id,
+                                                dense_features, labels);
+      } else {
+        int32 feature_id;
+        {
+          mutex_lock lock(mu_);
+          feature_id = rng_->Uniform(number_of_total_feature_);
+        }
+        auto bias = (*dense_features)(example_id, feature_id);
+
+        fertile_stats_resource->AddSplitToSlot(leaf_id, feature_id, bias,
+                                               example_id, num_targets,
+                                               dense_features, labels);
+      }
+      leaf_lock->unlock();
+    } else {
+      waiting->emplace(leaf_id, example_id);
+    }
+  };
+
+ private:
+  int32 random_seed_;
+  int32 number_of_total_feature_;
+  int32 num_splits_to_consider_;
+  int32 split_node_after_samples_;
+  bool is_regression_;
+  // Mutex for using random number generator.
+  mutable mutex mu_;
+  std::unique_ptr<random::PhiloxRandom> single_rand_;
+  std::unique_ptr<random::SimplePhilox> rng_;
+};
+
+// Op for growing finished nodes.
+class TensorForestGrowTreeOp : public OpKernel {
+ public:
+  explicit TensorForestGrowTreeOp(OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    TensorForestTreeResource* tree_resource;
+    OP_REQUIRES_OK(context, LookupResource(context, HandleFromInput(context, 0),
+                                           &tree_resource));
+
+    TensorForestFertileStatsResource* fertile_stats_resource;
+    OP_REQUIRES_OK(context, LookupResource(context, HandleFromInput(context, 1),
+                                           &fertile_stats_resource));
+
+    mutex_lock l1(*fertile_stats_resource->get_mutex());
+    mutex_lock l2(*tree_resource->get_mutex());
+
+    core::ScopedUnref unref_stats(fertile_stats_resource);
+    core::ScopedUnref unref_tree(tree_resource);
+
+    const Tensor* finished_nodes_t = nullptr;
+    OP_REQUIRES_OK(context,
+                   context->input("finished_nodes", &finished_nodes_t));
+
+    auto finished = finished_nodes_t->unaligned_flat<int32>();
+
+    const int32 batch_size = finished_nodes_t->dim_size(0);
+
+    for (int32 i = 0; i < batch_size; i++) {
+      auto node = finished(i);
+      auto slot = fertile_stats_resource->GetSlot(node);
+      std::unique_ptr<tensor_forest::SplitCandidate> best_candidate(
+          new tensor_forest::SplitCandidate);
+      bool found =
+          fertile_stats_resource->BestSplitFromSlot(slot, best_candidate.get());
+      if (found) {
+        std::vector<int32> new_children;
+        tree_resource->SplitNode(node, slot, best_candidate.get(),
+                                 &new_children);
+        for (auto new_node : new_children)
+          fertile_stats_resource->Allocate(new_node);
+        //
+        // We are done with best, so it is now safe to clear node.
+        fertile_stats_resource->Clear(node);
+        DCHECK(tree_resource->NodeHasLeaf(node) == false)
+            << "Node:" << node << " should have being splitted";
+      } else {  // reset
+        fertile_stats_resource->ResetSplitStats(node);
+      }
+    }
+  }
+};
+
+REGISTER_KERNEL_BUILDER(Name("TensorForestProcessInput").Device(DEVICE_CPU),
+                        TensorForestProcessInputOp);
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/tensor_forest/train_ops.cc
+++ b/tensorflow/core/kernels/tensor_forest/train_ops.cc
@@ -52,7 +52,7 @@ class TensorForestTraverseTreeOp : public OpKernel {
                                                      &output_predictions));
     auto out = output_predictions->matrix<int32>();
 
-    if (decision_tree_resource->GetSize() <= 1) {
+    if (decision_tree_resource->get_size() <= 1) {
       out.setZero();
       return;
     }
@@ -272,7 +272,7 @@ class TensorForestGrowTreeOp : public OpKernel {
 
     for (int32 i = 0; i < batch_size; i++) {
       auto node = finished(i);
-      auto slot = fertile_stats_resource->GetSlot(node);
+      auto slot = fertile_stats_resource->get_slot(node);
       std::unique_ptr<tensor_forest::SplitCandidate> best_candidate(
           new tensor_forest::SplitCandidate);
       bool found =


### PR DESCRIPTION
According to https://github.com/tensorflow/community/blob/master/rfcs/20180626-tensor-forest.md

This is a first step. And the whole process is tracked by #21830

We are adding an canned TensorForestClassifier and TensorForestRegressor into core.

The Pr is only a third step implementing TensorForestClassifier with train only functionality.