### PR TITLE
remove sentence about usage of rmsprop for RNN

### DIFF
--- a/tensorflow/python/keras/optimizers.py
+++ b/tensorflow/python/keras/optimizers.py
@@ -229,9 +229,6 @@ class RMSprop(Optimizer):
   at their default values
   (except the learning rate, which can be freely tuned).
 
-  This optimizer is usually a good choice for recurrent
-  neural networks.
-
   Arguments:
       lr: float >= 0. Learning rate.
       rho: float >= 0.


### PR DESCRIPTION
There is not enough evidence for the following sentence.

```
This optimizer is usually a good choice for recurrent
neural networks.
```