### PR TITLE
Use python3 if available to run gen_git_source.py.

### DIFF
--- a/third_party/git/git_configure.bzl
+++ b/third_party/git/git_configure.bzl
@@ -18,6 +18,9 @@ def _get_python_bin(repository_ctx):
     python_bin = repository_ctx.os.environ.get(_PYTHON_BIN_PATH)
     if python_bin != None:
         return python_bin
+    python_bin_path = repository_ctx.which("python3")
+    if python_bin_path != None:
+        return str(python_bin_path)
     python_bin_path = repository_ctx.which("python")
     if python_bin_path != None:
         return str(python_bin_path)


### PR DESCRIPTION
gen_git_source.py fails with an "ImportError: No module named builtins" on a default installation of Python 2 (at least, the one that comes with macOS). This can be worked around by installing the "future" package from pip. However, instead of requiring users to go through this extra step, we can simply run the script using Python 3 if it's installed. The script works on a default installation of Python 3, without requiring extra packages.