### PR TITLE
remove redundant entries in kernels:BUILD for no_mkldnn_contraction_k…

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -597,10 +597,6 @@ cc_library(
     srcs = ["eigen_contraction_kernel.cc"],
     hdrs = ["eigen_contraction_kernel.h"],
     defines = select({
-        "//tensorflow:android": [],
-        "//tensorflow:arm": [],
-        "//tensorflow:ios": [],
-        "//tensorflow:linux_ppc64le": [],
         ":no_mkldnn_contraction_kernel": [],
         "//conditions:default": [
             "TENSORFLOW_USE_CUSTOM_CONTRACTION_KERNEL",
@@ -610,10 +606,6 @@ cc_library(
     deps = [
         "//third_party/eigen3",
     ] + select({
-        "//tensorflow:android": [],
-        "//tensorflow:arm": [],
-        "//tensorflow:ios": [],
-        "//tensorflow:linux_ppc64le": [],
         ":no_mkldnn_contraction_kernel": [],
         "//conditions:default": ["@mkl_dnn//:mkldnn_single_threaded"],
     }),
@@ -2494,10 +2486,6 @@ tf_cc_test(
     name = "eigen_mkldnn_contraction_kernel_test",
     size = "small",
     srcs = select({
-        "//tensorflow:android": [],
-        "//tensorflow:arm": [],
-        "//tensorflow:ios": [],
-        "//tensorflow:linux_ppc64le": [],
         ":no_mkldnn_contraction_kernel": [],
         "//conditions:default": ["eigen_mkldnn_contraction_kernel_test.cc"],
     }),


### PR DESCRIPTION
…ernel

Addresses #24414 

Since `tensorflow_mkldnn_contraction_kernel` is set to `0` on line 104, we end up with multiple successful matches in these `select` structures. The architecture specific entries are currently not needed. If there is a chance that `tensorflow_mkldnn_contraction_kernel` will be set to 1 in the build config setting default, then we'll need a more robust solution.

This fixes a current build break on ppc64le community builds.