### PR TITLE
Added parameter `n` to DCT operation.

### DIFF
--- a/tensorflow/python/kernel_tests/signal/dct_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/dct_ops_test.py
@@ -48,18 +48,18 @@ def _modify_input_for_dct(signals, n=None):
   signal = np.array(signals)
   if n is None or n == signal.shape[-1]:
     signal_mod = signal
-  elif n>=1:
+  elif n >= 1:
     signal_len = signal.shape[-1]
-    if n<=signal_len:
-      signal_mod = signal[...,0:n]
+    if n <= signal_len:
+      signal_mod = signal[..., 0:n]
     else:
       output_shape = list(signal.shape)
       output_shape[-1] = n
       signal_mod = np.zeros(output_shape)
-      signal_mod[...,0:signal.shape[-1]] = signal
+      signal_mod[..., 0:signal.shape[-1]] = signal
   if n:
-    assert (signal_mod.shape[-1]==n)
-  return signal_mod 
+    assert signal_mod.shape[-1] == n
+  return signal_mod
 
 
 def _np_dct1(signals, n=None, norm=None):
@@ -104,7 +104,6 @@ def _np_dct3(signals, n=None, norm=None):
   # https://github.com/scipy/scipy/blob/v0.15.1/scipy/fftpack/src/dct.c.src
   signals_mod = _modify_input_for_dct(signals, n=n)
   dct_size = signals_mod.shape[-1]
-  
   signals_mod = np.array(signals_mod)  # make a copy so we can modify
   if norm == "ortho":
     signals_mod[..., 0] *= np.sqrt(4.0 / dct_size)

--- a/tensorflow/python/kernel_tests/signal/dct_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/dct_ops_test.py
@@ -165,7 +165,6 @@ class DCTOpsTest(parameterized.TestCase, test.TestCase):
     with spectral_ops_test_util.fft_kernel_label_map():
       with self.session(use_gpu=True):
         signals = np.random.rand(*shape).astype(np.float32)
-        print(signals)
         n = np.random.randint(1, 2*signals.shape[-1])
         n = np.random.choice([None, n])
         # Normalization not implemented for orthonormal.

--- a/tensorflow/python/kernel_tests/signal/dct_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/dct_ops_test.py
@@ -150,6 +150,9 @@ class DCTOpsTest(parameterized.TestCase, test.TestCase):
     # Unsupported type.
     with self.assertRaises(ValueError):
       dct_ops.dct(signals, type=5)
+    # Invalid n.
+    with self.assertRaises(ValueError):
+      dct_ops.dct(signals, n=-2)
     # DCT-I normalization not implemented.
     with self.assertRaises(ValueError):
       dct_ops.dct(signals, type=1, norm="ortho")
@@ -159,8 +162,6 @@ class DCTOpsTest(parameterized.TestCase, test.TestCase):
     # Unknown normalization.
     with self.assertRaises(ValueError):
       dct_ops.dct(signals, norm="bad")
-    with self.assertRaises(NotImplementedError):
-      dct_ops.dct(signals, n=10)
     with self.assertRaises(NotImplementedError):
       dct_ops.dct(signals, axis=0)
 

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -30,8 +30,6 @@ from tensorflow.python.util.tf_export import tf_export
 
 def _validate_dct_arguments(input_tensor, dct_type, n, axis, norm):
   """Checks that DCT/IDCT arguments are compatible and well formed."""
-  if n is not None:
-    raise NotImplementedError("The DCT length argument is not implemented.")
   if axis != -1:
     raise NotImplementedError("axis must be -1. Got: %s" % axis)
   if dct_type not in (1, 2, 3):

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -68,8 +68,8 @@ def dct(input, type=2, n=None, axis=-1, norm=None, name=None):  # pylint: disabl
     input: A `[..., samples]` `float32` `Tensor` containing the signals to
       take the DCT of.
     type: The DCT type to perform. Must be 1, 2 or 3.
-    n: The length of the transform. If length is less than sequence length, 
-      only the first n elements of the sequence are considered for the DCT. 
+    n: The length of the transform. If length is less than sequence length,
+      only the first n elements of the sequence are considered for the DCT.
       If n is greater than the sequence length, zeros are padded and then
       the DCT is computed as usual.
     axis: For future expansion. The axis to compute the DCT along. Must be `-1`.
@@ -82,7 +82,7 @@ def dct(input, type=2, n=None, axis=-1, norm=None, name=None):  # pylint: disabl
 
   Raises:
     ValueError: If `type` is not `1`, `2` or `3`, `axis` is
-      not `-1`, `n` is not `None` or greater than 0, 
+      not `-1`, `n` is not `None` or greater than 0,
       or `norm` is not `None` or `'ortho'`.
     ValueError: If `type` is `1` and `norm` is `ortho`.
 
