### PR TITLE
[TF 2.0 API Docs] tf.image.adjust_gamma

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1664,6 +1664,12 @@ def adjust_gamma(image, gamma=1, gain=1):
     gain  : A scalar or tensor. The constant multiplier.
   Returns:
     A Tensor. A Gamma-adjusted tensor of the same shape and type as `image`.
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.adjust_gamma(x, 0.2)
+    ```
   Raises:
     ValueError: If gamma is negative.
   Notes:


### PR DESCRIPTION
Updated adjust_gamma by adding a usage example in the docstring in image_ops_impl.py. The issue has been raised and is provided in this link https://github.com/tensorflow/tensorflow/issues/29325