### PR TITLE
Fix discrepancy between tf.placeholder and tf.sparse.placeholder

### DIFF
--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -968,7 +968,7 @@ class SparsePlaceholderTest(test.TestCase):
 
   def testPartialShapePlaceholder(self):
     foo = array_ops.sparse_placeholder(dtypes.float32, shape=(None, 47))
-    self.assertAllEqual([None, None], foo.get_shape().as_list())
+    self.assertAllEqual([None, 47], foo.get_shape().as_list())
     self.assertAllEqual([None, 2], foo.indices.get_shape().as_list())
 
   def testNoShapePlaceholder(self):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2086,10 +2086,11 @@ def _normalize_sparse_shape(shape, name):
   rank = shape.get_shape()[0] if isinstance(shape, ops.Tensor) else len(shape)
   if not isinstance(shape, ops.Tensor) and None in shape:
     if not isinstance(shape, (list, tuple)):
-        return (None, rank)
-    # In case shape is a list or tuple, we will convert None into -1 (Unknwon dims)
-    # so that the shape is preserved when calling convert_to_tensor below.
-    # This will make sure tf.sparse.placeholder accepts `(None, 4)` like tf.placeholder.
+      return (None, rank)
+    # In case shape is a list or tuple, we will convert None into
+    # -1 (Unknwon dims) so that the shape is preserved when calling
+    # convert_to_tensor below. This will make sure tf.sparse.placeholder
+    # accepts `(None, 4)` like tf.placeholder.
     shape = [dim if dim is not None else -1 for dim in shape]
   return (ops.convert_to_tensor(shape, dtype=dtypes.int64, name=name), rank)
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2087,6 +2087,9 @@ def _normalize_sparse_shape(shape, name):
   if not isinstance(shape, ops.Tensor) and None in shape:
     if not isinstance(shape, (list, tuple)):
         return (None, rank)
+    # In case shape is a list or tuple, we will convert None into -1 (Unknwon dims)
+    # so that the shape is preserved when calling convert_to_tensor below.
+    # This will make sure tf.sparse.placeholder accepts `(None, 4)` like tf.placeholder.
     shape = [dim if dim is not None else -1 for dim in shape]
   return (ops.convert_to_tensor(shape, dtype=dtypes.int64, name=name), rank)
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2085,7 +2085,9 @@ def _normalize_sparse_shape(shape, name):
     return (None, None)
   rank = shape.get_shape()[0] if isinstance(shape, ops.Tensor) else len(shape)
   if not isinstance(shape, ops.Tensor) and None in shape:
-    return (None, rank)
+    if not isinstance(shape, (list, tuple)):
+        return (None, rank)
+    shape = [dim if dim is not None else -1 for dim in shape]
   return (ops.convert_to_tensor(shape, dtype=dtypes.int64, name=name), rank)
 
 


### PR DESCRIPTION
When working on sparse placeholder I noticed that if shape is presented with `None` in any dims, the shape information is remvoed from sparse.placeholder. So `(None, 4)` will be `(None, None)`.

This is different from tf.placeholder:
```
root@ubuntu:/v# python
Python 2.7.15rc1 (default, Nov 12 2018, 14:31:15)
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import tensorflow as tf
>>> v1 = tf.placeholder(tf.float32, (None, 4))
>>> v1.get_shape()
TensorShape([Dimension(None), Dimension(4)])
>>> v2 = tf.sparse.placeholder(tf.float32, (None, 4))
>>> v2.get_shape()
TensorShape([Dimension(None), Dimension(None)])
>>>
```

This fix adds the fix so that tf.placeholder and tf.sparse.placeholder
behaves the same.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>