### PR TITLE
Fix dimension check for tf.keras.losses.BinaryCrossentropy

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4313,12 +4313,7 @@ def binary_crossentropy(target, output, from_logits=False):
   if not from_logits:
     if (isinstance(output, (ops.EagerTensor, variables_module.Variable)) or
         output.op.type != 'Sigmoid'):
-      try:
-        target.get_shape().merge_with(output.get_shape())
-      except ValueError:
-        raise ValueError(
-            "target and output must have the same shape (%s vs %s)" %
-            (target.get_shape(), output.get_shape()))
+      target.get_shape().assert_is_compatible_with(output.get_shape())
       epsilon_ = _constant_to_tensor(epsilon(), output.dtype.base_dtype)
       output = clip_ops.clip_by_value(output, epsilon_, 1. - epsilon_)
 

--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4313,6 +4313,12 @@ def binary_crossentropy(target, output, from_logits=False):
   if not from_logits:
     if (isinstance(output, (ops.EagerTensor, variables_module.Variable)) or
         output.op.type != 'Sigmoid'):
+      try:
+        target.get_shape().merge_with(output.get_shape())
+      except ValueError:
+        raise ValueError(
+            "target and output must have the same shape (%s vs %s)" %
+            (target.get_shape(), output.get_shape()))
       epsilon_ = _constant_to_tensor(epsilon(), output.dtype.base_dtype)
       output = clip_ops.clip_by_value(output, epsilon_, 1. - epsilon_)
 

--- a/tensorflow/python/keras/distribute/distribute_strategy_test.py
+++ b/tensorflow/python/keras/distribute/distribute_strategy_test.py
@@ -853,7 +853,7 @@ class TestDistributionStrategyWithDatasets(test.TestCase,
     with self.cached_session():
       with distribution.scope():
         input_img = keras.layers.Input([64, 64, 3], name='img')
-        input_lbl = keras.layers.Input([64, 64, 1], name='lbl')
+        input_lbl = keras.layers.Input([64, 64, 2], name='lbl')
         input_weight = keras.layers.Input([64, 64], name='weight')
         predict = keras.layers.Conv2D(2, [1, 1], padding='same')(input_img)
         loss_lambda = keras.layers.Lambda(
@@ -871,7 +871,7 @@ class TestDistributionStrategyWithDatasets(test.TestCase,
         return inputs, targets
 
       fake_imgs = np.ones([50, 64, 64, 3], dtype=np.float32)
-      fake_lbls = np.ones([50, 64, 64, 1], dtype=np.float32)
+      fake_lbls = np.ones([50, 64, 64, 2], dtype=np.float32)
       fake_weights = np.ones([50, 64, 64], dtype=np.float32)
 
       data = dataset_ops.Dataset.from_tensor_slices(

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -825,6 +825,22 @@ class BinaryCrossentropyTest(test.TestCase):
     expected_value = (100.0 + 50.0 * label_smoothing) / 3.0
     self.assertAlmostEqual(self.evaluate(loss), expected_value, 3)
 
+  def test_shape_mismatch(self):
+    # Test case fot GitHub issue 30040.
+    y_true = np.array(
+        [[1.], [1.], [1.], [0.], [1.], [0.], [0.], [1.], [1.], [0.]]
+    ).astype(np.float32)
+    y_pred = np.array(
+        [[0.], [0.], [0.], [1.], [1.], [0.], [0.], [1.], [0.], [1.]]
+    ).astype(np.float32)
+
+    bce_obj = keras.losses.BinaryCrossentropy()
+    loss = bce_obj(y_true, y_pred)
+    self.assertAlmostEqual(self.evaluate(loss), 9.23662, 3)
+    with self.assertRaisesRegexp(
+        ValueError, 'target and output must have the same shape'):
+      loss = bce_obj(np.squeeze(y_true), y_pred)
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class CategoricalCrossentropyTest(test.TestCase):

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -826,7 +826,6 @@ class BinaryCrossentropyTest(test.TestCase):
     self.assertAlmostEqual(self.evaluate(loss), expected_value, 3)
 
   def test_shape_mismatch(self):
-    # Test case fot GitHub issue 30040.
     y_true = np.array(
         [[1.], [1.], [1.], [0.], [1.], [0.], [0.], [1.], [1.], [0.]]
     ).astype(np.float32)
@@ -838,7 +837,7 @@ class BinaryCrossentropyTest(test.TestCase):
     loss = bce_obj(y_true, y_pred)
     self.assertAlmostEqual(self.evaluate(loss), 9.23662, 3)
     with self.assertRaisesRegexp(
-        ValueError, 'target and output must have the same shape'):
+        ValueError, 'Shapes .+ are incompatible'):
       loss = bce_obj(np.squeeze(y_true), y_pred)
 
 


### PR DESCRIPTION
This fix tries to address the issue raised in #30040 where tf.keras.losses.BinaryCrossentropy does not check the dimension match:
```
import numpy as np
import tensorflow as tf

y_true = np.array([[1.], [1.], [1.], [0.], [1.], [0.], [0.], [1.], [1.], [0.]]).astype(np.float32)
y_pred = np.array([[0.], [0.], [0.], [1.], [1.], [0.], [0.], [1.], [0.], [1.]]).astype(np.float32)
bce = tf.keras.losses.BinaryCrossentropy()
print(bce(np.squeeze(y_true), y_pred).numpy()) # should fail
```
The reason was that broadcasting was applied directly.
This fix adds dimension check to throw an error if there is a mismatch.

This fix fixes #30040.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>