### PR TITLE
Pretty print error message for mod op of Dimesion

### DIFF
--- a/tensorflow/python/framework/tensor_shape.py
+++ b/tensorflow/python/framework/tensor_shape.py
@@ -576,10 +576,7 @@ class Dimension(object):
     Returns:
       A Dimension whose value is `self` modulo `other`.
     """
-    try:
-      other = as_dimension(other)
-    except (TypeError, ValueError):
-      return NotImplemented
+    other = as_dimension(other)
     if self._value is None or other.value is None:
       return Dimension(None)
     else:

--- a/tensorflow/python/framework/tensor_shape.py
+++ b/tensorflow/python/framework/tensor_shape.py
@@ -591,11 +591,11 @@ class Dimension(object):
     Returns:
       A Dimension whose value is `other` modulo `self`.
     """
-    try:
-      other = as_dimension(other)
-    except (TypeError, ValueError):
-      return NotImplemented
-    return other % self
+    other = as_dimension(other)
+    if self._value is None or other.value is None:
+      return Dimension(None)
+    else:
+      return Dimension(other.value % self._value)
 
   def __lt__(self, other):
     """Returns True if `self` is known to be less than `other`.


### PR DESCRIPTION
This fix tries to address the issue raised in #30526 where the erorr message of mod with Dimension was not clear:
```
Traceback (most recent call last):
  File "v.py", line 12, in <module>
    print(z.shape[0] % (-3))
TypeError: unsupported operand type(s) for %: 'Dimension' and 'int'
```

The issue was that when TypeErorr or ValueError was thrown, they were rethrown as NotImplemented.

This fix expose the error message so that the error is clear:
```
Traceback (most recent call last):
  File "v.py", line 12, in <module>
    print(z.shape[0] % (-3))
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/framework/tensor_shape.py", line 579, in __mod__
    other = as_dimension(other)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/framework/tensor_shape.py", line 720, in as_dimension
    return Dimension(value)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/framework/tensor_shape.py", line 197, in __init__
    raise ValueError("Dimension %d must be >= 0" % self._value)
ValueError: Dimension -3 must be >= 0
```

This fix fixes #30526.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>