### PR TITLE
Fix math type setting in CudnnConvolutionDescriptor

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -3190,10 +3190,9 @@ port::Status CudnnSupport::DoFusedConvolveImpl(
                         "cuDNNv5 and cuDNNv6. See around b/68264959.");
   }
   if (IsTensorMathOpSet(conv) != algo_desc.tensor_ops_enabled()) {
-    return port::Status(
-        port::error::FAILED_PRECONDITION,
-        "Tensor op math type in the algorithm descriptor should "
-        "match that of the cudnn convolution descriptor");
+    return port::Status(port::error::FAILED_PRECONDITION,
+                        "Tensor op math type in dnn::AlgorithmDesc does not "
+                        "match that of the CudnnConvolutionDescriptor");
   }
 
   RETURN_IF_CUDNN_ERROR(cudnnConvolutionBiasActivationForward(


### PR DESCRIPTION
The ctor of `CudnnConvolutionDescriptor` sets its  `cudnnMathType` to `CUDNN_TENSOR_OP_MATH` by default.  Within `DoConvolve` in `cuda_dnn.cc`, the `CudnnConvolutionDescriptor` has its math type set to `CUDNN_TENSOR_OP_MATH` irrespective of what the `AlgorithmDesc` says  because a new `CudnnConvolutionDescriptor` is created and passed to be used in the cudnn API call. The idea was to use the same ref of `CudnnConvolutionDescriptor` that gets set correctly while computing the workspace size. However, based on the current design this doesn't happen. Currently, the workspace gets computed with `use_tensor_math_op` flag (say) `false` but the convolution actually occurs with the flag set to `true` (Note: `use_tensor_math_op` is the flag that sets the math type to either `CUDNN_TENSOR_OP_MATH` or `CUDNN_DEFAULT_MATH`). This works most of the times but there are some exceptions. For example, in mobilenet, convolution with stride 2 picks up a slower algorithm since cudnn call fails due to this mismatch. 
It should be noted that `DoFusedConvolveImpl` however, sets the flag correctly since the same  `CudnnConvolutionDescriptor` ref is used for workspace computation and the actual convolution. 