### PR TITLE
Unused variable removed from softmax_op_functor.h

### DIFF
--- a/tensorflow/core/kernels/softmax_op_functor.h
+++ b/tensorflow/core/kernels/softmax_op_functor.h
@@ -57,7 +57,6 @@ struct SoftmaxEigenImpl {
     Eigen::DSizes<int, 2> one_by_class(1, num_classes);
 #else
     Eigen::IndexList<Eigen::type2index<kClassDim> > along_class;
-    Eigen::IndexList<Eigen::type2index<1> > depth_dim;
     Eigen::IndexList<int, Eigen::type2index<1> > batch_by_one;
     batch_by_one.set(0, batch_size);
     Eigen::IndexList<Eigen::type2index<1>, int> one_by_class;


### PR DESCRIPTION
The below issue is resolved.

```
In file included from tensorflow/core/kernels/softmax_op.cc:26:
./tensorflow/core/kernels/softmax_op_functor.h:60:45: warning: unused variable 'depth_dim' [-Wunused-variable]
    Eigen::IndexList<Eigen::type2index<1> > depth_dim;
```
