### PR TITLE
'shape' attribute in strip_unused_lib.py

### DIFF
--- a/tensorflow/python/tools/strip_unused_lib.py
+++ b/tensorflow/python/tools/strip_unused_lib.py
@@ -75,6 +75,8 @@ def strip_unused(input_graph_def, input_node_names, output_node_names,
       if "_output_shapes" in node.attr:
         placeholder_node.attr["_output_shapes"].CopyFrom(node.attr[
             "_output_shapes"])
+      if "shape" in node.attr:
+        placeholder_node.attr["shape"].CopyFrom(node.attr["shape"])
       inputs_replaced_graph_def.node.extend([placeholder_node])
     else:
       inputs_replaced_graph_def.node.extend([copy.deepcopy(node)])


### PR DESCRIPTION
Added copying 'shape' attribute of graph node. Missing values caused unknown shapes for usages like TensorBoard or TensorRT.