### PR TITLE
Fix invalid deprecation pointer for tf.layers.average_pooling1d/max_pooling1d

### DIFF
--- a/tensorflow/python/layers/pooling.py
+++ b/tensorflow/python/layers/pooling.py
@@ -60,7 +60,7 @@ class AveragePooling1D(keras_layers.AveragePooling1D, base.Layer):
 
 @deprecation.deprecated(
     date=None,
-    instructions='Use keras.layers.average_pooling1d instead.')
+    instructions='Use keras.layers.AveragePooling1D instead.')
 @tf_export(v1=['layers.average_pooling1d'])
 def average_pooling1d(inputs, pool_size, strides,
                       padding='valid', data_format='channels_last',
@@ -131,7 +131,7 @@ class MaxPooling1D(keras_layers.MaxPooling1D, base.Layer):
 
 @deprecation.deprecated(
     date=None,
-    instructions='Use keras.layers.max_pooling1d instead.')
+    instructions='Use keras.layers.MaxPooling1D instead.')
 @tf_export(v1=['layers.max_pooling1d'])
 def max_pooling1d(inputs, pool_size, strides,
                   padding='valid', data_format='channels_last',

--- a/tensorflow/python/layers/pooling.py
+++ b/tensorflow/python/layers/pooling.py
@@ -202,7 +202,7 @@ class AveragePooling2D(keras_layers.AveragePooling2D, base.Layer):
 
 @deprecation.deprecated(
     date=None,
-    instructions='Use keras.layers.average_pooling2d instead.')
+    instructions='Use keras.layers.AveragePooling2D instead.')
 @tf_export(v1=['layers.average_pooling2d'])
 def average_pooling2d(inputs,
                       pool_size, strides,
@@ -276,7 +276,7 @@ class MaxPooling2D(keras_layers.MaxPooling2D, base.Layer):
 
 @deprecation.deprecated(
     date=None,
-    instructions='Use keras.layers.max_pooling2d instead.')
+    instructions='Use keras.layers.MaxPooling2D instead.')
 @tf_export(v1=['layers.max_pooling2d'])
 def max_pooling2d(inputs,
                   pool_size, strides,
@@ -352,7 +352,7 @@ class AveragePooling3D(keras_layers.AveragePooling3D, base.Layer):
 
 @deprecation.deprecated(
     date=None,
-    instructions='Use keras.layers.average_pooling3d instead.')
+    instructions='Use keras.layers.AveragePooling3D instead.')
 @tf_export(v1=['layers.average_pooling3d'])
 def average_pooling3d(inputs,
                       pool_size, strides,
@@ -430,7 +430,7 @@ class MaxPooling3D(keras_layers.MaxPooling3D, base.Layer):
 
 @deprecation.deprecated(
     date=None,
-    instructions='Use keras.layers.max_pooling3d instead.')
+    instructions='Use keras.layers.MaxPooling3D instead.')
 @tf_export(v1=['layers.max_pooling3d'])
 def max_pooling3d(inputs,
                   pool_size, strides,


### PR DESCRIPTION
In tf.layers the deprecation notice of tf.layers.average_pooling1d/max_pooling1d points to non-existance tf.keras.layers.average_pooling1d/max_pooling1d.

This fix updates the notice to point to tf.keras.layers.AveragePooling1D/MaxPooling1D

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>