### PR TITLE
Add Raises in the docstring of tf.histogram_fixed_width_bins

### DIFF
--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -55,6 +55,11 @@ def histogram_fixed_width_bins(values,
     A `Tensor` holding the indices of the binned values whose shape matches
     `values`.
 
+  Raises:
+    TypeError: If any unsupported dtype is provided.
+    tf.errors.InvalidArgumentError: If value_range does not
+        satisfy value_range[0] < value_range[1].
+
   Examples:
 
   ```python


### PR DESCRIPTION
This fix adds exception conditions for tf.histogram_fixed_width_bins in the docstring.

This fix fixes #29279.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>