### PR TITLE
[v1.13][CP Request] Prevent null pointer dereference in decode_gif.

### DIFF
--- a/tensorflow/core/lib/gif/gif_io.cc
+++ b/tensorflow/core/lib/gif/gif_io.cc
@@ -129,6 +129,10 @@ uint8* Decode(const void* srcdata, int datasize,
     ColorMapObject* color_map = this_image->ImageDesc.ColorMap
                                     ? this_image->ImageDesc.ColorMap
                                     : gif_file->SColorMap;
+    if (color_map == nullptr) {
+      *error_string = strings::StrCat("missing color map for frame ", k);
+      return nullptr;
+    }
 
     for (int i = imgTop; i < imgBottom; ++i) {
       uint8* p_dst = this_dst + i * width * channel;


### PR DESCRIPTION
PiperOrigin-RevId: 231841542

This has a fix for a security vulnerability discovered last night. We will have to patch other releases but for 1.13 we can cherry-pick this now.

Not including this will result in people being able to do denial of service attacks on tensorflow by using specially crafted GIF images.