### PR TITLE
[INTEL MKL] Fix to MKLDNN build failure

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1221,6 +1221,7 @@ def tf_cc_test_mkl(
             size = size,
             args = args,
             features = disable_header_modules,
+            nocopts = "-fno-exceptions",
         )
 
 def tf_cc_tests_gpu(
@@ -1508,7 +1509,8 @@ def tf_mkl_kernel_library(
         hdrs = None,
         deps = None,
         alwayslink = 1,
-        copts = tf_copts()):
+        copts = tf_copts(),
+        nocopts = "-fno-exceptions"):
     """A rule to build MKL-based TensorFlow kernel libraries."""
 
     if not bool(srcs):
@@ -1536,6 +1538,7 @@ def tf_mkl_kernel_library(
         deps = deps,
         alwayslink = alwayslink,
         copts = copts,
+        nocopts = nocopts,
         features = disable_header_modules,
     )
 

--- a/third_party/mkl_dnn/mkldnn.BUILD
+++ b/third_party/mkl_dnn/mkldnn.BUILD
@@ -91,6 +91,7 @@ cc_library(
         "src/cpu/gemm",
         "src/cpu/xbyak",
     ],
+    nocopts = "-fno-exceptions",
     visibility = ["//visibility:public"],
     deps = select({
         "@org_tensorflow//tensorflow:linux_x86_64": [


### PR DESCRIPTION
The following commit has caused mkldnn build failure. https://github.com/tensorflow/tensorflow/commit/ddde447e792231cdf83b435b0eeb59dd59bf4044
This PR re-enables exceptions flags for MKLDNN library.