### PR TITLE
Check whether the file descriptor is valid

### DIFF
--- a/tensorflow/core/platform/posix/posix_file_system.cc
+++ b/tensorflow/core/platform/posix/posix_file_system.cc
@@ -105,6 +105,9 @@ class PosixWritableFile : public WritableFile {
   }
 
   Status Close() override {
+    if (file_ == nullptr) {
+      return IOError(filename_, EBADF);
+    }
     Status result;
     if (fclose(file_) != 0) {
       result = IOError(filename_, errno);


### PR DESCRIPTION
calling PosixWritableFile::Close twice causes segfaults on some posix systems. better check the file stream pointer state and return error if it's already closed.