### PR TITLE
Fix random_normal with shape issue

### DIFF
--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -25,6 +25,7 @@ from tensorflow.python.eager import context
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import random_seed
+from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import random_ops
@@ -105,6 +106,14 @@ class RandomNormalTest(RandomOpTestCommon):
         self.assertAllClose(results[False], results[True], rtol=1e-3, atol=1e-3)
       else:
         self.assertAllClose(results[False], results[True], rtol=1e-6, atol=1e-6)
+
+  # Test case for GitHub issue 29434.
+  @test_util.run_deprecated_v1
+  def testWithShape(self):
+    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+      with self.session(use_gpu=True, graph=ops.Graph()) as sess:
+        rng = random_ops.random_normal((3, tensor_shape.Dimension(2), 1))
+        _ = self.evaluate(rng)
 
   @test_util.run_deprecated_v1
   def testSeed(self):

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -23,6 +23,7 @@ import numpy as np
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import random_seed
+from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
@@ -36,6 +37,17 @@ from tensorflow.python.ops.gen_random_ops import *
 
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
+
+def _ShapeTensor(shape):
+  """Convert to an int32 or int64 tensor, defaulting to int32 if empty."""
+  if isinstance(shape, (tuple, list)) and not shape:
+    dtype = dtypes.int32
+  else:
+    if isinstance(shape, (tuple, list)):
+      shape = [val.value if isinstance(
+          val, tensor_shape.Dimension) else val for val in shape]
+    dtype = None
+  return ops.convert_to_tensor(shape, dtype=dtype, name="shape")
 
 
 @tf_export("random.normal", v1=["random.normal", "random_normal"])

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -44,8 +44,7 @@ def _ShapeTensor(shape):
     dtype = dtypes.int32
   else:
     if isinstance(shape, (tuple, list)):
-      shape = [val.value if isinstance(
-          val, tensor_shape.Dimension) else val for val in shape]
+      shape = [tensor_shape.dimension_value(dim) for dim in shape]
     dtype = None
   return ops.convert_to_tensor(shape, dtype=dtype, name="shape")
 


### PR DESCRIPTION
This fix tries to address the issue raised in #29434 where error was encountered where shape is a list of Dimension:
```
TypeError: Failed to convert object of type <class 'tuple'> \
    to Tensor. Contents: (1, 1, Dimension(256), 16). \
    Consider casting elements to a supported type.
```

This fix fixes the issue.

This fix fixes #29434.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>