### PR TITLE
Update documentation template to match recommendations from doc sprints

### DIFF
--- a/.github/ISSUE_TEMPLATE/20-documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/20-documentation-issue.md
@@ -4,14 +4,33 @@ about: Use this template for documentation related issues
 
 ---
 
-<em>Please make sure that this is a documentation issue. As per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md), we only address code/doc bugs, performance issues, feature requests and build/installation issues on GitHub. tag:doc_template</em>
+<em>Thanks so much for taking the time to file a documentation issue and even more thanks if you intend to contribute to updating it! Please do introduce yourself on our Mailing List via [Google Groups](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs) or [email](mailto:docs@tensorflow.org list) and let us know if you have any questions. We also encourage you to review our [Documentation Contributor Guide](https://www.tensorflow.org/community/contribute/docs). As a side note, per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md), we only address code/doc bugs, performance issues, feature requests and build/installation issues on GitHub. tag:doc_template</em>
 
+## Existing URLs containing the issue:
+Link to the documentation entry, for example: https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/MyMethod
 
-**System information**
-- TensorFlow version:
-- Doc Link:
+## Description of issue (what needs changing):
 
+### Correct Links
+Is the link pointing to the source code correct? To find the source code, use `git grep my_method` from the git command line in your locally checked out repository.
 
-**Describe the documentation issue**
+### Clear Description
+Why should someone use this method? How is it useful?
 
-**We welcome contributions by users. Will you be able to update submit a PR (use the [doc style guide](https://www.tensorflow.org/community/documentation)) to fix the doc Issue?**
+### Usage Example
+Is there a usage example?
+
+### Parameters Defined
+Are all arguments that can be passed in defined and formatted correctly?
+
+### Returns Defined
+Are return values defined?
+
+### Raises Listed and Defined
+Are errors defined? [Example](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/feature_column/categorical_column_with_vocabulary_file#raises)
+
+### Request Visuals, if Applicable
+Are there currently visuals? If not, would they make the content clearer?
+
+### Submit PR?
+Are you planning to also submit a [Pull Request](https://help.github.com/en/articles/about-pull-requests) to fix this issue? See the [Documentation Contributor Guide](https://www.tensorflow.org/community/contribute/docs) the [Documentation Style Guide](https://www.tensorflow.org/community/contribute/docs_style).

--- a/.github/ISSUE_TEMPLATE/20-documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/20-documentation-issue.md
@@ -4,7 +4,9 @@ about: Use this template for documentation related issues
 
 ---
 
-<em>Thanks so much for taking the time to file a documentation issue and even more thanks if you intend to contribute to updating it! Please do introduce yourself on our Mailing List via [Google Groups](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs) or [email](mailto:docs@tensorflow.org list) and let us know if you have any questions. We also encourage you to review our [Documentation Contributor Guide](https://www.tensorflow.org/community/contribute/docs). As a side note, per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md), we only address code/doc bugs, performance issues, feature requests and build/installation issues on GitHub. tag:doc_template</em>
+<em>Thanks so much for taking the time to file a documentation issue and even more thanks if you intend to contribute to updating it! Please do introduce yourself on our mailing list with
+[Google Groups](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs) or
+[email](mailto:docs@tensorflow.org) and let us know if you have any questions. We also encourage you to review our [Documentation Contributor Guide](https://www.tensorflow.org/community/contribute/docs). As a side note, per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md), we only address code/doc bugs, performance issues, feature requests and build/installation issues on GitHub. tag:doc_template</em>
 
 ## Existing URLs containing the issue:
 Link to the documentation entry, for example: https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/MyMethod


### PR DESCRIPTION
Example issue from @dynamicwebpaige this template is based on - https://github.com/tensorflow/tensorflow/issues/25794

TF API 2.0 Symbol documentation: https://docs.google.com/document/d/1e20k9CuaZ_-hp25-sSd8E8qldxKPKQR-SkwojYr_r-U/edit

Tensorflow doc sprint tasks: https://docs.google.com/spreadsheets/d/1p3vqbocbKmcZQGrlxk9m2jHuleu8yr-XRbfKum0IDD8/edit#gid=0

From Gwitter conversation:
Augustina Ragwitz @missaugustina 12:51
There is a link to file a new docs issue in the README for the docs repo that uses a template that I'm not sure is current. I can file a bug for this against the docs repo - https://github.com/tensorflow/tensorflow/issues/new?template=20-documentation-issue.md
or maybe i can't.. .guess it would have to go in the main TF repo

Billy Lamberta @lamberta 13:17
The template shown yesterday was a proposal, but I agree it's better than what we have now. @margaretmz or @lc0 (or whoever) , can you make a PR for the new docs issue template on tensorflow/tensorflow? I think that file is here: https://github.com/tensorflow/tensorflow/blob/master/.github/ISSUE_TEMPLATE/20-documentation-issue.md

Augustina Ragwitz @missaugustina 13:19
I can do that
i just need the new suggested template
i didn't get a link yesterday, was it shared? i don't remember seeing it

Billy Lamberta @lamberta 13:20
Thanks. Yeah, I don't have it, I believe Margaret and Sergii have it

Augustina Ragwitz @missaugustina 13:22
i'll start a PR
i have the one Paige used in her example update, if anyone wants to suggest the new one I can update or someone else can