### PR TITLE
Update links to correct example projects

### DIFF
--- a/tensorflow/lite/g3doc/models/object_detection/overview.md
+++ b/tensorflow/lite/g3doc/models/object_detection/overview.md
@@ -11,9 +11,9 @@ If you are new to TensorFlow Lite and are working with Android or iOS, we
 recommend exploring the following example applications that can help you get
 started.
 
-<a class="button button-primary" href="https://github.com/tensorflow/examples/tree/master/lite/examples/image_classification/android">Android
+<a class="button button-primary" href="https://github.com/tensorflow/examples/tree/master/lite/examples/object_detection/android">Android
 example</a>
-<a class="button button-primary" href="https://github.com/tensorflow/examples/tree/master/lite/examples/image_classification/ios">iOS
+<a class="button button-primary" href="https://github.com/tensorflow/examples/tree/master/lite/examples/object_detection/ios">iOS
 example</a>
 
 If you are using a platform other than Android or iOS, or you are already


### PR DESCRIPTION
Currently, the links are opening the image classification examples, not object detection.