### PR TITLE
[XLA] Change the VLOG level of a Status message traceback to 2

### DIFF
--- a/tensorflow/compiler/xla/util.cc
+++ b/tensorflow/compiler/xla/util.cc
@@ -37,7 +37,7 @@ namespace xla {
 Status WithLogBacktrace(const Status& status) {
   CHECK(!status.ok());
   VLOG(1) << status.ToString();
-  VLOG(1) << tensorflow::CurrentStackTrace();
+  VLOG(2) << tensorflow::CurrentStackTrace();
   return status;
 }
 


### PR DESCRIPTION
Some people use Status messages a a method of flow control.  This happens in many places across the code base.

Producing a backtrace whenever one of these is done produces a lot of visual clutter in a VLOG 1 trace.  I have moved it to VLOG 2.