### PR TITLE
Reverting the changes in commit 0c1eb88 which causes Resnet50 accuracy to drop significantly

### DIFF
--- a/tensorflow/core/common_runtime/function_test.cc
+++ b/tensorflow/core/common_runtime/function_test.cc
@@ -1432,9 +1432,7 @@ TEST_F(FunctionLibraryRuntimeTest, Gradient_AddSum) {
 
     GraphDef actual;
     g->ToGraphDef(&actual);
-    // The optimizer is non-deterministic, so we only check that the number of
-    // nodes is not greater than expected.
-    EXPECT_LE(actual.node_size(), expected.node_size());
+    TF_EXPECT_GRAPH_EQ(expected, actual);
   }
 }
 

--- a/tensorflow/core/graph/edgeset.cc
+++ b/tensorflow/core/graph/edgeset.cc
@@ -37,7 +37,7 @@ std::pair<EdgeSet::const_iterator, bool> EdgeSet::insert(value_type value) {
       }
     }
     // array is full. convert to set.
-    s = new gtl::FlatSet<const Edge*>;
+    s = new std::set<const Edge*>;
     for (int i = 0; i < kInline; i++) {
       s->insert(static_cast<const Edge*>(ptrs_[i]));
     }

--- a/tensorflow/core/graph/edgeset.h
+++ b/tensorflow/core/graph/edgeset.h
@@ -17,18 +17,17 @@ limitations under the License.
 #define TENSORFLOW_GRAPH_EDGESET_H_
 
 #include <stddef.h>
