### PR TITLE
TF Remove the limitation of int max for dim_size in SparseSoftmax ops

### DIFF
--- a/tensorflow/core/kernels/sparse_softmax_op.cc
+++ b/tensorflow/core/kernels/sparse_softmax_op.cc
@@ -62,12 +62,8 @@ class SparseSoftmaxOp : public OpKernel {
                 errors::InvalidArgument(
                     "Input should have rank >= 2, but received shape: ",
                     shape_t->SummarizeValue(3)));
-    OP_REQUIRES(context,
-                indices_t->dim_size(0) < std::numeric_limits<int>::max(),
-                errors::InvalidArgument(
-                    "Number of non-zero elements exceeds int32 range"));
 
-    const int nnz = static_cast<int>(indices_t->dim_size(0));
+    const int64 nnz = indices_t->dim_size(0);
     const int rank = static_cast<int>(indices_t->dim_size(1));
     SparseTensor st;
     OP_REQUIRES_OK(


### PR DESCRIPTION
This fix tries to address the simmiliat issue raised in #25701 where the dim_size in SparseSoftmax ops was set to . The restriction is likely unnecessary, due to historical reasons. This fix remove this limitation.

Refer PR #25702.