### PR TITLE
Added input verification for tf.image.grayscale_to_rgb

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -230,7 +230,9 @@ def _CheckAtLeast3DImage(image, require_static=True):
         check_ops.assert_positive(
             array_ops.shape(image),
             ["all dims of 'image.shape' "
-             'must be > 0.'])
+             'must be > 0.']),
+        check_ops.assert_greater_equal(array_ops.rank(image), 3,
+            message="'image' must be at least three-dimensional.")
     ]
   else:
     return []
@@ -291,7 +293,9 @@ def _CheckGrayscaleImage(image, require_static=True):
   if not image_shape.is_fully_defined():
       return [
           check_ops.assert_equal(array_ops.shape(image)[-1], 1,
-              message="Last dimension of a grayscale image should be size 1.")
+              message="Last dimension of a grayscale image should be size 1."),
+          check_ops.assert_greater_equal(array_ops.rank(image), 3,
+            message="A grayscale image must be at least three-dimensional.")
       ]
   else:
       return []

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -261,39 +261,40 @@ def _AssertGrayscaleImage(image):
 
 
 def _CheckGrayscaleImage(image, require_static=True):
-    """Assert that we are working with properly shaped
-    grayscale image.
+  """Assert that we are working with properly shaped
+  grayscale image.
 
-    Args:
-      image: >= 3-D Tensor of size [*, height, width, depth]
+  Args:
+    image: >= 3-D Tensor of size [*, height, width, depth]
 
-    Raises:
-      ValueError: if image.shape is not a [>= 3] vector or if 
-                last dimension is not size 1.
+  Raises:
+    ValueError: if image.shape is not a [>= 3] vector or if 
+              last dimension is not size 1.
 
-    Returns:
-      An empty list, if `image` has fully defined dimensions. Otherwise, a list
-      containing an assert op is returned.
-    """
-    try:
-        if image.get_shape().ndims is None:
-            image_shape = image.get_shape().with_rank(3)
-        else:
-            image_shape = image.get_shape().with_rank_at_least(3)
-    except ValueError:
-        raise ValueError("A grayscale image must be at least three-dimensional.")
-    if require_static and not image_shape.is_fully_defined():
-      raise ValueError('\'image\' must be fully defined.')
-    if image_shape.is_fully_defined():
-        if image_shape[-1] != 1:
-            raise ValueError("Last dimension of a grayscale image should be size 1.")
-    if not image_shape.is_fully_defined():
-        return [
-            check_ops.assert_equal(array_ops.shape(image)[-1], 1,
-                message="Last dimension of a grayscale image should be size 1.")
-        ]
-    else:
-        return []
+  Returns:
+    An empty list, if `image` has fully defined dimensions. Otherwise, a list
+    containing an assert op is returned.
+  """
+  try:
+      if image.get_shape().ndims is None:
+          image_shape = image.get_shape().with_rank(3)
+      else:
+          image_shape = image.get_shape().with_rank_at_least(3)
+  except ValueError:
+      raise ValueError("A grayscale image must be at least three-dimensional.")
+  if require_static and not image_shape.is_fully_defined():
+    raise ValueError('\'image\' must be fully defined.')
+  if image_shape.is_fully_defined():
+      if image_shape[-1] != 1:
+          raise ValueError(
+              "Last dimension of a grayscale image should be size 1.")
+  if not image_shape.is_fully_defined():
+      return [
+          check_ops.assert_equal(array_ops.shape(image)[-1], 1,
+              message="Last dimension of a grayscale image should be size 1.")
+      ]
+  else:
+      return []
 
 
 def fix_image_flip_shape(image, result):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1818,7 +1818,7 @@ def grayscale_to_rgb(images, name=None):
     The converted grayscale image(s).
   """
   with ops.name_scope(name, 'grayscale_to_rgb', [images]) as name:    
-    _AssertGrayscaleImage(images)
+    images = _AssertGrayscaleImage(images)
     
     images = ops.convert_to_tensor(images, name='images')
     rank_1 = array_ops.expand_dims(array_ops.rank(images) - 1, 0)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -231,7 +231,8 @@ def _CheckAtLeast3DImage(image, require_static=True):
             array_ops.shape(image),
             ["all dims of 'image.shape' "
              'must be > 0.']),
-        check_ops.assert_greater_equal(array_ops.rank(image), 3,
+        check_ops.assert_greater_equal(
+            array_ops.rank(image), 3,
             message="'image' must be at least three-dimensional.")
     ]
   else:
@@ -250,7 +251,7 @@ def _AssertGrayscaleImage(image):
       image: >= 3-D Tensor of size [*, height, width, depth]
 
     Raises:
-      ValueError: if image.shape is not a [>= 3] vector or if 
+      ValueError: if image.shape is not a [>= 3] vector or if
                 last dimension is not size 1.
 
     Returns:
@@ -270,7 +271,7 @@ def _CheckGrayscaleImage(image, require_static=True):
     image: >= 3-D Tensor of size [*, height, width, depth]
 
   Raises:
-    ValueError: if image.shape is not a [>= 3] vector or if 
+    ValueError: if image.shape is not a [>= 3] vector or if
               last dimension is not size 1.
 
   Returns:
@@ -278,27 +279,29 @@ def _CheckGrayscaleImage(image, require_static=True):
     containing an assert op is returned.
   """
   try:
-      if image.get_shape().ndims is None:
-          image_shape = image.get_shape().with_rank(3)
-      else:
-          image_shape = image.get_shape().with_rank_at_least(3)
+    if image.get_shape().ndims is None:
+      image_shape = image.get_shape().with_rank(3)
+    else:
+      image_shape = image.get_shape().with_rank_at_least(3)
   except ValueError:
