### PR TITLE
Remove unnecessary use of getattr and setattr

### DIFF
--- a/tensorflow/contrib/eager/python/saver.py
+++ b/tensorflow/contrib/eager/python/saver.py
@@ -93,21 +93,25 @@ def restore_variables_on_create(save_path, map_func=None):
     old_init = getattr(resource_variable_ops.ResourceVariable,
                        "_init_from_args", None)
     assert old_init, "ResourceVariable misses _init_from_args method."
-    resource_variable_ops.ResourceVariable._init_from_args = \
-        _init_from_checkpoint
+    # pylint: disable=protected-access
+    resource_variable_ops.ResourceVariable._init_from_args = (
+        _init_from_checkpoint)
     resource_variable_ops.ResourceVariable._old_init = old_init
     resource_variable_ops.ResourceVariable._map_func = map_func_wrapper
     resource_variable_ops.ResourceVariable._ckpt_var_cache = ckpt_var_cache
+    # pylint: enable=protected-access
   try:
     yield
   except Exception as e:
     raise e
   finally:
     if save_path:
+      # pylint: disable=protected-access
       resource_variable_ops.ResourceVariable._init_from_args = old_init
       resource_variable_ops.ResourceVariable._old_init = None
       resource_variable_ops.ResourceVariable._map_func = None
       resource_variable_ops.ResourceVariable._ckpt_var_cache = None
+      # pylint: enable=protected-access
 
 
 class Saver(object):

--- a/tensorflow/contrib/eager/python/saver.py
+++ b/tensorflow/contrib/eager/python/saver.py
@@ -93,24 +93,21 @@ def restore_variables_on_create(save_path, map_func=None):
     old_init = getattr(resource_variable_ops.ResourceVariable,
                        "_init_from_args", None)
     assert old_init, "ResourceVariable misses _init_from_args method."
-    setattr(resource_variable_ops.ResourceVariable, "_init_from_args",
-            _init_from_checkpoint)
-    setattr(resource_variable_ops.ResourceVariable, "_old_init", old_init)
-    setattr(resource_variable_ops.ResourceVariable, "_map_func",
-            map_func_wrapper)
-    setattr(resource_variable_ops.ResourceVariable, "_ckpt_var_cache",
-            ckpt_var_cache)
+    resource_variable_ops.ResourceVariable._init_from_args = \
+        _init_from_checkpoint
+    resource_variable_ops.ResourceVariable._old_init = old_init
+    resource_variable_ops.ResourceVariable._map_func = map_func_wrapper
+    resource_variable_ops.ResourceVariable._ckpt_var_cache = ckpt_var_cache
   try:
     yield
   except Exception as e:
     raise e
   finally:
     if save_path:
-      setattr(resource_variable_ops.ResourceVariable, "_init_from_args",
-              old_init)
-      setattr(resource_variable_ops.ResourceVariable, "_old_init", None)
-      setattr(resource_variable_ops.ResourceVariable, "_map_func", None)
-      setattr(resource_variable_ops.ResourceVariable, "_ckpt_var_cache", None)
+      resource_variable_ops.ResourceVariable._init_from_args = old_init
+      resource_variable_ops.ResourceVariable._old_init = None
+      resource_variable_ops.ResourceVariable._map_func = None
+      resource_variable_ops.ResourceVariable._ckpt_var_cache = None
 
 
 class Saver(object):

--- a/tensorflow/contrib/framework/python/ops/arg_scope.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope.py
@@ -182,7 +182,7 @@ def add_arg_scope(func):
     return func(*args, **current_args)
 
   _add_op(func)
-  setattr(func_with_args, '_key_op', arg_scope_func_key(func))
+  func_with_args._key_op = arg_scope_func_key(func)
   return tf_decorator.make_decorator(func, func_with_args)
 
 

--- a/tensorflow/contrib/framework/python/ops/arg_scope.py
+++ b/tensorflow/contrib/framework/python/ops/arg_scope.py
@@ -182,7 +182,7 @@ def add_arg_scope(func):
     return func(*args, **current_args)
 
   _add_op(func)
-  func_with_args._key_op = arg_scope_func_key(func)
+  func_with_args._key_op = arg_scope_func_key(func)  # pylint: disable=protected-access
   return tf_decorator.make_decorator(func, func_with_args)
 
 

