### PR TITLE
Bug: Remove reciprocal from monotonic decreasing ops

### DIFF
--- a/tensorflow/core/grappler/op_types.cc
+++ b/tensorflow/core/grappler/op_types.cc
@@ -184,8 +184,7 @@ bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing) {
           "Sign",  "Sinh", "Softsign", "Softplus", "Sqrt",  "Tanh",
       }));
   static const gtl::FlatSet<string>* const kMonotonicNonIncreasingOps =
-      CHECK_NOTNULL((new gtl::FlatSet<string>{"Acos", "Erfc", "Inv", "Neg",
-                                              "Reciprocal", "Rsqrt"}));
+      CHECK_NOTNULL((new gtl::FlatSet<string>{"Acos", "Erfc", "Neg", "Rsqrt"}));
   if (kMonotonicNonDecreasingOps->count(node.op()) > 0) {
     if (is_non_decreasing) {
       *is_non_decreasing = true;


### PR DESCRIPTION
`1 / x` has an infinite discontinuity at `x = 0` (https://www.wolframalpha.com/input/?i=1+%2F+x). Thus it is not monotonic on the entire real line.

The algorithmic optimizer would optimize the case `Max(Inv(x)) => Inv(Min(x))`. But this is only true for `x > 0` or `x < 0`. E.g.:
```python
x = tf.constant([-1.5, 1., 2.])
tf.reduce_max(tf.reciprocal(x))  # 1.0
tf.reciprocal(tf.reduce_min(x))  # -0.6666667
```

This PR removes `Inv` and `Reciprocal` ops from the list of elementwise monotonic ops.
Fixes https://github.com/tensorflow/tensorflow/pull/25330#issuecomment-460858086

/cc @ezhulenev