### PR TITLE
TF Android Example compile warning fixes

### DIFF
--- a/tensorflow/examples/android/AndroidManifest.xml
+++ b/tensorflow/examples/android/AndroidManifest.xml
@@ -24,10 +24,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
-    <uses-sdk
-        android:minSdkVersion="21"
-        android:targetSdkVersion="23" />
-
     <application android:allowBackup="true"
         android:debuggable="true"
         android:label="@string/app_name"

--- a/tensorflow/examples/android/build.gradle
+++ b/tensorflow/examples/android/build.gradle
@@ -25,10 +25,11 @@ getProject().setBuildDir('gradleBuild')
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'org.apache.httpcomponents:httpclient:4.5.4'
     }
 }
@@ -36,6 +37,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 
@@ -73,11 +75,14 @@ def bazelLocation = '/usr/local/bin/bazel'
 project.ext.ASSET_DIR = projectDir.toString() + '/assets'
 project.ext.TMP_DIR   = project.buildDir.toString() + '/downloads'
 
+// Download default models; if you wish to use your own models then
+// place them in the "assets" directory and comment out this line.
+apply from: "download-models.gradle"
+
 apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '26.0.2'
 
     if (nativeBuildSystem == 'cmake') {
         defaultConfig {
@@ -135,6 +140,10 @@ android {
         debug.setRoot('build-types/debug')
         release.setRoot('build-types/release')
     }
+    defaultConfig {
+        targetSdkVersion 23
+        minSdkVersion 21
+    }
 }
 
 task buildNativeBazel(type: Exec) {
@@ -182,13 +191,8 @@ tasks.whenTaskAdded { task ->
     }
 }
 
-// Download default models; if you wish to use your own models then
-// place them in the "assets" directory and comment out this line.
-apply from: "download-models.gradle"
-
-
 dependencies {
     if (nativeBuildSystem == 'cmake' || nativeBuildSystem == 'none') {
-        compile 'org.tensorflow:tensorflow-android:+'
+        implementation 'org.tensorflow:tensorflow-android:+'
     }
 }


### PR DESCRIPTION
1. The minSdk and targetSdk version should not be declared in the android manifest file. You can move the version from the manifest to the defaultConfig in the build.gradle file.
Reference : https://developer.android.com/guide/topics/manifest/manifest-intro#uses-sdk
2. Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
Reference : http://d.android.com/r/tools/update-dependency-configurations.html
3. Caused by: java.io.FileNotFoundException: imagenet_comp_graph_label_strings.txt this error reported after application compile and run first time using Studio, this fix solves the exist problem.