### PR TITLE
Fix segmentation fault with tf.stack an keras Input in TF2.0

### DIFF
--- a/tensorflow/python/eager/pywrap_tfe_src.cc
+++ b/tensorflow/python/eager/pywrap_tfe_src.cc
@@ -1838,8 +1838,12 @@ bool CheckInputsOk(PyObject* seq, int start_index,
                 << item->ob_type->tp_name;
         return false;
       }
-      for (Py_ssize_t j = 0; j < PySequence_Fast_GET_SIZE(item); j++) {
-        PyObject* inner_item = PySequence_Fast_GET_ITEM(item, j);
+      tensorflow::Safe_PyObjectPtr fast_item(PySequence_Fast(item, "Could not parse sequence."));
+      if (fast_item.get() == nullptr) {
+        return false;
+      }
+      for (Py_ssize_t j = 0; j < PySequence_Fast_GET_SIZE(fast_item.get()); j++) {
+        PyObject* inner_item = PySequence_Fast_GET_ITEM(fast_item.get(), j);
         if (!CheckOneInput(inner_item)) {
           VLOG(1) << "Falling back to slow path for Op \"" << op_def.name()
                   << "\", Input \"" << op_def.input_arg(i).name()

--- a/tensorflow/python/eager/pywrap_tfe_test.py
+++ b/tensorflow/python/eager/pywrap_tfe_test.py
@@ -232,7 +232,8 @@ class Tests(test.TestCase):
   def testEagerExecute_InvalidType(self):
     # Test case for GitHub issue 26879.
     value = keras.layers.Input((128, 128, 1), dtype='float32')
-    with self.assertRaisesRegexp(TypeError, "Expected list for 'values' argument"):
+    with self.assertRaisesRegexp(
+        TypeError, "Expected list for 'values' argument"):
       _ = array_ops.stack(value, axis=1)
 
 

--- a/tensorflow/python/eager/pywrap_tfe_test.py
+++ b/tensorflow/python/eager/pywrap_tfe_test.py
@@ -31,6 +31,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python import keras
 
 
 class Tests(test.TestCase):
@@ -227,6 +228,12 @@ class Tests(test.TestCase):
       return 1.
 
     self.assertTrue(ctx.has_function(f.get_concrete_function().name))
+
+  def testEagerExecute_InvalidType(self):
+    # Test case for GitHub issue 26879.
+    value = keras.layers.Input((128, 128, 1), dtype='float32')
+    with self.assertRaisesRegexp(TypeError, "Expected list for 'values' argument"):
+      _ = array_ops.stack(value, axis=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fix tries to address the issue raised in #26879 where tf.stack encounters segmantation fault with keras's Input in TF2.0:
```
import tensorflow as tf
from tensorflow.keras.layers import Input

print(tf.__version__)

input_ = Input((128, 128, 1), dtype='float32')
print(input_)
output = tf.stack(input_, axis=1)
```

The issue is that in eager wrap, `PySequence_Fast_GET_ITEM` tries to access an object not through `PySequence_Fast`.

This fix adds the `PySequence_Fast` and checks the return value to make sure it is not nullptr.

This fix fixes #26879.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>