### PR TITLE
Fix the deadlock when freeing the shared resources

### DIFF
--- a/tensorflow/python/data/kernel_tests/from_generator_test.py
+++ b/tensorflow/python/data/kernel_tests/from_generator_test.py
@@ -378,6 +378,19 @@ class DatasetConstructorTest(test_base.DatasetTestBase):
       self.evaluate(get_next())
       self.assertTrue(event.is_set())
 
+  def testSharedName(self):
+
+    def generator():
+      for _ in range(10):
+        yield [20]
+
+    dataset = dataset_ops.Dataset.from_generator(generator,
+                                                 output_types=(dtypes.int64))
+    get_next = self.getNext(dataset, requires_initialization=True,
+                            shared_name="shared_dataset")
+
+    self.assertAllEqual([20], self.evaluate(get_next()))
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/data/kernel_tests/test_base.py
+++ b/tensorflow/python/data/kernel_tests/test_base.py
@@ -54,7 +54,7 @@ class DatasetTestBase(ragged_test_util.RaggedTensorTestCase, test.TestCase):
     self.assertAllEqual(a.values, b.values)
     self.assertAllEqual(a.dense_shape, b.dense_shape)
 
-  def getNext(self, dataset, requires_initialization=False):
+  def getNext(self, dataset, requires_initialization=False, shared_name=None):
     """Returns a callable that returns the next element of the dataset.
 
     Example use:
@@ -70,6 +70,9 @@ class DatasetTestBase(ragged_test_util.RaggedTensorTestCase, test.TestCase):
       requires_initialization: Indicates that when the test is executed in graph
         mode, it should use an initializable iterator to iterate through the
         dataset (e.g. when it contains stateful nodes). Defaults to False.
+      shared_name: (Optional.) If non-empty, the returned iterator will be
+        shared under the given name across multiple sessions that share the same
+        devices (e.g. when using a remote server).
     Returns:
       A callable that returns the next element of `dataset`. Any `TensorArray`
       objects `dataset` outputs are stacked.
@@ -87,7 +90,7 @@ class DatasetTestBase(ragged_test_util.RaggedTensorTestCase, test.TestCase):
       return ta_wrapper(iterator._next_internal)  # pylint: disable=protected-access
     else:
       if requires_initialization:
-        iterator = dataset_ops.make_initializable_iterator(dataset)
+        iterator = dataset_ops.make_initializable_iterator(dataset, shared_name)
         self.evaluate(iterator.initializer)
       else:
         iterator = dataset_ops.make_one_shot_iterator(dataset)


### PR DESCRIPTION
This PR tries to fix #29695. 

The root cause is that for a shared iterator, the resource is not private to the kernel, so the resource cannot be released by [~IteratorHandleOp](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/data/iterator_ops.cc#L438-L450), and the [ResourceMgr::Clear()](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/resource_mgr.cc#L109-L118) needs to be called to free the shared resources. 

For the case in #29695, the session close() tries to release the shared resources by calling `ResourceMgr::Clear()`, during which, as the generator dataset did not finish the iteration yet, it needs to delete the python generator by calling the finalizing function [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/data/generator_dataset_op.cc#L95). However,  when running the finalizing function, [the done function](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/data/captured_function.cc#L632) triggers the [ResourceMgr::CleanUp()](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/resource_mgr.cc#L218-L243) which causes the deadlock with `ResourceMgr::Clear()`.

Here is the Traceback:
```
frame #0: 0x00007fff7565686a libsystem_kernel.dylib`__psynch_cvwait + 10
    frame #1: 0x00007fff7571556e libsystem_pthread.dylib`_pthread_cond_wait + 722
    frame #2: 0x00007fff72750a0a libc++.1.dylib`std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18
    frame #3: 0x000000011c13c61b libtensorflow_framework.so`nsync::nsync_mu_semaphore_p(nsync::nsync_semaphore_s_*) + 123
    frame #4: 0x000000011c13a578 libtensorflow_framework.so`nsync::nsync_mu_lock_slow_(nsync::nsync_mu_s_*, nsync::waiter*, unsigned int, nsync::lock_type_s*) + 296
    frame #5: 0x000000011c13a650 libtensorflow_framework.so`nsync::nsync_mu_lock(nsync::nsync_mu_s_*) + 80
    frame #6: 0x000000011bbe9cf7 libtensorflow_framework.so`tensorflow::ResourceMgr::Cleanup(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 39
    frame #7: 0x0000000111fc5666 _pywrap_tensorflow_internal.so`std::__1::__function::__func<tensorflow::data::CapturedFunction::RunInstantiated(std::__1::vector<tensorflow::Tensor, std::__1::allocator<tensorflow::Tensor> > const&, std::__1::vector<tensorflow::Tensor, std::__1::allocator<tensorflow::Tensor> >*)::$_4, std::__1::allocator<tensorflow::data::CapturedFunction::RunInstantiated(std::__1::vector<tensorflow::Tensor, std::__1::allocator<tensorflow::Tensor> > const&, std::__1::vector<tensorflow::Tensor, std::__1::allocator<tensorflow::Tensor> >*)::$_4>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 54
    frame #8: 0x0000000111fc4ca6 _pywrap_tensorflow_internal.so`tensorflow::ScopedStepContainer::~ScopedStepContainer() + 38
    frame #9: 0x0000000111fc36a0 _pywrap_tensorflow_internal.so`tensorflow::data::CapturedFunction::RunInstantiated(std::__1::vector<tensorflow::Tensor, std::__1::allocator<tensorflow::Tensor> > const&, std::__1::vector<tensorflow::Tensor, std::__1::allocator<tensorflow::Tensor> >*) + 976
    frame #10: 0x0000000111eb1085 _pywrap_tensorflow_internal.so`tensorflow::data::GeneratorDatasetOp::Dataset::Iterator::~Iterator() + 101
    frame #11: 0x0000000111eb0d3e _pywrap_tensorflow_internal.so`tensorflow::data::GeneratorDatasetOp::Dataset::Iterator::~Iterator() + 14
    frame #12: 0x0000000111eaea89 _pywrap_tensorflow_internal.so`tensorflow::data::(anonymous namespace)::FlatMapDatasetOp::Dataset::Iterator::~Iterator() + 105
    frame #13: 0x00007fff72753d42 libc++.1.dylib`std::__1::__shared_weak_count::__release_shared() + 40
    frame #14: 0x0000000111ec3755 _pywrap_tensorflow_internal.so`tensorflow::data::IteratorResource::~IteratorResource() + 149
    frame #15: 0x0000000111ec366e _pywrap_tensorflow_internal.so`tensorflow::data::IteratorResource::~IteratorResource() + 14
    frame #16: 0x000000011bbe7fa4 libtensorflow_framework.so`tensorflow::ResourceMgr::Clear() + 116
    frame #17: 0x00000001139f362f _pywrap_tensorflow_internal.so`tensorflow::DirectSession::~DirectSession() + 655
    frame #18: 0x00000001139f3aae _pywrap_tensorflow_internal.so`tensorflow::DirectSession::~DirectSession() + 14
    frame #19: 0x00007fff72753d42 libc++.1.dylib`std::__1::__shared_weak_count::__release_shared() + 40
    frame #20: 0x00000001112ceb7f _pywrap_tensorflow_internal.so`tensorflow::SessionRef::Close() + 223
    frame #21: 0x000000011147f40b _pywrap_tensorflow_internal.so`TF_CloseSession + 27
```

cc: @jsimsa 
