### PR TITLE
Fix large (>4GB) files reading on windows

### DIFF
--- a/tensorflow/core/platform/windows/windows_file_system.cc
+++ b/tensorflow/core/platform/windows/windows_file_system.cc
@@ -122,7 +122,13 @@ class WindowsRandomAccessFile : public RandomAccessFile {
     Status s;
     char* dst = scratch;
     while (n > 0 && s.ok()) {
-      SSIZE_T r = pread(hfile_, dst, n, offset);
+      size_t requested_read_length;
+      if (n > std::numeric_limits<DWORD>::max()) {
+        requested_read_length = std::numeric_limits<DWORD>::max();
+      } else {
+        requested_read_length = n;
+      }
+      SSIZE_T r = pread(hfile_, dst, requested_read_length, offset);
       if (r > 0) {
         offset += r;
         dst += r;


### PR DESCRIPTION
There is a bug which prevents reading files larger than 4GB on Windows.
TF uses ::ReadFile winapi function (see pread in windows_file_system.cc)
This function accepts requested bytes number as DWORD, which is 32 bit on both 32bit
and 64bit systems. But WindowsRandomAccessFile::Read passes number of
bytes as size_t which is 64 bit on 64 bit systems. Then there is a
static_cast from 64 bit size_t to 32 bit DWORD, which causes the error.
Changed to read such files in portions of no more than
std::numeric_limits\<DWORD\>::max() bytes.