### PR TITLE
Add mask optional arg to Batchnormalization.call()

### DIFF
--- a/tensorflow/python/keras/layers/normalization.py
+++ b/tensorflow/python/keras/layers/normalization.py
@@ -613,8 +613,55 @@ class BatchNormalizationBase(Layer):
 
     return (r, d, out_mean, out_variance)
 
-  def _moments(self, inputs, reduction_axes, keep_dims):
-    mean, variance = nn.moments(inputs, reduction_axes, keep_dims=keep_dims)
+  def moment_calculation(self,
+          x,
+          axes,
+          shift=None,  # pylint: disable=unused-argument
+          name=None,
+          keep_dims=False,
+          mask=None):
+
+      with ops.name_scope(name, "moments", [x, axes]):
+          # The dynamic range of fp16 is too limited to support the collection of
+          # sufficient statistics. As a workaround we simply perform the operations
+          # on 32-bit floats before converting the mean and variance back to fp16
+          y = math_ops.cast(x, dtypes.float32) if x.dtype == dtypes.float16 else x
+          # Compute true mean while keeping the dims for proper broadcasting.
+
+          # Count the number of valid data points we have in each axis we are batchnorming
+          if mask is not None:
+              mask = array_ops.expand_dims(mask, axis=-1)
+              # Get a count of the number of actual values by summing the mask
+              axis_counts = math_ops.reduce_sum(math_ops.cast(mask, dtypes.float32), axes, keepdims=True, name="mask_sum")
+              sum = math_ops.reduce_sum(y, axes, keepdims=True, name="values_sum")
+              mean = math_ops.divide(sum, axis_counts)
+
+              squared_difference = math_ops.squared_difference(y, array_ops.stop_gradient(mean))
+              squared_difference = squared_difference * math_ops.cast(mask, y.dtype)
+              squared_sum = math_ops.reduce_sum(squared_difference, axes, keepdims=True, name="squared_sum")
+              variance = math_ops.divide(squared_sum, axis_counts)
+          else:
+              mean = math_ops.reduce_mean(y, axes, keepdims=True, name="mean")
+              # sample variance, not unbiased variance
+              # Note: stop_gradient does not change the gradient that gets
+              #       backpropagated to the mean from the variance calculation,
+              #       because that gradient is zero
+              variance = math_ops.reduce_mean(
+                  math_ops.squared_difference(y, array_ops.stop_gradient(mean)),
+                  axes,
+                  keepdims=True,
+                  name="variance")
+          if not keep_dims:
+              mean = array_ops.squeeze(mean, axes)
+              variance = array_ops.squeeze(variance, axes)
+          if x.dtype == dtypes.float16:
+              return (math_ops.cast(mean, dtypes.float16),
+                      math_ops.cast(variance, dtypes.float16))
+          else:
+              return (mean, variance)
+
+  def _moments(self, inputs, reduction_axes, keep_dims, mask=None):
+    mean, variance = self.moment_calculation(inputs, reduction_axes, keep_dims=keep_dims, mask=mask)
     # TODO(b/129279393): Support zero batch input in non DistributionStrategy
     # code as well.
     # TODO(b/130185866): Support zero batch input in graph mode.
@@ -638,7 +685,7 @@ class BatchNormalizationBase(Layer):
         training = math_ops.logical_and(training, self.trainable)
     return training
 
-  def call(self, inputs, training=None):
+  def call(self, inputs, training=None, mask=None):
     training = self._get_training_value(training)
 
     if self.virtual_batch_size is not None:
@@ -711,7 +758,8 @@ class BatchNormalizationBase(Layer):
       mean, variance = self._moments(
           math_ops.cast(inputs, self._param_dtype),
           reduction_axes,
-          keep_dims=keep_dims)
+          keep_dims=keep_dims,
+          mask=mask)
 
       moving_mean = self.moving_mean
       moving_variance = self.moving_variance

--- a/tensorflow/python/keras/layers/normalization_test.py
+++ b/tensorflow/python/keras/layers/normalization_test.py
@@ -221,10 +221,10 @@ class BatchNormalizationTest(keras_parameterized.TestCase):
     padded_data = np.array([[[1, 5], [2, 5], [0, 0], [0, 0]] for _ in range(10)], dtype='float32')  # Pad value of 0
     data = np.array([[[1, 5], [2, 5]] for _ in range(10)], dtype='float32')
 
-    input = tf.keras.layers.Input((None, 2))
-    masked = tf.keras.layers.Masking()(input)
-    normed = BatchNormalization(momentum=0.0)(masked)
-    model = tf.keras.models.Model(input, normed)
+    input = keras.layers.Input((None, 2))
+    masked = keras.layers.Masking()(input)
+    normed = keras.layers.BatchNormalization(momentum=0.0)(masked)
+    model = keras.models.Model(input, normed)
     model.compile('rmsprop', 'mse',
                   run_eagerly=testing_utils.should_run_eagerly())
 

--- a/tensorflow/python/keras/layers/normalization_test.py
+++ b/tensorflow/python/keras/layers/normalization_test.py
@@ -232,8 +232,9 @@ class BatchNormalizationTest(keras_parameterized.TestCase):
     moments_mask = model.layers[2].get_weights()
     model.fit(x=data, y=data, batch_size=10, epochs=5)
     moments = model.layers[2].get_weights()
-    self.assertEqual(moments_mask[2][0], moments[2][0]) # moving average mean comparison
-    self.assertEqual(moments_mask[3][0], moments[3][0])  # moving average variance comparison
+
+    self.assertEqual(moments_mask[2], moments[2])  # moving average mean comparison
+    self.assertEqual(moments_mask[3], moments[3])  # moving average variance comparison
 
   def test_eager_batchnorm_in_custom_model_call_with_tf_function(self):
 

--- a/tensorflow/python/keras/layers/normalization_test.py
+++ b/tensorflow/python/keras/layers/normalization_test.py
@@ -225,13 +225,15 @@ class BatchNormalizationTest(keras_parameterized.TestCase):
     masked = tf.keras.layers.Masking()(input)
     normed = BatchNormalization(momentum=0.0)(masked)
     model = tf.keras.models.Model(input, normed)
+    model.compile('rmsprop', 'mse',
+                  run_eagerly=testing_utils.should_run_eagerly())
 
     model.fit(x=padded_data, y=padded_data, batch_size=10, epochs=5)
     moments_mask = model.layers[2].get_weights()
     model.fit(x=data, y=data, batch_size=10, epochs=5)
     moments = model.layers[2].get_weights()
     self.assertEqual(moments_mask[2][0], moments[2][0]) # moving average mean comparison
-    self.assertEqual(moments_mask[3][0], moments_mask[3][0])  # moving average variance comparison
+    self.assertEqual(moments_mask[3][0], moments[3][0])  # moving average variance comparison
 
   def test_eager_batchnorm_in_custom_model_call_with_tf_function(self):
 


### PR DESCRIPTION
Attempt to support masked values in BatchNormalization layer, so that mean and variance are correctly calculated ( #30161 )

Uses a modified version of nn.moments() which takes a `mask` argument.

@karmel 