### PR TITLE
Update clip_ops.py

### DIFF
--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -306,7 +306,8 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
     date=None,
     instructions=
     "clip_by_average_norm is deprecated in TensorFlow 2.0. Please use "
-    "clip_by_norm(t, clip_norm * tf.cast(tf.size(t), tf.float32), name) instead.")
+    "clip_by_norm(t, clip_norm * tf.cast(tf.size(t), tf.float32), name) "
+    "instead.")
 @tf_export(v1=["clip_by_average_norm"])
 def clip_by_average_norm(t, clip_norm, name=None):
   """Clips tensor values to a maximum average L2-norm.

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -306,7 +306,7 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
     date=None,
     instructions=
     "clip_by_average_norm is deprecated in TensorFlow 2.0. Please use "
-    "clip_by_norm(t, clip_norm * tf.to_float(tf.size(t), name)) instead.")
+    "clip_by_norm(t, clip_norm * tf.cast(tf.size(t), tf.float32), name) instead.")
 @tf_export(v1=["clip_by_average_norm"])
 def clip_by_average_norm(t, clip_norm, name=None):
   """Clips tensor values to a maximum average L2-norm.


### PR DESCRIPTION
Interestingly, the deprecation warning uses a deprecated function (`tf.to_float`).
This changes it to `tf.cast`.