### PR TITLE
Add cuDNN deterministic env variable (only for convolution)

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -796,12 +796,12 @@ bool BatchnormSpatialPersistentEnabled() {
 
 // A helper function to decide whether to enable deterministic functionality.
 // TODO(pr/24355): Support all cuDNN functionality (currently only convolution).
-bool Deterministic() {
+bool RequireDeterminism() {
   static bool is_enabled = [] {
     bool is_enabled = false;
-    TF_CHECK_OK(
-        tensorflow::ReadBoolFromEnvVar("TF_CUDNN_DETERMINISTIC",
-                                       /*default_val=*/false, &is_enabled));
+    TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar("TF_CUDNN_DETERMINISTIC",
+                                               /*default_val=*/false,
+                                               &is_enabled));
     return is_enabled;
   }();
   return is_enabled;
@@ -3049,9 +3049,22 @@ port::Status CudnnSupport::DoFusedConvolveImpl(
   return port::Status::OK();
 }
 
+inline bool TensorOpMathAvailable(int cc_major) {
+  return cc_major >= 7 && CUDNN_VERSION >= 7000 && TensorOpMathEnabled();
+}
+
 bool CudnnSupport::GetConvolveAlgorithms(
     bool with_winograd_nonfused, int cc_major, int cc_minor,
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
+  bool tensor_op_math_available = TensorOpMathAvailable(cc_major);
+  out_algorithms->clear();
+
+  if (RequireDeterminism()) {
+    out_algorithms->push_back({CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM,
+                               tensor_op_math_available});
+    return true;
+  }
+
   std::vector<dnn::AlgorithmDesc::Index> algo_types = {
     // clang-format off
     CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM,
@@ -3069,22 +3082,13 @@ bool CudnnSupport::GetConvolveAlgorithms(
     algo_types.push_back(CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED);
   }
 
-  if (Deterministic()) {
-    algo_types.clear();
-    algo_types.push_back(CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM);
-  }
-
-  out_algorithms->clear();
   for (auto i : algo_types) {
     out_algorithms->push_back({i, /*use_tensor_ops=*/false});
-    if (cc_major >= 7 && CUDNN_VERSION >= 7000 && TensorOpMathEnabled()) {
-      if (Deterministic()) {
-        // For determinism: always use tensor op math, if it's available
-        out_algorithms->pop_back();
-      }
+    if (tensor_op_math_available) {
       out_algorithms->push_back({i, /*use_tensor_ops=*/true});
     }
   }
+
   return true;
 }
 
@@ -3113,6 +3117,15 @@ bool CudnnSupport::GetRnnAlgorithms(
 bool CudnnSupport::GetConvolveBackwardDataAlgorithms(
     bool with_winograd_nonfused, int cc_major, int cc_minor,
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
+  bool tensor_op_math_available = TensorOpMathAvailable(cc_major);
+  out_algorithms->clear();
+
+  if (RequireDeterminism()) {
+    out_algorithms->push_back(
+        {CUDNN_CONVOLUTION_BWD_DATA_ALGO_1, tensor_op_math_available});
+    return true;
+  }
+
   std::vector<dnn::AlgorithmDesc::Index> algo_types = {
       // clang-format off
     CUDNN_CONVOLUTION_BWD_DATA_ALGO_0,
@@ -3126,28 +3139,28 @@ bool CudnnSupport::GetConvolveBackwardDataAlgorithms(
     algo_types.push_back(CUDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD_NONFUSED);
   }
 
-  if (Deterministic()) {
-    algo_types.clear();
-    algo_types.push_back(CUDNN_CONVOLUTION_BWD_DATA_ALGO_1);
-  }
-
-  out_algorithms->clear();
   for (auto i : algo_types) {
     out_algorithms->push_back({i, /*use_tensor_ops=*/false});
-    if (cc_major >= 7 && CUDNN_VERSION >= 7000 && TensorOpMathEnabled()) {
-      if (Deterministic()) {
-        // For determinism: always use tensor op math, if it's available
-        out_algorithms->pop_back();
-      }
+    if (tensor_op_math_available) {
       out_algorithms->push_back({i, /*use_tensor_ops=*/true});
     }
   }
+
   return true;
 }
 
 bool CudnnSupport::GetConvolveBackwardFilterAlgorithms(
     bool with_winograd_nonfused, int cc_major, int cc_minor,
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
+  bool tensor_op_math_available = TensorOpMathAvailable(cc_major);
+  out_algorithms->clear();
+
+  if (RequireDeterminism()) {
+    out_algorithms->push_back(
+        {CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1, tensor_op_math_available});
+    return true;
+  }
+
   std::vector<dnn::AlgorithmDesc::Index> algo_types = {
       // clang-format off
       CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0,
@@ -3166,22 +3179,13 @@ bool CudnnSupport::GetConvolveBackwardFilterAlgorithms(
     algo_types.push_back(CUDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD_NONFUSED);
   }
 
-  if (Deterministic()) {
-    algo_types.clear();
-    algo_types.push_back(CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1);
-  }
-
-  out_algorithms->clear();
   for (auto i : algo_types) {
     out_algorithms->push_back({i, /*use_tensor_ops=*/false});
-    if (cc_major >= 7 && CUDNN_VERSION >= 7000 && TensorOpMathEnabled()) {
-      if (Deterministic()) {
-        // For determinism: always use tensor op math, if it's available
-        out_algorithms->pop_back();
-      }
+    if (tensor_op_math_available) {
       out_algorithms->push_back({i, /*use_tensor_ops=*/true});
     }
   }
+
   return true;
 }
 


### PR DESCRIPTION
This change is a component of the recipe for making TensorFlow training reproducible on GPUs.

Setting the environment variable TF_CUDNN_DETERMINISTIC=1 (or true) will ensure that both forward and backwards convolution algorithms are both fixed and deterministic. It overrides autotune and selects deterministic back-prop algorithms.

This pull request has two previous abandoned versions:
* [pr/24301](https://github.com/tensorflow/tensorflow/pull/24301) was issued incorrectly based on r1.12.
* [pr/24355](https://github.com/tensorflow/tensorflow/pull/24355) was temporarily closed and could not be re-opened after a force-push to the branch.

This pull request is different from 24355 in the following ways:

1. It caches the environment variable using a more favorable, pre-existing pattern.
2. It uses tensor op math, if it's available.
3. It factors the logic that decides if tensor op math is available into a separate inline function.
4. If TF_CUDNN_DETERMINISTIC is set, the code that accumulates the list of algorithm options is skipped.

Attention @azaks2 @timshen91 