### PR TITLE
1.14-rc1 cherry-pick request: Unexpose enable_mixed_precision_graph_rewrite in TF 2.

### DIFF
--- a/tensorflow/python/training/experimental/mixed_precision.py
+++ b/tensorflow/python/training/experimental/mixed_precision.py
@@ -27,7 +27,7 @@ from tensorflow.python.util import tf_inspect
 from tensorflow.python.util.tf_export import tf_export
 
 
-def _wrap_optimizer(opt, loss_scale, use_v1_behavior):
+def _wrap_optimizer(opt, loss_scale):
   """Wraps an optimizer with a LossScaleOptimizer."""
 
   if isinstance(opt, loss_scale_optimizer_v1.MixedPrecisionLossScaleOptimizer):
@@ -67,54 +67,12 @@ def _wrap_optimizer(opt, loss_scale, use_v1_behavior):
     from tensorflow.python.keras.mixed_precision.experimental import loss_scale_optimizer as loss_scale_optimizer_v2  # pylint: disable=g-import-not-at-top
     return loss_scale_optimizer_v2.LossScaleOptimizer(opt, loss_scale)
 
-  if use_v1_behavior:
-    raise ValueError('"opt" must be an instance of a tf.train.Optimizer or a '
-                     'tf.keras.optimizers.Optimizer, but got: %s' % opt)
-  else:
-    raise ValueError('"opt" must be an instance of a '
-                     'tf.keras.optimizers.Optimizer, but got: %s' % opt)
-
-
-@tf_export('train.experimental.enable_mixed_precision_graph_rewrite', v1=[])
-def enable_mixed_precision_graph_rewrite(opt, loss_scale='dynamic'):
-  """Enable mixed precision in `tf.function`s via a graph rewrite.
-
-  Mixed precision is the use of both float16 and float32 when training a model,
-  and is used to make the model run faster. This function will use mixed
-  precision to speed up the execution time of `tf.function`s when run on a GPU.
-  It does this by changing the dtype of certain operations in the function's
-  graph from float32 to float16.
-
-  This function additionally wraps an Optimizer with a LossScaleOptimizer, which
-  is required to prevent underflow in the float16 tensors during the backwards
-  pass. An optimizer must be passed to this function, which will then be wrapped
-  to use loss scaling.
-
-  When this function is used, gradients should only be computed and applied with
-  the returned optimizer through `opt.minimize()`, and not with a
-  `tf.GradientTape`. This is because the returned optimizer will apply loss
-  scaling, and `tf.GradientTape` will not. If you do use a `tf.GradientTape`,
-  your model may train to a worse quality.
-
-  Currently, mixed precision is only enabled on Volta GPUs and above. TPU
-  support is coming soon. CPUs are not supported, as CPUs do not run float16
-  operations faster than float32 operations.
-
-  Args:
-    opt: An instance of a `tf.keras.optimizers.Optimizer`.
-    loss_scale: Either an int/float, the string "dynamic", or an instance of a
-      `tf.train.experimental.LossScale`. The loss scale to use. It is
-      recommended to keep this as its default value of "dynamic".
-
-  Returns:
-    A version of `opt` that will use loss scaling to prevent underflow.
-  """
-  return _enable_mixed_precision_graph_rewrite_base(opt, loss_scale,
-                                                    use_v1_behavior=False)
+  raise ValueError('"opt" must be an instance of a tf.train.Optimizer or a '
+                   'tf.keras.optimizers.Optimizer, but got: %s' % opt)
 
 
 @tf_export(v1=['train.experimental.enable_mixed_precision_graph_rewrite'])
