### PR TITLE
Bug fix for Tensorflow Lite quantized ops tests

### DIFF
--- a/tensorflow/lite/kernels/conv_test.cc
+++ b/tensorflow/lite/kernels/conv_test.cc
@@ -1383,8 +1383,8 @@ TEST_P(ConvolutionOpTest, SimplePerChannelTest) {
   // output has dimension [1 * 1 * 2 * 2] as [batch, y, x, output_channel]
   m.Invoke();
   EXPECT_THAT(m.GetDequantizedOutput(),
-              ElementsAreArray(ArrayFloatNear({28.5, 64, -59.5, -46})));
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({56, 127, -120, -93}));
+              ElementsAreArray(ArrayFloatNear({31, 64, -57, -46})));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({61, 127, -115, -93}));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tensorflow/lite/kernels/depthwise_conv_test.cc
+++ b/tensorflow/lite/kernels/depthwise_conv_test.cc
@@ -1647,9 +1647,9 @@ TEST_P(PerChannelQuantizedDepthwiseConvolutionOpTest, SimpleTest) {
   m.Invoke();
   EXPECT_THAT(
       m.GetDequantizedOutput(),
-      ElementsAreArray(ArrayFloatNear({40.5, 48, 27, 40, 0.5, -4, -24, -36})));
+      ElementsAreArray(ArrayFloatNear({43, 48, 21, 22, 3, -4, -30, -54})));
   EXPECT_THAT(m.GetOutput(),
-              ElementsAreArray({80, 95, 53, 79, 0, -9, -49, -73}));
+              ElementsAreArray({85, 95, 41, 43, 5, -9, -61, -109}));
 }
 
 // Same as previous test, except the shift will be negative for the outputs.
@@ -1695,9 +1695,9 @@ TEST_P(PerChannelQuantizedDepthwiseConvolutionOpTest,
   m.Invoke();
   EXPECT_THAT(
       m.GetDequantizedOutput(),
-      ElementsAreArray(ArrayFloatNear({40, 50, 14.5, 16.5, 0, -2, -32, -42})));
+      ElementsAreArray(ArrayFloatNear({43, 48, 18.5, 22, 3, -4, -28.5, -36})));
   EXPECT_THAT(m.GetOutput(),
-              ElementsAreArray({79, 99, 28, 32, -1, -5, -65, -85}));
+              ElementsAreArray({85, 95, 36, 43, 5, -9, -58, -73}));
 }
 
 // Same as previous test, except the shift will be mixed for the outputs.
@@ -1743,9 +1743,9 @@ TEST_P(PerChannelQuantizedDepthwiseConvolutionOpTest,
   m.Invoke();
   EXPECT_THAT(
       m.GetDequantizedOutput(),
-      ElementsAreArray(ArrayFloatNear({40, 48, 27, 16.5, 0, -4, -24, -42})));
+      ElementsAreArray(ArrayFloatNear({43, 48, 21, 22, 3, -4, -30, -36})));
   EXPECT_THAT(m.GetOutput(),
-              ElementsAreArray({79, 95, 53, 32, -1, -9, -49, -85}));
+              ElementsAreArray({85, 95, 41, 43, 5, -9, -61, -73}));
 }
 
 TEST_P(PerChannelQuantizedDepthwiseConvolutionOpTest, Simple3x3FilterTest) {

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -236,7 +236,7 @@ class SingleOpModel {
     auto* params =
         reinterpret_cast<TfLiteAffineQuantization*>(t->quantization.params);
     for (int i = 0; i < num_inputs; ++i) {
-      quantized_output[i] = input_data[i] * params->scale->data[i];
+      quantized_output[i] = input_data[i] / params->scale->data[i];
     }
     PopulateTensor(index, /*offset=*/0, quantized_output.data(),
                    quantized_output.data() + quantized_output.size());


### PR DESCRIPTION
Use division instead of multiplication when applying
the quantisation scale in [PerChannelQuantizeBias()](https://github.com/tensorflow/tensorflow/blob/1f61f13f8715dc26dabe46a2686216674026d812/tensorflow/lite/kernels/test_util.h#L239)

Fixes #31756