### PR TITLE
Remove property from seekable method of FileIO

### DIFF
--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -241,7 +241,6 @@ class FileIO(object):
         pywrap_tensorflow.Set_TF_Status_from_Status(status, ret_status)
     self._writable_file = None
 
-  @property
   def seekable(self):
     """Returns True as FileIO supports random access ops of seek()/tell()"""
     return True

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -611,7 +611,7 @@ class FileIoTest(test.TestCase):
   def testFileSeekableWithZip(self):
     # Note: Test case for GitHub issue 27276, issue only exposed in python 3.7+.
     filename = os.path.join(self._base_dir, "a.npz")
-    np.savez_compressed(filename, { "a": 1, "b": 2 })
+    np.savez_compressed(filename, {"a": 1, "b": 2})
     with gfile.GFile(filename, "rb") as f:
       info = np.load(f)
     _ = [i for i in info.items()]

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -20,9 +20,11 @@ from __future__ import division
 from __future__ import print_function
 
 import os.path
+import numpy as np
 
 from tensorflow.python.framework import errors
 from tensorflow.python.lib.io import file_io
+from tensorflow.python.platform import gfile
 from tensorflow.python.platform import test
 
 
@@ -606,6 +608,13 @@ class FileIoTest(test.TestCase):
     # Change noread back so that it could be cleaned during tearDown.
     os.chmod(noread_path, 0o777)
 
+  def testFileSeekableWithZip(self):
+    # Note: Test case for GitHub issue 27276, issue only exposed in python 3.7+.
+    filename = os.path.join(self._base_dir, "a.npz")
+    np.savez_compressed(filename, { "a": 1, "b": 2 })
+    with gfile.GFile(filename, "rb") as f:
+      info = np.load(f)
+    _ = [i for i in info.items()]
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.-fast-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.-fast-g-file.pbtxt
@@ -11,10 +11,6 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
-  member {
-    name: "seekable"
-    mtype: "<type \'property\'>"
-  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -46,6 +42,10 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
+  }
+  member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.-g-file.pbtxt
@@ -11,10 +11,6 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
-  member {
-    name: "seekable"
-    mtype: "<type \'property\'>"
-  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -46,6 +42,10 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
+  }
+  member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.-open.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.-open.pbtxt
@@ -11,10 +11,6 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
-  member {
-    name: "seekable"
-    mtype: "<type \'property\'>"
-  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -46,6 +42,10 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
+  }
+  member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"

--- a/tensorflow/tools/api/golden/v1/tensorflow.io.gfile.-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.io.gfile.-g-file.pbtxt
@@ -11,10 +11,6 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
-  member {
-    name: "seekable"
-    mtype: "<type \'property\'>"
-  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -46,6 +42,10 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
+  }
+  member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"

--- a/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.-g-file.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.-g-file.pbtxt
@@ -11,10 +11,6 @@ tf_class {
     name: "name"
     mtype: "<type \'property\'>"
   }
-  member {
-    name: "seekable"
-    mtype: "<type \'property\'>"
-  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\', \'name\', \'mode\'], varargs=None, keywords=None, defaults=[\'r\'], "
@@ -46,6 +42,10 @@ tf_class {
   member_method {
     name: "seek"
     argspec: "args=[\'self\', \'offset\', \'whence\', \'position\'], varargs=None, keywords=None, defaults=[\'None\', \'0\', \'None\'], "
+  }
+  member_method {
+    name: "seekable"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "size"


### PR DESCRIPTION
This fix is a follow up to address the issue in #27276 where seekable with property causes the following error with Python 3.7.:
```
  File "/usr/lib/python3.7/_collections_abc.py", line 744, in __iter__
    yield (key, self._mapping[key])
  File "/usr/local/lib/python3.7/dist-packages/numpy/lib/npyio.py", line 251, in __getitem__
    bytes = self.zip.open(key)
  File "/usr/lib/python3.7/zipfile.py", line 1540, in open
    return ZipExtFile(zef_file, mode, zinfo, zd, True)
  File "/usr/lib/python3.7/zipfile.py", line 821, in __init__
    if fileobj.seekable():
TypeError: 'bool' object is not callable
```

This fix removed property annotation of the seekable methods.

This fix also adds a test case, though the test case is only exposed in python 3.7+.

This fix fixes #27276.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>