### PR TITLE
[Intel MKL] Bugfix for mkl slice

### DIFF
--- a/tensorflow/python/kernel_tests/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/slice_op_test.py
@@ -44,10 +44,8 @@ class SliceTest(test.TestCase):
       self.assertAllEqual(slice_val, inp[2, k:k])
 
   def testView(self):
-    cout = 45
     shape = [64, 28, 28, 32]
     dtype = dtypes.float32
-    gain = 3.14
     filter_size = [1, 1, 32, 32]
 
     convolution = nn_ops.conv2d
@@ -57,8 +55,8 @@ class SliceTest(test.TestCase):
       inputs, padding="VALID", strides=[1, 1, 1, 1], filter=filters)
 
     outputs = array_ops.slice(middle, [8, 8, 8, 8], [16, 16, 16, 16])
-    with self.session(use_gpu=True) as sess:
-      t = outputs.eval()
+    with self.session(use_gpu=True):
+      outputs.eval()
 
   def testInt32(self):
     inp = np.random.rand(4, 4).astype("i")

--- a/tensorflow/python/kernel_tests/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/slice_op_test.py
@@ -29,11 +29,8 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
-from tensorflow.python.ops import init_ops
-from tensorflow.python.ops import variables
+from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import test
-
-import tensorflow as tf
 
 class SliceTest(test.TestCase):
 
@@ -51,20 +48,16 @@ class SliceTest(test.TestCase):
     shape = [64, 28, 28, 32]
     dtype = dtypes.float32
     gain = 3.14
-    kernel_size = [1, 1]
+    filter_size = [1, 1, 32, 32]
 
-    convolution = tf.layers.Conv2D
+    convolution = nn_ops.conv2d
     inputs = random_ops.random_normal(shape, dtype=dtype)
+    filters = random_ops.random_normal(filter_size, dtype=dtype)
     middle = convolution(
-      padding="valid", filters=cout,
-      kernel_size=kernel_size, use_bias=False,
-      kernel_initializer=init_ops.convolutional_orthogonal_2d(gain=gain)
-    ).apply(inputs)
+      inputs, padding="VALID", strides=[1, 1, 1, 1], filter=filters)
 
     outputs = array_ops.slice(middle, [8, 8, 8, 8], [16, 16, 16, 16])
-    my_ops = variables.global_variables_initializer()
     with self.session(use_gpu=True) as sess:
-      sess.run(my_ops)
       t = outputs.eval()
 
   def testInt32(self):

--- a/tensorflow/python/kernel_tests/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/slice_op_test.py
@@ -53,7 +53,7 @@ class SliceTest(test.TestCase):
     gain = 3.14
     kernel_size = [1, 1]
 
-    convolution = tf.keras.layers.Conv2D
+    convolution = tf.layers.Conv2D
     inputs = random_ops.random_normal(shape, dtype=dtype)
     middle = convolution(
       padding="valid", filters=cout,

--- a/tensorflow/python/kernel_tests/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/slice_op_test.py
@@ -28,9 +28,8 @@ from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import random_ops
-from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import test
+
 
 class SliceTest(test.TestCase):
 
@@ -42,21 +41,6 @@ class SliceTest(test.TestCase):
         slice_t = a[2, k:k]
         slice_val = self.evaluate(slice_t)
       self.assertAllEqual(slice_val, inp[2, k:k])
-
-  def testView(self):
-    shape = [64, 28, 28, 32]
-    dtype = dtypes.float32
-    filter_size = [1, 1, 32, 32]
-
-    convolution = nn_ops.conv2d
-    inputs = random_ops.random_normal(shape, dtype=dtype)
-    filters = random_ops.random_normal(filter_size, dtype=dtype)
-    middle = convolution(
-      inputs, padding="VALID", strides=[1, 1, 1, 1], filter=filters)
-
-    outputs = array_ops.slice(middle, [8, 8, 8, 8], [16, 16, 16, 16])
-    with self.session(use_gpu=True):
-      outputs.eval()
 
   def testInt32(self):
     inp = np.random.rand(4, 4).astype("i")


### PR DESCRIPTION
We identified that mkldnn slice not working properly with block data format (nchw16c): it will crash when offset is 8.

This PR is to fix the problem.