### PR TITLE
Update docstring of tf.linspace.

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_LinSpace.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_LinSpace.pbtxt
@@ -26,8 +26,8 @@ END
   }
   summary: "Generates values in an interval."
   description: <<END
-A sequence of `num` evenly-spaced values are generated beginning at `start`.
-If `num > 1`, the values in the sequence increase by `stop - start / num - 1`,
+A sequence of `num` evenly-spaced values are generated beginning at `start`. If
+`num > 1`, the values in the sequence increase by `(stop - start) / (num - 1)`,
 so that the last one is exactly `stop`.
 
 For example:


### PR DESCRIPTION
Add braces to the documentation to avoid misunderstandings in the way the
increment is computed. Given the way that the help page is rendered and a
strict mathematical (or programmatic) understanding, one might misread the
formula as
`stop - (start / num) - 1`
which would be incorrect. While it is relatively obvious what linspace
does, the braces avoid any ambiguity.