### PR TITLE
More flexible fftshift and ifftshift

### DIFF
--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -616,8 +616,8 @@ class FFTShiftTest(test.TestCase):
         with self.session() as sess:
             x_np = np.random.rand(16, 256, 256)
             y_fftshift_res, y_ifftshift_res = sess.run([y_fftshift, y_ifftshift], feed_dict={x: x_np})
-            self.assertAllClose(y_fftshift_res, np.fft.fftshift(x_np))
-            self.assertAllClose(y_ifftshift_res, np.fft.ifftshift(x_np))
+            self.assertAllClose(y_fftshift_res, np.fft.fftshift(x_np, axes=axes))
+            self.assertAllClose(y_ifftshift_res, np.fft.ifftshift(x_np, axes=axes))
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -607,14 +607,17 @@ class FFTShiftTest(test.TestCase):
 
 
   @test_util.run_deprecated_v1
-  def testNoneAxes(self):
+  def testPlaceholder(self):
       x = array_ops.placeholder(shape=[None, None, None], dtype='float32')
       axes_to_test = [None, 1, [1, 2]]
       for axes in axes_to_test:
         y_fftshift = fft_ops.fftshift(x, axes=axes)
         y_ifftshift = fft_ops.ifftshift(x, axes=axes)
         with self.session() as sess:
-            sess.run([y_fftshift, y_ifftshift], feed_dict={x: np.zeros((16, 256, 256))})
+            x_np = np.random.rand(16, 256, 256)
+            y_fftshift_res, y_ifftshift_res = sess.run([y_fftshift, y_ifftshift], feed_dict={x: x_np})
+            self.assertAllEqual(y_fftshift_res, np.fft.fftshift(x_np))
+            self.assertAllEqual(y_ifftshift_res, np.fft.ifftshift(x_np))
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -608,16 +608,17 @@ class FFTShiftTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testPlaceholder(self):
-      x = array_ops.placeholder(shape=[None, None, None], dtype='float32')
-      axes_to_test = [None, 1, [1, 2]]
-      for axes in axes_to_test:
-        y_fftshift = fft_ops.fftshift(x, axes=axes)
-        y_ifftshift = fft_ops.ifftshift(x, axes=axes)
-        with self.session() as sess:
-            x_np = np.random.rand(16, 256, 256)
-            y_fftshift_res, y_ifftshift_res = sess.run([y_fftshift, y_ifftshift], feed_dict={x: x_np})
-            self.assertAllClose(y_fftshift_res, np.fft.fftshift(x_np, axes=axes))
-            self.assertAllClose(y_ifftshift_res, np.fft.ifftshift(x_np, axes=axes))
+    x = array_ops.placeholder(shape=[None, None, None], dtype='float32')
+    axes_to_test = [None, 1, [1, 2]]
+    for axes in axes_to_test:
+      y_fftshift = fft_ops.fftshift(x, axes=axes)
+      y_ifftshift = fft_ops.ifftshift(x, axes=axes)
+      with self.session() as sess:
+        x_np = np.random.rand(16, 256, 256)
+        y_fftshift_res, y_ifftshift_res = sess.run([y_fftshift, y_ifftshift],
+                                                   feed_dict={x: x_np},)
+        self.assertAllClose(y_fftshift_res, np.fft.fftshift(x_np, axes=axes))
+        self.assertAllClose(y_ifftshift_res, np.fft.ifftshift(x_np, axes=axes))
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -616,8 +616,8 @@ class FFTShiftTest(test.TestCase):
         with self.session() as sess:
             x_np = np.random.rand(16, 256, 256)
             y_fftshift_res, y_ifftshift_res = sess.run([y_fftshift, y_ifftshift], feed_dict={x: x_np})
-            self.assertAllEqual(y_fftshift_res, np.fft.fftshift(x_np))
-            self.assertAllEqual(y_ifftshift_res, np.fft.ifftshift(x_np))
+            self.assertAllClose(y_fftshift_res, np.fft.fftshift(x_np))
+            self.assertAllClose(y_ifftshift_res, np.fft.ifftshift(x_np))
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -606,5 +606,15 @@ class FFTShiftTest(test.TestCase):
           np.fft.ifftshift(shifted, axes=(0, 1)))
 
 
