### PR TITLE
[LITE] Fix aarch64 build error

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h
+++ b/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h
@@ -5775,7 +5775,7 @@ struct WorkspacePrefetchWrite<
     DepthwiseConvImplementation::kUseNeon3x3DotProduct> {
   static void __attribute__((noinline))
   Run(int8 fill_data, int size, int8* workspace) {
-    const int8x8_t fill_data_vec = vdup_n_s8(fill_data);
+    const uint32x2_t fill_data_vec = vdup_n_u32(fill_data);
     int i = 0;
     for (; i < (size - 15); i += 64) {
       int8* ptr = workspace + i;


### PR DESCRIPTION
I was building TF Lite for ARM64 board and encountered this error. Please review the fix.
```
In file included from ./tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8.h:22:0,
                 from tensorflow/lite/kernels/depthwise_conv.cc:29:
./tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h: In static member function ‘static void tflite::optimized_ops::depthwise_conv::WorkspacePrefetchWrite<(tflite::DepthwiseConvImplementation)3>::Run(int8, int, int8*)’:
./tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h:5783:71: note: use -flax-vector-conversions to permit conversions between vectors with differing element types or numbers of subparts
       vst1_lane_u32(reinterpret_cast<uint32_t*>(ptr), fill_data_vec, 0);
                                                                       ^
./tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h:5783:71: error: cannot convert ‘const int8x8_t {aka const __vector(8) signed char}’ to ‘uint32x2_t {aka __vector(2) unsigned int}’ for argument ‘2’ to ‘void vst1_lane_u32(uint32_t*, uint32x2_t, int)’
./tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8_3x3_filter.h:5786:35: error: cannot convert ‘const int8x8_t {aka const __vector(8) signed char}’ to ‘uint32x2_t {aka __vector(2) unsigned int}’ for argument ‘2’ to ‘void vst1_lane_u32(uint32_t*, uint32x2_t, int)’
                   fill_data_vec, 0);
                                   ^
tensorflow/lite/tools/make/Makefile:225: recipe for target '/home/siju/workspace/tensorflow-1/tensorflow/lite/tools/make/gen/aarch64_armv8-a/obj/tensorflow/lite/kernels/depthwise_conv.o' failed
make: *** [/home/siju/workspace/tensorflow-1/tensorflow/lite/tools/make/gen/aarch64_armv8-a/obj/tensorflow/lite/kernels/depthwise_conv.o] Error 1
````