### PR TITLE
Make vscode's pylint integration work on TensorFlow source

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,1 @@
+tensorflow/tools/ci_build/pylintrc


### PR DESCRIPTION
If you point a copy of Visual Studio Code at a TensorFlow source tree, the editor's built-in linter displays a large number of spurious errors and misses errors that would show up in CI builds. This PR adds a symbolic link to the `pylintrc` file for CI builds at the root of the source code tree. After this change, the default linter output of Visual Studio Code is much closer to what one sees when running `tensorflow/tools/ci_build/ci_sanity.sh`.