### PR TITLE
upgrade aws-sdk-cpp to the earliest release that enables authentication retries

### DIFF
--- a/third_party/aws/BUILD.bazel
+++ b/third_party/aws/BUILD.bazel
@@ -80,6 +80,11 @@ cc_library(
     deps = [
         "@curl",
     ],
+    copts = [
+        "-DAWS_SDK_VERSION_MAJOR=1", 
+        "-DAWS_SDK_VERSION_MINOR=5", 
+        "-DAWS_SDK_VERSION_PATCH=8"
+    ],
 )
 
 template_rule(

--- a/third_party/aws/workspace.bzl
+++ b/third_party/aws/workspace.bzl
@@ -2,14 +2,17 @@
 
 load("//third_party:repo.bzl", "third_party_http_archive")
 
+# NOTE: version updates here should also update the major, minor, and patch variables declared in 
+# the  copts field of the //third_party/aws:aws target
+
 def repo():
     third_party_http_archive(
         name = "aws",
         urls = [
-            "https://mirror.bazel.build/github.com/aws/aws-sdk-cpp/archive/1.3.15.tar.gz",
-            "https://github.com/aws/aws-sdk-cpp/archive/1.3.15.tar.gz",
+            "https://mirror.bazel.build/github.com/aws/aws-sdk-cpp/archive/1.5.8.tar.gz",
+            "https://github.com/aws/aws-sdk-cpp/archive/1.5.8.tar.gz",
         ],
-        sha256 = "b888d8ce5fc10254c3dd6c9020c7764dd53cf39cf011249d0b4deda895de1b7c",
-        strip_prefix = "aws-sdk-cpp-1.3.15",
+        sha256 = "89905075fe50aa13e0337ff905c2e8c1ce9caf77a3504484a7cda39179120ffc",
+        strip_prefix = "aws-sdk-cpp-1.5.8",
         build_file = "//third_party/aws:BUILD.bazel",
     )


### PR DESCRIPTION
The version currently in use, 1.3.15, attempts role based authentication with the MetadataService only once during initialization, which can result in a failure scenario when the MetadataService returns an error response or rate limits requests.

This changeset does the following:

- updates the aws-sdk-cpp lib to the earliest release that contains the retry logic introduced in this commit https://github.com/aws/aws-sdk-cpp/commit/c14746b997be16f294233ab7bc0900b3c7edb58e
- updates the corresponding BUILD.bazel file to define the major, minor, and patch variables that are now provided at compile time via cmake due to this commit https://github.com/aws/aws-sdk-cpp/commit/7142e6eb510b67371d576bca97585e14874db0c8 as copts