### PR TITLE
[INTEL MKL] Bugfix: 3d-dilated convolution crash on MKL-DNN build of tensorflow

### DIFF
--- a/tensorflow/core/kernels/mkl_conv_ops.h
+++ b/tensorflow/core/kernels/mkl_conv_ops.h
@@ -411,14 +411,15 @@ class MklDnnConvUtil {
                          input_cols, filter_cols, dilation_cols, stride_cols,
                          padding_type, &out_cols, &pad_left, &pad_right));
     } else {
-      OP_REQUIRES_OK(context_, GetWindowedOutputSizeVerbose(
-                                   input_planes, filter_planes, stride_planes,
-                                   padding_, &out_planes, &pad_D1, &pad_D2));
-      OP_REQUIRES_OK(context_, GetWindowedOutputSizeVerbose(
-                                   input_rows, filter_rows, stride_rows,
+      OP_REQUIRES_OK(context_, GetWindowedOutputSizeVerboseV2(
+                                   input_planes, filter_planes, dilation_planes,
+                                   stride_planes, padding_, &out_planes, &pad_D1,
+                                   &pad_D2));
+      OP_REQUIRES_OK(context_, GetWindowedOutputSizeVerboseV2(
+                                   input_rows, filter_rows, dilation_rows, stride_rows,
                                    padding_, &out_rows, &pad_top, &pad_bottom));
-      OP_REQUIRES_OK(context_, GetWindowedOutputSizeVerbose(
-                                   input_cols, filter_cols, stride_cols,
+      OP_REQUIRES_OK(context_, GetWindowedOutputSizeVerboseV2(
+                                   input_cols, filter_cols, dilation_cols, stride_cols,
                                    padding_, &out_cols, &pad_left, &pad_right));
     }
 

--- a/tensorflow/core/kernels/mkl_conv_ops.h
+++ b/tensorflow/core/kernels/mkl_conv_ops.h
@@ -196,9 +196,8 @@ class MklDnnConvUtil {
                                         filter_shape.DebugString()));
 
     for (int i = 0; i < ((strides_.size() == 4) ? 3 : 5); i++) {
-      OP_REQUIRES(context_,
-                  FastBoundsCheck(filter_shape.dim_size(i),
-                                  std::numeric_limits<int>::max()),
+      OP_REQUIRES(context_, FastBoundsCheck(filter_shape.dim_size(i),
+                                            std::numeric_limits<int>::max()),
                   errors::InvalidArgument("filter too large"));
     }
 
@@ -413,14 +412,16 @@ class MklDnnConvUtil {
     } else {
       OP_REQUIRES_OK(context_, GetWindowedOutputSizeVerboseV2(
                                    input_planes, filter_planes, dilation_planes,
-                                   stride_planes, padding_, &out_planes, &pad_D1,
-                                   &pad_D2));
-      OP_REQUIRES_OK(context_, GetWindowedOutputSizeVerboseV2(
-                                   input_rows, filter_rows, dilation_rows, stride_rows,
-                                   padding_, &out_rows, &pad_top, &pad_bottom));
-      OP_REQUIRES_OK(context_, GetWindowedOutputSizeVerboseV2(
-                                   input_cols, filter_cols, dilation_cols, stride_cols,
-                                   padding_, &out_cols, &pad_left, &pad_right));
+                                   stride_planes, padding_, &out_planes,
+                                   &pad_D1, &pad_D2));
+      OP_REQUIRES_OK(context_,
+                     GetWindowedOutputSizeVerboseV2(
+                         input_rows, filter_rows, dilation_rows, stride_rows,
+                         padding_, &out_rows, &pad_top, &pad_bottom));
+      OP_REQUIRES_OK(context_,
+                     GetWindowedOutputSizeVerboseV2(
+                         input_cols, filter_cols, dilation_cols, stride_cols,
+                         padding_, &out_cols, &pad_left, &pad_right));
     }
 
     if (is_conv2d) {

--- a/tensorflow/python/kernel_tests/conv_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_3d_test.py
@@ -32,6 +32,7 @@ from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import nn_ops
 import tensorflow.python.ops.nn_grad  # pylint: disable=unused-import
 from tensorflow.python.platform import test
+from tensorflow.python.framework import test_util
 
 
 def GetTestConfigs():
@@ -220,12 +221,13 @@ class Conv3DTest(test.TestCase):
         expected=expected_output)
 
   def testConv3D1x1x1Filter2x1x1Dilation(self):
-    self._VerifyDilatedConvValues(
-        tensor_in_sizes=[1, 3, 6, 1, 1],
-        filter_in_sizes=[1, 1, 1, 1, 1],
-        stride=1,
-        padding="VALID",
-        dilations=[2, 1, 1])
+    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+      self._VerifyDilatedConvValues(
+          tensor_in_sizes=[1, 3, 6, 1, 1],
+          filter_in_sizes=[1, 1, 1, 1, 1],
+          stride=1,
+          padding="VALID",
+          dilations=[2, 1, 1])
 
   # Expected values computed using scipy's correlate function.
   def testConv3D2x2x2Filter(self):
@@ -244,12 +246,13 @@ class Conv3DTest(test.TestCase):
         expected=expected_output)
 
   def testConv3D2x2x2Filter1x2x1Dilation(self):
-    self._VerifyDilatedConvValues(
-        tensor_in_sizes=[1, 4, 6, 3, 1],
-        filter_in_sizes=[2, 2, 2, 1, 1],
-        stride=1,
-        padding="VALID",
-        dilations=[1, 2, 1])
+    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+      self._VerifyDilatedConvValues(
+          tensor_in_sizes=[1, 4, 6, 3, 1],
+          filter_in_sizes=[2, 2, 2, 1, 1],
+          stride=1,
+          padding="VALID",
+          dilations=[1, 2, 1])
 
   def testConv3DStrides(self):
     expected_output = [

--- a/tensorflow/python/kernel_tests/conv_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_3d_test.py
@@ -220,13 +220,12 @@ class Conv3DTest(test.TestCase):
         expected=expected_output)
 
   def testConv3D1x1x1Filter2x1x1Dilation(self):
-    if test.is_gpu_available(cuda_only=True):
-      self._VerifyDilatedConvValues(
-          tensor_in_sizes=[1, 3, 6, 1, 1],
-          filter_in_sizes=[1, 1, 1, 1, 1],
-          stride=1,
-          padding="VALID",
-          dilations=[2, 1, 1])
+    self._VerifyDilatedConvValues(
+        tensor_in_sizes=[1, 3, 6, 1, 1],
+        filter_in_sizes=[1, 1, 1, 1, 1],
+        stride=1,
+        padding="VALID",
+        dilations=[2, 1, 1])
 
   # Expected values computed using scipy's correlate function.
   def testConv3D2x2x2Filter(self):
@@ -245,13 +244,12 @@ class Conv3DTest(test.TestCase):
         expected=expected_output)
 
   def testConv3D2x2x2Filter1x2x1Dilation(self):
