### PR TITLE
2.0-CherryPick:TF-TRT API changes and fix regressions

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -5191,7 +5191,11 @@ Status ConvertGraphDefToEngine(
   }
 
   // Build the network
-  VLOG(1) << "Starting engine conversion ";
+  if (VLOG_IS_ON(1)) {
+    string mode_str;
+    TF_RETURN_IF_ERROR(TrtPrecisionModeToName(precision_mode, &mode_str));
+    VLOG(1) << "Starting engine conversion, precision mode: " << mode_str;
+  }
   Converter converter(trt_network.get(), precision_mode, use_calibration);
   std::vector<Converter::EngineOutputInfo> output_tensors;
   // Graph nodes are already topologically sorted during construction

--- a/tensorflow/compiler/tf2tensorrt/kernels/get_calibration_data_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/get_calibration_data_op.cc
@@ -48,12 +48,10 @@ class GetCalibrationDataOp : public OpKernel {
                                 &resource));
     core::ScopedUnref sc(resource);
 
-    auto* calib_ctx = resource->calib_ctx_.get();
-
     // Serialize the resource as output.
-    string serialized_resource;
-    OP_REQUIRES_OK(context, calib_ctx->SerializeToString(&serialized_resource));
-    resource->calib_ctx_.reset();
+    string serialized_resource = resource->calib_ctx_->TerminateCalibration();
+    OP_REQUIRES(context, !serialized_resource.empty(),
+                errors::Unknown("Calibration table is empty."));
 
     Tensor* output = nullptr;
     OP_REQUIRES_OK(context,

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
@@ -184,13 +184,7 @@ class SerializeTRTResource : public OpKernel {
     core::ScopedUnref unref_me(resource);
 
     // Terminate the calibration if any.
-    if (resource->calib_ctx_) {
-      // We don't save the calibration_table for TF 2.0 at the moment, it's used
-      // in 1.x environment.
-      string calibration_table;
-      OP_REQUIRES_OK(
-          ctx, resource->calib_ctx_->SerializeToString(&calibration_table));
-    }
+    if (resource->calib_ctx_) resource->calib_ctx_->TerminateCalibration();
 
     // Serialize the engines and write them to file.
     std::unique_ptr<WritableFile> file;

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -148,7 +148,6 @@ TrtConversionParams = collections.namedtuple(
         "use_calibration",
 
         # Max size for the input batch.
-        # This option is deprecated in TF 2.0.
         "max_batch_size",
     ])
 
@@ -217,12 +216,11 @@ def _check_trt_version_compatibility():
 
 
 def get_tensorrt_rewriter_config(
-    conversion_params=DEFAULT_TRT_CONVERSION_PARAMS, is_v2=False):
+    conversion_params=DEFAULT_TRT_CONVERSION_PARAMS):
   """Returns a RewriterConfig proto for TRT transformation.
 
   Args:
     conversion_params: a TrtConversionParams instance.
-    is_v2: whether we're getting a RewriterConfig for TF 2.0.
 
   Returns:
     A RewriterConfig proto which sets a TensorRTOptimizer to run Grappler.
@@ -265,15 +263,9 @@ def get_tensorrt_rewriter_config(
       "maximum_cached_engines"].i = conversion_params.maximum_cached_engines
   optimizer.parameter_map[
       "use_calibration"].b = conversion_params.use_calibration
-
-  if is_v2:
-    # Static mode (a.k.a pre-generating TRT engines and make them node
-    # attributes) is deprecated in TF 2.0.
-    optimizer.parameter_map["is_dynamic_op"].b = True
-  else:
-    optimizer.parameter_map[
-        "max_batch_size"].i = conversion_params.max_batch_size
-    optimizer.parameter_map["is_dynamic_op"].b = conversion_params.is_dynamic_op
+  optimizer.parameter_map[
+      "max_batch_size"].i = conversion_params.max_batch_size
+  optimizer.parameter_map["is_dynamic_op"].b = conversion_params.is_dynamic_op
   return rewriter_config_with_trt
 
 
@@ -765,68 +757,89 @@ class _TRTEngineResource(tracking.TrackableResource):
 class TrtGraphConverterV2(object):
   """An offline converter for TF-TRT transformation for TF 2.0 SavedModels.
 
-  To run the conversion without quantization calibration (e.g. for FP32/FP16
-  precision modes):
+  There are several ways to run the conversion:
 
-  ```python
-  params = DEFAULT_TRT_CONVERSION_PARAMS._replace(precision_mode='FP16')
-  converter = TrtGraphConverterV2(
-      input_saved_model_dir="my_dir", conversion_params=params)
-  converter.convert()
-  converter.save(output_saved_model_dir)
-  ```
+  1. FP32/FP16 precision, static mode (i.e. one TRT engine will be built for
+     each segment without executing the TRTEngineOp)
 
-  As a result, a TF-TRT converted SavedModel will be generated and saved to
-  `output_saved_model_dir`. The SavedModel will have TRT compatible subgraph
-  replaced by TRTEngineOps, but no TRT engines will be pre-built until execution
-  time. We can also build the TRT engines offline by running the converted
-  function with some input data:
+     ```python
+     params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
+         precision_mode='FP16',
+         is_dynamic_op=False)
+     converter = TrtGraphConverterV2(
+         input_saved_model_dir="my_dir", conversion_params=params)
+     converter.convert()
+     converter.save(output_saved_model_dir)  # Save the converted SavedModel.
+     ```
 
-  ```python
-  params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
-      precision_mode='FP16',
-      # Set this to a large enough number so it can cache all the TRT engines.
-      maximum_cached_engines=16)
-  converter = TrtGraphConverterV2(
-      input_saved_model_dir="my_dir", conversion_params=params)
-  converted_func = converter.convert()
-  for data in my_input_data:
-    converted_func(my_input_data)  # Generate corresponding TRT engines.
-  converter.save(output_saved_model_dir)  # Generated engines will be saved.
-  ```
+     This saves the cost of building engines during inference, but also requires
+     that the input model has all tensor shapes fully specified (except for the
+     batch dimension).
 
-  In this way, for each unique shapes of the inputs to the TRTEngineOp, if it
-  cannot be handled by any previously generated TRT engine, a new engine will be
-  generated and serialized to the output SavedModel in `output_saved_model_dir`.
-  This is good for applications that cannot afford building TRT engines at
-  runtime but have access to input data that is similar to the one used in
-  production (for example, that will result in the same input shapes to the
-  TRTEngineOps). Also, the generated TRT engines is platform dependent, so we
-  need to run `converted_func` in an environment that is similar to production
-  (at least with same type of GPU).
+  2. FP32/FP16 precision, dynamic mode (i.e. TRT engines will be built only when
+     the corresponding TRTEngineOp is executed)
 
-  To run the conversion in INT8 mode with calibration:
+     ```python
+     params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
+         precision_mode='FP16',
+         is_dynamic_op=True)
+     converter = TrtGraphConverterV2(
+         input_saved_model_dir="my_dir", conversion_params=params)
+     converter.convert()
+     converter.save(output_saved_model_dir)
+     ```
 
-  ```python
-  params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
-      precision_mode='INT8',
-      is_dynamic_op=True,
-      # Currently only one INT8 engine is supported.
-      maximum_cached_engines=1,
-      use_calibration=True)
-  converter = TrtGraphConverterV2(
-      input_saved_model_dir="my_dir", conversion_params=params)
-  converted_func = converter.convert()
+     In this case, no TRT engines will be built or saved in the converted
+     SavedModel. But if input data is available during conversion, we can still
+     build and save the TRT engines to reduce the cost during inference (see
+     option 3 below).
 
-  # Run INT8 calibration.
-  for data in my_input_data:
-    converted_func(my_input_data)
+  3. FP32/FP16 precision, dynamic mode with pre-built engines
 
-  # Finalize the calibration, and generate and save the TRT engine.
-  converter.save(output_saved_model_dir)
-  ```
+     ```python
+     params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
+         precision_mode='FP16',
+         is_dynamic_op=True,
+         # Set this to a large enough number so it can cache all the engines.
+         maximum_cached_engines=16)
+     converter = TrtGraphConverterV2(
+         input_saved_model_dir="my_dir", conversion_params=params)
+     converted_func = converter.convert()
+     for data in my_input_data:
+       converted_func(my_input_data)  # Generate corresponding TRT engines.
+     converter.save(output_saved_model_dir)  # Generated engines will be saved.
+     ```
 
