### PR TITLE
Lite: Concatenation Op Refactored

### DIFF
--- a/tensorflow/lite/kernels/concatenation.cc
+++ b/tensorflow/lite/kernels/concatenation.cc
@@ -48,6 +48,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 
   // TODO(ahentz): These are limitations of our implementation that could be
   // removed with a bit of effort.
+  TF_LITE_ENSURE(context, t0->dims->size <= 4);
   TF_LITE_ENSURE_EQ(context, params->activation, kTfLiteActNone);
   TF_LITE_ENSURE(context,
                  input_type == kTfLiteFloat32 || input_type == kTfLiteUInt8 ||
@@ -140,13 +141,9 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteUInt8:
       TF_LITE_CONCATENATION_QUANTIZED(reference_ops);
       break;
-    case kTfLiteInt8: {
-      if (kernel_type == kReference) {
-        TF_LITE_CONCATENATION(reference_ops, int8_t);
-      } else {
-        TF_LITE_CONCATENATION(optimized_ops, int8_t);
-      }
-    } break;
+    case kTfLiteInt8:
+      TF_LITE_CONCATENATION(reference_ops, int8_t);
+      break;
     case kTfLiteInt64:
       TF_LITE_CONCATENATION(reference_ops, int64_t);
       break;

--- a/tensorflow/lite/kernels/concatenation.cc
+++ b/tensorflow/lite/kernels/concatenation.cc
@@ -160,8 +160,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-#undef TF_LITE_MACRO_DISPATCH
-
 }  // namespace concatenation
 
 TfLiteRegistration* Register_CONCATENATION_REF() {

--- a/tensorflow/lite/kernels/concatenation.cc
+++ b/tensorflow/lite/kernels/concatenation.cc
@@ -129,7 +129,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     }                                                                         \
   }
 
-#define TF_LITE_CONCATENATION_QUANTIZED                           \
+#define TF_LITE_CONCATENATION_QUANTIZED()                         \
   {                                                               \
     VectorOfQuantizedTensors all_inputs(*context, *node->inputs); \
     tflite::ConcatenationParams op_params;                        \
@@ -158,7 +158,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       TF_LITE_CONCATENATION(int32);
       break;
     case kTfLiteUInt8:
-      TF_LITE_CONCATENATION_QUANTIZED;
+      TF_LITE_CONCATENATION_QUANTIZED();
       break;
     case kTfLiteInt8:
       TF_LITE_CONCATENATION(int8_t);
@@ -178,6 +178,8 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   return kTfLiteOk;
 }
+
+#undef TF_LITE_MACRO_DISPATCH
 
 }  // namespace concatenation
 

--- a/tensorflow/lite/kernels/concatenation_test.cc
+++ b/tensorflow/lite/kernels/concatenation_test.cc
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <gtest/gtest.h>
 #include <cstdarg>
+#include <gtest/gtest.h>
 #include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/kernels/register.h"
 #include "tensorflow/lite/kernels/test_util.h"
