### PR TITLE
Solving problem with wrong type in seq2seq.BeamSearchDecoder label:prtype:bugfix 

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/beam_search_decoder.py
+++ b/tensorflow/contrib/seq2seq/python/ops/beam_search_decoder.py
@@ -727,8 +727,8 @@ def _beam_search_step(time, logits, next_cell_state, beam_state, batch_size,
   lengths_to_add = array_ops.one_hot(
       indices=array_ops.fill([batch_size, beam_width], end_token),
       depth=vocab_size,
-      on_value=np.int64(0),
-      off_value=np.int64(1),
+      on_value=math_ops.to_int64(0),
+      off_value=math_ops.to_int64(1),
       dtype=dtypes.int64)
   add_mask = math_ops.to_int64(not_finished)
   lengths_to_add *= array_ops.expand_dims(add_mask, 2)


### PR DESCRIPTION
This PR is solving of #25423 

Solving problem with wrong data type in _beam_search_step: lengths_to_add. Numpy int64 isn't equal tf int64.