### PR TITLE
Fix warning caused by to_int32

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3061,8 +3061,8 @@ def reduced_shape(input_shape, axes):
     input_shape[axes] = 1
     return input_shape
 
-  input_shape = to_int32(input_shape)  # [2, 3, 5, 7]
-  axes = to_int32(axes)  # [1, 2]
+  input_shape = cast(input_shape, dtypes.int32)  # [2, 3, 5, 7]
+  axes = cast(axes, dtypes.int32)  # [1, 2]
 
   input_rank = array_ops.size(input_shape)  # 4
   axes = (axes + input_rank) % input_rank


### PR DESCRIPTION
While running tf.keras I noticed the following warning:
```
WARNING:tensorflow:From /usr/local/lib/python2.7/dist-
  packages/tensorflow/python/ops/math_ops.py:3064: 
  to_int32 (from tensorflow.python.ops.math_ops) is 
  deprecated and will be removed in a future version.
Instructions for updating:
Use tf.cast instead.
```

This fix fixes the warning caused by deprecated to_int32.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>