### PR TITLE
[XLA:GPU][ROCm] Fix XLA runtime issue on custom PTX check.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
@@ -245,7 +245,8 @@ GpuExecutable::ResolveConstantGlobals(se::StreamExecutor* executor) {
   module_spec.AddCudaPtxInMemory(text().c_str());
 
   absl::flat_hash_map<int64, se::DeviceMemoryBase> globals;
-  if (module_spec.cuda_ptx_in_memory() == nullptr) {
+  if (executor->platform_kind() == se::PlatformKind::kCuda &&
+      module_spec.cuda_ptx_in_memory() == nullptr) {
     // No custom PTX => no globals.
     return &module_globals_.emplace(executor, std::move(globals)).first->second;
   }


### PR DESCRIPTION
Commit c52f26a538d498e616e8a454964591612d15dd5b is erroneous and doesn't apply on ROCm. The check is only applicable on CUDA.