### PR TITLE
Removed duplicated registration of Less with bfloat16

### DIFF
--- a/tensorflow/core/kernels/cwise_op_less.cc
+++ b/tensorflow/core/kernels/cwise_op_less.cc
@@ -18,8 +18,7 @@ limitations under the License.
 namespace tensorflow {
 REGISTER5(BinaryOp, CPU, "Less", functor::less, float, Eigen::half, double,
           bfloat16, int32);
-REGISTER5(BinaryOp, CPU, "Less", functor::less, int64, uint8, int8, int16,
-          bfloat16);
+REGISTER4(BinaryOp, CPU, "Less", functor::less, int64, uint8, int8, int16);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 REGISTER7(BinaryOp, GPU, "Less", functor::less, float, Eigen::half, double,


### PR DESCRIPTION
This fix tries to address the issue raised in #30476 where
Op Less was registered twice which triggered `Multiple OpKernel registrations` error
This fix removes the duplication.

This fix fies #30476.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>