### PR TITLE
add support for aarch64 (jetson gpu local build)

### DIFF
--- a/third_party/gpus/crosstool/BUILD.tpl
+++ b/third_party/gpus/crosstool/BUILD.tpl
@@ -24,6 +24,7 @@ cc_toolchain_suite(
         "x64_windows|msvc-cl": ":cc-compiler-windows",
         "x64_windows": ":cc-compiler-windows",
         "arm": ":cc-compiler-local",
+        "aarch64": ":cc-compiler-local",
         "k8": ":cc-compiler-local",
         "piii": ":cc-compiler-local",
         "ppc": ":cc-compiler-local",


### PR DESCRIPTION
Add support for building tensorflow 1.13+ with newer Bazel > 0.15.

Newer bazel >0.15 add aarch64 type of cpu.
[CPU.java](https://github.com/bazelbuild/bazel/blob/95d94fa1ebb5e173668f66fc24be10c24ea7dd45/src/main/java/com/google/devtools/build/lib/util/CPU.java#L28)

NVIDIA's jetson platform (aarch64 platform) has a CUDA GPU. full version of tensorflow can work on it.
https://docs.nvidia.com/deeplearning/dgx/install-tf-xavier/index.html