### PR TITLE
Fix make_csv_dataset error when combined with compression type

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/make_csv_dataset_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/make_csv_dataset_test.py
@@ -221,6 +221,38 @@ class MakeCsvDatasetTest(test_base.DatasetTestBase):
           compression_type=compression_type,
       )
 
+  def testMakeCSVDataset_withCompressionTypeAndNoColumnNames(self):
+    """Tests `compression_type` argument."""
+    record_defaults = [
+        constant_op.constant([], dtypes.int32),
+        constant_op.constant([], dtypes.int64),
+        constant_op.constant([], dtypes.float32),
+        constant_op.constant([], dtypes.float64),
+        constant_op.constant([], dtypes.string)
+    ]
+
+    column_names = ["col%d" % i for i in range(5)]
+    inputs = [[",".join(x for x in column_names), "0,1,2,3,4", "5,6,7,8,9"], [
+        ",".join(x for x in column_names), "10,11,12,13,14", "15,16,17,18,19"
+    ]]
+    expected_output = [[0, 1, 2, 3, b"4"], [5, 6, 7, 8, b"9"],
+                       [10, 11, 12, 13, b"14"], [15, 16, 17, 18, b"19"]]
+    label = "col0"
+
+    for compression_type in ["GZIP"]:
+      self._test_dataset(
+          inputs,
+          expected_output=expected_output,
+          expected_keys=column_names,
+          label_name=label,
+          batch_size=1,
+          num_epochs=1,
+          shuffle=False,
+          header=True,
+          column_defaults=record_defaults,
+          compression_type=compression_type,
+      )
+
   def testMakeCSVDataset_withBadInputs(self):
     """Tests that exception is raised when input is malformed.
     """

--- a/tensorflow/python/data/experimental/kernel_tests/make_csv_dataset_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/make_csv_dataset_test.py
@@ -239,7 +239,21 @@ class MakeCsvDatasetTest(test_base.DatasetTestBase):
                        [10, 11, 12, 13, b"14"], [15, 16, 17, 18, b"19"]]
     label = "col0"
 
