### PR TITLE
[ROCm] add ROCm support for GPU types

### DIFF
--- a/tensorflow/core/framework/types.cc
+++ b/tensorflow/core/framework/types.cc
@@ -40,9 +40,9 @@ const char* const DEVICE_GPU = "GPU";
 const char* const DEVICE_SYCL = "SYCL";
 
 const std::string DeviceName<Eigen::ThreadPoolDevice>::value = DEVICE_CPU;
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 const std::string DeviceName<Eigen::GpuDevice>::value = DEVICE_GPU;
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #ifdef TENSORFLOW_USE_SYCL
 const std::string DeviceName<Eigen::SyclDevice>::value = DEVICE_SYCL;
 #endif  // TENSORFLOW_USE_SYCL

--- a/tensorflow/core/framework/types.h
+++ b/tensorflow/core/framework/types.h
@@ -83,12 +83,12 @@ struct DeviceName<Eigen::ThreadPoolDevice> {
   static const std::string value;
 };
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 template <>
 struct DeviceName<Eigen::GpuDevice> {
   static const std::string value;
 };
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #ifdef TENSORFLOW_USE_SYCL
 template <>


### PR DESCRIPTION
This PR is subsequent to #26751 which adds fundamental type support on ROCm platform.

Relevant codes have been running for more than 1 year on ROCm platform. We have published docker images at:

https://hub.docker.com/r/rocm/tensorflow/tags

and also PyPI packages:

https://pypi.org/project/tensorflow-rocm/

for a sample public test run you can refer to:

http://ml-ci.amd.com:21096/job/tensorflow-upstream-unit-tests/721/console

relevant tests:

```
//tensorflow/python:framework_device_test                                [0m[32mPASSED[0m in 2.4s
```