### PR TITLE
TFTRT: Set engine output datatypes based on what TF is expecting

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -977,12 +977,12 @@ Status Converter::RenameAndMarkOutputTensors(
       tensor = layer->getOutput(0);
     }
     tensor->setName(output.dest_node_name.c_str());
+    network()->markOutput(*tensor);
     // Set type after marking as output. TRT only supports setType for engine
     // outputs and inputs (type is inferred otherwise).
     tensor->setType(output.trt_dtype);
     VLOG(1) << "Marking output TRT tensor " << output.source_tensor_name
             << ", which feeds TF node " << output.dest_node_name;
-    network()->markOutput(*tensor);
   }
   return Status::OK();
 }

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -946,17 +946,19 @@ Status Converter::AddInputTensor(const string& name, nvinfer1::DataType dtype,
 }
 
 Status Converter::RenameAndMarkOutputTensors(
-    const std::vector<std::pair<string, string>>& output_tensors) {
+    const std::vector<Converter::EngineOutputInfo>& output_tensors) {
   for (const auto& output : output_tensors) {
     TRT_TensorOrWeights tensor_or_weights;
-    TF_RETURN_IF_ERROR(GetTensorOrWeights(output.first, &tensor_or_weights));
+    TF_RETURN_IF_ERROR(
+        GetTensorOrWeights(output.source_tensor_name, &tensor_or_weights));
     if (!tensor_or_weights.is_tensor()) {
-      return errors::InvalidArgument("Output ", output.first,
+      return errors::InvalidArgument("Output ", output.source_tensor_name,
                                      " is weights not tensor");
     }
     nvinfer1::ITensor* tensor = tensor_or_weights.tensor();
     if (tensor == nullptr) {
-      return errors::NotFound("Output tensor not found: ", output.first);
+      return errors::NotFound("Output tensor not found: ",
+                              output.source_tensor_name);
     }
     // Check if this tensor has already been marked as an output.
     // ConvertIdentity can cause the same tensor to be repeated in
@@ -974,9 +976,12 @@ Status Converter::RenameAndMarkOutputTensors(
       MarkQuantizationRangesAsInferrable(tensor, layer->getOutput(0));
       tensor = layer->getOutput(0);
     }
-    tensor->setName(output.second.c_str());
-    VLOG(1) << "Marking output tensor " << output.first << ", as output tensor "
-            << output.second;
+    tensor->setName(output.dest_node_name.c_str());
+    // Set type after marking as output. TRT only supports setType for engine
+    // outputs and inputs (type is inferred otherwise).
+    tensor->setType(output.trt_dtype);
+    VLOG(1) << "Marking output TRT tensor " << output.source_tensor_name
+            << ", which feeds TF node " << output.dest_node_name;
     network()->markOutput(*tensor);
   }
   return Status::OK();
@@ -3560,9 +3565,9 @@ tensorflow::Status ConvertTopK(OpConverterParams* params) {
     op = nvinfer1::TopKOperation::kMAX;
     reducedAxes |= 1 << (nbDims - 1);
   } else {
-    return tensorflow::errors::Unimplemented(
-        "Operation: " + node_def.op() +
-        " not implemented, at: " + node_def.name());
+    return tensorflow::errors::Unimplemented("Operation: ", node_def.op(),
+                                             " not implemented, at: ",
+                                             node_def.name());
   }
 
   nvinfer1::ITopKLayer* layer = params->converter->network()->addTopK(
@@ -3571,9 +3576,6 @@ tensorflow::Status ConvertTopK(OpConverterParams* params) {
 
   nvinfer1::ITensor* output_value_tensor = layer->getOutput(0);
   nvinfer1::ITensor* output_indices_tensor = layer->getOutput(1);
-  // Tensor type for network output is not inferred. Indices should be INT32
-  // (default is float).
-  output_indices_tensor->setType(nvinfer1::DataType::kINT32);
   params->outputs->push_back(TRT_TensorOrWeights(output_value_tensor));
   params->outputs->push_back(TRT_TensorOrWeights(output_indices_tensor));
   return tensorflow::Status::OK();
@@ -3686,7 +3688,7 @@ tensorflow::Status ConvertGraphDefToEngine(
   // Build the network
   VLOG(1) << "Starting engine conversion ";
   Converter converter(trt_network.get(), precision_mode, use_calibration);
-  std::vector<std::pair<string, string>> output_tensors;
+  std::vector<Converter::EngineOutputInfo> output_tensors;
   // Graph nodes are already topologically sorted during construction
   for (const auto& node_def : gdef.node()) {
     string node_name = node_def.name();
@@ -3728,10 +3730,16 @@ tensorflow::Status ConvertGraphDefToEngine(
         return tensorflow::errors::InvalidArgument(
             "Failed to parse slot number from ", node_name);
       }
+      // Get output type that TensorFlow expects
+      TFAttrs attrs(node_def);
+      tensorflow::DataType tf_dtype = attrs.get<tensorflow::DataType>("T");
+      nvinfer1::DataType trt_dtype;
+      TF_RETURN_IF_ERROR(ConvertDType(tf_dtype, &trt_dtype));
       if (output_tensors.size() <= slot_number) {
         output_tensors.resize(slot_number + 1);
       }
-      output_tensors.at(slot_number) = {node_def.input(0), node_name};
+      output_tensors.at(slot_number) = {node_def.input(0), node_name,
+                                        trt_dtype};
     } else {
       VLOG(2) << "Converting node: " << node_def.name() << " , "
               << node_def.op();

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -415,7 +415,19 @@ class Converter {
   Status AddInputTensor(const string& name, nvinfer1::DataType dtype,
                         const nvinfer1::Dims& dims, int batch_size);
 
-  struct EngineOutputInfo;
+  // Used for Converter::RenameAndMarkOutputTensors()
+  struct EngineOutputInfo {
+    // The TRT tensor name which produces the output.
+    string source_tensor_name;
+    // The TensorFlow node name which is receiving the output from the TRT engine.
+    // This should always be the Identity node created in
+    // ConvertSegmentToGraphDef.
+    string dest_node_name;
+    // Output type. TensorRT requires this to be explicitly set for engine
+    // outputs.
+    nvinfer1::DataType trt_dtype;
+  };
+
   // Mark the tensors with names specified by source_tensor_name as output of
   // the TRT network, and set their names in the TRT network as dest_node_name.
   Status RenameAndMarkOutputTensors(
@@ -544,19 +556,6 @@ class Converter {
 
   friend class ConverterTest;
   friend class OpConverterTest;
-};
-
-// Used for Converter::RenameAndMarkOutputTensors()
-struct EngineOutputInfo {
-  // The TRT tensor name which produces the output.
-  string source_tensor_name;
-  // The TensorFlow node name which is receiving the output from the TRT engine.
-  // This should always be the Identity node created in
-  // ConvertSegmentToGraphDef.
-  string dest_node_name;
-  // Output type. TensorRT requires this to be explicitly set for engine
-  // outputs.
-  nvinfer1::DataType trt_dtype;
 };
 
 }  // namespace convert

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -415,13 +415,11 @@ class Converter {
   Status AddInputTensor(const string& name, nvinfer1::DataType dtype,
                         const nvinfer1::Dims& dims, int batch_size);
 
-  // Mark the tensors with names specified by output_tensors[i].first as output
-  // of the TRT network, and set their names in the TRT network as
-  // output_tensors[i].second. The tensor names (output_tensors[i].first) are
-  // standard TF tensor names, i.e. node names followed by output slot number
-  // (or just the node name if the tensor is the first output of the node).
+  struct EngineOutputInfo;
+  // Mark the tensors with names specified by source_tensor_name as output of
+  // the TRT network, and set their names in the TRT network as dest_node_name.
   Status RenameAndMarkOutputTensors(
-      const std::vector<std::pair<string, string>>& output_tensors);
+      const std::vector<EngineOutputInfo>& output_tensors);
 
   //////////////////////////////////////////////////////////////////////////////
   // Methods used by op converters to convert individual TF node and add layers
@@ -546,6 +544,19 @@ class Converter {
 
   friend class ConverterTest;
   friend class OpConverterTest;
+};
+
+// Used for Converter::RenameAndMarkOutputTensors()
+struct EngineOutputInfo {
+  // The TRT tensor name which produces the output.
+  string source_tensor_name;
+  // The TensorFlow node name which is receiving the output from the TRT engine.
+  // This should always be the Identity node created in
+  // ConvertSegmentToGraphDef.
+  string dest_node_name;
+  // Output type. TensorRT requires this to be explicitly set for engine
+  // outputs.
+  nvinfer1::DataType trt_dtype;
 };
 
 }  // namespace convert

--- a/tensorflow/contrib/tensorrt/test/topk_test.py
+++ b/tensorflow/contrib/tensorrt/test/topk_test.py
@@ -53,6 +53,36 @@ class TopKTest(trt_test.TfTrtIntegrationTestBase):
     """Return the expected engines to build."""
     return {"TRTEngineOp_0": ["Const", "TopK"]}
 
+class TopKOutputTypeTest(trt_test.TfTrtIntegrationTestBase):
+
+  def GetParams(self):
+    """Testing that output type of engine using Top-K is set correctly."""
+    dtype = dtypes.float32
+    input_name = "input"
+    input_dims = [100, 100]
+    k = 5
+    g = ops.Graph()
+    with g.as_default():
+      x = array_ops.placeholder(dtype=dtype, shape=input_dims, name=input_name)
+      k_tensor = constant_op.constant(k, dtype=dtypes.int32, name="Const")
+      values, indices = nn_ops.top_k(x, k_tensor, name="TopK")
+      # Reshape will act as a layer between the TopK output and the engine
+      # output, requiring the output tensor of reshape to be set explicitly to
+      # int32.
+      indices = array_ops.reshape(indices, [100, 1, 5], name="Reshape")
+      values = array_ops.identity(values, name="output_values")
+      indices = array_ops.identity(indices, name="output_indices")
+    return trt_test.TfTrtIntegrationTestParams(
+        gdef=g.as_graph_def(),
+        input_names=[input_name],
+        input_dims=[[input_dims]],
+        output_names=["output_values", "output_indices"],
+        expected_output_dims=[[[100, k], [100, 1, k]]])
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Return the expected engines to build."""
+    return {"TRTEngineOp_0": ["Const", "TopK", "Reshape", "Reshape/shape"]}
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
TRT requires the datatype of engine output tensors to be set explicitly. We will now tell TRT to output in the type that tensorflow is expecting.