### PR TITLE
Update build_def.bzl

### DIFF
--- a/tensorflow/lite/build_def.bzl
+++ b/tensorflow/lite/build_def.bzl
@@ -32,6 +32,10 @@ def tflite_copts():
             "/DTF_COMPILE_LIBRARY",
             "/wd4018",  # -Wno-sign-compare
         ],
+        str(Label("//tensorflow:linux_aarch64")): [
+            "-flax-vector-conversions",
+            "-fomit-frame-pointer",
+        ],
         "//conditions:default": [
             "-Wno-sign-compare",
         ],


### PR DESCRIPTION
To resolve the following two issues on a linux_aarch64 system:
1. prohibited conversions between vectors (https://github.com/tensorflow/tensorflow/issues/26731#issue-421396111)
2. prohibited explicit use of frame pointer register x29 in asm (https://github.com/tensorflow/tensorflow/issues/26731#issuecomment-499361715)