### PR TITLE
Fix issue of tf.math.real with numeric input

### DIFF
--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -1005,6 +1005,16 @@ class ComplexMakeRealImagTest(test.TestCase):
       self._compareMake(real, 12.0, use_gpu)
       self._compareMake(23.0, imag, use_gpu)
 
+  def testRealImagNumericType(self):
+    for use_gpu in [True, False]:
+      for value in [1., 1j, 1.+1j]:
+        np_real, np_imag = np.real(value), np.imag(value)
+        with test_util.device(use_gpu=use_gpu):
+          tf_real = math_ops.real(value)
+          tf_imag = math_ops.imag(value)
+          self.assertAllEqual(np_real, self.evaluate(tf_real))
+          self.assertAllEqual(np_imag, self.evaluate(tf_imag))
+
   def _compareRealImag(self, cplx, use_gpu):
     np_real, np_imag = np.real(cplx), np.imag(cplx)
     np_zeros = np_real * 0

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -556,6 +556,7 @@ def imag(input, name=None):
     A `Tensor` of type `float32` or `float64`.
   """
   with ops.name_scope(name, "Imag", [input]) as name:
+    input = ops.convert_to_tensor(input, name="input")
     if input.dtype.is_complex:
       return gen_math_ops.imag(input, Tout=input.dtype.real_dtype, name=name)
     else:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -522,6 +522,7 @@ def real(input, name=None):
     A `Tensor` of type `float32` or `float64`.
   """
   with ops.name_scope(name, "Real", [input]) as name:
+    input = ops.convert_to_tensor(input, name="input")
     if input.dtype.is_complex:
       real_dtype = input.dtype.real_dtype
       return gen_math_ops.real(input, Tout=real_dtype, name=name)


### PR DESCRIPTION
This fix tries to address the issue raised in #30029 where numeric input does not work with tf.math.real:
```
>>> import tensorflow as tf
>>> tf.math.real(1.)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/util/dispatch.py", line 180, in wrapper
    return target(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/ops/math_ops.py", line 525, in real
    if input.dtype.is_complex:
AttributeError: 'float' object has no attribute 'dtype'
```

The reason was that unlike other functions in math_ops.py, tf.math.real does not try to call ops.convert_to_tensor before processing.
This fix fixes the issue.

This fix fixes #30029.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>