### PR TITLE
bug in tf.histogram_fixed_width_bins

### DIFF
--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -67,7 +67,7 @@ def histogram_fixed_width_bins(values,
   with tf.compat.v1.get_default_session() as sess:
     indices = tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
     variables.global_variables_initializer().run()
-    sess.run(indices) => [0, 0, 1, 2, 4, 4]
+    sess.run(indices) # [0, 0, 1, 2, 4, 4]
   ```
   """
   with ops.name_scope(name, 'histogram_fixed_width_bins',

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -26,6 +26,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import clip_ops
 from tensorflow.python.ops import gen_math_ops
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.util.tf_export import tf_export
 
 
@@ -89,7 +90,7 @@ def histogram_fixed_width_bins(values,
     # values outside the open interval will be zero or less, or nbins or more.
     indices = math_ops.floor(nbins_float * scaled_values, name='indices')
     
-    if array_ops.where(value_range[0] == value_range[1]):
+    control_flow_ops.cond(array_ops.where(math_ops.equal(value_range[0], value_range[1]))):
       indices=array_ops.where(math_ops.is_nan(indices), array_ops.ones_like(indices), indices)
 
     # Clip edge cases (e.g. value = value_range[1]) or "outliers."

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -66,7 +66,7 @@ def histogram_fixed_width_bins(values,
   with tf.compat.v1.get_default_session() as sess:
     indices = tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
     variables.global_variables_initializer().run()
-    sess.run(indices) => [0, 0, 1, 2, 4]
+    sess.run(indices) => [0, 0, 1, 2, 4, 4]
   ```
   """
   with ops.name_scope(name, 'histogram_fixed_width_bins',

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -89,8 +89,8 @@ def histogram_fixed_width_bins(values,
     # values outside the open interval will be zero or less, or nbins or more.
     indices = math_ops.floor(nbins_float * scaled_values, name='indices')
     
-    if value_range[0].numpy() == value_range[1].numpy():
-      indices=tf.where(math_ops.is_nan(indices), tf.ones_like(indices), indices)
+    if array_ops.where(value_range[0] == value_range[1]):
+      indices=array_ops.where(math_ops.is_nan(indices), array_ops.ones_like(indices), indices)
 
     # Clip edge cases (e.g. value = value_range[1]) or "outliers."
     indices = math_ops.cast(

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -88,6 +88,9 @@ def histogram_fixed_width_bins(values,
     # map tensor values within the open interval value_range to {0,.., nbins-1},
     # values outside the open interval will be zero or less, or nbins or more.
     indices = math_ops.floor(nbins_float * scaled_values, name='indices')
+    
+    if value_range[0].numpy() == value_range[1].numpy():
+      indices=tf.where(math_ops.is_nan(indices), tf.ones_like(indices), indices)
 
     # Clip edge cases (e.g. value = value_range[1]) or "outliers."
     indices = math_ops.cast(

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -53,6 +53,19 @@ class BinValuesFixedWidth(test.TestCase):
           values, value_range, nbins=5, dtype=dtypes.int64)
       self.assertEqual(dtypes.int32, bins.dtype)
       self.assertAllClose(expected_bins, self.evaluate(bins))
+      
+  def test_same_min_max_range(self):
+    # Bins will be:
+    #   (-inf, 1), [1, 2), [2, 3), [3, 4), [4, inf)
+    value_range = [0.0, 0.0]
+    values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
+    expected_bins = [0, 0, 4, 4, 4, 4]
+    with self.cached_session():
+      bins = histogram_ops.histogram_fixed_width_bins(
+          values, value_range, nbins=5)
+      self.assertEqual(dtypes.int32, bins.dtype)
+      self.assertAllClose(expected_bins, self.evaluate(bins))
+      
 
   def test_1d_float64_values_int32_output(self):
     # Bins will be:


### PR DESCRIPTION
This PR is to correct a bug that is present in tf.histogram_fixed_width_bins. The issue was described in https://github.com/tensorflow/tensorflow/issues/29661.

When the elements of `value_range` are same and matches with one or more of the elements in input array `values`, then the index of the element will be outside `nbins`.