### PR TITLE
Fixed small markdown typos

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -286,7 +286,7 @@ class BinaryCrossentropy(Loss):
   ```python
   model = keras.models.Model(inputs, outputs)
   model.compile('sgd', loss=tf.keras.losses.BinaryCrossentropy())
-  ````
+  ```
 
   Args:
     from_logits: Whether `output` is expected to be a logits tensor. By default,
@@ -344,7 +344,7 @@ class CategoricalCrossentropy(Loss):
   ```python
   model = keras.models.Model(inputs, outputs)
   model.compile('sgd', loss=tf.keras.losses.CategoricalCrossentropy())
-  ````
+  ```
 
   Args:
     from_logits: Whether `output` is expected to be a logits tensor. By default,


### PR DESCRIPTION
Small typos were causing incorrect formatting here:
https://www.tensorflow.org/api_docs/python/tf/keras/losses/CategoricalCrossentropy
https://www.tensorflow.org/api_docs/python/tf/keras/losses/BinaryCrossentropy