### PR TITLE
[XLA] Split NextAfter test into a sepatate test instance

### DIFF
--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -313,30 +313,6 @@ class BinaryOpsTest(xla_test.XLATestCase):
           dtype(7),
           expected=np.array([[-6], [-5]], dtype=dtype))
 
-      if dtype in [np.float32, np.float64]:
-        x = np.array([
-            -0.0, 0.0, -0.0, +0.0, np.inf, np.inf, -np.inf, -np.inf, 2.0, 2.0,
-            1.0
-        ],
-                     dtype=dtype)
-        y = np.array(
-            [-0.0, 0.0, +0.0, -0.0, 1.0, -1.0, 1.0, -1.0, 2.0, 1.0, 2.0],
-            dtype=dtype)
-        expected = np.nextafter(x, y)
-
-        # We use assertAllEqual to expose any bugs hidden by relative or
-        # absolute error tolerances.
-        def NextAfterEqualityTest(result, expected, rtol):
-          del rtol
-          return self.assertAllEqual(result, expected)
-
-        self._testBinary(
-            math_ops.nextafter,
-            x,
-            y,
-            expected=expected,
-            equality_test=NextAfterEqualityTest)
-
       # min/max not supported for complex
       if dtype not in self.complex_types | {np.uint8, np.int8}:
         self._testBinary(
@@ -423,6 +399,34 @@ class BinaryOpsTest(xla_test.XLATestCase):
           np.array([1, 1, 0xffffffff, 0xfffffffff], dtype=np.int64),
           expected=np.array([1 << 32, 1 << 36, 1 << 32, 1 << 36],
                             dtype=np.int64))
+
+
+  def testNextAfter(self):
+    for dtype in self.numeric_types:
+      if dtype in [np.float32, np.float64]:
+        x = np.array([
+            -0.0, 0.0, -0.0, +0.0, np.inf, np.inf, -np.inf, -np.inf, 2.0, 2.0,
+            1.0
+        ],
+                     dtype=dtype)
+        y = np.array(
+            [-0.0, 0.0, +0.0, -0.0, 1.0, -1.0, 1.0, -1.0, 2.0, 1.0, 2.0],
+            dtype=dtype)
+        expected = np.nextafter(x, y)
+
+        # We use assertAllEqual to expose any bugs hidden by relative or
+        # absolute error tolerances.
+        def NextAfterEqualityTest(result, expected, rtol):
+          del rtol
+          return self.assertAllEqual(result, expected)
+
+        self._testBinary(
+            math_ops.nextafter,
+            x,
+            y,
+            expected=expected,
+            equality_test=NextAfterEqualityTest)
+
 
   def testComplexOps(self):
     for dtype in self.complex_types:


### PR DESCRIPTION
Split the NextAfter test into a separate test to allow it to be independently disabled using the test manifest.

