### PR TITLE
[INTEL MKL] Fix for failure in //tensorflow/core/kernels:eigen_spatial_convolutions_test

### DIFF
--- a/tensorflow/core/kernels/eigen_spatial_convolutions_test.cc
+++ b/tensorflow/core/kernels/eigen_spatial_convolutions_test.cc
@@ -1605,11 +1605,11 @@ static void PackLhsHelper(int iters,
       /*inner_dim_reordered*/ false,                  //
       /*Alignment*/ 0>;
 
-  using Traits = typename Eigen::internal::gebp_traits<float, float>;
 #if defined(TENSORFLOW_USE_MKLDNN_CONTRACTION_KERNEL)
   using PackLhsImpl = Eigen::internal::mkldnn_gemm_pack<float, Eigen::Index,
                                                         SubMapper, ColMajor>;
 #else
+  using Traits = typename Eigen::internal::gebp_traits<float, float>;
   using PackLhsImpl =
       Eigen::internal::gemm_pack_lhs<float, Eigen::Index, SubMapper,      //
                                      Traits::mr,                          //

--- a/tensorflow/core/kernels/eigen_spatial_convolutions_test.cc
+++ b/tensorflow/core/kernels/eigen_spatial_convolutions_test.cc
@@ -1605,6 +1605,7 @@ static void PackLhsHelper(int iters,
       /*inner_dim_reordered*/ false,                  //
       /*Alignment*/ 0>;
 
+  using Traits = typename Eigen::internal::gebp_traits<float, float>;
 #if defined(TENSORFLOW_USE_MKLDNN_CONTRACTION_KERNEL)
   using PackLhsImpl = Eigen::internal::mkldnn_gemm_pack<float, Eigen::Index,
                                                         SubMapper, ColMajor>;
@@ -1697,9 +1698,9 @@ static void PackLhsHelper(int iters,
     SubMapper sub_mapper =
         input_mappers[filter_idx].getSubMapper(row_offset, col_offset);
 
-    // NOTE: Eigen gemm_pack_lhs accepts contraction depth (k-th dimension) as a
-    // first argument (aka block cols). MKL-DNN pack is generic for lhs and rhs
-    // and accepts block rows and cols in the same order for lhs and rhs.
+// NOTE: Eigen gemm_pack_lhs accepts contraction depth (k-th dimension) as a
+// first argument (aka block cols). MKL-DNN pack is generic for lhs and rhs
+// and accepts block rows and cols in the same order for lhs and rhs.
 #if defined(TENSORFLOW_USE_MKLDNN_CONTRACTION_KERNEL)
     pack_lhs(packed.data() + packed_offset, sub_mapper, rows, cols);
 #else


### PR DESCRIPTION
Added missing definition to fix compilation errors when using --config=mkl  + Fixes for clang format errors.