### PR TITLE
Fix for OOM caused by access of kUnknownNumaNode

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
@@ -97,7 +97,12 @@ Allocator* GPUProcessState::GetGPUAllocator(const GPUOptions& options,
     PlatformGpuId platform_gpu_id;
     TF_CHECK_OK(GpuIdManager::TfToPlatformGpuId(tf_gpu_id, &platform_gpu_id));
     int bus_id = BusIdForGPU(tf_gpu_id);
-    while (bus_id >= gpu_visitors_.size()) {
+    static const int kUnknownNumaNode = -1;
+    // Not expecting `kUnknownNumaNode` for `bus_id`
+    // Default to 0, to avoid OOM exhaustion and `gpu_visitors_` address violation
+    if (bus_id == kUnknownNumaNode)
+      bus_id = 0;
+    while (bus_id >= static_cast<int64>(gpu_visitors_.size())) {
       gpu_visitors_.push_back({});
     }
     GPUMemAllocator* sub_allocator = new GPUMemAllocator(


### PR DESCRIPTION
This bug is produced since this commit:
33170cc661f3838aa7d0d7fc19bb0c6ba4812a3c

Bug Description:

When `/sys/devices/xxx/numa_node` is not accessible,
`bus_id` in `gpu_process_state.cc` would get negative
value -1 (even if numa_node is defaulting to 0 in other
modules), thus its following loop would execute infinitely
and crash with system memory exhaustion:

```
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
```

Afterwards, the container `gpu_visitors_` is also not
allowed to accept negative-value index access.

Signed-off-by: CUI Wei <ghostplant@qq.com>