### PR TITLE
Make N_CPUS check in ci_sanity.sh work on MacOS

### DIFF
--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -36,7 +36,12 @@ die() {
 
 num_cpus() {
   # Get the number of CPUs
-  N_CPUS=$(grep -c ^processor /proc/cpuinfo)
+  if [[ -f /proc/cpuinfo ]]; then
+    N_CPUS=$(grep -c ^processor /proc/cpuinfo)
+  else
+    # Fallback method
+    N_CPUS=`getconf _NPROCESSORS_ONLN`
+  fi
   if [[ -z ${N_CPUS} ]]; then
     die "ERROR: Unable to determine the number of CPUs"
   fi


### PR DESCRIPTION
The pylint sections of `tensorflow/tools/ci_build/ci_sanity.sh` do not run on MacOS because they contain code that assumes the existence of `/proc/cpuinfo`.

This is a problem for Mac users because pylint is extremely slow on Docker on Mac -- over 12 hours to to run a single pass of linting on my machine. The same pylint check runs in 15 minutes outside of Docker.

The changes in this PR allow the linting portions of `ci_sanity.sh` to run on MacOS with Docker. After my modifications, `ci_sanity.sh` uses the POSIX standard command `getconf` to query the number of cores if `/proc/cpuinfo` does not exist.

To get reliable results when running pylint locally, users will need a Python environment that is close to that of the TensorFlow Docker images. I have written a script that will set up such an environment. My script is currently checked into my TensorFlow config files repository at [https://github.com/frreiss/tf-dev-conf/blob/master/lintenv.sh](https://github.com/frreiss/tf-dev-conf/blob/master/lintenv.sh). I would be happy to contribute this script if there's interest.
