### PR TITLE
[XLA on GPU] reduce noise for autotune in multi-stream environment

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
@@ -136,6 +136,7 @@ Status GpuExecutable::ExecuteThunks(
     // thunks to finish.  This reduces noise and thus the probability of
     // choosing a suboptimal algorithm.
     if (thunk->WillAutotuneKernel(stream)) {
+      main_stream->ThenWaitFor(&sub_streams);
       TF_RETURN_IF_ERROR(main_stream->BlockHostUntilDone());
     }
 


### PR DESCRIPTION
Before this change, activities on sub-streams are ignored when `WillAutotuneKernel` is true, which is not consistent with its design.