### PR TITLE
Added missing test case in LinearModel

### DIFF
--- a/tensorflow/python/feature_column/feature_column_v2_test.py
+++ b/tensorflow/python/feature_column/feature_column_v2_test.py
@@ -1838,6 +1838,22 @@ class LinearModelTest(test.TestCase):
         sess.run(bias.assign([5.]))
         self.assertAllClose([[1005.], [5010.]], self.evaluate(predictions))
 
+  def test_sparse_combiner_sqrtn(self):
+    wire_cast = fc.categorical_column_with_hash_bucket('wire_cast', 4)
+    with ops.Graph().as_default():
+      wire_tensor = sparse_tensor.SparseTensor(
+          values=['omar', 'stringer', 'marlo'],  # hashed to = [2, 0, 3]
+          indices=[[0, 0], [1, 0], [1, 1]],
+          dense_shape=[2, 2])
+      features = {'wire_cast': wire_tensor}
+      model = fc.LinearModel([wire_cast], sparse_combiner='sqrtn')
+      predictions = model(features)
+      wire_cast_var, bias = model.variables
+      with _initialized_session() as sess:
+        self.evaluate(wire_cast_var.assign([[10.], [100.], [1000.], [10000.]]))
+        self.evaluate(bias.assign([5.]))
+        self.assertAllClose([[1005.], [7083.139]], self.evaluate(predictions))
+
   def test_sparse_combiner_with_negative_weights(self):
     wire_cast = fc.categorical_column_with_hash_bucket('wire_cast', 4)
     wire_cast_weights = fc.weighted_categorical_column(wire_cast, 'weights')


### PR DESCRIPTION
LinearModel is miising test case for sparse_combiner=sqrtn, added the
same to make the coverage complete.