### PR TITLE
[Features] Support gradients reduction in tf.gradients according to immediate_grads_reduction in CollectiveAllReduceStrategy and MirroredStrategy

### DIFF
--- a/tensorflow/contrib/distribute/python/examples/simple_estimator_example.py
+++ b/tensorflow/contrib/distribute/python/examples/simple_estimator_example.py
@@ -62,8 +62,9 @@ def build_model_fn_optimizer():
 
 
 def main(_):
+  cross_replica_ops = tf.distribute.NcclAllReduce()
   distribution = tf.contrib.distribute.MirroredStrategy(
-      ["/device:GPU:0", "/device:GPU:1"])
+      ["/device:GPU:0", "/device:GPU:1"], cross_device_ops=cross_replica_ops , immediate_grads_reduction=True)
   config = tf.estimator.RunConfig(train_distribute=distribution,
                                   eval_distribute=distribution)
   # Since there are 2 devices and 10 samples, we set steps=5.

--- a/tensorflow/python/distribute/distribute_lib.py
+++ b/tensorflow/python/distribute/distribute_lib.py
@@ -1207,6 +1207,21 @@ class DistributionStrategyExtended(object):
         for t, v in value_destination_pairs
     ]
 
+  def regroup(self, value, destinations):
+    return self._regroup(value, destinations)
+
+  def _regroup(self, value, destinations):
+    raise NotImplementedError("must be implemented in descendants")
+
+  def batch_regroup(self, value_destination_pairs):
+    return self._batch_regroup(value_destination_pairs)
+
+  def _batch_regroup(self, value_destination_pairs):
+    return [
+        self.regroup(t, destinations=v)
+        for t, v in value_destination_pairs
+    ]
+
   def update(self, var, fn, args=(), kwargs=None, group=True):
     """Run `fn` to update `var` using inputs mirrored to the same devices.
 
@@ -1629,6 +1644,10 @@ class _DefaultDistributionExtended(DistributionStrategyExtended):
   def _reduce_to(self, reduce_op, value, destinations):
     # TODO(josh11b): Use destinations?
     del reduce_op, destinations
+    return value
+
+  def _regroup(self, value, destinations):
+    del destinations
     return value
 
   def _update(self, var, fn, args, kwargs, group):

--- a/tensorflow/python/distribute/distribute_lib.py
+++ b/tensorflow/python/distribute/distribute_lib.py
@@ -909,6 +909,10 @@ class DistributionStrategyExtended(object):
   def _allow_variable_partition(self):
     return False
 
+  @property
+  def immediate_gradients_reduction(self):
+    return False
+
   def _create_variable(self, next_creator, *args, **kwargs):
     # Note: should support "colocate_with" argument.
     raise NotImplementedError("must be implemented in descendants")
@@ -1208,12 +1212,35 @@ class DistributionStrategyExtended(object):
     ]
 
   def regroup(self, value, destinations):
+    """Regroup PerReplicas into Mirrored bypassing `reduce_op`
+
+    Args:
+      value: A per-replica value with one value per replica.
+      destinations: A mirrored variable, a per-replica tensor, or a device
+        string. The return value will be copied to all destination devices (or
+        all the devices where the `destinations` value resides). To perform an
+        all-reduction, pass `value` to `destinations`.
+
+    Returns:
+      A list of mirrored values, one per pair in `value_destination_pairs`.
+
+    """
     return self._regroup(value, destinations)
 
   def _regroup(self, value, destinations):
     raise NotImplementedError("must be implemented in descendants")
 
   def batch_regroup(self, value_destination_pairs):
+    """Regroup PerReplicas into a batch of Mirroreds bypassing `reduce_op`
+
+    Args:
+      value_destination_pairs: A sequence of (value, destinations)
+        pairs. See `reduce_to()` for a description.
+
+    Returns:
+      A list of mirrored values, one per pair in `value_destination_pairs`.
+
+    """
     return self._batch_regroup(value_destination_pairs)
 
   def _batch_regroup(self, value_destination_pairs):

--- a/tensorflow/python/distribute/mirrored_strategy.py
+++ b/tensorflow/python/distribute/mirrored_strategy.py
@@ -712,6 +712,10 @@ class MirroredExtended(distribute_lib.DistributionStrategyExtended):
     return self._get_cross_device_ops().batch_reduce(
         reduce_op, value_destination_pairs)
 
+  def _regroup(self, value, destinations):
+    return self._get_cross_device_ops().regroup(
+        value, destinations)
+
   def _update(self, var, fn, args, kwargs, group):
     # TODO(josh11b): In eager mode, use one thread per device.
     assert isinstance(var, values.DistributedVariable)

--- a/tensorflow/python/distribute/parameter_server_strategy.py
+++ b/tensorflow/python/distribute/parameter_server_strategy.py
@@ -104,7 +104,8 @@ class ParameterServerStrategyExtended(
 
     # We typically don't need to do all-reduce in this strategy.
     self._cross_device_ops = (
-        cross_device_ops_lib.ReductionToOneDevice(reduce_to_device=_LOCAL_CPU))
+        cross_device_ops_lib.ReductionToOneDevice(
+            reduce_to_device=_LOCAL_CPU, need_broadcast=False))
 
   def _initialize_strategy(self, cluster_resolver):
     if cluster_resolver.cluster_spec().as_dict():
@@ -391,6 +392,13 @@ class ParameterServerStrategyExtended(
       self._verify_destinations_not_different_worker(destinations)
     return self._cross_device_ops.batch_reduce(reduce_op,
                                                value_destination_pairs)
+
+  def _regroup(self, value, destinations):
+    del destinations
+    if isinstance(value, values.PerDevice):
+      return list(value._index.values())[0]
+    else:
+      return value
 
   def _select_single_value(self, structured):
     """Select any single values in `structured`."""

--- a/tensorflow/python/training/optimizer.py
+++ b/tensorflow/python/training/optimizer.py
@@ -641,8 +641,7 @@ class Optimizer(
       replicas. If `global_step` was not None, that operation also
       increments `global_step`
     """
