### PR TITLE
Allow non-standard CUDA SDK installation directory when using clang as CUDA compiler

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -1235,17 +1235,18 @@ def _use_cuda_clang(repository_ctx):
   return _flag_enabled(repository_ctx, "TF_CUDA_CLANG")
 
 
-def _compute_cuda_extra_copts(repository_ctx, compute_capabilities):
+def _compute_cuda_extra_copts(repository_ctx, compute_capabilities, cuda_toolkit_path):
   if _use_cuda_clang(repository_ctx):
-    capability_flags = [
+    flags = [
         "--cuda-gpu-arch=sm_" + cap.replace(".", "")
         for cap in compute_capabilities
     ]
+    flags.append("--cuda-path=%s" % cuda_toolkit_path)
   else:
     # Capabilities are handled in the "crosstool_wrapper_driver_is_not_gcc" for nvcc
     # TODO(csigg): Make this consistent with cuda clang and pass to crosstool.
-    capability_flags = []
-  return str(capability_flags)
+    flags = []
+  return str(flags)
 
 
 def _create_local_cuda_repository(repository_ctx):
@@ -1325,6 +1326,7 @@ def _create_local_cuda_repository(repository_ctx):
               _compute_cuda_extra_copts(
                   repository_ctx,
                   cuda_config.compute_capabilities,
+                  cuda_config.cuda_toolkit_path,
               ),
       },
   )
@@ -1505,6 +1507,7 @@ def _create_remote_cuda_repository(repository_ctx, remote_config_repo):
               _compute_cuda_extra_copts(
                   repository_ctx,
                   compute_capabilities(repository_ctx),
+                  cuda_toolkit_path(repository_ctx),
               ),
       },
   )


