### PR TITLE
Fail when np.array and len are called on Tensors.

### DIFF
--- a/tensorflow/contrib/training/python/training/sampling_ops_test.py
+++ b/tensorflow/contrib/training/python/training/sampling_ops_test.py
@@ -71,7 +71,7 @@ class StratifiedSampleTest(test.TestCase):
                                      probs, batch_size, init_probs)
 
     # Data must be list, not singleton tensor.
-    with self.assertRaises(TypeError):
+    with self.assertRaises(NotImplementedError):
       sampling_ops.stratified_sample(
           array_ops.zeros([1, 3]), label, probs, batch_size, init_probs)
 

--- a/tensorflow/contrib/training/python/training/sampling_ops_test.py
+++ b/tensorflow/contrib/training/python/training/sampling_ops_test.py
@@ -71,7 +71,7 @@ class StratifiedSampleTest(test.TestCase):
                                      probs, batch_size, init_probs)
 
     # Data must be list, not singleton tensor.
-    with self.assertRaises(NotImplementedError):
+    with self.assertRaises(TypeError):
       sampling_ops.stratified_sample(
           array_ops.zeros([1, 3]), label, probs, batch_size, init_probs)
 

--- a/tensorflow/python/autograph/impl/api_test.py
+++ b/tensorflow/python/autograph/impl/api_test.py
@@ -511,7 +511,7 @@ class ApiTest(test.TestCase):
 
     # f should not be converted, causing len to error out.
     with self.assertRaisesRegexp(Exception,
-                                 'object of type \'Tensor\' has no len()'):
+                                 'len is not well defined'):
       api.converted_call(f, opts, (constant_op.constant([0]),), {})
 
     # len on the other hand should work fine.

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -726,6 +726,25 @@ class Tensor(_TensorLike):
   # with ndarrays.
   __array_priority__ = 100
 
+  def __array__(self):
+    try:
+      name = self.name
+    except ValueError:
+      name = "<Could not determine Tensor Name>"
+
+    raise NotImplementedError("Cannot convert a symbolic Tensor ({}) to a numpy"
+                              " array.".format(name))
+
+  def __len__(self):
+    try:
+      name = self.name
+    except ValueError:
+      name = "<Could not determine Tensor Name>"
+
+    raise NotImplementedError("len is not well defined for symbolic Tensors. "
+                              "({}) Please call `x.shape` rather than `len(x)` "
+                              "to determine shape information.".format(name))
+
   @staticmethod
   def _override_operator(operator, func):
     _override_helper(Tensor, operator, func)

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -731,9 +731,9 @@ class Tensor(_TensorLike):
                               " array.".format(self.name))
 
   def __len__(self):
-    raise NotImplementedError("len is not well defined for symbolic Tensors. "
-                              "({}) Please call `x.shape` rather than `len(x)` "
-                              "for shape information.".format(self.name))
+    raise AttributeError("len is not well defined for symbolic Tensors. ({}) "
+                         "Please call `x.shape` rather than `len(x)` for "
+                         "shape information.".format(self.name))
 
   @staticmethod
   def _override_operator(operator, func):

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -731,9 +731,9 @@ class Tensor(_TensorLike):
                               " array.".format(self.name))
 
   def __len__(self):
-    raise AttributeError("len is not well defined for symbolic Tensors. ({}) "
-                         "Please call `x.shape` rather than `len(x)` for "
-                         "shape information.".format(self.name))
+    raise TypeError("len is not well defined for symbolic Tensors. ({}) "
+                    "Please call `x.shape` rather than `len(x)` for "
+                    "shape information.".format(self.name))
 
   @staticmethod
   def _override_operator(operator, func):

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -727,23 +727,13 @@ class Tensor(_TensorLike):
   __array_priority__ = 100
 
   def __array__(self):
-    try:
-      name = self.name
-    except ValueError:
-      name = "<Could not determine Tensor Name>"
-
     raise NotImplementedError("Cannot convert a symbolic Tensor ({}) to a numpy"
-                              " array.".format(name))
+                              " array.".format(self.name))
 
   def __len__(self):
-    try:
-      name = self.name
-    except ValueError:
-      name = "<Could not determine Tensor Name>"
-
     raise NotImplementedError("len is not well defined for symbolic Tensors. "
                               "({}) Please call `x.shape` rather than `len(x)` "
-                              "to determine shape information.".format(name))
+                              "for shape information.".format(self.name))
 
   @staticmethod
   def _override_operator(operator, func):

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -197,7 +197,7 @@ class TensorAndShapeTest(test_util.TensorFlowTestCase):
                                  r"Cannot convert a symbolic.+test_ones"):
       np.array(x)
 
