### PR TITLE
Fix bug in hadoop_file_system.cc when reading big variable from hdfs

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -209,6 +209,8 @@ class HDFSRandomAccessFile : public RandomAccessFile {
       // We lock inside the loop rather than outside so we don't block other
       // concurrent readers.
       mutex_lock lock(mu_);
+      //Max read length is INT_MAX-2, for hdfsPread function take a parameter of int32. 
+      //-2 offset can avoid JVM OutOfMemoryError. 
       size_t read_n = std::min(n,static_cast<size_t>(std::numeric_limits<int>::max()-2));
       tSize r = hdfs_->hdfsPread(fs_, file_, static_cast<tOffset>(offset), dst,
                                  static_cast<tSize>(read_n));

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -209,8 +209,9 @@ class HDFSRandomAccessFile : public RandomAccessFile {
       // We lock inside the loop rather than outside so we don't block other
       // concurrent readers.
       mutex_lock lock(mu_);
+      size_t read_n = std::min(n,static_cast<size_t>(std::numeric_limits<int>::max()-2));
       tSize r = hdfs_->hdfsPread(fs_, file_, static_cast<tOffset>(offset), dst,
-                                 static_cast<tSize>(n));
+                                 static_cast<tSize>(read_n));
       if (r > 0) {
         dst += r;
         n -= r;


### PR DESCRIPTION
The parameter tSize of the libhdfs's hdfsPread function has type int32, casting a size_t of int64 to tSize is not safe in hadoop_file_system.cc. 

For example, we have a big user embedding of [250000000,28] in model, it will throw exception when reading from hdfs like this:

InvalidArgumentError (see above for traceback): Restoring from checkpoint failed. This is most likely due to a mismatch between the current graph and the graph from the checkpoint. Please ensure that you have not altered the graph expected based on the checkpoint. Original error:

hdfs://appcluster-cdh/user/tftest/model/model.ckpt-0.data-00003-of-00004; Invalid argument
         [[node save/RestoreV2 (defined at /data/home/tftest/python1.13rc/lib/python2.7/site-packages/tensorflow_estimator/python/estimator/estimator.py:1530) ]]