### PR TITLE
Xla int nearestneighbor resize

### DIFF
--- a/tensorflow/compiler/tests/image_ops_test.py
+++ b/tensorflow/compiler/tests/image_ops_test.py
@@ -514,6 +514,24 @@ class ResizeNearestNeighborTest(xla_test.XLATestCase):
                            [7, 7, 7, 8, 8, 8, 8, 8, 8, 9, 9, 9]],
                           dtype=np.float32))
 
+  def testAlignCorners3x3To12x12_uint8(self):
+    # Ensure that resize with convolution works on XLA/GPU for integer types
+    self._assertForwardOpMatchesExpected(
+        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.uint8), [12, 12],
+        expected=np.array([[1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3],
+                           [1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3],
+                           [1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3],
+                           [4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6],
+                           [4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6],
+                           [4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6],
+                           [4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6],
+                           [4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6],
+                           [4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6],
+                           [7, 7, 7, 8, 8, 8, 8, 8, 8, 9, 9, 9],
+                           [7, 7, 7, 8, 8, 8, 8, 8, 8, 9, 9, 9],
+                           [7, 7, 7, 8, 8, 8, 8, 8, 8, 9, 9, 9]],
+                          dtype=np.uint8))
+
 
 class ResizeBilinearTest(parameterized.TestCase, xla_test.XLATestCase):
 

--- a/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
@@ -568,12 +568,15 @@ void GeneralCompile(XlaOpKernelContext* ctx, bool align_corners_,
   ctx->SetOutput(0, input);
 }
 
+bool static IsGPUDevice(OpKernelConstruction* ctx) {
+  absl::string_view s = ctx->device_type().type_string();
+  return s == DEVICE_GPU_XLA_JIT || s == DEVICE_XLA_GPU;
+}
+
 class ResizeNearestNeighborOp : public XlaOpKernel {
  public:
   explicit ResizeNearestNeighborOp(OpKernelConstruction* ctx)
-      : XlaOpKernel(ctx), is_gpu_device_([](absl::string_view s) {
-          return s == DEVICE_GPU_XLA_JIT || s == DEVICE_XLA_GPU;
-        }(ctx->device_type().type_string())) {
+      : XlaOpKernel(ctx), is_gpu_device_(IsGPUDevice(ctx)) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("align_corners", &align_corners_));
     OP_REQUIRES(
         ctx, align_corners_ == true,
@@ -604,9 +607,7 @@ REGISTER_XLA_OP(Name("ResizeNearestNeighbor").CompileTimeConstantInput("size"),
 class ResizeBilinearOp : public XlaOpKernel {
  public:
   explicit ResizeBilinearOp(OpKernelConstruction* ctx)
-      : XlaOpKernel(ctx), is_gpu_device_([](absl::string_view s) {
-          return s == DEVICE_GPU_XLA_JIT || s == DEVICE_XLA_GPU;
-        }(ctx->device_type().type_string())) {
+      : XlaOpKernel(ctx), is_gpu_device_(IsGPUDevice(ctx)) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("align_corners", &align_corners_));
     OP_REQUIRES_OK(ctx,
                    ctx->GetAttr("half_pixel_centers", &half_pixel_centers_));

--- a/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
@@ -456,7 +456,8 @@ xla::XlaOp ResizeUsingDilationAndConvolutionGradOp(
 }
 
 void GeneralCompile(XlaOpKernelContext* ctx, bool align_corners_,
-                    bool is_kernel_bilinear) {
+                    bool is_kernel_bilinear,
+                    absl::string_view device_type_string) {
   xla::XlaBuilder* b = ctx->builder();
 
   TensorShape input_shape = ctx->InputShape(0);
@@ -508,7 +509,9 @@ void GeneralCompile(XlaOpKernelContext* ctx, bool align_corners_,
   // integer convolution on CuDNN is either not supported or not allowed
   // directly.
   xla::PrimitiveType original_input_type = input_type;
-  if (is_kernel_bilinear || (xla::primitive_util::IsIntegralType(input_type))) {
+  if (is_kernel_bilinear || ((device_type_string == DEVICE_GPU_XLA_JIT ||
+                              device_type_string == DEVICE_XLA_GPU) &&
+                             xla::primitive_util::IsIntegralType(input_type))) {
     input = xla::ConvertElementType(input, xla::F32);
     input_type = xla::F32;
   }
@@ -570,7 +573,8 @@ void GeneralCompile(XlaOpKernelContext* ctx, bool align_corners_,
 class ResizeNearestNeighborOp : public XlaOpKernel {
  public:
   explicit ResizeNearestNeighborOp(OpKernelConstruction* ctx)
-      : XlaOpKernel(ctx) {
+      : XlaOpKernel(ctx),
+        device_type_string_(ctx->device_type().type_string()) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("align_corners", &align_corners_));
     OP_REQUIRES(
         ctx, align_corners_ == true,
@@ -585,13 +589,15 @@ class ResizeNearestNeighborOp : public XlaOpKernel {
   }
 
   void Compile(XlaOpKernelContext* ctx) override {
-    GeneralCompile(ctx, align_corners_, is_kernel_bilinear_);
+    GeneralCompile(ctx, align_corners_, is_kernel_bilinear_,
+                   device_type_string_);
   }
 
  private:
   bool align_corners_ = true;
   bool half_pixel_centers_ = true;
   bool is_kernel_bilinear_ = false;
+  string device_type_string_;
 };
 
 REGISTER_XLA_OP(Name("ResizeNearestNeighbor").CompileTimeConstantInput("size"),
@@ -599,7 +605,9 @@ REGISTER_XLA_OP(Name("ResizeNearestNeighbor").CompileTimeConstantInput("size"),
 
 class ResizeBilinearOp : public XlaOpKernel {
  public:
-  explicit ResizeBilinearOp(OpKernelConstruction* ctx) : XlaOpKernel(ctx) {
+  explicit ResizeBilinearOp(OpKernelConstruction* ctx)
+      : XlaOpKernel(ctx),
+        device_type_string_(ctx->device_type().type_string()) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("align_corners", &align_corners_));
     OP_REQUIRES_OK(ctx,
                    ctx->GetAttr("half_pixel_centers", &half_pixel_centers_));
@@ -610,13 +618,15 @@ class ResizeBilinearOp : public XlaOpKernel {
   }
 
   void Compile(XlaOpKernelContext* ctx) override {
-    GeneralCompile(ctx, align_corners_, is_kernel_bilinear_);
+    GeneralCompile(ctx, align_corners_, is_kernel_bilinear_,
+                   device_type_string_);
   }
 
  private:
   bool align_corners_ = true;
   bool half_pixel_centers_ = true;
   bool is_kernel_bilinear_ = true;
+  string device_type_string_;
 };
 
 REGISTER_XLA_OP(Name("ResizeBilinear").CompileTimeConstantInput("size"),


### PR DESCRIPTION
Make nearest neighbor resize always use float to do convolution for GPU/XLA, even if the inputs are integers, because convolution with most integer types is not supported for GPU/XLA.