### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build.

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_platform.cc
+++ b/tensorflow/stream_executor/rocm/rocm_platform.cc
@@ -109,6 +109,11 @@ int ROCmPlatform::VisibleDeviceCount() const {
 
 const string& ROCmPlatform::Name() const { return name_; }
 
+port::StatusOr<std::unique_ptr<DeviceDescription>>
+ROCmPlatform::DescriptionForDevice(int ordinal) const {
+  return GpuExecutor::CreateDeviceDescription(ordinal);
+}
+
 port::StatusOr<StreamExecutor*> ROCmPlatform::ExecutorForDevice(int ordinal) {
   StreamExecutorConfig config;
   config.ordinal = ordinal;

--- a/tensorflow/stream_executor/rocm/rocm_platform.h
+++ b/tensorflow/stream_executor/rocm/rocm_platform.h
@@ -64,6 +64,9 @@ class ROCmPlatform : public Platform {
 
   const string& Name() const override;
 
+  port::StatusOr<std::unique_ptr<DeviceDescription>>
+  DescriptionForDevice(int ordinal) const override;
+
   port::StatusOr<StreamExecutor*> ExecutorForDevice(int ordinal) override;
 
   port::StatusOr<StreamExecutor*> ExecutorForDeviceWithPluginConfig(


### PR DESCRIPTION
The `--config=rocm` build was broken by the following commit.

https://github.com/tensorflow/tensorflow/commit/9b10284509bda0212e9d7eb7f797ad1b1ed63280

The changes made by the above commit were incomplete for the ROCm platform. This update fills in the missing gaps to complete the ROCm functionality associated with the commit above amd make the `--config=rocm` build working again.

-----------------------------

@tatianashp , @whchung just FYI

Please approve and merge. The changes here are trivial and only applicable for the `--config=rocm` build.

thanks