### PR TITLE
Clean up the lock&tmp files for CacheDatasetOp when needed

### DIFF
--- a/tensorflow/core/kernels/data/cache_dataset_ops.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops.cc
@@ -215,6 +215,19 @@ class CacheDatasetOp::FileDataset : public DatasetBase {
             lockfile_created_(false),
             iteration_completed_(false) {}
 
+      ~FileWriterIterator() {
+        if (!dataset()->env_->FileExists(MetaFilename(filename_)).ok()) {
+          std::vector<string> cache_files;
+          dataset()
+              ->env_
+              ->GetMatchingPaths(strings::StrCat(filename_, "*"), &cache_files)
+              .IgnoreError();
+          for (const string& path : cache_files) {
+            dataset()->env_->DeleteFile(path).IgnoreError();
+          }
+        }
+      }
+
       Status Initialize(IteratorContext* ctx) override {
         return dataset()->input_->MakeIterator(ctx, prefix(), &input_impl_);
       }
@@ -275,6 +288,9 @@ class CacheDatasetOp::FileDataset : public DatasetBase {
 
       Status SaveInternal(IteratorStateWriter* writer) override {
         mutex_lock l(mu_);
+        TF_RETURN_IF_ERROR(
+            writer->WriteScalar(full_name(kCurIndex), cur_index_));
+
         if (iteration_completed_) {
           TF_RETURN_IF_ERROR(
               writer->WriteScalar(full_name(kIterationCompleted), ""));
@@ -301,8 +317,6 @@ class CacheDatasetOp::FileDataset : public DatasetBase {
           lockfile_created_ = false;
         }
         TF_RETURN_IF_ERROR(SaveInput(writer, input_impl_));
-        TF_RETURN_IF_ERROR(
-            writer->WriteScalar(full_name(kCurIndex), cur_index_));
         TF_RETURN_IF_ERROR(writer->WriteScalar(full_name(kShardId), shard_id_));
         return Status::OK();
       }
@@ -310,12 +324,6 @@ class CacheDatasetOp::FileDataset : public DatasetBase {
       Status RestoreInternal(IteratorContext* ctx,
                              IteratorStateReader* reader) override {
         mutex_lock l(mu_);
-        if (reader->Contains(full_name(kIterationCompleted))) {
-          iteration_completed_ = true;
-          return Status::OK();
-        }
-
-        TF_RETURN_IF_ERROR(RestoreInput(ctx, reader, input_impl_));
         int64 temp;
         // TODO(b/78048575): Update this when saving size_t tensors directly
         // is supported.
@@ -326,6 +334,14 @@ class CacheDatasetOp::FileDataset : public DatasetBase {
             return errors::Internal("Invalid value for cur_index ", temp);
           }
         }
+
+        if (reader->Contains(full_name(kIterationCompleted))) {
+          iteration_completed_ = true;
+          return Status::OK();
+        }
+
+        TF_RETURN_IF_ERROR(RestoreInput(ctx, reader, input_impl_));
+
         // TODO(b/78048575): Update this when saving size_t tensors directly
         // is supported.
         {
@@ -409,7 +425,7 @@ class CacheDatasetOp::FileDataset : public DatasetBase {
         // Merge all the bundles.
         // Currently there are `shard_id_ + 1` bundles, one for each
         // checkpoint. Each bundle has prefix <filename>_<id> where `id` is an
-        // integer starting at 0 an incremented by 1 for each new checkpoint.
+        // integer starting at 0 and incremented by 1 for each new checkpoint.
         // We merge all these bundles into a bundle with prefix <filename> so
         // that the next call to `MakeIterator` can build a
         // `FileReaderIterator`.

--- a/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
@@ -23,6 +23,19 @@ constexpr char kFileDatasetPrefix[] = "File";
 constexpr char kMemoryDatasetPrefix[] = "Memory";
 
 class CacheDatasetOpTest : public DatasetOpsTestBase {
+ public:
+  ~CacheDatasetOpTest() {
+    if (!filename_.empty()) {
+      std::vector<string> cache_files;
+      device_->env()
+          ->GetMatchingPaths(strings::StrCat(filename_, "*"), &cache_files)
+          .IgnoreError();
+      for (const string& path : cache_files) {
+        device_->env()->DeleteFile(path).IgnoreError();
+      }
+    }
+  }
+
  protected:
   // Creates `TensorSliceDataset` variant tensor from the input vector of
   // tensors.
@@ -57,8 +70,13 @@ class CacheDatasetOpTest : public DatasetOpsTestBase {
       std::unique_ptr<OpKernelContext>* context) {
     TF_RETURN_IF_ERROR(CheckOpKernelInput(*op_kernel, *inputs));
     TF_RETURN_IF_ERROR(CreateOpKernelContext(op_kernel, inputs, context));
+    TF_RETURN_IF_ERROR(ParseScalarArgument<string>(
+        context->get(), CacheDatasetOp::kFileName, &filename_));
     return Status::OK();
   }
+
+ private:
+  string filename_ = "";
 };
 
 struct TestCase {
@@ -84,7 +102,7 @@ TestCase TestCase1() {
       /*expected_output_dtypes*/ {DT_INT64},
       /*expected_output_shapes*/ {PartialTensorShape({3, 1})},
       /*expected_cardinality*/ 3,
-      /*breakpoints*/ {0, 4, 11}};
+      /*breakpoints*/ {0, 2, 4, 11}};
 }
 
 // Test case 2: cache empty data in file.
@@ -96,7 +114,7 @@ TestCase TestCase2() {
           /*expected_output_dtypes*/ {DT_INT64},
           /*expected_output_shapes*/ {PartialTensorShape({})},
           /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 4, 11}};
+          /*breakpoints*/ {0, 2, 4, 11}};
 }
 
 // Test case 3: cache data in memory.
@@ -112,7 +130,7 @@ TestCase TestCase3() {
       /*expected_output_dtypes*/ {DT_INT64},
       /*expected_output_shapes*/ {PartialTensorShape({3, 1})},
       /*expected_cardinality*/ 3,
-      /*breakpoints*/ {0, 4, 11}};
+      /*breakpoints*/ {0, 2, 4, 11}};
 }
 
 // Test case 4: cache empty data in memory.
