### PR TITLE
[TF 2.0 API Docs] Docstring for tf.train.experimental.enable_mixed_precision_graph_rewrite

### DIFF
--- a/tensorflow/python/training/experimental/mixed_precision.py
+++ b/tensorflow/python/training/experimental/mixed_precision.py
@@ -77,41 +77,123 @@ def _wrap_optimizer(opt, loss_scale, use_v1_behavior):
 
 @tf_export('train.experimental.enable_mixed_precision_graph_rewrite', v1=[])
 def enable_mixed_precision_graph_rewrite(opt, loss_scale='dynamic'):
-  """Enable mixed precision in `tf.function`s via a graph rewrite.
+  """Enable mixed precision via a graph rewrite.
 
-  Mixed precision is the use of both float16 and float32 when training a model,
-  and is used to make the model run faster. This function will use mixed
-  precision to speed up the execution time of `tf.function`s when run on a GPU.
-  It does this by changing the dtype of certain operations in the function's
-  graph from float32 to float16.
-
-  This function additionally wraps an Optimizer with a LossScaleOptimizer, which
-  is required to prevent underflow in the float16 tensors during the backwards
-  pass. An optimizer must be passed to this function, which will then be wrapped
-  to use loss scaling.
-
-  When this function is used, gradients should only be computed and applied with
-  the returned optimizer through `opt.minimize()`, and not with a
-  `tf.GradientTape`. This is because the returned optimizer will apply loss
-  scaling, and `tf.GradientTape` will not. If you do use a `tf.GradientTape`,
-  your model may train to a worse quality.
-
-  Currently, mixed precision is only enabled on Volta GPUs and above. TPU
+  Mixed precision is the use of both float32 and float16 data types when
+  training a model to improve performance. This is achieved via a graph rewrite
+  operation and a loss-scale optimizer.
+  
+  Performing arithmetic operations in float16 takes advantage of specialized
+  processing units, such as NVIDIA Tensor Cores for much higher arithmetic
+  throughput. However, due to the smaller representable range, performing the
+  entire training with float16 can result in gradient underflow, that is, small
+  gradient values becoming zeroes. Instead, performing only select arithmetic
+  operations in float16 results in higher throughput and decreased training
+  time when using compatible hardware accelerators while also reducing memory
+  usage, typically without sacrificing model accuracy.
+  
+  Note: While the mixed precision rewrite changes the datatype of various
+  layers throughout the model, the same accuracy reached in float32 is
+  expected. If a `NaN` gradient occurs with dynamic loss scaling, the model
+  update for that batch is skipped. In this case, the global step count is not
+  incremented, and the `LossScaleOptimizer` attempts to decrease the loss
+  scaling value to avoid `NaN` values in subsequent iterations. This approach
+  has been shown to achieve the same accuracy as float32 and, in most cases,
+  better training throughput.
+  
+  Example:
+  
+  ```python
+  model = tf.keras.models.Sequential([
+    ...
+  ])
+  
+  opt = tf.keras.optimizers.SGD()
+  opt = tf.train.experimental.enable_mixed_precision_graph_rewrite(opt)
+  
+  model.compile(loss="categorical_crossentropy",
+              optimizer=opt,
+              metrics=["accuracy"])
+  
+  model.fit(x_train, y_train,
+          batch_size=batch_size,
+          epochs=epochs)
+  ```
+  
+  For a complete example showing the speed-up on training an image
+  classification task on CIFAR10, check out this
+  <a href="https://colab.research.google.com/github/NVIDIA/
+  DeepLearningExamples/blob/master/TensorFlow/docs/amp/notebook_v1.14/
+  auto_mixed_precision_demo_cifar10.ipynb">Colab notebook</a>.
+  
+  Calling `enable_mixed_precision_graph_rewrite(opt)` enables the graph rewrite
+  operation before computing gradients. The function additionally returns an
+  `Optimizer`(`opt`) wrapped with a `LossScaleOptimizer`. This prevents
+  underflow in the float16 tensors during the backward pass. An optimizer of
+  type `tf.train.Optimizer` or `tf.keras.optimizers.Optimizer` must be passed
+  to this function, which will then be wrapped to use loss scaling.
+  
+  <img src="
+  http://developer.download.nvidia.com/compute/machine-learning/frameworks/
+  TF_mixed_precision_training.png" width="500px">
+  
+  The graph rewrite operation changes the `dtype` of certain operations in the
+  graph from float32 to float16. There are several categories of operations
+  that are either included or excluded by this rewrite operation. The following
+  categories of Ops are defined inside corresponding functions under the class 
+  `AutoMixedPrecisionLists` in
+  <a href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/
+  core/grappler/optimizers/auto_mixed_precision_lists.h">
+  auto_mixed_precision_lists.h</a>:
+  
+  * `ClearList`: Ops that do not have numerically significant adverse effects.
+  E.g. `ArgMax` and `Floor`.
+  * `WhiteList`: Ops that are considered numerically safe for execution in
+  float16, and thus are always converted. E.g. `Conv2D`.
+  * `BlackList`: Ops that are numerically unsafe to execute in float16 and
+  can negatively affect downstream nodes. E.g. `Softmax`.
+  * `GrayList`: Ops that are considered numerically safe for execution in
+  float16 unless downstream from a BlackList Op. E.g. `Add` and `AvgPool`.
+  
+  When this function is used, gradients should only be computed and applied
+  with the returned optimizer, either by calling `opt.minimize()` or
+  `opt.compute_gradients()` followed by `opt.apply_gradients()`.
+  Gradients should not be computed with `tf.gradients` or `tf.GradientTape`.
+  This is because the returned optimizer will apply loss scaling, and
+  `tf.gradients` or `tf.GradientTape` will not. If you do directly use
+  `tf.gradients` or `tf.GradientTape`, your model may not converge due to
+  float16 underflow problems.
+  
+  When eager execution is enabled, the mixed precision graph rewrite is only
+  enabled within `tf.function`, as outside `tf.function`, there is no graph.
+  
+  For NVIDIA GPUs with Tensor cores, as a general performance guide, dimensions
+  (such as batch size, input size, output size, and channel counts)
+  should be powers of two if under 256, or  otherwise divisible by 8 if above
+  256. For more information, check out the
+  [NVIDIA Deep Learning Performance Guide](
+  https://docs.nvidia.com/deeplearning/sdk/dl-performance-guide/index.html).
+  
+  Currently, mixed precision is only enabled on NVIDIA Tensor Core GPUs with
+  Compute Capability 7.0 and above (Volta, Turing, or newer architectures). The
+  parts of the graph on CPUs and TPUs are untouched by the graph rewrite. TPU
   support is coming soon. CPUs are not supported, as CPUs do not run float16
   operations faster than float32 operations.
-
-  WARNING: This rewrite silently affects the entire model and can have
-  unintended consequences. One example: If a NaN occurs during dynamic loss
-  scaling, the data for the batch is silently dropped while the
-  LossScaleOptimizer attempts to find the appropriate scaling value on the next
-  batch.
-
+  
+  Raises:
+    `ValueError` when
+    `mixed_precision_global_state.using_default_mixed_precision_policy`
+    is set to `False` before
+    `tf.train.experimental.enable_mixed_precision_graph_rewrite()`
+    is called.
+  
   Args:
     opt: An instance of a `tf.keras.optimizers.Optimizer`.
-    loss_scale: Either an int/float, the string "dynamic", or an instance of a
-      `tf.train.experimental.LossScale`. The loss scale to use. It is
-      recommended to keep this as its default value of "dynamic".
-
+    loss_scale: Either an int/float, the string `"dynamic"`, or an instance of
+      a `tf.train.experimental.LossScale`. The loss scale to use. It is
+      recommended to keep this as its default value of `"dynamic"`, which will 
+      adjust the scaling automatically to prevent `Inf` or `NaN` values.
+  
   Returns:
     A version of `opt` that will use loss scaling to prevent underflow.
   """
@@ -123,36 +205,122 @@ def enable_mixed_precision_graph_rewrite(opt, loss_scale='dynamic'):
 def enable_mixed_precision_graph_rewrite_v1(opt, loss_scale='dynamic'):
   """Enable mixed precision via a graph rewrite.
 
-  Mixed precision is the use of both float16 and float32 when training a model,
-  and is used to make the model run faster. This function will use mixed
-  precision to speed up the execution time of your model when run on a GPU. It
-  does this by changing the dtype of certain operations in the graph from
-  float32 to float16.
-
-  This function additionally wraps an Optimizer with a LossScaleOptimizer, which
-  is required to prevent underflow in the float16 tensors during the backwards
-  pass. An optimizer must be passed to this function, which will then be wrapped
-  to use loss scaling.
-
-  When this function is used, gradients should only be computed and applied with
-  the returned optimizer, either by calling `opt.minimize()` or
-  `opt.compute_gradients()` followed by `opt.apply_gradients()`. Gradients
-  should not be computed with `tf.gradients` or `tf.GradientTape`. This is
-  because the returned optimizer will apply loss scaling, and
-  `tf.gradients`/`tf.GradientTape` will not. If you do directly use
-  `tf.gradients` or `tf.GradientTape`, your model may train to a worse quality.
-
-  Currently, mixed precision is only enabled on Volta GPUs and above. TPU
+  Mixed precision is the use of both float32 and float16 data types when
+  training a model to improve performance. This is achieved via a graph rewrite
+  operation and a loss-scale optimizer.
+  
+  Performing arithmetic operations in float16 takes advantage of specialized
+  processing units, such as NVIDIA Tensor Cores for much higher arithmetic
+  throughput. However, due to the smaller representable range, performing the
+  entire training with float16 can result in gradient underflow, that is, small
+  gradient values becoming zeroes. Instead, performing only select arithmetic
+  operations in float16 results in higher throughput and decreased training
+  time when using compatible hardware accelerators while also reducing memory
+  usage, typically without sacrificing model accuracy.
+  
+  Note: While the mixed precision rewrite changes the datatype of various
+  layers throughout the model, the same accuracy reached in float32 is
+  expected. If a `NaN` gradient occurs with dynamic loss scaling, the model
+  update for that batch is skipped. In this case, the global step count is not
+  incremented, and the `LossScaleOptimizer` attempts to decrease the loss
+  scaling value to avoid `NaN` values in subsequent iterations. This approach
+  has been shown to achieve the same accuracy as float32 and, in most cases,
+  better training throughput.
+  
+  Example:
+  
+  ```python
+  model = tf.keras.models.Sequential([
+    ...
+  ])
+  
+  opt = tf.keras.optimizers.SGD()
+  opt = tf.train.experimental.enable_mixed_precision_graph_rewrite(opt)
+  
+  model.compile(loss="categorical_crossentropy",
+              optimizer=opt,
+              metrics=["accuracy"])
+  
+  model.fit(x_train, y_train,
+          batch_size=batch_size,
+          epochs=epochs)
+  ```
+  
+  For a complete example showing the speed-up on training an image
+  classification task on CIFAR10, check out this
+  <a href="https://colab.research.google.com/github/NVIDIA/
+  DeepLearningExamples/blob/master/TensorFlow/docs/amp/notebook_v1.14/
+  auto_mixed_precision_demo_cifar10.ipynb">Colab notebook</a>.
+  
+  Calling `enable_mixed_precision_graph_rewrite(opt)` enables the graph rewrite
+  operation before computing gradients. The function additionally returns an
+  `Optimizer`(`opt`) wrapped with a `LossScaleOptimizer`. This prevents
+  underflow in the float16 tensors during the backward pass. An optimizer of
+  type `tf.train.Optimizer` or `tf.keras.optimizers.Optimizer` must be passed
+  to this function, which will then be wrapped to use loss scaling.
+  
+  <img src="
+  http://developer.download.nvidia.com/compute/machine-learning/frameworks/
+  TF_mixed_precision_training.png" width="500px">
+  
+  The graph rewrite operation changes the `dtype` of certain operations in the
+  graph from float32 to float16. There are several categories of operations
+  that are either included or excluded by this rewrite operation. The following
+  categories of Ops are defined inside corresponding functions under the class 
+  `AutoMixedPrecisionLists` in
+  <a href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/
+  core/grappler/optimizers/auto_mixed_precision_lists.h">
+  auto_mixed_precision_lists.h</a>:
+  
+  * `ClearList`: Ops that do not have numerically significant adverse effects.
+  E.g. `ArgMax` and `Floor`.
+  * `WhiteList`: Ops that are considered numerically safe for execution in
+  float16, and thus are always converted. E.g. `Conv2D`.
+  * `BlackList`: Ops that are numerically unsafe to execute in float16 and
+  can negatively affect downstream nodes. E.g. `Softmax`.
+  * `GrayList`: Ops that are considered numerically safe for execution in
+  float16 unless downstream from a BlackList Op. E.g. `Add` and `AvgPool`.
+  
+  When this function is used, gradients should only be computed and applied
+  with the returned optimizer, either by calling `opt.minimize()` or
+  `opt.compute_gradients()` followed by `opt.apply_gradients()`.
+  Gradients should not be computed with `tf.gradients` or `tf.GradientTape`.
+  This is because the returned optimizer will apply loss scaling, and
+  `tf.gradients` or `tf.GradientTape` will not. If you do directly use
+  `tf.gradients` or `tf.GradientTape`, your model may not converge due to
+  float16 underflow problems.
+  
+  When eager execution is enabled, the mixed precision graph rewrite is only
+  enabled within `tf.function`, as outside `tf.function`, there is no graph.
+  
+  For NVIDIA GPUs with Tensor cores, as a general performance guide, dimensions
+  (such as batch size, input size, output size, and channel counts)
+  should be powers of two if under 256, or  otherwise divisible by 8 if above
+  256. For more information, check out the
+  [NVIDIA Deep Learning Performance Guide](
+  https://docs.nvidia.com/deeplearning/sdk/dl-performance-guide/index.html).
+  
+  Currently, mixed precision is only enabled on NVIDIA Tensor Core GPUs with
+  Compute Capability 7.0 and above (Volta, Turing, or newer architectures). The
+  parts of the graph on CPUs and TPUs are untouched by the graph rewrite. TPU
   support is coming soon. CPUs are not supported, as CPUs do not run float16
   operations faster than float32 operations.
-
+  
+  Raises:
+    `ValueError` when
+    `mixed_precision_global_state.using_default_mixed_precision_policy`
+    is set to `False` before
+    `tf.train.experimental.enable_mixed_precision_graph_rewrite()`
+    is called.
+  
   Args:
     opt: An instance of a `tf.keras.optimizers.Optimizer` or a
       `tf.train.Optimizer`.
-    loss_scale: Either an int/float, the string "dynamic", or an instance of a
-      `tf.train.experimental.LossScale`. The loss scale to use. It is
-      recommended to keep this as its default value of "dynamic".
-
+    loss_scale: Either an int/float, the string `"dynamic"`, or an instance of
+      a `tf.train.experimental.LossScale`. The loss scale to use. It is
+      recommended to keep this as its default value of `"dynamic"`, which will 
+      adjust the scaling automatically to prevent `Inf` or `NaN` values.
+  
   Returns:
     A version of `opt` that will use loss scaling to prevent underflow.
   """


### PR DESCRIPTION
In response to #29241

Improved the docstring for `tf.train.experimental.enable_mixed_precision_graph_rewrite`:

* Added example for using function
* Added colab notebook to demonstrate speed-up without performance penalty
* Added original graphic for loss scaling ([source](https://docs.google.com/presentation/d/1ZCREpnt2H7I7J6Xek-Z0bZ_qE3bIHFzbTUed8Vdw6Ag/edit?usp=sharing))
* Added more information about graph rewrite operation
* Added performance guide
* Added exception information
* Added more clarification to `loss_scale` argument

A gist with the rendered docstring is [here](https://gist.github.com/tlkh/fa20c5bf3c8b48def4501cccff8b3559) for ease of review.

Thank you, any feedback or criticism is welcome.
