### PR TITLE
lite: promote precision of quantization multiplier (r1.12 branch)

### DIFF
--- a/tensorflow/contrib/lite/kernels/kernel_util.cc
+++ b/tensorflow/contrib/lite/kernels/kernel_util.cc
@@ -26,9 +26,11 @@ TfLiteStatus GetQuantizedConvolutionMultipler(TfLiteContext* context,
                                               const TfLiteTensor* input,
                                               const TfLiteTensor* filter,
                                               const TfLiteTensor* bias,
-                                              TfLiteTensor* output,
+                                              const TfLiteTensor* output,
                                               double* multiplier) {
-  const double input_product_scale = input->params.scale * filter->params.scale;
+  const double input_scale = input->params.scale;
+  const double filter_scale = filter->params.scale;
+  const double input_product_scale = input_scale * filter_scale;
   const double bias_scale = bias->params.scale;
   const double output_scale = output->params.scale;
 

--- a/tensorflow/contrib/lite/kernels/kernel_util.h
+++ b/tensorflow/contrib/lite/kernels/kernel_util.h
@@ -91,7 +91,7 @@ TfLiteStatus GetQuantizedConvolutionMultipler(TfLiteContext* context,
                                               const TfLiteTensor* input,
                                               const TfLiteTensor* filter,
                                               const TfLiteTensor* bias,
-                                              TfLiteTensor* output,
+                                              const TfLiteTensor* output,
                                               double* multiplier);
 
 // Calculates the useful quantized range of an activation layer given its

--- a/tensorflow/contrib/lite/kernels/kernel_util_test.cc
+++ b/tensorflow/contrib/lite/kernels/kernel_util_test.cc
@@ -30,12 +30,18 @@ class KernelUtilTest : public ::testing::Test {
 
     tensor1_.dims = nullptr;
     tensor2_.dims = nullptr;
+    tensor3_.dims = nullptr;
+    tensor4_.dims = nullptr;
     tensor1_.allocation_type = kTfLiteMmapRo;
     tensor2_.allocation_type = kTfLiteMmapRo;
+    tensor3_.allocation_type = kTfLiteMmapRo;
+    tensor4_.allocation_type = kTfLiteMmapRo;
   }
   ~KernelUtilTest() override {
     TfLiteTensorFree(&tensor1_);
     TfLiteTensorFree(&tensor2_);
+    TfLiteTensorFree(&tensor3_);
+    TfLiteTensorFree(&tensor4_);
   }
 
   void SetShape(TfLiteTensor* tensor, std::initializer_list<int> dims) {
@@ -60,6 +66,8 @@ class KernelUtilTest : public ::testing::Test {
   TfLiteContext context_;
   TfLiteTensor tensor1_;
   TfLiteTensor tensor2_;
+  TfLiteTensor tensor3_;
+  TfLiteTensor tensor4_;
 };
 
 TEST_F(KernelUtilTest, SameShapeEmpty) {
@@ -140,6 +148,29 @@ TEST_F(KernelUtilTest, BroadcastShapeDifferentSizes) {
                                                   &tensor2_, &output));
   EXPECT_THAT(GetShape(output), ::testing::ElementsAre(1, 2, 3, 4));
   TfLiteIntArrayFree(output);
+}
+
+TEST_F(KernelUtilTest, QuantizedConvolutionMultipler) {
+  TfLiteTensor* input  = &tensor1_;
+  TfLiteTensor* filter = &tensor2_;
+  TfLiteTensor* bias   = &tensor3_;
+  TfLiteTensor* output = &tensor4_;
+
+  // from quantized MobileNetV1's third conv.
+  constexpr float input_output_scale = 0.023528477177023888;
+  constexpr float filter_scale       = 0.015148180536925793;
+  constexpr float bias_scale         = 0.00035641359863802791;
+  constexpr double multiplier_expected  = static_cast<double>(filter_scale);
+
+  input->params.scale  = input_output_scale;
+  output->params.scale = input_output_scale;
+  filter->params.scale = filter_scale;
+  bias->params.scale   = bias_scale;
+
+  double multiplier = 0.0f;
+  EXPECT_EQ(kTfLiteOk, GetQuantizedConvolutionMultipler(&context_,
+                          input, filter, bias, output, &multiplier));
+  EXPECT_EQ(multiplier, multiplier_expected);
 }
 
 }  // namespace

--- a/tensorflow/contrib/lite/kernels/kernel_util_test.cc
+++ b/tensorflow/contrib/lite/kernels/kernel_util_test.cc
@@ -151,25 +151,26 @@ TEST_F(KernelUtilTest, BroadcastShapeDifferentSizes) {
 }
 
 TEST_F(KernelUtilTest, QuantizedConvolutionMultipler) {
-  TfLiteTensor* input  = &tensor1_;
+  TfLiteTensor* input = &tensor1_;
   TfLiteTensor* filter = &tensor2_;
-  TfLiteTensor* bias   = &tensor3_;
+  TfLiteTensor* bias = &tensor3_;
   TfLiteTensor* output = &tensor4_;
 
   // from quantized MobileNetV1's third conv.
   constexpr float input_output_scale = 0.023528477177023888;
-  constexpr float filter_scale       = 0.015148180536925793;
-  constexpr float bias_scale         = 0.00035641359863802791;
-  constexpr double multiplier_expected  = static_cast<double>(filter_scale);
+  constexpr float filter_scale = 0.015148180536925793;
+  constexpr float bias_scale = 0.00035641359863802791;
+  constexpr double multiplier_expected = static_cast<double>(filter_scale);
 
-  input->params.scale  = input_output_scale;
+  input->params.scale = input_output_scale;
   output->params.scale = input_output_scale;
   filter->params.scale = filter_scale;
-  bias->params.scale   = bias_scale;
+  bias->params.scale = bias_scale;
 
   double multiplier = 0.0f;
-  EXPECT_EQ(kTfLiteOk, GetQuantizedConvolutionMultipler(&context_,
-                          input, filter, bias, output, &multiplier));
+  EXPECT_EQ(kTfLiteOk,
+            GetQuantizedConvolutionMultipler(&context_, input, filter, bias,
+                                             output, &multiplier));
   EXPECT_EQ(multiplier, multiplier_expected);
 }
 


### PR DESCRIPTION
The original implementation loss precision when calculating
`input_product_scale`. This patch fixes it.

Test: bazel run tensorflow/contrib/lite/kernels:kernel_util_test