### PR TITLE
[tflite] include headers to fix undeclared PROT_READ on macos

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -38,7 +38,7 @@ limitations under the License.
 #ifdef __ANDROID__
 #include <sys/system_properties.h>
 #endif
-#if defined __ANDROID__ || defined __unix__
+#if defined __ANDROID__ || defined __unix__ || defined __APPLE__
 #include <sys/mman.h>
 #include <unistd.h>
 #endif


### PR DESCRIPTION
nnapi delegate doesn't compile on macOS after https://github.com/tensorflow/tensorflow/commit/19f417d905980cb7f2098e48c147cb301c087573. Add ` #include <sys/mman.h>` to fix it.