### PR TITLE
Marks Keras set_session as compat.v1 only. Also moves some renames to…

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -509,7 +509,7 @@ def _scratch_graph(graph=None):
     _CURRENT_SCRATCH_GRAPH = None
 
 
-@keras_export('keras.backend.set_session')
+@keras_export(v1=['keras.backend.set_session'])
 def set_session(session):
   """Sets the global TensorFlow session.
 

--- a/tensorflow/tools/api/golden/v2/tensorflow.keras.backend.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.keras.backend.pbtxt
@@ -441,10 +441,6 @@ tf_module {
     argspec: "args=[\'value\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
-    name: "set_session"
-    argspec: "args=[\'session\'], varargs=None, keywords=None, defaults=None"
-  }
-  member_method {
     name: "set_value"
     argspec: "args=[\'x\', \'value\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/compatibility/all_renames_v2.py
+++ b/tensorflow/tools/compatibility/all_renames_v2.py
@@ -528,6 +528,12 @@ manual_symbol_renames = {
         "tf.nn.conv2d_transpose",
     "tf.test.compute_gradient":
         "tf.compat.v1.test.compute_gradient",
+    "tf.floor_div":
+        "tf.math.floordiv",
+    "tf.where":
+        "tf.compat.v1.where",
+    "tf.where_v2":
+        "tf.compat.v2.where",
 }
 # pylint: enable=line-too-long
 

--- a/tensorflow/tools/compatibility/renames_v2.py
+++ b/tensorflow/tools/compatibility/renames_v2.py
@@ -388,11 +388,11 @@ renames = {
     'tf.fixed_size_partitioner':
         'tf.compat.v1.fixed_size_partitioner',
     'tf.floor_div':
+        'tf.compat.v1.floor_div',
+    'tf.floordiv':
         'tf.math.floordiv',
     'tf.floormod':
         'tf.math.floormod',
-    'tf.floordiv':
-        'tf.math.floordiv',
     'tf.get_collection':
         'tf.compat.v1.get_collection',
     'tf.get_collection_ref':
@@ -505,6 +505,8 @@ renames = {
         'tf.compat.v1.is_variable_initialized',
     'tf.keras.backend.get_session':
         'tf.compat.v1.keras.backend.get_session',
+    'tf.keras.backend.set_session':
+        'tf.compat.v1.keras.backend.set_session',
     'tf.keras.layers.CuDNNGRU':
         'tf.compat.v1.keras.layers.CuDNNGRU',
     'tf.keras.layers.CuDNNLSTM':
@@ -1551,10 +1553,8 @@ renames = {
         'tf.compat.v1.variables_initializer',
     'tf.verify_tensor_all_finite':
         'tf.compat.v1.verify_tensor_all_finite',
-    'tf.where':
-        'tf.compat.v1.where',
     'tf.where_v2':
-        'tf.compat.v2.where',
+        'tf.where',
     'tf.wrap_function':
         'tf.compat.v1.wrap_function',
     'tf.write_file':


### PR DESCRIPTION
… the manual renames that had been incorrectly placed in the auto-generated symbol mappings.

PiperOrigin-RevId: 251708447