### PR TITLE
Tests for ZipDataset and ConcatenateDataset

### DIFF
--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -510,6 +510,26 @@ tf_kernel_library(
     ],
 )
 
+tf_cc_test(
+    name = "zip_dataset_op_test",
+    size = "small",
+    srcs = ["zip_dataset_op_test.cc"],
+    deps = [
+        ":dataset_test_base",
+        ":dataset_utils",
+        ":iterator_ops",
+        ":range_dataset_op",
+        ":zip_dataset_op",
+        "//tensorflow/core:core_cpu_internal",
+        "//tensorflow/core:dataset_ops_op_lib",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+    ],
+)
+
 tf_kernel_library(
     name = "concatenate_dataset_op",
     srcs = ["concatenate_dataset_op.cc"],
@@ -518,6 +538,26 @@ tf_kernel_library(
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
+    ],
+)
+
+tf_cc_test(
+    name = "concatenate_dataset_op_test",
+    size = "small",
+    srcs = ["concatenate_dataset_op_test.cc"],
+    deps = [
+        ":concatenate_dataset_op",
+        ":dataset_test_base",
+        ":dataset_utils",
+        ":iterator_ops",
+        ":tensor_slice_dataset_op",
+        "//tensorflow/core:core_cpu_internal",
+        "//tensorflow/core:dataset_ops_op_lib",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
     ],
 )
 

