### PR TITLE
Reserve because we know the size before, helps save reallocation cost.

### DIFF
--- a/tensorflow/cc/tools/freeze_saved_model.cc
+++ b/tensorflow/cc/tools/freeze_saved_model.cc
@@ -124,7 +124,9 @@ Status GetVariableNameToTensorMap(
     return Status::OK();
   }
   std::vector<string> variable_names;
+  variable_names.reserve(variable_names.size());
   std::vector<string> tensor_names;
+  tensor_names.reserve(variable_names.size());
   for (const string& node_name : variable_names_set) {
     variable_names.push_back(node_name);
     NodeDef* node_def = name_to_node_map.at(node_name);


### PR DESCRIPTION
Reserve vector in advance to save reallocation cost.