### PR TITLE
Warning fix split_handler_ops.cc

### DIFF
--- a/tensorflow/contrib/boosted_trees/kernels/split_handler_ops.cc
+++ b/tensorflow/contrib/boosted_trees/kernels/split_handler_ops.cc
@@ -538,7 +538,6 @@ class BuildSparseInequalitySplitsOp : public OpKernel {
           partition_boundaries[non_empty_partitions[root_idx]];
 
       float best_gain = std::numeric_limits<float>::lowest();
-      int32 best_dimension_idx = 0;
       bool default_right = false;
       int32 best_element_idx = 0;
 
@@ -571,8 +570,6 @@ class BuildSparseInequalitySplitsOp : public OpKernel {
       // Iterate through dimensions.
       for (int j = 0; j < dimension_boundaries.size() - 1; ++j) {
         const DimensionBoundary& dimension_and_start = dimension_boundaries[j];
-        const int32 dimension_id = dimension_and_start.dimension_id;
-
         int start_index = dimension_and_start.start_index;
         // Even for the last dimension, we always have additional dummy
         // dimension that we can use to find the end index.
@@ -630,7 +627,6 @@ class BuildSparseInequalitySplitsOp : public OpKernel {
               best_right_node_stats = right_stats_default_left;
               best_element_idx = element_idx;
               default_right = false;
-              best_dimension_idx = dimension_id;
             }
           }
           // Consider calculating the default direction only when there were
@@ -648,7 +644,6 @@ class BuildSparseInequalitySplitsOp : public OpKernel {
               best_right_node_stats = right_stats_default_right;
               best_element_idx = element_idx;
               default_right = true;
-              best_dimension_idx = dimension_id;
             }
           }
         }


### PR DESCRIPTION
Warning fix:
tensorflow/contrib/boosted_trees/kernels/split_handler_ops.cc:541:13: warning: variable 'best_dimension_idx' set but not used [-Wunused-but-set-variable]
tensorflow/contrib/boosted_trees/kernels/split_handler_ops.cc:573:21: warning: unused variable 'dimension_id' [-Wunused-variable]