### PR TITLE
[ROCm] Adding ROCm support to gemm strided batched interface

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -100,161 +100,180 @@ namespace wrap {
 
 #endif
 
-#define ROCBLAS_BLAS_ROUTINE_EACH(__macro)                                     \
-  __macro(rocblas_snrm2) __macro(rocblas_dnrm2) /*  __macro(rocblas_scnrm2)    \
-                                                  __macro(rocblas_dznrm2) */   \
-      __macro(rocblas_sdot)                                                    \
-          __macro(rocblas_ddot) /*  __macro(rocblas_cdotu)                     \
-                                  __macro(rocblas_cdotc)                       \
-                                  __macro(rocblas_zdotu)                       \
-                                  __macro(rocblas_zdotc)                    */ \
-      __macro(rocblas_sscal)                                                   \
-          __macro(rocblas_dscal) /*  __macro(rocblas_cscal)                    \
-                                   __macro(rocblas_csscal)                     \
-                                   __macro(rocblas_zscal)                      \
-                                   __macro(rocblas_zdscal) */                  \
-      __macro(rocblas_saxpy)                                                   \
-          __macro(rocblas_daxpy) /*  __macro(rocblas_caxpy)                    \
-                                   __macro(rocblas_zaxpy) */                   \
-      __macro(rocblas_scopy)                                                   \
-          __macro(rocblas_dcopy) /*  __macro(rocblas_ccopy)                    \
-                                   __macro(rocblas_zcopy) */                   \
-      __macro(rocblas_sswap)                                                   \
-          __macro(rocblas_dswap) /*  __macro(rocblas_cswap)                    \
-                                   __macro(rocblas_zswap) */                   \
-      __macro(rocblas_isamax)                                                  \
-          __macro(rocblas_idamax) /*  __macro(rocblas_icamax)                  \
-                                    __macro(rocblas_izamax) */                 \
-      __macro(rocblas_isamin)                                                  \
-          __macro(rocblas_idamin) /*  __macro(rocblas_icamin)                  \
-                                    __macro(rocblas_izamin) */                 \
-      __macro(rocblas_sasum)                                                   \
-          __macro(rocblas_dasum) /*  __macro(rocblas_scasum)                   \
-                                   __macro(rocblas_dzasum)                     \
-                                   __macro(rocblas_srot)                       \
-                                   __macro(rocblas_drot)                       \
-                                   __macro(rocblas_crot)                       \
-                                   __macro(rocblas_csrot)                      \
-                                   __macro(rocblas_zrot)                       \
-                                   __macro(rocblas_zdrot)                      \
-                                   __macro(rocblas_srotg)                      \
-                                   __macro(rocblas_drotg)                      \
-                                   __macro(rocblas_Crotg)                      \
-                                   __macro(rocblas_crotg)                      \
-                                   __macro(rocblas_zrotm)                      \
-                                   __macro(rocblas_drotm)                      \
-                                   __macro(rocblas_srotmg)                     \
-                                   __macro(rocblas_drotmg) */                  \
-      __macro(rocblas_sgemv)                                                   \
-          __macro(rocblas_dgemv) /*  __macro(rocblas_cgemv)                    \
-                                   __macro(rocblas_zgemv)                      \
-                                   __macro(rocblas_sgbmv)                      \
-                                   __macro(rocblas_dgbmv)                      \
-                                   __macro(rocblas_cgbmv)                      \
-                                   __macro(rocblas_zgbmv)                      \
-                                   __macro(rocblas_strmv)                      \
-                                   __macro(rocblas_dtrmv)                      \
-                                   __macro(rocblas_ctrmv)                      \
-                                   __macro(rocblas_ztrmv)                      \
-                                   __macro(rocblas_stbmv)                      \
-                                   __macro(rocblas_dtbmv)                      \
-                                   __macro(rocblas_ctbmv)                      \
-                                   __macro(rocblas_ztbmv)                      \
-                                   __macro(rocblas_stpmv)                      \
-                                   __macro(rocblas_dtpmv)                      \
-                                   __macro(rocblas_ctpmv)                      \
-                                   __macro(rocblas_ztpmv)                      \
-                                   __macro(rocblas_strsv)                      \
-                                   __macro(rocblas_dtrsv)                      \
-                                   __macro(rocblas_ctrsv)                      \
-                                   __macro(rocblas_ztrsv)                      \
-                                   __macro(rocblas_stpsv)                      \
-                                   __macro(rocblas_dtpsv)                      \
-                                   __macro(rocblas_ctpsv)                      \
-                                   __macro(rocblas_ztpsv)                      \
-                                   __macro(rocblas_stbsv)                      \
-                                   __macro(rocblas_dtbsv)                      \
-                                   __macro(rocblas_ctbsv)                      \
-                                   __macro(rocblas_ztbsv)                      \
-                                   __macro(rocblas_ssymv)                      \
-                                   __macro(rocblas_dsymv)                      \
-                                   __macro(rocblas_csymv)                      \
-                                   __macro(rocblas_zsymv)                      \
-                                   __macro(rocblas_chemv)                      \
-                                   __macro(rocblas_zhemv)                      \
-                                   __macro(rocblas_ssbmv)                      \
-                                   __macro(rocblas_dsbmv)                      \
-                                   __macro(rocblas_chbmv)                      \
-                                   __macro(rocblas_zhbmv)                      \
-                                   __macro(rocblas_sspmv)                      \
-                                   __macro(rocblas_dspmv)                      \
-                                   __macro(rocblas_chpmv)                      \
-                                   __macro(rocblas_zhpmv) */                   \
-      __macro(rocblas_sger)                                                    \
-          __macro(rocblas_dger) /*  __macro(rocblas_cgeru)                     \
-                                  __macro(rocblas_cgerc)                       \
-                                  __macro(rocblas_zgeru)                       \
-                                  __macro(rocblas_zgerc)                    */ \
-      __macro(rocblas_ssyr)                                                    \
-          __macro(rocblas_dsyr) /*  __macro(rocblas_csyr)                      \
-                                  __macro(rocblas_zsyr)                        \
-                                  __macro(rocblas_cher)                        \
-                                  __macro(rocblas_zher)                        \
-                                  __macro(rocblas_sspr)                        \
-                                  __macro(rocblas_dspr)                        \
-                                  __macro(rocblas_chpr)                        \
-                                  __macro(rocblas_zhpr)                        \
-                                  __macro(rocblas_ssyr2)                       \
-                                  __macro(rocblas_dsyr2)                       \
-                                  __macro(rocblas_csyr2)                       \
-                                  __macro(rocblas_zsyr2)                       \
-                                  __macro(rocblas_cher2)                       \
-                                  __macro(rocblas_zher2)                       \
-                                  __macro(rocblas_sspr2)                       \
-                                  __macro(rocblas_dspr2)                       \
-                                  __macro(rocblas_chpr2)                       \
-                                  __macro(rocblas_zhpr2)                    */ \
-      __macro(rocblas_sgemm) __macro(rocblas_dgemm)                            \
-          __macro(rocblas_hgemm) /*  __macro(rocblas_cgemm)                    \
-                                   __macro(rocblas_zgemm)                      \
-                                   __macro(rocblas_ssyrk)                      \
-                                   __macro(rocblas_dsyrk)                      \
-                                   __macro(rocblas_csyrk)                      \
-                                   __macro(rocblas_zsyrk)                      \
-                                   __macro(rocblas_cherk)                      \
-                                   __macro(rocblas_zherk)                      \
-                                   __macro(rocblas_ssyr2k)                     \
-                                   __macro(rocblas_dsyr2k)                     \
-                                   __macro(rocblas_csyr2k)                     \
-                                   __macro(rocblas_zsyr2k)                     \
-                                   __macro(rocblas_cher2k)                     \
-                                   __macro(rocblas_zher2k)                     \
-                                   __macro(rocblas_ssyrkx)                     \
-                                   __macro(rocblas_dsyrkx)                     \
-                                   __macro(rocblas_csyrkx)                     \
-                                   __macro(rocblas_zsyrkx)                     \
-                                   __macro(rocblas_cherkx)                     \
-                                   __macro(rocblas_zherkx)                     \
-                                   __macro(rocblas_ssymm)                      \
-                                   __macro(rocblas_dsymm)                      \
-                                   __macro(rocblas_csymm)                      \
-                                   __macro(rocblas_zsymm)                      \
-                                   __macro(rocblas_chemm)                      \
-                                   __macro(rocblas_zhemm) */                   \
-      __macro(rocblas_strsm)                                                   \
-          __macro(rocblas_dtrsm) /*  __macro(rocblas_ctrsm)                    \
-                                   __macro(rocblas_ztrsm)                      \
-                                   __macro(rocblas_strmm)                      \
-                                   __macro(rocblas_dtrmm)                      \
-                                   __macro(rocblas_ctrmm)                      \
-                                   __macro(rocblas_ztrmm) */                   \
-      __macro(rocblas_sgeam)                                                   \
-          __macro(rocblas_dgeam) /*  __macro(rocblas_cgeam)                    \
-                                   __macro(rocblas_zgeam)                      \
-                                   __macro(rocblas_sdgmm)                      \
-                                   __macro(rocblas_ddgmm)                      \
-                                   __macro(rocblas_cdgmm)                      \
-                                   __macro(rocblas_zdgmm) */
+// clang-format off
+#define ROCBLAS_BLAS_ROUTINE_EACH(__macro)  \
+  __macro(rocblas_snrm2)                    \
+  __macro(rocblas_dnrm2)                    \
+  /*__macro(rocblas_scnrm2)                   \
+    __macro(rocblas_dznrm2)                */ \
+  __macro(rocblas_sdot)                     \
+  __macro(rocblas_ddot)                     \
+  /*__macro(rocblas_cdotu)                    \
+    __macro(rocblas_cdotc)                    \
+    __macro(rocblas_zdotu)                    \
+    __macro(rocblas_zdotc)                 */ \
+  __macro(rocblas_sscal)                    \
+  __macro(rocblas_dscal)                    \
+  /*__macro(rocblas_cscal)                    \
+    __macro(rocblas_csscal)                   \
+    __macro(rocblas_zscal)                    \
+    __macro(rocblas_zdscal)                */ \
+  __macro(rocblas_saxpy)                    \
+  __macro(rocblas_daxpy)                    \
+  /*__macro(rocblas_caxpy)                    \
+    __macro(rocblas_zaxpy)                 */ \
+  __macro(rocblas_scopy)                    \
+  __macro(rocblas_dcopy)                    \
+  /*__macro(rocblas_ccopy)                    \
+    __macro(rocblas_zcopy)                 */ \
+  __macro(rocblas_sswap)                    \
+  __macro(rocblas_dswap)                    \
+  /*__macro(rocblas_cswap)                    \
+    __macro(rocblas_zswap)                 */ \
+  __macro(rocblas_isamax)                   \
+  __macro(rocblas_idamax)                   \
+  /*__macro(rocblas_icamax)                   \
+    __macro(rocblas_izamax)                */ \
+  __macro(rocblas_isamin)                   \
+  __macro(rocblas_idamin)                   \
+  /*__macro(rocblas_icamin)                   \
+    __macro(rocblas_izamin)                */ \
+  __macro(rocblas_sasum)                    \
+  __macro(rocblas_dasum)                    \
+  /*__macro(rocblas_scasum)                   \
+    __macro(rocblas_dzasum)                   \
+    __macro(rocblas_srot)                     \
+    __macro(rocblas_drot)                     \
+    __macro(rocblas_crot)                     \
+    __macro(rocblas_csrot)                    \
+    __macro(rocblas_zrot)                     \
+    __macro(rocblas_zdrot)                    \
+    __macro(rocblas_srotg)                    \
+    __macro(rocblas_drotg)                    \
+    __macro(rocblas_Crotg)                    \
+    __macro(rocblas_crotg)                    \
+    __macro(rocblas_zrotm)                    \
+    __macro(rocblas_drotm)                    \
+    __macro(rocblas_srotmg)                   \
+    __macro(rocblas_drotmg)                */ \
+  __macro(rocblas_sgemv)                    \
+  __macro(rocblas_dgemv)                    \
+  /*__macro(rocblas_cgemv)                    \
+    __macro(rocblas_zgemv)                    \
+    __macro(rocblas_sgbmv)                    \
+    __macro(rocblas_dgbmv)                    \
+    __macro(rocblas_cgbmv)                    \
+    __macro(rocblas_zgbmv)                    \
+    __macro(rocblas_strmv)                    \
+    __macro(rocblas_dtrmv)                    \
+    __macro(rocblas_ctrmv)                    \
+    __macro(rocblas_ztrmv)                    \
+    __macro(rocblas_stbmv)                    \
+    __macro(rocblas_dtbmv)                    \
+    __macro(rocblas_ctbmv)                    \
+    __macro(rocblas_ztbmv)                    \
+    __macro(rocblas_stpmv)                    \
+    __macro(rocblas_dtpmv)                    \
+    __macro(rocblas_ctpmv)                    \
+    __macro(rocblas_ztpmv)                    \
+    __macro(rocblas_strsv)                    \
+    __macro(rocblas_dtrsv)                    \
+    __macro(rocblas_ctrsv)                    \
+    __macro(rocblas_ztrsv)                    \
+    __macro(rocblas_stpsv)                    \
+    __macro(rocblas_dtpsv)                    \
+    __macro(rocblas_ctpsv)                    \
+    __macro(rocblas_ztpsv)                    \
+    __macro(rocblas_stbsv)                    \
+    __macro(rocblas_dtbsv)                    \
+    __macro(rocblas_ctbsv)                    \
+    __macro(rocblas_ztbsv)                    \
+    __macro(rocblas_ssymv)                    \
+    __macro(rocblas_dsymv)                    \
+    __macro(rocblas_csymv)                    \
+    __macro(rocblas_zsymv)                    \
+    __macro(rocblas_chemv)                    \
+    __macro(rocblas_zhemv)                    \
+    __macro(rocblas_ssbmv)                    \
+    __macro(rocblas_dsbmv)                    \
+    __macro(rocblas_chbmv)                    \
+    __macro(rocblas_zhbmv)                    \
+    __macro(rocblas_sspmv)                    \
+    __macro(rocblas_dspmv)                    \
+    __macro(rocblas_chpmv)                    \
+    __macro(rocblas_zhpmv)                 */ \
+  __macro(rocblas_sger)                     \
+  __macro(rocblas_dger)                     \
+  /*__macro(rocblas_cgeru)                    \
+    __macro(rocblas_cgerc)                    \
+    __macro(rocblas_zgeru)                    \
+    __macro(rocblas_zgerc)                 */ \
+  __macro(rocblas_ssyr)                     \
+  __macro(rocblas_dsyr)                     \
+  /*__macro(rocblas_csyr)                     \
+    __macro(rocblas_zsyr)                     \
+    __macro(rocblas_cher)                     \
+    __macro(rocblas_zher)                     \
+    __macro(rocblas_sspr)                     \
+    __macro(rocblas_dspr)                     \
+    __macro(rocblas_chpr)                     \
+    __macro(rocblas_zhpr)                     \
+    __macro(rocblas_ssyr2)                    \
+    __macro(rocblas_dsyr2)                    \
+    __macro(rocblas_csyr2)                    \
+    __macro(rocblas_zsyr2)                    \
+    __macro(rocblas_cher2)                    \
+    __macro(rocblas_zher2)                    \
+    __macro(rocblas_sspr2)                    \
+    __macro(rocblas_dspr2)                    \
+    __macro(rocblas_chpr2)                    \
+    __macro(rocblas_zhpr2)                 */ \
+  __macro(rocblas_sgemm)                    \
+  __macro(rocblas_dgemm)                    \
+  __macro(rocblas_hgemm)                    \
+  /*__macro(rocblas_cgemm)                    \
+    __macro(rocblas_zgemm)                    \
+    __macro(rocblas_ssyrk)                    \
+    __macro(rocblas_dsyrk)                    \
+    __macro(rocblas_csyrk)                    \
+    __macro(rocblas_zsyrk)                    \
+    __macro(rocblas_cherk)                    \
+    __macro(rocblas_zherk)                    \
+    __macro(rocblas_ssyr2k)                   \
+    __macro(rocblas_dsyr2k)                   \
+    __macro(rocblas_csyr2k)                   \
+    __macro(rocblas_zsyr2k)                   \
+    __macro(rocblas_cher2k)                   \
+    __macro(rocblas_zher2k)                   \
+    __macro(rocblas_ssyrkx)                   \
+    __macro(rocblas_dsyrkx)                   \
+    __macro(rocblas_csyrkx)                   \
+    __macro(rocblas_zsyrkx)                   \
+    __macro(rocblas_cherkx)                   \
+    __macro(rocblas_zherkx)                   \
+    __macro(rocblas_ssymm)                    \
+    __macro(rocblas_dsymm)                    \
+    __macro(rocblas_csymm)                    \
+    __macro(rocblas_zsymm)                    \
+    __macro(rocblas_chemm)                    \
+    __macro(rocblas_zhemm)                 */ \
+  __macro(rocblas_strsm)                    \
+  __macro(rocblas_dtrsm)                    \
+  /*__macro(rocblas_ctrsm)                    \
+    __macro(rocblas_ztrsm)                    \
+    __macro(rocblas_strmm)                    \
+    __macro(rocblas_dtrmm)                    \
+    __macro(rocblas_ctrmm)                    \
+    __macro(rocblas_ztrmm)                 */ \
+  __macro(rocblas_sgeam)                    \
+  __macro(rocblas_dgeam)                    \
+  /*__macro(rocblas_cgeam)                    \
+    __macro(rocblas_zgeam)                    \
+    __macro(rocblas_sdgmm)                    \
+    __macro(rocblas_ddgmm)                    \
+    __macro(rocblas_cdgmm)                    \
+    __macro(rocblas_zdgmm) */
+// clang-format on
 
 STREAM_EXECUTOR_ROCBLAS_V2_WRAP(rocblas_create_handle)
 STREAM_EXECUTOR_ROCBLAS_V2_WRAP(rocblas_destroy_handle)
@@ -2275,21 +2294,33 @@ bool ROCMBlas::DoBlasGemmStridedBatched(
     int lda, int64 stride_a, const DeviceMemory<Eigen::half> &b, int ldb,
     int64 stride_b, float beta, DeviceMemory<Eigen::half> *c, int ldc,
     int64 stride_c, int batch_count) {
-  LOG(ERROR) << "rocBLAS does not currently support the "
-                "DoBlasGemmStridedBatched operation "
-             << "for the \"Eigen::half\" dataype";
-  return false;
+  const Eigen::half alpha_half(alpha);
+  const Eigen::half beta_half(beta);
+
+  return DoBlasInternal(
+      wrap::rocblas_hgemm_strided_batched, stream,
+      false, /* pointer_mode_host */
+      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
+      reinterpret_cast<const rocblas_half*>(&alpha_half),
+      reinterpret_cast<const rocblas_half*>(GpuMemory(a)), lda, stride_a,
+      reinterpret_cast<const rocblas_half*>(GpuMemory(b)), ldb, stride_b,
+      reinterpret_cast<const rocblas_half*>(&beta_half),
+      reinterpret_cast<rocblas_half*>(GpuMemoryMutable(c)), ldc, stride_c,
+      batch_count);
 }
+
 bool ROCMBlas::DoBlasGemmStridedBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
     uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
     int64 stride_a, const DeviceMemory<float> &b, int ldb, int64 stride_b,
     float beta, DeviceMemory<float> *c, int ldc, int64 stride_c,
     int batch_count) {
-  LOG(ERROR) << "rocBLAS does not currently support the "
-                "DoBlasGemmStridedBatched operation "
-             << "for the \"float\" dataype";
-  return false;
+  return DoBlasInternal(wrap::rocblas_sgemm_strided_batched, stream,
+                        false, /* pointer_mode_host */
+                        ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
+                        n, k, &alpha, GpuMemory(a), lda, stride_a, GpuMemory(b),
+                        ldb, stride_b, &beta, GpuMemoryMutable(c), ldc,
+                        stride_c, batch_count);
 }
 bool ROCMBlas::DoBlasGemmStridedBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
@@ -2297,10 +2328,12 @@ bool ROCMBlas::DoBlasGemmStridedBatched(
     int64 stride_a, const DeviceMemory<double> &b, int ldb, int64 stride_b,
     double beta, DeviceMemory<double> *c, int ldc, int64 stride_c,
     int batch_count) {
-  LOG(ERROR) << "rocBLAS does not currently support the "
-                "DoBlasGemmStridedBatched operation "
-             << "for the \"double\" dataype";
-  return false;
+  return DoBlasInternal(wrap::rocblas_dgemm_strided_batched, stream,
+                        false, /* pointer_mode_host */
+                        ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
+                        n, k, &alpha, GpuMemory(a), lda, stride_a, GpuMemory(b),
+                        ldb, stride_b, &beta, GpuMemoryMutable(c), ldc,
+                        stride_c, batch_count);
 }
 bool ROCMBlas::DoBlasGemmStridedBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,


### PR DESCRIPTION
This PR add support to the gemm strided batched interface, from the develop-upstream [PR405](https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/405). This PR has been thoroughly tested over the past two month. 

-----
@tatianashp @whchung @chsigg @deven-amd 