### PR TITLE
[TensorFlow Java] adding updateEdge function

### DIFF
--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -1026,6 +1026,11 @@ TF_CAPI_EXPORT extern void TF_GraphImportGraphDef(
     TF_Graph* graph, const TF_Buffer* graph_def,
     const TF_ImportGraphDefOptions* options, TF_Status* status);
 
+// Update the input to a `dst`.
+// Replaces the existing edge to `dst` with a new edge from  `newSrc` to `dst`.
+TF_CAPI_EXPORT extern void TF_UpdateEdge(TF_Graph* graph, TF_Output new_src,
+                                         TF_Input dst, TF_Status* status);
+
 // Adds a copy of function `func` and optionally its gradient function `grad`
 // to `g`. Once `func`/`grad` is added to `g`, it can be called by creating
 // an operation using the function's name.

--- a/tensorflow/java/src/main/java/org/tensorflow/Graph.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Graph.java
@@ -235,6 +235,23 @@ public final class Graph implements AutoCloseable {
   public Output<?>[] addGradients(Output<?> y, Output<?>[] x) {
     return addGradients(null, new Output<?>[] {y}, x, null);
   }
+
+  /**
+   * Updates the input to a node. Replaces the existing edge to `dst` with a new edge from  `newSrc` to `dst`.
+   *
+   * @param newSrc new source of input
+   * @param dst destination of input
+   */
+  public void updateEdge(Output<?> newSrc, Output<?> dst) {
+    synchronized (nativeHandleLock) {
+      long newSrcHandle = newSrc.op().getUnsafeNativeHandle();
+      int newSrcIndex = newSrc.index();
+      long dstHandle = dst.op().getUnsafeNativeHandle();
+      int dstIndex = dst.index();
+
+      updateEdge(nativeHandle, newSrcHandle, newSrcIndex, dstHandle, dstIndex);
+    }
+  }
   
   private final Object nativeHandleLock = new Object();
   private long nativeHandle;
@@ -356,6 +373,13 @@ public final class Graph implements AutoCloseable {
       int[] outputIndices,
       long[] gradInputHandles,
       int[] gradInputIndices);
+
+  private static native int updateEdge(
+          long handle,
+          long newSrcHandle,
+          int newSrcIndex,
+          long dstHandle,
+          int dstIndex);
 
   static {
     TensorFlow.init();

--- a/tensorflow/java/src/main/native/graph_jni.h
+++ b/tensorflow/java/src/main/native/graph_jni.h
@@ -82,6 +82,14 @@ JNIEXPORT jlongArray JNICALL Java_org_tensorflow_Graph_addGradients(
     JNIEnv *, jclass, jlong, jstring, jlongArray, jintArray, jlongArray,
     jintArray, jlongArray, jintArray);
 
+/*
+ * Class:     org_tensorflow_Graph
+ * Method:    updateInput
+ * Signature: (JJIJ)V
+ */
+JNIEXPORT void JNICALL Java_org_tensorflow_Graph_updateEdge(
+    JNIEnv *, jclass, jlong, jlong, jint, jlong, jint);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tensorflow/java/src/test/java/org/tensorflow/GraphTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/GraphTest.java
@@ -254,6 +254,36 @@ public class GraphTest {
       }
     }
   }
+
+  @Test
+  public void updateEdgeInGraph() {
+    try (Graph g = new Graph();
+         Session s1 = new Session(g);
+         Session s2 = new Session(g)) {
+
+      Output<?> a = TestUtil.constant(g, "a", 2);
+      Output<?> b = TestUtil.constant(g, "b", 3);
+      Output<?> x = TestUtil.square(g, "example_op", a);
+
+      try(Tensor<?> output1 = s1.runner()
+              .fetch("example_op")
+              .run()
+              .get(0)) {
+
+        assertEquals(4, output1.intValue());
+      }
+
+      g.updateEdge(b,x);
+
+      try(Tensor<?> output2 = s2.runner()
+              .fetch("example_op")
+              .run()
+              .get(0)) {
+
+        assertEquals(9, output2.intValue());
+      }
+    }
+  }
   
   private static Output<?>[] toArray(Output<?>... outputs) {
     return outputs;


### PR DESCRIPTION
This PR adds an updateEdge function for Java, addressing issue [#24231](https://github.com/tensorflow/tensorflow/issues/24231). 

Note: the TF_UpdateEdge function added to c_api.cc is from python_api.cc. 

Co-authored-by: Samantha Andow <samdow@fb.com>
Co-authored-by: Irene Dea <irenedea@fb.com>