### PR TITLE
Validate max_batch_size only in static mode

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
@@ -193,32 +193,32 @@ Status TRTOptimizationPass::Optimize(grappler::Cluster* cluster,
     LOG(INFO) << CurrentStackTrace();
     PrintDebugInfo(cluster, item);
   }
-  int max_dim = -1;
-  if (!item.feed.empty()) {
-    for (const auto& f : item.feed) {
-      const auto& shape = f.second.shape();
-      if (shape.dims() > 0) {
-        if (shape.dim_size(0) > max_dim) max_dim = shape.dim_size(0);
+  if (!is_dynamic_op_) {
+    int max_batch_dim = -1;
+    if (!item.feed.empty()) {
+      for (const auto& f : item.feed) {
+        const auto& shape = f.second.shape();
+        if (shape.dims() > 0) {
+          if (shape.dim_size(0) > max_batch_dim) max_batch_dim = shape.dim_size(0);
+          VLOG(2) << "Setting max_batch_dim to " << max_batch_dim
+                  << " using batch dimension of " << f.first
+                  << " with shape " << shape;
+        }
       }
     }
-  }
-  if (maximum_batch_size_ < 0) {  // automatic batch size from input
-    if (max_dim > 0) {
-      maximum_batch_size_ = max_dim;
-      VLOG(1) << "Setting maximum batch size to " << max_dim;
-    } else {
-      maximum_batch_size_ = 128;
-      LOG(WARNING) << "Maximum batch size is not set"
-                      " and can't be deduced from inputs setting it to"
-                   << maximum_batch_size_
-                   << ". Suggest configuring it from configuration parameters";
+    if (max_batch_dim > maximum_batch_size_) {
+      return errors::InvalidArgument(
+        "Specified max_batch_size=", maximum_batch_size_,
+        " is less than maximum batch dimension of inputs (",
+        max_batch_dim, "). ",
+        "To continue, set max_batch_size to >= ", max_batch_dim);
     }
-  } else {
-    if (max_dim > maximum_batch_size_) {
-      LOG(WARNING) << "Configured batch size " << maximum_batch_size_
-                   << " is less than input batch size " << max_dim
-                   << " adjusting maximum batch size to match input batch size";
-    }
+    else if (max_batch_dim < maximum_batch_size_) {
+       LOG(INFO) << "Specified max_batch_size=" << maximum_batch_size_
+                   << " is larger than maximum batch dimension of inputs ("
+                   << max_batch_dim << "). "
+                   << "This can result in poor performance.";
+   }
   }
   grappler::GraphProperties static_graph_properties(item);
   TF_RETURN_IF_ERROR(static_graph_properties.InferStatically(true));


### PR DESCRIPTION
- Dynamic mode doesn't use max_batch_size at all. So we shouldn't validate it neither.
- Do not change max_batch_size under the hood, let user make that change.
- Log a message in case max_batch_size is larger than the batch size in the model to warn about performance impact.