### PR TITLE
Expose underlying operation in op wrappers

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Session.java
@@ -149,19 +149,9 @@ public final class Session implements AutoCloseable {
 
     /**
      * Use {@code t} instead of the Tensor referred to by executing the operation referred to by
-     * {@code output}.
-     */
-    public Runner feed(Output<?> o, Tensor<?> t) {
-      inputs.add(o);
-      inputTensors.add(t);
-      return this;
-    }
-
-    /**
-     * Use {@code t} instead of the Tensor referred to by executing the operation referred to by
      * {@code operand}.
      */
-    public <T> Runner feed(Operand<T> operand, Tensor<T> t) {
+    public Runner feed(Operand<?> operand, Tensor<?> t) {
       inputs.add(operand.asOutput());
       inputTensors.add(t);
       return this;

--- a/tensorflow/java/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Session.java
@@ -158,6 +158,16 @@ public final class Session implements AutoCloseable {
     }
 
     /**
+     * Use {@code t} instead of the Tensor referred to by executing the operation referred to by
+     * {@code operand}.
+     */
+    public <T> Runner feed(Operand<T> operand, Tensor<T> t) {
+      inputs.add(operand.asOutput());
+      inputTensors.add(t);
+      return this;
+    }
+
+    /**
      * Make {@link #run()} return the output of {@code operation}.
      *
      * @param operation Is either the string name of the operation, in which case this method is a

--- a/tensorflow/java/src/main/java/org/tensorflow/op/PrimitiveOp.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/op/PrimitiveOp.java
@@ -24,6 +24,13 @@ import org.tensorflow.Operation;
  * PrimitiveOp}. Custom operations working with only one primitive may also derive from this class.
  */
 public abstract class PrimitiveOp implements Op {
+  
+  /**
+   * Returns the underlying {@link Operation}
+   */
+  public Operation op() {
+    return operation;
+  }
 
   @Override
   public final int hashCode() {
@@ -48,10 +55,6 @@ public abstract class PrimitiveOp implements Op {
     return String.format("<%s '%s'>", operation.type(), operation.name());
   }
 
-  /**
-   * Underlying operation. It is deliberately not exposed by a getter method to avoid any name
-   * conflict with generated methods of the subclasses.
-   */
   protected final Operation operation;
 
   /**


### PR DESCRIPTION
Little tweaks in the Java API here:

1) Expose the underlying operation of an op wrapper because some ops don't have any outputs (e.g. `WriteSummary`), which makes it harder to refer them after creation. So now, we can do:
```
WriteSummary summary = WriteSummary.create(...);
Session.runner.addTarget(summary.op()).run();
```

2) Allow feeding input tensors by referring an operand directly. ex:
```
Placeholder<Float> inputs = ops.placeholder(...);
try (Tensor<Float> inputTensors = Tensors.create(...)) {
    Session.runner.feed(inputs, inputTensors).run();
}
```

@asimshankar if you agree with those changes, is it possible to merge them for 1.13? I have some pending examples that I would like to add to `tensorflow/models` which depends on them. Thanks!