### PR TITLE
Replace deprecated usage of np.asscalar with np.ndarray.item()

### DIFF
--- a/tensorflow/python/eager/tensor_test.py
+++ b/tensorflow/python/eager/tensor_test.py
@@ -353,8 +353,8 @@ class TFETensorTest(test_util.TensorFlowTestCase):
   @test_util.assert_no_new_pyobjects_executing_eagerly
   @test_util.run_in_graph_and_eager_modes
   def testConvertToTensorNumpyScalar(self):
-    x = ops.convert_to_tensor([np.asscalar(np.array(321, dtype=np.int)),
-                               np.asscalar(np.array(16, dtype=np.int))])
+    x = ops.convert_to_tensor([np.array(321, dtype=np.int).item(),
+                               np.array(16, dtype=np.int).item()])
     self.assertAllEqual(x, [321, 16])
 
   def testEagerTensorError(self):


### PR DESCRIPTION
[`numpy.asscalar()` is deprecated since version 1.16](https://github.com/numpy/numpy/blob/master/numpy/lib/type_check.py#L519-L548).

This PR replaces its usage with [`numpy.ndarray.item()`](https://www.numpy.org/devdocs/reference/generated/numpy.ndarray.item.html)