### PR TITLE
elementwise requires C++14

### DIFF
--- a/tensorflow/lite/delegates/gpu/metal/kernels/BUILD
+++ b/tensorflow/lite/delegates/gpu/metal/kernels/BUILD
@@ -197,6 +197,9 @@ cc_library(
     name = "elementwise",
     srcs = ["elementwise.cc"],
     hdrs = ["elementwise.h"],
+    copts = [
+        "-std=c++14",
+    ],
     deps = [
         "//tensorflow/lite/delegates/gpu/common:model",
         "//tensorflow/lite/delegates/gpu/common:operations",


### PR DESCRIPTION
This file fails to compile when using C++11, which is the default when building with Bazel. This can be worked around by passing --cxxopt='-std=c++14' as a global build option, but it is more convenient for users if we just configure this cc_library to be built with C++14 by default.

The authors may also want to change it to be compatible with C++11, but that's out of scope for this change.