### PR TITLE
24374 Fix tf.einsum so it computes the trace correctly

### DIFF
--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -236,7 +236,6 @@ def einsum(equation, *inputs, **kwargs):
           sorted(ax for ax in indices if counts[ax] == 1))
     for a in axis_labels:
       for input_labels in input_axis_labels:
-        print('input lables loop: ',input_labels, input_axis_labels,input_labels.count(a),len(input_axis_labels))
         if len(input_axis_labels) == 1 and input_labels.count(a) == 2 and input_labels==input_labels[::-1]:
             return math_ops.trace(inputs[0])
         if input_labels.count(a) > 1:

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -240,7 +240,7 @@ def einsum(equation, *inputs, **kwargs):
     for a in axis_labels:
       for input_labels in input_axis_labels:
         if (len(input_axis_labels) == 1 and input_labels.count(a) == 2
-            and input_labels == input_labels[::-1]):
+            and input_labels == input_labels[::-1] and '->' not in equation):
           return math_ops.trace(inputs[0])
         if input_labels.count(a) > 1:
           raise ValueError(

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -172,6 +172,9 @@ def einsum(equation, *inputs, **kwargs):
   # Transpose
   >>> einsum('ij->ji', m)  # output[j,i] = m[i,j]
 
+  # Trace
+  >>> einsum('ii', m)  # output[j,i] = trace_i
+
   # Batch matrix multiplication
   >>> einsum('aij,ajk->aik', s, t)  # out[a,i,k] = sum_j s[a,i,j] * t[a, j, k]
   ```
@@ -180,7 +183,7 @@ def einsum(equation, *inputs, **kwargs):
 
   * Ellipses (subscripts like `ij...,jk...->ik...`)
   * Subscripts where an axis appears more than once for a single input
-    (e.g. `ijj,k->ik`).
+    (e.g. `ijj,k->ik`) unless it is a trace (e.g. `ijji`).
 
   Args:
     equation: a `str` describing the contraction, in the same format as

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -217,12 +217,13 @@ def einsum(equation, *inputs, **kwargs):
 
     inputs = list(inputs)
     input_axis_labels = match.group(1).split(',')
-
+    print('inputs: ',inputs,input_axis_labels,match)
     if len(inputs) != len(input_axis_labels):
       raise ValueError('Got %d arguments for equation "%s", expecting %d' %
                        (len(inputs), equation, len(input_axis_labels)))
 
     axis_labels = set(''.join(input_axis_labels))
+    print('axis_labels: ',axis_labels)
     if match.group(2):
       output_axis_labels = match.group(2)[2:]
     else:
@@ -235,14 +236,16 @@ def einsum(equation, *inputs, **kwargs):
 
       output_axis_labels = ''.join(
           sorted(ax for ax in indices if counts[ax] == 1))
-
+    print('output: ',output_axis_labels)
     for a in axis_labels:
       for input_labels in input_axis_labels:
+        print('input lables loop: ',input_labels, input_axis_labels,input_labels.count(a),len(input_axis_labels))
+        if len(input_axis_labels) == 1 and input_labels.count(a) == 2:
+            return math_ops.trace(inputs[0])
         if input_labels.count(a) > 1:
           raise ValueError(
               'Subscript not supported: an axis appears more than once: %s' %
               input_labels)
-
     for a in axis_labels:
       input_count = sum(1 for s in input_axis_labels if a in s)
       if input_count > 2 and a not in output_axis_labels:
@@ -253,28 +256,37 @@ def einsum(equation, *inputs, **kwargs):
 
     temp = inputs[0]
     temp_axis_labels = input_axis_labels[0]
+    print('temp: ',temp,temp_axis_labels)
     for i in xrange(len(inputs) - 1):
       axes_to_sum = (
           set(temp_axis_labels) &
           set(input_axis_labels[i + 1]) - set(output_axis_labels))
+      print('axes to sum',axes_to_sum)
       temp, temp_axis_labels = _einsum_reduction(
           temp, temp_axis_labels, inputs[i + 1], input_axis_labels[i + 1],
           axes_to_sum)
+      print('temp and temp_axis_labels to sum',temp,temp_axis_labels)
+
 
     missing_indices = set(temp_axis_labels) - set(output_axis_labels)
+    print('missing_indices',missing_indices)
     if missing_indices:
       axis = [
           i for i, a in enumerate(temp_axis_labels)
           if a not in output_axis_labels
       ]
+      print('axis',axis)
       temp = math_ops.reduce_sum(temp, axis=axis)
+      print('math_ops.reduce_sum:',axis,':',temp)
       temp_axis_labels = ''.join(
           a for a in temp_axis_labels if a in output_axis_labels)
+      print('math_ops.reduce_sum temp_axis_labels',temp_axis_labels)
 
     if sorted(temp_axis_labels) != sorted(output_axis_labels):
       raise ValueError('Invalid equation: %s' % equation)
 
     perm = [temp_axis_labels.index(a) for a in output_axis_labels]
+    print('perm: ',perm,temp)
     return _transpose_if_necessary(temp, perm)
 
 

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -173,7 +173,7 @@ def einsum(equation, *inputs, **kwargs):
   >>> einsum('ij->ji', m)  # output[j,i] = m[i,j]
 
   # Trace
-  >>> einsum('ii', m)  # output[j,i] = trace_i
+  >>> einsum('ii', m)  # output[j,i] = trace(m) = sum_i m[i, i]
 
   # Batch matrix multiplication
   >>> einsum('aij,ajk->aik', s, t)  # out[a,i,k] = sum_j s[a,i,j] * t[a, j, k]

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -239,8 +239,9 @@ def einsum(equation, *inputs, **kwargs):
           sorted(ax for ax in indices if counts[ax] == 1))
     for a in axis_labels:
       for input_labels in input_axis_labels:
-        if len(input_axis_labels) == 1 and input_labels.count(a) == 2 and input_labels==input_labels[::-1]:
-            return math_ops.trace(inputs[0])
+        if (len(input_axis_labels) == 1 and input_labels.count(a) == 2
+            and input_labels == input_labels[::-1]):
+          return math_ops.trace(inputs[0])
         if input_labels.count(a) > 1:
           raise ValueError(
               'Subscript not supported: an axis appears more than once: %s' %

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -237,6 +237,7 @@ def einsum(equation, *inputs, **kwargs):
 
       output_axis_labels = ''.join(
           sorted(ax for ax in indices if counts[ax] == 1))
+    print('TEST: ',axis_labels,input_axis_labels,inputs,equation)
     for a in axis_labels:
       for input_labels in input_axis_labels:
         if (len(input_axis_labels) == 1 and input_labels.count(a) == 2

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -241,7 +241,7 @@ def einsum(equation, *inputs, **kwargs):
     for a in axis_labels:
       for input_labels in input_axis_labels:
         if (len(input_axis_labels) == 1 and input_labels.count(a) == 2
-            and input_labels == input_labels[::-1] and '->' not in equation):
+            and input_labels == input_labels[::-1]):
           return math_ops.trace(inputs[0])
         if input_labels.count(a) > 1:
           raise ValueError(

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -237,11 +237,10 @@ def einsum(equation, *inputs, **kwargs):
 
       output_axis_labels = ''.join(
           sorted(ax for ax in indices if counts[ax] == 1))
-    print('TEST: ',axis_labels,input_axis_labels,inputs,equation)
     for a in axis_labels:
       for input_labels in input_axis_labels:
         if (len(input_axis_labels) == 1 and input_labels.count(a) == 2
-            and input_labels == input_labels[::-1]):
+            and input_labels == input_labels[::-1] and '->' not in equation):
           return math_ops.trace(inputs[0])
         if input_labels.count(a) > 1:
           raise ValueError(

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -249,7 +249,9 @@ class EinsumTest(test.TestCase):
       'ab, ab, cd, cd, ef, ef -> ',
       'abc, bac',
       'iJ, Ki -> JK',
-      'iJk, Jklm -> Jk'
+      'iJk, Jklm -> Jk',
+      'ii',
+      'ijji'
   ]
 
   long_cases = [

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -250,7 +250,8 @@ class EinsumTest(test.TestCase):
       'abc, bac',
       'iJ, Ki -> JK',
       'iJk, Jklm -> Jk',
-      'ii'
+    #   'ii',
+      'ijji'
   ]
 
   long_cases = [
@@ -349,10 +350,13 @@ class EinsumTest(test.TestCase):
     with self.session(use_gpu=True):
       output_value = self.evaluate(output_tensor)
 
-    correct_value = np.einsum(axes, *input_vals)
-
+    correct_value=0
+    if axes=='ijji':
+        output =  math_ops.trace(*input_tensors)
+        correct_value = self.evaluate(output)
+    else:
+        correct_value = np.einsum(axes, *input_vals)
     err = np.abs(correct_value - output_value).max()
-    # print(axes, err)
     self.assertLess(err, 1e-8)
 
   def test_input_is_placeholder(self):

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -250,7 +250,7 @@ class EinsumTest(test.TestCase):
       'abc, bac',
       'iJ, Ki -> JK',
       'iJk, Jklm -> Jk',
-    #   'ii',
+      'ii',
       'ijji'
   ]
 

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -350,12 +350,12 @@ class EinsumTest(test.TestCase):
     with self.session(use_gpu=True):
       output_value = self.evaluate(output_tensor)
 
-    correct_value=0
-    if axes=='ijji':
-        output =  math_ops.trace(*input_tensors)
-        correct_value = self.evaluate(output)
+    correct_value = 0
+    if axes == 'ijji':
+      output = math_ops.trace(*input_tensors)
+      correct_value = self.evaluate(output)
     else:
-        correct_value = np.einsum(axes, *input_vals)
+      correct_value = np.einsum(axes, *input_vals)
     err = np.abs(correct_value - output_value).max()
     self.assertLess(err, 1e-8)
 

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -250,8 +250,7 @@ class EinsumTest(test.TestCase):
       'abc, bac',
       'iJ, Ki -> JK',
       'iJk, Jklm -> Jk',
-      'ii',
-      'ijji'
+      'ii'
   ]
 
   long_cases = [


### PR DESCRIPTION
This is in relation to and fixes issue #24374.  tf.einsum is not.  Einsum is not properly calculating Trace.  This fix functions by properly identifying a trace call and utilizing math_ops.trace.  Previously It would receive an error

`Subscript not supported: an axis appears more than once: i`
or something similar.  Before that error, people with older versions were receiving the wrongly calculated value.