### PR TITLE
Use `PyLong_AsVoidPtr`, `PyLong_FromVoidPtr` for conversion

### DIFF
--- a/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.i
+++ b/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.i
@@ -26,7 +26,11 @@ limitations under the License.
 
 
 %typemap(in) TfLiteDelegate* {
- $1 = reinterpret_cast<TfLiteDelegate*>(PyLong_AsVoidPtr($input));
+  $1 = reinterpret_cast<TfLiteDelegate*>(PyLong_AsVoidPtr($input));
+}
+
+%typemap(out) TfLiteDelegate* {
+  $result = PyLong_FromVoidPtr($1)
 }
 
 


### PR DESCRIPTION
Use PyLong_AsVoidPtr, PyLong_FromVoidPtr to convert the pointer. Use of
PyInt_AsLong returns a long which will truncate the pointer on a LLP64
target (i.e. Windows). Using PyLong_AsVoidPtr will return a void * for
the Python integer or long integer. Define the corresponding "out" map
which specifies the conversion to wrap the return value of a function
returning a TfLiteDelegate *. This ensures that the conversion is always
valid as the value is constructed fro the PyLong_FromVoidPtr.