### PR TITLE
Use tf_logging instead of print in lazy_loader.py

### DIFF
--- a/tensorflow/python/util/lazy_loader.py
+++ b/tensorflow/python/util/lazy_loader.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 import importlib
 import types
+from tensorflow.python.platform import tf_logging as logging
 
 
 class LazyLoader(types.ModuleType):
@@ -46,7 +47,7 @@ class LazyLoader(types.ModuleType):
 
     # Emit a warning if one was specified
     if self._warning:
-      print(self._warning)
+      logging.warning(self._warning)
       # Make sure to only warn once.
       self._warning = None
 


### PR DESCRIPTION
User may want to ignore warning sometimes.