### PR TITLE
fix saved_model_cli to accept string feature as input

### DIFF
--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -484,6 +484,7 @@ def _create_example_string(example_dict):
       example.features.feature[feature_name].float_list.value.extend(
           feature_list)
     elif isinstance(feature_list[0], str):
+      feature_list = list(map(lambda x: x.encode(), feature_list))
       example.features.feature[feature_name].bytes_list.value.extend(
           feature_list)
     elif isinstance(feature_list[0], integer_types):


### PR DESCRIPTION
fix the argument parsing for `--input_examples` so that it accepts the feature with string value. Previously it always complains:

 `TypeError: 'some string' has type str, but expected one of: bytes`.

This is because it is try to append the bytes list inside a tf Example, with string list. 

