### PR TITLE
[ROCm] Added ROCm support for nn_ops_test

### DIFF
--- a/tensorflow/core/kernels/nn_ops_test.cc
+++ b/tensorflow/core/kernels/nn_ops_test.cc
@@ -15,9 +15,9 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #include <functional>
 #include <memory>


### PR DESCRIPTION
This minor mod adds ROCm support for the nn_ops_test.

Background info
These ops are fundamental to TensorFlow, and this mod has been running for more than 1 year on our ROCm port of TF.

We have published docker images at: https://hub.docker.com/r/rocm/tensorflow/tags
And also PyPI packages: https://pypi.org/project/tensorflow-rocm/

For a sample ROCm test run you can refer to:
http://ml-ci.amd.com:21096/job/tensorflow-upstream-unit-tests/721/console

```
//tensorflow/core/kernels:nn_ops_test                                    PASSED in 1.0s
```