### PR TITLE
Add --incompatible_remove_native_http_archive=false to windows bazel calls

### DIFF
--- a/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
@@ -103,7 +103,7 @@ fi
 
 run_configure_for_gpu_build
 
-bazel build --verbose_explanations --announce_rc --config=opt tensorflow/tools/pip_package:build_pip_package || exit $?
+bazel build --announce_rc --config=opt tensorflow/tools/pip_package:build_pip_package || exit $?
 
 if [[ "$SKIP_TEST" == 1 ]]; then
   exit 0

--- a/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
@@ -104,7 +104,6 @@ fi
 run_configure_for_gpu_build
 
 bazel build --verbose_explanations --announce_rc --config=opt tensorflow/tools/pip_package:build_pip_package || exit $?
-cat mm.txt
 
 if [[ "$SKIP_TEST" == 1 ]]; then
   exit 0

--- a/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
@@ -103,7 +103,7 @@ fi
 
 run_configure_for_gpu_build
 
-bazel build --announce_rc --config=opt tensorflow/tools/pip_package:build_pip_package || exit $?
+bazel build --incompatible_remove_native_http_archive=false --announce_rc --config=opt tensorflow/tools/pip_package:build_pip_package || exit $?
 
 if [[ "$SKIP_TEST" == 1 ]]; then
   exit 0
@@ -127,7 +127,7 @@ TF_GPU_COUNT=${TF_GPU_COUNT:-4}
 # Define no_tensorflow_py_deps=true so that every py_test has no deps anymore,
 # which will result testing system installed tensorflow
 # GPU tests are very flaky when running concurrently, so set local_test_jobs=1
-bazel test --announce_rc --config=opt -k --test_output=errors \
+bazel test --incompatible_remove_native_http_archive=false --announce_rc --config=opt -k --test_output=errors \
   --test_env=TF_GPU_COUNT \
   --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
   --define=no_tensorflow_py_deps=true --test_lang_filters=py \


### PR DESCRIPTION
First two commits are to remove debug stuff I just now I realized I missed on #27801 Let me know if you'd rather have them on a different PR instead.

The last one is the reason for this PR: after updating bazel to 0.20.0 to make windows GPU display messages we need this flag otherwise we get

```
Loading: 0 packages loaded
ERROR: error loading package '': Encountered error while reading extension file 'closure/defs.bzl': no such package '@io_bazel_rules_closure//closure': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
ERROR: error loading package '': Encountered error while reading extension file 'closure/defs.bzl': no such package '@io_bazel_rules_closure//closure': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
```