### PR TITLE
[ROCm] Adding ROCm support to optional_ops

### DIFF
--- a/tensorflow/core/kernels/data/optional_ops.cu.cc
+++ b/tensorflow/core/kernels/data/optional_ops.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #define EIGEN_USE_THREADS
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 
 #include "tensorflow/core/kernels/data/optional_ops.h"
@@ -34,4 +34,4 @@ REGISTER_UNARY_VARIANT_BINARY_OP_FUNCTION(ADD_VARIANT_BINARY_OP, DEVICE_GPU,
 }  // namespace data
 }  // namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
This PR adds ROCm support for optional_op

The changes in this PR are trivial, please review and merge...thanks.

-----
Test performed: //tensorflow/core/kernels/data:optional_ops and //tensorflow/python/data/ops:optional_ops compiles
@tatianashp @whchung