### PR TITLE
[tflite] fix incorrect conv params

### DIFF
--- a/tensorflow/lite/experimental/micro/kernels/conv_test.cc
+++ b/tensorflow/lite/experimental/micro/kernels/conv_test.cc
@@ -62,7 +62,7 @@ void TestConvFloat(std::initializer_list<int> input_dims_data,
   TfLiteConvParams builtin_data = {
       .padding = kTfLitePaddingValid,
       .stride_width = 2,
-      .stride_height = 2,
+      .stride_height = 0,
       .dilation_width_factor = 1,
       .dilation_height_factor = 1,
       .activation = kTfLiteActNone,


### PR DESCRIPTION
input shape's h,w is (2,4), and filter's is (2, 2)
so stride_height must to be 0.