### PR TITLE
[LITE] Add the missed header for osx platform in micro_speech example for makefile.

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/osx/Makefile.inc
+++ b/tensorflow/lite/micro/examples/micro_speech/osx/Makefile.inc
@@ -5,4 +5,5 @@ ifeq ($(TARGET), osx)
     -framework AudioToolbox
 
   MICROLITE_LIBS += $(LINKER_FLAGS)
+  MICRO_SPEECH_HDRS += tensorflow/lite/experimental/micro/examples/micro_speech/simple_features/simple_model_settings.h
 endif


### PR DESCRIPTION
When we use the target specific "audio_provider.cc"[1], we should also add
its header dependency[2] in makefile.

[1]
tensorflow/lite/experimental/micro/examples/micro_speech/osx/audio_provider.cc
[2]
tensorflow/lite/experimental/micro/examples/micro_speech/simple_features/simple_model_settings.h