### PR TITLE
TFLite: transpose_conv: fix padding height/width

### DIFF
--- a/tensorflow/lite/kernels/transpose_conv.cc
+++ b/tensorflow/lite/kernels/transpose_conv.cc
@@ -212,8 +212,8 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteFloat32: {
       tflite::ConvParams op_params;
       op_params.padding_type = PaddingType::kSame;
-      op_params.padding_values.width = padding_size.width;
-      op_params.padding_values.height = padding_size.height;
+      op_params.padding_values.width = padding_size.height;
+      op_params.padding_values.height = padding_size.width;
       op_params.stride_width = stride_width;
       op_params.stride_height = stride_height;
       switch (kernel_type) {


### PR DESCRIPTION
The Conv2D_transpose op in TFLite does not handle non-square padding
correctly and the outputs do not match regular TensorFlow. Since this op
is transposed, height and width of the padding must be swapped.
Thanks to Matt Elsey for discovering this and developing the fix.

Signed-off-by: Jason Zaman <jason@perfinion.com>

This verifies the error:

```
#!/usr/bin/env python3

import tensorflow as tf
import numpy as np
import matplotlib
matplotlib.use("agg")
from matplotlib import pyplot as plt


IN_IMG_SHAPE = (1, 50, 54, 3)
IN_FILTER_SHAPE = (3, 3, 6, 3)
OUT_SHAPE = (1, 100, 108, 8)

errs = np.zeros((10, 10))

for xf in range(10):
    for yf in range(10):
        IN_FILTER_SHAPE = (1+xf, 1+yf, 8, 3)

        xx = np.array(np.random.random_sample(IN_IMG_SHAPE), dtype=np.float32)
        kk = np.array(np.random.random_sample(IN_FILTER_SHAPE), dtype=np.float32)

        x = tf.placeholder(dtype=tf.float32, shape=IN_IMG_SHAPE)
        k = tf.placeholder(dtype=tf.float32, shape=IN_FILTER_SHAPE)

        y = tf.nn.conv2d_transpose(x, k, output_shape=OUT_SHAPE, padding='SAME', strides=(1, 2, 2, 1))


        with tf.Session() as sess:
            converter = tf.contrib.lite.TFLiteConverter.from_session(sess, [x, k], [y])
            tflite_model = converter.convert()

            z = sess.run(y, feed_dict={x: xx, k: kk})

        # Load TFLite model and allocate tensors.
        interpreter = tf.contrib.lite.Interpreter(model_content=tflite_model)
        interpreter.allocate_tensors()

        # Get input and output tensors.
        input_details = interpreter.get_input_details()
        output_details = interpreter.get_output_details()

        interpreter.set_tensor(input_details[0]['index'], xx)
        interpreter.set_tensor(input_details[1]['index'], kk)
        interpreter.invoke()

        output_data = interpreter.get_tensor(output_details[0]['index'])

        assert output_data.shape == OUT_SHAPE

        errs[yf, xf] = np.sqrt(np.sum(np.abs(output_data  - z) ** 2) / z.size)


plt.figure(figsize=(6, 6))
plt.imshow(errs, extent=[0.5, 10.5, 0.5, 10.5])
plt.xlabel("kernel x size")
plt.ylabel("kernel y size")
plt.title("L2 diff in tf/tflite output conv2d_transpose")
plt.colorbar()
plt.savefig("out.png")
#plt.show()
```