### PR TITLE
Initialize only CPU devices in optimize_dataset_op

### DIFF
--- a/tensorflow/core/grappler/grappler_item_builder.cc
+++ b/tensorflow/core/grappler/grappler_item_builder.cc
@@ -103,7 +103,11 @@ Status OptimizeGraph(const GraphDef& graph_def_arg, GraphDef* output_graph_def,
 
   // Instantiate all variables for function library runtime creation.
   std::vector<std::unique_ptr<Device>> devices;
-  TF_RETURN_IF_ERROR(DeviceFactory::AddDevices(
+  // Only CPU device is used so instead of calling DeviceFactory::AddDevices()
+  // with dummy session config, which will conflict with user defined options and
+  // create unwanted devices, call cpu_factory->CreateDevices() to get CPU only devices.
+  DeviceFactory* cpu_factory = DeviceFactory::GetFactory("CPU");
+  TF_RETURN_IF_ERROR(cpu_factory->CreateDevices(
       options, "/job:localhost/replica:0/task:0", &devices));
   Device* cpu_device = devices[0].get();
   std::unique_ptr<DeviceMgr> dvc_mgr(new DeviceMgr(std::move(devices)));

--- a/tensorflow/core/grappler/grappler_item_builder.cc
+++ b/tensorflow/core/grappler/grappler_item_builder.cc
@@ -104,8 +104,9 @@ Status OptimizeGraph(const GraphDef& graph_def_arg, GraphDef* output_graph_def,
   // Instantiate all variables for function library runtime creation.
   std::vector<std::unique_ptr<Device>> devices;
   // Only CPU device is used so instead of calling DeviceFactory::AddDevices()
-  // with dummy session config, which will conflict with user defined options and
-  // create unwanted devices, call cpu_factory->CreateDevices() to get CPU only devices.
+  // with dummy session config, which will conflict with user defined options
+  // and create unwanted devices, call cpu_factory->CreateDevices() to get CPU
+  // only devices.
   DeviceFactory* cpu_factory = DeviceFactory::GetFactory("CPU");
   TF_RETURN_IF_ERROR(cpu_factory->CreateDevices(
       options, "/job:localhost/replica:0/task:0", &devices));


### PR DESCRIPTION
optimize_dataset_op is making a rouge device initialization for all devices in the system through grappler_item_builder even though only CPU devices are used. This is causing problems mentioned in #24303  and #23458. This PR initializes only CPU devices to workaround these issues. Adding @asimshankar @jlebar and @azaks2 review. Please forward to correct responsible if needed.