### PR TITLE
Remove numerics check from clip_by_global_norm

### DIFF
--- a/tensorflow/python/kernel_tests/clip_ops_test.py
+++ b/tensorflow/python/kernel_tests/clip_ops_test.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -422,6 +421,7 @@ class ClipTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testClipByGlobalNormInf(self):
+    # Expect all NaNs when global norm is inf.
     with self.session(use_gpu=True):
       x0 = constant_op.constant([-2.0, 0.0, np.inf, 4.0, 0.0, 0.0],
                                 shape=[2, 3])
@@ -429,12 +429,12 @@ class ClipTest(test.TestCase):
       clip_norm = 6.0
 
       ans, norm = clip_ops.clip_by_global_norm([x0, x1], clip_norm)
-      with self.assertRaisesRegexp(errors.InvalidArgumentError, "global norm"):
-        self.evaluate(norm)
-      with self.assertRaisesRegexp(errors.InvalidArgumentError, "global norm"):
-        ans[0].eval()
-      with self.assertRaisesRegexp(errors.InvalidArgumentError, "global norm"):
-        ans[1].eval()
+      tf_ans_1 = ans[0].eval()
+      tf_ans_2 = ans[1].eval()
+      tf_norm = self.evaluate(norm)
+      self.assertAllEqual(tf_norm, float('inf'))
+      self.assertAllEqual(tf_ans_1, np.full([2, 3], float('nan')))
+      self.assertAllEqual(tf_ans_2, np.full([2], float('nan')))
 
   def testClipByAverageNormClipped(self):
     # Norm clipping when average clip_norm < 0.83333333

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -29,7 +29,6 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import gen_nn_ops
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import numerics
 from tensorflow.python.util import deprecation
 from tensorflow.python.util import dispatch
 from tensorflow.python.util.tf_export import tf_export
@@ -241,6 +240,9 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
   If `clip_norm > global_norm` then the entries in `t_list` remain as they are,
   otherwise they're all shrunk by the global ratio.
 
+  If `global_norm == infinity` then the entries in `t_list` are all set to `NaN`
+  to signal that an error occurred.
+
   Any of the entries of `t_list` that are of type `None` are ignored.
 
   This is the correct way to perform gradient clipping (for example, see
@@ -263,7 +265,6 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
 
   Raises:
     TypeError: If `t_list` is not a sequence.
-    InvalidArgumentError: If global norm is not finite.
   """
   if (not isinstance(t_list, collections.Sequence)
       or isinstance(t_list, six.string_types)):
@@ -271,15 +272,18 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
   t_list = list(t_list)
   if use_norm is None:
     use_norm = global_norm(t_list, name)
-  use_norm = numerics.verify_tensor_all_finite(use_norm,
-                                               "Found Inf or NaN global norm.")
 
   with ops.name_scope(name, "clip_by_global_norm",
                       t_list + [clip_norm]) as name:
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
-    scale = clip_norm * math_ops.minimum(
+    scale_for_finite = clip_norm * math_ops.minimum(
         1.0 / use_norm,
         constant_op.constant(1.0, dtype=use_norm.dtype) / clip_norm)
+    scale = array_ops.where(math_ops.is_finite(use_norm),
+                            scale_for_finite,
+                            # Return NaN if use_norm is not finite.
+                            constant_op.constant(float('nan'),
+                                                 dtype=use_norm.dtype))
 
     values = [
         ops.convert_to_tensor(


### PR DESCRIPTION
This changes clip_by_global_norm to return all NaNs instead of throwing an error when global_norm == infinity.

This is the only op in TF that throws an error like this, and it is problematic for (at least) a couple of reasons:
a) it breaks the TF-Debugger workflow, and
b) it breaks automatic loss scaling.

It appears that this was in fact the original plan in https://github.com/tensorflow/tensorflow/pull/21428, but it was changed at the last minute to throw an error instead of returning NaNs.

FYI @reedwm @tfboyd 