### PR TITLE
let jni BUILD defs be publicly visible

### DIFF
--- a/tensorflow/lite/java/jni/BUILD
+++ b/tensorflow/lite/java/jni/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//tensorflow/lite:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 


### PR DESCRIPTION
The tensorflow jni BUILD is not publicly visible, so external projects trying to BUILD custom tflite clients that require a jni are not able to use it.

For example, with this change, [the smartreply demo](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/models/smartreply) would be able to move to [tensorflow/examples](https://github.com/tensorflow/examples), which I think is a more fitting location for it.