### PR TITLE
Workaround for MSVC not merging bit-fields of different size.

### DIFF
--- a/tensorflow/compiler/tf2xla/cpu_function_runtime.h
+++ b/tensorflow/compiler/tf2xla/cpu_function_runtime.h
@@ -104,7 +104,10 @@ class BufferInfo {
  private:
   BufferInfo() = default;
 
-  enum class Kind : unsigned {
+  // The enum class Kind must be uint64 to ensure that the bit fields
+  // `kind_` and `size_` are merged and the resulting size of BufferInfo
+  // is 16 bytes (i.e. two 64 bit integers, used in `Encode()`).
+  enum class Kind : uint64 {
     kConstant,
     kTempBuffer,
     kEntryParameter,


### PR DESCRIPTION
See issue #26958.