### PR TITLE
[ROCm] Adding scratch_size field to dnn::AlgorithmDesc

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/backend_configs.proto
+++ b/tensorflow/compiler/xla/service/gpu/backend_configs.proto
@@ -38,4 +38,8 @@ message CudnnConvBackendConfig {
   // The scaling factor multiplied with the side input. If no side input buffer
   // is provided, this field must be 0.
   double side_input_scale = 5;
+
+  // The amount of scratch memory size required by the algorithm to do this
+  // convolution
+  uint64 scratch_size = 6;
 }

--- a/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.h
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_CUDNN_CONV_RUNNER_H_
 
 #include "absl/types/optional.h"
+#include "tensorflow/compiler/xla/service/gpu/ir_emission_utils.h"
 #include "tensorflow/compiler/xla/service/hlo_instruction.h"
 #include "tensorflow/compiler/xla/service/hlo_instructions.h"
 #include "tensorflow/compiler/xla/status.h"
@@ -35,6 +36,21 @@ struct RunConvOptions {
   // Use this algorithm, instead of the one from the instruction.
   absl::optional<se::dnn::AlgorithmDesc> algo_override;
 };
+
+struct CudnnConvDescriptors {
+  se::dnn::DataType element_type;
+  se::dnn::BatchDescriptor input;
+  se::dnn::FilterDescriptor filter;
+  se::dnn::ConvolutionDescriptor conv;
+  se::dnn::BatchDescriptor output;
+};
+
+// Returns the cudnn convolution descriptors generated from conv, which must be
+// a custom-call to a cudnn convolution.
+StatusOr<CudnnConvDescriptors> GetCudnnConvDescriptors(
+    const HloCustomCallInstruction* conv,
+    absl::Span<se::DeviceMemoryBase> operand_buffers,
+    se::DeviceMemoryBase result_buffer);
 
 // This file contains low-level routines for running cudnn convolutions.
 

