### PR TITLE
Update third-party BUILD files for NVIDIA Jetson (TF 1.14)

### DIFF
--- a/third_party/gif.BUILD
+++ b/third_party/gif.BUILD
@@ -26,6 +26,11 @@ cc_library(
             "S_IWRITE=S_IWUSR",
             "S_IEXEC=S_IXUSR",
         ],
+        "@org_tensorflow//tensorflow:linux_aarch64": [
+            "S_IREAD=S_IRUSR",
+            "S_IWRITE=S_IWUSR",
+            "S_IEXEC=S_IXUSR",
+        ],
         "//conditions:default": [],
     }),
     includes = ["lib/."],

--- a/third_party/gpus/crosstool/BUILD.tpl
+++ b/third_party/gpus/crosstool/BUILD.tpl
@@ -28,6 +28,7 @@ cc_toolchain_suite(
         "darwin|compiler": ":cc-compiler-darwin",
         "x64_windows|msvc-cl": ":cc-compiler-windows",
         "x64_windows": ":cc-compiler-windows",
+        "aarch64": ":cc-compiler-local",
         "arm": ":cc-compiler-local",
         "k8": ":cc-compiler-local",
         "piii": ":cc-compiler-local",


### PR DESCRIPTION
Why? The NVIDIA dev community is struggling hard to compile TensorFlow: https://devtalk.nvidia.com/default/topic/1055131/jetson-agx-xavier/building-tensorflow-1-13-on-jetson-xavier/post/5354734/

Basically the same PR for 1.14 as the already approved https://github.com/tensorflow/tensorflow/pull/26985 for 2.0 beta except that I also had to slightly modify `third_party/gif.BUILD`. Let me know if you think this change can cause trouble. Changing the compiler config might also work, but I've already spent 7 days compiling TF in various configurations and would like to focus on something else now... THANK YOU :)

Maybe you can release this with `v1.14.1` soon?

More information about the Jetson (Nano) in case haven't heard of it: https://developer.nvidia.com/embedded/jetson-nano-developer-kit