### PR TITLE
Fix TF GPU build with Bazel 0.25.2

### DIFF
--- a/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
+++ b/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
@@ -280,6 +280,7 @@ def _impl(ctx):
 
     preprocessor_defines_feature = feature(
         name = "preprocessor_defines",
+        enabled = True,
         flag_sets = [
             flag_set(
                 actions = [


### PR DESCRIPTION
When I tried to upgrade Bazel to 0.25.2, the GPU build failed with Bazel 0.25.2 with the following error:

external/grpc/src/core/tsi/alts/handshaker/handshaker.pb.c(118): error C2118: negative subscript

The reason is missing flags (/DPB_FIELD_32BIT=1 /DGRPC_ARES=0) when using the GPU toolchain. I compared cc_toolchain_config.bzl.tpl and Bazel's windows_cc_toolchain_config.bzl and found enable = True is missing for preprocessor_defines_feature

PiperOrigin-RevId: 249444921