### PR TITLE
fix nccl build bug

### DIFF
--- a/third_party/nccl/nccl_configure.bzl
+++ b/third_party/nccl/nccl_configure.bzl
@@ -91,7 +91,11 @@ def _nccl_configure_impl(repository_ctx):
     else:
         # Create target for locally installed NCCL.
         config = find_cuda_config(repository_ctx, ["nccl"])
-        repository_ctx.template("BUILD", _label("system.BUILD.tpl"), config)
+        config_wrap = {
+            "%{nccl_version}": config["nccl_version"],
+            "%{nccl_header_dir}": config["nccl_include_dir"],
+            "%{nccl_library_dir}": config["nccl_library_dir"]}
+        repository_ctx.template("BUILD", _label("system.BUILD.tpl"), config_wrap)
 
 nccl_configure = repository_rule(
     implementation = _nccl_configure_impl,


### PR DESCRIPTION
fix bug: nccl build fail as below:

ERROR: /root/.cache/bazel/_bazel_root/xxxxx/external/local_config_nccl/BUILD:8:12: in srcs attribute of cc_library rule @local_config_nccl//:nccl: generated file '@local_config_nccl//:libnccl.so.%{2}' is misplaced here (expected .cc, .cpp, .cxx, .c++, .C, .c, .h, .hh, .hpp, .ipp, .hxx, .inc, .inl, .H, .S, .s, .asm, .a, .lib, .pic.a, .lo, .lo.lib, .pic.lo, .so, .dylib, .dll, .o, .obj or .pic.o)
ERROR: /root/.cache/bazel/_bazel_root/xxxxx/external/local_config_nccl/BUILD:8:12: in srcs attribute of cc_library rule @local_config_nccl//:nccl: '@local_config_nccl//:libnccl.so.%{2}' does not produce any cc_library srcs files (expected .cc, .cpp, .cxx, .c++, .C, .c, .h, .hh, .hpp, .ipp, .hxx, .inc, .inl, .H, .S, .s, .asm, .a, .lib, .pic.a, .lo, .lo.lib, .pic.lo, .so, .dylib, .dll, .o, .obj or .pic.o)