### PR TITLE
Minimal ACL Integration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,7 @@ build:android_arm --fat_apk_cpu=armeabi-v7a
 build:android_arm64 --config=android
 build:android_arm64 --cpu=arm64-v8a
 build:android_arm64 --fat_apk_cpu=arm64-v8a
+build:acl --define=with_acl_support=true --copt -DUSE_ACL
 
 # Sets the default Apple platform to macOS.
 build --apple_platform_type=macos

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -397,6 +397,12 @@ config_setting(
 )
 
 config_setting(
+    name = "with_acl_support",
+    values = {"define": "with_acl_support=true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "override_eigen_strong_inline",
     values = {"define": "override_eigen_strong_inline=true"},
     visibility = ["//visibility:public"],

--- a/tensorflow/lite/c/c_api_internal.h
+++ b/tensorflow/lite/c/c_api_internal.h
@@ -44,11 +44,12 @@ typedef enum { kTfLiteOk = 0, kTfLiteError = 1 } TfLiteStatus;
 // need. Access to the external contexts is controled by one of the
 // corresponding support files.
 typedef enum {
-  kTfLiteEigenContext = 0,       // include eigen_support.h to use.
-  kTfLiteGemmLowpContext = 1,    // include gemm_support.h to use.
-  kTfLiteEdgeTpuContext = 2,     // Placeholder for Edge TPU support.
-  kTfLiteCpuBackendContext = 3,  // include cpu_backend_support.h to use.
-  kTfLiteMaxExternalContexts = 4
+  kTfLiteEigenContext = 0,          // include eigen_support.h to use.
+  kTfLiteGemmLowpContext = 1,       // include gemm_support.h to use.
+  kTfLiteEdgeTpuContext = 2,        // Placeholder for Edge TPU support.
+  kTfLiteCpuBackendContext = 3,     // include cpu_backend_support.h to use.
+  kTfLiteKernelBackendContext = 4,  // inlude backend_context.h to use.
+  kTfLiteMaxExternalContexts = 5
 } TfLiteExternalContextType;
 
 struct TfLiteContext;

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -374,6 +374,7 @@ cc_library(
         "//tensorflow/lite:string_util",
         "//tensorflow/lite/c:c_api_internal",
         "//tensorflow/lite/kernels/internal:audio_utils",
+        "//tensorflow/lite/kernels/internal:backends",
         "//tensorflow/lite/kernels/internal:kernel_utils",
         "//tensorflow/lite/kernels/internal:optimized",
         "//tensorflow/lite/kernels/internal:optimized_base",

--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -1,6 +1,7 @@
 load("//tensorflow:tensorflow.bzl", "transitive_hdrs")
 load("//tensorflow/lite:build_def.bzl", "tflite_copts")
 load("//tensorflow/lite:special_rules.bzl", "tflite_portable_test_suite")
+load("//third_party/acl:build_defs.bzl", "if_acl")
 
 package(default_visibility = [
     "//visibility:public",
@@ -186,6 +187,61 @@ cc_library(
         ":freebsd": tflite_deps_intel,
         "//conditions:default": [],
     }),
+)
+
+cc_library(
+    name = "acl_backend",
+    srcs = if_acl([
+            "backends/acl/backend.cc",
+            "backends/acl/conv2d.cc",
+            "backends/acl/depthwise_conv2d.cc",
+            "backends/acl/utils.cc",
+            ],
+            ["backends/acl/backend_disabled.cc"]
+    ),
+    hdrs = [
+        "backends/backend_interface.h",
+        "backends/backend_kernel.h",
+        "backends/acl/backend.h",
+    ] + if_acl([
+            "backends/acl/conv2d.h",
+            "backends/acl/depthwise_conv2d.h",
+            "backends/acl/utils.h",
+        ],
+        [],
+    ),
+    copts = NEON_FLAGS_IF_APPLICABLE + HARD_FP_FLAGS_IF_APPLICABLE,
+    deps = [
+        "//tensorflow/lite:kernel_api",
+        "//tensorflow/lite/c:c_api_internal",
+    ] + if_acl([
+            ":quantization_util",
+            ":tensor",
+            ":tensor_utils",
+            ":types",
+        ],
+        []
+    ),
+)
+
+cc_library(
+    name = "backends",
+    srcs = [
+        "backends/backend_context.cc",
+        "backends/backend_support.cc",
+    ],
+    hdrs = [
+        "backends/backend_context.h",
+        "backends/backend_interface.h",
+        "backends/backend_support.h",
+    ],
+    copts = tflite_copts(),
+    deps = [
+        "//tensorflow/lite:kernel_api",
+        "//tensorflow/lite/c:c_api_internal",
+        "//tensorflow/lite/kernels:op_macros",
+        ":acl_backend",
+    ],
 )
 
 cc_library(

--- a/tensorflow/lite/kernels/internal/backends/acl/README.md
+++ b/tensorflow/lite/kernels/internal/backends/acl/README.md
@@ -1,0 +1,63 @@
+<div align="center">
+ <img src="https://raw.githubusercontent.com/ARM-software/ComputeLibrary/gh-pages/ACL_logo.png"><br><br>
+</div>
+
+**Arm Compute Library** is an open source software library of optimized machine learning and computer vision primitives that target Arm IPs.
+
+Release repository: https://github.com/arm-software/ComputeLibrary
+
+Development repository: https://review.mlplatform.org/#/admin/projects/ml/ComputeLibrary
+
+This backend enables **TensorFlow Lite** to dispatch selected kernels to **Arm Compute Library**.
+
+The following kernels are currently off-loaded:
+- Conv2d (FP32)
+- Depthwise Conv2d (FP32)
+
+Further steps:
+- [ ] Add bazel build dependency
+- [ ] Use TensorFlow Lite memory manager in Compute Library
+- [ ] Add PreferredBackend(char *) interface to interpreter
+- [ ] Enable native half-precision floating point support
+- [ ] Enable quantized support
+- [ ] Profile and offload additional kernels
+
+## Installation
+
+Follow tutorial here https://www.tensorflow.org/lite/guide/build_arm64
+
+Add Compute library dependency:
+```
+cd tensorflow/lite/tools/make/downloads
+
+# Latest stable release
+git clone https://github.com/ARM-software/ComputeLibrary.git
+
+# or
+
+# Latest development branch
+git clone "https://review.mlplatform.org/ml/ComputeLibrary"
+```
+
+Compile Compute Library
+```
+# Linux (Cross-compile)
+scons Werror=1 -j8 debug=0 asserts=0 neon=1 opencl=0 os=linux arch=arm64-v8a
+
+# Linux (Native)
+scons Werror=1 -j8 debug=0 asserts=0 neon=1 opencl=0 os=linux arch=arm64-v8a build=native
+
+# Android
+CXX=clang++ CC=clang scons Werror=1 -j8 debug=0 asserts=0 neon=1 opencl=0 os=android arch=arm64-v8a
+```
+More details can be found in https://arm-software.github.io/ComputeLibrary/latest/index.xhtml
+
+Compile TensorFlow Lite with Compute Library support:
+```
+./tensorflow/lite/tools/make/build_aarch64_lib.sh USE_NNAPI=false USE_ACL=true
+```
+
+Strip symbols and reduce:
+```
+strip -R <binary>
+```

--- a/tensorflow/lite/kernels/internal/backends/acl/backend.cc
+++ b/tensorflow/lite/kernels/internal/backends/acl/backend.cc
@@ -1,0 +1,59 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/backends/acl/backend.h"
+
+// Supported builtins
+#include "tensorflow/lite/kernels/internal/backends/acl/conv2d.h"
+#include "tensorflow/lite/kernels/internal/backends/acl/depthwise_conv2d.h"
+
+#include "arm_compute/runtime/Scheduler.h"
+#include "support/ToolchainSupport.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace acl {
+
+bool ACLBackend::is_kernel_supported(TfLiteBuiltinOperator op) {
+  switch (op) {
+    case TfLiteBuiltinOperator::kTfLiteBuiltinConv2d:
+    case TfLiteBuiltinOperator::kTfLiteBuiltinDepthwiseConv2d:
+      return true;
+    default:
+      return false;
+  }
+}
+
+std::unique_ptr<IBackendKernel> ACLBackend::create_backend_kernel(
+    TfLiteBuiltinOperator op) {
+  switch (op) {
+    case TfLiteBuiltinOperator::kTfLiteBuiltinConv2d:
+      return arm_compute::support::cpp14::make_unique<ACLConv2dBackendKernel>();
+    case TfLiteBuiltinOperator::kTfLiteBuiltinDepthwiseConv2d:
+      return arm_compute::support::cpp14::make_unique<
+          ACLDepthwiseConv2dBackendKernel>();
+    default:
+      return nullptr;
+  }
+}
+
+void ACLBackend::set_max_num_threads(int max_num_threads) {
+  arm_compute::Scheduler::get().set_num_threads(max_num_threads);
+}
+
+}  // namespace acl
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite

--- a/tensorflow/lite/kernels/internal/backends/acl/backend.h
+++ b/tensorflow/lite/kernels/internal/backends/acl/backend.h
@@ -1,0 +1,40 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_BACKEND_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_BACKEND_H_
+
+#include "tensorflow/lite/kernels/internal/backends/backend_interface.h"
+#include "tensorflow/lite/kernels/internal/backends/backend_kernel.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace acl {
+
+// ACL Backend
+class ACLBackend final : public IBackend {
+ public:
+  // Inherited methods overidden:
+  bool is_kernel_supported(TfLiteBuiltinOperator op) override;
+  std::unique_ptr<IBackendKernel> create_backend_kernel(
+      TfLiteBuiltinOperator op) override;
+  void set_max_num_threads(int max_num_threads) override;
+};
+
+}  // namespace acl
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_BACKEND_H_

--- a/tensorflow/lite/kernels/internal/backends/acl/backend_disabled.cc
+++ b/tensorflow/lite/kernels/internal/backends/acl/backend_disabled.cc
@@ -1,0 +1,36 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/backends/acl/backend.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace acl {
+
+bool ACLBackend::is_kernel_supported(TfLiteBuiltinOperator op) { return false; }
+
+std::unique_ptr<IBackendKernel> ACLBackend::create_backend_kernel(
+    TfLiteBuiltinOperator op) {
+  return nullptr;
+}
+
+void ACLBackend::set_max_num_threads(int max_num_threads) {
+  // noop
+}
+
+}  // namespace acl
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite

--- a/tensorflow/lite/kernels/internal/backends/acl/conv2d.cc
+++ b/tensorflow/lite/kernels/internal/backends/acl/conv2d.cc
@@ -1,0 +1,172 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/backends/acl/conv2d.h"
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/c_api_internal.h"
+#include "tensorflow/lite/kernels/internal/backends/acl/utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/tensor.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/tensor_utils.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/kernels/padding.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace acl {
+
+void ACLConv2dBackendKernel::init(TfLiteContext* context, const char* buffer,
+                                  size_t length) {
+  // no-op for builtin ops
+}
+
+void ACLConv2dBackendKernel::free(TfLiteContext* context) {
+  // no-op for builtin ops
+}
+
+TfLiteStatus ACLConv2dBackendKernel::prepare(TfLiteContext* context,
+                                             TfLiteNode* node) {
+  _is_configured = false;
+
+  const auto* params = reinterpret_cast<TfLiteConvParams*>(node->builtin_data);
+  const bool has_bias = node->inputs->size == 3;
+
+  TfLiteTensor* output = &context->tensors[node->outputs->data[0]];
+  TfLiteTensor* input = &context->tensors[node->inputs->data[0]];
+  TfLiteTensor* filter = &context->tensors[node->inputs->data[1]];
+  TfLiteTensor* bias =
+      has_bias ? &context->tensors[node->inputs->data[2]] : nullptr;
+
+  // Data type
+  const auto io_data_type = map_datatype_to_acl(input->type);
+  const auto filter_data_type = map_datatype_to_acl(filter->type);
+  const auto bias_data_type = bias != nullptr ? map_datatype_to_acl(bias->type)
+                                              : arm_compute::DataType::UNKNOWN;
+  ACL_RETURN_ERROR_ON(io_data_type != arm_compute::DataType::F32);
+  ACL_RETURN_ERROR_ON(io_data_type != filter_data_type);
+
+  // Tensor shapes
+  const auto input_shape = map_shape_to_acl(*input->dims);
+  const auto filter_shape = map_shape_to_acl(*filter->dims);
+  const auto bias_shape = arm_compute::TensorShape(filter_shape[3]);
+  const auto output_shape = map_shape_to_acl(*output->dims);
+
+  // Quantization info
+  const auto input_qinfo = map_quantization_info_to_acl(input->quantization);
+  const auto filter_qinfo = map_quantization_info_to_acl(filter->quantization);
+  const auto output_qinfo = map_quantization_info_to_acl(output->quantization);
+  if (io_data_type != arm_compute::DataType::F32) {
+    const auto* affine_quantization =
+        reinterpret_cast<TfLiteAffineQuantization*>(
+            filter->quantization.params);
+    const int number_channel = affine_quantization->scale->size;
+    // Only asymmetric is supported
+    ACL_RETURN_ERROR_ON(number_channel != 1);
+    const double effective_output_scale =
+        static_cast<double>(input_qinfo.scale) * filter_qinfo.scale /
+        static_cast<double>(output_qinfo.scale);
+    ACL_RETURN_ERROR_ON(effective_output_scale > 1.f);
+  }
+
+  // Construct TensorInfo and set data layout to NHWC
+  arm_compute::TensorInfo input_info(input_shape, 1, io_data_type, input_qinfo);
+  arm_compute::TensorInfo filter_info(filter_shape, 1, filter_data_type,
+                                      filter_qinfo);
+  arm_compute::TensorInfo bias_info(bias_shape, 1, bias_data_type);
+  arm_compute::TensorInfo output_info(output_shape, 1, io_data_type,
+                                      output_qinfo);
+  input_info.set_data_layout(arm_compute::DataLayout::NHWC);
+  filter_info.set_data_layout(arm_compute::DataLayout::NHWC);
+  output_info.set_data_layout(arm_compute::DataLayout::NHWC);
+
+  // Calculate padding and create PadStrideInfo
+  const arm_compute::Size2D strides(params->stride_width,
+                                    params->stride_height);
+  const TfLitePadding padding_type = params->padding;
+  const auto conv_info = map_pad_stride_info_to_acl(strides, padding_type,
+                                                    input_shape, filter_shape);
+
+  // Extract activation and fuse with convolution
+  const auto activation_info = map_activation_info_to_acl(params->activation);
+  ACL_RETURN_ERROR_ON(
+      activation_info.enabled() &&
+      (arm_compute::ActivationLayerInfo::ActivationFunction::RELU !=
+           activation_info.activation() &&
+       arm_compute::ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU !=
+           activation_info.activation()));
+
+  // Extract dilation
+  const arm_compute::Size2D dilation(params->dilation_width_factor,
+                                     params->dilation_height_factor);
+  ACL_RETURN_ERROR_ON(dilation != arm_compute::Size2D(1U, 1U) &&
+                      io_data_type == arm_compute::DataType::QASYMM8);
+
+  // Validate if ACL function can run
+  arm_compute::Status s = arm_compute::NEConvolutionLayer::validate(
+      &input_info.clone()->set_is_resizable(false),
+      &filter_info.clone()->set_is_resizable(false),
+      has_bias ? &bias_info.clone()->set_is_resizable(false) : nullptr,
+      &output_info.clone()->set_is_resizable(false), conv_info,
+      arm_compute::WeightsInfo(), dilation, activation_info);
+
+  if (bool(s)) {
+    // Initialize tensors
+    _input.allocator()->init(input_info);
+    _filter.allocator()->init(filter_info);
+    _bias.allocator()->init(bias_info);
+    _output.allocator()->init(output_info);
+
+    // Configure function
+    _conv_func.configure(&_input, &_filter, has_bias ? &_bias : nullptr,
+                         &_output, conv_info, arm_compute::WeightsInfo(),
+                         dilation, activation_info);
+  }
+  _is_configured = bool(s);
+
+  return _is_configured ? kTfLiteOk : kTfLiteError;
+}
+
+TfLiteStatus ACLConv2dBackendKernel::invoke(TfLiteContext* context,
+                                            TfLiteNode* node) {
+  if (_is_configured) {
+    bool has_bias = node->inputs->size == 3;
+
+    TfLiteTensor* output = &context->tensors[node->outputs->data[0]];
+    TfLiteTensor* input = &context->tensors[node->inputs->data[0]];
+    TfLiteTensor* filter = &context->tensors[node->inputs->data[1]];
+    TfLiteTensor* bias =
+        has_bias ? &context->tensors[node->inputs->data[2]] : nullptr;
+
+    // Setup tensor memory
+    _input.allocator()->import_memory(reinterpret_cast<void*>(input->data.raw));
+    _filter.allocator()->import_memory(
+        reinterpret_cast<void*>(filter->data.raw));
+    if (has_bias) {
+      _bias.allocator()->import_memory(reinterpret_cast<void*>(bias->data.raw));
+    }
+    _output.allocator()->import_memory(
+        reinterpret_cast<void*>(output->data.raw));
+
+    // Run backend ACL function
+    _conv_func.run();
+  }
+}
+}  // namespace acl
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite

--- a/tensorflow/lite/kernels/internal/backends/acl/conv2d.h
+++ b/tensorflow/lite/kernels/internal/backends/acl/conv2d.h
@@ -1,0 +1,51 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+// This file defines a kernel abstraction API for external kernel
+// implementations.
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_CONV2D_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_CONV2D_H_
+
+#include "tensorflow/lite/kernels/internal/backends/backend_kernel.h"
+
+#include "arm_compute/runtime/NEON/functions/NEConvolutionLayer.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace acl {
+
+// Backend ACL kernel for Conv2d
+class ACLConv2dBackendKernel final : public IBackendKernel {
+ public:
+  // Inherited methods overridden:
+  void init(TfLiteContext* context, const char* buffer, size_t length) override;
+  void free(TfLiteContext* context) override;
+  TfLiteStatus prepare(TfLiteContext* context, TfLiteNode* node) override;
+  TfLiteStatus invoke(TfLiteContext* context, TfLiteNode* node) override;
+
+ private:
+  arm_compute::NEConvolutionLayer _conv_func{};
+  arm_compute::Tensor _input{};
+  arm_compute::Tensor _filter{};
+  arm_compute::Tensor _bias{};
+  arm_compute::Tensor _output{};
+  bool _is_configured{false};
+};
+
+}  // namespace acl
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_CONV2D_H_

