### PR TITLE
Enable opening TF source tree with Visual Studio Code

### DIFF
--- a/third_party/toolchains/cpus/arm/BUILD
+++ b/third_party/toolchains/cpus/arm/BUILD
@@ -1,5 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
+# The following line is only here to make this project import into IDEs that embed
+# a Bazel toolchain.
+licenses(["notice"])
+
 cc_toolchain_suite(
     name = "toolchain",
     toolchains = {
@@ -50,3 +54,4 @@ cc_toolchain(
     supports_param_files = 1,
     toolchain_identifier = "arm-linux-gnueabihf",
 )
+


### PR DESCRIPTION
When one attempts to open up the TensorFlow source code tree in Visual Studio Code with the `vscode-bazel` plugin, the IDE responds with this error:
![Screen Shot 2019-05-13 at 5 19 53 PM](https://user-images.githubusercontent.com/12436991/57662341-f611ee00-75a3-11e9-9546-9864e73e48c6.png)

This PR adds a small edit to one of the `BUILD` files that makes this error go away. After this change, Visual Studio Code is able to process the build files and display a list of Bazel build targets.