### PR TITLE
Implemented Gradient for RGBToHSV

### DIFF
--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -23,8 +23,6 @@ from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_image_ops
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops.array_ops import stack
-
 
 @ops.RegisterGradient("ResizeNearestNeighbor")
 def _ResizeNearestNeighborGrad(op, grad):
@@ -157,7 +155,7 @@ def _CropAndResizeGrad(op, grad):
   return [grad0, grad1, None, None]
 
 
-def _CustomReciprocal(x, my_eps=1e-10):
+def _CustomReciprocal(x):
   """
   Performs reciprocal with an eps added to the input. This is to avoid
   inversion errors or divide by zeros or NaNs.
@@ -360,15 +358,15 @@ def _RGBToHSVGrad(op, grad):
   dh_db = dh_db_1 + dh_db_2 + dh_db_3 + dh_db_4 + dh_db_5
 
   # Gradients wrt to inputs
-  dv_drgb = stack([grad[..., 2] * dv_dr,
-                   grad[..., 2] * dv_dg,
-                   grad[..., 2] * dv_db], axis=-1)
-  ds_drgb = stack([grad[..., 1] * ds_dr,
-                   grad[..., 1] * ds_dg,
-                   grad[..., 1] * ds_db], axis=-1)
-  dh_drgb = stack([grad[..., 0] * dh_dr,
-                   grad[..., 0] * dh_dg,
-                   grad[..., 0] * dh_db], axis=-1)
+  dv_drgb = array_ops.stack([grad[..., 2] * dv_dr,
+                             grad[..., 2] * dv_dg,
+                             grad[..., 2] * dv_db], axis=-1)
+  ds_drgb = array_ops.stack([grad[..., 1] * ds_dr,
+                             grad[..., 1] * ds_dg,
+                             grad[..., 1] * ds_db], axis=-1)
+  dh_drgb = array_ops.stack([grad[..., 0] * dh_dr,
+                             grad[..., 0] * dh_dg,
+                             grad[..., 0] * dh_db], axis=-1)
 
   gradient_input = math_ops.add(math_ops.add(dv_drgb, ds_drgb), dh_drgb)
 

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -188,5 +188,12 @@ def _rgb_to_hsv_grad(op, grad):
   green_smallest = cast((greens <= reds) & (greens < blues), dtypes.float32)
   blue_smallest = cast((blues <= reds) & (blues <= greens), dtypes.float32)
 
+  ##############################################################
+  #  Derivatives of R, G, B wrt Value slice
+  ##############################################################
+  dv_dr = red_biggest
+  dv_dg = green_biggest
+  dv_db = blue_biggest
+
 
   return None

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -157,13 +157,12 @@ def _CropAndResizeGrad(op, grad):
 
 def _CustomReciprocal(x):
   """
-  Performs reciprocal with an eps added to the input. This is to avoid
-  inversion errors or divide by zeros or NaNs.
-  Inputs:
-    x -> input tensor to be reciprocat-ed
-    my_eps -> custom machine precision epsilon
+  Wrapper function around `math_ops.div_no_nan()` to perform a "safe"
+  reciprocal incase the input is zero. Avoids divide by zero and NaNs.
+  Input:
+    x -> input tensor to be reciprocat-ed.
   Returns:
