### PR TITLE
Fix the issue of tf.range where tensor with a different dtype is passed

### DIFF
--- a/tensorflow/python/kernel_tests/init_ops_test.py
+++ b/tensorflow/python/kernel_tests/init_ops_test.py
@@ -537,6 +537,14 @@ class RangeTest(test.TestCase):
         math_ops.range(
             0, 0, 1, dtype=dtypes.float64).dtype, dtypes.float64)
 
+  def testMixedDType(self):
+    # Test case for GitHub issue 29867
+    with self.cached_session(use_gpu=True):
+      tf_ans = math_ops.range(constant_op.constant(5), dtype=dtypes.float32)
+      self.assertAllEqual(
+          self.evaluate(tf_ans),
+          np.arange(np.int32(5), dtype=np.float32))
+
 
 # TODO(vrv): move to sequence_ops_test?
 class LinSpaceTest(test.TestCase):

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1349,9 +1349,28 @@ def range(start, limit=None, delta=1, dtype=None, name="range"):  # pylint: disa
     start, limit = 0, start
 
   with ops.name_scope(name, "Range", [start, limit, delta]) as name:
-    start = ops.convert_to_tensor(start, dtype=dtype, name="start")
-    limit = ops.convert_to_tensor(limit, dtype=dtype, name="limit")
-    delta = ops.convert_to_tensor(delta, dtype=dtype, name="delta")
+    # In case start, limit, or delta is already a tensor and have different
+    # dtype with the specified dtype, try to do a cast to see if the dtype is
+    # compatible. Otherwise pass to convert_to_tensor. This is to handle
+    # the situation with:
+    #   tf.range(tf.constant(5), dtype=tf.float32)
+    # which is comparable with:
+    #   np.arange(np.int(5), dtype=np.float32)
+    if (isinstance(start, ops.Tensor) and
+        dtype is not None and dtype != start.dtype):
+      start = cast(start, dtype=dtype)
+    else:
+      start = ops.convert_to_tensor(start, dtype=dtype, name="start")
+    if (isinstance(limit, ops.Tensor) and
+        dtype is not None and dtype != limit.dtype):
+      limit = cast(limit, dtype=dtype)
+    else:
+      limit = ops.convert_to_tensor(limit, dtype=dtype, name="limit")
+    if (isinstance(delta, ops.Tensor) and
+        dtype is not None and dtype != delta.dtype):
+      delta = cast(delta, dtype=dtype)
+    else:
+      delta = ops.convert_to_tensor(delta, dtype=dtype, name="delta")
 
     # infer dtype if not explicitly provided
     if dtype is None:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1349,28 +1349,20 @@ def range(start, limit=None, delta=1, dtype=None, name="range"):  # pylint: disa
     start, limit = 0, start
 
   with ops.name_scope(name, "Range", [start, limit, delta]) as name:
-    # In case start, limit, or delta is already a tensor and have different
-    # dtype with the specified dtype, try to do a cast to see if the dtype is
-    # compatible. Otherwise pass to convert_to_tensor. This is to handle
+    # In case dtype is not none, cast start, limit, and delta directly.
+    # Otherwise pass to convert_to_tensor. This is to handle
     # the situation with:
     #   tf.range(tf.constant(5), dtype=tf.float32)
     # which is comparable with:
     #   np.arange(np.int(5), dtype=np.float32)
-    if (isinstance(start, ops.Tensor) and
-        dtype is not None and dtype != start.dtype):
+    if dtype is not None:
       start = cast(start, dtype=dtype)
-    else:
-      start = ops.convert_to_tensor(start, dtype=dtype, name="start")
-    if (isinstance(limit, ops.Tensor) and
-        dtype is not None and dtype != limit.dtype):
       limit = cast(limit, dtype=dtype)
-    else:
-      limit = ops.convert_to_tensor(limit, dtype=dtype, name="limit")
-    if (isinstance(delta, ops.Tensor) and
-        dtype is not None and dtype != delta.dtype):
       delta = cast(delta, dtype=dtype)
     else:
-      delta = ops.convert_to_tensor(delta, dtype=dtype, name="delta")
+      start = ops.convert_to_tensor(start, name="start")
+      limit = ops.convert_to_tensor(limit, name="limit")
+      delta = ops.convert_to_tensor(delta, name="delta")
 
     # infer dtype if not explicitly provided
     if dtype is None:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1356,9 +1356,9 @@ def range(start, limit=None, delta=1, dtype=None, name="range"):  # pylint: disa
     # which is comparable with:
     #   np.arange(np.int(5), dtype=np.float32)
     if dtype is not None:
-      start = cast(start, dtype=dtype)
-      limit = cast(limit, dtype=dtype)
-      delta = cast(delta, dtype=dtype)
+      start = cast(start, dtype=dtype, name="start")
+      limit = cast(limit, dtype=dtype, name="limit")
+      delta = cast(delta, dtype=dtype, name="delta")
     else:
       start = ops.convert_to_tensor(start, name="start")
       limit = ops.convert_to_tensor(limit, name="limit")


### PR DESCRIPTION
This fix tries to address the issue raised in #29867 where the following raises error:
```
tf.range(tf.constant(102), dtype=tf.float32)
...
...
ValueError: Tensor conversion requested dtype float32 for Tensor \
    with dtype int32: 'tf.Tensor(102, shape=(), dtype=int32)'
```

This is different from `tf.arange` where different types could be used:
```
np.arange(np.int(102), dtype=np.float32)
```

The issue is that in tf.range cast is only done when dtype is not passed explicitly.

This fix adds additional processing so that the above scenario is covered.

This fix fixes #29867.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>