### PR TITLE
Fix deprecation warning with assertEquals

### DIFF
--- a/tensorflow/python/framework/tensor_shape_test.py
+++ b/tensorflow/python/framework/tensor_shape_test.py
@@ -200,10 +200,10 @@ class DimensionTest(test_util.TensorFlowTestCase):
   def testReduce(self):
     dim = tensor_shape.Dimension(5)
     ctor, args = dim.__reduce__()
-    self.assertEquals(ctor, tensor_shape.Dimension)
-    self.assertEquals(args, (5,))
+    self.assertEqual(ctor, tensor_shape.Dimension)
+    self.assertEqual(args, (5,))
     reconstructed = ctor(*args)
-    self.assertEquals(reconstructed, dim)
+    self.assertEqual(reconstructed, dim)
 
 
 class ShapeTest(test_util.TensorFlowTestCase):
@@ -440,11 +440,11 @@ class ShapeTest(test_util.TensorFlowTestCase):
   def testReduce(self):
     shape = tensor_shape.TensorShape([2, 3])
     ctor, args = shape.__reduce__()
-    self.assertEquals(ctor, tensor_shape.TensorShape)
-    self.assertEquals(args, ([tensor_shape.Dimension(2),
+    self.assertEqual(ctor, tensor_shape.TensorShape)
+    self.assertEqual(args, ([tensor_shape.Dimension(2),
                               tensor_shape.Dimension(3)],))
     reconstructed = ctor(*args)
-    self.assertEquals(reconstructed, shape)
+    self.assertEqual(reconstructed, shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While running framework_tensor_shape_test with bazel the following
warnings surface:
```
/home/ubuntu/.cache/bazel/_bazel_ubuntu/ad1e09741bb4109fbc70ef8216b59ee2 \
    /execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/framework_tensor_shape_test.runfiles/ \
    org_tensorflow/tensorflow/python/framework/tensor_shape_test.py:203: \
    DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(ctor, tensor_shape.Dimension)
```
This fix fixes the deprecation warnings.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>