### PR TITLE
docs(gan): fix tutorial link for ipythonnotebook

### DIFF
--- a/tensorflow/contrib/gan/README.md
+++ b/tensorflow/contrib/gan/README.md
@@ -57,7 +57,7 @@ These include the following main pieces (explained in detail below).
     generative models.
 
 *   [examples](https://github.com/tensorflow/models/tree/master/research/gan/)
-    and [tutorial](http://https://github.com/tensorflow/models/tree/master/research/gan/tutorial.ipynb): See examples of how to use TF-GAN
+    and [tutorial](https://github.com/tensorflow/models/tree/master/research/gan/tutorial.ipynb): See examples of how to use TF-GAN
     to make GAN training easier, or use the more complicated examples to
     jumpstart your own project. These include unconditional and conditional
     GANs, InfoGANs, adversarial losses on existing networks, and image-to-image


### PR DESCRIPTION
Closes #25101

Fix the link in **tensorflow/contrib/gan/README.md**, line 60