### PR TITLE
Remove unnecessary cast

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/integer_ops/softmax.h
+++ b/tensorflow/lite/kernels/internal/reference/integer_ops/softmax.h
@@ -85,9 +85,8 @@ inline void Softmax(const SoftmaxParams& params,
             (shifted_scale * exp_in_0).raw(), num_bits_over_unit + 31 - 8);
         const int32 shifted_output = unsat_output - 128;
 
-        output_data[i * depth + c] = static_cast<int8>(
-            std::max(std::min(shifted_output, static_cast<int32>(127)),
-                     static_cast<int32>(-128)));
+        output_data[i * depth + c] =
+            static_cast<int8>(std::max(std::min(shifted_output, 127),-128));
 
       } else {
         output_data[i * depth + c] = -128;


### PR DESCRIPTION
The cast to int32 is not needed here.