### PR TITLE
Improve performance of LRNGrad on CPU builds

### DIFF
--- a/tensorflow/core/kernels/lrn_op.cc
+++ b/tensorflow/core/kernels/lrn_op.cc
@@ -312,7 +312,11 @@ struct LaunchLRNGrad;
 template <typename T>
 struct LaunchLRNGrad<CPUDevice, T> {
   LaunchLRNGrad(int depth_radius, T bias, T alpha, T beta)
-      : depth_radius_(depth_radius), bias_(bias), alpha_(alpha), beta_(beta) {}
+      : depth_radius_(depth_radius),
+        bias_(bias),
+        alpha_(alpha),
+        beta_(beta),
+        alpha_beta_2_(T(-2) * alpha * beta) {}
 
   void launch(OpKernelContext* context, OpKernel* kernel,
               const Tensor& in_grads, const Tensor& in_image,
@@ -358,13 +362,15 @@ struct LaunchLRNGrad<CPUDevice, T> {
           }
           norm = alpha_ * norm + bias_;
           DCHECK_GT(norm, T(1e-6));
+          T pre_computed_pow = Eigen::numext::pow(norm, -beta_);
+          T activations_ab2 = alpha_beta_2_ * activations(i, j);
+          T gs = grads_shaped(i, j);
           for (int64 k = depth_begin; k < depth_end; ++k) {
-            T dyi = T(-2) * alpha_ * beta_ * in_shaped(i, k) *
-                    activations(i, j) / norm;
+            T dyi = in_shaped(i, k) * activations_ab2 / norm;
             if (k == j) {
-              dyi += Eigen::numext::pow(norm, -beta_);
+              dyi += pre_computed_pow;
             }
-            dyi *= grads_shaped(i, j);
+            dyi *= gs;
             const_cast<typename TTypes<T, 2>::Tensor&>(out_shaped)(i, k) += dyi;
           }
         }
@@ -379,6 +385,7 @@ struct LaunchLRNGrad<CPUDevice, T> {
   T bias_;
   T alpha_;
   T beta_;
+  T alpha_beta_2_;
 };
 
 #if GOOGLE_CUDA

--- a/tensorflow/core/kernels/lrn_op_test.cc
+++ b/tensorflow/core/kernels/lrn_op_test.cc
@@ -29,6 +29,10 @@ limitations under the License.
 #include "tensorflow/core/lib/random/simple_philox.h"
 #include "tensorflow/core/platform/test.h"
 
+#include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/graph/node_builder.h"
+#include "tensorflow/core/platform/test_benchmark.h"
+
 namespace tensorflow {
 
 static const float tol_ = 1e-4;
@@ -195,4 +199,41 @@ TCASE(T3, 128,   4,     3,            2.0f, 1.0f,  1.0f)
 // clang-format on
 
 #undef TCASE
+
+static Graph* BM_LRNGrad(int batches, int rows, int cols, int depth,
+                         int depth_radius) {
+  Graph* g = new Graph(OpRegistry::Global());
+  Tensor grads(DT_FLOAT, TensorShape({batches, rows, cols, depth}));
+  grads.flat<float>().setRandom();
+
+  Tensor in(DT_FLOAT, TensorShape({batches, rows, cols, depth}));
+  in.flat<float>().setRandom();
+
+  Tensor out(DT_FLOAT, TensorShape({batches, rows, cols, depth}));
+
+  Node* ret;
+  TF_CHECK_OK(NodeBuilder(g->NewName("lrn_grad_op"), "LRNGrad")
+                  .Input(test::graph::Constant(g, grads))
+                  .Input(test::graph::Constant(g, in))
+                  .Input(test::graph::Constant(g, out))
+                  .Attr("depth_radius", depth_radius)
+                  .Attr("bias", 1.0f)
+                  .Attr("alpha", 1.0f / 10)
+                  .Attr("beta", 2.0f)
+                  .Finalize(g, &ret));
+  return g;
+}
+
+#define BM_LRNGradDev(DEVICE, B, R, C, D, DR)                                 \
+  static void BM_LRNGrad_##DEVICE##_##B##_##R##_##C##_##D##_##DR(int iters) { \
+    testing::ItemsProcessed(static_cast<int64>(iters) * B * R * C * D * DR *  \
+                            4);                                               \
+    test::Benchmark(#DEVICE, BM_LRNGrad(B, R, C, D, DR)).Run(iters);          \
+  }                                                                           \
+  BENCHMARK(BM_LRNGrad_##DEVICE##_##B##_##R##_##C##_##D##_##DR)
+
+BM_LRNGradDev(cpu, 128, 12, 12, 64, 4);
+BM_LRNGradDev(cpu, 128, 56, 56, 64, 2);
+BM_LRNGradDev(cpu, 128, 27, 27, 192, 2);
+
 }  // namespace tensorflow


### PR DESCRIPTION
This PR improves the performance of the CPU version of LRNGrad by moving a number of computations out of its innermost loop.  The extent of the resulting performance gains is dependent on the depth_radius, the compiler and the number of CPUs available.  The BM_LRNGrad benchmark is showing a 1.48x performance gain for a depth_radius of 4 and a 1.31x gain for a depth_radius of 2 when built with gcc 7.3.0 and run on a single core machine.  With gcc 5.4.0 the results on a single core machine are less impressive but are nonetheless significant;  1.13x for a depth radius of 4 and 1.10x with a depth radius of 2. With gcc 7.3.0 on a 16 core machine speed ups of 1.4x and 1.2x can be observed using a depth radius of 4 and 2 respectively.

The PR also includes a new benchmark for LRNGradOp, used to measure the performance gains, and fixes some formatting issues with the lrn_op.cc file.