### PR TITLE
build: introduce `configure.cmd`

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -1,0 +1,20 @@
+:: Copyright 2019 The TensorFlow Authors.  All Rights Reserved.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::    http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+:: WARRANTIES OR CONDITIONS OF ANY KIND< either express or implied.  See the
+:: License for the specific language governing permissions and limitations under
+:: the License.
+
+@echo off
+
+set configure_dir=%~dp0
+set configure_dir=%configure_dir:~0,-1%
+python %configure_dir%\configure.py %* || ( exit /b )
+echo Configuration finished


### PR DESCRIPTION
This adds a batch file to invoke the python configure script on Windows.
This mirrors the script for Linux and macOS (`configure`).  This is
needed since Windows does not support shebangs, and will not invoke the
python script as a result without the explicit interpreter.