### PR TITLE
Fix ops_testutilcc for GPU tests

### DIFF
--- a/tensorflow/core/kernels/ops_testutil.cc
+++ b/tensorflow/core/kernels/ops_testutil.cc
@@ -53,7 +53,7 @@ Tensor* OpsTestBase::GetOutput(int output_index) {
           new Tensor(allocator(), output->dtype(), output->shape());
       auto src = output->tensor_data();
       auto dst = managed_output->tensor_data();
-      context_->eigen_gpu_device().memcpy(const_cast<char*>(dst.data()),
+      context_->eigen_gpu_device().memcpyDeviceToHost(const_cast<char*>(dst.data()),
                                           src.data(), src.size());
       context_->eigen_gpu_device().synchronize();
       managed_outputs_[output_index] = managed_output;


### PR DESCRIPTION
This pr modifies ops_testutil.cc to copy the device tensor to host for test comparisons in GPU tests.