### PR TITLE
[XLA] Add resource arg count and indices to module config

### DIFF
--- a/tensorflow/compiler/jit/xla_compilation_cache.h
+++ b/tensorflow/compiler/jit/xla_compilation_cache.h
@@ -133,6 +133,8 @@ class XlaCompilationCache : public ResourceBase {
   // XLA computation already, and generates an XLA LocalExecutable `executable`.
   Status BuildExecutable(const XlaCompiler::Options& options,
                          const XlaCompiler::CompilationResult& result,
+                         const uint64 number_of_arguments,
+                         const uint64 number_of_variables,
                          std::unique_ptr<xla::LocalExecutable>* executable);
 
   xla::LocalClient* const client_;

--- a/tensorflow/compiler/xla/client/executable_build_options.cc
+++ b/tensorflow/compiler/xla/client/executable_build_options.cc
@@ -75,4 +75,48 @@ string ExecutableBuildOptions::ToString() const {
       device_ordinal_, result_layout, num_replicas_);
 }
 
+ExecutableBuildOptions& ExecutableBuildOptions::set_argument_count(
+    int count) {
+  argument_count_ = count;
+  return *this;
+}
+
+int ExecutableBuildOptions::argument_count() const {
+  return argument_count_;
+}
+
+ExecutableBuildOptions& ExecutableBuildOptions::set_resource_input_count(
+    int count) {
+  resource_input_count_ = count;
+  return *this;
+}
+
+int ExecutableBuildOptions::resource_input_count() const {
+  return resource_input_count_;
+}
+
+ExecutableBuildOptions& ExecutableBuildOptions::set_input_mapping(
+    const std::vector<int>& input_mapping) {
+  input_mapping_ = input_mapping;
+  return *this;
+}
+
+const std::vector<int>& ExecutableBuildOptions::input_mapping() const {
+  return input_mapping_;
+}
+
+ExecutableBuildOptions&
+ExecutableBuildOptions::set_resource_update_to_input_index(
+    const std::vector<int>& resource_update_to_input_index) {
+  std::copy(resource_update_to_input_index.begin(),
+            resource_update_to_input_index.end(),
+            std::back_inserter(resource_update_to_input_index_));
+  return *this;
+}
+
+const std::vector<int>& ExecutableBuildOptions::resource_update_to_input_index()
+    const {
+  return resource_update_to_input_index_;
+}
+
 }  // namespace xla

--- a/tensorflow/compiler/xla/client/executable_build_options.h
+++ b/tensorflow/compiler/xla/client/executable_build_options.h
@@ -63,6 +63,26 @@ class ExecutableBuildOptions {
       se::DeviceMemoryAllocator* allocator);
   se::DeviceMemoryAllocator* device_allocator() const;
 
+  // The number of arguments in the original operator
+  ExecutableBuildOptions& set_argument_count(int count);
+  int argument_count() const;
+
+  // An indicator of the number of resource variable inputs
+  ExecutableBuildOptions& set_resource_input_count(int count);
+  int resource_input_count() const;
+
+  // A map from the input of the computation to the original TF operation input
+  // index
+  ExecutableBuildOptions& set_input_mapping(
+      const std::vector<int>& input_mapping);
+  const std::vector<int>& input_mapping() const;
+
+  // An indicator of the number of resource variables updated by this
+  // executable.
+  ExecutableBuildOptions& set_resource_update_to_input_index(
+      const std::vector<int>& resource_update_to_input_index);
+  const std::vector<int>& resource_update_to_input_index() const;
+
   // Returns a string representation of the build options, suitable for
   // debugging.
   string ToString() const;
@@ -79,6 +99,11 @@ class ExecutableBuildOptions {
   absl::optional<DebugOptions> debug_options_;
   se::DeviceMemoryAllocator* device_allocator_ = nullptr;
   int num_replicas_ = 1;
+
+  int argument_count_ = 0;
+  int resource_input_count_ = 0;
+  std::vector<int> input_mapping_ = std::vector<int>{};
+  std::vector<int> resource_update_to_input_index_ = std::vector<int>{};
 };
 
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/hlo_module_config.cc
+++ b/tensorflow/compiler/xla/service/hlo_module_config.cc
@@ -41,6 +41,17 @@ void HloModuleConfig::SetDefaultComputationLayout(
   entry_computation_layout_ = ComputationLayout(program_shape);
 }
 
