### PR TITLE
Fix incorrectly returned error type during RaggedTensor iteration

### DIFF
--- a/tensorflow/python/ops/ragged/ragged_getitem.py
+++ b/tensorflow/python/ops/ragged/ragged_getitem.py
@@ -169,7 +169,7 @@ def _ragged_getitem(rt_input, key_list):
       # will simply be ignored as it will be processed later anyway.
       try:
         if row_key >= len(starts):
-          raise IndexError('row key {} out of bounds'.format(row_key))
+          raise IndexError('Row key {} out of bounds'.format(row_key))
       except TypeError:
         pass
     row = rt_input.values[starts[row_key]:limits[row_key]]

--- a/tensorflow/python/ops/ragged/ragged_getitem.py
+++ b/tensorflow/python/ops/ragged/ragged_getitem.py
@@ -168,9 +168,9 @@ def _ragged_getitem(rt_input, key_list):
       # TypeError which happens when row_key is not an integer, the exception
       # will simply be ignored as it will be processed later anyway.
       try:
-        if row_key >= len(starts):
+        if int(row_key) >= len(starts):
           raise IndexError('Row key {} out of bounds'.format(row_key))
-      except TypeError:
+      except (TypeError, ValueError):
         pass
     row = rt_input.values[starts[row_key]:limits[row_key]]
     return row.__getitem__(inner_keys)

--- a/tensorflow/python/ops/ragged/ragged_getitem.py
+++ b/tensorflow/python/ops/ragged/ragged_getitem.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorflow.python.eager import context
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
@@ -150,6 +151,27 @@ def _ragged_getitem(rt_input, key_list):
   else:
     starts = rt_input.row_splits[:-1]
     limits = rt_input.row_splits[1:]
+    if context.executing_eagerly():
+      # In python, __getitem__ should throw IndexError for out of bound
+      # indices. This will allow iteration run correctly as python will
+      # translate IndexError into StopIteration for next()/__next__().
+      # Below is an example:
+      #    import tensorflow as tf
+      #    r = tf.ragged.constant([[1., 2.], [3., 4., 5.], [6.]])
+      #    for elem in r:
+      #      print(elem)
+      # In non eager mode, the exception is thrown when session runs
+      # so we don't know if out of bound happens before.
+      # In eager mode, however, it is possible to find out when to
+      # throw out of bound IndexError.
+      # In the following row_key >= len(starts) is checked. In case of
+      # TypeError which happens when row_key is not an integer, the exception
+      # will simply be ignored as it will be processed later anyway.
+      try:
+        if row_key >= len(starts):
+          raise IndexError('row key {} out of bounds'.format(row_key))
+      except TypeError:
+        pass
     row = rt_input.values[starts[row_key]:limits[row_key]]
     return row.__getitem__(inner_keys)
 

--- a/tensorflow/python/ops/ragged/ragged_tensor_test.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor_test.py
@@ -1226,9 +1226,8 @@ class RaggedTensorTest(ragged_test_util.RaggedTensorTestCase,
     r = ragged_factory_ops.constant(values)
     i = 0
     for elem in r:
-      value = values[i]
+      self.assertAllEqual(elem, values[i])
       i += 1
-      self.assertAllEqual(elem, value)
 
 if __name__ == '__main__':
   googletest.main()

--- a/tensorflow/python/ops/ragged/ragged_tensor_test.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor_test.py
@@ -829,13 +829,13 @@ class RaggedTensorTest(ragged_test_util.RaggedTensorTestCase,
   @parameterized.parameters(
       # Tests for out-of-bound errors
       (SLICE_BUILDER[5],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
       (SLICE_BUILDER[-6],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
       (SLICE_BUILDER[0, 2],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
       (SLICE_BUILDER[3, 0],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
 
       # Indexing into an inner ragged dimension
       (SLICE_BUILDER[:, 3], ValueError,
@@ -954,13 +954,13 @@ class RaggedTensorTest(ragged_test_util.RaggedTensorTestCase,
 
       # Test for out-of-bounds errors.
       (SLICE_BUILDER[1, 0],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
       (SLICE_BUILDER[0, 0, 3],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
       (SLICE_BUILDER[5],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
       (SLICE_BUILDER[0, 5],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
   )
   def testRaggedTensorGetItemErrorsWithRaggedRank2(self, slice_spec, expected,
                                                    message):
@@ -983,9 +983,9 @@ class RaggedTensorTest(ragged_test_util.RaggedTensorTestCase,
 
   @parameterized.parameters(
       (SLICE_BUILDER[0],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
       (SLICE_BUILDER[-1],
-       (ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
   )
   def testRaggedTensorGetItemErrorsWithEmptyTensor(self, slice_spec, expected,
                                                    message):

--- a/tensorflow/python/ops/ragged/ragged_tensor_test.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor_test.py
@@ -1207,5 +1207,18 @@ class RaggedTensorTest(ragged_test_util.RaggedTensorTestCase,
       res2 = session.partial_run(handle, r2, feed_dict={c: c_val})
       self.assertAllEqual(res2, [15, 7])
 
+  # Test case for GitHub issue 24679.
+  def testEagerForLoop(self):
+    if not context.executing_eagerly():
+      return
+
+    values = [[1., 2.], [3., 4., 5.], [6.]]
+    r = ragged_factory_ops.constant(values)
+    i = 0
+    for elem in r:
+      value = values[i]
+      i += 1
+      self.assertAllEqual(elem, value)
+
 if __name__ == '__main__':
   googletest.main()

--- a/tensorflow/python/ops/ragged/ragged_tensor_test.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor_test.py
@@ -829,13 +829,17 @@ class RaggedTensorTest(ragged_test_util.RaggedTensorTestCase,
   @parameterized.parameters(
       # Tests for out-of-bound errors
       (SLICE_BUILDER[5],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
       (SLICE_BUILDER[-6],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
       (SLICE_BUILDER[0, 2],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
       (SLICE_BUILDER[3, 0],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
 
       # Indexing into an inner ragged dimension
       (SLICE_BUILDER[:, 3], ValueError,
@@ -954,13 +958,17 @@ class RaggedTensorTest(ragged_test_util.RaggedTensorTestCase,
 
       # Test for out-of-bounds errors.
       (SLICE_BUILDER[1, 0],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
       (SLICE_BUILDER[0, 0, 3],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
       (SLICE_BUILDER[5],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
       (SLICE_BUILDER[0, 5],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
   )
   def testRaggedTensorGetItemErrorsWithRaggedRank2(self, slice_spec, expected,
                                                    message):
@@ -983,9 +991,11 @@ class RaggedTensorTest(ragged_test_util.RaggedTensorTestCase,
 
   @parameterized.parameters(
       (SLICE_BUILDER[0],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
       (SLICE_BUILDER[-1],
-       (IndexError, ValueError, errors.InvalidArgumentError), '.*out of bounds.*'),
+       (IndexError, ValueError, errors.InvalidArgumentError),
+       '.*out of bounds.*'),
   )
   def testRaggedTensorGetItemErrorsWithEmptyTensor(self, slice_spec, expected,
                                                    message):


### PR DESCRIPTION
This fix tries to address the issue raised in #24679 where RaggedTensor iteration does not stop correctly (eager mode):
```
import tensorflow as tf
r = tf.ragged.constant([[1., 2.], [3., 4., 5.], [6.]])
for elem in r:
    print(elem)
```

The reason was that `__getitem__()` should have thrown IndexError (translated to StopIteration in next/__next__()) in order for python to correctly process iteration.

This fix fixes the issue.

This fix fixes #24679.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>