### PR TITLE
[INTEL MKL] Work around tf.data related performance regression on Int…

### DIFF
--- a/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op.cc
@@ -53,7 +53,11 @@ class MapAndBatchDatasetOp : public UnaryDatasetOpKernel {
   explicit MapAndBatchDatasetOp(OpKernelConstruction* ctx)
       : UnaryDatasetOpKernel(ctx) {
     FunctionMetadata::Params params;
+#ifdef INTEL_MKL
+    params.is_multi_device_function = false;
+#else
     params.is_multi_device_function = true;
+#endif
     OP_REQUIRES_OK(ctx,
                    FunctionMetadata::Create(ctx, "f", params, &func_metadata_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("output_types", &output_types_));


### PR DESCRIPTION
…el MKL backend.

RN50 real data performance regression was about 40%. This PR brings the
performance back by adding the MKL specific #ifdef macro.