### PR TITLE
[ROCm] Skipping subtests that check support for NAN propagation in the NN ops

### DIFF
--- a/tensorflow/python/kernel_tests/pooling_ops_test.py
+++ b/tensorflow/python/kernel_tests/pooling_ops_test.py
@@ -1439,6 +1439,13 @@ class PoolingTest(test.TestCase):
     if not test.is_gpu_available():
       return
 
+    # The functionality associated with TF_ENABLE_NANPROP is currently
+    # not supported on the ROCm platform, so skip this part of the test
+    # NANs in input lead to non-deterministic results, and hence skipping
+    # the remaining tests altogeher on the ROCm platform
+    if test.is_built_with_rocm():
+      return
+
     # Test the GPU implementation that uses cudnn for now.
     saved_nanprop = os.environ.get("TF_ENABLE_MAXPOOL_NANPROP")
     # Do not propagate the diff in cases of NaNs
@@ -1517,6 +1524,13 @@ class PoolingTest(test.TestCase):
           v2=v2)
 
     if not test.is_gpu_available():
+      return
+
+    # The functionality associated with TF_ENABLE_NANPROP is currently
+    # not supported on the ROCm platform, so skip this part of the test
+    # NANs in input lead to non-deterministic results, and hence skipping
+    # the remaining tests altogeher on the ROCm platform
+    if test.is_built_with_rocm():
       return
 
     # Test the GPU implementation that uses cudnn for now.

--- a/tensorflow/python/kernel_tests/pooling_ops_test.py
+++ b/tensorflow/python/kernel_tests/pooling_ops_test.py
@@ -1014,7 +1014,7 @@ class PoolingTest(test.TestCase):
           output_sizes,
           x_init_value=x_init_value,
           delta=1e-2)
-    tf_logging.info("%s gradient error = " % func_name, err)
+    tf_logging.info("%s gradient error = %.4f" % (func_name, err))
     self.assertLess(err, err_tolerance)
 
   def _ConstructAndTestSecondGradient(self,
@@ -1091,7 +1091,7 @@ class PoolingTest(test.TestCase):
           input_sizes,
           x_init_value=x_init_value,
           delta=1e-2)
-    tf_logging.info("%s second-order gradient error = " % func_name, err)
+    tf_logging.info("%s second-order gradient error = %.4f" % (func_name, err))
     self.assertLess(err, err_tolerance)
 
   def _testMaxPoolGradValidPadding1_1(self, data_format, use_gpu):


### PR DESCRIPTION
ROCm platform currently does not support the NAN propagation in the NN ops

This commit skips subtests (within python unit-tests) that test this functionality. The "skip" is guarded by the call to "is_built_with_rocm()", and hence these unit-tests will not be affected in any way when running with TF which was not built with ROCm support (i.e. `--config=rocm`)

---------------------------------------------

@tatianashp @whchung @chsigg 

--------------------------------------------

updating descriptions as per discussion with @whchung 

