### PR TITLE
Fix some typos and add built-tags output support

### DIFF
--- a/tensorflow/tools/dockerfiles/README.md
+++ b/tensorflow/tools/dockerfiles/README.md
@@ -29,12 +29,12 @@ in the Dockerfile itself.
 After building the image with the tag `tf` (for example), use `docker run` to
 run the images.
 
-Note for new Docker users: the `-v` and `-u` flags share directories between
-the Docker container and your machine, and very important. Without
-`-v`, your work will be wiped once the container quits, and without `-u`, files
-created by the container will have the wrong file permissions on your host
-machine. If you are confused, check out the [Docker run
-documentation](https://docs.docker.com/engine/reference/run/).
+Note for new Docker users: the `-v` and `-u` flags share directories and
+permissions between the Docker container and your machine. Without `-v`, your
+work will be wiped once the container quits, and without `-u`, files created by
+the container will have the wrong file permissions on your host machine.
+Check out the [Docker run
+documentation](https://docs.docker.com/engine/reference/run/) for more info.
 
 ```bash
 # Volume mount (-v) is optional but highly recommended, especially for Jupyter.
@@ -83,7 +83,7 @@ $ alias asm_images="docker run --rm -v $(pwd):/tf -v /var/run/docker.sock:/var/r
 # If you're REBUILDING OR ADDING DOCKERFILES, remove docker.sock and add -u:
 $ alias asm_dockerfiles="docker run --rm -u $(id -u):$(id -g) -v $(pwd):/tf tf-tools python3 assembler.py "
 
-# Check flags
+# Check assembler flags
 $ asm_dockerfiles --help
 
 # Assemble all of the Dockerfiles
@@ -93,5 +93,8 @@ $ asm_dockerfiles --release dockerfiles --construct_dockerfiles
 $ asm_images --release nightly --build_images
 
 # Build version release for version 99.0, except "gpu" tags:
-$ asm_images --release versioned --arg _TAG_PREFIX=99.0 --build_images --exclude_tags_matching '*.gpu.*'
+$ asm_images --release versioned --arg _TAG_PREFIX=99.0 --build_images --exclude_tags_matching '.*gpu.*'
+
+# Test your changes to the devel images:
+$ asm_images --release nightly --build_images --run_tests_path=$(realpath tests) --only_tags_matching="^devel-gpu-py3$"
 ```

--- a/tensorflow/tools/dockerfiles/README.md
+++ b/tensorflow/tools/dockerfiles/README.md
@@ -92,6 +92,9 @@ $ asm_dockerfiles --release dockerfiles --construct_dockerfiles
 # Build all of the "nightly" images on your local machine:
 $ asm_images --release nightly --build_images
 
+# Save the list of built images to a file:
+$ asm_images --release nightly --build_images > tf-built.txt
+
 # Build version release for version 99.0, except "gpu" tags:
 $ asm_images --release versioned --arg _TAG_PREFIX=99.0 --build_images --exclude_tags_matching '.*gpu.*'
 

--- a/tensorflow/tools/dockerfiles/assembler.py
+++ b/tensorflow/tools/dockerfiles/assembler.py
@@ -18,6 +18,9 @@
 - Builds images (and optionally runs image tests)
 - Pushes images to Docker Hub (provided with credentials)
 
+Logs are written to stderr; the list of successfully built images is
+written to stdout.
+
 Read README.md (in this directory) for instructions!
 """
 
@@ -676,13 +679,10 @@ def main(argv):
         'errors: {}'.format(','.join(failed_tags)))
     exit(1)
 
-  if FLAGS.write_tags_to:
-    eprint('> Writing built{} tags to {}.'.format(
-        ' and tested' if FLAGS.run_tests_path else '',
-        FLAGS.write_tags_to))
-    with open(FLAGS.write_tags_to, 'w') as f:
-      for tag in succeeded_tags:
-        f.write('{}:{}\n'.format(FLAGS.repository, tag))
+  eprint('> Writing built{} tags to standard out.'.format(
+      ' and tested' if FLAGS.run_tests_path else ''))
+  for tag in succeeded_tags:
+    print('{}:{}'.format(FLAGS.repository, tag))
 
 
 if __name__ == '__main__':

--- a/tensorflow/tools/dockerfiles/assembler.py
+++ b/tensorflow/tools/dockerfiles/assembler.py
@@ -92,11 +92,6 @@ flags.DEFINE_string(
      'Flag value must be a full path to the "tests" directory, which is usually'
      ' $(realpath ./tests). A failed tests counts the same as a failed build.'))
 
-flags.DEFINE_string(
-    'write_tags_to', None,
-    'Write the list of tagged images to a file. Useful for parallelizing tests.'
-)
-
 flags.DEFINE_boolean(
     'stop_on_failure', False,
     ('Stop processing tags if any one build fails. If False or not specified, '


### PR DESCRIPTION
This change makes some minor changes:

- Fix some typos
- Add a "test your changes" example to the README
- Add a --nocache flag to ignore the Docker build cache
- Add a --write_tags_to flag to save a clean list of
  built tags to a file. Can be used to build tags, then
  run tests in parallel by combining xargs with --only_tags_matching.