### PR TITLE
Update tf.keras.backend.cast_to_floatx example

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -150,7 +150,7 @@ def cast_to_floatx(x):
   Example:
   ```python
       >>> from tensorflow.keras import backend as K
-      >>> K.floatx()
+      >>> K.cast_to_floatx()
       'float32'
       >>> arr = numpy.array([1.0, 2.0], dtype='float64')
       >>> arr.dtype

--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -149,7 +149,7 @@ def cast_to_floatx(x):
 
   Example:
   ```python
-      >>> from keras import backend as K
+      >>> from tensorflow.keras import backend as K
       >>> K.floatx()
       'float32'
       >>> arr = numpy.array([1.0, 2.0], dtype='float64')

--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -150,7 +150,7 @@ def cast_to_floatx(x):
   Example:
   ```python
       >>> from tensorflow.keras import backend as K
-      >>> K.cast_to_floatx()
+      >>> K.floatx()
       'float32'
       >>> arr = numpy.array([1.0, 2.0], dtype='float64')
       >>> arr.dtype


### PR DESCRIPTION
Updated the import statement for cast_to_floatx to import keras backend from tensorflow.keras instead of keras.