### PR TITLE
[ROCm] updating Dockerfile.rocm to pick a specific version of the rocm libraries 

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -3,7 +3,7 @@
 FROM ubuntu:xenial
 MAINTAINER Jeff Poznanovic <jeffrey.poznanovic@amd.com>
 
-ARG DEB_ROCM_REPO=http://repo.radeon.com/rocm/apt/debian/
+ARG DEB_ROCM_REPO=http://repo.radeon.com/rocm/apt/2.6/
 ARG ROCM_PATH=/opt/rocm
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
The ROCm libraries get updated on a monthly basis, and picking the "latest" one is not always the right thing to do.  

This is a trivial and ROCm specific change, please review and approve

------------------------------------------------------

@tatianashp @whchung @chsigg @gunan @parallelo @sunway513 