### PR TITLE
fix tf_shared_library_deps on macOS

### DIFF
--- a/tensorflow/go/test.sh
+++ b/tensorflow/go/test.sh
@@ -40,6 +40,7 @@ fi
 
 # Setup a GOPATH that includes just the TensorFlow Go API.
 export GOPATH="${TEST_TMPDIR}/go"
+export GOCACHE="${TEST_TMPDIR}/cache"
 mkdir -p "${GOPATH}/src/github.com/tensorflow"
 ln -s "${PWD}" "${GOPATH}/src/github.com/tensorflow/tensorflow"
 

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -413,11 +413,12 @@ def tf_shared_library_deps():
     suffix = "." + VERSION.split(".")[0]
 
     return select({
-        clean_dep("//tensorflow:macos"): [
+        clean_dep("//tensorflow:macos_with_framework_shared_object"): [
             clean_dep("//tensorflow:libtensorflow.dylib"),
             clean_dep("//tensorflow:libtensorflow%s.dylib" % suffix),
             clean_dep("//tensorflow:libtensorflow%s.dylib" % longsuffix),
         ],
+        clean_dep("//tensorflow:macos"): [],
         clean_dep("//tensorflow:windows"): [
             clean_dep("//tensorflow:tensorflow.dll"),
         ],


### PR DESCRIPTION
On macos, //tensorflow/go:test failed to build because
tf_shared_library_deps was ambiguous on with the framework shared
object. Add macos_with_framework_shared_object explicit.

Signed-off-by: Jason Zaman <jason@perfinion.com>

Fixes build failure caused after: https://github.com/tensorflow/tensorflow/pull/27080