### PR TITLE
Raspberry PI example label image patch

### DIFF
--- a/tensorflow/contrib/pi_examples/label_image/Makefile
+++ b/tensorflow/contrib/pi_examples/label_image/Makefile
@@ -34,12 +34,14 @@ CXXFLAGS := --std=c++11 $(OPTFLAGS)
 LDFLAGS := \
 -L/usr/local/lib \
 -L$(TFLIBDIR) \
+-L$(DOWNLOADSDIR)/nsync/builds/default.linux.c++11/ \
 -Wl,--no-whole-archive
 INCLUDES := \
 -I/usr/local/include \
 -I. \
 -I$(DOWNLOADSDIR) \
 -I$(DOWNLOADSDIR)/eigen/ \
+-I$(DOWNLOADSDIR)/absl/ \
 -I$(PROTOGENDIR) \
 -I$(PBTGENDIR)
 LIBS := \
@@ -49,6 +51,7 @@ LIBS := \
 -Wl,--no-whole-archive \
 -lstdc++ \
 -lprotobuf \
+-lnsync \
 -ldl \
 -lpthread \
 -lm \

--- a/tensorflow/contrib/pi_examples/label_image/label_image.cc
+++ b/tensorflow/contrib/pi_examples/label_image/label_image.cc
@@ -23,9 +23,9 @@ limitations under the License.
 //
 // Full build instructions are at tensorflow/contrib/pi_examples/README.md.
 
+#include <stdio.h>
 #include <jpeglib.h>
 #include <setjmp.h>
-#include <stdio.h>
 #include <fstream>
 #include <vector>
 


### PR DESCRIPTION
In the Makefile, there were missing options that lead to compile / linking error :
* `absl` , according to [issue 22240](https://github.com/tensorflow/tensorflow/issues/22240)
* `nsync`, according to [issue12810](https://github.com/tensorflow/tensorflow/issues/12810)

Also in label_image.cc , there was an compile error as described in [issue 5200](https://github.com/tensorflow/tensorflow/issues/5200), the error can be solved if the included header `<stdio.h>` is moved before `<jpeglib.h>`.

The modified Makefile and label_image.cc is tested in my Raspbian Stretch 9 and GCC 6.3.0, it works well .

