### PR TITLE
make jni cc library publicly visible

### DIFF
--- a/tensorflow/lite/java/jni/BUILD
+++ b/tensorflow/lite/java/jni/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "//tensorflow:android": [],
         "//conditions:default": ["."],
     }),
+    visibility = ["//visibility:public"],
 )
 
 # Silly rules to make

--- a/tensorflow/lite/java/jni/BUILD
+++ b/tensorflow/lite/java/jni/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorflow/lite:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorflow/lite/java/jni/BUILD
+++ b/tensorflow/lite/java/jni/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//tensorflow/lite:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 


### PR DESCRIPTION
The tensorflow jni cc_library is not publicly visible, so external projects trying to BUILD custom tflite clients that require jni library are not able to use it.

For example, with this change, [the smartreply demo](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/models/smartreply) would be able to move to [tensorflow/examples](https://github.com/tensorflow/examples), which I think is a more fitting location for it.