### PR TITLE
[docs] Fixes docs for weighted_cross_entropy_with_logits

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -330,9 +330,12 @@ def weighted_cross_entropy_with_logits(labels=None,
   This is like `sigmoid_cross_entropy_with_logits()` except that `pos_weight`,
   allows one to trade off recall and precision by up- or down-weighting the
   cost of a positive error relative to a negative error.
+
   The usual cross-entropy cost is defined as:
+
       labels * -log(sigmoid(logits)) +
           (1 - labels) * -log(1 - sigmoid(logits))
+
   A value `pos_weight > 1` decreases the false negative count, hence increasing
   the recall.
   Conversely setting `pos_weight < 1` decreases the false positive count and
@@ -340,20 +343,27 @@ def weighted_cross_entropy_with_logits(labels=None,
   This can be seen from the fact that `pos_weight` is introduced as a
   multiplicative coefficient for the positive labels term
   in the loss expression:
+
       labels * -log(sigmoid(logits)) * pos_weight +
           (1 - labels) * -log(1 - sigmoid(logits))
+
   For brevity, let `x = logits`, `z = labels`, `q = pos_weight`.
   The loss is:
+
         qz * -log(sigmoid(x)) + (1 - z) * -log(1 - sigmoid(x))
       = qz * -log(1 / (1 + exp(-x))) + (1 - z) * -log(exp(-x) / (1 + exp(-x)))
       = qz * log(1 + exp(-x)) + (1 - z) * (-log(exp(-x)) + log(1 + exp(-x)))
       = qz * log(1 + exp(-x)) + (1 - z) * (x + log(1 + exp(-x))
       = (1 - z) * x + (qz +  1 - z) * log(1 + exp(-x))
       = (1 - z) * x + (1 + (q - 1) * z) * log(1 + exp(-x))
+
   Setting `l = (1 + (q - 1) * z)`, to ensure stability and avoid overflow,
   the implementation uses
+
       (1 - z) * x + l * (log(1 + exp(-abs(x))) + max(-x, 0))
+
   `logits` and `labels` must have the same type and shape.
+
   Args:
     labels: A `Tensor` of the same type and shape as `logits`.
     logits: A `Tensor` of type `float32` or `float64`.
@@ -364,6 +374,7 @@ def weighted_cross_entropy_with_logits(labels=None,
   Returns:
     A `Tensor` of the same shape as `logits` with the componentwise
     weighted logistic losses.
+
   Raises:
     ValueError: If `logits` and `labels` do not have the same shape.
   """


### PR DESCRIPTION
## What?

This PR fixes spacing issues in docs for `weighted_cross_entropy_with_logits` operation.

## Why?

Currently, there is no spacing between sections and everything looks jumbled up. See:
https://www.tensorflow.org/api_docs/python/tf/nn/weighted_cross_entropy_with_logits