-      raise ValueError("A grayscale image must be at least three-dimensional.")
+    raise ValueError("A grayscale image must be at least three-dimensional.")
   if require_static and not image_shape.is_fully_defined():
     raise ValueError('\'image\' must be fully defined.')
   if image_shape.is_fully_defined():
-      if image_shape[-1] != 1:
-          raise ValueError(
-              "Last dimension of a grayscale image should be size 1.")
+    if image_shape[-1] != 1:
+      raise ValueError(
+          "Last dimension of a grayscale image should be size 1.")
   if not image_shape.is_fully_defined():
-      return [
-          check_ops.assert_equal(array_ops.shape(image)[-1], 1,
-              message="Last dimension of a grayscale image should be size 1."),
-          check_ops.assert_greater_equal(array_ops.rank(image), 3,
+    return [
+        check_ops.assert_equal(
+            array_ops.shape(image)[-1], 1,
+            message="Last dimension of a grayscale image should be size 1."),
+        check_ops.assert_greater_equal(
+            array_ops.rank(image), 3,
             message="A grayscale image must be at least three-dimensional.")
-      ]
+    ]
   else:
-      return []
+    return []
 
 
 def fix_image_flip_shape(image, result):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -211,6 +211,48 @@ class GrayscaleToRGBTest(test_util.TensorFlowTestCase):
       y_tf = self.evaluate(y)
       self.assertAllEqual(y_tf, y_np)
 
+  def testGrayscaleToRGBInputValidation(self):
+    # tests whether the grayscale_to_rgb function raises
+    # an exception if the input images' last dimension is
+    # not of size 1, i.e. the images have shape
+    # [batch size, height, width] or [height, width]
+
+    # tests if an exception is raised if a three dimensional
+    # input is used, i.e. the images have shape [batch size, height, width]
+    with self.cached_session(use_gpu=True):
+      # 3-D input with batch dimension.
+      x_np = np.array([[1, 2]], dtype=np.uint8).reshape([1, 1, 2])
+    
+      # this is the error message we expect the function to raise
+      err_msg = "Last dimension of a grayscale image should be size 1."
+        
+      x_tf = constant_op.constant(x_np, shape=x_np.shape)
+      try:
+        image_ops.grayscale_to_rgb(x_tf)
+      except Exception as e:
+        if err_msg not in str(e):
+          raise
+      else:
+        raise AssertionError("Exception not raised: %s" % err_msg)
+
+    # tests if an exception is raised if a two dimensional
+    # input is used, i.e. the images have shape [height, width]
+    with self.cached_session(use_gpu=True):
+      # 2-D input without batch dimension.
+      x_np = np.array([[1, 2]], dtype=np.uint8).reshape([1, 2])
+    
+      # this is the error message we expect the function to raise
+      err_msg = "A grayscale image must be at least three-dimensional."
+        
+      x_tf = constant_op.constant(x_np, shape=x_np.shape)
+      try:
+        image_ops.grayscale_to_rgb(x_tf)
+      except Exception as e:
+        if err_msg not in str(e):
+          raise
+      else:
+        raise AssertionError("Exception not raised: %s" % err_msg)
+      
   @test_util.run_deprecated_v1
   def testShapeInference(self):
     # Shape inference works and produces expected output where possible

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -223,35 +223,25 @@ class GrayscaleToRGBTest(test_util.TensorFlowTestCase):
       # 3-D input with batch dimension.
       x_np = np.array([[1, 2]], dtype=np.uint8).reshape([1, 1, 2])
     
-      # this is the error message we expect the function to raise
-      err_msg = "Last dimension of a grayscale image should be size 1."
-        
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
-      try:
+
+      # this is the error message we expect the function to raise
+      err_msg = "Last dimension of a grayscale image should be size 1"
+      with self.assertRaisesRegexp(ValueError, err_msg):
         image_ops.grayscale_to_rgb(x_tf)
-      except Exception as e:
-        if err_msg not in str(e):
-          raise
-      else:
-        raise AssertionError("Exception not raised: %s" % err_msg)
 
     # tests if an exception is raised if a two dimensional
     # input is used, i.e. the images have shape [height, width]
     with self.cached_session(use_gpu=True):
       # 2-D input without batch dimension.
       x_np = np.array([[1, 2]], dtype=np.uint8).reshape([1, 2])
-    
-      # this is the error message we expect the function to raise
-      err_msg = "A grayscale image must be at least three-dimensional."
-        
+      
       x_tf = constant_op.constant(x_np, shape=x_np.shape)
-      try:
+
+      # this is the error message we expect the function to raise
+      err_msg = "A grayscale image must be at least three-dimensional"
+      with self.assertRaisesRegexp(ValueError, err_msg):
         image_ops.grayscale_to_rgb(x_tf)
-      except Exception as e:
-        if err_msg not in str(e):
-          raise
-      else:
-        raise AssertionError("Exception not raised: %s" % err_msg)
       
   @test_util.run_deprecated_v1
   def testShapeInference(self):


### PR DESCRIPTION
At the moment there is no verification of the input's shape in `tf.image.grayscale_to_rgb`. This means that if someone uses this operation on an input with invalid shape, e.g. only a `2D` tensor (this is how `matplotlib` defines grayscale images), an error message will be raised that might be hard to understand for users. This pull requests added some assertion operations inside the operation to give the user better feedback _why_ the operation failed. This might help preventing further confusion for users, e.g. [issue 26324](https://github.com/tensorflow/tensorflow/issues/26324)