### PR TITLE
Lite: Floor-Div different datatypes supported

### DIFF
--- a/tensorflow/lite/kernels/floor_div.cc
+++ b/tensorflow/lite/kernels/floor_div.cc
@@ -64,9 +64,16 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, input1->type, input2->type);
 
   const TfLiteType type = input1->type;
-  if (type != kTfLiteInt32) {
-    context->ReportError(context, "Currently floor_div only supports int32.");
-    return kTfLiteError;
+  switch (type) {
+    case kTfLiteFloat32:
+    case kTfLiteInt32:
+    case kTfLiteUInt8:
+    case kTfLiteInt64:
+      break;
+    default:
+      context->ReportError(context, "Type '%s' is not supported by floor_div.",
+                           TfLiteTypeGetName(type));
+      return kTfLiteError;
   }
   output->type = type;
 
@@ -123,8 +130,21 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       return EvalImpl<int32_t>(context, data->requires_broadcast, input1,
                                input2, output);
     }
+    case kTfLiteFloat32: {
+      return EvalImpl<float>(context, data->requires_broadcast, input1, input2,
+                             output);
+    }
+    case kTfLiteUInt8: {
+      return EvalImpl<uint8_t>(context, data->requires_broadcast, input1,
+                               input2, output);
+    }
+    case kTfLiteInt64: {
+      return EvalImpl<int64_t>(context, data->requires_broadcast, input1,
+                               input2, output);
+    }
     default: {
-      context->ReportError(context, "Currently floor_div only supports int32.");
+      context->ReportError(context, "Type '%s' is not supported by floor_div.",
+                           TfLiteTypeGetName(input1->type));
       return kTfLiteError;
     }
   }

