### PR TITLE
[TF 2.0 API Docs] tf.image.convert_image_dtype

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1733,7 +1733,8 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
     ```
     
   Raises:
-    AttributeError: Raises an attribute error when dtype is neither float nor integer
+    AttributeError: Raises an attribute error when dtype is neither
+    float nor integer
   """
   image = ops.convert_to_tensor(image, name='image')
   dtype = dtypes.as_dtype(dtype)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1731,9 +1731,16 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
     >> x = tf.random.normal(shape=(256, 256, 3), dtype=tf.float32)
     >> tf.image.convert_image_dtype(x, dtype=tf.float16, saturate=False)
     ```
+    
+  Raises:
+    AttributeError: Raises an attribute error when dtype is neither float nor integer
   """
   image = ops.convert_to_tensor(image, name='image')
   dtype = tf.dtypes.as_dtype(dtype)
+  if dtype.is_floating or dtype.is_integer:
+    pass
+  else:
+    raise AttributeError("dtype must be either floating point or integer")
   if dtype == image.dtype:
     return array_ops.identity(image, name=name)
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1736,7 +1736,7 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
     AttributeError: Raises an attribute error when dtype is neither float nor integer
   """
   image = ops.convert_to_tensor(image, name='image')
-  dtype = tf.dtypes.as_dtype(dtype)
+  dtype = dtypes.as_dtype(dtype)
   if not dtype.is_floating and not dtype.is_integer:
     raise AttributeError("dtype must be either floating point or integer")
   if dtype == image.dtype:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1724,8 +1724,22 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
 
   Returns:
     `image`, converted to `dtype`.
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3), dtype=tf.float32)
+    >> tf.image.convert_image_dtype(x, dtype=tf.float16, saturate=False)
+    ```
+  
+  Raises:
+    AttributeError: Type object has no attribute is_integer or is_floating
   """
   image = ops.convert_to_tensor(image, name='image')
+  if hasattr(dtype, 'is_floating') or hasattr(dtype, 'is_integer'):
+    pass
+  else:
+    raise AttributeError('Datatype provided must have is_integer or is_floating attribute')
   if dtype == image.dtype:
     return array_ops.identity(image, name=name)
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1731,15 +1731,9 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
     >> x = tf.random.normal(shape=(256, 256, 3), dtype=tf.float32)
     >> tf.image.convert_image_dtype(x, dtype=tf.float16, saturate=False)
     ```
-  
-  Raises:
-    AttributeError: Type object has no attribute is_integer or is_floating
   """
   image = ops.convert_to_tensor(image, name='image')
-  if hasattr(dtype, 'is_floating') or hasattr(dtype, 'is_integer'):
-    pass
-  else:
-    raise AttributeError('Datatype provided must have is_integer or is_floating attribute')
+  dtype = tf.dtypes.as_dtype(dtype)
   if dtype == image.dtype:
     return array_ops.identity(image, name=name)
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1737,9 +1737,7 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
   """
   image = ops.convert_to_tensor(image, name='image')
   dtype = tf.dtypes.as_dtype(dtype)
-  if dtype.is_floating or dtype.is_integer:
-    pass
-  else:
+  if not dtype.is_floating and not dtype.is_integer:
     raise AttributeError("dtype must be either floating point or integer")
   if dtype == image.dtype:
     return array_ops.identity(image, name=name)


### PR DESCRIPTION
Added a usage example in convert_image_dtype under image_ops_impl.py. Also added an attribute error raise and listed it in docstring. The issue has been raised in the link https://github.com/tensorflow/tensorflow/issues/29386