### PR TITLE
[InputContext] Add input_context examples in simple_estimator_example.py

### DIFF
--- a/tensorflow/contrib/distribute/python/examples/simple_estimator_example.py
+++ b/tensorflow/contrib/distribute/python/examples/simple_estimator_example.py
@@ -69,9 +69,10 @@ def main(_):
   # Since there are 2 devices and 10 samples, we set steps=5.
   steps = 5
 
-  def train_input_fn():
-    features = tf.data.Dataset.from_tensors([[1.]]).repeat(10)
-    labels = tf.data.Dataset.from_tensors([1.]).repeat(10)
+  def train_input_fn(input_context):
+    batch_size = input_context.get_per_replica_batch_size(2)
+    features = tf.data.Dataset.from_tensors([[1.]]).repeat(10).batch(batch_size)
+    labels = tf.data.Dataset.from_tensors([1.]).repeat(10).batch(batch_size)
     return tf.data.Dataset.zip((features, labels))
 
   estimator = tf.estimator.Estimator(

--- a/tensorflow/contrib/distribute/python/examples/simple_estimator_example.py
+++ b/tensorflow/contrib/distribute/python/examples/simple_estimator_example.py
@@ -69,6 +69,9 @@ def main(_):
   # Since there are 2 devices and 10 samples, we set steps=5.
   steps = 5
 
+  # The `batch_size` can be acquired from the argumtent `input_context`
+  # automatically accroding to the specific DistributionStrategy if that
+  # argument exists. The following `train_input_fn` shows the usage. 
   def train_input_fn(input_context):
     batch_size = input_context.get_per_replica_batch_size(2)
     features = tf.data.Dataset.from_tensors([[1.]]).repeat(10).batch(batch_size)


### PR DESCRIPTION
Hi @yuefengz ,
  This PR is just an example of using input_context in Estimator and it has been tested locally. This [PR](https://github.com/tensorflow/estimator/pull/15) 
shows the details of integration with `Estimator`. Please merge that before accept this mofification. Thanks.
