### PR TITLE
[ROCm] Fixes for broken `--config=rocm` build, post PR #26722

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -46,6 +46,7 @@ load(
 load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_test")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_tests")
+load("//tensorflow:tensorflow.bzl", "if_cuda_or_rocm")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda_is_configured")
 load(
     "//tensorflow/core:platform/default/build_config.bzl",
@@ -4090,13 +4091,15 @@ tf_kernel_library(
 tf_kernel_library(
     name = "bias_op",
     prefix = "bias_op",
-    deps = NN_DEPS + [":redux_functor"] + if_cuda([
+    deps = NN_DEPS + [
+        ":redux_functor",
+    ] + if_cuda_or_rocm([
         ":reduction_ops",
+    ]) + if_cuda([
         "@cub_archive//:cub",
         "//tensorflow/core:stream_executor",
         "//tensorflow/stream_executor/cuda:cuda_stream",
-    ]) + if_rocm_is_configured([
-        ":reduction_ops",
+    ]) + if_rocm([
         "@rocprim_archive//:rocprim",
     ]),
 )
@@ -4130,11 +4133,11 @@ tf_kernel_library(
 tf_kernel_library(
     name = "softmax_op",
     prefix = "softmax_op",
-    deps = NN_DEPS + if_cuda([
+    deps = NN_DEPS + if_cuda_or_rocm([
         ":reduction_ops",
+    ]) + if_cuda([
         "@cub_archive//:cub",
-    ]) + if_rocm_is_configured([
-        ":reduction_ops",
+    ]) + if_rocm([
         "@rocprim_archive//:rocprim",
     ]),
 )
@@ -4799,11 +4802,11 @@ tf_kernel_library(
     deps = SPARSE_DEPS + [
         ":bounds_check",
         "//third_party/eigen3",
-    ] + if_cuda([
+    ] + if_cuda_or_rocm([
         ":reduction_ops",
+    ]) + if_cuda([
         "@cub_archive//:cub",
-    ]) + if_rocm_is_configured([
-        ":reduction_ops",
+    ]) + if_rocm([
         "@rocprim_archive//:rocprim",
     ]),
 )
@@ -5296,11 +5299,11 @@ tf_kernel_library(
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
-    ] + if_cuda([
+    ] + if_cuda_or_rocm([
         ":reduction_ops",
+    ]) + if_cuda([
         "@cub_archive//:cub",
-    ]) + if_rocm_is_configured([
-        ":reduction_ops",
+    ]) + if_rocm([
         "@rocprim_archive//:rocprim",
     ]),
 )

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -2433,3 +2433,34 @@ def tf_pybind_extension(
         restricted_to = restricted_to,
         compatible_with = compatible_with,
     )
+
+def if_cuda_or_rocm(if_true, if_false = []):
+    """Shorthand for select()'ing on whether we're building with either
+    CUDA or ROCm.
+
+    Returns a select statement which evaluates to
+       if_true if we're building with either CUDA or ROCm enabled.
+       if_false, otherwise.
+
+    Sometimes a target has additional CUDa or ROCm specific dependencies.
+    The `if_cuda` / `if_rocm` functions are used to specify these additional
+    dependencies. For eg, see the `//tensorflow/core/kernels:bias_op` target
+
+    If the same additional dependency is needed for both CUDA and ROCm
+    (for eg. `reduction_ops` dependency for the `bias_op` target above),
+    then specifying that dependency in both  both `if_cuda` and `if_rocm` will
+    result in both those functions returning a select statement, which contains
+    the same dependency, which then leads to a duplicate dependency bazel error.
+
+    In order to work around this error, any additional dependency that is common
+    to both the CUDA and ROCm platforms, should be specified using this function.
+    Doing so will eliminate the cause of the bazel error (i.e. the  same
+    dependency showing up in two different select statements)
+
+    """
+    return select({
+        "@local_config_cuda//cuda:using_nvcc": if_true,
+        "@local_config_cuda//cuda:using_clang": if_true,
+        "@local_config_rocm//rocm:using_hipcc": if_true,
+        "//conditions:default": if_false,
+    })


### PR DESCRIPTION
This is a follow up to PR #26722 .

There were a couple of changes introduced in that PR that break the `--config=rocm` build, and this PR has fixes for the same.

1. changing `if_cuda` to `if_cuda_is_configured` in cases where a "duplicate dependency" is introduced, due to a common dependency in the CUDA + ROCm paths

2. correcting a filename typo for `@rocprim_archive//:LICENSE.txt` that was leading to compile error.

@tatianashp , just FYI.

@gunan , @chsigg, @whchung 

Link to discussion regarding `if_cuda` vs `if_cuda_is_configured` from another PR : https://github.com/tensorflow/tensorflow/pull/26753#discussion_r267022934


