### PR TITLE
Fix tf.signal.inverse_stft AttributeError in tf 2.0

### DIFF
--- a/tensorflow/python/ops/signal/spectral_ops.py
+++ b/tensorflow/python/ops/signal/spectral_ops.py
@@ -242,7 +242,7 @@ def inverse_stft(stfts,
     # truncate to frame_length.
     if (frame_length_static is None or
         real_frames.shape.ndims is None or
-        real_frames.shape[-1].value is None):
+        real_frames.shape.as_list()[-1] is None):
       real_frames = real_frames[..., :frame_length]
       real_frames_rank = array_ops.rank(real_frames)
       real_frames_shape = array_ops.shape(real_frames)
@@ -253,10 +253,10 @@ def inverse_stft(stfts,
       real_frames = array_ops.pad(real_frames, paddings)
     # We know real_frames's last dimension and frame_length statically. If they
     # are different, then pad or truncate real_frames to frame_length.
-    elif real_frames.shape[-1].value > frame_length_static:
+    elif real_frames.shape.as_list()[-1] > frame_length_static:
       real_frames = real_frames[..., :frame_length_static]
-    elif real_frames.shape[-1].value < frame_length_static:
-      pad_amount = frame_length_static - real_frames.shape[-1].value
+    elif real_frames.shape.as_list()[-1] < frame_length_static:
+      pad_amount = frame_length_static - real_frames.shape.as_list()[-1]
       real_frames = array_ops.pad(real_frames,
                                   [[0, 0]] * (real_frames.shape.ndims - 1) +
                                   [[0, pad_amount]])


### PR DESCRIPTION
This fix tries to address the issue raised in #28444 where tf.signal.inverse_stft causes AttributeError with:
```
frame_length = 512
frame_step = 256
signal = tf.random.uniform(shape=(1000,))
x = tf.signal.stft(signal, frame_length, frame_step)
y = tf.signal.inverse_stft(x, frame_length, frame_step)

AttributeError: 'int' object has no attribute 'value'
```

The issue is that, in `inverse_stft`, `real_frames.shape[-1].value` has been used to get the value of the dim -1 for shape. However, the `real_frames.shape[-1].value` only works in non-eager mode where shape gives list of `Dimension` (value works). It does not work in eager mode (2.0) where shape gives list of ints.

This fix replaces with `real_frames.shape.as_list()[-1]` which should work in eager and non-eager mode.

This fix fixes #28444.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>