### PR TITLE
Update protobuf to 3.6.1 in install_proto3.sh

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -60,8 +60,8 @@ pip2 install --upgrade markdown==2.6.8
 pip3 install --upgrade markdown==2.6.8
 
 # Install protobuf.
-pip2 install --upgrade protobuf==3.6.0
-pip3 install --upgrade protobuf==3.6.0
+pip2 install --upgrade protobuf==3.6.1
+pip3 install --upgrade protobuf==3.6.1
 
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
 rm -rf /usr/lib/python3/dist-packages/six*

--- a/tensorflow/tools/ci_build/install/install_proto3.sh
+++ b/tensorflow/tools/ci_build/install/install_proto3.sh
@@ -17,7 +17,7 @@
 # Install protobuf3.
 
 # Select protobuf version.
-PROTOBUF_VERSION="3.6.0"
+PROTOBUF_VERSION="3.6.1"
 protobuf_ver_flat=$(echo $PROTOBUF_VERSION | sed 's/\.//g' | sed 's/^0*//g')
 local_protobuf_ver=$(protoc --version)
 local_protobuf_ver_flat=$(echo $local_protobuf_ver | sed 's/\.//g' | sed 's/^0*//g')

--- a/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_python3.5_pip_packages.sh
@@ -52,7 +52,7 @@ pip3.5 install --upgrade absl-py
 pip3.5 install --upgrade six==1.10.0
 
 # Install protobuf.
-pip3.5 install --upgrade protobuf==3.6.0
+pip3.5 install --upgrade protobuf==3.6.1
 
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
 rm -rf /usr/lib/python3/dist-packages/six*

--- a/tensorflow/tools/ci_build/install/install_python3.6_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_python3.6_pip_packages.sh
@@ -64,7 +64,7 @@ pip3 install --upgrade absl-py
 pip3 install --upgrade six==1.10.0
 
 # Install protobuf.
-pip3 install --upgrade protobuf==3.6.0
+pip3 install --upgrade protobuf==3.6.1
 
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
 rm -rf /usr/lib/python3/dist-packages/six*


### PR DESCRIPTION
This fix updates protobuf to 3.6.1 in ci build's install.sh.

The protobuf library in workspace.bzl has been updated to 3.6.1 for some time, though in CI build protoc still uses 3.6.0.

When build a custom op (in docker image `tensorflow/tensorflow:custom-op`) and using grpc's `grpc_defs()` (`grpc/bazel/grpc_deps.bzl`) error happens because grpc ties to a specific Protobuf version:
https://github.com/grpc/grpc/blob/ac6795a57e05523b8fa220bc5cef26abb876aae5/bazel/grpc_deps.bzl#L5-L7



The issue arise because grpc's dependency is 3.6.1 (and an immediate earlier version is 3.5)
so there is no match to fit grpc+protobuf3.6.0 no matter which version of grpc is used.

This may not a problem for tensorflow itself as tensorflow does not call `grpc_defs()`. Tensorflow links to protobuf 3.6.1 explicitly.

Still, it would be good to match the version of installed protoc (3.6.0 before this PR) with protobuf library (3.6.1).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
