### PR TITLE
Modularized gaussian noises' dtype.

### DIFF
--- a/tensorflow/python/keras/layers/noise.py
+++ b/tensorflow/python/keras/layers/noise.py
@@ -65,7 +65,9 @@ class GaussianNoise(Layer):
 
     def noised():
       return inputs + K.random_normal(
-          shape=array_ops.shape(inputs), mean=0., stddev=self.stddev)
+          shape=array_ops.shape(inputs), mean=0., stddev=self.stddev,
+          dtype=inputs.dtype
+      )
 
     return K.in_train_phase(noised, inputs, training=training)
 
@@ -115,7 +117,9 @@ class GaussianDropout(Layer):
       def noised():
         stddev = np.sqrt(self.rate / (1.0 - self.rate))
         return inputs * K.random_normal(
-            shape=array_ops.shape(inputs), mean=1.0, stddev=stddev)
+            shape=array_ops.shape(inputs), mean=1.0, stddev=stddev,
+            dtype=inputs.dtype
+        )
 
       return K.in_train_phase(noised, inputs, training=training)
     return inputs

--- a/tensorflow/python/keras/layers/noise.py
+++ b/tensorflow/python/keras/layers/noise.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Layers that operate regularization via the addition of noise.
-"""
+"""Layers that operate regularization via the addition of noise."""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -65,8 +65,8 @@ class GaussianNoise(Layer):
 
     def noised():
       return inputs + K.random_normal(
-          shape=array_ops.shape(inputs), mean=0., stddev=self.stddev,
-          dtype=inputs.dtype
+        shape=array_ops.shape(inputs), mean=0., stddev=self.stddev,
+        dtype=inputs.dtype
       )
 
     return K.in_train_phase(noised, inputs, training=training)
@@ -117,8 +117,8 @@ class GaussianDropout(Layer):
       def noised():
         stddev = np.sqrt(self.rate / (1.0 - self.rate))
         return inputs * K.random_normal(
-            shape=array_ops.shape(inputs), mean=1.0, stddev=stddev,
-            dtype=inputs.dtype
+          shape=array_ops.shape(inputs), mean=1.0, stddev=stddev,
+          dtype=inputs.dtype
         )
 
       return K.in_train_phase(noised, inputs, training=training)
@@ -184,7 +184,8 @@ class AlphaDropout(Layer):
         alpha_p = -alpha * scale
 
         kept_idx = math_ops.greater_equal(
-            K.random_uniform(noise_shape, seed=seed), rate)
+          K.random_uniform(noise_shape, seed=seed), rate
+        )
         kept_idx = math_ops.cast(kept_idx, K.floatx())
 
         # Get affine transformation params

--- a/tensorflow/python/keras/layers/noise.py
+++ b/tensorflow/python/keras/layers/noise.py
@@ -65,8 +65,8 @@ class GaussianNoise(Layer):
 
     def noised():
       return inputs + K.random_normal(
-        shape=array_ops.shape(inputs), mean=0., stddev=self.stddev,
-        dtype=inputs.dtype
+          shape=array_ops.shape(inputs), mean=0., stddev=self.stddev,
+          dtype=inputs.dtype
       )
 
     return K.in_train_phase(noised, inputs, training=training)
@@ -117,8 +117,8 @@ class GaussianDropout(Layer):
       def noised():
         stddev = np.sqrt(self.rate / (1.0 - self.rate))
         return inputs * K.random_normal(
-          shape=array_ops.shape(inputs), mean=1.0, stddev=stddev,
-          dtype=inputs.dtype
+            shape=array_ops.shape(inputs), mean=1.0, stddev=stddev,
+            dtype=inputs.dtype
         )
 
       return K.in_train_phase(noised, inputs, training=training)
@@ -184,7 +184,7 @@ class AlphaDropout(Layer):
         alpha_p = -alpha * scale
 
         kept_idx = math_ops.greater_equal(
-          K.random_uniform(noise_shape, seed=seed), rate
+            K.random_uniform(noise_shape, seed=seed), rate
         )
         kept_idx = math_ops.cast(kept_idx, K.floatx())
 

--- a/tensorflow/python/keras/layers/noise_test.py
+++ b/tensorflow/python/keras/layers/noise_test.py
@@ -18,6 +18,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as np
+
+from tensorflow.python import dtypes
 from tensorflow.python import keras
 from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.keras import testing_utils
@@ -27,24 +30,61 @@ from tensorflow.python.platform import test
 @keras_parameterized.run_all_keras_modes
 class NoiseLayersTest(keras_parameterized.TestCase):
 
-  def test_GaussianNoise(self):
-    testing_utils.layer_test(
-        keras.layers.GaussianNoise,
-        kwargs={'stddev': 1.},
-        input_shape=(3, 2, 3))
+    def test_GaussianNoise(self):
+        testing_utils.layer_test(
+            keras.layers.GaussianNoise,
+            kwargs={'stddev': 1.},
+            input_shape=(3, 2, 3)
+        )
 
-  def test_GaussianDropout(self):
-    testing_utils.layer_test(
-        keras.layers.GaussianDropout,
-        kwargs={'rate': 0.5},
-        input_shape=(3, 2, 3))
+    def test_GaussianDropout(self):
+        testing_utils.layer_test(
+            keras.layers.GaussianDropout,
+            kwargs={'rate': 0.5},
+            input_shape=(3, 2, 3)
+        )
 
-  def test_AlphaDropout(self):
-    testing_utils.layer_test(
-        keras.layers.AlphaDropout,
-        kwargs={'rate': 0.2},
-        input_shape=(3, 2, 3))
+    def test_AlphaDropout(self):
+        testing_utils.layer_test(
+            keras.layers.AlphaDropout,
+            kwargs={'rate': 0.2},
+            input_shape=(3, 2, 3)
+        )
+
+    @staticmethod
+    def _make_model(dtype, gtype):
+        assert dtype in (dtypes.float32, dtypes.float64)
+        assert gtype in ('noise', 'dropout')
+        model = keras.Sequential()
+        model.add(keras.layers.Dense(8, input_shape=(32,), dtype=dtype))
+        if gtype == 'noise':
+            gaussian = keras.layers.GaussianNoise(0.0003)
+        else:
+            gaussian = keras.layers.GaussianDropout(0.1)
+        model.add(gaussian)
+        return model
+
+    def _train_model(self, dtype, gtype):
+        model = self._make_model(dtype, gtype)
+        model.compile(
+            optimizer='sgd',
+            loss='mse',
+            run_eagerly=testing_utils.should_run_eagerly()
+        )
+        model.train_on_batch(np.zeros((8, 32)), np.zeros((8, 8)))
+
+    def test_noise_float32(self):
+        self._train_model(dtypes.float32, 'noise')
+
+    def test_noise_float64(self):
+        self._train_model(dtypes.float64, 'noise')
+
+    def test_dropout_float32(self):
+        self._train_model(dtypes.float32, 'dropout')
+
+    def test_dropout_float64(self):
+        self._train_model(dtypes.float64, 'dropout')
 
 
 if __name__ == '__main__':
-  test.main()
+    test.main()

--- a/tensorflow/python/keras/layers/noise_test.py
+++ b/tensorflow/python/keras/layers/noise_test.py
@@ -20,8 +20,8 @@ from __future__ import print_function
 
 import numpy as np
 
-from tensorflow.python import dtypes
 from tensorflow.python import keras
+from tensorflow.python.keras.backend import dtypes_module
 from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.keras import testing_utils
 from tensorflow.python.platform import test
@@ -53,7 +53,7 @@ class NoiseLayersTest(keras_parameterized.TestCase):
 
     @staticmethod
     def _make_model(dtype, gtype):
-        assert dtype in (dtypes.float32, dtypes.float64)
+        assert dtype in (dtypes_module.float32, dtypes_module.float64)
         assert gtype in ('noise', 'dropout')
         model = keras.Sequential()
         model.add(keras.layers.Dense(8, input_shape=(32,), dtype=dtype))
@@ -74,16 +74,16 @@ class NoiseLayersTest(keras_parameterized.TestCase):
         model.train_on_batch(np.zeros((8, 32)), np.zeros((8, 8)))
 
     def test_noise_float32(self):
-        self._train_model(dtypes.float32, 'noise')
+        self._train_model(dtypes_module.float32, 'noise')
 
     def test_noise_float64(self):
-        self._train_model(dtypes.float64, 'noise')
+        self._train_model(dtypes_module.float64, 'noise')
 
     def test_dropout_float32(self):
-        self._train_model(dtypes.float32, 'dropout')
+        self._train_model(dtypes_module.float32, 'dropout')
 
     def test_dropout_float64(self):
-        self._train_model(dtypes.float64, 'dropout')
+        self._train_model(dtypes_module.float64, 'dropout')
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/layers/noise_test.py
+++ b/tensorflow/python/keras/layers/noise_test.py
@@ -44,46 +44,46 @@ class NoiseLayersTest(keras_parameterized.TestCase):
         input_shape=(3, 2, 3)
     )
 
-    def test_AlphaDropout(self):
-      testing_utils.layer_test(
-          keras.layers.AlphaDropout,
-          kwargs={'rate': 0.2},
-          input_shape=(3, 2, 3)
-      )
+  def test_AlphaDropout(self):
+    testing_utils.layer_test(
+        keras.layers.AlphaDropout,
+        kwargs={'rate': 0.2},
+        input_shape=(3, 2, 3)
+    )
 
-    @staticmethod
-    def _make_model(dtype, gtype):
-      assert dtype in (dtypes_module.float32, dtypes_module.float64)
-      assert gtype in ('noise', 'dropout')
-      model = keras.Sequential()
-      model.add(keras.layers.Dense(8, input_shape=(32,), dtype=dtype))
-      if gtype == 'noise':
-        gaussian = keras.layers.GaussianNoise(0.0003)
-      else:
-        gaussian = keras.layers.GaussianDropout(0.1)
-      model.add(gaussian)
-      return model
+  @staticmethod
+  def _make_model(dtype, gtype):
+    assert dtype in (dtypes_module.float32, dtypes_module.float64)
+    assert gtype in ('noise', 'dropout')
+    model = keras.Sequential()
+    model.add(keras.layers.Dense(8, input_shape=(32,), dtype=dtype))
+    if gtype == 'noise':
+      gaussian = keras.layers.GaussianNoise(0.0003)
+    else:
+      gaussian = keras.layers.GaussianDropout(0.1)
+    model.add(gaussian)
+    return model
 
-    def _train_model(self, dtype, gtype):
-      model = self._make_model(dtype, gtype)
-      model.compile(
-          optimizer='sgd',
-          loss='mse',
-          run_eagerly=testing_utils.should_run_eagerly()
-      )
-      model.train_on_batch(np.zeros((8, 32)), np.zeros((8, 8)))
+  def _train_model(self, dtype, gtype):
+    model = self._make_model(dtype, gtype)
+    model.compile(
+        optimizer='sgd',
+        loss='mse',
+        run_eagerly=testing_utils.should_run_eagerly()
+    )
+    model.train_on_batch(np.zeros((8, 32)), np.zeros((8, 8)))
 
-    def test_noise_float32(self):
-      self._train_model(dtypes_module.float32, 'noise')
+  def test_noise_float32(self):
+    self._train_model(dtypes_module.float32, 'noise')
 
-    def test_noise_float64(self):
-      self._train_model(dtypes_module.float64, 'noise')
+  def test_noise_float64(self):
+    self._train_model(dtypes_module.float64, 'noise')
 
-    def test_dropout_float32(self):
-      self._train_model(dtypes_module.float32, 'dropout')
+  def test_dropout_float32(self):
+    self._train_model(dtypes_module.float32, 'dropout')
 
-    def test_dropout_float64(self):
-      self._train_model(dtypes_module.float64, 'dropout')
+  def test_dropout_float64(self):
+    self._train_model(dtypes_module.float64, 'dropout')
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/layers/noise_test.py
+++ b/tensorflow/python/keras/layers/noise_test.py
@@ -39,16 +39,16 @@ class NoiseLayersTest(keras_parameterized.TestCase):
 
   def test_GaussianDropout(self):
     testing_utils.layer_test(
-      keras.layers.GaussianDropout,
-      kwargs={'rate': 0.5},
-      input_shape=(3, 2, 3)
+        keras.layers.GaussianDropout,
+        kwargs={'rate': 0.5},
+        input_shape=(3, 2, 3)
     )
 
     def test_AlphaDropout(self):
       testing_utils.layer_test(
-        keras.layers.AlphaDropout,
-        kwargs={'rate': 0.2},
-        input_shape=(3, 2, 3)
+          keras.layers.AlphaDropout,
+          kwargs={'rate': 0.2},
+          input_shape=(3, 2, 3)
       )
 
     @staticmethod
@@ -67,9 +67,9 @@ class NoiseLayersTest(keras_parameterized.TestCase):
     def _train_model(self, dtype, gtype):
       model = self._make_model(dtype, gtype)
       model.compile(
-        optimizer='sgd',
-        loss='mse',
-        run_eagerly=testing_utils.should_run_eagerly()
+          optimizer='sgd',
+          loss='mse',
+          run_eagerly=testing_utils.should_run_eagerly()
       )
       model.train_on_batch(np.zeros((8, 32)), np.zeros((8, 8)))
 

--- a/tensorflow/python/keras/layers/noise_test.py
+++ b/tensorflow/python/keras/layers/noise_test.py
@@ -30,61 +30,61 @@ from tensorflow.python.platform import test
 @keras_parameterized.run_all_keras_modes
 class NoiseLayersTest(keras_parameterized.TestCase):
 
-    def test_GaussianNoise(self):
-        testing_utils.layer_test(
-            keras.layers.GaussianNoise,
-            kwargs={'stddev': 1.},
-            input_shape=(3, 2, 3)
-        )
+  def test_GaussianNoise(self):
+    testing_utils.layer_test(
+      keras.layers.GaussianNoise,
+      kwargs={'stddev': 1.},
+      input_shape=(3, 2, 3)
+    )
 
-    def test_GaussianDropout(self):
-        testing_utils.layer_test(
-            keras.layers.GaussianDropout,
-            kwargs={'rate': 0.5},
-            input_shape=(3, 2, 3)
-        )
+  def test_GaussianDropout(self):
+    testing_utils.layer_test(
+      keras.layers.GaussianDropout,
+      kwargs={'rate': 0.5},
+      input_shape=(3, 2, 3)
+    )
 
     def test_AlphaDropout(self):
-        testing_utils.layer_test(
-            keras.layers.AlphaDropout,
-            kwargs={'rate': 0.2},
-            input_shape=(3, 2, 3)
-        )
+      testing_utils.layer_test(
+        keras.layers.AlphaDropout,
+        kwargs={'rate': 0.2},
+        input_shape=(3, 2, 3)
+      )
 
     @staticmethod
     def _make_model(dtype, gtype):
-        assert dtype in (dtypes_module.float32, dtypes_module.float64)
-        assert gtype in ('noise', 'dropout')
-        model = keras.Sequential()
-        model.add(keras.layers.Dense(8, input_shape=(32,), dtype=dtype))
-        if gtype == 'noise':
-            gaussian = keras.layers.GaussianNoise(0.0003)
-        else:
-            gaussian = keras.layers.GaussianDropout(0.1)
-        model.add(gaussian)
-        return model
+      assert dtype in (dtypes_module.float32, dtypes_module.float64)
+      assert gtype in ('noise', 'dropout')
+      model = keras.Sequential()
+      model.add(keras.layers.Dense(8, input_shape=(32,), dtype=dtype))
+      if gtype == 'noise':
+        gaussian = keras.layers.GaussianNoise(0.0003)
+      else:
+        gaussian = keras.layers.GaussianDropout(0.1)
+      model.add(gaussian)
+      return model
 
     def _train_model(self, dtype, gtype):
-        model = self._make_model(dtype, gtype)
-        model.compile(
-            optimizer='sgd',
-            loss='mse',
-            run_eagerly=testing_utils.should_run_eagerly()
-        )
-        model.train_on_batch(np.zeros((8, 32)), np.zeros((8, 8)))
+      model = self._make_model(dtype, gtype)
+      model.compile(
+        optimizer='sgd',
+        loss='mse',
+        run_eagerly=testing_utils.should_run_eagerly()
+      )
+      model.train_on_batch(np.zeros((8, 32)), np.zeros((8, 8)))
 
     def test_noise_float32(self):
-        self._train_model(dtypes_module.float32, 'noise')
+      self._train_model(dtypes_module.float32, 'noise')
 
     def test_noise_float64(self):
-        self._train_model(dtypes_module.float64, 'noise')
+      self._train_model(dtypes_module.float64, 'noise')
 
     def test_dropout_float32(self):
-        self._train_model(dtypes_module.float32, 'dropout')
+      self._train_model(dtypes_module.float32, 'dropout')
 
     def test_dropout_float64(self):
-        self._train_model(dtypes_module.float64, 'dropout')
+      self._train_model(dtypes_module.float64, 'dropout')
 
 
 if __name__ == '__main__':
-    test.main()
+  test.main()

--- a/tensorflow/python/keras/layers/noise_test.py
+++ b/tensorflow/python/keras/layers/noise_test.py
@@ -32,9 +32,9 @@ class NoiseLayersTest(keras_parameterized.TestCase):
 
   def test_GaussianNoise(self):
     testing_utils.layer_test(
-      keras.layers.GaussianNoise,
-      kwargs={'stddev': 1.},
-      input_shape=(3, 2, 3)
+        keras.layers.GaussianNoise,
+        kwargs={'stddev': 1.},
+        input_shape=(3, 2, 3)
     )
 
   def test_GaussianDropout(self):


### PR DESCRIPTION
As a reply to issue tensorflow#30834, I propose this very small fix that enforces the adjustment of gaussian noises' dtype with that of the inputs within tf.keras.layers.GaussianNoise and tf.keras.layers.GaussianDropout.