### PR TITLE
Lite: Strided_slice 4-D bottleneck removed from kernel

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/reference_ops.h
+++ b/tensorflow/lite/kernels/internal/reference/reference_ops.h
@@ -2127,14 +2127,6 @@ inline void BatchToSpaceND(
         const T* in =
             input1_data + Offset(input1_shape, in_batch, in_h, in_w, 0);
         memcpy(out, in, depth * sizeof(T));
-
-        if (out_w < 0 || out_w >= output_width) {
-          continue;
-        }
-        T* out = output_data + Offset(output_shape, out_batch, out_h, out_w, 0);
-        const T* in =
-            input1_data + Offset(input1_shape, in_batch, in_h, in_w, 0);
-        memcpy(out, in, depth * sizeof(T));
       }
     }
   }

--- a/tensorflow/lite/kernels/internal/reference/reference_ops.h
+++ b/tensorflow/lite/kernels/internal/reference/reference_ops.h
@@ -2127,6 +2127,14 @@ inline void BatchToSpaceND(
         const T* in =
             input1_data + Offset(input1_shape, in_batch, in_h, in_w, 0);
         memcpy(out, in, depth * sizeof(T));
+
+        if (out_w < 0 || out_w >= output_width) {
+          continue;
+        }
+        T* out = output_data + Offset(output_shape, out_batch, out_h, out_w, 0);
+        const T* in =
+            input1_data + Offset(input1_shape, in_batch, in_h, in_w, 0);
+        memcpy(out, in, depth * sizeof(T));
       }
     }
   }

--- a/tensorflow/lite/kernels/internal/reference/strided_slice.h
+++ b/tensorflow/lite/kernels/internal/reference/strided_slice.h
@@ -18,6 +18,8 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/common.h"
 #include "tensorflow/lite/kernels/internal/strided_slice_logic.h"
 #include "tensorflow/lite/kernels/internal/types.h"
+#include <functional>
+
 namespace tflite {
 
 namespace reference_ops {

--- a/tensorflow/lite/kernels/strided_slice_test.cc
+++ b/tensorflow/lite/kernels/strided_slice_test.cc
@@ -400,7 +400,7 @@ TYPED_TEST(StridedSliceOpTest, In3D_Strided2) {
 }
 
 TYPED_TEST(StridedSliceOpTest, In4D_Identity) {
-  StridedSliceOpModel<> m({2, 3, 2, 2}, {4}, {4}, {4}, 0, 0, 0, 0, 0);
+  StridedSliceOpModel<TypeParam> m({2, 3, 2, 2}, {4}, {4}, {4}, 0, 0, 0, 0, 0);
   m.SetInput({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
               13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24});
   m.SetBegin({0, 0, 0, 0});
@@ -415,7 +415,7 @@ TYPED_TEST(StridedSliceOpTest, In4D_Identity) {
 }
 
 TYPED_TEST(StridedSliceOpTest, In4D_NegStride) {
-  StridedSliceOpModel<> m({2, 3, 2, 2}, {4}, {4}, {4}, 0, 0, 0, 0, 0);
+  StridedSliceOpModel<TypeParam> m({2, 3, 2, 2}, {4}, {4}, {4}, 0, 0, 0, 0, 0);
   m.SetInput({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
               13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24});
   m.SetBegin({-1, -1, -1, -1});
@@ -429,7 +429,7 @@ TYPED_TEST(StridedSliceOpTest, In4D_NegStride) {
 }
 
 TYPED_TEST(StridedSliceOpTest, In4D_Strided2) {
-  StridedSliceOpModel<> m({2, 3, 2, 2}, {4}, {4}, {4}, 0, 0, 0, 0, 0);
+  StridedSliceOpModel<TypeParam> m({2, 3, 2, 2}, {4}, {4}, {4}, 0, 0, 0, 0, 0);
   m.SetInput({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
               13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24});
   m.SetBegin({0, 0, 0, 0});

--- a/tensorflow/lite/kernels/strided_slice_test.cc
+++ b/tensorflow/lite/kernels/strided_slice_test.cc
@@ -399,6 +399,47 @@ TYPED_TEST(StridedSliceOpTest, In3D_Strided2) {
   EXPECT_THAT(m.GetOutput(), ElementsAreArray({1, 5}));
 }
 
+TYPED_TEST(StridedSliceOpTest, In4D_Identity) {
+  StridedSliceOpModel<> m({2, 3, 2, 2}, {4}, {4}, {4}, 0, 0, 0, 0, 0);
+  m.SetInput({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+              13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24});
+  m.SetBegin({0, 0, 0, 0});
+  m.SetEnd({2, 3, 2, 2});
+  m.SetStrides({1, 1, 1, 1});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 3, 2, 2}));
+  EXPECT_THAT(
+      m.GetOutput(),
+      ElementsAreArray({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
+}
+
+TYPED_TEST(StridedSliceOpTest, In4D_NegStride) {
+  StridedSliceOpModel<> m({2, 3, 2, 2}, {4}, {4}, {4}, 0, 0, 0, 0, 0);
+  m.SetInput({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+              13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24});
+  m.SetBegin({-1, -1, -1, -1});
+  m.SetEnd({-3, -4, -3, -3});
+  m.SetStrides({-1, -1, -1, -1});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 3, 2, 2}));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({24, 23, 22, 21, 20, 19, 18, 17,
+                                               16, 15, 14, 13, 12, 11, 10, 9,
+                                               8,  7,  6,  5,  4,  3,  2,  1}));
+}
+
+TYPED_TEST(StridedSliceOpTest, In4D_Strided2) {
+  StridedSliceOpModel<> m({2, 3, 2, 2}, {4}, {4}, {4}, 0, 0, 0, 0, 0);
+  m.SetInput({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+              13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24});
+  m.SetBegin({0, 0, 0, 0});
+  m.SetEnd({2, 3, 2, 2});
+  m.SetStrides({2, 2, 2, 2});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 2, 1, 1}));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({1, 9}));
+}
+
 TYPED_TEST(StridedSliceOpTest, In1D_ShrinkAxisMask1) {
   StridedSliceOpModel<TypeParam> m({4}, {1}, {1}, {1}, 0, 0, 0, 0, 1);
   m.SetInput({1, 2, 3, 4});


### PR DESCRIPTION
1:> Removed hard coding or bottleneck to 4-Dim
2:> Add assumption, that begin size and input dim are equal
3:> Add assumptions, that begin, end, stride should be of same size
4:> Error message updated