### PR TITLE
[ROCm] Adding a macro wrapper for the ROCm/CUDA routine to get the error string

### DIFF
--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -56,6 +56,19 @@ using gpuError_t = hipError_t;
 #define GetGPUStream(context) context->eigen_gpu_device().stream()
 
 namespace tensorflow {
+
+#if GOOGLE_CUDA
+// cudaGetErrorString is available to both host and device
+__host__ __device__ inline const char* GpuGetErrorString(cudaError_t error) {
+  return cudaGetErrorString(error);
+}
+#elif TENSORFLOW_USE_ROCM
+// hipGetErrorString is available on host side only
+inline const char* GpuGetErrorString(hipError_t error) {
+  return hipGetErrorString(error);
+}
+#endif
+
 // Launches a GPU kernel through cudaLaunchKernel in CUDA environment, or
 // hipLaunchKernel in ROCm environment with the given arguments.
 //


### PR DESCRIPTION
This PR adds a macro wrapper `GPU_GET_ERROR_STRING` that resolves to the GPU platform specific error string function.

I tdo not know whether or not, the name `GPU_GET_ERROR_STRING` conforms to the TF coding standards, and any suggestions to change it something more conforming/consistent are welcome.

This is a trivial change, please review and merge....thanks

----------------------

@tatianashp @whchung @chsigg 
