### PR TITLE
Follow up the while signature change.

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/while_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/while_op.cc
@@ -37,6 +37,30 @@ namespace tensorflow {
 
 namespace {
 
+// Verify that input resources are grouped in the end.
+Status VerifyBodyFunctionSignature(XlaOpKernelContext* ctx,
+                                   const NameAttrList& body_name_attr) {
+  const FunctionBody* body;
+  TF_RETURN_IF_ERROR(ctx->compiler()->FindFunctionBody(body_name_attr, &body));
+  bool has_seen_resource = false;
+  for (int i = 0; i < body->arg_types.size(); i++) {
+    DataType arg_type = body->arg_types[i];
+    if (has_seen_resource) {
+      if (arg_type != DT_RESOURCE) {
+          return errors::InvalidArgument(
+              "Expect input resources are grouped in the end of while body ",
+              body_name_attr.name(), ", but see non-resource input ",
+              body->arg_nodes[i]->name(), ".");
+      }
+    } else {
+      if (arg_type == DT_RESOURCE) {
+        has_seen_resource = true;
+      }
+    }
+  }
+  return Status::OK();
+}
+
 // Builds XlaCompiler argument descriptions `args` from `ctx`.
 Status MakeXlaCompilerArgumentsFromInputs(
     XlaOpKernelContext* ctx, std::vector<XlaCompiler::Argument>* args,
@@ -269,6 +293,10 @@ XlaWhileOp::XlaWhileOp(OpKernelConstruction* ctx) : XlaOpKernel(ctx) {
 
 void XlaWhileOp::Compile(XlaOpKernelContext* ctx) {
   VLOG(1) << "WhileOp::Compile";
+
+  // Input resources need to be grouped in the end of the body function
+  // according to the convention of the XLA bridge.
+  OP_REQUIRES_OK(ctx, VerifyBodyFunctionSignature(ctx, body_name_attr_));
 
   std::vector<XlaCompiler::Argument> arguments;
   bool has_uninitialized_vars;

--- a/tensorflow/compiler/tf2xla/kernels/while_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/while_op.cc
@@ -38,7 +38,7 @@ namespace tensorflow {
 namespace {
 
 // Verify that input resources are grouped in the end.
-Status VerifyBodyFunctionSignature(XlaOpKernelContext* ctx,
+Status VerifyResourceArgsGroupedAtEnd(XlaOpKernelContext* ctx,
                                    const NameAttrList& body_name_attr) {
   const FunctionBody* body;
   TF_RETURN_IF_ERROR(ctx->compiler()->FindFunctionBody(body_name_attr, &body));
@@ -49,8 +49,8 @@ Status VerifyBodyFunctionSignature(XlaOpKernelContext* ctx,
       if (arg_type != DT_RESOURCE) {
           return errors::InvalidArgument(
               "Expect input resources are grouped in the end of while body ",
-              body_name_attr.name(), ", but see non-resource input ",
-              body->arg_nodes[i]->name(), ".");
+              body_name_attr.name(), ", but the ", i, "-th argument ",
+              body->arg_nodes[i]->name(), " is not a resource.");
       }
     } else {
       if (arg_type == DT_RESOURCE) {
@@ -296,7 +296,7 @@ void XlaWhileOp::Compile(XlaOpKernelContext* ctx) {
 
   // Input resources need to be grouped in the end of the body function
   // according to the convention of the XLA bridge.
-  OP_REQUIRES_OK(ctx, VerifyBodyFunctionSignature(ctx, body_name_attr_));
+  OP_REQUIRES_OK(ctx, VerifyResourceArgsGroupedAtEnd(ctx, body_name_attr_));
 
   std::vector<XlaCompiler::Argument> arguments;
   bool has_uninitialized_vars;

--- a/tensorflow/compiler/tf2xla/xla_compiler.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler.cc
@@ -236,10 +236,11 @@ Status BuildComputation(
 
       case XlaExpression::Kind::kResource:
         // Resources are pushed into elems later when processing resource
-        // arguments. This is correct as long as the input and output resources
-        // are in the same order. In the case of functionalized while body,
+        // arguments. We expect that the input and output resources are in the
+        // same order. For example, in the case of functionalized while body,
         // this property is guaranteed since a corresponding output is always
         // created for a DT_RESOURCE input in a corresponding location.
+        TF_RET_CHECK(retval.resource()->arg_num() == i);
         output.is_constant = false;
         output.input_index = retval.resource()->arg_num();
         output.shape = retval.resource()->shape();

--- a/tensorflow/compiler/tf2xla/xla_compiler.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler.cc
@@ -235,12 +235,8 @@ Status BuildComputation(
       }
 
       case XlaExpression::Kind::kResource:
-        // Resources are pushed into elems later when processing resource
-        // arguments. We expect that the input and output resources are in the
-        // same order. For example, in the case of functionalized while body,
-        // this property is guaranteed since a corresponding output is always
-        // created for a DT_RESOURCE input in a corresponding location.
-        TF_RET_CHECK(retval.resource()->arg_num() == i);
+        // Resources will be pushed into elems later when processing resource
+        // arguments below.
         output.is_constant = false;
         output.input_index = retval.resource()->arg_num();
         output.shape = retval.resource()->shape();

--- a/tensorflow/compiler/tf2xla/xla_compiler_test.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler_test.cc
@@ -1149,8 +1149,8 @@ TEST_F(XlaCompilerTest, ReturnResourceHandle) {
       scope.WithControlDependencies(std::vector<Operation>{write}), var,
       DT_INT32);
   auto read_plus_one = ops::Add(scope, read, ops::Const<int32>(scope, 1));
-  auto r = ops::_Retval(scope.WithOpName("R"), var, 0);
-  auto d = ops::_Retval(scope.WithOpName("D"), read_plus_one, 1);
+  auto d = ops::_Retval(scope.WithOpName("D"), read_plus_one, 0);
+  auto r = ops::_Retval(scope.WithOpName("R"), var, 1);
 
   std::unique_ptr<Graph> graph(new Graph(OpRegistry::Global()));
   TF_ASSERT_OK(scope.ToGraph(graph.get()));

--- a/tensorflow/compiler/tf2xla/xla_compiler_test.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler_test.cc
@@ -1149,8 +1149,8 @@ TEST_F(XlaCompilerTest, ReturnResourceHandle) {
       scope.WithControlDependencies(std::vector<Operation>{write}), var,
       DT_INT32);
   auto read_plus_one = ops::Add(scope, read, ops::Const<int32>(scope, 1));
-  auto d = ops::_Retval(scope.WithOpName("D"), read_plus_one, 0);
-  auto r = ops::_Retval(scope.WithOpName("R"), var, 1);
+  auto r = ops::_Retval(scope.WithOpName("R"), var, 0);
+  auto d = ops::_Retval(scope.WithOpName("D"), read_plus_one, 1);
 
   std::unique_ptr<Graph> graph(new Graph(OpRegistry::Global()));
   TF_ASSERT_OK(scope.ToGraph(graph.get()));


### PR DESCRIPTION
 - Assert that the input and output resources are in the same order to make the
   expected signature of the xla computation more straightforward.