### PR TITLE
[ROCm] Added ROCm support for identity op

### DIFF
--- a/tensorflow/core/kernels/identity_op.cc
+++ b/tensorflow/core/kernels/identity_op.cc
@@ -112,7 +112,7 @@ REGISTER_GPU_KERNEL(Variant);
 
 #undef REGISTER_GPU_KERNEL
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 // A special GPU kernel for int32 and bool.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel
 // registration requires all int32 inputs and outputs to be in host memory.
@@ -149,6 +149,6 @@ REGISTER_GPU_HOST_KERNEL(ResourceHandle);
 
 #undef REGISTER_GPU_HOST_KERNEL
 
-#endif
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow


### PR DESCRIPTION
This minor mod adds ROCm support for the identity op.

Background info
These ops are fundamental to TensorFlow, and this mod has been running for more than 1 year on our ROCm port of TF.

We have published docker images at: https://hub.docker.com/r/rocm/tensorflow/tags
And also PyPI packages: https://pypi.org/project/tensorflow-rocm/

For a sample ROCm test run you can refer to:
http://ml-ci.amd.com:21096/job/tensorflow-upstream-unit-tests/721/console

```
//tensorflow/core/kernels:identity_op_test                               PASSED in 0.2s
```