### PR TITLE
Refine permuation const device placement for LayoutOptimizer.

### DIFF
--- a/tensorflow/core/grappler/optimizers/layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/layout_optimizer.cc
@@ -476,14 +476,16 @@ struct OptimizeContext {
                   const GraphProperties& graph_properties,
                   const VirtualPlacer& virtual_placer,
                   const std::unordered_set<string>& nodes_to_preserve,
-                  bool is_in_frame)
+                  bool is_in_frame,
+                  std::unordered_set<string>* devices_with_perm_const)
       : graph(graph),
         node(node),
         node_map(node_map),
         graph_properties(graph_properties),
         virtual_placer(virtual_placer),
         nodes_to_preserve(nodes_to_preserve),
-        is_in_frame(is_in_frame) {}
+        is_in_frame(is_in_frame),
+        devices_with_perm_const(devices_with_perm_const) {}
   GraphDef* graph;
   NodeDef* node;
   NodeMap* node_map;
@@ -491,6 +493,7 @@ struct OptimizeContext {
   const VirtualPlacer& virtual_placer;
   const std::unordered_set<string>& nodes_to_preserve;
   bool is_in_frame;
+  std::unordered_set<string>* devices_with_perm_const; // not owned
 };
 
 class NodeProcessor : public GraphProcessor {
@@ -500,7 +503,8 @@ class NodeProcessor : public GraphProcessor {
                        opt_cxt.nodes_to_preserve, opt_cxt.graph,
                        opt_cxt.node_map),
         node_(opt_cxt.node),
-        is_in_frame_(opt_cxt.is_in_frame) {}
+        is_in_frame_(opt_cxt.is_in_frame),
+        devices_with_perm_const_(opt_cxt.devices_with_perm_const) {}
   virtual ~NodeProcessor() {}
   virtual Status ConvertNode() {
     if (ShouldProcess()) {
@@ -736,8 +740,16 @@ class NodeProcessor : public GraphProcessor {
 
   NodeDef* node_;
   bool is_in_frame_;
+  std::unordered_set<string>* devices_with_perm_const_;  // not owned.
 
  private:
+  string CompliantDeviceName(const string& device) {
+    string ret(device);
+    std::replace(ret.begin(), ret.end(), '/', '_');
+    std::replace(ret.begin(), ret.end(), ':', '_');
+    return ret;
+  }
+
   void UpdateAttrKSize() {
     if (node_->attr().find("ksize") != node_->attr().end()) {
       auto list = node_->mutable_attr()->at("ksize").mutable_list();
@@ -888,8 +900,8 @@ class NodeProcessor : public GraphProcessor {
     string name =
         LayoutOptimizerNode(strings::StrCat(base_name, "-", kPermNHWCToNCHW));
     auto const_node = AddNodePermConst(name, device, {0, 3, 1, 2});
-    // This is to ensure the transpose node and the const node are in the
-    // same frame.
+    // This is to ensure the transpose node and the const node are in the same
+    // frame.
     *const_node->add_input() = AsControlDependency(depended_node);
     return const_node;
   }
@@ -897,13 +909,35 @@ class NodeProcessor : public GraphProcessor {
   NodeDef* AddNodePermNCHWToNHWC(const string& base_name,
                                  const string& depended_node,
                                  const string& device) {
-    auto const_node = AddNodePermConst(
-        LayoutOptimizerNode(strings::StrCat(base_name, "-", kPermNCHWToNHWC)),
-        device, {0, 2, 3, 1});
+    string name =
+        LayoutOptimizerNode(strings::StrCat(base_name, "-", kPermNCHWToNHWC));
+    auto const_node = AddNodePermConst(name, device, {0, 2, 3, 1});
     // This is to ensure the transpose node and the const node are in the same
     // frame.
     *const_node->add_input() = AsControlDependency(depended_node);
     return const_node;
+  }
+
+  // NOTE(zycao): We try to make sure each device has the permutation consts
+  // iff the consts are really needed. Thus no unexpected inter-worker
+  // connections and no redundant nodes would be existed.
+  void AddNodePermConstOnDevice(const string& device) {
+    string compliant_device_prefix;
+    if (device.empty()) {
+      compliant_device_prefix = "_default_device";
+    } else {
+      compliant_device_prefix = CompliantDeviceName(device);
+    }
+    string node_name;
+    // Permutation const for NHWCToNCHW
+    node_name = strings::StrCat(compliant_device_prefix, "-",
+                                LayoutOptimizerNode(kPermNHWCToNCHW));
+    AddNodePermConst(node_name, device, {0, 3, 1, 2});
+
+    // Permutation const for NCHWToNHWC
+    node_name = strings::StrCat(compliant_device_prefix, "-",
+                                LayoutOptimizerNode(kPermNCHWToNHWC));
+    AddNodePermConst(node_name, device, {0, 2, 3, 1});
   }
 
   string GetOrAddNodePermNHWCToNCHW(int pos) {
@@ -922,7 +956,13 @@ class NodeProcessor : public GraphProcessor {
           AddNodePermNHWCToNCHW(base_name, depended_node, node_->device());
       const_name = const_node->name();
     } else {
-      const_name = LayoutOptimizerNode(kPermNHWCToNCHW);
+      if (devices_with_perm_const_->find(node_->device())
+          == devices_with_perm_const_->end()) {
+        AddNodePermConstOnDevice(node_->device());
+        devices_with_perm_const_->insert(node_->device());
+      }
+      const_name = strings::StrCat(CompliantDeviceName(node_->device()), "-",
+                                   LayoutOptimizerNode(kPermNHWCToNCHW));
     }
     return const_name;
   }
@@ -934,7 +974,13 @@ class NodeProcessor : public GraphProcessor {
           AddNodePermNCHWToNHWC(node_->name(), node_->name(), node_->device());
       const_name = const_node->name();
     } else {
-      const_name = LayoutOptimizerNode(kPermNCHWToNHWC);
+      if (devices_with_perm_const_->find(node_->device())
+          == devices_with_perm_const_->end()) {
+        AddNodePermConstOnDevice(node_->device());
+        devices_with_perm_const_->insert(node_->device());
+      }
+      const_name = strings::StrCat(CompliantDeviceName(node_->device()), "-",
+                                   LayoutOptimizerNode(kPermNCHWToNHWC));
     }
     return const_name;
   }
@@ -1991,19 +2037,10 @@ class DataLayoutOptimizer : GraphProcessor {
   }
 
  private:
-  NodeDef* AddNodePermNHWCToNCHW() {
-    return AddNodePermConst(LayoutOptimizerNode(kPermNHWCToNCHW), "",
-                            {0, 3, 1, 2});
-  }
-
-  NodeDef* AddNodePermNCHWToNHWC() {
-    return AddNodePermConst(LayoutOptimizerNode(kPermNCHWToNHWC), "",
-                            {0, 2, 3, 1});
-  }
-
   // Expand all nodes which is in NHWC, but supports NCHW or is layout agnostic.
   Status Expand() {
     int node_size_original = graph_->node_size();
+    std::unordered_set<string> devices_with_perm_const;
 
     FrameView frame_view;
     TF_RETURN_IF_ERROR(frame_view.InferFromGraph(*graph_));
@@ -2021,7 +2058,7 @@ class DataLayoutOptimizer : GraphProcessor {
         bool is_in_frame = frame_view.IsInFrame(*node);
         OptimizeContext opt_cxt(graph_, node, node_map_, graph_properties_,
                                 virtual_placer_, nodes_to_preserve_,
-                                is_in_frame);
+                                is_in_frame, &devices_with_perm_const);
         std::unique_ptr<NodeProcessor> node_processor;
         if (IsAvgPoolGrad(*node)) {
           node_processor.reset(new AvgPoolGradProcessor(opt_cxt));
@@ -2061,10 +2098,6 @@ class DataLayoutOptimizer : GraphProcessor {
     // only needs to be performed if at least one node in the previous pass is
     // expanded.
     if (graph_->node_size() > node_size_original) {
-      // Create Const nodes holding the permutation used by added Transposes of
-      // nodes not in a frame.
-      AddNodePermNHWCToNCHW();
-      AddNodePermNCHWToNHWC();
       std::set<string> ops_format_agnostic = GetOpsFormatAgnostic();
       for (int i = 0; i < graph_->node_size(); i++) {
         if (ops_format_agnostic.find(graph_->node(i).op()) !=
@@ -2073,7 +2106,7 @@ class DataLayoutOptimizer : GraphProcessor {
           bool is_in_frame = frame_view.IsInFrame(*node);
           OptimizeContext opt_cxt(graph_, node, node_map_, graph_properties_,
                                   virtual_placer_, nodes_to_preserve_,
-                                  is_in_frame);
+                                  is_in_frame, &devices_with_perm_const);
           std::unique_ptr<NodeProcessor> node_processor;
           if (IsAddN(*node)) {
             node_processor.reset(new AddNProcessor(opt_cxt));

--- a/tensorflow/core/grappler/optimizers/layout_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/layout_optimizer_test.cc
@@ -1236,6 +1236,42 @@ TEST_F(LayoutOptimizerTest, DevicePlacement) {
       node_map.GetNode("s-0-0-VecPermuteNCHWToNHWC-LayoutOptimizer");
   EXPECT_EQ(vec_permute->attr().at("_kernel").s(), "host");
 }
+
+TEST_F(LayoutOptimizerTest, PermConstWithDevice) {
+  tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+  const string worker0_gpu0 = "/job:w/replica:0/task:0/device:gpu:0";
+  const string worker1_gpu1 = "/job:w/replica:0/task:1/device:gpu:1";
+  const string worker0_node_prefix = "_job_w_replica_0_task_0_device_gpu_0-";
+  const string worker1_node_prefix = "_job_w_replica_0_task_1_device_gpu_1-";
+  const string perm_nchw2nhwc_str = "PermConstNCHWToNHWC-LayoutOptimizer";
+  const string perm_nhwc2nchw_str = "PermConstNHWCToNCHW-LayoutOptimizer";
+  auto conv_0 = SimpleConv2D(&s, 4, 2, "VALID", worker0_gpu0);
+  auto shape_0 = ops::Shape(s.WithOpName("s"), conv_0);
+  auto i_0 = ops::Identity(s.WithOpName("i"), shape_0);
+  auto conv_1 = SimpleConv2D(&s, 4, 2, "VALID", worker1_gpu1);
+  auto shape_1 = ops::Shape(s.WithOpName("s"), conv_1);
+  auto i_1 = ops::Identity(s.WithOpName("i"), shape_1);
+  GrapplerItem item;
+  TF_CHECK_OK(s.ToGraphDef(&item.graph));
+  LayoutOptimizer optimizer;
+  GraphDef output;
+  Status status = optimizer.Optimize(virtual_cluster_.get(), item, &output);
+  NodeMap node_map(&output);
+  auto const_permute_0_0 =
+      node_map.GetNode(worker0_node_prefix + perm_nchw2nhwc_str);
+  auto const_permute_0_1 =
+      node_map.GetNode(worker0_node_prefix + perm_nhwc2nchw_str);
+  EXPECT_EQ(const_permute_0_0->device(), worker0_gpu0);
+  EXPECT_EQ(const_permute_0_1->device(), worker0_gpu0);
+  auto const_permute_1_0 =
+      node_map.GetNode(worker1_node_prefix + perm_nchw2nhwc_str);
+  auto const_permute_1_1 =
+      node_map.GetNode(worker1_node_prefix + perm_nhwc2nchw_str);
+  EXPECT_EQ(const_permute_1_0->device(), worker1_gpu1);
+  EXPECT_EQ(const_permute_1_1->device(), worker1_gpu1);
+  EXPECT_FALSE(node_map.GetNode(perm_nchw2nhwc_str));
+  EXPECT_FALSE(node_map.GetNode(perm_nhwc2nchw_str));
+}
 }  // namespace
 }  // namespace grappler
 }  // namespace tensorflow

--- a/tensorflow/core/grappler/optimizers/layout_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/layout_optimizer_test.cc
@@ -1241,8 +1241,8 @@ TEST_F(LayoutOptimizerTest, PermConstWithDevice) {
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
   const string worker0_gpu0 = "/job:w/replica:0/task:0/device:gpu:0";
   const string worker1_gpu1 = "/job:w/replica:0/task:1/device:gpu:1";
-  const string worker0_node_prefix = "_job_w_replica_0_task_0_device_gpu_0-";
-  const string worker1_node_prefix = "_job_w_replica_0_task_1_device_gpu_1-";
+  const string worker0_node_prefix = "job_w_replica_0_task_0_device_gpu_0-";
+  const string worker1_node_prefix = "job_w_replica_0_task_1_device_gpu_1-";
   const string perm_nchw2nhwc_str = "PermConstNCHWToNHWC-LayoutOptimizer";
   const string perm_nhwc2nchw_str = "PermConstNHWCToNCHW-LayoutOptimizer";
   auto conv_0 = SimpleConv2D(&s, 4, 2, "VALID", worker0_gpu0);


### PR DESCRIPTION
In layout optimizer of Grappler, two permutation const nodes would be
added into the graph by default. The nodes should be placed to a default
device assigned by a Virtual Placer, which was constructed from the
cluster infomation. However, the Virtual Placer could not distinguish
remote devices from local ones in distributed runtime, which causes that
a remote device might be the default device. Thus unnecessary dependency
between workers would be implicitly built, unexpected crashed would
occur in asynchronous distributed graph running.

This fix only refines the behaviour of LayoutOptimizer. Permutation
const nodes would be lazy created when necessary and would be colocated
with the connected nodes if the device was already done. Each device
would keep one pair and at most one pair of permutation consts, so that
these consts would not bring cross-device send-recv in ideal cases.