### PR TITLE
Replace log(1 + x) with numerically more stable log1p(x)

### DIFF
--- a/tensorflow/core/kernels/logistic-loss.h
+++ b/tensorflow/core/kernels/logistic-loss.h
@@ -69,12 +69,12 @@ class LogisticLossUpdater : public DualLossUpdater {
     if (y_wx > 0) {
       // 0 + log(e^(0) + e^(-ywx - 0))
       // log(1 + e^(-ywx))
-      return log(1 + exp(-y_wx)) * example_weight;
+      return log1p(exp(-y_wx)) * example_weight;
     }
     // -ywx + log(e^(ywx) + e^(-ywx + ywx))
     // log(e^(ywx) + e^(0)) - ywx
     // log(1 + e^(ywx)) - ywx
-    return (log(1 + exp(y_wx)) - y_wx) * example_weight;
+    return (log1p(exp(y_wx)) - y_wx) * example_weight;
   }
 
   // Derivative of logistic loss

--- a/tensorflow/core/kernels/mfcc_mel_filterbank.cc
+++ b/tensorflow/core/kernels/mfcc_mel_filterbank.cc
@@ -196,7 +196,7 @@ void MfccMelFilterbank::Compute(const std::vector<double> &input,
 }
 
 double MfccMelFilterbank::FreqToMel(double freq) const {
-  return 1127.0 * log(1.0 + (freq / 700.0));
+  return 1127.0 * log1p(freq / 700.0);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/range_sampler.cc
+++ b/tensorflow/core/kernels/range_sampler.cc
@@ -154,7 +154,7 @@ int64 UniformSampler::Sample(random::SimplePhilox* rnd) const {
 float UniformSampler::Probability(int64 value) const { return inv_range_; }
 
 LogUniformSampler::LogUniformSampler(int64 range)
-    : RangeSampler(range), log_range_(log(range + 1)) {}
+    : RangeSampler(range), log_range_(log1p(range)) {}
 
 int64 LogUniformSampler::Sample(random::SimplePhilox* rnd) const {
   const int64 value =

--- a/tensorflow/lite/experimental/microfrontend/lib/filterbank_util.c
+++ b/tensorflow/lite/experimental/microfrontend/lib/filterbank_util.c
@@ -29,7 +29,7 @@ void FilterbankFillConfigWithDefaults(struct FilterbankConfig* config) {
 }
 
 static float FreqToMel(float freq) {
-  return 1127.0 * log(1.0 + (freq / 700.0));
+  return 1127.0 * log1p(freq / 700.0);
 }
 
 static void CalculateCenterFrequencies(const int num_channels,

--- a/tensorflow/lite/kernels/internal/mfcc_mel_filterbank.cc
+++ b/tensorflow/lite/kernels/internal/mfcc_mel_filterbank.cc
@@ -197,7 +197,7 @@ void MfccMelFilterbank::Compute(const std::vector<double> &input,
 }
 
 double MfccMelFilterbank::FreqToMel(double freq) const {
-  return 1127.0 * log(1.0 + (freq / 700.0));
+  return 1127.0 * log1p(freq / 700.0);
 }
 
 }  // namespace internal


### PR DESCRIPTION
This PR replaces `log(1 + x)` with `log1p(x)`. This function is more precise if x is close to zero.

I'd be happy to add this as a general [algorithmic optimizer](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc) if this would be appreciated.