### PR TITLE
Added support for list inputs

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2272,9 +2272,14 @@ class MeanIoU(Metric):
     Returns:
       Update op.
     """
-    # Converted y_true and y_pred into Tensors
-    y_true = ops.convert_to_tensor(y_true)
-    y_pred = ops.convert_to_tensor(y_pred)
+    
+    # If y_true and y_pred are lists then 
+    # they are converted into Tensors 
+    if type(y_true) == list:
+      y_true = ops.convert_to_tensor(y_true)
+      
+    if type(y_pred) == list:
+      y_pred = ops.convert_to_tensor(y_pred)
     
     # Flatten the input if its rank > 1.
     if y_pred.shape.ndims > 1:

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2273,10 +2273,10 @@ class MeanIoU(Metric):
       Update op.
     """
     # Flatten the input if its rank > 1.
-    if y_pred.shape.ndims > 1:
+    if array_ops.rank(y_pred).numpy() > 1:
       y_pred = array_ops.reshape(y_pred, [-1])
 
-    if y_true.shape.ndims > 1:
+    if array_ops.rank(y_true).numpy() > 1:
       y_true = array_ops.reshape(y_true, [-1])
 
     if sample_weight is not None and sample_weight.shape.ndims > 1:

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2272,11 +2272,15 @@ class MeanIoU(Metric):
     Returns:
       Update op.
     """
+    # Converted y_true and y_pred into Tensors
+    y_true = ops.convert_to_tensor(y_true)
+    y_pred = ops.convert_to_tensor(y_pred)
+    
     # Flatten the input if its rank > 1.
-    if array_ops.rank(y_pred).numpy() > 1:
+    if y_pred.shape.ndims > 1:
       y_pred = array_ops.reshape(y_pred, [-1])
 
-    if array_ops.rank(y_true).numpy() > 1:
+    if y_true.shape.ndims > 1:
       y_true = array_ops.reshape(y_true, [-1])
 
     if sample_weight is not None and sample_weight.shape.ndims > 1:

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2273,8 +2273,6 @@ class MeanIoU(Metric):
       Update op.
     """
     
-    # If y_true and y_pred are lists then 
-    # they are converted into Tensors 
     y_true = math_ops.cast(y_true, self._dtype)
     y_pred = math_ops.cast(y_pred, self._dtype)
     

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2275,11 +2275,8 @@ class MeanIoU(Metric):
     
     # If y_true and y_pred are lists then 
     # they are converted into Tensors 
-    if type(y_true) == list:
-      y_true = ops.convert_to_tensor(y_true)
-      
-    if type(y_pred) == list:
-      y_pred = ops.convert_to_tensor(y_pred)
+    y_true = math_ops.cast(y_true, self._dtype)
+    y_pred = math_ops.cast(y_pred, self._dtype)
     
     # Flatten the input if its rank > 1.
     if y_pred.shape.ndims > 1:

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -1141,8 +1141,8 @@ class MeanIoUTest(test.TestCase):
     self.assertEqual(m_obj2.num_classes, 2)
 
   def test_unweighted(self):
-    y_pred = constant_op.constant([0, 1, 0, 1], dtype=dtypes.float32)
-    y_true = constant_op.constant([0, 0, 1, 1])
+    y_pred = [0, 1, 0, 1]
+    y_true = [0, 0, 1, 1]
 
     m_obj = metrics.MeanIoU(num_classes=2)
     self.evaluate(variables.variables_initializer(m_obj.variables))


### PR DESCRIPTION
 ```y_pred.shape.ndims``` -> Not supports **list** as y_pred variable
 Whereas ```array_ops.rank(y_pred).numpy()```  works for all (Tensors, Numpy arrays, lists)

From #27150