### PR TITLE
[ROCm] Skipping subtests that check support for int8x4 type (on the GPU)

### DIFF
--- a/tensorflow/python/kernel_tests/relu_op_test.py
+++ b/tensorflow/python/kernel_tests/relu_op_test.py
@@ -80,6 +80,8 @@ class ReluTest(test.TestCase):
   def testReluInt8x4GoodShape(self):
     if not test.is_gpu_available(cuda_only=True):
       self.skipTest("No GPU available")
+    if test.is_built_with_rocm():
+      self.skipTest("ROCm does not support int8x4 type")
     inputs = np.array([[-50, 7, 23, 0], [-1, -5, 6, 11]])
     np_relu = self._npRelu(inputs)
     tf_relu = nn_ops.relu(constant_op.constant(inputs, dtypes.qint8))
@@ -90,6 +92,8 @@ class ReluTest(test.TestCase):
   def testReluInt8x4BadShape(self):
     if not test.is_gpu_available(cuda_only=True):
       self.skipTest("No GPU available")
+    if test.is_built_with_rocm():
+      self.skipTest("ROCm does not support int8x4 type")
     inputs = constant_op.constant(
         np.array([[-50, 7, 23], [0, 1, -5], [6, -2, 11]]), dtypes.qint8)
     with self.assertRaisesRegexp(


### PR DESCRIPTION
ROCm platform currently does not support int8x4 type (on the GPU)

This commit skips subtests (within python unit-tests) that test this functionality. The "skip" is guarded by the call to "is_built_with_rocm()", and hence these unit-tests will not be affected in any way when running with TF which was not built with ROCm support (i.e. `--config=rocm`)

---------------------------------

@tatianashp @whchung @chsigg 