### PR TITLE
Make MutableHashTableOfTensors trainable

### DIFF
--- a/tensorflow/contrib/lookup/BUILD
+++ b/tensorflow/contrib/lookup/BUILD
@@ -41,6 +41,7 @@ tf_py_test(
         "//tensorflow/python:framework_for_generated_wrappers",
         "//tensorflow/python:framework_test_lib",
         "//tensorflow/python:lookup_ops",
+	"//tensorflow/python:embedding_ops",
         "//tensorflow/python:session",
         "//tensorflow/python:sparse_tensor",
         "//tensorflow/python:training",

--- a/tensorflow/core/api_def/base_api/api_def_LookupTableScatterAddV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_LookupTableScatterAddV2.pbtxt
@@ -1,0 +1,29 @@
+op {
+  graph_op_name: "LookupTableScatterAddV2"
+  endpoint {
+    name: "LookupTableScatterAdd"
+  }
+  in_arg {
+    name: "table_handle"
+    description: <<END
+Handle to the table.
+END
+  }
+  in_arg {
+    name: "keys"
+    description: <<END
+Any shape.  Keys to look up.
+END
+  }
+  in_arg {
+    name: "values"
+    description: <<END
+Values to associate with keys.
+END
+  }
+  summary: "Updates the table to add keys with values."
+  description: <<END
+The tensor `keys` must be of the same type as the keys of the table.
+The tensor `values` must be of the type of the table values.
+END
+}

--- a/tensorflow/core/api_def/python_api/api_def_LookupTableScatterAddV2.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_LookupTableScatterAddV2.pbtxt
@@ -1,0 +1,4 @@
+op {
+  graph_op_name: "LookupTableScatterAddV2"
+  visibility: HIDDEN
+}

--- a/tensorflow/core/framework/lookup_interface.h
+++ b/tensorflow/core/framework/lookup_interface.h
@@ -64,6 +64,18 @@ class LookupInterface : public ResourceBase {
   virtual Status Insert(OpKernelContext* ctx, const Tensor& keys,
                         const Tensor& values) = 0;
 
+  // TODO: make a generic update
+  virtual Status ScatterAdd(OpKernelContext* ctx, const Tensor& keys,
+                            const Tensor& values) {
+    return Status::OK();
+  }
+
+  // TODO: make a generic update
+  virtual Status ScatterSub(OpKernelContext* ctx, const Tensor& keys,
+                            const Tensor& values) {
+    return Status::OK();
+  }
+
   // Removes elements from the table.
   // This method is only implemented in mutable tables that can be updated over
   // the execution of the graph. It returns Status::NotImplemented for read-only

--- a/tensorflow/core/framework/variable.proto
+++ b/tensorflow/core/framework/variable.proto
@@ -29,6 +29,10 @@ message VariableDef {
 
   // Whether this variable should be trained.
   bool trainable = 7;
+
+  // the resource type, so that we can init different
+  // type of resource from the proto
+  string resource_type = 8;
 }
 
 message SaveSliceInfoDef {

--- a/tensorflow/core/lib/gtl/map_util.h
+++ b/tensorflow/core/lib/gtl/map_util.h
@@ -155,6 +155,18 @@ typename Collection::value_type::second_type& LookupOrInsert(
                         typename Collection::value_type(key, value));
 }
 
+template <class Collection>
+typename Collection::value_type::second_type& LookupOrInsert(
+    Collection* const collection,
+    const typename Collection::value_type::first_type& key,
+    const typename Collection::value_type::second_type& value,
+    bool* inserted_ok) {
+  auto result = collection->insert(typename Collection::value_type(key, value));
+  if (inserted_ok != nullptr) {
+    *inserted_ok = result.second;
+  }
+  return result.first->second;
+}
 }  // namespace gtl
 }  // namespace tensorflow
 

--- a/tensorflow/core/ops/lookup_ops.cc
+++ b/tensorflow/core/ops/lookup_ops.cc
@@ -214,6 +214,30 @@ REGISTER_OP("LookupTableInsertV2")
       return Status::OK();
     });
 
+REGISTER_OP("LookupTableScatterAddV2")
+    .Input("table_handle: resource")
+    .Input("keys: Tin")
+    .Input("values: Tout")
+    .Attr("Tin: type")
+    .Attr("Tout: type")
+    .SetShapeFn([](InferenceContext* c) {
+      ShapeHandle handle;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &handle));
+      return Status::OK();
+    });
+
+REGISTER_OP("LookupTableScatterSubV2")
+    .Input("table_handle: resource")
+    .Input("keys: Tin")
+    .Input("values: Tout")
+    .Attr("Tin: type")
+    .Attr("Tout: type")
+    .SetShapeFn([](InferenceContext* c) {
+      ShapeHandle handle;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &handle));
+      return Status::OK();
+    });
+
 REGISTER_OP("LookupTableRemoveV2")
     .Input("table_handle: resource")
     .Input("keys: Tin")
@@ -377,6 +401,7 @@ REGISTER_OP("MutableHashTableV2")
     });
 
 REGISTER_OP("MutableHashTableOfTensors")
+    .Input("default_value: value_dtype")
     .Output("table_handle: Ref(string)")
     .Attr("container: string = ''")
     .Attr("shared_name: string = ''")
@@ -384,10 +409,13 @@ REGISTER_OP("MutableHashTableOfTensors")
     .Attr("key_dtype: type")
     .Attr("value_dtype: type")
     .Attr("value_shape: shape = {}")
+    .Attr("hash_table_segments: int >= 1")
+    .Attr("tensor_cache_size: int >= 1")
     .SetIsStateful()
     .SetShapeFn(TwoElementOutput);
 
 REGISTER_OP("MutableHashTableOfTensorsV2")