--- a/tensorflow/lite/kernels/internal/backends/acl/depthwise_conv2d.cc
+++ b/tensorflow/lite/kernels/internal/backends/acl/depthwise_conv2d.cc
@@ -1,0 +1,176 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/backends/acl/depthwise_conv2d.h"
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/c_api_internal.h"
+#include "tensorflow/lite/kernels/internal/backends/acl/utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/tensor.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/tensor_utils.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/kernels/padding.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace acl {
+
+void ACLDepthwiseConv2dBackendKernel::init(TfLiteContext* context,
+                                           const char* buffer, size_t length) {
+  // no-op for builtin ops
+}
+
+void ACLDepthwiseConv2dBackendKernel::free(TfLiteContext* context) {
+  // no-op for builtin ops
+}
+
+TfLiteStatus ACLDepthwiseConv2dBackendKernel::prepare(TfLiteContext* context,
+                                                      TfLiteNode* node) {
+  _is_configured = false;
+
+  const auto* params =
+      reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data);
+  const bool has_bias = node->inputs->size == 3;
+
+  TfLiteTensor* output = &context->tensors[node->outputs->data[0]];
+  TfLiteTensor* input = &context->tensors[node->inputs->data[0]];
+  TfLiteTensor* filter = &context->tensors[node->inputs->data[1]];
+  TfLiteTensor* bias =
+      has_bias ? &context->tensors[node->inputs->data[2]] : nullptr;
+
+  // Data type
+  const auto io_data_type = map_datatype_to_acl(input->type);
+  const auto filter_data_type = map_datatype_to_acl(filter->type);
+  const auto bias_data_type = bias != nullptr ? map_datatype_to_acl(bias->type)
+                                              : arm_compute::DataType::UNKNOWN;
+  ACL_RETURN_ERROR_ON(io_data_type != arm_compute::DataType::F32);
+  ACL_RETURN_ERROR_ON(io_data_type != filter_data_type);
+
+  // Tensor shapes
+  const auto input_shape = map_shape_to_acl(*input->dims);
+  const auto filter_shape = map_shape_to_acl(*filter->dims);
+  const auto bias_shape = arm_compute::TensorShape(filter_shape[0]);
+  const auto output_shape = map_shape_to_acl(*output->dims);
+
+  // Quantization info
+  const auto input_qinfo = map_quantization_info_to_acl(input->quantization);
+  const auto filter_qinfo = map_quantization_info_to_acl(filter->quantization);
+  const auto output_qinfo = map_quantization_info_to_acl(output->quantization);
+  if (io_data_type != arm_compute::DataType::F32) {
+    const auto* affine_quantization =
+        reinterpret_cast<TfLiteAffineQuantization*>(
+            filter->quantization.params);
+    const int number_channel = affine_quantization->scale->size;
+    // Only asymmetric is supported
+    ACL_RETURN_ERROR_ON(number_channel != 1);
+    const double effective_output_scale =
+        static_cast<double>(input_qinfo.scale) * filter_qinfo.scale /
+        static_cast<double>(output_qinfo.scale);
+    ACL_RETURN_ERROR_ON(effective_output_scale > 1.f);
+  }
+
+  // Construct TensorInfo and set data layout to NHWC
+  arm_compute::TensorInfo input_info(input_shape, 1, io_data_type, input_qinfo);
+  arm_compute::TensorInfo filter_info(filter_shape, 1, filter_data_type,
+                                      filter_qinfo);
+  arm_compute::TensorInfo bias_info(bias_shape, 1, bias_data_type);
+  arm_compute::TensorInfo output_info(output_shape, 1, io_data_type,
+                                      output_qinfo);
+  input_info.set_data_layout(arm_compute::DataLayout::NHWC);
+  filter_info.set_data_layout(arm_compute::DataLayout::NHWC);
+  output_info.set_data_layout(arm_compute::DataLayout::NHWC);
+
+  // Calculate padding and create PadStrideInfo
+  const arm_compute::Size2D strides(params->stride_width,
+                                    params->stride_height);
+  const TfLitePadding padding_type = params->padding;
+  const auto conv_info = map_pad_stride_info_to_acl(strides, padding_type,
+                                                    input_shape, filter_shape);
+
+  // Extract activation and fuse with convolution
+  const auto activation_info = map_activation_info_to_acl(params->activation);
+  ACL_RETURN_ERROR_ON(
+      activation_info.enabled() &&
+      (arm_compute::ActivationLayerInfo::ActivationFunction::RELU !=
+           activation_info.activation() &&
+       arm_compute::ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU !=
+           activation_info.activation()));
+
+  // Extract dilation
+  const arm_compute::Size2D dilation(params->dilation_width_factor,
+                                     params->dilation_height_factor);
+  ACL_RETURN_ERROR_ON(dilation != arm_compute::Size2D(1U, 1U));
+
+  // Depth multiplier
+  const int depth_multiplier = params->depth_multiplier;
+  ACL_RETURN_ERROR_ON(depth_multiplier != 1);
+
+  // Validate if ACL function can run
+  arm_compute::Status s = arm_compute::NEDepthwiseConvolutionLayer3x3::validate(
+      &input_info.clone()->set_is_resizable(false),
+      &filter_info.clone()->set_is_resizable(false),
+      has_bias ? &bias_info.clone()->set_is_resizable(false) : nullptr,
+      &output_info.clone()->set_is_resizable(false), conv_info,
+      depth_multiplier, activation_info, dilation);
+
+  if (bool(s)) {
+    // Initialize tensors
+    _input.allocator()->init(input_info);
+    _filter.allocator()->init(filter_info);
+    _bias.allocator()->init(bias_info);
+    _output.allocator()->init(output_info);
+
+    // Configure function
+    _conv_func.configure(&_input, &_filter, has_bias ? &_bias : nullptr,
+                         &_output, conv_info, depth_multiplier, activation_info,
+                         dilation);
+  }
+  _is_configured = bool(s);
+
+  return _is_configured ? kTfLiteOk : kTfLiteError;
+}
+
+TfLiteStatus ACLDepthwiseConv2dBackendKernel::invoke(TfLiteContext* context,
+                                                     TfLiteNode* node) {
+  if (_is_configured) {
+    bool has_bias = node->inputs->size == 3;
+
+    TfLiteTensor* output = &context->tensors[node->outputs->data[0]];
+    TfLiteTensor* input = &context->tensors[node->inputs->data[0]];
+    TfLiteTensor* filter = &context->tensors[node->inputs->data[1]];
+    TfLiteTensor* bias =
+        has_bias ? &context->tensors[node->inputs->data[2]] : nullptr;
+
+    // Setup tensor memory
+    _input.allocator()->import_memory(reinterpret_cast<void*>(input->data.raw));
+    _filter.allocator()->import_memory(
+        reinterpret_cast<void*>(filter->data.raw));
+    if (has_bias) {
+      _bias.allocator()->import_memory(reinterpret_cast<void*>(bias->data.raw));
+    }
+    _output.allocator()->import_memory(
+        reinterpret_cast<void*>(output->data.raw));
+
+    // Run backend ACL function
+    _conv_func.run();
+  }
+}
+}  // namespace acl
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite

