### PR TITLE
Improved tf.image.adjust_gamma for uint8 images

### DIFF
--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -239,26 +239,31 @@ class GrayscaleToRGBTest(test_util.TensorFlowTestCase):
 
 
 class AdjustGamma(test_util.TensorFlowTestCase):
-
-  def test_adjust_gamma_one(self):
-    """Same image should be returned for gamma equal to one"""
+  @test_util.run_deprecated_v1
+  def test_adjust_gamma_less_zero_float32(self):
+    """White image should be returned for gamma equal to zero"""
     with self.cached_session():
-      x_data = np.random.uniform(0, 255, (8, 8))
+      x_data = np.random.uniform(0, 1.0, (8, 8))
       x_np = np.array(x_data, dtype=np.float32)
 
       x = constant_op.constant(x_np, shape=x_np.shape)
-      y = image_ops.adjust_gamma(x, gamma=1)
 
-      y_tf = self.evaluate(y)
-      y_np = x_np
+      err_msg = "Gamma should be a non-negative real number."
 
-      self.assertAllClose(y_tf, y_np, 1e-6)
+      try:
+        image_ops.adjust_gamma(x, gamma=-1)
+      except Exception as e:
+        if err_msg not in str(e):
+          raise
+      else:
+        raise AssertionError("Exception not raised: %s" % err_msg)
 
-  def test_adjust_gamma_less_zero(self):
+  @test_util.run_deprecated_v1
+  def test_adjust_gamma_less_zero_uint8(self):
     """White image should be returned for gamma equal to zero"""
     with self.cached_session():
       x_data = np.random.uniform(0, 255, (8, 8))
-      x_np = np.array(x_data, dtype=np.float32)
+      x_np = np.array(x_data, dtype=np.uint8)
 
       x = constant_op.constant(x_np, shape=x_np.shape)
 
@@ -276,7 +281,7 @@ class AdjustGamma(test_util.TensorFlowTestCase):
   def test_adjust_gamma_less_zero_tensor(self):
     """White image should be returned for gamma equal to zero"""
     with self.cached_session():
-      x_data = np.random.uniform(0, 255, (8, 8))
+      x_data = np.random.uniform(0, 1.0, (8, 8))
       x_np = np.array(x_data, dtype=np.float32)
 
       x = constant_op.constant(x_np, shape=x_np.shape)
@@ -293,64 +298,81 @@ class AdjustGamma(test_util.TensorFlowTestCase):
       else:
         raise AssertionError("Exception not raised: %s" % err_msg)
 
-  def test_adjust_gamma_zero(self):
-    """White image should be returned for gamma equal to zero"""
+  def _test_adjust_gamma_uint8(self, gamma):
+    """Verifying the output with expected results for gamma
+    correction for uint8 images"""
     with self.cached_session():
-      x_data = np.random.uniform(0, 255, (8, 8))
-      x_np = np.array(x_data, dtype=np.float32)
-
+      x_np = np.random.uniform(0, 255, (8, 8)).astype(np.uint8)
       x = constant_op.constant(x_np, shape=x_np.shape)
-      y = image_ops.adjust_gamma(x, gamma=0)
+      y = image_ops.adjust_gamma(x, gamma=gamma)
+      y_tf = np.trunc(y.eval())
 
-      y_tf = self.evaluate(y)
+      # calculate gamma correction using numpy
+      # firstly, transform uint8 to float representation
+      # then perform correction
+      y_np = np.power(x_np / 255.0, gamma)
+      # convert correct numpy image back to uint8 type
+      y_np = np.trunc(np.clip(y_np * 255.5, 0, 255.0))
 
-      dtype = x.dtype.as_numpy_dtype
-      y_np = np.array([dtypes.dtype_range[dtype][1]] * x_np.size)
-      y_np = y_np.reshape((8, 8))
+      self.assertAllClose(y_tf, y_np, 1e-6)
+
+  def _test_adjust_gamma_float32(self, gamma):
+    """Verifying the output with expected results for gamma
+    correction for float32 images"""
+    with self.cached_session():
+      x_np = np.random.uniform(0, 1.0, (8, 8))
+      x = constant_op.constant(x_np, shape=x_np.shape)
+      y = image_ops.adjust_gamma(x, gamma=gamma)
+      y_tf = y.eval()
+
+      y_np = np.clip(np.power(x_np, gamma), 0, 1.0)
 
       self.assertAllClose(y_tf, y_np, 1e-6)
 
   @test_util.run_deprecated_v1
