### PR TITLE
tf.image.per_image_standardization respects input dtype

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1471,14 +1471,16 @@ def resize_image_with_pad_v2(image,
 
 @tf_export('image.per_image_standardization')
 def per_image_standardization(image):
-  """Linearly scales `image` to have zero mean and unit variance.
+  """Linearly scales each image in `image` to have zero mean and unit variance.
 
-  This op computes `(x - mean) / adjusted_stddev`, where `mean` is the average
-  of all values in image, and
-  `adjusted_stddev = max(stddev, 1.0/sqrt(image.NumElements()))`.
+  For each image `x` in `image`, computes `(x - mean) / adjusted_stddev`, where
 
-  `stddev` is the standard deviation of all values in `image`. It is capped
-  away from zero to protect against division by 0 when handling uniform images.
+  - `mean` is the average of all values in `x`
+  - `adjusted_stddev = max(stddev, 1.0/sqrt(N))`
+    - `N` is the number of elements in `x`
+    - `stddev` is the standard deviation of all values in `x`
+    - `adjusted_stddev` is capped away from zero to protect against division by 0
+      when handling uniform images
 
   Args:
     image: An n-D Tensor where the last 3 dimensions are `[height, width,
@@ -2923,7 +2925,7 @@ def _ssim_helper(x, y, reducer, max_val, compensation=1.0, k1=0.01, k2=0.03):
     x: First set of images.
     y: Second set of images.
     reducer: Function that computes 'local' averages from set of images. For
-      non-covolutional version, this is usually tf.reduce_mean(x, [1, 2]), and
+      non-convolutional version, this is usually tf.reduce_mean(x, [1, 2]), and
       for convolutional version, this is usually tf.nn.avg_pool2d or
       tf.nn.conv2d with weighted-sum kernel.
     max_val: The dynamic range (i.e., the difference between the maximum

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -31,7 +31,6 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import check_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_image_ops
-from tensorflow.python.ops import gen_nn_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn
 from tensorflow.python.ops import nn_ops

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -445,7 +445,7 @@ def flip_up_down(image):
       of shape `[height, width, channels]`.
 
   Returns:
-    A tensor of the same type and shape as `image`.
+    A `Tensor` of the same type and shape as `image`.
 
   Raises:
     ValueError: if the shape of `image` not supported.
@@ -467,7 +467,7 @@ def _flip(image, flip_index, scope_name):
     scope_name: string, scope name.
 
   Returns:
-    A tensor of the same type and shape as `image`.
+    A `Tensor` of the same type and shape as `image`.
 
   Raises:
     ValueError: if the shape of `image` not supported.
@@ -557,8 +557,7 @@ def _rot90_4D(images, k, name_scope):
     name_scope: A valid TensorFlow name scope.
 
   Returns:
-    A 4-D tensor of the same type and shape as `images`.
-
+    A 4-D `Tensor` of the same type and shape as `images`.
   """
 
   def _rot90():
@@ -1505,7 +1504,7 @@ def per_image_standardization(image):
 
     # Apply a minimum normalization that protects us against uniform images.
     stddev = math_ops.reduce_std(image, axis=[-1, -2, -3], keepdims=True)
-    min_stddev = math_ops.rsqrt(math_ops.cast(num_pixels, dtypes.float32))
+    min_stddev = math_ops.rsqrt(math_ops.cast(num_pixels, image.dtype))
     adjusted_stddev = math_ops.maximum(stddev, min_stddev)
 
     image -= image_mean
@@ -2070,7 +2069,7 @@ def is_jpeg(contents, name=None):
      is_jpeg is susceptible to false positives.
   """
   # Normal JPEGs start with \xff\xd8\xff\xe0
-  # JPEG with EXIF stats with \xff\xd8\xff\xe1
+  # JPEG with EXIF starts with \xff\xd8\xff\xe1
   # Use \xff\xd8\xff to cover both.
   with ops.name_scope(name, 'is_jpeg'):
     substr = string_ops.substr(contents, 0, 3)
@@ -2446,8 +2445,7 @@ def sample_distorted_bounding_box(image_size,
   original image. The output is returned as 3 tensors: `begin`, `size` and
   `bboxes`. The first 2 tensors can be fed directly into `tf.slice` to crop the
   image. The latter may be supplied to `tf.image.draw_bounding_boxes` to
-  visualize
-  what the bounding box looks like.
+  visualize what the bounding box looks like.
 
   Bounding boxes are supplied and returned as `[y_min, x_min, y_max, x_max]`.
   The
@@ -2473,7 +2471,7 @@ def sample_distorted_bounding_box(image_size,
   ```
 
   Note that if no bounding box information is available, setting
-  `use_image_if_no_bounding_boxes = true` will assume there is a single implicit
+  `use_image_if_no_bounding_boxes = True` will assume there is a single implicit
   bounding box covering the whole image. If `use_image_if_no_bounding_boxes` is
   false and no bounding boxes are supplied, an error is raised.
 

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1549,15 +1549,14 @@ class PerImageWhiteningTest(test_util.TensorFlowTestCase):
 
   def testPreservesDtype(self):
     imgs_npu8 = np.random.uniform(0., 255., [2, 5, 5, 3]).astype(np.uint8)
-    imgs_npf16 = np.random.uniform(0., 255., [2, 5, 5, 3]).astype(np.float16)
-    with self.cached_session(use_gpu=True):
-      imgs_tfu8 = constant_op.constant(imgs_npu8)
-      whiten_tfu8 = image_ops.per_image_standardization(imgs_tfu8)
-      self.assertEqual(whiten_tfu8.dtype, tf.uint8)
+    imgs_tfu8 = constant_op.constant(imgs_npu8)
+    whiten_tfu8 = image_ops.per_image_standardization(imgs_tfu8)
+    self.assertEqual(whiten_tfu8.dtype, tf.uint8)
 
-      imgs_tff16 = constant_op.constant(imgs_npf16)
-      whiten_tff16 = image_ops.per_image_standardization(imgs_tff16)
-      self.assertEqual(whiten_tff16.dtype, tf.float16)
+    imgs_npf16 = np.random.uniform(0., 255., [2, 5, 5, 3]).astype(np.float16)
+    imgs_tff16 = constant_op.constant(imgs_npf16)
+    whiten_tff16 = image_ops.per_image_standardization(imgs_tff16)
+    self.assertEqual(whiten_tff16.dtype, tf.float16)
 
 
 class CropToBoundingBoxTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1507,10 +1507,9 @@ class PerImageWhiteningTest(test_util.TensorFlowTestCase):
 
   def _NumpyPerImageWhitening(self, x):
     num_pixels = np.prod(x.shape)
-    x2 = np.square(x).astype(np.float32)
     mn = np.mean(x)
-    vr = np.mean(x2) - (mn * mn)
-    stddev = max(math.sqrt(vr), 1.0 / math.sqrt(num_pixels))
+    std = np.std(x)
+    stddev = max(std, 1.0 / math.sqrt(num_pixels))
 
     y = x.astype(np.float32)
     y -= mn
@@ -1520,7 +1519,7 @@ class PerImageWhiteningTest(test_util.TensorFlowTestCase):
   @test_util.run_deprecated_v1
   def testBasic(self):
     x_shape = [13, 9, 3]
-    x_np = np.arange(0, np.prod(x_shape), dtype=np.int32).reshape(x_shape)
+    x_np = np.arange(0, np.prod(x_shape), dtype=np.float32).reshape(x_shape)
     y_np = self._NumpyPerImageWhitening(x_np)
 
     with self.cached_session(use_gpu=True):
@@ -1547,6 +1546,18 @@ class PerImageWhiteningTest(test_util.TensorFlowTestCase):
       whiten_tf = self.evaluate(whiten)
       for w_tf, w_np in zip(whiten_tf, whiten_np):
         self.assertAllClose(w_tf, w_np, atol=1e-4)
+
+  def testPreservesDtype(self):
+    imgs_npu8 = np.random.uniform(0., 255., [2, 5, 5, 3]).astype(np.uint8)
+    imgs_npf16 = np.random.uniform(0., 255., [2, 5, 5, 3]).astype(np.float16)
+    with self.cached_session(use_gpu=True):
+      imgs_tfu8 = constant_op.constant(imgs_npu8)
+      whiten_tfu8 = image_ops.per_image_standardization(imgs_tfu8)
+      self.assertEqual(whiten_tfu8.dtype, tf.uint8)
+
+      imgs_tff16 = constant_op.constant(imgs_npf16)
+      whiten_tff16 = image_ops.per_image_standardization(imgs_tff16)
+      self.assertEqual(whiten_tff16.dtype, tf.float16)
 
 
 class CropToBoundingBoxTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1551,12 +1551,12 @@ class PerImageWhiteningTest(test_util.TensorFlowTestCase):
     imgs_npu8 = np.random.uniform(0., 255., [2, 5, 5, 3]).astype(np.uint8)
     imgs_tfu8 = constant_op.constant(imgs_npu8)
     whiten_tfu8 = image_ops.per_image_standardization(imgs_tfu8)
-    self.assertEqual(whiten_tfu8.dtype, tf.uint8)
+    self.assertEqual(whiten_tfu8.dtype, dtypes.uint8)
 
     imgs_npf16 = np.random.uniform(0., 255., [2, 5, 5, 3]).astype(np.float16)
     imgs_tff16 = constant_op.constant(imgs_npf16)
     whiten_tff16 = image_ops.per_image_standardization(imgs_tff16)
-    self.assertEqual(whiten_tff16.dtype, tf.float16)
+    self.assertEqual(whiten_tff16.dtype, dtypes.float16)
 
 
 class CropToBoundingBoxTest(test_util.TensorFlowTestCase):


### PR DESCRIPTION
Make it clear that it can operate on batches of image