### PR TITLE
Allow tf.contrib.tpu._prepare_validation_data to modify x,y

### DIFF
--- a/tensorflow/contrib/tpu/python/tpu/keras_support.py
+++ b/tensorflow/contrib/tpu/python/tpu/keras_support.py
@@ -1617,7 +1617,7 @@ class KerasTPUModel(models.Model):
         validation_split=validation_split)
 
     # Prepare validation data
-    val_x, val_y, val_sample_weights = self._prepare_validation_data(
+    x, y, val_x, val_y, val_sample_weights = self._prepare_validation_data(
         validation_data, validation_split, validation_steps, x, y,
         sample_weights, batch_size)
     return self._pipeline_fit_loop(
@@ -1910,7 +1910,7 @@ class KerasTPUModel(models.Model):
       batch_size: The training batch size (if provided)
 
     Returns:
-      A 3-tuple of (val_x, val_y, val_sample_weights).
+      A 5-tuple of (x, y, val_x, val_y, val_sample_weights).
 
     Raises:
       ValueError: If the provided arguments are not compatible with
@@ -1967,7 +1967,7 @@ class KerasTPUModel(models.Model):
       val_y = None
       val_sample_weights = None
 
-    return val_x, val_y, val_sample_weights
+    return x, y, val_x, val_y, val_sample_weights
 
   def predict(self,
               x,


### PR DESCRIPTION
When the user passes a validation_split parameter, the samples allocated to the val_x, val_y populations should be removed from the training data set (x, y).  In the _prepare_validation_split function, the validation split parameter branch already creates the correctly truncated x, y but does not return those modified x, y values back.  As a result, the validation samples are in both the training data set and the validation data sets. The validation loss/metrics are giving artificially good results since the model is training also the samples in the validation set.

Fixes #25034 