### PR TITLE
Fix "TypeError" when loading keras h5 model

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -2584,7 +2584,7 @@ class TensorFlowOpLayer(Layer):
         value = tensor_util.constant_value(constant)
         if value is not None:
           constant = constant_op.constant(value, name=node_def.input[index])
-        inputs.insert(int(index), constant)
+        inputs.insert(index, constant)
       # Check for case where first input should be a list of Tensors.
       if 'N' in node_def.attr:
         num_tensors = node_def.attr['N'].i

--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -2584,7 +2584,7 @@ class TensorFlowOpLayer(Layer):
         value = tensor_util.constant_value(constant)
         if value is not None:
           constant = constant_op.constant(value, name=node_def.input[index])
-        inputs.insert(index, constant)
+        inputs.insert(int(index), constant)
       # Check for case where first input should be a list of Tensors.
       if 'N' in node_def.attr:
         num_tensors = node_def.attr['N'].i

--- a/tensorflow/python/keras/layers/serialization.py
+++ b/tensorflow/python/keras/layers/serialization.py
@@ -32,6 +32,7 @@ from tensorflow.python.keras.layers.convolutional import *
 from tensorflow.python.keras.layers.convolutional_recurrent import *
 from tensorflow.python.keras.layers.core import *
 from tensorflow.python.keras.layers.cudnn_recurrent import *
+from tensorflow.python.keras.layers.dense_attention import *
 from tensorflow.python.keras.layers.embeddings import *
 from tensorflow.python.keras.layers.local import *
 from tensorflow.python.keras.layers.merge import *


### PR DESCRIPTION
h5 model used by keras was saved using json.dump function。 json.dump function silently converts int keys to string , [silently converts int keys to string](https://bugs.python.org/issue34972).  The keys in "constant" dict are INT type, but they convert to STRING in the saved model. 
For the above reasons，I got "TypeError: 'str' object cannot be interpreted as an integer" ERROR, when loading my h5 model.
Converting "index" variable to int type fixes the problem.