### PR TITLE
To set default OMP_NUM_THREADS to a smaller value for unit tests.

### DIFF
--- a/tensorflow/tools/ci_build/linux/cpu/run_mkl.sh
+++ b/tensorflow/tools/ci_build/linux/cpu/run_mkl.sh
@@ -31,8 +31,19 @@ export PYTHON_BIN_PATH=`which python2`
 yes "" | $PYTHON_BIN_PATH configure.py
 if [[ "$MODE" == "eigen" ]]; then
     CONFIG=""
+    OMPTHREADS=""
 else
     CONFIG="--config=mkl"
+# Setting OMP_THREADS for low performing benchmarks.
+#   Default value(=core count) degrades perfrmance of some banchmark cases. 
+#   Optimal thread count is case specific. 
+#   An argument can be passed to script, the value of which is used if given.
+#   Otherwise OMP_NUM_THREADS is set to 10
+    if [[ -z $1 ]]; then
+        OMPTHREADS="--action_env=OMP_NUM_THREADS=10"
+    else 
+        OMPTHREADS="--action_env=OMP_NUM_THREADS=$1"
+    fi
 fi
 
 # Run bazel test command. Double test timeouts to avoid flakes.
@@ -41,5 +52,5 @@ fi
 # caused by executing multiple tests concurrently.
 bazel test --test_tag_filters=-no_oss,-no_oss_py2,-oss_serial,-gpu,-benchmark-test --test_lang_filters=cc,py -k \
     --jobs=${N_JOBS} --test_timeout 300,450,1200,3600 --build_tests_only \
-    ${CONFIG} --test_env=KMP_BLOCKTIME=0 --config=opt --test_output=errors -- \
+    ${CONFIG} --test_env=KMP_BLOCKTIME=0 ${OMPTHREADS} --config=opt --test_output=errors -- \
     //tensorflow/... -//tensorflow/compiler/... -//tensorflow/contrib/... -//tensorflow/lite/...


### PR DESCRIPTION
Current default value for OMP_NUM_THREDS is set to number of physical cores. This degrades performance for some of the performance test cases when run on machines with many cores. 
This change sets it to a lower default value (10) for these tests. Alternate values can be set from the command line for the script.