--- a/tensorflow/lite/kernels/internal/backends/acl/depthwise_conv2d.h
+++ b/tensorflow/lite/kernels/internal/backends/acl/depthwise_conv2d.h
@@ -1,0 +1,51 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+// This file defines a kernel abstraction API for external kernel
+// implementations.
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_DEPTHWISE_CONV2D_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_DEPTHWISE_CONV2D_H_
+
+#include "tensorflow/lite/kernels/internal/backends/backend_kernel.h"
+
+#include "arm_compute/runtime/NEON/functions/NEDepthwiseConvolutionLayer.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace acl {
+
+// Backend ACL kernel for depthwise convolution
+class ACLDepthwiseConv2dBackendKernel final : public IBackendKernel {
+ public:
+  // Inherited methods overridden:
+  void init(TfLiteContext* context, const char* buffer, size_t length) override;
+  void free(TfLiteContext* context) override;
+  TfLiteStatus prepare(TfLiteContext* context, TfLiteNode* node) override;
+  TfLiteStatus invoke(TfLiteContext* context, TfLiteNode* node) override;
+
+ private:
+  arm_compute::NEDepthwiseConvolutionLayer3x3 _conv_func{};
+  arm_compute::Tensor _input{};
+  arm_compute::Tensor _filter{};
+  arm_compute::Tensor _bias{};
+  arm_compute::Tensor _output{};
+  bool _is_configured{false};
+};
+
+}  // namespace acl
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_DEPTHWISE_CONV2D_H_

