### PR TITLE
[XLA] Make the bfloat16 part of the iota test optional

### DIFF
--- a/tensorflow/compiler/xla/tests/iota_test.cc
+++ b/tensorflow/compiler/xla/tests/iota_test.cc
@@ -68,6 +68,11 @@ TEST_P(IotaR2Test, DoIt) {
   const auto element_type = std::get<0>(spec);
   const int64 num_elements = std::get<1>(spec);
   const int64 iota_dim = std::get<2>(spec);
+#ifdef XLA_BACKEND_DOES_NOT_SUPPORT_BFLOAT16
+  if (element_type == BF16) {
+    return;
+  }
+#endif
   XlaBuilder builder(TestName() + "_" + PrimitiveType_Name(element_type));
   std::vector<int64> dimensions = {42};
   dimensions.insert(dimensions.begin() + iota_dim, num_elements);
@@ -95,6 +100,11 @@ TEST_P(IotaR3Test, DoIt) {
   const auto element_type = std::get<0>(spec);
   const int64 num_elements = std::get<1>(spec);
   const int64 iota_dim = std::get<2>(spec);
+#ifdef XLA_BACKEND_DOES_NOT_SUPPORT_BFLOAT16
+  if (element_type == BF16) {
+    return;
+  }
+#endif
   XlaBuilder builder(TestName() + "_" + PrimitiveType_Name(element_type));
   std::vector<int64> dimensions = {42, 19};
   dimensions.insert(dimensions.begin() + iota_dim, num_elements);
@@ -116,7 +126,7 @@ INSTANTIATE_TEST_CASE_P(IotaR3TestInstantiation, IotaR3Test,
 class IotaR3PredTest : public ClientLibraryTestBase,
                        public ::testing::WithParamInterface<int> {};
 
-TEST_P(IotaR3PredTest, DoIt) {
+XLA_TEST_P(IotaR3PredTest, DoIt) {
   const auto element_type = PRED;
   const int64 num_elements = 2;
   const int64 iota_dim = GetParam();


### PR DESCRIPTION
For backends which do not support BF16, allow parts of the iota test to be disabled.
