### PR TITLE
Removed duplicated registration of LessEqual with bfloat16

### DIFF
--- a/tensorflow/core/kernels/cwise_op_less_equal.cc
+++ b/tensorflow/core/kernels/cwise_op_less_equal.cc
@@ -18,8 +18,8 @@ limitations under the License.
 namespace tensorflow {
 REGISTER5(BinaryOp, CPU, "LessEqual", functor::less_equal, float, Eigen::half,
           bfloat16, double, int32);
-REGISTER5(BinaryOp, CPU, "LessEqual", functor::less_equal, int64, uint8, int8,
-          int16, bfloat16);
+REGISTER4(BinaryOp, CPU, "LessEqual", functor::less_equal, int64, uint8, int8,
+          int16);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 REGISTER7(BinaryOp, GPU, "LessEqual", functor::less_equal, float, Eigen::half,


### PR DESCRIPTION
This is a follow up PR to #30479 where the duplicated registration of
Less with bfloat16 has been removed, but not LessEqual

This fix fixed duplicate bfloat16 entry of LessEqual as well.

This fix is related to #30476.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>