### PR TITLE
Fix label for loaded package nccl

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -3,7 +3,7 @@
 load("//third_party/gpus:cuda_configure.bzl", "cuda_configure")
 load("//third_party/gpus:rocm_configure.bzl", "rocm_configure")
 load("//third_party/tensorrt:tensorrt_configure.bzl", "tensorrt_configure")
-load("//third_party:nccl/nccl_configure.bzl", "nccl_configure")
+load("//third_party/nccl:nccl_configure.bzl", "nccl_configure")
 load("//third_party/mkl:build_defs.bzl", "mkl_repository")
 load("//third_party/git:git_configure.bzl", "git_configure")
 load("//third_party/py:python_configure.bzl", "python_configure")


### PR DESCRIPTION
Fixes:
$ bazel build //tensorflow/examples/tutorials/word2vec:word2vec_basic
ERROR: error loading package '': in /home/nicholas/tensorflow/tensorflow/workspace.bzl: Label '//third_party:nccl/nccl_configure.bzl' crosses boundary of subpackage 'third_party/nccl' (perhaps you meant to put the colon here: '//third_party/nccl:nccl_configure.bzl'?)
ERROR: error loading package '': in /home/nicholas/tensorflow/tensorflow/workspace.bzl: Label '//third_party:nccl/nccl_configure.bzl' crosses boundary of subpackage 'third_party/nccl' (perhaps you meant to put the colon here: '//third_party/nccl:nccl_configure.bzl'?)
INFO: Elapsed time: 0.955s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)