### PR TITLE
build: install TensorRT directly in dockerfiles

### DIFF
--- a/tensorflow/tools/dockerfiles/partials/ubuntu/devel-nvidia.partial.Dockerfile
+++ b/tensorflow/tools/dockerfiles/partials/ubuntu/devel-nvidia.partial.Dockerfile
@@ -38,14 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     find /usr/local/cuda-${CUDA}/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete && \
     rm /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libcudnn_static_v7.a
 
-RUN [[ "${ARCH}" = "ppc64le" ]] || { apt-get update && \
-        apt-get install nvinfer-runtime-trt-repo-ubuntu1804-5.0.2-ga-cuda${CUDA} \
-        && apt-get update \
-        && apt-get install -y --no-install-recommends \
-            libnvinfer5=5.0.2-1+cuda${CUDA} \
-            libnvinfer-dev=5.0.2-1+cuda${CUDA} \
-        && apt-get clean \
-        && rm -rf /var/lib/apt/lists/*; }
+RUN [[ "${ARCH}" = "ppc64le" ]] || { apt-get install -y --no-install-recommends libnvinfer5=5.0.2-1+cuda${CUDA} libnvinfer-dev=5.0.2-1+cuda${CUDA} }
 
 # Configure the build for our CUDA configuration.
 ENV CI_BUILD_PYTHON python

--- a/tensorflow/tools/dockerfiles/partials/ubuntu/nvidia.partial.Dockerfile
+++ b/tensorflow/tools/dockerfiles/partials/ubuntu/nvidia.partial.Dockerfile
@@ -27,12 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         software-properties-common \
         unzip
 
-RUN [ ${ARCH} = ppc64le ] || (apt-get update && \
-        apt-get install nvinfer-runtime-trt-repo-ubuntu1804-5.0.2-ga-cuda${CUDA} \
-        && apt-get update \
-        && apt-get install -y --no-install-recommends libnvinfer5=5.0.2-1+cuda${CUDA} \
-        && apt-get clean \
-        && rm -rf /var/lib/apt/lists/*)
+RUN [ ${ARCH} = ppc64le ] || { apt-get install -y --no-install-recommends libnvinfer5=5.0.2-1+cuda${CUDA} }
+
 
 # For CUDA profiling, TensorFlow requires CUPTI.
 ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH


### PR DESCRIPTION
@angersson I see TRT available in [https://developer.download.nvidia.cn/compute/machine-learning/repos/ubuntu1804/x86_64/](https://developer.download.nvidia.cn/compute/machine-learning/repos/ubuntu1804/x86_64/) so there is no need to install a local repo.

Unfortunately, the case is not true for ppc64le. Ping @tjakob to double-check.