### PR TITLE
Lite: Sparse_to_dense Operator performance improvement

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/reference_ops.h
+++ b/tensorflow/lite/kernels/internal/reference/reference_ops.h
@@ -4400,7 +4400,7 @@ void SelectTrueCoords(const RuntimeShape& input_condition_shape,
 }
 
 template <typename T, typename TI>
-inline void SparseToDense(const TI* indices, const int num_indices,
+inline void SparseToDense(std::unique_ptr<TI[]>& indices, const int num_indices,
                           const int true_dim, const T* values, T default_value,
                           bool value_is_scalar,
                           const RuntimeShape& unextended_output_shape,

--- a/tensorflow/lite/kernels/sparse_to_dense.cc
+++ b/tensorflow/lite/kernels/sparse_to_dense.cc
@@ -85,7 +85,8 @@ TfLiteStatus CheckDimensionsMatch(TfLiteContext* context,
 template <typename T>
 TfLiteStatus GetIndicesVector(TfLiteContext* context,
                               const TfLiteTensor* indices,
-                              const int num_indices, T* indices_vector) {
+                              const int num_indices,
+                              std::unique_ptr<T[]>& indices_vector) {
   switch (NumDimensions(indices)) {
     case 0:
     case 1: {
@@ -193,7 +194,7 @@ TfLiteStatus SparseToDenseImpl(TfLiteContext* context, TfLiteNode* node) {
   const int true_dim =
       NumDimensions(indices) == 2 ? SizeOfDimension(indices, 1) : 1;
   const bool value_is_scalar = NumDimensions(values) == 0;
-  TI* indices_vector = (TI*)malloc(num_indices * true_dim * sizeof(TI));
+  auto indices_vector = std::unique_ptr<TI[]>(new TI[num_indices * true_dim]);
   TF_LITE_ENSURE_OK(context, GetIndicesVector<TI>(context, indices, num_indices,
                                                   indices_vector));
   reference_ops::SparseToDense(
@@ -201,7 +202,6 @@ TfLiteStatus SparseToDenseImpl(TfLiteContext* context, TfLiteNode* node) {
       *GetTensorData<T>(default_value), value_is_scalar, GetTensorShape(output),
       GetTensorData<T>(output));
 
-  free(indices_vector);
   return kTfLiteOk;
 }
 

--- a/tensorflow/lite/kernels/sparse_to_dense_test.cc
+++ b/tensorflow/lite/kernels/sparse_to_dense_test.cc
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <cstdarg>
 #include <gtest/gtest.h>
+#include <cstdarg>
 #include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/kernels/register.h"
 #include "tensorflow/lite/kernels/test_util.h"
@@ -62,8 +62,8 @@ class SparseToDenseOpModel : public SingleOpModel {
   int output_;
 };
 
-TEST(SparseToDenseOpModelTest, ZeroDimensionTest) {
-  SparseToDenseOpModel<float> m({1}, {1}, {1}, 0, TensorType_INT32,
+TEST(SparseToDenseOpModelTest, ValueZeroDimIndicesZeroDimTest) {
+  SparseToDenseOpModel<float> m({}, {1}, {}, 0, TensorType_INT32,
                                 TensorType_FLOAT32);
   m.PopulateTensor<int32_t>(m.indices(), {3});
   m.PopulateTensor<int32_t>(m.output_shape(), {5});
@@ -72,6 +72,32 @@ TEST(SparseToDenseOpModelTest, ZeroDimensionTest) {
 
   EXPECT_THAT(m.GetOutput(), ElementsAreArray({0, 0, 0, 7, 0}));
   EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({5}));
+}
+
+TEST(SparseToDenseOpModelTest, ValueZeroDimIndicesOneDimTest) {
+  SparseToDenseOpModel<float> m({2}, {1}, {}, 0, TensorType_INT32,
+                                TensorType_FLOAT32);
+  m.PopulateTensor<int32_t>(m.indices(), {3, 4});
+  m.PopulateTensor<int32_t>(m.output_shape(), {5});
+  m.PopulateTensor<float>(m.values(), {9});
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({0, 0, 0, 9, 9}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({5}));
+}
+
+TEST(SparseToDenseOpModelTest, ValueZeroDimIndicesTwoDimTest) {
+  SparseToDenseOpModel<float> m({3, 3}, {3}, {}, 0, TensorType_INT32,
+                                TensorType_FLOAT32);
+  m.PopulateTensor<int32_t>(m.indices(), {0, 0, 0, 1, 2, 1, 2, 0, 1});
+  m.PopulateTensor<int32_t>(m.output_shape(), {3, 3, 3});
+  m.PopulateTensor<float>(m.values(), {3});
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 3, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({3, 3, 3}));
 }
 
 TEST(SparseToDenseOpModelTest, OneDimensionTest) {


### PR DESCRIPTION
1:> Code Optimized for performance, remove unnecessary std::vector usage
2:> Removed hard coding or bottleneck to 4-Dim
3:> Bug fix in wrong error condition
4:> New Test cases added for uncovered scenarios
5:> Bug fix for num_indices fetch for 0-Dim Indices