### PR TITLE
fix(TimeDistributed): error with custom layer output_shape tuples

### DIFF
--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -412,8 +412,10 @@ class Bidirectional(Wrapper):
 
   @tf_utils.shape_type_conversion
   def compute_output_shape(self, input_shape):
-    output_shape = tuple(self.forward_layer.compute_output_shape(
-        input_shape).as_list())
+    output_shape = self.forward_layer.compute_output_shape(input_shape)
+    if not isinstance(output_shape, tensor_shape.TensorShape):
+      output_shape = tensor_shape.TensorShape(output_shape)
+    output_shape = tuple(output_shape.as_list())
     if self.return_state:
       state_shape = output_shape[1:]
       output_shape = output_shape[0]

--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -207,7 +207,10 @@ class TimeDistributed(Wrapper):
     child_input_shape = tensor_shape.TensorShape([input_shape[0]] +
                                                  input_shape[2:])
     child_output_shape = self.layer.compute_output_shape(
-        child_input_shape).as_list()
+        child_input_shape)
+    if not isinstance(child_output_shape, tensor_shape.TensorShape):
+      child_output_shape = tensor_shape.TensorShape(child_output_shape)
+    child_output_shape = child_output_shape.as_list()
     timesteps = input_shape[1]
     return tensor_shape.TensorShape([child_output_shape[0], timesteps] +
                                     child_output_shape[1:])

--- a/tensorflow/python/keras/layers/wrappers_test.py
+++ b/tensorflow/python/keras/layers/wrappers_test.py
@@ -322,9 +322,9 @@ class TimeDistributedTest(test.TestCase):
                    TensorShapeOutputShapeLayer]
     # Custom layers can specify output shape as a list, tuple, or TensorShape
     for layer in test_layers:
-      td = layer()
-      ph = keras.backend.placeholder(shape=(None, 1, 13))
-      out = td(ph)
+      time_distributed = keras.layers.TimeDistributed(layer())
+      placeholder = keras.backend.placeholder(shape=(None, 1, 13))
+      out = time_distributed(placeholder)
       # all output shapes are exposed in the end as TensorShape instances
       self.assertEqual(isinstance(out, tensor_shape.TensorShape), True)
 

--- a/tensorflow/python/keras/layers/wrappers_test.py
+++ b/tensorflow/python/keras/layers/wrappers_test.py
@@ -296,24 +296,15 @@ class TimeDistributedTest(test.TestCase):
 
     class TupleOutputShapeLayer(keras.layers.Layer):
 
-      def call(self, inputs):
-        return inputs
-
       def compute_output_shape(self, input_shape):
           return (input_shape[0], input_shape[1])
 
-    class ListOutputShape(keras.layers.Layer):
-
-      def call(self, inputs):
-        return inputs
+    class ListOutputShapeLayer(keras.layers.Layer):
 
       def compute_output_shape(self, input_shape):
           return [input_shape[0], input_shape[1]]
 
     class TensorShapeOutputShapeLayer(keras.layers.Layer):
-
-      def call(self, inputs):
-        return inputs
 
       def compute_output_shape(self, input_shape):
           return tensor_shape.TensorShape([input_shape[0], input_shape[1]])
@@ -323,10 +314,12 @@ class TimeDistributedTest(test.TestCase):
     # Custom layers can specify output shape as a list, tuple, or TensorShape
     for layer in test_layers:
       time_distributed = keras.layers.TimeDistributed(layer())
-      placeholder = keras.backend.placeholder(shape=(None, 1, 13))
-      out = time_distributed(placeholder)
+      input_shape = (None, 1, 13)
+      output_shape = time_distributed.compute_output_shape(input_shape)
       # all output shapes are exposed in the end as TensorShape instances
-      self.assertEqual(isinstance(out, tensor_shape.TensorShape), True)
+      self.assertIsInstance(output_shape, tensor_shape.TensorShape)
+      # verify the expected shapes from our passthrough layers
+      self.assertListEqual(list(input_shape), output_shape.as_list())
 
 
 class BidirectionalTest(test.TestCase):


### PR DESCRIPTION
**Problem**
When using custom layers with the `TimeDistributed` wrapper in the v2 preview, an error is thrown if the output_shape is not returned as a `TensorShape` instance. This goes contrary to the v1 docs, and also how custom layers work without the time distributed wrapper. 

**Reproduction**
https://colab.research.google.com/gist/justindujardin/d22de372c3eb6adaf7b6d85c8f6c5dfb/tf_keras_layer_output_shape_bug.ipynb

**Solution**
Coerce tuple/list output shape types into TensorShape without erroring.