### PR TITLE
add allow_pickle for reuters

### DIFF
--- a/tensorflow/python/keras/datasets/reuters.py
+++ b/tensorflow/python/keras/datasets/reuters.py
@@ -80,7 +80,7 @@ def load_data(path='reuters.npz',
       path,
       origin=origin_folder + 'reuters.npz',
       file_hash='87aedbeb0cb229e378797a632c1997b6')
-  with np.load(path) as f:
+  with np.load(path, allow_pickle = True) as f:
     xs, labels = f['x'], f['y']
 
   np.random.seed(seed)


### PR DESCRIPTION
Starting with `numpy 1.16.3` the default of `allow_picke` in `np.load` has changed from `True` to `False`.

This means that all occurrences of 

```
with np.load(path) as f:
```

in Keras datasets need to be changed to

```
with np.load(path, allow_pickle=True) as f:
```

otherwise we get

```
ValueError: Object arrays cannot be loaded when allow_pickle=False
```

See also https://github.com/tensorflow/tensorflow/commit /79a8d5cdad942b9853aa70b59441983b42a8aeb3 which did this for `imdb`.
This PR does this for `reuters`.