### PR TITLE
Display exported concrete and polymorphic functions in SavedModel CLI

### DIFF
--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -212,7 +212,7 @@ def _print_args(arguments, argument_type="Argument", indent=0):
       if indent == 3:
         in_print('%s #%d' % (argument_type, index))
       if isinstance(element, tensor_spec.TensorSpec):
-        _print_tensor_spec(element, indent)
+        print((indent + 1) * '  ' + '%s: %s'%(element.name, repr(element)))
       elif is_nested(element):
         in_print('  DType: %s' % type(element).__name__)
         in_print('  Values: [', end='')
@@ -232,26 +232,6 @@ def _print_args(arguments, argument_type="Argument", indent=0):
       else:
         in_print('  DType: %s' % type(element).__name__)
         in_print('  Value: %s' % str(element))
-
-
-def _print_tensor_spec(tensor_spec, indent=0):
-  """Prints details of the given tensor_spec.
-
-     Args:
-       tensor_spec: TensorSpec object to be printed.
-       indent: How far (in increments of 2 spaces) to indent each line output
-  """
-  indent_str = '  ' * indent
-
-  def in_print(s):
-    print(indent_str + s)
-  in_print(
-      '  %s: Tensor(shape=%s, dtype=%s, name=\'%s\')' %
-      (tensor_spec.name,
-       tensor_spec.shape,
-       tensor_spec.dtype.name,
-       tensor_spec.name))
-
 
 def _print_tensor_info(tensor_info, indent=0):
   """Prints details of the given tensor_info.

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -166,13 +166,21 @@ def _show_inputs_outputs(
 
 
 def _show_defined_functions(saved_model_dir, indent=0):
+  """Prints the function definition of SavedModel2.0 located at saved_model_dir
+
+     Args:
+       saved_model_dir: Directory containing the SavedModel to inspect.
+       indent: How far (in increments of 2 spaces) to indent each line of output.
+  """
   if context.executing_eagerly():
+    # Disable eager execution to prevent loading of checkpoints
     ops_lib.disable_eager_execution()
   trackable_object = load.load(saved_model_dir)
   indent_str = '  ' * indent
 
   def in_print(s):
     print(indent_str + s)
+
   print('Defined Functions:')
   functions = save._AugmentedGraphView(
       trackable_object).list_functions(trackable_object)
@@ -184,9 +192,18 @@ def _show_defined_functions(saved_model_dir, indent=0):
       in_print('Option #%d' % index)
       in_print('  Callable with:')
       _print_args(args, indent=3)
+      if kwargs:
+        _print_args(args, "Named Argument", indent=3)
 
 
-def _print_args(arguments, indent=0):  # Level is indent
+def _print_args(arguments, argument_type="Argument", indent=0):
+  """Formats and prints the argument of the concrete functions defined in the model
+
+     Args:
+       arguments: Arguments of the concrete functions.
+       argument_type: Type of Argument List to Format and print.
+       indent: How far (in increments of 2 spaces) to indent each line of output.
+  """
   indent_str = '  ' * indent
 
   def quotes(value):
@@ -201,7 +218,7 @@ def _print_args(arguments, indent=0):  # Level is indent
   if is_nested(arguments):
     for index, element in enumerate(arguments, 1):
       if indent == 3:
-        in_print('Argument #%d' % index)
+        in_print('%s #%d' % (argument_type, index))
       if isinstance(element, tensor_spec.TensorSpec):
         _print_tensor_spec(element, indent)
       elif is_nested(element):
@@ -226,6 +243,12 @@ def _print_args(arguments, indent=0):  # Level is indent
 
 
 def _print_tensor_spec(tensor_spec, indent=0):
+  """Prints details of the given tensor_spec.
+
+     Args:
+       tensor_spec: TensorSpec object to be printed.
+       indent: How far (in increments of 2 spaces) to indent each line output
+  """
   indent_str = '  ' * indent
 
   def in_print(s):

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -181,12 +181,12 @@ def _show_defined_functions(saved_model_dir):
     trackable_object = load.load(saved_model_dir)
 
   print('\nDefined Functions:', end="")
-  functions = save._AugmentedGraphView(
-      trackable_object).list_functions(trackable_object)
+  functions = (save._AugmentedGraphView(trackable_object)  # pylint: disable=protected-access
+               .list_functions(trackable_object))
   functions = sorted(functions.items(), key=lambda x: x[0])
   for name, function in functions:
     print('\n  Function Name: \'%s\'' % name)
-    concrete_functions = function._list_all_concrete_functions_for_serialization()
+    concrete_functions = function._list_all_concrete_functions_for_serialization()  # pylint: disable=line-too-long, protected-access
     concrete_functions = sorted(concrete_functions, key=lambda x: x.name)
     for index, concrete_function in enumerate(concrete_functions, 1):
       args, kwargs = concrete_function.structured_input_signature
@@ -203,7 +203,8 @@ def _print_args(arguments, argument_type="Argument", indent=0):
      Args:
        arguments: Arguments of the concrete functions.
        argument_type: Type of Argument List to Format and print.
-       indent: How far (in increments of 2 spaces) to indent each line of output.
+       indent: How far (in increments of 2 spaces) to indent each line
+               of output.
   """
   indent_str = '  ' * indent
 
