### PR TITLE
Fix numpy warning with numpy 1.17.0+

### DIFF
--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -513,16 +513,16 @@ _STRING_TO_TF["double_ref"] = float64_ref
 # quantized types.
 # TODO(mrry,keveman): Investigate Numpy type registration to replace this
 # hard-coding of names.
-_np_qint8 = np.dtype([("qint8", np.int8, 1)])
-_np_quint8 = np.dtype([("quint8", np.uint8, 1)])
-_np_qint16 = np.dtype([("qint16", np.int16, 1)])
-_np_quint16 = np.dtype([("quint16", np.uint16, 1)])
-_np_qint32 = np.dtype([("qint32", np.int32, 1)])
+_np_qint8 = np.dtype([("qint8", np.int8)])
+_np_quint8 = np.dtype([("quint8", np.uint8)])
+_np_qint16 = np.dtype([("qint16", np.int16)])
+_np_quint16 = np.dtype([("quint16", np.uint16)])
+_np_qint32 = np.dtype([("qint32", np.int32)])
 
 # _np_bfloat16 is defined by a module import.
 
 # Custom struct dtype for directly-fed ResourceHandles of supported type(s).
-np_resource = np.dtype([("resource", np.ubyte, 1)])
+np_resource = np.dtype([("resource", np.ubyte)])
 
 # Standard mappings between types_pb2.DataType values and numpy.dtypes.
 _NP_TO_TF = {


### PR DESCRIPTION
This fix tries to address the issue raised in #30427 where
`import tensorflow` caused the following warning with numpy 1.17.0+:
```
/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/framework/dtypes.py:516: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  _np_qint8 = np.dtype([("qint8", np.int8, 1)])
```

The issue was cause by changes in numpy: https://github.com/numpy/numpy/commit/ad1e0600e45b9fa71096d0a0f10c1474e003f373

This fix fixes the warning.

This fix fixes #30427.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>