--- a/tensorflow/lite/kernels/internal/backends/acl/utils.cc
+++ b/tensorflow/lite/kernels/internal/backends/acl/utils.cc
@@ -1,0 +1,119 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/backends/acl/utils.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace acl {
+
+arm_compute::DataType map_datatype_to_acl(TfLiteType type) {
+  switch (type) {
+    case kTfLiteFloat32:
+      return arm_compute::DataType::F32;
+    case kTfLiteInt32:
+      return arm_compute::DataType::S32;
+    case kTfLiteUInt8:
+      return arm_compute::DataType::QASYMM8;
+    default:
+      return arm_compute::DataType::UNKNOWN;
+  }
+}
+
+arm_compute::TensorShape map_shape_to_acl(const TfLiteIntArray& dims) {
+  arm_compute::TensorShape shape;
+
+  const int num_dimensions = dims.size;
+  for (int i = num_dimensions - 1; i >= 0; --i) {
+    shape.set(num_dimensions - i - 1, dims.data[i]);
+  }
+  return shape;
+}
+
+arm_compute::ActivationLayerInfo map_activation_info_to_acl(
+    TfLiteFusedActivation activation) {
+  switch (activation) {
+    case kTfLiteActRelu:
+      return arm_compute::ActivationLayerInfo(
+          arm_compute::ActivationLayerInfo::ActivationFunction::RELU);
+    case kTfLiteActRelu1:
+      return arm_compute::ActivationLayerInfo(
+          arm_compute::ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU,
+          1.f, 0.f);
+    case kTfLiteActRelu6:
+      return arm_compute::ActivationLayerInfo(
+          arm_compute::ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU,
+          6.f, 0.f);
+    case kTfLiteActTanh:
+      return arm_compute::ActivationLayerInfo(
+          arm_compute::ActivationLayerInfo::ActivationFunction::TANH, 1.f, 1.f);
+    case kTfLiteActSigmoid:
+      return arm_compute::ActivationLayerInfo(
+          arm_compute::ActivationLayerInfo::ActivationFunction::LOGISTIC);
+    default:
+      return arm_compute::ActivationLayerInfo();
+  }
+}
+
+arm_compute::QuantizationInfo map_quantization_info_to_acl(
+    const TfLiteQuantization& quantization) {
+  arm_compute::QuantizationInfo qinfo;
+  if (quantization.type == kTfLiteAffineQuantization) {
+    const auto* affine_quantization =
+        reinterpret_cast<TfLiteAffineQuantization*>(quantization.params);
+    float scale = affine_quantization->scale->data[0];
+    int zero_point = affine_quantization->zero_point->data[0];
+    qinfo = arm_compute::QuantizationInfo(scale, zero_point);
+  }
+
+  return qinfo;
+}
+
+arm_compute::PadStrideInfo map_pad_stride_info_to_acl(
+    const arm_compute::Size2D& strides, TfLitePadding padding,
+    const arm_compute::TensorShape& input_shape,
+    const arm_compute::TensorShape& weights_shape) {
+  const int stride_w = strides.width;
+  const int stride_h = strides.height;
+
+  const int width = input_shape[1];
+  const int height = input_shape[2];
+  const int filter_width = weights_shape[1];
+  const int filter_height = weights_shape[2];
+
+  arm_compute::PadStrideInfo conv_info(stride_w, stride_h, 0, 0);
+  if (padding == TfLitePadding::kTfLitePaddingSame) {
+    const int out_width = std::ceil(float(width) / float(stride_w));
+    const int out_height = std::ceil(float(height) / float(stride_h));
+    const int pad_width = ((out_width - 1) * stride_w + filter_width - width);
+    const int pad_height =
+        ((out_height - 1) * stride_h + filter_height - height);
+    const int same_pad_left = pad_width / 2;
+    const int same_pad_top = pad_height / 2;
+    const int same_pad_right = pad_width - same_pad_left;
+    const int same_pad_bottom = pad_height - same_pad_top;
+
+    conv_info = arm_compute::PadStrideInfo(
+        stride_w, stride_h, same_pad_left, same_pad_right, same_pad_top,
+        same_pad_bottom, arm_compute::DimensionRoundingType::FLOOR);
+  }
+
+  return conv_info;
+}
+
+}  // namespace acl
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite

