### PR TITLE
[XLA:GPU][ROCm] Refactor IR emitter to cope with both NVPTX and AMDGPU for workgroup dims.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -260,6 +260,7 @@ cc_library(
     hdrs = ["parallel_loop_emitter.h"],
     deps = [
         ":partition_assignment",
+        ":target_util",
         "//tensorflow/compiler/xla:shape_util",
         "//tensorflow/compiler/xla:xla_data_proto",
         "//tensorflow/compiler/xla/service/llvm_ir:ir_array",

--- a/tensorflow/compiler/xla/service/gpu/elemental_ir_emitter.h
+++ b/tensorflow/compiler/xla/service/gpu/elemental_ir_emitter.h
@@ -100,13 +100,6 @@ class GpuElementalIrEmitter : public ElementalIrEmitter {
                                      llvm::Value* lhs_value,
                                      llvm::Value* rhs_value);
 
-  // Emits IR to call a device function named "callee_name" on the given
-  // operand. Returns the IR value that represents the return value.
-  llvm::Value* EmitDeviceFunctionCall(
-      const string& callee_name, absl::Span<llvm::Value* const> operands,
-      absl::Span<const PrimitiveType> input_type, PrimitiveType output_type,
-      absl::Span<const llvm::Attribute::AttrKind> attributes);
-
   // Emits IR to call an LLVM intrinsic of type [T] -> T.  Adjusts
   // callee_name according to T.  Returns the IR value that represents the
   // return value of the function.

--- a/tensorflow/compiler/xla/service/gpu/target_util.cc
+++ b/tensorflow/compiler/xla/service/gpu/target_util.cc
@@ -91,7 +91,7 @@ struct TargetIntrinsics GetIntrinsic(TargetIntrinsicID intrin) {
       return {llvm::Intrinsic::nvvm_read_ptx_sreg_ntid_z,
               [](llvm::IRBuilder<>* b_) -> llvm::CallInst* {
                 return EmitDeviceFunctionCall("__ockl_get_local_size",
-                                              {b_->getInt32(1)}, {U32}, U64, {},
+                                              {b_->getInt32(2)}, {U32}, U64, {},
                                               b_);
               }};
     }
@@ -225,9 +225,10 @@ llvm::CallInst* EmitCallToTargetIntrinsic(
   if (target_triple.isNVPTX()) {
     llvm_intrinsic_id = gpu_intrinsic_id.nvptx_intrinsic;
   } else if (target_triple.getArch() == llvm::Triple::amdgcn) {
-    llvm::Intrinsic::ID* llvm_intrinsic_id_ptr;
-    if ((llvm_intrinsic_id_ptr = absl::get_if<llvm::Intrinsic::ID>(
-             &gpu_intrinsic_id.amdgpu_intrinsic_or_function))) {
+    llvm::Intrinsic::ID* llvm_intrinsic_id_ptr =
+        absl::get_if<llvm::Intrinsic::ID>(
+            &gpu_intrinsic_id.amdgpu_intrinsic_or_function);
+    if (llvm_intrinsic_id_ptr) {
       llvm_intrinsic_id = *llvm_intrinsic_id_ptr;
     } else {
       std::function<llvm::CallInst*(llvm::IRBuilder<>*)>* builder_func =

--- a/tensorflow/compiler/xla/service/gpu/target_util.cc
+++ b/tensorflow/compiler/xla/service/gpu/target_util.cc
@@ -29,9 +29,14 @@ namespace {
 using absl::StrCat;
 
 // Wrapper structure for carrying llvm intrinsic ids for NVPTX/AMDGPU platforms.
+// On AMDGPU, some of these operations are made as device functions instead of
+// intrinsics. Therefore a variant type is used to wrap the lambda to call
+// those device functions.
 struct TargetIntrinsics {
   llvm::Intrinsic::ID nvptx_intrinsic;
-  llvm::Intrinsic::ID amdgpu_intrinsic;
+  absl::variant<llvm::Intrinsic::ID,
+                std::function<llvm::CallInst*(llvm::IRBuilder<>*)>>
+      amdgpu_intrinsic_or_function;
 };
 
 // Gets the llvm intrinsic ids on different platforms (NVPTX, AMDGPU)
@@ -65,6 +70,30 @@ struct TargetIntrinsics GetIntrinsic(TargetIntrinsicID intrin) {
     case TargetIntrinsicID::kBarrierId: {
       return {llvm::Intrinsic::nvvm_barrier0,
               llvm::Intrinsic::amdgcn_s_barrier};
+    }
+    case TargetIntrinsicID::kBlockDimx: {
+      return {llvm::Intrinsic::nvvm_read_ptx_sreg_ntid_x,
+              [](llvm::IRBuilder<>* b_) -> llvm::CallInst* {
+                return EmitDeviceFunctionCall("__ockl_get_local_size",
+                                              {b_->getInt32(0)}, {U32}, U64, {},
+                                              b_);
+              }};
+    }
+    case TargetIntrinsicID::kBlockDimy: {
+      return {llvm::Intrinsic::nvvm_read_ptx_sreg_ntid_y,
+              [](llvm::IRBuilder<>* b_) -> llvm::CallInst* {
+                return EmitDeviceFunctionCall("__ockl_get_local_size",
+                                              {b_->getInt32(1)}, {U32}, U64, {},
+                                              b_);
+              }};
+    }
+    case TargetIntrinsicID::kBlockDimz: {
+      return {llvm::Intrinsic::nvvm_read_ptx_sreg_ntid_z,
+              [](llvm::IRBuilder<>* b_) -> llvm::CallInst* {
+                return EmitDeviceFunctionCall("__ockl_get_local_size",
+                                              {b_->getInt32(1)}, {U32}, U64, {},
+                                              b_);
+              }};
     }
   }
 }
@@ -156,6 +185,36 @@ string ObtainDeviceFunctionName(TargetDeviceFunctionID func_id,
   }
 }
 
+llvm::CallInst* EmitDeviceFunctionCall(
+    const string& callee_name, absl::Span<llvm::Value* const> operands,
+    absl::Span<const PrimitiveType> input_types, PrimitiveType output_type,
+    absl::Span<const llvm::Attribute::AttrKind> attributes,
+    llvm::IRBuilder<>* b) {
+  std::vector<llvm::Type*> ir_input_types;
+  llvm::Module* module = b->GetInsertBlock()->getModule();
+  for (PrimitiveType input_type : input_types) {
+    ir_input_types.push_back(
+        llvm_ir::PrimitiveTypeToIrType(input_type, module));
+  }
+  llvm::FunctionType* callee_type = llvm::FunctionType::get(
+      llvm_ir::PrimitiveTypeToIrType(output_type, module),  // Return type.
+      ir_input_types,                                       // Parameter types.
+      false);  // No variadic arguments.
+
+  // Declares the callee if it is not declared already.
+  llvm::Function* callee = llvm::dyn_cast<llvm::Function>(
+      b->GetInsertBlock()
+          ->getModule()
+          ->getOrInsertFunction(callee_name, callee_type)
+          .getCallee());
+
+  for (auto attribute : attributes) {
+    callee->addFnAttr(attribute);
+  }
+
+  return b->CreateCall(callee, llvm_ir::AsArrayRef(operands));
+}
+
 llvm::CallInst* EmitCallToTargetIntrinsic(
     TargetIntrinsicID intrinsic_id, absl::Span<llvm::Value* const> operands,
     absl::Span<llvm::Type* const> overloaded_types, llvm::IRBuilder<>* b) {
@@ -166,7 +225,16 @@ llvm::CallInst* EmitCallToTargetIntrinsic(
   if (target_triple.isNVPTX()) {
     llvm_intrinsic_id = gpu_intrinsic_id.nvptx_intrinsic;
   } else if (target_triple.getArch() == llvm::Triple::amdgcn) {
-    llvm_intrinsic_id = gpu_intrinsic_id.amdgpu_intrinsic;
+    llvm::Intrinsic::ID* llvm_intrinsic_id_ptr;
+    if ((llvm_intrinsic_id_ptr = absl::get_if<llvm::Intrinsic::ID>(
+             &gpu_intrinsic_id.amdgpu_intrinsic_or_function))) {
+      llvm_intrinsic_id = *llvm_intrinsic_id_ptr;
+    } else {
+      std::function<llvm::CallInst*(llvm::IRBuilder<>*)>* builder_func =
+          absl::get_if<std::function<llvm::CallInst*(llvm::IRBuilder<>*)>>(
+              &gpu_intrinsic_id.amdgpu_intrinsic_or_function);
+      return (*builder_func)(b);
+    }
   } else {
     LOG(FATAL) << "Invalid triple " << target_triple.str();
   }

--- a/tensorflow/compiler/xla/service/gpu/target_util.h
+++ b/tensorflow/compiler/xla/service/gpu/target_util.h
@@ -39,6 +39,9 @@ enum class TargetIntrinsicID {
   kBlockIdy,
   kBlockIdz,
   kBarrierId,
+  kBlockDimx,
+  kBlockDimy,
+  kBlockDimz,
 };
 
 // Enumeration to get target specific device math function.
@@ -59,8 +62,15 @@ enum class TargetDeviceFunctionID {
   kHypot
 };
 
-// Emits a call to the specified target intrinsic with the given operands.
+// Emits IR to call a device function named "callee_name" on the given
+// operand. Returns the IR value that represents the return value.
+llvm::CallInst* EmitDeviceFunctionCall(
+    const std::string& callee_name, absl::Span<llvm::Value* const> operands,
+    absl::Span<const PrimitiveType> input_type, PrimitiveType output_type,
+    absl::Span<const llvm::Attribute::AttrKind> attributes,
+    llvm::IRBuilder<>* b);
 
+// Emits a call to the specified target intrinsic with the given operands.
 // Overloaded intrinsics (for example, "minnum") must include a type
 // in overloaded_types  for each overloaded type. Typically, overloaded
 // intrinsics have only a single overloaded type.


### PR DESCRIPTION
- Remove `EmitDeviceFunctionCall` from a member function in `GpuElementalIrEmitter` and put inside `target_util` module.
- Revise `TargetIntrinsics` in `target_util` module so it could contain either an LLVM intrinsic, or a custom function. This is to cope with the fact that certain operations on AMDGPU target aren't mapped to LLVM intrinsics but rather than device library functions.
- Remove explicit dependency to NVVM intrinsics in IR emitters.