### PR TITLE
Fix configure.py to properly compare "X.Y.Z" with "X.Y"

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -439,6 +439,9 @@ def convert_version_to_int(version):
   """
   version = version.split('-')[0]
   version_segments = version.split('.')
+  # Treat "0.24" as "0.24.0"
+  if len(version_segments) == 2:
+    version_segments.append('0')
   for seg in version_segments:
     if not seg.isdigit():
       return None


### PR DESCRIPTION
Right now, "0.24" is treated as lower than "*.*.*" because of the odd comparison method that adds digits to each existing section. This change converts "0.24" to "0.24.0" to fix that.

This will probably need to be pulled into r2.0.

PiperOrigin-RevId: 241950768