### PR TITLE
Replace special quotation marks from generated java class Ops.java to prevent encoding errors when compiling for windows.

### DIFF
--- a/tensorflow/java/src/gen/java/org/tensorflow/processor/OperatorProcessor.java
+++ b/tensorflow/java/src/gen/java/org/tensorflow/processor/OperatorProcessor.java
@@ -357,10 +357,10 @@ public final class OperatorProcessor extends AbstractProcessor {
                     + "  // Optional attributes\n"
                     + "  ops.math().matMul(a, b, MatMul.transposeA(true));\n"
                     + "  // Naming operators\n"
-                    + "  ops.withName(“foo”).constant(5); // name “foo”\n"
+                    + "  ops.withName(\"foo\").constant(5); // name \"foo\"\n"
                     + "  // Names can exist in a hierarchy\n"
-                    + "  Ops sub = ops.withSubScope(“sub”);\n"
-                    + "  sub.withName(“bar”).constant(4); // “sub/bar”\n"
+                    + "  Ops sub = ops.withSubScope(\"sub\");\n"
+                    + "  sub.withName(\"bar\").constant(4); // \"sub/bar\"\n"
                     + "}\n"
                     + "}</pre>\n",
                 T_GRAPH,


### PR DESCRIPTION
When compiling the tensorflow java api for windows, I experienced the encoding errors shown below. This seems to be caused by the annotation processor using the system's default encoding but for the compilation UTF-8 is assumed.

I found that only the special quotation marks used the javadoc generated for the Ops.java class cause this issue. They seem to be the only non-ascii characters. Therefore replacing them with standard escaped quotation marks fixes this issue.

The error message received when compiling on Windows 10 64 bit & Oracle JDK 1.8u201.
```
bazel --output_base=C:\tools\bazel\output build --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8 --config=opt //tensorflow/java:tensorflow //tensorflow/java:libtensorflow_jni
WARNING: The following rc files are no longer being read, please transfer their contents or import their path into one of the standard rc files:
d:\development\arconsis\dekra\dekra-pixelation\tensorflow/.bazelrc
WARNING: Option 'experimental_shortened_obj_file_path' is deprecated
INFO: Invocation ID: 7fe5ce06-9aec-4c38-baa3-f59aa598d508
WARNING: D:/development/arconsis/dekra/dekra-pixelation/tensorflow/tensorflow/java/BUILD:73:1: in genrule rule //tensorflow/java:java_op_gen_sources: target '//tensorflow/java:java_op_gen_sources' depends on deprecated target '@local_jdk//:jar': Don't depend on targets in the JDK workspace; use @bazel_tools//tools/jdk:current_java_runtime instead (see https://github.com/bazelbuild/bazel/issues/5594)
INFO: Analysed 2 targets (0 packages loaded, 0 targets configured).
INFO: Found 2 targets...
ERROR: D:/development/arconsis/dekra/dekra-pixelation/tensorflow/tensorflow/java/BUILD:20:1: Building tensorflow/java/libtensorflow.jar (27 source files, 1 source jar) and running annotation processors (OperatorProcessor) failed (Exit 1): java.exe failed: error executing command
  cd C:/tools/bazel/output/execroot/org_tensorflow
  SET LC_CTYPE=en_US.UTF-8
    SET PATH=C:\tools\msys2-64\usr\bin;C:\tools\msys2-64\bin
    SET PYTHON_BIN_PATH=D:/programs/python3.5/python3.exe
    SET PYTHON_LIB_PATH=D:/programs/python3.5/lib/site-packages
    SET TF_DOWNLOAD_CLANG=0
    SET TF_NEED_CUDA=0
    SET TF_NEED_OPENCL_SYCL=0
    SET TF_NEED_ROCM=0
  external/local_jdk/bin/java.exe -Xverify:none -Xbootclasspath/p:external/bazel_tools/third_party/java/jdk/langtools/javac-9+181-r4173-1.jar -jar external/bazel_tools/tools/jdk/JavaBuilder_deploy.jar @bazel-out/x64_windows-opt/bin/tensorflow/java/libtensorflow.jar-0.params
Execution platform: @bazel_tools//platforms:host_platform
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:782: error: unmappable character (0x93) for encoding UTF-8
 *   ops.withName(´┐¢foo´┐¢).constant(5); // name ´┐¢foo´┐¢
                  ^
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:782: error: unmappable character (0x94) for encoding UTF-8
 *   ops.withName(´┐¢foo´┐¢).constant(5); // name ´┐¢foo´┐¢
                      ^
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:782: error: unmappable character (0x93) for encoding UTF-8
 *   ops.withName(´┐¢foo´┐¢).constant(5); // name ´┐¢foo´┐¢
                                              ^
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:782: error: unmappable character (0x94) for encoding UTF-8
 *   ops.withName(´┐¢foo´┐¢).constant(5); // name ´┐¢foo´┐¢
                                                  ^
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:784: error: unmappable character (0x93) for encoding UTF-8
 *   Ops sub = ops.withSubScope(´┐¢sub´┐¢);
                                ^
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:784: error: unmappable character (0x94) for encoding UTF-8
 *   Ops sub = ops.withSubScope(´┐¢sub´┐¢);
                                    ^
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:785: error: unmappable character (0x93) for encoding UTF-8
 *   sub.withName(´┐¢bar´┐¢).constant(4); // ´┐¢sub/bar´┐¢
                  ^
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:785: error: unmappable character (0x94) for encoding UTF-8
 *   sub.withName(´┐¢bar´┐¢).constant(4); // ´┐¢sub/bar´┐¢
                      ^
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:785: error: unmappable character (0x93) for encoding UTF-8
 *   sub.withName(´┐¢bar´┐¢).constant(4); // ´┐¢sub/bar´┐¢
                                         ^
bazel-out\x64_windows-opt\bin\tensorflow\java\_javac\tensorflow\libtensorflow_sourcegenfiles\org\tensorflow\op\Ops.java:785: error: unmappable character (0x94) for encoding UTF-8
 *   sub.withName(´┐¢bar´┐¢).constant(4); // ´┐¢sub/bar´┐¢
                                                 ^
INFO: Elapsed time: 12,228s, Critical Path: 2,49s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
```