### PR TITLE
Deprecated random_uniform & random_normal ops removed from test and example files

### DIFF
--- a/tensorflow/contrib/eager/python/examples/densenet/densenet_test.py
+++ b/tensorflow/contrib/eager/python/examples/densenet/densenet_test.py
@@ -46,9 +46,9 @@ class DensenetTest(tf.test.TestCase):
                               pool_initial=False, include_top=True)
 
     if data_format == 'channels_last':
-      rand_input = tf.random_uniform((batch_size, 32, 32, 3))
+      rand_input = tf.random.uniform((batch_size, 32, 32, 3))
     else:
-      rand_input = tf.random_uniform((batch_size, 3, 32, 32))
+      rand_input = tf.random.uniform((batch_size, 3, 32, 32))
     output_shape = model(rand_input).shape
     self.assertEqual(output_shape, (batch_size, output_classes))
 
@@ -69,9 +69,9 @@ class DensenetTest(tf.test.TestCase):
                               pool_initial=False, include_top=True)
 
     if data_format == 'channels_last':
-      rand_input = tf.random_uniform((batch_size, 32, 32, 3))
+      rand_input = tf.random.uniform((batch_size, 32, 32, 3))
     else:
-      rand_input = tf.random_uniform((batch_size, 3, 32, 32))
+      rand_input = tf.random.uniform((batch_size, 3, 32, 32))
     output_shape = model(rand_input).shape
     self.assertEqual(output_shape, (batch_size, output_classes))
 
@@ -92,18 +92,18 @@ class DensenetTest(tf.test.TestCase):
                               pool_initial=True, include_top=True)
 
     if data_format == 'channels_last':
-      rand_input = tf.random_uniform((batch_size, 32, 32, 3))
+      rand_input = tf.random.uniform((batch_size, 32, 32, 3))
     else:
-      rand_input = tf.random_uniform((batch_size, 3, 32, 32))
+      rand_input = tf.random.uniform((batch_size, 3, 32, 32))
     output_shape = model(rand_input).shape
     self.assertEqual(output_shape, (batch_size, output_classes))
 
   def test_regularization(self):
     if tf.test.is_gpu_available():
-      rand_input = tf.random_uniform((10, 3, 32, 32))
+      rand_input = tf.random.uniform((10, 3, 32, 32))
       data_format = 'channels_first'
     else:
-      rand_input = tf.random_uniform((10, 32, 32, 3))
+      rand_input = tf.random.uniform((10, 32, 32, 3))
       data_format = 'channels_last'
     weight_decay = 1e-4
 
@@ -163,8 +163,8 @@ def random_batch(batch_size, data_format):
   shape = (batch_size,) + shape
 
   num_classes = 1000
