### PR TITLE
Fix broken LaTeX in documentation for tf.keras.optimizers.Adam

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/adam.py
+++ b/tensorflow/python/keras/optimizer_v2/adam.py
@@ -87,7 +87,7 @@ class Adam(optimizer_v2.OptimizerV2):
 
       $$m_t := beta_1 * m_{t-1} + (1 - beta_1) * g$$
       $$v_t := beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-      $$v_hat_t := max(v_hat_{t-1}, v_t)
+      $$v_hat_t := max(v_hat_{t-1}, v_t)$$
       $$variable := variable - lr_t * m_t / (\sqrt{v_hat_t} + \epsilon)$$
 
     The default value of 1e-7 for epsilon might not be a good default in


### PR DESCRIPTION
This PR should fix this:

![image](https://user-images.githubusercontent.com/4061736/59825594-8fdd6f80-9388-11e9-83f1-160912b7c0d5.png)

It's a tiny change, but I thought I may as well just go ahead and fix it.