-    x_reciprocal -> reciprocal of x added with my_eps
+    x_reciprocal -> reciprocal of x without NaNs.
   """
   return math_ops.div_no_nan(1.0, x)
 

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -280,6 +280,9 @@ def _RGBToHSVGrad(op, grad):
                   green_smallest * _CustomReciprocal(blues - greens))
 
   dh_dr = dh_dr_1 + dh_dr_2 + dh_dr_3 + dh_dr_4 + dh_dr_5
+  # Converting from degrees to [0,1] scale as specified in
+  # https://www.tensorflow.org/api_docs/python/tf/image/rgb_to_hsv
+  dh_dr = dh_dr / 360
 
   # for green, dh_dg -> dh_dg_1 + dh_dg_2 + dh_dg_3 + dh_dg_4 + dh_dg_5
   # dh_dg_1 ->
@@ -318,6 +321,9 @@ def _RGBToHSVGrad(op, grad):
                   red_smallest * -1 * _CustomReciprocal(blues - reds))
 
   dh_dg = dh_dg_1 + dh_dg_2 + dh_dg_3 + dh_dg_4 + dh_dg_5
+  # Converting from degrees to [0,1] scale as specified in
+  # https://www.tensorflow.org/api_docs/python/tf/image/rgb_to_hsv
+  dh_dg = dh_dg / 360
 
   # for blue, dh_db -> dh_db_1 + dh_db_2 + dh_db_3 + dh_db_4 + dh_db_5
   # dh_db_1 ->
@@ -356,6 +362,9 @@ def _RGBToHSVGrad(op, grad):
                   red_smallest * _CustomReciprocal(greens - reds))
 
   dh_db = dh_db_1 + dh_db_2 + dh_db_3 + dh_db_4 + dh_db_5
+  # Converting from degrees to [0,1] scale as specified in
+  # https://www.tensorflow.org/api_docs/python/tf/image/rgb_to_hsv
+  dh_db = dh_db / 360
 
   # Gradients wrt to inputs
   dv_drgb = array_ops.stack([grad[..., 2] * dv_dr,
@@ -369,5 +378,4 @@ def _RGBToHSVGrad(op, grad):
                              grad[..., 0] * dh_db], axis=-1)
 
   gradient_input = math_ops.add(math_ops.add(dv_drgb, ds_drgb), dh_drgb)
-
   return gradient_input

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -276,6 +276,11 @@ def _rgb_to_hsv_grad(op, grad):
   dh_db_5 = 60 * (cast(greens > 0, dtypes.float32) * green_biggest * red_smallest * _custom_reciprocal(greens - reds))
 
   dh_db = dh_db_1 + dh_db_2 + dh_db_3 + dh_db_4 + dh_db_5
+  # Gradients wrt to inputs
+  dv_drgb = stack([grad[...,2] * dv_dr, grad[...,2] * dv_dg, grad[...,2] * dv_db], axis=-1)
+  ds_drgb = stack([grad[...,1] * ds_dr, grad[...,1] * ds_dg, grad[...,1] * ds_db], axis=-1)
+  dh_drgb = stack([grad[...,0] * dh_dr, grad[...,0] * dh_dg, grad[...,0] * dh_db], axis=-1)
 
+  gradient_input = add(add(dv_drgb, ds_drgb), dh_drgb)
 
-  return None
+  return gradient_input

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -286,7 +286,7 @@ def _rgb_to_hsv_grad(op, grad):
   dh_db_1 = 60 * (cast(blues > 0, dtypes.float32) * blue_biggest * -1 * (reds - greens) * _custom_reciprocal(square(saturation)) * _custom_reciprocal(square(value)))
   dh_db_2 = 60 * (cast(reds > 0, dtypes.float32) * red_biggest * blue_smallest * (greens - reds) * _custom_reciprocal(square(reds - blues)))
   dh_db_3 = 60 * (cast(reds > 0, dtypes.float32) * red_biggest * green_smallest * -1 * _custom_reciprocal(reds - greens))
-  dh_db_4 = 60 * (cast(greens > 0, dtypes.float32) * green_biggest * blue_smallest * (greens - reds) * _custom_reciprocal(square(greebs - blues)))
+  dh_db_4 = 60 * (cast(greens > 0, dtypes.float32) * green_biggest * blue_smallest * (greens - reds) * _custom_reciprocal(square(greens - blues)))
   dh_db_5 = 60 * (cast(greens > 0, dtypes.float32) * green_biggest * red_smallest * _custom_reciprocal(greens - reds))
 
   dh_db = dh_db_1 + dh_db_2 + dh_db_3 + dh_db_4 + dh_db_5

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -153,3 +153,40 @@ def _CropAndResizeGrad(op, grad):
       grad, op.inputs[0], op.inputs[1], op.inputs[2])
 
   return [grad0, grad1, None, None]
+
+@ops.RegisterGradient("RGBToHSV")
+def _rgb_to_hsv_grad(op, grad):
+  """The gradients for `zero_out`.
+
+  Args:
+    op: The `rgb_to_hsv` `Operation` that we are differentiating, which we can use
+      to find the inputs and outputs of the original op.
+    grad: Gradient with respect to the output of the `rgb_to_hsv` op.
+
+  Returns:
+    Gradients with respect to the input of `rgb_to_hsv`.
+  """
+  print("******** This is a test implementation ********** \n")
+    
+  # Input Channels
+  reds = op.inputs[0][..., 0]
+  greens = op.inputs[0][..., 1]
+  blues = op.inputs[0][..., 2]
+  # Output Channels
+  hue = op.outputs[0][..., 0]
+  saturation = op.outputs[0][..., 1]
+  value = op.outputs[0][..., 2]
+
+  # Mask/Indicator for max and min values of each pixel. Arbitrary assignment in case 
+  # of tie breakers with R>G>B.
+  # Max values
+  red_biggest = cast((reds >= blues) & (reds >= greens), dtypes.float32)
+  green_biggest = cast((greens > reds) & (greens >= blues), dtypes.float32)
+  blue_biggest = cast((blues > reds) & (blues > greens), dtypes.float32)
+  # Min values
+  red_smallest = cast((reds < blues) & (reds < greens), dtypes.float32)
+  green_smallest = cast((greens <= reds) & (greens < blues), dtypes.float32)
+  blue_smallest = cast((blues <= reds) & (blues <= greens), dtypes.float32)
+
+
+  return None

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -170,18 +170,20 @@ def _CustomReciprocal(x, my_eps=1e-10):
 
 @ops.RegisterGradient("RGBToHSV")
 def _RGBToHSVGrad(op, grad):
-  """The gradients for `zero_out`.
+  """The gradients for `rgb_to_hsv` operation.
+  This function is a piecewise continuous function as defined here:
+  https://en.wikipedia.org/wiki/HSL_and_HSV#From_RGB
+  We perform the multi variate derivative and compute all partial derivates
+  seperately before adding them in the end. Formulas are given before each 
+  partial derivative calculation.
 
   Args:
-    op: The `rgb_to_hsv` `Operation` that we are differentiating,
-      which we can use
-      to find the inputs and outputs of the original op.
+    op: The `rgb_to_hsv` `Operation` that we are differentiating.
     grad: Gradient with respect to the output of the `rgb_to_hsv` op.
 
   Returns:
     Gradients with respect to the input of `rgb_to_hsv`.
   """