+void HloModuleConfig::set_input_mapping(
+    const std::vector<int32>& input_mapping) {
+  absl::c_copy(input_mapping, std::back_inserter(input_mapping_));
+}
+
+void HloModuleConfig::set_resource_update_to_input_index(
+    const std::vector<int32>& resource_update_to_input_index) {
+    absl::c_copy(resource_update_to_input_index,
+                 std::back_inserter(resource_update_to_input_index_));
+}
+
 string HloModuleConfig::compilation_cache_key() const {
   string key = absl::StrCat("profiling=", hlo_profiling_enabled());
   StrAppend(&key, "::(");
@@ -58,6 +69,20 @@ string HloModuleConfig::compilation_cache_key() const {
   }
   if (replica_count() != 1) {
     StrAppend(&key, "::replica_count=", replica_count());
+  }
+  if (argument_count() != 0) {
+    StrAppend(&key, "::argument_count=", argument_count());
+  }
+  if (resource_input_count() != 0) {
+    StrAppend(&key, "::resource_input_count=", resource_input_count());
+  }
+  if (input_mapping_.size()) {
+    StrAppend(&key, "::input_mapping=",
+              absl::StrJoin(input_mapping(), ","));
+  }
+  if (resource_update_to_input_index().size()) {
+    StrAppend(&key, "::resource_update_to_input_index=",
+              absl::StrJoin(resource_update_to_input_index(), ","));
   }
   StrAppend(&key, debug_options_.DebugString());
   if (intra_op_parallelism_threads() > 0) {

--- a/tensorflow/compiler/xla/service/hlo_module_config.h
+++ b/tensorflow/compiler/xla/service/hlo_module_config.h
@@ -84,6 +84,25 @@ class HloModuleConfig {
   }
   int64 replica_count() const { return replica_count_; }
 
+  // The number of arguments to the original TF operation
+  void set_argument_count(int32 count) { argument_count_ = count; }
+  int32 argument_count() const { return argument_count_; }
+
+  // The number of inputs which are resource variables
+  void set_resource_input_count(int32 count) { resource_input_count_ = count; }
+  int32 resource_input_count() const { return resource_input_count_; }
+
+  // Mapping of inputs from XLA computation to TF operation
+  void set_input_mapping(const std::vector<int32>& input_mapping);
+  const std::vector<int32>& input_mapping() const { return input_mapping_; }
+
+  // The number of outputs which are updates of resource variables
+  void set_resource_update_to_input_index(
+      const std::vector<int32>& resource_update_to_input_index);
+  const std::vector<int32>& resource_update_to_input_index() const {
+    return resource_update_to_input_index_;
+  }
+
   // Return a string which unambiguously represents all the fields of this data
   // structure. Used for generating a cache key for storing the compiled
   // executable.
@@ -132,6 +151,11 @@ class HloModuleConfig {
   // The target maximum parallelism at which to partition HLOs for parallel
   // execution on the CPU backend.
   int64 intra_op_parallelism_threads_ = -1;
+
+  int32 argument_count_ = 0;
+  int32 resource_input_count_ = 0;
+  std::vector<int32> input_mapping_ = std::vector<int32>{};
+  std::vector<int32> resource_update_to_input_index_ = std::vector<int32>{};
 
   DebugOptions debug_options_;
 

--- a/tensorflow/compiler/xla/service/local_service.cc
+++ b/tensorflow/compiler/xla/service/local_service.cc
@@ -101,6 +101,16 @@ ExecutionOptions CreateExecutionOptions(
   if (build_options.has_debug_options()) {
     *execution_options.mutable_debug_options() = build_options.debug_options();
   }
+  execution_options.set_argument_count(
+      build_options.argument_count());
+  execution_options.set_resource_input_count(
+      build_options.resource_input_count());
+  for (const int i : build_options.input_mapping()) {
+    execution_options.add_input_mapping(i);
+  }
+  for (const int i : build_options.resource_update_to_input_index()) {
+    execution_options.add_resource_update_to_input_index(i);
+  }
   if (build_options.result_layout() != nullptr) {
     *execution_options.mutable_shape_with_output_layout() =
         build_options.result_layout()->ToProto();

--- a/tensorflow/compiler/xla/service/service.cc
+++ b/tensorflow/compiler/xla/service/service.cc
@@ -310,6 +310,20 @@ StatusOr<std::unique_ptr<HloModuleConfig>> Service::CreateModuleConfig(
     }
     config->set_seed(execution_options->seed());
     config->set_debug_options(execution_options->debug_options());
+    config->set_argument_count(execution_options->argument_count());
+    config->set_resource_input_count(execution_options->resource_input_count());
+    const auto& proto_input_mapping =
+        execution_options->input_mapping();
+    std::vector<int> input_mapping(
+        proto_input_mapping.begin(),
+        proto_input_mapping.end());
+    config->set_input_mapping(input_mapping);
+    const auto& proto_resource_update_to_input_index =
+        execution_options->resource_update_to_input_index();
+    std::vector<int> resource_update_to_input_index(
+        proto_resource_update_to_input_index.begin(),
+        proto_resource_update_to_input_index.end());
+    config->set_resource_update_to_input_index(resource_update_to_input_index);
   } else {
     config->set_replica_count(options_.number_of_replicas());
     config->set_debug_options(GetDebugOptionsFromFlags());

--- a/tensorflow/compiler/xla/xla.proto
+++ b/tensorflow/compiler/xla/xla.proto
@@ -319,6 +319,23 @@ message ExecutionOptions {
   // This optional field specifies the device assignment if known at compile
   // time.
   DeviceAssignmentProto device_assignment = 7;
+
+  // The number of parameter arguments to the original TF operation. This does
+  // not include compile time constants or resource variables.
+  uint32 argument_count = 8;
+
+  // The number of arguments to the TF operation which are resource variables.
+  uint32 resource_input_count = 9;
+
+  // A map from the XLA computation inputs to the original TF operation inputs.
+  // There ought to be one entry for each of the parameter inputs to the XLA
+  // computation.
+  repeated int32 input_mapping = 10;
+
+  // The number of outputs which are updates for resource variables.  For each
+  // output which is a resource update, this contains a mapping to the input
+  // parameter which is for that resource.
+  repeated int32 resource_update_to_input_index = 11;
 }
 
 message GetDeviceHandlesRequest {


### PR DESCRIPTION
The GraphCore backend, and maybe others, benefits from knowing which inputs to the HloModule are associated with resource variables, and which are standard inputs.

There are 4 situations:
1) a standard input or output
2) a resource variable which is updated.  this appears as both an input and an output
3) a resource variable which is created.  this appears as only an output
4) a resource variable which is not updated.  this appears as only an input


This change introduces 4 useful pieces of information into the HloModuleConfig:

- The number of arguments to the original TF operation
this is useful because the original arguments are not always present in the HLO, and yet the update mapping refers to positions in the original op

- The number of inputs which are resource variables
this is important for telling which inputs are resource variables

- The number of outputs which are updates of resource variables
this is important for telling which outputs are resource variables

- Mapping of inputs from XLA computation to TF operation
this is important for telling which actual resources were updated, if any
