### PR TITLE
Limit the number of statements in exception raising test blocks to 1.

### DIFF
--- a/tensorflow/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/feature_column/sequence_feature_column_test.py
@@ -265,11 +265,11 @@ class SequenceFeaturesTest(test.TestCase, parameterized.TestCase):
     shared_embedding_columns = fc.shared_embedding_columns_v2(
         [categorical_column_a, categorical_column_b], dimension=2)
 
+    sequence_input_layer = sfc.SequenceFeatures(shared_embedding_columns)
     with self.assertRaisesRegexp(
         ValueError,
         r'In embedding_column: aaa_shared_embedding\. categorical_column must '
         r'be of type SequenceCategoricalColumn to use SequenceFeatures\.'):
-      sequence_input_layer = sfc.SequenceFeatures(shared_embedding_columns)
       _, _ = sequence_input_layer({'aaa': sparse_input_a,
                                    'bbb': sparse_input_b})
 
@@ -356,11 +356,11 @@ class SequenceFeaturesTest(test.TestCase, parameterized.TestCase):
         key='aaa', num_buckets=vocabulary_size)
     indicator_column_a = fc.indicator_column(categorical_column_a)
 
+    sequence_input_layer = sfc.SequenceFeatures([indicator_column_a])
     with self.assertRaisesRegexp(
         ValueError,
         r'In indicator_column: aaa_indicator\. categorical_column must be of '
         r'type SequenceCategoricalColumn to use SequenceFeatures\.'):
-      sequence_input_layer = sfc.SequenceFeatures([indicator_column_a])
       _, _ = sequence_input_layer({'aaa': sparse_input})
 
   @parameterized.named_parameters(
@@ -466,9 +466,8 @@ class SequenceFeaturesTest(test.TestCase, parameterized.TestCase):
 
     with self.assertRaisesRegexp(
         errors.InvalidArgumentError, r'Condition x == y did not hold.*'):
-      _, sequence_length = sequence_input_layer({
-          'aaa': sparse_input_a, 'bbb': sparse_input_b})
-      self.evaluate(sequence_length)
+        _, sequence_length = sequence_input_layer({'aaa': sparse_input_a, 'bbb': sparse_input_b})
+        self.evaluate(sequence_length)
 
   @parameterized.named_parameters(
       {'testcase_name': '2D',
@@ -659,11 +658,11 @@ class DenseFeaturesTest(test.TestCase):
     embedding_column_a = fc.embedding_column(
         categorical_column_a, dimension=2)
 
+    input_layer = fc.DenseFeatures([embedding_column_a])
     with self.assertRaisesRegexp(
         ValueError,
         r'In embedding_column: aaa_embedding\. categorical_column must not be '
         r'of type SequenceCategoricalColumn\.'):
-      input_layer = fc.DenseFeatures([embedding_column_a])
       _ = input_layer({'aaa': sparse_input})
 
   def test_indicator_column(self):
@@ -680,11 +679,11 @@ class DenseFeaturesTest(test.TestCase):
         key='aaa', num_buckets=vocabulary_size)
     indicator_column_a = fc.indicator_column(categorical_column_a)
 
+    input_layer = fc.DenseFeatures([indicator_column_a])
     with self.assertRaisesRegexp(
         ValueError,
         r'In indicator_column: aaa_indicator\. categorical_column must not be '
         r'of type SequenceCategoricalColumn\.'):
-      input_layer = fc.DenseFeatures([indicator_column_a])
       _ = input_layer({'aaa': sparse_input})
 
 

--- a/tensorflow/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/feature_column/sequence_feature_column_test.py
@@ -464,8 +464,7 @@ class SequenceFeaturesTest(test.TestCase, parameterized.TestCase):
     sequence_input_layer = sfc.SequenceFeatures(
         [numeric_column_a, numeric_column_b])
 
-    with self.assertRaisesRegexp(
-        errors.InvalidArgumentError, r'Condition x == y did not hold.*'):
+    with self.assertRaisesRegexp(errors.InvalidArgumentError, r'Condition x == y did not hold.*'):
         _, sequence_length = sequence_input_layer({'aaa': sparse_input_a, 'bbb': sparse_input_b})
         self.evaluate(sequence_length)
 

--- a/tensorflow/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/feature_column/sequence_feature_column_test.py
@@ -664,6 +664,7 @@ class DenseFeaturesTest(test.TestCase):
         ValueError,
         r'In embedding_column: aaa_embedding\. categorical_column must not be '
         r'of type SequenceCategoricalColumn\.'):
+      input_layer = dense_features.DenseFeatures([embedding_column_a])
       _ = input_layer({'aaa': sparse_input})
 
   def test_indicator_column(self):

--- a/tensorflow/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/feature_column/sequence_feature_column_test.py
@@ -465,8 +465,8 @@ class SequenceFeaturesTest(test.TestCase, parameterized.TestCase):
         [numeric_column_a, numeric_column_b])
 
     with self.assertRaisesRegexp(errors.InvalidArgumentError, r'Condition x == y did not hold.*'):
