### PR TITLE
[tflite] enable using the new NNAPI delegate in Java

### DIFF
--- a/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/BUILD
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/BUILD
@@ -1,0 +1,7 @@
+licenses(["notice"])  # Apache 2.0
+
+filegroup(
+    name = "nnapi_delegate",
+    srcs = ["NnApiDelegate.java"],
+    visibility = ["//visibility:public"],
+)

--- a/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/BUILD
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/BUILD
@@ -1,7 +1,7 @@
 licenses(["notice"])  # Apache 2.0
 
 filegroup(
-    name = "nnapi_delegate",
+    name = "nnapi_delegate_src",
     srcs = ["NnApiDelegate.java"],
     visibility = ["//visibility:public"],
 )

--- a/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
@@ -1,0 +1,36 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package org.tensorflow.lite.nnapi;
+
+import org.tensorflow.lite.Delegate;
+import org.tensorflow.lite.Tensor;
+
+/** {@link Delegate} for NNAPI inference. */
+public class NnApiDelegate implements Delegate {
+
+  private long delegateHandle;
+
+  public NnApiDelegate() {
+    delegateHandle = createDelegate();
+  }
+
+  @Override
+  public long getNativeHandle() {
+    return delegateHandle;
+  }
+
+  private static native long createDelegate();
+}

--- a/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
@@ -15,11 +15,14 @@ limitations under the License.
 
 package org.tensorflow.lite.nnapi;
 
+import java.io.Closeable;
 import org.tensorflow.lite.Delegate;
 import org.tensorflow.lite.Tensor;
 
 /** {@link Delegate} for NNAPI inference. */
-public class NnApiDelegate implements Delegate {
+public class NnApiDelegate implements Delegate, Closeable {
+
+  private static final long INVALID_DELEGATE_HANDLE = 0;
 
   private long delegateHandle;
 
@@ -30,6 +33,17 @@ public class NnApiDelegate implements Delegate {
   @Override
   public long getNativeHandle() {
     return delegateHandle;
+  }
+
+  /**
+   * The NNAPI delegate is singleton. Nothing to delete
+   * for now, so mark the handle invalid only.
+   */
+  @Override
+  public void close() {
+    if (delegateHandle != INVALID_DELEGATE_HANDLE) {
+      delegateHandle = INVALID_DELEGATE_HANDLE;
+    }
   }
 
   private static native long createDelegate();

--- a/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
@@ -15,12 +15,11 @@ limitations under the License.
 
 package org.tensorflow.lite.nnapi;
 
-import java.io.Closeable;
 import org.tensorflow.lite.Delegate;
 import org.tensorflow.lite.Tensor;
 
 /** {@link Delegate} for NNAPI inference. */
-public class NnApiDelegate implements Delegate, Closeable {
+public class NnApiDelegate implements Delegate, AutoCloseable {
 
   private static final long INVALID_DELEGATE_HANDLE = 0;
 

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/BUILD
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/BUILD
@@ -1,0 +1,25 @@
+# Description:
+# Java Native Interface (JNI) library intended for implementing the
+# TensorFlow Lite GPU delegate Java API using the TensorFlow Lite CC library.
+
+package(default_visibility = ["//visibility:public"])
+
+load("//tensorflow/lite:build_def.bzl", "tflite_copts")
+
+licenses(["notice"])  # Apache 2.0
+
+cc_library(
+    name = "native",
+    srcs = ["nnapi_delegate_jni.cc"],
+    hdrs = ["nnapi_delegate_jni.h"],
+    copts = tflite_copts(),
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//tensorflow/lite/delegates/nnapi:nnapi_delegate",
+        "//tensorflow/lite/java/jni",
+    ],
+    alwayslink = 1,
+)

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.cc
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.cc
@@ -1,0 +1,22 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/delegates/nnapi/nnapi_delegate.h"
+#include "tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.h"
+
+JNIEXPORT jlong JNICALL Java_org_tensorflow_lite_nnapi_NnApiDelegate_createDelegate(
+    JNIEnv* env, jclass clazz) {
+  return reinterpret_cast<jlong>(tflite::NnApiDelegate());
+}

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.h
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.h
@@ -1,0 +1,37 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_DELEGATES_NNPAI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
+#define TENSORFLOW_LITE_DELEGATES_NNAPI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/*
+ * Class:     org_tensorflow_lite_nnapi_NnApiDelegate
+ * Method:    createDelegate
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_org_tensorflow_lite_nnapi_NnApiDelegate_createDelegate(
+    JNIEnv* env, jclass clazz);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // TENSORFLOW_LITE_DELEGATES_NNPAI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.h
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef TENSORFLOW_LITE_DELEGATES_NNPAI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
-#define TENSORFLOW_LITE_DELEGATES_NNPAI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
+#ifndef TENSORFLOW_LITE_DELEGATES_NNAPI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
+#define TENSORFLOW_LITE_DELEGATES_NNAPI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
 
 #include <jni.h>
 
@@ -34,4 +34,4 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_lite_nnapi_NnApiDelegate_createDeleg
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // TENSORFLOW_LITE_DELEGATES_NNPAI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
+#endif  // TENSORFLOW_LITE_DELEGATES_NNAPI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.h
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.h
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #ifndef TENSORFLOW_LITE_DELEGATES_NNPAI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
-#define TENSORFLOW_LITE_DELEGATES_NNAPI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
+#define TENSORFLOW_LITE_DELEGATES_NNPAI_JAVA_SRC_MAIN_NATIVE_NNAPI_DELEGATE_JNI_H_
 
 #include <jni.h>
 

--- a/tensorflow/lite/java/BUILD
+++ b/tensorflow/lite/java/BUILD
@@ -13,7 +13,9 @@ load("//tensorflow/lite/java:aar_with_jni.bzl", "aar_with_jni")
 
 JAVA_SRCS = glob([
     "src/main/java/org/tensorflow/lite/*.java",
-])
+]) + [
+   "//tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi:nnapi_delegate"
+]
 
 # Building tensorflow-lite.aar including 4 variants of .so
 # To build an aar for release, run below command:
@@ -262,6 +264,8 @@ tflite_jni_binary(
     name = "libtensorflowlite_jni.so",
     deps = [
         "//tensorflow/lite/java/src/main/native",
+        "//tensorflow/lite/delegates/nnapi:nnapi_delegate",
+        "//tensorflow/lite/delegates/nnapi/java/src/main/native:native",
     ],
 )
 

--- a/tensorflow/lite/java/BUILD
+++ b/tensorflow/lite/java/BUILD
@@ -13,9 +13,12 @@ load("//tensorflow/lite/java:aar_with_jni.bzl", "aar_with_jni")
 
 JAVA_SRCS = glob([
     "src/main/java/org/tensorflow/lite/*.java",
-]) + [
-   "//tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi:nnapi_delegate"
-]
+]) + select({
+    "//tensorflow:android": [
+      "//tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi:nnapi_delegate_src"
+    ],
+    "//conditions:default": []
+})
 
 # Building tensorflow-lite.aar including 4 variants of .so
 # To build an aar for release, run below command:

