### PR TITLE
Opt out DEVICE_GPU_XLA_JIT and DEVICE_XLA_GPU from ResizeNearestNeigh…

### DIFF
--- a/tensorflow/compiler/jit/compilability_check_util.cc
+++ b/tensorflow/compiler/jit/compilability_check_util.cc
@@ -265,7 +265,10 @@ bool RecursiveCompilabilityChecker::OpIsSlow(const Node& node) const {
   // b/135640736: MatrixInverse performance issues.
   return node.type_string() == "SelfAdjointEigV2" ||
          node.type_string() == "Svd" || node.type_string() == "Qr" ||
-         node.type_string() == "MatrixInverse";
+         node.type_string() == "MatrixInverse" ||
+         node.type_string() == "ResizeNearestNeighbor" ||
+         node.type_string() == "ResizeBilinear" ||
+         node.type_string() == "ResizeBilinearGrad";
 }
 
 bool RecursiveCompilabilityChecker::IsCompilableNode(

--- a/tensorflow/compiler/jit/compilability_check_util.cc
+++ b/tensorflow/compiler/jit/compilability_check_util.cc
@@ -263,6 +263,9 @@ bool RecursiveCompilabilityChecker::OpIsInaccurate(const Node& node) const {
 bool RecursiveCompilabilityChecker::OpIsSlow(const Node& node) const {
   // b/128001705: SelfAdjointEigV2 and Svd performance issues.
   // b/135640736: MatrixInverse performance issues.
+  // https://github.com/tensorflow/tensorflow/pull/31012:
+  //    ResizeNearestNeighbor, ResizeBilinear, and ResizeBilinearGrad sometimes
+  //    create convolutions too large for CuDNN to handle.
   return node.type_string() == "SelfAdjointEigV2" ||
          node.type_string() == "Svd" || node.type_string() == "Qr" ||
          node.type_string() == "MatrixInverse" ||

--- a/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
@@ -587,13 +587,7 @@ void ResizeNearestNeighborOp::Compile(XlaOpKernelContext* ctx) {
   GeneralCompile(ctx, align_corners_, is_kernel_bilinear_);
 }
 
-REGISTER_XLA_OP(Name("ResizeNearestNeighbor")
-                    .Device(DEVICE_CPU_XLA_JIT)
-                    .CompileTimeConstantInput("size"),
-                ResizeNearestNeighborOp);
-REGISTER_XLA_OP(Name("ResizeNearestNeighbor")
-                    .Device(DEVICE_XLA_CPU)
-                    .CompileTimeConstantInput("size"),
+REGISTER_XLA_OP(Name("ResizeNearestNeighbor").CompileTimeConstantInput("size"),
                 ResizeNearestNeighborOp);
 
 ResizeBilinearOp::ResizeBilinearOp(OpKernelConstruction* ctx)
@@ -610,13 +604,7 @@ void ResizeBilinearOp::Compile(XlaOpKernelContext* ctx) {
   GeneralCompile(ctx, align_corners_, is_kernel_bilinear_);
 }
 
-REGISTER_XLA_OP(Name("ResizeBilinear")
-                    .Device(DEVICE_CPU_XLA_JIT)
-                    .CompileTimeConstantInput("size"),
-                ResizeBilinearOp);
-REGISTER_XLA_OP(Name("ResizeBilinear")
-                    .Device(DEVICE_XLA_CPU)
-                    .CompileTimeConstantInput("size"),
+REGISTER_XLA_OP(Name("ResizeBilinear").CompileTimeConstantInput("size"),
                 ResizeBilinearOp);
 
 ResizeBilinearGradOp::ResizeBilinearGradOp(OpKernelConstruction* ctx)
@@ -710,7 +698,6 @@ void ResizeBilinearGradOp::Compile(XlaOpKernelContext* ctx) {
   ctx->SetOutput(0, output);
 }
 
-REGISTER_XLA_OP(Name("ResizeBilinearGrad").Device(DEVICE_CPU_XLA_JIT), ResizeBilinearGradOp);
-REGISTER_XLA_OP(Name("ResizeBilinearGrad").Device(DEVICE_XLA_CPU), ResizeBilinearGradOp);
+REGISTER_XLA_OP(Name("ResizeBilinearGrad"), ResizeBilinearGradOp);
 
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
@@ -587,7 +587,13 @@ void ResizeNearestNeighborOp::Compile(XlaOpKernelContext* ctx) {
   GeneralCompile(ctx, align_corners_, is_kernel_bilinear_);
 }
 
-REGISTER_XLA_OP(Name("ResizeNearestNeighbor").CompileTimeConstantInput("size"),
+REGISTER_XLA_OP(Name("ResizeNearestNeighbor")
+                    .Device(DEVICE_CPU_XLA_JIT)
+                    .CompileTimeConstantInput("size"),
+                ResizeNearestNeighborOp);
+REGISTER_XLA_OP(Name("ResizeNearestNeighbor")
+                    .Device(DEVICE_XLA_CPU)
+                    .CompileTimeConstantInput("size"),
                 ResizeNearestNeighborOp);
 
 ResizeBilinearOp::ResizeBilinearOp(OpKernelConstruction* ctx)
@@ -604,7 +610,13 @@ void ResizeBilinearOp::Compile(XlaOpKernelContext* ctx) {
   GeneralCompile(ctx, align_corners_, is_kernel_bilinear_);
 }
 
-REGISTER_XLA_OP(Name("ResizeBilinear").CompileTimeConstantInput("size"),
+REGISTER_XLA_OP(Name("ResizeBilinear")
+                    .Device(DEVICE_CPU_XLA_JIT)
+                    .CompileTimeConstantInput("size"),
+                ResizeBilinearOp);
+REGISTER_XLA_OP(Name("ResizeBilinear")
+                    .Device(DEVICE_XLA_CPU)
+                    .CompileTimeConstantInput("size"),
                 ResizeBilinearOp);
 
 ResizeBilinearGradOp::ResizeBilinearGradOp(OpKernelConstruction* ctx)
@@ -698,6 +710,7 @@ void ResizeBilinearGradOp::Compile(XlaOpKernelContext* ctx) {
   ctx->SetOutput(0, output);
 }
 
-REGISTER_XLA_OP(Name("ResizeBilinearGrad"), ResizeBilinearGradOp);
+REGISTER_XLA_OP(Name("ResizeBilinearGrad").Device(DEVICE_CPU_XLA_JIT), ResizeBilinearGradOp);
+REGISTER_XLA_OP(Name("ResizeBilinearGrad").Device(DEVICE_XLA_CPU), ResizeBilinearGradOp);
 
 }  // namespace tensorflow


### PR DESCRIPTION
@sanjoy, this is the follow-up of our discussion.  This PR is mainly for discussion purpose at this moment.  I am also holding merging for PR (https://github.com/tensorflow/tensorflow/pull/30336), as it may not be necessary, if we decide to opt out GPU devices. 
 
Dilation-based resizing may create huge convolution for CuDNN.  For example: nearest neighbor resizing from 16x256x256x16 to 16x512x512x16.  The sizes are reasonable.
The following transforms create giant convolutions:
1. TF2XLA elaborates nearest neighbor resizing into two 1-D convolutions with window size 1021x1, but requires dilation on feature by 511 (not dilation on kernel), i.e.
{ conv(16x256x256x16, 1x1021x1x16, dilation on feature by 511 in dim0) -> conv(16x512x256x16, 1x1x1021x16, dilation on feature by 511 in dim1) }
2. cudnn_conv_padding_legalization sees the feature dilation.  It removes the feature dilation from the conv and adds physical padding to the input features, because cudnn only has kernel, but not feature dilation, i.e.
{ pad(16x256x256x16, pad 510 zeros before, between, and after pixels in dim0) -> conv(16x131326x256x16, 1x1021x1x16) -> pad(16x512x256x16, pad 510 zeros before, between, and after pixels in dim1)->conv(16x512x131326x16, 1x1x1021x16) }
It causes an error because cudnn doesn't allow tensor to have more than 2G elements, while the first padded tensor has 8G and the second one 16G.

A possible solution is to use a GEMM-based interpolation approach to replace the dilation-based convolution one for some cases during Op::compile().  Before alternative resizing algorithm is available, how about opting out GPU from these OPs to avoid failing entire XLA?  For U-net using multiple resizing ops, leaving nearest neighbor resizing out of XLA doesn't cause observable slow down.