### PR TITLE
FreeBSD build fixes for hwloc

### DIFF
--- a/third_party/hwloc/BUILD.bazel
+++ b/third_party/hwloc/BUILD.bazel
@@ -26,24 +26,30 @@ VAR_SETTINGS_COPTS = [
     "-DRUNSTATEDIR=",
 ]
 
+_INCLUDE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS = {
+    "#undef HWLOC_VERSION_MAJOR": "#define HWLOC_VERSION_MAJOR 2",
+    "#undef HWLOC_VERSION_MINOR": "#define HWLOC_VERSION_MINOR 0",
+    "#undef HWLOC_VERSION_RELEASE": "#define HWLOC_VERSION_RELEASE 3",
+    "#undef HWLOC_VERSION_GREEK": "#define HWLOC_VERSION_GREEK \"\"",
+    "#undef HWLOC_VERSION": "#define HWLOC_VERSION \"2.0.3\"",
+    "#undef hwloc_pid_t": "#define hwloc_pid_t pid_t",
+    "#undef hwloc_thread_t": "#define hwloc_thread_t pthread_t",
+    "#  undef HWLOC_HAVE_STDINT_H": "#  define HWLOC_HAVE_STDINT_H 1 ",
+    "#undef HWLOC_SYM_TRANSFORM": "#define HWLOC_SYM_TRANSFORM 0",
+    "#undef HWLOC_SYM_PREFIX": "#define HWLOC_SYM_PREFIX hwloc_",
+    "#undef HWLOC_SYM_PREFIX_CAPS": "#define HWLOC_SYM_PREFIX_CAPS HWLOC_",
+}
+
 template_rule(
     name = "include_hwloc_autogen_config_h",
     src = "include/hwloc/autogen/config.h.in",
     out = "include/hwloc/autogen/config.h",
-    substitutions = {
-        "#undef HWLOC_VERSION_MAJOR": "#define HWLOC_VERSION_MAJOR 2",
-        "#undef HWLOC_VERSION_MINOR": "#define HWLOC_VERSION_MINOR 0",
-        "#undef HWLOC_VERSION_RELEASE": "#define HWLOC_VERSION_RELEASE 3",
-        "#undef HWLOC_VERSION_GREEK": "#define HWLOC_VERSION_GREEK \"\"",
-        "#undef HWLOC_VERSION": "#define HWLOC_VERSION \"2.0.3\"",
-        "#undef HWLOC_LINUX_SYS": "#define HWLOC_LINUX_SYS 1",
-        "#undef hwloc_pid_t": "#define hwloc_pid_t pid_t",
-        "#undef hwloc_thread_t": "#define hwloc_thread_t pthread_t",
-        "#  undef HWLOC_HAVE_STDINT_H": "#  define HWLOC_HAVE_STDINT_H 1 ",
-        "#undef HWLOC_SYM_TRANSFORM": "#define HWLOC_SYM_TRANSFORM 0",
-        "#undef HWLOC_SYM_PREFIX": "#define HWLOC_SYM_PREFIX hwloc_",
-        "#undef HWLOC_SYM_PREFIX_CAPS": "#define HWLOC_SYM_PREFIX_CAPS HWLOC_",
-    },
+    substitutions = select({
+        "@org_tensorflow//tensorflow:linux_x86_64": dict(_INCLUDE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS, **{
+                "#undef HWLOC_LINUX_SYS": "#define HWLOC_LINUX_SYS 1"
+            }),
+        "//conditions:default": _INCLUDE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS,
+    }),
 )
 
 _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS = {
@@ -86,7 +92,6 @@ _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS = {
     "#undef HAVE_NL_LANGINFO": "#define HAVE_NL_LANGINFO 1",
     "#undef HAVE_OPENAT": "#define HAVE_OPENAT 1",
     "#undef HAVE_POSIX_MEMALIGN": "#define HAVE_POSIX_MEMALIGN 1",
-    "#undef HAVE_PROGRAM_INVOCATION_NAME": "#define HAVE_PROGRAM_INVOCATION_NAME 1",
     "#undef HAVE_PTHREAD_T": "#define HAVE_PTHREAD_T 1",
     "#undef HAVE_PUTWC": "#define HAVE_PUTWC 1",
     "#undef HAVE_SETLOCALE": "#define HAVE_SETLOCALE 1",
@@ -149,7 +154,6 @@ _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS = {
     "#undef HWLOC_HAVE_SYSCALL": "#define HWLOC_HAVE_SYSCALL 1",
     "#undef HWLOC_HAVE_X11_KEYSYM": "#define HWLOC_HAVE_X11_KEYSYM 1",
     "#undef HWLOC_HAVE_X86_CPUID": "#define HWLOC_HAVE_X86_CPUID 1",
-    "#undef HWLOC_LINUX_SYS": "#define HWLOC_LINUX_SYS 1",
     "#undef HWLOC_SIZEOF_UNSIGNED_INT": "#define HWLOC_SIZEOF_UNSIGNED_INT 4",
     "#undef HWLOC_SIZEOF_UNSIGNED_LONG": "#define HWLOC_SIZEOF_UNSIGNED_LONG 8",
     "#undef HWLOC_SYM_PREFIX": "#define HWLOC_SYM_PREFIX hwloc_",
@@ -192,7 +196,13 @@ _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_CUDA_SUBS = {
     "#undef HAVE_CUDA_RUNTIME_API_H": "#undef HAVE_CUDA_RUNTIME_API_H 1",
 }
 
-_INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_CUDA_SUBS.update(_INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS)
+_INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_LINUX_SUBS = {
+    "#undef HAVE_PROGRAM_INVOCATION_NAME": "#define HAVE_PROGRAM_INVOCATION_NAME 1",
+    "#undef HWLOC_LINUX_SYS": "#define HWLOC_LINUX_SYS 1",
+}
+
+_INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_LINUX_SUBS.update(_INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS)
+_INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_CUDA_SUBS.update(_INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_LINUX_SUBS)
 
 template_rule(
     name = "include_private_hwloc_autogen__config_h",
@@ -200,7 +210,7 @@ template_rule(
     out = "include/private/autogen/config.h",
     substitutions = if_cuda(
         _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_CUDA_SUBS,
-        if_false = _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS,
+        if_false = _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_LINUX_SUBS,
     ),
 )
 
@@ -226,13 +236,11 @@ cc_library(
         "hwloc/static-components.h",
         "hwloc/topology.c",
         "hwloc/topology-hardwired.c",
-        "hwloc/topology-linux.c",
         "hwloc/topology-noos.c",
         "hwloc/topology-synthetic.c",
         "hwloc/topology-xml.c",
         "hwloc/topology-xml-nolibxml.c",
         "hwloc/traversal.c",
-        "include/hwloc/linux.h",
         "include/hwloc/plugins.h",
         "include/hwloc/shmem.h",
         "include/private/autogen/config.h",
@@ -244,6 +252,13 @@ cc_library(
         "include/private/xml.h",
     ] + select({
         "@org_tensorflow//tensorflow:linux_x86_64": [
+            "hwloc/topology-linux.c",
+            "include/hwloc/linux.h",
+            "hwloc/topology-x86.c",
+            "include/private/cpuid-x86.h",
+        ],
+        "@org_tensorflow//tensorflow:freebsd": [
+            "hwloc/topology-freebsd.c",
             "hwloc/topology-x86.c",
             "include/private/cpuid-x86.h",
         ],

--- a/third_party/hwloc/static-components.h
+++ b/third_party/hwloc/static-components.h
@@ -22,8 +22,13 @@ static const struct hwloc_component* hwloc_static_components[] = {
     &hwloc_xml_component,
     &hwloc_synthetic_component,
     &hwloc_xml_nolibxml_component,
+#ifdef __Linux__
     &hwloc_linux_component,
     &hwloc_linuxio_component,
+#endif
+#ifdef __FreeBSD__
+    &hwloc_freebsd_component,
+#endif
 #if defined(__x86_64__) || defined(__amd64__) || defined(_M_IX86) || \
     defined(_M_X64)
     &hwloc_x86_component,


### PR DESCRIPTION
With this patches TensorFlow 2 can be built on FreeBSD out-of-box.