### PR TITLE
TFTRT: Add converter for ArgMin and ArgMax

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -4150,13 +4150,62 @@ Status ConvertSoftmax(OpConverterParams* params) {
   return Status::OK();
 }
 
+Status ConvertArgMinMax(OpConverterParams* params) {
+  const auto& inputs = params->inputs;
+  const auto& node_def = params->node_def;
+  TF_RETURN_IF_ERROR(
+      CheckInputsWeights(*params, {{"input", false}, {"dimension", true}}));
+  TF_RETURN_IF_ERROR(
+      AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
+  // INT64 outputs are not supported by TRT.
+  TFAttrs attrs(node_def);
+  DataType output_dtype = attrs.get<DataType>("output_type");
+  if (output_dtype != DataType::DT_INT32) {
+    return errors::Unimplemented("Output type ", DataTypeString(output_dtype),
+                                 " is not supported, at ", node_def.name());
+  }
+  int tf_axis = inputs.at(1).weights().GetSpan<int>()[0];
+  int trt_axis;
+  nvinfer1::Dims dims = inputs.at(0).GetTrtDims();
+  TF_RETURN_IF_ERROR(
+      ConvertAxis(tf_axis, dims.nbDims, node_def.name(), &trt_axis));
+  nvinfer1::TopKOperation topk_op;
+  if (node_def.op() == "ArgMin") {
+    topk_op = nvinfer1::TopKOperation::kMIN;
+  } else if (node_def.op() == "ArgMax") {
+    topk_op = nvinfer1::TopKOperation::kMAX;
+  } else {
+    return errors::InvalidArgument("Unsupported ArgMin/Max operation");
+  }
+  if (params->validation_only) return Status::OK();
+
+  // Use TopK with k = 1. Only indices output is needed (output 1).
+  const uint32_t reduce_axes = 1 << trt_axis;
+  nvinfer1::ITopKLayer* layer = params->converter->network()->addTopK(
+      *inputs.at(0).tensor(), topk_op, 1, reduce_axes);
+  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
+  nvinfer1::ITensor* output_indices_tensor = layer->getOutput(1);
+
+  // Squeeze on axis.
+  std::vector<int> size(dims.d, dims.d + dims.nbDims);
+  size.erase(size.begin() + trt_axis);
+  nvinfer1::Dims new_dims;
+  TF_RETURN_IF_ERROR(TensorShapeArrayToTrtDims(size, &new_dims));
+  nvinfer1::ITensor* output_tensor = nullptr;
+  TF_RETURN_IF_ERROR(params->converter->PrepareTensorForShape(
+      TRT_TensorOrWeights(output_indices_tensor), new_dims,
+      /*validation_only=*/false, &output_tensor));
+
+  params->outputs->push_back(TRT_TensorOrWeights(output_tensor));
+}
+
 Status ConvertTopK(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(
       CheckInputsWeights(*params, {{"input", false}, {"k", true}}));
-  TF_RETURN_IF_ERROR(AllowDataTypes(
-      *params, {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}));
+  TF_RETURN_IF_ERROR(
+      AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
   nvinfer1::ITensor* tensor = inputs.at(0).tensor();
   const int num_dims = tensor->getDimensions().nbDims;
   if (num_dims == 0) {
@@ -4411,6 +4460,9 @@ static void RegisterValidatableOpConverters(
   }
   for (auto reduce_op_type : {"Sum", "Prod", "Max", "Min", "Mean"}) {
     (*registration)[reduce_op_type] = ConvertReduce;
+  }
+  for (auto arg_minmax_type : {"ArgMin", "ArgMax"}) {
+    (*registration)[arg_minmax_type] = ConvertArgMinMax;
   }
 }
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -4197,6 +4197,7 @@ Status ConvertArgMinMax(OpConverterParams* params) {
       /*validation_only=*/false, &output_tensor));
 
   params->outputs->push_back(TRT_TensorOrWeights(output_tensor));
+  return Status::OK();
 }
 
 Status ConvertTopK(OpConverterParams* params) {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -3719,7 +3719,9 @@ TEST_F(OpConverterTest, ConvertTopK) {
         "TopKV2 got 0 inputs but expected 2, at my_topk");
   }
 
-  for (const auto dtype : {DT_FLOAT, DT_INT32}) {
+  // TODO(tmorris): This test isn't setting the input dtype properly. TopK with
+  // int32 is unsupported by TRT.
+  for (const auto dtype : {DT_FLOAT}) {
     // Get the NodeDef for TopKV2.
     Scope s = Scope::NewRootScope();
     auto input = ops::Placeholder(s.WithOpName("input"), dtype);
@@ -4758,6 +4760,160 @@ TEST_F(OpConverterTest, ConvertPack) {
 
   // TODO(hinsu): Enable INT32 with TensorRT version 5.1.3 after testing.
   // TestConvertPack<DT_INT32>(this);
+}
+
+// Get the NodeDef for ArgMax.
+NodeDef GetArgMaxNodeDef(DataType input_dtype, DataType output_dtype) {
+  Scope s = Scope::NewRootScope();
+  auto input = ops::Placeholder(s.WithOpName("input"), input_dtype);
+  auto dimension = ops::Placeholder(s.WithOpName("dimension"), DT_INT32);
+  auto attrs = ops::ArgMax::OutputType(output_dtype);
+  auto argmax = ops::ArgMax(s.WithOpName("my_argmax"), input, dimension, attrs);
+  return argmax.operation.node()->def();
+}
+
+// Get the NodeDef for ArgMin.
+NodeDef GetArgMinNodeDef(DataType input_dtype, DataType output_dtype) {
+  Scope s = Scope::NewRootScope();
+  auto input = ops::Placeholder(s.WithOpName("input"), input_dtype);
+  auto dimension = ops::Placeholder(s.WithOpName("dimension"), DT_INT32);
+  auto attrs = ops::ArgMin::OutputType(output_dtype);
+  auto argmin = ops::ArgMin(s.WithOpName("my_argmin"), input, dimension, attrs);
+  return argmin.operation.node()->def();
+}
+
+template <DataType dtype>
+void TestConvertArgMinMax(OpConverterTest* test) {
+  typedef typename EnumToDataType<dtype>::Type CType;
+
+  struct TestParams {
+    std::vector<int> input_shape;
+    std::vector<CType> input_value;
+    int axis;
+    std::vector<int> expected_output_dims;
+    std::vector<int> expected_argmax_output;
+    std::vector<int> expected_argmin_output;
+  };
+
+  const std::vector<CType> common_input = InitTestVector<CType>(6);
+  std::vector<TestParams> params = {
+      {
+          /*input_shape=*/{2, 3},
+          /*input_value=*/common_input,
+          /*axis=*/2,
+          /*expected_output_dims=*/{2},
+          /*expected_argmax_output=*/{2, 2},
+          /*expected_argmin_output=*/{0, 0},
+      },
+      {
+          /*input_shape=*/{2, 3},
+          /*input_value=*/common_input,
+          /*axis=*/-2,
+          /*expected_output_dims=*/{3},
+          /*expected_argmax_output=*/{1, 1, 1},
+          /*expected_argmin_output=*/{0, 0, 0},
+      },
+      {
+          /*input_shape=*/{6},
+          /*input_value=*/common_input,
+          /*axis=*/1,
+          /*expected_output_dims=*/{},
+          /*expected_argmax_output=*/{5},
+          /*expected_argmin_output=*/{0},
+      },
+      {
+          /*input_shape=*/{10},
+          /*input_value=*/{CType(-5), CType(3), CType(5), CType(1), CType(6),
+                           CType(-9), CType(7), CType(1), CType(0), CType(-1)},
+          /*axis=*/-1,
+          /*expected_output_dims=*/{},
+          /*expected_argmax_output=*/{6},
+          /*expected_argmin_output=*/{5},
+      },
+  };
+
+  for (int i = 0; i < params.size(); ++i) {
+    for (bool is_argmax : {true, false}) {
+      test->Reset();
+
+      NodeDef node_def = is_argmax ? GetArgMaxNodeDef(dtype, DT_INT32)
+                                   : GetArgMinNodeDef(dtype, DT_INT32);
+      // Create inputs.
+      test->AddTestTensor("input", params[i].input_shape, /*batch_size=*/1,
+                          /*trt_dtype=*/TfDataTypeToTrt(dtype));
+      test->AddTestWeights<int32>("dimension", {1}, {params[i].axis});
+      test->RunValidationAndConversion(node_def);
+
+      const string node_name = is_argmax ? "my_argmax" : "my_argmin";
+      TRT_TensorOrWeights output;
+      TF_EXPECT_OK(test->GetTensorOrWeights(node_name, &output));
+      EXPECT_TRUE(output.is_tensor());
+      ExpectTrtDimsEqualsArray(params[i].expected_output_dims,
+                               output.tensor()->getDimensions());
+      // Create input data for tensors.
+      const DataVec input_data{
+          {"input", test::AsTensor<CType>(params[i].input_value)}};
+      DataVec output_data{
+          {node_name,
+           ConstructTensor<int32>(params[i].expected_argmax_output.size())}};
+      test->BuildAndRun(input_data, &output_data, dtype == DT_HALF
+                                                      ? TrtPrecisionMode::FP16
+                                                      : TrtPrecisionMode::FP32);
+
+      if (is_argmax) {
+        EXPECT_THAT(GetSpanForData<int32>(output_data[0]),
+                    ElementsAreArray(params[i].expected_argmax_output));
+      } else {
+        EXPECT_THAT(GetSpanForData<int32>(output_data[0]),
+                    ElementsAreArray(params[i].expected_argmin_output));
+      }
+    }
+  }
+}
+
+TEST_F(OpConverterTest, ConvertArgMinMax) {
+  {
+    // Input list is empty, should fail.
+    NodeDef node_def = MakeNodeDef("my_argmax", "ArgMax", {});
+    RunValidationAndConversion(
+        node_def, error::INVALID_ARGUMENT,
+        "ArgMax got 0 inputs but expected 2, at my_argmax");
+  }
+  {
+    // Dimension is a tensor, should fail.
+    Reset();
+    NodeDef node_def = GetArgMaxNodeDef(DT_FLOAT, DT_INT32);
+    AddTestTensor("input", {1, 2, 3});
+    AddTestTensor("dimension", {1});
+    RunValidationAndConversion(
+        node_def, error::UNIMPLEMENTED,
+        "The input \"dimension\" for ArgMax must be a constant, at my_argmax");
+  }
+  {
+    // Output type is INT64, should fail.
+    Reset();
+    NodeDef node_def = GetArgMaxNodeDef(DT_FLOAT, DT_INT64);
+    AddTestTensor("input", {1, 2, 3});
+    AddTestWeights<int32>("dimension", {1}, {3});
+    RunValidationAndConversion(
+        node_def, error::UNIMPLEMENTED,
+        "Output type int64 is not supported, at my_argmax");
+  }
+  {
+    // Axis is batch dimension, should fail
+    Reset();
+    NodeDef node_def = GetArgMaxNodeDef(DT_FLOAT, DT_INT32);
+    AddTestTensor("input", {1, 2, 3});
+    AddTestWeights<int32>("dimension", {1}, {0});
+    RunValidationAndConversion(
+        node_def, error::UNIMPLEMENTED,
+        "TensorRT does not allow manipulation of the batch dimension, at "
+        "my_argmax");
+  }
+
+  TestConvertArgMinMax<DT_FLOAT>(this);
+  TestConvertArgMinMax<DT_HALF>(this);
+  // TestConvertArgMinMax<DT_INT32>(this);
 }
 
 }  // namespace convert


### PR DESCRIPTION
Also adds unit tests for ArgMin/ArgMax.

Disables INT32 for all ops using TopK because it is unsupported by TRT.