### PR TITLE
[r1.13] Update kinesis dataset to match v2 API

### DIFF
--- a/tensorflow/contrib/kinesis/python/ops/kinesis_dataset_ops.py
+++ b/tensorflow/contrib/kinesis/python/ops/kinesis_dataset_ops.py
@@ -71,7 +71,6 @@ class KinesisDataset(dataset_ops.DatasetSource):
       interval: The interval for the Kinesis Client to wait before
         it tries to get records again (in millisecond).
     """
-    super(KinesisDataset, self).__init__()
     self._stream = ops.convert_to_tensor(
         stream, dtype=dtypes.string, name="stream")
     self._shard = ops.convert_to_tensor(
@@ -80,6 +79,7 @@ class KinesisDataset(dataset_ops.DatasetSource):
         read_indefinitely, dtype=dtypes.bool, name="read_indefinitely")
     self._interval = ops.convert_to_tensor(
         interval, dtype=dtypes.int64, name="interval")
+    super(KinesisDataset, self).__init__(self._as_variant_tensor())
 
   def _as_variant_tensor(self):
     return gen_dataset_ops.kinesis_dataset(


### PR DESCRIPTION
**NOTE: This PR is to r1.13 branch and cherry-picked from #24903.**

Note also that #24899 may need to be cherry-picked as well to conform to the tf.data API changes in 1.13.

Since DatasetSource now requires varient_tensor to be passed into constructor,
the kinesis data will need to be updated to fix the incompatibility issue.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>