### PR TITLE
Add support for cudnn's group convolution.

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/conv_op_helpers.cc
+++ b/tensorflow/compiler/tf2xla/kernels/conv_op_helpers.cc
@@ -53,6 +53,52 @@ xla::Shape ExpandedFilterShapeForDepthwiseConvolution(const xla::Shape& shape) {
   return expanded_shape;
 }
 
+
+// Returns the transposed filter for use in BackpropInput of group convolution.
+xla::XlaOp TransposeFilterForGroupConvolutionBackpropInput(
+    const xla::XlaOp& filter, const xla::Shape& filter_shape, int64 num_groups, int num_spatial_dims) {
+  // 1. Reshape from [H, W, ..., filter_in_depth, out_depth] to [H, W, ..., filter_in_depth, G, out_depth / G]
+  int num_dims = filter_shape.dimensions_size();
+  CHECK_GE(num_dims, 2);  // Crash OK
+  xla::Shape new_shape = filter_shape;
+  new_shape.set_dimensions(num_dims - 1, num_groups);
+  new_shape.add_dimensions(filter_shape.dimensions(num_dims - 1) / num_groups);
+  xla::XlaOp result = xla::Reshape(filter, new_shape.dimensions());
+
+  // 2. Transpose to [H, W, ..., G, filter_in_depth, out_depth / G]
+  std::vector<int64> transpose_dims(num_dims + 1);
+  std::iota(transpose_dims.begin(), transpose_dims.end(), 0);
+  std::swap(transpose_dims[num_spatial_dims], transpose_dims[num_spatial_dims + 1]);
+  result = xla::Transpose(result, transpose_dims);
+
+  // 3. Reshape to [H, W, ..., in_depth, out_depth / G]
+  result = xla::Collapse(result, {num_spatial_dims, num_spatial_dims + 1});
+  return result;
+}
+
+// Returns the transposed input for use in BackpropFilter of group convolution.
+xla::XlaOp TransposeInputForGroupConvolutionBackpropFilter(
+    const xla::XlaOp& input, const xla::Shape& input_shape,
+    int64 num_groups, int batch_dim, int depth_dim) {
+  // 1. Reshape the depth_dim C into [G, C/G]
+  int num_dims = input_shape.dimensions_size();
+  std::vector<int64> reshape_dims = input_shape.dimensions();
+  reshape_dims[depth_dim] = reshape_dims[depth_dim] / num_groups;
+  reshape_dims.insert(reshape_dims.begin() + depth_dim, num_groups);
+  xla::XlaOp result = xla::Reshape(input, reshape_dims);
+
+  // 2. Transpose G to the axis before N, e.g.: [G, N, H, W, C/G]
+  std::vector<int64> transpose_dims(num_dims + 1);
+  std::iota(transpose_dims.begin(), transpose_dims.end(), 0);  // e.g.: [0, 1, 2, 3, 4] -> [N, H, W, G, C/G]
+  transpose_dims.erase(transpose_dims.begin() + depth_dim);
+  transpose_dims.insert(transpose_dims.begin() + batch_dim, depth_dim); // e.g.: [3, 0, 1, 2, 4] -> [G, N, H, W, C/G]
+  result = xla::Transpose(result, transpose_dims);
+
+  // 3. Merge [G, N] to [G*N]
+  result = xla::Collapse(result, {batch_dim, batch_dim + 1});
+  return result;
+}
+
 // Create a mask for depthwise convolution that will make a normal convolution
 // produce the same results as a depthwise convolution. For a [2, 2, 3, 2]
 // depthwise filter this returns a [2, 2, 3, 6] tensor
