### PR TITLE
Fix sanity build failure after #31425

### DIFF
--- a/tensorflow/python/framework/func_graph.py
+++ b/tensorflow/python/framework/func_graph.py
@@ -29,7 +29,6 @@ from tensorflow.python.eager import context
 from tensorflow.python.eager import execute
 from tensorflow.python.eager import tape
 from tensorflow.python.eager.graph_only_ops import graph_placeholder
-from tensorflow.python.framework import composite_tensor
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops


### PR DESCRIPTION
Error that this is fixing is

```
tensorflow/python/framework/func_graph.py:32: [W0611(unused-import), ] Unused composite_tensor imported from tensorflow.python.framework
```