### PR TITLE
Fixed Typo in GO Readme

### DIFF
--- a/tensorflow/go/README.md
+++ b/tensorflow/go/README.md
@@ -23,7 +23,7 @@ from source.
 
 -   [bazel](https://www.bazel.build/versions/master/docs/install.html)
 -   Environment to build TensorFlow from source code
-    ([Linux of macOS](https://www.tensorflow.org/install/source)).
+    ([Linux or macOS](https://www.tensorflow.org/install/source)).
     If you don't need GPU support, then try the following:
 
     ```sh


### PR DESCRIPTION
Hey, I was reading the [golang readme file](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/go/README.md) and noticed a little typo in `Linux of macOS` which should probably be `Linux or macOS`. So I just fixed it.