+  @test_util.run_deprecated_v1
+  def testNoneAxes(self):
+      x = array_ops.placeholder(shape=[None, None, None], dtype='float32')
+      axes_to_test = [None, 1, [1, 2]]
+      for axes in axes_to_test:
+        y_fftshift = fft_ops.fftshift(x, axes=axes)
+        y_ifftshift = fft_ops.ifftshift(x, axes=axes)
+        with self.session() as sess:
+            sess.run([y_fftshift, y_ifftshift], feed_dict={x: np.zeros((16, 256, 256))})
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -358,11 +358,11 @@ def fftshift(x, axes=None, name=None):
     x = _ops.convert_to_tensor(x)
     if axes is None:
       axes = tuple(range(x.shape.ndims))
-      shift = [int(dim // 2) for dim in x.shape]
+      shift = [dim // 2 for dim in _array_ops.shape(x)]
     elif isinstance(axes, int):
-      shift = int(x.shape[axes] // 2)
+      shift = _array_ops.shape(x)[axes] // 2
     else:
-      shift = [int((x.shape[ax]) // 2) for ax in axes]
+      shift = [(_array_ops.shape(x)[ax]) // 2 for ax in axes]
 
     return manip_ops.roll(x, shift, axes, name)
 
@@ -399,11 +399,11 @@ def ifftshift(x, axes=None, name=None):
     x = _ops.convert_to_tensor(x)
     if axes is None:
       axes = tuple(range(x.shape.ndims))
-      shift = [-int(dim // 2) for dim in x.shape]
+      shift = [-_math_ops.cast(dim // 2, _dtypes.int32) for dim in _array_ops.shape(x)]
     elif isinstance(axes, int):
-      shift = -int(x.shape[axes] // 2)
+      shift = -_math_ops.cast(_array_ops.shape(x)[axes] // 2, _dtypes.int32)
     else:
-      shift = [-int(x.shape[ax] // 2) for ax in axes]
+      shift = [-_math_ops.cast(_array_ops.shape(x)[ax] // 2, _dtypes.int32) for ax in axes]
 
     return manip_ops.roll(x, shift, axes, name)
 

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -358,11 +358,11 @@ def fftshift(x, axes=None, name=None):
     x = _ops.convert_to_tensor(x)
     if axes is None:
       axes = tuple(range(x.shape.ndims))
-      shift = [dim // 2 for dim in _array_ops.shape(x)]
+      shift = _array_ops.shape(x) // 2
     elif isinstance(axes, int):
       shift = _array_ops.shape(x)[axes] // 2
     else:
-      shift = [(_array_ops.shape(x)[ax]) // 2 for ax in axes]
+      shift = _array_ops.gather(_array_ops.shape(x), axes) // 2
 
     return manip_ops.roll(x, shift, axes, name)
 
@@ -399,11 +399,11 @@ def ifftshift(x, axes=None, name=None):
     x = _ops.convert_to_tensor(x)
     if axes is None:
       axes = tuple(range(x.shape.ndims))
-      shift = [-_math_ops.cast(dim // 2, _dtypes.int32) for dim in _array_ops.shape(x)]
+      shift = -(_array_ops.shape(x) // 2)
     elif isinstance(axes, int):
-      shift = -_math_ops.cast(_array_ops.shape(x)[axes] // 2, _dtypes.int32)
+      shift = -(_array_ops.shape(x)[axes] // 2)
     else:
-      shift = [-_math_ops.cast(_array_ops.shape(x)[ax] // 2, _dtypes.int32) for ax in axes]
+      shift = -(_array_ops.gather(_array_ops.shape(x), axes) // 2)
 
     return manip_ops.roll(x, shift, axes, name)
 


### PR DESCRIPTION
This fixes the issue raised at the end of the thread in issue #26989 .
That is, if we want to have `fftshift` and `ifftshift` accept None dimensions. This happens when building a keras model (sequential or functionnal API), using `Lambda` layers (i.e. `Lambda(fftshift, arguments={'axes': [1, 2]})(inputs)`, where `inputs` has shape `(None, None, None, 1)`).

I don't know if this requires unit testing.