### PR TITLE
[INTEL MKL] Fix the error 'install_pip_packages.sh: line 20: pip2: command not found

### DIFF
--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -48,16 +48,18 @@ apt-get install -y --no-install-recommends \
     ffmpeg \
     git \
     libcurl4-openssl-dev \
-    libtool \
     libssl-dev \
+    libtool \
     mlocate \
     openjdk-8-jdk \
     openjdk-8-jre-headless \
     pkg-config \
     python-dev \
+    python-pip \
     python-setuptools \
     python-virtualenv \
     python3-dev \
+    python3-pip \
     python3-setuptools \
     rsync \
     sudo \

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -20,6 +20,9 @@ set -e
 pip2 install --upgrade pip
 pip3 install --upgrade pip
 
+# update pip binary locations
+cp -rp /usr/local/bin/pip* /usr/bin/
+
 # Install pip packages from whl files to avoid the time-consuming process of
 # building from source.
 


### PR DESCRIPTION
This PR is to fix the `cpu` image build job here: https://tensorflow-ci.intel.com/job/tensorflow-mkl-linux-cpu/1190/console