### PR TITLE
[XLA] Unimplemented inst in call fusion

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_evaluator.cc
+++ b/tensorflow/compiler/xla/service/hlo_evaluator.cc
@@ -254,7 +254,6 @@ StatusOr<Literal> HloEvaluator::Evaluate(HloInstruction* instruction) {
 
 bool HloEvaluator::TryEvaluate(HloInstruction* instruction, Literal* result) {
   CHECK(result != nullptr);
-  LOG(INFO) << "TRY EVAL " << instruction->name();
   auto result_or = Evaluate(instruction);
   if (!result_or.ok()) {
     VLOG(1) << "TryEvaluate failed:" << result_or.status();

--- a/tensorflow/compiler/xla/service/hlo_evaluator.cc
+++ b/tensorflow/compiler/xla/service/hlo_evaluator.cc
@@ -254,6 +254,7 @@ StatusOr<Literal> HloEvaluator::Evaluate(HloInstruction* instruction) {
 
 bool HloEvaluator::TryEvaluate(HloInstruction* instruction, Literal* result) {
   CHECK(result != nullptr);
+  LOG(INFO) << "TRY EVAL " << instruction->name();
   auto result_or = Evaluate(instruction);
   if (!result_or.ok()) {
     VLOG(1) << "TryEvaluate failed:" << result_or.status();
@@ -1067,8 +1068,8 @@ Status HloEvaluator::HandleCall(HloInstruction* call) {
   }
 
   HloEvaluator embedded_evaluator;
-  Literal result = embedded_evaluator.Evaluate(*computation, arg_literals)
-                       .ConsumeValueOrDie();
+  TF_ASSIGN_OR_RETURN(Literal result,
+      embedded_evaluator.Evaluate(*computation, arg_literals));
 
   evaluated_[call] = std::move(result);
   return Status::OK();
@@ -1098,9 +1099,8 @@ Status HloEvaluator::HandleFusion(HloInstruction* fusion) {
   }
 
   HloEvaluator embedded_evaluator;
-  Literal result =
-      embedded_evaluator.Evaluate(*readded_computation, arg_literals)
-          .ConsumeValueOrDie();
+  TF_ASSIGN_OR_RETURN(Literal result,
+      embedded_evaluator.Evaluate(*readded_computation, arg_literals));
 
   evaluated_[fusion] = std::move(result);
   return Status::OK();

--- a/tensorflow/compiler/xla/service/hlo_evaluator_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_evaluator_test.cc
@@ -2925,7 +2925,7 @@ ENTRY main {
 }
 
 // Check that we correctly return error status when evaluating call instruction
-// containing an unimplemented instruction
+// containing an unimplemented instruction.
 TEST_F(HloEvaluatorTest, CallContainingUnimplementedInstruction) {
 constexpr absl::string_view hlo_text = R"(
 HloModule Test
@@ -2933,7 +2933,7 @@ HloModule Test
 sub {
   constant = f32[] constant(0)
   constant.1 = f32[] constant(1)
-  ROOT rng = f32[]{0} rng(constant, constant.1), distribution=rng_uniform
+  ROOT cst = f32[] custom-call(constant, constant.1), custom_call_target="?"
 }
 
 ENTRY main {
@@ -2951,8 +2951,8 @@ ENTRY main {
   EXPECT_FALSE(HloEvaluator().TryEvaluate(call, &lit));
 }
 
-// Check that we correctly return error status when evaluating call instruction
-// containing an unimplemented instruction
+// Check that we correctly return error status when evaluating fusion
+// instruction containing an unimplemented instruction.
 TEST_F(HloEvaluatorTest, FusionContainingUnimplementedInstruction) {
 constexpr absl::string_view hlo_text = R"(
 HloModule Test
@@ -2960,7 +2960,7 @@ HloModule Test
 sub {
   constant = f32[] constant(0)
   constant.1 = f32[] constant(1)
-  ROOT rng = f32[]{0} rng(constant, constant.1), distribution=rng_uniform
+  ROOT cst = f32[] custom-call(constant, constant.1), custom_call_target="?"
 }
 
 ENTRY main {


### PR DESCRIPTION
If an unimplemented instruction is embedded inside a call or fusion operation then currently the system aborts having done a ConsumeValueOrDie.  This change allows the various clients of the evaluator to process a graph containing calls/fusions safely.

Applies to all XLA systems.