### PR TITLE
KerasClassifier.score: Support `weighted_metrics`

### DIFF
--- a/tensorflow/python/keras/wrappers/scikit_learn.py
+++ b/tensorflow/python/keras/wrappers/scikit_learn.py
@@ -303,7 +303,7 @@ class KerasClassifier(BaseWrapper):
     if not isinstance(outputs, list):
       outputs = [outputs]
     for name, output in zip(self.model.metrics_names, outputs):
-      if name in ['accuracy', 'acc']:
+      if name in ['accuracy', 'acc', 'weighted_accuracy', 'weighted_acc']:
         return output
     raise ValueError('The model is not configured to compute accuracy. '
                      'You should pass `metrics=["accuracy"]` to '


### PR DESCRIPTION
**Background:**

`tf.keras.wrappers.scikit_learn.KerasClassifier` is a wrapper for `tf.keras.Model`.


**Problem:**

When [`tf.keras.Model.compile`](https://www.tensorflow.org/api_docs/python/tf/keras/Model#compile) is called with `weighted_metrics`,
it automatically [adds a `'weighted_'` prefix](https://github.com/tensorflow/tensorflow/blob/r1.14/tensorflow/python/keras/engine/training_utils.py#L796) to the metric's name.
I.e. `'acc'` becomes `'weighted_acc'`.
Even when the metric's `name` is set manually via its class initializer.

`KerasClassifier.score` on the other hand cares only for the metrics `'accuracy'` or `'acc'`,
but sometimes `tf.keras.Model.compile` is called only with `weighted_metrics` and not `metrics`.
And so these metrics are not found and an error is raised.


**Proposed solution:**

`KerasClassifier.score` should look for `'weighted_accuracy'` and `'weighted_acc'` too.