### PR TITLE
Constant Folding: Only apply size limit if size of tensor is increasing

### DIFF
--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -983,7 +983,8 @@ Status ConstantFolding::CreateNodeDef(const string& name,
 
   if (encoded_size > original_size && encoded_size >= 10 * 1024 * 1024) {
     return errors::InvalidArgument(
-        strings::StrCat("Can't fold ", name, ", its size would be too large"));
+        strings::StrCat("Can't fold ", name, ", its size would be too large (",
+                        encoded_size, " >= ", 10 * 1024 * 1024, " bytes)"));
   }
   return Status::OK();
 }

--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -901,8 +901,7 @@ DataType GetDataTypeFromNodeOrProps(const NodeDef& node,
 
 // static
 Status ConstantFolding::CreateNodeDef(const string& name,
-                                      const TensorValue& tensor,
-                                      NodeDef* node,
+                                      const TensorValue& tensor, NodeDef* node,
                                       size_t original_size) {
   node->set_name(name);
   node->set_op("Const");

--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -903,7 +903,7 @@ DataType GetDataTypeFromNodeOrProps(const NodeDef& node,
 Status ConstantFolding::CreateNodeDef(const string& name,
                                       const TensorValue& tensor,
                                       NodeDef* node,
-                                      size_t input_size) {
+                                      size_t original_size) {
   node->set_name(name);
   node->set_op("Const");
 
@@ -980,7 +980,8 @@ Status ConstantFolding::CreateNodeDef(const string& name,
     encoded_size = t->tensor_content().size();
   }
   node->mutable_attr()->insert({"value", attr_tensor});
-  if (encoded_size > input_size && encoded_size >= 10 * 1024 * 1024) {
+
+  if (encoded_size > original_size && encoded_size >= 10 * 1024 * 1024) {
     return errors::InvalidArgument(
         strings::StrCat("Can't fold ", name, ", its size would be too large"));
   }

--- a/tensorflow/core/grappler/optimizers/constant_folding.h
+++ b/tensorflow/core/grappler/optimizers/constant_folding.h
@@ -36,7 +36,7 @@ const char kConstantFoldingCtrl[] = "ConstantFoldingCtrl";
 class ConstantFolding : public GraphOptimizer {
  public:
   static Status CreateNodeDef(const string& name, const TensorValue& tensor,
-                              NodeDef* node);
+                              NodeDef* node, size_t input_size = 0);
   static string AddControlDependency(const string& input_name, GraphDef* graph,
                                      NodeMap* node_map);
 

--- a/tensorflow/core/grappler/optimizers/constant_folding.h
+++ b/tensorflow/core/grappler/optimizers/constant_folding.h
@@ -35,6 +35,8 @@ const char kConstantFoldingCtrl[] = "ConstantFoldingCtrl";
 // Constant folding optimization for a graph.
 class ConstantFolding : public GraphOptimizer {
  public:
+  // The size limit will only be considered if the newly created node is greater
+  // than input_size (optional).
   static Status CreateNodeDef(const string& name, const TensorValue& tensor,
                               NodeDef* node, size_t input_size = 0);
   static string AddControlDependency(const string& input_name, GraphDef* graph,

--- a/tensorflow/core/grappler/optimizers/constant_folding.h
+++ b/tensorflow/core/grappler/optimizers/constant_folding.h
@@ -36,9 +36,9 @@ const char kConstantFoldingCtrl[] = "ConstantFoldingCtrl";
 class ConstantFolding : public GraphOptimizer {
  public:
   // The size limit will only be considered if the newly created node is greater
-  // than input_size (optional).
+  // than original_size (optional).
   static Status CreateNodeDef(const string& name, const TensorValue& tensor,
-                              NodeDef* node, size_t input_size = 0);
+                              NodeDef* node, size_t original_size = 0);
   static string AddControlDependency(const string& input_name, GraphDef* graph,
                                      NodeMap* node_map);
 


### PR DESCRIPTION
Many kernels have sizes larger than the constfolding limit of 10mb. Many networks use identity ops or pointwise scaling ops on these kernels. The size limit prevents constant folding in these cases even though the output of the folding would not have increased the size of the protobuf, and in many cases would actually decrease it by removing the ops.

In TFTRT, TRT requires weights to be known statically so we rely heavily on constant folding. If a weight is not constant folded, we are unable to convert that layer into TRT.

This fixes https://github.com/tensorflow/tensorflow/issues/24083