### PR TITLE
pip_package: Remove duplicated libtensorflow_framework.so

### DIFF
--- a/tensorflow/python/platform/sysconfig.py
+++ b/tensorflow/python/platform/sysconfig.py
@@ -22,6 +22,7 @@ import os.path as _os_path
 
 from tensorflow.python.framework.versions import CXX11_ABI_FLAG as _CXX11_ABI_FLAG
 from tensorflow.python.framework.versions import MONOLITHIC_BUILD as _MONOLITHIC_BUILD
+from tensorflow.python.framework.versions import VERSION as _VERSION
 from tensorflow.python.util.tf_export import tf_export
 
 
@@ -75,5 +76,5 @@ def get_link_flags():
   flags = []
   if not _MONOLITHIC_BUILD:
     flags.append('-L%s' % get_lib())
-    flags.append('-ltensorflow_framework')
+    flags.append('-l:libtensorflow_framework.so.%s' % _VERSION.split(".")[0])
   return flags

--- a/tensorflow/tools/pip_package/MANIFEST.in
+++ b/tensorflow/tools/pip_package/MANIFEST.in
@@ -3,7 +3,7 @@ recursive-include * *.py
 recursive-include * *.pyd
 recursive-include * *.pd
 recursive-include * *.so
-recursive-include * *.so.*
+recursive-include * *.so.[0-9]
 recursive-include * *.dylib
 recursive-include * *.dll
 recursive-include * *.lib

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -135,6 +135,9 @@ function prepare_src() {
   cp tensorflow/tools/pip_package/MANIFEST.in ${TMPDIR}
   cp tensorflow/tools/pip_package/README ${TMPDIR}
   cp tensorflow/tools/pip_package/setup.py ${TMPDIR}
+
+  rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.so
+  rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.so.[0-9].*
 }
 
 function build_wheel() {


### PR DESCRIPTION
The current pip wheel has libtensorflow_framework.so duplicated three
times with the different versioned libs. The pip wheel is reaching size
limits so needs to be as small as possible. To run, the only requried
lib is libtensorflow_framework.so.1 (since it matches the soname).
Linking when libtensorflow_framework.so exists is done with
gcc -ltensorflow_framework. Since we only have the .so.1, we need to
change the linker flags to gcc -l:libtensorflow_framework.so.1.

Signed-off-by: Jason Zaman <jason@perfinion.com>