### PR TITLE
Reverting a commit that caused Wide and Deep model inference to fail

### DIFF
--- a/tensorflow/python/ops/embedding_ops.py
+++ b/tensorflow/python/ops/embedding_ops.py
@@ -691,10 +691,7 @@ def safe_embedding_lookup_sparse(embedding_weights,
 
   dtype = sparse_weights.dtype if sparse_weights is not None else None
   embedding_weights = [
-      w if (isinstance(w, resource_variable_ops.ResourceVariable)
-            and dtype in (None, w.dtype))
-      else ops.convert_to_tensor(w, dtype=dtype)
-      for w in embedding_weights
+      ops.convert_to_tensor(w, dtype=dtype) for w in embedding_weights
   ]
 
   with ops.name_scope(name, 'embedding_lookup',


### PR DESCRIPTION
This PR fixes this issue #25443 by reverting this commit https://github.com/tensorflow/tensorflow/commit/eb376a3dc2841f08ad2b54c08864e4c2653dbb9c
