### PR TITLE
Fix AttributeError on LocalBuffer.__delete__ call in python xla client

### DIFF
--- a/tensorflow/compiler/xla/python/xla_client.py
+++ b/tensorflow/compiler/xla/python/xla_client.py
@@ -431,7 +431,9 @@ class LocalBuffer(object):
 
   def delete(self):
     if self.c_buffer is not None:
-      self._backend.delete_buffer(self.c_buffer)
+      # Python may have freed c_api first.
+      if c_api:
+        self._backend.delete_buffer(self.c_buffer)
       self.c_buffer = None
 
   def destructure(self):


### PR DESCRIPTION
While playing around with some custom JAX primitives, I was noticing the python xla client throwing exceptions like below towards the end (probably when LocalBuffer is gc'd or in a separate cleanup operation). The exceptions are ignored, but they are logged many times in the code that I am working with. This adds a small check (taken from the Executable class) to ensure that `c_api` hasn't already been freed in the `LocalBuffer.delete()` method.

```
Exception ignored in: <bound method LocalBuffer.__del__ of <jaxlib.xla_client.LocalBuffer object at 0x1267a55c0>>
Traceback (most recent call last):
  File "/Users/npradhan/miniconda3/envs/numpyro/lib/python3.6/site-packages/jaxlib/xla_client.py", line 393, in __del__
  File "/Users/npradhan/miniconda3/envs/numpyro/lib/python3.6/site-packages/jaxlib/xla_client.py", line 377, in delete
  File "/Users/npradhan/miniconda3/envs/numpyro/lib/python3.6/site-packages/jaxlib/xla_client.py", line 104, in delete_buffer
AttributeError: 'NoneType' object has no attribute 'DeleteLocalShapedBuffer'
```

cc. @hawkinsp 