--- a/tensorflow/contrib/fused_conv/kernels/fused_conv2d_bias_activation_op.cc
+++ b/tensorflow/contrib/fused_conv/kernels/fused_conv2d_bias_activation_op.cc
@@ -696,7 +696,8 @@ void LaunchFusedConv2DBiasActivationOp<GPUDevice, T, BiasType, ScaleType>::
     CHECK(stream->parent()->GetConvolveAlgorithms(
         fused_conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
             stream->parent()),
-        &algorithms));
+        stream, dnn::ToDataType<T>::value, conv_input_desc, filter_desc,
+        conv_desc, output_desc, &algorithms));
     if (activation_mode == ActivationMode::NONE) {
       // Only CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM is supported for
       // identity activation, other algs seem to quietly do Relu.

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -842,7 +842,8 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
     std::vector<AlgorithmDesc> algorithms;
     CHECK(stream->parent()->GetConvolveBackwardFilterAlgorithms(
         conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(stream->parent()),
-        &algorithms));
+        stream, se::dnn::ToDataType<T>::value, input_desc, filter_desc,
+        conv_desc, output_desc, &algorithms));
     std::vector<tensorflow::AutotuneResult> results;
     for (auto profile_algorithm : algorithms) {
       // TODO(zhengxq): profile each algorithm multiple times to better

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -954,7 +954,8 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
     std::vector<AlgorithmDesc> algorithms;
     CHECK(stream->parent()->GetConvolveBackwardDataAlgorithms(
         conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(stream->parent()),
-        &algorithms));
+        stream, se::dnn::ToDataType<T>::value, input_desc, filter_desc,
+        conv_desc, output_desc, &algorithms));
     std::vector<tensorflow::AutotuneResult> results;
     for (auto profile_algorithm : algorithms) {
       // TODO(zhengxq): profile each algorithm multiple times to better

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1361,7 +1361,8 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
       CHECK(stream->parent()->GetConvolveBackwardDataAlgorithms(
           conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
               stream->parent()),
-          &algorithms));
+          stream, se::dnn::ToDataType<T>::value, input_desc, filter_desc,
+          conv_desc, output_desc, &algorithms));
       ProfileResult best_result;
       ProfileResult best_result_no_scratch;
       for (auto profile_algorithm : algorithms) {
@@ -1767,7 +1768,8 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
       CHECK(stream->parent()->GetConvolveBackwardFilterAlgorithms(
           conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
               stream->parent()),
-          &algorithms));
+          stream, se::dnn::ToDataType<T>::value, input_desc, filter_desc,
+          conv_desc, output_desc, &algorithms));
       ProfileResult best_result;
       ProfileResult best_result_no_scratch;
       for (auto profile_algorithm : algorithms) {

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -849,11 +849,11 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
       !AutoTuneConv::GetInstance()->Find(conv_parameters, &algorithm_config)) {
     std::vector<AlgorithmDesc> algorithms;
     OP_REQUIRES(
-        ctx,
-        stream->parent()->GetConvolveAlgorithms(
-            conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
-                stream->parent()),
-            &algorithms),
+        ctx, stream->parent()->GetConvolveAlgorithms(
+                 conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
+                     stream->parent()),
+                 stream, se::dnn::ToDataType<T>::value, input_desc, filter_desc,
+                 conv_desc, output_desc, &algorithms),
         errors::Unknown("Failed to get convolution algorithm. This is probably "
                         "because cuDNN failed to initialize, so try looking to "
                         "see if a warning log message was printed above."));

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -437,11 +437,11 @@ struct LaunchConvOp<GPUDevice, T> {
     if (cudnn_use_autotune && !AutoTuneConv3d::GetInstance()->Find(
                                   conv_parameters, &algorithm_config)) {
       std::vector<AlgorithmDesc> algorithms;
-      OP_REQUIRES(ctx,
-                  stream->parent()->GetConvolveAlgorithms(
-                      conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
-                          stream->parent()),
-                      &algorithms),
+      OP_REQUIRES(ctx, stream->parent()->GetConvolveAlgorithms(
+                           conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
+                               stream->parent()),
+                           stream, se::dnn::ToDataType<T>::value, input_desc,
+                           filter_desc, conv_desc, output_desc, &algorithms),
                   errors::Unknown(
                       "Failed to get convolution algorithm. This is probably "
                       "because cuDNN failed to initialize, so try looking to "

--- a/tensorflow/core/kernels/cudnn_rnn_ops.cc
+++ b/tensorflow/core/kernels/cudnn_rnn_ops.cc
@@ -1310,7 +1310,7 @@ class CudnnRNNForwardOp<GPUDevice, T> : public CudnnRNNKernelCommon {
     CudnnRnnAllocatorInTemp<uint8> workspace_allocator(context);
 
     if (is_debug_mode_) {
-      AlgorithmDesc algo_desc(debug_cudnn_rnn_algo_, debug_use_tensor_ops_);
+      AlgorithmDesc algo_desc(debug_cudnn_rnn_algo_, debug_use_tensor_ops_, 0);
       output_algo_config->set_algorithm(algo_desc);
     } else {
       OP_REQUIRES_OK(context,
@@ -1848,7 +1848,8 @@ class CudnnRNNBackwardOpV2<GPUDevice, T>
     TF_RETURN_IF_ERROR(context->input("host_reserved", &host_reserved));
 
     auto host_reserved_int8 = host_reserved->vec<int8>();
-    const AlgorithmDesc algo_desc(host_reserved_int8(0), host_reserved_int8(1));
+    const AlgorithmDesc algo_desc(host_reserved_int8(0), host_reserved_int8(1),
+                                  0);
     algo_config->set_algorithm(algo_desc);
     return Status::OK();
   }

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -2213,6 +2213,24 @@ GetCudnnConvolutionBackwardFilterAlgo(const CudnnHandle& cudnn,
   return algo_to_use;
 }
 
+port::StatusOr<size_t> GetCudnnConvolutionForwardWorkspaceSize(
+    const CudnnHandle& cudnn, const CudnnTensorDescriptor& input_nd,
+    const CudnnFilterDescriptor& filter, const CudnnConvolutionDescriptor& conv,
+    const CudnnTensorDescriptor& output_nd,
+    const cudnnConvolutionFwdAlgo_t algo_id) {
+  size_t size_in_bytes;
+  RETURN_IF_CUDNN_ERROR(
+      cudnnGetConvolutionForwardWorkspaceSize(cudnn.handle(),
+                                              /*xDesc=*/input_nd.handle(),
+                                              /*wDesc=*/filter.handle(),
+                                              /*convDesc=*/conv.handle(),
+                                              /*yDesc=*/output_nd.handle(),
+                                              /*algo=*/algo_id,
+                                              /*sizeInBytes=*/&size_in_bytes));
+
+  return size_in_bytes;
+}
+
 port::StatusOr<DeviceMemory<uint8>> AllocateCudnnConvolutionForwardWorkspace(
     Stream* stream, const CudnnHandle& cudnn,
     const CudnnTensorDescriptor& input_nd, const CudnnFilterDescriptor& filter,
@@ -2225,25 +2243,9 @@ port::StatusOr<DeviceMemory<uint8>> AllocateCudnnConvolutionForwardWorkspace(
   // the last call to this function, but should be fixed anyway.
   conv.set_use_tensor_op_math(algorithm_desc.tensor_ops_enabled());
 
-  // Query the size of the workspace and allocate it.
-  size_t size_in_bytes;
-  RETURN_IF_CUDNN_ERROR(cudnnGetConvolutionForwardWorkspaceSize(
-      cudnn.handle(),
-      /*xDesc=*/input_nd.handle(),
-      /*wDesc=*/filter.handle(), /*convDesc=*/conv.handle(),
-      /*yDesc=*/output_nd.handle(), /*algo=*/ToConvForwardAlgo(algorithm_desc),
-      /*sizeInBytes=*/&size_in_bytes));
+  size_t size_in_bytes = algorithm_desc.scratch_size();
 
-  int64 size_in_bytes_int64 = size_in_bytes;
-
-  if (TF_PREDICT_FALSE(size_in_bytes_int64 < 0)) {
-    return port::Status(
-        port::error::INTERNAL,
-        "cudnnGetConvolutionForwardWorkspaceSize() returned "
-        "negative sizeInBytes value. This could be a cudnn bug.");
-  }
-
-  if (size_in_bytes_int64 == 0) {
+  if (size_in_bytes == 0) {
     return DeviceMemory<uint8>();
   }
 
@@ -2253,6 +2255,24 @@ port::StatusOr<DeviceMemory<uint8>> AllocateCudnnConvolutionForwardWorkspace(
   }
 
   return scratch_allocator->AllocateBytes(stream, size_in_bytes);
+}
+
+port::StatusOr<size_t> GetCudnnConvolutionBackwardDataWorkspaceSize(
+    const CudnnHandle& cudnn, const CudnnTensorDescriptor& input_nd,
+    const CudnnFilterDescriptor& filter, const CudnnConvolutionDescriptor& conv,
+    const CudnnTensorDescriptor& output_nd,
+    const cudnnConvolutionBwdDataAlgo_t algo_id) {
+  size_t size_in_bytes;
+  RETURN_IF_CUDNN_ERROR(cudnnGetConvolutionBackwardDataWorkspaceSize(
+      cudnn.handle(),
+      /*wDesc=*/filter.handle(),
+      /*dyDesc=*/output_nd.handle(),
+      /*convDesc=*/conv.handle(),
+      /*dxDesc=*/input_nd.handle(),
+      /*algo=*/algo_id,
+      /*sizeInBytes=*/&size_in_bytes));
+
+  return size_in_bytes;
 }
 
 port::StatusOr<DeviceMemory<uint8>>
@@ -2268,27 +2288,9 @@ AllocateCudnnConvolutionBackwardDataWorkspace(
   // the last call to this function, but should be fixed anyway.
   conv.set_use_tensor_op_math(algorithm_desc.tensor_ops_enabled());
 
-  // Query the size of the workspace and allocate it.
-  size_t size_in_bytes;
-  RETURN_IF_CUDNN_ERROR(cudnnGetConvolutionBackwardDataWorkspaceSize(
-      cudnn.handle(),
-      /*wDesc=*/filter.handle(),
-      /*dyDesc=*/output_nd.handle(),
-      /*convDesc=*/conv.handle(),
-      /*dxDesc=*/input_nd.handle(),
-      /*algo=*/ToConvBackwardDataAlgo(algorithm_desc),
-      /*sizeInBytes=*/&size_in_bytes));
+  int64 size_in_bytes = algorithm_desc.scratch_size();
 
-  int64 size_in_bytes_int64 = size_in_bytes;
-
-  if (TF_PREDICT_FALSE(size_in_bytes_int64 < 0)) {
-    return port::Status(
-        port::error::INTERNAL,
-        "cudnnGetConvolutionBackwardDataWorkspaceSize() returned "
-        "negative sizeInBytes value. This could be a cudnn bug.");
-  }
-
-  if (size_in_bytes_int64 == 0) {
+  if (size_in_bytes == 0) {
     return DeviceMemory<uint8>();
   }
 
@@ -2298,6 +2300,24 @@ AllocateCudnnConvolutionBackwardDataWorkspace(
   }
 
   return scratch_allocator->AllocateBytes(stream, size_in_bytes);
+}
+
+port::StatusOr<size_t> GetCudnnConvolutionBackwardFilterWorkspaceSize(
+    const CudnnHandle& cudnn, const CudnnTensorDescriptor& input_nd,
+    const CudnnFilterDescriptor& filter, const CudnnConvolutionDescriptor& conv,
+    const CudnnTensorDescriptor& output_nd,
+    const cudnnConvolutionBwdFilterAlgo_t algo_id) {
+  size_t size_in_bytes;
+  RETURN_IF_CUDNN_ERROR(cudnnGetConvolutionBackwardFilterWorkspaceSize(
+      cudnn.handle(),
+      /*xDesc=*/input_nd.handle(),
+      /*dyDesc=*/output_nd.handle(),
+      /*convDesc=*/conv.handle(),
+      /*gradDesc=*/filter.handle(),
+      /*algo=*/algo_id,
+      /*sizeInBytes=*/&size_in_bytes));
+
+  return size_in_bytes;
 }
 
 port::StatusOr<DeviceMemory<uint8>>
@@ -2313,27 +2333,9 @@ AllocateCudnnConvolutionBackwardFilterWorkspace(
   // the last call to this function, but should be fixed anyway.
   conv.set_use_tensor_op_math(algorithm_desc.tensor_ops_enabled());
 
-  // Query the size of the workspace and allocate it.
-  size_t size_in_bytes;
-  RETURN_IF_CUDNN_ERROR(cudnnGetConvolutionBackwardFilterWorkspaceSize(
-      cudnn.handle(),
-      /*xDesc=*/input_nd.handle(),
-      /*dyDesc=*/output_nd.handle(),
-      /*convDesc=*/conv.handle(),
-      /*gradDesc=*/filter.handle(),
-      /*algo=*/ToConvBackwardFilterAlgo(algorithm_desc),
-      /*sizeInBytes=*/&size_in_bytes));
+  size_t size_in_bytes = algorithm_desc.scratch_size();
 
-  int64 size_in_bytes_int64 = size_in_bytes;
-
-  if (TF_PREDICT_FALSE(size_in_bytes_int64 < 0)) {
-    return port::Status(
-        port::error::INTERNAL,
-        "cudnnGetConvolutionBackwardFilterWorkspaceSize() returned "
-        "negative sizeInBytes value. This could be a cudnn bug.");
-  }
-
-  if (size_in_bytes_int64 == 0) {
+  if (size_in_bytes == 0) {
     return DeviceMemory<uint8>();
   }
 
@@ -2365,7 +2367,12 @@ port::StatusOr<dnn::AlgorithmDesc> GetCudnnConvolutionForwardAlgorithm(
                         GetCudnnConvolutionForwardAlgo(
                             cudnn, input_nd, filter, conv, output_nd,
                             specify_workspace_limit, memory_limit_bytes));
-    algo_desc = dnn::AlgorithmDesc(algo, /*use_tensor_ops=*/true);
+
+    SE_ASSIGN_OR_RETURN(uint64 scratch_size,
+                        GetCudnnConvolutionForwardWorkspaceSize(
+                            cudnn, input_nd, filter, conv, output_nd, algo));
+
+    algo_desc = dnn::AlgorithmDesc(algo, /*use_tensor_ops=*/true, scratch_size);
   }
 
   const auto scratch_or = AllocateCudnnConvolutionForwardWorkspace(
@@ -2414,7 +2421,12 @@ port::StatusOr<dnn::AlgorithmDesc> GetCudnnConvolutionBackwardDataAlgorithm(
                         GetCudnnConvolutionBackwardDataAlgo(
                             cudnn, input_nd, filter, conv, output_nd,
                             specify_workspace_limit, memory_limit_bytes));
-    algo_desc = dnn::AlgorithmDesc(algo, /*use_tensor_ops=*/true);
+
+    SE_ASSIGN_OR_RETURN(uint64 scratch_size,
+                        GetCudnnConvolutionBackwardDataWorkspaceSize(
+                            cudnn, input_nd, filter, conv, output_nd, algo));
+
+    algo_desc = dnn::AlgorithmDesc(algo, /*use_tensor_ops=*/true, scratch_size);
   }
 
   const auto scratch_or = AllocateCudnnConvolutionBackwardDataWorkspace(
@@ -2463,7 +2475,12 @@ port::StatusOr<dnn::AlgorithmDesc> GetCudnnConvolutionBackwardFilterAlgorithm(
                         GetCudnnConvolutionBackwardFilterAlgo(
                             cudnn, input_nd, filter, conv, output_nd,
                             specify_workspace_limit, memory_limit_bytes));
-    algo_desc = dnn::AlgorithmDesc(algo, /*use_tensor_ops=*/true);
+
+    SE_ASSIGN_OR_RETURN(uint64 scratch_size,
+                        GetCudnnConvolutionBackwardFilterWorkspaceSize(
+                            cudnn, input_nd, filter, conv, output_nd, algo));
+
+    algo_desc = dnn::AlgorithmDesc(algo, /*use_tensor_ops=*/true, scratch_size);
   }
 
   auto scratch_or = AllocateCudnnConvolutionBackwardFilterWorkspace(
@@ -2919,7 +2936,6 @@ port::Status CudnnSupport::DoConvolve(
     output_profile_result->set_algorithm(algorithm_desc);
     output_profile_result->set_elapsed_time_in_ms(
         timer->GetElapsedMilliseconds());
-    output_profile_result->set_scratch_size(scratch_memory.size());
   }
 
   return port::Status::OK();
@@ -3036,7 +3052,6 @@ port::Status CudnnSupport::DoFusedConvolveImpl(
     output_profile_result->set_algorithm(algo_desc);
     output_profile_result->set_elapsed_time_in_ms(
         timer->GetElapsedMilliseconds());
-    output_profile_result->set_scratch_size(scratch.size());
   }
 
   return port::Status::OK();
@@ -3047,14 +3062,45 @@ inline bool TensorOpMathAvailable(int cc_major) {
 }
 
 bool CudnnSupport::GetConvolveAlgorithms(
-    bool with_winograd_nonfused, int cc_major, int cc_minor,
+    bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+    dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
   bool tensor_op_math_available = TensorOpMathAvailable(cc_major);
   out_algorithms->clear();
 
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+
+  CudnnTensorDescriptor input_nd(
+      input_descriptor,
+      ToCudnnDataType(element_type, input_descriptor.layout()));
+  CudnnFilterDescriptor filter(
+      filter_descriptor,
+      ToCudnnDataType(element_type, filter_descriptor.layout()));
+  CudnnTensorDescriptor output_nd(
+      output_descriptor,
+      ToCudnnDataType(element_type, output_descriptor.layout()));
+  CudnnConvolutionDescriptor conv(
+      convolution_descriptor,
+      ToCudnnDataType(GetConvAccumulatorType(element_type)));
+
+  uint64 scratch_size = 0;
+
   if (RequireDeterminism()) {
-    out_algorithms->push_back({CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM,
-                               tensor_op_math_available});
+    cudnnConvolutionFwdAlgo_t algo =
+        CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM;
+
+    conv.set_use_tensor_op_math(tensor_op_math_available);
+    auto scratch_size_or = GetCudnnConvolutionForwardWorkspaceSize(
+        cudnn, input_nd, filter, conv, output_nd, algo);
+    if (!scratch_size_or.ok()) {
+      return false;
+    }
+    scratch_size = scratch_size_or.ValueOrDie();
+
+    out_algorithms->push_back({algo, tensor_op_math_available, scratch_size});
     return true;
   }
 
@@ -3076,9 +3122,28 @@ bool CudnnSupport::GetConvolveAlgorithms(
   }
 
   for (auto i : algo_types) {
-    out_algorithms->push_back({i, /*use_tensor_ops=*/false});
+    conv.set_use_tensor_op_math(false);
+    auto scratch_size_or = GetCudnnConvolutionBackwardFilterWorkspaceSize(
+        cudnn, input_nd, filter, conv, output_nd,
+        (cudnnConvolutionBwdFilterAlgo_t)i);
+    if (!scratch_size_or.ok()) {
+      return false;
+    }
+    scratch_size = scratch_size_or.ValueOrDie();
+
+    out_algorithms->push_back({i, /*use_tensor_ops=*/false, scratch_size});
+
     if (tensor_op_math_available) {
-      out_algorithms->push_back({i, /*use_tensor_ops=*/true});
+      conv.set_use_tensor_op_math(true);
+      auto scratch_size_or = GetCudnnConvolutionBackwardFilterWorkspaceSize(
+          cudnn, input_nd, filter, conv, output_nd,
+          (cudnnConvolutionBwdFilterAlgo_t)i);
+      if (!scratch_size_or.ok()) {
+        return false;
+      }
+      scratch_size = scratch_size_or.ValueOrDie();
+
+      out_algorithms->push_back({i, /*use_tensor_ops=*/true, scratch_size});
     }
   }
 
@@ -3097,10 +3162,12 @@ bool CudnnSupport::GetRnnAlgorithms(
 
   out_algorithms->clear();
   for (auto i : algo_types) {
-    out_algorithms->push_back({i, /*use_tensor_ops=*/false});
+    out_algorithms->push_back(
+        {i, /*use_tensor_ops=*/false, /*scratch_size*/ 0});
 #if CUDNN_VERSION >= 7100
     if (RnnTensorOpMathEnabled()) {
-      out_algorithms->push_back({i, /*use_tensor_ops=*/true});
+      out_algorithms->push_back(
+          {i, /*use_tensor_ops=*/true, /*scratch_size*/ 0});
     }
 #endif
   }
@@ -3108,14 +3175,44 @@ bool CudnnSupport::GetRnnAlgorithms(
 }
 
 bool CudnnSupport::GetConvolveBackwardDataAlgorithms(
-    bool with_winograd_nonfused, int cc_major, int cc_minor,
+    bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+    dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
   bool tensor_op_math_available = TensorOpMathAvailable(cc_major);
   out_algorithms->clear();
 
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+
+  CudnnTensorDescriptor input_nd(
+      input_descriptor,
+      ToCudnnDataType(element_type, input_descriptor.layout()));
+  CudnnFilterDescriptor filter(
+      filter_descriptor,
+      ToCudnnDataType(element_type, filter_descriptor.layout()));
+  CudnnTensorDescriptor output_nd(
+      output_descriptor,
+      ToCudnnDataType(element_type, output_descriptor.layout()));
+  CudnnConvolutionDescriptor conv(
+      convolution_descriptor,
+      ToCudnnDataType(GetConvAccumulatorType(element_type)));
+
+  uint64 scratch_size = 0;
+
   if (RequireDeterminism()) {
-    out_algorithms->push_back(
-        {CUDNN_CONVOLUTION_BWD_DATA_ALGO_1, tensor_op_math_available});
+    cudnnConvolutionBwdDataAlgo_t algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
+
+    conv.set_use_tensor_op_math(tensor_op_math_available);
+    auto scratch_size_or = GetCudnnConvolutionBackwardDataWorkspaceSize(
+        cudnn, input_nd, filter, conv, output_nd, algo);
+    if (!scratch_size_or.ok()) {
+      return false;
+    }
+    scratch_size = scratch_size_or.ValueOrDie();
+
+    out_algorithms->push_back({algo, tensor_op_math_available, scratch_size});
     return true;
   }
 
@@ -3133,9 +3230,28 @@ bool CudnnSupport::GetConvolveBackwardDataAlgorithms(
   }
 
   for (auto i : algo_types) {
-    out_algorithms->push_back({i, /*use_tensor_ops=*/false});
+    conv.set_use_tensor_op_math(false);
+    auto scratch_size_or = GetCudnnConvolutionBackwardDataWorkspaceSize(
+        cudnn, input_nd, filter, conv, output_nd,
+        (cudnnConvolutionBwdDataAlgo_t)i);
+    if (!scratch_size_or.ok()) {
+      return false;
+    }
+    scratch_size = scratch_size_or.ValueOrDie();
+
+    out_algorithms->push_back({i, /*use_tensor_ops=*/false, scratch_size});
+
     if (tensor_op_math_available) {
-      out_algorithms->push_back({i, /*use_tensor_ops=*/true});
+      conv.set_use_tensor_op_math(true);
+      auto scratch_size_or = GetCudnnConvolutionBackwardDataWorkspaceSize(
+          cudnn, input_nd, filter, conv, output_nd,
+          (cudnnConvolutionBwdDataAlgo_t)i);
+      if (!scratch_size_or.ok()) {
+        return false;
+      }
+      scratch_size = scratch_size_or.ValueOrDie();
+
+      out_algorithms->push_back({i, /*use_tensor_ops=*/true, scratch_size});
     }
   }
 
@@ -3143,14 +3259,44 @@ bool CudnnSupport::GetConvolveBackwardDataAlgorithms(
 }
 
 bool CudnnSupport::GetConvolveBackwardFilterAlgorithms(
-    bool with_winograd_nonfused, int cc_major, int cc_minor,
+    bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+    dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
   bool tensor_op_math_available = TensorOpMathAvailable(cc_major);
   out_algorithms->clear();
 
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+
+  CudnnTensorDescriptor input_nd(
+      input_descriptor,
+      ToCudnnDataType(element_type, input_descriptor.layout()));
+  CudnnFilterDescriptor filter(
+      filter_descriptor,
+      ToCudnnDataType(element_type, filter_descriptor.layout()));
+  CudnnTensorDescriptor output_nd(
+      output_descriptor,
+      ToCudnnDataType(element_type, output_descriptor.layout()));
+  CudnnConvolutionDescriptor conv(
+      convolution_descriptor,
+      ToCudnnDataType(GetConvAccumulatorType(element_type)));
+
+  uint64 scratch_size = 0;
+
   if (RequireDeterminism()) {
-    out_algorithms->push_back(
-        {CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1, tensor_op_math_available});
+    cudnnConvolutionBwdFilterAlgo_t algo = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1;
+
+    conv.set_use_tensor_op_math(tensor_op_math_available);
+    auto scratch_size_or = GetCudnnConvolutionBackwardFilterWorkspaceSize(
+        cudnn, input_nd, filter, conv, output_nd, algo);
+    if (!scratch_size_or.ok()) {
+      return false;
+    }
+    scratch_size = scratch_size_or.ValueOrDie();
+
+    out_algorithms->push_back({algo, tensor_op_math_available, scratch_size});
     return true;
   }
 
@@ -3173,9 +3319,27 @@ bool CudnnSupport::GetConvolveBackwardFilterAlgorithms(
   }
 
   for (auto i : algo_types) {
-    out_algorithms->push_back({i, /*use_tensor_ops=*/false});
+    conv.set_use_tensor_op_math(false);
+    auto scratch_size_or = GetCudnnConvolutionForwardWorkspaceSize(
+        cudnn, input_nd, filter, conv, output_nd, (cudnnConvolutionFwdAlgo_t)i);
+    if (!scratch_size_or.ok()) {
+      return false;
+    }
+    scratch_size = scratch_size_or.ValueOrDie();
+
+    out_algorithms->push_back({i, /*use_tensor_ops=*/false, scratch_size});
+
     if (tensor_op_math_available) {
-      out_algorithms->push_back({i, /*use_tensor_ops=*/true});
+      conv.set_use_tensor_op_math(true);
+      auto scratch_size_or = GetCudnnConvolutionForwardWorkspaceSize(
+          cudnn, input_nd, filter, conv, output_nd,
+          (cudnnConvolutionFwdAlgo_t)i);
+      if (!scratch_size_or.ok()) {
+        return false;
+      }
+      scratch_size = scratch_size_or.ValueOrDie();
+
+      out_algorithms->push_back({i, /*use_tensor_ops=*/true, scratch_size});
     }
   }
 

--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -200,18 +200,30 @@ class CudnnSupport : public dnn::DnnSupport {
                      dnn::ProfileResult* output_profile_result) override;
 
   bool GetConvolveAlgorithms(
-      bool with_winograd_nonfused, int cc_major, int cc_minor,
+      bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+      dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool GetConvolveBackwardDataAlgorithms(
-      bool with_winograd_nonfused, int cc_major, int cc_minor,
+      bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+      dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool GetConvolveBackwardFilterAlgorithms(
-      bool with_winograd_nonfused, int cc_major, int cc_minor,
+      bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+      dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool DoBatchNormalizationForward(

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -23,11 +23,17 @@ namespace stream_executor {
 namespace dnn {
 
 uint64 AlgorithmDesc::hash() const {
-  return ::tensorflow::Hash64Combine(algo_id(), tensor_ops_enabled());
+  uint64 hash_value =
+      ::tensorflow::Hash64Combine(algo_id(), tensor_ops_enabled());
+  return ::tensorflow::Hash64Combine(hash_value, scratch_size());
 }
 
 bool DnnSupport::GetConvolveAlgorithms(
-    bool with_winograd_nonfused, int cc_major, int cc_minor,
+    bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+    dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
     std::vector<AlgorithmDesc>* out_algorithms) {
   return false;
 }
@@ -37,13 +43,21 @@ bool DnnSupport::GetRnnAlgorithms(std::vector<AlgorithmDesc>* out_algorithms) {
 }
 
 bool DnnSupport::GetConvolveBackwardDataAlgorithms(
-    bool with_winograd_nonfused, int cc_major, int cc_minor,
+    bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+    dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
     std::vector<AlgorithmDesc>* out_algorithms) {
   return false;
 }
 
 bool DnnSupport::GetConvolveBackwardFilterAlgorithms(
-    bool with_winograd_nonfused, int cc_major, int cc_minor,
+    bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+    dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
     std::vector<AlgorithmDesc>* out_algorithms) {
   return false;
 }

--- a/tensorflow/stream_executor/dnn.proto
+++ b/tensorflow/stream_executor/dnn.proto
@@ -93,6 +93,7 @@ message AlgorithmProto {
   }
   int64 algo_id = 1;
   MathType math_type = 2;
+  uint64 scratch_size = 3;
 }
 
 // Convolution-specific parameters.

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -191,18 +191,30 @@ class MIOpenSupport : public dnn::DnnSupport {
                      dnn::ProfileResult* output_profile_result) override;
 
   bool GetConvolveAlgorithms(
-      bool with_winograd_nonfused, int cc_major, int cc_minor,
+      bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+      dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool GetConvolveBackwardDataAlgorithms(
-      bool with_winograd_nonfused, int cc_major, int cc_minor,
+      bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+      dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool GetConvolveBackwardFilterAlgorithms(
-      bool with_winograd_nonfused, int cc_major, int cc_minor,
+      bool with_winograd_nonfused, int cc_major, int cc_minor, Stream* stream,
+      dnn::DataType element_type, const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool DoBatchNormalizationForward(

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -321,16 +321,22 @@ bool StreamExecutor::SupportsDnn() const {
 }
 
 bool StreamExecutor::GetConvolveAlgorithms(
-    bool with_winograd_nonfused,
-    std::vector<dnn::AlgorithmDesc> *out_algorithms) {
+    bool with_winograd_nonfused, Stream* stream, dnn::DataType element_type,
+    const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    std::vector<dnn::AlgorithmDesc>* out_algorithms) {
   dnn::DnnSupport *dnn_support = AsDnn();
   if (!dnn_support) {
     return false;
   }
   int cc_major, cc_minor;
   GetDeviceDescription().cuda_compute_capability(&cc_major, &cc_minor);
-  return dnn_support->GetConvolveAlgorithms(with_winograd_nonfused, cc_major,
-                                            cc_minor, out_algorithms);
+  return dnn_support->GetConvolveAlgorithms(
+      with_winograd_nonfused, cc_major, cc_minor, stream, element_type,
+      input_descriptor, filter_descriptor, convolution_descriptor,
+      output_descriptor, out_algorithms);
 }
 
 bool StreamExecutor::GetRnnAlgorithms(
@@ -343,8 +349,12 @@ bool StreamExecutor::GetRnnAlgorithms(
 }
 
 bool StreamExecutor::GetConvolveBackwardDataAlgorithms(
-    bool with_winograd_nonfused,
-    std::vector<dnn::AlgorithmDesc> *out_algorithms) {
+    bool with_winograd_nonfused, Stream* stream, dnn::DataType element_type,
+    const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    std::vector<dnn::AlgorithmDesc>* out_algorithms) {
   dnn::DnnSupport *dnn_support = AsDnn();
   if (!dnn_support) {
     return false;
@@ -352,12 +362,18 @@ bool StreamExecutor::GetConvolveBackwardDataAlgorithms(
   int cc_major, cc_minor;
   GetDeviceDescription().cuda_compute_capability(&cc_major, &cc_minor);
   return dnn_support->GetConvolveBackwardDataAlgorithms(
-      with_winograd_nonfused, cc_major, cc_minor, out_algorithms);
+      with_winograd_nonfused, cc_major, cc_minor, stream, element_type,
+      input_descriptor, filter_descriptor, convolution_descriptor,
+      output_descriptor, out_algorithms);
 }
 
 bool StreamExecutor::GetConvolveBackwardFilterAlgorithms(
-    bool with_winograd_nonfused,
-    std::vector<dnn::AlgorithmDesc> *out_algorithms) {
+    bool with_winograd_nonfused, Stream* stream, dnn::DataType element_type,
+    const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    std::vector<dnn::AlgorithmDesc>* out_algorithms) {
   dnn::DnnSupport *dnn_support = AsDnn();
   if (!dnn_support) {
     return false;
@@ -365,7 +381,9 @@ bool StreamExecutor::GetConvolveBackwardFilterAlgorithms(
   int cc_major, cc_minor;
   GetDeviceDescription().cuda_compute_capability(&cc_major, &cc_minor);
   return dnn_support->GetConvolveBackwardFilterAlgorithms(
-      with_winograd_nonfused, cc_major, cc_minor, out_algorithms);
+      with_winograd_nonfused, cc_major, cc_minor, stream, element_type,
+      input_descriptor, filter_descriptor, convolution_descriptor,
+      output_descriptor, out_algorithms);
 }
 
 bool StreamExecutor::GetBlasGemmAlgorithms(

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -382,22 +382,35 @@ class StreamExecutor {
 
   // Returns the list of supported algorithms for the forward convolution
   // operation.
-  bool GetConvolveAlgorithms(bool with_winograd_nonfused,
-                             std::vector<dnn::AlgorithmDesc> *out_algorithms);
+  bool GetConvolveAlgorithms(
+      bool with_winograd_nonfused, Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      std::vector<dnn::AlgorithmDesc>* out_algorithms);
 
   // Returns the list of supported algorithms for rnn operation.
   bool GetRnnAlgorithms(std::vector<dnn::AlgorithmDesc> *out_algorithms);
 
   // Get the list of supported algorithms for the backward convolution on data.
   bool GetConvolveBackwardDataAlgorithms(
-      bool with_winograd_nonfused,
-      std::vector<dnn::AlgorithmDesc> *out_algorithms);
+      bool with_winograd_nonfused, Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      std::vector<dnn::AlgorithmDesc>* out_algorithms);
 
   // Get the list of supported algorithms for the backward convolution on the
   // filter.
   bool GetConvolveBackwardFilterAlgorithms(
-      bool with_winograd_nonfused,
-      std::vector<dnn::AlgorithmDesc> *out_algorithms);
+      bool with_winograd_nonfused, Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      std::vector<dnn::AlgorithmDesc>* out_algorithms);
 
   // Get the list of supported algorithms for BLAS gemm.
   bool GetBlasGemmAlgorithms(std::vector<blas::AlgorithmType> *out_algorithms);


### PR DESCRIPTION

Description:

Currently the scratch_size (workspace memory size), required to execute
a given convolution using a given algorithm, is determined via a call to
the CUDNN API. This call happens each time a convolution kernel is
called, because the scratch_size is not stored on neither the
dnn::AlgorithmDesc nor the dnn::AlgorithmConfig datastructures. Adding
scratch_size to dnn::AlgorithmDesc will remove the need to call the
CUDNN API to retrieve this information everytime we need to do
convolution.

There are also some ROCm platform specific reasons for making this change.

1. on the ROCm platform, there is no equivalent of the CUDNN API to
   determine the workspace memory size corresponding to a given
   (conv_params, algo) tuple. There is a ROCm API to determine the
   workspace memory size for a given conv_params, but that gives a
   worst case answer since that API does not take a specific algo as an
   input. As a consequence, on the ROCm fork of TF, we maintain a
   scratch_size field on the dnn::AlgorithmConfig data-structure. This
   change will remove the need for this discrepancy in the ROCm TF fork.

2. A side-effect of this commit is that the GetConvolve*Algorithms
   routines will now take the conv_params (input, filter, conv, output)
   as input. This will allow TF code to leverage underlying CUDNN /
   ROCm MIOpen APIs that return a list of algos that are applicable to
   the given conv_params. Currently the list of algorithms list is
   compiled in the TF code itself, without querying the CUDNN / MIOpen
   APIs.

----


@tatianashp : just FYI
@timshen91 : I am changing code that you recently refactored and hence including you on the cc-list
@chsigg @whchung 
