### PR TITLE
Pull support for latest Bazel version

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1611,7 +1611,7 @@ def main():
   # environment variables.
   environ_cp = dict(os.environ)
 
-  check_bazel_version('0.19.0', '0.23.0')
+  check_bazel_version('0.19.0', '0.24')
 
   reset_tf_configure_bazelrc()
 


### PR DESCRIPTION
This makes the 2.0 branch match the current maximum Bazel version settings on `master`. It should help resolve https://github.com/tensorflow/tensorflow/issues/26553, where the latest `devel` images don't support `r2.0`.

I'm not sure what the minimum version really is, though.