### PR TITLE
Fix build breaks in tf-nightly-2.0-preview

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -46,7 +46,7 @@ from tensorflow.python.tools import module_util as _module_util
 # Make sure directory containing top level submodules is in
 # the __path__ so that "from tensorflow.foo import bar" works.
 # We're using bitwise, but there's nothing special about that.
-_API_MODULE = sys.modules[__name__].bitwise  # pylint: disable=undefined-variable
+_API_MODULE = _sys.modules[__name__].bitwise  # pylint: disable=undefined-variable
 _tf_api_dir = _os.path.dirname(_os.path.dirname(_API_MODULE.__file__))
 _current_module = _sys.modules[__name__]
 


### PR DESCRIPTION
This fix tries to address the issue raised in #30560 where
tf-nightly-2.0-preview throws error:
```
ubuntu@ubuntu:/# python -c "import tensorflow as tf"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/__init__.py", line 98, in <module>
    from tensorflow_core import *
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/__init__.py", line 363, in <module>
    _API_MODULE = sys.modules[__name__].bitwise  # pylint: disable=undefined-variable
NameError: name 'sys' is not defined
ubuntu@ubuntu:/#
```

The issue was cause by the typo sys -> _sys in `tensorflow/api_template.__init__.py`

This fix fixes the issue.

This fix fixes #30560.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>