### PR TITLE
add mean absolute percentage error metric for estimator

### DIFF
--- a/tensorflow/contrib/metrics/python/metrics/classification.py
+++ b/tensorflow/contrib/metrics/python/metrics/classification.py
@@ -19,15 +19,19 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.distribute import distribution_strategy_context
+from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import clip_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import metrics_impl
 from tensorflow.python.ops import variable_scope
 
 # TODO(nsilberman): move into metrics/python/ops/
 
+EPSILON = 1e-7
 
 def accuracy(predictions, labels, weights=None, name=None):
   """Computes the percentage of times that predictions matches labels.
@@ -183,3 +187,77 @@ def f1_score(labels, predictions, weights=None, num_thresholds=200,
       ops.add_to_collections(updates_collections, update_op)
 
     return best_f1, update_op
+
+def mean_absolute_percentage_error(labels,
+                        predictions,
+                        weights=None,
+                        metrics_collections=None,
+                        updates_collections=None,
+                        name=None):
+  """Computes the mean absolute percentage error between the labels and predictions.
+
+  The `mean_absolute_percentage_error` function creates two local variables,
+  `total` and `count` that are used to compute the mean absolute percentage error.
+  This average is weighted by `weights`, and it is ultimately returned as
+  `mean_absolute_percentage_error`: an idempotent operation that simply divides `total`
+  by `count`.
+
+  For estimation of the metric over a stream of data, the function creates an
+  `update_op` operation that updates these variables and returns the
+  `mean_absolute_percentage_error`. Internally, an `absolute_percentage_errors` operation
+  computes the absolute value of the percentage differences between `predictions` and `labels`.
+  Then `update_op` increments `total` with the reduced sum of the product of
+  `weights` and `absolute_percentage_errors`, and it increments `count` with the reduced
+  sum of `weights`
+
+  If `weights` is `None`, weights default to 1. Use weights of 0 to mask values.
+
+  Args:
+    labels: A `Tensor` of the same shape as `predictions`.
+    predictions: A `Tensor` of arbitrary shape.
+    weights: Optional `Tensor` whose rank is either 0, or the same rank as
+      `labels`, and must be broadcastable to `labels` (i.e., all dimensions must
+      be either `1`, or the same as the corresponding `labels` dimension).
+    metrics_collections: An optional list of collections that
+      `mean_absolute_percentage_error` should be added to.
+    updates_collections: An optional list of collections that `update_op` should
+      be added to.
+    name: An optional variable_scope name.
+
+  Returns:
+    mean_absolute_percentage_error: A `Tensor` representing the current mean, the value
+    of `total` divided by `count`.
+    update_op: An operation that increments the `total` and `count` variables
+      appropriately and whose value matches `mean_absolute_percentage_error`.
+
+  Raises:
+    ValueError: If `predictions` and `labels` have mismatched shapes, or if
+      `weights` is not `None` and its shape doesn't match `predictions`, or if
+      either `metrics_collections` or `updates_collections` are not a list or
+      tuple.
+    RuntimeError: If eager execution is enabled.
+  """
+  if context.executing_eagerly():
+    raise RuntimeError('tf.metrics.mean_absolute_percentage_error is not supported '
+                       'when eager execution is enabled.')
+
+  if predictions.dtype in (dtypes.float16, dtypes.float32, dtypes.float64) \
+      and labels.dtype != predictions.dtype:
+    labels = math_ops.cast(labels, predictions.dtype)
+  elif labels.dtype in (dtypes.float16, dtypes.float32, dtypes.float64) \
+      and labels.dtype != predictions.dtype:
+    predictions = math_ops.cast(predictions, labels.dtype)
+  else:
+    labels = math_ops.cast(labels, dtypes.float32)
+    predictions = math_ops.cast(predictions, dtypes.float32)
+
+  predictions, labels, weights = metrics_impl._remove_squeezable_dimensions(
+      predictions=predictions, labels=labels, weights=weights)
+  min_value = constant_op.constant(EPSILON, dtype=labels.dtype.base_dtype)
+  max_value = constant_op.constant(float('Inf'), dtype=labels.dtype.base_dtype)
+  percentage_absolute_errors = 100 * math_ops.abs(
+      (predictions - labels) / clip_ops.clip_by_value(math_ops.abs(labels),
+                                                      min_value, max_value)
+  )
+  return metrics_impl.mean(percentage_absolute_errors, weights, metrics_collections,
+          updates_collections, name or 'mape')

--- a/tensorflow/contrib/metrics/python/metrics/classification_test.py
+++ b/tensorflow/contrib/metrics/python/metrics/classification_test.py
@@ -30,7 +30,6 @@ from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
-
 class ClassificationTest(test.TestCase):
 
   def testAccuracy1D(self):
@@ -308,6 +307,87 @@ class F1ScoreTest(test.TestCase):
       # accuracy improving
       self.assertAlmostEqual(expected_max_f1, f1.eval(), 2)
 
+class MAPETest(test.TestCase):
+
+  def setUp(self):
+    super(MAPETest, self).setUp()
+    np.random.seed(1)
+
+  def testVars(self):
+    classification.mean_absolute_percentage_error(
+      labels = array_ops.ones((10, 1)),
+      predictions = array_ops.ones((10, 1)),
+    )
+    expected = {'mape/total:0', 'mape/count:0'}
+    self.assertEqual(expected, {v.name for v in variables.local_variables()})
+    self.assertEqual(expected, {v.name for v in ops.get_collection(ops.GraphKeys.METRIC_VARIABLES)})
+
+  def testMetricsCollection(self):
+    my_collection_name = '__metrics__'
+    mape, _ = classification.mean_absolute_percentage_error(
+      labels = array_ops.ones((10, 1)),
+      predictions = array_ops.ones((10, 1)),
+      metrics_collections=[my_collection_name]
+    )
+    self.assertEqual([mape], ops.get_collection(my_collection_name))
+
+  def testUpdatesCollection(self):
+    my_collection_name = '__updates__'
+    _, mape_op = classification.mean_absolute_percentage_error(
+        labels = array_ops.ones((10, 1)),
+        predictions = array_ops.ones((10, 1)),
+        updates_collections=[my_collection_name]
+    )
+    self.assertEqual([mape_op], ops.get_collection(my_collection_name))
+
+  def testMAPEUnweighted(self):
+    labels = constant_op.constant(((0, 1, 0, 1, 0), (0, 0, 1, 1, 1),
+                                   (1, 1, 1, 1, 0), (0, 0, 0, 0, 1)))
+
+    pred = constant_op.constant(((0, 0, 1, 1, 0), (1, 1, 1, 1, 1),
+                                   (0, 1, 0, 1, 0), (1, 1, 1, 1, 1)))
+
+    mape, mape_op = classification.mean_absolute_percentage_error(labels, pred)
+    with self.cached_session() as sess:
+      sess.run(variables.local_variables_initializer())
+      sess.run([mape_op])
+      self.assertAllClose(35e7, mape.eval(), atol=1e-5)
+
+  def testMAPEWeighted(self):
+    labels = constant_op.constant(((0, 1, 0, 1, 0), (0, 0, 1, 1, 1),
+                                   (1, 1, 1, 1, 0), (0, 0, 0, 0, 1)))
+    pred = constant_op.constant(((0, 0, 1, 1, 0), (1, 1, 1, 1, 1),
+                                 (0, 1, 0, 1, 0), (1, 1, 1, 1, 1)))
+    sample_weight = constant_op.constant((1., 1.5, 2., 2.5))
+    mape, mape_op = classification.mean_absolute_percentage_error(labels, pred, sample_weight)
+    with self.cached_session() as sess:
+      sess.run(variables.local_variables_initializer())
+      sess.run([mape_op])
+      self.assertAllClose(40e7, mape.eval(), atol=1e-5)
+
+  def testMultiUpdates(self):
+    num_samples = 6400
+    batch_size = 64
+    num_step = int(num_samples / batch_size)
+    labels = np.random.randint(0, 1000, size=(num_samples, 1)).astype(np.float32)
+    predictions = np.random.randint(0, 1000, size=(num_samples, 1)).astype(np.float32)
+    expected = np.mean(
+      100 * np.abs(
+        (labels - predictions) \
+        / np.clip(np.abs(labels), classification.EPSILON, np.inf)
+      )
+    )
+    tf_predictions, tf_labels = dataset_ops.make_one_shot_iterator(
+      dataset_ops.Dataset
+      .from_tensor_slices((predictions, labels))
+      .repeat()
+      .batch(batch_size)).get_next()
+    mape, mape_op = classification.mean_absolute_percentage_error(tf_labels, tf_predictions)
+    with self.cached_session() as sess:
+      sess.run(variables.local_variables_initializer())
+      for _ in range(num_step):
+        sess.run([mape_op])
+      self.assertAllClose(expected, mape.eval(), atol=1e-5)
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
MAPE(mean absolute percentage error) is widely used in many machine learning tasks. Even though this is a implementation under `tf.keras.metrics` , it's not compatible with `tf.Estimator`. I added my implementation, hope it is useful for others too.