### PR TITLE
[ROCm] Adding ROCm support for "depth_to_space" and "space_to_depth" ops

### DIFF
--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -183,7 +183,7 @@ struct DepthToSpaceOpFunctor<CPUDevice, T, FORMAT_NHWC> {
 TF_CALL_ALL_TYPES(REGISTER);
 #undef REGISTER
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 REGISTER_KERNEL_BUILDER(
     Name("DepthToSpace").Device(DEVICE_GPU).TypeConstraint<float>("T"),
     DepthToSpaceOp<GPUDevice, float>);
@@ -193,6 +193,6 @@ REGISTER_KERNEL_BUILDER(
 REGISTER_KERNEL_BUILDER(
     Name("DepthToSpace").Device(DEVICE_GPU).TypeConstraint<qint8>("T"),
     DepthToSpaceOp<GPUDevice, qint8>);
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // end namespace tensorflow

--- a/tensorflow/core/kernels/depthtospace_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/depthtospace_op_gpu.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -37,7 +37,7 @@ __global__ void D2S_NHWC(const int32 nthreads,
                          const int input_depth, const int output_height,
                          const int output_width, const int output_depth,
                          dtype* __restrict__ output_ptr) {
-  CUDA_1D_KERNEL_LOOP(out_idx, nthreads) {
+  GPU_1D_KERNEL_LOOP(out_idx, nthreads) {
     // out_idx = d + output_depth * (w + output_width * (h + output_height * b))
     const int d = out_idx % output_depth;
     const int out_idx2 = out_idx / output_depth;
@@ -66,7 +66,7 @@ __global__ void D2S_NCHW(const int32 nthreads,
                          const int block_size, const int input_width,
                          const int output_depth_by_input_height,
                          dtype* __restrict__ output_ptr) {
-  CUDA_1D_KERNEL_LOOP(input_idx, nthreads) {
+  GPU_1D_KERNEL_LOOP(input_idx, nthreads) {
     // We will be converting the image from ordering:
     // n, bY, bX, oC, iY, iX    (== input_idx)   to
     // n, oC, iY, bY, iX, bX
@@ -104,7 +104,7 @@ __global__ void D2S_NCHW_LOOP(const int32 nthreads,
                               const int output_depth_by_input_area,
                               const int input_depth_by_input_area,
                               dtype* __restrict__ output) {
-  CUDA_1D_KERNEL_LOOP(thread_idx, nthreads) {
+  GPU_1D_KERNEL_LOOP(thread_idx, nthreads) {
     // We will be converting the image from ordering:
     // n, bY, bX, oC, iY, iX   to
     // n, oC, iY, bY, iX, bX
@@ -160,8 +160,8 @@ struct DepthToSpaceOpFunctor<GPUDevice, T, FORMAT_NHWC> {
     if (total_count == 0) {
       return;
     }
-    GpuLaunchConfig config = GetCudaLaunchConfig(total_count, d);
-    TF_CHECK_OK(CudaLaunchKernel(
+    GpuLaunchConfig config = GetGpuLaunchConfig(total_count, d);
+    TF_CHECK_OK(GpuLaunchKernel(
         D2S_NHWC<T>, config.block_count, config.thread_per_block, 0, d.stream(),
         config.virtual_thread_count, input.data(), block_size, batch_size,
         input_height, input_width, input_depth, output_height, output_width,
@@ -194,24 +194,24 @@ struct DepthToSpaceOpFunctor<GPUDevice, T, FORMAT_NCHW> {
       if (total_count == 0) {
         return;
       }
-      GpuLaunchConfig config = GetCudaLaunchConfig(total_count, d);
+      GpuLaunchConfig config = GetGpuLaunchConfig(total_count, d);
       switch (block_size) {
         case 2:
-          TF_CHECK_OK(CudaLaunchKernel(
+          TF_CHECK_OK(GpuLaunchKernel(
               D2S_NCHW_LOOP<T, 2>, config.block_count, config.thread_per_block,
               0, d.stream(), total_count, input.data(), input_width,
               output_width, output_depth_by_input_area,
               input_depth_by_input_area, output.data()));
           return;
         case 3:
-          TF_CHECK_OK(CudaLaunchKernel(
+          TF_CHECK_OK(GpuLaunchKernel(
               D2S_NCHW_LOOP<T, 3>, config.block_count, config.thread_per_block,
               0, d.stream(), total_count, input.data(), input_width,
               output_width, output_depth_by_input_area,
               input_depth_by_input_area, output.data()));
           return;
         case 4:
-          TF_CHECK_OK(CudaLaunchKernel(
+          TF_CHECK_OK(GpuLaunchKernel(
               D2S_NCHW_LOOP<T, 4>, config.block_count, config.thread_per_block,
               0, d.stream(), total_count, input.data(), input_width,
               output_width, output_depth_by_input_area,
@@ -226,7 +226,7 @@ struct DepthToSpaceOpFunctor<GPUDevice, T, FORMAT_NCHW> {
       return;
     }
     auto config = GetGpuLaunchConfig(total_count, d);
-    TF_CHECK_OK(CudaLaunchKernel(
+    TF_CHECK_OK(GpuLaunchKernel(
         D2S_NCHW<T>, config.block_count, config.thread_per_block, 0, d.stream(),
         config.virtual_thread_count, input.data(), block_size, input_width,
         output_depth * input_height, output.data()));
@@ -253,4 +253,4 @@ template struct functor::DepthToSpaceOpFunctor<GPUDevice, int32, FORMAT_NCHW>;
 
 }  // end namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/spacetodepth_op.cc
+++ b/tensorflow/core/kernels/spacetodepth_op.cc
@@ -183,7 +183,7 @@ struct SpaceToDepthOpFunctor<CPUDevice, T, FORMAT_NHWC> {
 TF_CALL_ALL_TYPES(REGISTER);
 #undef REGISTER
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 REGISTER_KERNEL_BUILDER(
     Name("SpaceToDepth").Device(DEVICE_GPU).TypeConstraint<float>("T"),
     SpaceToDepthOp<GPUDevice, float>);
@@ -196,6 +196,6 @@ REGISTER_KERNEL_BUILDER(
 REGISTER_KERNEL_BUILDER(
     Name("SpaceToDepth").Device(DEVICE_GPU).TypeConstraint<uint8>("T"),
     SpaceToDepthOp<GPUDevice, uint8>);
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // end namespace tensorflow


### PR DESCRIPTION
This PR adds support for "depth_to_space" and "space_to_depth" ops

PR #28343 is a pre-req for this PR, and hence this PR includes commits from PR #28343
Only the last two commits in this PR is exclusive to this PR, and hence should be the only one reviewed.

--------------------

Please ignore the cla check failure...that is getting triggered because this PR builds on top of PR #28343 (which is submitted by a different developer). Once that PR is merged, and I rebase this PR, the commit triggering the cla check failure will be gone from this commit

---------------------

@tatianashp , @whchung : just FYI