### PR TITLE
Fix two golint warnings in graph.go

### DIFF
--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -53,7 +53,7 @@ type Graph struct {
 	c *C.TF_Graph
 }
 
-// Graph execution options
+// The GraphImportOptions struct holds parameters for the ImportWithOptions function.
 type GraphImportOptions struct {
 	// Node prefix
 	Prefix string
@@ -170,7 +170,7 @@ func (g *Graph) Operation(name string) *Operation {
 
 // Operations returns a list of all operations in the graph
 func (g *Graph) Operations() []Operation {
-	var pos C.size_t = 0
+	var pos C.size_t 
 	ops := []Operation{}
 	for {
 		cop := C.TF_GraphNextOperation(g.c, &pos)


### PR DESCRIPTION
The current verion of `graph.go` produces some warnings when run through
`golint`:
```shell
$ ~/go/bin/golint 
graph.go:56:1: comment on exported type GraphImportOptions should be of the form "GraphImportOptions ..." (with optional leading article)
graph.go:173:21: should drop = 0 from declaration of var pos; it is the zero value
```
I'm presuming that these warnings are unintentional, as all of the other non-generated files in the TensorFlow Go API pass `golint` cleanly.

This PR fixes the two warnings by changing two lines in `graph.go`.

After the change, running `golint` in `tensorflow/go` produces no warnings. The regression tests for the Go API also pass.
