### PR TITLE
Fix init_ops_test on AVX512 builds

### DIFF
--- a/tensorflow/core/kernels/eigen_contraction_kernel.h
+++ b/tensorflow/core/kernels/eigen_contraction_kernel.h
@@ -197,7 +197,8 @@ class TensorContractionBlocking<float, float, float, StorageIndex,
     // We split Kth dimensions in roughly equal slices.
     StorageIndex target_k_slices =
         (std::max)(StorageIndex(1), Eigen::divup(k, kc_));
-    StorageIndex packet_size = 8;
+    StorageIndex packet_size = internal::packet_traits<Scalar>::size;
+    if (packet_size < 8) packet_size = 8;
     StorageIndex target_bk =
         Eigen::divup(k / target_k_slices, packet_size) * packet_size;
     kc_ = (std::min)(k, target_bk);


### PR DESCRIPTION
The init_ops_tests unit test is failing on AVX512 builds due
to a hard coded packet size in eigen_contraction_kernel.h.
This commit fixes the issue by determining the appropriate
packet size using internal::packet_traits.  It maintains
the minimum packet size of 8 used in the existing code and
so should have no effect on non AVX512 builds.

Fixes: https://github.com/tensorflow/tensorflow/issues/25127

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>