### PR TITLE
[TF 2.0 API Docs] tf.image.adjust_hue

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1889,6 +1889,13 @@ def adjust_hue(image, delta, name=None):
 
   Returns:
     Adjusted image(s), same shape and DType as `image`.
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.adjust_hue(x, 0.2)
+    ```
   """
   with ops.name_scope(name, 'adjust_hue', [image]) as name:
     image = ops.convert_to_tensor(image, name='image')


### PR DESCRIPTION
Updated adjust_hue by adding a usage example in the docstring in image_ops_impl.py. The issue has been raised and is provided in this link https://github.com/tensorflow/tensorflow/issues/29327