### PR TITLE
Fix for future incompatible changes in Bazel

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1357,7 +1357,7 @@ def _py_wrap_cc_impl(ctx):
     args += ["-I" + i for i in swig_include_dirs.to_list()]
     args += [src.path]
     outputs = [ctx.outputs.cc_out, ctx.outputs.py_out]
-    ctx.action(
+    ctx.actions.run(
         executable = ctx.executable._swig,
         arguments = args,
         inputs = inputs.to_list(),
@@ -1655,8 +1655,7 @@ _append_init_to_versionscript = rule(
     attrs = {
         "module_name": attr.string(mandatory = True),
         "template_file": attr.label(
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "is_version_script": attr.bool(

--- a/third_party/common.bzl
+++ b/third_party/common.bzl
@@ -21,7 +21,7 @@
 #   substitutions: A dictionary mapping strings to their substitutions
 
 def template_rule_impl(ctx):
-    ctx.template_action(
+    ctx.actions.expand_template(
         template = ctx.file.src,
         output = ctx.outputs.out,
         substitutions = ctx.attr.substitutions,
@@ -31,8 +31,7 @@ template_rule = rule(
     attrs = {
         "src": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "substitutions": attr.string_dict(mandatory = True),
         "out": attr.output(mandatory = True),

--- a/third_party/systemlibs/protobuf.bzl
+++ b/third_party/systemlibs/protobuf.bzl
@@ -107,7 +107,7 @@ def _proto_gen_impl(ctx):
         inputs += [plugin]
 
     if args:
-        ctx.action(
+        ctx.actions.run(
             inputs = inputs,
             outputs = ctx.outputs.outs,
             arguments = args + import_flags + [s.path for s in srcs],
@@ -132,7 +132,7 @@ proto_gen = rule(
         "protoc": attr.label(
             cfg = "host",
             executable = True,
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "plugin": attr.label(


### PR DESCRIPTION
Certain API methods in Bazel are being deprecated:

  * `ctx.action()` -> `ctx.actions.run()`
  * `attr.label(allow_files = True, single_file = True)` -> `attr.label(allow_single_file = True)`
  * `ctx.template_action()` -> `ctx.actions.expand_template()`

The PR is created by `find -name *.bzl | xargs buildifier --lint=fix --warnings=attr-non-empty,attr-single-file,ctx-actions,output-group`