### PR TITLE
Copy cluster_def from TPUClusterResolver to session config

### DIFF
--- a/tensorflow/python/tpu/tpu_strategy_util.py
+++ b/tensorflow/python/tpu/tpu_strategy_util.py
@@ -86,7 +86,12 @@ def initialize_tpu_system(cluster_resolver=None):
     serialized_topology = output.numpy()
   else:
     master = cluster_resolver.master()
+    cluster_spec = cluster_resolver.cluster_spec()
+
     session_config = config_pb2.ConfigProto(allow_soft_placement=True)
+    if cluster_spec:
+      session_config.cluster_def.CopyFrom(cluster_spec.as_cluster_def())
+
     with ops.Graph().as_default():
       with session_lib.Session(config=session_config, target=master) as sess:
         serialized_topology = sess.run(tpu.initialize_system())


### PR DESCRIPTION
This patch fixes a TPU issue, where TPU pods cannot work with some variants of TPUStrategy because the cluster_def wasn't set.

Original commit: 5874bc234851a8ab7f86c67a99c43ba9ca12aece
PiperOrigin-RevId: 254299719