### PR TITLE
Fix deprecated args to buildifier in ci_sanity.sh

### DIFF
--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -306,7 +306,7 @@ do_buildifier(){
   if [[ -s ${BUILDIFIER_OUTPUT_FILE} ]]; then
     echo "FAIL: buildifier found errors and/or warnings in above BUILD files."
     echo "buildifier suggested the following changes:"
-    buildifier -v -mode=diff ${BUILD_FILES}
+    buildifier -v -mode=diff -diff_command=diff ${BUILD_FILES}
     echo "Please fix manually or run buildifier <file> to auto-fix."
     return 1
   else


### PR DESCRIPTION
The call to the `buildifier` utility in `tensorflow/tools/ci_build/ci_sanity.sh` uses a deprecated method of asking `builidifier` for a diff. As a result, the script generates output like this when run in an environment with a recent version of `builidifier`:
```
FAIL: buildifier found errors and/or warnings in above BUILD files.
buildifier suggested the following changes:
buildifier: selecting diff program with the BUILDIFIER_DIFF, BUILDIFIER_MULTIDIFF, and DISPLAY environment variables is deprecated, use flags -diff_command and -multi_diff instead
tensorflow/java/src/main/native/BUILD:
tensorflow/contrib/mpi_collectives/BUILD:
tensorflow/contrib/kafka/BUILD:
tensorflow/compiler/xla/BUILD:
tensorflow/compiler/jit/BUILD:
--: tkdiff: command not found
exit status 127
```
This PR modifies `tensorflow/tools/ci_build/ci_sanity.sh` to set the `-diff_command` argument when asking `buildifer` for a diff. After the change, the script's output looks like this:
```
FAIL: buildifier found errors and/or warnings in above BUILD files.
buildifier suggested the following changes:
tensorflow/java/src/main/native/BUILD:
17c17
< load("//tensorflow:tensorflow.bzl", "tf_cuda_library", "tf_copts")
---
> load("//tensorflow:tensorflow.bzl", "tf_copts", "tf_cuda_library")
exit status 1
[...]
```