### PR TITLE
[INTEL MKL]  RequantizeOp to support int8 data type

### DIFF
--- a/tensorflow/core/kernels/requantize.cc
+++ b/tensorflow/core/kernels/requantize.cc
@@ -18,8 +18,6 @@ limitations under the License.
 #define EIGEN_USE_THREADS
 
 #include <math.h>
-
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/type_traits.h"
@@ -27,6 +25,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/meta_support.h"
 #include "tensorflow/core/kernels/quantization_utils.h"
 #include "tensorflow/core/lib/core/errors.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -99,5 +98,11 @@ REGISTER_KERNEL_BUILDER(Name("Requantize")
                             .TypeConstraint<qint32>("Tinput")
                             .TypeConstraint<quint8>("out_type"),
                         RequantizeOp<qint32, quint8>);
+
+REGISTER_KERNEL_BUILDER(Name("Requantize")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<qint32>("Tinput")
+                            .TypeConstraint<qint8>("out_type"),
+                        RequantizeOp<qint32, qint8>);
 
 }  // namespace tensorflow


### PR DESCRIPTION
Add registration for RequantizeOp for to support "int8" date type.

Currently RequantizeOp only supports "qint8". MklQuantizedConvOp etc ops already support both. 