### PR TITLE
[TF 2.0 API Docs] Added usage and examples to tf.compat.path_to_str

### DIFF
--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -111,13 +111,32 @@ def as_str_any(value):
 
 @tf_export('compat.path_to_str')
 def path_to_str(path):
-  """Returns the file system path representation of a `PathLike` object, else as it is.
+  """Returns the file system path representation of a `PathLike` object, else returns it as it is.
 
   Args:
     path: An object that can be converted to path representation.
 
   Returns:
     A `str` object.
+
+  Usage:
+    In case a simplified `str` version of the path is needed from an `os.PathLike` object
+
+  Examples:
+  ```python3
+  >>> tf.compat.path_to_str('C:\XYZ\tensorflow\./.././tensorflow')
+  'C:\\XYZ\tensorflow\\./.././tensorflow' # Windows OS
+  >>> tf.compat.path_to_str(Path('C:\XYZ\tensorflow\./.././tensorflow'))
+  'C:\\XYZ\tensorflow\\..\\tensorflow' # Windows OS
+  >>> tf.compat.path_to_str(Path('./corpus'))
+  'corpus' # Linux OS
+  >>> tf.compat.path_to_str('./.././Corpus')
+  './.././Corpus' # Linux OS
+  >>> tf.compat.path_to_str(Path('./.././Corpus'))
+  '../Corpus' # Linux OS
+  >>> tf.compat.path_to_str(Path('./..////../'))
+  '../..' # Linux OS
+  ```
   """
   if hasattr(path, '__fspath__'):
     path = as_str_any(path.__fspath__())


### PR DESCRIPTION
Fix #25826 by adding usage and examples to `tf.compat.path_to_str`

Here I have also commented the OS used (since `Path` is OS dependent)
If `tf` uses a differently flavored Markdown or my PR is not up-to-standard, kindly excuse me as I'm not used to the Tensorflow Doc Generation process, also I'd be happy to learn more about it!