### PR TITLE
Use rate instead of keep_prob in rnn_cell_impl.py

### DIFF
--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -1370,8 +1370,8 @@ class DropoutWrapper(_RNNCellWrapperV1):
     if not self._variational_recurrent:
       def dropout(i, do_dropout, v):
         if not isinstance(do_dropout, bool) or do_dropout:
-          return nn_ops.dropout(
-              v, keep_prob=keep_prob, seed=self._gen_seed(salt_prefix, i))
+          return nn_ops.dropout_v2(
+              v, 1. - keep_prob, seed=self._gen_seed(salt_prefix, i))
         else:
           return v
       return _enumerated_map_structure_up_to(

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -1371,7 +1371,7 @@ class DropoutWrapper(_RNNCellWrapperV1):
       def dropout(i, do_dropout, v):
         if not isinstance(do_dropout, bool) or do_dropout:
           return nn_ops.dropout_v2(
-              v, 1. - keep_prob, seed=self._gen_seed(salt_prefix, i))
+              v, rate=1. - keep_prob, seed=self._gen_seed(salt_prefix, i))
         else:
           return v
       return _enumerated_map_structure_up_to(


### PR DESCRIPTION
While running rnn_cell_test found the following warning:
```
tensorflow/python/ops/rnn_cell_impl.py:1376: calling dropout (from tensorflow.python.ops.nn_ops) with keep_prob is deprecated and will be removed in a future version.
Instructions for updating:
Please use `rate` instead of `keep_prob`. Rate should be set to `rate = 1 - keep_prob`.
```

This fix replaces deprecated dropout with dropout_v2, and use rate instead
to fix the warning.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>