### PR TITLE
Lite: Add_n Op refactored

### DIFF
--- a/tensorflow/lite/kernels/add_n.cc
+++ b/tensorflow/lite/kernels/add_n.cc
@@ -96,6 +96,7 @@ void EvalAddN(TfLiteContext* context, TfLiteNode* node) {
   OpData* data = reinterpret_cast<OpData*>(node->user_data);
   VectorOfTensors<T>* all_inputs =
       static_cast<VectorOfTensors<T>*>(data->all_inputs);
+  all_inputs->update(*context, *node->inputs);
   const int num_inputs = data->num_inputs;
   TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
   const TfLiteTensor* input1 = GetInput(context, node, kInputTensor1);

--- a/tensorflow/lite/kernels/add_n.cc
+++ b/tensorflow/lite/kernels/add_n.cc
@@ -85,7 +85,7 @@ void EvalAddN(TfLiteContext* context, TfLiteNode* node) {
   OpData* data = reinterpret_cast<OpData*>(node->user_data);
   VectorOfTensors<T>* all_inputs =
       static_cast<VectorOfTensors<T>*>(data->all_inputs);
-  int num_inputs = data->num_inputs;
+  const int num_inputs = data->num_inputs;
   TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
   const TfLiteTensor* input1 = GetInput(context, node, kInputTensor1);
   reference_ops::AddN<T>(GetTensorShape(input1), num_inputs, all_inputs->data(),

--- a/tensorflow/lite/kernels/internal/tensor.h
+++ b/tensorflow/lite/kernels/internal/tensor.h
@@ -76,6 +76,11 @@ class VectorOfTensors {
   //   f[0][1] is the second element of the first tensor.
   // NOTE: This function should be called only in Eval/Invoke context
   T* const* data() {
+    // Reset before writing all tensor data, as this function can be called
+    // multiple times
+    // NOTE: It should always read fresh data from Tensors, even though over
+    // head if Tensors are not changed, but desirable
+    all_data_.clear();
     for (auto it = all_tensors_.begin(); it != all_tensors_.end(); ++it) {
       all_data_.push_back(GetTensorData<T>(*it));
     }

--- a/tensorflow/lite/kernels/internal/tensor.h
+++ b/tensorflow/lite/kernels/internal/tensor.h
@@ -53,39 +53,37 @@ class VectorOfTensors {
     int num_tensors = tensor_list.size;
 
     all_data_.reserve(num_tensors);
-    all_tensors_.reserve(num_tensors);
     all_shape_.reserve(num_tensors);
     all_shape_ptr_.reserve(num_tensors);
 
     for (int i = 0; i < num_tensors; ++i) {
       TfLiteTensor* t = &context.tensors[tensor_list.data[i]];
-      all_tensors_.push_back(t);
       all_shape_.push_back(GetTensorShape(t));
-    }
-
-    // Taking the pointer from inside a std::vector is only OK if the vector is
-    // never modified, so we populate all_shape in the previous loop and then we
-    // are free to grab iterators here.
-    for (int i = 0; i < num_tensors; ++i) {
       all_shape_ptr_.push_back(&all_shape_[i]);
     }
   }
+
+  // Note: Call update in Eval every time before fetching data.
+  void update(const TfLiteContext& context, const TfLiteIntArray& tensor_list) {
+    int num_tensors = tensor_list.size;
+
+    all_data_.clear();
+    all_shape_.clear();
+    all_shape_ptr_.clear();
+
+    for (int i = 0; i < num_tensors; ++i) {
+      TfLiteTensor* t = &context.tensors[tensor_list.data[i]];
+      all_data_.push_back(GetTensorData<T>(t));
+      all_shape_.push_back(GetTensorShape(t));
+      all_shape_ptr_.push_back(&all_shape_[i]);
+    }
+  }
+
   // Return a pointer to the data pointers of all tensors in the list. For
   // example:
   //   float* const* f = v.data();
   //   f[0][1] is the second element of the first tensor.
-  // NOTE: This function should be called only in Eval/Invoke context
-  T* const* data() {
-    // Reset before writing all tensor data, as this function can be called
-    // multiple times
-    // NOTE: It should always read fresh data from Tensors, even though over
-    // head if Tensors are not changed, but desirable
-    all_data_.clear();
-    for (auto it = all_tensors_.begin(); it != all_tensors_.end(); ++it) {
-      all_data_.push_back(GetTensorData<T>(*it));
-    }
-    return all_data_.data();
-  }
+  T* const* data() const { return all_data_.data(); }
 
   // Return a pointer the shape pointers of all tensors in the list. For
   // example:
@@ -95,7 +93,6 @@ class VectorOfTensors {
 
  private:
   std::vector<T*> all_data_;
-  std::vector<TfLiteTensor*> all_tensors_;
   std::vector<RuntimeShape> all_shape_;
   std::vector<RuntimeShape*> all_shape_ptr_;
 };

--- a/tensorflow/lite/kernels/internal/tensor.h
+++ b/tensorflow/lite/kernels/internal/tensor.h
@@ -76,8 +76,7 @@ class VectorOfTensors {
   //   f[0][1] is the second element of the first tensor.
   // NOTE: This function should be called only in Eval/Invoke context
   T* const* data() {
-    for (std::vector<TfLiteTensor*>::iterator it = all_tensors_.begin();
-         it != all_tensors_.end(); ++it) {
+    for (auto it = all_tensors_.begin(); it != all_tensors_.end(); ++it) {
       all_data_.push_back(GetTensorData<T>(*it));
     }
     return all_data_.data();

--- a/tensorflow/lite/kernels/pack.cc
+++ b/tensorflow/lite/kernels/pack.cc
@@ -27,6 +27,46 @@ namespace {
 
 constexpr int kOutputTensor = 0;
 
+struct OpData {
+  void* all_inputs;
+  TfLiteType type;
+};
+
+void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+  // This is a builtin op, so we don't use the contents in 'buffer', if any.
+  // Instead, we allocate a new object to carry information from Prepare() to
+  // Eval().
+  return new OpData();
+}
+
+void Free(TfLiteContext* context, void* buffer) {
+  auto* data = reinterpret_cast<OpData*>(buffer);
+
+  switch (data->type) {
+    case kTfLiteFloat32:
+      delete static_cast<VectorOfTensors<float>*>(data->all_inputs);
+      break;
+    case kTfLiteInt32:
+      delete static_cast<VectorOfTensors<int32_t>*>(data->all_inputs);
+      break;
+    case kTfLiteUInt8:
+      delete static_cast<VectorOfTensors<int8_t>*>(data->all_inputs);
+      break;
+    case kTfLiteInt8:
+      delete static_cast<VectorOfTensors<int8_t>*>(data->all_inputs);
+      break;
+    case kTfLiteInt64:
+      delete static_cast<VectorOfTensors<int64_t>*>(data->all_inputs);
+      break;
+
+    default:
+      context->ReportError(context, "Unexpected data type - [%s] received.",
+                           TfLiteTypeGetName(data->type));
+  }
+
+  delete data;
+}
+
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TfLitePackParams* data =
       reinterpret_cast<TfLitePackParams*>(node->builtin_data);
@@ -44,7 +84,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 
   if (input0->type != kTfLiteInt32 && input0->type != kTfLiteFloat32 &&
       input0->type != kTfLiteUInt8 && input0->type != kTfLiteInt8 &&
-      input0->type != kTfLiteInt16 && input0->type != kTfLiteInt64) {
+      input0->type != kTfLiteInt64) {
     context->ReportError(context, "Type '%s' is not supported by pack.",
                          TfLiteTypeGetName(input0->type));
     return kTfLiteError;
@@ -71,6 +111,36 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
   TF_LITE_ENSURE_EQ(context, output->type, input0->type);
 
+  OpData* user_data = reinterpret_cast<OpData*>(node->user_data);
+  user_data->type = output->type;
+
+  switch (user_data->type) {
+    case kTfLiteFloat32:
+      user_data->all_inputs = reinterpret_cast<void*>(
+          new VectorOfTensors<float>(*context, *node->inputs));
+      break;
+    case kTfLiteInt32:
+      user_data->all_inputs = reinterpret_cast<void*>(
+          new VectorOfTensors<int32_t>(*context, *node->inputs));
+      break;
+    case kTfLiteUInt8:
+      user_data->all_inputs = reinterpret_cast<void*>(
+          new VectorOfTensors<uint8_t>(*context, *node->inputs));
+      break;
+    case kTfLiteInt8:
+      user_data->all_inputs = reinterpret_cast<void*>(
+          new VectorOfTensors<int8_t>(*context, *node->inputs));
+      break;
+    case kTfLiteInt64:
+      user_data->all_inputs = reinterpret_cast<void*>(
+          new VectorOfTensors<int64_t>(*context, *node->inputs));
+      break;
+
+    default:
+      context->ReportError(context, "Unexpected data type - [%s] received.",
+                           TfLiteTypeGetName(user_data->type));
+  }
+
   // Guarantee input/output quantization params match as we do not support
   // packing quantized tensors.
   for (int i = 0; i < data->values_count; i++) {
@@ -88,12 +158,15 @@ TfLiteStatus PackImpl(TfLiteContext* context, TfLiteNode* node,
                       TfLiteTensor* output, int values_count, int axis) {
   TF_LITE_ENSURE(context, axis >= 0);
 
-  VectorOfTensors<T> all_inputs(*context, *node->inputs);
+  OpData* data = reinterpret_cast<OpData*>(node->user_data);
+  VectorOfTensors<T>* all_inputs =
+      static_cast<VectorOfTensors<T>*>(data->all_inputs);
+  all_inputs->update(*context, *node->inputs);
   tflite::PackParams op_params;
   op_params.axis = axis;
   op_params.inputs_count = values_count;
 
-  reference_ops::Pack<T>(op_params, all_inputs.shapes(), all_inputs.data(),
+  reference_ops::Pack<T>(op_params, all_inputs->shapes(), all_inputs->data(),
                          GetTensorShape(output), GetTensorData<T>(output));
   return kTfLiteOk;
 }
@@ -138,7 +211,8 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 }  // namespace pack
 
 TfLiteRegistration* Register_PACK() {
-  static TfLiteRegistration r = {nullptr, nullptr, pack::Prepare, pack::Eval};
+  static TfLiteRegistration r = {pack::Init, pack::Free, pack::Prepare,
+                                 pack::Eval};
   return &r;
 }
 


### PR DESCRIPTION
1:> Dynamic memory allocation moved from Eval to Prepare.
2:> VectorOfTensors refactored to eliminate the limitation of 

> "can be used only in Eval"

.