### PR TITLE
Change many incorrect uses of ValueError to TypeError

### DIFF
--- a/tensorflow/contrib/constrained_optimization/python/external_regret_optimizer.py
+++ b/tensorflow/contrib/constrained_optimization/python/external_regret_optimizer.py
@@ -75,7 +75,7 @@ def _project_multipliers_wrt_euclidean_norm(multipliers, radius):
       a fully-known shape, or is not one-dimensional.
   """
   if not multipliers.dtype.is_floating:
-    raise ValueError("multipliers must have a floating-point dtype")
+    raise TypeError("multipliers must have a floating-point dtype")
   multipliers_shape = multipliers.get_shape()
   if multipliers_shape.ndims is None:
     raise ValueError("multipliers must have known shape")
@@ -220,7 +220,7 @@ class _ExternalRegretOptimizer(constrained_optimizer.ConstrainedOptimizer):
       grad_loss: as in `tf.compat.v1.train.Optimizer`'s `minimize` method.
 
     Raises:
-      ValueError: If the minimization_problem tensors have different dtypes.
+      TypeError: If the minimization_problem tensors have different dtypes.
 
     Returns:
       `Operation`, the train_op.
@@ -236,7 +236,7 @@ class _ExternalRegretOptimizer(constrained_optimizer.ConstrainedOptimizer):
     # the same dtype.
     if (objective.dtype.base_dtype != constraints.dtype.base_dtype or
         objective.dtype.base_dtype != proxy_constraints.dtype.base_dtype):
-      raise ValueError("objective, constraints and proxy_constraints must "
+      raise TypeError("objective, constraints and proxy_constraints must "
                        "have the same dtype")
 
     # Flatten both constraints tensors to 1d.

--- a/tensorflow/contrib/constrained_optimization/python/swap_regret_optimizer.py
+++ b/tensorflow/contrib/constrained_optimization/python/swap_regret_optimizer.py
@@ -82,7 +82,7 @@ def _maximal_eigenvector_power_method(matrix,
       `epsilon` or `maximum_iterations` parameters violate their bounds.
   """
   if not matrix.dtype.is_floating:
-    raise ValueError("multipliers must have a floating-point dtype")
+    raise TypeError("multipliers must have a floating-point dtype")
   if epsilon <= 0.0:
     raise ValueError("epsilon must be strictly positive")
   if maximum_iterations <= 0:
