### PR TITLE
[XLA] Reduce the logging level for two utilities

### DIFF
--- a/tensorflow/compiler/xla/service/call_graph.cc
+++ b/tensorflow/compiler/xla/service/call_graph.cc
@@ -277,8 +277,8 @@ std::unique_ptr<CallGraph> CallGraph::Build(const HloModule* module) {
   // Constructor for CallGraph is private so absl::make_unique can't be used.
   auto call_graph = absl::WrapUnique<CallGraph>(new CallGraph(module));
 
-  VLOG(2) << "Building call graph for:";
-  XLA_VLOG_LINES(2, module->ToString());
+  VLOG(3) << "Building call graph for:";
+  XLA_VLOG_LINES(3, module->ToString());
 
   // Construct nodes of the call graph and populate the callsites.
   for (HloComputation* computation : module->computations()) {
@@ -309,7 +309,7 @@ std::unique_ptr<CallGraph> CallGraph::Build(const HloModule* module) {
   call_graph->SetCallContexts();
   call_graph->SetNodeDepths();
 
-  XLA_VLOG_LINES(1, call_graph->ToString());
+  XLA_VLOG_LINES(2, call_graph->ToString());
 
   return call_graph;
 }

--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -2671,7 +2671,7 @@ bool HloParser::ParseAttributeHelper(
   if (!ParseAttributeName(&name)) {
     return Error(loc, "error parsing attributes");
   }
-  VLOG(1) << "Parsing attribute " << name;
+  VLOG(3) << "Parsing attribute " << name;
   if (!seen_attrs->insert(name).second) {
     return Error(loc, StrFormat("attribute %s already exists", name));
   }
@@ -2943,7 +2943,7 @@ bool HloParser::ParseAttributeAsProtoMessageHelper(
   if (!ParseAttributeName(&name)) {
     return Error(loc, "error parsing attributes");
   }
-  VLOG(1) << "Parsing attribute " << name;
+  VLOG(3) << "Parsing attribute " << name;
   if (!seen_attrs->insert(name).second) {
     return Error(loc, StrFormat("attribute %s already exists", name));
   }
@@ -3650,7 +3650,7 @@ bool HloParser::CanBeShape() {
 }
 
 bool HloParser::ParseName(string* result) {
-  VLOG(1) << "ParseName";
+  VLOG(3) << "ParseName";
   if (lexer_.GetKind() != TokKind::kIdent &&
       lexer_.GetKind() != TokKind::kName) {
     return TokenError("expects name");
@@ -3670,7 +3670,7 @@ bool HloParser::ParseAttributeName(string* result) {
 }
 
 bool HloParser::ParseString(string* result) {
-  VLOG(1) << "ParseString";
+  VLOG(3) << "ParseString";
   if (lexer_.GetKind() != TokKind::kString) {
     return TokenError("expects string");
   }
@@ -3784,7 +3784,7 @@ bool HloParser::ParseMetadata(OpMetadata* metadata) {
 }
 
 bool HloParser::ParseOpcode(HloOpcode* result) {
-  VLOG(1) << "ParseOpcode";
+  VLOG(3) << "ParseOpcode";
   if (lexer_.GetKind() != TokKind::kIdent) {
     return TokenError("expects opcode");
   }
@@ -3800,7 +3800,7 @@ bool HloParser::ParseOpcode(HloOpcode* result) {
 }
 
 bool HloParser::ParseFftType(FftType* result) {
-  VLOG(1) << "ParseFftType";
+  VLOG(3) << "ParseFftType";
   if (lexer_.GetKind() != TokKind::kIdent) {
     return TokenError("expects fft type");
   }
@@ -3829,7 +3829,7 @@ bool HloParser::ParseComparisonDirection(ComparisonDirection* result) {
 }
 
 bool HloParser::ParseFusionKind(HloInstruction::FusionKind* result) {
-  VLOG(1) << "ParseFusionKind";
+  VLOG(3) << "ParseFusionKind";
   if (lexer_.GetKind() != TokKind::kIdent) {
     return TokenError("expects fusion kind");
   }
@@ -3846,7 +3846,7 @@ bool HloParser::ParseFusionKind(HloInstruction::FusionKind* result) {
 }
 
 bool HloParser::ParseRandomDistribution(RandomDistribution* result) {
-  VLOG(1) << "ParseRandomDistribution";
+  VLOG(3) << "ParseRandomDistribution";
   if (lexer_.GetKind() != TokKind::kIdent) {
     return TokenError("expects random distribution");
   }
@@ -3863,7 +3863,7 @@ bool HloParser::ParseRandomDistribution(RandomDistribution* result) {
 }
 
 bool HloParser::ParsePrecision(PrecisionConfig::Precision* result) {
-  VLOG(1) << "ParsePrecision";
+  VLOG(3) << "ParsePrecision";
   if (lexer_.GetKind() != TokKind::kIdent) {
     return TokenError("expects random distribution");
   }
@@ -3880,7 +3880,7 @@ bool HloParser::ParsePrecision(PrecisionConfig::Precision* result) {
 }
 
 bool HloParser::ParseInt64(int64* result) {
-  VLOG(1) << "ParseInt64";
+  VLOG(3) << "ParseInt64";
   if (lexer_.GetKind() != TokKind::kInt) {
     return TokenError("expects integer");
   }
@@ -3969,7 +3969,7 @@ bool HloParser::ParseBool(bool* result) {
 }
 
 bool HloParser::ParseToken(TokKind kind, const string& msg) {
-  VLOG(1) << "ParseToken " << TokKindToString(kind) << " " << msg;
+  VLOG(3) << "ParseToken " << TokKindToString(kind) << " " << msg;
   if (lexer_.GetKind() != kind) {
     return TokenError(msg);
   }


### PR DESCRIPTION
This change reduces the visual clutter by reducing the log level for two of the utility classes in XLA.  It seems to me that log level 1 should be for a high level tracing of the whole system, and the messages that these modules are producing are more like debug trace.