### PR TITLE
bugfix: functionalize_control_flow_pass_registration.cc has been moved to another dir

### DIFF
--- a/tensorflow/compiler/jit/jit_compilation_pass_registration.cc
+++ b/tensorflow/compiler/jit/jit_compilation_pass_registration.cc
@@ -36,7 +36,7 @@ REGISTER_OPTIMIZATION(OptimizationPassRegistry::PRE_PLACEMENT, 25,
                       IntroduceFloatingPointJitterPass);
 
 // from
-// third_party/tensorflow/compiler/tf2xla/functionalize_control_flow_pass_registration.cc
+// tensorflow/compiler/tf2xla/functionalize_control_flow_pass_registration.cc
 // FunctionalizeControlFlowPass: 27
 //
 // This pass looks at the graph and all associated FunctionDefs, and turns


### PR DESCRIPTION
functionalize_control_flow_pass_registration.cc has been moved from third_party/tensorflow/compiler/tf2xla/  to tensorflow/compiler/tf2xla/ in the current version