### PR TITLE
Fix a bug in algebraic simplification pass.

### DIFF
--- a/tensorflow/compiler/xla/service/algebraic_simplifier.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.cc
@@ -1581,6 +1581,15 @@ AlgebraicSimplifierVisitor::OptimizeDotOfReorderContractingDims(
       lhs_contracting_dims.Add(i);
     }
   }
+  // We require the "unsquished" lhs contracting dims to be consecutive.
+  auto is_iota = [](absl::Span<const int64> dims) {
+    return absl::c_adjacent_find(dims, [](const int64 a, const int64 b) {
+             return (b != a + 1);
+           }) == dims.end();
+  };
+  if (!is_iota(AsInt64Slice(lhs_contracting_dims))) {
+    return nullptr;
+  }
   lhs = lhs->mutable_operand(0);
 
   // Check that the transpose only permutes the contracting dims.
@@ -1597,6 +1606,7 @@ AlgebraicSimplifierVisitor::OptimizeDotOfReorderContractingDims(
   for (auto dim : lhs_contracting_dims) {
     permutation.push_back(transpose_dims[dim] - lhs_contracting_dims[0]);
   }
+  CHECK(IsPermutation(permutation, permutation.size()));
   auto new_lhs_contracting_dims =
       ComposePermutations(AsInt64Slice(lhs_contracting_dims), permutation);
   lhs_contracting_dims.Clear();

--- a/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
@@ -5372,10 +5372,8 @@ TEST_F(AlgebraicSimplifierTest, DotContractingReorder_SizeOneDims) {
   EXPECT_THAT(transpose->dimensions(), ElementsAre(0, 2, 1, 3));
 }
 
-// This test exposes a real bug: It tries to read an out-of-bounds array index
-// from within ComposePermutations().  TODO(b/132330723): Fix this.
 TEST_F(AlgebraicSimplifierTest,
-       DISABLED_DotContractingReorder_NoChangeInContractingDimsOrder) {
+       DotContractingReorder_NoChangeInContractingDimsOrder) {
   // No optimization opportunity here because the transpose does not reorder the
   // contracting dims.
   const char* kModuleStr = R"(


### PR DESCRIPTION
In the dot contracting dimensions reorder optimization, check if the reshape op squishes consecutive dimensions, and bail out if it is not the case.

The current algorithm to compute unsquished lhs contracting dims in reshape input could result in non-consecutive dimensions. For example for A = f32[5,6] reshape(f32[1,5,2,3] B), the unsquished lhs contracting dims = {0, 2, 3}. The check for transpose only permutes contracting dims won't catch this case. Later transformation assume the contracting dims are consecutive to compute and compose permutations.