### PR TITLE
Fix issue of rnn.ResidualWrapper not compatible with keras.layers

### DIFF
--- a/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
+++ b/tensorflow/contrib/rnn/python/kernel_tests/rnn_cell_test.py
@@ -1554,6 +1554,16 @@ class RNNCellTest(test.TestCase):
       self.assertEqual(len(outputs), batch)
       self.assertEqual(len(state), batch)
 
+  def testWrapperWithKerasLSTMCellGetInitialState(self):
+    for wrapper in [
+        rnn_cell_impl.DropoutWrapperV2,
+        rnn_cell_impl.DropoutWrapper,
+        rnn_cell_impl.ResidualWrapperV2,
+        rnn_cell_impl.ResidualWrapper]:
+      cell = keras_layers.LSTMCell(10)
+      cell = wrapper(cell)
+      cell.get_initial_state(batch_size=4, dtype=dtypes.float32)
+
 
 class LayerNormBasicLSTMCellTest(test.TestCase):
 

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -1344,7 +1344,9 @@ class DropoutWrapper(_RNNCellWrapperV1):
 
   def zero_state(self, batch_size, dtype):
     with ops.name_scope(type(self).__name__ + "ZeroState", values=[batch_size]):
-      return self._cell.zero_state(batch_size, dtype)
+      if (hasattr(self._cell, "zero_state")):
+        return self._cell.zero_state(batch_size, dtype)
+      return super(DropoutWrapper, self).zero_state(batch_size, dtype)
 
   def _variational_recurrent_dropout_value(
       self, index, value, noise, keep_prob):
@@ -1542,7 +1544,9 @@ class ResidualWrapper(_RNNCellWrapperV1):
 
   def zero_state(self, batch_size, dtype):
     with ops.name_scope(type(self).__name__ + "ZeroState", values=[batch_size]):
-      return self._cell.zero_state(batch_size, dtype)
+      if (hasattr(self._cell, "zero_state")):
+        return self._cell.zero_state(batch_size, dtype)
+      return super(ResidualWrapper, self).zero_state(batch_size, dtype)
 
   def _call_wrapped_cell(self, inputs, state, cell_call_fn, **kwargs):
     """Run the cell and then apply the residual_fn on its inputs to its outputs.


### PR DESCRIPTION
This fix tries to fix the issue raised in #25641 where rnn.ResidualWrapper
is not compatible with keras.layers. The issue was that parent class may not
be invoked to process zero_state.

This fix fixes #25641.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>