### PR TITLE
[Intel MKL] Update TF to fuse Conv2d+Relu6/Elu

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -1409,7 +1409,11 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     TF_CHECK_OK(GetNodeAttr(n->def(), "fused_ops", &fused_ops));
     return (fused_ops == std::vector<string>{"BiasAdd"} ||
             fused_ops == std::vector<string>{"Relu"} ||
+            fused_ops == std::vector<string>{"Relu6"} ||
+            fused_ops == std::vector<string>{"Elu"} ||
             fused_ops == std::vector<string>{"BiasAdd", "Relu"} ||
+            fused_ops == std::vector<string>{"BiasAdd", "Relu6"} ||
+            fused_ops == std::vector<string>{"BiasAdd", "Elu"} ||
             fused_ops == std::vector<string>{"BiasAdd", "Add"} ||
             fused_ops == std::vector<string>{"BiasAdd", "Add", "Relu"});
   }

--- a/tensorflow/core/graph/mkl_layout_pass_test.cc
+++ b/tensorflow/core/graph/mkl_layout_pass_test.cc
@@ -1412,7 +1412,7 @@ TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive5) {
 }
 
 // Rewrite test for _FusedConv2D Op with BiasAdd+Add fusion
-TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive4) {
+TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive6) {
   InitGraph(
       "node { name: 'A' op: 'Input'}"
       "node { name: 'B' op: 'Input'}"
@@ -1441,7 +1441,7 @@ TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive4) {
 }
 
 // Rewrite test for _FusedConv2D Op with BiasAdd+Add+Relu fusion
-TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive5) {
+TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive7) {
   InitGraph(
       "node { name: 'A' op: 'Input'}"
       "node { name: 'B' op: 'Input'}"

--- a/tensorflow/core/graph/mkl_layout_pass_test.cc
+++ b/tensorflow/core/graph/mkl_layout_pass_test.cc
@@ -1357,6 +1357,60 @@ TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive3) {
             "DMT/_0->D:3;DMT/_1->D:4;DMT/_2->D:5");
 }
 
