### PR TITLE
[Java] Implements EagerSession for eager execution.

### DIFF
--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -134,6 +134,19 @@ java_library(
 )
 
 tf_java_test(
+    name = "EagerSessionTest",
+    size = "small",
+    srcs = ["src/test/java/org/tensorflow/EagerSessionTest.java"],
+    javacopts = JAVACOPTS,
+    test_class = "org.tensorflow.EagerSessionTest",
+    deps = [
+        ":tensorflow",
+        ":testutil",
+        "@junit",
+    ],
+)
+
+tf_java_test(
     name = "GraphTest",
     size = "small",
     srcs = ["src/test/java/org/tensorflow/GraphTest.java"],

--- a/tensorflow/java/src/main/java/org/tensorflow/EagerSession.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/EagerSession.java
@@ -1,0 +1,426 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package org.tensorflow;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * An environment for executing TensorFlow operations eagerly.
+ * <p>
+ * Eager execution is an imperative programming environment that evaluates operations immediately, 
+ * without building graphs. Operations return concrete values instead of constructing a computational 
+ * graph to run later, as with {@link Graph}s and {@link Session}s.
+ * <p> 
+ * This makes it easy to develop with TensorFlow and debug models, as it behaves more like a standard
+ * programming library.
+ * <p>
+ * Instances of a {@code EagerSession} are thread-safe.
+ * <p>
+ * <b>WARNING:</b> Resources consumed by an {@code EagerSession} object must be explicitly freed by invoking
+ * the {@link #close()} method when it is no longer needed. This could be achieve using the `try-with-resources`
+ * technique as the example below:
+ * <pre>{@code
+ * try (EagerSession s = EagerSession.create()) {
+ *    // execute operations eagerly
+ * }
+ * }</pre>
+ * In addition, {@code EagerSession} objects clean up unused resources during the session, working in pair 
+ * with the JVM garbage collector. See {@link ResourceCleanupStrategy} for more details.
+ */
+public final class EagerSession implements ExecutionEnvironment, AutoCloseable {
+
+  /**
+   * Controls how to act when we try to run an operation on a given device but
+   * some input tensors are not on that device.
+   */
+  public static enum DevicePlacementPolicy {
+
+    /** 
+     * Running operations with input tensors on the wrong device will fail. 
+     */
+    EXPLICIT(0),
+
+    /** 
+     * Copy the tensor to the right device but log a warning. 
+     */
+    WARN(1),
+
+    /** 
+     * Silently copy the tensor, which has a performance cost since the 
+     * operation will be blocked till the copy completes. This is the default 
+     * placement policy.
+     */
+    SILENT(2),
+
+    /** 
+     * Placement policy which silently copies int32 tensors but not other 
+     * dtypes.
+     */
+    SILENT_FOR_INT32(3);
+    
+    private DevicePlacementPolicy(int code) {
+      this.code = code;
+    }
+    
+    private final int code;
+  }
+  
+  /**
+   * Controls how TensorFlow resources are cleaned up when they are no longer needed.
+   * <p>
+   * All resources allocated during an {@code EagerSession} are deleted when the session is closed. 
+   * To prevent out-of-memory errors, it is also strongly suggest to cleanup those resources during 
+   * the session. For example, executing n operations in a loop of m iterations will allocate a 
+   * minimum of n*m resources while in most cases, only resources of the last iteration are still 
+   * being used.
+   * <p>
+   * {@code EagerSession} instances can be notified in different ways when TensorFlow objects are no 
+   * longer being referred, so they can proceed to the cleanup of any resources they owned.
+   */
+  public static enum ResourceCleanupStrategy {
+    
+    /**
+     * Monitor and delete unused resources from a new thread running in background.
+     * <p>
+     * This is the most reliable approach to cleanup TensorFlow resources, at the cost of starting 
+     * and running an additional thread dedicated to this task. Each {@code EagerSession} instance 
+     * has its own thread, which is stopped only when the session is closed.
+     * <p>
+     * This strategy is used by default.
+     */
+    IN_BACKGROUND,
+    
+    /**
+     * Monitor and delete unused resources from existing threads, before or after they complete 
+     * another task.
+     * <p>
+     * Unused resources are released when a call to the TensorFlow library reaches a safe point for 
+     * cleanup. This is done synchronously and might block for a short period of time the thread who 
+     * triggered that call.
+     * <p> 
+     * This strategy should be used only if, for some reasons, no additional thread should be allocated 
+     * for cleanup. Otherwise, {@link #IN_BACKGROUND} should be preferred.
+     */
+    ON_SAFE_POINTS,
+    
+    /**
+     * Only delete resources when the session is closed.
+     * <p>
+     * All resources allocated during the session will remained in memory until the session is 
+     * explicitly closed (or via the traditional `try-with-resource` technique). No extra task for 
+     * resource cleanup will be attempted.
+     * <p>
+     * This strategy can lead up to out-of-memory errors and its usage is not recommended, unless the 
+     * scope of the session is limited to execute only a small amount of operations.
+     */
+    ON_SESSION_CLOSE,
+  }
+  
+  public static class Options {
+    
+    /**
+     * Controls how operations dispatched are actually executed. 
+     * <p>
+     * When set to true, each operation are executed asynchronously (in which case some operations
+     * might return "non-ready" outputs). When set to false, all operations are executed synchronously.
+     * <p>
+     * Synchronous execution is used by default.
+     * 
+     * @param value true for asynchronous execution, false for synchronous.
+     */
+    public Options async(boolean value) {
+      async = value;
+      return this;
+    }
+    
+    /**
+     * Controls how to act when we try to run an operation on a given device but
+     * some input tensors are not on that device.
+     * <p>
+     * {@link DevicePlacementPolicy#SILENT} is used by default.
+     * 
+     * @param value policy to apply
+     * @see {@link DevicePlacementPolicy}
+     */
+    public Options devicePlacementPolicy(DevicePlacementPolicy value) {
+      devicePlacementPolicy = value;
+      return this;
+    }
+    
+    /**
+     * Controls how TensorFlow resources are cleaned up when no longer needed.
+     * <p>
+     * {@link ResourceCleanupStrategy#IN_BACKGROUND} is used by default.
+     * 
+     * @param value strategy to use
+     * @see {@link ResourceCleanupStrategy}
+     */
+    public Options resourceCleanupStrategy(ResourceCleanupStrategy value) {
+      resourceCleanupStrategy = value;
+      return this;
+    }
+    
+    /**
+     * Configures the session based on the data found in the provided buffer, which is serialized TensorFlow 
+     * config proto.
+     * <p>
+     * Warning: the support of this feature is subject to changes since TensorFlow protos might not be supported
+     * on public endpoints in the future. 
+     * 
+     * @param value a serialized config proto
+     * @see https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/protobuf/config.proto
+     */
+    public Options config(byte[] value) {
+      config = value;
+      return this;
+    }
+    
+    /** 
+     * Builds an eager session with the selected options.
+     */
+    public EagerSession build() {
+      return new EagerSession(this);
+    }
+    
+    private boolean async;
+    private DevicePlacementPolicy devicePlacementPolicy;
+    private ResourceCleanupStrategy resourceCleanupStrategy;
+    private byte[] config;
+    
+    private Options() {
+      async = false;
+      devicePlacementPolicy = DevicePlacementPolicy.SILENT;
+      resourceCleanupStrategy = ResourceCleanupStrategy.IN_BACKGROUND;
+      config = null;
+    }
+  }
+  
+  /**
+   * Returns an object that configures and builds a {@code EagerSession} with custom options.
+   */
+  public static EagerSession.Options options() {
+    return new Options();
+  }
+  
+  /**
+   * Returns an {@code EagerSession} configured with default options.
+   */
+  public static EagerSession create() {
+    return options().build();
+  }
+
+  private EagerSession(Options options) {
+    this.nativeHandle = allocate(options.async, options.devicePlacementPolicy.code, options.config);
+    this.resourceCleanupStrategy = options.resourceCleanupStrategy;
+
+    if (resourceCleanupStrategy == ResourceCleanupStrategy.IN_BACKGROUND) {
+      nativeResources.startCleanupThread();
+    }
+  }
+
+  @Override
+  public synchronized void close() {
+    if (nativeHandle != 0L) {
+      if (resourceCleanupStrategy == ResourceCleanupStrategy.IN_BACKGROUND) {
+        nativeResources.stopCleanupThread();
+      }
+      nativeResources.deleteAll();
+      delete(nativeHandle);
+      nativeHandle = 0L;
+    }
+  }
+
+  @Override
+  public OperationBuilder opBuilder(String type, String name) {
+    if (resourceCleanupStrategy == ResourceCleanupStrategy.ON_SAFE_POINTS) {
+      nativeResources.tryCleanup();
+    }
+    checkSession();
+    // TODO (karllessard) create a new EagerOperationBuilder
+    throw new UnsupportedOperationException("Eager execution mode is not yet supported in this version of TensorFlow");
+  }
+  
+  /**
+   * A reference to one or more allocated native resources.
+   * <p>
+   * Any Java objects owning native resources must declare a reference to those resources in a 
+   * subclass that extends from {@code NativeReference}. When {@link NativeReference#delete()} is invoked, 
+   * the resources must be freed. For example:
+   * <pre>{@code
+   * private static class NativeReference extends EagerSession.NativeReference {
+   * 
+   *    NativeReference(EagerSession session, MyClass referent, long handle) {
+   *        super(session, referent);
+   *        this.handle = handle;
+   *    }
+   *    
+   *    @Override
+   *    void delete() {
+   *        MyClass.nativeDelete(handle);
+   *    }
+   *    
+   *    private final long handle;
+   * }
+   * }</pre>
+   * 
+   * A Java object "owns" a native resource if this resource should not survive beyond the lifetime of
+   * this object.
+   * <p> 
+   * <b>IMPORTANT</b>: All nested subclasses of {@code NativeReference} must be declared as static, otherwise 
+   * their instances will hold an implicit reference to their enclosing object, preventing the garbage
+   * collector to release them when they are no longer needed.
+   */
+  static abstract class NativeReference extends PhantomReference<Object> {
+
+    /**
+     * Attach a new phantom reference of {@code referent} to {@code session}.
+     */
+    public NativeReference(EagerSession session, Object referent) {
+      super(referent, session.nativeResources.garbageQueue);
+      session.checkSession();
+      nativeResources = session.nativeResources;
+      nativeResources.attach(this);
+    }
+    
+    /**
+     * Detach this reference from its current session.
+     * <p>
+     * Clearing a NativeReference does not invoke {@link #delete()}, thus won't release the native resources it 
+     * refers to. It can be used when passing the ownership of those resources to another object.
+     * <p>
+     * If native resources needs to be deleted as well, call {@link #delete()} explicitly.
+     */
+    @Override
+    public void clear() {
+      nativeResources.detach(this);
+      super.clear();
+    }
+    
+    /**
+     * Releases all native resources owned by the referred object, now deleted.  
+     */
+    abstract void delete();
+    
+    private final NativeResourceCollector nativeResources;
+  }
+  
+  /**
+   * Collects native references attached to this session and releases their resources if they are
+   * no longer needed.
+   */
+  private static class NativeResourceCollector {
+    
+    void attach(NativeReference nativeRef) {
+      synchronized(nativeRefs) {
+        nativeRefs.put(nativeRef, null);
+      }
+    }
+    
+    void detach(NativeReference nativeRef) {
+      synchronized(nativeRefs) {
+        nativeRefs.remove(nativeRef);
+      }
+    }
+    
+    void delete(NativeReference nativeRef) {
+      synchronized(nativeRefs) {
+        if (!nativeRefs.keySet().remove(nativeRef)) {
+          return;  // safety check
+        }
+      }
+      nativeRef.delete();
+    }
+    
+    void deleteAll() {
+      synchronized(nativeRefs) {
+        for (NativeReference nativeRef : nativeRefs.keySet()) {
+          nativeRef.delete();
+        }
+        nativeRefs.clear();
+      }
+    }
+
+    void tryCleanup() {
+      Reference<?> nativeRef;
+      synchronized(nativeRefs) {
+        while ((nativeRef = garbageQueue.poll()) != null) {
+          delete((NativeReference)nativeRef);
+        }
+      }
+    }
+    
+    synchronized void startCleanupThread() {
+      if (cleanupInBackground) {
+        return;  // ignore if cleanup thread is already running
+      }
+      try {
+        cleanupInBackground = true;
+        cleanupService.execute(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              while(cleanupInBackground) {
+                NativeReference nativeRef = (NativeReference)garbageQueue.remove();
+                delete(nativeRef);
+              }
+            } catch (InterruptedException e) {
+              // exit
+            }
+          }
+        });
+      } catch (Exception e) {
+        cleanupInBackground = false;
+        throw e;
+      }
+    }
+    
+    void stopCleanupThread() {
+      cleanupInBackground = false;
+      cleanupService.shutdownNow();  // returns without waiting for the thread to stop
+    }
+
+    private final ExecutorService cleanupService = Executors.newSingleThreadExecutor();
+    private final Map<NativeReference, Void> nativeRefs = new IdentityHashMap<>();
+    private final ReferenceQueue<Object> garbageQueue = new ReferenceQueue<>();
+    private volatile boolean cleanupInBackground = false;
+  }
+  
+  private final NativeResourceCollector nativeResources = new NativeResourceCollector();
+  private final ResourceCleanupStrategy resourceCleanupStrategy;
+  private long nativeHandle;
+  
+  private void checkSession() {
+    if (nativeHandle == 0L) {
+      throw new IllegalStateException("Eager session has been closed");
+    }
+  }
+
+  private static native long allocate(boolean async, int devicePlacementPolicy, byte[] config);
+
+  private static native void delete(long handle);
+  
+  private static native long allocateOperation(long contextHandle, String name);
+
+  static {
+    TensorFlow.init();
+  }
+}

