### PR TITLE
Fix import of tools/bazel.rc for Bazel 0.19.0 or later

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1559,6 +1559,8 @@ def main():
   check_bazel_version('0.19.0', '0.21.0')
 
   reset_tf_configure_bazelrc()
+  # Explicitly import tools/bazel.rc, this is needed for Bazel 0.19.0 or later
+  write_to_bazelrc('import %workspace%/tools/bazel.rc')
 
   cleanup_makefile()
   setup_python(environ_cp)


### PR DESCRIPTION
This was removed in https://github.com/tensorflow/tensorflow/pull/22964/files which causes build errors with bazel 0.20.0 because tools/bazel.rc is ignored so the grpc_no_ares=true flag doesn't get set and grpc is compiled with c-ares support:

```
ERROR: /user_data/.tmp/cache.srbo/bazel/_bazel_srbo/96431eb3bb8da25a1741c1c1ac91e19b/external/grpc/BUILD:1332:1: C++ compilation of rule '@grpc//:grpc_resolver_dns_ares' failed (Exit 1) gcc failed: error executing command /builds/gcc/4.9.4/12a8bec7dd/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG ... (remaining 56 argument(s) skipped) 

  

Use --sandbox_debug to see verbose messages from the sandbox 

external/grpc/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc:30:18: fatal error: ares.h: No such file or directory 

#include <ares.h> 

                  ^ 

compilation terminated. 

Target //tensorflow/tools/pip_package:build_pip_package failed to build 

Use --verbose_failures to see the command lines of failed build steps. 

INFO: Elapsed time: 98.819s, Critical Path: 17.24s 

INFO: 750 processes: 2 local, 748 processwrapper-sandbox. 

FAILED: Build did NOT complete successfully
```

Re-adding this line fixes the issue.