### PR TITLE
Preserve run_metadata when session run fails.

### DIFF
--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -673,6 +673,9 @@ Status DirectSession::RunInternal(int64 step_id, const RunOptions& run_options,
 
   {
     mutex_lock l(run_state.mu_);
+    if (!run_state.status.ok() && run_state.collector) {
+      run_state.collector->Finalize();
+    }
     TF_RETURN_IF_ERROR(run_state.status);
   }
 

--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -933,6 +933,9 @@ class BaseSession(SessionInterface):
         run_metadata.ParseFromString(compat.as_bytes(proto_data))
     finally:
       if run_metadata_ptr:
+        if run_metadata_ptr.length > 0:
+          proto_data = tf_session.TF_GetBuffer(run_metadata_ptr)
+          run_metadata.ParseFromString(compat.as_bytes(proto_data))
         tf_session.TF_DeleteBuffer(run_metadata_ptr)
       if options:
         tf_session.TF_DeleteBuffer(options_ptr)


### PR DESCRIPTION
Fixes #25990 