### PR TITLE
Fix memory leak in gcs file cache under certain STL versions.

### DIFF
--- a/tensorflow/core/platform/cloud/ram_file_block_cache.cc
+++ b/tensorflow/core/platform/cloud/ram_file_block_cache.cc
@@ -104,7 +104,9 @@ Status RamFileBlockCache::MaybeFetch(const Key& key,
           mutex_lock l(mu_);
           // Do not update state if the block is already to be evicted.
           if (block->timestamp != 0) {
-            cache_size_ += block->data.size();
+            // Use capacity() instead of size() to account for all  memory
+            // used by the cache.
+            cache_size_ += block->data.capacity();
             // Put to beginning of LRA list.
             lra_list_.erase(block->lra_iterator);
             lra_list_.push_front(key);
@@ -132,7 +134,9 @@ Status RamFileBlockCache::MaybeFetch(const Key& key,
         block->mu.lock();  // Reacquire the lock immediately afterwards
         if (status.ok()) {
           block->data.resize(bytes_transferred, 0);
-          block->data.shrink_to_fit();
+          // Shrink the data capacity to the actual size used.
+          // NOLINTNEXTLINE: shrink_to_fit() may not shrink the capacity.
+          std::vector<char>(block->data).swap(block->data);
           downloaded_block = true;
           block->state = FetchState::FINISHED;
         } else {
@@ -285,7 +289,7 @@ void RamFileBlockCache::RemoveBlock(BlockMap::iterator entry) {
   entry->second->timestamp = 0;
   lru_list_.erase(entry->second->lru_iterator);
   lra_list_.erase(entry->second->lra_iterator);
-  cache_size_ -= entry->second->data.size();
+  cache_size_ -= entry->second->data.capacity();
   block_map_.erase(entry);
 }
 


### PR DESCRIPTION
The memory leak results from using vector<T>::shrink_to_fit() to attempt to
shrink the allocated space to the size used, however, the behavior of
shrink_to_fit() is implemention defined and may not actually shrink the
allocated space. This results in memory leak when Tensorflow is compiled under
certain compiler versions (e.g. g++ 5.4).

PiperOrigin-RevId: 245458291