### PR TITLE
Fix call to backend.placeholder()

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1679,7 +1679,7 @@ class Layer(trackable.Trackable):
     output_shapes = self.compute_output_shape(input_shapes)
 
     def _make_placeholder_like(shape):
-      ph = backend.placeholder(shape, self.dtype)
+      ph = backend.placeholder(shape=shape, dtype=self.dtype)
       ph._keras_mask = None
       return ph
 


### PR DESCRIPTION
In `base_layer.py`, there is this line:

```python
ph = backend.placeholder(shape, self.dtype)
```

But the `placeholder()` function's signature in `backend.py` is:

```python
def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):
    ...
```

So it is actually sending `ndim=self.dtype`. Not sure when it will break, but it will break. So I'm replacing it with:

```python
ph = backend.placeholder(shape=shape, dtype=self.dtype)
```