### PR TITLE
Allow the config APIs dealing with memory growth to work with

### DIFF
--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -1068,6 +1068,9 @@ class Context(object):
       raise ValueError(
           "Cannot set memory growth on device when virtual devices configured")
 
+    if dev.device_type != "GPU":
+      raise ValueError("Cannot set memory growth on non-GPU devices")
+
     self._memory_growth_map[dev] = enable
 
   def get_virtual_device_configuration(self, dev):

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -5956,8 +5956,8 @@ def enable_eager_execution_internal(config=None,
         (context._context._config, config, context._context._device_policy,
          device_policy, context._context._execution_mode, execution_mode))
   else:
-    raise ValueError(
-        "tf.enable_eager_execution must be called at program startup.")
+    # We already created everything, so update the thread local data.
+    context._context._thread_local_data.is_eager = True
 
   # Monkey patch to get rid of an unnecessary conditional since the context is
   # now initialized.


### PR DESCRIPTION
enable_v2_behavior

This entails allowing the Context() object to be created early (which already
seemed like the intention given the physical device APIs).
If enable_v2_behavior is called after, then we update the thread local data to
say we are in eager mode.

PiperOrigin-RevId: 250727360