### PR TITLE
[Intel MKL] Enabling BFloat16 element-wise ops using MKLDNN API - Rou…

### DIFF
--- a/tensorflow/core/kernels/mkl_cwise_ops_common.cc
+++ b/tensorflow/core/kernels/mkl_cwise_ops_common.cc
@@ -67,17 +67,17 @@ class MklBinaryOp : public BinaryOp<Device, Functor> {
                               .Label(mkl_op_registry::kMklOpLabel), \
                           OP<D##Device, F<T>>);
 
-REGISTER5(MklBinaryOp, CPU, "_MklAdd", functor::add, float, Eigen::half, double,
-          int32, int64);
-REGISTER7(MklBinaryOp, CPU, "_MklSub", functor::sub, float, Eigen::half, double,
-          int32, int64, complex64, complex128);
-REGISTER5(MklBinaryOp, CPU, "_MklMul", functor::mul, float, Eigen::half, double,
-          uint8, int32);
-REGISTER5(MklBinaryOp, CPU, "_MklMaximum", functor::maximum, float, Eigen::half,
-          double, int32, int64);
-REGISTER5(MklBinaryOp, CPU, "_MklSquaredDifference",
-          functor::squared_difference, float, Eigen::half, double, int32,
-          int64);
+REGISTER6(MklBinaryOp, CPU, "_MklAdd", functor::add, float, Eigen::half, double,
+          int32, int64, bfloat16);
+REGISTER8(MklBinaryOp, CPU, "_MklSub", functor::sub, float, Eigen::half, double,
+          int32, int64, complex64, complex128, bfloat16);
+REGISTER6(MklBinaryOp, CPU, "_MklMul", functor::mul, float, Eigen::half, double,
+          uint8, int32, bfloat16);
+REGISTER6(MklBinaryOp, CPU, "_MklMaximum", functor::maximum, float, Eigen::half,
+          double, int32, int64, bfloat16);
+REGISTER6(MklBinaryOp, CPU, "_MklSquaredDifference",
+          functor::squared_difference, float, Eigen::half, double, int32, int64,
+          bfloat16);
 
 #undef REGISTER
 #pragma pop_macro("REGISTER")

--- a/tensorflow/core/kernels/mkl_input_conversion_op.cc
+++ b/tensorflow/core/kernels/mkl_input_conversion_op.cc
@@ -306,6 +306,7 @@ class MklInputConversionOp : public OpKernel {
 // not support types.
 // TF_CALL_NUMBER_TYPES(REGISTER_CPU);
 TF_CALL_float(REGISTER_CPU);
+TF_CALL_bfloat16(REGISTER_CPU);
 #undef REGISTER_CPU
 }  // namespace tensorflow
 #endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl_relu_op.cc
+++ b/tensorflow/core/kernels/mkl_relu_op.cc
@@ -17,13 +17,13 @@ limitations under the License.
 #ifdef INTEL_MKL
 
 #include "mkldnn.hpp"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/mkl_util.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 using mkldnn::algorithm;
 using mkldnn::eltwise_bounded_relu;
@@ -43,11 +43,11 @@ class MklEltwiseFwdParams {
   memory::dims src_dims;  // check if this is needed
   memory::desc src_md;
   algorithm alg_kind;
-  T alpha;
-  T beta;
+  float alpha;
+  float beta;
 
   MklEltwiseFwdParams(memory::dims src_dims, memory::desc src_md,
-                      algorithm alg_kind, T alpha, T beta)
+                      algorithm alg_kind, float alpha, float beta)
       : src_dims(src_dims),
         src_md(src_md),
         alg_kind(alg_kind),
@@ -226,12 +226,12 @@ class MklEltwiseBwdParams {
   memory::dims src_dims;
   memory::desc common_md;
   algorithm alg_kind;
-  T alpha;
-  T beta;
+  float alpha;
+  float beta;
 
   MklEltwiseBwdParams(const memory::dims& src_dims,
                       const memory::desc& common_md, algorithm alg_kind,
-                      T alpha, T beta)
+                      float alpha, float beta)
       : src_dims(src_dims),
         common_md(common_md),
         alg_kind(alg_kind),
@@ -530,9 +530,9 @@ class MklReluOpBase : public OpKernel {
       // execute eltwise
       eltwise_fwd->Execute(src_data, dst_data);
     } catch (mkldnn::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(
           context,
           errors::Aborted("Operation received an exception:", error_msg));
@@ -698,9 +698,9 @@ class MklReluGradOpBase : public OpKernel {
       // execute eltwise bwd
       eltwise_bwd->Execute(src_data, diff_dst_data, diff_src_data);
     } catch (mkldnn::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(
           context,
           errors::Aborted("Operation received an exception:", error_msg));
@@ -774,7 +774,8 @@ class MklReluGradOp : public MklReluGradOpBase<Device, T, eltwise_relu> {
     void* user_g =
         static_cast<void*>(const_cast<T*>(diff_dst_tensor.flat<T>().data()));
     (static_cast<T*>(out_o))[0] =
-        (static_cast<T*>(user_g))[0] * ((static_cast<T*>(user_i))[0] > 0);
+        (static_cast<T*>(user_g))[0] *
+        (static_cast<T>((static_cast<T*>(user_i))[0] > static_cast<T>(0)));
     return;
   }
 };
@@ -804,7 +805,7 @@ class MklEluOp : public MklReluOpBase<Device, T, eltwise_elu> {
     void* out_o = static_cast<void*>(dst_tensor->flat<T>().data());
     // return exp(feature) - 1 if feature > 0; feature otherwise
     T feature = (static_cast<T*>(user_i))[0];
-    if (feature < 0)
+    if (feature < static_cast<T>(0))
       (static_cast<T*>(out_o))[0] = std::exp(feature);
     else
       (static_cast<T*>(out_o))[0] = feature;
@@ -842,11 +843,12 @@ class MklEluGradOp : public MklReluGradOpBase<Device, T, eltwise_elu> {
         static_cast<void*>(const_cast<T*>(diff_dst_tensor.flat<T>().data()));
     // gradient of elu(x) = 1 if x > 0; elu(x) + 1 otherwise
     T feature = (static_cast<T*>(user_i))[0];
-    if (feature > 0) {
+    if (feature > static_cast<T>(0)) {
       (static_cast<T*>(out_o))[0] = (static_cast<T*>(user_g))[0];
     } else {
-      T elu = std::exp(feature) - 1;
-      (static_cast<T*>(out_o))[0] = (static_cast<T*>(user_g))[0] * (elu + 1);
+      T elu = std::exp(feature) - static_cast<T>(1);
+      (static_cast<T*>(out_o))[0] =
+          (static_cast<T*>(user_g))[0] * (elu + static_cast<T>(1));
     }
   }
 };
@@ -917,7 +919,7 @@ class MklTanhGradOp : public MklReluGradOpBase<Device, T, eltwise_tanh> {
     void* user_g =
         static_cast<void*>(const_cast<T*>(diff_dst_tensor.flat<T>().data()));
     (static_cast<T*>(out_o))[0] =
-        (static_cast<T*>(user_g))[0] * (1 - tanh * tanh);
+        (static_cast<T*>(user_g))[0] * (static_cast<T>(1) - tanh * tanh);
   }
 };
 
@@ -979,8 +981,9 @@ class MklRelu6GradOp
     T* out_o = diff_src_tensor->flat<T>().data();
     T* user_i = const_cast<T*>(src_tensor.flat<T>().data());
     T* user_g = const_cast<T*>(diff_dst_tensor.flat<T>().data());
-    out_o[0] = user_g[0] * (user_i[0] > 0 &&
-                            (user_i[0] < static_cast<T>(RELU6_UPPER_BOUND)));
+    out_o[0] = user_g[0] *
+               static_cast<T>(user_i[0] > static_cast<T>(0) &&
+                              (user_i[0] < static_cast<T>(RELU6_UPPER_BOUND)));
     return;
   }
 };
