### PR TITLE
Compiling TensorFlow when configured with CUDA and MPI support result…

### DIFF
--- a/tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc
+++ b/tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include "tensorflow/contrib/mpi_collectives/kernels/ring.h"
 #include "tensorflow/core/util/gpu_launch_config.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
 
 namespace tensorflow {
 namespace contrib {


### PR DESCRIPTION
…s in compilation failure:

tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc(110): error: identifier "CudaLaunchKernel" is undefined

tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc(111): error: identifier "CudaLaunchKernel" is undefined

tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc(112): error: identifier "CudaLaunchKernel" is undefined

Include tensorflow/core/util/gpu_kernel_helper.h in ring.cu.cc to pull in declaartion of CudaLaunchKernel