### PR TITLE
Update API docs for SamplingDataset op

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_SamplingDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SamplingDataset.pbtxt
@@ -22,8 +22,10 @@ END
   }
   summary: "Creates a dataset that takes a Bernoulli sample of the contents of another dataset."
   description: <<END
-There is no direct Python API for creating Datasets of this type. Rewrite rules in 
-`tensorflow/core/grappler/optimizers/data/filter_with_random_uniform_fusion.cc`
-create instances of this dataset.
+There is no direct Python API for creating Datasets of this type.  
+TensorFlow's graph optimizer creates instances of SamplingDataset by fusing multiple 
+operations together. Use the `experimental_optimization.filter_with_random_uniform_fusion`
+flag in `tf.data.experimental.OptimizationOptions` to control whether this
+optimization happens.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_SamplingDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SamplingDataset.pbtxt
@@ -22,10 +22,10 @@ END
   }
   summary: "Creates a dataset that takes a Bernoulli sample of the contents of another dataset."
   description: <<END
-There is no direct Python API for creating Datasets of this type.  
-TensorFlow's graph optimizer creates instances of SamplingDataset by fusing multiple 
-operations together. Use the `experimental_optimization.filter_with_random_uniform_fusion`
-flag in `tf.data.experimental.OptimizationOptions` to control whether this
-optimization happens.
+There is no transformation in the `tf.data` Python API for creating this dataset.
+Instead, it is created as a result of the `filter_with_random_uniform_fusion`
+static optimization. Whether this optimization is performed is determined by the
+`experimental_optimization.filter_with_random_uniform_fusion` option of
+`tf.data.Options`.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_SamplingDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SamplingDataset.pbtxt
@@ -4,8 +4,8 @@ op {
   in_arg {
     name: "rate"
     description: <<END
-A scalar representing the sample rate of elements from the `input_dataset`
-that should be taken.
+A scalar representing the sample rate. Each element of `input_dataset` is 
+retained with this probability, independent of all other elements.
 END
   }
   in_arg {
@@ -20,5 +20,10 @@ END
 A scalar representing seed2 of random number generator.
 END
   }
-  summary: "Creates a dataset that contains `rate` elements from the `input_dataset`."
+  summary: "Creates a dataset that takes a Bernoulli sample of the contents of another dataset."
+  description: <<END
+There is no direct Python API for creating Datasets of this type. Rewrite rules in 
+`tensorflow/core/grappler/optimizers/data/filter_with_random_uniform_fusion.cc`
+create instances of this dataset.
+END
 }


### PR DESCRIPTION
Following a discussion with @jsimsa on #31176, I've started updating the API docs for the C++ side of `tf.data.experimental`. This PR contains updates to the documentation for `SamplingDataset`. I've added a description of what type of sampling the dataset performs, as well as information about the code paths by which the dataset is instantiated.