### PR TITLE
Add Python 3.7 to classifiers (PyPI)

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -284,6 +284,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',


### PR DESCRIPTION
Python 3.7 compatibility seems fixed in 1.13, see eg. tensorflow/tensorflow#20517 and tensorflow/tensorflow#17022.

Not sure if this is also true for the profiler and should be added there too: https://github.com/tensorflow/tensorflow/blob/8a3407d7ec8d2a79534cc1b4c587eae0fd8dd924/tensorflow/contrib/tpu/profiler/pip_package/setup.py#L53-L60