### PR TITLE
Fix index bug in RemoveStackStridedSliceSameAxis

### DIFF
--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc
@@ -3126,12 +3126,11 @@ class RemoveStackStridedSliceSameAxis : public ArithmeticOptimizerStage {
       return Status::OK();
     }
     *pack_output_shape = slice_properties[0].shape();
-    const int pack_input_rank = pack_output_shape->dims() - 1;
+    const int pack_output_rank = pack_output_shape->dims();
     if (*pack_axis < 0) {
-      // The ndims of any input into Pack op is its output ndims - 1.
-      *pack_axis += pack_input_rank;
+      *pack_axis += pack_output_rank;
     }
-    if (*pack_axis < 0 || *pack_axis >= pack_input_rank) {
+    if (*pack_axis < 0 || *pack_axis >= pack_output_rank) {
       return errors::InvalidArgument(
           "Pack node (", pack->name(),
           ") axis attribute is out of bounds: ", pack->attr().at("axis").i());

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
@@ -3851,6 +3851,131 @@ TEST_F(ArithmeticOptimizerTest, RemoveStackStridedSliceSameAxis) {
                                  tensors[fCSlice2ToOut]);
 }
 
+TEST_F(ArithmeticOptimizerTest, RemoveStackStridedSliceSameAxisWithScalars) {
+  tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+  auto a_in = ops::Const(s.WithOpName("a_in"), {1.0f}, {});
+  auto b_in = ops::Const(s.WithOpName("b_in"), {-1.0f}, {});
+  auto c_in = ops::Const(s.WithOpName("c_in"), {5.0f}, {});
+  auto a = ops::PlaceholderWithDefault(s.WithOpName("a"), a_in,
+                                       PartialTensorShape({}));
+  auto b = ops::PlaceholderWithDefault(s.WithOpName("b"), b_in,
+                                       PartialTensorShape({}));
+  auto c = ops::PlaceholderWithDefault(s.WithOpName("c"), c_in,
+                                       PartialTensorShape({}));
+  // The results with axis = 0 and axis = -1 should be equivalent, so test both.
+  for (const int axis : {0, -1}) {
+    // stacked = tf.stack((a, b, c), axis=0).
+    // stacked.shape == [3] (a, b, c are stacked along new axis 0)
+    auto stacked =
+        ops::Stack(s.WithOpName("stacked"), {a.output, b.output, c.output},
+                   ops::Stack::Axis(axis));
+    auto expanded_a = ops::ExpandDims(s.WithOpName("expanded_a"), a, {0});
+    auto expanded_b = ops::ExpandDims(s.WithOpName("expanded_b"), b, {0});
+    auto expanded_c = ops::ExpandDims(s.WithOpName("expanded_c"), c, {0});
+    auto begin_a = ops::Const(s.WithOpName("begin_a"), {0}, {1});
+    auto end_a = ops::Const(s.WithOpName("end_a"), {1}, {1});
+    auto begin_b = ops::Const(s.WithOpName("begin_b"), {1}, {1});
+    auto end_b = ops::Const(s.WithOpName("end_b"), {2}, {1});
+    auto begin_c = ops::Const(s.WithOpName("begin_c"), {2}, {1});
+    auto end_c = ops::Const(s.WithOpName("end_c"), {3}, {1});
+    auto strides = ops::Const(s.WithOpName("strides"), {1}, {1});
+
+    // stacked[0]
+    using SS = ops::StridedSlice;
+    auto pa_slice = ops::Identity(
+        s.WithOpName("pa_slice_out"),
+        SS(s.WithOpName("pa_slice"), stacked, begin_a, end_a, strides,
+           SS::BeginMask(0b1)  // 1
+               .EllipsisMask(0)
+               .EndMask(0b1)  // 1
+               .NewAxisMask(0)
+               .ShrinkAxisMask(0b1)));  // 1
+
+    // stacked[1]
+    auto pb_slice = ops::Identity(
+        s.WithOpName("pb_slice_out"),
+        SS(s.WithOpName("pb_slice"), stacked, begin_b, end_b, strides,
+           SS::BeginMask(0b1)  // 1
+               .EllipsisMask(0)
+               .EndMask(0b1)  // 1
+               .NewAxisMask(0)
+               .ShrinkAxisMask(0b1)));  // 1
+
+    // stacked[2]
+    auto pc_slice = ops::Identity(
+        s.WithOpName("pc_slice_out"),
+        SS(s.WithOpName("pc_slice"), stacked, begin_c, end_c, strides,
+           SS::BeginMask(0b1)  // 1
+               .EllipsisMask(0)
+               .EndMask(0b1)  // 1
+               .NewAxisMask(0)
+               .ShrinkAxisMask(0b1)));  // 1
+
+    GrapplerItem item;
+    item.fetch = {"a",
+                  "b",
+                  "c",
+                  "pa_slice_out",
+                  "pb_slice_out",
+                  "pc_slice_out",
+                  "expanded_a",
+                  "expanded_b",
+                  "expanded_c"};
+    enum FetchItem {
+      fA,
+      fB,
+      fC,
+      fASliceOut,
+      fBSliceOut,
+      fCSliceOut,
+      fExpandedA,
+      fExpandedB,
+      fExpandedC,
+    };
+    TF_CHECK_OK(s.ToGraphDef(&item.graph));
+    auto tensors_expected = EvaluateNodes(item.graph, item.fetch);
+
+    // stacked[0] == a.
+    test::ExpectTensorEqual<float>(tensors_expected[fA],
+                                   tensors_expected[fASliceOut]);
+    // stacked[1] == b.
+    test::ExpectTensorEqual<float>(tensors_expected[fB],
+                                   tensors_expected[fBSliceOut]);
+    // stacked[2] == c.
+    test::ExpectTensorEqual<float>(tensors_expected[fC],
+                                   tensors_expected[fCSliceOut]);
+
+    GraphDef output;
+    ArithmeticOptimizer optimizer;
+    EnableOnlyRemoveStackStridedSliceSameAxis(&optimizer);
+    OptimizeAndPrune(&optimizer, &item, &output);
+
+    for (const auto& node : output.node()) {
+      if (node.name() == "pa_slice_out") {
+        EXPECT_EQ(node.input(0), "a");
+      } else if (node.name() == "pb_slice_out") {
+        EXPECT_EQ(node.input(0), "b");
+      } else if (node.name() == "pc_slice_out") {
+        EXPECT_EQ(node.input(0), "c");
+      } else if (str_util::EndsWith(node.name(), "_out")) {
+        EXPECT_EQ(strings::StrCat(node.input(0), "_out"),
+                  strings::StrCat(
+                      "ArithmeticOptimizer/RemoveStackStridedSliceSameAxis_",
+                      node.name()));
+      }
+    }
+
+    auto tensors = EvaluateNodes(output, item.fetch);
+
+    // stacked[0] == a.
+    test::ExpectTensorEqual<float>(tensors_expected[fA], tensors[fASliceOut]);
+    // stacked[1] == b.
+    test::ExpectTensorEqual<float>(tensors_expected[fB], tensors[fBSliceOut]);
+    // stacked[2] == c.
+    test::ExpectTensorEqual<float>(tensors_expected[fC], tensors[fCSliceOut]);
+  }
+}
+
 TEST_F(ArithmeticOptimizerTest, SimplifyAggregationBFloat16) {
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
   Output x = ops::Const(s.WithOpName("x"), {1.0f, 2.0f}, {1, 2});


### PR DESCRIPTION
This arithmetic optimizer pass incorrectly used the Pack op's input rank (instead of output rank) as the limit of its axis attribute.
I added a new test to check that it now works on scalar inputs and with negative axis values.

This probably went unnoticed because it only prints a warning on failure (and as of https://github.com/tensorflow/tensorflow/commit/8871d29c8f21317b5a421c4b143790c142f01d17 it only prints at VLOG(2)).

For reference, the correct range of the Pack op's axis value is documented here:
https://github.com/tensorflow/tensorflow/blob/r1.13/tensorflow/core/api_def/base_api/api_def_Pack.pbtxt#L22