### PR TITLE
Add check_ops.assert_shapes and tests

### DIFF
--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -1467,7 +1467,10 @@ class AssertShapesTest(test.TestCase):
       x: ('N', 'Q'),
       y: ('N', 'D'),
     }
-    regex = "Specified by tensor .* dimension 0.  Tensor .* dimension 0 must have size 3.  Received size 2"
+    regex = (
+        r"Specified by tensor .* dimension 0.  "
+        r"Tensor .* dimension 0 must have size 3.  "
+        r"Received size 2")
     self.raises_static_error(shapes=shapes, regex=regex)
 
   def test_raise_dynamic_shape_mismatch(self):
@@ -1478,7 +1481,9 @@ class AssertShapesTest(test.TestCase):
         x: ('N', 'Q'),
         y: ('N', 'D'),
       }
-      regex = "\[Specified by tensor x.* dimension 0\] \[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]"
+      regex = (
+          "\[Specified by tensor x.* dimension 0\] "
+          "\[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]")
       feed_dict = {
         x: np.ones([3, 2]),
         y: np.ones([2, 3])
@@ -1493,7 +1498,10 @@ class AssertShapesTest(test.TestCase):
       x: (3, 'Q'),
       y: (3, 'D'),
     }
-    regex = "Specified explicitly.  Tensor .* dimension 0 must have size 3.  Received size 2"
+    regex = (
+        r"Specified explicitly.  "
+        r"Tensor .* dimension 0 must have size 3.  "
+        r"Received size 2")
     self.raises_static_error(shapes=shapes, regex=regex)
 
   @test_util.run_in_graph_and_eager_modes
@@ -1504,7 +1512,10 @@ class AssertShapesTest(test.TestCase):
       x: (3, 'Q'),
       y: (..., 3, 'D'),
     }
-    regex = "Specified explicitly.  Tensor .* dimension -2 must have size 3.  Received size 2"
+    regex = (
+        r"Specified explicitly.  "
+        r"Tensor .* dimension -2 must have size 3.  "
+        r"Received size 2")
     self.raises_static_error(shapes=shapes, regex=regex)
 
   def test_raise_dynamic_shape_explicit_mismatch(self):
@@ -1515,7 +1526,9 @@ class AssertShapesTest(test.TestCase):
         x: (3, 'Q'),
         y: (3, 'D'),
       }
-      regex = "\[Specified explicitly\] \[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]"
+      regex = (
+          r"\[Specified explicitly\] "
+          r"\[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]")
       feed_dict = {
         x: np.ones([3, 2]),
         y: np.ones([2, 3])
@@ -1540,8 +1553,9 @@ class AssertShapesTest(test.TestCase):
     shapes={
       x: ('N', ..., 'Q'),
     }
-    regex = r"Tensor .*.  Symbol `...` for variable number of " \
-            r"unspecified dimensions is only allowed as the first entry"
+    regex = (
+        r"Tensor .*.  Symbol `...` for variable number of "
+        r"unspecified dimensions is only allowed as the first entry")
     self.raises_static_error(shapes=shapes, regex=regex)
 
   @test_util.run_in_graph_and_eager_modes
@@ -1583,12 +1597,17 @@ class AssertShapesTest(test.TestCase):
 
     def raises_static_rank_error(shapes, x, correct_rank, actual_rank):
       for shape in shapes:
-        regex = "Tensor .* must have rank %d.  Received rank %d" % (correct_rank, actual_rank)
+        regex = (
+            r"Tensor .* must have rank %d.  Received rank %d"
+            % (correct_rank, actual_rank))
         self.raises_static_error(shapes={x: shape}, regex=regex)
 
-    raises_static_rank_error(rank_two_shapes, array_ops.ones([1]), correct_rank=2, actual_rank=1)
-    raises_static_rank_error(rank_three_shapes, array_ops.ones([1, 1]), correct_rank=3, actual_rank=2)
-    raises_static_rank_error(rank_three_shapes, array_ops.constant(1), correct_rank=3, actual_rank=0)
+    raises_static_rank_error(rank_two_shapes, array_ops.ones([1]),
+                             correct_rank=2, actual_rank=1)
+    raises_static_rank_error(rank_three_shapes, array_ops.ones([1, 1]),
+                             correct_rank=3, actual_rank=2)
+    raises_static_rank_error(rank_three_shapes, array_ops.constant(1),
+                             correct_rank=3, actual_rank=0)
 
   def test_raises_dynamic_incorrect_rank(self):
     x_value = 5
@@ -1602,8 +1621,9 @@ class AssertShapesTest(test.TestCase):
       x = array_ops.placeholder(dtypes.float32, None)
 
       for shape in rank_two_shapes:
-        regex = "Tensor .* must have rank\] \[2\]"
-        self.raises_dynamic_error(shapes={x: shape}, regex=regex, feed_dict={x: x_value})
+        regex = r"Tensor .* must have rank\] \[2\]"
+        self.raises_dynamic_error(shapes={x: shape}, regex=regex,
+                                  feed_dict={x: x_value})
 
   @test_util.run_in_graph_and_eager_modes
   def test_correctly_matching(self):

--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -1554,7 +1554,7 @@ class AssertShapesTest(test.TestCase):
         x: ('N', ..., 'Q'),
     }
     regex = (
-        r"Tensor .*.  Symbol `...` for variable number of "
+        r"Tensor .*.  Symbol `...` for a variable number of "
         r"unspecified dimensions is only allowed as the first entry")
     self.raises_static_error(shapes=shapes, regex=regex)
 

