### PR TITLE
TFTRT: Make segmenter deterministic

### DIFF
--- a/tensorflow/contrib/tensorrt/convert/convert_graph.cc
+++ b/tensorflow/contrib/tensorrt/convert/convert_graph.cc
@@ -326,7 +326,7 @@ tensorflow::Status ConvertGraphDefToTensorRT(
 struct EdgePtrCompare {
   bool operator()(const tensorflow::Edge* lhs,
                   const tensorflow::Edge* rhs) const {
-    return (lhs->id() < rhs->id());
+    return lhs->id() < rhs->id();
   }
 };
 

--- a/tensorflow/contrib/tensorrt/convert/convert_graph.cc
+++ b/tensorflow/contrib/tensorrt/convert/convert_graph.cc
@@ -323,6 +323,13 @@ tensorflow::Status ConvertGraphDefToTensorRT(
   return Status::OK();
 }
 
+struct EdgePtrCompare {
+  bool operator()(const tensorflow::Edge* lhs,
+                  const tensorflow::Edge* rhs) const {
+    return (lhs->id() < rhs->id());
+  }
+};
+
 // Function to get subsegment information structure.
 tensorflow::Status GetEngineInfo(
     const tensorflow::Graph* g,
@@ -361,8 +368,12 @@ tensorflow::Status GetEngineInfo(
     }
     const int node_id = node->id();
     subgraph_node_ids.push_back(node_id);
-    // Create input connections.
-    for (const auto edge : node->in_edges()) {
+    // Create input connections. Sort edges first to make determnistic since
+    // in_edges is a set of pointers.
+    std::vector<const tensorflow::Edge*> in_edges(node->in_edges().begin(),
+                                                  node->in_edges().end());
+    std::sort(in_edges.begin(), in_edges.end(), EdgePtrCompare());
+    for (const auto edge : in_edges) {
       auto input_node = edge->src();
       if (input_node->IsSource() || segment_nodes.count(input_node->name())) {
         continue;
@@ -410,8 +421,12 @@ tensorflow::Status GetEngineInfo(
             node_id, edge->dst_input(), /*input_edge=*/true, port);
       }
     }
-    // Create output connections.
-    for (const auto edge : node->out_edges()) {
+    // Create output connections. Sort edges first to make determnistic since
+    // out_edges is a set of pointers.
+    std::vector<const tensorflow::Edge*> out_edges(node->out_edges().begin(),
+                                                   node->out_edges().end());
+    std::sort(out_edges.begin(), out_edges.end(), EdgePtrCompare());
+    for (const auto edge : out_edges) {
       auto output_node = edge->dst();
       if (output_node->IsSink() || segment_nodes.count(output_node->name())) {
         continue;

--- a/tensorflow/contrib/tensorrt/segment/segment.cc
+++ b/tensorflow/contrib/tensorrt/segment/segment.cc
@@ -232,14 +232,14 @@ SimpleGraph::~SimpleGraph() {
 // cause a mismatch between the calibration tables of the conversions.
 struct SimpleEdgePtrCompare {
   bool operator()(const SimpleEdge* lhs, const SimpleEdge* rhs) const {
-    return (lhs->id() < rhs->id());
+    return lhs->id() < rhs->id();
   }
 };
 
 struct NodePtrCompare {
   bool operator()(const tensorflow::Node* lhs,
                   const tensorflow::Node* rhs) const {
-    return (lhs->name() < rhs->name());
+    return lhs->name() < rhs->name();
   }
 };
 


### PR DESCRIPTION
Due to using pointers as key for std::set, TFTRT's segmenter was not deterministic. This led to problems (specifically with InceptionV4) in INT8 mode because the graph is created multiple times and the mismatch led to accuracy issues.