### PR TITLE
Fix a memory leak in MklDnnData.

### DIFF
--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1766,6 +1766,7 @@ class MklDnnData {
   inline void SetUsrMem(const memory::primitive_desc& pd,
                         void* data_buffer = nullptr) {
     CHECK_NOTNULL(cpu_engine_);
+    if (user_memory_) delete user_memory_;
     // TODO(nhasabni): can we remove dynamic memory allocation?
     if (data_buffer) {
       user_memory_ = new memory(pd, data_buffer);


### PR DESCRIPTION
This commit fixes leak caused by field user_memory_, which I can repro
and verify. From reading the code, I think the same leak may happen to
fields like reorder_memory_. Since I cannot repro or verify the later,
I'll leave it the authors.