### PR TITLE
Add the missing comma

### DIFF
--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -358,7 +358,7 @@ class WhileOp(object):
     output = False
     if op.type in [
         "Shape",
-        "Rank"
+        "Rank",
         "ShapeN",
         "ZerosLike",
         "TensorArrayV3",


### PR DESCRIPTION
A missing comma in a list of string means the string "Rank" and "ShapeN" will be concatenated implicitly.