### PR TITLE
[INTEL MKL] Revert tensorflow_estimator to 1.13.0rc0, < 1.14.0rc0

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -60,7 +60,7 @@ REQUIRED_PACKAGES = [
     'six >= 1.10.0',
     'protobuf >= 3.6.1',
     'tensorboard >= 1.13.0, < 1.14.0',
-    'tensorflow_estimator >= 1.14.0rc0, < 1.15.0rc0',
+    'tensorflow_estimator >= 1.13.0rc0, < 1.14.0rc0',
     'termcolor >= 1.1.0',
     'wrapt >= 1.11.1',
 ]


### PR DESCRIPTION
Looks like we should stick with:
```
'tensorflow_estimator >= 1.13.0rc0, < 1.14.0rc0'
```
Until version `1.14.0rco` of `tensorflow_estimator` is published until you want me to use the `nightly` builds which I believe is risky.