### PR TITLE
TF-TRT API: Add build method. Not return function from convert. Calibrate in convert.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -5215,7 +5215,11 @@ Status ConvertGraphDefToEngine(
   }
 
   // Build the network
-  VLOG(1) << "Starting engine conversion ";
+  if (VLOG_IS_ON(1)) {
+    string mode_str;
+    TF_RETURN_IF_ERROR(TrtPrecisionModeToName(precision_mode, &mode_str));
+    VLOG(1) << "Starting engine conversion, precision mode: " << mode_str;
+  }
   Converter converter(trt_network.get(), precision_mode, use_calibration);
   std::vector<Converter::EngineOutputInfo> output_tensors;
   // Graph nodes are already topologically sorted during construction

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -31,7 +31,6 @@ from tensorflow.core.protobuf import meta_graph_pb2
 from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python.client import session
 from tensorflow.python.eager import context
-from tensorflow.python.eager import def_function
 from tensorflow.python.eager import wrap_function
 from tensorflow.python.framework import convert_to_constants
 from tensorflow.python.framework import dtypes

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -885,7 +885,6 @@ class TrtGraphConverterV2(object):
     if (self._need_calibration and not conversion_params.is_dynamic_op):
       raise ValueError("INT8 precision mode with calibration is not supported "
                        "with static TensorRT ops. Set is_dynamic_op to True.")
-    self._calibration_data_collected = False
 
     self._converted = False
 
@@ -908,9 +907,7 @@ class TrtGraphConverterV2(object):
 
   # TODO(laigd): provide a utility function to optimize a ConcreteFunction and
   # use it here (b/124792963).
-  def convert(self,
-              num_calibration_runs=None,
-              calibration_input_map_fn=None):
+  def convert(self, num_calibration_runs=None, calibration_input_map_fn=None):
     """Convert the input SavedModel in 2.0 format.
 
     Args:
@@ -922,6 +919,7 @@ class TrtGraphConverterV2(object):
         def input_map_fn():
           return input1, input2, input3
         ```
+
     Raises:
       ValueError: if the input combination is invalid.
 
@@ -931,14 +929,12 @@ class TrtGraphConverterV2(object):
     assert not self._converted
 
     if (self._need_calibration and
-        (not num_calibration_runs or
-         not calibration_input_map_fn)):
+        (not num_calibration_runs or not calibration_input_map_fn)):
       raise ValueError(
           "Should specify num_calibration_runs and calibration_input_map_fn"
           "because INT8 calibration is needed")
     if (not self._need_calibration and
-        (num_calibration_runs or
-         calibration_input_map_fn)):
+        (num_calibration_runs or calibration_input_map_fn)):
       raise ValueError(
           "Should not specify num_calibration_runs or calibration_input_map_fn"
           "because INT8 calibration is not needed")
@@ -968,39 +964,16 @@ class TrtGraphConverterV2(object):
         func.graph.structured_outputs,
         self._converted_func.graph.structured_outputs)
 
+    if self._need_calibration:
+      for _ in range(num_calibration_runs):
+        self._converted_func(
+            *map(ops.convert_to_tensor, calibration_input_map_fn()))
+
     self._converted = True
-
-    if self._need_calibration and not self._calibration_data_collected:
-      self._calibrate(num_runs=num_calibration_runs,
-                      input_map_fn=calibration_input_map_fn)
-
-  def _calibrate(self,
-                 num_runs=None,
-                 input_map_fn=None):
-    """Run calibration.
-
-    Args:
-      num_runs: number of runs of the graph during calibration.
-      input_map_fn: a function that returns inputs for the converted
-        tf_function to be calibrated.
-        Example:
-        ```
-        def input_map_fn():
-          return input1, input2, input3
-        ```
-    """
-    assert self._converted
-    assert self._need_calibration
-    assert num_runs
-    assert input_map_fn
-
-    for _ in range(num_runs):
-      self._converted_func(*map(ops.convert_to_tensor, input_map_fn()))
-
-    self._calibration_data_collected = True
 
   def build(self, *args, **kwargs):
     """Run inference on graph in order to build a TensorRT engine
+
        in the cahce of TRTEngineOp.
 
     Returns:
@@ -1011,8 +984,8 @@ class TrtGraphConverterV2(object):
     try:
       return self._converted_func(*args_tensor, **kwargs_tensor)
     except OpError:
-      print('Failure in execution of function with input args {}'
-            'and kwargs {}'.format(args_tensor, kwargs_tensor))
+      print("Failure in execution of function with input args {}"
+            "and kwargs {}".format(args_tensor, kwargs_tensor))
 
   def save(self, output_saved_model_dir):
     """Save the converted SavedModel.

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -885,6 +885,7 @@ class TrtGraphConverterV2(object):
     if (self._need_calibration and not conversion_params.is_dynamic_op):
       raise ValueError("INT8 precision mode with calibration is not supported "
                        "with static TensorRT ops. Set is_dynamic_op to True.")
+    self._calibration_data_collected = False
 
     self._converted = False
 
@@ -907,13 +908,41 @@ class TrtGraphConverterV2(object):
 
   # TODO(laigd): provide a utility function to optimize a ConcreteFunction and
   # use it here (b/124792963).
-  def convert(self):
+  def convert(self,
+              num_calibration_runs=None,
+              calibration_input_map_fn=None):
     """Convert the input SavedModel in 2.0 format.
