### PR TITLE
Update Go test documentation to include all required library files

### DIFF
--- a/tensorflow/go/README.md
+++ b/tensorflow/go/README.md
@@ -49,12 +49,13 @@ from source.
 
     This can take a while (tens of minutes, more if also building for GPU).
 
-3.  Make `libtensorflow.so` available to the linker. This can be done by either:
+3.  Make `libtensorflow.so` and `libtensorflow_framework.so` available to the linker. This can be done by either:
 
     a. Copying it to a system location, e.g.,
 
     ```sh
     sudo cp ${GOPATH}/src/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/libtensorflow.so /usr/local/lib
+    sudo cp ${GOPATH}/src/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/libtensorflow_framework.so /usr/local/lib
     ```
 
     OR


### PR DESCRIPTION
The README for running the Go tests includes instructions for installing `libtensorflow.so` but does not mention that `libtensorflow_framework.so` is also required. This PR adds a note about this in prose and updates the command to explicitly install this shared object file.

I would note that the `cp` command that I added could be combined into a single `cp` command with a wildcard. I left them separate for now to further illustrate that both files are needed but I'm happy to update the commands if that would be desirable.