### PR TITLE
Fix: typo in gpu_hlo_support_checker.h

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_hlo_support_checker.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_hlo_support_checker.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 namespace xla {
 
-// his pass should run early in the HLO pipeline and checks for HLO constructs
+// This pass should run early in the HLO pipeline and checks for HLO constructs
 // which are not supported by the GPU backend and cannot be removed via HLO
 // transformations (eg, sparse layouts).
 class GpuHloSupportChecker : public HloModulePass {


### PR DESCRIPTION
There is a comment typo in gpu_hlo_support_checker.h.  
This patch fixes it.