### PR TITLE
Ruy: Fix include of cstring for memset

### DIFF
--- a/tensorflow/lite/experimental/ruy/detect_dotprod.cc
+++ b/tensorflow/lite/experimental/ruy/detect_dotprod.cc
@@ -82,8 +82,8 @@ bool try_asm_snippet(bool (*asm_snippet)()) {
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <mutex>  // NOLINT(build/c++11)
-#include <string>
 
 // Intentionally keep checking for __linux__ here in case we want to
 // extend RUY_IMPLEMENT_DETECT_DOTPROD outside of linux in the future.


### PR DESCRIPTION
Fixes build on aarch64 Ubuntu 18.04