### PR TITLE
Fix warning eigen_spatial_convolutions.h

### DIFF
--- a/tensorflow/core/kernels/eigen_spatial_convolutions.h
+++ b/tensorflow/core/kernels/eigen_spatial_convolutions.h
@@ -832,7 +832,7 @@ struct gemm_pack_rhs<
   typedef SubMapper DataMapper;
   typedef typename packet_traits<Scalar>::type Packet;
 
-  EIGEN_STATIC_ASSERT((nr == 4), YOU_MADE_A_PROGRAMMING_MISTAKE);
+  EIGEN_STATIC_ASSERT((nr == 4), YOU_MADE_A_PROGRAMMING_MISTAKE)
 
   EIGEN_DEVICE_FUNC
   EIGEN_DONT_INLINE void operator()(Scalar* block, const DataMapper& rhs,
@@ -1039,7 +1039,7 @@ struct gemm_pack_rhs<
   typedef SubMapper DataMapper;
   typedef typename packet_traits<Scalar>::type Packet;
 
-  EIGEN_STATIC_ASSERT((nr == 4), YOU_MADE_A_PROGRAMMING_MISTAKE);
+  EIGEN_STATIC_ASSERT((nr == 4), YOU_MADE_A_PROGRAMMING_MISTAKE)
 
   EIGEN_DEVICE_FUNC
   EIGEN_DONT_INLINE void operator()(Scalar* block, const DataMapper& rhs,
@@ -1254,7 +1254,7 @@ struct gemm_pack_rhs<
       SubMapper;
   typedef SubMapper DataMapper;
 
-  EIGEN_STATIC_ASSERT((nr == 4), YOU_MADE_A_PROGRAMMING_MISTAKE);
+  EIGEN_STATIC_ASSERT((nr == 4), YOU_MADE_A_PROGRAMMING_MISTAKE)
 
   EIGEN_DEVICE_FUNC
   EIGEN_DONT_INLINE void operator()(Scalar* block, const DataMapper& rhs,
@@ -1583,7 +1583,7 @@ EIGEN_DEVICE_FUNC
 
   EIGEN_STATIC_ASSERT(
       internal::traits<Input>::Layout == internal::traits<Kernel>::Layout,
-      YOU_MADE_A_PROGRAMMING_MISTAKE);
+      YOU_MADE_A_PROGRAMMING_MISTAKE)
   const bool isColMajor = (internal::traits<Input>::Layout == ColMajor);
 
   const int NumDims = internal::traits<Input>::NumDimensions;


### PR DESCRIPTION
Fixed warning due to extra semicolon
./tensorflow/core/kernels/eigen_spatial_convolutions.h(835): warning: extra ";" ignored
./tensorflow/core/kernels/eigen_spatial_convolutions.h(1042): warning: extra ";" ignored
./tensorflow/core/kernels/eigen_spatial_convolutions.h(1257): warning: extra ";" ignored
