### PR TITLE
fixed Comments for CategorcialCrossEntropy

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -336,7 +336,7 @@ class CategoricalCrossentropy(Loss):
   loss = cce(
     [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
     [[.9, .05, .05], [.05, .89, .06], [.05, .01, .94]])
-  print('Loss: ', loss.numpy())  # Loss: 0.3239
+  print('Loss: ', loss.numpy())  # Loss: 0.0945
   ```
 
   Usage with tf.keras API:

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -335,7 +335,7 @@ class CategoricalCrossentropy(Loss):
   cce = tf.keras.losses.CategoricalCrossentropy()
   loss = cce(
     [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
-    [[.9, .05, .05], [.5, .89, .6], [.05, .01, .94]])
+    [[.9, .05, .05], [.05, .89, .06], [.05, .01, .94]])
   print('Loss: ', loss.numpy())  # Loss: 0.3239
   ```
 


### PR DESCRIPTION
Typo in doc: `tf.keras.losses.CategoricalCrossentropy` #27070

The probabilities must be add up to 1.00, therefore ```[.5, .89, .6]``` -> ```[.05, .89, .06]```