### PR TITLE
[LITE] Create the objects to hold the tensor data in elementwise_test and recognize_commands_test.

### DIFF
--- a/tensorflow/lite/experimental/micro/examples/micro_speech/recognize_commands_test.cc
+++ b/tensorflow/lite/experimental/micro/examples/micro_speech/recognize_commands_test.cc
@@ -78,8 +78,10 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestBasic) {
 
   RecognizeCommands recognize_commands(error_reporter);
 
+  std::initializer_list<uint8_t> result_data = {255, 0, 0, 0};
+  auto result_dims = {2, 1, 4};
   TfLiteTensor results = tflite::testing::CreateQuantizedTensor(
-      {255, 0, 0, 0}, tflite::testing::IntArrayFromInitializer({2, 1, 4}),
+      result_data, tflite::testing::IntArrayFromInitializer(result_dims),
       "input_tensor", 0.0f, 128.0f);
 
   const char* found_command;
@@ -96,8 +98,10 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestFindCommands) {
 
   RecognizeCommands recognize_commands(error_reporter, 1000, 51);
 
+  std::initializer_list<uint8_t> yes_data = {0, 0, 255, 0};
+  auto yes_dims = {2, 1, 4};
   TfLiteTensor yes_results = tflite::testing::CreateQuantizedTensor(
-      {0, 0, 255, 0}, tflite::testing::IntArrayFromInitializer({2, 1, 4}),
+      yes_data, tflite::testing::IntArrayFromInitializer(yes_dims),
       "input_tensor", 0.0f, 128.0f);
 
   bool has_found_new_command = false;
@@ -122,8 +126,10 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestFindCommands) {
     TF_LITE_MICRO_EXPECT_EQ(0, tflite::testing::TestStrcmp("yes", new_command));
   }
 
+  std::initializer_list<uint8_t> no_data = {0, 0, 0, 255};
+  auto no_dims = {2, 1, 4};
   TfLiteTensor no_results = tflite::testing::CreateQuantizedTensor(
-      {0, 0, 0, 255}, tflite::testing::IntArrayFromInitializer({2, 1, 4}),
+      no_data, tflite::testing::IntArrayFromInitializer(no_dims),
       "input_tensor", 0.0f, 128.0f);
   has_found_new_command = false;
   new_command = "";
@@ -155,8 +161,10 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestBadInputLength) {
 
   RecognizeCommands recognize_commands(error_reporter, 1000, 51);
 
+  std::initializer_list<uint8_t> bad_data = {0, 0, 255};
+  auto bad_dims = {2, 1, 3};
   TfLiteTensor bad_results = tflite::testing::CreateQuantizedTensor(
-      {0, 0, 255}, tflite::testing::IntArrayFromInitializer({2, 1, 3}),
+      bad_data, tflite::testing::IntArrayFromInitializer(bad_dims),
       "input_tensor", 0.0f, 128.0f);
 
   const char* found_command;
@@ -173,8 +181,10 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestBadInputTimes) {
 
   RecognizeCommands recognize_commands(error_reporter, 1000, 51);
 
+  std::initializer_list<uint8_t> result_data = {0, 0, 255, 0};
+  auto result_dims = {2, 1, 4};
   TfLiteTensor results = tflite::testing::CreateQuantizedTensor(
-      {0, 0, 255, 0}, tflite::testing::IntArrayFromInitializer({2, 1, 4}),
+      result_data, tflite::testing::IntArrayFromInitializer(result_dims),
       "input_tensor", 0.0f, 128.0f);
 
   const char* found_command;
@@ -194,8 +204,10 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestTooFewInputs) {
 
   RecognizeCommands recognize_commands(error_reporter, 1000, 51);
 
+  std::initializer_list<uint8_t> result_data = {0, 0, 255, 0};
+  auto result_dims = {2, 1, 4};
   TfLiteTensor results = tflite::testing::CreateQuantizedTensor(
-      {0, 0, 255, 0}, tflite::testing::IntArrayFromInitializer({2, 1, 4}),
+      result_data, tflite::testing::IntArrayFromInitializer(result_dims),
       "input_tensor", 0.0f, 128.0f);
 
   const char* found_command;

--- a/tensorflow/lite/experimental/micro/kernels/elementwise_test.cc
+++ b/tensorflow/lite/experimental/micro/kernels/elementwise_test.cc
@@ -54,9 +54,12 @@ void TestElementwiseFloat(std::initializer_list<int> input_dims_data,
   if (registration->init) {
     user_data = registration->init(&context, nullptr, 0);
   }
-  TfLiteIntArray* inputs_array = IntArrayFromInitializer({1, 0});
-  TfLiteIntArray* outputs_array = IntArrayFromInitializer({1, 1});
-  TfLiteIntArray* temporaries_array = IntArrayFromInitializer({0});
+  auto inputs_array_data = {1, 0};
+  TfLiteIntArray* inputs_array = IntArrayFromInitializer(inputs_array_data);
+  auto outputs_array_data = {1, 1};
+  TfLiteIntArray* outputs_array = IntArrayFromInitializer(outputs_array_data);
+  auto temporaries_array_data = {0};
+  TfLiteIntArray* temporaries_array = IntArrayFromInitializer(temporaries_array_data);
 
   TfLiteNode node;
   node.inputs = inputs_array;


### PR DESCRIPTION
The elementwise_test and recognize_commands_test use the deleted temporary object. That might cause the wrong result. I can't pass these two tests locally.

This pr creates some local variables to hold the tensor data.