### PR TITLE
Update README.md

### DIFF
--- a/tensorflow/contrib/makefile/README.md
+++ b/tensorflow/contrib/makefile/README.md
@@ -87,8 +87,9 @@ need to install the standalone toolchain, however.
 Assign your NDK location to $NDK_ROOT:
 
 ```bash
-export NDK_ROOT=/absolute/path/to/NDK/android-ndk-rxxx/
+export NDK_ROOT=/absolute/path/to/NDK/android-ndk-r14b
 ```
+Note : libtensorflow-core.a cannot be compiled with any ndk version above r14b.
 
 Download the graph if you haven't already:
 


### PR DESCRIPTION
libtensorflow-core.a can only be compiled with r14b and below.