### PR TITLE
Add one more flag for Bazel compatibility.

### DIFF
--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -444,6 +444,7 @@ do_bazel_nobuild() {
   BUILD_TARGET="${BUILD_TARGET} -//tensorflow/lite/schema/..."
   BAZEL_FLAGS="${BAZEL_FLAGS} --incompatible_package_name_is_a_function=false"
   BAZEL_FLAGS="${BAZEL_FLAGS} --incompatible_remove_native_http_archive=false"
+  BAZEL_FLAGS="${BAZEL_FLAGS} --incompatible_strict_action_env=false"
   BUILD_CMD="bazel build --nobuild ${BAZEL_FLAGS} -- ${BUILD_TARGET}"
 
   ${BUILD_CMD}

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -122,6 +122,9 @@ fi
 
 run_configure_for_cpu_build
 
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} --incompatible_package_name_is_a_function=false"
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} --incompatible_remove_native_http_archive=false"
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} --incompatible_strict_action_env=false"
 bazel build --announce_rc --config=opt ${EXTRA_BUILD_FLAGS} \
   tensorflow/tools/pip_package:build_pip_package \
   --incompatible_remove_native_http_archive=false || exit $?
@@ -148,7 +151,11 @@ N_JOBS="${NUMBER_OF_PROCESSORS}"
 
 # Define no_tensorflow_py_deps=true so that every py_test has no deps anymore,
 # which will result testing system installed tensorflow
-bazel test --announce_rc --config=opt -k --test_output=errors \
+bazel test \
+  --incompatible_package_name_is_a_function=false \
+  --incompatible_remove_native_http_archive=false \
+  --incompatible_strict_action_env=false \
+  --announce_rc --config=opt -k --test_output=errors \
   --define=no_tensorflow_py_deps=true --test_lang_filters=py \
   --test_tag_filters=-no_pip,-no_windows,-no_oss,-gpu \
   --build_tag_filters=-no_pip,-no_windows,-no_oss,-gpu --build_tests_only \

--- a/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
@@ -124,6 +124,9 @@ fi
 
 run_configure_for_gpu_build
 
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} --incompatible_package_name_is_a_function=false"
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} --incompatible_remove_native_http_archive=false"
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} --incompatible_strict_action_env=false"
 bazel build --announce_rc --config=opt --define=no_tensorflow_py_deps=true \
   ${EXTRA_BUILD_FLAGS} \
   tensorflow/tools/pip_package:build_pip_package || exit $?
@@ -151,7 +154,11 @@ TF_GPU_COUNT=${TF_GPU_COUNT:-4}
 # Define no_tensorflow_py_deps=true so that every py_test has no deps anymore,
 # which will result testing system installed tensorflow
 # GPU tests are very flaky when running concurrently, so set local_test_jobs=1
-bazel test --announce_rc --config=opt -k --test_output=errors \
+bazel test \
+  --incompatible_package_name_is_a_function=false \
+  --incompatible_remove_native_http_archive=false \
+  --incompatible_strict_action_env=false \
+  --announce_rc --config=opt -k --test_output=errors \
   --test_env=TF_GPU_COUNT \
   --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
   --define=no_tensorflow_py_deps=true --test_lang_filters=py \

--- a/tensorflow/tools/pip_package/check_load_py_test.py
+++ b/tensorflow/tools/pip_package/check_load_py_test.py
@@ -49,6 +49,7 @@ def main():
         'bazel', 'query',
         "--incompatible_package_name_is_a_function=false",
         "--incompatible_remove_native_http_archive=false",
+        "--incompatible_strict_action_env=false",
         'kind(py_test, //tensorflow/contrib/... + '
         '//tensorflow/python/... - '
         '//tensorflow/contrib/tensorboard/...)']).strip()

--- a/tensorflow/tools/pip_package/pip_smoke_test.py
+++ b/tensorflow/tools/pip_package/pip_smoke_test.py
@@ -32,7 +32,8 @@ PIP_PACKAGE_QUERY_EXPRESSION = (
 
 RELEASE_PATCH_FLAGS = (
   " --incompatible_package_name_is_a_function=false"
-  " --incompatible_remove_native_http_archive=false")
+  " --incompatible_remove_native_http_archive=false"
+  " --incompatible_strict_action_env=false")
 
 
 def GetBuild(dir_base):


### PR DESCRIPTION
This also adds the 3 compatibility flags on windows builds, as I missed doing that in #30583