-  print("******** This is a test implementation ********** \n")
   # Input Channels
   reds = op.inputs[0][..., 0]
   greens = op.inputs[0][..., 1]

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -174,7 +174,7 @@ def _RGBToHSVGrad(op, grad):
   This function is a piecewise continuous function as defined here:
   https://en.wikipedia.org/wiki/HSL_and_HSV#From_RGB
   We perform the multi variate derivative and compute all partial derivates
-  seperately before adding them in the end. Formulas are given before each 
+  seperately before adding them in the end. Formulas are given before each
   partial derivative calculation.
 
   Args:

--- a/tensorflow/python/ops/image_grad_test.py
+++ b/tensorflow/python/ops/image_grad_test.py
@@ -29,7 +29,8 @@ from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import image_ops
 from tensorflow.python.ops import gen_image_ops
 from tensorflow.python.platform import test
-
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import array_ops
 
 @test_util.for_all_test_methods(test_util.disable_xla,
                                 'align_corners=False not supported by XLA')
@@ -477,19 +478,71 @@ class RGBToHSVOpTest(test.TestCase):
         hsv_out = self.evaluate(hsv_out)
       self.assertEqual(out_shape, list(hsv_out.shape))
 
-  def testRGBToHSVGrad(self):
-    in_shape = [2, 20, 30, 3]
+  def testRGBToHSVGradSimpleCase(self):
+
     def f(x):
       return gen_image_ops.rgb_to_hsv(x)
 
-    x = np.random.rand(2, 20, 30, 3).astype(np.float32)
-    rgb_input_tensor = constant_op.constant(x, shape=in_shape)
+    # Building a simple input tensor to avoid any discontinuity
+    x = np.array(
+        [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]).astype(np.float32)
+    rgb_input_tensor = constant_op.constant(x, shape=x.shape)
+    # Computing Analytical and Numerical gradients of f(x)
     analytical, numerical = gradient_checker_v2.compute_gradient(
         f, [rgb_input_tensor])
