### PR TITLE
Fix incorrect usage of execution plan in GPU delegate

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/model_builder.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder.cc
@@ -2245,9 +2245,10 @@ TfLiteIntArray* GetOpsToReplaceFromGraphWithDequantize(TfLiteContext* context) {
     std::vector<int> inputs_from_dequant;
     std::vector<int> orig_inputs;
 
+    int node_id = execution_plan->data[i];
     TfLiteNode* node = nullptr;
     TfLiteRegistration* registration = nullptr;
-    auto status = GetNodeAndRegistration(context, i, &node, &registration);
+    auto status = GetNodeAndRegistration(context, node_id, &node, &registration);
     if (!status.ok()) {
       context->ReportError(context, status.error_message().c_str());
       return nullptr;
@@ -2258,9 +2259,9 @@ TfLiteIntArray* GetOpsToReplaceFromGraphWithDequantize(TfLiteContext* context) {
       // Record the output->input mapping for the op.
       node_map[node->outputs->data[0]] = node->inputs->data[0];
       // For now, add the node to the list of ops to replace.
-      ops_to_replace.push_back(i);
+      ops_to_replace.push_back(node_id);
       // Record the dequant node id, indexed by output id.
-      dequant_nodes[node->outputs->data[0]] = i;
+      dequant_nodes[node->outputs->data[0]] = node_id;
       continue;
     }
     TfLiteIntArray* inputs = node->inputs;
@@ -2337,9 +2338,10 @@ TfLiteIntArray* GetOpsToReplace(TfLiteContext* context) {
 
   // Dispatch to another function if graph has Dequantize nodes.
   for (int i = 0; i < execution_plan->size; ++i) {
+    int node_id = execution_plan->data[i];
     TfLiteNode* node = nullptr;
     TfLiteRegistration* registration = nullptr;
-    auto status = GetNodeAndRegistration(context, i, &node, &registration);
+    auto status = GetNodeAndRegistration(context, node_id, &node, &registration);
     if (!status.ok()) {
       context->ReportError(context, status.error_message().c_str());
       return nullptr;
@@ -2356,9 +2358,10 @@ TfLiteIntArray* GetOpsToReplace(TfLiteContext* context) {
   subgraph->size = 0;
   std::set<std::string> errors;
   for (int i = 0; i < execution_plan->size; ++i) {
+    int node_id = execution_plan->data[i];
     TfLiteNode* node = nullptr;
     TfLiteRegistration* registration = nullptr;
-    auto status = GetNodeAndRegistration(context, i, &node, &registration);
+    auto status = GetNodeAndRegistration(context, node_id, &node, &registration);
     if (!status.ok()) {
       context->ReportError(context, status.error_message().c_str());
       return nullptr;
@@ -2369,7 +2372,7 @@ TfLiteIntArray* GetOpsToReplace(TfLiteContext* context) {
         // registration->builtin_code != kTfLiteBuiltinSub &&
         IsAllFloatTensors(context, node->inputs) &&
         IsAllFloatTensors(context, node->outputs)) {
-      if (errors.empty()) subgraph->data[subgraph->size++] = i;
+      if (errors.empty()) subgraph->data[subgraph->size++] = node_id;
     } else {
       errors.insert(GetOpNameByRegistration(registration) + ": " +
                     status.error_message());

--- a/tensorflow/lite/delegates/gpu/common/model_builder.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder.cc
@@ -2245,7 +2245,7 @@ TfLiteIntArray* GetOpsToReplaceFromGraphWithDequantize(TfLiteContext* context) {
     std::vector<int> inputs_from_dequant;
     std::vector<int> orig_inputs;
 
-    int node_id = execution_plan->data[i];
+    const int node_id = execution_plan->data[i];
     TfLiteNode* node = nullptr;
     TfLiteRegistration* registration = nullptr;
     auto status = GetNodeAndRegistration(context, node_id, &node, &registration);
@@ -2338,7 +2338,7 @@ TfLiteIntArray* GetOpsToReplace(TfLiteContext* context) {
 
   // Dispatch to another function if graph has Dequantize nodes.
   for (int i = 0; i < execution_plan->size; ++i) {
-    int node_id = execution_plan->data[i];
+    const int node_id = execution_plan->data[i];
     TfLiteNode* node = nullptr;
     TfLiteRegistration* registration = nullptr;
     auto status = GetNodeAndRegistration(context, node_id, &node, &registration);
@@ -2358,7 +2358,7 @@ TfLiteIntArray* GetOpsToReplace(TfLiteContext* context) {
   subgraph->size = 0;
   std::set<std::string> errors;
   for (int i = 0; i < execution_plan->size; ++i) {
-    int node_id = execution_plan->data[i];
+    const int node_id = execution_plan->data[i];
     TfLiteNode* node = nullptr;
     TfLiteRegistration* registration = nullptr;
     auto status = GetNodeAndRegistration(context, node_id, &node, &registration);


### PR DESCRIPTION
When checking supported ops, instead of using the node id values from the execution plan, the delegate was just using node ids 0..execution_plan.size. In a case where your graph has 20 nodes, and your execution plan covers nodes 5-20, this would instead build a subgraph out of nodes 0-15.