### PR TITLE
Static lib path fix for arm64 build

### DIFF
--- a/tensorflow/lite/g3doc/guide/build_arm64.md
+++ b/tensorflow/lite/g3doc/guide/build_arm64.md
@@ -59,4 +59,4 @@ Compile:
 ```
 
 This should compile a static library in:
-`tensorflow/lite/gen/gen/aarch64_armv8-a/lib/libtensorflow-lite.a`.
+`tensorflow/lite/tools/make/gen/aarch64_armv8-a/lib/libtensorflow-lite.a`.


### PR DESCRIPTION
Updated the libtensorflow-lite.a path