### PR TITLE
Fix build of TensorFlow Lite

### DIFF
--- a/tensorflow/lite/experimental/c/c_api.cc
+++ b/tensorflow/lite/experimental/c/c_api.cc
@@ -77,7 +77,7 @@ void TFL_InterpreterOptionsSetNumThreads(TFL_InterpreterOptions* options,
   options->num_threads = num_threads;
 }
 
-TFL_CAPI_EXPORT extern void TFL_InterpreterOptionsSetErrorReporter(
+void TFL_InterpreterOptionsSetErrorReporter(
     TFL_InterpreterOptions* options,
     void (*reporter)(void* user_data, const char* format, va_list args),
     void* user_data) {


### PR DESCRIPTION
Fixes compilation error on MinGW64 compiler.

https://github.com/tensorflow/tensorflow/blob/489f2cac03ee2940d971be0042e7c025686759ac/tensorflow/lite/experimental/c/c_api.cc#L80-L86

This is broken C syntax.