### PR TITLE
[ROCm] Adding ROCm support for the parameterized_truncated_normal op

### DIFF
--- a/tensorflow/core/kernels/parameterized_truncated_normal_op.cc
+++ b/tensorflow/core/kernels/parameterized_truncated_normal_op.cc
@@ -450,7 +450,7 @@ TF_CALL_double(REGISTER);
 
 #undef REGISTER
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define REGISTER(TYPE)                                         \
   REGISTER_KERNEL_BUILDER(Name("ParameterizedTruncatedNormal") \
@@ -465,6 +465,6 @@ TF_CALL_double(REGISTER);
 
 #undef REGISTER
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // end namespace tensorflow


### PR DESCRIPTION
This PR adds ROCm support for the  parameterized_truncated_normal op

The changes in this PR are trivial, please review and merge...thanks.

----------------------------------------

@tatianashp @whchung