### PR TITLE
[Grappler] Support unknown shapes in SimplifyReduction

### DIFF
--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -2396,8 +2396,13 @@ bool ConstantFolding::IsReductionWithConstantIndices(
   }
   const TensorProto& reduction_indices_tensor =
       reductions_indices->attr().at("value").tensor();
-  *indices_is_empty =
-      reduction_indices_tensor.tensor_shape().dim(0).size() == 0;
+  *indices_is_empty = false;
+  for (const auto& dim : reduction_indices_tensor.tensor_shape().dim()) {
+    if (dim.size() == 0) {
+      *indices_is_empty = true;
+      break;
+    }
+  }
   return true;
 }
 

--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -2382,20 +2382,29 @@ bool ConstantFolding::SimplifySwitch(GraphDef* optimized_graph, NodeDef* node) {
   return false;
 }
 
-bool ConstantFolding::IsReductionCandidateForSimplification(
-    const NodeDef& node, const GraphProperties& properties,
-    TensorShapeProto* input_tensor_shape, TensorShapeProto* output_tensor_shape,
-    bool* is_single_element_op) const {
+bool ConstantFolding::IsReductionWithConstantIndices(
+    const NodeDef& node, bool* indices_is_empty) const {
   // Ensure its an appropriate Reduce node.
   if (!IsReduction(node) || node.input_size() < 2) {
     return false;
   }
   // Ensure that the axes to reduce by are constant.
   NodeDef* reductions_indices = node_map_->GetNode(node.input(1));
-  if (!IsReallyConstant(*reductions_indices)) {
+  if (!IsReallyConstant(*reductions_indices) ||
+      !reductions_indices->attr().count("value")) {
     return false;
   }
+  const TensorProto& reduction_indices_tensor =
+      reductions_indices->attr().at("value").tensor();
+  *indices_is_empty =
+      reduction_indices_tensor.tensor_shape().dim(0).size() == 0;
+  return true;
+}
 
+bool ConstantFolding::IsReductionCandidateForSimplification(
+    const NodeDef& node, const GraphProperties& properties,
+    TensorShapeProto* input_tensor_shape, TensorShapeProto* output_tensor_shape,
+    bool* is_single_element_op) const {
   // Get the properties of the input & output tensors and check if they both
   // contain a single element.
   if (!properties.HasInputProperties(node.name()) ||
@@ -2460,9 +2469,33 @@ bool ConstantFolding::IsReductionSimplifiableToIdentity(
   return simplifiable;
 }
 
+bool ConstantFolding::ReplaceReductionWithIdentity(NodeDef* node) const {
+  // Replace the reduction node with an identity node, that can be further
+  // optimized by the model pruner.
+  DataType output_type;
+  if (node->attr().count("T") != 0) {
+    output_type = node->attr().at("T").type();
+  } else {
+    // This is an 'any' or 'all' reduction. The output is always boolean.
+    output_type = DT_BOOL;
+  }
+  node->set_op("Identity");
+  node->clear_attr();
+  (*node->mutable_attr())["T"].set_type(output_type);
+  *node->mutable_input(1) = AsControlDependency(node->input(1));
+  return true;
+}
+
 bool ConstantFolding::SimplifyReduction(GraphDef* optimized_graph,
                                         const GraphProperties& properties,
                                         NodeDef* node) {
+  bool indices_is_empty = false;
+  if (!IsReductionWithConstantIndices(*node, &indices_is_empty)) {
+    return false;
+  }
+  if (indices_is_empty) {
+    return ReplaceReductionWithIdentity(node);
+  }
   bool is_single_element_op = false;
   TensorShapeProto input_tensor_shape, output_tensor_shape;
   if (!IsReductionCandidateForSimplification(
@@ -2524,20 +2557,7 @@ bool ConstantFolding::SimplifyReduction(GraphDef* optimized_graph,
     (*node->mutable_attr())["Tshape"] = attr_type_indices;
     return true;
   } else if (simplifiable_to_identity) {
-    // Replace the reduction node with an identity node, that can be further
-    // optimized by the model pruner.
-    DataType output_type;
-    if (node->attr().count("T") != 0) {
-      output_type = node->attr().at("T").type();
-    } else {
-      // This is an 'any' or 'all' reduction. The output is always boolean.
-      output_type = DT_BOOL;
-    }
-    node->set_op("Identity");
-    node->clear_attr();
-    (*node->mutable_attr())["T"].set_type(output_type);
-    *node->mutable_input(1) = AsControlDependency(node->input(1));
-    return true;
+    return ReplaceReductionWithIdentity(node);
   }
   return false;
 }

--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -2394,15 +2394,9 @@ bool ConstantFolding::IsReductionWithConstantIndices(
       !reductions_indices->attr().count("value")) {
     return false;
   }
-  const TensorProto& reduction_indices_tensor =
-      reductions_indices->attr().at("value").tensor();
-  *indices_is_empty = false;
-  for (const auto& dim : reduction_indices_tensor.tensor_shape().dim()) {
-    if (dim.size() == 0) {
-      *indices_is_empty = true;
-      break;
-    }
-  }
+  const TensorShapeProto& reduction_indices_shape =
+      reductions_indices->attr().at("value").tensor().tensor_shape();
+  *indices_is_empty = TensorShape(reduction_indices_shape).num_elements() == 0;
   return true;
 }
 

--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -2470,7 +2470,7 @@ bool ConstantFolding::IsReductionSimplifiableToIdentity(
 
 bool ConstantFolding::ReplaceReductionWithIdentity(NodeDef* node) const {
   // Replace the reduction node with an identity node, that can be further
-  // optimized by the model pruner.
+  // optimized by other passes.
   DataType output_type;
   if (node->attr().count("T") != 0) {
     output_type = node->attr().at("T").type();

--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -2474,9 +2474,10 @@ bool ConstantFolding::ReplaceReductionWithIdentity(NodeDef* node) const {
   DataType output_type;
   if (node->attr().count("T") != 0) {
     output_type = node->attr().at("T").type();
-  } else {
-    // This is an 'any' or 'all' reduction. The output is always boolean.
+  } else if (IsAny(*node) || IsAll(*node)) {
     output_type = DT_BOOL;
+  } else {
+    return false;
   }
   node->set_op("Identity");
   node->clear_attr();

--- a/tensorflow/core/grappler/optimizers/constant_folding.h
+++ b/tensorflow/core/grappler/optimizers/constant_folding.h
@@ -153,6 +153,11 @@ class ConstantFolding : public GraphOptimizer {
   bool SimplifyReshape(const GraphProperties& properties, bool use_shape_info,
                        NodeDef* node);
 
+  // Returns true iff the node is a reduction and its reduction indices are
+  // constant. Sets *indices_is_empty to true if the set of dimensions to reduce
+  // along is empty (this happens often in the gradient graphs).
+  bool IsReductionWithConstantIndices(const NodeDef& node,
+                                      bool* indices_is_empty) const;
   // Returns true if theres a possibility that a Reduce node could be simplified
   // to an Identity/Reshape.
   bool IsReductionCandidateForSimplification(
@@ -160,11 +165,12 @@ class ConstantFolding : public GraphOptimizer {
       TensorShapeProto* input_tensor_shape,
       TensorShapeProto* output_tensor_shape, bool* is_single_element_op) const;
   // Returns true iff this reduction can be reduced to an identity (i.e if the
-  // set of dimensions to reduce along is empty). This happens often in the
-  // gradient graphs.
+  // input dimensions to reduce along are all of size 1 and keep_dims is true).
   bool IsReductionSimplifiableToIdentity(
       const NodeDef& node, const TensorShapeProto& input_shape, bool keep_dims,
       const gtl::InlinedVector<TensorValue, 4>& reduction_indices_vector) const;
+  // Changes a reduction into an Identity op, returning true on success.
+  bool ReplaceReductionWithIdentity(NodeDef* node) const;
   // Simplifies a Reduction operation to an Identity/Reshape operation if
   // applicable.
   bool SimplifyReduction(GraphDef* optimized_graph,


### PR DESCRIPTION
Allows reductions over unknown shapes to be replaced with Identity when the set of reduction indices is empty (which is common in the gradient graph). Previously this only worked if the input shape was known.

Extends the tests to include this case.

This can have a big impact on the subsequent auto_mixed_precision pass, where the presence of reductions prevents optimizations.

FYI @reedwm 