### PR TITLE
Fix `cmake` build error in Android example

### DIFF
--- a/tensorflow/examples/android/build.gradle
+++ b/tensorflow/examples/android/build.gradle
@@ -94,7 +94,7 @@ android {
             }
             externalNativeBuild {
                 cmake {
-                    arguments '-DANDROID_TOOLCHAIN=gcc', '-DANDROID_STL=gnustl_static'
+                    arguments '-DANDROID_STL=c++_static'
                 }
             }
         }


### PR DESCRIPTION
1. Remove `gcc`(https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md)
2. Change `gnustl_static` to `c++_static` (https://developer.android.com/ndk/guides/cpp-support.html)