@@ -95,13 +95,13 @@ def dct(input, type=2, n=None, axis=-1, norm=None, name=None):  # pylint: disabl
     input = _ops.convert_to_tensor(input, dtype=_dtypes.float32)
 
     seq_len = (tensor_shape.dimension_value(input.shape[-1])
-                or _array_ops.shape(input)[-1])
+               or _array_ops.shape(input)[-1])
     if n is not None:
       if n <= seq_len:
         input = input[..., 0:n]
       else:
         rank = len(input.shape)
-        padding = [[0,0] for i in range(rank)]
+        padding = [[0, 0] for i in range(rank)]
         padding[rank-1][1] = n - seq_len
         padding = _ops.convert_to_tensor(padding, dtype=_dtypes.int32)
         input = _array_ops.pad(input, paddings=padding)

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -27,13 +27,12 @@ from tensorflow.python.ops import math_ops as _math_ops
 from tensorflow.python.ops.signal import fft_ops
 from tensorflow.python.util.tf_export import tf_export
 
-
 def _validate_dct_arguments(input_tensor, dct_type, n, axis, norm):
   """Checks that DCT/IDCT arguments are compatible and well formed."""
   if axis != -1:
     raise NotImplementedError("axis must be -1. Got: %s" % axis)
   if n is not None and n < 1:
-    raise ValueError("n should be an integer greater than 1 or None")
+    raise ValueError("n should be a positive integer or None")
   if dct_type not in (1, 2, 3):
     raise ValueError("Only Types I, II and III (I)DCT are supported.")
   if dct_type == 1:

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -32,6 +32,8 @@ def _validate_dct_arguments(input_tensor, dct_type, n, axis, norm):
   """Checks that DCT/IDCT arguments are compatible and well formed."""
   if axis != -1:
     raise NotImplementedError("axis must be -1. Got: %s" % axis)
+  if n is not None and n < 1:
+    raise ValueError("n should be an integer greater than 1 or None")
   if dct_type not in (1, 2, 3):
     raise ValueError("Only Types I, II and III (I)DCT are supported.")
   if dct_type == 1:
@@ -81,7 +83,8 @@ def dct(input, type=2, n=None, axis=-1, norm=None, name=None):  # pylint: disabl
 
   Raises:
     ValueError: If `type` is not `1`, `2` or `3`, `axis` is
-      not `-1`, or `norm` is not `None` or `'ortho'`.
+      not `-1`, `n` is not `None` or greater than 0, 
+      or `norm` is not `None` or `'ortho'`.
     ValueError: If `type` is `1` and `norm` is `ortho`.
 
   [dct]: https://en.wikipedia.org/wiki/Discrete_cosine_transform

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -69,7 +69,10 @@ def dct(input, type=2, n=None, axis=-1, norm=None, name=None):  # pylint: disabl
     input: A `[..., samples]` `float32` `Tensor` containing the signals to
       take the DCT of.
     type: The DCT type to perform. Must be 1, 2 or 3.
-    n: For future expansion. The length of the transform. Must be `None`.
+    n: The length of the transform. If length is less than sequence length, 
+      only the first n elements of the sequence are considered for the DCT. 
+      If n is greater than the sequence length, zeros are padded and then
+      the DCT is computed as usual.
     axis: For future expansion. The axis to compute the DCT along. Must be `-1`.
     norm: The normalization to apply. `None` for no normalization or `'ortho'`
       for orthonormal normalization.

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -80,7 +80,7 @@ def dct(input, type=2, n=None, axis=-1, norm=None, name=None):  # pylint: disabl
     A `[..., samples]` `float32` `Tensor` containing the DCT of `input`.
 
   Raises:
-    ValueError: If `type` is not `1`, `2` or `3`, `n` is not `None, `axis` is
+    ValueError: If `type` is not `1`, `2` or `3`, `axis` is
       not `-1`, or `norm` is not `None` or `'ortho'`.
     ValueError: If `type` is `1` and `norm` is `ortho`.
 


### PR DESCRIPTION


Hello, 

This PR closes issue #26074 and adds the optional argument `n` to the Discrete Cosine Transform Operation. While there are more than one ways to do this, I've done it in a fashion that adds minimal changes to the code and retains the original function as much as possible. 
Please also find attached a demo [notebook](https://colab.research.google.com/drive/1BIGm4ACLT6Ndg_zPZokyO59CnX0wbUUQ) illustrating some test cases (ran locally on my test build) where I compare different dct operations with the `n` argument changing and compare it to `scipy.fftpack.dct()`. In all cases it matches the scipy outputs. 

