### PR TITLE
Move dataset op names into name_utils namespace

### DIFF
--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -30,6 +30,7 @@ cc_library(
         ":dataset_utils",
         ":iterator_ops",
         ":name_utils",
+        ":range_dataset_op",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:framework",

--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -29,6 +29,7 @@ cc_library(
     deps = [
         ":dataset_utils",
         ":iterator_ops",
+        ":name_utils",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:framework",
@@ -70,6 +71,15 @@ tf_cc_test(
         "//tensorflow/core:framework",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
+    ],
+)
+
+cc_library(
+    name = "name_utils",
+    srcs = ["name_utils.cc"],
+    hdrs = ["name_utils.h"],
+    deps = [
+        "//tensorflow/core:lib",
     ],
 )
 
@@ -315,6 +325,7 @@ tf_kernel_library(
     deps = [
         ":captured_function",
         ":dataset_utils",
+        ":name_utils",
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:dataset_ops_op_lib",
         "//tensorflow/core:framework",
@@ -681,6 +692,7 @@ tf_kernel_library(
     name = "range_dataset_op",
     srcs = ["range_dataset_op.cc"],
     deps = [
+        ":name_utils",
         "//tensorflow/core:dataset_ops_op_lib",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",

--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -322,6 +322,7 @@ tf_kernel_library(
 tf_kernel_library(
     name = "map_dataset_op",
     srcs = ["map_dataset_op.cc"],
+    hdrs = ["map_dataset_op.h"],
     deps = [
         ":captured_function",
         ":dataset_utils",
@@ -563,6 +564,7 @@ tf_kernel_library(
     srcs = ["prefetch_dataset_op.cc"],
     hdrs = ["prefetch_dataset_op.h"],
     deps = [
+        ":name_utils",
         ":prefetch_autotuner",
         ":stats_utils",
         "//tensorflow/core:core_cpu_internal",
@@ -691,6 +693,7 @@ tf_cc_test(
 tf_kernel_library(
     name = "range_dataset_op",
     srcs = ["range_dataset_op.cc"],
+    hdrs = ["range_dataset_op.h"],
     deps = [
         ":name_utils",
         "//tensorflow/core:dataset_ops_op_lib",

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -95,8 +95,9 @@ class DatasetOpsTestBase : public ::testing::Test {
     std::vector<PartialTensorShape> shapes({{}});
     NodeDef node_def = test::function::NDef(
         node_name, name_utils::OpName(RangeDatasetOp::kDatasetType),
-        {"start", "stop", "step"},
-        {{"output_types", dtypes}, {"output_shapes", shapes}});
+        {RangeDatasetOp::kStart, RangeDatasetOp::kStop, RangeDatasetOp::kStep},
+        {{RangeDatasetOp::kOutputTypes, dtypes},
+         {RangeDatasetOp::kOutputShapes, shapes}});
 
     TF_RETURN_IF_ERROR(CreateOpKernel(node_def, range_op_kernel));
     return Status::OK();

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/data/dataset_utils.h"
 #include "tensorflow/core/kernels/data/iterator_ops.h"
 #include "tensorflow/core/kernels/data/name_utils.h"
+#include "tensorflow/core/kernels/data/range_dataset_op.h"
 #include "tensorflow/core/kernels/ops_testutil.h"
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/platform/types.h"
@@ -93,7 +94,8 @@ class DatasetOpsTestBase : public ::testing::Test {
     DataTypeVector dtypes({tensorflow::DataTypeToEnum<T>::value});
     std::vector<PartialTensorShape> shapes({{}});
     NodeDef node_def = test::function::NDef(
-        node_name, "RangeDataset", {"start", "stop", "step"},
+        node_name, name_utils::OpName(RangeDatasetOp::kDatasetType),
+        {"start", "stop", "step"},
         {{"output_types", dtypes}, {"output_shapes", shapes}});
 
     TF_RETURN_IF_ERROR(CreateOpKernel(node_def, range_op_kernel));

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/core/framework/variant_tensor_data.h"
 #include "tensorflow/core/kernels/data/dataset_utils.h"
 #include "tensorflow/core/kernels/data/iterator_ops.h"
+#include "tensorflow/core/kernels/data/name_utils.h"
 #include "tensorflow/core/kernels/ops_testutil.h"
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/platform/types.h"
@@ -35,6 +36,8 @@ limitations under the License.
 
 namespace tensorflow {
 namespace data {
+
+using namespace tensorflow::data::name_utils;
 
 // Helpful functions to test Dataset op kernels.
 class DatasetOpsTestBase : public ::testing::Test {

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -37,8 +37,6 @@ limitations under the License.
 namespace tensorflow {
 namespace data {
 
-using namespace tensorflow::data::name_utils;
-
 // Helpful functions to test Dataset op kernels.
 class DatasetOpsTestBase : public ::testing::Test {
  public:

--- a/tensorflow/core/kernels/data/map_dataset_op.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op.cc
@@ -28,6 +28,14 @@ namespace data {
 // description of the following op.
 
 constexpr char MapDatasetOp::kDatasetType[];
+constexpr char MapDatasetOp::kInputDataset[];
+constexpr char MapDatasetOp::kOtherArguments[];
+constexpr char MapDatasetOp::kF[];
+constexpr char MapDatasetOp::kTarguments[];
+constexpr char MapDatasetOp::kOutputTypes[];
+constexpr char MapDatasetOp::kOutputShapes[];
+constexpr char MapDatasetOp::kUseInterOpParallelism[];
+constexpr char MapDatasetOp::kPreserveCardinality[];
 
 class MapDatasetOp::Dataset : public DatasetBase {
  public:
@@ -96,11 +104,10 @@ class MapDatasetOp::Dataset : public DatasetBase {
     TF_RETURN_IF_ERROR(b->AddDataset(
         this, {std::make_pair(0, input_graph_node)},  // Single tensor inputs.
         {std::make_pair(1, other_arguments)},         // Tensor list inputs.
-        {std::make_pair("f", f_attr),
-         std::make_pair("Targuments", other_arguments_types_attr),
-         std::make_pair("use_inter_op_parallelism",
-                        use_inter_op_parallelism_attr),
-         std::make_pair("preserve_cardinality",
+        {std::make_pair(kF, f_attr),
+         std::make_pair(kTarguments, other_arguments_types_attr),
+         std::make_pair(kUseInterOpParallelism, use_inter_op_parallelism_attr),
+         std::make_pair(kPreserveCardinality,
                         preserve_cardinality_attr)},  // Attrs
         output));
     return Status::OK();
@@ -186,9 +193,9 @@ class MapDatasetOp::Dataset : public DatasetBase {
 void MapDatasetOp::MakeDataset(OpKernelContext* ctx, DatasetBase* input,
                                DatasetBase** output) {
   std::unique_ptr<CapturedFunction> captured_func;
-  OP_REQUIRES_OK(
-      ctx, CapturedFunction::Create(ctx, func_metadata_, "other_arguments",
-                                    &captured_func));
+  OP_REQUIRES_OK(ctx,
+                 CapturedFunction::Create(ctx, func_metadata_, kOtherArguments,
+                                          &captured_func));
 
   *output = new Dataset(ctx, input, std::move(captured_func), output_types_,
                         output_shapes_, preserve_cardinality_);

--- a/tensorflow/core/kernels/data/map_dataset_op.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op.cc
@@ -12,214 +12,187 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include "tensorflow/core/kernels/data/map_dataset_op.h"
 #include "tensorflow/core/common_runtime/function.h"
 #include "tensorflow/core/framework/dataset.h"
 #include "tensorflow/core/framework/partial_tensor_shape.h"
 #include "tensorflow/core/framework/tensor.h"
-#include "tensorflow/core/kernels/data/captured_function.h"
 #include "tensorflow/core/kernels/data/dataset_utils.h"
 #include "tensorflow/core/kernels/data/name_utils.h"
 #include "tensorflow/core/lib/random/random.h"
 
 namespace tensorflow {
 namespace data {
-namespace {
 
 // See documentation in ../../ops/dataset_ops.cc for a high-level
 // description of the following op.
 
-class MapDatasetOp : public UnaryDatasetOpKernel {
- public:
-  using MapIteratorFunction =
-      std::function<Status(IteratorContext*, InstantiatedCapturedFunction*,
-                           std::vector<Tensor>, std::vector<Tensor>*)>;
+constexpr char MapDatasetOp::kDatasetType[];
 
-  explicit MapDatasetOp(OpKernelConstruction* ctx) : UnaryDatasetOpKernel(ctx) {
-    FunctionMetadata::Params params;
-    OP_REQUIRES_OK(ctx, ctx->GetAttr("use_inter_op_parallelism",
-                                     &params.use_inter_op_parallelism));
-    OP_REQUIRES_OK(ctx,
-                   FunctionMetadata::Create(ctx, "f", params, &func_metadata_));
-    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_types", &output_types_));
-    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_shapes", &output_shapes_));
-    OP_REQUIRES_OK(
-        ctx, ctx->GetAttr("preserve_cardinality", &preserve_cardinality_));
+class MapDatasetOp::Dataset : public DatasetBase {
+ public:
+  Dataset(OpKernelContext* ctx, const DatasetBase* input,
+          std::unique_ptr<CapturedFunction> captured_func,
+          const DataTypeVector& output_types,
+          const std::vector<PartialTensorShape>& output_shapes,
+          bool preserve_cardinality)
+      : DatasetBase(DatasetContext(ctx)),
+        input_(input),
+        preserve_cardinality_(preserve_cardinality),
+        captured_func_(std::move(captured_func)),
+        output_types_(output_types),
+        output_shapes_(output_shapes) {
+    input_->Ref();
   }
 
-  void MakeDataset(OpKernelContext* ctx, DatasetBase* input,
-                   DatasetBase** output) override {
-    std::unique_ptr<CapturedFunction> captured_func;
-    OP_REQUIRES_OK(
-        ctx, CapturedFunction::Create(ctx, func_metadata_, "other_arguments",
-                                      &captured_func));
+  ~Dataset() override { input_->Unref(); }
 
-    *output = new Dataset(ctx, input, std::move(captured_func), output_types_,
-                          output_shapes_, preserve_cardinality_);
+  std::unique_ptr<IteratorBase> MakeIteratorInternal(
+      const string& prefix) const override {
+    return absl::make_unique<Iterator>(Iterator::Params{
+        this, name_utils::IteratorPrefix(kDatasetType, prefix)});
+  }
+
+  const DataTypeVector& output_dtypes() const override { return output_types_; }
+  const std::vector<PartialTensorShape>& output_shapes() const override {
+    return output_shapes_;
+  }
+
+  string DebugString() const override {
+    return name_utils::DatasetDebugString(kDatasetType);
+  }
+
+  int64 Cardinality() const override { return input_->Cardinality(); }
+
+ protected:
+  Status AsGraphDefInternal(SerializationContext* ctx,
+                            DatasetGraphDefBuilder* b,
+                            Node** output) const override {
+    Node* input_graph_node = nullptr;
+    TF_RETURN_IF_ERROR(b->AddInputDataset(ctx, input_, &input_graph_node));
+
+    std::vector<Node*> other_arguments;
+    DataTypeVector other_arguments_types;
+    TF_RETURN_IF_ERROR(captured_func_->AddToGraph(ctx, b, &other_arguments,
+                                                  &other_arguments_types));
+
+    // Attr: f
+    AttrValue f_attr;
+    b->BuildAttrValue(captured_func_->func(), &f_attr);
+
+    // Attr: Targuments
+    AttrValue other_arguments_types_attr;
+    b->BuildAttrValue(other_arguments_types, &other_arguments_types_attr);
+
+    // Attr: use_inter_op_parallelism
+    AttrValue use_inter_op_parallelism_attr;
+    b->BuildAttrValue(captured_func_->use_inter_op_parallelism(),
+                      &use_inter_op_parallelism_attr);
+
+    // Attr: preserve_cardinality
+    AttrValue preserve_cardinality_attr;
+    b->BuildAttrValue(preserve_cardinality_, &preserve_cardinality_attr);
+
+    TF_RETURN_IF_ERROR(b->AddDataset(
+        this, {std::make_pair(0, input_graph_node)},  // Single tensor inputs.
+        {std::make_pair(1, other_arguments)},         // Tensor list inputs.
+        {std::make_pair("f", f_attr),
+         std::make_pair("Targuments", other_arguments_types_attr),
+         std::make_pair("use_inter_op_parallelism",
+                        use_inter_op_parallelism_attr),
+         std::make_pair("preserve_cardinality",
+                        preserve_cardinality_attr)},  // Attrs
+        output));
+    return Status::OK();
   }
 
  private:
-  class Dataset : public DatasetBase {
+  class Iterator : public DatasetIterator<Dataset> {
    public:
-    Dataset(OpKernelContext* ctx, const DatasetBase* input,
-            std::unique_ptr<CapturedFunction> captured_func,
-            const DataTypeVector& output_types,
-            const std::vector<PartialTensorShape>& output_shapes,
-            bool preserve_cardinality)
-        : DatasetBase(DatasetContext(ctx)),
-          input_(input),
-          preserve_cardinality_(preserve_cardinality),
-          captured_func_(std::move(captured_func)),
-          output_types_(output_types),
-          output_shapes_(output_shapes) {
-      input_->Ref();
+    explicit Iterator(const Params& params)
+        : DatasetIterator<Dataset>(params) {}
+
+    Status Initialize(IteratorContext* ctx) override {
+      TF_RETURN_IF_ERROR(
+          dataset()->input_->MakeIterator(ctx, prefix(), &input_impl_));
+      return dataset()->captured_func_->Instantiate(
+          ctx, &instantiated_captured_func_);
     }
 
-    ~Dataset() override { input_->Unref(); }
+    Status GetNextInternal(IteratorContext* ctx,
+                           std::vector<Tensor>* out_tensors,
+                           bool* end_of_sequence) override {
+      // NOTE(mrry): This method is thread-safe as long as
+      // `input_impl_` and `f` are thread-safe. However, if multiple
+      // threads enter this method, outputs may be observed in a
+      // non-deterministic order.
 
-    std::unique_ptr<IteratorBase> MakeIteratorInternal(
-        const string& prefix) const override {
-      return absl::make_unique<Iterator>(Iterator::Params{
-          this, name_utils::IteratorPrefix(name_utils::MAP, prefix)});
-    }
+      std::vector<Tensor> args;
+      TF_RETURN_IF_ERROR(input_impl_->GetNext(ctx, &args, end_of_sequence));
+      if (*end_of_sequence) {
+        return Status::OK();
+      }
 
-    const DataTypeVector& output_dtypes() const override {
-      return output_types_;
+      Status s =
+          instantiated_captured_func_->Run(ctx, std::move(args), out_tensors);
+      if (errors::IsOutOfRange(s)) {
+        if (dataset()->preserve_cardinality_) {
+          // To guarantee that the transformation preserves the cardinality of
+          // the dataset, we convert `OutOfRange` to `InvalidArgument` as the
+          // former may be interpreted by a caller as the end of sequence.
+          return errors::InvalidArgument(
+              "Function invocation produced OutOfRangeError: ",
+              s.error_message());
+        } else {
+          // `f` may deliberately raise `errors::OutOfRange` to indicate
+          // that we should terminate the iteration early.
+          *end_of_sequence = true;
+          return Status::OK();
+        }
+      } else {
+        return s;
+      }
     }
-    const std::vector<PartialTensorShape>& output_shapes() const override {
-      return output_shapes_;
-    }
-
-    string DebugString() const override {
-      return name_utils::DatasetDebugString(name_utils::MAP);
-    }
-
-    int64 Cardinality() const override { return input_->Cardinality(); }
 
    protected:
-    Status AsGraphDefInternal(SerializationContext* ctx,
-                              DatasetGraphDefBuilder* b,
-                              Node** output) const override {
-      Node* input_graph_node = nullptr;
-      TF_RETURN_IF_ERROR(b->AddInputDataset(ctx, input_, &input_graph_node));
+    std::shared_ptr<model::Node> CreateNode(
+        IteratorContext* ctx, model::Node::Args args) const override {
+      return model::MakeKnownRatioNode(std::move(args), /*ratio=*/1);
+    }
 
-      std::vector<Node*> other_arguments;
-      DataTypeVector other_arguments_types;
-      TF_RETURN_IF_ERROR(captured_func_->AddToGraph(ctx, b, &other_arguments,
-                                                    &other_arguments_types));
+    Status SaveInternal(IteratorStateWriter* writer) override {
+      TF_RETURN_IF_ERROR(SaveInput(writer, input_impl_));
+      return Status::OK();
+    }
 
-      // Attr: f
-      AttrValue f_attr;
-      b->BuildAttrValue(captured_func_->func(), &f_attr);
-
-      // Attr: Targuments
-      AttrValue other_arguments_types_attr;
-      b->BuildAttrValue(other_arguments_types, &other_arguments_types_attr);
-
-      // Attr: use_inter_op_parallelism
-      AttrValue use_inter_op_parallelism_attr;
-      b->BuildAttrValue(captured_func_->use_inter_op_parallelism(),
-                        &use_inter_op_parallelism_attr);
-
-      // Attr: preserve_cardinality
-      AttrValue preserve_cardinality_attr;
-      b->BuildAttrValue(preserve_cardinality_, &preserve_cardinality_attr);
-
-      TF_RETURN_IF_ERROR(b->AddDataset(
-          this, {std::make_pair(0, input_graph_node)},  // Single tensor inputs.
-          {std::make_pair(1, other_arguments)},         // Tensor list inputs.
-          {std::make_pair("f", f_attr),
-           std::make_pair("Targuments", other_arguments_types_attr),
-           std::make_pair("use_inter_op_parallelism",
-                          use_inter_op_parallelism_attr),
-           std::make_pair("preserve_cardinality",
-                          preserve_cardinality_attr)},  // Attrs
-          output));
+    Status RestoreInternal(IteratorContext* ctx,
+                           IteratorStateReader* reader) override {
+      TF_RETURN_IF_ERROR(RestoreInput(ctx, reader, input_impl_));
       return Status::OK();
     }
 
    private:
-    class Iterator : public DatasetIterator<Dataset> {
-     public:
-      explicit Iterator(const Params& params)
-          : DatasetIterator<Dataset>(params) {}
-
-      Status Initialize(IteratorContext* ctx) override {
-        TF_RETURN_IF_ERROR(
-            dataset()->input_->MakeIterator(ctx, prefix(), &input_impl_));
-        return dataset()->captured_func_->Instantiate(
-            ctx, &instantiated_captured_func_);
-      }
-
-      Status GetNextInternal(IteratorContext* ctx,
-                             std::vector<Tensor>* out_tensors,
-                             bool* end_of_sequence) override {
-        // NOTE(mrry): This method is thread-safe as long as
-        // `input_impl_` and `f` are thread-safe. However, if multiple
-        // threads enter this method, outputs may be observed in a
-        // non-deterministic order.
-
-        std::vector<Tensor> args;
-        TF_RETURN_IF_ERROR(input_impl_->GetNext(ctx, &args, end_of_sequence));
-        if (*end_of_sequence) {
-          return Status::OK();
-        }
-
-        Status s =
-            instantiated_captured_func_->Run(ctx, std::move(args), out_tensors);
-        if (errors::IsOutOfRange(s)) {
-          if (dataset()->preserve_cardinality_) {
-            // To guarantee that the transformation preserves the cardinality of
-            // the dataset, we convert `OutOfRange` to `InvalidArgument` as the
-            // former may be interpreted by a caller as the end of sequence.
-            return errors::InvalidArgument(
-                "Function invocation produced OutOfRangeError: ",
-                s.error_message());
-          } else {
-            // `f` may deliberately raise `errors::OutOfRange` to indicate
-            // that we should terminate the iteration early.
-            *end_of_sequence = true;
-            return Status::OK();
-          }
-        } else {
-          return s;
-        }
-      }
-
-     protected:
-      std::shared_ptr<model::Node> CreateNode(
-          IteratorContext* ctx, model::Node::Args args) const override {
-        return model::MakeKnownRatioNode(std::move(args),
-                                         /*ratio=*/1);
-      }
-
-      Status SaveInternal(IteratorStateWriter* writer) override {
-        TF_RETURN_IF_ERROR(SaveInput(writer, input_impl_));
-        return Status::OK();
-      }
-
-      Status RestoreInternal(IteratorContext* ctx,
-                             IteratorStateReader* reader) override {
-        TF_RETURN_IF_ERROR(RestoreInput(ctx, reader, input_impl_));
-        return Status::OK();
-      }
-
-     private:
-      std::unique_ptr<IteratorBase> input_impl_;
-      std::unique_ptr<InstantiatedCapturedFunction> instantiated_captured_func_;
-    };
-
-    const DatasetBase* const input_;
-    const bool preserve_cardinality_;
-    const std::unique_ptr<CapturedFunction> captured_func_;
-    const DataTypeVector output_types_;
-    const std::vector<PartialTensorShape> output_shapes_;
+    std::unique_ptr<IteratorBase> input_impl_;
+    std::unique_ptr<InstantiatedCapturedFunction> instantiated_captured_func_;
   };
 
-  std::shared_ptr<FunctionMetadata> func_metadata_ = nullptr;
-  DataTypeVector output_types_;
-  std::vector<PartialTensorShape> output_shapes_;
-  bool preserve_cardinality_;
+  const DatasetBase* const input_;
+  const bool preserve_cardinality_;
+  const std::unique_ptr<CapturedFunction> captured_func_;
+  const DataTypeVector output_types_;
+  const std::vector<PartialTensorShape> output_shapes_;
 };
+
+void MapDatasetOp::MakeDataset(OpKernelContext* ctx, DatasetBase* input,
+                               DatasetBase** output) {
+  std::unique_ptr<CapturedFunction> captured_func;
+  OP_REQUIRES_OK(
+      ctx, CapturedFunction::Create(ctx, func_metadata_, "other_arguments",
+                                    &captured_func));
+
+  *output = new Dataset(ctx, input, std::move(captured_func), output_types_,
+                        output_shapes_, preserve_cardinality_);
+}
 
 REGISTER_KERNEL_BUILDER(Name("MapDataset").Device(DEVICE_CPU), MapDatasetOp);
 REGISTER_KERNEL_BUILDER(Name("ExperimentalMapDataset")
@@ -228,6 +201,5 @@ REGISTER_KERNEL_BUILDER(Name("ExperimentalMapDataset")
                             .HostMemory("handle"),
                         MapDatasetOp);
 
-}  // namespace
 }  // namespace data
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/data/map_dataset_op.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/kernels/data/captured_function.h"
 #include "tensorflow/core/kernels/data/dataset_utils.h"
+#include "tensorflow/core/kernels/data/name_utils.h"
 #include "tensorflow/core/lib/random/random.h"
 
 namespace tensorflow {
@@ -26,6 +27,8 @@ namespace {
 
 // See documentation in ../../ops/dataset_ops.cc for a high-level
 // description of the following op.
+
+using namespace tensorflow::data::name_utils;
 
 class MapDatasetOp : public UnaryDatasetOpKernel {
  public:
@@ -78,7 +81,7 @@ class MapDatasetOp : public UnaryDatasetOpKernel {
     std::unique_ptr<IteratorBase> MakeIteratorInternal(
         const string& prefix) const override {
       return absl::make_unique<Iterator>(
-          Iterator::Params{this, strings::StrCat(prefix, "::Map")});
+          Iterator::Params{this, IteratorPrefix(MAP_DATASET, prefix)});
     }
 
     const DataTypeVector& output_dtypes() const override {
@@ -88,7 +91,9 @@ class MapDatasetOp : public UnaryDatasetOpKernel {
       return output_shapes_;
     }
 
-    string DebugString() const override { return "MapDatasetOp::Dataset"; }
+    string DebugString() const override {
+      return DatasetDebugString(MAP_DATASET);
+    }
 
     int64 Cardinality() const override { return input_->Cardinality(); }
 

--- a/tensorflow/core/kernels/data/map_dataset_op.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op.cc
@@ -194,12 +194,14 @@ void MapDatasetOp::MakeDataset(OpKernelContext* ctx, DatasetBase* input,
                         output_shapes_, preserve_cardinality_);
 }
 
+namespace {
 REGISTER_KERNEL_BUILDER(Name("MapDataset").Device(DEVICE_CPU), MapDatasetOp);
 REGISTER_KERNEL_BUILDER(Name("ExperimentalMapDataset")
                             .Device(DEVICE_GPU)
                             .HostMemory("input_dataset")
                             .HostMemory("handle"),
                         MapDatasetOp);
+}  // namespace
 
 }  // namespace data
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/data/map_dataset_op.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op.cc
@@ -28,8 +28,6 @@ namespace {
 // See documentation in ../../ops/dataset_ops.cc for a high-level
 // description of the following op.
 
-using namespace tensorflow::data::name_utils;
-
 class MapDatasetOp : public UnaryDatasetOpKernel {
  public:
   using MapIteratorFunction =
@@ -80,8 +78,8 @@ class MapDatasetOp : public UnaryDatasetOpKernel {
 
     std::unique_ptr<IteratorBase> MakeIteratorInternal(
         const string& prefix) const override {
-      return absl::make_unique<Iterator>(
-          Iterator::Params{this, IteratorPrefix(MAP_DATASET, prefix)});
+      return absl::make_unique<Iterator>(Iterator::Params{
+          this, name_utils::IteratorPrefix(name_utils::MAP, prefix)});
     }
 
     const DataTypeVector& output_dtypes() const override {
@@ -92,7 +90,7 @@ class MapDatasetOp : public UnaryDatasetOpKernel {
     }
 
     string DebugString() const override {
-      return DatasetDebugString(MAP_DATASET);
+      return name_utils::DatasetDebugString(name_utils::MAP);
     }
 
     int64 Cardinality() const override { return input_->Cardinality(); }

--- a/tensorflow/core/kernels/data/map_dataset_op.h
+++ b/tensorflow/core/kernels/data/map_dataset_op.h
@@ -29,17 +29,25 @@ class MapDatasetOp : public UnaryDatasetOpKernel {
                            std::vector<Tensor>, std::vector<Tensor>*)>;
 
   static constexpr char kDatasetType[] = "Map";
+  static constexpr char kInputDataset[] = "input_dataset";
+  static constexpr char kOtherArguments[] = "other_arguments";
+  static constexpr char kF[] = "f";
+  static constexpr char kTarguments[] = "Targuments";
+  static constexpr char kOutputTypes[] = "output_types";
+  static constexpr char kOutputShapes[] = "output_shapes";
+  static constexpr char kUseInterOpParallelism[] = "use_inter_op_parallelism";
+  static constexpr char kPreserveCardinality[] = "preserve_cardinality";
 
   explicit MapDatasetOp(OpKernelConstruction* ctx) : UnaryDatasetOpKernel(ctx) {
     FunctionMetadata::Params params;
-    OP_REQUIRES_OK(ctx, ctx->GetAttr("use_inter_op_parallelism",
+    OP_REQUIRES_OK(ctx, ctx->GetAttr(kUseInterOpParallelism,
                                      &params.use_inter_op_parallelism));
     OP_REQUIRES_OK(ctx,
-                   FunctionMetadata::Create(ctx, "f", params, &func_metadata_));
-    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_types", &output_types_));
-    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_shapes", &output_shapes_));
-    OP_REQUIRES_OK(
-        ctx, ctx->GetAttr("preserve_cardinality", &preserve_cardinality_));
+                   FunctionMetadata::Create(ctx, kF, params, &func_metadata_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr(kOutputTypes, &output_types_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr(kOutputShapes, &output_shapes_));
+    OP_REQUIRES_OK(ctx,
+                   ctx->GetAttr(kPreserveCardinality, &preserve_cardinality_));
   }
 
  protected:

--- a/tensorflow/core/kernels/data/map_dataset_op.h
+++ b/tensorflow/core/kernels/data/map_dataset_op.h
@@ -1,0 +1,60 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_DATA_MAP_DATASET_OP_H_
+#define TENSORFLOW_CORE_KERNELS_DATA_MAP_DATASET_OP_H_
+
+#include "tensorflow/core/framework/dataset.h"
+#include "tensorflow/core/kernels/data/captured_function.h"
+
+namespace tensorflow {
+namespace data {
+
+class MapDatasetOp : public UnaryDatasetOpKernel {
+ public:
+  using MapIteratorFunction =
+      std::function<Status(IteratorContext*, InstantiatedCapturedFunction*,
+                           std::vector<Tensor>, std::vector<Tensor>*)>;
+
+  static constexpr char kDatasetType[] = "Map";
+
+  explicit MapDatasetOp(OpKernelConstruction* ctx) : UnaryDatasetOpKernel(ctx) {
+    FunctionMetadata::Params params;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("use_inter_op_parallelism",
+                                     &params.use_inter_op_parallelism));
+    OP_REQUIRES_OK(ctx,
+                   FunctionMetadata::Create(ctx, "f", params, &func_metadata_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_types", &output_types_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_shapes", &output_shapes_));
+    OP_REQUIRES_OK(
+        ctx, ctx->GetAttr("preserve_cardinality", &preserve_cardinality_));
+  }
+
+ protected:
+  void MakeDataset(OpKernelContext* ctx, DatasetBase* input,
+                   DatasetBase** output) override;
+
+ private:
+  class Dataset;
+  std::shared_ptr<FunctionMetadata> func_metadata_ = nullptr;
+  DataTypeVector output_types_;
+  std::vector<PartialTensorShape> output_shapes_;
+  bool preserve_cardinality_;
+};
+
+}  // namespace data
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_DATA_MAP_DATASET_OP_H_

--- a/tensorflow/core/kernels/data/map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op_test.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/core/kernels/data/map_dataset_op.h"
 #include "tensorflow/core/framework/dataset.h"
 #include "tensorflow/core/framework/fake_input.h"
 #include "tensorflow/core/framework/function.h"
@@ -49,7 +50,8 @@ class MapDatasetOpTest : public DatasetOpsTestBase {
         FunctionDefHelper::FunctionRef(func_name, {{"T", DT_INT64}});
 
     NodeDef map_dataset_node_def = test::function::NDef(
-        kNodeName, name_utils::OpName(name_utils::MAP), {input_dataset},
+        kNodeName, name_utils::OpName(MapDatasetOp::kDatasetType),
+        {input_dataset},
         {{"f", func},
          {"Targuments", {}},
          {"output_shapes", gtl::ArraySlice<TensorShape>{{}}},
@@ -251,7 +253,8 @@ TEST_F(MapDatasetOpTest, DatasetTypeString) {
                              map_dataset_context.get(), &map_dataset));
   core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
-  EXPECT_EQ(map_dataset->type_string(), name_utils::OpName(name_utils::MAP));
+  EXPECT_EQ(map_dataset->type_string(),
+            name_utils::OpName(MapDatasetOp::kDatasetType));
 }
 
 TEST_F(MapDatasetOpTest, DatasetOutputDtypes) {
@@ -499,7 +502,7 @@ TEST_F(MapDatasetOpTest, IteratorOutputPrefix) {
       map_dataset->MakeIterator(iterator_context.get(), "Iterator", &iterator));
 
   EXPECT_EQ(iterator->prefix(),
-            name_utils::IteratorPrefix(name_utils::MAP, "Iterator"));
+            name_utils::IteratorPrefix(MapDatasetOp::kDatasetType, "Iterator"));
 }
 
 TEST_P(ParameterizedMapDatasetOpTest, Roundtrip) {

--- a/tensorflow/core/kernels/data/map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op_test.cc
@@ -49,7 +49,7 @@ class MapDatasetOpTest : public DatasetOpsTestBase {
         FunctionDefHelper::FunctionRef(func_name, {{"T", DT_INT64}});
 
     NodeDef map_dataset_node_def = test::function::NDef(
-        kNodeName, OpName(MAP_DATASET), {input_dataset},
+        kNodeName, name_utils::OpName(name_utils::MAP), {input_dataset},
         {{"f", func},
          {"Targuments", {}},
          {"output_shapes", gtl::ArraySlice<TensorShape>{{}}},
@@ -251,7 +251,7 @@ TEST_F(MapDatasetOpTest, DatasetTypeString) {
                              map_dataset_context.get(), &map_dataset));
   core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
-  EXPECT_EQ(map_dataset->type_string(), OpName(MAP_DATASET));
+  EXPECT_EQ(map_dataset->type_string(), name_utils::OpName(name_utils::MAP));
 }
 
 TEST_F(MapDatasetOpTest, DatasetOutputDtypes) {
@@ -498,7 +498,8 @@ TEST_F(MapDatasetOpTest, IteratorOutputPrefix) {
   TF_ASSERT_OK(
       map_dataset->MakeIterator(iterator_context.get(), "Iterator", &iterator));
 
-  EXPECT_EQ(iterator->prefix(), IteratorPrefix(MAP_DATASET, "Iterator"));
+  EXPECT_EQ(iterator->prefix(),
+            name_utils::IteratorPrefix(name_utils::MAP, "Iterator"));
 }
 
 TEST_P(ParameterizedMapDatasetOpTest, Roundtrip) {

--- a/tensorflow/core/kernels/data/map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op_test.cc
@@ -14,22 +14,8 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/core/kernels/data/map_dataset_op.h"
-#include "tensorflow/core/framework/dataset.h"
-#include "tensorflow/core/framework/fake_input.h"
-#include "tensorflow/core/framework/function.h"
-#include "tensorflow/core/framework/function_handle_cache.h"
-#include "tensorflow/core/framework/function_testlib.h"
-#include "tensorflow/core/framework/node_def_builder.h"
-#include "tensorflow/core/framework/partial_tensor_shape.h"
-#include "tensorflow/core/framework/variant.h"
-#include "tensorflow/core/framework/variant_tensor_data.h"
+
 #include "tensorflow/core/kernels/data/dataset_test_base.h"
-#include "tensorflow/core/kernels/data/dataset_utils.h"
-#include "tensorflow/core/kernels/data/iterator_ops.h"
-#include "tensorflow/core/kernels/data/stats_utils.h"
-#include "tensorflow/core/kernels/ops_testutil.h"
-#include "tensorflow/core/platform/test.h"
-#include "tensorflow/core/util/ptr_util.h"
 
 namespace tensorflow {
 namespace data {

--- a/tensorflow/core/kernels/data/map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op_test.cc
@@ -35,7 +35,6 @@ namespace data {
 namespace {
 
 constexpr char kNodeName[] = "map_dataset";
-constexpr char kOpName[] = "MapDataset";
 
 class MapDatasetOpTest : public DatasetOpsTestBase {
  protected:
@@ -50,7 +49,7 @@ class MapDatasetOpTest : public DatasetOpsTestBase {
         FunctionDefHelper::FunctionRef(func_name, {{"T", DT_INT64}});
 
     NodeDef map_dataset_node_def = test::function::NDef(
-        kNodeName, kOpName, {input_dataset},
+        kNodeName, OpName(MAP_DATASET), {input_dataset},
         {{"f", func},
          {"Targuments", {}},
          {"output_shapes", gtl::ArraySlice<TensorShape>{{}}},
@@ -252,7 +251,7 @@ TEST_F(MapDatasetOpTest, DatasetTypeString) {
                              map_dataset_context.get(), &map_dataset));
   core::ScopedUnref scoped_unref_map_dataset(map_dataset);
 
-  EXPECT_EQ(map_dataset->type_string(), kOpName);
+  EXPECT_EQ(map_dataset->type_string(), OpName(MAP_DATASET));
 }
 
 TEST_F(MapDatasetOpTest, DatasetOutputDtypes) {
@@ -499,7 +498,7 @@ TEST_F(MapDatasetOpTest, IteratorOutputPrefix) {
   TF_ASSERT_OK(
       map_dataset->MakeIterator(iterator_context.get(), "Iterator", &iterator));
 
-  EXPECT_EQ(iterator->prefix(), "Iterator::Map");
+  EXPECT_EQ(iterator->prefix(), IteratorPrefix(MAP_DATASET, "Iterator"));
 }
 
 TEST_P(ParameterizedMapDatasetOpTest, Roundtrip) {

--- a/tensorflow/core/kernels/data/name_utils.cc
+++ b/tensorflow/core/kernels/data/name_utils.cc
@@ -19,7 +19,7 @@ namespace tensorflow {
 namespace data {
 namespace name_utils {
 
-ABSL_CONST_INIT const char kPrefixDelimiter[] = "::";
+ABSL_CONST_INIT const char kDelimiter[] = "::";
 
 string OpName(const string& dataset_type) {
   if (dataset_type == "Map") {
@@ -36,7 +36,7 @@ string OpName(const string& dataset_type) {
 string DatasetDebugString(const string& dataset_type,
                           std::initializer_list<StringPiece> args) {
   if (args.size() == 0) {
-    return strings::StrCat(dataset_type, "Op::Dataset");
+    return strings::StrCat(dataset_type, "Op", kDelimiter, "Dataset");
   }
 
   string debug_str;
@@ -46,12 +46,12 @@ string DatasetDebugString(const string& dataset_type,
     strings::StrAppend(&debug_str, *iter, ", ");
     ++iter;
   }
-  strings::StrAppend(&debug_str, *iter, ")::Dataset");
+  strings::StrAppend(&debug_str, *iter, ")", kDelimiter, "Dataset");
   return debug_str;
 }
 
 string IteratorPrefix(const string& dataset_type, const string& prefix) {
-  return strings::StrCat(prefix, kPrefixDelimiter, dataset_type);
+  return strings::StrCat(prefix, kDelimiter, dataset_type);
 }
 
 }  // namespace name_utils

--- a/tensorflow/core/kernels/data/name_utils.cc
+++ b/tensorflow/core/kernels/data/name_utils.cc
@@ -1,0 +1,68 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/core/kernels/data/name_utils.h"
+
+namespace tensorflow {
+namespace data {
+namespace name_utils {
+
+string ToString(const DatasetType& dataset_type) {
+  switch (dataset_type) {
+    case RANGE_DATASET:
+      return "range";
+    case MAP_DATASET:
+      return "map";
+    default:
+      LOG(FATAL) << "Unknown dataset type " << dataset_type << std::endl;
+  }
+  return "Unknown dataset type";
+}
+
+string OpName(const DatasetType& dataset_type) {
+  switch (dataset_type) {
+    case RANGE_DATASET:
+      return "RangeDataset";
+    case MAP_DATASET:
+      return "MapDataset";
+    default:
+      LOG(FATAL) << "Unknown dataset type " << dataset_type << std::endl;
+  }
+  return "Unknown dataset type";
+}
+
+string DatasetDebugString(const DatasetType& dataset_type,
+                          std::initializer_list<StringPiece> args) {
+  if (args.size() == 0) {
+    return StrCat(OpName(dataset_type), "Op::Dataset");
+  }
+
+  string debug_str;
+  StrAppend(&debug_str, OpName(dataset_type), "Op(");
+  auto iter = args.begin();
+  while (iter != args.end() - 1) {
+    StrAppend(&debug_str, *iter, ", ");
+    ++iter;
+  }
+  StrAppend(&debug_str, *iter, ")::Dataset");
+  return debug_str;
+}
+
+string IteratorPrefix(const DatasetType& dataset_type, const string& prefix) {
+  return strings::StrCat(prefix, "::", ToString(dataset_type));
+}
+
+}  // namespace name_utils
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/data/name_utils.cc
+++ b/tensorflow/core/kernels/data/name_utils.cc
@@ -19,6 +19,8 @@ namespace tensorflow {
 namespace data {
 namespace name_utils {
 
+ABSL_CONST_INIT const char kPrefixDelimiter[] = "::";
+
 string OpName(const string& dataset_type) {
   if (dataset_type == "Map") {
     return "MapDataset";
@@ -27,11 +29,9 @@ string OpName(const string& dataset_type) {
   } else if (dataset_type == "Range") {
     return "RangeDataset";
   }
-  LOG(FATAL) << "Unknown dataset type " << dataset_type << std::endl;
-  return "Unknown dataset type";
+  LOG(WARNING) << "Unknown dataset type " << dataset_type << std::endl;
+  return "UnknownDataset";
 }
-
-namespace internal {
 
 string DatasetDebugString(const string& dataset_type,
                           std::initializer_list<StringPiece> args) {
@@ -50,10 +50,8 @@ string DatasetDebugString(const string& dataset_type,
   return debug_str;
 }
 
-}  // namespace internal
-
 string IteratorPrefix(const string& dataset_type, const string& prefix) {
-  return strings::StrCat(prefix, "::", dataset_type);
+  return strings::StrCat(prefix, kPrefixDelimiter, dataset_type);
 }
 
 }  // namespace name_utils

--- a/tensorflow/core/kernels/data/name_utils.cc
+++ b/tensorflow/core/kernels/data/name_utils.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #include "tensorflow/core/kernels/data/name_utils.h"
+#include "tensorflow/core/platform/logging.h"
 
 namespace tensorflow {
 namespace data {
@@ -20,10 +21,10 @@ namespace name_utils {
 
 string ToString(const DatasetType& dataset_type) {
   switch (dataset_type) {
-    case RANGE_DATASET:
-      return "range";
-    case MAP_DATASET:
+    case MAP:
       return "map";
+    case RANGE:
+      return "range";
     default:
       LOG(FATAL) << "Unknown dataset type " << dataset_type << std::endl;
   }
@@ -32,10 +33,10 @@ string ToString(const DatasetType& dataset_type) {
 
 string OpName(const DatasetType& dataset_type) {
   switch (dataset_type) {
-    case RANGE_DATASET:
-      return "RangeDataset";
-    case MAP_DATASET:
+    case MAP:
       return "MapDataset";
+    case RANGE:
+      return "RangeDataset";
     default:
       LOG(FATAL) << "Unknown dataset type " << dataset_type << std::endl;
   }
@@ -45,17 +46,17 @@ string OpName(const DatasetType& dataset_type) {
 string DatasetDebugString(const DatasetType& dataset_type,
                           std::initializer_list<StringPiece> args) {
   if (args.size() == 0) {
-    return StrCat(OpName(dataset_type), "Op::Dataset");
+    return strings::StrCat(OpName(dataset_type), "Op::Dataset");
   }
 
   string debug_str;
-  StrAppend(&debug_str, OpName(dataset_type), "Op(");
+  strings::StrAppend(&debug_str, OpName(dataset_type), "Op(");
   auto iter = args.begin();
   while (iter != args.end() - 1) {
-    StrAppend(&debug_str, *iter, ", ");
+    strings::StrAppend(&debug_str, *iter, ", ");
     ++iter;
   }
-  StrAppend(&debug_str, *iter, ")::Dataset");
+  strings::StrAppend(&debug_str, *iter, ")::Dataset");
   return debug_str;
 }
 

--- a/tensorflow/core/kernels/data/name_utils.cc
+++ b/tensorflow/core/kernels/data/name_utils.cc
@@ -19,38 +19,28 @@ namespace tensorflow {
 namespace data {
 namespace name_utils {
 
-string ToString(const DatasetType& dataset_type) {
-  switch (dataset_type) {
-    case MAP:
-      return "map";
-    case RANGE:
-      return "range";
-    default:
-      LOG(FATAL) << "Unknown dataset type " << dataset_type << std::endl;
+string OpName(const string& dataset_type) {
+  if (dataset_type == "Map") {
+    return "MapDataset";
+  } else if (dataset_type == "Prefetch") {
+    return "PrefetchDataset";
+  } else if (dataset_type == "Range") {
+    return "RangeDataset";
   }
+  LOG(FATAL) << "Unknown dataset type " << dataset_type << std::endl;
   return "Unknown dataset type";
 }
 
-string OpName(const DatasetType& dataset_type) {
-  switch (dataset_type) {
-    case MAP:
-      return "MapDataset";
-    case RANGE:
-      return "RangeDataset";
-    default:
-      LOG(FATAL) << "Unknown dataset type " << dataset_type << std::endl;
-  }
-  return "Unknown dataset type";
-}
+namespace internal {
 
-string DatasetDebugString(const DatasetType& dataset_type,
+string DatasetDebugString(const string& dataset_type,
                           std::initializer_list<StringPiece> args) {
   if (args.size() == 0) {
-    return strings::StrCat(OpName(dataset_type), "Op::Dataset");
+    return strings::StrCat(dataset_type, "Op::Dataset");
   }
 
   string debug_str;
-  strings::StrAppend(&debug_str, OpName(dataset_type), "Op(");
+  strings::StrAppend(&debug_str, dataset_type, "Op(");
   auto iter = args.begin();
   while (iter != args.end() - 1) {
     strings::StrAppend(&debug_str, *iter, ", ");
@@ -60,8 +50,10 @@ string DatasetDebugString(const DatasetType& dataset_type,
   return debug_str;
 }
 
-string IteratorPrefix(const DatasetType& dataset_type, const string& prefix) {
-  return strings::StrCat(prefix, "::", ToString(dataset_type));
+}  // namespace internal
+
+string IteratorPrefix(const string& dataset_type, const string& prefix) {
+  return strings::StrCat(prefix, "::", dataset_type);
 }
 
 }  // namespace name_utils

--- a/tensorflow/core/kernels/data/name_utils.h
+++ b/tensorflow/core/kernels/data/name_utils.h
@@ -23,7 +23,7 @@ namespace tensorflow {
 namespace data {
 namespace name_utils {
 
-extern const char kPrefixDelimiter[];
+extern const char kDelimiter[];
 
 // Returns the dataset op name.
 //

--- a/tensorflow/core/kernels/data/name_utils.h
+++ b/tensorflow/core/kernels/data/name_utils.h
@@ -23,47 +23,40 @@ namespace tensorflow {
 namespace data {
 namespace name_utils {
 
-enum DatasetType {
-  MAP = 0,
-  RANGE = 1,
-};
-
-// Returns the base name of the dataset.
-//
-// e.g. ToString(MAP) -> "map".
-string ToString(const DatasetType& dataset_type);
-
 // Returns the dataset op name.
 //
-// e.g. OpName(MAP) -> "MapDataset".
-string OpName(const DatasetType& dataset_type);
+// e.g. OpName("Map") -> "MapDataset".
+string OpName(const string& dataset_type);
+
+namespace internal {
 
 // Returns a human-readable debug string for this dataset in the format of
 // "FooDatasetOp(arg1, arg2, ...)::Dataset".
 //
-// e.g. DatasetDebugString(MAP, {}) -> "MapDatasetOp::Dataset";
-// DatasetDebugString(RANGE, {"0", "10", "3"}) ->
+// e.g. DatasetDebugString("Map", {}) -> "MapDatasetOp::Dataset";
+// DatasetDebugString("Range", {"0", "10", "3"}) ->
 // "RangeDatasetOp(0, 10, 3)::Dataset".
-string DatasetDebugString(const DatasetType& dataset_type,
+string DatasetDebugString(const string& dataset_type,
                           std::initializer_list<StringPiece> args);
 
+}  // namespace internal
+
 // Returns a human-readable debug string for this dataset in the format of
 // "FooDatasetOp(arg1, arg2, ...)::Dataset".
 //
-// e.g. DatasetDebugString(MAP) -> "MapDatasetOp::Dataset";
-// DatasetDebugString(RANGE, 0, 10, 3) -> "RangeDatasetOp(0, 10, 3)::Dataset".
+// e.g. DatasetDebugString("Map") -> "MapDatasetOp::Dataset";
+// DatasetDebugString("Range", 0, 10, 3) -> "RangeDatasetOp(0, 10, 3)::Dataset".
 template <typename... Args>
-string DatasetDebugString(const DatasetType& dataset_type,
-                          const Args&... args) {
-  return DatasetDebugString(
+string DatasetDebugString(const string& dataset_type, const Args&... args) {
+  return internal::DatasetDebugString(
       dataset_type, {static_cast<const strings::AlphaNum&>(args).Piece()...});
 }
 
 // Returns a string that identifies the sequence of iterators leading up to
 // the iterator of this dataset.
 //
-// e.g. IteratorPrefix(MAP, "Iterator::range") -> "Iterator::range::map".
-string IteratorPrefix(const DatasetType& dataset_type, const string& prefix);
+// e.g. IteratorPrefix("Map", "Iterator::range") -> "Iterator::Range::Map".
+string IteratorPrefix(const string& dataset_type, const string& prefix);
 
 }  // namespace name_utils
 }  // namespace data

--- a/tensorflow/core/kernels/data/name_utils.h
+++ b/tensorflow/core/kernels/data/name_utils.h
@@ -23,12 +23,12 @@ namespace tensorflow {
 namespace data {
 namespace name_utils {
 
+extern const char kPrefixDelimiter[];
+
 // Returns the dataset op name.
 //
 // e.g. OpName("Map") -> "MapDataset".
 string OpName(const string& dataset_type);
-
-namespace internal {
 
 // Returns a human-readable debug string for this dataset in the format of
 // "FooDatasetOp(arg1, arg2, ...)::Dataset".
@@ -39,8 +39,6 @@ namespace internal {
 string DatasetDebugString(const string& dataset_type,
                           std::initializer_list<StringPiece> args);
 
-}  // namespace internal
-
 // Returns a human-readable debug string for this dataset in the format of
 // "FooDatasetOp(arg1, arg2, ...)::Dataset".
 //
@@ -48,7 +46,7 @@ string DatasetDebugString(const string& dataset_type,
 // DatasetDebugString("Range", 0, 10, 3) -> "RangeDatasetOp(0, 10, 3)::Dataset".
 template <typename... Args>
 string DatasetDebugString(const string& dataset_type, const Args&... args) {
-  return internal::DatasetDebugString(
+  return DatasetDebugString(
       dataset_type, {static_cast<const strings::AlphaNum&>(args).Piece()...});
 }
 

--- a/tensorflow/core/kernels/data/name_utils.h
+++ b/tensorflow/core/kernels/data/name_utils.h
@@ -17,39 +17,52 @@ limitations under the License.
 
 #include "tensorflow/core/lib/core/stringpiece.h"
 #include "tensorflow/core/lib/strings/strcat.h"
-#include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/types.h"
 
 namespace tensorflow {
 namespace data {
 namespace name_utils {
-using namespace tensorflow::strings;
 
 enum DatasetType {
-  RANGE_DATASET = 0,
-  MAP_DATASET = 1,
+  MAP = 0,
+  RANGE = 1,
 };
 
 // Returns the base name of the dataset.
+//
+// e.g. ToString(MAP) -> "map".
 string ToString(const DatasetType& dataset_type);
 
 // Returns the dataset op name.
+//
+// e.g. OpName(MAP) -> "MapDataset".
 string OpName(const DatasetType& dataset_type);
 
+// Returns a human-readable debug string for this dataset in the format of
+// "FooDatasetOp(arg1, arg2, ...)::Dataset".
+//
+// e.g. DatasetDebugString(MAP, {}) -> "MapDatasetOp::Dataset";
+// DatasetDebugString(RANGE, {"0", "10", "3"}) ->
+// "RangeDatasetOp(0, 10, 3)::Dataset".
 string DatasetDebugString(const DatasetType& dataset_type,
                           std::initializer_list<StringPiece> args);
 
 // Returns a human-readable debug string for this dataset in the format of
-// "FooDatasetOp(arg1, arg2, ...)::Dataset"
+// "FooDatasetOp(arg1, arg2, ...)::Dataset".
+//
+// e.g. DatasetDebugString(MAP) -> "MapDatasetOp::Dataset";
+// DatasetDebugString(RANGE, 0, 10, 3) -> "RangeDatasetOp(0, 10, 3)::Dataset".
 template <typename... Args>
 string DatasetDebugString(const DatasetType& dataset_type,
                           const Args&... args) {
-  return DatasetDebugString(dataset_type,
-                            {static_cast<const AlphaNum&>(args).Piece()...});
+  return DatasetDebugString(
+      dataset_type, {static_cast<const strings::AlphaNum&>(args).Piece()...});
 }
 
 // Returns a string that identifies the sequence of iterators leading up to
 // the iterator of this dataset.
+//
+// e.g. IteratorPrefix(MAP, "Iterator::range") -> "Iterator::range::map".
 string IteratorPrefix(const DatasetType& dataset_type, const string& prefix);
 
 }  // namespace name_utils

--- a/tensorflow/core/kernels/data/name_utils.h
+++ b/tensorflow/core/kernels/data/name_utils.h
@@ -1,0 +1,59 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_CORE_KERNELS_DATA_NAME_UTILS_H_
+#define TENSORFLOW_CORE_KERNELS_DATA_NAME_UTILS_H_
+
+#include "tensorflow/core/lib/core/stringpiece.h"
+#include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/types.h"
+
+namespace tensorflow {
+namespace data {
+namespace name_utils {
+using namespace tensorflow::strings;
+
+enum DatasetType {
+  RANGE_DATASET = 0,
+  MAP_DATASET = 1,
+};
+
+// Returns the base name of the dataset.
+string ToString(const DatasetType& dataset_type);
+
+// Returns the dataset op name.
+string OpName(const DatasetType& dataset_type);
+
+string DatasetDebugString(const DatasetType& dataset_type,
+                          std::initializer_list<StringPiece> args);
+
+// Returns a human-readable debug string for this dataset in the format of
+// "FooDatasetOp(arg1, arg2, ...)::Dataset"
+template <typename... Args>
+string DatasetDebugString(const DatasetType& dataset_type,
+                          const Args&... args) {
+  return DatasetDebugString(dataset_type,
+                            {static_cast<const AlphaNum&>(args).Piece()...});
+}
+
+// Returns a string that identifies the sequence of iterators leading up to
+// the iterator of this dataset.
+string IteratorPrefix(const DatasetType& dataset_type, const string& prefix);
+
+}  // namespace name_utils
+}  // namespace data
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_DATA_NAME_UTILS_H_

--- a/tensorflow/core/kernels/data/prefetch_dataset_op.h
+++ b/tensorflow/core/kernels/data/prefetch_dataset_op.h
@@ -25,11 +25,16 @@ namespace data {
 class PrefetchDatasetOp : public UnaryDatasetOpKernel {
  public:
   static constexpr char kDatasetType[] = "Prefetch";
+  static constexpr char kInputDataset[] = "input_dataset";
+  static constexpr char kBufferSize[] = "buffer_size";
+  static constexpr char kOutputTypes[] = "output_types";
+  static constexpr char kOutputShapes[] = "output_shapes";
+  static constexpr char kSlackPeriod[] = "slack_period";
 
   explicit PrefetchDatasetOp(OpKernelConstruction* ctx)
       : UnaryDatasetOpKernel(ctx) {
-    if (ctx->HasAttr("slack_period")) {
-      OP_REQUIRES_OK(ctx, ctx->GetAttr("slack_period", &slack_period_));
+    if (ctx->HasAttr(kSlackPeriod)) {
+      OP_REQUIRES_OK(ctx, ctx->GetAttr(kSlackPeriod, &slack_period_));
     }
   }
 

--- a/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
@@ -13,7 +13,6 @@ limitations under the License.
 #include "tensorflow/core/kernels/data/prefetch_dataset_op.h"
 
 #include "tensorflow/core/kernels/data/dataset_test_base.h"
-#include "tensorflow/core/kernels/data/name_utils.h"
 
 namespace tensorflow {
 namespace data {

--- a/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
@@ -42,10 +42,10 @@ class PrefetchDatasetOpTest : public DatasetOpsTestBase {
       std::unique_ptr<OpKernel> *op_kernel) {
     NodeDef node_def = test::function::NDef(
         kNodeName, name_utils::OpName(PrefetchDatasetOp::kDatasetType),
-        {"input_dataset", "buffer_size"},
-        {{"output_types", output_types},
-         {"output_shapes", output_shapes},
-         {"slack_period", 0}});
+        {PrefetchDatasetOp::kInputDataset, PrefetchDatasetOp::kBufferSize},
+        {{PrefetchDatasetOp::kOutputTypes, output_types},
+         {PrefetchDatasetOp::kOutputShapes, output_shapes},
+         {PrefetchDatasetOp::kSlackPeriod, 0}});
     TF_RETURN_IF_ERROR(CreateOpKernel(node_def, op_kernel));
     return Status::OK();
   }

--- a/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
@@ -11,6 +11,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/core/kernels/data/prefetch_dataset_op.h"
+
 #include "tensorflow/core/kernels/data/dataset_test_base.h"
 #include "tensorflow/core/kernels/data/name_utils.h"
 

--- a/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
@@ -10,14 +10,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/core/kernels/data/prefetch_dataset_op.h"
 #include "tensorflow/core/kernels/data/dataset_test_base.h"
+#include "tensorflow/core/kernels/data/name_utils.h"
 
 namespace tensorflow {
 namespace data {
 namespace {
 
 constexpr char kNodeName[] = "prefetch_dataset";
-constexpr char kOpName[] = "PrefetchDataset";
 
 class PrefetchDatasetOpTest : public DatasetOpsTestBase {
  protected:
@@ -38,11 +39,12 @@ class PrefetchDatasetOpTest : public DatasetOpsTestBase {
       const DataTypeVector &output_types,
       const std::vector<PartialTensorShape> &output_shapes,
       std::unique_ptr<OpKernel> *op_kernel) {
-    NodeDef node_def = test::function::NDef(kNodeName, kOpName,
-                                            {"input_dataset", "buffer_size"},
-                                            {{"output_types", output_types},
-                                             {"output_shapes", output_shapes},
-                                             {"slack_period", 0}});
+    NodeDef node_def = test::function::NDef(
+        kNodeName, name_utils::OpName(PrefetchDatasetOp::kDatasetType),
+        {"input_dataset", "buffer_size"},
+        {{"output_types", output_types},
+         {"output_shapes", output_shapes},
+         {"slack_period", 0}});
     TF_RETURN_IF_ERROR(CreateOpKernel(node_def, op_kernel));
     return Status::OK();
   }
@@ -293,7 +295,8 @@ TEST_F(PrefetchDatasetOpTest, DatasetTypeString) {
                              &prefetch_dataset));
   core::ScopedUnref scoped_unref(prefetch_dataset);
 
-  EXPECT_EQ(prefetch_dataset->type_string(), kOpName);
+  EXPECT_EQ(prefetch_dataset->type_string(),
+            name_utils::OpName(PrefetchDatasetOp::kDatasetType));
 }
 
 TEST_F(PrefetchDatasetOpTest, DatasetOutputDtypes) {
@@ -547,7 +550,9 @@ TEST_F(PrefetchDatasetOpTest, IteratorOutputPrefix) {
   TF_ASSERT_OK(prefetch_dataset->MakeIterator(iterator_ctx.get(), "Iterator",
                                               &iterator));
 
-  EXPECT_EQ(iterator->prefix(), "Iterator::Prefetch");
+  EXPECT_EQ(
+      iterator->prefix(),
+      name_utils::IteratorPrefix(PrefetchDatasetOp::kDatasetType, "Iterator"));
 }
 
 TEST_P(ParameterizedPrefetchDatasetOpTest, Roundtrip) {

--- a/tensorflow/core/kernels/data/range_dataset_op.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op.cc
@@ -25,6 +25,11 @@ namespace data {
 // description of the following op.
 
 constexpr char RangeDatasetOp::kDatasetType[];
+constexpr char RangeDatasetOp::kStart[];
+constexpr char RangeDatasetOp::kStop[];
+constexpr char RangeDatasetOp::kStep[];
+constexpr char RangeDatasetOp::kOutputTypes[];
+constexpr char RangeDatasetOp::kOutputShapes[];
 
 class RangeDatasetOp::Dataset : public DatasetBase {
  public:
@@ -132,13 +137,13 @@ class RangeDatasetOp::Dataset : public DatasetBase {
 
 void RangeDatasetOp::MakeDataset(OpKernelContext* ctx, DatasetBase** output) {
   int64 start;
-  OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, "start", &start));
+  OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, kStart, &start));
 
   int64 stop;
-  OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, "stop", &stop));
+  OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, kStop, &stop));
 
   int64 step;
-  OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, "step", &step));
+  OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, kStep, &step));
   OP_REQUIRES(ctx, step != 0,
               errors::InvalidArgument("step must be a non-zero integer."));
 

--- a/tensorflow/core/kernels/data/range_dataset_op.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include "tensorflow/core/kernels/data/range_dataset_op.h"
 #include "tensorflow/core/framework/dataset.h"
 #include "tensorflow/core/framework/partial_tensor_shape.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -19,141 +20,132 @@ limitations under the License.
 
 namespace tensorflow {
 namespace data {
-namespace {
 
 // See documentation in ../../ops/dataset_ops.cc for a high-level
 // description of the following op.
 
-class RangeDatasetOp : public DatasetOpKernel {
+constexpr char RangeDatasetOp::kDatasetType[];
+
+class RangeDatasetOp::Dataset : public DatasetBase {
  public:
-  explicit RangeDatasetOp(OpKernelConstruction* ctx) : DatasetOpKernel(ctx) {}
+  Dataset(OpKernelContext* ctx, int64 start, int64 stop, int64 step)
+      : DatasetBase(DatasetContext(ctx)),
+        start_(start),
+        stop_(stop),
+        step_(step) {}
 
-  void MakeDataset(OpKernelContext* ctx, DatasetBase** output) override {
-    int64 start;
-    OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, "start", &start));
+  std::unique_ptr<IteratorBase> MakeIteratorInternal(
+      const string& prefix) const override {
+    return absl::make_unique<Iterator>(Iterator::Params{
+        this, name_utils::IteratorPrefix(kDatasetType, prefix)});
+  }
 
-    int64 stop;
-    OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, "stop", &stop));
+  const DataTypeVector& output_dtypes() const override {
+    static DataTypeVector* dtypes = new DataTypeVector({DT_INT64});
+    return *dtypes;
+  }
 
-    int64 step;
-    OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, "step", &step));
-    OP_REQUIRES(ctx, step != 0,
-                errors::InvalidArgument("step must be a non-zero integer."));
+  const std::vector<PartialTensorShape>& output_shapes() const override {
+    static std::vector<PartialTensorShape>* shapes =
+        new std::vector<PartialTensorShape>({PartialTensorShape({})});
+    return *shapes;
+  }
 
-    *output = new Dataset(ctx, start, stop, step);
+  string DebugString() const override {
+    return name_utils::DatasetDebugString(kDatasetType, start_, stop_, step_);
+  }
+
+  int64 Cardinality() const override {
+    if (step_ > 0) {
+      return std::max(0LL, (stop_ - start_ - 1) / step_ + 1);
+    } else {
+      return std::max(0LL, (start_ - stop_ - 1) / -step_ + 1);
+    }
+  }
+
+ protected:
+  Status AsGraphDefInternal(SerializationContext* ctx,
+                            DatasetGraphDefBuilder* b,
+                            Node** output) const override {
+    Node* start = nullptr;
+    Node* stop = nullptr;
+    Node* step = nullptr;
+    TF_RETURN_IF_ERROR(b->AddScalar(start_, &start));
+    TF_RETURN_IF_ERROR(b->AddScalar(stop_, &stop));
+    TF_RETURN_IF_ERROR(b->AddScalar(step_, &step));
+    TF_RETURN_IF_ERROR(b->AddDataset(this, {start, stop, step}, output));
+    return Status::OK();
   }
 
  private:
-  class Dataset : public DatasetBase {
+  class Iterator : public DatasetIterator<Dataset> {
    public:
-    Dataset(OpKernelContext* ctx, int64 start, int64 stop, int64 step)
-        : DatasetBase(DatasetContext(ctx)),
-          start_(start),
-          stop_(stop),
-          step_(step) {}
-
-    std::unique_ptr<IteratorBase> MakeIteratorInternal(
-        const string& prefix) const override {
-      return absl::make_unique<Iterator>(Iterator::Params{
-          this, name_utils::IteratorPrefix(name_utils::RANGE, prefix)});
+    explicit Iterator(const Params& params) : DatasetIterator<Dataset>(params) {
+      next_ = params.dataset->start_;
     }
 
-    const DataTypeVector& output_dtypes() const override {
-      static DataTypeVector* dtypes = new DataTypeVector({DT_INT64});
-      return *dtypes;
-    }
-
-    const std::vector<PartialTensorShape>& output_shapes() const override {
-      static std::vector<PartialTensorShape>* shapes =
-          new std::vector<PartialTensorShape>({PartialTensorShape({})});
-      return *shapes;
-    }
-
-    string DebugString() const override {
-      return name_utils::DatasetDebugString(name_utils::RANGE, start_, stop_,
-                                            step_);
-    }
-
-    int64 Cardinality() const override {
-      if (step_ > 0) {
-        return std::max(0LL, (stop_ - start_ - 1) / step_ + 1);
-      } else {
-        return std::max(0LL, (start_ - stop_ - 1) / -step_ + 1);
+    Status GetNextInternal(IteratorContext* ctx,
+                           std::vector<Tensor>* out_tensors,
+                           bool* end_of_sequence) override {
+      mutex_lock l(mu_);
+      if ((dataset()->step_ > 0 && next_ >= dataset()->stop_) ||
+          (dataset()->step_ < 0 && next_ <= dataset()->stop_)) {
+        *end_of_sequence = true;
+        return Status::OK();
       }
+      out_tensors->reserve(1);
+      out_tensors->emplace_back(next_);
+      *end_of_sequence = false;
+      next_ += dataset()->step_;
+
+      return Status::OK();
     }
 
    protected:
-    Status AsGraphDefInternal(SerializationContext* ctx,
-                              DatasetGraphDefBuilder* b,
-                              Node** output) const override {
-      Node* start = nullptr;
-      Node* stop = nullptr;
-      Node* step = nullptr;
-      TF_RETURN_IF_ERROR(b->AddScalar(start_, &start));
-      TF_RETURN_IF_ERROR(b->AddScalar(stop_, &stop));
-      TF_RETURN_IF_ERROR(b->AddScalar(step_, &step));
-      TF_RETURN_IF_ERROR(b->AddDataset(this, {start, stop, step}, output));
+    std::shared_ptr<model::Node> CreateNode(
+        IteratorContext* ctx, model::Node::Args args) const override {
+      return model::MakeSourceNode(std::move(args));
+    }
+
+    Status SaveInternal(IteratorStateWriter* writer) override {
+      mutex_lock l(mu_);
+      TF_RETURN_IF_ERROR(writer->WriteScalar(full_name("next"), next_));
+      return Status::OK();
+    }
+
+    Status RestoreInternal(IteratorContext* ctx,
+                           IteratorStateReader* reader) override {
+      mutex_lock l(mu_);
+      TF_RETURN_IF_ERROR(reader->ReadScalar(full_name("next"), &next_));
       return Status::OK();
     }
 
    private:
-    class Iterator : public DatasetIterator<Dataset> {
-     public:
-      explicit Iterator(const Params& params)
-          : DatasetIterator<Dataset>(params) {
-        next_ = params.dataset->start_;
-      }
-
-      Status GetNextInternal(IteratorContext* ctx,
-                             std::vector<Tensor>* out_tensors,
-                             bool* end_of_sequence) override {
-        mutex_lock l(mu_);
-        if ((dataset()->step_ > 0 && next_ >= dataset()->stop_) ||
-            (dataset()->step_ < 0 && next_ <= dataset()->stop_)) {
-          *end_of_sequence = true;
-          return Status::OK();
-        }
-        out_tensors->reserve(1);
-        out_tensors->emplace_back(next_);
-        *end_of_sequence = false;
-        next_ += dataset()->step_;
-
-        return Status::OK();
-      }
-
-     protected:
-      std::shared_ptr<model::Node> CreateNode(
-          IteratorContext* ctx, model::Node::Args args) const override {
-        return model::MakeSourceNode(std::move(args));
-      }
-
-      Status SaveInternal(IteratorStateWriter* writer) override {
-        mutex_lock l(mu_);
-        TF_RETURN_IF_ERROR(writer->WriteScalar(full_name("next"), next_));
-        return Status::OK();
-      }
-
-      Status RestoreInternal(IteratorContext* ctx,
-                             IteratorStateReader* reader) override {
-        mutex_lock l(mu_);
-        TF_RETURN_IF_ERROR(reader->ReadScalar(full_name("next"), &next_));
-        return Status::OK();
-      }
-
-     private:
-      mutex mu_;
-      int64 next_ GUARDED_BY(mu_);
-    };
-
-    const int64 start_;
-    const int64 stop_;
-    const int64 step_;
+    mutex mu_;
+    int64 next_ GUARDED_BY(mu_);
   };
+
+  const int64 start_;
+  const int64 stop_;
+  const int64 step_;
 };
+
+void RangeDatasetOp::MakeDataset(OpKernelContext* ctx, DatasetBase** output) {
+  int64 start;
+  OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, "start", &start));
+
+  int64 stop;
+  OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, "stop", &stop));
+
+  int64 step;
+  OP_REQUIRES_OK(ctx, ParseScalarArgument<int64>(ctx, "step", &step));
+  OP_REQUIRES(ctx, step != 0,
+              errors::InvalidArgument("step must be a non-zero integer."));
+
+  *output = new Dataset(ctx, start, stop, step);
+}
 
 REGISTER_KERNEL_BUILDER(Name("RangeDataset").Device(DEVICE_CPU),
                         RangeDatasetOp);
-
-}  // namespace
 }  // namespace data
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/data/range_dataset_op.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op.cc
@@ -24,8 +24,6 @@ namespace {
 // See documentation in ../../ops/dataset_ops.cc for a high-level
 // description of the following op.
 
-using namespace tensorflow::data::name_utils;
-
 class RangeDatasetOp : public DatasetOpKernel {
  public:
   explicit RangeDatasetOp(OpKernelConstruction* ctx) : DatasetOpKernel(ctx) {}
@@ -56,8 +54,8 @@ class RangeDatasetOp : public DatasetOpKernel {
 
     std::unique_ptr<IteratorBase> MakeIteratorInternal(
         const string& prefix) const override {
-      return absl::make_unique<Iterator>(
-          Iterator::Params{this, IteratorPrefix(RANGE_DATASET, prefix)});
+      return absl::make_unique<Iterator>(Iterator::Params{
+          this, name_utils::IteratorPrefix(name_utils::RANGE, prefix)});
     }
 
     const DataTypeVector& output_dtypes() const override {
@@ -72,7 +70,8 @@ class RangeDatasetOp : public DatasetOpKernel {
     }
 
     string DebugString() const override {
-      return DatasetDebugString(RANGE_DATASET, start_, stop_, step_);
+      return name_utils::DatasetDebugString(name_utils::RANGE, start_, stop_,
+                                            step_);
     }
 
     int64 Cardinality() const override {

--- a/tensorflow/core/kernels/data/range_dataset_op.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op.cc
@@ -145,7 +145,10 @@ void RangeDatasetOp::MakeDataset(OpKernelContext* ctx, DatasetBase** output) {
   *output = new Dataset(ctx, start, stop, step);
 }
 
+namespace {
 REGISTER_KERNEL_BUILDER(Name("RangeDataset").Device(DEVICE_CPU),
                         RangeDatasetOp);
+}  // namespace
+
 }  // namespace data
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/data/range_dataset_op.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op.cc
@@ -15,6 +15,7 @@ limitations under the License.
 #include "tensorflow/core/framework/dataset.h"
 #include "tensorflow/core/framework/partial_tensor_shape.h"
 #include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/kernels/data/name_utils.h"
 
 namespace tensorflow {
 namespace data {
@@ -22,6 +23,8 @@ namespace {
 
 // See documentation in ../../ops/dataset_ops.cc for a high-level
 // description of the following op.
+
+using namespace tensorflow::data::name_utils;
 
 class RangeDatasetOp : public DatasetOpKernel {
  public:
@@ -54,7 +57,7 @@ class RangeDatasetOp : public DatasetOpKernel {
     std::unique_ptr<IteratorBase> MakeIteratorInternal(
         const string& prefix) const override {
       return absl::make_unique<Iterator>(
-          Iterator::Params{this, strings::StrCat(prefix, "::Range")});
+          Iterator::Params{this, IteratorPrefix(RANGE_DATASET, prefix)});
     }
 
     const DataTypeVector& output_dtypes() const override {
@@ -69,8 +72,7 @@ class RangeDatasetOp : public DatasetOpKernel {
     }
 
     string DebugString() const override {
-      return strings::StrCat("RangeDatasetOp(", start_, ", ", stop_, ", ",
-                             step_, ")::Dataset");
+      return DatasetDebugString(RANGE_DATASET, start_, stop_, step_);
     }
 
     int64 Cardinality() const override {

--- a/tensorflow/core/kernels/data/range_dataset_op.h
+++ b/tensorflow/core/kernels/data/range_dataset_op.h
@@ -24,6 +24,11 @@ namespace data {
 class RangeDatasetOp : public DatasetOpKernel {
  public:
   static constexpr char kDatasetType[] = "Range";
+  static constexpr char kStart[] = "start";
+  static constexpr char kStop[] = "stop";
+  static constexpr char kStep[] = "step";
+  static constexpr char kOutputTypes[] = "output_types";
+  static constexpr char kOutputShapes[] = "output_shapes";
 
   explicit RangeDatasetOp(OpKernelConstruction* ctx) : DatasetOpKernel(ctx) {}
 

--- a/tensorflow/core/kernels/data/range_dataset_op.h
+++ b/tensorflow/core/kernels/data/range_dataset_op.h
@@ -1,4 +1,4 @@
-/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,36 +13,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef TENSORFLOW_CORE_KERNELS_DATA_PREFETCH_DATASET_OP_H_
-#define TENSORFLOW_CORE_KERNELS_DATA_PREFETCH_DATASET_OP_H_
+#ifndef TENSORFLOW_CORE_KERNELS_DATA_RANGE_DATASET_OP_H_
+#define TENSORFLOW_CORE_KERNELS_DATA_RANGE_DATASET_OP_H_
 
 #include "tensorflow/core/framework/dataset.h"
-#include "tensorflow/core/kernels/data/prefetch_autotuner.h"
 
 namespace tensorflow {
 namespace data {
 
-class PrefetchDatasetOp : public UnaryDatasetOpKernel {
+class RangeDatasetOp : public DatasetOpKernel {
  public:
-  static constexpr char kDatasetType[] = "Prefetch";
+  static constexpr char kDatasetType[] = "Range";
 
-  explicit PrefetchDatasetOp(OpKernelConstruction* ctx)
-      : UnaryDatasetOpKernel(ctx) {
-    if (ctx->HasAttr("slack_period")) {
-      OP_REQUIRES_OK(ctx, ctx->GetAttr("slack_period", &slack_period_));
-    }
-  }
+  explicit RangeDatasetOp(OpKernelConstruction* ctx) : DatasetOpKernel(ctx) {}
 
  protected:
-  void MakeDataset(OpKernelContext* ctx, DatasetBase* input,
-                   DatasetBase** output) override;
+  void MakeDataset(OpKernelContext* ctx, DatasetBase** output) override;
 
  private:
   class Dataset;
-  int64 slack_period_ = 0;
 };
 
 }  // namespace data
 }  // namespace tensorflow
 
-#endif  // TENSORFLOW_CORE_KERNELS_DATA_PREFETCH_DATASET_OP_H_
+#endif  // TENSORFLOW_CORE_KERNELS_DATA_RANGE_DATASET_OP_H_

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -39,7 +39,7 @@ class RangeDatasetOpTest : public DatasetOpsTestBase {
 
 struct TestCase {
   int64 start;
-  int64 end;
+  int64 stop;
   int64 step;
   std::vector<Tensor> expected_outputs;
   DataTypeVector expected_output_dtypes;
@@ -50,7 +50,7 @@ struct TestCase {
 
 TestCase PositiveStepTestCase() {
   return {/*start*/ 0,
-          /*end*/ 10,
+          /*stop*/ 10,
           /*step*/ 3,
           /*expected_outputs*/
           {DatasetOpsTestBase::CreateTensor<int64>(TensorShape({}), {0}),
@@ -65,7 +65,7 @@ TestCase PositiveStepTestCase() {
 
 TestCase NegativeStepTestCase() {
   return {/*start*/ 10,
-          /*end*/ 0,
+          /*stop*/ 0,
           /*step*/ -3,
           /*expected_outputs*/
           {DatasetOpsTestBase::CreateTensor<int64>(TensorShape({}), {10}),
@@ -80,7 +80,7 @@ TestCase NegativeStepTestCase() {
 
 TestCase ZeroStepTestCase() {
   return {/*start*/ 0,
-          /*end*/ 10,
+          /*stop*/ 10,
           /*step*/ 0,
           /*expected_outputs*/ {},
           /*expected_output_dtypes*/ {},
@@ -99,13 +99,10 @@ TEST_P(ParameterizedRangeDatasetOpTest, GetNext) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = GetParam();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -146,13 +143,10 @@ TEST_F(RangeDatasetOpTest, ZeroStep) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = ZeroStepTestCase();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -173,13 +167,10 @@ TEST_F(RangeDatasetOpTest, DatasetNodeName) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = PositiveStepTestCase();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -201,13 +192,10 @@ TEST_F(RangeDatasetOpTest, DatasetTypeString) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = PositiveStepTestCase();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -230,13 +218,10 @@ TEST_F(RangeDatasetOpTest, DatasetOutputDtypes) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = PositiveStepTestCase();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -259,13 +244,10 @@ TEST_F(RangeDatasetOpTest, DatasetOutputShapes) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = PositiveStepTestCase();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -288,13 +270,10 @@ TEST_P(ParameterizedRangeDatasetOpTest, Cardinality) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = GetParam();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -316,13 +295,10 @@ TEST_F(RangeDatasetOpTest, DatasetSave) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = PositiveStepTestCase();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -350,13 +326,10 @@ TEST_F(RangeDatasetOpTest, IteratorOutputDtypes) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = PositiveStepTestCase();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -386,13 +359,10 @@ TEST_F(RangeDatasetOpTest, IteratorOutputShapes) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = PositiveStepTestCase();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -422,13 +392,10 @@ TEST_F(RangeDatasetOpTest, IteratorOutputPrefix) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = PositiveStepTestCase();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(
@@ -448,9 +415,8 @@ TEST_F(RangeDatasetOpTest, IteratorOutputPrefix) {
   TF_ASSERT_OK(range_dataset->MakeIterator(iterator_context.get(), "Iterator",
                                            &iterator));
 
-  EXPECT_EQ(
-      iterator->prefix(),
-      name_utils::IteratorPrefix(RangeDatasetOp::kDatasetType, "Iterator"));
+  EXPECT_EQ(iterator->prefix(), name_utils::IteratorPrefix(
+                                    RangeDatasetOp::kDatasetType, "Iterator"));
 }
 
 TEST_P(ParameterizedRangeDatasetOpTest, Roundtrip) {
@@ -459,13 +425,10 @@ TEST_P(ParameterizedRangeDatasetOpTest, Roundtrip) {
   TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
 
   TestCase test_case = GetParam();
-  gtl::InlinedVector<TensorValue, 4> inputs;
   Tensor start = CreateTensor<int64>(TensorShape({}), {test_case.start});
-  Tensor end = CreateTensor<int64>(TensorShape({}), {test_case.end});
+  Tensor stop = CreateTensor<int64>(TensorShape({}), {test_case.stop});
   Tensor step = CreateTensor<int64>(TensorShape({}), {test_case.step});
-  inputs.emplace_back(&start);
-  inputs.emplace_back(&end);
-  inputs.emplace_back(&step);
+  gtl::InlinedVector<TensorValue, 4> inputs({&start, &stop, &step});
 
   std::unique_ptr<OpKernel> range_dataset_kernel;
   TF_ASSERT_OK(

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -218,7 +218,8 @@ TEST_F(RangeDatasetOpTest, DatasetTypeString) {
                              range_dataset_context.get(), &range_dataset));
   core::ScopedUnref scoped_unref(range_dataset);
 
-  EXPECT_EQ(range_dataset->type_string(), OpName(RANGE_DATASET));
+  EXPECT_EQ(range_dataset->type_string(),
+            name_utils::OpName(name_utils::RANGE));
 }
 
 TEST_F(RangeDatasetOpTest, DatasetOutputDtypes) {
@@ -445,7 +446,8 @@ TEST_F(RangeDatasetOpTest, IteratorOutputPrefix) {
   TF_ASSERT_OK(range_dataset->MakeIterator(iterator_context.get(), "Iterator",
                                            &iterator));
 
-  EXPECT_EQ(iterator->prefix(), IteratorPrefix(RANGE_DATASET, "Iterator"));
+  EXPECT_EQ(iterator->prefix(),
+            name_utils::IteratorPrefix(name_utils::RANGE, "Iterator"));
 }
 
 TEST_P(ParameterizedRangeDatasetOpTest, Roundtrip) {

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -20,7 +20,6 @@ namespace data {
 namespace {
 
 constexpr char kNodeName[] = "range_dataset";
-constexpr char kOpName[] = "RangeDataset";
 
 class RangeDatasetOpTest : public DatasetOpsTestBase {
  protected:
@@ -219,7 +218,7 @@ TEST_F(RangeDatasetOpTest, DatasetTypeString) {
                              range_dataset_context.get(), &range_dataset));
   core::ScopedUnref scoped_unref(range_dataset);
 
-  EXPECT_EQ(range_dataset->type_string(), kOpName);
+  EXPECT_EQ(range_dataset->type_string(), OpName(RANGE_DATASET));
 }
 
 TEST_F(RangeDatasetOpTest, DatasetOutputDtypes) {
@@ -446,7 +445,7 @@ TEST_F(RangeDatasetOpTest, IteratorOutputPrefix) {
   TF_ASSERT_OK(range_dataset->MakeIterator(iterator_context.get(), "Iterator",
                                            &iterator));
 
-  EXPECT_EQ(iterator->prefix(), "Iterator::Range");
+  EXPECT_EQ(iterator->prefix(), IteratorPrefix(RANGE_DATASET, "Iterator"));
 }
 
 TEST_P(ParameterizedRangeDatasetOpTest, Roundtrip) {

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/core/kernels/data/range_dataset_op.h"
 #include "tensorflow/core/kernels/data/dataset_test_base.h"
 
 namespace tensorflow {
@@ -219,7 +220,7 @@ TEST_F(RangeDatasetOpTest, DatasetTypeString) {
   core::ScopedUnref scoped_unref(range_dataset);
 
   EXPECT_EQ(range_dataset->type_string(),
-            name_utils::OpName(name_utils::RANGE));
+            name_utils::OpName(RangeDatasetOp::kDatasetType));
 }
 
 TEST_F(RangeDatasetOpTest, DatasetOutputDtypes) {
@@ -446,8 +447,9 @@ TEST_F(RangeDatasetOpTest, IteratorOutputPrefix) {
   TF_ASSERT_OK(range_dataset->MakeIterator(iterator_context.get(), "Iterator",
                                            &iterator));
 
-  EXPECT_EQ(iterator->prefix(),
-            name_utils::IteratorPrefix(name_utils::RANGE, "Iterator"));
+  EXPECT_EQ(
+      iterator->prefix(),
+      name_utils::IteratorPrefix(RangeDatasetOp::kDatasetType, "Iterator"));
 }
 
 TEST_P(ParameterizedRangeDatasetOpTest, Roundtrip) {

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/core/kernels/data/range_dataset_op.h"
+
 #include "tensorflow/core/kernels/data/dataset_test_base.h"
 
 namespace tensorflow {


### PR DESCRIPTION
This PR aims to move all dataset op names into `tensorflow::data::name_utils` namespace and replace all uses of string literals for dataset names.

cc: @jsimsa 