### PR TITLE
Add the eager coverage for some dataset experimental kernels

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/cardinality_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/cardinality_test.py
@@ -151,8 +151,8 @@ class NumElementsTest(test_base.DatasetTestBase, parameterized.TestCase):
       # pylint: enable=g-long-lambda
   )
   def testNumElements(self, dataset_fn, expected_result):
-      self.assertEqual(
-          self.evaluate(cardinality.cardinality(dataset_fn())), expected_result)
+    self.assertEqual(
+        self.evaluate(cardinality.cardinality(dataset_fn())), expected_result)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/data/experimental/kernel_tests/cardinality_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/cardinality_test.py
@@ -151,9 +151,8 @@ class NumElementsTest(test_base.DatasetTestBase, parameterized.TestCase):
       # pylint: enable=g-long-lambda
   )
   def testNumElements(self, dataset_fn, expected_result):
-    with self.cached_session() as sess:
       self.assertEqual(
-          sess.run(cardinality.cardinality(dataset_fn())), expected_result)
+          self.evaluate(cardinality.cardinality(dataset_fn())), expected_result)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/data/experimental/kernel_tests/dense_to_sparse_batch_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/dense_to_sparse_batch_test.py
@@ -22,7 +22,6 @@ import numpy as np
 from tensorflow.python.data.experimental.ops import batching
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -99,7 +98,7 @@ class DenseToSparseBatchTest(test_base.DatasetTestBase):
       input_tensor = array_ops.constant([[1]])
       get_next = self.getNext(
           dataset_ops.Dataset.from_tensors(input_tensor).apply(
-            batching.dense_to_sparse_batch(4, [12])),
+              batching.dense_to_sparse_batch(4, [12])),
           requires_initialization=True)
       self.evaluate(get_next())
 
@@ -108,9 +107,9 @@ class DenseToSparseBatchTest(test_base.DatasetTestBase):
                                  "larger than the row shape"):
       input_tensor = math_ops.range(0, 13)
       get_next = self.getNext(
-        dataset_ops.Dataset.from_tensors(input_tensor).apply(
-          batching.dense_to_sparse_batch(4, [12])),
-        requires_initialization=True)
+          dataset_ops.Dataset.from_tensors(input_tensor).apply(
+              batching.dense_to_sparse_batch(4, [12])),
+          requires_initialization=True)
       self.evaluate(get_next())
 
 


### PR DESCRIPTION
This PR adds the eager coverage for `NumElementsTest`, `CounterTest`, `DenseToSparseBatchTest`, and `DirectedInterleaveDatasetTest`.