### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build.

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/stream_executor/rocm/rocm_driver.cc
@@ -305,8 +305,8 @@ static port::Status InternalInit() {
 /* static */ port::Status GpuDriver::Init() {
   // Cached return value from calling InternalInit(), as hipInit need only be
   // called once, but GpuDriver::Init may be called many times.
-  static port::Status* init_retval = [&] {
-    init_retval = new Status(InternalInit());
+  static port::Status* init_retval = [] {
+    return new port::Status(InternalInit());
   }();
   return *init_retval;
 }


### PR DESCRIPTION
Note: This ia a different PR from PRs #28189 and #28263 (same symptom, different cause and fix)

The `--config=rocm` build was broken by the following commit.

https://github.com/tensorflow/tensorflow/commit/481748b5c92d217dd1b10725ce259ba8c7086df0

The changes made by the above commit had one bug in the changes for the ROCm platform, whias was leading to the build failure. Fixing that bug to make the `--config=rocm` build working again.

-------------------------------------------------

@tatianashp , @whchung, @timshen91  just FYI

Please approve and merge. As with PRs #28189 and #28263, the changes here are trivial and only applicable for the --config=rocm build.

thanks