### PR TITLE
Remove symbolic link from Docker build tests

### DIFF
--- a/tensorflow/tools/dockerfiles/tests/build-gpu.sh
+++ b/tensorflow/tools/dockerfiles/tests/build-gpu.sh
@@ -22,8 +22,6 @@ cd /tensorflow
 
 ln -s $(which ${PYTHON}) /usr/local/bin/python 
 
-ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
-
 LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH} \
 tensorflow/tools/ci_build/builds/configured GPU \
 bazel build -c opt --copt=-mavx --config=cuda \


### PR DESCRIPTION
This was added directly to the partials in a recent PR, so this test fails with
a "link already exists" warning.