### PR TITLE
Fix macos makefile build

### DIFF
--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -909,11 +909,17 @@ $(PROTO_TEXT_OBJS) : $(PROTO_TEXT_PB_H_FILES)
 
 # Ensures we link CoreFoundation as it is used for time library when building
 # for Mac.
+ifeq ($(TARGET),OSX)
+  HOST_LDOPTS += -framework CoreFoundation
+  LIBS += -framework CoreFoundation
+endif
 ifeq ($(TARGET),IOS)
   ifeq ($(IOS_ARCH),X86_64)
     HOST_LDOPTS += -framework CoreFoundation
   endif
 endif
+
+
 
 # Runs proto_text to generate C++ source files from protos.
 $(PROTO_TEXT): $(PROTO_TEXT_OBJS) $(PROTO_TEXT_PB_H_FILES)


### PR DESCRIPTION
- Adding `CoreFoundation` to `HOST_LDFLAGS` is necessary as the library target uses that variable
- Adding `CoreFoundation` to `LIBS` is necessary as the benchmark target uses that variable