### PR TITLE
Install 'future' when building Docker images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,8 +168,8 @@ There are two ways to run TensorFlow unit tests.
     [GPU developer Dockerfile](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/dockerfiles/dockerfiles/devel-gpu.Dockerfile)
     for the required packages. Alternatively, use the said
     [Docker images](https://hub.docker.com/r/tensorflow/tensorflow/tags/), e.g.,
-    `tensorflow/tensorflow:nightly-devel` and
-    `tensorflow/tensorflow:nightly-devel-gpu` for development to avoid
+    `tensorflow/tensorflow:devel` and
+    `tensorflow/tensorflow:devel-gpu` for development to avoid
     installing the packages directly on your system (in which case remember to
     change directory from `/root` to `/tensorflow` once you get into the running
     container so `bazel` can find the `tensorflow` workspace).

--- a/tensorflow/tools/dockerfiles/assembler.py
+++ b/tensorflow/tools/dockerfiles/assembler.py
@@ -32,13 +32,13 @@ import collections
 import copy
 import errno
 import itertools
+import json
 import multiprocessing
 import os
 import platform
 import re
 import shutil
 import sys
-import json
 
 from absl import app
 from absl import flags
@@ -162,6 +162,7 @@ flags.DEFINE_string(
 # Note: can add python references with e.g.
 # !!python/name:builtins.str
 # !!python/name:__main__.funcname
+# (but this may not be considered safe?)
 SCHEMA_TEXT = """
 header:
   type: string
@@ -475,13 +476,13 @@ def main(argv):
 
   # Read the full spec file, used for everything
   with open(FLAGS.spec_file, 'r') as spec_file:
-    tag_spec = yaml.load(spec_file)
+    tag_spec = yaml.safe_load(spec_file)
 
   # Get existing partial contents
   partials = gather_existing_partials(FLAGS.partial_dir)
 
   # Abort if spec.yaml is invalid
-  schema = yaml.load(SCHEMA_TEXT)
+  schema = yaml.safe_load(SCHEMA_TEXT)
   v = TfDockerTagValidator(schema, partials=partials)
   if not v.validate(tag_spec):
     eprint('> Error: {} is an invalid spec! The errors are:'.format(

--- a/tensorflow/tools/dockerfiles/dockerfiles/devel-cpu-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/devel-cpu-jupyter.Dockerfile
@@ -92,6 +92,7 @@ RUN ${PIP} --no-cache-dir install \
     scipy \
     sklearn \
     pandas \
+    future \
     portpicker \
     && test "${USE_PYTHON_3_NOT_2}" -eq 1 && true || ${PIP} --no-cache-dir install \
     enum34

--- a/tensorflow/tools/dockerfiles/dockerfiles/devel-cpu.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/devel-cpu.Dockerfile
@@ -92,6 +92,7 @@ RUN ${PIP} --no-cache-dir install \
     scipy \
     sklearn \
     pandas \
+    future \
     portpicker \
     && test "${USE_PYTHON_3_NOT_2}" -eq 1 && true || ${PIP} --no-cache-dir install \
     enum34

--- a/tensorflow/tools/dockerfiles/dockerfiles/devel-gpu-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/devel-gpu-jupyter.Dockerfile
@@ -124,6 +124,7 @@ RUN ${PIP} --no-cache-dir install \
     scipy \
     sklearn \
     pandas \
+    future \
     portpicker \
     && test "${USE_PYTHON_3_NOT_2}" -eq 1 && true || ${PIP} --no-cache-dir install \
     enum34

--- a/tensorflow/tools/dockerfiles/dockerfiles/devel-gpu.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/devel-gpu.Dockerfile
@@ -124,6 +124,7 @@ RUN ${PIP} --no-cache-dir install \
     scipy \
     sklearn \
     pandas \
+    future \
     portpicker \
     && test "${USE_PYTHON_3_NOT_2}" -eq 1 && true || ${PIP} --no-cache-dir install \
     enum34

--- a/tensorflow/tools/dockerfiles/partials/ubuntu/bazel.partial.Dockerfile
+++ b/tensorflow/tools/dockerfiles/partials/ubuntu/bazel.partial.Dockerfile
@@ -19,6 +19,7 @@ RUN ${PIP} --no-cache-dir install \
     scipy \
     sklearn \
     pandas \
+    future \
     portpicker \
     && test "${USE_PYTHON_3_NOT_2}" -eq 1 && true || ${PIP} --no-cache-dir install \
     enum34


### PR DESCRIPTION
Python 2-based images have been failing to build, and I think it's
because 'future' is missing. This PR resolves that, safe_loads yaml to
quiet a warning about safety, and rewords a few things in
CONTRIBUTING.md.