### PR TITLE
Remove jessie-backports release validity check

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.debian.jessie.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.debian.jessie.cpu
@@ -7,6 +7,7 @@ COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
 RUN echo "deb http://archive.debian.org/debian jessie-backports main" | \
     tee -a /etc/apt/sources.list
+RUN echo "Acquire::Check-Valid-Until no;" > /etc/apt/apt.conf.d/99no-check-valid-until
 # Workaround bug in Jessie backport repository deb packages
 # http://serverfault.com/questions/830636/cannot-install-openjdk-8-jre-headless-on-debian-jessie
 RUN apt-get update && \


### PR DESCRIPTION
Fixes:
E: Release file for http://archive.debian.org/debian/dists/jessie-backports/InRelease is expired (invalid since 94d 2h 16min 15s). Updates for this repository will not be applied.

Solution: https://www.lucas-nussbaum.net/blog/?p=947