### PR TITLE
[ROCm] Adding ROCm support to host_constant_op

### DIFF
--- a/tensorflow/core/kernels/host_constant_op.cc
+++ b/tensorflow/core/kernels/host_constant_op.cc
@@ -43,7 +43,7 @@ void _HostConstantOp::Compute(OpKernelContext* ctx) {
   ctx->set_output(0, tensor_);
 }
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel
 // registration requires all int32 inputs and outputs to be in host memory.
@@ -52,7 +52,7 @@ REGISTER_KERNEL_BUILDER(Name("Const")
                             .HostMemory("output")
                             .TypeConstraint<int32>("dtype"),
                         _HostConstantOp);
-#endif
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #ifdef TENSORFLOW_USE_SYCL
 REGISTER_KERNEL_BUILDER(Name("Const")


### PR DESCRIPTION
This PR adds ROCm support for host_constant_op

The changes in this PR are trivial, please review and merge...thanks.

-----
Test performed: tensorflow/core/kernels:host_constant_op and tensorflow/tools/pip_package:build_pip_package compiles
@tatianashp @whchung