### PR TITLE
Prevent stream executor construction for XLA devices

### DIFF
--- a/tensorflow/compiler/jit/xla_device.cc
+++ b/tensorflow/compiler/jit/xla_device.cc
@@ -201,7 +201,8 @@ XlaDevice::XlaDevice(const SessionOptions& session_options,
       jit_device_name_(options.compilation_device_name),
       platform_(options.platform),
       use_multiple_streams_(options.use_multiple_streams),
-      shape_representation_fn_(options.shape_representation_fn) {
+      shape_representation_fn_(options.shape_representation_fn),
+      allowed_devices_(options.allowed_devices) {
   VLOG(1) << "Created XLA device " << options.compilation_device_name << " "
           << this;
   thread_pool_.reset(new thread::ThreadPool(session_options.env, "xla_device",
@@ -234,7 +235,8 @@ xla::LocalClient* XlaDevice::client() const {
 
   // TODO(b/78468222): This can fail, at least when the backend is GPU and
   // there is no GPU on the host.
-  return xla::ClientLibrary::GetOrCreateLocalClient(platform_).ValueOrDie();
+  return xla::ClientLibrary::GetOrCreateLocalClient(platform_, allowed_devices_)
+      .ValueOrDie();
 }
 
 Allocator* XlaDevice::GetAllocator(AllocatorAttributes attr) {

--- a/tensorflow/compiler/jit/xla_device.h
+++ b/tensorflow/compiler/jit/xla_device.h
@@ -168,7 +168,6 @@ class XlaDevice : public LocalDevice {
 
   bool RequiresSyncOnCompletion() const override LOCKS_EXCLUDED(mu_);
 
-
   // A simple RAII handle. On construction the device's
   // outstanding_asynchronous_operations_ field is incremented; on destruction
   // it is decremented.

--- a/tensorflow/compiler/jit/xla_device.h
+++ b/tensorflow/compiler/jit/xla_device.h
@@ -126,8 +126,8 @@ class XlaDevice : public LocalDevice {
     // the logical on-device shape without padding is used.
     PaddedShapeFn padded_shape_fn;
 
-    // Set of devices to use. This controls which of the devices given type in
-    // the system will have resources allocated for. For GPUs this will be
+    // Set of devices to use. This controls which of the devices on the given
+    // platform resources will have resources allocated. For GPUs this will be
     // filled from visible_gpu_devices list from session configuration.
     absl::optional<std::set<int>> allowed_devices;
   };
@@ -264,8 +264,8 @@ class XlaDevice : public LocalDevice {
   int64 outstanding_asynchronous_operations_ GUARDED_BY(mu_) = 0;
   condition_variable outstanding_asynchronous_operations_cv_;
 
-  // Set of devices to use. This controls which of the devices of current type
-  // in the system will have resources allocated for. For GPUs this will be
+  // Set of devices to use. This controls which of the devices on the given
+  // platform resources will have resources allocated. For GPUs this will be
   // filled from visible_gpu_devices list from session configuration.
   absl::optional<std::set<int>> allowed_devices_;
 };

--- a/tensorflow/compiler/jit/xla_device.h
+++ b/tensorflow/compiler/jit/xla_device.h
@@ -24,6 +24,7 @@ limitations under the License.
 
 #ifndef TENSORFLOW_COMPILER_JIT_XLA_DEVICE_H_
 #define TENSORFLOW_COMPILER_JIT_XLA_DEVICE_H_
+#include <set>
 
 #include "tensorflow/compiler/jit/xla_device_context.h"
 #include "tensorflow/compiler/jit/xla_tensor.h"
@@ -123,6 +124,8 @@ class XlaDevice : public LocalDevice {
     // If padded_shape_fn is empty, a default implementation that returns
     // the logical on-device shape without padding is used.
     PaddedShapeFn padded_shape_fn;
+    // Set of allowed devices. -1 is all devices
+    std::set<int> allowed_devices = {-1};
   };
 
   // Creates a new XLA Device.
@@ -164,6 +167,7 @@ class XlaDevice : public LocalDevice {
   void SetRequiresSyncOnCompletion(bool sync_on_completion) LOCKS_EXCLUDED(mu_);
 
   bool RequiresSyncOnCompletion() const override LOCKS_EXCLUDED(mu_);
+
 
   // A simple RAII handle. On construction the device's
   // outstanding_asynchronous_operations_ field is incremented; on destruction
@@ -256,6 +260,9 @@ class XlaDevice : public LocalDevice {
   // completion.
   int64 outstanding_asynchronous_operations_ GUARDED_BY(mu_) = 0;
   condition_variable outstanding_asynchronous_operations_cv_;
+
+  // Set of allowed gpu devices at the time of construction.
+  std::set<int> allowed_devices_ = {-1};
 };
 
 // Builds OpKernel registrations on 'device' for the JIT operators

--- a/tensorflow/compiler/jit/xla_device.h
+++ b/tensorflow/compiler/jit/xla_device.h
@@ -127,7 +127,7 @@ class XlaDevice : public LocalDevice {
     PaddedShapeFn padded_shape_fn;
 
     // Set of devices to use. This controls which of the devices on the given
-    // platform resources will have resources allocated. For GPUs this will be
+    // platform will have resources allocated. For GPUs this will be
     // filled from visible_gpu_devices list from session configuration.
     absl::optional<std::set<int>> allowed_devices;
   };
@@ -265,7 +265,7 @@ class XlaDevice : public LocalDevice {
   condition_variable outstanding_asynchronous_operations_cv_;
 
   // Set of devices to use. This controls which of the devices on the given
-  // platform resources will have resources allocated. For GPUs this will be
+  // platform will have resources allocated. For GPUs this will be
   // filled from visible_gpu_devices list from session configuration.
   absl::optional<std::set<int>> allowed_devices_;
 };

--- a/tensorflow/compiler/jit/xla_device.h
+++ b/tensorflow/compiler/jit/xla_device.h
@@ -26,6 +26,7 @@ limitations under the License.
 #define TENSORFLOW_COMPILER_JIT_XLA_DEVICE_H_
 #include <set>
 
+#include "absl/types/optional.h"
 #include "tensorflow/compiler/jit/xla_device_context.h"
 #include "tensorflow/compiler/jit/xla_tensor.h"
 #include "tensorflow/compiler/tf2xla/xla_compiler.h"
@@ -124,8 +125,11 @@ class XlaDevice : public LocalDevice {
     // If padded_shape_fn is empty, a default implementation that returns
     // the logical on-device shape without padding is used.
     PaddedShapeFn padded_shape_fn;
-    // Set of allowed devices. -1 is all devices
-    std::set<int> allowed_devices = {-1};
+
+    // Set of devices to use. This controls which of the devices given type in
+    // the system will have resources allocated for. For GPUs this will be
+    // filled from visible_gpu_devices list from session configuration.
+    absl::optional<std::set<int>> allowed_devices;
   };
 
   // Creates a new XLA Device.
@@ -260,8 +264,10 @@ class XlaDevice : public LocalDevice {
   int64 outstanding_asynchronous_operations_ GUARDED_BY(mu_) = 0;
   condition_variable outstanding_asynchronous_operations_cv_;
 
-  // Set of allowed gpu devices at the time of construction.
-  std::set<int> allowed_devices_ = {-1};
+  // Set of devices to use. This controls which of the devices of current type
+  // in the system will have resources allocated for. For GPUs this will be
+  // filled from visible_gpu_devices list from session configuration.
+  absl::optional<std::set<int>> allowed_devices_;
 };
 
 // Builds OpKernel registrations on 'device' for the JIT operators

--- a/tensorflow/compiler/jit/xla_gpu_device.cc
+++ b/tensorflow/compiler/jit/xla_gpu_device.cc
@@ -53,8 +53,8 @@ XlaGpuDeviceFactory::ParseVisibleDeviceList(const string& visible_device_list) {
     if (!absl::SimpleAtoi(platform_gpu_id_str, &platform_gpu_id)) {
       return errors::InvalidArgument(
           "Could not parse entry in 'visible_device_list': '",
-          platform_gpu_id_str,
-          "'. visible_device_list = ", visible_device_list);
+          platform_gpu_id_str, "'. visible_device_list = ",
+          visible_device_list);
     }
     gpu_ids.insert(platform_gpu_id);
   }
@@ -83,7 +83,7 @@ Status XlaGpuDeviceFactory::CreateDevices(
   }
   string allowed_gpus =
       session_options.config.gpu_options().visible_device_list();
-  auto parsed_gpus=ParseVisibleDeviceList(allowed_gpus).ValueOrDie();
+  auto parsed_gpus = ParseVisibleDeviceList(allowed_gpus).ValueOrDie();
   // We want to fill the gpu_ids set with all devices if config string is empty.
   std::set<int> gpu_ids;
   int num_visible_devices = platform.ValueOrDie()->VisibleDeviceCount();

--- a/tensorflow/compiler/jit/xla_gpu_device.cc
+++ b/tensorflow/compiler/jit/xla_gpu_device.cc
@@ -81,7 +81,8 @@ Status XlaGpuDeviceFactory::CreateDevices(
   }
   string allowed_gpus =
       session_options.config.gpu_options().visible_device_list();
-  absl::optional<std::set<int>> gpu_ids = ParseVisibleDeviceList(allowed_gpus).ValueOrDie();
+  absl::optional<std::set<int>> gpu_ids =
+      ParseVisibleDeviceList(allowed_gpus).ValueOrDie();
   if (!gpu_ids) {
     gpu_ids.emplace();
     // Fill the gpu_ids set with all devices if config string is empty.

--- a/tensorflow/compiler/jit/xla_gpu_device.cc
+++ b/tensorflow/compiler/jit/xla_gpu_device.cc
@@ -53,8 +53,8 @@ xla::StatusOr<std::set<int>> XlaGpuDeviceFactory::ParseVisibleDeviceList(
     if (!absl::SimpleAtoi(platform_gpu_id_str, &platform_gpu_id)) {
       return errors::InvalidArgument(
           "Could not parse entry in 'visible_device_list': '",
-          platform_gpu_id_str,
-          "'. visible_device_list = ", visible_device_list);
+          platform_gpu_id_str, "'. visible_device_list = ",
+          visible_device_list);
     }
     gpu_ids.insert(platform_gpu_id);
   }

--- a/tensorflow/compiler/jit/xla_gpu_device.cc
+++ b/tensorflow/compiler/jit/xla_gpu_device.cc
@@ -100,7 +100,7 @@ Status XlaGpuDeviceFactory::CreateDevices(
     options.device_ordinal = i;
     options.compilation_device_name = DEVICE_GPU_XLA_JIT;
     options.use_multiple_streams = true;
-    options.allowed_devices=gpu_ids;
+    options.allowed_devices = gpu_ids;
     auto device = absl::make_unique<XlaDevice>(session_options, options);
 
     Status status = device->UseGpuDeviceInfo();

--- a/tensorflow/compiler/xla/client/client_library.cc
+++ b/tensorflow/compiler/xla/client/client_library.cc
@@ -24,14 +24,14 @@ limitations under the License.
 
 namespace xla {
 
-LocalClientOptions::LocalClientOptions(se::Platform* platform,
-                                       int number_of_replicas,
-                                       int intra_op_parallelism_threads,
-                                       std::set<int> device_set)
+LocalClientOptions::LocalClientOptions(
+    se::Platform* platform, int number_of_replicas,
+    int intra_op_parallelism_threads,
+    const absl::optional<std::set<int>>& allowed_devices)
     : platform_(platform),
       number_of_replicas_(number_of_replicas),
       intra_op_parallelism_threads_(intra_op_parallelism_threads),
-      allowed_devices_(device_set) {}
+      allowed_devices_(allowed_devices) {}
 
 LocalClientOptions& LocalClientOptions::set_platform(se::Platform* platform) {
   platform_ = platform;
@@ -61,12 +61,13 @@ int LocalClientOptions::intra_op_parallelism_threads() const {
 }
 
 LocalClientOptions& LocalClientOptions::set_allowed_devices(
-    std::set<int> device_set) {
-  allowed_devices_ = device_set;
+    const absl::optional<std::set<int>>& allowed_devices) {
+  allowed_devices_ = allowed_devices;
   return *this;
 }
 
-std::set<int> LocalClientOptions::get_allowed_devices() const {
+const absl::optional<std::set<int>>& LocalClientOptions::allowed_devices()
+    const {
   return allowed_devices_;
 }
 
@@ -79,7 +80,7 @@ ClientLibrary::ClientLibrary() = default;
 ClientLibrary::~ClientLibrary() = default;
 
 /* static */ StatusOr<LocalClient*> ClientLibrary::GetOrCreateLocalClient(
-    se::Platform* platform, const std::set<int> device_set) {
+    se::Platform* platform, const absl::optional<std::set<int>>& device_set) {
   LocalClientOptions default_options;
   default_options.set_platform(platform);
   default_options.set_allowed_devices(device_set);
@@ -107,7 +108,7 @@ ClientLibrary::~ClientLibrary() = default;
   service_options.set_number_of_replicas(replica_count);
   service_options.set_intra_op_parallelism_threads(
       options.intra_op_parallelism_threads());
-  service_options.set_allowed_devices(options.get_allowed_devices());
+  service_options.set_allowed_devices(options.allowed_devices());
   auto instance = absl::make_unique<LocalInstance>();
   TF_ASSIGN_OR_RETURN(instance->service,
                       LocalService::NewService(service_options));

--- a/tensorflow/compiler/xla/client/client_library.cc
+++ b/tensorflow/compiler/xla/client/client_library.cc
@@ -26,10 +26,12 @@ namespace xla {
 
 LocalClientOptions::LocalClientOptions(se::Platform* platform,
                                        int number_of_replicas,
-                                       int intra_op_parallelism_threads)
+                                       int intra_op_parallelism_threads,
+                                       std::set<int> device_set)
     : platform_(platform),
       number_of_replicas_(number_of_replicas),
-      intra_op_parallelism_threads_(intra_op_parallelism_threads) {}
+      intra_op_parallelism_threads_(intra_op_parallelism_threads),
+      allowed_devices_(device_set) {}
 
 LocalClientOptions& LocalClientOptions::set_platform(se::Platform* platform) {
   platform_ = platform;
@@ -58,6 +60,16 @@ int LocalClientOptions::intra_op_parallelism_threads() const {
   return intra_op_parallelism_threads_;
 }
 
+LocalClientOptions& LocalClientOptions::set_allowed_devices(
+    std::set<int> device_set) {
+  allowed_devices_ = device_set;
+  return *this;
+}
+
+std::set<int> LocalClientOptions::get_allowed_devices() const {
+  return allowed_devices_;
+}
+
 /* static */ ClientLibrary& ClientLibrary::Singleton() {
   static ClientLibrary* c = new ClientLibrary;
   return *c;
@@ -67,9 +79,10 @@ ClientLibrary::ClientLibrary() = default;
 ClientLibrary::~ClientLibrary() = default;
 
 /* static */ StatusOr<LocalClient*> ClientLibrary::GetOrCreateLocalClient(
-    se::Platform* platform) {
+    se::Platform* platform, const std::set<int> device_set) {
   LocalClientOptions default_options;
   default_options.set_platform(platform);
+  default_options.set_allowed_devices(device_set);
   return GetOrCreateLocalClient(default_options);
 }
 
@@ -94,7 +107,7 @@ ClientLibrary::~ClientLibrary() = default;
   service_options.set_number_of_replicas(replica_count);
   service_options.set_intra_op_parallelism_threads(
       options.intra_op_parallelism_threads());
-
+  service_options.set_allowed_devices(options.get_allowed_devices());
   auto instance = absl::make_unique<LocalInstance>();
   TF_ASSIGN_OR_RETURN(instance->service,
                       LocalService::NewService(service_options));

--- a/tensorflow/compiler/xla/client/client_library.h
+++ b/tensorflow/compiler/xla/client/client_library.h
@@ -23,9 +23,9 @@ limitations under the License.
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 
 #include "tensorflow/compiler/xla/client/compile_only_client.h"
 #include "tensorflow/compiler/xla/client/local_client.h"
@@ -81,8 +81,8 @@ class ClientLibrary {
   //
   //   platform : The platform the underlying XLA service should target. If
   //     null then default platform is used.
-  //   device_set: Set of device IDs for which the stream executor will be created
-  //   for, for the given platform.
+  //   device_set: Set of device IDs for which the stream executor will be
+  //   created for, for the given platform.
   static StatusOr<LocalClient*> GetOrCreateLocalClient(
       se::Platform* platform = nullptr, const std::set<int> device_set = {-1});
   static StatusOr<LocalClient*> GetOrCreateLocalClient(

--- a/tensorflow/compiler/xla/client/client_library.h
+++ b/tensorflow/compiler/xla/client/client_library.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "absl/types/optional.h"
 #include "tensorflow/compiler/xla/client/compile_only_client.h"
 #include "tensorflow/compiler/xla/client/local_client.h"
 #include "tensorflow/compiler/xla/service/compile_only_service.h"
@@ -47,7 +48,7 @@ class LocalClientOptions {
   LocalClientOptions(se::Platform* platform = nullptr,
                      int number_of_replicas = 1,
                      int intra_op_parallelism_threads = -1,
-                     std::set<int> device_set = {-1});
+                     const absl::optional<std::set<int>>& allowed_devices = {});
 
   // Set the platform backing the service, or nullptr for the default platform.
   LocalClientOptions& set_platform(se::Platform* platform);
@@ -63,15 +64,16 @@ class LocalClientOptions {
   int intra_op_parallelism_threads() const;
 
   // Sets the allowed_devices set for creation of stream executors.
-  LocalClientOptions& set_allowed_devices(const std::set<int> device_set);
+  LocalClientOptions& set_allowed_devices(
+      const absl::optional<std::set<int>>& allowed_devices);
 
-  std::set<int> get_allowed_devices() const;
+  const absl::optional<std::set<int>>& allowed_devices() const;
 
  private:
   se::Platform* platform_;
   int number_of_replicas_;
   int intra_op_parallelism_threads_;
-  std::set<int> allowed_devices_;
+  absl::optional<std::set<int>> allowed_devices_;
 };
 
 class ClientLibrary {
@@ -84,7 +86,8 @@ class ClientLibrary {
   //   device_set: Set of device IDs for which the stream executor will be
   //   created for, for the given platform.
   static StatusOr<LocalClient*> GetOrCreateLocalClient(
-      se::Platform* platform = nullptr, const std::set<int> device_set = {-1});
+      se::Platform* platform = nullptr,
+      const absl::optional<std::set<int>>& allowed_devices = {});
   static StatusOr<LocalClient*> GetOrCreateLocalClient(
       const LocalClientOptions& options);
 

--- a/tensorflow/compiler/xla/client/client_library.h
+++ b/tensorflow/compiler/xla/client/client_library.h
@@ -83,7 +83,7 @@ class ClientLibrary {
   //   platform : The platform the underlying XLA service should target. If
   //     null then default platform is used.
   //   device_set: Set of device IDs for which the stream executor will be
-  //   created for, for the given platform.
+  //   created, for the given platform.
   static StatusOr<LocalClient*> GetOrCreateLocalClient(
       se::Platform* platform = nullptr,
       const absl::optional<std::set<int>>& allowed_devices = absl::nullopt);

--- a/tensorflow/compiler/xla/client/client_library.h
+++ b/tensorflow/compiler/xla/client/client_library.h
@@ -45,10 +45,10 @@ namespace xla {
 // Options to configure the local client when it is created.
 class LocalClientOptions {
  public:
-  LocalClientOptions(se::Platform* platform = nullptr,
-                     int number_of_replicas = 1,
-                     int intra_op_parallelism_threads = -1,
-                     const absl::optional<std::set<int>>& allowed_devices = {});
+  LocalClientOptions(
+      se::Platform* platform = nullptr, int number_of_replicas = 1,
+      int intra_op_parallelism_threads = -1,
+      const absl::optional<std::set<int>>& allowed_devices = absl::nullopt);
 
   // Set the platform backing the service, or nullptr for the default platform.
   LocalClientOptions& set_platform(se::Platform* platform);
@@ -66,7 +66,6 @@ class LocalClientOptions {
   // Sets the allowed_devices set for creation of stream executors.
   LocalClientOptions& set_allowed_devices(
       const absl::optional<std::set<int>>& allowed_devices);
-
   const absl::optional<std::set<int>>& allowed_devices() const;
 
  private:
@@ -87,7 +86,7 @@ class ClientLibrary {
   //   created for, for the given platform.
   static StatusOr<LocalClient*> GetOrCreateLocalClient(
       se::Platform* platform = nullptr,
-      const absl::optional<std::set<int>>& allowed_devices = {});
+      const absl::optional<std::set<int>>& allowed_devices = absl::nullopt);
   static StatusOr<LocalClient*> GetOrCreateLocalClient(
       const LocalClientOptions& options);
 

--- a/tensorflow/compiler/xla/client/client_library.h
+++ b/tensorflow/compiler/xla/client/client_library.h
@@ -63,7 +63,8 @@ class LocalClientOptions {
   LocalClientOptions& set_intra_op_parallelism_threads(int num_threads);
   int intra_op_parallelism_threads() const;
 
-  // Sets the allowed_devices set for creation of stream executors.
+  // Sets the allowed_devices set for selectively constructing stream executors
+  // on the platform.
   LocalClientOptions& set_allowed_devices(
       const absl::optional<std::set<int>>& allowed_devices);
   const absl::optional<std::set<int>>& allowed_devices() const;

--- a/tensorflow/compiler/xla/client/client_library.h
+++ b/tensorflow/compiler/xla/client/client_library.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <memory>
 #include <string>
 #include <vector>
+#include <set>
 
 #include "tensorflow/compiler/xla/client/compile_only_client.h"
 #include "tensorflow/compiler/xla/client/local_client.h"
@@ -45,7 +46,8 @@ class LocalClientOptions {
  public:
   LocalClientOptions(se::Platform* platform = nullptr,
                      int number_of_replicas = 1,
-                     int intra_op_parallelism_threads = -1);
+                     int intra_op_parallelism_threads = -1,
+                     std::set<int> device_set = {-1});
 
   // Set the platform backing the service, or nullptr for the default platform.
   LocalClientOptions& set_platform(se::Platform* platform);
@@ -60,10 +62,16 @@ class LocalClientOptions {
   LocalClientOptions& set_intra_op_parallelism_threads(int num_threads);
   int intra_op_parallelism_threads() const;
 
+  // Sets the allowed_devices set for creation of stream executors.
+  LocalClientOptions& set_allowed_devices(const std::set<int> device_set);
+
+  std::set<int> get_allowed_devices() const;
+
  private:
   se::Platform* platform_;
   int number_of_replicas_;
   int intra_op_parallelism_threads_;
+  std::set<int> allowed_devices_;
 };
 
 class ClientLibrary {
@@ -73,8 +81,10 @@ class ClientLibrary {
   //
   //   platform : The platform the underlying XLA service should target. If
   //     null then default platform is used.
+  //   device_set: Set of device IDs for which the stream executor will be created
+  //   for, for the given platform.
   static StatusOr<LocalClient*> GetOrCreateLocalClient(
-      se::Platform* platform = nullptr);
+      se::Platform* platform = nullptr, const std::set<int> device_set = {-1});
   static StatusOr<LocalClient*> GetOrCreateLocalClient(
       const LocalClientOptions& options);
 

--- a/tensorflow/compiler/xla/service/backend.cc
+++ b/tensorflow/compiler/xla/service/backend.cc
@@ -183,7 +183,7 @@ StatusOr<se::StreamExecutor*> Backend::stream_executor(
         device_ordinal, stream_executors_.back()->device_ordinal());
   }
   for (auto* executor : stream_executors_) {
-    if (executor && executor->device_ordinal() == device_ordinal) {
+    if (executor->device_ordinal() == device_ordinal) {
       return executor;
     }
   }

--- a/tensorflow/compiler/xla/service/backend.cc
+++ b/tensorflow/compiler/xla/service/backend.cc
@@ -57,12 +57,13 @@ int BackendOptions::intra_op_parallelism_threads() const {
   return intra_op_parallelism_threads_;
 }
 
-BackendOptions& BackendOptions::set_allowed_devices(std::set<int> device_set) {
-  allowed_devices_ = device_set;
+BackendOptions& BackendOptions::set_allowed_devices(
+    const absl::optional<std::set<int>>& allowed_devices) {
+  allowed_devices_ = allowed_devices;
   return *this;
 }
 
-std::set<int> BackendOptions::get_allowed_devices() const {
+const absl::optional<std::set<int>>& BackendOptions::allowed_devices() const {
   return allowed_devices_;
 }
 
@@ -85,9 +86,9 @@ struct Backend::EigenThreadPoolWrapper {
     const BackendOptions& options) {
   se::Platform* platform = options.platform();
   TF_ASSIGN_OR_RETURN(auto compiler, Compiler::GetForPlatform(platform));
-  TF_ASSIGN_OR_RETURN(auto stream_executors,
-                      PlatformUtil::GetStreamExecutors(
-                          platform, options.get_allowed_devices()));
+  TF_ASSIGN_OR_RETURN(
+      auto stream_executors,
+      PlatformUtil::GetStreamExecutors(platform, options.allowed_devices()));
   TF_ASSIGN_OR_RETURN(auto transfer_manager,
                       TransferManager::GetForPlatform(platform));
   TF_ASSIGN_OR_RETURN(auto computation_placer,

--- a/tensorflow/compiler/xla/service/backend.cc
+++ b/tensorflow/compiler/xla/service/backend.cc
@@ -57,6 +57,15 @@ int BackendOptions::intra_op_parallelism_threads() const {
   return intra_op_parallelism_threads_;
 }
 
+BackendOptions& BackendOptions::set_allowed_devices(std::set<int> device_set) {
+  allowed_devices_ = device_set;
+  return *this;
+}
+
+std::set<int> BackendOptions::get_allowed_devices() const {
+  return allowed_devices_;
+}
+
 // Define this in .cc file to avoid having to include eigen or forward declare
 // these types in the header.
 struct Backend::EigenThreadPoolWrapper {
@@ -77,7 +86,8 @@ struct Backend::EigenThreadPoolWrapper {
   se::Platform* platform = options.platform();
   TF_ASSIGN_OR_RETURN(auto compiler, Compiler::GetForPlatform(platform));
   TF_ASSIGN_OR_RETURN(auto stream_executors,
-                      PlatformUtil::GetStreamExecutors(platform));
+                      PlatformUtil::GetStreamExecutors(
+                          platform, options.get_allowed_devices()));
   TF_ASSIGN_OR_RETURN(auto transfer_manager,
                       TransferManager::GetForPlatform(platform));
   TF_ASSIGN_OR_RETURN(auto computation_placer,
@@ -172,7 +182,7 @@ StatusOr<se::StreamExecutor*> Backend::stream_executor(
         device_ordinal, stream_executors_.back()->device_ordinal());
   }
   for (auto* executor : stream_executors_) {
-    if (executor->device_ordinal() == device_ordinal) {
+    if (executor && executor->device_ordinal() == device_ordinal) {
       return executor;
     }
   }

--- a/tensorflow/compiler/xla/service/backend.cc
+++ b/tensorflow/compiler/xla/service/backend.cc
@@ -22,7 +22,6 @@ limitations under the License.
 #include <utility>
 
 #include "absl/memory/memory.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/compiler/xla/service/compiler.h"
 #include "tensorflow/compiler/xla/service/platform_util.h"
 #include "tensorflow/compiler/xla/status_macros.h"
@@ -37,6 +36,7 @@ limitations under the License.
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/stream_executor_no_cuda.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace xla {
 

--- a/tensorflow/compiler/xla/service/backend.h
+++ b/tensorflow/compiler/xla/service/backend.h
@@ -18,9 +18,9 @@ limitations under the License.
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
@@ -114,8 +114,8 @@ class Backend {
   se::StreamExecutor* default_stream_executor() const {
     CHECK(!stream_executors_.empty());
 
-    for(se::StreamExecutor* e :stream_executors_){
-      if(e){
+    for (se::StreamExecutor* e : stream_executors_) {
+      if (e) {
         return e;
       }
     }

--- a/tensorflow/compiler/xla/service/backend.h
+++ b/tensorflow/compiler/xla/service/backend.h
@@ -55,14 +55,15 @@ class BackendOptions {
   int intra_op_parallelism_threads() const;
 
   // Sets the allowed_devices set for creation of stream executors.
-  BackendOptions& set_allowed_devices(const std::set<int> device_set);
+  BackendOptions& set_allowed_devices(
+      const absl::optional<std::set<int>>& allowed_devices);
 
-  std::set<int> get_allowed_devices() const;
+  const absl::optional<std::set<int>>& allowed_devices() const;
 
  private:
   se::Platform* platform_ = nullptr;
   int intra_op_parallelism_threads_ = -1;
-  std::set<int> allowed_devices_ = {-1};
+  absl::optional<std::set<int>> allowed_devices_;
 };
 
 // Class which encapsulates an XLA backend. It includes everything necessary
@@ -113,12 +114,6 @@ class Backend {
   // can be > 1).
   se::StreamExecutor* default_stream_executor() const {
     CHECK(!stream_executors_.empty());
-
-    for (se::StreamExecutor* e : stream_executors_) {
-      if (e) {
-        return e;
-      }
-    }
     return stream_executors_[0];
   }
 

--- a/tensorflow/compiler/xla/service/backend.h
+++ b/tensorflow/compiler/xla/service/backend.h
@@ -54,7 +54,8 @@ class BackendOptions {
   BackendOptions& set_intra_op_parallelism_threads(int num_threads);
   int intra_op_parallelism_threads() const;
 
-  // Sets the allowed_devices set for creation of stream executors.
+  // Sets the allowed_devices for selectively constructing stream executors
+  // on the platform.
   BackendOptions& set_allowed_devices(
       const absl::optional<std::set<int>>& allowed_devices);
   const absl::optional<std::set<int>>& allowed_devices() const;

--- a/tensorflow/compiler/xla/service/backend.h
+++ b/tensorflow/compiler/xla/service/backend.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <memory>
 #include <string>
 #include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
@@ -53,9 +54,15 @@ class BackendOptions {
   BackendOptions& set_intra_op_parallelism_threads(int num_threads);
   int intra_op_parallelism_threads() const;
 
+  // Sets the allowed_devices set for creation of stream executors.
+  BackendOptions& set_allowed_devices(const std::set<int> device_set);
+
+  std::set<int> get_allowed_devices() const;
+
  private:
   se::Platform* platform_ = nullptr;
   int intra_op_parallelism_threads_ = -1;
+  std::set<int> allowed_devices_ = {-1};
 };
 
 // Class which encapsulates an XLA backend. It includes everything necessary
@@ -106,6 +113,12 @@ class Backend {
   // can be > 1).
   se::StreamExecutor* default_stream_executor() const {
     CHECK(!stream_executors_.empty());
+
+    for(se::StreamExecutor* e :stream_executors_){
+      if(e){
+        return e;
+      }
+    }
     return stream_executors_[0];
   }
 

--- a/tensorflow/compiler/xla/service/backend.h
+++ b/tensorflow/compiler/xla/service/backend.h
@@ -57,7 +57,6 @@ class BackendOptions {
   // Sets the allowed_devices set for creation of stream executors.
   BackendOptions& set_allowed_devices(
       const absl::optional<std::set<int>>& allowed_devices);
-
   const absl::optional<std::set<int>>& allowed_devices() const;
 
  private:

--- a/tensorflow/compiler/xla/service/local_service.cc
+++ b/tensorflow/compiler/xla/service/local_service.cc
@@ -54,7 +54,7 @@ namespace xla {
   BackendOptions backend_options;
   backend_options.set_platform(platform)
       .set_intra_op_parallelism_threads(options.intra_op_parallelism_threads())
-      .set_allowed_devices(options.get_allowed_devices());
+      .set_allowed_devices(options.allowed_devices());
 
   TF_ASSIGN_OR_RETURN(std::unique_ptr<Backend> backend,
                       Backend::CreateBackend(backend_options));

--- a/tensorflow/compiler/xla/service/local_service.cc
+++ b/tensorflow/compiler/xla/service/local_service.cc
@@ -52,8 +52,10 @@ namespace xla {
   }
 
   BackendOptions backend_options;
-  backend_options.set_platform(platform).set_intra_op_parallelism_threads(
-      options.intra_op_parallelism_threads());
+  backend_options.set_platform(platform)
+      .set_intra_op_parallelism_threads(options.intra_op_parallelism_threads())
+      .set_allowed_devices(options.get_allowed_devices());
+
   TF_ASSIGN_OR_RETURN(std::unique_ptr<Backend> backend,
                       Backend::CreateBackend(backend_options));
 

--- a/tensorflow/compiler/xla/service/platform_util.cc
+++ b/tensorflow/compiler/xla/service/platform_util.cc
@@ -205,8 +205,9 @@ static bool IsDeviceSupported(se::StreamExecutor* executor) {
 }
 
 /* static */ StatusOr<std::vector<se::StreamExecutor*>>
-PlatformUtil::GetStreamExecutors(se::Platform* platform,
-                                 std::set<int> allowed_devices) {
+PlatformUtil::GetStreamExecutors(
+    se::Platform* platform,
+    const absl::optional<std::set<int>>& allowed_devices) {
   int device_count = platform->VisibleDeviceCount();
   if (device_count <= 0) {
     return NotFound("no %s devices found", platform->Name());
@@ -227,8 +228,8 @@ PlatformUtil::GetStreamExecutors(se::Platform* platform,
     tensorflow::thread::ThreadPool thread_pool(
         tensorflow::Env::Default(), "device_initialization", device_count);
     for (int i = 0; i < device_count; ++i) {
-      if (allowed_devices.count(-1) == 0 && allowed_devices.count(i) == 0) {
-        VLOG(1) << "Skipping stream executor for device " << i
+      if (allowed_devices && (*allowed_devices).count(i) == 0) {
+        VLOG(1) << "Not initializing StreamExecutor for device " << i
                 << " since it is not in the visible device list";
         continue;
       }

--- a/tensorflow/compiler/xla/service/platform_util.cc
+++ b/tensorflow/compiler/xla/service/platform_util.cc
@@ -205,7 +205,8 @@ static bool IsDeviceSupported(se::StreamExecutor* executor) {
 }
 
 /* static */ StatusOr<std::vector<se::StreamExecutor*>>
-PlatformUtil::GetStreamExecutors(se::Platform* platform) {
+PlatformUtil::GetStreamExecutors(se::Platform* platform,
+                                 std::set<int> allowed_devices) {
   int device_count = platform->VisibleDeviceCount();
   if (device_count <= 0) {
     return NotFound("no %s devices found", platform->Name());
@@ -226,6 +227,11 @@ PlatformUtil::GetStreamExecutors(se::Platform* platform) {
     tensorflow::thread::ThreadPool thread_pool(
         tensorflow::Env::Default(), "device_initialization", device_count);
     for (int i = 0; i < device_count; ++i) {
+      if (allowed_devices.count(-1) == 0 && allowed_devices.count(i) == 0) {
+        VLOG(1) << "Skipping stream executor for device " << i
+                << " since it is not in the visible device list";
+        continue;
+      }
       thread_pool.Schedule([platform, i, &stream_executors]() {
         VLOG(1) << "Started device init " << i;
         se::StreamExecutorConfig config;

--- a/tensorflow/compiler/xla/service/platform_util.h
+++ b/tensorflow/compiler/xla/service/platform_util.h
@@ -61,11 +61,13 @@ class PlatformUtil {
   // Returns a vector of StreamExecutors for the given platform. The vector is
   // indexed by device ordinal (device numbering used by StreamExecutor). If an
   // element is nullptr, then the device is present by not supported by XLA.
+  // Optional parameter, allowed_devices controls which of the devices on the
+  // platform will have StreamExecutors constructed for. 
   //
   // If the platform has no visible devices, a not-found error is returned.
   static StatusOr<std::vector<se::StreamExecutor*>> GetStreamExecutors(
       se::Platform* platform,
-      const absl::optional<std::set<int>>& allowed_devices = {});
+      const absl::optional<std::set<int>>& allowed_devices = absl::nullopt);
 
  private:
   TF_DISALLOW_COPY_AND_ASSIGN(PlatformUtil);

--- a/tensorflow/compiler/xla/service/platform_util.h
+++ b/tensorflow/compiler/xla/service/platform_util.h
@@ -16,9 +16,9 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_XLA_SERVICE_PLATFORM_UTIL_H_
 #define TENSORFLOW_COMPILER_XLA_SERVICE_PLATFORM_UTIL_H_
 
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 
 #include "tensorflow/compiler/xla/statusor.h"
 #include "tensorflow/compiler/xla/types.h"

--- a/tensorflow/compiler/xla/service/platform_util.h
+++ b/tensorflow/compiler/xla/service/platform_util.h
@@ -64,7 +64,8 @@ class PlatformUtil {
   //
   // If the platform has no visible devices, a not-found error is returned.
   static StatusOr<std::vector<se::StreamExecutor*>> GetStreamExecutors(
-      se::Platform* platform, std::set<int> allowed_devices = {-1});
+      se::Platform* platform,
+      const absl::optional<std::set<int>>& allowed_devices = {});
 
  private:
   TF_DISALLOW_COPY_AND_ASSIGN(PlatformUtil);

--- a/tensorflow/compiler/xla/service/platform_util.h
+++ b/tensorflow/compiler/xla/service/platform_util.h
@@ -61,8 +61,9 @@ class PlatformUtil {
   // Returns a vector of StreamExecutors for the given platform. The vector is
   // indexed by device ordinal (device numbering used by StreamExecutor). If an
   // element is nullptr, then the device is present by not supported by XLA.
-  // Optional parameter, allowed_devices controls which of the devices on the
-  // platform will have StreamExecutors constructed for. 
+  // If populated, only the devices in allowed_devices will have
+  // their StreamExecutors initialized, otherwise all StreamExecutors will be
+  // initialized and returned.
   //
   // If the platform has no visible devices, a not-found error is returned.
   static StatusOr<std::vector<se::StreamExecutor*>> GetStreamExecutors(

--- a/tensorflow/compiler/xla/service/platform_util.h
+++ b/tensorflow/compiler/xla/service/platform_util.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <string>
 #include <vector>
+#include <set>
 
 #include "tensorflow/compiler/xla/statusor.h"
 #include "tensorflow/compiler/xla/types.h"
@@ -63,7 +64,7 @@ class PlatformUtil {
   //
   // If the platform has no visible devices, a not-found error is returned.
   static StatusOr<std::vector<se::StreamExecutor*>> GetStreamExecutors(
-      se::Platform* platform);
+      se::Platform* platform, std::set<int> allowed_devices = {-1});
 
  private:
   TF_DISALLOW_COPY_AND_ASSIGN(PlatformUtil);

--- a/tensorflow/compiler/xla/service/service.cc
+++ b/tensorflow/compiler/xla/service/service.cc
@@ -160,13 +160,13 @@ Service::Service(const ServiceOptions& options,
     LOG(INFO) << StrFormat(
         "XLA service %p executing computations on platform %s. Devices:", this,
         execute_backend_->platform()->Name());
-    auto stream_executors=execute_backend_->stream_executors();
+    auto stream_executors = execute_backend_->stream_executors();
     for (int i = 0; i < execute_backend_->device_count(); ++i) {
-        se::StreamExecutor* executor =stream_executors.at(i);
-        const auto& description = executor->GetDeviceDescription();
-        LOG(INFO) << StrFormat("  StreamExecutor device (%d): %s, %s", i,
-                               description.name(),
-                               description.platform_version());
+      se::StreamExecutor* executor = stream_executors.at(i);
+      const auto& description = executor->GetDeviceDescription();
+      LOG(INFO) << StrFormat("  StreamExecutor device (%d): %s, %s", i,
+                             description.name(),
+                             description.platform_version());
     }
   } else {
     VLOG(1) << "XLA compile-only service constructed";

--- a/tensorflow/compiler/xla/service/service.cc
+++ b/tensorflow/compiler/xla/service/service.cc
@@ -113,6 +113,15 @@ int ServiceOptions::intra_op_parallelism_threads() const {
   return intra_op_parallelism_threads_;
 }
 
+ServiceOptions& ServiceOptions::set_allowed_devices(std::set<int> device_set) {
+  allowed_devices_ = device_set;
+  return *this;
+}
+
+std::set<int> ServiceOptions::get_allowed_devices() const {
+  return allowed_devices_;
+}
+
 /* static */ StatusOr<std::unique_ptr<Service>> Service::NewService(
     se::Platform* platform) {
   ServiceOptions default_options;
@@ -129,6 +138,7 @@ int ServiceOptions::intra_op_parallelism_threads() const {
   }
   BackendOptions backend_options;
   backend_options.set_platform(platform);
+  backend_options.set_allowed_devices(options.get_allowed_devices());
   TF_ASSIGN_OR_RETURN(execute_backend, Backend::CreateBackend(backend_options));
 
   std::unique_ptr<Service> service(
@@ -150,17 +160,13 @@ Service::Service(const ServiceOptions& options,
     LOG(INFO) << StrFormat(
         "XLA service %p executing computations on platform %s. Devices:", this,
         execute_backend_->platform()->Name());
+    auto stream_executors=execute_backend_->stream_executors();
     for (int i = 0; i < execute_backend_->device_count(); ++i) {
-      if (execute_backend_->device_ordinal_supported(i)) {
-        se::StreamExecutor* executor =
-            execute_backend_->stream_executor(i).ValueOrDie();
+        se::StreamExecutor* executor =stream_executors.at(i);
         const auto& description = executor->GetDeviceDescription();
         LOG(INFO) << StrFormat("  StreamExecutor device (%d): %s, %s", i,
                                description.name(),
                                description.platform_version());
-      } else {
-        LOG(INFO) << StrFormat("  StreamExecutor device (%d) not supported", i);
-      }
     }
   } else {
     VLOG(1) << "XLA compile-only service constructed";

--- a/tensorflow/compiler/xla/service/service.cc
+++ b/tensorflow/compiler/xla/service/service.cc
@@ -113,12 +113,13 @@ int ServiceOptions::intra_op_parallelism_threads() const {
   return intra_op_parallelism_threads_;
 }
 
-ServiceOptions& ServiceOptions::set_allowed_devices(std::set<int> device_set) {
-  allowed_devices_ = device_set;
+ServiceOptions& ServiceOptions::set_allowed_devices(
+    const absl::optional<std::set<int>>& allowed_devices) {
+  allowed_devices_ = allowed_devices;
   return *this;
 }
 
-std::set<int> ServiceOptions::get_allowed_devices() const {
+const absl::optional<std::set<int>>& ServiceOptions::allowed_devices() const {
   return allowed_devices_;
 }
 
@@ -138,7 +139,7 @@ std::set<int> ServiceOptions::get_allowed_devices() const {
   }
   BackendOptions backend_options;
   backend_options.set_platform(platform);
-  backend_options.set_allowed_devices(options.get_allowed_devices());
+  backend_options.set_allowed_devices(options.allowed_devices());
   TF_ASSIGN_OR_RETURN(execute_backend, Backend::CreateBackend(backend_options));
 
   std::unique_ptr<Service> service(

--- a/tensorflow/compiler/xla/service/service.h
+++ b/tensorflow/compiler/xla/service/service.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <memory>
 #include <string>
 #include <vector>
+#include <set>
 
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/debug_options_flags.h"
@@ -61,10 +62,16 @@ class ServiceOptions {
   ServiceOptions& set_intra_op_parallelism_threads(int num_threads);
   int intra_op_parallelism_threads() const;
 
+  // Sets the allowed_devices set for creation of stream executors.
+  ServiceOptions& set_allowed_devices(const std::set<int> device_set);
+
+  std::set<int> get_allowed_devices() const;
+
  private:
   se::Platform* platform_ = nullptr;
   int number_of_replicas_ = 1;
   int intra_op_parallelism_threads_ = -1;
+  std::set<int> allowed_devices_ = {-1};
 };
 
 // The XLA service object, which is the same across all platforms. It maintains

--- a/tensorflow/compiler/xla/service/service.h
+++ b/tensorflow/compiler/xla/service/service.h
@@ -65,7 +65,6 @@ class ServiceOptions {
   // Sets the allowed_devices set for creation of stream executors.
   ServiceOptions& set_allowed_devices(
       const absl::optional<std::set<int>>& allowed_devices);
-
   const absl::optional<std::set<int>>& allowed_devices() const;
 
  private:

--- a/tensorflow/compiler/xla/service/service.h
+++ b/tensorflow/compiler/xla/service/service.h
@@ -63,15 +63,16 @@ class ServiceOptions {
   int intra_op_parallelism_threads() const;
 
   // Sets the allowed_devices set for creation of stream executors.
-  ServiceOptions& set_allowed_devices(const std::set<int> device_set);
+  ServiceOptions& set_allowed_devices(
+      const absl::optional<std::set<int>>& allowed_devices);
 
-  std::set<int> get_allowed_devices() const;
+  const absl::optional<std::set<int>>& allowed_devices() const;
 
  private:
   se::Platform* platform_ = nullptr;
   int number_of_replicas_ = 1;
   int intra_op_parallelism_threads_ = -1;
-  std::set<int> allowed_devices_ = {-1};
+  absl::optional<std::set<int>> allowed_devices_;
 };
 
 // The XLA service object, which is the same across all platforms. It maintains

--- a/tensorflow/compiler/xla/service/service.h
+++ b/tensorflow/compiler/xla/service/service.h
@@ -18,9 +18,9 @@ limitations under the License.
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/debug_options_flags.h"

--- a/tensorflow/compiler/xla/service/service.h
+++ b/tensorflow/compiler/xla/service/service.h
@@ -62,7 +62,8 @@ class ServiceOptions {
   ServiceOptions& set_intra_op_parallelism_threads(int num_threads);
   int intra_op_parallelism_threads() const;
 
-  // Sets the allowed_devices set for creation of stream executors.
+  // Sets the allowed_devices set for selectively constructing stream executors
+  // on the platform.
   ServiceOptions& set_allowed_devices(
       const absl::optional<std::set<int>>& allowed_devices);
   const absl::optional<std::set<int>>& allowed_devices() const;


### PR DESCRIPTION
This PR prevents stream executor construction for the devices that are not in the visible_gpu_devices list given by the user. Construction of executors was causing allocations on other devices, reducing available memory.