### PR TITLE
[tflite] make Metal Mul kernel unlinkable

### DIFF
--- a/tensorflow/lite/delegates/gpu/metal/kernels/mul.cc
+++ b/tensorflow/lite/delegates/gpu/metal/kernels/mul.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/common/operations.h"
 #include "tensorflow/lite/delegates/gpu/common/shape.h"
 #include "tensorflow/lite/delegates/gpu/common/tensor.h"
+#include "tensorflow/lite/delegates/gpu/common/util.h"
 #include "tensorflow/lite/delegates/gpu/metal/compute_task_descriptor.h"
 #include "tensorflow/lite/delegates/gpu/metal/runtime_options.h"
 
@@ -40,38 +41,73 @@ std::vector<ComputeTaskDescriptorPtr> Multiply(
     const MultiplyScalarAttributes& attr, const RuntimeOptions& options) {
   auto desc = std::make_shared<ComputeTaskDescriptor>();
   desc->id = id;
-  desc->is_linkable = true;
+  desc->is_linkable = false;
   auto multiplier = absl::get_if<float>(&attr.param);
   auto mul_buffer =
       absl::get_if<Tensor<Linear, DataType::FLOAT32>>(&attr.param);
   const bool scalar = multiplier != nullptr;
-  const std::string param_desc =
-      scalar ? "float multiplier" : "device FLT4* const mul_buf";
-  std::string code =
-      "FLT4 linkable$0(FLT4 value, int linear_index, uint3 gid, ";
-  code += param_desc + ") {\n";
+  std::string code = R"(
+    #include <metal_stdlib>
+    using namespace metal;
+    $0
+    kernel void ComputeFunction(
+                                $1
+                                uint3 gid[[thread_position_in_grid]]
+                                ) {
+        if (int(gid.x) >= size.x || int(gid.y) >= size.y) {
+            return;
+        }
+        const int linear_index = (gid.z * size.y + gid.y) * size.x + gid.x;
+        FLT4 value = FLT4(0.0f);
+    )";
   if (scalar) {
-    code += "return value * multiplier;\n";
+    code += "value = input_buffer[linear_index] * multiplier;\n";
   } else {
-    code += "return value * mul_buf[gid.z];\n";
+    code += "value = input_buffer[linear_index] * mul_buf[gid.z];\n";
   }
+  code += "$2\n";
+  code += "output_buffer[linear_index] = value;\n";
   code += "}\n";
   desc->shader_source = code;
-  desc->input_buffers = {{input_id}};
-  desc->output_buffer = {output_id};
+  desc->input_buffers = {{input_id, "device FLT4* const input_buffer"}};
+  desc->output_buffer = {output_id, "device FLT4* output_buffer", [input_id](const std::map<ValueId, BHWC>& buffers) {
+    return buffers.find(input_id)->second;
+  }};
   if (scalar) {
     std::vector<uint8_t> multiplier_bits =
         GetByteBuffer(std::vector<float>{*multiplier});
     desc->uniform_buffers = {
-        {"constant float&",
+        {"constant float& multiplier",
          [multiplier_bits](const std::map<ValueId, BHWC>& buffers) {
            return multiplier_bits;
          }},
+        {"constant int2& size", [input_id](const std::map<ValueId, BHWC>& buffers) {
+            const auto& dimension = buffers.find(input_id)->second;
+            std::vector<int> uniform_params = {dimension.w, dimension.h};
+            return VectorToUint8Vector(uniform_params);
+        }}
     };
   } else {
+    auto coeffs = GetByteBufferConverted(mul_buffer->data, options.storage_precision);
+    desc->uniform_buffers = {
+      {"constant int2& size", [input_id](const std::map<ValueId, BHWC>& buffers) {
+          const auto& dimension = buffers.find(input_id)->second;
+          std::vector<int> uniform_params = {dimension.w, dimension.h};
+          return VectorToUint8Vector(uniform_params);
+      }}
+    };
     desc->immutable_buffers = {
-        {"device FLT4* const",
-         GetByteBufferConverted(mul_buffer->data, options.storage_precision)},
+        {"device FLT4* const mul_buf", coeffs},
+    };
+
+    desc->resize_function = [input_id](const std::map<ValueId, BHWC>& buffers) {
+      const auto& src_dim = buffers.find(input_id)->second;
+      const uint3 groups_size{16, 16, 1};
+      int groups_x = IntegralDivideRoundUp(src_dim.w, groups_size.x);
+      int groups_y = IntegralDivideRoundUp(src_dim.h, groups_size.y);
+      const int dst_layers = IntegralDivideRoundUp(src_dim.c, 4);
+      int groups_z = IntegralDivideRoundUp(dst_layers, groups_size.z);
+      return std::make_pair(groups_size, uint3{groups_x, groups_y, groups_z});
     };
   }
   return {desc};


### PR DESCRIPTION
As highlighted in #31468, the Mul operator causes an error when run on larger inputs. As far as I could tell from my digging, this is caused by the fact that:

 * the Mul kernel is linked with other compute tasks, and as a result does not specify a `resize_function`
 * when the Mul task is the first in a `FusionChain`, the `NonLinkableStub`'s resize function is used, which assigns the entire input to a single threadgroup

It seems that this then triggers a timeout on the GPU for larger inputs because there are not enough threads associated to this group. This workaround, which makes the Mul kernel unlinkable and specifies a proper thread grouping for this kernel, enables #31468 to work as expected.

I would imagine this change does incur some performance penalty, but I'm not sure how else to specify proper threading grouping for a linked operator.

closes #31468