### PR TITLE
Fix misleading comment in layer normalization

### DIFF
--- a/tensorflow/contrib/layers/python/layers/layers.py
+++ b/tensorflow/contrib/layers/python/layers/layers.py
@@ -2308,7 +2308,7 @@ def layer_norm(inputs,
           initializer=init_ops.ones_initializer(),
           collections=gamma_collections,
           trainable=trainable)
-    # Calculate the moments on the last axis (layer activations).
+    # By default, compute the moments across all the dimensions except the one with index 0.
     norm_axes = list(range(begin_norm_axis, inputs_rank))
     mean, variance = nn.moments(inputs, norm_axes, keep_dims=True)
     # Compute layer normalization using the batch_normalization function.


### PR DESCRIPTION
Comment states that moments are calculated across the last dimension, however this is not true for convolutional layers, where the moments are calculated on all dimensions except the one with index 0.

I changed the comment from "Calculate the moments on the last axis (layer activations)." to "By default, compute the moments across all the dimensions except the one with index 0."