### PR TITLE
Fix the issue of dense layer failure with initializer in 2.0

### DIFF
--- a/tensorflow/python/keras/engine/base_layer_utils.py
+++ b/tensorflow/python/keras/engine/base_layer_utils.py
@@ -25,6 +25,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.keras import backend
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import init_ops_v2
 from tensorflow.python.ops import variables as tf_variables
 from tensorflow.python.util import nest
 
@@ -121,7 +122,7 @@ def make_variable(name,
       variable_dtype = None
     else:
       # Instantiate initializer if provided initializer is a type object.
-      if isinstance(initializer, type(init_ops.Initializer)):
+      if isinstance(initializer, (type(init_ops.Initializer), type(init_ops_v2.Initializer))):
         initializer = initializer(dtype=dtype)
       if isinstance(initializer, init_ops.Initializer):
         init_val = lambda: initializer(  # pylint: disable=g-long-lambda

--- a/tensorflow/python/keras/engine/base_layer_utils.py
+++ b/tensorflow/python/keras/engine/base_layer_utils.py
@@ -122,8 +122,17 @@ def make_variable(name,
       variable_dtype = None
     else:
       # Instantiate initializer if provided initializer is a type object.
-      if isinstance(initializer, (type(init_ops.Initializer), type(init_ops_v2.Initializer))):
+      if isinstance(initializer, (type(init_ops.Initializer),
+                                  type(init_ops_v2.Initializer))):
         initializer = initializer(dtype=dtype)
+
+      # In case initializer is an instance of init_ops.Initializer,
+      # then the signature is:
+      #   def _initializer(shape, dtype=dtypes.float32, partition_info=None):
+      #
+      # Otherwise, the initializer is an instance of init_ops_v2.Initializer,
+      # and the signature is:
+      #   def _initializer(shape, dtype=dtypes.float32):
       if isinstance(initializer, init_ops.Initializer):
         init_val = lambda: initializer(  # pylint: disable=g-long-lambda
             shape, dtype=dtype, partition_info=partition_info)

--- a/tensorflow/python/keras/engine/base_layer_utils.py
+++ b/tensorflow/python/keras/engine/base_layer_utils.py
@@ -123,8 +123,12 @@ def make_variable(name,
       # Instantiate initializer if provided initializer is a type object.
       if isinstance(initializer, type(init_ops.Initializer)):
         initializer = initializer(dtype=dtype)
-      init_val = lambda: initializer(  # pylint: disable=g-long-lambda
-          shape, dtype=dtype, partition_info=partition_info)
+      if isinstance(initializer, init_ops.Initializer):
+        init_val = lambda: initializer(  # pylint: disable=g-long-lambda
+            shape, dtype=dtype, partition_info=partition_info)
+      else:
+        init_val = lambda: initializer(  # pylint: disable=g-long-lambda
+            shape, dtype=dtype)
       variable_dtype = dtype.base_dtype
   if use_resource is None:
     use_resource = True


### PR DESCRIPTION
This fix tries to address the issue raised in #24573 where the dense layer fails with kernel_initializer=tf.keras.initializers.Zeros() in 2.0 mode.

The reason was that the initializer passed could be v1 or v2 depending on the mode of the build, but only v1 mode is assumed (which has different signature with v2). This fix fixes the issue.

This fix fixes #24573.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>