### PR TITLE
[XLA:GPU][ROCm] Emit llvm::Intrinsic::nvvm_atomic_load_add_f32 only on NVPTX

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -205,8 +205,9 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
   }
 
   if (root_opcode == HloOpcode::kAdd) {
+    llvm::Triple target_triple = llvm::Triple(module_->getTargetTriple());
     // NVPTX supports atomicAdd on F32 and integer types.
-    if (element_type == F32) {
+    if (target_triple.isNVPTX() && element_type == F32) {
       // F32 + F32
       llvm_ir::EmitCallToIntrinsic(llvm::Intrinsic::nvvm_atomic_load_add_f32,
                                    {output_address, source},


### PR DESCRIPTION
Emit llvm::Intrinsic::nvvm_atomic_load_add_f32 only on NVPTX