### PR TITLE
Calculate the output size instead of using hardcoded value in the iOS Camera Example

### DIFF
--- a/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm
+++ b/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm
@@ -330,8 +330,10 @@ void ProcessInputWithQuantizedModel(
   const int output_tensor_index = interpreter->outputs()[0];
   TfLiteTensor* output_tensor = interpreter->tensor(output_tensor_index);
   TfLiteIntArray* output_dims = output_tensor->dims;
-  assert(output_dims->size == 2);
-  const int output_size = output_dims->data[1]-output_dims->data[0];
+  if(output_dims->size != 2 || output_dims->data[0] != 1) {
+    LOG(FATAL) << "Output of the model is in invalid format.";
+  }
+  const int output_size = output_dims->data[1];
     
   const int kNumResults = 5;
   const float kThreshold = 0.1f;

--- a/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm
+++ b/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm
@@ -326,7 +326,13 @@ void ProcessInputWithQuantizedModel(
   NSLog(@"Time: %.4lf, avg: %.4lf, count: %d", end - start, total_latency / total_count,
         total_count);
 
-  const int output_size = 1000;
+  // read output size from the output sensor
+  const int output_tensor_index = interpreter->outputs()[0];
+  TfLiteTensor* output_tensor = interpreter->tensor(output_tensor_index);
+  TfLiteIntArray* output_dims = output_tensor->dims;
+  assert(output_dims->size == 2);
+  const int output_size = output_dims->data[1]-output_dims->data[0];
+    
   const int kNumResults = 5;
   const float kThreshold = 0.1f;
 


### PR DESCRIPTION
[The Tensorflow Lite Camera example](https://www.tensorflow.org/lite/demo_ios) hardcodes the output tensor size to `1000`. If you test the example with a retrained model having a smaller number of outputs, the iOS app crashes. The PR fixes the problem by reading the output size from the model output tensor dimensions.