### PR TITLE
[OpenMP] Fix undeclared identifier in eigen_support.cc

### DIFF
--- a/tensorflow/lite/kernels/eigen_support.cc
+++ b/tensorflow/lite/kernels/eigen_support.cc
@@ -39,7 +39,7 @@ void SetEigenNbThreads(int threads) {
 #if defined(EIGEN_HAS_OPENMP)
   // The global Eigen thread count is only used when OpenMP is enabled. As this
   // call causes problems with tsan, make it only when OpenMP is available.
-  Eigen::setNbThreads(context->recommended_num_threads);
+  Eigen::setNbThreads(threads);
 #endif  // defined(EIGEN_HAS_OPENMP)
 }
 


### PR DESCRIPTION
When OpenMP is enabled, the following error occurs during a
compilation of the `tensorflow/lite/kernels/eigen_support.cc` unit:

tensorflow/lite/kernels/eigen_support.cc:42:23: error: use of undeclared
identifier 'context'
  Eigen::setNbThreads(context->recommended_num_threads);

The `SetEigenNbThreads` method already gets the number of threads as the
`threads` parameter and doesn't need to calculate it using a method of
the `context` variable, so the invocation of the `Eigen::setNbThreads`
member must be changed a little bit.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>