### PR TITLE
Fix bug in test_streaming_accuracy.cc

### DIFF
--- a/tensorflow/examples/speech_commands/test_streaming_accuracy.cc
+++ b/tensorflow/examples/speech_commands/test_streaming_accuracy.cc
@@ -244,7 +244,7 @@ int main(int argc, char* argv[]) {
   std::vector<std::pair<string, int64>> all_found_words;
   tensorflow::StreamingAccuracyStats previous_stats;
 
-  const int64 audio_data_end = (sample_count - clip_duration_ms);
+  const int64 audio_data_end = (sample_count - clip_duration_samples);
   for (int64 audio_data_offset = 0; audio_data_offset < audio_data_end;
        audio_data_offset += clip_stride_samples) {
     const float* input_start = &(audio_data[audio_data_offset]);


### PR DESCRIPTION
This fix fixes the issue raised in #24601 where `clip_duration_ms` should be `clip_duration_samples` to calculate `audio_data_end` in test_streaming_accuracy.cc. (Thanks Alireza89).

This fix #24601.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>