--- a/tensorflow/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/ImageClassifier.java
+++ b/tensorflow/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/ImageClassifier.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import org.tensorflow.lite.Interpreter;
 import org.tensorflow.lite.gpu.GpuDelegate;
+import org.tensorflow.lite.nnapi.NnApiDelegate;
 
 /**
  * Classifies images with Tensorflow Lite.
@@ -96,6 +97,8 @@ public abstract class ImageClassifier {
 
   /** holds a gpu delegate */
   GpuDelegate gpuDelegate = null;
+  /** holds an nnapi delegate */
+  NnApiDelegate nnapiDelegate = null;
 
   /** Initializes an {@code ImageClassifier}. */
   ImageClassifier(Activity activity) throws IOException {
@@ -176,12 +179,12 @@ public abstract class ImageClassifier {
   }
 
   public void useCPU() {
-    tfliteOptions.setUseNNAPI(false);
     recreateInterpreter();
   }
 
   public void useNNAPI() {
-    tfliteOptions.setUseNNAPI(true);
+    nnapiDelegate = new NnApiDelegate();
+    tfliteOptions.addDelegate(nnapiDelegate);
     recreateInterpreter();
   }
 
@@ -198,6 +201,8 @@ public abstract class ImageClassifier {
       gpuDelegate.close();
       gpuDelegate = null;
     }
+    if (nnapiDelegate != null)
+      gpuDelegate = null;
     tfliteModel = null;
   }
 

--- a/tensorflow/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/ImageClassifier.java
+++ b/tensorflow/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/ImageClassifier.java
@@ -201,8 +201,10 @@ public abstract class ImageClassifier {
       gpuDelegate.close();
       gpuDelegate = null;
     }
-    if (nnapiDelegate != null)
-      gpuDelegate = null;
+    if (nnapiDelegate != null) {
+      nnapiDelegate.close();
+      nnapiDelegate = null;
+    }
     tfliteModel = null;
   }
 


### PR DESCRIPTION
1. add a wrapper for NNAPI delegate can be accessed in Java
2. modify the demo app to use it

enable using the new NNAPI delegate in Java so that we can avoid situation described in https://github.com/tensorflow/tensorflow/issues/27983