### PR TITLE
1.14.0-rc0 cherry-pick request: Set mixed precision in ConfigProto if mixed precision is enabled.

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -4842,7 +4842,7 @@ tf_cc_test_gpu(
     name = "gpu_debug_allocator_test",
     size = "medium",
     srcs = ["common_runtime/gpu/gpu_debug_allocator_test.cc"],
-    args = ["\"--gtest_death_test_style=threadsafe\""],
+    args = ["--gtest_death_test_style=threadsafe"],
     linkstatic = tf_kernel_tests_linkstatic(),
     tags = tf_cuda_tests_tags(),
     deps = [

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -2908,6 +2908,12 @@ py_test(
 )
 
 py_library(
+    name = "mixed_precision_global_state",
+    srcs = ["training/experimental/mixed_precision_global_state.py"],
+    srcs_version = "PY2AND3",
+)
+
+py_library(
     name = "mixed_precision",
     srcs = ["training/experimental/mixed_precision.py"],
     srcs_version = "PY2AND3",
@@ -2915,6 +2921,7 @@ py_library(
         ":config",
         ":loss_scale",
         ":loss_scale_optimizer",
+        ":mixed_precision_global_state",
         "//tensorflow/python:util",
     ],
 )
@@ -4713,6 +4720,7 @@ py_library(
         ":pywrap_tensorflow",
         ":session_ops",
         ":util",
+        "//tensorflow/python:mixed_precision_global_state",
         "//third_party/py/numpy",
     ],
 )

--- a/tensorflow/python/training/experimental/mixed_precision_global_state.py
+++ b/tensorflow/python/training/experimental/mixed_precision_global_state.py
@@ -1,0 +1,34 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains global variables related to mixed precision.
+
+This is not part of mixed_precision.py to avoid a circular dependency.
+mixed_precision.py depends on Session, and Session depends on this file.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+# Whether mixed precision has been enabled or not with
+# `enable_mixed_precision_graph_rewrite`. Used to turn on auto_mixed_precision
+# in ConfigProtos passed to Sessions.
+mixed_precision_is_enabled = False
+
+# True if a Session has been created without mixed precision being enabled. Used
+# to give a warning if mixed precision is enabled after a Session has already
+# been created.
+non_mixed_precision_session_created = False


### PR DESCRIPTION
Before, if a user enabled mixed precision with 'enable_mixed_precision_graph_rewrite', but explicitly passed a ConfigProto to Session, the auto_mixed_precision grappler pass would not be enabled. This change causes Session to enable auto_mixed_precision in that case.

Also, give a warning if 'enable_mixed_precision_graph_rewrite' when a Session has already been created.

PiperOrigin-RevId: 244748138