### PR TITLE
Print type of the optimizer class name in case of ValueError

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -257,7 +257,7 @@ class Model(Network):
       raise ValueError(
           'When running a model in eager execution, the optimizer must be an '
           'instance of tf.train.Optimizer. Received: '
-          '%s' % optimizer)
+          '%s' % type(optimizer))
 
     self.optimizer = optimizer
     # We've disabled automatic dependency tracking for this method, but do want


### PR DESCRIPTION
This fix adds `type` to the optimizer class so that the class
name is pretty printted (vs. the object name and memory address itself, previously).

Before the fix:
```
Traceback (most recent call last):
...
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/engine/training.py", line 260, in compile
    '%s' % optimizer)
ValueError: When running a model in eager execution, the optimizer must be \
  an instance of  tf.train.Optimizer. Received: \
  <tensorflow.python.keras.optimizers.SGD object at 0x7f9a99088b38>
```

After the fix:
```
ValueError: When running a model in eager execution, the optimizer must be \
  an instance of tf.train.Optimizer. Received: \
  <class 'tensorflow.python.keras.optimizers.SGD'>
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>