### PR TITLE
Add deprecation notice to tf.contrib.libsvm

### DIFF
--- a/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
+++ b/tensorflow/contrib/libsvm/python/ops/libsvm_ops.py
@@ -22,12 +22,17 @@ from tensorflow.contrib.util import loader
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.platform import resource_loader
+from tensorflow.python.util.deprecation import deprecated
 
 
 _libsvm_ops_so = loader.load_op_library(
     resource_loader.get_path_to_datafile("_libsvm_ops.so"))
 
-
+@deprecated(
+    None,
+    'tf.contrib.libsvm will be removed in 2.0, the support for libsvm '
+    'format will continue to be provided in tensorflow-io: '
+    'https://github.com/tensorflow/io')
 def decode_libsvm(content, num_features, dtype=None, label_dtype=None):
   """Convert Libsvm records to a tensor of label and a tensor of feature.
 


### PR DESCRIPTION
Since tf.contrib has been deprecated and will be removed
in TF 2.0, it makes sense to add deprecation notice
so that users could be pointed to tensorflow-io

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>