### PR TITLE
Removal of warning from backend.py file

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4023,12 +4023,16 @@ def dropout(x, level, noise_shape=None, seed=None):
   Returns:
       A tensor.
   """
-  retain_prob = 1. - level
   if seed is None:
     seed = np.random.randint(10e6)
   # the dummy 1. works around a TF bug
   # (float32_ref vs. float32 incompatibility)
-  return nn.dropout(x * 1., retain_prob, noise_shape, seed=seed)
+  if level is None:
+    raise ValueError('None values not supported. Received argument '
+                     '`level=None` in `keras.backend.dropout`.')
+  retain_prob = 1. - level
+
+  return nn.dropout(x * 1., rate=retain_prob, noise_shape=noise_shape, seed=seed)
 
 
 @keras_export('keras.backend.l2_normalize')


### PR DESCRIPTION
Removed the compiler warning where rate to be used in the dropout op