-  def test_adjust_gamma_less_one(self):
-    """Verifying the output with expected results for gamma
-    correction with gamma equal to half"""
-    with self.cached_session():
-      x_np = np.arange(0, 255, 4, np.uint8).reshape(8, 8)
-      y = image_ops.adjust_gamma(x_np, gamma=0.5)
-      y_tf = np.trunc(y.eval())
-
-      y_np = np.array(
-          [[0, 31, 45, 55, 63, 71, 78, 84], [
-              90, 95, 100, 105, 110, 115, 119, 123
-          ], [127, 131, 135, 139, 142, 146, 149, 153], [
-              156, 159, 162, 165, 168, 171, 174, 177
-          ], [180, 183, 186, 188, 191, 194, 196, 199], [
-              201, 204, 206, 209, 211, 214, 216, 218
-          ], [221, 223, 225, 228, 230, 232, 234, 236],
-           [238, 241, 243, 245, 247, 249, 251, 253]],
-          dtype=np.float32)
-
-      self.assertAllClose(y_tf, y_np, 1e-6)
+  def test_adjust_gamma_one_float32(self):
+    """Same image should be returned for gamma equal to one"""
+    self._test_adjust_gamma_float32(1.0)
 
   @test_util.run_deprecated_v1
-  def test_adjust_gamma_greater_one(self):
+  def test_adjust_gamma_one_uint8(self):
+    self._test_adjust_gamma_uint8(1.0)
+
+  @test_util.run_deprecated_v1
+  def test_adjust_gamma_zero_uint8(self):
+    """White image should be returned for gamma equal
+    to zero for uint8 images"""
+    self._test_adjust_gamma_uint8(gamma=0.0)
+
+  @test_util.run_deprecated_v1
+  def test_adjust_gamma_less_one_uint8(self):
     """Verifying the output with expected results for gamma
-    correction with gamma equal to two"""
-    with self.cached_session():
-      x_np = np.arange(0, 255, 4, np.uint8).reshape(8, 8)
-      y = image_ops.adjust_gamma(x_np, gamma=2)
-      y_tf = np.trunc(y.eval())
+    correction with gamma equal to half for uint8 images"""
+    self._test_adjust_gamma_uint8(gamma=0.5)
 
-      y_np = np.array(
-          [[0, 0, 0, 0, 1, 1, 2, 3], [4, 5, 6, 7, 9, 10, 12, 14], [
-              16, 18, 20, 22, 25, 27, 30, 33
-          ], [36, 39, 42, 45, 49, 52, 56, 60], [64, 68, 72, 76, 81, 85, 90, 95],
-           [100, 105, 110, 116, 121, 127, 132, 138], [
-               144, 150, 156, 163, 169, 176, 182, 189
-           ], [196, 203, 211, 218, 225, 233, 241, 249]],
-          dtype=np.float32)
+  @test_util.run_deprecated_v1
+  def test_adjust_gamma_greater_one_uint8(self):
+    """Verifying the output with expected results for gamma
+    correction for uint8 images"""
+    self._test_adjust_gamma_uint8(gamma=1.0)
 
-      self.assertAllClose(y_tf, y_np, 1e-6)
+  @test_util.run_deprecated_v1
+  def test_adjust_gamma_less_one_float32(self):
+    """Verifying the output with expected results for gamma
+    correction with gamma equal to half for float32 images"""
+    self._test_adjust_gamma_float32(0.5)
+
+  @test_util.run_deprecated_v1
+  def test_adjust_gamma_greater_one_float32(self):
+    """Verifying the output with expected results for gamma
+    correction with gamma equal to two for float32 images"""
+    self._test_adjust_gamma_float32(1.0)
+
+  @test_util.run_deprecated_v1
+  def test_adjust_gamma_zero_float32(self):
+    """White image should be returned for gamma equal
+    to zero for float32 images"""
+    self._test_adjust_gamma_float32(0.0)
 
 
 class AdjustHueTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -278,7 +278,7 @@ class AdjustGamma(test_util.TensorFlowTestCase):
       image = image_ops.adjust_gamma(x, gamma=y)
 
       err_msg = "Gamma should be a non-negative real number"
-      with self.assertRaisesRegexp(ValueError, err_msg):
+      with self.assertRaisesRegexp(errors.InvalidArgumentError, err_msg):
         self.evaluate(image)
 
   def _test_adjust_gamma_uint8(self, gamma):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -249,14 +249,8 @@ class AdjustGamma(test_util.TensorFlowTestCase):
       x = constant_op.constant(x_np, shape=x_np.shape)
 
       err_msg = "Gamma should be a non-negative real number."
-
-      try:
+      with self.assertRaisesRegexp(ValueError, err_msg):
         image_ops.adjust_gamma(x, gamma=-1)
-      except Exception as e:
-        if err_msg not in str(e):
-          raise
-      else:
-        raise AssertionError("Exception not raised: %s" % err_msg)
 
   @test_util.run_deprecated_v1
   def test_adjust_gamma_less_zero_uint8(self):
@@ -268,14 +262,8 @@ class AdjustGamma(test_util.TensorFlowTestCase):
       x = constant_op.constant(x_np, shape=x_np.shape)
 
       err_msg = "Gamma should be a non-negative real number."
-
-      try:
+      with self.assertRaisesRegexp(ValueError, err_msg):
         image_ops.adjust_gamma(x, gamma=-1)
-      except Exception as e:
-        if err_msg not in str(e):
-          raise
-      else:
-        raise AssertionError("Exception not raised: %s" % err_msg)
 
   @test_util.run_deprecated_v1
   def test_adjust_gamma_less_zero_tensor(self):
@@ -290,13 +278,8 @@ class AdjustGamma(test_util.TensorFlowTestCase):
       image = image_ops.adjust_gamma(x, gamma=y)
 
       err_msg = "Gamma should be a non-negative real number."
-      try:
+      with self.assertRaisesRegexp(ValueError, err_msg):
         self.evaluate(image)
-      except Exception as e:
-        if err_msg not in str(e):
-          raise
-      else:
-        raise AssertionError("Exception not raised: %s" % err_msg)
 
   def _test_adjust_gamma_uint8(self, gamma):
     """Verifying the output with expected results for gamma

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -248,7 +248,7 @@ class AdjustGamma(test_util.TensorFlowTestCase):
 
       x = constant_op.constant(x_np, shape=x_np.shape)
 
