### PR TITLE
[TF 2.0 Build] Fix bug caused by typo in check_bazel_version()

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1611,7 +1611,7 @@ def main():
   # environment variables.
   environ_cp = dict(os.environ)
 
-  check_bazel_version('0.19.0', '0.24')
+  check_bazel_version('0.19.0', '0.24.0')
 
   reset_tf_configure_bazelrc()
 


### PR DESCRIPTION
This PR resolves issue #27450.
Previously typo enters '0.24' instead of '0.24.0' for max bazel version in call to 'check_bazel_version' function, causing build to fail when compiling from source. Such typo is now fixed.
This PR may also relates to @perfinion 's comment in #27399 where he states that he will re-access min max version everywhere else later.