### PR TITLE
optimize node placement policy in initialized_value stage.

### DIFF
--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -511,9 +511,10 @@ class Variable(six.with_metaclass(VariableMetaclass,
       has run.
     """
     with ops.init_scope():
-      return control_flow_ops.cond(is_variable_initialized(self),
-                                   self.read_value,
-                                   lambda: self.initial_value)
+      with ops.colocate_with(self):
+        return control_flow_ops.cond(is_variable_initialized(self),
+                                     self.read_value,
+                                     lambda: self.initial_value)
 
   @property
   def initial_value(self):


### PR DESCRIPTION
Optimize node placement policy in initialized_value stage.
Before optimize, the graph is as follows:
![before-optimize](https://user-images.githubusercontent.com/6914481/55848387-49e17f80-5b7f-11e9-985f-396f3e654b40.png)
The variable 'global_step' is placed to ps1, and 'global_step/initial_value' is placed to worker. The 'IsVariableInitialized' and 'cond/read/Switch' nodes will be colocated to 'global_step', the 'cond/Switch_1' will be colocated to 'global_step/initial_value'. The left three nodes are not specified to which device, so they will be placed to ps0 by Placer in default. The placement brings some Send/Recv nodes between ps0 and ps1. So I think we can optimize node placement policy in initialized_value stage by colocate these three nodes with the variable(here is global_step). :)