### PR TITLE
Fix the related docs for MatchingFilesOp

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_MatchingFiles.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_MatchingFiles.pbtxt
@@ -16,6 +16,6 @@ END
   description: <<END
 Note that this routine only supports wildcard characters in the
 basename portion of the pattern, not in the directory portion.
-Note also that the order of filenames returned can be non-deterministic.
+Note also that the order of filenames returned is deterministic.
 END
 }

--- a/tensorflow/go/op/wrappers.go
+++ b/tensorflow/go/op/wrappers.go
@@ -40809,7 +40809,7 @@ func UniqueDataset(scope *Scope, input_dataset tf.Output, output_types []tf.Data
 //
 // Note that this routine only supports wildcard characters in the
 // basename portion of the pattern, not in the directory portion.
-// Note also that the order of filenames returned can be non-deterministic.
+// Note also that the order of filenames returned is deterministic.
 //
 // Arguments:
 //	pattern: Shell wildcard pattern(s). Scalar or vector of type string.

--- a/tensorflow/python/training/input.py
+++ b/tensorflow/python/training/input.py
@@ -63,7 +63,7 @@ _restore_sparse = sparse_ops._take_many_sparse_from_tensors_map
 def match_filenames_once(pattern, name=None):
   """Save the list of files matching pattern, so it is only computed once.
 
-  NOTE: The order of the files returned can be non-deterministic.
+  NOTE: The order of the files returned is deterministic.
 
   Args:
     pattern: A file pattern (glob), or 1D tensor of file patterns.


### PR DESCRIPTION
This PR fixes #30436. As `MatchingFilesOp` sorts the matched files [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/matching_files_op.cc#L63), the order of filenames returned is deterministic. This PR revises the related docs. 