### PR TITLE
Make the APIs in name_utils more robust

### DIFF
--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -84,7 +84,6 @@ cc_library(
     deps = [
         "//tensorflow/core:lib",
         "@com_google_absl//absl/strings",
-        "@com_googlesource_code_re2//:re2",
     ],
 )
 

--- a/tensorflow/core/kernels/data/name_utils.cc
+++ b/tensorflow/core/kernels/data/name_utils.cc
@@ -14,9 +14,7 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/core/kernels/data/name_utils.h"
 
-#include "absl/strings/match.h"
-#include "re2/re2.h"
-#include "tensorflow/core/platform/logging.h"
+#include "absl/strings/str_join.h"
 
 namespace tensorflow {
 namespace data {
@@ -28,39 +26,36 @@ ABSL_CONST_INIT const char kDefaultDatasetDebugStringPrefix[] = "";
 constexpr char kDataset[] = "Dataset";
 constexpr char kOp[] = "Op";
 constexpr char kVersion[] = "V";
-constexpr char kVersionNumRegex[] = "V(\\d+)$";
 
 string OpName(const string& dataset_type) {
-  // For the dataset ops with different versions of kernels (e.g.
-  // ParallelInterleaveDatasetOp), the version number needs to be added to the
-  // end of op name.
-  int version_num;
-  if (RE2::PartialMatch(dataset_type, kVersionNumRegex, &version_num)) {
-    string op_name = dataset_type;
-    RE2::Replace(&op_name, kVersionNumRegex,
-                 strings::StrCat(kDataset, kVersion, version_num));
-    return op_name;
-  } else {
+  return OpName(dataset_type, OpNameParams());
+}
+
+string OpName(const string& dataset_type, const OpNameParams& params) {
+  if (params.op_version == 1) {
     return strings::StrCat(dataset_type, kDataset);
+  } else {
+    return strings::StrCat(dataset_type, kDataset, kVersion, params.op_version);
   }
 }
 
-string ArgsToString(std::initializer_list<StringPiece> args) {
-  return strings::StrCat("(", absl::StrJoin(args, ", "), ")");
+string ArgsToString(const std::vector<string>& args) {
+  if (args.empty()) {
+    return "";
+  } else {
+    return strings::StrCat("(", absl::StrJoin(args, ", "), ")");
+  }
+}
+
+string DatasetDebugString(const string& dataset_type) {
+  return DatasetDebugString(dataset_type, DatasetDebugStringParams());
 }
 
 string DatasetDebugString(const string& dataset_type,
-                          const string& dataset_name_prefix,
-                          std::initializer_list<StringPiece> args) {
-  if (args.size() == 0) {
-    return strings::StrCat(OpName(dataset_type), kOp, kDelimiter,
-                           dataset_name_prefix, kDataset);
-  }
-
-  string debug_str;
-  strings::StrAppend(&debug_str, OpName(dataset_type), kOp, ArgsToString(args));
-  strings::StrAppend(&debug_str, kDelimiter, dataset_name_prefix, kDataset);
-  return debug_str;
+                          const DatasetDebugStringParams& params) {
+  string op_name = OpName(dataset_type, OpNameParams(params.op_version));
+  return strings::StrCat(op_name, kOp, ArgsToString(params.args), kDelimiter,
+                         params.dataset_prefix, kDataset);
 }
 
 string IteratorPrefix(const string& dataset_type, const string& prefix) {

--- a/tensorflow/core/kernels/data/name_utils.cc
+++ b/tensorflow/core/kernels/data/name_utils.cc
@@ -34,17 +34,15 @@ string OpName(const string& dataset_type) {
 string OpName(const string& dataset_type, const OpNameParams& params) {
   if (params.op_version == 1) {
     return strings::StrCat(dataset_type, kDataset);
-  } else {
-    return strings::StrCat(dataset_type, kDataset, kVersion, params.op_version);
   }
+  return strings::StrCat(dataset_type, kDataset, kVersion, params.op_version);
 }
 
 string ArgsToString(const std::vector<string>& args) {
   if (args.empty()) {
     return "";
-  } else {
-    return strings::StrCat("(", absl::StrJoin(args, ", "), ")");
   }
+  return strings::StrCat("(", absl::StrJoin(args, ", "), ")");
 }
 
 string DatasetDebugString(const string& dataset_type) {
@@ -53,7 +51,9 @@ string DatasetDebugString(const string& dataset_type) {
 
 string DatasetDebugString(const string& dataset_type,
                           const DatasetDebugStringParams& params) {
-  string op_name = OpName(dataset_type, OpNameParams(params.op_version));
+  OpNameParams op_name_params;
+  op_name_params.op_version = params.op_version;
+  string op_name = OpName(dataset_type, op_name_params);
   return strings::StrCat(op_name, kOp, ArgsToString(params.args), kDelimiter,
                          params.dataset_prefix, kDataset);
 }

--- a/tensorflow/core/kernels/data/name_utils.h
+++ b/tensorflow/core/kernels/data/name_utils.h
@@ -32,6 +32,11 @@ struct OpNameParams {
 };
 
 struct DatasetDebugStringParams {
+  template <typename... T>
+  void set_args(T... input_args) {
+    args = {static_cast<const strings::AlphaNum&>(input_args).data()...};
+  }
+
   int op_version = 1;
   string dataset_prefix = "";
   std::vector<string> args;
@@ -69,9 +74,7 @@ string DatasetDebugString(const string& dataset_type);
 //
 // e.g.
 //  DatasetDebugStringParams range_params;
-//  range_params.args.emplace_back(std::to_string(0));
-//  range_params.args.emplace_back(std::to_string(10));
-//  range_params.args.emplace_back(std::to_string(3));
+//  range_params.set_args(0, 10, 3);
 //  DatasetDebugString(RangeDatasetOp::kDatasetType, range_params)
 //  -> "RangeDatasetOp(0, 10, 3)::Dataset");
 string DatasetDebugString(const string& dataset_type,

--- a/tensorflow/core/kernels/data/name_utils.h
+++ b/tensorflow/core/kernels/data/name_utils.h
@@ -28,23 +28,10 @@ extern const char kDelimiter[];
 extern const char kDefaultDatasetDebugStringPrefix[];
 
 struct OpNameParams {
-  OpNameParams() = default;
-
-  explicit OpNameParams(int op_version) : op_version(op_version){};
-
   int op_version = 1;
 };
 
 struct DatasetDebugStringParams {
-  DatasetDebugStringParams() = default;
-
-  template <typename... T>
-  explicit DatasetDebugStringParams(int op_version, string dataset_prefix,
-                                    const T&... args)
-      : op_version(op_version),
-        dataset_prefix(std::move(dataset_prefix)),
-        args({static_cast<const strings::AlphaNum&>(args).data()...}){};
-
   int op_version = 1;
   string dataset_prefix = "";
   std::vector<string> args;
@@ -65,7 +52,9 @@ string OpName(const string& dataset_type);
 // e.g. OpName(ConcatenateDatasetOp::kDatasetType, OpNameParams())
 // -> "ConcatenateDataset"
 //
-// OpName(ParallelInterleaveDatasetOp::kDatasetType, OpNameParams(2)),
+// OpNameParams params;
+// params.op_version = 2;
+// OpName(ParallelInterleaveDatasetOp::kDatasetType, params)
 // -> "ParallelInterleaveDatasetV2"
 string OpName(const string& dataset_type, const OpNameParams& params);
 
@@ -78,12 +67,13 @@ string DatasetDebugString(const string& dataset_type);
 // Returns a human-readable debug string for this dataset in the format of
 // "FooDatasetOp(arg1, arg2, ...)::Dataset".
 //
-// e.g. DatasetDebugString(
-// "Shuffle", DatasetDebugStringParams(1, "FixedSeed", 10, 1, 2))
-// -> "ShuffleDatasetOp(10, 1, 2)::FixedSeedDataset";
-//
-// DatasetDebugString("ParallelInterleave", DatasetDebugStringParams(2, ""))
-// -> "ParallelInterleaveDatasetV2Op::Dataset").
+// e.g.
+//  DatasetDebugStringParams range_params;
+//  range_params.args.emplace_back(std::to_string(0));
+//  range_params.args.emplace_back(std::to_string(10));
+//  range_params.args.emplace_back(std::to_string(3));
+//  DatasetDebugString(RangeDatasetOp::kDatasetType, range_params)
+//  -> "RangeDatasetOp(0, 10, 3)::Dataset");
 string DatasetDebugString(const string& dataset_type,
                           const DatasetDebugStringParams& params);
 

--- a/tensorflow/core/kernels/data/name_utils_test.cc
+++ b/tensorflow/core/kernels/data/name_utils_test.cc
@@ -33,20 +33,29 @@ TEST(DeviceNameUtils, ArgsToString) {
 TEST(NameUtilsTest, DatasetDebugString) {
   EXPECT_EQ(name_utils::DatasetDebugString(ConcatenateDatasetOp::kDatasetType),
             "ConcatenateDatasetOp::Dataset");
-  EXPECT_EQ(name_utils::DatasetDebugString(
-                RangeDatasetOp::kDatasetType,
-                name_utils::DatasetDebugStringParams(
-                    1, name_utils::kDefaultDatasetDebugStringPrefix, 0, 10, 3)),
+  name_utils::DatasetDebugStringParams range_params;
+  range_params.args.emplace_back(std::to_string(0));
+  range_params.args.emplace_back(std::to_string(10));
+  range_params.args.emplace_back(std::to_string(3));
+  EXPECT_EQ(name_utils::DatasetDebugString(RangeDatasetOp::kDatasetType,
+                                           range_params),
             "RangeDatasetOp(0, 10, 3)::Dataset");
-  EXPECT_EQ(name_utils::DatasetDebugString(
-                ShuffleDatasetOp::kDatasetType,
-                name_utils::DatasetDebugStringParams(1, "FixedSeed", 10, 1, 2)),
+
+  name_utils::DatasetDebugStringParams shuffle_params;
+  shuffle_params.dataset_prefix = "FixedSeed";
+  shuffle_params.args.emplace_back(std::to_string(10));
+  shuffle_params.args.emplace_back(std::to_string(1));
+  shuffle_params.args.emplace_back(std::to_string(2));
+  EXPECT_EQ(name_utils::DatasetDebugString(ShuffleDatasetOp::kDatasetType,
+                                           shuffle_params),
             "ShuffleDatasetOp(10, 1, 2)::FixedSeedDataset");
-  EXPECT_EQ(name_utils::DatasetDebugString(
-                ParallelInterleaveDatasetOp::kDatasetType,
-                name_utils::DatasetDebugStringParams(
-                    2, name_utils::kDefaultDatasetDebugStringPrefix)),
-            "ParallelInterleaveDatasetV2Op::Dataset");
+
+  name_utils::DatasetDebugStringParams parallel_interleave_params;
+  parallel_interleave_params.op_version = 2;
+  EXPECT_EQ(
+      name_utils::DatasetDebugString(ParallelInterleaveDatasetOp::kDatasetType,
+                                     parallel_interleave_params),
+      "ParallelInterleaveDatasetV2Op::Dataset");
 }
 
 TEST(NameUtilsTest, OpName) {
@@ -54,9 +63,11 @@ TEST(NameUtilsTest, OpName) {
   EXPECT_EQ(name_utils::OpName(ConcatenateDatasetOp::kDatasetType,
                                name_utils::OpNameParams()),
             "ConcatenateDataset");
-  EXPECT_EQ(name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType,
-                               name_utils::OpNameParams(2)),
-            "ParallelInterleaveDatasetV2");
+  name_utils::OpNameParams params;
+  params.op_version = 2;
+  EXPECT_EQ(
+      name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType, params),
+      "ParallelInterleaveDatasetV2");
 }
 
 }  // namespace

--- a/tensorflow/core/kernels/data/name_utils_test.cc
+++ b/tensorflow/core/kernels/data/name_utils_test.cc
@@ -34,18 +34,14 @@ TEST(NameUtilsTest, DatasetDebugString) {
   EXPECT_EQ(name_utils::DatasetDebugString(ConcatenateDatasetOp::kDatasetType),
             "ConcatenateDatasetOp::Dataset");
   name_utils::DatasetDebugStringParams range_params;
-  range_params.args.emplace_back(std::to_string(0));
-  range_params.args.emplace_back(std::to_string(10));
-  range_params.args.emplace_back(std::to_string(3));
+  range_params.set_args(0, 10, 3);
   EXPECT_EQ(name_utils::DatasetDebugString(RangeDatasetOp::kDatasetType,
                                            range_params),
             "RangeDatasetOp(0, 10, 3)::Dataset");
 
   name_utils::DatasetDebugStringParams shuffle_params;
   shuffle_params.dataset_prefix = "FixedSeed";
-  shuffle_params.args.emplace_back(std::to_string(10));
-  shuffle_params.args.emplace_back(std::to_string(1));
-  shuffle_params.args.emplace_back(std::to_string(2));
+  shuffle_params.set_args(10, 1, 2);
   EXPECT_EQ(name_utils::DatasetDebugString(ShuffleDatasetOp::kDatasetType,
                                            shuffle_params),
             "ShuffleDatasetOp(10, 1, 2)::FixedSeedDataset");

--- a/tensorflow/core/kernels/data/name_utils_test.cc
+++ b/tensorflow/core/kernels/data/name_utils_test.cc
@@ -25,7 +25,7 @@ namespace data {
 namespace {
 
 TEST(DeviceNameUtils, ArgsToString) {
-  EXPECT_EQ(name_utils::ArgsToString({}), "()");
+  EXPECT_EQ(name_utils::ArgsToString({}), "");
   EXPECT_EQ(name_utils::ArgsToString({"a"}), "(a)");
   EXPECT_EQ(name_utils::ArgsToString({"1", "2", "3"}), "(1, 2, 3)");
 }
@@ -33,15 +33,30 @@ TEST(DeviceNameUtils, ArgsToString) {
 TEST(NameUtilsTest, DatasetDebugString) {
   EXPECT_EQ(name_utils::DatasetDebugString(ConcatenateDatasetOp::kDatasetType),
             "ConcatenateDatasetOp::Dataset");
-  EXPECT_EQ(
-      name_utils::DatasetDebugString(RangeDatasetOp::kDatasetType, 0, 10, 3),
-      "RangeDatasetOp(0, 10, 3)::Dataset");
-  EXPECT_EQ(name_utils::DatasetDebugString(ShuffleDatasetOp::kDatasetType,
-                                           "FixedSeed", {"10", "1", "2"}),
+  EXPECT_EQ(name_utils::DatasetDebugString(
+                RangeDatasetOp::kDatasetType,
+                name_utils::DatasetDebugStringParams(
+                    1, name_utils::kDefaultDatasetDebugStringPrefix, 0, 10, 3)),
+            "RangeDatasetOp(0, 10, 3)::Dataset");
+  EXPECT_EQ(name_utils::DatasetDebugString(
+                ShuffleDatasetOp::kDatasetType,
+                name_utils::DatasetDebugStringParams(1, "FixedSeed", 10, 1, 2)),
             "ShuffleDatasetOp(10, 1, 2)::FixedSeedDataset");
-  EXPECT_EQ(
-      name_utils::DatasetDebugString(ParallelInterleaveDatasetOp::kDatasetType),
-      "ParallelInterleaveDatasetV2Op::Dataset");
+  EXPECT_EQ(name_utils::DatasetDebugString(
+                ParallelInterleaveDatasetOp::kDatasetType,
+                name_utils::DatasetDebugStringParams(
+                    2, name_utils::kDefaultDatasetDebugStringPrefix)),
+            "ParallelInterleaveDatasetV2Op::Dataset");
+}
+
+TEST(NameUtilsTest, OpName) {
+  EXPECT_EQ(name_utils::OpName(RangeDatasetOp::kDatasetType), "RangeDataset");
+  EXPECT_EQ(name_utils::OpName(ConcatenateDatasetOp::kDatasetType,
+                               name_utils::OpNameParams()),
+            "ConcatenateDataset");
+  EXPECT_EQ(name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType,
+                               name_utils::OpNameParams(2)),
+            "ParallelInterleaveDatasetV2");
 }
 
 }  // namespace

--- a/tensorflow/core/kernels/data/padded_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/padded_batch_dataset_op.cc
@@ -100,7 +100,7 @@ class PaddedBatchDatasetOp::Dataset : public DatasetBase {
   string DebugString() const override {
     name_utils::DatasetDebugStringParams params;
     params.op_version = op_version_;
-    params.args.emplace_back(std::to_string(batch_size_));
+    params.set_args(batch_size_);
     return name_utils::DatasetDebugString(kDatasetType, params);
   }
 

--- a/tensorflow/core/kernels/data/padded_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/padded_batch_dataset_op.cc
@@ -361,11 +361,11 @@ class PaddedBatchDatasetOp::Dataset : public DatasetBase {
 
   const int64 batch_size_;
   const bool drop_remainder_;
-  const int op_version_;
   const bool parallel_copy_;
   const std::vector<PartialTensorShape> padded_shapes_;
   const std::vector<Tensor> padding_values_;
   const DatasetBase* const input_;
+  const int op_version_;
   std::vector<PartialTensorShape> output_shapes_;
 };
 

--- a/tensorflow/core/kernels/data/padded_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/padded_batch_dataset_op.cc
@@ -98,11 +98,10 @@ class PaddedBatchDatasetOp::Dataset : public DatasetBase {
   }
 
   string DebugString() const override {
-    return name_utils::DatasetDebugString(
-        kDatasetType,
-        name_utils::DatasetDebugStringParams(
-            op_version_, name_utils::kDefaultDatasetDebugStringPrefix,
-            batch_size_));
+    name_utils::DatasetDebugStringParams params;
+    params.op_version = op_version_;
+    params.args.emplace_back(std::to_string(batch_size_));
+    return name_utils::DatasetDebugString(kDatasetType, params);
   }
 
   int64 Cardinality() const override {

--- a/tensorflow/core/kernels/data/padded_batch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/padded_batch_dataset_op_test.cc
@@ -19,6 +19,7 @@ namespace data {
 namespace {
 
 constexpr char kNodeName[] = "padded_batch_dataset";
+constexpr int kOpVersion = 2;
 
 class PaddedBatchDatasetOpTest : public DatasetOpsTestBase {
  protected:
@@ -98,7 +99,10 @@ class PaddedBatchDatasetOpTest : public DatasetOpsTestBase {
     inputs.push_back(PaddedBatchDatasetOp::kDropRemainder);
 
     NodeDef node_def = test::function::NDef(
-        kNodeName, "PaddedBatchDatasetV2", inputs,
+        kNodeName,
+        name_utils::OpName(PaddedBatchDatasetOp::kDatasetType,
+                           name_utils::OpNameParams(kOpVersion)),
+        inputs,
         {{PaddedBatchDatasetOp::kParallelCopy, parallel_copy},
          {PaddedBatchDatasetOp::kToutputTypes, output_types},
          {PaddedBatchDatasetOp::kOutputShapes, output_shapes},
@@ -687,7 +691,9 @@ TEST_F(PaddedBatchDatasetOpTest, DatasetTypeString) {
                              &padded_batch_dataset));
   core::ScopedUnref scoped_unref(padded_batch_dataset);
 
-  EXPECT_EQ(padded_batch_dataset->type_string(), "PaddedBatchDatasetV2");
+  EXPECT_EQ(padded_batch_dataset->type_string(),
+            name_utils::OpName(PaddedBatchDatasetOp::kDatasetType,
+                               name_utils::OpNameParams(kOpVersion)));
 }
 
 TEST_P(ParameterizedPaddedBatchDatasetOpTest, DatasetOutputDtypes) {

--- a/tensorflow/core/kernels/data/padded_batch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/padded_batch_dataset_op_test.cc
@@ -98,10 +98,11 @@ class PaddedBatchDatasetOpTest : public DatasetOpsTestBase {
     }
     inputs.push_back(PaddedBatchDatasetOp::kDropRemainder);
 
+    name_utils::OpNameParams params;
+    params.op_version = kOpVersion;
     NodeDef node_def = test::function::NDef(
         kNodeName,
-        name_utils::OpName(PaddedBatchDatasetOp::kDatasetType,
-                           name_utils::OpNameParams(kOpVersion)),
+        name_utils::OpName(PaddedBatchDatasetOp::kDatasetType, params),
         inputs,
         {{PaddedBatchDatasetOp::kParallelCopy, parallel_copy},
          {PaddedBatchDatasetOp::kToutputTypes, output_types},
@@ -691,9 +692,10 @@ TEST_F(PaddedBatchDatasetOpTest, DatasetTypeString) {
                              &padded_batch_dataset));
   core::ScopedUnref scoped_unref(padded_batch_dataset);
 
+  name_utils::OpNameParams params;
+  params.op_version = kOpVersion;
   EXPECT_EQ(padded_batch_dataset->type_string(),
-            name_utils::OpName(PaddedBatchDatasetOp::kDatasetType,
-                               name_utils::OpNameParams(kOpVersion)));
+            name_utils::OpName(PaddedBatchDatasetOp::kDatasetType, params));
 }
 
 TEST_P(ParameterizedPaddedBatchDatasetOpTest, DatasetOutputDtypes) {

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
@@ -133,10 +133,10 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
   }
 
   string DebugString() const override {
+    name_utils::DatasetDebugStringParams params;
+    params.op_version = op_version_;
     return name_utils::DatasetDebugString(
-        ParallelInterleaveDatasetOp::kDatasetType,
-        name_utils::DatasetDebugStringParams(
-            op_version_, name_utils::kDefaultDatasetDebugStringPrefix));
+        ParallelInterleaveDatasetOp::kDatasetType, params);
   }
 
  protected:

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
@@ -134,7 +134,9 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
 
   string DebugString() const override {
     return name_utils::DatasetDebugString(
-        ParallelInterleaveDatasetOp::kDatasetType);
+        ParallelInterleaveDatasetOp::kDatasetType,
+        name_utils::DatasetDebugStringParams(
+            op_version_, name_utils::kDefaultDatasetDebugStringPrefix));
   }
 
  protected:
@@ -916,6 +918,7 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
   const int64 cycle_length_;
   const int64 block_length_;
   const int64 num_parallel_calls_;
+  const int op_version_ = 2;
   const bool sloppy_;
   const DataTypeVector output_types_;
   const std::vector<PartialTensorShape> output_shapes_;

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op.h
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op.h
@@ -23,7 +23,7 @@ namespace data {
 
 class ParallelInterleaveDatasetOp : public UnaryDatasetOpKernel {
  public:
-  static constexpr const char* const kDatasetType = "ParallelInterleaveV2";
+  static constexpr const char* const kDatasetType = "ParallelInterleave";
   static constexpr const char* const kInputDataset = "input_dataset";
   static constexpr const char* const kOtherArguments = "other_arguments";
   static constexpr const char* const kCycleLength = "cycle_length";

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
@@ -40,10 +40,11 @@ class ParallelInterleaveDatasetOpTest : public DatasetOpsTestBase {
       const DataTypeVector &output_types,
       const std::vector<PartialTensorShape> &output_shapes, bool sloppy,
       std::unique_ptr<OpKernel> *op_kernel) {
+    name_utils::OpNameParams params;
+    params.op_version = kOpVersion;
     NodeDef node_def = test::function::NDef(
         kNodeName,
-        name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType,
-                           name_utils::OpNameParams(kOpVersion)),
+        name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType, params),
         {ParallelInterleaveDatasetOp::kInputDataset,
          ParallelInterleaveDatasetOp::kCycleLength,
          ParallelInterleaveDatasetOp::kBlockLength,
@@ -609,9 +610,11 @@ TEST_F(ParallelInterleaveDatasetOpTest, DatasetTypeString) {
                              &parallel_interleave_dataset));
   core::ScopedUnref scoped_unref(parallel_interleave_dataset);
 
-  EXPECT_EQ(parallel_interleave_dataset->type_string(),
-            name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType,
-                               name_utils::OpNameParams(kOpVersion)));
+  name_utils::OpNameParams params;
+  params.op_version = kOpVersion;
+  EXPECT_EQ(
+      parallel_interleave_dataset->type_string(),
+      name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType, params));
 }
 
 TEST_P(ParameterizedParallelInterleaveDatasetOpTest, DatasetOutputDtypes) {

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
@@ -18,6 +18,7 @@ namespace data {
 namespace {
 
 constexpr char kNodeName[] = "parallel_interleave_dataset";
+constexpr int kOpVersion = 2;
 
 class ParallelInterleaveDatasetOpTest : public DatasetOpsTestBase {
  protected:
@@ -41,7 +42,8 @@ class ParallelInterleaveDatasetOpTest : public DatasetOpsTestBase {
       std::unique_ptr<OpKernel> *op_kernel) {
     NodeDef node_def = test::function::NDef(
         kNodeName,
-        name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType),
+        name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType,
+                           name_utils::OpNameParams(kOpVersion)),
         {ParallelInterleaveDatasetOp::kInputDataset,
          ParallelInterleaveDatasetOp::kCycleLength,
          ParallelInterleaveDatasetOp::kBlockLength,
@@ -608,7 +610,8 @@ TEST_F(ParallelInterleaveDatasetOpTest, DatasetTypeString) {
   core::ScopedUnref scoped_unref(parallel_interleave_dataset);
 
   EXPECT_EQ(parallel_interleave_dataset->type_string(),
-            name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType));
+            name_utils::OpName(ParallelInterleaveDatasetOp::kDatasetType,
+                               name_utils::OpNameParams(kOpVersion)));
 }
 
 TEST_P(ParameterizedParallelInterleaveDatasetOpTest, DatasetOutputDtypes) {

--- a/tensorflow/core/kernels/data/range_dataset_op.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op.cc
@@ -33,6 +33,7 @@ namespace data {
 /* static */ constexpr const char* const RangeDatasetOp::kOutputShapes;
 
 constexpr char kNext[] = "next";
+constexpr int kOpVersion = 1;
 
 class RangeDatasetOp::Dataset : public DatasetBase {
  public:
@@ -60,7 +61,11 @@ class RangeDatasetOp::Dataset : public DatasetBase {
   }
 
   string DebugString() const override {
-    return name_utils::DatasetDebugString(kDatasetType, start_, stop_, step_);
+    return name_utils::DatasetDebugString(
+        kDatasetType,
+        name_utils::DatasetDebugStringParams(
+            kOpVersion, name_utils::kDefaultDatasetDebugStringPrefix, start_,
+            stop_, step_));
   }
 
   int64 Cardinality() const override {

--- a/tensorflow/core/kernels/data/range_dataset_op.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op.cc
@@ -33,7 +33,6 @@ namespace data {
 /* static */ constexpr const char* const RangeDatasetOp::kOutputShapes;
 
 constexpr char kNext[] = "next";
-constexpr int kOpVersion = 1;
 
 class RangeDatasetOp::Dataset : public DatasetBase {
  public:
@@ -61,11 +60,11 @@ class RangeDatasetOp::Dataset : public DatasetBase {
   }
 
   string DebugString() const override {
-    return name_utils::DatasetDebugString(
-        kDatasetType,
-        name_utils::DatasetDebugStringParams(
-            kOpVersion, name_utils::kDefaultDatasetDebugStringPrefix, start_,
-            stop_, step_));
+    name_utils::DatasetDebugStringParams params;
+    params.args.emplace_back(std::to_string(start_));
+    params.args.emplace_back(std::to_string(stop_));
+    params.args.emplace_back(std::to_string(step_));
+    return name_utils::DatasetDebugString(kDatasetType, params);
   }
 
   int64 Cardinality() const override {

--- a/tensorflow/core/kernels/data/range_dataset_op.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op.cc
@@ -61,9 +61,7 @@ class RangeDatasetOp::Dataset : public DatasetBase {
 
   string DebugString() const override {
     name_utils::DatasetDebugStringParams params;
-    params.args.emplace_back(std::to_string(start_));
-    params.args.emplace_back(std::to_string(stop_));
-    params.args.emplace_back(std::to_string(step_));
+    params.set_args(start_, stop_, step_);
     return name_utils::DatasetDebugString(kDatasetType, params);
   }
 

--- a/tensorflow/core/kernels/data/shard_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shard_dataset_op.cc
@@ -67,8 +67,7 @@ class ShardDatasetOp::Dataset : public DatasetBase {
 
   string DebugString() const override {
     name_utils::DatasetDebugStringParams params;
-    params.args.emplace_back(std::to_string(num_shards_));
-    params.args.emplace_back(std::to_string(index_));
+    params.set_args(num_shards_, index_);
     return name_utils::DatasetDebugString(kDatasetType, params);
   }
 

--- a/tensorflow/core/kernels/data/shard_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shard_dataset_op.cc
@@ -36,6 +36,7 @@ namespace data {
 
 constexpr char kInputImplEmpty[] = "input_impl_empty";
 constexpr char kNextIndex[] = "next_index";
+constexpr int kOpVersion = 1;
 
 class ShardDatasetOp::Dataset : public DatasetBase {
  public:
@@ -66,7 +67,11 @@ class ShardDatasetOp::Dataset : public DatasetBase {
   }
 
   string DebugString() const override {
-    return name_utils::DatasetDebugString(kDatasetType, num_shards_, index_);
+    return name_utils::DatasetDebugString(
+        kDatasetType,
+        name_utils::DatasetDebugStringParams(
+            kOpVersion, name_utils::kDefaultDatasetDebugStringPrefix,
+            num_shards_, index_));
   }
 
   int64 Cardinality() const override {

--- a/tensorflow/core/kernels/data/shard_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shard_dataset_op.cc
@@ -36,7 +36,6 @@ namespace data {
 
 constexpr char kInputImplEmpty[] = "input_impl_empty";
 constexpr char kNextIndex[] = "next_index";
-constexpr int kOpVersion = 1;
 
 class ShardDatasetOp::Dataset : public DatasetBase {
  public:
@@ -67,11 +66,10 @@ class ShardDatasetOp::Dataset : public DatasetBase {
   }
 
   string DebugString() const override {
-    return name_utils::DatasetDebugString(
-        kDatasetType,
-        name_utils::DatasetDebugStringParams(
-            kOpVersion, name_utils::kDefaultDatasetDebugStringPrefix,
-            num_shards_, index_));
+    name_utils::DatasetDebugStringParams params;
+    params.args.emplace_back(std::to_string(num_shards_));
+    params.args.emplace_back(std::to_string(index_));
+    return name_utils::DatasetDebugString(kDatasetType, params);
   }
 
   int64 Cardinality() const override {

--- a/tensorflow/core/kernels/data/shuffle_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shuffle_dataset_op.cc
@@ -50,6 +50,7 @@ namespace data {
 const int64 kLogIntervalMicros = 10 * 1000000;  // 10 seconds.
 const int64 kMaxEpochsInBuffer = 3;
 
+constexpr int kOpVersion = 1;
 constexpr char kNumRandomSamples[] = "num_random_samples";
 constexpr char kEndOfInputSequence[] = "end_of_input_sequence";
 constexpr char kEpoch[] = "epoch";
@@ -401,9 +402,9 @@ class ShuffleDatasetOp::ReshufflingDataset : public ShuffleDatasetBase {
 
   string DebugString() const override {
     return name_utils::DatasetDebugString(
-        kDatasetType, kReshufflingDatasetPrefix,
-        {std::to_string(buffer_size_), std::to_string(seed_),
-         std::to_string(seed2_)});
+        kDatasetType, name_utils::DatasetDebugStringParams(
+                          kOpVersion, kReshufflingDatasetPrefix, buffer_size_,
+                          seed_, seed2_));
   }
 
   std::unique_ptr<IteratorBase> MakeIteratorInternal(
@@ -585,9 +586,9 @@ class ShuffleDatasetOp::FixedSeedDataset : public ShuffleDatasetBase {
 
   string DebugString() const override {
     return name_utils::DatasetDebugString(
-        kDatasetType, kFixedSeedDatasetPrefix,
-        {std::to_string(buffer_size_), std::to_string(seed_),
-         std::to_string(seed2_)});
+        kDatasetType,
+        name_utils::DatasetDebugStringParams(
+            kOpVersion, kFixedSeedDatasetPrefix, buffer_size_, seed_, seed2_));
   }
 
   std::unique_ptr<IteratorBase> MakeIteratorInternal(
@@ -666,8 +667,11 @@ class ShuffleAndRepeatDatasetOp::Dataset : public ShuffleDatasetBase {
         seed2_(seed2) {}
 
   string DebugString() const override {
-    return name_utils::DatasetDebugString(kDatasetType, buffer_size_, seed_,
-                                          seed2_, count_);
+    return name_utils::DatasetDebugString(
+        kDatasetType,
+        name_utils::DatasetDebugStringParams(
+            kOpVersion, name_utils::kDefaultDatasetDebugStringPrefix,
+            buffer_size_, seed_, seed2_));
   }
 
   std::unique_ptr<IteratorBase> MakeIteratorInternal(

--- a/tensorflow/core/kernels/data/shuffle_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shuffle_dataset_op.cc
@@ -402,9 +402,7 @@ class ShuffleDatasetOp::ReshufflingDataset : public ShuffleDatasetBase {
   string DebugString() const override {
     name_utils::DatasetDebugStringParams params;
     params.dataset_prefix = kReshufflingDatasetPrefix;
-    params.args.emplace_back(std::to_string(buffer_size_));
-    params.args.emplace_back(std::to_string(seed_));
-    params.args.emplace_back(std::to_string(seed2_));
+    params.set_args(buffer_size_, seed_, seed2_);
     return name_utils::DatasetDebugString(kDatasetType, params);
   }
 
@@ -588,9 +586,7 @@ class ShuffleDatasetOp::FixedSeedDataset : public ShuffleDatasetBase {
   string DebugString() const override {
     name_utils::DatasetDebugStringParams params;
     params.dataset_prefix = kFixedSeedDatasetPrefix;
-    params.args.emplace_back(std::to_string(buffer_size_));
-    params.args.emplace_back(std::to_string(seed_));
-    params.args.emplace_back(std::to_string(seed2_));
+    params.set_args(buffer_size_, seed_, seed2_);
     return name_utils::DatasetDebugString(kDatasetType, params);
   }
 
@@ -671,9 +667,7 @@ class ShuffleAndRepeatDatasetOp::Dataset : public ShuffleDatasetBase {
 
   string DebugString() const override {
     name_utils::DatasetDebugStringParams params;
-    params.args.emplace_back(std::to_string(buffer_size_));
-    params.args.emplace_back(std::to_string(seed_));
-    params.args.emplace_back(std::to_string(seed2_));
+    params.set_args(buffer_size_, seed_, seed2_);
     return name_utils::DatasetDebugString(kDatasetType, params);
   }
 

--- a/tensorflow/core/kernels/data/shuffle_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shuffle_dataset_op.cc
@@ -50,7 +50,6 @@ namespace data {
 const int64 kLogIntervalMicros = 10 * 1000000;  // 10 seconds.
 const int64 kMaxEpochsInBuffer = 3;
 
-constexpr int kOpVersion = 1;
 constexpr char kNumRandomSamples[] = "num_random_samples";
 constexpr char kEndOfInputSequence[] = "end_of_input_sequence";
 constexpr char kEpoch[] = "epoch";
@@ -401,10 +400,12 @@ class ShuffleDatasetOp::ReshufflingDataset : public ShuffleDatasetBase {
         seed2_(seed2) {}
 
   string DebugString() const override {
-    return name_utils::DatasetDebugString(
-        kDatasetType, name_utils::DatasetDebugStringParams(
-                          kOpVersion, kReshufflingDatasetPrefix, buffer_size_,
-                          seed_, seed2_));
+    name_utils::DatasetDebugStringParams params;
+    params.dataset_prefix = kReshufflingDatasetPrefix;
+    params.args.emplace_back(std::to_string(buffer_size_));
+    params.args.emplace_back(std::to_string(seed_));
+    params.args.emplace_back(std::to_string(seed2_));
+    return name_utils::DatasetDebugString(kDatasetType, params);
   }
 
   std::unique_ptr<IteratorBase> MakeIteratorInternal(
@@ -585,10 +586,12 @@ class ShuffleDatasetOp::FixedSeedDataset : public ShuffleDatasetBase {
         seed2_(seed2) {}
 
   string DebugString() const override {
-    return name_utils::DatasetDebugString(
-        kDatasetType,
-        name_utils::DatasetDebugStringParams(
-            kOpVersion, kFixedSeedDatasetPrefix, buffer_size_, seed_, seed2_));
+    name_utils::DatasetDebugStringParams params;
+    params.dataset_prefix = kFixedSeedDatasetPrefix;
+    params.args.emplace_back(std::to_string(buffer_size_));
+    params.args.emplace_back(std::to_string(seed_));
+    params.args.emplace_back(std::to_string(seed2_));
+    return name_utils::DatasetDebugString(kDatasetType, params);
   }
 
   std::unique_ptr<IteratorBase> MakeIteratorInternal(
@@ -667,11 +670,11 @@ class ShuffleAndRepeatDatasetOp::Dataset : public ShuffleDatasetBase {
         seed2_(seed2) {}
 
   string DebugString() const override {
-    return name_utils::DatasetDebugString(
-        kDatasetType,
-        name_utils::DatasetDebugStringParams(
-            kOpVersion, name_utils::kDefaultDatasetDebugStringPrefix,
-            buffer_size_, seed_, seed2_));
+    name_utils::DatasetDebugStringParams params;
+    params.args.emplace_back(std::to_string(buffer_size_));
+    params.args.emplace_back(std::to_string(seed_));
+    params.args.emplace_back(std::to_string(seed2_));
+    return name_utils::DatasetDebugString(kDatasetType, params);
   }
 
   std::unique_ptr<IteratorBase> MakeIteratorInternal(


### PR DESCRIPTION
This PR refactors `OpName()` and `DatasetDebugString` in name_utils to make them more robust and consistent.

cc: @jsimsa 