### PR TITLE
modified the documentation of tf.math.add and tf.math.acos operations

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
@@ -5,6 +5,9 @@ op {
 The `tf.math.acos` operation returns the inverse of `tf.math.cos`, such that
 if `y = tf.math.cos(x)` then, `x = tf.math.acos(y)`.
 
+**Note**: The output of `tf.math.acos` will lie within the invertible range
+of cosine, i.e [0, pi].
+
 For example:
 
 ```python

--- a/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
@@ -1,6 +1,6 @@
 op {
   graph_op_name: "Acos"
-  summary: "Computes acos of x element-wise."
+  summary: "Computes the trignometric inverse cosine of x element-wise."
   description: <<END
 The `tf.math.acos` operation returns the inverse of `tf.math.cos`, such that
 if `y = tf.math.cos(x)` then, `x = tf.math.acos(y)`.
@@ -8,11 +8,11 @@ if `y = tf.math.cos(x)` then, `x = tf.math.acos(y)`.
 For example:
 
 ```python
-# [1.047, 0.785] ~= [(pi/3), (pi/4)]
-a = tf.constant([1.047, 0.785])
-b = tf.math.cos(a)
+# Note: [1.047, 0.785] ~= [(pi/3), (pi/4)]
+x = tf.constant([1.047, 0.785])
+y = tf.math.sin(x) # [0.500171, 0.7073882]
 
-tf.math.acos(b)  # [1.047, 0.785] = a
+tf.math.asin(y) # [1.047, 0.785] = x
 ```
 
 END

--- a/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
@@ -8,11 +8,11 @@ if `y = tf.math.cos(x)` then, `x = tf.math.acos(y)`.
 For example:
 
 ```python
-# [1.047, 0.785] roughly means [(pi/3), (pi/4)]
+# [1.047, 0.785] ~= [(pi/3), (pi/4)]
 a = tf.constant([1.047, 0.785])
-b = tf.math.cos(a) # ~= [0.500171, 0.7073882]
+b = tf.math.cos(a)
 
-tf.math.acos(b) ~= [1.047, 0.785] => a
+tf.math.acos(b)  # [1.047, 0.785] = a
 ```
 
 END

--- a/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
@@ -1,4 +1,19 @@
 op {
   graph_op_name: "Acos"
   summary: "Computes acos of x element-wise."
+  description: <<END
+The `tf.math.acos` operation returns the inverse of `tf.math.cos`, such that
+if `y = tf.math.cos(x)` then, `x = tf.math.acos(y)`.
+
+For example:
+
+```
+# [1.047, 0.785] roughly means [(pi/3), (pi/4)]
+a = tf.constant([1.047, 0.785])
+b = tf.math.cos(a) # ~= [0.500171, 0.7073882]
+
+tf.math.acos(b) ~= [1.047, 0.785] => a
+```
+
+END
 }

--- a/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Acos.pbtxt
@@ -7,7 +7,7 @@ if `y = tf.math.cos(x)` then, `x = tf.math.acos(y)`.
 
 For example:
 
-```
+```python
 # [1.047, 0.785] roughly means [(pi/3), (pi/4)]
 a = tf.constant([1.047, 0.785])
 b = tf.math.cos(a) # ~= [0.500171, 0.7073882]

--- a/tensorflow/core/api_def/base_api/api_def_Add.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Add.pbtxt
@@ -4,5 +4,20 @@ op {
   description: <<END
 *NOTE*: `Add` supports broadcasting. `AddN` does not. More about broadcasting
 [here](http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html)
+
+For example:
+
+```
+# x and y are rank 3 tensors of shape (2, 2, 2)
+x = tf.constant([[[1, 2], [3, 4]],
+                 [[5, 6], [7, 8]]])
+
+y = tf.constant([[[8, 7], [6, 5]],
+                 [[4, 3], [2, 1]]])
+
+tf.add(x, y) ==> [[[9, 9], [9, 9]],
+                  [[9, 9], [9, 9]]]
+```
+
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_Add.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Add.pbtxt
@@ -7,7 +7,7 @@ op {
 
 For example:
 
-```
+```python
 # x and y are rank 3 tensors of shape (2, 2, 2)
 x = tf.constant([[[1, 2], [3, 4]],
                  [[5, 6], [7, 8]]])


### PR DESCRIPTION
A Pull Request for issues #25802   and #25846 . I have tried to improve the documentation of `tf.math.acos` and `tf.math.add` with this patch. I did this by editing the files `api_def_Acos.pbtxt` and `api_def_Add.pbtxt` and by modelling them after the `api_def_Angle.pbtxt` file within the `tensorflow/tensorflow/core/api_def/base_api` directory. The changes I made were reflected in the generated file `python/ops/gen_math_ops.py`. The `gen_math_ops.py` file was generated by following [these](https://www.tensorflow.org/community/documentation#api_documentation) instructions. 

This is my first time editing a piece of documentation which is created from a generated file, and so it may not be perfect. Please feel free to point out any errors that I may have made, and I'll be happy to work on them.