### PR TITLE
Add the XLA_FLAGS xla_gpu_ptx_code to allow specifing the PTX code to use in XLA

### DIFF
--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -149,6 +149,12 @@ static void AllocateFlags() {
         return true;
       };
 
+  // Custom "sub-parser" lambda for xla_gpu_ptx_code
+  auto setter_for_xla_gpu_ptx_code = [](string value) {
+      flag_values->add_xla_gpu_ptx_code(value);
+    return true;
+  };
+
   // Custom "sub-parser" lambda for xla_backend_extra_options.
   auto setter_for_xla_backend_extra_options =
       [](string comma_separated_values) {
@@ -342,6 +348,14 @@ static void AllocateFlags() {
           int32_setter_for(&DebugOptions::set_xla_gpu_max_kernel_unroll_factor),
           flag_values->xla_gpu_max_kernel_unroll_factor(),
           "Specify the maximum kernel unroll factor for the GPU backend."),
+      tensorflow::Flag("xla_gpu_ptx_code",
+                       setter_for_xla_gpu_ptx_code, "",
+                       "If non-empty, speficies a file containing ptx to use."
+                       "The filename prefix must have the same pattern as PTX dumped by XLA. "
+                       "This allows to match one specific module."
+                       "General workflow. Get the "
+                       "generated module ptx from XLA. Modify it. Then pass it "
+                       "back via this option."),
       tensorflow::Flag(
           "xla_test_all_output_layouts",
           bool_setter_for(&DebugOptions::set_xla_test_all_output_layouts),

--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -149,9 +149,9 @@ static void AllocateFlags() {
         return true;
       };
 
-  // Custom "sub-parser" lambda for xla_gpu_ptx_code
-  auto setter_for_xla_gpu_ptx_code = [](string value) {
-      flag_values->add_xla_gpu_ptx_code(value);
+  // Custom "sub-parser" lambda for xla_gpu_ptx_file.
+  auto setter_for_xla_gpu_ptx_file = [](string value) {
+      flag_values->add_xla_gpu_ptx_file(value);
     return true;
   };
 
@@ -348,14 +348,14 @@ static void AllocateFlags() {
           int32_setter_for(&DebugOptions::set_xla_gpu_max_kernel_unroll_factor),
           flag_values->xla_gpu_max_kernel_unroll_factor(),
           "Specify the maximum kernel unroll factor for the GPU backend."),
-      tensorflow::Flag("xla_gpu_ptx_code",
-                       setter_for_xla_gpu_ptx_code, "",
-                       "If non-empty, speficies a file containing ptx to use."
-                       "The filename prefix must have the same pattern as PTX dumped by XLA. "
-                       "This allows to match one specific module."
-                       "General workflow. Get the "
-                       "generated module ptx from XLA. Modify it. Then pass it "
-                       "back via this option."),
+      tensorflow::Flag("xla_gpu_ptx_file",
+                       setter_for_xla_gpu_ptx_file, "",
+                       "If non-empty, speficies a file containing ptx to use. "
+                       "The filename prefix must have the same pattern as PTX "
+                       "dumped by XLA. This allows to match one specific "
+                       "module. General workflow. Get the generated module "
+                       "ptx from XLA. Modify it. Then pass it back via this "
+                       "option."),
       tensorflow::Flag(
           "xla_test_all_output_layouts",
           bool_setter_for(&DebugOptions::set_xla_test_all_output_layouts),

--- a/tensorflow/compiler/xla/service/dump.cc
+++ b/tensorflow/compiler/xla/service/dump.cc
@@ -136,10 +136,6 @@ struct CanonicalDebugOptions {
   bool dump_snapshots;
 };
 
-string FilenameFor(const HloModule& module, string_view suffix) {
-  return StrFormat("module_%04d.%s", module.unique_id(), suffix);
-}
-
 void DumpToFileInDirImpl(string_view filename, string_view contents,
                          const CanonicalDebugOptions& opts) {
   if (opts.dumping_to_stdout()) {
@@ -262,6 +258,10 @@ static auto& module_id_to_step_number GUARDED_BY(mu) =
     *new absl::flat_hash_map<int64, int64>();
 
 }  // namespace
+
+string FilenameFor(const HloModule& module, string_view suffix) {
+  return StrFormat("module_%04d.%s", module.unique_id(), suffix);
+}
 
 void DumpToFileInDir(const HloModule& module, string_view suffix,
                      string_view contents) {

--- a/tensorflow/compiler/xla/service/dump.h
+++ b/tensorflow/compiler/xla/service/dump.h
@@ -33,6 +33,9 @@ class BufferAssignment;
 class HloExecutionProfile;
 class HloSnapshot;
 
+// Create the filename we will use to dump in DumpToFileInDir.
+string FilenameFor(const HloModule& module, absl::string_view suffix);
+
 // Writes the given string to a file in the xla_dump_to directory specified by
 // module's DebugOptions.
 //

--- a/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
@@ -228,27 +228,27 @@ bool MaybeLoadPtxFromFile(const HloModule* module, std::string* ptx) {
   // If the xla_gpu_ptx_file options is set, be explicit when a file is used
   // and warn when a file is not used to ease catching typo in filename.
   std::string prefix = xla::FilenameFor(*module, *ptx);
-  std::string ptx_filename;
+  std::string matched_filename;
   for (const string filename : module->config().debug_options().xla_gpu_ptx_file()) {
-    // To ease comparing many PTX versions, accept different suffix then
+    // To ease comparing many PTX versions, accept different suffixes then
     // the original filename.
     if(absl::StartsWith(filename, prefix)) {
-      ptx_filename = filename;
+      matched_filename = filename;
       VLOG(0) << "RunBackend() - Will load PTX from file: " << filename;
       break;
     }
   }
   if (module->config().debug_options().xla_gpu_ptx_file().size() > 0 &&
-      ptx_filename.empty()) {
+      matched_filename.empty()) {
     VLOG(0) << "RunBackend() - For module with prefix '" << prefix
             << "', we did not found a PTX file to load.";
   }
 
-  if(!ptx_filename.empty()) {
-    std::ifstream ifs(ptx_filename, std::ifstream::in);
+  if(!matched_filename.empty()) {
+    std::ifstream ifs(matched_filename, std::ifstream::in);
     *ptx = std::string(std::istreambuf_iterator<char>(ifs),
                       std::istreambuf_iterator<char>());
-    CHECK(!ptx->empty()) << "Empty or non existing PTX file: " << ptx_filename;
+    CHECK(!ptx->empty()) << "Empty or non existing PTX file: " << matched_filename;
     return true;
   }
   return false;

--- a/tensorflow/compiler/xla/xla.proto
+++ b/tensorflow/compiler/xla/xla.proto
@@ -276,13 +276,16 @@ message DebugOptions {
   // directory.
   bool xla_dump_hlo_snapshots = 118;
 
+  bool xla_gpu_force_conv_nchw = 125;
+
+  // Path to a file with ptx code.
+  repeated string xla_gpu_ptx_code = 127;
+
   //
   // END flags controlling dumping HLO modules.
   //
 
-  bool xla_gpu_force_conv_nchw = 125;
-
-  // Next id: 127
+  // Next id: 128
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/tensorflow/compiler/xla/xla.proto
+++ b/tensorflow/compiler/xla/xla.proto
@@ -276,14 +276,14 @@ message DebugOptions {
   // directory.
   bool xla_dump_hlo_snapshots = 118;
 
-  bool xla_gpu_force_conv_nchw = 125;
-
-  // Path to a file with ptx code.
-  repeated string xla_gpu_ptx_code = 127;
-
   //
   // END flags controlling dumping HLO modules.
   //
+
+  bool xla_gpu_force_conv_nchw = 125;
+
+  // Paths to files with ptx code.
+  repeated string xla_gpu_ptx_file = 127;
 
   // Next id: 128
 


### PR DESCRIPTION
This add an XLA_FLAGS xla_gpu_ptx_code to allow specifing the PTX code to use in XLA.
The goal is to allow quick testing of new PTX code to compare the speed.

@thomasjoerg 