### PR TITLE
Fix multiline magic

### DIFF
--- a/tensorflow/tools/compatibility/ipynb.py
+++ b/tensorflow/tools/compatibility/ipynb.py
@@ -157,7 +157,7 @@ def _update_notebook(original_notebook, original_raw_lines, updated_code_lines):
 
   code_cell_idx = 0
   for cell in new_notebook["cells"]:
-    if cell["cell_type"] != "code":
+    if not is_python(cell):
       continue
 
     applicable_lines = [


### PR DESCRIPTION
Unfortunately, the feature for multiline introduced by another contributor in https://github.com/tensorflow/tensorflow/commit/93557712d0082a7e9fda3daacefddefb15e5d722#diff-db01673eb6e019b39689cd41bfae3d5e breaks notebook cell alignment. 

The problem is that we skip the cell, during `_get_code `, but do not skip the same cells during `_update_notebook `. As a result, the diffs, that have such multiline magic, are aligned

This PR should fix the problem.