### PR TITLE
TFTRT: Use IInt8EntropyCalibrator2 for TRT 5.1 onward

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/utils/trt_int8_calibrator.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_int8_calibrator.h
@@ -34,7 +34,12 @@ namespace tensorrt {
 // TRTs pull model for calibration. When TRT implements a means for
 // a push calibration This class should be updated accordingly
 
+// IInt8EntropyCalibrator2 is prefferred for TRT 5.1+.
+#if NV_TENSORRT_MAJOR > 5 || (NV_TENSORRT_MAJOR == 5 && NV_TENSORRT_MINOR >= 1)
+struct TRTInt8Calibrator : public nvinfer1::IInt8EntropyCalibrator2 {
+#else
 struct TRTInt8Calibrator : public nvinfer1::IInt8EntropyCalibrator {
+#endif
  public:
   // Construct a calibrator for future calibration.
   TRTInt8Calibrator(


### PR DESCRIPTION
TRT 5.1 added IInt8EntropyCalibrator2 which is an improvement over IInt8EntropyCalibrator.

A few differences:
1) Calibration table is generated prior to fusions, so it can be used across
   engines with different fusions.
2) "Per-tensor scaling" (e.g for a concat, all inputs along with output will
   share a single scale factor. Previously, all connections would have a
   different scale factor requiring many extra scale operations with no
   benefit).
3) Pool op output scale = input scale (shown to produce better accuracy)