### PR TITLE
support max_profiling_buffer_entries

### DIFF
--- a/tensorflow/lite/examples/label_image/BUILD
+++ b/tensorflow/lite/examples/label_image/BUILD
@@ -32,6 +32,7 @@ cc_binary(
         "//tensorflow/lite:string_util",
         "//tensorflow/lite/kernels:builtin_ops",
         "//tensorflow/lite/profiling:profiler",
+        "@com_google_absl//absl/memory",
     ],
 )
 

--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -184,7 +184,8 @@ void RunInference(Settings* s) {
       exit(-1);
   }
 
-  profiling::Profiler* profiler = new profiling::Profiler();
+  profiling::Profiler* profiler =
+      new profiling::Profiler(s->max_profiling_buffer_entries);
   interpreter->SetProfiler(profiler);
 
   if (s->profiling) profiler->StartProfiling();
@@ -287,12 +288,13 @@ int Main(int argc, char** argv) {
         {"input_mean", required_argument, nullptr, 'b'},
         {"input_std", required_argument, nullptr, 's'},
         {"num_results", required_argument, nullptr, 'r'},
+        {"max_profiling_buffer_entries", required_argument, nullptr, 'e'},
         {nullptr, 0, nullptr, 0}};
 
     /* getopt_long stores the option index here. */
     int option_index = 0;
 
-    c = getopt_long(argc, argv, "a:b:c:f:i:l:m:p:r:s:t:v:", long_options,
+    c = getopt_long(argc, argv, "a:b:c:e:f:i:l:m:p:r:s:t:v:", long_options,
                     &option_index);
 
     /* Detect the end of the options. */
@@ -307,6 +309,10 @@ int Main(int argc, char** argv) {
         break;
       case 'c':
         s.loop_count =
+            strtol(optarg, nullptr, 10);  // NOLINT(runtime/deprecated_fn)
+        break;
+      case 'e':
+        s.max_profiling_buffer_entries =
             strtol(optarg, nullptr, 10);  // NOLINT(runtime/deprecated_fn)
         break;
       case 'f':

--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -32,6 +32,7 @@ limitations under the License.
 #include <unordered_set>
 #include <vector>
 
+#include "absl/memory/memory.h"
 #include "tensorflow/lite/examples/label_image/bitmap_helpers.h"
 #include "tensorflow/lite/examples/label_image/get_top_n.h"
 #include "tensorflow/lite/kernels/register.h"
@@ -184,9 +185,8 @@ void RunInference(Settings* s) {
       exit(-1);
   }
 
-  profiling::Profiler* profiler =
-      new profiling::Profiler(s->max_profiling_buffer_entries);
-  interpreter->SetProfiler(profiler);
+  auto profiler = absl::make_unique<profiling::Profiler>(s->max_profiling_buffer_entries);
+  interpreter->SetProfiler(profiler.get());
 
   if (s->profiling) profiler->StartProfiling();
 

--- a/tensorflow/lite/examples/label_image/label_image.h
+++ b/tensorflow/lite/examples/label_image/label_image.h
@@ -36,6 +36,7 @@ struct Settings {
   string input_layer_type = "uint8_t";
   int number_of_threads = 4;
   int number_of_results = 5;
+  int max_profiling_buffer_entries = 1024;
 };
 
 }  // namespace label_image

--- a/tensorflow/lite/profiling/noop_profiler.h
+++ b/tensorflow/lite/profiling/noop_profiler.h
@@ -27,6 +27,7 @@ namespace profiling {
 class NoopProfiler : public tflite::Profiler {
  public:
   NoopProfiler() {}
+  NoopProfiler(int max_profiling_buffer_entries) {}
 
   uint32_t BeginEvent(const char*, EventType, uint32_t) override { return 0; }
   void EndEvent(uint32_t) override {}


### PR DESCRIPTION
```
bazel build --config android_arm64 \
//tensorflow/lite/examples/label_image:label_image \
--copt=-DTFLITE_PROFILING_ENABLED
```
doesn't work after fbda4a1c5540b81dc6fd4f720e5e1353e08c44e6, which changed `profiling::Profiler` constructor