### PR TITLE
TFTRT: Support Split and Unstack/Unpack

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3492,6 +3492,105 @@ Status ConvertPad(OpConverterParams* params) {
   return Status::OK();
 }
 
+Status ConvertSplitHelper(OpConverterParams* params,
+                          const TRT_TensorOrWeights& input, int tf_axis,
+                          int num_splits, bool squeeze_after) {
+  const auto& node_def = params->node_def;
+  const nvinfer1::Dims dims = input.GetTrtDims();
+  // Convert axis.
+  int trt_axis;
+  TF_RETURN_IF_ERROR(
+      ConvertAxis(tf_axis, dims.nbDims, node_def.name(), &trt_axis));
+  // Dimension must equal num_splits for Unstack (when squeeze_after is true)
+  if (squeeze_after && dims.d[trt_axis] != num_splits) {
+    return errors::InvalidArgument(
+        "Dimension ", tf_axis, " has size ", dims.d[trt_axis],
+        " which is not equal to num of ", num_splits, ", at ", node_def.name());
+  }
+  // Dimension must be evenly divisible by num_splits.
+  if (dims.d[trt_axis] % num_splits != 0) {
+    return errors::InvalidArgument(
+        "Dimension ", tf_axis, " of size ", dims.d[trt_axis],
+        " is not evenly divisble by ", num_splits, ", at ", node_def.name());
+  }
+
+  // Create parameters for StridedSliceHelper.
+  // Slice will begin on zero for all dims, except the one being split which
+  // will change.
+  std::vector<int> begin(dims.nbDims, 0);
+  // Determine size of split. Slice will get the full length of all dims, except
+  // the one being split.
+  std::vector<int> size(dims.d, dims.d + dims.nbDims);
+  const int split_size_on_axis = dims.d[trt_axis] / num_splits;
+  size[trt_axis] = split_size_on_axis;
+  // Stride will always be 1
+  std::vector<int> stride(dims.nbDims, 1);
+  // Add dummy batch dimension
+  begin.insert(begin.begin(), 0);
+  size.insert(size.begin(), 1);
+  stride.insert(stride.begin(), 1);
+
+  // Slice the input. ConvertStridedSliceHelper will push the outputs onto
+  // params->outputs.
+  for (int i = 0; i < num_splits; ++i) {
+    begin[trt_axis + 1] = i * split_size_on_axis;
+    TF_RETURN_IF_ERROR(
+        ConvertStridedSliceHelper(params, input, begin, size, stride));
+  }
+  if (params->validation_only) return Status::OK();
+
+  // For Unpack/Unstack, remove axis that we split upon.
+  if (squeeze_after) {
+    // Create the new shape.
+    size.erase(size.begin() + trt_axis + 1);
+    nvinfer1::Dims new_dims;
+    TF_RETURN_IF_ERROR(
+        TensorShapeArrayToTrtDims(size, &new_dims, /*ignore_frst_dim=*/true));
+    // Reshape each slice.
+    for (int i = 0; i < params->outputs->size(); i++) {
+      nvinfer1::ITensor* output_tensor = nullptr;
+      TF_RETURN_IF_ERROR(params->converter->PrepareTensorForShape(
+          params->outputs->at(i), new_dims, /*validation_only=*/false,
+          &output_tensor));
+      (*params->outputs)[i] = TRT_TensorOrWeights(output_tensor);
+    }
+  }
+  return Status::OK();
+}
+
+Status ConvertSplit(OpConverterParams* params) {
+  const auto& inputs = params->inputs;
+  const auto& node_def = params->node_def;
+  TF_RETURN_IF_ERROR(
+      CheckInputsWeights(*params, {{"axis", true}, {"value", false}}));
+  TF_RETURN_IF_ERROR(AllowDataTypes(
+      *params, {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}));
+  int tf_axis = inputs.at(0).weights().GetSpan<int>()[0];
+  TFAttrs attrs(node_def);
+  const int num_split = attrs.get<int64>("num_split");
+
+  return ConvertSplitHelper(params, inputs.at(1), tf_axis, num_split, false);
+}
+
+Status ConvertUnpack(OpConverterParams* params) {
+  const auto& inputs = params->inputs;
+  const auto& node_def = params->node_def;
+  TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"value", false}}));
+  TF_RETURN_IF_ERROR(AllowDataTypes(
+      *params, {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}));
+  // Input must be rank 1 or higher, since we can't unpack on axis 0.
+  if (inputs.at(0).GetTrtDims().nbDims == 0) {
+    return errors::Unimplemented(
+        "Input \"value\" for Unpack must be rank 2 or greater, at ",
+        node_def.name());
+  }
+  TFAttrs attrs(node_def);
+  const int tf_axis = attrs.get<int64>("axis");
+  const int num = attrs.get<int64>("num");
+
+  return ConvertSplitHelper(params, inputs.at(0), tf_axis, num, true);
+}
+
 Status ConvertConcat(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
@@ -4128,6 +4227,7 @@ Status ConvertCombinedNMS(OpConverterParams* params) {
 
 static void RegisterValidatableOpConverters(
     std::unordered_map<string, OpConverter>* registration) {
+  (*registration)["BatchMatMul"] = ConvertBatchMatMul;
   (*registration)["BiasAdd"] = ConvertBiasAdd;
 #if IS_TRT_VERSION_GE(5, 1, 0, 0)
   (*registration)["CombinedNonMaxSuppression"] = ConvertCombinedNMS;
@@ -4139,6 +4239,7 @@ static void RegisterValidatableOpConverters(
   (*registration)["DepthwiseConv2dNative"] = ConvertConv2DDepthwise;
   (*registration)["ExpandDims"] = ConvertExpandDims;
   (*registration)["GatherV2"] = ConvertGather;
+  (*registration)["Identity"] = ConvertIdentity;  // Identity should be removed
   (*registration)["LeakyRelu"] = ConvertLeakyRelu;
   (*registration)["MatMul"] = ConvertMatMul;
   (*registration)["Pad"] = ConvertPad;
@@ -4146,23 +4247,15 @@ static void RegisterValidatableOpConverters(
   (*registration)["Reshape"] = ConvertReshape;
   (*registration)["Rsqrt"] = ConvertRsqrt;
   (*registration)["Slice"] = ConvertSlice;
+  (*registration)["Snapshot"] = ConvertIdentity;  // Snapshot should be removed
+  (*registration)["Softmax"] = ConvertSoftmax;
+  (*registration)["Split"] = ConvertSplit;
   (*registration)["Square"] = ConvertSquare;
   (*registration)["Squeeze"] = ConvertSqueeze;
   (*registration)["StridedSlice"] = ConvertStridedSlice;
-  (*registration)["Transpose"] = ConvertTranspose;
   (*registration)["TopKV2"] = ConvertTopK;
-
-  // TODO(ben,jie): this is a temp hack.
-  (*registration)["Identity"] = ConvertIdentity;  // Identity should be removed
-  (*registration)["Snapshot"] = ConvertIdentity;  // Snapshot should be removed
-
-  (*registration)["Sum"] = ConvertReduce;
-  (*registration)["Prod"] = ConvertReduce;
-  (*registration)["Max"] = ConvertReduce;
-  (*registration)["Min"] = ConvertReduce;
-  (*registration)["Mean"] = ConvertReduce;
-  (*registration)["Softmax"] = ConvertSoftmax;
-  (*registration)["BatchMatMul"] = ConvertBatchMatMul;
+  (*registration)["Transpose"] = ConvertTranspose;
+  (*registration)["Unpack"] = ConvertUnpack;
 
   for (auto quantization_op_type :
        {"QuantizeAndDequantizeV2", "QuantizeAndDequantizeV3",
@@ -4184,6 +4277,9 @@ static void RegisterValidatableOpConverters(
   }
   for (auto unary_op_pair : *UnaryOperationMap()) {
     (*registration)[unary_op_pair.first] = ConvertUnary;
+  }
+  for (auto reduce_op_type : {"Sum", "Prod", "Max", "Min", "Mean"}) {
+    (*registration)[reduce_op_type] = ConvertReduce;
   }
 }
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -4073,7 +4073,7 @@ void TestConvertConcat(OpConverterTest* test) {
   };
 
   // Ok.
-  auto make_vector = [](int size, CType start_value = 0) {
+  auto make_vector = [](int size, int start_value = 0) {
     std::vector<CType> v(size);
     for (int i = 0; i < size; ++i) {
       v[i] = CType(start_value) + CType(i);
@@ -4129,7 +4129,8 @@ void TestConvertConcat(OpConverterTest* test) {
     NodeDef node_def = get_concat_nodedef(dtype, num_inputs);
     // Create inputs.
     for (int j = 0; j < num_inputs; ++j) {
-      test->AddTestTensor(StrCat("values_", j), ok_params[i].input_shapes[j]);
+      test->AddTestTensor(StrCat("values_", j), ok_params[i].input_shapes[j], 1,
+                          TfDataTypeToTrt(dtype));
     }
     test->AddTestWeights<int32>("axis", {1}, {ok_params[i].axis});
     test->RunValidationAndConversion(node_def);
@@ -4149,7 +4150,9 @@ void TestConvertConcat(OpConverterTest* test) {
     DataVec output_data{
         {"my_concat",
          ConstructTensor<CType>(ok_params[i].expected_output.size())}};
-    test->BuildAndRun(input_data, &output_data);
+    test->BuildAndRun(input_data, &output_data, dtype == DT_HALF
+                                                    ? TrtPrecisionMode::FP16
+                                                    : TrtPrecisionMode::FP32);
     EXPECT_THAT(GetSpanForData<CType>(output_data[0]),
                 ElementsAreArray(ok_params[i].expected_output));
   }
@@ -4224,11 +4227,354 @@ TEST_F(OpConverterTest, ConvertConcat) {
   }
 
   TestConvertConcat<DT_FLOAT>(this);
-  // TODO(tmorris): We appear to not be handling FP16 inputs correctly. Enable
-  // once this is fixed.
-  // TestConvertConcat<DT_HALF>(this);
+  TestConvertConcat<DT_HALF>(this);
   // TODO(tmorris): Enable once TRT adds support.
   // TestConvertConcat<DT_INT32>(this);
+}
+
+// Get the NodeDef for Split.
+auto get_split_nodedef = [](DataType dtype, int num_split) -> NodeDef {
+  Scope s = Scope::NewRootScope();
+  auto axis = ops::Placeholder(s.WithOpName("axis"), DT_INT32);
+  auto value = ops::Placeholder(s.WithOpName("value"), dtype);
+  auto split = ops::Split(s.WithOpName("my_split"), axis, value, num_split);
+  return split.operation.node()->def();
+};
+
+template <DataType dtype>
+void TestConvertSplit(OpConverterTest* test) {
+  typedef typename EnumToDataType<dtype>::Type CType;
+
+  struct TestParams {
+    std::vector<int> input_shape;
+    std::vector<CType> value;
+    int axis;
+    int num_split;
+    std::vector<int> expected_output_dims;
+    std::vector<std::vector<CType>> expected_outputs;
+  };
+
+  // Ok.
+  auto make_vector = [](int size, int start_value = 0) {
+    std::vector<CType> v(size);
+    for (int i = 0; i < size; ++i) {
+      v[i] = CType(start_value) + CType(i);
+    }
+    return v;
+  };
+  const std::vector<CType> common_input = make_vector(6);
+  const int kSplitOKCases = 4;
+  TestParams ok_params[kSplitOKCases] = {
+      // Identity (num_split = 1)
+      {/*input_shape=*/{1, 2, 3}, /*value=*/common_input, /*axis=*/1,
+       /*num_split=*/1, /*expected_output_dims=*/{1, 2, 3},
+       /*expected_outputs=*/{make_vector(6)}},
+      {/*input_shape=*/{1, 2, 3}, /*value=*/common_input, /*axis=*/3,
+       /*num_split=*/3, /*expected_output_dims=*/{1, 2, 1},
+       /*expected_outputs=*/{{CType(0), CType(3)},
+                             {CType(1), CType(4)},
+                             {CType(2), CType(5)}}},
+      {/*input_shape=*/{1, 6}, /*value=*/common_input, /*axis=*/2,
+       /*num_split=*/6, /*expected_output_dims=*/{1, 1},
+       /*expected_outputs=*/{{CType(0)},
+                             {CType(1)},
+                             {CType(2)},
+                             {CType(3)},
+                             {CType(4)},
+                             {CType(5)}}},
+      {/*input_shape=*/{1, 6}, /*value=*/common_input, /*axis=*/-1,
+       /*num_split=*/2, /*expected_output_dims=*/{1, 3},
+       /*expected_outputs=*/{make_vector(3), make_vector(3, 3)}},
+  };
+
+  for (int i = 0; i < kSplitOKCases; ++i) {
+    test->Reset();
+    NodeDef node_def = get_split_nodedef(dtype, ok_params[i].num_split);
+    // Create inputs.
+    test->AddTestWeights<int32>("axis", {1}, {ok_params[i].axis});
+    test->AddTestTensor("value", ok_params[i].input_shape, 1,
+                        TfDataTypeToTrt(dtype));
+    // Convert.
+    test->RunValidationAndConversion(node_def);
+
+    // Get output tensors and verify output dims.
+    EXPECT_EQ(ok_params[i].expected_outputs.size(), ok_params[i].num_split);
+    std::vector<TRT_TensorOrWeights> outputs(ok_params[i].num_split);
+    DataVec output_data;
+    for (int j = 0; j < outputs.size(); ++j) {
+      const string name = j == 0 ? StrCat("my_split") : StrCat("my_split:", j);
+      TF_EXPECT_OK(test->GetTensorOrWeights(name, &outputs[j]));
+      EXPECT_TRUE(outputs[j].is_tensor());
+      ExpectTrtDimsEqualsArray(ok_params[i].expected_output_dims,
+                               outputs[j].tensor()->getDimensions());
+      // Create buffer to store output.
+      output_data.push_back(
+          {name,
+           ConstructTensor<CType>(ok_params[i].expected_outputs[j].size())});
+    }
+
+    // Verify output values are correct.
+    const DataVec input_data{
+        {"value", test::AsTensor<CType>(ok_params[i].value)}};
+    test->BuildAndRun(input_data, &output_data, dtype == DT_HALF
+                                                    ? TrtPrecisionMode::FP16
+                                                    : TrtPrecisionMode::FP32);
+    for (int j = 0; j < outputs.size(); ++j) {
+      EXPECT_THAT(GetSpanForData<CType>(output_data[j]),
+                  ElementsAreArray(ok_params[i].expected_outputs[j]));
+    }
+  }
+}
+
+TEST_F(OpConverterTest, ConvertSplit) {
+  {
+    // Input list is empty, should fail.
+    NodeDef node_def = MakeNodeDef("my_split", "Split", {});
+    RunValidationAndConversion(
+        node_def, error::INVALID_ARGUMENT,
+        "Split got 0 inputs but expected 2, at my_split");
+  }
+  {
+    // Axis is a tensor, should fail.
+    Reset();
+    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    AddTestTensor("axis", {1});
+    AddTestTensor("value", {1, 2, 3});
+    RunValidationAndConversion(
+        node_def, error::UNIMPLEMENTED,
+        "The input \"axis\" for Split must be a constant, at my_split");
+  }
+  {
+    // Axis is out of bounds, should fail.
+    Reset();
+    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    AddTestWeights<int32>("axis", {1}, {4});
+    AddTestTensor("value", {1, 2, 3});
+    RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
+                               "Axis value of 4 is out of bounds, must be in "
+                               "range [-4, 4), at my_split");
+  }
+  {
+    // Axis is out of bounds (negative), should fail.
+    Reset();
+    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    AddTestWeights<int32>("axis", {1}, {-5});
+    AddTestTensor("value", {1, 2, 3});
+    RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
+                               "Axis value of -5 is out of bounds, must be in "
+                               "range [-4, 4), at my_split");
+  }
+  {
+    // Axis is batch dimension, should fail.
+    Reset();
+    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    AddTestWeights<int32>("axis", {1}, {0});
+    AddTestTensor("value", {1, 2, 3});
+    RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
+                               "TensorRT does not allow manipulation of the "
+                               "batch dimension, at my_split");
+  }
+  {
+    // Value is a weight, should fail.
+    Reset();
+    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    AddTestWeights<int32>("axis", {1}, {1});
+    AddTestWeights<float>("value", {1, 2, 3}, {1, 2, 3, 4, 5, 6});
+    RunValidationAndConversion(
+        node_def, error::UNIMPLEMENTED,
+        "The input \"value\" for Split must be a tensor, at my_split");
+  }
+  {
+    // Dim is not evenly divisibly by num_split, should fail.
+    Reset();
+    NodeDef node_def = get_split_nodedef(DT_FLOAT, 2);
+    AddTestWeights<int32>("axis", {1}, {3});
+    AddTestTensor("value", {1, 2, 3});
+    RunValidationAndConversion(
+        node_def, error::INVALID_ARGUMENT,
+        "Dimension 3 of size 3 is not evenly divisble by 2, at my_split");
+  }
+  {
+    // num_split > dim size, should fail.
+    Reset();
+    NodeDef node_def = get_split_nodedef(DT_FLOAT, 4);
+    AddTestWeights<int32>("axis", {1}, {3});
+    AddTestTensor("value", {1, 2, 3});
+    RunValidationAndConversion(
+        node_def, error::INVALID_ARGUMENT,
+        "Dimension 3 of size 3 is not evenly divisble by 4, at my_split");
+  }
+
+  TestConvertSplit<DT_FLOAT>(this);
+  TestConvertSplit<DT_HALF>(this);
+  TestConvertSplit<DT_INT32>(this);
+}
+
+// Get the NodeDef for Unpack (Unstack in TF API).
+auto get_unpack_nodedef = [](DataType dtype, int num, int axis) -> NodeDef {
+  Scope s = Scope::NewRootScope();
+  auto value = ops::Placeholder(s.WithOpName("value"), dtype);
+  auto unstack_attrs = ops::Unstack::Axis(axis);
+  auto unstack =
+      ops::Unstack(s.WithOpName("my_unpack"), value, num, unstack_attrs);
+  return unstack.operation.node()->def();
+};
+
+template <DataType dtype>
+void TestConvertUnpack(OpConverterTest* test) {
+  typedef typename EnumToDataType<dtype>::Type CType;
+
+  struct TestParams {
+    std::vector<int> input_shape;
+    std::vector<CType> value;
+    int axis;
+    int num;
+    std::vector<int> expected_output_dims;
+    std::vector<std::vector<CType>> expected_outputs;
+  };
+
+  // Ok.
+  auto make_vector = [](int size, int start_value = 0) {
+    std::vector<CType> v(size);
+    for (int i = 0; i < size; ++i) {
+      v[i] = CType(start_value) + CType(i);
+    }
+    return v;
+  };
+  const std::vector<CType> common_input = make_vector(6);
+  const int kUnpackOKCases = 4;
+  TestParams ok_params[kUnpackOKCases] = {
+      {/*input_shape=*/{1, 2, 3}, /*value=*/common_input, /*axis=*/1,
+       /*num=*/1, /*expected_output_dims=*/{2, 3},
+       /*expected_outputs=*/{make_vector(6)}},
+      {/*input_shape=*/{1, 2, 3}, /*value=*/common_input, /*axis=*/3,
+       /*num=*/3, /*expected_output_dims=*/{1, 2},
+       /*expected_outputs=*/{{CType(0), CType(3)},
+                             {CType(1), CType(4)},
+                             {CType(2), CType(5)}}},
+      {/*input_shape=*/{6, 1}, /*value=*/common_input, /*axis=*/-2,
+       /*num=*/6, /*expected_output_dims=*/{1},
+       /*expected_outputs=*/{{CType(0)},
+                             {CType(1)},
+                             {CType(2)},
+                             {CType(3)},
+                             {CType(4)},
+                             {CType(5)}}},
+      {/*input_shape=*/{6}, /*value=*/common_input, /*axis=*/1,
+       /*num=*/6, /*expected_output_dims=*/{},
+       /*expected_outputs=*/{{CType(0)},
+                             {CType(1)},
+                             {CType(2)},
+                             {CType(3)},
+                             {CType(4)},
+                             {CType(5)}}},
+  };
+
+  for (int i = 0; i < kUnpackOKCases; ++i) {
+    test->Reset();
+    NodeDef node_def =
+        get_unpack_nodedef(dtype, ok_params[i].num, ok_params[i].axis);
+    // Create inputs.
+    test->AddTestTensor("value", ok_params[i].input_shape, 1,
+                        TfDataTypeToTrt(dtype));
+    // Convert.
+    test->RunValidationAndConversion(node_def);
+
+    // Get output tensors and verify output dims.
+    EXPECT_EQ(ok_params[i].expected_outputs.size(), ok_params[i].num);
+    std::vector<TRT_TensorOrWeights> outputs(ok_params[i].num);
+    DataVec output_data;
+    for (int j = 0; j < outputs.size(); ++j) {
+      const string name = j == 0 ? "my_unpack" : StrCat("my_unpack:", j);
+      TF_EXPECT_OK(test->GetTensorOrWeights(name, &outputs[j]));
+      EXPECT_TRUE(outputs[j].is_tensor());
+      ExpectTrtDimsEqualsArray(ok_params[i].expected_output_dims,
+                               outputs[j].tensor()->getDimensions());
+      // Create buffer to store output.
+      output_data.push_back(
+          {name,
+           ConstructTensor<CType>(ok_params[i].expected_outputs[j].size())});
+    }
+
+    // Verify output values are correct.
+    const DataVec input_data{
+        {"value", test::AsTensor<CType>(ok_params[i].value)}};
+    test->BuildAndRun(input_data, &output_data, dtype == DT_HALF
+                                                    ? TrtPrecisionMode::FP16
+                                                    : TrtPrecisionMode::FP32);
+    for (int j = 0; j < outputs.size(); ++j) {
+      EXPECT_THAT(GetSpanForData<CType>(output_data[j]),
+                  ElementsAreArray(ok_params[i].expected_outputs[j]));
+    }
+  }
+}
+
+TEST_F(OpConverterTest, ConvertUnpack) {
+  {
+    // Input list is empty, should fail.
+    NodeDef node_def = MakeNodeDef("my_unpack", "Unpack", {});
+    RunValidationAndConversion(
+        node_def, error::INVALID_ARGUMENT,
+        "Unpack got 0 inputs but expected 1, at my_unpack");
+  }
+  {
+    // Value is weights, should fail.
+    Reset();
+    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/3, /*axis=*/3);
+    AddTestWeights<float>("value", {1, 2, 3}, {1, 2, 3, 4, 5, 6});
+    RunValidationAndConversion(
+        node_def, error::UNIMPLEMENTED,
+        "The input \"value\" for Unpack must be a tensor, at my_unpack");
+  }
+  {
+    // Axis is out of bounds, should fail.
+    Reset();
+    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/1, /*axis=*/4);
+    AddTestTensor("value", {1, 2, 3});
+    RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
+                               "Axis value of 4 is out of bounds, must be in "
+                               "range [-4, 4), at my_unpack");
+  }
+  {
+    // Axis is out of bounds (negative), should fail.
+    Reset();
+    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/1, /*axis=*/-5);
+    AddTestTensor("value", {1, 2, 3});
+    RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
+                               "Axis value of -5 is out of bounds, must be in "
+                               "range [-4, 4), at my_unpack");
+  }
+  {
+    // Axis is batch dimension, should fail.
+    Reset();
+    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/1, /*axis=*/0);
+    AddTestTensor("value", {1, 2, 3});
+    RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
+                               "TensorRT does not allow manipulation of the "
+                               "batch dimension, at my_unpack");
+  }
+  {
+    // Dim size does not match num, should fail.
+    Reset();
+    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/5, /*axis=*/2);
+    AddTestTensor("value", {1, 6});
+    RunValidationAndConversion(
+        node_def, error::INVALID_ARGUMENT,
+        "Dimension 2 has size 6 which is not equal to num of 5, at my_unpack");
+  }
+  {
+    // Output would be TF scalar, should fail.
+    Reset();
+    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/1, /*axis=*/0);
+    AddTestTensor("value", {});
+    RunValidationAndConversion(
+        node_def, error::UNIMPLEMENTED,
+        "Input \"value\" for Unpack must be rank 2 or greater, at my_unpack");
+  }
+
+  TestConvertUnpack<DT_FLOAT>(this);
+  TestConvertUnpack<DT_HALF>(this);
+  TestConvertUnpack<DT_INT32>(this);
 }
 
 }  // namespace convert


### PR DESCRIPTION
* Add converter for Split using Slice.
* Add converter for Unpack using Slice + Reshape
* Add unit tests for Split and Unpack.
* Fix Concat unit tests for FP16.
* Sort validators alphabetically in RegisterValidatableOpConverters, also separate Reduce ops.