### PR TITLE
[Intel Mkl] Fix for Mkl builds in Ubuntu 18.04 containers

### DIFF
--- a/tensorflow/tools/ci_build/linux/mkl/set-build-env.py
+++ b/tensorflow/tools/ci_build/linux/mkl/set-build-env.py
@@ -106,8 +106,9 @@ class BuildEnvSetter(object):
         raise ValueError(
             "{} does not exist or is not executable.".format(gcc_path))
 
-      gcc_output = subprocess.check_output([gcc_path, "-dumpversion"],
-                                           stderr=subprocess.STDOUT)
+      gcc_output = subprocess.check_output([gcc_path, "-dumpfullversion",
+                                            "-dumpversion"],
+                                           stderr=subprocess.STDOUT).strip()
       # handle python2 vs 3 (bytes vs str type)
       if isinstance(gcc_output, bytes):
         gcc_output = gcc_output.decode("utf-8")


### PR DESCRIPTION
With gcc 7 `gcc -dumpversion` gives only the major version, not the major.minor.release pattern from prior versions. Adding `-dumpfullversion` before `-dumpversion` prints major.minor.release on new and older versions of gcc (back to 4.8).