### PR TITLE
Add Raises in the docstring of tf.histogram_fixed_width

### DIFF
--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -119,6 +119,11 @@ def histogram_fixed_width(values,
   Returns:
     A 1-D `Tensor` holding histogram of values.
 
+  Raises:
+    TypeError: If any unsupported dtype is provided.
+    tf.errors.InvalidArgumentError: If value_range does not
+        satisfy value_range[0] < value_range[1].
+
   Examples:
 
   ```python


### PR DESCRIPTION
This fix adds exception conditions for tf.histogram_fixed_width in the docstring.

This fix fixes #29276.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>