### PR TITLE
Add a better error message when unsupported ops are used for Dimension

### DIFF
--- a/tensorflow/python/framework/tensor_shape.py
+++ b/tensorflow/python/framework/tensor_shape.py
@@ -468,6 +468,54 @@ class Dimension(object):
     """
     return self // other
 
+  def __rdiv__(self, other):
+    """Use `__floordiv__` via `x // y` instead.
+
+    This function exists only to have a better error message. Instead of:
+    `TypeError: unsupported operand type(s) for /: 'int' and 'Dimension'`,
+    this function will explicitly call for usage of `//` instead.
+
+    Args:
+      other: Another `Dimension`.
+
+    Raises:
+      TypeError.
+    """
+    raise TypeError("unsupported operand type(s) for /: '{}' and 'Dimension', "
+                    "please use // instead".format(type(other).__name__))
+
+  def __truediv__(self, other):
+    """Use `__floordiv__` via `x // y` instead.
+
+    This function exists only to have a better error message. Instead of:
+    `TypeError: unsupported operand type(s) for /: 'Dimension' and 'int'`,
+    this function will explicitly call for usage of `//` instead.
+
+    Args:
+      other: Another `Dimension`.
+
+    Raises:
+      TypeError.
+    """
+    raise TypeError("unsupported operand type(s) for /: 'Dimension' and '{}', "
+                    "please use // instead".format(type(other).__name__))
+
+  def __rtruediv__(self, other):
+    """Use `__floordiv__` via `x // y` instead.
+
+    This function exists only to have a better error message. Instead of:
+    `TypeError: unsupported operand type(s) for /: 'int' and 'Dimension'`,
+    this function will explicitly call for usage of `//` instead.
+
+    Args:
+      other: Another `Dimension`.
+
+    Raises:
+      TypeError.
+    """
+    raise TypeError("unsupported operand type(s) for /: '{}' and 'Dimension', "
+                    "please use // instead".format(type(other).__name__))
+
   def __mod__(self, other):
     """Returns `self` modulo `other`.
 

--- a/tensorflow/python/framework/tensor_shape_div_test.py
+++ b/tensorflow/python/framework/tensor_shape_div_test.py
@@ -35,6 +35,15 @@ class DimensionDivTest(test_util.TensorFlowTestCase):
         for y in values:
           self.assertEqual((x / y).value, (x // y).value)
 
+  def testRDivFail(self):
+    # Note: This test is related to GitHub issue 25790.
+    """Without from __future__ import division, __rdiv__ is used."""
+    if six.PY2:  # Old division exists only in Python 2
+      two = tensor_shape.Dimension(2)
+      message = (r"unsupported operand type\(s\) for \/: "
+                 r"'int' and 'Dimension', please use \/\/ instead")
+      with self.assertRaisesRegexp(TypeError, message):
+        _ = 6 / two
 
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/python/framework/tensor_shape_div_test.py
+++ b/tensorflow/python/framework/tensor_shape_div_test.py
@@ -40,8 +40,8 @@ class DimensionDivTest(test_util.TensorFlowTestCase):
     """Without from __future__ import division, __rdiv__ is used."""
     if six.PY2:  # Old division exists only in Python 2
       two = tensor_shape.Dimension(2)
-      message = (r"unsupported operand type\(s\) for \/: "
-                 r"'int' and 'Dimension', please use \/\/ instead")
+      message = (r"unsupported operand type\(s\) for /: "
+                 r"'int' and 'Dimension', please use // instead")
       with self.assertRaisesRegexp(TypeError, message):
         _ = 6 / two
 

--- a/tensorflow/python/framework/tensor_shape_test.py
+++ b/tensorflow/python/framework/tensor_shape_test.py
@@ -205,6 +205,23 @@ class DimensionTest(test_util.TensorFlowTestCase):
     reconstructed = ctor(*args)
     self.assertEquals(reconstructed, dim)
 
+  def testDiv(self):
+    # Note: This test is related to GitHub issue 25790.
+    six = tensor_shape.Dimension(6)
+    two = tensor_shape.Dimension(2)
+    message = (r"unsupported operand type\(s\) for \/: "
+               r"'Dimension' and 'Dimension', please use \/\/ instead")
+    with self.assertRaisesRegexp(TypeError, message):
+      _ = six / two
+    message = (r"unsupported operand type\(s\) for \/: "
+               r"'Dimension' and 'int', please use \/\/ instead")
+    with self.assertRaisesRegexp(TypeError, message):
+      _ = six / 2
+    message = (r"unsupported operand type\(s\) for \/: "
+               r"'int' and 'Dimension', please use \/\/ instead")
+    with self.assertRaisesRegexp(TypeError, message):
+      _ = 6 / two
+
 
 class ShapeTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/framework/tensor_shape_test.py
+++ b/tensorflow/python/framework/tensor_shape_test.py
@@ -209,16 +209,16 @@ class DimensionTest(test_util.TensorFlowTestCase):
     # Note: This test is related to GitHub issue 25790.
     six = tensor_shape.Dimension(6)
     two = tensor_shape.Dimension(2)
-    message = (r"unsupported operand type\(s\) for \/: "
-               r"'Dimension' and 'Dimension', please use \/\/ instead")
+    message = (r"unsupported operand type\(s\) for /: "
+               r"'Dimension' and 'Dimension', please use // instead")
     with self.assertRaisesRegexp(TypeError, message):
       _ = six / two
-    message = (r"unsupported operand type\(s\) for \/: "
-               r"'Dimension' and 'int', please use \/\/ instead")
+    message = (r"unsupported operand type\(s\) for /: "
+               r"'Dimension' and 'int', please use // instead")
     with self.assertRaisesRegexp(TypeError, message):
       _ = six / 2
-    message = (r"unsupported operand type\(s\) for \/: "
-               r"'int' and 'Dimension', please use \/\/ instead")
+    message = (r"unsupported operand type\(s\) for /: "
+               r"'int' and 'Dimension', please use // instead")
     with self.assertRaisesRegexp(TypeError, message):
       _ = 6 / two
 


### PR DESCRIPTION

This fix is related to #25790. In #25790, `Dimension` with division will thrown an TypeError:
```
output_dim = input_shape[-1] / 2
...
TypeError: unsupported operand type(s) for /: 'Dimension' and 'int'
```
The error is expected, as Dimension only support `//` (not `/`).

However, for backward compatible reasons, `__div__`(`/`) is actually implemented (but deprecated). See code.

This issue causes confusion and it has been mentioned multiple times in GitHub (https://github.com/DrSleep/tensorflow-deeplab-resnet/issues/83) and StackOverflow (https://stackoverflow.com/questions/51692253/typeerror-unsupported-operand-types-for-dimension-and-int)

This fix is an attempt to print a better error message with:
```
TypeError: unsupported operand type(s) for /: 'Dimension' and 'int', please use // instead
```

Note that this PR does not change any current behavior, and have no impact with respect
to backward-compatible `__div__`. It merely adds additional notes in the error message.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>