### PR TITLE
Update kissfft to fix stdint.h issue on Windows

### DIFF
--- a/third_party/kissfft/workspace.bzl
+++ b/third_party/kissfft/workspace.bzl
@@ -5,11 +5,11 @@ load("//third_party:repo.bzl", "third_party_http_archive")
 def repo():
     third_party_http_archive(
         name = "kissfft",
-        strip_prefix = "kissfft-cddf3833fdf24fa84b79be37efdcd348cae0e39c",
-        sha256 = "7ba83a3da1636350472e501e3e6c3418df72466990530ea273c05fa7e3dd8635",
+        strip_prefix = "kissfft-36dbc057604f00aacfc0288ddad57e3b21cfc1b8",
+        sha256 = "42b7ef406d5aa2d57a7b3b56fc44e8ad3011581692458a69958a911071efdcf2",
         urls = [
-            "http://mirror.tensorflow.org/github.com/mborgerding/kissfft/archive/cddf3833fdf24fa84b79be37efdcd348cae0e39c.tar.gz",
-            "https://github.com/mborgerding/kissfft/archive/cddf3833fdf24fa84b79be37efdcd348cae0e39c.tar.gz",
+            "http://mirror.tensorflow.org/github.com/mborgerding/kissfft/archive/36dbc057604f00aacfc0288ddad57e3b21cfc1b8.tar.gz",
+            "https://github.com/mborgerding/kissfft/archive/36dbc057604f00aacfc0288ddad57e3b21cfc1b8.tar.gz",
         ],
         build_file = "//third_party/kissfft:BUILD.bazel",
     )


### PR DESCRIPTION
This fix tries to address the issue raised in #30447
where kissfft compile error on Windows 10 + VS 2019.
This fix updates kissfft to the latest commit to fix the issue.

This fix fixes #30447.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>