+
+    Args:
+      num_calibration_runs: number of runs of the graph during calibration.
+      calibration_input_map_fn: a function that returns inputs for the converted
+        tf_function to be calibrated.
+        Example:
+        ```
+        def input_map_fn():
+          return input1, input2, input3
+        ```
+    Raises:
+      ValueError: if the input combination is invalid.
 
     Returns:
       The TF-TRT converted Function.
     """
     assert not self._converted
+
+    if (self._need_calibration and
+        (not num_calibration_runs or
+         not calibration_input_map_fn)):
+      raise ValueError(
+          "Should specify num_calibration_runs and calibration_input_map_fn"
+          "because INT8 calibration is needed")
+    if (not self._need_calibration and
+        (num_calibration_runs or
+         calibration_input_map_fn)):
+      raise ValueError(
+          "Should not specify num_calibration_runs or calibration_input_map_fn"
+          "because INT8 calibration is not needed")
+
     self._saved_model = load.load(self._input_saved_model_dir,
                                   self._input_saved_model_tags)
     func = self._saved_model.signatures[self._input_saved_model_signature_key]
@@ -941,13 +970,49 @@ class TrtGraphConverterV2(object):
 
     self._converted = True
 
-    # Wrap the converted ConcreteFunction in a Function so it can accept numpy
-    # arrays as input.
-    @def_function.function
-    def wrapper_func(*args, **kwargs):
-      return self._converted_func(*args, **kwargs)
+    if self._need_calibration and not self._calibration_data_collected:
+      self._calibrate(num_runs=num_calibration_runs,
+                      input_map_fn=calibration_input_map_fn)
 
-    return wrapper_func
+  def _calibrate(self,
+                 num_runs=None,
+                 input_map_fn=None):
+    """Run calibration.
+
+    Args:
+      num_runs: number of runs of the graph during calibration.
+      input_map_fn: a function that returns inputs for the converted
+        tf_function to be calibrated.
+        Example:
+        ```
+        def input_map_fn():
+          return input1, input2, input3
+        ```
+    """
+    assert self._converted
+    assert self._need_calibration
+    assert num_runs
+    assert input_map_fn
+
+    for _ in range(num_runs):
+      self._converted_func(*map(ops.convert_to_tensor, input_map_fn()))
+
+    self._calibration_data_collected = True
+
+  def build(self, *args, **kwargs):
+    """Run inference on graph in order to build a TensorRT engine
+       in the cahce of TRTEngineOp.
+
+    Returns:
+      The output of the converted Function for the given inputs.
+    """
+    args_tensor = [ops.convert_to_tensor(arg) for arg in args]
+    kwargs_tensor = {k: ops.convert_to_tensor(v) for k, v in kwargs.items()}
+    try:
+      return self._converted_func(*args_tensor, **kwargs_tensor)
+    except OpError:
+      print('Failure in execution of function with input args {}'
+            'and kwargs {}'.format(args_tensor, kwargs_tensor))
 
   def save(self, output_saved_model_dir):
     """Save the converted SavedModel.

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -127,7 +127,7 @@ TrtConversionParams = collections.namedtuple(
 
         # Whether to generate dynamic TRT ops which will build the TRT network
         # and engine at run time.
-        # This option will always be set to True in TF 2.0.
+        # This option should be set to True in TF 2.0.
         "is_dynamic_op",
 
         # Max number of cached TRT engines in dynamic TRT ops. If the number of
@@ -157,7 +157,7 @@ DEFAULT_TRT_CONVERSION_PARAMS = TrtConversionParams(
     max_workspace_size_bytes=DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES,
     precision_mode=TrtPrecisionMode.FP32,
     minimum_segment_size=3,
-    is_dynamic_op=False,
+    is_dynamic_op=True,
     maximum_cached_engines=1,
     use_calibration=True,
     max_batch_size=1)
@@ -216,8 +216,7 @@ def _check_trt_version_compatibility():
                     ".".join([str(x) for x in loaded_version]))
 
 
