### PR TITLE
[INTEL MKL] Check if filter is a constant only in the forward pass for Depthwise Conv2D.

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -389,7 +389,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
                       CopyAttrsConv, AlwaysRewrite});
     rinfo_.push_back({csinfo_.depthwise_conv2d,
                       mkl_op_registry::GetMklOpName(csinfo_.depthwise_conv2d),
-                      CopyAttrsConv2DDepthwise, AlwaysRewrite});
+                      CopyAttrsConv2DDepthwiseCheckConstFilter, AlwaysRewrite});
     rinfo_.push_back(
         {csinfo_.depthwise_conv2d_grad_input,
          mkl_op_registry::GetMklOpName(csinfo_.depthwise_conv2d_grad_input),
@@ -1495,6 +1495,8 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
                             bool change_format = false);
   static void CopyAttrsConv2DDepthwise(const Node* orig_node, NodeBuilder* nb,
                                        bool change_format = false);
+  static void CopyAttrsConv2DDepthwiseCheckConstFilter(
+      const Node* orig_node, NodeBuilder* nb, bool change_format = false);
   static void CopyAttrsConvCheckConstFilter(const Node* orig_node,
                                             NodeBuilder* nb,
                                             bool change_format = false);
@@ -2218,6 +2220,29 @@ void MklLayoutRewritePass::CopyAttrsFromPadAndFusedConv2D(
 void MklLayoutRewritePass::CopyAttrsConv2DDepthwise(const Node* orig_node,
                                                     NodeBuilder* nb,
                                                     bool change_format) {
+  DataType T;
+  string data_format;
+  string padding;
+  std::vector<int32> strides;
+  std::vector<int32> dilations;
+
+  // Get all attributes from old node.
+  TF_CHECK_OK(GetNodeAttr(orig_node->def(), "T", &T));
+  TF_CHECK_OK(GetNodeAttr(orig_node->def(), "strides", &strides));
+  TF_CHECK_OK(GetNodeAttr(orig_node->def(), "dilations", &dilations));
+  TF_CHECK_OK(GetNodeAttr(orig_node->def(), "padding", &padding));
+  TF_CHECK_OK(GetNodeAttr(orig_node->def(), "data_format", &data_format));
+
+  // Add attributes to new node.
+  nb->Attr("T", T);
+  nb->Attr("strides", strides);
+  nb->Attr("dilations", dilations);
+  nb->Attr("padding", padding);
+  nb->Attr("data_format", data_format);
+}
+
+void MklLayoutRewritePass::CopyAttrsConv2DDepthwiseCheckConstFilter(
+    const Node* orig_node, NodeBuilder* nb, bool change_format) {
   DataType T;
   string data_format;
   string padding;

--- a/tensorflow/core/kernels/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl_fused_ops_test.cc
@@ -434,7 +434,7 @@ class FilterCacheTest : public OpsTestBase {
     // Compare outputs to expected results
     const Tensor& output = *GetOutput(0);
     const Tensor& output_layout = *GetOutput(2);
-    ConvMklToTF<T> conv_comp;
+    CommonTestUtilities<T> conv_comp;
     conv_comp.ConvertAndCompare(dtype, output, output_layout, expected);
 
     // TODO(bhavanis): For now, we rely on internal performance tests to
@@ -446,7 +446,7 @@ class FilterCacheTest : public OpsTestBase {
     // Compare output to expected results
     const Tensor& output_new = *GetOutput(0);
     const Tensor& output_layout_new = *GetOutput(2);
-    ConvMklToTF<T> conv_comp_new;
+    CommonTestUtilities<T> conv_comp_new;
     conv_comp_new.ConvertAndCompare(dtype, output_new, output_layout_new,
                                     expected);
   }


### PR DESCRIPTION
This fix causes `//tensorflow/core:graph_mkl_layout_pass_test` and `//tensorflow/python/keras:convolutional_test` unit tests to pass.