### PR TITLE
[Lite]Bugfix System.loadLibrary exception handle

### DIFF
--- a/tensorflow/lite/models/smartreply/demo/app/src/main/java/com/example/android/smartreply/SmartReplyClient.java
+++ b/tensorflow/lite/models/smartreply/demo/app/src/main/java/com/example/android/smartreply/SmartReplyClient.java
@@ -53,8 +53,13 @@ public class SmartReplyClient implements AutoCloseable {
   @WorkerThread
   public synchronized void loadModel() {
     if (!isLibraryLoaded) {
-      System.loadLibrary(JNI_LIB);
-      isLibraryLoaded = true;
+      try {
+        System.loadLibrary(JNI_LIB);
+        isLibraryLoaded = true;
+      } catch (Exception e) {
+        Log.e(TAG, "Failed to load prebuilt smartreply_jni lib", e);
+        return;
+      }
     }
 
     try {


### PR DESCRIPTION
Exception handle when application couldn't able to load the prebuilt smartreply_jni library.