### PR TITLE
Make sure the executor type same when recursively creating items for a function

### DIFF
--- a/tensorflow/core/kernels/data/parallel_map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/parallel_map_dataset_op_test.cc
@@ -812,7 +812,8 @@ INSTANTIATE_TEST_SUITE_P(ParallelMapDatasetOpTest,
                          ParameterizedParallelMapDatasetOpTest,
                          ::testing::ValuesIn(std::vector<TestCase>(
                              {TestCase1(), TestCase2(), TestCase3(),
-                              TestCase4(), TestCase5(), TestCase6()})));
+                              TestCase4(), TestCase5(), TestCase6(),
+                              TestCase7(), TestCase8()})));
 
 }  // namespace
 }  // namespace data


### PR DESCRIPTION
This PR makes sure the executor types are the same when multiple items are recursively created for a function. 

It fixes a timeout issue in the `ParallelMapDatasetOp` tests. I'm not sure my understanding is correct. 

Taken [TestCase7](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/data/parallel_map_dataset_op_test.cc#L220) as an example, it sets `num_parallel_calls` as same as `thread_num` of `thread_pool_` while `use_inter_op_parallelism = false`. Two items with different types of executor are created for the function `XTimesFour` and `XTimesTwo`, where `XTimesFour` call `XTimesTwo` internally. The executor type of `XTimesFour` is `SINGLE_THREADED_EXECUTOR` and that of `XTimesTwo` is `Default`. This inconsistency causes a timeout issue when running the `XTimesFour` function inside `SingleThreadedExecutorImpl::RunAsync` which calls `ExecutorImpl::RunAsync` to run `XTimesTwo`, because there is no more availale resournce in `thread_pool_` to run `XTimesTwo` in `ExecutorImpl::RunAsync`. 

cc: @jsimsa 