### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build

### DIFF
--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -1068,15 +1068,9 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
   auto filter_ptr =
       AsDeviceMemory(transformed_filter.template flat<T>().data(),
                      transformed_filter.template flat<T>().size());
-  se::TfAllocatorAdapter tf_allocator_adapter(stream->parent()->platform(),
-                                              ctx->device()->GetAllocator({}));
-  se::cuda::RedzoneAllocator rz_allocator(stream, &tf_allocator_adapter,
-                                          se::cuda::PtxCompilationOptions());
   auto in_backprop_ptr =
       AsDeviceMemory(pre_transformed_in_backprop.template flat<T>().data(),
                      pre_transformed_in_backprop.template flat<T>().size());
-  se::DeviceMemory<T> in_backprop_ptr_rz(
-      WrapRedzoneBestEffort(&rz_allocator, in_backprop_ptr));
 
   static int64 ConvolveBackwardDataScratchSize = GetDnnWorkspaceLimit(
       "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32  // 4GB by default
@@ -1107,6 +1101,16 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
   if (cudnn_use_autotune && !AutoTuneConvBwdData::GetInstance()->Find(
                                 conv_parameters, &algorithm_config)) {
 #if GOOGLE_CUDA
+
+    se::TfAllocatorAdapter tf_allocator_adapter(
+        stream->parent()->platform(), ctx->device()->GetAllocator({}));
+
+    se::cuda::RedzoneAllocator rz_allocator(stream, &tf_allocator_adapter,
+                                            se::cuda::PtxCompilationOptions());
+
+    se::DeviceMemory<T> in_backprop_ptr_rz(
+        WrapRedzoneBestEffort(&rz_allocator, in_backprop_ptr));
+
     std::vector<AlgorithmDesc> algorithms;
     CHECK(stream->parent()->GetConvolveBackwardDataAlgorithms(
         conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(stream->parent()),


### PR DESCRIPTION
The following PR/commit breaks the --config=rocm build

https://github.com/tensorflow/tensorflow/commit/ddd77ee043ac720793d8dfb887b0eab3cfcb0adb

It introduces references to se::cuda::RedzoneAllocator (which is only visible in the CUDA build) within code that is common to both the ROCm and CUDA builds. This "fix" moves those reference to code that is visible only in the CUDA build

This is essentially the same bug + fix as in PR #31393 (but in a different file)

---------------------------------------------

@tatianashp @whchung @chsigg 
