### PR TITLE
Fix for -latomic flag not working for Mac OSX Mojave builds

### DIFF
--- a/tensorflow/lite/build_def.bzl
+++ b/tensorflow/lite/build_def.bzl
@@ -82,6 +82,7 @@ def tflite_jni_linkopts_unstripped():
         "//tensorflow:android": [
             "-Wl,--gc-sections",  # Eliminate unused code and data.
             "-Wl,--as-needed",  # Don't link unused libs.
+            "-latomic", # Non Android builds don't work with libatomic
         ],
         "//conditions:default": [],
     })
@@ -99,7 +100,7 @@ def tflite_jni_linkopts():
     """Defines linker flags to reduce size of TFLite binary with JNI."""
     return tflite_jni_linkopts_unstripped() + select({
         "//tensorflow:android": [
-            "-latomic",
+            "-latomic", "-s", # Omit symbol table, for all non debug builds.
         ],
         "//tensorflow:debug": [],
         "//conditions:default": [

--- a/tensorflow/lite/build_def.bzl
+++ b/tensorflow/lite/build_def.bzl
@@ -97,9 +97,10 @@ def tflite_linkopts():
 
 def tflite_jni_linkopts():
     """Defines linker flags to reduce size of TFLite binary with JNI."""
-    return tflite_jni_linkopts_unstripped() + [
-        "-latomic",  # Required for some uses of ISO C++11 <atomic> in x86.]
-    ] + select({
+    return tflite_jni_linkopts_unstripped() + select({
+        "//tensorflow:android": [
+            "-latomic",
+        ],
         "//tensorflow:debug": [],
         "//conditions:default": [
             "-s",  # Omit symbol table, for all non debug builds


### PR DESCRIPTION
This two line fix moves -latomic to be Android specific, allowing for libtensorflowlite.so to build for MacOS X 10.14.3, since it doesn't even need JNI.