### PR TITLE
Set the forward-compat date to the future.

### DIFF
--- a/tensorflow/python/compat/compat.py
+++ b/tensorflow/python/compat/compat.py
@@ -27,7 +27,7 @@ import datetime
 from tensorflow.python.util import tf_contextlib
 from tensorflow.python.util.tf_export import tf_export
 
-_FORWARD_COMPATIBILITY_HORIZON = datetime.date(2019, 5, 17)
+_FORWARD_COMPATIBILITY_HORIZON = datetime.date(2019, 11, 1)
 
 
 @tf_export("compat.forward_compatible")


### PR DESCRIPTION
This way we pick up all changes that were only being delayed for
forward-compatibility reasons.