### PR TITLE
Add optimization to convert Square(Sub(x, y)) to SquaredDifference(x, y)

### DIFF
--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer.h
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer.h
@@ -61,6 +61,7 @@ class ArithmeticOptimizer : public GraphOptimizer {
     bool fold_conjugate_into_transpose = true;
     bool fold_multiply_into_conv = true;
     bool fold_transpose_into_matmul = true;
+    bool fuse_squared_diff = true;
     bool hoist_common_factor_out_of_aggregation = true;
     bool hoist_cwise_unary_chains = true;
     bool minimize_broadcasts = true;

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
@@ -71,10 +71,6 @@ string AggregationMulName(const string& name) {
   return AddPrefixToNodeName(name, kSimplifyAggregationMul, "");
 }
 
-string OptimizedName(const string& name) {
-  return AddPrefixToNodeName(name, kArithmeticOptimizer);
-}
-
 void VerifyGraphsMatch(const GraphDef& original_graph,
                        const GraphDef& optimized_graph, int line) {
   EXPECT_EQ(original_graph.node_size(), optimized_graph.node_size()) << line;

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test_utils.h
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test_utils.h
@@ -188,6 +188,11 @@ class ArithmeticOptimizerTest : public GrapplerTest {
     optimizer->options_.convert_pow = true;
   }
 
+  void EnableOnlyFuseSquaredDiff(ArithmeticOptimizer* optimizer) {
+    DisableAllStages(optimizer);
+    optimizer->options_.fuse_squared_diff = true;
+  }
+
   void EnableOnlyRemoveIdempotent(ArithmeticOptimizer* optimizer) {
     DisableAllStages(optimizer);
     optimizer->options_.remove_idempotent = true;


### PR DESCRIPTION
This PR adds a graph optimization that converts `Square(Sub(x, y))` to `Identity(SquaredDifference(x, y))` for improved performance.

This is basically a generalization of #25256 making this optimization available for user code as well.

Note: I haven't rigorously benchmarked `tf.square(x - y)` against `tf.squared_difference(x, y)` to verify the performance boost for every case. Also, this is my first PR that touches C++ in the TF codebase, so please keep in mind that there may be some subtleties that I miss that would prevent this optimization from working well in all cases.