--- a/tensorflow/lite/kernels/internal/backends/acl/utils.h
+++ b/tensorflow/lite/kernels/internal/backends/acl/utils.h
@@ -1,0 +1,59 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+// Utility functions used for interpolarity between TFLite and ACL
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_UTILS_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_UTILS_H_
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/c_api_internal.h"
+
+#include "arm_compute/core/Types.h"
+
+#define ACL_RETURN_ERROR_ON(cond) \
+  do {                            \
+    if ((cond)) {                 \
+      return kTfLiteError;        \
+    }                             \
+  } while (0)
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace acl {
+
+// Maps tflite data type to ACL
+arm_compute::DataType map_datatype_to_acl(TfLiteType type);
+
+// Maps tflite tensor dimensions to ACL
+arm_compute::TensorShape map_shape_to_acl(const TfLiteIntArray &dims);
+
+// Maps tflite activation type to ACL
+arm_compute::ActivationLayerInfo map_activation_info_to_acl(
+    TfLiteFusedActivation activation);
+
+// Maps tflite quantization information to ACL
+arm_compute::QuantizationInfo map_quantization_info_to_acl(
+    const TfLiteQuantization &quantization);
+
+// Maps tflite pad stride info to ACL
+arm_compute::PadStrideInfo map_pad_stride_info_to_acl(
+    const arm_compute::Size2D &strides, TfLitePadding padding,
+    const arm_compute::TensorShape &input_shape,
+    const arm_compute::TensorShape &weights_shape);
+}  // namespace acl
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_ACL_UTILS_H_

--- a/tensorflow/lite/kernels/internal/backends/backend_context.cc
+++ b/tensorflow/lite/kernels/internal/backends/backend_context.cc
@@ -1,0 +1,79 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/backends/backend_context.h"
+
+// Supported backends
+#include "tensorflow/lite/kernels/internal/backends/acl/backend.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+
+KernelBackendContext::KernelBackendContext() : _backends() {
+  _backends.emplace("acl", std::unique_ptr<IBackend>(new acl::ACLBackend()));
+}
+
+KernelBackendContext::~KernelBackendContext() {}
+
+IBackend *KernelBackendContext::backend(std::string backend) {
+  if (_backends.count(backend)) {
+    return _backends[backend].get();
+  }
+  return nullptr;
+}
+
+std::unique_ptr<IBackendKernel> KernelBackendContext::backend_kernel(
+    std::string backend, TfLiteBuiltinOperator op) {
+  if (_backends.count(backend) && _backends[backend] != nullptr) {
+    return _backends[backend]->create_backend_kernel(op);
+  }
+  return nullptr;
+}
+
+std::unique_ptr<IBackendKernel> KernelBackendContext::backend_kernel(
+    TfLiteBuiltinOperator op) {
+  std::unique_ptr<IBackendKernel> kernel = nullptr;
+
+  auto backend_it = _backends.cbegin();
+  while (backend_it != _backends.cend() && kernel == nullptr) {
+    IBackend *backend = backend_it->second.get();
+    if (backend != nullptr) {
+      kernel = backend->create_backend_kernel(op);
+    }
+    ++backend_it;
+  }
+
+  return kernel;
+}
+
+void KernelBackendContext::set_max_num_threads(std::string backend,
+                                               int max_num_threads) {
+  if (_backends.count(backend) && _backends[backend] != nullptr) {
+    _backends[backend]->set_max_num_threads(max_num_threads);
+  }
+}
+
+void KernelBackendContext::set_max_num_threads_all(int max_num_threads) {
+  for (auto &backend_pair : _backends) {
+    IBackend *backend = backend_pair.second.get();
+    if (backend != nullptr) {
+      backend->set_max_num_threads(max_num_threads);
+    }
+  }
+}
+
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite

