### PR TITLE
TFTRT: Fix bug with renaming output bindings + test case

### DIFF
--- a/tensorflow/contrib/tensorrt/BUILD
+++ b/tensorflow/contrib/tensorrt/BUILD
@@ -491,6 +491,7 @@ cuda_py_tests(
         "test/binary_tensor_weight_broadcast_test.py",
         "test/concatenation_test.py",
         "test/const_broadcast_test.py",
+        "test/identity_output_test.py",
         "test/manual_test.py",
         "test/memory_alignment_test.py",
         "test/multi_connection_neighbor_engine_test.py",

--- a/tensorflow/contrib/tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/contrib/tensorrt/convert/convert_nodes.cc
@@ -950,6 +950,7 @@ Status Converter::RenameAndMarkOutputTensors(
     // TODO(tmorris): Remove this work-around once we use TRT's IIdentityLayer
     // in ConvertIdentity.
     if (tensorflow::str_util::StartsWith(tensor->getName(), kOutputPHName)) {
+      // Using shuffle layer for identity by not setting reshape or transpose.
       nvinfer1::IShuffleLayer* layer = network()->addShuffle(*tensor);
       TFTRT_RETURN_ERROR_IF_NULLPTR(
           layer, StrCat("Output Copy for ", tensor->getName()));

--- a/tensorflow/contrib/tensorrt/test/identity_output_test.py
+++ b/tensorflow/contrib/tensorrt/test/identity_output_test.py
@@ -29,9 +29,7 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import nn
 from tensorflow.python.platform import test
 
 

--- a/tensorflow/contrib/tensorrt/test/identity_output_test.py
+++ b/tensorflow/contrib/tensorrt/test/identity_output_test.py
@@ -71,6 +71,11 @@ class IdentityTest(trt_test.TfTrtIntegrationTestBase):
     """Return the expected engines to build."""
     return ["TRTEngineOp_0"]
 
+  def ShouldRunTest(self, run_params):
+    """Whether to run the test."""
+    # TODO(aaroey): Trt 4.0 forbids conversion for tensors with rank <3 in int8
+    # mode, which is a bug. Re-enable this when trt library is fixed.
+    return not trt_test.IsQuantizationMode(run_params.precision_mode)
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/contrib/tensorrt/test/identity_output_test.py
+++ b/tensorflow/contrib/tensorrt/test/identity_output_test.py
@@ -37,7 +37,7 @@ class IdentityTest(trt_test.TfTrtIntegrationTestBase):
     return constant_op.constant(np.random.randn(*shape), dtype=dtypes.float32)
 
   def GetParams(self):
-    """Testing conversion of BiasAdd MatMul in TF-TRT conversion."""
+    """Testing engine with the same tensor repeated as output via identity."""
     input_name = "input"
     input_dims = [100, 32]
     g = ops.Graph()

--- a/tensorflow/contrib/tensorrt/test/identity_output_test.py
+++ b/tensorflow/contrib/tensorrt/test/identity_output_test.py
@@ -1,0 +1,72 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Model script to test TF-TensorRT integration."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow.contrib.tensorrt.test import tf_trt_integration_test_base as trt_test
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn
+from tensorflow.python.platform import test
+
+
+class IdentityTest(trt_test.TfTrtIntegrationTestBase):
+
+  def _ConstOp(self, shape):
+    return constant_op.constant(np.random.randn(*shape), dtype=dtypes.float32)
+
+  def GetParams(self):
+    """Testing conversion of BiasAdd MatMul in TF-TRT conversion."""
+    input_name = "input"
+    input_dims = [100, 32]
+    g = ops.Graph()
+    with g.as_default():
+      x = array_ops.placeholder(
+          dtype=dtypes.float32, shape=input_dims, name=input_name)
+
+      b = self._ConstOp((32, 4))
+      x1 = math_ops.matmul(x, b)
+      b = self._ConstOp((1, 4))
+      x1 = x1 + b
+
+      out1 = array_ops.identity(x1, name='output1')
+      out2 = array_ops.identity(x1, name='output2')
+      iden1 = array_ops.identity(x1)
+      out3 = array_ops.identity(iden1, name='output3')
+
+    return trt_test.TfTrtIntegrationTestParams(
+        gdef=g.as_graph_def(),
+        input_names=[input_name],
+        input_dims=[input_dims],
+        output_names=['output1', 'output2', 'output3'],
+        expected_output_dims=[(100, 4), (100, 4), (100, 4)])
+
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Return the expected engines to build."""
+    return ["TRTEngineOp_0"]
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/contrib/tensorrt/test/identity_output_test.py
+++ b/tensorflow/contrib/tensorrt/test/identity_output_test.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Model script to test TF-TensorRT integration."""
+"""This test checks a situation where the same tensor is considered as an output
+multiple times because it has been duplicated by 2+ indentity ops. Previously,
+the tensor would be renamed multiple times, overwriting the output binding name
+which resulted in a runtime error when the binding would not be found.
+"""
 
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
If the same tensor is considered as an output multiple times, that tensor will be renamed which will result in a runtime error when the first output binding cannot be found.

This can occur if two or more separate identity ops are used on a tensor and those identity ops are the output of the network. Since our ConvertIdentity implementation just returns the input tensor, the output of both identity ops will be the same tensor. This is very similar to the "rename input tensors" issue (convert_nodes.cc line 944-958). Both of these would be solved by actually using a TRT layer in ConvertIdentity. However we can't do that yet without interfering with fusions and therefore performance.

I've added a new test identity_output_test with a repro for the bug. The test passes after this fix.