### PR TITLE
Lite: Fully_connected Op bug-fix

### DIFF
--- a/tensorflow/lite/kernels/fully_connected.cc
+++ b/tensorflow/lite/kernels/fully_connected.cc
@@ -69,39 +69,41 @@ inline TfLiteStatus CheckTypes(TfLiteContext* context,
                                const TfLiteTensor* filter,
                                const TfLiteTensor* bias, TfLiteTensor* output,
                                TfLiteFullyConnectedParams* params) {
-  const bool is_Quantized =
+  const bool is_quantized =
       ((filter->type == kTfLiteUInt8) || (filter->type == kTfLiteInt8));
-  const bool is_Hybrid = is_Quantized && (input->type == kTfLiteFloat32);
-  const bool is_Shuffled =
-      is_Quantized && (params->weights_format ==
+  const bool is_hybrid = is_quantized && (input->type == kTfLiteFloat32);
+  const bool is_shuffled =
+      is_quantized && (params->weights_format ==
                        kTfLiteFullyConnectedWeightsFormatShuffled4x16Int8);
-  const bool is_BiasNotFloatType = bias && (bias->type != kTfLiteFloat32);
-  const bool is_BiasNotIntType = bias && (bias->type != kTfLiteInt32);
 
-  if (is_Quantized) {
-    if (is_Shuffled) {
+  // optional bias tensor.
+  const bool is_optional_bias_float = !bias || (bias->type == kTfLiteFloat32);
+  const bool is_optional_bias_int = !bias || (bias->type == kTfLiteInt32);
+
+  if (is_quantized) {
+    if (is_shuffled) {
       TF_LITE_ENSURE_EQ(context, input->type, kTfLiteUInt8);
       TF_LITE_ENSURE_EQ(context, filter->type, kTfLiteUInt8);
       TF_LITE_ENSURE_EQ(context, output->type, kTfLiteInt16);
-      TF_LITE_ENSURE_EQ(context, is_BiasNotIntType, false);
-    } else if (is_Hybrid) {
+      TF_LITE_ENSURE_EQ(context, is_optional_bias_int, true);
+    } else if (is_hybrid) {
       TF_LITE_ENSURE_EQ(context, input->type, kTfLiteFloat32);
       TF_LITE_ENSURE_EQ(context, output->type, kTfLiteFloat32);
-      TF_LITE_ENSURE_EQ(context, is_BiasNotFloatType, false);
+      TF_LITE_ENSURE_EQ(context, is_optional_bias_float, true);
     } else {
       TF_LITE_ENSURE(context,
                      input->type == kTfLiteUInt8 || input->type == kTfLiteInt8);
       TF_LITE_ENSURE(context, output->type == kTfLiteUInt8 ||
                                   output->type == kTfLiteInt8 ||
                                   output->type == kTfLiteInt16);
-      TF_LITE_ENSURE_EQ(context, is_BiasNotIntType, false);
+      TF_LITE_ENSURE_EQ(context, is_optional_bias_int, true);
     }
   } else {
     // Only float32 is supported currently
     TF_LITE_ENSURE_EQ(context, input->type, kTfLiteFloat32);
     TF_LITE_ENSURE_EQ(context, output->type, kTfLiteFloat32);
     TF_LITE_ENSURE_EQ(context, filter->type, kTfLiteFloat32);
-    TF_LITE_ENSURE_EQ(context, is_BiasNotFloatType, false);
+    TF_LITE_ENSURE_EQ(context, is_optional_bias_float, true);
   }
 
   return kTfLiteOk;


### PR DESCRIPTION
1:> Move data type check to one central place, to improve code readability
2:> 2 Bug fixed as part of above change

    

-  The code was prone to significant data loss, if user has given Input as int16 type which was explicitly type casted to int8/uint8, so restrict user input to int8/uint8 only.
-  Null pointer access when Bias is not present at EvalShuffledQuantized()