### PR TITLE
[INTEL_MKL] Parallelizing scatter update operation

### DIFF
--- a/tensorflow/core/kernels/scatter_functor.h
+++ b/tensorflow/core/kernels/scatter_functor.h
@@ -207,7 +207,7 @@ struct ScatterFunctorBase {
     const Index N = static_cast<Index>(indices.size());
     const Index limit = static_cast<Index>(params.dimension(0));
     mutex mu_;
-    Index bad_index = -1 GUARDED_BY(mu_);
+    Index bad_index GUARDED_BY(mu_) = -1;
     auto ParallelScatter = [&](Index start, Index end) LOCKS_EXCLUDED(mu_){
       for (Index i = start; i < end; i++) {
         // Grab the index and check its validity.  Do this carefully,

--- a/tensorflow/core/kernels/scatter_op_test.cc
+++ b/tensorflow/core/kernels/scatter_op_test.cc
@@ -341,7 +341,7 @@ static void BM_ScatterMaxInt32(int iters, int embedding_size) {
 static void BM_ScatterMaxInt64(int iters, int embedding_size) {
   BM_ScatterHelper<int64>(iters, embedding_size, "ScatterMax");
 }
-/*
+
 BENCHMARK(BM_ScatterUpdateInt32)
     ->Arg(1)
     ->Arg(10)
@@ -364,9 +364,9 @@ BENCHMARK(BM_ScatterUpdateInt64)
     ->Arg(256)
     ->Arg(1024)
     ->Arg(100000);
-*/
+
 BENCHMARK(BM_ScatterAddInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
-/*
+
 BENCHMARK(BM_ScatterAddInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 
 BENCHMARK(BM_ScatterMulInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
@@ -380,6 +380,6 @@ BENCHMARK(BM_ScatterMinInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 
 BENCHMARK(BM_ScatterMaxInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 BENCHMARK(BM_ScatterMaxInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
-*/
+
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/scatter_op_test.cc
+++ b/tensorflow/core/kernels/scatter_op_test.cc
@@ -47,6 +47,17 @@ class ScatterUpdateOpTest : public OpsTestBase {
     TF_ASSERT_OK(InitOp());
   }
 };
+class ScatterSubOpTest : public OpsTestBase {
+ protected:
+  void MakeOp(DataType variable_ref_type, DataType index_type) {
+    TF_ASSERT_OK(NodeDefBuilder("myop", "ScatterSub")
+                     .Input(FakeInput(variable_ref_type))
+                     .Input(FakeInput(index_type))
+                     .Input(FakeInput(RemoveRefType(variable_ref_type)))
+                     .Finalize(node_def()));
+    TF_ASSERT_OK(InitOp());
+  }
+};
 
 TEST_F(ScatterUpdateOpTest, Simple_StringType) {
   MakeOp(DT_STRING_REF, DT_INT32);
@@ -175,6 +186,19 @@ TEST_F(ScatterUpdateOpTest, Error_IndexOutOfRange) {
       << s;
 }
 
+TEST_F(ScatterSubOpTest, Error_IndexOutOfRange) {
+  MakeOp(DT_FLOAT_REF, DT_INT32);
+  // Feed and run
+  AddInputFromArray<float>(TensorShape({14}),
+                           {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+  AddInputFromArray<int32>(TensorShape({3}), {0, 1, 99});
+  AddInputFromArray<float>(TensorShape({3}), {100, 101, 102});
+  Status s = RunOpKernel();
+  EXPECT_TRUE(
+      absl::StrContains(s.ToString(), "indices[2] = 99 is not in [0, 14)"))
+      << s;
+}
+
 TEST_F(ScatterUpdateOpTest, Error_WrongDimsIndices) {
   MakeOp(DT_FLOAT_REF, DT_INT32);
 
@@ -238,7 +262,8 @@ class ScatterUpdateBM : public ScatterUpdateOpTest {
 };
 
 template <typename Index>
-static void BM_ScatterHelper(int iters, int embedding_size, const char* op) {
+static void BM_ScatterHelper(int iters, int embedding_size, const char* op,
+                             bool big_num_updates = false) {
   testing::StopTiming();
   const int kRows = 10000000 / embedding_size;
   std::vector<float> values;
@@ -246,7 +271,7 @@ static void BM_ScatterHelper(int iters, int embedding_size, const char* op) {
   for (int i = 0; i < kRows * embedding_size; i++) {
     values.push_back(i);
   }
-  const int kNumUpdates = 1000;
+  int kNumUpdates = big_num_updates ? 1000000 : 1000;
   random::PhiloxRandom philox(301, 17);
   random::SimplePhilox rnd(&philox);
   std::vector<Index> indices;
@@ -282,7 +307,9 @@ static void BM_ScatterUpdateInt64(int iters, int embedding_size) {
 
 static void BM_ScatterAddInt32(int iters, int embedding_size) {
   BM_ScatterHelper<int32>(iters, embedding_size, "ScatterAdd");
+  BM_ScatterHelper<int32>(iters, embedding_size, "ScatterAdd", true);
 }
+
 static void BM_ScatterAddInt64(int iters, int embedding_size) {
   BM_ScatterHelper<int64>(iters, embedding_size, "ScatterAdd");
 }
@@ -314,7 +341,7 @@ static void BM_ScatterMaxInt32(int iters, int embedding_size) {
 static void BM_ScatterMaxInt64(int iters, int embedding_size) {
   BM_ScatterHelper<int64>(iters, embedding_size, "ScatterMax");
 }
-
+/*
 BENCHMARK(BM_ScatterUpdateInt32)
     ->Arg(1)
     ->Arg(10)
@@ -337,8 +364,9 @@ BENCHMARK(BM_ScatterUpdateInt64)
     ->Arg(256)
     ->Arg(1024)
     ->Arg(100000);
-
+*/
 BENCHMARK(BM_ScatterAddInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
+/*
 BENCHMARK(BM_ScatterAddInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 
 BENCHMARK(BM_ScatterMulInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
@@ -352,6 +380,6 @@ BENCHMARK(BM_ScatterMinInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 
 BENCHMARK(BM_ScatterMaxInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 BENCHMARK(BM_ScatterMaxInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
-
+*/
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/scatter_op_test.cc
+++ b/tensorflow/core/kernels/scatter_op_test.cc
@@ -47,6 +47,7 @@ class ScatterUpdateOpTest : public OpsTestBase {
     TF_ASSERT_OK(InitOp());
   }
 };
+
 class ScatterSubOpTest : public OpsTestBase {
  protected:
   void MakeOp(DataType variable_ref_type, DataType index_type) {
@@ -271,7 +272,7 @@ static void BM_ScatterHelper(int iters, int embedding_size, const char* op,
   for (int i = 0; i < kRows * embedding_size; i++) {
     values.push_back(i);
   }
-  int kNumUpdates = big_num_updates ? 1000000 : 1000;
+  const int kNumUpdates = big_num_updates ? 1000000 : 1000;
   random::PhiloxRandom philox(301, 17);
   random::SimplePhilox rnd(&philox);
   std::vector<Index> indices;


### PR DESCRIPTION
This PR parallelizes scatter update op using TF thread pool.

Benchmark results from tensorflow/core/kernels/scatter_op_test.cc

Single Threaded
Benchmark                 Time(ns) Iterations
---------------------------------------------
BM_ScatterAddInt32/1      11742060        100    85.2M items/s
BM_ScatterAddInt32/10     23648080        100    422.9M items/s
BM_ScatterAddInt32/64     62754140        100    1019.9M items/s
BM_ScatterAddInt32/256   187718030        100    1363.7M items/s
BM_ScatterAddInt32/1024  662454890        100    1545.8M items/s

TF_NUM_INTRAOP_THREADS=13
Benchmark                 Time(ns) Iterations
---------------------------------------------
BM_ScatterAddInt32/1       2277507        282    439.1M items/s
BM_ScatterAddInt32/10      3805265        181    2627.9M items/s
BM_ScatterAddInt32/64     11039150        100    5797.5M items/s
BM_ScatterAddInt32/256    42545230        100    6017.1M items/s
BM_ScatterAddInt32/1024  139565500        100    7337.1M items/s

We are seeing about 5x improvements from the benchmark results on Skylake CPU's