### PR TITLE
TFTRT: Capture new logging level introduced by TRT 5.1

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/utils/trt_logger.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_logger.cc
@@ -26,6 +26,9 @@ namespace tensorrt {
 void Logger::log(Severity severity, const char* msg) {
   // Suppress info-level messages
   switch (severity) {
+#if NV_TENSORRT_MAJOR >= 5 && NV_TENSORRT_MINOR >= 1
+    case Severity::kVERBOSE:
+#endif
     case Severity::kINFO: {  // Mark TRT info messages as debug!
       VLOG(2) << name_ << " " << msg;
       break;


### PR DESCRIPTION
TRT 5.1 added a new logging severity level, kVERBOSE. We will now capture this level and report it as VLOG(2) like with kINFO, instead of the default LOG(FATAL).