### PR TITLE
Format tf.function's error message when input and signature does not match

### DIFF
--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -1541,7 +1541,7 @@ def _convert_inputs_to_signature(inputs, input_signature, flat_input_signature):
         expand_composites=True)
   except ValueError:
     raise ValueError("Structure of Python function inputs does not match "
-                     "input_signature:\n" %
+                     "input_signature:\n%s" %
                      format_error_message(inputs, input_signature))
 
   need_packing = False
@@ -1555,7 +1555,7 @@ def _convert_inputs_to_signature(inputs, input_signature, flat_input_signature):
       except ValueError:
         raise ValueError("When input_signature is provided, all inputs to "
                          "the Python function must be convertible to "
-                         "tensors:\n" %
+                         "tensors:\n%s" %
                          format_error_message(inputs, input_signature))
 
   if any(not spec.is_compatible_with(other) for spec, other in zip(

--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -1522,11 +1522,15 @@ def _convert_numpy_inputs(inputs):
 def _convert_inputs_to_signature(inputs, input_signature, flat_input_signature):
   """Convert inputs to pass into a function with an explicit signature."""
   def format_error_message(inputs, input_signature):
-      return ("  inputs: (\n    " +
-      ",\n    ".join([str(i) for i in inputs]) +
-      ")\n  input_signature: (\n    " +
-      ",\n    ".join([str(i) for i in input_signature]) +
-      ")")
+    return ("  inputs: (\n" +
+            "    " +
+            ",\n    ".join([str(i) for i in inputs]) +
+            ")\n" +
+            "  input_signature: (\n" +
+            "    " +
+            ",\n    ".join([str(i) for i in input_signature]) +
+            ")")
+
   try:
     # TODO(b/124370185): Use all elements as inputs to throw an error if there
     # are ignored arguments. Calling with arguments that are not part of the

--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -1521,6 +1521,12 @@ def _convert_numpy_inputs(inputs):
 
 def _convert_inputs_to_signature(inputs, input_signature, flat_input_signature):
   """Convert inputs to pass into a function with an explicit signature."""
+  def format_error_message(inputs, input_signature):
+      return ("  inputs: (\n    " +
+      ",\n    ".join([str(i) for i in inputs]) +
+      ")\n  input_signature: (\n    " +
+      ",\n    ".join([str(i) for i in input_signature]) +
+      ")")
   try:
     # TODO(b/124370185): Use all elements as inputs to throw an error if there
     # are ignored arguments. Calling with arguments that are not part of the
@@ -1531,8 +1537,8 @@ def _convert_inputs_to_signature(inputs, input_signature, flat_input_signature):
         expand_composites=True)
   except ValueError:
     raise ValueError("Structure of Python function inputs does not match "
-                     "input_signature. Inputs (%s), input_signature(%s)." %
-                     (str(inputs), str(input_signature)))
+                     "input_signature:\n" %
+                     format_error_message(inputs, input_signature))
 
   need_packing = False
   for index, (value, spec) in enumerate(zip(flatten_inputs,
@@ -1544,16 +1550,10 @@ def _convert_inputs_to_signature(inputs, input_signature, flat_input_signature):
         need_packing = True
       except ValueError:
         raise ValueError("When input_signature is provided, all inputs to "
-                         "the Python function must be convertible to tensors."
-                         "Inputs (%s), input_signature(%s)." %
-                         (str(inputs), str(input_signature)))
+                         "the Python function must be convertible to "
+                         "tensors:\n" %
+                         format_error_message(inputs, input_signature))
 
-  def format_error_message(inputs, input_signature):
-      return ("  inputs: (\n    " +
-      ",\n    ".join([str(i) for i in inputs]) +
-      ")\n  input_signature: (\n    " +
-      ",\n    ".join([str(i) for i in input_signature]) +
-      ")")
   if any(not spec.is_compatible_with(other) for spec, other in zip(
       flat_input_signature,
       flatten_inputs)):

--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -1548,12 +1548,17 @@ def _convert_inputs_to_signature(inputs, input_signature, flat_input_signature):
                          "Inputs (%s), input_signature(%s)." %
                          (str(inputs), str(input_signature)))
 
