### PR TITLE
verbs: fixes GPU build broken by 55a7da3

### DIFF
--- a/tensorflow/contrib/verbs/rdma.cc
+++ b/tensorflow/contrib/verbs/rdma.cc
@@ -1634,7 +1634,7 @@ void RdmaTensorRequest::RecvTensorContent() {
                                 [this](const Status& s) {
                                   CHECK(s.ok()) << "copy tensor to gpu sync";
                                   Done(s);
-                                });
+                                }, true);
     return;
   }
 #endif


### PR DESCRIPTION
Use the default argument sync_dst_compute=true as in DeviceContext::CopyCPUTensorToDevice.

Signed-off-by: Bairen Yi <byi@connect.ust.hk>