### PR TITLE
Fix TF Lite Android Demo app build to work in Android Studio

### DIFF
--- a/tensorflow/lite/java/demo/app/build.gradle
+++ b/tensorflow/lite/java/demo/app/build.gradle
@@ -1,8 +1,21 @@
 apply plugin: 'com.android.application'
 
+buildscript {
+    repositories {
+        // Gradle 4.1 and higher include support for Google's Maven repo using
+        // the google() method. And you need to include this repo to download
+        // Android Gradle plugin 3.0.0 or higher.
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.2.1'
+    }
+}
+
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "android.example.com.tflitecamerademo"
         // Required by Camera2 API.
@@ -10,11 +23,6 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
-
-        // Remove this block.
-        jackOptions {
-            enabled true
-        }
     }
     lintOptions {
         abortOnError false
@@ -44,22 +52,24 @@ allprojects {
     repositories {
         // Uncomment if you want to use a local repo.
         // mavenLocal()
+        google()
         jcenter()
+        mavenCentral()
     }
 }
 
-
+ext.supportLibraryVersion = '26.1.0'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.2.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'com.android.support:design:25.2.0'
-    compile 'com.android.support:support-annotations:25.3.1'
-    compile 'com.android.support:support-v13:25.2.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support.constraint:constraint-layout:1.1.3"
+    implementation "com.android.support:design:$supportLibraryVersion"
+    implementation "com.android.support:support-annotations:$supportLibraryVersion"
+    implementation "com.android.support:support-v13:$supportLibraryVersion"
 
     // Build off of nightly TensorFlow Lite
-    compile 'org.tensorflow:tensorflow-lite:0.0.0-nightly'
+    implementation "org.tensorflow:tensorflow-lite:0.0.0-nightly"
     // Use local TensorFlow library
     // compile 'org.tensorflow:tensorflow-lite-local:0.0.0'
 }
@@ -69,7 +79,6 @@ def modelFloatDownloadUrl = "http://download.tensorflow.org/models/mobilenet_v1_
 def modelQuantDownloadUrl = "http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz"
 def localCacheFloat = "build/intermediates/mobilenet_v1_1.0_224.tgz"
 def localCacheQuant = "build/intermediates/mmobilenet_v1_1.0_224_quant.tgz"
-
 
 task downloadModelFloat(type: DownloadUrlTask) {
     doFirst {

--- a/tensorflow/lite/java/demo/app/src/main/AndroidManifest.xml
+++ b/tensorflow/lite/java/demo/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />
 
+    <!-- Kept in the manifest too so this project can be built with Bazel. -->
     <uses-sdk android:minSdkVersion="21" />
 
     <application android:allowBackup="true"

--- a/tensorflow/lite/java/demo/build.gradle
+++ b/tensorflow/lite/java/demo/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tensorflow/lite/java/demo/gradle/wrapper/gradle-wrapper.properties
+++ b/tensorflow/lite/java/demo/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 28 09:01:41 PDT 2017
+#Sun Dec 09 11:55:51 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
**TESTING**

- Before the fix I was unable to build in either Android Studio 3.1, or Android Studio 3.2.  
- After the fix I could build and launch the app using Android Studio 3.2.1 and emulator Pixel XL API 24.

**DETAIL**

Here is a list of seven of the errors resolved by these updates:

1) Disable Jack to fix compile errors.

Error was:
```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':app:transformJackWithJackForDebug'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:84)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:55)
	... (truncated)
```

Source: https://developer.android.com/studio/write/java8-support#disable_jack

2) Update the plugin to support Java 8 features.

Error was:
```
Jack is required to support java 8 language features. Either enable Jack or remove sourceCompatibility JavaVersion.VERSION_1_8.
```

Source: https://developer.android.com/studio/releases/gradle-plugin#updating-plugin

3) Update repositories to include google()

Error was:
```
Could not find com.android.tools.build:aapt2:3.2.1-4818971.
```

4) Change 'compile' to 'implementation' in build.gradle

Error was:
```
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```

5) Update build tools

Error was:
```
The specified Android SDK Build Tools version (26.0.3) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.2.1.
Android SDK Build Tools 28.0.3 will be used.
To suppress this warning, remove "buildToolsVersion '26.0.3'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
Update Build Tools version and sync project
Open File
```

6) Update library dependencies

![screen shot 2018-12-09 at 11 51 26 am](https://user-images.githubusercontent.com/739125/49700514-97d47f80-fbad-11e8-8222-74469ddb705d.png)

![screen shot 2018-12-09 at 12 16 09 pm](https://user-images.githubusercontent.com/739125/49700518-a6229b80-fbad-11e8-9cf1-50637de78ed1.png)

**MISC NOTES**

AndroidManifest.xml shows this warning in Android Studio:
```
The minSdk version should not be declared in the android manifest file. You can move the version from the manifest to the defaultConfig in the build.gradle file.
Open Manifest File
Remove minSdkVersion and sync project
```
@jdduke requested we leave the minSdkVersion in AndroidManifest.xml so it can still be built with Bazel.  I added a [comment to the XML](https://github.com/tensorflow/tensorflow/pull/24255/files#diff-b2a1cafabbd44e7687f1ac02600d8da4R26
) to warn other people not to try and fix that warning.