### PR TITLE
Add reallocation capability to bfc_allocator.

### DIFF
--- a/tensorflow/core/common_runtime/bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/bfc_allocator.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/bfc_allocator.h"
 
 #include <atomic>
+#include "absl/container/flat_hash_set.h"
 
 #include "tensorflow/core/common_runtime/allocator_retry.h"
 #include "tensorflow/core/lib/core/bits.h"
@@ -260,6 +261,76 @@ size_t BFCAllocator::RoundedBytes(size_t bytes) {
   return rounded_bytes;
 }
 
+bool BFCAllocator::DeallocateFreeRegions(size_t rounded_bytes) {
+  // Searching for free regions.
+  absl::flat_hash_set<void*> free_region_ptrs;
+  size_t total_free_bytes = 0;
+  for (const auto& region : region_manager_.regions()) {
+    ChunkHandle h = region_manager_.get_handle(region.ptr());
+    bool any_use = false;
+    while (h != kInvalidChunkHandle) {
+      const Chunk* c = ChunkFromHandle(h);
+      if (c->in_use()) {
+        any_use = true;
+        break;
+      }
+      h = c->next;
+    }
+
+    if (!any_use) {
+      VLOG(2) << "Found free region with ptr = " << region.ptr();
+      free_region_ptrs.insert(region.ptr());
+      total_free_bytes += region.memory_size();
+    }
+  }
+
+  if (total_free_bytes == 0) {
+    return false;
+  }
+
+  // Rough estimation to check whether deallocation can help.
+  size_t available_bytes =
+      memory_limit_ - total_region_allocated_bytes_ + total_free_bytes;
+  if (rounded_bytes > available_bytes) {
+    return false;
+  }
+
+  VLOG(INFO) << "Re-allocate memory regions to avoid OOM due to memory"
+             << " fragmentation. If you see this message frequently, note"
+             << " that the re-allocation may incur performance overhead despite"
+             << " better memory utilization. You may try smaller batch sizes"
+             << " to see if it can give you better performance.";
+
+  // Deallocate free regions.
+  auto it = region_manager_.regions().begin();
+  while (it != region_manager_.regions().end()) {
+    if (!free_region_ptrs.contains(it->ptr())) {
+      ++it;
+      continue;
+    }
+
+    VLOG(2) << "Deallocate region with ptr = " << it->ptr();
+    // Remove all chunk registrations from Bins.
+    ChunkHandle h = region_manager_.get_handle(it->ptr());
+    while (h != kInvalidChunkHandle) {
+      const Chunk* c = ChunkFromHandle(h);
+      if (c->bin_num != kInvalidBinNum) {
+        RemoveFreeChunkFromBin(h);
+      }
+      auto h_to_delete = h;
+      h = c->next;
+      DeleteChunk(h_to_delete);
+    }
+
+    // Deallocate the memory.
+    sub_allocator_->Free(it->ptr(), it->memory_size());
+    total_region_allocated_bytes_ -= it->memory_size();
+    it = region_manager_.RemoveAllocationRegion(it);
+  }
+
+  return true;
+}
+
 void* BFCAllocator::AllocateRawInternal(size_t unused_alignment,
                                         size_t num_bytes,
                                         bool dump_log_on_failure,
@@ -304,6 +375,18 @@ void* BFCAllocator::AllocateRawInternal(size_t unused_alignment,
       if (ptr != nullptr) {
         return ptr;
       }
+    }
+  }
+
+  // Reaching this point means that no chunks can satisfy the request. Also,
+  // the unallocated bytes cannot satisfy the request. Before giving up, let's
+  // try deallocating free regions so that suballocator can combine them with
+  // the unallocated bytes and form a larger region.
+  if (DeallocateFreeRegions(rounded_bytes) &&
+      Extend(unused_alignment, rounded_bytes)) {
+    ptr = FindChunkPtr(bin_num, rounded_bytes, num_bytes, freed_before);
+    if (ptr != nullptr) {
+      return ptr;
     }
   }
 

--- a/tensorflow/core/common_runtime/bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/bfc_allocator.cc
@@ -294,13 +294,13 @@ bool BFCAllocator::DeallocateFreeRegions(size_t rounded_bytes) {
     return false;
   }
 
