### PR TITLE
Add details for running tests from nightly build images. Closes #24993.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,10 @@ There are two ways to run TensorFlow unit tests.
    for the required packages. Alternatively, use the said
    [Docker images](https://hub.docker.com/r/tensorflow/tensorflow/tags/), e.g.,
    `tensorflow/tensorflow:nightly-devel` and `tensorflow/tensorflow:nightly-devel-gpu`
-   for development to avoid installing the packages directly on your system.
+   for development to avoid installing the packages directly on your system (in
+   which case remember to change directory from `/root` to `/tensorflow` once
+   you get into the running container so `bazel` can find the `tensorflow`
+   workspace).
 
    Once you have the packages installed, you can run a specific unit test in
    bazel by doing as follows:


### PR DESCRIPTION
The current documentation guidelines throw an error after running the
commands in the tensorflow nightly build container. Following this
Magenta issue:

https://github.com/tensorflow/magenta/issues/1232

running the test requires changing directory. Rather than changing the
WORKDIR in the image, which would probably affect many uses and users,
this change adds the direction of changing directory after mentioning
the nightly build image.