### PR TITLE
Constant Folding: Only apply size limit if size of tensor is increasing

### DIFF
--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -60,7 +60,7 @@ namespace grappler {
 using TensorVector = gtl::InlinedVector<TensorValue, 4>;
 
 // We only fold/materialize constants smaller than 10 MiB.
-static const int64 kMaxConstantSize = 10 * 1024 * 1024;
+const int64 kMaxConstantSize = 10 * 1024 * 1024;
 
 namespace {
 template <typename T>

--- a/tensorflow/core/grappler/optimizers/constant_folding.h
+++ b/tensorflow/core/grappler/optimizers/constant_folding.h
@@ -32,6 +32,7 @@ namespace grappler {
 
 const char kConstantFoldingConst[] = "ConstantFolding";
 const char kConstantFoldingCtrl[] = "ConstantFoldingCtrl";
+extern const int64 kMaxConstantSize;
 
 // Constant folding optimization for a graph.
 class ConstantFolding : public GraphOptimizer {

--- a/tensorflow/core/grappler/optimizers/constant_folding_test.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding_test.cc
@@ -2772,6 +2772,39 @@ TEST_F(ConstantFoldingTest, Packing) {
   EXPECT_GT(8000, output.ByteSizeLong());
 }
 
+TEST_F(ConstantFoldingTest, LargeConstantNoSizeIncrease) {
+  // Build a simple graph with a large constant with size greater than
+  // kMaxConstantSize that can be folded because the resulting size does not
+  // increase.
+  tensorflow::Scope scope = tensorflow::Scope::NewRootScope();
+  const int64 large_constant_size = kMaxConstantSize + 1;
+  Output a = ops::Variable(scope.WithOpName("a"), {1, 1}, DT_FLOAT);
+  Output b_const =
+      ops::Const(scope.WithOpName("b_const"), 3.14f, {1, large_constant_size});
+  Output b = ops::Identity(scope.WithOpName("b"), b_const);
+  Output matmul = ops::MatMul(scope.WithOpName("matmul"), a, b);
+
+  GrapplerItem item;
+  TF_CHECK_OK(scope.ToGraphDef(&item.graph));
+
+  ConstantFolding optimizer(/*cpu_device=*/nullptr);
+  GraphDef output;
+  Status status = optimizer.Optimize(/*cluster=*/nullptr, item, &output);
+  TF_EXPECT_OK(status);
+
+  item.graph.Swap(&output);
+  status = optimizer.Optimize(/*cluster=*/nullptr, item, &output);
+  TF_EXPECT_OK(status);
+
+  for (const auto& node : output.node()) {
+    if (node.name() == "b") {
+      EXPECT_EQ("Const", node.op());
+    }
+  }
+  EXPECT_EQ(4, output.node_size());
+  EXPECT_LT(output.ByteSizeLong(), sizeof(float) * large_constant_size + 500);
+}
+
 TEST_F(ConstantFoldingTest, MaterializeBroadcastGradientArgs) {
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
   Output a =


### PR DESCRIPTION
[This recent commit](https://github.com/tensorflow/tensorflow/commit/56488bea5c1258fc89207944f1aa5d3f4e32a495#diff-f3c968af33d813270dacefabc01b6a73) accidently reverted my improvements from #24478

This PR adds now ensures that CreateNodeDef and IsConstantFoldable follow the same logic regarding max size.

I also added a unit test to make sure such a regression doesn't happen in the future.