### PR TITLE
Fix: EagerFunc tensor conversion error

### DIFF
--- a/tensorflow/python/ops/script_ops.py
+++ b/tensorflow/python/ops/script_ops.py
@@ -97,7 +97,7 @@ class EagerFunc(object):
       #
       # TODO(akshayka): Make it possible to return a list of both Tensors and
       # Nones from an EagerPyFunc.
-      return constant_op.constant(0.0, dtype=dtype)
+      return constant_op.constant(0 if dtype.is_integer else 0.0, dtype=dtype)
     return ops.convert_to_tensor(value, dtype=dtype)
 
   def __call__(self, device, token, args):


### PR DESCRIPTION
This is the fix to the issue [https://github.com/tensorflow/tensorflow/issues/29727](https://github.com/tensorflow/tensorflow/issues/29727). When the desired dtype is integer, let input argument be 0 (strict integer) instead of 0.0.