### PR TITLE
Why stop gets backpropagated to the mean from the

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -902,11 +902,8 @@ def moments(
     # Compute true mean while keeping the dims for proper broadcasting.
     mean = math_ops.reduce_mean(y, axes, keepdims=True, name="mean")
     # sample variance, not unbiased variance
-    # Note: stop_gradient does not change the gradient that gets
-    #       backpropagated to the mean from the variance calculation,
-    #       because that gradient is zero
     variance = math_ops.reduce_mean(
-        math_ops.squared_difference(y, array_ops.stop_gradient(mean)),
+        math_ops.squared_difference(y, mean),
         axes,
         keepdims=True,
         name="variance")


### PR DESCRIPTION
I have noticed there is a request[Add a note that stop_gradient in moments does not change the gradient](https://github.com/tensorflow/tensorflow/pull/19609), but I wonder why stop gets backpropagated to the mean from the variance calculation.
In paper[Batch normalization layer (Ioffe and Szegedy, 2014)](https://arxiv.org/abs/1502.03167) Section 3, I have derived the formula:
![](http://latex.codecogs.com/gif.latex?\\frac{\\partial\L}{\\partial\\mu_B}=(\\sum_{i=1}^m\\frac{\\partial\L}{\\partial\hat\{x_i}}\\cdot\\frac{\hat\{x_i}}{\\partial\\mu_B}+\\frac{\\partial\L}{\\partial\\sigma_B^2}\\cdot\\frac{\\partial\\sigma_B^2}{\\partial\\mu_B})=(\\sum_{i=1}^m\\frac{\\partial\L}{\\partial\\hat\{x_i}}\\cdot\\frac{-1}{\\sqrt{\\sigma_B^2+\\epsilon}})+\\frac{\\partial\L}{\\partial\\sigma_B^2}\\cdot\\frac{\\sum_{i=1}^m-2(x_i-\\mu_B)}{m})
Gradients of mean are from two parts, one is gradients of variance, so I have some doubts about this.
Besides, I have mentioned ![](http://latex.codecogs.com/gif.latex?\\frac{\\sum_{i=1}^m-2(x_i-\\mu_B)}{m}) may be zero, or little, but I can't prove this, is this the answer for my doubt?