### PR TITLE
Add a missing header file to MICROLITE_CC_HDRS.

### DIFF
--- a/tensorflow/lite/experimental/micro/tools/make/Makefile
+++ b/tensorflow/lite/experimental/micro/tools/make/Makefile
@@ -105,6 +105,7 @@ tensorflow/lite/kernels/kernel_util.h \
 tensorflow/lite/kernels/op_macros.h \
 tensorflow/lite/kernels/padding.h \
 tensorflow/lite/kernels/internal/common.h \
+tensorflow/lite/kernels/internal/compatibility.h \
 tensorflow/lite/kernels/internal/optimized/neon_check.h \
 tensorflow/lite/kernels/internal/reference/conv.h \
 tensorflow/lite/kernels/internal/reference/depthwiseconv_float.h \


### PR DESCRIPTION
When running

$ make -f tensorflow/lite/experimental/micro/tools/make/Makefile generate_projects

the kernel tests fails to compile for mbed since tensorflow/lite/kernels/internal/compatibility.h is missing from the header list in the Makefile.

This PR adds that file to the list of headers.