-    with self.assertRaisesRegexp(NotImplementedError,
+    with self.assertRaisesRegexp(AttributeError,
                                  "len is not well defined.+test_ones"):
       len(x)
 

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -190,7 +190,7 @@ class TensorAndShapeTest(test_util.TensorFlowTestCase):
         _ = a + b
 
   def testNumpyArray(self):
-    with context.graph_mode():
+    with ops.Graph().as_default():
       x = array_ops.ones((3, 4), name="test_ones")
 
     with self.assertRaisesRegexp(NotImplementedError,

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -25,8 +25,6 @@ import os
 import threading
 import weakref
 
-import numpy as np
-
 from tensorflow.core.framework import attr_value_pb2
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.autograph.core import ag_ctx

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -197,8 +197,7 @@ class TensorAndShapeTest(test_util.TensorFlowTestCase):
                                  r"Cannot convert a symbolic.+test_ones"):
       np.array(x)
 
-    with self.assertRaisesRegexp(AttributeError,
-                                 "len is not well defined.+test_ones"):
+    with self.assertRaisesRegexp(TypeError, "not well defined.+test_ones"):
       len(x)
 
     with context.eager_mode():

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -25,6 +25,8 @@ import os
 import threading
 import weakref
 
+import numpy as np
+
 from tensorflow.core.framework import attr_value_pb2
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.autograph.core import ag_ctx
@@ -186,6 +188,24 @@ class TensorAndShapeTest(test_util.TensorFlowTestCase):
           ValueError, r"Dimensions must be equal, but are 2 and 5 for 'add' "
           r"\(op: 'Add(V2)?'\) with input shapes: \[1,2,3\], \[4,5,6\]."):
         _ = a + b
+
+  def testNumpyArray(self):
+    with context.graph_mode():
+      x = array_ops.ones((3, 4), name="test_ones")
+
+    with self.assertRaisesRegexp(NotImplementedError,
+                                 r"Cannot convert a symbolic.+test_ones"):
+      np.array(x)
+
+    with self.assertRaisesRegexp(NotImplementedError,
+                                 "len is not well defined.+test_ones"):
+      len(x)
+
+    with context.eager_mode():
+      x = array_ops.ones((3, 4))
+
+    self.assertAllEqual(x, np.ones((3, 4)))
+    self.assertEqual(len(x), 3)
 
 
 class IndexedSlicesTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -200,10 +200,12 @@ class TensorAndShapeTest(test_util.TensorFlowTestCase):
     with self.assertRaisesRegexp(TypeError, "not well defined.+test_ones"):
       len(x)
 
+    # EagerTensors should still behave as numpy arrays.
     with context.eager_mode():
       x = array_ops.ones((3, 4))
 
     self.assertAllEqual(x, np.ones((3, 4)))
+    self.assertAllEqual(np.array(x), np.ones((3, 4)))
     self.assertEqual(len(x), 3)
 
 

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -333,6 +333,11 @@ def _AssertCompatible(values, dtype):
 
 def _is_array_like(obj):  # pylint: disable=invalid-name
   """Check if a given object is array-like."""
+  if isinstance(obj, ops.Tensor) and not isinstance(obj, ops._EagerTensorBase):
+    # Tensor implements __array__ only so it can inform the user that it is not
+    # a valid array.
+    return False
+
   # TODO(slebedev): an object could also implement C-level array interface.
   if (callable(getattr(obj, "__array__", None)) or
       isinstance(getattr(obj, "__array_interface__", None), dict)):

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -333,7 +333,7 @@ def _AssertCompatible(values, dtype):
 
 def _is_array_like(obj):  # pylint: disable=invalid-name
   """Check if a given object is array-like."""
-  if isinstance(obj, ops.Tensor) and not isinstance(obj, ops._EagerTensorBase):
+  if isinstance(obj, ops.Tensor) and not isinstance(obj, ops._EagerTensorBase):  # pylint: disable=protected-access
     # Tensor implements __array__ only so it can inform the user that it is not
     # a valid array.
     return False

--- a/tensorflow/python/keras/engine/training_utils.py
+++ b/tensorflow/python/keras/engine/training_utils.py
@@ -474,9 +474,14 @@ def standardize_input_data(data,
   Raises:
       ValueError: in case of improperly formatted user-provided data.
   """
+  try:
+    data_len = len(data)
+  except TypeError:
+    # For instance if data is `None` or a symbolic Tensor.
+    data_len = None
+
   if not names:
-    if (data is not None and hasattr(data, '__len__') and len(data) and
-        not isinstance(data, dict)):
+    if data_len and not isinstance(data, dict):
       raise ValueError(
           'Error when checking model ' + exception_prefix + ': '
           'expected no data, but got:', data)

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2601,10 +2601,10 @@ def conv_transpose(input,  # pylint: disable=redefined-builtin
   """
   with ops.name_scope(name, "conv_transpose",
                       [input, filter, output_shape]) as name:
-    if isinstance(output_shape, collections.Sized):
-      n = len(output_shape) - 2
-    elif isinstance(output_shape, ops.Tensor):
+    if isinstance(output_shape, ops.Tensor):
       n = output_shape.shape[0] - 2
+    elif isinstance(output_shape, collections.Sized):
+      n = len(output_shape) - 2
     else:
       raise ValueError("output_shape must be a tensor or sized collection.")
 

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2601,7 +2601,7 @@ def conv_transpose(input,  # pylint: disable=redefined-builtin
   """
   with ops.name_scope(name, "conv_transpose",
                       [input, filter, output_shape]) as name:
-    if isinstance(output_shape, ops.Tensor):
+    if tensor_util.is_tensor(output_shape):
       n = output_shape.shape[0] - 2
     elif isinstance(output_shape, collections.Sized):
       n = len(output_shape) - 2


### PR DESCRIPTION
When np.array is called on a symbolic Tensor the result is a `shape=()` numpy array of objects which is basically never what was intended. Similarly, length is not defined and can lead to rather cryptic error messages. This surfaced through https://github.com/tensorflow/tensorflow/issues/28619; however the fact is that accidentally passing a Tensor rather than and EagerTensor to a package in the NumPy ecosystem can result in very cryptic error messages.

This PR simply makes Tensors fail with clear error messages in such cases. (Similar to the treatment of `__iter__`)