@@ -218,8 +219,9 @@ def _print_args(arguments, argument_type="Argument", indent=0):
     if indent == 4:
       in_print('%s #%d' % (argument_type, index))
     if isinstance(element, tensor_spec.TensorSpec):
-      print((indent + 1) * '  ' + '%s: %s' % (element.name, repr(element)))
-    elif isinstance(element, collections.Iterable) and not isinstance(element, dict):
+      print((indent + 1) * '  ' +
+            '%s: %s' % (element.name, repr(element)))
+    elif isinstance(element, collections.Iterable) and not isinstance(element, dict):  # pylint: disable=line-too-long
       in_print('  DType: %s' % type(element).__name__)
       in_print('  Value: [', end='')
       for value in element:

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -177,11 +177,13 @@ def _show_defined_functions(saved_model_dir, indent=0):
   functions = save._AugmentedGraphView(
       trackable_object).list_functions(trackable_object)
   for name, function in functions.items():
-    for concrete_functions in function._list_all_concrete_functions_for_serialization():
+    in_print('Function Name: \'%s\'' % name)
+    for index, concrete_functions in enumerate(
+            function._list_all_concrete_functions_for_serialization(), 1):
       args, kwargs = (concrete_functions.structured_input_signature)
-      in_print('Function Name: \'%s\'' % name)
-      in_print('Callable with:')
-      _print_args(args, indent=2)
+      in_print('Option #%d' % index)
+      in_print('  Callable with:')
+      _print_args(args, indent=3)
 
 
 def _print_args(arguments, indent=0):  # Level is indent
@@ -198,7 +200,7 @@ def _print_args(arguments, indent=0):  # Level is indent
     return nest.is_nested(args) and not isinstance(args, dict)
   if is_nested(arguments):
     for index, element in enumerate(arguments, 1):
-      if indent == 2:
+      if indent == 3:
         in_print('Argument #%d' % index)
       if isinstance(element, tensor_spec.TensorSpec):
         _print_tensor_spec(element, indent)

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -193,7 +193,7 @@ def _show_defined_functions(saved_model_dir, indent=0):
       in_print('  Callable with:')
       _print_args(args, indent=3)
       if kwargs:
-        _print_args(args, "Named Argument", indent=3)
+        _print_args(kwargs, "Named Argument", indent=3)
 
 
 def _print_args(arguments, argument_type="Argument", indent=0):

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -172,10 +172,8 @@ def _show_defined_functions(saved_model_dir, indent=0):
        saved_model_dir: Directory containing the SavedModel to inspect.
        indent: How far (in increments of 2 spaces) to indent each line of output.
   """
-  if context.executing_eagerly():
-    # Disable eager execution to prevent loading of checkpoints
-    ops_lib.disable_eager_execution()
-  trackable_object = load.load(saved_model_dir)
+  with ops_lib.Graph().as_default():
+    trackable_object = load.load(saved_model_dir)
   indent_str = '  ' * indent
 
   def in_print(s):

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -219,14 +219,8 @@ def _print_args(arguments, argument_type="Argument", indent=0):
         _print_args(element, indent + 1)
         in_print('  ]')
       elif isinstance(element, dict):
-        in_print('  DType: %s' % type(element).__name__)
-        in_print('  Values:  {', end='')
+        in_print('  {', end='')
         for (key, value) in element.items():
-          if is_nested(element):
-            in_print('\n      \'%s\': [' % str(key), end='')
-            _print_args(element, indent + 1)
-            in_print('        ]')
-          else:
             print('\'%s\': %s' % (str(key), _may_be_add_quotes(value)), end=', ')
         print('\b\b}')
       else:

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -121,10 +121,10 @@ def _get_outputs_tensor_info_from_meta_graph_def(meta_graph_def,
 
 
 def _show_inputs_outputs(
-        saved_model_dir,
-        tag_set,
-        signature_def_key,
-        indent=0):
+    saved_model_dir,
+    tag_set,
+    signature_def_key,
+    indent=0):
   """Prints input and output TensorInfos.
 
   Prints the details of input and output TensorInfos for the SignatureDef mapped
