### PR TITLE
Removed kOutput variable which was not used

### DIFF
--- a/tensorflow/lite/kernels/expand_dims.cc
+++ b/tensorflow/lite/kernels/expand_dims.cc
@@ -27,7 +27,6 @@ namespace builtin {
 namespace expand_dims {
 constexpr int kInput = 0;
 constexpr int kAxis = 1;
-constexpr int kOutput = 0;
 
 namespace {
 TfLiteStatus ExpandTensorDim(TfLiteContext* context, const TfLiteTensor& input,


### PR DESCRIPTION
tensorflow/lite/kernels/expand_dims.cc:30:15: warning: unused variable 'kOutput' [-Wunused-const-variable]
constexpr int kOutput = 0;