### PR TITLE
Add support for np.ndarray in ragged tensor construction.

### DIFF
--- a/tensorflow/python/ops/ragged/convert_to_tensor_or_ragged_tensor_op_test.py
+++ b/tensorflow/python/ops/ragged/convert_to_tensor_or_ragged_tensor_op_test.py
@@ -41,6 +41,15 @@ class RaggedConvertToTensorOrRaggedTensorTest(
       dict(pylist=[[1, 2], [3]]),
       dict(pylist=[[1, 2], [3]], preferred_dtype=dtypes.float32),
       dict(pylist=[[1, 2], [3]], preferred_dtype=dtypes.string),
+      # Note: Conversion of a single np.array is tested below. These tests
+      # check nestings consisting of multiple or irregularily-shaped np.arrays.
+      dict(pylist=[np.array([1, 2]), np.array([3])],
+           preferred_dtype=dtypes.string),
+      dict(pylist=np.array([[1, 2], [3]]), preferred_dtype=dtypes.float32),
+      dict(pylist=np.array([[1, 2], [3]]), preferred_dtype=dtypes.string),
+      dict(pylist=[np.array([[1], np.array([2])]), [np.array([3])]],
+           preferred_dtype=dtypes.float32),
+      dict(pylist=[np.array(1)], preferred_dtype=dtypes.string),
   ])
   def testConvertRaggedTensor(self, pylist, dtype=None, preferred_dtype=None):
     rt = ragged_factory_ops.constant(pylist)
