### PR TITLE
Update normalization.py - fixed tf.layer.batch_normalization deprecate note

### DIFF
--- a/tensorflow/python/layers/normalization.py
+++ b/tensorflow/python/layers/normalization.py
@@ -157,7 +157,7 @@ class BatchNormalization(keras_layers.BatchNormalization, base.Layer):
 
 @deprecation.deprecated(
     date=None,
-    instructions='Use keras.layers.batch_normalization instead.')
+    instructions='Use keras.layers.BatchNormalization instead.')
 @tf_export(v1=['layers.batch_normalization'])
 def batch_normalization(inputs,
                         axis=-1,


### PR DESCRIPTION
tf.layer.batch_normalization referenced incorrect keras.layer.BatchNormalization function.