### PR TITLE
[ROCm] Fix for the broken `--config=rocm` build 

### DIFF
--- a/tensorflow/core/util/ctc/ctc_loss_calculator.h
+++ b/tensorflow/core/util/ctc/ctc_loss_calculator.h
@@ -447,18 +447,18 @@ void CTCLossCalculator<TT>::CalculateBackwardVariables(
       // Begin (GravesTh) Eq 7.15
       // Add in the u, t + 1 term.
       if (ctc_merge_repeated || l_prime[u] == blank_index_) {
-        log_beta->coeffRef(u, t) =
-            LogSumExp(log_beta->coeff(u, t),
-                      log_beta->coeff(u, t + 1) +
-                          log(y(l_prime[u], output_delay_ + t + 1)));
+        log_beta->coeffRef(u, t) = LogSumExp(
+            log_beta->coeff(u, t),
+            log_beta->coeff(u, t + 1) +
+                static_cast<TT>(log(y(l_prime[u], output_delay_ + t + 1))));
       }
 
       // Add in the u + 1, t + 1 term.
       if (u + 1 < U) {
-        log_beta->coeffRef(u, t) =
-            LogSumExp(log_beta->coeff(u, t),
-                      log_beta->coeff(u + 1, t + 1) +
-                          log(y(l_prime[u + 1], output_delay_ + t + 1)));
+        log_beta->coeffRef(u, t) = LogSumExp(
+            log_beta->coeff(u, t),
+            log_beta->coeff(u + 1, t + 1) +
+                static_cast<TT>(log(y(l_prime[u + 1], output_delay_ + t + 1))));
       }
 
       // Add in the u + 2, t + 1 term if l_prime(u) != blank or l_prime(u+2).
@@ -470,7 +470,8 @@ void CTCLossCalculator<TT>::CalculateBackwardVariables(
           log_beta->coeffRef(u, t) =
               LogSumExp(log_beta->coeff(u, t),
                         log_beta->coeff(u + 2, t + 1) +
-                            log(y(l_prime[u + 2], output_delay_ + t + 1)));
+                            static_cast<TT>(
+                                log(y(l_prime[u + 2], output_delay_ + t + 1))));
         }
       }  // End (GravesTh) Eq. 7.15
     }


### PR DESCRIPTION
The `--config=rocm` build was broken by two different commits. 

This PR has two commits that fix each of those two breaks. The commit message for each commit has the details on the error and the fix.

Neither error seems to be ROCm specific, and I am curious about whether the same error was also detected in builds for other platforms. Is there a way to find this out? Thanks.

The fixes are trivial in nature. please review and merge. thanks.


--------------------------------------------------------------------------------------


@tatianashp @whchung @chsigg 
