### PR TITLE
[INTEL MKL] Code clean - MklSliceOp

### DIFF
--- a/tensorflow/core/kernels/mkl_slice_op.cc
+++ b/tensorflow/core/kernels/mkl_slice_op.cc
@@ -16,8 +16,8 @@ limitations under the License.
 // See docs in ../ops/array_ops.cc.
 
 #ifdef INTEL_MKL
-#ifndef INTEL_MKL_ML_ONLY
 
+#include "mkldnn.hpp"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -25,10 +25,8 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/lib/gtl/array_slice.h"
 #include "tensorflow/core/platform/prefetch.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
-
-#include "mkldnn.hpp"
 #include "tensorflow/core/util/mkl_util.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 using mkldnn::stream;
 using mkldnn::view;
@@ -490,5 +488,4 @@ TF_CALL_bfloat16(REGISTER_MKL_SLICE);
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL_DNN
 #endif  // INTEL_MKL


### PR DESCRIPTION
Remove MKL ML related #if/#else/#endif statements related to MklSliceOp

MKL ML is not supported anymore. It has been replaced with MKL DNN.