### PR TITLE
Fix bazel dependencies for cublas 10.1

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -637,6 +637,7 @@ cc_library(
     hdrs = ["cusolver_context.h"],
     deps = [
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cublas_headers",
         "//tensorflow/compiler/xla:statusor",
         "//tensorflow/compiler/xla:types",
         "//tensorflow/compiler/xla:util",

--- a/tensorflow/stream_executor/cuda/BUILD
+++ b/tensorflow/stream_executor/cuda/BUILD
@@ -214,6 +214,7 @@ cc_library(
     textual_hdrs = glob(["cublas_*.inc"]),
     deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cublas_headers",
         "//tensorflow/stream_executor/lib",
         "//tensorflow/stream_executor/platform:dso_loader",
     ]),
@@ -244,6 +245,7 @@ cc_library(
         "@com_google_absl//absl/strings",
         "//third_party/eigen3",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cublas_headers",
         "//tensorflow/core:lib_internal",
         "//tensorflow/stream_executor",
         "//tensorflow/stream_executor:event",


### PR DESCRIPTION
Attention @chsigg

These three dependency tweaks are needed to build against CUDA 10.1.