### PR TITLE
[ROCm] Skipping subtests that check support for the Cholesky and QR ops

### DIFF
--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -235,6 +235,7 @@ cuda_py_test(
     shard_count = 5,
     tags = [
         "no_gpu",  # TODO(b/131773093): Re-enable.
+        "no_rocm", # TODO(rocm): feature not supported on ROCm platform
         "nomsan",  # TODO(b/131773093): Re-enable.
     ],
     xla_enable_strict_auto_jit = True,
@@ -3502,6 +3503,9 @@ cuda_py_test(
         "//tensorflow/python:framework_for_generated_wrappers",
         "//tensorflow/python:linalg_ops",
         "//tensorflow/python:math_ops",
+    ],
+    tags = [
+        "no_rocm",  # TODO(rocm): feature not supported on ROCm platform
     ],
     shard_count = 20,
     xla_enable_strict_auto_jit = True,

--- a/tensorflow/python/ops/control_flow_ops_test.py
+++ b/tensorflow/python/ops/control_flow_ops_test.py
@@ -51,6 +51,7 @@ from tensorflow.python.ops import variable_scope
 from tensorflow.python.ops import variables
 import tensorflow.python.ops.tensor_array_grad  # pylint: disable=unused-import
 from tensorflow.python.platform import googletest
+from tensorflow.python.platform import test
 from tensorflow.python.training import momentum
 from tensorflow.python.util import nest
 
@@ -1081,6 +1082,10 @@ class IndexedCaseTest(test_util.TensorFlowTestCase, parameterized.TestCase):
   @test_util.disable_xla("Wants RunMetadata")
   def testParallelExecution(self):
     """Verify disjoint branches across while iterations are run in parallel."""
+    if test.is_built_with_rocm():
+      self.skipTest(
+          'Disable subtest on ROCm due to missing Cholesky op support')
+
     with ops.Graph().as_default() as g:
       nbranches = 7
       matrices = array_ops.unstack(  # Ensure all are ready before while.

--- a/tensorflow/python/ops/init_ops_test.py
+++ b/tensorflow/python/ops/init_ops_test.py
@@ -178,6 +178,10 @@ class InitializersTest(test.TestCase):
 
   @test_util.run_gpu_only
   def testVariablePlacementWithOrthogonalInitializer(self):
+
+    if test.is_built_with_rocm():
+      self.skipTest('Disable subtest on ROCm due to missing QR op support')
+
     with ops.Graph().as_default() as g:
       with ops.device('gpu:0'):
         variable_scope.get_variable(

--- a/tensorflow/python/ops/init_ops_v2_test.py
+++ b/tensorflow/python/ops/init_ops_v2_test.py
@@ -366,6 +366,10 @@ class OrthogonalInitializerTest(InitializersTest):
 
   @test_util.run_in_graph_and_eager_modes
   def testShapesValues(self):
+
+    if test.is_built_with_rocm():
+      self.skipTest('Disable subtest on ROCm due to missing QR op support')
+
     for shape in [(10, 10), (10, 9, 8), (100, 5, 5), (50, 40), (40, 50)]:
       init = init_ops_v2.Orthogonal()
       tol = 1e-5


### PR DESCRIPTION
ROCm platform currently does not support the Cholesky and QR ops (on the GPU)

This commit skip subtests (within python unit-tests) that test this functionality. 

The "skip" is guarded by the call to "is_built_with_rocm()", and hence these unit-tests will not be affected in any way when running with TF which was not built with ROCm support (i.e. `--config=rocm`)

----------------------------------

@tatianashp @whchung @chsigg 
