### PR TITLE
1.14.1 cherry-pick request: Add contents of wrapped module __dict__ to DeprecationWrapper __dict__.

### DIFF
--- a/tensorflow/python/util/deprecation_wrapper.py
+++ b/tensorflow/python/util/deprecation_wrapper.py
@@ -31,7 +31,7 @@ from tensorflow.python.util import tf_stack
 from tensorflow.tools.compatibility import all_renames_v2
 
 
-_PER_MODULE_WARNING_LIMIT = 5
+_PER_MODULE_WARNING_LIMIT = 1
 
 
 def get_rename_v2(name):
@@ -86,26 +86,26 @@ class DeprecationWrapper(types.ModuleType):
   # TODO(annarev): remove unused_depr_to_canonical once estimator stops
   # passing it in the next nightly build.
   def __init__(self, wrapped, module_name, unused_depr_to_canonical=None):  # pylint: disable=super-on-old-class
+    super(DeprecationWrapper, self).__init__(wrapped.__name__)
+    self.__dict__.update(wrapped.__dict__)
     # Prefix all local attributes with _dw_ so that we can
     # handle them differently in attribute access methods.
     self._dw_wrapped_module = wrapped
     self._dw_module_name = module_name
-    self._dw_deprecated_printed = set()  # names we already printed warning for
-    self.__file__ = wrapped.__file__
-    self.__name__ = wrapped.__name__
-    if hasattr(self._dw_wrapped_module, '__all__'):
-      self.__all__ = self._dw_wrapped_module.__all__
-    else:
-      self.__all__ = dir(self._dw_wrapped_module)
+    # names we already checked for deprecation
+    self._dw_deprecated_checked = set()
     self._dw_warning_count = 0
-    super(DeprecationWrapper, self).__init__(wrapped.__name__)
 
-  def __getattr__(self, name):
-    if name.startswith('_dw_'):
-      raise AttributeError('Accessing local variables before they are created.')
-    attr = getattr(self._dw_wrapped_module, name)
+  def __getattribute__(self, name):  # pylint: disable=super-on-old-class
+    attr = super(DeprecationWrapper, self).__getattribute__(name)
+    if name.startswith('__') or name.startswith('_dw_'):
+      return attr
+
     if (self._dw_warning_count < _PER_MODULE_WARNING_LIMIT and
-        name not in self._dw_deprecated_printed):
+        name not in self._dw_deprecated_checked):
+
+      self._dw_deprecated_checked.add(name)
+
       if self._dw_module_name:
         full_name = 'tf.%s.%s' % (self._dw_module_name, name)
       else:
@@ -117,7 +117,6 @@ class DeprecationWrapper(types.ModuleType):
           logging.warning(
               'From %s: The name %s is deprecated. Please use %s instead.\n',
               _call_location(), full_name, rename)
-          self._dw_deprecated_printed.add(name)
           self._dw_warning_count += 1
     return attr
 
@@ -126,6 +125,7 @@ class DeprecationWrapper(types.ModuleType):
       super(DeprecationWrapper, self).__setattr__(arg, val)
     else:
       setattr(self._dw_wrapped_module, arg, val)
+      self.__dict__[arg] = val
 
   def __dir__(self):
     return dir(self._dw_wrapped_module)

--- a/tensorflow/python/util/deprecation_wrapper.py
+++ b/tensorflow/python/util/deprecation_wrapper.py
@@ -120,22 +120,6 @@ class DeprecationWrapper(types.ModuleType):
           self._dw_warning_count += 1
     return attr
 
-  def __setattr__(self, arg, val):  # pylint: disable=super-on-old-class
-    if arg.startswith('_dw_'):
-      super(DeprecationWrapper, self).__setattr__(arg, val)
-    else:
-      setattr(self._dw_wrapped_module, arg, val)
-      self.__dict__[arg] = val
-
-  def __dir__(self):
-    return dir(self._dw_wrapped_module)
-
-  def __delattr__(self, name):  # pylint: disable=super-on-old-class
-    if name.startswith('_dw_'):
-      super(DeprecationWrapper, self).__delattr__(name)
-    else:
-      delattr(self._dw_wrapped_module, name)
-
   def __repr__(self):
     return self._dw_wrapped_module.__repr__()
 

--- a/tensorflow/python/util/deprecation_wrapper_test.py
+++ b/tensorflow/python/util/deprecation_wrapper_test.py
@@ -27,9 +27,11 @@ from tensorflow.python.util import deprecation_wrapper
 from tensorflow.python.util import tf_inspect
 from tensorflow.tools.compatibility import all_renames_v2
 
+deprecation_wrapper._PER_MODULE_WARNING_LIMIT = 5
+
 
 class MockModule(types.ModuleType):
-  __file__ = 'test.py'
+  pass
 
 
 class DeprecationWrapperTest(test.TestCase):

--- a/tensorflow/tools/api/tests/BUILD
+++ b/tensorflow/tools/api/tests/BUILD
@@ -58,6 +58,17 @@ py_test(
     ],
 )
 
+py_test(
+    name = "module_test",
+    srcs = ["module_test.py"],
+    python_version = "PY3",
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorflow:tensorflow_py",
+        "//tensorflow/python:client_testlib",
+    ],
+)
+
 tf_cc_binary(
     name = "convert_from_multiline",
     srcs = ["convert_from_multiline.cc"],

--- a/tensorflow/tools/api/tests/deprecation_test.py
+++ b/tensorflow/tools/api/tests/deprecation_test.py
@@ -24,6 +24,9 @@ import tensorflow as tf
 
 from tensorflow.python.platform import test
 from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.util import deprecation_wrapper
+
+deprecation_wrapper._PER_MODULE_WARNING_LIMIT = 5
 
 
 class DeprecationTest(test.TestCase):

--- a/tensorflow/tools/api/tests/module_test.py
+++ b/tensorflow/tools/api/tests/module_test.py
@@ -1,0 +1,50 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+"""Smoke tests for tensorflow module."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pkgutil
+
+import tensorflow as tf
+
+from tensorflow.python.platform import test
+
+
+class ModuleTest(test.TestCase):
+
+  def testCanLoadWithPkgutil(self):
+    out = pkgutil.find_loader('tensorflow')
+    self.assertIsNotNone(out)
+
+  def testDocString(self):
+    self.assertIn('TensorFlow', tf.__doc__)
+    self.assertNotIn('Wrapper', tf.__doc__)
+
+  def testDict(self):
+    # Check that a few modules are in __dict__.
+    self.assertIn('nn', tf.__dict__)
+    self.assertIn('keras', tf.__dict__)
+    self.assertIn('image', tf.__dict__)
+
+  def testName(self):
+    self.assertEqual('tensorflow', tf.__name__)
+
+
+if __name__ == '__main__':
+  test.main()


### PR DESCRIPTION
Cherrypick of https://github.com/tensorflow/tensorflow/commit/b789a3b37b59e6795f799645a6e8b1a6c70fc346

Add contents of wrapped module __dict__ to DeprecationWrapper __dict__.
Should fix the following two issues:
https://github.com/tensorflow/tensorflow/issues/30184,
https://github.com/tensorflow/tensorflow/issues/30028.

Also, while at it, reducing maximum deprecation warnings to 1 per module to reduce amount of spam.