### PR TITLE
Bugfix: Memory leak due to TF_LITE_ENSURE fixed

### DIFF
--- a/tensorflow/lite/experimental/kernels/ctc_beam_search_decoder.cc
+++ b/tensorflow/lite/experimental/kernels/ctc_beam_search_decoder.cc
@@ -197,11 +197,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       merge_repeated);
 
   // Allocate temporary memory for holding chip operation data.
-  float* input_chip_t_data =
-      static_cast<float*>(malloc(num_classes * sizeof(float)));
+  std::unique_ptr<float[]> input_chip_t_data(
+      new float[num_classes * sizeof(float)]);
   Eigen::array<Eigen::DenseIndex, 1> dims;
   dims[0] = num_classes;
-  optimized_ops::TTypes<float>::Flat input_chip_t(input_chip_t_data, dims);
+  optimized_ops::TTypes<float>::Flat input_chip_t(input_chip_t_data.get(),
+                                                  dims);
 
   std::vector<std::vector<std::vector<int>>> best_paths(batch_size);
   std::vector<float> log_probs;
@@ -229,7 +230,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     }
   }
 
-  free(input_chip_t_data);
   return StoreAllDecodedSequences(context, best_paths, node, top_paths);
 }
 


### PR DESCRIPTION
There is a memory leak due to the return path in TF_LITE_ENSURE at line 223
```
    TF_LITE_ENSURE(context, beam_search.TopPaths(top_paths, &best_paths_b,
                                                 &log_probs, merge_repeated));
```