### PR TITLE
install_headers: fix paths of generated headers

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -750,8 +750,8 @@ genrule(
     mkdir $@
     for f in $(SRCS); do
       d="$${f%/*}"
-      d="$${d#bazel-out*genfiles/}"
-      d="$${d#*external/eigen_archive/}"
+      d="$${d#bazel-out/*/genfiles/}"
+      d="$${d#bazel-out/*/bin/}"
 
       if [[ $${d} == *local_config_* ]]; then
         continue
@@ -763,6 +763,9 @@ genrule(
         if [[ $${TF_SYSTEM_LIBS:-} == *$${extname}* ]]; then
           continue
         fi
+
+        d="$${d#*external/farmhash_archive/src}"
+        d="$${d#*external/$${extname}/}"
       fi
 
       mkdir -p "$@/$${d}"


### PR DESCRIPTION
The generated headers moved from bazel-genfiles to bazel-bin so change
the match to remove both. Also adjust the external library header files
so they have the right paths to work with the base include.

All the TensorFlow header files should compile cleanly on their own
(excluding the windows ones etc). To verify, run the target then install
to /usr/include/tensorflow and run the following:

for i in $(find /usr/include/tensorflow -iname "*.h"); do \
g++ -o/dev/null -E -I/usr/include/tensorflow -I/opt/cuda/include $i \
|| echo $i; done

Signed-off-by: Jason Zaman <jason@perfinion.com>

I'll file a separate PR to merge these into 1.14.1. I've added this into gentoo's tensorflow-1.14.0-r1 and verified things work to build against the headers now.