### PR TITLE
Typo in an example of Binary crossentropy

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -301,7 +301,7 @@ class BinaryCrossentropy(LossFunctionWrapper):
   ```python
   bce = tf.keras.losses.BinaryCrossentropy()
   loss = bce([0., 0., 1., 1.], [1., 1., 1., 0.])
-  print('Loss: ', loss.numpy())  # Loss: 12.007
+  print('Loss: ', loss.numpy())  # Loss: 11.522857
   ```
 
   Usage with tf.keras API:


### PR DESCRIPTION
The Binarycrossentropy estimated using TF2.0.0-alpha0 is `11.522857` (listed on website as `12.0007`) where as Binarycrossentropy estimated using TF1.13.1 is 12.0007 which is correct. Gists are provided below. I suspect there was a change in `tf.math.eps` between TF1.13.1 and TF2.0. Thanks!

[Gist](https://colab.sandbox.google.com/gist/jvishnuvardhan/cd6abcd1fc7534b17e3f5887b41d91c6/untitled167.ipynb) using TF2.0.0-alpha0 
[Gist](https://colab.sandbox.google.com/gist/jvishnuvardhan/cedb0385df9f5713f462745ab11dc69e/untitled168.ipynb) using TF1,13,1