### PR TITLE
Gradient clipping by norm has different semantics in tf.keras.optimizers against keras.optimizers.

### DIFF
--- a/tensorflow/python/keras/optimizers.py
+++ b/tensorflow/python/keras/optimizers.py
@@ -96,7 +96,7 @@ class Optimizer(object):
                        'Common ops without gradient: '
                        'K.argmax, K.round, K.eval.')
     if hasattr(self, 'clipnorm'):
-      grads = [clip_ops.clip_by_norm(g, self.clipnorm) for g in grads]
+      grads, _ = clip_ops.clip_by_global_norm(grads, self.clipnorm)
     if hasattr(self, 'clipvalue'):
       grads = [
           clip_ops.clip_by_value(g, -self.clipvalue, self.clipvalue)


### PR DESCRIPTION
Fixes #29108 .