### PR TITLE
Remove `set -ex` on `ci_sanity.sh`

### DIFF
--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -22,8 +22,6 @@
 #  --incremental  Performs checks incrementally, by using the files changed in
 #                 the latest commit
 
-set -ex
-
 # Current script directory
 SCRIPT_DIR=$( cd ${0%/*} && pwd -P )
 source "${SCRIPT_DIR}/builds/builds_common.sh"


### PR DESCRIPTION
It causes the build to fail on stuff like `((a++))` as that evaluates to `1` which `set -ex` considers to be an error