### PR TITLE
Fixing build break of compiler/xla/tests

### DIFF
--- a/tensorflow/compiler/xla/bit_cast.h
+++ b/tensorflow/compiler/xla/bit_cast.h
@@ -28,6 +28,7 @@ limitations under the License.
 
 #include "absl/base/casts.h"
 #include "third_party/eigen3/Eigen/Core"
+#include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "tensorflow/core/platform/types.h"
 

--- a/tensorflow/compiler/xla/test.h
+++ b/tensorflow/compiler/xla/test.h
@@ -41,6 +41,7 @@ limitations under the License.
 #else
 #include <gmock/gmock-generated-matchers.h>
 #include <gmock/gmock-matchers.h>
+#include <gmock/gmock-more-matchers.h>
 #endif
 
 #include "tensorflow/core/platform/test.h"

--- a/tensorflow/compiler/xla/tests/BUILD
+++ b/tensorflow/compiler/xla/tests/BUILD
@@ -1650,6 +1650,7 @@ xla_test(
     name = "fmax_fmin_test",
     srcs = ["fmax_fmin_test.cc"],
     deps = [
+        ":test_macros_header",
         "//tensorflow/compiler/xla/client:local_client",
         "//tensorflow/compiler/xla/client:xla_builder",
         "//tensorflow/compiler/xla/client:xla_computation",
@@ -1889,6 +1890,7 @@ xla_test(
         "//tensorflow/compiler/xla/service:hlo",
         "//tensorflow/compiler/xla/service:hlo_parser",
         "//tensorflow/compiler/xla/service:hlo_runner",
+        "//tensorflow/compiler/xla/service/gpu:nccl_all_reduce_thunk",
         "//tensorflow/compiler/xla/tests:client_library_test_base",
         "//tensorflow/compiler/xla/tests:hlo_test_base",
         "//tensorflow/compiler/xla/tests:literal_test_util",

--- a/tensorflow/compiler/xla/tests/collective_ops_test.cc
+++ b/tensorflow/compiler/xla/tests/collective_ops_test.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "absl/strings/str_replace.h"
 #include "absl/types/span.h"
 #include "tensorflow/compiler/xla/literal.h"
 #include "tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h"

--- a/tensorflow/compiler/xla/tests/exhaustive_op_test_utils.h
+++ b/tensorflow/compiler/xla/tests/exhaustive_op_test_utils.h
@@ -1121,7 +1121,7 @@ FpValues GetNans(int approx_num_values) {
 
 template <typename T>
 FpValues GetNormals(int approx_num_values) {
-  float component_total = std::sqrtf(approx_num_values);
+  float component_total = std::sqrt(static_cast<float>(approx_num_values));
   return GetFpValues<T>(
       BitChunks(0x1, GetAllOneMantissa<T>(),
                 (1ull << (GetMantissaTotalBits<T>() + 1)) / component_total),


### PR DESCRIPTION
Fixing build breaks for missing dependencies mostly due to discrepancy between google internal build system and the OSS build system.

See commit logs for details.
