### PR TITLE
[INTEL MKL] Fix to the unit test "print_selective_registration_header_test"

### DIFF
--- a/tensorflow/python/tools/print_selective_registration_header_test.py
+++ b/tensorflow/python/tools/print_selective_registration_header_test.py
@@ -24,7 +24,6 @@ import sys
 from google.protobuf import text_format
 
 from tensorflow.core.framework import graph_pb2
-from tensorflow.python.framework import test_util
 from tensorflow.python.platform import gfile
 from tensorflow.python.platform import test
 from tensorflow.python.tools import selective_registration_header_lib

--- a/tensorflow/python/tools/print_selective_registration_header_test.py
+++ b/tensorflow/python/tools/print_selective_registration_header_test.py
@@ -104,8 +104,6 @@ class PrintOpFilegroupTest(test.TestCase):
     ops_and_kernels = selective_registration_header_lib.get_ops_and_kernels(
         'rawproto', self.WriteGraphFiles(graphs), default_ops)
     matmul_prefix = ''
-    if test_util.IsMklEnabled():
-      matmul_prefix = 'Mkl'
 
     self.assertListEqual(
         [


### PR DESCRIPTION
Removed the check and code to append prefix 'Mkl' if mkl is enabled in the print_selective_registration_header_test unit test, as it was causing a failure with new changes wherein all operators get re-written into MKL versions including matmul. The 'if' check is no longer needed in the test.