### PR TITLE
Fix compile error on MacOS

### DIFF
--- a/tensorflow/core/kernels/eigen_mkldnn_contraction_kernel_test.cc
+++ b/tensorflow/core/kernels/eigen_mkldnn_contraction_kernel_test.cc
@@ -21,7 +21,6 @@ limitations under the License.
 #include "tensorflow/core/kernels/eigen_contraction_kernel.h"
 #include "tensorflow/core/platform/test.h"
 
-
 namespace Eigen {
 namespace internal {
 

--- a/tensorflow/core/kernels/eigen_mkldnn_contraction_kernel_test.cc
+++ b/tensorflow/core/kernels/eigen_mkldnn_contraction_kernel_test.cc
@@ -13,9 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+// Need to #include Eigen's Tensor class first because Eigen/CXX11/FixedPoint
+// depends on the file but doesn't include it. This breaks compilation on
+// clang.
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/FixedPoint"
 #include "tensorflow/core/kernels/eigen_contraction_kernel.h"
 #include "tensorflow/core/platform/test.h"
+
 
 namespace Eigen {
 namespace internal {

--- a/tensorflow/core/kernels/eigen_mkldnn_contraction_kernel_test.cc
+++ b/tensorflow/core/kernels/eigen_mkldnn_contraction_kernel_test.cc
@@ -16,7 +16,9 @@ limitations under the License.
 // Need to #include Eigen's Tensor class first because Eigen/CXX11/FixedPoint
 // depends on the file but doesn't include it. This breaks compilation on
 // clang.
+// clang-format off
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+// clang-format on
 #include "third_party/eigen3/unsupported/Eigen/CXX11/FixedPoint"
 #include "tensorflow/core/kernels/eigen_contraction_kernel.h"
 #include "tensorflow/core/platform/test.h"


### PR DESCRIPTION
The test case for optimized contraction kernels depends on some hard-coded Eigen kernels for 8- and 16-bit data types. These kernels are implemented in `Eigen/CXX11/src/FixedPoint/MatMatProductAVX2.h` as hard-coded specializations of the templated class `TensorContractionBlocking`. At the point that these specializations are declared, the underlying `TensorContractionBlocking` class is not in scope. This missing forward declaration causes `clang` to exit with an error, which prevents the target `//tensorflow/core/kernels:eigen_mkldnn_contraction_kernel_test` from compiling on MacOS.

This PR adds an additional `#include` to the test file that ensures that `TensorContractionBlocking` has been defined at the point that `MatMatProductAVX2.h` specializes it. This change fixes the compilation problem on my Mac environment.