### PR TITLE
Added Average Filtering with 2D filter

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -40,7 +40,9 @@ from tensorflow.python.ops import string_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
-from tensorflow.python.client import session
+from tensorflow.python.ops import script_ops
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import image_ops_impl
 
 ops.NotDifferentiable('RandomCrop')
 # TODO(b/31222613): This op may be differentiable, and there may be
@@ -3543,58 +3545,56 @@ def combined_non_max_suppression(boxes,
         boxes, scores, max_output_size_per_class, max_total_size, iou_threshold,
         score_threshold, pad_per_class)
   
-@tf_export('image.average_filtering_2D')
-def average_filtering_2D(tf_img,filter_shapex=3,filter_shapey=3):
-    # This methods takes both 2D Tensor as well as 3D Tensor Images
-    # Other than Tensor it takes optional parameter filter_Size
-    # Default Filter Size = 3 x 3
-    # Filter_size should be odd
-    # This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
-    try:
-        m,no = int(tf_img.shape[0]),int(tf_img.shape[1])
-    except:
-        raise Exception("Input Tensor is not an image")
-    try :
-        ch = int(tf_img.shape[2])
-    except:
-        ch = 1
-        tf_img = array_ops.reshape(tf_img, [m,no,ch])
-    if m < filter_shapex or no < filter_shapey:
-        raise Exception('No of Pixels in the image should be more than the filter size')
-    if filter_shapex % 2 == 0 or filter_shapey % 2 == 0:
-        raise Exception("Filter size should be odd")
-    sess = session.InteractiveSession()
-    tf_img = tf_img.eval()
-    tf_img = tf_img.astype('float64')
-    tf_i = tf_img.reshape(m*no*ch)
-    maxi = max(tf_i)
-    if maxi == 1:
-        tf_img /= maxi
-    else :
-        tf_img /= 255
-    #k is the Zero-padding size
-    res = np.empty((m,no,ch))
-    for a in range(ch):
-        img = tf_img[:,:,a:a+1]
-        img = img.reshape(m,no)
-        k = (filter_shapex - 1)
-        l = filter_shapey - 1
-        img = tf.convert_to_tensor(img)
-        img  = tf.pad(img,tf.constant([[k / 2, k / 2], [l / 2,l / 2]]),'CONSTANT')
-        img = img.eval()
-        res1 = np.empty((m,no))
-        for i in range(img.shape[0] - k) :
-            for j in range(img.shape[1] - l) :
-                li = []
-                for b in range(i, i + filter_shapex):
-                    for d in range(j, j + filter_shapey):
-                        li.append(img[b][d])
-                res1[i][j] = sum(li) / len(li)
-        res1 = res1.reshape(m,no,1)
-        res[:,:,a:a+1] = res1
+@tf_export('image.average_filter_2D')
+def average_filter_2D(input,filter_shape=(3,3)):
+    """  This methods takes 3D Tensor Images.
+         Other than Tensor it takes optional parameter filter_Size
+         Default Filter Shape = (3 , 3)
+         This Median Filtering is done by using 2D filters of user's choice
+         Filter_size should be odd
+         This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
 
-    res *= 255
-    res = res.astype('int')
-    res = ops.convert_to_tensor(res)
-    sess.close()
-    return res
+    """
+
+    input = image_ops_impl._Assert3DImage(input)
+    m,no,ch = int(input.shape[0]),int(input.shape[1]),int(input.shape[2])
+    filter_shapex = filter_shape[0]
+    filter_shapey = filter_shape[1]
+    if m < filter_shapex or no < filter_shapey:
+        raise ValueError("No of Pixels in each dimension of the image should be more than the filter size. Got filter_shape "
+                         "(%sx" % filter_shape[0]+"%s)."%filter_shape[1] +" Image Shape (%s)"% input.shape)
+    if filter_shapex % 2 == 0 or filter_shapey % 2 == 0:
+        raise ValueError("Filter size should be odd. Got filter_shape (%sx" % filter_shape[0]+"%s)"%filter_shape[1] )
+    input = math_ops.cast(input,dtypes.int64)
+    def my_func (input2):
+        input2 = input2.astype('float64')
+        tf_i = input2.reshape(m*no*ch)
+        maxi = max(tf_i)
+        if maxi == 1:
+            input2 /= maxi
+        else :
+            input2 /= 255
+        #k and l is the Zero-padding size
+        res = np.empty((m,no,ch))
+        for a in range(ch):
+            img = input2[:,:,a:a+1]
+            img = img.reshape(m,no)
+            k = filter_shapex - 1
+            l = filter_shapey - 1
+            img  = np.pad(img,((k / 2, k / 2), (l / 2,l / 2)),'constant', constant_values=(0, 0))
+            res1 = np.empty((m,no))
+            for i in range(img.shape[0] - k) :
+                for j in range(img.shape[1] - l) :
+                    li = []
+                    for b in range(i, i + filter_shapex):
+                        for d in range(j, j + filter_shapey):
+                            li.append(img[b][d])
+                    res1[i][j] = sum(li) / len(li)
+            res1 = res1.reshape(m,no,1)
+            res[:,:,a:a+1] = res1
+        res *= 255
+        res = res.astype('int64')
+        return res
+
+    y = script_ops.py_func(my_func, [input], dtypes.int64)
+    return y

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3568,8 +3568,8 @@ def average_filter_2D(input,filter_shape=(3,3)):
     def my_func (input2):
         tf_i = input2.reshape(m*no*ch)
         maxi = max(tf_i)
