### PR TITLE
Fix eigen_spatial_convolutions_test benchmarks

### DIFF
--- a/tensorflow/core/kernels/eigen_spatial_convolutions_test.cc
+++ b/tensorflow/core/kernels/eigen_spatial_convolutions_test.cc
@@ -1468,6 +1468,10 @@ static void PackRhsHelper(int iters,
   std::vector<Evaluator> evaluators;
   std::vector<InputMapper> input_mappers;
 
+  inputs.reserve(num_inputs);
+  evaluators.reserve(num_inputs);
+  input_mappers.reserve(num_inputs);
+
   for (int i = 0; i < num_inputs; ++i) {
     inputs.emplace_back(input_dims);
     inputs[i].setRandom();
@@ -1651,6 +1655,10 @@ static void PackLhsHelper(int iters,
   std::vector<Tensor<float, 4>> filters;
   std::vector<Evaluator> evaluators;
   std::vector<InputMapper> input_mappers;
+
+  filters.reserve(num_filters);
+  evaluators.reserve(num_filters);
+  input_mappers.reserve(num_filters);
 
   for (int i = 0; i < num_filters; ++i) {
     filters.emplace_back(filter_dims);


### PR DESCRIPTION
This commit fixes a crash in PackRhsHelper caused by a memory corruption
error.  The function contains a loop that populates two vectors, one
containing input Tensors and the other containing InputMappers that point to
those input Tensors.  The problem is that the emplace_back call on the
vector of input Tensors can cause that vector to grow which can
invalidate the pointers to the previously allocated input Tensors.
Unfortunately, these invalidated pointers are still used by the InputMappers
in the second vector and so when we use the InputMappers we get a crash.
The commit fixes the issue by reserving sufficient space in the input vector
thereby preventing reallocations and invalidation of the pointers to the
Input Tensors.

Although the PackLhsHelper function does not crash on my machine it suffers
from the same error and so this commit also contains a fix for that function.

Fixes: https://github.com/tensorflow/tensorflow/issues/26251