### PR TITLE
[TF 2.0 API Docs] tf.image.adjust_saturation

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2041,6 +2041,16 @@ def adjust_saturation(image, saturation_factor, name=None):
 
   Returns:
     Adjusted image(s), same shape and DType as `image`.
+    
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.adjust_saturation(x, 0.5)
+    ```
+    
+  Raises:
+    InvalidArgumentError: input must have 3 channels
   """
   with ops.name_scope(name, 'adjust_saturation', [image]) as name:
     image = ops.convert_to_tensor(image, name='image')


### PR DESCRIPTION
Updated adjust_saturation by adding a usage example in the docstring in image_ops_impl.py. Also added a raise InvalidArgumentError for incorrect shape in the docstring. The issue has been raised and is provided in this link https://github.com/tensorflow/tensorflow/issues/29332