-        if maxi == 1:
-            input2 /= maxi
+        if maxi <= 1:
+            input2 /= 1
         else :
             input2 /= 255
         #k and l is the Zero-padding size

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3553,7 +3553,6 @@ def average_filter_2D(input,filter_shape=(3,3)):
          This Median Filtering is done by using 2D filters of user's choice
          Filter_size should be odd
          This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
-
     """
 
     input = image_ops_impl._Assert3DImage(input)
@@ -3565,9 +3564,8 @@ def average_filter_2D(input,filter_shape=(3,3)):
                          "(%sx" % filter_shape[0]+"%s)."%filter_shape[1] +" Image Shape (%s)"% input.shape)
     if filter_shapex % 2 == 0 or filter_shapey % 2 == 0:
         raise ValueError("Filter size should be odd. Got filter_shape (%sx" % filter_shape[0]+"%s)"%filter_shape[1] )
-    input = math_ops.cast(input,dtypes.int64)
+    input = math_ops.cast(input,dtypes.float64)
     def my_func (input2):
-        input2 = input2.astype('float64')
         tf_i = input2.reshape(m*no*ch)
         maxi = max(tf_i)
         if maxi == 1:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -40,6 +40,7 @@ from tensorflow.python.ops import string_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
+from tensorflow.python.client import session
 
 ops.NotDifferentiable('RandomCrop')
 # TODO(b/31222613): This op may be differentiable, and there may be
@@ -3541,3 +3542,59 @@ def combined_non_max_suppression(boxes,
     return gen_image_ops.combined_non_max_suppression(
         boxes, scores, max_output_size_per_class, max_total_size, iou_threshold,
         score_threshold, pad_per_class)
+  
+@tf_export('image.average_filtering_2D')
+def average_filtering_2D(tf_img,filter_shapex=3,filter_shapey=3):
+    # This methods takes both 2D Tensor as well as 3D Tensor Images
+    # Other than Tensor it takes optional parameter filter_Size
+    # Default Filter Size = 3 x 3
+    # Filter_size should be odd
+    # This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
+    try:
+        m,no = int(tf_img.shape[0]),int(tf_img.shape[1])
+    except:
+        raise Exception("Input Tensor is not an image")
+    try :
+        ch = int(tf_img.shape[2])
+    except:
+        ch = 1
+        tf_img = array_ops.reshape(tf_img, [m,no,ch])
+    if m < filter_shapex or no < filter_shapey:
+        raise Exception('No of Pixels in the image should be more than the filter size')
+    if filter_shapex % 2 == 0 or filter_shapey % 2 == 0:
+        raise Exception("Filter size should be odd")
+    sess = session.InteractiveSession()
+    tf_img = tf_img.eval()
+    tf_img = tf_img.astype('float64')
+    tf_i = tf_img.reshape(m*no*ch)
+    maxi = max(tf_i)
+    if maxi == 1:
+        tf_img /= maxi
+    else :
+        tf_img /= 255
+    #k is the Zero-padding size
+    res = np.empty((m,no,ch))
+    for a in range(ch):
+        img = tf_img[:,:,a:a+1]
+        img = img.reshape(m,no)
+        k = (filter_shapex - 1)
+        l = filter_shapey - 1
+        img = tf.convert_to_tensor(img)
+        img  = tf.pad(img,tf.constant([[k / 2, k / 2], [l / 2,l / 2]]),'CONSTANT')
+        img = img.eval()
+        res1 = np.empty((m,no))
+        for i in range(img.shape[0] - k) :
+            for j in range(img.shape[1] - l) :
+                li = []
+                for b in range(i, i + filter_shapex):
+                    for d in range(j, j + filter_shapey):
+                        li.append(img[b][d])
+                res1[i][j] = sum(li) / len(li)
+        res1 = res1.reshape(m,no,1)
+        res[:,:,a:a+1] = res1
+
+    res *= 255
+    res = res.astype('int')
+    res = ops.convert_to_tensor(res)
+    sess.close()
+    return res


### PR DESCRIPTION
Average Filtering with 1D filter was added by me at #26381 
This is 2D filtering
Test Code-

import tensorflow as tf
import matplotlib.pyplot
import matplotlib.pyplot as plt
from tensorflow.python.ops import array_ops
from tensorflow.python.util.tf_export import tf_export
from tensorflow.python.framework import ops
from tensorflow.python.ops import script_ops
from tensorflow.python.ops import math_ops
from tensorflow.python.framework import dtypes
from tensorflow.python.ops import image_ops_impl
fname = 'index.jpeg'
img = matplotlib.pyplot.imread(fname)
import numpy as np

tf_img = tf.convert_to_tensor(img)


@tf_export('image.average_filter_2D')
def average_filter_2D(input,filter_shape=(3,3)):
    """  This methods takes 3D Tensor Images.
         Other than Tensor it takes optional parameter filter_Size
         Default Filter Shape = (3 , 3)
         This Median Filtering is done by using 2D filters of user's choice
         Filter_size should be odd
         This method takes both kind of images where pixel values lie between 0 to 255 and where it lies between 0.0 and 1.0
    """

    input = image_ops_impl._Assert3DImage(input)
    m,no,ch = int(input.shape[0]),int(input.shape[1]),int(input.shape[2])
    filter_shapex = filter_shape[0]
    filter_shapey = filter_shape[1]
    if m < filter_shapex or no < filter_shapey:
        raise ValueError("No of Pixels in each dimension of the image should be more than the filter size. Got filter_shape "
                         "(%sx" % filter_shape[0]+"%s)."%filter_shape[1] +" Image Shape (%s)"% input.shape)
    if filter_shapex % 2 == 0 or filter_shapey % 2 == 0:
        raise ValueError("Filter size should be odd. Got filter_shape (%sx" % filter_shape[0]+"%s)"%filter_shape[1] )
    input = math_ops.cast(input,dtypes.float64)
    def my_func (input2):
        tf_i = input2.reshape(m*no*ch)
        maxi = max(tf_i)
        if maxi == 1:
            input2 /= maxi
        else :
            input2 /= 255
        #k and l is the Zero-padding size
        res = np.empty((m,no,ch))
        for a in range(ch):
            img = input2[:,:,a:a+1]
            img = img.reshape(m,no)
            k = filter_shapex - 1
            l = filter_shapey - 1
            img  = np.pad(img,((k / 2, k / 2), (l / 2,l / 2)),'constant', constant_values=(0, 0))
            res1 = np.empty((m,no))
            for i in range(img.shape[0] - k) :
                for j in range(img.shape[1] - l) :
                    li = []
                    for b in range(i, i + filter_shapex):
                        for d in range(j, j + filter_shapey):
                            li.append(img[b][d])
                    res1[i][j] = sum(li) / len(li)
            res1 = res1.reshape(m,no,1)
            res[:,:,a:a+1] = res1
        res *= 255
        res = res.astype('int64')
        return res

    y = script_ops.py_func(my_func, [input], dtypes.int64)
    return y

sess = tf.InteractiveSession()

mimage = average_filter_2D(tf_img,(5,5))

fig = plt.figure()
fig.add_subplot()
plt.imshow(img,cmap='gray')
plt.show()
mimage = mimage.eval()
fig.add_subplot()
if mimage.shape[2] == 1:
    mimage = mimage.reshape(mimage.shape[0],mimage.shape[1])
plt.imshow(mimage,cmap = 'gray')
plt.show()