### PR TITLE
Change signature of functionalized while loop.

### DIFF
--- a/tensorflow/compiler/tf2xla/functionalize_control_flow_test.cc
+++ b/tensorflow/compiler/tf2xla/functionalize_control_flow_test.cc
@@ -1010,13 +1010,14 @@ TEST(FunctionalizeControlFlow, Complex) {
           ops::_Retval(scope.WithOpName("_retval0_RetVal"), add_i, 0);
       auto retval1 = ops::_Retval(scope.WithOpName("_retval1_RetVal"), arg1, 1);
       auto retval2 = ops::_Retval(scope.WithOpName("_retval2_RetVal"), arg2, 2);
+      auto retval3 = ops::_Retval(scope.WithOpName("_retval3_RetVal"), arg3, 3);
 
       GraphDef expected;
       TF_EXPECT_OK(scope.ToGraphDef(&expected));
 
       EXPECT_EQ((DataTypeVector{DT_INT32, DT_INT32, DT_INT32, DT_RESOURCE}),
                 result.arg_types);
-      EXPECT_EQ((DataTypeVector{DT_INT32, DT_INT32, DT_INT32}),
+      EXPECT_EQ((DataTypeVector{DT_INT32, DT_INT32, DT_INT32, DT_RESOURCE}),
                 result.ret_types);
       TF_EXPECT_GRAPH_EQ(expected, result.gdef);
     }
@@ -1083,6 +1084,7 @@ TEST(FunctionalizeControlFlow, Complex) {
       auto retval1 =
           ops::_Retval(scope.WithOpName("_retval1_RetVal"), identity_k, 1);
       auto retval2 = ops::_Retval(scope.WithOpName("_retval2_RetVal"), arg2, 2);
+      auto retval3 = ops::_Retval(scope.WithOpName("_retval3_RetVal"), arg3, 3);
 
       GraphDef expected;
       TF_EXPECT_OK(scope.ToGraphDef(&expected));
@@ -1093,7 +1095,7 @@ TEST(FunctionalizeControlFlow, Complex) {
 
       EXPECT_EQ((DataTypeVector{DT_INT32, DT_INT32, DT_INT32, DT_RESOURCE}),
                 result.arg_types);
-      EXPECT_EQ((DataTypeVector{DT_INT32, DT_INT32, DT_INT32}),
+      EXPECT_EQ((DataTypeVector{DT_INT32, DT_INT32, DT_INT32, DT_RESOURCE}),
                 result.ret_types);
       TF_EXPECT_GRAPH_EQ(expected, result.gdef);
     }

--- a/tensorflow/compiler/tf2xla/functionalize_while.cc
+++ b/tensorflow/compiler/tf2xla/functionalize_while.cc
@@ -200,33 +200,23 @@ Status BuildLoopBody(const Graph& graph, Frame* frame,
     arg_types->push_back(dtype);
 
     TF_ASSIGN_OR_RETURN(Node * arg_node, BuildArgNode(output, dtype, i));
-
-    if (dtype == DT_RESOURCE) {
-      // The convention of the XLA bridge is that resource variable arguments
-      // are only inputs to the loop body and have no corresponding output.
-      // TODO(b/37741920): change the convention so that DT_RESOURCE variables
-      // are both inputs and outputs, and then remove this case.
-      TF_RET_CHECK(arg.is_loop_invariant);
+    TF_ASSIGN_OR_RETURN(Node * retval_node,
+                        BuildRetvalNode(output, dtype, i));
+    if (arg.is_loop_invariant) {
+      // Argument is loop-invariant. Forward it from the Arg to the Retval.
+      // DT_RESOURCE falls into this case.
       node_map[arg.enter->id()] = arg_node;
+      output->AddEdge(arg_node, 0, retval_node, 0);
     } else {
-      TF_ASSIGN_OR_RETURN(Node * retval_node,
-                          BuildRetvalNode(output, dtype, i));
-
-      if (arg.is_loop_invariant) {
-        // Argument is loop-invariant. Forward it from the Arg to the Retval.
-        node_map[arg.enter->id()] = arg_node;
-        output->AddEdge(arg_node, 0, retval_node, 0);
-      } else {
-        // Argument is loop-varying.
-        node_map[arg.switch_node->id()] = arg_node;
-        // The Switch node has two outputs, but _Arg only has one. This tells
-        // the CopySubgraph function to rewrite the output number of edges from
-        // the _Arg node to be 0 rather than copying the output number from the
-        // Switch node.
-        squash_src_outputs[arg.switch_node->id()] = true;
-        node_map[arg.next_iteration->id()] = retval_node;
-        next_iterations.push_back(arg.next_iteration);
-      }
+      // Argument is loop-varying.
+      node_map[arg.switch_node->id()] = arg_node;
+      // The Switch node has two outputs, but _Arg only has one. This tells
+      // the CopySubgraph function to rewrite the output number of edges from
+      // the _Arg node to be 0 rather than copying the output number from the
+      // Switch node.
+      squash_src_outputs[arg.switch_node->id()] = true;
+      node_map[arg.next_iteration->id()] = retval_node;
+      next_iterations.push_back(arg.next_iteration);
     }
   }
 

--- a/tensorflow/compiler/tf2xla/functionalize_while.cc
+++ b/tensorflow/compiler/tf2xla/functionalize_while.cc
@@ -204,11 +204,13 @@ Status BuildLoopBody(const Graph& graph, Frame* frame,
                         BuildRetvalNode(output, dtype, i));
     if (arg.is_loop_invariant) {
       // Argument is loop-invariant. Forward it from the Arg to the Retval.
-      // DT_RESOURCE falls into this case.
       node_map[arg.enter->id()] = arg_node;
       output->AddEdge(arg_node, 0, retval_node, 0);
     } else {
-      // Argument is loop-varying.
+      // Argument is loop-varying. Note that DT_RESOURCE is always loop
+      // invariant in the graph generated from tf.while and should not fall
+      // into this case.
+      TF_RET_CHECK(dtype != DT_RESOURCE);
       node_map[arg.switch_node->id()] = arg_node;
       // The Switch node has two outputs, but _Arg only has one. This tells
       // the CopySubgraph function to rewrite the output number of edges from

--- a/tensorflow/compiler/tf2xla/functionalize_while.cc
+++ b/tensorflow/compiler/tf2xla/functionalize_while.cc
@@ -209,7 +209,7 @@ Status BuildLoopBody(const Graph& graph, Frame* frame,
     } else {
       // Argument is loop-varying.
       if (dtype == DT_RESOURCE) {
-        // DT_RESOURCE arguments should always be loop-invariant in the graph
+        // DT_RESOURCE arguments should always be loop-invariant in the graphs
         // generated from TF.
         return errors::Unimplemented("Loop-varying DT_RESOURCE Enter node ",
                                      arg.enter->name(), " is currently not",

--- a/tensorflow/compiler/tf2xla/functionalize_while.cc
+++ b/tensorflow/compiler/tf2xla/functionalize_while.cc
@@ -207,10 +207,14 @@ Status BuildLoopBody(const Graph& graph, Frame* frame,
       node_map[arg.enter->id()] = arg_node;
       output->AddEdge(arg_node, 0, retval_node, 0);
     } else {
-      // Argument is loop-varying. Note that DT_RESOURCE is always loop
-      // invariant in the graph generated from tf.while and should not fall
-      // into this case.
-      TF_RET_CHECK(dtype != DT_RESOURCE);
+      // Argument is loop-varying.
+      if (dtype == DT_RESOURCE) {
+        // DT_RESOURCE arguments should always be loop-invariant in the graph
+        // generated from TF.
+        return errors::Unimplemented("Loop-varying DT_RESOURCE Enter node ",
+                                     arg.enter->name(), " is currently not",
+                                     " supported.");
+      }
       node_map[arg.switch_node->id()] = arg_node;
       // The Switch node has two outputs, but _Arg only has one. This tells
       // the CopySubgraph function to rewrite the output number of edges from

--- a/tensorflow/compiler/tf2xla/xla_compiler.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler.cc
@@ -234,6 +234,9 @@ Status BuildComputation(
       }
 
       case XlaExpression::Kind::kResource:
+        // resources are pushed into elems later when processing resource
+        // arguments. This is correct as long as the input and output resources
+        // are in the same order.
         output.is_constant = false;
         output.input_index = retval.resource()->arg_num();
         output.shape = retval.resource()->shape();

--- a/tensorflow/compiler/tf2xla/xla_compiler.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler.cc
@@ -234,7 +234,7 @@ Status BuildComputation(
       }
 
       case XlaExpression::Kind::kResource:
-        // resources are pushed into elems later when processing resource
+        // Resources are pushed into elems later when processing resource
         // arguments. This is correct as long as the input and output resources
         // are in the same order. In the case of functionalized while body,
         // this property is guaranteed since a corresponding output is always

--- a/tensorflow/compiler/tf2xla/xla_compiler.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler.cc
@@ -236,7 +236,9 @@ Status BuildComputation(
       case XlaExpression::Kind::kResource:
         // resources are pushed into elems later when processing resource
         // arguments. This is correct as long as the input and output resources
-        // are in the same order.
+        // are in the same order. In the case of functionalized while body,
+        // this property is guaranteed since a corresponding output is always
+        // created for a DT_RESOURCE input in a corresponding location.
         output.is_constant = false;
         output.input_index = retval.resource()->arg_num();
         output.shape = retval.resource()->shape();

--- a/tensorflow/compiler/tf2xla/xla_compiler_test.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler_test.cc
@@ -1576,5 +1576,120 @@ TEST_F(XlaCompilerTest, OpsWithTensorListInput) {
   ASSERT_TRUE(output1.is_tensor_list);
 }
 
+// Test the compiler supports WhileOp with a loop body where DT_RESOURCE
+// variables are both inputs and outputs.
+TEST_F(XlaCompilerTest, WhileWithResources) {
+  FunctionDefLibrary fdef_lib;
+  FunctionLibraryDefinition flib_def(OpRegistry::Global(), fdef_lib);
+  // Build cond fn for While.
+  {
+    Scope scope = Scope::NewRootScope().ExitOnError();
+    std::unique_ptr<Graph> graph(new Graph(OpRegistry::Global()));
+    auto arg0 = ops::_Arg(scope.WithOpName("arg0"), DT_INT32, 0);
+    auto arg1 = ops::_Arg(scope.WithOpName("arg1"), DT_RESOURCE, 1);
+    auto arg2 = ops::_Arg(scope.WithOpName("arg2"), DT_RESOURCE, 2);
+    auto less = ops::Less(scope, arg0, ops::Const<int32>(scope, 10));
+    ops::_Retval(scope.WithOpName("ret"), less, 0);
+    TF_ASSERT_OK(scope.ToGraph(graph.get()));
+    FunctionDef fdef;
+    TF_ASSERT_OK(GraphToFunctionDef(*graph, "cond", &fdef));
+    TF_ASSERT_OK(flib_def.AddFunctionDef(fdef));
+  }
+  // Build body fn for While.
+  {
+    Scope scope = Scope::NewRootScope().ExitOnError();
+    std::unique_ptr<Graph> graph(new Graph(OpRegistry::Global()));
+    auto arg0 = ops::_Arg(scope.WithOpName("arg0"), DT_INT32, 0);
+    auto arg1 = ops::_Arg(scope.WithOpName("arg1"), DT_RESOURCE, 1);
+    auto arg2 = ops::_Arg(scope.WithOpName("arg2"), DT_RESOURCE, 2);
+    auto read1 = ops::ReadVariableOp(scope.WithOpName("read1"), arg1, DT_INT32);
+    auto plus_read1 = ops::Add(scope, arg0, read1);
+    auto read2 = ops::ReadVariableOp(scope.WithOpName("read2"), arg2, DT_INT32);
+    auto minus_read2 = ops::Sub(scope, plus_read1, read2);
+    ops::_Retval(scope.WithOpName("ret0"), minus_read2, 0);
+    ops::_Retval(scope.WithOpName("ret1"), arg1, 1);
+    ops::_Retval(scope.WithOpName("ret2"), arg2, 2);
+    TF_ASSERT_OK(scope.ToGraph(graph.get()));
+    FunctionDef fdef;
+    TF_ASSERT_OK(GraphToFunctionDef(*graph, "body", &fdef));
+    TF_ASSERT_OK(flib_def.AddFunctionDef(fdef));
+  }
+
+  Scope scope = Scope::NewRootScope().ExitOnError();
+  auto arg0 = ops::_Arg(scope.WithOpName("arg0"), DT_INT32, 0);
+  auto arg1 = ops::_Arg(scope.WithOpName("arg1"), DT_RESOURCE, 1);
+  auto arg2 = ops::_Arg(scope.WithOpName("arg2"), DT_RESOURCE, 2);
+
+  NameAttrList cond_fn, body_fn;
+  cond_fn.set_name("cond");
+  body_fn.set_name("body");
+  auto while_op = ops::While(
+      scope, std::initializer_list<Input>{arg0, arg1, arg2}, cond_fn, body_fn);
+
+  ops::_Retval(scope.WithOpName("ret0"), while_op.output[0], 0);
+  ops::_Retval(scope.WithOpName("ret1"), while_op.output[1], 1);
+  ops::_Retval(scope.WithOpName("ret2"), while_op.output[2], 2);
+  std::unique_ptr<Graph> graph(new Graph(OpRegistry::Global()));
+  TF_ASSERT_OK(scope.ToGraph(graph.get()));
+
+  // Builds a description of the arguments.
+  std::vector<XlaCompiler::Argument> args(3);
+  args[0].kind = XlaCompiler::Argument::kParameter;
+  args[0].type = DT_INT32;
+  args[0].shape = TensorShape({});
+  args[1].kind = XlaCompiler::Argument::kResource;
+  args[1].resource_kind = XlaResource::kVariable;
+  args[1].initialized = true;
+  args[1].type = DT_INT32;
+  args[1].shape = TensorShape({});
+  args[2].kind = XlaCompiler::Argument::kResource;
+  args[2].resource_kind = XlaResource::kVariable;
+  args[2].initialized = true;
+  args[2].type = DT_INT32;
+  args[2].shape = TensorShape({});
+
+  // Compiles the graph.
+  XlaCompiler::Options options = DefaultOptions();
+  options.flib_def = &flib_def;
+  XlaCompiler compiler(options);
+
+  XlaCompiler::CompileOptions compile_options = XlaCompiler::CompileOptions();
+  compile_options.return_updated_values_for_all_resources = true;
+  XlaCompiler::CompilationResult result;
+  TF_ASSERT_OK(compiler.CompileGraph(compile_options, "tested_while_with_vars",
+                                     std::move(graph), args,
+                                     /*user_aliases=*/{}, &result));
+  ASSERT_EQ(result.outputs.size(), 3);
+  const XlaCompiler::OutputDescription &output1 = result.outputs[1];
+  ASSERT_EQ(output1.input_index, 1);
+  const XlaCompiler::OutputDescription &output2 = result.outputs[2];
+  ASSERT_EQ(output2.input_index, 2);
+
+  // Tests that the generated computation works.
+  xla::Literal literal0 = xla::LiteralUtil::CreateR0<int32>(0);
+  xla::Literal literal1 = xla::LiteralUtil::CreateR0<int32>(2);
+  xla::Literal literal2 = xla::LiteralUtil::CreateR0<int32>(1);
+  std::unique_ptr<xla::GlobalData> data0 =
+      client_->TransferToServer(literal0).ConsumeValueOrDie();
+  std::unique_ptr<xla::GlobalData> data1 =
+      client_->TransferToServer(literal1).ConsumeValueOrDie();
+  std::unique_ptr<xla::GlobalData> data2 =
+      client_->TransferToServer(literal2).ConsumeValueOrDie();
+
+  std::unique_ptr<xla::GlobalData> actual =
+      client_
+          ->Execute(*result.computation,
+                    {data0.get(), data1.get(), data2.get()})
+          .ConsumeValueOrDie();
+  xla::Literal actual_literal = client_->Transfer(*actual).ConsumeValueOrDie();
+
+  xla::Literal expected0 = xla::LiteralUtil::CreateR0<int32>(10);
+  xla::Literal expected1 = xla::LiteralUtil::CreateR0<int32>(2);
+  xla::Literal expected2 = xla::LiteralUtil::CreateR0<int32>(1);
+  xla::Literal expected_literal =
+      xla::LiteralUtil::MakeTuple({&expected0, &expected1, &expected2});
+  EXPECT_TRUE(xla::LiteralTestUtil::Equal(expected_literal, actual_literal));
+}
+
 }  // namespace
 }  // namespace tensorflow


### PR DESCRIPTION
Change signature of functionalized while loop such that the numbers of input and
output resources of loop body are matched. This signature is expected by other
places in tf2xla, e.g., GetCompileTimeConstInputs(). This signature can already
be supported by the current while lowering of xla_compiler. A new test is added
to ensure that.