@@ -176,7 +176,7 @@ def _show_defined_functions(saved_model_dir):
   for meta_graph_def in meta_graphs:
     has_object_graph_def |= meta_graph_def.HasField("object_graph_def")
   if not has_object_graph_def:
-    return 
+    return
   with ops_lib.Graph().as_default():
     trackable_object = load.load(saved_model_dir)
 
@@ -218,22 +218,23 @@ def _print_args(arguments, argument_type="Argument", indent=0):
     if indent == 4:
       in_print('%s #%d' % (argument_type, index))
     if isinstance(element, tensor_spec.TensorSpec):
-      print((indent + 1) * '  ' + '%s: %s'%(element.name, repr(element)))
+      print((indent + 1) * '  ' + '%s: %s' % (element.name, repr(element)))
     elif isinstance(element, collections.Iterable) and not isinstance(element, dict):
       in_print('  DType: %s' % type(element).__name__)
       in_print('  Value: [', end='')
       for value in element:
-          print('%s' %  _maybe_add_quotes(value), end=', ')
+        print('%s' % _maybe_add_quotes(value), end=', ')
       print('\b\b]')
     elif isinstance(element, dict):
       in_print('  DType: %s' % type(element).__name__)
       in_print('  Value: {', end='')
       for (key, value) in element.items():
-          print('\'%s\': %s' % (str(key), _maybe_add_quotes(value)), end=', ')
+        print('\'%s\': %s' % (str(key), _maybe_add_quotes(value)), end=', ')
       print('\b\b}')
     else:
       in_print('  DType: %s' % type(element).__name__)
       in_print('  Value: %s' % str(element))
+
 
 def _print_tensor_info(tensor_info, indent=0):
   """Prints details of the given tensor_info.

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -200,7 +200,7 @@ def _print_args(arguments, argument_type="Argument", indent=0):
 
   def _may_be_add_quotes(value):
     is_quotes = '\'' * isinstance(value, str)
-    return is_quotes + value + is_quotes
+    return is_quotes + str(value) + is_quotes
 
   def in_print(s, end='\n'):
     print(indent_str + s, end=end)
@@ -221,14 +221,14 @@ def _print_args(arguments, argument_type="Argument", indent=0):
       elif isinstance(element, dict):
         in_print('  DType: %s' % type(element).__name__)
         in_print('  Values:  {', end='')
-        for key, value in element.items():
+        for (key, value) in element.items():
           if is_nested(element):
-            in_print('      \'%s\': [' % str(key), end='')
+            in_print('\n      \'%s\': [' % str(key), end='')
             _print_args(element, indent + 1)
             in_print('        ]')
           else:
-            in_print('      \'%s\': %s' % (str(key), _may_be_add_quotes(value)), end='')
-        in_print('      }')
+            print('\'%s\': %s' % (str(key), _may_be_add_quotes(value)), end=', ')
+        print('\b\b}')
       else:
         in_print('  DType: %s' % type(element).__name__)
         in_print('  Value: %s' % str(element))

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -180,7 +180,7 @@ def _show_defined_functions(saved_model_dir):
     print('  Function Name: \'%s\'' % name)
     for index, concrete_functions in enumerate(
             function._list_all_concrete_functions_for_serialization(), 1):
-      args, kwargs = (concrete_functions.structured_input_signature)
+      args, kwargs = concrete_functions.structured_input_signature
       print('  Option #%d' % index)
       print('    Callable with:')
       _print_args(args, indent=3)

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -207,7 +207,7 @@ def _print_args(arguments, argument_type="Argument", indent=0):
 
   def is_nested(args):
     return nest.is_nested(args) and not isinstance(args, dict)
-  if is_nested(arguments):
+  if nest.is_nested(arguments):
     for index, element in enumerate(arguments, 1):
       if indent == 3:
         in_print('%s #%d' % (argument_type, index))

--- a/tensorflow/python/tools/saved_model_cli_test.py
+++ b/tensorflow/python/tools/saved_model_cli_test.py
@@ -41,6 +41,7 @@ from tensorflow.python.tools import saved_model_cli
 from tensorflow.python.training.tracking import util
 SAVED_MODEL_PATH = ('cc/saved_model/testdata/half_plus_two/00000123')
 
+
 @contextlib.contextmanager
 def captured_output():
   new_out, new_err = StringIO(), StringIO()
@@ -144,7 +145,7 @@ signature_def['serving_default']:
         name: y:0
   Method name is: tensorflow/serving/predict"""
     # pylint: enable=line-too-long
