### PR TITLE
Fix tf.keras.dataset.mnist/reuters np v1.16.3

### DIFF
--- a/tensorflow/python/keras/datasets/boston_housing.py
+++ b/tensorflow/python/keras/datasets/boston_housing.py
@@ -45,7 +45,7 @@ def load_data(path='boston_housing.npz', test_split=0.2, seed=113):
       origin=origin_folder + 'boston_housing.npz',
       file_hash=
       'f553886a1f8d56431e820c5b82552d9d95cfcb96d1e678153f8839538947dff5')
-  with np.load(path) as f:
+  with np.load(path, allow_pickle=True) as f:
     x = f['x']
     y = f['y']
 

--- a/tensorflow/python/keras/datasets/mnist.py
+++ b/tensorflow/python/keras/datasets/mnist.py
@@ -48,7 +48,7 @@ def load_data(path='mnist.npz'):
       origin=origin_folder + 'mnist.npz',
       file_hash=
       '731c5ac602752760c8e48fbffcf8c3b850d9dc2a2aedcf2cc48468fc17b673d1')
-  with np.load(path) as f:
+  with np.load(path, allow_pickle=True) as f:
     x_train, y_train = f['x_train'], f['y_train']
     x_test, y_test = f['x_test'], f['y_test']
 


### PR DESCRIPTION
This fix add `allow_pickle=True` to fix the numpy issue in 1.16.3.

See keras-team/keras@3423197
and keras-team/keras#12714

for related changes in keras-team/keras.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>