### PR TITLE
TFTRT: LOG(ERROR) --> VLOG(1) when use_calibration=True with fp32/fp16

### DIFF
--- a/tensorflow/contrib/tensorrt/convert/trt_optimization_pass.cc
+++ b/tensorflow/contrib/tensorrt/convert/trt_optimization_pass.cc
@@ -226,8 +226,9 @@ tensorflow::Status TRTOptimizationPass::Optimize(
   tensorflow::tensorrt::convert::ConversionParams cp;
 
   if (use_calibration_ && precision_mode_ != INT8MODE) {
-    LOG(ERROR) << "Calibration with FP32 or FP16 is not implemented. "
-               << "Falling back to use_calibration = False.";
+    VLOG(1) << "Calibration with FP32 or FP16 is not implemented. "
+            << "Falling back to use_calibration = False."
+            << "Note that the default value of use_calibration is True.";
     use_calibration_ = false;
   }
 


### PR DESCRIPTION
This is just to keep the default LOG cleaner.

The API mentions that `use_calibration` is ignored in case of precisions fp32/fp16.

My preference would be to change the default to `use_calibration = False` but that's a change in API behavior, and @aaroey asked to postpone that to TF2.0.