### PR TITLE
removed whitespaces from MPI_LIB_IS_OPENMPI

### DIFF
--- a/third_party/mpi/mpi.bzl
+++ b/third_party/mpi/mpi.bzl
@@ -2,7 +2,7 @@
 #based on the configuration options return one or the other
 
 def mpi_hdr():
-    MPI_LIB_IS_OPENMPI = True
+    MPI_LIB_IS_OPENMPI=True
     hdrs = []
     if MPI_LIB_IS_OPENMPI:
         hdrs = ["mpi.h", "mpi_portable_platform.h"]  #When using OpenMPI


### PR DESCRIPTION
when mvpaich2/mpich by configure.py MPI_LIB_IS_OPENMPI=True is
replaced with MPI_LIB_IS_OPENMPI=False which fails if
whitespaces are included