### PR TITLE
Porting the Pooling kernel to Tensorflow Lite Micro with MaxPool support

### DIFF
--- a/tensorflow/lite/experimental/micro/kernels/BUILD
+++ b/tensorflow/lite/experimental/micro/kernels/BUILD
@@ -51,7 +51,6 @@ cc_library(
     name = "portable_optimized_micro_ops",
     srcs = [
         "fully_connected.cc",
-        "pooling.cc",
         "portable_optimized/depthwise_conv.cc",
         "softmax.cc",
     ],
@@ -140,19 +139,6 @@ tflite_micro_cc_test(
     name = "softmax_test",
     srcs = [
         "softmax_test.cc",
-    ],
-    deps = [
-        ":all_ops_resolver",
-        "//tensorflow/lite/c:c_api_internal",
-        "//tensorflow/lite/experimental/micro:micro_framework",
-        "//tensorflow/lite/experimental/micro/testing:micro_test",
-    ],
-)
-
-tflite_micro_cc_test(
-    name = "pooling_test",
-    srcs = [
-        "pooling_test.cc",
     ],
     deps = [
         ":all_ops_resolver",

--- a/tensorflow/lite/experimental/micro/kernels/BUILD
+++ b/tensorflow/lite/experimental/micro/kernels/BUILD
@@ -52,6 +52,7 @@ cc_library(
     srcs = [
         "fully_connected.cc",
         "portable_optimized/depthwise_conv.cc",
+        "pooling.cc",
         "softmax.cc",
     ],
     hdrs = [

--- a/tensorflow/lite/experimental/micro/kernels/BUILD
+++ b/tensorflow/lite/experimental/micro/kernels/BUILD
@@ -148,3 +148,16 @@ tflite_micro_cc_test(
         "//tensorflow/lite/experimental/micro/testing:micro_test",
     ],
 )
+
+tflite_micro_cc_test(
+    name = "pooling_test",
+    srcs = [
+        "pooling_test.cc",
+    ],
+    deps = [
+        ":all_ops_resolver",
+        "//tensorflow/lite/c:c_api_internal",
+        "//tensorflow/lite/experimental/micro:micro_framework",
+        "//tensorflow/lite/experimental/micro/testing:micro_test",
+    ],
+)

--- a/tensorflow/lite/experimental/micro/kernels/BUILD
+++ b/tensorflow/lite/experimental/micro/kernels/BUILD
@@ -51,8 +51,8 @@ cc_library(
     name = "portable_optimized_micro_ops",
     srcs = [
         "fully_connected.cc",
-        "portable_optimized/depthwise_conv.cc",
         "pooling.cc",
+        "portable_optimized/depthwise_conv.cc",
         "softmax.cc",
     ],
     hdrs = [

--- a/tensorflow/lite/experimental/micro/kernels/all_ops_resolver.cc
+++ b/tensorflow/lite/experimental/micro/kernels/all_ops_resolver.cc
@@ -34,12 +34,18 @@ TfLiteRegistration* Micro_Register_AVERAGE_POOL_2D() {
   return Register_AVERAGE_POOL_2D();
 }
 
+TfLiteRegistration* Register_MAX_POOL_REF();
+TfLiteRegistration* Micro_Register_MAX_POOL_REF() {
+  return Register_MAX_POOL_REF();
+}
+
 AllOpsResolver::AllOpsResolver() {
   AddBuiltin(BuiltinOperator_DEPTHWISE_CONV_2D,
              Micro_Register_DEPTHWISE_CONV_2D());
   AddBuiltin(BuiltinOperator_FULLY_CONNECTED, Micro_Register_FULLY_CONNECTED(),
              /* min_version */ 1,
              /* max_version */ 2);
+  AddBuiltin(BuiltinOperator_MAX_POOL_2D, Micro_Register_MAX_POOL_REF());
   AddBuiltin(BuiltinOperator_SOFTMAX, Micro_Register_SOFTMAX());
   AddBuiltin(BuiltinOperator_AVERAGE_POOL_2D, Micro_Register_AVERAGE_POOL_2D());
 }

--- a/tensorflow/lite/experimental/micro/kernels/all_ops_resolver.cc
+++ b/tensorflow/lite/experimental/micro/kernels/all_ops_resolver.cc
@@ -34,9 +34,9 @@ TfLiteRegistration* Micro_Register_AVERAGE_POOL_2D() {
   return Register_AVERAGE_POOL_2D();
 }
 
-TfLiteRegistration* Register_MAX_POOL();
-TfLiteRegistration* Micro_Register_MAX_POOL() {
-  return Register_MAX_POOL();
+TfLiteRegistration* Register_MAX_POOL_2D();
+TfLiteRegistration* Micro_Register_MAX_POOL_2D() {
+  return Register_MAX_POOL_2D();
 }
 
 AllOpsResolver::AllOpsResolver() {
@@ -45,7 +45,7 @@ AllOpsResolver::AllOpsResolver() {
   AddBuiltin(BuiltinOperator_FULLY_CONNECTED, Micro_Register_FULLY_CONNECTED(),
              /* min_version */ 1,
              /* max_version */ 2);
-  AddBuiltin(BuiltinOperator_MAX_POOL_2D, Micro_Register_MAX_POOL());
+  AddBuiltin(BuiltinOperator_MAX_POOL_2D, Micro_Register_MAX_POOL_2D());
   AddBuiltin(BuiltinOperator_SOFTMAX, Micro_Register_SOFTMAX());
   AddBuiltin(BuiltinOperator_AVERAGE_POOL_2D, Micro_Register_AVERAGE_POOL_2D());
 }

--- a/tensorflow/lite/experimental/micro/kernels/all_ops_resolver.cc
+++ b/tensorflow/lite/experimental/micro/kernels/all_ops_resolver.cc
@@ -34,9 +34,9 @@ TfLiteRegistration* Micro_Register_AVERAGE_POOL_2D() {
   return Register_AVERAGE_POOL_2D();
 }
 
-TfLiteRegistration* Register_MAX_POOL_REF();
-TfLiteRegistration* Micro_Register_MAX_POOL_REF() {
-  return Register_MAX_POOL_REF();
+TfLiteRegistration* Register_MAX_POOL();
+TfLiteRegistration* Micro_Register_MAX_POOL() {
+  return Register_MAX_POOL();
 }
 
 AllOpsResolver::AllOpsResolver() {
@@ -45,7 +45,7 @@ AllOpsResolver::AllOpsResolver() {
   AddBuiltin(BuiltinOperator_FULLY_CONNECTED, Micro_Register_FULLY_CONNECTED(),
              /* min_version */ 1,
              /* max_version */ 2);
-  AddBuiltin(BuiltinOperator_MAX_POOL_2D, Micro_Register_MAX_POOL_REF());
+  AddBuiltin(BuiltinOperator_MAX_POOL_2D, Micro_Register_MAX_POOL());
   AddBuiltin(BuiltinOperator_SOFTMAX, Micro_Register_SOFTMAX());
   AddBuiltin(BuiltinOperator_AVERAGE_POOL_2D, Micro_Register_AVERAGE_POOL_2D());
 }

--- a/tensorflow/lite/experimental/micro/kernels/pooling.cc
+++ b/tensorflow/lite/experimental/micro/kernels/pooling.cc
@@ -189,8 +189,8 @@ TfLiteStatus MaxEval(TfLiteContext* context, TfLiteNode* node) {
       MaxEvalQuantizedUInt8(context, node, params, &data, input, output);
       break;
     default:
-      context->ReportError(context, "Type %d not currently supported.",
-                           input->type);
+      context->ReportError(context, "Type %s not currently supported.",
+                           TfLiteTypeGetName(input->type));
       return kTfLiteError;
   }
   return kTfLiteOk;
@@ -208,7 +208,7 @@ TfLiteRegistration* Register_AVERAGE_POOL_2D() {
   return &r;
 }
 
-TfLiteRegistration* Register_MAX_POOL() {
+TfLiteRegistration* Register_MAX_POOL_2D() {
   static TfLiteRegistration r = {pooling::Init, pooling::Free, pooling::Prepare,
                                  pooling::MaxEval};
   return &r;

--- a/tensorflow/lite/experimental/micro/kernels/pooling.cc
+++ b/tensorflow/lite/experimental/micro/kernels/pooling.cc
@@ -93,6 +93,48 @@ void AverageEvalUint8(const TfLiteContext* context, const TfLiteNode* node,
       GetTensorShape(output), GetTensorData<uint8_t>(output));
 }
 
+void MaxEvalFloat(TfLiteContext* context, TfLiteNode* node,
+                  TfLitePoolParams* params, OpData* data,
+                  const TfLiteTensor* input, TfLiteTensor* output) {
+  float activation_min, activation_max;
+  CalculateActivationRange(params->activation, &activation_min,
+                           &activation_max);
+
+  tflite::PoolParams op_params;
+  op_params.stride_height = params->stride_height;
+  op_params.stride_width = params->stride_width;
+  op_params.filter_height = params->filter_height;
+  op_params.filter_width = params->filter_width;
+  op_params.padding_values.height = data->padding.height;
+  op_params.padding_values.width = data->padding.width;
+  op_params.float_activation_min = activation_min;
+  op_params.float_activation_max = activation_max;
+  reference_ops::MaxPool(op_params, GetTensorShape(input),
+                         GetTensorData<float>(input), GetTensorShape(output),
+                         GetTensorData<float>(output));
+}
+
+void MaxEvalQuantizedUInt8(TfLiteContext* context, TfLiteNode* node,
+                           TfLitePoolParams* params, OpData* data,
+                           const TfLiteTensor* input, TfLiteTensor* output) {
+  int32_t activation_min, activation_max;
+  CalculateActivationRangeUint8(params->activation, output, &activation_min,
+                                &activation_max);
+
+  tflite::PoolParams op_params;
+  op_params.stride_height = params->stride_height;
+  op_params.stride_width = params->stride_width;
+  op_params.filter_height = params->filter_height;
+  op_params.filter_width = params->filter_width;
+  op_params.padding_values.height = data->padding.height;
+  op_params.padding_values.width = data->padding.width;
+  op_params.quantized_activation_min = activation_min;
+  op_params.quantized_activation_max = activation_max;
+  reference_ops::MaxPool(op_params, GetTensorShape(input),
+                         GetTensorData<uint8_t>(input), GetTensorShape(output),
+                         GetTensorData<uint8_t>(output));
+}
+
 }  // namespace
 
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
@@ -130,6 +172,30 @@ TfLiteStatus AverageEval(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
+TfLiteStatus MaxEval(TfLiteContext* context, TfLiteNode* node) {
+  auto* params = reinterpret_cast<TfLitePoolParams*>(node->builtin_data);
+  OpData data;
+
+  const TfLiteTensor* input = GetInput(context, node, kInputTensor);
+  TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
+
+  TF_LITE_ENSURE_STATUS(CalculateOpData(context, params, input, output, &data));
+
+  switch (input->type) {
+    case kTfLiteFloat32:
+      MaxEvalFloat(context, node, params, &data, input, output);
+      break;
+    case kTfLiteUInt8:
+      MaxEvalQuantizedUInt8(context, node, params, &data, input, output);
+      break;
+    default:
+      context->ReportError(context, "Type %d not currently supported.",
+                           input->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
 }  // namespace pooling
 
 TfLiteRegistration* Register_AVERAGE_POOL_2D() {
@@ -139,6 +205,12 @@ TfLiteRegistration* Register_AVERAGE_POOL_2D() {
       pooling::Prepare,
       pooling::AverageEval,
   };
+  return &r;
+}
+
+TfLiteRegistration* Register_MAX_POOL_REF() {
+  static TfLiteRegistration r = {pooling::Init, pooling::Free, pooling::Prepare,
+                                 pooling::MaxEval};
   return &r;
 }
 

--- a/tensorflow/lite/experimental/micro/kernels/pooling.cc
+++ b/tensorflow/lite/experimental/micro/kernels/pooling.cc
@@ -208,7 +208,7 @@ TfLiteRegistration* Register_AVERAGE_POOL_2D() {
   return &r;
 }
 
-TfLiteRegistration* Register_MAX_POOL_REF() {
+TfLiteRegistration* Register_MAX_POOL() {
   static TfLiteRegistration r = {pooling::Init, pooling::Free, pooling::Prepare,
                                  pooling::MaxEval};
   return &r;

--- a/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
+++ b/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
@@ -235,6 +235,77 @@ void TestMaxPoolFloat(std::initializer_list<int> input_dims_data,
   }
 }
 
+void TestMaxPoolQuantizedUInt8(
+    std::initializer_list<int> input_dims_data,
+    std::initializer_list<uint8_t> input_data, float input_min, float input_max,
+    int filter_width, int filter_height, int stride_width, int stride_height,
+    std::initializer_list<uint8_t> expected_output_data, float output_min,
+    float output_max, std::initializer_list<int> output_dims_data,
+    TfLitePadding padding, TfLiteFusedActivation activation,
+    uint8_t* output_data) {
+  TfLiteIntArray* input_dims = IntArrayFromInitializer(input_dims_data);
+  TfLiteIntArray* output_dims = IntArrayFromInitializer(output_dims_data);
+  const int output_dims_count = ElementCount(*output_dims);
+
+  constexpr int inputs_size = 1;
+  constexpr int outputs_size = 1;
+  constexpr int tensors_size = inputs_size + outputs_size;
+  TfLiteTensor tensors[tensors_size] = {
+      CreateQuantizedTensor(input_data, input_dims, "input_tensor", input_min,
+                            input_max),
+      CreateQuantizedTensor(output_data, output_dims, "output_tensor",
+                            output_min, output_max),
+  };
+
+  TfLiteContext context;
+  PopulateContext(tensors, tensors_size, &context);
+
+  ::tflite::ops::micro::AllOpsResolver resolver;
+  const TfLiteRegistration* registration =
+      resolver.FindOp(tflite::BuiltinOperator_MAX_POOL_2D, 1);
+  TF_LITE_MICRO_EXPECT_NE(nullptr, registration);
+
+  TfLitePoolParams builtin_data = {
+      padding,      stride_width,  stride_height,
+      filter_width, filter_height, activation,
+  };
+
+  const char* init_data = reinterpret_cast<const char*>(&builtin_data);
+  size_t init_data_size = 0;
+  void* user_data = nullptr;
+  if (registration->init) {
+    user_data = registration->init(&context, init_data, init_data_size);
+  }
+
+  int inputs_array_data[] = {1, 0};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 1};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+  int temporaries_array_data[] = {0};
+  TfLiteIntArray* temporaries_array = IntArrayFromInts(temporaries_array_data);
+
+  TfLiteNode node;
+  node.inputs = inputs_array;
+  node.outputs = outputs_array;
+  node.temporaries = temporaries_array;
+  node.user_data = user_data;
+  node.builtin_data = reinterpret_cast<void*>(&builtin_data);
+  node.custom_initial_data = nullptr;
+  node.custom_initial_data_size = 0;
+  node.delegate = nullptr;
+  if (registration->prepare) {
+    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, registration->prepare(&context, &node));
+  }
+  TF_LITE_MICRO_EXPECT_NE(nullptr, registration->invoke);
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, registration->invoke(&context, &node));
+  if (registration->free) {
+    registration->free(&context, user_data);
+  }
+  for (int i = 0; i < output_dims_count; ++i) {
+    TF_LITE_MICRO_EXPECT_EQ(expected_output_data.begin()[i], output_data[i]);
+  }
+}
+
 }  // namespace
 
 }  // namespace testing

--- a/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
+++ b/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
@@ -166,6 +166,75 @@ void TestAveragePoolingUint8(
   }
 }
 
+void TestMaxPoolFloat(std::initializer_list<int> input_dims_data,
+                      std::initializer_list<float> input_data, int filter_width,
+                      int filter_height, int stride_width, int stride_height,
+                      std::initializer_list<float> expected_output_data,
+                      std::initializer_list<int> output_dims_data,
+                      TfLitePadding padding, TfLiteFusedActivation activation,
+                      float* output_data) {
+  TfLiteIntArray* input_dims = IntArrayFromInitializer(input_dims_data);
+  TfLiteIntArray* output_dims = IntArrayFromInitializer(output_dims_data);
+  const int output_dims_count = ElementCount(*output_dims);
+
+  constexpr int inputs_size = 1;
+  constexpr int outputs_size = 1;
+  constexpr int tensors_size = inputs_size + outputs_size;
+  TfLiteTensor tensors[tensors_size] = {
+      CreateFloatTensor(input_data, input_dims, "input_tensor"),
+      CreateFloatTensor(output_data, output_dims, "output_tensor"),
+  };
+
+  TfLiteContext context;
+  PopulateContext(tensors, tensors_size, &context);
+
+  ::tflite::ops::micro::AllOpsResolver resolver;
+  const TfLiteRegistration* registration =
+      resolver.FindOp(tflite::BuiltinOperator_MAX_POOL_2D, 1);
+  TF_LITE_MICRO_EXPECT_NE(nullptr, registration);
+
+  TfLitePoolParams builtin_data = {
+      padding,      stride_width,  stride_height,
+      filter_width, filter_height, activation,
+  };
+
+  const char* init_data = reinterpret_cast<const char*>(&builtin_data);
+  size_t init_data_size = 0;
+  void* user_data = nullptr;
+  if (registration->init) {
+    user_data = registration->init(&context, init_data, init_data_size);
+  }
+
+  int inputs_array_data[] = {1, 0};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 1};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+  int temporaries_array_data[] = {0};
+  TfLiteIntArray* temporaries_array = IntArrayFromInts(temporaries_array_data);
+
+  TfLiteNode node;
+  node.inputs = inputs_array;
+  node.outputs = outputs_array;
+  node.temporaries = temporaries_array;
+  node.user_data = user_data;
+  node.builtin_data = reinterpret_cast<void*>(&builtin_data);
+  node.custom_initial_data = nullptr;
+  node.custom_initial_data_size = 0;
+  node.delegate = nullptr;
+  if (registration->prepare) {
+    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, registration->prepare(&context, &node));
+  }
+  TF_LITE_MICRO_EXPECT_NE(nullptr, registration->invoke);
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, registration->invoke(&context, &node));
+  if (registration->free) {
+    registration->free(&context, user_data);
+  }
+  for (int i = 0; i < output_dims_count; ++i) {
+    TF_LITE_MICRO_EXPECT_NEAR(expected_output_data.begin()[i], output_data[i],
+                              1e-5f);
+  }
+}
+
 }  // namespace
 
 }  // namespace testing

--- a/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
+++ b/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
@@ -293,4 +293,151 @@ TF_LITE_MICRO_TEST(SimpleAveragePoolTestUint8) {
       kTfLitePaddingValid, kTfLiteActRelu, output_data);
 }
 
+TF_LITE_MICRO_TEST(SimpleMaxPoolTestFloat) {
+  float output_data[2];
+  tflite::testing::TestMaxPoolFloat(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          0, 6, 2, 4,
+          3, 2, 10, 7
+      },
+      2, 2,             // filter width, filter height
+      2, 2,             // stride width, stride height
+      {
+          // Output values
+          6, 10,
+      },
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActNone, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleMaxPoolTestFloatRelu) {
+  float output_data[2];
+  tflite::testing::TestMaxPoolFloat(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          -1, -6, 2, 4,     //
+          -3, -2, 10.5, 7,  //
+      },
+      2, 2,             // filter width, filter height
+      2, 2,             // stride width, stride height
+      {
+          // Output values
+          0.0, 10.5,
+      },
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActRelu, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleMaxPoolTestFloatRelu1) {
+  float output_data[2];
+  tflite::testing::TestMaxPoolFloat(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          -2.75, -6, 0.2, 0.4,  //
+          -3, -2, -0.3, 0.7,    //
+      },
+      2, 2,             // filter width, filter height
+      2, 2,             // stride width, stride height
+      {
+          // Output values
+          -1.0, 0.7,
+      },
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActRelu1, output_data);
+
+  tflite::testing::TestMaxPoolFloat(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          -2.75, -6, -2, -4,  //
+          -3, -2, 10, -7,     //
+      },
+      2, 2,             // filter width, filter height
+      2, 2,             // stride width, stride height
+      {
+          // Output values
+          -1.0, 1.0,
+      },
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActRelu1, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleMaxPoolTestFloatRelu6) {
+  float output_data[2];
+  tflite::testing::TestMaxPoolFloat(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          -1.5, -6, 12, 4,  //
+          -3, -2, 10, 7,    //
+      },
+      2, 2,             // filter width, filter height
+      2, 2,             // stride width, stride height
+      {
+          // Output values
+          0.0, 6.0,
+      },
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActRelu6, output_data);
+
+  tflite::testing::TestMaxPoolFloat(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          0, 4.5, 12, 4,  //
+          3, 2, 10, 7,    //
+      },
+      2, 2,             // filter width, filter height
+      2, 2,             // stride width, stride height
+      {
+          // Output values
+          4.5, 6.0,
+      },
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActRelu6, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleMaxPoolTestPaddingSameStride1) {
+  float output_data[8];
+  tflite::testing::TestMaxPoolFloat(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          0, 6, 2, 4,   //
+          3, 2, 10, 7,  //
+      },
+      2, 2,             // filter width, filter height
+      1, 1,             // stride width, stride height
+      {
+          // Output values
+          6, 10, 10, 7, //
+          3, 10, 10, 7, //
+      },
+      {4, 1, 2, 4, 1},  // Output shape
+      kTfLitePaddingSame, kTfLiteActNone, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleMaxPoolTestPaddingValidStride1) {
+  float output_data[3];
+  tflite::testing::TestMaxPoolFloat(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          0, 6, 2, 4,   //
+          3, 2, 10, 7,  //
+      },
+      2, 2,             // filter width, filter height
+      1, 1,             // stride width, stride height
+      {
+          // Output values
+          6, 10, 10,
+      },
+      {4, 1, 1, 3, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActNone, output_data);
+}
+
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
+++ b/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
@@ -511,4 +511,257 @@ TF_LITE_MICRO_TEST(SimpleMaxPoolTestPaddingValidStride1) {
       kTfLitePaddingValid, kTfLiteActNone, output_data);
 }
 
