### PR TITLE
[INTEL_MKL] Parallelizing scatter update op.

### DIFF
--- a/tensorflow/core/kernels/scatter_functor.h
+++ b/tensorflow/core/kernels/scatter_functor.h
@@ -18,14 +18,15 @@ limitations under the License.
 
 #include <type_traits>
 
-#include "third_party/eigen3/Eigen/Core"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/variant_op_registry.h"
 #include "tensorflow/core/kernels/dense_update_functor.h"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/work_sharder.h"
+#include "third_party/eigen3/Eigen/Core"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -188,6 +189,7 @@ struct AssignSYCL<scatter_op::UpdateOp::MAX> {
 }  // namespace scatter_op
 
 namespace functor {
+#define kMaxLocks 1024
 template <typename Device, typename T, typename Index, scatter_op::UpdateOp op>
 struct ScatterFunctor {
   Index operator()(OpKernelContext* c, const Device& d,
@@ -205,17 +207,61 @@ struct ScatterFunctorBase {
     // indices and params sizes were validated in DoCompute().
     const Index N = static_cast<Index>(indices.size());
     const Index limit = static_cast<Index>(params.dimension(0));
-    for (Index i = 0; i < N; i++) {
-      // Grab the index and check its validity.  Do this carefully,
-      // to avoid checking the value and grabbing it again from
-      // memory a second time (a security risk since it may change in between).
-      const Index index = ::tensorflow::internal::SubtleMustCopy(indices(i));
-      if (!FastBoundsCheck(index, limit)) return i;
-      // Copy last Ndim-1 dimensions of updates[i] to params[index]
-      scatter_op::internal::Assign<op>::Run(params.template chip<0>(index),
-                                            updates.template chip<0>(i));
+    unsigned long int num_locks, entries_per_lock;
+    // Duplicate entries need to be handled correctly.
+    // Multiple updates to the same index has to be serialized.
+    // To reduce the number of locks and the memory usage,
+    // we divide the whole index space into kMaxLocks regions
+    // with each lock serializing access to a region.
+    if (limit <= kMaxLocks) {
+      num_locks = limit;
+      entries_per_lock = 1;
+
+    } else {
+      num_locks = kMaxLocks;
+      entries_per_lock = (limit % kMaxLocks == 0) ? limit / kMaxLocks
+                                                  : (limit / kMaxLocks + 1);
     }
-    return -1;
+
+    std::vector<std::atomic<bool>> accessed(num_locks);
+    auto ParallelInit = [&](Index start, Index end) {
+      for (Index i = start; i < end; i++) accessed.at(i) = false;
+    };
+    Index bad_index = -1;
+    auto ParallelScatter = [&](Index start, Index end) {
+      for (Index i = start; i < end; i++) {
+        // Grab the index and check its validity.  Do this carefully,
+        // to avoid checking the value and grabbing it again from
+        // memory a second time (a security risk since it may change in
+        // between).
+        const Index index = ::tensorflow::internal::SubtleMustCopy(indices(i));
+        if (!FastBoundsCheck(index, limit)) {
+          bad_index = i;
+          return;
+        }
+        unsigned long int lock_id =
+            (entries_per_lock == 1) ? index : (index / entries_per_lock);
+        // Copy last Ndim-1 dimensions of updates[i] to params[index]
+        // Separating test from test and set to improve performance and reduce
+        // coherence overhead.
+        // Test
+        while (accessed.at(lock_id)) {
+        }
+        // Test and Set
+        while (accessed.at(lock_id).exchange(true)) {
+        }
+        scatter_op::internal::Assign<op>::Run(params.template chip<0>(index),
+                                              updates.template chip<0>(i));
+        accessed.at(lock_id) = false;
+      }
+    };
+    const DeviceBase::CpuWorkerThreads& worker_threads =
+        *(c->device()->tensorflow_cpu_worker_threads());
+    Shard(worker_threads.num_threads, worker_threads.workers, num_locks, 3500.0,
+          ParallelInit);  // Cost is arbitrary for now.
+    Shard(worker_threads.num_threads, worker_threads.workers, N, 3500.0,
+          ParallelScatter);  // Cost is arbitrary for now.
+    return bad_index;
   }
 };
 

--- a/tensorflow/core/kernels/scatter_functor.h
+++ b/tensorflow/core/kernels/scatter_functor.h
@@ -211,9 +211,8 @@ struct ScatterFunctorBase {
     // same index has to be serialized. To reduce the number of locks and the
     // memory usage, we divide the whole index space into kMaxLocks regions with
     // each lock serializing access to a region.
-    const Index num_locks = std::min(limit, kMaxLocks);
     const Index entries_per_lock = (limit + kMaxLocks - 1) / kMaxLocks;
-    mutex accessed[num_locks];
+    mutex accessed[kMaxLocks];
     std::atomic<Index> bad_index(-1);
     auto ParallelScatter = [&](Index start, Index end) {
       for (Index i = start; i < end; ++i) {

--- a/tensorflow/core/kernels/scatter_op_test.cc
+++ b/tensorflow/core/kernels/scatter_op_test.cc
@@ -47,6 +47,17 @@ class ScatterUpdateOpTest : public OpsTestBase {
     TF_ASSERT_OK(InitOp());
   }
 };
+class ScatterSubOpTest : public OpsTestBase {
+ protected:
+  void MakeOp(DataType variable_ref_type, DataType index_type) {
+    TF_ASSERT_OK(NodeDefBuilder("myop", "ScatterSub")
+                     .Input(FakeInput(variable_ref_type))
+                     .Input(FakeInput(index_type))
+                     .Input(FakeInput(RemoveRefType(variable_ref_type)))
+                     .Finalize(node_def()));
+    TF_ASSERT_OK(InitOp());
+  }
+};
 
 TEST_F(ScatterUpdateOpTest, Simple_StringType) {
   MakeOp(DT_STRING_REF, DT_INT32);
@@ -175,6 +186,47 @@ TEST_F(ScatterUpdateOpTest, Error_IndexOutOfRange) {
       << s;
 }
 
+TEST_F(ScatterSubOpTest, Error_IndexOutOfRange) {
+  MakeOp(DT_FLOAT_REF, DT_INT32);
+  // Feed and run
+  AddInputFromArray<float>(TensorShape({14}),
+                           {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+  AddInputFromArray<int32>(TensorShape({3}), {0, 1, 99});
+  AddInputFromArray<float>(TensorShape({3}), {100, 101, 102});
+  Status s = RunOpKernel();
+  EXPECT_TRUE(
+      absl::StrContains(s.ToString(), "indices[2] = 99 is not in [0, 14)"))
+      << s;
+}
+
+TEST_F(ScatterSubOpTest, StressIndexTest) {
+  MakeOp(DT_INT32_REF, DT_INT32);
+  // Feed and run
+  const int kRows = 1;
+  std::vector<int32> values;
+  values.reserve(kRows);
+  for (int i = 0; i < kRows; i++) {
+    values.push_back(0);
+  }
+  const int kNumUpdates = 1000000;
+  std::vector<int32> indices;
+  std::vector<int32> updates;
+  for (int i = 0; i < kNumUpdates; i++) {
+    indices.push_back(0);
+    updates.push_back(1);
+  }
+
+  AddInputFromArray<int32>(TensorShape({kRows}), values);
+  AddInputFromArray<int32>(TensorShape({kNumUpdates}), indices);
+  AddInputFromArray<int32>(TensorShape({kNumUpdates}), updates);
+  testing::ItemsProcessed((static_cast<int64>(kNumUpdates)));
+  Status s = RunOpKernel();
+  Tensor params_tensor = *mutable_input(0).tensor;
+  Tensor expected(allocator(), DT_INT32, TensorShape({1}));
+  test::FillValues<int32>(&expected, {-1000000});
+  test::ExpectTensorEqual<int32>(expected, params_tensor);
+}
+
 TEST_F(ScatterUpdateOpTest, Error_WrongDimsIndices) {
   MakeOp(DT_FLOAT_REF, DT_INT32);
 
@@ -238,7 +290,8 @@ class ScatterUpdateBM : public ScatterUpdateOpTest {
 };
 
 template <typename Index>
-static void BM_ScatterHelper(int iters, int embedding_size, const char* op) {
+static void BM_ScatterHelper(int iters, int embedding_size, const char* op,
+                             bool big_num_updates = false) {
   testing::StopTiming();
   const int kRows = 10000000 / embedding_size;
   std::vector<float> values;
@@ -246,7 +299,7 @@ static void BM_ScatterHelper(int iters, int embedding_size, const char* op) {
   for (int i = 0; i < kRows * embedding_size; i++) {
     values.push_back(i);
   }
-  const int kNumUpdates = 1000;
+  const int kNumUpdates = big_num_updates ? 1000000 : 1000;
   random::PhiloxRandom philox(301, 17);
   random::SimplePhilox rnd(&philox);
   std::vector<Index> indices;
@@ -282,7 +335,9 @@ static void BM_ScatterUpdateInt64(int iters, int embedding_size) {
 
 static void BM_ScatterAddInt32(int iters, int embedding_size) {
   BM_ScatterHelper<int32>(iters, embedding_size, "ScatterAdd");
+  BM_ScatterHelper<int32>(iters, embedding_size, "ScatterAdd", true);
 }
+
 static void BM_ScatterAddInt64(int iters, int embedding_size) {
   BM_ScatterHelper<int64>(iters, embedding_size, "ScatterAdd");
 }
@@ -339,6 +394,7 @@ BENCHMARK(BM_ScatterUpdateInt64)
     ->Arg(100000);
 
 BENCHMARK(BM_ScatterAddInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
+
 BENCHMARK(BM_ScatterAddInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 
 BENCHMARK(BM_ScatterMulInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);

--- a/tensorflow/core/kernels/scatter_op_test.cc
+++ b/tensorflow/core/kernels/scatter_op_test.cc
@@ -204,17 +204,9 @@ TEST_F(ScatterSubOpTest, StressIndexTest) {
   // Feed and run
   const int kRows = 1;
   std::vector<int32> values(kRows, 0);
-  for (int i = 0; i < kRows; i++) {
-    values.at(i) = 0;
-  }
   const int kNumUpdates = 1000000;
   std::vector<int32> indices(kNumUpdates, 0);
-  std::vector<int32> updates(kNumUpdates, 0);
-  for (int i = 0; i < kNumUpdates; i++) {
-    indices.at(i) = 0;
-    updates.at(i) = 1;
-  }
-
+  std::vector<int32> updates(kNumUpdates, 1);
   AddInputFromArray<int32>(TensorShape({kRows}), values);
   AddInputFromArray<int32>(TensorShape({kNumUpdates}), indices);
   AddInputFromArray<int32>(TensorShape({kNumUpdates}), updates);

--- a/tensorflow/core/kernels/scatter_op_test.cc
+++ b/tensorflow/core/kernels/scatter_op_test.cc
@@ -203,17 +203,16 @@ TEST_F(ScatterSubOpTest, StressIndexTest) {
   MakeOp(DT_INT32_REF, DT_INT32);
   // Feed and run
   const int kRows = 1;
-  std::vector<int32> values;
-  values.reserve(kRows);
+  std::vector<int32> values(kRows, 0);
   for (int i = 0; i < kRows; i++) {
-    values.push_back(0);
+    values.at(i) = 0;
   }
   const int kNumUpdates = 1000000;
-  std::vector<int32> indices;
-  std::vector<int32> updates;
+  std::vector<int32> indices(kNumUpdates, 0);
+  std::vector<int32> updates(kNumUpdates, 0);
   for (int i = 0; i < kNumUpdates; i++) {
-    indices.push_back(0);
-    updates.push_back(1);
+    indices.at(i) = 0;
+    updates.at(i) = 1;
   }
 
   AddInputFromArray<int32>(TensorShape({kRows}), values);
@@ -394,7 +393,6 @@ BENCHMARK(BM_ScatterUpdateInt64)
     ->Arg(100000);
 
 BENCHMARK(BM_ScatterAddInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
-
 BENCHMARK(BM_ScatterAddInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 
 BENCHMARK(BM_ScatterMulInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
@@ -408,6 +406,5 @@ BENCHMARK(BM_ScatterMinInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 
 BENCHMARK(BM_ScatterMaxInt32)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
 BENCHMARK(BM_ScatterMaxInt64)->Arg(1)->Arg(10)->Arg(64)->Arg(256)->Arg(1024);
-
 }  // namespace
 }  // namespace tensorflow


### PR DESCRIPTION
This is a follow up for https://github.com/tensorflow/tensorflow/pull/30375 and fixes the regression failure.

INTRA_OP=1
Benchmark Time(ns) Iterations
BM_ScatterAddInt32/1 89109380 100 11.2M items/s
BM_ScatterAddInt32/10 123866710 100 80.7M items/s
BM_ScatterAddInt32/64 177304560 100 361.0M items/s
BM_ScatterAddInt32/256 270029460 100 948.0M items/s
BM_ScatterAddInt32/1024 762985280 100 1342.1M items/s

INTRA_OP=13
Running main() from test_main.cc
Benchmark Time(ns) Iterations
BM_ScatterAddInt32/1 47192100 100 21.2M items/s
BM_ScatterAddInt32/10 48498980 100 206.2M items/s
BM_ScatterAddInt32/64 52246600 100 1225.0M items/s
BM_ScatterAddInt32/256 70786030 100 3616.5M items/s
BM_ScatterAddInt32/1024 150688620 100 6795.5M items/s