### PR TITLE
[LITE] Deprecated tf.app.run removed from lite files.

### DIFF
--- a/tensorflow/lite/schema/upgrade_schema.py
+++ b/tensorflow/lite/schema/upgrade_schema.py
@@ -348,4 +348,4 @@ def main(argv):
 
 if __name__ == "__main__":
   FLAGS, unparsed = parser.parse_known_args()
-  tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
+  tf.compat.v1.app.run(main=main, argv=[sys.argv[0]] + unparsed)

--- a/tensorflow/lite/testing/generate_examples.py
+++ b/tensorflow/lite/testing/generate_examples.py
@@ -105,4 +105,4 @@ if __name__ == "__main__":
   if unparsed:
     print("Usage: %s <path out> <zip file to generate>")
   else:
-    tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
+    tf.compat.v1.app.run(main=main, argv=[sys.argv[0]] + unparsed)

--- a/tensorflow/lite/tutorials/mnist_tflite.py
+++ b/tensorflow/lite/tutorials/mnist_tflite.py
@@ -84,4 +84,4 @@ def main(_):
 
 if __name__ == '__main__':
   tf.logging.set_verbosity(tf.logging.INFO)
-  tf.app.run(main)
+  tf.compat.v1.app.run(main)


### PR DESCRIPTION
The below deprecation warning is removed from all lite files.
` The name tf.app.run is deprecated. Please use tf.compat.v1.app.run instead.`
