### PR TITLE
Log failure reason in org.tensorflow.TensorFlow.init()

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/TensorFlow.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/TensorFlow.java
@@ -63,7 +63,19 @@ public final class TensorFlow {
 
   /** Load the TensorFlow runtime C library. */
   static void init() {
-    NativeLibrary.load();
+    try {
+      NativeLibrary.load();
+    } catch (Exception e) {
+      /*
+       * This code is called during static initialization of this and of other classes.
+       * If this fails then a NoClassDefFoundError is thrown however this does not
+       * include a cause. Printing the exception manually here ensures that the
+       * necessary information to fix the problem is available.
+       */
+      System.err.println("Failed to load TensorFlow native library");
+      e.printStackTrace();
+      throw e;
+    }
   }
 
   static {


### PR DESCRIPTION
Loading the native library can fail for various reasons, especially if it is being run on a machine other than where the tensorflow c++ code was compiled. Unfortunately it can be hard to determine the reason because Java seems to throw away the cause when it throws a `NoClassDefFoundError`.

We have worked around this for now by manually calling `TensorFlow.init()` in a try-catch block before calling any other tensorflow code. A better solution would be if the library logged the failure before rethrowing the exception.

Do you think this is acceptable? I'm very happy to change the message or use some other method of logging.