@@ -269,13 +315,21 @@ xla::StatusOr<xla::XlaOp> MakeXlaForwardConvOp(StringPiece /*type_string*/,
   int batch_dim = GetTensorBatchDimIndex(num_dims, attrs.data_format);
   int feature_dim = GetTensorFeatureDimIndex(num_dims, attrs.data_format);
 
-  int64 in_depth = filter_shape.dimensions(attrs.num_spatial_dims);
-  // The 'C' dimension for input is in_depth. It must be the same as
-  // the filter's in_depth.
-  if (in_depth != input_shape.dimensions(feature_dim)) {
+  int64 filter_in_depth = filter_shape.dimensions(attrs.num_spatial_dims),
+        out_depth = filter_shape.dimensions(attrs.num_spatial_dims + 1),
+        in_depth = input_shape.dimensions(feature_dim);
+  // The 'C' dimension for input is in_depth.
+  // It must be a multiple of the filter's in_depth.
+  if (in_depth % filter_in_depth != 0) {
     return errors::InvalidArgument(
-        "input and filter must have the same depth: ", in_depth, " vs ",
-        input_shape.dimensions(feature_dim));
+        "Depth of input must be a multiple of depth of filter: ",
+        in_depth, " vs ", filter_in_depth);
+  }
+  int64 feature_group_count = in_depth / filter_in_depth;
+  if (out_depth % feature_group_count != 0) {
+    return errors::InvalidArgument(
+        "Depth of output must be a multiple of the number of groups: ",
+        out_depth, " vs ", feature_group_count);
   }
 
   if (attrs.depthwise) {
@@ -317,7 +371,7 @@ xla::StatusOr<xla::XlaOp> MakeXlaForwardConvOp(StringPiece /*type_string*/,
 
   return xla::ConvGeneralDilated(
       conv_input, filter, window_strides, padding, lhs_dilation, rhs_dilation,
-      dims, /*feature_group_count=*/attrs.depthwise ? in_depth : 1);
+      dims, /*feature_group_count=*/attrs.depthwise ? in_depth : feature_group_count);
 }
 
 xla::StatusOr<xla::XlaOp> MakeXlaBackpropInputConvOp(
@@ -333,6 +387,10 @@ xla::StatusOr<xla::XlaOp> MakeXlaBackpropInputConvOp(
   TF_ASSIGN_OR_RETURN(xla::Shape filter_shape, builder->GetShape(filter));
   TF_ASSIGN_OR_RETURN(xla::Shape out_backprop_shape,
                       builder->GetShape(out_backprop));
+
+  int64 in_depth = input_shape.dimensions(feature_dim),
+        filter_in_depth = filter_shape.dimensions(attrs.num_spatial_dims),
+        feature_group_count = in_depth / filter_in_depth;
 
   xla::Shape expanded_filter_shape =
       attrs.depthwise ? ExpandedFilterShapeForDepthwiseConvolution(filter_shape)
@@ -377,18 +435,22 @@ xla::StatusOr<xla::XlaOp> MakeXlaBackpropInputConvOp(
     rhs_dilation[i] = attrs.dilations[dim];
   }
 
+  if (feature_group_count != 1 && !attrs.depthwise) {
+    filter = TransposeFilterForGroupConvolutionBackpropInput(
+        filter, filter_shape, feature_group_count, attrs.num_spatial_dims);
+  }
   // Mirror the filter in the spatial dimensions.
-  xla::XlaOp mirrored_weights = xla::Rev(filter, kernel_spatial_dims);
+  filter = xla::Rev(filter, kernel_spatial_dims);
 
   // activation gradients
   //   = gradients (with padding and dilation) <conv> mirrored_weights
   return xla::ConvGeneralDilated(
-      out_backprop, mirrored_weights, /*window_strides=*/ones, padding,
+      out_backprop, filter, /*window_strides=*/ones, padding,
       lhs_dilation, rhs_dilation, dnums,
       /*feature_group_count=*/
       attrs.depthwise ? out_backprop_shape.dimensions(feature_dim) /
                             filter_shape.dimensions(attrs.num_spatial_dims + 1)
-                      : 1);
+                      : feature_group_count);
 }
 
 xla::StatusOr<xla::XlaOp> MakeXlaBackpropFilterConvOp(
@@ -427,17 +489,27 @@ xla::StatusOr<xla::XlaOp> MakeXlaBackpropFilterConvOp(
       expanded_filter_shape, out_backprop_shape, attrs.dilations, attrs.strides,
       attrs.padding, attrs.data_format, &dims, attrs.explicit_paddings));
 
-  // The activations (inputs) form the LHS of the convolution.
-  // Activations have shape: [batch, in_rows, in_cols, ..., in_depth]
-  // For the gradient computation, we flip the roles of the batch and
-  // feature dimensions.
-  // Each spatial entry has size in_depth * batch
-
+  // Obtain some useful dimensions:
   // The last two dimensions of the filter are the input and output shapes.
   int num_dims = attrs.num_spatial_dims + 2;
   int n_dim = GetTensorBatchDimIndex(num_dims, attrs.data_format);
   int c_dim = GetTensorFeatureDimIndex(num_dims, attrs.data_format);
+  int64 in_depth = input_shape.dimensions(c_dim),
+        filter_in_depth = filter_shape.dimensions(attrs.num_spatial_dims),
+        feature_group_count = in_depth / filter_in_depth;
 
+  // The activations (inputs) form the LHS of the convolution.
+  // Activations have shape: [batch, in_rows, in_cols, ..., in_depth]
+  // For the gradient computation, we need to:
+  // 1. In the case of group convolution, move the num_groups dimension before the batch dimension
+  // 2. Swap the roles of the batch and feature dimensions.
+  if (feature_group_count != 1 && !attrs.depthwise) {
+    activations = TransposeInputForGroupConvolutionBackpropFilter(
+        activations, input_shape, feature_group_count, n_dim, c_dim);
+  }
+
+  // In the case of depthwise convolution with no multiplier,
+  // the computation can be done by the batch_group_count parameter.
   bool use_batch_group_count =
       filter_tensor_shape.dim_size(num_dims - 1) == 1 && attrs.depthwise;
 
@@ -532,7 +604,7 @@ xla::StatusOr<xla::XlaOp> MakeXlaBackpropFilterConvOp(
   filter_backprop = xla::ConvGeneralDilated(
       activations, gradients, window_strides, padding, /*lhs_dilation=*/ones,
       rhs_dilation, dnums,
-      /*feature_group_count=*/1,
+      /*feature_group_count=*/feature_group_count,
       /*batch_group_count=*/use_batch_group_count ? dims.in_depth : 1);
 
   if (!use_batch_group_count && attrs.depthwise) {

--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -492,11 +492,23 @@ Status Conv2DShapeImpl(shape_inference::InferenceContext* c,
         filter_shape, GetFilterDimIndex<num_spatial_dims>(filter_format, 'I'));
   }
 
-  // Check that the input tensor and the filter tensor agree on the input
-  // channel count.
-  DimensionHandle unused;
-  TF_RETURN_IF_ERROR(
-      c->Merge(input_depth_dim, filter_input_depth_dim, &unused));
+  // Check that the input tensor and the filter tensor agree on the channel count.
+  if (c->ValueKnown(input_depth_dim) && c->ValueKnown(filter_input_depth_dim)) {
+    int64 input_depth_value = c->Value(input_depth_dim),
+          filter_input_depth_value = c->Value(filter_input_depth_dim);
+    if (input_depth_value % filter_input_depth_value != 0)
+      return errors::InvalidArgument("Depth of input (", input_depth_value,
+          ") is not a multiple of input depth of filter (", filter_input_depth_value, ")");
+    if (input_depth_value != filter_input_depth_value) {
+      int64 num_groups = input_depth_value / filter_input_depth_value;
+      if (c->ValueKnown(output_depth_dim)) {
+        int64 output_depth_value = c->Value(output_depth_dim);
+        if (output_depth_value % num_groups != 0)
+          return errors::InvalidArgument("Depth of output (", output_depth_value,
+              ") is not a multiple of the number of groups (", num_groups, ")");
+      }
+    }
+  }
 
   Padding padding;
   TF_RETURN_IF_ERROR(c->GetAttr("padding", &padding));

--- a/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
+++ b/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
@@ -612,6 +612,7 @@ OpLevelCostEstimator::ConvolutionDimensionsFromInputs(
   int64 iz = image_shape.dim(channel_index).size();
   int64 kx = filter_shape.dim(filter_x_index).size();
   int64 ky = filter_shape.dim(filter_y_index).size();
+  int64 kz = filter_shape.dim(in_channel_index).size();
   std::vector<int64> strides = GetStrides(op_info);
   const auto padding = GetPadding(op_info);
   int64 sx = strides[x_index];
@@ -621,20 +622,21 @@ OpLevelCostEstimator::ConvolutionDimensionsFromInputs(
   int64 oz = filter_shape.dim(out_channel_index).size();
   // Only check equality when both sizes are known (in other words, when
   // neither is set to a minimum dimension size of 1).
-  if (iz != 1 && filter_shape.dim(in_channel_index).size() != 1) {
-    CHECK_EQ(iz, filter_shape.dim(in_channel_index).size());
+  if (iz != 1 && kz != 1) {
+    CHECK(iz % kz == 0) << "Input channel " << iz << " is not a multiple of filter channel " << kz << ".";
   } else {
     iz = std::max<int64>(iz, filter_shape.dim(in_channel_index).size());
   }
   OpLevelCostEstimator::ConvolutionDimensions conv_dims = {
-      batch, ix, iy, iz, kx, ky, oz, ox, oy, sx, sy, padding};
+      batch, ix, iy, iz, kx, ky, kz, oz, ox, oy, sx, sy, padding};
 
   VLOG(1) << "Batch Size:" << batch;
   VLOG(1) << "Image Dims:" << ix << "," << iy;
-  VLOG(1) << "Input Features:" << iz;
+  VLOG(1) << "Input Depth:" << iz;
   VLOG(1) << "Kernel Dims:" << kx << "," << ky;
-  VLOG(1) << "Output Features:" << oz;
+  VLOG(1) << "Kernel Depth:" << kz;
   VLOG(1) << "Output Dims:" << ox << "," << oy;
+  VLOG(1) << "Output Depth:" << oz;
   VLOG(1) << "Strides:" << sx << "," << sy;
   VLOG(1) << "Padding:" << (padding == Padding::VALID ? "VALID" : "SAME");
   return conv_dims;
@@ -653,13 +655,13 @@ int64 OpLevelCostEstimator::CountConv2DOperations(
   //  in DepthwiseConv2dNative conv_dims.oz is actually the channel depth
   //  multiplier; The effective output channel depth oz_effective is
   //  conv_dims.iz * conv_dims.oz. thus # ops = N x H x W x oz_effective x 2RS.
-  //  Compare to Conv2D where # ops =  N x H x W x iz x oz x 2RS,
-  //  oz = oz_effective,  then Conv2D_ops / Depthwise_conv2d_native_ops = iz.
+  //  Compare to Conv2D where # ops =  N x H x W x kz x oz x 2RS,
+  //  oz = oz_effective,  then Conv2D_ops / Depthwise_conv2d_native_ops = kz.
   int64 ops = conv_dims.batch;
   ops *= conv_dims.ox * conv_dims.oy;
   ops *= conv_dims.kx * conv_dims.ky;
   if (op_info.op() == kConv2d) {
-    ops *= conv_dims.iz * conv_dims.oz;
+    ops *= conv_dims.kz * conv_dims.oz;
   } else {
     // To ensure output tensor dims to be correct for DepthwiseConv2DNative,
     // although ops are the same as Conv2D.
@@ -952,7 +954,7 @@ int64 OpLevelCostEstimator::CountConv2DBackpropInputOperations(
   ops *= conv_dims.ox * conv_dims.oy;
   ops *= conv_dims.kx * conv_dims.ky;
   if (op_info.op() == kConv2dBackpropInput) {
-    ops *= conv_dims.iz * conv_dims.oz;
+    ops *= conv_dims.kz * conv_dims.oz;
   } else {
     // conv_dims always use forward path definition regardless
     conv_dims.oz *= conv_dims.iz;
@@ -1009,7 +1011,7 @@ int64 OpLevelCostEstimator::CountConv2DBackpropFilterOperations(
   ops *= conv_dims.ox * conv_dims.oy;
   ops *= conv_dims.kx * conv_dims.ky;
   if (op_info.op() == kConv2dBackpropFilter) {
-    ops *= conv_dims.iz * conv_dims.oz;
+    ops *= conv_dims.kz * conv_dims.oz;
   } else {
     // conv_dims always use forward path definition regardless
     conv_dims.oz *= conv_dims.iz;
@@ -1420,6 +1422,7 @@ OpLevelCostEstimator::OpDimensionsFromInputs(
   std::vector<int64> ksize = GetKernelSize(op_info);
   int64 kx = ksize[x_index];
   int64 ky = ksize[y_index];
+  int64 kz = iz;  // These ops don't support groupwise operation, therefore kz == iz.
 
   std::vector<int64> strides = GetStrides(op_info);
   int64 sx = strides[x_index];

--- a/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
+++ b/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
@@ -623,7 +623,7 @@ OpLevelCostEstimator::ConvolutionDimensionsFromInputs(
   // Only check equality when both sizes are known (in other words, when
   // neither is set to a minimum dimension size of 1).
   if (iz != 1 && kz != 1) {
-    CHECK(iz % kz == 0) << "Input channel " << iz << " is not a multiple of filter channel " << kz << ".";
+    CHECK_EQ(iz % kz, 0) << "Input channel " << iz << " is not a multiple of filter channel " << kz << ".";
   } else {
     iz = std::max<int64>(iz, filter_shape.dim(in_channel_index).size());
   }
@@ -1434,7 +1434,7 @@ OpLevelCostEstimator::OpDimensionsFromInputs(
   int64 oz = iz;
 
   OpLevelCostEstimator::ConvolutionDimensions conv_dims = {
-      batch, ix, iy, iz, kx, ky, oz, ox, oy, sx, sy, padding};
+      batch, ix, iy, iz, kx, ky, kz, oz, ox, oy, sx, sy, padding};
   return conv_dims;
 }
 

--- a/tensorflow/core/grappler/costs/op_level_cost_estimator.h
+++ b/tensorflow/core/grappler/costs/op_level_cost_estimator.h
@@ -68,6 +68,7 @@ class OpLevelCostEstimator {
     int64 iz;         // Input depth.
     int64 kx;         // Kernel x.
     int64 ky;         // Kernel y.
+    int64 kz;         // Kernel depth (in case of group convolution, this will be smaller than input depth).
     int64 oz;         // Output depth.
     int64 ox;         // Output size x.
     int64 oy;         // Output size y.

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -740,25 +740,15 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       .set_group_count(dims.in_depth / filter_shape.dim_size(2));
 
   // NOTE(zhengxq):
-  // cuDNN only supports the following layouts :
-  // Input  : B x D x R x C
-  // Filter : OD x ID x R x C
-  // Whereas, we have
-  // Input  : B x R x C x D
-  // Filter : R x C x ID x OD
-  // TransformFilter performs (R x C x ID x OD) => (OD x ID x R x C)
-  // The first TransformDepth performs
-  // (B x R x C x D) => (B x D x R x C).
-  // Since the tensor returned from cuDNN is B x D x R x C also,
-  // the second TransformDepth performs
-  // (B x D x R x C) => (B x R x C x D).
+  // cuDNN only supports the filter layouts: OD x FD x R x C
+  // Whereas, we have: R x C x ID x OD
+  // TransformFilter performs (R x C x FD x OD) => (OD x FD x R x C)
 
   Tensor pre_transformed_filter_backprop;
   OP_REQUIRES_OK(
       ctx, ctx->allocate_temp(DataTypeToEnum<T>::value,
-                              TensorShape({dims.out_depth, dims.in_depth,
-                                           dims.spatial_dims[0].filter_size,
-                                           dims.spatial_dims[1].filter_size}),
+                              TensorShape({filter_shape.dim_size(3), filter_shape.dim_size(2),
+                                           filter_shape.dim_size(0), filter_shape.dim_size(1)}),
                               &pre_transformed_filter_backprop));
 
   Tensor transformed_out_backprop;

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -856,24 +856,14 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
       .set_group_count(dims.in_depth / filter_shape.dim_size(2));
 
   // NOTE(keveman):
-  // cuDNN only supports the following layouts :
-  // Input  : B x D x R x C
-  // Filter : OD x ID x R x C
-  // Whereas, we have
-  // Input  : B x R x C x D
-  // Filter : R x C x ID x OD
-  // TransformFilter performs (R x C x ID x OD) => (OD x ID x R x C)
-  // The first TransformDepth performs
-  // (B x R x C x D) => (B x D x R x C).
-  // Since the tensor returned from cuDNN is B x D x R x C also,
-  // the second TransformDepth performs
-  // (B x D x R x C) => (B x R x C x D).
+  // cuDNN only supports the filter layouts: OD x FD x R x C
+  // Whereas, we have: R x C x FD x OD
+  // TransformFilter performs (R x C x FD x OD) => (OD x FD x R x C)
   Tensor transformed_filter;
   OP_REQUIRES_OK(
       ctx, ctx->allocate_temp(DataTypeToEnum<T>::value,
-                              TensorShape({dims.out_depth, dims.in_depth,
-                                           dims.spatial_dims[0].filter_size,
-                                           dims.spatial_dims[1].filter_size}),
+                              TensorShape({filter_shape.dim_size(3), filter_shape.dim_size(2),
+                                           filter_shape.dim_size(0), filter_shape.dim_size(1)}),
                               &transformed_filter));
 
   functor::TransformFilter<GPUDevice, T, int, 4>()(

--- a/tensorflow/python/kernel_tests/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_test.py
@@ -693,6 +693,74 @@ class Conv2DTest(test.TestCase):
         dilations=[2, 3],
         test_grappler_layout_optimizer=True)
 
+  def _VerifyGroupConvFwd(self, tensor_in_sizes, filter_in_sizes, dilations,
+                          strides, padding, data_format, dtype):
+    """
+    Verify the output of group convolution is equal to a
+    for-loop implementation.
+
+    Args:
+      tensor_in_sizes: Input tensor dimensions in
+        [batch, input_rows, input_cols, input_depth].
+      filter_in_sizes: Filter tensor dimensions in
+        [kernel_rows, kernel_cols, input_depth, output_depth].
+      dilations: Dilated rate: [col_dilation, row_dilation]
+      strides: Stride: [col_stride, row_stride]
+      padding: Padding type.
+      data_format: Format of the data tensors.
+      dtype: Data type for inputs and outputs.
+    """
+    tensor_in = self._CreateNumpyTensor(tensor_in_sizes)
+    filter_in = self._CreateNumpyTensor(filter_in_sizes)
+    num_groups = tensor_in_sizes[3] // filter_in_sizes[2]
+    assert num_groups > 1 and \
+        filter_in_sizes[2] * num_groups == tensor_in_sizes[3]
+    with test_util.device(True):
+      t1 = constant_op.constant(tensor_in, dtype=dtype)
+      t2 = constant_op.constant(filter_in, dtype=dtype)
+      strides = [1] + strides + [1]
+      dilations = [1] + dilations + [1]
+      if data_format == "NCHW":
+        t1 = test_util.NHWCToNCHW(t1)
+        strides = test_util.NHWCToNCHW(strides)
+        dilations = test_util.NHWCToNCHW(dilations)
+        t1_splits = array_ops.split(t1, num_groups, axis=1)
+      else:
+        t1_splits = array_ops.split(t1, num_groups, axis=3)
+      t2_splits = array_ops.split(t2, num_groups, axis=3)
+
+      group_conv = nn_ops.conv2d(
+          t1,
+          t2,
+          dilations=dilations,
+          strides=strides,
+          padding=padding,
+          data_format=data_format)
+      group_conv_loop = array_ops.concat(
+          [nn_ops.conv2d(t1s, t2s,
+                         dilations=dilations,
+                         strides=strides,
+                         padding=padding,
+                         data_format=data_format)
+           for t1s, t2s in zip(t1_splits, t2_splits)],
+          axis=1 if data_format == "NCHW" else 3)
+      results = self.evaluate([group_conv, group_conv_loop])
+      tol_to_use = 1e-5
+      self.assertAllClose(results[0], results[1],
+                          atol=tol_to_use, rtol=tol_to_use)
+
+  @test_util.run_in_graph_and_eager_modes
+  @test_util.run_cuda_only
+  def testConv2DGroupConvFwd(self):
+    for data_format in ["NHWC", "NCHW"]:
+      for dilation in [1, 2]:
+        for stride in [1, 2]:
+          self._VerifyGroupConvFwd([10, 32, 32, 16], [3, 3, 4, 8],
+                                   dilations=[dilation, dilation],
+                                   strides=[stride, stride], padding="SAME",
+                                   data_format=data_format,
+                                   dtype=dtypes.float32)
+
   # TODO(yzhwang): this currently fails.
   # self._VerifyValues(tensor_in_sizes=[1, 8, 8, 1],
   #                   filter_in_sizes=[2, 2, 1, 1],
@@ -2274,6 +2342,16 @@ class Conv2DTest(test.TestCase):
               dtypes.float32, shape=[4, 4, 2, 2]),
           strides=[1, 1, 1, 1],
           padding="SAME")
+
+    # Input depth divisible by filter depth (group convolution).
+    # No exceptions should appear.
+    nn_ops.conv2d(
+        array_ops.placeholder(
+            dtypes.float32, shape=[32, 20, 20, 8]),
+        array_ops.placeholder(
+            dtypes.float32, shape=[4, 4, 2, 16]),
+        strides=[1, 1, 1, 1],
+        padding="SAME")
 
     # Negative padding.
     with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR enables group convolution in cudnn, a feature that's highly desired for many years (#3332, https://github.com/tensorflow/tensorflow/issues/12052#issuecomment-320465264, #11662, #10482).

With this PR, now it's allowed to call `tf.nn.conv2d(inputs, filters)`, where the depth of `inputs` is not necessarily equal to `filters.shape[2]`, but be a multiple of `filters.shape[2]`.

The core of this PR is only two lines of code (https://github.com/tensorflow/tensorflow/issues/3332#issuecomment-464308902) which removes the shape check. Then I added some extra checks and tests.

This benchmark script:
```python
import tensorflow as tf
import time
import os

N = 64
C = 256
G = 32
H, W = 64, 64
print("N, C, H, W:", [N, C, H, W])


def benchmark_all(use_loop, format):
    shape4d = [N, C, H, W] if format == 'NCHW' else [N, H, W, C]

    tf.reset_default_graph()
    input = tf.get_variable('input', shape=shape4d, dtype=tf.float32)
    filter = tf.get_variable('filter', shape=[3, 3, C // G, C], dtype=tf.float32)

    if use_loop:
        inputs = tf.split(input, G, axis=1 if format == 'NCHW' else 3)
        filters = tf.split(filter, G, axis=3)
        output = tf.concat(
            [tf.nn.conv2d(i, f,
                strides=[1,1,1,1],
                padding='SAME',
                data_format=format) for i, f in zip(inputs, filters)], axis=1 if format == 'NCHW' else 3)
    else:
        output = tf.nn.conv2d(input, filter, strides=[1, 1, 1, 1], padding='SAME', data_format=format)


    forward_op = output.op
    cost = tf.reduce_sum(output)
    backward_op = tf.train.GradientDescentOptimizer(0.1).minimize(cost)

    def benchmark(op, nr_iter=200, nr_warmup=10):
        for k in range(nr_warmup):
            op.run()
        start = time.perf_counter()
        for k in range(nr_iter):
            op.run()
        end = time.perf_counter()
        itr_per_sec = nr_iter * 1. / (end - start)
        return itr_per_sec

    sess = tf.Session()
    with sess.as_default():
        sess.run(tf.global_variables_initializer())

        spd_forward = benchmark(forward_op)
        print("Loop={}, Format={}, Forward: {} itr/s".format(use_loop, format, spd_forward))
        spd_backward = benchmark(backward_op)
        print("Loop={}, Format={}, Backward: {} itr/s".format(use_loop, format, spd_backward))


formats = ['NHWC', 'NCHW']
for format in formats:
    for use_loop in [True, False]:
        benchmark_all(use_loop, format)
```
Executed on V100, cuda10, cudnn 7.4.2, it prints:
```
N, C, H, W: [64, 256, 64, 64]
Loop=True, Format=NHWC, Forward: 65.49446747235214 itr/s
Loop=True, Format=NHWC, Backward: 32.26484275606916 itr/s
Loop=False, Format=NHWC, Forward: 117.40288830454352 itr/s
Loop=False, Format=NHWC, Backward: 50.051492362319074 itr/s
Loop=True, Format=NCHW, Forward: 98.8428390274372 itr/s
Loop=True, Format=NCHW, Backward: 35.672312085388455 itr/s
Loop=False, Format=NCHW, Forward: 152.24726060851506 itr/s
Loop=False, Format=NCHW, Backward: 56.21414524041962 itr/s
```
which shows around 50~80% speed up over a naive loop-based implementation.