### PR TITLE
Override zip on AutoGraph 

### DIFF
--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -342,7 +342,24 @@ def _py_enumerate(s, start=0):
   return enumerate(s, start)
 
 
-SUPPORTED_BUILTINS = (abs, float, int, len, print, range, enumerate)
+def zip_(*s):
+  if all(isinstance(x, dataset_ops.DatasetV2) for x in s):
+    return _tf_dataset_zip(*s)
+  return _py_zip(*s)
+
+
+def _tf_dataset_zip(*s):
+  tup = ()
+  for x in s:
+    tup += (x,)
+  return dataset_ops.DatasetV2.zip(tup)
+
+
+def _py_zip(*s):
+  return zip(*s)
+
+
+SUPPORTED_BUILTINS = (abs, float, int, len, print, range, enumerate, zip)
 
 if six.PY2:
   SUPPORTED_BUILTINS += (xrange,)
@@ -357,4 +374,5 @@ BUILTIN_FUINCTIONS_MAP = {
     # TODO(mdan): This might make more sense as tf.data.range.
     'xrange': range_,
     'enumerate': enumerate_,
+    'zip': zip_,
 }

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -342,21 +342,18 @@ def _py_enumerate(s, start=0):
   return enumerate(s, start)
 
 
-def zip_(*s):
-  if all(isinstance(x, dataset_ops.DatasetV2) for x in s):
-    return _tf_dataset_zip(*s)
-  return _py_zip(*s)
+def zip_(*iterables):
+  if all(isinstance(x, dataset_ops.DatasetV2) for x in iterables):
+    return _tf_dataset_zip(*iterables)
+  return _py_zip(*iterables)
 
 
-def _tf_dataset_zip(*s):
-  tup = ()
-  for x in s:
-    tup += (x,)
-  return dataset_ops.DatasetV2.zip(tup)
+def _tf_dataset_zip(*iterables):
+  return dataset_ops.DatasetV2.zip(tuple(iterables))
 
 
-def _py_zip(*s):
-  return zip(*s)
+def _py_zip(*iterables):
+  return zip(*iterables)
 
 
 SUPPORTED_BUILTINS = (abs, float, int, len, print, range, enumerate, zip)

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -158,10 +158,25 @@ class PyBuiltinsTest(test.TestCase):
     start = constant_op.constant(20, dtype=dtypes.int64)
     dataset = py_builtins.enumerate_(dataset, start)
     iterator = dataset_ops.make_one_shot_iterator(dataset)
-
     with self.cached_session() as sess:
       self.assertAllEqual(self.evaluate(iterator.get_next()), (20, b'a'))
       self.assertAllEqual(self.evaluate(iterator.get_next()), (21, b'c'))
+
+  def test_zip(self):
+    self.assertListEqual(
+        list(py_builtins.zip_([3, 2, 1], [1, 2, 3])), [(3, 1), (2, 2), (1, 3)])
+    self.assertListEqual(
+        list(py_builtins.zip_([4, 5, 6], [-1, -2])), [(4, -1), (5, -2)])
+
+  def test_zip_dataset(self):
+    ds1 = dataset_ops.DatasetV2.from_tensor_slices([-11, -12, 4])
+    ds2 = dataset_ops.DatasetV2.from_tensor_slices([-21, -22, 5])
+    ds3 = py_builtins.zip_(ds1, ds2)
+    iterator = dataset_ops.make_one_shot_iterator(ds3)
+    with self.cached_session() as sess:
+      self.assertAllEqual(self.evaluate(iterator.get_next()), (-11, -21))
+      self.assertAllEqual(self.evaluate(iterator.get_next()), (-12, -22))
+      self.assertAllEqual(self.evaluate(iterator.get_next()), (4, 5))
 
   def _basic_function_scope(self):
     return function_wrappers.FunctionScope(


### PR DESCRIPTION
This pull request address what @mdanatg said on #31038 PR about overriding zip on AutoGraph. The current implementation override zip when all of the input was dataset. But when not all of it was a dataset, it will execute the built-in python zip. Is this the correct behaviour?