### PR TITLE
TF Lite stride_slice begin/end/strided supports int64

### DIFF
--- a/tensorflow/lite/kernels/internal/strided_slice_logic.h
+++ b/tensorflow/lite/kernels/internal/strided_slice_logic.h
@@ -166,10 +166,12 @@ inline bool LoopCondition(int index, int stop, int stride) {
   return stride > 0 ? index >= stop : index <= stop;
 }
 
+template <typename IndexingT>
 inline tflite::StridedSliceParams BuildStridedSliceParams(
     int begin_mask, int end_mask, int shrink_axis_mask,
-    const std::vector<int>& start_indices, const std::vector<int>& stop_indices,
-    const std::vector<int>& strides) {
+    const std::vector<IndexingT>& start_indices,
+    const std::vector<IndexingT>& stop_indices,
+    const std::vector<IndexingT>& strides) {
   tflite::StridedSliceParams op_params;
   const int dims_count = start_indices.size();
 

--- a/tensorflow/lite/kernels/internal/types.h
+++ b/tensorflow/lite/kernels/internal/types.h
@@ -984,11 +984,11 @@ struct SqueezeParams {
 
 struct StridedSliceParams {
   int8 start_indices_count;
-  int16 start_indices[4];
+  int32 start_indices[4];
   int8 stop_indices_count;
-  int16 stop_indices[4];
+  int32 stop_indices[4];
   int8 strides_count;
-  int16 strides[4];
+  int32 strides[4];
 
   int16 begin_mask;
   int16 ellipsis_mask;

--- a/tensorflow/lite/kernels/strided_slice.cc
+++ b/tensorflow/lite/kernels/strided_slice.cc
@@ -61,54 +61,64 @@ struct StridedSliceContext {
 // implementation, the 1-3D tensors are mapped to 4D.
 const int kMaxDim = 4;
 
-inline int32_t PositiveRemainder(int32_t dividend, int32_t divisor) {
+template <typename IndexingT>
+inline IndexingT PositiveRemainder(IndexingT dividend, IndexingT divisor) {
   return (divisor + (dividend % divisor)) % divisor;
 }
 
-inline int32_t ClampedIndex(int32_t index, int dim, bool pos_stride) {
+template <typename IndexingT>
+inline IndexingT ClampedIndex(IndexingT index, IndexingT dim, bool pos_stride) {
   return pos_stride
              ? (index >= dim ? dim
-                             : PositiveRemainder(
+                             : PositiveRemainder<IndexingT>(
                                    std::min(std::max(index, -dim), dim), dim))
              : (index < -dim
                     ? -1
-                    : PositiveRemainder(
+                    : PositiveRemainder<IndexingT>(
                           std::min(std::max(index, -dim), dim - 1), dim));
 }
 
 // TODO(b/77971377) this logic should be removed, as it's a duplication of
 // StartForAxis() & StopForAxis() in kernels/internal/reference/reference_ops.h
-inline int32_t GetBeginValueAtIndex(StridedSliceContext* op_context, int idx) {
-  const int dim = op_context->input->dims->data[idx];
-  const bool pos_stride = GetTensorData<int32_t>(op_context->strides)[idx] > 0;
+template <typename IndexingT>
+inline IndexingT GetBeginValueAtIndex(StridedSliceContext* op_context,
+                                      int idx) {
+  const IndexingT dim = op_context->input->dims->data[idx];
+  const bool pos_stride =
+      GetTensorData<IndexingT>(op_context->strides)[idx] > 0;
   return op_context->params->begin_mask & (1 << idx)
              ? pos_stride ? 0 : dim - 1
-             : ClampedIndex(GetTensorData<int32_t>(op_context->begin)[idx], dim,
-                            pos_stride);
+             : ClampedIndex<IndexingT>(
+                   GetTensorData<IndexingT>(op_context->begin)[idx], dim,
+                   pos_stride);
 }
 
-inline int32_t GetEndValueAtIndex(StridedSliceContext* op_context, int idx) {
-  const int dim = op_context->input->dims->data[idx];
-  const bool pos_stride = GetTensorData<int32_t>(op_context->strides)[idx] > 0;
+template <typename IndexingT>
+inline IndexingT GetEndValueAtIndex(StridedSliceContext* op_context, int idx) {
+  const IndexingT dim = op_context->input->dims->data[idx];
+  const bool pos_stride =
+      GetTensorData<IndexingT>(op_context->strides)[idx] > 0;
   return op_context->params->end_mask & (1 << idx)
              ? pos_stride ? dim : -1
-             : ClampedIndex(GetTensorData<int32_t>(op_context->end)[idx], dim,
-                            pos_stride);
+             : ClampedIndex<IndexingT>(
+                   GetTensorData<IndexingT>(op_context->end)[idx], dim,
+                   pos_stride);
 }
 
 // Processes the indexing tensors (begin, end and strides) to resize the
 // output tensor. This function is callable from both Prepare() and Eval() as
 // long as the caller ensures the indexing tensors are present.
+template <typename IndexingT>
 TfLiteStatus ResizeOutputTensor(TfLiteContext* context,
                                 StridedSliceContext* op_context) {
-  std::vector<int> output_shape_vector;
+  std::vector<IndexingT> output_shape_vector;
 
   for (int idx = op_context->dims - 1; idx >= 0; --idx) {
-    int32_t stride = GetTensorData<int32_t>(op_context->strides)[idx];
+    IndexingT stride = GetTensorData<IndexingT>(op_context->strides)[idx];
     TF_LITE_ENSURE_MSG(context, stride != 0, "stride value has to be non-zero");
 
-    int32_t begin = GetBeginValueAtIndex(op_context, idx);
-    int32_t end = GetEndValueAtIndex(op_context, idx);
+    IndexingT begin = GetBeginValueAtIndex<IndexingT>(op_context, idx);
+    IndexingT end = GetEndValueAtIndex<IndexingT>(op_context, idx);
 
     // When shrinking an axis, the end position does not matter (and can be
     // incorrect when negative indexing is used, see Issue #19260). Always use
@@ -120,7 +130,7 @@ TfLiteStatus ResizeOutputTensor(TfLiteContext* context,
     }
 
     // This is valid for both positive and negative strides
-    int32_t dim_shape = ceil((end - begin) / static_cast<float>(stride));
+    IndexingT dim_shape = ceil((end - begin) / static_cast<float>(stride));
     dim_shape = dim_shape < 0 ? 0 : dim_shape;
     if (!shrink_axis) {
       output_shape_vector.push_back(dim_shape);
@@ -152,9 +162,45 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, op_context.input->type, op_context.output->type);
   // Only INT32 begin/end/strides are supported
   // TODO(soroosh) add support for INT64
-  TF_LITE_ENSURE_EQ(context, op_context.begin->type, kTfLiteInt32);
-  TF_LITE_ENSURE_EQ(context, op_context.end->type, kTfLiteInt32);
-  TF_LITE_ENSURE_EQ(context, op_context.strides->type, kTfLiteInt32);
+  switch (op_context.begin->type) {
+    case kTfLiteInt64:
+    case kTfLiteInt32:
+      break;
+    default:
+      context->ReportError(
+          context, "begin of type '%s' are not supported by strided_slice.",
+          TfLiteTypeGetName(op_context.begin->type));
+      return kTfLiteError;
+  }
+  switch (op_context.end->type) {
+    case kTfLiteInt64:
+    case kTfLiteInt32:
+      break;
+    default:
+      context->ReportError(
+          context, "end of type '%s' are not supported by strided_slice.",
+          TfLiteTypeGetName(op_context.end->type));
+      return kTfLiteError;
+  }
+  switch (op_context.strides->type) {
+    case kTfLiteInt64:
+    case kTfLiteInt32:
+      break;
+    default:
+      context->ReportError(
+          context, "strides of type '%s' are not supported by strided_slice.",
+          TfLiteTypeGetName(op_context.strides->type));
+      return kTfLiteError;
+  }
+  if (!(op_context.begin->type == op_context.end->type &&
+        op_context.end->type == op_context.strides->type &&
+        op_context.strides->type == op_context.begin->type)) {
+    context->ReportError(
+        context,
+        "indexing different of type '%s' are not supported by strided_slice.",
+        TfLiteTypeGetName(op_context.strides->type));
+    return kTfLiteError;
+  }
   TF_LITE_ENSURE_MSG(context, op_context.dims <= 4,
                      "StridedSlice op only supports 1D-4D input arrays.");
 
@@ -172,7 +218,16 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     SetTensorToDynamic(op_context.output);
     return kTfLiteOk;
   }
-  return ResizeOutputTensor(context, &op_context);
+  if (op_context.begin->type == kTfLiteInt64) {
+    return ResizeOutputTensor<int64_t>(context, &op_context);
+  } else if (op_context.begin->type == kTfLiteInt32) {
+    return ResizeOutputTensor<int32_t>(context, &op_context);
+  }
+  context->ReportError(
+      context,
+      "Beign-End-Stride of type '%s' are not supported by StridedSlice.",
+      TfLiteTypeGetName(op_context.begin->type));
+  return kTfLiteError;
 }
 
 template <KernelType kernel_type>
@@ -180,12 +235,18 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   StridedSliceContext op_context(context, node);
 
   if (IsDynamicTensor(op_context.output)) {
-    TF_LITE_ENSURE_OK(context, ResizeOutputTensor(context, &op_context));
+    if (op_context.begin->type == kTfLiteInt64) {
+      TF_LITE_ENSURE_OK(context,
+                        ResizeOutputTensor<int64_t>(context, &op_context));
+    } else if (op_context.begin->type == kTfLiteInt32) {
+      TF_LITE_ENSURE_OK(context,
+                        ResizeOutputTensor<int32_t>(context, &op_context));
+    }
   }
 
-  std::vector<int32_t> starts;
-  std::vector<int32_t> stops;
-  std::vector<int32_t> strides;
+  std::vector<int64_t> starts;
+  std::vector<int64_t> stops;
+  std::vector<int64_t> strides;
 
   for (int i = op_context.dims; i < kMaxDim; i++) {
     starts.emplace_back(0);
@@ -193,10 +254,18 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     strides.emplace_back(1);
   }
 
-  for (int idx = 0; idx < op_context.dims; ++idx) {
-    starts.emplace_back(GetTensorData<int32_t>(op_context.begin)[idx]);
-    stops.emplace_back(GetTensorData<int32_t>(op_context.end)[idx]);
-    strides.emplace_back(GetTensorData<int32_t>(op_context.strides)[idx]);
+  if (op_context.begin->type == kTfLiteInt64) {
+    for (int idx = 0; idx < op_context.dims; ++idx) {
+      starts.emplace_back(GetTensorData<int64_t>(op_context.begin)[idx]);
+      stops.emplace_back(GetTensorData<int64_t>(op_context.end)[idx]);
+      strides.emplace_back(GetTensorData<int64_t>(op_context.strides)[idx]);
+    }
+  } else if (op_context.begin->type == kTfLiteInt32) {
+    for (int idx = 0; idx < op_context.dims; ++idx) {
+      starts.emplace_back(GetTensorData<int32_t>(op_context.begin)[idx]);
+      stops.emplace_back(GetTensorData<int32_t>(op_context.end)[idx]);
+      strides.emplace_back(GetTensorData<int32_t>(op_context.strides)[idx]);
+    }
   }
 
   int begin_mask = op_context.params->begin_mask << (4 - op_context.dims);
@@ -204,7 +273,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   int shrink_axis_mask = op_context.params->shrink_axis_mask
                          << (4 - op_context.dims);
   TF_LITE_ENSURE_EQ(context, starts.size(), 4);
-  auto op_params = ::tflite::strided_slice::BuildStridedSliceParams(
+  auto op_params = ::tflite::strided_slice::BuildStridedSliceParams<int64_t>(
       begin_mask, end_mask, shrink_axis_mask, starts, stops, strides);
 
 #define TF_LITE_STRIDED_SLICE(kernel_type, data_type)                    \


### PR DESCRIPTION
This PR supports stride_slice ops begin/end/strided params with int64 type.