### PR TITLE
Disable bincount_op_test on windows gpu.

### DIFF
--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -179,6 +179,7 @@ tf_py_test(
         "//tensorflow/python:math_ops",
         "//tensorflow/python:framework_for_generated_wrappers",
     ],
+    tags = ["no_windows_gpu"],
 )
 
 tf_py_test(


### PR DESCRIPTION
PiperOrigin-RevId: 236907827