### PR TITLE
Build v2 by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -155,6 +155,14 @@ build:rbe --strategy=TestRunner=remote
 build:rbe --tls_enabled
 test:rbe --test_env=USER=anon
 
+# Options to build TensorFlow 1.x or 2.x.
+build:v1 --define=tf_api_version=1
+build:v2 --define=tf_api_version=2
+test:v1 --test_env=TF2_BEHAVIOR=0
+test:v2 --test_env=TF2_BEHAVIOR=1
+build --config=v2
+test --config=v2
+
 # Default options should come above this line
 
 # Options from ./configure

--- a/configure.py
+++ b/configure.py
@@ -50,7 +50,7 @@ _TF_WORKSPACE_ROOT = ''
 _TF_BAZELRC = ''
 _TF_CURRENT_BAZEL_VERSION = None
 _TF_MIN_BAZEL_VERSION = '0.24.1'
-_TF_MAX_BAZEL_VERSION = '0.26.1'
+_TF_MAX_BAZEL_VERSION = '0.28.1'
 
 NCCL_LIB_PATHS = [
     'lib64/', 'lib/powerpc64le-linux-gnu/', 'lib/x86_64-linux-gnu/', ''
@@ -1558,9 +1558,6 @@ def main():
   set_system_libs_flag(environ_cp)
   if is_windows():
     set_windows_build_flags(environ_cp)
-
-  # Add a config option to build TensorFlow 2.0 API.
-  write_to_bazelrc('build:v2 --define=tf_api_version=2')
 
   if get_var(environ_cp, 'TF_SET_ANDROID_WORKSPACE', 'android workspace', False,
              ('Would you like to interactively configure ./WORKSPACE for '

--- a/configure.py
+++ b/configure.py
@@ -50,7 +50,7 @@ _TF_WORKSPACE_ROOT = ''
 _TF_BAZELRC = ''
 _TF_CURRENT_BAZEL_VERSION = None
 _TF_MIN_BAZEL_VERSION = '0.24.1'
-_TF_MAX_BAZEL_VERSION = '0.28.1'
+_TF_MAX_BAZEL_VERSION = '0.26.1'
 
 NCCL_LIB_PATHS = [
     'lib64/', 'lib/powerpc64le-linux-gnu/', 'lib/x86_64-linux-gnu/', ''

--- a/tensorflow/api_template_v1.__init__.py
+++ b/tensorflow/api_template_v1.__init__.py
@@ -134,6 +134,10 @@ if _running_from_pip_package():
     if _fi.file_exists(plugin_dir):
       _ll.load_library(plugin_dir)
 
+# Disable TF2 behavior
+from tensorflow.python.compat import v2_compat as _compat  # pylint: disable=g-import-not-at-top
+_compat.disable_v2_behavior()
+
 # These symbols appear because we import the python package which
 # in turn imports from tensorflow.core and tensorflow.python. They
 # must come from this module. So python adds these symbols for the

--- a/tensorflow/examples/adding_an_op/cuda_op.py
+++ b/tensorflow/examples/adding_an_op/cuda_op.py
@@ -23,5 +23,5 @@ import tensorflow as tf
 
 if tf.test.is_built_with_cuda():
   _cuda_op_module = tf.load_op_library(os.path.join(
-      tf.resource_loader.get_data_files_path(), 'cuda_op_kernel.so'))
+      tf.compat.v1.resource_loader.get_data_files_path(), 'cuda_op_kernel.so'))
   add_one = _cuda_op_module.add_one

--- a/tensorflow/examples/adding_an_op/fact_test.py
+++ b/tensorflow/examples/adding_an_op/fact_test.py
@@ -27,7 +27,7 @@ class FactTest(tf.test.TestCase):
   @test_util.run_deprecated_v1
   def test(self):
     with self.cached_session():
-      print(tf.user_ops.my_fact().eval())
+      print(tf.compat.v1.user_ops.my_fact().eval())
 
 
 if __name__ == '__main__':

--- a/tensorflow/examples/adding_an_op/zero_out_1_test.py
+++ b/tensorflow/examples/adding_an_op/zero_out_1_test.py
@@ -36,7 +36,8 @@ class ZeroOut1Test(tf.test.TestCase):
 
   def testLoadTwice(self):
     zero_out_loaded_again = tf.load_op_library(os.path.join(
-        tf.resource_loader.get_data_files_path(), 'zero_out_op_kernel_1.so'))
+        tf.compat.v1.resource_loader.get_data_files_path(),
+        'zero_out_op_kernel_1.so'))
     self.assertEqual(zero_out_loaded_again, zero_out_op_1._zero_out_module)
 
 

