### PR TITLE
[TF-TRT] Adds support for INT64 constants (and bounds checks)

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3201,34 +3201,35 @@ Status TfTensorToTrtWeights(const Tensor& tensor, TrtWeightStore* weight_store,
     return Status::OK();
   }
 
+  Status status = Status::OK();
   // Copy tensor elements after casting them to the converted DataType.
   int32* dst = static_cast<int32*>(weights->GetValues());
   switch (dtype) {
     case DT_INT8:
-      CopyToTrtInt32Array<DT_INT8>(tensor, dst);
+      status = CopyToTrtInt32Array<DT_INT8>(tensor, dst);
       break;
     case DT_UINT8:
-      CopyToTrtInt32Array<DT_UINT8>(tensor, dst);
+      status = CopyToTrtInt32Array<DT_UINT8>(tensor, dst);
       break;
     case DT_INT16:
-      CopyToTrtInt32Array<DT_INT16>(tensor, dst);
+      status = CopyToTrtInt32Array<DT_INT16>(tensor, dst);
       break;
     case DT_UINT16:
-      CopyToTrtInt32Array<DT_UINT16>(tensor, dst);
+      status = CopyToTrtInt32Array<DT_UINT16>(tensor, dst);
       break;
     case DT_UINT32:
-      CopyToTrtInt32Array<DT_UINT32>(tensor, dst);
+      status = CopyToTrtInt32Array<DT_UINT32>(tensor, dst);
       break;
     case DT_INT64:
-      CopyToTrtInt32Array<DT_INT64>(tensor, dst);
+      status = CopyToTrtInt32Array<DT_INT64>(tensor, dst);
       break;
     case DT_UINT64:
-      CopyToTrtInt32Array<DT_UINT64>(tensor, dst);
+      status = CopyToTrtInt32Array<DT_UINT64>(tensor, dst);
       break;
     default:
       return errors::Internal("Unexpected DataType: ", DataTypeString(dtype));
   }
-  return Status::OK();
+  return status;
 }
 
 // Convert a Const NodeDef to TRT_ShapedWeights. This is a special converter, it

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3163,9 +3163,8 @@ Status CopyToTrtInt32Array(const Tensor& tensor, int32* dst) {
       return errors::InvalidArgument("Value at index ", i,
                                      " is outside the range of int32");
     }
+    dst[i] = static_cast<int32>(src[i]);
   }
