### PR TITLE
TFTRT: Allow FP16 inputs and outputs. 

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -112,6 +112,32 @@ tf_cuda_cc_test(
     ],
 )
 
+tf_cuda_cc_test(
+    name = "trt_engine_op_test",
+    size = "small",
+    srcs = ["kernels/trt_engine_op_test.cc"],
+    tags = [
+        "no_cuda_on_cpu_tap",
+        "no_windows",
+        "nomac",
+    ],
+    deps = [
+        ":trt_op_kernels",
+        ":trt_op_libs",
+        ":trt_resources",
+        "//tensorflow/cc:cc_ops",
+        "//tensorflow/cc:ops",
+        "//tensorflow/cc:scope",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+        "//tensorflow/core/kernels:ops_testutil",
+    ],
+)
+
 tf_gen_op_libs(
     op_lib_names = [
         "trt_engine_op",

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1589,18 +1589,6 @@ Status AllowDataTypes(const OpConverterParams& params,
   return Status::OK();
 }
 
-TRT_ShapedWeights ConvertFP32ToFP16(TrtWeightStore* store,
-                                    const TRT_ShapedWeights& weights_src) {
-  TRT_ShapedWeights weights =
-      store->GetTempWeights(nvinfer1::DataType::kHALF, weights_src.shape_);
-  const float* src = static_cast<const float*>(weights_src.GetValues());
-  Eigen::half* dst = static_cast<Eigen::half*>(weights.GetValues());
-  for (int64_t i = 0; i < weights_src.count(); i++) {
-    dst[i] = Eigen::half_impl::float_to_half_rtne(src[i]);
-  }
-  return weights;
-}
-
 // ****************************************************************************
 // Constant folding functions for weights.
 // TODO(laigd): we should probably use eigen directly.
@@ -1772,10 +1760,6 @@ Status BinaryTensorOpWeight(OpConverterParams* params,
         params->converter->TransposeTensor(tensor, permutation, &tensor));
   }
 
-  if (params->converter->precision_mode() == TrtPrecisionMode::FP16) {
-    weights = ConvertFP32ToFP16(params->weight_store, weights);
-  }
-
   // Prepare weights
   TRT_ShapedWeights shift_weights(weights.TrtDType());
   TRT_ShapedWeights scale_weights(weights.TrtDType());
@@ -1937,9 +1921,6 @@ Status ConvertConv2DHelper(OpConverterParams* params, int group,
   // num_groups will be 1.
   const int num_groups = (group == 0) ? tensor_dim.d[0] : group;
 
-  if (params->converter->precision_mode() == TrtPrecisionMode::FP16) {
-    weights_rsck = ConvertFP32ToFP16(params->weight_store, weights_rsck);
-  }
   // For conv, TF weights are RSCK, and TRT expects KCRS.
   // For backprop, TF weights are RSKC, and TRT expects CKRS.
   // Therefore, this reorder will work for both cases.
@@ -3038,9 +3019,6 @@ Status ConvertBiasAdd(OpConverterParams* params) {
   }
 
   TRT_ShapedWeights weights = inputs.at(1).weights();
-  if (params->converter->precision_mode() == TrtPrecisionMode::FP16) {
-    weights = ConvertFP32ToFP16(params->weight_store, weights);
-  }
   nvinfer1::ScaleMode mode = nvinfer1::ScaleMode::kCHANNEL;
   if (weights.shape_.d[0] == 1) {
     mode = nvinfer1::ScaleMode::kUNIFORM;

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -425,8 +425,9 @@ bool TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
             const_cast<float*>(input_tensor.flat<float>().data());
         break;
       case nvinfer1::DataType::kHALF:
-        LOG(ERROR) << "FP16 inputs are not supported yet!";
-        return kRetry;
+        buffers[binding_index] =
+            const_cast<Eigen::half*>(input_tensor.flat<Eigen::half>().data());
+        break;
       case nvinfer1::DataType::kINT8:
         LOG(ERROR) << "INT8 inputs are not supported yet!";
         return kRetry;
@@ -480,8 +481,9 @@ bool TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
             const_cast<float*>(output_tensor->flat<float>().data());
         break;
       case nvinfer1::DataType::kHALF:
-        LOG(WARNING) << "half size is not supported yet!";
-        return kRetry;
+        buffers[binding_index] =
+            const_cast<Eigen::half*>(output_tensor->flat<Eigen::half>().data());
+        break;
       case nvinfer1::DataType::kINT8:
         LOG(WARNING) << "int8 is not supported yet!";
         return kRetry;

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
@@ -1,0 +1,98 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <dirent.h>
+#include <string.h>
+#include <fstream>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_resources.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/platform/test.h"
+
+#if GOOGLE_CUDA
+#if GOOGLE_TENSORRT
+
+namespace tensorflow {
+namespace tensorrt {
+
+using ::testing::ElementsAre;
+
+class TRTEngineOpTest : public OpsTestBase {};
+
+TEST_F(TRTEngineOpTest, Basic) {
+  // Create the GPU device.
+  std::unique_ptr<Device> device(
+      DeviceFactory::NewDevice("GPU", {}, "/job:worker/replica:0/task:0"));
+
+  // Create simple TF graph.
+  Scope s = Scope::NewRootScope();
+  auto feed = ops::Placeholder(s.WithOpName("TensorRTInputPH_0"), DT_FLOAT, ops::Placeholder::Shape({1, 2}));
+  auto const_1 = ops::Const(s.WithOpName("const_1"), 1.0f, TensorShape({1, 2}));
+  auto add = ops::Add(s.WithOpName("add"), feed, const_1);
+  ops::Identity(s.WithOpName("TensorRTOutputPH_0"), add);
+
+  // Serialize the graph. TRTEngineOp will convert it using dynamic mode.
+  GraphDef graph_def;
+  s.ToGraphDef(&graph_def);
+  const string segment_string = graph_def.SerializeAsString();
+  std::vector<TensorShapeProto> input_shape_protos(1);
+  TensorShape({1, 2}).AsProto(&input_shape_protos[0]);
+  std::vector<TensorShapeProto> output_shape_protos(1);
+  TensorShape({1, 2}).AsProto(&output_shape_protos[0]);
+
+  // Create the op.
+  SetDevice(DEVICE_GPU, std::move(device));
+  TF_ASSERT_OK(NodeDefBuilder("op", "TRTEngineOp")
+                   .Input(FakeInput(1, DT_FLOAT))
+                   .Attr("input_shapes", input_shape_protos)
+          .Attr("output_shapes", output_shape_protos)
+          .Attr("static_engine", false)
+          .Attr("segment_funcdef_name", "") // no native fallback
+          .Attr("serialized_segment", segment_string)
+          .Attr("calibration_data", "")
+          .Attr("max_cached_engines_count", 1)
+          .Attr("workspace_size_bytes", 1 << 20)
+          .Attr("precision_mode", "FP32")
+          .Attr("use_calibration", false)
+          .Attr("OutT", {DT_FLOAT})
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+
+  // Execute the op.
+  AddInputFromArray<float>(TensorShape({1, 2}), {0.0f, 1.0f});
+  TF_ASSERT_OK(RunOpKernel());
+
+  // Verify the result.
+  // TODO(laigd): OpsTestBase::GetOutput() doesn't work.
+  Tensor* output = context_->mutable_output(0);
+  // Tensor* output = GetOutput(0);
+  const auto& tensor_map = output->flat<float>();
+  const auto span = absl::Span<const float>(tensor_map.data(), tensor_map.size());
+  EXPECT_THAT(span, ElementsAre(1.0f, 2.0f));
+}
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_TENSORRT
+#endif  // GOOGLE_CUDA


### PR DESCRIPTION
This change allows models trained in FP16 precision to be imported using TF-TRT.
Also remove unnecessary conversions of weights from FP32 to FP16 because TRT does this automatically.