-    if test.is_gpu_available(cuda_only=True):
-      self._VerifyDilatedConvValues(
-          tensor_in_sizes=[1, 4, 6, 3, 1],
-          filter_in_sizes=[2, 2, 2, 1, 1],
-          stride=1,
-          padding="VALID",
-          dilations=[1, 2, 1])
+    self._VerifyDilatedConvValues(
+        tensor_in_sizes=[1, 4, 6, 3, 1],
+        filter_in_sizes=[2, 2, 2, 1, 1],
+        stride=1,
+        padding="VALID",
+        dilations=[1, 2, 1])
 
   def testConv3DStrides(self):
     expected_output = [


### PR DESCRIPTION
Code to reproduce this bug:
<pre>
import tensorflow as tf

image_shape = (1,224,224,224,1)
kernel_1_shape = (5,5,5,1,1)

#Dummy image:
dummy_image = tf.truncated_normal(
                     image_shape,
                     dtype=tf.float32,
                     mean=0,
                     stddev=1,
                     name='3Dconv_input')
dummy_kernel_1 = tf.truncated_normal(
                     kernel_1_shape,
                     dtype=tf.float32,
                     mean=0,
                     stddev=1,
                     name='3Dconv_kernel_1')

conv = tf.nn.conv3d(dummy_image, dummy_kernel_1, [1, 1, 1, 1, 1], dilations=[1, 2, 2, 2, 1], 
                                 padding='SAME', data_format='NDHWC')

with tf.Session() as sess:
       sess.run(conv)
</pre>

We fix the bug in this PR, and also add testcases to make sure it won't happen again.