### PR TITLE
Remove enum34 from bazel BUILD file for pip package

### DIFF
--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -159,7 +159,6 @@ filegroup(
         "@curl//:COPYING",
         "@double_conversion//:LICENSE",
         "@eigen_archive//:COPYING.MPL2",
-        "@enum34_archive//:LICENSE",
         "@farmhash_archive//:COPYING",
         "@fft2d//:fft/readme.txt",
         "@flatbuffers//:LICENSE.txt",


### PR DESCRIPTION
Attempt to fix the error:
```
tensorflow/tools/pip_package/BUILD:240:1: //tensorflow/tools/pip_package:build_pip_package: missing input file '@enum34_archive//:LICENSE'
```
As it's happening here:
https://source.cloud.google.com/results/invocations/1b52e710-ee08-4aeb-986f-5dffaeb2fc26/log