### PR TITLE
Fix incorrect deprecation warning for tf.numpy_function

### DIFF
--- a/tensorflow/python/ops/script_ops.py
+++ b/tensorflow/python/ops/script_ops.py
@@ -389,21 +389,7 @@ def eager_py_func(func, inp, Tout, name=None):
   return _internal_py_func(func=func, inp=inp, Tout=Tout, eager=True, name=name)
 
 
-@deprecation.deprecated(
-    date=None,
-    instructions="""tf.py_func is deprecated in TF V2. Instead, there are two
-    options available in V2.
-    - tf.py_function takes a python function which manipulates tf eager
-    tensors instead of numpy arrays. It's easy to convert a tf eager tensor to
-    an ndarray (just call tensor.numpy()) but having access to eager tensors
-    means `tf.py_function`s can use accelerators such as GPUs as well as
-    being differentiable using a gradient tape.
-    - tf.numpy_function maintains the semantics of the deprecated tf.py_func
-    (it is not differentiable, and manipulates numpy arrays). It drops the
-    stateful argument making all functions stateful.
-    """)
-@tf_export(v1=["py_func"])
-def py_func(func, inp, Tout, stateful=True, name=None):
+def py_func_common(func, inp, Tout, stateful=True, name=None):
   """Wraps a python function and uses it as a TensorFlow op.
 
   Given a python function `func`, which takes numpy arrays as its
@@ -471,11 +457,30 @@ def py_func(func, inp, Tout, stateful=True, name=None):
   return _internal_py_func(
       func=func, inp=inp, Tout=Tout, stateful=stateful, eager=False, name=name)
 
+@deprecation.deprecated(
+    date=None,
+    instructions="""tf.py_func is deprecated in TF V2. Instead, there are two
+    options available in V2.
+    - tf.py_function takes a python function which manipulates tf eager
+    tensors instead of numpy arrays. It's easy to convert a tf eager tensor to
+    an ndarray (just call tensor.numpy()) but having access to eager tensors
+    means `tf.py_function`s can use accelerators such as GPUs as well as
+    being differentiable using a gradient tape.
+    - tf.numpy_function maintains the semantics of the deprecated tf.py_func
+    (it is not differentiable, and manipulates numpy arrays). It drops the
+    stateful argument making all functions stateful.
+    """)
+@tf_export(v1=["py_func"])
+def py_func(func, inp, Tout, stateful=True, name=None):
+  return py_func_common(func, inp, Tout, stateful=True, name=name)
+
+numpy_function.__doc__ = py_func_common.__doc__
+
 @tf_export("numpy_function", v1=[])
 def numpy_function(func, inp, Tout, name=None):
-  return py_func(func, inp, Tout, stateful=True, name=name)
+  return py_func_common(func, inp, Tout, stateful=True, name=name)
 
-numpy_function.__doc__ = py_func.__doc__.replace(
+numpy_function.__doc__ = py_func_common.__doc__.replace(
     "py_func", "numpy_function")
 
 

--- a/tensorflow/python/ops/script_ops.py
+++ b/tensorflow/python/ops/script_ops.py
@@ -472,9 +472,9 @@ def py_func_common(func, inp, Tout, stateful=True, name=None):
     """)
 @tf_export(v1=["py_func"])
 def py_func(func, inp, Tout, stateful=True, name=None):
-  return py_func_common(func, inp, Tout, stateful=True, name=name)
+  return py_func_common(func, inp, Tout, stateful, name=name)
 
-numpy_function.__doc__ = py_func_common.__doc__
+py_func.__doc__ = py_func_common.__doc__
 
 @tf_export("numpy_function", v1=[])
 def numpy_function(func, inp, Tout, name=None):


### PR DESCRIPTION
This fix tries to address the issue raised in #26735 where
usage of tf.numpy_function in v2 generates incorrect deprecation
warning:
```
tf.py_func is deprecated in TF V2.
```

The reason was that tf.numpy_function calls tf.py_func internal
so a warning (on tf.py_func) is always in place even though
tf.numpy_function is the correct usage in v2.

This fix reorders the calling so that incorrect warning could be addressed.

This fix fixes #26735.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>