### PR TITLE
Keras Optimizer Documentation Fix

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
+++ b/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
@@ -304,8 +304,7 @@ class OptimizerV2(trackable.Trackable):
       name: Optional name for the returned operation.
 
     Returns:
-      An Operation that updates the variables in `var_list`.  If `global_step`
-      was not `None`, that operation also increments `global_step`.
+      An Operation that updates the variables in `var_list`.
 
     Raises:
       ValueError: If some of the variables are not `Variable` objects.
@@ -415,8 +414,7 @@ class OptimizerV2(trackable.Trackable):
         passed to the `Optimizer` constructor.
 
     Returns:
-      An `Operation` that applies the specified gradients. If `global_step`
-      was not None, that operation also increments `global_step`.
+      An `Operation` that applies the specified gradients.
 
     Raises:
       TypeError: If `grads_and_vars` is malformed.


### PR DESCRIPTION
The documentation of Keras Optimizer mention the following:
```python
If global_step  was not `None`, that operation also increments global_step.
```

You can also find it here: https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/keras/optimizers/Optimizer#apply_gradients

Keras Optimizer do not use the concept of global_step. It's misleading and shall be removed.

**Note:** As it impacts directly the TF2.0 documentation. It would be nice if this PR could be cherrypicked in the next beta/official release for TF2.0