-      err_msg = "Gamma should be a non-negative real number."
+      err_msg = "Gamma should be a non-negative real number"
       with self.assertRaisesRegexp(ValueError, err_msg):
         image_ops.adjust_gamma(x, gamma=-1)
 
@@ -261,7 +261,7 @@ class AdjustGamma(test_util.TensorFlowTestCase):
 
       x = constant_op.constant(x_np, shape=x_np.shape)
 
-      err_msg = "Gamma should be a non-negative real number."
+      err_msg = "Gamma should be a non-negative real number"
       with self.assertRaisesRegexp(ValueError, err_msg):
         image_ops.adjust_gamma(x, gamma=-1)
 
@@ -277,7 +277,7 @@ class AdjustGamma(test_util.TensorFlowTestCase):
 
       image = image_ops.adjust_gamma(x, gamma=y)
 
-      err_msg = "Gamma should be a non-negative real number."
+      err_msg = "Gamma should be a non-negative real number"
       with self.assertRaisesRegexp(ValueError, err_msg):
         self.evaluate(image)
 


### PR DESCRIPTION
At the moment there is an inconsistency in the `adjust_*` functions of [`tf.image`](https://www.tensorflow.org/api_docs/python/tf/image): While almost all of them work perfectly fine on either `float32` or `uint8` versions of the images by converting them internally at first to the `float32` representation and them applying the modification, the `adjust_gamma` does not behave in the same way. Instead of converting the image at first to `float32` version it immediately applies the transformation. This inconsistency might confuse users or cause an unwanted behavior.

**Changes**:

- inserted a type cast to `float32` and back to the original type like in the other `adjust_*` functions
- updated docstring
- extended unit tests