### PR TITLE
Retrieve input/output lengths from Eager C API

### DIFF
--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -1527,7 +1527,7 @@ int TF_OperationOutputListLength(TF_Operation* oper, const char* arg_name,
   if (!status->status.ok()) return -1;
   auto iter = name_ranges.find(arg_name);
   if (iter == name_ranges.end()) {
-    status->status = InvalidArgument("Input arg '", arg_name, "' not found");
+    status->status = InvalidArgument("Output arg '", arg_name, "' not found");
     return -1;
   }
   return iter->second.second - iter->second.first;

--- a/tensorflow/c/eager/c_api.cc
+++ b/tensorflow/c/eager/c_api.cc
@@ -63,6 +63,17 @@ using tensorflow::int64;
 using tensorflow::string;
 
 namespace {
+
+const tensorflow::OpDef* GetOpDef(TFE_Op* op, TF_Status* status) {
+  if (op->inference_ctx) {
+    return op->inference_ctx->op_def;
+  }
+  const tensorflow::OpDef* op_def;
+  status->status =
+      tensorflow::OpDefForOp(op->operation.Name().c_str(), &op_def);
+  return op_def;
+}
+
 bool IsCPU(const tensorflow::Device* d) {
   return d == nullptr || d->tensorflow_gpu_device_info() == nullptr;
 }
@@ -805,6 +816,54 @@ void TFE_OpSetAttrFunctionList(TFE_Op* op, const char* attr_name,
   op->operation.MutableAttrs()->Set(
       attr_name, tensorflow::gtl::ArraySlice<const tensorflow::NameAttrList>(
                      funcs.get(), num_values));
+}
+
+TF_CAPI_EXPORT extern int TFE_OpGetInputLength(TFE_Op* op,
+                                               const char* input_name,
+                                               TF_Status* status) {
+  const tensorflow::OpDef* op_def = GetOpDef(op, status);
+  if (!status->status.ok()) {
+    return -1;
+  }
+  tensorflow::AttrValueMap attrs;
+  op->operation.Attrs().FillAttrValueMap(&attrs);
+  tensorflow::NameRangeMap name_ranges;
+  status->status = tensorflow::NameRangesForNode(
+      tensorflow::AttrSlice(&attrs), *op_def, &name_ranges, nullptr);
+  if (!status->status.ok()) {
+    return -1;
+  }
+  auto iter = name_ranges.find(input_name);
+  if (iter == name_ranges.end()) {
+    status->status = tensorflow::errors::InvalidArgument(
+        "Input '", input_name, "' not found");
+    return -1;
+  }
+  return iter->second.second - iter->second.first;
+}
+
+TF_CAPI_EXPORT extern int TFE_OpGetOutputLength(TFE_Op* op,
+                                                const char* output_name,
+                                                TF_Status* status) {
+  const tensorflow::OpDef* op_def = GetOpDef(op, status);
+  if (!status->status.ok()) {
+    return -1;
+  }
+  tensorflow::AttrValueMap attrs;
+  op->operation.Attrs().FillAttrValueMap(&attrs);
+  tensorflow::NameRangeMap name_ranges;
+  status->status = tensorflow::NameRangesForNode(
+      tensorflow::AttrSlice(&attrs), *op_def, nullptr, &name_ranges);
+  if (!status->status.ok()) {
+    return -1;
+  }
+  auto iter = name_ranges.find(output_name);
+  if (iter == name_ranges.end()) {
+    status->status = tensorflow::errors::InvalidArgument(
+        "Output '", output_name, "' not found");
+    return -1;
+  }
+  return iter->second.second - iter->second.first;
 }
 
 void TFE_Execute(TFE_Op* op, TFE_TensorHandle** retvals, int* num_retvals,

--- a/tensorflow/c/eager/c_api.h
+++ b/tensorflow/c/eager/c_api.h
@@ -367,6 +367,16 @@ TF_CAPI_EXPORT extern void TFE_OpSetAttrFunctionList(TFE_Op* op,
                                                      const TFE_Op** value,
                                                      int num_values);
 
+// Returns the length (number of tensors) of the input argument `input_name`
+// found in the provided `op`.
+TF_CAPI_EXPORT extern int TFE_OpGetInputLength(
+    TFE_Op* op, const char* input_name, TF_Status* status);
+
+// Returns the length (number of tensors) of the output argument `output_name`
+// found in the provided `op`.
+TF_CAPI_EXPORT extern int TFE_OpGetOutputLength(
+    TFE_Op* op, const char* output_name, TF_Status* status);
+
 // Execute the operation defined by 'op' and return handles to computed
 // tensors in `retvals`.
 //

--- a/tensorflow/c/eager/c_api_test.cc
+++ b/tensorflow/c/eager/c_api_test.cc
@@ -1825,6 +1825,8 @@ TEST(CAPI, TestTFE_OpGetInputAndOutputLengths) {
   TFE_DeleteOp(identityOp);
   TFE_DeleteTensorHandle(input1);
   TFE_DeleteTensorHandle(input2);
+  TFE_DeleteTensorHandle(retvals[0]);
+  TFE_DeleteTensorHandle(retvals[1]);
 }
 
 TEST(CAPI, TestTFE_OpGetInputAndOutputLengthsFailForUnknownArguments) {

--- a/tensorflow/core/framework/node_def_util.h
+++ b/tensorflow/core/framework/node_def_util.h
@@ -294,7 +294,7 @@ Status ValidateNodeDef(const NodeDef& node_def, const OpDef& op_def);
 // returned `NameRangeMap` objects.
 typedef gtl::FlatMap<StringPiece, std::pair<int, int>, hash<StringPiece>>
     NameRangeMap;
-Status NameRangesForNode(const NodeDef& node_def, const OpDef& op_def,
+Status NameRangesForNode(const AttrSlice& attrs, const OpDef& op_def,
                          NameRangeMap* inputs, NameRangeMap* outputs);
 Status NameRangesForNode(const Node& node, const OpDef& op_def,
                          NameRangeMap* inputs, NameRangeMap* outputs);


### PR DESCRIPTION
Adds the equivalent of `TF_OperationInputListLength` and `TF_OperationOutputListLength` in the eager C API.

Note: I based the solution on the same algorithm found in these methods, which is not optimal in case you are having more than one input/output of interest and you need to call the API more than once for the same operation (e.g. attributes are collected and name ranges are computed on each call).

I presumed that optimizations could be applied later, maybe for both graph and eager execution mode.

CC: @alextp 