-def enable_mixed_precision_graph_rewrite_v1(opt, loss_scale='dynamic'):
+def enable_mixed_precision_graph_rewrite(opt, loss_scale='dynamic'):
   """Enable mixed precision via a graph rewrite.
 
   Mixed precision is the use of both float16 and float32 when training a model,
@@ -136,9 +94,11 @@ def enable_mixed_precision_graph_rewrite_v1(opt, loss_scale='dynamic'):
   `tf.gradients`/`tf.GradientTape` will not. If you do directly use
   `tf.gradients` or `tf.GradientTape`, your model may train to a worse quality.
 
-  Currently, mixed precision is only enabled on Volta GPUs and above. TPU
-  support is coming soon. CPUs are not supported, as CPUs do not run float16
-  operations faster than float32 operations.
+  When eager execution is enabled, the mixed precision graph rewrite is only
+  enabled within `tf.function`s, as outside `tf.function`s, there is no graph.
+
+  When enabled, mixed precision is only used on Volta GPUs and above. The parts
+  of the graph on CPUs and TPUs are untouched by the graph rewrite.
 
   Args:
     opt: An instance of a `tf.keras.optimizers.Optimizer` or a
@@ -152,51 +112,20 @@ def enable_mixed_precision_graph_rewrite_v1(opt, loss_scale='dynamic'):
   """
   # TODO(reedwm): If a ConfigProto is passed to Session, either assert that
   # auto_mixed_precision is on or turn it on for the user.
-  return _enable_mixed_precision_graph_rewrite_base(opt, loss_scale,
-                                                    use_v1_behavior=True)
-
-
-def _enable_mixed_precision_graph_rewrite_base(opt, loss_scale,
-                                               use_v1_behavior):
-  """Enables mixed precision. See `enable_mixed_precision_graph_rewrite`."""
   if mixed_precision_global_state.non_mixed_precision_session_created:
     # TODO(reedwm): Give the stacktrace of the existing Sessions. And if the
     # Sessions have already been closed, do not raise this error message.
     tf_logging.warn('You already have existing Sessions that do not use mixed '
                     'precision. enable_mixed_precision_graph_rewrite() will '
                     'not affect these Sessions.')
-  opt = _wrap_optimizer(opt, loss_scale, use_v1_behavior=use_v1_behavior)
+  opt = _wrap_optimizer(opt, loss_scale)
   config.set_optimizer_experimental_options({'auto_mixed_precision': True})
   mixed_precision_global_state.mixed_precision_is_enabled = True
   return opt
 
 
-@tf_export('train.experimental.disable_mixed_precision_graph_rewrite', v1=[])
-def disable_mixed_precision_graph_rewrite():
-  """Disables the mixed precision graph rewrite.
-
-  After this is called, the mixed precision graph rewrite will no longer run for
-  tf.functions, and so float32 operations will no longer be converted to
-  float16.
-
-  This does not undo the effects of loss scaling. Any optimizers wrapped with a
-  LossScaleOptimizer will continue to do loss scaling, although this loss
-  scaling will no longer be useful, as the graph rewrite no longer converts
-  tf.functions to use float16.
-
-  This function is useful for unit testing. A unit test can test using the mixed
-  precision graph rewrite, then disable it so future unit tests continue using
-  float32.
-  """
-  if not mixed_precision_global_state.mixed_precision_is_enabled:
-    tf_logging.warn('disable_mixed_precision_graph_rewrite() called when mixed '
-                    'precision is already disabled.')
-  config.set_optimizer_experimental_options({'auto_mixed_precision': False})
-  mixed_precision_global_state.mixed_precision_is_enabled = False
-
-
 @tf_export(v1=['train.experimental.disable_mixed_precision_graph_rewrite'])
-def disable_mixed_precision_graph_rewrite_v1():
+def disable_mixed_precision_graph_rewrite():
   """Disables the mixed precision graph rewrite.
 
   After this is called, the mixed precision graph rewrite will no longer run for
@@ -217,6 +146,8 @@ def disable_mixed_precision_graph_rewrite_v1():
   as `enable_mixed_precision_graph_rewrite` and
   `disable_mixed_precision_graph_rewrite` have no effect on existing sessions.
   """
-  # We only have a separate V1 version of this function, because the V1
-  # docstring mentions sessions.
-  disable_mixed_precision_graph_rewrite()
+  if not mixed_precision_global_state.mixed_precision_is_enabled:
+    tf_logging.warn('disable_mixed_precision_graph_rewrite() called when mixed '
+                    'precision is already disabled.')
+  config.set_optimizer_experimental_options({'auto_mixed_precision': False})
+  mixed_precision_global_state.mixed_precision_is_enabled = False

