### PR TITLE
TFTRT: Fix compilation errors and crash in NMS test

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -2355,7 +2355,7 @@ Status ConvertStridedSliceHelper(OpConverterParams* params,
   if (params->validation_only) return Status::OK();
 
   nvinfer1::ISliceLayer* layer = params->converter->network()->addSlice(
-      input.tensor(), begin_dims, size_dims, stride_dims);
+      *input.tensor(), begin_dims, size_dims, stride_dims);
   params->outputs->push_back(TRT_TensorOrWeights(layer->getOutput(0)));
   return Status::OK();
 #else

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -214,7 +214,8 @@ inline nvinfer1::Dims TensorShapeToTrtDims(const TensorShapeType& shape,
   return trt_dims;
 }
 
-Status TensorShapeArrayToTrtDims(const std::vector<int>& shape,
+template <typename Container>
+Status TensorShapeArrayToTrtDims(const Container& shape,
                                  nvinfer1::Dims* out,
                                  bool ignore_first_dim = false) {
   PartialTensorShape tensor_shape;

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -215,8 +215,7 @@ inline nvinfer1::Dims TensorShapeToTrtDims(const TensorShapeType& shape,
 }
 
 template <typename Container>
-Status TensorShapeArrayToTrtDims(const Container& shape,
-                                 nvinfer1::Dims* out,
+Status TensorShapeArrayToTrtDims(const Container& shape, nvinfer1::Dims* out,
                                  bool ignore_first_dim = false) {
   PartialTensorShape tensor_shape;
   TF_RETURN_IF_ERROR(TensorShapeUtils::MakeShape(shape, &tensor_shape));

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -2427,7 +2427,7 @@ TEST_F(OpConverterTest, ConvertCombinedNMS) {
                 ElementsAre(0, 0, 0.3, 0.4, 0, 0, 0.3, 0.4));
     EXPECT_THAT(GetSpanForData<float>(output_data[1]), ElementsAre(0.7, 0.4));
     EXPECT_THAT(GetSpanForData<float>(output_data[2]), ElementsAre(1, 0));
-    EXPECT_THAT(GetSpanForData<float>(output_data[3]), ElementsAre(2));
+    EXPECT_THAT(GetSpanForData<int32>(output_data[3]), ElementsAre(2));
   }
 }
 


### PR DESCRIPTION
* Fix type mismatch crash in CombinedNMS test.
* Fix compilation error due to absl::InlinedVector
* Fix compilation error for input argument to network()->addSlice()