### PR TITLE
Fix symlinks in lib_package

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -55,6 +55,7 @@ def register_extension_info(**kwargs):
 # Also update tensorflow/core/public/version.h
 # and tensorflow/tools/pip_package/setup.py
 VERSION = "1.13.1"
+VERSION_MAJOR = VERSION.split(".")[0]
 
 def if_v2(a):
     return select({
@@ -395,7 +396,7 @@ def tf_binary_additional_srcs(fullversion = False):
     if fullversion:
         suffix = "." + VERSION
     else:
-        suffix = "." + VERSION.split(".")[0]
+        suffix = "." + VERSION_MAJOR
 
     return if_static(
         extra_deps = [],
@@ -408,33 +409,27 @@ def tf_binary_additional_srcs(fullversion = False):
     )
 
 def tf_binary_additional_data_deps():
-    longsuffix = "." + VERSION
-    suffix = "." + VERSION.split(".")[0]
-
     return if_static(
         extra_deps = [],
         macos = [
             clean_dep("//tensorflow:libtensorflow_framework.dylib"),
-            clean_dep("//tensorflow:libtensorflow_framework%s.dylib" % suffix),
-            clean_dep("//tensorflow:libtensorflow_framework%s.dylib" % longsuffix),
+            clean_dep("//tensorflow:libtensorflow_framework.%s.dylib" % VERSION_MAJOR),
+            clean_dep("//tensorflow:libtensorflow_framework.%s.dylib" % VERSION),
         ],
         otherwise = [
             clean_dep("//tensorflow:libtensorflow_framework.so"),
-            clean_dep("//tensorflow:libtensorflow_framework.so%s" % suffix),
-            clean_dep("//tensorflow:libtensorflow_framework.so%s" % longsuffix),
+            clean_dep("//tensorflow:libtensorflow_framework.so.%s" % VERSION_MAJOR),
+            clean_dep("//tensorflow:libtensorflow_framework.so.%s" % VERSION),
         ],
     )
 
 # Helper function for the per-OS tensorflow libraries and their version symlinks
 def tf_shared_library_deps():
-    longsuffix = "." + VERSION
-    suffix = "." + VERSION.split(".")[0]
-
     return select({
         clean_dep("//tensorflow:macos_with_framework_shared_object"): [
             clean_dep("//tensorflow:libtensorflow.dylib"),
-            clean_dep("//tensorflow:libtensorflow%s.dylib" % suffix),
-            clean_dep("//tensorflow:libtensorflow%s.dylib" % longsuffix),
+            clean_dep("//tensorflow:libtensorflow.%s.dylib" % VERSION_MAJOR),
+            clean_dep("//tensorflow:libtensorflow.%s.dylib" % VERSION),
         ],
         clean_dep("//tensorflow:macos"): [],
         clean_dep("//tensorflow:windows"): [
@@ -443,8 +438,8 @@ def tf_shared_library_deps():
         ],
         clean_dep("//tensorflow:framework_shared_object"): [
             clean_dep("//tensorflow:libtensorflow.so"),
-            clean_dep("//tensorflow:libtensorflow.so%s" % suffix),
-            clean_dep("//tensorflow:libtensorflow.so%s" % longsuffix),
+            clean_dep("//tensorflow:libtensorflow.so.%s" % VERSION_MAJOR),
+            clean_dep("//tensorflow:libtensorflow.so.%s" % VERSION),
         ],
         "//conditions:default": [],
     }) + tf_binary_additional_srcs()

--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -5,7 +5,7 @@ package(default_visibility = ["//visibility:private"])
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@local_config_syslibs//:build_defs.bzl", "if_not_system_lib")
-load("//tensorflow:tensorflow.bzl", "tf_binary_additional_data_deps", "tf_shared_library_deps", "if_cuda", "if_not_windows")
+load("//tensorflow:tensorflow.bzl", "VERSION", "VERSION_MAJOR", "if_cuda", "if_not_windows", "tf_binary_additional_data_deps", "tf_shared_library_deps")
 load("//third_party/mkl:build_defs.bzl", "if_mkl")
 
 genrule(
@@ -34,12 +34,12 @@ pkg_tar(
 
 pkg_tar(
     name = "libtensorflow_jni",
-    extension = "tar.gz",
-    files = [
+    srcs = [
         "include/tensorflow/jni/LICENSE",
         "//:LICENSE",
         "//tensorflow/java:libtensorflow_jni",
     ],
+    extension = "tar.gz",
     # Mark as "manual" till
     # https://github.com/bazelbuild/bazel/issues/2352
     # and https://github.com/bazelbuild/bazel/issues/1580
@@ -52,13 +52,17 @@ pkg_tar(
 # Shared objects that all TensorFlow libraries depend on.
 pkg_tar(
     name = "common_deps",
-    files = tf_binary_additional_data_deps(),
+    srcs = ["//tensorflow:tensorflow_framework"],
+    symlinks = {
+        "libtensorflow_framework.so": "libtensorflow_framework.so.%s" % VERSION_MAJOR,
+        "libtensorflow_framework.so.%s" % VERSION_MAJOR: "libtensorflow.so_framework.%s" % VERSION,
+    },
     tags = ["manual"],
 )
 
 pkg_tar(
     name = "cheaders",
-    files = [
+    srcs = [
         "//tensorflow/c:headers",
     ],
     package_dir = "include/tensorflow/c",
@@ -72,7 +76,7 @@ pkg_tar(
 
 pkg_tar(
     name = "eager_cheaders",
-    files = [
+    srcs = [
         "//tensorflow/c/eager:headers",
     ],
     package_dir = "include/tensorflow/c/eager",
@@ -86,8 +90,12 @@ pkg_tar(
 
 pkg_tar(
     name = "clib",
-    srcs = tf_shared_library_deps(),
+    srcs = ["//tensorflow"],
     package_dir = "lib",
+    symlinks = {
+        "lib/libtensorflow.so": "lib/libtensorflow.so.%s" % VERSION_MAJOR,
+        "lib/libtensorflow.so.%s" % VERSION_MAJOR: "lib/libtensorflow.so.%s" % VERSION,
+    },
     # Mark as "manual" till
     # https://github.com/bazelbuild/bazel/issues/2352
     # and https://github.com/bazelbuild/bazel/issues/1580
@@ -99,7 +107,7 @@ pkg_tar(
 
 pkg_tar(
     name = "clicenses",
-    files = [
+    srcs = [
         ":include/tensorflow/c/LICENSE",
         "//:LICENSE",
     ],


### PR DESCRIPTION
As of https://github.com/tensorflow/tensorflow/pull/27493, lib_package
had the libraries three times instead of symlinks. This uses pkg_tar's
symlink arg to set things correctly.

Also define VERSION_MAJOR for cleanliness and bazel renamed the 'files'
arg in pkg_tar to 'srcs'.

Signed-off-by: Jason Zaman <jason@perfinion.com>