### PR TITLE
lite: change usage of 'fileno' to allow for msvc implementation

### DIFF
--- a/tensorflow/lite/allocation.cc
+++ b/tensorflow/lite/allocation.cc
@@ -17,12 +17,12 @@ limitations under the License.
 
 #include <sys/stat.h>
 #include <sys/types.h>
-#ifdef _WIN32
-#include <stdio.h>
-#endif
 #include <cassert>
 #include <cstdarg>
 #include <cstdint>
+#ifdef _WIN32
+#include <cstdio>
+#endif
 #include <cstring>
 #include <utility>
 

--- a/tensorflow/lite/allocation.cc
+++ b/tensorflow/lite/allocation.cc
@@ -20,9 +20,7 @@ limitations under the License.
 #include <cassert>
 #include <cstdarg>
 #include <cstdint>
-#ifdef _WIN32
 #include <cstdio>
-#endif
 #include <cstring>
 #include <utility>
 

--- a/tensorflow/lite/allocation.cc
+++ b/tensorflow/lite/allocation.cc
@@ -17,6 +17,9 @@ limitations under the License.
 
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include <stdio.h>
+#endif
 #include <cassert>
 #include <cstdarg>
 #include <cstdint>
@@ -42,10 +45,18 @@ FileCopyAllocation::FileCopyAllocation(const char* filename,
   // TODO(ahentz): Why did you think using fseek here was better for finding
   // the size?
   struct stat sb;
-  if (fstat(fileno(file.get()), &sb) != 0) {
+
+// support usage of msvc's posix-like fileno symbol
+#ifdef _WIN32
+#define FILENO(_x) _fileno(_x)
+#else
+#define FILENO(_x) fileno(_x)
+#endif
+  if (fstat(FILENO(file.get()), &sb) != 0) {
     error_reporter_->Report("Failed to get file size of '%s'.", filename);
     return;
   }
+#undef FILENO
   buffer_size_bytes_ = sb.st_size;
   std::unique_ptr<char[]> buffer(new char[buffer_size_bytes_]);
   if (!buffer) {


### PR DESCRIPTION
Very straightforward change, just guarding the usage of `fileno` to sub it with `_fileno` where needed. 

In this case there shouldn't be an instance where the differences in the MSVC definition which fall outside of the POSIX version will matter. See https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fileno?view=vs-2019 for the specific differences, but it is quite common for libraries to utilize this workaround (see: gtest).

Also yes, you really can build TFLite on Windows if you're brave enough. 