### PR TITLE
Fix: typo in SavedModelBundle.java

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/SavedModelBundle.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/SavedModelBundle.java
@@ -84,7 +84,7 @@ public class SavedModelBundle implements AutoCloseable {
    * <p>This method is a shorthand for:
    *
    * <pre>{@code
-   * SavedModelBundler.loader().withTags(tags).load();
+   * SavedModelBundle.loader().withTags(tags).load();
    * }</pre>
    *
    * @param exportDir the directory path containing a saved model.


### PR DESCRIPTION
There is a typo in `tensorflow/java/src/main/java/org/tensorflow/SavedModelBundle.java`.
This patch fixes this typo.