### PR TITLE
resolved incompatible dimension reshape before feed into final dense …

### DIFF
--- a/tensorflow/contrib/eager/python/examples/rnn_ptb/rnn_ptb.py
+++ b/tensorflow/contrib/eager/python/examples/rnn_ptb/rnn_ptb.py
@@ -128,7 +128,7 @@ class PTBModel(tf.keras.Model):
 
     self.linear = layers.Dense(
         vocab_size, kernel_initializer=tf.random_uniform_initializer(-0.1, 0.1))
-    self._output_shape = [-1, embedding_dim]
+    self._output_shape = [-1, hidden_dim]
 
   def call(self, input_seq, training):
     """Run the forward pass of PTBModel.


### PR DESCRIPTION
modify simple error in rnn_ptb.py in an example in tf.eager mode
since rnn cell yield (sequence_length, batch_size, hidden_dim), hidden_dim is correct when reshaping tensor right before feed into the final dense layer, not embedding_dim