### PR TITLE
Update deprecation notice to tf.contrib.ffmpeg

### DIFF
--- a/tensorflow/api_template_v1.__init__.py
+++ b/tensorflow/api_template_v1.__init__.py
@@ -50,6 +50,7 @@ WARNING: The TensorFlow contrib module will not be included in TensorFlow 2.0.
 For more information, please see:
   * https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md
   * https://github.com/tensorflow/addons
+  * https://github.com/tensorflow/io (for I/O related ops)
 If you depend on functionality not listed there, please file an issue.
 """
 contrib = LazyLoader('contrib', globals(), 'tensorflow.contrib',

--- a/tensorflow/contrib/ffmpeg/ffmpeg_ops.py
+++ b/tensorflow/contrib/ffmpeg/ffmpeg_ops.py
@@ -29,8 +29,11 @@ from tensorflow.python.util.deprecation import deprecated
 _ffmpeg_so = loader.load_op_library(
     resource_loader.get_path_to_datafile('ffmpeg.so'))
 
-
-@deprecated('2018-09-04', 'This will be deleted and should not be used.')
+@deprecated(
+    '2018-09-04',
+    'tf.contrib.ffmpeg will be removed in 2.0, the support for video '
+    'and audio will continue to be provided in tensorflow-io: '
+    'https://github.com/tensorflow/io')
 def decode_audio(contents, file_format=None, samples_per_second=None,
                  channel_count=None, stream=None):
   """Create an op that decodes the contents of an audio file.
@@ -71,7 +74,11 @@ def decode_audio(contents, file_format=None, samples_per_second=None,
 ops.NotDifferentiable('DecodeAudio')
 
 
-@deprecated('2018-09-04', 'This will be deleted and should not be used.')
+@deprecated(
+    '2018-09-04',
+    'tf.contrib.ffmpeg will be removed in 2.0, the support for video '
+    'and audio will continue to be provided in tensorflow-io: '
+    'https://github.com/tensorflow/io')
 def encode_audio(audio, file_format=None, samples_per_second=None):
   """Creates an op that encodes an audio file using sampled audio from a tensor.
 
@@ -98,7 +105,11 @@ def encode_audio(audio, file_format=None, samples_per_second=None):
 ops.NotDifferentiable('EncodeAudio')
 
 
-@deprecated('2018-09-04', 'This will be deleted and should not be used.')
+@deprecated(
+    '2018-09-04',
+    'tf.contrib.ffmpeg will be removed in 2.0, the support for video '
+    'and audio will continue to be provided in tensorflow-io: '
+    'https://github.com/tensorflow/io')
 def decode_video(contents):
   """Create an op that decodes the contents of a video file.
 


### PR DESCRIPTION
This fix is related to #21549.

The tf.contrib.ffmpeg will be removed from 2.0 and support for audio and video formats are not in tensorflow-io. This PR updates the deprecation notice so that users could be redirected to related project.

This fix fixes #21549 .

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>