### PR TITLE
Add Int32 and Int64 value support to SplitV.

### DIFF
--- a/tensorflow/lite/kernels/split_v.cc
+++ b/tensorflow/lite/kernels/split_v.cc
@@ -126,7 +126,9 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   auto input_type = op_context.input->type;
   TF_LITE_ENSURE(context, input_type == kTfLiteFloat32 ||
                               input_type == kTfLiteUInt8 ||
-                              input_type == kTfLiteInt16);
+                              input_type == kTfLiteInt16 ||
+                              input_type == kTfLiteInt32 ||
+                              input_type == kTfLiteInt64);
   for (int i = 0; i < NumOutputs(node); ++i) {
     GetOutput(context, node, i)->type = input_type;
   }
@@ -180,6 +182,14 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     }
     case kTfLiteInt16: {
       TF_LITE_SPLIT_V(int16_t);
+      break;
+    }
+    case kTfLiteInt32: {
+      TF_LITE_SPLIT_V(int32_t);
+      break;
+    }
+    case kTfLiteInt64: {
+      TF_LITE_SPLIT_V(int64_t);
       break;
     }
     default:

--- a/tensorflow/lite/kernels/split_v_test.cc
+++ b/tensorflow/lite/kernels/split_v_test.cc
@@ -200,6 +200,34 @@ TEST(SplitVOpTest, TwoDimensionalInt16) {
       {{1, 2, 3}, {4, 5, 6}, {7, 8, 9, 10, 11, 12}});
 }
 
+TEST(SplitVOpTest, TwoDimensionalInt32) {
+  // Input shape: {4, 3}
+  // size_splits: {1, 1, 2}
+  // axis: 0
+  // We should have 3 outpus with shapes respectively:
+  //  output 1 : {1, 3}
+  //  output 2 : {1, 3}
+  //  output 3 : {2, 3}
+  Check<int32_t, TensorType_INT32>(
+      /*axis=*/0, {4, 3}, {3}, {{1, 3}, {1, 3}, {2, 3}},
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {1, 1, 2},
+      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9, 10, 11, 12}});
+}
+
+TEST(SplitVOpTest, TwoDimensionalInt64) {
+  // Input shape: {4, 3}
+  // size_splits: {1, 1, 2}
+  // axis: 0
+  // We should have 3 outpus with shapes respectively:
+  //  output 1 : {1, 3}
+  //  output 2 : {1, 3}
+  //  output 3 : {2, 3}
+  Check<int64_t, TensorType_INT64>(
+      /*axis=*/0, {4, 3}, {3}, {{1, 3}, {1, 3}, {2, 3}},
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {1, 1, 2},
+      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9, 10, 11, 12}});
+}
+
 }  // namespace
 }  // namespace tflite
 


### PR DESCRIPTION
Support additional data types for the SplitV operator in TensorFlow Lite.