### PR TITLE
Fix-Bug: CHECK_GT(2^32, 0) return false

### DIFF
--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -240,8 +240,7 @@ string* MakeCheckOpString(const T1& v1, const T2& v2, const char* exprtext) {
     if (TF_PREDICT_FALSE(v2 < 0)) {                                       \
       return ::tensorflow::internal::MakeCheckOpString(v1, v2, exprtext); \
     }                                                                     \
-    const size_t uval = (size_t)((unsigned)v1);                           \
-    return name##Impl<size_t, size_t>(uval, v2, exprtext);                \
+    return name##Impl<size_t, size_t>(v1, v2, exprtext);                  \
   }                                                                       \
   inline string* name##Impl(const int v1, const size_t v2,                \
                             const char* exprtext) {                       \


### PR DESCRIPTION
it seems that 'const size_t uval = (size_t)((unsigned)v1); ' make the unsigned long cast to unsigned int sometimes.
it is a bug when I new a Tensor with 2^32 totalBytes and try to save/restore from ckpt.
https://github.com/tensorflow/tensorflow/blob/r1.4/tensorflow/core/util/tensor_bundle/tensor_bundle.cc#L200