### PR TITLE
fix return type error in python3

### DIFF
--- a/tensorflow/contrib/tpu/python/tpu/tpu_estimator.py
+++ b/tensorflow/contrib/tpu/python/tpu/tpu_estimator.py
@@ -2783,7 +2783,7 @@ def _export_output_to_tensors(export_output):
   elif isinstance(export_output, export_output_lib.RegressionOutput):
     return [export_output.value]
   elif isinstance(export_output, export_output_lib.PredictOutput):
-    return export_output.outputs.values()
+    return list(export_output.outputs.values())
   else:
     raise ValueError(
         '`export_output` must be have type `ClassificationOutput`, '


### PR DESCRIPTION
The function `_export_output_to_tensors` in [tpu_estimator.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/tpu/python/tpu/tpu_estimator.py) is expected to return a list, but the third conditional branch returns a dict_values in python3 which could potentially cause type error in some situations.
An example is when calling tf.contrib.tpu.TPUEstimator.export_savedmodel in python3.