### PR TITLE
Use environment markers for enum34

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -52,6 +52,8 @@ _VERSION = '1.14.0'
 REQUIRED_PACKAGES = [
     'absl-py >= 0.7.0',
     'astor >= 0.6.0',
+    'backports.weakref >= 1.0rc1;python_version<"3.4"',
+    'enum34 >= 1.1.6;python_version<"3.4"',
     'gast >= 0.2.0',
     'google_pasta >= 0.1.6',
     'keras_applications >= 1.0.8',
@@ -96,11 +98,6 @@ if 'tf_nightly' in project_name:
       REQUIRED_PACKAGES[i] = 'tensorflow-estimator-2.0-preview'
     elif 'tensorflow_estimator' in pkg:
       REQUIRED_PACKAGES[i] = 'tf-estimator-nightly'
-
-# weakref.finalize and enum were introduced in Python 3.4
-if sys.version_info < (3, 4):
-  REQUIRED_PACKAGES.append('backports.weakref >= 1.0rc1')
-  REQUIRED_PACKAGES.append('enum34 >= 1.1.6')
 
 # pylint: disable=line-too-long
 CONSOLE_SCRIPTS = [


### PR DESCRIPTION
This fix tries to addres the issue raised in #30200 where enum34 caused poetry breaks due to the conditional sys.version_info

This fix changes to use environment markers for enum34 (conform to PEP508)

This fix fixes #30200.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>