### PR TITLE
keras/saving_utils: call losses.deserialize instead of losses.get in `compile_args_from_training_config`

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1154,14 +1154,14 @@ def deserialize(name, custom_objects=None):
 
 
 @keras_export('keras.losses.get')
-def get(identifier, custom_objects=None):
+def get(identifier):
   if identifier is None:
     return None
   if isinstance(identifier, six.string_types):
     identifier = str(identifier)
-    return deserialize(identifier, custom_objects)
+    return deserialize(identifier)
   if isinstance(identifier, dict):
-    return deserialize(identifier, custom_objects)
+    return deserialize(identifier)
   elif callable(identifier):
     return identifier
   else:

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1154,14 +1154,14 @@ def deserialize(name, custom_objects=None):
 
 
 @keras_export('keras.losses.get')
-def get(identifier):
+def get(identifier, custom_objects=None):
   if identifier is None:
     return None
   if isinstance(identifier, six.string_types):
     identifier = str(identifier)
-    return deserialize(identifier)
+    return deserialize(identifier, custom_objects)
   if isinstance(identifier, dict):
-    return deserialize(identifier)
+    return deserialize(identifier, custom_objects)
   elif callable(identifier):
     return identifier
   else:

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -219,7 +219,7 @@ def compile_args_from_training_config(training_config, custom_objects=None):
   # Recover loss functions and metrics.
   loss_config = training_config['loss']  # Deserialize loss class.
   if isinstance(loss_config, dict) and 'class_name' in loss_config:
-    loss_config = losses.get(loss_config)
+    loss_config = losses.get(loss_config, custom_objects=custom_objects)
   loss = nest.map_structure(
       lambda obj: custom_objects.get(obj, obj), loss_config)
   metrics = nest.map_structure(

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -219,7 +219,7 @@ def compile_args_from_training_config(training_config, custom_objects=None):
   # Recover loss functions and metrics.
   loss_config = training_config['loss']  # Deserialize loss class.
   if isinstance(loss_config, dict) and 'class_name' in loss_config:
-    loss_config = losses.get(loss_config, custom_objects=custom_objects)
+    loss_config = losses.deserialize(loss_config, custom_objects=custom_objects)
   loss = nest.map_structure(
       lambda obj: custom_objects.get(obj, obj), loss_config)
   metrics = nest.map_structure(


### PR DESCRIPTION
When loading a keras model saved in `h5` format, there is a problem with custom losses.

Reproduction: https://gist.github.com/suyash/d45f664f0a9d62fd4ab052b4040e6a16

Essentially, from the stack trace, the `keras.losses.get` function does not accept a `custom_objects` parameter, which makes loading a custom loss break.

This changes `compile_args_from_training_config` to call `losses.deserialize` instead of `losses.get`, similar to `optimizers.deserialize` a couple of lines above