### PR TITLE
Consider integer division/remainder by constant scalar as cheap.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -730,6 +730,7 @@ cc_library(
         "//tensorflow/compiler/xla:shape_util",
         "//tensorflow/compiler/xla:xla_data_proto",
         "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service:hlo_query",
         "//tensorflow/compiler/xla/service:instruction_fusion",
         "//tensorflow/compiler/xla/service:pattern_matcher",
         "//tensorflow/compiler/xla/service/llvm_ir:fused_ir_emitter",

--- a/tensorflow/compiler/xla/service/gpu/instruction_fusion_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/instruction_fusion_test.cc
@@ -581,5 +581,62 @@ TEST_F(InstructionFusionTest, FuseReverse) {
               op::Reverse(op::Add(op::Parameter(), op::Parameter())));
 }
 
+TEST_F(InstructionFusionTest, GpuIsExpensiveF32) {
+  auto m = CreateNewVerifiedModule();
+  Shape r0f32 = ShapeUtil::MakeShape(F32, {});
+  HloComputation::Builder builder(TestName());
+  HloInstruction* param0 = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, r0f32, "param0"));
+
+  HloInstruction* one = builder.AddInstruction(
+      HloInstruction::CreateConstant(LiteralUtil::CreateR0<float>(1.0f)));
+  HloInstruction* div = builder.AddInstruction(
+      HloInstruction::CreateBinary(r0f32, HloOpcode::kDivide, param0, one));
+  HloInstruction* rem = builder.AddInstruction(
+      HloInstruction::CreateBinary(r0f32, HloOpcode::kRemainder, param0, one));
+
+  EXPECT_FALSE(GpuInstructionFusion::IsExpensive(*div));
+  EXPECT_TRUE(GpuInstructionFusion::IsExpensive(*rem));
+}
+
+TEST_F(InstructionFusionTest, GpuIsExpensiveS32) {
+  auto m = CreateNewVerifiedModule();
+  Shape r0s32 = ShapeUtil::MakeShape(S32, {});
+  HloComputation::Builder builder(TestName());
+  HloInstruction* param0 = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, r0s32, "param0"));
+
+  HloInstruction* one = builder.AddInstruction(
+      HloInstruction::CreateConstant(LiteralUtil::CreateR0<float>(1.0f)));
+  HloInstruction* div = builder.AddInstruction(
+      HloInstruction::CreateBinary(r0s32, HloOpcode::kDivide, param0, one));
+  HloInstruction* rem = builder.AddInstruction(
+      HloInstruction::CreateBinary(r0s32, HloOpcode::kRemainder, param0, one));
+
+  EXPECT_FALSE(GpuInstructionFusion::IsExpensive(*div));
+  EXPECT_FALSE(GpuInstructionFusion::IsExpensive(*rem));
+}
+
+TEST_F(InstructionFusionTest, GpuIsExpensiveBroadcastS32) {
+  auto m = CreateNewVerifiedModule();
+  Shape r1s32 = ShapeUtil::MakeShape(S32, {10});
+  HloComputation::Builder builder(TestName());
+  HloInstruction* param0 = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, r1s32, "param0"));
+
+  HloInstruction* one = builder.AddInstruction(
+      HloInstruction::CreateConstant(LiteralUtil::CreateR0<float>(1.0f)));
+  HloInstruction* one_broad = builder.AddInstruction(
+      HloInstruction::CreateBroadcast(r1s32, one, {}));
+
+  HloInstruction* div = builder.AddInstruction(
+      HloInstruction::CreateBinary(r1s32, HloOpcode::kDivide, param0, one_broad));
+  HloInstruction* rem = builder.AddInstruction(
+      HloInstruction::CreateBinary(r1s32, HloOpcode::kRemainder, param0, one_broad));
+
+      EXPECT_FALSE(GpuInstructionFusion::IsExpensive(*div));
+      EXPECT_FALSE(GpuInstructionFusion::IsExpensive(*rem));
+}
+
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
Consider integer division/remainder by constant scalar as cheap.
LLVM optimize that to faster instruction.

@sanjoy 