### PR TITLE
[tensor_forest] Add total variance in the additional_data of tree leaf

### DIFF
--- a/tensorflow/contrib/tensor_forest/kernels/v4/BUILD
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/BUILD
@@ -100,6 +100,7 @@ cc_library(
     deps = [
         ":input_target",
         ":params",
+        ":stat_utils",
     ] + if_static(
         [
             "//tensorflow/contrib/decision_trees/proto:generic_tree_model_cc",

--- a/tensorflow/contrib/tensor_forest/kernels/v4/leaf_model_operators.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/leaf_model_operators.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 // =============================================================================
 #include "tensorflow/contrib/tensor_forest/kernels/v4/leaf_model_operators.h"
+#include "tensorflow/contrib/tensor_forest/kernels/v4/stat_utils.h"
 
 namespace tensorflow {
 namespace tensorforest {
@@ -158,6 +159,10 @@ void RegressionLeafModelOperator::ExportModel(
         stat.weight_sum();
     leaf->mutable_vector()->add_value()->set_float_value(new_val);
   }
+  const float total_variance = TotalVariance(stat);
+  decision_trees::Value v;
+  v.set_float_value(total_variance);
+  leaf->mutable_additional_data()->Add()->PackFrom(v);
 }
 
 }  // namespace tensorforest


### PR DESCRIPTION
To support total variance on forest level, we need to add total variance to tree level 

This pr add variance to the leaf  during export the leaf for regression task