### PR TITLE
lite/micro/micro_vision: Missing separator at line 21.

### DIFF
--- a/tensorflow/lite/experimental/micro/examples/micro_vision/Makefile.inc
+++ b/tensorflow/lite/experimental/micro/examples/micro_vision/Makefile.inc
@@ -18,7 +18,7 @@ tensorflow/lite/experimental/micro/examples/micro_vision/person_image_data.h \
 $(MICRO_VISION_MODEL_HDRS)
 
 IMAGE_PROVIDER_TEST_SRCS := \
-tensorflow/lite/experimental/micro/examples/micro_vision/image_provider.cc
+tensorflow/lite/experimental/micro/examples/micro_vision/image_provider.cc \
 tensorflow/lite/experimental/micro/examples/micro_vision/image_provider_test.cc \
 tensorflow/lite/experimental/micro/examples/micro_vision/model_settings.cc \
 


### PR DESCRIPTION
Line separator is needed to get the makefile to work.
 
e.g. 
```make -f tensorflow/lite/experimental/micro/tools/make/Makefile test``` 
will return a **missing separator error**.