### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -203,7 +203,7 @@ bool GpuExecutor::FindOnDiskForISAVersion(absl::string_view filename,
 //                 would return /usr/bin.
 static string GetBinaryDir(bool strip_exe) {
   char exe_path[PATH_MAX] = {0};
-  CHECK_ERR(readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1));
+  PCHECK(readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1) != -1);
   // Make sure it's null-terminated:
   exe_path[sizeof(exe_path) - 1] = 0;
 


### PR DESCRIPTION
The `--config=rocm` build was broken by the following commit

https://github.com/tensorflow/tensorflow/commit/3e3b915613637e5fae14dafe2de6b8525c866242

The above commit contains update for CUDA implementation of GPU stream executor code, but not for the corresponding ROCm implementation. This commit adds in the missing ROCm piece.

-----------------------------------------------------------------------

@tatianashp @whchung @chsigg 
