### PR TITLE
copy_graph.copy_variable_to_graph fix shape

### DIFF
--- a/tensorflow/contrib/copy_graph/python/util/copy_elements.py
+++ b/tensorflow/contrib/copy_graph/python/util/copy_elements.py
@@ -93,7 +93,7 @@ def copy_variable_to_graph(org_instance, to_graph, scope=''):
         trainable,
         name=new_name,
         collections=collections,
-        validate_shape=False)
+        validate_shape=True)
 
   return new_var
 

--- a/tensorflow/contrib/copy_graph/python/util/copy_test.py
+++ b/tensorflow/contrib/copy_graph/python/util/copy_test.py
@@ -66,6 +66,7 @@ class CopyVariablesTest(test.TestCase):
     assert isinstance(copy1, variables.Variable)
     assert isinstance(copy2, variables.Variable)
     assert v1 == v2 == v3 == 2
+    assert copy1.get_shape() == some_var.get_shape()
 
 
 class CopyOpsTest(test.TestCase):


### PR DESCRIPTION
This pull request fixes #24442
Add flag `validate_shape=True` to the Variable initializer. In this way the resulting variable has the same shape as the original variable.