### PR TITLE
avoid SONAME check using objdump on Windows

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -735,7 +735,7 @@ def find_lib(repository_ctx, paths, check_soname = True):
     for path in [repository_ctx.path(path) for path in paths]:
         if not path.exists:
             continue
-        if check_soname and objdump != None:
+        if check_soname and objdump != None and not _is_windows(repository_ctx):
             output = repository_ctx.execute([objdump, "-p", str(path)]).stdout
             output = [line for line in output.splitlines() if "SONAME" in line]
             sonames = [line.strip().split(" ")[-1] for line in output]


### PR DESCRIPTION
Haskell Platform comes with a objdump in PATH, which fails finding cuda libs because of SONAME checking.
This is already patched in mainstream, but not merged into 2.0 branch.