### PR TITLE
Cherry-picked from master e43b94649d3e1ac5d538e4eca9166b899511d681.

### DIFF
--- a/tensorflow/core/platform/cloud/gcs_file_system.cc
+++ b/tensorflow/core/platform/cloud/gcs_file_system.cc
@@ -66,18 +66,14 @@ constexpr uint64 HTTP_CODE_RESUME_INCOMPLETE = 308;
 // The environment variable that overrides the size of the readahead buffer.
 ABSL_DEPRECATED("Use GCS_READ_CACHE_BLOCK_SIZE_MB instead.")
 constexpr char kReadaheadBufferSize[] = "GCS_READAHEAD_BUFFER_SIZE_BYTES";
-// The environment variable that disables the GCS block cache for reads.
-// This is the explicit alternative to setting BLOCK_SIZE or MAX_SIZE to 0, and
-// takes precedence over either of those environment variables.
-constexpr char kReadCacheDisabled[] = "GCS_READ_CACHE_DISABLED";
 // The environment variable that overrides the block size for aligned reads from
 // GCS. Specified in MB (e.g. "16" = 16 x 1024 x 1024 = 16777216 bytes).
 constexpr char kBlockSize[] = "GCS_READ_CACHE_BLOCK_SIZE_MB";
-constexpr size_t kDefaultBlockSize = 16 * 1024 * 1024;
+constexpr size_t kDefaultBlockSize = 64 * 1024 * 1024;
 // The environment variable that overrides the max size of the LRU cache of
 // blocks read from GCS. Specified in MB.
 constexpr char kMaxCacheSize[] = "GCS_READ_CACHE_MAX_SIZE_MB";
-constexpr size_t kDefaultMaxCacheSize = kDefaultBlockSize;
+constexpr size_t kDefaultMaxCacheSize = 0;
 // The environment variable that overrides the maximum staleness of cached file
 // contents. Once any block of a file reaches this staleness, all cached blocks
 // will be evicted on the next read.
@@ -326,6 +322,97 @@ class GcsRandomAccessFile : public RandomAccessFile {
   const string filename_;
   /// The implementation of the read operation (provided by the GCSFileSystem).
   const ReadFn read_fn_;
+};
+
+/// A GCS-based implementation of a random access file with a read buffer.
+class BufferedGcsRandomAccessFile : public RandomAccessFile {
+ public:
+  using ReadFn =
+      std::function<Status(const string& filename, uint64 offset, size_t n,
+                           StringPiece* result, char* scratch)>;
+
+  // Initialize the reader. Provided read_fn should be thread safe.
+  BufferedGcsRandomAccessFile(const string& filename, uint64 buffer_size,
+                              ReadFn read_fn)
+      : filename_(filename),
+        read_fn_(std::move(read_fn)),
+        buffer_size_(buffer_size),
+        buffer_start_(0) {}
+
+  Status Name(StringPiece* result) const override {
+    *result = filename_;
+    return Status::OK();
+  }
+
+  /// The implementation of reads with an read buffer. Thread safe.
+  /// Returns `OUT_OF_RANGE` if fewer than n bytes were stored in `*result`
+  /// because of EOF.
+  Status Read(uint64 offset, size_t n, StringPiece* result,
+              char* scratch) const override {
+    if (n > buffer_size_) {
+      return read_fn_(filename_, offset, n, result, scratch);
+    }
+    {
+      mutex_lock l(buffer_mutex_);
+      size_t buffer_end = buffer_start_ + buffer_.size();
+      size_t copy_size = 0;
+      if (offset < buffer_end && offset >= buffer_start_) {
+        copy_size = std::min(n, static_cast<size_t>(buffer_end - offset));
+        memcpy(scratch, buffer_.data() + (offset - buffer_start_), copy_size);
+        *result = StringPiece(scratch, copy_size);
+      }
+      if (copy_size < n) {
+        // Try reading from the file regardless of previous read status.
+        // The file might have grown since the last read.
+        Status status = FillBuffer(offset + copy_size);
+        if (!status.ok() && status.code() != errors::Code::OUT_OF_RANGE) {
+          // Empty the buffer to avoid caching bad reads.
+          buffer_.resize(0);
+          return status;
+        }
+        size_t remaining_copy = std::min(n - copy_size, buffer_.size());
+        memcpy(scratch + copy_size, buffer_.data(), remaining_copy);
+        copy_size += remaining_copy;
+        *result = StringPiece(scratch, copy_size);
+      }
+      if (copy_size < n) {
+        return errors::OutOfRange("EOF reached. Requested to read ", n,
+                                  " bytes from ", offset, " but only got ",
+                                  copy_size, " bytes.");
+      }
+    }
+    return Status::OK();
+  }
+
+ private:
+  Status FillBuffer(uint64 start) const
+      EXCLUSIVE_LOCKS_REQUIRED(buffer_mutex_) {
+    buffer_start_ = start;
+    buffer_.resize(buffer_size_);
+    StringPiece str_piece;
+    Status status = read_fn_(filename_, buffer_start_, buffer_size_, &str_piece,
+                             &(buffer_[0]));
+    buffer_.resize(str_piece.size());
+    return status;
+  }
+
+  // The filename of this file.
+  const string filename_;
+
+  // The implementation of the read operation (provided by the GCSFileSystem).
+  const ReadFn read_fn_;
+
+  // Size of buffer that we read from GCS each time we send a request.
+  const uint64 buffer_size_;
+
+  // Mutex for buffering operations that can be accessed from multiple threads.
+  // The following members are mutable in order to provide a const Read.
+  mutable mutex buffer_mutex_;
+
+  // Offset of buffer from start of the file.
+  mutable uint64 buffer_start_ GUARDED_BY(buffer_mutex_);
+
+  mutable string buffer_ GUARDED_BY(buffer_mutex_);
 };
 
 /// \brief GCS-based implementation of a writeable file.
