### PR TITLE
[ROCm] Adding ROCm support for reduction gpu kernels 

### DIFF
--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -16,7 +16,7 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_KERNELS_REDUCTION_GPU_KERNELS_CU_H_
 #define TENSORFLOW_CORE_KERNELS_REDUCTION_GPU_KERNELS_CU_H_
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -1071,6 +1071,6 @@ struct ReduceFunctor<GPUDevice, Eigen::internal::OrReducer> {
 }  // namespace functor
 }  // namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #endif  // TENSORFLOW_CORE_KERNELS_REDUCTION_GPU_KERNELS_CU_H_

--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -88,6 +88,9 @@ struct DividesBy {
   __host__ __device__ outT operator()(const T& x) const { return x / divisor; }
 };
 
+#if GOOGLE_CUDA
+// TODO(rocm) : enable this once ROCm platform has support for complex datatypes
+//
 // needed to work around a compiler bug in nvcc - it doesn't seem to like
 // the overloaded ops for std::complex
 template <>
@@ -119,6 +122,7 @@ struct DividesBy<std::complex<double>> {
     return std::complex<double>(result.x, result.y);
   }
 };
+#endif  // GOOGLE_CUDA
 
 template <>
 struct DividesBy<float, Eigen::half> {

--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -291,10 +291,15 @@ __global__ void ColumnReduceMax16ColumnsKernel(
   // This is to mimic the following, but without any constructors:
   //   __shared__ storage_type<value_type> partial_sums[TF_RED_WARPSIZE *
   //   (TF_RED_WARPSIZE+1)];
+#if GOOGLE_CUDA || TENSORFLOW_COMPILER_IS_HIP_CLANG
   __shared__ __align__(alignof(value_type)) char
       partial_sums_raw[TF_RED_WARPSIZE * (TF_RED_WARPSIZE + 1) *
                        sizeof(value_type)];
   value_type* partial_sums = reinterpret_cast<value_type*>(partial_sums_raw);
+#elif TENSORFLOW_USE_ROCM
+  __shared__ storage_type<value_type>
+      partial_sums[TF_RED_WARPSIZE * (TF_RED_WARPSIZE + 1)];
+#endif
 
   row += rows_per_warp * gridDim.y * blockDim.y;
   for (; row < num_rows; row += rows_per_warp * gridDim.y * blockDim.y) {
@@ -347,10 +352,15 @@ __global__ void ColumnReduceKernel(
   // This is to mimic the following, but without constructors:
   //     __shared__ storage_type<value_type> partial_sums[TF_RED_WARPSIZE *
   //     (TF_RED_WARPSIZE + 1)];
+#if GOOGLE_CUDA || TENSORFLOW_COMPILER_IS_HIP_CLANG
   __shared__ __align__(alignof(value_type)) char
       partial_sums_raw[TF_RED_WARPSIZE * (TF_RED_WARPSIZE + 1) *
                        sizeof(value_type)];
   value_type* partial_sums = reinterpret_cast<value_type*>(partial_sums_raw);
+#elif TENSORFLOW_USE_ROCM
+  __shared__ storage_type<value_type>
+      partial_sums[TF_RED_WARPSIZE * (TF_RED_WARPSIZE + 1)];
+#endif
 
   row += gridDim.y * blockDim.y;
 

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -82,6 +82,19 @@ inline const char* GpuGetErrorString(hipError_t error) {
 }
 #endif
 
+// Exact copy from GetCudaStream() in gpu_launch_config.h
+// Returns a raw reference to the current cuda stream. Required by a
+// number of kernel calls (for which StreamInterface* does not work),
+// i.e. CUB and certain cublas primitives.
+inline const gpuStream_t& GetGpuStream(OpKernelContext* context) {
+  const gpuStream_t* ptr = CHECK_NOTNULL(
+      reinterpret_cast<const gpuStream_t*>(context->op_device_context()
+                                               ->stream()
+                                               ->implementation()
+                                               ->GpuStreamMemberHack()));
+  return *ptr;
+}
+
 // Launches a GPU kernel through cudaLaunchKernel in CUDA environment, or
 // hipLaunchKernel in ROCm environment with the given arguments.
 //


### PR DESCRIPTION
This PR adds ROCm support for the code within the `reduction_gpu_kernels.cu.h file`

There are a few different functional changes associated with this PR, and they have been broken down into individual commits. Reviewing this PR on a per-commit basis will be easier.

The last commit in this PR is actually from another PR ( #29181 ). Though not a part of this PR, I have included it here, because it is required to make the `--config=rocm` build work after the changes contained within this PR. If PR 29181 gets merged before this PR, we can drop that commit from this PR (and vice-versa)

This is a non-trivial change, and a pre-req for upstream ROCm support for all operators that rely on the GPU reduction kernels contained within this file.

-----------------------------------------------------------------

@tatianashp @whchung @chsigg 
