### PR TITLE
Display bazel log file on trapped cleanup.

### DIFF
--- a/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
@@ -48,6 +48,7 @@ rm -f "${TMP_BAZELRC}"
 touch "${TMP_BAZELRC}"
 
 function cleanup {
+  cat mm.txt
   # Remove all options in .tmp.bazelrc
   echo "" > "${TMP_BAZELRC}"
 }


### PR DESCRIPTION
Follows from #27793, I should have `cat`'ed the file there