### PR TITLE
add clear user instructions for dataset.prefetch

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -699,8 +699,8 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
   def prefetch(self, buffer_size):
     """Creates a `Dataset` that prefetches elements from this dataset.
 
-    Note that if the dataset was batched using `Dataset.batch`, each element is
-    a batch and this operation will prefetch `buffer_size` batches.
+    NOTE: If prefetch after batch, such as: dataset.batch(20).prefetch(2),
+    which means prefetch 2 batches, totally 40 samples.
 
     Args:
       buffer_size: A `tf.int64` scalar `tf.Tensor`, representing the maximum

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -699,8 +699,11 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
   def prefetch(self, buffer_size):
     """Creates a `Dataset` that prefetches elements from this dataset.
 
-    NOTE: If prefetch after batch, such as: dataset.batch(20).prefetch(2),
-    which means prefetch 2 batches, totally 40 samples.
+    Note: Like other `Dataset` methods, prefetch operates on the elements of
+    the dataset. It has no concept of examples vs. batches. `examples.prefetch(2)`
+    will prefetch two elements (2 examples), while `examples.batch(20).prefetch(2)`
+    will prefetch 2 elements (2 batches, of 20 examples each). The typical
+    use-case is to `prefetch` batches.
 
     Args:
       buffer_size: A `tf.int64` scalar `tf.Tensor`, representing the maximum

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -700,11 +700,10 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     """Creates a `Dataset` that prefetches elements from this dataset.
 
     Note: Like other `Dataset` methods, prefetch operates on the
-    elements of the dataset. It has no concept of examples vs. batches.
+    elements of the input dataset. It has no concept of examples vs. batches.
     `examples.prefetch(2)` will prefetch two elements (2 examples),
     while `examples.batch(20).prefetch(2)` will prefetch 2 elements
-    (2 batches, of 20 examples each). The typical use-case is to
-    `prefetch` batches.
+    (2 batches, of 20 examples each).
 
     Args:
       buffer_size: A `tf.int64` scalar `tf.Tensor`, representing the maximum

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -699,11 +699,12 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
   def prefetch(self, buffer_size):
     """Creates a `Dataset` that prefetches elements from this dataset.
 
-    Note: Like other `Dataset` methods, prefetch operates on the elements of
-    the dataset. It has no concept of examples vs. batches. `examples.prefetch(2)`
-    will prefetch two elements (2 examples), while `examples.batch(20).prefetch(2)`
-    will prefetch 2 elements (2 batches, of 20 examples each). The typical
-    use-case is to `prefetch` batches.
+    Note: Like other `Dataset` methods, prefetch operates on the
+    elements of the dataset. It has no concept of examples vs. batches.
+    `examples.prefetch(2)` will prefetch two elements (2 examples),
+    while `examples.batch(20).prefetch(2)` will prefetch 2 elements
+    (2 batches, of 20 examples each). The typical use-case is to
+    `prefetch` batches.
 
     Args:
       buffer_size: A `tf.int64` scalar `tf.Tensor`, representing the maximum


### PR DESCRIPTION
The argument's name "buffer_size" and api_doc "Creates a Dataset that prefetches elements from this dataset." mislead users, which could lead to huge memory usage. Several users made such misunderstanding which trigger huge memory usage, similar confuse in stack overflow: https://stackoverflow.com/questions/49707062/tensorflow-dataset-api-dataset-batchn-prefetchm-prefetches-m-batches-or-sam