### PR TITLE
Support run_forever used by low-latency usecases

### DIFF
--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -463,6 +463,8 @@ Status DirectSession::RunInternal(int64 step_id, const RunOptions& run_options,
                                   CallFrameInterface* call_frame,
                                   ExecutorsAndKeys* executors_and_keys,
                                   RunMetadata* run_metadata) {
+  do {
+
   const uint64 start_time_usecs = Env::Default()->NowMicros();
   string session_id_meta = strings::StrCat("SessionRun #id=", step_id, "#");
   tracing::ScopedActivity activity(session_id_meta);
@@ -721,6 +723,8 @@ Status DirectSession::RunInternal(int64 step_id, const RunOptions& run_options,
     }
   }
   metrics::UpdateGraphExecTime(Env::Default()->NowMicros() - start_time_usecs);
+
+  } while (run_options.experimental().run_forever());
 
   return Status::OK();
 }

--- a/tensorflow/core/protobuf/config.proto
+++ b/tensorflow/core/protobuf/config.proto
@@ -501,6 +501,11 @@ message RunOptions {
     // and tail) latency.
     // Consider using this option for CPU-bound workloads like inference.
     bool use_run_handler_pool = 2;
+    // If true, then operations within this session::run() calls will be
+    // kept executing forever, without passing through python runtime:
+    // e.g. sess.run(tf.print(tf.constant(1)), options=tf.RunOptions(
+    //        experimental=tf.RunOptions.Experimental(run_forever=True)))
+    bool run_forever = 3;
   };
 
   Experimental experimental = 8;

--- a/tensorflow/tools/api/golden/v1/tensorflow.-run-options.-experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.-run-options.-experimental.pbtxt
@@ -14,5 +14,11 @@ tf_proto {
       label: LABEL_OPTIONAL
       type: TYPE_BOOL
     }
+    field {
+      name: "run_forever"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+    }
   }
 }

--- a/tensorflow/tools/api/golden/v1/tensorflow.-run-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.-run-options.pbtxt
@@ -61,6 +61,12 @@ tf_proto {
         label: LABEL_OPTIONAL
         type: TYPE_BOOL
       }
+      field {
+        name: "run_forever"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_BOOL
+      }
     }
     enum_type {
       name: "TraceLevel"


### PR DESCRIPTION
`run_forever` is an explicit option which is not enabled by default.

This PR corresponds with https://github.com/tensorflow/tensorflow/issues/26318.

Usage sample:
```python
opts = tf.RunOptions(experimental=tf.RunOptions.Experimental(run_forever=True))
sess.run(tf.print(tf.constant(1)), options=opts)
```