### PR TITLE
Fix keras mode evaluate() progress bar issue

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -706,7 +706,7 @@ class ProgbarLogger(Callback):
     if self.seen < self.target:
       self.log_values = []
 
-  def on_batch_end(self, batch, logs=None):
+  def on_batch_end(self, batch, logs=None, train=True):
     logs = logs or {}
     batch_size = logs.get('size', 0)
     # In case of distribution strategy we can potentially run multiple steps
@@ -721,9 +721,9 @@ class ProgbarLogger(Callback):
       if k in logs:
         self.log_values.append((k, logs[k]))
 
-    # Skip progbar update for the last batch;
+    # In Train mode, skip progbar update for the last batch;
     # will be handled by on_epoch_end.
-    if self.verbose and self.seen < self.target:
+    if self.verbose and (self.seen < self.target or not train):
       self.progbar.update(self.seen, self.log_values)
 
   def on_epoch_end(self, epoch, logs=None):

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -706,7 +706,7 @@ class ProgbarLogger(Callback):
     if self.seen < self.target:
       self.log_values = []
 
-  def on_batch_end(self, batch, logs=None, train=True):
+  def on_batch_end(self, batch, logs=None):
     logs = logs or {}
     batch_size = logs.get('size', 0)
     # In case of distribution strategy we can potentially run multiple steps
@@ -721,9 +721,9 @@ class ProgbarLogger(Callback):
       if k in logs:
         self.log_values.append((k, logs[k]))
 
-    # In Train mode, skip progbar update for the last batch;
+    # Skip progbar update for the last batch;
     # will be handled by on_epoch_end.
-    if self.verbose and (self.seen < self.target or not train):
+    if self.verbose and self.seen < self.target:
       self.progbar.update(self.seen, self.log_values)
 
   def on_epoch_end(self, epoch, logs=None):

--- a/tensorflow/python/keras/engine/training_arrays.py
+++ b/tensorflow/python/keras/engine/training_arrays.py
@@ -343,7 +343,7 @@ def model_iteration(model,
         # Callbacks batch end.
         batch_logs = cbks.make_logs(model, batch_logs, batch_outs, mode)
         callbacks._call_batch_hook(mode, 'end', batch_index, batch_logs)
-        progbar.on_batch_end(batch_index, batch_logs)
+        progbar.on_batch_end(batch_index, batch_logs, mode==ModeKeys.TRAIN)
 
         if callbacks.model.stop_training:
           break

--- a/tensorflow/python/keras/engine/training_arrays.py
+++ b/tensorflow/python/keras/engine/training_arrays.py
@@ -343,7 +343,7 @@ def model_iteration(model,
         # Callbacks batch end.
         batch_logs = cbks.make_logs(model, batch_logs, batch_outs, mode)
         callbacks._call_batch_hook(mode, 'end', batch_index, batch_logs)
-        progbar.on_batch_end(batch_index, batch_logs, mode==ModeKeys.TRAIN)
+        progbar.on_batch_end(batch_index, batch_logs)
 
         if callbacks.model.stop_training:
           break
@@ -373,9 +373,11 @@ def model_iteration(model,
           model, epoch_logs, val_results, mode, prefix='val_')
 
     if mode == ModeKeys.TRAIN:
-      # Epochs only apply to `fit`.
       callbacks.on_epoch_end(epoch, epoch_logs)
-      progbar.on_epoch_end(epoch, epoch_logs)
+    # Epochs only apply to `fit`. However, progbar depends
+    # on on_epoch_end to flush out the last update, so
+    # on_epoch_end always apply.
+    progbar.on_epoch_end(epoch, epoch_logs)
 
   callbacks._call_end_hook(mode)
 


### PR DESCRIPTION
This fix tries to address the issue raised in #24593 where the display of evaluate() progress bar is incorrect at the last batch in keras mode.

The issue was that on_batch_end() was relying on on_epoch_end for the last step processing:
https://github.com/tensorflow/tensorflow/blob/8f60a381d210478f21762a6cf14f547a05e98878/tensorflow/python/keras/callbacks.py#L724-L727
but on_epoch_end was only called for train mode:
https://github.com/tensorflow/tensorflow/blob/8f60a381d210478f21762a6cf14f547a05e98878/tensorflow/python/keras/engine/training_arrays.py#L375-L378

This fix addresses the issue.

This fix fixes #24593.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>