### PR TITLE
Fix endpoint of string_split

### DIFF
--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -192,7 +192,7 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
                                       name=name)
 
 
-@tf_export("string_split")
+@tf_export(v1=["string_split"])
 def string_split(source, delimiter=" ", skip_empty=True):  # pylint: disable=invalid-name
   """Split elements of `source` based on `delimiter` into a `SparseTensor`.
 

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -989,10 +989,6 @@ tf_module {
     argspec: "args=[\'input_\', \'begin\', \'end\', \'strides\', \'begin_mask\', \'end_mask\', \'ellipsis_mask\', \'new_axis_mask\', \'shrink_axis_mask\', \'var\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'0\', \'0\', \'0\', \'0\', \'None\', \'None\'], "
   }
   member_method {
-    name: "string_split"
-    argspec: "args=[\'source\', \'delimiter\', \'skip_empty\'], varargs=None, keywords=None, defaults=[\' \', \'True\'], "
-  }
-  member_method {
     name: "subtract"
     argspec: "args=[\'x\', \'y\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/compatibility/tf_upgrade_v2.py
+++ b/tensorflow/tools/compatibility/tf_upgrade_v2.py
@@ -790,6 +790,8 @@ class TFAPIChangeSpec(ast_edits.APIChangeSpec):
             "tf.nn.conv2d_transpose",
         "tf.test.compute_gradient":
             "tf.compat.v1.test.compute_gradient",
+        "tf.string_split":
+            "tf.compat.v1.string_split",
     }
     # pylint: enable=line-too-long
 


### PR DESCRIPTION
It looks like at the moment, `string_split` is expose as `@tf_export("string_split")` which supports both v1 and v2.

And `string_split_v2` is exposed as `@tf_export("strings.split")` which support both v1 and v2 as well.

I think it makes sense to expose `@tf_export("strings.split")` in v1 and v2 for
`string_split_v2`.

But `@tf_export("string_split")` should really be v1 only.

This fix changes `@tf_export("string_split")` to `@tf_export(v1=["string_split"])`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>