### PR TITLE
Fix hwloc build for non x86 platforms

### DIFF
--- a/third_party/hwloc/BUILD.bazel
+++ b/third_party/hwloc/BUILD.bazel
@@ -228,7 +228,6 @@ cc_library(
         "hwloc/topology-linux.c",
         "hwloc/topology-noos.c",
         "hwloc/topology-synthetic.c",
-        "hwloc/topology-x86.c",
         "hwloc/topology-xml.c",
         "hwloc/topology-xml-nolibxml.c",
         "hwloc/traversal.c",
@@ -237,13 +236,18 @@ cc_library(
         "include/hwloc/shmem.h",
         "include/private/autogen/config.h",
         "include/private/components.h",
-        "include/private/cpuid-x86.h",
         "include/private/debug.h",
         "include/private/internal-components.h",
         "include/private/misc.h",
         "include/private/private.h",
         "include/private/xml.h",
-    ],
+    ] + select({
+        "@org_tensorflow//tensorflow:linux_x86_64": [
+            "hwloc/topology-x86.c",
+            "include/private/cpuid-x86.h",
+        ],
+        "//conditions:default": []
+    }),
     hdrs = [
         "include/hwloc.h",
         "include/hwloc/autogen/config.h",

--- a/third_party/hwloc/static-components.h
+++ b/third_party/hwloc/static-components.h
@@ -21,7 +21,8 @@ static const struct hwloc_component* hwloc_static_components[] = {
     &hwloc_noos_component,      &hwloc_xml_component,
     &hwloc_synthetic_component, &hwloc_xml_nolibxml_component,
     &hwloc_linux_component,     &hwloc_linuxio_component,
-#ifdef PLATFORM_IS_X86
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_IX86) || \
+defined(_M_X64)
     &hwloc_x86_component,
 #endif
     NULL};

--- a/third_party/hwloc/static-components.h
+++ b/third_party/hwloc/static-components.h
@@ -21,6 +21,9 @@ static const struct hwloc_component* hwloc_static_components[] = {
     &hwloc_noos_component,      &hwloc_xml_component,
     &hwloc_synthetic_component, &hwloc_xml_nolibxml_component,
     &hwloc_linux_component,     &hwloc_linuxio_component,
-    &hwloc_x86_component,       NULL};
+#ifdef PLATFORM_IS_X86
+    &hwloc_x86_component,
+#endif
+    NULL};
 
 #endif  // THIRD_PARTY_HWLOC_STATIC_COMPONENTS_H_


### PR DESCRIPTION
Commit a6bf9c8 yesterday triggered the building of hwloc in TensorFlow.
While many platforms (windows, mac, android) were excluded from building
hwloc, others like ppc64le and raspberry pi still tried to build hwloc.

This fails because hwloc references x86 specific files. Instead of excluding
those platforms from building with hwloc, lets add conditions to only include
the x86 files during a build on the x86 platform. This might enable the
other platforms to still take advantage of hwloc function.