### PR TITLE
Fix linker error

### DIFF
--- a/tensorflow/compiler/jit/xla_compilation_cache.cc
+++ b/tensorflow/compiler/jit/xla_compilation_cache.cc
@@ -171,7 +171,7 @@ Status XlaCompilationCache::Compile(
     xla::LocalExecutable** out_executable) {
   absl::optional<int64> compile_threshold;
   if (compile_mode == CompileMode::kLazy) {
-    compile_threshold = kDefaultCompilationThreshold;
+    compile_threshold = XlaCompilationCache::kDefaultCompilationThreshold;
   }
   auto compile_fn = [&](XlaCompiler* compiler,
                         XlaCompiler::CompilationResult* result) {


### PR DESCRIPTION
MacOS nonpip jobs are failing with a linker error. This should fix it