### PR TITLE
Fix incorrect docstring of compression type in `TFRecordOptions`

### DIFF
--- a/tensorflow/python/lib/io/tf_record.py
+++ b/tensorflow/python/lib/io/tf_record.py
@@ -69,7 +69,7 @@ class TFRecordOptions(object):
     Leaving an option as `None` allows C++ to set a reasonable default.
 
     Args:
-      compression_type: `"GZIP"`, "ZLIB" or `"NONE"`.
+      compression_type: `"GZIP"`, "ZLIB", or `""` (no compression).
       flush_mode: flush mode or `None`, Default: Z_NO_FLUSH.
       input_buffer_size: int or `None`.
       output_buffer_size: int or `None`.

--- a/tensorflow/python/lib/io/tf_record.py
+++ b/tensorflow/python/lib/io/tf_record.py
@@ -69,7 +69,7 @@ class TFRecordOptions(object):
     Leaving an option as `None` allows C++ to set a reasonable default.
 
     Args:
-      compression_type: `"GZIP"`, "ZLIB", or `""` (no compression).
+      compression_type: `"GZIP"`, `"ZLIB"`, or `""` (no compression).
       flush_mode: flush mode or `None`, Default: Z_NO_FLUSH.
       input_buffer_size: int or `None`.
       output_buffer_size: int or `None`.


### PR DESCRIPTION
This fix is a followup to https://github.com/tensorflow/tensorflow/pull/26676#discussion_r267883241 (thanks @wchargin 👍 )

In PR #26676, the compression type of "no compression" was incorrectly specified as `"NONE"`. This fix addresses the issue and change it to `""`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>