### PR TITLE
Pass the Android aar build with android-ndk-r19c clang 3.8

### DIFF
--- a/tensorflow/core/kernels/image_resizer_state.h
+++ b/tensorflow/core/kernels/image_resizer_state.h
@@ -48,6 +48,7 @@ inline float CalculateResizeScale(int64 in_size, int64 out_size,
 // Half pixel scaler scales assuming that the pixel centers are at 0.5, i.e. the
 // floating point coordinates of the top,left pixel is 0.5,0.5.
 struct HalfPixelScaler {
+  HalfPixelScaler() {};
   inline float operator()(const int x, const float scale) const {
     // Note that we subtract 0.5 from the return value, as the existing bilinear
     // sampling code etc assumes pixels are in the old coordinate system.
@@ -59,6 +60,7 @@ struct HalfPixelScaler {
 // translation leading to inconsistent results. For example, a flip then a
 // resize gives different results then a resize then a flip.
 struct LegacyScaler {
+  LegacyScaler() {};
   inline float operator()(const int x, const float scale) const {
     return static_cast<float>(x) * scale;
   }

--- a/tensorflow/core/kernels/redux_functor.h
+++ b/tensorflow/core/kernels/redux_functor.h
@@ -37,6 +37,7 @@ namespace functor {
 //   output: [Di, ... , DN] where i belongs to set [1,N]
 template <typename T, typename AccumT, typename BinaryFunctor>
 struct ReduceOuterDimensions {
+  ReduceOuterDimensions() {};
   template <int num_dims>
   void operator()(const CPUDevice& device,
                   const Eigen::DSizes<Eigen::Index, num_dims>& input_dims,
@@ -198,6 +199,7 @@ struct ReduceOuterDimensions {
 //   output: [Di, ... , Dj] where i & j belongs to set [1,N].
 template <typename T, typename AccumT, typename BinaryFunctor, typename Reducer>
 struct ReduceMiddleDimensions {
+  ReduceMiddleDimensions() {};
   template <int num_dims>
   void operator()(const CPUDevice& device,
                   const Eigen::DSizes<Eigen::Index, num_dims>& input_dims,
@@ -256,7 +258,7 @@ struct ReduceMiddleDimensions {
     using Input = Eigen::TensorMap<Eigen::Tensor<const T, 1>>;
 
     Eigen::array<Eigen::Index, 1> reduction_axis = {0};
-    const Reducer reducer;
+    Reducer reducer;
     const BinaryFunctor binary_op;
 
     const auto compute = [inner_dim, middle_dim, input_data, buffer_data,


### PR DESCRIPTION
Add user-provided default constructor and remove "const" statement
for "reducer".

Build cmds:
$bazel build --cxxopt='--std=c++11' -c opt --config=android_arm64 \
   --config=monolithic //tensorflow/lite/java:tensorflow-lite-with-select-tf-ops

Build error:
tensorflow/core/kernels/bias_op.cc:278:13: error: default initialization of an object
of const type 'const functor::ReduceMiddleDimensions<float, AccumT,
Eigen::internal::scalar_sum_op<AccumT>, Eigen::internal::SumReducer<float> >'
(aka 'const ReduceMiddleDimensions<float, float, scalar_sum_op<float>,
 SumReducer<float> >') without a user-provided default constructor
            redux;
                        ^
tensorflow/core/kernels/quantized_resize_bilinear_op.cc:52:16: error: default
initialization of an object of const type 'const tensorflow::LegacyScaler'
without a user-provided default constructor
  const Scaler scaler;
                 ^

Signed-off-by: guoyin.chen <guoyin.chen@nxp.com>