### PR TITLE
Fix deprecated use of `sparse_to_dense`.

### DIFF
--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -1422,7 +1422,7 @@ def sparse_tensor_to_dense(sp_input,
   """
   sp_input = _convert_to_sparse_tensor(sp_input)
 
-  return sparse_to_dense(
+  return gen_sparse_ops.sparse_to_dense(
       sp_input.indices,
       sp_input.dense_shape,
       sp_input.values,


### PR DESCRIPTION
Calling `sparse_to_dense` gives a deprecation warning that asks users to use `sparse.to_dense`:
https://github.com/tensorflow/tensorflow/blob/71f40f044450736cd6acd29e92ffbfc0e571ee14/tensorflow/python/ops/sparse_ops.py#L952-L955

However, `sparse.to_dense` calls `sparse_to_dense`, which again produces the deprecation warning.