### PR TITLE
TFTRT: Allow FP16 kernels in INT8 mode

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3770,8 +3770,11 @@ tensorflow::Status ConvertGraphDefToEngine(
   builder->setMaxWorkspaceSize(max_workspace_size_bytes);
   builder->setGpuAllocator(allocator);
   if (precision_mode == TrtPrecisionMode::FP16) {
-    builder->setHalf2Mode(true);
+    builder->setFp16Mode(true);
   } else if (precision_mode == TrtPrecisionMode::INT8) {
+    // Setting FP16 mode as well allows TRT to also consider FP16 kernels and
+    // use them in situations where they are faster than INT8.
+    builder->setFp16Mode(true);
     builder->setInt8Mode(true);
     if (use_calibration) {
       builder->setInt8Calibrator(calibrator);

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3773,7 +3773,8 @@ tensorflow::Status ConvertGraphDefToEngine(
     builder->setFp16Mode(true);
   } else if (precision_mode == TrtPrecisionMode::INT8) {
     // Setting FP16 mode as well allows TRT to also consider FP16 kernels and
-    // use them in situations where they are faster than INT8.
+    // use them in situations where they are faster than INT8 or where INT8 is
+    // not supported for a given layer.
     builder->setFp16Mode(true);
     builder->setInt8Mode(true);
     if (use_calibration) {


### PR DESCRIPTION
 
Change deprecated setHalf2Mode -> setFp16Mode. setHalf2Mode was deprecated in TRT 4.0.

Allow int8 mode to use fp16 kernels when they are more performant. Setting a precision mode is not a strict limitation. Instead, it simply allows TRT to consider kernels of the given precision. Previously, our int8 mode only considered fp32 and int8 kernels. But we can allow it to also consider fp16 kernels when they perform better. This will result in better performance overall.

TRT also does not support INT8 mode for many layers, but does support them in FP16. Previously we would've been using the FP32 kernels for those layers but now we can use the FP16 kernels.