### PR TITLE
[XLA] Allow HloCustomCallInstruction to have a side-effect

### DIFF
--- a/tensorflow/compiler/xla/service/hlo.proto
+++ b/tensorflow/compiler/xla/service/hlo.proto
@@ -219,7 +219,7 @@ message HloInstructionProto {
   // elements in that dimension.
   repeated int64 outer_dimension_partitions = 64;
 
-  // Whether the kCustomCall instruction has a side effect, only present for
+  // Whether the kCustomCall instruction has side-effects, only present for
   // kCustomCall.
   bool custom_call_has_side_effect = 65;
 }

--- a/tensorflow/compiler/xla/service/hlo.proto
+++ b/tensorflow/compiler/xla/service/hlo.proto
@@ -35,7 +35,7 @@ import "tensorflow/compiler/xla/xla_data.proto";
 option cc_enable_arenas = true;
 
 // Serialization of HloInstruction.
-// Next ID: 65
+// Next ID: 66
 message HloInstructionProto {
   reserved 10;
   reserved "parameter_name";
@@ -218,6 +218,10 @@ message HloInstructionProto {
   // It's illegal to partition a dimension into more shards than there are
   // elements in that dimension.
   repeated int64 outer_dimension_partitions = 64;
+
+  // Whether the kCustomCall instruction has a side effect, only present for
+  // kCustomCall.
+  bool custom_call_has_side_effect = 65;
 }
 
 // Serialization of HloComputation.

--- a/tensorflow/compiler/xla/service/hlo_dce_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_dce_test.cc
@@ -98,7 +98,7 @@ TEST_F(HloDceTest, CustomCallInstructionsWithSideEffect) {
       HloInstruction::CreateCustomCall(ShapeUtil::MakeShape(F32, {}),
                                        /*operands=*/{},
                                        /*custom_call_target=*/"foo")));
-  instr->set_has_side_effect(true);
+  instr->set_custom_call_has_side_effect(true);
   builder.AddInstruction(HloInstruction::CreateTuple({}));
 
   auto module = CreateNewVerifiedModule();

