### PR TITLE
Add support for line breaks in jupyter

### DIFF
--- a/tensorflow/tools/compatibility/ipynb.py
+++ b/tensorflow/tools/compatibility/ipynb.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import collections
 import copy
 import json
+import re
 import shutil
 import tempfile
 
@@ -63,8 +64,13 @@ def process_file(in_filename, out_filename, upgrader):
 
 
 def skip_magic(code_line, magic_list):
-  """
-  Checks if the cell has magic, that is not python-based.
+  """Checks if the cell has magic, that is not Python-based.
+
+  Args:
+      code_line: A line of Python code
+      magic_list: A list of jupyter "magic" exceptions
+  Returns:
+    If the line jupyter "magic" line, not Python line
 
    >>> skip_magic('!ls -laF', ['%', '!', '?'])
   True
@@ -78,18 +84,18 @@ def skip_magic(code_line, magic_list):
 
 
 def check_line_split(code_line):
-  r"""
-  Checks if a line was splitted with `\`.
+  r"""Checks if a line was split with `\`.
+
+  Args:
+      code_line: A line of Python code
+  Returns:
+    If the line was split with `\`
 
   >>> skip_magic("!gcloud ml-engine models create ${MODEL} \\\n")
   True
   """
 
-  if code_line.endswith('\\\n'):
-    return True
-
-  return False
-
+  return re.search(r'\\\s*\n$', code_line)
 
 def _get_code(input_file):
   """Loads the ipynb file and returns a list of CodeLines."""

--- a/tensorflow/tools/compatibility/ipynb.py
+++ b/tensorflow/tools/compatibility/ipynb.py
@@ -64,9 +64,9 @@ def process_file(in_filename, out_filename, upgrader):
 
 def skip_magic(code_line, magic_list):
     """
-    Checks if the cell has magic, that is not python based
+    Checks if the cell has magic, that is not python-based.
 
-    >>> skip_magic('!ls -laF')
+    >>> skip_magic('!ls -laF', ['%', '!', '?'])
     True
     """
 
@@ -79,7 +79,8 @@ def skip_magic(code_line, magic_list):
 
 def check_line_split(code_line):
     r"""
-    Checks if line was splitted with `\`
+    Checks if a line was splitted with `\`.
+
     >>> skip_magic("!gcloud ml-engine models create ${MODEL} \\\n")
     True
     """

--- a/tensorflow/tools/compatibility/ipynb.py
+++ b/tensorflow/tools/compatibility/ipynb.py
@@ -113,7 +113,8 @@ def _get_code(input_file):
           # Found a special character, need to "encode"
           code_line = "###!!!" + code_line
 
-        is_line_split = check_line_split(code_line)
+          # if this cell ends with `\` -> skip the next line
+          is_line_split = check_line_split(code_line)
 
         # Sometimes, people leave \n at the end of cell
         # in order to migrate only related things, and make the diff

--- a/tensorflow/tools/compatibility/ipynb.py
+++ b/tensorflow/tools/compatibility/ipynb.py
@@ -63,32 +63,32 @@ def process_file(in_filename, out_filename, upgrader):
 
 
 def skip_magic(code_line, magic_list):
-    """
-    Checks if the cell has magic, that is not python-based.
+  """
+  Checks if the cell has magic, that is not python-based.
 
-    >>> skip_magic('!ls -laF', ['%', '!', '?'])
-    True
-    """
+   >>> skip_magic('!ls -laF', ['%', '!', '?'])
+  True
+  """
 
-    for magic in magic_list:
-        if code_line.startswith(magic):
-            return True
+  for magic in magic_list:
+    if code_line.startswith(magic):
+      return True
 
-    return False
+  return False
 
 
 def check_line_split(code_line):
-    r"""
-    Checks if a line was splitted with `\`.
+  r"""
+  Checks if a line was splitted with `\`.
 
-    >>> skip_magic("!gcloud ml-engine models create ${MODEL} \\\n")
-    True
-    """
+  >>> skip_magic("!gcloud ml-engine models create ${MODEL} \\\n")
+  True
+  """
 
-    if code_line.endswith('\\\n'):
-        return True
+  if code_line.endswith('\\\n'):
+    return True
 
-    return False
+  return False
 
 
 def _get_code(input_file):
@@ -114,6 +114,9 @@ def _get_code(input_file):
           code_line = "###!!!" + code_line
 
           # if this cell ends with `\` -> skip the next line
+          is_line_split = check_line_split(code_line)
+
+        if is_line_split:
           is_line_split = check_line_split(code_line)
 
         # Sometimes, people leave \n at the end of cell


### PR DESCRIPTION
jupyter cells could have a single line magic, but that splits a line with `\`. 
This PR adds support for such cases.

Closes https://github.com/lc0/tf2up/issues/31