@@ -654,7 +741,7 @@ string ZoneToRegion(string* zone) {
 
 GcsFileSystem::GcsFileSystem() {
   uint64 value;
-  size_t block_size = kDefaultBlockSize;
+  block_size_ = kDefaultBlockSize;
   size_t max_bytes = kDefaultMaxCacheSize;
   uint64 max_staleness = kDefaultMaxStaleness;
 
@@ -668,27 +755,26 @@ GcsFileSystem::GcsFileSystem() {
 
   // Apply the sys env override for the readahead buffer size if it's provided.
   if (GetEnvVar(kReadaheadBufferSize, strings::safe_strtou64, &value)) {
-    block_size = value;
+    block_size_ = value;
   }
+
   // Apply the overrides for the block size (MB), max bytes (MB), and max
   // staleness (seconds) if provided.
   if (GetEnvVar(kBlockSize, strings::safe_strtou64, &value)) {
-    block_size = value * 1024 * 1024;
+    block_size_ = value * 1024 * 1024;
   }
+
   if (GetEnvVar(kMaxCacheSize, strings::safe_strtou64, &value)) {
     max_bytes = value * 1024 * 1024;
   }
+
   if (GetEnvVar(kMaxStaleness, strings::safe_strtou64, &value)) {
     max_staleness = value;
   }
-  if (std::getenv(kReadCacheDisabled)) {
-    // Setting either to 0 disables the cache; set both for good measure.
-    block_size = max_bytes = 0;
-  }
   VLOG(1) << "GCS cache max size = " << max_bytes << " ; "
-          << "block size = " << block_size << " ; "
+          << "block size = " << block_size_ << " ; "
           << "max staleness = " << max_staleness;
-  file_block_cache_ = MakeFileBlockCache(block_size, max_bytes, max_staleness);
+  file_block_cache_ = MakeFileBlockCache(block_size_, max_bytes, max_staleness);
   // Apply overrides for the stat cache max age and max entries, if provided.
   uint64 stat_cache_max_age = kStatCacheDefaultMaxAge;
   size_t stat_cache_max_entries = kStatCacheDefaultMaxEntries;
@@ -814,6 +900,7 @@ GcsFileSystem::GcsFileSystem(
     : auth_provider_(std::move(auth_provider)),
       http_request_factory_(std::move(http_request_factory)),
       zone_provider_(std::move(zone_provider)),
+      block_size_(block_size),
       file_block_cache_(
           MakeFileBlockCache(block_size, max_bytes, max_staleness)),
       stat_cache_(new StatCache(stat_cache_max_age, stat_cache_max_entries)),
@@ -831,13 +918,18 @@ Status GcsFileSystem::NewRandomAccessFile(
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseGcsPath(fname, false, &bucket, &object));
   TF_RETURN_IF_ERROR(CheckBucketLocationConstraint(bucket));
-  result->reset(new GcsRandomAccessFile(fname, [this, bucket, object](
-                                                   const string& fname,
-                                                   uint64 offset, size_t n,
-                                                   StringPiece* result,
-                                                   char* scratch) {
-    tf_shared_lock l(block_cache_lock_);
-    if (file_block_cache_->IsCacheEnabled()) {
+  bool cache_enabled;
+  {
+    mutex_lock l(block_cache_lock_);
+    cache_enabled = file_block_cache_->IsCacheEnabled();
+  }
+  if (cache_enabled) {
+    result->reset(new GcsRandomAccessFile(fname, [this, bucket, object](
+                                                     const string& fname,
+                                                     uint64 offset, size_t n,
+                                                     StringPiece* result,
+                                                     char* scratch) {
+      tf_shared_lock l(block_cache_lock_);
       GcsFileStat stat;
       TF_RETURN_IF_ERROR(stat_cache_->LookupOrCompute(
           fname, &stat,
@@ -850,19 +942,36 @@ Status GcsFileSystem::NewRandomAccessFile(
             << "File signature has been changed. Refreshing the cache. Path: "
             << fname;
       }
-    }
-    *result = StringPiece();
-    size_t bytes_transferred;
-    TF_RETURN_IF_ERROR(
-        file_block_cache_->Read(fname, offset, n, scratch, &bytes_transferred));
-    *result = StringPiece(scratch, bytes_transferred);
-    if (bytes_transferred < n) {
-      return errors::OutOfRange("EOF reached, ", result->size(),
-                                " bytes were read out of ", n,
-                                " bytes requested.");
-    }
-    return Status::OK();
-  }));
+      *result = StringPiece();
+      size_t bytes_transferred;
+      TF_RETURN_IF_ERROR(file_block_cache_->Read(fname, offset, n, scratch,
+                                                 &bytes_transferred));
+      *result = StringPiece(scratch, bytes_transferred);
+      if (bytes_transferred < n) {
+        return errors::OutOfRange("EOF reached, ", result->size(),
+                                  " bytes were read out of ", n,
+                                  " bytes requested.");
+      }
+      return Status::OK();
+    }));
+  } else {
+    result->reset(new BufferedGcsRandomAccessFile(
+        fname, block_size_,
+        [this, bucket, object](const string& fname, uint64 offset, size_t n,
+                               StringPiece* result, char* scratch) {
+          *result = StringPiece();
+          size_t bytes_transferred;
+          TF_RETURN_IF_ERROR(
+              LoadBufferFromGCS(fname, offset, n, scratch, &bytes_transferred));
+          *result = StringPiece(scratch, bytes_transferred);
+          if (bytes_transferred < n) {
+            return errors::OutOfRange("EOF reached, ", result->size(),
+                                      " bytes were read out of ", n,
+                                      " bytes requested.");
+          }
+          return Status::OK();
+        }));
+  }
   return Status::OK();
 }
 

--- a/tensorflow/core/platform/cloud/gcs_file_system.h
+++ b/tensorflow/core/platform/cloud/gcs_file_system.h
@@ -308,6 +308,10 @@ class GcsFileSystem : public FileSystem {
   std::unique_ptr<AuthProvider> auth_provider_ GUARDED_BY(mu_);
   std::shared_ptr<HttpRequest::Factory> http_request_factory_;
   std::unique_ptr<ZoneProvider> zone_provider_;
+
+  // Reads smaller than block_size_ will trigger a read of block_size_.
+  uint64 block_size_;
+
   // block_cache_lock_ protects the file_block_cache_ pointer (Note that
   // FileBlockCache instances are themselves threadsafe).
   mutex block_cache_lock_;

--- a/tensorflow/core/platform/cloud/gcs_file_system_test.cc
+++ b/tensorflow/core/platform/cloud/gcs_file_system_test.cc
@@ -97,6 +97,238 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_NoBlockCache) {
   EXPECT_EQ("6789", result);
 }
 
+TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered) {
+  std::vector<HttpRequest*> requests({
+      new FakeHttpRequest(
+          "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+          "Auth Token: fake_token\n"
+          "Range: 0-9\n"
+          "Timeouts: 5 1 20\n",
+          "0123456789"),
+      new FakeHttpRequest(
+          "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+          "Auth Token: fake_token\n"
+          "Range: 10-19\n"
+          "Timeouts: 5 1 20\n",
+          ""),
+  });
+  GcsFileSystem fs(
+      std::unique_ptr<AuthProvider>(new FakeAuthProvider),
+      std::unique_ptr<HttpRequest::Factory>(
+          new FakeHttpRequestFactory(&requests)),
+      std::unique_ptr<ZoneProvider>(new FakeZoneProvider), 10 /* block size */,
+      0 /* max bytes */, 0 /* max staleness */, 0 /* stat cache max age */,
+      0 /* stat cache max entries */, 0 /* matching paths cache max age */,
+      0 /* matching paths cache max entries */, kTestRetryConfig,
+      kTestTimeoutConfig, *kAllowedLocationsDefault,
+      nullptr /* gcs additional header */);
+
+  std::unique_ptr<RandomAccessFile> file;
+  TF_EXPECT_OK(fs.NewRandomAccessFile("gs://bucket/random_access.txt", &file));
+
+  StringPiece filename;
+  TF_EXPECT_OK(file->Name(&filename));
+  EXPECT_EQ(filename, "gs://bucket/random_access.txt");
+
+  char scratch[6];
+  StringPiece result;
+
+  // Read the first chunk.
+  TF_EXPECT_OK(file->Read(0, sizeof(scratch), &result, scratch));
+  EXPECT_EQ("012345", result);
+
+  // Read the second chunk.
+  EXPECT_EQ(
+      errors::Code::OUT_OF_RANGE,
+      file->Read(sizeof(scratch), sizeof(scratch), &result, scratch).code());
+  EXPECT_EQ("6789", result);
+}
+
+TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_Errors) {
+  std::vector<HttpRequest*> requests({
+      new FakeHttpRequest(
+          "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+          "Auth Token: fake_token\n"
+          "Range: 0-9\n"
+          "Timeouts: 5 1 20\n",
+          "Server Not", errors::Unavailable("important HTTP error 308"),
+          nullptr, {}, 308),
+      new FakeHttpRequest(
+          "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+          "Auth Token: fake_token\n"
+          "Range: 6-15\n"
+          "Timeouts: 5 1 20\n",
+          "123"),
+  });
+  GcsFileSystem fs(
+      std::unique_ptr<AuthProvider>(new FakeAuthProvider),
+      std::unique_ptr<HttpRequest::Factory>(
+          new FakeHttpRequestFactory(&requests)),
+      std::unique_ptr<ZoneProvider>(new FakeZoneProvider), 10 /* block size */,
+      0 /* max bytes */, 0 /* max staleness */, 0 /* stat cache max age */,
+      0 /* stat cache max entries */, 0 /* matching paths cache max age */,
+      0 /* matching paths cache max entries */, kTestRetryConfig,
+      kTestTimeoutConfig, *kAllowedLocationsDefault,
+      nullptr /* gcs additional header */);
+
+  std::unique_ptr<RandomAccessFile> file;
+  TF_EXPECT_OK(fs.NewRandomAccessFile("gs://bucket/random_access.txt", &file));
+
+  StringPiece filename;
+  TF_EXPECT_OK(file->Name(&filename));
+  EXPECT_EQ(filename, "gs://bucket/random_access.txt");
+
+  char scratch[6];
+  StringPiece result;
+
+  // Read the first chunk.
+  EXPECT_EQ(errors::Code::UNAVAILABLE,
+            file->Read(0, sizeof(scratch), &result, scratch).code());
+  EXPECT_EQ("", result);
+
+  // Read the second chunk.
+  EXPECT_EQ(
+      errors::Code::OUT_OF_RANGE,
+      file->Read(sizeof(scratch), sizeof(scratch), &result, scratch).code());
+  EXPECT_EQ("123", result);
+}
+
+TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_ReadAtEOF) {
+  std::vector<HttpRequest*> requests(
+      {new FakeHttpRequest(
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+           "Auth Token: fake_token\n"
+           "Range: 0-9\n"
+           "Timeouts: 5 1 20\n",
+           "0123456789"),
+       new FakeHttpRequest(
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+           "Auth Token: fake_token\n"
+           "Range: 10-19\n"
+           "Timeouts: 5 1 20\n",
+           "")});
+  GcsFileSystem fs(
+      std::unique_ptr<AuthProvider>(new FakeAuthProvider),
+      std::unique_ptr<HttpRequest::Factory>(
+          new FakeHttpRequestFactory(&requests)),
+      std::unique_ptr<ZoneProvider>(new FakeZoneProvider), 10 /* block size */,
+      0 /* max bytes */, 0 /* max staleness */, 0 /* stat cache max age */,
+      0 /* stat cache max entries */, 0 /* matching paths cache max age */,
+      0 /* matching paths cache max entries */, kTestRetryConfig,
+      kTestTimeoutConfig, *kAllowedLocationsDefault,
+      nullptr /* gcs additional header */);
+
+  std::unique_ptr<RandomAccessFile> file;
+  TF_EXPECT_OK(fs.NewRandomAccessFile("gs://bucket/random_access.txt", &file));
+
+  StringPiece filename;
+  TF_EXPECT_OK(file->Name(&filename));
+  EXPECT_EQ(filename, "gs://bucket/random_access.txt");
+
+  char scratch[10];
+  StringPiece result;
+
+  // Read the first chunk.
+  TF_EXPECT_OK(file->Read(0, sizeof(scratch), &result, scratch));
+  EXPECT_EQ("0123456789", result);
+
+  // Read the second chunk.
+  EXPECT_EQ(
+      errors::Code::OUT_OF_RANGE,
+      file->Read(sizeof(scratch), sizeof(scratch), &result, scratch).code());
+  EXPECT_EQ("", result);
+}
+
+TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_Growing) {
+  std::vector<HttpRequest*> requests(
+      {new FakeHttpRequest(
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+           "Auth Token: fake_token\n"
+           "Range: 0-9\n"
+           "Timeouts: 5 1 20\n",
+           "012345678"),
+       new FakeHttpRequest(
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+           "Auth Token: fake_token\n"
+           "Range: 9-18\n"
+           "Timeouts: 5 1 20\n",
+           "9")});
+  GcsFileSystem fs(
+      std::unique_ptr<AuthProvider>(new FakeAuthProvider),
+      std::unique_ptr<HttpRequest::Factory>(
+          new FakeHttpRequestFactory(&requests)),
+      std::unique_ptr<ZoneProvider>(new FakeZoneProvider), 10 /* block size */,
+      0 /* max bytes */, 0 /* max staleness */, 0 /* stat cache max age */,
+      0 /* stat cache max entries */, 0 /* matching paths cache max age */,
+      0 /* matching paths cache max entries */, kTestRetryConfig,
+      kTestTimeoutConfig, *kAllowedLocationsDefault,
+      nullptr /* gcs additional header */);
+
+  std::unique_ptr<RandomAccessFile> file;
+  TF_EXPECT_OK(fs.NewRandomAccessFile("gs://bucket/random_access.txt", &file));
+
+  StringPiece filename;
+  TF_EXPECT_OK(file->Name(&filename));
+  EXPECT_EQ(filename, "gs://bucket/random_access.txt");
+
+  char scratch[10];
+  StringPiece result;
+
+  // Read the first chunk.
+  EXPECT_EQ(errors::Code::OUT_OF_RANGE,
+            file->Read(0, sizeof(scratch), &result, scratch).code());
+  EXPECT_EQ("012345678", result);
+
+  TF_EXPECT_OK(file->Read(0, sizeof(scratch), &result, scratch));
+  EXPECT_EQ("0123456789", result);
+}
+
+TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_ReadBackwards) {
+  // Go backwards in the file. It should trigger a new read.
+  std::vector<HttpRequest*> requests(
+      {new FakeHttpRequest(
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+           "Auth Token: fake_token\n"
+           "Range: 5-14\n"
+           "Timeouts: 5 1 20\n",
+           "56789"),
+       new FakeHttpRequest(
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
+           "Auth Token: fake_token\n"
+           "Range: 0-9\n"
+           "Timeouts: 5 1 20\n",
+           "0123456789")});
+  GcsFileSystem fs(
+      std::unique_ptr<AuthProvider>(new FakeAuthProvider),
+      std::unique_ptr<HttpRequest::Factory>(
+          new FakeHttpRequestFactory(&requests)),
+      std::unique_ptr<ZoneProvider>(new FakeZoneProvider), 10 /* block size */,
+      0 /* max bytes */, 0 /* max staleness */, 0 /* stat cache max age */,
+      0 /* stat cache max entries */, 0 /* matching paths cache max age */,
+      0 /* matching paths cache max entries */, kTestRetryConfig,
+      kTestTimeoutConfig, *kAllowedLocationsDefault,
+      nullptr /* gcs additional header */);
+
+  std::unique_ptr<RandomAccessFile> file;
+  TF_EXPECT_OK(fs.NewRandomAccessFile("gs://bucket/random_access.txt", &file));
+
+  StringPiece filename;
+  TF_EXPECT_OK(file->Name(&filename));
+  EXPECT_EQ(filename, "gs://bucket/random_access.txt");
+
+  char scratch[10];
+  StringPiece result;
+
+  // Read the first chunk.
+  EXPECT_EQ(errors::Code::OUT_OF_RANGE,
+            file->Read(5, sizeof(scratch), &result, scratch).code());
+  EXPECT_EQ("56789", result);
+
+  // Go back and read from the beginning of the file.
+  TF_EXPECT_OK(file->Read(0, sizeof(scratch), &result, scratch));
+  EXPECT_EQ("0123456789", result);
+}
+
 TEST(GcsFileSystemTest,
      NewRandomAccessFile_WithLocationConstraintInSameLocation) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
