### PR TITLE
Add StringLower/StringUpper op to support lower/upper() for string operations

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_StringLower.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_StringLower.pbtxt
@@ -1,0 +1,3 @@
+op {
+  graph_op_name: "StringLower"
+}

--- a/tensorflow/core/api_def/base_api/api_def_StringUpper.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_StringUpper.pbtxt
@@ -1,0 +1,3 @@
+op {
+  graph_op_name: "StringUpper"
+}

--- a/tensorflow/core/api_def/python_api/api_def_StringLower.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_StringLower.pbtxt
@@ -1,0 +1,6 @@
+op {
+  graph_op_name: "StringLower"
+  endpoint {
+    name: "strings.lower"
+  }
+}

--- a/tensorflow/core/api_def/python_api/api_def_StringUpper.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_StringUpper.pbtxt
@@ -1,0 +1,6 @@
+op {
+  graph_op_name: "StringUpper"
+  endpoint {
+    name: "strings.upper"
+  }
+}

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4924,6 +4924,7 @@ cc_library(
         ":string_split_op",
         ":string_strip_op",
         ":string_to_hash_bucket_op",
+        ":string_upper_op",
         ":substr_op",
         ":unicode_ops",
         ":unicode_script_op",
@@ -5062,6 +5063,12 @@ tf_kernel_library(
 tf_kernel_library(
     name = "string_lower_op",
     prefix = "string_lower_op",
+    deps = STRING_DEPS,
+)
+
+tf_kernel_library(
+    name = "string_upper_op",
+    prefix = "string_upper_op",
     deps = STRING_DEPS,
 )
 

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4920,6 +4920,7 @@ cc_library(
         ":string_format_op",
         ":string_join_op",
         ":string_length_op",
+        ":string_lower_op",
         ":string_split_op",
         ":string_strip_op",
         ":string_to_hash_bucket_op",
@@ -5055,6 +5056,12 @@ tf_cc_test(
 tf_kernel_library(
     name = "string_strip_op",
     prefix = "string_strip_op",
+    deps = STRING_DEPS,
+)
+
+tf_kernel_library(
+    name = "string_lower_op",
+    prefix = "string_lower_op",
     deps = STRING_DEPS,
 )
 

--- a/tensorflow/core/kernels/string_lower_op.cc
+++ b/tensorflow/core/kernels/string_lower_op.cc
@@ -1,0 +1,52 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/string_ops.cc.
+
+#include <string>
+
+#include "tensorflow/core/framework/kernel_def_builder.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/strings/str_util.h"
+
+namespace tensorflow {
+
+class StringLowerOp : public OpKernel {
+ public:
+  explicit StringLowerOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(ctx, ctx->input("input", &input_tensor));
+    Tensor* output_tensor;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_output(0, input_tensor->shape(), &output_tensor));
+
+    const auto input = input_tensor->flat<string>();
+    auto output = output_tensor->flat<string>();
+
+    for (int64 i = 0; i < input.size(); ++i) {
+      StringPiece entry(input(i));
+      output(i) = str_util::Lowercase(entry);
+    }
+  }
+};
+
+REGISTER_KERNEL_BUILDER(Name("StringLower").Device(DEVICE_CPU), StringLowerOp);
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/string_lower_op.cc
+++ b/tensorflow/core/kernels/string_lower_op.cc
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include <string>
 
+#include "unicode/unistr.h"  // TF:icu
+
 #include "tensorflow/core/framework/kernel_def_builder.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -28,7 +30,12 @@ namespace tensorflow {
 
 class StringLowerOp : public OpKernel {
  public:
-  explicit StringLowerOp(OpKernelConstruction* context) : OpKernel(context) {}
+  explicit StringLowerOp(OpKernelConstruction* context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("encoding", &encoding_));
+    OP_REQUIRES(
+        context, encoding_ != "" || encoding_ != "utf-8",
+        errors::InvalidArgument("only utf-8 or '' (no encoding) is supported, received ", encoding_));
+  }
 
   void Compute(OpKernelContext* ctx) override {
     const Tensor* input_tensor;
@@ -40,11 +47,22 @@ class StringLowerOp : public OpKernel {
     const auto input = input_tensor->flat<string>();
     auto output = output_tensor->flat<string>();
 
-    for (int64 i = 0; i < input.size(); ++i) {
-      StringPiece entry(input(i));
-      output(i) = str_util::Lowercase(entry);
+    if (encoding_ == "") {
+      for (int64 i = 0; i < input.size(); ++i) {
+        StringPiece entry(input(i));
+        output(i) = str_util::Lowercase(entry);
+      }
+    } else {
+      // The validation of utf-8 has already been done in GetAttr above.
+      for (int64 i = 0; i < input.size(); ++i) {
+        icu::UnicodeString us(input(i).c_str(), "UTF-8");
+        us.toLower();
+        us.toUTF8String(output(i));
+      }
     }
   }
+ private:
+  string encoding_;
 };
 
 REGISTER_KERNEL_BUILDER(Name("StringLower").Device(DEVICE_CPU), StringLowerOp);

--- a/tensorflow/core/kernels/string_upper_op.cc
+++ b/tensorflow/core/kernels/string_upper_op.cc
@@ -1,0 +1,52 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/string_ops.cc.
+
+#include <string>
+
+#include "tensorflow/core/framework/kernel_def_builder.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/strings/str_util.h"
+
+namespace tensorflow {
+
+class StringUpperOp : public OpKernel {
+ public:
+  explicit StringUpperOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(ctx, ctx->input("input", &input_tensor));
+    Tensor* output_tensor;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_output(0, input_tensor->shape(), &output_tensor));
+
+    const auto input = input_tensor->flat<string>();
+    auto output = output_tensor->flat<string>();
+
+    for (int64 i = 0; i < input.size(); ++i) {
+      StringPiece entry(input(i));
+      output(i) = str_util::Uppercase(entry);
+    }
+  }
+};
+
+REGISTER_KERNEL_BUILDER(Name("StringUpper").Device(DEVICE_CPU), StringUpperOp);
+
+}  // namespace tensorflow

--- a/tensorflow/core/ops/string_ops.cc
+++ b/tensorflow/core/ops/string_ops.cc
@@ -211,6 +211,11 @@ REGISTER_OP("StringLower")
     .Output("output: string")
     .SetShapeFn(shape_inference::UnchangedShape);
 
+REGISTER_OP("StringUpper")
+    .Input("input: string")
+    .Output("output: string")
+    .SetShapeFn(shape_inference::UnchangedShape);
+
 REGISTER_OP("StringStrip")
     .Input("input: string")
     .Output("output: string")

--- a/tensorflow/core/ops/string_ops.cc
+++ b/tensorflow/core/ops/string_ops.cc
@@ -206,6 +206,11 @@ REGISTER_OP("StringSplitV2")
       return Status::OK();
     });
 
