### PR TITLE
Improve Flatten to avoid using dynamic shapes when possible

### DIFF
--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -580,9 +580,10 @@ class Flatten(Layer):
       permutation.append(1)
       inputs = array_ops.transpose(inputs, perm=permutation)
 
-    input_shape = tensor_shape.TensorShape(inputs.shape).as_list()
-    if input_shape and all(input_shape[1:]):
-      outputs = array_ops.reshape(inputs, (-1, int(np.prod(input_shape[1:]))))
+    input_shape = inputs.shape
+    if input_shape[1:].is_fully_defined():
+      outputs = array_ops.reshape(
+          inputs, (-1, tensor_shape.dimension_value(np.prod(input_shape[1:]))))
     else:
       outputs = array_ops.reshape(
           inputs, (tensor_shape.dimension_value(inputs.shape[0]) or

--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -580,9 +580,13 @@ class Flatten(Layer):
       permutation.append(1)
       inputs = array_ops.transpose(inputs, perm=permutation)
 
-    outputs = array_ops.reshape(
-        inputs, (tensor_shape.dimension_value(inputs.shape[0]) or
-                 array_ops.shape(inputs)[0], -1))
+    input_shape = tensor_shape.TensorShape(inputs.shape).as_list()
+    if input_shape and all(input_shape[1:]):
+      outputs = array_ops.reshape(inputs, (-1, np.prod(input_shape[1:])))
+    else:
+      outputs = array_ops.reshape(
+          inputs, (tensor_shape.dimension_value(inputs.shape[0]) or
+                  array_ops.shape(inputs)[0], -1))
     if not context.executing_eagerly():
       outputs.set_shape(self.compute_output_shape(inputs.shape))
     return outputs

--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -582,11 +582,11 @@ class Flatten(Layer):
 
     input_shape = tensor_shape.TensorShape(inputs.shape).as_list()
     if input_shape and all(input_shape[1:]):
-      outputs = array_ops.reshape(inputs, (-1, np.prod(input_shape[1:])))
+      outputs = array_ops.reshape(inputs, (-1, int(np.prod(input_shape[1:]))))
     else:
       outputs = array_ops.reshape(
           inputs, (tensor_shape.dimension_value(inputs.shape[0]) or
-                  array_ops.shape(inputs)[0], -1))
+                   array_ops.shape(inputs)[0], -1))
     if not context.executing_eagerly():
       outputs.set_shape(self.compute_output_shape(inputs.shape))
     return outputs

--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -582,8 +582,9 @@ class Flatten(Layer):
 
     input_shape = inputs.shape
     if input_shape[1:].is_fully_defined():
-      outputs = array_ops.reshape(
-          inputs, (-1, tensor_shape.dimension_value(np.prod(input_shape[1:]))))
+      flattened_dim = tensor_shape.dimension_value(
+          np.prod(input_shape[1:], dtype=int))
+      outputs = array_ops.reshape(inputs, (-1, flattened_dim))
     else:
       outputs = array_ops.reshape(
           inputs, (tensor_shape.dimension_value(inputs.shape[0]) or


### PR DESCRIPTION
Flatten currently creates a reshape which introduces a dependency on the size of the batch dimension. In the cases where flatten is commonly used, the batch dimension is usually not known statically but the rest of the dimensions are. 
This means that the constant folding grappler pass cannot resolve the shape ahead of time. This also makes it difficult to convert using TF-TRT.

The implementation of Flatten can be rewritten such that there is no dependency on an unknown batch dimension.

Previous implementation (simplification):
```
def flatten(x):
  return tf.reshape(x, [tf.shape(x)[0], -1])
```
This implementation:
```
def flatten(x):
  if all(x.shape[1:]):
    return tf.reshape(x, shape=(-1, prod(x.shape[1:]))
  else:
    return tf.reshape(x, shape=(tf.shape(x)[0], -1))
```

Fixes #25402