### PR TITLE
Added Average Filtering 1D

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3536,6 +3536,7 @@ def combined_non_max_suppression(boxes,
         boxes, scores, max_output_size_per_class, max_total_size, iou_threshold,
         score_threshold, pad_per_class)
 
+
 @tf_export('image.average_filtering')
 def average_filtering(tf_img,filter_shape=3):
     # This methods takes both 2D Tensor as well as 3D Tensor Images
@@ -3544,50 +3545,47 @@ def average_filtering(tf_img,filter_shape=3):
     # Filter_size should be odd
     # This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
     try:
-        m,no = int(tf_img.shape[0]),int(tf_img.shape[1])
+        m, no = int(tf_img.shape[0]), int(tf_img.shape[1])
     except:
         raise Exception("Input Tensor is not an image")
-    try :
+    try:
         ch = int(tf_img.shape[2])
     except:
         ch = 1
-    tf_img = array_ops.reshape(tf_img,[m * no * ch])
-    if tf_img.shape[0] < filter_shape:
+        tf_img = array_ops.reshape(tf_img, [m, no, ch])
+    if m * no < filter_shape:
         raise Exception('No of Pixels in the image should be more than the filter size')
     if filter_shape % 2 == 0:
         raise Exception("Filter size should be odd")
     sess = session.InteractiveSession()
     tf_img = tf_img.eval()
     tf_img = tf_img.astype('float64')
-    maxi = max(tf_img)
+    t_i = tf_img.reshape(m * no * ch)
+    maxi = max(t_i)
     if maxi == 1:
         tf_img /= maxi
-    else :
+    else:
         tf_img /= 255
-    #k is the Zero-padding size
-    k = (filter_shape - 1)
-    n = np.empty((tf_img.shape[0] + k) )
-    for i in range(0,k/2) :
-        n[i] =  0
-    for i in range(0,tf_img.shape[0]) :
-        n[i + k/2] = tf_img[i]
-    for i in range(n.shape[0] - k/2,n.shape[0]):
-        n[i] = 0
-    res = np.empty([tf_img.shape[0]])
-    l = []
-    for i in range(filter_shape):
-        l.append(n[i])
-    for i in range(tf_img.shape[0]):
-        res[i] = sum(l) / len(l)
-        if i == tf_img.shape[0] :
-            break
-        del(l[0])
-        l.append(n[i + k])
+    res = np.empty((m, no, ch))
 
+    for a in range(ch):
+        img = tf_img[:, :, a:a + 1]
+        img = img.reshape(m * no)
+        k = (filter_shape - 1)
+        img = tf.convert_to_tensor(img)
+        img = tf.pad(img, tf.constant([[k / 2, k / 2]]), 'CONSTANT')
+        img = img.eval()
+        res1 = np.empty((m * no))
+        for i in range(img.shape[0] - k):
+            li = []
+            for b in range(i, i + filter_shape):
+                li.append(img[b])
+            li.sort()
+            res1[i] = sum(li) / filter_shape
+        res1 = res1.reshape(m, no, 1)
+        res[:, :, a:a + 1] = res1
     res *= 255
     res = res.astype('int')
     res = ops.convert_to_tensor(res)
-    res = array_ops.reshape(res,(m,no,ch))
     sess.close()
-
     return res

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3580,7 +3580,6 @@ def average_filtering(tf_img,filter_shape=3):
             li = []
             for b in range(i, i + filter_shape):
                 li.append(img[b])
-            li.sort()
             res1[i] = sum(li) / filter_shape
         res1 = res1.reshape(m, no, 1)
         res[:, :, a:a + 1] = res1

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -40,7 +40,9 @@ from tensorflow.python.ops import string_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
-from tensorflow.python.client import session
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import image_ops_impl
+from tensorflow.python.ops import script_ops
 
 
 ops.NotDifferentiable('RandomCrop')
@@ -3536,55 +3538,51 @@ def combined_non_max_suppression(boxes,
         boxes, scores, max_output_size_per_class, max_total_size, iou_threshold,
         score_threshold, pad_per_class)
 