-  This is similar to the steps above for generating pre-built TRT engines.
+     In this way, one engine will be built/saved for each unique input shapes of
+     the TRTEngineOp. This is good for applications that cannot afford building
+     engines during inference but have access to input data that is similar to
+     the one used in production (for example, that has the same input shapes).
+     Also, the generated TRT engines is platform dependent, so we need to run
+     `converted_func` in an environment that is similar to production (e.g. with
+     same type of GPU).
+
+  4. INT8 precision with calibration, dynamic mode with pre-built engine
+
+     ```python
+     params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
+         precision_mode='INT8',
+         is_dynamic_op=True,
+         # Currently only one INT8 engine is supported in this mode.
+         maximum_cached_engines=1,
+         use_calibration=True)
+     converter = TrtGraphConverterV2(
+         input_saved_model_dir="my_dir", conversion_params=params)
+     converted_func = converter.convert()
+
+     # Run INT8 calibration.
+     for data in my_input_data:
+       converted_func(my_input_data)
+
+     # Finalize the calibration, generate and save the TRT engine.
+     converter.save(output_saved_model_dir)
+     ```
+
+     The steps are similar to option 3 for FP32/FP16 precisions.
   """
 
   def __init__(self,
@@ -878,7 +891,7 @@ class TrtGraphConverterV2(object):
       The optimized GraphDef.
     """
     rewriter_config = get_tensorrt_rewriter_config(
-        conversion_params=self._conversion_params, is_v2=True)
+        conversion_params=self._conversion_params)
     grappler_session_config = config_pb2.ConfigProto()
     grappler_session_config.graph_options.rewrite_options.CopyFrom(
         rewriter_config)

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -31,7 +31,6 @@ from tensorflow.core.protobuf import meta_graph_pb2
 from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python.client import session
 from tensorflow.python.eager import context
-from tensorflow.python.eager import def_function
 from tensorflow.python.eager import wrap_function
 from tensorflow.python.framework import convert_to_constants
 from tensorflow.python.framework import dtypes

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -100,6 +100,7 @@ class TrtPrecisionMode(object):
     ]
     return precisions + [p.lower() for p in precisions]
 
+
 # Use a large enough number as the default max_workspace_size for TRT engines,
 # so it can produce reasonable performance results with the default.
 DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = 1 << 30
@@ -263,8 +264,7 @@ def get_tensorrt_rewriter_config(
       "maximum_cached_engines"].i = conversion_params.maximum_cached_engines
   optimizer.parameter_map[
       "use_calibration"].b = conversion_params.use_calibration
-  optimizer.parameter_map[
-      "max_batch_size"].i = conversion_params.max_batch_size
+  optimizer.parameter_map["max_batch_size"].i = conversion_params.max_batch_size
   optimizer.parameter_map["is_dynamic_op"].b = conversion_params.is_dynamic_op
   return rewriter_config_with_trt
 
@@ -955,14 +955,20 @@ class TrtGraphConverterV2(object):
     engine_asset_dir = tempfile.mkdtemp()
     resource_map = {}
 
-    def _serialize_and_track_engine(canonical_engine_name):
+    def _serialize_and_track_engine(node):
       """Serialize TRT engines in the cache and track them."""
       # Don't dump the same cache twice.
+      canonical_engine_name = _get_canonical_engine_name(node.name)
       if canonical_engine_name in resource_map:
         return
 
       filename = os.path.join(engine_asset_dir,
                               "trt-serialized-engine." + canonical_engine_name)
