### PR TITLE
Explicitly pass the genfiles directory to cc_op_gen.

### DIFF
--- a/tensorflow/cc/framework/cc_op_gen.h
+++ b/tensorflow/cc/framework/cc_op_gen.h
@@ -24,7 +24,8 @@ namespace tensorflow {
 
 /// Result is written to files dot_h and dot_cc.
 void WriteCCOps(const OpList& ops, const ApiDefMap& api_def_map,
-                const string& dot_h_fname, const string& dot_cc_fname);
+                const string& dot_h_fname, const string& dot_cc_fname,
+                const string& genfiles_dir);
 
 }  // namespace tensorflow
 

--- a/tensorflow/cc/framework/cc_op_gen_main.cc
+++ b/tensorflow/cc/framework/cc_op_gen_main.cc
@@ -29,7 +29,8 @@ namespace {
 
 void PrintAllCCOps(const std::string& dot_h, const std::string& dot_cc,
                    bool include_internal,
-                   const std::vector<string>& api_def_dirs) {
+                   const std::vector<string>& api_def_dirs,
+                   const std::string& genfiles_dir) {
   OpList ops;
   OpRegistry::Global()->Export(include_internal, &ops);
   ApiDefMap api_def_map(ops);
@@ -49,7 +50,7 @@ void PrintAllCCOps(const std::string& dot_h, const std::string& dot_cc,
 
   api_def_map.UpdateDocs();
 
-  WriteCCOps(ops, api_def_map, dot_h, dot_cc);
+  WriteCCOps(ops, api_def_map, dot_h, dot_cc, genfiles_dir);
 }
 
 }  // namespace
@@ -57,13 +58,13 @@ void PrintAllCCOps(const std::string& dot_h, const std::string& dot_cc,
 
 int main(int argc, char* argv[]) {
   tensorflow::port::InitMain(argv[0], &argc, &argv);
-  if (argc != 5) {
+  if (argc != 6) {
     for (int i = 1; i < argc; ++i) {
       fprintf(stderr, "Arg %d = %s\n", i, argv[i]);
     }
     fprintf(stderr,
             "Usage: %s out.h out.cc include_internal "
-            "api_def_dirs1,api_def_dir2 ...\n"
+            "api_def_dirs1,api_def_dir2... genfiles_dir\n"
             "  include_internal: 1 means include internal ops\n",
             argv[0]);
     exit(1);
@@ -72,6 +73,6 @@ int main(int argc, char* argv[]) {
   bool include_internal = tensorflow::StringPiece("1") == argv[3];
   std::vector<tensorflow::string> api_def_dirs = tensorflow::str_util::Split(
       argv[4], ",", tensorflow::str_util::SkipEmpty());
-  tensorflow::PrintAllCCOps(argv[1], argv[2], include_internal, api_def_dirs);
+  tensorflow::PrintAllCCOps(argv[1], argv[2], include_internal, api_def_dirs, argv[5]);
   return 0;
 }

--- a/tensorflow/cc/framework/cc_op_gen_test.cc
+++ b/tensorflow/cc/framework/cc_op_gen_test.cc
@@ -93,7 +93,7 @@ void GenerateCcOpFiles(Env* env, const OpList& ops,
   const auto internal_h_file_path = io::JoinPath(tmpdir, "test_internal.h");
   const auto internal_cc_file_path = io::JoinPath(tmpdir, "test_internal.cc");
 
-  WriteCCOps(ops, api_def_map, h_file_path, cc_file_path);
+  WriteCCOps(ops, api_def_map, h_file_path, cc_file_path, "");
 
   TF_ASSERT_OK(ReadFileToString(env, h_file_path, h_file_text));
   TF_ASSERT_OK(

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -700,7 +700,7 @@ def tf_gen_op_wrapper_cc(
         tools = [":" + tool] + tf_binary_additional_srcs(),
         cmd = ("$(location :" + tool + ") $(location :" + out_ops_file + ".h) " +
                "$(location :" + out_ops_file + ".cc) " +
-               str(include_internal_ops) + " " + api_def_args_str),
+               str(include_internal_ops) + " " + api_def_args_str + " $(GENDIR)/"),
     )
 
 # Given a list of "op_lib_names" (a list of files in the ops directory


### PR DESCRIPTION
This makes path computation code shorter and more robust. In particular, it makes things work under Bazel flag --incompatible_merge_genfiles_directory (https://github.com/bazelbuild/bazel/issues/6761).