@@ -144,7 +144,7 @@ def _project_stochastic_matrix_wrt_euclidean_norm(matrix):
       fully-known shape, or is not two-dimensional and square.
   """
   if not matrix.dtype.is_floating:
-    raise ValueError("multipliers must have a floating-point dtype")
+    raise TypeError("multipliers must have a floating-point dtype")
   matrix_shape = matrix.get_shape()
   if matrix_shape.ndims is None:
     raise ValueError("matrix must have known shape")
@@ -326,7 +326,7 @@ class _SwapRegretOptimizer(constrained_optimizer.ConstrainedOptimizer):
       grad_loss: as in `tf.compat.v1.train.Optimizer`'s `minimize` method.
 
     Raises:
-      ValueError: If the minimization_problem tensors have different dtypes.
+      TypeError: If the minimization_problem tensors have different dtypes.
 
     Returns:
       `Operation`, the train_op.
@@ -342,7 +342,7 @@ class _SwapRegretOptimizer(constrained_optimizer.ConstrainedOptimizer):
     # the same dtype.
     if (objective.dtype.base_dtype != constraints.dtype.base_dtype or
         objective.dtype.base_dtype != proxy_constraints.dtype.base_dtype):
-      raise ValueError("objective, constraints and proxy_constraints must "
+      raise TypeError("objective, constraints and proxy_constraints must "
                        "have the same dtype")
 
     # Flatten both constraints tensors to 1d.

--- a/tensorflow/contrib/distributions/python/ops/mixture_same_family.py
+++ b/tensorflow/contrib/distributions/python/ops/mixture_same_family.py
@@ -133,7 +133,7 @@ class MixtureSameFamily(distribution.Distribution):
       name: Python `str` name prefixed to Ops created by this class.
 
     Raises:
-      ValueError: `if not mixture_distribution.dtype.is_integer`.
+      TypeError: `if not mixture_distribution.dtype.is_integer`.
       ValueError: if mixture_distribution does not have scalar `event_shape`.
       ValueError: if `mixture_distribution.batch_shape` and
         `components_distribution.batch_shape[:-1]` are both fully defined and
@@ -154,7 +154,7 @@ class MixtureSameFamily(distribution.Distribution):
                            else array_ops.shape(s)[0])
 
       if not mixture_distribution.dtype.is_integer:
-        raise ValueError(
+        raise TypeError(
             "`mixture_distribution.dtype` ({}) is not over integers".format(
                 mixture_distribution.dtype.name))
 

--- a/tensorflow/contrib/feature_column/python/feature_column/sequence_feature_column.py
+++ b/tensorflow/contrib/feature_column/python/feature_column/sequence_feature_column.py
@@ -261,7 +261,7 @@ def sequence_categorical_column_with_hash_bucket(
 
   Raises:
     ValueError: `hash_bucket_size` is not greater than 1.
-    ValueError: `dtype` is neither string nor integer.
+    TypeError: `dtype` is neither string nor integer.
   """
   return fc._SequenceCategoricalColumn(
       fc._categorical_column_with_hash_bucket(

--- a/tensorflow/contrib/kernel_methods/python/losses.py
+++ b/tensorflow/contrib/kernel_methods/python/losses.py
@@ -66,7 +66,7 @@ def sparse_multiclass_hinge_loss(
   Raises:
     ValueError: If `logits`, `labels` or `weights` have invalid or inconsistent
       shapes.
-    ValueError: If `labels` tensor has invalid dtype.
+    TypeError: If `labels` tensor has invalid dtype.
   """
 
   with ops.name_scope(scope, 'sparse_multiclass_hinge_loss', (logits,
@@ -84,7 +84,7 @@ def sparse_multiclass_hinge_loss(
 
     # Check labels have valid type.
     if labels.dtype != dtypes.int32 and labels.dtype != dtypes.int64:
-      raise ValueError(
+      raise TypeError(
           'Invalid dtype for labels: {}. Acceptable dtypes: int32 and int64'.
           format(labels.dtype))
 

--- a/tensorflow/contrib/metrics/python/metrics/classification.py
+++ b/tensorflow/contrib/metrics/python/metrics/classification.py
@@ -44,16 +44,16 @@ def accuracy(predictions, labels, weights=None, name=None):
     Accuracy `Tensor`.
 
   Raises:
-    ValueError: if dtypes don't match or
+    TypeError: if dtypes don't match or
                 if dtype is not bool, integer, or string.
   """
   if not (labels.dtype.is_integer or
           labels.dtype in (dtypes.bool, dtypes.string)):
-    raise ValueError(
+    raise TypeError(
         'Labels should have bool, integer, or string dtype, not %r' %
         labels.dtype)
   if not labels.dtype.is_compatible_with(predictions.dtype):
-    raise ValueError('Dtypes of predictions and labels should match. '
+    raise TypeError('Dtypes of predictions and labels should match. '
                      'Given: predictions (%r) and labels (%r)' %
                      (predictions.dtype, labels.dtype))
   with ops.name_scope(name, 'accuracy', values=[predictions, labels]):

--- a/tensorflow/python/autograph/operators/data_structures.py
+++ b/tensorflow/python/autograph/operators/data_structures.py
@@ -71,7 +71,7 @@ def tf_tensor_array_new(elements, element_dtype=None, element_shape=None):
         ' {}'.format(elements))
   else:
     if element_dtype is None:
-      raise ValueError('dtype is required to create an empty TensorArray')
+      raise TypeError('dtype is required to create an empty TensorArray')
 
   all_shapes = set(tuple(el.shape.as_list()) for el in elements)
   if len(all_shapes) == 1:

--- a/tensorflow/python/data/experimental/ops/map_defun.py
+++ b/tensorflow/python/data/experimental/ops/map_defun.py
@@ -45,17 +45,17 @@ def map_defun(fn,
       limit of each function call to this.
 
   Raises:
-    ValueError: if any of the inputs are malformed.
+    TypeError: if any of the inputs are malformed.
 
   Returns:
     A list of `Tensor` objects with the same types as `output_dtypes`.
   """
   if not isinstance(elems, list):
-    raise ValueError("`elems` must be a list of tensors.")
+    raise TypeError("`elems` must be a list of tensors.")
   if not isinstance(output_dtypes, list):
-    raise ValueError("`output_dtypes` must be a list of `tf.DType` objects.")
+    raise TypeError("`output_dtypes` must be a list of `tf.DType` objects.")
   if not isinstance(output_shapes, list):
-    raise ValueError("`output_shapes` must be a list of `tf.TensorShape` "
+    raise TypeError("`output_shapes` must be a list of `tf.TensorShape` "
                      "objects.")
 
   concrete_fn = fn._get_concrete_function_internal()  # pylint: disable=protected-access

--- a/tensorflow/python/framework/constant_op.py
+++ b/tensorflow/python/framework/constant_op.py
@@ -335,7 +335,7 @@ def _tensor_shape_tensor_conversion_function(s,
     if dtype not in (dtypes.int32, dtypes.int64):
       raise TypeError("Cannot convert a TensorShape to dtype: %s" % dtype)
     if dtype == dtypes.int32 and int64_value:
-      raise ValueError("Cannot convert a TensorShape to dtype int32; "
+      raise TypeError("Cannot convert a TensorShape to dtype int32; "
                        "a dimension is too large (%s)" % int64_value)
   else:
     dtype = dtypes.int64 if int64_value else dtypes.int32

--- a/tensorflow/python/framework/function.py
+++ b/tensorflow/python/framework/function.py
@@ -1245,7 +1245,7 @@ def get_extra_args():
 
 def _type_list_to_str(types):
   if any(_ not in _DTYPE_TO_STR for _ in types):
-    raise ValueError("Unsupported dtypes: %s" % types)
+    raise TypeError("Unsupported dtypes: %s" % types)
   return "".join([_DTYPE_TO_STR[_] for _ in types])
 
 

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -1379,14 +1379,14 @@ def internal_convert_to_tensor_or_indexed_slices(value,
     A `Tensor`, `IndexedSlices`, or `SparseTensor` based on `value`.
 
   Raises:
-    ValueError: If `dtype` does not match the element type of `value`.
+    TypeError: If `dtype` does not match the element type of `value`.
   """
   if isinstance(value, EagerTensor) and not context.executing_eagerly():
     return internal_convert_to_tensor(
         value, dtype=dtype, name=name, as_ref=as_ref)
   elif isinstance(value, _TensorLike):
     if dtype and not dtypes.as_dtype(dtype).is_compatible_with(value.dtype):
-      raise ValueError(
+      raise TypeError(
           "Tensor conversion requested dtype %s for Tensor with dtype %s: %r" %
           (dtypes.as_dtype(dtype).name, value.dtype.name, str(value)))
     return value
@@ -1507,12 +1507,12 @@ def internal_convert_to_tensor_or_composite(value,
     A `Tensor` or `CompositeTensor`, based on `value`.
 
   Raises:
-    ValueError: If `dtype` does not match the element type of `value`.
+    TypeError: If `dtype` does not match the element type of `value`.
   """
   if isinstance(value, composite_tensor.CompositeTensor):
     value_dtype = getattr(value, "dtype", None)
     if dtype and not dtypes.as_dtype(dtype).is_compatible_with(value_dtype):
-      raise ValueError(
+      raise TypeError(
           "Tensor conversion requested dtype %s for Tensor with dtype %s: %r" %
           (dtypes.as_dtype(dtype).name, value.dtype.name, str(value)))
     return value

--- a/tensorflow/python/keras/distribute/keras_utils_test.py
+++ b/tensorflow/python/keras/distribute/keras_utils_test.py
@@ -223,7 +223,7 @@ class TestDistributionStrategyErrorCases(test.TestCase, parameterized.TestCase):
       # since the order of the device and the corresponding input tensor dtype
       # is not deterministic over different runs.
       with self.assertRaisesRegexp(
-          ValueError, 'Input tensor dtypes do not match for '
+          TypeError, 'Input tensor dtypes do not match for '
           'distributed tensor inputs '
           'DistributedValues:.+'):
         with distribution.scope():

--- a/tensorflow/python/layers/base_test.py
+++ b/tensorflow/python/layers/base_test.py
@@ -356,7 +356,7 @@ class BaseLayerTest(test.TestCase):
         return inputs
 
     layer = CustomerLayer()
-    with self.assertRaisesRegexp(ValueError, r'expected dtype=float32'):
+    with self.assertRaisesRegexp(TypeError, r'expected dtype=float32'):
       layer.apply(constant_op.constant(1, dtype=dtypes.int32))
 
     # Works

--- a/tensorflow/python/ops/gradients_util.py
+++ b/tensorflow/python/ops/gradients_util.py
@@ -66,11 +66,12 @@ def _IndexedSlicesToTensor(value, dtype=None, name=None, as_ref=False):
     A dense Tensor representing the values in the given IndexedSlices.
 
   Raises:
-    ValueError: If the IndexedSlices does not have the same dtype.
+    ValueError: If the IndexedSlices is without dense_shape.
+    TypeError: If the IndexedSlices does not have the same dtype.
   """
   _ = as_ref
   if dtype and not dtype.is_compatible_with(value.dtype):
-    raise ValueError(
+    raise TypeError(
         "Tensor conversion requested dtype %s for IndexedSlices with dtype %s" %
         (dtype.name, value.dtype.name))
   if value.dense_shape is None:

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -1451,8 +1451,8 @@ def _assert_float_dtype(dtype):
     Validated type.
 
   Raises:
-    ValueError: if `dtype` is not a floating point type.
+    TypeError: if `dtype` is not a floating point type.
   """
   if not dtype.is_floating:
-    raise ValueError("Expected floating point type, got %s." % dtype)
+    raise TypeError("Expected floating point type, got %s." % dtype)
   return dtype

--- a/tensorflow/python/ops/init_ops_v2.py
+++ b/tensorflow/python/ops/init_ops_v2.py
@@ -111,11 +111,11 @@ class Ones(Initializer):
        supported.
 
     Raises:
-      ValuesError: If the dtype is not numeric or boolean.
+      TypeError: If the dtype is not numeric or boolean.
     """
     dtype = dtypes.as_dtype(dtype)
     if not dtype.is_numpy_compatible or dtype == dtypes.string:
-      raise ValueError("Expected numeric or boolean dtype, got %s." % dtype)
+      raise TypeError("Expected numeric or boolean dtype, got %s." % dtype)
     return array_ops.ones(shape, dtype)
 
 
@@ -244,11 +244,11 @@ class RandomUniform(Initializer):
       types are supported.
 
     Raises:
-      ValueError: If the dtype is not numeric.
+      TypeError: If the dtype is not numeric.
     """
     dtype = dtypes.as_dtype(dtype)
     if not dtype.is_floating and not dtype.is_integer:
-      raise ValueError("Expected float or integer dtype, got %s." % dtype)
+      raise TypeError("Expected float or integer dtype, got %s." % dtype)
     return self._random_generator.random_uniform(shape, self.minval,
                                                  self.maxval, dtype)
 
@@ -289,7 +289,7 @@ class RandomNormal(Initializer):
        supported.
 
     Raises:
-      ValueError: If the dtype is not floating point
+      TypeError: If the dtype is not floating point
     """
     dtype = _assert_float_dtype(dtype)
     return self._random_generator.random_normal(shape, self.mean, self.stddev,
@@ -336,7 +336,7 @@ class TruncatedNormal(Initializer):
        supported.
 
     Raises:
-      ValueError: If the dtype is not floating point
+      TypeError: If the dtype is not floating point
     """
     dtype = _assert_float_dtype(dtype)
     return self._random_generator.truncated_normal(shape, self.mean,
@@ -410,7 +410,7 @@ class VarianceScaling(Initializer):
        supported.
 
     Raises:
-      ValueError: If the dtype is not floating point
+      TypeError: If the dtype is not floating point
     """
     partition_info = None  # Keeps logic so can be readded later if necessary
     dtype = _assert_float_dtype(dtype)
@@ -762,11 +762,11 @@ def _assert_float_dtype(dtype):
     Validated type.
 
   Raises:
-    ValueError: if `dtype` is not a floating point type.
+    TypeError: if `dtype` is not a floating point type.
   """
   dtype = dtypes.as_dtype(dtype)
   if not dtype.is_floating:
-    raise ValueError("Expected floating point type, got %s." % dtype)
+    raise TypeError("Expected floating point type, got %s." % dtype)
   return dtype
 
 

--- a/tensorflow/python/ops/lookup_ops.py
+++ b/tensorflow/python/ops/lookup_ops.py
@@ -537,8 +537,9 @@ class TextFileInitializer(TableInitializerBase):
       name: A name for the operation (optional).
 
     Raises:
-      ValueError: when the filename is empty, or when the table key and value
-      data types do not match the expected data types.
+      ValueError: when the filename is empty.
+      TypeError: when the table key and value data types do not match the
+      expected data types.
     """
     if not isinstance(filename, ops.Tensor) and not filename:
       raise ValueError("Filename required for %s." % name)
@@ -551,7 +552,7 @@ class TextFileInitializer(TableInitializerBase):
       raise ValueError("Invalid key index %s." % (key_index))
 
     if key_index == TextFileIndex.LINE_NUMBER and key_dtype != dtypes.int64:
-      raise ValueError("Signature mismatch. Keys must be dtype %s, got %s." %
+      raise TypeError("Signature mismatch. Keys must be dtype %s, got %s." %
                        (dtypes.int64, key_dtype))
     if ((key_index == TextFileIndex.WHOLE_LINE) and
         (not key_dtype.is_integer) and (key_dtype != dtypes.string)):
@@ -562,10 +563,10 @@ class TextFileInitializer(TableInitializerBase):
       raise ValueError("Invalid value index %s." % (value_index))
 
     if value_index == TextFileIndex.LINE_NUMBER and value_dtype != dtypes.int64:
-      raise ValueError("Signature mismatch. Values must be dtype %s, got %s." %
+      raise TypeError("Signature mismatch. Values must be dtype %s, got %s." %
                        (dtypes.int64, value_dtype))
     if value_index == TextFileIndex.WHOLE_LINE and value_dtype != dtypes.string:
-      raise ValueError("Signature mismatch. Values must be dtype %s, got %s." %
+      raise TypeError("Signature mismatch. Values must be dtype %s, got %s." %
                        (dtypes.string, value_dtype))
 
     if (vocab_size is not None) and (vocab_size <= 0):
@@ -1365,7 +1366,7 @@ def index_table_from_tensor(vocabulary_list,
           "Expected %s, got %s." %
           ("integer" if dtype.is_integer else "non-integer", keys.dtype))
     if (not dtype.is_integer) and (keys.dtype.base_dtype != dtype):
-      raise ValueError("Expected %s, got %s." % (dtype, keys.dtype))
+      raise TypeError("Expected %s, got %s." % (dtype, keys.dtype))
     num_elements = array_ops.size(keys)
     values = math_ops.cast(math_ops.range(num_elements), dtypes.int64)
 

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2926,12 +2926,12 @@ def accumulate_n(inputs, shape=None, tensor_dtype=None, name=None):
     A `Tensor` of same shape and type as the elements of `inputs`.
 
   Raises:
-    ValueError: If `inputs` don't all have same shape and dtype or the shape
+    TypeError: If `inputs` don't all have same shape and dtype or the shape
     cannot be inferred.
   """
 
   def _input_error():
-    return ValueError("inputs must be a list of at least one Tensor with the "
+    return TypeError("inputs must be a list of at least one Tensor with the "
                       "same dtype and shape")
 
   if not inputs or not isinstance(inputs, (list, tuple)):

--- a/tensorflow/python/ops/ragged/ragged_tensor_shape.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor_shape.py
@@ -433,7 +433,7 @@ class RaggedTensorDynamicShape(object):
 
   def with_dim_size_dtype(self, dtype):
     if dtype not in (dtypes.int32, dtypes.int64):
-      raise ValueError('dtype must be int32 or int64')
+      raise TypeError('dtype must be int32 or int64')
     if self.dim_size_dtype == dtype:
       return self
     return RaggedTensorDynamicShape(

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -225,15 +225,15 @@ def random_uniform(shape,
     A tensor of the specified shape filled with random uniform values.
 
   Raises:
-    ValueError: If `dtype` is integral and `maxval` is not specified.
+    TypeError: If `dtype` is integral and `maxval` is not specified.
   """
   dtype = dtypes.as_dtype(dtype)
   if dtype not in (dtypes.float16, dtypes.bfloat16, dtypes.float32,
                    dtypes.float64, dtypes.int32, dtypes.int64):
-    raise ValueError("Invalid dtype %r" % dtype)
+    raise TypeError("Invalid dtype %r" % dtype)
   if maxval is None:
     if dtype.is_integer:
-      raise ValueError("Must specify maxval for integer dtype %r" % dtype)
+      raise TypeError("Must specify maxval for integer dtype %r" % dtype)
     maxval = 1
   with ops.name_scope(name, "random_uniform", [shape, minval, maxval]) as name:
     shape = _ShapeTensor(shape)

--- a/tensorflow/python/ops/rnn.py
+++ b/tensorflow/python/ops/rnn.py
@@ -105,17 +105,17 @@ def _infer_state_dtype(explicit_dtype, state):
     dtype: inferred dtype of hidden state.
 
   Raises:
-    ValueError: if `state` has heterogeneous dtypes or is empty.
+    TypeError: if `state` has heterogeneous dtypes or is empty.
   """
   if explicit_dtype is not None:
     return explicit_dtype
   elif nest.is_sequence(state):
     inferred_dtypes = [element.dtype for element in nest.flatten(state)]
     if not inferred_dtypes:
-      raise ValueError("Unable to infer dtype from empty state.")
+      raise TypeError("Unable to infer dtype from empty state.")
     all_same = all(x == inferred_dtypes[0] for x in inferred_dtypes)
     if not all_same:
-      raise ValueError(
+      raise TypeError(
           "State has tensors of different inferred_dtypes. Unable to infer a "
           "single representative dtype.")
     return inferred_dtypes[0]
@@ -672,7 +672,7 @@ def dynamic_rnn(cell,
       state = initial_state
     else:
       if not dtype:
-        raise ValueError("If there is no initial_state, you must give a dtype.")
+        raise TypeError("If there is no initial_state, you must give a dtype.")
       if getattr(cell, "get_initial_state", None) is not None:
         state = cell.get_initial_state(
             inputs=None, batch_size=batch_size, dtype=dtype)

--- a/tensorflow/python/ops/rnn_cell_impl.py
+++ b/tensorflow/python/ops/rnn_cell_impl.py
@@ -1738,7 +1738,7 @@ def _check_rnn_cell_input_dtypes(inputs):
       input or state.
 
   Raises:
-    ValueError: if any of the input tensor are not having dtypes of float or
+    TypeError: if any of the input tensor are not having dtypes of float or
       complex.
   """
   for t in nest.flatten(inputs):
@@ -1750,5 +1750,5 @@ def _check_supported_dtypes(dtype):
     return
   dtype = dtypes.as_dtype(dtype)
   if not (dtype.is_floating or dtype.is_complex):
-    raise ValueError("RNN cell only supports floating point inputs, "
+    raise TypeError("RNN cell only supports floating point inputs, "
                      "but saw dtype: %s" % dtype)

--- a/tensorflow/python/ops/stateful_random_ops.py
+++ b/tensorflow/python/ops/stateful_random_ops.py
@@ -488,12 +488,12 @@ class Generator(tracking.AutoTrackable):
       A tensor of the specified shape filled with random uniform values.
 
     Raises:
-      ValueError: If `dtype` is integral and `maxval` is not specified.
+      TypeError: If `dtype` is integral and `maxval` is not specified.
     """
     dtype = dtypes.as_dtype(dtype)
     if maxval is None:
       if dtype.is_integer:
-        raise ValueError("Must specify maxval for integer dtype %r" % dtype)
+        raise TypeError("Must specify maxval for integer dtype %r" % dtype)
       maxval = 1
     with ops.name_scope(name, "stateful_uniform",
                         [shape, minval, maxval]) as name:

--- a/tensorflow/python/ops/stateless_random_ops.py
+++ b/tensorflow/python/ops/stateless_random_ops.py
@@ -77,15 +77,15 @@ def stateless_random_uniform(shape,
     A tensor of the specified shape filled with random uniform values.
 
   Raises:
-    ValueError: If `dtype` is integral and `maxval` is not specified.
+    TypeError: If `dtype` is integral and `maxval` is not specified.
   """
   dtype = dtypes.as_dtype(dtype)
   if dtype not in (dtypes.float16, dtypes.bfloat16, dtypes.float32,
                    dtypes.float64, dtypes.int32, dtypes.int64):
-    raise ValueError("Invalid dtype %r" % dtype)
+    raise TypeError("Invalid dtype %r" % dtype)
   if maxval is None:
     if dtype.is_integer:
-      raise ValueError("Must specify maxval for integer dtype %r" % dtype)
+      raise TypeError("Must specify maxval for integer dtype %r" % dtype)
     maxval = 1
   with ops.name_scope(name, "stateless_random_uniform",
                       [shape, seed, minval, maxval]) as name:

--- a/tensorflow/python/saved_model/model_utils/export_output.py
+++ b/tensorflow/python/saved_model/model_utils/export_output.py
@@ -177,10 +177,10 @@ class RegressionOutput(ExportOutput):
       value: a float `Tensor` giving the predicted values.  Required.
 
     Raises:
-      ValueError: if the value is not a `Tensor` with dtype tf.float32.
+      TypeError: if the value is not a `Tensor` with dtype tf.float32.
     """
     if not (isinstance(value, ops.Tensor) and value.dtype.is_floating):
-      raise ValueError('Regression output value must be a float32 Tensor; '
+      raise TypeError('Regression output value must be a float32 Tensor; '
                        'got {}'.format(value))
     self._value = value
 

--- a/tensorflow/python/summary/summary.py
+++ b/tensorflow/python/summary/summary.py
@@ -258,7 +258,7 @@ def text(name, tensor, collections=None):
     ValueError: If tensor has the wrong type.
   """
   if tensor.dtype != _dtypes.string:
-    raise ValueError('Expected tensor %s to have dtype string, got %s' %
+    raise TypeError('Expected tensor %s to have dtype string, got %s' %
                      (tensor.name, tensor.dtype))
 
   summary_metadata = _SummaryMetadata(


### PR DESCRIPTION
These are TypeError instead of ValueError. See https://docs.python.org/3/library/exceptions.html#TypeError :
Passing arguments of the wrong type (e.g. passing a list when an int is expected) should result in a TypeError, but passing arguments with the wrong value (e.g. a number outside expected boundaries) should result in a ValueError.