### PR TITLE
Allow importing of V1 SavedModels that output SparseTensors

### DIFF
--- a/tensorflow/python/eager/wrap_function.py
+++ b/tensorflow/python/eager/wrap_function.py
@@ -192,24 +192,6 @@ def _lift_unlifted_variables(graph, variable_holder):
         mutable_collection[index] = lifted_variables.get(current, current)
 
 
-def _lift_sparse_tensor(orig_sparse_tensor, lift_map):
-  """
-  Args:
-    orig_sparse_tensor: SparseTensors object whose underlying dense Tensors
-      reside in a different graph
-    lift_map: Map (as returned by `lift_to_graph`) from tensors in the other
-      graph to tensors in the current graph.
-  Returns:
-    A new copy of `orig_sparse_tensor` whose underlying dense tensors are in
-    the current graph
-  """
-  return sparse_tensor.SparseTensor(
-      indices=lift_map[orig_sparse_tensor.indices],
-      values=lift_map[orig_sparse_tensor.values],
-      dense_shape=lift_map[orig_sparse_tensor.dense_shape]
-  )
-
-
 # TODO(allenl): make this trackable
 class WrappedFunction(function.ConcreteFunction):
   """Wraps a tf V1 piece of code in a function."""

--- a/tensorflow/python/eager/wrap_function.py
+++ b/tensorflow/python/eager/wrap_function.py
@@ -270,8 +270,8 @@ class WrappedFunction(function.ConcreteFunction):
       Also extracts ops from `fetches`.
 
       Args:
-        fetch: The fetch to preprocess: Tensor, TensorInfo, or Operation, or string
-          identifying a Tensor or Operation.
+        fetch: The fetch to preprocess: Tensor, TensorInfo, or Operation, or
+          string identifying a Tensor or Operation.
 
       Returns:
         `fetch` converted to a Tensor.

--- a/tensorflow/python/saved_model/load_v1_in_v2_test.py
+++ b/tensorflow/python/saved_model/load_v1_in_v2_test.py
@@ -29,6 +29,7 @@ from tensorflow.python.eager import test
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import test_util
 from tensorflow.python.framework import versions
@@ -488,6 +489,30 @@ class LoadTest(test.TestCase):
                      ops.GraphKeys.TRAINABLE_VARIABLES])
     root = load.load(path)
     self.assertFalse(root.variables[0].trainable)
+
+  def _model_with_sparse_output(self):
+    """Generate a graph with a SparseTensor output and serialize in V1 format"""
+    export_graph = ops.Graph()
+    with export_graph.as_default():
+      in_placeholder = array_ops.placeholder(dtype=dtypes.int64, shape=[1])
+      out_sparse_tensor = sparse_tensor.SparseTensor(indices=[[0]],
+                                                     values=in_placeholder,
+                                                     dense_shape=[1]) * 2
+      with session_lib.Session() as session:
+        path = os.path.join(self.get_temp_dir(), "saved_model", str(ops.uid()))
+        simple_save.simple_save(
+            session,
+            path,
+            inputs={"start": in_placeholder},
+            outputs={"output": out_sparse_tensor})
+    return path
+
+  def test_load_sparse_outputs(self):
+    path = self._model_with_sparse_output()
+    imported = load.load(path)
+    imported_fn = imported.signatures["serving_default"]
+    forty_two = constant_op.constant([42], dtype=dtypes.int64)
+    self.assertEqual([84], imported_fn(forty_two)["output"].values.numpy())
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
If one attempts to load a V1 SavedModel that outputs a `SparseTensor`, the import code fails with an internal error. This PR adds the necessary hooks to the import code to allow it to load models with `SparseTensor` outputs.

The changes are centered in `WrappedFunction.prune()`. I also added a regression test in `load_v1_in_v2_test.py`.