### PR TITLE
Fixed invalid link in model_pruning readme

### DIFF
--- a/tensorflow/contrib/model_pruning/README.md
+++ b/tensorflow/contrib/model_pruning/README.md
@@ -63,13 +63,13 @@ The pruning library allows for specification of the following hyper parameters:
 | sparsity_function_exponent | float | 3.0 | exponent = 1 is linearly varying sparsity between initial and final. exponent > 1 varies more slowly towards the end than the beginning |
 | use_tpu | bool | False | Training using TPUs? |
 
-The sparsity $$s_t$$ at global step $$t$$ is given by:
+The sparsity $s_t$ at global step $t$ is given by:
 
-$$ s_{t}=s_{f}+\left(s_{i}-s_{f}\right)\left(1-\frac{t-t_{0}}{n\Delta t}\right)^{3} $$
+$s_{t}=s_{f}+\left(s_{i}-s_{f}\right)\left(1-\frac{t-t_{0}}{n\Delta t}\right)^{3}$
 
 The interval between sparsity_function_begin_step and sparsity_function_end_step
-is divided into $$n$$ intervals of size equal to the pruning_frequency ($$\Delta
-t$$). $$s_f$$ is the target_sparsity, $$s_i$$ is the initial_sparsity, $$t_0$$
+is divided into $n$ intervals of size equal to the pruning_frequency ($\Delta
+t$). $s_f$ is the target_sparsity, $s_i$ is the initial_sparsity, $t_0$
 is the sparsity_function_begin_step. In this equation, the
 sparsity_function_exponent is set to 3.
 

--- a/tensorflow/contrib/model_pruning/README.md
+++ b/tensorflow/contrib/model_pruning/README.md
@@ -63,13 +63,13 @@ The pruning library allows for specification of the following hyper parameters:
 | sparsity_function_exponent | float | 3.0 | exponent = 1 is linearly varying sparsity between initial and final. exponent > 1 varies more slowly towards the end than the beginning |
 | use_tpu | bool | False | Training using TPUs? |
 
-The sparsity $s_t$ at global step $t$ is given by:
+The sparsity $$s_t$$ at global step $$t$$ is given by:
 
-$s_{t}=s_{f}+\left(s_{i}-s_{f}\right)\left(1-\frac{t-t_{0}}{n\Delta t}\right)^{3}$
+$$s_{t}=s_{f}+\left(s_{i}-s_{f}\right)\left(1-\frac{t-t_{0}}{n\Delta t}\right)^{3}$$
 
 The interval between sparsity_function_begin_step and sparsity_function_end_step
-is divided into $n$ intervals of size equal to the pruning_frequency ($\Delta
-t$). $s_f$ is the target_sparsity, $s_i$ is the initial_sparsity, $t_0$
+is divided into $$n$$ intervals of size equal to the pruning_frequency ($$\Delta
+t$$). $$s_f$$ is the target_sparsity, $$s_i$$ is the initial_sparsity, $$t_0$$
 is the sparsity_function_begin_step. In this equation, the
 sparsity_function_exponent is set to 3.
 

--- a/tensorflow/contrib/model_pruning/README.md
+++ b/tensorflow/contrib/model_pruning/README.md
@@ -133,7 +133,8 @@ For now, it is assumed that the underlying hardware platform will provide mechan
 
 ## Example: Pruning and training deep CNNs on the cifar10 dataset <a name="example"></a>
 
-Please see https://www.tensorflow.org/tutorials/deep_cnn for details on neural
+Please see [Advanced Convolutional Neural Networks
+](https://www.tensorflow.org/tutorials/images/deep_cnn) for details on neural
 network architecture, setting up inputs etc. The additional changes needed to
 incorporate pruning are captured in the following:
 

--- a/tensorflow/contrib/model_pruning/README.md
+++ b/tensorflow/contrib/model_pruning/README.md
@@ -133,10 +133,7 @@ For now, it is assumed that the underlying hardware platform will provide mechan
 
 ## Example: Pruning and training deep CNNs on the cifar10 dataset <a name="example"></a>
 
-Please see [Advanced Convolutional Neural Networks
-](https://www.tensorflow.org/tutorials/images/deep_cnn) for details on neural
-network architecture, setting up inputs etc. The additional changes needed to
-incorporate pruning are captured in the following:
+Please see [Advanced Convolutional Neural Networks](https://www.tensorflow.org/tutorials/images/deep_cnn) for details on neural network architecture, setting up inputs etc. The additional changes needed to incorporate pruning are captured in the following:
 
 *   [cifar10_pruning.py](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/model_pruning/examples/cifar10/cifar10_pruning.py)
     creates a deep CNN with the same architecture, but adds mask and threshold


### PR DESCRIPTION
Current link to deep cnn is invalid and leads to the start page for tutorials.