### PR TITLE
Expose tf.keras.preprocessing.text.tokenizer_from_json to match Keras API

### DIFF
--- a/tensorflow/python/keras/preprocessing/text.py
+++ b/tensorflow/python/keras/preprocessing/text.py
@@ -27,9 +27,12 @@ text_to_word_sequence = text.text_to_word_sequence
 one_hot = text.one_hot
 hashing_trick = text.hashing_trick
 Tokenizer = text.Tokenizer
+tokenizer_from_json = text.tokenizer_from_json
 
 keras_export(
     'keras.preprocessing.text.text_to_word_sequence')(text_to_word_sequence)
 keras_export('keras.preprocessing.text.one_hot')(one_hot)
 keras_export('keras.preprocessing.text.hashing_trick')(hashing_trick)
 keras_export('keras.preprocessing.text.Tokenizer')(Tokenizer)
+keras_export(
+    'keras.preprocessing.text.tokenizer_from_json')(tokenizer_from_json)


### PR DESCRIPTION
This fix tries to address the issue raised in #30061 where `tf.keras.preprocessing.text.tokenizer_from_json` is not available, while in keras, `keras.preprocessing.text.tokenizer_from_json` is available.

This fix expose `tf.keras.preprocessing.text.tokenizer_from_json` and alias to `keras.preprocessing.text.tokenizer_from_json`, like all other similar APIs in the same keras_proprocessing/text.py

This fix fixes #30061.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>