### PR TITLE
r2.0-rc0 cherry-pick request: Rollback gradients change which broke convergence for NCF

### DIFF
--- a/tensorflow/python/eager/pywrap_tfe_src.cc
+++ b/tensorflow/python/eager/pywrap_tfe_src.cc
@@ -2371,6 +2371,7 @@ bool OpGradientDoesntRequireInputIndices(
           {"Relu6", {true, {}}},
           {"Elu", {true, {}}},
           {"Selu", {true, {}}},
+          {"SparseSoftmaxCrossEntropyWithLogits", {true, {}}},
           {"Neg", {true, {}}},
           {"Inv", {true, {}}},
           {"Reciprocal", {true, {}}},
@@ -2388,7 +2389,6 @@ bool OpGradientDoesntRequireInputIndices(
 
           // Ops that don't require a subset of inputs.
           {"FusedBatchNorm", {false, {2}}},
-          {"SparseSoftmaxCrossEntropyWithLogits", {false, {1}}},
       });
 
   auto it = m->find(op_name);

--- a/tensorflow/python/kernel_tests/xent_op_test.py
+++ b/tensorflow/python/kernel_tests/xent_op_test.py
@@ -242,7 +242,6 @@ class XentTest(test.TestCase):
           op.op_def.name for op in sess.graph.get_operations() if op.op_def
       ]
       self.assertNotIn("BatchMatMul", op_names)
-      self.assertNotIn("BatchMatMulV2", op_names)
 
     print("cross entropy gradient err = ", err)
     self.assertLess(err, 5e-8)

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -513,24 +513,6 @@ def _BroadcastMul(vec, mat):
   return vec * mat
 
 
-def _IsZero(tensor):
-  """Check if tensor contains only zeros.
-
-  Args:
-    tensor: tensor to check
-
-  Returns:
-    True if tensor contains only zeros and False otherwise
-  """
-  if context.executing_eagerly():
-    # TODO(apassos) add an efficient way to detect eager zeros here.
-    return False
-  if tensor.op.type in ("ZerosLike", "Zeros"):
-    return True
-  const_fill_value = tensor_util.constant_value(tensor)
-  return const_fill_value is not None and (const_fill_value == 0).all()
-
-
 @ops.RegisterGradient("SoftmaxCrossEntropyWithLogits")
 def _SoftmaxCrossEntropyWithLogitsGrad(op, grad_loss, grad_grad):
   """Gradient function for SoftmaxCrossEntropyWithLogits."""
@@ -542,8 +524,18 @@ def _SoftmaxCrossEntropyWithLogitsGrad(op, grad_loss, grad_grad):
   softmax_grad = op.outputs[1]
   grad = _BroadcastMul(grad_loss, softmax_grad)
 
+  def IsZero(g):
+    # Some introspection to check if the gradient is feeding zeros
+    if context.executing_eagerly():
+      # TODO(apassos) add an efficient way to detect eager zeros here.
+      return False
+    if g.op.type in ("ZerosLike", "Zeros"):
+      return True
+    const_fill_value = tensor_util.constant_value(g)
+    return const_fill_value is not None and (const_fill_value == 0).all()
+
   logits = op.inputs[0]
-  if grad_grad is not None and not _IsZero(grad_grad):
+  if grad_grad is not None and not IsZero(grad_grad):
     softmax = nn_ops.softmax(logits)
 
     grad += ((grad_grad - array_ops.squeeze(
@@ -556,28 +548,22 @@ def _SoftmaxCrossEntropyWithLogitsGrad(op, grad_loss, grad_grad):
 
 
 @ops.RegisterGradient("SparseSoftmaxCrossEntropyWithLogits")
-def _SparseSoftmaxCrossEntropyWithLogitsGrad(op, grad_loss, grad_grad):
+def _SparseSoftmaxCrossEntropyWithLogitsGrad(op, grad_0, _):
   """Gradient function for SparseSoftmaxCrossEntropyWithLogits."""
-  # grad_loss is the backprop for cost, and we multiply it with the gradients
+  # grad_0 is the backprop for cost, and we multiply it with the gradients
   # (which is output[1])
-  # grad_grad is the backprop for softmax gradient.
   # There is no gradient for the labels
   #
-  # Second derivative is just softmax derivative w.r.t. logits.
-  softmax_grad = op.outputs[1]
-  grad = _BroadcastMul(grad_loss, softmax_grad)
-
-  logits = op.inputs[0]
-  if grad_grad is not None and not _IsZero(grad_grad):
-    softmax = nn_ops.softmax(logits)
-
-    grad += ((grad_grad - array_ops.squeeze(
-        math_ops.matmul(
-            array_ops.expand_dims(grad_grad, 1),
-            array_ops.expand_dims(softmax, 2)),
-        axis=1)) * softmax)
-
-  return grad, None
+  # Currently there is no way to take the second derivative of this op
+  # due to the fused implementation's interaction with tf.gradients(),
+  # so we make sure we prevent silently incorrect results by raising
+  # an error if the second derivative is requested via prevent_gradient.
+  sparse_softmax_grad_without_gradient = array_ops.prevent_gradient(
+      op.outputs[1],
+      message="Currently there is no way to take the second "
+      "derivative of sparse_softmax_cross_entropy_with_logits due to the fused "
+      "implementation's interaction with tf.gradients()")
+  return _BroadcastMul(grad_0, sparse_softmax_grad_without_gradient), None
 
 
 @ops.RegisterGradient("Conv2D")


### PR DESCRIPTION
The original change broken convergence for NCF keras model with run_eagerly=True. This change reverts it.

Automated rollback of commit cadb1283346e08ab780e9cc7338916ebf6ebb482. Revert #22231.
PiperOrigin-RevId: 262947974