### PR TITLE
moved slice by class id before shape matching

### DIFF
--- a/tensorflow/python/keras/utils/metrics_utils.py
+++ b/tensorflow/python/keras/utils/metrics_utils.py
@@ -288,6 +288,12 @@ def update_confusion_matrix_variables(variables_to_update,
         'Invalid keys: {}. Valid variable key options are: "{}"'.format(
             invalid_keys, list(ConfusionMatrix)))
 
+  if top_k is not None:
+    y_pred = _filter_top_k(y_pred, top_k)
+  if class_id is not None:
+    y_true = y_true[..., class_id]
+    y_pred = y_pred[..., class_id]
+
   with ops.control_dependencies([
       check_ops.assert_greater_equal(
           y_pred,
@@ -305,12 +311,6 @@ def update_confusion_matrix_variables(variables_to_update,
       y_pred, y_true, sample_weight = (
           tf_losses_utils.squeeze_or_expand_dimensions(
               y_pred, y_true, sample_weight=sample_weight))
-
-  if top_k is not None:
-    y_pred = _filter_top_k(y_pred, top_k)
-  if class_id is not None:
-    y_true = y_true[..., class_id]
-    y_pred = y_pred[..., class_id]
 
   thresholds = to_list(thresholds)
   num_thresholds = len(thresholds)


### PR DESCRIPTION
Addressing issue https://github.com/tensorflow/tensorflow/issues/30983

If you passed sample weights and a class id to a keras metric it would
enforce that the predictions, labels and weights had the same shape
before slicing the labels and predictions, resulting in a shape mismatch
when trying to apply the weights later.