### PR TITLE
Fix for unit test failure

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass_test.cc
+++ b/tensorflow/core/graph/mkl_layout_pass_test.cc
@@ -3683,7 +3683,7 @@ TEST_F(MklLayoutPassTest, NodeRewrite_FusedBatchNormV3_DeviceTest) {
       kGPUDevice);
   EXPECT_EQ(DoMklLayoutOptimizationPass(),
             "A(Input);B(Input);C(Input);D(Input);E(Input);"
-            "F(FusedBatchNormV3);G(Zeta)|A->F;A->G;B->F:1;C->F:2;D->F:3;"
+            "F(FusedBatchNorm);G(Zeta)|A->F;A->G;B->F:1;C->F:2;D->F:3;"
             "E->F:4;F->G:1");
 }
 


### PR DESCRIPTION
[INTEL MKL] Fix for failing unit testcase in : //tensorflow/core:graph_mkl_layout_pass.
It was failing due to wrong output check. The testcase was added for FusedBatchNormV3 support with Intel MKL DN PR: #30386 