-
-#include "tensorflow/core/lib/gtl/flatset.h"
-#include "tensorflow/core/platform/logging.h"
+#include <set>
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/platform/types.h"
+
+#include "tensorflow/core/platform/logging.h"
 namespace tensorflow {
 
 class Edge;
 
 // An unordered set of edges.  Uses very little memory for small sets.
-// Unlike gtl::FlatSet, EdgeSet does NOT allow mutations during
-// iteration.
+// Unlike std::set, EdgeSet does NOT allow mutations during iteration.
 class EdgeSet {
  public:
   EdgeSet();
@@ -55,15 +54,12 @@ class EdgeSet {
  private:
   // Up to kInline elements are stored directly in ptrs_ (nullptr means none).
   // If ptrs_[0] == this then ptrs_[1] points to a set<const Edge*>.
-  // kInline must be >= 2, and is chosen such that ptrs_ fills a 64 byte
-  // cacheline.
-  static constexpr int kInline = 64 / sizeof(const void*);
+  static const int kInline = 4;  // Must be >= 2.
   const void* ptrs_[kInline];
 
-  gtl::FlatSet<const Edge*>* get_set() const {
+  std::set<const Edge*>* get_set() const {
     if (ptrs_[0] == this) {
-      return static_cast<gtl::FlatSet<const Edge*>*>(
-          const_cast<void*>(ptrs_[1]));
+      return static_cast<std::set<const Edge*>*>(const_cast<void*>(ptrs_[1]));
     } else {
       return nullptr;
     }
@@ -103,7 +99,7 @@ class EdgeSet::const_iterator {
   friend class EdgeSet;
 
   void const* const* array_iter_ = nullptr;
-  typename gtl::FlatSet<const Edge*>::const_iterator tree_iter_;
+  typename std::set<const Edge*>::const_iterator tree_iter_;
 
 #ifdef NDEBUG
   inline void Init(const EdgeSet* e) {}

--- a/tensorflow/core/graph/edgeset_test.cc
+++ b/tensorflow/core/graph/edgeset_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/core/graph/edgeset.h"
 
-#include <set>
 #include <vector>
 #include "tensorflow/core/graph/graph.h"
 #include "tensorflow/core/platform/test.h"
@@ -23,27 +22,30 @@ limitations under the License.
 namespace tensorflow {
 class EdgeSetTest : public ::testing::Test {
  public:
-  EdgeSetTest() : edges_(nullptr) {}
-  ~EdgeSetTest() override { delete[] edges_; }
+  EdgeSetTest() : edges_(nullptr), eset_(nullptr) {}
+
+  ~EdgeSetTest() override {
+    delete eset_;
+    delete[] edges_;
+  }
 
   void MakeEdgeSet(int n) {
-    if (edges_) {
-      delete[] edges_;
-    }
+    delete eset_;
+    delete[] edges_;
     edges_ = new Edge[n];
-    eset_.clear();
+    eset_ = new EdgeSet;
     model_.clear();
     for (int i = 0; i < n; i++) {
-      eset_.insert(&edges_[i]);
+      eset_->insert(&edges_[i]);
       model_.insert(&edges_[i]);
     }
   }
 
   void CheckSame() {
-    EXPECT_EQ(model_.size(), eset_.size());
-    EXPECT_EQ(model_.empty(), eset_.empty());
+    EXPECT_EQ(model_.size(), eset_->size());
+    EXPECT_EQ(model_.empty(), eset_->empty());
     std::vector<const Edge*> modelv(model_.begin(), model_.end());
-    std::vector<const Edge*> esetv(eset_.begin(), eset_.end());
+    std::vector<const Edge*> esetv(eset_->begin(), eset_->end());
     std::sort(modelv.begin(), modelv.end());
     std::sort(esetv.begin(), esetv.end());
     EXPECT_EQ(modelv.size(), esetv.size());
@@ -52,27 +54,26 @@ class EdgeSetTest : public ::testing::Test {
     }
   }
 
-  static constexpr int kInline = 64 / sizeof(const void*);
   Edge nonexistent_;
   Edge* edges_;
-  EdgeSet eset_;
+  EdgeSet* eset_;
   std::set<const Edge*> model_;
 };
 
 namespace {
 
 TEST_F(EdgeSetTest, Ops) {
-  for (int n : {0, 1, 2, kInline + 1}) {
+  for (int n : {0, 1, 2, 3, 4, 10}) {
     MakeEdgeSet(n);
     CheckSame();
-    EXPECT_EQ((n == 0), eset_.empty());
-    EXPECT_EQ(n, eset_.size());
+    EXPECT_EQ((n == 0), eset_->empty());
+    EXPECT_EQ(n, eset_->size());
 
-    eset_.clear();
+    eset_->clear();
     model_.clear();
     CheckSame();
 
-    eset_.insert(&edges_[0]);
+    eset_->insert(&edges_[0]);
     model_.insert(&edges_[0]);
     CheckSame();
   }
@@ -80,14 +81,15 @@ TEST_F(EdgeSetTest, Ops) {
 
 // Try insert/erase of existing elements at different positions.
 TEST_F(EdgeSetTest, Exists) {
-  for (int n : {0, 1, 2, kInline + 1}) {
+  for (int n : {0, 1, 2, 3, 4, 10}) {
     MakeEdgeSet(n);
     for (int pos = 0; pos < n; pos++) {
-      auto p = eset_.insert(&edges_[pos]);
+      MakeEdgeSet(n);
+      auto p = eset_->insert(&edges_[pos]);
       EXPECT_FALSE(p.second);
       EXPECT_EQ(&edges_[pos], *p.first);
 
-      EXPECT_EQ(1, eset_.erase(&edges_[pos]));
+      EXPECT_EQ(1, eset_->erase(&edges_[pos]));
       model_.erase(&edges_[pos]);
       CheckSame();
     }
@@ -96,10 +98,10 @@ TEST_F(EdgeSetTest, Exists) {
 
 // Try insert/erase of non-existent element.
 TEST_F(EdgeSetTest, DoesNotExist) {
-  for (int n : {0, 1, 2, kInline + 1}) {
+  for (int n : {0, 1, 2, 3, 4, 10}) {
     MakeEdgeSet(n);
-    EXPECT_EQ(0, eset_.erase(&nonexistent_));
-    auto p = eset_.insert(&nonexistent_);
+    EXPECT_EQ(0, eset_->erase(&nonexistent_));
+    auto p = eset_->insert(&nonexistent_);
     EXPECT_TRUE(p.second);
     EXPECT_EQ(&nonexistent_, *p.first);
   }

--- a/tensorflow/core/graph/graph_test.cc
+++ b/tensorflow/core/graph/graph_test.cc
@@ -799,44 +799,5 @@ BENCHMARK(BM_GraphCreation)->ArgPair(1 << 9, 16);
 BENCHMARK(BM_GraphCreation)->ArgPair(1 << 12, 16);
 BENCHMARK(BM_GraphCreation)->ArgPair(1 << 15, 16);
 
-static void BM_ToGraphDef(int iters, int num_nodes, int num_edges_per_node) {
-  testing::StopTiming();
-  const GraphDef graph_def = CreateGraphDef(num_nodes, num_edges_per_node);
-  const auto registry = OpRegistry::Global();
-  GraphConstructorOptions opts;
-  // Warmup step.
-  Graph graph(registry);
-  TF_CHECK_OK(ConvertGraphDefToGraph(opts, graph_def, &graph));
-  int64 sum = 0;
-  testing::StartTiming();
-  for (int i = 0; i < iters; ++i) {
-    GraphDef graph_def;
-    graph.ToGraphDef(&graph_def);
-    sum += graph_def.node_size();
-  }
-  VLOG(1) << sum;
-  testing::StopTiming();
-}
-BENCHMARK(BM_ToGraphDef)->ArgPair(10, 2);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 6, 2);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 9, 2);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 12, 2);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 15, 2);
-BENCHMARK(BM_ToGraphDef)->ArgPair(10, 4);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 6, 4);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 9, 4);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 12, 4);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 15, 4);
-BENCHMARK(BM_ToGraphDef)->ArgPair(10, 8);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 6, 8);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 9, 8);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 12, 8);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 15, 8);
-BENCHMARK(BM_ToGraphDef)->ArgPair(10, 16);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 6, 16);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 9, 16);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 12, 16);
-BENCHMARK(BM_ToGraphDef)->ArgPair(1 << 15, 16);
-
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/core/graph/optimizer_cse_test.cc
+++ b/tensorflow/core/graph/optimizer_cse_test.cc
@@ -337,13 +337,9 @@ TEST_F(OptimizerCSETest, Constant_Dedup) {
   EXPECT_EQ(OriginalGraph(),
             "n/_0(Const);n/_1(Const);n/_2(Const);n/_3(Const);"
             "n/_4(Const);n/_5(Const);n/_6(Const);n/_7(Const)|");
-  std::vector<string> nodes = str_util::Split(DoCSE(), ";|");
-  std::set<string> node_set(nodes.begin(), nodes.end());
-  // Expect exactly one of each type of node to be retained after CSE.
-  EXPECT_EQ(node_set.count("n/_0(Const)") + node_set.count("n/_7(Const)"), 1);
-  EXPECT_EQ(node_set.count("n/_1(Const)") + node_set.count("n/_6(Const)"), 1);
-  EXPECT_EQ(node_set.count("n/_2(Const)") + node_set.count("n/_5(Const)"), 1);
-  EXPECT_EQ(node_set.count("n/_3(Const)") + node_set.count("n/_4(Const)"), 1);
+  // In theory, there are 2^4 possible correct output of CSE.  In this
+  // test, it happens to eliminate the last 4 nodes.
+  EXPECT_EQ(DoCSE(), "n/_0(Const);n/_1(Const);n/_2(Const);n/_3(Const)|");
 }
 
 static void BM_CSE(int iters, int op_nodes) {


### PR DESCRIPTION
Commit 0c1eb88 included some changes that cause the inference accuracy of trained Resnet50 to drop to zero. Reverting these changes fixes the issue.