### PR TITLE
1.14-rc1 cherry-pick request: Support explicit padding in conv2d second order gradients.

### DIFF
--- a/tensorflow/python/kernel_tests/conv2d_backprop_filter_grad_test.py
+++ b/tensorflow/python/kernel_tests/conv2d_backprop_filter_grad_test.py
@@ -35,7 +35,12 @@ class Conv2DBackpropFilterGradTest(test.TestCase):
   @test_util.run_deprecated_v1
   def testGradient(self):
     with self.cached_session():
-      for padding in ["SAME", "VALID"]:
+      for padding in [
+          "SAME",
+          "VALID",
+          [(0, 0), (1, 2), (3, 4), (0, 0)],
+          [(0, 0), (0, 3), (4, 2), (0, 0)]
+      ]:
         for stride in [1, 2]:
           np.random.seed(1)
           in_shape = [5, 8, 6, 4]
@@ -70,7 +75,12 @@ class Conv2DBackpropFilterGradTest(test.TestCase):
   def testGradientDilatedConv(self):
     if test.is_gpu_available(cuda_only=True):
       with self.session(use_gpu=True):
-        for padding in ["SAME", "VALID"]:
+        for padding in [
+            "SAME",
+            "VALID",
+            [(0, 0), (3, 5), (2, 1), (0, 0)],
+            [(0, 0), (5, 2), (5, 1), (0, 0)]
+        ]:
           for stride in [1, 2]:
             np.random.seed(1)
             in_shape = [5, 8, 6, 4]

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -40,23 +40,27 @@ def _Conv2DBackpropInputGrad(op, grad):
   Returns:
     the gradients w.r.t. the input and the filter
   """
+  # We call the gen_nn_ops backprop functions instead of nn_ops backprop
+  # functions for performance reasons in Eager mode. See _Conv2DGrad.
   return [
       None,
-      nn_ops.conv2d_backprop_filter(
+      gen_nn_ops.conv2d_backprop_filter(
           grad,
           array_ops.shape(op.inputs[1]),
           op.inputs[2],
           dilations=op.get_attr("dilations"),
           strides=op.get_attr("strides"),
           padding=op.get_attr("padding"),
+          explicit_paddings=op.get_attr("explicit_paddings"),
           use_cudnn_on_gpu=op.get_attr("use_cudnn_on_gpu"),
           data_format=op.get_attr("data_format").decode()),
-      nn_ops.conv2d(
+      gen_nn_ops.conv2d(
           grad,
           op.inputs[1],
           dilations=op.get_attr("dilations"),
           strides=op.get_attr("strides"),
           padding=op.get_attr("padding"),
+          explicit_paddings=op.get_attr("explicit_paddings"),
           use_cudnn_on_gpu=op.get_attr("use_cudnn_on_gpu"),
           data_format=op.get_attr("data_format").decode())
   ]
@@ -64,22 +68,26 @@ def _Conv2DBackpropInputGrad(op, grad):
 
 @ops.RegisterGradient("Conv2DBackpropFilter")
 def _Conv2DBackpropFilterGrad(op, grad):
+  # We call the gen_nn_ops backprop functions instead of nn_ops backprop
+  # functions for performance reasons in Eager mode. See _Conv2DGrad.
   return [
-      nn_ops.conv2d_backprop_input(
+      gen_nn_ops.conv2d_backprop_input(
           array_ops.shape(op.inputs[0]),
           grad,
           op.inputs[2],
           dilations=op.get_attr("dilations"),
           strides=op.get_attr("strides"),
           padding=op.get_attr("padding"),
+          explicit_paddings=op.get_attr("explicit_paddings"),
           use_cudnn_on_gpu=op.get_attr("use_cudnn_on_gpu"),
           data_format=op.get_attr("data_format").decode()), None,
-      nn_ops.conv2d(
+      gen_nn_ops.conv2d(
           op.inputs[0],
           grad,
           dilations=op.get_attr("dilations"),
           strides=op.get_attr("strides"),
           padding=op.get_attr("padding"),
+          explicit_paddings=op.get_attr("explicit_paddings"),
           use_cudnn_on_gpu=op.get_attr("use_cudnn_on_gpu"),
           data_format=op.get_attr("data_format").decode())
   ]


### PR DESCRIPTION
PiperOrigin-RevId: 249105971

This fixes a crash when second order gradients are taken with Conv2d when explicit padding is used.