### PR TITLE
updated documentation for tf.math.argmin and tf.math.argmax operations

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -12,8 +12,14 @@ END
   description: <<END
 Note that in case of ties the identity of the return value is not guaranteed.
 
-For example:
-
-
+Usage:
+	```python
+	import tensorflow as tf
+	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+	b = tf.math.argmax(input = a)
+	c = tf.keras.backend.eval(b)  
+	# c = 4
+	# here a[4] = 166.32 which is the largest element of a across axis 0
+	```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -13,13 +13,13 @@ END
 Note that in case of ties the identity of the return value is not guaranteed.
 
 Usage:
-	```python
-	import tensorflow as tf
-	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-	b = tf.math.argmax(input = a)
-	c = tf.keras.backend.eval(b)  
-	# c = 4
-	# here a[4] = 166.32 which is the largest element of a across axis 0
-	```
+  ```python
+  import tensorflow as tf
+  a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+  b = tf.math.argmax(input = a)
+  c = tf.keras.backend.eval(b)  
+  # c = 4
+  # here a[4] = 166.32 which is the largest element of a across axis 0
+  ```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -24,5 +24,7 @@ b = tf.math.argmax(input = a)
 c = tf.keras.backend.eval(b)  # c = 4
 
 # here a[4] = 166.32 which is the largest element of a
+
+```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -11,5 +11,18 @@ END
   summary: "Returns the index with the largest value across dimensions of a tensor."
   description: <<END
 Note that in case of ties the identity of the return value is not guaranteed.
+
+For example:
+
+```
+import tensorflow as tf
+
+a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+
+b = tf.math.argmax(input = a)
+
+c = tf.keras.backend.eval(b)  # c = 4
+
+# here a[4] = 166.32 which is the largest element of a
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -14,17 +14,6 @@ Note that in case of ties the identity of the return value is not guaranteed.
 
 For example:
 
-```
-import tensorflow as tf
 
-a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-
-b = tf.math.argmax(input = a)
-
-c = tf.keras.backend.eval(b)  # c = 4
-
-# here a[4] = 166.32 which is the largest element of a across axis 0
-
-```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -12,7 +12,16 @@ END
   description: <<END
 Note that in case of ties the identity of the return value is not guaranteed.
 
-For example:
+Usage:
+
+	```python
+	import tensorflow as tf
+	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+	b = tf.math.argmax(input = a)
+	c = tf.keras.backend.eval(b)  
+	# c = 4
+	# here a[4] = 166.32 which is the largest element of a across axis 0
+	```
 
 
 END

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -23,7 +23,7 @@ b = tf.math.argmax(input = a)
 
 c = tf.keras.backend.eval(b)  # c = 4
 
-# here a[4] = 166.32 which is the largest element of a
+# here a[4] = 166.32 which is the largest element of a across axis 0
 
 ```
 END

--- a/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMax.pbtxt
@@ -17,12 +17,11 @@ Usage:
 	```python
 	import tensorflow as tf
 	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-	b = tf.math.argmax(input = a)
+	b = tf.math.argmin(input = a)
 	c = tf.keras.backend.eval(b)  
