### PR TITLE
Disable InterpreterFlexTest

### DIFF
--- a/tensorflow/lite/java/BUILD
+++ b/tensorflow/lite/java/BUILD
@@ -163,6 +163,9 @@ java_test(
         "//tensorflow/lite:testdata/multi_add_flex.bin",
     ],
     javacopts = JAVACOPTS,
+    tags = [
+        "no_oss",  # Currently requires --config=monolithic, b/118895218.
+    ],
     test_class = "org.tensorflow.lite.InterpreterFlexTest",
     visibility = ["//visibility:private"],
     deps = [


### PR DESCRIPTION
This test currently only works with --config=monolithic. Disable for
now until the select .so supports execution against the shared TF lib.

PiperOrigin-RevId: 229269278