### PR TITLE
Added comment to Decoder.finalize

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/decoder.py
+++ b/tensorflow/contrib/seq2seq/python/ops/decoder.py
@@ -112,6 +112,20 @@ class Decoder(object):
     raise NotImplementedError
 
   def finalize(self, outputs, final_state, sequence_lengths):
+    """Called after any decoding iterations.
+
+    Args:
+      outputs: RNNCell outputs (possibly nested tuple of) tensor[s] for all time
+        steps.
+      final_state: RNNCell final state (possibly nested tuple of) tensor[s] for
+        last time step.
+      sequence_lengths: Scalar `int32` tensor. Maximum sequence length.
+
+    Returns:
+      `(final_outputs, final_state)`: `final_outputs` is an object containing
+      the final decoder output, `final_state` is a (structure of) state tensors and
+      TensorArrays.
+    """
     raise NotImplementedError
 
   @property

--- a/tensorflow/contrib/seq2seq/python/ops/decoder.py
+++ b/tensorflow/contrib/seq2seq/python/ops/decoder.py
@@ -119,7 +119,7 @@ class Decoder(object):
         steps.
       final_state: RNNCell final state (possibly nested tuple of) tensor[s] for
         last time step.
-      sequence_lengths: `int32` tensor containing lengths of each sequences.
+      sequence_lengths: 1-D `int32` tensor containing lengths of each sequences.
 
     Returns:
       `(final_outputs, final_state)`: `final_outputs` is an object containing

--- a/tensorflow/contrib/seq2seq/python/ops/decoder.py
+++ b/tensorflow/contrib/seq2seq/python/ops/decoder.py
@@ -119,7 +119,7 @@ class Decoder(object):
         steps.
       final_state: RNNCell final state (possibly nested tuple of) tensor[s] for
         last time step.
-      sequence_lengths: Scalar `int32` tensor. Maximum sequence length.
+      sequence_lengths: `int32` tensor containing lengths of each sequences.
 
     Returns:
       `(final_outputs, final_state)`: `final_outputs` is an object containing

--- a/tensorflow/contrib/seq2seq/python/ops/decoder.py
+++ b/tensorflow/contrib/seq2seq/python/ops/decoder.py
@@ -123,8 +123,8 @@ class Decoder(object):
 
     Returns:
       `(final_outputs, final_state)`: `final_outputs` is an object containing
-      the final decoder output, `final_state` is a (structure of) state tensors and
-      TensorArrays.
+      the final decoder output, `final_state` is a (structure of) state tensors
+      and TensorArrays.
     """
     raise NotImplementedError
 

--- a/tensorflow/contrib/seq2seq/python/ops/decoder.py
+++ b/tensorflow/contrib/seq2seq/python/ops/decoder.py
@@ -112,14 +112,14 @@ class Decoder(object):
     raise NotImplementedError
 
   def finalize(self, outputs, final_state, sequence_lengths):
-    """Called after any decoding iterations.
+    """Called after decoding iterations complete.
 
     Args:
       outputs: RNNCell outputs (possibly nested tuple of) tensor[s] for all time
         steps.
       final_state: RNNCell final state (possibly nested tuple of) tensor[s] for
         last time step.
-      sequence_lengths: 1-D `int32` tensor containing lengths of each sequences.
+      sequence_lengths: 1-D `int32` tensor containing lengths of each sequence.
 
     Returns:
       `(final_outputs, final_state)`: `final_outputs` is an object containing


### PR DESCRIPTION
Hi. I'm Korean student, recently studying tensorflow.

At first, I'm sorry about my poor english.

I found a curious thing that only `finalize` method in `contrib.seq2seq.Decoder` doesn't have any comment in documents.

So, I tried to write some comments on it, usually copying from comments from other methods.