### PR TITLE
[tflite] make coco_object_detection:run_eval build

### DIFF
--- a/tensorflow/lite/tools/evaluation/stages/object_detection_stage.cc
+++ b/tensorflow/lite/tools/evaluation/stages/object_detection_stage.cc
@@ -174,7 +174,7 @@ TfLiteStatus PopulateGroundTruth(
   std::string proto_str((std::istreambuf_iterator<char>(t)),
                         std::istreambuf_iterator<char>());
   ObjectDetectionGroundTruth ground_truth_proto;
-  proto2::TextFormat::ParseFromString(proto_str, &ground_truth_proto);
+  google::protobuf::TextFormat::ParseFromString(proto_str, &ground_truth_proto);
 
   for (auto image_ground_truth : ground_truth_proto.detection_results()) {
     (*ground_truth_mapping)[image_ground_truth.image_name()] =


### PR DESCRIPTION
fix a namespace problem so that we can build
```
//tensorflow/lite/tools/evaluation/tasks/coco_object_detection:run_eval
```
(because Google's internal environment is different from public TensorFlow repo?)
@srjoglekar246 