+      if self._need_calibration:
+        calibration_table = gen_trt_ops.get_calibration_data_op(
+            canonical_engine_name)
+        node.attr["calibration_data"].s = calibration_table.numpy()
+
       try:
         gen_trt_ops.serialize_trt_resource(
             resource_name=canonical_engine_name,
@@ -980,19 +986,28 @@ class TrtGraphConverterV2(object):
 
     for node in self._converted_graph_def.node:
       if node.op == _TRT_ENGINE_OP_NAME:
-        _serialize_and_track_engine(_get_canonical_engine_name(node.name))
+        _serialize_and_track_engine(node)
     for func in self._converted_graph_def.library.function:
       for node in func.node_def:
         if node.op == _TRT_ENGINE_OP_NAME:
-          _serialize_and_track_engine(canonical_engine_name(node))
+          _serialize_and_track_engine(node)
 
     self._saved_model.trt_engine_resources = resource_map
+
+    # Rebuild the function since calibration may change the graph.
+    func_to_save = wrap_function.function_from_graph_def(
+        self._converted_graph_def,
+        [tensor.name for tensor in self._converted_func.inputs],
+        [tensor.name for tensor in self._converted_func.outputs])
+    func_to_save.graph.structured_outputs = nest.pack_sequence_as(
+        self._converted_func.graph.structured_outputs,
+        func_to_save.graph.structured_outputs)
 
     # Rewrite the signature map using the optimized ConcreteFunction.
     signatures = {
         key: value for key, value in self._saved_model.signatures.items()
     }
-    signatures[self._input_saved_model_signature_key] = self._converted_func
+    signatures[self._input_saved_model_signature_key] = func_to_save
     save.save(self._saved_model, output_saved_model_dir, signatures)
 
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -878,6 +878,7 @@ class TrtGraphConverterV2(object):
     if (self._need_calibration and not conversion_params.is_dynamic_op):
       raise ValueError("INT8 precision mode with calibration is not supported "
                        "with static TensorRT ops. Set is_dynamic_op to True.")
+    self._calibration_data_collected = False
 
     self._converted = False
 
@@ -900,13 +901,41 @@ class TrtGraphConverterV2(object):
 
   # TODO(laigd): provide a utility function to optimize a ConcreteFunction and
   # use it here (b/124792963).
-  def convert(self):
+  def convert(self,
+              num_calibration_runs=None,
+              calibration_input_map_fn=None):
     """Convert the input SavedModel in 2.0 format.
+
+    Args:
+      num_calibration_runs: number of runs of the graph during calibration.
+      calibration_input_map_fn: a function that returns inputs for the converted
+        tf_function to be calibrated.
+        Example:
+        ```
+        def input_map_fn():
+          return input1, input2, input3
+        ```
+    Raises:
+      ValueError: if the input combination is invalid.
 
     Returns:
       The TF-TRT converted Function.
     """
     assert not self._converted
+
+    if (self._need_calibration and
+        (not num_calibration_runs or
+         not calibration_input_map_fn)):
+      raise ValueError(
+          "Should specify num_calibration_runs and calibration_input_map_fn"
+          "because INT8 calibration is needed")
+    if (not self._need_calibration and
+        (num_calibration_runs or
+         calibration_input_map_fn)):
+      raise ValueError(
+          "Should not specify num_calibration_runs or calibration_input_map_fn"
+          "because INT8 calibration is not needed")
+
     self._saved_model = load.load(self._input_saved_model_dir,
                                   self._input_saved_model_tags)
     func = self._saved_model.signatures[self._input_saved_model_signature_key]
@@ -934,13 +963,49 @@ class TrtGraphConverterV2(object):
 
     self._converted = True
 
-    # Wrap the converted ConcreteFunction in a Function so it can accept numpy
-    # arrays as input.
-    @def_function.function
-    def wrapper_func(*args, **kwargs):
-      return self._converted_func(*args, **kwargs)
+    if self._need_calibration and not self._calibration_data_collected:
+      self._calibrate(num_runs=num_calibration_runs,
+                      input_map_fn=calibration_input_map_fn)
 
-    return wrapper_func
+  def _calibrate(self,
+                 num_runs=None,
+                 input_map_fn=None):
+    """Run calibration.
+
+    Args:
+      num_runs: number of runs of the graph during calibration.
+      input_map_fn: a function that returns inputs for the converted
+        tf_function to be calibrated.
+        Example:
+        ```
+        def input_map_fn():
+          return input1, input2, input3
+        ```
+    """
+    assert self._converted
+    assert self._need_calibration
+    assert num_runs
+    assert input_map_fn
+
+    for _ in range(num_runs):
+      self._converted_func(*map(ops.convert_to_tensor, input_map_fn()))
+
+    self._calibration_data_collected = True
+
+  def build(self, *args, **kwargs):
+    """Run inference on graph in order to build a TensorRT engine
+       in the cahce of TRTEngineOp.
+
+    Returns:
+      The output of the converted Function for the given inputs.
+    """
+    args_tensor = [ops.convert_to_tensor(arg) for arg in args]
+    kwargs_tensor = {k: ops.convert_to_tensor(v) for k, v in kwargs.items()}
+    try:
+      return self._converted_func(*args_tensor, **kwargs_tensor)
+    except OpError:
+      print('Failure in execution of function with input args {}'
+            'and kwargs {}'.format(args_tensor, kwargs_tensor))
 
   def save(self, output_saved_model_dir):
     """Save the converted SavedModel.

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -801,8 +801,15 @@ class TrtGraphConverterV2(object):
      converter = TrtGraphConverterV2(
          input_saved_model_dir="my_dir", conversion_params=params)
      converter.convert()
-     for data in my_input_data:
-       converter.build(my_input_data)  # Generate corresponding TRT engines.
+
+     # Define an input function that returns input data, and executes the graph
+     # to build TRT engines. With TensorRT 5.1, different engines will be built
+     # (and saved later) for different input shapes to the TRTEngineOp.
+     def my_input_fn():
+       data = ...
+       return (data,)
+
+     converter.build(input_fn=my_input_fn)  # Generate corresponding TRT engines
      converter.save(output_saved_model_dir)  # Generated engines will be saved.
      ```
 
@@ -825,23 +832,25 @@ class TrtGraphConverterV2(object):
      converter = TrtGraphConverterV2(
          input_saved_model_dir="my_dir", conversion_params=params)
 
-     # Define an input function that yields input data, and run INT8 calibration
-     # with the data. All input data should have the same shape. At the end of
-     # convert(), the calibration stats (e.g. range information) will be saved
-     # and can be used to generate more TRT engines with different shapes. Also,
-     # one TRT engine will be generated (with the same shape as the calibration
-     # data) for save later.
-     def my_input_map_fn():
+     # Define an input function that returns input data, and run INT8
+     # calibration with the data. All input data should have the same shape.
+     # At the end of convert(), the calibration stats (e.g. range information)
+     # will be saved and can be used to generate more TRT engines with different
+     # shapes. Also, one TRT engine will be generated (with the same shape as
+     # the calibration data) for save later.
+     def my_input_fn():
        data = ...
-       yield (data,)
+       return (data,)
 
      converter.convert(
-         num_calibration_runs=100, calibration_input_fn=my_input_map_fn)
+         num_calibration_runs=100, calibration_input_fn=my_input_fn)
 
-     # (Optional) Generate more TRT engines offline to avoid the cost of
-     # generating them during inference.
-     for data in my_input_data:
-       converter.build(my_input_data)
+     # (Optional) Generate more TRT engines offline (same as the previous
+     # option), to avoid the cost of generating them during inference.
+     def my_input_fn():
+       data = ...
+       return (data,)
+     converter.build(input_fn=my_input_fn)
 
      # Save the TRT engine and the engines.
      converter.save(output_saved_model_dir)
@@ -920,13 +929,14 @@ class TrtGraphConverterV2(object):
     """Convert the input SavedModel in 2.0 format.
 
     Args:
-      num_calibration_runs: number of runs of the graph during calibration.
+      num_calibration_runs: number of runs of the graph with
+        calibration_input_fn during calibration.
       calibration_input_fn: a function that returns input data as a list or
         tuple, which will be used to execute the converted signature for
         calibration. All the returned input data should have the same shape.
         Example:
         ```
-        def input_map_fn():
+        def input_fn():
           return input1, input2, input3
         ```
 
@@ -999,19 +1009,23 @@ class TrtGraphConverterV2(object):
 
     self._converted = True
 
-  def build(self, *args, **kwargs):
+  def build(self, num_runs, input_fn):
     """Run inference with converted graph in order to build TensorRT engines.
 
-    Returns:
-      The output of the converted Function for the given inputs.
+    Args:
+      num_runs: number of runs of the graph with input_fn.
+      input_fn: a function that returns input data as a list or tuple, which
+        will be used to execute the converted signature to generate TRT engines.
+        All the returned input data should have the same shape.
+        Example:
+        ```
+        def input_fn():
+          return input1, input2, input3
+        ```
     """
-    args_tensor = [ops.convert_to_tensor(arg) for arg in args]
-    kwargs_tensor = {k: ops.convert_to_tensor(v) for k, v in kwargs.items()}
-    try:
-      return self._converted_func(*args_tensor, **kwargs_tensor)
-    except OpError:
-      print("Failure in execution of function with input args {}"
-            "and kwargs {}".format(args_tensor, kwargs_tensor))
+    for _ in range(num_runs):
+      self._converted_func(
+          *map(ops.convert_to_tensor, input_fn()))
 
   def save(self, output_saved_model_dir):
     """Save the converted SavedModel.

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -128,6 +128,7 @@ TrtConversionParams = collections.namedtuple(
 
         # Whether to generate dynamic TRT ops which will build the TRT network
         # and engine at run time.
+        # This option will always be set to True in TF 2.0.
         "is_dynamic_op",
 
         # Max number of cached TRT engines in dynamic TRT ops. If the number of
@@ -148,6 +149,7 @@ TrtConversionParams = collections.namedtuple(
         "use_calibration",
 
         # Max size for the input batch.
+        # This option is deprecated in TF 2.0.
         "max_batch_size",
     ])
 
@@ -216,11 +218,12 @@ def _check_trt_version_compatibility():
 
 
 def get_tensorrt_rewriter_config(
-    conversion_params=DEFAULT_TRT_CONVERSION_PARAMS):
+    conversion_params=DEFAULT_TRT_CONVERSION_PARAMS, is_v2=False):
   """Returns a RewriterConfig proto for TRT transformation.
 
   Args:
     conversion_params: a TrtConversionParams instance.
+    is_v2: whether we're getting a RewriterConfig for TF 2.0.
 
   Returns:
     A RewriterConfig proto which sets a TensorRTOptimizer to run Grappler.
@@ -263,8 +266,17 @@ def get_tensorrt_rewriter_config(
       "maximum_cached_engines"].i = conversion_params.maximum_cached_engines
   optimizer.parameter_map[
       "use_calibration"].b = conversion_params.use_calibration
-  optimizer.parameter_map["max_batch_size"].i = conversion_params.max_batch_size
-  optimizer.parameter_map["is_dynamic_op"].b = conversion_params.is_dynamic_op
+  if is_v2:
+    # Static mode (building TRT engine without executing the op) is deprecated
+    # in TF 2.0. See TrtGraphConverterV2 for more details.
+    if not conversion_params.is_dynamic_op:
+      tf_logging.warn("Option is_dynamic_op=False is deprecated in TF 2.0, "
+                      "resetting it to True.")
+    optimizer.parameter_map["is_dynamic_op"].b = True
+  else:
+    optimizer.parameter_map[
+        "max_batch_size"].i = conversion_params.max_batch_size
+    optimizer.parameter_map["is_dynamic_op"].b = conversion_params.is_dynamic_op
   return rewriter_config_with_trt
 
 
@@ -756,32 +768,18 @@ class _TRTEngineResource(tracking.TrackableResource):
 class TrtGraphConverterV2(object):
   """An offline converter for TF-TRT transformation for TF 2.0 SavedModels.
 
+  Note that in V2, is_dynamic_op=False is not supported, meaning TRT engines
+  will be built only when the corresponding TRTEngineOp is executed. But we
+  still provide a way to avoid the cost of building TRT engines during inference
+  (see more below).
+
   There are several ways to run the conversion:
 
-  1. FP32/FP16 precision, static mode (i.e. one TRT engine will be built for
-     each segment without executing the TRTEngineOp)
+  1. FP32/FP16 precision
 
      ```python
      params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
-         precision_mode='FP16',
-         is_dynamic_op=False)
-     converter = TrtGraphConverterV2(
-         input_saved_model_dir="my_dir", conversion_params=params)
-     converter.convert()
-     converter.save(output_saved_model_dir)  # Save the converted SavedModel.
-     ```
-
-     This saves the cost of building engines during inference, but also requires
-     that the input model has all tensor shapes fully specified (except for the
-     batch dimension).
-
-  2. FP32/FP16 precision, dynamic mode (i.e. TRT engines will be built only when
-     the corresponding TRTEngineOp is executed)
-
-     ```python
-     params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
-         precision_mode='FP16',
-         is_dynamic_op=True)
+         precision_mode='FP16')
      converter = TrtGraphConverterV2(
          input_saved_model_dir="my_dir", conversion_params=params)
      converter.convert()
@@ -791,21 +789,20 @@ class TrtGraphConverterV2(object):
      In this case, no TRT engines will be built or saved in the converted
      SavedModel. But if input data is available during conversion, we can still
      build and save the TRT engines to reduce the cost during inference (see
-     option 3 below).
+     option 2 below).
 
-  3. FP32/FP16 precision, dynamic mode with pre-built engines
+  2. FP32/FP16 precision with pre-built engines
 
      ```python
      params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
          precision_mode='FP16',
-         is_dynamic_op=True,
          # Set this to a large enough number so it can cache all the engines.
          maximum_cached_engines=16)
      converter = TrtGraphConverterV2(
          input_saved_model_dir="my_dir", conversion_params=params)
-     converted_func = converter.convert()
+     converter.convert()
      for data in my_input_data:
-       converted_func(my_input_data)  # Generate corresponding TRT engines.
+       converter.build(my_input_data)  # Generate corresponding TRT engines.
      converter.save(output_saved_model_dir)  # Generated engines will be saved.
      ```
 
@@ -814,31 +811,41 @@ class TrtGraphConverterV2(object):
      engines during inference but have access to input data that is similar to
      the one used in production (for example, that has the same input shapes).
      Also, the generated TRT engines is platform dependent, so we need to run
-     `converted_func` in an environment that is similar to production (e.g. with
+     `build()` in an environment that is similar to production (e.g. with
      same type of GPU).
 
-  4. INT8 precision with calibration, dynamic mode with pre-built engine
+  3. INT8 precision and calibration with pre-built engines
 
      ```python
      params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
          precision_mode='INT8',
-         is_dynamic_op=True,
          # Currently only one INT8 engine is supported in this mode.
          maximum_cached_engines=1,
          use_calibration=True)
      converter = TrtGraphConverterV2(
          input_saved_model_dir="my_dir", conversion_params=params)
-     converted_func = converter.convert()
 
-     # Run INT8 calibration.
+     # Define an input function that yields input data, and run INT8 calibration
+     # with the data. All input data should have the same shape. At the end of
+     # convert(), the calibration stats (e.g. range information) will be saved
+     # and can be used to generate more TRT engines with different shapes. Also,
+     # one TRT engine will be generated (with the same shape as the calibration
+     # data) for save later.
+     def my_input_map_fn():
+       data = ...
+       yield (data,)
+
+     converter.convert(
+         num_calibration_runs=100, calibration_input_fn=my_input_map_fn)
+
+     # (Optional) Generate more TRT engines offline to avoid the cost of
+     # generating them during inference.
      for data in my_input_data:
-       converted_func(my_input_data)
+       converter.build(my_input_data)
 
-     # Finalize the calibration, generate and save the TRT engine.
+     # Save the TRT engine and the engines.
      converter.save(output_saved_model_dir)
      ```
-
-     The steps are similar to option 3 for FP32/FP16 precisions.
   """
 
   def __init__(self,
@@ -890,7 +897,7 @@ class TrtGraphConverterV2(object):
       The optimized GraphDef.
     """
     rewriter_config = get_tensorrt_rewriter_config(
-        conversion_params=self._conversion_params)
+        conversion_params=self._conversion_params, is_v2=True)
     grappler_session_config = config_pb2.ConfigProto()
     grappler_session_config.graph_options.rewrite_options.CopyFrom(
         rewriter_config)
@@ -909,15 +916,19 @@ class TrtGraphConverterV2(object):
 
   # TODO(laigd): provide a utility function to optimize a ConcreteFunction and
   # use it here (b/124792963).
-  def convert(self, num_calibration_runs=None, calibration_input_map_fn=None):
+  def convert(self, num_calibration_runs=None, calibration_input_fn=None):
     """Convert the input SavedModel in 2.0 format.
 
     Args:
       num_calibration_runs: number of runs of the graph during calibration.
-      calibration_input_map_fn: a function that returns inputs for the converted
-        tf_function to be calibrated.
-        Example: ```
-        def input_map_fn(): return input1, input2, input3 ```
+      calibration_input_fn: a function that returns input data as a list or
+        tuple, which will be used to execute the converted signature for
+        calibration. All the returned input data should have the same shape.
+        Example:
+        ```
+        def input_map_fn():
+          return input1, input2, input3
+        ```
 
     Raises:
       ValueError: if the input combination is invalid.
@@ -928,14 +939,14 @@ class TrtGraphConverterV2(object):
     assert not self._converted
 
     if (self._need_calibration and
-        (not num_calibration_runs or not calibration_input_map_fn)):
+        (not num_calibration_runs or not calibration_input_fn)):
       raise ValueError(
-          "Should specify num_calibration_runs and calibration_input_map_fn"
+          "Should specify num_calibration_runs and calibration_input_fn"
           "because INT8 calibration is needed")
     if (not self._need_calibration and
-        (num_calibration_runs or calibration_input_map_fn)):
+        (num_calibration_runs or calibration_input_fn)):
       raise ValueError(
-          "Should not specify num_calibration_runs or calibration_input_map_fn"
+          "Should not specify num_calibration_runs or calibration_input_fn"
           "because INT8 calibration is not needed")
 
     self._saved_model = load.load(self._input_saved_model_dir,
@@ -966,7 +977,7 @@ class TrtGraphConverterV2(object):
     if self._need_calibration:
       for _ in range(num_calibration_runs):
         self._converted_func(
-            *map(ops.convert_to_tensor, calibration_input_map_fn()))
+            *map(ops.convert_to_tensor, calibration_input_fn()))
 
       def _save_calibration_table(node):
         calibration_table = gen_trt_ops.get_calibration_data_op(
@@ -989,9 +1000,7 @@ class TrtGraphConverterV2(object):
     self._converted = True
 
   def build(self, *args, **kwargs):
-    """Run inference on graph in order to build a TensorRT engine
-
-       in the cahce of TRTEngineOp.
+    """Run inference with converted graph in order to build TensorRT engines.
 
     Returns:
       The output of the converted Function for the given inputs.

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -800,12 +800,14 @@ class TrtGraphConverterV2(object):
          input_saved_model_dir="my_dir", conversion_params=params)
      converter.convert()
 
