### PR TITLE
[ROCm] Adding Cuda Alias to Gpu functions

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -47,6 +47,7 @@ load(
 load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_test")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_tests")
+load("//tensorflow:tensorflow.bzl", "if_cuda_or_rocm")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda_is_configured")
 load(
     "//tensorflow/core:platform/default/build_config.bzl",

--- a/tensorflow/core/kernels/check_numerics_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/check_numerics_op_gpu.cu.cc
@@ -24,6 +24,7 @@ limitations under the License.
 
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/gpu_launch_config.h"
 
 namespace tensorflow {

--- a/tensorflow/core/kernels/scan_ops_gpu.h
+++ b/tensorflow/core/kernels/scan_ops_gpu.h
@@ -33,6 +33,7 @@ limitations under the License.
 #include "tensorflow/core/framework/numeric_types.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/scan_ops.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/gpu_launch_config.h"
 #include "tensorflow/core/util/permutation_input_iterator.h"
 #include "tensorflow/core/util/permutation_output_iterator.h"

--- a/tensorflow/core/kernels/tridiagonal_solve_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/tridiagonal_solve_op_gpu.cu.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/transpose_functor.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/gpu_device_functions.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/gpu_launch_config.h"
 
 namespace tensorflow {

--- a/tensorflow/core/util/gpu_cuda_alias.h
+++ b/tensorflow/core/util/gpu_cuda_alias.h
@@ -13,8 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+// Several forwarding macros are defined in this file to serve for backward
+// compatibility usage as we migrating from Cuda prefixed function to Gpu prefixed
+// functions. Both Cuda and ROCm can unify under the new Gpu prefix naming scheme.
+// In the migration period, we provide equivalent Cuda* and Gpu* function. Over time,
+// all Cuda* functions will be deprecated.
+
 namespace tensorflow {
 
+// CREATE_CUDA_HOST_FUNCTION_ALIAS forward the host function to its Cuda Alias.
 #ifndef TENSORFLOW_USE_ROCM
   #define CREATE_CUDA_HOST_FUNCTION_ALIAS(func, cuda_alias) \
   template <typename... Args> \
@@ -25,6 +32,7 @@ namespace tensorflow {
   #define CREATE_CUDA_HOST_FUNCTION_ALIAS(func, cuda_alias)
 #endif
 
+// CREATE_CUDA_DEVICE_FUNCTION_ALIAS forward the device function to its Cuda Alias.
 #ifndef TENSORFLOW_USE_ROCM
   #define CREATE_CUDA_DEVICE_FUNCTION_ALIAS(func, cuda_alias) \
   template <typename... Args> \
@@ -35,7 +43,7 @@ namespace tensorflow {
   #define CREATE_CUDA_DEVICE_FUNCTION_ALIAS(func, cuda_alias)
 #endif
 
-
+// CREATE_CUDA_TYPE_ALIAS forward the type to its Cuda Alias.
 #ifndef TENSORFLOW_USE_ROCM
   #define CREATE_CUDA_TYPE_ALIAS(type, cuda_alias) \
   using cuda_alias = type;

--- a/tensorflow/core/util/gpu_cuda_alias.h
+++ b/tensorflow/core/util/gpu_cuda_alias.h
@@ -1,0 +1,47 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+namespace tensorflow {
+
+#ifndef TENSORFLOW_USE_ROCM
+  #define CREATE_CUDA_HOST_FUNCTION_ALIAS(func, cuda_alias) \
+  template <typename... Args> \
+  auto cuda_alias(Args&&... args) -> decltype(func(std::forward<Args>(args)...)) { \
+    return func(std::forward<Args>(args)...); \
+  }
+#else
+  #define CREATE_CUDA_HOST_FUNCTION_ALIAS(func, cuda_alias)
+#endif
+
+#ifndef TENSORFLOW_USE_ROCM
+  #define CREATE_CUDA_DEVICE_FUNCTION_ALIAS(func, cuda_alias) \
+  template <typename... Args> \
+  __device__ auto cuda_alias(Args&&... args) -> decltype(func(std::forward<Args>(args)...)) { \
+    return func(std::forward<Args>(args)...); \
+  }
+#else
+  #define CREATE_CUDA_DEVICE_FUNCTION_ALIAS(func, cuda_alias)
+#endif
+
+
+#ifndef TENSORFLOW_USE_ROCM
+  #define CREATE_CUDA_TYPE_ALIAS(type, cuda_alias) \
+  using cuda_alias = type;
+#else
+  #define CREATE_CUDA_TYPE_ALIAS(type, cuda_alias)
+#endif
+}
+
+

--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -16,6 +16,14 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_UTIL_GPU_DEVICE_FUNCTIONS_H_
 #define TENSORFLOW_CORE_UTIL_GPU_DEVICE_FUNCTIONS_H_
 
+/**
+ * Wrappers and helpers for CUDA device code.
+ *
+ * Wraps the warp-cooperative intrinsics introduced in CUDA 9 to provide
+ * backwards compatibility, see go/volta-porting for details.
+ * Provides atomic operations on types that aren't natively supported.
+ */
+
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #include <algorithm>
@@ -133,9 +141,12 @@ __device__ const unsigned kCudaWarpAll = 0xffffffff;
 __device__ inline unsigned GpuLaneId() {
   unsigned int lane_id;
 #if GOOGLE_CUDA
+#if __clang__
+  return __nvvm_read_ptx_sreg_laneid();
+#else   // __clang__
   asm("mov.u32 %0, %%laneid;" : "=r"(lane_id));
+#endif  // __clang__
 #elif TENSORFLOW_USE_ROCM
-  // ROCM TODO add ROCM implementation
   lane_id = __lane_id();
 #endif
   return lane_id;
@@ -163,7 +174,8 @@ __device__ inline bool GpuValidateShuffleSyncMask(unsigned mask,
 #if GOOGLE_CUDA
   unsigned src_lane_mask = __shfl(mask, src_lane);
 #elif TENSORFLOW_USE_ROCM
-  unsigned src_lane_mask = __shfl(static_cast<int>(mask), static_cast<int>(src_lane));
+  unsigned src_lane_mask =
+      __shfl(static_cast<int>(mask), static_cast<int>(src_lane));
 #endif
 #endif
   return (src_dst_mask & ~mask) == 0 && src_lane_mask == mask;
@@ -286,20 +298,21 @@ __device__ T GpuShuffleSync(unsigned mask, T value, int src_lane,
 // See b/69446944.
 __device__ inline double GpuShuffleSync(unsigned mask, double value,
                                          int src_lane, int width = warpSize) {
-  unsigned lo, hi;
 #if GOOGLE_CUDA
-  asm volatile("mov.b64 {%0,%1}, %2;" : "=r"(lo), "=r"(hi) : "d"(value));
+  auto tmp = __double_as_longlong(value);
+  auto lo = static_cast<unsigned>(tmp);
+  auto hi = static_cast<unsigned>(tmp >> 32);
   hi = GpuShuffleSync(mask, hi, src_lane, width);
   lo = GpuShuffleSync(mask, lo, src_lane, width);
-  asm volatile("mov.b64 %0, {%1,%2};" : "=d"(value) : "r"(lo), "r"(hi));
-  return value;
+  return __longlong_as_double(static_cast<uint64_t>(hi) << 32 | lo);
 #elif TENSORFLOW_USE_ROCM
-  uint64_t tmp = static_cast<uint64_t>(value);
-  lo = static_cast<unsigned>(tmp);
-  hi = static_cast<unsigned>(tmp >> 32);
+  auto tmp = static_cast<uint64_t>(value);
+  auto lo = static_cast<unsigned>(tmp);
+  auto hi = static_cast<unsigned>(tmp >> 32);
   hi = __shfl(static_cast<int>(hi), src_lane, width);
   lo = __shfl(static_cast<int>(lo), src_lane, width);
-  return static_cast<double>(static_cast<uint64_t>(hi) << 32 | static_cast<uint64_t>(lo));
+  return static_cast<double>(static_cast<uint64_t>(hi) << 32 |
+                             static_cast<uint64_t>(lo));
 #endif
 }
 CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleSync, CudaShuffleSync);
@@ -325,23 +338,23 @@ __device__ inline T GpuShuffleUpSync(unsigned mask, T value, unsigned delta,
 __device__ inline double GpuShuffleUpSync(unsigned mask, double value,
                                            unsigned delta,
                                            int width = warpSize) {
-  unsigned lo, hi;
 #if GOOGLE_CUDA
-  asm volatile("mov.b64 {%0,%1}, %2;" : "=r"(lo), "=r"(hi) : "d"(value));
+  auto tmp = __double_as_longlong(value);
+  auto lo = static_cast<unsigned>(tmp);
+  auto hi = static_cast<unsigned>(tmp >> 32);
   hi = GpuShuffleUpSync(mask, hi, delta, width);
   lo = GpuShuffleUpSync(mask, lo, delta, width);
-  asm volatile("mov.b64 %0, {%1,%2};" : "=d"(value) : "r"(lo), "r"(hi));
-  return value;
+  return __longlong_as_double(static_cast<uint64_t>(hi) << 32 | lo);
 #elif TENSORFLOW_USE_ROCM
-  uint64_t tmp = static_cast<uint64_t>(value);
-  lo = static_cast<unsigned>(tmp);
-  hi = static_cast<unsigned>(tmp >> 32);
+  auto tmp = static_cast<uint64_t>(value);
+  auto lo = static_cast<unsigned>(tmp);
+  auto hi = static_cast<unsigned>(tmp >> 32);
   hi = __shfl_up(static_cast<int>(hi), delta, width);
   lo = __shfl_up(static_cast<int>(lo), delta, width);
-  return static_cast<double>(static_cast<uint64_t>(hi) << 32 | static_cast<uint64_t>(lo));
+  return static_cast<double>(static_cast<uint64_t>(hi) << 32 |
+                             static_cast<uint64_t>(lo));
 #endif
 }
-CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleUpSync, CudaShuffleUpSync);
 
 // Wrapper for __shfl_down_sync. All threads in 'mask' must call this function
 // in convergence, see comment above for details.
@@ -364,23 +377,23 @@ __device__ inline T GpuShuffleDownSync(unsigned mask, T value, unsigned delta,
 __device__ inline double GpuShuffleDownSync(unsigned mask, double value,
                                              unsigned delta,
                                              int width = warpSize) {
-  unsigned lo, hi;
 #if GOOGLE_CUDA
-  asm volatile("mov.b64 {%0,%1}, %2;" : "=r"(lo), "=r"(hi) : "d"(value));
+  auto tmp = __double_as_longlong(value);
+  auto lo = static_cast<unsigned>(tmp);
+  auto hi = static_cast<unsigned>(tmp >> 32);
   hi = GpuShuffleDownSync(mask, hi, delta, width);
   lo = GpuShuffleDownSync(mask, lo, delta, width);
-  asm volatile("mov.b64 %0, {%1,%2};" : "=d"(value) : "r"(lo), "r"(hi));
-  return value;
+  return __longlong_as_double(static_cast<uint64_t>(hi) << 32 | lo);
 #elif TENSORFLOW_USE_ROCM
-  uint64_t tmp = static_cast<uint64_t>(value);
-  lo = static_cast<unsigned>(tmp);
-  hi = static_cast<unsigned>(tmp >> 32);
+  auto tmp = static_cast<uint64_t>(value);
+  auto lo = static_cast<unsigned>(tmp);
+  auto hi = static_cast<unsigned>(tmp >> 32);
   hi = __shfl_down(static_cast<int>(hi), delta, width);
   lo = __shfl_down(static_cast<int>(lo), delta, width);
-  return static_cast<double>(static_cast<uint64_t>(hi) << 32 | static_cast<uint64_t>(lo));
+  return static_cast<double>(static_cast<uint64_t>(hi) << 32 |
+                             static_cast<uint64_t>(lo));
 #endif
 }
-CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleDownSync, CudaShuffleDownSync);
 
 // Wrapper for __shfl_xor_sync. All threads in 'mask' must call this function in
 // convergence, see comment above for details.
@@ -402,14 +415,18 @@ __device__ T GpuShuffleXorSync(unsigned mask, T value, int lane_mask,
 #endif
 }
 
-
 #if TENSORFLOW_USE_ROCM
-__device__ inline Eigen::half GpuShuffleXorSync(unsigned mask, Eigen::half value, int lane_mask,
-                                int width = warpSize) {
+__device__ inline Eigen::half GpuShuffleXorSync(unsigned mask,
+                                                Eigen::half value,
+                                                int lane_mask,
+                                                int width = warpSize) {
   assert(!(width & width - 1));
   assert(detail::GpuValidateShuffleSyncMask(
       mask, detail::GpuShuffleXorGetSrcLane(lane_mask, width)));
-  return static_cast<Eigen::half>(__shfl_xor(static_cast<float>(value), lane_mask, width));
+  // TODO(rocm): This doesn't preserve NaN payload and flushes denorms to zero,
+  // maybe this should be implemented differently?
+  return static_cast<Eigen::half>(
+      __shfl_xor(static_cast<float>(value), lane_mask, width));
 }
 #endif
 
@@ -419,20 +436,21 @@ __device__ inline Eigen::half GpuShuffleXorSync(unsigned mask, Eigen::half value
 __device__ inline double GpuShuffleXorSync(unsigned mask, double value,
                                             int lane_mask,
                                             int width = warpSize) {
-  unsigned lo, hi;
 #if GOOGLE_CUDA
-  asm volatile("mov.b64 {%0,%1}, %2;" : "=r"(lo), "=r"(hi) : "d"(value));
+  auto tmp = __double_as_longlong(value);
+  auto lo = static_cast<unsigned>(tmp);
+  auto hi = static_cast<unsigned>(tmp >> 32);
   hi = GpuShuffleXorSync(mask, hi, lane_mask, width);
   lo = GpuShuffleXorSync(mask, lo, lane_mask, width);
-  asm volatile("mov.b64 %0, {%1,%2};" : "=d"(value) : "r"(lo), "r"(hi));
-  return value;
+  return __longlong_as_double(static_cast<uint64_t>(hi) << 32 | lo);
 #elif TENSORFLOW_USE_ROCM
-  uint64_t tmp = static_cast<uint64_t>(value);
-  lo = static_cast<unsigned>(tmp);
-  hi = static_cast<unsigned>(tmp >> 32);
+  auto tmp = static_cast<uint64_t>(value);
+  auto lo = static_cast<unsigned>(tmp);
+  auto hi = static_cast<unsigned>(tmp >> 32);
   hi = __shfl_xor(static_cast<int>(hi), lane_mask, width);
   lo = __shfl_xor(static_cast<int>(lo), lane_mask, width);
-  return static_cast<double>(static_cast<uint64_t>(hi) << 32 | static_cast<uint64_t>(lo));
+  return static_cast<double>(static_cast<uint64_t>(hi) << 32 |
+                             static_cast<uint64_t>(lo));
 #endif
 }
 CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleXorSync, CudaShuffleXorSync);
@@ -522,15 +540,16 @@ __device__ float GpuAtomicCasHelper(float* ptr, F accumulate) {
 template <typename F>
 __device__ double GpuAtomicCasHelper(double* ptr, F accumulate) {
 #if TENSORFLOW_USE_ROCM
-  // FIXME : remove the workaround below once bug is fixed
+  // FIXME: remove the workaround below once bug is fixed.
   // HIP has a bug in the implementation of __longlong_as_double
-  // So workaround it by using reinterpret_cast<double*>
-  uint64_t result = GpuAtomicCasHelper(
-      reinterpret_cast<tensorflow::uint64*>(ptr),
-      [accumulate](tensorflow::uint64 a) {
-	return __double_as_longlong(accumulate(*(reinterpret_cast<double*>(&a))));
-      });
- return *(reinterpret_cast<double*>(&result));
+  // So workaround it by using reinterpret_cast<double*>.
+  uint64_t result =
+      GpuAtomicCasHelper(reinterpret_cast<tensorflow::uint64*>(ptr),
+                          [accumulate](tensorflow::uint64 a) {
+                            return __double_as_longlong(
+                                accumulate(*(reinterpret_cast<double*>(&a))));
+                          });
+  return *(reinterpret_cast<double*>(&result));
 #else
   return __longlong_as_double(GpuAtomicCasHelper(
       reinterpret_cast<tensorflow::uint64*>(ptr),
@@ -805,9 +824,8 @@ __device__ detail::ToTypeIfConvertible<U, T> GpuAtomicDiv(T* ptr, U value) {
 }
 CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAtomicDiv, CudaAtomicDiv);
 
-#if GOOGLE_CUDA
 // Operator overloads for complex numbers.
-
+#if GOOGLE_CUDA
 __device__ inline std::complex<float> operator+(const std::complex<float>& a,
                                                 const std::complex<float>& b) {
   auto result = cuCaddf(make_cuComplex(a.real(), a.imag()),
@@ -863,7 +881,7 @@ __device__ inline std::complex<double> operator/(
                        make_cuDoubleComplex(b.real(), b.imag()));
   return std::complex<double>(result.x, result.y);
 }
-#endif // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -355,6 +355,7 @@ __device__ inline double GpuShuffleUpSync(unsigned mask, double value,
                              static_cast<uint64_t>(lo));
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleUpSync, CudaShuffleUpSync);
 
 // Wrapper for __shfl_down_sync. All threads in 'mask' must call this function
 // in convergence, see comment above for details.
@@ -394,6 +395,7 @@ __device__ inline double GpuShuffleDownSync(unsigned mask, double value,
                              static_cast<uint64_t>(lo));
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleDownSync, CudaShuffleDownSync);
 
 // Wrapper for __shfl_xor_sync. All threads in 'mask' must call this function in
 // convergence, see comment above for details.

--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -16,34 +16,35 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_UTIL_GPU_DEVICE_FUNCTIONS_H_
 #define TENSORFLOW_CORE_UTIL_GPU_DEVICE_FUNCTIONS_H_
 
-/**
- * Wrappers and helpers for CUDA device code.
- *
- * Wraps the warp-cooperative intrinsics introduced in CUDA 9 to provide
- * backwards compatibility, see go/volta-porting for details.
- * Provides atomic operations on types that aren't natively supported.
- */
-
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #include <algorithm>
 #include <complex>
-
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #if GOOGLE_CUDA
 #include "cuda/include/cuComplex.h"
 #include "cuda/include/cuda.h"
 #endif
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/gpu_cuda_alias.h"
 
 namespace tensorflow {
+
+// According to HIP developer guide at
+// https://github.com/ROCm-Developer-Tools/HIP/blob/master/docs/markdown/hip_kernel_language.md#assert
+// assert is not supported by HIP. While we are waiting for assert support in hip kernels, the assert
+// call should be macroed to NOP so that it does not block us from creating a debug build
+#if TENSORFLOW_USE_ROCM
+  #undef assert
+  #define assert(x) {}
+#endif
 
 namespace detail {
 
 // Helper for range-based for loop using 'delta' increments.
-// Usage: see CudaGridRange?() functions below.
+// Usage: see GpuGridRange?() functions below.
 template <typename T>
-class CudaGridRange {
+class GpuGridRange {
   struct Iterator {
     __device__ Iterator(T index, T delta) : index_(index), delta_(delta) {}
     __device__ T operator*() const { return index_; }
@@ -71,7 +72,7 @@ class CudaGridRange {
   };
 
  public:
-  __device__ CudaGridRange(T begin, T delta, T end)
+  __device__ GpuGridRange(T begin, T delta, T end)
       : begin_(begin), delta_(delta), end_(end) {}
 
   __device__ Iterator begin() const { return Iterator{begin_, delta_}; }
@@ -83,51 +84,63 @@ class CudaGridRange {
   T end_;
 };
 
+#ifndef TENSORFLOW_USE_ROCM
+template <typename... T>
+using CudaGridRange = GpuGridRange<T...>;
+#endif
 }  // namespace detail
 
 // Helper to visit indices in the range 0 <= i < count, using the x-coordinate
 // of the global thread index. That is, each index i is visited by all threads
 // with the same x-coordinate.
-// Usage: for(int i : CudaGridRangeX(count)) { visit(i); }
+// Usage: for(int i : GpuGridRangeX(count)) { visit(i); }
 template <typename T>
-__device__ detail::CudaGridRange<T> CudaGridRangeX(T count) {
-  return detail::CudaGridRange<T>(blockIdx.x * blockDim.x + threadIdx.x,
+__device__ detail::GpuGridRange<T> GpuGridRangeX(T count) {
+  return detail::GpuGridRange<T>(blockIdx.x * blockDim.x + threadIdx.x,
                                   gridDim.x * blockDim.x, count);
 }
 
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuGridRangeX, CudaGridRangeX);
+
 // Helper to visit indices in the range 0 <= i < count using the y-coordinate.
-// Usage: for(int i : CudaGridRangeY(count)) { visit(i); }
+// Usage: for(int i : GpuGridRangeY(count)) { visit(i); }
 template <typename T>
-__device__ detail::CudaGridRange<T> CudaGridRangeY(T count) {
-  return detail::CudaGridRange<T>(blockIdx.y * blockDim.y + threadIdx.y,
+__device__ detail::GpuGridRange<T> GpuGridRangeY(T count) {
+  return detail::GpuGridRange<T>(blockIdx.y * blockDim.y + threadIdx.y,
                                   gridDim.y * blockDim.y, count);
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuGridRangeY, CudaGridRangeY);
 
 // Helper to visit indices in the range 0 <= i < count using the z-coordinate.
-// Usage: for(int i : CudaGridRangeZ(count)) { visit(i); }
+// Usage: for(int i : GpuGridRangeZ(count)) { visit(i); }
 template <typename T>
-__device__ detail::CudaGridRange<T> CudaGridRangeZ(T count) {
-  return detail::CudaGridRange<T>(blockIdx.z * blockDim.z + threadIdx.z,
+__device__ detail::GpuGridRange<T> GpuGridRangeZ(T count) {
+  return detail::GpuGridRange<T>(blockIdx.z * blockDim.z + threadIdx.z,
                                   gridDim.z * blockDim.z, count);
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuGridRangeZ, CudaGridRangeZ);
 
+#if GOOGLE_CUDA
 // Mask for all 32 threads in a warp.
-const unsigned kCudaWarpAll = 0xffffffff;
+__device__ const unsigned kCudaWarpAll = 0xffffffff;
+#elif TENSORFLOW_USE_ROCM
+// ROCM TODO add ROCM implementation
+// Mask for all 64 threads in a wavefront.
+__device__ const unsigned kCudaWarpAll = 0xffffffff;
+#endif
 
 // Returns the warp lane ID of the calling thread
-__device__ inline unsigned CudaLaneId() {
+__device__ inline unsigned GpuLaneId() {
   unsigned int lane_id;
 #if GOOGLE_CUDA
-#if __clang__
-  return __nvvm_read_ptx_sreg_laneid();
-#else   // __clang__
   asm("mov.u32 %0, %%laneid;" : "=r"(lane_id));
-#endif  // __clang__
 #elif TENSORFLOW_USE_ROCM
-  land_id = __lane_id();
+  // ROCM TODO add ROCM implementation
+  lane_id = __lane_id();
 #endif
   return lane_id;
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuLaneId, CudaLaneId);
 
 namespace detail {
 // Returns true if mask is a valid parameter for __shfl*sync to return a well
@@ -141,58 +154,62 @@ namespace detail {
 // On Volta, for some invalid masks, this function hangs or returns false
 // positives, because the implementation shuffles with the same mask that
 // we are validating. Run on Pascal if you suspect that the mask is incorrect.
-__device__ inline bool CudaValidateShuffleSyncMask(unsigned mask,
+__device__ inline bool GpuValidateShuffleSyncMask(unsigned mask,
                                                    unsigned src_lane) {
-  unsigned src_dst_mask = 1u << CudaLaneId() | 1u << src_lane;
+  unsigned src_dst_mask = 1u << GpuLaneId() | 1u << src_lane;
 #if CUDA_VERSION >= 9000
   unsigned src_lane_mask = __shfl_sync(mask, mask, src_lane);
 #else
 #if GOOGLE_CUDA
   unsigned src_lane_mask = __shfl(mask, src_lane);
 #elif TENSORFLOW_USE_ROCM
-  unsigned src_lane_mask =
-      __shfl(static_cast<int>(mask), static_cast<int>(src_lane));
+  unsigned src_lane_mask = __shfl(static_cast<int>(mask), static_cast<int>(src_lane));
 #endif
 #endif
   return (src_dst_mask & ~mask) == 0 && src_lane_mask == mask;
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuValidateShuffleSyncMask, CudaValidateShuffleSyncMask);
 
 // Returns the actual source lane for shuffle.
-__device__ inline unsigned CudaShuffleGetSrcLane(int src_lane, int width) {
-  int lane_id = CudaLaneId();
+__device__ inline unsigned GpuShuffleGetSrcLane(int src_lane, int width) {
+  int lane_id = GpuLaneId();
   int lane_base = lane_id & ~width + 1;
   int lane_offset = src_lane & width - 1;
   return lane_base + lane_offset;
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleGetSrcLane, CudaShuffleGetSrcLane);
 
 // Returns the source lane for shuffle up.
-__device__ inline unsigned CudaShuffleUpGetSrcLane(unsigned delta, int width) {
-  unsigned lane_id = CudaLaneId();
+__device__ inline unsigned GpuShuffleUpGetSrcLane(unsigned delta, int width) {
+  unsigned lane_id = GpuLaneId();
   if ((lane_id & width - 1) < delta) {
     return lane_id;
   }
   return lane_id - delta;
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleUpGetSrcLane, CudaShuffleUpGetSrcLane);
 
 // Returns the source lane for shuffle down.
-__device__ inline unsigned CudaShuffleDownGetSrcLane(unsigned delta,
+__device__ inline unsigned GpuShuffleDownGetSrcLane(unsigned delta,
                                                      int width) {
-  unsigned lane_id = CudaLaneId();
+  unsigned lane_id = GpuLaneId();
   if ((lane_id & width - 1) + delta >= width) {
     return lane_id;
   }
   return lane_id + delta;
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleDownGetSrcLane, CudaShuffleDownGetSrcLane);
 
 // Returns the source lane for shuffle xor.
-__device__ inline unsigned CudaShuffleXorGetSrcLane(int lane_mask, int width) {
-  int lane_id = CudaLaneId();
+__device__ inline unsigned GpuShuffleXorGetSrcLane(int lane_mask, int width) {
+  int lane_id = GpuLaneId();
   int src_lane = lane_id ^ lane_mask;
   if (src_lane > (lane_id | width - 1)) {
     return lane_id;
   }
   return src_lane;
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleXorGetSrcLane, CudaShuffleXorGetSrcLane);
 }  // namespace detail
 
 // For all *_sync wrappers below, it is illegal to synchronize threads from
@@ -205,54 +222,58 @@ __device__ inline unsigned CudaShuffleXorGetSrcLane(int lane_mask, int width) {
 // must have their corresponding bit in 'mask' set.
 
 // Wrapper for __syncwarp. No-op for CUDA 8 and earlier.
-__device__ inline void CudaSyncWarp(unsigned mask = kCudaWarpAll) {
-  assert(mask & 1u << CudaLaneId());
+__device__ inline void GpuSyncWarp(unsigned mask = kCudaWarpAll) {
+  assert(mask & 1u << GpuLaneId());
 #if CUDA_VERSION >= 9000
   __syncwarp(mask);
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuSyncWarp, CudaSyncWarp);
 
 // Wrapper for __ballot_sync. All threads in 'mask' must call this function in
 // convergence, see comment above for details.
-__device__ inline unsigned CudaBallotSync(unsigned mask, int pred) {
-  assert(mask & 1u << CudaLaneId());
+__device__ inline unsigned GpuBallotSync(unsigned mask, int pred) {
+  assert(mask & 1u << GpuLaneId());
 #if CUDA_VERSION >= 9000
   return __ballot_sync(mask, pred);
 #else
   return __ballot(pred) & mask;  // Apply mask to match __ballot_sync's spec.
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuBallotSync, CudaBallotSync);
 
 // Wrapper for __any_sync. All threads in 'mask' must call this function in
 // convergence, see comment above for details.
-__device__ inline int CudaAnySync(unsigned mask, int pred) {
-  assert(mask & 1u << CudaLaneId());
+__device__ inline int GpuAnySync(unsigned mask, int pred) {
+  assert(mask & 1u << GpuLaneId());
 #if CUDA_VERSION >= 9000
   return __any_sync(mask, pred);
 #else
   return __any(pred);
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAnySync, CudaAnySync);
 
 // Wrapper for __all_sync. All threads in 'mask' must call this function in
 // convergence, see comment above for details.
-__device__ inline int CudaAllSync(unsigned mask, int pred) {
-  assert(mask & 1u << CudaLaneId());
+__device__ inline int GpuAllSync(unsigned mask, int pred) {
+  assert(mask & 1u << GpuLaneId());
 #if CUDA_VERSION >= 9000
   return __all_sync(mask, pred);
 #else
   return __all(pred);
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAllSync, CudaAllSync);
 
 // Wrapper for __shfl_sync. All threads in 'mask' must call this function in
 // convergence, see comment above for details.
 template <typename T>
-__device__ T CudaShuffleSync(unsigned mask, T value, int src_lane,
+__device__ T GpuShuffleSync(unsigned mask, T value, int src_lane,
                              int width = warpSize) {
   assert(!(width & width - 1));
-  assert(detail::CudaValidateShuffleSyncMask(
-      mask, detail::CudaShuffleGetSrcLane(src_lane, width)));
+  assert(detail::GpuValidateShuffleSyncMask(
+      mask, detail::GpuShuffleGetSrcLane(src_lane, width)));
 #if CUDA_VERSION >= 9000
   return __shfl_sync(mask, value, src_lane, width);
 #else
@@ -263,34 +284,34 @@ __device__ T CudaShuffleSync(unsigned mask, T value, int src_lane,
 // Variant of the (undocumented) version from the CUDA SDK, but using unsigned
 // instead of float for lo and hi (which is incorrect with ftz, for example).
 // See b/69446944.
-__device__ inline double CudaShuffleSync(unsigned mask, double value,
+__device__ inline double GpuShuffleSync(unsigned mask, double value,
                                          int src_lane, int width = warpSize) {
+  unsigned lo, hi;
 #if GOOGLE_CUDA
-  auto tmp = __double_as_longlong(value);
-  auto lo = static_cast<unsigned>(tmp);
-  auto hi = static_cast<unsigned>(tmp >> 32);
-  hi = CudaShuffleSync(mask, hi, src_lane, width);
-  lo = CudaShuffleSync(mask, lo, src_lane, width);
-  return __longlong_as_double(static_cast<uint64_t>(hi) << 32 | lo);
+  asm volatile("mov.b64 {%0,%1}, %2;" : "=r"(lo), "=r"(hi) : "d"(value));
+  hi = GpuShuffleSync(mask, hi, src_lane, width);
+  lo = GpuShuffleSync(mask, lo, src_lane, width);
+  asm volatile("mov.b64 %0, {%1,%2};" : "=d"(value) : "r"(lo), "r"(hi));
+  return value;
 #elif TENSORFLOW_USE_ROCM
-  auto tmp = static_cast<uint64_t>(value);
-  auto lo = static_cast<unsigned>(tmp);
-  auto hi = static_cast<unsigned>(tmp >> 32);
+  uint64_t tmp = static_cast<uint64_t>(value);
+  lo = static_cast<unsigned>(tmp);
+  hi = static_cast<unsigned>(tmp >> 32);
   hi = __shfl(static_cast<int>(hi), src_lane, width);
   lo = __shfl(static_cast<int>(lo), src_lane, width);
-  return static_cast<double>(static_cast<uint64_t>(hi) << 32 |
-                             static_cast<uint64_t>(lo));
+  return static_cast<double>(static_cast<uint64_t>(hi) << 32 | static_cast<uint64_t>(lo));
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleSync, CudaShuffleSync);
 
 // Wrapper for __shfl_up_sync. All threads in 'mask' must call this function in
 // convergence, see comment above for details.
 template <typename T>
-__device__ inline T CudaShuffleUpSync(unsigned mask, T value, unsigned delta,
+__device__ inline T GpuShuffleUpSync(unsigned mask, T value, unsigned delta,
                                       int width = warpSize) {
   assert(!(width & width - 1));
-  assert(detail::CudaValidateShuffleSyncMask(
-      mask, detail::CudaShuffleUpGetSrcLane(delta, width)));
+  assert(detail::GpuValidateShuffleSyncMask(
+      mask, detail::GpuShuffleUpGetSrcLane(delta, width)));
 #if CUDA_VERSION >= 9000
   return __shfl_up_sync(mask, value, delta, width);
 #else
@@ -301,35 +322,35 @@ __device__ inline T CudaShuffleUpSync(unsigned mask, T value, unsigned delta,
 // Variant of the (undocumented) version from the CUDA SDK, but using unsigned
 // instead of float for lo and hi (which is incorrect with ftz, for example).
 // See b/69446944.
-__device__ inline double CudaShuffleUpSync(unsigned mask, double value,
+__device__ inline double GpuShuffleUpSync(unsigned mask, double value,
                                            unsigned delta,
                                            int width = warpSize) {
+  unsigned lo, hi;
 #if GOOGLE_CUDA
-  auto tmp = __double_as_longlong(value);
-  auto lo = static_cast<unsigned>(tmp);
-  auto hi = static_cast<unsigned>(tmp >> 32);
-  hi = CudaShuffleUpSync(mask, hi, delta, width);
-  lo = CudaShuffleUpSync(mask, lo, delta, width);
-  return __longlong_as_double(static_cast<uint64_t>(hi) << 32 | lo);
+  asm volatile("mov.b64 {%0,%1}, %2;" : "=r"(lo), "=r"(hi) : "d"(value));
+  hi = GpuShuffleUpSync(mask, hi, delta, width);
+  lo = GpuShuffleUpSync(mask, lo, delta, width);
+  asm volatile("mov.b64 %0, {%1,%2};" : "=d"(value) : "r"(lo), "r"(hi));
+  return value;
 #elif TENSORFLOW_USE_ROCM
-  auto tmp = static_cast<uint64_t>(value);
-  auto lo = static_cast<unsigned>(tmp);
-  auto hi = static_cast<unsigned>(tmp >> 32);
+  uint64_t tmp = static_cast<uint64_t>(value);
+  lo = static_cast<unsigned>(tmp);
+  hi = static_cast<unsigned>(tmp >> 32);
   hi = __shfl_up(static_cast<int>(hi), delta, width);
   lo = __shfl_up(static_cast<int>(lo), delta, width);
-  return static_cast<double>(static_cast<uint64_t>(hi) << 32 |
-                             static_cast<uint64_t>(lo));
+  return static_cast<double>(static_cast<uint64_t>(hi) << 32 | static_cast<uint64_t>(lo));
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleUpSync, CudaShuffleUpSync);
 
 // Wrapper for __shfl_down_sync. All threads in 'mask' must call this function
 // in convergence, see comment above for details.
 template <typename T>
-__device__ inline T CudaShuffleDownSync(unsigned mask, T value, unsigned delta,
+__device__ inline T GpuShuffleDownSync(unsigned mask, T value, unsigned delta,
                                         int width = warpSize) {
   assert(!(width & width - 1));
-  assert(detail::CudaValidateShuffleSyncMask(
-      mask, detail::CudaShuffleDownGetSrcLane(delta, width)));
+  assert(detail::GpuValidateShuffleSyncMask(
+      mask, detail::GpuShuffleDownGetSrcLane(delta, width)));
 #if CUDA_VERSION >= 9000
   return __shfl_down_sync(mask, value, delta, width);
 #else
@@ -340,35 +361,35 @@ __device__ inline T CudaShuffleDownSync(unsigned mask, T value, unsigned delta,
 // Variant of the (undocumented) version from the CUDA SDK, but using unsigned
 // instead of float for lo and hi (which is incorrect with ftz, for example).
 // See b/69446944.
-__device__ inline double CudaShuffleDownSync(unsigned mask, double value,
+__device__ inline double GpuShuffleDownSync(unsigned mask, double value,
                                              unsigned delta,
                                              int width = warpSize) {
+  unsigned lo, hi;
 #if GOOGLE_CUDA
-  auto tmp = __double_as_longlong(value);
-  auto lo = static_cast<unsigned>(tmp);
-  auto hi = static_cast<unsigned>(tmp >> 32);
-  hi = CudaShuffleDownSync(mask, hi, delta, width);
-  lo = CudaShuffleDownSync(mask, lo, delta, width);
-  return __longlong_as_double(static_cast<uint64_t>(hi) << 32 | lo);
+  asm volatile("mov.b64 {%0,%1}, %2;" : "=r"(lo), "=r"(hi) : "d"(value));
+  hi = GpuShuffleDownSync(mask, hi, delta, width);
+  lo = GpuShuffleDownSync(mask, lo, delta, width);
+  asm volatile("mov.b64 %0, {%1,%2};" : "=d"(value) : "r"(lo), "r"(hi));
+  return value;
 #elif TENSORFLOW_USE_ROCM
-  auto tmp = static_cast<uint64_t>(value);
-  auto lo = static_cast<unsigned>(tmp);
-  auto hi = static_cast<unsigned>(tmp >> 32);
+  uint64_t tmp = static_cast<uint64_t>(value);
+  lo = static_cast<unsigned>(tmp);
+  hi = static_cast<unsigned>(tmp >> 32);
   hi = __shfl_down(static_cast<int>(hi), delta, width);
   lo = __shfl_down(static_cast<int>(lo), delta, width);
-  return static_cast<double>(static_cast<uint64_t>(hi) << 32 |
-                             static_cast<uint64_t>(lo));
+  return static_cast<double>(static_cast<uint64_t>(hi) << 32 | static_cast<uint64_t>(lo));
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleDownSync, CudaShuffleDownSync);
 
 // Wrapper for __shfl_xor_sync. All threads in 'mask' must call this function in
 // convergence, see comment above for details.
 template <typename T>
-__device__ T CudaShuffleXorSync(unsigned mask, T value, int lane_mask,
+__device__ T GpuShuffleXorSync(unsigned mask, T value, int lane_mask,
                                 int width = warpSize) {
   assert(!(width & width - 1));
-  assert(detail::CudaValidateShuffleSyncMask(
-      mask, detail::CudaShuffleXorGetSrcLane(lane_mask, width)));
+  assert(detail::GpuValidateShuffleSyncMask(
+      mask, detail::GpuShuffleXorGetSrcLane(lane_mask, width)));
 #if GOOGLE_CUDA
 #if CUDA_VERSION >= 9000
   return __shfl_xor_sync(mask, value, lane_mask, width);
@@ -376,64 +397,62 @@ __device__ T CudaShuffleXorSync(unsigned mask, T value, int lane_mask,
   return __shfl_xor(value, lane_mask, width);
 #endif
 #elif TENSORFLOW_USE_ROCM
+  // ROCM TODO: check if HIP should be changed to cope with more types
   return __shfl_xor(static_cast<int>(value), lane_mask, width);
 #endif
 }
 
+
 #if TENSORFLOW_USE_ROCM
-__device__ inline Eigen::half GpuShuffleXorSync(unsigned mask,
-                                                Eigen::half value,
-                                                int lane_mask,
-                                                int width = warpSize) {
+__device__ inline Eigen::half GpuShuffleXorSync(unsigned mask, Eigen::half value, int lane_mask,
+                                int width = warpSize) {
   assert(!(width & width - 1));
-  assert(detail::CudaValidateShuffleSyncMask(
-      mask, detail::CudaShuffleXorGetSrcLane(lane_mask, width)));
-  // TODO(rocm): This doesn't preserve NaN payload and flushes denorms to zero,
-  // maybe this should be implemented differently?
-  return static_cast<Eigen::half>(
-      __shfl_xor(static_cast<float>(value), lane_mask, width));
+  assert(detail::GpuValidateShuffleSyncMask(
+      mask, detail::GpuShuffleXorGetSrcLane(lane_mask, width)));
+  return static_cast<Eigen::half>(__shfl_xor(static_cast<float>(value), lane_mask, width));
 }
 #endif
 
 // Variant of the (undocumented) version from the CUDA SDK, but using unsigned
 // instead of float for lo and hi (which is incorrect with ftz, for example).
 // See b/69446944.
-__device__ inline double CudaShuffleXorSync(unsigned mask, double value,
+__device__ inline double GpuShuffleXorSync(unsigned mask, double value,
                                             int lane_mask,
                                             int width = warpSize) {
+  unsigned lo, hi;
 #if GOOGLE_CUDA
-  auto tmp = __double_as_longlong(value);
-  auto lo = static_cast<unsigned>(tmp);
-  auto hi = static_cast<unsigned>(tmp >> 32);
-  hi = CudaShuffleXorSync(mask, hi, lane_mask, width);
-  lo = CudaShuffleXorSync(mask, lo, lane_mask, width);
-  return __longlong_as_double(static_cast<uint64_t>(hi) << 32 | lo);
+  asm volatile("mov.b64 {%0,%1}, %2;" : "=r"(lo), "=r"(hi) : "d"(value));
+  hi = GpuShuffleXorSync(mask, hi, lane_mask, width);
+  lo = GpuShuffleXorSync(mask, lo, lane_mask, width);
+  asm volatile("mov.b64 %0, {%1,%2};" : "=d"(value) : "r"(lo), "r"(hi));
+  return value;
 #elif TENSORFLOW_USE_ROCM
-  auto tmp = static_cast<uint64_t>(value);
-  auto lo = static_cast<unsigned>(tmp);
-  auto hi = static_cast<unsigned>(tmp >> 32);
+  uint64_t tmp = static_cast<uint64_t>(value);
+  lo = static_cast<unsigned>(tmp);
+  hi = static_cast<unsigned>(tmp >> 32);
   hi = __shfl_xor(static_cast<int>(hi), lane_mask, width);
   lo = __shfl_xor(static_cast<int>(lo), lane_mask, width);
-  return static_cast<double>(static_cast<uint64_t>(hi) << 32 |
-                             static_cast<uint64_t>(lo));
+  return static_cast<double>(static_cast<uint64_t>(hi) << 32 | static_cast<uint64_t>(lo));
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuShuffleXorSync, CudaShuffleXorSync);
 
 // Wrapper for __ldg.
 template <typename T>
-__host__ __device__ T CudaLdg(const T* address) {
+__host__ __device__ T GpuLdg(const T* address) {
 #if __CUDA_ARCH__ >= 350
   return __ldg(address);
 #else
   return *address;
 #endif
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuLdg, CudaLdg);
 
-__host__ __device__ inline bool CudaLdg(const bool* address) {
-  return CudaLdg(reinterpret_cast<const char*>(address)) != 0;
+__host__ __device__ inline bool GpuLdg(const bool* address) {
+  return GpuLdg(reinterpret_cast<const char*>(address)) != 0;
 }
 
-__host__ __device__ inline std::complex<float> CudaLdg(
+__host__ __device__ inline std::complex<float> GpuLdg(
     const std::complex<float>* address) {
 #if __CUDA_ARCH__ >= 350
   float2 mem = __ldg(reinterpret_cast<const float2*>(address));
@@ -443,7 +462,7 @@ __host__ __device__ inline std::complex<float> CudaLdg(
 #endif
 }
 
-__host__ __device__ inline std::complex<double> CudaLdg(
+__host__ __device__ inline std::complex<double> GpuLdg(
     const std::complex<double>* address) {
 #if __CUDA_ARCH__ >= 350
   double2 mem = __ldg(reinterpret_cast<const double2*>(address));
@@ -461,7 +480,7 @@ __global__ void SetZero(const int count, T* ptr) {
   // Check that the grid is one dimensional and index doesn't overflow.
   assert(blockDim.y == 1 && blockDim.z == 1);
   assert(blockDim.x * gridDim.x / blockDim.x == gridDim.x);
-  for (int i : CudaGridRangeX(count)) {
+  for (int i : GpuGridRangeX(count)) {
     ptr[i] = T(0);
   }
 }
@@ -472,7 +491,7 @@ __global__ void SetToValue(const int count, T* ptr, T value) {
   // Check that the grid is one dimensional and index doesn't overflow.
   assert(blockDim.y == 1 && blockDim.z == 1);
   assert(blockDim.x * gridDim.x / blockDim.x == gridDim.x);
-  for (int i : CudaGridRangeX(count)) {
+  for (int i : GpuGridRangeX(count)) {
     ptr[i] = value;
   }
 }
@@ -480,7 +499,7 @@ __global__ void SetToValue(const int count, T* ptr, T value) {
 namespace detail {
 // Helper function for atomic accumulation implemented as CAS.
 template <typename T, typename F>
-__device__ T CudaAtomicCasHelper(T* ptr, F accumulate) {
+__device__ T GpuAtomicCasHelper(T* ptr, F accumulate) {
   T old = *ptr;
   T assumed;
   do {
@@ -489,31 +508,31 @@ __device__ T CudaAtomicCasHelper(T* ptr, F accumulate) {
   } while (assumed != old);
   return old;
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAtomicCasHelper, CudaAtomicCasHelper);
 
 // Overload for floating point (using integer comparison to handle NaN
 // correctly).
 template <typename F>
-__device__ float CudaAtomicCasHelper(float* ptr, F accumulate) {
+__device__ float GpuAtomicCasHelper(float* ptr, F accumulate) {
   return __float_as_int(
-      CudaAtomicCasHelper(reinterpret_cast<int32*>(ptr), [accumulate](int32 a) {
+      GpuAtomicCasHelper(reinterpret_cast<int32*>(ptr), [accumulate](int32 a) {
         return __float_as_int(accumulate(__int_as_float(a)));
       }));
 }
 template <typename F>
-__device__ double CudaAtomicCasHelper(double* ptr, F accumulate) {
+__device__ double GpuAtomicCasHelper(double* ptr, F accumulate) {
 #if TENSORFLOW_USE_ROCM
-  // FIXME: remove the workaround below once bug is fixed.
+  // FIXME : remove the workaround below once bug is fixed
   // HIP has a bug in the implementation of __longlong_as_double
-  // So workaround it by using reinterpret_cast<double*>.
-  uint64_t result =
-      CudaAtomicCasHelper(reinterpret_cast<tensorflow::uint64*>(ptr),
-                          [accumulate](tensorflow::uint64 a) {
-                            return __double_as_longlong(
-                                accumulate(*(reinterpret_cast<double*>(&a))));
-                          });
-  return *(reinterpret_cast<double*>(&result));
+  // So workaround it by using reinterpret_cast<double*>
+  uint64_t result = GpuAtomicCasHelper(
+      reinterpret_cast<tensorflow::uint64*>(ptr),
+      [accumulate](tensorflow::uint64 a) {
+	return __double_as_longlong(accumulate(*(reinterpret_cast<double*>(&a))));
+      });
+ return *(reinterpret_cast<double*>(&result));
 #else
-  return __longlong_as_double(CudaAtomicCasHelper(
+  return __longlong_as_double(GpuAtomicCasHelper(
       reinterpret_cast<tensorflow::uint64*>(ptr),
       [accumulate](tensorflow::uint64 a) {
         return __double_as_longlong(accumulate(__longlong_as_double(a)));
@@ -534,7 +553,7 @@ __device__ double CudaAtomicCasHelper(double* ptr, F accumulate) {
 //
 // Note: Assumes little endian.
 template <typename F>
-__device__ Eigen::half CudaAtomicCasHelper(Eigen::half* ptr, F accumulate) {
+__device__ Eigen::half GpuAtomicCasHelper(Eigen::half* ptr, F accumulate) {
 #if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
   static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__, "Not little endian");
 #endif
@@ -544,7 +563,7 @@ __device__ Eigen::half CudaAtomicCasHelper(Eigen::half* ptr, F accumulate) {
   if (intptr & 0x2) {
     // The half is in the second part of the uint32 (upper 16 bits).
     uint32* address = reinterpret_cast<uint32*>(intptr - 2);
-    uint32 result = CudaAtomicCasHelper(address, [accumulate](uint32 arg) {
+    uint32 result = GpuAtomicCasHelper(address, [accumulate](uint32 arg) {
       unsigned short high = static_cast<unsigned short>(arg >> 16);
       Eigen::half acc = accumulate(half_impl::raw_uint16_to_half(high));
       return (static_cast<uint32>(acc.x) << 16) | (arg & 0xffff);
@@ -553,7 +572,7 @@ __device__ Eigen::half CudaAtomicCasHelper(Eigen::half* ptr, F accumulate) {
   } else {
     // The half is in the first part of the uint32 (lower 16 bits).
     uint32* address = reinterpret_cast<uint32*>(intptr);
-    uint32 result = CudaAtomicCasHelper(address, [accumulate](uint32 arg) {
+    uint32 result = GpuAtomicCasHelper(address, [accumulate](uint32 arg) {
       unsigned short low = static_cast<unsigned short>(arg & 0xffff);
       Eigen::half acc = accumulate(half_impl::raw_uint16_to_half(low));
       return (arg & 0xffff0000) | static_cast<uint32>(acc.x);
@@ -572,74 +591,89 @@ using ToTypeIfConvertible =
 // for some ops and provide implementation for all reasonable types.
 
 template <typename T, typename U>
-__device__ detail::ToTypeIfConvertible<U, T> CudaAtomicAdd(T* ptr, U value) {
+__device__ detail::ToTypeIfConvertible<U, T> GpuAtomicAdd(T* ptr, U value) {
   return atomicAdd(ptr, value);
 }
 
-__device__ inline Eigen::half CudaAtomicAdd(Eigen::half* ptr,
+__device__ inline Eigen::half GpuAtomicAdd(Eigen::half* ptr,
                                             Eigen::half value) {
-  return detail::CudaAtomicCasHelper(
+  return detail::GpuAtomicCasHelper(
       ptr, [value](Eigen::half a) { return a + value; });
 }
 
-#if __CUDA_ARCH__ < 600
-__device__ inline double CudaAtomicAdd(double* ptr, double value) {
-  return detail::CudaAtomicCasHelper(ptr,
+
+#if (__CUDA_ARCH__ < 600) || TENSORFLOW_USE_ROCM
+__device__ inline double GpuAtomicAdd(double* ptr, double value) {
+  return detail::GpuAtomicCasHelper(ptr,
                                      [value](double a) { return a + value; });
 }
+#elif __clang__
+// Clang cannot compile __nvvm_atom_add_gen_d builtin yet, use inline PTX.
+// see https://reviews.llvm.org/D39638
+__device__ inline double GpuAtomicAdd(double* ptr, double value) {
+  double result;
+  asm volatile("atom.add.f64 %0, [%1], %2;"
+               : "=d"(result)
+               : "l"(ptr), "d"(value)
+               : "memory");
+  return result;
+}
 #endif
-
-// CudaAtomicAdd
-// Specializations of CudaAtomicAdd for complex types, which CudaAtomicAdd does
+// GpuAtomicAdd
+// Specializations of GpuAtomicAdd for complex types, which GpuAtomicAdd does
 // not support. We treat a std::complex<T>* as a T* (the C++ standard section
 // 26.4.4 allows this explicitly) and atomic add the real and imaginary
 // components individually. The operation as a whole is not atomic, but we can
 // safely treat the components independently for the purpose of accumulating.
+
+// ROCM TODO support GpuAtomicAdd for std::complex<>
 #if GOOGLE_CUDA
-__device__ inline std::complex<float> CudaAtomicAdd(std::complex<float>* ptr,
+__device__ inline std::complex<float> GpuAtomicAdd(std::complex<float>* ptr,
                                                     std::complex<float> value) {
   auto ptr_scalar = reinterpret_cast<float*>(ptr);
-  return std::complex<float>(CudaAtomicAdd(ptr_scalar, value.real()),
-                             CudaAtomicAdd(ptr_scalar + 1, value.imag()));
+  return std::complex<float>(GpuAtomicAdd(ptr_scalar, value.real()),
+                             GpuAtomicAdd(ptr_scalar + 1, value.imag()));
 }
 
-__device__ inline std::complex<double> CudaAtomicAdd(
+__device__ inline std::complex<double> GpuAtomicAdd(
     std::complex<double>* ptr, std::complex<double> value) {
   auto ptr_scalar = reinterpret_cast<double*>(ptr);
-  return std::complex<double>(CudaAtomicAdd(ptr_scalar, value.real()),
-                              CudaAtomicAdd(ptr_scalar + 1, value.imag()));
+  return std::complex<double>(GpuAtomicAdd(ptr_scalar, value.real()),
+                              GpuAtomicAdd(ptr_scalar + 1, value.imag()));
 }
 #endif
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAtomicAdd, CudaAtomicAdd);
 
-// CudaAtomicSub
+// GpuAtomicSub
 template <typename T, typename U>
-__device__ detail::ToTypeIfConvertible<U, T> CudaAtomicSub(T* ptr, U value) {
+__device__ detail::ToTypeIfConvertible<U, T> GpuAtomicSub(T* ptr, U value) {
   return atomicSub(ptr, value);
 }
 
-// Specializations of subtraction which add the negative value.
-__device__ inline float CudaAtomicSub(float* ptr, float value) {
-  return CudaAtomicAdd(ptr, -value);
+// Specializations of substraction which add the negative value.
+__device__ inline float GpuAtomicSub(float* ptr, float value) {
+  return GpuAtomicAdd(ptr, -value);
 }
 
-__device__ inline double CudaAtomicSub(double* ptr, double value) {
-  return CudaAtomicAdd(ptr, -value);
+__device__ inline double GpuAtomicSub(double* ptr, double value) {
+  return GpuAtomicAdd(ptr, -value);
 }
 
-__device__ inline tensorflow::uint64 CudaAtomicSub(tensorflow::uint64* ptr,
+__device__ inline tensorflow::uint64 GpuAtomicSub(tensorflow::uint64* ptr,
                                                    tensorflow::uint64 value) {
-  return CudaAtomicAdd(ptr, -value);
+  return GpuAtomicAdd(ptr, -value);
 }
 
-__device__ inline Eigen::half CudaAtomicSub(Eigen::half* ptr,
+__device__ inline Eigen::half GpuAtomicSub(Eigen::half* ptr,
                                             Eigen::half value) {
-  return detail::CudaAtomicCasHelper(
+  return detail::GpuAtomicCasHelper(
       ptr, [value](Eigen::half a) { return a - value; });
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAtomicSub, CudaAtomicSub);
 
-// CudaAtomicMax
+// GpuAtomicMax
 template <typename T, typename U>
-__device__ detail::ToTypeIfConvertible<U, T> CudaAtomicMax(T* ptr, U value) {
+__device__ detail::ToTypeIfConvertible<U, T> GpuAtomicMax(T* ptr, U value) {
   return atomicMax(ptr, value);
 }
 
@@ -658,47 +692,48 @@ __device__ detail::ToTypeIfConvertible<U, T> CudaAtomicMax(T* ptr, U value) {
  *
  */
 
-__device__ inline float CudaAtomicMax(float* ptr, float value) {
-  return detail::CudaAtomicCasHelper(
+__device__ inline float GpuAtomicMax(float* ptr, float value) {
+  return detail::GpuAtomicCasHelper(
       ptr, [value](float a) { return fmaxf(a, value); });
 }
 
-__device__ inline double CudaAtomicMax(double* ptr, double value) {
-  return detail::CudaAtomicCasHelper(
+__device__ inline double GpuAtomicMax(double* ptr, double value) {
+  return detail::GpuAtomicCasHelper(
       ptr, [value](double a) { return fmax(a, value); });
 }
 
 #else
 
-__device__ inline float CudaAtomicMax(float* ptr, float value) {
-  return detail::CudaAtomicCasHelper(
+__device__ inline float GpuAtomicMax(float* ptr, float value) {
+  return detail::GpuAtomicCasHelper(
       ptr, [value](float a) { return max(a, value); });
 }
 
-__device__ inline double CudaAtomicMax(double* ptr, double value) {
-  return detail::CudaAtomicCasHelper(
+__device__ inline double GpuAtomicMax(double* ptr, double value) {
+  return detail::GpuAtomicCasHelper(
       ptr, [value](double a) { return max(a, value); });
 }
 
 #endif
 
-__device__ inline Eigen::half CudaAtomicMax(Eigen::half* ptr,
+__device__ inline Eigen::half GpuAtomicMax(Eigen::half* ptr,
                                             Eigen::half value) {
-  return detail::CudaAtomicCasHelper(
+  return detail::GpuAtomicCasHelper(
       ptr, [value](Eigen::half a) { return max(a, value); });
 }
 
 #if __CUDA_ARCH__ < 320
-__device__ inline tensorflow::uint64 CudaAtomicMax(tensorflow::uint64* ptr,
+__device__ inline tensorflow::uint64 GpuAtomicMax(tensorflow::uint64* ptr,
                                                    tensorflow::uint64 value) {
-  return detail::CudaAtomicCasHelper(
+  return detail::GpuAtomicCasHelper(
       ptr, [value](tensorflow::uint64 a) { return max(a, value); });
 }
 #endif
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAtomicMax, CudaAtomicMax);
 
-// CudaAtomicMin
+// GpuAtomicMin
 template <typename T, typename U>
-__device__ detail::ToTypeIfConvertible<U, T> CudaAtomicMin(T* ptr, U value) {
+__device__ detail::ToTypeIfConvertible<U, T> GpuAtomicMin(T* ptr, U value) {
   return atomicMin(ptr, value);
 }
 
@@ -717,58 +752,62 @@ __device__ detail::ToTypeIfConvertible<U, T> CudaAtomicMin(T* ptr, U value) {
  *
  */
 
-__device__ inline float CudaAtomicMin(float* ptr, float value) {
-  return detail::CudaAtomicCasHelper(
+__device__ inline float GpuAtomicMin(float* ptr, float value) {
+  return detail::GpuAtomicCasHelper(
       ptr, [value](float a) { return fminf(a, value); });
 }
 
-__device__ inline double CudaAtomicMin(double* ptr, double value) {
-  return detail::CudaAtomicCasHelper(
+__device__ inline double GpuAtomicMin(double* ptr, double value) {
+  return detail::GpuAtomicCasHelper(
       ptr, [value](double a) { return fmin(a, value); });
 }
 
 #else
 
-__device__ inline float CudaAtomicMin(float* ptr, float value) {
-  return detail::CudaAtomicCasHelper(
+__device__ inline float GpuAtomicMin(float* ptr, float value) {
+  return detail::GpuAtomicCasHelper(
       ptr, [value](float a) { return min(a, value); });
 }
 
-__device__ inline double CudaAtomicMin(double* ptr, double value) {
-  return detail::CudaAtomicCasHelper(
+__device__ inline double GpuAtomicMin(double* ptr, double value) {
+  return detail::GpuAtomicCasHelper(
       ptr, [value](double a) { return min(a, value); });
 }
 
 #endif
 
-__device__ inline Eigen::half CudaAtomicMin(Eigen::half* ptr,
+__device__ inline Eigen::half GpuAtomicMin(Eigen::half* ptr,
                                             Eigen::half value) {
-  return detail::CudaAtomicCasHelper(
+  return detail::GpuAtomicCasHelper(
       ptr, [value](Eigen::half a) { return min(a, value); });
 }
 
 #if __CUDA_ARCH__ < 320
-__device__ inline tensorflow::uint64 CudaAtomicMin(tensorflow::uint64* ptr,
+__device__ inline tensorflow::uint64 GpuAtomicMin(tensorflow::uint64* ptr,
                                                    tensorflow::uint64 value) {
-  return detail::CudaAtomicCasHelper(
+  return detail::GpuAtomicCasHelper(
       ptr, [value](tensorflow::uint64 a) { return min(a, value); });
 }
 #endif
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAtomicMin, CudaAtomicMin);
 
-// CudaAtomicMul
+// GpuAtomicMul
 template <typename T, typename U>
-__device__ detail::ToTypeIfConvertible<U, T> CudaAtomicMul(T* ptr, U value) {
-  return detail::CudaAtomicCasHelper(ptr, [value](T a) { return a * value; });
+__device__ detail::ToTypeIfConvertible<U, T> GpuAtomicMul(T* ptr, U value) {
+  return detail::GpuAtomicCasHelper(ptr, [value](T a) { return a * value; });
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAtomicMul, CudaAtomicMul);
 
-// CudaAtomicDiv
+// GpuAtomicDiv
 template <typename T, typename U>
-__device__ detail::ToTypeIfConvertible<U, T> CudaAtomicDiv(T* ptr, U value) {
-  return detail::CudaAtomicCasHelper(ptr, [value](T a) { return a / value; });
+__device__ detail::ToTypeIfConvertible<U, T> GpuAtomicDiv(T* ptr, U value) {
+  return detail::GpuAtomicCasHelper(ptr, [value](T a) { return a / value; });
 }
+CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAtomicDiv, CudaAtomicDiv);
 
-// Operator overloads for complex numbers.
 #if GOOGLE_CUDA
+// Operator overloads for complex numbers.
+
 __device__ inline std::complex<float> operator+(const std::complex<float>& a,
                                                 const std::complex<float>& b) {
   auto result = cuCaddf(make_cuComplex(a.real(), a.imag()),
@@ -824,7 +863,7 @@ __device__ inline std::complex<double> operator/(
                        make_cuDoubleComplex(b.real(), b.imag()));
   return std::complex<double>(result.x, result.y);
 }
-#endif  // GOOGLE_CUDA
+#endif // GOOGLE_CUDA
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -73,6 +73,39 @@ using gpuError_t = hipError_t;
 #endif
 
 namespace tensorflow {
+// Launches a GPU kernel through cudaLaunchKernel in Cuda environment, or
+// hipLaunchKernel in ROCm environment with the given arguments.
+//
+// The kernel parameters 'Ts' must be constructible from the arguments 'Args'.
+template <typename... Ts, typename... Args>
+Status GpuLaunchKernel(void (*function)(Ts...), dim3 grid_dim, dim3 block_dim,
+                        size_t shared_memory_size_bytes, gpuStream_t stream,
+                        Args... arguments) {
+  static_assert(detail::NoneIsReference<Ts...>(),
+                "Kernels with reference arguments have undefined behaviour.");
+#if GOOGLE_CUDA
+  auto func_ptr = absl::bit_cast<const void*>(function);
+  // Cast arguments and forward them as an array of pointers.
+  auto args_tuple = std::tuple<Ts...>(arguments...);
+  auto arg_ptrs = detail::GetArrayOfElementPointers(&args_tuple);
+  auto result = cudaLaunchKernel(func_ptr, grid_dim, block_dim, arg_ptrs.data(),
+                                 shared_memory_size_bytes, stream);
+  if (result != cudaSuccess) {
+    return errors::Internal(cudaGetErrorString(result));
+  }
+#elif TENSORFLOW_USE_ROCM
+  hipLaunchKernelGGL(function, grid_dim, block_dim, shared_memory_size_bytes,
+                     stream, std::forward<Args>(arguments)...);
+#endif
+  return Status::OK();
+}
+
+// Perfect forwarding to make CudaLaunchKernel available to both ROCm and Cuda builds
+template <typename... Args>
+auto CudaLaunchKernel(Args&&... args) -> decltype(GpuLaunchKernel(std::forward<Args>(args)...)) {
+  return GpuLaunchKernel(std::forward<Args>(args)...);
+}
+
 __host__ __device__ inline tensorflow::bfloat16 GpuLdg(
     const tensorflow::bfloat16* address) {
   tensorflow::bfloat16 return_value;

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -35,18 +35,6 @@ limitations under the License.
 #define TF_RED_WARPSIZE 64
 #endif
 
-#if GOOGLE_CUDA
-#define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, \
-                          shared_mem, stream, ...) \
-  kernel<<<block_count, threads_per_block, shared_mem, stream>>>(__VA_ARGS__);
-#elif TENSORFLOW_USE_ROCM
-#define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, \
-                          shared_mem, stream, ...) \
-  hipLaunchKernelGGL(kernel, \
-    block_count, threads_per_block, shared_mem, stream, \
-    __VA_ARGS__);
-#endif
-
 // Deprecated, use 'for(int i : GpuGridRangeX(n))' instead.
 #define GPU_1D_KERNEL_LOOP(i, n) \
   for (int i : ::tensorflow::GpuGridRangeX<int>(n))

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -21,6 +21,7 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "cuda/include/cuda_fp16.h"
 #endif
+#include "tensorflow/core/util/gpu_cuda_alias.h"
 #include "tensorflow/core/util/gpu_device_functions.h"
 #include "tensorflow/core/util/gpu_launch_config.h"
 
@@ -46,6 +47,7 @@ limitations under the License.
 #define gpuSuccess cudaSuccess
 using gpuStream_t = cudaStream_t;
 using gpuError_t = cudaError_t;
+
 #elif TENSORFLOW_USE_ROCM
 #define gpuSuccess hipSuccess
 using gpuStream_t = hipStream_t;
@@ -59,7 +61,7 @@ __host__ __device__ inline const char* gpuGetErrorString(cudaError_t error){
 #elif TENSORFLOW_USE_ROCM
 // hipGetErrorString is available on host side only
 inline const char* gpuGetErrorString(hipError_t error){
-   return hipGetErrorString(error);
+  return hipGetErrorString(error);
 #endif
 }
 
@@ -142,24 +144,28 @@ __device__ inline Eigen::half GpuShuffleSync(unsigned mask, Eigen::half value,
   return Eigen::half(
       GpuShuffleSync(mask, static_cast<uint16>(value), src_lane, width));
 }
+// Aliased in gpu_device_functions.h
 
 __device__ EIGEN_ALWAYS_INLINE Eigen::half GpuShuffleUpSync(
     unsigned mask, Eigen::half value, int delta, int width = warpSize) {
   return Eigen::half(
       GpuShuffleUpSync(mask, static_cast<uint16>(value), delta, width));
 }
+// Aliased in gpu_device_functions.h
 
 __device__ EIGEN_ALWAYS_INLINE Eigen::half GpuShuffleDownSync(
     unsigned mask, Eigen::half value, int delta, int width = warpSize) {
   return Eigen::half(
       GpuShuffleDownSync(mask, static_cast<uint16>(value), delta, width));
 }
+// Aliased in gpu_device_functions.h
 
 __device__ EIGEN_ALWAYS_INLINE Eigen::half GpuShuffleXorSync(
     unsigned mask, Eigen::half value, int lane_mask, int width = warpSize) {
   return Eigen::half(
       GpuShuffleXorSync(mask, static_cast<uint16>(value), lane_mask, width));
 }
+// Aliased in gpu_device_functions.h
 #endif
 
 namespace gpu_helper {

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -24,6 +24,11 @@ limitations under the License.
 #include "tensorflow/core/util/gpu_device_functions.h"
 #include "tensorflow/core/util/gpu_launch_config.h"
 
+#if GPU_VERSION >= 7050
+#include "cuda/include/cuda_fp16.h"
+#define TF_HAS_GPU_FP16
+#endif
+
 #if GOOGLE_CUDA
 #define TF_RED_WARPSIZE 32
 #elif TENSORFLOW_USE_ROCM
@@ -31,48 +36,54 @@ limitations under the License.
 #endif
 
 #if GOOGLE_CUDA
-#define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, shared_mem, \
-                          stream, ...)                                        \
-  TF_CHECK_OK(CudaLaunchKernel(kernel, block_count, threads_per_block,        \
-                               shared_mem, stream, __VA_ARGS__));
+#define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, \
+                          shared_mem, stream, ...) \
+  kernel<<<block_count, threads_per_block, shared_mem, stream>>>(__VA_ARGS__);
 #elif TENSORFLOW_USE_ROCM
-#define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, shared_mem, \
-                          stream, ...)                                        \
-  hipLaunchKernelGGL(kernel, block_count, threads_per_block, shared_mem,      \
-                     stream, __VA_ARGS__);
+#define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, \
+                          shared_mem, stream, ...) \
+  hipLaunchKernelGGL(kernel, \
+    block_count, threads_per_block, shared_mem, stream, \
+    __VA_ARGS__);
 #endif
 
-// Deprecated, use 'for(int i : CudaGridRangeX(n))' instead.
+// Deprecated, use 'for(int i : GpuGridRangeX(n))' instead.
+#define GPU_1D_KERNEL_LOOP(i, n) \
+  for (int i : ::tensorflow::GpuGridRangeX<int>(n))
 #define CUDA_1D_KERNEL_LOOP(i, n) \
-  for (int i : ::tensorflow::CudaGridRangeX<int>(n))
-// Deprecated, use 'for(int i : CudaGridRange?(n))' instead.
+  for (int i : ::tensorflow::GpuGridRangeX<int>(n))
+
+// Deprecated, use 'for(int i : GpuGridRange?(n))' instead.
+#define GPU_AXIS_KERNEL_LOOP(i, n, axis) \
+  for (int i : ::tensorflow::GpuGridRange##axis<int>(n))
 #define CUDA_AXIS_KERNEL_LOOP(i, n, axis) \
-  for (int i : ::tensorflow::CudaGridRange##axis<int>(n))
+  for (int i : ::tensorflow::GpuGridRange##axis<int>(n))
 
 #if GOOGLE_CUDA
 #define gpuSuccess cudaSuccess
+#define GPU_GET_ERROR_STRING(error) cudaGetErrorString(error)
 using gpuStream_t = cudaStream_t;
 using gpuError_t = cudaError_t;
 
 #elif TENSORFLOW_USE_ROCM
 #define gpuSuccess hipSuccess
+#define GPU_GET_ERROR_STRING(error) hipGetErrorString(error)
 using gpuStream_t = hipStream_t;
 using gpuError_t = hipError_t;
 #endif
 
-#define GetGPUStream(context) context->eigen_gpu_device().stream()
-
 namespace tensorflow {
-__host__ __device__ inline tensorflow::bfloat16 CudaLdg(
+__host__ __device__ inline tensorflow::bfloat16 GpuLdg(
     const tensorflow::bfloat16* address) {
   tensorflow::bfloat16 return_value;
-  return_value.value = CudaLdg(reinterpret_cast<const uint16_t*>(address));
+  return_value.value = GpuLdg(reinterpret_cast<const uint16_t*>(address));
   return return_value;
 }
+// Already aliased in gpu_device_functions.h
 
 template <typename T>
 __host__ __device__ inline T ldg(const T* ptr) {
-  return CudaLdg(ptr);
+  return GpuLdg(ptr);
 }
 
 template <typename T>
@@ -99,32 +110,35 @@ __host__ __device__ inline double tf_max(double x, double y) {
   return fmax(x, y);
 }
 
-__device__ inline Eigen::half CudaShuffleSync(unsigned mask, Eigen::half value,
+// ROCM TODO re-enable them after adding fp16 support logic
+#if GOOGLE_CUDA
+__device__ inline Eigen::half GpuShuffleSync(unsigned mask, Eigen::half value,
                                               int src_lane,
                                               int width = warpSize) {
   return Eigen::half(
-      CudaShuffleSync(mask, static_cast<uint16>(value), src_lane, width));
+      GpuShuffleSync(mask, static_cast<uint16>(value), src_lane, width));
 }
 
-__device__ EIGEN_ALWAYS_INLINE Eigen::half CudaShuffleUpSync(
+__device__ EIGEN_ALWAYS_INLINE Eigen::half GpuShuffleUpSync(
     unsigned mask, Eigen::half value, int delta, int width = warpSize) {
   return Eigen::half(
-      CudaShuffleUpSync(mask, static_cast<uint16>(value), delta, width));
+      GpuShuffleUpSync(mask, static_cast<uint16>(value), delta, width));
 }
 
-__device__ EIGEN_ALWAYS_INLINE Eigen::half CudaShuffleDownSync(
+__device__ EIGEN_ALWAYS_INLINE Eigen::half GpuShuffleDownSync(
     unsigned mask, Eigen::half value, int delta, int width = warpSize) {
   return Eigen::half(
-      CudaShuffleDownSync(mask, static_cast<uint16>(value), delta, width));
+      GpuShuffleDownSync(mask, static_cast<uint16>(value), delta, width));
 }
 
-__device__ EIGEN_ALWAYS_INLINE Eigen::half CudaShuffleXorSync(
+__device__ EIGEN_ALWAYS_INLINE Eigen::half GpuShuffleXorSync(
     unsigned mask, Eigen::half value, int lane_mask, int width = warpSize) {
   return Eigen::half(
-      CudaShuffleXorSync(mask, static_cast<uint16>(value), lane_mask, width));
+      GpuShuffleXorSync(mask, static_cast<uint16>(value), lane_mask, width));
 }
+#endif
 
-namespace cuda_helper {
+namespace gpu_helper {
 template <typename T, typename OutType = int32>
 __device__ OutType upper_bound(const T* first, OutType count, T val) {
   const T* orig = first;
@@ -164,8 +178,8 @@ __device__ OutType lower_bound(const T* first, OutType count, T val) {
 
   return first - orig;
 }
-
-}  // namespace cuda_helper
+}  // namespace gpu_helper
+namespace cuda_helper = gpu_helper;
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/util/gpu_launch_config.h
+++ b/tensorflow/core/util/gpu_launch_config.h
@@ -100,7 +100,7 @@ void MyDriverFunc(const Eigen::GpuDevice &d) {
 
 // See the test for this for more example:
 //
-https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/util/cuda_kernel_helper_test.cu.cc
+https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/util/gpu_kernel_helper_test.cu.cc
 
 */
 
@@ -310,12 +310,12 @@ Cuda3DLaunchConfig GetGpu3DLaunchConfig(int xdim, int ydim, int zdim,
       block_size_limit);
   CHECK_EQ(err, cudaSuccess);
 #elif TENSORFLOW_USE_ROCM
-  // XXX FIXME re-enable this after hipOccupancyMaxPotentialBlockSize is
+  // ROCM FIXME re-enable this after hipOccupancyMaxPotentialBlockSize is
   // implemented
-  //hipError_t err = hipOccupancyMaxPotentialBlockSize(
+  // hipError_t err = hipOccupancyMaxPotentialBlockSize(
   //    &block_count, &thread_per_block, func, dynamic_shared_memory_size,
   //    block_size_limit);
-  //CHECK_EQ(err, hipSuccess);
+  // CHECK_EQ(err, hipSuccess);
 
   const int physical_thread_count =
       d.getNumGpuMultiProcessors() * d.maxGpuThreadsPerMultiProcessor();

--- a/tensorflow/core/util/gpu_launch_config.h
+++ b/tensorflow/core/util/gpu_launch_config.h
@@ -396,32 +396,7 @@ constexpr bool NoneIsReference() {
   return NoneTrue<(std::is_reference<Ts>::value)...>::value;
 }
 }  // namespace detail
-
-#if GOOGLE_CUDA
-// Launches a CUDA kernel through cudaLaunchKernel with the given arguments.
-//
-// The kernel parameters 'Ts' must be constructible from the arguments 'Args'.
-template <typename... Ts, typename... Args>
-Status CudaLaunchKernel(void (*function)(Ts...), dim3 grid_dim, dim3 block_dim,
-                        size_t shared_memory_size_bytes, cudaStream_t stream,
-                        Args... arguments) {
-  static_assert(detail::NoneIsReference<Ts...>(),
-                "Kernels with reference arguments have undefined behaviour.");
-  // Cast arguments and forward them as an array of pointers.
-  auto args_tuple = std::tuple<Ts...>(arguments...);
-  auto arg_ptrs = detail::GetArrayOfElementPointers(&args_tuple);
-  auto func_ptr = absl::bit_cast<const void*>(function);
-  auto result = cudaLaunchKernel(func_ptr, grid_dim, block_dim, arg_ptrs.data(),
-                                 shared_memory_size_bytes, stream);
-  if (result != cudaSuccess) {
-    return errors::Internal(cudaGetErrorString(result));
-  }
-  return Status::OK();
-}
-
-#endif
-
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-#endif  // TENSORFLOW_CORE_UTIL_GPU_KERNEL_HELPER_H_
+#endif  // TENSORFLOW_CORE_UTIL_GPU_LAUNCH_CONFIG_H_

--- a/tensorflow/examples/adding_an_op/cuda_op_kernel.cu.cc
+++ b/tensorflow/examples/adding_an_op/cuda_op_kernel.cu.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #if GOOGLE_CUDA
 #define EIGEN_USE_GPU
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/gpu_launch_config.h"
 
 __global__ void AddOneKernel(const int* in, const int N, int* out) {

--- a/tensorflow/stream_executor/gpu/gpu_driver.h
+++ b/tensorflow/stream_executor/gpu/gpu_driver.h
@@ -21,7 +21,9 @@ limitations under the License.
 #include <stddef.h>
 #include "tensorflow/stream_executor/platform/port.h"
 
+#if GOOGLE_CUDA
 #include "cuda/include/cuda.h"
+#endif
 #include "tensorflow/stream_executor/device_options.h"
 #include "tensorflow/stream_executor/lib/status.h"
 #include "tensorflow/stream_executor/lib/statusor.h"


### PR DESCRIPTION
This PR is a follow-up to PR #24293. This PR depends on & includes code changes from PR #28116. Code updates for this PR are in the `tensorflow/core/util` path

Through utility functions defined in gpu_cuda_alias.h, this PR provides a Cuda* alias to existing Gpu* functions. The reason for this PR is to create backward compatibility to both the TensorFlow master branch as well as ROCm's develop-upstream branch. It allows TensorFlow master branch to slowly deprecate Cuda* aliased function, to the final goal of using GPU as the prefix to unify both Cuda and ROCm builds. All aliasing is done through perfect forwarding macro so that it is easy to maintain/take out.

Tests performed: Both Cuda/ROCm build successfully in both master and develop-upstream branch.

@whchung @deven-amd 