--- a/tensorflow/contrib/tensor_forest/python/tensor_forest.py
+++ b/tensorflow/contrib/tensor_forest/python/tensor_forest.py
@@ -198,8 +198,8 @@ class ForestHParams(object):
   def fill(self):
     """Intelligently sets any non-specific parameters."""
     # Fail fast if num_classes or num_features isn't set.
-    _ = getattr(self, 'num_classes')
-    _ = getattr(self, 'num_features')
+    _ = self.num_classes
+    _ = self.num_features
 
     self.bagged_num_features = int(self.feature_bagging_fraction *
                                    self.num_features)

--- a/tensorflow/python/autograph/impl/api.py
+++ b/tensorflow/python/autograph/impl/api.py
@@ -99,7 +99,7 @@ def convert(
 
     # Sometimes the decorator is just desugared, making it impossible to detect.
     # This attribute makes detection easier.
-    setattr(wrapper, '__ag_compiled', True)
+    wrapper.__ag_compiled = True
     return wrapper
 
   return decorator
@@ -163,7 +163,7 @@ def do_not_convert(run_as=RunMode.GRAPH, return_dtypes=None):
     else:
       raise ValueError('unknown value for run_as: %s' % run_as)
 
-    setattr(wrapper, '__ag_compiled', True)
+    wrapper.__ag_compiled = True
     return wrapper
 
   return decorator

--- a/tensorflow/python/autograph/impl/api.py
+++ b/tensorflow/python/autograph/impl/api.py
@@ -99,7 +99,7 @@ def convert(
 
     # Sometimes the decorator is just desugared, making it impossible to detect.
     # This attribute makes detection easier.
-    wrapper.__ag_compiled = True
+    wrapper.__ag_compiled = True  # pylint: disable=protected-access
     return wrapper
 
   return decorator
@@ -121,7 +121,7 @@ class RunMode(Enum):
 
 def do_not_convert_internal(f):
   """Decorator that marks internal functions which do not need conversion."""
-  setattr(f, '__ag_compiled', True)
+  f.__ag_compiled = True  # pylint: disable=protected-access
   return f
 
 
@@ -163,7 +163,7 @@ def do_not_convert(run_as=RunMode.GRAPH, return_dtypes=None):
     else:
       raise ValueError('unknown value for run_as: %s' % run_as)
 
-    wrapper.__ag_compiled = True
+    wrapper.__ag_compiled = True  # pylint: disable=protected-access
     return wrapper
 
   return decorator

--- a/tensorflow/python/autograph/pyct/ast_util_test.py
+++ b/tensorflow/python/autograph/pyct/ast_util_test.py
@@ -76,7 +76,7 @@ class AstUtilTest(test.TestCase):
       def f(a):
         return a + 1
     """))
-    node.body[0].__foo = 'bar'
+    node.body[0].__foo = 'bar'  # pylint: disable=protected-access
     new_node = ast_util.copy_clean(node)
     self.assertIsNot(new_node, node)
     self.assertIsNot(new_node.body[0], node.body[0])

--- a/tensorflow/python/autograph/pyct/ast_util_test.py
+++ b/tensorflow/python/autograph/pyct/ast_util_test.py
@@ -76,7 +76,7 @@ class AstUtilTest(test.TestCase):
       def f(a):
         return a + 1
     """))
-    setattr(node.body[0], '__foo', 'bar')
+    node.body[0].__foo = 'bar'
     new_node = ast_util.copy_clean(node)
     self.assertIsNot(new_node, node)
     self.assertIsNot(new_node.body[0], node.body[0])

--- a/tensorflow/python/autograph/pyct/inspect_utils.py
+++ b/tensorflow/python/autograph/pyct/inspect_utils.py
@@ -64,7 +64,7 @@ def isnamedtuple(f):
     return False
   if not hasattr(f, '_fields'):
     return False
-  fields = f._fields
+  fields = f._fields  # pylint: disable=protected-access
   if not isinstance(fields, tuple):
     return False
   if not all(isinstance(f, str) for f in fields):

--- a/tensorflow/python/autograph/pyct/inspect_utils.py
+++ b/tensorflow/python/autograph/pyct/inspect_utils.py
@@ -64,7 +64,7 @@ def isnamedtuple(f):
     return False
   if not hasattr(f, '_fields'):
     return False
