### PR TITLE
[XLA:GPU][ROCm] adding a DISABLED_ON_GPU_ROCM macro 

### DIFF
--- a/tensorflow/compiler/xla/tests/convolution_test.cc
+++ b/tensorflow/compiler/xla/tests/convolution_test.cc
@@ -1950,7 +1950,7 @@ class ConvolutionHloTest : public HloTestBase {};
 
 // double datatype is not yet supported in ROCm
 XLA_TEST_F(ConvolutionHloTest,
-           DISABLED_ON_GPU_ROCM(DISABLED_ON_CPU(ConvolveF64Forward))) {
+           DISABLED_ON_GPU_ROCM(ConvolveF64Forward)) {
   constexpr char kHlo[] = R"(
 HloModule TestModule
 
@@ -1976,7 +1976,7 @@ ENTRY Test {
 
 // double datatype is not yet supported in ROCm
 XLA_TEST_F(ConvolutionHloTest,
-           DISABLED_ON_GPU_ROCM(DISABLED_ON_CPU(ConvolveF64BackwardFilter))) {
+           DISABLED_ON_GPU_ROCM(ConvolveF64BackwardFilter)) {
   constexpr char kHlo[] = R"(
 HloModule TestModule
 
@@ -1990,7 +1990,7 @@ ENTRY Test {
 
 // double datatype is not yet supported in ROCm
 XLA_TEST_F(ConvolutionHloTest,
-           DISABLED_ON_GPU_ROCM(DISABLED_ON_CPU(ConvolveF64BackwardInput))) {
+           DISABLED_ON_GPU_ROCM(ConvolveF64BackwardInput)) {
   constexpr char kHlo[] = R"(
 HloModule TestModule
 

--- a/tensorflow/compiler/xla/tests/convolution_test.cc
+++ b/tensorflow/compiler/xla/tests/convolution_test.cc
@@ -408,7 +408,9 @@ class Convolve1D_1x2x5_1x2x2_WithPadding : public ConvolutionTest {
 TYPED_TEST_CASE(Convolve1D_1x2x5_1x2x2_WithPadding, TestTypes);
 TYPED_TEST(Convolve1D_1x2x5_1x2x2_WithPadding, Types) { this->RunTest(); }
 
-XLA_TEST_F(ConvolutionTest, Convolve3D_1x4x2x3x3_2x2x2x3x3_Valid) {
+// 5D tensors are not yet supported in ROCm
+XLA_TEST_F(ConvolutionTest,
+           DISABLED_ON_GPU_ROCM(Convolve3D_1x4x2x3x3_2x2x2x3x3_Valid)) {
   XlaBuilder builder(TestName());
   std::vector<int64> input_dims = {1, 4, 2, 3, 3};
   std::vector<int64> filter_dims = {2, 2, 2, 3, 3};
@@ -1946,7 +1948,9 @@ XLA_TEST_F(ConvolutionTest, ConvolveF32BackwardInputGroupedConvolution) {
 
 class ConvolutionHloTest : public HloTestBase {};
 
-XLA_TEST_F(ConvolutionHloTest, ConvolveF64Forward) {
+// double datatype is not yet supported in ROCm
+XLA_TEST_F(ConvolutionHloTest,
+           DISABLED_ON_GPU_ROCM(DISABLED_ON_CPU(ConvolveF64Forward))) {
   constexpr char kHlo[] = R"(
 HloModule TestModule
 
@@ -1970,7 +1974,9 @@ ENTRY Test {
   EXPECT_TRUE(RunAndCompare(kHlo, ErrorSpec{0.001}));
 }
 
-XLA_TEST_F(ConvolutionHloTest, ConvolveF64BackwardFilter) {
+// double datatype is not yet supported in ROCm
+XLA_TEST_F(ConvolutionHloTest,
+           DISABLED_ON_GPU_ROCM(DISABLED_ON_CPU(ConvolveF64BackwardFilter))) {
   constexpr char kHlo[] = R"(
 HloModule TestModule
 
@@ -1982,7 +1988,9 @@ ENTRY Test {
   EXPECT_TRUE(RunAndCompare(kHlo, ErrorSpec{0.001}));
 }
 
-XLA_TEST_F(ConvolutionHloTest, ConvolveF64BackwardInput) {
+// double datatype is not yet supported in ROCm
+XLA_TEST_F(ConvolutionHloTest,
+           DISABLED_ON_GPU_ROCM(DISABLED_ON_CPU(ConvolveF64BackwardInput))) {
   constexpr char kHlo[] = R"(
 HloModule TestModule
 

--- a/tensorflow/compiler/xla/tests/convolution_test.cc
+++ b/tensorflow/compiler/xla/tests/convolution_test.cc
@@ -408,9 +408,7 @@ class Convolve1D_1x2x5_1x2x2_WithPadding : public ConvolutionTest {
 TYPED_TEST_CASE(Convolve1D_1x2x5_1x2x2_WithPadding, TestTypes);
 TYPED_TEST(Convolve1D_1x2x5_1x2x2_WithPadding, Types) { this->RunTest(); }
 
-// 5D tensors are not yet supported in ROCm
-XLA_TEST_F(ConvolutionTest,
-           DISABLED_ON_GPU_ROCM(Convolve3D_1x4x2x3x3_2x2x2x3x3_Valid)) {
+XLA_TEST_F(ConvolutionTest, Convolve3D_1x4x2x3x3_2x2x2x3x3_Valid) {
   XlaBuilder builder(TestName());
   std::vector<int64> input_dims = {1, 4, 2, 3, 3};
   std::vector<int64> filter_dims = {2, 2, 2, 3, 3};

--- a/tensorflow/compiler/xla/tests/convolution_variants_test.cc
+++ b/tensorflow/compiler/xla/tests/convolution_variants_test.cc
@@ -1330,9 +1330,7 @@ XLA_TEST_F(ConvolutionVariantsTest, BackwardFilterEvenPadding1D) {
   ComputeAndCompareR3<float>(&builder, {{{13, 24, 130}}}, {}, error_spec_);
 }
 
-// 5D tensors are not yet supported in ROCm
-XLA_TEST_F(ConvolutionVariantsTest,
-           DISABLED_ON_GPU_ROCM(BackwardInputEvenPadding3D)) {
+XLA_TEST_F(ConvolutionVariantsTest, BackwardInputEvenPadding3D) {
   XlaBuilder builder(TestName());
 
   auto gradients_flat = LiteralUtil::CreateR1<float>({1});
@@ -1356,9 +1354,7 @@ XLA_TEST_F(ConvolutionVariantsTest,
   ComputeAndCompareLiteral(&builder, expected_literal, {}, error_spec_);
 }
 
-// 5D tensors are not yet supported in ROCm
-XLA_TEST_F(ConvolutionVariantsTest,
-           DISABLED_ON_GPU_ROCM(BackwardFilterEvenPadding3D)) {
+XLA_TEST_F(ConvolutionVariantsTest, BackwardFilterEvenPadding3D) {
   XlaBuilder builder(TestName());
 
   auto activations_flat = LiteralUtil::CreateR1<float>({1, 2, 3, 4});

--- a/tensorflow/compiler/xla/tests/convolution_variants_test.cc
+++ b/tensorflow/compiler/xla/tests/convolution_variants_test.cc
@@ -1330,7 +1330,9 @@ XLA_TEST_F(ConvolutionVariantsTest, BackwardFilterEvenPadding1D) {
   ComputeAndCompareR3<float>(&builder, {{{13, 24, 130}}}, {}, error_spec_);
 }
 
-XLA_TEST_F(ConvolutionVariantsTest, BackwardInputEvenPadding3D) {
+// 5D tensors are not yet supported in ROCm
+XLA_TEST_F(ConvolutionVariantsTest,
+           DISABLED_ON_GPU_ROCM(BackwardInputEvenPadding3D)) {
   XlaBuilder builder(TestName());
 
   auto gradients_flat = LiteralUtil::CreateR1<float>({1});
@@ -1354,7 +1356,9 @@ XLA_TEST_F(ConvolutionVariantsTest, BackwardInputEvenPadding3D) {
   ComputeAndCompareLiteral(&builder, expected_literal, {}, error_spec_);
 }
 
-XLA_TEST_F(ConvolutionVariantsTest, BackwardFilterEvenPadding3D) {
+// 5D tensors are not yet supported in ROCm
+XLA_TEST_F(ConvolutionVariantsTest,
+           DISABLED_ON_GPU_ROCM(BackwardFilterEvenPadding3D)) {
   XlaBuilder builder(TestName());
 
   auto activations_flat = LiteralUtil::CreateR1<float>({1, 2, 3, 4});

--- a/tensorflow/compiler/xla/tests/test_macros.h
+++ b/tensorflow/compiler/xla/tests/test_macros.h
@@ -36,6 +36,7 @@ limitations under the License.
 
 #define DISABLED_ON_CPU(X) X
 #define DISABLED_ON_GPU(X) X
+#define DISABLED_ON_GPU_ROCM(X) X
 #define DISABLED_ON_INTERPRETER(X) X
 
 // We need this macro instead of pasting directly to support nesting
@@ -54,6 +55,12 @@ limitations under the License.
 #ifdef XLA_TEST_BACKEND_GPU
 # undef DISABLED_ON_GPU
 # define DISABLED_ON_GPU(X) XLA_TEST_PASTE(DISABLED_, X)
+
+#if TENSORFLOW_USE_ROCM
+# undef DISABLED_ON_GPU_ROCM
+# define DISABLED_ON_GPU_ROCM(X) XLA_TEST_PASTE(DISABLED_, X)
+#endif // TENSORFLOW_USE_ROCM
+
 #endif  // XLA_TEST_BACKEND_GPU
 
 #ifdef XLA_TEST_BACKEND_INTERPRETER


### PR DESCRIPTION
adding a DISABLED_ON_GPU_ROCM macro to disable subtests that are not yet supported on ROCm.

Applying that macro to a few subtests in convolution_test.cc and convolution_variants_test.cc