-     # Define an input function that returns input data, and executes the graph
-     # to build TRT engines. With TensorRT 5.1, different engines will be built
-     # (and saved later) for different input shapes to the TRTEngineOp.
+     # Define a generator function that yields input data, and use it to execute
+     # the graph to build TRT engines.
+     # With TensorRT 5.1, different engines will be built (and saved later) for
+     # different input shapes to the TRTEngineOp.
      def my_input_fn():
-       data = ...
-       return (data,)
+       for _ in range(num_runs):
+         inp1, inp2 = ...
+         yield inp1, inp2
 
      converter.build(input_fn=my_input_fn)  # Generate corresponding TRT engines
      converter.save(output_saved_model_dir)  # Generated engines will be saved.
@@ -830,24 +832,25 @@ class TrtGraphConverterV2(object):
      converter = TrtGraphConverterV2(
          input_saved_model_dir="my_dir", conversion_params=params)
 
-     # Define an input function that returns input data, and run INT8
+     # Define a generator function that yields input data, and run INT8
      # calibration with the data. All input data should have the same shape.
      # At the end of convert(), the calibration stats (e.g. range information)
      # will be saved and can be used to generate more TRT engines with different
      # shapes. Also, one TRT engine will be generated (with the same shape as
      # the calibration data) for save later.
