### PR TITLE
Issue #23410 fix - Change deprecated 'np.asscalar(a)' function

### DIFF
--- a/tensorflow/python/framework/fast_tensor_util.pyx
+++ b/tensorflow/python/framework/fast_tensor_util.pyx
@@ -131,4 +131,4 @@ def AppendBoolArrayToTensorProto(tensor_proto, nparray):
   cdef long i, n
   n = nparray.size
   for i in range(n):
-    tensor_proto.bool_val.append(np.asscalar(nparray[i]))
+    tensor_proto.bool_val.append(nparray[i].item())


### PR DESCRIPTION
'np.asscalar(a)' is deprecated since NumPy v1.16, use 'a.item()' instead'. 
See 'numpy/lib/type_check.py'.