### PR TITLE
Little fix in docstring for DynamicRnnEstimator

### DIFF
--- a/tensorflow/contrib/learn/python/learn/estimators/dynamic_rnn_estimator.py
+++ b/tensorflow/contrib/learn/python/learn/estimators/dynamic_rnn_estimator.py
@@ -625,14 +625,14 @@ class DynamicRnnEstimator(estimator.Estimator):
       optimizer: The type of optimizer to use. Either a subclass of
         `Optimizer`, an instance of an `Optimizer`, a callback that returns an
         optimizer, or a string. Strings must be one of 'Adagrad', 'Adam',
-        'Ftrl', 'Momentum', 'RMSProp' or 'SGD. See `layers.optimize_loss` for
+        'Ftrl', 'Momentum', 'RMSProp' or 'SGD'. See `layers.optimize_loss` for
         more details.
       learning_rate: Learning rate. This argument has no effect if `optimizer`
         is an instance of an `Optimizer`.
       predict_probabilities: A boolean indicating whether to predict
         probabilities for all classes. Used only if `problem_type` is
         `ProblemType.CLASSIFICATION`
-      momentum: Momentum value. Only used if `optimizer_type` is 'Momentum'.
+      momentum: Momentum value. Only used if `optimizer` is 'Momentum'.
       gradient_clipping_norm: Parameter used for gradient clipping. If `None`,
         then no clipping is performed.
       dropout_keep_probabilities: a list of dropout probabilities or `None`.


### PR DESCRIPTION
The constructor has the `optimizer` argument that is referred to as 'optimizer_type' later in parameters description.