### PR TITLE
Compilation issue: 'string' was not declared in this scope

### DIFF
--- a/tensorflow/lite/testing/kernel_test/generate_diff_report.cc
+++ b/tensorflow/lite/testing/kernel_test/generate_diff_report.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
+#include <string>
 #include <vector>
 
 #include "tensorflow/core/util/command_line_flags.h"

--- a/tensorflow/lite/testing/kernel_test/generate_diff_report.cc
+++ b/tensorflow/lite/testing/kernel_test/generate_diff_report.cc
@@ -19,7 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/testing/kernel_test/diff_analyzer.h"
 
 int main(int argc, char** argv) {
-  string base, test, output;
+  std::string base, test, output;
   std::vector<tensorflow::Flag> flag_list = {
       tensorflow::Flag("base", &base, "Path to the base serialized tensor."),
       tensorflow::Flag("test", &test, "Path to the test serialized tensor."),


### PR DESCRIPTION
```
tensorflow/lite/testing/kernel_test/generate_diff_report.cc:22:3: error: 'string' was not declared in this scope
   string base, test, output;
   ^~~~~~
```

The above compilation error is fixed.