### PR TITLE
Fix the issue when PYTHON_LIB_PATH consists of multiple paths

### DIFF
--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -207,10 +207,13 @@ def _get_python_lib(repository_ctx, python_bin):
 
 def _check_python_lib(repository_ctx, python_lib):
   """Checks the python lib path."""
-  cmd = 'test -d "%s" -a -x "%s"' % (python_lib, python_lib)
-  result = repository_ctx.execute([_get_bash_bin(repository_ctx), "-c", cmd])
-  if result.return_code == 1:
-    _fail("Invalid python library path: %s" % python_lib)
+  return_codes = []
+  for entry in python_lib.split(":"):
+      cmd = 'test -d "%s" -a -x "%s"' % (entry, entry)
+      result = repository_ctx.execute([_get_bash_bin(repository_ctx), "-c", cmd])
+      return_codes.append(result.return_code)
+  if all(return_codes):
+      _fail("Invalid python library path: %s" % python_lib)
 
 
 def _check_python_bin(repository_ctx, python_bin):

--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -209,11 +209,11 @@ def _check_python_lib(repository_ctx, python_lib):
   """Checks the python lib path."""
   return_codes = []
   for entry in python_lib.split(":"):
-      cmd = 'test -d "%s" -a -x "%s"' % (entry, entry)
-      result = repository_ctx.execute([_get_bash_bin(repository_ctx), "-c", cmd])
-      return_codes.append(result.return_code)
+    cmd = 'test -d "%s" -a -x "%s"' % (entry, entry)
+    result = repository_ctx.execute([_get_bash_bin(repository_ctx), "-c", cmd])
+    return_codes.append(result.return_code)
   if all(return_codes):
-      _fail("Invalid python library path: %s" % python_lib)
+    _fail("Invalid python library path: %s" % python_lib)
 
 
 def _check_python_bin(repository_ctx, python_bin):


### PR DESCRIPTION
This fix tries to address the issue raise in #24567 where `PYTHON_LIB_PATH` does not support specifying multiple paths for bazel.

This fix update python_configure.bzl so that it is possible to process multiple paths for `PYTHON_LIB_PATH`.

This fix fixes #24567.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>