@@ -124,7 +142,7 @@ TestCase TestCase4() {
           /*expected_output_dtypes*/ {DT_INT64},
           /*expected_output_shapes*/ {PartialTensorShape({})},
           /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 4, 11}};
+          /*breakpoints*/ {0, 2, 4, 11}};
 }
 
 class ParameterizedCacheDatasetOpTest

--- a/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
@@ -27,11 +27,17 @@ class CacheDatasetOpTest : public DatasetOpsTestBase {
   ~CacheDatasetOpTest() {
     if (!filename_.empty()) {
       std::vector<string> cache_files;
-      device_->env()
-          ->GetMatchingPaths(strings::StrCat(filename_, "*"), &cache_files)
-          .IgnoreError();
+      Status s = device_->env()->GetMatchingPaths(
+          strings::StrCat(filename_, "*"), &cache_files);
+      if (!s.ok()) {
+        LOG(WARNING) << "Failed to get matching files on " << filename_
+                     << "* : " << s.ToString();
+      }
       for (const string& path : cache_files) {
-        device_->env()->DeleteFile(path).IgnoreError();
+        s = device_->env()->DeleteFile(path);
+        if (!s.ok()) {
+          LOG(WARNING) << "Failed to delete " << path << " : " << s.ToString();
+        }
       }
     }
   }

--- a/tensorflow/python/data/experimental/kernel_tests/serialization/cache_dataset_serialization_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/serialization/cache_dataset_serialization_test.py
@@ -85,24 +85,14 @@ class CacheDatasetSerializationTest(
         ds_fn, [5], 8, verify_exhausted=False, save_checkpoint_at_end=False)
     self.assertSequenceEqual(outputs, range(8))
 
-    if is_memory:
-      outputs = outputs[:5]
-      outputs.extend(
-          self.gen_outputs(
-              ds_fn, [],
-              self.num_outputs - 5,
-              ckpt_saved=True,
-              verify_exhausted=False))
-      self.assertSequenceEqual(outputs, self.expected_outputs())
-    else:
-      # Restoring from checkpoint and running GetNext should return
-      # `AlreadExistsError` now because the lockfile already exists.
-      with self.assertRaises(errors.AlreadyExistsError):
+    outputs = outputs[:5]
+    outputs.extend(
         self.gen_outputs(
             ds_fn, [],
             self.num_outputs - 5,
             ckpt_saved=True,
-            verify_exhausted=False)
+            verify_exhausted=False))
+    self.assertSequenceEqual(outputs, self.expected_outputs())
 
   @parameterized.named_parameters(
       ('Memory', True),

--- a/tensorflow/python/data/kernel_tests/cache_test.py
+++ b/tensorflow/python/data/kernel_tests/cache_test.py
@@ -181,9 +181,12 @@ class FileCacheTest(test_base.DatasetTestBase):
         except errors.OutOfRangeError:
           break
 
-    if context.executing_eagerly():
-      for i in [0, 3, 10, 12, 15]:
-        do_test(i)
+    if not context.executing_eagerly():
+      self.skipTest(
+          "Test requires eager mode for iterators to be deconstructed")
+
+    for i in [0, 3, 10, 12, 15]:
+      do_test(i)
 
 @test_util.run_all_in_graph_and_eager_modes
 class MemoryCacheTest(test_base.DatasetTestBase):


### PR DESCRIPTION
This PR fixes #28798 and also enhances the tests for the `CacheDatasetOp` kernel.

cc: @jsimsa 