### PR TITLE
issue 27543 workaround, allow model with inputs not used to be saved successfully

### DIFF
--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -401,6 +401,9 @@ def _packed_nest_with_indices(structure, flat, index, is_seq):
     else:
       packed.append(flat[index])
       index += 1
+      # workaround for issue 27543 to save model successfully when input is not used directly in model
+      if index > len(flat)-1:
+        break
   return index, packed
 
 


### PR DESCRIPTION
This is a workaround for #27543, allowing model with inputs not used to be saved successfully

I think this PR should also be merged to r1.14 and r2.0 branch, this issue does not exist before r1.14

```
import numpy as np

import tensorflow as tf
import tensorflow.keras as tfk
Sequence = tfk.utils.Sequence

Dense = tfk.layers.Dense
Input = tfk.layers.Input

Model = tfk.models.Model

def special_loss(weights):
    def special_loss_internal(true, pred):
        return (true - pred / weights)
    return special_loss_internal

# Model 1 which does not have Flatten
input_tensor1 = Input(shape=[200], name='input_1')
input_tensor2 = Input(shape=[10], name='input_2')
output_tensor1 = Dense(units=10, name='output_1')(input_tensor1)
output_tensor2 = Dense(units=10, name='output_2')(input_tensor1)

neuralnet = Model(inputs=[input_tensor1, input_tensor2], outputs=[output_tensor1, output_tensor2])
neuralnet.compile(loss=special_loss(input_tensor2), optimizer='adam')

neuralnet.save("test.h5")
```

which performs successfully with this patch.

and to load the `.h5` model back
```
import numpy as np

import tensorflow as tf
import tensorflow.keras as tfk
Sequence = tfk.utils.Sequence

Dense = tfk.layers.Dense
Input = tfk.layers.Input

Model = tfk.models.Model

def special_loss(weights):
    def special_loss_internal(true, pred):
        return (true - pred / weights)
    return special_loss_internal

# Model 1 which does not have Flatten
input_tensor1 = Input(shape=[200], name='input_1')
input_tensor2 = Input(shape=[10], name='input_2')
output_tensor1 = Dense(units=10, name='output_1')(input_tensor1)
output_tensor2 = Dense(units=10, name='output_2')(input_tensor1)

neuralnet = Model(inputs=[input_tensor1, input_tensor2], outputs=[output_tensor1, output_tensor2])
neuralnet.compile(loss=special_loss(input_tensor2), optimizer='adam')

model = neuralnet.load_weights('test.h5')
```

which also performs successfully with this patch.