@@ -3154,9 +3386,11 @@ TEST(GcsFileSystemTest, AdditionalRequestHeaderTest) {
 
 TEST(GcsFileSystemTest, OverrideCacheParameters) {
   // Verify defaults are propagated correctly.
+  setenv("GCS_READ_CACHE_BLOCK_SIZE_MB", "16", 1);
+  setenv("GCS_READ_CACHE_MAX_SIZE_MB", "128", 1);
   GcsFileSystem fs1;
   EXPECT_EQ(16 * 1024 * 1024, fs1.block_size());
-  EXPECT_EQ(fs1.block_size(), fs1.max_bytes());
+  EXPECT_EQ(128 * 1024 * 1024, fs1.max_bytes());
   EXPECT_EQ(0, fs1.max_staleness());
   EXPECT_EQ(120, fs1.timeouts().connect);
   EXPECT_EQ(60, fs1.timeouts().idle);
@@ -3165,6 +3399,7 @@ TEST(GcsFileSystemTest, OverrideCacheParameters) {
   EXPECT_EQ(3600, fs1.timeouts().write);
 
   // Verify legacy readahead buffer override sets block size.
+  unsetenv("GCS_READ_CACHE_BLOCK_SIZE_MB");
   setenv("GCS_READAHEAD_BUFFER_SIZE_BYTES", "123456789", 1);
   GcsFileSystem fs2;
   EXPECT_EQ(123456789L, fs2.block_size());


### PR DESCRIPTION
Disable caching by default unless GCS_READ_CACHE_MAX_SIZE_MB is set.
Add a buffered GCS reader ideal for sequential reads. This reader will preload up to 64MB (default GCS_READ_CACHE_BLOCK_SIZE_MB) to avoid reading small chunks of data from GCS. This buffer is per file handle and not shared with other readers of the same file. Use this new reader when caching is disabled.

PiperOrigin-RevId: 255689024