### PR TITLE
GraphOptimizationPass(POST_PARTITIONING) after graph partition

### DIFF
--- a/tensorflow/core/common_runtime/process_function_library_runtime.cc
+++ b/tensorflow/core/common_runtime/process_function_library_runtime.cc
@@ -637,10 +637,16 @@ Status ProcessFunctionLibraryRuntime::InstantiateMultiDevice(
       PartitionFunctionGraph(device_set, std::move(graph), &subgraphs));
 
   for (const auto& pair : subgraphs) {
-    DumpGraph("Before running POST_PARTITIONING passes", pair.second.get());
+    DumpGraph(strings::StrCat("Before running POST_PARTITIONING passes (",
+                              pair.first, ")"),
+              pair.second.get());
   }
   optimization_options.graph = nullptr;
+  optimization_options.device_set = nullptr;
   optimization_options.partition_graphs = &subgraphs;
+  // Normally POST_PARTITIONING passes are run by distributed workers.
+  // Distributed workers are currently not supported in this code path, so we
+  // run the passes here.
   TF_RETURN_IF_ERROR(OptimizationPassRegistry::Global()->RunGrouping(
       OptimizationPassRegistry::POST_PARTITIONING, optimization_options));
   for (const auto& pair : subgraphs) {

--- a/tensorflow/core/common_runtime/process_function_library_runtime.cc
+++ b/tensorflow/core/common_runtime/process_function_library_runtime.cc
@@ -624,7 +624,6 @@ Status ProcessFunctionLibraryRuntime::InstantiateMultiDevice(
   DumpGraph("Before running POST_REWRITE_FOR_EXEC passes", graph.get());
   TF_RETURN_IF_ERROR(OptimizationPassRegistry::Global()->RunGrouping(
       OptimizationPassRegistry::POST_REWRITE_FOR_EXEC, optimization_options));
-  DumpGraph("After all optimization passes", graph.get());
 
   if (options.graph_collector != nullptr) {
     GraphDef def;
@@ -636,6 +635,19 @@ Status ProcessFunctionLibraryRuntime::InstantiateMultiDevice(
   std::unordered_map<string, std::unique_ptr<Graph>> subgraphs;
   TF_RETURN_IF_ERROR(
       PartitionFunctionGraph(device_set, std::move(graph), &subgraphs));
+
+  for (const auto& pair : subgraphs) {
+    DumpGraph("Before running POST_PARTITIONING passes", pair.second.get());
+  }
+  optimization_options.graph = nullptr;
+  optimization_options.partition_graphs = &subgraphs;
+  TF_RETURN_IF_ERROR(OptimizationPassRegistry::Global()->RunGrouping(
+      OptimizationPassRegistry::POST_PARTITIONING, optimization_options));
+  for (const auto& pair : subgraphs) {
+    DumpGraph(
+        strings::StrCat("After all optimization passes (", pair.first, ")"),
+        pair.second.get());
+  }
 
   if (options.graph_collector != nullptr) {
     for (const auto& pair : subgraphs) {


### PR DESCRIPTION
There is difference about GraphOptimizationPass between DirectSession::CreateGraphs and ProcessFunctionLibraryRuntime::InstantiateMultiDevice.
Because **POST_REWRITE_FOR_EXEC** pass is missing in the ProcessFunctionLibraryRuntime::InstantiateMultiDevice, we can not apply the optimizations.

This PR adds the **POST_REWRITE_FOR_EXEC** pass to ProcessFunctionLibraryRuntime::InstantiateMultiDevice.