-  std::transform(src, src + tensor.NumElements(), dst,
-                 [](const CType& val) { return static_cast<int32>(val); });
   return Status::OK();
 }
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3136,13 +3136,15 @@ void GetTensorDimsWithProtoShape(const Tensor& tensor, nvinfer1::Dims* dims) {
 
 template <typename Bounds, typename Input>
 constexpr bool IsIntegerInBounds(const Input& inp) {
-  static_assert(std::is_integral<Input>::value, "This function is only implemented for integral types.");
+  static_assert(std::is_integral<Input>::value,
+                "This function is only implemented for integral types.");
   return (sizeof(Bounds) >= sizeof(Input))
-    // Since Input is smaller, it will always be in range of Bounds.
-    ? true
-    // Since Input is larger, we cast all values to that.
-    : (inp >= static_cast<Input>(std::numeric_limits<Bounds>::lowest())
-      && inp <= static_cast<Input>(std::numeric_limits<Bounds>::max()));
+             // Since Input is smaller, it will always be in range of Bounds.
+             ? true
+             // Since Input is larger, we cast all values to that.
+             : (inp >=
+                    static_cast<Input>(std::numeric_limits<Bounds>::lowest()) &&
+                inp <= static_cast<Input>(std::numeric_limits<Bounds>::max()));
 }
 
 template <DataType dtype>
@@ -3152,7 +3154,8 @@ Status CopyToTrtInt32Array(const Tensor& tensor, int32* dst) {
   for (int i = 0; i < tensor.NumElements(); ++i) {
     // This becomes a no-op if sizeof(CType) < sizeof(int32)
     if (!IsIntegerInBounds<int32>(src[i])) {
-      return errors::InvalidArgument("Value at index " + std::to_string(i) + " is outside the range of int32");
+      return errors::InvalidArgument("Value at index " + std::to_string(i) +
+                                     " is outside the range of int32");
     }
     dst[i] = static_cast<int32>(src[i]);
   }
@@ -3171,7 +3174,8 @@ Status TfTensorToTrtWeights(const Tensor& tensor, TrtWeightStore* weight_store,
   // this.
   DataType converted_dtype = dtype;
   if (dtype == DataType::DT_INT8 || dtype == DataType::DT_UINT8 ||
-      dtype == DataType::DT_INT16 || dtype == DataType::DT_UINT16 || dtype == DataType::DT_INT64) {
+      dtype == DataType::DT_INT16 || dtype == DataType::DT_UINT16 ||
+      dtype == DataType::DT_INT64) {
     converted_dtype = DT_INT32;
   }
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3139,8 +3139,9 @@ inline bool IsIntegerInBounds(const Input& inp) {
   static_assert(std::is_integral<Input>::value,
                 "This function is only implemented for integral types.");
   // If Input is always within the range of Bounds, return true.
-  if (std::numeric_limits<Input>::lowest() >= std::numeric_limits<Bounds>::lowest()
-      && std::numeric_limits<Input>::max() <= std::numeric_limits<Bounds>::max()) {
+  if (std::numeric_limits<Input>::lowest() >=
+          std::numeric_limits<Bounds>::lowest() &&
+      std::numeric_limits<Input>::max() <= std::numeric_limits<Bounds>::max()) {
     return true;
   }
   // Otherwise, we need to check the value of the input.
@@ -3176,7 +3177,8 @@ Status TfTensorToTrtWeights(const Tensor& tensor, TrtWeightStore* weight_store,
   DataType converted_dtype = dtype;
   if (dtype == DataType::DT_INT8 || dtype == DataType::DT_UINT8 ||
       dtype == DataType::DT_INT16 || dtype == DataType::DT_UINT16 ||
-      dtype == DataType::DT_INT64) {
+      dtype == DataType::DT_UINT32 || dtype == DataType::DT_INT64 ||
+      dtype == DataType::DT_UINT64) {
     converted_dtype = DT_INT32;
   }
 
@@ -3217,8 +3219,14 @@ Status TfTensorToTrtWeights(const Tensor& tensor, TrtWeightStore* weight_store,
     case DT_UINT16:
       CopyToTrtInt32Array<DT_UINT16>(tensor, dst);
       break;
+    case DT_UINT32:
+      CopyToTrtInt32Array<DT_UINT32>(tensor, dst);
+      break;
     case DT_INT64:
       CopyToTrtInt32Array<DT_INT64>(tensor, dst);
+      break;
+    case DT_UINT64:
+      CopyToTrtInt32Array<DT_UINT64>(tensor, dst);
       break;
     default:
       return errors::Internal("Unexpected DataType: ", DataTypeString(dtype));

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1464,6 +1464,23 @@ TEST_F(OpConverterTest, ConvertConst) {
     RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
                                "Unsupported data type double");
   }
+  {
+    Reset();
+    Tensor tensor =
+        test::AsTensor<int64>({1, std::numeric_limits<int64>::max(), 1, 1, 1,
+                               std::numeric_limits<int64>::lowest()},
+                              TensorShape({2, 3}));
+    NodeDef node_def;
+    node_def.set_name("my_const");
+    node_def.set_op("Const");
+    (*node_def.mutable_attr())["dtype"].set_type(DT_INT64);
+    TensorProto* tensor_attr =
+        (*node_def.mutable_attr())["value"].mutable_tensor();
+    tensor_attr->Clear();
+    tensor.AsProtoTensorContent(tensor_attr);
+    RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
+                               "outside the range of int32");
+  }
 
   TestConvertConst<DT_FLOAT, float, float>(this);
   TestConvertConst<DT_INT8, int8, int32>(this);
@@ -1471,6 +1488,9 @@ TEST_F(OpConverterTest, ConvertConst) {
   TestConvertConst<DT_INT16, int16, int32>(this);
   TestConvertConst<DT_UINT16, uint16, int32>(this);
   TestConvertConst<DT_INT32, int32, int32>(this);
+  TestConvertConst<DT_UINT32, uint32, int32>(this);
+  TestConvertConst<DT_INT64, int64, int32>(this);
+  TestConvertConst<DT_UINT64, uint64, int32>(this);
 }
 
 TEST_F(OpConverterTest, ConvertTranspose) {


### PR DESCRIPTION
Modifies the Constant converter in TF-TRT so that it will cast int64 values down to int32 if they are in range. 