### PR TITLE
r1.13-rc0 cherry-pick request: Fix --config=mkl performance regression

### DIFF
--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -674,7 +674,7 @@ tf_cc_test(
     ],
 )
 
-cc_library(
+tf_kernel_library(
     name = "remapper",
     srcs = ["remapper.cc"],
     hdrs = [

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -690,6 +690,9 @@ Status Remapper::Optimize(Cluster* /*cluster*/, const GrapplerItem& item,
       continue;
     }
 
+// TODO(penporn):
+// Remove this once TF-MKL supports _FusedConv2D with these operations.
+#ifndef INTEL_MKL
     // Remap Conv2D+Squeeze+BiasAdd into the _FusedConv2D+Squeeze.
     if (FindConv2DWithSqueezeAndBias(ctx, &node,
                                      &conv2d_with_squeeze_and_bias)) {
@@ -712,6 +715,7 @@ Status Remapper::Optimize(Cluster* /*cluster*/, const GrapplerItem& item,
                          &invalidated_nodes);
       continue;
     }
+#endif  // !INTEL_MKL
 
     // Infer properties lazily in case they are not needed.
     if (!ctx.inferred_graph_properties && IsFusedBatchNormCandidate(node)) {


### PR DESCRIPTION
This fixes a ~4x slowdown (compared to r1.12) observed when running [DeepVariant](https://github.com/google/deepvariant) on cloud. If not fixed, we could see similarly huge slowdowns in other TF-MKL runs with models that have Conv2D following directly by FusedBatchNorm (and also Conv2D followed by Squeeze and BiasAdd).

Details:
https://github.com/tensorflow/tensorflow/commit/ffde93148d82093c9cd8703e8d7d81bff67a1dc6 makes Grappler generate some _FusedConv2D nodes that doesn't have corresponding TF-MKL nodes. For example, MKL graph rewriter doesn't support _FusedConv2D with BatchNorm yet so any Conv2D that gets fused with BatchNorm will miss using MKL-DNN's convolutions, causing a big performance slowdown compared to r1.12.