### PR TITLE
r2.0-rc0 cherry-pick request: Fix FlushQuantileSummaries Op

### DIFF
--- a/tensorflow/core/kernels/boosted_trees/quantile_ops.cc
+++ b/tensorflow/core/kernels/boosted_trees/quantile_ops.cc
@@ -264,6 +264,7 @@ class BoostedTreesFlushQuantileSummariesOp : public OpKernel {
         *context->device()->tensorflow_cpu_worker_threads();
     Shard(worker_threads.num_threads, worker_threads.workers, num_features_,
           kCostPerUnit, do_quantile_summary_gen);
+    stream_resource->ResetStreams();
   }
 
  private:
@@ -424,6 +425,7 @@ class BoostedTreesQuantileStreamResourceFlushOp : public OpKernel {
     Shard(worker_threads.num_threads, worker_threads.workers, num_streams,
           kCostPerUnit, do_quantile_flush);
 
+    stream_resource->ResetStreams();
     stream_resource->set_buckets_ready(true);
   }
 

--- a/tensorflow/core/kernels/boosted_trees/quantiles/quantile_stream_resource.h
+++ b/tensorflow/core/kernels/boosted_trees/quantiles/quantile_stream_resource.h
@@ -67,6 +67,14 @@ class BoostedTreesQuantileStreamResource : public ResourceBase {
     are_buckets_ready_ = are_buckets_ready;
   }
 
+  void ResetStreams() {
+    streams_.clear();
+    streams_.reserve(num_streams_);
+    for (int64 idx = 0; idx < num_streams_; ++idx) {
+      streams_.push_back(QuantileStream(epsilon_, max_elements_));
+    }
+  }
+
  private:
   ~BoostedTreesQuantileStreamResource() override {}
 

--- a/tensorflow/python/kernel_tests/boosted_trees/quantile_ops_test.py
+++ b/tensorflow/python/kernel_tests/boosted_trees/quantile_ops_test.py
@@ -108,31 +108,31 @@ class QuantileOpsTest(test_util.TensorFlowTestCase):
       self.assertAllClose(self._feature_0_quantiles, quantiles[0].eval())
       self.assertAllClose(self._feature_1_quantiles, quantiles[1].eval())
 
-  def testBasicQuantileBucketsMultipleResourcesAddFlushed(self):
+  def testBasicQuantileBucketsSingleResourcesAddFlushed(self):
     with self.cached_session():
-      quantile_accumulator_handle_0 = self.create_resource("floats_0", self.eps,
-                                                           self.max_elements, 2)
-      quantile_accumulator_handle_1 = self.create_resource("floats_1", self.eps,
-                                                           self.max_elements, 2)
+      quantile_accumulator_handle = self.create_resource("floats_0", self.eps,
+                                                         self.max_elements, 2)
       resources.initialize_resources(resources.shared_resources()).run()
       summaries = boosted_trees_ops.make_quantile_summaries(
           [self._feature_0, self._feature_1], self._example_weights,
           epsilon=self.eps)
       summary_op = boosted_trees_ops.quantile_add_summaries(
-          quantile_accumulator_handle_0, summaries)
+          quantile_accumulator_handle, summaries)
       flushed_summaries = flush_quantile_summaries(
-          quantile_accumulator_handle_0, num_features=2)
+          quantile_accumulator_handle, num_features=2)
 
       # We are testing whether the flushed summaries output at the previous step
-      # will give the same expected results by inputting it to add_summaries
+      # will give the same expected results by inputing it to add_summaries
       summary_op_2 = boosted_trees_ops.quantile_add_summaries(
-          quantile_accumulator_handle_1, flushed_summaries)
+          quantile_accumulator_handle, flushed_summaries)
+
       flush_op = boosted_trees_ops.quantile_flush(
-          quantile_accumulator_handle_1, self.num_quantiles)
+          quantile_accumulator_handle, self.num_quantiles)
       buckets = boosted_trees_ops.get_bucket_boundaries(
-          quantile_accumulator_handle_1, num_features=2)
+          quantile_accumulator_handle, num_features=2)
       quantiles = boosted_trees_ops.boosted_trees_bucketize(
           [self._feature_0, self._feature_1], buckets)
+
       self.evaluate(summary_op)
       self.evaluate(summary_op_2)
       self.evaluate(flush_op)


### PR DESCRIPTION
Without this change TF.Transform compatibility with TF 2.0 will be significantly delayed and hindered. This new op is necessary for quantiles to function without tf.contrib.