### PR TITLE
Add cuDNN deterministic env variable (only for convolution)

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -340,8 +340,8 @@ port::Status GetLoadedCudnnVersion(CudnnVersion* version) {
 }  // namespace
 
 CudnnSupport::CudnnSupport(CUDAExecutor* parent) : parent_(parent) {
-  tensorflow::ReadBoolFromEnvVar("CUDNN_DETERMINISTIC", false,
-                                 &cudnn_deterministic);
+  tensorflow::ReadBoolFromEnvVar("TF_CUDNN_DETERMINISTIC", false,
+                                 &cudnn_deterministic_);
 }
 
 port::Status CudnnSupport::Init() {
@@ -2682,7 +2682,7 @@ bool CudnnSupport::GetConvolveAlgorithms(
   }
 
   out_algorithms->clear();
-  if (cudnn_deterministic) {
+  if (cudnn_deterministic_) {
     out_algorithms->push_back({CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM,
                                /*user_tensor_ops=*/false});
   } else {
@@ -2735,7 +2735,7 @@ bool CudnnSupport::GetConvolveBackwardDataAlgorithms(
   }
 
   out_algorithms->clear();
-  if (cudnn_deterministic) {
+  if (cudnn_deterministic_) {
     out_algorithms->push_back({CUDNN_CONVOLUTION_BWD_DATA_ALGO_1,
                                /*use_tensor_ops=*/false});
   } else {
@@ -2771,7 +2771,7 @@ bool CudnnSupport::GetConvolveBackwardFilterAlgorithms(
   }
 
   out_algorithms->clear();
-  if (cudnn_deterministic) {
+  if (cudnn_deterministic_) {
     out_algorithms->push_back({CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1,
                                /*use_tensor_ops=*/false});
   } else {

--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -637,6 +637,8 @@ class CudnnSupport : public dnn::DnnSupport {
   // Provides access to the cuDNN handle.
   std::unique_ptr<class CudnnAccess> cudnn_;
 
+  bool cudnn_deterministic = false;
+
   template <class T, class U>
   port::Status DoBatchNormalizationForwardImpl(
       Stream* stream, dnn::DataType input_data_type,

--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -637,7 +637,7 @@ class CudnnSupport : public dnn::DnnSupport {
   // Provides access to the cuDNN handle.
   std::unique_ptr<class CudnnAccess> cudnn_;
 
-  bool cudnn_deterministic = false;
+  bool cudnn_deterministic_ = false;
 
   template <class T, class U>
   port::Status DoBatchNormalizationForwardImpl(


### PR DESCRIPTION
This change is a major component of the recipe for making TensorFlow training reproducible on GPUs.

Setting the environment variable TF_CUDNN_DETERMINISTIC=1 (or true) will ensure that both forward and  backwards convolution algorithms are both fixed and deterministic. It overrides autotune and selects deterministic back-prop algorithms.