### PR TITLE
[TF 2.0 API Docs] Fix missing docstrings for tf.keras.applications.MobileNetV2

### DIFF
--- a/tensorflow/python/keras/applications/__init__.py
+++ b/tensorflow/python/keras/applications/__init__.py
@@ -21,6 +21,8 @@ from __future__ import print_function
 
 import keras_applications
 
+from functools import wraps
+
 from tensorflow.python.keras import backend
 from tensorflow.python.keras import engine
 from tensorflow.python.keras import layers
@@ -59,7 +61,7 @@ def keras_modules_injection(base_fun):
       Decorated function that injects keyword argument for the tf.keras
       modules required by the Applications.
   """
-
+  @wraps(base_fun)
   def wrapper(*args, **kwargs):
     if hasattr(keras_applications, 'get_submodules_from_kwargs'):
       kwargs['backend'] = backend

--- a/tensorflow/python/keras/applications/mobilenet_v2.py
+++ b/tensorflow/python/keras/applications/mobilenet_v2.py
@@ -29,6 +29,57 @@ from tensorflow.python.util.tf_export import keras_export
               'keras.applications.MobileNetV2')
 @keras_modules_injection
 def MobileNetV2(*args, **kwargs):
+  """Instantiates the MobileNetV2 architecture.
+    # Arguments
+        input_shape: optional shape tuple, to be specified if you would
+            like to use a model with an input img resolution that is not
+            (224, 224, 3).
+            It should have exactly 3 inputs channels (224, 224, 3).
+            You can also omit this option if you would like
+            to infer input_shape from an input_tensor.
+            If you choose to include both input_tensor and input_shape then
+            input_shape will be used if they match, if the shapes
+            do not match then we will throw an error.
+            E.g. `(160, 160, 3)` would be one valid value.
+        alpha: controls the width of the network. This is known as the
+        width multiplier in the MobileNetV2 paper, but the name is kept for
+        consistency with MobileNetV1 in Keras.
+            - If `alpha` < 1.0, proportionally decreases the number
+                of filters in each layer.
+            - If `alpha` > 1.0, proportionally increases the number
+                of filters in each layer.
+            - If `alpha` = 1, default number of filters from the paper
+                 are used at each layer.
+        include_top: whether to include the fully-connected
+            layer at the top of the network.
+        weights: one of `None` (random initialization),
+              'imagenet' (pre-training on ImageNet),
+              or the path to the weights file to be loaded.
+        input_tensor: optional Keras tensor (i.e. output of
+            `layers.Input()`)
+            to use as image input for the model.
+        pooling: Optional pooling mode for feature extraction
+            when `include_top` is `False`.
+            - `None` means that the output of the model
+                will be the 4D tensor output of the
+                last convolutional block.
+            - `avg` means that global average pooling
+                will be applied to the output of the
+                last convolutional block, and thus
+                the output of the model will be a
+                2D tensor.
+            - `max` means that global max pooling will
+                be applied.
+        classes: optional number of classes to classify images
+            into, only to be specified if `include_top` is True, and
+            if no `weights` argument is specified.
+    # Returns
+        A Keras model instance.
+    # Raises
+        ValueError: in case of invalid argument for `weights`,
+            or invalid input shape or invalid alpha, rows when
+            weights='imagenet'
+  """
   return mobilenet_v2.MobileNetV2(*args, **kwargs)
 
 
@@ -41,4 +92,10 @@ def decode_predictions(*args, **kwargs):
 @keras_export('keras.applications.mobilenet_v2.preprocess_input')
 @keras_modules_injection
 def preprocess_input(*args, **kwargs):
+  """Preprocesses a numpy array encoding a batch of images.
+    # Arguments
+        x: a 4D numpy array consists of RGB values within [0, 255].
+    # Returns
+        Preprocessed array.
+  """
   return mobilenet_v2.preprocess_input(*args, **kwargs)

--- a/tensorflow/python/keras/applications/mobilenet_v2.py
+++ b/tensorflow/python/keras/applications/mobilenet_v2.py
@@ -86,6 +86,18 @@ def MobileNetV2(*args, **kwargs):
 @keras_export('keras.applications.mobilenet_v2.decode_predictions')
 @keras_modules_injection
 def decode_predictions(*args, **kwargs):
+  """Decodes the prediction of an ImageNet model.
+    # Arguments
+        preds: Numpy tensor encoding a batch of predictions.
+        top: Integer, how many top-guesses to return.
+    # Returns
+        A list of lists of top class prediction tuples
+        `(class_name, class_description, score)`.
+        One list of tuples per sample in batch input.
+    # Raises
+        ValueError: In case of invalid shape of the `pred` array
+            (must be 2D).
+  """
   return mobilenet_v2.decode_predictions(*args, **kwargs)
 
 


### PR DESCRIPTION
Fix issue #25988 by adding a wrapper for decorated functions for `keras.applications` and adding missing docstrings for `tf.keras.applications.MobileNetV2`.