### PR TITLE
fix logic adding generated API directory to tensorflow.__path__

### DIFF
--- a/tensorflow/api_template_v1.__init__.py
+++ b/tensorflow/api_template_v1.__init__.py
@@ -62,12 +62,15 @@ if '__all__' in vars():
   vars()['__all__'].append('contrib')
 
 from tensorflow.python.platform import flags  # pylint: disable=g-import-not-at-top
-from tensorflow.python.platform import app  # pylint: disable=g-import-not-at-top
-app.flags = flags
+# The 'app' module will be imported as part of the placeholder section above.
+app.flags = flags  # pylint: disable=undefined-variable
+
+# Also use 'app' module (choice is arbitrary) to derive the API directory below.
+_API_MODULE = app  # pylint: disable=undefined-variable
 
 # Make sure directory containing top level submodules is in
 # the __path__ so that "from tensorflow.foo import bar" works.
-_tf_api_dir = _os.path.dirname(_os.path.dirname(app.__file__))  # pylint: disable=undefined-variable
+_tf_api_dir = _os.path.dirname(_os.path.dirname(_API_MODULE.__file__))  # pylint: disable=undefined-variable
 if not hasattr(_current_module, '__path__'):
   __path__ = [_tf_api_dir]
 elif _tf_api_dir not in __path__:


### PR DESCRIPTION
This reverts part of PR #24247 that broke logic in the v1 `__init__.py` template that sets up `tensorflow.__path` so that generated API modules can be imported directly.

The breakage can be reproduced in current `tf-nightly` by just doing:

```
>>> import tensorflow
>>> tensorflow.compat
<module 'tensorflow._api.v1.compat' from '/.../tensorflow/_api/v1/compat/__init__.pyc'>
>>> import tensorflow.compat
>>> tensorflow.compat
<module 'tensorflow.compat' from '/.../tensorflow/python/compat/__init__.pyc'>
```
The latter version of `tensorflow.compat` only contains utility functions and lacks any `v1` submodule, which is only in `_api/v1/compat/v1`, so this change manifests as `import tensorflow.compat.v1` failing with "No module named v1".  This is a particularly obvious failure, but it actually affects any top-level module that also exists under tensorflow/python, it's just that only a few of them are noticeably different.

The problem in the original change was that re-importing app via `from tensorflow.python.platform import app` actually changed which `app` module file was in use, and `app` was being used as an arbitrarily chosen module in logic below that adjusts the `__path__` attribute of the `tensorflow` to include the generated API directory, as determined by using `dirname(dirname(app.__file__))`.

The logic for this should be made more robust so it's not affected by seemingly unrelated changes like this, but for now I'm just reverting it (with an intermediate variable to make the usage more obvious) to get tf-nightly unbroken.