### PR TITLE
Add some macros to simplify the parameterized dataset tests

### DIFF
--- a/tensorflow/core/kernels/data/batch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/batch_dataset_op_test.cc
@@ -19,7 +19,6 @@ namespace {
 
 constexpr char kNodeName[] = "batch_dataset_v2";
 constexpr int kOpVersion = 2;
-constexpr char kIteratorPrefix[] = "Iterator";
 
 class BatchDatasetParams : public DatasetParams {
  public:
@@ -36,8 +35,7 @@ class BatchDatasetParams : public DatasetParams {
         parallel_copy(parallel_copy) {}
 
   Status MakeInputs(gtl::InlinedVector<TensorValue, 4>* inputs) override {
-    if (input_dataset.NumElements() == 0 ||
-        input_dataset.dtype() != DT_VARIANT) {
+    if (!IsDatasetTensor(input_dataset)) {
       return errors::Internal(
           "The input dataset is not populated as the dataset tensor yet.");
     }
@@ -67,7 +65,7 @@ class BatchDatasetOpTest : public DatasetOpsTestBaseV2<BatchDatasetParams> {
                                         &batch_dataset_params->input_dataset));
     // Create the dataset kernel.
     TF_RETURN_IF_ERROR(
-        CreateBatchDatasetOpKernel(*batch_dataset_params, &dataset_kernel_));
+        MakeDatasetOpKernel(*batch_dataset_params, &dataset_kernel_));
     // Create the inputs for the dataset op.
     gtl::InlinedVector<TensorValue, 4> inputs;
     TF_RETURN_IF_ERROR(batch_dataset_params->MakeInputs(&inputs));
@@ -82,16 +80,17 @@ class BatchDatasetOpTest : public DatasetOpsTestBaseV2<BatchDatasetParams> {
     TF_RETURN_IF_ERROR(
         CreateIteratorContext(dataset_ctx_.get(), &iterator_ctx_));
     // Create the iterator.
-    TF_RETURN_IF_ERROR(dataset_->MakeIterator(iterator_ctx_.get(),
-                                              kIteratorPrefix, &iterator_));
+    TF_RETURN_IF_ERROR(dataset_->MakeIterator(
+        iterator_ctx_.get(), batch_dataset_params->iterator_prefix,
+        &iterator_));
     return Status::OK();
   }
 
  protected:
   // Creates a new `BatchDataset` op kernel.
-  Status CreateBatchDatasetOpKernel(
+  Status MakeDatasetOpKernel(
       const BatchDatasetParams& dataset_params,
-      std::unique_ptr<OpKernel>* batch_dataset_op_kernel) {
+      std::unique_ptr<OpKernel>* batch_dataset_op_kernel) override {
     name_utils::OpNameParams params;
     params.op_version = kOpVersion;
     NodeDef node_def = test::function::NDef(
@@ -202,10 +201,6 @@ BatchDatasetParams InvalidBatchSizeBatchDatasetParams() {
           /*node_name=*/kNodeName};
 }
 
-class ParameterizedGetNextTest : public BatchDatasetOpTest,
-                                 public ::testing::WithParamInterface<
-                                     GetNextTestCase<BatchDatasetParams>> {};
-
 std::vector<GetNextTestCase<BatchDatasetParams>> GetNextTestCases() {
   return {{/*dataset_params=*/BatchDatasetParams1(),
            /*expected_outputs=*/
@@ -236,17 +231,8 @@ std::vector<GetNextTestCase<BatchDatasetParams>> GetNextTestCases() {
            /*expected_outputs=*/{}}};
 }
 
-TEST_P(ParameterizedGetNextTest, GetNext) {
-  auto test_case = GetParam();
-  TF_ASSERT_OK(Initialize(&test_case.dataset_params));
-  TF_ASSERT_OK(
-      CheckIteratorGetNext(test_case.expected_outputs, /*compare_order=*/true));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    BatchDatasetOpTest, ParameterizedGetNextTest,
-    ::testing::ValuesIn(
-        std::vector<GetNextTestCase<BatchDatasetParams>>(GetNextTestCases())));
+ITERATOR_GET_NEXT_TEST_P(BatchDatasetOpTest, BatchDatasetParams,
+                         GetNextTestCases())
 
 TEST_F(BatchDatasetOpTest, DatasetNodeName) {
   auto batch_dataset_params = BatchDatasetParams1();
@@ -269,11 +255,6 @@ TEST_F(BatchDatasetOpTest, DatasetOutputDtypes) {
   TF_ASSERT_OK(CheckDatasetOutputDtypes({DT_INT64}));
 }
 
-class ParameterizedDatasetOutputShapesTest
-    : public BatchDatasetOpTest,
-      public ::testing::WithParamInterface<
-          DatasetOutputShapesTestCase<BatchDatasetParams>> {};
-
 std::vector<DatasetOutputShapesTestCase<BatchDatasetParams>>
 DatasetOutputShapesTestCases() {
   return {{/*dataset_params=*/BatchDatasetParams1(),
@@ -292,22 +273,8 @@ DatasetOutputShapesTestCases() {
            /*expected_output_shapes=*/{PartialTensorShape({4})}}};
 }
 
-TEST_P(ParameterizedDatasetOutputShapesTest, DatasetOutputShapes) {
-  auto test_case = GetParam();
-  TF_ASSERT_OK(Initialize(&test_case.dataset_params));
-  TF_ASSERT_OK(CheckDatasetOutputShapes(test_case.expected_output_shapes));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    BatchDatasetOpTest, ParameterizedDatasetOutputShapesTest,
-    ::testing::ValuesIn(
-        std::vector<DatasetOutputShapesTestCase<BatchDatasetParams>>(
-            DatasetOutputShapesTestCases())));
-
-class ParameterizedCardinalityTest
-    : public BatchDatasetOpTest,
-      public ::testing::WithParamInterface<
-          CardinalityTestCase<BatchDatasetParams>> {};
+DATASET_OUTPUT_SHAPES_TEST_P(BatchDatasetOpTest, BatchDatasetParams,
+                             DatasetOutputShapesTestCases())
 
 std::vector<CardinalityTestCase<BatchDatasetParams>> CardinalityTestCases() {
   return {
@@ -320,27 +287,14 @@ std::vector<CardinalityTestCase<BatchDatasetParams>> CardinalityTestCases() {
       {/*dataset_params=*/BatchDatasetParams7(), /*expected_cardinality=*/0}};
 }
 
-TEST_P(ParameterizedCardinalityTest, Cardinality) {
-  auto test_case = GetParam();
-  TF_ASSERT_OK(Initialize(&test_case.dataset_params));
-  TF_ASSERT_OK(CheckDatasetCardinality(test_case.expected_cardinality));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    BatchDatasetOpTest, ParameterizedCardinalityTest,
-    ::testing::ValuesIn(std::vector<CardinalityTestCase<BatchDatasetParams>>(
-        CardinalityTestCases())));
+DATASET_CARDINALITY_TEST_P(BatchDatasetOpTest, BatchDatasetParams,
+                           CardinalityTestCases())
 
 TEST_F(BatchDatasetOpTest, IteratorOutputDtypes) {
   auto batch_dataset_params = BatchDatasetParams1();
   TF_ASSERT_OK(Initialize(&batch_dataset_params));
   TF_ASSERT_OK(CheckIteratorOutputDtypes({DT_INT64}));
 }
-
-class ParameterizedIteratorOutputShapesTest
-    : public BatchDatasetOpTest,
-      public ::testing::WithParamInterface<
-          IteratorOutputShapesTestCase<BatchDatasetParams>> {};
 
 std::vector<IteratorOutputShapesTestCase<BatchDatasetParams>>
 IteratorOutputShapesTestCases() {
@@ -360,17 +314,8 @@ IteratorOutputShapesTestCases() {
            /*expected_output_shapes=*/{PartialTensorShape({4})}}};
 }
 
-TEST_P(ParameterizedIteratorOutputShapesTest, IteratorOutputShapes) {
-  auto test_case = GetParam();
-  TF_ASSERT_OK(Initialize(&test_case.dataset_params));
-  TF_ASSERT_OK(CheckIteratorOutputShapes(test_case.expected_output_shapes));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    BatchDatasetOpTest, ParameterizedIteratorOutputShapesTest,
-    ::testing::ValuesIn(
-        std::vector<IteratorOutputShapesTestCase<BatchDatasetParams>>(
-            IteratorOutputShapesTestCases())));
+ITERATOR_OUTPUT_SHAPES_TEST_P(BatchDatasetOpTest, BatchDatasetParams,
+                              IteratorOutputShapesTestCases())
 
 TEST_F(BatchDatasetOpTest, IteratorOutputPrefix) {
   auto batch_dataset_params = BatchDatasetParams1();
@@ -378,13 +323,9 @@ TEST_F(BatchDatasetOpTest, IteratorOutputPrefix) {
   name_utils::IteratorPrefixParams params;
   params.op_version = kOpVersion;
   TF_ASSERT_OK(CheckIteratorPrefix(name_utils::IteratorPrefix(
-      BatchDatasetOp::kDatasetType, kIteratorPrefix, params)));
+      BatchDatasetOp::kDatasetType, batch_dataset_params.iterator_prefix,
+      params)));
 }
-
-class ParameterizedIteratorSaveAndRestoreTest
-    : public BatchDatasetOpTest,
-      public ::testing::WithParamInterface<
-          IteratorSaveAndRestoreTestCase<BatchDatasetParams>> {};
 
 std::vector<IteratorSaveAndRestoreTestCase<BatchDatasetParams>>
 IteratorSaveAndRestoreTestCases() {
@@ -424,18 +365,8 @@ IteratorSaveAndRestoreTestCases() {
            /*expected_outputs=*/{}}};
 }
 
-TEST_P(ParameterizedIteratorSaveAndRestoreTest, IteratorSaveAndRestore) {
-  auto test_case = GetParam();
-  TF_ASSERT_OK(Initialize(&test_case.dataset_params));
-  TF_ASSERT_OK(CheckIteratorSaveAndRestore(
-      kIteratorPrefix, test_case.expected_outputs, test_case.breakpoints));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    BatchDatasetOpTest, ParameterizedIteratorSaveAndRestoreTest,
-    ::testing::ValuesIn(
-        std::vector<IteratorSaveAndRestoreTestCase<BatchDatasetParams>>(
-            IteratorSaveAndRestoreTestCases())));
+ITERATOR_SAVE_AND_RESTORE_TEST_P(BatchDatasetOpTest, BatchDatasetParams,
+                                 IteratorSaveAndRestoreTestCases())
 
 TEST_F(BatchDatasetOpTest, InvalidBatchSize) {
   auto batch_dataset_params = InvalidBatchSizeBatchDatasetParams();


### PR DESCRIPTION
This PR adds some macros (e.g. `ITERATOR_GET_NEXT_TEST_P` and `ITERATOR_SAVE_AND_RESTORE_TEST_P`) to simplify the parameterized dataset tests.

cc: @jsimsa  