### PR TITLE
Fix macos makefile build

### DIFF
--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -914,7 +914,7 @@ ifeq ($(TARGET),OSX)
   ifeq($(HOST_ARCH), x86_64)
 	HOST_LDOPTS += -framework CoreFoundation
 	LIBS += -framework CoreFoundation
-  endif()
+  endif
 endif
 ifeq ($(TARGET),IOS)
   ifeq ($(IOS_ARCH),X86_64)

--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -911,8 +911,10 @@ $(PROTO_TEXT_OBJS) : $(PROTO_TEXT_PB_H_FILES)
 # Ensures we link CoreFoundation as it is used for time library when building
 # for Mac.
 ifeq ($(TARGET),OSX)
-  HOST_LDOPTS += -framework CoreFoundation
-  LIBS += -framework CoreFoundation
+  ifeq($(HOST_ARCH), x86_64)
+	HOST_LDOPTS += -framework CoreFoundation
+	LIBS += -framework CoreFoundation
+  endif()
 endif
 ifeq ($(TARGET),IOS)
   ifeq ($(IOS_ARCH),X86_64)

--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -910,11 +910,17 @@ $(PROTO_TEXT_OBJS) : $(PROTO_TEXT_PB_H_FILES)
 
 # Ensures we link CoreFoundation as it is used for time library when building
 # for Mac.
+ifeq ($(TARGET),OSX)
+  HOST_LDOPTS += -framework CoreFoundation
+  LIBS += -framework CoreFoundation
+endif
 ifeq ($(TARGET),IOS)
   ifeq ($(IOS_ARCH),X86_64)
     HOST_LDOPTS += -framework CoreFoundation
   endif
 endif
+
+
 
 # Runs proto_text to generate C++ source files from protos.
 $(PROTO_TEXT): $(PROTO_TEXT_OBJS) $(PROTO_TEXT_PB_H_FILES)

--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -911,15 +911,15 @@ $(PROTO_TEXT_OBJS) : $(PROTO_TEXT_PB_H_FILES)
 # Ensures we link CoreFoundation as it is used for time library when building
 # for Mac and iOS
 ifeq ($(TARGET),OSX)
-	ifeq ($(HOST_ARCH),x86_64)
-		HOST_LDOPTS += -framework CoreFoundation
-		LIBS += -framework CoreFoundation
-	endif
+  ifeq ($(HOST_ARCH),x86_64)
+    HOST_LDOPTS += -framework CoreFoundation
+    LIBS += -framework CoreFoundation
+  endif
 endif
 ifeq ($(TARGET),IOS)
-	ifeq ($(IOS_ARCH),X86_64)
-		HOST_LDOPTS += -framework CoreFoundation
-	endif
+  ifeq ($(IOS_ARCH),X86_64)
+    HOST_LDOPTS += -framework CoreFoundation
+  endif
 endif
 
 # Runs proto_text to generate C++ source files from protos.

--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -909,17 +909,17 @@ $(HOST_OBJDIR)%.pb.o: $(HOST_GENDIR)%.pb.cc
 $(PROTO_TEXT_OBJS) : $(PROTO_TEXT_PB_H_FILES)
 
 # Ensures we link CoreFoundation as it is used for time library when building
-# for Mac.
+# for Mac and iOS
 ifeq ($(TARGET),OSX)
-  ifeq($(HOST_ARCH), x86_64)
-	HOST_LDOPTS += -framework CoreFoundation
-	LIBS += -framework CoreFoundation
-  endif
+	ifeq ($(HOST_ARCH),x86_64)
+		HOST_LDOPTS += -framework CoreFoundation
+		LIBS += -framework CoreFoundation
+	endif
 endif
 ifeq ($(TARGET),IOS)
-  ifeq ($(IOS_ARCH),X86_64)
-    HOST_LDOPTS += -framework CoreFoundation
-  endif
+	ifeq ($(IOS_ARCH),X86_64)
+		HOST_LDOPTS += -framework CoreFoundation
+	endif
 endif
 
 # Runs proto_text to generate C++ source files from protos.

--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -920,8 +920,6 @@ ifeq ($(TARGET),IOS)
   endif
 endif
 
-
-
 # Runs proto_text to generate C++ source files from protos.
 $(PROTO_TEXT): $(PROTO_TEXT_OBJS) $(PROTO_TEXT_PB_H_FILES)
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
- Adding `CoreFoundation` to `HOST_LDFLAGS` is necessary as the library target uses that variable
- Adding `CoreFoundation` to `LIBS` is necessary as the benchmark target uses that variable