### PR TITLE
Fix bazel rule for cuda bazel generation from templates

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -1131,7 +1131,7 @@ def _create_local_cuda_repository(repository_ctx):
         # switch it off for now.
         "-Wno-invalid-partial-specialization"
     """
-        cuda_defines["%{cxx_builtin_include_directories}"] = host_compiler_includes
+        cuda_defines["%{cxx_builtin_include_directories}"] = to_list_of_strings(host_compiler_includes)
         cuda_defines["%{linker_files}"] = ":empty"
         cuda_defines["%{win_linker_files}"] = ":empty"
         repository_ctx.file(


### PR DESCRIPTION
This PR fixes the issue in templated bazel file generation for cuda repositories. In clang compilation case, 
 template replacement argument is passed as a list of strings instead of a single string. This PR adds necessary change to convert the list of strings to a string.