### PR TITLE
Fix errors of incorrect session for evaluation in the clusterspec propagation test.

### DIFF
--- a/tensorflow/python/client/session_clusterspec_prop_test.py
+++ b/tensorflow/python/client/session_clusterspec_prop_test.py
@@ -105,9 +105,9 @@ class SessionClusterSpecPropagationTest(test_util.TensorFlowTestCase):
 
     with ops.Graph().as_default() as g, ops.device('/job:worker/task:0'):
       const = constant_op.constant(17)
-    sess = session.Session(server1.target, config=config, graph=g)
-    output = self.evaluate(const)
-    self.assertEqual(17, output)
+    with session.Session(server1.target, config=config, graph=g):
+      output = self.evaluate(const)
+      self.assertEqual(17, output)
 
   def testCanonicalDeviceNames(self):
     server1 = server_lib.Server.create_local_server()
@@ -207,9 +207,9 @@ class SessionClusterSpecPropagationTest(test_util.TensorFlowTestCase):
 
       with ops.device('/job:worker/task:0/cpu:0'):
         sum3 = sum1 + sum2
-    sess = session.Session(server1.target, config=config, graph=g)
-    output = self.evaluate(sum3)
-    self.assertEqual(40, output)
+    with session.Session(server1.target, config=config, graph=g):
+      output = self.evaluate(sum3)
+      self.assertEqual(40, output)
 
   def testLegacyDeviceNames(self):
     server1 = server_lib.Server.create_local_server()


### PR DESCRIPTION
For a `TensorFlowTestCase` instance, its `self.evalute(...)` uses the default session to fetch a tensor value.
In `testClusterSpecPropagationWorker1Placement` and `testMultipleLocalDevices`, the default session has no graph registered, which brings errors like the following:
```bash
======================================================================
ERROR: testClusterSpecPropagationWorker1Placement (__main__.SessionClusterSpecPropagationTest)
testClusterSpecPropagationWorker1Placement (__main__.SessionClusterSpecPropagationTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    yield
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    testMethod()
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    output = self.evaluate(const)
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    return sess.run(tensors)
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    return super(ErrorLoggingSession, self).run(*args, **kwargs)
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    run_metadata_ptr)
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    raise RuntimeError('The Session graph is empty.  Add operations to the '
RuntimeError: The Session graph is empty.  Add operations to the graph before calling run().

======================================================================
ERROR: testMultipleLocalDevices (__main__.SessionClusterSpecPropagationTest)
testMultipleLocalDevices (__main__.SessionClusterSpecPropagationTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    yield
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    testMethod()
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    output = self.evaluate(sum3)
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    return sess.run(tensors)
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    return super(ErrorLoggingSession, self).run(*args, **kwargs)
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    run_metadata_ptr)
  File "/data00/home/shishaochen/.cache/bazel/_bazel_shishaochen/66654af5b8967893709f1bb873fdbb49/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/session
    raise RuntimeError('The Session graph is empty.  Add operations to the '
RuntimeError: The Session graph is empty.  Add operations to the graph before calling run().

----------------------------------------------------------------------
```
**Thus, we'd better explicitly use the created GRPC session registered with the wanted graph to evaluate tensors.**