-def get_tensorrt_rewriter_config(
-    conversion_params=DEFAULT_TRT_CONVERSION_PARAMS, is_v2=False):
+def get_tensorrt_rewriter_config(conversion_params, is_v2=False):
   """Returns a RewriterConfig proto for TRT transformation.
 
   Args:
@@ -269,8 +268,8 @@ def get_tensorrt_rewriter_config(
     # Static mode (building TRT engine without executing the op) is deprecated
     # in TF 2.0. See TrtGraphConverterV2 for more details.
     if not conversion_params.is_dynamic_op:
-      tf_logging.warn("Option is_dynamic_op=False is deprecated in TF 2.0, "
-                      "resetting it to True.")
+      raise ValueError("Option is_dynamic_op=False is not supported in TF 2.0, "
+                       "please set it to True instead.")
     optimizer.parameter_map["is_dynamic_op"].b = True
   else:
     optimizer.parameter_map[
@@ -1022,7 +1021,6 @@ class TrtGraphConverterV2(object):
       num_runs: number of runs of the graph with input_fn.
       input_fn: a function that returns input data as a list or tuple, which
         will be used to execute the converted signature to generate TRT engines.
-        All the returned input data should have the same shape.
         Example:
         ```
         def input_fn():

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -117,22 +117,13 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     return config
 
   @classmethod
-  def _GetGraph(cls, inp, var):
+  def _GetGraph(cls, inp1, inp2, var):
     """Get the graph for testing."""
-    # The graph computes (input+1)^2, it looks like:
-    #
-    # input (Placeholder)  v1 (Variable)
-    #               |   \ /
-    #                \   +
-    #                 \ / \
-    #                  *   |
-    #                   \ /
-    #                    +
-    #                    |
-    #                 output (Identity)
-    add = inp + var
-    mul = inp * add
+    # The graph computes: inp1^2 + inp1*var + inp1 + inp2 + var
+    add = inp1 + var
+    mul = inp1 * add
     add = mul + add
+    add = add + inp2
     out = array_ops.identity(add, name="output")
     return out
 
@@ -144,12 +135,13 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
         self.v = None
 
       @def_function.function(input_signature=[
+          tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32),
           tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32)
       ])
-      def run(self, inp):
+      def run(self, inp1, inp2):
         if self.v is None:
           self.v = variables.Variable([[[1.0]]], dtype=dtypes.float32)
-        return TrtConvertTest._GetGraph(inp, self.v)
+        return TrtConvertTest._GetGraph(inp1, inp2, self.v)
 
     return SimpleModel()
 
@@ -157,15 +149,17 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     g = ops.Graph()
     with g.as_default():
       with g.device("/GPU:0"):
-        inp = array_ops.placeholder(
-            dtype=dtypes.float32, shape=[None, 1, 1], name="input")
+        inp1 = array_ops.placeholder(
+            dtype=dtypes.float32, shape=[None, 1, 1], name="input1")
+        inp2 = array_ops.placeholder(
+            dtype=dtypes.float32, shape=[None, 1, 1], name="input2")
         var = variables.Variable([[[1.0]]], dtype=dtypes.float32, name="v1")
-        out = TrtConvertTest._GetGraph(inp, var)
-        return g, var, inp, out
+        out = TrtConvertTest._GetGraph(inp1, inp2, var)
+        return g, var, inp1, inp2, out
 
   def _GetGraphDef(self):
     """Get the graph def for testing."""
-    g, var, _, _ = self._GetGraphForV1()
+    g, var, _, _, _ = self._GetGraphForV1()
     with self.session(graph=g, config=self._GetConfigProto()) as sess:
       sess.run(var.initializer)
       graph_def = graph_util.convert_variables_to_constants(
@@ -175,19 +169,22 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
         {
             "v1": "Const",
             "add/ReadVariableOp": "Identity",
-            "input": "Placeholder",
+            "input1": "Placeholder",
+            "input2": "Placeholder",
             "add": "AddV2",
             "mul": "Mul",
             "add_1": "AddV2",
+            "add_2": "AddV2",
             "output": "Identity"
         }, node_name_to_op)
     return graph_def
 
   def _WriteInputSavedModel(self, input_saved_model_dir):
     """Write the saved model as an input for testing."""
-    g, var, inp, out = self._GetGraphForV1()
+    g, var, inp1, inp2, out = self._GetGraphForV1()
     signature_def = signature_def_utils.build_signature_def(
-        inputs={"myinput": utils.build_tensor_info(inp)},
+        inputs={"myinput1": utils.build_tensor_info(inp1),
+                "myinput2": utils.build_tensor_info(inp2)},
         outputs={"myoutput": utils.build_tensor_info(out)},
         method_name=signature_constants.PREDICT_METHOD_NAME)
     saved_model_builder = builder.SavedModelBuilder(input_saved_model_dir)
@@ -231,7 +228,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
 
         def next(self):
           self._data += 1
-          return {"input:0": [[[self._data]]]}
+          return {"input1:0": [[[self._data]]],
+                  "input2:0": [[[self._data]]]}
 
       output_graph_def = converter.calibrate(
           fetch_names=["output:0"],
@@ -265,7 +263,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
       node_name_to_op = {node.name: node.op for node in graph_def.node}
       self.assertEqual(
           {
-              "input": "Placeholder",
+              "input1": "Placeholder",
+              "input2": "Placeholder",
               "TRTEngineOp_0": "TRTEngineOp",
               "output": "Identity"
           }, node_name_to_op)
@@ -284,8 +283,9 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
           with self.session(config=self._GetConfigProto()) as sess:
             for test_data in range(10):
               self.assertEqual(
-                  (test_data + 1.0)**2,
-                  sess.run("output:0", feed_dict={"input:0": [[[test_data]]]}))
+                  (test_data + 1.0)**2 + test_data,
+                  sess.run("output:0", feed_dict={"input1:0": [[[test_data]]],
+                                                  "input2:0": [[[test_data]]]}))
 
   @test_util.deprecated_graph_mode_only
   def testTrtGraphConverter_BasicConversion(self):
@@ -345,24 +345,19 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     if not is_tensorrt_enabled():
       return
 
-    np_input = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input1 = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input2 = np.random.random_sample([4, 1, 1]).astype(np.float32)
 
     # Create a model and save it.
     input_saved_model_dir = self.mkdtemp()
     root = self._GetModelForV2()
-    expected_output = root.run(np_input)
+    expected_output = root.run(np_input1, np_input2)
     save.save(root, input_saved_model_dir,
               {_SAVED_MODEL_SIGNATURE_KEY: root.run})
 
     # Run TRT conversion.
     converter = self._CreateConverterV2(input_saved_model_dir)
-    converted_func = converter.convert()
-
-    # Verify the converted GraphDef and ConcreteFunction.
-    self.assertIsInstance(converted_func, def_function.Function)
-    converted_concrete_func = converted_func.get_concrete_function(
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
-    self._CheckTrtOps(converted_concrete_func)
+    converter.convert()
 
     # Save the converted model without any TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
@@ -372,7 +367,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self.assertFalse(os.path.exists(unexpected_asset_file))
 
     # Run the converted function to populate the engine cache.
-    output_with_trt = converted_func(np_input)
+    output_with_trt = converter.build(np_input1, np_input2)
     self.assertEqual(1, len(output_with_trt))
     self.assertAllClose(
         expected_output,
@@ -402,7 +397,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     # self._CheckTrtOps(root_with_trt.run.get_concrete_function())
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
     self._CheckTrtOps(converted_signature)
-    output_with_trt = converted_signature(ops.convert_to_tensor(np_input))
+    output_with_trt = converted_signature(inp1=ops.convert_to_tensor(np_input1),
+                                          inp2=ops.convert_to_tensor(np_input2))
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
     self.assertAllClose(
@@ -420,27 +416,22 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     if not is_tensorrt_enabled():
       return
 
-    np_input = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input1 = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input2 = np.random.random_sample([4, 1, 1]).astype(np.float32)
 
     # Create a model and save it.
     input_saved_model_dir = self.mkdtemp()
     root = self._GetModelForV2()
-    expected_output = root.run(np_input)
+    expected_output = root.run(np_input1, np_input2)
     save.save(root, input_saved_model_dir,
               {_SAVED_MODEL_SIGNATURE_KEY: root.run})
 
     # Run TRT conversion.
     converter = self._CreateConverterV2(input_saved_model_dir, max_batch_size=4)
-    converted_func = converter.convert()
+    converter.convert()
 
     def _CheckFn(node):
       self.assertTrue(len(node.attr["serialized_segment"].s), node.name)
-
-    # Verify the converted GraphDef and ConcreteFunction.
-    self.assertIsInstance(converted_func, def_function.Function)
-    converted_concrete_func = converted_func.get_concrete_function(
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
-    self._CheckTrtOps(converted_concrete_func, _CheckFn)
 
     # Save the converted model with the statically-built engine inlined.
     output_saved_model_dir = self.mkdtemp()
@@ -456,7 +447,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     root_with_trt = load.load(output_saved_model_dir)
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
     self._CheckTrtOps(converted_signature, _CheckFn)
-    output_with_trt = converted_signature(ops.convert_to_tensor(np_input))
+    output_with_trt = converted_signature(inp1=ops.convert_to_tensor(np_input1),
+                                          inp2=ops.convert_to_tensor(np_input2))
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
     self.assertAllClose(
@@ -473,28 +465,25 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     if not is_tensorrt_enabled():
       return
 
-    np_input = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input1 = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input2 = np.random.random_sample([4, 1, 1]).astype(np.float32)
 
     # Create a model and save it.
     input_saved_model_dir = tempfile.mkdtemp(dir=self.get_temp_dir())
     root = self._GetModelForV2()
-    expected_output = root.run(np_input)
+    expected_output = root.run(np_input1, np_input2)
     save.save(root, input_saved_model_dir,
               {_SAVED_MODEL_SIGNATURE_KEY: root.run})
 
     # Run TRT conversion.
     converter = self._CreateConverterV2(
         input_saved_model_dir, precision_mode=trt_convert.TrtPrecisionMode.INT8)
-    converted_func = converter.convert()
 
-    # Run the converted function for INT8 calibration.
-    calibration_output = converted_func(np_input)
-    self.assertEqual(1, len(calibration_output))
-    self.assertAllClose(
-        expected_output,
-        list(calibration_output.values())[0],
-        atol=1e-6,
-        rtol=1e-6)
+    # Convert and perform INT8 calibration
+    def input_map_fn():
+      return np_input1, np_input2
+    converter.convert(num_calibration_runs=1,
+                      calibration_input_map_fn=input_map_fn)
 
     # Save the converted model again with serialized engine cache.
     output_saved_model_dir = self.mkdtemp()
@@ -514,7 +503,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     root_with_trt = load.load(output_saved_model_dir)
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
     self._CheckTrtOps(converted_signature, _CheckFn)
-    output_with_trt = converted_signature(ops.convert_to_tensor(np_input))
+    output_with_trt = converted_signature(inp1=ops.convert_to_tensor(np_input1),
+                                          inp2=ops.convert_to_tensor(np_input2))
     self.assertEqual(1, len(output_with_trt))
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
@@ -526,8 +516,10 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
 
     # Run with an input of different batch size. It should build a new engine
     # using calibration table.
-    np_input = np.random.random_sample([5, 1, 1]).astype(np.float32)
-    converted_signature(ops.convert_to_tensor(np_input))
+    np_input1 = np.random.random_sample([5, 1, 1]).astype(np.float32)
+    np_input2 = np.random.random_sample([5, 1, 1]).astype(np.float32)
+    output_with_trt = converted_signature(inp1=ops.convert_to_tensor(np_input1),
+                                          inp2=ops.convert_to_tensor(np_input2))
 
     del root_with_trt
     gc.collect()  # Force GC to destroy the TRT engine cache.
@@ -538,7 +530,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     if not is_tensorrt_enabled():
       return
 
-    np_input = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input1 = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input2 = np.random.random_sample([4, 1, 1]).astype(np.float32)
 
     # Create a model and save it.
     input_saved_model_dir = self.mkdtemp()
@@ -548,8 +541,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
 
     # Run TRT conversion.
     converter = self._CreateConverterV2(input_saved_model_dir)
-    converted_func = converter.convert()
-    converted_func(np_input)  # Populate the TRT engine cache.
+    converter.convert()
+    converter.build(np_input1, np_input2)  # Populate the TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
 
@@ -699,22 +692,26 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self._CompareSavedModel(_Model)
 
   def _TestRun(self, sess, batch_size, expect_engine_is_run=True):
-    result = sess.run("output:0", feed_dict={"input:0": [[[1.0]]] * batch_size})
-    self.assertAllEqual([[[4.0]]] * batch_size, result)
+    result = sess.run("output:0",
+                      feed_dict={"input1:0": [[[1.0]]] * batch_size,
+                                 "input2:0": [[[1.0]]] * batch_size})
+    self.assertAllEqual([[[5.0]]] * batch_size, result)
 
   @test_util.deprecated_graph_mode_only
   def testTrtGraphConverter_MinimumSegmentSize(self):
     if not is_tensorrt_enabled():
       return
-    output_graph_def = self._ConvertGraph(minimum_segment_size=5)
+    output_graph_def = self._ConvertGraph(minimum_segment_size=7)
     node_name_to_op = {node.name: node.op for node in output_graph_def.node}
     self.assertEqual(
         {
             "add/ReadVariableOp": "Const",
-            "input": "Placeholder",
+            "input1": "Placeholder",
+            "input2": "Placeholder",
             "add": "AddV2",
             "mul": "Mul",
             "add_1": "AddV2",
+            "add_2": "AddV2",
             "output": "Identity"
         }, node_name_to_op)
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -30,7 +30,6 @@ from tensorflow.core.protobuf import config_pb2
 from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python.compiler.tensorrt import trt_convert
 from tensorflow.python.eager import def_function
-from tensorflow.python.eager import wrap_function
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import graph_util
@@ -361,15 +360,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     converter.convert()
 
     # Verify the converted GraphDef and ConcreteFunction.
-    @def_function.function
-    def wrapper_converted_func(*args, **kwargs):
-      return converter._converted_func(*args, **kwargs)
-    converted_func = wrapper_converted_func
-    self.assertIsInstance(converted_func, def_function.Function)
-    converted_concrete_func = converted_func.get_concrete_function(
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32),
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
-    self._CheckTrtOps(converted_concrete_func)
+    self._CheckTrtOps(converter._converted_func)
 
     # Save the converted model without any TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
@@ -446,15 +437,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
       self.assertTrue(len(node.attr["serialized_segment"].s), node.name)
 
     # Verify the converted GraphDef and ConcreteFunction.
-    @def_function.function
-    def wrapper_converted_func(*args, **kwargs):
-      return converter._converted_func(*args, **kwargs)
-    converted_func = wrapper_converted_func
-    self.assertIsInstance(converted_func, def_function.Function)
-    converted_concrete_func = converted_func.get_concrete_function(
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32),
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
-    self._CheckTrtOps(converted_concrete_func, _CheckFn)
+    self._CheckTrtOps(converter._converted_func, _CheckFn)
 
     # Save the converted model with the statically-built engine inlined.
     output_saved_model_dir = self.mkdtemp()

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -422,54 +422,18 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     if not is_tensorrt_enabled():
       return
 
-    np_input1, np_input2 = self._RandomInput([4, 1, 1])
-
     # Create a model and save it.
     input_saved_model_dir = self.mkdtemp()
     root = self._GetModelForV2()
-    expected_output = root.run(np_input1, np_input2)
     save.save(root, input_saved_model_dir,
               {_SAVED_MODEL_SIGNATURE_KEY: root.run})
 
     # Run TRT conversion.
     converter = self._CreateConverterV2(
         input_saved_model_dir, is_dynamic_op=False)
-    converter.convert()
-
-    def _CheckFn(node):
-      # Attribute serialized_segment should be empty.
-      self.assertFalse(len(node.attr["serialized_segment"].s), node.name)
-
-    # Verify the converted GraphDef.
-    self._CheckTrtOps(converter._converted_func, _CheckFn)  # pylint: disable=protected-access
-
-    # Save the converted model with the statically-built engine inlined.
-    output_saved_model_dir = self.mkdtemp()
-    converter.save(output_saved_model_dir)
-    unexpected_asset_file = os.path.join(
-        output_saved_model_dir, "assets/trt-serialized-engine.TRTEngineOp_0")
-    self.assertFalse(os.path.exists(unexpected_asset_file))
-
-    del converter
-    gc.collect()  # Force GC to destroy the TRT engine cache.
-
-    # Load and verify the converted model.
-    root_with_trt = load.load(output_saved_model_dir)
-    converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
-    self._CheckTrtOps(converted_signature, _CheckFn)
-    output_with_trt = converted_signature(
-        inp1=ops.convert_to_tensor(np_input1),
-        inp2=ops.convert_to_tensor(np_input2))
-    # The output of running the converted signature is a dict due to
-    # compatibility reasons with V1 SavedModel signature mechanism.
-    self.assertAllClose(
-        expected_output,
-        list(output_with_trt.values())[0],
-        atol=1e-6,
-        rtol=1e-6)
-
-    del root_with_trt
-    gc.collect()  # Force GC to destroy the TRT engine cache.
+    with self.assertRaisesRegexp(
+        ValueError, r"Option is_dynamic_op=False is not supported in TF 2.0"):
+      converter.convert()
 
   @test_util.run_v2_only
   def testTrtGraphConverter_Int8Conversion_v2(self):
@@ -493,8 +457,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
 
     # Convert and perform INT8 calibration
     input_fn = lambda: (np_input1, np_input2)
-    converter.convert(
-        num_calibration_runs=2, calibration_input_fn=input_fn)
+    converter.convert(num_calibration_runs=2, calibration_input_fn=input_fn)
 
     def _CheckFn(node):
       self.assertTrue(len(node.attr["calibration_data"].s), node.name)
@@ -563,7 +526,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     converter = self._CreateConverterV2(input_saved_model_dir)
     converter.convert()
     input_fn = lambda: (np_input1, np_input2)
-    converter.build(num_runs=1, input_fn=input_fn)  # Populate the TRT engine cache.
+    converter.build(
+        num_runs=1, input_fn=input_fn)  # Populate the TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -57,9 +57,8 @@ from tensorflow.python.util.lazy_loader import LazyLoader
 
 _SAVED_MODEL_SIGNATURE_KEY = "mypredict"
 
-gen_trt_ops = LazyLoader(
-    "gen_trt_ops", globals(),
-    "tensorflow.compiler.tf2tensorrt.ops.gen_trt_ops")
+gen_trt_ops = LazyLoader("gen_trt_ops", globals(),
+                         "tensorflow.compiler.tf2tensorrt.ops.gen_trt_ops")
 
 
 class TrtConvertTest(test_util.TensorFlowTestCase):
@@ -183,8 +182,10 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     """Write the saved model as an input for testing."""
     g, var, inp1, inp2, out = self._GetGraphForV1()
     signature_def = signature_def_utils.build_signature_def(
-        inputs={"myinput1": utils.build_tensor_info(inp1),
-                "myinput2": utils.build_tensor_info(inp2)},
+        inputs={
+            "myinput1": utils.build_tensor_info(inp1),
+            "myinput2": utils.build_tensor_info(inp2)
+        },
         outputs={"myoutput": utils.build_tensor_info(out)},
         method_name=signature_constants.PREDICT_METHOD_NAME)
     saved_model_builder = builder.SavedModelBuilder(input_saved_model_dir)
@@ -228,8 +229,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
 
         def next(self):
           self._data += 1
-          return {"input1:0": [[[self._data]]],
-                  "input2:0": [[[self._data]]]}
+          return {"input1:0": [[[self._data]]], "input2:0": [[[self._data]]]}
 
       output_graph_def = converter.calibrate(
           fetch_names=["output:0"],
@@ -282,10 +282,13 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
           importer.import_graph_def(graph_def, name="")
           with self.session(config=self._GetConfigProto()) as sess:
             for test_data in range(10):
-              self.assertEqual(
-                  (test_data + 1.0)**2 + test_data,
-                  sess.run("output:0", feed_dict={"input1:0": [[[test_data]]],
-                                                  "input2:0": [[[test_data]]]}))
+              self.assertEqual((test_data + 1.0)**2 + test_data,
+                               sess.run(
+                                   "output:0",
+                                   feed_dict={
+                                       "input1:0": [[[test_data]]],
+                                       "input2:0": [[[test_data]]]
+                                   }))
 
   @test_util.deprecated_graph_mode_only
   def testTrtGraphConverter_BasicConversion(self):
@@ -311,7 +314,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
       input_saved_model_dir,
       input_saved_model_signature_key=_SAVED_MODEL_SIGNATURE_KEY,
       precision_mode=trt_convert.TrtPrecisionMode.FP32,
-      max_batch_size=None):
+      max_batch_size=None,
+      maximum_cached_engines=2):
     return trt_convert.TrtGraphConverterV2(
         input_saved_model_dir=input_saved_model_dir,
         input_saved_model_signature_key=input_saved_model_signature_key,
@@ -319,7 +323,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
             max_workspace_size_bytes=10 << 20,  # Use a smaller workspace.
             precision_mode=precision_mode,
             is_dynamic_op=False if max_batch_size else True,
-            maximum_cached_engines=2,
+            maximum_cached_engines=maximum_cached_engines,
             max_batch_size=max_batch_size if max_batch_size else 1))
 
   def _CheckTrtOps(self, concrete_func, check_fn=None):
@@ -339,14 +343,18 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self.assertEqual(1, len(trt_op_names))
     self.assertIn("TRTEngineOp_0", trt_op_names[0])
 
+  def _RandomInput(self, shape, dtype=np.float32):
+    inp1 = np.random.random_sample(shape).astype(dtype)
+    inp2 = np.random.random_sample(shape).astype(dtype)
+    return inp1, inp2
+
   @test_util.run_v2_only
   def testTrtGraphConverter_DynamicConversion_v2(self):
     """Test case for trt_convert.TrtGraphConverter()."""
     if not is_tensorrt_enabled():
       return
 
-    np_input1 = np.random.random_sample([4, 1, 1]).astype(np.float32)
-    np_input2 = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input1, np_input2 = self._RandomInput([4, 1, 1])
 
     # Create a model and save it.
     input_saved_model_dir = self.mkdtemp()
@@ -360,7 +368,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     converter.convert()
 
     # Verify the converted GraphDef and ConcreteFunction.
-    self._CheckTrtOps(converter._converted_func)
+    self._CheckTrtOps(converter._converted_func)  # pylint: disable=protected-access
 
     # Save the converted model without any TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
@@ -400,8 +408,9 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     # self._CheckTrtOps(root_with_trt.run.get_concrete_function())
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
     self._CheckTrtOps(converted_signature)
-    output_with_trt = converted_signature(inp1=ops.convert_to_tensor(np_input1),
-                                          inp2=ops.convert_to_tensor(np_input2))
+    output_with_trt = converted_signature(
+        inp1=ops.convert_to_tensor(np_input1),
+        inp2=ops.convert_to_tensor(np_input2))
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
     self.assertAllClose(
@@ -419,8 +428,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     if not is_tensorrt_enabled():
       return
 
-    np_input1 = np.random.random_sample([4, 1, 1]).astype(np.float32)
-    np_input2 = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input1, np_input2 = self._RandomInput([4, 1, 1])
 
     # Create a model and save it.
     input_saved_model_dir = self.mkdtemp()
@@ -436,8 +444,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     def _CheckFn(node):
       self.assertTrue(len(node.attr["serialized_segment"].s), node.name)
 
-    # Verify the converted GraphDef and ConcreteFunction.
-    self._CheckTrtOps(converter._converted_func, _CheckFn)
+    # Verify the converted GraphDef.
+    self._CheckTrtOps(converter._converted_func, _CheckFn)  # pylint: disable=protected-access
 
     # Save the converted model with the statically-built engine inlined.
     output_saved_model_dir = self.mkdtemp()
@@ -453,8 +461,9 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     root_with_trt = load.load(output_saved_model_dir)
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
     self._CheckTrtOps(converted_signature, _CheckFn)
-    output_with_trt = converted_signature(inp1=ops.convert_to_tensor(np_input1),
-                                          inp2=ops.convert_to_tensor(np_input2))
+    output_with_trt = converted_signature(
+        inp1=ops.convert_to_tensor(np_input1),
+        inp2=ops.convert_to_tensor(np_input2))
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
     self.assertAllClose(
@@ -471,8 +480,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     if not is_tensorrt_enabled():
       return
 
-    np_input1 = np.random.random_sample([4, 1, 1]).astype(np.float32)
-    np_input2 = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input1, np_input2 = self._RandomInput([4, 1, 1])
 
     # Create a model and save it.
     input_saved_model_dir = tempfile.mkdtemp(dir=self.get_temp_dir())
@@ -483,15 +491,26 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
 
     # Run TRT conversion.
     converter = self._CreateConverterV2(
-        input_saved_model_dir, precision_mode=trt_convert.TrtPrecisionMode.INT8)
+        input_saved_model_dir,
+        precision_mode=trt_convert.TrtPrecisionMode.INT8,
+        maximum_cached_engines=3)
 
     # Convert and perform INT8 calibration
-    def input_map_fn():
-      return np_input1, np_input2
-    converter.convert(num_calibration_runs=1,
-                      calibration_input_map_fn=input_map_fn)
+    input_map_fn = lambda: (np_input1, np_input2)
+    converter.convert(
+        num_calibration_runs=2, calibration_input_map_fn=input_map_fn)
 
-    # Save the converted model again with serialized engine cache.
+    def _CheckFn(node):
+      self.assertTrue(len(node.attr["calibration_data"].s), node.name)
+
+    # Verify the converted GraphDef.
+    self._CheckTrtOps(converter._converted_func, _CheckFn)  # pylint: disable=protected-access
+
+    # Build another engine with different batch size.
+    converter.build(*self._RandomInput([5, 1, 1]))
+
+    # Save the converted model.
+    # TODO(laigd): check that it should contain two engines.
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
     expected_asset_file = os.path.join(
@@ -502,15 +521,13 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     del converter
     gc.collect()  # Force GC to destroy the TRT engine cache.
 
-    def _CheckFn(node):
-      self.assertTrue(len(node.attr["calibration_data"].s), node.name)
-
     # Load and verify the converted model.
     root_with_trt = load.load(output_saved_model_dir)
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
     self._CheckTrtOps(converted_signature, _CheckFn)
-    output_with_trt = converted_signature(inp1=ops.convert_to_tensor(np_input1),
-                                          inp2=ops.convert_to_tensor(np_input2))
+    output_with_trt = converted_signature(
+        inp1=ops.convert_to_tensor(np_input1),
+        inp2=ops.convert_to_tensor(np_input2))
     self.assertEqual(1, len(output_with_trt))
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
@@ -522,10 +539,11 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
 
     # Run with an input of different batch size. It should build a new engine
     # using calibration table.
-    np_input1 = np.random.random_sample([5, 1, 1]).astype(np.float32)
-    np_input2 = np.random.random_sample([5, 1, 1]).astype(np.float32)
-    output_with_trt = converted_signature(inp1=ops.convert_to_tensor(np_input1),
-                                          inp2=ops.convert_to_tensor(np_input2))
+    # TODO(laigd): check that it should contain three engines.
+    np_input1, np_input2 = self._RandomInput([6, 1, 1])
+    converted_signature(
+        inp1=ops.convert_to_tensor(np_input1),
+        inp2=ops.convert_to_tensor(np_input2))
 
     del root_with_trt
     gc.collect()  # Force GC to destroy the TRT engine cache.
@@ -536,8 +554,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     if not is_tensorrt_enabled():
       return
 
-    np_input1 = np.random.random_sample([4, 1, 1]).astype(np.float32)
-    np_input2 = np.random.random_sample([4, 1, 1]).astype(np.float32)
+    np_input1, np_input2 = self._RandomInput([4, 1, 1])
 
     # Create a model and save it.
     input_saved_model_dir = self.mkdtemp()
@@ -698,9 +715,12 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self._CompareSavedModel(_Model)
 
   def _TestRun(self, sess, batch_size, expect_engine_is_run=True):
-    result = sess.run("output:0",
-                      feed_dict={"input1:0": [[[1.0]]] * batch_size,
-                                 "input2:0": [[[1.0]]] * batch_size})
+    result = sess.run(
+        "output:0",
+        feed_dict={
+            "input1:0": [[[1.0]]] * batch_size,
+            "input2:0": [[[1.0]]] * batch_size
+        })
     self.assertAllEqual([[[5.0]]] * batch_size, result)
 
   @test_util.deprecated_graph_mode_only

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -30,6 +30,7 @@ from tensorflow.core.protobuf import config_pb2
 from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python.compiler.tensorrt import trt_convert
 from tensorflow.python.eager import def_function
+from tensorflow.python.eager import wrap_function
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import graph_util
@@ -359,6 +360,17 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     converter = self._CreateConverterV2(input_saved_model_dir)
     converter.convert()
 
+    # Verify the converted GraphDef and ConcreteFunction.
+    @def_function.function
+    def wrapper_converted_func(*args, **kwargs):
+      return converter._converted_func(*args, **kwargs)
+    converted_func = wrapper_converted_func
+    self.assertIsInstance(converted_func, def_function.Function)
+    converted_concrete_func = converted_func.get_concrete_function(
+        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32),
+        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
+    self._CheckTrtOps(converted_concrete_func)
+
     # Save the converted model without any TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
@@ -432,6 +444,17 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
 
     def _CheckFn(node):
       self.assertTrue(len(node.attr["serialized_segment"].s), node.name)
+
+    # Verify the converted GraphDef and ConcreteFunction.
+    @def_function.function
+    def wrapper_converted_func(*args, **kwargs):
+      return converter._converted_func(*args, **kwargs)
+    converted_func = wrapper_converted_func
+    self.assertIsInstance(converted_func, def_function.Function)
+    converted_concrete_func = converted_func.get_concrete_function(
+        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32),
+        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
+    self._CheckTrtOps(converted_concrete_func, _CheckFn)
 
     # Save the converted model with the statically-built engine inlined.
     output_saved_model_dir = self.mkdtemp()


### PR DESCRIPTION
- Add TrtGraphConverterV2.build method. Every time this function is called, new TRT engines get built in the cache if needed.
- Do not return function from convert. Exposing the function currently is not safe due to save() method.
- Calibrate in convert method.
- Update tests accordingly.