### PR TITLE
Fix crash of GFile in python 3.7

### DIFF
--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -246,6 +246,10 @@ class FileIO(object):
         pywrap_tensorflow.Set_TF_Status_from_Status(status, ret_status)
     self._writable_file = None
 
+  def seekable(self):
+    """Returns True as FileIO supports random access ops of seek()/tell()"""
+    return True
+
 
 @tf_export(v1=["gfile.Exists"])
 def file_exists(filename):

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -246,6 +246,7 @@ class FileIO(object):
         pywrap_tensorflow.Set_TF_Status_from_Status(status, ret_status)
     self._writable_file = None
 
+  @property
   def seekable(self):
     """Returns True as FileIO supports random access ops of seek()/tell()"""
     return True

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.-fast-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.-fast-g-file.pbtxt
@@ -44,6 +44,10 @@ tf_class {
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
   }
   member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "size"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.-fast-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.-fast-g-file.pbtxt
@@ -11,6 +11,10 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
+  member {
+    name: "seekable"
+    mtype: "<type \'property\'>"
+  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -42,10 +46,6 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
-  }
-  member_method {
-    name: "seekable"
-    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.-g-file.pbtxt
@@ -44,6 +44,10 @@ tf_class {
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
   }
   member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "size"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.-g-file.pbtxt
@@ -11,6 +11,10 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
+  member {
+    name: "seekable"
+    mtype: "<type \'property\'>"
+  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -42,10 +46,6 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
-  }
-  member_method {
-    name: "seekable"
-    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.-open.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.-open.pbtxt
@@ -44,6 +44,10 @@ tf_class {
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
   }
   member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "size"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.-open.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.-open.pbtxt
@@ -11,6 +11,10 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
+  member {
+    name: "seekable"
+    mtype: "<type \'property\'>"
+  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -42,10 +46,6 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
-  }
-  member_method {
-    name: "seekable"
-    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"

--- a/tensorflow/tools/api/golden/v1/tensorflow.io.gfile.-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.io.gfile.-g-file.pbtxt
@@ -44,6 +44,10 @@ tf_class {
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
   }
   member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "size"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.io.gfile.-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.io.gfile.-g-file.pbtxt
@@ -11,6 +11,10 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
+  member {
+    name: "seekable"
+    mtype: "<type \'property\'>"
+  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -42,10 +46,6 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
-  }
-  member_method {
-    name: "seekable"
-    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"

--- a/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.-g-file.pbtxt
@@ -44,6 +44,10 @@ tf_class {
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
   }
   member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "size"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.-g-file.pbtxt
@@ -11,6 +11,10 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
+  member {
+    name: "seekable"
+    mtype: "<type \'property\'>"
+  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -42,10 +46,6 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
-  }
-  member_method {
-    name: "seekable"
-    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"


### PR DESCRIPTION
This fix tries to address the issue raised in #27276 where in Python 3.7, opening a zip file (of GFile) will results in the error of
```
    bytes = self.zip.open(key)
  File "/usr/lib64/python3.7/zipfile.py", line 1480, in open
    self._fpclose, self._lock, lambda: self._writing)
  File "/usr/lib64/python3.7/zipfile.py", line 722, in __init__
    self.seekable = file.seekable
AttributeError: 'GFile' object has no attribute 'seekable'
```

The issue is that Python 3.7 adds seekable check:
https://github.com/python/cpython/commit/066df4fd454d6ff9be66e80b2a65995b10af174f

This fix adds `seekable()` and returns True, as GFile is indeed seekable.

This fix fixes #27276

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>