-  images = tf.random_uniform(shape)
-  labels = tf.random_uniform(
+  images = tf.random.uniform(shape)
+  labels = tf.random.uniform(
       [batch_size], minval=0, maxval=num_classes, dtype=tf.int32)
   one_hot = tf.one_hot(labels, num_classes)
 

--- a/tensorflow/contrib/eager/python/examples/gan/mnist.py
+++ b/tensorflow/contrib/eager/python/examples/gan/mnist.py
@@ -220,7 +220,7 @@ def train_one_epoch(generator, discriminator, generator_optimizer,
     with tf.contrib.summary.record_summaries_every_n_global_steps(
         log_interval, global_step=step_counter):
       current_batch_size = images.shape[0]
-      noise = tf.random_uniform(
+      noise = tf.random.uniform(
           shape=[current_batch_size, noise_dim],
           minval=-1.,
           maxval=1.,

--- a/tensorflow/contrib/eager/python/examples/gan/mnist_test.py
+++ b/tensorflow/contrib/eager/python/examples/gan/mnist_test.py
@@ -54,10 +54,10 @@ class MnistEagerGanBenchmark(tf.test.Benchmark):
     for batch_size in [64, 128, 256]:
       # Generate some random data.
       burn_batches, measure_batches = (3, 100)
-      burn_images = [tf.random_normal([batch_size, 784])
+      burn_images = [tf.random.normal([batch_size, 784])
                      for _ in range(burn_batches)]
       burn_dataset = tf.data.Dataset.from_tensor_slices(burn_images)
-      measure_images = [tf.random_normal([batch_size, 784])
+      measure_images = [tf.random.normal([batch_size, 784])
                         for _ in range(measure_batches)]
       measure_dataset = tf.data.Dataset.from_tensor_slices(measure_images)
 
@@ -97,13 +97,13 @@ class MnistEagerGanBenchmark(tf.test.Benchmark):
 
         num_burn, num_iters = (30, 1000)
         for _ in range(num_burn):
-          noise = tf.random_uniform(shape=[batch_size, NOISE_DIM],
+          noise = tf.random.uniform(shape=[batch_size, NOISE_DIM],
                                     minval=-1., maxval=1.)
           generator(noise)
 
         start = time.time()
         for _ in range(num_iters):
-          noise = tf.random_uniform(shape=[batch_size, NOISE_DIM],
+          noise = tf.random.uniform(shape=[batch_size, NOISE_DIM],
                                     minval=-1., maxval=1.)
           generator(noise)
         self._report('generate', start, num_iters, batch_size)

--- a/tensorflow/contrib/eager/python/examples/l2hmc/l2hmc.py
+++ b/tensorflow/contrib/eager/python/examples/l2hmc/l2hmc.py
@@ -77,7 +77,7 @@ class Dynamics(tf.keras.Model):
 
     # Decide direction uniformly
     batch_size = tf.shape(position)[0]
-    forward_mask = tf.cast(tf.random_uniform((batch_size,)) > .5, tf.float32)
+    forward_mask = tf.cast(tf.random.uniform((batch_size,)) > .5, tf.float32)
     backward_mask = 1. - forward_mask
 
     # Obtain proposed states
@@ -93,7 +93,7 @@ class Dynamics(tf.keras.Model):
 
     # Accept or reject step
     accept_mask = tf.cast(
-        accept_prob > tf.random_uniform(tf.shape(accept_prob)), tf.float32)
+        accept_prob > tf.random.uniform(tf.shape(accept_prob)), tf.float32)
     reject_mask = 1. - accept_mask
 
     # Samples after accept/reject step
@@ -108,7 +108,7 @@ class Dynamics(tf.keras.Model):
     lf_fn = self._forward_lf if forward else self._backward_lf
 
     # Resample momentum
-    momentum = tf.random_normal(tf.shape(position))
+    momentum = tf.random.normal(tf.shape(position))
     position_post, momentum_post = position, momentum
     sumlogdet = 0.
     # Apply augmented leapfrog steps
@@ -328,7 +328,7 @@ def get_rw_energy_fn():
 def compute_loss(dynamics, x, scale=.1, eps=1e-4):
   """Compute loss defined in equation (8)."""
 
-  z = tf.random_normal(tf.shape(x))  # Auxiliary variable
+  z = tf.random.normal(tf.shape(x))  # Auxiliary variable
   x_, _, x_accept_prob, x_out = dynamics.apply_transition(x)
   z_, _, z_accept_prob, _ = dynamics.apply_transition(z)
 

--- a/tensorflow/contrib/eager/python/examples/l2hmc/l2hmc_test.py
+++ b/tensorflow/contrib/eager/python/examples/l2hmc/l2hmc_test.py
@@ -63,7 +63,7 @@ def warmup(dynamics,
            step_fn=step):
   """Warmup optimization to reduce overhead."""
 
-  samples = tf.random_normal(
+  samples = tf.random.normal(
       shape=[n_samples, dynamics.x_dim], dtype=tf.float32)
 
   for _ in range(n_iters):
@@ -107,7 +107,7 @@ class L2hmcTest(tf.test.TestCase):
         minus_loglikelihood_fn=energy_fn,
         n_steps=hparams.n_steps,
         eps=hparams.eps)
-    samples = tf.random_normal(shape=[hparams.n_samples, hparams.x_dim])
+    samples = tf.random.normal(shape=[hparams.n_samples, hparams.x_dim])
     x_, v_, x_accept_prob, x_out = dynamics.apply_transition(samples)
 
     self.assertEqual(x_.shape, v_.shape)
@@ -151,7 +151,7 @@ class L2hmcBenchmark(tf.test.Benchmark):
       tf.reset_default_graph()
       with tf.Graph().as_default():
         energy_fn, _, _ = l2hmc.get_scg_energy_fn()
-        x = tf.random_normal([hparams.n_samples, hparams.x_dim],
+        x = tf.random.normal([hparams.n_samples, hparams.x_dim],
                              dtype=tf.float32)
         dynamics = l2hmc.Dynamics(
             x_dim=hparams.x_dim,
@@ -218,7 +218,7 @@ class L2hmcBenchmark(tf.test.Benchmark):
           step_fn=step_fn)
 
       # Training
-      samples = tf.random_normal(
+      samples = tf.random.normal(
           shape=[hparams.n_samples, hparams.x_dim], dtype=tf.float32)
       start_time = time.time()
       fit(dynamics,

--- a/tensorflow/contrib/eager/python/examples/l2hmc/main.py
+++ b/tensorflow/contrib/eager/python/examples/l2hmc/main.py
@@ -75,7 +75,7 @@ def main(_):
     else:
       loss_fn = l2hmc.compute_loss
 
-    samples = tf.random_normal(shape=[n_samples, x_dim])
+    samples = tf.random.normal(shape=[n_samples, x_dim])
     for i in range(1, train_iters + 1):
       loss, samples, accept_prob = train_one_iter(
           dynamics,
@@ -108,7 +108,7 @@ def main(_):
   else:
     apply_transition = dynamics.apply_transition
 
-  samples = tf.random_normal(shape=[n_samples, x_dim])
+  samples = tf.random.normal(shape=[n_samples, x_dim])
   samples_history = []
   for i in range(eval_iters):
     samples_history.append(samples.numpy())

--- a/tensorflow/contrib/eager/python/examples/linear_regression/linear_regression.py
+++ b/tensorflow/contrib/eager/python/examples/linear_regression/linear_regression.py
@@ -110,8 +110,8 @@ def synthetic_dataset_helper(w, b, num_features, noise_level, batch_size,
   # - Generate x's as vectors with shape [batch_size N]
   # - y = tf.matmul(x, W) + b + noise
   def batch(_):
-    x = tf.random_normal([batch_size, num_features])
-    y = tf.matmul(x, w) + b + noise_level * tf.random_normal([])
+    x = tf.random.normal([batch_size, num_features])
+    y = tf.matmul(x, w) + b + noise_level * tf.random.normal([])
     return x, y
 
   with tf.device("/device:CPU:0"):

--- a/tensorflow/contrib/eager/python/examples/linear_regression/linear_regression_graph_test.py
+++ b/tensorflow/contrib/eager/python/examples/linear_regression/linear_regression_graph_test.py
@@ -30,8 +30,8 @@ class GraphLinearRegressionBenchmark(tf.test.Benchmark):
     num_batches = 200
     batch_size = 64
     dataset = linear_regression.synthetic_dataset_helper(
-        w=tf.random_uniform([3, 1]),
-        b=tf.random_uniform([1]),
+        w=tf.random.uniform([3, 1]),
+        b=tf.random.uniform([1]),
         num_features=3,
         noise_level=0.01,
         batch_size=batch_size,

--- a/tensorflow/contrib/eager/python/examples/linear_regression/linear_regression_test.py
+++ b/tensorflow/contrib/eager/python/examples/linear_regression/linear_regression_test.py
@@ -45,7 +45,7 @@ class LinearRegressionTest(tf.test.TestCase):
     super(LinearRegressionTest, self).tearDown()
 
   def testSyntheticDataset(self):
-    true_w = tf.random_uniform([3, 1])
+    true_w = tf.random.uniform([3, 1])
     true_b = [1.0]
     batch_size = 10
     num_batches = 2
@@ -87,8 +87,8 @@ class EagerLinearRegressionBenchmark(tf.test.Benchmark):
     num_batches = 200
     batch_size = 64
     dataset = linear_regression.synthetic_dataset(
-        w=tf.random_uniform([3, 1]),
-        b=tf.random_uniform([1]),
+        w=tf.random.uniform([3, 1]),
+        b=tf.random.uniform([1]),
         noise_level=0.01,
         batch_size=batch_size,
         num_batches=num_batches)

--- a/tensorflow/contrib/eager/python/examples/resnet50/resnet50_test.py
+++ b/tensorflow/contrib/eager/python/examples/resnet50/resnet50_test.py
@@ -42,8 +42,8 @@ def random_batch(batch_size, data_format):
   shape = (batch_size,) + shape
 
   num_classes = 1000
-  images = tf.random_uniform(shape)
-  labels = tf.random_uniform(
+  images = tf.random.uniform(shape)
+  labels = tf.random.uniform(
       [batch_size], minval=0, maxval=num_classes, dtype=tf.int32)
   one_hot = tf.one_hot(labels, num_classes)
 

--- a/tensorflow/contrib/eager/python/examples/revnet/blocks_test.py
+++ b/tensorflow/contrib/eager/python/examples/revnet/blocks_test.py
@@ -56,7 +56,7 @@ def _validate_block_call_channels_last(block_factory, test):
   with tf.device("/cpu:0"):  # NHWC format
     input_shape = (8, 8, 128)
     data_shape = (16,) + input_shape
-    x = tf.random_normal(shape=data_shape)
+    x = tf.random.normal(shape=data_shape)
 
     # Stride 1
     block = block_factory(
@@ -97,7 +97,7 @@ def _validate_block_call_channels_first(block_factory, test):
   with tf.device("/gpu:0"):  # Default NCHW format
     input_shape = (128, 8, 8)
     data_shape = (16,) + input_shape
-    x = tf.random_normal(shape=data_shape)
+    x = tf.random.normal(shape=data_shape)
 
     # Stride of 1
     block = block_factory(filters=128, strides=(1, 1), input_shape=input_shape)
@@ -131,8 +131,8 @@ class RevBlockTest(tf.test.TestCase):
       # Stride 1
       input_shape = (128, 8, 8)
       data_shape = (16,) + input_shape
-      x = tf.random_normal(shape=data_shape, dtype=tf.float64)
-      dy = tf.random_normal(shape=data_shape, dtype=tf.float64)
+      x = tf.random.normal(shape=data_shape, dtype=tf.float64)
+      dy = tf.random.normal(shape=data_shape, dtype=tf.float64)
       dy1, dy2 = tf.split(dy, num_or_size_splits=2, axis=1)
       block = blocks.RevBlock(
           n_res=3,
@@ -160,8 +160,8 @@ class RevBlockTest(tf.test.TestCase):
       self._check_grad_angle(dw_true, dw)
 
       # Stride 2
-      x = tf.random_normal(shape=data_shape, dtype=tf.float64)
-      dy = tf.random_normal(shape=(16, 128, 4, 4), dtype=tf.float64)
+      x = tf.random.normal(shape=data_shape, dtype=tf.float64)
+      dy = tf.random.normal(shape=(16, 128, 4, 4), dtype=tf.float64)
       dy1, dy2 = tf.split(dy, num_or_size_splits=2, axis=1)
       block = blocks.RevBlock(
           n_res=3,
@@ -194,8 +194,8 @@ class RevBlockTest(tf.test.TestCase):
 
     input_shape = (128, 8, 8)
     data_shape = (16,) + input_shape
-    x = tf.random_normal(shape=data_shape, dtype=tf.float64)
-    dy = tf.random_normal(shape=data_shape, dtype=tf.float64)
+    x = tf.random.normal(shape=data_shape, dtype=tf.float64)
+    dy = tf.random.normal(shape=data_shape, dtype=tf.float64)
     dy1, dy2 = tf.split(dy, num_or_size_splits=2, axis=1)
     block = blocks.RevBlock(
         n_res=3,
@@ -234,8 +234,8 @@ class _ResidualTest(tf.test.TestCase):
       input_shape = (128, 8, 8)
       data_shape = (16,) + input_shape
       # Use double precision for testing
-      x_true = tf.random_normal(shape=data_shape, dtype=tf.float64)
-      dy = tf.random_normal(shape=data_shape, dtype=tf.float64)
+      x_true = tf.random.normal(shape=data_shape, dtype=tf.float64)
+      dy = tf.random.normal(shape=data_shape, dtype=tf.float64)
       dy1, dy2 = tf.split(dy, num_or_size_splits=2, axis=1)
       residual = blocks._Residual(
           filters=128,

--- a/tensorflow/contrib/eager/python/examples/revnet/ops_test.py
+++ b/tensorflow/contrib/eager/python/examples/revnet/ops_test.py
@@ -30,7 +30,7 @@ class OpsTest(tf.test.TestCase):
 
     batch_size = 100
     # NHWC format
-    x = tf.random_normal(shape=[batch_size, 32, 32, 3])
+    x = tf.random.normal(shape=[batch_size, 32, 32, 3])
     # HW doesn't change but number of features increased
     y = ops.downsample(x, filters=5, strides=(1, 1), axis=3)
     self.assertEqual(y.shape, [batch_size, 32, 32, 5])
@@ -42,18 +42,18 @@ class OpsTest(tf.test.TestCase):
     self.assertEqual(y.shape, [batch_size, 16, 16, 5])
 
     # Test gradient flow
-    x = tf.random_normal(shape=[batch_size, 32, 32, 3])
+    x = tf.random.normal(shape=[batch_size, 32, 32, 3])
     with tfe.GradientTape() as tape:
       tape.watch(x)
       y = ops.downsample(x, filters=3, strides=(1, 1))
     self.assertEqual(y.shape, x.shape)
-    dy = tf.random_normal(shape=[batch_size, 32, 32, 3])
+    dy = tf.random.normal(shape=[batch_size, 32, 32, 3])
     grad, = tape.gradient(y, [x], output_gradients=[dy])
     self.assertEqual(grad.shape, x.shape)
 
     # Default NCHW format
     if tf.test.is_gpu_available():
-      x = tf.random_normal(shape=[batch_size, 3, 32, 32])
+      x = tf.random.normal(shape=[batch_size, 3, 32, 32])
       # HW doesn't change but feature map reduced
       y = ops.downsample(x, filters=5, strides=(1, 1))
       self.assertEqual(y.shape, [batch_size, 5, 32, 32])
@@ -65,12 +65,12 @@ class OpsTest(tf.test.TestCase):
       self.assertEqual(y.shape, [batch_size, 5, 16, 16])
 
       # Test gradient flow
-      x = tf.random_normal(shape=[batch_size, 3, 32, 32])
+      x = tf.random.normal(shape=[batch_size, 3, 32, 32])
       with tfe.GradientTape() as tape:
         tape.watch(x)
         y = ops.downsample(x, filters=3, strides=(1, 1))
       self.assertEqual(y.shape, x.shape)
-      dy = tf.random_normal(shape=[batch_size, 3, 32, 32])
+      dy = tf.random.normal(shape=[batch_size, 3, 32, 32])
       grad, = tape.gradient(y, [x], output_gradients=[dy])
       self.assertEqual(grad.shape, x.shape)
 

--- a/tensorflow/contrib/eager/python/examples/revnet/revnet_test.py
+++ b/tensorflow/contrib/eager/python/examples/revnet/revnet_test.py
@@ -55,8 +55,8 @@ class RevNetTest(tf.test.TestCase):
     config.batch_size = 2
     shape = (config.batch_size,) + config.input_shape
     self.model = revnet.RevNet(config=config)
-    self.x = tf.random_normal(shape=shape, dtype=tf.float64)
-    self.t = tf.random_uniform(
+    self.x = tf.random.normal(shape=shape, dtype=tf.float64)
+    self.t = tf.random.uniform(
         shape=[config.batch_size],
         minval=0,
         maxval=config.n_classes,
@@ -147,9 +147,9 @@ class RevNetTest(tf.test.TestCase):
       config.add_hparam("n_classes", 10)
       config.add_hparam("dataset", "cifar-10")
 
-      x = tf.random_normal(
+      x = tf.random.normal(
           shape=(self.config.batch_size,) + self.config.input_shape)
-      t = tf.random_uniform(
+      t = tf.random.uniform(
           shape=(self.config.batch_size,),
           minval=0,
           maxval=self.config.n_classes,
@@ -177,8 +177,8 @@ def device_and_data_format():
 
 def random_batch(batch_size, config):
   shape = (batch_size,) + config.input_shape
-  images = tf.random_uniform(shape)
-  labels = tf.random_uniform(
+  images = tf.random.uniform(shape)
+  labels = tf.random.uniform(
       [batch_size], minval=0, maxval=config.n_classes, dtype=tf.int32)
 
   return images, labels

--- a/tensorflow/contrib/eager/python/examples/rnn_colorbot/rnn_colorbot_test.py
+++ b/tensorflow/contrib/eager/python/examples/rnn_colorbot/rnn_colorbot_test.py
@@ -31,12 +31,12 @@ def random_dataset():
   time_steps = 10
   alphabet = 50
   chars = tf.one_hot(
-      tf.random_uniform(
+      tf.random.uniform(
           [batch_size, time_steps], minval=0, maxval=alphabet, dtype=tf.int32),
       alphabet)
   sequence_length = tf.constant(
       [time_steps for _ in range(batch_size)], dtype=tf.int64)
-  labels = tf.random_normal([batch_size, LABEL_DIMENSION])
+  labels = tf.random.normal([batch_size, LABEL_DIMENSION])
   return tf.data.Dataset.from_tensors((labels, chars, sequence_length))
 
 

--- a/tensorflow/contrib/eager/python/examples/spinn/spinn_test.py
+++ b/tensorflow/contrib/eager/python/examples/spinn/spinn_test.py
@@ -45,14 +45,14 @@ def _generate_synthetic_snli_data_batch(sequence_length,
                                         vocab_size):
   """Generate a fake batch of SNLI data for testing."""
   with tf.device("cpu:0"):
-    labels = tf.random_uniform([batch_size], minval=1, maxval=4, dtype=tf.int64)
-    prem = tf.random_uniform(
+    labels = tf.random.uniform([batch_size], minval=1, maxval=4, dtype=tf.int64)
+    prem = tf.random.uniform(
         (sequence_length, batch_size), maxval=vocab_size, dtype=tf.int64)
     prem_trans = tf.constant(np.array(
         [[3, 3, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3,
           2, 3, 3, 2, 2, 3, 3, 3, 2, 2, 2, 2,
           3, 2, 2]] * batch_size, dtype=np.int64).T)
-    hypo = tf.random_uniform(
+    hypo = tf.random.uniform(
         (sequence_length, batch_size), maxval=vocab_size, dtype=tf.int64)
     hypo_trans = tf.constant(np.array(
         [[3, 3, 2, 3, 3, 3, 2, 2, 2, 3, 3, 3,
@@ -168,9 +168,9 @@ class SpinnTest(test_util.TensorFlowTestCase):
       right_in = []
       tracking = []
       for _ in range(batch_size):
-        left_in.append(tf.random_normal((1, size * 2)))
-        right_in.append(tf.random_normal((1, size * 2)))
-        tracking.append(tf.random_normal((1, tracker_size * 2)))
+        left_in.append(tf.random.normal((1, size * 2)))
+        right_in.append(tf.random.normal((1, size * 2)))
+        tracking.append(tf.random.normal((1, tracker_size * 2)))
 
       out = reducer(left_in, right_in, tracking=tracking)
       self.assertEqual(batch_size, len(out))
@@ -210,7 +210,7 @@ class SpinnTest(test_util.TensorFlowTestCase):
       bufs = []
       buf = []
       for _ in range(buffer_length):
-        buf.append(tf.random_normal((batch_size, size * 2)))
+        buf.append(tf.random.normal((batch_size, size * 2)))
       bufs.append(buf)
       self.assertEqual(1, len(bufs))
       self.assertEqual(buffer_length, len(bufs[0]))
@@ -219,7 +219,7 @@ class SpinnTest(test_util.TensorFlowTestCase):
       stacks = []
       stack = []
       for _ in range(stack_size):
-        stack.append(tf.random_normal((batch_size, size * 2)))
+        stack.append(tf.random.normal((batch_size, size * 2)))
       stacks.append(stack)
       self.assertEqual(1, len(stacks))
       self.assertEqual(3, len(stacks[0]))
@@ -251,7 +251,7 @@ class SpinnTest(test_util.TensorFlowTestCase):
       s = spinn.SPINN(config)
 
       # Create some fake data.
-      buffers = tf.random_normal((sequence_length, 1, config.d_proj))
+      buffers = tf.random.normal((sequence_length, 1, config.d_proj))
       transitions = tf.constant(
           [[3], [3], [2], [3], [3], [3], [2], [2], [2], [3], [3], [3],
            [2], [3], [3], [2], [2], [3], [3], [3], [2], [2], [2], [2],
@@ -274,7 +274,7 @@ class SpinnTest(test_util.TensorFlowTestCase):
       config = _test_spinn_config(d_embed, d_out)
 
       # Create fake embedding matrix.
-      embed = tf.random_normal((vocab_size, d_embed))
+      embed = tf.random.normal((vocab_size, d_embed))
 
       model = spinn.SNLIClassifier(config, embed)
       trainer = spinn.SNLIClassifierTrainer(model, config.lr)
@@ -446,7 +446,7 @@ class EagerSpinnSNLIClassifierBenchmark(test.Benchmark):
       d_embed = 200
       d_out = 4
 
-      embed = tf.random_normal((vocab_size, d_embed))
+      embed = tf.random.normal((vocab_size, d_embed))
 
       config = _test_spinn_config(d_embed, d_out)
       model = spinn.SNLIClassifier(config, embed)

--- a/tensorflow/contrib/mpi_collectives/mpi_ops_test.py
+++ b/tensorflow/contrib/mpi_collectives/mpi_ops_test.py
@@ -90,7 +90,7 @@ class MPITests(tf.test.TestCase):
       dims = [1, 2, 3]
       for dtype, dim in itertools.product(dtypes, dims):
         tf.set_random_seed(1234)
-        tensor = tf.random_uniform([17] * dim, -100, 100, dtype=dtype)
+        tensor = tf.random.uniform([17] * dim, -100, 100, dtype=dtype)
         summed = mpi.allreduce(tensor, average=False)
         multiplied = tensor * size
         max_difference = tf.reduce_max(tf.abs(summed - multiplied))
@@ -134,7 +134,7 @@ class MPITests(tf.test.TestCase):
       dim = 3
       with tf.device("/gpu:0"):
         tf.set_random_seed(1234)
-        tensor = tf.random_uniform([17] * dim, -100, 100, dtype=dtype)
+        tensor = tf.random.uniform([17] * dim, -100, 100, dtype=dtype)
         summed = mpi.allreduce(tensor, average=False)
         multiplied = tensor * size
         max_difference = tf.reduce_max(tf.abs(summed - multiplied))
@@ -168,7 +168,7 @@ class MPITests(tf.test.TestCase):
       # Same rank, different dimension
       tf.set_random_seed(1234)
       dims = [17 + rank] * 3
-      tensor = tf.random_uniform(dims, -1.0, 1.0)
+      tensor = tf.random.uniform(dims, -1.0, 1.0)
       with self.assertRaises(tf.errors.FailedPreconditionError):
         session.run(mpi.allreduce(tensor))
 
@@ -178,7 +178,7 @@ class MPITests(tf.test.TestCase):
         dims = [17, 23 * 57]
       else:
         dims = [17, 23, 57]
-      tensor = tf.random_uniform(dims, -1.0, 1.0)
+      tensor = tf.random.uniform(dims, -1.0, 1.0)
       with self.assertRaises(tf.errors.FailedPreconditionError):
         session.run(mpi.allreduce(tensor))
 

--- a/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
+++ b/tensorflow/examples/tutorials/word2vec/word2vec_basic.py
@@ -172,7 +172,7 @@ def word2vec_basic(log_dir):
       # Look up embeddings for inputs.
       with tf.name_scope('embeddings'):
         embeddings = tf.Variable(
-            tf.random_uniform([vocabulary_size, embedding_size], -1.0, 1.0))
+            tf.random.uniform([vocabulary_size, embedding_size], -1.0, 1.0))
         embed = tf.nn.embedding_lookup(embeddings, train_inputs)
 
       # Construct the variables for the NCE loss

--- a/tensorflow/python/data/experimental/ops/optimization_options.py
+++ b/tensorflow/python/data/experimental/ops/optimization_options.py
@@ -116,7 +116,7 @@ class OptimizationOptions(options.OptionsBase):
       name="hoist_random_uniform",
       ty=bool,
       docstring=
-      "Whether to hoist `tf.random_uniform()` ops out of map transformations. "
+      "Whether to hoist `tf.random.uniform()` ops out of map transformations. "
       "If None, defaults to False.")
 
   map_and_batch_fusion = options.create_option(

--- a/tensorflow/python/debug/examples/debug_tflearn_iris.py
+++ b/tensorflow/python/debug/examples/debug_tflearn_iris.py
@@ -35,11 +35,11 @@ def main(_):
   # debugger, not how to use machine learning to solve the Iris classification
   # problem.
   def training_input_fn():
-    return ({"features": tf.random_normal([128, 4])},
-            tf.random_uniform([128], minval=0, maxval=3, dtype=tf.int32))
+    return ({"features": tf.random.normal([128, 4])},
+            tf.random.uniform([128], minval=0, maxval=3, dtype=tf.int32))
   def test_input_fn():
-    return ({"features": tf.random_normal([32, 4])},
-            tf.random_uniform([32], minval=0, maxval=3, dtype=tf.int32))
+    return ({"features": tf.random.normal([32, 4])},
+            tf.random.uniform([32], minval=0, maxval=3, dtype=tf.int32))
   feature_columns = [
       tf.feature_column.numeric_column("features", shape=(4,))]
 


### PR DESCRIPTION

`From /media/siju/DATA/ubuntu_cache/bazel/_bazel_siju/800a48f78ba10e98e4a18f338aa2c1e2/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/debug/examples_test.runfiles/org_tensorflow/tensorflow/python/debug/examples/debug_tflearn_iris.py:38: The name tf.random_normal is deprecated. Please use tf.random.normal instead.
`
`From /media/siju/DATA/ubuntu_cache/bazel/_bazel_siju/800a48f78ba10e98e4a18f338aa2c1e2/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/examples/tutorials/word2vec_test.runfiles/org_tensorflow/tensorflow/examples/tutorials/word2vec/word2vec_basic.py:175: The name tf.random_uniform is deprecated. Please use tf.random.uniform instead.
`