### PR TITLE
Rprop Optimizer

### DIFF
--- a/tensorflow/contrib/optimizer_v2/BUILD
+++ b/tensorflow/contrib/optimizer_v2/BUILD
@@ -44,6 +44,8 @@ py_library(
         "momentum.py",
         "optimizer_v2.py",
         "rmsprop.py",
+        "irprop_plus.py",
+        "rprop_minus.py",
     ],
     srcs_version = "PY2AND3",
     deps = [
@@ -192,6 +194,44 @@ cuda_py_test(
     name = "rmsprop_test",
     size = "small",
     srcs = ["rmsprop_test.py"],
+    additional_deps = [
+        ":training",
+        "@absl_py//absl/testing:parameterized",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:embedding_ops",
+        "//tensorflow/python:framework",
+        "//tensorflow/python:math_ops",
+        "//tensorflow/python:platform",
+        "//tensorflow/python:platform_test",
+        "//tensorflow/python:client_testlib",
+        "//third_party/py/numpy",
+    ],
+    tags = ["optonly"],
+)
+
+cuda_py_test(
+    name = "irprop_plus_test",
+    size = "small",
+    srcs = ["irprop_plus_test.py"],
+    additional_deps = [
+        ":training",
+        "@absl_py//absl/testing:parameterized",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:embedding_ops",
+        "//tensorflow/python:framework",
+        "//tensorflow/python:math_ops",
+        "//tensorflow/python:platform",
+        "//tensorflow/python:platform_test",
+        "//tensorflow/python:client_testlib",
+        "//third_party/py/numpy",
+    ],
+    tags = ["optonly"],
+)
+
+cuda_py_test(
+    name = "rprop_minus_test",
+    size = "small",
+    srcs = ["rprop_minus_test.py"],
     additional_deps = [
         ":training",
         "@absl_py//absl/testing:parameterized",

--- a/tensorflow/contrib/optimizer_v2/irprop_plus.py
+++ b/tensorflow/contrib/optimizer_v2/irprop_plus.py
@@ -1,0 +1,281 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Implementation of iRprop+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from tensorflow.contrib.optimizer_v2 import optimizer_v2
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.training import training_ops
+
+
+class IRpropPlusOptimizer(optimizer_v2.OptimizerV2):
+  """Optimizer that implements the iRprop+ algorithm.
+
+  The Rprop (resilient backpropagation) algorithms are efficient gradient-based
+  optimization algorithms. They require hardly any hyperparameter tuning.
+
+  In Rprop, the direction of each objective variable update is given by the sign
+  of the partial derivative. The amount of the change is decoupled
+  from the absolute value of the partial derivativsadasdase. It is determined by a
+  step-size parameter, which is individually adapted for each objective
+  variable.
+
+  Rprop was originally proposed by Riedmiller and Braun in the article
+  [A direct adaptive method for faster backpropagation learning:
+  the RPROP algorithm](https://doi.org/10.1109/ICNN.1993.298623).
+  The original Rprop algorithm uses weight-backtracking. It retracts the update
+  of an objective variable if the update caused a change in sign of the
+  corresponding partial derivative. The implememented Rprop variant, which is
+  called iRprop+ and is described in the article
+  [Empirical evaluation of the improved Rprop learning algorithms](https://doi.org/10.1016/S0925-2312(01)00700-7)
+  only retracts an update if additionally the overall error increased.
+  The TensorFlow implementation is described in the article
+  [Resilient Backpropagation (Rprop) for Batch-learning in TensorFlow](https://openreview.net/forum?id=r1R0o7yDz).
+
+  **The Rprop algorithms are recommended for batch learning, _not_ for
+  mini-batch learning.** The iRprop+ (improved Rprop with weight-backtracking)
+  algorithm is empirically found to be faster and more robust than the
+  [standard variant](RpropMinusOptimizer.md).
+  See [Resilient Backpropagation (Rprop) for Batch-learning in
+  TensorFlow](https://openreview.net/forum?id=r1R0o7yDz)
+  for details and references.
+  """
+
+  def __init__(self,
+               eta_minus=0.5,
+               eta_plus=1.2,
+               delta_zero=0.5,
+               delta_min=1e-6,
+               delta_max=50,
+               use_locking=False, name="IRpropPlusOptimizer"):
+    """Constructs a new IRpropPlusOptimizer object.
+
+    The pseudocode of the algorithm can be found in the articles
+    [Empirical evaluation of the improved Rprop learning algorithms](https://doi.org/10.1016/S0925-2312(01)00700-7)
+    and [Resilient Backpropagation (Rprop) for Batch-learning in TensorFlow](https://openreview.net/forum?id=r1R0o7yDz).
+
+    Initialization:
+
+    ```
+    old_grad <- 0 (Initialize the gradient from the previous iteration g{t-1})
+    delta_update <- delta_zero (Initialize step-size)
+    t <- 0 (Initialize iteration counter)
+    ```
+
+    The following update rule is performed for each individual objective
+    variable (e.g., weight), where `g{t}` denotes the partial derivative of the
+    objective function with respect to the objective variable at iteration `t`:
+
+    ```
+    t <- t + 1
+    grad_sign <- sign(g{t} * g{t-1})
+    if (grad_sign > 0)
+      delta_update{t} <- min(eta_plus * delta_update{t-1}, delta_max)
+      variable{t+1} <- variable{t} -sign(g{t}) * delta_update{t}
+    else if (grad_sign < 0)
+      delta_update{t} <- max(eta_minus * delta_update{t-1}, delta_min)
+      if (error{t} > error{t-1})
+        variable{t+1} <- variable{t-1}
+      g{t} = 0
+    else
+      variable{t+1} <- variable{t} - sign(g{t}) * delta_update{t}
+
+    ```
+
+    Args:
+      eta_minus: Step-size decrease factor.
+      eta_plus: Step-size increase factor.
+      delta_zero: Initial step-size.
+      delta_min: Lower bound on step-size.
+      delta_max: Upper bound on step-size.
+      use_locking: If True, use locks for update operations.
+      name: Optional name for the operations created when applying gradients.
+         Defaults to "IRpropPlusOptimizer".
+   """
+
+    super(IRpropPlusOptimizer, self).__init__(use_locking, name)
+
+    # Init parameters
+    self._set_hyper("eta_minus", eta_minus)
+    self._set_hyper("eta_plus", eta_plus)
+    self._set_hyper("delta_zero", delta_zero)
+    self._set_hyper("delta_min", delta_min)
+    self._set_hyper("delta_max", delta_max)
+
+    # Error auxiliary var
+    self._error = None
+
+  def _create_vars(self, var_list, state):
+
+    for v in var_list:
+      state.zeros_slot(v, "old_grad")
+
+      init_step = math_ops.add(
+          array_ops.zeros_like(v),
+          state.get_hyper("delta_zero", v.dtype.base_dtype))
+      state.create_slot_with_initializer(v, init_step, v.get_shape(),
+                                         v.dtype.base_dtype, "delta_update")
+      # Error tensors
+      state.create_non_slot(array_ops.zeros_like(v), "error")
+      state.create_non_slot(array_ops.zeros_like(v), "old_error")
+
+  def _get_error_values(self, state=None):
+    if state is None:
+      state = self._get_per_graph_state()
+    return (state.get_non_slot("error"),
+            state.get_non_slot("old_error"))
+
+
+  def _apply_dense(self, grad, var, state):
+    old_grad = state.get_slot(var, "old_grad")
+    delta_update = state.get_slot(var, "delta_update")
+
+    error, old_error = self._get_error_values(state)
+    # Update the error E(t) passed in apply_gradients or minimize
+    update_err = error.assign(math_ops.cast(self._error, var.dtype.base_dtype),
+                              use_locking=self._use_locking)
+
+    with ops.control_dependencies([update_err]):
+      return training_ops.apply_i_rprop_plus(
+          var,
+          old_grad,
+          delta_update,
+          state.get_hyper("eta_minus", var.dtype.base_dtype),
+          state.get_hyper("eta_plus", var.dtype.base_dtype),
+          state.get_hyper("delta_min", var.dtype.base_dtype),
+          state.get_hyper("delta_max", var.dtype.base_dtype),
+          math_ops.cast(error, var.dtype.base_dtype),
+          math_ops.cast(old_error, var.dtype.base_dtype),
+          grad, use_locking=self._use_locking).op
+
+  def _resource_apply_dense(self, grad, var, state):
+    old_grad = state.get_slot(var, "old_grad")
+    delta_update = state.get_slot(var, "delta_update")
+    error, old_error = self._get_error_values(state)
+    update_err = error.assign(math_ops.cast(self._error, var.dtype.base_dtype),
+                              use_locking=self._use_locking)
+
+    with ops.control_dependencies([update_err]):
+      return training_ops.resource_apply_i_rprop_plus(
+          var.handle,
+          old_grad.handle,
+          delta_update.handle,
+          state.get_hyper("eta_minus", var.dtype.base_dtype),
+          state.get_hyper("eta_plus", var.dtype.base_dtype),
+          state.get_hyper("delta_min", var.dtype.base_dtype),
+          state.get_hyper("delta_max", var.dtype.base_dtype),
+          math_ops.cast(error, var.dtype.base_dtype),
+          math_ops.cast(old_error, var.dtype.base_dtype),
+          grad, use_locking=self._use_locking)
+
+  def minimize(self,
+               loss,
+               global_step=None,
+               var_list=None,
+               gate_gradients=optimizer_v2.OptimizerV2.GATE_OP,
+               aggregation_method=None,
+               name=None,
+               grad_loss=None,
+               stop_gradients=None,
+               scale_loss_by_num_replicas=None):
+    """Add operations to minimize `loss` by updating `var_list`.
+    This method simply combines calls `compute_gradients()` and
+    `apply_gradients()`. If you want to process the gradient before applying
+    them call `compute_gradients()` and `apply_gradients()` explicitly instead
+    of using this function. The loss argument has to be passed as a 0-D Tensor.
+    Args:
+      loss: A 0-D `Tensor` containing the value to minimize.
+      global_step: Optional `Variable` to increment by one after the
+        variables have been updated.
+      var_list: Optional list or tuple of `Variable` objects to update to
+        minimize `loss`.  Defaults to the list of variables collected in
+        the graph under the key `GraphKeys.TRAINABLE_VARIABLES`.
+      gate_gradients: How to gate the computation of gradients.  Can be
+        `GATE_NONE`, `GATE_OP`, or  `GATE_GRAPH`.
+      aggregation_method: Specifies the method used to combine gradient terms.
+        Valid values are defined in the class `AggregationMethod`.
+      colocate_gradients_with_ops: If True, try colocating gradients with
+        the corresponding op.
+      name: Optional name for the returned operation.
+      grad_loss: Optional. A `Tensor` holding the gradient computed for `loss`.
+    Returns:
+      An Operation that updates the variables in `var_list`.  If `global_step`
+      was not `None`, that operation also increments `global_step`.
+    Raises:
+      ValueError: If some of the variables are not `Variable` objects.
+      ValueError: If the `loss` is not a 0-D tensor (scalar).
+    @compatibility(eager)
+    When eager execution is enabled, `loss` should be a Python function that
+    takes elements of `var_list` as arguments and computes the value to be
+    minimized. If `var_list` is `None`, `loss` should take no arguments.
+    Minimization (and gradient computation) is done with respect to the
+    elements of `var_list` if not `None`, else with respect to any trainable
+    variables created during the execution of the `loss` function.
+    `gate_gradients`, `aggregation_method`, `colocate_gradients_with_ops` and
+    `grad_loss` are ignored when eager execution is enabled.
+    @end_compatibility
+    """
+    # Override method from base class, the loss is required in the update step
+    if callable(loss):
+      self._error = loss()
+    else:
+      self._error = loss
+
+    return super(IRpropPlusOptimizer, self).minimize(
+        loss,
+        global_step=global_step,
+        var_list=var_list,
+        gate_gradients=gate_gradients,
+        aggregation_method=aggregation_method,
+        name=name,
+        grad_loss=grad_loss,
+        stop_gradients=stop_gradients,
+        scale_loss_by_num_replicas=scale_loss_by_num_replicas)
+
+  def compute_gradients(self,
+                        loss,
+                        var_list=None,
+                        gate_gradients=optimizer_v2.OptimizerV2.GATE_OP,
+                        aggregation_method=None,
+                        grad_loss=None,
+                        stop_gradients=None,
+                        scale_loss_by_num_replicas=None):
+    # eager compatibility
+    if callable(loss):
+      self._error = loss()
+    else:
+      self._error = loss
+
+    return super(IRpropPlusOptimizer, self).compute_gradients(
+        loss=loss,
+        var_list=var_list,
+        gate_gradients=gate_gradients,
+        aggregation_method=aggregation_method,
+        grad_loss=grad_loss,
+        stop_gradients=stop_gradients,
+        scale_loss_by_num_replicas=scale_loss_by_num_replicas)
+
+  def _finish(self, state):
+    error, old_error = self._get_error_values(state)
+    # Update the old error E(t-1) <- E(t)
+    update_old_error = old_error.assign(error, use_locking=self._use_locking)
+    return control_flow_ops.group(update_old_error)

--- a/tensorflow/contrib/optimizer_v2/irprop_plus_test.py
+++ b/tensorflow/contrib/optimizer_v2/irprop_plus_test.py
@@ -1,0 +1,261 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for IRpropPlus."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow.contrib.optimizer_v2 import irprop_plus
+from tensorflow.python.client import session
+from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import test_util
+from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import test
+
+def irprop_update_np(params,
+                     old_w_t,
+                     g_t,
+                     old_g_t,
+                     delta_t,
+                     error,
+                     old_error,
+                     eta_minus=0.5,
+                     eta_plus=1.2,
+                     delta_min=1e-6,
+                     delta_max=50):
+
+  # Hold an extra var to restore the previous weight
+  old_params = np.copy(params)
+  old_g = np.copy(g_t)
+
+  for i, _ in enumerate(g_t):
+    if g_t[i] * old_g_t[i] > 0:
+      delta_t[i] = np.fmin(delta_max, delta_t[i] * eta_plus)
+      params[i] -= np.sign(g_t[i]) * delta_t[i]
+
+    elif g_t[i] * old_g_t[i] < 0:
+      delta_t[i] = np.fmax(delta_min, delta_t[i] * eta_minus)
+
+      # retract step
+      if error[i] > old_error[i]:
+        params[i] = old_w_t[i]
+      old_g[i] = 0
+
+    else:
+      params[i] -= np.sign(g_t[i]) * delta_t[i]
+
+  old_error = np.copy(error)
+  return params, delta_t, old_g, old_params, old_error
+
+
+class IRpropPlusTest(test.TestCase):
+
+  def testBasic(self):
+    with self.cached_session():
+      self.doTestBasic(use_resource=False)
+
+  @test_util.run_in_graph_and_eager_modes(reset_test=True)
+  def testResourceBasic(self):
+    self.doTestBasic(use_resource=True)
+
+  def doTestBasic(self, use_resource=False):
+    for i, dtype in enumerate([dtypes.half, dtypes.float32, dtypes.float64]):
+      with self.session(graph=ops.Graph()):
+        # trainable variables
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+
+        if use_resource:
+          var0 = resource_variable_ops.ResourceVariable(
+              var0_np, name="var0_%d" % i)
+          var1 = resource_variable_ops.ResourceVariable(
+              var1_np, name="var1_%d" % i)
+        else:
+          var0 = variables.Variable(var0_np, dtype=dtype)
+          var1 = variables.Variable(var1_np, dtype=dtype)
+
+        # vars used to restore the previous weight
+        old_w_t0 = var0_np
+        old_w_t1 = var1_np
+
+        grads0_np = np.array([10, 20], dtype=dtype.as_numpy_dtype)
+        neg_grads0_np = np.negative(grads0_np)
+
+        grads1_np = np.array([3, 3], dtype=dtype.as_numpy_dtype)
+        neg_grads1_np = np.negative(grads1_np)
+
+        delta0 = np.array([0.5, 0.5], dtype=dtype.as_numpy_dtype)
+        delta1 = np.array([0.5, 0.5], dtype=dtype.as_numpy_dtype)
+
+        old_error0 = np.array([0.0, 0.0], dtype=dtype.as_numpy_dtype)
+        old_error1 = np.array([0.0, 0.0], dtype=dtype.as_numpy_dtype)
+
+        old_grads0 = np.array([0, 0], dtype=dtype.as_numpy_dtype)
+        old_grads1 = np.array([0, 0], dtype=dtype.as_numpy_dtype)
+
+        opt = irprop_plus.IRpropPlusOptimizer()
+
+        # eager loss has to be a callable
+        def cost():
+          return 5 * var0 ** 2 + 3 * var1
+
+        if not context.executing_eagerly():
+          cost = 5 * var0 **2 + 3 * var1
+
+        gvs = opt.compute_gradients(cost, [var0, var1])
+        opt.apply_gradients(gvs)
+
+        opt_variables = opt.variables()
+        error, old_error = opt._get_error_values()
+        self.assertTrue(error is not None)
+        self.assertTrue(old_error is not None)
+        self.assertIn(error, opt_variables)
+        self.assertIn(old_error, opt_variables)
+
+        with ops.Graph().as_default():
+          # Shouldn't return non-slot variables from other graphs.
+          self.assertEqual(0, len(opt.variables()))
+
+        if not context.executing_eagerly():
+          self.evaluate(variables.global_variables_initializer())
+          # Fetch params to validate initial values
+          self.assertAllClose([1.0, 2.0], self.evaluate(var0))
+          self.assertAllClose([3.0, 4.0], self.evaluate(var1))
+          self.assertAllClose([0.0, 0.0], self.evaluate(error))
+          self.assertAllClose([0.0, 0.0], self.evaluate(old_error))
+
+        if not context.executing_eagerly():
+          self.evaluate(variables.global_variables_initializer())
+          pos_update = opt.apply_gradients(zip([grads0_np, grads1_np],
+                                               [var0, var1]))
+          neg_update = opt.apply_gradients(zip([neg_grads0_np, neg_grads1_np],
+                                               [var0, var1]))
+
+        # Run 10 steps of irprop+
+        # first 3 steps with positive gradient (same consecutive sign)
+        # next 3 steps with negative gradient
+        # - 4th iteration with negative sign will not retract the weight
+        # - 5th iteration will have 0 sign
+        # - next iteration will have the same sign
+        # last 4 steps with alternate gradient sign
+        # - 7th iteration will retract the weight (neg sign, err>old_err)
+        # - 8th it will have 0 sign
+        # - 9th iteration will retract the weight (neg sign, err>old_err)
+        # - last iteration 0 sign
+        for t in range(1, 11):
+          # get error for the local update
+          error = self._cost(var0_np, var1_np)
+
+          if t < 3:
+            grads0 = grads0_np
+            grads1 = grads1_np
+
+            if not context.executing_eagerly():
+              self.evaluate(pos_update)
+            elif t > 1:
+              opt.compute_gradients(cost, [var0, var1])
+              opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+          elif t < 7:
+            grads0 = neg_grads0_np
+            grads1 = neg_grads1_np
+
+            if not context.executing_eagerly():
+              self.evaluate(neg_update)
+            else:
+              opt.compute_gradients(cost, [var0, var1])
+              opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+          else:
+            if t & 1 == 0:
+              grads0 = neg_grads0_np
+              grads1 = neg_grads1_np
+              if not context.executing_eagerly():
+                self.evaluate(neg_update)
+              else:
+                opt.compute_gradients(cost, [var0, var1])
+                opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+            else:
+              grads0 = grads0_np
+              grads1 = grads1_np
+              if not context.executing_eagerly():
+                self.evaluate(pos_update)
+              else:
+                opt.compute_gradients(cost, [var0, var1])
+                opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+          var0_np, delta0, old_grads0, old_w_t0, old_error0 = irprop_update_np(
+              var0_np,
+              old_w_t0,
+              grads0,
+              old_grads0,
+              delta0,
+              error=error,
+              old_error=old_error0)
+          var1_np, delta1, old_grads1, old_w_t1, old_error1 = irprop_update_np(
+              var1_np,
+              old_w_t1,
+              grads1,
+              old_grads1,
+              delta1,
+              error=error,
+              old_error=old_error1)
+
+          self.assertAllCloseAccordingToType(var0_np, self.evaluate(var0))
+          self.assertAllCloseAccordingToType(var1_np, self.evaluate(var1))
+
+  def _cost(self, x, y):
+    return 5 * x **2 + 3 * y
+
+  def testTwoSessions(self):
+    optimizer = irprop_plus.IRpropPlusOptimizer()
+    g = ops.Graph()
+    with g.as_default():
+      with session.Session():
+        var0 = variables.Variable(np.array([1.0, 2.0]), name="v0")
+        cost0 = 2 * var0 ** 2
+        gv0 = optimizer.compute_gradients(cost0, [var0])
+        optimizer.apply_gradients(gv0)
+
+    gg = ops.Graph()
+    with gg.as_default():
+      with session.Session():
+        var0 = variables.Variable(np.array([1.0, 2.0]), name="v0")
+        cost0 = 2 * var0 ** 2
+        gv0 = optimizer.compute_gradients(cost0, [var0])
+        # If the optimizer saves any state not keyed by graph the following line
+        # fails.
+        optimizer.apply_gradients(gv0)
+
+  def testSlotsUniqueEager(self):
+    with context.eager_mode():
+      v1 = resource_variable_ops.ResourceVariable(1.)
+      v2 = resource_variable_ops.ResourceVariable(1.)
+      opt = irprop_plus.IRpropPlusOptimizer()
+      opt.minimize(lambda: v1 + v2)
+      # There should be two non-slot variables, and two unique slot variables
+      # for v1 and v2 respectively.
+      self.assertEqual(6, len(set(opt.variables())))
+
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow/contrib/optimizer_v2/optimizer_v2_symbols.py
+++ b/tensorflow/contrib/optimizer_v2/optimizer_v2_symbols.py
@@ -26,6 +26,8 @@ from tensorflow.contrib.optimizer_v2.gradient_descent import GradientDescentOpti
 from tensorflow.contrib.optimizer_v2.momentum import MomentumOptimizer
 from tensorflow.contrib.optimizer_v2.optimizer_v2 import OptimizerV2
 from tensorflow.contrib.optimizer_v2.rmsprop import RMSPropOptimizer
+from tensorflow.contrib.optimizer_v2.irprop_plus import IRpropPlusOptimizer
+from tensorflow.contrib.optimizer_v2.rprop_minus import RpropMinusOptimizer
 
 from tensorflow.python.util.all_util import remove_undocumented
 
@@ -37,6 +39,8 @@ _allowed_symbols = [
     'MomentumOptimizer',
     'OptimizerV2',
     'RMSPropOptimizer',
+    'IRpropPlusOptimizer',
+    'RpropMinusOptimizer',
 ]
 
 remove_undocumented(__name__, _allowed_symbols)

--- a/tensorflow/contrib/optimizer_v2/rprop_minus.py
+++ b/tensorflow/contrib/optimizer_v2/rprop_minus.py
@@ -1,0 +1,140 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Implementation of Rprop-"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.contrib.optimizer_v2 import optimizer_v2
+from tensorflow.python.training import training_ops
+
+
+class RpropMinusOptimizer(optimizer_v2.OptimizerV2):
+  """Optimizer that implements the Rprop- algorithm.
+
+  The Rprop (resilient backpropagation) algorithms are efficient gradient-based
+  optimization algorithms. They require hardly any hyperparameter tuning.
+
+  In Rprop, the direction of each objective variable update is given by the sign
+  of the partial derivative. The amount of the change is decoupled
+  from the absolute value of the partial derivative. It is determined by a step-size
+  parameter, which is individually adapted for each objective variable.
+
+  Rprop was originally proposed by Riedmiller and Braun in the paper
+  [A direct adaptive method for faster backpropagation learning: the RPROP algorithm](https://doi.org/10.1109/ICNN.1993.298623).
+  The Rprop variant implemented here is described in Riedmiller's article
+  [Advanced supervised learning in multi-layer perceptrons — From backpropagation to adaptive learning algorithms](https://doi.org/10.1016/0920-5489(94)90017-5),
+  and is referred to as Rprop- (Rprop without weight-backtracking) in the
+  article [Empirical evaluation of the improved Rprop learning algorithms](https://doi.org/10.1016/S0925-2312(01)00700-7).
+
+  **The Rprop algorithms are recommended for batch learning, _not_
+  for mini-batch learning.** The variant
+  [iRprop+ (improved Rprop with weight-backtracking)
+   algorithm](IRpropPlusOptimizer.md)
+  is empirically found to be faster and more robust than Rprop-.
+  See [Resilient Backpropagation (Rprop) for Batch-learning in TensorFlow](https://openreview.net/forum?id=r1R0o7yDz)
+  for details and references.
+  """
+
+  def __init__(self,
+               eta_minus=0.5,
+               eta_plus=1.2,
+               delta_zero=0.5,
+               delta_min=1e-6,
+               delta_max=50,
+               use_locking=False, name="RpropMinusOptimizer"):
+    """Constructs a new RpropMinusOptimizer object.
+
+    Initialization:
+
+    ```
+    old_grad <- 0 (Initialize the gradient from the previous timestep g{t-1})
+    delta_update <- delta_zero (Initialize step-size)
+    t <- 0 (Initialize iteration counter)
+    ```
+
+    The following update rule is performed for each individual objective
+    variable (e.g., weight), where `g{t}` denotes the partial derivative of the
+    objective function with respect to the objective variable at iteration `t`:
+
+    ```
+    t <- t + 1
+    grad_sign <- sign(g{t} * g{t-1})
+    if (grad_sign > 0)
+      delta_update{t} <- min(eta_plus * delta_update{t-1}, delta_max)
+    else if (grad_sign < 0)
+      delta_update{t} <- max(eta_minus * delta_update{t-1}, delta_min)
+    variable{t+1} <- variable{t} - sign(g{t}) * delta_update{t}
+    ```
+
+    Args:
+      eta_minus: Step-size decrease factor.
+      eta_plus: Step-size increase factor.
+      delta_zero: Initial step-size.
+      delta_min: Lower bound on step-size.
+      delta_max: Upper bound on step-size.
+      use_locking: If True, use locks for update operations.
+      name: Optional name for the operations created when applying gradients.
+         Defaults to "RpropMinusOptimizer".
+    """
+    super(RpropMinusOptimizer, self).__init__(use_locking, name)
+
+    # Init parameters
+    self._set_hyper("eta_minus", eta_minus)
+    self._set_hyper("eta_plus", eta_plus)
+    self._set_hyper("delta_zero", delta_zero)
+    self._set_hyper("delta_min", delta_min)
+    self._set_hyper("delta_max", delta_max)
+
+  def _create_vars(self, var_list, state):
+    for v in var_list:
+      state.zeros_slot(v, "old_grad")
+
+      init_step = math_ops.add(
+          array_ops.zeros_like(v),
+          state.get_hyper("delta_zero", v.dtype.base_dtype))
+      state.create_slot_with_initializer(v, init_step, v.get_shape(),
+                                         v.dtype.base_dtype, "delta_update")
+
+  def _apply_dense(self, grad, var, state):
+    old_grad = state.get_slot(var, "old_grad")
+    delta_update = state.get_slot(var, "delta_update")
+
+    return training_ops.apply_rprop_minus(
+        var,
+        old_grad,
+        delta_update,
+        state.get_hyper("eta_minus", var.dtype.base_dtype),
+        state.get_hyper("eta_plus", var.dtype.base_dtype),
+        state.get_hyper("delta_min", var.dtype.base_dtype),
+        state.get_hyper("delta_max", var.dtype.base_dtype),
+        grad, use_locking=self._use_locking).op
+
+  def _resource_apply_dense(self, grad, var, state):
+    old_grad = state.get_slot(var, "old_grad")
+    delta_update = state.get_slot(var, "delta_update")
+
+    return training_ops.resource_apply_rprop_minus(
+        var.handle,
+        old_grad.handle,
+        delta_update.handle,
+        state.get_hyper("eta_minus", var.dtype.base_dtype),
+        state.get_hyper("eta_plus", var.dtype.base_dtype),
+        state.get_hyper("delta_min", var.dtype.base_dtype),
+        state.get_hyper("delta_max", var.dtype.base_dtype),
+        grad, use_locking=self._use_locking)

--- a/tensorflow/contrib/optimizer_v2/rprop_minus_test.py
+++ b/tensorflow/contrib/optimizer_v2/rprop_minus_test.py
@@ -1,0 +1,224 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for Rprop-"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow.contrib.optimizer_v2 import rprop_minus
+from tensorflow.python.client import session
+from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import test_util
+from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import test
+
+
+def rprop_update_numpy(params,
+                       g_t,
+                       old_g_t,
+                       d_t,
+                       eta_minus,
+                       eta_plus,
+                       delta_min,
+                       delta_max):
+
+  for i, _ in enumerate(g_t):
+
+    current_g = g_t[i]
+    mul_grad = g_t[i] * old_g_t[i]
+
+    if mul_grad > 0:
+      d_t[i] = np.fmin(delta_max, d_t[i] * eta_plus)
+    elif mul_grad < 0:
+      d_t[i] = np.fmax(delta_min, d_t[i] * eta_minus)
+
+    params[i] -= np.sign(current_g) * d_t[i]
+
+  return params, d_t, g_t
+
+class RpropMinusTest(test.TestCase):
+
+  def _testDense(self,
+                 use_resource=False,
+                 eta_minus=0.5,
+                 eta_plus=1.2,
+                 delta_min=1e-6,
+                 delta_max=50,
+                 delta_zero=0.5):
+    for dtype in [dtypes.half, dtypes.float32, dtypes.float64]:
+      with self.test_session(use_gpu=True):
+
+        # Initialize variables for numpy implementation.
+        var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+        grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+        neg_grads0_np = np.negative(grads0_np)
+        old_grads0 = np.array([0, 0], dtype=dtype.as_numpy_dtype)
+        delta0 = np.array([delta_zero, delta_zero], dtype=dtype.as_numpy_dtype)
+
+        var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+        grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+        neg_grads1_np = np.negative(grads1_np)
+        old_grads1 = np.array([0, 0], dtype=dtype.as_numpy_dtype)
+        delta1 = np.array([delta_zero, delta_zero], dtype=dtype.as_numpy_dtype)
+
+        if use_resource:
+          var0 = resource_variable_ops.ResourceVariable(var0_np)
+          var1 = resource_variable_ops.ResourceVariable(var1_np)
+        else:
+          var0 = variables.Variable(var0_np)
+          var1 = variables.Variable(var1_np)
+
+        grads0 = constant_op.constant(grads0_np)
+        grads1 = constant_op.constant(grads1_np)
+        neg_grads0 = constant_op.constant(neg_grads0_np)
+        neg_grads1 = constant_op.constant(neg_grads1_np)
+
+        # Helpers
+        vars_arr = [var0, var1]
+        pos_grads = [grads0, grads1]
+        neg_grads = [neg_grads0, neg_grads1]
+
+        opt = rprop_minus.RpropMinusOptimizer(eta_minus=eta_minus,
+                                              eta_plus=eta_plus,
+                                              delta_min=delta_min,
+                                              delta_max=delta_max,
+                                              delta_zero=delta_zero)
+
+        if not context.executing_eagerly():
+          pos_update = opt.apply_gradients(zip(pos_grads, vars_arr))
+          neg_update = opt.apply_gradients(zip(neg_grads, vars_arr))
+
+        if not context.executing_eagerly():
+          self.evaluate(variables.global_variables_initializer())
+          # Fetch params to validate initial values
+          self.assertAllClose([1.0, 2.0], self.evaluate(var0))
+          self.assertAllClose([3.0, 4.0], self.evaluate(var1))
+
+        # Run 10 steps of rprop-
+        # first 3 steps with positive gradient (same consecutive sign)
+        # next 3 steps with negative gradient (first iteration only will have negative sign)
+        # last 4 steps with alternate gradient (negative sign)
+        for t in range(1, 10):
+          if t < 4:
+            grads0_sign = grads0_np
+            grads1_sign = grads1_np
+            if not context.executing_eagerly():
+              self.evaluate(pos_update)
+            else:
+              opt.apply_gradients(zip(pos_grads, vars_arr))
+          elif t < 7:
+            grads0_sign = neg_grads0_np
+            grads1_sign = neg_grads1_np
+            if not context.executing_eagerly():
+              self.evaluate(neg_update)
+            else:
+              opt.apply_gradients(zip(neg_grads, vars_arr))
+          else:
+            if t & 1 == 0:
+              grads0_sign = neg_grads0_np
+              grads1_sign = neg_grads1_np
+              if not context.executing_eagerly():
+                self.evaluate(neg_update)
+              else:
+                opt.apply_gradients(zip(neg_grads, vars_arr))
+            else:
+              grads0_sign = grads0_np
+              grads1_sign = grads1_np
+              if not context.executing_eagerly():
+                self.evaluate(pos_update)
+              else:
+                opt.apply_gradients(zip(pos_grads, vars_arr))
+
+          var0_np, delta0, old_grads0 = rprop_update_numpy(
+              var0_np,
+              grads0_sign,
+              old_grads0,
+              delta0,
+              eta_minus=eta_minus,
+              eta_plus=eta_plus,
+              delta_min=delta_min,
+              delta_max=delta_max)
+          var1_np, delta1, old_grads1 = rprop_update_numpy(
+              var1_np,
+              grads1_sign,
+              old_grads1,
+              delta1,
+              eta_minus=eta_minus,
+              eta_plus=eta_plus,
+              delta_min=delta_min,
+              delta_max=delta_max)
+
+          self.assertAllCloseAccordingToType(var0_np, self.evaluate(var0))
+          self.assertAllCloseAccordingToType(var1_np, self.evaluate(var1))
+
+  def testBasic(self):
+    self._testDense(use_resource=False)
+    self._testDense(use_resource=False,
+                    eta_minus=0.25,
+                    eta_plus=1.5,
+                    delta_min=1e-8,
+                    delta_max=25,
+                    delta_zero=1)
+
+  @test_util.run_in_graph_and_eager_modes(reset_test=True)
+  def testResourceBasic(self):
+    self._testDense(use_resource=True)
+    self._testDense(use_resource=True,
+                    eta_minus=0.25,
+                    eta_plus=1.5,
+                    delta_min=1e-8,
+                    delta_max=25,
+                    delta_zero=1)
+
+
+  def testTwoSessions(self):
+    optimizer = rprop_minus.RpropMinusOptimizer()
+    g = ops.Graph()
+    with g.as_default():
+      with session.Session():
+        var0 = variables.Variable(np.array([1.0, 2.0]), name="v0")
+        cost0 = 2 * var0 ** 2
+        gv0 = optimizer.compute_gradients(cost0, [var0])
+        optimizer.apply_gradients(gv0)
+
+    gg = ops.Graph()
+    with gg.as_default():
+      with session.Session():
+        var0 = variables.Variable(np.array([1.0, 2.0]), name="v0")
+        cost0 = 2 * var0 ** 2
+        gv0 = optimizer.compute_gradients(cost0, [var0])
+        # If the optimizer saves any state not keyed by graph the following line
+        # fails.
+        optimizer.apply_gradients(gv0)
+
+  def testSlotsUniqueEager(self):
+    with context.eager_mode():
+      v1 = resource_variable_ops.ResourceVariable(1.)
+      v2 = resource_variable_ops.ResourceVariable(1.)
+      opt = rprop_minus.RpropMinusOptimizer()
+      opt.minimize(lambda: v1 + v2)
+      # There should be two non-slot variables, and two unique slot variables
+      # for v1 and v2 respectively.
+      self.assertEqual(4, len(set(opt.variables())))
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -455,6 +455,83 @@ struct ApplyPowerSign<CPUDevice, T> {
   }
 };
 
+template <typename T>
+struct ApplyIRpropPlus<CPUDevice, T> {
+  void operator()(const CPUDevice& d, typename TTypes<T>::Flat var,
+                  typename TTypes<T>::Flat old_grad,
+                  typename TTypes<T>::Flat delta_update,
+                  typename TTypes<T>::ConstScalar eta_minus,
+                  typename TTypes<T>::ConstScalar eta_plus,
+                  typename TTypes<T>::ConstScalar delta_min,
+                  typename TTypes<T>::ConstScalar delta_max,
+                  typename TTypes<T>::ConstFlat error,
+                  typename TTypes<T>::ConstFlat old_error,
+                  typename TTypes<T>::ConstFlat grad) {
+    auto sign_t = (old_grad * grad).sign();
+    // change to ColMaj to perform operations
+    Eigen::Tensor<T, 1> grad_sign = sign_t.swap_layout();
+
+    for (int i = 0; i < var.size(); i++) {
+      auto sign = grad_sign(i);
+
+      if (sign < T(0)) {
+        // revert deltaW(t-1) first then update delta
+        if (error(i) > old_error(i)) {
+          // compute deltaW and update the weight
+          var(i) -= delta_update(i) * -sgn(old_grad(i));
+        }
+
+        delta_update(i) = std::max(delta_min(), delta_update(i) * eta_minus());
+        // gradient backtracking trick
+        old_grad(i) = T(0);
+      } else {
+        // no sign change
+        if (sign > T(0)) {
+          delta_update(i) = std::min(delta_max(), delta_update(i) * eta_plus());
+        }
+
+        var(i) += -sgn(grad(i)) * delta_update(i);
+        old_grad(i) = grad(i);
+      }
+    }
+    old_grad.device(d) = old_grad;
+    delta_update.device(d) = delta_update;
+    var.device(d) = var;
+  }
+};
+
+template <typename T>
+struct ApplyRpropMinus<CPUDevice, T> {
+  void operator()(const CPUDevice& d, typename TTypes<T>::Flat var,
+                  typename TTypes<T>::Flat old_grad,
+                  typename TTypes<T>::Flat delta_update,
+                  typename TTypes<T>::ConstScalar eta_minus,
+                  typename TTypes<T>::ConstScalar eta_plus,
+                  typename TTypes<T>::ConstScalar delta_min,
+                  typename TTypes<T>::ConstScalar delta_max,
+                  typename TTypes<T>::ConstFlat grad) {
+    auto sign_t = (old_grad * grad).sign();
+    Eigen::Tensor<T, 1> grad_sign = sign_t.swap_layout();
+
+    for (int i = 0; i < var.size(); i++) {
+      auto sign = grad_sign(i);
+      // no sign change
+      if (sign > T(0)) {
+        // min delta
+        delta_update(i) = std::min(delta_max(), delta_update(i) * eta_plus());
+      } else if (sign < T(0)) {
+        delta_update(i) = std::max(delta_min(), delta_update(i) * eta_minus());
+      }
+    }
+    // update slots
+    old_grad.device(d) = grad;
+    delta_update.device(d) = delta_update;
+
+    // update step
+    var.device(d) -= grad.sign() * delta_update;
+  }
+};
+
 }  // namespace functor
 
 template <typename Device, typename T>
@@ -4080,6 +4157,288 @@ namespace functor {
 DECLARE_GPU_SPEC(Eigen::half);
 DECLARE_GPU_SPEC(float);
 DECLARE_GPU_SPEC(double);
+#undef DECLARE_GPU_SPEC
+}  // namespace functor
+
+REGISTER_KERNELS(GPU, Eigen::half);
+REGISTER_KERNELS(GPU, float);
+REGISTER_KERNELS(GPU, double);
+#endif
+#undef REGISTER_CPU_KERNELS
+#undef REGISTER_KERNELS
+
+template <typename Device, typename T>
+class ApplyIRpropPlusOp : public OpKernel {
+ public:
+  explicit ApplyIRpropPlusOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("use_locking", &use_exclusive_lock_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    const bool sparse = false;
+    auto locks = MaybeLockVariableInputMutexesInOrder<Device, T>(
+        ctx, use_exclusive_lock_, sparse, {0, 1, 2});
+
+    Tensor var;
+    OP_REQUIRES_OK(ctx, GetInputTensorFromVariable<Device, T>(
+                            ctx, 0, use_exclusive_lock_, sparse, &var));
+    Tensor old_grad;
+    OP_REQUIRES_OK(ctx, GetInputTensorFromVariable<Device, T>(
+                            ctx, 1, use_exclusive_lock_, sparse, &old_grad));
+    Tensor delta_update;
+    OP_REQUIRES_OK(
+        ctx, GetInputTensorFromVariable<Device, T>(ctx, 2, use_exclusive_lock_,
+                                                   sparse, &delta_update));
+    OP_REQUIRES(
+        ctx, var.IsInitialized(),
+        errors::FailedPrecondition(
+            "Attempting to use uninitialized variables: ", requested_input(0)));
+
+    OP_REQUIRES(
+        ctx, old_grad.IsInitialized(),
+        errors::FailedPrecondition(
+            "Attempting to use uninitialized variables: ", requested_input(1)));
+
+    OP_REQUIRES(
+        ctx, delta_update.IsInitialized(),
+        errors::FailedPrecondition(
+            "Attempting to use uninitialized variables: ", requested_input(2)));
+
+    const Tensor& eta_minus = ctx->input(3);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(eta_minus.shape()),
+                errors::InvalidArgument("eta_minus is not a scalar: ",
+                                        eta_minus.shape().DebugString()));
+    const Tensor& eta_plus = ctx->input(4);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(eta_plus.shape()),
+                errors::InvalidArgument("eta_plus is not a scalar: ",
+                                        eta_plus.shape().DebugString()));
+    const Tensor& delta_min = ctx->input(5);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(delta_min.shape()),
+                errors::InvalidArgument("delta_min is not a scalar: ",
+                                        delta_min.shape().DebugString()));
+    const Tensor& delta_max = ctx->input(6);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(delta_max.shape()),
+                errors::InvalidArgument("delta_max is not a scalar: ",
+                                        delta_max.shape().DebugString()));
+
+    const Tensor& error = ctx->input(7);
+    OP_REQUIRES(
+        ctx, var.shape().IsSameSize(error.shape()),
+        errors::InvalidArgument("var and error do not have the same shape",
+                                var.shape().DebugString(), " ",
+                                error.shape().DebugString()));
+
+    const Tensor& old_error = ctx->input(8);
+    OP_REQUIRES(
+        ctx, var.shape().IsSameSize(old_error.shape()),
+        errors::InvalidArgument("var and old_error do not have the same shape",
+                                var.shape().DebugString(), " ",
+                                old_error.shape().DebugString()));
+
+    const Tensor& grad = ctx->input(9);
+    OP_REQUIRES(
+        ctx, var.shape().IsSameSize(grad.shape()),
+        errors::InvalidArgument("var and grad do not have the same shape",
+                                var.shape().DebugString(), " ",
+                                grad.shape().DebugString()));
+
+    OP_REQUIRES(ctx, var.shape().IsSameSize(delta_update.shape()),
+                errors::InvalidArgument(
+                    "var and delta_update do not have the same shape",
+                    var.shape().DebugString(), " ",
+                    delta_update.shape().DebugString()));
+
+    OP_REQUIRES(
+        ctx, var.shape().IsSameSize(old_grad.shape()),
+        errors::InvalidArgument("var and old_grad do not have the same shape",
+                                var.shape().DebugString(), " ",
+                                old_grad.shape().DebugString()));
+
+    const Device& device = ctx->template eigen_device<Device>();
+
+    functor::ApplyIRpropPlus<Device, T>()(
+        device, var.flat<T>(), old_grad.flat<T>(), delta_update.flat<T>(),
+        eta_minus.scalar<T>(), eta_plus.scalar<T>(), delta_min.scalar<T>(),
+        delta_max.scalar<T>(), error.flat<T>(), old_error.flat<T>(),
+        grad.flat<T>());
+    MaybeForwardRefInputToRefOutput(ctx, 0, 0);
+  }
+
+ private:
+  bool use_exclusive_lock_;
+};
+
+#define REGISTER_KERNELS(D, T)                                           \
+  REGISTER_KERNEL_BUILDER(                                               \
+      Name("ApplyIRpropPlus").Device(DEVICE_##D).TypeConstraint<T>("T"), \
+      ApplyIRpropPlusOp<D##Device, T>);                                  \
+  REGISTER_KERNEL_BUILDER(Name("ResourceApplyIRpropPlus")                \
+                              .Device(DEVICE_##D)                        \
+                              .HostMemory("var")                         \
+                              .HostMemory("old_grad")                    \
+                              .HostMemory("delta_update")                \
+                              .TypeConstraint<T>("T"),                   \
+                          ApplyIRpropPlusOp<D##Device, T>);
+#define REGISTER_CPU_KERNELS(T) REGISTER_KERNELS(CPU, T);
+
+TF_CALL_half(REGISTER_CPU_KERNELS);
+TF_CALL_bfloat16(REGISTER_CPU_KERNELS);
+TF_CALL_float(REGISTER_CPU_KERNELS);
+TF_CALL_double(REGISTER_CPU_KERNELS);
+
+#if GOOGLE_CUDA
+// Forward declarations of the functor specializations for GPU.
+namespace functor {
+#define DECLARE_GPU_SPEC(T)                             \
+  template <>                                           \
+  void ApplyIRpropPlus<GPUDevice, T>::operator()(       \
+      const GPUDevice& d, typename TTypes<T>::Flat var, \
+      typename TTypes<T>::Flat old_grad,                \
+      typename TTypes<T>::Flat delta_update,            \
+      typename TTypes<T>::ConstScalar eta_minus,        \
+      typename TTypes<T>::ConstScalar eta_plus,         \
+      typename TTypes<T>::ConstScalar delta_min,        \
+      typename TTypes<T>::ConstScalar delta_max,        \
+      typename TTypes<T>::ConstFlat error,              \
+      typename TTypes<T>::ConstFlat old_error,          \
+      typename TTypes<T>::ConstFlat grad);              \
+  extern template struct ApplyIRpropPlus<GPUDevice, T>;
+TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPEC)
+#undef DECLARE_GPU_SPEC
+}  // namespace functor
+
+REGISTER_KERNELS(GPU, Eigen::half);
+REGISTER_KERNELS(GPU, float);
+REGISTER_KERNELS(GPU, double);
+#endif
+#undef REGISTER_CPU_KERNELS
+#undef REGISTER_KERNELS
+
+template <typename Device, typename T>
+class ApplyRpropMinusOp : public OpKernel {
+ public:
+  explicit ApplyRpropMinusOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("use_locking", &use_exclusive_lock_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    const bool sparse = false;
+    auto locks = MaybeLockVariableInputMutexesInOrder<Device, T>(
+        ctx, use_exclusive_lock_, sparse, {0, 1, 2});
+
+    Tensor var;
+    OP_REQUIRES_OK(ctx, GetInputTensorFromVariable<Device, T>(
+                            ctx, 0, use_exclusive_lock_, sparse, &var));
+    Tensor old_grad;
+    OP_REQUIRES_OK(ctx, GetInputTensorFromVariable<Device, T>(
+                            ctx, 1, use_exclusive_lock_, sparse, &old_grad));
+    Tensor delta_update;
+    OP_REQUIRES_OK(
+        ctx, GetInputTensorFromVariable<Device, T>(ctx, 2, use_exclusive_lock_,
+                                                   sparse, &delta_update));
+    OP_REQUIRES(
+        ctx, var.IsInitialized(),
+        errors::FailedPrecondition(
+            "Attempting to use uninitialized variables: ", requested_input(0)));
+
+    OP_REQUIRES(
+        ctx, old_grad.IsInitialized(),
+        errors::FailedPrecondition(
+            "Attempting to use uninitialized variables: ", requested_input(1)));
+
+    OP_REQUIRES(
+        ctx, delta_update.IsInitialized(),
+        errors::FailedPrecondition(
+            "Attempting to use uninitialized variables: ", requested_input(2)));
+
+    const Tensor& eta_minus = ctx->input(3);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(eta_minus.shape()),
+                errors::InvalidArgument("eta_minus is not a scalar: ",
+                                        eta_minus.shape().DebugString()));
+    const Tensor& eta_plus = ctx->input(4);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(eta_plus.shape()),
+                errors::InvalidArgument("eta_plus is not a scalar: ",
+                                        eta_plus.shape().DebugString()));
+    const Tensor& delta_min = ctx->input(5);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(delta_min.shape()),
+                errors::InvalidArgument("delta_min is not a scalar: ",
+                                        delta_min.shape().DebugString()));
+    const Tensor& delta_max = ctx->input(6);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(delta_max.shape()),
+                errors::InvalidArgument("delta_max is not a scalar: ",
+                                        delta_max.shape().DebugString()));
+
+    const Tensor& grad = ctx->input(7);
+    OP_REQUIRES(
+        ctx, var.shape().IsSameSize(grad.shape()),
+        errors::InvalidArgument("var and grad do not have the same shape",
+                                var.shape().DebugString(), " ",
+                                grad.shape().DebugString()));
+
+    OP_REQUIRES(ctx, var.shape().IsSameSize(delta_update.shape()),
+                errors::InvalidArgument(
+                    "var and delta_update do not have the same shape",
+                    var.shape().DebugString(), " ",
+                    delta_update.shape().DebugString()));
+    OP_REQUIRES(
+        ctx, var.shape().IsSameSize(old_grad.shape()),
+        errors::InvalidArgument("var and old_grad do not have the same shape",
+                                var.shape().DebugString(), " ",
+                                old_grad.shape().DebugString()));
+    OP_REQUIRES(
+        ctx, var.shape().IsSameSize(grad.shape()),
+        errors::InvalidArgument("var and delta do not have the same shape",
+                                var.shape().DebugString(), " ",
+                                grad.shape().DebugString()));
+
+    const Device& device = ctx->template eigen_device<Device>();
+
+    functor::ApplyRpropMinus<Device, T>()(
+        device, var.flat<T>(), old_grad.flat<T>(), delta_update.flat<T>(),
+        eta_minus.scalar<T>(), eta_plus.scalar<T>(), delta_min.scalar<T>(),
+        delta_max.scalar<T>(), grad.flat<T>());
+    MaybeForwardRefInputToRefOutput(ctx, 0, 0);
+  }
+
+ private:
+  bool use_exclusive_lock_;
+};
+
+#define REGISTER_KERNELS(D, T)                                           \
+  REGISTER_KERNEL_BUILDER(                                               \
+      Name("ApplyRpropMinus").Device(DEVICE_##D).TypeConstraint<T>("T"), \
+      ApplyRpropMinusOp<D##Device, T>);                                  \
+  REGISTER_KERNEL_BUILDER(Name("ResourceApplyRpropMinus")                \
+                              .Device(DEVICE_##D)                        \
+                              .HostMemory("var")                         \
+                              .HostMemory("old_grad")                    \
+                              .HostMemory("delta_update")                \
+                              .TypeConstraint<T>("T"),                   \
+                          ApplyRpropMinusOp<D##Device, T>);
+#define REGISTER_CPU_KERNELS(T) REGISTER_KERNELS(CPU, T);
+
+TF_CALL_half(REGISTER_CPU_KERNELS);
+TF_CALL_bfloat16(REGISTER_CPU_KERNELS);
+TF_CALL_float(REGISTER_CPU_KERNELS);
+TF_CALL_double(REGISTER_CPU_KERNELS);
+
+#if GOOGLE_CUDA
+// Forward declarations of the functor specializations for GPU.
+namespace functor {
+
+#define DECLARE_GPU_SPEC(T)                             \
+  template <>                                           \
+  void ApplyRpropMinus<GPUDevice, T>::operator()(       \
+      const GPUDevice& d, typename TTypes<T>::Flat var, \
+      typename TTypes<T>::Flat old_grad,                \
+      typename TTypes<T>::Flat delta_update,            \
+      typename TTypes<T>::ConstScalar eta_minus,        \
+      typename TTypes<T>::ConstScalar eta_plus,         \
+      typename TTypes<T>::ConstScalar delta_min,        \
+      typename TTypes<T>::ConstScalar delta_max,        \
+      typename TTypes<T>::ConstFlat grad);              \
+  extern template struct ApplyRpropMinus<GPUDevice, T>;
+TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPEC)
 #undef DECLARE_GPU_SPEC
 }  // namespace functor
 

--- a/tensorflow/core/kernels/training_ops.h
+++ b/tensorflow/core/kernels/training_ops.h
@@ -219,6 +219,32 @@ struct ApplyPowerSign {
                   typename TTypes<T>::ConstFlat grad);
 };
 
+template <typename Device, typename T>
+struct ApplyIRpropPlus {
+  void operator()(const Device& d, typename TTypes<T>::Flat var,
+                  typename TTypes<T>::Flat old_grad,
+                  typename TTypes<T>::Flat delta_update,
+                  typename TTypes<T>::ConstScalar eta_minus,
+                  typename TTypes<T>::ConstScalar eta_plus,
+                  typename TTypes<T>::ConstScalar delta_min,
+                  typename TTypes<T>::ConstScalar delta_max,
+                  typename TTypes<T>::ConstFlat error,
+                  typename TTypes<T>::ConstFlat old_error,
+                  typename TTypes<T>::ConstFlat grad);
+};
+
+template <typename Device, typename T>
+struct ApplyRpropMinus {
+  void operator()(const Device& d, typename TTypes<T>::Flat var,
+                  typename TTypes<T>::Flat old_grad,
+                  typename TTypes<T>::Flat delta_update,
+                  typename TTypes<T>::ConstScalar eta_minus,
+                  typename TTypes<T>::ConstScalar eta_plus,
+                  typename TTypes<T>::ConstScalar delta_min,
+                  typename TTypes<T>::ConstScalar delta_max,
+                  typename TTypes<T>::ConstFlat grad);
+};
+
 }  // end namespace functor
 }  // end namespace tensorflow
 

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -19,12 +19,70 @@ limitations under the License.
 
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/training_ops.h"
+#include "tensorflow/core/util/cuda_kernel_helper.h"
 
 namespace tensorflow {
 
 typedef Eigen::GpuDevice GPUDevice;
 
+namespace {
+// device sign function
+template <class T>
+EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE T sgn(const T x) {
+  T zero(0);
+  T one(1);
+  return (x == zero ? zero : (x < zero ? -one : one));
+}
+}  // namespace
+
 namespace functor {
+namespace {
+
+template <typename T>
+__global__ void IRpropPlusKernel(const int32 N, T* var, const T* grad,
+                                 const T* eta_minus, const T* eta_plus,
+                                 const T* delta_min, const T* delta_max,
+                                 const T* error, const T* old_error,
+                                 T* old_grad, T* delta_update) {
+  for (int i : CudaGridRangeX(N)) {
+    auto sign_t = sgn(grad[i] * old_grad[i]);
+
+    if (sign_t < T(0)) {
+      // backtracking-weight
+      if (error[i] > old_error[i])
+        var[i] -= -sgn(old_grad[i]) * delta_update[i];
+      delta_update[i] = tf_max(*delta_min, delta_update[i] * *eta_minus);
+      old_grad[i] = T(0);
+
+    } else {
+      if (sign_t > T(0))
+        delta_update[i] = tf_min(*delta_max, delta_update[i] * *eta_plus);
+
+      old_grad[i] = grad[i];
+      var[i] += -sgn(grad[i]) * delta_update[i];
+    }
+  }
+}
+
+template <typename T>
+__global__ void RpropMinusKernel(const int32 N, T* var, const T* grad,
+                                 const T* eta_minus, const T* eta_plus,
+                                 const T* delta_min, const T* delta_max,
+                                 T* old_grad, T* delta_update) {
+  for (int i : CudaGridRangeX(N)) {
+    auto sign_t = sgn(grad[i] * old_grad[i]);
+
+    if (sign_t > T(0)) {
+      delta_update[i] = tf_min(*delta_max, delta_update[i] * *eta_plus);
+
+    } else if (sign_t < T(0)) {
+      delta_update[i] = tf_max(*delta_min, delta_update[i] * *eta_minus);
+    }
+  }
+}
+
+}  // namespace
+
 template <typename T>
 struct ApplyGradientDescent<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat var,
@@ -338,6 +396,76 @@ struct ApplyPowerSign<GPUDevice, T> {
   }
 };
 
+template <typename T>
+struct ApplyIRpropPlus<GPUDevice, T> {
+  void operator()(const GPUDevice& d, typename TTypes<T>::Flat var,
+                  typename TTypes<T>::Flat old_grad,
+                  typename TTypes<T>::Flat delta_update,
+                  typename TTypes<T>::ConstScalar eta_minus,
+                  typename TTypes<T>::ConstScalar eta_plus,
+                  typename TTypes<T>::ConstScalar delta_min,
+                  typename TTypes<T>::ConstScalar delta_max,
+                  typename TTypes<T>::ConstFlat error,
+                  typename TTypes<T>::ConstFlat old_error,
+                  typename TTypes<T>::ConstFlat grad) {
+    const int32 N = var.size();
+
+    // The RProp Optimizers can also be implemented by using the gpu operations
+    // from TF. The update step is dependent on the sign of the multiplication
+    // of the gradients at (t) and (t-1), which can have 3 values (1, -1, 0).
+    // Moreover, each var_{i,j} is updated individually according to the value
+    // of the sign. The vectorized implementation is possible by using a
+    // combination of Where and Cond ops. To implement the update, we would need
+    // to create 3 vars that hold a tensor for each value of the sign function.
+    // Each of the 3 tensors would be updated according to the sign value.
+    // After performing the updates, we need to take into account if the weight
+    // needs to be retracted, therefore the Cond op has to be used once more.
+    // The final step is to aggregate the 3 tensors that contain the computed
+    // vars. Whereas the implementation by launching a CUDA kernel
+    // is straightforward compared to fusing ops together.
+    // GetCudaLaunchConfig is used to determine the launch parameters
+    // of the GPU hardware.
+    CudaLaunchConfig config = GetCudaLaunchConfig(N, d);
+    IRpropPlusKernel<<<config.block_count, config.thread_per_block, 0,
+                       d.stream()>>>(
+        config.virtual_thread_count, var.data(), grad.data(), eta_minus.data(),
+        eta_plus.data(), delta_min.data(), delta_max.data(), error.data(),
+        old_error.data(), old_grad.data(), delta_update.data());
+
+    old_grad.device(d) = old_grad;
+    delta_update.device(d) = delta_update;
+    // update step
+    var.device(d) = var;
+  }
+};
+
+template <typename T>
+struct ApplyRpropMinus<GPUDevice, T> {
+  void operator()(const GPUDevice& d, typename TTypes<T>::Flat var,
+                  typename TTypes<T>::Flat old_grad,
+                  typename TTypes<T>::Flat delta_update,
+                  typename TTypes<T>::ConstScalar eta_minus,
+                  typename TTypes<T>::ConstScalar eta_plus,
+                  typename TTypes<T>::ConstScalar delta_min,
+                  typename TTypes<T>::ConstScalar delta_max,
+                  typename TTypes<T>::ConstFlat grad) {
+    const int32 N = var.size();
+
+    CudaLaunchConfig config = GetCudaLaunchConfig(N, d);
+    RpropMinusKernel<<<config.block_count, config.thread_per_block, 0,
+                       d.stream()>>>(
+        config.virtual_thread_count, var.data(), grad.data(), eta_minus.data(),
+        eta_plus.data(), delta_min.data(), delta_max.data(), old_grad.data(),
+        delta_update.data());
+
+    old_grad.device(d) = grad;
+    delta_update.device(d) = delta_update;
+
+    // update step
+    var.device(d) -= grad.sign() * delta_update;
+  }
+};
+
 }  // namespace functor
 
 template struct functor::ApplyGradientDescent<GPUDevice, Eigen::half>;
