### PR TITLE
Fix unique_ptr type

### DIFF
--- a/tensorflow/contrib/ignite/kernels/dataset/ignite_dataset_iterator.cc
+++ b/tensorflow/contrib/ignite/kernels/dataset/ignite_dataset_iterator.cc
@@ -379,7 +379,7 @@ Status IgniteDatasetIterator::LoadNextPage() {
 
 Status IgniteDatasetIterator::ReceivePage(int32_t page_size) {
   remainder_ = page_size;
-  page_ = std::unique_ptr<uint8_t>(new uint8_t[remainder_]);
+  page_ = std::unique_ptr<uint8_t[]>(new uint8_t[remainder_]);
   ptr_ = page_.get();
 
   uint64 start = Env::Default()->NowMicros();

--- a/tensorflow/contrib/ignite/kernels/dataset/ignite_dataset_iterator.h
+++ b/tensorflow/contrib/ignite/kernels/dataset/ignite_dataset_iterator.h
@@ -74,7 +74,7 @@ class IgniteDatasetIterator : public DatasetIterator<IgniteDataset> {
 
   mutex mutex_;
 
-  std::unique_ptr<uint8_t> page_;
+  std::unique_ptr<uint8_t[]> page_;
   uint8_t* ptr_;
 };
 


### PR DESCRIPTION
`std::unique_ptr<uint8_t>(new uint8_t[remainder_])` would be deleted using `delete` and not `delete[]`.