### PR TITLE
[LITE] Deprecated tf.random_normal changed to tf.random.normal

### DIFF
--- a/tensorflow/lite/experimental/examples/lstm/bidirectional_sequence_lstm_test.py
+++ b/tensorflow/lite/experimental/examples/lstm/bidirectional_sequence_lstm_test.py
@@ -86,8 +86,8 @@ class BidirectionalSequenceLstmTest(test_util.TensorFlowTestCase):
     """
     # Weights and biases for output softmax layer.
     out_weights = tf.Variable(
-        tf.random_normal([self.num_units * 2, self.n_classes]))
-    out_bias = tf.Variable(tf.random_normal([self.n_classes]))
+        tf.random.normal([self.num_units * 2, self.n_classes]))
+    out_bias = tf.Variable(tf.random.normal([self.n_classes]))
 
     # input image placeholder
     x = tf.placeholder(

--- a/tensorflow/lite/experimental/examples/lstm/bidirectional_sequence_rnn_test.py
+++ b/tensorflow/lite/experimental/examples/lstm/bidirectional_sequence_rnn_test.py
@@ -90,8 +90,8 @@ class BidirectionalSequenceRnnTest(test_util.TensorFlowTestCase):
     """
     # Weights and biases for output softmax layer.
     out_weights = tf.Variable(
-        tf.random_normal([self.num_units * 2, self.n_classes]))
-    out_bias = tf.Variable(tf.random_normal([self.n_classes]))
+        tf.random.normal([self.num_units * 2, self.n_classes]))
+    out_bias = tf.Variable(tf.random.normal([self.n_classes]))
 
     batch_size = self.batch_size
     if is_inference:

--- a/tensorflow/lite/experimental/examples/lstm/g3doc/README.md
+++ b/tensorflow/lite/experimental/examples/lstm/g3doc/README.md
@@ -71,7 +71,7 @@ tflite_model = converter.convert()  # You got a tflite model!
 +          tf.lite.experimental.nn.TFLiteLSTMCell(
                self.num_lstm_units, forget_bias=0))
      # Weights and biases for output softmax layer.
-     out_weights = tf.Variable(tf.random_normal([self.units, self.num_class]))
+     out_weights = tf.Variable(tf.random.normal([self.units, self.num_class]))
 @@ -67,7 +67,7 @@ class MnistLstmModel(object):
      lstm_cells = tf.nn.rnn_cell.MultiRNNCell(lstm_layers)
      # Note here, we use `tf.lite.experimental.nn.dynamic_rnn` and `time_major`
@@ -170,7 +170,7 @@ class MnistLstmModel(object):
           tf.lite.experimental.nn.TFLiteLSTMCell(
               self.num_lstm_units, forget_bias=0))
     # Weights and biases for output softmax layer.
-    out_weights = tf.Variable(tf.random_normal([self.units, self.num_class]))
+    out_weights = tf.Variable(tf.random.normal([self.units, self.num_class]))
     out_bias = tf.Variable(tf.zeros([self.num_class]))
 
     # Transpose input x to make it time major.

--- a/tensorflow/lite/experimental/examples/lstm/unidirectional_sequence_lstm_test.py
+++ b/tensorflow/lite/experimental/examples/lstm/unidirectional_sequence_lstm_test.py
@@ -83,8 +83,8 @@ class UnidirectionalSequenceLstmTest(test_util.TensorFlowTestCase):
     """
     # Weights and biases for output softmax layer.
     out_weights = tf.Variable(
-        tf.random_normal([self.num_units, self.n_classes]))
-    out_bias = tf.Variable(tf.random_normal([self.n_classes]))
+        tf.random.normal([self.num_units, self.n_classes]))
+    out_bias = tf.Variable(tf.random.normal([self.n_classes]))
 
     # input image placeholder
     x = tf.placeholder(

--- a/tensorflow/lite/experimental/examples/lstm/unidirectional_sequence_rnn_test.py
+++ b/tensorflow/lite/experimental/examples/lstm/unidirectional_sequence_rnn_test.py
@@ -79,8 +79,8 @@ class UnidirectionalSequenceRnnTest(test_util.TensorFlowTestCase):
     """
     # Weights and biases for output softmax layer.
     out_weights = tf.Variable(
-        tf.random_normal([self.num_units, self.n_classes]))
-    out_bias = tf.Variable(tf.random_normal([self.n_classes]))
+        tf.random.normal([self.num_units, self.n_classes]))
+    out_bias = tf.Variable(tf.random.normal([self.n_classes]))
 
     # input image placeholder
     x = tf.placeholder(


### PR DESCRIPTION
` From /media/siju/DATA/ubuntu_cache/bazel/_bazel_siju/800a48f78ba10e98e4a18f338aa2c1e2/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/lite/experimental/examples/lstm_test.runfiles/org_tensorflow/tensorflow/lite/experimental/examples/lstm/bidirectional_sequence_lstm_test.py:86: The name tf.random_normal is deprecated. Please use tf.random.normal instead.`