### PR TITLE
cuda: fix symbol name in cudart_stub for cuda10.1

### DIFF
--- a/tensorflow/stream_executor/cuda/cudart_stub.cc
+++ b/tensorflow/stream_executor/cuda/cudart_stub.cc
@@ -122,9 +122,9 @@ extern __host__ __device__ unsigned CUDARTAPI __cudaPushCallConfiguration(
 }
 
 #if CUDA_VERSION >= 10010
-extern void CUDARTAPI __cudaUnregisterFatBinaryEnd(void **fatCubinHandle) {
+extern void CUDARTAPI __cudaRegisterFatBinaryEnd(void **fatCubinHandle) {
   using FuncPtr = void(CUDARTAPI *)(void **fatCubinHandle);
-  static auto func_ptr = LoadSymbol<FuncPtr>("__cudaUnregisterFatBinaryEnd");
+  static auto func_ptr = LoadSymbol<FuncPtr>("__cudaRegisterFatBinaryEnd");
   if (!func_ptr) return;
   func_ptr(fatCubinHandle);
 }


### PR DESCRIPTION
The symbol name is __cudaRegisterFatBinaryEnd, not
__cudaUnregisterFatBinaryEnd

Signed-off-by: Jason Zaman <jason@perfinion.com>