### PR TITLE
Update gradient_descent.py

### DIFF
--- a/tensorflow/python/training/gradient_descent.py
+++ b/tensorflow/python/training/gradient_descent.py
@@ -48,7 +48,7 @@ class GradientDescentOptimizer(optimizer.Optimizer):
     functions.
     @end_compatibility
     """
-    super(GradientDescentOptimizer, self).__init__(use_locking, name)
+    super().__init__(use_locking, name)
     self._learning_rate = learning_rate
     self._learning_rate_tensor = None
 


### PR DESCRIPTION
Python 3 allows this kind of syntax. As of now, the old syntax is used, where you specify the child's name. Should supercharge be referred to in this way, or does this change break functionality somehow? I can update statements in other files as well, if this change is accepted and meaningful. My apologies for this silly commit!