### PR TITLE
Fix types for tflite micro

### DIFF
--- a/tensorflow/lite/experimental/micro/micro_allocator.cc
+++ b/tensorflow/lite/experimental/micro/micro_allocator.cc
@@ -42,7 +42,7 @@ MicroAllocator::MicroAllocator(TfLiteContext* context, const Model* model,
 
   // Null all inputs so we can later perform a null check to avoid re-allocating
   // registered pre-allocated inputs.
-  for (int i = 0; i < subgraph_->inputs()->size(); ++i) {
+  for (flatbuffers::uoffset_t i = 0; i < subgraph_->inputs()->size(); ++i) {
     const int tensor_index = subgraph_->inputs()->Get(i);
     context_->tensors[tensor_index].data.raw = nullptr;
   }
@@ -74,7 +74,7 @@ TfLiteStatus MicroAllocator::AllocateTensors() {
       sizeof(int) * tensors_->size(), sizeof(int)));
   int* last_used = reinterpret_cast<int*>(tensor_allocator_.AllocateMemory(
       sizeof(int) * tensors_->size(), sizeof(int)));
-  for (int i = 0; i < tensors_->size(); ++i) {
+  for (flatbuffers::uoffset_t i = 0; i < tensors_->size(); ++i) {
     first_created[i] = -1;
     last_used[i] = -1;
   }
@@ -83,7 +83,7 @@ TfLiteStatus MicroAllocator::AllocateTensors() {
   // re-allocating later.  Since inputs are not created by a particular node, we
   // make up an index which does not overlap with any node.
   const int kInputIndex = subgraph_->inputs()->size();
-  for (int i = 0; i < subgraph_->inputs()->size(); ++i) {
+  for (flatbuffers::uoffset_t i = 0; i < subgraph_->inputs()->size(); ++i) {
     const int tensor_index = subgraph_->inputs()->Get(i);
     const auto* tensor = tensors_->Get(tensor_index);
     // Check for and skip pre-allocated inputs.
@@ -96,15 +96,15 @@ TfLiteStatus MicroAllocator::AllocateTensors() {
     first_created[tensor_index] = kInputIndex;
   }
 
-  for (int i = (operators_->size() - 1); i >= 0; --i) {
+  for (flatbuffers::uoffset_t i = (operators_->size() - 1); i >= 0; --i) {
     const auto* op = operators_->Get(i);
-    for (int n = 0; n < op->inputs()->size(); ++n) {
+    for (flatbuffers::uoffset_t n = 0; n < op->inputs()->size(); ++n) {
       const int tensor_index = op->inputs()->Get(n);
-      if ((last_used[tensor_index] == -1) || (last_used[tensor_index] < i)) {
+      if ((last_used[tensor_index] == -1) || ((flatbuffers::uoffset_t)last_used[tensor_index] < i)) {
         last_used[tensor_index] = i;
       }
     }
-    for (int n = 0; n < op->outputs()->size(); ++n) {
+    for (flatbuffers::uoffset_t n = 0; n < op->outputs()->size(); ++n) {
       const int tensor_index = op->outputs()->Get(n);
       const int create_before = i;
       int destroy_after = last_used[tensor_index];
@@ -124,7 +124,7 @@ TfLiteStatus MicroAllocator::AllocateTensors() {
     }
   }
 
-  for (int i = 0; i < tensors_->size(); ++i) {
+  for (flatbuffers::uoffset_t i = 0; i < tensors_->size(); ++i) {
     const auto* tensor = tensors_->Get(i);
     const bool is_read_only = (first_created[i] == -1) && (last_used[i] != -1);
     if (tensor->is_variable() || is_read_only) {

--- a/tensorflow/lite/experimental/micro/micro_interpreter.cc
+++ b/tensorflow/lite/experimental/micro/micro_interpreter.cc
@@ -102,9 +102,9 @@ TfLiteStatus MicroInterpreter::Invoke() {
   }
   TfLiteStatus status = kTfLiteOk;
   auto opcodes = model_->operator_codes();
-  for (int i = 0; i < operators_->size(); ++i) {
+  for (flatbuffers::uoffset_t i = 0; i < operators_->size(); ++i) {
     const auto* op = operators_->Get(i);
-    int index = op->opcode_index();
+    uint32_t index = op->opcode_index();
     if (index < 0 || index >= opcodes->size()) {
       error_reporter_->Report("Missing registration for opcode_index %d\n",
                               index);
@@ -207,7 +207,7 @@ TfLiteStatus MicroInterpreter::Invoke() {
 TfLiteTensor* MicroInterpreter::input(int index) {
   const flatbuffers::Vector<int32_t>* inputs = subgraph_->inputs();
   const size_t length = inputs->size();
-  if ((index < 0) || (index >= length)) {
+  if ((index < 0) || (index >= (int)length)) {
     error_reporter_->Report("Input index %d out of range (length is %d)", index,
                             length);
     return nullptr;
@@ -218,7 +218,7 @@ TfLiteTensor* MicroInterpreter::input(int index) {
 TfLiteTensor* MicroInterpreter::output(int index) {
   const flatbuffers::Vector<int32_t>* outputs = subgraph_->outputs();
   const size_t length = outputs->size();
-  if ((index < 0) || (index >= outputs->size())) {
+  if ((index < 0) || (index >= (int)outputs->size())) {
     error_reporter_->Report("Output index %d out of range (length is %d)",
                             index, length);
     return nullptr;

--- a/tensorflow/lite/experimental/micro/simple_tensor_allocator.cc
+++ b/tensorflow/lite/experimental/micro/simple_tensor_allocator.cc
@@ -102,7 +102,7 @@ TfLiteStatus SimpleTensorAllocator::AllocateTensor(
     result->allocation_type = kTfLiteMmapRo;
   } else {
     int data_size = 1;
-    for (int n = 0; n < flatbuffer_tensor.shape()->Length(); ++n) {
+    for (flatbuffers::uoffset_t n = 0; n < flatbuffer_tensor.shape()->Length(); ++n) {
       data_size *= flatbuffer_tensor.shape()->Get(n);
     }
     size_t type_size;
@@ -131,7 +131,7 @@ TfLiteStatus SimpleTensorAllocator::AllocateTensor(
   result->dims = reinterpret_cast<TfLiteIntArray*>(AllocateMemory(
       sizeof(int) * (flatbuffer_tensor.shape()->Length() + 1), sizeof(int)));
   result->dims->size = flatbuffer_tensor.shape()->Length();
-  for (int n = 0; n < flatbuffer_tensor.shape()->Length(); ++n) {
+  for (flatbuffers::uoffset_t n = 0; n < flatbuffer_tensor.shape()->Length(); ++n) {
     result->dims->data[n] = flatbuffer_tensor.shape()->Get(n);
   }
   const auto* src_quantization = flatbuffer_tensor.quantization();
@@ -159,7 +159,7 @@ uint8_t* SimpleTensorAllocator::AllocateMemory(size_t size, size_t alignment) {
   uint8_t* aligned_result = AlignPointerRoundUp(current_data, alignment);
   uint8_t* next_free = aligned_result + size;
   size_t aligned_size = (next_free - current_data);
-  if ((data_size_ + aligned_size) > data_size_max_) {
+  if ((data_size_ + aligned_size) > (size_t)data_size_max_) {
     // TODO(petewarden): Add error reporting beyond returning null!
     return nullptr;
   }


### PR DESCRIPTION
When build the tflite-micro for the stm32f746 with `-Wall` the build fails in several points because there are warnings about types and different signedness.

For example:
`code-stm32f476-tflite/source/libs/tensorflow/lite/experimental/micro/micro_interpreter.cc: In member function 'TfLiteStatus tflite::MicroInterpreter::Invoke()':
code-stm32f476-tflite/source/libs/tensorflow/lite/experimental/micro/micro_interpreter.cc:104:21: warning: comparison of integer expressions of different signedness: 'int' and 'flatbuffers::uoffset_t' {aka 'long unsigned int'} [-Wsign-compare]
   for (int i = 0; i < operators_->size(); ++i) {`

With this commit my cmake project that uses `-Wall` compiles without errors.