--- a/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
@@ -24,16 +24,17 @@ constexpr char kOpName[] = "ConcatenateDataset";
 
 class ConcatenateDatasetOpTest : public DatasetOpsTestBase {
  protected:
-  // Creates TensorSliceDatasets and save them as the variant tensors.
+  // Creates `TensorSliceDataset` variant tensors from the input vector of
+  // tensor vectors.
   Status CreateTensorSliceDatasetTensors(
-      std::vector<std::vector<Tensor>> tensor_vectors,
-      std::vector<Tensor> *dataset_tensors) {
+      const std::vector<std::vector<Tensor>> &tensor_vectors,
+      std::vector<Tensor> *const dataset_tensors) {
     for (int i = 0; i < tensor_vectors.size(); ++i) {
       std::vector<Tensor> tensors = tensor_vectors[i];
       DatasetBase *tensor_slice_dataset;
       TF_RETURN_IF_ERROR(
           CreateTensorSliceDataset(strings::StrCat("tensor_slice_node_", i),
-                                   tensors, &tensor_slice_dataset));
+                                   &tensors, &tensor_slice_dataset));
       Tensor dataset_tensor(DT_VARIANT, TensorShape({}));
       TF_RETURN_IF_ERROR(
           StoreDatasetInVariantTensor(tensor_slice_dataset, &dataset_tensor));
@@ -44,8 +45,8 @@ class ConcatenateDatasetOpTest : public DatasetOpsTestBase {
 
   // Creates a new ConcatenateDataset op kernel.
   Status CreateConcatenateDatasetKernel(
-      DataTypeVector output_tyeps,
-      std::vector<PartialTensorShape> output_shapes,
+      const DataTypeVector &output_tyeps,
+      const std::vector<PartialTensorShape> &output_shapes,
       std::unique_ptr<OpKernel> *op_kernel) {
     node_def_ = test::function::NDef(
         kNodeName, kOpName, {"input_dataset", "another_dataset"},
@@ -56,7 +57,8 @@ class ConcatenateDatasetOpTest : public DatasetOpsTestBase {
 
   // Creates a new ConcatenateDataset op kernel context.
   Status CreateConcatenateDatasetContext(
-      OpKernel *const op_kernel, gtl::InlinedVector<TensorValue, 4> *inputs,
+      OpKernel *const op_kernel,
+      gtl::InlinedVector<TensorValue, 4> *const inputs,
       std::unique_ptr<OpKernelContext> *context) {
     TF_RETURN_IF_ERROR(CheckOpKernelInput(*op_kernel, *inputs));
     TF_RETURN_IF_ERROR(CreateOpKernelContext(op_kernel, inputs, context));

--- a/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
@@ -1,0 +1,594 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/data/dataset_test_base.h"
+
+namespace tensorflow {
+namespace data {
+namespace {
+
+constexpr char kNodeName[] = "concatenate_dataset";
+constexpr char kOpName[] = "ConcatenateDataset";
+
+class ConcatenateDatasetOpTest : public DatasetOpsTestBase {
+ protected:
+  // Creates TensorSliceDatasets and save them as the variant tensors.
+  Status CreateTensorSliceDatasetTensors(
+      std::vector<std::vector<Tensor>> tensor_vectors,
+      std::vector<Tensor> *dataset_tensors) {
+    for (int i = 0; i < tensor_vectors.size(); ++i) {
+      std::vector<Tensor> tensors = tensor_vectors[i];
+      DatasetBase *tensor_slice_dataset;
+      TF_RETURN_IF_ERROR(
+          CreateTensorSliceDataset(strings::StrCat("tensor_slice_node_", i),
+                                   tensors, &tensor_slice_dataset));
+      Tensor dataset_tensor(DT_VARIANT, TensorShape({}));
+      TF_RETURN_IF_ERROR(
+          StoreDatasetInVariantTensor(tensor_slice_dataset, &dataset_tensor));
+      dataset_tensors->emplace_back(std::move(dataset_tensor));
+    }
+    return Status::OK();
+  }
+
+  // Creates a new ConcatenateDataset op kernel.
+  Status CreateConcatenateDatasetKernel(
+      DataTypeVector output_tyeps,
+      std::vector<PartialTensorShape> output_shapes,
+      std::unique_ptr<OpKernel> *op_kernel) {
+    node_def_ = test::function::NDef(
+        kNodeName, kOpName, {"input_dataset", "another_dataset"},
+        {{"output_types", output_tyeps}, {"output_shapes", output_shapes}});
+    TF_CHECK_OK(CreateOpKernel(node_def_, op_kernel));
+    return Status::OK();
+  }
+
+  // Creates a new ConcatenateDataset op kernel context.
+  Status CreateConcatenateDatasetContext(
+      OpKernel *const op_kernel, gtl::InlinedVector<TensorValue, 4> *inputs,
+      std::unique_ptr<OpKernelContext> *context) {
+    TF_RETURN_IF_ERROR(CheckOpKernelInput(*op_kernel, *inputs));
+    TF_RETURN_IF_ERROR(CreateOpKernelContext(op_kernel, inputs, context));
+    return Status::OK();
+  }
+
+ private:
+  NodeDef node_def_;
+};
+
+struct TestParam {
+  std::vector<std::vector<Tensor>> input_tensors;
+  std::vector<Tensor> expected_outputs;
+  DataTypeVector expected_output_dtypes;
+  std::vector<PartialTensorShape> expected_output_shapes;
+  int64 expected_cardinality;
+  std::vector<int> breakpoints;
+} TestCases[] = {
+    // Same shape.
+    {{{DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2, 2}, {1, 2, 3, 4}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2, 2},
+                                               {5, 6, 7, 8})},
+      {DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2, 2},
+                                               {11, 12, 13, 14}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2, 2},
+                                               {15, 16, 17, 18})}},
+     {{DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {1, 2}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {5, 6}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {3, 4}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {7, 8}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {11, 12}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {15, 16}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {13, 14}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {17, 18})}},
+     {DT_INT64, DT_INT64},
+     {PartialTensorShape({2}), PartialTensorShape({2})},
+     4,
+     {0, 2, 5}},
+    // Different shape.
+    {{{DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2, 3},
+                                               {1, 2, 3, 4, 5, 6}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2, 2},
+                                               {7, 8, 9, 10})},
+      {DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2, 2},
+                                               {11, 12, 13, 14}),
+       DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2, 1}, {15, 16})}},
+     {DatasetOpsTestBase::CreateTensor<int64>(TensorShape{3}, {1, 2, 3}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {7, 8}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{3}, {4, 5, 6}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {9, 10}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {11, 12}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{1}, {15}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{2}, {13, 14}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{1}, {16})},
+     {DT_INT64, DT_INT64},
+     {PartialTensorShape({-1}), PartialTensorShape({-1})},
+     4,
+     {0, 2, 5}}};
+
+struct DatasetGetNextTest : ConcatenateDatasetOpTest,
+                            ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(DatasetGetNextTest, GetNext) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = GetParam().input_tensors;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+  auto expected_outputs_it = expected_outputs.begin();
+  std::vector<PartialTensorShape> expected_output_shapes =
+      GetParam().expected_output_shapes;
+  DataTypeVector expected_output_dtypes = GetParam().expected_output_dtypes;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(
+      expected_output_dtypes, expected_output_shapes, &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+
+  bool end_of_sequence = false;
+  std::vector<Tensor> out_tensors;
+  while (!end_of_sequence) {
+    TF_EXPECT_OK(
+        iterator->GetNext(iterator_ctx.get(), &out_tensors, &end_of_sequence));
+    if (!end_of_sequence) {
+      for (auto &tensor : out_tensors) {
+        EXPECT_NE(expected_outputs_it, expected_outputs.end());
+        TF_EXPECT_OK(ExpectEqual(tensor, *expected_outputs_it));
+        expected_outputs_it++;
+      }
+    }
+  }
+  EXPECT_EQ(expected_outputs_it, expected_outputs.end());
+}
+
+INSTANTIATE_TEST_CASE_P(ConcatenateDatasetOpTest, DatasetGetNextTest,
+                        ::testing::ValuesIn(TestCases));
+
+TEST_F(ConcatenateDatasetOpTest, DifferentDtypes) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = {
+      {CreateTensor<int64>(TensorShape({2, 2}), {1, 2, 3, 4})},
+      {CreateTensor<double>(TensorShape({2, 2}), {1.0, 2.0, 3.0, 4.0})}};
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  std::vector<PartialTensorShape> output_shapes =
+      TestCases[0].expected_output_shapes;
+  DataTypeVector output_dtypes = TestCases[0].expected_output_dtypes;
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(output_dtypes, output_shapes,
+                                              &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  EXPECT_EQ(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset)
+          .code(),
+      tensorflow::error::INVALID_ARGUMENT);
+}
+
+TEST_F(ConcatenateDatasetOpTest, DatasetName) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = TestCases[0].input_tensors;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  std::vector<PartialTensorShape> output_shapes =
+      TestCases[0].expected_output_shapes;
+  DataTypeVector output_dtypes = TestCases[0].expected_output_dtypes;
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(output_dtypes, output_shapes,
+                                              &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  EXPECT_EQ(dataset->name(), kOpName);
+}
+
+struct DatasetOutputDtypesTest : ConcatenateDatasetOpTest,
+                                 ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(DatasetOutputDtypesTest, DatasetOutputDtypes) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = GetParam().input_tensors;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+  std::vector<PartialTensorShape> expected_output_shapes =
+      GetParam().expected_output_shapes;
+  DataTypeVector expected_output_dtypes = GetParam().expected_output_dtypes;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(
+      expected_output_dtypes, expected_output_shapes, &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  EXPECT_OK(VerifyTypesMatch(dataset->output_dtypes(), expected_output_dtypes));
+}
+
+INSTANTIATE_TEST_CASE_P(ConcatenateDatasetOpTest, DatasetOutputDtypesTest,
+                        ::testing::ValuesIn(TestCases));
+
+struct DatasetOutputShapesTest : ConcatenateDatasetOpTest,
+                                 ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(DatasetOutputShapesTest, DatasetOutputShapes) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = GetParam().input_tensors;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+  std::vector<PartialTensorShape> expected_output_shapes =
+      GetParam().expected_output_shapes;
+  DataTypeVector expected_output_dtypes = GetParam().expected_output_dtypes;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(
+      expected_output_dtypes, expected_output_shapes, &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  EXPECT_OK(
+      VerifyShapesCompatible(dataset->output_shapes(), expected_output_shapes));
+}
+
+INSTANTIATE_TEST_CASE_P(ConcatenateDatasetOpTest, DatasetOutputShapesTest,
+                        ::testing::ValuesIn(TestCases));
+
+struct DatasetCardinalityTest : ConcatenateDatasetOpTest,
+                                ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(DatasetCardinalityTest, Cardinality) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = GetParam().input_tensors;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+  std::vector<PartialTensorShape> expected_output_shapes =
+      GetParam().expected_output_shapes;
+  DataTypeVector expected_output_dtypes = GetParam().expected_output_dtypes;
+  int64 expected_cardinality = GetParam().expected_cardinality;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(
+      expected_output_dtypes, expected_output_shapes, &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  EXPECT_EQ(dataset->Cardinality(), expected_cardinality);
+}
+
+INSTANTIATE_TEST_CASE_P(ConcatenateDatasetOpTest, DatasetCardinalityTest,
+                        ::testing::ValuesIn(TestCases));
+
+TEST_F(ConcatenateDatasetOpTest, DatasetSave) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = TestCases[0].input_tensors;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  std::vector<PartialTensorShape> output_shapes =
+      TestCases[0].expected_output_shapes;
+  DataTypeVector output_dtypes = TestCases[0].expected_output_dtypes;
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(output_dtypes, output_shapes,
+                                              &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<SerializationContext> serialization_ctx;
+  TF_ASSERT_OK(CreateSerializationContext(&serialization_ctx));
+  VariantTensorData data;
+  VariantTensorDataWriter writer(&data);
+  TF_ASSERT_OK(dataset->Save(serialization_ctx.get(), &writer));
+  TF_ASSERT_OK(writer.Flush());
+}
+
+struct IteratorOutputDtypesTest : ConcatenateDatasetOpTest,
+                                  ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(IteratorOutputDtypesTest, IteratorOutputDtypes) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = GetParam().input_tensors;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+  std::vector<PartialTensorShape> expected_output_shapes =
+      GetParam().expected_output_shapes;
+  DataTypeVector expected_output_dtypes = GetParam().expected_output_dtypes;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(
+      expected_output_dtypes, expected_output_shapes, &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+
+  TF_EXPECT_OK(
+      VerifyTypesMatch(iterator->output_dtypes(), expected_output_dtypes));
+}
+
+INSTANTIATE_TEST_CASE_P(ConcatenateDatasetOpTest, IteratorOutputDtypesTest,
+                        ::testing::ValuesIn(TestCases));
+
+struct IteratorOutputShapesTest : ConcatenateDatasetOpTest,
+                                  ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(IteratorOutputShapesTest, IteratorOutputShapes) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = GetParam().input_tensors;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+  std::vector<PartialTensorShape> expected_output_shapes =
+      GetParam().expected_output_shapes;
+  DataTypeVector expected_output_dtypes = GetParam().expected_output_dtypes;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(
+      expected_output_dtypes, expected_output_shapes, &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+
+  TF_EXPECT_OK(VerifyShapesCompatible(iterator->output_shapes(),
+                                      expected_output_shapes));
+}
+
+INSTANTIATE_TEST_CASE_P(ConcatenateDatasetOpTest, IteratorOutputShapesTest,
+                        ::testing::ValuesIn(TestCases));
+
+TEST_F(ConcatenateDatasetOpTest, IteratorOutputPrefix) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = TestCases[0].input_tensors;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  std::vector<PartialTensorShape> output_shapes =
+      TestCases[0].expected_output_shapes;
+  DataTypeVector output_dtypes = TestCases[0].expected_output_dtypes;
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(output_dtypes, output_shapes,
+                                              &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+  EXPECT_EQ(iterator->prefix(), "Iterator::Concatenate");
+}
+
+struct IteratorRoundtripTest : ConcatenateDatasetOpTest,
+                               ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(IteratorRoundtripTest, Roundtrip) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<std::vector<Tensor>> tensor_vectors = GetParam().input_tensors;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+  auto expected_outputs_it = expected_outputs.begin();
+  std::vector<PartialTensorShape> expected_output_shapes =
+      GetParam().expected_output_shapes;
+  DataTypeVector expected_output_dtypes = GetParam().expected_output_dtypes;
+  std::vector<Tensor> tensor_slice_dataset_tensors;
+  TF_ASSERT_OK(CreateTensorSliceDatasetTensors(tensor_vectors,
+                                               &tensor_slice_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : tensor_slice_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateConcatenateDatasetKernel(
+      expected_output_dtypes, expected_output_shapes, &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateConcatenateDatasetContext(dataset_kernel.get(), &inputs,
+                                               &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+
+  std::unique_ptr<SerializationContext> serialization_ctx;
+  TF_ASSERT_OK(CreateSerializationContext(&serialization_ctx));
+
+  bool end_of_sequence = false;
+  std::vector<Tensor> out_tensors;
+  int cur_iteration = 0;
+  std::vector<int> breakpoints = GetParam().breakpoints;
+  for (int breakpoint : breakpoints) {
+    VariantTensorData data;
+    VariantTensorDataWriter writer(&data);
+    TF_EXPECT_OK(iterator->Save(serialization_ctx.get(), &writer));
+    TF_EXPECT_OK(writer.Flush());
+    VariantTensorDataReader reader(&data);
+    TF_EXPECT_OK(iterator->Restore(iterator_ctx.get(), &reader));
+
+    while (cur_iteration < breakpoint) {
+      TF_EXPECT_OK(iterator->GetNext(iterator_ctx.get(), &out_tensors,
+                                     &end_of_sequence));
+      if (!end_of_sequence) {
+        for (auto &tensor : out_tensors) {
+          EXPECT_NE(expected_outputs_it, expected_outputs.end());
+          TF_EXPECT_OK(ExpectEqual(tensor, *expected_outputs_it));
+          expected_outputs_it++;
+        }
+      }
+      cur_iteration++;
+    }
+
+    if (breakpoint >= dataset->Cardinality()) {
+      EXPECT_TRUE(end_of_sequence);
+      EXPECT_EQ(expected_outputs_it, expected_outputs.end());
+    } else {
+      EXPECT_FALSE(end_of_sequence);
+    }
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(ConcatenateDatasetOpTest, IteratorRoundtripTest,
+                        ::testing::ValuesIn(TestCases));
+}  // namespace
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -86,7 +86,6 @@ Status DatasetOpsTestBase::CreateTensorSliceDataset(
   return Status::OK();
 }
 
->>>>>>> Add CreateTensorSliceDataset[Kernel] functions to the test base class
 Status DatasetOpsTestBase::CreateOpKernel(
     const NodeDef& node_def, std::unique_ptr<OpKernel>* op_kernel) {
   Status status;

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -35,6 +35,54 @@ Status DatasetOpsTestBase::ExpectEqual(const Tensor& a, const Tensor& b) {
   return Status::OK();
 }
 
+Status DatasetOpsTestBase::CreateTensorSliceDatasetKernel(
+    StringPiece node_name, DataTypeVector dtypes,
+    std::vector<PartialTensorShape> shapes,
+    std::unique_ptr<OpKernel>* tensor_dataset_kernel) {
+  std::vector<string> components;
+  components.reserve(dtypes.size());
+  for (int i = 0; i < dtypes.size(); i++) {
+    components.emplace_back(strings::StrCat("component_", i));
+  }
+  NodeDef node_def = test::function::NDef(
+      node_name, "TensorSliceDataset", components,
+      {{"Toutput_types", dtypes}, {"output_shapes", shapes}});
+  TF_RETURN_IF_ERROR(CreateOpKernel(node_def, tensor_dataset_kernel));
+  return Status::OK();
+}
+
+Status DatasetOpsTestBase::CreateTensorSliceDataset(
+    StringPiece node_name, std::vector<Tensor> components,
+    DatasetBase** tensor_slice_data) {
+  std::unique_ptr<OpKernel> tensor_slice_dataset_kernel;
+  DataTypeVector dtypes;
+  std::vector<PartialTensorShape> shapes;
+  for (auto& t : components) {
+    dtypes.push_back(t.dtype());
+    gtl::InlinedVector<int64, 4> partial_dim_sizes;
+    for (int i = 1; i < t.dims(); ++i) {
+      partial_dim_sizes.push_back(t.dim_size(i));
+    }
+    shapes.emplace_back(std::move(partial_dim_sizes));
+  }
+  TF_RETURN_IF_ERROR(CreateTensorSliceDatasetKernel(
+      node_name, dtypes, shapes, &tensor_slice_dataset_kernel));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto& tensor : components) {
+    inputs.emplace_back(&tensor);
+  }
+  TF_RETURN_IF_ERROR(CheckOpKernelInput(*tensor_slice_dataset_kernel, inputs));
+  std::unique_ptr<OpKernelContext> context;
+  TF_RETURN_IF_ERROR(CreateOpKernelContext(tensor_slice_dataset_kernel.get(),
+                                           &inputs, &context));
+  TF_RETURN_IF_ERROR(
+      RunOpKernel(tensor_slice_dataset_kernel.get(), context.get()));
+  TF_RETURN_IF_ERROR(
+      GetDatasetFromContext(context.get(), 0, tensor_slice_data));
+  return Status::OK();
+}
+
+>>>>>>> Add CreateTensorSliceDataset[Kernel] functions to the test base class
 Status DatasetOpsTestBase::CreateOpKernel(
     const NodeDef& node_def, std::unique_ptr<OpKernel>* op_kernel) {
   Status status;

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -36,28 +36,30 @@ Status DatasetOpsTestBase::ExpectEqual(const Tensor& a, const Tensor& b) {
 }
 
 Status DatasetOpsTestBase::CreateTensorSliceDatasetKernel(
-    const StringPiece& node_name, const DataTypeVector& dtypes,
+    StringPiece node_name, const DataTypeVector& dtypes,
     const std::vector<PartialTensorShape>& shapes,
-    std::unique_ptr<OpKernel>* tensor_dataset_kernel) {
+    std::unique_ptr<OpKernel>* tensor_slice_dataset_kernel) {
   std::vector<string> components;
   components.reserve(dtypes.size());
   for (int i = 0; i < dtypes.size(); ++i) {
+    // Create the placeholder names for the input components of
+    // `TensorSliceDataset`.
     components.emplace_back(strings::StrCat("component_", i));
   }
   NodeDef node_def = test::function::NDef(
       node_name, "TensorSliceDataset", components,
       {{"Toutput_types", dtypes}, {"output_shapes", shapes}});
-  TF_RETURN_IF_ERROR(CreateOpKernel(node_def, tensor_dataset_kernel));
+  TF_RETURN_IF_ERROR(CreateOpKernel(node_def, tensor_slice_dataset_kernel));
   return Status::OK();
 }
 
 Status DatasetOpsTestBase::CreateTensorSliceDataset(
-    const StringPiece& node_name, std::vector<Tensor>& components,
-    DatasetBase** tensor_slice_data) {
+    StringPiece node_name, std::vector<Tensor>* const components,
+    DatasetBase** tensor_slice_dataset) {
   std::unique_ptr<OpKernel> tensor_slice_dataset_kernel;
   DataTypeVector dtypes;
   std::vector<PartialTensorShape> shapes;
-  for (const auto& t : components) {
+  for (const auto& t : *components) {
     dtypes.push_back(t.dtype());
     gtl::InlinedVector<int64, 4> partial_dim_sizes;
     for (int i = 1; i < t.dims(); ++i) {
@@ -68,7 +70,7 @@ Status DatasetOpsTestBase::CreateTensorSliceDataset(
   TF_RETURN_IF_ERROR(CreateTensorSliceDatasetKernel(
       node_name, dtypes, shapes, &tensor_slice_dataset_kernel));
   gtl::InlinedVector<TensorValue, 4> inputs;
-  for (auto& tensor : components) {
+  for (auto& tensor : *components) {
     inputs.emplace_back(&tensor);
   }
   TF_RETURN_IF_ERROR(CheckOpKernelInput(*tensor_slice_dataset_kernel, inputs));
@@ -78,7 +80,7 @@ Status DatasetOpsTestBase::CreateTensorSliceDataset(
   TF_RETURN_IF_ERROR(
       RunOpKernel(tensor_slice_dataset_kernel.get(), context.get()));
   TF_RETURN_IF_ERROR(
-      GetDatasetFromContext(context.get(), 0, tensor_slice_data));
+      GetDatasetFromContext(context.get(), 0, tensor_slice_dataset));
   return Status::OK();
 }
 

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -58,7 +58,9 @@ Status DatasetOpsTestBase::CreateTensorSliceDataset(
     DatasetBase** tensor_slice_dataset) {
   std::unique_ptr<OpKernel> tensor_slice_dataset_kernel;
   DataTypeVector dtypes;
+  dtypes.reserve(components->size());
   std::vector<PartialTensorShape> shapes;
+  shapes.reserve(components->size());
   for (const auto& t : *components) {
     dtypes.push_back(t.dtype());
     gtl::InlinedVector<int64, 4> partial_dim_sizes;

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -36,12 +36,12 @@ Status DatasetOpsTestBase::ExpectEqual(const Tensor& a, const Tensor& b) {
 }
 
 Status DatasetOpsTestBase::CreateTensorSliceDatasetKernel(
-    StringPiece node_name, DataTypeVector dtypes,
-    std::vector<PartialTensorShape> shapes,
+    const StringPiece& node_name, const DataTypeVector& dtypes,
+    const std::vector<PartialTensorShape>& shapes,
     std::unique_ptr<OpKernel>* tensor_dataset_kernel) {
   std::vector<string> components;
   components.reserve(dtypes.size());
-  for (int i = 0; i < dtypes.size(); i++) {
+  for (int i = 0; i < dtypes.size(); ++i) {
     components.emplace_back(strings::StrCat("component_", i));
   }
   NodeDef node_def = test::function::NDef(
@@ -52,12 +52,12 @@ Status DatasetOpsTestBase::CreateTensorSliceDatasetKernel(
 }
 
 Status DatasetOpsTestBase::CreateTensorSliceDataset(
-    StringPiece node_name, std::vector<Tensor> components,
+    const StringPiece& node_name, std::vector<Tensor>& components,
     DatasetBase** tensor_slice_data) {
   std::unique_ptr<OpKernel> tensor_slice_dataset_kernel;
   DataTypeVector dtypes;
   std::vector<PartialTensorShape> shapes;
-  for (auto& t : components) {
+  for (const auto& t : components) {
     dtypes.push_back(t.dtype());
     gtl::InlinedVector<int64, 4> partial_dim_sizes;
     for (int i = 1; i < t.dims(); ++i) {

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -110,14 +110,14 @@ class DatasetOpsTestBase : public ::testing::Test {
 
   // Creates a new TensorSliceDataset op kernel.
   Status CreateTensorSliceDatasetKernel(
-      const StringPiece& node_name, const DataTypeVector& dtypes,
+      StringPiece node_name, const DataTypeVector& dtypes,
       const std::vector<PartialTensorShape>& shapes,
-      std::unique_ptr<OpKernel>* tensor_dataset_kernel);
+      std::unique_ptr<OpKernel>* tensor_slice_dataset_kernel);
 
   // Creates a new TensorSliceDataset.
-  Status CreateTensorSliceDataset(const StringPiece& node_name,
-                                  std::vector<Tensor>& components,
-                                  DatasetBase** tensor_slice_data);
+  Status CreateTensorSliceDataset(StringPiece node_name,
+                                  std::vector<Tensor>* const components,
+                                  DatasetBase** tensor_slice_dataset);
 
   // Fetches the dataset from the operation context.
   Status GetDatasetFromContext(OpKernelContext* context, int output_index,

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -110,13 +110,13 @@ class DatasetOpsTestBase : public ::testing::Test {
 
   // Creates a new TensorSliceDataset op kernel.
   Status CreateTensorSliceDatasetKernel(
-      StringPiece node_name, DataTypeVector dtypes,
-      std::vector<PartialTensorShape> shapes,
+      const StringPiece& node_name, const DataTypeVector& dtypes,
+      const std::vector<PartialTensorShape>& shapes,
       std::unique_ptr<OpKernel>* tensor_dataset_kernel);
 
   // Creates a new TensorSliceDataset.
-  Status CreateTensorSliceDataset(StringPiece node_name,
-                                  std::vector<Tensor> components,
+  Status CreateTensorSliceDataset(const StringPiece& node_name,
+                                  std::vector<Tensor>& components,
                                   DatasetBase** tensor_slice_data);
 
   // Fetches the dataset from the operation context.

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -108,6 +108,17 @@ class DatasetOpsTestBase : public ::testing::Test {
     return Status::OK();
   }
 
+  // Creates a new TensorSliceDataset op kernel.
+  Status CreateTensorSliceDatasetKernel(
+      StringPiece node_name, DataTypeVector dtypes,
+      std::vector<PartialTensorShape> shapes,
+      std::unique_ptr<OpKernel>* tensor_dataset_kernel);
+
+  // Creates a new TensorSliceDataset.
+  Status CreateTensorSliceDataset(StringPiece node_name,
+                                  std::vector<Tensor> components,
+                                  DatasetBase** tensor_slice_data);
+
   // Fetches the dataset from the operation context.
   Status GetDatasetFromContext(OpKernelContext* context, int output_index,
                                DatasetBase** const dataset);

--- a/tensorflow/core/kernels/data/map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op_test.cc
@@ -130,7 +130,7 @@ TEST_P(DatasetGetNextTest, GetNext) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(map_context.get(), &iterator_context));
@@ -176,7 +176,7 @@ TEST_F(MapDatasetOpTest, DatasetName) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateRangeDataset<int64>(start, end, step, "range", &range_dataset));
-  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+  core::ScopedUnref scoped_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -187,7 +187,7 @@ TEST_F(MapDatasetOpTest, DatasetName) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   EXPECT_EQ(map_dataset->name(), kOpName);
 }
@@ -203,7 +203,7 @@ TEST_F(MapDatasetOpTest, DatasetOutputDtypes) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateRangeDataset<int64>(start, end, step, "range", &range_dataset));
-  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+  core::ScopedUnref scoped_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -214,7 +214,7 @@ TEST_F(MapDatasetOpTest, DatasetOutputDtypes) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   DataTypeVector expected_dtypes({DT_INT64});
   EXPECT_EQ(map_dataset->output_dtypes(), expected_dtypes);
@@ -231,7 +231,7 @@ TEST_F(MapDatasetOpTest, DatasetOutputShapes) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateRangeDataset<int64>(start, end, step, "range", &range_dataset));
-  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+  core::ScopedUnref scoped_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -242,7 +242,7 @@ TEST_F(MapDatasetOpTest, DatasetOutputShapes) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   std::vector<PartialTensorShape> expected_shapes({PartialTensorShape({})});
   EXPECT_EQ(map_dataset->output_shapes().size(), expected_shapes.size());
@@ -283,7 +283,7 @@ TEST_P(DatasetCardinalityTest, Cardinality) {
   TF_ASSERT_OK(CreateRangeDataset<int64>(test_params.start, test_params.end,
                                          test_params.step, "range",
                                          &range_dataset));
-  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+  core::ScopedUnref scoped_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -294,7 +294,7 @@ TEST_P(DatasetCardinalityTest, Cardinality) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   EXPECT_EQ(map_dataset->Cardinality(), test_params.expected_cardinality);
 }
@@ -315,7 +315,7 @@ TEST_F(MapDatasetOpTest, DatasetSave) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateRangeDataset<int64>(start, end, step, "range", &range_dataset));
-  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+  core::ScopedUnref scoped_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -326,7 +326,7 @@ TEST_F(MapDatasetOpTest, DatasetSave) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   std::unique_ptr<SerializationContext> serialization_context;
   TF_ASSERT_OK(CreateSerializationContext(&serialization_context));
@@ -347,7 +347,7 @@ TEST_F(MapDatasetOpTest, IteratorOutputDtypes) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateRangeDataset<int64>(start, end, step, "range", &range_dataset));
-  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+  core::ScopedUnref scoped_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -358,7 +358,7 @@ TEST_F(MapDatasetOpTest, IteratorOutputDtypes) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(map_context.get(), &iterator_context));
@@ -380,7 +380,7 @@ TEST_F(MapDatasetOpTest, IteratorOutputShapes) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateRangeDataset<int64>(start, end, step, "range", &range_dataset));
-  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+  core::ScopedUnref scoped_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -391,7 +391,7 @@ TEST_F(MapDatasetOpTest, IteratorOutputShapes) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(map_context.get(), &iterator_context));
@@ -417,7 +417,7 @@ TEST_F(MapDatasetOpTest, IteratorOutputPrefix) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateRangeDataset<int64>(start, end, step, "range", &range_dataset));
-  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+  core::ScopedUnref scoped_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -428,7 +428,7 @@ TEST_F(MapDatasetOpTest, IteratorOutputPrefix) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(map_context.get(), &iterator_context));
@@ -477,7 +477,7 @@ TEST_P(IteratorRoundtripTest, Roundtrip) {
   TF_ASSERT_OK(CreateRangeDataset<int64>(test_params.start, test_params.end,
                                          test_params.step, "range",
                                          &range_dataset));
-  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+  core::ScopedUnref scoped_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -488,7 +488,7 @@ TEST_P(IteratorRoundtripTest, Roundtrip) {
   DatasetBase* map_dataset;
   TF_ASSERT_OK(
       CreateDataset(map_kernel.get(), map_context.get(), &map_dataset));
-  core::ScopedUnref scored_unref_map_dataset(map_dataset);
+  core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(map_context.get(), &iterator_context));

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -85,7 +85,7 @@ TEST_P(DatasetGetNextTest, GetNext) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(range_context.get(), &iterator_context));
@@ -134,7 +134,7 @@ TEST_F(RangeDatasetOpTest, DatasetName) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   EXPECT_EQ(range_dataset->name(), kOpName);
 }
@@ -154,7 +154,7 @@ TEST_F(RangeDatasetOpTest, DatasetOutputDtypes) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   DataTypeVector expected_dtypes({DT_INT64});
   EXPECT_EQ(range_dataset->output_dtypes(), expected_dtypes);
@@ -175,7 +175,7 @@ TEST_F(RangeDatasetOpTest, DatasetOutputShapes) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   std::vector<PartialTensorShape> expected_shapes({PartialTensorShape({})});
   EXPECT_EQ(range_dataset->output_shapes().size(), expected_shapes.size());
@@ -219,7 +219,7 @@ TEST_P(DatasetCardinalityTest, Cardinality) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   EXPECT_EQ(range_dataset->Cardinality(), params.expected_cardinality);
 }
@@ -244,7 +244,7 @@ TEST_F(RangeDatasetOpTest, DatasetSave) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   std::unique_ptr<SerializationContext> serialization_context;
   TF_ASSERT_OK(CreateSerializationContext(&serialization_context));
@@ -270,7 +270,7 @@ TEST_F(RangeDatasetOpTest, IteratorOutputDtypes) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(range_context.get(), &iterator_context));
@@ -297,7 +297,7 @@ TEST_F(RangeDatasetOpTest, IteratorOutputShapes) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(range_context.get(), &iterator_context));
@@ -327,7 +327,7 @@ TEST_F(RangeDatasetOpTest, IteratorOutputPrefix) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(range_context.get(), &iterator_context));
@@ -371,7 +371,7 @@ TEST_P(IteratorRoundtripTest, Roundtrip) {
   DatasetBase* range_dataset;
   TF_ASSERT_OK(
       CreateDataset(range_kernel.get(), range_context.get(), &range_dataset));
-  core::ScopedUnref scored_unref(range_dataset);
+  core::ScopedUnref scoped_unref(range_dataset);
 
   std::unique_ptr<IteratorContext> iterator_context;
   TF_ASSERT_OK(CreateIteratorContext(range_context.get(), &iterator_context));

--- a/tensorflow/core/kernels/data/zip_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/zip_dataset_op_test.cc
@@ -1,0 +1,539 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/data/dataset_test_base.h"
+
+namespace tensorflow {
+namespace data {
+namespace {
+
+constexpr char kNodeName[] = "zip_dataset";
+constexpr char kOpName[] = "ZipDataset";
+
+struct RangeDatasetParam {
+  int64 start;
+  int64 end;
+  int64 step;
+};
+
+class ZipDatasetOpTest : public DatasetOpsTestBase {
+ protected:
+  // Creates RangeDatasets and save them as the variant tensors.
+  Status CreateRangeDatasetTensors(std::vector<RangeDatasetParam> params,
+                                   std::vector<Tensor> *dataset_tensors) {
+    for (int i = 0; i < params.size(); ++i) {
+      DatasetBase *range_dataset;
+      TF_RETURN_IF_ERROR(CreateRangeDataset<int64>(
+          params[i].start, params[i].end, params[i].step,
+          strings::StrCat("range_", i), &range_dataset));
+      Tensor dataset_tensor(DT_VARIANT, TensorShape({}));
+      TF_RETURN_IF_ERROR(
+          StoreDatasetInVariantTensor(range_dataset, &dataset_tensor));
+      dataset_tensors->emplace_back(std::move(dataset_tensor));
+    }
+  }
+
+  // Creates a new ZipDataset op kernel.
+  Status CreateZipDatasetKernel(DataTypeVector dtypes,
+                                std::vector<PartialTensorShape> output_shapes,
+                                int n, std::unique_ptr<OpKernel> *op_kernel) {
+    std::vector<string> input_datasets;
+    input_datasets.reserve(n);
+    for (int i = 0; i < n; ++i) {
+      input_datasets.emplace_back(strings::StrCat("input_dataset_", i));
+    }
+    node_def_ = test::function::NDef(
+        kNodeName, kOpName, input_datasets,
+        {{"output_types", dtypes}, {"output_shapes", output_shapes}, {"N", n}});
+    TF_RETURN_IF_ERROR(CreateOpKernel(node_def_, op_kernel));
+    return Status::OK();
+  }
+
+  // Creates a new ZipDataset op kernel context.
+  Status CreateZipDatasetContext(OpKernel *const op_kernel,
+                                 gtl::InlinedVector<TensorValue, 4> *inputs,
+                                 std::unique_ptr<OpKernelContext> *context) {
+    TF_RETURN_IF_ERROR(CheckOpKernelInput(*op_kernel, *inputs));
+    TF_RETURN_IF_ERROR(CreateOpKernelContext(op_kernel, inputs, context));
+    return Status::OK();
+  }
+
+ private:
+  NodeDef node_def_;
+};
+
+struct TestParam {
+  std::vector<RangeDatasetParam> testcases;
+  std::vector<Tensor> expected_outputs;
+  std::vector<int> breakpoints;
+} TestCases[] = {
+    // Test the input datasets with same number of outputs.
+    {{RangeDatasetParam{0, 3, 1}, RangeDatasetParam{10, 13, 1}},
+     {DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {0}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {10}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {1}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {11}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {2}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {12})},
+     {0, 1, 4}},
+    // Test the input datasets with different number of outputs.
+    {{RangeDatasetParam{0, 3, 1}, RangeDatasetParam{10, 15, 1}},
+     {DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {0}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {10}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {1}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {11}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {2}),
+      DatasetOpsTestBase::CreateTensor<int64>(TensorShape{}, {12})},
+     {0, 1, 4}}};
+
+struct DatasetGetNextTest : ZipDatasetOpTest,
+                            ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(DatasetGetNextTest, GetNext) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases = GetParam().testcases;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+  auto expected_outputs_it = expected_outputs.begin();
+
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  int num_tensors_per_slice = testcases.size();
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{num_tensors_per_slice}},
+                                      inputs.size(), &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+
+  bool end_of_sequence = false;
+  std::vector<Tensor> out_tensors;
+  while (!end_of_sequence) {
+    TF_EXPECT_OK(
+        iterator->GetNext(iterator_ctx.get(), &out_tensors, &end_of_sequence));
+    if (!end_of_sequence) {
+      EXPECT_NE(expected_outputs_it, expected_outputs.end());
+      for (int i = 0; i < num_tensors_per_slice; ++i) {
+        TF_EXPECT_OK(ExpectEqual(out_tensors[i], *expected_outputs_it));
+        expected_outputs_it++;
+      }
+    }
+  }
+  EXPECT_EQ(expected_outputs_it, expected_outputs.end());
+}
+
+INSTANTIATE_TEST_CASE_P(ZipDatasetOpTest, DatasetGetNextTest,
+                        ::testing::ValuesIn(TestCases));
+
+TEST_F(ZipDatasetOpTest, DatasetName) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases = TestCases[0].testcases;
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{2}}, inputs.size(),
+                                      &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  EXPECT_EQ(dataset->name(), kOpName);
+}
+
+struct DatasetOutputDtypesTest : ZipDatasetOpTest,
+                                 ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(DatasetOutputDtypesTest, DatasetOutputDtypes) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases = GetParam().testcases;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  int num_tensors_per_slice = testcases.size();
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{num_tensors_per_slice}},
+                                      inputs.size(), &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  DataTypeVector expected_output_dtypes;
+  for (int i = 0; i < num_tensors_per_slice; ++i) {
+    expected_output_dtypes.emplace_back(expected_outputs[i].dtype());
+  }
+
+  TF_EXPECT_OK(
+      VerifyTypesMatch(dataset->output_dtypes(), expected_output_dtypes));
+}
+
+INSTANTIATE_TEST_CASE_P(ZipDatasetOpTest, DatasetOutputDtypesTest,
+                        ::testing::ValuesIn(TestCases));
+
+struct DatasetOutputShapesTest : ZipDatasetOpTest,
+                                 ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(DatasetOutputShapesTest, DatasetOutputShapes) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases = GetParam().testcases;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  int num_tensors_per_slice = testcases.size();
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{num_tensors_per_slice}},
+                                      inputs.size(), &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::vector<PartialTensorShape> expected_output_shapes;
+  for (int i = 0; i < num_tensors_per_slice; ++i) {
+    expected_output_shapes.emplace_back(expected_outputs[i].shape());
+  }
+
+  TF_EXPECT_OK(
+      VerifyShapesCompatible(dataset->output_shapes(), expected_output_shapes));
+}
+
+INSTANTIATE_TEST_CASE_P(ZipDatasetOpTest, DatasetOutputShapesTest,
+                        ::testing::ValuesIn(TestCases));
+
+struct DatasetCardinalityTest : ZipDatasetOpTest,
+                                ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(DatasetCardinalityTest, Cardinality) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases = GetParam().testcases;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  int num_tensors_per_slice = testcases.size();
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{num_tensors_per_slice}},
+                                      inputs.size(), &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  EXPECT_EQ(dataset->Cardinality(),
+            expected_outputs.size() / num_tensors_per_slice);
+}
+
+INSTANTIATE_TEST_CASE_P(ZipDatasetOpTest, DatasetCardinalityTest,
+                        ::testing::ValuesIn(TestCases));
+
+TEST_F(ZipDatasetOpTest, DatasetSave) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases = TestCases[0].testcases;
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{2}}, inputs.size(),
+                                      &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<SerializationContext> serialization_ctx;
+  TF_ASSERT_OK(CreateSerializationContext(&serialization_ctx));
+  VariantTensorData data;
+  VariantTensorDataWriter writer(&data);
+  TF_ASSERT_OK(dataset->Save(serialization_ctx.get(), &writer));
+  TF_ASSERT_OK(writer.Flush());
+}
+
+struct IteratorOutputDtypesTest : ZipDatasetOpTest,
+                                  ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(IteratorOutputDtypesTest, IteratorOutputDtypes) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases = GetParam().testcases;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  int num_tensors_per_slice = testcases.size();
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{num_tensors_per_slice}},
+                                      inputs.size(), &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+
+  DataTypeVector expected_output_dtypes;
+  for (int i = 0; i < num_tensors_per_slice; ++i) {
+    expected_output_dtypes.emplace_back(expected_outputs[i].dtype());
+  }
+
+  TF_EXPECT_OK(
+      VerifyTypesMatch(iterator->output_dtypes(), expected_output_dtypes));
+}
+
+INSTANTIATE_TEST_CASE_P(ZipDatasetOpTest, IteratorOutputDtypesTest,
+                        ::testing::ValuesIn(TestCases));
+
+struct IteratorOutputShapesTest : ZipDatasetOpTest,
+                                  ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(IteratorOutputShapesTest, IteratorOutputShapes) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases = GetParam().testcases;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  int num_tensors_per_slice = testcases.size();
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{num_tensors_per_slice}},
+                                      inputs.size(), &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+
+  std::vector<PartialTensorShape> expected_output_shapes;
+  expected_output_shapes.reserve(num_tensors_per_slice);
+  for (int i = 0; i < num_tensors_per_slice; ++i) {
+    expected_output_shapes.emplace_back(expected_outputs[i].shape());
+  }
+
+  TF_EXPECT_OK(VerifyShapesCompatible(iterator->output_shapes(),
+                                      expected_output_shapes));
+}
+
+INSTANTIATE_TEST_CASE_P(ZipDatasetOpTest, IteratorOutputShapesTest,
+                        ::testing::ValuesIn(TestCases));
+
+TEST_F(ZipDatasetOpTest, IteratorOutputPrefix) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases(
+      {RangeDatasetParam{0, 10, 1}, RangeDatasetParam{10, 20, 1}});
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{2}}, inputs.size(),
+                                      &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+  EXPECT_EQ(iterator->prefix(), "Iterator::Zip");
+}
+
+struct IteratorRoundtripTest : ZipDatasetOpTest,
+                               ::testing::WithParamInterface<TestParam> {};
+
+TEST_P(IteratorRoundtripTest, Roundtrip) {
+  int thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+
+  std::vector<RangeDatasetParam> testcases = GetParam().testcases;
+  std::vector<Tensor> expected_outputs = GetParam().expected_outputs;
+  auto expected_outputs_it = expected_outputs.begin();
+  std::vector<int> breakpoints = GetParam().breakpoints;
+
+  std::vector<Tensor> range_dataset_tensors;
+  TF_ASSERT_OK(CreateRangeDatasetTensors(testcases, &range_dataset_tensors));
+  gtl::InlinedVector<TensorValue, 4> inputs;
+  for (auto &tensor : range_dataset_tensors) {
+    inputs.emplace_back(&tensor);
+  }
+  int num_tensors_per_slice = testcases.size();
+  std::unique_ptr<OpKernel> dataset_kernel;
+  TF_ASSERT_OK(CreateZipDatasetKernel({DT_INT64}, {{num_tensors_per_slice}},
+                                      inputs.size(), &dataset_kernel));
+  std::unique_ptr<OpKernelContext> dataset_kernel_ctx;
+  TF_ASSERT_OK(CreateZipDatasetContext(dataset_kernel.get(), &inputs,
+                                       &dataset_kernel_ctx));
+  DatasetBase *dataset;
+  TF_ASSERT_OK(
+      CreateDataset(dataset_kernel.get(), dataset_kernel_ctx.get(), &dataset));
+  core::ScopedUnref scoped_unref(dataset);
+
+  std::unique_ptr<IteratorContext> iterator_ctx;
+  TF_ASSERT_OK(CreateIteratorContext(dataset_kernel_ctx.get(), &iterator_ctx));
+  std::unique_ptr<IteratorBase> iterator;
+  TF_ASSERT_OK(
+      dataset->MakeIterator(iterator_ctx.get(), "Iterator", &iterator));
+
+  std::unique_ptr<SerializationContext> serialization_ctx;
+  TF_ASSERT_OK(CreateSerializationContext(&serialization_ctx));
+
+  bool end_of_sequence = false;
+  std::vector<Tensor> out_tensors;
+  int cur_iteration = 0;
+  for (int breakpoint : breakpoints) {
+    VariantTensorData data;
+    VariantTensorDataWriter writer(&data);
+    TF_EXPECT_OK(iterator->Save(serialization_ctx.get(), &writer));
+    TF_EXPECT_OK(writer.Flush());
+    VariantTensorDataReader reader(&data);
+    TF_EXPECT_OK(iterator->Restore(iterator_ctx.get(), &reader));
+
+    while (cur_iteration < breakpoint) {
+      TF_EXPECT_OK(iterator->GetNext(iterator_ctx.get(), &out_tensors,
+                                     &end_of_sequence));
+      if (!end_of_sequence) {
+        for (auto &tensor : out_tensors) {
+          EXPECT_NE(expected_outputs_it, expected_outputs.end());
+          TF_EXPECT_OK(ExpectEqual(tensor, *expected_outputs_it));
+          expected_outputs_it++;
+        }
+      }
+      cur_iteration++;
+    }
+
+    if (breakpoint >= dataset->Cardinality()) {
+      EXPECT_TRUE(end_of_sequence);
+      EXPECT_EQ(expected_outputs_it, expected_outputs.end());
+    } else {
+      EXPECT_FALSE(end_of_sequence);
+    }
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(ZipDatasetOpTest, IteratorRoundtripTest,
+                        ::testing::ValuesIn(TestCases));
+
+}  // namespace
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/data/zip_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/zip_dataset_op_test.cc
@@ -30,9 +30,9 @@ struct RangeDatasetParam {
 
 class ZipDatasetOpTest : public DatasetOpsTestBase {
  protected:
-  // Creates RangeDatasets and save them as the variant tensors.
-  Status CreateRangeDatasetTensors(std::vector<RangeDatasetParam> params,
-                                   std::vector<Tensor> *dataset_tensors) {
+  // Creates `RangeDataset` variant tensors
+  Status CreateRangeDatasetTensors(const std::vector<RangeDatasetParam> &params,
+                                   std::vector<Tensor> *const dataset_tensors) {
     for (int i = 0; i < params.size(); ++i) {
       DatasetBase *range_dataset;
       TF_RETURN_IF_ERROR(CreateRangeDataset<int64>(
@@ -46,9 +46,10 @@ class ZipDatasetOpTest : public DatasetOpsTestBase {
   }
 
   // Creates a new ZipDataset op kernel.
-  Status CreateZipDatasetKernel(DataTypeVector dtypes,
-                                std::vector<PartialTensorShape> output_shapes,
-                                int n, std::unique_ptr<OpKernel> *op_kernel) {
+  Status CreateZipDatasetKernel(
+      const DataTypeVector &dtypes,
+      const std::vector<PartialTensorShape> &output_shapes, int n,
+      std::unique_ptr<OpKernel> *op_kernel) {
     std::vector<string> input_datasets;
     input_datasets.reserve(n);
     for (int i = 0; i < n; ++i) {
@@ -62,9 +63,10 @@ class ZipDatasetOpTest : public DatasetOpsTestBase {
   }
 
   // Creates a new ZipDataset op kernel context.
-  Status CreateZipDatasetContext(OpKernel *const op_kernel,
-                                 gtl::InlinedVector<TensorValue, 4> *inputs,
-                                 std::unique_ptr<OpKernelContext> *context) {
+  Status CreateZipDatasetContext(
+      OpKernel *const op_kernel,
+      gtl::InlinedVector<TensorValue, 4> *const inputs,
+      std::unique_ptr<OpKernelContext> *context) {
     TF_RETURN_IF_ERROR(CheckOpKernelInput(*op_kernel, *inputs));
     TF_RETURN_IF_ERROR(CreateOpKernelContext(op_kernel, inputs, context));
     return Status::OK();


### PR DESCRIPTION
This PR adds tests for `ZipDataset` and `ConcatenateDataset`. It also fixes some typo issues in `map_dataset_op_test.cc` and `range_dataset_op_test.cc`.

cc @jsimsa 
 