### PR TITLE
Enable dataset.map to respect seeds from the outer context

### DIFF
--- a/tensorflow/python/data/kernel_tests/map_test.py
+++ b/tensorflow/python/data/kernel_tests/map_test.py
@@ -32,6 +32,7 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import random_seed
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.framework import test_util
@@ -1063,6 +1064,20 @@ class MapDatasetTest(test_base.DatasetTestBase, parameterized.TestCase):
     with self.assertRaises(errors.InvalidArgumentError):
       self.evaluate(get_next())
 
+  def testRandomShuffleWithGlobalSeed(self):
+    random_seed.set_random_seed(999)
+
+    dataset1 = dataset_ops.Dataset.range(100).batch(4).map(
+        lambda x: random_ops.random_shuffle(x))
+    get_next1 = self.getNext(dataset1)
+    output1 = [self.evaluate(get_next1()) for _ in range(25)]
+
+    dataset2 = dataset_ops.Dataset.range(100).batch(4).map(
+        lambda x: random_ops.random_shuffle(x))
+    get_next2 = self.getNext(dataset2)
+    output2 = [self.evaluate(get_next2()) for _ in range(25)]
+
+    self.assertAllEqual(output1, output2)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2035,11 +2035,16 @@ class StructuredFunctionWrapper(object):
     if defun_kwargs is None:
       defun_kwargs = {}
 
+    self._graph_level_seed, _ = core_random_seed.get_seed(None)
+
     @function.Defun(
         *self._input_structure._flat_types, func_name=self._func_name,  # pylint: disable=protected-access
         **defun_kwargs)
     def tf_data_structured_function_wrapper(*args):
       """Wrapper for passing nested structures to and from tf.data functions."""
+      if self._graph_level_seed is not None:
+        core_random_seed.set_random_seed(self._graph_level_seed)
+
       # pylint: disable=protected-access
       nested_args = self._input_structure._from_compatible_tensor_list(args)
       if not _should_unpack_args(nested_args):


### PR DESCRIPTION
This PR fix #23789. It enables `dataset.map` to respect seeds from the outer context.