### PR TITLE
Improving S3 File System

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -3348,6 +3348,34 @@ cc_library(
     alwayslink = 0,
 )
 
+cc_library(
+    name = "retrying_utils",
+    srcs = [
+        "platform/retrying_utils.cc",
+    ],
+    hdrs = [
+        "platform/retrying_utils.h",
+    ],
+    copts = tf_copts(),
+    deps = [
+        "//tensorflow/core:framework_headers_lib",
+        "//tensorflow/core:lib_internal",
+    ],
+)
+
+cc_library(
+    name = "retrying_file_system",
+    hdrs = [
+        "platform/retrying_file_system.h",
+    ],
+    copts = tf_copts(),
+    deps = [
+        ":retrying_utils",
+        "//tensorflow/core:framework_headers_lib",
+        "//tensorflow/core:lib_internal",
+    ],
+)
+
 # -----------------------------------------------------------------------------
 # Tests
 
@@ -4986,6 +5014,32 @@ tf_cc_tests(
         "//tensorflow/cc:client_session",
         "//tensorflow/cc:function_ops",
         "//tensorflow/cc:ops",
+    ],
+)
+
+tf_cc_test(
+    name = "retrying_file_system_test",
+    size = "small",
+    srcs = ["platform/retrying_file_system_test.cc"],
+    deps = [
+        ":retrying_file_system",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+    ],
+)
+
+tf_cc_test(
+    name = "retrying_utils_test",
+    size = "small",
+    srcs = ["platform/retrying_utils_test.cc"],
+    deps = [
+        "//tensorflow/core:retrying_utils",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
     ],
 )
 

