### PR TITLE
Correct out-of-date reference to Python file

### DIFF
--- a/tensorflow/c/c_api_function.cc
+++ b/tensorflow/c/c_api_function.cc
@@ -295,7 +295,8 @@ Status FillFunctionBody(
 }
 
 // Graph to FunctionDef conversion. This code is closely modeled on the Python
-// code in tensorflow/python/framework/function.py.
+// function graph_to_function_def(), which is located in 
+// tensorflow/python/framework/graph_to_function_def.py.
 Status GraphToFunctionDef(const Graph& fn_body, const string& fn_name,
                           bool append_hash_to_fn_name,
                           const std::vector<const Node*>& body_nodes,


### PR DESCRIPTION
The C++ function `GraphToFunctionDef` is the the core of the C API entry points `TF_GraphToFunction` and `TF_GraphToFunctionWithControlOutputs`. This function is actually a port of a Python function, and there is a comment above the function definition with a pointer to the original  Python source. Unfortunately the Python code to which the comment refers has moved. I lost several hours of productivity figuring out that there is a Python function that does the same thing as `GraphToFunctionDef`.

This PR corrects the C++ source code comment to point to the correct Python file and Python function.