### PR TITLE
1.13.0-rc2 cherry-pick request: Don't initialize tpu system twice for mesh-tensorflow.

### DIFF
--- a/tensorflow/contrib/tpu/python/tpu/tpu_estimator.py
+++ b/tensorflow/contrib/tpu/python/tpu/tpu_estimator.py
@@ -440,7 +440,11 @@ class TPUInfeedOutfeedSessionHook(session_run_hook.SessionRunHook):
 
     self._feed_error = None
     self._finished = False
-    self._should_initialize_tpu = True
+    # When using model parallelism, the TPU is pre-initialized at startup to
+    # fetch mesh information.  We skip re-initializing it here to avoid
+    # suspected issues due to the mesh layout changing on the second
+    # initialization.
+    self._should_initialize_tpu = not ctx.model_parallelism_enabled
     self._tpu_compile_op = tpu_compile_op
 
   def begin(self):


### PR DESCRIPTION
PiperOrigin-RevId: 232234083
