### PR TITLE
Use localtime instead of gmtime for message logged

### DIFF
--- a/tensorflow/python/training/evaluation.py
+++ b/tensorflow/python/training/evaluation.py
@@ -254,7 +254,7 @@ def _evaluate_once(checkpoint_path,
         h._set_evals_completed_tensor(eval_step_value)  # pylint: disable=protected-access
 
   logging.info('Starting evaluation at ' + time.strftime('%Y-%m-%dT%H:%M:%SZ',
-                                                         time.gmtime()))
+                                                         time.localtime()))
 
   # Prepare the session creator.
   session_creator = monitored_session.ChiefSessionCreator(
@@ -274,5 +274,5 @@ def _evaluate_once(checkpoint_path,
         session.run(eval_ops, feed_dict)
 
   logging.info('Finished evaluation at ' + time.strftime('%Y-%m-%d-%H:%M:%S',
-                                                         time.gmtime()))
+                                                         time.localtime()))
   return final_ops_hook.final_ops_values


### PR DESCRIPTION
C++ logging and python logging both use localtime(), however this
one method uses gmtime() which causes the log of a run to show
timestamps that can be hours apart. Let's be consistent as use
localtime() everywhere.