--- a/tensorflow/examples/adding_an_op/zero_out_2_test.py
+++ b/tensorflow/examples/adding_an_op/zero_out_2_test.py
@@ -47,7 +47,7 @@ class ZeroOut2Test(tf.test.TestCase):
       shape = (5,)
       x = tf.constant([5, 4, 3, 2, 1], dtype=tf.float32)
       y = zero_out_op_2.zero_out(x)
-      err = tf.test.compute_gradient_error(x, shape, y, shape)
+      err = tf.compat.v1.test.compute_gradient_error(x, shape, y, shape)
       self.assertLess(err, 1e-4)
 
   @test_util.run_deprecated_v1
@@ -56,7 +56,7 @@ class ZeroOut2Test(tf.test.TestCase):
       shape = (2, 3)
       x = tf.constant([[6, 5, 4], [3, 2, 1]], dtype=tf.float32)
       y = zero_out_op_2.zero_out(x)
-      err = tf.test.compute_gradient_error(x, shape, y, shape)
+      err = tf.compat.v1.test.compute_gradient_error(x, shape, y, shape)
       self.assertLess(err, 1e-4)
 
 

--- a/tensorflow/examples/adding_an_op/zero_out_op_1.py
+++ b/tensorflow/examples/adding_an_op/zero_out_op_1.py
@@ -22,6 +22,6 @@ import os.path
 import tensorflow as tf
 
 _zero_out_module = tf.load_op_library(
-    os.path.join(tf.resource_loader.get_data_files_path(),
+    os.path.join(tf.compat.v1.resource_loader.get_data_files_path(),
                  'zero_out_op_kernel_1.so'))
 zero_out = _zero_out_module.zero_out

--- a/tensorflow/examples/adding_an_op/zero_out_op_2.py
+++ b/tensorflow/examples/adding_an_op/zero_out_op_2.py
@@ -22,7 +22,7 @@ import os.path
 import tensorflow as tf
 
 _zero_out_module = tf.load_op_library(
-    os.path.join(tf.resource_loader.get_data_files_path(),
+    os.path.join(tf.compat.v1.resource_loader.get_data_files_path(),
                  'zero_out_op_kernel_2.so'))
 zero_out = _zero_out_module.zero_out
 zero_out2 = _zero_out_module.zero_out2

--- a/tensorflow/examples/adding_an_op/zero_out_op_3.py
+++ b/tensorflow/examples/adding_an_op/zero_out_op_3.py
@@ -22,6 +22,6 @@ import os.path
 import tensorflow as tf
 
 _zero_out_module = tf.load_op_library(
-    os.path.join(tf.resource_loader.get_data_files_path(),
+    os.path.join(tf.compat.v1.resource_loader.get_data_files_path(),
                  'zero_out_op_kernel_3.so'))
 zero_out = _zero_out_module.zero_out

--- a/tensorflow/examples/speech_commands/BUILD
+++ b/tensorflow/examples/speech_commands/BUILD
@@ -62,6 +62,7 @@ tf_py_test(
     ],
     tags = [
         "no_pip",  # b/131330719
+        "v1only",  # uses contrib
     ],
 )
 
@@ -98,6 +99,7 @@ tf_py_test(
     ],
     tags = [
         "no_pip",  # b/131330719
+        "v1only",  # uses contrib
     ],
 )
 
@@ -144,6 +146,7 @@ tf_py_test(
     ],
     tags = [
         "no_pip",  # b/131330719
+        "v1only",  # uses contrib
     ],
 )
 
@@ -187,6 +190,7 @@ tf_py_test(
     ],
     tags = [
         "no_pip",  # b/131330719
+        "v1only",  # uses contrib
     ],
 )
 
@@ -230,6 +234,7 @@ tf_py_test(
     ],
     tags = [
         "no_pip",  # b/131330719
+        "v1only",  # uses contrib
     ],
 )
 
@@ -284,6 +289,7 @@ tf_py_test(
     ],
     tags = [
         "no_pip",  # b/131330719
+        "v1only",  # uses contrib
     ],
 )
 

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1443,6 +1443,7 @@ tf_py_test(
     tags = [
         "no_pip",
         "no_windows",
+        "v1only",
     ],
 )
 

