### PR TITLE
Exception handling fix in `math_ops.div_no_nan()`

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1108,8 +1108,8 @@ def div_no_nan(x, y, name=None):
   """
 
   with ops.name_scope(name, "div_no_nan", [x, y]) as name:
-    x = ops.convert_to_tensor(x, name="x", dtype=x.dtype.base_dtype)
-    y = ops.convert_to_tensor(y, name="y", )
+    x = ops.convert_to_tensor(x, name="x")
+    y = ops.convert_to_tensor(y, name="y", dtype=x.dtype.base_dtype)
     return gen_math_ops.div_no_nan(x, y, name=name)
 
 

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1105,19 +1105,11 @@ def div_no_nan(x, y, name=None):
 
   Returns:
     The element-wise value of the x divided by y.
-  
-  Raises:
-    TypeError: if x and y are not of the same dtype.
   """
 
   with ops.name_scope(name, "div_no_nan", [x, y]) as name:
-    x = ops.convert_to_tensor(x, name="x")
-    y = ops.convert_to_tensor(y, name="y")
-    x_dtype = x.dtype.base_dtype
-    y_dtype = y.dtype.base_dtype
-    if x_dtype != y_dtype:
-      raise TypeError("x and y must have the same dtype, got %r != %r" %
-                      (x_dtype, y_dtype))
+    x = ops.convert_to_tensor(x, name="x", dtype=x.dtype.base_dtype)
+    y = ops.convert_to_tensor(y, name="y", )
     return gen_math_ops.div_no_nan(x, y, name=name)
 
 

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1109,7 +1109,7 @@ def div_no_nan(x, y, name=None):
 
   with ops.name_scope(name, "div_no_nan", [x, y]) as name:
     x = ops.convert_to_tensor(x, name="x")
-    y = ops.convert_to_tensor(y, name="y", dtype=x.dtype.base_dtype)
+    y = ops.convert_to_tensor(y, name="y")
     x_dtype = x.dtype.base_dtype
     y_dtype = y.dtype.base_dtype
     if x_dtype != y_dtype:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1105,6 +1105,9 @@ def div_no_nan(x, y, name=None):
 
   Returns:
     The element-wise value of the x divided by y.
+  
+  Raises:
+    TypeError: if x and y are not of the same dtype.
   """
 
   with ops.name_scope(name, "div_no_nan", [x, y]) as name:

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -557,16 +557,6 @@ class DivNoNanTest(test_util.TensorFlowTestCase):
         tf_result = math_ops.div_no_nan(nums, divs).eval()
         self.assertAllEqual(tf_result, np_result)
 
-  @test_util.run_in_graph_and_eager_modes
-  def testdTypeException(self):
-    dtype_list = [np.float16, np.float32, np.int32, np.float64]
-    for i, dt in enumerate(dtype_list):
-      nums = np.random.rand(5, 5).astype(dt)
-      divs = np.random.rand(5, 5).astype(dtype_list[(i-1)%len(dtype_list)])
-      with self.assertRaisesRegexp(TypeError,
-                                   "x and y must have the same dtype"):
-        math_ops.div_no_nan(nums, divs)
-
 
 class MultiplyNoNanTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -556,14 +556,15 @@ class DivNoNanTest(test_util.TensorFlowTestCase):
       with self.cached_session(use_gpu=True):
         tf_result = math_ops.div_no_nan(nums, divs).eval()
         self.assertAllEqual(tf_result, np_result)
-  
-  @test_util.run_in_graph_and_eager_modes  
+
+  @test_util.run_in_graph_and_eager_modes
   def testdTypeException(self):
     dtype_list = [np.float16, np.float32, np.int32, np.float64]
     for i, dt in enumerate(dtype_list):
-      nums = np.random.rand(5,5).astype(dt)
-      divs = np.random.rand(5,5).astype(dtype_list[(i-1)%len(dtype_list)])
-      with self.assertRaises(TypeError):
+      nums = np.random.rand(5, 5).astype(dt)
+      divs = np.random.rand(5, 5).astype(dtype_list[(i-1)%len(dtype_list)])
+      with self.assertRaisesRegexp(TypeError,
+                                   "x and y must have the same dtype"):
         math_ops.div_no_nan(nums, divs)
 
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -556,6 +556,15 @@ class DivNoNanTest(test_util.TensorFlowTestCase):
       with self.cached_session(use_gpu=True):
         tf_result = math_ops.div_no_nan(nums, divs).eval()
         self.assertAllEqual(tf_result, np_result)
+  
+  @test_util.run_in_graph_and_eager_modes  
+  def testdTypeException(self):
+    dtype_list = [np.float16, np.float32, np.int32, np.float64]
+    for i, dt in enumerate(dtype_list):
+      nums = np.random.rand(5,5).astype(dt)
+      divs = np.random.rand(5,5).astype(dtype_list[(i-1)%len(dtype_list)])
+      with self.assertRaises(TypeError):
+        math_ops.div_no_nan(nums, divs)
 
 
 class MultiplyNoNanTest(test_util.TensorFlowTestCase):


### PR DESCRIPTION
Currently `div_no_nan()` does not raise a `TypeError` if the inputs are of different types. Although the code for that exists, it is never executed as in one of the lines above that, the code fails with a different error. This is fixed in the first [commit](https://github.com/tensorflow/tensorflow/commit/25ffbdfccc02b7f8c2e05f76c066ddef2503af39). 

Code to execute:

```python
import tensorflow as tf
a = tf.constant(1, dtype=tf.float32)
b = tf.constant(2, dtype=tf.float64)
c = tf.div_no_nan(a,b)
```
Earlier:
```python

ValueError: Tensor conversion requested dtype float32 for Tensor with dtype float64: 'tf.Tensor(2.0, shape=(), dtype=float64)'

```
Now:
```python

TypeError: x and y must have the same dtype, got tf.float32 != tf.float64
```
