### PR TITLE
Stream image build logs in dockerfile assembler system

### DIFF
--- a/tensorflow/tools/dockerfiles/assembler.py
+++ b/tensorflow/tools/dockerfiles/assembler.py
@@ -592,6 +592,7 @@ def main(argv):
               buildargs=tag_def['cli_args'],
               tag=repo_tag)
           last_event = None
+          image_id = None
           # Manually process log output extracting build success and image id
           # in order to get built image
           while True:
@@ -608,7 +609,7 @@ def main(argv):
                   image_id = match.group(2)
                 last_event = json_output['stream']
                 # collect all log lines into the logs object
-                logs.append(last_event)
+                logs.append(json_output)
             except StopIteration:
               eprint('Docker image build complete.')
               break


### PR DESCRIPTION
This change enables streaming image build logs when using `assembler.py` by using the lower level docker APIClient and manually handling the returned log stream.

This change is useful for modifications on dockerfiles, since behavior can be inspected before a build is finished.