### PR TITLE
[Intel MKL] Graph Transform tool fold_old_batchnorms biasadd node bug

### DIFF
--- a/tensorflow/tools/graph_transforms/fold_old_batch_norms.cc
+++ b/tensorflow/tools/graph_transforms/fold_old_batch_norms.cc
@@ -163,7 +163,7 @@ Status FuseScaleOffsetToConvWeights(const std::vector<float>& scale_values,
   NodeDef bias_add_node;
   bias_add_node.set_op("BiasAdd");
   bias_add_node.set_name(conv_output_name);
-  if (!conv_node.attr().count("data_format")) {
+  if (conv_node.attr().count("data_format")) {
     CopyNodeAttr(conv_node, "data_format", "data_format", &bias_add_node);
   }
   CopyNodeAttr(conv_node, "T", "T", &bias_add_node);


### PR DESCRIPTION
tensorflow/tensorflow/tools/graph_transforms/fold_old_batch_norms.cc has a bug.

Biasadd node copy needs to copy the attribute dataformat. Else there will be a load bug after batchnorm folding.. i.e. The data_format attribute of NCHW is not copied from conv2d node to Biasadd node without which the shape for convolution with the mismatched order is improperly checked.