### PR TITLE
Disable one more macos test for python35

### DIFF
--- a/tensorflow/python/keras/BUILD
+++ b/tensorflow/python/keras/BUILD
@@ -688,7 +688,10 @@ py_test(
     size = "enormous",
     srcs = ["engine/training_test.py"],
     srcs_version = "PY2AND3",
-    tags = ["notsan"],
+    tags = [
+        "notsan",
+        "no_oss",
+    ],
     deps = [
         ":keras",
         "//tensorflow/python:client_testlib",


### PR DESCRIPTION
Only py2 and wingpus left after this