### PR TITLE
[ROCm] Adding ROCm support for partitioned_function_ops

### DIFF
--- a/tensorflow/core/kernels/partitioned_function_ops.cc
+++ b/tensorflow/core/kernels/partitioned_function_ops.cc
@@ -34,9 +34,9 @@ limitations under the License.
 #include "tensorflow/core/grappler/optimizers/meta_optimizer.h"
 #endif
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/stream_executor/stream.h"
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace tensorflow {
 


### PR DESCRIPTION
This PR adds ROCm support for partitioned_function_ops

The changes in this PR are trivial, please review and merge...thanks.

-----
Test performed:
//tensorflow/core/kernels:partitioned_function_ops compiles

@tatianashp @whchung