### PR TITLE
Fix #27994: compat.as_bytes should support bytearray

### DIFF
--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -40,12 +40,12 @@ from tensorflow.python.util.tf_export import tf_export
 
 
 def as_bytes(bytes_or_text, encoding='utf-8'):
-  """Converts either `bytes` or unicode python input types to `bytes`.
+  """Converts `bytearray`, `bytes`, or unicode python input types to `bytes`.
 
   Uses utf-8 encoding for text by default.
 
   Args:
-    bytes_or_text: A `bytes`, `str`, or `unicode` object.
+    bytes_or_text: A `bytearray`, `bytes`, `str`, or `unicode` object.
     encoding: A string indicating the charset for encoding unicode.
 
   Returns:
@@ -54,7 +54,9 @@ def as_bytes(bytes_or_text, encoding='utf-8'):
   Raises:
     TypeError: If `bytes_or_text` is not a binary or unicode string.
   """
-  if isinstance(bytes_or_text, _six.text_type):
+  if isinstance(bytes_or_text, bytearray):
+    return bytes(bytes_or_text)
+  elif isinstance(bytes_or_text, _six.text_type):
     return bytes_or_text.encode(encoding)
   elif isinstance(bytes_or_text, bytes):
     return bytes_or_text


### PR DESCRIPTION
I made these changes manually in a local venv and was then able to write to a GFile handle from a fastavro Writer, which writes out `bytearray`s.