### PR TITLE
Fix astor url to pypi.python.org

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -285,7 +285,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
         system_build_file = clean_dep("//third_party/systemlibs:astor.BUILD"),
         urls = [
             "https://mirror.bazel.build/pypi.python.org/packages/99/80/f9482277c919d28bebd85813c0a70117214149a96b08981b72b63240b84c/astor-0.7.1.tar.gz",
-            "https://files.pythonhosted.org/packages/99/80/f9482277c919d28bebd85813c0a70117214149a96b08981b72b63240b84c/astor-0.7.1.tar.gz",
+            "https://pypi.python.org/packages/99/80/f9482277c919d28bebd85813c0a70117214149a96b08981b72b63240b84c/astor-0.7.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This PR is alternative to #24493  Fixes proper pypi.python.org url in bazel build file. Include d314cb4d8a293140ba864038bfcee1bdd3e18cf4 and this commit in r1.13 ASAP, as it fixes the build error in r1.13.

And shall I include a note in **Contributing Guidelines** specifying only PRs to **master** are accepted?
Since I made the mistake earlier because it wasn't clear.