+TF_LITE_MICRO_TEST(SimpleMaxPoolTestUInt8ActNone) {
+  using tflite::testing::F2Q;
+
+  uint8_t output_data[2];
+  float input_min = 0;
+  float input_max = 15.9375;
+  float output_min = 0;
+  float output_max = 15.9375;
+  int filter_width = 2;
+  int filter_height = 2;
+  int stride_width = 2;
+  int stride_height = 2;
+  tflite::testing::TestMaxPoolQuantizedUInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2Q(0, input_min, input_max),
+          F2Q(6, input_min, input_max),
+          F2Q(2, input_min, input_max),
+          F2Q(4, input_min, input_max),
+          F2Q(3, input_min, input_max),
+          F2Q(2, input_min, input_max),
+          F2Q(10, input_min, input_max),
+          F2Q(7, input_min, input_max),
+      }, input_min, input_max,
+      filter_width, filter_height,
+      stride_width, stride_height,
+      {
+          // Output values
+          F2Q(6, output_min, output_max),
+          F2Q(10, output_min, output_max)
+      }, output_min, output_max,
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActNone,
+      output_data);
+}
+
+TF_LITE_MICRO_TEST(MaxPoolTestUInt8ActRelu) {
+  using tflite::testing::F2Q;
+
+  uint8_t output_data[2];
+  float input_min = -15.9375;
+  float input_max = 15.9375;
+  float output_min = -15.9375;
+  float output_max = 15.9375;
+  int filter_width = 2;
+  int filter_height = 2;
+  int stride_width = 2;
+  int stride_height = 2;
+  tflite::testing::TestMaxPoolQuantizedUInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2Q(-1.5, input_min, input_max),
+          F2Q(-6, input_min, input_max),
+          F2Q(2, input_min, input_max),
+          F2Q(4, input_min, input_max),
+          F2Q(-3, input_min, input_max),
+          F2Q(-2, input_min, input_max),
+          F2Q(10, input_min, input_max),
+          F2Q(7, input_min, input_max),
+      }, input_min, input_max,
+      filter_width, filter_height,
+      stride_width, stride_height,
+      {
+          // Output values
+          F2Q(0, output_min, output_max),
+          F2Q(10, output_min, output_max)
+      }, output_min, output_max,
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActRelu,
+      output_data);
+}
+
+TF_LITE_MICRO_TEST(MaxPoolTestUInt8ActRelu1) {
+  using tflite::testing::F2Q;
+
+  uint8_t output_data[2];
+  float input_min = -15.9375;
+  float input_max = 15.9375;
+  float output_min = -15.9375;
+  float output_max = 15.9375;
+  int filter_width = 2;
+  int filter_height = 2;
+  int stride_width = 2;
+  int stride_height = 2;
+  tflite::testing::TestMaxPoolQuantizedUInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2Q(-1.7, input_min, input_max),
+          F2Q(-6, input_min, input_max),
+          F2Q(2, input_min, input_max),
+          F2Q(4, input_min, input_max),
+          F2Q(-3, input_min, input_max),
+          F2Q(-2, input_min, input_max),
+          F2Q(-10, input_min, input_max),
+          F2Q(7, input_min, input_max),
+      }, input_min, input_max,
+      filter_width, filter_height,
+      stride_width, stride_height,
+      {
+          // Output values
+          F2Q(-1.0, output_min, output_max),
+          F2Q(1.0, output_min, output_max)
+      }, output_min, output_max,
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActRelu1,
+      output_data);
+}
+
+TF_LITE_MICRO_TEST(MaxPoolTestUInt8ActRelu6) {
+  using tflite::testing::F2Q;
+
+  uint8_t output_data[8];
+  float input_min = -15.9375;
+  float input_max = 15.9375;
+  float output_min = -15.9375;
+  float output_max = 15.9375;
+  int filter_width = 2;
+  int filter_height = 2;
+  int stride_width = 2;
+  int stride_height = 2;
+  tflite::testing::TestMaxPoolQuantizedUInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2Q(0, input_min, input_max),
+          F2Q(-6, input_min, input_max),
+          F2Q(12, input_min, input_max),
+          F2Q(4, input_min, input_max),
+          F2Q(-3, input_min, input_max),
+          F2Q(-2, input_min, input_max),
+          F2Q(10, input_min, input_max),
+          F2Q(7, input_min, input_max),
+      }, input_min, input_max,
+      filter_width, filter_height,
+      stride_width, stride_height,
+      {
+          // Output values
+          F2Q(0.0, output_min, output_max),
+          F2Q(6.0, output_min, output_max)
+      }, output_min, output_max,
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActRelu6,
+      output_data);
+
+  tflite::testing::TestMaxPoolQuantizedUInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2Q(0, input_min, input_max),
+          F2Q(4.5, input_min, input_max),
+          F2Q(12, input_min, input_max),
+          F2Q(4, input_min, input_max),
+          F2Q(3, input_min, input_max),
+          F2Q(2, input_min, input_max),
+          F2Q(10, input_min, input_max),
+          F2Q(7, input_min, input_max),
+      }, input_min, input_max,
+      filter_width, filter_height,
+      stride_width, stride_height,
+      {
+          // Output values
+          F2Q(4.5, output_min, output_max),
+          F2Q(6.0, output_min, output_max)
+      }, output_min, output_max,
+      {4, 1, 1, 2, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActRelu6,
+      output_data);
+}
+
+TF_LITE_MICRO_TEST(MaxPoolTestUInt8PaddingSameStride1) {
+  using tflite::testing::F2Q;
+
+  uint8_t output_data[8];
+  float input_min = 0;
+  float input_max = 15.9375;
+  float output_min = 0;
+  float output_max = 15.9375;
+  int filter_width = 2;
+  int filter_height = 2;
+  int stride_width = 1;
+  int stride_height = 1;
+  tflite::testing::TestMaxPoolQuantizedUInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2Q(0, input_min, input_max),
+          F2Q(6, input_min, input_max),
+          F2Q(2, input_min, input_max),
+          F2Q(4, input_min, input_max),
+          F2Q(3, input_min, input_max),
+          F2Q(2, input_min, input_max),
+          F2Q(10, input_min, input_max),
+          F2Q(7, input_min, input_max),
+      }, input_min, input_max,
+      filter_width, filter_height,
+      stride_width, stride_height,
+      {
+          // Output values
+          F2Q(6, output_min, output_max),
+          F2Q(10, output_min, output_max),
+          F2Q(10, output_min, output_max),
+          F2Q(7, output_min, output_max),
+          F2Q(3, output_min, output_max),
+          F2Q(10, output_min, output_max),
+          F2Q(10, output_min, output_max),
+          F2Q(7, output_min, output_max),
+      }, output_min, output_max,
+      {4, 1, 2, 4, 1},  // Output shape
+      kTfLitePaddingSame, kTfLiteActNone,
+      output_data);
+}
+
+TF_LITE_MICRO_TEST(MaxPoolTestUInt8PaddingValidStride1) {
+  using tflite::testing::F2Q;
+
+  uint8_t output_data[3];
+  float input_min = 0;
+  float input_max = 15.9375;
+  float output_min = 0;
+  float output_max = 15.9375;
+  int filter_width = 2;
+  int filter_height = 2;
+  int stride_width = 1;
+  int stride_height = 1;
+  tflite::testing::TestMaxPoolQuantizedUInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2Q(0, input_min, input_max),
+          F2Q(6, input_min, input_max),
+          F2Q(2, input_min, input_max),
+          F2Q(4, input_min, input_max),
+          F2Q(3, input_min, input_max),
+          F2Q(2, input_min, input_max),
+          F2Q(10, input_min, input_max),
+          F2Q(7, input_min, input_max),
+      }, input_min, input_max,
+      filter_width, filter_height,
+      stride_width, stride_height,
+      {
+          // Output values
+          F2Q(6, output_min, output_max),
+          F2Q(10, output_min, output_max),
+          F2Q(10, output_min, output_max),
+      }, output_min, output_max,
+      {4, 1, 1, 3, 1},  // Output shape
+      kTfLitePaddingValid, kTfLiteActNone,
+      output_data);
+}
+
 TF_LITE_MICRO_TESTS_END


### PR DESCRIPTION
This PR ports the MaxPool-part of the pooling kernel from Tensorflow Lite to Tensorflow Lite Micro.