### PR TITLE
Fix support for generators in Keras fit_generator

### DIFF
--- a/tensorflow/python/keras/engine/training_generator.py
+++ b/tensorflow/python/keras/engine/training_generator.py
@@ -455,7 +455,7 @@ def convert_to_generator_like(data,
     - ValueError: If `batch_size` is not provided for NumPy or EagerTensor
       inputs.
   """
-  if hasattr(data, '__next__'):
+  if hasattr(data, '__next__') or hasattr(data, 'next'):
     def _gen(data):
       """Make generator compatible."""
       for batch in data:

--- a/tensorflow/python/keras/engine/training_generator.py
+++ b/tensorflow/python/keras/engine/training_generator.py
@@ -455,6 +455,16 @@ def convert_to_generator_like(data,
     - ValueError: If `batch_size` is not provided for NumPy or EagerTensor
       inputs.
   """
+  if hasattr(data, '__next__'):
+    def _gen(data):
+      """Make generator compatible."""
+      for batch in data:
+        if len(batch) > 1:
+          yield batch[0], batch[1]
+        else:
+          yield batch[0]
+    return _gen(data), steps_per_epoch
+
   if isinstance(data, tuple):
     # Scrub `Nones` that might have been passed for `targets`, `sample_weights`.
     data = tuple(


### PR DESCRIPTION
Keras supports generators in [fit_generator](https://keras.io/models/model/#fit_generator); however, support for generators was dropped in TensorFlow Keras with https://github.com/tensorflow/tensorflow/commit/8420f5741558c79fa71b442bcc613800c3b3dfa6.

Notice that `data` should support a `generator` [training_generator.py#L439-L442](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/training_generator.py#L439-L442).

However, current code does not handle generators and assume the objects have a `shape` [training_generator.py#L458-L475](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/training_generator.py#L458-L475)

This PR fixes https://github.com/rstudio/keras/issues/682, but this is likely to be also reproducible in the Python interface. Tests are already available in the R interface for Keras.