### PR TITLE
Add soversion to libraries

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -15,6 +15,7 @@ exports_files([
     "leakr_file_type_recipe.ftrcp",
 ])
 
+load("//tensorflow:tensorflow.bzl", "VERSION")
 load("//tensorflow:tensorflow.bzl", "tf_cc_shared_object")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_library_additional_deps_impl")
 load("//tensorflow:tensorflow.bzl", "tf_native_cc_binary")
@@ -490,6 +491,7 @@ tf_cc_shared_object(
     }),
     linkstatic = 1,
     per_os_targets = True,
+    soversion = VERSION,
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:core_cpu_impl",
@@ -530,6 +532,7 @@ tf_cc_shared_object(
         ],
     }),
     per_os_targets = True,
+    soversion = VERSION,
     visibility = ["//visibility:public"],
     # add win_def_file for tensorflow
     win_def_file = select({
@@ -560,6 +563,7 @@ tf_cc_shared_object(
         ],
     }),
     per_os_targets = True,
+    soversion = VERSION,
     visibility = ["//visibility:public"],
     # add win_def_file for tensorflow_cc
     win_def_file = select({

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -326,6 +326,18 @@ config_setting(
 )
 
 config_setting(
+    name = "macos_with_framework_shared_object",
+    define_values = {
+        "framework_shared_object": "true",
+    },
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "using_cuda_clang",
     define_values = {
         "using_cuda_clang": "true",
@@ -467,7 +479,7 @@ cc_library(
 # projects building with Bazel and importing TensorFlow as a dependency will not
 # depend on libtensorflow_framework.so unless they opt in.
 tf_cc_shared_object(
-    name = "libtensorflow_framework.so",
+    name = "tensorflow_framework",
     framework_so = [],
     linkopts = select({
         "//tensorflow:macos": [],
@@ -477,6 +489,7 @@ tf_cc_shared_object(
         ],
     }),
     linkstatic = 1,
+    per_os_targets = True,
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/core:core_cpu_impl",
@@ -508,7 +521,6 @@ tf_cc_shared_object(
     linkopts = select({
         "//tensorflow:macos": [
             "-Wl,-exported_symbols_list,$(location //tensorflow/c:exported_symbols.lds)",
-            "-Wl,-install_name,@rpath/libtensorflow.so",
         ],
         "//tensorflow:windows": [
         ],

--- a/tensorflow/core/public/version.h
+++ b/tensorflow/core/public/version.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 // TensorFlow uses semantic versioning, see http://semver.org/.
 
+// Also update tensorflow/tensorflow.bzl and
+// tensorflow/tools/pip_package/setup.py
 #define TF_MAJOR_VERSION 1
 #define TF_MINOR_VERSION 13
 #define TF_PATCH_VERSION 1

--- a/tensorflow/go/BUILD
+++ b/tensorflow/go/BUILD
@@ -9,17 +9,21 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+load(
+    "//tensorflow:tensorflow.bzl",
+    "tf_shared_library_deps",
+)
+
 sh_test(
     name = "test",
     size = "small",
     srcs = ["test.sh"],
     data = [
         ":all_files",  # Go sources
-        "//tensorflow:libtensorflow.so",  # C library
         "//tensorflow/c:headers",  # C library header
         "//tensorflow/c/eager:headers",  # Eager C library header
         "//tensorflow/cc/saved_model:saved_model_half_plus_two",  # Testdata for LoadSavedModel
-    ],
+    ] + tf_shared_library_deps(),
 )
 
 filegroup(

--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -23,7 +23,7 @@ java_library(
         ":java_op_sources",
         ":java_sources",
     ],
-    data = [":libtensorflow_jni"],
+    data = [":libtensorflow_jni"] + tf_binary_additional_srcs(),
     javacopts = JAVACOPTS,
     plugins = [":processor"],
     visibility = ["//visibility:public"],

--- a/tensorflow/lite/BUILD
+++ b/tensorflow/lite/BUILD
@@ -71,10 +71,14 @@ cc_library(
     ],
 )
 
+# TODO(b/122597976) Move this off of tf_cc_test for portability.
 tf_cc_test(
     name = "arena_planner_test",
     size = "small",
     srcs = ["arena_planner_test.cc"],
+    tags = [
+        "tflite_not_portable_android",
+    ],
     deps = [
         ":arena_planner",
         "//tensorflow/core:tflite_portable_logging",

--- a/tensorflow/lite/tools/accuracy/BUILD
+++ b/tensorflow/lite/tools/accuracy/BUILD
@@ -156,12 +156,13 @@ cc_library(
     ],
 )
 
+# TODO(b/122597976) Move this off of tf_cc_test for portability.
 tf_cc_test(
     name = "file_reader_stage_test",
     srcs = ["file_reader_stage_test.cc"],
     linkopts = common_linkopts,
     linkstatic = 1,
-    tags = ["tflite_not_portable_ios"],
+    tags = ["tflite_not_portable"],
     deps = [
         ":file_reader_stage",
         "@com_google_googletest//:gtest",
@@ -231,12 +232,13 @@ cc_library(
     ),
 )
 
+# TODO(b/122597976) Move this off of tf_cc_test for portability.
 tf_cc_test(
     name = "eval_pipeline_test",
     srcs = ["eval_pipeline_test.cc"],
     linkopts = common_linkopts,
     linkstatic = 1,
-    tags = ["tflite_not_portable_ios"],
+    tags = ["tflite_not_portable"],
     deps = [
         ":eval_pipeline",
         "//tensorflow/cc:cc_ops",
@@ -283,12 +285,13 @@ cc_library(
     ),
 )
 
+# TODO(b/122597976) Move this off of tf_cc_test for portability.
 tf_cc_test(
     name = "eval_pipeline_builder_test",
     srcs = ["eval_pipeline_builder_test.cc"],
     linkopts = common_linkopts,
     linkstatic = 1,
-    tags = ["tflite_not_portable_ios"],
+    tags = ["tflite_not_portable"],
     deps = [
         ":eval_pipeline_builder",
         "//tensorflow/cc:cc_ops",

--- a/tensorflow/lite/tools/accuracy/ilsvrc/BUILD
+++ b/tensorflow/lite/tools/accuracy/ilsvrc/BUILD
@@ -97,12 +97,13 @@ cc_library(
     ),
 )
 
+# TODO(b/122597976) Move this off of tf_cc_test for portability.
 tf_cc_test(
     name = "imagenet_topk_eval_test",
     srcs = ["imagenet_topk_eval_test.cc"],
     linkopts = common_linkopts,
     linkstatic = 1,
-    tags = ["tflite_not_portable_ios"],
+    tags = ["tflite_not_portable"],
     deps = [
         ":imagenet_topk_eval",
         "@com_google_googletest//:gtest",

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1,5 +1,11 @@
 # -*- Python -*-
 
+# version for the shared libraries, can
+# not contain rc or alpha, only numbers.
+# Also update tensorflow/core/public/version.h
+# and tensorflow/tools/pip_package/setup.py
+VERSION = "1.13.1"
+
 # Return the options to use for a C++ library or binary build.
 # Uses the ":optmode" config_setting to pick the options.
 load(
@@ -385,29 +391,41 @@ def _rpath_linkopts(name):
 
 # Bazel-generated shared objects which must be linked into TensorFlow binaries
 # to define symbols from //tensorflow/core:framework and //tensorflow/core:lib.
-def tf_binary_additional_srcs():
+def tf_binary_additional_srcs(fullversion = False):
+    if fullversion:
+        suffix = "." + VERSION
+    else:
+        suffix = "." + VERSION.split(".")[0]
+
     return select({
         clean_dep("//tensorflow:macos_with_framework_shared_object"): [
-            clean_dep("//tensorflow:libtensorflow_framework.dylib"),
+            clean_dep("//tensorflow:libtensorflow_framework%s.dylib" % suffix),
         ],
         clean_dep("//tensorflow:framework_shared_object"): [
-            clean_dep("//tensorflow:libtensorflow_framework.so"),
+            clean_dep("//tensorflow:libtensorflow_framework.so%s" % suffix),
         ],
         "//conditions:default": [
         ],
     })
 
-# Helper function for the per-OS tensorflow libraries
+# Helper function for the per-OS tensorflow libraries and their version symlinks
 def tf_shared_library_deps():
+    longsuffix = "." + VERSION
+    suffix = "." + VERSION.split(".")[0]
+
     return select({
         clean_dep("//tensorflow:macos"): [
             clean_dep("//tensorflow:libtensorflow.dylib"),
+            clean_dep("//tensorflow:libtensorflow%s.dylib" % suffix),
+            clean_dep("//tensorflow:libtensorflow%s.dylib" % longsuffix),
         ],
         clean_dep("//tensorflow:windows"): [
             clean_dep("//tensorflow:tensorflow.dll"),
         ],
         "//conditions:default": [
             clean_dep("//tensorflow:libtensorflow.so"),
+            clean_dep("//tensorflow:libtensorflow.so%s" % suffix),
+            clean_dep("//tensorflow:libtensorflow.so%s" % longsuffix),
         ],
     }) + tf_binary_additional_srcs()
 
@@ -435,9 +453,9 @@ def tf_binary_dynamic_kernel_deps(kernels):
 # TODO(pcloudy): Remove this workaround when https://github.com/bazelbuild/bazel/issues/4570
 # is done and cc_shared_library is available.
 SHARED_LIBRARY_NAME_PATTERNS = [
-    "lib%s.so",  # On Linux, shared libraries are usually named as libfoo.so
-    "lib%s.dylib",  # On macos, shared libraries are usually named as libfoo.dylib
-    "%s.dll",  # On Windows, shared libraries are usually named as foo.dll
+    "lib%s.so%s",  # On Linux, shared libraries are usually named as libfoo.so
+    "lib%s%s.dylib",  # On macos, shared libraries are usually named as libfoo.dylib
+    "%s%s.dll",  # On Windows, shared libraries are usually named as foo.dll
 ]
 
 def tf_cc_shared_object(
@@ -447,40 +465,86 @@ def tf_cc_shared_object(
         data = [],
         linkopts = [],
         framework_so = tf_binary_additional_srcs(),
+        soversion = None,
         kernels = [],
         per_os_targets = False,  # Generate targets with SHARED_LIBRARY_NAME_PATTERNS
         visibility = None,
         **kwargs):
-    if per_os_targets:
-        names = [pattern % name for pattern in SHARED_LIBRARY_NAME_PATTERNS]
+    """Configure the shared object (.so) file for TensorFlow."""
+    if soversion != None:
+        suffix = "." + str(soversion).split(".")[0]
+        longsuffix = "." + str(soversion)
     else:
-        names = [name]
-    for name_os in names:
+        suffix = ""
+        longsuffix = ""
+
+    if per_os_targets:
+        names = [
+            (
+                pattern % (name, ""),
+                pattern % (name, suffix),
+                pattern % (name, longsuffix),
+            )
+            for pattern in SHARED_LIBRARY_NAME_PATTERNS
+        ]
+    else:
+        names = [(
+            name,
+            name + suffix,
+            name + longsuffix,
+        )]
+
+    for name_os, name_os_major, name_os_full in names:
+        # Windows DLLs cant be versioned
+        if name_os.endswith(".dll"):
+            name_os_major = name_os
+            name_os_full = name_os
+
+        if name_os != name_os_major:
+            native.genrule(
+                name = name_os + "_sym",
+                outs = [name_os],
+                srcs = [name_os_major],
+                output_to_bindir = 1,
+                cmd = "ln -sf $$(basename $<) $@",
+            )
+            native.genrule(
+                name = name_os_major + "_sym",
+                outs = [name_os_major],
+                srcs = [name_os_full],
+                output_to_bindir = 1,
+                cmd = "ln -sf $$(basename $<) $@",
+            )
+
+        soname = name_os_major.split("/")[-1]
+
         native.cc_binary(
-            name = name_os,
+            name = name_os_full,
             srcs = srcs + framework_so,
             deps = deps,
             linkshared = 1,
             data = data,
-            linkopts = linkopts + _rpath_linkopts(name_os) + select({
+            linkopts = linkopts + _rpath_linkopts(name_os_full) + select({
                 clean_dep("//tensorflow:macos"): [
-                    "-Wl,-install_name,@rpath/" + name_os.split("/")[-1],
+                    "-Wl,-install_name,@rpath/" + soname,
                 ],
                 clean_dep("//tensorflow:windows"): [],
                 "//conditions:default": [
-                    "-Wl,-soname," + name_os.split("/")[-1],
+                    "-Wl,-soname," + soname,
                 ],
             }),
             visibility = visibility,
             **kwargs
         )
-    if name not in names:
+
+    flat_names = [item for sublist in names for item in sublist]
+    if name not in flat_names:
         native.filegroup(
             name = name,
             srcs = select({
-                "//tensorflow:windows": [":%s.dll" % name],
-                "//tensorflow:macos": [":lib%s.dylib" % name],
-                "//conditions:default": [":lib%s.so" % name],
+                "//tensorflow:windows": [":%s.dll" % (name)],
+                "//tensorflow:macos": [":lib%s%s.dylib" % (name, longsuffix)],
+                "//conditions:default": [":lib%s.so%s" % (name, longsuffix)],
             }),
             visibility = visibility,
         )
@@ -511,7 +575,7 @@ def tf_cc_binary(
         added_data_deps = []
 
     if per_os_targets:
-        names = [pattern % name for pattern in SHARED_LIBRARY_NAME_PATTERNS]
+        names = [pattern % (name, "") for pattern in SHARED_LIBRARY_NAME_PATTERNS]
     else:
         names = [name]
     for name_os in names:
@@ -1164,7 +1228,7 @@ def tf_java_test(
     native.java_test(
         name = name,
         srcs = srcs,
-        deps = deps + tf_binary_additional_srcs() + tf_binary_dynamic_kernel_dsos() + tf_binary_dynamic_kernel_deps(kernels),
+        deps = deps + tf_binary_additional_srcs(fullversion = True) + tf_binary_dynamic_kernel_dsos() + tf_binary_dynamic_kernel_deps(kernels),
         *args,
         **kwargs
     )
@@ -1848,6 +1912,7 @@ def tf_py_wrap_cc(
         linkopts = extra_linkopts,
         linkstatic = 1,
         deps = deps + extra_deps,
+        data = tf_binary_additional_srcs() + tf_binary_additional_srcs(fullversion=True),
         **kwargs
     )
     native.genrule(

--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -89,6 +89,9 @@ pkg_tar(
 pkg_tar(
     name = "clib",
     files = select({
+        "//tensorflow:macos": [
+            "//tensorflow:libtensorflow.dylib",
+        ],
         "//tensorflow:windows": [
             "//tensorflow:tensorflow.dll",
             "//tensorflow:tensorflow_dll_import_lib",

--- a/tensorflow/tools/pip_package/MANIFEST.in
+++ b/tensorflow/tools/pip_package/MANIFEST.in
@@ -3,6 +3,7 @@ recursive-include * *.py
 recursive-include * *.pyd
 recursive-include * *.pd
 recursive-include * *.so
+recursive-include * *.so.*
 recursive-include * *.dylib
 recursive-include * *.dll
 recursive-include * *.lib

--- a/tensorflow/tools/pip_package/MANIFEST.in
+++ b/tensorflow/tools/pip_package/MANIFEST.in
@@ -3,6 +3,7 @@ recursive-include * *.py
 recursive-include * *.pyd
 recursive-include * *.pd
 recursive-include * *.so
+recursive-include * *.dylib
 recursive-include * *.dll
 recursive-include * *.lib
 recursive-include * *.csv

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -45,6 +45,8 @@ DOCLINES = __doc__.split('\n')
 # This version string is semver compatible, but incompatible with pip.
 # For pip, we will remove all '-' characters from this string, and use the
 # result for pip.
+# Also update tensorflow/tensorflow.bzl and
+# tensorflow/core/public/version.h
 _VERSION = '1.13.1'
 
 REQUIRED_PACKAGES = [


### PR DESCRIPTION
Previously the libs were just "libtensorflow.so" without any version.
This adds the version to the library (eg libtensorflow.so.1.13.0) and
adds the appropriate symlinks to the full name from the base and
soversion.

The soname is used by compilers to fill in the DT_NEEDED section in the
header of binaries that link to the library. Having the version means
that different versions of the library are able to co-exist and if the
ABI changes, programs linking to the lib do not break.

For more info see:
https://www.debian.org/doc/debian-policy/ch-sharedlibs.html
https://autotools.io/libtool/version.html

Signed-off-by: Jason Zaman <jason@perfinion.com>

This was previously merged in
https://github.com/tensorflow/tensorflow/pull/22797
but then an issue with the pip wheel was found so reverted in
https://github.com/tensorflow/tensorflow/commit/52bd1737373cb3e64fcbc0c64d7a5b1fe62ef6b6

The libtensorflow_framework.so libs were missing in the build_pip_package deps
and in the MANIFEST.in file so they were not included in the wheel.

The single patch is also now split into separate patches for enabling the per-OS libs for tensorflow_framework and for the versioning.