### PR TITLE
Use current_java_runtime instead of local_jdk.

### DIFF
--- a/tensorflow/java/src/gen/gen_ops.bzl
+++ b/tensorflow/java/src/gen/gen_ops.bzl
@@ -49,15 +49,15 @@ def tf_java_op_gen_srcjar(
 
     # Generate a source archive containing generated code for these ops.
     gen_srcjar = out_dir + name + ".srcjar"
-    gen_cmds += ["$(location @bazel_tools//tools/jdk:current_java_runtime) cMf $(location :" + gen_srcjar + ") -C $(@D) src"]
+    gen_cmds += ["$(JAVABASE)/bin/jar cMf $(location :" + gen_srcjar + ") -C $(@D) src"]
 
     native.genrule(
         name = name,
         srcs = srcs,
         outs = [gen_srcjar],
         tools = [
-            "@bazel_tools//tools/jdk:current_java_runtime",
             gen_tool,
         ] + tf_binary_additional_srcs(),
+        toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
         cmd = " && ".join(gen_cmds),
     )

--- a/tensorflow/java/src/gen/gen_ops.bzl
+++ b/tensorflow/java/src/gen/gen_ops.bzl
@@ -49,15 +49,14 @@ def tf_java_op_gen_srcjar(
 
     # Generate a source archive containing generated code for these ops.
     gen_srcjar = out_dir + name + ".srcjar"
-    gen_cmds += ["$(location @local_jdk//:jar) cMf $(location :" + gen_srcjar + ") -C $(@D) src"]
+    gen_cmds += ["$(location @bazel_tools//tools/jdk:current_java_runtime) cMf $(location :" + gen_srcjar + ") -C $(@D) src"]
 
     native.genrule(
         name = name,
         srcs = srcs,
         outs = [gen_srcjar],
         tools = [
-            "@local_jdk//:jar",
-            "@local_jdk//:jdk",
+            "@bazel_tools//tools/jdk:current_java_runtime",
             gen_tool,
         ] + tf_binary_additional_srcs(),
         cmd = " && ".join(gen_cmds),

--- a/tensorflow/java/src/gen/gen_ops.bzl
+++ b/tensorflow/java/src/gen/gen_ops.bzl
@@ -58,6 +58,6 @@ def tf_java_op_gen_srcjar(
         tools = [
             gen_tool,
         ] + tf_binary_additional_srcs(),
-        toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+        toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
         cmd = " && ".join(gen_cmds),
     )


### PR DESCRIPTION
Relying on @local_jdk breaks remote execution from a host without JDK installed.

https://github.com/bazelbuild/bazel/issues/5594