### PR TITLE
Fix a bug for loss calculation

### DIFF
--- a/tensorflow/python/keras/engine/training_utils.py
+++ b/tensorflow/python/keras/engine/training_utils.py
@@ -682,10 +682,12 @@ def weighted_masked_objective(fn):
         score_array = K.mean(score_array, axis=list(range(weight_ndim, ndim)))
 
       score_array = math_ops.multiply(score_array, weights)
+      batch_size = K.cast(K.shape(score_array)[0], dtype=K.dtype(score_array))
       score_array = math_ops.reduce_sum(score_array)
       weights = math_ops.reduce_sum(weights)
       score_array = math_ops.div_no_nan(score_array, weights)
-    return K.mean(score_array)
+      score_array = math_ops.div(score_array, batch_size)
+    return score_array
 
   return weighted
 


### PR DESCRIPTION
I think it is a bug for mini batch loss calculation. math_ops.reduce_sum(score_array) will make the 'batch' dim disappear. In the end, K.mean(score_map) doesn't work.