-  fields = getattr(f, '_fields')
+  fields = f._fields
   if not isinstance(fields, tuple):
     return False
   if not all(isinstance(f, str) for f in fields):

--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -198,7 +198,7 @@ def _is_attrs_instance(obj):
 
 def _get_attrs_values(obj):
   """Returns the list of values from an attrs instance."""
-  attrs = getattr(obj.__class__, '__attrs_attrs__')
+  attrs = obj.__class__.__attrs_attrs__
   return [getattr(obj, a.name) for a in attrs]
 
 

--- a/tensorflow/python/framework/function.py
+++ b/tensorflow/python/framework/function.py
@@ -523,7 +523,7 @@ class _DefinedFunction(object):
     # Set a hidden attr in 'op' so that gradients_impl can refer back
     # to this _DefinedFunction instance to access python_grad_func.
     assert isinstance(op, ops.Operation)
-    setattr(op, "__defun", self)
+    op.__defun = self
 
     if self._shape_func is not None:
       shapes = self._shape_func(op)

--- a/tensorflow/python/framework/function.py
+++ b/tensorflow/python/framework/function.py
@@ -523,7 +523,7 @@ class _DefinedFunction(object):
     # Set a hidden attr in 'op' so that gradients_impl can refer back
     # to this _DefinedFunction instance to access python_grad_func.
     assert isinstance(op, ops.Operation)
-    op.__defun = self
+    op.__defun = self  # pylint: disable=protected-access
 
     if self._shape_func is not None:
       shapes = self._shape_func(op)

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -1088,7 +1088,7 @@ def deprecated_graph_mode_only(func=None):
     if tf_inspect.isclass(f):
       setup = f.__dict__.get("setUp")
       if setup is not None:
