### PR TITLE
[Intel MKL] Bugfix: MklSlice op crash on 3d shapes

### DIFF
--- a/tensorflow/core/kernels/mkl_slice_op.cc
+++ b/tensorflow/core/kernels/mkl_slice_op.cc
@@ -18,7 +18,6 @@ limitations under the License.
 #ifdef INTEL_MKL
 
 #include "mkldnn.hpp"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -27,6 +26,7 @@ limitations under the License.
 #include "tensorflow/core/lib/gtl/array_slice.h"
 #include "tensorflow/core/platform/prefetch.h"
 #include "tensorflow/core/util/mkl_util.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 using mkldnn::stream;
 using mkldnn::view;
@@ -396,8 +396,9 @@ class MklSliceOp : public OpKernel {
         auto input_tf_format = MklDnnDataFormatToTFDataFormat(input_mkl_format);
 
         bool is_slice2d = (input_mkl_shape.GetDimension() == 4);
-        begin_dims = is_slice2d ? MklDnnDimsInNCHW(begin_dims, input_tf_format)
-                                : MklDnnDimsInNCDHW(begin_dims, input_tf_format);
+        begin_dims = is_slice2d
+                         ? MklDnnDimsInNCHW(begin_dims, input_tf_format)
+                         : MklDnnDimsInNCDHW(begin_dims, input_tf_format);
         size_dims = is_slice2d ? MklDnnDimsInNCHW(size_dims, input_tf_format)
                                : MklDnnDimsInNCDHW(size_dims, input_tf_format);
         auto input_md = input_mkl_shape.GetMklLayout();

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1087,8 +1087,8 @@ inline memory::dims TFShapeToMklDnnDimsInNCDHW(const TensorShape& shape,
   return memory::dims({n, c, d, h, w});
 }
 
-/// Overloaded version of function above. Input parameters are
-/// self-explanatory.
+/// Overloaded version of function TFShapeToMklDnnDimsInNCHW above.
+/// Input parameters are self-explanatory.
 inline memory::dims MklDnnDimsInNCHW(const memory::dims& in_dims,
                                      TensorFormat format) {
   // Validate format.
@@ -1101,6 +1101,24 @@ inline memory::dims MklDnnDimsInNCHW(const memory::dims& in_dims,
 
   // MKL-DNN requires dimensions in NCHW format.
   return memory::dims({n, c, h, w});
+}
+
+/// Overloaded version of function TFShapeToMklDnnDimsInNCDHW above.
+/// Input parameters are self-explanatory.
+inline memory::dims MklDnnDimsInNCDHW(const memory::dims& in_dims,
+                                      TensorFormat format) {
+  // Check validity of format.
+  CHECK_NE(TFDataFormatToMklDnnDataFormat(format),
+           memory::format::format_undef);
+
+  int n = in_dims[GetTensorDimIndex<3>(format, 'N')];
+  int c = in_dims[GetTensorDimIndex<3>(format, 'C')];
+  int d = in_dims[GetTensorDimIndex<3>(format, '0')];
+  int h = in_dims[GetTensorDimIndex<3>(format, '1')];
+  int w = in_dims[GetTensorDimIndex<3>(format, '2')];
+
+  // MKL-DNN requires dimensions in NCDHW format.
+  return memory::dims({n, c, d, h, w});
 }
 
 /// Map MklDnn memory::dims object into TensorShape object.

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1107,7 +1107,7 @@ inline memory::dims MklDnnDimsInNCHW(const memory::dims& in_dims,
 /// Input parameters are self-explanatory.
 inline memory::dims MklDnnDimsInNCDHW(const memory::dims& in_dims,
                                       TensorFormat format) {
-  // Check validity of format.
+  // Validate format.
   CHECK_NE(TFDataFormatToMklDnnDataFormat(format),
            memory::format::format_undef);
 
@@ -1117,7 +1117,7 @@ inline memory::dims MklDnnDimsInNCDHW(const memory::dims& in_dims,
   int h = in_dims[GetTensorDimIndex<3>(format, '1')];
   int w = in_dims[GetTensorDimIndex<3>(format, '2')];
 
-  // MKL-DNN requires dimensions in NCDHW format.
+  // MKL DNN requires dimensions in NCDHW format.
   return memory::dims({n, c, d, h, w});
 }
 

--- a/tensorflow/python/kernel_tests/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/slice_op_test.py
@@ -28,6 +28,7 @@ from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import test
 
 
@@ -145,6 +146,18 @@ class SliceTest(test.TestCase):
         slice_t = a[lo:hi]
         slice_val = self.evaluate(slice_t)
         self.assertAllEqual(slice_val, inp[lo:hi])
+
+  def test3Dimension(self):
+    with self.session() as sess:
+      input_shape = [1, 8, 8, 8, 3]
+      inp = np.random.rand(*input_shape).astype("f")
+      a = constant_op.constant(inp, shape=input_shape, dtype=dtypes.float32)
+
+      filter_shape = [2, 2, 2, 3, 3]
+      filters = np.random.rand(*filter_shape).astype("f") 
+      conv_t = nn_ops.conv3d(a, filter=filters, strides=[1, 1, 1, 1, 1], padding="SAME")
+      slice_t = array_ops.slice(conv_t, [0, 0, 0, 0, 0], [1, 2, 1, 2, 1])
+      result = self.evaluate(slice_t)
 
   @test_util.run_deprecated_v1
   def testScalarInput(self):

--- a/tensorflow/python/kernel_tests/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/slice_op_test.py
@@ -154,8 +154,9 @@ class SliceTest(test.TestCase):
       a = constant_op.constant(inp, shape=input_shape, dtype=dtypes.float32)
 
       filter_shape = [2, 2, 2, 3, 3]
-      filters = np.random.rand(*filter_shape).astype("f") 
-      conv_t = nn_ops.conv3d(a, filter=filters, strides=[1, 1, 1, 1, 1], padding="SAME")
+      filters = np.random.rand(*filter_shape).astype("f")
+      conv_t = nn_ops.conv3d(a, filter=filters, strides=[1, 1, 1, 1, 1],
+                             padding="SAME")
       slice_t = array_ops.slice(conv_t, [0, 0, 0, 0, 0], [1, 2, 1, 2, 1])
       result = self.evaluate(slice_t)
 


### PR DESCRIPTION
We found 3d shapes (NCDHW / NDHWC) are not well supported in MklSlice op, and causes crashes on 3d-CNN models such as https://github.com/Youngseok0001/Intel_benchmark/tree/master/3D_CNN.

This PR is to enable 3d support in MklSlice op.