### PR TITLE
Fix incorrect example in tf.data.Dataset.window

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1377,7 +1377,7 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
 
     For example:
 
-    - `tf.data.Dataset.from_tensor_slices((range(4), range(4)).window(2)`
+    - `tf.data.Dataset.from_tensor_slices((range(4), range(4))).window(2)`
       produces `{({0, 1}, {0, 1}), ({2, 3}, {2, 3})}`
     - `tf.data.Dataset.from_tensor_slices({"a": range(4)}).window(2)`
       produces `{{"a": {0, 1}}, {"a": {2, 3}}}`


### PR DESCRIPTION
This fix fixes an incorrect example in tf.data.Dataset.window

The previous example:
```
tf.data.Dataset.from_tensor_slices((range(4), range(4)).window(2)
```

does not have close parentheses, and should be

```
tf.data.Dataset.from_tensor_slices((range(4), range(4))).window(2)
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>