### PR TITLE
Remove tf.floor endpoint from TF 2.0

### DIFF
--- a/tensorflow/core/api_def/python_api/api_def_Floor.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_Floor.pbtxt
@@ -5,5 +5,6 @@ op {
   }
   endpoint {
     name: "floor"
+    deprecation_version: 2
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -601,10 +601,6 @@ tf_module {
     argspec: "args=[\'dims\', \'value\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
-    name: "floor"
-    argspec: "args=[\'x\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
-  }
-  member_method {
     name: "floor_div"
     argspec: "args=[\'x\', \'y\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/compatibility/renames_v2.py
+++ b/tensorflow/tools/compatibility/renames_v2.py
@@ -369,6 +369,8 @@ renames = {
         'tf.signal.fft3d',
     'tf.fixed_size_partitioner':
         'tf.compat.v1.fixed_size_partitioner',
+    'tf.floor':
+        'tf.math.floor',
     'tf.floordiv':
         'tf.math.floordiv',
     'tf.get_collection':


### PR DESCRIPTION
This fix tries to address the issue raised in #27003 where `ceil` is only exposed as `tf.math.ceil` for TF 2.0 while `floor` is exposed in both `tf.floor` and `tf.math.floor` for TF 2.0.

It makes sense to keep consistency for `ceil` and `floor`. This PR deprecates tf.floor and exposes only tf.math.floor in TF 2.0.

This fix fixes #27003.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>