### PR TITLE
Update docs for create_local_cluster

### DIFF
--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -2715,7 +2715,8 @@ def create_local_cluster(num_workers,
 
   Read more at https://www.tensorflow.org/guide/extend/architecture
 
-  TODO: image from https://www.tensorflow.org/images/diag1.svg
+  ![components](https://www.tensorflow.org/images/diag1.svg "components")
+
 
   Figure illustrates the interaction of these components.
   "/job:worker/task:0" and "/job:ps/task:0" are both tasks with worker services.

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -2708,6 +2708,19 @@ def create_local_cluster(num_workers,
                          ps_config=None):
   """Create and start local servers and return the associated `Server` objects.
 
+  "PS" stands for "parameter server": a task responsible for storing and
+  updating the model's parameters. Other tasks send updates to these parameters
+  as they work on optimizing the parameters. This particular division of labor
+  between tasks is not required, but is common for distributed training.
+
+  Read more at https://www.tensorflow.org/guide/extend/architecture
+
+  TODO: image from https://www.tensorflow.org/images/diag1.svg
+
+  Figure 2 illustrates the interaction of these components.
+  "/job:worker/task:0" and "/job:ps/task:0" are both tasks with worker services.
+
+
   Example:
   ```python
   workers, _ = tf.test.create_local_cluster(num_workers=2, num_ps=2)

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -2717,7 +2717,7 @@ def create_local_cluster(num_workers,
 
   TODO: image from https://www.tensorflow.org/images/diag1.svg
 
-  Figure 2 illustrates the interaction of these components.
+  Figure illustrates the interaction of these components.
   "/job:worker/task:0" and "/job:ps/task:0" are both tasks with worker services.
 
 
@@ -2744,9 +2744,9 @@ def create_local_cluster(num_workers,
     num_ps: Number of PS servers to start.
     protocol: Communication protocol.  Allowed values are documented in the
       documentation of `tf.train.Server`.
-    worker_config: (optional) ConfigProto to initialize workers. Can be used to
+    worker_config: (optional) `tf.ConfigProto` to initialize workers. Can be used to
       instantiate multiple devices etc.
-    ps_config: (optional) ConfigProto to initialize PS servers.
+    ps_config: (optional) `tf.ConfigProto` to initialize PS servers.
 
   Returns:
     A tuple `(worker_servers, ps_servers)`.  `worker_servers` is a list

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -2742,10 +2742,10 @@ def create_local_cluster(num_workers,
   Args:
     num_workers: Number of worker servers to start.
     num_ps: Number of PS servers to start.
-    protocol: Communication protocol.  Allowed values are documented in the
+    protocol: Communication protocol. Allowed values are documented in the
       documentation of `tf.train.Server`.
-    worker_config: (optional) `tf.ConfigProto` to initialize workers. Can be used to
-      instantiate multiple devices etc.
+    worker_config: (optional) `tf.ConfigProto` to initialize workers. Can be
+      used to instantiate multiple devices etc.
     ps_config: (optional) `tf.ConfigProto` to initialize PS servers.
 
   Returns:


### PR DESCRIPTION

WRONG
- currently docs links to `tf.train.Server` that does not exist anymore

TODO:
- [x] add image in a proper way
- [ ] fix a link to architecture page


cc @dynamicwebpaige 