### PR TITLE
[TF 2.0 API Docs] tf.image.adjust_jpeg_quality

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1965,6 +1965,16 @@ def adjust_jpeg_quality(image, jpeg_quality, name=None):
 
   Returns:
     Adjusted image(s), same shape and DType as `image`.
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.adjust_jpeg_quality(x, 75)
+    ```
+  Raises:
+    InvalidArgumentError: quality must be in [0,100]
+    InvalidArgumentError: image must have 1 or 3 channels
   """
   with ops.name_scope(name, 'adjust_jpeg_quality', [image]) as name:
     image = ops.convert_to_tensor(image, name='image')


### PR DESCRIPTION
Updated adjust_jpeg_quality by adding a usage example in the docstring in image_ops_impl.py. Added raises that were happening but not occurring in the docstring. The issue has been raised and is provided in this link https://github.com/tensorflow/tensorflow/issues/29330