### PR TITLE
[XLA] Include sort in ReplaceComputations check

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_module.cc
+++ b/tensorflow/compiler/xla/service/hlo_module.cc
@@ -137,7 +137,8 @@ void HloModule::ReplaceComputations(
         case HloOpcode::kMap:
         case HloOpcode::kReduce:
         case HloOpcode::kReduceWindow:
-        case HloOpcode::kScatter: {
+        case HloOpcode::kScatter:
+        case HloOpcode::kSort: {
           HloComputation* new_arg = tensorflow::gtl::FindWithDefault(
               replacements, instruction->to_apply(), nullptr);
           if (new_arg != nullptr) {


### PR DESCRIPTION
Sort has a subcomputation, and therefore should be included in this check.  The check is in ReplaceComputations, and is checking all operations which have a subcomputation.
