### PR TITLE
devices: inform user that tensorflow wasn't compiled with CUDA support

### DIFF
--- a/tensorflow/core/grappler/devices.cc
+++ b/tensorflow/core/grappler/devices.cc
@@ -47,9 +47,13 @@ int GetNumAvailableGPUs() {
       }
     }
   }
-#endif  // GOOGLE_CUDA
   LOG(INFO) << "Number of eligible GPUs (core count >= 8): "
             << num_eligible_gpus;
+#else
+  LOG(INFO) << "Number of eligible GPUs (core count >= 8): "
+            << num_eligible_gpus
+            << " (Note: TensorFlow was not compiled with CUDA support)";
+#endif  // GOOGLE_CUDA
   return num_eligible_gpus;
 }
 


### PR DESCRIPTION
The current behaviour can be confusing when no GPU are found on a computer that does have GPUs, so add a warning.