### PR TITLE
Make check_load_test.py and pip_smoke_test.py run on Python 3

### DIFF
--- a/tensorflow/tools/pip_package/check_load_py_test.py
+++ b/tensorflow/tools/pip_package/check_load_py_test.py
@@ -52,6 +52,7 @@ def main():
         '//tensorflow/contrib/tensorboard/...)']).strip()
   except subprocess.CalledProcessError as e:
     targets = e.output
+  targets = targets.decode("utf-8") if isinstance(targets, bytes) else targets
 
   # Only keep py_test targets, and filter out targets with 'no_pip' tag.
   valid_targets = []

--- a/tensorflow/tools/pip_package/pip_smoke_test.py
+++ b/tensorflow/tools/pip_package/pip_smoke_test.py
@@ -141,6 +141,8 @@ def main():
   # pip_package_dependencies_list is the list of included files in pip packages
   pip_package_dependencies = subprocess.check_output(
       ["bazel", "cquery", PIP_PACKAGE_QUERY_EXPRESSION])
+  if isinstance(pip_package_dependencies, bytes):
+    pip_package_dependencies = pip_package_dependencies.decode("utf-8")
   pip_package_dependencies_list = pip_package_dependencies.strip().split("\n")
   pip_package_dependencies_list = [
       x.split()[0] for x in pip_package_dependencies_list
@@ -151,6 +153,8 @@ def main():
   # tests in tensorflow
   tf_py_test_dependencies = subprocess.check_output(
       ["bazel", "cquery", PY_TEST_QUERY_EXPRESSION])
+  if isinstance(tf_py_test_dependencies, bytes):
+    tf_py_test_dependencies = tf_py_test_dependencies.decode("utf-8")
   tf_py_test_dependencies_list = tf_py_test_dependencies.strip().split("\n")
   tf_py_test_dependencies_list = [
       x.split()[0] for x in tf_py_test_dependencies.strip().split("\n")


### PR DESCRIPTION
The scripts `check_load_py_test.py` and `pip_smoke_test.py` in `tensorflow/tools/pip_package` currently fail under Python 3 because they call `split()` on a `bytes` object. This PR adds some code to convert the bytes to a UTF-8 string. After the change, the scripts run on Python 2 and 3.