### PR TITLE
Go: allow larger C array backed slices on 64 bit machines

### DIFF
--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -94,7 +94,12 @@ func (g *Graph) WriteTo(w io.Writer) (int64, error) {
 	// A []byte slice backed by C memory.
 	// See: https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
 	length := int(buf.length)
-	slice := (*[1 << 30]byte)(unsafe.Pointer(buf.data))[:length:length]
+	var slice []byte
+	if unsafe.Sizeof(unsafe.Pointer(nil)) == 8 {
+		slice = (*[1<<50 - 1]byte)(unsafe.Pointer(buf.data))[:length:length]
+	} else {
+		slice = (*[1 << 30]byte)(unsafe.Pointer(buf.data))[:length:length]
+	}
 	n, err := w.Write(slice)
 	return int64(n), err
 }

--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -207,7 +207,12 @@ func tensorData(c *C.TF_Tensor) []byte {
 		return nil
 	}
 	length := int(C.TF_TensorByteSize(c))
-	slice := (*[1 << 30]byte)(unsafe.Pointer(cbytes))[:length:length]
+	var slice []byte
+	if unsafe.Sizeof(unsafe.Pointer(nil)) == 8 {
+		slice = (*[1<<50 - 1]byte)(unsafe.Pointer(cbytes))[:length:length]
+	} else {
+		slice = (*[1 << 30]byte)(unsafe.Pointer(cbytes))[:length:length]
+	}
 	return slice
 }
 


### PR DESCRIPTION
See the discussion on https://github.com/golang/go/issues/13656

In particular, https://github.com/golang/go/issues/13656#issuecomment-291957684