### PR TITLE
Export keras merge layer.

### DIFF
--- a/tensorflow/python/keras/layers/merge.py
+++ b/tensorflow/python/keras/layers/merge.py
@@ -29,6 +29,7 @@ from tensorflow.python.ops import nn
 from tensorflow.python.util.tf_export import keras_export
 
 
+@keras_export('keras.layers._Merge')
 class _Merge(Layer):
   """Generic merge layer for elementwise merge functions.
 


### PR DESCRIPTION
This layer is accessible in raw Keras API, and useful to build custom merge layers.

Also fixed a typo preventing wheel from building successfully.