### PR TITLE
Fix #24818 by updating linalg_ops.py

### DIFF
--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -335,7 +335,7 @@ def self_adjoint_eigvals(tensor, name=None):
   """Computes the eigenvalues of one or more self-adjoint matrices.
 
   Note: If your program backpropagates through this function, you should replace
-  it with a call to tf.linalg.eigvalsh (possibly ignoring the second output) to
+  it with a call to tf.linalg.eigh (possibly ignoring the second output) to
   avoid computing the eigen decomposition twice. This is because the
   eigenvectors are used to compute the gradient w.r.t. the eigenvalues. See
   _SelfAdjointEigV2Grad in linalg_grad.py.


### PR DESCRIPTION
Fix #24818 by replacing the circular reference to `tf.linalg.eigvalsh`  with `tf.linalg.eigh`  [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/linalg_ops.py#L338) which also returns two outputs.
I believe that `tf.linalg.eigh` is the correct equivalent to resolve:
1. Circular Reference
2. Two outputs instead of one output, highlighted as "(possibly ignoring the second output)" in [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/linalg_ops.py#L338)