### PR TITLE
Improve shape function of tf.sparse_concat when inputs are fully defined

### DIFF
--- a/tensorflow/python/kernel_tests/sparse_concat_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_concat_op_test.py
@@ -337,6 +337,13 @@ class SparseConcatTest(test.TestCase):
         self.assertEqual(sp_concat.values.get_shape().as_list(), [None])
         self.assertEqual(sp_concat.dense_shape.get_shape(), [3])
 
+  def testConcatShape(self):
+    # Test case for GitHub 21964.
+    x = sparse_tensor.SparseTensor(indices=[[0,0],[1,1]], values=[1,2], dense_shape=[2,2])
+    y = sparse_tensor.SparseTensor(indices=[[0,0],[1,1]], values=[1,2], dense_shape=[2,2])
+    z = sparse_ops.sparse_concat(-1, [x,y])
+    self.assertEqual(z.get_shape().as_list(), [2, 4])
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/sparse_concat_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_concat_op_test.py
@@ -339,9 +339,11 @@ class SparseConcatTest(test.TestCase):
 
   def testConcatShape(self):
     # Test case for GitHub 21964.
-    x = sparse_tensor.SparseTensor(indices=[[0,0],[1,1]], values=[1,2], dense_shape=[2,2])
-    y = sparse_tensor.SparseTensor(indices=[[0,0],[1,1]], values=[1,2], dense_shape=[2,2])
-    z = sparse_ops.sparse_concat(-1, [x,y])
+    x = sparse_tensor.SparseTensor(
+        indices=[[0, 0], [1, 1]], values=[1, 2], dense_shape=[2, 2])
+    y = sparse_tensor.SparseTensor(
+        indices=[[0, 0], [1, 1]], values=[1, 2], dense_shape=[2, 2])
+    z = sparse_ops.sparse_concat(-1, [x, y])
     self.assertEqual(z.get_shape().as_list(), [2, 4])
 
 

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -323,7 +323,7 @@ def sparse_concat(axis,
       gen_sparse_ops.sparse_concat(inds, vals, shapes, axis, name=name))
 
   shapes_value = [tensor_util.constant_value(shape) for shape in shapes]
-  if len(shapes_value) != 0 and all(shape is not None for shape in shapes_value):
+  if not shapes_value and all(shape is not None for shape in shapes_value):
     dim = sum(shape[axis] for shape in shapes_value)
     output_shape = shapes_value[0]
     output_shape[axis] = dim

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -323,7 +323,7 @@ def sparse_concat(axis,
       gen_sparse_ops.sparse_concat(inds, vals, shapes, axis, name=name))
 
   shapes_value = [tensor_util.constant_value(shape) for shape in shapes]
-  if all(shape is not None for shape in shapes_value):
+  if len(shapes_value) != 0 and all(shape is not None for shape in shapes_value):
     dim = sum(shape[axis] for shape in shapes_value)
     output_shape = shapes_value[0]
     output_shape[axis] = dim

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -322,6 +322,12 @@ def sparse_concat(axis,
   output_ind, output_val, output_shape = (
       gen_sparse_ops.sparse_concat(inds, vals, shapes, axis, name=name))
 
+  shapes_value = [tensor_util.constant_value(shape) for shape in shapes]
+  if all(shape is not None for shape in shapes_value):
+    dim = sum(shape[axis] for shape in shapes_value)
+    output_shape = shapes_value[0]
+    output_shape[axis] = dim
+    output_shape = tensor_shape.as_shape(output_shape)
   return sparse_tensor.SparseTensor(output_ind, output_val, output_shape)
 
 

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -323,11 +323,11 @@ def sparse_concat(axis,
       gen_sparse_ops.sparse_concat(inds, vals, shapes, axis, name=name))
 
   shapes_value = [tensor_util.constant_value(shape) for shape in shapes]
-  if not shapes_value and all(shape is not None for shape in shapes_value):
+  if shapes_value and all(shape is not None for shape in shapes_value):
     dim = sum(shape[axis] for shape in shapes_value)
     output_shape = shapes_value[0]
     output_shape[axis] = dim
-    output_shape = tensor_shape.as_shape(output_shape)
+    output_shape = ops.convert_to_tensor(output_shape)
   return sparse_tensor.SparseTensor(output_ind, output_val, output_shape)
 
 


### PR DESCRIPTION

This fix tries to address the issue raised in #21964 where the shape function of tf.sparse_concat always returns `TensorShape([Dimension(None), Dimension(None)])` even if the inputs are fully defined.

This fix addresses the issue by finding the shape if the inputs are fully defined.

This fix fixes #21964.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
