### PR TITLE
Fix bug in GpuAtomicCasHelper

### DIFF
--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -538,7 +538,7 @@ CREATE_CUDA_DEVICE_FUNCTION_ALIAS(GpuAtomicCasHelper, CudaAtomicCasHelper);
 // correctly).
 template <typename F>
 __device__ float GpuAtomicCasHelper(float* ptr, F accumulate) {
-  return __float_as_int(
+  return __int_as_float(
       GpuAtomicCasHelper(reinterpret_cast<int32*>(ptr), [accumulate](int32 a) {
         return __float_as_int(accumulate(__int_as_float(a)));
       }));


### PR DESCRIPTION
I happened to notice this as I was looking through the code. I don't think this code path is used for CUDA devices so I'm not sure how to test it, but it looks pretty clear to me that it's a bug.

cc @nluehr 