### PR TITLE
[INTEL MKL] Reverting changes made to Add + Conv fusion during MKL-DNN v1.x integration

### DIFF
--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -24,8 +24,8 @@ limitations under the License.
 #include <map>
 #include <vector>
 
-#include "mkldnn.hpp"
 #include "absl/strings/str_join.h"
+#include "mkldnn.hpp"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -567,17 +567,15 @@ class MklConvOp : public OpKernel {
       OP_REQUIRES(context, dilations_.size() == 5,
                   errors::InvalidArgument("Dilation rates field must "
                                           "specify 5 dimensions"));
-      OP_REQUIRES(context,
-                  (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
-                   GetTensorDim(dilations_, data_format_, 'C') == 1),
+      OP_REQUIRES(context, (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
+                            GetTensorDim(dilations_, data_format_, 'C') == 1),
                   errors::InvalidArgument(
                       "Current implementation does not yet support "
                       "dilations rates in the batch and depth dimensions."));
       OP_REQUIRES(
-          context,
-          (GetTensorDim(dilations_, data_format_, '0') > 0 &&
-           GetTensorDim(dilations_, data_format_, '1') > 0 &&
-           GetTensorDim(dilations_, data_format_, '2') > 0),
+          context, (GetTensorDim(dilations_, data_format_, '0') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '1') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '2') > 0),
           errors::InvalidArgument("Dilated rates should be larger than 0."));
     }
   }
@@ -972,40 +970,34 @@ class MklConvOp : public OpKernel {
     output_tf_shape.AddDim((DST_MD.get_size() / sizeof(Toutput)));
     AllocateOutputSetMklShape(context, kOutputIndex_Dst, output_tensor,
                               output_tf_shape, output_mkl_shape);
+    // TODO(bhavanis): Need to integrate the following Add fusion code with
+    // MKL-DNN v1.x
     if (fuse_add_) {
       const Tensor& add_tensor = MklGetInput(context, kInputIndex_Add);
       MklDnnShape add_mkl_shape;
       GetMklShape(context, kInputIndex_Add, &add_mkl_shape);
 
-      // Check if reorder is needed
+      // Check if need reorder
       if (add_mkl_shape == output_mkl_shape) {
-        DCHECK((*output_tensor)->CopyFrom(add_tensor, output_tf_shape));
+        CHECK((*output_tensor)->CopyFrom(add_tensor, output_tf_shape));
       } else {
-        if (add_mkl_shape.IsMklTensor()) {
-          auto add_md = add_mkl_shape.GetMklLayout();
-        } else {
-#ifdef ENABLE_MKLDNN_V1
-          auto output_format_tag = MklTensorFormatToMklDnnDataFormat(
-              output_mkl_shape.GetTfDataFormat());
-          DCHECK_NE(output_format_tag, memory::format_tag::undef);
-          auto add_md = memory::desc(output_dims_mkl_order,
-                                     MklDnnType<Toutput>(), output_format_tag);
-#else
-          auto add_md =
-              memory::desc(output_dims_mkl_order, MklDnnType<Toutput>(),
-                           output_mkl_shape.GetTfDataFormat());
-          auto add_pd = memory::primitive_desc(add_md, this->cpu_engine_);
-#endif  // ENABLE_MKLDNN_V1
-          void* add_buf = static_cast<void*>(
-              const_cast<Toutput*>(add_tensor.flat<Toutput>().data()));
-          void* dst_buf =
-              static_cast<void*>((*output_tensor)->flat<Ttemp_output>().data());
-          auto add = new MEMORY_CONSTRUCTOR(ADD_MD, this->cpu_engine_, add_buf);
-          auto dst = new MEMORY_CONSTRUCTOR(DST_MD, this->cpu_engine_, dst_buf);
-          auto reorder_desc =
-              REORDER_PD_CONSTRUCTOR(ADD_MD, DST_MD, this->cpu_engine_);
-          CreateAndExecuteReorder(reorder_desc, *add, *dst, this->cpu_engine_);
-        }
+        auto add_md =
+            add_mkl_shape.IsMklTensor()
+                ? add_mkl_shape.GetMklLayout()
+                : memory::desc(output_dims_mkl_order, MklDnnType<Toutput>(),
+                               output_mkl_shape.GetTfDataFormat());
+        auto add_pd = memory::primitive_desc(add_md, this->cpu_engine_);
+        void* add_buf = static_cast<void*>(
+            const_cast<Toutput*>(add_tensor.flat<Toutput>().data()));
+        void* dst_buf =
+            static_cast<void*>((*output_tensor)->flat<Ttemp_output>().data());
+        auto add = new memory(add_pd, add_buf);
+        auto dst = new memory(dst_pd, dst_buf);
+        auto reorder_desc = mkldnn::reorder::primitive_desc(add_pd, dst_pd);
+
+        std::vector<mkldnn::primitive> net;
+        net.push_back(mkldnn::reorder(reorder_desc, *add, *dst));
+        stream(stream::kind::eager).submit(net).wait();
       }
     }
   }

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -979,7 +979,8 @@ class MklConvOp : public OpKernel {
 
       // Check if need reorder
       if (add_mkl_shape == output_mkl_shape) {
-        DCHECK((*output_tensor)->CopyFrom(add_tensor, output_tf_shape));
+        auto result = (*output_tensor)->CopyFrom(add_tensor, output_tf_shape);
+        DCHECK(result);
       } else {
         auto add_md =
             add_mkl_shape.IsMklTensor()

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -979,7 +979,7 @@ class MklConvOp : public OpKernel {
 
       // Check if need reorder
       if (add_mkl_shape == output_mkl_shape) {
-        CHECK((*output_tensor)->CopyFrom(add_tensor, output_tf_shape));
+        DCHECK((*output_tensor)->CopyFrom(add_tensor, output_tf_shape));
       } else {
         auto add_md =
             add_mkl_shape.IsMklTensor()


### PR DESCRIPTION
This fixes the accuracy regression in Resnet-50 for FP32.