### PR TITLE
Make tf.image.convert_image_dtype() float to int conversions symmetric

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1493,13 +1493,13 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
         scale = 1. / image.dtype.max
         return math_ops.multiply(cast, scale, name=name)
       else:
-        # Converting from float: first scale, then cast
-        scale = dtype.max + 0.5  # avoid rounding problems in the cast
-        scaled = math_ops.multiply(image, scale)
+        # Converting from float: first scale, then round and cast
+        scaled = math_ops.multiply(image, dtype.max)
+        rounded = math_ops.round(scaled)
         if saturate:
-          return math_ops.saturate_cast(scaled, dtype, name=name)
+          return math_ops.saturate_cast(rounded, dtype, name=name)
         else:
-          return math_ops.cast(scaled, dtype, name=name)
+          return math_ops.cast(rounded, dtype, name=name)
 
 
 @tf_export('image.rgb_to_grayscale')


### PR DESCRIPTION
When `tf.image.convert_image_dtype()` converts floating-point image data to integer types, it is currently scaling by `dtype.max + 0.5` and then truncating. This biases the converted values, and is not symmetric with respect to  the integer to floating-point transformation, which simply scales the integer values by `1. / dtype.max`. As a result, integer data values that are read from an image file, converted to floats in the [0, 1.0] range, perturbed only very slightly, and then converted back to an integer image type, may result in different pixel values than the original image (which is undesirable).

This PR changes the floating-point to integer conversion such that values are scaled by simply multiplying by `dtype.max` and rounding, which results in better numerical stability and symmetry with the conversion in the opposite direction.

The type conversion method in this PR is also more consistent with other image processing libraries. For example, the `scikit-image` (`skimage`) behavior is documented as:

> By default...floating point values are scaled and rounded to the nearest integers, which minimizes back and forth conversion errors.