### PR TITLE
Expose __version__ correctly at the top level

### DIFF
--- a/tensorflow/virtual_root_template_v1.__init__.py
+++ b/tensorflow/virtual_root_template_v1.__init__.py
@@ -98,6 +98,10 @@ for _m in _top_level_modules:
 # We still need all the names that are toplevel on tensorflow_core
 from tensorflow_core import *
 
+# All symbols start with `_` have been hided from `__all__` so we need
+# explicitly import `__version__`.
+from tensorflow_core import __version__
+
 # In V1 API we need to print deprecation messages
 from tensorflow.python.util import deprecation_wrapper as _deprecation
 if not isinstance(_sys.modules[__name__], _deprecation.DeprecationWrapper):

--- a/tensorflow/virtual_root_template_v2.__init__.py
+++ b/tensorflow/virtual_root_template_v2.__init__.py
@@ -97,4 +97,8 @@ for _m in _top_level_modules:
 # We still need all the names that are toplevel on tensorflow_core
 from tensorflow_core import *
 
+# All symbols start with `_` have been hided from `__all__` so we need
+# explicitly import `__version__`.
+from tensorflow_core import __version__
+
 # LINT.ThenChange(//tensorflow/virtual_root_template_v1.__init__.py.oss)


### PR DESCRIPTION
This fix tries to address the issue raised in #30769 where `tf.__version__` raises an AttributeError exception, not conforming to PEP 396.

The issue comes from the fact that the module wrapping removes any symboles with `_` by updating `__all__` so
```
from tensorflow_core import *
```
does not import `__version__` any more.

This fix explicitly import `__version__`:
```
from tensorflow_core import __version__
```

This fix fixes #30769

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>