### PR TITLE
[XLA] Fix type mismatch of operations on slices in slice-sinker pass

### DIFF
--- a/tensorflow/compiler/xla/service/slice_sinker.cc
+++ b/tensorflow/compiler/xla/service/slice_sinker.cc
@@ -69,7 +69,10 @@ bool IsElementwiseOperationOnSimilarSlices(const HloInstruction* inst) {
 // checks whether another operation, candidate, is an operation that hasn't been
 // transformed and is similar to operation_on_slices as defined by the following
 // criteria:
-// (1) candidate has the same opcode as the operation_on_slices.
+// (1) candidate has the same opcode and result element type as
+//     operation_on_slices. The check for same result element type is necessary
+//     because kConvert can produce different result element types for the same
+//     input element type.
 // (2) The ith operand of candidate is a slice from the same slice source of
 //     the ith operand in operation_on_slices.
 // (3) All operands of candidate are slices taken from the same indices as the

--- a/tensorflow/compiler/xla/service/slice_sinker.cc
+++ b/tensorflow/compiler/xla/service/slice_sinker.cc
@@ -82,7 +82,9 @@ bool IsSimilarOperationOnSlices(const HloInstruction* operation_on_slices,
     return false;
   }
 
-  if (candidate->opcode() != operation_on_slices->opcode()) {
+  if (candidate->opcode() != operation_on_slices->opcode() ||
+      operation_on_slices->shape().element_type() !=
+          candidate->shape().element_type()) {
     return false;
   }
 

--- a/tensorflow/compiler/xla/service/slice_sinker_test.cc
+++ b/tensorflow/compiler/xla/service/slice_sinker_test.cc
@@ -494,5 +494,24 @@ TEST_F(SliceSinkerTest, Cascade) {
   EXPECT_THAT(slice1->slice_strides(), ElementsAre(1, 1));
 }
 
+TEST_F(SliceSinkerTest, DifferentTypeOperation) {
+  const char* kModuleStr = R"(
+    HloModule m
+    test {
+      p0 = f32[8,9] parameter(0)
+      s00 = f32[2,9] slice(f32[8,9] p0), slice={[0:2], [0:9]}
+      s01 = f32[6,9] slice(f32[8,9] p0), slice={[2:8], [0:9]}
+      convert0 = s32[2,9] convert(f32[2,9] s00)
+      convert1 = s64[6,9] convert(f32[6,9] s01)
+      ROOT tuple = (s32[2,9], s64[6,9]) tuple(convert0, convert1)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+  SliceSinker slice_sinker;
+  TF_ASSERT_OK_AND_ASSIGN(bool result, RunHloPass(&slice_sinker, module.get()));
+  EXPECT_FALSE(result);
+}
+
 }  // namespace
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/slice_sinker_test.cc
+++ b/tensorflow/compiler/xla/service/slice_sinker_test.cc
@@ -494,7 +494,7 @@ TEST_F(SliceSinkerTest, Cascade) {
   EXPECT_THAT(slice1->slice_strides(), ElementsAre(1, 1));
 }
 
-TEST_F(SliceSinkerTest, DifferentTypeOperation) {
+TEST_F(SliceSinkerTest, SameOpcodeDifferentResultElementTypes) {
   const char* kModuleStr = R"(
     HloModule m
     test {


### PR DESCRIPTION
Fix bug: the different primitive types of the operations(like convert) on slices are not peer instructions, and the their slice operands should not be sunk down.
And add UT for this bug.

Example:
    test {
      p0 = f32[8,9] parameter(0)
      s00 = f32[2,9] slice(f32[8,9] p0), slice={[0:2], [0:9]}
      s01 = f32[6,9] slice(f32[8,9] p0), slice={[2:8], [0:9]}
      convert0 = s32[2,9] convert(f32[2,9] s00)
      convert1 = s64[6,9] convert(f32[6,9] s01)
      ROOT tuple = (s32[2,9], s64[6,9]) tuple(convert0, convert1)
    }  
