### PR TITLE
Bazel: Remove deprecated experimental_shortened_obj_file_path option

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1513,10 +1513,6 @@ def set_windows_build_flags(environ_cp):
   # The host and target platforms are the same in Windows build. So we don't
   # have to distinct them. This avoids building the same targets twice.
   write_to_bazelrc('build --distinct_host_configuration=false')
-  # Enable short object file path to avoid long path issue on Windows.
-  # TODO(pcloudy): Remove this flag when upgrading Bazel to 0.16.0
-  # Short object file path will be enabled by default.
-  write_to_bazelrc('build --experimental_shortened_obj_file_path=true')
 
   if get_var(
       environ_cp, 'TF_OVERRIDE_EIGEN_STRONG_INLINE', 'Eigen strong inline',


### PR DESCRIPTION
`experimental_shortened_obj_file_path` is depreacted since [version `0.17.0`](https://blog.bazel.build/2018/09/14/bazel-0.17.html) and activated by default. Since Tensorflow requires [at least bazel `0.19.0`](https://github.com/tensorflow/tensorflow/blob/master/configure.py#L1559), this flag can be savely removed.