### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build

### DIFF
--- a/tensorflow/stream_executor/gpu/gpu_driver.h
+++ b/tensorflow/stream_executor/gpu/gpu_driver.h
@@ -21,7 +21,9 @@ limitations under the License.
 #include <stddef.h>
 #include "tensorflow/stream_executor/platform/port.h"
 
+#if GOOGLE_CUDA
 #include "cuda/include/cuda.h"
+#endif
 #include "tensorflow/stream_executor/device_options.h"
 #include "tensorflow/stream_executor/lib/status.h"
 #include "tensorflow/stream_executor/lib/statusor.h"


### PR DESCRIPTION
The --config=rocm build was broken by the following commit.

d58b53e19c3d06cea5909c66379d073aea153651

The changes made by the above commit did not contain the corresponding changes for the ROCm platform, which was leading to the build failure. Making the corresponding update for ROCm, to make the --config=rocm build working again.

----------
@tatianashp , @whchung, @timshen91 just FYI

Please approve and merge. As with other such PRs this week, the changes here are trivial and only applicable for the --config=rocm build.

thanks