### PR TITLE
Safely terminate server RPC loops

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/grpc_master_service.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_master_service.cc
@@ -128,6 +128,7 @@ class GrpcMasterService : public AsyncServiceInterface {
         // NOTE(mrry): A null `callback_tag` indicates that this is
         // the shutdown alarm.
         cq_->Shutdown();
+        break;
       }
     }
   }

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -382,6 +382,7 @@ Status GrpcServer::Stop() {
       state_ = STOPPED;
       return Status::OK();
     case STARTED:
+      server_.get()->Shutdown();
       worker_service_->Shutdown();
       master_service_->Shutdown();
       eager_service_->Shutdown();

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -385,6 +385,7 @@ Status GrpcServer::Stop() {
       worker_service_->Shutdown();
       master_service_->Shutdown();
       eager_service_->Shutdown();
+      state_ = STOPPED;
       return Status::OK();
     case STOPPED:
       LOG(INFO) << "Server already stopped (target: " << target() << ")";

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -382,8 +382,10 @@ Status GrpcServer::Stop() {
       state_ = STOPPED;
       return Status::OK();
     case STARTED:
-      return errors::Unimplemented(
-          "Clean shutdown is not currently implemented");
+      worker_service_->Shutdown();
+      master_service_->Shutdown();
+      eager_service_->Shutdown();
+      return Status::OK();
     case STOPPED:
       LOG(INFO) << "Server already stopped (target: " << target() << ")";
       return Status::OK();


### PR DESCRIPTION
**Issue:** Clean server shutdown is currently not supported. This is because the RPC loops in `GrpcWorkerService` and `GrpcMasterService` do not actually exit even after `Shutdown()` is called.

**Fix:** This commit adds the mechanism to break out of the RPC loops in both of these classes, modeled after how `GrpcEagerServiceImpl` does it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tensorflow/28935)
<!-- Reviewable:end -->
