### PR TITLE
cloud oauth_client: update for OpenSSL 1.1.0 compatibility

### DIFF
--- a/tensorflow/core/platform/cloud/oauth_client_test.cc
+++ b/tensorflow/core/platform/cloud/oauth_client_test.cc
@@ -166,7 +166,6 @@ TEST(OAuthClientTest, GetTokenFromServiceAccountJson) {
                 const_cast<unsigned char*>(
                     reinterpret_cast<const unsigned char*>(signature.data())),
                 signature.size()));
-  EVP_MD_CTX_cleanup(md_ctx);
 
   // Free all the crypto-related resources.
   EVP_PKEY_free(key);


### PR DESCRIPTION
EVP_MD_CTX_cleanup was removed in OpenSSL 1.1.0. There is a call to
EVP_MD_CTX_destroy right after and _destroy will call _cleanup if
required. EVP_MD_CTX_destroy exists in OpenSSL 1.0, 1.1 and BoringSSL so
removing the call to _cleanup works everywhere.

Signed-off-by: Jason Zaman <jason@perfinion.com>