### PR TITLE
Make sure tasks in FutureElementsManager finish when saving/destructing ParallelInterleaveIterator

### DIFF
--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
@@ -196,7 +196,8 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
                 Env::Default(), ThreadOptions(),
                 "data_parallel_interleave_worker_pool",
                 port::NumSchedulableCPUs() /* num_threads */,
-                false /* low_latency_hint */)) {}
+                false /* low_latency_hint */)) {
+      }
 
       ~ParallelInterleaveIterator() override {
         mutex_lock l(*mu_);
@@ -896,9 +897,9 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
       // Identifies the number of open iterators.
       int64 num_open_ GUARDED_BY(*mu_) = 0;
 
-      // Identifies the number of outstanding calls for CurrentElementManager.
+      // Identifies the number of outstanding calls for CurrentElementsManager.
       int64 current_num_calls_ GUARDED_BY(*mu_) = 0;
-      // Identifies the number of outstanding calls for FutureElementManager.
+      // Identifies the number of outstanding calls for FutureElementsManager.
       int64 future_num_calls_ GUARDED_BY(*mu_) = 0;
 
       std::unique_ptr<thread::ThreadPool> thread_pool_;

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
@@ -196,8 +196,7 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
                 Env::Default(), ThreadOptions(),
                 "data_parallel_interleave_worker_pool",
                 port::NumSchedulableCPUs() /* num_threads */,
-                false /* low_latency_hint */)) {
-      }
+                false /* low_latency_hint */)) {}
 
       ~ParallelInterleaveIterator() override {
         mutex_lock l(*mu_);
@@ -205,7 +204,7 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
         cancelled_ = true;
         cond_var_->notify_all();
         // Wait for all in-flight calls to complete.
-        while (num_calls_ > 0) {
+        while (current_num_calls_ > 0 || future_num_calls_ > 0) {
           cond_var_->wait(l);
         }
       }
@@ -258,10 +257,11 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
       Status SaveInternal(IteratorStateWriter* writer) override {
         mutex_lock l(*mu_);
         // Wait for all in-flight calls to complete.
-        while (num_calls_ > 0) {
+        while (current_num_calls_ > 0 || future_num_calls_ > 0) {
           cond_var_->wait(l);
         }
-        DCHECK_EQ(num_calls_, 0);
+        DCHECK_EQ(current_num_calls_, 0);
+        DCHECK_EQ(future_num_calls_, 0);
         TF_RETURN_IF_ERROR(SaveInput(writer, input_impl_));
         TF_RETURN_IF_ERROR(
             writer->WriteScalar(full_name("block_index"), block_index_));
@@ -438,7 +438,8 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
               }
             }
           }
-          return all_elements_busy || num_calls_ >= num_parallel_calls_->value;
+          return all_elements_busy ||
+                 current_num_calls_ >= num_parallel_calls_->value;
         };
         while (true) {
           mutex_lock l(*mu_);
@@ -482,19 +483,19 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
                     dataset()->block_length_ - element->results.size();
               }
               if (num_results > 0) {
-                num_calls_++;
+                current_num_calls_++;
                 element->in_use = true;
                 thread_pool_->Schedule(std::bind(
                     &ParallelInterleaveIterator::FetchResults, this, ctx,
                     std::move(element), num_results,
                     [this, ctx]() EXCLUSIVE_LOCKS_REQUIRED(*mu_) {
-                      --num_calls_;
+                      --current_num_calls_;
                       const auto& stats_aggregator = ctx->stats_aggregator();
                       if (stats_aggregator) {
                         stats_aggregator->AddScalar(
                             stats_utils::ThreadUtilizationScalarName(
                                 dataset()->node_name()),
-                            static_cast<float>(num_calls_) /
+                            static_cast<float>(current_num_calls_) /
                                 static_cast<float>(num_parallel_calls_->value),
                             num_elements());
                       }
@@ -507,7 +508,7 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
             stats_aggregator->AddScalar(
                 stats_utils::ThreadUtilizationScalarName(
                     dataset()->node_name()),
-                static_cast<float>(num_calls_) /
+                static_cast<float>(current_num_calls_) /
                     static_cast<float>(num_parallel_calls_->value),
                 num_elements());
           }
@@ -604,10 +605,13 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
               continue;
             }
             DisableAutotune(ctx.get(), element->iterator.get());
+            ++future_num_calls_;
             element->in_use = true;
-            thread_pool_->Schedule(
-                std::bind(&ParallelInterleaveIterator::FetchResults, this, ctx,
-                          std::move(element), dataset()->block_length_, [] {}));
+            thread_pool_->Schedule(std::bind(
+                &ParallelInterleaveIterator::FetchResults, this, ctx,
+                std::move(element), dataset()->block_length_,
+                [this]()
+                    EXCLUSIVE_LOCKS_REQUIRED(*mu_) { --future_num_calls_; }));
           }
           cond_var_->notify_all();
         }
@@ -892,8 +896,10 @@ class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
       // Identifies the number of open iterators.
       int64 num_open_ GUARDED_BY(*mu_) = 0;
 
-      // Identifies the number of outstanding calls.
-      int64 num_calls_ GUARDED_BY(*mu_) = 0;
+      // Identifies the number of outstanding calls for CurrentElementManager.
+      int64 current_num_calls_ GUARDED_BY(*mu_) = 0;
+      // Identifies the number of outstanding calls for FutureElementManager.
+      int64 future_num_calls_ GUARDED_BY(*mu_) = 0;
 
       std::unique_ptr<thread::ThreadPool> thread_pool_;
       std::unique_ptr<Thread> current_elements_manager_ GUARDED_BY(*mu_);

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
@@ -884,7 +884,6 @@ TEST_F(ParallelInterleaveDatasetOpTest, IteratorOutputPrefix) {
   EXPECT_EQ(iterator->prefix(), "Iterator::ParallelInterleaveV2");
 }
 
-// TODO(b/130309946): Re-enable once deflaked.
 TEST_P(ParameterizedParallelInterleaveDatasetOpTest, Roundtrip) {
   int thread_num = 2, cpu_num = 2;
   const TestCase &test_case = GetParam();

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
@@ -885,7 +885,7 @@ TEST_F(ParallelInterleaveDatasetOpTest, IteratorOutputPrefix) {
 }
 
 // TODO(b/130309946): Re-enable once deflaked.
-TEST_P(ParameterizedParallelInterleaveDatasetOpTest, DISABLED_Roundtrip) {
+TEST_P(ParameterizedParallelInterleaveDatasetOpTest, Roundtrip) {
   int thread_num = 2, cpu_num = 2;
   const TestCase &test_case = GetParam();
   TF_ASSERT_OK(InitThreadPool(thread_num));


### PR DESCRIPTION
This PR makes sure that all the tasks in `FutureElementsManager` finish when saving/destructing `ParallelInterleaveIterator`. Otherwise, it may miss some elements that are under processing by `FutureElementsManager` when saving `ParallelInterleaveIterator`. It fixes the flaky issue in `ParallelInterleaveDatasetOpTest`.

cc: @jsimsa 