+    self.assertAllClose(numerical, analytical, atol=1e-4)
+
+  def testRGBToHSVGradRandomCase(self):
+
+    def f(x):
+      return gen_image_ops.rgb_to_hsv(x)
+    np.random.seed(0)
+    # Building a simple input tensor to avoid any discontinuity
+    x = np.random.rand(1, 5, 5, 3).astype(np.float32)
+    rgb_input_tensor = constant_op.constant(x, shape=x.shape)
+    # Computing Analytical and Numerical gradients of f(x)
     self.assertLess(
-        gradient_checker_v2.max_error(analytical, numerical), 1e-2)
+        gradient_checker_v2.max_error(*gradient_checker_v2.compute_gradient(
+            f, [rgb_input_tensor])), 1e-4)
 
+  def testRGBToHSVGradSpecialCaseRGreatest(self):
+    # This test tests a specific subset of the input space
+    # with a dummy function implemented with native TF operations.
+    in_shape = [2, 10, 20, 3]
+    def f(x):
+      return gen_image_ops.rgb_to_hsv(x)
 
+    def f_dummy(x):
+      # This dummy function is a implementation of RGB to HSV using
+      # primitive TF functions for one particular case when R>G>B.
+      r = x[..., 0]
+      g = x[..., 1]
+      b = x[..., 2]
+      # Since MAX = r and MIN = b, we get the following h,s,v values.
+      v = r
+      s = 1 - math_ops.div_no_nan(b, r)
+      h = 60 * math_ops.div_no_nan(g - b, r - b)
+      h = h/360
+      return array_ops.stack([h, s, v], axis=-1)
+
+    # Building a custom input tensor where R>G>B
+    x_reds = np.ones((in_shape[0], in_shape[1], in_shape[2])).astype(np.float32)
+    x_greens = 0.5 * np.ones(
+        (in_shape[0], in_shape[1], in_shape[2])).astype(np.float32)
+    x_blues = 0.2 * np.ones(
+        (in_shape[0], in_shape[1], in_shape[2])).astype(np.float32)
+    x = np.stack([x_reds, x_greens, x_blues], axis=-1)
+    rgb_input_tensor = constant_op.constant(x, shape=in_shape)
+
+    # Computing Analytical and Numerical gradients of f(x)
+    analytical, numerical = gradient_checker_v2.compute_gradient(
+        f, [rgb_input_tensor])
+    # Computing Analytical and Numerical gradients of f_dummy(x)
+    analytical_dummy, numerical_dummy = gradient_checker_v2.compute_gradient(
+        f_dummy, [rgb_input_tensor])
+    self.assertAllClose(numerical, analytical, atol=1e-4)
+    self.assertAllClose(analytical_dummy, analytical, atol=1e-4)
+    self.assertAllClose(numerical_dummy, numerical, atol=1e-4)
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -43,9 +43,6 @@ from tensorflow.python.util.tf_export import tf_export
 ops.NotDifferentiable('RandomCrop')
 # TODO(b/31222613): This op may be differentiable, and there may be
 # latent bugs here.
-ops.NotDifferentiable('RGBToHSV')
-# TODO(b/31222613): This op may be differentiable, and there may be
-# latent bugs here.
 ops.NotDifferentiable('HSVToRGB')
 ops.NotDifferentiable('DrawBoundingBoxes')
 ops.NotDifferentiable('SampleDistortedBoundingBox')


### PR DESCRIPTION
Hello, 

This PR implements the gradient for RGB to HSV operation which was marked as a [TODO](https://github.com/tensorflow/tensorflow/blob/08082cdab025ff095001e42839d3efbf9cd45a8e/tensorflow/python/ops/image_ops_impl.py#L46). The function is piecewise continuous and has a lot of sub-cases (with MAX() and MIN()) so the derivative calculation tends to get a bit complicated. I have left as much comments as possible in the code to explain the derivative calculations but I'd be glad to add something else if needed (i have a lot of whiteboard/pen-and-paper notes on this derivation!). 

I tried to add a test case to `tensorflow/python/ops/image_grad_test.py`, but I wasn't sure if that file is actually a real test file as I didn't find any bazel linakges. Most of the other functions in that file also seem to be using deprecated gradient functions which aren't part of TF2.0 so I wanted to first check here before I add any test(s) to the wrong file. 
