### PR TITLE
(Resubmission) Improve Flatten to avoid using dynamic shapes when possible

### DIFF
--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -601,9 +601,7 @@ class Flatten(Layer):
         else:
           shape_dtype = dtypes.int32
         outputs = array_ops.reshape(
-            inputs, constant_op.constant(
-                (tensor_shape.dimension_value(inputs.shape[0]), -1),
-                dtype=shape_dtype))
+            inputs, constant_op.constant((batch_size, -1), dtype=shape_dtype))
       else:
         outputs = array_ops.reshape(inputs, (array_ops.shape(inputs)[0], -1))
     if not context.executing_eagerly():

--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -26,6 +26,7 @@ import warnings
 import numpy as np
 
 from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
@@ -580,9 +581,21 @@ class Flatten(Layer):
       permutation.append(1)
       inputs = array_ops.transpose(inputs, perm=permutation)
 
-    outputs = array_ops.reshape(
-        inputs, (tensor_shape.dimension_value(inputs.shape[0]) or
-                 array_ops.shape(inputs)[0], -1))
+    input_shape = inputs.shape
+    if input_shape[1:].is_fully_defined():
+      flattened_dim = tensor_shape.dimension_value(
+          np.prod(input_shape[1:], dtype=int))
+      # Temporary fix for integer overflow issue.
+      if flattened_dim > np.iinfo(np.int32).max:
+        shape_dtype = dtypes.int64
+      else:
+        shape_dtype = dtypes.int32
+      outputs = array_ops.reshape(
+          inputs, constant_op.constant((-1, flattened_dim), shape_dtype))
+    else:
+      outputs = array_ops.reshape(
+          inputs, (tensor_shape.dimension_value(inputs.shape[0]) or
+                   array_ops.shape(inputs)[0], -1))
     if not context.executing_eagerly():
       outputs.set_shape(self.compute_output_shape(inputs.shape))
     return outputs

--- a/tensorflow/python/layers/core_test.py
+++ b/tensorflow/python/layers/core_test.py
@@ -556,6 +556,12 @@ class FlattenTest(test.TestCase):
       self.assertEqual(list(np_output.shape), [5, 6])
       self.assertEqual(y.get_shape().as_list(), [5, None])
 
+  @test_util.run_deprecated_v1
+  def testFlattenLargeDim(self):
+    x = array_ops.placeholder(shape=(None, 21316, 21316, 80), dtype='float32')
+    y = core_layers.Flatten()(x)
+    self.assertEqual(y.shape.as_list(), [None, 21316 * 21316 * 80])
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/layers/core_test.py
+++ b/tensorflow/python/layers/core_test.py
@@ -562,6 +562,13 @@ class FlattenTest(test.TestCase):
     y = core_layers.Flatten()(x)
     self.assertEqual(y.shape.as_list(), [None, 21316 * 21316 * 80])
 
+  @test_util.run_deprecated_v1
+  def testFlattenLargeBatchDim(self):
+    batch_size = np.iinfo(np.int32).max + 10
+    x = array_ops.placeholder(
+        shape=(batch_size, None, None, 1), dtype='float32')
+    y = core_layers.Flatten()(x)
+    self.assertEqual(y.shape.as_list(), [batch_size, None])
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Fixes issues @ebrevdo pointed out with #30380 
I also added a unit test for the int32 overflow situation.
See original PR for explanation of overall changes.