### PR TITLE
tensorflow/lite/experimental/microfrontend/lib/frontend_memmap_genera…

### DIFF
--- a/tensorflow/lite/experimental/microfrontend/lib/frontend_memmap_generator.c
+++ b/tensorflow/lite/experimental/microfrontend/lib/frontend_memmap_generator.c
@@ -22,7 +22,7 @@ int main(int argc, char** argv) {
   if (argc != 3) {
     fprintf(stderr,
             "%s requires exactly two parameters - the names of the header and "
-            "source files to save\n");
+            "source files to save\n", argv[0]);
     return 1;
   }
   struct FrontendConfig frontend_config;


### PR DESCRIPTION
I added a missing fprintf string argument in tensorflow/lite/experimental/microfrontend/lib/frontend_memmap_generator.c, which probably would have caused a memory fault.  I am currently having a build problem so I have not tried running it, but I did confirm that compiling this file from the command line with g++ originally generated an appropriate warning about this problem and that this change at least eliminates that warning.

I am not currently a tensorflow user or developer, but just happened to notice this problem when trying out cppcheck on different source trees.  Because of this and the problem I was having with bazel, I have not included the unit test recommended by your coding guidelines.  Because this change is trivial and only effects a code path that probably almost always crashed before, I hope you will merge this patch without the test case for now.

Thanks for considering this patch.