### PR TITLE
Enabling integer data types in autograd

### DIFF
--- a/tensorflow/python/ops/gradients_impl.py
+++ b/tensorflow/python/ops/gradients_impl.py
@@ -304,6 +304,8 @@ def IsTrainable(tensor_or_dtype):
     dtype = tensor_or_dtype
   dtype = dtypes.as_dtype(dtype)
   return dtype.base_dtype in (dtypes.float16, dtypes.float32, dtypes.float64,
+                              dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64,
+                              dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64,
                               dtypes.complex64, dtypes.complex128,
                               dtypes.resource, dtypes.variant)
 


### PR DESCRIPTION
Refer #25386

Adds all of (u)int(8,16,32,64) dtypes to IsTrainable

(reopened to point CLA to correct email address)