### PR TITLE
[ROCm] Adding support to rnn ops

### DIFF
--- a/tensorflow/core/kernels/rnn/BUILD
+++ b/tensorflow/core/kernels/rnn/BUILD
@@ -10,6 +10,10 @@ load(
     "//tensorflow/core:platform/default/cuda_build_defs.bzl",
     "if_cuda_is_configured",
 )
+load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    "if_rocm_is_configured",
+)
 
 package(
     default_visibility = ["//tensorflow:internal"],
@@ -19,7 +23,8 @@ licenses(["notice"])  # Apache 2.0
 
 tf_gpu_library(
     name = "blas_gemm",
-    srcs = if_cuda_is_configured(["blas_gemm.cc"]),
+    srcs = if_cuda_is_configured(["blas_gemm.cc"])
+    + if_rocm_is_configured(["blas_gemm.cc"]),
     hdrs = ["blas_gemm.h"],
     deps = [
         "//tensorflow/core:framework",

--- a/tensorflow/core/kernels/rnn/BUILD
+++ b/tensorflow/core/kernels/rnn/BUILD
@@ -23,8 +23,11 @@ licenses(["notice"])  # Apache 2.0
 
 tf_gpu_library(
     name = "blas_gemm",
-    srcs = if_cuda_is_configured(["blas_gemm.cc"])
-    + if_rocm_is_configured(["blas_gemm.cc"]),
+    srcs = [] + if_cuda_is_configured([
+        "blas_gemm.cc",
+    ]) + if_rocm_is_configured([
+        "blas_gemm.cc",
+    ]),
     hdrs = ["blas_gemm.h"],
     deps = [
         "//tensorflow/core:framework",

--- a/tensorflow/core/kernels/rnn/blas_gemm.cc
+++ b/tensorflow/core/kernels/rnn/blas_gemm.cc
@@ -15,15 +15,15 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/platform/stream_executor.h"
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/kernels/rnn/blas_gemm.h"
 namespace tensorflow {
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace {
 template <typename T>
 se::DeviceMemory<T> AsDeviceMemory(const T* cuda_memory) {
@@ -32,7 +32,7 @@ se::DeviceMemory<T> AsDeviceMemory(const T* cuda_memory) {
   return typed;
 }
 }  // namespace
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace functor {
 template <typename T>
@@ -41,7 +41,7 @@ void TensorCuBlasGemm<T>::operator()(OpKernelContext* ctx, bool transa,
                                      float alpha, const T* a, int lda,
                                      const T* b, int ldb, float beta, T* c,
                                      int ldc) {
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
                                  se::blas::Transpose::kTranspose};
 

--- a/tensorflow/core/kernels/rnn/gru_ops.cc
+++ b/tensorflow/core/kernels/rnn/gru_ops.cc
@@ -380,7 +380,7 @@ REGISTER_KERNEL(float);
 #undef REGISTER_KERNEL
 
 // GPU support.
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 
 // Forward declare the GPU Fprop functor.
@@ -445,6 +445,6 @@ DECLARE_GPU_SPEC(float);
 
 REGISTER_GPU_KERNEL(float);
 #undef REGISTER_GPU_KERNEL
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // end namespace tensorflow

--- a/tensorflow/core/kernels/rnn/gru_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/rnn/gru_ops_gpu.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 #include "tensorflow/core/kernels/rnn/gru_ops.h"
@@ -32,4 +32,4 @@ DEFINE_GPU_SPECS(float);
 
 }  // end namespace functor
 }  // end namespace tensorflow
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/rnn/lstm_ops.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops.cc
@@ -15,9 +15,9 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #include "tensorflow/core/kernels/rnn/lstm_ops.h"
 
@@ -378,7 +378,7 @@ REGISTER_KERNEL(float);
 REGISTER_KERNEL(Eigen::half);
 #undef REGISTER_KERNEL
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace functor {
 #define DECLARE_GPU_SPEC(T)                                                \
   template <>                                                              \
@@ -412,7 +412,7 @@ REGISTER_GPU_KERNEL(float);
 REGISTER_GPU_KERNEL(Eigen::half);
 // REGISTER_GPU_KERNEL(double);
 #undef REGISTER_GPU_KERNEL
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 template <typename Device, typename T, bool USE_CUBLAS>
 class LSTMBlockCellGradOp : public OpKernel {
@@ -665,7 +665,7 @@ REGISTER_KERNEL(float);
 REGISTER_KERNEL(Eigen::half);
 #undef REGISTER_KERNEL
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace functor {
 #define DECLARE_GPU_SPEC(T)                                                   \
   template <>                                                                 \
@@ -707,7 +707,7 @@ REGISTER_GPU_KERNEL(float);
 REGISTER_GPU_KERNEL(Eigen::half);
 // REGISTER_GPU_KERNEL(double);
 #undef REGISTER_GPU_KERNEL
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace {
 
@@ -1012,7 +1012,7 @@ REGISTER_KERNEL(float);
 REGISTER_KERNEL(Eigen::half);
 #undef REGISTER_KERNEL
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace functor {
 #define DECLARE_GPU_SPEC(T)                                              \
   template <>                                                            \
@@ -1044,7 +1044,7 @@ REGISTER_GPU_KERNEL(float);
 REGISTER_GPU_KERNEL(Eigen::half);
 // REGISTER_GPU_KERNEL(double);
 #undef REGISTER_GPU_KERNEL
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 template <typename Device, typename T, bool USE_CUBLAS>
 class BlockLSTMGradOp : public OpKernel {
@@ -1287,7 +1287,7 @@ REGISTER_KERNEL(float);
 REGISTER_KERNEL(Eigen::half);
 #undef REGISTER_KERNEL
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace functor {
 #define DECLARE_GPU_SPEC(T)                                                    \
   template <>                                                                  \
@@ -1355,6 +1355,6 @@ REGISTER_GPU_KERNEL(float);
 REGISTER_GPU_KERNEL(Eigen::half);
 // REGISTER_GPU_KERNEL(double);
 #undef REGISTER_GPU_KERNEL
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // end namespace tensorflow

--- a/tensorflow/core/kernels/rnn/lstm_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops_gpu.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -460,4 +460,4 @@ DEFINE_GPU_SPECS(Eigen::half);
 
 }  // end namespace functor
 }  // end namespace tensorflow
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
Add ROCm support to core/kernels/rnn/*. The code change is trivial, please review and merge. @whchung @chsigg 

------
Test performed:

//tensorflow/contrib/rnn:lstm_ops_test
//tensorflow/contrib/rnn:gru_ops_test
//tensorflow/contrib/rnn:fused_rnn_cell_test
//tensorflow/contrib/rnn:rnn_test