### PR TITLE
Make swish an inlinable function

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -29,6 +29,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import candidate_sampling_ops
 from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import custom_gradient
 from tensorflow.python.ops import embedding_ops
 from tensorflow.python.ops import gen_array_ops  # pylint: disable=unused-import
 from tensorflow.python.ops import gen_nn_ops
@@ -499,32 +500,8 @@ def relu_layer(x, weights, biases, name=None):
     return nn_ops.relu(xw_plus_b, name=name)
 
 
-def _swish_shape(op):
-  """Shape helper function for swish and _swish_grad function below."""
-  return [op.inputs[0].shape]
-
-
-@function.Defun(shape_func=_swish_shape, func_name="swish_grad")
-def _swish_grad(features, grad):
-  """Gradient of Swish function defined below."""
-  # Naively, x * tf.nn.sigmoid(x) requires keeping both x and sigmoid(x) around
-  # for backprop, effectively doubling the tensor's memory consumption. We use a
-  # control dependency here so that sigmoid(features) is re-computed during
-  # backprop (the control dep prevents it being de-duped with the forward pass)
-  # and we can free the sigmoid(features) expression immediately after use
-  # during the forward pass.
-  with ops.control_dependencies([grad]):
-    sigmoid_features = math_ops.sigmoid(features)
-  activation_grad = (
-      sigmoid_features * (1.0 + features * (1.0 - sigmoid_features)))
-  return grad * activation_grad
-
-
 @tf_export("nn.swish")
-@function.Defun(
-    grad_func=_swish_grad,
-    shape_func=_swish_shape,
-    func_name="swish")
+@custom_gradient.custom_gradient
 def swish(features):
   # pylint: disable=g-doc-args
   """Computes the Swish activation function: `x * sigmoid(x)`.
@@ -541,7 +518,20 @@ def swish(features):
   """
   # pylint: enable=g-doc-args
   features = ops.convert_to_tensor(features, name="features")
-  return features * math_ops.sigmoid(features)
+  def grad(dy):
+    """Gradient for the Swish activation function"""
+    # Naively, x * tf.nn.sigmoid(x) requires keeping both x and sigmoid(x)
+    # around for backprop, effectively doubling the tensor's memory consumption.
+    # We use a control dependency here so that sigmoid(features) is re-computed
+    # during backprop (the control dep prevents it being de-duped with the
+    # forward pass) and we can free the sigmoid(features) expression immediately
+    # after use during the forward pass.
+    with ops.control_dependencies([dy]):
+      sigmoid_features = math_ops.sigmoid(features)
+    activation_grad = (
+        sigmoid_features * (1.0 + features * (1.0 - sigmoid_features)))
+    return dy * activation_grad
+  return features * math_ops.sigmoid(features), grad
 
 
 # pylint: disable=redefined-builtin

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -24,7 +24,6 @@ from tensorflow.python.compat import compat
 from tensorflow.python.distribute import distribution_strategy_context as ds
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import function
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import candidate_sampling_ops

--- a/tensorflow/tools/api/golden/v1/tensorflow.nn.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.nn.pbtxt
@@ -4,10 +4,6 @@ tf_module {
     name: "rnn_cell"
     mtype: "<type \'module\'>"
   }
-  member {
-    name: "swish"
-    mtype: "<class \'tensorflow.python.framework.function._OverloadedFunction\'>"
-  }
   member_method {
     name: "all_candidate_sampler"
     argspec: "args=[\'true_classes\', \'num_true\', \'num_sampled\', \'unique\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
@@ -403,6 +399,10 @@ tf_module {
   member_method {
     name: "sufficient_statistics"
     argspec: "args=[\'x\', \'axes\', \'shift\', \'keep_dims\', \'name\', \'keepdims\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\'], "
+  }
+  member_method {
+    name: "swish"
+    argspec: "args=[\'features\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "tanh"

--- a/tensorflow/tools/api/golden/v2/tensorflow.nn.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.nn.pbtxt
@@ -12,10 +12,6 @@ tf_module {
     name: "RNNCellResidualWrapper"
     mtype: "<type \'type\'>"
   }
-  member {
-    name: "swish"
-    mtype: "<class \'tensorflow.python.framework.function._OverloadedFunction\'>"
-  }
   member_method {
     name: "all_candidate_sampler"
     argspec: "args=[\'true_classes\', \'num_true\', \'num_sampled\', \'unique\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
@@ -311,6 +307,10 @@ tf_module {
   member_method {
     name: "sufficient_statistics"
     argspec: "args=[\'x\', \'axes\', \'shift\', \'keepdims\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'False\', \'None\'], "
+  }
+  member_method {
+    name: "swish"
+    argspec: "args=[\'features\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
     name: "tanh"


### PR DESCRIPTION
The implementation of swish currently uses a Defun that specifies noinline=True for the purpose of forcing recomputation of the sigmoid(x) tensor, instead of incurring the memory overhead of keeping it alive from the forward pass.

This detail (unique within the codebase) is undesirable because non-inlined functions are difficult to deal with inside graph optimization passes. E.g., the layout optimizer in grappler is currently unable to optimize through a non-inlined function call.

This commit changes the implementation of swish to achieve the same force-recomputation effect using a control dependency instead of setting noinline=True, allowing the function to be inlined and fully optimized by the backend.

Attn. @reedwm 
cc. @nluehr 