--- a/tensorflow/lite/kernels/internal/backends/backend_context.h
+++ b/tensorflow/lite/kernels/internal/backends/backend_context.h
@@ -1,0 +1,64 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_CONTEXT_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_CONTEXT_H_
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "tensorflow/lite/kernels/internal/backends/backend_interface.h"
+#include "tensorflow/lite/kernels/internal/backends/backend_kernel.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+
+// Context tracking all the external backends
+class KernelBackendContext final {
+ public:
+  // Constructor
+  KernelBackendContext();
+  // Destructor
+  ~KernelBackendContext();
+
+  // Backend accessor given the backend name
+  //
+  // Return pointer to the backend on success else nullptr
+  IBackend* backend(std::string backend);
+  // Extract a backend kernel object of a given backend
+  //
+  // Return a backend kernel on success else nullptr
+  std::unique_ptr<IBackendKernel> backend_kernel(std::string backend,
+                                                 TfLiteBuiltinOperator op);
+  // Extract a backend kernel object of the first backend that supports it
+  //
+  // Return a backend kernel on success else nullptr
+  std::unique_ptr<IBackendKernel> backend_kernel(TfLiteBuiltinOperator op);
+  // Set number of threads on a given backend
+  void set_max_num_threads(std::string backend, int max_num_threads);
+  // Set number of threads on all backends
+  void set_max_num_threads_all(int max_num_threads);
+
+ private:
+  std::map<std::string, std::unique_ptr<IBackend>> _backends;
+
+  KernelBackendContext(const KernelBackendContext&) = delete;
+};
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_CONTEXT_H_

--- a/tensorflow/lite/kernels/internal/backends/backend_interface.h
+++ b/tensorflow/lite/kernels/internal/backends/backend_interface.h
@@ -1,0 +1,46 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_INTERFACE_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_INTERFACE_H_
+
+#include <memory>
+
+#include "tensorflow/lite/builtin_ops.h"
+#include "tensorflow/lite/kernels/internal/backends/backend_kernel.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+
+// Backend interface
+class IBackend {
+ public:
+  // Default virtual destructor
+  virtual ~IBackend() = default;
+  // Check if backend has a kernel implementation for a given builtin
+  virtual bool is_kernel_supported(TfLiteBuiltinOperator op) = 0;
+  // Create a kernel wrapper for a given builtin
+  //
+  // Returns nullptr if the builtin is not supported
+  virtual std::unique_ptr<IBackendKernel> create_backend_kernel(
+      TfLiteBuiltinOperator op) = 0;
+  // Set maximum number of threads
+  virtual void set_max_num_threads(int max_num_threads) = 0;
+};
+
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_INTERFACE_H_

--- a/tensorflow/lite/kernels/internal/backends/backend_kernel.h
+++ b/tensorflow/lite/kernels/internal/backends/backend_kernel.h
@@ -1,0 +1,61 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+// This file defines a kernel abstraction API for external kernel
+// implementations.
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_KERNEL_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_KERNEL_H_
+
+#include "tensorflow/lite/c/c_api_internal.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+
+// Backend kernel interface
+class IBackendKernel {
+ public:
+  // Default virtual destructor
+  virtual ~IBackendKernel() = default;
+  // Initializes the backend operation from serialized data.
+  // If a built-in op:
+  //   `buffer` is the op's params data (TfLiteLSTMParams*).
+  //   `length` is zero.
+  // If custom op:
+  //   `buffer` is the op's `custom_options`.
+  //   `length` is the size of the buffer.
+  //
+  // All required data are stored internally to the object to encapsulate
+  // backend resource handling.
+  virtual void init(TfLiteContext* context, const char* buffer,
+                    size_t length) = 0;
+  // Free custom resources
+  // Note: This could be handled by the object destructor, adding this for
+  // alignment.
+  virtual void free(TfLiteContext* context) = 0;
+  // Prepare is called when the inputs this node depends on have been resized.
+  // context->ResizeTensor() can be called to request output tensors to be
+  // resized. Moreover, prepare is responsible for validating if the backend
+  // kernel can execute the given workload.
+  //
+  // Returns kTfLiteOk on success.
+  virtual TfLiteStatus prepare(TfLiteContext* context, TfLiteNode* node) = 0;
+  // Execute the node (should read node->inputs and output to node->outputs).
+  // Returns kTfLiteOk on success.
+  virtual TfLiteStatus invoke(TfLiteContext* context, TfLiteNode* node) = 0;
+};
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_KERNEL_H_

