### PR TITLE
Canonicalize symbolic link include paths

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -283,7 +283,7 @@ def _normalize_include_path(repository_ctx, path):
     path is returned.
     If path points outside the 'crosstool' folder, an absolute path is returned.
     """
-  path = str(repository_ctx.path(path))
+  path = str(repository_ctx.path(path).realpath)
   crosstool_folder = str(repository_ctx.path(".").get_child("crosstool"))
 
   if path.startswith(crosstool_folder):


### PR DESCRIPTION
This change will canonicalize symbolic link include paths similar to the change for cuda include paths in https://github.com/tensorflow/tensorflow/issues/3985.

In my build environment the output of:
`gcc -E -xc++ - -v`

includes (normalised):
```
/builds/gcc/4.9.4/12a8bec7dd/include/c++/4.9.4
/builds/gcc/4.9.4/12a8bec7dd/include/c++/4.9.4/x86_64-unknown-linux-gnu
/builds/gcc/4.9.4/12a8bec7dd/include/c++/4.9.4/backward
/builds/gcc/4.9.4/12a8bec7dd/lib/gcc/x86_64-unknown-linux-gnu/4.9.4/include
/builds/gcc/4.9.4/12a8bec7dd/lib/gcc/x86_64-unknown-linux-gnu/4.9.4/include-fixed
```

The 12a8bec7dd directory is a symbolic link to another directory. This means that my build fails because of undeclared inclusions as bazel requires the canonical include paths when validating inclusions:
```
ERROR: /user_data/.tmp/bazel/8138e9654dfcdfe7ea4dbdd7c7e74b8c/external/com_google_absl/absl/base/BUILD.bazel:58:1: undeclared inclusion(s) in rule '@com_google_absl//absl/base:dynamic_annotations':
this rule is missing dependency declarations for the following files included by 'external/com_google_absl/absl/base/dynamic_annotations.cc':
  '/builds/gcc/4.9.4/53516a8e20/lib/gcc/x86_64-unknown-linux-gnu/4.9.4/include/stddef.h'
```

```
$ readlink -f /builds/gcc/4.9.4/12a8bec7dd/lib/gcc/x86_64-unknown-linux-gnu/4.9.4/include
/builds/gcc/4.9.4/53516a8e20/lib/gcc/x86_64-unknown-linux-gnu/4.9.4/include
```

This change fixes my issue and may help others who have their C/C++ toolchain installed in a non-standard location with symbolic links.