### PR TITLE
Fix tf-mlir-translate GraphDef <-> MLIR round-trip bug in node name

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/tests/mlir2graphdef/tf_node_name.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/mlir2graphdef/tf_node_name.mlir
@@ -1,27 +1,8 @@
 // RUN: tf-mlir-translate -mlir-to-graphdef %s -o - | FileCheck %s
 
-// CHECK: node {
-// CHECK-NEXT:  name: "Const"
-// CHECK-NEXT:  op: "Const"
-// CHECK-NEXT:  attr {
-// CHECK-NEXT:    key: "dtype"
-// CHECK-NEXT:    value {
-// CHECK-NEXT:      type: DT_INT32
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
-// CHECK-NEXT:  attr {
-// CHECK-NEXT:    key: "value"
-// CHECK-NEXT:    value {
-// CHECK-NEXT:      tensor {
-// CHECK-NEXT:        dtype: DT_INT32
-// CHECK-NEXT:        tensor_shape {
-// CHECK-NEXT:        }
-// CHECK-NEXT:        int_val: 1
-// CHECK-NEXT:      }
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
+// CHECK:  name: "foo"
 
 func @main() {
-    %0:2 = "_tf.Const"() {device = "", dtype = "tfdtype$DT_INT32", name = "Const", value = dense<1> : tensor<i32>} : () -> (tensor<i32>, !_tf.control)
+    %0:2 = "_tf.Const"() {device = "", dtype = "tfdtype$DT_INT32", name = "foo", value = dense<1> : tensor<i32>} : () -> (tensor<i32>, !_tf.control)
     return
 }

--- a/tensorflow/compiler/mlir/tensorflow/tests/mlir2graphdef/tf_node_name.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/mlir2graphdef/tf_node_name.mlir
@@ -1,0 +1,27 @@
+// RUN: tf-mlir-translate -mlir-to-graphdef %s -o - | FileCheck %s
+
+// CHECK: node {
+// CHECK-NEXT:  name: "Const"
+// CHECK-NEXT:  op: "Const"
+// CHECK-NEXT:  attr {
+// CHECK-NEXT:    key: "dtype"
+// CHECK-NEXT:    value {
+// CHECK-NEXT:      type: DT_INT32
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// CHECK-NEXT:  attr {
+// CHECK-NEXT:    key: "value"
+// CHECK-NEXT:    value {
+// CHECK-NEXT:      tensor {
+// CHECK-NEXT:        dtype: DT_INT32
+// CHECK-NEXT:        tensor_shape {
+// CHECK-NEXT:        }
+// CHECK-NEXT:        int_val: 1
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+func @main() {
+    %0:2 = "_tf.Const"() {device = "", dtype = "tfdtype$DT_INT32", name = "Const", value = dense<1> : tensor<i32>} : () -> (tensor<i32>, !_tf.control)
+    return
+}

--- a/tensorflow/compiler/mlir/tensorflow/translate/export_graphdef.cc
+++ b/tensorflow/compiler/mlir/tensorflow/translate/export_graphdef.cc
@@ -85,7 +85,7 @@ std::string GetName(Operation* inst) {
 
   // If the location is none of the expected types, then simply use name
   // generated using the op type.
-  return inst->getName().getStringRef().str();
+  return inst->getAttrOfType<mlir::StringAttr>("name").getValue().str();
 }
 
 // Stateful helper class to export a function into a Graph.

--- a/tensorflow/compiler/mlir/tensorflow/translate/export_graphdef.cc
+++ b/tensorflow/compiler/mlir/tensorflow/translate/export_graphdef.cc
@@ -85,6 +85,7 @@ std::string GetName(Operation* inst) {
 
   // If the location is none of the expected types, then simply use name
   // generated using the op type.
+  // TODO(jpienaar): update to not use the name attribute
   return inst->getAttrOfType<mlir::StringAttr>("name").getValue().str();
 }
 


### PR DESCRIPTION
I have found that the `tf-mlir-translate` tool built under `tensorflow/compiler/mlir/tensorflow` cannot round-trip (GraphDef -> MLIR -> GraphDef) as expected.

- How to reproduce.

```
$ cd tensorflow/compiler/mlir/tensorflow
$ curl -o simple.pbtxt https://gist.githubusercontent.com/nagachika/22c7d37555a1a9ed295dc3d915ebac35/raw/cb378e5745d59c5c6b34cfd58c24800af0081c0a/simple.pbtxt
$ bazel run tf-mlir-translate -- --graphdef-to-mlir ${PWD}/simple.pbtxt -o ${PWD}/simple.mlir
$ bazel run tf-mlir-translate -- --mlir-to-graphdef ${PWD}/simple.mlir -o ${PWD}/simple_round_tripped.pbtxt
$ diff simple.pbtxt simple_round_tripped.pbtxt
2c2
<   name: "Const"
---
>   name: "_tf.Const"
25c25
<   name: "Const_1"
---
>   name: "_tf.Const1"
48c48
<   name: "add"
---
>   name: "_tf.Add"
50,51c50,51
<   input: "Const"
<   input: "Const_1"
---
>   input: "_tf.Const"
>   input: "_tf.Const1"
65c65
< }
\ No newline at end of file
---
> }
```

As shown above, --mlir-to-graphdef wrongly use Function name as corresponding Node name  in GraphDef.

I have took a short investigation and found that the issue was in `GetName()` in `tensorflow/compiler/mlir/tensorflow/translate/export_graphdef.cc`.
