### PR TITLE
Correct API docs for tf.io.decode_gif

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_DecodeGif.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DecodeGif.pbtxt
@@ -9,13 +9,14 @@ END
   out_arg {
     name: "image"
     description: <<END
-4-D with shape `[num_frames, height, width, 3]`. RGB order
+4-D with shape `[num_frames, height, width, 3]`. RGB channel order.
 END
   }
   summary: "Decode the frame(s) of a GIF-encoded image to a uint8 tensor."
   description: <<END
 GIF images with frame or transparency compression are not supported.
-On Linux and MacOS systems, convert animated GIFs from compressed to uncompressed by running:
+On Linux and MacOS systems, convert animated GIFs from compressed to
+uncompressed by running:
 
     convert $src.gif -coalesce $dst.gif
 

--- a/tensorflow/core/api_def/base_api/api_def_DecodeGif.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DecodeGif.pbtxt
@@ -12,10 +12,10 @@ END
 4-D with shape `[num_frames, height, width, 3]`. RGB order
 END
   }
-  summary: "Decode the first frame of a GIF-encoded image to a uint8 tensor."
+  summary: "Decode the frame(s) of a GIF-encoded image to a uint8 tensor."
   description: <<END
-GIF with frame or transparency compression are not supported
-convert animated GIF from compressed to uncompressed by:
+GIF images with frame or transparency compression are not supported.
+On Linux and MacOS systems, convert animated GIFs from compressed to uncompressed by running:
 
     convert $src.gif -coalesce $dst.gif
 


### PR DESCRIPTION
The API docs for `tf.io.decode_gif` currently state that the op only decodes the first frame of animated GIFs. But the C++ implementation actually extracts all frames from animated GIF files; see code [here](https://github.com/tensorflow/tensorflow/blob/623e6671213cd5286f3f053c2dec355282a679fb/tensorflow/core/kernels/decode_image_op.cc#L300).

This PR corrects the API docs to match the implementation.