### PR TITLE
Fix wheel building.

### DIFF
--- a/tensorflow/lite/build_def.bzl
+++ b/tensorflow/lite/build_def.bzl
@@ -157,7 +157,7 @@ def tf_to_tflite(name, src, options, out):
     """
 
     toco_cmdline = " ".join([
-        "//tensorflow/lite/toco:toco",
+        "$(location //tensorflow/lite/toco:toco)",
         "--input_format=TENSORFLOW_GRAPHDEF",
         "--output_format=TFLITE",
         ("--input_file=$(location %s)" % src),


### PR DESCRIPTION
This pr fixes an issue with the toco package that was preventing build. It is likely that during migration $(location ) call accidentally dropped and genrule command-line was created using bazel target label instead of the binary. This was causing build to fail.