### PR TITLE
[XLA] rename xla compile mark from _XlaCompile to XlaCompile

### DIFF
--- a/tensorflow/compiler/jit/defs.cc
+++ b/tensorflow/compiler/jit/defs.cc
@@ -17,7 +17,7 @@ limitations under the License.
 
 namespace tensorflow {
 
-const char* const kXlaCompileAttr = "_XlaCompile";
-const char* const kXlaScopeAttr = "_XlaScope";
+const char* const kXlaCompileAttr = "XlaCompile";
+const char* const kXlaScopeAttr = "XlaScope";
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -58,7 +58,7 @@ namespace {
 // Copy of the definition in third_party/tensorflow/compiler/jit/defs.h
 // Copied here because we don't currently compile XLA on windows. So, can't
 // depend on it directly.
-const char* const kXlaCompileAttr = "_XlaCompile";
+const char* const kXlaCompileAttr = "XlaCompile";
 
 // Initializes the step stats if needed.
 void MaybeInitializeStepStats(StepStats* step_stats, EagerContext* ctx) {


### PR DESCRIPTION
code in mark_for_compilation_pass.cc shows that we can force an op to be compiled by xla by adding a mark "kXlaCompileAttr" to the op in its op.cc. However,  tf framework does not support a node attr name with the beginning of "_" such as "_XlaCompile", which makes the design in mark_for_compilation.cc  not work. 
i have tested this solution in nccl_ops.cc and it worked. 