### PR TITLE
Use TF_CUDA_PATHS to find cuBLAS if CUDA version >= 10.1, otherwise C…

### DIFF
--- a/third_party/gpus/find_cuda_config.py
+++ b/third_party/gpus/find_cuda_config.py
@@ -428,6 +428,10 @@ def find_cuda_config():
     result.update(_find_cuda_config(cuda_paths, cuda_version))
 
     cuda_version = result["cuda_version"]
+    cublas_paths = base_paths
+    if cuda_version.split(".") < (10, 1):
+      # Before CUDA 10.1, cuBLAS was in the same directory as the toolkit.
+      cublas_paths = cuda_paths
     cublas_version = os.environ.get("TF_CUBLAS_VERSION", "")
     result.update(_find_cublas_config(cuda_paths, cublas_version, cuda_version))
 


### PR DESCRIPTION
…UDA_TOOLKIT_PATH.

I need this patch to get TF1.14 to build with CUDA 10.1.

PiperOrigin-RevId: 247743023