### PR TITLE
[Grappler] Prevent segfault in shape inference

### DIFF
--- a/tensorflow/core/grappler/costs/graph_properties.cc
+++ b/tensorflow/core/grappler/costs/graph_properties.cc
@@ -783,13 +783,13 @@ class SymbolicShapeRefiner {
       int src_output = fanin.port_id;
       const NodeDef* src = fanin.node;
       NodeContext* src_ctx = GetNodeContext(src);
-      InferenceContext* src_ic = src_ctx->inference_context.get();
       if (src_ctx == nullptr) {
         return errors::FailedPrecondition(
-            "Input ", dst_input, " ('", src->name(), "') for '", node->name(),
+            "Input ", dst_input, " for '", node->name(),
             "' was not previously added to SymbolicShapeRefiner.");
       }
 
+      InferenceContext* src_ic = src_ctx->inference_context.get();
       if (src_output >= src_ic->num_outputs()) {
         return errors::OutOfRange("src_output = ", src_output,
                                   ", but num_outputs is only ",


### PR DESCRIPTION
If `src_context` is `nullptr` because the `src` was null, the error message will cause a segfault trying to access `src->name()`.

Also, src_context was used before it was checked to be null, so I moved that usage after the nullptr check.

This bug was discovered by a segfault during a call to `GraphProperties::InferStatically()` inside of TF-TRT: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc#L231