### PR TITLE
fix build wheel parse error

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -58,7 +58,7 @@ REQUIRED_PACKAGES = [
     'six >= 1.10.0',
     'protobuf >= 3.6.1',
     'tensorboard >= 1.12.0, < 1.13.0',
-    'tensorflow_estimator >= 1.13.0 < 1.14.0',
+    'tensorflow_estimator >= 1.13.0, < 1.14.0',
     'termcolor >= 1.1.0',
 ]
 


### PR DESCRIPTION
Sat Jan 26 03:08:49 UTC 2019 : === Building wheel
error in tensorflow setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "'< 1.14.0'"