### PR TITLE
[mlir] enable Affine Dialect in tf-opt

### DIFF
--- a/tensorflow/compiler/mlir/BUILD
+++ b/tensorflow/compiler/mlir/BUILD
@@ -38,6 +38,7 @@ cc_library(
         "//tensorflow/compiler/mlir/xla:xla_legalize_to_standard",
         "//tensorflow/core:lib",
         "@llvm//:support",
+        "@local_config_mlir//:AffineDialectRegistration",
         "@local_config_mlir//:MlirOptLib",
         "@local_config_mlir//:Pass",
         "@local_config_mlir//:QuantOps",


### PR DESCRIPTION
`tf-opt --help` shows Affine dialect passes, but it doesn't
recognize the Affine dialect because AffineDialectRegistration
is not linked in.