--- a/tensorflow/lite/kernels/internal/backends/backend_support.cc
+++ b/tensorflow/lite/kernels/internal/backends/backend_support.cc
@@ -1,0 +1,89 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/backends/backend_support.h"
+
+#include <memory>
+
+#include "tensorflow/lite/kernels/op_macros.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+namespace {
+
+struct RefCountedKernelBackendContext : public TfLiteExternalContext {
+  std::unique_ptr<KernelBackendContext> backend_context;
+  int num_references = 0;
+};
+
+RefCountedKernelBackendContext* GetKernelBackendContext(
+    TfLiteContext* context) {
+  return reinterpret_cast<RefCountedKernelBackendContext*>(
+      context->GetExternalContext(context, kTfLiteKernelBackendContext));
+}
+
+TfLiteStatus Refresh(TfLiteContext* context) {
+  auto* ptr = GetKernelBackendContext(context);
+  if (ptr != nullptr) {
+    ptr->backend_context->set_max_num_threads_all(
+        context->recommended_num_threads);
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+void IncrementUsageCounter(TfLiteContext* context) {
+  auto* ptr = GetKernelBackendContext(context);
+  if (ptr == nullptr) {
+    ptr = new RefCountedKernelBackendContext;
+    ptr->type = kTfLiteKernelBackendContext;
+    ptr->Refresh = Refresh;
+    ptr->backend_context.reset(new KernelBackendContext());
+    if (context->recommended_num_threads != -1) {
+      ptr->backend_context->set_max_num_threads_all(
+          context->recommended_num_threads);
+    }
+    ptr->num_references = 0;
+    context->SetExternalContext(context, kTfLiteKernelBackendContext, ptr);
+  }
+  ptr->num_references++;
+}
+
+void DecrementUsageCounter(TfLiteContext* context) {
+  auto* ptr = GetKernelBackendContext(context);
+  if (ptr == nullptr) {
+    TF_LITE_FATAL(
+        "Call to DecrementUsageCounter() not preceded by "
+        "IncrementUsageCounter()");
+  }
+  if (--ptr->num_references == 0) {
+    delete ptr;
+    context->SetExternalContext(context, kTfLiteKernelBackendContext, nullptr);
+  }
+}
+
+KernelBackendContext* GetFromContext(TfLiteContext* context) {
+  auto* ptr = GetKernelBackendContext(context);
+  if (ptr == nullptr) {
+    TF_LITE_FATAL(
+        "Call to GetFromContext() not preceded by IncrementUsageCounter()");
+  }
+  return ptr->backend_context.get();
+}
+
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite

--- a/tensorflow/lite/kernels/internal/backends/backend_support.h
+++ b/tensorflow/lite/kernels/internal/backends/backend_support.h
@@ -1,0 +1,54 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_SUPPORT_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_SUPPORT_H_
+
+#include "tensorflow/lite/c/c_api_internal.h"
+#include "tensorflow/lite/kernels/internal/backends/backend_context.h"
+
+namespace tflite {
+namespace internal {
+namespace backends {
+// Returns the BackendKernelContext stored in 'context', allowing multiple ops
+// to share a single object, as long as they share a TfLiteContext. The caller
+// must ensure that this is called between IncrementUsageCounter() and
+// DecrementUsageCounter(). For example, in the implementation of an op:
+//   void* Init(TfLiteContext* context, const char*, size_t) {
+//     tflite::ops::backends::IncrementUsageCounter(context);
+//     return nullptr;
+//   }
+//   void Free(TfLiteContext* context, void*) {
+//     tflite::ops::backends::DecrementUsageCounter(context);
+//   }
+//   TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+//     auto* backends_context =
+//     tflite::ops::backends::::GetFromContext(context);
+//   }
+KernelBackendContext* GetFromContext(TfLiteContext* context);
+
+// Let the framework know that the BackendKernelContext stored in 'context' will
+// be used by an op. If necessary a new BackendKernelContext is created and
+// placed in 'context'.
+void IncrementUsageCounter(TfLiteContext* context);
+
+// Let the framework know that the op stopped using the BackendKernelContext
+// stored in 'context'. If there are no more usages the BackendKernelContext
+// will be deleted.
+void DecrementUsageCounter(TfLiteContext* context);
+
+}  // namespace backends
+}  // namespace internal
+}  // namespace tflite
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_BACKENDS_BACKEND_SUPPORT_H_

--- a/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h
+++ b/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h
@@ -5780,10 +5780,10 @@ struct WorkspacePrefetchWrite<
     for (; i < (size - 15); i += 64) {
       int8* ptr = workspace + i;
       asm volatile("prfm pstl1keep, [%[ptr]]\n" ::[ptr] "r"(ptr) :);
-      vst1_lane_u32(reinterpret_cast<uint32_t*>(ptr), fill_data_vec, 0);
+      vst1_lane_u32(reinterpret_cast<uint32_t*>(ptr), vreinterpret_u32_s8(fill_data_vec), 0);
     }
     vst1_lane_u32(reinterpret_cast<uint32_t*>(workspace + size - 4),
-                  fill_data_vec, 0);
+                  vreinterpret_u32_s8(fill_data_vec), 0);
   }
 };
 #endif  // USE_NEON &&__aarch64__

--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -39,6 +39,8 @@ INCLUDES := \
 -I$(MAKEFILE_DIR)/downloads/neon_2_sse \
 -I$(MAKEFILE_DIR)/downloads/farmhash/src \
 -I$(MAKEFILE_DIR)/downloads/flatbuffers/include \
+-I$(MAKEFILE_DIR)/downloads/ComputeLibrary/ \
+-I$(MAKEFILE_DIR)/downloads/ComputeLibrary/include \
 -I$(OBJDIR)
 # This is at the end so any globally-installed frameworks like protobuf don't
 # override local versions in the source tree.
