### PR TITLE
[ROCm] Adding ROCm support to gemm batched interface

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -100,161 +100,180 @@ namespace wrap {
 
 #endif
 
-#define ROCBLAS_BLAS_ROUTINE_EACH(__macro)                                     \
-  __macro(rocblas_snrm2) __macro(rocblas_dnrm2) /*  __macro(rocblas_scnrm2)    \
-                                                  __macro(rocblas_dznrm2) */   \
-      __macro(rocblas_sdot)                                                    \
-          __macro(rocblas_ddot) /*  __macro(rocblas_cdotu)                     \
-                                  __macro(rocblas_cdotc)                       \
-                                  __macro(rocblas_zdotu)                       \
-                                  __macro(rocblas_zdotc)                    */ \
-      __macro(rocblas_sscal)                                                   \
-          __macro(rocblas_dscal) /*  __macro(rocblas_cscal)                    \
-                                   __macro(rocblas_csscal)                     \
-                                   __macro(rocblas_zscal)                      \
-                                   __macro(rocblas_zdscal) */                  \
-      __macro(rocblas_saxpy)                                                   \
-          __macro(rocblas_daxpy) /*  __macro(rocblas_caxpy)                    \
-                                   __macro(rocblas_zaxpy) */                   \
-      __macro(rocblas_scopy)                                                   \
-          __macro(rocblas_dcopy) /*  __macro(rocblas_ccopy)                    \
-                                   __macro(rocblas_zcopy) */                   \
-      __macro(rocblas_sswap)                                                   \
-          __macro(rocblas_dswap) /*  __macro(rocblas_cswap)                    \
-                                   __macro(rocblas_zswap) */                   \
-      __macro(rocblas_isamax)                                                  \
-          __macro(rocblas_idamax) /*  __macro(rocblas_icamax)                  \
-                                    __macro(rocblas_izamax) */                 \
-      __macro(rocblas_isamin)                                                  \
-          __macro(rocblas_idamin) /*  __macro(rocblas_icamin)                  \
-                                    __macro(rocblas_izamin) */                 \
-      __macro(rocblas_sasum)                                                   \
-          __macro(rocblas_dasum) /*  __macro(rocblas_scasum)                   \
-                                   __macro(rocblas_dzasum)                     \
-                                   __macro(rocblas_srot)                       \
-                                   __macro(rocblas_drot)                       \
-                                   __macro(rocblas_crot)                       \
-                                   __macro(rocblas_csrot)                      \
-                                   __macro(rocblas_zrot)                       \
-                                   __macro(rocblas_zdrot)                      \
-                                   __macro(rocblas_srotg)                      \
-                                   __macro(rocblas_drotg)                      \
-                                   __macro(rocblas_Crotg)                      \
-                                   __macro(rocblas_crotg)                      \
-                                   __macro(rocblas_zrotm)                      \
-                                   __macro(rocblas_drotm)                      \
-                                   __macro(rocblas_srotmg)                     \
-                                   __macro(rocblas_drotmg) */                  \
-      __macro(rocblas_sgemv)                                                   \
-          __macro(rocblas_dgemv) /*  __macro(rocblas_cgemv)                    \
-                                   __macro(rocblas_zgemv)                      \
-                                   __macro(rocblas_sgbmv)                      \
-                                   __macro(rocblas_dgbmv)                      \
-                                   __macro(rocblas_cgbmv)                      \
-                                   __macro(rocblas_zgbmv)                      \
-                                   __macro(rocblas_strmv)                      \
-                                   __macro(rocblas_dtrmv)                      \
-                                   __macro(rocblas_ctrmv)                      \
-                                   __macro(rocblas_ztrmv)                      \
-                                   __macro(rocblas_stbmv)                      \
-                                   __macro(rocblas_dtbmv)                      \
-                                   __macro(rocblas_ctbmv)                      \
-                                   __macro(rocblas_ztbmv)                      \
-                                   __macro(rocblas_stpmv)                      \
-                                   __macro(rocblas_dtpmv)                      \
-                                   __macro(rocblas_ctpmv)                      \
-                                   __macro(rocblas_ztpmv)                      \
-                                   __macro(rocblas_strsv)                      \
-                                   __macro(rocblas_dtrsv)                      \
-                                   __macro(rocblas_ctrsv)                      \
-                                   __macro(rocblas_ztrsv)                      \
-                                   __macro(rocblas_stpsv)                      \
-                                   __macro(rocblas_dtpsv)                      \
-                                   __macro(rocblas_ctpsv)                      \
-                                   __macro(rocblas_ztpsv)                      \
-                                   __macro(rocblas_stbsv)                      \
-                                   __macro(rocblas_dtbsv)                      \
-                                   __macro(rocblas_ctbsv)                      \
-                                   __macro(rocblas_ztbsv)                      \
-                                   __macro(rocblas_ssymv)                      \
-                                   __macro(rocblas_dsymv)                      \
-                                   __macro(rocblas_csymv)                      \
-                                   __macro(rocblas_zsymv)                      \
-                                   __macro(rocblas_chemv)                      \
-                                   __macro(rocblas_zhemv)                      \
-                                   __macro(rocblas_ssbmv)                      \
-                                   __macro(rocblas_dsbmv)                      \
-                                   __macro(rocblas_chbmv)                      \
-                                   __macro(rocblas_zhbmv)                      \
-                                   __macro(rocblas_sspmv)                      \
-                                   __macro(rocblas_dspmv)                      \
-                                   __macro(rocblas_chpmv)                      \
-                                   __macro(rocblas_zhpmv) */                   \
-      __macro(rocblas_sger)                                                    \
-          __macro(rocblas_dger) /*  __macro(rocblas_cgeru)                     \
-                                  __macro(rocblas_cgerc)                       \
-                                  __macro(rocblas_zgeru)                       \
-                                  __macro(rocblas_zgerc)                    */ \
-      __macro(rocblas_ssyr)                                                    \
-          __macro(rocblas_dsyr) /*  __macro(rocblas_csyr)                      \
-                                  __macro(rocblas_zsyr)                        \
-                                  __macro(rocblas_cher)                        \
-                                  __macro(rocblas_zher)                        \
-                                  __macro(rocblas_sspr)                        \
-                                  __macro(rocblas_dspr)                        \
-                                  __macro(rocblas_chpr)                        \
-                                  __macro(rocblas_zhpr)                        \
-                                  __macro(rocblas_ssyr2)                       \
-                                  __macro(rocblas_dsyr2)                       \
-                                  __macro(rocblas_csyr2)                       \
-                                  __macro(rocblas_zsyr2)                       \
-                                  __macro(rocblas_cher2)                       \
-                                  __macro(rocblas_zher2)                       \
-                                  __macro(rocblas_sspr2)                       \
-                                  __macro(rocblas_dspr2)                       \
-                                  __macro(rocblas_chpr2)                       \
-                                  __macro(rocblas_zhpr2)                    */ \
-      __macro(rocblas_sgemm) __macro(rocblas_dgemm)                            \
-          __macro(rocblas_hgemm) /*  __macro(rocblas_cgemm)                    \
-                                   __macro(rocblas_zgemm)                      \
-                                   __macro(rocblas_ssyrk)                      \
-                                   __macro(rocblas_dsyrk)                      \
-                                   __macro(rocblas_csyrk)                      \
-                                   __macro(rocblas_zsyrk)                      \
-                                   __macro(rocblas_cherk)                      \
-                                   __macro(rocblas_zherk)                      \
-                                   __macro(rocblas_ssyr2k)                     \
-                                   __macro(rocblas_dsyr2k)                     \
-                                   __macro(rocblas_csyr2k)                     \
-                                   __macro(rocblas_zsyr2k)                     \
-                                   __macro(rocblas_cher2k)                     \
-                                   __macro(rocblas_zher2k)                     \
-                                   __macro(rocblas_ssyrkx)                     \
-                                   __macro(rocblas_dsyrkx)                     \
-                                   __macro(rocblas_csyrkx)                     \
-                                   __macro(rocblas_zsyrkx)                     \
-                                   __macro(rocblas_cherkx)                     \
-                                   __macro(rocblas_zherkx)                     \
-                                   __macro(rocblas_ssymm)                      \
-                                   __macro(rocblas_dsymm)                      \
-                                   __macro(rocblas_csymm)                      \
-                                   __macro(rocblas_zsymm)                      \
-                                   __macro(rocblas_chemm)                      \
-                                   __macro(rocblas_zhemm) */                   \
-      __macro(rocblas_strsm)                                                   \
-          __macro(rocblas_dtrsm) /*  __macro(rocblas_ctrsm)                    \
-                                   __macro(rocblas_ztrsm)                      \
-                                   __macro(rocblas_strmm)                      \
-                                   __macro(rocblas_dtrmm)                      \
-                                   __macro(rocblas_ctrmm)                      \
-                                   __macro(rocblas_ztrmm) */                   \
-      __macro(rocblas_sgeam)                                                   \
-          __macro(rocblas_dgeam) /*  __macro(rocblas_cgeam)                    \
-                                   __macro(rocblas_zgeam)                      \
-                                   __macro(rocblas_sdgmm)                      \
-                                   __macro(rocblas_ddgmm)                      \
-                                   __macro(rocblas_cdgmm)                      \
-                                   __macro(rocblas_zdgmm) */
+// clang-format off
+#define ROCBLAS_BLAS_ROUTINE_EACH(__macro)  \
+  __macro(rocblas_snrm2)                    \
+  __macro(rocblas_dnrm2)                    \
+  /*__macro(rocblas_scnrm2)                   \
+    __macro(rocblas_dznrm2)                */ \
+  __macro(rocblas_sdot)                     \
+  __macro(rocblas_ddot)                     \
+  /*__macro(rocblas_cdotu)                    \
+    __macro(rocblas_cdotc)                    \
+    __macro(rocblas_zdotu)                    \
+    __macro(rocblas_zdotc)                 */ \
+  __macro(rocblas_sscal)                    \
+  __macro(rocblas_dscal)                    \
+  /*__macro(rocblas_cscal)                    \
+    __macro(rocblas_csscal)                   \
+    __macro(rocblas_zscal)                    \
+    __macro(rocblas_zdscal)                */ \
+  __macro(rocblas_saxpy)                    \
+  __macro(rocblas_daxpy)                    \
+  /*__macro(rocblas_caxpy)                    \
+    __macro(rocblas_zaxpy)                 */ \
+  __macro(rocblas_scopy)                    \
+  __macro(rocblas_dcopy)                    \
+  /*__macro(rocblas_ccopy)                    \
+    __macro(rocblas_zcopy)                 */ \
+  __macro(rocblas_sswap)                    \
+  __macro(rocblas_dswap)                    \
+  /*__macro(rocblas_cswap)                    \
+    __macro(rocblas_zswap)                 */ \
+  __macro(rocblas_isamax)                   \
+  __macro(rocblas_idamax)                   \
+  /*__macro(rocblas_icamax)                   \
+    __macro(rocblas_izamax)                */ \
+  __macro(rocblas_isamin)                   \
+  __macro(rocblas_idamin)                   \
+  /*__macro(rocblas_icamin)                   \
+    __macro(rocblas_izamin)                */ \
+  __macro(rocblas_sasum)                    \
+  __macro(rocblas_dasum)                    \
+  /*__macro(rocblas_scasum)                   \
+    __macro(rocblas_dzasum)                   \
+    __macro(rocblas_srot)                     \
+    __macro(rocblas_drot)                     \
+    __macro(rocblas_crot)                     \
+    __macro(rocblas_csrot)                    \
+    __macro(rocblas_zrot)                     \
+    __macro(rocblas_zdrot)                    \
+    __macro(rocblas_srotg)                    \
+    __macro(rocblas_drotg)                    \
+    __macro(rocblas_Crotg)                    \
+    __macro(rocblas_crotg)                    \
+    __macro(rocblas_zrotm)                    \
+    __macro(rocblas_drotm)                    \
+    __macro(rocblas_srotmg)                   \
+    __macro(rocblas_drotmg)                */ \
+  __macro(rocblas_sgemv)                    \
+  __macro(rocblas_dgemv)                    \
+  /*__macro(rocblas_cgemv)                    \
+    __macro(rocblas_zgemv)                    \
+    __macro(rocblas_sgbmv)                    \
+    __macro(rocblas_dgbmv)                    \
+    __macro(rocblas_cgbmv)                    \
+    __macro(rocblas_zgbmv)                    \
+    __macro(rocblas_strmv)                    \
+    __macro(rocblas_dtrmv)                    \
+    __macro(rocblas_ctrmv)                    \
+    __macro(rocblas_ztrmv)                    \
+    __macro(rocblas_stbmv)                    \
+    __macro(rocblas_dtbmv)                    \
+    __macro(rocblas_ctbmv)                    \
+    __macro(rocblas_ztbmv)                    \
+    __macro(rocblas_stpmv)                    \
+    __macro(rocblas_dtpmv)                    \
+    __macro(rocblas_ctpmv)                    \
+    __macro(rocblas_ztpmv)                    \
+    __macro(rocblas_strsv)                    \
+    __macro(rocblas_dtrsv)                    \
+    __macro(rocblas_ctrsv)                    \
+    __macro(rocblas_ztrsv)                    \
+    __macro(rocblas_stpsv)                    \
+    __macro(rocblas_dtpsv)                    \
+    __macro(rocblas_ctpsv)                    \
+    __macro(rocblas_ztpsv)                    \
+    __macro(rocblas_stbsv)                    \
+    __macro(rocblas_dtbsv)                    \
+    __macro(rocblas_ctbsv)                    \
+    __macro(rocblas_ztbsv)                    \
+    __macro(rocblas_ssymv)                    \
+    __macro(rocblas_dsymv)                    \
+    __macro(rocblas_csymv)                    \
+    __macro(rocblas_zsymv)                    \
+    __macro(rocblas_chemv)                    \
+    __macro(rocblas_zhemv)                    \
+    __macro(rocblas_ssbmv)                    \
+    __macro(rocblas_dsbmv)                    \
+    __macro(rocblas_chbmv)                    \
+    __macro(rocblas_zhbmv)                    \
+    __macro(rocblas_sspmv)                    \
+    __macro(rocblas_dspmv)                    \
+    __macro(rocblas_chpmv)                    \
+    __macro(rocblas_zhpmv)                 */ \
+  __macro(rocblas_sger)                     \
+  __macro(rocblas_dger)                     \
+  /*__macro(rocblas_cgeru)                    \
+    __macro(rocblas_cgerc)                    \
+    __macro(rocblas_zgeru)                    \
+    __macro(rocblas_zgerc)                 */ \
+  __macro(rocblas_ssyr)                     \
+  __macro(rocblas_dsyr)                     \
+  /*__macro(rocblas_csyr)                     \
+    __macro(rocblas_zsyr)                     \
+    __macro(rocblas_cher)                     \
+    __macro(rocblas_zher)                     \
+    __macro(rocblas_sspr)                     \
+    __macro(rocblas_dspr)                     \
+    __macro(rocblas_chpr)                     \
+    __macro(rocblas_zhpr)                     \
+    __macro(rocblas_ssyr2)                    \
+    __macro(rocblas_dsyr2)                    \
+    __macro(rocblas_csyr2)                    \
+    __macro(rocblas_zsyr2)                    \
+    __macro(rocblas_cher2)                    \
+    __macro(rocblas_zher2)                    \
+    __macro(rocblas_sspr2)                    \
+    __macro(rocblas_dspr2)                    \
+    __macro(rocblas_chpr2)                    \
+    __macro(rocblas_zhpr2)                 */ \
+  __macro(rocblas_sgemm)                    \
+  __macro(rocblas_dgemm)                    \
+  __macro(rocblas_hgemm)                    \
+  /*__macro(rocblas_cgemm)                    \
+    __macro(rocblas_zgemm)                    \
+    __macro(rocblas_ssyrk)                    \
+    __macro(rocblas_dsyrk)                    \
+    __macro(rocblas_csyrk)                    \
+    __macro(rocblas_zsyrk)                    \
+    __macro(rocblas_cherk)                    \
+    __macro(rocblas_zherk)                    \
+    __macro(rocblas_ssyr2k)                   \
+    __macro(rocblas_dsyr2k)                   \
+    __macro(rocblas_csyr2k)                   \
+    __macro(rocblas_zsyr2k)                   \
+    __macro(rocblas_cher2k)                   \
+    __macro(rocblas_zher2k)                   \
+    __macro(rocblas_ssyrkx)                   \
+    __macro(rocblas_dsyrkx)                   \
+    __macro(rocblas_csyrkx)                   \
+    __macro(rocblas_zsyrkx)                   \
+    __macro(rocblas_cherkx)                   \
+    __macro(rocblas_zherkx)                   \
+    __macro(rocblas_ssymm)                    \
+    __macro(rocblas_dsymm)                    \
+    __macro(rocblas_csymm)                    \
+    __macro(rocblas_zsymm)                    \
+    __macro(rocblas_chemm)                    \
+    __macro(rocblas_zhemm)                 */ \
+  __macro(rocblas_strsm)                    \
+  __macro(rocblas_dtrsm)                    \
+  /*__macro(rocblas_ctrsm)                    \
+    __macro(rocblas_ztrsm)                    \
+    __macro(rocblas_strmm)                    \
+    __macro(rocblas_dtrmm)                    \
+    __macro(rocblas_ctrmm)                    \
+    __macro(rocblas_ztrmm)                 */ \
+  __macro(rocblas_sgeam)                    \
+  __macro(rocblas_dgeam)                    \
+  /*__macro(rocblas_cgeam)                    \
+    __macro(rocblas_zgeam)                    \
+    __macro(rocblas_sdgmm)                    \
+    __macro(rocblas_ddgmm)                    \
+    __macro(rocblas_cdgmm)                    \
+    __macro(rocblas_zdgmm) */
+// clang-format on
 
 STREAM_EXECUTOR_ROCBLAS_V2_WRAP(rocblas_create_handle)
 STREAM_EXECUTOR_ROCBLAS_V2_WRAP(rocblas_destroy_handle)
@@ -1795,14 +1814,66 @@ bool ROCMBlas::DoBlasGemmWithAlgorithm(
 }
 
 template <typename T>
-struct EigenHalfToRocBlasHalf {
-  using type = T;
-};
+port::Status ROCMBlas::AllocateStridedBuffer(
+    const std::vector<typename RocBlasTypeConversionHelper<T>::mapped_type*>&
+        raw_ptrs,
+    int batch_count, uint64_t batch_stride, ScratchAllocator* scratch_allocator,
+    Stream* stream,
+    std::unique_ptr<TemporaryDeviceMemory<
+        typename RocBlasTypeConversionHelper<T>::mapped_type>>* temp_memory,
+    DeviceMemory<typename RocBlasTypeConversionHelper<T>::mapped_type>*
+        device_memory) {
+  assert(device_memory != nullptr);
 
-template <>
-struct EigenHalfToRocBlasHalf<Eigen::half> {
-  using type = rocblas_half;
-};
+  using MAPPED_T = typename RocBlasTypeConversionHelper<T>::mapped_type;
+
+  bool needs_allocate_strided = false;
+  for (int i = 1; i < batch_count; ++i) {
+    uint64_t tmp_batch_stride = raw_ptrs[i] - raw_ptrs[i - 1];
+    if (tmp_batch_stride != batch_stride) {
+      needs_allocate_strided = true;
+      break;
+    }
+  }
+
+  size_t matrix_byte_size = batch_stride * sizeof(MAPPED_T);
+  size_t matrix_batch_byte_size = matrix_byte_size * batch_count;
+
+  // No need to do re-allocation, take the short cut and return
+  if (!needs_allocate_strided) {
+    *device_memory = DeviceMemory<MAPPED_T>(
+        DeviceMemoryBase(raw_ptrs[0], matrix_batch_byte_size));
+    return port::Status::OK();
+  }
+
+  if (scratch_allocator != nullptr) {
+    SE_ASSIGN_OR_RETURN(
+        DeviceMemory<uint8> batch_matrix_bytes,
+        scratch_allocator->AllocateBytes(stream, matrix_batch_byte_size));
+    *device_memory = DeviceMemory<MAPPED_T>(batch_matrix_bytes);
+  } else {
+    assert(temp_memory != nullptr);
+    SE_ASSIGN_OR_RETURN(*temp_memory, stream->AllocateTemporaryArray<MAPPED_T>(
+                                          matrix_batch_byte_size));
+    *device_memory =
+        DeviceMemory<MAPPED_T>(*(*temp_memory)->mutable_device_memory());
+  }
+
+  for (int i = 0; i < batch_count; ++i) {
+    char* device_memory_ptr = static_cast<char*>(device_memory->opaque());
+    DeviceMemoryBase src_mem = DeviceMemoryBase(raw_ptrs[i], matrix_byte_size);
+    DeviceMemoryBase target_mem = DeviceMemoryBase(
+        device_memory_ptr + i * matrix_byte_size, matrix_byte_size);
+    bool a_status =
+        stream->ThenMemcpy(&target_mem, src_mem, matrix_byte_size).ok();
+    if (!a_status) {
+      return port::Status(
+          port::error::INTERNAL,
+          "failed to copy device memory in ROCMBlas::DoBlasGemmBatched");
+    }
+  }
+  return port::Status::OK();
+}
 
 template <typename T, typename FuncT>
 port::Status ROCMBlas::DoBlasGemmBatchedInternal(
@@ -1812,15 +1883,37 @@ port::Status ROCMBlas::DoBlasGemmBatchedInternal(
     const port::ArraySlice<DeviceMemory<T> *> &b_ptrs_to_wrappers, int ldb,
     T beta, const port::ArraySlice<DeviceMemory<T> *> &c_ptrs_to_wrappers,
     int ldc, int batch_count, ScratchAllocator *scratch_allocator) {
-  // MAPPED_T will be same as T for all types except Eigen::Half
-  // for T = Eigen::half, MAPPED_T = rocblas_half
-  using MAPPED_T = typename EigenHalfToRocBlasHalf<T>::type;
+  using MAPPED_T = typename RocBlasTypeConversionHelper<T>::mapped_type;
+
+  // Sanity checks before making any further progress
+  uint64_t batch_stride_a = 0;
+  uint64_t batch_stride_b = 0;
+  uint64_t batch_stride_c = 0;
+
+  assert(ldc >= m);
+  batch_stride_c = ldc * n;
+
+  if (ROCMBlasTranspose(transa) == rocblas_operation_none) {
+    assert(lda >= m);
+    batch_stride_a = lda * k;
+  } else {
+    assert(lda >= k);
+    batch_stride_a = lda * m;
+  }
+
+  if (ROCMBlasTranspose(transb) == rocblas_operation_none) {
+    assert(ldb >= k);
+    batch_stride_b = ldb * n;
+  } else {
+    assert(ldb >= n);
+    batch_stride_b = ldb * k;
+  }
 
   // Alocate local vectors to hold device pointers to matrices
   std::vector<MAPPED_T *> a_raw_ptrs, b_raw_ptrs, c_raw_ptrs;
   for (int i = 0; i < batch_count; ++i) {
     // static_cast does work when converting Eigen::half* to rocblas_half*,
-    // hence the use od reinterpret_cast
+    // hence the use of reinterpret_cast
     a_raw_ptrs.push_back(
         reinterpret_cast<MAPPED_T *>(a_ptrs_to_wrappers[i]->opaque()));
     b_raw_ptrs.push_back(
@@ -1829,76 +1922,50 @@ port::Status ROCMBlas::DoBlasGemmBatchedInternal(
         reinterpret_cast<MAPPED_T *>(c_ptrs_to_wrappers[i]->opaque()));
   }
 
-  //  batch_count <= 1 is base case, no definable matrix stride, set it same as
-  //  ld*
-  long long bsa = lda;
-  long long bsb = ldb;
-  long long bsc = ldc;
-  bool bsa_is_constant = true;
-  bool bsb_is_constant = true;
-  bool bsc_is_constant = true;
-
-  if (batch_count > 1) {
-    // Remember first stride; if any other stride is different that this one,
-    // KABLAM
-    bsa = a_raw_ptrs[1] - a_raw_ptrs[0];
-    bsb = b_raw_ptrs[1] - b_raw_ptrs[0];
-    bsc = c_raw_ptrs[1] - c_raw_ptrs[0];
-
-    //  Loop to verify that batched strides are constant
-    //  All the test cases from batch_matmul_op_test.py seem to satisfy this
-    //  requirement of a constant stride.  If this can be proven globally, then
-    //  this loop check can be safely removed
-    for (int i = 1; i < batch_count - 1; ++i) {
-      long long iterative_bsa = a_raw_ptrs[i + 1] - a_raw_ptrs[i];
-      if (iterative_bsa != bsa) {
-        bsa_is_constant = false;
-        break;
-      }
-
-      long long iterative_bsb = b_raw_ptrs[i + 1] - b_raw_ptrs[i];
-      if (iterative_bsb != bsb) {
-        bsb_is_constant = false;
-        break;
-      }
-
-      long long iterative_bsc = c_raw_ptrs[i + 1] - c_raw_ptrs[i];
-      if (iterative_bsc != bsc) {
-        bsc_is_constant = false;
-        break;
-      }
-    }
+  DeviceMemory<MAPPED_T> a;
+  // Make sure the temporary memory are in-scope before the function returns
+  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> a_temp;
+  port::Status a_allocation_status =
+      AllocateStridedBuffer<T>(a_raw_ptrs, batch_count, batch_stride_a,
+                               scratch_allocator, stream, &a_temp, &a);
+  if (a_allocation_status != port::Status::OK()) {
+    return a_allocation_status;
   }
 
-  assert(!(ldc < m || bsc < ldc * n));
+  DeviceMemory<MAPPED_T> b;
+  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> b_temp;
+  port::Status b_allocation_status =
+      AllocateStridedBuffer<T>(b_raw_ptrs, batch_count, batch_stride_b,
+                               scratch_allocator, stream, &b_temp, &b);
+  if (b_allocation_status != port::Status::OK()) {
+    return b_allocation_status;
+  }
 
-  if (ROCMBlasTranspose(transa) == rocblas_operation_none)
-    assert(!(lda < m || bsa < lda * k));
-  else
-    assert(!(lda < k || bsa < lda * m));
-
-  if (ROCMBlasTranspose(transb) == rocblas_operation_none)
-    assert(!(ldb < k || bsb < ldb * n));
-  else
-    assert(!(ldb < n || bsc < ldc * k));
+  DeviceMemory<MAPPED_T> c;
+  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> c_temp;
+  port::Status c_allocation_status =
+      AllocateStridedBuffer<T>(c_raw_ptrs, batch_count, batch_stride_c,
+                               scratch_allocator, stream, &c_temp, &c);
+  if (c_allocation_status != port::Status::OK()) {
+    return c_allocation_status;
+  }
 
   MAPPED_T *alpha_ptr = reinterpret_cast<MAPPED_T *>(&alpha);
   MAPPED_T *beta_ptr = reinterpret_cast<MAPPED_T *>(&beta);
 
-  if (bsa_is_constant && bsb_is_constant && bsc_is_constant) {
-    bool ok = DoBlasInternal(
-        rocblas_func, stream, true /* = pointer_mode_host */,
-        ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
-        GpuComplex(alpha_ptr), a_raw_ptrs[0], lda, bsa, b_raw_ptrs[0], ldb, bsb,
-        GpuComplex(beta_ptr), c_raw_ptrs[0], ldc, bsc, batch_count);
+  bool ok = DoBlasInternal(rocblas_func, stream, true /* = pointer_mode_host */,
+                           ROCMBlasTranspose(transa), ROCMBlasTranspose(transb),
+                           m, n, k, GpuComplex(alpha_ptr), GpuMemory(a), lda,
+                           batch_stride_a, GpuMemory(b), ldb, batch_stride_b,
+                           GpuComplex(beta_ptr), GpuMemoryMutable(&c), ldc,
+                           batch_stride_c, batch_count);
 
-    if (ok) {
-      return port::Status::OK();
-    }
+  if (ok) {
+    return port::Status::OK();
+  } else {
+    return port::Status(port::error::INTERNAL,
+                        "failed BLAS call, see log for details");
   }
-
-  return port::Status(port::error::INTERNAL,
-                      "failed BLAS call, see log for details");
 }
 
 bool ROCMBlas::DoBlasGemmBatched(

--- a/tensorflow/stream_executor/rocm/rocm_blas.h
+++ b/tensorflow/stream_executor/rocm/rocm_blas.h
@@ -25,12 +25,25 @@ limitations under the License.
 #include "tensorflow/stream_executor/platform/port.h"
 #include "tensorflow/stream_executor/platform/thread_annotations.h"
 #include "tensorflow/stream_executor/plugin_registry.h"
+#include "tensorflow/stream_executor/temporary_device_memory.h"
 
 namespace stream_executor {
 
 class Stream;
 
 namespace gpu {
+
+// Type conversion helper that helps to map non-rocblas types to rocblas types
+// Right now, it only converts the Eigen::half type to rocblas_half type
+template <typename T>
+struct RocBlasTypeConversionHelper {
+  using mapped_type = T;
+};
+
+template <>
+struct RocBlasTypeConversionHelper<Eigen::half> {
+  using mapped_type = rocblas_half;
+};
 
 // Opaque and unique identifier for the rocBLAS plugin.
 extern const PluginId kRocBlasPlugin;
@@ -97,16 +110,43 @@ class ROCMBlas : public blas::BlasSupport {
                               /*err_on_failure=*/false, args...);
   }
 
+  // A helper allocation funciton to convert raw pointers memory layout to
+  // strided flavor
+  template <typename T>
+  port::Status AllocateStridedBuffer(
+      const std::vector<typename RocBlasTypeConversionHelper<T>::mapped_type*>&
+          raw_ptrs,
+      int batch_count, uint64_t batch_stride,
+      ScratchAllocator* scratch_allocator, Stream* stream,
+      std::unique_ptr<TemporaryDeviceMemory<
+          typename RocBlasTypeConversionHelper<T>::mapped_type>>* temp_memory,
+      DeviceMemory<typename RocBlasTypeConversionHelper<T>::mapped_type>*
+          device_memory);
+
   // A helper function to implement DoBlasGemmBatched interfaces for generic
   // types.
+  //
+  // Note: This function is implemented using gemm_strided_batched interface,
+  // NOT gemm_batched interface, because rocblas do not support it. As a
+  // result, if the passed in batch matrix are not allocated in strided batched
+  // format, it might end up in non-trivial amount of memory allocation and
+  // copy. To avoid this, always prioritize to use DoBlasGemmStridedBatched
+  // interface.
+  //
+  // In most use cases, batch matrix do get allocated in strided manner, making
+  // calling this interface equivalent with DoBlasGemmStridedBatched. The only
+  // use case we see so far that violates this observation is when batch
+  // matrix is created by broadcasting from a smaller matrix. When it happens,
+  // It will take advantage of the AllocateStridedBuffer subroutine to
+  // reallocate the memory layout to be strided batched.
   template <typename T, typename FuncT>
   port::Status DoBlasGemmBatchedInternal(
-      FuncT rocblas_func, Stream *stream, blas::Transpose transa,
+      FuncT rocblas_func, Stream* stream, blas::Transpose transa,
       blas::Transpose transb, uint64 m, uint64 n, uint64 k, T alpha,
-      const port::ArraySlice<DeviceMemory<T> *> &a_array, int lda,
-      const port::ArraySlice<DeviceMemory<T> *> &b_array, int ldb, T beta,
-      const port::ArraySlice<DeviceMemory<T> *> &c_array, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
+      const port::ArraySlice<DeviceMemory<T>*>& a_ptrs_to_wrappers, int lda,
+      const port::ArraySlice<DeviceMemory<T>*>& b_ptrs_to_wrappers, int ldb,
+      T beta, const port::ArraySlice<DeviceMemory<T>*>& c_ptrs_to_wrappers,
+      int ldc, int batch_count, ScratchAllocator* scratch_allocator);
 
   // Helper function for implementing DoBlasGemmWithAlgorithm.
   //


### PR DESCRIPTION
This PR fixed the original flawed implementation from gemm batched interface, from the develop-upstream [PR437](https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/437). This PR has been thoroughly tested over the past two month. Without the PR, gemm batch interface is only able to handle strided buffer.

The changes in the PR is very narrowly scoped to the one function `DoBlasGemmBatchedInternal()`.

A brief explanation of what it does quoting the original PR437

> Adding a new subroutine AllocateStridedBuffer() to do memory allocation properly. The subroutine will take the shortcut when buffer is already allocated in a strided manner. And re-allocate when gemm batched buffer isn't properly strided.

------
Test passed: tensorflow/python/kernel_tests/batch_matmul_op_test
@tatianashp @whchung @chsigg