### PR TITLE
Deprecated warning removed from contrib timeseries

### DIFF
--- a/tensorflow/contrib/timeseries/examples/known_anomaly.py
+++ b/tensorflow/contrib/timeseries/examples/known_anomaly.py
@@ -177,4 +177,4 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-  tf.app.run(main=main)
+  tf.compat.v1.app.run(main=main)

--- a/tensorflow/contrib/timeseries/examples/lstm.py
+++ b/tensorflow/contrib/timeseries/examples/lstm.py
@@ -202,7 +202,8 @@ def train_and_predict(
   estimator = ts_estimators.TimeSeriesRegressor(
       model=_LSTMModel(num_features=5, num_units=128,
                        exogenous_feature_columns=exogenous_feature_columns),
-      optimizer=tf.compat.v1.train.AdamOptimizer(0.001), config=estimator_config,
+      optimizer=tf.compat.v1.train.AdamOptimizer(0.001),
+      config=estimator_config,
       # Set state to be saved across windows.
       state_manager=state_management.ChainingStateManager())
   reader = tf.contrib.timeseries.CSVReader(

--- a/tensorflow/contrib/timeseries/examples/lstm.py
+++ b/tensorflow/contrib/timeseries/examples/lstm.py
@@ -202,7 +202,7 @@ def train_and_predict(
   estimator = ts_estimators.TimeSeriesRegressor(
       model=_LSTMModel(num_features=5, num_units=128,
                        exogenous_feature_columns=exogenous_feature_columns),
-      optimizer=tf.train.AdamOptimizer(0.001), config=estimator_config,
+      optimizer=tf.compat.v1.train.AdamOptimizer(0.001), config=estimator_config,
       # Set state to be saved across windows.
       state_manager=state_management.ChainingStateManager())
   reader = tf.contrib.timeseries.CSVReader(
@@ -258,7 +258,7 @@ def train_and_predict(
                                                  input_receiver_fn)
   # Warm up and predict using the SavedModel
   with tf.Graph().as_default():
-    with tf.Session() as session:
+    with tf.compat.v1.Session() as session:
       signatures = tf.saved_model.loader.load(
           session, [tf.saved_model.tag_constants.SERVING], export_location)
       state = tf.contrib.timeseries.saved_model_utils.cold_start_filter(
@@ -293,4 +293,4 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-  tf.app.run(main=main)
+  tf.compat.v1.app.run(main=main)

--- a/tensorflow/contrib/timeseries/examples/multivariate.py
+++ b/tensorflow/contrib/timeseries/examples/multivariate.py
@@ -70,7 +70,7 @@ def multivariate_train_and_sample(
                                                  input_receiver_fn)
   with tf.Graph().as_default():
     numpy.random.seed(1)  # Make the example a bit more deterministic
-    with tf.Session() as session:
+    with tf.compat.v1.Session() as session:
       signatures = tf.saved_model.loader.load(
           session, [tf.saved_model.tag_constants.SERVING], export_location)
       for _ in range(100):
@@ -114,4 +114,4 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-  tf.app.run(main=main)
+  tf.compat.v1.app.run(main=main)

--- a/tensorflow/contrib/timeseries/examples/predict.py
+++ b/tensorflow/contrib/timeseries/examples/predict.py
@@ -137,4 +137,4 @@ if __name__ == "__main__":
       required=False,
       help="Input csv file (omit to use the data/period_trend.csv).")
   FLAGS, unparsed = parser.parse_known_args()
-  tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
+  tf.compat.v1.app.run(main=main, argv=[sys.argv[0]] + unparsed)


### PR DESCRIPTION
The following deprecated warnings are removed from contrib/timeseries examples
```
The name tf.app.run is deprecated. Please use tf.compat.v1.app.run instead.
The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.
The name tf.train.AdamOptimizer is deprecated. Please use tf.compat.v1.train.AdamOptimizer instead.

```
