### PR TITLE
Remove duplicated LD_LIBRARY_PATH in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ There are two ways to run TensorFlow unit tests.
     the `cuda` option flag
 
     ```bash
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH"
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
 
     export flags="--config=opt --config=cuda -k"
     ```


### PR DESCRIPTION
non-functional, fixing a readme typo.