### PR TITLE
[INTEL MKL] Adding a build flag to enable MKL-DNN v1.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,6 +40,7 @@ build:mkl -c opt
 # This config option is used to enable MKL-DNN open source library only,
 # without depending on MKL binary version.
 build:mkl_open_source_only --define=build_with_mkl_dnn_only=true
+build:mkl_open_source_only --define=build_with_mkl_dnn_v1_only=true
 build:mkl_open_source_only --define=build_with_mkl=true --define=enable_mkl=true
 build:mkl_open_source_only --define=tensorflow_mkldnn_contraction_kernel=0
 

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -44,6 +44,7 @@ load(
 load(
     "//third_party/mkl_dnn:build_defs.bzl",
     "if_mkl_open_source_only",
+    "if_mkl_v1_open_source_only",
 )
 load(
     "//third_party/ngraph:build_defs.bzl",
@@ -292,6 +293,7 @@ def tf_copts(android_optimization_level_override = "-O2", is_external = False):
         if_tensorrt(["-DGOOGLE_TENSORRT=1"]) +
         if_mkl(["-DINTEL_MKL=1", "-DEIGEN_USE_VML"]) +
         if_mkl_open_source_only(["-DINTEL_MKL_DNN_ONLY"]) +
+        if_mkl_v1_open_source_only(["-DENABLE_MKLDNN_v1"]) +
         if_enable_mkl(["-DENABLE_MKL"]) +
         if_ngraph(["-DINTEL_NGRAPH=1"]) +
         if_mkl_lnx_x64(["-fopenmp"]) +

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -293,7 +293,7 @@ def tf_copts(android_optimization_level_override = "-O2", is_external = False):
         if_tensorrt(["-DGOOGLE_TENSORRT=1"]) +
         if_mkl(["-DINTEL_MKL=1", "-DEIGEN_USE_VML"]) +
         if_mkl_open_source_only(["-DINTEL_MKL_DNN_ONLY"]) +
-        if_mkl_v1_open_source_only(["-DENABLE_MKLDNN_v1"]) +
+        if_mkl_v1_open_source_only(["-DENABLE_MKLDNN_V1"]) +
         if_enable_mkl(["-DENABLE_MKL"]) +
         if_ngraph(["-DINTEL_NGRAPH=1"]) +
         if_mkl_lnx_x64(["-fopenmp"]) +

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -140,6 +140,17 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     )
 
     tf_http_archive(
+        name = "mkl_dnn_v1",
+        build_file = clean_dep("//third_party/mkl_dnn:mkldnn.BUILD"),
+        sha256 = "fcc2d951f7170eade0cfdd0d8d1d58e3e7785bd326bca6555f3722f8cba71811",
+        strip_prefix = "mkl-dnn-1.0-pc2",
+        urls = [
+            "http://mirror.tensorflow.org/github.com/intel/mkl-dnn/archive/v1.0-pc2.tar.gz",
+            "https://github.com/intel/mkl-dnn/archive/v1.0-pc2.tar.gz",
+        ],
+    )
+
+    tf_http_archive(
         name = "com_google_absl",
         build_file = clean_dep("//third_party:com_google_absl.BUILD"),
         sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",

--- a/third_party/mkl/build_defs.bzl
+++ b/third_party/mkl/build_defs.bzl
@@ -107,6 +107,7 @@ def mkl_deps():
     """
     return select({
         str(Label("//third_party/mkl_dnn:build_with_mkl_dnn_only")): ["@mkl_dnn"],
+        str(Label("//third_party/mkl_dnn:build_with_mkl_dnn_v1_only")): ["@mkl_dnn_v1"],
         str(Label("//third_party/mkl:build_with_mkl_ml_only")): ["//third_party/mkl:intel_binary_blob"],
         str(Label("//third_party/mkl:build_with_mkl")): [
             "//third_party/mkl:intel_binary_blob",

--- a/third_party/mkl/build_defs.bzl
+++ b/third_party/mkl/build_defs.bzl
@@ -107,7 +107,7 @@ def mkl_deps():
     """
     return select({
         str(Label("//third_party/mkl_dnn:build_with_mkl_dnn_only")): ["@mkl_dnn"],
-        str(Label("//third_party/mkl_dnn:build_with_mkl_dnn_v1_only")): ["@mkl_dnn_v1"],
+        str(Label("//third_party/mkl_dnn:build_with_mkl_dnn_v1_only")): ["@mkl_dnn_v1//:mkl_dnn"],
         str(Label("//third_party/mkl:build_with_mkl_ml_only")): ["//third_party/mkl:intel_binary_blob"],
         str(Label("//third_party/mkl:build_with_mkl")): [
             "//third_party/mkl:intel_binary_blob",

--- a/third_party/mkl_dnn/BUILD
+++ b/third_party/mkl_dnn/BUILD
@@ -10,3 +10,12 @@ config_setting(
     },
     visibility = ["//visibility:public"],
 )
+
+config_setting(
+    name = "build_with_mkl_dnn_v1_only",
+    define_values = {
+        "build_with_mkl": "true",
+        "build_with_mkl_dnn_v1_only": "true",
+    },
+    visibility = ["//visibility:public"],
+)

--- a/third_party/mkl_dnn/build_defs.bzl
+++ b/third_party/mkl_dnn/build_defs.bzl
@@ -1,13 +1,27 @@
 def if_mkl_open_source_only(if_true, if_false = []):
     """Shorthand for select()'ing on whether we're building with
-    MKL-DNN open source lib only, without depending on MKL binary form.
+    MKL-DNN v0.x open source library only, without depending on MKL binary form.
 
     Returns a select statement which evaluates to if_true if we're building
-    with MKL-DNN open source lib only. Otherwise,
-    the select statement evaluates to if_false.
+    with MKL-DNN v0.x open source library only. Otherwise, the select statement
+    evaluates to if_false.
 
     """
     return select({
         str(Label("//third_party/mkl_dnn:build_with_mkl_dnn_only")): if_true,
+        "//conditions:default": if_false,
+    })
+
+def if_mkl_v1_open_source_only(if_true, if_false = []):
+    """Shorthand for select()'ing on whether we're building with MKL-DNN v1.x
+    (and v0.x) open source library only, without depending on MKL binary form.
+
+    Returns a select statement which evaluates to if_true if we're building
+    with MKL-DNN v1.x (and v0.x) open source library only. Otherwise, the
+    select statement evaluates to if_false.
+
+    """
+    return select({
+        str(Label("//third_party/mkl_dnn:build_with_mkl_dnn_v1_only")): if_true,
         "//conditions:default": if_false,
     })

--- a/third_party/mkl_dnn/build_defs.bzl
+++ b/third_party/mkl_dnn/build_defs.bzl
@@ -13,11 +13,11 @@ def if_mkl_open_source_only(if_true, if_false = []):
     })
 
 def if_mkl_v1_open_source_only(if_true, if_false = []):
-    """Shorthand for select()'ing on whether we're building with MKL-DNN v1.x
-    (and v0.x) open source library only, without depending on MKL binary form.
+    """Shorthand for select()'ing on whether we're building with
+    MKL-DNN v1.x open source library only, without depending on MKL binary form.
 
     Returns a select statement which evaluates to if_true if we're building
-    with MKL-DNN v1.x (and v0.x) open source library only. Otherwise, the
+    with MKL-DNN v1.x open source library only. Otherwise, the
     select statement evaluates to if_false.
 
     """

--- a/third_party/mkl_dnn/build_defs.bzl
+++ b/third_party/mkl_dnn/build_defs.bzl
@@ -1,5 +1,7 @@
 def if_mkl_open_source_only(if_true, if_false = []):
-    """Shorthand for select()'ing on whether we're building with
+    """Returns `if_true` if MKL-DNN v0.x is used.
+
+    Shorthand for select()'ing on whether we're building with
     MKL-DNN v0.x open source library only, without depending on MKL binary form.
 
     Returns a select statement which evaluates to if_true if we're building
@@ -13,7 +15,9 @@ def if_mkl_open_source_only(if_true, if_false = []):
     })
 
 def if_mkl_v1_open_source_only(if_true, if_false = []):
-    """Shorthand for select()'ing on whether we're building with
+    """Returns `if_true` if MKL-DNN v1.x is used.
+
+    Shorthand for select()'ing on whether we're building with
     MKL-DNN v1.x open source library only, without depending on MKL binary form.
 
     Returns a select statement which evaluates to if_true if we're building

--- a/third_party/mkl_dnn/mkldnn.BUILD
+++ b/third_party/mkl_dnn/mkldnn.BUILD
@@ -34,6 +34,7 @@ template_rule(
 # set to "version_major.version_minor.version_patch". The git hash version can
 # be set to NA.
 # TODO(agramesh1) Automatically get the version numbers from CMakeLists.txt.
+# TODO(bhavanis): MKL-DNN version needs to be updated for MKL-DNN v1.x
 
 template_rule(
     name = "mkldnn_version_h",
@@ -42,20 +43,6 @@ template_rule(
     substitutions = {
         "@MKLDNN_VERSION_MAJOR@": "0",
         "@MKLDNN_VERSION_MINOR@": "18",
-        "@MKLDNN_VERSION_PATCH@": "0",
-        "@MKLDNN_VERSION_HASH@": "N/A",
-    },
-)
-
-# TODO(bhavanis): Once we automatically get version numbers from CMakeLists.txt,
-# the following template rule needs to be removed.
-template_rule(
-    name = "mkldnn_v1_version_h",
-    src = "include/mkldnn_version.h.in",
-    out = "include/mkldnn_version.h",
-    substitutions = {
-        "@MKLDNN_VERSION_MAJOR@": "0",
-        "@MKLDNN_VERSION_MINOR@": "95",
         "@MKLDNN_VERSION_PATCH@": "0",
         "@MKLDNN_VERSION_HASH@": "N/A",
     },
@@ -141,7 +128,7 @@ cc_library(
         "src/cpu/rnn/*.hpp",
         "src/cpu/xbyak/*.h",
     ]) + [
-        ":mkldnn_v1_version_h",  # newly added
+        ":mkldnn_version_h",
         ":mkldnn_config_h",  # newly added
     ],
     hdrs = glob(["include/*"]),

--- a/third_party/mkl_dnn/mkldnn.BUILD
+++ b/third_party/mkl_dnn/mkldnn.BUILD
@@ -67,9 +67,9 @@ cc_library(
         "src/cpu/rnn/*.hpp",
         "src/cpu/xbyak/*.h",
     ]) + if_mkl_v1_open_source_only([
+        ":mkldnn_config_h",
         "src/cpu/jit_utils/jit_utils.cpp",
         "src/cpu/jit_utils/jit_utils.hpp",
-        ":mkldnn_config_h",
     ]) + [":mkldnn_version_h"],
     hdrs = glob(["include/*"]),
     copts = [

--- a/third_party/mkl_dnn/mkldnn.BUILD
+++ b/third_party/mkl_dnn/mkldnn.BUILD
@@ -17,6 +17,16 @@ config_setting(
     },
 )
 
+template_rule(
+    name = "mkldnn_config_h",
+    src = "include/mkldnn_config.h.in",
+    out = "include/mkldnn_config.h",
+    substitutions = {
+        "#cmakedefine MKLDNN_CPU_BACKEND MKLDNN_BACKEND_${MKLDNN_CPU_BACKEND}": "#define MKLDNN_CPU_BACKEND MKLDNN_BACKEND_NATIVE",
+        "#cmakedefine MKLDNN_GPU_BACKEND MKLDNN_BACKEND_${MKLDNN_GPU_BACKEND}": "#define MKLDNN_GPU_BACKEND MKLDNN_BACKEND_NONE",
+    },
+)
+
 # Create the file mkldnn_version.h with MKL-DNN version numbers.
 # Currently, the version numbers are hard coded here. If MKL-DNN is upgraded then
 # the version numbers have to be updated manually. The version numbers can be
@@ -32,6 +42,20 @@ template_rule(
     substitutions = {
         "@MKLDNN_VERSION_MAJOR@": "0",
         "@MKLDNN_VERSION_MINOR@": "18",
+        "@MKLDNN_VERSION_PATCH@": "0",
+        "@MKLDNN_VERSION_HASH@": "N/A",
+    },
+)
+
+# TODO(bhavanis): Once we automatically get version numbers from CMakeLists.txt,
+# the following template rule needs to be removed.
+template_rule(
+    name = "mkldnn_v1_version_h",
+    src = "include/mkldnn_version.h.in",
+    out = "include/mkldnn_version.h",
+    substitutions = {
+        "@MKLDNN_VERSION_MAJOR@": "0",
+        "@MKLDNN_VERSION_MINOR@": "95",
         "@MKLDNN_VERSION_PATCH@": "0",
         "@MKLDNN_VERSION_HASH@": "N/A",
     },
@@ -54,6 +78,72 @@ cc_library(
         "src/cpu/rnn/*.hpp",
         "src/cpu/xbyak/*.h",
     ]) + [":mkldnn_version_h"],
+    hdrs = glob(["include/*"]),
+    copts = [
+        "-fexceptions",
+        "-DUSE_MKL",
+        "-DUSE_CBLAS",
+    ] + if_mkl_open_source_only([
+        "-UUSE_MKL",
+        "-UUSE_CBLAS",
+    ]) + select({
+        "@org_tensorflow//tensorflow:linux_x86_64": [
+            "-fopenmp",  # only works with gcc
+        ],
+        # TODO(ibiryukov): enable openmp with clang by including libomp as a
+        # dependency.
+        ":clang_linux_x86_64": [],
+        "//conditions:default": [],
+    }),
+    includes = [
+        "include",
+        "src",
+        "src/common",
+        "src/cpu",
+        "src/cpu/gemm",
+        "src/cpu/xbyak",
+    ],
+    nocopts = "-fno-exceptions",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@org_tensorflow//tensorflow:linux_x86_64": [
+            "@mkl_linux//:mkl_headers",
+            "@mkl_linux//:mkl_libs_linux",
+        ],
+        "@org_tensorflow//tensorflow:macos": [
+            "@mkl_darwin//:mkl_headers",
+            "@mkl_darwin//:mkl_libs_darwin",
+        ],
+        "@org_tensorflow//tensorflow:windows": [
+            "@mkl_windows//:mkl_headers",
+            "@mkl_windows//:mkl_libs_windows",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "mkl_dnn_v1",
+    srcs = glob([
+        "src/common/*.cpp",
+        "src/common/*.hpp",
+        "src/cpu/*.cpp",
+        "src/cpu/*.hpp",
+        "src/cpu/gemm/*.cpp",
+        "src/cpu/gemm/*.hpp",
+        "src/cpu/gemm/f32/*.cpp",
+        "src/cpu/gemm/f32/*.hpp",
+        "src/cpu/gemm/s8x8s32/*.cpp",
+        "src/cpu/gemm/s8x8s32/*.hpp",
+        "src/cpu/jit_utils/*.cpp",  # newly added
+        "src/cpu/jit_utils/*.hpp",  # newly added
+        "src/cpu/rnn/*.cpp",
+        "src/cpu/rnn/*.hpp",
+        "src/cpu/xbyak/*.h",
+    ]) + [
+        ":mkldnn_v1_version_h",  # newly added
+        ":mkldnn_config_h",  # newly added
+    ],
     hdrs = glob(["include/*"]),
     copts = [
         "-fexceptions",

--- a/third_party/mkl_dnn/mkldnn.BUILD
+++ b/third_party/mkl_dnn/mkldnn.BUILD
@@ -35,7 +35,8 @@ template_rule(
 # set to "version_major.version_minor.version_patch". The git hash version can
 # be set to NA.
 # TODO(agramesh1) Automatically get the version numbers from CMakeLists.txt.
-# TODO(bhavanis): MKL-DNN version needs to be updated for MKL-DNN v1.x
+# TODO(bhavanis): MKL-DNN minor version needs to be updated for MKL-DNN v1.x.
+# The current version numbers will work only if MKL-DNN v0.18 is used.
 
 template_rule(
     name = "mkldnn_version_h",
@@ -68,9 +69,8 @@ cc_library(
     ]) + if_mkl_v1_open_source_only([
         "src/cpu/jit_utils/jit_utils.cpp",
         "src/cpu/jit_utils/jit_utils.hpp",
-    ]) + [":mkldnn_version_h"] + if_mkl_v1_open_source_only([
         ":mkldnn_config_h",
-    ]),
+    ]) + [":mkldnn_version_h"],
     hdrs = glob(["include/*"]),
     copts = [
         "-fexceptions",


### PR DESCRIPTION
When TF-MKL is built with `--define build_with_mkl_dnn_v1_only=true` option, MKL-DNN v1.0 binary will be installed. Otherwise, the default v0.x binary will be used.