### PR TITLE
fix Apache License 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 The TensorFlow Authors.  All rights reserved.
+Copyright 2015 - 2019 The TensorFlow Authors. All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +188,7 @@ Copyright 2018 The TensorFlow Authors.  All rights reserved.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017, The TensorFlow Authors.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The text in the Apache License 2.0 appendix is not intended to be substituted in LICENSE - only when deployed in file headers. Related info, see https://github.com/github/choosealicense.com/issues/558