### PR TITLE
Fix model_to_dot() for Sequential models

### DIFF
--- a/tensorflow/python/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/utils/vis_utils.py
@@ -77,7 +77,7 @@ def model_to_dot(model, show_shapes=False, show_layer_names=True, rankdir='TB'):
   if isinstance(model, Sequential):
     if not model.built:
       model.build()
-  layers = model.layers
+  layers = model._layers
 
   # Create graph nodes.
   for layer in layers:


### PR DESCRIPTION
The model_to_dot() function does not display the input layer of `Sequential` models correctly. This change (just one character added, haha) fixes that. See https://github.com/keras-team/keras/issues/10638
Note: this fix seems to have been applied already in keras-team/keras, but not in tf.keras.