### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build.

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_platform.cc
+++ b/tensorflow/stream_executor/rocm/rocm_platform.cc
@@ -134,8 +134,9 @@ port::StatusOr<StreamExecutor*> ROCmPlatform::GetExecutor(
 port::StatusOr<std::unique_ptr<StreamExecutor>>
 ROCmPlatform::GetUncachedExecutor(const StreamExecutorConfig& config) {
   auto executor = absl::make_unique<StreamExecutor>(
-      this, absl::make_unique<GpuExecutor>(config.plugin_config));
-  auto init_status = executor->Init(config.ordinal, config.device_options);
+      this, absl::make_unique<GpuExecutor>(config.plugin_config),
+      config.ordinal);
+  auto init_status = executor->Init(config.device_options);
   if (!init_status.ok()) {
     return port::Status{
         port::error::INTERNAL,


### PR DESCRIPTION
This PR contains a fix for the broken `--config=rocm` build, which was broken by the following commit

https://github.com/tensorflow/tensorflow/commit/47984a7d05937b978d7a80f2e9d60b2d32c06c07

The commit above made changes to the stream executor interface, updated the CUDA implementation to account for the interface change, but did not apply the same change to the ROCm implementation.

-----------------------------------

@tatianashp @whchung 

