### PR TITLE
compact rendering of layer I/O shapes in plot_model

### DIFF
--- a/tensorflow/python/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/utils/vis_utils.py
@@ -116,14 +116,16 @@ def model_to_dot(model, show_shapes=False, show_layer_names=True, rankdir='TB'):
 
     # Rebuild the label as a table including input/output shapes.
     if show_shapes:
+      def format_shape(shape):
+        return str(shape).replace(str(None), '?')
       try:
-        outputlabels = str(layer.output_shape)
+        outputlabels = format_shape(layer.output_shape)
       except AttributeError:
         outputlabels = 'multiple'
       if hasattr(layer, 'input_shape'):
-        inputlabels = str(layer.input_shape)
+        inputlabels = format_shape(layer.input_shape)
       elif hasattr(layer, 'input_shapes'):
-        inputlabels = ', '.join([str(ishape) for ishape in layer.input_shapes])
+        inputlabels = ', '.join([format_shape(ishape) for ishape in layer.input_shapes])
       else:
         inputlabels = 'multiple'
       label = '%s\n|{input:|output:}|{{%s}|{%s}}' % (label, inputlabels,


### PR DESCRIPTION
Render the input/output shapes of a layer more compactly by replacing `None` with `?`, e.g. render `(None,100,100)` to `(?,100,100)`.