### PR TITLE
Improvement to tf.einsum documentation

### DIFF
--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -169,7 +169,7 @@ def _enclosing_tpu_context():
 
 @tf_export('einsum', 'linalg.einsum')
 def einsum(equation, *inputs, **kwargs):
-  """A generalized contraction between tensors of arbitrary dimension.
+  """Contraction over specified indices and outer product for an arbitrary number of tensors.
 
   This function returns a tensor whose elements are defined by `equation`,
   which is written in a shorthand form inspired by the Einstein summation


### PR DESCRIPTION
Improve tf.einsum documentation to include outer product. Based on the consensus
https://www.reddit.com/r/deeplearning/comments/ckxyb5/tensorflow_proposal_for_outer_product_operation/
 that outer product is poorly documented generally in Tensorflow, though it is supported.