### PR TITLE
TF Keras slice_arrays object is not subscriptable problem fix

### DIFF
--- a/tensorflow/python/keras/utils/generic_utils.py
+++ b/tensorflow/python/keras/utils/generic_utils.py
@@ -140,8 +140,7 @@ def serialize_keras_object(instance):
                                             instance.get_config())
   if hasattr(instance, '__name__'):
     return instance.__name__
-  else:
-    raise ValueError('Cannot serialize', instance)
+  raise ValueError('Cannot serialize', instance)
 
 
 def class_and_config_for_serialized_keras_object(
@@ -272,8 +271,7 @@ def func_load(code, defaults=None, closure=None, globs=None):
     cell_value = dummy_fn.__closure__[0]
     if not isinstance(value, type(cell_value)):
       return cell_value
-    else:
-      return value
+    return value
 
   if closure is not None:
     closure = tuple(ensure_value_to_cell(_) for _ in closure)
@@ -526,17 +524,17 @@ def slice_arrays(arrays, start=None, stop=None):
       if hasattr(start, 'shape'):
         start = start.tolist()
       return [None if x is None else x[start] for x in arrays]
-    else:
-      return [None if x is None else x[start:stop] for x in arrays]
+    return [None if x is None
+            else None if not hasattr(x, '__getitem__')
+            else x[start:stop] for x in arrays]
   else:
     if hasattr(start, '__len__'):
       if hasattr(start, 'shape'):
         start = start.tolist()
       return arrays[start]
-    elif hasattr(start, '__getitem__'):
+    if hasattr(start, '__getitem__'):
       return arrays[start:stop]
-    else:
-      return [None]
+    return [None]
 
 
 def to_list(x):

--- a/tensorflow/python/keras/utils/generic_utils_test.py
+++ b/tensorflow/python/keras/utils/generic_utils_test.py
@@ -81,5 +81,18 @@ class SerializeKerasObjectTest(test.TestCase):
     self.assertEqual(deserialized, None)
 
 
+class SliceArraysTest(test.TestCase):
+
+  def test_slice_arrays(self):
+    input_a = list([1, 2, 3])
+    self.assertEqual(keras.utils.generic_utils.slice_arrays(input_a, start=0),
+                     [None, None, None])
+    self.assertEqual(keras.utils.generic_utils.slice_arrays(input_a, stop=3),
+                     [None, None, None])
+    self.assertEqual(keras.utils.generic_utils.slice_arrays(
+        input_a, start=0, stop=1),
+                     [None, None, None])
+
+
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
slice_arrays method fails to slice when receive arrays contains object not subscriptable.

Issue Reproduction:
tensorflow.python.keras.utils.generic_utils.slice_arrays(list([1, 2, 3], start=0, stop=1)