@@ -387,6 +515,14 @@ template struct functor::ApplyAddSign<GPUDevice, double>;
 template struct functor::ApplyPowerSign<GPUDevice, Eigen::half>;
 template struct functor::ApplyPowerSign<GPUDevice, float>;
 template struct functor::ApplyPowerSign<GPUDevice, double>;
+
+template struct functor::ApplyIRpropPlus<GPUDevice, Eigen::half>;
+template struct functor::ApplyIRpropPlus<GPUDevice, float>;
+template struct functor::ApplyIRpropPlus<GPUDevice, double>;
+
+template struct functor::ApplyRpropMinus<GPUDevice, Eigen::half>;
+template struct functor::ApplyRpropMinus<GPUDevice, float>;
+template struct functor::ApplyRpropMinus<GPUDevice, double>;
 
 }  // end namespace tensorflow
 

--- a/tensorflow/core/ops/training_ops.cc
+++ b/tensorflow/core/ops/training_ops.cc
@@ -1119,4 +1119,94 @@ REGISTER_OP("ResourceApplyPowerSign")
       return ApplyPowerSignShapeFn(c, /*sparse=*/false);
     });
 
+static Status ApplyRpropShapeFn(InferenceContext* c, bool withError) {
+  ShapeHandle unused;
+  ShapeHandle s = ShapeOrHandleShape(c, 0);                       // var
+  TF_RETURN_IF_ERROR(c->Merge(s, ShapeOrHandleShape(c, 1), &s));  // old_grad
+  TF_RETURN_IF_ERROR(c->Merge(s, ShapeOrHandleShape(c, 2), &s));  // delta
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &unused));       // scalar
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 0, &unused));       // scalar
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(5), 0, &unused));       // scalar
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(6), 0, &unused));       // scalar
+  // for iRprop+ which uses the error (loss) value
+  if (withError) {
+    TF_RETURN_IF_ERROR(c->Merge(s, ShapeOrHandleShape(c, 7), &s));  // infer var
+    TF_RETURN_IF_ERROR(c->Merge(s, ShapeOrHandleShape(c, 8), &s));  // infer var
+    TF_RETURN_IF_ERROR(c->Merge(s, c->input(9), &s));  // grad (delta)
+  } else {
+    TF_RETURN_IF_ERROR(c->Merge(s, c->input(7), &s));  // grad (delta)
+  }
+
+  if (c->num_outputs() > 0) {
+    c->set_output(0, s);
+  }
+  return Status::OK();
+}
+
+REGISTER_OP("ApplyIRpropPlus")
+    .Input("var: Ref(T)")
+    .Input("old_grad: Ref(T)")
+    .Input("delta_update: Ref(T)")
+    .Input("eta_minus: T")
+    .Input("eta_plus: T")
+    .Input("delta_min: T")
+    .Input("delta_max: T")
+    .Input("error: T")
+    .Input("old_error: T")
+    .Input("grad: T")
+    .Output("out: Ref(T)")
+    .Attr("T: numbertype")
+    .Attr("use_locking: bool = false")
+    .SetShapeFn([](InferenceContext* c) {
+      return ApplyRpropShapeFn(c, /*error=*/true);
+    });
+
+REGISTER_OP("ResourceApplyIRpropPlus")
+    .Input("var: resource")
+    .Input("old_grad: resource")
+    .Input("delta_update: resource")
+    .Input("eta_minus: T")
+    .Input("eta_plus: T")
+    .Input("delta_min: T")
+    .Input("delta_max: T")
+    .Input("error: T")
+    .Input("old_error: T")
+    .Input("grad: T")
+    .Attr("T: numbertype")
+    .Attr("use_locking: bool = false")
+    .SetShapeFn([](InferenceContext* c) {
+      return ApplyRpropShapeFn(c, /*error=*/true);
+    });
+
+REGISTER_OP("ApplyRpropMinus")
+    .Input("var: Ref(T)")
+    .Input("old_grad: Ref(T)")
+    .Input("delta_update: Ref(T)")
+    .Input("eta_minus: T")
+    .Input("eta_plus: T")
+    .Input("delta_min: T")
+    .Input("delta_max: T")
+    .Input("grad: T")
+    .Output("out: Ref(T)")
+    .Attr("T: numbertype")
+    .Attr("use_locking: bool = false")
+    .SetShapeFn([](InferenceContext* c) {
+      return ApplyRpropShapeFn(c, /*error=*/false);
+    });
+
+REGISTER_OP("ResourceApplyRpropMinus")
+    .Input("var: resource")
+    .Input("old_grad: resource")
+    .Input("delta_update: resource")
+    .Input("eta_minus: T")
+    .Input("eta_plus: T")
+    .Input("delta_min: T")
+    .Input("delta_max: T")
+    .Input("grad: T")
+    .Attr("T: numbertype")
+    .Attr("use_locking: bool = false")
+    .SetShapeFn([](InferenceContext* c) {
+      return ApplyRpropShapeFn(c, /*error=*/false);
+    });
+
 }  // namespace tensorflow

