### PR TITLE
Add _FusedBatchNormEx to auto_mixed_precision list

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -120,6 +120,7 @@ class AutoMixedPrecisionLists {
         "FusedBatchNormGradV2",
         "FusedBatchNormV3",
         "FusedBatchNormGradV3",
+        "_FusedBatchNormEx",
         "Inv",
         "LeakyRelu",
         "LeakyReluGrad",


### PR DESCRIPTION
This op is added by the remapper grappler pass, which runs before auto_mixed_precision.

attn. @reedwm 
cc. @nluehr 