### PR TITLE
fix absl import issue #25282

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -48,7 +48,7 @@ DOCLINES = __doc__.split('\n')
 _VERSION = '1.12.0'
 
 REQUIRED_PACKAGES = [
-    'absl-py >= 0.1.6',
+    'absl-py >= 0.7.0',
     'astor >= 0.6.0',
     'gast >= 0.2.0',
     'google_pasta >= 0.1.1',


### PR DESCRIPTION
fix issue when using:

```
from tensorflow.python.platform.googletest import mock
```
there is code in `tensorflow/python/platform/googletest.py`

```
from absl.testing.absltest import *
```
but absl.testing.absltest have `mock` object after absl>=0.4.0

this case is occur after commit 87cc788e1cc
@revan 
87cc788e1cc (Revan Sopher           2019-01-23 13:14:20 -0800

https://github.com/tensorflow/tensorflow/issues/25282