### PR TITLE
Changes to build files for patch release

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.debian.jessie.cpu
+++ b/tensorflow/tools/ci_build/Dockerfile.debian.jessie.cpu
@@ -5,7 +5,7 @@ LABEL maintainer="Jan Prach <jendap@google.com>"
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
-RUN echo "deb http://http.debian.net/debian jessie-backports main" | \
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" | \
     tee -a /etc/apt/sources.list
 # Workaround bug in Jessie backport repository deb packages
 # http://serverfault.com/questions/830636/cannot-install-openjdk-8-jre-headless-on-debian-jessie

--- a/tensorflow/tools/ci_build/ci_parameterized_build.sh
+++ b/tensorflow/tools/ci_build/ci_parameterized_build.sh
@@ -98,6 +98,8 @@
 #
 # This script can be used by Jenkins parameterized / matrix builds.
 
+set -ex
+
 # Helper function: Convert to lower case
 to_lower () {
   echo "$1" | tr '[:upper:]' '[:lower:]'

--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -444,6 +444,8 @@ do_bazel_nobuild() {
   BUILD_TARGET="${BUILD_TARGET} -//tensorflow/lite/java/demo/app/..."
   BUILD_TARGET="${BUILD_TARGET} -//tensorflow/lite/examples/android/..."
   BUILD_TARGET="${BUILD_TARGET} -//tensorflow/lite/schema/..."
+  BAZEL_FLAGS="${BAZEL_FLAGS} --incompatible_package_name_is_a_function=false"
+  BAZEL_FLAGS="${BAZEL_FLAGS} --incompatible_remove_native_http_archive=false"
   BUILD_CMD="bazel build --nobuild ${BAZEL_FLAGS} -- ${BUILD_TARGET}"
 
   ${BUILD_CMD}

--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -22,6 +22,8 @@
 #  --incremental  Performs checks incrementally, by using the files changed in
 #                 the latest commit
 
+set -ex
+
 # Current script directory
 SCRIPT_DIR=$( cd ${0%/*} && pwd -P )
 source "${SCRIPT_DIR}/builds/builds_common.sh"

--- a/tensorflow/tools/pip_package/check_load_py_test.py
+++ b/tensorflow/tools/pip_package/check_load_py_test.py
@@ -47,6 +47,8 @@ def main():
   try:
     targets = subprocess.check_output([
         'bazel', 'query',
+        "--incompatible_package_name_is_a_function=false",
+        "--incompatible_remove_native_http_archive=false",
         'kind(py_test, //tensorflow/contrib/... + '
         '//tensorflow/python/... - '
         '//tensorflow/contrib/tensorboard/...)']).strip()

--- a/tensorflow/tools/pip_package/pip_smoke_test.py
+++ b/tensorflow/tools/pip_package/pip_smoke_test.py
@@ -30,6 +30,10 @@ os.chdir(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 PIP_PACKAGE_QUERY_EXPRESSION = (
     "deps(//tensorflow/tools/pip_package:build_pip_package)")
 
+RELEASE_PATCH_FLAGS = (
+  " --incompatible_package_name_is_a_function=false"
+  " --incompatible_remove_native_http_archive=false")
+
 
 def GetBuild(dir_base):
   """Get the list of BUILD file all targets recursively startind at dir_base."""
@@ -127,7 +131,7 @@ def main():
 
   # pip_package_dependencies_list is the list of included files in pip packages
   pip_package_dependencies = subprocess.check_output(
-      ["bazel", "cquery", PIP_PACKAGE_QUERY_EXPRESSION])
+      ["bazel", "cquery", RELEASE_PATCH_FLAGS, PIP_PACKAGE_QUERY_EXPRESSION])
   pip_package_dependencies_list = pip_package_dependencies.strip().split("\n")
   pip_package_dependencies_list = [
       x.split()[0] for x in pip_package_dependencies_list
@@ -137,7 +141,7 @@ def main():
   # tf_py_test_dependencies is the list of dependencies for all python
   # tests in tensorflow
   tf_py_test_dependencies = subprocess.check_output(
-      ["bazel", "cquery", PY_TEST_QUERY_EXPRESSION])
+      ["bazel", "cquery", RELEASE_PATCH_FLAGS, PY_TEST_QUERY_EXPRESSION])
   tf_py_test_dependencies_list = tf_py_test_dependencies.strip().split("\n")
   tf_py_test_dependencies_list = [
       x.split()[0] for x in tf_py_test_dependencies.strip().split("\n")
@@ -174,7 +178,8 @@ def main():
       print("Affected Tests:")
       rdep_query = ("rdeps(kind(py_test, %s), %s)" %
                     (" + ".join(PYTHON_TARGETS), missing_dependency))
-      affected_tests = subprocess.check_output(["bazel", "cquery", rdep_query])
+      affected_tests = subprocess.check_output(
+          ["bazel", "cquery", RELEASE_PATCH_FLAGS, rdep_query])
       affected_tests_list = affected_tests.split("\n")[:-2]
       print("\n".join(affected_tests_list))
 


### PR DESCRIPTION
Add `set -ex` to build scripts as well as bazel flags for incompatible versions.

Also change `Dockerfile` for Debian-based docker container