### PR TITLE
Create directory automatically in save_weights with h5 format

### DIFF
--- a/tensorflow/python/keras/engine/network.py
+++ b/tensorflow/python/keras/engine/network.py
@@ -1393,6 +1393,8 @@ class Network(base_layer.Layer):
       if not proceed:
         return
     if save_format == 'h5':
+      if not os.path.exists(os.path.dirname(filepath)):
+        os.makedirs(os.path.dirname(filepath))
       with h5py.File(filepath, 'w') as f:
         hdf5_format.save_weights_to_hdf5_group(f, self.layers)
     else:

--- a/tensorflow/python/keras/saving/hdf5_format_test.py
+++ b/tensorflow/python/keras/saving/hdf5_format_test.py
@@ -748,6 +748,30 @@ class TestWholeModelSaving(test.TestCase):
       os.close(fd)
       os.remove(fname)
 
+  def test_saving_with_dir_not_created(self):
+    if h5py is None:
+      self.skipTest('h5py required to run this test')
+
+    temp_dir = self.get_temp_dir()
+    self.addCleanup(shutil.rmtree, temp_dir)
+    for f in ['tf', 'h5']:
+      with self.cached_session():
+        data = np.random.random((1000, 32)).astype(np.float32)
+        labels = np.random.random((1000, 10)).astype(np.float32)
+
+        model = keras.models.Sequential([
+            keras.layers.Dense(10, activation='softmax'),
+            keras.layers.Dense(10, activation='softmax')])
+
+        model.compile(optimizer=training_module.RMSPropOptimizer(0.001),
+                      loss='categorical_crossentropy',
+                      metrics=['accuracy'])
+
+        model.fit(data, labels)
+        prefix = os.path.join(temp_dir, f, 'ckpt')
+        model.save_weights(prefix, save_format=f)
+        model.load_weights(prefix)
+
 
 class SubclassedModel(training.Model):
 


### PR DESCRIPTION
This fix tries to address the issue raised in #25835 where
save_weight with tf format creates directories automatically
as needed, yet h5 format throws out excetion.

This fix update the save_weight with h5 format to address
the discrepancy between h5 and tf.

This fix fixes #25835.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>