--- a/tensorflow/lite/kernels/floor_div.cc
+++ b/tensorflow/lite/kernels/floor_div.cc
@@ -67,7 +67,6 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   switch (type) {
     case kTfLiteFloat32:
     case kTfLiteInt32:
-    case kTfLiteUInt8:
       break;
     default:
       context->ReportError(context, "Type '%s' is not supported by floor_div.",
@@ -132,10 +131,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteFloat32: {
       return EvalImpl<float>(context, data->requires_broadcast, input1, input2,
                              output);
-    }
-    case kTfLiteUInt8: {
-      return EvalImpl<uint8_t>(context, data->requires_broadcast, input1,
-                               input2, output);
     }
     default: {
       context->ReportError(context, "Type '%s' is not supported by floor_div.",

--- a/tensorflow/lite/kernels/floor_div.cc
+++ b/tensorflow/lite/kernels/floor_div.cc
@@ -68,7 +68,6 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteFloat32:
     case kTfLiteInt32:
     case kTfLiteUInt8:
-    case kTfLiteInt64:
       break;
     default:
       context->ReportError(context, "Type '%s' is not supported by floor_div.",
@@ -136,10 +135,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     }
     case kTfLiteUInt8: {
       return EvalImpl<uint8_t>(context, data->requires_broadcast, input1,
-                               input2, output);
-    }
-    case kTfLiteInt64: {
-      return EvalImpl<int64_t>(context, data->requires_broadcast, input1,
                                input2, output);
     }
     default: {

--- a/tensorflow/lite/kernels/floor_div_test.cc
+++ b/tensorflow/lite/kernels/floor_div_test.cc
@@ -48,7 +48,7 @@ class FloorDivModel : public SingleOpModel {
   int output_;
 };
 
-TEST(PowOpModel, Simple) {
+TEST(FloorDivModel, Simple) {
   FloorDivModel<int32_t> model({TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {}});
@@ -59,7 +59,7 @@ TEST(PowOpModel, Simple) {
   EXPECT_THAT(model.GetOutput(), ElementsAre(5, 4, 3, 0));
 }
 
-TEST(PowOpModel, NegativeValue) {
+TEST(FloorDivModel, NegativeValue) {
   FloorDivModel<int32_t> model({TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {}});
@@ -70,7 +70,7 @@ TEST(PowOpModel, NegativeValue) {
   EXPECT_THAT(model.GetOutput(), ElementsAre(5, -5, 3, -2));
 }
 
-TEST(PowOpModel, BroadcastFloorDiv) {
+TEST(FloorDivModel, BroadcastFloorDiv) {
   FloorDivModel<int32_t> model({TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {1}}, {TensorType_INT32, {}});
   model.PopulateTensor<int32_t>(model.input1(), {10, -9, -11, 7});
@@ -78,6 +78,81 @@ TEST(PowOpModel, BroadcastFloorDiv) {
   model.Invoke();
   EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
   EXPECT_THAT(model.GetOutput(), ElementsAre(-4, 3, 3, -3));
+}
+
+TEST(FloorDivModel, SimpleFloat) {
+  FloorDivModel<float> model({TensorType_FLOAT32, {1, 2, 2, 1}},
+                             {TensorType_FLOAT32, {1, 2, 2, 1}},
+                             {TensorType_FLOAT32, {}});
+  model.PopulateTensor<float>(model.input1(), {10.05, 9.09, 11.9, 3.01});
+  model.PopulateTensor<float>(model.input2(), {2.05, 2.03, 3.03, 4.03});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(4.0, 4.0, 3.0, 0.0));
+}
+
+TEST(FloorDivModel, NegativeValueFloat) {
+  FloorDivModel<float> model({TensorType_FLOAT32, {1, 2, 2, 1}},
+                             {TensorType_FLOAT32, {1, 2, 2, 1}},
+                             {TensorType_FLOAT32, {}});
+  model.PopulateTensor<float>(model.input1(), {10.03, -9.9, -11.0, 7.0});
+  model.PopulateTensor<float>(model.input2(), {2.0, 2.3, -3.0, -4.1});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(5.0, -5.0, 3.0, -2.0));
+}
+
+TEST(FloorDivModel, BroadcastFloorDivFloat) {
+  FloorDivModel<float> model({TensorType_FLOAT32, {1, 2, 2, 1}},
+                             {TensorType_FLOAT32, {1}},
+                             {TensorType_FLOAT32, {}});
+  model.PopulateTensor<float>(model.input1(), {10.03, -9.9, -11.0, 7.0});
+  model.PopulateTensor<float>(model.input2(), {-3.3});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(-4.0, 2.0, 3.0, -3.0));
+}
+
+TEST(FloorDivModel, NegativeValueInt64) {
+  FloorDivModel<int64_t> model({TensorType_INT64, {1, 2, 2, 1}},
+                               {TensorType_INT64, {1, 2, 2, 1}},
+                               {TensorType_INT64, {}});
+  model.PopulateTensor<int64_t>(model.input1(), {10, -9, -11, 7});
+  model.PopulateTensor<int64_t>(model.input2(), {2, 2, -3, -4});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(5, -5, 3, -2));
+}
+
+TEST(FloorDivModel, BroadcastFloorDivInt64) {
+  FloorDivModel<int64_t> model({TensorType_INT64, {1, 2, 2, 1}},
+                               {TensorType_INT64, {1}}, {TensorType_INT64, {}});
+  model.PopulateTensor<int64_t>(model.input1(), {10, -9, -11, 7});
+  model.PopulateTensor<int64_t>(model.input2(), {-3});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(-4, 3, 3, -3));
+}
+
+TEST(FloorDivModel, SimpleUInt8) {
+  FloorDivModel<uint8_t> model({TensorType_UINT8, {1, 2, 2, 1}},
+                               {TensorType_UINT8, {1, 2, 2, 1}},
+                               {TensorType_UINT8, {}});
+  model.PopulateTensor<uint8_t>(model.input1(), {10, 9, 11, 7});
+  model.PopulateTensor<uint8_t>(model.input2(), {2, 2, 3, 4});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(5, 4, 3, 1));
+}
+
+TEST(FloorDivModel, BroadcastFloorDivUInt8) {
+  FloorDivModel<uint8_t> model({TensorType_UINT8, {1, 2, 2, 1}},
+                               {TensorType_UINT8, {1}}, {TensorType_UINT8, {}});
+  model.PopulateTensor<uint8_t>(model.input1(), {10, 9, 11, 7});
+  model.PopulateTensor<uint8_t>(model.input2(), {3});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(3, 3, 3, 2));
 }
 
 }  // namespace

--- a/tensorflow/lite/kernels/floor_div_test.cc
+++ b/tensorflow/lite/kernels/floor_div_test.cc
@@ -113,27 +113,6 @@ TEST(FloorDivModel, BroadcastFloorDivFloat) {
   EXPECT_THAT(model.GetOutput(), ElementsAre(-4.0, 2.0, 3.0, -3.0));
 }
 
-TEST(FloorDivModel, NegativeValueInt64) {
-  FloorDivModel<int64_t> model({TensorType_INT64, {1, 2, 2, 1}},
-                               {TensorType_INT64, {1, 2, 2, 1}},
-                               {TensorType_INT64, {}});
-  model.PopulateTensor<int64_t>(model.input1(), {10, -9, -11, 7});
-  model.PopulateTensor<int64_t>(model.input2(), {2, 2, -3, -4});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
-  EXPECT_THAT(model.GetOutput(), ElementsAre(5, -5, 3, -2));
-}
-
-TEST(FloorDivModel, BroadcastFloorDivInt64) {
-  FloorDivModel<int64_t> model({TensorType_INT64, {1, 2, 2, 1}},
-                               {TensorType_INT64, {1}}, {TensorType_INT64, {}});
-  model.PopulateTensor<int64_t>(model.input1(), {10, -9, -11, 7});
-  model.PopulateTensor<int64_t>(model.input2(), {-3});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
-  EXPECT_THAT(model.GetOutput(), ElementsAre(-4, 3, 3, -3));
-}
-
 TEST(FloorDivModel, SimpleUInt8) {
   FloorDivModel<uint8_t> model({TensorType_UINT8, {1, 2, 2, 1}},
                                {TensorType_UINT8, {1, 2, 2, 1}},

--- a/tensorflow/lite/kernels/floor_div_test.cc
+++ b/tensorflow/lite/kernels/floor_div_test.cc
@@ -112,28 +112,6 @@ TEST(FloorDivModel, BroadcastFloorDivFloat) {
   EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
   EXPECT_THAT(model.GetOutput(), ElementsAre(-4.0, 2.0, 3.0, -3.0));
 }
-
-TEST(FloorDivModel, SimpleUInt8) {
-  FloorDivModel<uint8_t> model({TensorType_UINT8, {1, 2, 2, 1}},
-                               {TensorType_UINT8, {1, 2, 2, 1}},
-                               {TensorType_UINT8, {}});
-  model.PopulateTensor<uint8_t>(model.input1(), {10, 9, 11, 7});
-  model.PopulateTensor<uint8_t>(model.input2(), {2, 2, 3, 4});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
-  EXPECT_THAT(model.GetOutput(), ElementsAre(5, 4, 3, 1));
-}
-
-TEST(FloorDivModel, BroadcastFloorDivUInt8) {
-  FloorDivModel<uint8_t> model({TensorType_UINT8, {1, 2, 2, 1}},
-                               {TensorType_UINT8, {1}}, {TensorType_UINT8, {}});
-  model.PopulateTensor<uint8_t>(model.input1(), {10, 9, 11, 7});
-  model.PopulateTensor<uint8_t>(model.input2(), {3});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
-  EXPECT_THAT(model.GetOutput(), ElementsAre(3, 3, 3, 2));
-}
-
 }  // namespace
 }  // namespace tflite
 

--- a/tensorflow/lite/kernels/register.cc
+++ b/tensorflow/lite/kernels/register.cc
@@ -367,7 +367,9 @@ BuiltinOpResolver::BuiltinOpResolver() {
   AddBuiltin(BuiltinOperator_LOGICAL_AND, Register_LOGICAL_AND());
   AddBuiltin(BuiltinOperator_LOGICAL_NOT, Register_LOGICAL_NOT());
   AddBuiltin(BuiltinOperator_UNPACK, Register_UNPACK());
-  AddBuiltin(BuiltinOperator_FLOOR_DIV, Register_FLOOR_DIV());
+  AddBuiltin(BuiltinOperator_FLOOR_DIV, Register_FLOOR_DIV(),
+             /* min_version */ 1,
+             /* max_version */ 2);
   AddBuiltin(BuiltinOperator_SQUARE, Register_SQUARE());
   AddBuiltin(BuiltinOperator_ZEROS_LIKE, Register_ZEROS_LIKE());
   AddBuiltin(BuiltinOperator_FLOOR_MOD, Register_FLOOR_MOD());

--- a/tensorflow/lite/toco/tflite/operator.cc
+++ b/tensorflow/lite/toco/tflite/operator.cc
@@ -2347,6 +2347,20 @@ class Select : public SimpleOperator<SelectOperator> {
   }
 };
 
+class FloorDiv : public SimpleOperator<FloorDivOperator> {
+ public:
+  explicit FloorDiv() : SimpleOperator("FLOOR_DIV", OperatorType::kFloorDiv) {}
+  int GetVersion(const OperatorSignature& op_signature) const override {
+    const string& input_name = op_signature.op->inputs[0];
+    const Array& input_array = op_signature.model->GetArray(input_name);
+    // Version 2 supports float input types.
+    if (input_array.data_type == ArrayDataType::kFloat) {
+      return 2;
+    }
+    return 1;
+  }
+};
+
 namespace {
 // Build a vector containing all the known operators.
 std::vector<std::unique_ptr<BaseOperator>> BuildOperatorList(
@@ -2551,8 +2565,7 @@ std::vector<std::unique_ptr<BaseOperator>> BuildOperatorList(
       "LOGICAL_AND", OperatorType::kLogicalAnd));
   ops.emplace_back(new SimpleOperator<LogicalNotOperator>(
       "LOGICAL_NOT", OperatorType::kLogicalNot));
-  ops.emplace_back(new SimpleOperator<FloorDivOperator>(
-      "FLOOR_DIV", OperatorType::kFloorDiv));
+  ops.push_back(MakeUnique<FloorDiv>());
   ops.emplace_back(new SimpleOperator<FloorModOperator>(
       "FLOOR_MOD", OperatorType::kFloorMod));
   ops.emplace_back(

--- a/tensorflow/lite/toco/tflite/operator_test.cc
+++ b/tensorflow/lite/toco/tflite/operator_test.cc
@@ -968,6 +968,29 @@ TEST_F(OperatorTest, VersioningConv2DTest) {
   EXPECT_EQ(op->GetVersion(float_signature), 2);
 }
 
+TEST_F(OperatorTest, VersioningFloorDivOperatorTest) {
+  FloorDivOperator floordiv_op;
+  floordiv_op.inputs = {"input1"};
+  auto operator_by_type_map = BuildOperatorByTypeMap(false /*enable_flex_ops*/);
+  const BaseOperator* op = operator_by_type_map.at(floordiv_op.type).get();
+
+  Model int32_model;
+  Array& input_int32_array =
+      int32_model.GetOrCreateArray(floordiv_op.inputs[0]);
+  input_int32_array.data_type = ArrayDataType::kInt32;
+  OperatorSignature int32_signature = {.op = &floordiv_op,
+                                       .model = &int32_model};
+  EXPECT_EQ(op->GetVersion(int32_signature), 1);
+
+  Model float_model;
+  Array& input_float_array =
+      float_model.GetOrCreateArray(floordiv_op.inputs[0]);
+  input_float_array.data_type = ArrayDataType::kFloat;
+  OperatorSignature float_signature = {.op = &floordiv_op,
+                                       .model = &float_model};
+  EXPECT_EQ(op->GetVersion(float_signature), 2);
+}
+
 }  // namespace
 }  // namespace tflite
 


### PR DESCRIPTION
TFLite FloorDiv currently supports only Int32.
This PR add support for other datatypes as well.
Test cases also updated.