### PR TITLE
systemlibs: unbundle enum34 and fix jsoncpp header links for jsoncpp 1.9

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -389,6 +389,7 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         ],
         sha256 = "8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1",
         build_file = clean_dep("//third_party:enum34.BUILD"),
+        system_build_file = clean_dep("//third_party/systemlibs:enum34.BUILD"),
         strip_prefix = "enum34-1.1.6/enum",
     )
 

--- a/third_party/systemlibs/enum34.BUILD
+++ b/third_party/systemlibs/enum34.BUILD
@@ -1,0 +1,14 @@
+# Description:
+#   enum34 provides a backport of the enum module for Python 2.
+
+licenses(["notice"])  # MIT
+
+filegroup(
+    name = "LICENSE",
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "enum",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/systemlibs/jsoncpp.BUILD
+++ b/third_party/systemlibs/jsoncpp.BUILD
@@ -6,6 +6,8 @@ filegroup(
 )
 
 HEADERS = [
+    "include/json/allocator.h",
+    "include/json/assertions.h",
     "include/json/autolink.h",
     "include/json/config.h",
     "include/json/features.h",

--- a/third_party/systemlibs/syslibs_configure.bzl
+++ b/third_party/systemlibs/syslibs_configure.bzl
@@ -20,6 +20,7 @@ VALID_LIBS = [
     "curl",
     "cython",
     "double_conversion",
+    "enum34_archive",
     "flatbuffers",
     "gast_archive",
     "gif_archive",


### PR DESCRIPTION
This PR unbundles enum34 like normal python libs.
Jsoncpp 1.8->1.9 added new headers. The current includes use a path that disagrees with how the headers are normally installed so needs symlinks to adjust the paths. This adds symlinks to these new headers.

I've added these patches to the Gentoo tensorflow-1.14.0-r1 package a few days ago and had no problems so far.

I'll file a separate PR to cherry-pick these also into 1.14.1 when these are merged.
