### PR TITLE
Force ICU to look for its data statically. This is required for Windows 10 builds. Patch suggested by github.com/cielavenir.

### DIFF
--- a/tensorflow/core/kernels/unicode_script_op.cc
+++ b/tensorflow/core/kernels/unicode_script_op.cc
@@ -13,6 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+// ICU codemap data is linked statically.
+#define U_STATIC_IMPLEMENTATION
+
 #include "unicode/errorcode.h"  // TF:icu
 #include "unicode/uscript.h"  // TF:icu
 #include "tensorflow/core/framework/op_kernel.h"

--- a/third_party/icu/BUILD.bazel
+++ b/third_party/icu/BUILD.bazel
@@ -44,6 +44,7 @@ cc_library(
     ]),
     copts = [
         "-DU_COMMON_IMPLEMENTATION",
+        "-DU_STATIC_IMPLEMENTATION",
         "-DU_HAVE_STD_ATOMICS",
     ] + select({
         ":android": [


### PR DESCRIPTION
Fixes #23655
Fixes #23963