### PR TITLE
Add missing include

### DIFF
--- a/tensorflow/core/kernels/data/stats_utils.cc
+++ b/tensorflow/core/kernels/data/stats_utils.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/core/kernels/data/stats_utils.h"
 
+#include "absl/base/attributes.h"
 #include "tensorflow/core/lib/strings/strcat.h"
 
 namespace tensorflow {


### PR DESCRIPTION
This is needed for building on macOS 10.14.3, bazel 0.23.1, clang `Apple LLVM version 10.0.0 (clang-1000.11.45.5)`.