### PR TITLE
Fix/Enable keras.utils.metrics_utils AUCCurve api

### DIFF
--- a/tensorflow/python/keras/utils/__init__.py
+++ b/tensorflow/python/keras/utils/__init__.py
@@ -36,6 +36,7 @@ from tensorflow.python.keras.utils.layer_utils import convert_all_kernels_in_mod
 from tensorflow.python.keras.utils.layer_utils import get_source_inputs
 from tensorflow.python.keras.utils.layer_utils import print_summary
 from tensorflow.python.keras.utils.losses_utils import squeeze_or_expand_dimensions
+from tensorflow.python.keras.utils.metrics_utils import AUCCurve
 from tensorflow.python.keras.utils.multi_gpu_utils import multi_gpu_model
 from tensorflow.python.keras.utils.np_utils import normalize
 from tensorflow.python.keras.utils.np_utils import to_categorical


### PR DESCRIPTION
PR enabling AUCCurve API that is needed by https://github.com/tensorflow/estimator, particularly PR https://github.com/tensorflow/estimator/pull/27