### PR TITLE
fix the issue in Cast operation

### DIFF
--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -1205,7 +1205,7 @@ Status ConstantFolding::CreateNodeDef(const string& name,
       case DT_INT64:
         POPULATE_TENSOR_PROTO(tensor, t, int64, int64);
       case DT_UINT64:
-        POPULATE_TENSOR_PROTO(tensor, t, uint64, int64);
+        POPULATE_TENSOR_PROTO(tensor, t, uint64, uint64);
       case DT_INT32:
         POPULATE_TENSOR_PROTO(tensor, t, int32, int);
       case DT_UINT32:

--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -1209,7 +1209,7 @@ Status ConstantFolding::CreateNodeDef(const string& name,
       case DT_INT32:
         POPULATE_TENSOR_PROTO(tensor, t, int32, int);
       case DT_UINT32:
-        POPULATE_TENSOR_PROTO(tensor, t, uint32, int);
+        POPULATE_TENSOR_PROTO(tensor, t, uint32, uint32);
       case DT_INT16:
         POPULATE_TENSOR_PROTO(tensor, t, int16, int);
       case DT_UINT16:


### PR DESCRIPTION
Fix the issue: https://github.com/tensorflow/tensorflow/issues/30691  and  https://github.com/tensorflow/tensorflow/issues/30215

When doing cast tensor into uint64(uint32) type ( and tensor's elements num is greater than 4. Note that there are some conditions to trigger this code)
The code would fill the values into the int64_val(int_val) field instead of uint64_val(uint32_val) or tensor_content field in the message TensorProto.
so when reading the tensor, it would read uint64_val(uint32_val) field in the message TensorProto which by default is 0.