### PR TITLE
Add cuDNN deterministic env variable (only for convolution)

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -643,6 +643,8 @@ class CudnnSupport : public dnn::DnnSupport {
   // Provides access to the cuDNN handle.
   std::unique_ptr<class CudnnAccess> cudnn_;
 
+  bool cudnn_deterministic_ = false;
+
   template <class T, class U>
   port::Status DoBatchNormalizationForwardImpl(
       Stream* stream, dnn::DataType input_data_type,


### PR DESCRIPTION
This change is a major component of the recipe for making TensorFlow training reproducible on GPUs.

Setting the environment variable TF_CUDNN_DETERMINISTIC=1 (or true) will ensure that both forward and backwards convolution algorithms are both fixed and deterministic. It overrides autotune and selects deterministic back-prop algorithms.

Attention @azaks2

Note: This pull request was [previous issued incorrectly](https://github.com/tensorflow/tensorflow/pull/24301) based on r1.12.