### PR TITLE
Python: Use `PyLong_AsVoidPtr`, `PyLong_FromVoidPtr` for conversion

### DIFF
--- a/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.i
+++ b/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.i
@@ -26,12 +26,12 @@ limitations under the License.
 
 
 %typemap(in) TfLiteDelegate* {
- auto pointer_as_int =  PyInt_AsLong($input);
- static_assert(sizeof(pointer_as_int)==sizeof(TfLiteDelegate*),
-        "TFLiteDelegate must be representable as a long.");
- $1 = reinterpret_cast<TfLiteDelegate*>(pointer_as_int);
+  $1 = reinterpret_cast<TfLiteDelegate*>(PyLong_AsVoidPtr($input));
 }
 
+%typemap(out) TfLiteDelegate* {
+  $result = PyLong_FromVoidPtr($1);
+}
 
 %include "tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.h"
 


### PR DESCRIPTION
Use `PyLong_AsVoidPtr`, `PyLong_FromVoidPtr` to convert the pointer.  Use of `PyInt_AsLong` returns a `long` which will truncate the pointer on a LLP64 target (i.e. Windows).  Using `PyLong_AsVoidPtr` will return a `void *` for the Python integer or long integer.  Define the corresponding "out" map which specifies the conversion to wrap the return value of a function returning a `TfLiteDelegate *`.  This ensures that the conversion is always valid as the value is constructed fro the `PyLong_FromVoidPtr`.