### PR TITLE
[INTEL MKL] Build failure fix for MKL-DNN v1.x

### DIFF
--- a/third_party/mkl_dnn/mkldnn.BUILD
+++ b/third_party/mkl_dnn/mkldnn.BUILD
@@ -62,8 +62,6 @@ cc_library(
         "src/cpu/xbyak/*.h",
     ]) + if_mkl_v1_open_source_only([
         ":mkldnn_config_h",
-        "src/cpu/jit_utils/jit_utils.cpp",
-        "src/cpu/jit_utils/jit_utils.hpp",
     ]) + [":mkldnn_version_h"],
     hdrs = glob(["include/*"]),
     copts = [


### PR DESCRIPTION
Since we have already included all the `*.h` and `*.cpp` files under `src/cpu` via the `*` wildcard, we no longer need to explicitly include files that are under `src/cpu/jit_utils` for `v1.x`.