### PR TITLE
Fix regression in XLA in TensorFlow 1.13 RC0, RC1

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/conv_op_helpers.cc
+++ b/tensorflow/compiler/tf2xla/kernels/conv_op_helpers.cc
@@ -434,8 +434,10 @@ xla::StatusOr<xla::XlaOp> MakeXlaBackpropFilterConvOp(
   }
 
   // We use this approach only for depthwise convolutions where feature counts
-  // are large but space dimensions are small.
+  // are large but space dimensions are small. The conversion logic below
+  // assumes that the data format is NHWC, so we also check that here.
   bool should_perform_depthwise_conv =
+      attrs.data_format == FORMAT_NHWC &&
       (total_spatial_size < dims.in_depth) &&
       filter_tensor_shape.dim_size(num_dims - 1) == 1 && attrs.depthwise;
 


### PR DESCRIPTION
Only convert BackpropFilterConv to depthwise convolution if format is… … NHWC.

The logic for the conversion has this assumption. This CL makes sure that this
assumption holds, and adds tests for NCHW format.

Fixes #25734

PiperOrigin-RevId: 225534508