### PR TITLE
TFTRT: Allow native segment to use CPU and move outputs to GPU

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -173,6 +173,9 @@ Status TRTEngineOp::ConstructFunctionHandle(OpKernelContext* ctx) {
   FunctionLibraryRuntime::InstantiateOptions inst_ops;
   inst_ops.state_handle = "";
   inst_ops.target = ctx->device()->name();
+  inst_ops.is_multi_device_function = true;
+  inst_ops.input_devices.assign(ctx->num_inputs(), ctx->device()->name());
+  inst_ops.output_devices.assign(ctx->num_outputs(), ctx->device()->name());
   native_func_ = 0;
   auto status = lib->Instantiate(funcdef_name_, AttrSlice(&fdef->attr()),
                                  inst_ops, &native_func_);


### PR DESCRIPTION
This changes allows the native segments to use both CPU and GPU and always move the output to GPU.

The kIntsonDevice attribute was recently added to fix a problem encountered with the native fallback. The problem was that certain ops in TF (ex: element-wise Less) are marked as GPU ops but actually execute entirely on CPU. This caused issues when one of these ops was the output of a native segment, since the output data was located on the CPU but TRTEngineOp expected it to be on the GPU. The kIntsonDevice forces outputs to go to the GPU, which fixed that problem but also prevents us from using a multi-device function. This prevents any native segments containing ops that could not run on the GPU. This affected CombinedNMS since there is no GPU implementation for CombinedNMS. The result was that calibrating a model with CombinedNMS for INT8 was impossible since the native fallback is used for calibration.

We made the following fixes to how TF-TRT uses TF functions for the native fallback:
* Don't set kIntsOnDevice attribute
* Register the funcdef as a multi-device function, setting all inputs and outputs to the current GPU
* Keep output identity nodes in funcdef. These identity ops with GPU placement nodes allow TF to copy data onto the correct output device. Previously, we removed the identity nodes so the output of the funcdef was directly connected to the last node in the graph.

Thanks to @samikama for the help with this