-    self.maxDiff = None # Produce a useful error msg if the comparison fails
+    self.maxDiff = None  # Produce a useful error msg if the comparison fails
     self.assertMultiLineEqual(output, exp_out)
     self.assertEqual(err.getvalue().strip(), '')
 
@@ -154,20 +155,22 @@ signature_def['serving_default']:
           and using it for test
       """
       @def_function.function
-      def func1(self, a, b, c): 
+      def func1(self, a, b, c):
         if c:
-          return a + b 
+          return a + b
         else:
-          return a * b 
+          return a * b
+
       @def_function.function(
-    		input_signature=[
-    				tensor_spec.TensorSpec(shape=(2, 2),
-    				dtype=dtypes.float32)])
-      def func2(self, x): 
-        return x + 2 
+          input_signature=[
+              tensor_spec.TensorSpec(shape=(2, 2),
+                                     dtype=dtypes.float32)])
+      def func2(self, x):
+        return x + 2
+
       @def_function.function
       def __call__(self, y, c=7):
-        return y + 2 * c 
+        return y + 2 * c
 
     temp_dir = self.get_temp_dir()
     trackable_object = DummyModel()
@@ -175,7 +178,10 @@ signature_def['serving_default']:
         constant_op.constant(5),
         constant_op.constant(9),
         True)
-    trackable_object.func1(constant_op.constant(5), constant_op.constant(9), False)
+    trackable_object.func1(
+        constant_op.constant(5),
+        constant_op.constant(9),
+        False)
     trackable_object(constant_op.constant(5))
     save.save(trackable_object, temp_dir)
     self.parser = saved_model_cli.create_parser()
@@ -192,7 +198,7 @@ signature_def['__saved_model_init_op']:
         dtype: DT_INVALID
         shape: unknown_rank
         name: NoOp
-  Method name is: 
+  Method name is:
 
 signature_def['serving_default']:
   The given SavedModel SignatureDef contains the following input(s):
@@ -242,8 +248,8 @@ Defined Functions:
       Callable with:
         Argument #1
           x: TensorSpec(shape=(2, 2), dtype=tf.float32, name='x')
-""".strip() # pylint: enable=line-too-long
-    self.maxDiff = None # Produce a useful error msg if the comparison fails
+""".strip()  # pylint: enable=line-too-long
+    self.maxDiff = None  # Produce a useful error msg if the comparison fails
     self.assertMultiLineEqual(output, exp_out)
     self.assertEqual(err.getvalue().strip(), '')
 
@@ -274,9 +280,8 @@ Defined Functions:
         '"regress_x_to_y"', '"regress_x_to_y2"', '"serving_default"'
     ]
     # Order of signatures does not matter
-    self.assertMultiLineEqual(
-        output,
-        '\n'.join([exp_header] + [exp_start + exp_key for exp_key in exp_keys]))
+    self.assertMultiLineEqual(output, '\n'.join(
+        [exp_header] + [exp_start + exp_key for exp_key in exp_keys]))
     self.assertEqual(err.getvalue().strip(), '')
 
   def testShowCommandErrorNoTagSet(self):

--- a/tensorflow/python/tools/saved_model_cli_test.py
+++ b/tensorflow/python/tools/saved_model_cli_test.py
@@ -31,11 +31,15 @@ from six import StringIO
 from tensorflow.core.framework import types_pb2
 from tensorflow.core.protobuf import meta_graph_pb2
 from tensorflow.python.debug.wrappers import local_cli_wrapper
+from tensorflow.python.eager import def_function
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import tensor_spec
 from tensorflow.python.platform import test
-from tensorflow.python.tools import saved_model_cli
-
+from tensorflow.python.saved_model import save
+import saved_model_cli
+from tensorflow.python.training.tracking import util
 SAVED_MODEL_PATH = ('cc/saved_model/testdata/half_plus_two/00000123')
-
 
 @contextlib.contextmanager
 def captured_output():
@@ -47,6 +51,22 @@ def captured_output():
   finally:
     sys.stdout, sys.stderr = old_out, old_err
 
+class DummyModel(util.Checkpoint):
+  @def_function.function
+  def func1(self, a, b, c): 
+    if c:
+      return a + b 
+    else:
+      return a * b 
+  @def_function.function(
+		input_signature=[
+				tensor_spec.TensorSpec(shape=(2, 2),
+				dtype=dtypes.float32)])
+  def func2(self, x): 
+    return x + 2 
+  @def_function.function
+  def __call__(self, y, c=7):
+    return y + 2 * c 
 
 class SavedModelCLITestCase(test.TestCase):
 
@@ -57,6 +77,8 @@ class SavedModelCLITestCase(test.TestCase):
     with captured_output() as (out, err):
       saved_model_cli.show(args)
     output = out.getvalue().strip()
+    with open("out.txt", "w") as f:
+      f.write(output)
     # pylint: disable=line-too-long
     exp_out = """MetaGraphDef with tag-set: 'serve' contains the following SignatureDefs:
 
