### PR TITLE
[Intel MKL]Bug fix for redundant transpose removal

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -1025,7 +1025,8 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
             e->dst_input() == kPermTensorIndex) {
           // we find the "perm" node, now try to retrieve its value.
           const TensorProto* proto = nullptr;
-          DCHECK(GetNodeAttr(perm_node->def(), "value", &proto).ok());
+          bool perm_has_value_attr = GetNodeAttr(perm_node->def(), "value", &proto).ok();
+          DCHECK(perm_has_value_attr);
 
           DataType type;
           GetNodeAttr(perm_node->def(), "dtype", &type);
@@ -3110,8 +3111,9 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   for (const Edge* e : transpose_to_nchw->out_edges()) {
     if (!e->IsControlEdge()) {
       const int kTransposeWithMklOpOutputSlot = 0;
-      DCHECK((*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot, e->dst(),
-                           e->dst_input()));
+      bool succ_add_edge = (*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot, e->dst(),
+                                         e->dst_input());
+      DCHECK(succ_add_edge);
     }
   }
 
@@ -3312,7 +3314,6 @@ bool MklLayoutRewritePass::RunPass(std::unique_ptr<Graph>* g) {
 
   DumpGraph("After running MklLayoutRewritePass(NodeMerge)", &**g);
 
-#ifdef ENABLE_TRANSPOSE_OPTIMIZATION
   order.clear();
   GetReversePostOrder(**g, &order);  // This will give us topological sort.
   for (Node* n : order) {
@@ -3334,7 +3335,6 @@ bool MklLayoutRewritePass::RunPass(std::unique_ptr<Graph>* g) {
     }
   }
   DumpGraph("After running MklLayoutRewritePass(NodeFusion)", &**g);
-#endif  // ENABLE_TRANSPOSE_OPTIMIZATION
 
   order.clear();
   GetReversePostOrder(**g, &order);  // This will give us topological sort.

--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -1025,8 +1025,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
             e->dst_input() == kPermTensorIndex) {
           // we find the "perm" node, now try to retrieve its value.
           const TensorProto* proto = nullptr;
-          bool perm_has_value_attr = GetNodeAttr(perm_node->def(), "value", &proto).ok();
-          DCHECK(perm_has_value_attr);
+          TF_CHECK_OK(GetNodeAttr(perm_node->def(), "value", &proto));
 
           DataType type;
           GetNodeAttr(perm_node->def(), "dtype", &type);
@@ -3111,9 +3110,9 @@ Status MklLayoutRewritePass::FuseTransposeMklOpTranspose(
   for (const Edge* e : transpose_to_nchw->out_edges()) {
     if (!e->IsControlEdge()) {
       const int kTransposeWithMklOpOutputSlot = 0;
-      bool succ_add_edge = (*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot, e->dst(),
-                                         e->dst_input());
-      DCHECK(succ_add_edge);
+      auto new_edge = (*g)->AddEdge(new_node, kTransposeWithMklOpOutputSlot, e->dst(),
+                                    e->dst_input());
+      DCHECK(new_edge);
     }
   }
 

--- a/tensorflow/core/graph/mkl_layout_pass_test.cc
+++ b/tensorflow/core/graph/mkl_layout_pass_test.cc
@@ -707,7 +707,7 @@ TEST_F(MklLayoutPassTest, NodeMerge_PadWithConv2D_Negative) {
       "C:control->DMT/_0:control;C:control->DMT/_1:control;"
       "D->E:1;DMT/_0->E:2;DMT/_1->E:3;E->Z;Y->Z:1");
 }
-#ifdef ENABLE_TRANSPOSE_OPTIMIZATION
+
 TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Positive) {
   InitGraph(
       "node { name: 'Input0' op: 'Input'}"
@@ -1016,7 +1016,6 @@ TEST_F(MklLayoutPassTest, NodeMerge_TransposeConv2DTranspose_Negative) {
       "Transpose0:control->DMT/"
       "_1:control;Transpose1->Relu;Transpose1:control->DMT/_2:control");
 }
-#endif  // ENABLE_TRANSPOSE_OPTIMIZATION
 
 /////////////////////////////////////////////////////////////////////
 //  Unit tests related to rewriting node to Mkl node


### PR DESCRIPTION
1. this bug is a last minute check-in to replace "CHECK()" with "DCHECK()", however it turns out that "CHECK()" and "DCHECK()" are not functional equivalent;
2. unlike "CHECK()" whose expression will always be excuted, the expression in "DCHECK()" will not be executed in release mode. This causes dangling pointer failures.
3. to fix this bug, we should check the result of the expression instead of the expression itself.