@@ -1017,7 +1020,7 @@ class MklLeakyReluOp : public MklReluOpBase<Device, T, eltwise_relu> {
     AllocateOutputSetMklShape(context, dst_index, &dst_tensor,
                               src_tensor.shape(), dnn_shape_dst);
     T* out_o = dst_tensor->flat<T>().data();
-    out_o[0] = user_i[0] >= 0 ? user_i[0] : user_i[0] * this->alpha_;
+    out_o[0] = user_i[0] >= T(0) ? user_i[0] : user_i[0] * T(this->alpha_);
     return;
   }
 };
@@ -1058,7 +1061,9 @@ class MklLeakyReluGradOp : public MklReluGradOpBase<Device, T, eltwise_relu> {
     T* out_o = diff_src_tensor->flat<T>().data();
     T* user_i = const_cast<T*>(src_tensor.flat<T>().data());
     T* user_g = const_cast<T*>(diff_dst_tensor.flat<T>().data());
-    out_o[0] = user_i[0] >= 0 ? user_g[0] : user_g[0] * this->alpha_;
+    out_o[0] = user_i[0] >= static_cast<T>(0)
+                   ? user_g[0]
+                   : user_g[0] * static_cast<T>(this->alpha_);
     return;
   }
 };
@@ -1076,6 +1081,7 @@ class MklLeakyReluGradOp : public MklReluGradOpBase<Device, T, eltwise_relu> {
                               .Label(mkl_op_registry::kMklOpLabel), \
                           MklReluGradOp<CPUDevice, type>);
 TF_CALL_float(REGISTER_RELU_MKL_SUPPORTED_KERNELS_TYPES);
