### PR TITLE
Corrected typo in evaluate() method

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -814,7 +814,7 @@ class Model(network.Network):
         batch_size: Integer or `None`.
             Number of samples per gradient update.
             If unspecified, `batch_size` will default to 32.
-            Do not specify the `batch_size` is your data is in the
+            Do not specify the `batch_size` if your data is in the
             form of symbolic tensors, dataset, dataset iterators,
             generators, or `keras.utils.Sequence` instances (since they generate
             batches).


### PR DESCRIPTION
Instead of "Do not specify the batch_size IS your data is", it should be "Do not specify the batch_size IF your data is