-    reduced_grads = distribution.extended.batch_reduce_to(
-        ds_reduce_util.ReduceOp.SUM, grads_and_vars)
+    reduced_grads = distribution.extended.batch_regroup(grads_and_vars)
     var_list = [v for _, v in grads_and_vars]
     grads_and_vars = zip(reduced_grads, var_list)
 

--- a/tensorflow/python/training/optimizer.py
+++ b/tensorflow/python/training/optimizer.py
@@ -641,7 +641,11 @@ class Optimizer(
       replicas. If `global_step` was not None, that operation also
       increments `global_step`
     """
-    reduced_grads = distribution.extended.batch_regroup(grads_and_vars)
+    if distribution.extended.immediate_gradients_reduction:
+      reduced_grads = distribution.extended.batch_regroup(grads_and_vars)
+    else:
+      reduced_grads = distribution.extended.batch_reduce_to(
+          ds_reduce_util.ReduceOp.SUM, grads_and_vars)
     var_list = [v for _, v in grads_and_vars]
     grads_and_vars = zip(reduced_grads, var_list)
 

--- a/tensorflow/tools/api/golden/v1/tensorflow.distribute.-cross-device-ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.distribute.-cross-device-ops.pbtxt
@@ -15,6 +15,14 @@ tf_class {
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup_implementation"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "broadcast"
     argspec: "args=[\'self\', \'tensor\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
@@ -29,5 +37,13 @@ tf_class {
   member_method {
     name: "reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup_implementation"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
 }

--- a/tensorflow/tools/api/golden/v1/tensorflow.distribute.-hierarchical-copy-all-reduce.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.distribute.-hierarchical-copy-all-reduce.pbtxt
@@ -17,6 +17,14 @@ tf_class {
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup_implementation"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "broadcast"
     argspec: "args=[\'self\', \'tensor\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
@@ -31,5 +39,13 @@ tf_class {
   member_method {
     name: "reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup_implementation"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
 }

--- a/tensorflow/tools/api/golden/v1/tensorflow.distribute.-mirrored-strategy.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.distribute.-mirrored-strategy.pbtxt
@@ -13,7 +13,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'devices\', \'cross_device_ops\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
+    argspec: "args=[\'self\', \'devices\', \'cross_device_ops\', \'immediate_grads_reduction\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
   }
   member_method {
     name: "colocate_vars_with"

--- a/tensorflow/tools/api/golden/v1/tensorflow.distribute.-nccl-all-reduce.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.distribute.-nccl-all-reduce.pbtxt
@@ -17,6 +17,14 @@ tf_class {
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup_implementation"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "broadcast"
     argspec: "args=[\'self\', \'tensor\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
@@ -31,5 +39,13 @@ tf_class {
   member_method {
     name: "reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup_implementation"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
 }

--- a/tensorflow/tools/api/golden/v1/tensorflow.distribute.-reduction-to-one-device.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.distribute.-reduction-to-one-device.pbtxt
@@ -5,7 +5,7 @@ tf_class {
   is_instance: "<type \'object\'>"
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'reduce_to_device\', \'accumulation_fn\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
+    argspec: "args=[\'self\', \'reduce_to_device\', \'accumulation_fn\', \'need_broadcast\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'True\'], "
   }
   member_method {
     name: "batch_reduce"
@@ -14,6 +14,14 @@ tf_class {
   member_method {
     name: "batch_reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup_implementation"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "broadcast"
@@ -30,5 +38,13 @@ tf_class {
   member_method {
     name: "reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup_implementation"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
 }

--- a/tensorflow/tools/api/golden/v1/tensorflow.distribute.-strategy-extended.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.distribute.-strategy-extended.pbtxt
@@ -15,6 +15,10 @@ tf_class {
     mtype: "<type \'property\'>"
   }
   member {
+    name: "immediate_gradients_reduction"
+    mtype: "<type \'property\'>"
+  }
+  member {
     name: "parameter_devices"
     mtype: "<type \'property\'>"
   }
@@ -37,6 +41,10 @@ tf_class {
   member_method {
     name: "batch_reduce_to"
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "broadcast_to"
@@ -69,6 +77,10 @@ tf_class {
   member_method {
     name: "reduce_to"
     argspec: "args=[\'self\', \'reduce_op\', \'value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "update"

--- a/tensorflow/tools/api/golden/v1/tensorflow.distribute.experimental.-multi-worker-mirrored-strategy.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.distribute.experimental.-multi-worker-mirrored-strategy.pbtxt
@@ -13,7 +13,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'communication\'], varargs=None, keywords=None, defaults=[\'CollectiveCommunication.AUTO\'], "
+    argspec: "args=[\'self\', \'communication\', \'immediate_grads_reduction\'], varargs=None, keywords=None, defaults=[\'CollectiveCommunication.AUTO\', \'False\'], "
   }
   member_method {
     name: "colocate_vars_with"

--- a/tensorflow/tools/api/golden/v2/tensorflow.distribute.-cross-device-ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.distribute.-cross-device-ops.pbtxt
@@ -15,6 +15,14 @@ tf_class {
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup_implementation"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "broadcast"
     argspec: "args=[\'self\', \'tensor\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
@@ -29,5 +37,13 @@ tf_class {
   member_method {
     name: "reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup_implementation"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.distribute.-hierarchical-copy-all-reduce.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.distribute.-hierarchical-copy-all-reduce.pbtxt
@@ -17,6 +17,14 @@ tf_class {
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup_implementation"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "broadcast"
     argspec: "args=[\'self\', \'tensor\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
@@ -31,5 +39,13 @@ tf_class {
   member_method {
     name: "reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup_implementation"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.distribute.-mirrored-strategy.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.distribute.-mirrored-strategy.pbtxt
@@ -13,7 +13,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'devices\', \'cross_device_ops\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
+    argspec: "args=[\'self\', \'devices\', \'cross_device_ops\', \'immediate_grads_reduction\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
   }
   member_method {
     name: "colocate_vars_with"

--- a/tensorflow/tools/api/golden/v2/tensorflow.distribute.-nccl-all-reduce.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.distribute.-nccl-all-reduce.pbtxt
@@ -17,6 +17,14 @@ tf_class {
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup_implementation"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "broadcast"
     argspec: "args=[\'self\', \'tensor\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
@@ -31,5 +39,13 @@ tf_class {
   member_method {
     name: "reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup_implementation"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.distribute.-reduction-to-one-device.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.distribute.-reduction-to-one-device.pbtxt
@@ -5,7 +5,7 @@ tf_class {
   is_instance: "<type \'object\'>"
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'reduce_to_device\', \'accumulation_fn\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
+    argspec: "args=[\'self\', \'reduce_to_device\', \'accumulation_fn\', \'need_broadcast\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'True\'], "
   }
   member_method {
     name: "batch_reduce"
@@ -14,6 +14,14 @@ tf_class {
   member_method {
     name: "batch_reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup_implementation"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "broadcast"
@@ -30,5 +38,13 @@ tf_class {
   member_method {
     name: "reduce_implementation"
     argspec: "args=[\'self\', \'reduce_op\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup_implementation"
+    argspec: "args=[\'self\', \'per_replica_value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.distribute.-strategy-extended.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.distribute.-strategy-extended.pbtxt
@@ -15,6 +15,10 @@ tf_class {
     mtype: "<type \'property\'>"
   }
   member {
+    name: "immediate_gradients_reduction"
+    mtype: "<type \'property\'>"
+  }
+  member {
     name: "parameter_devices"
     mtype: "<type \'property\'>"
   }
@@ -37,6 +41,10 @@ tf_class {
   member_method {
     name: "batch_reduce_to"
     argspec: "args=[\'self\', \'reduce_op\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "batch_regroup"
+    argspec: "args=[\'self\', \'value_destination_pairs\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "broadcast_to"
@@ -69,6 +77,10 @@ tf_class {
   member_method {
     name: "reduce_to"
     argspec: "args=[\'self\', \'reduce_op\', \'value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "regroup"
+    argspec: "args=[\'self\', \'value\', \'destinations\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "update"

--- a/tensorflow/tools/api/golden/v2/tensorflow.distribute.experimental.-multi-worker-mirrored-strategy.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.distribute.experimental.-multi-worker-mirrored-strategy.pbtxt
@@ -13,7 +13,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'communication\'], varargs=None, keywords=None, defaults=[\'CollectiveCommunication.AUTO\'], "
+    argspec: "args=[\'self\', \'communication\', \'immediate_grads_reduction\'], varargs=None, keywords=None, defaults=[\'CollectiveCommunication.AUTO\', \'False\'], "
   }
   member_method {
     name: "colocate_vars_with"


### PR DESCRIPTION
Currently, gradients_reduction will be called in `apply_gradients` when using `DistributionStrategy`. It will block computation and communication overlapping with `clip_by_global_norm`. In this pull request, the `immediate_grads_reduction` has been add to `MirroredStrategy` and `CollectiveAllReduceStrategy`. When it is True, the gradients reduction will be called in `tf.gradients` so that the clipping operation will be executed after communication. Otherwise, it preserves the original cases. 

`immedeiate_grads_reduction` has been only enabled in graph mode. We will also add support in eager mode in the future.

This PR will change some API. Could you please take a look at this PR?  This performance feature has been widely used in Alibaba. Any comments are welcome.

@yuefengz 