-        _, sequence_length = sequence_input_layer({'aaa': sparse_input_a, 'bbb': sparse_input_b})
-        self.evaluate(sequence_length)
+      _, sequence_length = sequence_input_layer({'aaa': sparse_input_a, 'bbb': sparse_input_b})
+      self.evaluate(sequence_length)
 
   @parameterized.named_parameters(
       {'testcase_name': '2D',

--- a/tensorflow/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/feature_column/sequence_feature_column_test.py
@@ -464,8 +464,10 @@ class SequenceFeaturesTest(test.TestCase, parameterized.TestCase):
     sequence_input_layer = sfc.SequenceFeatures(
         [numeric_column_a, numeric_column_b])
 
-    with self.assertRaisesRegexp(errors.InvalidArgumentError, r'Condition x == y did not hold.*'):
-      _, sequence_length = sequence_input_layer({'aaa': sparse_input_a, 'bbb': sparse_input_b})
+    with self.assertRaisesRegexp(
+            errors.InvalidArgumentError, r'Condition x == y did not hold.*'):
+      _, sequence_length = sequence_input_layer(
+          {'aaa': sparse_input_a, 'bbb': sparse_input_b})
       self.evaluate(sequence_length)
 
   @parameterized.named_parameters(

--- a/tensorflow/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/feature_column/sequence_feature_column_test.py
@@ -166,11 +166,11 @@ class SequenceFeaturesTest(test.TestCase, parameterized.TestCase):
     embedding_column_a = fc.embedding_column(
         categorical_column_a, dimension=2)
 
+    sequence_input_layer = sfc.SequenceFeatures([embedding_column_a])
     with self.assertRaisesRegexp(
         ValueError,
         r'In embedding_column: aaa_embedding\. categorical_column must be of '
         r'type SequenceCategoricalColumn to use SequenceFeatures\.'):
-      sequence_input_layer = sfc.SequenceFeatures([embedding_column_a])
       _, _ = sequence_input_layer({'aaa': sparse_input})
 
   @test_util.run_in_graph_and_eager_modes

--- a/tensorflow/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/feature_column/sequence_feature_column_test.py
@@ -23,6 +23,7 @@ from absl.testing import parameterized
 import numpy as np
 
 from tensorflow.python.client import session
+from tensorflow.python.feature_column import dense_features
 from tensorflow.python.feature_column import feature_column_v2 as fc
 from tensorflow.python.feature_column import sequence_feature_column as sfc
 from tensorflow.python.feature_column import serialization
@@ -659,7 +660,7 @@ class DenseFeaturesTest(test.TestCase):
     embedding_column_a = fc.embedding_column(
         categorical_column_a, dimension=2)
 
-    input_layer = fc.DenseFeatures([embedding_column_a])
+    input_layer = dense_features.DenseFeatures([embedding_column_a])
     with self.assertRaisesRegexp(
         ValueError,
         r'In embedding_column: aaa_embedding\. categorical_column must not be '
@@ -680,7 +681,7 @@ class DenseFeaturesTest(test.TestCase):
         key='aaa', num_buckets=vocabulary_size)
     indicator_column_a = fc.indicator_column(categorical_column_a)
 
-    input_layer = fc.DenseFeatures([indicator_column_a])
+    input_layer = dense_features.DenseFeatures([indicator_column_a])
     with self.assertRaisesRegexp(
         ValueError,
         r'In indicator_column: aaa_indicator\. categorical_column must not be '

--- a/tensorflow/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/feature_column/sequence_feature_column_test.py
@@ -686,6 +686,7 @@ class DenseFeaturesTest(test.TestCase):
         ValueError,
         r'In indicator_column: aaa_indicator\. categorical_column must not be '
         r'of type SequenceCategoricalColumn\.'):
+      input_layer = fc.DenseFeatures([indicator_column_a])
       _ = input_layer({'aaa': sparse_input})
 
 

--- a/tensorflow/python/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/feature_column/sequence_feature_column_test.py
@@ -664,7 +664,6 @@ class DenseFeaturesTest(test.TestCase):
         ValueError,
         r'In embedding_column: aaa_embedding\. categorical_column must not be '
         r'of type SequenceCategoricalColumn\.'):
-      input_layer = dense_features.DenseFeatures([embedding_column_a])
       _ = input_layer({'aaa': sparse_input})
 
   def test_indicator_column(self):
@@ -686,7 +685,6 @@ class DenseFeaturesTest(test.TestCase):
         ValueError,
         r'In indicator_column: aaa_indicator\. categorical_column must not be '
         r'of type SequenceCategoricalColumn\.'):
-      input_layer = fc.DenseFeatures([indicator_column_a])
       _ = input_layer({'aaa': sparse_input})
 
 


### PR DESCRIPTION
We may locate the exact statement where the exception is raiased.