### PR TITLE
[ROCm] remove GPU_LAUNCH_KERNEL macro

### DIFF
--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -30,18 +30,6 @@ limitations under the License.
 #define TF_RED_WARPSIZE 64
 #endif
 
-#if GOOGLE_CUDA
-#define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, shared_mem, \
-                          stream, ...)                                        \
-  TF_CHECK_OK(CudaLaunchKernel(kernel, block_count, threads_per_block,        \
-                               shared_mem, stream, __VA_ARGS__));
-#elif TENSORFLOW_USE_ROCM
-#define GPU_LAUNCH_KERNEL(kernel, block_count, threads_per_block, shared_mem, \
-                          stream, ...)                                        \
-  hipLaunchKernelGGL(kernel, block_count, threads_per_block, shared_mem,      \
-                     stream, __VA_ARGS__);
-#endif
-
 // Deprecated, use 'for(int i : CudaGridRangeX(n))' instead.
 #define CUDA_1D_KERNEL_LOOP(i, n) \
   for (int i : ::tensorflow::CudaGridRangeX<int>(n))


### PR DESCRIPTION
This PR is a follow-up to the original PR #28343. The reviewer requested to break down the original large PR to a series of smaller ones. According to the plan here, this PR is the sixth one in the whole series.

@chsigg @whchung