### PR TITLE
Fix build break because of mv command

### DIFF
--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -188,7 +188,7 @@ function prepare_src() {
   sed \
     "/_deprecation_wrapper$/,/_sys.modules[__name__],/ d" \
     "${TMPDIR}/tensorflow_core/__init__.py" > "${TMPDIR}/tensorflow_core/__init__.out"
-  mv "${TMPDIR}/tensorflow_core/__init__.out ${TMPDIR}/tensorflow_core/__init__.py"
+  mv "${TMPDIR}/tensorflow_core/__init__.out" "${TMPDIR}/tensorflow_core/__init__.py"
 }
 
 function build_wheel() {


### PR DESCRIPTION
Commit 93ebb3fb4abefdfbcd39d07f27660d52c418e8a9 broke the build
because the mv command only contained a single argument. Both the
source and destination are in one pair of quotes. Need to quote each
the source and destination.