### PR TITLE
[XLA] Make HasSideEffectNoRecurse virtual

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_instruction.h
+++ b/tensorflow/compiler/xla/service/hlo_instruction.h
@@ -823,7 +823,7 @@ class HloInstruction {
 
   // Returns true if this instruction has a side effect, irrespective of whether
   // any called computations may contain an instruction with side effects.
-  bool HasSideEffectNoRecurse() const;
+  virtual bool HasSideEffectNoRecurse() const;
 
   // Returns true if this instruction has a side effect. An instruction has a
   // side effect if it uses certain opcodes or calls a computation with a side


### PR DESCRIPTION
This allows for instructions which inherit from HloInstruction to be marked as having side effects and not be removed from the graph by DCE - for example we can create a class/HLO Instruction which inherits from HloCustomCallInstruction and has side effects, such as print.