### PR TITLE
TFTRT: Convert between str and unicode in py2

### DIFF
--- a/tensorflow/contrib/tensorrt/python/trt_convert.py
+++ b/tensorflow/contrib/tensorrt/python/trt_convert.py
@@ -48,30 +48,18 @@ from tensorflow.python.training import saver
 def _to_bytes(s):
     """Returns encoded of s if s is a sequence of chars otherwise returns s.
     """
-    if _six.PY2:
-        if isinstance(s, unicode):
-            return s.encode("utf-8", errors="surrogateescape")
-        else:
-            return s
+    if isinstance(s, _six.text_type):
+        return s.encode("utf-8", errors="surrogateescape")
     else:
-        if isinstance(s, str):
-            return s.encode("utf-8", errors="surrogateescape")
-        else:
-            return s
+        return s
 
 def _to_string(s):
     """Returns decoded of s if s is a sequence of bytes otherwise returns s.
     """
-    if _six.PY2:
-        if isinstance(s, str):
-            return s.decode("utf-8")
-        else:
-            return s
+    if isinstance(s, _six.binary_type):
+        return s.decode("utf-8")
     else:
-        if isinstance(s, bytes):
-            return s.decode("utf-8")
-        else:
-            return s
+        return s
 
 class TrtPrecisionMode(object):
   FP32 = "FP32"

--- a/tensorflow/contrib/tensorrt/python/trt_convert.py
+++ b/tensorflow/contrib/tensorrt/python/trt_convert.py
@@ -45,15 +45,33 @@ from tensorflow.python.saved_model import loader_impl
 from tensorflow.python.saved_model import tag_constants
 from tensorflow.python.training import saver
 
-if _six.PY2:
-  _to_bytes = lambda s: s.encode("utf-8", errors="surrogateescape") \
-    if isinstance(s, unicode) else s
-  _to_string = lambda s: s.decode("utf-8") if isinstance(s, str) else s
-else:
-  _to_bytes = lambda s: s.encode("utf-8", errors="surrogateescape") \
-    if isinstance(s, str) else s
-  _to_string = lambda s: s.decode("utf-8") if isinstance(s, bytes) else s
+def _to_bytes(s):
+    """Returns encoded of s if s is a sequence of chars otherwise returns s.
+    """
+    if _six.PY2:
+        if isinstance(s, unicode):
+            return s.encode("utf-8", errors="surrogateescape")
+        else:
+            return s
+    else:
+        if isinstance(s, str):
+            return s.encode("utf-8", errors="surrogateescape")
+        else:
+            return s
 
+def _to_string(s):
+    """Returns decoded of s if s is a sequence of bytes otherwise returns s.
+    """
+    if _six.PY2:
+        if isinstance(s, str):
+            return s.decode("utf-8")
+        else:
+            return s
+    else:
+        if isinstance(s, bytes):
+            return s.decode("utf-8")
+        else:
+            return s
 
 class TrtPrecisionMode(object):
   FP32 = "FP32"

--- a/tensorflow/contrib/tensorrt/python/trt_convert.py
+++ b/tensorflow/contrib/tensorrt/python/trt_convert.py
@@ -46,11 +46,13 @@ from tensorflow.python.saved_model import tag_constants
 from tensorflow.python.training import saver
 
 if _six.PY2:
-  _to_bytes = lambda s: s
-  _to_string = lambda s: s
+  _to_bytes = lambda s: s.encode("utf-8", errors="surrogateescape") \
+    if isinstance(s, unicode) else s
+  _to_string = lambda s: s.decode("utf-8") if isinstance(s, str) else s
 else:
-  _to_bytes = lambda s: s.encode("utf-8", errors="surrogateescape")
-  _to_string = lambda s: s.decode("utf-8")
+  _to_bytes = lambda s: s.encode("utf-8", errors="surrogateescape") \
+    if isinstance(s, str) else s
+  _to_string = lambda s: s.decode("utf-8") if isinstance(s, bytes) else s
 
 
 class TrtPrecisionMode(object):


### PR DESCRIPTION
We need to convert string to binary before storing a value in protobufs. We already had this encoding for python3 but not for python2. This PR adds that.

This PR also makes sure we only do the conversion if the input type is right (avoid encoding a binary or decoding a string).