### PR TITLE
[tflite] fix the location of build_ios_universal_lib.sh in TFLite bechmark doc

### DIFF
--- a/tensorflow/lite/tools/benchmark/ios/README.md
+++ b/tensorflow/lite/tools/benchmark/ios/README.md
@@ -24,7 +24,7 @@ to build TFLite.
 Running
 
 ```bash
-tensorflow/lite/build_ios_universal_lib.sh
+tensorflow/lite/tools/make/build_ios_universal_lib.sh
 ```
 will also build `tensorflow/lite/gen/lib/benchmark-lib.a` .
 


### PR DESCRIPTION
fix the location of build_ios_universal_lib.sh in TFLite benchmark for iOS README.md