### PR TITLE
Undef OPAQUE marco conflicting with TensorFlow symbol.

### DIFF
--- a/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
+++ b/third_party/eigen3/unsupported/Eigen/CXX11/Tensor
@@ -12,4 +12,5 @@ inline void sleep(unsigned int seconds) { Sleep(1000*seconds); }
 #undef DeleteFile
 #undef ERROR
 #undef LoadLibrary
+#undef OPAQUE
 #endif  // _WIN32


### PR DESCRIPTION
See issue #25773.
@jlebar @rmlarsen.