### PR TITLE
Fix Windows build due to winsock2.h conflicts

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1508,6 +1508,8 @@ def set_windows_build_flags(environ_cp):
   write_to_bazelrc('build --config monolithic')
   # Suppress warning messages
   write_to_bazelrc('build --copt=-w --host_copt=-w')
+  # Fix winsock2.h conflicts
+  write_to_bazelrc('build --copt=-DWIN32_LEAN_AND_MEAN --host_copt=-DWIN32_LEAN_AND_MEAN')
   # Output more verbose information when something goes wrong
   write_to_bazelrc('build --verbose_failures')
   # The host and target platforms are the same in Windows build. So we don't


### PR DESCRIPTION
Some abseil header files include `windows.h`. Without `WIN32_LEAN_AND_MEAN` macro, `windows.h` will include `winsock.h` which will conflict with other files that want to include `winsock2.h` instead.

We should be able to revert these rollbacks after this PR.

- https://github.com/tensorflow/tensorflow/commit/d08271d73c9f7d399d16917b47fcfda74806dd02
- https://github.com/tensorflow/tensorflow/commit/eeaca34ce368eae8cf54c053678f464fd05bcaa6