### PR TITLE
Fix the wrong container name in AddResourceInput

### DIFF
--- a/tensorflow/core/kernels/ops_testutil.h
+++ b/tensorflow/core/kernels/ops_testutil.h
@@ -140,14 +140,13 @@ class OpsTestBase : public ::testing::Test {
     CHECK_GT(input_types_.size(), inputs_.size())
         << "Adding more inputs than types; perhaps you need to call MakeOp";
     ResourceMgr* rm = device_->resource_manager();
+    std::string container_name = container == "" ? rm->default_container() : container;
     EXPECT_TRUE(
-        rm->Create(container == "" ? rm->default_container() : container, name,
-                   resource)
-            .ok());
+        rm->Create(container_name, name, resource).ok());
     TypeIndex type_index = MakeTypeIndex<T>();
     ResourceHandle handle;
     handle.set_device(device_->name());
-    handle.set_container(container);
+    handle.set_container(container_name);
     handle.set_name(name);
     handle.set_hash_code(type_index.hash_code());
     handle.set_maybe_type_name(type_index.name());


### PR DESCRIPTION
When `container == ""`, this function puts the resource in container `default_container()`, but sets the handle to the wrong container `""`.

This PR fixes the behavior.

// Originally found by Wendy Huang. fix #26454