The second commit in this PR contains a fix for what seems to be a string format specification bug, which results in the following error 
```
--- Logging error ---                                                                                                                                                                                                                                                                                                                            
Traceback (most recent call last):                                                                                                                                                                                                                                                                                                               
  File "/usr/lib/python3.5/logging/__init__.py", line 980, in emit                                                                                                                                                                                                                                                                               
    msg = self.format(record)                                                                                                                                                                                                                                                                                                                    
  File "/usr/lib/python3.5/logging/__init__.py", line 830, in format                                                                                                                                                                                                                                                                             
    return fmt.format(record)                                                                                                                                                                                                                                                                                                                    
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/absl_py/absl/logging/__init__.py", line 928, in format                    
    return prefix + super(PythonFormatter, self).format(record)                                                                                                                                                                                                                                                                                  
  File "/usr/lib/python3.5/logging/__init__.py", line 567, in format                                                                                                                                                                                                                                                                             
    record.message = record.getMessage()                                                                                                                                                                                                                                                                                                         
  File "/usr/lib/python3.5/logging/__init__.py", line 330, in getMessage                                                                                                                                                                                                                                                                         
    msg = msg % self.args                                                                                                                                                                                                                                                                                                                        
TypeError: not all arguments converted during string formatting                                                                                                                                                                                                                                                                                  
Call stack:                                                                                                                                                                                                                                                                                                                                      
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/kernel_tests/pooling_ops_test.py", line $
    test.main()                                                                                                                                                                                                                                                                                                                                  
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/platform/test.py", line 62, in main      
    return _googletest.main(argv)                                                                                                                                                                                                                                                                                                                
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/platform/googletest.py", line 65, in mai$
    benchmark.benchmarks_main(true_main=main_wrapper)                                                                                                                                                                                                                                                                                            
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/platform/benchmark.py", line 407, in ben$
    true_main()                                                                                                                                                                                                                                                                                                                                  
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/platform/googletest.py", line 64, in mai$
    return app.run(main=g_main, argv=args)                                                                                                                                                                                                                                                                                                       
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/platform/app.py", line 40, in run        
    _run(main=main, argv=argv, flags_parser=_parse_flags_tolerate_undef)                                                                                                                                                                                                                                                                         
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/absl_py/absl/app.py", line 300, in run                                    
    _run_main(main, args)                                                                                                                                                                                                                                                                                                                        
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/absl_py/absl/app.py", line 251, in _run_main                              
    sys.exit(main(argv))                                                                                                                                                                                                                                                                                                                         
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/platform/googletest.py", line 55, in g_m$
    absltest_main(argv=argv)                                                                                                                                                                                                                                                                                                                     
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/absl_py/absl/testing/absltest.py", line 1855, in main                     
    _run_in_app(run_tests, args, kwargs)                                                                                                                                                                                                                                                                                                         
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/absl_py/absl/testing/absltest.py", line 1963, in _run_in_app              
    function(argv, args, kwargs)                                                                                                                                                                                                                                                                                                                 
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/absl_py/absl/testing/absltest.py", line 2230, in run_tests                
    argv, args, kwargs, xml_reporter.TextAndXMLTestRunner)                                                                                                                                                                                                                                                                                       
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/absl_py/absl/testing/absltest.py", line 2200, in _run_and_get_tests_resul$
    test_program = unittest.TestProgram(*args, **kwargs)                                                                                                                                                                                                                                                                                         
  File "/usr/lib/python3.5/unittest/main.py", line 94, in __init__                                                                                                                                                                                                                                                                               
    self.runTests()                                                                                                                                                                                                                                                                                                                              
  File "/usr/lib/python3.5/unittest/main.py", line 255, in runTests                                                                                                                                                                                                                                                                              
    self.result = testRunner.run(self.test)                                                                                                                                                                                                                                                                                                      
  File "/usr/lib/python3.5/unittest/runner.py", line 176, in run                                                                                                                                                                                                                                                                                 
    test(result)                                                                                                                                                                                                                                                                                                                                 
  File "/usr/lib/python3.5/unittest/suite.py", line 84, in __call__                                                                                                                                                                                                                                                                              
    return self.run(*args, **kwds)                                                                                                                                                                                                                                                                                                               
  File "/usr/lib/python3.5/unittest/suite.py", line 122, in run                                                                                                                                                                                                                                                                                  
    test(result)                                                                                                                                                                                                                                                                                                                                 
  File "/usr/lib/python3.5/unittest/suite.py", line 84, in __call__                                                                                                                                                                                                                                                                              
    return self.run(*args, **kwds)                                                                                                                                                                                                                                                                                                               
  File "/usr/lib/python3.5/unittest/suite.py", line 122, in run                                                                                                                                                                                                                                                                                  
    test(result)                                                                                                                                                                                                                                                                                                                                 
  File "/usr/lib/python3.5/unittest/case.py", line 648, in __call__                                                                                                                                                                                                                                                                              
    return self.run(*args, **kwds)                                                                                                                                                                                                                                                                                                               
  File "/usr/lib/python3.5/unittest/case.py", line 600, in run                                                                                                                                                                                                                                                                                   
    testMethod()                                                                                                                                                                                                                                                                                                                                 
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/framework/test_util.py", line 1189, in d$
    return f(self, *args, **kwargs)                                                                                                                                                                                                                                                                                                              
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/kernel_tests/pooling_ops_test.py", line $
    self._testAvgPoolGradValidPadding1_1(data_format, use_gpu)                                                                                                                                                                                                                                                                                   
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/kernel_tests/pooling_ops_test.py", line $
    use_gpu=use_gpu)                                                                                                                                                                                                                                                                                                                             
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/kernel_tests/pooling_ops_test.py", line $
    tf_logging.info("%s gradient error = " % func_name, err)                                                                                                                                                                                                                                                                                     
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/platform/tf_logging.py", line 156, in in$
    get_logger().info(msg, *args, **kwargs)                                                                                                                                                                                                                                                                                                      
  File "/usr/lib/python3.5/logging/__init__.py", line 1279, in info                                                                                                                                                                                                                                                                              
    self._log(INFO, msg, args, **kwargs)                                                                                                                                                                                                                                                                                                         
  File "/usr/lib/python3.5/logging/__init__.py", line 1415, in _log                                                                                                                                                                                                                                                                              
    self.handle(record)                                                                                                                                                                                                                                                                                                                          
  File "/usr/lib/python3.5/logging/__init__.py", line 1425, in handle                                                                                                                                                                                                                                                                            
    self.callHandlers(record)                                                                                                                                                                                                                                                                                                                    
  File "/usr/lib/python3.5/logging/__init__.py", line 1487, in callHandlers                                                                                                                                                                                                                                                                      
    hdlr.handle(record)                                                                                                                                                                                                                                                                                                                          
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/absl_py/absl/logging/__init__.py", line 891, in handle                    
    return self._current_handler.handle(record)                                                                                                                                                                                                                                                                                                  
  File "/usr/lib/python3.5/logging/__init__.py", line 855, in handle                                                                                                                                                                                                                                                                             
    self.emit(record)                                                                                                                                                                                                                                                                                                                            
  File "/home/jenkins/workspace/tensorflow-upstream-csb-debug-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/kernel_tests/pooling_ops_test_gpu.runfiles/absl_py/absl/logging/__init__.py", line 829, in emit                      
    super(PythonHandler, self).emit(record)                                                                                                                                                                                                                                                                                                      
Message: 'avg_pool gradient error = '                                                                                                                                                                                                                                                                                                            
Arguments: (9.5367431640625e-07,)    
```
The above error does not seem to prevent the corresponding subtests from "passing", and hence fixing it is not a "must". Also this error does not seem to be ROCm specific...guessing it is an issue on other platforms too


