### PR TITLE
TF Lite operator_test non-trivial initializers not support fix

### DIFF
--- a/tensorflow/lite/toco/tflite/operator_test.cc
+++ b/tensorflow/lite/toco/tflite/operator_test.cc
@@ -758,13 +758,13 @@ void SimpleOutputVersioningTest() {
   Model uint8_model;
   Array& uint8_array = uint8_model.GetOrCreateArray(op.outputs[0]);
   uint8_array.data_type = ArrayDataType::kUint8;
-  OperatorSignature uint8_signature = {.model = &uint8_model, .op = &op};
+  OperatorSignature uint8_signature = {.op = &op, .model = &uint8_model};
   EXPECT_EQ(base_op->GetVersion(uint8_signature), 1);
 
   Model int8_model;
   Array& int8_array = int8_model.GetOrCreateArray(op.outputs[0]);
   int8_array.data_type = ArrayDataType::kInt8;
-  OperatorSignature int8_signature = {.model = &int8_model, .op = &op};
+  OperatorSignature int8_signature = {.op = &op, .model = &int8_model};
   EXPECT_EQ(base_op->GetVersion(int8_signature), 2);
 }
 


### PR DESCRIPTION
Bazel test case run operator_test non-trivial designated initializers not supported fix