### PR TITLE
Fix incorrect get_link_flags on Mac

### DIFF
--- a/tensorflow/python/platform/sysconfig.py
+++ b/tensorflow/python/platform/sysconfig.py
@@ -80,7 +80,7 @@ def get_link_flags():
   if not _MONOLITHIC_BUILD:
     flags.append('-L%s' % get_lib())
     if is_mac:
-      flags.append('-l:libtensorflow_framework.%s.dylib' % ver)
+      flags.append('-ltensorflow_framework.%s' % ver)
     else:
       flags.append('-l:libtensorflow_framework.so.%s' % ver)
   return flags


### PR DESCRIPTION
This fix tries to address the issue raised in #30633 where `tf.sysconfig.get_link_flags` on mac returned
'-l:libtensorflow_framework.1.dylib' which is not valid for ld on macOS.

This fix changes to `-ltensorflow_framework.1`

This fix fixes #30633.

This fix also fixed #30564.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>