-    for compression_type in ["GZIP"]:
+    self._test_dataset(
+        inputs,
+        expected_output=expected_output,
+        expected_keys=column_names,
+        label_name=label,
+        batch_size=1,
+        num_epochs=1,
+        shuffle=False,
+        header=True,
+        column_defaults=record_defaults,
+        compression_type="GZIP",
+    )
+
+    with self.assertRaisesRegexp(
+        ValueError, "compression_type .ZLIB. is not supported"):
       self._test_dataset(
           inputs,
           expected_output=expected_output,
@@ -250,7 +264,7 @@ class MakeCsvDatasetTest(test_base.DatasetTestBase):
           shuffle=False,
           header=True,
           column_defaults=record_defaults,
-          compression_type=compression_type,
+          compression_type="ZLIB",
       )
 
   def testMakeCSVDataset_withBadInputs(self):

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -431,6 +431,12 @@ def make_csv_dataset_v2(
     dataset = dataset.shuffle(len(filenames), shuffle_seed)
 
   # Clean arguments; figure out column names and defaults
+  def gzip_file_io_open(filename, mode):
+    # By default, gzip will open in byte mode which will
+    # not work with csv.reader so we create a wrapper to
+    # append `t`.
+    mode = mode + "t" if "t" not in mode else mode
+    return gzip.open(filename, mode)
   if column_names is None or column_defaults is None:
     # Find out which io function to open the file
     file_io_fn = file_io.FileIO
@@ -439,7 +445,7 @@ def make_csv_dataset_v2(
       if compression_type_value is None:
         raise ValueError("Received unkown compression_type")
       if compression_type_value == "GZIP":
-        file_io_fn = gzip.GzipFile
+        file_io_fn = gzip_file_io_open
       elif compression_type_value == "ZLIB":
         raise ValueError(
             "compression_type (%s) is not supported for probing columns" %

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -110,7 +110,8 @@ def _infer_type(str_val, na_value, prev_type):
       return type_list[i]
 
 
-def _next_csv_row(filenames, num_cols, field_delim, use_quote_delim, header, file_io_fn):
+def _next_csv_row(
+    filenames, num_cols, field_delim, use_quote_delim, header, file_io_fn):
   """Generator that yields rows of CSV file(s) in order."""
   for fn in filenames:
     with file_io_fn(fn, "r") as f:
@@ -138,7 +139,9 @@ def _infer_column_defaults(filenames, num_cols, field_delim, use_quote_delim,
   inferred_types = [None] * len(select_columns)
 
   for i, csv_row in enumerate(
-      _next_csv_row(filenames, num_cols, field_delim, use_quote_delim, header, file_io_fn)):
+      _next_csv_row(
+          filenames, num_cols, field_delim, use_quote_delim,
+          header, file_io_fn)):
     if num_rows_for_inference is not None and i >= num_rows_for_inference:
       break
 
@@ -438,14 +441,18 @@ def make_csv_dataset_v2(
       if compression_type_value == "GZIP":
         file_io_fn = gzip.GzipFile
       elif compression_type_value == "ZLIB":
-        raise ValueError("compression_type (%s) is not supported for probing columns" % compression_type)
+        raise ValueError(
+            "compression_type (%s) is not supported for probing columns" %
+            compression_type)
       elif compression_type_value != "":
-        raise ValueError("compression_type (%s) is not supported" % compression_type)
+        raise ValueError(
+            "compression_type (%s) is not supported" % compression_type)
   if column_names is None:
     if not header:
       raise ValueError("Cannot infer column names without a header line.")
     # If column names are not provided, infer from the header lines
-    column_names = _infer_column_names(filenames, field_delim, use_quote_delim, file_io_fn)
+    column_names = _infer_column_names(
+        filenames, field_delim, use_quote_delim, file_io_fn)
   if len(column_names) != len(set(column_names)):
     raise ValueError("Cannot have duplicate column names.")
 

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 import collections
 import csv
+import gzip
 import functools
 
 import numpy as np
@@ -37,6 +38,7 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_spec
+from tensorflow.python.framework import tensor_util
 from tensorflow.python.lib.io import file_io
 from tensorflow.python.ops import gen_experimental_dataset_ops
 from tensorflow.python.ops import io_ops
@@ -108,10 +110,10 @@ def _infer_type(str_val, na_value, prev_type):
       return type_list[i]
 
 
-def _next_csv_row(filenames, num_cols, field_delim, use_quote_delim, header):
+def _next_csv_row(filenames, num_cols, field_delim, use_quote_delim, header, file_io_fn):
   """Generator that yields rows of CSV file(s) in order."""
   for fn in filenames:
-    with file_io.FileIO(fn, "r") as f:
+    with file_io_fn(fn, "r") as f:
       rdr = csv.reader(
           f,
           delimiter=field_delim,
@@ -129,14 +131,14 @@ def _next_csv_row(filenames, num_cols, field_delim, use_quote_delim, header):
 
 def _infer_column_defaults(filenames, num_cols, field_delim, use_quote_delim,
                            na_value, header, num_rows_for_inference,
-                           select_columns):
+                           select_columns, file_io_fn):
   """Infers column types from the first N valid CSV records of files."""
   if select_columns is None:
     select_columns = range(num_cols)
   inferred_types = [None] * len(select_columns)
 
   for i, csv_row in enumerate(
-      _next_csv_row(filenames, num_cols, field_delim, use_quote_delim, header)):
+      _next_csv_row(filenames, num_cols, field_delim, use_quote_delim, header, file_io_fn)):
     if num_rows_for_inference is not None and i >= num_rows_for_inference:
       break
 
@@ -153,13 +155,13 @@ def _infer_column_defaults(filenames, num_cols, field_delim, use_quote_delim,
   ]
 
 
-def _infer_column_names(filenames, field_delim, use_quote_delim):
+def _infer_column_names(filenames, field_delim, use_quote_delim, file_io_fn):
   """Infers column names from first rows of files."""
   csv_kwargs = {
       "delimiter": field_delim,
       "quoting": csv.QUOTE_MINIMAL if use_quote_delim else csv.QUOTE_NONE
   }
-  with file_io.FileIO(filenames[0], "r") as f:
+  with file_io_fn(filenames[0], "r") as f:
     try:
       column_names = next(csv.reader(f, **csv_kwargs))
     except StopIteration:
@@ -167,7 +169,7 @@ def _infer_column_names(filenames, field_delim, use_quote_delim):
                         "of %s.  Empty file?") % filenames[0])
 
   for name in filenames[1:]:
-    with file_io.FileIO(name, "r") as f:
+    with file_io_fn(name, "r") as f:
       try:
         if next(csv.reader(f, **csv_kwargs)) != column_names:
           raise ValueError(
@@ -426,12 +428,24 @@ def make_csv_dataset_v2(
     dataset = dataset.shuffle(len(filenames), shuffle_seed)
 
   # Clean arguments; figure out column names and defaults
-
+  if column_names is None or column_defaults is None:
+    # Find out which io function to open the file
+    file_io_fn = file_io.FileIO
+    if compression_type is not None:
+      compression_type_value = tensor_util.constant_value(compression_type)
+      if compression_type_value is None:
+        raise ValueError("Received unkown compression_type")
+      if compression_type_value == "GZIP":
+        file_io_fn = gzip.GzipFile
+      elif compression_type_value == "ZLIB":
+        raise ValueError("compression_type (%s) is not supported for probing columns" % compression_type)
+      elif compression_type_value != "":
+        raise ValueError("compression_type (%s) is not supported" % compression_type)
   if column_names is None:
     if not header:
       raise ValueError("Cannot infer column names without a header line.")
     # If column names are not provided, infer from the header lines
-    column_names = _infer_column_names(filenames, field_delim, use_quote_delim)
+    column_names = _infer_column_names(filenames, field_delim, use_quote_delim, file_io_fn)
   if len(column_names) != len(set(column_names)):
     raise ValueError("Cannot have duplicate column names.")
 
@@ -448,7 +462,7 @@ def make_csv_dataset_v2(
     # construction time
     column_defaults = _infer_column_defaults(
         filenames, len(column_names), field_delim, use_quote_delim, na_value,
-        header, num_rows_for_inference, select_columns)
+        header, num_rows_for_inference, select_columns, file_io_fn)
 
   if select_columns is not None and len(column_defaults) != len(select_columns):
     raise ValueError(


### PR DESCRIPTION
This fix tries to address the issue raised in #30849 where make_csv_dataset throw out an error if combined with compression_type. This fix address the issue by using different file io functions
in case compression_type is provided.

Note this fix only addresses GZIP format. For ZLIB format, as python's zlib package does not comes with a way to read file stream (only from data buffer) as gzip package, it is not supported.

This fix fixes #30849.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>