### PR TITLE
TF Lite lstm.cc warnings fix

### DIFF
--- a/tensorflow/lite/kernels/lstm.cc
+++ b/tensorflow/lite/kernels/lstm.cc
@@ -841,6 +841,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
     case kTfLiteLSTMBasicKernel:
       return basic::Init(context, buffer, length);
   }
+  return nullptr;
 }
 void Free(TfLiteContext* context, void* buffer) {
   gemm_support::DecrementUsageCounter(context);
@@ -856,6 +857,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteLSTMBasicKernel:
       return basic::Prepare(context, node);
   }
+  return kTfLiteError;
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
@@ -866,6 +868,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteLSTMBasicKernel:
       return basic::Eval(context, node);
   }
+  return kTfLiteError;
 }
 
 }  // namespace lstm


### PR DESCRIPTION
Warning[warning: control reaches end of non-void function] fix.