### PR TITLE
[Intel MKL] Disable BFloat16 transpose op

### DIFF
--- a/tensorflow/core/kernels/mkl_transpose_op.cc
+++ b/tensorflow/core/kernels/mkl_transpose_op.cc
@@ -184,9 +184,10 @@ Status MklTransposeCpuOp::DoTranspose(OpKernelContext* ctx, const Tensor& in,
       case DT_FLOAT:
         return MKLTransposeND<float>(ctx, in, out, perm);
         break;
-      case DT_BFLOAT16:
-        return MKLTransposeND<bfloat16>(ctx, in, out, perm);
-        break;
+      // TODO(nhasabni): Enable this case when we turn on bfloat16 compilation.
+      // case DT_BFLOAT16:
+      //  return MKLTransposeND<bfloat16>(ctx, in, out, perm);
+      //  break;
       // TODO(nhasabni): support other types such as INT8.
       default:
         break;
@@ -231,9 +232,10 @@ Status MklConjugateTransposeCpuOp::DoTranspose(OpKernelContext* ctx,
       case DT_FLOAT:
         return MKLTransposeND<float>(ctx, in, out, perm);
         break;
-      case DT_BFLOAT16:
-        return MKLTransposeND<bfloat16>(ctx, in, out, perm);
-        break;
+      // TODO(nhasabni): Enable this case when we turn on bfloat16 compilation.
+      // case DT_BFLOAT16:
+      //  return MKLTransposeND<bfloat16>(ctx, in, out, perm);
+      //  break;
       // TODO(nhasabni): support other types such as INT8.
       default:
         break;


### PR DESCRIPTION
This commit disables incorrectly enabled BFloat16 transpose op. The op
will be enabled when bfloat16 compilation is supported.