-     def my_input_fn():
-       data = ...
-       return (data,)
+     def my_calibration_input_fn():
+       for _ in range(num_runs):
+         inp1, inp2 = ...
+         yield inp1, inp2
 
-     converter.convert(
-         num_calibration_runs=100, calibration_input_fn=my_input_fn)
+     converter.convert(calibration_input_fn=my_calibration_input_fn)
 
      # (Optional) Generate more TRT engines offline (same as the previous
      # option), to avoid the cost of generating them during inference.
      def my_input_fn():
-       data = ...
-       return (data,)
+       for _ in range(num_runs):
+         inp1, inp2 = ...
+         yield inp1, inp2
      converter.build(input_fn=my_input_fn)
 
      # Save the TRT engine and the engines.
@@ -923,19 +926,17 @@ class TrtGraphConverterV2(object):
 
   # TODO(laigd): provide a utility function to optimize a ConcreteFunction and
   # use it here (b/124792963).
-  def convert(self, num_calibration_runs=None, calibration_input_fn=None):
+  def convert(self, calibration_input_fn=None):
     """Convert the input SavedModel in 2.0 format.
 
     Args:
-      num_calibration_runs: number of runs of the graph with
-        calibration_input_fn during calibration.
-      calibration_input_fn: a function that returns input data as a list or
-        tuple, which will be used to execute the converted signature for
+      calibration_input_fn: a generator function that yields input data as a
+        list or tuple, which will be used to execute the converted signature for
         calibration. All the returned input data should have the same shape.
         Example:
         ```
         def input_fn():
-          return input1, input2, input3
+          yield input1, input2, input3
         ```
 
     Raises:
@@ -946,16 +947,12 @@ class TrtGraphConverterV2(object):
     """
     assert not self._converted
 
-    if (self._need_calibration and
-        (not num_calibration_runs or not calibration_input_fn)):
-      raise ValueError(
-          "Should specify num_calibration_runs and calibration_input_fn"
-          "because INT8 calibration is needed")
-    if (not self._need_calibration and
-        (num_calibration_runs or calibration_input_fn)):
-      raise ValueError(
-          "Should not specify num_calibration_runs or calibration_input_fn"
-          "because INT8 calibration is not needed")
+    if (self._need_calibration and not calibration_input_fn):
+      raise ValueError("Should specify calibration_input_fn because INT8 "
+                       "calibration is needed")
+    if (not self._need_calibration and calibration_input_fn):
+      raise ValueError("Should not specify calibration_input_fn because INT8 "
+                       "calibration is not needed")
 
     self._saved_model = load.load(self._input_saved_model_dir,
                                   self._input_saved_model_tags)
@@ -983,9 +980,8 @@ class TrtGraphConverterV2(object):
         self._converted_func.graph.structured_outputs)
 
     if self._need_calibration:
-      for _ in range(num_calibration_runs):
-        self._converted_func(
-            *map(ops.convert_to_tensor, calibration_input_fn()))
+      for inp in calibration_input_fn():
+        self._converted_func(*map(ops.convert_to_tensor, inp))
 
       def _save_calibration_table(node):
         calibration_table = gen_trt_ops.get_calibration_data_op(
@@ -1007,22 +1003,21 @@ class TrtGraphConverterV2(object):
 
     self._converted = True
 
-  def build(self, num_runs, input_fn):
+  def build(self, input_fn):
     """Run inference with converted graph in order to build TensorRT engines.
 
     Args:
-      num_runs: number of runs of the graph with input_fn.
-      input_fn: a function that returns input data as a list or tuple, which
-        will be used to execute the converted signature to generate TRT engines.
+      input_fn: a generator function that yields input data as a list or tuple,
+        which will be used to execute the converted signature to generate TRT
+        engines.
         Example:
         ```
         def input_fn():
-          return input1, input2, input3
+          yield input1, input2, input3
         ```
     """
-    for _ in range(num_runs):
-      self._converted_func(
-          *map(ops.convert_to_tensor, input_fn()))
+    for inp in input_fn():
+      self._converted_func(*map(ops.convert_to_tensor, inp))
 
   def save(self, output_saved_model_dir):
     """Save the converted SavedModel.

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -57,9 +57,8 @@ from tensorflow.python.util.lazy_loader import LazyLoader
 # Lazily load the op, since it's not available in cpu-only builds. Importing
 # this at top will cause tests that imports TF-TRT fail when they're built
 # and run without CUDA/GPU.
-gen_trt_ops = LazyLoader(
-    "gen_trt_ops", globals(),
-    "tensorflow.compiler.tf2tensorrt.ops.gen_trt_ops")
+gen_trt_ops = LazyLoader("gen_trt_ops", globals(),
+                         "tensorflow.compiler.tf2tensorrt.ops.gen_trt_ops")
 
 # Register TRT ops in python, so that when users import this module they can
 # execute a TRT-converted graph without calling any of the methods in this
@@ -898,6 +897,16 @@ class TrtGraphConverterV2(object):
     return tf_optimizer.OptimizeGraph(
         grappler_session_config, meta_graph_def, graph_id=b"tf_graph")
 
+  def _for_each_trt_node(self, graph_def, fn):
+    """Helper method to manipulate all TRTEngineOps in a GraphDef."""
+    for node in graph_def.node:
+      if node.op == _TRT_ENGINE_OP_NAME:
+        fn(node)
+    for func in graph_def.library.function:
+      for node in func.node_def:
+        if node.op == _TRT_ENGINE_OP_NAME:
+          fn(node)
+
   # TODO(laigd): provide a utility function to optimize a ConcreteFunction and
   # use it here (b/124792963).
   def convert(self, num_calibration_runs=None, calibration_input_map_fn=None):
@@ -907,11 +916,8 @@ class TrtGraphConverterV2(object):
       num_calibration_runs: number of runs of the graph during calibration.
       calibration_input_map_fn: a function that returns inputs for the converted
         tf_function to be calibrated.
-        Example:
-        ```
-        def input_map_fn():
-          return input1, input2, input3
-        ```
+        Example: ```
+        def input_map_fn(): return input1, input2, input3 ```
 
     Raises:
       ValueError: if the input combination is invalid.
@@ -962,6 +968,24 @@ class TrtGraphConverterV2(object):
         self._converted_func(
             *map(ops.convert_to_tensor, calibration_input_map_fn()))
 
+      def _save_calibration_table(node):
+        calibration_table = gen_trt_ops.get_calibration_data_op(
+            _get_canonical_engine_name(node.name))
+        node.attr["calibration_data"].s = calibration_table.numpy()
+
+      self._for_each_trt_node(self._converted_graph_def,
+                              _save_calibration_table)
+
+      # Rebuild the function since calibration has changed the graph.
+      calibrated_func = wrap_function.function_from_graph_def(
+          self._converted_graph_def,
+          [tensor.name for tensor in self._converted_func.inputs],
+          [tensor.name for tensor in self._converted_func.outputs])
+      calibrated_func.graph.structured_outputs = nest.pack_sequence_as(
+          self._converted_func.graph.structured_outputs,
+          calibrated_func.graph.structured_outputs)
+      self._converted_func = calibrated_func
+
     self._converted = True
 
   def build(self, *args, **kwargs):
@@ -1002,10 +1026,6 @@ class TrtGraphConverterV2(object):
 
       filename = os.path.join(engine_asset_dir,
                               "trt-serialized-engine." + canonical_engine_name)
-      if self._need_calibration:
-        calibration_table = gen_trt_ops.get_calibration_data_op(
-            canonical_engine_name)
-        node.attr["calibration_data"].s = calibration_table.numpy()
 
       try:
         gen_trt_ops.serialize_trt_resource(
@@ -1022,30 +1042,15 @@ class TrtGraphConverterV2(object):
           canonical_engine_name, filename,
           self._conversion_params.maximum_cached_engines)
 
-    for node in self._converted_graph_def.node:
-      if node.op == _TRT_ENGINE_OP_NAME:
-        _serialize_and_track_engine(node)
-    for func in self._converted_graph_def.library.function:
-      for node in func.node_def:
-        if node.op == _TRT_ENGINE_OP_NAME:
-          _serialize_and_track_engine(node)
-
+    self._for_each_trt_node(self._converted_graph_def,
+                            _serialize_and_track_engine)
     self._saved_model.trt_engine_resources = resource_map
-
-    # Rebuild the function since calibration may change the graph.
-    func_to_save = wrap_function.function_from_graph_def(
-        self._converted_graph_def,
-        [tensor.name for tensor in self._converted_func.inputs],
-        [tensor.name for tensor in self._converted_func.outputs])
-    func_to_save.graph.structured_outputs = nest.pack_sequence_as(
-        self._converted_func.graph.structured_outputs,
-        func_to_save.graph.structured_outputs)
 
     # Rewrite the signature map using the optimized ConcreteFunction.
     signatures = {
         key: value for key, value in self._saved_model.signatures.items()
     }
-    signatures[self._input_saved_model_signature_key] = func_to_save
+    signatures[self._input_saved_model_signature_key] = self._converted_func
     save.save(self._saved_model, output_saved_model_dir, signatures)
 
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -30,7 +30,6 @@ from tensorflow.core.protobuf import config_pb2
 from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python.compiler.tensorrt import trt_convert
 from tensorflow.python.eager import def_function
-from tensorflow.python.eager import wrap_function
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import graph_util
@@ -361,15 +360,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     converter.convert()
 
     # Verify the converted GraphDef and ConcreteFunction.
-    @def_function.function
-    def wrapper_converted_func(*args, **kwargs):
-      return converter._converted_func(*args, **kwargs)
-    converted_func = wrapper_converted_func
-    self.assertIsInstance(converted_func, def_function.Function)
-    converted_concrete_func = converted_func.get_concrete_function(
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32),
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
-    self._CheckTrtOps(converted_concrete_func)
+    self._CheckTrtOps(converter._converted_func)
 
     # Save the converted model without any TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
@@ -443,15 +434,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
       self.assertTrue(len(node.attr["serialized_segment"].s), node.name)
 
     # Verify the converted GraphDef and ConcreteFunction.
-    @def_function.function
-    def wrapper_converted_func(*args, **kwargs):
-      return converter._converted_func(*args, **kwargs)
-    converted_func = wrapper_converted_func
-    self.assertIsInstance(converted_func, def_function.Function)
-    converted_concrete_func = converted_func.get_concrete_function(
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32),
-        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
-    self._CheckTrtOps(converted_concrete_func, _CheckFn)
+    self._CheckTrtOps(converter._converted_func, _CheckFn)
 
     # Save the converted model with the statically-built engine inlined.
     output_saved_model_dir = self.mkdtemp()

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -377,13 +377,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self.assertFalse(os.path.exists(unexpected_asset_file))
 
     # Run the converted function to populate the engine cache.
-    output_with_trt = converter.build(np_input1, np_input2)
-    self.assertEqual(1, len(output_with_trt))
-    self.assertAllClose(
-        expected_output,
-        list(output_with_trt.values())[0],
-        atol=1e-6,
-        rtol=1e-6)
+    input_fn = lambda: (np_input1, np_input2)
+    converter.build(num_runs=1, input_fn=input_fn)
 
     # Save the converted model again with serialized engine cache.
     output_saved_model_dir = self.mkdtemp()
@@ -494,9 +489,9 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
         maximum_cached_engines=3)
 
     # Convert and perform INT8 calibration
-    input_map_fn = lambda: (np_input1, np_input2)
+    input_fn = lambda: (np_input1, np_input2)
     converter.convert(
-        num_calibration_runs=2, calibration_input_fn=input_map_fn)
+        num_calibration_runs=2, calibration_input_fn=input_fn)
 
     def _CheckFn(node):
       self.assertTrue(len(node.attr["calibration_data"].s), node.name)
@@ -505,7 +500,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self._CheckTrtOps(converter._converted_func, _CheckFn)  # pylint: disable=protected-access
 
     # Build another engine with different batch size.
-    converter.build(*self._RandomInput([5, 1, 1]))
+    input_fn = lambda: self._RandomInput([5, 1, 1])
+    converter.build(num_runs=1, input_fn=input_fn)
 
     # Save the converted model.
     # TODO(laigd): check that it should contain two engines.
@@ -563,7 +559,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     # Run TRT conversion.
     converter = self._CreateConverterV2(input_saved_model_dir)
     converter.convert()
-    converter.build(np_input1, np_input2)  # Populate the TRT engine cache.
+    input_fn = lambda: (np_input1, np_input2)
+    converter.build(num_runs=1, input_fn=input_fn)  # Populate the TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -314,7 +314,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
       input_saved_model_dir,
       input_saved_model_signature_key=_SAVED_MODEL_SIGNATURE_KEY,
       precision_mode=trt_convert.TrtPrecisionMode.FP32,
-      max_batch_size=None,
+      is_dynamic_op=True,
       maximum_cached_engines=2):
     return trt_convert.TrtGraphConverterV2(
         input_saved_model_dir=input_saved_model_dir,
@@ -322,9 +322,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
         conversion_params=trt_convert.DEFAULT_TRT_CONVERSION_PARAMS._replace(
             max_workspace_size_bytes=10 << 20,  # Use a smaller workspace.
             precision_mode=precision_mode,
-            is_dynamic_op=False if max_batch_size else True,
-            maximum_cached_engines=maximum_cached_engines,
-            max_batch_size=max_batch_size if max_batch_size else 1))
+            is_dynamic_op=is_dynamic_op,
+            maximum_cached_engines=maximum_cached_engines))
 
   def _CheckTrtOps(self, concrete_func, check_fn=None):
     graph_def = concrete_func.graph.as_graph_def()
@@ -420,7 +419,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     gc.collect()  # Force GC to destroy the TRT engine cache.
 
   @test_util.run_v2_only
-  def testTrtGraphConverter_StaticConversion_v2(self):
+  def testTrtGraphConverter_StaticConversionNotSupportedInV2(self):
     """Test case for trt_convert.TrtGraphConverter() using static mode."""
     if not is_tensorrt_enabled():
       return
@@ -435,11 +434,13 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
               {_SAVED_MODEL_SIGNATURE_KEY: root.run})
 
     # Run TRT conversion.
-    converter = self._CreateConverterV2(input_saved_model_dir, max_batch_size=4)
+    converter = self._CreateConverterV2(
+        input_saved_model_dir, is_dynamic_op=False)
     converter.convert()
 
     def _CheckFn(node):
-      self.assertTrue(len(node.attr["serialized_segment"].s), node.name)
+      # Attribute serialized_segment should be empty.
+      self.assertFalse(len(node.attr["serialized_segment"].s), node.name)
 
     # Verify the converted GraphDef.
     self._CheckTrtOps(converter._converted_func, _CheckFn)  # pylint: disable=protected-access
@@ -495,7 +496,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     # Convert and perform INT8 calibration
     input_map_fn = lambda: (np_input1, np_input2)
     converter.convert(
-        num_calibration_runs=2, calibration_input_map_fn=input_map_fn)
+        num_calibration_runs=2, calibration_input_fn=input_map_fn)
 
     def _CheckFn(node):
       self.assertTrue(len(node.attr["calibration_data"].s), node.name)

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -377,8 +377,10 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self.assertFalse(os.path.exists(unexpected_asset_file))
 
     # Run the converted function to populate the engine cache.
-    input_fn = lambda: (np_input1, np_input2)
-    converter.build(num_runs=1, input_fn=input_fn)
+    def _InputFn():
+      yield np_input1, np_input2
+
+    converter.build(input_fn=_InputFn)
 
     # Save the converted model again with serialized engine cache.
     output_saved_model_dir = self.mkdtemp()
@@ -453,8 +455,10 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
         maximum_cached_engines=3)
 
     # Convert and perform INT8 calibration
-    input_fn = lambda: (np_input1, np_input2)
-    converter.convert(num_calibration_runs=2, calibration_input_fn=input_fn)
+    def _CalibrationInputFn():
+      yield np_input1, np_input2
+
+    converter.convert(calibration_input_fn=_CalibrationInputFn)
 
     def _CheckFn(node):
       self.assertTrue(len(node.attr["calibration_data"].s), node.name)
@@ -463,8 +467,10 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self._CheckTrtOps(converter._converted_func, _CheckFn)  # pylint: disable=protected-access
 
     # Build another engine with different batch size.
-    input_fn = lambda: self._RandomInput([5, 1, 1])
-    converter.build(num_runs=1, input_fn=input_fn)
+    def _InputFn():
+      yield self._RandomInput([5, 1, 1])
+
+    converter.build(input_fn=_InputFn)
 
     # Save the converted model.
     # TODO(laigd): check that it should contain two engines.
@@ -522,9 +528,11 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     # Run TRT conversion.
     converter = self._CreateConverterV2(input_saved_model_dir)
     converter.convert()
-    input_fn = lambda: (np_input1, np_input2)
-    converter.build(
-        num_runs=1, input_fn=input_fn)  # Populate the TRT engine cache.
+
+    def _InputFn():
+      yield np_input1, np_input2
+
+    converter.build(input_fn=_InputFn)  # Populate the TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -322,6 +322,23 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
             maximum_cached_engines=2,
             max_batch_size=max_batch_size if max_batch_size else 1))
 
+  def _CheckTrtOps(self, concrete_func, check_fn=None):
+    graph_def = concrete_func.graph.as_graph_def()
+    trt_op_names = []
+    for node in graph_def.node:
+      if node.op == "TRTEngineOp":
+        trt_op_names.append(node.name)
+        if check_fn:
+          check_fn(node)
+    for func in graph_def.library.function:
+      for node in func.node_def:
+        if node.op == "TRTEngineOp":
+          trt_op_names.append(node.name)
+          if check_fn:
+            check_fn(node)
+    self.assertEqual(1, len(trt_op_names))
+    self.assertIn("TRTEngineOp_0", trt_op_names[0])
+
   @test_util.run_v2_only
   def testTrtGraphConverter_DynamicConversion_v2(self):
     """Test case for trt_convert.TrtGraphConverter()."""
@@ -341,22 +358,11 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     converter = self._CreateConverterV2(input_saved_model_dir)
     converted_func = converter.convert()
 
-    def _CheckTrtOps(graph_def):
-      trt_op_names = [
-          node.name for node in graph_def.node if node.op == "TRTEngineOp"
-      ]
-      for func in graph_def.library.function:
-        for node in func.node_def:
-          if node.op == "TRTEngineOp":
-            trt_op_names.append(node.name)
-      self.assertEqual(1, len(trt_op_names))
-      self.assertIn("TRTEngineOp_0", trt_op_names[0])
-
     # Verify the converted GraphDef and ConcreteFunction.
     self.assertIsInstance(converted_func, def_function.Function)
     converted_concrete_func = converted_func.get_concrete_function(
         tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
-    _CheckTrtOps(converted_concrete_func.graph.as_graph_def())
+    self._CheckTrtOps(converted_concrete_func)
 
     # Save the converted model without any TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
@@ -382,6 +388,9 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self.assertTrue(os.path.exists(expected_asset_file))
     self.assertTrue(os.path.getsize(expected_asset_file))
 
+    del converter
+    gc.collect()  # Force GC to destroy the TRT engine cache.
+
     # Load and verify the converted model.
     #
     # TODO(laigd): the name of the new input_signature of the
@@ -390,15 +399,17 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     root_with_trt = load.load(output_saved_model_dir)
     # TODO(laigd): `root_with_trt.run` is still using the original graph without
     # trt. Consider changing that.
-    # _CheckTrtOps(
-    #     root_with_trt.run.get_concrete_function().graph.as_graph_def())
+    # self._CheckTrtOps(root_with_trt.run.get_concrete_function())
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
-    _CheckTrtOps(converted_signature.graph.as_graph_def())
+    self._CheckTrtOps(converted_signature)
     output_with_trt = converted_signature(ops.convert_to_tensor(np_input))
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
     output_with_trt = output_with_trt.values()[0]
     self.assertAllClose(expected_output, output_with_trt, atol=1e-6, rtol=1e-6)
+
+    del root_with_trt
+    gc.collect()  # Force GC to destroy the TRT engine cache.
 
   @test_util.run_v2_only
   def testTrtGraphConverter_StaticConversion_v2(self):
@@ -419,23 +430,14 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     converter = self._CreateConverterV2(input_saved_model_dir, max_batch_size=4)
     converted_func = converter.convert()
 
-    def _CheckTrtOps(graph_def):
-      trt_op_names = [
-          node.name for node in graph_def.node if node.op == "TRTEngineOp"
-      ]
-      for func in graph_def.library.function:
-        for node in func.node_def:
-          if node.op == "TRTEngineOp":
-            trt_op_names.append(node.name)
-            self.assertTrue(len(node.attr["serialized_segment"].s), node.name)
-      self.assertEqual(1, len(trt_op_names))
-      self.assertIn("TRTEngineOp_0", trt_op_names[0])
+    def _CheckFn(node):
+      self.assertTrue(len(node.attr["serialized_segment"].s), node.name)
 
     # Verify the converted GraphDef and ConcreteFunction.
     self.assertIsInstance(converted_func, def_function.Function)
     converted_concrete_func = converted_func.get_concrete_function(
         tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
-    _CheckTrtOps(converted_concrete_func.graph.as_graph_def())
+    self._CheckTrtOps(converted_concrete_func, _CheckFn)
 
     # Save the converted model with the statically-built engine inlined.
     output_saved_model_dir = self.mkdtemp()
@@ -444,10 +446,13 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
         output_saved_model_dir, "assets/trt-serialized-engine.TRTEngineOp_0")
     self.assertFalse(os.path.exists(unexpected_asset_file))
 
+    del converter
+    gc.collect()  # Force GC to destroy the TRT engine cache.
+
     # Load and verify the converted model.
     root_with_trt = load.load(output_saved_model_dir)
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
-    _CheckTrtOps(converted_signature.graph.as_graph_def())
+    self._CheckTrtOps(converted_signature, _CheckFn)
     output_with_trt = converted_signature(ops.convert_to_tensor(np_input))
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
@@ -456,6 +461,9 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
         list(output_with_trt.values())[0],
         atol=1e-6,
         rtol=1e-6)
+
+    del root_with_trt
+    gc.collect()  # Force GC to destroy the TRT engine cache.
 
   @test_util.run_v2_only
   def testTrtGraphConverter_Int8Conversion_v2(self):
@@ -493,12 +501,18 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self.assertTrue(os.path.exists(expected_asset_file))
     self.assertTrue(os.path.getsize(expected_asset_file))
 
+    del converter
+    gc.collect()  # Force GC to destroy the TRT engine cache.
+
+    def _CheckFn(node):
+      self.assertTrue(len(node.attr["calibration_data"].s), node.name)
+
     # Load and verify the converted model.
     root_with_trt = load.load(output_saved_model_dir)
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
+    self._CheckTrtOps(converted_signature, _CheckFn)
     output_with_trt = converted_signature(ops.convert_to_tensor(np_input))
     self.assertEqual(1, len(output_with_trt))
-
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
     self.assertAllClose(
@@ -506,6 +520,14 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
         list(output_with_trt.values())[0],
         atol=1e-6,
         rtol=1e-6)
+
+    # Run with an input of different batch size. It should build a new engine
+    # using calibration table.
+    np_input = np.random.random_sample([5, 1, 1]).astype(np.float32)
+    converted_signature(ops.convert_to_tensor(np_input))
+
+    del root_with_trt
+    gc.collect()  # Force GC to destroy the TRT engine cache.
 
   @test_util.run_v2_only
   def testTrtGraphConverter_DestroyEngineCache(self):

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -310,18 +310,20 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
       self,
       input_saved_model_dir,
       input_saved_model_signature_key=_SAVED_MODEL_SIGNATURE_KEY,
-      precision_mode=trt_convert.TrtPrecisionMode.FP32):
+      precision_mode=trt_convert.TrtPrecisionMode.FP32,
+      max_batch_size=None):
     return trt_convert.TrtGraphConverterV2(
         input_saved_model_dir=input_saved_model_dir,
         input_saved_model_signature_key=input_saved_model_signature_key,
         conversion_params=trt_convert.DEFAULT_TRT_CONVERSION_PARAMS._replace(
             max_workspace_size_bytes=10 << 20,  # Use a smaller workspace.
             precision_mode=precision_mode,
-            is_dynamic_op=True,
-            maximum_cached_engines=2))
+            is_dynamic_op=False if max_batch_size else True,
+            maximum_cached_engines=2,
+            max_batch_size=max_batch_size if max_batch_size else 1))
 
   @test_util.run_v2_only
-  def testTrtGraphConverter_BasicConversion_v2(self):
+  def testTrtGraphConverter_DynamicConversion_v2(self):
     """Test case for trt_convert.TrtGraphConverter()."""
     if not is_tensorrt_enabled():
       return
@@ -339,7 +341,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     converter = self._CreateConverterV2(input_saved_model_dir)
     converted_func = converter.convert()
 
-    def _check_trt_ops(graph_def):
+    def _CheckTrtOps(graph_def):
       trt_op_names = [
           node.name for node in graph_def.node if node.op == "TRTEngineOp"
       ]
@@ -354,7 +356,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     self.assertIsInstance(converted_func, def_function.Function)
     converted_concrete_func = converted_func.get_concrete_function(
         tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
-    _check_trt_ops(converted_concrete_func.graph.as_graph_def())
+    _CheckTrtOps(converted_concrete_func.graph.as_graph_def())
 
     # Save the converted model without any TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
@@ -388,10 +390,64 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     root_with_trt = load.load(output_saved_model_dir)
     # TODO(laigd): `root_with_trt.run` is still using the original graph without
     # trt. Consider changing that.
-    # _check_trt_ops(
+    # _CheckTrtOps(
     #     root_with_trt.run.get_concrete_function().graph.as_graph_def())
     converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
-    _check_trt_ops(converted_signature.graph.as_graph_def())
+    _CheckTrtOps(converted_signature.graph.as_graph_def())
+    output_with_trt = converted_signature(ops.convert_to_tensor(np_input))
+    # The output of running the converted signature is a dict due to
+    # compatibility reasons with V1 SavedModel signature mechanism.
+    output_with_trt = output_with_trt.values()[0]
+    self.assertAllClose(expected_output, output_with_trt, atol=1e-6, rtol=1e-6)
+
+  @test_util.run_v2_only
+  def testTrtGraphConverter_StaticConversion_v2(self):
+    """Test case for trt_convert.TrtGraphConverter() using static mode."""
+    if not is_tensorrt_enabled():
+      return
+
+    np_input = np.random.random_sample([4, 1, 1]).astype(np.float32)
+
+    # Create a model and save it.
+    input_saved_model_dir = self.mkdtemp()
+    root = self._GetModelForV2()
+    expected_output = root.run(np_input)
+    save.save(root, input_saved_model_dir,
+              {_SAVED_MODEL_SIGNATURE_KEY: root.run})
+
+    # Run TRT conversion.
+    converter = self._CreateConverterV2(input_saved_model_dir, max_batch_size=4)
+    converted_func = converter.convert()
+
+    def _CheckTrtOps(graph_def):
+      trt_op_names = [
+          node.name for node in graph_def.node if node.op == "TRTEngineOp"
+      ]
+      for func in graph_def.library.function:
+        for node in func.node_def:
+          if node.op == "TRTEngineOp":
+            trt_op_names.append(node.name)
+            self.assertTrue(len(node.attr["serialized_segment"].s), node.name)
+      self.assertEqual(1, len(trt_op_names))
+      self.assertIn("TRTEngineOp_0", trt_op_names[0])
+
+    # Verify the converted GraphDef and ConcreteFunction.
+    self.assertIsInstance(converted_func, def_function.Function)
+    converted_concrete_func = converted_func.get_concrete_function(
+        tensor_spec.TensorSpec(shape=[None, 1, 1], dtype=dtypes.float32))
+    _CheckTrtOps(converted_concrete_func.graph.as_graph_def())
+
+    # Save the converted model with the statically-built engine inlined.
+    output_saved_model_dir = self.mkdtemp()
+    converter.save(output_saved_model_dir)
+    unexpected_asset_file = os.path.join(
+        output_saved_model_dir, "assets/trt-serialized-engine.TRTEngineOp_0")
+    self.assertFalse(os.path.exists(unexpected_asset_file))
+
+    # Load and verify the converted model.
+    root_with_trt = load.load(output_saved_model_dir)
+    converted_signature = root_with_trt.signatures[_SAVED_MODEL_SIGNATURE_KEY]
+    _CheckTrtOps(converted_signature.graph.as_graph_def())
     output_with_trt = converted_signature(ops.convert_to_tensor(np_input))
     # The output of running the converted signature is a dict due to
     # compatibility reasons with V1 SavedModel signature mechanism.
@@ -472,7 +528,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
 
-    def _destroy_cache():
+    def _DestroyCache():
       with ops.device("GPU:0"):
         handle = gen_trt_ops.create_trt_resource_handle(
             resource_name="TRTEngineOp_0")
@@ -481,15 +537,15 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
 
     with self.assertRaisesRegexp(errors.NotFoundError,
                                  r"Resource .* does not exist."):
-      _destroy_cache()
+      _DestroyCache()
 
     # Load the converted model and make sure the engine cache is populated by
     # default.
     root = load.load(output_saved_model_dir)
-    _destroy_cache()
+    _DestroyCache()
     with self.assertRaisesRegexp(errors.NotFoundError,
                                  r"Resource .* does not exist."):
-      _destroy_cache()
+      _DestroyCache()
 
     # Load the converted model again and make sure the engine cache is destroyed
     # when the model goes out of scope.
@@ -498,7 +554,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase):
     gc.collect()  # Force GC to destroy the TRT engine cache.
     with self.assertRaisesRegexp(errors.NotFoundError,
                                  r"Resource .* does not exist."):
-      _destroy_cache()
+      _DestroyCache()
 
   def _CompareSavedModel(self, model_class):
     signature_key = "serving_default"


### PR DESCRIPTION
This PR improves the API of TF-TRT conversion to fix regressions compared to V1, by adding support for multiple int8 TRT engines in V2, improving usability, and fixing corresponding tests.