### PR TITLE
Correct the size of downsampledFrame

### DIFF
--- a/tensorflow/examples/android/src/org/tensorflow/demo/tracking/ObjectTracker.java
+++ b/tensorflow/examples/android/src/org/tensorflow/demo/tracking/ObjectTracker.java
@@ -244,7 +244,7 @@ public class ObjectTracker {
         new byte
             [(frameWidth + DOWNSAMPLE_FACTOR - 1)
                 / DOWNSAMPLE_FACTOR
-                * (frameWidth + DOWNSAMPLE_FACTOR - 1)
+                * (frameHeight + DOWNSAMPLE_FACTOR - 1)
                 / DOWNSAMPLE_FACTOR];
   }
 


### PR DESCRIPTION
Both frameWidth and frameHeight should be considered when determining the size of downsampledFrame.
The previous code only used frameWidth, potentially causing an illegal memory access.