### PR TITLE
A bug in the docs of count_nozero

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1504,7 +1504,7 @@ def reduce_euclidean_norm(input_tensor, axis=None, keepdims=False, name=None):
                              "keep_dims is deprecated, use keepdims instead",
                              "keep_dims")
 @deprecation.deprecated_args(
-    None, "reduction_indices is deprecated, use axis instead", "axis")
+    None, "reduction_indices is deprecated, use axis instead", "reduction_indices")
 def count_nonzero(input_tensor=None,
                   axis=None,
                   keepdims=None,


### PR DESCRIPTION
It is the "reduction_indices" that is deprecated instead of "axis"
Same bugs appear in tf2.0, too.