### PR TITLE
TF Lite Exp Complex64 datatypes supported

### DIFF
--- a/tensorflow/lite/kernels/exp.cc
+++ b/tensorflow/lite/kernels/exp.cc
@@ -59,11 +59,14 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                               NumElements(op_context.input),              \
                               GetTensorData<data_type>(op_context.output))
 
-  // TODO(kanlig): supports half, bfloat16, float64, complex64, and complex128.
+  // TODO(kanlig): supports half, bfloat16, float64, and complex128.
   if (kernel_type == kReference) {
     switch (op_context.input->type) {
       case kTfLiteFloat32:
         TF_LITE_EXP(reference_ops, float);
+        break;
+      case kTfLiteComplex64:
+        TF_LITE_EXP(reference_ops, std::complex<float>);
         break;
       default:
         context->ReportError(context,

--- a/tensorflow/lite/kernels/exp_test.cc
+++ b/tensorflow/lite/kernels/exp_test.cc
@@ -60,6 +60,26 @@ TEST(ExpOpTest, FloatTest) {
                   {2.71828, 1, 0.367879, 2.71828, 2.71828, 0.367879})));
 }
 
+TEST(ExpOpTest, Complex64Test) {
+  std::initializer_list<std::complex<float>> data = {
+      std::complex<float>(1.0f, 0.0f),  std::complex<float>(0.0f, 0.0f),
+      std::complex<float>(-1.0f, 0.0f), std::complex<float>(1.0f, 0.0f),
+      std::complex<float>(1.0f, 0.0f),  std::complex<float>(-1.0f, 0.0f)};
+
+  ExpOpModel m({TensorType_COMPLEX64, {3, 1, 2}}, TensorType_COMPLEX64);
+  m.SetInput<std::complex<float>>(data);
+  m.Invoke();
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({3, 1, 2}));
+  EXPECT_THAT(
+      m.GetOutput<std::complex<float>>(),
+      ElementsAreArray(ArrayComplex64Near(
+          {std::complex<float>(2.71828f, 0.0f), std::complex<float>(1.0f, 0.0f),
+           std::complex<float>(0.367879f, 0.0f),
+           std::complex<float>(2.71828f, 0.0f),
+           std::complex<float>(2.71828f, 0.0f),
+           std::complex<float>(0.367879f, 0.0f)})));
+}
+
 }  // namespace
 }  // namespace tflite
 


### PR DESCRIPTION
TFLite Exp currently supports only Float32.
This PR add support for Complex64 datatypes as well.