### PR TITLE
Update docstring for tf.train.init_from_checkpoint

### DIFF
--- a/tensorflow/python/training/checkpoint_utils.py
+++ b/tensorflow/python/training/checkpoint_utils.py
@@ -180,8 +180,8 @@ def init_from_checkpoint(ckpt_dir_or_file, assignment_map):
       (in default graph).
 
   Raises:
-    tf.errors.OpError: If missing checkpoints or tensors in checkpoints.
-    ValueError: If missing variables in current graph.
+    ValueError: If missing variables in current graph, or if missing
+      checkpoints or tensors in checkpoints.
   """
   if distribution_strategy_context.get_cross_replica_context():
     _init_from_checkpoint(None, ckpt_dir_or_file, assignment_map)


### PR DESCRIPTION
This fix updates docstring for tf.train.init_from_checkpoint,
to match the actual implementation. (thanks @sharvil)

This fix fixes #24756.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>