### PR TITLE
Implement GetStats function for cuda malloc allocator

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.cc
@@ -61,6 +61,10 @@ void GPUcudaMallocAllocator::DeallocateRaw(void* ptr) {
 #endif  // GOOGLE_CUDA
 }
 
+absl::optional<AllocatorStats> GPUcudaMallocAllocator::GetStats() {
+  return base_allocator_->GetStats();
+}
+
 bool GPUcudaMallocAllocator::TracksAllocationSizes() const { return false; }
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.h
@@ -38,6 +38,7 @@ class GPUcudaMallocAllocator : public Allocator {
   void* AllocateRaw(size_t alignment, size_t num_bytes) override;
   void DeallocateRaw(void* ptr) override;
   bool TracksAllocationSizes() const override;
+  absl::optional<AllocatorStats> GetStats() override;
 
  private:
   Allocator* base_allocator_ = nullptr;  // owned


### PR DESCRIPTION
Addresses issue #30736 by overriding Allocator's virtual GetStats function in the cuda malloc allocator.

This rudimentary implementation calls GetStats with the base_allocator_ private member, as the [GPUDebugAllocator does](https://github.com/tensorflow/tensorflow/blob/r1.14/tensorflow/core/common_runtime/gpu/gpu_debug_allocator.cc#L135-L137).