### PR TITLE
Fixing missed saving of "interpolation" parameter in UpSampling2D layer

### DIFF
--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -1985,7 +1985,7 @@ class UpSampling2D(Layer):
         interpolation=self.interpolation)
 
   def get_config(self):
-    config = {'size': self.size, 'data_format': self.data_format}
+    config = {'size': self.size, 'data_format': self.data_format, 'interpolation': self.interpolation}
     base_config = super(UpSampling2D, self).get_config()
     return dict(list(base_config.items()) + list(config.items()))
 


### PR DESCRIPTION
**Bug description**: UpSampling2D layers in a model restored by "tf.keras.models.load_model" are initialized with interpolation="nearest" even if in original model UpSampling2D layers have interpolation="bilinear".