### PR TITLE
[XLA] Add required header

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_verifier_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_verifier_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <memory>
 #include <utility>
 
+#include "absl/strings/str_replace.h"
 #include "tensorflow/compiler/xla/service/hlo_computation.h"
 #include "tensorflow/compiler/xla/service/hlo_instruction.h"
 #include "tensorflow/compiler/xla/service/hlo_module_config.h"
@@ -31,8 +32,6 @@ limitations under the License.
 #include "tensorflow/compiler/xla/xla.pb.h"
 #include "tensorflow/compiler/xla/xla_data.pb.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
-
-#include "absl/strings/str_replace.h"
 
 namespace xla {
 namespace {

--- a/tensorflow/compiler/xla/service/hlo_verifier_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_verifier_test.cc
@@ -32,6 +32,8 @@ limitations under the License.
 #include "tensorflow/compiler/xla/xla_data.pb.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
 
+#include "absl/strings/str_replace.h"
+
 namespace xla {
 namespace {
 


### PR DESCRIPTION
For me, the master branch fails to build with this header not explicitly included in the source file.  I'm not sure where the transitive inclusion occurs for the main CI system.  Perhaps it is better to avoid relying on transitive inclusions anyway.

