### PR TITLE
[tflite] Metal GPU delegate: implement Mean operator

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/model_builder.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder.cc
@@ -1360,6 +1360,27 @@ class LSTMOperationParser : public TFLiteOperationParser {
   }
 };
 
+class MeanOperationParser : public TFLiteOperationParser {
+ public:
+  Status IsSupported(const TfLiteContext* context,
+                     const TfLiteNode* tflite_node,
+                     const TfLiteRegistration* registration) final {
+    RETURN_IF_ERROR(CheckMaxSupportedOpVersion(registration, 1));
+    return OkStatus();
+  }
+
+  Status Parse(const TfLiteNode* tflite_node,
+               const TfLiteRegistration* registration, GraphFloat32* graph,
+               ObjectReader* reader) final {
+    Node* node = graph->NewNode();
+    node->operation.type = ToString(OperationType::MEAN);
+
+    RETURN_IF_ERROR(reader->AddInput(node, 0));
+
+    return reader->AddOutputs(node);
+  }
+};
+
 class MulOperationParser : public TFLiteOperationParser {
  public:
   Status IsSupported(const TfLiteContext* context,
@@ -2143,6 +2164,8 @@ std::unique_ptr<TFLiteOperationParser> NewOperationParser(
       return absl::make_unique<LSTMOperationParser>();
     case kTfLiteBuiltinMaxPool2d:
       return absl::make_unique<Pooling2DOperationParser>(PoolingType::MAX);
+    case kTfLiteBuiltinMean:
+      return absl::make_unique<MeanOperationParser>();
     case kTfLiteBuiltinMul:
       return absl::make_unique<MulOperationParser>();
     case kTfLiteBuiltinPad:

--- a/tensorflow/lite/delegates/gpu/common/operations.cc
+++ b/tensorflow/lite/delegates/gpu/common/operations.cc
@@ -80,6 +80,8 @@ std::string ToString(enum OperationType op) {
       return "lstm";
     case OperationType::MAX_UNPOOLING_2D:
       return "max_unpooling";
+    case OperationType::MEAN:
+      return "mean";
     case OperationType::MUL:
       return "mul";
     case OperationType::MULTIPLY_SCALAR:
@@ -146,6 +148,7 @@ OperationType OperationTypeFromString(const std::string& name) {
           {"log", OperationType::LOG},
           {"lstm", OperationType::LSTM},
           {"max_unpooling", OperationType::MAX_UNPOOLING_2D},
+          {"mean", OperationType::MEAN},
           {"mul", OperationType::MUL},
           {"multiply_scalar", OperationType::MULTIPLY_SCALAR},
           {"pad", OperationType::PAD},

--- a/tensorflow/lite/delegates/gpu/common/operations.h
+++ b/tensorflow/lite/delegates/gpu/common/operations.h
@@ -50,6 +50,7 @@ enum class OperationType {
   LOG,
   LSTM,
   MAX_UNPOOLING_2D,
+  MEAN,
   MUL,
   MULTIPLY_SCALAR,
   PAD,

--- a/tensorflow/lite/delegates/gpu/metal/api.cc
+++ b/tensorflow/lite/delegates/gpu/metal/api.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/metal/kernels/fully_connected.h"
 #include "tensorflow/lite/delegates/gpu/metal/kernels/hard_swish.h"
 #include "tensorflow/lite/delegates/gpu/metal/kernels/max_unpooling.h"
+#include "tensorflow/lite/delegates/gpu/metal/kernels/mean.h"
 #include "tensorflow/lite/delegates/gpu/metal/kernels/mul.h"
 #include "tensorflow/lite/delegates/gpu/metal/kernels/padding.h"
 #include "tensorflow/lite/delegates/gpu/metal/kernels/pooling.h"
@@ -175,6 +176,9 @@ Status RegisterPrimaryOps(const GraphFloat32& graph, const Node* node,
           node_id, inputs[0], inputs[1], outputs[0],
           absl::any_cast<MaxUnpooling2DAttributes>(node->operation.attributes));
       break;
+    case OperationType::MEAN:
+      *tasks = Mean(node_id, inputs[0], outputs[0], options);
+      break;
     case OperationType::MULTIPLY_SCALAR:
       *tasks = Multiply(
           node_id, inputs[0], outputs[0],
@@ -277,8 +281,8 @@ Status Compile(const GraphFloat32& graph, const RuntimeOptions& options,
         return UnimplementedError(
             absl::Substitute("Unsupported op type: $0; custom registry error: "
                              "$1; primary registry error: $2;",
-                             node->operation.type, custom_status.message(),
-                             primary_status.message()));
+                             node->operation.type, custom_status.error_message(),
+                             primary_status.error_message()));
       }
     }
     compiled_model->insert(compiled_model->end(), tasks.begin(), tasks.end());

--- a/tensorflow/lite/delegates/gpu/metal/kernels/BUILD
+++ b/tensorflow/lite/delegates/gpu/metal/kernels/BUILD
@@ -17,6 +17,7 @@ cc_library(
         ":fully_connected",
         ":hard_swish",
         ":max_unpooling",
+        ":mean",
         ":mul",
         ":padding",
         ":pooling",
@@ -318,6 +319,23 @@ ios_unit_test(
         "tflite_not_portable_android",
     ],
     deps = [":max_unpooling_test_lib"],
+)
+
+cc_library(
+    name = "mean",
+    srcs = ["mean.cc"],
+    hdrs = ["mean.h"],
+    deps = [
+        "//tensorflow/lite/delegates/gpu/common:model",
+        "//tensorflow/lite/delegates/gpu/common:operations",
+        "//tensorflow/lite/delegates/gpu/common:shape",
+        "//tensorflow/lite/delegates/gpu/common:types",
+        "//tensorflow/lite/delegates/gpu/common:util",
+        "//tensorflow/lite/delegates/gpu/metal:compute_task_descriptor",
+        "//tensorflow/lite/delegates/gpu/metal:runtime_options",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:variant",
+    ],
 )
 
 cc_library(

--- a/tensorflow/lite/delegates/gpu/metal/kernels/mean.cc
+++ b/tensorflow/lite/delegates/gpu/metal/kernels/mean.cc
@@ -1,0 +1,94 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/delegates/gpu/metal/kernels/mean.h"
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "absl/strings/substitute.h"
+#include "absl/types/variant.h"
+#include "tensorflow/lite/delegates/gpu/common/data_type.h"
+#include "tensorflow/lite/delegates/gpu/common/model.h"
+#include "tensorflow/lite/delegates/gpu/common/operations.h"
+#include "tensorflow/lite/delegates/gpu/common/shape.h"
+#include "tensorflow/lite/delegates/gpu/common/tensor.h"
+#include "tensorflow/lite/delegates/gpu/common/util.h"
+#include "tensorflow/lite/delegates/gpu/metal/compute_task_descriptor.h"
+#include "tensorflow/lite/delegates/gpu/metal/runtime_options.h"
+
+namespace tflite {
+namespace gpu {
+namespace metal {
+
+std::vector<ComputeTaskDescriptorPtr> Mean(
+    int id, ValueId input_id, ValueId output_id,
+    const RuntimeOptions& options) {
+  auto desc = std::make_shared<ComputeTaskDescriptor>();
+  desc->id = id;
+  desc->is_linkable = false;
+  std::string code = R"(
+    #include <metal_stdlib>
+    using namespace metal;
+    $0
+    kernel void ComputeFunction(
+                                $1
+                                uint3 gid[[thread_position_in_grid]],
+                                uint3 tid[[thread_position_in_threadgroup]]
+                                ) {
+        if (int(gid.x) >= size.x || int(gid.y) >= size.y || int(tid.x) != 0 || int(tid.y) != 0) {
+            return;
+        }
+        FLT4 sum = FLT4(0.0);
+        int linear_index = 0;
+        for (int x = 0; x < size.x; x++) {
+          for (int y = 0; y < size.y; y++) {
+            linear_index = (gid.z * size.y + y) * size.x + x;
+            sum += input_buffer[linear_index];
+          }
+        }
+
+        output_buffer[gid.z] = sum / (size.x * size.y);
+    })";
+  desc->shader_source = code;
+  desc->input_buffers = {{input_id, "device FLT4* const input_buffer"}};
+  desc->output_buffer = {output_id, "device FLT4* output_buffer", [input_id](const std::map<ValueId, BHWC>& buffers) {
+    auto in_size = buffers.find(input_id)->second;
+    return BHWC(in_size.b, 1, 1, in_size.c);
+  }};
+  desc->uniform_buffers = {
+      {"constant int2& size", [input_id](const std::map<ValueId, BHWC>& buffers) {
+          const auto& dimension = buffers.find(input_id)->second;
+          std::vector<int> uniform_params = {dimension.w, dimension.h};
+          return VectorToUint8Vector(uniform_params);
+      }}
+  };
+  desc->resize_function = [input_id](const std::map<ValueId, BHWC>& buffers) {
+    const auto& src_dim = buffers.find(input_id)->second;
+    const uint3 groups_size{src_dim.w, src_dim.h, 1};
+    int groups_x = 1;
+    int groups_y = 1;
+    int groups_z = AlignByN(src_dim.c, 4);
+    return std::make_pair(groups_size, uint3{groups_x, groups_y, groups_z});
+  };
+  return {desc};
+}
+
+}  // namespace metal
+}  // namespace gpu
+}  // namespace tflite

--- a/tensorflow/lite/delegates/gpu/metal/kernels/mean.h
+++ b/tensorflow/lite/delegates/gpu/metal/kernels/mean.h
@@ -1,0 +1,38 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_DELEGATES_GPU_METAL_KERNELS_MEAN_H_
+#define TENSORFLOW_LITE_DELEGATES_GPU_METAL_KERNELS_MEAN_H_
+
+#include "tensorflow/lite/delegates/gpu/common/model.h"
+#include "tensorflow/lite/delegates/gpu/common/operations.h"
+#include "tensorflow/lite/delegates/gpu/metal/compute_task_descriptor.h"
+#include "tensorflow/lite/delegates/gpu/metal/runtime_options.h"
+
+namespace tflite {
+namespace gpu {
+namespace metal {
+
+// Compute the mean, currently only supported on width and height dimensions
+// simultaneously.
+std::vector<ComputeTaskDescriptorPtr> Mean(
+    int id, ValueId input_id, ValueId output_id,
+    const RuntimeOptions& options);
+
+}  // namespace metal
+}  // namespace gpu
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_DELEGATES_GPU_METAL_KERNELS_MEAN_H_


### PR DESCRIPTION
Basic first-pass implementation of the Mean operator (assumes mean is always taken over axis 1 and 2, shader code likely has room for optimization)