### PR TITLE
Fix build error TensorFlow Lite for ARM64

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/neon_tensor_utils.cc
+++ b/tensorflow/lite/kernels/internal/optimized/neon_tensor_utils.cc
@@ -880,8 +880,8 @@ inline int32x4_t RoundToNearest(const float32x4_t input) {
   static const float32x4_t zero_val_dup = vdupq_n_f32(0.0f);
   static const float32x4_t point5_val_dup = vdupq_n_f32(0.5f);
 
-  const int32x4_t mask = static_cast<int32x4_t>(vcltq_f32(input, zero_val_dup));
-  const float32x4_t casted_mask = vcvtq_f32_s32(mask);
+  const uint32x4_t mask = vcltq_f32(input, zero_val_dup);
+  const float32x4_t casted_mask = vcvtq_f32_u32(mask);
   const float32x4_t round = vaddq_f32(casted_mask, point5_val_dup);
   return vcvtq_s32_f32(vaddq_f32(input, round));
 #endif

--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -167,7 +167,7 @@ endif
 ifeq ($(BUILD_WITH_NNAPI),true)
 	CORE_CC_ALL_SRCS += tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
 	CORE_CC_ALL_SRCS += tensorflow/lite/nnapi/nnapi_implementation.cc
-	CORE_CC_ALL_SRCS += tensorflow/lite/nnapi/quant_lstm_sup.cc
+	CORE_CC_ALL_SRCS += tensorflow/lite/delegates/nnapi/quant_lstm_sup.cc
 	LIBS += -lrt
 else
 	CORE_CC_ALL_SRCS += tensorflow/lite/delegates/nnapi/nnapi_delegate_disabled.cc


### PR DESCRIPTION
Resolves #31320

Fix build error TensorFlow Lite for ARM64
1.neon_tensor_utils.cc
Fix compile error.
`error: invalid static_cast from type ‘uint32x4_t {aka __vector(4) unsigned int}’ to type ‘int32x4_t {aka __vector(4) int}’`

2.tensorflow/lite/tools/make/Makefile
Fix quant_lstm_sup.cc path.