--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -309,7 +309,6 @@ tf_py_test(
     size = "small",
     srcs = ["iterator_cluster_test.py"],
     additional_deps = [
-        "//tensorflow/contrib/lookup:lookup_py",
         "//tensorflow/core:protos_all_py",
         "//tensorflow/python/data/ops:dataset_ops",
         "//tensorflow/python/data/ops:iterator_ops",

--- a/tensorflow/python/data/kernel_tests/iterator_cluster_test.py
+++ b/tensorflow/python/data/kernel_tests/iterator_cluster_test.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 
 import numpy as np
 
-from tensorflow.contrib import lookup as lookup_ops
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.client import session
 from tensorflow.python.data.ops import dataset_ops
@@ -32,6 +31,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import functional_ops
+from tensorflow.python.ops import lookup_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import string_ops
 from tensorflow.python.platform import test

--- a/tensorflow/python/debug/BUILD
+++ b/tensorflow/python/debug/BUILD
@@ -1188,5 +1188,6 @@ sh_test(
     ],
     tags = [
         "no_windows",
+        "v1only",
     ],
 )

--- a/tensorflow/python/distribute/BUILD
+++ b/tensorflow/python/distribute/BUILD
@@ -935,7 +935,6 @@ distribute_py_test(
     ],
     deps = [
         ":single_loss_example",
-        "//tensorflow/contrib/tpu:tpu_lib",
         "//tensorflow/python:framework_test_lib",
         "//tensorflow/python:variables",
         "//tensorflow/python/distribute:combinations",

--- a/tensorflow/python/distribute/BUILD
+++ b/tensorflow/python/distribute/BUILD
@@ -882,7 +882,6 @@ distribute_py_test(
     deps = [
         ":mirrored_strategy",
         ":single_loss_example",
-        "//tensorflow/contrib/tpu:tpu_lib",
         "//tensorflow/python:control_flow_ops",
         "//tensorflow/python:control_flow_v2_toggles",
         "//tensorflow/python:framework_ops",

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -2978,7 +2978,6 @@ cuda_py_test(
     srcs = ["conv_ops_test.py"],
     additional_deps = [
         "//third_party/py/numpy",
-        "//tensorflow/contrib/layers:layers_py",
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client",
         "//tensorflow/python:client_testlib",

--- a/tensorflow/python/profiler/model_analyzer_test.py
+++ b/tensorflow/python/profiler/model_analyzer_test.py
@@ -462,6 +462,7 @@ class PrintModelAnalysisTest(test.TestCase):
       self.assertTrue(has_rnn)
       self.assertTrue(has_loop)
 
+  @test_util.run_v1_only('b/139088991')
   def testPprof(self):
     for attr in ['micros', 'bytes', 'accelerator_micros', 'cpu_micros',
                  'params', 'float_ops']:

--- a/tensorflow/python/tpu/BUILD
+++ b/tensorflow/python/tpu/BUILD
@@ -257,7 +257,7 @@ tf_py_test(
     size = "small",
     srcs = ["tpu_sharding_test.py"],
     additional_deps = [
-        ":tpu",
+        ":tpu_lib",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:framework",
     ],
@@ -268,7 +268,7 @@ tf_py_test(
     size = "small",
     srcs = ["bfloat16_test.py"],
     additional_deps = [
-        ":tpu",
+        ":tpu_lib",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:framework",
     ],
@@ -279,7 +279,7 @@ tf_py_test(
     size = "small",
     srcs = ["tpu_infeed_test.py"],
     additional_deps = [
-        ":tpu",
+        ":tpu_lib",
         "//tensorflow/python:framework",
         "//tensorflow/python:framework_test_lib",
     ],
@@ -290,7 +290,7 @@ tf_py_test(
     size = "medium",
     srcs = ["topology_test.py"],
     additional_deps = [
-        ":tpu",
+        ":tpu_lib",
         "//tensorflow/python:framework_test_lib",
     ],
 )

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -95,6 +95,7 @@ COMMON_PIP_DEPS = [
     "//tensorflow/python/saved_model:saved_model",
     "//tensorflow/python/tools:tools_pip",
     "//tensorflow/python/tools/api/generator:create_python_api",
+    "//tensorflow/python/tpu:tpu",
     "//tensorflow/python/tpu:tpu_lib",
     "//tensorflow/python:test_ops",
     "//tensorflow/python:while_v2",

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -95,6 +95,7 @@ COMMON_PIP_DEPS = [
     "//tensorflow/python/saved_model:saved_model",
     "//tensorflow/python/tools:tools_pip",
     "//tensorflow/python/tools/api/generator:create_python_api",
+    "//tensorflow/python/tpu:tpu_lib",
     "//tensorflow/python:test_ops",
     "//tensorflow/python:while_v2",
     "//tensorflow/tools/common:public_api",

--- a/tensorflow/tools/pip_package/pip_smoke_test.py
+++ b/tensorflow/tools/pip_package/pip_smoke_test.py
@@ -50,7 +50,7 @@ def GetBuild(dir_base):
   return items
 
 
-def BuildPyTestDependencies(api_version):
+def BuildPyTestDependencies():
   python_targets = GetBuild("tensorflow/python")
   tensorflow_targets = GetBuild("tensorflow")
   # Build list of test targets,
@@ -147,7 +147,7 @@ def main():
   # tf_py_test_dependencies is the list of dependencies for all python
   # tests in tensorflow
   tf_py_test_dependencies = subprocess.check_output(
-      ["bazel", "cquery", py_test_query_expression])
+      ["bazel", "cquery", PY_TEST_QUERY_EXPRESSION])
   if isinstance(tf_py_test_dependencies, bytes):
     tf_py_test_dependencies = tf_py_test_dependencies.decode("utf-8")
   tf_py_test_dependencies_list = tf_py_test_dependencies.strip().split("\n")
@@ -187,7 +187,7 @@ def main():
       print("\nMissing dependency: %s " % missing_dependency)
       print("Affected Tests:")
       rdep_query = ("rdeps(kind(py_test, %s), %s)" %
-                    (" + ".join(python_targets), missing_dependency))
+                    (" + ".join(PYTHON_TARGETS), missing_dependency))
       affected_tests = subprocess.check_output(["bazel", "cquery", rdep_query])
       affected_tests_list = affected_tests.split("\n")[:-2]
       print("\n".join(affected_tests_list))

--- a/tensorflow/tools/pip_package/pip_smoke_test.py
+++ b/tensorflow/tools/pip_package/pip_smoke_test.py
@@ -50,16 +50,12 @@ def GetBuild(dir_base):
   return items
 
 
-def BuildPyTestDependencies():
+def BuildPyTestDependencies(api_version):
   python_targets = GetBuild("tensorflow/python")
-  contrib_targets = GetBuild("tensorflow/contrib")
-  tensorboard_targets = GetBuild("tensorflow/contrib/tensorboard")
   tensorflow_targets = GetBuild("tensorflow")
   # Build list of test targets,
-  # python + contrib - tensorboard - attr(manual|pno_pip)
+  # python - tensorboard - attr(manual|pno_pip)
   targets = " + ".join(python_targets)
-  for t in contrib_targets:
-    targets += " + " + t
   for t in tensorboard_targets:
     targets += " - " + t
   targets += ' - attr(tags, "manual|no_pip", %s)' % " + ".join(
@@ -137,7 +133,6 @@ def main():
       3. Configure has been run.
 
   """
-
   # pip_package_dependencies_list is the list of included files in pip packages
   pip_package_dependencies = subprocess.check_output(
       ["bazel", "cquery", PIP_PACKAGE_QUERY_EXPRESSION])
@@ -152,7 +147,7 @@ def main():
   # tf_py_test_dependencies is the list of dependencies for all python
   # tests in tensorflow
   tf_py_test_dependencies = subprocess.check_output(
-      ["bazel", "cquery", PY_TEST_QUERY_EXPRESSION])
+      ["bazel", "cquery", py_test_query_expression])
   if isinstance(tf_py_test_dependencies, bytes):
     tf_py_test_dependencies = tf_py_test_dependencies.decode("utf-8")
   tf_py_test_dependencies_list = tf_py_test_dependencies.strip().split("\n")
@@ -192,7 +187,7 @@ def main():
       print("\nMissing dependency: %s " % missing_dependency)
       print("Affected Tests:")
       rdep_query = ("rdeps(kind(py_test, %s), %s)" %
-                    (" + ".join(PYTHON_TARGETS), missing_dependency))
+                    (" + ".join(python_targets), missing_dependency))
       affected_tests = subprocess.check_output(["bazel", "cquery", rdep_query])
       affected_tests_list = affected_tests.split("\n")[:-2]
       print("\n".join(affected_tests_list))

--- a/tensorflow/tools/pip_package/pip_smoke_test.py
+++ b/tensorflow/tools/pip_package/pip_smoke_test.py
@@ -56,8 +56,6 @@ def BuildPyTestDependencies():
   # Build list of test targets,
   # python - tensorboard - attr(manual|pno_pip)
   targets = " + ".join(python_targets)
-  for t in tensorboard_targets:
-    targets += " - " + t
   targets += ' - attr(tags, "manual|no_pip", %s)' % " + ".join(
       tensorflow_targets)
   query_kind = "kind(py_test, %s)" % targets


### PR DESCRIPTION
When running bazel build on r2.0 branch, we should build TensorFlow 2.0 by default.

After this change, behavior is as follows:
* If --config=v2 is passed in, generate TensorFlow 2.x API and run tests with 2.x behavior.
* If --config=v1 is passed in, generate TensorFlow 1.x API and run tests with 1.x behavior.
* Default is same as if --config=v2 was passed in.
