### PR TITLE
Fix duplicate node name in graph for tf.concat

### DIFF
--- a/tensorflow/contrib/gan/python/eval/python/classifier_metrics_test.py
+++ b/tensorflow/contrib/gan/python/eval/python/classifier_metrics_test.py
@@ -366,7 +366,7 @@ class ClassifierMetricsTest(test.TestCase, parameterized.TestCase):
     incscore = _run_with_mock(classifier_metrics.inception_score, unused_image)
 
     with self.cached_session(use_gpu=True) as sess:
-      incscore_np = sess.run(incscore, {'concat:0': logits})
+      incscore_np = sess.run(incscore, {'concat/concat:0': logits})
 
     self.assertAllClose(_expected_inception_score(logits), incscore_np)
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1385,7 +1385,7 @@ def concat(values, axis, name="concat"):
       ops.convert_to_tensor(
           axis, name="concat_dim",
           dtype=dtypes.int32).get_shape().assert_has_rank(0)
-      return identity(values[0], name=scope)
+      return identity(values[0], name=name)
   return gen_array_ops.concat_v2(values=values, axis=axis, name=name)
 
 


### PR DESCRIPTION
This fix tries to address the issue raised in #31137 where
`Duplicate node name in graph: 'concat'` shown up with the
following:
```
import tensorflow as tf
from tensorflow.keras import Input

print('Using Tensorflow version {} (git version {})'.format(tf.version.VERSION, tf.version.GIT_VERSION))

i = Input(shape=3)
j = Input(shape=4)
try:
    print(tf.concat([i, j], axis=-1))
except Exception as e:
    print(type(e))
    print(e)
try:
    print(tf.concat([i, j], axis=-1))
except Exception as e:
    print(type(e))
    print(e)
try:
    print(tf.concat([i], axis=-1))
except Exception as e:
    print(type(e))
    print(e)
try:
    print(tf.concat(i, axis=-1))
except Exception as e:
    print(type(e))
    print(e)
```

The issue was that `identity` node passed the scope as the name.
This fix fixes the issue.

This fix fixes #31137.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>