### PR TITLE
Fix incorrect display of keras model summary

### DIFF
--- a/tensorflow/python/keras/utils/layer_utils.py
+++ b/tensorflow/python/keras/utils/layer_utils.py
@@ -196,7 +196,7 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
         continue
 
       for inbound_layer, node_index, tensor_index, _ in node.iterate_inbound():
-        connections.append('{}[{}][{}]'.format(inbound_layer, node_index,
+        connections.append('{}[{}][{}]'.format(inbound_layer.name, node_index,
                                                tensor_index))
 
     name = layer.name


### PR DESCRIPTION
This fix fixes the issue raised in #24627 where the display of keras model summary is incorrect (regression from 1.12). The reason was that `layer.name` (vs. layer object itself) should be used,

This fix fixes #24627.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>