@@ -116,6 +118,8 @@ ifneq ($(BUILD_TYPE),micro)
 CORE_CC_ALL_SRCS += \
 $(wildcard tensorflow/lite/kernels/*.cc) \
 $(wildcard tensorflow/lite/kernels/internal/*.cc) \
+$(wildcard tensorflow/lite/kernels/internal/backends/*.cc) \
+$(wildcard tensorflow/lite/kernels/internal/backends/*/*.cc) \
 $(wildcard tensorflow/lite/kernels/internal/optimized/*.cc) \
 $(wildcard tensorflow/lite/kernels/internal/reference/*.cc) \
 $(PROFILER_SRCS) \
@@ -149,7 +153,7 @@ else
 	CORE_CC_EXCLUDE_SRCS += tensorflow/lite/mmap_allocation_disabled.cc
 endif
 
-BUILD_WITH_NNAPI=true
+BUILD_WITH_NNAPI=$(USE_NNAPI)
 ifeq ($(BUILD_TYPE),micro)
 	BUILD_WITH_NNAPI=false
 endif
@@ -178,6 +182,12 @@ else
 	CORE_CC_EXCLUDE_SRCS += tensorflow/lite/minimal_logging_ios.cc
 endif
 
+ifeq ($(USE_ACL),true)
+	CORE_CC_EXCLUDE_SRCS += tensorflow/lite/kernels/internal/backends/acl/backend_disabled.cc
+else
+	CORE_CC_EXCLUDE_SRCS += $(wildcard tensorflow/lite/kernels/internal/backends/acl/*.cc)
+	CORE_CC_EXCLUDE_SRCS := $(filter-out tensorflow/lite/kernels/internal/backends/acl/backend_disabled.cc, $(CORE_CC_EXCLUDE_SRCS))
+endif
 
 # Filter out all the excluded files.
 TF_LITE_CC_SRCS := $(filter-out $(CORE_CC_EXCLUDE_SRCS), $(CORE_CC_ALL_SRCS))
@@ -195,7 +205,16 @@ BENCHMARK_ALL_SRCS := $(TF_LITE_CC_SRCS) \
 BENCHMARK_SRCS := $(filter-out \
 	$(wildcard $(BENCHMARK_SRCS_DIR)/*_test.cc) \
 	$(BENCHMARK_SRCS_DIR)/benchmark_plus_flex_main.cc, \
-    $(BENCHMARK_ALL_SRCS))
+	$(BENCHMARK_ALL_SRCS))
+
+# Label image sources
+LABEL_IMAGE_SRCS_DIR := tensorflow/lite/examples/label_image
+LABEL_IMAGE_ALL_SRCS := \
+	$(wildcard $(LABEL_IMAGE_SRCS_DIR)/*.cc) \
+
+LABEL_IMAGE_SRCS := $(filter-out \
+	$(wildcard $(LABEL_IMAGE_SRCS_DIR)/*_test.cc), \
+	$(LABEL_IMAGE_ALL_SRCS))
 
 # These target-specific makefiles should modify or replace options like
 # CXXFLAGS or LIBS to work for a specific targetted architecture. All logic
@@ -203,8 +222,20 @@ BENCHMARK_SRCS := $(filter-out \
 # keep this main makefile focused on the sources and dependencies.
 include $(wildcard $(MAKEFILE_DIR)/targets/*_makefile.inc)
 
+# ACL dependencies
+ifeq ($(USE_ACL), true)
+	LDFLAGS += \
+		-L$(MAKEFILE_DIR)/downloads/ComputeLibrary/build
+
+	LIBS += \
+		-static -larm_compute-static \
+		-static -larm_compute_core-static
+endif
+
+
 ALL_SRCS := \
 	$(MINIMAL_SRCS) \
+	$(LABEL_IMAGE_SRCS) \
 	$(PROFILER_SRCS) \
 	$(PROFILER_SUMMARIZER_SRCS) \
 	$(TF_LITE_CC_SRCS) \
@@ -220,6 +251,7 @@ LIBDIR := $(GENDIR)lib/
 LIB_PATH := $(LIBDIR)$(LIB_NAME)
 BENCHMARK_LIB := $(LIBDIR)$(BENCHMARK_LIB_NAME)
 BENCHMARK_BINARY := $(BINDIR)$(BENCHMARK_BINARY_NAME)
+LABEL_IMAGE_BINARY := $(BINDIR)label_image
 MINIMAL_BINARY := $(BINDIR)minimal
 
 CXX := $(CC_PREFIX)${TARGET_TOOLCHAIN_PREFIX}g++
@@ -228,6 +260,9 @@ AR := $(CC_PREFIX)${TARGET_TOOLCHAIN_PREFIX}ar
 
 MINIMAL_OBJS := $(addprefix $(OBJDIR), \
 $(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(MINIMAL_SRCS))))
+
+LABEL_IMAGE_OBJS := $(addprefix $(OBJDIR), \
+$(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(LABEL_IMAGE_SRCS))))
 
 LIB_OBJS := $(addprefix $(OBJDIR), \
 $(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(TF_LITE_CC_SRCS))))
@@ -245,7 +280,7 @@ $(OBJDIR)%.o: %.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 # The target that's compiled if there's no command-line arguments.
-all: $(LIB_PATH)  $(MINIMAL_BINARY) $(BENCHMARK_BINARY)
+all: $(LIB_PATH)  $(MINIMAL_BINARY) $(LABEL_IMAGE_BINARY) $(BENCHMARK_BINARY)
 
 # The target that's compiled for micro-controllers
 micro: $(LIB_PATH)
@@ -268,6 +303,14 @@ $(MINIMAL_BINARY): $(MINIMAL_OBJS) $(LIB_PATH)
 	$(LIBFLAGS) $(LIB_PATH) $(LDFLAGS) $(LIBS)
 
 minimal: $(MINIMAL_BINARY)
+
+$(LABEL_IMAGE_BINARY): $(LABEL_IMAGE_OBJS) $(LIB_PATH)
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) \
+	-o $(LABEL_IMAGE_BINARY) $(LABEL_IMAGE_OBJS) \
+	$(LIBFLAGS) $(LIB_PATH) $(LDFLAGS) $(LIBS)
+
+label_image: $(LABEL_IMAGE_BINARY)
 
 $(BENCHMARK_LIB) : $(LIB_PATH) $(BENCHMARK_OBJS)
 	@mkdir -p $(dir $@)

--- a/tensorflow/lite/tools/make/build_aarch64_lib.sh
+++ b/tensorflow/lite/tools/make/build_aarch64_lib.sh
@@ -19,4 +19,4 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/../../../.."
 
-CC_PREFIX=aarch64-linux-gnu- make -j 3 -f tensorflow/lite/tools/make/Makefile TARGET=aarch64 TARGET_ARCH=armv8-a
+CC_PREFIX=aarch64-linux-gnu- make -j 3 -f tensorflow/lite/tools/make/Makefile TARGET=aarch64 TARGET_ARCH=armv8-a $@

--- a/tensorflow/lite/tools/make/targets/aarch64_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/aarch64_makefile.inc
@@ -26,7 +26,7 @@ ifeq ($(TARGET),aarch64)
        
   LIBS := \
     -lstdc++ \
-    -lpthread \
+    -Wl,--whole-archive -lpthread -Wl,--no-whole-archive \
     -lm \
     -ldl
 

--- a/third_party/acl/BUILD
+++ b/third_party/acl/BUILD
@@ -1,0 +1,1 @@
+# This empty BUILD file is required to make Bazel treat this directory as a package.

--- a/third_party/acl/BUILD.bazel
+++ b/third_party/acl/BUILD.bazel
@@ -1,0 +1,3 @@
+package(
+    default_visibility = ["//visibility:public"],
+)

--- a/third_party/acl/build_defs.bzl
+++ b/third_party/acl/build_defs.bzl
@@ -1,0 +1,11 @@
+"""Build configurations for Arm Compute Library."""
+
+def clean_dep(dep):
+    return str(Label(dep))
+
+def if_acl(if_true, if_false = []):
+    """select()'ing on whether we're building with Arm Compute Library support."""
+    return select({
+        clean_dep("//tensorflow:with_acl_support"): if_true,
+        "//conditions:default": if_false,
+    })

--- a/third_party/acl/workspace.bzl
+++ b/third_party/acl/workspace.bzl
@@ -1,0 +1,14 @@
+"""Loads the Arm Compute Library library, used by TF Lite."""
+
+load("//third_party:repo.bzl", "third_party_http_archive")
+
+def repo():
+    third_party_http_archive(
+        name = "acl",
+        strip_prefix = "ComputeLibrary-refs_heads_branches_arm_compute_19_05",
+        sha256 = "c520b7887487ff4179efb0f63c10ac95def9dbf2",
+        urls = [
+            "https://git.mlplatform.org/ml/ComputeLibrary.git/snapshot/ComputeLibrary-refs/heads/branches/arm_compute_19_05.tar.gz",
+        ],
+        build_file = "//third_party/acl:BUILD.bazel",
+    )


### PR DESCRIPTION
Adds interfaces to offload kernels to Arm Compute Library.
This is a minimal integration effort and further steps are needed.
Bazel dependency is still not in place, thus the makefile system can be used for testing.
More details can be found in README.md file under the acl backend.