### PR TITLE
1.13.0 cherry-pick request: Update tensorboard dependency to 1.13.x

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -56,7 +56,7 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.13.3',
     'six >= 1.10.0',
     'protobuf >= 3.6.1',
-    'tensorboard >= 1.12.0, < 1.13.0',
+    'tensorboard >= 1.13.0, < 1.14.0',
     'tensorflow_estimator >= 1.13.0, < 1.14.0rc0',
     'termcolor >= 1.1.0',
 ]


### PR DESCRIPTION
Cherrypick of b6ed9186089de852c933244a7d772f836cc3eb27 to bump dependency on TensorBoard to 1.13.x.

TensorBoard release: https://pypi.org/project/tensorboard/1.13.0/

PiperOrigin-RevId: 235563447