### PR TITLE
Exclude device_tracer for CPU build

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -612,8 +612,9 @@ def tf_additional_device_tracer_test_flags():
 def tf_additional_profiler_lib_deps():
     return [
         "//tensorflow/core/profiler/internal/cpu:host_tracer",
+    ] + if_cuda([
         "//tensorflow/core/profiler/internal/gpu:device_tracer",
-    ]
+    ])
 
 def tf_additional_libdevice_data():
     return []


### PR DESCRIPTION
The file tensorflow/core/platform/default/device_tracer.cc is actually empty during the CPU build because GOOGLE_CUDA is not defined. So the cc library for device_tracer is empty, and when force linking (/WHOLEARCHIVE is used for linking shared library) an empty cc library with MSVC, we hit this compiler bug:
https://support.microsoft.com/en-hk/help/4020481/fix-link-exe-crashes-with-a-fatal-lnk1000-error-when-you-use-wholearch

Since device tracer is only for GPU build, the solution is to exclude it from CPU build.

PiperOrigin-RevId: 244872492