### PR TITLE
Fix build failure with v2 config

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -6805,11 +6805,10 @@ tf_kernel_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core/lib/db:sqlite",
-    ] + if_not_v2([
         "//tensorflow/contrib/tensorboard/db:schema",
         "//tensorflow/contrib/tensorboard/db:summary_db_writer",
         "//tensorflow/contrib/tensorboard/db:summary_file_writer",
-    ]),
+    ],
 )
 
 tf_kernel_library(


### PR DESCRIPTION
While trying to build tensorflow with v2 config:
```
bazel build -s --verbose_failures --config=opt --config=v2 \
//tensorflow/tools/pip_package:build_pip_package
```

The following failure was encountered:
```
ERROR: /home/ubuntu/tensorflow/tensorflow/core/kernels/BUILD:6800:1: undeclared inclusion(s) in rule '//tensorflow/core/kernels:summary_kernels':
this rule is missing dependency declarations for the following files included by 'tensorflow/core/kernels/summary_kernels.cc':
  'tensorflow/contrib/tensorboard/db/schema.h'
  'tensorflow/contrib/tensorboard/db/summary_db_writer.h'
  'tensorflow/core/kernels/summary_interface.h'
  'tensorflow/contrib/tensorboard/db/summary_file_writer.h'
Target //tensorflow/tools/pip_package:build_pip_package failed to build
```

The issue was that summary_kernels.cc still depends on tensorflow/contrib/tensorboard
no matter if v1 or v2 is selected.

NOTE: The `tf.summary.create_file_writer` that is exposed to `v2` calls `create_summary_file_writer` in `tensorflow/contrib/tensorboard` anyway.

This fix fixes the issue so that it is possible to build tensorflow with v2 config.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>