### PR TITLE
[TF 2.0 API docs] expanding the tf.keras.activations.relu and tf.keras.activations.softmax documentation 

### DIFF
--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -42,17 +42,26 @@ _TF_ACTIVATIONS_V2 = {
 
 @keras_export('keras.activations.softmax')
 def softmax(x, axis=-1):
-  """Softmax activation function.
+  """Applies the softmax activation function.
+
+  This activation, often used to generate outputs representing probabilities, first applies the standard exponential function to the input and then normalizes the result.
+
+  ```python
+  t = tf.constant([[-1.1, 1.1, .7])
+  softmax(t).numpy() # ==> [[0.06220971, 0.5614435 , 0.37634683]]
+  sum(sum(softmax(t))).numpy() # ==> 1.0
+  ```
 
   Arguments:
-      x : Input tensor.
-      axis: Integer, axis along which the softmax normalization is applied.
+      `x` : A `Tensor` or `Variable`.
+      `axis`: An `integer` giving the axis along which the softmax normalization is to be applied.
 
   Returns:
-      Tensor, output of softmax transformation.
+      A `Tensor` representing the softmax transformation of the input tensor.
 
   Raises:
-      ValueError: In case `dim(x) == 1`.
+      ValueError: if the dimension of `x` is 1.
+      ValueError: if an element of the input is not of a permissible `float`, `half`, or `double` type.
   """
   ndim = K.ndim(x)
   if ndim == 2:
@@ -158,7 +167,7 @@ def relu(x, alpha=0., max_value=None, threshold=0.):
   ```
 
   Arguments:
-    `x`: A tensor or variable.
+    `x`: A `Tensor` or `Variable`.
     `alpha`: A `float` that governs the slope of the activation function for values lower than the threshold. By default, this is `0.`; small positive values correspond to 'leaky' ReLUs.
     `max_value`: A `float` or `None` giving the saturation threshold (the largest value the function can take). The default is `None`, indicating that there is no such threshold.
     `threshold`: A `float` giving the threshold value below which values will be damped or set to zero (`0.` by default).

--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -159,15 +159,15 @@ def relu(x, alpha=0., max_value=None, threshold=0.):
 
   Arguments:
     `x`: A tensor or variable.
-    `alpha`: A scalar that governs the slope of the activation function for values lower than the threshold. By default, this is `0.`; small positive values correspond to 'leaky' ReLUs.
-    `max_value`: A float or `None` giving the saturation threshold (the largest value the function can take). The default is `None`, indicating that there is no such threshold.
-    `threshold`: A float giving the threshold value below which values will be damped or set to zero (`0.` by default).
+    `alpha`: A `float` that governs the slope of the activation function for values lower than the threshold. By default, this is `0.`; small positive values correspond to 'leaky' ReLUs.
+    `max_value`: A `float` or `None` giving the saturation threshold (the largest value the function can take). The default is `None`, indicating that there is no such threshold.
+    `threshold`: A `float` giving the threshold value below which values will be damped or set to zero (`0.` by default).
 
   Returns:
     A `Tensor` representing the input tensor transformed by the ReLU activation function.
 
   Raises:
-    ValueError: if an element of the input is not a permissible `float` or `int` type.
+    ValueError: if an element of the input is not of a permissible `float` or `int` type.
   """
   return K.relu(x, alpha=alpha, max_value=max_value, threshold=threshold)
 

--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -141,24 +141,33 @@ def softsign(x):
 
 
 @keras_export('keras.activations.relu')
-def relu(x, alpha=0., max_value=None, threshold=0):
-  """Rectified Linear Unit.
+def relu(x, alpha=0., max_value=None, threshold=0.):
+  """Applies the ReLU activation function.
 
-  With default values, it returns element-wise `max(x, 0)`.
+  With default values, this returns the standard ReLU activation: the element-wise maximum of 0 and the input tensor. This activation is used in many graph architectures.
 
-  Otherwise, it follows:
-  `f(x) = max_value` for `x >= max_value`,
-  `f(x) = x` for `threshold <= x < max_value`,
-  `f(x) = alpha * (x - threshold)` otherwise.
+  Modifying default parameter values allows you to use thresholds other than zero, to set maximum values of the activation, and to use non-zero multiples of the input for values below the threshold.
+  
+  ```python
+  t = tf.constant([.55, -.25, 0, -1.25, .75, 1.333])
+
+  relu(t).eval() # ==> [0.55  0.    0.    0.    0.75  1.333]
+  relu(t, alpha=.05).eval() # ==> [0.55   -0.0125  0.     -0.0625  0.75    1.333]
+  relu(t, max_value=1.0).eval() # ==> [0.55 0.   0.   0.   0.75 1.]
+  relu(t, threshold=-.5).eval() # ==> [ 0.55  -0.25   0.    -0.     0.75   1.333]
+  ```
 
   Arguments:
-      x: A tensor or variable.
-      alpha: A scalar, slope of negative section (default=`0.`).
-      max_value: float. Saturation threshold.
-      threshold: float. Threshold value for thresholded activation.
+    `x`: A tensor or variable.
+    `alpha`: A scalar that governs the slope of the activation function for values lower than the threshold. By default, this is `0.`; small positive values correspond to 'leaky' ReLUs.
+    `max_value`: A float or `None` giving the saturation threshold (the largest value the function can take). The default is `None`, indicating that there is no such threshold.
+    `threshold`: A float giving the threshold value below which values will be damped or set to zero (`0.` by default).
 
   Returns:
-      A tensor.
+    A `Tensor` representing the input tensor transformed by the ReLU activation function.
+
+  Raises:
+    ValueError: if an element of the input is not a permissible `float` or `int` type.
   """
   return K.relu(x, alpha=alpha, max_value=max_value, threshold=threshold)
 


### PR DESCRIPTION
This addresses issue #26211 (https://github.com/tensorflow/tensorflow/issues/26211). I would be very happy to revise anything that's still incorrect here.