### PR TITLE
tf.nn.conv2d_transpose error if output-shape is tuple #25609

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2042,6 +2042,9 @@ def atrous_conv2d_transpose(value,
     if not output_shape_.get_shape().is_compatible_with(tensor_shape.vector(4)):
       raise ValueError("output_shape must have shape (4,), got {}".format(
           output_shape_.get_shape()))
+ 
+    if isinstance(output_shape, tuple):
+      raise ValueError("output_shape cannot be of type tuple")
 
     if isinstance(output_shape, (list, np.ndarray)):
       # output_shape's shape should be == [4] if reached this point.

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2044,7 +2044,7 @@ def atrous_conv2d_transpose(value,
           output_shape_.get_shape()))
  
     if isinstance(output_shape, tuple):
-      raise ValueError("output_shape cannot be of type tuple")
+      output_shape = list(output_shape)
 
     if isinstance(output_shape, (list, np.ndarray)):
       # output_shape's shape should be == [4] if reached this point.


### PR DESCRIPTION
pr for #25609,
one line to throw error if output-shape is a tuple instead of list in python client nn_ops.py.