### PR TITLE
[INTEL MKL] Disable MKL Op Rewrite for Conv with padding==EXPLICIT

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -3404,6 +3404,16 @@ MklLayoutRewritePass::CheckForNodeRewrite(const Node* n) const {
     return nullptr;
   }
 
+  // We make an exception for Conv2D, as the corresponding MKL ops
+  // currently do not support the case of padding == EXPLICIT yet.
+  if (n->type_string() == csinfo_.conv2d ||
+      n->type_string() == csinfo_.conv2d_grad_input ||
+      n->type_string() == csinfo_.conv2d_grad_filter) {
+    string padding;
+    TF_CHECK_OK(GetNodeAttr(n->def(), "padding", &padding));
+    if (padding == "EXPLICIT") return nullptr;
+  }
+
   // We make an exception for __MklDummyConv2DWithBias,
   // __MklConv2DBackpropFilterWithBias, and __MklDummyPadWithConv2D since their
   // names do not match Mkl node names.


### PR DESCRIPTION
Tensorflow recently added a new feature of supporting a new "EXPLICIT" padding value with Conv2D op.
However, MklConv does not support it yet.

This PR disables MKL node rewritting for such a special case (thus TF will pick up the Eigen version Conv2D). 