### PR TITLE
Cast `inputs` array to float64 in case of big endian architecture for normalization

### DIFF
--- a/nohup.out
+++ b/nohup.out
@@ -1,0 +1,6 @@
+Starting local Bazel server and connecting to it...
+INFO: Options provided by the client:
+  Inherited 'common' options: --isatty=0 --terminal_columns=80
+INFO: Reading rc options for 'build' from /home/test/tensorflow/.bazelrc:
+  'build' options: --apple_platform_type=macos --define framework_shared_object=true --define=use_fast_cpp_protos=true --define=allow_oversize_protos=true --spawn_strategy=standalone --strategy=Genrule=standalone -c opt --announce_rc --define=grpc_no_ares=true --define=PREFIX=/usr --define=LIBDIR=$(PREFIX)/lib --define=INCLUDEDIR=$(PREFIX)/include
+ERROR: Config value opt is not defined in any .rc file

--- a/nohup.out
+++ b/nohup.out
@@ -1,6 +1,0 @@
-Starting local Bazel server and connecting to it...
-INFO: Options provided by the client:
-  Inherited 'common' options: --isatty=0 --terminal_columns=80
-INFO: Reading rc options for 'build' from /home/test/tensorflow/.bazelrc:
-  'build' options: --apple_platform_type=macos --define framework_shared_object=true --define=use_fast_cpp_protos=true --define=allow_oversize_protos=true --spawn_strategy=standalone --strategy=Genrule=standalone -c opt --announce_rc --define=grpc_no_ares=true --define=PREFIX=/usr --define=LIBDIR=$(PREFIX)/lib --define=INCLUDEDIR=$(PREFIX)/include
-ERROR: Config value opt is not defined in any .rc file

--- a/tensorflow/contrib/layers/python/layers/normalization.py
+++ b/tensorflow/contrib/layers/python/layers/normalization.py
@@ -99,7 +99,7 @@ def instance_norm(inputs,
   # The cast to float64 will calculate mean and variance correctly while 
   # normalization of `inputs` tensor.
   if sys.byteorder == "big" and inputs.dtype.base_dtype == dtypes.float32:
-      inputs = math_ops.cast(inputs, dtypes.float64)
+    inputs = math_ops.cast(inputs, dtypes.float64)
 
   if inputs_rank is None:
     raise ValueError('Inputs %s has undefined rank.' % inputs.name)

--- a/tensorflow/contrib/layers/python/layers/normalization.py
+++ b/tensorflow/contrib/layers/python/layers/normalization.py
@@ -94,7 +94,10 @@ def instance_norm(inputs,
   inputs = ops.convert_to_tensor(inputs)
   inputs_shape = inputs.shape
   inputs_rank = inputs.shape.ndims
-  # Cast `inputs` array to float64 if machine is big endian
+  # For big endian, precision difference in last decimal values getting in 
+  # float32 Vs float64 data type is causing normalization_test failure. 
+  # The cast to float64 will calculate mean and variance correctly while 
+  # normalization of `inputs` tensor.
   if sys.byteorder == "big" and inputs.dtype.base_dtype == dtypes.float32:
       inputs = math_ops.cast(inputs, dtypes.float64)
 

--- a/tensorflow/contrib/layers/python/layers/normalization.py
+++ b/tensorflow/contrib/layers/python/layers/normalization.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
 
 from tensorflow.contrib.framework.python.ops import add_arg_scope
 from tensorflow.contrib.framework.python.ops import variables
@@ -27,7 +28,7 @@ from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn
 from tensorflow.python.ops import variable_scope
-
+from tensorflow.python.framework import dtypes
 
 __all__ = [
     'group_norm',
@@ -93,6 +94,9 @@ def instance_norm(inputs,
   inputs = ops.convert_to_tensor(inputs)
   inputs_shape = inputs.shape
   inputs_rank = inputs.shape.ndims
+  # Cast `inputs` array to float64 if machine is big endian
+  if sys.byteorder == "big" and inputs.dtype.base_dtype == dtypes.float32:
+      inputs = math_ops.cast(inputs, dtypes.float64)
 
   if inputs_rank is None:
     raise ValueError('Inputs %s has undefined rank.' % inputs.name)


### PR DESCRIPTION
These changes fixes https://github.com/tensorflow/tensorflow/issues/26135 