### PR TITLE
[tflite] make metal delegate code build

### DIFF
--- a/tensorflow/lite/delegates/gpu/metal/inference_context.mm
+++ b/tensorflow/lite/delegates/gpu/metal/inference_context.mm
@@ -18,7 +18,7 @@ limitations under the License.
 #include <map>
 #include <vector>
 
-#include "third_party/absl/strings/substitute.h"
+#include "absl/strings/substitute.h"
 #include "tensorflow/lite/delegates/gpu/common/memory_management.h"
 #include "tensorflow/lite/delegates/gpu/common/model.h"
 #include "tensorflow/lite/delegates/gpu/common/shape.h"

--- a/tensorflow/lite/delegates/gpu/metal_delegate.mm
+++ b/tensorflow/lite/delegates/gpu/metal_delegate.mm
@@ -23,7 +23,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "third_party/absl/types/span.h"
+#include "absl/types/span.h"
 #include "tensorflow/lite/builtin_ops.h"
 #include "tensorflow/lite/c/c_api_internal.h"
 #include "tensorflow/lite/delegates/gpu/common/convert.h"


### PR DESCRIPTION
changes to build libtflite_gpu_metal.so and libmetal_delegate.a.

```
bazel build --apple_platform_type ios --cpu=ios_arm64 --cxxopt=-std=c++14 \
tensorflow/lite/delegates/gpu:libtflite_gpu_metal.so
```
and
```
bazel build --apple_platform_type ios --cpu=ios_arm64 --cxxopt=-std=c++14 \
tensorflow/lite/delegates/gpu:metal_delegate
```
build.

https://github.com/tensorflow/tensorflow/issues/27325