--- a/tensorflow/compiler/xla/service/hlo_dce_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_dce_test.cc
@@ -101,7 +101,7 @@ TEST_F(HloDceTest, CustomCallInstructionsWithSideEffect) {
   builder.AddInstruction(HloInstruction::CreateTuple({}));
 
   auto module = CreateNewVerifiedModule();
-  auto computation = module->AddEntryComputation(builder.Build());
+  module->AddEntryComputation(builder.Build());
 
   HloDCE dce;
   TF_ASSERT_OK_AND_ASSIGN(bool result, RunHloPass(&dce, module.get()));
@@ -111,14 +111,14 @@ TEST_F(HloDceTest, CustomCallInstructionsWithSideEffect) {
 TEST_F(HloDceTest, CustomCallInstructionsWithoutSideEffect) {
   // Verify that custom call instruction without side-effect is removed.
   auto builder = HloComputation::Builder(TestName());
-  auto instr = builder.AddInstruction(
+  builder.AddInstruction(
       HloInstruction::CreateCustomCall(ShapeUtil::MakeShape(F32, {}),
                                        /*operands=*/{},
                                        /*custom_call_target=*/"foo"));
   builder.AddInstruction(HloInstruction::CreateTuple({}));
 
   auto module = CreateNewVerifiedModule();
-  auto computation = module->AddEntryComputation(builder.Build());
+  module->AddEntryComputation(builder.Build());
 
   HloDCE dce;
   TF_ASSERT_OK_AND_ASSIGN(bool result, RunHloPass(&dce, module.get()));

--- a/tensorflow/compiler/xla/service/hlo_dce_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_dce_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "absl/memory/memory.h"
 #include "tensorflow/compiler/xla/layout_util.h"
 #include "tensorflow/compiler/xla/literal_util.h"
+#include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
 #include "tensorflow/compiler/xla/service/hlo_computation.h"
 #include "tensorflow/compiler/xla/service/hlo_instruction.h"
 #include "tensorflow/compiler/xla/service/hlo_instructions.h"
@@ -93,10 +94,10 @@ TEST_F(HloDceTest, InstructionsWithSideEffect) {
 TEST_F(HloDceTest, CustomCallInstructionsWithSideEffect) {
   // Verify that custom call instruction with side-effect is not removed.
   auto builder = HloComputation::Builder(TestName());
-  auto instr = builder.AddInstruction(
+  auto instr = Cast<HloCustomCallInstruction>(builder.AddInstruction(
       HloInstruction::CreateCustomCall(ShapeUtil::MakeShape(F32, {}),
                                        /*operands=*/{},
-                                       /*custom_call_target=*/"foo"));
+                                       /*custom_call_target=*/"foo")));
   instr->set_has_side_effect(true);
   builder.AddInstruction(HloInstruction::CreateTuple({}));
 

--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -1272,7 +1272,7 @@ bool HloInstruction::HasSideEffectNoRecurse() const {
     case HloOpcode::kAllReduce:
       return all_reduce_id().has_value();
     case HloOpcode::kCustomCall:
-      return Cast<HloCustomCallInstruction>(this)->has_side_effect();
+      return has_side_effect();
     default:
       return false;
   }

--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -449,8 +449,6 @@ StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
                                            operands(2), computations(1));
       break;
     case HloOpcode::kCustomCall: {
-      auto custom_call_instr =
-          Cast<HloCustomCallInstruction>(instruction.get());
       if (proto.constrain_layout()) {
         // A proto RepeatedPtrField cannot be converted to a Span (it is a
         // vector of pointers essentially) so create a vector of shapes to pass
@@ -468,6 +466,8 @@ StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
             CreateCustomCall(shape, all_operands(), proto.custom_call_target(),
                              proto.backend_config());
       }
+      auto custom_call_instr =
+          Cast<HloCustomCallInstruction>(instruction.get());
       if (proto.has_window()) {
         custom_call_instr->set_window(proto.window());
       }

--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -481,6 +481,8 @@ StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
       static_cast<HloCustomCallInstruction*>(instruction.get())
           ->set_batch_group_count(
               std::max(static_cast<int64>(proto.batch_group_count()), 1LL));
+      static_cast<HloCustomCallInstruction*>(instruction.get())
+          ->set_has_side_effect(proto.custom_call_has_side_effect());
       break;
     case HloOpcode::kPad:
       TF_RET_CHECK(proto.has_padding_config());
@@ -1270,6 +1272,8 @@ bool HloInstruction::HasSideEffectNoRecurse() const {
       return true;
     case HloOpcode::kAllReduce:
       return all_reduce_id().has_value();
+    case HloOpcode::kCustomCall:
+      return Cast<HloCustomCallInstruction>(this)->has_side_effect();
     default:
       return false;
   }

--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -1272,7 +1272,7 @@ bool HloInstruction::HasSideEffectNoRecurse() const {
     case HloOpcode::kAllReduce:
       return all_reduce_id().has_value();
     case HloOpcode::kCustomCall:
-      return has_side_effect();
+      return Cast<HloCustomCallInstruction>(this)->has_side_effect();
     default:
       return false;
   }
@@ -3607,14 +3607,6 @@ void HloInstruction::set_scatter(HloComputation* computation) {
 
 const string& HloInstruction::custom_call_target() const {
   return Cast<HloCustomCallInstruction>(this)->custom_call_target();
-}
-
-const bool HloInstruction::has_side_effect() const {
-  return Cast<HloCustomCallInstruction>(this)->has_side_effect();
-}
-
-void HloInstruction::set_has_side_effect(const bool has_side_effect) {
-  Cast<HloCustomCallInstruction>(this)->set_has_side_effect(has_side_effect);
 }
 
 const PaddingConfig& HloInstruction::padding_config() const {

--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -479,7 +479,7 @@ StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
           std::max(static_cast<int64>(proto.feature_group_count()), 1LL));
       custom_call_instr->set_batch_group_count(
           std::max(static_cast<int64>(proto.batch_group_count()), 1LL));
-      custom_call_instr->set_has_side_effect(
+      custom_call_instr->set_custom_call_has_side_effect(
           proto.custom_call_has_side_effect());
       break;
     }
@@ -1272,7 +1272,8 @@ bool HloInstruction::HasSideEffectNoRecurse() const {
     case HloOpcode::kAllReduce:
       return all_reduce_id().has_value();
     case HloOpcode::kCustomCall:
-      return Cast<HloCustomCallInstruction>(this)->has_side_effect();
+      return Cast<HloCustomCallInstruction>(this)
+          ->custom_call_has_side_effect();
     default:
       return false;
   }

--- a/tensorflow/compiler/xla/service/hlo_instruction.h
+++ b/tensorflow/compiler/xla/service/hlo_instruction.h
@@ -1603,6 +1603,12 @@ class HloInstruction {
   // Delegates to HloCustomCallInstruction::custom_call_target.
   const string& custom_call_target() const;
 
+  // Delegates to HloCustomCallInstruction::has_side_effect.
+  const bool has_side_effect() const;
+
+  // Delegates to HloCustomCallInstruction::set_has_side_effect.
+  void set_has_side_effect(const bool has_side_effect);
+
   // Delegates to HloPadInstruction::padding_config.
   const PaddingConfig& padding_config() const;
 

--- a/tensorflow/compiler/xla/service/hlo_instruction.h
+++ b/tensorflow/compiler/xla/service/hlo_instruction.h
@@ -1603,12 +1603,6 @@ class HloInstruction {
   // Delegates to HloCustomCallInstruction::custom_call_target.
   const string& custom_call_target() const;
 
-  // Delegates to HloCustomCallInstruction::has_side_effect.
-  const bool has_side_effect() const;
-
-  // Delegates to HloCustomCallInstruction::set_has_side_effect.
-  void set_has_side_effect(const bool has_side_effect);
-
   // Delegates to HloPadInstruction::padding_config.
   const PaddingConfig& padding_config() const;
 

--- a/tensorflow/compiler/xla/service/hlo_instruction_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction_test.cc
@@ -1734,9 +1734,7 @@ TEST_F(HloInstructionTest, IdenticalAccountsForCustomCallHasSideEffect) {
   auto instr2 = instr1->Clone();
   EXPECT_TRUE(instr1->Identical(*instr2));
 
-  auto custom_call_instr1 =
-      static_cast<HloCustomCallInstruction*>(instr1.get());
-  custom_call_instr1->set_has_side_effect(true);
+  instr1->set_has_side_effect(true);
   EXPECT_FALSE(instr1->Identical(*instr2));
 }
 
@@ -1768,13 +1766,11 @@ TEST_F(HloInstructionTest, CloneHasSideEffectOnCustomCall) {
   auto instr = HloInstruction::CreateCustomCall(ShapeUtil::MakeShape(F32, {}),
                                                 /*operands=*/{},
                                                 /*custom_call_target=*/"foo");
-  auto custom_call_instr = static_cast<HloCustomCallInstruction*>(instr.get());
-  EXPECT_FALSE(custom_call_instr->has_side_effect());
-  custom_call_instr->set_has_side_effect(true);
-  EXPECT_TRUE(custom_call_instr->has_side_effect());
+  EXPECT_FALSE(instr->has_side_effect());
+  instr->set_has_side_effect(true);
+  EXPECT_TRUE(instr->has_side_effect());
   auto clone = instr->Clone();
-  auto custom_call_clone = static_cast<HloCustomCallInstruction*>(clone.get());
-  EXPECT_TRUE(custom_call_clone->has_side_effect());
+  EXPECT_TRUE(clone->has_side_effect());
 }
 
 TEST_F(HloInstructionTest, CustomCallHasSideEffect) {
@@ -1782,8 +1778,7 @@ TEST_F(HloInstructionTest, CustomCallHasSideEffect) {
                                                 /*operands=*/{},
                                                 /*custom_call_target=*/"foo");
   EXPECT_FALSE(instr->HasSideEffect());
-  auto custom_call_instr = static_cast<HloCustomCallInstruction*>(instr.get());
-  custom_call_instr->set_has_side_effect(true);
+  instr->set_has_side_effect(true);
   EXPECT_TRUE(instr->HasSideEffect());
 }
 

--- a/tensorflow/compiler/xla/service/hlo_instruction_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/literal.h"
 #include "tensorflow/compiler/xla/protobuf_util.h"
 #include "tensorflow/compiler/xla/service/dfs_hlo_visitor_with_default.h"
+#include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
 #include "tensorflow/compiler/xla/service/hlo_computation.h"
 #include "tensorflow/compiler/xla/service/hlo_instructions.h"
 #include "tensorflow/compiler/xla/service/hlo_parser.h"
@@ -1734,7 +1735,8 @@ TEST_F(HloInstructionTest, IdenticalAccountsForCustomCallHasSideEffect) {
   auto instr2 = instr1->Clone();
   EXPECT_TRUE(instr1->Identical(*instr2));
 
-  instr1->set_has_side_effect(true);
+  auto custom_call_instr1 = Cast<HloCustomCallInstruction>(instr1.get());
+  custom_call_instr1->set_has_side_effect(true);
   EXPECT_FALSE(instr1->Identical(*instr2));
 }
 
@@ -1766,19 +1768,22 @@ TEST_F(HloInstructionTest, CloneHasSideEffectOnCustomCall) {
   auto instr = HloInstruction::CreateCustomCall(ShapeUtil::MakeShape(F32, {}),
                                                 /*operands=*/{},
                                                 /*custom_call_target=*/"foo");
-  EXPECT_FALSE(instr->has_side_effect());
-  instr->set_has_side_effect(true);
-  EXPECT_TRUE(instr->has_side_effect());
+  auto custom_call_instr = Cast<HloCustomCallInstruction>(instr.get());
+  EXPECT_FALSE(custom_call_instr->has_side_effect());
+  custom_call_instr->set_has_side_effect(true);
+  EXPECT_TRUE(custom_call_instr->has_side_effect());
   auto clone = instr->Clone();
-  EXPECT_TRUE(clone->has_side_effect());
+  auto custom_call_clone = Cast<HloCustomCallInstruction>(clone.get());
+  EXPECT_TRUE(custom_call_clone->has_side_effect());
 }
 
 TEST_F(HloInstructionTest, CustomCallHasSideEffect) {
   auto instr = HloInstruction::CreateCustomCall(ShapeUtil::MakeShape(F32, {}),
                                                 /*operands=*/{},
                                                 /*custom_call_target=*/"foo");
+  auto custom_call_instr = Cast<HloCustomCallInstruction>(instr.get());
   EXPECT_FALSE(instr->HasSideEffect());
-  instr->set_has_side_effect(true);
+  custom_call_instr->set_has_side_effect(true);
   EXPECT_TRUE(instr->HasSideEffect());
 }
 

--- a/tensorflow/compiler/xla/service/hlo_instruction_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction_test.cc
@@ -1736,7 +1736,7 @@ TEST_F(HloInstructionTest, IdenticalAccountsForCustomCallHasSideEffect) {
   EXPECT_TRUE(instr1->Identical(*instr2));
 
   auto custom_call_instr1 = Cast<HloCustomCallInstruction>(instr1.get());
-  custom_call_instr1->set_has_side_effect(true);
+  custom_call_instr1->set_custom_call_has_side_effect(true);
   EXPECT_FALSE(instr1->Identical(*instr2));
 }
 
@@ -1769,12 +1769,12 @@ TEST_F(HloInstructionTest, CloneHasSideEffectOnCustomCall) {
                                                 /*operands=*/{},
                                                 /*custom_call_target=*/"foo");
   auto custom_call_instr = Cast<HloCustomCallInstruction>(instr.get());
-  EXPECT_FALSE(custom_call_instr->has_side_effect());
-  custom_call_instr->set_has_side_effect(true);
-  EXPECT_TRUE(custom_call_instr->has_side_effect());
+  EXPECT_FALSE(custom_call_instr->custom_call_has_side_effect());
+  custom_call_instr->set_custom_call_has_side_effect(true);
+  EXPECT_TRUE(custom_call_instr->custom_call_has_side_effect());
   auto clone = instr->Clone();
   auto custom_call_clone = Cast<HloCustomCallInstruction>(clone.get());
-  EXPECT_TRUE(custom_call_clone->has_side_effect());
+  EXPECT_TRUE(custom_call_clone->custom_call_has_side_effect());
 }
 
 TEST_F(HloInstructionTest, CustomCallHasSideEffect) {
@@ -1783,7 +1783,7 @@ TEST_F(HloInstructionTest, CustomCallHasSideEffect) {
                                                 /*custom_call_target=*/"foo");
   auto custom_call_instr = Cast<HloCustomCallInstruction>(instr.get());
   EXPECT_FALSE(instr->HasSideEffect());
-  custom_call_instr->set_has_side_effect(true);
+  custom_call_instr->set_custom_call_has_side_effect(true);
   EXPECT_TRUE(instr->HasSideEffect());
 }
 

--- a/tensorflow/compiler/xla/service/hlo_instructions.cc
+++ b/tensorflow/compiler/xla/service/hlo_instructions.cc
@@ -2055,7 +2055,7 @@ HloCustomCallInstruction::HloCustomCallInstruction(
       feature_group_count_(1),
       batch_group_count_(1),
       layout_constrained_(false),
-      has_side_effect_(false) {
+      custom_call_has_side_effect_(false) {
   set_raw_backend_config_string(std::move(opaque));
   for (auto operand : operands) {
     AppendOperand(operand);
@@ -2073,7 +2073,7 @@ HloCustomCallInstruction::HloCustomCallInstruction(
       layout_constrained_(true),
       operand_shapes_with_layout_(operand_shapes_with_layout.begin(),
                                   operand_shapes_with_layout.end()),
-      has_side_effect_(false) {
+      custom_call_has_side_effect_(false) {
   set_raw_backend_config_string(std::move(opaque));
   for (auto operand : operands) {
     AppendOperand(operand);
@@ -2098,7 +2098,7 @@ HloInstructionProto HloCustomCallInstruction::ToProto() const {
       *proto.add_operand_shapes_with_layout() = shape.ToProto();
     }
   }
-  proto.set_custom_call_has_side_effect(has_side_effect_);
+  proto.set_custom_call_has_side_effect(custom_call_has_side_effect_);
   return proto;
 }
 
@@ -2133,8 +2133,8 @@ std::vector<string> HloCustomCallInstruction::ExtraAttributesToStringImpl(
     extra.push_back(StrCat("operand_layout_constraints={",
                            StrJoin(shape_strings, ", "), "}"));
   }
-  if (has_side_effect_) {
-    extra.push_back("has_side_effect=true");
+  if (custom_call_has_side_effect_) {
+    extra.push_back("custom_call_has_side_effect=true");
   }
   return extra;
 }
@@ -2175,7 +2175,8 @@ bool HloCustomCallInstruction::IdenticalSlowPath(
       }
     }
   }
-  if (has_side_effect_ != casted_other.has_side_effect()) {
+  if (custom_call_has_side_effect_ !=
+      casted_other.custom_call_has_side_effect()) {
     return false;
   }
   // Note: backend_config comparison is done in Identical, which is the
@@ -2201,7 +2202,7 @@ HloCustomCallInstruction::CloneWithNewOperandsImpl(
   }
   cloned->set_feature_group_count(feature_group_count_);
   cloned->set_batch_group_count(batch_group_count_);
-  cloned->set_has_side_effect(has_side_effect_);
+  cloned->set_custom_call_has_side_effect(custom_call_has_side_effect_);
   return std::move(cloned);
 }
 

--- a/tensorflow/compiler/xla/service/hlo_instructions.cc
+++ b/tensorflow/compiler/xla/service/hlo_instructions.cc
@@ -2134,7 +2134,7 @@ std::vector<string> HloCustomCallInstruction::ExtraAttributesToStringImpl(
                            StrJoin(shape_strings, ", "), "}"));
   }
   if (has_side_effect_) {
-    extra.push_back(StrCat("has_side_effect=", has_side_effect_));
+    extra.push_back("has_side_effect=true");
   }
   return extra;
 }

--- a/tensorflow/compiler/xla/service/hlo_instructions.cc
+++ b/tensorflow/compiler/xla/service/hlo_instructions.cc
@@ -2054,7 +2054,8 @@ HloCustomCallInstruction::HloCustomCallInstruction(
       custom_call_target_(custom_call_target.begin(), custom_call_target.end()),
       feature_group_count_(1),
       batch_group_count_(1),
-      layout_constrained_(false) {
+      layout_constrained_(false),
+      has_side_effect_(false) {
   set_raw_backend_config_string(std::move(opaque));
   for (auto operand : operands) {
     AppendOperand(operand);
@@ -2071,7 +2072,8 @@ HloCustomCallInstruction::HloCustomCallInstruction(
       batch_group_count_(1),
       layout_constrained_(true),
       operand_shapes_with_layout_(operand_shapes_with_layout.begin(),
-                                  operand_shapes_with_layout.end()) {
+                                  operand_shapes_with_layout.end()),
+      has_side_effect_(false) {
   set_raw_backend_config_string(std::move(opaque));
   for (auto operand : operands) {
     AppendOperand(operand);
@@ -2096,6 +2098,7 @@ HloInstructionProto HloCustomCallInstruction::ToProto() const {
       *proto.add_operand_shapes_with_layout() = shape.ToProto();
     }
   }
+  proto.set_custom_call_has_side_effect(has_side_effect_);
   return proto;
 }
 
@@ -2129,6 +2132,9 @@ std::vector<string> HloCustomCallInstruction::ExtraAttributesToStringImpl(
     }
     extra.push_back(StrCat("operand_layout_constraints={",
                            StrJoin(shape_strings, ", "), "}"));
+  }
+  if (has_side_effect_) {
+    extra.push_back(StrCat("has_side_effect=", has_side_effect_));
   }
   return extra;
 }
@@ -2169,6 +2175,9 @@ bool HloCustomCallInstruction::IdenticalSlowPath(
       }
     }
   }
+  if (has_side_effect_ != casted_other.has_side_effect()) {
+    return false;
+  }
   // Note: backend_config comparison is done in Identical, which is the
   // intended/exposed way to compare computations, and so not repeated here.
   return custom_call_target_ == casted_other.custom_call_target_;
@@ -2192,6 +2201,7 @@ HloCustomCallInstruction::CloneWithNewOperandsImpl(
   }
   cloned->set_feature_group_count(feature_group_count_);
   cloned->set_batch_group_count(batch_group_count_);
+  cloned->set_has_side_effect(has_side_effect_);
   return std::move(cloned);
 }
 

--- a/tensorflow/compiler/xla/service/hlo_instructions.h
+++ b/tensorflow/compiler/xla/service/hlo_instructions.h
@@ -1217,12 +1217,14 @@ class HloCustomCallInstruction : public HloInstruction {
   void set_batch_group_count(int64 batch_group_count) {
     batch_group_count_ = batch_group_count;
   }
-  void set_has_side_effect(const bool has_side_effect) {
+  // Sets whether this custom call has a side-effect - by default a custom call
+  // has no side-effects.
+  void set_has_side_effect(bool has_side_effect) {
     has_side_effect_ = has_side_effect;
   }
   int64 feature_group_count() const { return feature_group_count_; }
   int64 batch_group_count() const { return batch_group_count_; }
-  const bool has_side_effect() const { return has_side_effect_; }
+  bool has_side_effect() const { return has_side_effect_; }
   // Returns a serialized representation of this instruction.
   HloInstructionProto ToProto() const override;
 
@@ -1261,7 +1263,7 @@ class HloCustomCallInstruction : public HloInstruction {
   // For layout-constrained custom calls, this vector holds the shape with
   // layout for each operand.
   std::vector<Shape> operand_shapes_with_layout_;
-  // Whether this call has a side-effect - by default there are no side-effects.
+  // Whether this custom call has a side-effect.
   bool has_side_effect_;
 };
 

--- a/tensorflow/compiler/xla/service/hlo_instructions.h
+++ b/tensorflow/compiler/xla/service/hlo_instructions.h
@@ -1261,7 +1261,7 @@ class HloCustomCallInstruction : public HloInstruction {
   // For layout-constrained custom calls, this vector holds the shape with
   // layout for each operand.
   std::vector<Shape> operand_shapes_with_layout_;
-  // Whether this call has a side-effect.
+  // Whether this call has a side-effect - by default there are no side-effects.
   bool has_side_effect_;
 };
 

--- a/tensorflow/compiler/xla/service/hlo_instructions.h
+++ b/tensorflow/compiler/xla/service/hlo_instructions.h
@@ -1261,7 +1261,7 @@ class HloCustomCallInstruction : public HloInstruction {
   // For layout-constrained custom calls, this vector holds the shape with
   // layout for each operand.
   std::vector<Shape> operand_shapes_with_layout_;
-  // Whether this call has side effects.
+  // Whether this call has a side-effect.
   bool has_side_effect_;
 };
 

--- a/tensorflow/compiler/xla/service/hlo_instructions.h
+++ b/tensorflow/compiler/xla/service/hlo_instructions.h
@@ -1217,8 +1217,12 @@ class HloCustomCallInstruction : public HloInstruction {
   void set_batch_group_count(int64 batch_group_count) {
     batch_group_count_ = batch_group_count;
   }
+  void set_has_side_effect(const bool has_side_effect) {
+    has_side_effect_ = has_side_effect;
+  }
   int64 feature_group_count() const { return feature_group_count_; }
   int64 batch_group_count() const { return batch_group_count_; }
+  const bool has_side_effect() const { return has_side_effect_; }
   // Returns a serialized representation of this instruction.
   HloInstructionProto ToProto() const override;
 
@@ -1257,6 +1261,8 @@ class HloCustomCallInstruction : public HloInstruction {
   // For layout-constrained custom calls, this vector holds the shape with
   // layout for each operand.
   std::vector<Shape> operand_shapes_with_layout_;
+  // Whether this call has side effects.
+  bool has_side_effect_;
 };
 
 class HloPadInstruction : public HloInstruction {

--- a/tensorflow/compiler/xla/service/hlo_instructions.h
+++ b/tensorflow/compiler/xla/service/hlo_instructions.h
@@ -1219,12 +1219,14 @@ class HloCustomCallInstruction : public HloInstruction {
   }
   // Sets whether this custom call has a side-effect - by default a custom call
   // has no side-effects.
-  void set_has_side_effect(bool has_side_effect) {
-    has_side_effect_ = has_side_effect;
+  void set_custom_call_has_side_effect(bool custom_call_has_side_effect) {
+    custom_call_has_side_effect_ = custom_call_has_side_effect;
   }
   int64 feature_group_count() const { return feature_group_count_; }
   int64 batch_group_count() const { return batch_group_count_; }
-  bool has_side_effect() const { return has_side_effect_; }
+  bool custom_call_has_side_effect() const {
+    return custom_call_has_side_effect_;
+  }
   // Returns a serialized representation of this instruction.
   HloInstructionProto ToProto() const override;
 
@@ -1264,7 +1266,7 @@ class HloCustomCallInstruction : public HloInstruction {
   // layout for each operand.
   std::vector<Shape> operand_shapes_with_layout_;
   // Whether this custom call has a side-effect.
-  bool has_side_effect_;
+  bool custom_call_has_side_effect_;
 };
 
 class HloPadInstruction : public HloInstruction {

--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -1514,6 +1514,7 @@ bool HloParser::ParseInstructionRhs(HloComputation::Builder* builder,
       optional<int64> feature_group_count;
       optional<int64> batch_group_count;
       optional<std::vector<Shape>> operand_layout_constraints;
+      optional<bool> has_side_effect;
       attrs["custom_call_target"] = {/*required=*/true, AttrTy::kString,
                                      &custom_call_target};
       attrs["window"] = {/*required=*/false, AttrTy::kWindow, &window};
@@ -1525,6 +1526,8 @@ bool HloParser::ParseInstructionRhs(HloComputation::Builder* builder,
                                     &batch_group_count};
       attrs["operand_layout_constraints"] = {
           /*required=*/false, AttrTy::kShapeList, &operand_layout_constraints};
+      attrs["has_side_effect"] = {/*required=*/false, AttrTy::kBool,
+                                  &has_side_effect};
       if (!ParseOperands(&operands) || !ParseAttributes(attrs)) {
         return false;
       }
@@ -1580,6 +1583,9 @@ bool HloParser::ParseInstructionRhs(HloComputation::Builder* builder,
       }
       if (batch_group_count.has_value()) {
         instruction->set_batch_group_count(*batch_group_count);
+      }
+      if (has_side_effect.has_value()) {
+        instruction->set_has_side_effect(*has_side_effect);
       }
       break;
     }

--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -1515,7 +1515,7 @@ bool HloParser::ParseInstructionRhs(HloComputation::Builder* builder,
       optional<int64> feature_group_count;
       optional<int64> batch_group_count;
       optional<std::vector<Shape>> operand_layout_constraints;
-      optional<bool> has_side_effect;
+      optional<bool> custom_call_has_side_effect;
       attrs["custom_call_target"] = {/*required=*/true, AttrTy::kString,
                                      &custom_call_target};
       attrs["window"] = {/*required=*/false, AttrTy::kWindow, &window};
@@ -1527,8 +1527,8 @@ bool HloParser::ParseInstructionRhs(HloComputation::Builder* builder,
                                     &batch_group_count};
       attrs["operand_layout_constraints"] = {
           /*required=*/false, AttrTy::kShapeList, &operand_layout_constraints};
-      attrs["has_side_effect"] = {/*required=*/false, AttrTy::kBool,
-                                  &has_side_effect};
+      attrs["custom_call_has_side_effect"] = {/*required=*/false, AttrTy::kBool,
+                                  &custom_call_has_side_effect};
       if (!ParseOperands(&operands) || !ParseAttributes(attrs)) {
         return false;
       }
@@ -1586,8 +1586,9 @@ bool HloParser::ParseInstructionRhs(HloComputation::Builder* builder,
       if (batch_group_count.has_value()) {
         custom_call_instr->set_batch_group_count(*batch_group_count);
       }
-      if (has_side_effect.has_value()) {
-        custom_call_instr->set_has_side_effect(*has_side_effect);
+      if (custom_call_has_side_effect.has_value()) {
+        custom_call_instr->set_custom_call_has_side_effect(
+            *custom_call_has_side_effect);
       }
       break;
     }

--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/literal.h"
 #include "tensorflow/compiler/xla/literal_util.h"
 #include "tensorflow/compiler/xla/primitive_util.h"
+#include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
 #include "tensorflow/compiler/xla/service/hlo_domain_metadata.h"
 #include "tensorflow/compiler/xla/service/hlo_instructions.h"
 #include "tensorflow/compiler/xla/service/hlo_lexer.h"
@@ -1572,20 +1573,21 @@ bool HloParser::ParseInstructionRhs(HloComputation::Builder* builder,
             shape, operands, *custom_call_target,
             backend_config ? *backend_config : ""));
       }
+      auto custom_call_instr = Cast<HloCustomCallInstruction>(instruction);
       if (window.has_value()) {
-        instruction->set_window(*window);
+        custom_call_instr->set_window(*window);
       }
       if (dnums.has_value()) {
-        instruction->set_convolution_dimension_numbers(*dnums);
+        custom_call_instr->set_convolution_dimension_numbers(*dnums);
       }
       if (feature_group_count.has_value()) {
-        instruction->set_feature_group_count(*feature_group_count);
+        custom_call_instr->set_feature_group_count(*feature_group_count);
       }
       if (batch_group_count.has_value()) {
-        instruction->set_batch_group_count(*batch_group_count);
+        custom_call_instr->set_batch_group_count(*batch_group_count);
       }
       if (has_side_effect.has_value()) {
-        instruction->set_has_side_effect(*has_side_effect);
+        custom_call_instr->set_has_side_effect(*has_side_effect);
       }
       break;
     }

--- a/tensorflow/compiler/xla/service/hlo_parser_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser_test.cc
@@ -945,6 +945,19 @@ ENTRY %CustomCallWithLayoutConstraints (p0: (f32[2,2], f32[42,2,3]), p1: f32[123
 
 )"
 },
+// CustomCallWithHasSideEffect
+{
+"CustomCallWithHasSideEffect",
+R"(HloModule CustomCallWithHasSideEffect
+
+ENTRY %CustomCallWithHasSideEffect (p0: (f32[2,2], f32[42,2,3]), p1: f32[123,4]) -> (f32[1,2,3], f32[1,2,3]) {
+  %p0 = (f32[2,2]{0,1}, f32[42,2,3]{0,1,2}) parameter(0)
+  %p1 = f32[123,4]{0,1} parameter(1)
+  ROOT %custom-call = (f32[1,2,3]{0,2,1}, f32[1,2,3]{1,2,0}) custom-call((f32[2,2]{0,1}, f32[42,2,3]{0,1,2}) %p0, f32[123,4]{0,1} %p1), custom_call_target="baz", has_side_effect=true
+}
+
+)"
+},
 // Parse c64 literal
 {
 "ParseC64Literal",

--- a/tensorflow/compiler/xla/service/hlo_parser_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser_test.cc
@@ -953,7 +953,7 @@ R"(HloModule CustomCallWithHasSideEffect
 ENTRY %CustomCallWithHasSideEffect (p0: (f32[2,2], f32[42,2,3]), p1: f32[123,4]) -> (f32[1,2,3], f32[1,2,3]) {
   %p0 = (f32[2,2]{0,1}, f32[42,2,3]{0,1,2}) parameter(0)
   %p1 = f32[123,4]{0,1} parameter(1)
-  ROOT %custom-call = (f32[1,2,3]{0,2,1}, f32[1,2,3]{1,2,0}) custom-call((f32[2,2]{0,1}, f32[42,2,3]{0,1,2}) %p0, f32[123,4]{0,1} %p1), custom_call_target="baz", has_side_effect=true
+  ROOT %custom-call = (f32[1,2,3]{0,2,1}, f32[1,2,3]{1,2,0}) custom-call((f32[2,2]{0,1}, f32[42,2,3]{0,1,2}) %p0, f32[123,4]{0,1} %p1), custom_call_target="baz", custom_call_has_side_effect=true
 }
 
 )"


### PR DESCRIPTION
Allows HloCustomCallInstruction to have a side-effect, which means CustomCall instructions which are configured to have a side-effect won't be removed from the graph by DCE - for example a custom call instruction which implements a print.

This is a follow up from https://github.com/tensorflow/tensorflow/pull/29355 with feedback from @jlebar 