### PR TITLE
[DONOTMERGE] Test pip test failure.

### DIFF
--- a/tensorflow/core/profiler/rpc/profiler_server.cc
+++ b/tensorflow/core/profiler/rpc/profiler_server.cc
@@ -26,7 +26,7 @@ namespace tensorflow {
 std::unique_ptr<Thread> StartProfilerServer(EagerContext* const eager_context,
                                             int32 port) {
   return WrapUnique(eager_context->TFEnv()->StartThread(
-      {}, "profiler_server", [eager_context, port]() {
+      {}, "profiler server", [eager_context, port]() {
         string server_address = strings::StrCat("0.0.0.0:", port);
         std::unique_ptr<TPUProfiler::Service> service =
             CreateProfilerService(eager_context);


### PR DESCRIPTION
Revert "Rename thread to "profiler_server" from "profiler server" (replace space with "_")."

This reverts commit 5458340eced84db0827af1464d216dea9257b8dd.