### PR TITLE
Corrected a typo in CategorcialCrossEntropy

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -419,8 +419,8 @@ class CategoricalCrossentropy(LossFunctionWrapper):
   cce = tf.keras.losses.CategoricalCrossentropy()
   loss = cce(
     [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
-    [[.9, .05, .05], [.5, .89, .6], [.05, .01, .94]])
-  print('Loss: ', loss.numpy())  # Loss: 0.3239
+    [[.9, .05, .05], [.05, .89, .06], [.05, .01, .94]])
+  print('Loss: ', loss.numpy())  # Loss: 0.0945
   ```
 
   Usage with the `compile` API:


### PR DESCRIPTION
Here is a [gist](https://colab.sandbox.google.com/gist/jvishnuvardhan/13a4de468dbb3853369b8c68caf521d1/pr_categorcialcrossentropy.ipynb) that show the corrected output after correcting typo. Thanks!