### PR TITLE
Removal of "third_party" from iOS example

### DIFF
--- a/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm
+++ b/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm
@@ -24,17 +24,17 @@
 #include <queue>
 
 #if TFLITE_USE_CONTRIB_LITE
-#include "third_party/tensorflow/contrib/lite/kernels/register.h"
-#include "third_party/tensorflow/contrib/lite/model.h"
-#include "third_party/tensorflow/contrib/lite/op_resolver.h"
-#include "third_party/tensorflow/contrib/lite/string_util.h"
+#include "tensorflow/contrib/lite/kernels/register.h"
+#include "tensorflow/contrib/lite/model.h"
+#include "tensorflow/contrib/lite/op_resolver.h"
+#include "tensorflow/contrib/lite/string_util.h"
 #else
-#include "third_party/tensorflow/lite/kernels/register.h"
-#include "third_party/tensorflow/lite/model.h"
-#include "third_party/tensorflow/lite/op_resolver.h"
-#include "third_party/tensorflow/lite/string_util.h"
+#include "tensorflow/lite/kernels/register.h"
+#include "tensorflow/lite/model.h"
+#include "tensorflow/lite/op_resolver.h"
+#include "tensorflow/lite/string_util.h"
 #if TFLITE_USE_GPU_DELEGATE
-#include "third_party/tensorflow/lite/delegates/gpu/metal_delegate.h"
+#include "tensorflow/lite/delegates/gpu/metal_delegate.h"
 #endif
 #endif
 


### PR DESCRIPTION
The example does not build external to Google due to third_party being included in the headers. Tensorflow is not typically put in a third_party directory on a personal machine. I believe this should build both internal/external but someone might need to verify internally. If not, this might need to be a flag or something.