--- a/tensorflow/core/kernels/save_restore_v2_ops.cc
+++ b/tensorflow/core/kernels/save_restore_v2_ops.cc
@@ -103,8 +103,7 @@ class SaveV2 : public OpKernel {
     const int num_tensors = static_cast<int>(tensor_names.NumElements());
     const string& prefix_string = prefix.scalar<string>()();
     const auto& tensor_names_flat = tensor_names.flat<string>();
-    const auto& shape_and_slices_flat = shape_and_slices.flat<string>();
-
+    const auto& shape_and_slices_flat = shape_and_slices.flat<string>(); 
     BundleWriter writer(Env::Default(), prefix_string);
     OP_REQUIRES_OK(context, writer.status());
     VLOG(1) << "BundleWriter, prefix_string: " << prefix_string;

--- a/tensorflow/core/platform/cloud/BUILD
+++ b/tensorflow/core/platform/cloud/BUILD
@@ -9,9 +9,9 @@ licenses(["notice"])  # Apache 2.0
 
 load(
     "//tensorflow:tensorflow.bzl",
+    "if_windows",
     "tf_cc_test",
     "tf_copts",
-    "if_windows",
 )
 
 cc_library(
@@ -83,12 +83,12 @@ cc_library(
         ":google_auth_provider",
         ":http_request",
         ":ram_file_block_cache",
-        ":retrying_file_system",
-        ":retrying_utils",
         ":time_util",
         "//tensorflow/core:framework_headers_lib",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
+        "//tensorflow/core:retrying_file_system",
+        "//tensorflow/core:retrying_utils",
         "@jsoncpp_git//:jsoncpp",
     ],
     alwayslink = 1,
@@ -148,9 +148,9 @@ cc_library(
     deps = [
         ":compute_engine_metadata_client",
         ":oauth_client",
-        ":retrying_utils",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
+        "//tensorflow/core:retrying_utils",
         "@jsoncpp_git//:jsoncpp",
     ],
 )
@@ -168,9 +168,9 @@ cc_library(
     deps = [
         ":curl_http_request",
         ":http_request",
-        ":retrying_utils",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
+        "//tensorflow/core:retrying_utils",
     ],
 )
 
@@ -221,34 +221,6 @@ cc_library(
         "//tensorflow/core:lib_internal",
         "@boringssl//:crypto",
         "@jsoncpp_git//:jsoncpp",
-    ],
-)
-
-cc_library(
-    name = "retrying_utils",
-    srcs = [
-        "retrying_utils.cc",
-    ],
-    hdrs = [
-        "retrying_utils.h",
-    ],
-    copts = tf_copts(),
-    deps = [
-        "//tensorflow/core:framework_headers_lib",
-        "//tensorflow/core:lib_internal",
-    ],
-)
-
-cc_library(
-    name = "retrying_file_system",
-    hdrs = [
-        "retrying_file_system.h",
-    ],
-    copts = tf_copts(),
-    deps = [
-        ":retrying_utils",
-        "//tensorflow/core:framework_headers_lib",
-        "//tensorflow/core:lib_internal",
     ],
 )
 
@@ -412,37 +384,11 @@ tf_cc_test(
 )
 
 tf_cc_test(
-    name = "retrying_file_system_test",
-    size = "small",
-    srcs = ["retrying_file_system_test.cc"],
-    deps = [
-        ":retrying_file_system",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
-        "//tensorflow/core:test",
-        "//tensorflow/core:test_main",
-    ],
-)
-
-tf_cc_test(
     name = "time_util_test",
     size = "small",
     srcs = ["time_util_test.cc"],
     deps = [
         ":time_util",
-        "//tensorflow/core:test",
-        "//tensorflow/core:test_main",
-    ],
-)
-
-tf_cc_test(
-    name = "retrying_utils_test",
-    size = "small",
-    srcs = ["retrying_utils_test.cc"],
-    deps = [
-        ":retrying_utils",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
     ],

--- a/tensorflow/core/platform/cloud/compute_engine_metadata_client.cc
+++ b/tensorflow/core/platform/cloud/compute_engine_metadata_client.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <utility>
 #include "tensorflow/core/platform/cloud/curl_http_request.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 
 namespace tensorflow {
 

--- a/tensorflow/core/platform/cloud/compute_engine_metadata_client.h
+++ b/tensorflow/core/platform/cloud/compute_engine_metadata_client.h
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/cloud/http_request.h"
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 
 namespace tensorflow {
 

--- a/tensorflow/core/platform/cloud/gcs_file_system.cc
+++ b/tensorflow/core/platform/cloud/gcs_file_system.cc
@@ -38,7 +38,7 @@ limitations under the License.
 #include "tensorflow/core/platform/cloud/file_block_cache.h"
 #include "tensorflow/core/platform/cloud/google_auth_provider.h"
 #include "tensorflow/core/platform/cloud/ram_file_block_cache.h"
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 #include "tensorflow/core/platform/cloud/time_util.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/mutex.h"

--- a/tensorflow/core/platform/cloud/gcs_file_system.h
+++ b/tensorflow/core/platform/cloud/gcs_file_system.h
@@ -29,7 +29,7 @@ limitations under the License.
 #include "tensorflow/core/platform/cloud/gcs_dns_cache.h"
 #include "tensorflow/core/platform/cloud/gcs_throttle.h"
 #include "tensorflow/core/platform/cloud/http_request.h"
-#include "tensorflow/core/platform/cloud/retrying_file_system.h"
+#include "tensorflow/core/platform/retrying_file_system.h"
 #include "tensorflow/core/platform/file_system.h"
 
 namespace tensorflow {

--- a/tensorflow/core/platform/cloud/google_auth_provider.cc
+++ b/tensorflow/core/platform/cloud/google_auth_provider.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/lib/strings/base64.h"
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 #include "tensorflow/core/platform/env.h"
 
 namespace tensorflow {

--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -105,14 +105,6 @@ int ParseInteger(const char* str, size_t size) {
   return level;
 }
 
-// Parse log level (int64) from environment variable (char*)
-int64 LogLevelStrToInt(const char* tf_env_var_val) {
-  if (tf_env_var_val == nullptr) {
-    return 0;
-  }
-  return ParseInteger(tf_env_var_val, strlen(tf_env_var_val));
-}
-
 // Using StringPiece breaks Windows build.
 struct StringData {
   struct Hasher {
@@ -181,6 +173,14 @@ VmoduleMap* VmodulesMapFromEnv() {
 }
 
 }  // namespace
+
+// Parse log level (int64) from environment variable (char*)
+int64 LogLevelStrToInt(const char* tf_env_var_val) {
+  if (tf_env_var_val == nullptr) {
+    return 0;
+  }
+  return ParseInteger(tf_env_var_val, strlen(tf_env_var_val));
+}
 
 int64 MinLogLevelFromEnv() {
   // We don't want to print logs during fuzzing as that would slow fuzzing down

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -340,6 +340,8 @@ int64 MinLogLevelFromEnv();
 
 int64 MinVLogLevelFromEnv();
 
+int64 LogLevelStrToInt(const char* tf_env_var_val);
+
 }  // namespace internal
 }  // namespace tensorflow
 

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -258,6 +258,12 @@ Status Env::IsDirectory(const string& fname) {
   return fs->IsDirectory(fname);
 }
 
+Status Env::NeedsTempLocation(const string& path) {
+  FileSystem* fs;
+  TF_RETURN_IF_ERROR(GetFileSystemForFile(path, &fs));
+  return fs->NeedsTempLocation(path);
+}
+
 Status Env::DeleteRecursively(const string& dirname, int64* undeleted_files,
                               int64* undeleted_dirs) {
   FileSystem* fs;

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -221,6 +221,15 @@ class Env {
   ///  * UNIMPLEMENTED - The file factory doesn't support directories.
   Status IsDirectory(const string& fname);
 
+  /// \brief Returns whether the given path needs a temp location
+  /// to safely write objects.
+  /// Typical return codes (not guaranteed exhaustive):
+  ///  * OK - The path is on a file system that should use a temp location
+  ///         to safely write objects
+  ///  * FAILED_PRECONDITION - The path is on a file system that does not
+  ///  	      need a temp location
+  Status NeedsTempLocation(const string& path);
+
   /// Stores the size of `fname` in `*file_size`.
   Status GetFileSize(const string& fname, uint64* file_size);
 

--- a/tensorflow/core/platform/file_system.cc
+++ b/tensorflow/core/platform/file_system.cc
@@ -47,6 +47,10 @@ Status FileSystem::IsDirectory(const string& name) {
   return Status(tensorflow::error::FAILED_PRECONDITION, "Not a directory");
 }
 
+Status FileSystem::NeedsTempLocation(const string& path) {
+  return Status::OK();
+}
+
 void FileSystem::FlushCaches() {}
 
 RandomAccessFile::~RandomAccessFile() {}

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -220,6 +220,14 @@ class FileSystem {
   ///  * UNIMPLEMENTED - The file factory doesn't support directories.
   virtual Status IsDirectory(const string& fname);
 
+  /// \brief Returns whether the given path needs a temp location to write
+  /// safely
+  ///
+  /// Typical return codes (not guaranteed exhaustive):
+  ///  * OK - Needs a temp location
+  ///  * FAILED_PRECONDITION - Does not need a temp location
+  virtual Status NeedsTempLocation(const string& path);
+
   /// \brief Flushes any cached filesystem objects from memory.
   virtual void FlushCaches();
 
@@ -276,7 +284,7 @@ class WritableFile {
   /// \brief Append 'data' to the file.
   virtual Status Append(StringPiece data) = 0;
 
-  // TODO(ebrevdo): Remove this ifdef when absl is updated.
+// TODO(ebrevdo): Remove this ifdef when absl is updated.
 #if defined(PLATFORM_GOOGLE)
   // \brief Append 'data' to the file.
   virtual Status Append(const absl::Cord& cord) {

--- a/tensorflow/core/platform/file_system_test.cc
+++ b/tensorflow/core/platform/file_system_test.cc
@@ -261,6 +261,12 @@ TEST(InterPlanetaryFileSystemTest, RecursivelyCreateAlreadyExistingDir) {
   TF_EXPECT_OK(ipfs.RecursivelyCreateDir(dirname));
 }
 
+TEST(InterPlanetaryFileSystemTest, NeedsTempLocation) {
+  InterPlanetaryFileSystem ipfs;
+  const string dirname = io::JoinPath(kPrefix, "match-00/abc/00");
+  TF_EXPECT_OK(ipfs.NeedsTempLocation(dirname));
+}
+
 // A simple file system with a root directory and a single file underneath it.
 class TestFileSystem : public NullFileSystem {
  public:

--- a/tensorflow/core/platform/retrying_file_system.h
+++ b/tensorflow/core/platform/retrying_file_system.h
@@ -23,9 +23,9 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/lib/random/random.h"
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/file_system.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 
 namespace tensorflow {
 
@@ -121,6 +121,11 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
+  Status NeedsTempLocation(const string& path) override {
+    // this does not need to be retried
+    return base_file_system_->NeedsTempLocation(path);
+  }
+
   Status DeleteRecursively(const string& dirname, int64* undeleted_files,
                            int64* undeleted_dirs) override {
     return RetryingUtils::DeleteWithRetries(
@@ -138,7 +143,6 @@ class RetryingFileSystem : public FileSystem {
  private:
   std::unique_ptr<Underlying> base_file_system_;
   const RetryConfig retry_config_;
-
   TF_DISALLOW_COPY_AND_ASSIGN(RetryingFileSystem);
 };
 

--- a/tensorflow/core/platform/retrying_file_system_test.cc
+++ b/tensorflow/core/platform/retrying_file_system_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/platform/cloud/retrying_file_system.h"
+#include "tensorflow/core/platform/retrying_file_system.h"
 #include <fstream>
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/lib/strings/str_util.h"

--- a/tensorflow/core/platform/retrying_utils.h
+++ b/tensorflow/core/platform/retrying_utils.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_CORE_PLATFORM_CLOUD_RETRYING_UTILS_H_
 
 #include <functional>
+#include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
 
 namespace tensorflow {
@@ -24,11 +25,14 @@ namespace tensorflow {
 // Default time before reporting failure: ~100 seconds.
 struct RetryConfig {
   RetryConfig(int64 init_delay_time_us = 100 * 1000,
-              int64 max_delay_time_us = 32 * 1000 * 1000,
-              int max_retries = 10) {
+              int64 max_delay_time_us = 32 * 1000 * 1000, int max_retries = 10,
+              std::set<error::Code> retriable_errors = {
+                  error::UNAVAILABLE, error::DEADLINE_EXCEEDED,
+                  error::UNKNOWN}) {
     this->init_delay_time_us = init_delay_time_us;
     this->max_delay_time_us = max_delay_time_us;
     this->max_retries = max_retries;
+    this->retriable_errors = retriable_errors;
   }
 
   // In case of failure, every call will be retried max_retries times.
@@ -39,6 +43,9 @@ struct RetryConfig {
 
   // Maximum backoff time in microseconds.
   int64 max_delay_time_us;
+
+  // Set of errors which need to be retried
+  std::set<error::Code> retriable_errors;
 };
 
 class RetryingUtils {
@@ -57,6 +64,7 @@ class RetryingUtils {
   static Status CallWithRetries(const std::function<Status()>& f,
                                 const std::function<void(int64)>& sleep_usec,
                                 const RetryConfig& config);
+
   /// \brief A retrying wrapper for a function that deletes a resource.
   ///
   /// The function takes care of the scenario when a delete operation

--- a/tensorflow/core/platform/retrying_utils_test.cc
+++ b/tensorflow/core/platform/retrying_utils_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 #include <fstream>
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/lib/strings/str_util.h"

--- a/tensorflow/core/platform/s3/aws_crypto.cc
+++ b/tensorflow/core/platform/s3/aws_crypto.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/core/platform/s3/aws_crypto.h"
 #include <openssl/hmac.h>
+#include <openssl/rand.h>
 #include <openssl/sha.h>
 
 #include <aws/core/utils/crypto/HashResult.h>
@@ -100,6 +101,22 @@ class AWSSha256OpenSSLImpl : public Aws::Utils::Crypto::Hash {
   }
 };
 
+class AWSSecureRandomBytesImpl : public Aws::Utils::Crypto::SecureRandomBytes {
+ public:
+  AWSSecureRandomBytesImpl() {}
+  virtual ~AWSSecureRandomBytesImpl() = default;
+  virtual void GetBytes(unsigned char* buffer, size_t bufferSize) override {
+    assert(buffer);
+    int success = RAND_bytes(buffer, static_cast<int>(bufferSize));
+    if (success != 1) {
+      m_failure = true;
+    }
+  }
+
+ private:
+  bool m_failure;
+};
+
 std::shared_ptr<Aws::Utils::Crypto::Hash>
 AWSSHA256Factory::CreateImplementation() const {
   return Aws::MakeShared<AWSSha256OpenSSLImpl>(AWSCryptoAllocationTag);
@@ -108,6 +125,11 @@ AWSSHA256Factory::CreateImplementation() const {
 std::shared_ptr<Aws::Utils::Crypto::HMAC>
 AWSSHA256HmacFactory::CreateImplementation() const {
   return Aws::MakeShared<AWSSha256HMACOpenSSLImpl>(AWSCryptoAllocationTag);
+}
+
+std::shared_ptr<Aws::Utils::Crypto::SecureRandomBytes>
+AWSSecureRandomFactory::CreateImplementation() const {
+  return Aws::MakeShared<AWSSecureRandomBytesImpl>(AWSCryptoAllocationTag);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/s3/aws_crypto.h
+++ b/tensorflow/core/platform/s3/aws_crypto.h
@@ -16,6 +16,7 @@ limitations under the License.
 #include <aws/core/utils/crypto/Factories.h>
 #include <aws/core/utils/crypto/HMAC.h>
 #include <aws/core/utils/crypto/Hash.h>
+#include <aws/core/utils/crypto/SecureRandom.h>
 
 namespace tensorflow {
 static const char* AWSCryptoAllocationTag = "AWSCryptoAllocation";
@@ -29,6 +30,12 @@ class AWSSHA256Factory : public Aws::Utils::Crypto::HashFactory {
 class AWSSHA256HmacFactory : public Aws::Utils::Crypto::HMACFactory {
  public:
   std::shared_ptr<Aws::Utils::Crypto::HMAC> CreateImplementation()
+      const override;
+};
+
+class AWSSecureRandomFactory : public Aws::Utils::Crypto::SecureRandomFactory {
+ public:
+  std::shared_ptr<Aws::Utils::Crypto::SecureRandomBytes> CreateImplementation()
       const override;
 };
 

--- a/tensorflow/core/platform/s3/aws_logging.cc
+++ b/tensorflow/core/platform/s3/aws_logging.cc
@@ -63,7 +63,7 @@ void AWSLogSystem::LogMessage(Aws::Utils::Logging::LogLevel log_level,
       LOG(FATAL) << message;
       break;
     default:
-      LOG(ERROR) << message;
+      LOG(INFO) << message;
       break;
   }
 }
@@ -73,24 +73,39 @@ static const char* kAWSLoggingTag = "AWSLogging";
 
 Aws::Utils::Logging::LogLevel ParseLogLevelFromEnv() {
   Aws::Utils::Logging::LogLevel log_level = Aws::Utils::Logging::LogLevel::Info;
-
-  const int64_t level = tensorflow::internal::MinLogLevelFromEnv();
+  const char* aws_sdk_log = std::getenv("TF_S3_LOG_LEVEL");
+  int64_t level;
+  if (aws_sdk_log == nullptr) {
+    // default logging level of FATAL
+    level = 1;
+  } else {
+    level = tensorflow::internal::LogLevelStrToInt(aws_sdk_log);
+  }
 
   switch (level) {
-    case INFO:
-      log_level = Aws::Utils::Logging::LogLevel::Info;
+    case 0:
+      log_level = Aws::Utils::Logging::LogLevel::Off;
       break;
-    case WARNING:
-      log_level = Aws::Utils::Logging::LogLevel::Warn;
-      break;
-    case ERROR:
-      log_level = Aws::Utils::Logging::LogLevel::Error;
-      break;
-    case FATAL:
+    case 1:
       log_level = Aws::Utils::Logging::LogLevel::Fatal;
       break;
-    default:
+    case 2:
+      log_level = Aws::Utils::Logging::LogLevel::Error;
+      break;
+    case 3:
+      log_level = Aws::Utils::Logging::LogLevel::Warn;
+      break;
+    case 4:
       log_level = Aws::Utils::Logging::LogLevel::Info;
+      break;
+    case 5:
+      log_level = Aws::Utils::Logging::LogLevel::Debug;
+      break;
+    case 6:
+      log_level = Aws::Utils::Logging::LogLevel::Trace;
+      break;
+    default:
+      log_level = Aws::Utils::Logging::LogLevel::Fatal;
       break;
   }
 

--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/logging/AWSLogging.h>
 #include <aws/core/utils/logging/LogSystemInterface.h>
+#include <aws/core/utils/threading/Executor.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/S3Errors.h>
 #include <aws/s3/model/CopyObjectRequest.h>
@@ -35,6 +36,7 @@ limitations under the License.
 #include <aws/s3/model/HeadObjectRequest.h>
 #include <aws/s3/model/ListObjectsRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
+#include <aws/transfer/TransferManager.h>
 
 #include <cstdlib>
 
@@ -44,6 +46,9 @@ namespace {
 static const char* kS3FileSystemAllocationTag = "S3FileSystemAllocation";
 static const size_t kS3ReadAppendableFileBufferSize = 1024 * 1024;
 static const int kS3GetChildrenMaxKeys = 100;
+static const int kExecutorPoolSize = 5;
+static const int kUploadRetries = 5;
+static const char* kExecutorTag = "TransferManagerExecutor";
 
 Aws::Client::ClientConfiguration& GetDefaultClientConfig() {
   static mutex cfg_lock(LINKER_INITIALIZED);
@@ -139,6 +144,18 @@ void ShutdownClient(Aws::S3::S3Client* s3_client) {
   }
 }
 
+void ShutdownTransferManager(Aws::Transfer::TransferManager* transfer_manager) {
+  if (transfer_manager != nullptr) {
+    delete transfer_manager;
+  }
+}
+
+void ShutdownExecutor(Aws::Utils::Threading::PooledThreadExecutor* executor) {
+  if (executor != nullptr) {
+    delete executor;
+  }
+}
+
 Status ParseS3Path(const string& fname, bool empty_object_ok, string* bucket,
                    string* object) {
   if (!bucket || !object) {
@@ -176,6 +193,7 @@ class S3RandomAccessFile : public RandomAccessFile {
 
   Status Read(uint64 offset, size_t n, StringPiece* result,
               char* scratch) const override {
+    VLOG(1) << "ReadFilefromS3 s3://" << bucket_ << "/" << object_;
     Aws::S3::Model::GetObjectRequest getObjectRequest;
     getObjectRequest.WithBucket(bucket_.c_str()).WithKey(object_.c_str());
     string bytes = strings::StrCat("bytes=", offset, "-", offset + n - 1);
@@ -204,10 +222,13 @@ class S3RandomAccessFile : public RandomAccessFile {
 
 class S3WritableFile : public WritableFile {
  public:
-  S3WritableFile(const string& bucket, const string& object,
-                 std::shared_ptr<Aws::S3::S3Client> s3_client)
+  S3WritableFile(
+      const string& bucket, const string& object,
+      std::shared_ptr<Aws::Transfer::TransferManager> transfer_manager,
+      std::shared_ptr<Aws::S3::S3Client> s3_client)
       : bucket_(bucket),
         object_(object),
+        transfer_manager_(transfer_manager),
         s3_client_(s3_client),
         sync_needed_(true),
         outfile_(Aws::MakeShared<Aws::Utils::TempFile>(
@@ -251,28 +272,39 @@ class S3WritableFile : public WritableFile {
     if (!sync_needed_) {
       return Status::OK();
     }
-    Aws::S3::Model::PutObjectRequest putObjectRequest;
-    putObjectRequest.WithBucket(bucket_.c_str()).WithKey(object_.c_str());
+    VLOG(1) << "WriteFileToS3: s3://" << bucket_ << "/" << object_;
     long offset = outfile_->tellp();
-    outfile_->seekg(0);
-    putObjectRequest.SetBody(outfile_);
-    putObjectRequest.SetContentLength(offset);
-    auto putObjectOutcome = this->s3_client_->PutObject(putObjectRequest);
+    std::shared_ptr<Aws::Transfer::TransferHandle> handle =
+        transfer_manager_.get()->UploadFile(
+            outfile_, bucket_.c_str(), object_.c_str(),
+            "application/octet-stream", Aws::Map<Aws::String, Aws::String>());
+    handle->WaitUntilFinished();
+    int retries = 0;
+    while (handle->GetStatus() == Aws::Transfer::TransferStatus::FAILED &&
+           retries++ < kUploadRetries) {
+      // if multipart upload was used, only the failed parts will be re-sent
+      VLOG(1) << "Retrying Upload of s3://" << bucket_ << "/" << object_
+              << " after failure. Current retry count:" << retries;
+      transfer_manager_.get()->RetryUpload(outfile_, handle);
+      handle->WaitUntilFinished();
+    }
+    if (handle->GetStatus() != Aws::Transfer::TransferStatus::COMPLETED) {
+      return errors::Unknown(handle->GetLastError().GetExceptionName(), ": ",
+                             handle->GetFailedParts().size(), " failed parts. ",
+                             handle->GetLastError().GetMessage());
+    }
     outfile_->clear();
     outfile_->seekp(offset);
-    if (!putObjectOutcome.IsSuccess()) {
-      return errors::Unknown(putObjectOutcome.GetError().GetExceptionName(),
-                             ": ", putObjectOutcome.GetError().GetMessage());
-    }
     return Status::OK();
   }
 
  private:
   string bucket_;
   string object_;
-  std::shared_ptr<Aws::S3::S3Client> s3_client_;
   bool sync_needed_;
   std::shared_ptr<Aws::Utils::TempFile> outfile_;
+  std::shared_ptr<Aws::S3::S3Client> s3_client_;
+  std::shared_ptr<Aws::Transfer::TransferManager> transfer_manager_;
 };
 
 class S3ReadOnlyMemoryRegion : public ReadOnlyMemoryRegion {
@@ -290,13 +322,16 @@ class S3ReadOnlyMemoryRegion : public ReadOnlyMemoryRegion {
 }  // namespace
 
 S3FileSystem::S3FileSystem()
-    : s3_client_(nullptr, ShutdownClient), client_lock_() {}
+    : s3_client_(nullptr, ShutdownClient),
+      initialization_lock_(),
+      transfer_manager_(nullptr, ShutdownTransferManager),
+      executor_(nullptr, ShutdownExecutor) {}
 
 S3FileSystem::~S3FileSystem() {}
 
 // Initializes s3_client_, if needed, and returns it.
 std::shared_ptr<Aws::S3::S3Client> S3FileSystem::GetS3Client() {
-  std::lock_guard<mutex> lock(this->client_lock_);
+  std::lock_guard<mutex> lock(this->initialization_lock_);
 
   if (this->s3_client_.get() == nullptr) {
     AWSLogSystem::InitializeAWSLogging();
@@ -307,6 +342,9 @@ std::shared_ptr<Aws::S3::S3Client> S3FileSystem::GetS3Client() {
     };
     options.cryptoOptions.sha256HMACFactory_create_fn = []() {
       return Aws::MakeShared<AWSSHA256HmacFactory>(AWSCryptoAllocationTag);
+    };
+    options.cryptoOptions.secureRandomFactory_create_fn = []() {
+      return Aws::MakeShared<AWSSecureRandomFactory>(AWSCryptoAllocationTag);
     };
     Aws::InitAPI(options);
 
@@ -324,6 +362,29 @@ std::shared_ptr<Aws::S3::S3Client> S3FileSystem::GetS3Client() {
   return this->s3_client_;
 }
 
+std::shared_ptr<Aws::Transfer::TransferManager>
+S3FileSystem::GetTransferManager() {
+  std::shared_ptr<Aws::S3::S3Client> s3_client = this->GetS3Client();
+  std::lock_guard<mutex> lock(this->initialization_lock_);
+  if (this->transfer_manager_.get() == nullptr) {
+    Aws::Transfer::TransferManagerConfiguration config(
+        this->GetExecutor().get());
+    config.s3Client = s3_client;
+    this->transfer_manager_ = Aws::Transfer::TransferManager::Create(config);
+  }
+  return this->transfer_manager_;
+}
+
+std::shared_ptr<Aws::Utils::Threading::PooledThreadExecutor>
+S3FileSystem::GetExecutor() {
+  if (this->executor_.get() == nullptr) {
+    this->executor_ =
+        Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>(
+            kExecutorTag, kExecutorPoolSize);
+  }
+  return this->executor_;
+}
+
 Status S3FileSystem::NewRandomAccessFile(
     const string& fname, std::unique_ptr<RandomAccessFile>* result) {
   string bucket, object;
@@ -336,7 +397,8 @@ Status S3FileSystem::NewWritableFile(const string& fname,
                                      std::unique_ptr<WritableFile>* result) {
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(fname, false, &bucket, &object));
-  result->reset(new S3WritableFile(bucket, object, this->GetS3Client()));
+  result->reset(new S3WritableFile(bucket, object, this->GetTransferManager(),
+                                   this->GetS3Client()));
   return Status::OK();
 }
 
@@ -351,7 +413,8 @@ Status S3FileSystem::NewAppendableFile(const string& fname,
 
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(fname, false, &bucket, &object));
-  result->reset(new S3WritableFile(bucket, object, this->GetS3Client()));
+  result->reset(new S3WritableFile(bucket, object, this->GetTransferManager(),
+                                   this->GetS3Client()));
 
   while (true) {
     status = reader->Read(offset, kS3ReadAppendableFileBufferSize, &read_chunk,
@@ -485,9 +548,11 @@ Status S3FileSystem::Stat(const string& fname, FileStatistics* stats) {
   auto listObjectsOutcome =
       this->GetS3Client()->ListObjects(listObjectsRequest);
   if (listObjectsOutcome.IsSuccess()) {
-    if (listObjectsOutcome.GetResult().GetContents().size() > 0) {
+    auto listObjects = listObjectsOutcome.GetResult().GetContents();
+    if (listObjects.size() > 0) {
       stats->length = 0;
       stats->is_directory = 1;
+      stats->mtime_nsec = listObjects[0].GetLastModified().Millis() * 1e6;
       found = true;
     }
   }
@@ -521,7 +586,6 @@ Status S3FileSystem::DeleteFile(const string& fname) {
 Status S3FileSystem::CreateDir(const string& dirname) {
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(dirname, true, &bucket, &object));
-
   if (object.empty()) {
     Aws::S3::Model::HeadBucketRequest headBucketRequest;
     headBucketRequest.WithBucket(bucket.c_str());
@@ -535,13 +599,16 @@ Status S3FileSystem::CreateDir(const string& dirname) {
   if (filename.back() != '/') {
     filename.push_back('/');
   }
-  std::unique_ptr<WritableFile> file;
-  TF_RETURN_IF_ERROR(NewWritableFile(filename, &file));
-  TF_RETURN_IF_ERROR(file->Close());
+  if (!this->FileExists(filename).ok()) {
+    std::unique_ptr<WritableFile> file;
+    TF_RETURN_IF_ERROR(NewWritableFile(filename, &file));
+    TF_RETURN_IF_ERROR(file->Close());
+  }
   return Status::OK();
 }
 
 Status S3FileSystem::DeleteDir(const string& dirname) {
+  VLOG(1) << "DeleteDir: " << dirname;
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(dirname, false, &bucket, &object));
 
@@ -582,6 +649,7 @@ Status S3FileSystem::GetFileSize(const string& fname, uint64* file_size) {
 }
 
 Status S3FileSystem::RenameFile(const string& src, const string& target) {
+  VLOG(1) << "RenameFile from: " << src << " to: " << target;
   string src_bucket, src_object, target_bucket, target_object;
   TF_RETURN_IF_ERROR(ParseS3Path(src, false, &src_bucket, &src_object));
   TF_RETURN_IF_ERROR(
@@ -651,6 +719,11 @@ Status S3FileSystem::RenameFile(const string& src, const string& target) {
   return Status::OK();
 }
 
-REGISTER_FILE_SYSTEM("s3", S3FileSystem);
+Status S3FileSystem::NeedsTempLocation(const string& path) {
+  return Status(tensorflow::error::FAILED_PRECONDITION,
+                "Does not need a temp location");
+}
+
+REGISTER_FILE_SYSTEM("s3", RetryingS3FileSystem);
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/s3/s3_file_system.h
+++ b/tensorflow/core/platform/s3/s3_file_system.h
@@ -17,8 +17,10 @@ limitations under the License.
 #define TENSORFLOW_CONTRIB_S3_S3_FILE_SYSTEM_H_
 
 #include <aws/s3/S3Client.h>
+#include <aws/transfer/TransferManager.h>
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/retrying_file_system.h"
 
 namespace tensorflow {
 
@@ -59,6 +61,8 @@ class S3FileSystem : public FileSystem {
 
   Status RenameFile(const string& src, const string& target) override;
 
+  virtual Status NeedsTempLocation(const string& path) override;
+
  private:
   // Returns the member S3 client, initializing as-needed.
   // When the client tries to access the object in S3, e.g.,
@@ -74,10 +78,31 @@ class S3FileSystem : public FileSystem {
   // This S3 Client does not support Virtual Hosted–Style Method
   // for a bucket.
   std::shared_ptr<Aws::S3::S3Client> GetS3Client();
-
   std::shared_ptr<Aws::S3::S3Client> s3_client_;
-  // Lock held when checking for s3_client_ initialization.
-  mutex client_lock_;
+
+  // Returns the member transfer manager, initializing as-needed.
+  std::shared_ptr<Aws::Transfer::TransferManager> GetTransferManager();
+  std::shared_ptr<Aws::Transfer::TransferManager> transfer_manager_;
+
+  // Returns the member executor for transfer manager, initializing as-needed.
+  std::shared_ptr<Aws::Utils::Threading::PooledThreadExecutor> GetExecutor();
+  std::shared_ptr<Aws::Utils::Threading::PooledThreadExecutor> executor_;
+
+  // Lock held when checking for s3_client_ and transfer_manager_ initialization
+  mutex initialization_lock_;
+};
+
+/// S3 implementation of a file system with retry on failures.
+class RetryingS3FileSystem : public RetryingFileSystem<S3FileSystem> {
+ public:
+  RetryingS3FileSystem()
+      : RetryingFileSystem(
+            std::unique_ptr<S3FileSystem>(new S3FileSystem),
+            RetryConfig(
+                100000 /* init_delay_time_us */,
+                32000000 /* max_delay_time_us */, 10 /* max_retries */,
+                {error::UNAVAILABLE, error::DEADLINE_EXCEEDED, error::UNKNOWN,
+                 error::FAILED_PRECONDITION, error::INTERNAL})) {}
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/s3/s3_file_system_test.cc
+++ b/tensorflow/core/platform/s3/s3_file_system_test.cc
@@ -231,5 +231,12 @@ TEST_F(S3FileSystemTest, StatFile) {
   EXPECT_FALSE(stat.is_directory);
 }
 
+TEST_F(S3FileSystemTest, NeedsTempLocation) {
+  const string fname = TmpDir("NeedsTempLocation");
+  TF_ASSERT_OK(WriteString(fname, "test"));
+  EXPECT_EQ(error::Code::FAILED_PRECONDITION, s3fs.NeedsTempLocation(fname).code());
+}
+
+
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle.h
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle.h
@@ -149,8 +149,9 @@ class BundleWriter {
   Env* const env_;  // Not owned.
   const Options options_;
   const string prefix_;
-  const string tmp_metadata_path_;
-  const string tmp_data_path_;
+  string metadata_path_;
+  string data_path_;
+  bool use_temp_file_;
   std::unique_ptr<FileOutputBuffer> out_;
   int64 size_;  // Number of bytes written into out_.
   std::map<string, BundleEntryProto> entries_;

--- a/tensorflow/python/lib/io/file_io.i
+++ b/tensorflow/python/lib/io/file_io.i
@@ -167,6 +167,19 @@ bool IsDirectory(const string& dirname, TF_Status* out_status) {
   return false;
 }
 
+bool NeedsTempLocation(const string& path, TF_Status* out_status) {
+  tensorflow::Status status = tensorflow::Env::Default()->NeedsTempLocation(path);
+  if (status.ok()) {
+    return true;
+  }
+  // FAILED_PRECONDITION Status response means that writing to the path
+  // does not need a temp location
+  if (status.code() != tensorflow::error::FAILED_PRECONDITION) {
+    Set_TF_Status_from_Status(out_status, status);
+  }
+  return false;
+}
+
 using tensorflow::FileStatistics;
 
 void Stat(const string& filename, FileStatistics* stats,
@@ -266,6 +279,7 @@ void RenameFile(const string& oldname, const string& newname, bool overwrite,
                 TF_Status* out_status);
 void DeleteRecursively(const string& dirname, TF_Status* out_status);
 bool IsDirectory(const string& dirname, TF_Status* out_status);
+bool NeedsTempLocation(const string& path, TF_Status* out_status);
 void Stat(const string& filename, tensorflow::FileStatistics* stats,
           TF_Status* out_status);
 tensorflow::io::BufferedInputStream* CreateBufferedInputStream(

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -564,10 +564,6 @@ def needs_temp_location_v2(path):
   status = c_api_util.ScopedTFStatus()
   return pywrap_tensorflow.NeedsTempLocation(compat.as_bytes(path), status)
 
-@tf_export("gfile.NeedsTempLocation")
-def needs_temp_location(path):
-  status = c_api_util.ScopedTFStatus()
-  return pywrap_tensorflow.NeedsTempLocation(compat.as_bytes(path), status)
 
 def atomic_write_string_to_file(filename, contents, overwrite=True):
   """Writes to `filename` atomically.

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -531,6 +531,43 @@ def rename_v2(src, dst, overwrite=False):
     pywrap_tensorflow.RenameFile(
         compat.as_bytes(src), compat.as_bytes(dst), overwrite, status)
 
+@tf_export(v1=["gfile.NeedsTempLocation"])
+def needs_temp_location(path):
+  """ Returns whether or not writing to the given path needs to use
+      a temporary location for safety
+
+  Args:
+    path: string, path to a file
+
+  Returns:
+    True, if the path is on a file system that needs to use a temporary
+          location to write safely. In such cases it is recommended to write to
+          a temporary location and then do (atomic) move to the final location.
+    False, if it is safe to write to the path without a temp location
+  """
+  return needs_temp_location_v2(path)
+
+@tf_export("io.gfile.needstemp")
+def needs_temp_location_v2(path):
+  """ Returns whether or not writing to the given path needs to use
+      a temporary location for safety
+
+  Args:
+    path: string, path to a file
+    
+  Returns:
+    True, if the path is on a file system that needs to use a temporary
+          location to write safely. In such cases it is recommended to write to
+          a temporary location and then do (atomic) move to the final location.
+    False, if it is safe to write to the path without a temp location
+  """
+  status = c_api_util.ScopedTFStatus()
+  return pywrap_tensorflow.NeedsTempLocation(compat.as_bytes(path), status)
+
+@tf_export("gfile.NeedsTempLocation")
+def needs_temp_location(path):
+  status = c_api_util.ScopedTFStatus()
+  return pywrap_tensorflow.NeedsTempLocation(compat.as_bytes(path), status)
 
 def atomic_write_string_to_file(filename, contents, overwrite=True):
   """Writes to `filename` atomically.
@@ -547,13 +584,16 @@ def atomic_write_string_to_file(filename, contents, overwrite=True):
     overwrite: boolean, if false it's an error for `filename` to be occupied by
         an existing file.
   """
-  temp_pathname = filename + ".tmp" + uuid.uuid4().hex
-  write_string_to_file(temp_pathname, contents)
-  try:
-    rename(temp_pathname, filename, overwrite)
-  except errors.OpError:
-    delete_file(temp_pathname)
-    raise
+  if not needs_temp_location(filename):
+    write_string_to_file(filename, contents)
+  else:
+    temp_pathname = filename + ".tmp" + uuid.uuid4().hex
+    write_string_to_file(temp_pathname, contents)
+    try:
+      rename(temp_pathname, filename, overwrite)
+    except errors.OpError:
+      delete_file(temp_pathname)
+      raise
 
 
 @tf_export(v1=["gfile.DeleteRecursively"])
@@ -608,7 +648,6 @@ def is_directory_v2(path):
   """
   status = c_api_util.ScopedTFStatus()
   return pywrap_tensorflow.IsDirectory(compat.as_bytes(path), status)
-
 
 @tf_export(v1=["gfile.ListDirectory"])
 def list_directory(dirname):

--- a/tensorflow/python/platform/gfile.py
+++ b/tensorflow/python/platform/gfile.py
@@ -27,6 +27,7 @@ from tensorflow.python.lib.io.file_io import file_exists as Exists
 from tensorflow.python.lib.io.file_io import FileIO as _FileIO
 from tensorflow.python.lib.io.file_io import get_matching_files as Glob
 from tensorflow.python.lib.io.file_io import is_directory as IsDirectory
+from tensorflow.python.lib.io.file_io import needs_temp_location as NeedsTempLocation
 from tensorflow.python.lib.io.file_io import list_directory as ListDirectory
 from tensorflow.python.lib.io.file_io import recursive_create_dir as MakeDirs
 from tensorflow.python.lib.io.file_io import rename as Rename

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.pbtxt
@@ -60,4 +60,8 @@ tf_module {
     name: "Walk"
     argspec: "args=[\'top\', \'in_order\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
+  member_method {
+    name: "NeedsTempLocation"
+    argspec: "args=[\'path\'], varargs=None, keywords=None, defaults=None"
+  }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.pbtxt
@@ -52,4 +52,8 @@ tf_module {
     name: "walk"
     argspec: "args=[\'top\', \'topdown\', \'onerror\'], varargs=None, keywords=None, defaults=[\'True\', \'None\'], "
   }
+  member_method {
+    name: "needstemp"
+    argspec: "args=[\'path\'], varargs=None, keywords=None, defaults=None"
+  }
 }

--- a/third_party/aws/BUILD.bazel
+++ b/third_party/aws/BUILD.bazel
@@ -50,6 +50,8 @@ cc_library(
         "aws-cpp-sdk-kinesis/source/**/*.cpp",
         "aws-cpp-sdk-s3/include/**/*.h",
         "aws-cpp-sdk-s3/source/**/*.cpp",
+        "aws-cpp-sdk-transfer/include/**/*.h",
+        "aws-cpp-sdk-transfer/source/**/*.cpp",
     ]),
     hdrs = [
         "aws-cpp-sdk-core/include/aws/core/SDKConfig.h",
@@ -81,6 +83,7 @@ cc_library(
         "aws-cpp-sdk-core/include/",
         "aws-cpp-sdk-kinesis/include/",
         "aws-cpp-sdk-s3/include/",
+        "aws-cpp-sdk-transfer/include/",
     ],
     deps = [
         "@curl",


### PR DESCRIPTION
**Usability:**
- Adds an environment variable TF_S3_LOG_LEVEL to control the logging information from S3 operations. 
  - By default, this level is set to 1, which only logs fatal errors. This removes the flood of unnecessary logs that are thrown when using S3 currently which stem from improper usage of AWS_CPP_SDK logging levels. 
  - User can change the level when necessary using the following values: 0 (OFF), 1 (FATAL), 2 (ERROR), 3 (WARNING), 4 (INFO), 5 (DEBUG), 6 (TRACE)

**Reliability**
S3 supports an [eventual consistency model](https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel), which does not work like a regular file system. This means that many operations currently in the s3 file system crash now and then because the conditions it expects are not satisfied by S3. The following changes tries to address such crashes. 

- _Skip usage of temp file when writing to S3:_
  When writing a file to S3, the file system currently writes a temp file locally and syncs at the end by creating a file on S3. This coupled with the fact that S3 provides atomic uploads of files means that we will never see incomplete data uploaded for a file. In this scenario, the current usage of temp files when writing anything to the s3 file system (such as for Checkpoints, SavedModels) are unnecessary. I've removed such usage of temp files for S3 as they not just are unnecessary but cause issues with S3's consistency model. (It may so happen that after writing to a temp file, the file is not visible while moving to final location because changes haven't propagated yet. )

- _Skip usage of temp directory when saving Checkpoints and SavedModels to S3:_ 
  When saving Checkpoints and SavedModels, there is also the use of a temp directory where all files are uploaded and then moved to the final location. This is even more problematic given S3's eventual consistency model. This sequence of operations involves the writing to temp location, listing of files in temp location, copying each file from this temp location to final location, and deleting the temp location. There are multiple issues users have experienced because of this sequence. When listing files in temp directory, in some cases not all files show up in the list. This causes some files to not be copied. While deleting directory, there is another listing of all files in the directory. Again this list may be inconsistent and the deleting of directory fails. So the usage of such temp directory has been bypassed for S3 file system.

- The above two changes have been implemented by introducing a NeedsTempLocation method for the filesystem and exposing it to python through gfile similar to how IsDirectory works. This method needs to be used multiple places both in python and CPP. By default for any file system other than S3, it returns False, which allows us to skip the usage of temp locations.

- The above issues for Checkpointing and SavedModels have been addressed and verified for both code paths of Estimator based training, Session based training as well as Keras. 

- _Retry failed operations before crashing:_
  It is recommended to use retries to handle exceptions in the case of unexpected errors due to the eventual consistency paradigm. Moved the class retrying_file_system from `platform/cloud` to `platform/` and reused that for S3 file system.

**Reliability and Performance**
- _Use TransferManager from the AWS CPP SDK to upload files to S3_ 
Using PUT for uploads as is done currently has a few limitations. It doesn't allow the upload of files larger than 5GB which in our experience, users have run into. It also doesn't retry in the case of crashes. Using the TransferManager allows us to upload larger files, upload files faster by using multi-part upload, and retry only the failed parts in case of crashes.


  | Time to upload 2GB | Time to upload 4GB | Time to upload 5.5GB
-- | -- | -- | --
Official Tensorflow r1.12 | 103 sec | 116 sec | Crash: Entity too large
Tensorflow 1.12 with S3 patch | 9 sec | 20 sec | 28 sec
Speedup | 11x | 6x |  


I request the maintainers to review, and provide feedback. 