--- a/tensorflow/python/training/experimental/mixed_precision_test.py
+++ b/tensorflow/python/training/experimental/mixed_precision_test.py
@@ -21,7 +21,6 @@ import os
 from absl.testing import parameterized
 
 from tensorflow.core.protobuf import config_pb2
-from tensorflow.python import tf2
 from tensorflow.python.client import session
 from tensorflow.python.eager import context
 from tensorflow.python.eager import def_function
@@ -38,14 +37,6 @@ from tensorflow.python.training import gradient_descent as gradient_descent_v1
 from tensorflow.python.training.experimental import loss_scale_optimizer as loss_scale_optimizer_v1
 from tensorflow.python.training.experimental import mixed_precision
 from tensorflow.python.training.experimental import mixed_precision_global_state
-
-
-if tf2.enabled():
-  enable_mixed_precision_graph_rewrite = (
-      mixed_precision.enable_mixed_precision_graph_rewrite)
-else:
-  enable_mixed_precision_graph_rewrite = (
-      mixed_precision.enable_mixed_precision_graph_rewrite_v1)
 
 
 class MixedPrecisionTest(test.TestCase, parameterized.TestCase):
@@ -76,13 +67,13 @@ class MixedPrecisionTest(test.TestCase, parameterized.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def test_wrap_optimizer(self):
     opt = gradient_descent_v1.GradientDescentOptimizer(1.0)
-    opt = enable_mixed_precision_graph_rewrite(opt, 123.)
+    opt = mixed_precision.enable_mixed_precision_graph_rewrite(opt, 123.)
     self.assertIsInstance(
         opt, loss_scale_optimizer_v1.MixedPrecisionLossScaleOptimizer)
     self.assertEqual(self.evaluate(opt._loss_scale()), 123.)
 
     opt = gradient_descent_v2.SGD(1.0)
-    opt = enable_mixed_precision_graph_rewrite(opt, 123.)
+    opt = mixed_precision.enable_mixed_precision_graph_rewrite(opt, 123.)
     self.assertIsInstance(
         opt, loss_scale_optimizer_v2.LossScaleOptimizer)
     self.assertEqual(self.evaluate(opt._loss_scale()), 123.)
@@ -90,14 +81,10 @@ class MixedPrecisionTest(test.TestCase, parameterized.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def test_optimizer_errors(self):
     opt = 1
-    if tf2.enabled():
-      expected_regex = ('"opt" must be an instance of a '
-                        'tf.keras.optimizers.Optimizer, but got')
-    else:
-      expected_regex = ('"opt" must be an instance of a tf.train.Optimizer or '
-                        'a tf.keras.optimizers.Optimizer, but got')
+    expected_regex = ('"opt" must be an instance of a tf.train.Optimizer or '
+                      'a tf.keras.optimizers.Optimizer, but got')
     with self.assertRaisesRegexp(ValueError, expected_regex):
-      enable_mixed_precision_graph_rewrite(opt)
+      mixed_precision.enable_mixed_precision_graph_rewrite(opt)
     self.assertFalse(config.get_optimizer_experimental_options()
                      .get('auto_mixed_precision', False))
 
@@ -107,7 +94,7 @@ class MixedPrecisionTest(test.TestCase, parameterized.TestCase):
     with self.assertRaisesRegexp(ValueError,
                                  '"opt" must not already be an instance of a '
                                  'MixedPrecisionLossScaleOptimizer.'):
-      enable_mixed_precision_graph_rewrite(opt)
+      mixed_precision.enable_mixed_precision_graph_rewrite(opt)
     self.assertFalse(config.get_optimizer_experimental_options()
                      .get('auto_mixed_precision', False))
 
@@ -116,7 +103,7 @@ class MixedPrecisionTest(test.TestCase, parameterized.TestCase):
     with self.assertRaisesRegexp(ValueError,
                                  '"opt" must not already be an instance of a '
                                  'LossScaleOptimizer.'):
-      enable_mixed_precision_graph_rewrite(opt)
+      mixed_precision.enable_mixed_precision_graph_rewrite(opt)
     self.assertFalse(config.get_optimizer_experimental_options()
                      .get('auto_mixed_precision', False))
 
@@ -124,7 +111,7 @@ class MixedPrecisionTest(test.TestCase, parameterized.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def test_grappler_pass_enabled(self):
     opt = gradient_descent_v2.SGD(1.0)
-    enable_mixed_precision_graph_rewrite(opt, 123.)
+    mixed_precision.enable_mixed_precision_graph_rewrite(opt, 123.)
 
     var = variables.Variable([[1.0]])
 
@@ -169,7 +156,8 @@ class MixedPrecisionTest(test.TestCase, parameterized.TestCase):
     mixed_precision_global_state.non_mixed_precision_session_created = False
 
     with session.Session():
-      enable_mixed_precision_graph_rewrite(gradient_descent_v2.SGD(1.0))
+      mixed_precision.enable_mixed_precision_graph_rewrite(
+          gradient_descent_v2.SGD(1.0))
       mock_warn.assert_any_call(
           'You already have existing Sessions that do not use mixed precision. '
           'enable_mixed_precision_graph_rewrite() will not affect these '
@@ -181,7 +169,8 @@ class MixedPrecisionTest(test.TestCase, parameterized.TestCase):
     # the warning.
     mixed_precision_global_state.non_mixed_precision_session_created = False
 
-    enable_mixed_precision_graph_rewrite(gradient_descent_v2.SGD(1.0))
+    mixed_precision.enable_mixed_precision_graph_rewrite(
+        gradient_descent_v2.SGD(1.0))
     with session.Session():
       # Make sure the "You already have existing Sessions" warning was not
       # issued, since the Session was only created after

--- a/tensorflow/python/training/training.py
+++ b/tensorflow/python/training/training.py
@@ -35,7 +35,6 @@ from tensorflow.python.training.adam import AdamOptimizer
 from tensorflow.python.training.ftrl import FtrlOptimizer
 from tensorflow.python.training.experimental.loss_scale_optimizer import MixedPrecisionLossScaleOptimizer
 from tensorflow.python.training.experimental.mixed_precision import enable_mixed_precision_graph_rewrite
-from tensorflow.python.training.experimental.mixed_precision import enable_mixed_precision_graph_rewrite_v1
 from tensorflow.python.training.momentum import MomentumOptimizer
 from tensorflow.python.training.moving_averages import ExponentialMovingAverage
 from tensorflow.python.training.optimizer import Optimizer

--- a/tensorflow/tools/api/golden/v2/tensorflow.train.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.train.experimental.pbtxt
@@ -16,12 +16,4 @@ tf_module {
     name: "PythonState"
     mtype: "<type \'type\'>"
   }
-  member_method {
-    name: "disable_mixed_precision_graph_rewrite"
-    argspec: "args=[], varargs=None, keywords=None, defaults=None"
-  }
-  member_method {
-    name: "enable_mixed_precision_graph_rewrite"
-    argspec: "args=[\'opt\', \'loss_scale\'], varargs=None, keywords=None, defaults=[\'dynamic\'], "
-  }
 }

--- a/tensorflow/tools/compatibility/renames_v2.py
+++ b/tensorflow/tools/compatibility/renames_v2.py
@@ -1439,6 +1439,10 @@ renames = {
         'tf.compat.v1.train.do_quantize_training_on_graphdef',
     'tf.train.experimental.MixedPrecisionLossScaleOptimizer':
         'tf.compat.v1.train.experimental.MixedPrecisionLossScaleOptimizer',
+    'tf.train.experimental.disable_mixed_precision_graph_rewrite':
+        'tf.compat.v1.train.experimental.disable_mixed_precision_graph_rewrite',
+    'tf.train.experimental.enable_mixed_precision_graph_rewrite':
+        'tf.compat.v1.train.experimental.enable_mixed_precision_graph_rewrite',
     'tf.train.exponential_decay':
         'tf.compat.v1.train.exponential_decay',
     'tf.train.export_meta_graph':


### PR DESCRIPTION
This needs to be cherrypicked in TF 1.14, so that the symbol is not exposed in tf.compat.v2 in a stable release of TensorFlow.