### PR TITLE
Build tf with trt 6

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -790,6 +790,14 @@ class TRT_TensorOrWeights::SimpleITensor : public nvinfer1::ITensor {
   float getDynamicRangeMax() const override { return 0.f; }
 #endif
 
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+  void setAllowedFormats(nvinfer1::TensorFormats formats) override {}
+
+  nvinfer1::TensorFormats getAllowedFormats() const override { return 1; }
+
+  bool isShape() const override { return false; }
+#endif
+
  private:
   nvinfer1::DataType trt_dtype_;
   nvinfer1::Dims trt_dims_;

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -280,6 +280,14 @@ class FakeITensor : public nvinfer1::ITensor {
   float getDynamicRangeMax() const override { return 0.f; }
 #endif
 
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+  void setAllowedFormats(nvinfer1::TensorFormats formats) override {}
+
+  nvinfer1::TensorFormats getAllowedFormats() const override { return 1; }
+
+  bool isShape() const override { return false; }
+#endif
+
  private:
   string name_;
   nvinfer1::Dims dims_;

--- a/third_party/gpus/find_cuda_config.py
+++ b/third_party/gpus/find_cuda_config.py
@@ -388,6 +388,12 @@ def _find_tensorrt_config(base_paths, required_version):
   header_path, header_version = _find_header(base_paths, "NvInfer.h",
                                              required_version,
                                              get_header_version)
+
+  if ".." in header_version:
+    header_path, header_version = _find_header(base_paths, "NvInferRTSafe.h",
+                                               required_version,
+                                               get_header_version)
+
   tensorrt_version = header_version.split(".")[0]
 
   library_path = _find_library(base_paths, "nvinfer", tensorrt_version)

--- a/third_party/gpus/find_cuda_config.py
+++ b/third_party/gpus/find_cuda_config.py
@@ -390,7 +390,8 @@ def _find_tensorrt_config(base_paths, required_version):
                                              get_header_version)
 
   if ".." in header_version:
-    header_path, header_version = _find_header(base_paths, "NvInferRTSafe.h",
+    # From TRT 6.0 onwards, version information has been moved to NvInferVersion.h.
+    header_path, header_version = _find_header(base_paths, "NvInferVersion.h",
                                                required_version,
                                                get_header_version)
 

--- a/third_party/tensorrt/tensorrt_configure.bzl
+++ b/third_party/tensorrt/tensorrt_configure.bzl
@@ -27,6 +27,16 @@ _DEFINE_TENSORRT_SONAME_MAJOR = "#define NV_TENSORRT_SONAME_MAJOR"
 _DEFINE_TENSORRT_SONAME_MINOR = "#define NV_TENSORRT_SONAME_MINOR"
 _DEFINE_TENSORRT_SONAME_PATCH = "#define NV_TENSORRT_SONAME_PATCH"
 
+def _at_least_version(actual_version, required_version):
+  actual = [int(v) for v in actual_version.split(".")]
+  required = [int(v) for v in required_version.split(".")]
+  return actual >= required
+
+def _update_tensorrt_headers(tensorrt_version):
+    if not _at_least_version(tensorrt_version, "6"):
+        return
+    _TF_TENSORRT_HEADERS = ["NvInferVersion.h", "NvInfer.h", "NvUtils.h", "NvInferPlugin.h", "NvInferRTSafe.h", "NvInferRTExt.h", "NvInferPluginUtils.h"]
+
 def _tpl(repository_ctx, tpl, substitutions):
     repository_ctx.template(
         tpl,
@@ -69,6 +79,7 @@ def _tensorrt_configure_impl(repository_ctx):
     cpu_value = get_cpu_value(repository_ctx)
 
     # Copy the library and header files.
+    _update_tensorrt_headers(trt_version)
     libraries = [lib_name(lib, cpu_value, trt_version) for lib in _TF_TENSORRT_LIBS]
     library_dir = config["tensorrt_library_dir"] + "/"
     headers = _TF_TENSORRT_HEADERS

--- a/third_party/tensorrt/tensorrt_configure.bzl
+++ b/third_party/tensorrt/tensorrt_configure.bzl
@@ -28,14 +28,16 @@ _DEFINE_TENSORRT_SONAME_MINOR = "#define NV_TENSORRT_SONAME_MINOR"
 _DEFINE_TENSORRT_SONAME_PATCH = "#define NV_TENSORRT_SONAME_PATCH"
 
 def _at_least_version(actual_version, required_version):
-  actual = [int(v) for v in actual_version.split(".")]
-  required = [int(v) for v in required_version.split(".")]
-  return actual >= required
+    actual = [int(v) for v in actual_version.split(".")]
+    required = [int(v) for v in required_version.split(".")]
+    return actual >= required
 
 def _update_tensorrt_headers(tensorrt_version):
     if not _at_least_version(tensorrt_version, "6"):
         return
-    _TF_TENSORRT_HEADERS = ["NvInferVersion.h", "NvInfer.h", "NvUtils.h", "NvInferPlugin.h", "NvInferRTSafe.h", "NvInferRTExt.h", "NvInferPluginUtils.h"]
+    _TF_TENSORRT_HEADERS = ["NvInferVersion.h", "NvInfer.h", "NvUtils.h",
+                            "NvInferPlugin.h", "NvInferRTSafe.h",
+                            "NvInferRTExt.h", "NvInferPluginUtils.h"]
 
 def _tpl(repository_ctx, tpl, substitutions):
     repository_ctx.template(


### PR DESCRIPTION
Enable building TF with TRT 6.0 (onwards). 
Changes:
1. tensorrt_configure.bzl -   Include new header files when tensorrt version >= 6.
2. find_cuda_config.py - Retrieve version information from NvInferVerison.h for tensorrt version >= 6.
3. convert_nodes.cc - Add new virtual methods override to derived classes of ITensor.
4. convert_nodes_test.cc -  Add new virtual methods override to derived classes of ITensor.