### PR TITLE
LICENSE: Restore original Apache license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright 2019 The TensorFlow Authors.  All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-Copyright 2019 The TensorFlow Authors.  All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +187,7 @@ Copyright 2019 The TensorFlow Authors.  All rights reserved.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017, The TensorFlow Authors.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Remove copyright notice from first line. Apache's instruction: 

> Each original source document (code and documentation, but **excluding the LICENSE** and NOTICE files) SHOULD include a short license header at the top. 

Ref: http://www.apache.org/dev/apply-license.html#new

* The Apache 2.0 license includes an Appendix about how to apply the license terms to files. We should not modify the license file. 
Reference: https://github.com/kubernetes/kubernetes/commit/d30db1f9a915aa95402e1190461469a1889d92be