### PR TITLE
Update eigen for pcmp_eq method for altivec [ppc64le]

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -145,11 +145,11 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
         name = "eigen_archive",
         build_file = clean_dep("//third_party:eigen.BUILD"),
         patch_file = clean_dep("//third_party/eigen3:gpu_packet_math.patch"),
-        sha256 = "1a8b03c2ae56722c0ff038174e55f82c88b68785c8ec6298659e573ddedbc6cc",
-        strip_prefix = "eigen-eigen-b5237bb1dd4b",
+        sha256 = "ab5bee2dc4b6918a2696932fc687ea3da50c3937ea3a8df86d1c239d90376a28",
+        strip_prefix = "eigen-eigen-f7f1947d95a6",
         urls = [
-            "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/b5237bb1dd4b.tar.gz",
-            "https://bitbucket.org/eigen/eigen/get/b5237bb1dd4b.tar.gz",
+            "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/f7f1947d95a6.tar.gz",
+            "https://bitbucket.org/eigen/eigen/get/f7f1947d95a6.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Commit dcbc812 made use of the pcmp_eq method for Packet
for the first time, this works fine on x86 but fails to compile
on ppc64le because the pcmp_eq method was not implemented in
Eigen's arch/AltiVec/Complex.h for float.

Eigen has now been updated to implement pcmp_eq in AltiVec,
updating TensorFlow to use that version of Eigen.