### PR TITLE
Updating `_get_noise_shape()` to work in graph mode

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4016,7 +4016,7 @@ def _get_noise_shape(x, noise_shape):
 
   if x.shape.dims is not None and n_dims == len(noise_shape_dims):
     new_dims = []
-    for i range(n_dims):
+    for i in range(n_dims):
       if noise_shape_dims[i].value is None:
         new_dims.append(x_shape[i])
       else:

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4012,9 +4012,9 @@ def _get_noise_shape(x, noise_shape):
 
   if x.shape.dims is not None and len(x.shape.dims) == len(noise_shape_.dims):
     new_dims = []
-    for i, dim in enumerate(x.shape.dims):
-      if noise_shape_.dims[i].value is None and dim.value is not None:
-        new_dims.append(dim.value)
+    for i, dim in enumerate(tf.shape(x))):
+      if noise_shape_.dims[i].value is None:
+        new_dims.append(dim.numpy())
       else:
         new_dims.append(noise_shape_.dims[i].value)
     return tensor_shape.TensorShape(new_dims)

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4009,15 +4009,19 @@ def _get_noise_shape(x, noise_shape):
     noise_shape_ = tensor_shape.as_shape(noise_shape)
   except (TypeError, ValueError):
     return noise_shape
+  
+  n_dims = len(x.shape.dims)
+  x_shape = array_ops.shape(x, out_type=tf.int64)
+  noise_shape_dims = noise_shape_.dims
 
-  if x.shape.dims is not None and len(x.shape.dims) == len(noise_shape_.dims):
+  if x.shape.dims is not None and n_dims == len(noise_shape_dims):
     new_dims = []
-    for i, dim in enumerate(tf.shape(x)):
-      if noise_shape_.dims[i].value is None:
-        new_dims.append(dim.numpy())
+    for i range(n_dims):
+      if noise_shape_dims[i].value is None:
+        new_dims.append(x_shape[i])
       else:
-        new_dims.append(noise_shape_.dims[i].value)
-    return tensor_shape.TensorShape(new_dims)
+        new_dims.append(noise_shape_dims[i].value)
+    return ops.convert_to_tensor(new_dims)
 
   return noise_shape
 

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4012,7 +4012,7 @@ def _get_noise_shape(x, noise_shape):
 
   if x.shape.dims is not None and len(x.shape.dims) == len(noise_shape_.dims):
     new_dims = []
-    for i, dim in enumerate(tf.shape(x))):
+    for i, dim in enumerate(tf.shape(x)):
       if noise_shape_.dims[i].value is None:
         new_dims.append(dim.numpy())
       else:


### PR DESCRIPTION
Using the `noise_shape` argument in the `tf.keras.layers.Dropout` initializer currently doesn't work with `tf.function` if you have variable batch sizes because TF can't get the correct dropout mask size to use each batch. This was due to using `x.shape.dims` to fill in batch-specific sizes, but that doesn't work when autographed because the values stay as `None`. Changing this to `tf.shape(x)` fixes that.