### PR TITLE
Bump abseil-py dep and min Bazel version

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1621,7 +1621,7 @@ def main():
   # environment variables.
   environ_cp = dict(os.environ)
 
-  current_bazel_version = check_bazel_version('0.19.0', '0.23.2')
+  current_bazel_version = check_bazel_version('0.22.0', '0.23.2')
   _TF_CURRENT_BAZEL_VERSION = convert_version_to_int(current_bazel_version)
 
   reset_tf_configure_bazelrc()

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -322,16 +322,16 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
 
     tf_http_archive(
         name = "absl_py",
-        sha256 = "595726be4bf3f7e6d64a1a255fa03717b693c01b913768abd52649cbb7ddf2bd",
-        strip_prefix = "abseil-py-pypi-v0.7.0",
+        sha256 = "3d0f39e0920379ff1393de04b573bca3484d82a5f8b939e9e83b20b6106c9bbe",
+        strip_prefix = "abseil-py-pypi-v0.7.1",
         system_build_file = clean_dep("//third_party/systemlibs:absl_py.BUILD"),
         system_link_files = {
             "//third_party/systemlibs:absl_py.absl.flags.BUILD": "absl/flags/BUILD",
             "//third_party/systemlibs:absl_py.absl.testing.BUILD": "absl/testing/BUILD",
         },
         urls = [
-            "https://mirror.bazel.build/github.com/abseil/abseil-py/archive/pypi-v0.7.0.tar.gz",
-            "https://github.com/abseil/abseil-py/archive/pypi-v0.7.0.tar.gz",
+            "https://mirror.bazel.build/github.com/abseil/abseil-py/archive/pypi-v0.7.1.tar.gz",
+            "https://github.com/abseil/abseil-py/archive/pypi-v0.7.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This makes builds not fail with --incompatible_remove_old_python_version_api enabled, which will become the default in Bazel 0.25. Fixes #26616.