### PR TITLE
[CUDA] Fix invalid nvcc configuration

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -1409,9 +1409,11 @@ def _create_local_cuda_repository(repository_ctx):
     # bazel's header check failing.
     cuda_defines["%{extra_no_canonical_prefixes_flags}"] = (
         "flag: \"-fno-canonical-system-headers\"")
-    nvcc_path = "cuda/bin/nvcc"
-    if _is_windows(repository_ctx):
-      nvcc_path += ".exe"
+    nvcc_path = str(
+        repository_ctx.path("%s/bin/nvcc%s" % (
+            cuda_config.cuda_toolkit_path,
+            ".exe" if _is_windows(repository_ctx) else "",
+        )))
     _tpl(
         repository_ctx,
         "crosstool:BUILD",


### PR DESCRIPTION
Commit https://github.com/tensorflow/tensorflow/commit/5bb89f16124ebbcff38a7bd6ec404cfa54ec9b91#diff-15230e5dad94ffaefa7b526c0c1e89e5 fixates nvcc to a certain location which is invalid for various build targets. Restore to original logic.