### PR TITLE
Fix the return dtype of IsZero() function

### DIFF
--- a/tensorflow/core/framework/function_testlib.cc
+++ b/tensorflow/core/framework/function_testlib.cc
@@ -81,7 +81,7 @@ FunctionDef IsZero() {
       // Args
       {"x: T"},
       // Return values
-      {"equal: T"},
+      {"equal: bool"},
       // Attr def
       {"T:{float, double, int32, int64, string}"},
       {


### PR DESCRIPTION
`IsZero` function use `Equal` Op internally, so the return dtype should be `bool` rather than `T`.