+    .Input("default_value: value_dtype")
     .Output("table_handle: resource")
     .Attr("container: string = ''")
     .Attr("shared_name: string = ''")
@@ -395,6 +423,8 @@ REGISTER_OP("MutableHashTableOfTensorsV2")
     .Attr("key_dtype: type")
     .Attr("value_dtype: type")
     .Attr("value_shape: shape = {}")
+    .Attr("hash_table_segments: int >= 1")
+    .Attr("tensor_cache_size: int >= 1")
     .SetIsStateful()
     .SetShapeFn([](InferenceContext* c) {
       PartialTensorShape value_p;

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -2276,6 +2276,7 @@ py_library(
         ":sparse_ops",
         ":tensor_shape",
         ":variables",
+        ":lookup_ops",
     ],
 )
 

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -5846,6 +5846,9 @@ class GraphKeys(object):
   COND_CONTEXT = "cond_context"
   WHILE_CONTEXT = "while_context"
 
+  # Key for lookup interface
+  MUTABLE_HASH_TABLE = "mutable_hash_table"
+
   # Used to store v2 summary names.
   _SUMMARY_COLLECTION = "_SUMMARY_V2"
 

--- a/tensorflow/python/kernel_tests/embedding_ops_test.py
+++ b/tensorflow/python/kernel_tests/embedding_ops_test.py
@@ -32,6 +32,7 @@ from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import data_flow_ops
 from tensorflow.python.ops import embedding_ops
+from tensorflow.python.ops import gen_lookup_ops
 from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import linalg_ops
@@ -43,7 +44,7 @@ from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 from tensorflow.python.platform import tf_logging
 from tensorflow.python.util import compat
-
+from tensorflow.contrib.lookup import lookup_ops
 
 def _AsLong(array):
   """Casts arrays elements to long type. Used to convert from numpy tf."""

--- a/tensorflow/python/ops/lookup_ops.py
+++ b/tensorflow/python/ops/lookup_ops.py
@@ -126,8 +126,33 @@ class LookupInterface(checkpointable.TrackableResource):
     return self._value_dtype
 
   @property
+  def value_shape(self):
+    """The table value shape."""
+    return NotImplementedError
+
+  @property
   def name(self):
     """The name of the table."""
+    return NotImplementedError
+
+  @property
+  def handle(self):
+    """The handle of the interface"""
+    return NotImplementedError
+
+  @property
+  def op(self):
+    """The op for this table."""
+    return NotImplementedError
+
+  @property
+  def dtype(self):
+    """The dtype for this table"""
+    return NotImplementedError
+
+  @property
+  def trainable(self):
+    """whether the table is trainable"""
     return NotImplementedError
 
   def size(self, name=None):
@@ -1351,9 +1376,12 @@ def index_to_string_table_from_tensor(vocabulary_list,
     # TODO(yleon): Use a more effienct structure.
     return HashTable(init, default_value, shared_name=shared_name, name=scope)
 
+@ops.RegisterGradient("LookupTableFind")
+@ops.RegisterGradient("LookupTableFindV2")
+def _LookupTableFindGrad(op, grad):
+  keys = op.inputs[1]
+  return [ops.IndexedSlices(grad, keys), None, None]
 
-ops.NotDifferentiable("LookupTableFind")
-ops.NotDifferentiable("LookupTableFindV2")
 ops.NotDifferentiable("LookupTableInsert")
 ops.NotDifferentiable("LookupTableInsertV2")
 ops.NotDifferentiable("LookupTableSize")

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -1491,6 +1491,8 @@ def _to_proto_fn(v, export_scope=None):
 def _from_proto_fn(v, import_scope=None):
   """Creates Variable or ResourceVariable from VariableDef as needed."""
   if v.is_resource:
+    if v.resource_type != "":
+      ops.get_from_proto_function(v.resource_type)(v, import_scope)
     return ResourceVariable.from_proto(v, import_scope=import_scope)
   return variables.Variable.from_proto(v, import_scope=import_scope)
 

--- a/tensorflow/python/training/gradient_descent.py
+++ b/tensorflow/python/training/gradient_descent.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python.ops import gen_lookup_ops
 from tensorflow.python.training import optimizer
 from tensorflow.python.training import training_ops
 from tensorflow.python.util.tf_export import tf_export
@@ -68,6 +69,10 @@ class GradientDescentOptimizer(optimizer.Optimizer):
   def _resource_apply_sparse_duplicate_indices(self, grad, handle, indices):
     return resource_variable_ops.resource_scatter_add(
         handle.handle, indices, -grad * self._learning_rate)
+
+  def _lookuptable_apply_sparse_duplicate_indices(self, grad, handle, indices):
+    return gen_lookup_ops.lookup_table_scatter_sub_v2(
+        handle.handle, indices, grad * self._learning_rate)
 
   def _apply_sparse_duplicate_indices(self, grad, var):
     delta = ops.IndexedSlices(


### PR DESCRIPTION
This is a part implementation of issues https://github.com/tensorflow/tensorflow/issues/19324 and https://github.com/tensorflow/tensorflow/issues/24539.

The main idea is making `MutableHashTableOfTensors` trainable and segments the unordered_map in  `MutableHashTableOfTensors` to speed up. In our testing, it can achieve about 80% training speed in 6-maching distribution compared with `MutableDenseHashTable`. But you can add new features to the table flexibility.

Currently, the changes only support `MutableHashTableOfTensors` and imperfect. But can you give some suggestion for the implementation route? 
