### PR TITLE
Fix doc not displayed properly issue (block) in "predict" function of keras

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -1048,7 +1048,7 @@ class Model(network.Network):
     Computation is done in batches.
 
     Arguments:
-         x: Input samples. It could be:
+        x: Input samples. It could be:
           - A Numpy array (or array-like), or a list of arrays
             (in case the model has multiple inputs).
           - A TensorFlow tensor, or a list of tensors


### PR DESCRIPTION
This fix fixes the issue raised in #27583 where the doc
in "predict" function of keras is not displayed properly. (full
block instead of list).
The reason of the issue seems to be casue by the unaligned
first line: `x: Input samples.` should be prefixed by 4 spaces (not 5).

This fix fixes #27583 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>