### PR TITLE
BeagleBone Black Tensorflow Lite build scripts

### DIFF
--- a/tensorflow/lite/tools/make/build_bbb_lib.sh
+++ b/tensorflow/lite/tools/make/build_bbb_lib.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -x
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/../../../.."
+
+CC_PREFIX=arm-linux-gnueabihf- make -j 3 -f tensorflow/lite/tools/make/Makefile TARGET=bbb TARGET_ARCH=armv7l

--- a/tensorflow/lite/tools/make/targets/bbb_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/bbb_makefile.inc
@@ -1,0 +1,35 @@
+# Settings for BeagleBone Black.
+ifeq ($(TARGET),bbb)
+  TARGET_ARCH := armv7l
+  TARGET_TOOLCHAIN_PREFIX := arm-linux-gnueabihf-
+
+  ifeq ($(TARGET_ARCH), armv7l)
+    CXXFLAGS += \
+      -march=armv7-a \
+      -mfpu=neon \
+      -funsafe-math-optimizations \
+      -ftree-vectorize \
+      -fPIC
+
+    CFLAGS += \
+      -march=armv7-a \
+      -mfpu=neon \
+      -funsafe-math-optimizations \
+      -ftree-vectorize \
+      -fPIC
+
+    LDFLAGS := \
+      -Wl,--no-export-dynamic \
+      -Wl,--exclude-libs,ALL \
+      -Wl,--gc-sections \
+      -Wl,--as-needed
+  endif
+
+  LIBS := \
+    -lstdc++ \
+    -lpthread \
+    -lm \
+    -ldl \
+    -lrt
+
+endif


### PR DESCRIPTION
Added build_bbb_lib.sh and targets/bbb_makefile.inc to tensorflow/tensorflow/lite/tools/make/
Build tested on Raspberry Pi 3 B+.
Static Library tested on BeagleBone Black Industrial Edition.

Once the library has been generated, rename gen/bbb_armv7l/lib/libtensorflow-lite.a to libtflite.a
and link to your gcc projects with "-ltflite -lpthread -ldl -lrt -march=armv7-a -mfpu=neon -I . -L ."
e.g.:
        g++ -c main.cpp -o main.o -I .
	g++ -o test.run main.o -march=armv7-a -mfpu=neon -L . -l tflite -l pthread -l dl -l rt

Please see the Tensorflow Lite documentation for more information:
https://www.tensorflow.org/lite/guide/inference#running_a_model
