### PR TITLE
Mention 'num_parallel_calls' bugfix into 1.13 release note

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,6 +83,7 @@
   * Deprecate `tf.data.Dataset.make_initializable_iterator()` in V1, removed it from V2, and added `tf.compat.v1.data.make_initializable_iterator()`.
   * Enable nested dataset support in core `tf.data` transformations.
   * For `tf.data.Dataset` implementers: Added `tf.data.Dataset._element_structured property` to replace `Dataset.output_{types,shapes,classes}`.
+  * Make `num_parallel_calls` of `tf.data.Dataset.interleave` and `tf.data.Dataset.map` work in Eager mode.
 * Toolchains
   * Fixed OpenSSL compatibility by avoiding `EVP_MD_CTX_destroy`.
   * Added bounds checking to printing deprecation warnings.


### PR DESCRIPTION
Mention Bug #19945 in the release note of TF 1.13.

>  Make `num_parallel_calls` of `tf.data.Dataset.interleave` and `tf.data.Dataset.map` work in Eager mode.
