### PR TITLE
kTfLiteNullBufferHandle must be macro

### DIFF
--- a/tensorflow/lite/c/c_api_internal.h
+++ b/tensorflow/lite/c/c_api_internal.h
@@ -50,6 +50,8 @@ typedef enum {
   kTfLiteMaxExternalContexts = 3
 } TfLiteExternalContextType;
 
+struct TfLiteContext;
+
 // An external context is a collection of information unrelated to the TF Lite
 // framework, but useful to a subset of the ops. TF Lite knows very little
 // about about the actual contexts, but it keeps a list of them, and is able to

--- a/tensorflow/lite/c/c_api_internal.h
+++ b/tensorflow/lite/c/c_api_internal.h
@@ -279,7 +279,7 @@ typedef enum {
 // The delegates should use zero or positive integers to represent handles.
 // -1 is reserved from unallocated status.
 typedef int TfLiteBufferHandle;
-const TfLiteBufferHandle kTfLiteNullBufferHandle = -1;
+#define kTfLiteNullBufferHandle ((TfLiteBufferHandle)(-1))
 
 // An tensor in the interpreter system which is a wrapper around a buffer of
 // data including a dimensionality (or NULL if not currently defined).

--- a/tensorflow/lite/c/c_api_internal.h
+++ b/tensorflow/lite/c/c_api_internal.h
@@ -279,7 +279,7 @@ typedef enum {
 // The delegates should use zero or positive integers to represent handles.
 // -1 is reserved from unallocated status.
 typedef int TfLiteBufferHandle;
-#define kTfLiteNullBufferHandle ((TfLiteBufferHandle)(-1))
+#define kTfLiteNullBufferHandle (-1)
 
 // An tensor in the interpreter system which is a wrapper around a buffer of
 // data including a dimensionality (or NULL if not currently defined).


### PR DESCRIPTION
tensorflow/lite/c/c_api_internal.h have constant variable kTfLiteNullBufferHandle (not macro or static const). So we can't include this header file in several codes.