### PR TITLE
Use rate instead of keep_prob calling dropout in keras

### DIFF
--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -138,9 +138,10 @@ class Dropout(Layer):
       training = K.learning_phase()
 
     def dropped_inputs():
-      return nn.dropout(inputs, 1  - self.rate,
+      return nn.dropout(inputs,
                         noise_shape=self._get_noise_shape(inputs),
-                        seed=self.seed)
+                        seed=self.seed,
+                        rate = self.rate)
     output = tf_utils.smart_cond(training,
                                  dropped_inputs,
                                  lambda: array_ops.identity(inputs))

--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -141,7 +141,7 @@ class Dropout(Layer):
       return nn.dropout(inputs,
                         noise_shape=self._get_noise_shape(inputs),
                         seed=self.seed,
-                        rate = self.rate)
+                        rate=self.rate)
     output = tf_utils.smart_cond(training,
                                  dropped_inputs,
                                  lambda: array_ops.identity(inputs))


### PR DESCRIPTION

While running tf.keras I noticed the following warning:
```
WARNING:tensorflow:From /usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/layers/core.py:143: calling dropout (from tensorflow.python.ops.nn_ops) with keep_prob is deprecated and will be removed in a future version.
Instructions for updating:
Please use `rate` instead of `keep_prob`. Rate should be set to `rate = 1 - keep_prob`.
```

This fix fixes the warning by replacing keep_prob with rate.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>