### PR TITLE
Fix incorrect documentation in batch_normalization

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -2254,7 +2254,7 @@ def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
   """Applies batch normalization on x given mean, var, beta and gamma.
 
   I.e. returns:
-  `output = (x - mean) / (sqrt(var) + epsilon) * gamma + beta`
+  `output = (x - mean) / sqrt(var + epsilon) * gamma + beta`
 
   Arguments:
       x: Input tensor or variable.


### PR DESCRIPTION
This fix fixes the incorrect in batch_normalization
`output = (x - mean) / (sqrt(var) + epsilon) * gamma + beta`
->
`output = (x - mean) / sqrt(var + epsilon) * gamma + beta`

This fix fixes #24690.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>