### PR TITLE
Yet another performance improvement of LRNGrad on CPU builds

### DIFF
--- a/tensorflow/core/kernels/lrn_op.cc
+++ b/tensorflow/core/kernels/lrn_op.cc
@@ -353,6 +353,10 @@ struct LaunchLRNGrad<CPUDevice, T> {
           // However, this is numerically unstable for small values of xi. We
           // compute N explicitly here to avoid that.
 
+          T gs = grads_shaped(i, j);
+          if (gs == T(0))
+            continue;
+
           int64 depth_begin = std::max<int64>(0, j - depth_radius_);
           int64 depth_end = std::min<int64>(depth, j + depth_radius_ + 1);
 
@@ -364,7 +368,6 @@ struct LaunchLRNGrad<CPUDevice, T> {
           DCHECK_GT(norm, T(1e-6));
           T pre_computed_pow = Eigen::numext::pow(norm, -beta_);
           T activations_ab2 = alpha_beta_2_ * activations(i, j);
-          T gs = grads_shaped(i, j);
           for (int64 k = depth_begin; k < depth_end; ++k) {
             T dyi = in_shaped(i, k) * activations_ab2 / norm;
             if (k == j) {


### PR DESCRIPTION
This improves the performance of the CPU version of LRNGrad by
skipping the innermost loop altogether when the gradient to be applied
at the end is *explicitly* zero (and thus nothing would change in the
output tensor). It turns out a lot of loops have 0 as value, and this
gives us a ~3% speed up on CIFAR-10 training on a Intel(R) Core(TM)
i9-7900X CPU @ 3.30GHz, with 20 threads (and remember that IEEE 754
defines the comparison 0.0==-0.0 to be true). Training accuracy on that
same model has been check with/without the changes and nothing
changes on that regard.

This was sitting in my hard drive for a while now, finally making its way up to here.