### PR TITLE
tflite/tools/make: add missing cflags override for linux

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -199,11 +199,11 @@ $(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(TF_LITE_CC_SRCS))))
 BENCHMARK_OBJS := $(addprefix $(OBJDIR), \
 $(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(BENCHMARK_SRCS))))
 
-# For normal manually-created TensorFlow C++ source files.
+# For normal manually-created TensorFlow Lite C++ source files.
 $(OBJDIR)%.o: %.cc
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
-# For normal manually-created TensorFlow C++ source files.
+# For normal manually-created TensorFlow Lite C source files.
 $(OBJDIR)%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -57,7 +57,7 @@ LIBS := \
 # these settings are for the target compiler.
 CXXFLAGS := -O3 -DNDEBUG -fPIC
 CXXFLAGS += $(EXTRA_CXXFLAGS)
-CCFLAGS := ${CXXFLAGS}
+CFLAGS := ${CXXFLAGS}
 CXXFLAGS += --std=c++11
 CFLAGS :=
 LDOPTS := -L/usr/local/lib
@@ -206,7 +206,7 @@ $(OBJDIR)%.o: %.cc
 # For normal manually-created TensorFlow C++ source files.
 $(OBJDIR)%.o: %.c
 	@mkdir -p $(dir $@)
-	$(CC) $(CCFLAGS) $(INCLUDES) -c $< -o $@
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 # The target that's compiled if there's no command-line arguments.
 all: $(LIB_PATH)  $(MINIMAL_BINARY) $(BENCHMARK_BINARY)

--- a/tensorflow/lite/tools/make/targets/aarch64_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/aarch64_makefile.inc
@@ -11,7 +11,7 @@ ifeq ($(TARGET),aarch64)
     -ftree-vectorize \
     -fPIC
 
-  CCFLAGS += \
+  CFLAGS += \
     -march=armv8-a \
     -funsafe-math-optimizations \
     -ftree-vectorize \

--- a/tensorflow/lite/tools/make/targets/ios_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/ios_makefile.inc
@@ -32,7 +32,7 @@ ifeq ($(TARGET), ios)
 		-arch $(TARGET_ARCH) \
 		-O3
 	CFLAGS += -miphoneos-version-min=$(MIN_SDK_VERSION) \
-	       	-fembed-bitcode \
+		-fembed-bitcode \
 		-mno-thumb \
 		-isysroot \
 		${IPHONEOS_SYSROOT} \

--- a/tensorflow/lite/tools/make/targets/ios_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/ios_makefile.inc
@@ -31,8 +31,8 @@ ifeq ($(TARGET), ios)
 		${IPHONEOS_SYSROOT} \
 		-arch $(TARGET_ARCH) \
 		-O3
-	CCFLAGS += -miphoneos-version-min=$(MIN_SDK_VERSION) \
-		-fembed-bitcode \
+	CFLAGS += -miphoneos-version-min=$(MIN_SDK_VERSION) \
+	       	-fembed-bitcode \
 		-mno-thumb \
 		-isysroot \
 		${IPHONEOS_SYSROOT} \

--- a/tensorflow/lite/tools/make/targets/linux_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/linux_makefile.inc
@@ -4,6 +4,10 @@ ifeq ($(TARGET), linux)
     -fPIC \
     -DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK \
     -pthread
+  CCFLAGS += \
+    -fPIC \
+    -DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK \
+    -pthread    
   # TODO(petewarden): In the future we may want to add architecture-specific
   # flags like -msse4.2
 	LIBS += -ldl

--- a/tensorflow/lite/tools/make/targets/linux_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/linux_makefile.inc
@@ -4,7 +4,7 @@ ifeq ($(TARGET), linux)
     -fPIC \
     -DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK \
     -pthread
-  CCFLAGS += \
+  CFLAGS += \
     -fPIC \
     -DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK \
     -pthread    

--- a/tensorflow/lite/tools/make/targets/rpi_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/rpi_makefile.inc
@@ -13,7 +13,7 @@ ifeq ($(TARGET),rpi)
       -ftree-vectorize \
       -fPIC
 
-    CCFLAGS += \
+    CFLAGS += \
       -march=armv7-a \
       -mfpu=neon-vfpv4 \
       -funsafe-math-optimizations \
@@ -37,7 +37,7 @@ ifeq ($(TARGET),rpi)
       -ftree-vectorize \
       -fPIC
 
-    CCFLAGS += \
+    CFLAGS += \
       -march=armv6 \
       -mfpu=vfp \
       -funsafe-math-optimizations \


### PR DESCRIPTION
Add missing CC flags for linux makefiles, without this linking tensorflow in a shared library will fail with:
```
/usr/bin/ld: tensorflow-1.13.1/tensorflow/lite/tools/make/gen/linux_x86_64/lib/libtensorflow-lite.a(fftsg.o): relocation R_X86_64_PC32 against symbol `cftmdl1' can not be used when making a shared object; recompile with -fPIC
```

/cc @dansitu