### PR TITLE
Move LazyLoader warning to stderr

### DIFF
--- a/tensorflow/python/util/lazy_loader.py
+++ b/tensorflow/python/util/lazy_loader.py
@@ -20,6 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import importlib
+import sys
 import types
 
 
@@ -46,7 +47,7 @@ class LazyLoader(types.ModuleType):
 
     # Emit a warning if one was specified
     if self._warning:
-      print(self._warning)
+      print(self._warning, file=sys.stderr)
       # Make sure to only warn once.
       self._warning = None
 


### PR DESCRIPTION
Commit d32dee99 add a warning message to LazyLoader class. The extra lines written to stdout breaks some of my scripts. I think that the warning message should be moved to stderr.