### PR TITLE
Fixed a nccl broadcast bug

### DIFF
--- a/tensorflow/core/kernels/nccl_ops.cc
+++ b/tensorflow/core/kernels/nccl_ops.cc
@@ -248,7 +248,7 @@ class NcclBroadcastRecvKernel : public NcclAsyncOpBase {
         compute_stream->parent(), compute_stream, gpu_info->event_mgr,
         gpu_info->gpu_id, /*input=*/nullptr, output, /*global_rank=*/-1,
         std::move(actual_done));
-    NcclManager::instance()->AddBroadcastSend(
+    NcclManager::instance()->AddBroadcastRecv(
         std::move(participant), {GetCollectiveKey(c),
                                  /*num_local_devices=*/num_devices(),
                                  /*num_global_devices=*/num_devices(),

--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -410,13 +410,12 @@ void NcclManager::AddParticipant(std::unique_ptr<Participant> participant,
                                  CollectiveType collective_type,
                                  ncclRedOp_t reduction_op) {
   Collective* to_run = nullptr;
-  DataType data_type_val;
+  DataType data_type;
   if (participant->input != nullptr) {
-    data_type_val = participant->input->dtype();
+    data_type = participant->input->dtype();
   } else {
-    data_type_val = participant->output->dtype();
+    data_type = participant->output->dtype();
   }
-  const DataType data_type = data_type_val;
   {
     mutex_lock l(mu_);
     auto collective_it = collectives_.find(context.collective_key);

--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -410,7 +410,13 @@ void NcclManager::AddParticipant(std::unique_ptr<Participant> participant,
                                  CollectiveType collective_type,
                                  ncclRedOp_t reduction_op) {
   Collective* to_run = nullptr;
-  const DataType data_type = participant->input->dtype();
+  DataType data_type_val;
+  if (participant->input != nullptr) {
+    data_type_val = participant->input->dtype();
+  } else {
+    data_type_val = participant->output->dtype();
+  }
+  const DataType data_type = data_type_val;
   {
     mutex_lock l(mu_);
     auto collective_it = collectives_.find(context.collective_key);


### PR DESCRIPTION
The `NcclBroadcastRecvKernel` in `tensorflow/core/kernels/nccl_ops.cc` mistakenly calls the `AddBroadcastSend` and the `NcclManager::AddParticipant` doesn't consider the situation when `participant->input` might be a nullptr, causing the segfault error (e.g., in the broadcast receive, the input is a nullptr).

These two problems are fixed in this PR.

FYI. @nluehr 