### PR TITLE
[ROCm] Adding ROCm support for the sparse_xent op

### DIFF
--- a/tensorflow/core/kernels/sparse_xent_op.cc
+++ b/tensorflow/core/kernels/sparse_xent_op.cc
@@ -125,12 +125,12 @@ REGISTER(CPU, double, int64)
 REGISTER(CPU, Eigen::half, int32)
 REGISTER(CPU, Eigen::half, int64)
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 REGISTER(GPU, float, int32)
 REGISTER(GPU, float, int64)
 REGISTER(GPU, Eigen::half, int32)
 REGISTER(GPU, Eigen::half, int64)
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #undef REGISTER
 

--- a/tensorflow/core/kernels/sparse_xent_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/sparse_xent_op_gpu.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -23,6 +23,12 @@ limitations under the License.
 #include "tensorflow/core/kernels/reduction_gpu_kernels.cu.h"
 #include "tensorflow/core/kernels/reduction_ops_common.h"
 #include "tensorflow/core/platform/types.h"
+
+#if GOOGLE_CUDA
+namespace gpuprim = ::cub;
+#elif TENSORFLOW_USE_ROCM
+namespace gpuprim = ::hipcub;
+#endif
 
 namespace tensorflow {
 
@@ -48,8 +54,8 @@ struct RowMaxReduction<GPUDevice, T> {
 
     typedef const Eigen::array<TTypes<float>::Tensor::Index, 1>& ReductionAxes;
     Constants<GPUDevice> constants;
-    cub::Max op;
-    functor::ReduceImpl<T, cub::Max, T*, const T*, ReductionAxes>(
+    gpuprim::Max op;
+    functor::ReduceImpl<T, gpuprim::Max, T*, const T*, ReductionAxes>(
         ctx, maximum.data(), logits.data(), 2, rows, cols, 1, 1, constants.kOne,
         op);
   }
@@ -81,4 +87,4 @@ REGISTER(int64)
 
 }  // end namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/sparse_xent_op_test.cc
+++ b/tensorflow/core/kernels/sparse_xent_op_test.cc
@@ -49,7 +49,7 @@ static Graph* SparseXent(int batch_size, int num_classes) {
   BENCHMARK(BM_SparseXent##_##BATCH##_##CLASS##_##DEVICE);
 
 /// The representative tests for ptb_word on GPU
-#ifdef GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 BM_SparseXentDev(8, 1000000, gpu);
 
 BM_SparseXentDev(16, 10000, gpu);
@@ -63,7 +63,7 @@ BM_SparseXentDev(32, 100000, gpu);
 BM_SparseXentDev(64, 10000, gpu);
 BM_SparseXentDev(64, 30000, gpu);
 BM_SparseXentDev(64, 100000, gpu);
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 // CPU
 BM_SparseXentDev(8, 1000000, cpu);


### PR DESCRIPTION
This PR adds ROCm support for the sparse_xent op

The changes in this PR are trivial, please review and merge...thanks.

----------------------------------------------------------

@tatianashp @whchung @chsigg