### PR TITLE
TF Android Example compile warning fixes

### DIFF
--- a/tensorflow/lite/examples/android/app/build.gradle
+++ b/tensorflow/lite/examples/android/app/build.gradle
@@ -45,6 +45,6 @@ project.ext.TMP_DIR   = project.buildDir.toString() + '/downloads'
 apply from: "download-models.gradle"
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'org.tensorflow:tensorflow-lite:0.0.0-nightly'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'org.tensorflow:tensorflow-lite:0.0.0-nightly'
 }

--- a/tensorflow/lite/examples/android/app/src/main/AndroidManifest.xml
+++ b/tensorflow/lite/examples/android/app/src/main/AndroidManifest.xml
@@ -24,10 +24,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
-    <uses-sdk
-        android:minSdkVersion="21"
-        android:targetSdkVersion="23" />
-
     <application android:allowBackup="true"
         android:debuggable="true"
         android:label="@string/app_name"

--- a/tensorflow/lite/java/AndroidManifest.xml
+++ b/tensorflow/lite/java/AndroidManifest.xml
@@ -3,7 +3,6 @@
     package="org.tensorflow.lite">
 
     <uses-sdk
-        android:minSdkVersion="4"
         android:targetSdkVersion="19" />
 
     <application />


### PR DESCRIPTION
1. The minSdk and targetSdk version should not be declared in the android manifest file. You can move the version from the manifest to the defaultConfig in the build.gradle file.
Reference : https://developer.android.com/guide/topics/manifest/manifest-intro#uses-sdk
2. Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
Reference : http://d.android.com/r/tools/update-dependency-configurations.html