### PR TITLE
Fix infinite loop when ignore_errors is used with TFRecordDataset

### DIFF
--- a/tensorflow/core/kernels/data/reader_dataset_ops.cc
+++ b/tensorflow/core/kernels/data/reader_dataset_ops.cc
@@ -821,6 +821,11 @@ class TFRecordDatasetOp : public DatasetOpKernel {
             }
             out_tensors->pop_back();
             if (!errors::IsOutOfRange(s)) {
+              // In case of other errors e.g., DataLoss, we still move forward
+              // the file index so that it works with ignore_errors.
+              // Otherwise the same file will repeat.
+              ResetStreamsLocked();
+              ++current_file_index_;
               return s;
             }
 

--- a/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
@@ -113,7 +113,7 @@ class IgnoreErrorsTest(test_base.DatasetTestBase):
       writer.close()
       # Append corrupted data
       with open(fn, "a") as f:
-        f.write(b"corrupted data")
+        f.write("corrupted data")
 
     dataset = readers.TFRecordDataset(filenames).apply(
         error_ops.ignore_errors())

--- a/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
@@ -24,8 +24,10 @@ import numpy as np
 from tensorflow.python.data.experimental.ops import error_ops
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.data.ops import readers
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
+from tensorflow.python.lib.io import python_io
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import io_ops
 from tensorflow.python.platform import test
@@ -97,6 +99,29 @@ class IgnoreErrorsTest(test_base.DatasetTestBase):
     get_next = self.getNext(dataset)
     for filename in filenames[1:]:
       self.assertEqual(compat.as_bytes(filename), self.evaluate(get_next()))
+    with self.assertRaises(errors.OutOfRangeError):
+      self.evaluate(get_next())
+
+  def testTFRecordDatasetIgnoreError(self):
+    filenames = []
+    for i in range(5):
+      fn = os.path.join(self.get_temp_dir(), "tf_record.%d.txt" % i)
+      filenames.append(fn)
+      writer = python_io.TFRecordWriter(fn)
+      for j in range(10):
+        writer.write(b"record")
+      writer.close()
+      # Append corrupted data
+      with open(fn, "a") as f:
+        f.write(b"corrupted data")
+
+    dataset = readers.TFRecordDataset(filenames).apply(error_ops.ignore_errors())
+    get_next = self.getNext(dataset)
+
+    # All of the files are present.
+    for filename in filenames:
+      for j in range(10):
+        self.assertEqual(b"record", self.evaluate(get_next()))
     with self.assertRaises(errors.OutOfRangeError):
       self.evaluate(get_next())
 

--- a/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
@@ -115,7 +115,8 @@ class IgnoreErrorsTest(test_base.DatasetTestBase):
       with open(fn, "a") as f:
         f.write(b"corrupted data")
 
-    dataset = readers.TFRecordDataset(filenames).apply(error_ops.ignore_errors())
+    dataset = readers.TFRecordDataset(filenames).apply(
+        error_ops.ignore_errors())
     get_next = self.getNext(dataset)
 
     # All of the files are present.


### PR DESCRIPTION
This fix tries to address the issue raised in #25700 where
ignore_errors combined with TFRecordDataset will have a infinite loop.
The issue was that when ignore errors happen, the index of the file names
are not moved forward with error returned. So the same file is repeated.

This fix is a short solution to fix it.

This fix fixes #25700.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>