### PR TITLE
[TF Lite] Add Ruy sources to Makefile

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -239,11 +239,15 @@ $(LIB_PATH): tensorflow/lite/schema/schema_generated.h $(LIB_OBJS)
 	@mkdir -p $(dir $@)
 	$(AR) $(ARFLAGS) $(LIB_PATH) $(LIB_OBJS)
 
+lib: $(LIB_PATH)
+
 $(MINIMAL_BINARY): $(MINIMAL_OBJS) $(LIB_PATH)
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) \
 	-o $(MINIMAL_BINARY) $(MINIMAL_OBJS) \
 	$(LIBFLAGS) $(LIB_PATH) $(LDFLAGS) $(LIBS)
+
+minimal: $(MINIMAL_BINARY)
 
 $(BENCHMARK_LIB) : $(LIB_PATH) $(BENCHMARK_OBJS)
 	@mkdir -p $(dir $@)

--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -93,10 +93,21 @@ CORE_CC_ALL_SRCS := \
 $(wildcard tensorflow/lite/*.cc) \
 $(wildcard tensorflow/lite/*.c) \
 $(wildcard tensorflow/lite/c/*.c) \
+$(wildcard tensorflow/lite/core/*.cc) \
+$(wildcard tensorflow/lite/core/api/*.cc) \
 $(wildcard tensorflow/lite/experimental/c/*.c) \
 $(wildcard tensorflow/lite/experimental/c/*.cc) \
-$(wildcard tensorflow/lite/core/*.cc) \
-$(wildcard tensorflow/lite/core/api/*.cc)
+$(wildcard tensorflow/lite/experimental/ruy/allocator.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/block_map.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/blocking_counter.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/context.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/detect_dotprod.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/kernel.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/pack.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/pmu.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/thread_pool.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/trace.cc) \
+$(wildcard tensorflow/lite/experimental/ruy/tune.cc)
 ifneq ($(BUILD_TYPE),micro)
 CORE_CC_ALL_SRCS += \
 $(wildcard tensorflow/lite/kernels/*.cc) \


### PR DESCRIPTION
This PR makes the Makefile makeable again.

Changes:
1. Add Ruy sources to the Makefile.
    - The source files need to be listed separately instead of a wildcard as the flat `ruy` folder contains also tests and benchmarks that should not be in the static library (and they also have some heavy dependencies). Making a few folders in Ruy would help significantly (e.g., standard `src/`, `test/` and `tools/`).
    - Continuous integration for the Makefile would be great.
2. (Add platform independent aliases to the Makefile targets, similarly to what is done for `benchmark`.)

It needs to be noted that for Raspberry Pi build, it is still necessary to disable NNAPI for some reason. See #25120.