### PR TITLE
Fetch real CPU cache values for Conv2DCustomBackpropInputOp kernel

### DIFF
--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -394,9 +394,9 @@ class Conv2DCustomBackpropInputOp : public OpKernel {
     const int output_image_size =
         dims.spatial_dims[0].output_size * dims.spatial_dims[1].output_size;
 
-    // TODO(andydavis) Get L2/L3 cache sizes from device.
-    const size_t l2_cache_size = 256LL << 10;
-    const size_t l3_cache_size = 30LL << 20;
+    // We're always under CPUDevice for the class, so this is safe
+    const size_t l2_cache_size = Eigen::l2CacheSize();
+    const size_t l3_cache_size = Eigen::l3CacheSize();
 
     // Use L3 cache size as target working set size.
     const size_t target_working_set_size = l3_cache_size / sizeof(T);


### PR DESCRIPTION
This brings about from 4%/5%/7% speedups on cifar10 runs on an
Intel(R) Core(TM) i9-7900X CPU @ 3.30GHz for
MKL-DNN/Eigen-AVX512/Eigen-AVX2 builds, respectively.