### PR TITLE
Prevent spurious wakeup in threadpool test

### DIFF
--- a/tensorflow/core/lib/core/threadpool_test.cc
+++ b/tensorflow/core/lib/core/threadpool_test.cc
@@ -229,7 +229,7 @@ static void BM_Sequential(int iters) {
   };
   work();
   mutex_lock l(done_lock);
-  if (!done_flag) {
+  while (!done_flag) {
     done.wait(l);
   }
 }
@@ -252,7 +252,7 @@ static void BM_Parallel(int iters) {
     });
   }
   mutex_lock l(done_lock);
-  if (!done_flag) {
+  while (!done_flag) {
     done.wait(l);
   }
 }
@@ -279,7 +279,7 @@ static void BM_ParallelFor(int iters, int total, int cost_per_unit) {
         });
   }
   mutex_lock l(done_lock);
-  if (!done_flag) {
+  while (!done_flag) {
     done.wait(l);
   }
 }


### PR DESCRIPTION
It's good practice to check condition of a conditional variable in a while loop.