### PR TITLE
Update docs for tf.linalg.triangular_solve

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_MatrixTriangularSolve.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_MatrixTriangularSolve.pbtxt
@@ -74,7 +74,8 @@ x
 #        [ 2.6666665 ],
 #        [-1.3333331 ]], dtype=float32)>
 
-a@x
+# in python3 one can use `a@x`
+tf.matmul(a, x)
 # <tf.Tensor: id=263, shape=(4, 1), dtype=float32, numpy=
 # array([[4.       ],
 #        [2.       ],

--- a/tensorflow/core/api_def/base_api/api_def_MatrixTriangularSolve.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_MatrixTriangularSolve.pbtxt
@@ -36,9 +36,8 @@ Equivalent to scipy.linalg.solve_triangular
 @end_compatibility
 END
   }
-  summary: "Solves systems of linear equations with upper or lower triangular matrices by"
+  summary: "Solves systems of linear equations with upper or lower triangular matrices by backsubstitution."
   description: <<END
-backsubstitution.
 
 `matrix` is a tensor of shape `[..., M, M]` whose inner-most 2 dimensions form
 square matrices. If `lower` is `True` then the strictly upper triangular part

--- a/tensorflow/core/api_def/base_api/api_def_MatrixTriangularSolve.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_MatrixTriangularSolve.pbtxt
@@ -52,5 +52,34 @@ The output is a tensor of shape `[..., M, K]`. If `adjoint` is
 If `adjoint` is `False` then the strictly then the  innermost matrices in
 `output` satisfy matrix equations
 `adjoint(matrix[..., i, k]) * output[..., k, j] = rhs[..., i, j]`.
+
+Example:
+```python
+
+a = tf.constant([[3,  0,  0,  0],
+                 [2,  1,  0,  0],
+                 [1,  0,  1,  0],
+                 [1,  1,  1,  1]], dtype=tf.float32)
+
+b = tf.constant([[4],
+                 [2],
+                 [4],
+                 [2]], dtype=tf.float32)
+
+x = tf.linalg.triangular_solve(a, b, lower=True)
+x
+# <tf.Tensor: id=257, shape=(4, 1), dtype=float32, numpy=
+# array([[ 1.3333334 ],
+#        [-0.66666675],
+#        [ 2.6666665 ],
+#        [-1.3333331 ]], dtype=float32)>
+
+a@x
+# <tf.Tensor: id=263, shape=(4, 1), dtype=float32, numpy=
+# array([[4.       ],
+#        [2.       ],
+#        [4.       ],
+#        [1.9999999]], dtype=float32)>
+```
 END
 }


### PR DESCRIPTION
Not sure if `api_def_MatrixTriangularSolve.pbtxt` is going to be rendered as I expect it to be rendered

As a part of TensorFlow docs sprints from Munich.

cc @dynamicwebpaige