### PR TITLE
Document AssertNextDataset op

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_AssertNextDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_AssertNextDataset.pbtxt
@@ -1,4 +1,30 @@
 op {
   graph_op_name: "AssertNextDataset"
   visibility: HIDDEN
+  in_arg {
+    name: "input_dataset"
+    description: <<END
+A variant tensor representing the input dataset.
+`AssertNextDataset` passes through the outputs of its input dataset.
+END
+  }
+  in_arg {
+  name: "transformations"
+  description: <<END
+A `tf.string` vector `tf.Tensor` identifying the transformations that are
+expected to happen next.
+END
+  }
+  summary: "A transformation that asserts which transformations happen next."
+  description: <<END
+Core C++ implementation of the transformation `assert_next()`, which is
+an internal component of `tf.data`'s Python API.
+This transformation checks whether the Pascal-case names (i.e. "FlatMap", not
+"flat_map") of the transformations immediately after it match the list of names
+in the `transformations` argument. The transformation raises an exception if
+it finds any discrepancies.
+The check occurs immediately before iterating over the results of the
+root dataset, which means that the check happens *after* any `tf.data`
+optimizations or static optimizations are applied to the dataflow graph.
+END
 }

--- a/tensorflow/core/api_def/base_api/api_def_AssertNextDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_AssertNextDataset.pbtxt
@@ -19,12 +19,14 @@ END
   description: <<END
 Core C++ implementation of the transformation `assert_next()`, which is
 an internal component of `tf.data`'s Python API.
-This transformation checks whether the Pascal-case names (i.e. "FlatMap", not
-"flat_map") of the transformations immediately after it match the list of names
-in the `transformations` argument. The transformation raises an exception if
-it finds any discrepancies.
-The check occurs immediately before iterating over the results of the
-root dataset, which means that the check happens *after* any `tf.data`
-optimizations or static optimizations are applied to the dataflow graph.
+
+This transformation checks whether the camel-case names (i.e. "FlatMap", not
+"flat_map") of the transformations following this transformation match the list
+of names in the `transformations` argument. If there is a mismatch, the
+transformation raises an exception.
+
+The check occurs when iterating over the contents of the dataset, which
+means that the check happens *after* any static optimizations are applied
+to the dataset graph.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_AssertNextDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_AssertNextDataset.pbtxt
@@ -17,9 +17,6 @@ END
   }
   summary: "A transformation that asserts which transformations happen next."
   description: <<END
-Core C++ implementation of the transformation `assert_next()`, which is
-an internal component of `tf.data`'s Python API.
-
 This transformation checks whether the camel-case names (i.e. "FlatMap", not
 "flat_map") of the transformations following this transformation match the list
 of names in the `transformations` argument. If there is a mismatch, the


### PR DESCRIPTION
This PR adds documentation to the API file for the `AssertNextDataset` op, which is part of `tf.data`.