### PR TITLE
Fix to restore desired blocks-per-core behavior to XLA

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/partition_assignment.cc
+++ b/tensorflow/compiler/xla/service/gpu/partition_assignment.cc
@@ -40,8 +40,13 @@ std::ostream& operator<<(std::ostream& out,
 }
 
 int64 ThreadsPerBlockLimit(const se::DeviceDescription& device_desc) {
-  int64 threads_per_block = device_desc.threads_per_block_limit();
-  if (threads_per_block == 0) {
+  auto threads_per_core = device_desc.threads_per_core_limit();
+  auto blocks_per_core = device_desc.blocks_per_core_limit();
+  int64 threads_per_block;
+  if (threads_per_core != 0 && blocks_per_core != 0) {
+    threads_per_block = device_desc.threads_per_core_limit() /
+                        device_desc.blocks_per_core_limit();
+  } else {
     static std::atomic<int64> log_count{0};
     if (log_count.fetch_add(1) < 8) {
       LOG(WARNING) << "Attempting to calculate launch dimensions for GPU "

--- a/tensorflow/compiler/xla/service/gpu/partition_assignment.cc
+++ b/tensorflow/compiler/xla/service/gpu/partition_assignment.cc
@@ -43,7 +43,7 @@ int64 ThreadsPerBlockLimit(const se::DeviceDescription& device_desc) {
   auto threads_per_core = device_desc.threads_per_core_limit();
   auto blocks_per_core = device_desc.blocks_per_core_limit();
   int64 threads_per_block;
-  if (threads_per_core != 0 && blocks_per_core != 0) {
+  if (threads_per_core > 0 && blocks_per_core > 0) {
     threads_per_block = device_desc.threads_per_core_limit() /
                         device_desc.blocks_per_core_limit();
   } else {

--- a/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
+++ b/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
@@ -1150,7 +1150,7 @@ DeviceDescription *CUDAExecutor::PopulateDeviceDescription() const {
 
   int bpc;
   CUresult result = cuOccupancyMaxActiveBlocksPerMultiprocessor(
-      &bpc, blank_function, 1, (size_t)1);
+      &bpc, blank_function, 1, 1);
   builder.set_blocks_per_core_limit(bpc);
 
   auto built = builder.Build();

--- a/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
+++ b/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
@@ -1154,7 +1154,7 @@ DeviceDescription *CUDAExecutor::PopulateDeviceDescription() const {
   CUresult result = cuOccupancyMaxActiveBlocksPerMultiprocessor(
       &bpc, blank_function, 1, 1);
   if (result != CUDA_SUCCESS) {
-    VLOG(1) << "Failed to calculate max blocks per SM using dummy kernel.";
+    LOG(ERROR) << "Failed to calculate max blocks per SM using dummy kernel.";
     bpc = -1;
   }
   builder.set_blocks_per_core_limit(bpc);

--- a/tensorflow/stream_executor/device_description.cc
+++ b/tensorflow/stream_executor/device_description.cc
@@ -37,6 +37,7 @@ DeviceDescription::DeviceDescription()
                         kUninitializedUint64),
       block_dim_limit_(kUninitializedUint64, kUninitializedUint64,
                        kUninitializedUint64),
+      blocks_per_core_limit_(kUninitializedUint64),
       threads_per_core_limit_(kUninitializedUint64),
       threads_per_block_limit_(kUninitializedUint64),
       threads_per_warp_(kUninitializedUint64),

--- a/tensorflow/stream_executor/device_description.h
+++ b/tensorflow/stream_executor/device_description.h
@@ -78,6 +78,10 @@ class DeviceDescription {
   // legitimate kernel launch request.
   const BlockDim &block_dim_limit() const { return block_dim_limit_; }
 
+  // Returns the limit on the number of simultaneously resident blocks
+  // on a multiprocessor.
+  uint64 blocks_per_core_limit() const { return blocks_per_core_limit_; }
+
   // Returns the limit on the total number of threads that can be launched in a
   // single block; i.e. the limit on x * y * z dimensions of a ThreadDim.
   // This limit affects what constitutes a legitimate kernel launch request.
@@ -174,6 +178,8 @@ class DeviceDescription {
   ThreadDim thread_dim_limit_;
   BlockDim block_dim_limit_;
 
+  uint64 blocks_per_core_limit_;
+
   uint64 threads_per_core_limit_;
   uint64 threads_per_block_limit_;
   uint64 threads_per_warp_;
@@ -235,6 +241,10 @@ class DeviceDescriptionBuilder {
   }
   void set_block_dim_limit(const BlockDim &value) {
     device_description_->block_dim_limit_ = value;
+  }
+
+  void set_blocks_per_core_limit(uint64 value) {
+    device_description_->blocks_per_core_limit_ = value;
   }
 
   void set_threads_per_core_limit(uint64 value) {

--- a/tensorflow/stream_executor/device_description.h
+++ b/tensorflow/stream_executor/device_description.h
@@ -78,7 +78,7 @@ class DeviceDescription {
   // legitimate kernel launch request.
   const BlockDim &block_dim_limit() const { return block_dim_limit_; }
 
-  // Returns the limit on the number of simultaneously resident blocks
+  // Returns the maximum number of simultaneously resident blocks
   // on a multiprocessor.
   uint64 blocks_per_core_limit() const { return blocks_per_core_limit_; }
 


### PR DESCRIPTION
-Fixes unintentional threads per block change introduced in PR #21958
-Calls CUDA occupancy calculator function on dummy PTX kernel so the maximum number of blocks per core is returned.  (A dummy kernel is used here as a workaround because we don't have access to the actual kernel at this point, and the parameters to the occupancy function result in the max blocks per SM as the return value)