### PR TITLE
Fixes broken GPU build

### DIFF
--- a/third_party/gpus/find_cuda_config.py
+++ b/third_party/gpus/find_cuda_config.py
@@ -451,7 +451,7 @@ def find_cuda_config():
 
     cuda_version = result["cuda_version"]
     cublas_paths = base_paths
-    if cuda_version.split(".") < (10, 1):
+    if tuple(int(v) for v in cuda_version.split(".")) < (10, 1):
       # Before CUDA 10.1, cuBLAS was in the same directory as the toolkit.
       cublas_paths = cuda_paths
     cublas_version = os.environ.get("TF_CUBLAS_VERSION", "")


### PR DESCRIPTION
```
ERROR: Skipping '//tensorflow/tools/pip_package:build_pip_package': error loading package 'tensorflow/tools/pip_package': Encountered error while reading extension file 'cuda/build_defs.bzl': no such package '@local_config_cuda//cuda': Traceback (most recent call last):
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 1244
		_create_local_cuda_repository(repository_ctx)
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 960, in _create_local_cuda_repository
		_get_cuda_config(repository_ctx)
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 686, in _get_cuda_config
		find_cuda_config(repository_ctx, ["cuda", "cudnn"])
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 666, in find_cuda_config
		auto_configure_fail(("Failed to run find_cuda_config...))
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 274, in auto_configure_fail
		fail(("\n%sCuda Configuration Error:%...)))

Cuda Configuration Error: Failed to run find_cuda_config.py: Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/43801f1e35f242fb634ebbc6079cf6c5/external/org_tensorflow/third_party/gpus/find_cuda_config.py", line 493, in <module>
    main()
  File "/root/.cache/bazel/_bazel_root/43801f1e35f242fb634ebbc6079cf6c5/external/org_tensorflow/third_party/gpus/find_cuda_config.py", line 485, in main
    for key, value in sorted(find_cuda_config().items()):
  File "/root/.cache/bazel/_bazel_root/43801f1e35f242fb634ebbc6079cf6c5/external/org_tensorflow/third_party/gpus/find_cuda_config.py", line 454, in find_cuda_config
    if tuple(cuda_version.split(".")) < (10, 1):
TypeError: unorderable types: str() < int()

WARNING: Target pattern parsing failed.
ERROR: error loading package 'tensorflow/tools/pip_package': Encountered error while reading extension file 'cuda/build_defs.bzl': no such package '@local_config_cuda//cuda': Traceback (most recent call last):
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 1244
		_create_local_cuda_repository(repository_ctx)
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 960, in _create_local_cuda_repository
		_get_cuda_config(repository_ctx)
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 686, in _get_cuda_config
		find_cuda_config(repository_ctx, ["cuda", "cudnn"])
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 666, in find_cuda_config
		auto_configure_fail(("Failed to run find_cuda_config...))
	File "/tensorflow_src/third_party/gpus/cuda_configure.bzl", line 274, in auto_configure_fail
		fail(("\n%sCuda Configuration Error:%...)))

Cuda Configuration Error: Failed to run find_cuda_config.py: Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/43801f1e35f242fb634ebbc6079cf6c5/external/org_tensorflow/third_party/gpus/find_cuda_config.py", line 493, in <module>
    main()
  File "/root/.cache/bazel/_bazel_root/43801f1e35f242fb634ebbc6079cf6c5/external/org_tensorflow/third_party/gpus/find_cuda_config.py", line 485, in main
    for key, value in sorted(find_cuda_config().items()):
  File "/root/.cache/bazel/_bazel_root/43801f1e35f242fb634ebbc6079cf6c5/external/org_tensorflow/third_party/gpus/find_cuda_config.py", line 454, in find_cuda_config
    if tuple(cuda_version.split(".")) < (10, 1):
TypeError: unorderable types: str() < int()

INFO: Elapsed time: 17.630s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
```