### PR DESCRIPTION
This fixes the following error when using clang as the CUDA compiler with a non-standard CUDA SDK installation directory by setting cuda-path to CUDA_TOOLKIT_PATH (as outlined here: https://llvm.org/docs/CompileCudaWithLLVM.html):

```
ERROR: /user_data/.tmp/cache.srbo/bazel/_bazel_srbo/96431eb3bb8da25a1741c1c1ac91e19b/external/nccl_archive/BUILD.bazel:33:1: C++ compilation of rule '@nccl_archive//:nccl' failed (Exit 1): clang failed: error executing command 
  (cd /user_data/.tmp/cache.srbo/bazel/_bazel_srbo/96431eb3bb8da25a1741c1c1ac91e19b/execroot/org_tensorflow && \
  exec env - \
    CLANG_CUDA_COMPILER_PATH=/builds/clang/5.0.1/771843fbd0/bin/clang \
    CUDA_TOOLKIT_PATH=/builds/cuda/8.0.61/68e269425a \
    CUDNN_INSTALL_PATH=/builds/cudnn/7/4fdffde0c4 \
    LD_LIBRARY_PATH=/builds/gcc/4.9.4/12a8bec7dd/lib64:/builds/gcc/4.9.4/12a8bec7dd/lib:/builds/ncurses/5.9/7514ad76af/lib:/builds/readline/6.0/19c81cf560/lib:/builds/python/2.7.8/db3474c23a/lib:/builds/hdf5/1.8.14/22c15aa4cc/lib:/builds/intel_mkl/11.1.3/53d6c44ec1/lib:/builds/cuda/8.0.61/68e269425a/lib64:/builds/cuda/8.0.61/68e269425a/lib:/builds/cudnn/7/4fdffde0c4/lib64:/builds/llvm/5.0.1/8294c740c5/lib:/builds/clang/5.0.1/771843fbd0/lib \
    PATH=/builds/gcc/4.9.4/12a8bec7dd/bin:/builds/ncurses/5.9/7514ad76af/bin:/builds/python/2.7.8/db3474c23a/bin:/builds/python_setuptools/18.2/effab46b3c/bin:/builds/hdf5/1.8.14/22c15aa4cc/bin:/builds/python_cython/0.22.1/a0ebdb4b77/bin:/builds/python_numpy/1.9.2/dec6a1e459/bin:/builds/python_wheel/0.32.3/5ea8be18ae/bin:/builds/cuda/8.0.61/68e269425a/bin:/builds/openjdk/1.8.0/4a629ebe98/bin:/builds/bazel/0.18.0/08c43177ba/bin:/builds/llvm/5.0.1/8294c740c5/bin:/builds/clang/5.0.1/771843fbd0/bin:/builds/dneg_bobtools/1.5.0/ea7a1f49e0/bin:/builds/app_wrappers/27deea27ba/bin:/bin:/usr/bin:/usr/sbin:/sbin:/etc:/usr/etc:/usr/local/bin:/usr/bin/X11 \
    PWD=/proc/self/cwd \
    PYTHONPATH=/builds/python_sitecustomize/720267664e/lib/python:/builds/python/2.7.8/db3474c23a/lib/python2.7/site-packages:/builds/python_setuptools/18.2/effab46b3c/lib/python:/builds/python_enum34/1.1.6/ac652bf4db/lib/python:/builds/python_cython/0.22.1/a0ebdb4b77/lib/python:/builds/python_numpy/1.9.2/dec6a1e459/lib/python:/builds/python_six/1.11.0/46e57fd0ea/lib/python:/builds/python_h5py/2.5.0/a63bb4b8bc/lib/python:/builds/python_keras_applications/1.0.6/e8b5c55fe4/lib/python:/builds/python_keras_preprocessing/1.0.5/a82d888721/lib/python:/builds/python_mock/1.0.1/bc8f23773f/lib/python:/builds/python_wheel/0.32.3/5ea8be18ae/lib/python:/builds/clang/5.0.1/771843fbd0/lib/python:/builds/dneg_bobtools/1.5.0/ea7a1f49e0/lib/python:/builds/dneg_bobhelper/1.0.0/bf3f7e07dc/lib/python \
    PYTHON_BIN_PATH=/builds/python/2.7.8/db3474c23a/bin/python \
    PYTHON_LIB_PATH=/builds/python/2.7.8/db3474c23a/lib/python2.7/site-packages \
    TF_CUDA_CLANG=1 \
    TF_CUDA_COMPUTE_CAPABILITIES=3.5,5.2,6.0,6.1 \
    TF_CUDA_VERSION=8.0 \
    TF_CUDNN_VERSION=7 \
    TF_DOWNLOAD_CLANG=0 \
    TF_NCCL_VERSION=1 \
    TF_NEED_CUDA=1 \
    TF_NEED_OPENCL_SYCL=0 \
    TF_NEED_ROCM=0 \
  /builds/clang/5.0.1/771843fbd0/bin/clang -MD -MF bazel-out/k8-opt/bin/external/nccl_archive/_objs/nccl/core.cu.pic.d '-frandom-seed=bazel-out/k8-opt/bin/external/nccl_archive/_objs/nccl/core.cu.pic.o' -iquote external/nccl_archive -iquote bazel-out/k8-opt/genfiles/external/nccl_archive -iquote bazel-out/k8-opt/bin/external/nccl_archive -iquote external/local_config_cuda -iquote bazel-out/k8-opt/genfiles/external/local_config_cuda -iquote bazel-out/k8-opt/bin/external/local_config_cuda -iquote external/bazel_tools -iquote bazel-out/k8-opt/genfiles/external/bazel_tools -iquote bazel-out/k8-opt/bin/external/bazel_tools -Ibazel-out/k8-opt/bin/external/nccl_archive/_virtual_includes/nccl -isystem external/local_config_cuda/cuda -isystem bazel-out/k8-opt/genfiles/external/local_config_cuda/cuda -isystem bazel-out/k8-opt/bin/external/local_config_cuda/cuda -isystem external/local_config_cuda/cuda/cuda/include -isystem bazel-out/k8-opt/genfiles/external/local_config_cuda/cuda/cuda/include -isystem bazel-out/k8-opt/bin/external/local_config_cuda/cuda/cuda/include -isystem external/local_config_cuda/cuda/cuda/include/crt -isystem bazel-out/k8-opt/genfiles/external/local_config_cuda/cuda/cuda/include/crt -isystem bazel-out/k8-opt/bin/external/local_config_cuda/cuda/cuda/include/crt '-std=c++11' -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -fPIC -U_FORTIFY_SOURCE '-D_FORTIFY_SOURCE=1' -fstack-protector -Wall -Wno-invalid-partial-specialization -fno-omit-frame-pointer -no-canonical-prefixes -DNDEBUG -g0 -O2 -ffunction-sections -fdata-sections '-DCUDA_MAJOR=0' '-DCUDA_MINOR=0' '-DNCCL_MAJOR=0' '-DNCCL_MINOR=0' '-DNCCL_PATCH=0' -Iexternal/nccl_archive/src -O3 -x cuda '-DGOOGLE_CUDA=1' '--cuda-gpu-arch=sm_35' '--cuda-gpu-arch=sm_52' '--cuda-gpu-arch=sm_60' '--cuda-gpu-arch=sm_61' -c bazel-out/k8-opt/genfiles/external/nccl_archive/src/core.cu.cc -o bazel-out/k8-opt/bin/external/nccl_archive/_objs/nccl/core.cu.pic.o)
clang: error: cannot find libdevice for sm_35. Provide path to different CUDA installation via --cuda-path, or pass -nocudalib to build without linking with libdevice.
clang: error: cannot find CUDA installation.  Provide its path via --cuda-path, or pass -nocudainc to build without CUDA includes.
clang: error: cannot find libdevice for sm_52. Provide path to different CUDA installation via --cuda-path, or pass -nocudalib to build without linking with libdevice.
clang: error: cannot find CUDA installation.  Provide its path via --cuda-path, or pass -nocudainc to build without CUDA includes.
clang: error: cannot find libdevice for sm_60. Provide path to different CUDA installation via --cuda-path, or pass -nocudalib to build without linking with libdevice.
clang: error: cannot find CUDA installation.  Provide its path via --cuda-path, or pass -nocudainc to build without CUDA includes.
clang: error: cannot find libdevice for sm_61. Provide path to different CUDA installation via --cuda-path, or pass -nocudalib to build without linking with libdevice.
clang: error: cannot find CUDA installation.  Provide its path via --cuda-path, or pass -nocudainc to build without CUDA includes.
clang: error: cannot find CUDA installation.  Provide its path via --cuda-path, or pass -nocudainc to build without CUDA includes.
Target //tensorflow/tools/pip_package:build_pip_package failed to build
INFO: Elapsed time: 74.398s, Critical Path: 16.08s
INFO: 512 processes: 512 local.
FAILED: Build did NOT complete successfully
```

Built using:
`bazel build --distdir=distdir --action_env=PYTHONPATH --distinct_host_configuration=false //tensorflow/tools/pip_package:build_pip_package`

