### PR TITLE
TFTRT: Complete IActivationLayer coverage for TRT 5.1

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -2898,8 +2898,8 @@ Status ConvertClipByValue(OpConverterParams* params) {
   TF_RETURN_IF_ERROR(CheckInputsWeights(
       *params,
       {{"t", false}, {"clip_value_min", true}, {"clip_value_max", true}}));
-  TF_RETURN_IF_ERROR(AllowDataTypes(
-      *params, {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}));
+  TF_RETURN_IF_ERROR(
+      AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
   if (params->validation_only) return Status::OK();
 
   TFAttrs attrs(node_def);
@@ -2916,11 +2916,6 @@ Status ConvertClipByValue(OpConverterParams* params) {
         inputs.at(1).weights().GetSpan<Eigen::half>()[0]);
     clip_value_max = Eigen::half_impl::half_to_float(
         inputs.at(2).weights().GetSpan<Eigen::half>()[0]);
-  } else if (dtype == DataType::DT_INT32) {
-    clip_value_min =
-        static_cast<float>(inputs.at(1).weights().GetSpan<int>()[0]);
-    clip_value_max =
-        static_cast<float>(inputs.at(2).weights().GetSpan<int>()[0]);
   }
 
   nvinfer1::IActivationLayer* layer =

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -2936,14 +2936,14 @@ const std::unordered_map<string, nvinfer1::ActivationType>*
 ActivationTypeMap() {
   static auto* const m =
       new std::unordered_map<string, nvinfer1::ActivationType>({
-          {"Relu", nvinfer1::ActivationType::kRELU},
-          {"Sigmoid", nvinfer1::ActivationType::kSIGMOID},
-          {"Tanh", nvinfer1::ActivationType::kTANH},
+        {"Relu", nvinfer1::ActivationType::kRELU},
+            {"Sigmoid", nvinfer1::ActivationType::kSIGMOID},
+            {"Tanh", nvinfer1::ActivationType::kTANH},
 #if IS_TRT_VERSION_GE(5, 1, 2, 0)
-        {"Elu", nvinfer1::ActivationType::kELU},
-        {"Selu", nvinfer1::ActivationType::kSELU},
-        {"Softsign", nvinfer1::ActivationType::kSOFTSIGN},
-        {"Softplus", nvinfer1::ActivationType::kSOFTPLUS},
+            {"Elu", nvinfer1::ActivationType::kELU},
+            {"Selu", nvinfer1::ActivationType::kSELU},
+            {"Softsign", nvinfer1::ActivationType::kSOFTSIGN},
+            {"Softplus", nvinfer1::ActivationType::kSOFTPLUS},
 #endif
       });
   return m;

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -2835,17 +2835,28 @@ Status ConvertPool(OpConverterParams* params) {
   return Status::OK();
 }
 
-// TODO(tmorris): Use ActivationType::kLEAKY_RELU in TRT 5.1+ once perf
-// improves.
 Status ConvertLeakyRelu(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"input", false}}));
   TF_RETURN_IF_ERROR(
       AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
-
   TFAttrs attrs(node_def);
   const float alpha = attrs.get<float>("alpha");
+
+#if IS_TRT_VERSION_GE(5, 1, 2, 0)
+  // Use IActivationLayer when available.
+  if (params->validation_only) return Status::OK();
+
+  nvinfer1::IActivationLayer* layer =
+      params->converter->network()->addActivation(
+          *inputs.at(0).tensor(), nvinfer1::ActivationType::kLEAKY_RELU);
+  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
+  layer->setAlpha(alpha);
+  params->outputs->push_back(TRT_TensorOrWeights(layer->getOutput(0)));
+  return Status::OK();
+#else
+  // Use elementwise ops when IActivationLayer is not available.
   if (alpha < 0.0f || alpha > 1.0f) {
     return errors::Unimplemented(
         "Alpha value for LeakyRelu must be between 0 and 1, at ",
@@ -2853,7 +2864,6 @@ Status ConvertLeakyRelu(OpConverterParams* params) {
   }
   if (params->validation_only) return Status::OK();
 
-  // Input Tensor
   nvinfer1::ITensor* tensor = inputs.at(0).tensor();
   // Create const for alpha.
   nvinfer1::ITensor* const_alpha_tensor = nullptr;
@@ -2876,6 +2886,72 @@ Status ConvertLeakyRelu(OpConverterParams* params) {
 
   params->outputs->push_back(TRT_TensorOrWeights(output_tensor));
   return Status::OK();
+#endif
+}
+
+#if IS_TRT_VERSION_GE(5, 1, 2, 0)
+Status ConvertClipByValue(OpConverterParams* params) {
+  const auto& inputs = params->inputs;
+  const auto& node_def = params->node_def;
+  // TODO(tmorris): We can also allow the case where min and max are tensors by
+  // using elementwise min and max layers.
+  TF_RETURN_IF_ERROR(CheckInputsWeights(
+      *params,
+      {{"t", false}, {"clip_value_min", true}, {"clip_value_max", true}}));
+  TF_RETURN_IF_ERROR(AllowDataTypes(
+      *params, {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}));
+  if (params->validation_only) return Status::OK();
+
+  TFAttrs attrs(node_def);
+  const DataType dtype = attrs.get<DataType>("T");
+  float clip_value_min = 0.0f;
+  float clip_value_max = 0.0f;
+  // TODO(tmorris): Add a templated helper function to get scalar weights of
+  // InType casted to OutType.
+  if (dtype == DataType::DT_FLOAT) {
+    clip_value_min = inputs.at(1).weights().GetSpan<float>()[0];
+    clip_value_max = inputs.at(2).weights().GetSpan<float>()[0];
+  } else if (dtype == DataType::DT_HALF) {
+    clip_value_min = Eigen::half_impl::half_to_float(
+        inputs.at(1).weights().GetSpan<Eigen::half>()[0]);
+    clip_value_max = Eigen::half_impl::half_to_float(
+        inputs.at(2).weights().GetSpan<Eigen::half>()[0]);
+  } else if (dtype == DataType::DT_INT32) {
+    clip_value_min =
+        static_cast<float>(inputs.at(1).weights().GetSpan<int>()[0]);
+    clip_value_max =
+        static_cast<float>(inputs.at(2).weights().GetSpan<int>()[0]);
+  }
+
+  nvinfer1::IActivationLayer* layer =
+      params->converter->network()->addActivation(
+          *inputs.at(0).tensor(), nvinfer1::ActivationType::kCLIP);
+  layer->setAlpha(clip_value_min);
+  layer->setBeta(clip_value_max);
+  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
+  nvinfer1::ITensor* output_tensor = layer->getOutput(0);
+  params->converter->ProvideQuantizationRange(output_tensor, clip_value_min,
+                                              clip_value_max);
+  params->outputs->push_back(TRT_TensorOrWeights(output_tensor));
+  return Status::OK();
+}
+#endif
+
+const std::unordered_map<string, nvinfer1::ActivationType>*
+ActivationTypeMap() {
+  static auto* const m =
+      new std::unordered_map<string, nvinfer1::ActivationType>({
+          {"Relu", nvinfer1::ActivationType::kRELU},
+          {"Sigmoid", nvinfer1::ActivationType::kSIGMOID},
+          {"Tanh", nvinfer1::ActivationType::kTANH},
+#if IS_TRT_VERSION_GE(5, 1, 2, 0)
+        {"Elu", nvinfer1::ActivationType::kELU},
+        {"Selu", nvinfer1::ActivationType::kSELU},
+        {"Softsign", nvinfer1::ActivationType::kSOFTSIGN},
+        {"Softplus", nvinfer1::ActivationType::kSOFTPLUS},
+#endif
+      });
+  return m;
 }
 
 Status ConvertActivation(OpConverterParams* params) {
@@ -2884,28 +2960,38 @@ Status ConvertActivation(OpConverterParams* params) {
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"input", false}}));
   TF_RETURN_IF_ERROR(
       AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
-  static const std::unordered_map<string, nvinfer1::ActivationType> ops{
-      {"Relu", nvinfer1::ActivationType::kRELU},
-      {"Sigmoid", nvinfer1::ActivationType::kSIGMOID},
-      {"Tanh", nvinfer1::ActivationType::kTANH},
-  };
-  auto op_pair = ops.find(node_def.op());
-  if (op_pair == ops.end()) {
+  auto op_pair = ActivationTypeMap()->find(node_def.op());
+  if (op_pair == ActivationTypeMap()->end()) {
     return errors::Unimplemented("Activation op: ", node_def.op(),
                                  " not supported at: ", node_def.name());
   }
   if (params->validation_only) return Status::OK();
 
   // Start conversion.
-  nvinfer1::ITensor* tensor = inputs.at(0).tensor();
   nvinfer1::IActivationLayer* layer =
-      params->converter->network()->addActivation(*tensor, op_pair->second);
+      params->converter->network()->addActivation(*inputs.at(0).tensor(),
+                                                  op_pair->second);
   TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
+  // Set parameters.
+#if IS_TRT_VERSION_GE(5, 1, 2, 0)
+  if (node_def.op() == "Elu") {
+    layer->setAlpha(1.0f);
+  } else if (node_def.op() == "Selu") {
+    // From tensorflow/core/kernels/relu_op_functor.h
+    layer->setAlpha(1.7580993408473768599402175208123f);
+    layer->setBeta(1.0507009873554804934193349852946f);
+  } else if (node_def.op() == "Softplus") {
+    layer->setAlpha(1.0f);
+    layer->setBeta(1.0f);
+  }
+#endif
   nvinfer1::ITensor* output_tensor = layer->getOutput(0);
-  // Set quantization range for output of Sigmoid, Tanh.
+  // Set quantization range for output when known.
   if (node_def.op() == "Sigmoid") {
     params->converter->ProvideQuantizationRange(output_tensor, 0.0f, 1.0f);
   } else if (node_def.op() == "Tanh") {
+    params->converter->ProvideQuantizationRange(output_tensor, -1.0f, 1.0f);
+  } else if (node_def.op() == "Softsign") {
     params->converter->ProvideQuantizationRange(output_tensor, -1.0f, 1.0f);
   }
   params->outputs->push_back(TRT_TensorOrWeights(output_tensor));
@@ -2973,7 +3059,6 @@ Status ConvertQuantize(OpConverterParams* params) {
   return Status::OK();
 }
 
-// TODO(tmorris): Use ActivationType::kCLIP in TRT 5.1+ once perf improves.
 Status ConvertRelu6(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
@@ -2981,11 +3066,21 @@ Status ConvertRelu6(OpConverterParams* params) {
   TF_RETURN_IF_ERROR(
       AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
   if (params->validation_only) return Status::OK();
-  // ***************************************************************************
-  // TensorRT does not implement Relu6 natively. This function converts Relu6 op
-  // to available TensorRT ops: Relu6(x) = min(Relu(x), 6)
-  // ***************************************************************************
 
+#if IS_TRT_VERSION_GE(5, 1, 2, 0)
+  // Use IActivationLayer for TRT >= 5.1
+  nvinfer1::IActivationLayer* layer =
+      params->converter->network()->addActivation(
+          *inputs.at(0).tensor(), nvinfer1::ActivationType::kCLIP);
+  layer->setAlpha(0.0f);
+  layer->setBeta(6.0f);
+  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
+  nvinfer1::ITensor* output_tensor = layer->getOutput(0);
+  params->converter->ProvideQuantizationRange(output_tensor, 0.0f, 6.0f);
+  params->outputs->push_back(TRT_TensorOrWeights(output_tensor));
+  return Status::OK();
+#else
+  // Convert using min(Relu(x), 6) before TRT 5.1
   // Input Tensor
   nvinfer1::ITensor* tensor = inputs.at(0).tensor();
 
@@ -3020,6 +3115,7 @@ Status ConvertRelu6(OpConverterParams* params) {
 
   params->outputs->push_back(TRT_TensorOrWeights(output_tensor));
   return Status::OK();
+#endif
 }
 
 Status ConvertBiasAdd(OpConverterParams* params) {
@@ -4536,6 +4632,9 @@ static void RegisterValidatableOpConverters(
     std::unordered_map<string, OpConverter>* registration) {
   (*registration)["BatchMatMul"] = ConvertBatchMatMul;
   (*registration)["BiasAdd"] = ConvertBiasAdd;
+#if IS_TRT_VERSION_GE(5, 1, 2, 0)
+  (*registration)["ClipByValue"] = ConvertClipByValue;
+#endif
 #if IS_TRT_VERSION_GE(5, 1, 0, 0)
   (*registration)["CombinedNonMaxSuppression"] = ConvertCombinedNMS;
 #endif
@@ -4576,8 +4675,8 @@ static void RegisterValidatableOpConverters(
        {"Add", "Mul", "Sub", "Div", "RealDiv", "Maximum", "Minimum", "Pow"}) {
     (*registration)[binary_op_type] = ConvertBinary;
   }
-  for (auto activation_op_type : {"Relu", "Sigmoid", "Tanh"}) {
-    (*registration)[activation_op_type] = ConvertActivation;
+  for (auto activation_op_pair : *ActivationTypeMap()) {
+    (*registration)[activation_op_pair.first] = ConvertActivation;
   }
   for (auto pool_op_type : {"AvgPool", "MaxPool"}) {
     (*registration)[pool_op_type] = ConvertPool;

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -594,6 +594,8 @@ class Converter {
 
 // Map of all supported UnaryOperations
 const std::unordered_map<string, nvinfer1::UnaryOperation>* UnaryOperationMap();
+// Map of all supported ActivationTypes
+const std::unordered_map<string, nvinfer1::ActivationType>* ActivationTypeMap();
 
 }  // namespace convert
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -2481,7 +2481,9 @@ TEST_F(OpConverterTest, ConvertActivation) {
         "The input \"input\" for Relu must be a tensor, at my_act");
   }
 
-  constexpr float kAlpha = 0.2f;
+  constexpr float kLeakyReluAlpha = 0.2f;
+  constexpr float kSeluAlpha = 1.7580993408473768599402175208123f;
+  constexpr float kSeluScale = 1.0507009873554804934193349852946f;
 
   // Get nodedef for activation layer.
   auto get_act_nodedef = [](string op_name) -> NodeDef {
@@ -2489,8 +2491,9 @@ TEST_F(OpConverterTest, ConvertActivation) {
     auto input = ops::Placeholder(s.WithOpName("input"), DT_FLOAT);
     if (op_name == "LeakyRelu") {
       auto act =
-          ops::internal::LeakyRelu(s.WithOpName("my_act"), input,
-                                   ops::internal::LeakyRelu::Alpha(kAlpha));
+          ops::internal::LeakyRelu(
+              s.WithOpName("my_act"), input,
+              ops::internal::LeakyRelu::Alpha(kLeakyReluAlpha));
       return act.operation.node()->def();
     } else if (op_name == "Relu") {
       auto act = ops::Relu(s.WithOpName("my_act"), input);
@@ -2504,6 +2507,18 @@ TEST_F(OpConverterTest, ConvertActivation) {
     } else if (op_name == "Tanh") {
       auto act = ops::Tanh(s.WithOpName("my_act"), input);
       return act.operation.node()->def();
+    } else if (op_name == "Elu") {
+      auto act = ops::Elu(s.WithOpName("my_act"), input);
+      return act.operation.node()->def();
+    } else if (op_name == "Selu") {
+      auto act = ops::Selu(s.WithOpName("my_act"), input);
+      return act.operation.node()->def();
+    } else if (op_name == "Softsign") {
+      auto act = ops::Softsign(s.WithOpName("my_act"), input);
+      return act.operation.node()->def();
+    } else if (op_name == "Softplus") {
+      auto act = ops::Softplus(s.WithOpName("my_act"), input);
+      return act.operation.node()->def();
     }
     EXPECT_TRUE(false);
     return NodeDef();
@@ -2511,7 +2526,7 @@ TEST_F(OpConverterTest, ConvertActivation) {
   // Get expected output for activation layer.
   auto get_act_output = [](string op_name, float input) -> float {
     if (op_name == "LeakyRelu") {
-      return (input > 0.0f) ? input : input * kAlpha;
+      return (input > 0.0f) ? input : input * kLeakyReluAlpha;
     } else if (op_name == "Relu") {
       return (input > 0.0f) ? input : 0.0f;
     } else if (op_name == "Relu6") {
@@ -2520,14 +2535,33 @@ TEST_F(OpConverterTest, ConvertActivation) {
       return 1.0f / (1.0f + std::exp(-input));
     } else if (op_name == "Tanh") {
       return std::tanh(input);
+    } else if (op_name == "Elu") {
+      return (input > 0.0f) ? input : std::exp(input) - 1;
+    } else if (op_name == "Selu") {
+      return (input > 0.0f) ? kSeluScale * input
+                            : kSeluScale * kSeluAlpha * (std::exp(input) - 1);
+    } else if (op_name == "Softsign") {
+      return input / (std::abs(input) + 1);
+    } else if (op_name == "Softplus") {
+      return std::log(std::exp(input) + 1);
     }
     EXPECT_TRUE(false);
     return 0;
   };
 
+  // Get list of ops to test.
+  std::vector<string> ops_to_test;
+  // Add all ops supported by ConvertUnary.
+  auto* map = ActivationTypeMap();
+  ops_to_test.reserve(map->size());
+  for (auto& pair : *map) {
+    ops_to_test.push_back(pair.first);
+  }
+  // Add other activation ops to test.
+  ops_to_test.push_back("Relu6");
+  ops_to_test.push_back("LeakyRelu");
   // Ok.
-  for (const string& op_name :
-       {"LeakyRelu", "Relu", "Relu6", "Sigmoid", "Tanh"}) {
+  for (string op_name : ops_to_test) {
     Reset();
     NodeDef node_def = get_act_nodedef(op_name);
     AddTestTensor("input", {1, 2, 3});
@@ -2536,13 +2570,18 @@ TEST_F(OpConverterTest, ConvertActivation) {
     TF_EXPECT_OK(GetTensorOrWeights("my_act", &output));
     ASSERT_TRUE(output.is_tensor());
     ExpectTrtDimsEqualsArray({1, 2, 3}, output.tensor()->getDimensions());
+
+    // Certain activations should set quantization range automatically.
+    auto ranges = quantization_ranges();
     if (op_name == "Relu6") {
-      // Relu6 should set quantization range automatically.
-      auto ranges = quantization_ranges();
       EXPECT_EQ(ranges[output.tensor()], 6.0f);
+    } else if (op_name == "Sigmoid" || op_name == "Tanh" ||
+               op_name == "Softsign") {
+      EXPECT_EQ(ranges[output.tensor()], 1.0f);
     }
 
-    const std::vector<float> input = {-100, -2, -1, 0, 1, 100};
+    // std::exp in Softplus will overflow for input > 88
+    const std::vector<float> input = {-100, -2, -1, 0, 1, 88};
     const DataVec input_data{{"input", test::AsTensor<float>(input)}};
     DataVec output_data{{"my_act", ConstructTensor<float>(6)}};
     BuildAndRun(input_data, &output_data);
@@ -5197,6 +5236,125 @@ TEST_F(OpConverterTest, ConvertSpaceToDepth) {
   TestConvertSpaceToDepth<DT_HALF>(this);
   TestConvertSpaceToDepth<DT_INT32>(this);
 }
+
+#if IS_TRT_VERSION_GE(5, 1, 0, 0)
+// Get the NodeDef for ClipByValue.
+NodeDef GetClipByValueNodeDef(DataType dtype) {
+  Scope s = Scope::NewRootScope();
+  auto t = ops::Placeholder(s.WithOpName("t"), dtype);
+  auto clip_value_min = ops::Placeholder(s.WithOpName("clip_value_min"), dtype);
+  auto clip_value_max = ops::Placeholder(s.WithOpName("clip_value_max"), dtype);
+  auto clip = ops::ClipByValue(s.WithOpName("my_clip"), t, clip_value_min,
+                               clip_value_max);
+  return clip.operation.node()->def();
+}
+
+template <DataType dtype>
+void TestConvertClipByValue(OpConverterTest* test) {
+  typedef typename EnumToDataType<dtype>::Type CType;
+
+  struct TestParams {
+    std::vector<int> dims;
+    std::vector<CType> input_value;
+    CType clip_value_min;
+    CType clip_value_max;
+    std::vector<CType> expected_output;
+  };
+
+  const std::vector<CType> common_input = InitTestVector<CType>(6);
+  std::vector<TestParams> params = {
+      {
+          /*dims=*/{1, 2, 3},
+          /*input_value=*/common_input,
+          /*clip_value_min=*/CType(2),
+          /*clip_value_max=*/CType(5),
+          /*expected_output=*/{CType(2), CType(2), CType(2), CType(3), CType(4),
+                               CType(5)},
+      },
+      {
+          /*dims=*/{2, 1, 3},
+          /*input_value=*/common_input,
+          /*clip_value_min=*/CType(-1),
+          /*clip_value_max=*/CType(8),
+          /*expected_output=*/common_input,
+      },
+  };
+
+  for (int i = 0; i < params.size(); ++i) {
+    test->Reset();
+
+    NodeDef node_def = GetClipByValueNodeDef(dtype);
+    test->AddTestTensor("t", params[i].dims, 1, TfDataTypeToTrt(dtype));
+    test->AddTestWeights<CType>("clip_value_min", {1},
+                                {params[i].clip_value_min});
+    test->AddTestWeights<CType>("clip_value_max", {1},
+                                {params[i].clip_value_max});
+    test->RunValidationAndConversion(node_def);
+
+    TRT_TensorOrWeights output;
+    TF_EXPECT_OK(test->GetTensorOrWeights("my_clip", &output));
+    EXPECT_TRUE(output.is_tensor());
+    ExpectTrtDimsEqualsArray(params[i].dims, output.tensor()->getDimensions());
+
+    DataVec input_data{{"t", test::AsTensor<CType>(params[i].input_value)}};
+    DataVec output_data{
+        {"my_clip", ConstructTensor<CType>(params[i].expected_output.size())}};
+    test->BuildAndRun(input_data, &output_data, dtype == DT_HALF
+                                                    ? TrtPrecisionMode::FP16
+                                                    : TrtPrecisionMode::FP32);
+    EXPECT_THAT(GetSpanForData<CType>(output_data[0]),
+                ElementsAreArray(params[i].expected_output));
+  }
+}
+
+TEST_F(OpConverterTest, ConvertClipByValue) {
+  {
+    // Input list is empty, should fail.
+    NodeDef node_def = MakeNodeDef("my_clip", "ClipByValue", {});
+    RunValidationAndConversion(
+        node_def, error::INVALID_ARGUMENT,
+        "ClipByValue got 0 inputs but expected 3, at my_clip");
+  }
+  {
+    // Input is a weight, should fail.
+    Reset();
+    NodeDef node_def = GetClipByValueNodeDef(DT_FLOAT);
+    AddTestWeights<float>("t", {1, 2, 3}, {1, 2, 3, 4, 5, 6});
+    AddTestWeights<float>("clip_value_min", {1}, {1});
+    AddTestWeights<float>("clip_value_max", {1}, {5});
+    RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
+                               "The input \"t\" for ClipByValue must be a "
+                               "tensor, at my_clip");
+  }
+  {
+    // Clip min is a tensor, should fail.
+    Reset();
+    NodeDef node_def = GetClipByValueNodeDef(DT_FLOAT);
+    AddTestTensor("t", {1, 2, 3});
+    AddTestTensor("clip_value_min", {1});
+    AddTestWeights<float>("clip_value_max", {1}, {1});
+    RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
+                               "The input \"clip_value_min\" for ClipByValue "
+                               "must be a constant, at my_clip");
+  }
+  {
+    // Clip max is a tensor, should fail.
+    Reset();
+    NodeDef node_def = GetClipByValueNodeDef(DT_FLOAT);
+    AddTestTensor("t", {1, 2, 3});
+    AddTestWeights<float>("clip_value_min", {1}, {1});
+    AddTestTensor("clip_value_max", {1});
+    RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
+                               "The input \"clip_value_max\" for ClipByValue "
+                               "must be a constant, at my_clip");
+  }
+
+  TestConvertClipByValue<DT_FLOAT>(this);
+  TestConvertClipByValue<DT_HALF>(this);
+  // TRT does not support INT32 for this layer.
+  // TestConvertClipByValue<DT_INT32>(this);
+}
+#endif // IS_TRT_VERSION_GE(5, 1, 0, 0)
 
 }  // namespace convert
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -5351,8 +5351,6 @@ TEST_F(OpConverterTest, ConvertClipByValue) {
 
   TestConvertClipByValue<DT_FLOAT>(this);
   TestConvertClipByValue<DT_HALF>(this);
-  // TRT does not support INT32 for this layer.
-  // TestConvertClipByValue<DT_INT32>(this);
 }
 #endif // IS_TRT_VERSION_GE(5, 1, 2, 0)
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -5237,7 +5237,7 @@ TEST_F(OpConverterTest, ConvertSpaceToDepth) {
   TestConvertSpaceToDepth<DT_INT32>(this);
 }
 
-#if IS_TRT_VERSION_GE(5, 1, 0, 0)
+#if IS_TRT_VERSION_GE(5, 1, 2, 0)
 // Get the NodeDef for ClipByValue.
 NodeDef GetClipByValueNodeDef(DataType dtype) {
   Scope s = Scope::NewRootScope();
@@ -5354,7 +5354,7 @@ TEST_F(OpConverterTest, ConvertClipByValue) {
   // TRT does not support INT32 for this layer.
   // TestConvertClipByValue<DT_INT32>(this);
 }
-#endif // IS_TRT_VERSION_GE(5, 1, 0, 0)
+#endif // IS_TRT_VERSION_GE(5, 1, 2, 0)
 
 }  // namespace convert
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -2490,10 +2490,9 @@ TEST_F(OpConverterTest, ConvertActivation) {
     Scope s = Scope::NewRootScope();
     auto input = ops::Placeholder(s.WithOpName("input"), DT_FLOAT);
     if (op_name == "LeakyRelu") {
-      auto act =
-          ops::internal::LeakyRelu(
-              s.WithOpName("my_act"), input,
-              ops::internal::LeakyRelu::Alpha(kLeakyReluAlpha));
+      auto act = ops::internal::LeakyRelu(
+          s.WithOpName("my_act"), input,
+          ops::internal::LeakyRelu::Alpha(kLeakyReluAlpha));
       return act.operation.node()->def();
     } else if (op_name == "Relu") {
       auto act = ops::Relu(s.WithOpName("my_act"), input);
@@ -5352,7 +5351,7 @@ TEST_F(OpConverterTest, ConvertClipByValue) {
   TestConvertClipByValue<DT_FLOAT>(this);
   TestConvertClipByValue<DT_HALF>(this);
 }
-#endif // IS_TRT_VERSION_GE(5, 1, 2, 0)
+#endif  // IS_TRT_VERSION_GE(5, 1, 2, 0)
 
 }  // namespace convert
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -2561,7 +2561,7 @@ TEST_F(OpConverterTest, ConvertActivation) {
   ops_to_test.push_back("Relu6");
   ops_to_test.push_back("LeakyRelu");
   // Ok.
-  for (string op_name : ops_to_test) {
+  for (const string& op_name : ops_to_test) {
     Reset();
     NodeDef node_def = get_act_nodedef(op_name);
     AddTestTensor("input", {1, 2, 3});
@@ -4093,7 +4093,7 @@ TEST_F(OpConverterTest, ConvertUnary) {
   // Add other unary ops to test.
   ops_to_test.push_back("Rsqrt");
   // Ok.
-  for (string op_name : ops_to_test) {
+  for (const string& op_name : ops_to_test) {
     Reset();
     NodeDef node_def = get_unary_nodedef(op_name);
     AddTestTensor("input", {1, 2, 3});


### PR DESCRIPTION
* The following ops are now supported for TRT >= 5.1.2: ClipByValue, Elu, Selu, Softsign, Softplus
* Relu6 and LeakyRelu will use the new accelerated IActivationLayer implementations if TRT 5.1.2+ is present
* ConvertActivation now uses `ActivationTypeMap()` similar to how ConvertUnary does.
* Unit tests for all new ops