### PR TITLE
sysconfig: fix library name on macos

### DIFF
--- a/tensorflow/python/platform/sysconfig.py
+++ b/tensorflow/python/platform/sysconfig.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os.path as _os_path
+import platform as _platform
 
 from tensorflow.python.framework.versions import CXX11_ABI_FLAG as _CXX11_ABI_FLAG
 from tensorflow.python.framework.versions import MONOLITHIC_BUILD as _MONOLITHIC_BUILD
@@ -73,8 +74,13 @@ def get_link_flags():
   Returns:
     The link flags.
   """
+  is_mac = _platform.system() == 'Darwin'
+  ver = _VERSION.split('.')[0]
   flags = []
   if not _MONOLITHIC_BUILD:
     flags.append('-L%s' % get_lib())
-    flags.append('-l:libtensorflow_framework.so.%s' % _VERSION.split('.')[0])
+    if is_mac:
+      flags.append('-l:libtensorflow_framework.%s.dylib' % ver)
+    else:
+      flags.append('-l:libtensorflow_framework.so.%s' % ver)
   return flags


### PR DESCRIPTION
On darwin, the library is named libtensorflow_framework.2.dylib

Signed-off-by: Jason Zaman <jason@perfinion.com>