### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build

### DIFF
--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -608,6 +608,7 @@ typedef AutoTuneSingleton<ConvAutoTuneGroup, ConvParameters,
                           se::dnn::AlgorithmConfig>
     AutoTuneConv;
 
+#if GOOGLE_CUDA
 // Check the passed allocator for redzone violations.
 // If violations have occurred, mark the corresponding autotune result
 // as a failure.
@@ -646,6 +647,7 @@ static void CheckRedzones(const se::cuda::RedzoneAllocator& rz_allocator,
     LOG(ERROR) << rz_check_status.RedzoneFailureMsg();
   }
 }
+#endif
 
 template <typename T>
 void LaunchConv2DOp<GPUDevice, T>::operator()(


### PR DESCRIPTION
The following commit broken the `--config=rocm` build when it was merged
https://github.com/tensorflow/tensorflow/commit/b7d4805838a64e6a33135b19281345032c400f56#diff-f9ae051d576c85eab133e77af84c1937

The "CheckRedzones" routine (in file conv_ops.cc) has CUDA specific code, and hence results in a compile error when building TF with ROCm support. That routine was added while the above commit/PR (which enables ROCm support for convolution ops) was being reviewed, and the combination of the two changes leads to the compile error.

The "fix" is to make the "CheckRedzone" routine visible only in the TF build with CUDA support.

--------------------------------------------------

@tatianashp @whchung @chsigg 