### PR TITLE
Remove kissfft license from the OSS licenses group as it is still causing build issues.

### DIFF
--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -178,7 +178,6 @@ filegroup(
         "@icu//:icu4c/LICENSE",
         "@jpeg//:LICENSE.md",
         "@keras_applications_archive//:LICENSE",
-        "@kissfft//:LICENSE",
         "@lmdb//:LICENSE",
         "@local_config_sycl//sycl:LICENSE.text",
         "@nasm//:LICENSE",


### PR DESCRIPTION
PiperOrigin-RevId: 245155471