### PR TITLE
TFTRT: Don't allow empty tensors

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -192,6 +192,15 @@ Status ValidateTensorProperties(const string& producer_node_type,
   *trt_dims = TensorShapeToTrtDims(shape, /*ignore_first_dim=*/true);
   *batch_size = shape.dim_size(0);
 
+  // Don't convert empty tensors (dim value of 0).
+  for (int d = 1; d < shape.dims(); ++d) {
+    if (shape.dim_size(d) == 0) {
+      return errors::Unimplemented(
+          "Input tensor with shape ", shape.DebugString(),
+          " is an empty tensor, which is not supported by TRT");
+    }
+  }
+
   if (validation_only) return Status::OK();
   // Following are validations at runtime.
 


### PR DESCRIPTION
Tensorflow allows "empty tensors", which have shapes that look like `[128, 0, 512]`. These can be created by a `tf.where(x)` in the case that only False is present in `x`. Since TRT doesn't appear to support anything like this, we don't allow tensors with a dim size of 0 to convert.