### PR TITLE
Make tensorforest deterministic by pre generate split features

### DIFF
--- a/tensorflow/contrib/tensor_forest/client/random_forest_test.py
+++ b/tensorflow/contrib/tensor_forest/client/random_forest_test.py
@@ -41,7 +41,7 @@ def _get_classification_input_fns():
       x=data, y=labels, batch_size=150, num_epochs=None, shuffle=False)
 
   predict_input_fn = numpy_io.numpy_input_fn(
-      x=data[:1,], y=None, batch_size=1, num_epochs=1, shuffle=False)
+      x=data[:1, ], y=None, batch_size=1, num_epochs=1, shuffle=False)
   return train_input_fn, predict_input_fn
 
 
@@ -53,12 +53,12 @@ def _get_classification_big_input_fns():
   x = x.astype(np.float32)
   y = y.astype(np.int32)
   x_train, x_test, y_train, y_test = train_test_split(
-    x, y, test_size=0.33, random_state=42)
+      x, y, test_size=0.33, random_state=42)
   train_input_fn = numpy_io.numpy_input_fn(
-    x=x_train, y=y_train, batch_size=150, num_epochs=None, shuffle=False)
+      x=x_train, y=y_train, batch_size=150, num_epochs=None, shuffle=False)
 
   predict_input_fn = numpy_io.numpy_input_fn(
-    x=x_test, y=None, batch_size=1, num_epochs=1, shuffle=False)
+      x=x_test, y=None, batch_size=1, num_epochs=1, shuffle=False)
   return train_input_fn, predict_input_fn
 
 
@@ -71,7 +71,7 @@ def _get_regression_input_fns():
       x=data, y=labels, batch_size=506, num_epochs=None, shuffle=False)
 
   predict_input_fn = numpy_io.numpy_input_fn(
-      x=data[:1,], y=None, batch_size=1, num_epochs=1, shuffle=False)
+      x=data[:1, ], y=None, batch_size=1, num_epochs=1, shuffle=False)
   return train_input_fn, predict_input_fn
 
 
@@ -107,7 +107,8 @@ class TensorForestTrainerTests(test.TestCase):
         num_classes=3,
         num_features=4,
         split_after_samples=20,
-        inference_tree_paths=True)
+        inference_tree_paths=True,
+        base_random_seed=1)
     input_fn, predict_input_fn = _get_classification_big_input_fns()
 
     classifier_first = random_forest.TensorForestEstimator(hparams.fill())
@@ -140,7 +141,8 @@ class TensorForestTrainerTests(test.TestCase):
     self.assertGreaterEqual(0.1, res['loss'])
 
     predictions = list(regressor.predict(input_fn=predict_input_fn))
-    self.assertAllClose([24.], [pred['scores'] for pred in predictions], atol=1)
+    self.assertAllClose([24.], [pred['scores']
+                                for pred in predictions], atol=1)
 
   def testAdditionalOutputs(self):
     """Tests multi-class classification using matrix data as input."""

