### PR TITLE
[TF port] Disable tests for GetCurrentCpu() on iOS/OS X because MacOS…

### DIFF
--- a/tensorflow/core/platform/port_test.cc
+++ b/tensorflow/core/platform/port_test.cc
@@ -35,8 +35,11 @@ TEST(Port, AlignedMalloc) {
 
 TEST(Port, GetCurrentCPU) {
   const int cpu = GetCurrentCPU();
+#if !defined(__APPLE__)
+  // GetCurrentCPU does not currently work on MacOS.
   EXPECT_GE(cpu, 0);
   EXPECT_LT(cpu, NumTotalCPUs());
+#endif
 }
 
 TEST(ConditionVariable, WaitForMilliseconds_Timeout) {


### PR DESCRIPTION
… has a __cpuid bug.

PiperOrigin-RevId: 226125575