### PR TITLE
Allow functions of `DistributedVariable`s to implement `custom_gradient`

### DIFF
--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -185,7 +185,7 @@ def _graph_mode_decorator(f, *args, **kwargs):
                    current_var_scope.local_variables())
   new_vars = after_vars - before_vars
   for v in new_vars:
-    if not isinstance(v, resource_variable_ops.ResourceVariable):
+    if not resource_variable_ops.is_resource_variable(v):
       raise TypeError(
           "All variables used by a function wrapped with @custom_gradient must "
           "be `ResourceVariable`s. Ensure that no `variable_scope` is created "


### PR DESCRIPTION
Previously, variables created by functions decorated with `custom_gradient` had to pass:
```python 
isinstance(v, resource_variable_ops.ResourceVariable)
```
With this patch, they instead must pass:
```python
resource_variable_ops.is_resource_variable(v)
```
This allows functions that create [`DistributedVariable`](https://github.com/tensorflow/tensorflow/blob/a799b815e5b497fd85e36ec36e44df0f3cebf802/tensorflow/python/distribute/values.py#L429)s (which already implement the method [`_should_act_as_resource_variable`](https://github.com/tensorflow/tensorflow/blob/a799b815e5b497fd85e36ec36e44df0f3cebf802/tensorflow/python/distribute/values.py#L568)) to use `custom_gradient`, which is necessary for cross-replica batch normalization, among other things.