### PR TITLE
add -lm to mlir-tblgen linkopts

### DIFF
--- a/third_party/mlir/BUILD
+++ b/third_party/mlir/BUILD
@@ -1251,7 +1251,7 @@ cc_binary(
         "tools/mlir-tblgen/mlir-tblgen.cpp",
     ],
     includes = ["include"],
-    linkopts = ["-lpthread"],
+    linkopts = ["-lpthread", "-lm"],
     deps = [
         ":Support",
         ":TableGen",


### PR DESCRIPTION
Fixes the following build error:

```
Couldn't build file external/local_config_mlir/mlir-tblgen: Linking of rule '@local_config_mlir//:mlir-tblgen' failed (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing command
...
/usr/bin/ld: bazel-out/k8-opt/bin/external/llvm/libsupport.a(APInt.o): undefined reference to symbol 'round@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```