--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -1460,60 +1460,54 @@ class AssertTypeTest(test.TestCase):
 class AssertShapesTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
-  def test_raise_shape_mismatch(self):
-    x_known = array_ops.ones([3, 2], name="x")
-    y_known = array_ops.ones([2, 3], name="y")
-
+  def test_raise_static_shape_mismatch(self):
+    x = array_ops.ones([3, 2], name="x")
+    y = array_ops.ones([2, 3], name="y")
     shapes = {
-        x_known: ('N', 'Q'),
-        y_known: ('N', 'D'),
+      x: ('N', 'Q'),
+      y: ('N', 'D'),
     }
-    regex = r"Specified by tensor .* dimension 0.  " \
-            r"Tensor .* dimension 0 must have size 3.  Received size 2"
+    regex = "Specified by tensor .* dimension 0.  Tensor .* dimension 0 must have size 3.  Received size 2"
     self.raises_static_error(shapes=shapes, regex=regex)
 
-    if not context.executing_eagerly():
-      x_unknown = array_ops.placeholder(dtypes.float32, [None, 2], name="x")
-      y_unknown = array_ops.placeholder(dtypes.float32, [None, 3], name="y")
-
+  def test_raise_dynamic_shape_mismatch(self):
+    with ops.Graph().as_default():
+      x = array_ops.placeholder(dtypes.float32, [None, 2], name="x")
+      y = array_ops.placeholder(dtypes.float32, [None, 3], name="y")
       shapes = {
-          x_unknown: ('N', 'Q'),
-          y_unknown: ('N', 'D'),
+        x: ('N', 'Q'),
+        y: ('N', 'D'),
       }
-      regex = r"\[Specified by tensor x.* dimension 0\] " \
-              r"\[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]"
+      regex = "\[Specified by tensor x.* dimension 0\] \[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]"
       feed_dict = {
-          x_unknown: np.ones([3, 2]),
-          y_unknown: np.ones([2, 3])
+        x: np.ones([3, 2]),
+        y: np.ones([2, 3])
       }
       self.raises_dynamic_error(shapes=shapes, regex=regex, feed_dict=feed_dict)
 
   @test_util.run_in_graph_and_eager_modes
-  def test_raise_shape_explicit_mismatch(self):
-    x_known = array_ops.ones([3, 2], name="x")
-    y_known = array_ops.ones([2, 3], name="y")
-
+  def test_raise_static_shape_explicit_mismatch(self):
+    x = array_ops.ones([3, 2], name="x")
+    y = array_ops.ones([2, 3], name="y")
     shapes = {
-        x_known: (3, 'Q'),
-        y_known: (3, 'D'),
+      x: (3, 'Q'),
+      y: (3, 'D'),
     }
-    regex = r"Specified explicitly.  " \
-            r"Tensor .* dimension 0 must have size 3.  Received size 2"
+    regex = "Specified explicitly.  Tensor .* dimension 0 must have size 3.  Received size 2"
     self.raises_static_error(shapes=shapes, regex=regex)
 
-    if not context.executing_eagerly():
-      x_unknown = array_ops.placeholder(dtypes.float32, [None, 2], name="xa")
-      y_unknown = array_ops.placeholder(dtypes.float32, [None, 3], name="y")
-
+  def test_raise_dynamic_shape_explicit_mismatch(self):
+    with ops.Graph().as_default():
+      x = array_ops.placeholder(dtypes.float32, [None, 2], name="xa")
+      y = array_ops.placeholder(dtypes.float32, [None, 3], name="y")
       shapes = {
-          x_unknown: (3, 'Q'),
-          y_unknown: (3, 'D'),
+        x: (3, 'Q'),
+        y: (3, 'D'),
       }
-      regex = r"\[Specified explicitly\] \[Tensor y.* dimension\] \[0\] " \
-              r"\[must have size\] \[3\]"
+      regex = "\[Specified explicitly\] \[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]"
       feed_dict = {
-          x_unknown: np.ones([3, 2]),
-          y_unknown: np.ones([2, 3])
+        x: np.ones([3, 2]),
+        y: np.ones([2, 3])
       }
       self.raises_dynamic_error(shapes=shapes, regex=regex, feed_dict=feed_dict)
 
