### PR TITLE
updated documentation for tf.math.argmin and tf.math.argmax operations

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -24,5 +24,7 @@ b = tf.math.argmax(input = a)
 c = tf.keras.backend.eval(b)  # c = 4
 
 # here a[4] = 166.32 which is the largest element of a
+
+```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -11,5 +11,18 @@ END
   summary: "Returns the index with the largest value across dimensions of a tensor."
   description: <<END
 Note that in case of ties the identity of the return value is not guaranteed.
+
+For example:
+
+```
+import tensorflow as tf
+
+a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+
+b = tf.math.argmax(input = a)
+
+c = tf.keras.backend.eval(b)  # c = 4
+
+# here a[4] = 166.32 which is the largest element of a
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -14,17 +14,6 @@ Note that in case of ties the identity of the return value is not guaranteed.
 
 For example:
 
-```
-import tensorflow as tf
 
-a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-
-b = tf.math.argmax(input = a)
-
-c = tf.keras.backend.eval(b)  # c = 4
-
-# here a[4] = 166.32 which is the largest element of a across axis 0
-
-```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -23,7 +23,7 @@ b = tf.math.argmax(input = a)
 
 c = tf.keras.backend.eval(b)  # c = 4
 
-# here a[4] = 166.32 which is the largest element of a
+# here a[4] = 166.32 which is the largest element of a across axis 0
 
 ```
 END

--- a/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
@@ -14,17 +14,5 @@ Note that in case of ties the identity of the return value is not guaranteed.
 
 For example:
 
-```
-import tensorflow as tf
-
-a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-
-b = tf.math.argmin(input = a)
-
-c = tf.keras.backend.eval(b)  # c = 0
-
-# here a[0] = 1 which is the smallest element of a across axis 0
-
-```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
@@ -11,5 +11,20 @@ END
   summary: "Returns the index with the smallest value across dimensions of a tensor."
   description: <<END
 Note that in case of ties the identity of the return value is not guaranteed.
+
+For example:
+
+```
+import tensorflow as tf
+
+a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+
+b = tf.math.argmin(input = a)
+
+c = tf.keras.backend.eval(b)  # c = 0
+
+# here a[0] = 1 which is the smallest element of a across axis 0
+
+```
 END
 }

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -973,17 +973,6 @@ REGISTER_OP("ArgMax")
 	.Doc(R"doc(Returns the index with the largest value across dimensions of a tensor.
 inputs: Must all be the same size and shape.
 Note that in case of ties the identity of the return value is not guaranteed.
-For example:
-import tensorflow as tf
-
-a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-
-b = tf.math.argmax(input = a)
-
-c = tf.keras.backend.eval(b)  # c = 4
-
-# here a[4] = 166.32 which is the largest element of a
-
 )doc");
 
 REGISTER_OP("ArgMin")
@@ -993,7 +982,10 @@ REGISTER_OP("ArgMin")
     .Attr("T: numbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("output_type: {int32, int64} = DT_INT64")
-    .SetShapeFn(ArgOpShape);
+    .SetShapeFn(ArgOpShape)
+	.Doc(R"doc(Returns the index with the smallest value across axes of a tensor.
+Note that in case of ties the identity of the return value is not guaranteed
+)doc");
 
 namespace {
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -969,7 +969,22 @@ REGISTER_OP("ArgMax")
     .Attr("T: numbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("output_type: {int32, int64} = DT_INT64")
-    .SetShapeFn(ArgOpShape);
+    .SetShapeFn(ArgOpShape)
+	.Doc(R"doc(Returns the index with the largest value across dimensions of a tensor.
+inputs: Must all be the same size and shape.
+Note that in case of ties the identity of the return value is not guaranteed.
+For example:
+import tensorflow as tf
+
+a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+
+b = tf.math.argmax(input = a)
+
+c = tf.keras.backend.eval(b)  # c = 4
+
+# here a[4] = 166.32 which is the largest element of a
+
+)doc");
 
 REGISTER_OP("ArgMin")
     .Input("input: T")

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -160,6 +160,18 @@ def argmax_v2(input,
 
   Returns:
     A `Tensor` of type `output_type`.
+	
+	For example:
+	Usage:
+
+	```python
+	import tensorflow as tf
+	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+	b = tf.math.argmax(input = a)
+	c = tf.keras.backend.eval(b)  # c = 4
+	# here a[4] = 166.32 which is the largest element of a across axis 0
+
+	```
   """
   if axis is None:
     axis = 0
@@ -205,6 +217,17 @@ def argmin_v2(input,
 
   Returns:
     A `Tensor` of type `output_type`.
+	
+	Usage:
+
+	```python
+	import tensorflow as tf
+	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+	b = tf.math.argmin(input = a)
+	c = tf.keras.backend.eval(b)  # c = 0
+	# here a[0] = 1 which is the smallest element of a across axis 0
+
+	```
   """
   if axis is None:
     axis = 0


### PR DESCRIPTION
PR for issue #26530 and #26532

Added usage examples for `tf.math.argmin` and `tf.math.argmax` functions with this patch. Modified the `api_def_ArgMin.pbtxt` and  ` api_def_ArgMax.pbtxt`. Also added usage summary to `/tensorflow/core/ops/math_ops.cc`.