### PR TITLE
[ROCm] Adding ROCm support for "sparse_tensor_dense_matmul" op 

### DIFF
--- a/tensorflow/core/kernels/sparse_tensor_dense_matmul_op.cc
+++ b/tensorflow/core/kernels/sparse_tensor_dense_matmul_op.cc
@@ -174,7 +174,7 @@ REGISTER_KERNELS_CPU(int32);
 REGISTER_KERNELS_CPU(complex64);
 REGISTER_KERNELS_CPU(complex128);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace functor {
 #define DECLARE_GPU_SPEC(T, Tindices, ADJ_A, ADJ_B)                       \
@@ -221,7 +221,7 @@ DECLARE_ADJOINT_GPU_SPEC(float);
 REGISTER_KERNELS_GPU(float);
 #undef REGISTER_GPU
 #undef REGISTER_KERNELS_GPU
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace functor {
 

--- a/tensorflow/core/kernels/sparse_tensor_dense_matmul_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/sparse_tensor_dense_matmul_op_gpu.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -35,7 +35,7 @@ __global__ void SparseTensorDenseMatMulKernel(int nnz, int m, int b_rows,
   // out_{ij} = sum_k {a_ik b_kj}
   // out = A * B', out_{ij} = sum_k {a_ik (b')_kj}; b'_{kj} = b_{jk}
   const int n = (ADJ_B) ? b_cols : b_rows;
-  CUDA_1D_KERNEL_LOOP(index, nnz * p) {
+  GPU_1D_KERNEL_LOOP(index, nnz * p) {
     const int a_ix = index / p;
     const int j = index % p;
     const int i = ldg(a_indices + 2 * a_ix + ((ADJ_A) ? 1 : 0));
@@ -46,7 +46,7 @@ __global__ void SparseTensorDenseMatMulKernel(int nnz, int m, int b_rows,
     // out[i, j]
     T* out_location = out + i * p + j;
     if (!FastBoundsCheck(k, n)) {
-      CudaAtomicAdd(out_location, std::numeric_limits<T>::quiet_NaN());
+      GpuAtomicAdd(out_location, std::numeric_limits<T>::quiet_NaN());
       continue;
     }
 
@@ -55,7 +55,7 @@ __global__ void SparseTensorDenseMatMulKernel(int nnz, int m, int b_rows,
 
     // b_value == (ADJ_B) ? b[j, k] : b[k, j]
     const T b_value = ldg(b + ((ADJ_B) ? j * b_cols + k : k * b_cols + j));
-    CudaAtomicAdd(out_location, a_value * b_value);
+    GpuAtomicAdd(out_location, a_value * b_value);
   }
 }
 
@@ -78,9 +78,9 @@ struct SparseTensorDenseMatMulFunctor<GPUDevice, T, Tindices, ADJ_A, ADJ_B> {
 
     // TODO(ebrevdo): Should this be alpha * nnz instead of
     // out.size()?  Perhaps p * nnz ?
-    GpuLaunchConfig config = GetCudaLaunchConfig(p * nnz, d);
+    GpuLaunchConfig config = GetGpuLaunchConfig(p * nnz, d);
 
-    TF_CHECK_OK(CudaLaunchKernel(
+    TF_CHECK_OK(GpuLaunchKernel(
         SparseTensorDenseMatMulKernel<T, Tindices, ADJ_A, ADJ_B>,
         config.block_count, config.thread_per_block, 0, d.stream(), nnz, m,
         b_rows, b_cols, p, a_indices.data(), a_values.data(), b.data(),
@@ -108,4 +108,4 @@ DEFINE(float, int64);
 
 }  // end namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
This PR adds ROCm support for  "sparse_tensor_dense_matmul" op 

PR #28343 is a pre-req for this PR, and hence this PR includes commits from PR #28343
Only the last commit in this PR is exclusive to this PR, and hence should be the only one reviewed.

---------------------

Please ignore the cla check failure...that is getting triggered because this PR builds on top of PR #28343 (which is submitted by a different developer). Once that PR is merged, and I rebase this PR, the commit triggering the cla check failure will be gone from this commit

---------------------

@tatianashp , @whchung : just FYI
