### PR TITLE
remove HAVE_XLOCALE_H in hwloc BUILD.bazel

### DIFF
--- a/third_party/hwloc/BUILD.bazel
+++ b/third_party/hwloc/BUILD.bazel
@@ -112,7 +112,6 @@ _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS = {
     "#undef HAVE_X11_KEYSYM_H": "#define HAVE_X11_KEYSYM_H 1",
     "#undef HAVE_X11_XLIB_H": "#define HAVE_X11_XLIB_H 1",
     "#undef HAVE_X11_XUTIL_H": "#define HAVE_X11_XUTIL_H 1",
-    "#undef HAVE_XLOCALE_H": "#define HAVE_XLOCALE_H 1",
     "#undef HAVE___PROGNAME": "#define HAVE___PROGNAME 1",
     "#undef HWLOC_C_HAVE_VISIBILITY": "#define HWLOC_C_HAVE_VISIBILITY 1",
     "#undef HWLOC_HAVE_ATTRIBUTE": "#define HWLOC_HAVE_ATTRIBUTE 1",


### PR DESCRIPTION
xlocale.h is not a standard header and is not shipped with newer glibc.