### PR TITLE
[Intel MKL] Fix "Missing 1-th output from" Crash caused by MKL MaxPooling

### DIFF
--- a/tensorflow/core/kernels/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl_maxpooling_op.cc
@@ -88,8 +88,10 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
         bool int8_forward_inference =
             std::is_same<T, qint8>::value || std::is_same<T, quint8>::value;
 
+        // Allocate an empty workspace tensor if not Quantized MaxPooling
+        // Because Quantized MaxPooling does not have backward pass
+        // Therefore no workspace, which is used to help backward pass in MKL
         if (!int8_forward_inference) {
-          // Allocate an empty workspace tensor if not Quantized MaxPooling
           const int kOutputWorkspaceIndex = 1;
           // output_ws_tensor is not really used, so using output_dims_mkl_order
           this->AllocateEmptyOutputTensor(context, kOutputWorkspaceIndex,

--- a/tensorflow/core/kernels/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl_pooling_ops_common.h
@@ -548,23 +548,21 @@ class MklPoolingOpBase : public OpKernel {
     if (pool_params->data_format == TensorFormat::FORMAT_NCHW) {
       output_tf_shape = MklDnnDimsToTFShape(output_dims_mkl_order);
     } else {
+      memory::dims output_dims_order;
       // determine Pooling2D (NHWC) or Pooling3D (NDHWC)
       if (this->ksize_.size() == 4) {
-        memory::dims output_dims_NHWC_order;
-        output_dims_NHWC_order = {pool_params->tensor_in_batch,
-                                  static_cast<int>(pool_params->out_height),
-                                  static_cast<int>(pool_params->out_width),
-                                  pool_params->out_depth};
-        output_tf_shape = MklDnnDimsToTFShape(output_dims_NHWC_order);
+        output_dims_order = {pool_params->tensor_in_batch,
+                             static_cast<int>(pool_params->out_height),
+                             static_cast<int>(pool_params->out_width),
+                             pool_params->out_depth};
       } else {
-        memory::dims output_dims_NDHWC_order;
-        output_dims_NDHWC_order = {pool_params->tensor_in_batch,
-                                   static_cast<int>(pool_params->out_planes),
-                                   static_cast<int>(pool_params->out_height),
-                                   static_cast<int>(pool_params->out_width),
-                                   pool_params->out_depth};
-        output_tf_shape = MklDnnDimsToTFShape(output_dims_NDHWC_order);
+        output_dims_order = {pool_params->tensor_in_batch,
+                             static_cast<int>(pool_params->out_planes),
+                             static_cast<int>(pool_params->out_height),
+                             static_cast<int>(pool_params->out_width),
+                             pool_params->out_depth};
       }
+      output_tf_shape = MklDnnDimsToTFShape(output_dims_order);
     }
     AllocateOutputSetMklShape(context, kOutputIndex, output_tensor,
                               output_tf_shape, output_mkl_shape);

--- a/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
@@ -205,6 +205,26 @@ class PoolingTest(test.TestCase):
         padding="VALID",
         expected=[29.5, 32.5, 50.5, 53.5, 176.5, 179.5, 197.5, 200.5])
 
+  def _MaxPool3DEmptyTensorOutputShape(self):
+    """Verifies the output shape of the max pooling function when tensor is empty.
+
+    Args: none
+    """
+    input_sizes = [0, 112, 112, 112, 64]
+
+    input_data = 1
+    input_tensor = constant_op.constant(input_data, shape=input_sizes,
+                                        name="input")
+    max_pool_3d = nn_ops.max_pool3d(
+        input_tensor,
+        ksize=[2, 2, 2],
+        strides=[2, 2, 2],
+        padding="VALID",
+        data_format="NDHWC",
+        name="max_pool_3d")
+    values = self.evaluate(max_pool_3d)
+    self.assertEqual(values.shape, (0, 56, 56, 56, 64))
+
   def _ConstructAndTestGradientForConfig(self,
                                          pool_func,
                                          input_sizes,


### PR DESCRIPTION
node having an extra workspace tensor as auxiliary output. Such output should never be left unallocated (0x0) even for cases that the output tensors are empty. If not, code will fail at this check in https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/common_runtime/executor.cc#L2034-L2042 (i.e. the if (val.tensor == nullptr) check ). In addition, only MKL MaxPool has such a workspace tensor. AvgPool does not and Quantized MaxPool does not.