### PR TITLE
Add kZlib to compression namespace

### DIFF
--- a/tensorflow/core/lib/io/compression.cc
+++ b/tensorflow/core/lib/io/compression.cc
@@ -22,6 +22,7 @@ namespace compression {
 const char kNone[] = "";
 const char kGzip[] = "GZIP";
 const char kSnappy[] = "SNAPPY";
+const char kZlib[] = "ZLIB";
 
 }  // namespace compression
 }  // namespace io

--- a/tensorflow/core/lib/io/compression.h
+++ b/tensorflow/core/lib/io/compression.h
@@ -23,6 +23,7 @@ namespace compression {
 extern const char kNone[];
 extern const char kGzip[];
 extern const char kSnappy[];
+extern const char kZlib[];
 
 }  // namespace compression
 }  // namespace io

--- a/tensorflow/core/lib/io/record_reader.cc
+++ b/tensorflow/core/lib/io/record_reader.cc
@@ -31,7 +31,7 @@ namespace io {
 RecordReaderOptions RecordReaderOptions::CreateRecordReaderOptions(
     const string& compression_type) {
   RecordReaderOptions options;
-  if (compression_type == "ZLIB") {
+  if (compression_type == compression::kZlib) {
     options.compression_type = io::RecordReaderOptions::ZLIB_COMPRESSION;
 #if defined(IS_SLIM_BUILD)
     LOG(ERROR) << "Compression is not supported but compression_type is set."

--- a/tensorflow/core/lib/io/record_writer.cc
+++ b/tensorflow/core/lib/io/record_writer.cc
@@ -31,7 +31,7 @@ bool IsZlibCompressed(RecordWriterOptions options) {
 RecordWriterOptions RecordWriterOptions::CreateRecordWriterOptions(
     const string& compression_type) {
   RecordWriterOptions options;
-  if (compression_type == "ZLIB") {
+  if (compression_type == compression::kZlib) {
     options.compression_type = io::RecordWriterOptions::ZLIB_COMPRESSION;
 #if defined(IS_SLIM_BUILD)
     LOG(ERROR) << "Compression is not supported but compression_type is set."


### PR DESCRIPTION
This PR adds the missing `kZlib` to the compression namespace so that the related files can reuse this named constant like [kNone](https://github.com/tensorflow/tensorflow/pull/30667/files#diff-88365edc1cef483dfe0eb2946fd3c5ceL50) and [kGzip](https://github.com/tensorflow/tensorflow/pull/30667/files#diff-88365edc1cef483dfe0eb2946fd3c5ceR42).