### PR TITLE
Not pass dtype from Glorot initialization

### DIFF
--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -1253,8 +1253,7 @@ class GlorotUniform(VarianceScaling):
         scale=1.0,
         mode="fan_avg",
         distribution="uniform",
-        seed=seed,
-        dtype=dtype)
+        seed=seed)
 
   def get_config(self):
     return {"seed": self.seed, "dtype": self.dtype.name}
@@ -1292,8 +1291,7 @@ class GlorotNormal(VarianceScaling):
         scale=1.0,
         mode="fan_avg",
         distribution="truncated_normal",
-        seed=seed,
-        dtype=dtype)
+        seed=seed)
 
   def get_config(self):
     return {"seed": self.seed, "dtype": self.dtype.name}


### PR DESCRIPTION
`VarianceScaling` is deprecated `dtype` argument and this flow is called only for floating number initialization. So, passing the `dtype` argument can be ignored. This issue will not be there with the `init_ops_v2` implementation. But currently used one is `init_ops` and this PR avoid warning thrown from all the tests run this initialization code.