### PR TITLE
Fix version number in Bazel downgrade warning

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -491,7 +491,7 @@ def check_bazel_version(min_version, max_version):
     sys.exit(0)
   if curr_version_int > max_version_int:
     print('Please downgrade your bazel installation to version %s or lower to '
-          'build TensorFlow!' % min_version)
+          'build TensorFlow!' % max_version)
     sys.exit(0)
   return curr_version
 


### PR DESCRIPTION
I have upgraded to Bazel 0.20:

```bash
$ bazel version
INFO: Invocation ID: 00114105-2567-451d-b22d-bb21e2d14b11
Build label: 0.20.0
Build target: bazel-out/k8-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Fri Nov 30 14:39:01 2018 (1543588741)
Build timestamp: 1543588741
Build timestamp as int: 1543588741
```

Bazel version check is introduced in e7a123f4b361b8104b783d8b1407b45dc087491c. 
Before this patch:

```bash
$ ./configure
WARNING: Running Bazel server needs to be killed, because the startup options are different.
WARNING: --batch mode is deprecated. Please instead explicitly shut down your Bazel server using the command "bazel shutdown".
INFO: Invocation ID: b6a7b9a2-db26-4777-a4bb-f5a668e52e82
You have bazel 0.20.0 installed.
Please downgrade your bazel installation to version 0.15.0 or lower to build TensorFlow!
Configuration finished
```

After this patch:

```bash
$ ./configure
WARNING: --batch mode is deprecated. Please instead explicitly shut down your Bazel server using the command "bazel shutdown".
INFO: Invocation ID: 34b75ed8-1359-4fa7-ba71-b67fd887ee3a
You have bazel 0.20.0 installed.
Please downgrade your bazel installation to version 0.19.2 or lower to build TensorFlow!
Configuration finished
```