### PR TITLE
[ROCm] Correcting license filename for rocprim

### DIFF
--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -198,7 +198,7 @@ genrule(
             "@grpc//third_party/address_sorting:LICENSE",
         ],
     ) + if_rocm([
-        "@rocprim_archive//:LICENSE.TXT",
+        "@rocprim_archive//:LICENSE.txt",
     ]) + tf_additional_license_deps(),
     outs = ["include/tensorflow/c/LICENSE"],
     cmd = "$(location :concat_licenses.sh) $(SRCS) >$@",
@@ -265,7 +265,7 @@ genrule(
         "//third_party/mkl:LICENSE",
         "//third_party/mkl_dnn:LICENSE",
     ]) + if_rocm([
-        "@rocprim_archive//:LICENSE.TXT",
+        "@rocprim_archive//:LICENSE.txt",
     ]) + tf_additional_license_deps(),
     outs = ["include/tensorflow/jni/LICENSE"],
     cmd = "$(location :concat_licenses.sh) $(SRCS) >$@",

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -244,7 +244,7 @@ filegroup(
         "@nlohmann_json_lib//:LICENSE.MIT",
         "@tbb//:LICENSE",
     ]) + if_rocm([
-        "@rocprim_archive//:LICENSE.TXT",
+        "@rocprim_archive//:LICENSE.txt",
     ]) + tf_additional_license_deps(),
 )
 

--- a/third_party/rocprim.BUILD
+++ b/third_party/rocprim.BUILD
@@ -2,7 +2,7 @@
 
 licenses(["notice"])  # BSD
 
-exports_files(["LICENSE.TXT"])
+exports_files(["LICENSE.txt"])
 
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm", "rocm_default_copts")
 


### PR DESCRIPTION
The actual filename in the rocprim archive is LICENSE.txt (lowecase extension).
Updating the TF BUILD files to correct the name.

This change is (one of two) needed to fix the broken `--config=rocm` build (post PR 26722 merge). See PR #28116 for the other part of the fix