### PR TITLE
Skip a SavedModel captured dataset loading test in v1 on gpu

### DIFF
--- a/tensorflow/python/saved_model/save_test.py
+++ b/tensorflow/python/saved_model/save_test.py
@@ -330,6 +330,9 @@ class SaveTest(test.TestCase):
     save.save(root, save_dir)
 
   def test_function_with_captured_dataset(self):
+    if test_util.is_gpu_available():
+      self.skipTest("Currently broken when a GPU is available.")
+
     class HasDataset(module.Module):
 
       def __init__(self):


### PR DESCRIPTION
It's broken not a very important use-case. Loading in v2 on GPU works.

PiperOrigin-RevId: 245172655