### PR TITLE
Fix C++14-compat warning in pattern_matcher.h

### DIFF
--- a/tensorflow/compiler/xla/service/pattern_matcher.h
+++ b/tensorflow/compiler/xla/service/pattern_matcher.h
@@ -1878,7 +1878,7 @@ class HloInstructionPattern {
   // Make this a templated function to work around gcc 4.9.4 template infinite
   // recursion bug.
   template <typename Dummy = void>
-  constexpr auto WithShapeEqualTo(const ::xla::Shape* shape)
+  constexpr auto WithShapeEqualTo(const ::xla::Shape* shape) const
       -> decltype(this->WithShape(Shape().EqualTo(shape))) {
     return WithShape(Shape().EqualTo(shape));
   }
@@ -1886,7 +1886,7 @@ class HloInstructionPattern {
   // Make this a templated function to work around gcc 4.9.4 template infinite
   // recursion bug.
   template <typename Dummy = void>
-  constexpr auto WithShapeCompatibleTo(const ::xla::Shape* shape)
+  constexpr auto WithShapeCompatibleTo(const ::xla::Shape* shape) const
       -> decltype(this->WithShape(Shape().CompatibleTo(shape))) {
     return WithShape(Shape().CompatibleTo(shape));
   }


### PR DESCRIPTION
The below issue is fixed

```
INFO: From Compiling tensorflow/compiler/xla/service/hlo_graph_dumper.cc [for host]:
In file included from tensorflow/compiler/xla/service/hlo_graph_dumper.cc:42:
./tensorflow/compiler/xla/service/pattern_matcher.h:1880:18: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
  constexpr auto WithShapeEqualTo(const ::xla::Shape* shape)
                 ^
                                                             const
./tensorflow/compiler/xla/service/pattern_matcher.h:1888:18: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
  constexpr auto WithShapeCompatibleTo(const ::xla::Shape* shape)
                 ^

```