### PR TITLE
Fix inconsistent default learning rate in tensorflow.keras.optimizers.Adadelta()

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/adadelta.py
+++ b/tensorflow/python/keras/optimizer_v2/adadelta.py
@@ -59,7 +59,7 @@ class Adadelta(optimizer_v2.OptimizerV2):
   """
 
   def __init__(self,
-               learning_rate=0.001,
+               learning_rate=1.0,
                rho=0.95,
                epsilon=1e-7,
                name='Adadelta',


### PR DESCRIPTION
Fixing [#31024 issue](https://github.com/tensorflow/tensorflow/issues/31024) of inconsistencies between tensorflow.keras.optimizers.Adadelta() and keras.optimizers.Adadelta().