### PR TITLE
TF Lite micro_speech package test build error fix

### DIFF
--- a/tensorflow/lite/experimental/micro/testing/micro_test.bzl
+++ b/tensorflow/lite/experimental/micro/testing/micro_test.bzl
@@ -8,7 +8,7 @@ def tflite_micro_cc_test(
         defines = [],
         copts = [],
         nocopts = "",
-        linkopts = [],
+        linkopts = ["-lm"],
         deps = [],
         tags = [],
         visibility = None):


### PR DESCRIPTION
Test micro_speech package run encounter "undefined reference to symbol 'floor@@GLIBC_2.2.5'", this PR solve the problem.