### PR TITLE
[ROCm] ROCm-specific GPU utility functions.

### DIFF
--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -33,7 +33,8 @@ limitations under the License.
 #if GOOGLE_CUDA
 #define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, \
                           shared_mem, stream, ...) \
-  kernel<<<block_count, threads_per_block, shared_mem, stream>>>(__VA_ARGS__);
+  TF_CHECK_OK(CudaLaunchKernel(kernel, block_count, threads_per_block, \
+                               shared_mem, stream, __VA_ARGS__));
 #elif TENSORFLOW_USE_ROCM
 #define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, \
                           shared_mem, stream, ...) \

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -52,25 +52,16 @@ limitations under the License.
 
 #if GOOGLE_CUDA
 #define gpuSuccess cudaSuccess
-#define GPUGETERRORSTRING(error) cudaGetErrorString(error)
 using gpuStream_t = cudaStream_t;
-#define GPUGETLASTERROR() cudaGetLastError()
 using gpuError_t = cudaError_t;
-#define GPUSUCCESSS cudaSuccess
+
 #elif TENSORFLOW_USE_ROCM
 #define gpuSuccess hipSuccess
-#define GPUGETERRORSTRING(error) hipGetErrorString(error)
 using gpuStream_t = hipStream_t;
-#define GPUGETLASTERROR() hipGetLastError()
 using gpuError_t = hipError_t;
-#define GPUSUCCESSS hipSuccess
 #endif
 
-#if GOOGLE_CUDA
 #define GetGPUStream(context) context->eigen_gpu_device().stream()
-#elif TENSORFLOW_USE_ROCM
-#define GetGPUStream(context) context->eigen_gpu_device().stream()
-#endif
 
 namespace tensorflow {
 __host__ __device__ inline tensorflow::bfloat16 CudaLdg(

--- a/tensorflow/core/util/gpu_launch_config.h
+++ b/tensorflow/core/util/gpu_launch_config.h
@@ -168,9 +168,13 @@ inline CudaLaunchConfig GetCudaLaunchConfig(int work_element_count,
   //    block_size_limit);
   //CHECK_EQ(err, hipSuccess);
 
+  // Apply the heuristic in GetGpuLaunchConfig(int, const Eigen::GpuDevice&)
+  // that the kernel is quite simple and will largely be memory-limited.
   const int physical_thread_count = std::min(
       d.getNumGpuMultiProcessors() * d.maxGpuThreadsPerMultiProcessor(),
       work_element_count);
+  // Assume the kernel be simple enough that it is okay to use 1024 threads
+  // per workgroup.
   thread_per_block = std::min(1024, d.maxGpuThreadsPerBlock());
   block_count =
       std::min(DivUp(physical_thread_count, thread_per_block),
@@ -212,9 +216,13 @@ inline CudaLaunchConfig GetCudaLaunchConfigFixedBlockSize(
   //    block_size_limit);
   //CHECK_EQ(err, hipSuccess);
 
+  // Apply the heuristic in GetGpuLaunchConfig(int, const Eigen::GpuDevice&)
+  // that the kernel is quite simple and will largely be memory-limited.
   const int physical_thread_count = std::min(
       d.getNumGpuMultiProcessors() * d.maxGpuThreadsPerMultiProcessor(),
       work_element_count);
+  // Assume the kernel be simple enough that it is okay to use 1024 threads
+  // per workgroup.
   int thread_per_block = std::min(1024, d.maxGpuThreadsPerBlock());
   block_count =
       std::min(DivUp(physical_thread_count, thread_per_block),
@@ -304,10 +312,10 @@ inline Cuda3DLaunchConfig GetCuda3DLaunchConfig(
 #elif TENSORFLOW_USE_ROCM
   // ROCM TODO re-enable this after hipOccupancyMaxPotentialBlockSize is
   // implemented
-  //hipError_t err = hipOccupancyMaxPotentialBlockSize(
+  // hipError_t err = hipOccupancyMaxPotentialBlockSize(
   //    &block_count, &thread_per_block, func, dynamic_shared_memory_size,
   //    block_size_limit);
-  //CHECK_EQ(err, hipSuccess);
+  // CHECK_EQ(err, hipSuccess);
 
   const int physical_thread_count =
       d.getNumGpuMultiProcessors() * d.maxGpuThreadsPerMultiProcessor();


### PR DESCRIPTION
Common utility helpers between CUDa and ROCm are renamed:
- core/util/cuda_device_functions.h -> core/util/gpu_device_functions.h
- core/util/cuda_kernel_helper.h -> core/util/gpu_kernel_helper.h
- core/util/cuda_kernel_helper_test.cu.cc -> core/util/gpu_kernel_helper_test.cu.cc
- core/util/cuda_launch_config.h -> core/util/gpu_launch_cnofig.h

ROCm-specific changes for GPU device functions are also introduced in this PR.

GPU kernel invocation logic would be introduced in the next PR. All custom CUDA kernels are still launched as `CudaLaunchKernel` for now.