### PR TITLE
fixed the documentation of glorot_normal according to issue 25564

### DIFF
--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -1263,9 +1263,10 @@ class GlorotNormal(VarianceScaling):
   """The Glorot normal initializer, also called Xavier normal initializer.
 
   It draws samples from a truncated normal distribution centered on 0
-  with `stddev = sqrt(2 / (fan_in + fan_out))`
-  where `fan_in` is the number of input units in the weight tensor
-  and `fan_out` is the number of output units in the weight tensor.
+  with standard deviation (after truncation) given by
+  `stddev = sqrt(2 / (fan_in + fan_out))` where `fan_in` is the number
+  of input units in the weight tensor and `fan_out` is the number of
+  output units in the weight tensor.
 
   Args:
     seed: A Python integer. Used to create random seeds. See


### PR DESCRIPTION
PR for issue #25564. Modified the documentation of `tf.keras.initializers.glorot_normal` to specify that the 'stddev' argument refers to the standard deviation of the truncated normal distribution and not the standard deviation of the underling normal distribution.