### PR TITLE
[proposal] Implementing K.rnn(reverse_sequence=True)

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -3342,6 +3342,7 @@ def rnn(step_function,
         inputs,
         initial_states,
         go_backwards=False,
+        # reverse_sequence=False,
         mask=None,
         constants=None,
         unroll=False,
@@ -3373,6 +3374,8 @@ def rnn(step_function,
           structure.
       go_backwards: Boolean. If True, do the iteration over the time
           dimension in reverse order and return the reversed sequence.
+      reverse_sequence: Reverse the order of the sequence of outputs that is being returned.
+          (this can be useful if you try to implement a system like ELMo)
       mask: Binary tensor with shape `(samples, time, 1)`,
           with a zero for every element that is masked.
       constants: List of constant values passed at each step.
@@ -3504,6 +3507,7 @@ def rnn(step_function,
         successive_states.append(states)
       last_output = successive_outputs[-1]
       new_states = successive_states[-1]
+      # reverse successive_outputs if reverse_sequence has been set
       outputs = array_ops.stack(successive_outputs)
 
       if zero_output_for_mask:
@@ -3524,6 +3528,7 @@ def rnn(step_function,
         successive_states.append(states)
       last_output = successive_outputs[-1]
       new_states = successive_states[-1]
+      # reverse successive_outputs if reverse_sequence has been set
       outputs = array_ops.stack(successive_outputs)
 
   else:


### PR DESCRIPTION
Hi,

I am a Tensorflow.js user and I made a proposed change to enable RNNs to return their output sequence in the reversed order, which is especially useful if you use go_backwards.

> https://github.com/tensorflow/tfjs-layers/pull/517

It was mentioned there that compatibility with the Python version of Tensorflow was something they cared about, and therefore it was suggested to also create a pull request on the Python side to gather feedback, and see if this implementation is something your team would support.

I'm not a Python developer but could make the necessary changes I believe, though I'd rather get an approval before going deeper because this might take a fair chunk of my time since this change has to be propagated to the layers etc. Now if in addition to approving the idea someone else also wanted to help me out and advance this pull request, I'd appreciate it of course :)