-  VLOG(WARNING) << "Re-allocate memory regions (i.e., allocations) to avoid OOM"
-                << " due to memory fragmentation. If you see this message"
-                << " frequently, you are running near the threshold of the"
-                << " available device memory and re-allocation can incur great"
-                << " performance overhead. You may try smaller batch sizes to"
-                << " observe the performance impact. Alternatively you may try"
-                << " setting `allow_growth=false` in GPUOptions.";
+  LOG(WARNING) << "Re-allocate memory regions (i.e., allocations) to avoid OOM"
+               << " due to memory fragmentation. If you see this message"
+               << " frequently, you are running near the threshold of the"
+               << " available device memory and re-allocation can incur great"
+               << " performance overhead. You may try smaller batch sizes to"
+               << " observe the performance impact. Alternatively you may try"
+               << " setting `allow_growth=false` in GPUOptions.";
 
   // Deallocate free regions.
   DeallocateRegions(free_region_ptrs);

--- a/tensorflow/core/common_runtime/bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/bfc_allocator.cc
@@ -319,8 +319,13 @@ bool BFCAllocator::DeallocateFreeRegions(size_t rounded_bytes) {
 
 void BFCAllocator::DeallocateRegions(
     const absl::flat_hash_set<void*>& region_ptrs) {
-  auto it = region_manager_.regions().begin();
-  while (it != region_manager_.regions().end()) {
+  // Explicitly remove the const qualifier as some compilers disallow passing
+  // const_iterator to std::vector::erase(), which is used in
+  // RemoveAllocationRegion().
+  auto regions =
+      const_cast<std::vector<AllocationRegion>*>(&region_manager_.regions());
+  auto it = regions->begin();
+  while (it != regions->end()) {
     if (!region_ptrs.contains(it->ptr())) {
       ++it;
       continue;

--- a/tensorflow/core/common_runtime/bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/bfc_allocator.cc
@@ -297,10 +297,10 @@ bool BFCAllocator::DeallocateFreeRegions(size_t rounded_bytes) {
   VLOG(WARNING) << "Re-allocate memory regions (i.e., allocations) to avoid OOM"
                 << " due to memory fragmentation. If you see this message"
                 << " frequently, you are running near the threshold of the"
-                << " available device memory and it can incur great performance"
-                << " overhead. You may try smaller batch sizes to observe the"
-                << " performance impact. Alternatively you may try setting"
-                << " `allow_growth=false` in GPUOptions.";
+                << " available device memory and re-allocation can incur great"
+                << " performance overhead. You may try smaller batch sizes to"
+                << " observe the performance impact. Alternatively you may try"
+                << " setting `allow_growth=false` in GPUOptions.";
 
   // Deallocate free regions.
   DeallocateRegions(free_region_ptrs);

--- a/tensorflow/core/common_runtime/bfc_allocator.h
+++ b/tensorflow/core/common_runtime/bfc_allocator.h
@@ -48,7 +48,8 @@ class BFCAllocator : public Allocator {
  public:
   // Takes ownership of sub_allocator.
   BFCAllocator(SubAllocator* sub_allocator, size_t total_memory,
-               bool allow_growth, const string& name);
+               bool allow_growth, const string& name,
+               bool garbage_collection = false);
   ~BFCAllocator() override;
 
   string Name() override { return name_; }
@@ -485,6 +486,10 @@ class BFCAllocator : public Allocator {
   // An indicator that expansion of a region has hit the limits
   // of the available memory.
   bool started_backpedal_ = false;
+
+  // Whether the allocator will deallocate free regions to avoid OOM due to
+  // memory fragmentation.
+  bool garbage_collection_;
 
   std::unique_ptr<SubAllocator> sub_allocator_;
   string name_;

--- a/tensorflow/core/common_runtime/bfc_allocator.h
+++ b/tensorflow/core/common_runtime/bfc_allocator.h
@@ -311,8 +311,8 @@ class BFCAllocator : public Allocator {
       regions_.insert(entry, AllocationRegion(ptr, memory_size));
     }
 
-    std::vector<AllocationRegion>::const_iterator RemoveAllocationRegion(
-        std::vector<AllocationRegion>::const_iterator it) {
+    std::vector<AllocationRegion>::iterator RemoveAllocationRegion(
+        std::vector<AllocationRegion>::iterator it) {
       return regions_.erase(it);
     }
 

--- a/tensorflow/core/common_runtime/bfc_allocator.h
+++ b/tensorflow/core/common_runtime/bfc_allocator.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "tensorflow/core/common_runtime/allocator_retry.h"
 #include "tensorflow/core/common_runtime/shared_counter.h"
 #include "tensorflow/core/framework/allocator.h"
@@ -363,9 +364,12 @@ class BFCAllocator : public Allocator {
   // we can re-allocate a larger region.  The main use scenario of this function
   // is when OOM happens but we have free regions and the sum of sizes of free
   // regions and unallocated bytes is larger than the requested size, implying
-  // (external) memory fragmentation.  Returns true if deallocating any free
-  // regions; false otherwise.
+  // (external) memory fragmentation.  Returns true if any free regions are
+  // found and freed; false otherwise.
   bool DeallocateFreeRegions(size_t rounded_bytes);
+
+  // Helper function to deallocate regions.
+  void DeallocateRegions(const absl::flat_hash_set<void*>& region_ptrs);
 
   // Returns a pointer to an underlying allocated chunk of size
   // 'rounded_bytes'.

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc
@@ -52,6 +52,27 @@ bool GPUBFCAllocator::GetAllowGrowthValue(const GPUOptions& gpu_options) {
   return gpu_options.allow_growth();
 }
 
+bool GPUBFCAllocator::GetGarbageCollectionValue() {
+  const char* enable_gpu_garbage_collection =
+      std::getenv("TF_ENABLE_GPU_GARBAGE_COLLECTION");
+  if (enable_gpu_garbage_collection == nullptr) {
+    // By default, turn on the memory garbage collection.
+    return true;
+  }
+  if (strcmp("false", enable_gpu_garbage_collection) == 0) {
+    return false;
+  } else if (strcmp("true", enable_gpu_garbage_collection) == 0) {
+    return true;
+  }
+
+  LOG(ERROR)
+      << "The TF_ENABLE_GPU_GARBAGE_COLLECTION environment variable is set but"
+      << " could not be parsed: \"" << enable_gpu_garbage_collection << "\"."
+      << " Valid values are \"true\" or \"false\"."
+      << " Using the default value \"true\".";
+  return true;
+}
+
 GPUBFCAllocator::GPUBFCAllocator(GPUMemAllocator* sub_allocator,
                                  size_t total_memory, const string& name)
     : GPUBFCAllocator(sub_allocator, total_memory, GPUOptions(), name) {}
@@ -61,6 +82,7 @@ GPUBFCAllocator::GPUBFCAllocator(GPUMemAllocator* sub_allocator,
                                  const GPUOptions& gpu_options,
                                  const string& name)
     : BFCAllocator(sub_allocator, total_memory,
-                   GPUBFCAllocator::GetAllowGrowthValue(gpu_options), name) {}
+                   GPUBFCAllocator::GetAllowGrowthValue(gpu_options), name,
+                   GPUBFCAllocator::GetGarbageCollectionValue()) {}
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.h
@@ -43,6 +43,7 @@ class GPUBFCAllocator : public BFCAllocator {
 
  private:
   static bool GetAllowGrowthValue(const GPUOptions& gpu_options);
+  static bool GetGarbageCollectionValue();
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_bfc_allocator_test.cc
@@ -570,7 +570,6 @@ class GPUBFCAllocatorPrivateMethodsTest : public ::testing::Test {
   }
 
   void TestRegionDeallocation() {
-    setenv("TF_FORCE_GPU_ALLOW_GROWTH", "unparseable", 1);
     GPUOptions options;
     options.set_allow_growth(true);
 


### PR DESCRIPTION
This commit mitigates external fragmentation in bfc_allocator by reallocation.
That is, although the sum of regions and unallocated bytes is larger than the
requested bytes but the bfc_allocator still fails to allocate a large enough
contiguous region to fulfill the request due to fragmentation. To avoid this
case, a relocation feature is implemented to deallocate free regions so that
a larger region can be formed.

Note that essentially we are able to play this trick because the underlying GPU
driver will be able to manipulate the vtable to return a region with a contiguous
virtual address space.