+TF_CALL_bfloat16(REGISTER_RELU_MKL_SUPPORTED_KERNELS_TYPES);
 
 // register dnn kernels for supported operations and supported types
 #define REGISTER_ELU_MKL_SUPPORTED_KERNELS_TYPES(type)              \
@@ -1090,6 +1096,7 @@ TF_CALL_float(REGISTER_RELU_MKL_SUPPORTED_KERNELS_TYPES);
                               .Label(mkl_op_registry::kMklOpLabel), \
                           MklEluGradOp<CPUDevice, type>);
 TF_CALL_float(REGISTER_ELU_MKL_SUPPORTED_KERNELS_TYPES);
+TF_CALL_bfloat16(REGISTER_ELU_MKL_SUPPORTED_KERNELS_TYPES);
 
 #define REGISTER_TANH_MKL_SUPPORTED_KERNELS_TYPES(type)             \
   REGISTER_KERNEL_BUILDER(Name("_MklTanh")                          \
@@ -1103,6 +1110,7 @@ TF_CALL_float(REGISTER_ELU_MKL_SUPPORTED_KERNELS_TYPES);
                               .Label(mkl_op_registry::kMklOpLabel), \
                           MklTanhGradOp<CPUDevice, type>);
 TF_CALL_float(REGISTER_TANH_MKL_SUPPORTED_KERNELS_TYPES);
+TF_CALL_bfloat16(REGISTER_TANH_MKL_SUPPORTED_KERNELS_TYPES);
 
 #define REGISTER_RELU6_MKL_SUPPORTED_KERNELS_TYPES(type)            \
   REGISTER_KERNEL_BUILDER(Name("_MklRelu6")                         \
@@ -1116,6 +1124,7 @@ TF_CALL_float(REGISTER_TANH_MKL_SUPPORTED_KERNELS_TYPES);
                               .Label(mkl_op_registry::kMklOpLabel), \
                           MklRelu6GradOp<CPUDevice, type>);
 TF_CALL_float(REGISTER_RELU6_MKL_SUPPORTED_KERNELS_TYPES);
