### PR TITLE
[XLA] Check shape has layout

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_tfgraph_builder.cc
+++ b/tensorflow/compiler/xla/service/hlo_tfgraph_builder.cc
@@ -163,6 +163,9 @@ void HloTfGraphBuilder::SetNodeAttrs(const HloInstruction* instruction,
       // represented in a single Layout field.
       layout_string = ShapeUtil::HumanStringWithLayout(instruction->shape());
     } else if (instruction->shape().has_layout()) {
+      // For non-tuples, only emit the layout when the shape has a Layout.
+      // This extra check is required because LayoutUtil::HasLayout ignores
+      // token, opaque types etc.
       layout_string = StrCat(
           "{",
           absl::StrJoin(LayoutUtil::MinorToMajor(instruction->shape()), ","),

--- a/tensorflow/compiler/xla/service/hlo_tfgraph_builder.cc
+++ b/tensorflow/compiler/xla/service/hlo_tfgraph_builder.cc
@@ -162,7 +162,7 @@ void HloTfGraphBuilder::SetNodeAttrs(const HloInstruction* instruction,
       // For tuples, emit the full shape because the layout of a tuple is not
       // represented in a single Layout field.
       layout_string = ShapeUtil::HumanStringWithLayout(instruction->shape());
-    } else {
+    } else if (instruction->shape().has_layout()) {
       layout_string = StrCat(
           "{",
           absl::StrJoin(LayoutUtil::MinorToMajor(instruction->shape()), ","),

--- a/tensorflow/compiler/xla/service/hlo_tfgraph_builder_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_tfgraph_builder_test.cc
@@ -178,6 +178,23 @@ TEST_F(HloTfGraphBuilderTest, EmbeddedComputationsDiamond) {
   EXPECT_GT(generator_.GetGraphDef().node_size(), 0);
 }
 
+TEST_F(HloTfGraphBuilderTest, TokenHasNoLayout) {
+  auto builder = HloComputation::Builder("Token");
+  auto token = builder.AddInstruction(HloInstruction::CreateToken());
+  OpMetadata metadata;
+  metadata.set_op_name("x");
+  metadata.set_op_type("y");
+  token->set_metadata(metadata);
+  TF_CHECK_OK(generator_.AddComputation(*builder.Build()));
+  GraphDef graph_def = generator_.GetGraphDef();
+  EXPECT_EQ(graph_def.node_size(), 1);
+  const auto &node = graph_def.node(0);
+  EXPECT_EQ(GetNodeAttr(node, "type").s(), "TOKEN");
+  EXPECT_EQ(GetNodeAttr(node, "layout").s(), "");
+  EXPECT_EQ(GetNodeAttr(node, "tf_op_name").s(), "x");
+  EXPECT_EQ(GetNodeAttr(node, "tf_op_type").s(), "y");
+}
+
 }  // namespace
 }  // namespace hlo_graph_dumper
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/hlo_tfgraph_builder_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_tfgraph_builder_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/tests/hlo_test_base.h"
 #include "tensorflow/core/framework/attr_value.pb.h"
 #include "tensorflow/core/framework/tensor_shape.pb.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
 
 namespace xla {
 namespace hlo_graph_dumper {
@@ -185,14 +186,14 @@ TEST_F(HloTfGraphBuilderTest, TokenHasNoLayout) {
   metadata.set_op_name("x");
   metadata.set_op_type("y");
   token->set_metadata(metadata);
-  TF_CHECK_OK(generator_.AddComputation(*builder.Build()));
+  TF_ASSERT_OK(generator_.AddComputation(*builder.Build()));
   GraphDef graph_def = generator_.GetGraphDef();
-  EXPECT_EQ(graph_def.node_size(), 1);
+  ASSERT_EQ(graph_def.node_size(), 1);
   const auto &node = graph_def.node(0);
-  EXPECT_EQ(GetNodeAttr(node, "type").s(), "TOKEN");
-  EXPECT_EQ(GetNodeAttr(node, "layout").s(), "");
-  EXPECT_EQ(GetNodeAttr(node, "tf_op_name").s(), "x");
-  EXPECT_EQ(GetNodeAttr(node, "tf_op_type").s(), "y");
+  ASSERT_EQ(GetNodeAttr(node, "type").s(), "TOKEN");
+  ASSERT_EQ(GetNodeAttr(node, "layout").s(), "");
+  ASSERT_EQ(GetNodeAttr(node, "tf_op_name").s(), "x");
+  ASSERT_EQ(GetNodeAttr(node, "tf_op_type").s(), "y");
 }
 
 }  // namespace


### PR DESCRIPTION
`LayoutUtil::HasLayout` Ignores tokens etc, so need to check first that the shape has a layout before trying to access it.