### PR TITLE
Remove additional bazel flags in pip_smoke_test

### DIFF
--- a/tensorflow/tools/pip_package/pip_smoke_test.py
+++ b/tensorflow/tools/pip_package/pip_smoke_test.py
@@ -30,11 +30,6 @@ os.chdir(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 PIP_PACKAGE_QUERY_EXPRESSION = (
     "deps(//tensorflow/tools/pip_package:build_pip_package)")
 
-RELEASE_PATCH_FLAGS = (
-  " --incompatible_package_name_is_a_function=false"
-  " --incompatible_remove_native_http_archive=false"
-  " --incompatible_strict_action_env=false")
-
 
 def GetBuild(dir_base):
   """Get the list of BUILD file all targets recursively startind at dir_base."""
@@ -132,7 +127,7 @@ def main():
 
   # pip_package_dependencies_list is the list of included files in pip packages
   pip_package_dependencies = subprocess.check_output(
-      ["bazel", "cquery", RELEASE_PATCH_FLAGS, PIP_PACKAGE_QUERY_EXPRESSION])
+      ["bazel", "cquery", PIP_PACKAGE_QUERY_EXPRESSION])
   pip_package_dependencies_list = pip_package_dependencies.strip().split("\n")
   pip_package_dependencies_list = [
       x.split()[0] for x in pip_package_dependencies_list
@@ -142,7 +137,7 @@ def main():
   # tf_py_test_dependencies is the list of dependencies for all python
   # tests in tensorflow
   tf_py_test_dependencies = subprocess.check_output(
-      ["bazel", "cquery", RELEASE_PATCH_FLAGS, PY_TEST_QUERY_EXPRESSION])
+      ["bazel", "cquery", PY_TEST_QUERY_EXPRESSION])
   tf_py_test_dependencies_list = tf_py_test_dependencies.strip().split("\n")
   tf_py_test_dependencies_list = [
       x.split()[0] for x in tf_py_test_dependencies.strip().split("\n")
@@ -180,7 +175,7 @@ def main():
       rdep_query = ("rdeps(kind(py_test, %s), %s)" %
                     (" + ".join(PYTHON_TARGETS), missing_dependency))
       affected_tests = subprocess.check_output(
-          ["bazel", "cquery", RELEASE_PATCH_FLAGS, rdep_query])
+          ["bazel", "cquery", rdep_query])
       affected_tests_list = affected_tests.split("\n")[:-2]
       print("\n".join(affected_tests_list))
 


### PR DESCRIPTION
`pip_smoke_test.py` only does `bazel cquery` so it doesn't need the build flags I added in the past few commits (#30651, #30583).

This should now fix sanity build.