### PR TITLE
Make install_deb_packages.sh platform independent

### DIFF
--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -68,12 +68,6 @@ apt-get install -y --no-install-recommends \
     zip \
     zlib1g-dev
 
-apt-get update && \
-  apt-get install nvinfer-runtime-trt-repo-ubuntu1604-4.0.1-ga-cuda9.0 && \
-  apt-get update && \
-  apt-get install libnvinfer4=4.1.2-1+cuda9.0 && \
-  apt-get install libnvinfer-dev=4.1.2-1+cuda9.0
-
 # populate the database
 updatedb
 


### PR DESCRIPTION
install_deb_packages.sh currently installs platform dependent packages.  These should go into the platform-specific Dockerfiles instead, like this relevant commit to Dockerfile.gpu:  
https://github.com/tensorflow/tensorflow/commit/03ec3f7b11572b70ef7f33f2a9af9bebbb6ce473