### PR TITLE
Fix loading for tf_exec_compatible_with and tf_cuda_tests_tags

### DIFF
--- a/tensorflow/examples/adding_an_op/BUILD
+++ b/tensorflow/examples/adding_an_op/BUILD
@@ -7,10 +7,13 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
+load(
+    "//tensorflow/core:platform/default/build_config_root.bzl",
+    "tf_cuda_tests_tags",
+    "tf_exec_compatible_with",
+)
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
-load("//tensorflow:tensorflow.bzl", "tf_cuda_tests_tags")
 load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
-load("//tensorflow:tensorflow.bzl", "tf_exec_compatible_with")
 
 exports_files(["LICENSE"])
 


### PR DESCRIPTION
PiperOrigin-RevId: 249041071

Cherry picking the above commit as macos builds fail with

```
ERROR: /Volumes/BuildData/tmpfs/src/github/tensorflow/tensorflow/examples/adding_an_op/BUILD:11:1: file '//tensorflow:tensorflow.bzl' does not contain symbol 'tf_cuda_tests_tags'
ERROR: /Volumes/BuildData/tmpfs/src/github/tensorflow/tensorflow/examples/adding_an_op/BUILD:13:1: file '//tensorflow:tensorflow.bzl' does not contain symbol 'tf_exec_compatible_with'
ERROR: /Volumes/BuildData/tmpfs/src/github/tensorflow/tensorflow/examples/adding_an_op/BUILD:134:28: Traceback (most recent call last):
	File "/Volumes/BuildData/tmpfs/src/github/tensorflow/tensorflow/examples/adding_an_op/BUILD", line 130
		py_test(name = "cuda_op_test", size = "sma...", <6 more arguments>)
	File "/Volumes/BuildData/tmpfs/src/github/tensorflow/tensorflow/examples/adding_an_op/BUILD", line 134, in py_test
		tf_exec_compatible_with
name 'tf_exec_compatible_with' is not defined
ERROR: package contains errors: tensorflow/examples/adding_an_op
```