### PR TITLE
DOC: Review keras.losses 

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -977,7 +977,31 @@ def binary_crossentropy(y_true, y_pred, from_logits=False, label_smoothing=0):  
               'keras.losses.kullback_leibler_divergence',
               'keras.losses.kld',
               'keras.losses.KLD')
-def kullback_leibler_divergence(y_true, y_pred):  # pylint: disable=missing-docstring
+def kullback_leibler_divergence(y_true, y_pred):
+  """Computes Kullback-Leibler divergence loss between `y_true` and `y_pred`.
+
+  `loss = y_true * log(y_true / y_pred)`
+
+  See: https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence
+
+  Usage:
+
+  ```python
+  loss = tf.keras.losses.KLD([.4, .9, .2], [.5, .8, .12])
+  print('Loss: ', loss.numpy())  # Loss: 0.11891246
+  ```
+
+  Args:
+    y_true: Tensor of true targets.
+    y_pred: Tensor of predicted targets.
+
+  Returns:
+    A `Tensor` with loss.
+
+  Raises:
+      TypeError: If `y_true` cannot be cast to the `y_pred.dtype`.
+
+  """
   y_pred = ops.convert_to_tensor(y_pred)
   y_true = math_ops.cast(y_true, y_pred.dtype)
   y_true = K.clip(y_true, K.epsilon(), 1)

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -671,6 +671,8 @@ class KLDivergence(LossFunctionWrapper):
 
   `loss = y_true * log(y_true / y_pred)`
 
+  See: https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence
+
   Usage:
 
   ```python

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -667,7 +667,7 @@ class LogCosh(LossFunctionWrapper):
 
 @keras_export('keras.losses.KLDivergence')
 class KLDivergence(LossFunctionWrapper):
-  """Computes Kullback Leibler divergence loss between `y_true` and `y_pred`.
+  """Computes Kullback-Leibler divergence loss between `y_true` and `y_pred`.
 
   `loss = y_true * log(y_true / y_pred)`
 
@@ -678,7 +678,7 @@ class KLDivergence(LossFunctionWrapper):
   ```python
   k = tf.keras.losses.KLDivergence()
   loss = k([.4, .9, .2], [.5, .8, .12])
-  print('Loss: ', loss.numpy())  # Loss: -0.043
+  print('Loss: ', loss.numpy())  # Loss: 0.11891246
   ```
 
   Usage with tf.keras API:

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -623,8 +623,8 @@ class Poisson(LossFunctionWrapper):
 
   ```python
   p = tf.keras.losses.Poisson()
-  loss = p([1, 9, 2], [4, 8, 12])
-  print('Loss: ', loss.numpy())  # Loss: -4.63
+  loss = p([1., 9., 2.], [4., 8., 12.])
+  print('Loss: ', loss.numpy())  # Loss: -0.35702705
   ```
 
   Usage with tf.keras API:


### PR DESCRIPTION
- fix failing example for `tf.keras.losses.Poisson`
- update numbers for `tf.keras.losses.Poisson`
- update numbers for `tf.keras.losses.KLDivergence`
- add example for `tf.keras.losses.kullback_leibler_divergence`

btw, @lamberta do we have any way to reduce duplication of such docs? 
currently we support support for losses as a function as well as object-style

Pushed during Munich TFDocSprint cc @dynamicwebpaige 