### PR TITLE
Fix compilation warning

### DIFF
--- a/tensorflow/lite/delegates/gpu/gl_delegate.h
+++ b/tensorflow/lite/delegates/gpu/gl_delegate.h
@@ -39,7 +39,7 @@ limitations under the License.
 extern "C" {
 #endif  // __cplusplus
 
-enum TFL_CAPI_EXPORT TfLiteGlObjectType {
+enum TfLiteGlObjectType {
   TFLITE_GL_OBJECT_TYPE_FASTEST = 0,
   TFLITE_GL_OBJECT_TYPE_TEXTURE = 1,
   TFLITE_GL_OBJECT_TYPE_BUFFER = 2,


### PR DESCRIPTION
```
c:/users/mattn/go/src/github.com/tensorflow/tensorflow/tensorflow/lite/delegates/gpu/gl_delegate.h:42:22:
warning: 'dllimport' attribute ignored [-Wattributes]
 enum TFL_CAPI_EXPORT TfLiteGlObjectType {
                      ^~~~~~~~~~~~~~~~~~
```
enum is not an exportable type for DLL.