### PR TITLE
r2.0-CherryPick:Fix unwanted deprecation warning in optimizers v2

### DIFF
--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -540,9 +540,6 @@ class BaseResourceVariable(variables.VariableV1):
     return self._initial_value
 
   @property
-  @deprecated(
-      None,
-      "Apply a constraint manually following the optimizer update step.")
   def constraint(self):
     """Returns the constraint function associated with this variable.
 


### PR DESCRIPTION
Get rid of unwanted deprecation warning in optimizer v2.

Currently, optimizers need to access variable.constraint. Doing so raises a user-visible deprecation warning. As a result, every time an optimizer is used in TF 2.0, a deprecation warning is raised, which is not an acceptable user-facing behavior.