@@ -51,6 +60,11 @@ class RaggedConvertToTensorOrRaggedTensorTest(
   @parameterized.parameters([
       dict(
           pylist=[[1, 2], [3, 4]],
+          dtype=dtypes.float32,
+          message=('Tensor conversion requested dtype float32 for '
+                   'RaggedTensor with dtype int32')),
+      dict(
+          pylist=np.array([[1, 2], [3, 4]]),
           dtype=dtypes.float32,
           message=('Tensor conversion requested dtype float32 for '
                    'RaggedTensor with dtype int32')),

--- a/tensorflow/python/ops/ragged/ragged_const_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_const_op_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 from absl.testing import parameterized
+import numpy as np
 
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import test_util
@@ -65,6 +66,27 @@ class RaggedConstOpTest(ragged_test_util.RaggedTensorTestCase,
           ragged_rank=1,
           inner_shape=(2,),
           expected_shape=(3, None, 2)),
+      # 3-dimensional tensors with numpy arrays
+      dict(
+          pylist=[[[1, 2], np.array([3, np.array(4)])],
+                  np.array([]), [[5, 6], [7, 8], [9, 0]]],
+          expected_shape=(3, None, None)),
+      dict(
+          pylist=[[[1, 2], np.array([3, np.array(4)])],
+                  np.array([]), [[5, 6], [7, 8], [9, 0]]],
+          ragged_rank=1,
+          expected_shape=(3, None, 2)),
+      dict(
+          pylist=[[[1, 2], np.array([3, np.array(4)])],
+                  np.array([]), [[5, 6], [7, 8], [9, 0]]],
+          inner_shape=(2,),
+          expected_shape=(3, None, 2)),
+      dict(
+          pylist=[[[1, 2], np.array([3, np.array(4)])],
+                  np.array([]), [[5, 6], [7, 8], [9, 0]]],
+          ragged_rank=1,
+          inner_shape=(2,),
+          expected_shape=(3, None, 2)),
       #=========================================================================
       # 4-dimensional tensors.
       dict(
@@ -86,13 +108,21 @@ class RaggedConstOpTest(ragged_test_util.RaggedTensorTestCase,
                   [[[2, 4], [6, 8]], [[1, 5], [7, 9]]]],
           inner_shape=(2, 2),
           expected_shape=(2, None, 2, 2)),
+      # 4-dimensional tensors with numpy arrays
+      dict(
+          pylist=np.array([[[np.array([1, 2]), [3, 4]], [[5, 6], [7, 8]]],
+                           np.array([[[2, 4], [6, 8]], [[1, 5], [7, 9]]])]),
+          expected_shape=(2, None, None, None)),
 
       #=========================================================================
       # Empty tensors (no scalar values) w/ default ragged_rank and inner_shape
       dict(pylist=[], expected_shape=(0,)),
-      dict(pylist=[[], [], []], expected_shape=(3, None)),
+      dict(pylist=[[], [], np.array([])], expected_shape=(3, None)),
       dict(
           pylist=[[[], []], [], [[], [[]]]],
+          expected_shape=(3, None, None, None)),
+      dict(
+          pylist=np.array([np.array([[], []]), np.array([]), [[], [[]]]]),
           expected_shape=(3, None, None, None)),
 
       #=========================================================================
@@ -113,6 +143,11 @@ class RaggedConstOpTest(ragged_test_util.RaggedTensorTestCase,
       dict(pylist=[[], [], []], ragged_rank=2, expected_shape=(3, None, None)),
       dict(pylist=[], inner_shape=(0,), expected_shape=(0,)),
       dict(pylist=[[]], inner_shape=(1, 0), expected_shape=(1, 0)),
+      dict(
+          pylist=np.array([]),
+          ragged_rank=1,
+          inner_shape=(100, 20),
+          expected_shape=(0, None, 100, 20)),
 
       #=========================================================================
       # default/inferred dtypes
@@ -123,6 +158,9 @@ class RaggedConstOpTest(ragged_test_util.RaggedTensorTestCase,
       dict(pylist=[[1, 2], [3.], [4, 5, 6]], expected_dtype=dtypes.float32),
       dict(pylist=[[b'a', b'b'], [b'c']], expected_dtype=dtypes.string),
       dict(pylist=[[True]], expected_dtype=dtypes.bool),
+      dict(pylist=[np.array([1, 2]), np.array([3.]), [4, 5, 6]],
+           expected_dtype=dtypes.float32),
+
 
       #=========================================================================
       # explicit dtypes
@@ -161,6 +199,9 @@ class RaggedConstOpTest(ragged_test_util.RaggedTensorTestCase,
     """
     rt = ragged_factory_ops.constant(
         pylist, dtype=dtype, ragged_rank=ragged_rank, inner_shape=inner_shape)
+    # Normalize the pylist, i.e., convert all np.arrays to list.
+    # E.g., [np.array((1,2))] --> [[1,2]]
+    pylist = self._normalize_pylist(pylist)
 
     # If dtype was explicitly specified, check it.
     if dtype is not None:

--- a/tensorflow/python/ops/ragged/ragged_constant_value_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_constant_value_op_test.py
@@ -64,6 +64,27 @@ class RaggedConstantValueOpTest(ragged_test_util.RaggedTensorTestCase,
           ragged_rank=1,
           inner_shape=(2,),
           expected_shape=(3, None, 2)),
+      # 3-dimensional tensors with numpy arrays
+      dict(
+          pylist=[[[1, 2], np.array([3, np.array(4)])],
+                  np.array([]), [[5, 6], [7, 8], [9, 0]]],
+          expected_shape=(3, None, None)),
+      dict(
+          pylist=[[[1, 2], np.array([3, np.array(4)])],
+                  np.array([]), [[5, 6], [7, 8], [9, 0]]],
+          ragged_rank=1,
+          expected_shape=(3, None, 2)),
+      dict(
+          pylist=[[[1, 2], np.array([3, np.array(4)])],
+                  np.array([]), [[5, 6], [7, 8], [9, 0]]],
+          inner_shape=(2,),
+          expected_shape=(3, None, 2)),
+      dict(
+          pylist=[[[1, 2], np.array([3, np.array(4)])],
+                  np.array([]), [[5, 6], [7, 8], [9, 0]]],
+          ragged_rank=1,
+          inner_shape=(2,),
+          expected_shape=(3, None, 2)),
       #=========================================================================
       # 4-dimensional tensors.
       dict(
@@ -85,13 +106,21 @@ class RaggedConstantValueOpTest(ragged_test_util.RaggedTensorTestCase,
                   [[[2, 4], [6, 8]], [[1, 5], [7, 9]]]],
           inner_shape=(2, 2),
           expected_shape=(2, None, 2, 2)),
+      # 4-dimensional tensors with numpy arrays
+      dict(
+          pylist=np.array([[[np.array([1, 2]), [3, 4]], [[5, 6], [7, 8]]],
+                           np.array([[[2, 4], [6, 8]], [[1, 5], [7, 9]]])]),
+          expected_shape=(2, None, None, None)),
 
       #=========================================================================
       # Empty tensors (no scalar values) w/ default ragged_rank and inner_shape
       dict(pylist=[], expected_shape=(0,)),
-      dict(pylist=[[], [], []], expected_shape=(3, None)),
+      dict(pylist=[[], [], np.array([])], expected_shape=(3, None)),
       dict(
           pylist=[[[], []], [], [[], [[]]]],
+          expected_shape=(3, None, None, None)),
+      dict(
+          pylist=np.array([np.array([[], []]), np.array([]), [[], [[]]]]),
           expected_shape=(3, None, None, None)),
 
       #=========================================================================
@@ -112,6 +141,11 @@ class RaggedConstantValueOpTest(ragged_test_util.RaggedTensorTestCase,
       dict(pylist=[[], [], []], ragged_rank=2, expected_shape=(3, None, None)),
       dict(pylist=[], inner_shape=(0,), expected_shape=(0,)),
       dict(pylist=[[]], inner_shape=(1, 0), expected_shape=(1, 0)),
+      dict(
+          pylist=np.array([]),
+          ragged_rank=1,
+          inner_shape=(100, 20),
+          expected_shape=(0, None, 100, 20)),
 
       #=========================================================================
       # default/inferred dtypes.
@@ -126,6 +160,8 @@ class RaggedConstantValueOpTest(ragged_test_util.RaggedTensorTestCase,
       dict(pylist=[[1, 2], [3.], [4, 5, 6]], expected_dtype=np.float64),
       dict(pylist=[[b'a', b'b'], [b'c']], expected_dtype=np.dtype('S1')),
       dict(pylist=[[True]], expected_dtype=np.bool),
+      dict(pylist=[np.array([1, 2]), np.array([3.]), [4, 5, 6]],
+           expected_dtype=np.float64),
 
       #=========================================================================
       # explicit dtypes
@@ -136,9 +172,8 @@ class RaggedConstantValueOpTest(ragged_test_util.RaggedTensorTestCase,
       dict(pylist=[[1, 2], [3], [4, 5, 6]], dtype=np.float32),
       dict(pylist=[[1., 2.], [3.], [4., 5., 6.]], dtype=np.float16),
       dict(pylist=[[1., 2.], [3.], [4., 5., 6.]], dtype=np.float32),
-      dict(
-          pylist=[[b'a', b'b'], [b'c'], [b'd', b'e', b'f']],
-          dtype=np.dtype('S1')),
+      dict(pylist=[[b'a', b'b'], [b'c'], [b'd', b'e', b'f']],
+           dtype=np.dtype('S1')),
   )
   def testRaggedValues(self,
                        pylist,
@@ -150,7 +185,9 @@ class RaggedConstantValueOpTest(ragged_test_util.RaggedTensorTestCase,
     """Tests that `ragged_value(pylist).to_list() == pylist`."""
     rt = ragged_factory_ops.constant_value(
         pylist, dtype=dtype, ragged_rank=ragged_rank, inner_shape=inner_shape)
-
+    # Normalize the pylist, i.e., convert all np.arrays to list.
+    # E.g., [np.array((1,2))] --> [[1,2]]
+    pylist = self._normalize_pylist(pylist)
     # If dtype was explicitly specified, check it.
     if dtype is not None:
       self.assertEqual(rt.dtype, dtype)
@@ -192,6 +229,12 @@ class RaggedConstantValueOpTest(ragged_test_util.RaggedTensorTestCase,
           ragged_rank=1,
           exception=ValueError,
           message='Invalid pylist=12: incompatible with ragged_rank=1'),
+      dict(
+          pylist=np.array(12),
+          ragged_rank=1,
+          exception=ValueError,
+          message='Invalid pylist=array\\(12\\): incompatible with '
+                  'ragged_rank=1'),
       dict(
           pylist=12,
           inner_shape=(1,),

--- a/tensorflow/python/ops/ragged/ragged_factory_ops.py
+++ b/tensorflow/python/ops/ragged/ragged_factory_ops.py
@@ -156,7 +156,7 @@ def _constant_value(ragged_factory, inner_factory, pylist, dtype, ragged_rank,
   if ragged_tensor.is_ragged(pylist):
     raise TypeError("pylist may not be a RaggedTensor or RaggedTensorValue.")
 
-  if not isinstance(pylist, (list, tuple, np.ndarray)):
+  if np.ndim(pylist) == 0:
     # Scalar value
     if ragged_rank is not None and ragged_rank != 0:
       raise ValueError("Invalid pylist=%r: incompatible with ragged_rank=%d" %
@@ -243,7 +243,7 @@ def _find_scalar_and_max_depth(pylist):
   Raises:
     ValueError: If pylist has inconsistent nesting depths for scalars.
   """
-  if isinstance(pylist, (list, tuple, np.ndarray)):
+  if np.ndim(pylist) != 0:  # Check if pylist is not scalar
     scalar_depth = None
     max_depth = 1
     for child in pylist:
@@ -254,8 +254,7 @@ def _find_scalar_and_max_depth(pylist):
         scalar_depth = child_scalar_depth + 1
       max_depth = max(max_depth, child_max_depth + 1)
     return (scalar_depth, max_depth)
-  else:
-    return (0, 0)
+  return (0, 0)
 
 
 def _default_inner_shape_for_pylist(pylist, ragged_rank):
@@ -263,16 +262,15 @@ def _default_inner_shape_for_pylist(pylist, ragged_rank):
 
   def get_inner_shape(item):
     """Returns the inner shape for a python list `item`."""
-    if not isinstance(item, (list, tuple, np.ndarray)):
+    if np.ndim(item) == 0:
       return ()
     elif item:
       return (len(item),) + get_inner_shape(item[0])
-    else:
-      return (0,)
+    return (0,)
 
   def check_inner_shape(item, shape):
     """Checks that `item` has a consistent shape matching `shape`."""
-    is_nested = isinstance(item, (list, tuple, np.ndarray))
+    is_nested = np.ndim(item) != 0
     if is_nested != bool(shape):
       raise ValueError("inner values have inconsistent shape")
     if is_nested:
@@ -284,7 +282,7 @@ def _default_inner_shape_for_pylist(pylist, ragged_rank):
   # Collapse the ragged layers to get the list of inner values.
   flat_values = pylist
   for dim in range(ragged_rank):
-    if not all(isinstance(v, (list, tuple, np.ndarray)) for v in flat_values):
+    if not all(np.ndim(v) != 0 for v in flat_values):
       raise ValueError("pylist has scalar values depth %d, but ragged_rank=%d "
                        "requires scalar value depth greater than %d" %
                        (dim + 1, ragged_rank, ragged_rank))

--- a/tensorflow/python/ops/ragged/ragged_test_util.py
+++ b/tensorflow/python/ops/ragged/ragged_test_util.py
@@ -94,3 +94,13 @@ class RaggedTensorTestCase(test_util.TensorFlowTestCase):
           self._eval_tensor(tensor.row_splits))
     else:
       return test_util.TensorFlowTestCase._eval_tensor(self, tensor)
+  
+  @staticmethod
+  def _normalize_pylist(item):
+    """Convert all (possibly nested) np.arrays contained in item to list."""
+    # convert np.arrays in current level to list
+    if np.ndim(item) == 0:
+      return item
+    level = (x.tolist() if isinstance(x, np.ndarray) else x for x in item)
+    _normalize = RaggedTensorTestCase._normalize_pylist
+    return [_normalize(el) if np.ndim(el) != 0  else el for el in level]


### PR DESCRIPTION
First of all, thanks a lot for implementing the awesome ragged tensors! :)

This pull request adds support for `np.ndarray ` as nested type. With the pull request, the following is possible:
```
tf.ragged.constant([np.array([1,2]), np.array([4,5,6])])
```
With the current head, this snippet throws:
`TypeError: Eager execution of tf.constant with unsupported shape (value has 6 elements, shape is (3,) with 3 elements)`

I guess storing data as lists of (differently sized)  numpy arrays is not too uncommon, e.g., in object detection there's usually a different number of bounding boxes per image.

Note: I couldn't find a test file for `ragged_factory_op`, where should unit tests for this go?
