### PR TITLE
Fix links in TensorFlow Lite for Microcontrollers readme

### DIFF
--- a/tensorflow/lite/experimental/micro/README.md
+++ b/tensorflow/lite/experimental/micro/README.md
@@ -14,7 +14,7 @@ detection model, takes up a total of 22KB.
     *   [Getting Started with Portable Reference Code](#getting-started-with-portable-reference-code)
     *   [Building Portable Reference Code using Make](#building-portable-reference-code-using-make)
     *   [Building for the "Blue Pill" STM32F103 using Make](#building-for-the-blue-pill-stm32f103-using-make)
-    *   [Building for "Hifive1" SiFive FE310 development board using Make](#building-for-hifive1-sifive-fe310-development-board-using-make)
+    *   [Building for "Hifive1" SiFive FE310 development board using Make](#building-for-hifive1-sifive-fe310-development-board)
     *   [Building for Ambiq Micro Apollo3Blue EVB using Make](#building-for-ambiq-micro-apollo3blue-evb-using-make)
         *   [Additional Apollo3 Instructions](#additional-apollo3-instructions)
     *   [Building for the Eta Compute ECM3531 EVB using Make](#Building-for-the-Eta-Compute-ECM3531-EVB-using-Make)
@@ -23,12 +23,12 @@ detection model, takes up a total of 22KB.
 
 -   [Generating Project Files](#generating-project-files)
 
--   [Generating Arduino Libraries](#generating-arduino_libraries)
+-   [Generating Arduino Libraries](#generating-arduino-libraries)
 
 -   [How to Port TensorFlow Lite Micro to a New Platform](#how-to-port-tensorflow-lite-micro-to-a-new-platform)
 
     *   [Requirements](#requirements)
-    *   [Getting Started](getting-started)
+    *   [Getting Started](#getting-started-1)
     *   [Troubleshooting](#troubleshooting)
     *   [Optimizing for your Platform](#optimizing-for-your-platform)
     *   [Code Module Organization](#code-module-organization)
@@ -615,7 +615,7 @@ As mentioned above, the one function you will need to implement for a completely
 new platform is debug logging. If your device is just a variation on an existing
 platform you may be able to reuse code that's already been written. To
 understand what's available, begin with the default reference implementation at
-[tensorflow/lite/experimental/micro/debug_log.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/experimental/micro/debug_log.cc]),
+[tensorflow/lite/experimental/micro/debug_log.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/experimental/micro/debug_log.cc),
 which uses fprintf and stderr. If your platform has this level of support for
 the C standard library in its toolchain, then you can just reuse this.
 Otherwise, you'll need to do some research into how your platform and device can
@@ -900,7 +900,7 @@ git commit -a -m "Added DebugLog() support for <your platform>"
 git push origin master
 ```
 
-Then go back to https://github.com/<your account>/tensorflow, and choose "New
+Then go back to `https://github.com/<your account>/tensorflow`, and choose "New
 Pull Request" near the top. You should then be able to go through the standard
 TensorFlow PR process to get your change added to the main repository, and
 available to the rest of the community!


### PR DESCRIPTION
Some of the links were broken.