+REGISTER_OP("StringLower")
+    .Input("input: string")
+    .Output("output: string")
+    .SetShapeFn(shape_inference::UnchangedShape);
+
 REGISTER_OP("StringStrip")
     .Input("input: string")
     .Output("output: string")

--- a/tensorflow/core/ops/string_ops.cc
+++ b/tensorflow/core/ops/string_ops.cc
@@ -209,11 +209,13 @@ REGISTER_OP("StringSplitV2")
 REGISTER_OP("StringLower")
     .Input("input: string")
     .Output("output: string")
+    .Attr("encoding: string =''")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 REGISTER_OP("StringUpper")
     .Input("input: string")
     .Output("output: string")
+    .Attr("encoding: string =''")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 REGISTER_OP("StringStrip")

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -1111,6 +1111,20 @@ tf_py_test(
 )
 
 tf_py_test(
+    name = "string_upper_op_test",
+    size = "small",
+    srcs = ["string_upper_op_test.py"],
+    additional_deps = [
+        "//third_party/py/numpy",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:errors",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:string_ops",
+    ],
+)
+
+tf_py_test(
     name = "substr_op_test",
     size = "small",
     srcs = ["substr_op_test.py"],

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -1097,6 +1097,20 @@ tf_py_test(
 )
 
 tf_py_test(
+    name = "string_lower_op_test",
+    size = "small",
+    srcs = ["string_lower_op_test.py"],
+    additional_deps = [
+        "//third_party/py/numpy",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:errors",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:string_ops",
+    ],
+)
+
+tf_py_test(
     name = "substr_op_test",
     size = "small",
     srcs = ["substr_op_test.py"],

--- a/tensorflow/python/kernel_tests/string_lower_op_test.py
+++ b/tensorflow/python/kernel_tests/string_lower_op_test.py
@@ -1,0 +1,48 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for string_lower_op."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.ops import string_ops
+from tensorflow.python.platform import test
+
+
+class StringLowerOpTest(test.TestCase):
+  """ Test cases for tf.strings.lower."""
+
+  def test_string_lower(self):
+    strings = ["Pigs on The Wing", "aNimals"]
+
+    with self.cached_session() as sess:
+      output = string_ops.string_lower(strings)
+      output = self.evaluate(output)
+      self.assertAllEqual(output, [b"pigs on the wing", b"animals"])
+
+  def test_string_lower_2d(self):
+    strings = [["pigS on THE wIng", "aniMals"],
+               [" hello ", "\n\tWorld! \r \n"]]
+
+    with self.cached_session() as sess:
+      output = string_ops.string_lower(strings)
+      output = self.evaluate(output)
+      self.assertAllEqual(output, [[b"pigs on the wing", b"animals"],
+                                   [b" hello ", b"\n\tworld! \r \n"]])
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/kernel_tests/string_lower_op_test.py
+++ b/tensorflow/python/kernel_tests/string_lower_op_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,6 +43,13 @@ class StringLowerOpTest(test.TestCase):
       output = self.evaluate(output)
       self.assertAllEqual(output, [[b"pigs on the wing", b"animals"],
                                    [b" hello ", b"\n\tworld! \r \n"]])
+
+  def test_string_upper_unicode(self):
+    strings = [["ÓÓSSCHLOË"]]
+    with self.cached_session() as sess:
+      output = string_ops.string_lower(strings, encoding='utf-8')
+      output = self.evaluate(output)
+      self.assertAllEqual(output, [[b"óósschloë"]]),
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/string_lower_op_test.py
+++ b/tensorflow/python/kernel_tests/string_lower_op_test.py
@@ -49,7 +49,8 @@ class StringLowerOpTest(test.TestCase):
     with self.cached_session() as sess:
       output = string_ops.string_lower(strings, encoding='utf-8')
       output = self.evaluate(output)
-      self.assertAllEqual(output, [[b"óósschloë"]]),
+      # output: "óósschloë"
+      self.assertAllEqual(output, [[b"\xc3\xb3\xc3\xb3sschlo\xc3\xab"]])
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/string_upper_op_test.py
+++ b/tensorflow/python/kernel_tests/string_upper_op_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,6 +43,13 @@ class StringUpperOpTest(test.TestCase):
       output = self.evaluate(output)
       self.assertAllEqual(output, [[b"PIGS ON THE WING", b"ANIMALS"],
                                    [b" HELLO ", b"\n\tWORLD! \r \n"]])
+
+  def test_string_upper_unicode(self):
+    strings = [["óósschloë"]]
+    with self.cached_session() as sess:
+      output = string_ops.string_upper(strings, encoding='utf-8')
+      output = self.evaluate(output)
+      self.assertAllEqual(output, [[b"ÓÓSSCHLOË"]]),
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/string_upper_op_test.py
+++ b/tensorflow/python/kernel_tests/string_upper_op_test.py
@@ -1,0 +1,48 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for string_upper_op."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.ops import string_ops
+from tensorflow.python.platform import test
+
+
+class StringUpperOpTest(test.TestCase):
+  """ Test cases for tf.strings.upper."""
+
+  def test_string_upper(self):
+    strings = ["Pigs on The Wing", "aNimals"]
+
+    with self.cached_session() as sess:
+      output = string_ops.string_upper(strings)
+      output = self.evaluate(output)
+      self.assertAllEqual(output, [b"PIGS ON THE WING", b"ANIMALS"])
+
+  def test_string_upper_2d(self):
+    strings = [["pigS on THE wIng", "aniMals"],
+               [" hello ", "\n\tWorld! \r \n"]]
+
+    with self.cached_session() as sess:
+      output = string_ops.string_upper(strings)
+      output = self.evaluate(output)
+      self.assertAllEqual(output, [[b"PIGS ON THE WING", b"ANIMALS"],
+                                   [b" HELLO ", b"\n\tWORLD! \r \n"]])
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/kernel_tests/string_upper_op_test.py
+++ b/tensorflow/python/kernel_tests/string_upper_op_test.py
@@ -49,7 +49,8 @@ class StringUpperOpTest(test.TestCase):
     with self.cached_session() as sess:
       output = string_ops.string_upper(strings, encoding='utf-8')
       output = self.evaluate(output)
-      self.assertAllEqual(output, [[b"ÓÓSSCHLOË"]]),
+      # output: "ÓÓSSCHLOË"
+      self.assertAllEqual(output, [[b"\xc3\x93\xc3\x93SSCHLO\xc3\x8b"]])
 
 
 if __name__ == "__main__":

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -3790,7 +3790,7 @@ tf_module {
   }
   member_method {
     name: "StringLower"
-    argspec: "args=[\'input\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'input\', \'encoding\', \'name\'], varargs=None, keywords=None, defaults=[\'\', \'None\'], "
   }
   member_method {
     name: "StringSplit"
@@ -3822,7 +3822,7 @@ tf_module {
   }
   member_method {
     name: "StringUpper"
-    argspec: "args=[\'input\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'input\', \'encoding\', \'name\'], varargs=None, keywords=None, defaults=[\'\', \'None\'], "
   }
   member_method {
     name: "Sub"

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -3789,6 +3789,10 @@ tf_module {
     argspec: "args=[\'input\', \'unit\', \'name\'], varargs=None, keywords=None, defaults=[\'BYTE\', \'None\'], "
   }
   member_method {
+    name: "StringLower"
+    argspec: "args=[\'input\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "StringSplit"
     argspec: "args=[\'input\', \'delimiter\', \'skip_empty\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'None\'], "
   }
@@ -3815,6 +3819,10 @@ tf_module {
   member_method {
     name: "StringToNumber"
     argspec: "args=[\'string_tensor\', \'out_type\', \'name\'], varargs=None, keywords=None, defaults=[\"<dtype: \'float32\'>\", \'None\'], "
+  }
+  member_method {
+    name: "StringUpper"
+    argspec: "args=[\'input\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "Sub"

--- a/tensorflow/tools/api/golden/v1/tensorflow.strings.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.strings.pbtxt
@@ -17,6 +17,10 @@ tf_module {
     argspec: "args=[\'input\', \'name\', \'unit\'], varargs=None, keywords=None, defaults=[\'None\', \'BYTE\'], "
   }
   member_method {
+    name: "lower"
+    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "reduce_join"
     argspec: "args=[\'inputs\', \'axis\', \'keep_dims\', \'separator\', \'name\', \'reduction_indices\', \'keepdims\'], varargs=None, keywords=None, defaults=[\'None\', \'False\', \'\', \'None\', \'None\', \'None\'], "
   }
@@ -83,5 +87,9 @@ tf_module {
   member_method {
     name: "unicode_transcode"
     argspec: "args=[\'input\', \'input_encoding\', \'output_encoding\', \'errors\', \'replacement_char\', \'replace_control_characters\', \'name\'], varargs=None, keywords=None, defaults=[\'replace\', \'65533\', \'False\', \'None\'], "
+  }
+  member_method {
+    name: "upper"
+    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
 }

--- a/tensorflow/tools/api/golden/v1/tensorflow.strings.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.strings.pbtxt
@@ -18,7 +18,7 @@ tf_module {
   }
   member_method {
     name: "lower"
-    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input\', \'encoding\', \'name\'], varargs=None, keywords=None, defaults=[\'\', \'None\'], "
   }
   member_method {
     name: "reduce_join"
@@ -90,6 +90,6 @@ tf_module {
   }
   member_method {
     name: "upper"
-    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input\', \'encoding\', \'name\'], varargs=None, keywords=None, defaults=[\'\', \'None\'], "
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -3790,7 +3790,7 @@ tf_module {
   }
   member_method {
     name: "StringLower"
-    argspec: "args=[\'input\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'input\', \'encoding\', \'name\'], varargs=None, keywords=None, defaults=[\'\', \'None\'], "
   }
   member_method {
     name: "StringSplit"
@@ -3822,7 +3822,7 @@ tf_module {
   }
   member_method {
     name: "StringUpper"
-    argspec: "args=[\'input\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'input\', \'encoding\', \'name\'], varargs=None, keywords=None, defaults=[\'\', \'None\'], "
   }
   member_method {
     name: "Sub"

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -3789,6 +3789,10 @@ tf_module {
     argspec: "args=[\'input\', \'unit\', \'name\'], varargs=None, keywords=None, defaults=[\'BYTE\', \'None\'], "
   }
   member_method {
+    name: "StringLower"
+    argspec: "args=[\'input\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "StringSplit"
     argspec: "args=[\'input\', \'delimiter\', \'skip_empty\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'None\'], "
   }
@@ -3815,6 +3819,10 @@ tf_module {
   member_method {
     name: "StringToNumber"
     argspec: "args=[\'string_tensor\', \'out_type\', \'name\'], varargs=None, keywords=None, defaults=[\"<dtype: \'float32\'>\", \'None\'], "
+  }
+  member_method {
+    name: "StringUpper"
+    argspec: "args=[\'input\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "Sub"

--- a/tensorflow/tools/api/golden/v2/tensorflow.strings.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.strings.pbtxt
@@ -18,7 +18,7 @@ tf_module {
   }
   member_method {
     name: "lower"
-    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input\', \'encoding\', \'name\'], varargs=None, keywords=None, defaults=[\'\', \'None\'], "
   }
   member_method {
     name: "reduce_join"
@@ -90,6 +90,6 @@ tf_module {
   }
   member_method {
     name: "upper"
-    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input\', \'encoding\', \'name\'], varargs=None, keywords=None, defaults=[\'\', \'None\'], "
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.strings.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.strings.pbtxt
@@ -17,6 +17,10 @@ tf_module {
     argspec: "args=[\'input\', \'unit\', \'name\'], varargs=None, keywords=None, defaults=[\'BYTE\', \'None\'], "
   }
   member_method {
+    name: "lower"
+    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "reduce_join"
     argspec: "args=[\'inputs\', \'axis\', \'keepdims\', \'separator\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'False\', \'\', \'None\'], "
   }
@@ -83,5 +87,9 @@ tf_module {
   member_method {
     name: "unicode_transcode"
     argspec: "args=[\'input\', \'input_encoding\', \'output_encoding\', \'errors\', \'replacement_char\', \'replace_control_characters\', \'name\'], varargs=None, keywords=None, defaults=[\'replace\', \'65533\', \'False\', \'None\'], "
+  }
+  member_method {
+    name: "upper"
+    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
 }


### PR DESCRIPTION
This fix tries to address the issue raised in #25857 where there is no lower() or upper() for string operations yet.

This fix adds StringLower/StringUpper to the kernel to support this op.

The endpoints are exposed as `strings.lower` and `strings.upper`.

This fix fixes #25857.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>