### PR TITLE
[INTEL MKL] Use the new switch -dumpfullversion to get full gcc version number

### DIFF
--- a/tensorflow/tools/ci_build/linux/mkl/set-build-env.py
+++ b/tensorflow/tools/ci_build/linux/mkl/set-build-env.py
@@ -106,8 +106,9 @@ class BuildEnvSetter(object):
         raise ValueError(
             "{} does not exist or is not executable.".format(gcc_path))
 
-      gcc_output = subprocess.check_output([gcc_path, "-dumpversion"],
-                                           stderr=subprocess.STDOUT)
+      gcc_output = subprocess.check_output(
+          [gcc_path, "-dumpfullversion", "-dumpversion"],
+          stderr=subprocess.STDOUT).strip()
       # handle python2 vs 3 (bytes vs str type)
       if isinstance(gcc_output, bytes):
         gcc_output = gcc_output.decode("utf-8")


### PR DESCRIPTION
Looks like this one didn't make it to the `v1.14.0` or `r1.14` branch 🙁 
But we need it, otherwise we get:
```
Step 15/21 : RUN ${PYTHON} set-build-env.py -p ${TARGET_PLATFORM} -f /root/.mkl.bazelrc --disable-v2
 ---> Running in 09a31032ce3b
gcc_path_cmd = command -v gcc
gcc located here: /usr/bin/gcc
gcc version: 7

[91mTraceback (most recent call last):
  File "set-build-env.py", line 225, in <module>
    env_setter = BuildEnvSetter()
  File "set-build-env.py", line 92, in __init__
    self.go()
  File "set-build-env.py", line 218, in go
    target_platform["min_gcc_minor_version"]):
  File "set-build-env.py", line 134, in gcc_version_ok
    except subprocess.CalledProcessException as e:
AttributeError: 'module' object has no attribute 'CalledProcessException'
[0mThe command '/bin/sh -c ${PYTHON} set-build-env.py -p ${TARGET_PLATFORM} -f /root/.mkl.bazelrc --disable-v2' returned a non-zero code: 1
```