### PR TITLE
[ROCm] Fixes unit-test failures on the ROCm platform

### DIFF
--- a/tensorflow/lite/python/convert.py
+++ b/tensorflow/lite/python/convert.py
@@ -153,7 +153,18 @@ def toco_convert_protos(model_flags_str,
       fp_toco.write(toco_flags_str)
       fp_input.write(input_data_str)
       debug_info_str = debug_info_str if debug_info_str else ""
-      fp_debug.write(debug_info_str)
+      # if debug_info_str contains a "string value", then the call to
+      # fp_debug.write(debug_info_str) will fail with the following error
+      #
+      # TypeError: a bytes-like object is required, not 'str'
+      #
+      # Some of the subtests within the "convert_test" unit-test fail
+      # with the error shown above. So watch out for that scenario and
+      # convert debug_info_str to bytes where needed
+      if isinstance(debug_info_str, str):
+        fp_debug.write(debug_info_str.encode('utf-8'))
+      else:
+        fp_debug.write(debug_info_str)
 
     # Reserve an output file
     with _tempfile.NamedTemporaryFile(delete=False) as fp:

--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -99,8 +99,8 @@ class Delegate(object):
     options_keys = (ctypes.c_char_p * len(options))()
     options_values = (ctypes.c_char_p * len(options))()
     for idx, (key, value) in enumerate(options.items()):
-      options_keys[idx] = str(key)
-      options_values[idx] = str(value)
+      options_keys[idx] = str(key).encode('utf-8')
+      options_values[idx] = str(value).encode('utf-8')
 
     class ErrorMessageCapture(object):
 

--- a/tensorflow/python/compiler/xla/BUILD
+++ b/tensorflow/python/compiler/xla/BUILD
@@ -86,6 +86,7 @@ cuda_py_test(
     ],
     tags = [
         "no_mac",
+        "no_rocm",  # XLA support is not enabled on the ROCm platform
         "no_windows",
     ],
     xla_enable_strict_auto_jit = True,

--- a/tensorflow/python/keras/distribute/BUILD
+++ b/tensorflow/python/keras/distribute/BUILD
@@ -105,6 +105,7 @@ distribute_py_test(
     shard_count = 5,
     tags = [
         "multi_and_single_gpu",
+        "no_rocm",  # times out on ROCm
         "no_windows_gpu",
         "notsan",
     ],
@@ -165,6 +166,7 @@ distribute_py_test(
     shard_count = 19,
     tags = [
         "multi_and_single_gpu",
+        "no_rocm",  # times out on ROCm
         "no_windows_gpu",
         # TODO(b/134764123): Re-enable this test.
         "notap",
@@ -184,6 +186,7 @@ distribute_py_test(
     shard_count = 4,
     tags = [
         "multi_and_single_gpu",
+        "no_rocm",  # times out on ROCm
         "no_windows_gpu",
         "notsan",
     ],
@@ -201,6 +204,7 @@ distribute_py_test(
     shard_count = 8,
     tags = [
         "multi_and_single_gpu",
+        "no_rocm",  # times out on ROCm
         "no_windows_gpu",
         "notsan",
     ],


### PR DESCRIPTION
This PR contains a two commits
* the first commit updates a couple of python files in the TF list source to fix a couple of unit test failures we were running into on the ROCm fork. The reason for the failure was that the code was expecting "bytes" but was getting passed "string" instead. The failure does not seem ROCm specific (rather it seems to be Python3 specific), so don't know why it is not showing up on other platforms.
* the second commit disables XLA support specific unit test on the ROCm platform (since support for the same has not yet been enabled in the TF repo)

Please review. thanks

---------------------------------------------------

@tatianashp @whchung @chsigg 

---------------------------------------------------

update : amended the PR to add "no_rocm" tag to some tests in the `tensorflow/python/keras/distribute` directory. These tests timeout when run on a single GPU on the ROCm platform.