### PR TITLE
TFTRT: Don't try to rebuild failed engines in dynamic mode

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -376,9 +376,9 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
   }
   EngineContext* engine_context = GetEngine(input_shapes, ctx);
   if (!engine_context->cuda_engine) {
-    LOG(WARNING) << "Engine retrieval for input shapes: "
-                 << TensorShapeUtils::ShapeListString(input_shapes)
-                 << " failed. Running native segment for " << name();
+    VLOG(1) << "Engine retrieval for input shapes: "
+            << TensorShapeUtils::ShapeListString(input_shapes)
+            << " failed. Running native segment for " << name();
     ExecuteNativeSegment(ctx, helper);
     return;
   }
@@ -625,17 +625,12 @@ EngineContext* TRTEngineOp::GetEngine(
         partial_shapes, &logger, allocator, calibrator_.get(), &engine,
         use_calibration_, &convert_successfully);
     if (!status.ok()) {
-      if (convert_successfully) {
-        // This means it fail to build the engine even when the network is built
-        // successfully, probably due to internal issues. In this case we don't
-        // retry in the future.
-        cache.emplace(engine_input_shapes, absl::make_unique<EngineContext>());
-      }
-      LOG(WARNING) << "Engine creation for batch size " << batch_size
-                   << " failed " << status;
-      // Store an empty engine here so we don't try to build the same engine
-      // again.
-      cache.emplace(engine_input_shapes, empty_context);
+      LOG(WARNING) << "Engine creation for " << name() << " failed. "
+                   << "The native segment will be used instead. "
+                   << "Reason: " << status;
+      // Store an empty engine in the cache for these input shapes so we don't
+      // try to build the same failing engine again.
+      cache.emplace(engine_input_shapes, absl::make_unique<EngineContext>());
       return &empty_context;
     }
     VLOG(1) << "Conversion is done";

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -633,6 +633,9 @@ EngineContext* TRTEngineOp::GetEngine(
       }
       LOG(WARNING) << "Engine creation for batch size " << batch_size
                    << " failed " << status;
+      // Store an empty engine here so we don't try to build the same engine
+      // again.
+      cache.emplace(engine_input_shapes, empty_context);
       return &empty_context;
     }
     VLOG(1) << "Conversion is done";


### PR DESCRIPTION
If conversion fails in dynamic mode for an engine with a given input shape, we attempted to keep rebuilding it every time that input shape is seen. Since the conversion process should be deterministic wrt the input shapes, we can't expect building the same engine to succeed after failing once.

* An empty engine will be stored in the cache for the input shape which failed to build.
* The warning message which tells the user that the engine native fallback will be used will only appear the first time.
* This will prevent us from attempting to build the same engine over and over, as well as spamming the user with warnings.