-        setattr(f, "setUp", decorator(setup))
+        f.setUp = decorator(setup)
 
       for name, value in f.__dict__.copy().items():
         if (callable(value) and
@@ -1139,7 +1139,7 @@ def run_v1_only(reason, func=None):
     if tf_inspect.isclass(f):
       setup = f.__dict__.get("setUp")
       if setup is not None:
-        setattr(f, "setUp", decorator(setup))
+        f.setUp = decorator(setup)
 
       for name, value in f.__dict__.copy().items():
         if (callable(value) and

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -500,7 +500,7 @@ def disable_control_flow_v2(unused_msg):
   """
 
   def wrapper(func):
-    func._disable_control_flow_v2 = True
+    func._disable_control_flow_v2 = True  # pylint: disable=protected-access
     return func
 
   return wrapper

--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1486,7 +1486,7 @@ class Layer(trackable.Trackable):
 
       for output, mask in zip(flat_outputs, flat_masks):
         try:
-          output._keras_mask = mask
+          output._keras_mask = mask  # pylint: disable=protected-access
         except AttributeError:
           # C Type such as np.ndarray.
           pass

--- a/tensorflow/python/keras/engine/topology_test.py
+++ b/tensorflow/python/keras/engine/topology_test.py
@@ -755,7 +755,7 @@ class TopologyConstructionTest(keras_parameterized.TestCase):
       self.assertTrue(hasattr(b, '_keras_mask'))
       self.assertAllEqual(
           self.evaluate(array_ops.ones_like(mask)),
-          self.evaluate(getattr(b, '_keras_mask')))
+          self.evaluate(b._keras_mask))
       self.assertAllEqual(self.evaluate(a * mask), self.evaluate(b))
     else:
       x = input_layer_lib.Input(shape=(32,))

--- a/tensorflow/python/keras/saving/hdf5_format.py
+++ b/tensorflow/python/keras/saving/hdf5_format.py
@@ -639,7 +639,7 @@ def save_optimizer_weights_to_hdf5_group(hdf5_group, optimizer):
       optimizer: optimizer instance.
   """
 
-  symbolic_weights = getattr(optimizer, 'weights')
+  symbolic_weights = optimizer.weights
   if symbolic_weights:
     weights_group = hdf5_group.create_group('optimizer_weights')
     weight_names = [str(w.name).encode('utf8') for w in symbolic_weights]

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -330,7 +330,7 @@ class RNNCell(base_layer.Layer):
     is_eager = context.executing_eagerly()
     if is_eager and _hasattr(self, "_last_zero_state"):
       (last_state_size, last_batch_size, last_dtype,
-       last_output) = self._last_zero_state
+       last_output) = self._last_zero_state  # pylint: disable=protected-access
       if (last_batch_size == batch_size and
           last_dtype == dtype and
           last_state_size == state_size):

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -330,7 +330,7 @@ class RNNCell(base_layer.Layer):
     is_eager = context.executing_eagerly()
     if is_eager and _hasattr(self, "_last_zero_state"):
       (last_state_size, last_batch_size, last_dtype,
-       last_output) = getattr(self, "_last_zero_state")
+       last_output) = self._last_zero_state
       if (last_batch_size == batch_size and
           last_dtype == dtype and
           last_state_size == state_size):

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -935,7 +935,7 @@ class Variable(six.with_metaclass(VariableMetaclass,
     # For slicing, bind getitem differently than a tensor (use SliceHelperVar
     # instead)
     # pylint: disable=protected-access
-    setattr(cls, "__getitem__", array_ops._SliceHelperVar)
+    cls.__getitem__ = array_ops._SliceHelperVar
 
   @classmethod
   def _OverloadOperator(cls, operator):  # pylint: disable=invalid-name

--- a/tensorflow/python/profiler/profile_context.py
+++ b/tensorflow/python/profiler/profile_context.py
@@ -342,11 +342,11 @@ class ProfileContext(object):
         raise errors.InternalError(None, None,
                                    'Already in context or context not cleaned.')
       else:
-        setattr(session.BaseSession, 'run', _profiled_run)
-        setattr(session.BaseSession, '__init__', _profiled_init)
-        setattr(session.BaseSession, '_profiler_run_internal', self.old_run)
-        setattr(session.BaseSession, '_profiler_init_internal', self.old_init)
-        setattr(session.BaseSession, 'profile_context', self)
+        session.BaseSession.run = _profiled_run
+        session.BaseSession.__init__ = _profiled_init
+        session.BaseSession._profiler_run_internal = self.old_run
+        session.BaseSession._profiler_init_internal = self.old_init
+        session.BaseSession.profile_context = self
         return self
     else:
       return self
@@ -355,8 +355,8 @@ class ProfileContext(object):
     if not self._enabled:
       return
     print_mdl.DeleteProfiler()
-    setattr(session.BaseSession, 'run', self.old_run)
-    setattr(session.BaseSession, '__init__', self.old_init)
-    setattr(session.BaseSession, '_profiler_run_internal', None)
-    setattr(session.BaseSession, '_profiler_init_internal', None)
-    setattr(session.BaseSession, 'profile_context', None)
+    session.BaseSession.run = self.old_run
+    session.BaseSession.__init__ = self.old_init
+    session.BaseSession._profiler_run_internal = None
+    session.BaseSession._profiler_init_internal = None
+    session.BaseSession.profile_context = None

--- a/tensorflow/python/profiler/profile_context.py
+++ b/tensorflow/python/profiler/profile_context.py
@@ -344,8 +344,8 @@ class ProfileContext(object):
       else:
         session.BaseSession.run = _profiled_run
         session.BaseSession.__init__ = _profiled_init
-        session.BaseSession._profiler_run_internal = self.old_run
-        session.BaseSession._profiler_init_internal = self.old_init
+        session.BaseSession._profiler_run_internal = self.old_run  # pylint: disable=protected-access
+        session.BaseSession._profiler_init_internal = self.old_init  # pylint: disable=protected-access
         session.BaseSession.profile_context = self
         return self
     else:
@@ -357,6 +357,6 @@ class ProfileContext(object):
     print_mdl.DeleteProfiler()
     session.BaseSession.run = self.old_run
     session.BaseSession.__init__ = self.old_init
-    session.BaseSession._profiler_run_internal = None
-    session.BaseSession._profiler_init_internal = None
+    session.BaseSession._profiler_run_internal = None  # pylint: disable=protected-access
+    session.BaseSession._profiler_init_internal = None  # pylint: disable=protected-access
     session.BaseSession.profile_context = None

--- a/tensorflow/python/saved_model/load.py
+++ b/tensorflow/python/saved_model/load.py
@@ -141,7 +141,7 @@ class _Loader(object):
         # that allows `obj()` syntax to work. This is done per-instance to
         # allow `callable` to be used to find out if an object is callable.
         if reference.local_name == "__call__":
-          setattr(type(obj), "__call__", _call_attribute)
+          type(obj).__call__ = _call_attribute
 
   def _restore_checkpoint(self):
     """Load state from checkpoint into the deserialized objects."""

--- a/tensorflow/python/tools/api/generator/create_python_api_test.py
+++ b/tensorflow/python/tools/api/generator/create_python_api_test.py
@@ -45,8 +45,8 @@ class CreatePythonApiTest(test.TestCase):
   def setUp(self):
     # Add fake op to a module that has 'tensorflow' in the name.
     sys.modules[_MODULE_NAME] = imp.new_module(_MODULE_NAME)
-    setattr(sys.modules[_MODULE_NAME], 'test_op', test_op)
-    setattr(sys.modules[_MODULE_NAME], 'TestClass', TestClass)
+    sys.modules[_MODULE_NAME].test_op = test_op
+    sys.modules[_MODULE_NAME].TestClass = TestClass
     test_op.__module__ = _MODULE_NAME
     TestClass.__module__ = _MODULE_NAME
     tf_export('consts._TEST_CONSTANT').export_constant(

--- a/tensorflow/python/training/supervisor.py
+++ b/tensorflow/python/training/supervisor.py
@@ -1115,13 +1115,13 @@ class SVTimerCheckpointThread(coordinator.LooperThread):
 
 
 # TODO(sherrym): All non-PEP8 compliant names will be deprecated shortly.
-setattr(Supervisor, "PrepareSession", Supervisor.prepare_or_wait_for_session)
-setattr(Supervisor, "StartQueueRunners", Supervisor.start_queue_runners)
-setattr(Supervisor, "StartStandardServices", Supervisor.start_standard_services)
-setattr(Supervisor, "Stop", Supervisor.stop)
-setattr(Supervisor, "RequestStop", Supervisor.request_stop)
-setattr(Supervisor, "Loop", Supervisor.loop)
-setattr(Supervisor, "ShouldStop", Supervisor.should_stop)
-setattr(Supervisor, "StopOnException", Supervisor.stop_on_exception)
-setattr(Supervisor, "WaitForStop", Supervisor.wait_for_stop)
-setattr(Supervisor, "SummaryComputed", Supervisor.summary_computed)
+Supervisor.PrepareSession = Supervisor.prepare_or_wait_for_session
+Supervisor.StartQueueRunners = Supervisor.start_queue_runners
+Supervisor.StartStandardServices = Supervisor.start_standard_services
+Supervisor.Stop = Supervisor.stop
+Supervisor.RequestStop = Supervisor.request_stop
+Supervisor.Loop = Supervisor.loop
+Supervisor.ShouldStop = Supervisor.should_stop
+Supervisor.StopOnException = Supervisor.stop_on_exception
+Supervisor.WaitForStop = Supervisor.wait_for_stop
+Supervisor.SummaryComputed = Supervisor.summary_computed

--- a/tensorflow/python/util/deprecation_test.py
+++ b/tensorflow/python/util/deprecation_test.py
@@ -303,7 +303,7 @@ class DeprecationTest(test.TestCase):
         "\n"
         "\nReturns:"
         "\n  Sum of args." % (date, instructions),
-        getattr(_Object, "_fn").__doc__)
+        _Object._fn.__doc__)
 
     # Assert calling new fn issues log warning.
     self.assertEqual(3, _Object()._fn(1, 2))
@@ -333,7 +333,7 @@ class DeprecationTest(test.TestCase):
         "\n"
         "\nWarning: THIS FUNCTION IS DEPRECATED. It will be removed after %s."
         "\nInstructions for updating:\n%s" % (date, instructions),
-        getattr(_Object, "_fn").__doc__)
+        _Object._fn.__doc__)
 
     # Assert calling new fn issues log warning.
     self.assertEqual(3, _Object()._fn(1, 2))
