### PR TITLE
Adding tensorflow as a default custom_object in keras.models.load_model

### DIFF
--- a/tensorflow/python/keras/saving/hdf5_format.py
+++ b/tensorflow/python/keras/saving/hdf5_format.py
@@ -23,6 +23,7 @@ import json
 import os
 
 import numpy as np
+import tensorflow
 from six.moves import zip  # pylint: disable=redefined-builtin
 
 from tensorflow.python.keras import backend as K
@@ -171,7 +172,7 @@ def load_model(filepath, custom_objects=None, compile=True):  # pylint: disable=
     raise ImportError('`load_model` requires h5py.')
 
   if not custom_objects:
-    custom_objects = {}
+    custom_objects = {'tf': tensorflow, 'tensorflow': tensorflow}
 
   def convert_custom_objects(obj):
     """Handles custom object lookup.


### PR DESCRIPTION
Adding tensorflow and tf as default custom objects. The commit makes it easier to include simple tensorflow operations as part of keras models (like `tf.reduce_sum` for example) and then reload the model without issues.
- Closes https://github.com/tensorflow/tensorflow/issues/27364