### PR TITLE
Remove the limitation of int max for dim_size in SparseDenseCwise ops

### DIFF
--- a/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc
+++ b/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc
@@ -78,9 +78,6 @@ class SparseDenseBinaryOpShared : public OpKernel {
                     "but received shapes: ",
                     values_t->shape().DebugString(), " and ",
                     shape_t->shape().DebugString()));
-    OP_REQUIRES(ctx, indices_t->dim_size(0) < std::numeric_limits<int>::max(),
-                errors::InvalidArgument(
-                    "Number of non-zero elements exceeds int32 range"));
 
     const auto indices_mat = indices_t->matrix<int64>();
     const auto shape_vec = shape_t->vec<int64>();
@@ -106,7 +103,7 @@ class SparseDenseBinaryOpShared : public OpKernel {
 
     Tensor *output_values = nullptr;
     Tensor dense_gathered;
-    const int nnz = static_cast<int>(indices_t->dim_size(0));
+    const int64 nnz = indices_t->dim_size(0);
     OP_REQUIRES_OK(ctx,
                    ctx->allocate_output(0, TensorShape({nnz}), &output_values));
     OP_REQUIRES_OK(


### PR DESCRIPTION
This fix tries to address the issue raised in #25701 where the dim_size in SparseDenseCwise ops was set to `std::numeric_limits<int>::max`. The restriction is likely unnecessary, due to historical reasons. This fix remove this limitation.

This fix fixes #25701.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>