### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build

### DIFF
--- a/tensorflow/core/kernels/scan_ops_gpu_int.cu.cc
+++ b/tensorflow/core/kernels/scan_ops_gpu_int.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -32,4 +32,4 @@ template struct functor::Scan<GpuDevice, Eigen::internal::ProdReducer<int32>,
                               int32>;
 }  // namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
The `--config=rocm` build was broken due to a combination of following PR + commit getting merged
 * PR #28488 - Adding ROCm support for scan ops
   * (merged yesterday)
 * db3ecd34a4fd527912207e1374a905d8fd247622 - adds a new file `scan_ops_gpu_int.cu.cc`
   * (merged 4 days ago)

The scan_ops_* file is a recent addition and has was not included in PR 28488 (which was filed a couple of weeks ago). It has kernels within it (which are enabled for CUDA only) and are referred to by the rest of the scan ops code, which is enabled for CUDA as well as ROCm (as a consequence of PR 28488 getting merged). This results in the `--config=rocm` build failure.

The "fix" here is to merely enable the code within the `scan_ops_gpu_int.cu.cc` file for the ROCm platform as well

--------------------------------------------------------------------------

@tatianashp @whchung @chsigg 

