### PR TITLE
Expose tf.lookup.TextFileIndex in 2.0

### DIFF
--- a/tensorflow/python/ops/lookup_ops.py
+++ b/tensorflow/python/ops/lookup_ops.py
@@ -421,6 +421,18 @@ class KeyValueTensorInitializer(TableInitializerBase):
 
 @tf_export("lookup.TextFileIndex")
 class TextFileIndex(object):
+  """The key and value content to get from each line.
+
+  The key and value content to get from each line is specified either
+  by the following, or a value `>=0`.
+  * `TextFileIndex.LINE_NUMBER` means use the line number starting from zero,
+    expects data type int64.
+  * `TextFileIndex.WHOLE_LINE` means use the whole line content, expects data
+    type string.
+
+  A value `>=0` means use the index (starting at zero) of the split line based
+      on `delimiter`.
+  """
   WHOLE_LINE = -2
   LINE_NUMBER = -1
 

--- a/tensorflow/python/ops/lookup_ops.py
+++ b/tensorflow/python/ops/lookup_ops.py
@@ -423,6 +423,8 @@ class KeyValueTensorInitializer(TableInitializerBase):
 class TextFileIndex(object):
   """The key and value content to get from each line.
 
+  This class defines the key and value used for tf.lookup.TextFileInitializer.
+
   The key and value content to get from each line is specified either
   by the following, or a value `>=0`.
   * `TextFileIndex.LINE_NUMBER` means use the line number starting from zero,

--- a/tensorflow/python/ops/lookup_ops.py
+++ b/tensorflow/python/ops/lookup_ops.py
@@ -419,6 +419,7 @@ class KeyValueTensorInitializer(TableInitializerBase):
     return init_op
 
 
+@tf_export("lookup.TextFileIndex")
 class TextFileIndex(object):
   WHOLE_LINE = -2
   LINE_NUMBER = -1

--- a/tensorflow/tools/api/golden/v1/tensorflow.lookup.-text-file-index.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.lookup.-text-file-index.pbtxt
@@ -1,0 +1,16 @@
+path: "tensorflow.lookup.TextFileIndex"
+tf_class {
+  is_instance: "<class \'tensorflow.python.ops.lookup_ops.TextFileIndex\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "LINE_NUMBER"
+    mtype: "<type \'int\'>"
+  }
+  member {
+    name: "WHOLE_LINE"
+    mtype: "<type \'int\'>"
+  }
+  member_method {
+    name: "__init__"
+  }
+}

--- a/tensorflow/tools/api/golden/v1/tensorflow.lookup.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.lookup.pbtxt
@@ -13,6 +13,10 @@ tf_module {
     mtype: "<type \'type\'>"
   }
   member {
+    name: "TextFileIndex"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "TextFileInitializer"
     mtype: "<type \'type\'>"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.lookup.-text-file-index.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.lookup.-text-file-index.pbtxt
@@ -1,0 +1,16 @@
+path: "tensorflow.lookup.TextFileIndex"
+tf_class {
+  is_instance: "<class \'tensorflow.python.ops.lookup_ops.TextFileIndex\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "LINE_NUMBER"
+    mtype: "<type \'int\'>"
+  }
+  member {
+    name: "WHOLE_LINE"
+    mtype: "<type \'int\'>"
+  }
+  member_method {
+    name: "__init__"
+  }
+}

--- a/tensorflow/tools/api/golden/v2/tensorflow.lookup.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.lookup.pbtxt
@@ -13,6 +13,10 @@ tf_module {
     mtype: "<type \'type\'>"
   }
   member {
+    name: "TextFileIndex"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "TextFileInitializer"
     mtype: "<type \'type\'>"
   }


### PR DESCRIPTION
This fix tries to address the issue raised in #26622 where tf.lookup.TextFileIndex was not exposed from public API though it is used by tf.lookup.TextFileInitializer which actually needs tf.lookup.TextFileIndex.

This fix exposed the tf.lookup.TextFileIndex.

This fix fixes #26622.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