-	# c = 4
-	# here a[4] = 166.32 which is the largest element of a across axis 0
+	# c = 0
+	# here a[0] = 1 which is the smallest element of a across axis 0
 	```
-
 
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
@@ -13,13 +13,13 @@ END
 Note that in case of ties the identity of the return value is not guaranteed.
 
 Usage:
-	```python
-	import tensorflow as tf
-	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-	b = tf.math.argmin(input = a)
-	c = tf.keras.backend.eval(b)  
-	# c = 0
-	# here a[0] = 1 which is the smallest element of a across axis 0
-	```
+  ```python
+  import tensorflow as tf
+  a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+  b = tf.math.argmin(input = a)
+  c = tf.keras.backend.eval(b)  
+  # c = 0
+  # here a[0] = 1 which is the smallest element of a across axis 0
+  ```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
@@ -14,17 +14,5 @@ Note that in case of ties the identity of the return value is not guaranteed.
 
 For example:
 
-```
-import tensorflow as tf
-
-a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-
-b = tf.math.argmin(input = a)
-
-c = tf.keras.backend.eval(b)  # c = 0
-
-# here a[0] = 1 which is the smallest element of a across axis 0
-
-```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
@@ -12,7 +12,14 @@ END
   description: <<END
 Note that in case of ties the identity of the return value is not guaranteed.
 
-For example:
-
+Usage:
+	```python
+	import tensorflow as tf
+	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+	b = tf.math.argmin(input = a)
+	c = tf.keras.backend.eval(b)  
+	# c = 0
+	# here a[0] = 1 which is the smallest element of a across axis 0
+	```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ArgMin.pbtxt
@@ -11,5 +11,20 @@ END
   summary: "Returns the index with the smallest value across dimensions of a tensor."
   description: <<END
 Note that in case of ties the identity of the return value is not guaranteed.
+
+For example:
+
+```
+import tensorflow as tf
+
+a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+
+b = tf.math.argmin(input = a)
+
+c = tf.keras.backend.eval(b)  # c = 0
+
+# here a[0] = 1 which is the smallest element of a across axis 0
+
+```
 END
 }

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -970,7 +970,6 @@ REGISTER_OP("ArgMax")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("output_type: {int32, int64} = DT_INT64")
     .SetShapeFn(ArgOpShape);
- 
 
 REGISTER_OP("ArgMin")
     .Input("input: T")
@@ -980,7 +979,6 @@ REGISTER_OP("ArgMin")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("output_type: {int32, int64} = DT_INT64")
     .SetShapeFn(ArgOpShape);
-
 
 namespace {
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -973,17 +973,6 @@ REGISTER_OP("ArgMax")
 	.Doc(R"doc(Returns the index with the largest value across dimensions of a tensor.
 inputs: Must all be the same size and shape.
 Note that in case of ties the identity of the return value is not guaranteed.
-For example:
-import tensorflow as tf
-
-a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-
-b = tf.math.argmax(input = a)
-
-c = tf.keras.backend.eval(b)  # c = 4
-
-# here a[4] = 166.32 which is the largest element of a
-
 )doc");
 
 REGISTER_OP("ArgMin")
@@ -993,7 +982,10 @@ REGISTER_OP("ArgMin")
     .Attr("T: numbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("output_type: {int32, int64} = DT_INT64")
-    .SetShapeFn(ArgOpShape);
+    .SetShapeFn(ArgOpShape)
+	.Doc(R"doc(Returns the index with the smallest value across axes of a tensor.
+Note that in case of ties the identity of the return value is not guaranteed
+)doc");
 
 namespace {
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -971,7 +971,6 @@ REGISTER_OP("ArgMax")
     .Attr("output_type: {int32, int64} = DT_INT64")
     .SetShapeFn(ArgOpShape)
 	.Doc(R"doc(Returns the index with the largest value across axes of a tensor.
-inputs: Must all be the same size and shape.
 Note that in case of ties the identity of the return value is not guaranteed.
 )doc");
 
@@ -984,7 +983,6 @@ REGISTER_OP("ArgMin")
     .Attr("output_type: {int32, int64} = DT_INT64")
     .SetShapeFn(ArgOpShape)
 	.Doc(R"doc(Returns the index with the smallest value across axes of a tensor.
-inputs: Must all be the same size and shape.
 Note that in case of ties the identity of the return value is not guaranteed.
 )doc");
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -968,8 +968,9 @@ REGISTER_OP("ArgMax")
     .Output("output: output_type")
     .Attr("T: numbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
-    .Attr("output_type: {int32, int64} = DT_INT64");
-
+    .Attr("output_type: {int32, int64} = DT_INT64")
+    .SetShapeFn(ArgOpShape);
+ 
 
 REGISTER_OP("ArgMin")
     .Input("input: T")
@@ -977,7 +978,8 @@ REGISTER_OP("ArgMin")
     .Output("output: output_type")
     .Attr("T: numbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
-    .Attr("output_type: {int32, int64} = DT_INT64");
+    .Attr("output_type: {int32, int64} = DT_INT64")
+    .SetShapeFn(ArgOpShape);
 
 
 namespace {

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -970,7 +970,7 @@ REGISTER_OP("ArgMax")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("output_type: {int32, int64} = DT_INT64")
     .SetShapeFn(ArgOpShape)
-	.Doc(R"doc(Returns the index with the largest value across dimensions of a tensor.
+	.Doc(R"doc(Returns the index with the largest value across axes of a tensor.
 inputs: Must all be the same size and shape.
 Note that in case of ties the identity of the return value is not guaranteed.
 )doc");
@@ -984,7 +984,8 @@ REGISTER_OP("ArgMin")
     .Attr("output_type: {int32, int64} = DT_INT64")
     .SetShapeFn(ArgOpShape)
 	.Doc(R"doc(Returns the index with the smallest value across axes of a tensor.
-Note that in case of ties the identity of the return value is not guaranteed
+inputs: Must all be the same size and shape.
+Note that in case of ties the identity of the return value is not guaranteed.
 )doc");
 
 namespace {

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -969,11 +969,7 @@ REGISTER_OP("ArgMax")
     .Attr("T: numbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("output_type: {int32, int64} = DT_INT64")
-    .SetShapeFn(ArgOpShape)
-	.Doc(R"doc(Returns the index with the largest value across axes of a tensor.
-inputs: Must all be the same size and shape.
-Note that in case of ties the identity of the return value is not guaranteed.
-)doc");
+    .SetShapeFn(ArgOpShape);
 
 REGISTER_OP("ArgMin")
     .Input("input: T")
@@ -982,11 +978,7 @@ REGISTER_OP("ArgMin")
     .Attr("T: numbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("output_type: {int32, int64} = DT_INT64")
-    .SetShapeFn(ArgOpShape)
-	.Doc(R"doc(Returns the index with the smallest value across axes of a tensor.
-inputs: Must all be the same size and shape.
-Note that in case of ties the identity of the return value is not guaranteed.
-)doc");
+    .SetShapeFn(ArgOpShape);
 
 namespace {
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -969,7 +969,22 @@ REGISTER_OP("ArgMax")
     .Attr("T: numbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("output_type: {int32, int64} = DT_INT64")
-    .SetShapeFn(ArgOpShape);
+    .SetShapeFn(ArgOpShape)
+	.Doc(R"doc(Returns the index with the largest value across dimensions of a tensor.
+inputs: Must all be the same size and shape.
+Note that in case of ties the identity of the return value is not guaranteed.
+For example:
+import tensorflow as tf
+
+a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+
+b = tf.math.argmax(input = a)
+
+c = tf.keras.backend.eval(b)  # c = 4
+
+# here a[4] = 166.32 which is the largest element of a
+
+)doc");
 
 REGISTER_OP("ArgMin")
     .Input("input: T")

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -161,16 +161,15 @@ def argmax_v2(input,
   Returns:
     A `Tensor` of type `output_type`.
 	
-	For example:
-	Usage:
+  Usage:
 
 	```python
 	import tensorflow as tf
 	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
 	b = tf.math.argmax(input = a)
