### PR TITLE
[ROCm] Added ROCm support for the extract_image_patches op

### DIFF
--- a/tensorflow/core/kernels/extract_image_patches_op.cc
+++ b/tensorflow/core/kernels/extract_image_patches_op.cc
@@ -130,7 +130,7 @@ TF_CALL_REAL_NUMBER_TYPES(REGISTER);
 
 #undef REGISTER
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 // Forward declarations of the functor specializations for GPU.
 namespace functor {
@@ -160,6 +160,6 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER);
 
 #undef REGISTER
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/extract_image_patches_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/extract_image_patches_op_gpu.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -35,4 +35,4 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER);
 }  // end namespace functor
 }  // end namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
This minor mod adds ROCm support for the extract_image_patches ops.

#### Background info ####
These ops are fundamental to TensorFlow, and this mod has been running for more than 1 year on our ROCm port of TF.

We have published docker images at: https://hub.docker.com/r/rocm/tensorflow/tags
And also PyPI packages: https://pypi.org/project/tensorflow-rocm/

For a sample ROCm test run you can refer to:
http://ml-ci.amd.com:21096/job/tensorflow-upstream-unit-tests/721/console

```
//tensorflow/python/kernel_tests:extract_image_patches_op_test           PASSED in 2.9s
```