### PR TITLE
TPU support for training with scheduled sampling

### DIFF
--- a/tensorflow/contrib/seq2seq/python/ops/helper.py
+++ b/tensorflow/contrib/seq2seq/python/ops/helper.py
@@ -392,7 +392,7 @@ class ScheduledEmbeddingTrainingHelper(TrainingHelper):
       def maybe_sample():
         """Perform scheduled sampling."""
         sampling_mask = math_ops.cast(sample_ids > -1, base_next_inputs.dtype)
-        sampling_mask = tf.expand_dims(sampling_mask, axis=-1)
+        sampling_mask = array_ops.expand_dims(sampling_mask, axis=-1)
         outputs_sampled = self._embedding_fn(sample_ids)
         sampled_masked = sampling_mask * outputs_sampled
         not_sampled_masked = (1 - sampling_mask) * base_next_inputs

--- a/tensorflow/contrib/seq2seq/python/ops/helper.py
+++ b/tensorflow/contrib/seq2seq/python/ops/helper.py
@@ -392,8 +392,9 @@ class ScheduledEmbeddingTrainingHelper(TrainingHelper):
       def maybe_sample():
         """Perform scheduled sampling."""
         sampling_mask = math_ops.cast(sample_ids > -1, base_next_inputs.dtype)
+        # Embedding lookup will fail for negative samples for some embedding_fn.
+        outputs_sampled = self._embedding_fn(sample_ids + math_ops.cast(1 - sampling_mask, dtypes.int32))
         sampling_mask = array_ops.expand_dims(sampling_mask, axis=-1)
-        outputs_sampled = self._embedding_fn(sample_ids)
         sampled_masked = sampling_mask * outputs_sampled
         not_sampled_masked = (1 - sampling_mask) * base_next_inputs
         return sampled_masked + not_sampled_masked


### PR DESCRIPTION
Scheduled sampling in `tf.contrib.seq2seq` is implemented using form of `where` that is not supported on TPU. This PR modifies scheduled sampling helper so that it can be used to train on any device.