### PR TITLE
fix genop/internal/api_def_map.go cannot find package bug

### DIFF
--- a/tensorflow/go/genop/generate.sh
+++ b/tensorflow/go/genop/generate.sh
@@ -55,4 +55,4 @@ mkdir -p ./internal/proto
 ${PROTOC} \
   -I ${TF_DIR} \
   --go_out=./internal/proto \
-  ${TF_DIR}/tensorflow/core/framework/*.proto
+  /tensorflow/core/framework/*.proto


### PR DESCRIPTION
run generate.sh will generate path ```${GOPATH}/src/github.com/tensorflow/tensorflow/tensorflow/go/genop/internal/proto/github.com/tensorflow/tensorflow/tensorflow/go/core/framework```

but in https://github.com/tensorflow/tensorflow/blob/master/tensorflow/go/genop/internal/api_def_map.go?L34#L34 

tensorflow/tensorflow/go/genop/internal/api_def_map.go
```go
import (
//...

//  line 34
pb "github.com/tensorflow/tensorflow/tensorflow/go/genop/internal/proto/tensorflow/core/framework_go_proto"
)

```

run ```go generate github.com/tensorflow/tensorflow/tensorflow/go/op``` will has cannot find package error

```text
../genop/internal/api_def_map.go:34:2: cannot find package "github.com/tensorflow/tensorflow/tensorflow/go/genop/internal/proto/tensorflow/core/framework_go_proto" in any of:
	/usr/local/go/src/github.com/tensorflow/tensorflow/tensorflow/go/genop/internal/proto/tensorflow/core/framework_go_proto (from $GOROOT)
	/home/qydev/go/src/github.com/tensorflow/tensorflow/tensorflow/go/genop/internal/proto/tensorflow/core/framework_go_proto (from $GOPATH)
go/src/github.com/tensorflow/tensorflow/tensorflow/go/op/generate.go:18: running "go": exit status 1
```