### PR TITLE
Mac OS X can not access clock_gettime

### DIFF
--- a/tensorflow/core/platform/posix/env_time.cc
+++ b/tensorflow/core/platform/posix/env_time.cc
@@ -16,6 +16,11 @@ limitations under the License.
 #include <sys/time.h>
 #include <time.h>
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 #include "tensorflow/core/platform/env_time.h"
 
 namespace tensorflow {
@@ -28,7 +33,19 @@ class PosixEnvTime : public EnvTime {
 
   uint64 NowNanos() override {
     struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
+    
+#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+    ts.tv_sec = mts.tv_sec;
+    ts.tv_nsec = mts.tv_nsec;
+#else
+    clock_gettime(CLOCK_REALTIME, ts);
+#endif
+    
     return (static_cast<uint64>(ts.tv_sec) * kSecondsToNanos +
             static_cast<uint64>(ts.tv_nsec));
   }


### PR DESCRIPTION
the function clock_gettime was replaced by clock_get_time