### PR TITLE
Run build files through buildifier

### DIFF
--- a/tensorflow/compiler/jit/BUILD
+++ b/tensorflow/compiler/jit/BUILD
@@ -1,4 +1,4 @@
-load("//tensorflow:tensorflow.bzl", "tf_cc_test", "cc_header_only_library")
+load("//tensorflow:tensorflow.bzl", "cc_header_only_library", "tf_cc_test")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 

--- a/tensorflow/compiler/xla/BUILD
+++ b/tensorflow/compiler/xla/BUILD
@@ -1,4 +1,4 @@
-load("//tensorflow:tensorflow.bzl", "tf_cc_test", "cc_header_only_library")
+load("//tensorflow:tensorflow.bzl", "cc_header_only_library", "tf_cc_test")
 load("//tensorflow/compiler/xla:xla.bzl", "xla_proto_library")
 load(
     "//tensorflow/core:platform/default/build_config.bzl",

--- a/tensorflow/contrib/kafka/BUILD
+++ b/tensorflow/contrib/kafka/BUILD
@@ -6,11 +6,11 @@ exports_files(["LICENSE"])
 
 load(
     "//tensorflow:tensorflow.bzl",
-    "tf_gen_op_wrapper_py",
-    "tf_kernel_library",
     "tf_custom_op_library",
     "tf_custom_op_py_library",
     "tf_gen_op_libs",
+    "tf_gen_op_wrapper_py",
+    "tf_kernel_library",
     "tf_py_test",
 )
 

--- a/tensorflow/contrib/mpi_collectives/BUILD
+++ b/tensorflow/contrib/mpi_collectives/BUILD
@@ -29,10 +29,10 @@ cc_library(
 
 load(
     "//tensorflow:tensorflow.bzl",
-    "tf_custom_op_py_library",
     "tf_custom_op_library",
-    "tf_gen_op_wrapper_py",
+    "tf_custom_op_py_library",
     "tf_gen_op_libs",
+    "tf_gen_op_wrapper_py",
     "tf_kernel_library",
     "tf_py_test",
 )

--- a/tensorflow/core/distributed_runtime/BUILD
+++ b/tensorflow/core/distributed_runtime/BUILD
@@ -3,7 +3,7 @@
 # to be distributed and performed in parallel across multiple
 # processes.
 
-load("//tensorflow:tensorflow.bzl", "tf_cc_test", "tf_cuda_library", "tf_copts")
+load("//tensorflow:tensorflow.bzl", "tf_cc_test", "tf_copts", "tf_cuda_library")
 load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_test")
 
 # For platform specific build config

--- a/tensorflow/core/profiler/BUILD
+++ b/tensorflow/core/profiler/BUILD
@@ -1,5 +1,5 @@
 load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
-load("//tensorflow/core:platform/default/build_config.bzl", "tf_proto_library", "tf_additional_all_protos", "tf_profiler_all_protos")
+load("//tensorflow/core:platform/default/build_config.bzl", "tf_additional_all_protos", "tf_profiler_all_protos", "tf_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/tensorflow/java/src/main/native/BUILD
+++ b/tensorflow/java/src/main/native/BUILD
@@ -14,7 +14,7 @@ package(default_visibility = [
 
 licenses(["notice"])  # Apache 2.0
 
-load("//tensorflow:tensorflow.bzl", "tf_cuda_library", "tf_copts")
+load("//tensorflow:tensorflow.bzl", "tf_copts", "tf_cuda_library")
 
 tf_cuda_library(
     name = "native",

--- a/tensorflow/python/debug/BUILD
+++ b/tensorflow/python/debug/BUILD
@@ -9,7 +9,7 @@
 # ":grpc_debug_server": Server interface for grpc:// debug URLs.
 
 load("//tensorflow:tensorflow.bzl", "cuda_py_test")
-load("//tensorflow:tensorflow.bzl", "py_test", "py_binary", "if_not_v2", "if_not_windows")
+load("//tensorflow:tensorflow.bzl", "if_not_v2", "if_not_windows", "py_binary", "py_test")
 
 package(
     default_visibility = ["//tensorflow:internal"],


### PR DESCRIPTION
Somehow some BUILD files that don't pass recent versions of `buildifier` have snuck into the master branch. I'm not sure how that happened. Anyhow, this PR adjusts a few BUILD files so that they pass `buildifier` version 0.26.