--- a/tensorflow/contrib/tensor_forest/kernels/stats_ops.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/stats_ops.cc
@@ -186,7 +186,7 @@ void UpdateStats(FertileStatsResource* fertile_stats_resource,
 
     bool is_finished;
     fertile_stats_resource->AddExampleToStatsAndInitialize(
-        data, &target, {example_id}, leaf_id, &is_finished);
+        data, &target, {example_id}, leaf_id, &is_finished, nullptr);
     leaf_lock->unlock();
     if (is_finished) {
       set_lock->lock();
@@ -212,7 +212,7 @@ void UpdateStatsCollated(
   std::advance(end_it, end);
   while (it != end_it) {
     int32 leaf_id = it->first;
-    const auto& random_features = features_per_split.at(leaf_id);
+    const auto* random_features = &features_per_split.at(leaf_id);
     bool is_finished;
     fertile_stats_resource->AddExampleToStatsAndInitialize(
         data, &target, it->second, leaf_id, &is_finished, random_features);
@@ -291,7 +291,7 @@ class ProcessInputOp : public OpKernel {
     // with mutexes.
     std::unordered_map<int, std::unique_ptr<mutex>> locks;
     std::unordered_map<int32, std::vector<int>> leaf_examples;
-    // keep a id of subsampled feature which this leaf will use.
+    // keep an id of subsampled features which this leaf will use.
     std::unordered_map<int32, std::vector<int>> features_per_split;
     const int32 num_total_features = input_spec_.dense_features_size();
     const int32 num_splits_to_consider =

--- a/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.cc
@@ -22,7 +22,7 @@ namespace tensorforest {
 void FertileStatsResource::AddExampleToStatsAndInitialize(
     const std::unique_ptr<TensorDataSet>& input_data, const InputTarget* target,
     const std::vector<int>& examples, int32 node_id, bool* is_finished,
-    const std::vector<int>& feature_per_split) {
+    const std::vector<int>* feature_per_split) {
   // Update stats or initialize if needed.
   if (collection_op_->IsInitialized(node_id)) {
     collection_op_->AddExample(input_data, target, examples, node_id);
@@ -31,13 +31,13 @@ void FertileStatsResource::AddExampleToStatsAndInitialize(
     // the top but gradually becomes less of an issue as the tree grows.
     for (int i = 0; i < examples.size(); i++) {
       const auto& example = examples[i];
-      if (feature_per_split != NULL) {
+      if (feature_per_split != nullptr) {
         const auto& rand_feature = feature_per_split[i];
         collection_op_->CreateAndInitializeCandidateWithExample(
             input_data, target, example, node_id, rand_feature);
       } else {
         collection_op_->CreateAndInitializeCandidateWithExample(
-            input_data, target, example, node_id);
+            input_data, target, example, node_id, nullptr);
       }
       if (collection_op_->IsInitialized(node_id)) {
         break;

--- a/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.cc
@@ -21,16 +21,24 @@ namespace tensorforest {
 
 void FertileStatsResource::AddExampleToStatsAndInitialize(
     const std::unique_ptr<TensorDataSet>& input_data, const InputTarget* target,
-    const std::vector<int>& examples, int32 node_id, bool* is_finished) {
+    const std::vector<int>& examples, int32 node_id, bool* is_finished,
+    const std::vector<int>& feature_per_split) {
   // Update stats or initialize if needed.
   if (collection_op_->IsInitialized(node_id)) {
     collection_op_->AddExample(input_data, target, examples, node_id);
   } else {
     // This throws away any extra examples, which is more inefficient towards
     // the top but gradually becomes less of an issue as the tree grows.
-    for (int example : examples) {
-      collection_op_->CreateAndInitializeCandidateWithExample(
-          input_data, target, example, node_id);
+    for (int i = 0; i < examples.size(); i++) {
+      const auto& example = examples[i];
+      if (feature_per_split != NULL) {
+        const auto& rand_feature = feature_per_split[i];
+        collection_op_->CreateAndInitializeCandidateWithExample(
+            input_data, target, example, node_id, rand_feature);
+      } else {
+        collection_op_->CreateAndInitializeCandidateWithExample(
+            input_data, target, example, node_id);
+      }
       if (collection_op_->IsInitialized(node_id)) {
         break;
       }

--- a/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.cc
@@ -32,9 +32,9 @@ void FertileStatsResource::AddExampleToStatsAndInitialize(
     for (int i = 0; i < examples.size(); i++) {
       const auto& example = examples[i];
       if (feature_per_split != nullptr) {
-        const auto& rand_feature = feature_per_split[i];
+        const auto* random_features = &feature_per_split->at(i);
         collection_op_->CreateAndInitializeCandidateWithExample(
-            input_data, target, example, node_id, rand_feature);
+            input_data, target, example, node_id, random_features);
       } else {
         collection_op_->CreateAndInitializeCandidateWithExample(
             input_data, target, example, node_id, nullptr);

--- a/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.h
@@ -64,10 +64,13 @@ class FertileStatsResource : public ResourceBase {
   // node's fertile slot's statistics if or initializes a split candidate,
   // where applicable.  Returns if the node is finished or if it's ready to
   // allocate to a fertile slot.
+  // With pre-generated feature_per_split, so it's
+  // thread safe.
   void AddExampleToStatsAndInitialize(
       const std::unique_ptr<TensorDataSet>& input_data,
       const InputTarget* target, const std::vector<int>& examples,
-      int32 node_id, bool* is_finished);
+      int32 node_id, bool* is_finished,
+      const std::vector<int>& feature_per_split = NULL);
 
   // Allocate a fertile slot for each ready node, then new children up to
   // max_fertile_nodes_.

--- a/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.h
@@ -64,13 +64,13 @@ class FertileStatsResource : public ResourceBase {
   // node's fertile slot's statistics if or initializes a split candidate,
   // where applicable.  Returns if the node is finished or if it's ready to
   // allocate to a fertile slot.
-  // With pre-generated feature_per_split, so it's
-  // thread safe.
+  // When pre-generated feature_per_split is provided, this method is thread
+  // safe?
   void AddExampleToStatsAndInitialize(
       const std::unique_ptr<TensorDataSet>& input_data,
       const InputTarget* target, const std::vector<int>& examples,
       int32 node_id, bool* is_finished,
-      const std::vector<int>& feature_per_split = NULL);
+      const std::vector<int>* feature_per_split);
 
   // Allocate a fertile slot for each ready node, then new children up to
   // max_fertile_nodes_.

--- a/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/fertile-stats-resource.h
@@ -65,7 +65,7 @@ class FertileStatsResource : public ResourceBase {
   // where applicable.  Returns if the node is finished or if it's ready to
   // allocate to a fertile slot.
   // When pre-generated feature_per_split is provided, this method is thread
-  // safe?
+  // safe.
   void AddExampleToStatsAndInitialize(
       const std::unique_ptr<TensorDataSet>& input_data,
       const InputTarget* target, const std::vector<int>& examples,

--- a/tensorflow/contrib/tensor_forest/kernels/v4/input_data.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/input_data.cc
@@ -121,7 +121,7 @@ void TensorDataSet::set_input_tensors(const Tensor& dense,
 void TensorDataSet::RandomSample(int example,
                                  decision_trees::FeatureId* feature_id,
                                  float* bias, int* type,
-                                 int* rand_feature) const {
+                                 const int* rand_feature) const {
   int32 num_total_features = input_spec_.dense_features_size();
   int64 sparse_input_start;
   if (sparse_indices_ != nullptr) {
@@ -133,7 +133,8 @@ void TensorDataSet::RandomSample(int example,
   }
   if (rand_feature == nullptr) {
     mutex_lock lock(mu_);
-    *rand_feature = rng_->Uniform(num_total_features);
+    const_cast<int&>(*rand_feature) =
+        static_cast<int>(rng_->Uniform(num_total_features));
   }
   if (*rand_feature < available_features_.size()) {  // it's dense.
     *feature_id = available_features_[*rand_feature];

--- a/tensorflow/contrib/tensor_forest/kernels/v4/input_data.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/input_data.cc
@@ -121,7 +121,7 @@ void TensorDataSet::set_input_tensors(const Tensor& dense,
 void TensorDataSet::RandomSample(int example,
                                  decision_trees::FeatureId* feature_id,
                                  float* bias, int* type,
-                                 int rand_feature) const {
+                                 int* rand_feature) const {
   int32 num_total_features = input_spec_.dense_features_size();
   int64 sparse_input_start;
   if (sparse_indices_ != nullptr) {
@@ -131,16 +131,16 @@ void TensorDataSet::RandomSample(int example,
       num_total_features += num_sparse;
     }
   }
-  if (rand_feature == NULL) {
+  if (rand_feature == nullptr) {
     mutex_lock lock(mu_);
-    rand_feature = rng_->Uniform(num_total_features);
+    *rand_feature = rng_->Uniform(num_total_features);
   }
-  if (rand_feature < available_features_.size()) {  // it's dense.
-    *feature_id = available_features_[rand_feature];
-    *type = input_spec_.GetDenseFeatureType(rand_feature);
+  if (*rand_feature < available_features_.size()) {  // it's dense.
+    *feature_id = available_features_[*rand_feature];
+    *type = input_spec_.GetDenseFeatureType(*rand_feature);
   } else {
     const int32 sparse_index =
-        sparse_input_start + rand_feature - input_spec_.dense_features_size();
+        sparse_input_start + *rand_feature - input_spec_.dense_features_size();
     const int32 saved_index =
         (*sparse_indices_)(sparse_index, 1) + input_spec_.dense_features_size();
     *feature_id = decision_trees::FeatureId();

--- a/tensorflow/contrib/tensor_forest/kernels/v4/input_data.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/input_data.cc
@@ -120,7 +120,8 @@ void TensorDataSet::set_input_tensors(const Tensor& dense,
 
 void TensorDataSet::RandomSample(int example,
                                  decision_trees::FeatureId* feature_id,
-                                 float* bias, int* type) const {
+                                 float* bias, int* type,
+                                 int rand_feature) const {
   int32 num_total_features = input_spec_.dense_features_size();
   int64 sparse_input_start;
   if (sparse_indices_ != nullptr) {
@@ -130,8 +131,7 @@ void TensorDataSet::RandomSample(int example,
       num_total_features += num_sparse;
     }
   }
-  int rand_feature = 0;
-  {
+  if (rand_feature == NULL) {
     mutex_lock lock(mu_);
     rand_feature = rng_->Uniform(num_total_features);
   }

--- a/tensorflow/contrib/tensor_forest/kernels/v4/input_data.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/input_data.h
@@ -106,7 +106,7 @@ class TensorDataSet {
   // Randomly samples a feature from example, returns its id in feature_name,
   // the value in bias, and it's type from input_spec in type.
   void RandomSample(int example, decision_trees::FeatureId* feature_name,
-                    float* bias, int* type, int rand_feature) const;
+                    float* bias, int* type, const int rand_feature) const;
 
  private:
   std::unique_ptr<DenseStorageType> dense_data_;

--- a/tensorflow/contrib/tensor_forest/kernels/v4/input_data.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/input_data.h
@@ -106,7 +106,7 @@ class TensorDataSet {
   // Randomly samples a feature from example, returns its id in feature_name,
   // the value in bias, and it's type from input_spec in type.
   void RandomSample(int example, decision_trees::FeatureId* feature_name,
-                    float* bias, int* type) const;
+                    float* bias, int* type, int rand_feature) const;
 
  private:
   std::unique_ptr<DenseStorageType> dense_data_;

--- a/tensorflow/contrib/tensor_forest/kernels/v4/input_data.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/input_data.h
@@ -106,7 +106,7 @@ class TensorDataSet {
   // Randomly samples a feature from example, returns its id in feature_name,
   // the value in bias, and it's type from input_spec in type.
   void RandomSample(int example, decision_trees::FeatureId* feature_name,
-                    float* bias, int* type, const int rand_feature) const;
+                    float* bias, int* type, const int* rand_feature) const;
 
  private:
   std::unique_ptr<DenseStorageType> dense_data_;

--- a/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.cc
@@ -110,13 +110,13 @@ bool SplitCollectionOperator::IsInitialized(int32 node_id) const {
 
 void SplitCollectionOperator::CreateAndInitializeCandidateWithExample(
     const std::unique_ptr<TensorDataSet>& input_data, const InputTarget* target,
-    int example, int32 node_id) const {
-  // Assumes split_initializations_per_input == 1.
+    const int example, const int32 node_id, int feature_id_for_split) const {
   decision_trees::BinaryNode split;
   float bias;
   int type;
   decision_trees::FeatureId feature_id;
-  input_data->RandomSample(example, &feature_id, &bias, &type);
+  input_data->RandomSample(example, &feature_id, &bias, &type,
+                           feature_id_for_split);
 
   if (type == kDataFloat) {
     decision_trees::InequalityTest* test =

--- a/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.cc
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.cc
@@ -110,7 +110,8 @@ bool SplitCollectionOperator::IsInitialized(int32 node_id) const {
 
 void SplitCollectionOperator::CreateAndInitializeCandidateWithExample(
     const std::unique_ptr<TensorDataSet>& input_data, const InputTarget* target,
-    const int example, const int32 node_id, int feature_id_for_split) const {
+    const int example, const int32 node_id,
+    const int* feature_id_for_split) const {
   decision_trees::BinaryNode split;
   float bias;
   int type;

--- a/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.h
@@ -59,7 +59,7 @@ class SplitCollectionOperator {
   virtual void CreateAndInitializeCandidateWithExample(
       const std::unique_ptr<TensorDataSet>& input_data,
       const InputTarget* target, const int example, const int32 node_id,
-      int* rand_feature) const;
+      const int* rand_feature) const;
 
   // Create a new GrowStats for the given node id and initialize it.
   virtual void InitializeSlot(int32 node_id, int32 depth);

--- a/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.h
@@ -59,7 +59,7 @@ class SplitCollectionOperator {
   virtual void CreateAndInitializeCandidateWithExample(
       const std::unique_ptr<TensorDataSet>& input_data,
       const InputTarget* target, const int example, const int32 node_id,
-      int rand_feature = NULL) const;
+      int* rand_feature) const;
 
   // Create a new GrowStats for the given node id and initialize it.
   virtual void InitializeSlot(int32 node_id, int32 depth);

--- a/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.h
+++ b/tensorflow/contrib/tensor_forest/kernels/v4/split_collection_operators.h
@@ -54,10 +54,12 @@ class SplitCollectionOperator {
                           const std::vector<int>& examples,
                           int32 node_id) const;
 
-  // Create a new candidate and initialize it with the given example.
+  // Create a new candidate and initialize it with the given example and
+  // rand_feature.
   virtual void CreateAndInitializeCandidateWithExample(
       const std::unique_ptr<TensorDataSet>& input_data,
-      const InputTarget* target, int example, int32 node_id) const;
+      const InputTarget* target, const int example, const int32 node_id,
+      int rand_feature = NULL) const;
 
   // Create a new GrowStats for the given node id and initialize it.
   virtual void InitializeSlot(int32 node_id, int32 depth);


### PR DESCRIPTION
Address https://github.com/tensorflow/tensorflow/issues/24040

Right now even  there is a lock for the random number generator which is being used to find a feature to split on.  And there is an option to partition the data into different threads based on leaf_id.
there is still a possibility of non-deterministic by the order of consuming random numbers is not guaranteed. Which comes from the multi-thread. And it is hard to reproduce, if we only train a small tree, (set the max_leaf as a small number). since the multi-thread macro is smart enough not to use multi-thread.

This pr pre-generate random numbers as requested, sequentially single threaded and save them and partition them into different threads to ensure the deterministic.

 