### PR TITLE
[ROCm] Adding ROCm support for batch_to_space op

### DIFF
--- a/tensorflow/core/kernels/batchtospace_op.cc
+++ b/tensorflow/core/kernels/batchtospace_op.cc
@@ -266,7 +266,7 @@ class BatchToSpaceOp : public OpKernel {
 TF_CALL_REAL_NUMBER_TYPES(REGISTER);
 #undef REGISTER
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define REGISTER(T)                                        \
   REGISTER_KERNEL_BUILDER(Name("BatchToSpaceND")           \
                               .Device(DEVICE_GPU)          \
@@ -282,6 +282,6 @@ TF_CALL_REAL_NUMBER_TYPES(REGISTER);
 
 TF_CALL_GPU_NUMBER_TYPES(REGISTER);
 #undef REGISTER
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // end namespace tensorflow


### PR DESCRIPTION
This PR (re) adds ROCm support for batch_to_space op

The changes in this PR are trivial, please review and merge.

Note, ROCm support for this op was previously enabled and then disabled because of dependency issues. 

-------------------------------------------------

@tatianashp @whchung @chsigg 
