### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build.

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/stream_executor/rocm/rocm_driver.cc
@@ -995,9 +995,9 @@ GpuDriver::ContextGetSharedMemConfig(GpuContext* context) {
   return true;
 }
 
-/* static */ port::Status GpuDriver::CreateEvent(GpuContext* context,
-                                                 GpuEventHandle* event,
-                                                 EventFlags flags) {
+/* static */ port::Status GpuDriver::InitEvent(GpuContext* context,
+					       GpuEventHandle* event,
+					       EventFlags flags) {
   int hipflags;
   switch (flags) {
     case EventFlags::kDefault:


### PR DESCRIPTION
The --config=rocm build was broken by the following commit.

https://github.com/tensorflow/tensorflow/commit/084e14e7032f08810ee73b4bdc9b590cdcc0ef92

The changes made by the above commit did not contain the corresponding changes for the ROCm platform, which was leading to the build failure. Making the corresponding update for ROCm, to make the --config=rocm build working again.

---------------------

@tatianashp , @whchung, @timshen91 just FYI

Please approve and merge. As with other such PRs this week, the changes here are trivial and only applicable for the --config=rocm build.

thanks