### PR TITLE
Update backprop.py

### DIFF
--- a/tensorflow/python/eager/backprop.py
+++ b/tensorflow/python/eager/backprop.py
@@ -1013,6 +1013,7 @@ class GradientTape(object):
     target_shape = array_ops.shape(target)
     # Note that we push and pop the tape here and below. This is needed since we
     # need gradients through the enclosed operations.
+    self._recording = False # _recording flag will be toogled to True after _push_tape method is called
     self._push_tape()
     target = array_ops.reshape(target, [-1])
     self._pop_tape()


### PR DESCRIPTION
I tried the example in the docs of GradientTape.jacobian method. However, I got an error like so:

    with tf.GradientTape() as g:
      x  = tf.constant([1.0, 2.0])
      g.watch(x)
      y = x * x
    jacobian = g.jacobian(y, x)
    # jacobian value is [[2., 0.], [0., 4.]]

ValueError                                Traceback (most recent call last)
<ipython-input-1-98cbf513a095> in <module>
      4       g.watch(x)
      5       y = x * x
----> 6       jacobian = g.jacobian(y, x)
      7 

/anaconda3/envs/ml4u/lib/python3.7/site-packages/tensorflow/python/eager/backprop.py in jacobian(self, target, sources, unconnected_gradients, parallel_iterations, experimental_use_pfor)
   1015     # need gradients through the enclosed operations.
   1016     #self._recording = False
-> 1017     self._push_tape()
   1018     target = array_ops.reshape(target, [-1])
   1019     self._pop_tape()

/anaconda3/envs/ml4u/lib/python3.7/site-packages/tensorflow/python/eager/backprop.py in _push_tape(self)
    778   def _push_tape(self):
    779     if self._recording:
--> 780       raise ValueError("Tape is already recording.")
    781     if self._tape is None:
    782       self._tape = tape.push_new_tape(

ValueError: Tape is already recording.

I checked the source code and found that when calling method '_push_tape', it check for flag "self._recording". If 'self._recording' == True,  generate the error message as above. So I have to manually add "self._recording = False' to line 1016.  I have tested and found no more errors.