### PR TITLE
Fix warning in sparse.from_dense caused by where

### DIFF
--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -142,7 +142,7 @@ def sparse_expand_dims(sp_input, axis=None, name=None):
                       " - 1, rank(sp_input)]")
 
     # Convert axis to a positive value if it is negative.
-    axis = array_ops.where(axis >= 0, axis, axis + rank + 1)
+    axis = array_ops.where_v2(axis >= 0, axis, axis + rank + 1)
 
     # Create the new column of indices for the sparse tensor by slicing
     # the indices and inserting a new column of indices for the new dimension.
@@ -1727,7 +1727,7 @@ def sparse_retain(sp_input, to_retain):
     sp_input.values.get_shape().dims[0].merge_with(
         tensor_shape.dimension_at_index(retain_shape, 0))
 
-  where_true = array_ops.reshape(array_ops.where(to_retain), [-1])
+  where_true = array_ops.reshape(array_ops.where_v2(to_retain), [-1])
   new_indices = array_ops.gather(sp_input.indices, where_true)
   new_values = array_ops.gather(sp_input.values, where_true)
   return sparse_tensor.SparseTensor(new_indices, new_values,

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -104,7 +104,7 @@ def _make_int64_tensor(value, name):
 def from_dense(tensor, name=None):
   with ops.name_scope(name, "dense_to_sparse"):
     tensor = ops.convert_to_tensor(tensor)
-    indices = array_ops.where(
+    indices = array_ops.where_v2(
         math_ops.not_equal(tensor, array_ops.constant(0, tensor.dtype)))
     values = array_ops.gather_nd(tensor, indices)
     shape = array_ops.shape(tensor, out_type=dtypes.int64)


### PR DESCRIPTION
While running tf.sparse.from_dense the following warning surface:
```
$ python
Python 2.7.15+ (default, Nov 27 2018, 23:36:35)
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> import tensorflow as tf
>>> tf.sparse.from_dense(np.array([[.1, .3, .5, .9]]))
WARNING: Logging before flag parsing goes to stderr.
W0623 02:24:12.467936 140242193565504 deprecation.py:323] From /usr/local/lib/python2.7/dist-packages/tensorflow_core/python/ops/sparse_ops.py:108: where (from tensorflow.python.ops.array_ops) is deprecated and will be removed in a future version.
Instructions for updating:
Use tf.where in 2.0, which has the same broadcast rule as np.where
<tensorflow.python.framework.sparse_tensor.SparseTensor object at 0x7f8ca17ade90>
```

This fix fixes the warning.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>