### PR TITLE
[ROCm] Update eigen_contraction_kernel subroutine to make it device compatible

### DIFF
--- a/tensorflow/core/kernels/eigen_contraction_kernel.cc
+++ b/tensorflow/core/kernels/eigen_contraction_kernel.cc
@@ -36,7 +36,12 @@ namespace internal {
 // TODO(ezhulenev): This is a temporary workaround for disabling custom kernels
 // at runtime in tests. We should always rely on compile time flags for that.
 // Example: ... --test_env=TENSORFLOW_USE_CUSTOM_CONTRACTION_KERNEL=false //test
-bool UseCustomContractionKernels() {
+EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE bool UseCustomContractionKernels() {
+// This subroutine should not be used in GPU. In case it is, a custom kernel
+// should always be used
+#if (defined(__NVCC__)) || (defined(__HIP_DEVICE_COMPILE__))
+  return true;
+#else
   static bool use_custom_contraction_kernel = true;
 
   static std::once_flag initialized;
@@ -48,6 +53,7 @@ bool UseCustomContractionKernels() {
   });
 
   return use_custom_contraction_kernel;
+#endif
 }
 
 }  // namespace internal

--- a/tensorflow/core/kernels/eigen_contraction_kernel.h
+++ b/tensorflow/core/kernels/eigen_contraction_kernel.h
@@ -49,7 +49,7 @@ namespace internal {
 #if defined(TENSORFLOW_USE_CUSTOM_CONTRACTION_KERNEL)
 // Returns `true` iff we can use custom contraction kernels. This is a runtime
 // check, that uses environment variables.
-bool UseCustomContractionKernels();
+EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE bool UseCustomContractionKernels();
 
 // Pack a 2D block of a Tensor expression into contiguous block of memory with
 // col-major storage order. We do not have access to the underlying Tensor


### PR DESCRIPTION
This PR addresses ROCm specific compilation issues. Below is the summary of the PR changes.

-----

First of all, `UseCustomContractionKernels()` should be declared with `EIGEN_DEVICE_FUNC` and `EIGEN_DONT_INLINE` as well to be consistent with the signature from `packLhs()` or `packRhs()`, `invoke()`.

Secondly, `std::call_once()` is not available in gpu device code, and this function should not be invoked in device as well. If it does happen, take the short cut and return.

-----
The change has been thoroughly tested under different compilation targets in develop-upstream branch.

@tatianashp @whchung @chsigg 