### PR TITLE
[XLA:GPU] Add sm_75 to LLVM supported procs list

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/nvptx_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/nvptx_backend_lib.cc
@@ -125,6 +125,7 @@ static string GetSmName(std::pair<int, int> compute_capability) {
       {{6, 2}, 62},
       {{7, 0}, 70},
       {{7, 2}, 72},
+      {{7, 5}, 75},
   });
   int sm_version = 30;
   auto it = m->find(compute_capability);


### PR DESCRIPTION
This is required to prevent fallback to the default sm version when running on GPUs with the Turing architecture.

Attn @jlebar 

I only noticed this because I got the below error. It also suggests that sm_30 is not actually supported by XLA and should be dropped (especially as the default). TF itself also only supports >= sm_35. I can add that to this PR if you think that's a good idea.

```
2018-12-13 15:04:11.447530: W tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/nvptx_backend_lib.cc:135] Unknown compute capability (7, 5) .Defaulting to telling LLVM that we're compiling for sm_30
2018-12-13 15:04:11.854629: I tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc:535] ptxas /tmp/tempfile-astrobox-7d7fa700-29182-57cef552f0d6f, line 1059; error   : Instruction 'atom.{min,max}.{s64,u64}' requires .target sm_32 or higher
2018-12-13 15:04:11.854697: I tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc:535] ptxas fatal   : Ptx assembly aborted due to errors 
```