### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build

### DIFF
--- a/tensorflow/core/kernels/pooling_ops_common.cc
+++ b/tensorflow/core/kernels/pooling_ops_common.cc
@@ -383,6 +383,7 @@ void DnnPoolingGradOp<T>::Compute(
         context->eigen_device<Device>(), out_backprop.tensor<T, 4>(),
         transformed_output_backprop.tensor<T, 4>());
   }
+  se::dnn::DataLayout data_layout = se::dnn::DataLayout::kBatchDepthYX;
 #else
   Tensor transformed_input;
   if (!tensor_in) {


### PR DESCRIPTION
The following PR/commit breaks the `--config=rocm` build

https://github.com/tensorflow/tensorflow/pull/30997

It introduces a declaration of the variable "data_layout" , within only the #else section of a #if-else block, and then adds a reference to "data_layout" outside of that #if-else block. Since the ROCm build takes #if path, the declaration for "data_layout" is missing, leading to the compile error on the reference to it.

The fix is add the corresponding declaration for "data_layout" in the #if section.

------------------------------------------------------------------

@tatianashp @whchung @chsigg 
