### PR TITLE
Add missing elementwise monotonic functions

### DIFF
--- a/tensorflow/core/grappler/op_types.cc
+++ b/tensorflow/core/grappler/op_types.cc
@@ -164,17 +164,39 @@ bool IsDiv(const NodeDef& node) { return node.op() == "Div"; }
 bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing) {
   static const gtl::FlatSet<string>* const kMonotonicNonDecreasingOps =
       CHECK_NOTNULL((new gtl::FlatSet<string>{
-          "Asinh", "Atanh",   "Ceil",  "Elu",  "Erf",  "Exp",   "Expm1",
-          "Floor", "Log",     "Log1p", "Relu", "Relu", "Relu6", "Rint",
-          "Selu",  "Sigmoid", "Sign",  "Sinh", "Sqrt", "Tanh",
+          "Acosh",
+          "Asin",
+          "Asinh",
+          "Atan",
+          "Atanh",
+          "Ceil",
+          "Elu",
+          "Erf",
+          "Exp",
+          "Expm1",
+          "Floor",
+          "Log",
+          "Log1p",
+          "Relu",
+          "Relu6",
+          "Rint",
+          "Selu",
+          "Sigmoid",
+          "Sign",
+          "Sinh",
+          "Softsign",
+          "Softplus",
+          "Sqrt",
+          "Tanh",
       }));
   static const gtl::FlatSet<string>* const kMonotonicNonIncreasingOps =
       CHECK_NOTNULL((new gtl::FlatSet<string>{
-          "Inv",
-          "Reciprocal",
+          "Acos",
           "Erfc",
-          "Rsqrt",
+          "Inv",
           "Neg",
+          "Reciprocal",
+          "Rsqrt"
       }));
   if (kMonotonicNonDecreasingOps->count(node.op()) > 0) {
     if (is_non_decreasing) {


### PR DESCRIPTION
This PR adds `Acos`, `Acosh`, `Asin`, `Atan`, `Softsign` and `Softplus` to the collection of elementwise monotonic operations. This allows the arithmetic optimizer to optimize more cases.

Continuation of #25330