### PR TITLE
Added dynamic pad subgraph test

### DIFF
--- a/tensorflow/lite/kernels/subgraph_test_util.cc
+++ b/tensorflow/lite/kernels/subgraph_test_util.cc
@@ -27,9 +27,11 @@ namespace tflite {
 namespace ops {
 namespace builtin {
 // ADD and MUL are used to test simple branch.
+// ADD and MUL can be used to test dynamic sized subgraphs with the
+// use of IF op.
 TfLiteRegistration* Register_ADD();
 TfLiteRegistration* Register_MUL();
-// ADD and MUL are used to test dynamic sized subgraphs.
+// PAD is used to test dynamic sized subgraphs.
 TfLiteRegistration* Register_PAD();
 TfLiteRegistration* Register_LESS_EQUAL();
 }  // namespace builtin

--- a/tensorflow/lite/kernels/subgraph_test_util_test.cc
+++ b/tensorflow/lite/kernels/subgraph_test_util_test.cc
@@ -13,11 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/lite/kernels/subgraph_test_util.h"
+
 #include <gtest/gtest.h>
 #include "tensorflow/lite/interpreter.h"
-#include "tensorflow/lite/kernels/test_util.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/subgraph_test_util.h"
+#include "tensorflow/lite/kernels/test_util.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/kernels/subgraph_test_util_test.cc
+++ b/tensorflow/lite/kernels/subgraph_test_util_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/kernels/test_util.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
 
 namespace tflite {
 
@@ -103,6 +104,22 @@ TEST_F(SubgraphBuilderTest, TestBuildPadSubgraph) {
   ASSERT_EQ(interpreter_->Invoke(), kTfLiteOk);
 
   TfLiteTensor* output = interpreter_->tensor(interpreter_->outputs()[0]);
+  CheckIntTensor(output, {5}, {0, 5, 7, 0, 0});
+}
+
+TEST_F(SubgraphBuilderTest, TestBuildDynamicPadSubgraph) {
+  builder_->BuildPadSubgraph(&interpreter_->primary_subgraph());
+
+  interpreter_->ResizeInputTensor(interpreter_->inputs()[0], {2});
+  interpreter_->ResizeInputTensor(interpreter_->inputs()[1], {1, 2});
+  ASSERT_EQ(interpreter_->AllocateTensors(), kTfLiteOk);
+
+  FillIntTensor(interpreter_->tensor(interpreter_->inputs()[0]), {5, 7});
+  FillIntTensor(interpreter_->tensor(interpreter_->inputs()[1]), {1, 2});
+  ASSERT_EQ(interpreter_->Invoke(), kTfLiteOk);
+
+  TfLiteTensor* output = interpreter_->tensor(interpreter_->outputs()[0]);
+  EXPECT_TRUE(IsDynamicTensor(output));
   CheckIntTensor(output, {5}, {0, 5, 7, 0, 0});
 }
 


### PR DESCRIPTION
PAD op return dynamic tensor directly. But ADD and MUL only return static tensors and with the use of IF, dynamic tensor subgraph can be built with ADD and MUL. 