### PR TITLE
[XLA:GPU][ROCm] Introduce ROCm-Device-Libs into TensorFlow ROCm build

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -132,6 +132,9 @@ load(
     "tf_additional_numa_lib_defines",
     "tf_additional_proto_hdrs",
     "tf_additional_proto_srcs",
+    "tf_additional_rocdl_data",
+    "tf_additional_rocdl_deps",
+    "tf_additional_rocdl_srcs",
     "tf_additional_test_deps",
     "tf_additional_test_srcs",
     "tf_additional_verbs_lib_defines",
@@ -155,6 +158,7 @@ load(
     "if_dynamic_kernels",
     "if_static",
     "tf_cuda_tests_tags",
+    "tf_gpu_tests_tags",
 )
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load("@local_config_tensorrt//:build_defs.bzl", "if_tensorrt")
@@ -1845,6 +1849,7 @@ filegroup(
             # :platform_base, a common dependency for downstream targets.
             "platform/**/env_time.cc",
             "platform/**/logging.cc",
+            "platform/**/rocm_rocdl_path.*",
             "platform/default/test_benchmark.*",
             "platform/cuda.h",
             "platform/rocm.h",
@@ -2521,6 +2526,7 @@ cc_library(
             "platform/**/logger.cc",
             "platform/**/logging.cc",
             "platform/**/human_readable_json.cc",
+            "platform/**/rocm_rocdl_path.cc",
             "platform/abi.cc",
             "platform/protobuf.cc",
         ],
@@ -2537,6 +2543,8 @@ cc_library(
             "platform/**/logger.cc",
             "platform/**/logging.cc",
             "platform/**/human_readable_json.cc",
+            "platform/**/rocm.h",
+            "platform/**/rocm_rocdl_path.cc",
             "platform/abi.cc",
         ] +
         # Protobuf deps already included through the ":lib_proto_parsing"
@@ -4581,6 +4589,20 @@ tf_cuda_cc_test(
     ],
 )
 
+tf_cc_test_gpu(
+    name = "rocm_rocdl_path_test",
+    size = "small",
+    srcs = ["platform/rocm_rocdl_path_test.cc"],
+    linkstatic = tf_kernel_tests_linkstatic(),
+    tags = tf_gpu_tests_tags(),
+    deps = [
+        ":rocm_rocdl_path",
+        ":lib",
+        ":test",
+        ":test_main",
+    ],
+)
+
 tf_cuda_only_cc_test(
     name = "util_gpu_kernel_helper_test",
     srcs = [
@@ -5555,6 +5577,18 @@ cc_library(
     deps = [
         ":lib",
     ] + tf_additional_libdevice_deps(),
+)
+
+cc_library(
+    name = "rocm_rocdl_path",
+    srcs = ["platform/rocm_rocdl_path.cc"] + tf_additional_rocdl_srcs(),
+    hdrs = ["platform/rocm_rocdl_path.h"],
+    copts = tf_copts(),
+    data = tf_additional_rocdl_data(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":lib",
+    ] + tf_additional_rocdl_deps(),
 )
 
 transitive_hdrs(

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -4596,8 +4596,8 @@ tf_cc_test_gpu(
     linkstatic = tf_kernel_tests_linkstatic(),
     tags = tf_gpu_tests_tags(),
     deps = [
-        ":rocm_rocdl_path",
         ":lib",
+        ":rocm_rocdl_path",
         ":test",
         ":test_main",
     ],

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -626,6 +626,15 @@ def tf_additional_libdevice_deps():
 def tf_additional_libdevice_srcs():
     return ["platform/default/cuda_libdevice_path.cc"]
 
+def tf_additional_rocdl_data():
+  return []
+
+def tf_additional_rocdl_deps():
+  return ["@local_config_rocm//rocm:rocm_headers"]
+
+def tf_additional_rocdl_srcs():
+  return ["platform/default/rocm_rocdl_path.cc"]
+
 def tf_additional_test_deps():
     return []
 

--- a/tensorflow/core/platform/default/rocm_rocdl_path.cc
+++ b/tensorflow/core/platform/default/rocm_rocdl_path.cc
@@ -1,0 +1,32 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/platform/rocm_rocdl_path.h"
+
+#include <stdlib.h>
+
+#if !defined(PLATFORM_GOOGLE)
+#include "rocm/rocm_config.h"
+#endif
+#include "tensorflow/core/platform/logging.h"
+
+namespace tensorflow {
+
+string ROCmRoot() {
+  VLOG(3) << "ROCM root = " << TF_ROCM_TOOLKIT_PATH;
+  return TF_ROCM_TOOLKIT_PATH;
+}
+
+}  // namespace tensorflow

--- a/tensorflow/core/platform/default/rocm_rocdl_path.cc
+++ b/tensorflow/core/platform/default/rocm_rocdl_path.cc
@@ -18,7 +18,7 @@ limitations under the License.
 #include <stdlib.h>
 
 #if !defined(PLATFORM_GOOGLE)
-#include "rocm/rocm_config.h"
+#include "third_party/gpus/rocm/rocm_config.h"
 #endif
 #include "tensorflow/core/platform/logging.h"
 

--- a/tensorflow/core/platform/default/rocm_rocdl_path.cc
+++ b/tensorflow/core/platform/default/rocm_rocdl_path.cc
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include <stdlib.h>
 
-#if !defined(PLATFORM_GOOGLE)
+#if !defined(PLATFORM_GOOGLE) && TENSORFLOW_USE_ROCM
 #include "third_party/gpus/rocm/rocm_config.h"
 #endif
 #include "tensorflow/core/platform/logging.h"
@@ -25,8 +25,12 @@ limitations under the License.
 namespace tensorflow {
 
 string ROCmRoot() {
+#if TENSORFLOW_USE_ROCM
   VLOG(3) << "ROCM root = " << TF_ROCM_TOOLKIT_PATH;
   return TF_ROCM_TOOLKIT_PATH;
+#else
+  return "";
+#endif
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/rocm_rocdl_path.cc
+++ b/tensorflow/core/platform/rocm_rocdl_path.cc
@@ -1,0 +1,26 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/platform/rocm_rocdl_path.h"
+
+#include "tensorflow/core/lib/io/path.h"
+
+namespace tensorflow {
+
+string ROCDLRoot() {
+  return tensorflow::io::JoinPath(tensorflow::ROCmRoot(), "hcc/lib");
+}
+
+}  // namespace tensorflow

--- a/tensorflow/core/platform/rocm_rocdl_path.h
+++ b/tensorflow/core/platform/rocm_rocdl_path.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef THIRD_PARTY_TENSORFLOW_CORE_PLATFORM_ROCM_ROCDL_PATH_H_
-#define THIRD_PARTY_TENSORFLOW_CORE_PLATFORM_ROCM_ROCDL_PATH_H_
+#ifndef TENSORFLOW_CORE_PLATFORM_ROCM_ROCDL_PATH_H_
+#define TENSORFLOW_CORE_PLATFORM_ROCM_ROCDL_PATH_H_
 
 #include "tensorflow/core/platform/types.h"
 
@@ -29,4 +29,4 @@ string ROCDLRoot();
 
 }  // namespace tensorflow
 
-#endif  // THIRD_PARTY_TENSORFLOW_CORE_PLATFORM_ROCM_ROCDL_PATH_H_
+#endif  // TENSORFLOW_CORE_PLATFORM_ROCM_ROCDL_PATH_H_

--- a/tensorflow/core/platform/rocm_rocdl_path.h
+++ b/tensorflow/core/platform/rocm_rocdl_path.h
@@ -1,0 +1,32 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef THIRD_PARTY_TENSORFLOW_CORE_PLATFORM_ROCM_ROCDL_PATH_H_
+#define THIRD_PARTY_TENSORFLOW_CORE_PLATFORM_ROCM_ROCDL_PATH_H_
+
+#include "tensorflow/core/platform/types.h"
+
+namespace tensorflow {
+
+// Returns the root directory of the ROCM SDK, which contains sub-folders such
+// as bin, lib, and rocdl.
+string ROCmRoot();
+
+// Returns the directory that contains ROCm-Device-Libs files in the ROCm SDK.
+string ROCDLRoot();
+
+}  // namespace tensorflow
+
+#endif  // THIRD_PARTY_TENSORFLOW_CORE_PLATFORM_ROCM_ROCDL_PATH_H_

--- a/tensorflow/core/platform/rocm_rocdl_path_test.cc
+++ b/tensorflow/core/platform/rocm_rocdl_path_test.cc
@@ -1,0 +1,36 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/platform/rocm_rocdl_path.h"
+
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/lib/io/path.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+
+#if TENSORFLOW_USE_ROCM
+TEST(ROCmROCDLPathTest, ROCDLPath) {
+  VLOG(2) << "ROCm-Deivce-Libs root = " << ROCDLRoot();
+  std::vector<string> rocdl_files;
+  TF_EXPECT_OK(Env::Default()->GetMatchingPaths(
+      io::JoinPath(ROCDLRoot(), "*.amdgcn.bc"),
+      &rocdl_files));
+  EXPECT_LT(0, rocdl_files.size());
+}
+#endif
+
+}  // namespace tensorflow


### PR DESCRIPTION
ROCm-Device-Libs is used by XLA on ROCm for various device intrinsics.