### PR TITLE
Fix ValueError when passing tf.data.Dataset to model.fit

### DIFF
--- a/tensorflow/python/keras/engine/training_utils.py
+++ b/tensorflow/python/keras/engine/training_utils.py
@@ -229,7 +229,7 @@ def standardize_single_array(x, expected_shape=None):
   if x is None:
     return None
   if tensor_util.is_tensor(x):
-    x_shape_ndims = x.shape.ndims if x.shape is not None else None
+    x_shape_ndims = array_ops.rank(x)
   else:
     x_shape_ndims = len(x.shape)
 

--- a/tensorflow/python/keras/engine/training_utils.py
+++ b/tensorflow/python/keras/engine/training_utils.py
@@ -228,9 +228,8 @@ def standardize_single_array(x, expected_shape=None):
   """Expand data of shape (x,) to (x, 1), unless len(expected_shape)==1."""
   if x is None:
     return None
-
   if (x.shape is not None
-      and len(x.shape) == 1
+      and x.shape.ndims == 1
       and (expected_shape is None or len(expected_shape) != 1)):
     if tensor_util.is_tensor(x):
       x = array_ops.expand_dims(x, axis=1)

--- a/tensorflow/python/keras/engine/training_utils.py
+++ b/tensorflow/python/keras/engine/training_utils.py
@@ -228,8 +228,12 @@ def standardize_single_array(x, expected_shape=None):
   """Expand data of shape (x,) to (x, 1), unless len(expected_shape)==1."""
   if x is None:
     return None
-  if (x.shape is not None
-      and x.shape.ndims == 1
+  if tensor_util.is_tensor(x):
+    x_shape_ndims = x.shape.ndims if x.shape is not None else None
+  else:
+    x_shape_ndims = len(x.shape)
+
+  if (x_shape_ndims == 1
       and (expected_shape is None or len(expected_shape) != 1)):
     if tensor_util.is_tensor(x):
       x = array_ops.expand_dims(x, axis=1)


### PR DESCRIPTION
This fix tries to address the issue raised in #24520 where
passing tf.data.Dataset to model.fit might result in:
```
ValueError: Cannot take the length of Shape with unknown rank.
```

This fix fixes the error by replacing len(x.shape) with x.shape.ndims

This fix fixes #24520.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>