### PR TITLE
Point tpu_cluster_resolver.py to the v1 TPU API.

### DIFF
--- a/tensorflow/python/distribute/cluster_resolver/tpu_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/tpu_cluster_resolver.py
@@ -109,11 +109,11 @@ class TPUClusterResolver(ClusterResolver):
 
     if self._discovery_url:
       return discovery.build(
-          'tpu', 'v1alpha1', credentials=credentials,
+          'tpu', 'v1', credentials=credentials,
           discoveryServiceUrl=self._discovery_url, cache_discovery=False)
     else:
       return discovery.build(
-          'tpu', 'v1alpha1', credentials=credentials, cache_discovery=False)
+          'tpu', 'v1', credentials=credentials, cache_discovery=False)
 
   def _request_compute_metadata(self, path):
     req = Request('%s/computeMetadata/v1/%s' % (_GCE_METADATA_ENDPOINT, path),


### PR DESCRIPTION
The v1 API is available. It might be good to consider allowing customers to pick which API version they want, but for now use the v1 API.