### PR TITLE
Unification with return indentation of other functions.

### DIFF
--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -219,7 +219,11 @@ def _ConcatGrad(op, grad):
 @ops.RegisterGradient("ConcatV2")
 def _ConcatGradV2(op, grad):
   return _ConcatGradHelper(
-      op, grad, start_value_index=0, end_value_index=-1, dim_index=-1)
+      op,
+      grad,
+      start_value_index=0,
+      end_value_index=-1,
+      dim_index=-1)
 
 
 ops.NotDifferentiable("ConcatOffset")


### PR DESCRIPTION
Listing the return values like the _ConcatGrad function or the _StrideSliceGrad function in the same file seems to be readable.