### PR TITLE
MarkForCompilationPass: don't create clusters with control-flow

### DIFF
--- a/tensorflow/compiler/jit/mark_for_compilation_pass.cc
+++ b/tensorflow/compiler/jit/mark_for_compilation_pass.cc
@@ -535,6 +535,10 @@ Status FindCompilationCandidates(
       VLOG(2) << "Rejecting " << node->name() << ": is a control trigger op";
       continue;
     }
+    if (node->IsControlFlow()) {
+      VLOG(2) << "Rejecting " << node->name() << ": is a control-flow op";
+      continue;
+    }
     if (!op_filter.allow_dummy_ops && IsDummyImplOp(node->type_string())) {
       VLOG(2) << "Rejecting " << node->name() << ": dummy op ("
               << node->type_string() << ")";


### PR DESCRIPTION
When using while loops, sometimes Tensorflow crashes with the error:
`Found control flow node in clustering worklist: Enter`

This is because FindCompilationCandidates() in MarkForCompilationPass doesn't explicitly disallow control-flow ops when checking if an op is valid. Later in RunImpl(), the codes checks if the representative of the cluster is a control-flow op and exits with the above message.

When doing resnet with a tf.while_loop, I had this cluster being created:
representative: resnet_model/block2/Enter
node: resnet_model/block2/Merge

This patch makes FindCompilationCandidates() reject control-flow ops outright. I don't know enough of TF if it fuses clusters with control-flow, but if so, the above assertion must be changed.