### PR TITLE
Fix #30526: raise `ValueError` when using modular arithmetic with negative integers and `Dimension`

### DIFF
--- a/tensorflow/python/framework/tensor_shape.py
+++ b/tensorflow/python/framework/tensor_shape.py
@@ -576,10 +576,7 @@ class Dimension(object):
     Returns:
       A Dimension whose value is `self` modulo `other`.
     """
-    try:
-      other = as_dimension(other)
-    except (TypeError, ValueError):
-      return NotImplemented
+    other = as_dimension(other)
     if self._value is None or other.value is None:
       return Dimension(None)
     else:
@@ -594,10 +591,7 @@ class Dimension(object):
     Returns:
       A Dimension whose value is `other` modulo `self`.
     """
-    try:
-      other = as_dimension(other)
-    except (TypeError, ValueError):
-      return NotImplemented
+    other = as_dimension(other)
     return other % self
 
   def __lt__(self, other):


### PR DESCRIPTION
not show `raise ValueError` but `unsupported operand` error when using modular arithmetic as minus integer in TF 1.13.1, 1.14.0 #30526