+@tf_export('image.average_filter_1D')
+def average_filter_1D(input,filter_shape=3):
+    """  This methods takes 3D Tensor Images.
+         Other than Tensor it takes optional parameter filter_Size
+         Default Filter Shape = 3
+         This Median Filtering is done by using 1D filters of user's choice
+         Filter_size should be odd
+         This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
+    """
 
-@tf_export('image.average_filtering')
-def average_filtering(tf_img,filter_shape=3):
-    # This methods takes both 2D Tensor as well as 3D Tensor Images
-    # Other than Tensor it takes optional parameter filter_Size
-    # Default Filter Size = 3
-    # Filter_size should be odd
-    # This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
-    try:
-        m, no = int(tf_img.shape[0]), int(tf_img.shape[1])
-    except:
-        raise Exception("Input Tensor is not an image")
-    try:
-        ch = int(tf_img.shape[2])
-    except:
-        ch = 1
-        tf_img = array_ops.reshape(tf_img, [m, no, ch])
-    if m * no < filter_shape:
-        raise Exception('No of Pixels in the image should be more than the filter size')
-    if filter_shape % 2 == 0:
-        raise Exception("Filter size should be odd")
-    sess = session.InteractiveSession()
-    tf_img = tf_img.eval()
-    tf_img = tf_img.astype('float64')
-    t_i = tf_img.reshape(m * no * ch)
-    maxi = max(t_i)
-    if maxi == 1:
-        tf_img /= maxi
-    else:
-        tf_img /= 255
-    res = np.empty((m, no, ch))
+    input = image_ops_impl._Assert3DImage(input)
+    m,no,ch = int(input.shape[0]),int(input.shape[1]),int(input.shape[2])
+    filter_shapex = filter_shape
+    if m * no < filter_shapex :
+        raise ValueError("No of Pixels in each dimension of the image should be more than the filter size. Got filter_shape "
+                         "(%s)"% filter_shape+" Image Shape (%s)"% input.shape)
+    if filter_shapex % 2 == 0 :
+        raise ValueError("Filter size should be odd. Got filter_shape (%s)" % filter_shape )
+    input = math_ops.cast(input,dtypes.float64)
+    def my_func (input2):
+        tf_i = input2.reshape(m*no*ch)
+        maxi = max(tf_i)
+        if maxi == 1:
+            input2 /= maxi
+        else :
+            input2 /= 255
+        #k and l is the Zero-padding size
+        res = np.empty((m,no,ch))
+        for a in range(ch):
+            img = input2[:,:,a:a+1]
+            img = img.reshape(m * no)
+            k = filter_shapex - 1
+            img  = np.pad(img,((k / 2, k / 2)),'constant', constant_values=(0))
+            res1 = np.empty((m*no))
+            for i in range(img.shape[0] - k):
+                li = []
+                for b in range(i, i + filter_shapex):
+                    li.append(img[b])
+                res1[i] = sum(li) / filter_shapex
+            res1 = res1.reshape(m,no,1)
+            res[:,:,a:a+1] = res1
+        res *= 255
+        res = res.astype('int64')
+        return res
 
