### PR TITLE
Remove bazel installation from install_pi_toolchain.sh

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pi_python3_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3_toolchain.sh
@@ -22,7 +22,4 @@ echo 'deb [arch=armhf] http://ports.ubuntu.com/ trusty-backports main restricted
 sed -i 's#deb http://archive.ubuntu.com/ubuntu/#deb [arch=amd64] http://archive.ubuntu.com/ubuntu/#g' /etc/apt/sources.list
 apt-get update
 apt-get install -y libpython3-all-dev:armhf
-echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-apt-get update
 apt-get install -y python3 python3-numpy python3-dev python3-pip

--- a/tensorflow/tools/ci_build/install/install_pi_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_toolchain.sh
@@ -22,7 +22,4 @@ echo 'deb [arch=armhf] http://ports.ubuntu.com/ trusty-backports main restricted
 sed -i 's#deb http://archive.ubuntu.com/ubuntu/#deb [arch=amd64] http://archive.ubuntu.com/ubuntu/#g' /etc/apt/sources.list
 apt-get update
 apt-get install -y libpython-all-dev:armhf
-echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-apt-get update
 apt-get install -y python python-numpy python-dev python-pip


### PR DESCRIPTION
1. Bazel is installed by install_bazel.sh, no need to install twice.
2. Because the bazel installation in install_pi_toolchain.sh does not specify the target version of bazel, when bazel is newly released and TF is not ready to use it, It will make a error which is happend in r1.12(#24104) now.