### PR TITLE
Fix lint issue in Ubuntu Sanity

### DIFF
--- a/tensorflow/contrib/input_pipeline/BUILD
+++ b/tensorflow/contrib/input_pipeline/BUILD
@@ -9,11 +9,10 @@ exports_files(["LICENSE"])
 package(default_visibility = ["//visibility:public"])
 
 load("//tensorflow:tensorflow.bzl", "py_test")
-
 load(
     "//tensorflow:tensorflow.bzl",
-    "tf_custom_op_library",
     "tf_cc_tests",
+    "tf_custom_op_library",
     "tf_gen_op_libs",
     "tf_gen_op_wrapper_py",
     "tf_kernel_library",

--- a/tensorflow/contrib/input_pipeline/BUILD
+++ b/tensorflow/contrib/input_pipeline/BUILD
@@ -8,9 +8,10 @@ exports_files(["LICENSE"])
 
 package(default_visibility = ["//visibility:public"])
 
+load("//tensorflow:tensorflow.bzl", "py_test")
+
 load(
     "//tensorflow:tensorflow.bzl",
-    "py_test",
     "tf_custom_op_library",
     "tf_cc_tests",
     "tf_gen_op_libs",

--- a/tensorflow/contrib/periodic_resample/BUILD
+++ b/tensorflow/contrib/periodic_resample/BUILD
@@ -4,6 +4,8 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+load("//tensorflow:tensorflow.bzl", "py_test")
+
 load(
     "//tensorflow:tensorflow.bzl",
     "tf_cc_test",
@@ -11,7 +13,6 @@ load(
     "tf_custom_op_library",
     "tf_gen_op_wrapper_py",
 )
-load("//tensorflow:tensorflow.bzl", "py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 
 cc_library(

--- a/tensorflow/contrib/periodic_resample/BUILD
+++ b/tensorflow/contrib/periodic_resample/BUILD
@@ -5,12 +5,11 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "py_test")
-
 load(
     "//tensorflow:tensorflow.bzl",
     "tf_cc_test",
-    "tf_gen_op_libs",
     "tf_custom_op_library",
+    "tf_gen_op_libs",
     "tf_gen_op_wrapper_py",
 )
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")


### PR DESCRIPTION
It seems that a lot of build tests (e.g., #27210, #27179, among others) failed with Ubuntu Sanity,  due to the following error:
```
Traceback (most recent call last):
  File "check_load_py_test.py", line 91, in <module>
    main()
  File "check_load_py_test.py", line 85, in main
    '\n'.join(files_missing_load)))
RuntimeError: The following files are missing load("//tensorflow:tensorflow.bzl", "py_test").
This load statement is needed because otherwise pip tests will try to use their dependencies, which are not visible to them.:
 tensorflow/contrib/input_pipeline/BUILD
tensorflow/contrib/periodic_resample/BUILD
```

This fix is an attempt to fix the issue

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>