### PR TITLE
Ruy: Fix cstring include in detect_dotprod.cc

### DIFF
--- a/tensorflow/lite/experimental/ruy/detect_dotprod.cc
+++ b/tensorflow/lite/experimental/ruy/detect_dotprod.cc
@@ -83,7 +83,7 @@ bool try_asm_snippet(bool (*asm_snippet)()) {
 #include <cstdio>
 #include <cstdlib>
 #include <mutex>  // NOLINT(build/c++11)
-#include <string>
+#include <cstring>
 
 // Intentionally keep checking for __linux__ here in case we want to
 // extend RUY_IMPLEMENT_DETECT_DOTPROD outside of linux in the future.


### PR DESCRIPTION
`detect_dotprod.cc` uses `memset` command which is defined in `<cstring> (string.h)`.
However `detect_dotprod.cc` includes `<string>` instead of `<cstring>`.
This PR fixes the include statement.

TFLite compilation Error (using `aarch64-linux-gnu-g++-5.4.0` on Ubuntu 16.04):
```
aarch64-linux-gnu-g++ -O3 -DNDEBUG -fPIC  --std=c++11 -march=armv8-a -funsafe-math-optimizations -ftree-vectorize -fPIC -I. -I/root/tensorflow/tensorflow/lite/tools/make/../../../../../ -I/root/tensorflow/tensorflow/lite/tools/make/../../../../../../ -I/root/tensorflow/tensorflow/lite/tools/make/downloads/ -I/root/tensorflow/tensorflow/lite/tools/make/downloads/eigen -I/root/tensorflow/tensorflow/lite/tools/make/downloads/absl -I/root/tensorflow/tensorflow/lite/tools/make/downloads/gemmlowp -I/root/tensorflow/tensorflow/lite/tools/make/downloads/neon_2_sse -I/root/tensorflow/tensorflow/lite/tools/make/downloads/farmhash/src -I/root/tensorflow/tensorflow/lite/tools/make/downloads/flatbuffers/include -I -I/usr/local/include -c tensorflow/lite/experimental/ruy/detect_dotprod.cc -o /root/tensorflow/tensorflow/lite/tools/make/gen/aarch64_armv8-a/obj/tensorflow/lite/experimental/ruy/detect_dotprod.o
tensorflow/lite/experimental/ruy/detect_dotprod.cc: In function 'bool ruy::{anonymous}::try_asm_snippet(bool (*)())':
tensorflow/lite/experimental/ruy/detect_dotprod.cc:138:50: error: 'memset' was not declared in this scope
   memset(&sigill_action, 0, sizeof(sigill_action));
                                                  ^
tensorflow/lite/tools/make/Makefile:244: recipe for target '/root/tensorflow/tensorflow/lite/tools/make/gen/aarch64_armv8-a/obj/tensorflow/lite/experimental/ruy/detect_dotprod.o' failed
make: *** [/root/tensorflow/tensorflow/lite/tools/make/gen/aarch64_armv8-a/obj/tensorflow/lite/experimental/ruy/detect_dotprod.o] Error 1
make: *** Waiting for unfinished jobs....
make: Leaving directory '/root/tensorflow'
```