-    for a in range(ch):
-        img = tf_img[:, :, a:a + 1]
-        img = img.reshape(m * no)
-        k = (filter_shape - 1)
-        img = tf.convert_to_tensor(img)
-        img = tf.pad(img, tf.constant([[k / 2, k / 2]]), 'CONSTANT')
-        img = img.eval()
-        res1 = np.empty((m * no))
-        for i in range(img.shape[0] - k):
-            li = []
-            for b in range(i, i + filter_shape):
-                li.append(img[b])
-            res1[i] = sum(li) / filter_shape
-        res1 = res1.reshape(m, no, 1)
-        res[:, :, a:a + 1] = res1
-    res *= 255
-    res = res.astype('int')
-    res = ops.convert_to_tensor(res)
-    sess.close()
-    return res
+    y = script_ops.py_func(my_func, [input], dtypes.int64)
+    return y
+

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3541,7 +3541,7 @@ def combined_non_max_suppression(boxes,
   
 @tf_export('image.average_filter_1D')
 def average_filter_1D(input,filter_shape=3):
-    """This method performs 1D Median Filtering on images.Filter shape can be user given.
+    """This method performs 1D Average Filtering on images.Filter shape can be user given.
        This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
        Args:
            input: A 3D `Tensor` of type `float32` or 'int32' or 'float64' or 'int64 and of shape`[rows, columns, channels]`

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -41,7 +41,7 @@ from tensorflow.python.ops import variables
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
 from tensorflow.python.framework import dtypes
-from tensorflow.python.ops import image_ops_impl
+from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import script_ops
 
 
@@ -3540,19 +3540,30 @@ def combined_non_max_suppression(boxes,
 
 @tf_export('image.average_filter_1D')
 def average_filter_1D(input,filter_shape=3):
-    """  This methods takes 3D Tensor Images.
-         Other than Tensor it takes optional parameter filter_Size
-         Default Filter Shape = 3
-         This Median Filtering is done by using 1D filters of user's choice
-         Filter_size should be odd
-         This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
+    """This method performs 1D Average Filtering on images. Filter shape can be user given.
+       This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
+       Args:
+           input: A 3D `Tensor` of type `float32` or 'int32' or 'float64' or 'int64 and of shape`[rows, columns, channels]`
+
+           filter_shape: Optional Argument.Single Integer. Default value = 3
+
+        Returns:
+            A 3D median filtered image tensor of shape [rows,columns,channels] and type 'int64'. Pixel value of returned tensor
+            ranges between 0 to 255
     """
 
-    input = image_ops_impl._Assert3DImage(input)
-    m,no,ch = int(input.shape[0]),int(input.shape[1]),int(input.shape[2])
+    if not isinstance(filter_shape, int):
+        raise TypeError("Filter shape must be an Integer")
     filter_shapex = filter_shape
+    input = image_ops_impl._Assert3DImage(input)
+    m, no, ch = input.shape[0], input.shape[1], input.shape[2]
+    if not m.__eq__(tensor_shape.Dimension(None)) and not no.__eq__(tensor_shape.Dimension(None)) \
+            and not ch.__eq__(tensor_shape.Dimension(None)):
+        m, no, ch = int(m), int(no), int(ch)
+    else:
+        raise TypeError("All the Dimensions of the input image tensor must be Integers")
     if m * no < filter_shapex :
-        raise ValueError("No of Pixels in each dimension of the image should be more than the filter size. Got filter_shape "
+        raise ValueError("No of Pixels in each channel of the image should be more than the filter size. Got filter_shape "
                          "(%s)"% filter_shape+" Image Shape (%s)"% input.shape)
     if filter_shapex % 2 == 0 :
         raise ValueError("Filter size should be odd. Got filter_shape (%s)" % filter_shape )

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3560,8 +3560,8 @@ def average_filter_1D(input,filter_shape=3):
     def my_func (input2):
         tf_i = input2.reshape(m*no*ch)
         maxi = max(tf_i)
-        if maxi == 1:
-            input2 /= maxi
+        if maxi <= 1:
+            input2 /= 1
         else :
             input2 /= 255
         #k and l is the Zero-padding size

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -40,6 +40,8 @@ from tensorflow.python.ops import string_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
+from tensorflow.python.client import session
+
 
 ops.NotDifferentiable('RandomCrop')
 # TODO(b/31222613): This op may be differentiable, and there may be
@@ -3533,3 +3535,59 @@ def combined_non_max_suppression(boxes,
     return gen_image_ops.combined_non_max_suppression(
         boxes, scores, max_output_size_per_class, max_total_size, iou_threshold,
         score_threshold, pad_per_class)
+
+@tf_export('image.average_filtering')
+def average_filtering(tf_img,filter_shape=3):
+    # This methods takes both 2D Tensor as well as 3D Tensor Images
+    # Other than Tensor it takes optional parameter filter_Size
+    # Default Filter Size = 3
+    # Filter_size should be odd
+    # This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
+    try:
+        m,no = int(tf_img.shape[0]),int(tf_img.shape[1])
+    except:
+        raise Exception("Input Tensor is not an image")
+    try :
+        ch = int(tf_img.shape[2])
+    except:
+        ch = 1
+    tf_img = array_ops.reshape(tf_img,[m * no * ch])
+    if tf_img.shape[0] < filter_shape:
+        raise Exception('No of Pixels in the image should be more than the filter size')
+    if filter_shape % 2 == 0:
+        raise Exception("Filter size should be odd")
+    sess = session.InteractiveSession()
+    tf_img = tf_img.eval()
+    tf_img = tf_img.astype('float64')
+    maxi = max(tf_img)
+    if maxi == 1:
+        tf_img /= maxi
+    else :
+        tf_img /= 255
+    #k is the Zero-padding size
+    k = (filter_shape - 1)
+    n = np.empty((tf_img.shape[0] + k) )
+    for i in range(0,k/2) :
+        n[i] =  0
+    for i in range(0,tf_img.shape[0]) :
+        n[i + k/2] = tf_img[i]
+    for i in range(n.shape[0] - k/2,n.shape[0]):
+        n[i] = 0
+    res = np.empty([tf_img.shape[0]])
+    l = []
+    for i in range(filter_shape):
+        l.append(n[i])
+    for i in range(tf_img.shape[0]):
+        res[i] = sum(l) / len(l)
+        if i == tf_img.shape[0] :
+            break
+        del(l[0])
+        l.append(n[i + k])
+
+    res *= 255
+    res = res.astype('int')
+    res = ops.convert_to_tensor(res)
+    res = array_ops.reshape(res,(m,no,ch))
+    sess.close()
+
+    return res


### PR DESCRIPTION
Code to test the newly added Average filtering feature. This is working fine at my end.

import tensorflow as tf
import matplotlib.pyplot
import matplotlib.pyplot as plt
from tensorflow.python.ops import array_ops
from tensorflow.python.util.tf_export import tf_export
from tensorflow.python.framework import ops
from tensorflow.python.ops import math_ops
from tensorflow.python.framework import dtypes
from tensorflow.python.ops import image_ops_impl
from tensorflow.python.ops import script_ops

fname = 'add noise  image.png'
img = matplotlib.pyplot.imread(fname)
import numpy as np

tf_img = tf.convert_to_tensor(img)

@tf_export('image.average_filter_1D')
def average_filter_1D(input,filter_shape=3):
    """  This methods takes 3D Tensor Images.
         Other than Tensor it takes optional parameter filter_Size
         Default Filter Shape = 3
         This Median Filtering is done by using 1D filters of user's choice
         Filter_size should be odd
         This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
    """

    input = image_ops_impl._Assert3DImage(input)
    m,no,ch = int(input.shape[0]),int(input.shape[1]),int(input.shape[2])
    filter_shapex = filter_shape
    if m * no < filter_shapex :
        raise ValueError("No of Pixels in each dimension of the image should be more than the filter size. Got filter_shape "
                         "(%s)"% filter_shape+" Image Shape (%s)"% input.shape)
    if filter_shapex % 2 == 0 :
        raise ValueError("Filter size should be odd. Got filter_shape (%s)" % filter_shape )
    input = math_ops.cast(input,dtypes.float64)
    def my_func (input2):
        tf_i = input2.reshape(m*no*ch)
        maxi = max(tf_i)
        if maxi == 1:
            input2 /= maxi
        else :
            input2 /= 255
        #k and l is the Zero-padding size
        res = np.empty((m,no,ch))
        for a in range(ch):
            img = input2[:,:,a:a+1]
            img = img.reshape(m * no)
            k = filter_shapex - 1
            img  = np.pad(img,((k / 2, k / 2)),'constant', constant_values=(0))
            res1 = np.empty((m*no))
            for i in range(img.shape[0] - k):
                li = []
                for b in range(i, i + filter_shapex):
                    li.append(img[b])
                res1[i] = sum(li) / filter_shapex
            res1 = res1.reshape(m,no,1)
            res[:,:,a:a+1] = res1
        res *= 255
        res = res.astype('int64')
        return res

    y = script_ops.py_func(my_func, [input], dtypes.int64)
    return y

sess = tf.InteractiveSession()

mimage = average_filter_1D(tf_img,5)

fig = plt.figure()
fig.add_subplot()
plt.imshow(img,cmap='gray')
plt.show()
mimage = mimage.eval()
fig.add_subplot()
if mimage.shape[2] == 1:
    mimage = mimage.reshape(mimage.shape[0],mimage.shape[1])
plt.imshow(mimage,cmap = 'gray')
plt.show()