@@ -363,7 +363,7 @@ class DeprecationTest(test.TestCase):
         "\nWarning: THIS FUNCTION IS DEPRECATED. It will be removed after %s."
         "\nInstructions for updating:"
         "\n%s" % (date, instructions),
-        getattr(_Object, "_fn").__doc__)
+        _Object._fn.__doc__)
 
     # Assert calling new fn issues log warning.
     self.assertEqual(3, _Object()._fn(1, 2))
@@ -418,7 +418,7 @@ class DeprecationTest(test.TestCase):
         "\n"
         "\nReturns:"
         "\n  String." % (date, instructions),
-        getattr(_Object, "_prop").__doc__)
+        _Object._prop.__doc__)
 
     # Assert calling new fn issues log warning.
     self.assertEqual("prop_with_doc", _Object()._prop)
@@ -449,7 +449,7 @@ class DeprecationTest(test.TestCase):
         "\nWarning: THIS FUNCTION IS DEPRECATED. It will be removed after %s."
         "\nInstructions for updating:"
         "\n%s" % (date, instructions),
-        getattr(_Object, "_prop").__doc__)
+        _Object._prop.__doc__)
 
     # Assert calling new fn issues log warning.
     self.assertEqual("prop_no_doc", _Object()._prop)

--- a/tensorflow/python/util/deprecation_test.py
+++ b/tensorflow/python/util/deprecation_test.py
@@ -303,7 +303,7 @@ class DeprecationTest(test.TestCase):
         "\n"
         "\nReturns:"
         "\n  Sum of args." % (date, instructions),
