### PR TITLE
Call CMSIS-NN optimized kernel for depthwise_conv

### DIFF
--- a/tensorflow/lite/experimental/micro/tools/make/ext_libs/cmsis.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/ext_libs/cmsis.inc
@@ -1,26 +1,26 @@
 ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
     # Enable u-arch specfic behaviours
     ifneq (,$(filter $(TARGET_ARCH), cortex-m3))
-        CCFLAGS += -DARM_MATH_CM3
-        CXXFLAGS += -DARM_CMSIS_NN_M3
+        # CMSIS-NN optimizations not supported
     endif
     ifneq (,$(filter $(TARGET_ARCH), cortex-m4))
-        CCFLAGS += -DARM_MATH_CM4
-        CXXFLAGS += -DARM_CMSIS_NN_M4
+        CCFLAGS += -DARM_MATH_DSP
+        CXXFLAGS += -DARM_MATH_DSP
     endif
     ifneq (,$(filter $(TARGET_ARCH), cortex-m7))
-        CCFLAGS += -DARM_MATH_CM7
-        CXXFLAGS += -DARM_CMSIS_NN_M7
+        CCFLAGS += -DARM_MATH_DSP
+        CXXFLAGS += -DARM_MATH_DSP
     endif
     ifneq (,$(filter $(TARGET_ARCH), x86_64))
-        # For development purposes
-        CCFLAGS += -DARM_MATH_CM4
-        CXXFLAGS += -DARM_CMSIS_NN_X86_64
+        # CMSIS-NN optimizations not supported
     endif
 
     # Setup CMSIS-NN lib and add required header files to microlite lib INCLUDE
     CMSIS_PATH = $(MAKEFILE_DIR)/downloads/cmsis/
-    MICROLITE_CC_SRCS += $(shell find $(CMSIS_PATH)/CMSIS/NN/Source/ -name *.c)
+    THIRD_PARTY_CC_SRCS += $(shell find $(CMSIS_PATH)/CMSIS/NN/Source/ -name *.c)
+    THIRD_PARTY_CC_HDRS += $(shell find $(CMSIS_PATH)/CMSIS/Core/Include/ -name *.h) \
+                           $(shell find $(CMSIS_PATH)/CMSIS/NN/Include/ -name *.h) \
+                           $(shell find $(CMSIS_PATH)/CMSIS/DSP/Include/ -name *.h)
     INCLUDES += -I$(CMSIS_PATH)/CMSIS/Core/Include \
                 -I$(CMSIS_PATH)/CMSIS/NN/Include \
                 -I$(CMSIS_PATH)/CMSIS/DSP/Include


### PR DESCRIPTION
By usings TAGS=cmsis-nn, the optimized depthwise conv is called,
under the restriction that the kernel meets size requirements.

Change-Id: I0a070b37ce7dcd06dd8c747de362b4fd42ed4e5a