### PR TITLE
Provide a better error output with incorrect input for tf.keras.layers.Dot

### DIFF
--- a/tensorflow/python/keras/utils/tf_utils.py
+++ b/tensorflow/python/keras/utils/tf_utils.py
@@ -210,9 +210,14 @@ def convert_shapes(input_shape, to_tuples=True):
       return True
     if isinstance(input_shape, tensor_shape.TensorShape):
       return True
-    if (isinstance(input_shape, (tuple, list)) and
-        all(_is_shape_component(ele) for ele in input_shape)):
-      return True
+    if isinstance(input_shape, (tuple, list)):
+      # In case _is_shape_component is not valid, it may also
+      # throw out TypeError so we catch TypeError here.
+      try:
+        if all(_is_shape_component(ele) for ele in input_shape):
+          return True
+      except TypeError:
+        pass
     return False
 
   def _convert_shape(input_shape):


### PR DESCRIPTION
This fix tries to address the issue raised in #25049 where the error output
was not very clear when incorrect input was passed for tf.keras.layers.Dot.
When tuple instead of list was passed, the following erorr shwon up:
```
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/framework/tensor_shape.py", line 187, in __init__
    self._value = int(value)
TypeError: int() argument must be a string or a number, not 'TensorShapeV1'
```

This fix catch the TypeError so that correct error message could be returned:
```
ValueError: A `Dot` layer should be called on a list of 2 inputs.
```

This fix fixes #25049.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>