### PR TITLE
Use SourceVersion#latest instead of latestSupported

### DIFF
--- a/tensorflow/java/src/gen/java/org/tensorflow/processor/OperatorProcessor.java
+++ b/tensorflow/java/src/gen/java/org/tensorflow/processor/OperatorProcessor.java
@@ -72,7 +72,7 @@ public final class OperatorProcessor extends AbstractProcessor {
 
   @Override
   public SourceVersion getSupportedSourceVersion() {
-    return SourceVersion.latestSupported();
+    return SourceVersion.latest();
   }
 
   @Override


### PR DESCRIPTION
latestSupported doesn't work if the JDK is newer than the compiler
version; see https://github.com/bazelbuild/bazel/issues/7776