### PR TITLE
Add `maximize` method to Optimizer base class.

### DIFF
--- a/tensorflow/python/training/optimizer.py
+++ b/tensorflow/python/training/optimizer.py
@@ -411,6 +411,10 @@ class Optimizer(
 
     return self.apply_gradients(grads_and_vars, global_step=global_step,
                                 name=name)
+  
+  def maximize(self, reward, **kwargs):
+    """Add operations to maximize `reward`. All kwargs forwarded to `minimize`.
+    return self.minimize(-reward, **kwargs)
 
   def compute_gradients(self, loss, var_list=None,
                         gate_gradients=GATE_OP,


### PR DESCRIPTION
In some fields, such as reinforcement learning, the optimization problem is posed as maximization of reward. By only supporting minimization, TensorFlow optimizers force a slight mismatch between code and math.

Consider translating the objective `maximize f1 + f2` to code. One could make the following careless error:

    opt_op = adam.minimize(-f1 + f2)

Adding a `maximize` method comes at almost no implementation cost, and it removes a (minor) potential source of errors when translating math to code, so it could be worth including.