### PR TITLE
Fix misalignment of documentation in BahdanauAttention

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
+++ b/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
@@ -937,7 +937,7 @@ class BahdanauAttention(_BaseAttentionMechanism):
       num_units: The depth of the query mechanism.
       memory: The memory to query; usually the output of an RNN encoder.  This
         tensor should be shaped `[batch_size, max_time, ...]`.
-      memory_sequence_length (optional): Sequence lengths for the batch entries
+      memory_sequence_length: (optional) Sequence lengths for the batch entries
         in memory.  If provided, the memory tensor rows are masked with zeros
         for values past the respective sequence lengths.
       normalize: Python boolean.  Whether to normalize the energy term.


### PR DESCRIPTION
This fix fixes the misalignment of documentation in BahdanauAttention,
as was specified in #28054. The issue seems to be that ` (optional)`
should be placed after the `:` so that memory_sequence_length
could be identified as an arg.

This fix fixes #28054.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>