### PR TITLE
"Issue #22387: Compilation Error MSVC 2017"

### DIFF
--- a/tensorflow/core/framework/op_kernel.h
+++ b/tensorflow/core/framework/op_kernel.h
@@ -431,7 +431,7 @@ class OpArgIterator {
     return old_value;
   }
 
-  reference operator*() { return (*list_)[i_]; }
+  reference operator*() const { return (*list_)[i_]; }
   pointer operator->() { return &(*list_)[i_]; }
 
   const_reference operator*() const { return (*list_)[i_]; }


### PR DESCRIPTION
Added const specifier in op_kernel.h for compilation to go through on Microsoft Visual Studio 2017. See https://github.com/tensorflow/tensorflow/issues/22387