+TF_CALL_bfloat16(REGISTER_RELU6_MKL_SUPPORTED_KERNELS_TYPES);
 
 #define REGISTER_LeakyRelu_MKL_SUPPORTED_KERNELS_TYPES(type)        \
   REGISTER_KERNEL_BUILDER(Name("_MklLeakyRelu")                     \
@@ -1129,6 +1138,7 @@ TF_CALL_float(REGISTER_RELU6_MKL_SUPPORTED_KERNELS_TYPES);
                               .Label(mkl_op_registry::kMklOpLabel), \
                           MklLeakyReluGradOp<CPUDevice, type>);
 TF_CALL_float(REGISTER_LeakyRelu_MKL_SUPPORTED_KERNELS_TYPES);
+TF_CALL_bfloat16(REGISTER_LeakyRelu_MKL_SUPPORTED_KERNELS_TYPES);
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -414,7 +414,7 @@ REGISTER_OP("_MklAdd")
     .Output("mkl_z: uint8")
     .Attr(
         "T: {half, float, double, uint8, int8, int16, int32, int64, complex64, "
-        "complex128, string}")
+        "complex128, string, bfloat16}")
     .SetShapeFn(shape_inference::BroadcastBinaryOpShapeFn)
     .Doc(R"doc(
 Returns `x` + `y` element-wise.
@@ -536,7 +536,7 @@ REGISTER_OP("_MklMaximum")
     .Input("mkl_y: uint8")
     .Output("z: T")
     .Output("mkl_z: uint8")
-    .Attr("T: {half, float, double, int32, int64}")
+    .Attr("T: {half, float, double, int32, int64, bfloat16}")
     .SetIsCommutative()
     .SetShapeFn(shape_inference::BroadcastBinaryOpShapeFn)
     .Doc(R"doc(

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -1999,7 +1999,7 @@ REGISTER_OP("_MklLeakyRelu")
     .Input("mkl_features: uint8")
     .Output("activations: T")
     .Output("mkl_activations: uint8")
-    .Attr("T: {half, float, double} = DT_FLOAT")
+    .Attr("T: realnumbertype = DT_FLOAT")
     .Attr("alpha: float = 0.2")
     .SetShapeFn(shape_inference::UnchangedShape)
     .Doc(R"doc(
@@ -2017,7 +2017,7 @@ REGISTER_OP("_MklLeakyReluGrad")
     .Input("mkl_features: uint8")
     .Output("backprops: T")
     .Output("mkl_backprops: uint8")
-    .Attr("T: {half, float, double} = DT_FLOAT")
+    .Attr("T: realnumbertype = DT_FLOAT")
     .Attr("alpha: float = 0.2")
     .SetShapeFn(shape_inference::MergeBothInputsShapeFn)
     .Doc(R"doc(
@@ -2510,7 +2510,7 @@ REGISTER_OP("_MklToTf")
     .Input("input: T")
     .Input("mkl_input: uint8")
     .Output("output: T")
-    .Attr("T: {half, float, double, qint8, quint8, qint32}")
+    .Attr("T: {half, float, double, bfloat16, qint8, quint8, qint32}")
     .Attr(GetConvnetDataFormat2D3DAttrString())
     .SetShapeFn(shape_inference::UnknownShape)
     .Doc(R"doc(
@@ -2531,8 +2531,8 @@ REGISTER_OP("_MklInputConversion")
     .Output("mkl_output_1: uint8")
     // All datatypes supported by element-wise ops
     .Attr(
-        "T: {half, float, double, uint8, int8, uint16, int16, int32, int64, "
-        "complex64, complex128}")
+        "T: {half, float, bfloat16, double, uint8, int8, uint16, int16, int32, "
+        "int64, complex64, complex128}")
     .Attr(GetConvnetDataFormat2D3DAttrString())
     .SetShapeFn(shape_inference::UnknownShape)
     .Doc(R"doc(

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -1937,7 +1937,7 @@ REGISTER_OP("_MklRelu")
     .Input("mkl_features: uint8")
     .Output("activations: T")
     .Output("mkl_activations: uint8")
-    .Attr("T: realnumbertype")
+    .Attr("T: {float, bfloat16} = DT_FLOAT")
     .SetShapeFn(shape_inference::UnchangedShape)
     .Doc(R"doc(
 MKL version of Relu operator. Uses MKL DNN APIs to implement Relu operator.
@@ -1953,7 +1953,7 @@ REGISTER_OP("_MklReluGrad")
     .Input("mkl_features: uint8")
     .Output("backprops: T")
     .Output("mkl_backprops: uint8")
-    .Attr("T: realnumbertype")
+    .Attr("T: {float, bfloat16} = DT_FLOAT")
     .SetShapeFn(shape_inference::MergeBothInputsShapeFn)
     .Doc(R"doc(
 MKL version of ReluGrad operator. Uses MKL DNN APIs to compute rectified
@@ -1968,7 +1968,7 @@ REGISTER_OP("_MklRelu6")
     .Input("mkl_features: uint8")
     .Output("activations: T")
     .Output("mkl_activations: uint8")
-    .Attr("T: realnumbertype")
+    .Attr("T: {float, bfloat16} = DT_FLOAT")
     .SetShapeFn(shape_inference::UnchangedShape)
     .Doc(R"doc(
 MKL version of Relu6 operator. Uses MKL DNN APIs to implement Relu6 operator.
@@ -1984,7 +1984,7 @@ REGISTER_OP("_MklRelu6Grad")
     .Input("mkl_features: uint8")
     .Output("backprops: T")
     .Output("mkl_backprops: uint8")
-    .Attr("T: realnumbertype")
+    .Attr("T: {float, bfloat16} = DT_FLOAT")
     .SetShapeFn(shape_inference::MergeBothInputsShapeFn)
     .Doc(R"doc(
 MKL version of Relu6Grad operator. Uses MKL DNN APIs to compute rectified
@@ -1999,7 +1999,7 @@ REGISTER_OP("_MklLeakyRelu")
     .Input("mkl_features: uint8")
     .Output("activations: T")
     .Output("mkl_activations: uint8")
-    .Attr("T: realnumbertype = DT_FLOAT")
+    .Attr("T: {float, bfloat16} = DT_FLOAT")
     .Attr("alpha: float = 0.2")
     .SetShapeFn(shape_inference::UnchangedShape)
     .Doc(R"doc(
@@ -2017,7 +2017,7 @@ REGISTER_OP("_MklLeakyReluGrad")
     .Input("mkl_features: uint8")
     .Output("backprops: T")
     .Output("mkl_backprops: uint8")
-    .Attr("T: realnumbertype = DT_FLOAT")
+    .Attr("T: {float, bfloat16} = DT_FLOAT")
     .Attr("alpha: float = 0.2")
     .SetShapeFn(shape_inference::MergeBothInputsShapeFn)
     .Doc(R"doc(
@@ -2033,7 +2033,7 @@ REGISTER_OP("_MklElu")
     .Input("mkl_features: uint8")
     .Output("activations: T")
     .Output("mkl_activations: uint8")
-    .Attr("T: realnumbertype")
+    .Attr("T: {float, bfloat16} = DT_FLOAT")
     .SetShapeFn(shape_inference::UnchangedShape)
     .Doc(R"doc(
 MKL version of Elu operator. Uses MKL DNN APIs to implement Elu operator.
@@ -2048,7 +2048,7 @@ REGISTER_OP("_MklEluGrad")
     .Input("mkl_features: uint8")
     .Output("backprops: T")
     .Output("mkl_backprops: uint8")
-    .Attr("T: realnumbertype")
+    .Attr("T: {float, bfloat16} = DT_FLOAT")
     .SetShapeFn(shape_inference::MergeBothInputsShapeFn)
     .Doc(R"doc(
 MKL version of EluGrad operator. Uses MKL DNN APIs to compute Elu


### PR DESCRIPTION
…nd 2

This PR enables support for BFloat16 versions of element-wise arithmetic ops
and activation functions using MKL-DNN API.