### PR TITLE
Lite: Range Op small refactor

### DIFF
--- a/tensorflow/lite/kernels/range.cc
+++ b/tensorflow/lite/kernels/range.cc
@@ -88,12 +88,20 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // Currently only supports int32 and float.
   // TODO(b/117912892): Support quantization as well.
   const auto dtype = start->type;
-  TF_LITE_ENSURE(context, dtype == kTfLiteInt32 || dtype == kTfLiteFloat32);
   TF_LITE_ENSURE_EQ(context, limit->type, dtype);
   TF_LITE_ENSURE_EQ(context, delta->type, dtype);
   TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
 
-  output->type = dtype;
+  switch (dtype) {
+    case kTfLiteInt32:
+    case kTfLiteFloat32:
+      output->type = dtype;
+      break;
+    default:
+      context->ReportError(context, "Unknown index output data type: %s",
+                           TfLiteTypeGetName(dtype));
+      return kTfLiteError;
+  }
 
   if (IsConstantTensor(start) && IsConstantTensor(limit) &&
       IsConstantTensor(delta)) {

--- a/tensorflow/lite/kernels/range.cc
+++ b/tensorflow/lite/kernels/range.cc
@@ -88,20 +88,17 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // Currently only supports int32 and float.
   // TODO(b/117912892): Support quantization as well.
   const auto dtype = start->type;
+  if (dtype != kTfLiteFloat32 && dtype != kTfLiteInt32) {
+    context->ReportError(context, "Unknown index output data type: %s",
+                         TfLiteTypeGetName(dtype));
+    return kTfLiteError;
+  }
+
   TF_LITE_ENSURE_EQ(context, limit->type, dtype);
   TF_LITE_ENSURE_EQ(context, delta->type, dtype);
-  TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
 
-  switch (dtype) {
-    case kTfLiteInt32:
-    case kTfLiteFloat32:
-      output->type = dtype;
-      break;
-    default:
-      context->ReportError(context, "Unknown index output data type: %s",
-                           TfLiteTypeGetName(dtype));
-      return kTfLiteError;
-  }
+  TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
+  output->type = dtype;
 
   if (IsConstantTensor(start) && IsConstantTensor(limit) &&
       IsConstantTensor(delta)) {

--- a/tensorflow/lite/kernels/range.cc
+++ b/tensorflow/lite/kernels/range.cc
@@ -93,18 +93,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, delta->type, dtype);
   TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
 
-  switch (dtype) {
-    case kTfLiteInt32:
-      output->type = kTfLiteInt32;
-      break;
-    case kTfLiteFloat32:
-      output->type = kTfLiteFloat32;
-      break;
-    default:
-      context->ReportError(context, "Unknown index output data type: %d",
-                           dtype);
-      return kTfLiteError;
-  }
+  output->type = dtype;
 
   if (IsConstantTensor(start) && IsConstantTensor(limit) &&
       IsConstantTensor(delta)) {


### PR DESCRIPTION
The switch case is not required, as the dtype check is already done above.