### PR TITLE
Support lowercase for precision mode

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -666,6 +666,7 @@ class TrtGraphConverter(GraphConverter):
                       ".".join([str(x) for x in loaded_version]))
 
     # Check input arguments.
+    precision_mode = precision_mode.upper()
     if precision_mode not in TrtPrecisionMode.supported_precision_modes():
       raise ValueError(("precision mode '{}' is not supported."
                         "It should be one of {}").format(


### PR DESCRIPTION
TF-TRT used to work with lowercase letters for the precision mode in the API. This was broken recently. I am not sure if the breakage was in purpose. But we would need this for backward compatibility.