### PR TITLE
Don't copy more variant elements than allowed by tensor shape

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,7 @@
 * Update `RaggedTensors` to support int32 `row_splits`.
 * Add `TensorSpec` support for `CompositeTensors`.
 * Add environment variable TF_CUDNN_DETERMINISTIC. Setting to "true" or "1" forces the selection of deterministic cuDNN convolution and max-pooling algorithms. When this is enabled, the algorithm selection procedure itself is also deterministic. This change was already present in release 1.14.0, but this note was missing from the 1.14.0 release notes tagged v1.14.0.
+* Fix potential security vulnerability where decoding variant tensors from proto could result in heap out of bounds memory access.
 
 # Release 1.14.0
 

--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -514,7 +514,12 @@ TensorBuffer* FromProtoField<Variant>(Allocator* a, const TensorProto& in,
   if (in_n <= 0) {
     std::fill_n(data, n, Variant());
   } else {
-    for (int64 i = 0; i < in_n; ++i) {
+    // If tensor shape says we have n < in_n elements in the output tensor
+    // then make sure to only decode the first n out of the in_n elements in the
+    // in tensors. In all other cases, we decode all in_n elements of in and set
+    // the remaining elements up to n to be the default Variant() value.
+    const int64 real_n = n < in_n ? n : in_n;
+    for (int64 i = 0; i < real_n; ++i) {
       data[i] = in.variant_val(i);
       if (!DecodeUnaryVariant(&data[i])) {
         LOG(ERROR) << "Could not decode variant with type_name: \""


### PR DESCRIPTION
PiperOrigin-RevId: 261962798

Cherry-pick of 966a8f9aeac3ce7ce3e106a9d429f1a415792c8e