### PR TITLE
Tf-TRT minor test fixes

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/const_broadcast_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/const_broadcast_test.py
@@ -29,6 +29,7 @@ class ConstBroadcastTest(trt_test.TfTrtIntegrationTestBase):
   """Test for Constant broadcasting in TF-TRT."""
 
   def GraphFn(self, x):
+    """Return the expected graph to convert."""
     dtype = x.dtype
     filt1 = constant_op.constant(
         0.3, shape=(3, 3, 2, 1), dtype=dtype, name='filt1')

--- a/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
@@ -55,6 +55,7 @@ OUTPUT_NODE_NAME = 'output'
 
 
 class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
+  """Testing usage of quantization ranges inserted in graph."""
 
   def _BuildGraph(self, x):
 
@@ -239,7 +240,7 @@ class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
       if mode == ModeKeys.EVAL:
         return EstimatorSpec(
             mode, loss=loss, eval_metric_ops={'accuracy': accuracy})
-      elif mode == ModeKeys.TRAIN:
+      if mode == ModeKeys.TRAIN:
         optimizer = AdamOptimizer(learning_rate=1e-2)
         train_op = optimizer.minimize(loss, global_step=get_global_step())
         return EstimatorSpec(mode, loss=loss, train_op=train_op)


### PR DESCRIPTION
- Check if checkpoints are available in TF-TRT quantization test
- Use constant input test tensors instead of random tensors Otherwise the test sometimes fails depending on the generated random values.