### PR TITLE
[MLIR] Attempt to fix build errors in MLIR transofmration.

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/transforms/executor_island_coarsening.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/executor_island_coarsening.cc
@@ -43,7 +43,7 @@ namespace {
 
 // IslandType is an enum representing if an island is the island (parent)
 // merging another island or is the island (child) being being merged.
-enum class IslandType : bool { kParentIsland, kChildIsland };
+enum IslandType { kParentIsland, kChildIsland };
 
 // Output is a helper struct holding a result index and island type (parent or
 // child).


### PR DESCRIPTION
This transformation pass seems to break on g++ 5.4. The commit attempts to
fix it. At least `//tensorflow/compiler/...` now pass after this commit.