### PR TITLE
Fix linking error of CoreFoundation for iOS

### DIFF
--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -917,9 +917,7 @@ ifeq ($(TARGET),OSX)
   endif
 endif
 ifeq ($(TARGET),IOS)
-  ifeq ($(IOS_ARCH),X86_64)
-    HOST_LDOPTS += -framework CoreFoundation
-  endif
+  HOST_LDOPTS += -framework CoreFoundation
 endif
 
 # Runs proto_text to generate C++ source files from protos.


### PR DESCRIPTION
It appears linking error while building iOS package for arm64 only.
tensorflow/contrib/makefile/build_all_ios.sh -a arm64