-        _Object._fn.__doc__)
+        _Object._fn.__doc__)  # pylint: disable=protected-access
 
     # Assert calling new fn issues log warning.
     self.assertEqual(3, _Object()._fn(1, 2))
@@ -333,7 +333,7 @@ class DeprecationTest(test.TestCase):
         "\n"
         "\nWarning: THIS FUNCTION IS DEPRECATED. It will be removed after %s."
         "\nInstructions for updating:\n%s" % (date, instructions),
-        _Object._fn.__doc__)
+        _Object._fn.__doc__)  # pylint: disable=protected-access
 
     # Assert calling new fn issues log warning.
     self.assertEqual(3, _Object()._fn(1, 2))
@@ -363,7 +363,7 @@ class DeprecationTest(test.TestCase):
         "\nWarning: THIS FUNCTION IS DEPRECATED. It will be removed after %s."
         "\nInstructions for updating:"
         "\n%s" % (date, instructions),
-        _Object._fn.__doc__)
+        _Object._fn.__doc__)  # pylint: disable=protected-access
 
     # Assert calling new fn issues log warning.
     self.assertEqual(3, _Object()._fn(1, 2))
@@ -418,7 +418,7 @@ class DeprecationTest(test.TestCase):
         "\n"
         "\nReturns:"
         "\n  String." % (date, instructions),
-        _Object._prop.__doc__)
+        _Object._prop.__doc__)  # pylint: disable=protected-access
 
     # Assert calling new fn issues log warning.
     self.assertEqual("prop_with_doc", _Object()._prop)
@@ -449,7 +449,7 @@ class DeprecationTest(test.TestCase):
         "\nWarning: THIS FUNCTION IS DEPRECATED. It will be removed after %s."
         "\nInstructions for updating:"
         "\n%s" % (date, instructions),
-        _Object._prop.__doc__)
+        _Object._prop.__doc__)  # pylint: disable=protected-access
 
     # Assert calling new fn issues log warning.
     self.assertEqual("prop_no_doc", _Object()._prop)