--- a/tensorflow/core/ops/training_ops_test.cc
+++ b/tensorflow/core/ops/training_ops_test.cc
@@ -366,4 +366,59 @@ TEST(TrainingOpsTest, ApplyPowerSign_ShapeFn) {
   INFER_ERROR("Shape must be rank 0 but is rank 1", op, "?;?;?;?;?;[?];?");
 }
 
+static void TestIRpropPlusOp(ShapeInferenceTestOp op) {
+  // Output is a merge of inputs 0, 1, 2, 7,8 and 9
+  // (var, old_grad, delta, and grad).
+  INFER_OK(op,
+           "[1,?,?,?,?,?];[?,2,?,?,?,?];[?,?,3,?,?,?];[];[];[];[];"
+           "[?,?,?,4,?,?];[?,?,?,?,5,?];[?,?,?,?,?,6]",
+           "[d0_0,d1_1,d2_2,d7_3,d8_4,d9_5]");
+
+  INFER_ERROR("Dimension 0 in both shapes must be equal, but are 1 and 2", op,
+              "[1];[2];[1];[];[];[];[];[1];[1];[1]");
+  INFER_ERROR("Dimension 0 in both shapes must be equal, but are 1 and 2", op,
+              "[1];[1];[2];[];[];[];[];[1];[1];[1]");
+  INFER_ERROR("Dimension 0 in both shapes must be equal, but are 1 and 2", op,
+              "[1];[1];[1];[];[];[];[];[2];[1];[1]");
+  INFER_ERROR("Dimension 0 in both shapes must be equal, but are 1 and 2", op,
+              "[1];[1];[1];[];[];[];[];[1];[2];[1]");
+  INFER_ERROR("Dimension 0 in both shapes must be equal, but are 1 and 2", op,
+              "[1];[1];[1];[];[];[];[];[1];[1];[2]");
+
+  // eta_minus, eta_plus, delta_min, delta_max - scalars.
+  const char err[] = "Shape must be rank 0 but is rank 1";
+  INFER_ERROR(err, op, "?;?;?;[?];?;?;?;?;?;?");
+  INFER_ERROR(err, op, "?;?;?;?;[?];?;?;?;?;?");
+  INFER_ERROR(err, op, "?;?;?;?;?;[?];?;?;?;?");
+  INFER_ERROR(err, op, "?;?;?;?;?;?;[?];?;?;?");
+}
+
+static void TestRpropMinusOp(ShapeInferenceTestOp op) {
+  // Output is a merge of inputs 0, 1, 2, and 7
+  // (var, old_grad, delta, and grad).
+  INFER_OK(op, "[1,?,?,?];[?,2,?,?];[?,?,3,?];[];[];[];[];[?,?,?,4]",
+           "[d0_0,d1_1,d2_2,d7_3]");
+  INFER_ERROR("Dimension 0 in both shapes must be equal, but are 1 and 2", op,
+              "[1];[2];[1];[];[];[];[];[1]");
+  INFER_ERROR("Dimension 0 in both shapes must be equal, but are 1 and 2", op,
+              "[1];[1];[2];[];[];[];[];[1]");
+  INFER_ERROR("Dimension 0 in both shapes must be equal, but are 1 and 2", op,
+              "[1];[1];[1];[];[];[];[];[2]");
+
+  // eta_minus, eta_plus, delta_min, delta_max - scalars.
+  const char err[] = "Shape must be rank 0 but is rank 1";
+  INFER_ERROR(err, op, "?;?;?;[?];?;?;?;?");
+  INFER_ERROR(err, op, "?;?;?;?;[?];?;?;?");
+  INFER_ERROR(err, op, "?;?;?;?;?;[?];?;?");
+  INFER_ERROR(err, op, "?;?;?;?;?;?;[?];?");
+}
+
+TEST(TrainingOpsTest, ApplyRpropShapeFn) {
+  ShapeInferenceTestOp irprop_plus_op("ApplyIRpropPlus");
+  ShapeInferenceTestOp rprop_minus_op("ApplyRpropMinus");
+
+  TestIRpropPlusOp(irprop_plus_op);
+  TestRpropMinusOp(rprop_minus_op);
+}
+
 }  // end namespace tensorflow


### PR DESCRIPTION
Rprop was originally proposed by Riedmiller and Braun in the paper [A direct adaptive method for faster backpropagation learning: the RPROP algorithm](https://doi.org/10.1109/ICNN.1993.298623)

There are two variants implemented in this contribution:

1. iRprop+ which is described in the article
  [Empirical evaluation of the improved Rprop learning algorithms](https://doi.org/10.1016/S0925-2312(01)00700-7)

2. Rprop-  which is described in Riedmiller's article
  [Advanced supervised learning in multi-layer perceptrons — From backpropagation to adaptive learning algorithms](https://doi.org/10.1016/0920-5489(94)90017-5), and is referred to as Rprop- (Rprop without weight-backtracking) in the
  article [Empirical evaluation of the improved Rprop learning algorithms](https://doi.org/10.1016/S0925-2312(01)00700-7).




The TensorFlow implementation is described in the article
  [Resilient Backpropagation (Rprop) for Batch-learning in TensorFlow](https://openreview.net/forum?id=r1R0o7yDz)

recreated from: https://github.com/tensorflow/tensorflow/pull/20918