@@ -1522,11 +1516,11 @@ class AssertShapesTest(test.TestCase):
     x = array_ops.ones([1, 2, 3, 2], name="x")
     y = array_ops.ones([2, 3, 3], name="y")
     assertion = check_ops.assert_shapes(
-        shapes={
-            x: ('N', 'Q'),
-            y: ('N', 'D'),
-        },
-        event_shape_only=True
+      {
+        x: ('N', 'Q'),
+        y: ('N', 'D'),
+      },
+      event_shape_only=True
     )
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)
@@ -1536,62 +1530,62 @@ class AssertShapesTest(test.TestCase):
   def test_no_op_when_specified_as_unknown(self):
     x = array_ops.constant([1, 1], name="x")
     assertion = check_ops.assert_shapes({
-        x: None
+      x: None
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)
     self.evaluate(out)
 
   @test_util.run_in_graph_and_eager_modes
-  def test_dim_size_specfified_as_unknown(self):
+  def test_dim_size_specified_as_unknown(self):
     x = array_ops.ones([1, 2, 3], name="x")
     y = array_ops.ones([2, 1], name="y")
     assertion = check_ops.assert_shapes({
-        x: (None, 2, None),
-        y: (None, 1),
+      x: (None, 2, None),
+      y: (None, 1),
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)
     self.evaluate(out)
 
   @test_util.run_in_graph_and_eager_modes
-  def test_raises_incorrect_rank(self):
+  def test_raises_static_incorrect_rank(self):
     rank_two_shapes = [
-        (1, 1),
-        (1, 3),
-        ('a', 'b'),
-        (None, None)
+      (1, 1),
+      (1, 3),
+      ('a', 'b'),
+      (None, None)
     ]
     rank_three_shapes = [
-        (1, 1, 1),
-        ('a', 'b', 'c'),
-        (None, None, None),
-        (1, 'b', None),
+      (1, 1, 1),
+      ('a', 'b', 'c'),
+      (None, None, None),
+      (1, 'b', None),
     ]
 
     def raises_static_rank_error(shapes, x, correct_rank, actual_rank):
       for shape in shapes:
-        regex = r"Tensor .* must have rank %d.  Received rank %d" % \
-                (correct_rank, actual_rank)
+        regex = "Tensor .* must have rank %d.  Received rank %d" % (correct_rank, actual_rank)
         self.raises_static_error(shapes={x: shape}, regex=regex)
 
-    def raises_dynamic_rank_error(shapes, x, x_value, correct_rank):
-      for shape in shapes:
-        regex = r"Tensor .* must have rank\] \[%d\]" % correct_rank
-        self.raises_dynamic_error(shapes={x: shape}, regex=regex,
-                                  feed_dict={x: x_value})
+    raises_static_rank_error(rank_two_shapes, array_ops.ones([1]), correct_rank=2, actual_rank=1)
+    raises_static_rank_error(rank_three_shapes, array_ops.ones([1, 1]), correct_rank=3, actual_rank=2)
+    raises_static_rank_error(rank_three_shapes, array_ops.constant(1), correct_rank=3, actual_rank=0)
 
-    raises_static_rank_error(rank_two_shapes, array_ops.ones([1]),
-                             correct_rank=2, actual_rank=1)
-    raises_static_rank_error(rank_three_shapes, array_ops.ones([1, 1]),
-                             correct_rank=3, actual_rank=2)
-    raises_static_rank_error(rank_three_shapes, array_ops.constant(1),
-                             correct_rank=3, actual_rank=0)
+  def test_raises_dynamic_incorrect_rank(self):
+    x_value = 5
+    rank_two_shapes = [
+      (1, 1),
+      (1, 3),
+      ('a', 'b'),
+      (None, None)
+    ]
+    with ops.Graph().as_default():
+      x = array_ops.placeholder(dtypes.float32, None)
 
-    if not context.executing_eagerly():
-      raises_dynamic_rank_error(
-          rank_two_shapes, array_ops.placeholder(dtypes.float32, None), 5,
-          correct_rank=2)
+      for shape in rank_two_shapes:
+        regex = "Tensor .* must have rank\] \[2\]"
+        self.raises_dynamic_error(shapes={x: shape}, regex=regex, feed_dict={x: x_value})
 
   @test_util.run_in_graph_and_eager_modes
   def test_correctly_matching(self):
@@ -1602,23 +1596,23 @@ class AssertShapesTest(test.TestCase):
     y = array_ops.ones([3, 1, 2], name="y")
     z = array_ops.ones([2, 3, 1], name="z")
     assertion = check_ops.assert_shapes({
-        x: ('a', 'b', 'c'),
-        y: ('c', 'a', 'b'),
-        z: ('b', 'c', 'a'),
-        v: ('a', 'b'),
-        w: ('c',),
-        u: 'a'
+      x: ('a', 'b', 'c'),
+      y: ('c', 'a', 'b'),
+      z: ('b', 'c', 'a'),
+      v: ('a', 'b'),
+      w: ('c',),
+      u: 'a'
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)
     self.evaluate(out)
     assertion = check_ops.assert_shapes({
-        x: (1, 'b', 'c'),
-        y: ('c', 'a', 2),
-        z: ('b', 3, 'a'),
-        v: ('a', 2),
-        w: (3,),
-        u: 1
+      x: (1, 'b', 'c'),
+      y: ('c', 'a', 2),
+      z: ('b', 3, 'a'),
+      v: ('a', 2),
+      w: (3,),
+      u: 1
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)
@@ -1629,8 +1623,8 @@ class AssertShapesTest(test.TestCase):
     x = array_ops.ones([4, 1], name="x")
     y = array_ops.ones([4, 2], name="y")
     assertion = check_ops.assert_shapes({
-        x: ('num_observations', 'input_dimensionality'),
-        y: ('num_observations', 'output_dimensionality'),
+      x: ('num_observations', 'input_dim'),
+      y: ('num_observations', 'output_dim'),
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)

--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -1464,8 +1464,8 @@ class AssertShapesTest(test.TestCase):
     x = array_ops.ones([3, 2], name="x")
     y = array_ops.ones([2, 3], name="y")
     shapes = {
-      x: ('N', 'Q'),
-      y: ('N', 'D'),
+        x: ('N', 'Q'),
+        y: ('N', 'D'),
     }
     regex = (
         r"Specified by tensor .* dimension 0.  "
@@ -1478,15 +1478,15 @@ class AssertShapesTest(test.TestCase):
       x = array_ops.placeholder(dtypes.float32, [None, 2], name="x")
       y = array_ops.placeholder(dtypes.float32, [None, 3], name="y")
       shapes = {
-        x: ('N', 'Q'),
-        y: ('N', 'D'),
+          x: ('N', 'Q'),
+          y: ('N', 'D'),
       }
       regex = (
-          "\[Specified by tensor x.* dimension 0\] "
-          "\[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]")
+          r"\[Specified by tensor x.* dimension 0\] "
+          r"\[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]")
       feed_dict = {
-        x: np.ones([3, 2]),
-        y: np.ones([2, 3])
+          x: np.ones([3, 2]),
+          y: np.ones([2, 3])
       }
       self.raises_dynamic_error(shapes=shapes, regex=regex, feed_dict=feed_dict)
 
@@ -1495,8 +1495,8 @@ class AssertShapesTest(test.TestCase):
     x = array_ops.ones([3, 2], name="x")
     y = array_ops.ones([2, 3], name="y")
     shapes = {
-      x: (3, 'Q'),
-      y: (3, 'D'),
+        x: (3, 'Q'),
+        y: (3, 'D'),
     }
     regex = (
         r"Specified explicitly.  "
@@ -1509,8 +1509,8 @@ class AssertShapesTest(test.TestCase):
     x = array_ops.ones([3, 2], name="x")
     y = array_ops.ones([2, 3], name="y")
     shapes = {
-      x: (3, 'Q'),
-      y: (..., 3, 'D'),
+        x: (3, 'Q'),
+        y: (..., 3, 'D'),
     }
     regex = (
         r"Specified explicitly.  "
@@ -1523,15 +1523,15 @@ class AssertShapesTest(test.TestCase):
       x = array_ops.placeholder(dtypes.float32, [None, 2], name="xa")
       y = array_ops.placeholder(dtypes.float32, [None, 3], name="y")
       shapes = {
-        x: (3, 'Q'),
-        y: (3, 'D'),
+          x: (3, 'Q'),
+          y: (3, 'D'),
       }
       regex = (
           r"\[Specified explicitly\] "
           r"\[Tensor y.* dimension\] \[0\] \[must have size\] \[3\]")
       feed_dict = {
-        x: np.ones([3, 2]),
-        y: np.ones([2, 3])
+          x: np.ones([3, 2]),
+          y: np.ones([2, 3])
       }
       self.raises_dynamic_error(shapes=shapes, regex=regex, feed_dict=feed_dict)
 
@@ -1550,8 +1550,8 @@ class AssertShapesTest(test.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def test_raise_variable_num_outer_dims_prefix_misuse(self):
     x = array_ops.ones([1, 2], name="x")
-    shapes={
-      x: ('N', ..., 'Q'),
+    shapes = {
+        x: ('N', ..., 'Q'),
     }
     regex = (
         r"Tensor .*.  Symbol `...` for variable number of "
@@ -1562,7 +1562,7 @@ class AssertShapesTest(test.TestCase):
   def test_no_op_when_specified_as_unknown(self):
     x = array_ops.constant([1, 1], name="x")
     assertion = check_ops.assert_shapes({
-      x: None
+        x: None
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)
@@ -1573,8 +1573,8 @@ class AssertShapesTest(test.TestCase):
     x = array_ops.ones([1, 2, 3], name="x")
     y = array_ops.ones([2, 1], name="y")
     assertion = check_ops.assert_shapes({
-      x: (None, 2, None),
-      y: (None, 1),
+        x: (None, 2, None),
+        y: (None, 1),
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)
@@ -1583,16 +1583,16 @@ class AssertShapesTest(test.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def test_raises_static_incorrect_rank(self):
     rank_two_shapes = [
-      (1, 1),
-      (1, 3),
-      ('a', 'b'),
-      (None, None),
+        (1, 1),
+        (1, 3),
+        ('a', 'b'),
+        (None, None),
     ]
     rank_three_shapes = [
-      (1, 1, 1),
-      ('a', 'b', 'c'),
-      (None, None, None),
-      (1, 'b', None),
+        (1, 1, 1),
+        ('a', 'b', 'c'),
+        (None, None, None),
+        (1, 'b', None),
     ]
 
     def raises_static_rank_error(shapes, x, correct_rank, actual_rank):
@@ -1612,10 +1612,10 @@ class AssertShapesTest(test.TestCase):
   def test_raises_dynamic_incorrect_rank(self):
     x_value = 5
     rank_two_shapes = [
-      (1, 1),
-      (1, 3),
-      ('a', 'b'),
-      (None, None)
+        (1, 1),
+        (1, 3),
+        ('a', 'b'),
+        (None, None)
     ]
     with ops.Graph().as_default():
       x = array_ops.placeholder(dtypes.float32, None)
@@ -1634,23 +1634,23 @@ class AssertShapesTest(test.TestCase):
     y = array_ops.ones([3, 1, 2], name="y")
     z = array_ops.ones([2, 3, 1], name="z")
     assertion = check_ops.assert_shapes({
-      x: ('a', 'b', 'c'),
-      y: ('c', 'a', 'b'),
-      z: ('b', 'c', 'a'),
-      v: ('a', 'b'),
-      w: ('c',),
-      u: 'a'
+        x: ('a', 'b', 'c'),
+        y: ('c', 'a', 'b'),
+        z: ('b', 'c', 'a'),
+        v: ('a', 'b'),
+        w: ('c',),
+        u: 'a'
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)
     self.evaluate(out)
     assertion = check_ops.assert_shapes({
-      x: (1, 'b', 'c'),
-      y: ('c', 'a', 2),
-      z: ('b', 3, 'a'),
-      v: ('a', 2),
-      w: (3,),
-      u: 1
+        x: (1, 'b', 'c'),
+        y: ('c', 'a', 2),
+        z: ('b', 3, 'a'),
+        v: ('a', 2),
+        w: (3,),
+        u: 1
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)
@@ -1661,8 +1661,8 @@ class AssertShapesTest(test.TestCase):
     x = array_ops.ones([4, 1], name="x")
     y = array_ops.ones([4, 2], name="y")
     assertion = check_ops.assert_shapes({
-      x: ('num_observations', 'input_dim'),
-      y: ('num_observations', 'output_dim'),
+        x: ('num_observations', 'input_dim'),
+        y: ('num_observations', 'output_dim'),
     })
     with ops.control_dependencies([assertion]):
       out = array_ops.identity(x)

--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -1773,7 +1773,7 @@ class AssertShapesTest(test.TestCase):
     y = array_ops.ones([2, 3], name="y")
     s1 = {
         x: (3, 'Q'),
-        y: (..., 3, 'D'),
+        y: (Ellipsis, 3, 'D'),
     }
     s2 = {
         x: "3Q",
@@ -1791,8 +1791,8 @@ class AssertShapesTest(test.TestCase):
     x = array_ops.ones([1, 2, 3, 2], name="x")
     y = array_ops.ones([2, 3, 3], name="y")
     a1 = check_ops.assert_shapes({
-        x: (..., 'N', 'Q'),
-        y: (..., 'N', 'D'),
+        x: (Ellipsis, 'N', 'Q'),
+        y: (Ellipsis, 'N', 'D'),
     })
     a2 = check_ops.assert_shapes({
         x: "*NQ",
@@ -1806,7 +1806,7 @@ class AssertShapesTest(test.TestCase):
   def test_raise_variable_num_outer_dims_prefix_misuse(self):
     x = array_ops.ones([1, 2], name="x")
     s1 = {
-        x: ('N', ..., 'Q'),
+        x: ('N', Ellipsis, 'Q'),
     }
     s2 = {
         x: "N*Q",

--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -1564,7 +1564,7 @@ class AssertShapesTest(test.TestCase):
     regex = (
         r"Tensor .*.  "
         r"Specified shape must be an iterable.  "
-        r"An iterable has the attribute `__iter__`.  "
+        r"An iterable has the attribute `__iter__` or `__getitem__`.  "
         r"Received specified shape: 2")
     self.raises_static_error(shapes=shapes, regex=regex)
 

--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -1756,12 +1756,12 @@ class AssertShapesTest(test.TestCase):
         y: (None, 1),
     })
     a2 = check_ops.assert_shapes({
-        x: ('*', 2, '*'),
-        y: ('*', 1),
+        x: ('.', 2, '.'),
+        y: ('.', 1),
     })
     a3 = check_ops.assert_shapes({
-        x: "*2*",
-        y: "*1",
+        x: ".2.",
+        y: ".1",
     })
     with ops.control_dependencies([a1, a2, a3]):
       out = array_ops.identity(x)
@@ -1777,7 +1777,7 @@ class AssertShapesTest(test.TestCase):
     }
     s2 = {
         x: "3Q",
-        y: "#3D",
+        y: "*3D",
     }
     regex = (
         r"Specified explicitly.  "
@@ -1795,8 +1795,8 @@ class AssertShapesTest(test.TestCase):
         y: (..., 'N', 'D'),
     })
     a2 = check_ops.assert_shapes({
-        x: "#NQ",
-        y: "#ND",
+        x: "*NQ",
+        y: "*ND",
     })
     with ops.control_dependencies([a1, a2]):
       out = array_ops.identity(x)
@@ -1809,11 +1809,11 @@ class AssertShapesTest(test.TestCase):
         x: ('N', ..., 'Q'),
     }
     s2 = {
-        x: "N#Q",
+        x: "N*Q",
     }
     regex = (
         r"Tensor .* specified shape index .*.  "
-        r"Symbol `...` or `#` for a variable number of "
+        r"Symbol `...` or `\*` for a variable number of "
         r"unspecified dimensions is only allowed as the first entry")
     self.raises_static_error(shapes=s1, regex=regex)
     self.raises_static_error(shapes=s2, regex=regex)

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1707,13 +1707,6 @@ def assert_shapes(shapes, event_shape_only=False, data=None, summarize=None,
           size = actual_sizes[tensor_dim]
           size_specifications[size_symbol] = (size, x, tensor_dim)
 
-    if not rank_assertions:
-      rank_assertions = \
-        [control_flow_ops.no_op(name='static_checks_determined_all_ok')]
-    if not size_assertions:
-      size_assertions = \
-        [control_flow_ops.no_op(name='static_checks_determined_all_ok')]
-
     with ops.control_dependencies(rank_assertions):
       shapes_assertion = control_flow_ops.group(size_assertions)
     return shapes_assertion

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1629,7 +1629,7 @@ def assert_shapes(shapes, data=None, summarize=None,
         else:
           name = x.name
         raise ValueError(
-            '%s.  Tensor %s.  Symbol `...` for variable number of unspecified '
+            '%s.  Tensor %s.  Symbol `...` for a variable number of unspecified '
             'dimensions is only allowed as the first entry' % (message, name))
 
     # Shape specified as None implies no constraint
@@ -1675,7 +1675,7 @@ def assert_shapes(shapes, data=None, summarize=None,
 
       innermost_dims = False
       if _contains_variable_num_outer_dims_prefix(symbolic_sizes):
-        # inner-most symbolic sizes, i.e. (..., sizes)
+        # Inner-most symbolic sizes, i.e. (..., sizes)
         symbolic_sizes = symbolic_sizes[1:]
         innermost_dims = True
 

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1675,7 +1675,8 @@ def assert_shapes(shapes, data=None, summarize=None,
 
       innermost_dims = False
       if _contains_variable_num_outer_dims_prefix(symbolic_sizes):
-        symbolic_sizes = symbolic_sizes[1:] # inner-most symbolic sizes, i.e. (..., sizes)
+        # inner-most symbolic sizes, i.e. (..., sizes)
+        symbolic_sizes = symbolic_sizes[1:]
         innermost_dims = True
 
       for i, size_symbol in enumerate(symbolic_sizes):
@@ -1700,8 +1701,9 @@ def assert_shapes(shapes, data=None, summarize=None,
               name_y = _shape_and_dtype_str(specified_by_y)
             else:
               name_y = specified_by_y.name
-            size_check_message = 'Specified by tensor %s dimension %d' % \
-                                 (name_y, specified_at_dim)
+            size_check_message = (
+                'Specified by tensor %s dimension %d' %
+                (name_y, specified_at_dim))
 
           if executing_eagerly:
             name = _shape_and_dtype_str(x)

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1555,7 +1555,7 @@ def _has_known_value(dimension_size):
 
 
 @tf_export('debugging.assert_shapes', 'assert_shapes')
-def assert_shapes(shapes, event_shape_only=False, data=None, summarize=None,
+def assert_shapes(shapes, innermost_dims=False, data=None, summarize=None,
                   message=None, name=None):
   """Assert tensor shapes and dimension size relationships between tensors.
 
@@ -1584,8 +1584,8 @@ def assert_shapes(shapes, event_shape_only=False, data=None, summarize=None,
   Args:
     shapes: dictionary with (`Tensor` to shape) items. A shape is either a
     tuple/list of size entries or a single size entry.
-    event_shape_only: `bool`, if to apply constraints on only
-      the rightmost dimensions or on the whole shapes (default).
+    innermost_dims: `bool`, if to apply constraints on the inner-most
+    dimensions only.
     message: A string to prefix to the default message.
     summarize: Print this many entries of each tensor.
     name: A name for this operation (optional).  Defaults to "assert_shapes".
@@ -1624,7 +1624,7 @@ def assert_shapes(shapes, event_shape_only=False, data=None, summarize=None,
     rank_assertions = []
     for x in shapes.keys():
       shape = shapes[x]
-      if event_shape_only:
+      if innermost_dims:
         assertion = assert_rank_at_least(
             x=x, rank=rank(shape), data=data, summarize=summarize,
             message=message, name=name)
@@ -1655,7 +1655,7 @@ def assert_shapes(shapes, event_shape_only=False, data=None, summarize=None,
           # Size specified with None implies no constraint
           continue
 
-        if event_shape_only:
+        if innermost_dims:
           tensor_dim = i - len(symbolic_sizes)
         else:
           tensor_dim = i

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1613,8 +1613,8 @@ def assert_shapes(shapes, data=None, summarize=None,
   with ops.name_scope(name, 'assert_shapes', [shapes, data]):
 
     shapes = {
-      ops.convert_to_tensor(x): shapes[x]
-      for x in shapes
+        ops.convert_to_tensor(x): shapes[x]
+        for x in shapes
     }
 
     executing_eagerly = context.executing_eagerly()
@@ -1629,8 +1629,8 @@ def assert_shapes(shapes, data=None, summarize=None,
         else:
           name = x.name
         raise ValueError(
-          '%s.  Tensor %s.  Symbol `...` for variable number of unspecified '
-          'dimensions is only allowed as the first entry' % (message, name))
+            '%s.  Tensor %s.  Symbol `...` for variable number of unspecified '
+            'dimensions is only allowed as the first entry' % (message, name))
 
     # Shape specified as None implies no constraint
     shapes = {

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1586,8 +1586,10 @@ def assert_shapes(shapes, innermost_dims=False, data=None, summarize=None,
     tuple/list of size entries or a single size entry.
     innermost_dims: `bool`, if to apply constraints on the inner-most
     dimensions only.
-    message: A string to prefix to the default message.
+    data: The tensors to print out if the condition is False.  Defaults to
+    error message and first few entries of the violating tensor.
     summarize: Print this many entries of each tensor.
+    message: A string to prefix to the default message.
     name: A name for this operation (optional).  Defaults to "assert_shapes".
 
   Returns:

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1629,7 +1629,8 @@ def assert_shapes(shapes, data=None, summarize=None,
         else:
           name = x.name
         raise ValueError(
-            '%s.  Tensor %s.  Symbol `...` for a variable number of unspecified '
+            '%s.  '
+            'Tensor %s.  Symbol `...` for a variable number of unspecified '
             'dimensions is only allowed as the first entry' % (message, name))
 
     # Shape specified as None implies no constraint

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1643,11 +1643,15 @@ def assert_shapes(shapes, data=None, summarize=None,
 
     for x in shapes:
       symbolic_shape = shapes[x]
-      if not hasattr(symbolic_shape, "__iter__"):
+      is_iterable = (
+        hasattr(symbolic_shape, "__iter__") or
+        hasattr(symbolic_shape, "__getitem__") # For Python 2 compat.
+      )
+      if not is_iterable:
         raise ValueError(
             '%s.  '
             'Tensor %s.  Specified shape must be an iterable.  '
-            'An iterable has the attribute `__iter__`.  '
+            'An iterable has the attribute `__iter__` or `__getitem__`.  '
             'Received specified shape: %s'
             % (message, tensor_name(x), symbolic_shape))
       shapes[x] = tuple(shapes[x])

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1561,7 +1561,7 @@ def _is_symbol_for_any_size(symbol):
 
 
 def _is_symbol_for_unspecified_dims(symbol):
-  return symbol in [..., '*']
+  return symbol in [Ellipsis, '*']
 
 
 @tf_export('debugging.assert_shapes', 'assert_shapes')

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1557,11 +1557,11 @@ def _has_known_value(dimension_size):
 
 
 def _is_symbol_for_any_size(symbol):
-  return symbol in [None, '*']
+  return symbol in [None, '.']
 
 
 def _is_symbol_for_unspecified_dims(symbol):
-  return symbol in [..., '#']
+  return symbol in [..., '*']
 
 
 @tf_export('debugging.assert_shapes', 'assert_shapes')
@@ -1592,9 +1592,9 @@ def assert_shapes(shapes, data=None, summarize=None,
   their __hash__, except:
     - a size entry is interpreted as an explicit size if it can be parsed as an
       integer primitive.
-    - a size entry is interpreted as *any* size if it is None or '*'.
+    - a size entry is interpreted as *any* size if it is None or '.'.
 
-  If the first entry of a shape is `...` (type `Ellipsis`) or '#' that indicates
+  If the first entry of a shape is `...` (type `Ellipsis`) or '*' that indicates
   a variable number of outer dimensions of unspecified size, i.e. the constraint
   applies to the inner-most dimensions only.
 
@@ -1662,7 +1662,7 @@ def assert_shapes(shapes, data=None, summarize=None,
           raise ValueError(
               '%s.  '
               'Tensor %s specified shape index %d.  '
-              'Symbol `...` or `#` for a variable number of '
+              'Symbol `...` or `*` for a variable number of '
               'unspecified dimensions is only allowed as the first entry'
               % (message, tensor_name(x), i))
         tensors_specified_innermost.add(x)

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1564,7 +1564,60 @@ def _is_symbol_for_unspecified_dims(symbol):
   return symbol in [Ellipsis, '*']
 
 
-@tf_export('debugging.assert_shapes', 'assert_shapes')
+@tf_export('debugging.assert_shapes', v1=[])
+def assert_shapes_v2(shapes, data=None, summarize=None,
+                     message=None, name=None):
+  """Assert tensor shapes and dimension size relationships between tensors.
+
+  This Op checks that a collection of tensors shape relationships
+  satisfies given constraints.
+
+  Example:
+
+  ```python
+  tf.assert_shapes({
+    x: ('N', 'Q'),
+    y: ('N', 'D'),
+    param: ('Q',),
+    scalar: ()
+  })
+  ```
+
+  If `x`, `y`, `param` or `scalar` does not have a shape that satisfies
+  all specified constraints, `message`, as well as the first `summarize` entries
+  of the first encountered violating tensor are printed, and
+  `InvalidArgumentError` is raised.
+
+  Size entries in the specified shapes are checked against other entries by
+  their __hash__, except:
+    - a size entry is interpreted as an explicit size if it can be parsed as an
+      integer primitive.
+    - a size entry is interpreted as *any* size if it is None or '.'.
+
+  If the first entry of a shape is `...` (type `Ellipsis`) or '*' that indicates
+  a variable number of outer dimensions of unspecified size, i.e. the constraint
+  applies to the inner-most dimensions only.
+
+  Scalar tensors and specified shapes of length zero (excluding the 'inner-most'
+  prefix) are both treated as having a single dimension of size one.
+
+  Args:
+    shapes: dictionary with (`Tensor` to shape) items. A shape must be an
+    iterable.
+    data: The tensors to print out if the condition is False.  Defaults to
+    error message and first few entries of the violating tensor.
+    summarize: Print this many entries of the tensor.
+    message: A string to prefix to the default message.
+    name: A name for this operation (optional).  Defaults to "assert_shapes".
+
+  Raises:
+    ValueError:  If static checks determine any shape constraint is violated.
+  """
+  assert_shapes(shapes, data=data, summarize=summarize,
+                message=message, name=name)
+
+
+@tf_export(v1=['debugging.assert_shapes'])
 def assert_shapes(shapes, data=None, summarize=None,
                   message=None, name=None):
   """Assert tensor shapes and dimension size relationships between tensors.
@@ -1581,6 +1634,13 @@ def assert_shapes(shapes, data=None, summarize=None,
     param: ('Q',),
     scalar: ()
   })
+  ```
+
+  Example of adding a dependency to an operation:
+
+  ```python
+  with tf.control_dependencies([tf.assert_shapes(shapes)]):
+    output = tf.matmul(x, y, transpose_a=True)
   ```
 
   If `x`, `y`, `param` or `scalar` does not have a shape that satisfies
@@ -1644,8 +1704,8 @@ def assert_shapes(shapes, data=None, summarize=None,
     for x in shapes:
       symbolic_shape = shapes[x]
       is_iterable = (
-        hasattr(symbolic_shape, "__iter__") or
-        hasattr(symbolic_shape, "__getitem__") # For Python 2 compat.
+          hasattr(symbolic_shape, "__iter__") or
+          hasattr(symbolic_shape, "__getitem__") # For Python 2 compat.
       )
       if not is_iterable:
         raise ValueError(

--- a/tensorflow/tools/api/golden/v1/tensorflow.debugging.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.debugging.pbtxt
@@ -81,6 +81,10 @@ tf_module {
     argspec: "args=[\'tensor\', \'name\', \'message\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "assert_shapes"
+    argspec: "args=[\'shapes\', \'data\', \'summarize\', \'message\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "assert_type"
     argspec: "args=[\'tensor\', \'tf_type\', \'message\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.debugging.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.debugging.pbtxt
@@ -81,6 +81,10 @@ tf_module {
     argspec: "args=[\'tensor\', \'message\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "assert_shapes"
+    argspec: "args=[\'shapes\', \'data\', \'summarize\', \'message\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "assert_type"
     argspec: "args=[\'tensor\', \'tf_type\', \'message\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -421,6 +421,10 @@ tf_module {
     argspec: "args=[\'x\', \'rank\', \'message\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "assert_shapes"
+    argspec: "args=[\'shapes\', \'data\', \'summarize\', \'message\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "atan"
     argspec: "args=[\'x\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -421,10 +421,6 @@ tf_module {
     argspec: "args=[\'x\', \'rank\', \'message\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
-    name: "assert_shapes"
-    argspec: "args=[\'shapes\', \'data\', \'summarize\', \'message\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\'], "
-  }
-  member_method {
     name: "atan"
     argspec: "args=[\'x\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }


### PR DESCRIPTION
Issue #24779

Now supports static and dynamic shape checks. 

Names are now passed via tensors only. 

A suggestion included is also the 'event_shape_only' flag for when only checks on the rightmost dimensions are warranted.