### PR TITLE
Fix incorrect default values of tf.sparse.to_dense

### DIFF
--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -1430,7 +1430,7 @@ def sparse_reduce_sum_sparse(sp_input,
 @tf_export("sparse.to_dense", v1=["sparse.to_dense", "sparse_tensor_to_dense"])
 @deprecation.deprecated_endpoints("sparse_tensor_to_dense")
 def sparse_tensor_to_dense(sp_input,
-                           default_value=0,
+                           default_value=None,
                            validate_indices=True,
                            name=None):
   """Converts a `SparseTensor` into a dense tensor.
@@ -1470,6 +1470,8 @@ def sparse_tensor_to_dense(sp_input,
     TypeError: If `sp_input` is not a `SparseTensor`.
   """
   sp_input = _convert_to_sparse_tensor(sp_input)
+  if default_value is None:
+    default_value = array_ops.zeros([], dtype=sp_input.dtype)
 
   return gen_sparse_ops.sparse_to_dense(
       sp_input.indices,

--- a/tensorflow/python/ops/sparse_ops_test.py
+++ b/tensorflow/python/ops/sparse_ops_test.py
@@ -125,6 +125,16 @@ class SparseOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     epsilon = 1e-4
     self.assertLess(gradient_checker.max_error(*grads), epsilon)
 
+  def testSparseTensorToDenseString(self):
+    sp = sparse_tensor.SparseTensor(
+        indices=[[0, 0], [1, 2]],
+        values=['a', 'b'],
+        dense_shape=[2, 3])
+    dense = sparse_ops.sparse_tensor_to_dense(sp)
+    expected_dense = [['a', '', ''], ['', '', 'b']]
+    result_dense = self.evaluate(dense)
+    self.assertAllEqual(expected_dense, result_dense)
+
 
 if __name__ == '__main__':
   googletest.main()

--- a/tensorflow/python/ops/sparse_ops_test.py
+++ b/tensorflow/python/ops/sparse_ops_test.py
@@ -131,7 +131,7 @@ class SparseOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
         values=['a', 'b'],
         dense_shape=[2, 3])
     dense = sparse_ops.sparse_tensor_to_dense(sp)
-    expected_dense = [['a', '', ''], ['', '', 'b']]
+    expected_dense = [[b'a', b'', b''], [b'', b'', b'b']]
     result_dense = self.evaluate(dense)
     self.assertAllEqual(expected_dense, result_dense)
 

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -2210,7 +2210,7 @@ tf_module {
   }
   member_method {
     name: "sparse_tensor_to_dense"
-    argspec: "args=[\'sp_input\', \'default_value\', \'validate_indices\', \'name\'], varargs=None, keywords=None, defaults=[\'0\', \'True\', \'None\'], "
+    argspec: "args=[\'sp_input\', \'default_value\', \'validate_indices\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'True\', \'None\'], "
   }
   member_method {
     name: "sparse_to_dense"

--- a/tensorflow/tools/api/golden/v1/tensorflow.sparse.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.sparse.pbtxt
@@ -126,7 +126,7 @@ tf_module {
   }
   member_method {
     name: "to_dense"
-    argspec: "args=[\'sp_input\', \'default_value\', \'validate_indices\', \'name\'], varargs=None, keywords=None, defaults=[\'0\', \'True\', \'None\'], "
+    argspec: "args=[\'sp_input\', \'default_value\', \'validate_indices\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'True\', \'None\'], "
   }
   member_method {
     name: "to_indicator"

--- a/tensorflow/tools/api/golden/v2/tensorflow.sparse.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.sparse.pbtxt
@@ -102,7 +102,7 @@ tf_module {
   }
   member_method {
     name: "to_dense"
-    argspec: "args=[\'sp_input\', \'default_value\', \'validate_indices\', \'name\'], varargs=None, keywords=None, defaults=[\'0\', \'True\', \'None\'], "
+    argspec: "args=[\'sp_input\', \'default_value\', \'validate_indices\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'True\', \'None\'], "
   }
   member_method {
     name: "to_indicator"


### PR DESCRIPTION
This fix tries to address the issue in #30750 where tf.sparse.to_dense without specifying default value explicitly leads to TypeError:
```
import tensorflow as tf
sample_string = tf.sparse.SparseTensor(indices=[[0, 0], [1, 2]], values=['a', 'b'], dense_shape=[3, 4])
tf.sparse.to_dense( sample_string )
...
TypeError: Expected string passed to parameter 'default_value' of op 'SparseToDense', got 0 of type 'int' instead. Error: Expected string, got 0 of type 'int' instead.
```

The issue was that tf.sparse.to_dense use 0 as the default value
which does not work well with string.

This fix changes from `default_value=0` -> `default_value=None`
and use zeros instead.

It consists of an API change though the change is backward compatible.

This fix fixes #30750

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
