### PR TITLE
verbs: fixes GPU build broken by 4c3a1fb

### DIFF
--- a/tensorflow/contrib/verbs/rdma.cc
+++ b/tensorflow/contrib/verbs/rdma.cc
@@ -1634,7 +1634,7 @@ void RdmaTensorRequest::RecvTensorContent() {
                                 [this](const Status& s) {
                                   CHECK(s.ok()) << "copy tensor to gpu sync";
                                   Done(s);
-                                });
+                                }, true /*sync_dst_compute*/);
     return;
   }
 #endif


### PR DESCRIPTION
Use the default argument as in DeviceContext::CopyCPUTensorToDevice.

@poxvoculi is probably the best person to review this, but he's currently on leave.

Ping @dubey if you have time reviewing this. As r1.14 is to be recut, in case we missed it, ping @bananabowl to see if we can cherry-pick this PR.

Thanks!