### PR TITLE
Add release note about TF_CUDNN_DETERMINISTIC

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@
 * Added `key` and `skip` methods to `random.experimental.Generator`.
 * Update `RaggedTensors` to support int32 `row_splits`.
 * Add `TensorSpec` support for `CompositeTensors`.
-
+* Add environment variable TF_CUDNN_DETERMINISTIC. Setting to "true" or "1" forces the selection of deterministic cuDNN convolution and max-pooling algorithms. When this is enabled, the algorithm selection procedure itself is also deterministic. This change was already present in release 1.14.0, but this note was missing from the 1.14.0 release notes tagged v1.14.0.
 
 # Release 1.14.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -120,6 +120,7 @@
   * Post-training quantization tool supports quantizing weights shared by multiple operations. The models made with versions of this tool will use INT8 types for weights and will only be executable interpreters from this version onwards.
   * Malformed gif images could result in an access out of bounds in the color palette of the frame. This has been fixed now
   * image.resize now considers proper pixel centers and has new kernels (incl. anti-aliasing).
+  * Add environment variable TF_CUDNN_DETERMINISTIC. Setting to "true" or "1" forces the selection of deterministic cuDNN convolution and max-pooling algorithms. When this is enabled, the algorithm selection procedure itself is also deterministic.
 * Performance
   * Turn on MKL-DNN contraction kernels by default. MKL-DNN dynamically dispatches the best kernel implementation based on CPU vector architecture. To disable them, build with --define=tensorflow_mkldnn_contraction_kernel=0.
   * Support for multi-host ncclAllReduce in Distribution Strategy.


### PR DESCRIPTION
This is the release note associated with:

- PR [24747](https://github.com/tensorflow/tensorflow/pull/24747): Add cuDNN deterministic env variable (only for convolution)
- PR [25269](https://github.com/tensorflow/tensorflow/pull/25269): Add deterministic cuDNN max-pooling
- PR [25796](https://github.com/tensorflow/tensorflow/pull/25796): Added tests for TF_CUDNN_DETERMINISTIC