### PR TITLE
TFTRT: Prevent segments with no inputs

### DIFF
--- a/tensorflow/contrib/tensorrt/convert/convert_graph.cc
+++ b/tensorflow/contrib/tensorrt/convert/convert_graph.cc
@@ -588,7 +588,7 @@ tensorflow::Status CreateTRTNode(const std::vector<EngineInfo>& infos, int pos,
   // We don't support segments with no inputs. Fall back to native TF here to
   // avoid crash later. Constant folding should've folded the ops that make up
   // these segments.
-  if (inputs.size() == 0) {
+  if (inputs.empty()) {
     return tensorflow::errors::Internal("Segment has no inputs (possible "
                                         "constfold failure)");
   }

--- a/tensorflow/contrib/tensorrt/convert/convert_graph.cc
+++ b/tensorflow/contrib/tensorrt/convert/convert_graph.cc
@@ -585,6 +585,13 @@ tensorflow::Status CreateTRTNode(const std::vector<EngineInfo>& infos, int pos,
       }
     }
   }
+  // We don't support segments with no inputs. Fall back to native TF here to
+  // avoid crash later. Constant folding should've folded the ops that make up
+  // these segments.
+  if (inputs.size() == 0) {
+    return tensorflow::errors::Internal("Segment has no inputs (possible "
+                                        "constfold failure)");
+  }
 
   const bool calibrate_int8 =
       (info.precision_mode == INT8MODE && info.use_calibration);


### PR DESCRIPTION
If a segment is created with no inputs, the TRTEngineOp created by TFTRT currently crashes during runtime. This PR simply prevents the engine for that segment from building so that the native TF fallback will be executed instead of crashing.

This issue came up for me recently trying to convert ConvS2S which uses weight normalization. I've created an issue for the potential bug in constant folding: https://github.com/tensorflow/tensorflow/issues/24083.

This may become redundant when the node validation is working for all nodes - that would disqualify these nodes from even being considered for a segment because their inputs are weights not tensors. Nevertheless it is a good check to have.