### PR TITLE
Allow ci_build.sh to use CUDA images on non-GPU machines

### DIFF
--- a/tensorflow/tools/ci_build/ci_build.sh
+++ b/tensorflow/tools/ci_build/ci_build.sh
@@ -81,6 +81,12 @@ fi
 # Use nvidia-docker if the container is GPU.
 if [[ "${CONTAINER_TYPE}" == gpu* ]]; then
   DOCKER_BINARY="nvidia-docker"
+  if [[ -z `which ${DOCKER_BINARY}` ]]; then
+    # No nvidia-docker; fall back on docker to allow build operations that
+    # require CUDA but don't require a GPU to run.
+    echo "Warning: nvidia-docker not found in PATH. Falling back on 'docker'."
+    DOCKER_BINARY="docker"
+  fi
 else
   DOCKER_BINARY="docker"
 fi


### PR DESCRIPTION
The script `tensorflow/tools/ci_build/ci_build.sh` assumes that the `nvidia-docker` utility is present when running with a GPU-enabled Docker image. This assumption makes it difficult to check whether your code will configure, build, and link against CUDA when the machine you're running on doesn't have NVidia's development toolchain installed.

This PR modifies `ci_build.sh` slightly so that the script will fall back on `docker` if the program `nvidia-docker` is not available on the host machine. With this version of the script, I'm able to perform a full build against CUDA on a machine with neither CUDA nor a GPU installed by running the command:
```
tensorflow/tools/ci_build/ci_build.sh GPU bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package
```
I'm also able to run the configuration checks in `tensorflow/tools/ci_build/ci_sanity.sh` on the same machine without errors by running:
```
tensorflow/tools/ci_build/ci_build.sh GPU tensorflow/tools/ci_build/ci_sanity.sh
```