### PR TITLE
Phase 2 of XLA int8 convolution on CUDA.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.cc
@@ -73,31 +73,85 @@ class ScratchBufAllocator : public se::ScratchAllocator {
   bool allocated_ = false;
 };
 
-template <typename T>
-Status RunCudnnConvImpl(const CudnnConvParams& params,
-                        se::ScratchAllocator* scratch_allocator,
-                        se::Stream* stream, RunConvOptions options) {
-  auto input_buf = se::DeviceMemory<T>(params.input_buf);
-  auto filter_buf = se::DeviceMemory<T>(params.filter_buf);
-  auto output_buf = se::DeviceMemory<T>(params.output_buf);
-  AlgorithmConfig algorithm = params.algorithm;
+template <typename ElementType, typename OutputType>
+Status RunCudnnConvForward(CudnnConvParams params,
+                           se::ScratchAllocator* scratch_allocator,
+                           se::Stream* stream, RunConvOptions options,
+                           DeviceMemory<ElementType> input_buf,
+                           DeviceMemory<ElementType> filter_buf,
+                           DeviceMemory<OutputType> output_buf,
+                           AlgorithmConfig algorithm) {
+  if (params.conv_result_scale != 1) {
+    return InternalError(
+        "StreamExecutor doesn't support scaled convolution: %lf.",
+        params.conv_result_scale);
+  }
+  stream->ThenConvolveWithAlgorithm(
+      params.input_descriptor, input_buf, params.filter_descriptor, filter_buf,
+      params.conv_desc, params.output_descriptor, &output_buf,
+      scratch_allocator, algorithm, options.profile_result);
+  return Status::OK();
+}
 
-  if (options.algo_override) {
-    algorithm = AlgorithmConfig(*options.algo_override);
+template <typename ElementType, typename BiasType, typename OutputType>
+Status RunCudnnConvForwardActivation(CudnnConvParams params,
+                                     se::ScratchAllocator* scratch_allocator,
+                                     se::Stream* stream, RunConvOptions options,
+                                     DeviceMemory<ElementType> input_buf,
+                                     DeviceMemory<ElementType> filter_buf,
+                                     DeviceMemory<OutputType> output_buf,
+                                     AlgorithmConfig algorithm) {
+  BatchDescriptor bias_desc;
+  bias_desc.set_count(1)
+      .set_height(1)
+      .set_width(1)
+      .set_feature_map_count(params.output_descriptor.feature_map_count())
+      .set_layout(params.output_descriptor.layout());
+
+  se::DeviceMemory<OutputType> side_input(params.fusion->side_input_buf);
+  // If there is no side input, use output as the side input.
+  if (side_input.is_null()) {
+    if (params.fusion->side_input_scale != 0) {
+      return InternalError(
+          "Side input scale is not 0, yet no side input buffer is "
+          "provided");
+    }
+    // Since side-input scale is 0, the values in the side input don't
+    // matter.  The simplest thing to do would be to pass in a null buffer
+    // for the side input, but cudnn doesn't allow this.  cudnn does promise
+    // that if side-input-scale is 0 the side input won't be read, so we
+    // just pass in the output buffer, since it's handy and has the correct
+    // size.
+    side_input = output_buf;
   }
 
+  stream->ThenFusedConvolveWithAlgorithm(
+      params.input_descriptor, input_buf, params.conv_result_scale,
+      params.filter_descriptor, filter_buf, params.conv_desc, side_input,
+      params.fusion->side_input_scale, bias_desc,
+      DeviceMemory<BiasType>(params.fusion->bias_buf), params.fusion->mode,
+      params.output_descriptor, &output_buf, scratch_allocator, algorithm,
+      options.profile_result);
+
+  return Status::OK();
+}
+
+// Specialization for double, float, and half types.  All kinds of convolutions
+// are supported here.
+template <typename ElementType, typename BiasType, typename OutputType,
+          typename std::enable_if<
+              !std::is_integral<ElementType>::value>::type* = nullptr>
+Status RunCudnnConvInternalImpl(CudnnConvParams params,
+                                se::ScratchAllocator* scratch_allocator,
+                                se::Stream* stream, RunConvOptions options,
+                                DeviceMemory<ElementType> input_buf,
+                                DeviceMemory<ElementType> filter_buf,
+                                DeviceMemory<OutputType> output_buf,
+                                AlgorithmConfig algorithm) {
   switch (params.kind) {
     case CudnnConvKind::kForward:
-      if (params.conv_result_scale != 1) {
-        return InternalError(
-            "StreamExecutor doesn't support scaled convolution: %lf.",
-            params.conv_result_scale);
-      }
-      stream->ThenConvolveWithAlgorithm(
-          params.input_descriptor, input_buf, params.filter_descriptor,
-          filter_buf, params.conv_desc, params.output_descriptor, &output_buf,
-          scratch_allocator, algorithm, options.profile_result);
-      break;
+      return RunCudnnConvForward(params, scratch_allocator, stream, options,
+                                 input_buf, filter_buf, output_buf, algorithm);
     case CudnnConvKind::kBackwardInput:
       if (params.conv_result_scale != 1) {
         return InternalError(
@@ -121,39 +175,59 @@ Status RunCudnnConvImpl(const CudnnConvParams& params,
           scratch_allocator, algorithm, options.profile_result);
       break;
     case CudnnConvKind::kForwardActivation: {
-      BatchDescriptor bias_desc;
-      bias_desc.set_count(1)
-          .set_height(1)
-          .set_width(1)
-          .set_feature_map_count(params.output_descriptor.feature_map_count())
-          .set_layout(params.output_descriptor.layout());
-
-      se::DeviceMemory<T> side_input(params.fusion->side_input_buf);
-      // If there is no side input, use output as the side input.
-      if (side_input.is_null()) {
-        if (params.fusion->side_input_scale != 0) {
-          return InternalError(
-              "Side input scale is not 0, yet no side input buffer is "
-              "provided");
-        }
-        // Since side-input scale is 0, the values in the side input don't
-        // matter.  The simplest thing to do would be to pass in a null buffer
-        // for the side input, but cudnn doesn't allow this.  cudnn does promise
-        // that if side-input-scale is 0 the side input won't be read, so we
-        // just pass in the output buffer, since it's handy and has the correct
-        // size.
-        side_input = output_buf;
-      }
-
-      stream->ThenFusedConvolveWithAlgorithm(
-          params.input_descriptor, input_buf, params.conv_result_scale,
-          params.filter_descriptor, filter_buf, params.conv_desc, side_input,
-          params.fusion->side_input_scale, bias_desc,
-          DeviceMemory<T>(params.fusion->bias_buf), params.fusion->mode,
-          params.output_descriptor, &output_buf, scratch_allocator, algorithm,
-          options.profile_result);
-      break;
+      return RunCudnnConvForwardActivation<ElementType, BiasType, OutputType>(
+          params, scratch_allocator, stream, options, input_buf, filter_buf,
+          output_buf, algorithm);
     }
+  }
+  return Status::OK();
+}
+
+// Specialization for integer types.  Only two forward convolutions are allowed.
+template <typename ElementType, typename BiasType, typename OutputType,
+          typename std::enable_if<std::is_integral<ElementType>::value>::type* =
+              nullptr>
+Status RunCudnnConvInternalImpl(CudnnConvParams params,
+                                se::ScratchAllocator* scratch_allocator,
+                                se::Stream* stream, RunConvOptions options,
+                                DeviceMemory<ElementType> input_buf,
+                                DeviceMemory<ElementType> filter_buf,
+                                DeviceMemory<OutputType> output_buf,
+                                AlgorithmConfig algorithm) {
+  switch (params.kind) {
+    case CudnnConvKind::kForward:
+      return RunCudnnConvForward(params, scratch_allocator, stream, options,
+                                 input_buf, filter_buf, output_buf, algorithm);
+      break;
+    case CudnnConvKind::kForwardActivation: {
+      return RunCudnnConvForwardActivation<ElementType, BiasType, OutputType>(
+          params, scratch_allocator, stream, options, input_buf, filter_buf,
+          output_buf, algorithm);
+    }
+  }
+  return Status::OK();
+}
+
+template <typename ElementType, typename BiasType, typename OutputType>
+Status RunCudnnConvImpl(const CudnnConvParams& params,
+                        se::ScratchAllocator* scratch_allocator,
+                        se::Stream* stream, RunConvOptions options) {
+  auto input_buf = se::DeviceMemory<ElementType>(params.input_buf);
+  auto filter_buf = se::DeviceMemory<ElementType>(params.filter_buf);
+  auto output_buf = se::DeviceMemory<OutputType>(params.output_buf);
+  AlgorithmConfig algorithm = params.algorithm;
+
+  if (options.algo_override) {
+    algorithm = AlgorithmConfig(*options.algo_override);
+  }
+
+  Status run_status =
+      RunCudnnConvInternalImpl<ElementType, BiasType, OutputType>(
+          params, scratch_allocator, stream, options, input_buf, filter_buf,
+          output_buf, algorithm);
+
+  if (run_status != Status::OK()) {
+    return run_status;
   }
 
   if (!stream->ok()) {
@@ -366,6 +440,19 @@ Status RunCudnnConv(const HloCustomCallInstruction* conv,
                       stream, options);
 }
 
+// CuDNN Convolutions all go through and are dispatched from this function.
+// Dispatching are based on three conditions: input data type, output data type,
+// and convolution kind. Although these three conditions are independent, not
+// all combinations are supported: convolutions with float, double, and half
+// input must have the same output type and support all kinds of convolutions;
+// convolutions with int8 input allow both int8 and float output type, but only
+// support two kinds: kForward and kForwardActivation.
+//
+// This function itself dispatches convolutions for input and output data types;
+// RunCudnnConvInternalImpl later dispatches for convolution kind.
+// RunCudnnConvInternalImpl has two template specializations for floating point
+// types and for integer types, respectively, and only invoke the supported
+// convolutions.
 Status RunCudnnConv(const HloCustomCallInstruction* conv,
                     absl::Span<se::DeviceMemoryBase> operand_buffers,
                     se::DeviceMemoryBase result_buffer,
@@ -374,18 +461,31 @@ Status RunCudnnConv(const HloCustomCallInstruction* conv,
   TF_ASSIGN_OR_RETURN(CudnnConvParams params,
                       GetCudnnConvParams(conv, operand_buffers, result_buffer));
 
-  PrimitiveType output_primitive_type =
-      conv->shape().tuple_shapes(0).element_type();
-  switch (output_primitive_type) {
+  PrimitiveType input_primitive_type = conv->operand(0)->shape().element_type();
+  switch (input_primitive_type) {
     case F16:
-      return RunCudnnConvImpl<Eigen::half>(params, scratch_allocator, stream,
-                                           options);
+      return RunCudnnConvImpl<Eigen::half, Eigen::half, Eigen::half>(
+          params, scratch_allocator, stream, options);
     case F32:
-      return RunCudnnConvImpl<float>(params, scratch_allocator, stream,
-                                     options);
+      return RunCudnnConvImpl<float, float, float>(params, scratch_allocator,
+                                                   stream, options);
     case F64:
-      return RunCudnnConvImpl<double>(params, scratch_allocator, stream,
-                                      options);
+      return RunCudnnConvImpl<double, double, double>(params, scratch_allocator,
+                                                      stream, options);
+    case S8: {
+      PrimitiveType output_primitive_type =
+          conv->shape().tuple_shapes(0).element_type();
+      switch (output_primitive_type) {
+        case F32:
+          return RunCudnnConvImpl<int8, float, float>(params, scratch_allocator,
+                                                      stream, options);
+        case S8:
+          return RunCudnnConvImpl<int8, float, int8>(params, scratch_allocator,
+                                                     stream, options);
+        default:
+          LOG(FATAL) << conv->ToString();
+      }
+    }
     default:
       LOG(FATAL) << conv->ToString();
   }

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -2934,6 +2934,16 @@ port::Status CudnnSupport::DoConvolve(
           "This configuration has potential integer overflow in "
           "cuDNNv5 and cuDNNv6. See b/68264959.");
     }
+    if (CUDNN_VERSION < 8000) {
+      if (algorithm_desc.algo_id() ==
+              CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM &&
+          ToCudnnDataType(element_type) == CUDNN_DATA_INT8 &&
+          ToCudnnDataType(output_type) == CUDNN_DATA_FLOAT) {
+        return port::Status(
+            port::error::FAILED_PRECONDITION,
+            "This configuration potentially produces incorrect results.");
+      }
+    }
     return port::Status::OK();
   };
 

--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -266,7 +266,8 @@ class CudnnSupport : public dnn::DnnSupport {
       ScratchAllocator* workspace_allocator) override;
 
   port::Status DoConvolve(
-      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      dnn::ConvolutionKind kind, dnn::DataType element_type,
+      dnn::DataType output_type, Stream* stream,
       const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
       const dnn::FilterDescriptor& filter_descriptor,
       DeviceMemoryBase filter_data,
@@ -333,6 +334,20 @@ class CudnnSupport : public dnn::DnnSupport {
       const DeviceMemory<float>& biases, dnn::ActivationMode activation_mode,
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemory<int8>* output_data, ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result) override;
+
+  bool DoFusedConvolve(
+      Stream* stream, const dnn::BatchDescriptor& conv_input_descriptor,
+      const DeviceMemory<int8>& conv_input_data, float conv_input_scale,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<int8>& filter_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const DeviceMemory<float>& side_input_data, float side_input_scale,
+      const dnn::BatchDescriptor& bias_descriptor,
+      const DeviceMemory<float>& biases, dnn::ActivationMode activation_mode,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<float>* output_data, ScratchAllocator* scratch_allocator,
       const dnn::AlgorithmConfig& algorithm_config,
       dnn::ProfileResult* output_profile_result) override;
 
@@ -587,7 +602,8 @@ class CudnnSupport : public dnn::DnnSupport {
       DeviceMemory<U>* offset_backprop, DeviceMemory<uint8>* reserve_space_data,
       ScratchAllocator* workspace_allocator);
 
-  template <typename ElementType, typename BiasType, typename ScaleType>
+  template <typename ElementType, typename BiasType, typename ScaleType,
+            typename OutputType>
   port::Status DoFusedConvolveImpl(
       Stream* stream, const dnn::BatchDescriptor& conv_input_descriptor,
       const DeviceMemory<ElementType>& conv_input_data,
@@ -595,11 +611,11 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::FilterDescriptor& filter_descriptor,
       const DeviceMemory<ElementType>& filter_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
-      const DeviceMemory<ElementType>& side_input_data,
+      const DeviceMemory<OutputType>& side_input_data,
       ScaleType side_input_scale, const dnn::BatchDescriptor& bias_descriptor,
       const DeviceMemory<BiasType>& biases, dnn::ActivationMode activation_mode,
       const dnn::BatchDescriptor& output_descriptor,
-      DeviceMemory<ElementType>* output_data, dnn::DataType accumulator_type,
+      DeviceMemory<OutputType>* output_data, dnn::DataType accumulator_type,
       ScratchAllocator* scratch_allocator,
       const dnn::AlgorithmConfig& algorithm_config,
       dnn::ProfileResult* output_profile_result);

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2806,7 +2806,8 @@ static DeviceMemoryBase MaybeTransformLayout(
 }
 
 port::Status MIOpenSupport::DoConvolve(
-    dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+    dnn::ConvolutionKind kind, dnn::DataType element_type,
+    dnn::DataType output_type, Stream* stream,
     const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
     const dnn::FilterDescriptor& filter_descriptor,
     DeviceMemoryBase filter_data, const dnn::BatchDescriptor& output_descriptor,

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -258,7 +258,8 @@ class MIOpenSupport : public dnn::DnnSupport {
       ScratchAllocator* workspace_allocator) override;
 
   port::Status DoConvolve(
-      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      dnn::ConvolutionKind kind, dnn::DataType element_type,
+      dnn::DataType output_type, Stream* stream,
       const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
       const dnn::FilterDescriptor& filter_descriptor,
       DeviceMemoryBase filter_data,

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -606,6 +606,44 @@ Stream &Stream::ThenFusedConvolveWithAlgorithm(
   return *this;
 }
 
+Stream& Stream::ThenFusedConvolveWithAlgorithm(
+    const dnn::BatchDescriptor& conv_input_descriptor,
+    const DeviceMemory<int8>& conv_input_data, float conv_input_scale,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const DeviceMemory<int8>& filter_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const DeviceMemory<float>& side_input_data, float side_input_scale,
+    const dnn::BatchDescriptor& bias_descriptor,
+    const DeviceMemory<float>& biases, dnn::ActivationMode activation_mode,
+    const dnn::BatchDescriptor& output_descriptor, DeviceMemory<float>* output,
+    ScratchAllocator* scratch_allocator,
+    const dnn::AlgorithmConfig& algorithm_config,
+    dnn::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(conv_input_descriptor), PARAM(conv_input_data),
+            PARAM(conv_input_scale), PARAM(filter_descriptor),
+            PARAM(filter_data), PARAM(convolution_descriptor), PARAM(biases),
+            PARAM(side_input_data), PARAM(side_input_scale),
+            PARAM(bias_descriptor), PARAM(biases), PARAM(activation_mode),
+            PARAM(output_descriptor), PARAM(output), PARAM(algorithm_config));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      auto status = dnn->DoFusedConvolve(
+          this, conv_input_descriptor, conv_input_data, conv_input_scale,
+          filter_descriptor, filter_data, convolution_descriptor,
+          side_input_data, side_input_scale, bias_descriptor, biases,
+          activation_mode, output_descriptor, output, scratch_allocator,
+          algorithm_config, output_profile_result);
+      if (!status && !output_profile_result) {
+        SetError();
+      }
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
 Stream &Stream::ThenConvolveWithAlgorithm(
     const dnn::BatchDescriptor &input_descriptor,
     const DeviceMemory<double> &input_data,
@@ -700,6 +738,90 @@ Stream &Stream::ThenConvolveWithAlgorithm(
     DeviceMemory<Eigen::half> *output, ScratchAllocator *scratch_allocator,
     const dnn::AlgorithmConfig &algorithm_config,
     dnn::ProfileResult *output_profile_result) {
+  VLOG_CALL(PARAM(input_descriptor), PARAM(input_data),
+            PARAM(filter_descriptor), PARAM(filter_data),
+            PARAM(convolution_descriptor), PARAM(output_descriptor),
+            PARAM(output), PARAM(algorithm_config));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      DeviceMemory<uint8> scratch_memory;
+      dnn::AlgorithmDesc algorithm_desc;
+      auto status =
+          dnn->PrepareForConvolution(
+                 dnn::ConvolutionKind::FORWARD, this, input_descriptor,
+                 input_data, filter_descriptor, filter_data, output_descriptor,
+                 *output, convolution_descriptor, algorithm_config,
+                 scratch_allocator, &algorithm_desc, &scratch_memory)
+              .ok();
+      if (status) {
+        status = dnn->DoConvolve(
+            this, input_descriptor, input_data, filter_descriptor, filter_data,
+            convolution_descriptor, output_descriptor, output, algorithm_desc,
+            &scratch_memory, output_profile_result);
+      }
+      if (!status && !output_profile_result) {
+        SetError();
+      }
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenConvolveWithAlgorithm(
+    const dnn::BatchDescriptor& input_descriptor,
+    const DeviceMemory<int8>& input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const DeviceMemory<int8>& filter_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor, DeviceMemory<float>* output,
+    ScratchAllocator* scratch_allocator,
+    const dnn::AlgorithmConfig& algorithm_config,
+    dnn::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(input_descriptor), PARAM(input_data),
+            PARAM(filter_descriptor), PARAM(filter_data),
+            PARAM(convolution_descriptor), PARAM(output_descriptor),
+            PARAM(output), PARAM(algorithm_config));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      DeviceMemory<uint8> scratch_memory;
+      dnn::AlgorithmDesc algorithm_desc;
+      auto status =
+          dnn->PrepareForConvolution(
+                 dnn::ConvolutionKind::FORWARD, this, input_descriptor,
+                 input_data, filter_descriptor, filter_data, output_descriptor,
+                 *output, convolution_descriptor, algorithm_config,
+                 scratch_allocator, &algorithm_desc, &scratch_memory)
+              .ok();
+      if (status) {
+        status = dnn->DoConvolve(
+            this, input_descriptor, input_data, filter_descriptor, filter_data,
+            convolution_descriptor, output_descriptor, output, algorithm_desc,
+            &scratch_memory, output_profile_result);
+      }
+      if (!status && !output_profile_result) {
+        SetError();
+      }
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenConvolveWithAlgorithm(
+    const dnn::BatchDescriptor& input_descriptor,
+    const DeviceMemory<int8>& input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const DeviceMemory<int8>& filter_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor, DeviceMemory<int8>* output,
+    ScratchAllocator* scratch_allocator,
+    const dnn::AlgorithmConfig& algorithm_config,
+    dnn::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(input_descriptor), PARAM(input_data),
             PARAM(filter_descriptor), PARAM(filter_data),
             PARAM(convolution_descriptor), PARAM(output_descriptor),

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -343,6 +343,28 @@ class Stream {
       const dnn::AlgorithmConfig &algorithm_config,
       dnn::ProfileResult *output_profile_result);
 
+  Stream& ThenConvolveWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<int8>& input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<int8>& filter_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<float>* output, ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
+
+  Stream& ThenConvolveWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<int8>& input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<int8>& filter_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor, DeviceMemory<int8>* output,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
+
   Stream &ThenFusedConvolveWithAlgorithm(
       const dnn::BatchDescriptor &conv_input_descriptor,
       const DeviceMemory<double> &conv_input_data, double conv_input_scale,
@@ -399,6 +421,20 @@ class Stream {
       ScratchAllocator *scratch_allocator,
       const dnn::AlgorithmConfig &algorithm_config,
       dnn::ProfileResult *output_profile_result);
+
+  Stream& ThenFusedConvolveWithAlgorithm(
+      const dnn::BatchDescriptor& conv_input_descriptor,
+      const DeviceMemory<int8>& conv_input_data, float conv_input_scale,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<int8>& filter_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const DeviceMemory<float>& side_input_data, float side_input_scale,
+      const dnn::BatchDescriptor& bias_descriptor,
+      const DeviceMemory<float>& biases, dnn::ActivationMode activation_mode,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<float>* output, ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
 
   Stream &ThenSeparableConvolve(
       const dnn::BatchDescriptor &input_descriptor,


### PR DESCRIPTION
This is a breakdown of previous PR (https://github.com/tensorflow/tensorflow/pull/29158) per @timshen91 's suggestion.
This PR doesn't depend on (https://github.com/tensorflow/tensorflow/pull/30761).
1. Refactor RunCudnnConvImpl in cudnn_conv_runner.cc to dispatch CuDNN function calls based on input/output types in addition to convolution kind.
2. Modify dnn, cuda_dnn, and rocm_dnn to separate convolution output type from input/element type.
3. Add int8 ThenConvolveWithAlgorithm overloads to stream.h.