### PR TITLE
[GPU][ROCm] Fix copy rules for ROCm path

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -1193,7 +1193,7 @@ def make_copy_dir_rule(repository_ctx, name, src_dir, out_dir):
     outs = [
 %s
     ],
-    cmd = \"""cp -rf "%s/." "%s/" \""",
+    cmd = \"""cp -rLf "%s/." "%s/" \""",
 )""" % (name, "\n".join(outs), src_dir, out_dir)
 
 def _read_dir(repository_ctx, src_dir):

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -580,13 +580,13 @@ def _create_local_rocm_repository(repository_ctx):
         ),
         make_copy_dir_rule(
             repository_ctx,
-            name = "rocm-blas",
+            name = "rocblas-include",
             src_dir = rocm_toolkit_path + "/rocblas/include",
             out_dir = "rocm/include/rocblas",
         ),
         make_copy_dir_rule(
             repository_ctx,
-            name = "rocm-miopen",
+            name = "miopen-include",
             src_dir = rocm_toolkit_path + "/miopen/include",
             out_dir = "rocm/include/miopen",
         ),


### PR DESCRIPTION
Addressed one bazel change in upstream TensorFlow:

commit 5bb89f16124ebbcff38a7bd6ec404cfa54ec9b91

The logic for the commit was sound, but didn't taken much consideration on the layout of ROCm header files. Fixed it in this PR.

Fix incorrect targets for ROCm headers, and how ROCm headers are copied into
execroot.