### PR TITLE
Fix two linter warnings

### DIFF
--- a/tensorflow/examples/saved_model/integration_tests/integration_scripts.py
+++ b/tensorflow/examples/saved_model/integration_tests/integration_scripts.py
@@ -61,4 +61,5 @@ def MaybeRunScriptInstead():
     # Append current path to import path and execute `SCRIPT_NAME` main.
     sys.path.extend([os.path.dirname(__file__)])
     module_name = os.environ["SCRIPT_NAME"]
-    app.run(importlib.import_module(module_name).main)
+    retval = app.run(importlib.import_module(module_name).main) # pylint: disable=assignment-from-no-return
+    sys.exit(retval)

--- a/tensorflow/examples/saved_model/integration_tests/integration_scripts.py
+++ b/tensorflow/examples/saved_model/integration_tests/integration_scripts.py
@@ -61,5 +61,4 @@ def MaybeRunScriptInstead():
     # Append current path to import path and execute `SCRIPT_NAME` main.
     sys.path.extend([os.path.dirname(__file__)])
     module_name = os.environ["SCRIPT_NAME"]
-    retval = app.run(importlib.import_module(module_name).main)
-    sys.exit(retval)
+    app.run(importlib.import_module(module_name).main)

--- a/tensorflow/python/platform/googletest.py
+++ b/tensorflow/python/platform/googletest.py
@@ -24,9 +24,9 @@ import sys
 import tempfile
 
 # go/tf-wildcard-import
-# pylint: disable=wildcard-import
+# pylint: disable=wildcard-import,redefined-builtin
 from absl.testing.absltest import *
-# pylint: enable=wildcard-import
+# pylint: enable=wildcard-import,redefined-builtin
 
 from tensorflow.python.framework import errors
 from tensorflow.python.lib.io import file_io


### PR DESCRIPTION
I've been seeing the following linter warnings in my test builds for a few days now:
```
FAIL: Found 2 non-whitelited pylint errors:
tensorflow/python/platform/googletest.py:28: [W0622(redefined-builtin), ] Redefining built-in 'xrange'

tensorflow/examples/saved_model/integration_tests/integration_scripts.py:64: [E1111(assignment-from-no-return), MaybeRunScriptInstead] Assigning to function call which doesn't return
```

This PR fixes the two issues that cause these warnings.