### PR TITLE
Bugfix: avoid casting a type 'type'

### DIFF
--- a/tensorflow/contrib/training/python/training/hparam.py
+++ b/tensorflow/contrib/training/python/training/hparam.py
@@ -183,6 +183,10 @@ def _cast_to_type_if_compatible(name, param_type, value):
   if (issubclass(param_type, numbers.Number) and
       not isinstance(value, numbers.Number)):
     raise ValueError(fail_msg)
+    
+  # Avoid converting a type 'type' - python doesn't handle this in the intuitive way
+  if issubclass(param_type, type):
+    return value
 
   return param_type(value)
 


### PR DESCRIPTION
Hi! This is my first fix.

The problem is in `HParams` class in `contrib`. Minimal example:
```
import tensorflow as tf
from tensorflow.contrib.training import HParams

hp = HParams()
hp.add_hparam('param', tf.Tensor)
print(hp.param)
hp.set_hparam('param', tf.Tensor)
print(hp.param)
```

Expected output: 
```
<class 'tensorflow.python.framework.ops.Tensor'>
<class 'tensorflow.python.framework.ops.Tensor'>
```
Actual output: 
```
<class 'tensorflow.python.framework.ops.Tensor'>
<class 'type'>
```

I.e., while the function add_hparam works correctly, the function set_hparam destroys the value passed to it if the value is a class.

The problem seems to in `def _cast_to_type_if_compatible` function. The proposed fix is to not apply the parameter conversion if the param is a type i.e. if the type of the param is `type`.