### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build

### DIFF
--- a/third_party/eigen3/gpu_packet_math.patch
+++ b/third_party/eigen3/gpu_packet_math.patch
@@ -22,3 +22,14 @@
      return res;
    }
  };
+--- a/unsupported/Eigen/CXX11/src/Tensor/TensorForwardDeclarations.h
++++ b/unsupported/Eigen/CXX11/src/Tensor/TensorForwardDeclarations.h
+@@ -23,7 +23,7 @@
+ };
+ 
+ template <typename T>
+-EIGEN_STRONG_INLINE T* constCast(const T* data) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T* constCast(const T* data) {
+   return const_cast<T*>(data);
+ }
+ 


### PR DESCRIPTION
The following commit breaks the `--config=rocm` build

https://github.com/tensorflow/tensorflow/commit/e4a0ae3ed04d4d7f8c0381cb8a2d187f86411de8#diff-455a4c7f8e22d7c514e8c2caa27506c5

The above commit moves forward the Eigen pointer to which introduces changes (on the Eigen side) which lead to the following errors

```
In file included from tensorflow/core/kernels/cross_op_gpu.cu.cc:20:
In file included from ./tensorflow/core/framework/register_types.h:20:
In file included from ./tensorflow/core/framework/numeric_types.h:20:
In file included from ./third_party/eigen3/unsupported/Eigen/CXX11/Tensor:1:
In file included from external/eigen_archive/unsupported/Eigen/CXX11/Tensor:140:
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorChipping.h:356:37: error:  'Eigen::constCast':  no overloaded function has restriction specifiers that are compatible with the ambient context 'data'
    typename Storage::Type result = constCast(m_impl.data());
                                    ^
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorChipping.h:356:37: error:  'Eigen::constCast':  no overloaded function has restriction specifiers that are compatible with the ambient context 'data'
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorAssign.h:148:56: note: in instantiation of member function 'Eigen::TensorEvaluator<const Eigen::TensorChippingOp<1, Eigen::TensorMap<Eigen::Tensor<int, 2, 1, long>, 16, MakePointer> >, Eigen::Gpu\
Device>::data' requested here
    return m_rightImpl.evalSubExprsIfNeeded(m_leftImpl.data());

```

The fix for this is trivial and a PR for it has already been submitted to the official Eigen repo

https://bitbucket.org/eigen/eigen/pull-requests/669/adding-the-eigen_device_func-attribute-to/diff

This PR is to update the eigen patch to apply the fix, to get the `--config=rocm` build working again

This commit can be undone once the Eigen PR is merged and the TF eigen pointer has moved forward to pick up the fix.

@rmlarsen , please approve.  This is a trivial update to the eigen patch file. 

------------------------------------------------

@tatianashp @whchung 