--- a/tensorflow/java/src/main/native/BUILD
+++ b/tensorflow/java/src/main/native/BUILD
@@ -39,6 +39,7 @@ tf_cuda_library(
         ],
         "//conditions:default": [
             "//tensorflow/c:c_api",
+            "//tensorflow/c/eager:c_api",
             "//tensorflow/core:all_kernels",
             "//tensorflow/core:direct_session",
             "//tensorflow/core:ops",

--- a/tensorflow/java/src/main/native/eager_session_jni.cc
+++ b/tensorflow/java/src/main/native/eager_session_jni.cc
@@ -1,0 +1,92 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+
+#include <cstring>
+#include <memory>
+#include "tensorflow/c/eager/c_api.h"
+#include "tensorflow/java/src/main/native/exception_jni.h"
+#include "tensorflow/java/src/main/native/eager_session_jni.h"
+
+namespace {
+
+TFE_Context* requireContext(JNIEnv* env, jlong handle) {
+  if (handle == 0) {
+    throwException(env, kIllegalStateException,
+                   "Context has been deleted");
+    return nullptr;
+  }
+  return reinterpret_cast<TFE_Context*>(handle);
+}
+
+}  // namespace
+
+JNIEXPORT jlong JNICALL Java_org_tensorflow_EagerSession_allocate(
+    JNIEnv* env, jclass clazz, jboolean async, jint dpp, jbyteArray config) {
+  TFE_ContextOptions* opts = TFE_NewContextOptions();
+  jbyte* cconfig = nullptr;
+  TF_Status* status = TF_NewStatus();
+  if (config != nullptr) {
+    cconfig = env->GetByteArrayElements(config, nullptr);
+    TFE_ContextOptionsSetConfig(opts, cconfig,
+                 static_cast<size_t>(env->GetArrayLength(config)), status);
+    if (!throwExceptionIfNotOK(env, status)) {
+      env->ReleaseByteArrayElements(config, cconfig, JNI_ABORT);
+      TFE_DeleteContextOptions(opts);
+      TF_DeleteStatus(status);
+      return 0;
+    }
+  }
+  TFE_ContextOptionsSetAsync(opts, static_cast<unsigned char>(async));
+  TFE_ContextOptionsSetDevicePlacementPolicy(opts,
+      static_cast<TFE_ContextDevicePlacementPolicy>(dpp));
+  TFE_Context* context = TFE_NewContext(opts, status);
+  TFE_DeleteContextOptions(opts);
+  if (config != nullptr) {
+    env->ReleaseByteArrayElements(config, cconfig, JNI_ABORT);
+  }
+  if (!throwExceptionIfNotOK(env, status)) {
+    TF_DeleteStatus(status);
+    return 0;
+  }
+  TF_DeleteStatus(status);
+  static_assert(sizeof(jlong) >= sizeof(TFE_Context*),
+                "Cannot represent a C TFE_Op as a Java long");
+  return reinterpret_cast<jlong>(context);
+}
+
+JNIEXPORT void JNICALL Java_org_tensorflow_EagerSession_delete(
+    JNIEnv* env, jclass clazz, jlong handle) {
+  if (handle == 0) return;
+  TFE_DeleteContext(reinterpret_cast<TFE_Context*>(handle));
+}
+
+JNIEXPORT jlong JNICALL Java_org_tensorflow_EagerSession_allocateOperation(
+    JNIEnv* env, jclass clazz, jlong handle, jstring name) {
+  TFE_Context* context = requireContext(env, handle);
+  if (context == nullptr) return 0;
+  const char* op_or_function_name = env->GetStringUTFChars(name, nullptr);
+  TF_Status* status = TF_NewStatus();
+  TFE_Op* op = TFE_NewOp(context, op_or_function_name, status);
+  env->ReleaseStringUTFChars(name, op_or_function_name);
+  if (!throwExceptionIfNotOK(env, status)) {
+    TF_DeleteStatus(status);
+    return 0;
+  }
+  TF_DeleteStatus(status);
+  static_assert(sizeof(jlong) >= sizeof(TFE_Op*),
+                "Cannot represent a C TFE_Op as a Java long");
+  return reinterpret_cast<jlong>(op);
+}

--- a/tensorflow/java/src/main/native/eager_session_jni.h
+++ b/tensorflow/java/src/main/native/eager_session_jni.h
@@ -1,0 +1,52 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_JAVA_SRC_MAIN_NATIVE_EAGER_SESSION_JNI_H_
+#define TENSORFLOW_JAVA_SRC_MAIN_NATIVE_EAGER_SESSION_JNI_H_
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Class:     org_tensorflow_EagerSession
+ * Method:    allocate
+ * Signature: (ZI[B)J
+ */
+JNIEXPORT jlong JNICALL Java_org_tensorflow_EagerSession_allocate(
+    JNIEnv* env, jclass clazz, jboolean async, jint dpp, jbyteArray config);
+
+/*
+ * Class:     org_tensorflow_EagerSession
+ * Method:    delete
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_tensorflow_EagerSession_delete(
+    JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_tensorflow_EagerSession
+ * Method:    allocateOperation
+ * Signature: (JLjava/lang/String;)J
+ */
+JNIEXPORT jlong JNICALL Java_org_tensorflow_EagerSession_allocateOperation(
+    JNIEnv *, jclass, jlong, jstring);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  // TENSORFLOW_JAVA_SRC_MAIN_NATIVE_EAGER_SESSION_JNI_H_

--- a/tensorflow/java/src/test/java/org/tensorflow/EagerSessionTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/EagerSessionTest.java
@@ -1,0 +1,170 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package org.tensorflow;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.tensorflow.EagerSession.ResourceCleanupStrategy;
+
+@RunWith(JUnit4.class)
+public class EagerSessionTest {
+  
+  @Test
+  public void closeSessionTwiceDoesNotFail() {
+    try (EagerSession s = EagerSession.create()) {
+      s.close();
+    }
+  }
+  
+  @Test
+  public void cleanupResourceOnSessionClose() {
+    AtomicBoolean deleted = new AtomicBoolean();
+
+    try (EagerSession s = EagerSession.options()
+        .resourceCleanupStrategy(ResourceCleanupStrategy.ON_SESSION_CLOSE)
+        .build()) {
+
+      new TestReference(s, new Object(), deleted);
+
+      assertFalse(deleted.get());
+      runGC();
+      assertFalse(deleted.get());
+
+      buildOp(s);
+      assertFalse(deleted.get());  // reaching safe point did not release resources
+    }
+    assertTrue(deleted.get());
+  }
+
+  @Test
+  public void cleanupResourceOnSafePoints() {
+    AtomicBoolean deleted = new AtomicBoolean();
+
+    try (EagerSession s = EagerSession.options()
+        .resourceCleanupStrategy(ResourceCleanupStrategy.ON_SAFE_POINTS)
+        .build()) {
+
+      new TestReference(s, new Object(), deleted);
+
+      assertFalse(deleted.get());
+      runGC();
+      assertFalse(deleted.get());
+
+      buildOp(s);  
+      assertTrue(deleted.get());  // reaching safe point released resources
+    }
+  }
+
+  @Test
+  public void cleanupResourceInBackground() {
+    AtomicBoolean deleted = new AtomicBoolean();
+
+    try (EagerSession s = EagerSession.options()
+        .resourceCleanupStrategy(ResourceCleanupStrategy.IN_BACKGROUND)
+        .build()) {
+
+      new TestReference(s, new Object(), deleted);
+
+      assertFalse(deleted.get());
+      runGC();
+      sleep(50);  // allow some time to the background thread for cleaning up resources
+      assertTrue(deleted.get());
+    }
+  }
+
+  @Test
+  public void clearedResourcesAreNotCleanedUp() {
+    AtomicBoolean deleted = new AtomicBoolean();
+
+    try (EagerSession s = EagerSession.create()) {
+      TestReference ref = new TestReference(s, new Object(), deleted);
+      ref.clear();
+    }
+    assertFalse(deleted.get());
+  }
+  
+  @Test
+  public void buildingOpWithClosedSessionFails() {
+    EagerSession s = EagerSession.create();
+    s.close();
+    try {
+      buildOp(s);
+      fail();
+    } catch (IllegalStateException e) {
+      // ok
+    }
+  }
+
+  @Test
+  public void addingReferenceToClosedSessionFails() {
+    EagerSession s = EagerSession.create();
+    s.close();
+    try {
+      new TestReference(s, new Object(), new AtomicBoolean());
+      fail();
+    } catch (IllegalStateException e) {
+      // ok
+    }
+  }
+ 
+  private static class TestReference extends EagerSession.NativeReference {
+    
+    TestReference(EagerSession session, Object referent, AtomicBoolean deleted) {
+      super(session, referent);
+      this.deleted = deleted;
+    }
+    
+    @Override
+    void delete() {
+      if (!deleted.compareAndSet(false, true)) {
+        fail("Reference was deleted more than once");
+      }
+    }
+    
+    private final AtomicBoolean deleted;
+  }
+  
+  private static void buildOp(EagerSession s) {
+    // Creating an operation is a safe point for resource cleanup
+    try {
+      s.opBuilder("Const", "Const");
+    } catch (UnsupportedOperationException e) {
+      // TODO (karlllessard) remove this exception catch when EagerOperationBuilder is implemented
+    }
+  }
+  
+  private static void runGC() {
+    // Warning: There is no way to force the garbage collector to run, so here we simply to our best
+    // to get it triggered but it might be sufficient on some platforms. Adjust accordingly if some 
+    // cleanup tests start to fail.
+    System.gc();
+    System.runFinalization();
+  }
+  
+  private static void sleep(int millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+    }
+  }
+}


### PR DESCRIPTION
This is part of eager execution in Java epic (work in progress).

It adds a `EagerSession` that implements the `ExecutionEnvironment` interface to make it interchangeable with `Graph`. For example:

GraphExecution:
```java
try (Graph g = new Graph()) {
   Ops tf = Ops.create(g);
    ...
}  
```
EagerExecution:
```java
try (EagerSession s = EagerSession.create()) {
   Ops tf = Ops.create(s);
   ...
}
```
In addition, since in eager mode we can't only rely on the `try-with-resources` technique to free up native resources (as we may create a lot, think of a while loop), it has its own cleanup mechanics that is closely bound to the JVM garbage collector to know when it is safe to release resources.

CC: @sjamesr 