--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -71,7 +71,7 @@ def _get_attrs_items(obj):
   Returns:
     A list of (attr_name, attr_value) pairs, sorted by attr_name.
   """
-  attrs = getattr(obj.__class__, "__attrs_attrs__")
+  attrs = obj.__class__.__attrs_attrs__
   attr_names = sorted([a.name for a in attrs])
   return [(attr_name, getattr(obj, attr_name)) for attr_name in attr_names]
 

--- a/tensorflow/python/util/tf_decorator.py
+++ b/tensorflow/python/util/tf_decorator.py
@@ -88,7 +88,7 @@ def make_decorator(target,
     decorator_name = getattr(frame, 'name', frame[2])  # Caller's name
   decorator = TFDecorator(decorator_name, target, decorator_doc,
                           decorator_argspec)
-  setattr(decorator_func, '_tf_decorator', decorator)
+  decorator_func._tf_decorator = decorator
   # Objects that are callables (e.g., a functools.partial object) may not have
   # the following attributes.
   if hasattr(target, '__name__'):

--- a/tensorflow/python/util/tf_decorator.py
+++ b/tensorflow/python/util/tf_decorator.py
@@ -88,7 +88,7 @@ def make_decorator(target,
     decorator_name = getattr(frame, 'name', frame[2])  # Caller's name
   decorator = TFDecorator(decorator_name, target, decorator_doc,
                           decorator_argspec)
-  decorator_func._tf_decorator = decorator
+  decorator_func._tf_decorator = decorator  # pylint: disable=protected-access
   # Objects that are callables (e.g., a functools.partial object) may not have
   # the following attributes.
   if hasattr(target, '__name__'):
@@ -150,7 +150,7 @@ def rewrap(decorator_func, previous_target, new_target):
   target = None
   while hasattr(cur, '_tf_decorator'):
     innermost_decorator = cur
-    target = cur._tf_decorator
+    target = cur._tf_decorator  # pylint: disable=protected-access
     if target.decorated_target is previous_target:
       break
     cur = target.decorated_target
@@ -201,7 +201,7 @@ def unwrap(maybe_tf_decorator):
     if isinstance(cur, TFDecorator):
       decorators.append(cur)
     elif hasattr(cur, '_tf_decorator'):
-      decorators.append(cur._tf_decorator)
+      decorators.append(cur._tf_decorator)  # pylint: disable=protected-access
     else:
       break
     if not hasattr(decorators[-1], 'decorated_target'):

--- a/tensorflow/python/util/tf_decorator.py
+++ b/tensorflow/python/util/tf_decorator.py
@@ -150,7 +150,7 @@ def rewrap(decorator_func, previous_target, new_target):
   target = None
   while hasattr(cur, '_tf_decorator'):
     innermost_decorator = cur
-    target = getattr(cur, '_tf_decorator')
+    target = cur._tf_decorator
     if target.decorated_target is previous_target:
       break
     cur = target.decorated_target
@@ -201,7 +201,7 @@ def unwrap(maybe_tf_decorator):
     if isinstance(cur, TFDecorator):
       decorators.append(cur)
     elif hasattr(cur, '_tf_decorator'):
-      decorators.append(getattr(cur, '_tf_decorator'))
+      decorators.append(cur._tf_decorator)
     else:
       break
     if not hasattr(decorators[-1], 'decorated_target'):

--- a/tensorflow/python/util/tf_decorator_test.py
+++ b/tensorflow/python/util/tf_decorator_test.py
@@ -190,7 +190,8 @@ class TfMakeDecoratorTest(test.TestCase):
 
   def testAttachesATFDecoratorAttr(self):
     decorated = tf_decorator.make_decorator(test_function, test_wrapper)
-    self.assertIsInstance(decorated._tf_decorator, tf_decorator.TFDecorator)
+    decorator = decorated._tf_decorator  # pylint: disable=protected-access
+    self.assertIsInstance(decorator, tf_decorator.TFDecorator)
 
   def testAttachesWrappedAttr(self):
     decorated = tf_decorator.make_decorator(test_function, test_wrapper)
@@ -199,13 +200,13 @@ class TfMakeDecoratorTest(test.TestCase):
   def testSetsTFDecoratorNameToDecoratorNameArg(self):
     decorated = tf_decorator.make_decorator(test_function, test_wrapper,
                                             'test decorator name')
-    decorator = decorated._tf_decorator
+    decorator = decorated._tf_decorator  # pylint: disable=protected-access
     self.assertEqual('test decorator name', decorator.decorator_name)
 
   def testSetsTFDecoratorDocToDecoratorDocArg(self):
     decorated = tf_decorator.make_decorator(
         test_function, test_wrapper, decorator_doc='test decorator doc')
-    decorator = decorated._tf_decorator
+    decorator = decorated._tf_decorator  # pylint: disable=protected-access
     self.assertEqual('test decorator doc', decorator.decorator_doc)
 
   def testUpdatesDictWithMissingEntries(self):
@@ -230,7 +231,8 @@ class TfMakeDecoratorTest(test.TestCase):
         defaults=(1, 'hello'))
     decorated = tf_decorator.make_decorator(test_function, test_wrapper, '', '',
                                             argspec)
-    self.assertEqual(argspec, decorated._tf_decorator.decorator_argspec)
+    decorator = decorated._tf_decorator  # pylint: disable=protected-access
+    self.assertEqual(argspec, decorator.decorator_argspec)
 
   def testSetsDecoratorNameToFunctionThatCallsMakeDecoratorIfAbsent(self):
 
@@ -238,7 +240,7 @@ class TfMakeDecoratorTest(test.TestCase):
       return tf_decorator.make_decorator(test_function, wrapper)
 
     decorated = test_decorator_name(test_wrapper)
-    decorator = decorated._tf_decorator
+    decorator = decorated._tf_decorator  # pylint: disable=protected-access
     self.assertEqual('test_decorator_name', decorator.decorator_name)
 
   def testCompatibleWithNamelessCallables(self):
@@ -276,7 +278,7 @@ class TfDecoratorRewrapTest(test.TestCase):
     def new_target(x):
       return x * 3
 
-    prev_target = test_rewrappable_decorated._tf_decorator._decorated_target
+    prev_target = test_rewrappable_decorated._tf_decorator._decorated_target  # pylint: disable=protected-access
     # In this case, only the outer decorator (test_injectable_decorator_square)
     # should be preserved.
     tf_decorator.rewrap(test_rewrappable_decorated, prev_target, new_target)

--- a/tensorflow/python/util/tf_decorator_test.py
+++ b/tensorflow/python/util/tf_decorator_test.py
@@ -190,24 +190,22 @@ class TfMakeDecoratorTest(test.TestCase):
 
   def testAttachesATFDecoratorAttr(self):
     decorated = tf_decorator.make_decorator(test_function, test_wrapper)
-    decorator = getattr(decorated, '_tf_decorator')
-    self.assertIsInstance(decorator, tf_decorator.TFDecorator)
+    self.assertIsInstance(decorated._tf_decorator, tf_decorator.TFDecorator)
 
   def testAttachesWrappedAttr(self):
     decorated = tf_decorator.make_decorator(test_function, test_wrapper)
-    wrapped_attr = getattr(decorated, '__wrapped__')
-    self.assertIs(test_function, wrapped_attr)
+    self.assertIs(test_function, decorated.__wrapped__)
 
   def testSetsTFDecoratorNameToDecoratorNameArg(self):
     decorated = tf_decorator.make_decorator(test_function, test_wrapper,
                                             'test decorator name')
-    decorator = getattr(decorated, '_tf_decorator')
+    decorator = decorated._tf_decorator
     self.assertEqual('test decorator name', decorator.decorator_name)
 
   def testSetsTFDecoratorDocToDecoratorDocArg(self):
     decorated = tf_decorator.make_decorator(
         test_function, test_wrapper, decorator_doc='test decorator doc')
-    decorator = getattr(decorated, '_tf_decorator')
+    decorator = decorated._tf_decorator
     self.assertEqual('test decorator doc', decorator.decorator_doc)
 
   def testUpdatesDictWithMissingEntries(self):
@@ -232,8 +230,7 @@ class TfMakeDecoratorTest(test.TestCase):
         defaults=(1, 'hello'))
     decorated = tf_decorator.make_decorator(test_function, test_wrapper, '', '',
                                             argspec)
-    decorator = getattr(decorated, '_tf_decorator')
-    self.assertEqual(argspec, decorator.decorator_argspec)
+    self.assertEqual(argspec, decorated._tf_decorator.decorator_argspec)
 
   def testSetsDecoratorNameToFunctionThatCallsMakeDecoratorIfAbsent(self):
 
@@ -241,7 +238,7 @@ class TfMakeDecoratorTest(test.TestCase):
       return tf_decorator.make_decorator(test_function, wrapper)
 
     decorated = test_decorator_name(test_wrapper)
-    decorator = getattr(decorated, '_tf_decorator')
+    decorator = decorated._tf_decorator
     self.assertEqual('test_decorator_name', decorator.decorator_name)
 
   def testCompatibleWithNamelessCallables(self):


### PR DESCRIPTION
This PR remove unnecessary use of `getattr` and `setattr`.

From [`flake8-bugbear`](https://github.com/PyCQA/flake8-bugbear#list-of-warnings):

> Do not call `getattr(x, 'attr')`, instead use normal property access: `x.attr`. Missing a default to `getattr` will cause an `AttributeError` to be raised for non-existent properties. There is no additional safety in using `getattr` if you know the attribute name ahead of time.
>
> Do not call `setattr(x, 'attr', val)`, instead use normal property access: `x.attr = val`. There is no additional safety in using `setattr` if you know the attribute name ahead of time.