+// Rewrite test for _FusedConv2D Op with BiasAdd+Relu6 fusion
+TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive4) {
+  InitGraph(
+      "node { name: 'A' op: 'Input'}"
+      "node { name: 'B' op: 'Input'}"
+      "node { name: 'C' op: 'Input'}"
+      "node { name: 'D' op: '_FusedConv2D'"
+      " attr { key: 'T'                value { type: DT_FLOAT } }"
+      " attr { key: 'num_args'         value { i: 1 } }"
+      " attr { key: 'data_format'      value { s: 'NCHW' } }"
+      " attr { key: 'strides'          value { list: {i: 1, i:1, i:1, i:1} } }"
+      " attr { key: 'padding'          value { s: 'SAME' } }"
+      " attr { key: 'dilations'        value { list: {i: 1, i:1, i:1, i:1} } }"
+      " attr { key: 'fused_ops'"
+      "             value { list: {s: 'BiasAdd', s: 'Relu6'} } }"
+      " attr { key: 'epsilon'          value { f: 0.001 }}"
+      " input: ['A', 'B', 'C']}"
+      "node { name: 'E' op: 'Zeta' attr { key: 'T' value { type: DT_FLOAT } }"
+      " input: ['D', 'C'] }");
+  EXPECT_EQ(DoMklLayoutOptimizationPass(),
+            "A(Input);B(Input);C(Input);D(_MklFusedConv2D);DMT/_0(Const);"
+            "DMT/_1(Const);DMT/_2(Const);E(Zeta)|A->D;"
+            "A:control->DMT/_0:control;A:control->DMT/_1:control;"
+            "A:control->DMT/_2:control;B->D:1;C->D:2;C->E:1;D->E;"
+            "DMT/_0->D:3;DMT/_1->D:4;DMT/_2->D:5");
+}
+
+// Rewrite test for _FusedConv2D Op with BiasAdd+Elu fusion
+TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive5) {
+  InitGraph(
+      "node { name: 'A' op: 'Input'}"
+      "node { name: 'B' op: 'Input'}"
+      "node { name: 'C' op: 'Input'}"
+      "node { name: 'D' op: '_FusedConv2D'"
+      " attr { key: 'T'                value { type: DT_FLOAT } }"
+      " attr { key: 'num_args'         value { i: 1 } }"
+      " attr { key: 'data_format'      value { s: 'NCHW' } }"
+      " attr { key: 'strides'          value { list: {i: 1, i:1, i:1, i:1} } }"
+      " attr { key: 'padding'          value { s: 'SAME' } }"
+      " attr { key: 'dilations'        value { list: {i: 1, i:1, i:1, i:1} } }"
+      " attr { key: 'fused_ops'"
+      "             value { list: {s: 'BiasAdd', s: 'Elu'} } }"
+      " attr { key: 'epsilon'          value { f: 0.001 }}"
+      " input: ['A', 'B', 'C']}"
+      "node { name: 'E' op: 'Zeta' attr { key: 'T' value { type: DT_FLOAT } }"
+      " input: ['D', 'C'] }");
+  EXPECT_EQ(DoMklLayoutOptimizationPass(),
+            "A(Input);B(Input);C(Input);D(_MklFusedConv2D);DMT/_0(Const);"
+            "DMT/_1(Const);DMT/_2(Const);E(Zeta)|A->D;"
+            "A:control->DMT/_0:control;A:control->DMT/_1:control;"
+            "A:control->DMT/_2:control;B->D:1;C->D:2;C->E:1;D->E;"
+            "DMT/_0->D:3;DMT/_1->D:4;DMT/_2->D:5");
+}
+
 // Rewrite test for _FusedConv2D Op with BiasAdd+Add fusion
 TEST_F(MklLayoutPassTest, NodeRewrite_FusedConv2D_Positive4) {
   InitGraph(

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -318,13 +318,7 @@ bool IsDeviceCompatible(const RemapperContext& ctx, Pattern& matched) {
 }
 
 bool IsSupportedActivation(const NodeDef& node) {
-// Temporarily disable fusing Relu6 and Elu if MKL is enabled.
-// TODO(Intel) Enable Relu6 and Elu fusion when MklConv2D supports them.
-#ifndef INTEL_MKL
   return IsRelu(node) || IsRelu6(node) || IsElu(node);
-#else
-  return IsRelu(node);
-#endif  // !INTEL_MKL
 }
 
 bool FindContractionWithBias(const RemapperContext& ctx,
@@ -885,8 +879,6 @@ void AddFusedContractionNode(
     absl::flat_hash_set<const NodeDef*>* invalidated_nodes) {
   // MKL version only support fusion for Conv2D
   DCHECK(IsConv2D(*matched.contraction));
-  // MKL version only support relu as activation
-  DCHECK(IsRelu(*matched.activation));
 
   NodeDef* fused_conv2d = optimized_graph->add_node();
   fused_conv2d->set_name(matched.activation->name());

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -24,8 +24,8 @@ limitations under the License.
 #include <map>
 #include <vector>
 
-#include "mkldnn.hpp"
 #include "absl/strings/str_join.h"
+#include "mkldnn.hpp"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -67,6 +67,7 @@ struct MklConvFwdParams {
   string dtypes = string("");
   struct PostOpParam {
     string name;
+    mkldnn::algorithm alg;
     std::vector<float> param;
   };
   std::vector<PostOpParam> post_op_params;
@@ -240,12 +241,12 @@ class MklConvFwdPrimitive : public MklPrimitive {
     mkldnn::post_ops post_ops;
     if (!post_op_params.empty()) {
       for (auto const& post_op_param : post_op_params) {
-        if (post_op_param.name == "relu") {
+        if (post_op_param.name == "Activation") {
           DCHECK_EQ(post_op_param.param.size(), 3);
           float op_scale = post_op_param.param[0];
           float op_alpha = post_op_param.param[1];
           float op_beta = post_op_param.param[2];
-          post_ops.append_eltwise(op_scale, mkldnn::eltwise_relu, op_alpha,
+          post_ops.append_eltwise(op_scale, post_op_param.alg, op_alpha,
                                   op_beta);
         } else if (post_op_param.name == "sum") {
           DCHECK_EQ(post_op_param.param.size(), 1);
@@ -258,7 +259,7 @@ class MklConvFwdPrimitive : public MklPrimitive {
             post_ops_attr.set_output_scales(2, post_op_param.param);
           }
         } else {
-          DCHECK((post_op_param.name == "relu") ||
+          DCHECK((post_op_param.name == "Activation") ||
                  (post_op_param.name == "sum") ||
                  (post_op_param.name == "output_scale"));
         }
@@ -368,7 +369,7 @@ class MklConvFwdPrimitiveFactory : public MklPrimitiveFactory<float> {
 
     // Generate keys for post-ops
     for (auto const& post_op_param : convFwdDims.post_op_params) {
-      if (post_op_param.name == "relu") {
+      if (post_op_param.name == "Activation") {
         DCHECK_EQ(post_op_param.param.size(), 3);
       } else if (post_op_param.name == "sum") {
         DCHECK_EQ(post_op_param.param.size(), 1);
@@ -449,17 +450,15 @@ class MklConvOp : public OpKernel {
       OP_REQUIRES(context, dilations_.size() == 5,
                   errors::InvalidArgument("Dilation rates field must "
                                           "specify 5 dimensions"));
-      OP_REQUIRES(context,
-                  (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
-                   GetTensorDim(dilations_, data_format_, 'C') == 1),
+      OP_REQUIRES(context, (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
+                            GetTensorDim(dilations_, data_format_, 'C') == 1),
                   errors::InvalidArgument(
                       "Current implementation does not yet support "
                       "dilations rates in the batch and depth dimensions."));
       OP_REQUIRES(
-          context,
-          (GetTensorDim(dilations_, data_format_, '0') > 0 &&
-           GetTensorDim(dilations_, data_format_, '1') > 0 &&
-           GetTensorDim(dilations_, data_format_, '2') > 0),
+          context, (GetTensorDim(dilations_, data_format_, '0') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '1') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '2') > 0),
           errors::InvalidArgument("Dilated rates should be larger than 0."));
     }
   }
@@ -757,7 +756,13 @@ class MklConvOp : public OpKernel {
 
  protected:
   void set_fuse_biasadd(bool fuse_biasadd) { fuse_biasadd_ = fuse_biasadd; }
-  void set_fuse_relu(bool fuse_relu) { fuse_relu_ = fuse_relu; }
+  void set_fuse_activation(bool fuse_activation,
+                           mkldnn::algorithm activation_alg,
+                           float relu_up_bound = 0.0) {
+    fuse_activation_ = fuse_activation;
+    activation_alg_ = activation_alg;
+    relu_up_bound_ = relu_up_bound;
+  }
   void set_fuse_pad(bool fuse_pad) {
     fuse_pad_ = fuse_pad;
     // In PadwithFusedConv OP, pad is the fourth index.
@@ -779,8 +784,11 @@ class MklConvOp : public OpKernel {
     // Add fusions as post ops
     // NOTE: Fusion of BiasAdd is handled directly inside MklConvOp by
     // checking `fuse_biasadd_` flag.
-    if (fuse_add_) params.post_op_params.push_back({"sum", {1.0}});
-    if (fuse_relu_) params.post_op_params.push_back({"relu", {1.0, 0.0, 0.0}});
+    if (fuse_add_)
+      params.post_op_params.push_back({"sum", mkldnn::algorithm_undef, {1.0}});
+    if (fuse_activation_)
+      params.post_op_params.push_back(
+          {"Activation", activation_alg_, {1.0, relu_up_bound_, 0.0}});
   }
 
   virtual Tbias* GetBiasHandle(OpKernelContext* context,
@@ -866,9 +874,12 @@ class MklConvOp : public OpKernel {
 
   // Initialize to values the template is instantiated with
   bool fuse_biasadd_ = bias_enabled;
-  bool fuse_relu_ = false;
+  bool fuse_activation_ = false;
   bool fuse_pad_ = pad_enabled;
   bool fuse_add_ = false;
+
+  float relu_up_bound_ = 0.0;
+  mkldnn::algorithm activation_alg_ = mkldnn::algorithm_undef;
 
   int input_index_pad_ = 2;
 
@@ -1054,10 +1065,26 @@ class MklFusedConvOp
                   errors::InvalidArgument(
                       "Fused Conv2D must have one extra argument: bias."));
     } else if (fused_ops == std::vector<string>{"Relu"}) {
-      this->set_fuse_relu(true);
+      this->set_fuse_activation(true, mkldnn::eltwise_relu);
+    } else if (fused_ops == std::vector<string>{"Relu6"}) {
+      this->set_fuse_activation(true, mkldnn::eltwise_bounded_relu, 6.0);
+    } else if (fused_ops == std::vector<string>{"Elu"}) {
+      this->set_fuse_activation(true, mkldnn::eltwise_elu);
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Relu"}) {
       this->set_fuse_biasadd(true);
-      this->set_fuse_relu(true);
+      this->set_fuse_activation(true, mkldnn::eltwise_relu);
+      OP_REQUIRES(context, num_args == 1,
+                  errors::InvalidArgument(
+                      "Fused Conv2D must have one extra argument: bias."));
+    } else if (fused_ops == std::vector<string>{"BiasAdd", "Relu6"}) {
+      this->set_fuse_biasadd(true);
+      this->set_fuse_activation(true, mkldnn::eltwise_bounded_relu, 6.0);
+      OP_REQUIRES(context, num_args == 1,
+                  errors::InvalidArgument(
+                      "Fused Conv2D must have one extra argument: bias."));
+    } else if (fused_ops == std::vector<string>{"BiasAdd", "Elu"}) {
+      this->set_fuse_biasadd(true);
+      this->set_fuse_activation(true, mkldnn::eltwise_elu);
       OP_REQUIRES(context, num_args == 1,
                   errors::InvalidArgument(
                       "Fused Conv2D must have one extra argument: bias."));
@@ -1071,7 +1098,23 @@ class MklFusedConvOp
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Add", "Relu"}) {
       this->set_fuse_biasadd(true);
       this->set_fuse_add(true);
-      this->set_fuse_relu(true);
+      this->set_fuse_activation(true, mkldnn::eltwise_relu);
+      OP_REQUIRES(
+          context, num_args == 2,
+          errors::InvalidArgument(
+              "Fused Conv2D must have two extra arguments: bias and add."));
+    } else if (fused_ops == std::vector<string>{"BiasAdd", "Add", "Relu6"}) {
+      this->set_fuse_biasadd(true);
+      this->set_fuse_add(true);
+      this->set_fuse_activation(true, mkldnn::eltwise_bounded_relu, 6.0);
+      OP_REQUIRES(
+          context, num_args == 2,
+          errors::InvalidArgument(
+              "Fused Conv2D must have two extra arguments: bias and add."));
+    } else if (fused_ops == std::vector<string>{"BiasAdd", "Add", "Elu"}) {
+      this->set_fuse_biasadd(true);
+      this->set_fuse_add(true);
+      this->set_fuse_activation(true, mkldnn::eltwise_elu);
       OP_REQUIRES(
           context, num_args == 2,
           errors::InvalidArgument(
@@ -1226,7 +1269,8 @@ class MklQuantizedConv2DOp
         scales[i] = factor * input_range * filter_range /
                     (255.0f * 127.0f * output_range);
       }
-      params.post_op_params.push_back({"output_scale", scales});
+      params.post_op_params.push_back(
+          {"output_scale", mkldnn::algorithm_undef, scales});
     }
   }
 
@@ -1309,7 +1353,8 @@ class MklQuantizedConv2DReluOp
                            MklConvFwdParams& params) override {
     MklQuantizedConv2DOp<Device, Tbias, Toutput, Ttemp_output, bias_enabled,
                          is_depthwise>::ExtendConvFwdParams(context, params);
-    params.post_op_params.push_back({"relu", {1.0, 0.0, 0.0}});
+    params.post_op_params.push_back(
+        {"Activation", mkldnn::eltwise_relu, {1.0, 0.0, 0.0}});
   }
 };
 
@@ -1366,14 +1411,17 @@ class MklQuantizedConv2DSumReluOp
       // If it is not then  it is DT_INT8 and is scaled appropriately.
       if (summand_type == DT_QUINT8)
         params.post_op_params.push_back(
-            {"sum", {scale_summand / scale_output}});
+            {"sum", mkldnn::algorithm_undef, {scale_summand / scale_output}});
       else
         params.post_op_params.push_back(
-            {"sum", {255.0f * scale_summand / (scale_output * 127.0f)}});
+            {"sum",
+             mkldnn::algorithm_undef,
+             {255.0f * scale_summand / (scale_output * 127.0f)}});
     } else {
-      params.post_op_params.push_back({"sum", {1.0}});
+      params.post_op_params.push_back({"sum", mkldnn::algorithm_undef, {1.0}});
     }
-    params.post_op_params.push_back({"relu", {1.0, 0.0, 0.0}});
+    params.post_op_params.push_back(
+        {"Activation", mkldnn::eltwise_relu, {1.0, 0.0, 0.0}});
   }
 
   void AllocateOutputTensor(OpKernelContext* context,

--- a/tensorflow/core/kernels/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl_fused_ops_test.cc
@@ -201,7 +201,7 @@ class MklFusedConv2DOpTest : public OpsTestBase {
     if (std::find(fused_ops.begin(), fused_ops.end(), "Relu6") !=
         fused_ops.end()) {
       last_op = "with_relu6";
-      next_op = ops::Relu(root.WithOpName(last_op), next_op);
+      next_op = ops::Relu6(root.WithOpName(last_op), next_op);
     }
 
     if (std::find(fused_ops.begin(), fused_ops.end(), "Elu") !=
@@ -298,103 +298,103 @@ TYPED_TEST_CASE_P(MklFusedConv2DWithBiasOpTest);
 // -------------------------------------------------------------------------- //
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, OneByOneConvolution) {
-  const int filter_size = 1;
-  const int filter_count = 12;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd"});
+  const int KFilterSize = 1;
+  const int KFilterCount = 12;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, SpatialConvolution) {
-  const int filter_size = 3;
-  const int filter_count = 12;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd"});
+  const int KFilterSize = 3;
+  const int KFilterCount = 12;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, OneByOneConvolutionAndRelu) {
-  const int filter_size = 1;
-  const int filter_count = 12;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Relu"});
+  const int KFilterSize = 1;
+  const int KFilterCount = 12;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Relu"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, SpatialConvolutionAndRelu) {
-  const int filter_size = 3;
-  const int filter_count = 12;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Relu"});
+  const int KFilterSize = 3;
+  const int KFilterCount = 12;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Relu"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, OneByOneConvolutionAndRelu6) {
-  const int filter_size = 1;
-  const int filter_count = 12;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Relu6"});
+  const int KFilterSize = 1;
+  const int KFilterCount = 12;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Relu6"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, SpatialConvolutionAndRelu6) {
-  const int filter_size = 3;
-  const int filter_count = 12;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Relu6"});
+  const int KFilterSize = 3;
+  const int KFilterCount = 12;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Relu6"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, OneByOneConvolutionAndElu) {
-  const int filter_size = 1;
-  const int filter_count = 12;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Elu"});
+  const int KFilterSize = 1;
+  const int KFilterCount = 12;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Elu"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, SpatialConvolutionAndElu) {
-  const int filter_size = 3;
-  const int filter_count = 12;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Elu"});
+  const int KFilterSize = 3;
+  const int KFilterCount = 12;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Elu"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, OneByOneConvolutionAndAdd) {
-  const int filter_size = 1;
-  const int filter_count = 3;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Add"});
+  const int KFilterSize = 1;
+  const int KFilterCount = 3;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Add"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, SpatialConvolutionAndAdd) {
-  const int filter_size = 3;
-  const int filter_count = 3;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Add"});
+  const int KFilterSize = 3;
+  const int KFilterCount = 3;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Add"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, OneByOneConvolutionAndAddRelu) {
-  const int filter_size = 1;
-  const int filter_count = 3;
-  this->VerifyFusedConv2D(filter_size, filter_count,
+  const int KFilterSize = 1;
+  const int KFilterCount = 3;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount,
                           {"BiasAdd", "Add", "Relu"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, SpatialConvolutionAndAddRelu) {
-  const int filter_size = 3;
-  const int filter_count = 3;
-  this->VerifyFusedConv2D(filter_size, filter_count,
+  const int KFilterSize = 3;
+  const int KFilterCount = 3;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount,
                           {"BiasAdd", "Add", "Relu"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, OneByOneConvolutionAndAddRelu6) {
-  const int filter_size = 1;
-  const int filter_count = 3;
-  this->VerifyFusedConv2D(filter_size, filter_count,
+  const int KFilterSize = 1;
+  const int KFilterCount = 3;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount,
                           {"BiasAdd", "Add", "Relu6"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, SpatialConvolutionAndAddRelu6) {
-  const int filter_size = 3;
-  const int filter_count = 3;
-  this->VerifyFusedConv2D(filter_size, filter_count,
+  const int KFilterSize = 3;
+  const int KFilterCount = 3;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount,
                           {"BiasAdd", "Add", "Relu6"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, OneByOneConvolutionAndAddElu) {
-  const int filter_size = 1;
-  const int filter_count = 3;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Add", "Elu"});
+  const int KFilterSize = 1;
+  const int KFilterCount = 3;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Add", "Elu"});
 }
 
 TYPED_TEST_P(MklFusedConv2DWithBiasOpTest, SpatialConvolutionAndAddElu) {
-  const int filter_size = 3;
-  const int filter_count = 3;
-  this->VerifyFusedConv2D(filter_size, filter_count, {"BiasAdd", "Add", "Elu"});
+  const int KFilterSize = 3;
+  const int KFilterCount = 3;
+  this->VerifyFusedConv2D(KFilterSize, KFilterCount, {"BiasAdd", "Add", "Elu"});
 }
 
 REGISTER_TYPED_TEST_CASE_P(
@@ -460,9 +460,9 @@ TEST_F(FusedPadConvOpTest, PaddingConvTest) {
   Tensor image(DT_FLOAT, {image_batch_count, image_height, image_width, depth});
   test::FillValues<float>(&image, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
 
-  const int filter_size = 3;
-  const int filter_count = 1;
-  Tensor filter(DT_FLOAT, {filter_size, filter_size, depth, filter_count});
+  const int KFilterSize = 3;
+  const int KFilterCount = 1;
+  Tensor filter(DT_FLOAT, {KFilterSize, KFilterSize, depth, KFilterCount});
   test::FillValues<float>(&filter, {1, 4, 7, 2, 5, 8, 3, 6, 9});
 
   const int padding_height = 4;
@@ -488,9 +488,9 @@ TEST_F(FusedPadConvOpTest, PaddingConvTestNchw) {
   Tensor image(DT_FLOAT, {image_batch_count, depth, image_height, image_width});
   test::FillValues<float>(&image, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
 
-  const int filter_size = 3;
-  const int filter_count = 1;
-  Tensor filter(DT_FLOAT, {filter_size, filter_size, depth, filter_count});
+  const int KFilterSize = 3;
+  const int KFilterCount = 1;
+  Tensor filter(DT_FLOAT, {KFilterSize, KFilterSize, depth, KFilterCount});
   test::FillValues<float>(&filter, {1, 4, 7, 2, 5, 8, 3, 6, 9});
 
   const int padding_height = 4;
@@ -566,9 +566,9 @@ TEST_F(FilterCacheTest, Conv2DFilterCacheTest) {
   Tensor image(DT_FLOAT, {image_batch_count, image_height, image_width, depth});
   test::FillValues<float>(&image, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
 
-  const int filter_size = 3;
-  const int filter_count = 1;
-  Tensor filter(DT_FLOAT, {filter_size, filter_size, depth, filter_count});
+  const int KFilterSize = 3;
+  const int KFilterCount = 1;
+  Tensor filter(DT_FLOAT, {KFilterSize, KFilterSize, depth, KFilterCount});
   test::FillValues<float>(&filter, {1, 4, 7, 2, 5, 8, 3, 6, 9});
 
   Tensor expected(DT_FLOAT, TensorShape({1, 1, 2, 1}));
@@ -759,31 +759,31 @@ class MklPadWithFusedConv2DOpTest : public OpsTestBase {
 TYPED_TEST_CASE_P(MklPadWithFusedConv2DOpTest);
 
 TYPED_TEST_P(MklPadWithFusedConv2DOpTest, WithBiasAndRoundPad) {
-  const int filter_size = 1;
-  const int filter_count = 12;
+  const int KFilterSize = 1;
+  const int KFilterCount = 12;
   this->SetPaddingList(2, 2, 1, 1);
-  this->VerifyPadAndConv2DWithBias(filter_size, filter_count);
+  this->VerifyPadAndConv2DWithBias(KFilterSize, KFilterCount);
 }
 
 TYPED_TEST_P(MklPadWithFusedConv2DOpTest, WithBiasAndPartialPad) {
-  const int filter_size = 1;
-  const int filter_count = 12;
+  const int KFilterSize = 1;
+  const int KFilterCount = 12;
   this->SetPaddingList(4, 0, 2, 0);
-  this->VerifyPadAndConv2DWithBias(filter_size, filter_count);
+  this->VerifyPadAndConv2DWithBias(KFilterSize, KFilterCount);
 }
 
 TYPED_TEST_P(MklPadWithFusedConv2DOpTest, WithBiasReluAndRoundPad) {
-  const int filter_size = 1;
-  const int filter_count = 12;
+  const int KFilterSize = 1;
+  const int KFilterCount = 12;
   this->SetPaddingList(2, 2, 1, 1);
-  this->VerifyPadAndConv2DWithBiasRelu(filter_size, filter_count);
+  this->VerifyPadAndConv2DWithBiasRelu(KFilterSize, KFilterCount);
 }
 
 TYPED_TEST_P(MklPadWithFusedConv2DOpTest, WithBiasReluAndPartialPad) {
-  const int filter_size = 1;
-  const int filter_count = 12;
+  const int KFilterSize = 1;
+  const int KFilterCount = 12;
   this->SetPaddingList(4, 0, 2, 0);
-  this->VerifyPadAndConv2DWithBiasRelu(filter_size, filter_count);
+  this->VerifyPadAndConv2DWithBiasRelu(KFilterSize, KFilterCount);
 }
 
 REGISTER_TYPED_TEST_CASE_P(MklPadWithFusedConv2DOpTest,  //


### PR DESCRIPTION
We first disable Conv2d+Relu6/Elu in MKL build as lack of the backend support, now add the support in backend and remove the limitation in Conv2d fusion.