### PR TITLE
Set 1.14 forward compatibility date to 9/10

### DIFF
--- a/tensorflow/python/compat/compat.py
+++ b/tensorflow/python/compat/compat.py
@@ -27,7 +27,7 @@ import datetime
 from tensorflow.python.util import tf_contextlib
 from tensorflow.python.util.tf_export import tf_export
 
-_FORWARD_COMPATIBILITY_HORIZON = datetime.date(2019, 11, 1)
+_FORWARD_COMPATIBILITY_HORIZON = datetime.date(2019, 9, 10)
 
 
 @tf_export("compat.forward_compatible")


### PR DESCRIPTION
Sets it before 9/14 so the gated feature in cl/252672618 isn't triggered.