### PR TITLE
lite: promote precision of quantization multiplier (master branch)

### DIFF
--- a/tensorflow/lite/kernels/kernel_util.cc
+++ b/tensorflow/lite/kernels/kernel_util.cc
@@ -94,9 +94,11 @@ TfLiteStatus GetQuantizedConvolutionMultipler(TfLiteContext* context,
                                               const TfLiteTensor* input,
                                               const TfLiteTensor* filter,
                                               const TfLiteTensor* bias,
-                                              TfLiteTensor* output,
+                                              const TfLiteTensor* output,
                                               double* multiplier) {
-  const double input_product_scale = input->params.scale * filter->params.scale;
+  const double input_scale = input->params.scale;
+  const double filter_scale = filter->params.scale;
+  const double input_product_scale = input_scale * filter_scale;
   const double bias_scale = bias->params.scale;
   const double output_scale = output->params.scale;
 

--- a/tensorflow/lite/kernels/kernel_util.h
+++ b/tensorflow/lite/kernels/kernel_util.h
@@ -99,7 +99,7 @@ TfLiteStatus GetQuantizedConvolutionMultipler(TfLiteContext* context,
                                               const TfLiteTensor* input,
                                               const TfLiteTensor* filter,
                                               const TfLiteTensor* bias,
-                                              TfLiteTensor* output,
+                                              const TfLiteTensor* output,
                                               double* multiplier);
 
 // Calculates the useful quantized range of an activation layer given its


### PR DESCRIPTION
This is https://github.com/tensorflow/tensorflow/pull/24036 (`1.12` branch) for `master` branch.

*Btw, though this (and some other potential) precision issue exist on branches like `1.11`, `1.9` and so on, I will personally only look into master branch after...*