-	c = tf.keras.backend.eval(b)  # c = 4
+	c = tf.keras.backend.eval(b)  
+	# c = 4
 	# here a[4] = 166.32 which is the largest element of a across axis 0
-
 	```
   """
   if axis is None:
@@ -218,15 +217,15 @@ def argmin_v2(input,
   Returns:
     A `Tensor` of type `output_type`.
 	
-	Usage:
+  Usage:
 
 	```python
 	import tensorflow as tf
 	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
 	b = tf.math.argmin(input = a)
-	c = tf.keras.backend.eval(b)  # c = 0
+	c = tf.keras.backend.eval(b)  
+	# c = 0
 	# here a[0] = 1 which is the smallest element of a across axis 0
-
 	```
   """
   if axis is None:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -160,6 +160,18 @@ def argmax_v2(input,
 
   Returns:
     A `Tensor` of type `output_type`.
+	
+	For example:
+	Usage:
+
+	```python
+	import tensorflow as tf
+	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+	b = tf.math.argmax(input = a)
+	c = tf.keras.backend.eval(b)  # c = 4
+	# here a[4] = 166.32 which is the largest element of a across axis 0
+
+	```
   """
   if axis is None:
     axis = 0
@@ -205,6 +217,17 @@ def argmin_v2(input,
 
   Returns:
     A `Tensor` of type `output_type`.
+	
+	Usage:
+
+	```python
+	import tensorflow as tf
+	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
+	b = tf.math.argmin(input = a)
+	c = tf.keras.backend.eval(b)  # c = 0
+	# here a[0] = 1 which is the smallest element of a across axis 0
+
+	```
   """
   if axis is None:
     axis = 0

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -217,7 +217,7 @@ def argmin_v2(input,
     A `Tensor` of type `output_type`.
 	
   Usage:
-    ```python
+    	```python
 	import tensorflow as tf
 	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
 	b = tf.math.argmin(input = a)

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -217,7 +217,7 @@ def argmin_v2(input,
     A `Tensor` of type `output_type`.
 	
   Usage:
-	```python
+    ```python
 	import tensorflow as tf
 	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
 	b = tf.math.argmin(input = a)

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -162,7 +162,6 @@ def argmax_v2(input,
     A `Tensor` of type `output_type`.
 	
   Usage:
-
 	```python
 	import tensorflow as tf
 	a = [1, 10, 26.9, 2.8, 166.32, 62.3]
@@ -218,7 +217,6 @@ def argmin_v2(input,
     A `Tensor` of type `output_type`.
 	
   Usage:
-
 	```python
 	import tensorflow as tf
 	a = [1, 10, 26.9, 2.8, 166.32, 62.3]


### PR DESCRIPTION
PR for issue #26530 and #26532

Added usage examples for tf.math.argmin and tf.math.argmax functions with this patch.
Updated docstring in tensorflow/python/ops/math_ops.py