+  def format_error_message(inputs, input_signature):
+      return ("  inputs: (\n    " +
+      ",\n    ".join([str(i) for i in inputs]) +
+      ")\n  input_signature: (\n    " +
+      ",\n    ".join([str(i) for i in input_signature]) +
+      ")")
   if any(not spec.is_compatible_with(other) for spec, other in zip(
       flat_input_signature,
       flatten_inputs)):
-    raise ValueError("Python inputs incompatible with input_signature: "
-                     "inputs (%s), input_signature (%s)" %
-                     (str(inputs), str(input_signature)))
+    raise ValueError("Python inputs incompatible with input_signature:\n%s" %
+                     format_error_message(inputs, input_signature))
 
   if need_packing:
     inputs = nest.pack_sequence_as(


### PR DESCRIPTION
This fix tries to address the issue raised in #30576 where the error message is hard to interpret:
```
ValueError: Python inputs incompatible with input_signature: inputs ((<tf.Tensor 'random_normal:0' shape=(1, 123, 1) dtype=float32>, <tf.Tensor 'random_normal_1:0' shape=(1, 123, 2) dtype=float32>, <tf.Tensor 'random_normal_2:0' shape=(1, 123, 3) dtype=float32>, <tf.Tensor 'random_normal_3:0' shape=(1, 123, 4) dtype=float32>, <tf.Tensor 'random_normal_4:0' shape=(1, 123, 5) dtype=float32>, <tf.Tensor 'random_normal_5:0' shape=(1, 123, 6) dtype=float32>, <tf.Tensor 'random_normal_6:0' shape=(1, 123, 7) dtype=float32>, <tf.Tensor 'random_normal_7:0' shape=(1, 123, 8) dtype=float32>, <tf.Tensor 'random_normal_8:0' shape=(1, 123, 1) dtype=float32>)), input_signature ((TensorSpec(shape=(?, ?, 1), dtype=tf.float32, name=None), TensorSpec(shape=(?, ?, 2), dtype=tf.float32, name=None), TensorSpec(shape=(?, ?, 3), dtype=tf.float32, name=None), TensorSpec(shape=(?, ?, 4), dtype=tf.float32, name=None), TensorSpec(shape=(?, ?, 5), dtype=tf.float32, name=None), TensorSpec(shape=(?, ?, 6), dtype=tf.float32, name=None), TensorSpec(shape=(?, ?, 7), dtype=tf.float32, name=None), TensorSpec(shape=(?, ?, 8), dtype=tf.float32, name=None), TensorSpec(shape=(?, ?, 9), dtype=tf.float32, name=None)))
```

This fix formats the error message:
```
ValueError: Python inputs incompatible with input_signature:
  inputs: (
    Tensor("random_normal:0", shape=(1, 123, 1), dtype=float32),
    Tensor("random_normal_1:0", shape=(1, 123, 2), dtype=float32),
    Tensor("random_normal_2:0", shape=(1, 123, 3), dtype=float32),
    Tensor("random_normal_3:0", shape=(1, 123, 4), dtype=float32),
    Tensor("random_normal_4:0", shape=(1, 123, 5), dtype=float32),
    Tensor("random_normal_5:0", shape=(1, 123, 6), dtype=float32),
    Tensor("random_normal_6:0", shape=(1, 123, 7), dtype=float32),
    Tensor("random_normal_7:0", shape=(1, 123, 8), dtype=float32),
    Tensor("random_normal_8:0", shape=(1, 123, 1), dtype=float32))
  input_signature: (
    TensorSpec(shape=(?, ?, 1), dtype=tf.float32, name=None),
    TensorSpec(shape=(?, ?, 2), dtype=tf.float32, name=None),
    TensorSpec(shape=(?, ?, 3), dtype=tf.float32, name=None),
    TensorSpec(shape=(?, ?, 4), dtype=tf.float32, name=None),
    TensorSpec(shape=(?, ?, 5), dtype=tf.float32, name=None),
    TensorSpec(shape=(?, ?, 6), dtype=tf.float32, name=None),
    TensorSpec(shape=(?, ?, 7), dtype=tf.float32, name=None),
    TensorSpec(shape=(?, ?, 8), dtype=tf.float32, name=None),
    TensorSpec(shape=(?, ?, 9), dtype=tf.float32, name=None))
```

This fix fixes #30576.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
