### PR TITLE
Handle checking equality of unknown Tensorshapes

### DIFF
--- a/tensorflow/python/framework/tensor_shape.py
+++ b/tensorflow/python/framework/tensor_shape.py
@@ -1175,6 +1175,8 @@ class TensorShape(object):
       other = as_shape(other)
     except TypeError:
       return NotImplemented
+    if self.rank is None or other.rank is None:
+      raise ValueError("The inequality of unknown TensorShapes is undefined.")
     return self._dims == other.dims
 
   def __ne__(self, other):

--- a/tensorflow/python/framework/tensor_shape.py
+++ b/tensorflow/python/framework/tensor_shape.py
@@ -1176,7 +1176,7 @@ class TensorShape(object):
     except TypeError:
       return NotImplemented
     if self.rank is None or other.rank is None:
-      raise ValueError("The inequality of unknown TensorShapes is undefined.")
+      raise ValueError("The equality of unknown TensorShapes is undefined.")
     return self._dims == other.dims
 
   def __ne__(self, other):


### PR DESCRIPTION
Hi,

This PR adds code for handling unknown TensorShape when checking if one is equal to the other. 

Reference: `Not Equal` condition has this check but `equal to` is missing it. I assume that we are not handling unknown Tensorshape based on how it is being handled in 'Not Equal to`

Lines added:
```
    if self.rank is None or other.rank is None:
      raise ValueError("The equality of unknown TensorShapes is undefined.")
```
