### PR TITLE
Remove incorrect extra `)` in tf_upgrade_v2 documentation

### DIFF
--- a/tensorflow/tools/compatibility/README.md
+++ b/tensorflow/tools/compatibility/README.md
@@ -47,9 +47,9 @@ e.g.:
 Added keyword 'input' to reordered function 'tf.argmax'
 Renamed keyword argument from 'dimension' to 'axis'
 
-    Old:         tf.argmax([[1, 3, 2]], dimension=0))
+    Old:         tf.argmax([[1, 3, 2]], dimension=0)
                                         ~~~~~~~~~~
-    New:         tf.argmax(input=[[1, 3, 2]], axis=0))
+    New:         tf.argmax(input=[[1, 3, 2]], axis=0)
 
 ```
 


### PR DESCRIPTION
While testing tf_upgrade_v2 noticed there is
one extra `)` in tf_upgrade_v2 documentation:
```
  File "<unknown>", line 7
    tf.argmax([[1, 3, 2]], dimension=0))
                                       ^
SyntaxError: invalid syntax
```

This fix fixes the issue.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>