@@ -141,7 +163,85 @@ signature_def['serving_default']:
     self.maxDiff = None # Produce a useful error msg if the comparison fails
     self.assertMultiLineEqual(output, exp_out)
     self.assertEqual(err.getvalue().strip(), '')
+  def testShowAllWithConcreteFunctions(self):
+    
+    temp_dir = self.get_temp_dir()
+    trackable_object = DummyModel()
+    trackable_object.func1(
+        constant_op.constant(5),
+        constant_op.constant(9),
+        True)
+    trackable_object.func1(constant_op.constant(5), constant_op.constant(9), False)
+    trackable_object(constant_op.constant(5))
+    save.save(trackable_object, temp_dir)
+    self.parser = saved_model_cli.create_parser()
+    args = self.parser.parse_args(['show', '--dir', temp_dir, '--all'])
+    with captured_output() as (out, err):
+      saved_model_cli.show(args)
+    output = out.getvalue().strip()
+    exp_out = """MetaGraphDef with tag-set: 'serve' contains the following SignatureDefs:
 
+signature_def['__saved_model_init_op']:
+  The given SavedModel SignatureDef contains the following input(s):
+  The given SavedModel SignatureDef contains the following output(s):
+    outputs['__saved_model_init_op'] tensor_info:
+        dtype: DT_INVALID
+        shape: unknown_rank
+        name: NoOp
+  Method name is: 
+
+signature_def['serving_default']:
+  The given SavedModel SignatureDef contains the following input(s):
+    inputs['x'] tensor_info:
+        dtype: DT_FLOAT
+        shape: (2, 2)
+        name: serving_default_x:0
+  The given SavedModel SignatureDef contains the following output(s):
+    outputs['output_0'] tensor_info:
+        dtype: DT_FLOAT
+        shape: (2, 2)
+        name: PartitionedCall:0
+  Method name is: tensorflow/serving/predict
+
+Defined Functions:
+  Function Name: '__call__'
+    Option #1
+      Callable with:
+        Argument #1
+          y: TensorSpec(shape=(), dtype=tf.int32, name='y')
+        Argument #2
+          DType: int
+          Value: 7
+
+  Function Name: 'func1'
+    Option #1
+      Callable with:
+        Argument #1
+          a: TensorSpec(shape=(), dtype=tf.int32, name='a')
+        Argument #2
+          b: TensorSpec(shape=(), dtype=tf.int32, name='b')
+        Argument #3
+          DType: bool
+          Value: False
+    Option #2
+      Callable with:
+        Argument #1
+          a: TensorSpec(shape=(), dtype=tf.int32, name='a')
+        Argument #2
+          b: TensorSpec(shape=(), dtype=tf.int32, name='b')
+        Argument #3
+          DType: bool
+          Value: True
+
+  Function Name: 'func2'
+    Option #1
+      Callable with:
+        Argument #1
+          x: TensorSpec(shape=(2, 2), dtype=tf.float32, name='x')
+""".strip() # pylint: enable=line-too-long
+    self.maxDiff = None # Produce a useful error msg if the comparison fails
+    self.assertMultiLineEqual(output, exp_out)
+    self.assertEqual(err.getvalue().strip(), '')
   def testShowCommandTags(self):
     base_path = test.test_src_dir_path(SAVED_MODEL_PATH)
     self.parser = saved_model_cli.create_parser()


### PR DESCRIPTION
Adding features to `saved_model_cli` to show SavedModel2.0 Functions.
SavedModelCLI doesn't show details of Polymorphic Functions or multiple Concrete Functions. This Pull request addresses this problem,
The Sample output is provided here: https://github.com/tensorflow/tensorflow/pull/30752#issuecomment-514622204
This PR is made for Google Summer of Code 2019

CC: @vbardiovskyg @srjoglekar246 