### PR TITLE
Close code environment in docstring for adjoint

### DIFF
--- a/tensorflow/python/ops/linalg/linalg_impl.py
+++ b/tensorflow/python/ops/linalg/linalg_impl.py
@@ -104,6 +104,7 @@ def adjoint(matrix, name=None):
   tf.linalg.adjoint(x)  # [[1 - 1j, 4 - 4j],
                         #  [2 - 2j, 5 - 5j],
                         #  [3 - 3j, 6 - 6j]]
+  ```
 
   Args:
     matrix:  A `Tensor`. Must be `float16`, `float32`, `float64`, `complex64`,


### PR DESCRIPTION
This PR adds the delimiter for the code environment in the docs for tf.linalg.adjoint. Without this, the docs were rendered inappropriately as shown below:

![image](https://user-images.githubusercontent.com/23639302/50403262-2d355d80-07c3-11e9-80af-9de4b0c83bff.png)
