### PR TITLE
[INTEL MKL] Fix for conv_ops_test failure

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -843,6 +843,12 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     CHECK_NOTNULL(m);
     Node* n = nullptr;
 
+    DataType T_m;
+    TF_CHECK_OK(GetNodeAttr(m->def(), "T", &T_m));
+
+    // Don't try to merge if datatype is not DT_FLOAT
+    if (T_m != DT_FLOAT) return n;
+
     if (m->type_string() == csinfo_.bias_add) {
       // If a is BiasAdd, then Conv2D is 0th input of BiasAdd.
       TF_CHECK_OK(m->input_node(0, &n));
@@ -876,6 +882,12 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
   static Node* GetPadOrConv2D(const Node* m) {
     DCHECK(m);
     Node* n = nullptr;
+
+    DataType T_m;
+    TF_CHECK_OK(GetNodeAttr(m->def(), "T", &T_m));
+
+    // Don't try to merge if datatype is not DT_FLOAT
+    if (T_m != DT_FLOAT) return n;
 
     const Node* conv_node;
     if (m->type_string() == csinfo_.pad) {
@@ -934,6 +946,12 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
   static Node* GetConv2DBackpropFilterOrBiasAddGrad(const Node* m) {
     CHECK_NOTNULL(m);
     Node* n = nullptr;
+
+    DataType T_m;
+    TF_CHECK_OK(GetNodeAttr(m->def(), "T", &T_m));
+
+    // Don't try to merge if datatype is not DT_FLOAT
+    if (T_m != DT_FLOAT) return n;
 
     if (m->type_string() == csinfo_.bias_add_grad) {
       // Get 1st input 'g' of BiasAddGrad.

--- a/tensorflow/core/kernels/conv_ops_test.cc
+++ b/tensorflow/core/kernels/conv_ops_test.cc
@@ -775,7 +775,7 @@ class FusedConv2DOpTest : public OpsTestBase {
     // a full sum reduction, which causes larger numerical error
     // than usual cases.
     if (image_width == filter_size && image_height == filter_size) {
-      test::ExpectTensorNear<T>(conv_2d, fused_conv_2d, 1e-4);
+      test::ExpectClose(conv_2d, fused_conv_2d, /*atol=*/1e-4);
     } else {
       test::ExpectClose(conv_2d, fused_conv_2d, /*atol=*/1e-6);
     }
@@ -825,7 +825,7 @@ class FusedConv2DOpTest : public OpsTestBase {
     // a full sum reduction, which causes larger numerical error
     // than usual cases.
     if (image_width == filter_size && image_height == filter_size) {
-      test::ExpectTensorNear<T>(conv_2d, fused_conv_2d, 1e-4);
+      test::ExpectClose(conv_2d, fused_conv_2d, /*atol=*/1e-4);
     } else {
       test::ExpectClose(conv_2d, fused_conv_2d, /*atol=*/1e-6);
     }


### PR DESCRIPTION
The test has been failing with mkl build for two instances:

1. No mkl kernel for `double` data type. [Already a PR #24532 is there]
2. precision when filter size is same as input image size

(1) is fixed by enabling mkl kernel only for `float` data type 
(2) is fixed using lowering the error tolerance to `1e-4` (motivation from
[https://github.com/tensorflow/tensorflow/commit/f66961fe7987bbb2c41c8dec56bb80990c465701])