### PR TITLE
Fix typo in generated temporary placeholder name

### DIFF
--- a/tensorflow/python/eager/lift_to_graph.py
+++ b/tensorflow/python/eager/lift_to_graph.py
@@ -183,7 +183,7 @@ def _copy_non_source(op, graph, op_map):
       # a placeholder for now and return information about the required post-hoc
       # mutation.
       copied_input = array_ops.placeholder(
-          name="unusued_control_flow_input",
+          name="unused_control_flow_input",
           shape=original_input.shape,
           dtype=original_input.dtype)
       input_mutations.append(


### PR DESCRIPTION
While working on some code to feed the contents of a SavedModel through the Graph Transform Tool, I used the new SavedModel loader to load the object detection model from [here](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz) and noticed two issues:
a. The graph had several hundred additional, unused Placeholder ops after converting to a GraphDef proto
b. The names of these ops contained a misspelled word.

This PR corrects problem (b). Correcting problem (a) will require some more thought. One of the possible ways around problem (a) is to detect the unused ops by name and remove them prior to passing the graph through the Graph Transform Tool. But that solution would break if someone were to correct the spelling mistake later on. Hence correcting it now.