@@ -99,16 +99,6 @@ TEST(ConcatenationOpTest, ThreeDimensionalOneInput) {
   m0.SetInput(0, {1.0f, 3.0f, 4.0f, 7.0f});
   m0.Invoke();
   EXPECT_THAT(m0.GetOutput(), ElementsAreArray({1, 3, 4, 7}));
-}
-
-TEST(ConcatenationOpTest, FiveDimensionalOneInput) {
-  ConcatenationOpModel m0({TensorType_FLOAT32, {2, 1, 2, 1, 3}}, /*axis=*/2,
-                          /*num_inputs=*/1);
-  m0.SetInput(0, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f,
-                  11.0f, 12.0f});
-  m0.Invoke();
-  EXPECT_THAT(m0.GetOutput(),
-              ElementsAreArray({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
 }
 
 TEST(ConcatenationOpTest, OneTrivialInput) {
@@ -280,9 +270,9 @@ TEST(ConcatenationOpTest, ThreeDimensionalNonQuantizedOneInput) {
       {TensorType_UINT8, {2, 1, 2}, 0, std::numeric_limits<uint8_t>::max()},
       /*axis=*/1,
       /*num_inputs=*/1);
-  m0.SetInput(0, {1.0f, 3.0f, 4.0f, 7.0f});
+  m0.SetInput<uint8_t>(0, {1.0f, 3.0f, 4.0f, 7.0f});
   m0.Invoke();
-  EXPECT_THAT(m0.GetOutput(),
+  EXPECT_THAT(m0.GetOutput<uint8_t>(),
               ElementsAreArray(ArrayFloatNear({1.0f, 3.0f, 4.0f, 7.0f})));
 }
 
@@ -291,9 +281,9 @@ TEST(ConcatenationOpTest, OneTrivialNonQuantizedInput) {
       {TensorType_UINT8, {1}, 0, std::numeric_limits<uint8_t>::max()},
       /*axis=*/0,
       /*num_inputs=*/1);
-  m0.SetInput(0, {5.0f});
+  m0.SetInput<uint8_t>(0, {5.0f});
   m0.Invoke();
-  EXPECT_THAT(m0.GetOutput(), ::testing::ElementsAre(5));
+  EXPECT_THAT(m0.GetOutput<uint8_t>(), ::testing::ElementsAre(5));
 }
 
 TEST(ConcatenationOpTest, TwoDimensionalNonQuantizedOneInput) {
@@ -301,9 +291,9 @@ TEST(ConcatenationOpTest, TwoDimensionalNonQuantizedOneInput) {
       {TensorType_UINT8, {2, 3}, 0, std::numeric_limits<uint8_t>::max()},
       /*axis=*/0,
       /*num_inputs=*/1);
-  m0.SetInput(0, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  m0.SetInput<uint8_t>(0, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
   m0.Invoke();
-  EXPECT_THAT(m0.GetOutput(), ElementsAreArray({1, 2, 3, 4, 5, 6}));
+  EXPECT_THAT(m0.GetOutput<uint8_t>(), ElementsAreArray({1, 2, 3, 4, 5, 6}));
 }
 
 TEST(ConcatenationOpTest, TwoInputsTwoAxesNegativeAxesNonQuantized) {
@@ -315,40 +305,40 @@ TEST(ConcatenationOpTest, TwoInputsTwoAxesNegativeAxesNonQuantized) {
       {TensorType_UINT8, {2, 3}, 0, std::numeric_limits<uint8_t>::max()},
       /*axis=*/0,
       /*num_inputs=*/2);
-  m0.SetInput(0, tensor0);
-  m0.SetInput(1, tensor1);
+  m0.SetInput<uint8_t>(0, tensor0);
+  m0.SetInput<uint8_t>(1, tensor1);
   m0.Invoke();
-  EXPECT_THAT(m0.GetOutput(),
+  EXPECT_THAT(m0.GetOutput<uint8_t>(),
               ElementsAreArray({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
 
   QuantizedConcatenationOpModel m0_negative(
       {TensorType_UINT8, {2, 3}, 0, std::numeric_limits<uint8_t>::max()},
       /*axis=*/-2,
       /*num_inputs=*/2);
-  m0_negative.SetInput(0, tensor0);
-  m0_negative.SetInput(1, tensor1);
+  m0_negative.SetInput<uint8_t>(0, tensor0);
+  m0_negative.SetInput<uint8_t>(1, tensor1);
   m0_negative.Invoke();
-  EXPECT_THAT(m0_negative.GetOutput(),
+  EXPECT_THAT(m0_negative.GetOutput<uint8_t>(),
               ElementsAreArray({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
 
   QuantizedConcatenationOpModel m1(
       {TensorType_UINT8, {2, 3}, 0, std::numeric_limits<uint8_t>::max()},
       /*axis=*/1,
       /*num_inputs=*/2);
-  m1.SetInput(0, tensor0);
-  m1.SetInput(1, tensor1);
+  m1.SetInput<uint8_t>(0, tensor0);
+  m1.SetInput<uint8_t>(1, tensor1);
   m1.Invoke();
-  EXPECT_THAT(m1.GetOutput(),
+  EXPECT_THAT(m1.GetOutput<uint8_t>(),
               ElementsAreArray({1, 2, 3, 7, 8, 9, 4, 5, 6, 10, 11, 12}));
 
   QuantizedConcatenationOpModel m1_negative(
       {TensorType_UINT8, {2, 3}, 0, std::numeric_limits<uint8_t>::max()},
       /*axis=*/-1,
       /*num_inputs=*/2);
-  m1_negative.SetInput(0, tensor0);
-  m1_negative.SetInput(1, tensor1);
+  m1_negative.SetInput<uint8_t>(0, tensor0);
+  m1_negative.SetInput<uint8_t>(1, tensor1);
   m1_negative.Invoke();
-  EXPECT_THAT(m1_negative.GetOutput(),
+  EXPECT_THAT(m1_negative.GetOutput<uint8_t>(),
               ElementsAreArray({1, 2, 3, 7, 8, 9, 4, 5, 6, 10, 11, 12}));
 }
 


### PR DESCRIPTION
1:> Code refactored for reference_ops usage as both optimized and reference are same.
2:> Error message corrected.
3:> Wrong restriction removed.
4:> Test case added for Quantizied Input.