### PR TITLE
Add fused kernel of ExperimentalUnbatchAndBatchDataset for static optimization

### DIFF
--- a/tensorflow/core/grappler/optimizers/data/BUILD
+++ b/tensorflow/core/grappler/optimizers/data/BUILD
@@ -31,6 +31,7 @@ cc_library(
         ":parallel_batch",
         ":shuffle_and_repeat_fusion",
         ":slack",
+        ":unbatch_and_batch_fusion",
     ],
 )
 
@@ -453,6 +454,27 @@ tf_cc_test(
         "//tensorflow/core:test_main",
         "//tensorflow/core/grappler:grappler_item",
     ],
+)
+
+cc_library(
+    name = "unbatch_and_batch_fusion",
+    srcs = ["unbatch_and_batch_fusion.cc"],
+    hdrs = [
+        "unbatch_and_batch_fusion.h",
+    ],
+    deps = [
+        ":graph_utils",
+        ":optimizer_base",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "//tensorflow/core:lib",
+        "//tensorflow/core/grappler:mutable_graph_view",
+        "//tensorflow/core/grappler:grappler_item",
+        "//tensorflow/core/grappler:op_types",
+        "//tensorflow/core/grappler:utils",
+        "//tensorflow/core/grappler/clusters:cluster",
+        "//tensorflow/core/grappler/optimizers:custom_graph_optimizer_registry",
+    ] + tf_protos_all(),
+    alwayslink = 1,
 )
 
 cc_library(

--- a/tensorflow/core/grappler/optimizers/data/BUILD
+++ b/tensorflow/core/grappler/optimizers/data/BUILD
@@ -477,6 +477,19 @@ cc_library(
     alwayslink = 1,
 )
 
+tf_cc_test(
+    name = "unbatch_and_batch_fusion_test",
+    srcs = ["unbatch_and_batch_fusion_test.cc"],
+    deps = [
+        ":graph_utils",
+        ":unbatch_and_batch_fusion",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core/grappler:grappler_item",
+    ],
+)
+
 cc_library(
     name = "map_and_filter_fusion",
     srcs = ["map_and_filter_fusion.cc"],

--- a/tensorflow/core/grappler/optimizers/data/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/data/meta_optimizer.cc
@@ -36,7 +36,7 @@ using ConfigMap =
     std::map<string, tensorflow::RewriterConfig_CustomGraphOptimizer>;
 
 // tf.data optimizations, in the order we want to perform them.
-constexpr std::array<const char*, 16> kTFDataOptimizations = {
+constexpr std::array<const char*, 17> kTFDataOptimizations = {
     "make_stateless",
     "noop_elimination",
     "shuffle_and_repeat_fusion",
@@ -52,7 +52,8 @@ constexpr std::array<const char*, 16> kTFDataOptimizations = {
     "make_sloppy",
     "parallel_batch",
     "slack",
-    "inject_prefetch"};
+    "inject_prefetch",
+    "unbatch_and_batch_fusion"};
 
 // Standard grappler optimizations, in the order we want to perform them.
 constexpr std::array<const char*, 5> kGrapplerOptimizations = {

--- a/tensorflow/core/grappler/optimizers/data/unbatch_and_batch_fusion.cc
+++ b/tensorflow/core/grappler/optimizers/data/unbatch_and_batch_fusion.cc
@@ -1,0 +1,112 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/grappler/optimizers/data/unbatch_and_batch_fusion.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "tensorflow/core/framework/attr_value.pb.h"
+#include "tensorflow/core/framework/node_def.pb.h"
+#include "tensorflow/core/grappler/clusters/cluster.h"
+#include "tensorflow/core/grappler/grappler_item.h"
+#include "tensorflow/core/grappler/mutable_graph_view.h"
+#include "tensorflow/core/grappler/op_types.h"
+#include "tensorflow/core/grappler/optimizers/custom_graph_optimizer_registry.h"
+#include "tensorflow/core/grappler/optimizers/data/graph_utils.h"
+#include "tensorflow/core/grappler/utils.h"
+#include "tensorflow/core/platform/protobuf.h"
+
+namespace tensorflow {
+namespace grappler {
+namespace {
+
+constexpr char kFusedOpName[] = "ExperimentalUnbatchAndBatchDataset";
+
+NodeDef MakeUnbatchAndBatchNode(const NodeDef& unbatch_node, const NodeDef& batch_node,
+                            MutableGraphView* graph) {
+  NodeDef new_node;
+  new_node.set_op(kFusedOpName);
+  graph_utils::SetUniqueGraphNodeName(kFusedOpName, graph->graph(), &new_node);
+
+  // Set the `input` input argument.
+  new_node.add_input(unbatch_node.input(0));
+
+  // Set the `batch_size` input argument.
+  new_node.add_input(batch_node.input(1));
+
+  // Set the `drop_remainder` input argument.
+  if (batch_node.op() == "BatchDatasetV2") {
+    new_node.add_input(batch_node.input(2));
+  } else {
+    NodeDef* tmp = graph_utils::AddScalarConstNode<bool>(false, graph);
+    new_node.add_input(tmp->name());
+  }
+
+  // Required attributes.
+  for (auto key : {"output_shapes", "output_types"}) {
+    graph_utils::CopyAttribute(key, batch_node, &new_node);
+  }
+
+  return new_node;
+}
+
+}  // namespace
+
+Status UnbatchAndBatchFusion::OptimizeAndCollectStats(Cluster* cluster,
+                                                  const GrapplerItem& item,
+                                                  GraphDef* output,
+                                                  OptimizationStats* stats) {
+  *output = item.graph;
+  MutableGraphView graph(output);
+  absl::flat_hash_set<string> nodes_to_delete;
+  for (const NodeDef& node : item.graph.node()) {
+    if (node.op() != "BatchDataset" && node.op() != "BatchDatasetV2") {
+      continue;
+    }
+
+    // Use a more descriptive variable name now that we know the node type.
+    const NodeDef& batch_node = node;
+    NodeDef* node2 = graph_utils::GetInputNode(batch_node, graph);
+
+    if (node2->op() != "UnbatchDataset") {
+      continue;
+    }
+    // Use a more descriptive variable name now that we know the node type.
+    NodeDef* unbatch_node = node2;
+
+    auto* new_node =
+        graph.AddNode(MakeUnbatchAndBatchNode(*unbatch_node, batch_node, &graph));
+    TF_RETURN_IF_ERROR(
+        graph.UpdateFanouts(batch_node.name(), new_node->name()));
+
+    // Mark the `Unbatch` and `Batch` nodes for removal.
+    nodes_to_delete.insert(unbatch_node->name());
+    nodes_to_delete.insert(batch_node.name());
+    stats->num_changes++;
+  }
+
+  TF_RETURN_IF_ERROR(graph.DeleteNodes(nodes_to_delete));
+  return Status::OK();
+}
+
+void UnbatchAndBatchFusion::Feedback(Cluster* cluster, const GrapplerItem& item,
+                                 const GraphDef& optimize_output,
+                                 double result) {
+  // no-op
+}
+
+REGISTER_GRAPH_OPTIMIZER_AS(UnbatchAndBatchFusion, "unbatch_and_batch_fusion");
+
+}  // namespace grappler
+}  // namespace tensorflow

--- a/tensorflow/core/grappler/optimizers/data/unbatch_and_batch_fusion.h
+++ b/tensorflow/core/grappler/optimizers/data/unbatch_and_batch_fusion.h
@@ -1,0 +1,49 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_GRAPPLER_OPTIMIZERS_DATA_UNBATCH_AND_BATCH_FUSION_H_
+#define TENSORFLOW_CORE_GRAPPLER_OPTIMIZERS_DATA_UNBATCH_AND_BATCH_FUSION_H_
+
+#include "tensorflow/core/grappler/optimizers/data/optimizer_base.h"
+
+namespace tensorflow {
+namespace grappler {
+
+class UnbatchAndBatchFusion : public TFDataOptimizerBase {
+ public:
+  UnbatchAndBatchFusion() = default;
+  ~UnbatchAndBatchFusion() override = default;
+
+  string name() const override { return "unbatch_and_batch_fusion"; };
+
+  bool UsesFunctionLibrary() const override { return false; }
+
+  Status Init(
+      const tensorflow::RewriterConfig_CustomGraphOptimizer* config) override {
+    return Status::OK();
+  }
+
+  Status OptimizeAndCollectStats(Cluster* cluster, const GrapplerItem& item,
+                                 GraphDef* output,
+                                 OptimizationStats* stats) override;
+
+  void Feedback(Cluster* cluster, const GrapplerItem& item,
+                const GraphDef& optimize_output, double result) override;
+};
+
+}  // namespace grappler
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_GRAPPLER_OPTIMIZERS_DATA_UNBATCH_AND_BATCH_FUSION_H_

--- a/tensorflow/core/grappler/optimizers/data/unbatch_and_batch_fusion_test.cc
+++ b/tensorflow/core/grappler/optimizers/data/unbatch_and_batch_fusion_test.cc
@@ -1,0 +1,197 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/grappler/optimizers/data/unbatch_and_batch_fusion.h"
+
+#include "tensorflow/core/framework/attr_value_util.h"
+#include "tensorflow/core/grappler/grappler_item.h"
+#include "tensorflow/core/grappler/optimizers/data/graph_utils.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+namespace grappler {
+namespace {
+
+TEST(UnbatchAndBatchFusionTest, FuseUnbatchAndBatchNodesIntoOne) {
+  GrapplerItem item;
+  MutableGraphView graph(&item.graph);
+
+  NodeDef *start_node = graph_utils::AddScalarConstNode<int64>(0, &graph);
+  NodeDef *stop_node = graph_utils::AddScalarConstNode<int64>(10, &graph);
+  NodeDef *step_node = graph_utils::AddScalarConstNode<int64>(1, &graph);
+
+  std::vector<string> range_inputs(3);
+  range_inputs[0] = start_node->name();
+  range_inputs[1] = stop_node->name();
+  range_inputs[2] = step_node->name();
+  std::vector<std::pair<string, AttrValue>> range_attrs;
+  NodeDef *range_node = graph_utils::AddNode("", "RangeDataset", range_inputs,
+                                             range_attrs, &graph);
+
+  NodeDef *unbatch_node;
+  {
+    std::vector<string> unbatch_inputs(1);
+    unbatch_inputs[0] = range_node->name();
+    std::vector<std::pair<string, AttrValue>> unbatch_attrs;
+    unbatch_node =
+        graph_utils::AddNode("", "UnbatchDataset", unbatch_inputs, unbatch_attrs, &graph);
+  }
+
+  NodeDef *batch_size_node = graph_utils::AddScalarConstNode<int64>(5, &graph);
+  NodeDef *batch_node;
+  {
+    std::vector<string> batch_inputs(2);
+    batch_inputs[0] = unbatch_node->name();
+    batch_inputs[1] = batch_size_node->name();
+    std::vector<std::pair<string, AttrValue>> batch_attrs(2);
+    AttrValue shapes_attr;
+    SetAttrValue("output_shapes", &shapes_attr);
+    batch_attrs[0] = std::make_pair("output_shapes", shapes_attr);
+    AttrValue types_attr;
+    SetAttrValue("output_types", &types_attr);
+    batch_attrs[1] = std::make_pair("output_types", types_attr);
+    batch_node = graph_utils::AddNode("", "BatchDataset", batch_inputs,
+                                      batch_attrs, &graph);
+  }
+
+  UnbatchAndBatchFusion optimizer;
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  EXPECT_FALSE(
+      graph_utils::ContainsGraphNodeWithName(unbatch_node->name(), output));
+  EXPECT_FALSE(
+      graph_utils::ContainsGraphNodeWithName(batch_node->name(), output));
+  EXPECT_TRUE(graph_utils::ContainsNodeWithOp("ExperimentalUnbatchAndBatchDataset", output));
+  NodeDef unbatch_and_batch_node = output.node(
+      graph_utils::FindGraphNodeWithOp("ExperimentalUnbatchAndBatchDataset", output));
+  EXPECT_EQ(unbatch_and_batch_node.input_size(), 3);
+
+  EXPECT_EQ(unbatch_and_batch_node.input(0), unbatch_node->input(0));
+  EXPECT_EQ(unbatch_and_batch_node.input(1), batch_node->input(1));
+  NodeDef drop_remainder_node = output.node(
+      graph_utils::FindGraphNodeWithName(unbatch_and_batch_node.input(2), output));
+  EXPECT_EQ(drop_remainder_node.attr().at("value").tensor().bool_val(0), false);
+  EXPECT_TRUE(AreAttrValuesEqual(unbatch_and_batch_node.attr().at("output_shapes"),
+                                 batch_node->attr().at("output_shapes")));
+  EXPECT_TRUE(AreAttrValuesEqual(unbatch_and_batch_node.attr().at("output_types"),
+                                 batch_node->attr().at("output_types")));
+}
+
+TEST(UnbatchAndBatchFusionTest, FuseUnbatchAndBatchV2NodesIntoOne) {
+  GrapplerItem item;
+  MutableGraphView graph(&item.graph);
+  NodeDef *start_node = graph_utils::AddScalarConstNode<int64>(0, &graph);
+  NodeDef *stop_node = graph_utils::AddScalarConstNode<int64>(10, &graph);
+  NodeDef *step_node = graph_utils::AddScalarConstNode<int64>(1, &graph);
+
+  std::vector<string> range_inputs(3);
+  range_inputs[0] = start_node->name();
+  range_inputs[1] = stop_node->name();
+  range_inputs[2] = step_node->name();
+  std::vector<std::pair<string, AttrValue>> range_attrs;
+  NodeDef *range_node = graph_utils::AddNode("", "RangeDataset", range_inputs,
+                                             range_attrs, &graph);
+
+  NodeDef *unbatch_node;
+  {
+    std::vector<string> unbatch_inputs(1);
+    unbatch_inputs[0] = range_node->name();
+    std::vector<std::pair<string, AttrValue>> unbatch_attrs;
+    unbatch_node =
+        graph_utils::AddNode("", "UnbatchDataset", unbatch_inputs, unbatch_attrs, &graph);
+  }
+
+  NodeDef *batch_size_node = graph_utils::AddScalarConstNode<int64>(5, &graph);
+  NodeDef *drop_remainder_node =
+      graph_utils::AddScalarConstNode<bool>(true, &graph);
+  NodeDef *batch_node;
+  {
+    std::vector<string> batch_inputs(3);
+    batch_inputs[0] = unbatch_node->name();
+    batch_inputs[1] = batch_size_node->name();
+    batch_inputs[2] = drop_remainder_node->name();
+    std::vector<std::pair<string, AttrValue>> batch_attrs(2);
+    AttrValue shapes_attr;
+    SetAttrValue("output_shapes", &shapes_attr);
+    batch_attrs[0] = std::make_pair("output_shapes", shapes_attr);
+    AttrValue types_attr;
+    SetAttrValue("output_types", &types_attr);
+    batch_attrs[1] = std::make_pair("output_types", types_attr);
+    batch_node = graph_utils::AddNode("", "BatchDatasetV2", batch_inputs,
+                                      batch_attrs, &graph);
+  }
+
+  UnbatchAndBatchFusion optimizer;
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  EXPECT_FALSE(
+      graph_utils::ContainsGraphNodeWithName(unbatch_node->name(), output));
+  EXPECT_FALSE(
+      graph_utils::ContainsGraphNodeWithName(batch_node->name(), output));
+  EXPECT_TRUE(graph_utils::ContainsNodeWithOp("ExperimentalUnbatchAndBatchDataset", output));
+  NodeDef unbatch_and_batch_node = output.node(
+      graph_utils::FindGraphNodeWithOp("ExperimentalUnbatchAndBatchDataset", output));
+  EXPECT_EQ(unbatch_and_batch_node.input_size(), 3);
+  EXPECT_EQ(unbatch_and_batch_node.input(0), unbatch_node->input(0));
+  EXPECT_EQ(unbatch_and_batch_node.input(1), batch_node->input(1));
+  EXPECT_EQ(unbatch_and_batch_node.input(2), batch_node->input(2));
+  EXPECT_TRUE(AreAttrValuesEqual(unbatch_and_batch_node.attr().at("output_shapes"),
+                                 batch_node->attr().at("output_shapes")));
+  EXPECT_TRUE(AreAttrValuesEqual(unbatch_and_batch_node.attr().at("output_types"),
+                                 batch_node->attr().at("output_types")));
+}
+
+TEST(UnbatchAndBatchFusionTest, NoChange) {
+  GrapplerItem item;
+  MutableGraphView graph(&item.graph);
+
+  NodeDef *start_node = graph_utils::AddScalarConstNode<int64>(0, &graph);
+  NodeDef *stop_node = graph_utils::AddScalarConstNode<int64>(10, &graph);
+  NodeDef *step_node = graph_utils::AddScalarConstNode<int64>(1, &graph);
+
+  std::vector<string> range_inputs(3);
+  range_inputs[0] = start_node->name();
+  range_inputs[1] = stop_node->name();
+  range_inputs[2] = step_node->name();
+  std::vector<std::pair<string, AttrValue>> range_attrs;
+  NodeDef *range_node = graph_utils::AddNode("", "RangeDataset", range_inputs,
+                                             range_attrs, &graph);
+
+  NodeDef *batch_size_node = graph_utils::AddScalarConstNode<int64>(5, &graph);
+  std::vector<string> batch_inputs(2);
+  batch_inputs[0] = range_node->name();
+  batch_inputs[1] = batch_size_node->name();
+  std::vector<std::pair<string, AttrValue>> batch_attrs(2);
+  AttrValue shapes_attr;
+  SetAttrValue("output_shapes", &shapes_attr);
+  batch_attrs[0] = std::make_pair("output_shapes", shapes_attr);
+  AttrValue types_attr;
+  SetAttrValue("output_types", &types_attr);
+  batch_attrs[1] = std::make_pair("output_types", types_attr);
+  graph_utils::AddNode("", "BatchDataset", batch_inputs, batch_attrs, &graph);
+
+  UnbatchAndBatchFusion optimizer;
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  EXPECT_TRUE(graph_utils::Compare(*graph.graph(), output));
+}
+
+}  // namespace
+}  // namespace grappler
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/data/experimental/BUILD
+++ b/tensorflow/core/kernels/data/experimental/BUILD
@@ -193,6 +193,24 @@ tf_kernel_library(
 )
 
 tf_kernel_library(
+    name = "unbatch_and_batch_dataset_op",
+    srcs = ["unbatch_and_batch_dataset_op.cc"],
+    deps = [
+        "//tensorflow/core:array_ops_op_lib",
+        "//tensorflow/core:core_cpu_internal",
+        "//tensorflow/core:dataset_ops_op_lib",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:nn_ops_op_lib",
+        "//tensorflow/core/kernels:inplace_ops",
+        "//tensorflow/core/kernels/data:captured_function",
+        "//tensorflow/core/kernels/data:dataset_utils",
+        "//tensorflow/core/kernels/data:stats_utils",
+    ],
+)
+
+tf_kernel_library(
     name = "matching_files_dataset_op",
     srcs = ["matching_files_dataset_op.cc"],
     deps = [
@@ -494,6 +512,7 @@ tf_kernel_library(
         ":ignore_errors_dataset_op",
         ":lmdb_dataset_op",
         ":map_and_batch_dataset_op",
+        ":unbatch_and_batch_dataset_op",
         ":matching_files_dataset_op",
         ":non_serializable_dataset_op",
         ":parallel_interleave_dataset_op",

--- a/tensorflow/core/kernels/data/experimental/unbatch_and_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/unbatch_and_batch_dataset_op.cc
@@ -1,0 +1,285 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <atomic>
+#include <utility>
+
+#include "tensorflow/core/common_runtime/function.h"
+#include "tensorflow/core/common_runtime/input_colocation_exemption_registry.h"
+#include "tensorflow/core/common_runtime/metrics.h"
+#include "tensorflow/core/framework/dataset.h"
+#include "tensorflow/core/framework/partial_tensor_shape.h"
+#include "tensorflow/core/framework/stats_aggregator.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/kernels/data/captured_function.h"
+#include "tensorflow/core/kernels/data/dataset_utils.h"
+#include "tensorflow/core/kernels/data/stats_utils.h"
+#include "tensorflow/core/kernels/inplace_ops_functor.h"
+#include "tensorflow/core/lib/core/blocking_counter.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/gtl/cleanup.h"
+#include "tensorflow/core/lib/random/random.h"
+#include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/platform/cpu_info.h"
+#include "tensorflow/core/platform/tracing.h"
+
+namespace tensorflow {
+namespace data {
+namespace experimental {
+namespace {
+
+constexpr char kDatasetName[] = "ExperimentalUnbatchAndBatch";
+
+class UnbatchAndBatchDatasetOp : public UnaryDatasetOpKernel {
+ public:
+  explicit UnbatchAndBatchDatasetOp(OpKernelConstruction* ctx)
+      : UnaryDatasetOpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_types", &output_types_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("output_shapes", &output_shapes_));
+  }
+
+ protected:
+  void MakeDataset(OpKernelContext* ctx, DatasetBase* input,
+                   DatasetBase** output) override {
+    int64 batch_size = 0;
+    OP_REQUIRES_OK(ctx, ParseScalarArgument(ctx, "batch_size", &batch_size));
+    OP_REQUIRES(
+        ctx, batch_size > 0,
+        errors::InvalidArgument("batch_size must be greater than zero."));
+
+    bool drop_remainder;
+    OP_REQUIRES_OK(ctx,
+                   ParseScalarArgument(ctx, "drop_remainder", &drop_remainder));
+
+    *output = new Dataset(ctx, input, batch_size, drop_remainder,
+                          output_types_, output_shapes_);
+  }
+
+ private:
+  class Dataset : public DatasetBase {
+   public:
+    Dataset(OpKernelContext* ctx, const DatasetBase* input,
+            int64 batch_size,
+            bool drop_remainder,
+            const DataTypeVector& output_types,
+            const std::vector<PartialTensorShape>& output_shapes)
+        : DatasetBase(DatasetContext(ctx)),
+          input_(input),
+          batch_size_(batch_size),
+          drop_remainder_(drop_remainder),
+          output_types_(output_types),
+          output_shapes_(output_shapes) {
+      input_->Ref();
+    }
+
+    ~Dataset() override { input_->Unref(); }
+
+    std::unique_ptr<IteratorBase> MakeIteratorInternal(
+        const string& prefix) const override {
+      return absl::make_unique<Iterator>(
+          Iterator::Params{this, strings::StrCat(prefix, "::", kDatasetName)});
+    }
+
+    const DataTypeVector& output_dtypes() const override {
+      return output_types_;
+    }
+
+    const std::vector<PartialTensorShape>& output_shapes() const override {
+      return output_shapes_;
+    }
+
+    string DebugString() const override {
+      return "UnbatchAndBatchDatasetOp::Dataset";
+    }
+
+    int64 Cardinality() const override {
+      int64 n = input_->Cardinality();
+      if (n == kInfiniteCardinality || n == kUnknownCardinality) {
+        return n;
+      }
+      return n / batch_size_ +
+             (n % batch_size_ == 0 || drop_remainder_ ? 0 : 1);
+    }
+
+    Status CheckExternalState() const override {
+      return input_->CheckExternalState();
+    }
+
+   protected:
+    Status AsGraphDefInternal(SerializationContext* ctx,
+                              DatasetGraphDefBuilder* b,
+                              Node** output) const override {
+      Node* input_graph_node = nullptr;
+      TF_RETURN_IF_ERROR(b->AddInputDataset(ctx, input_, &input_graph_node));
+      Node* batch_size_node;
+      TF_RETURN_IF_ERROR(b->AddScalar(batch_size_, &batch_size_node));
+      Node* drop_remainder_node;
+      TF_RETURN_IF_ERROR(b->AddScalar(drop_remainder_, &drop_remainder_node));
+
+      TF_RETURN_IF_ERROR(b->AddDataset(
+          this, {input_graph_node, batch_size_node, drop_remainder_node}, output));
+      return Status::OK();
+    }
+
+    class Iterator : public DatasetIterator<Dataset> {
+     public:
+      explicit Iterator(const Params& params)
+          : DatasetIterator<Dataset>(params)
+          , current_index_(0)
+	  , current_batch_size_(0) {}
+
+      Status Initialize(IteratorContext* ctx) override {
+        return dataset()->input_->MakeIterator(ctx, prefix(), &input_impl_);
+      }
+
+      Status GetNextInternal(IteratorContext* ctx,
+                             std::vector<Tensor>* out_tensors,
+                             bool* end_of_sequence) override {
+        mutex_lock l(mu_);
+        if (!input_impl_) {
+          *end_of_sequence = true;
+          return Status::OK();
+        }
+        *end_of_sequence = false;
+
+        int64 chunk_read = 0;
+
+        out_tensors->clear();
+        std::vector<Tensor> elements;
+
+        while (!*end_of_sequence) {
+          if (current_index_ < current_batch_size_) {
+            if (out_tensors->size() == 0) {
+
+              out_tensors->reserve(tensors_.size());
+              elements.reserve(tensors_.size());
+              for (size_t i = 0; i < tensors_.size(); ++i) {
+                TensorShape shape = tensors_[i].shape();
+
+                shape.RemoveDim(0);
+                elements.emplace_back(ctx->allocator({}), tensors_[i].dtype(), shape);
+
+                shape.InsertDim(0, dataset()->batch_size_);
+                out_tensors->emplace_back(ctx->allocator({}), tensors_[i].dtype(), shape);
+              }
+            }
+
+            if (out_tensors->size() != tensors_.size()) {
+              return errors::InvalidArgument("number tensors should match previous one, ", tensors_.size(), " vs. ", out_tensors->size());
+            }
+
+            int64 chunk_to_read = (current_batch_size_ - current_index_) < (dataset()->batch_size_ - chunk_read) ? (current_batch_size_ - current_index_) : (dataset()->batch_size_ - chunk_read);
+            for (int i = 0; i < tensors_.size(); ++i) {
+              // TODO: concurrent copy?
+              for (int64 r = 0; r < chunk_to_read; ++r) {
+                TF_RETURN_IF_ERROR(batch_util::MaybeMoveSliceToElement(
+                    &tensors_[i], &elements[i], current_index_ + r));
+                TF_RETURN_IF_ERROR(batch_util::CopyElementToSlice(
+                    elements[i], &(*out_tensors)[i], chunk_read + r));
+              }
+            }
+
+            chunk_read += chunk_to_read;
+            current_index_ += chunk_to_read;
+            if (chunk_read == dataset()->batch_size_) {
+              *end_of_sequence = false;
+              return Status::OK();
+            }
+          }
+
+          current_index_ = 0;
+          current_batch_size_ = 0;
+          tensors_.clear();
+          TF_RETURN_IF_ERROR(
+              input_impl_->GetNext(ctx, &tensors_, end_of_sequence));
+          if (!*end_of_sequence) {
+            for (size_t i = 0; i < tensors_.size(); ++i) {
+              if (tensors_[i].dims() == 0) {
+                return errors::InvalidArgument(
+                    "Input element must have a non-scalar value in each "
+                    "component.");
+              }
+              if (tensors_[i].dim_size(0) != tensors_[0].dim_size(0)) {
+                return errors::InvalidArgument(
+                    "Input element must have the same batch size in each "
+                    "component. Component 0 had size ",
+                    tensors_[0].dim_size(0), " but component ", i,
+                    " had size, ", tensors_[i].dim_size(0), ".");
+              }
+            }
+            current_batch_size_ = tensors_[0].dim_size(0);
+          }
+        }
+
+        // Finally, resize if needed
+        if (chunk_read > 0) {
+          if (chunk_read < dataset()->batch_size_) {
+            // No need to resieze with drop_reminder
+            if (dataset()->drop_remainder_) {
+              out_tensors->clear();
+              input_impl_.reset();
+              *end_of_sequence = true;
+              return Status::OK();
+	    }
+            for (int i = 0; i < out_tensors->size(); ++i) {
+              TensorShape shape = (*out_tensors)[i].shape();
+              shape.set_dim(0, chunk_read);
+              Tensor value_tensor;
+	      value_tensor.CopyFrom((*out_tensors)[i], shape);
+              (*out_tensors)[i] = std::move(value_tensor);
+            }
+          }
+          *end_of_sequence = false;
+          return Status::OK();
+        }
+        out_tensors->clear();
+        input_impl_.reset();
+        return Status::OK();
+      }
+
+     protected:
+      std::shared_ptr<model::Node> CreateNode(
+          IteratorContext* ctx, model::Node::Args args) const override {
+        return model::MakeKnownRatioNode(std::move(args), dataset()->batch_size_);
+      }
+
+     private:
+      mutex mu_;
+      int64 current_index_ GUARDED_BY(mu_);
+      int64 current_batch_size_ GUARDED_BY(mu_);
+      std::vector<Tensor> tensors_ GUARDED_BY(mu_);
+      std::unique_ptr<IteratorBase> input_impl_ GUARDED_BY(mu_);
+    };
+
+    const DatasetBase* const input_;
+    const int64 batch_size_;
+    const bool drop_remainder_;
+    const DataTypeVector output_types_;
+    const std::vector<PartialTensorShape> output_shapes_;
+  };
+
+  DataTypeVector output_types_;
+  std::vector<PartialTensorShape> output_shapes_;
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("ExperimentalUnbatchAndBatchDataset").Device(DEVICE_CPU),
+    UnbatchAndBatchDatasetOp);
+
+REGISTER_INPUT_COLOCATION_EXEMPTION("ExperimentalUnbatchAndBatchDataset");
+
+}  // namespace
+}  // namespace experimental
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow/core/ops/experimental_dataset_ops.cc
+++ b/tensorflow/core/ops/experimental_dataset_ops.cc
@@ -972,4 +972,19 @@ REGISTER_OP("ExperimentalUniqueDataset")
     .Attr("output_shapes: list(shape) >= 1")
     .SetShapeFn(shape_inference::ScalarShape);
 
+REGISTER_OP("ExperimentalUnbatchAndBatchDataset")
+    .Input("input_dataset: variant")
+    .Input("batch_size: int64")
+    .Input("drop_remainder: bool")
+    .Output("handle: variant")
+    .Attr("output_types: list(type) >= 1")
+    .Attr("output_shapes: list(shape) >= 1")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      shape_inference::ShapeHandle unused;
+      // batch_size should be a scalar.
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 0, &unused));
+      // drop_remainder should be a scalar.
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &unused));
+      return shape_inference::ScalarShape(c);
+    });
 }  // namespace tensorflow

--- a/tensorflow/python/data/experimental/kernel_tests/optimization/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/optimization/BUILD
@@ -421,3 +421,23 @@ py_test(
         "//tensorflow/python/data/ops:dataset_ops",
     ],
 )
+
+py_test(
+    name = "unbatch_and_batch_fusion_test",
+    srcs = ["unbatch_and_batch_fusion_test.py"],
+    python_version = "PY2",
+    srcs_version = "PY2AND3",
+    tags = [
+        "no_oss",
+        "no_pip",
+        "no_windows",
+    ],
+    deps = [
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:errors",
+        "//tensorflow/python/data/experimental/ops:optimization",
+        "//tensorflow/python/data/experimental/ops:optimization_options",
+        "//tensorflow/python/data/kernel_tests:test_base",
+        "//tensorflow/python/data/ops:dataset_ops",
+    ],
+)

--- a/tensorflow/python/data/experimental/kernel_tests/optimization/unbatch_and_batch_fusion_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/optimization/unbatch_and_batch_fusion_test.py
@@ -1,0 +1,43 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the `UnbatchAndBatchFusion` optimization."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.data.experimental.ops import optimization
+from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.framework import test_util
+from tensorflow.python.platform import test
+
+
+@test_util.run_all_in_graph_and_eager_modes
+class UnbatchAndBatchFusionTest(test_base.DatasetTestBase):
+
+  def testUnbatchAndBatchFusion(self):
+    dataset = dataset_ops.Dataset.range(10).batch(5).apply(
+        optimization.assert_next(
+            ["Map", "ExperimentalUnbatchAndBatch"])).unbatch().batch(2)
+    options = dataset_ops.Options()
+    options.experimental_optimization.apply_default_optimizations = False
+    options.experimental_optimization.unbatch_and_batch_fusion = True
+    dataset = dataset.with_options(options)
+    self.assertDatasetProduces(
+        dataset, expected_output=[[x, x + 1] for x in range(0, 10, 2)])
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/data/experimental/ops/optimization_options.py
+++ b/tensorflow/python/data/experimental/ops/optimization_options.py
@@ -181,10 +181,10 @@ class OptimizationOptions(options.OptionsBase):
       "defaults to True.")
 
   unbatch_and_batch_fusion = options.create_option(
-       name="unbatch_and_batch_fusion",
-       ty=bool,
-       docstring="Whether to fuse unbatch and batch transformations. If None, "
-       "defaults to False.")
+      name="unbatch_and_batch_fusion",
+      ty=bool,
+      docstring="Whether to fuse unbatch and batch transformations. If None, "
+      "defaults to False.")
 
   def _static_optimizations(self):
     """Produces the list of enabled static optimizations."""

--- a/tensorflow/python/data/experimental/ops/optimization_options.py
+++ b/tensorflow/python/data/experimental/ops/optimization_options.py
@@ -180,6 +180,12 @@ class OptimizationOptions(options.OptionsBase):
       docstring="Whether to fuse shuffle and repeat transformations. If None, "
       "defaults to True.")
 
+  unbatch_and_batch_fusion = options.create_option(
+       name="unbatch_and_batch_fusion",
+       ty=bool,
+       docstring="Whether to fuse unbatch and batch transformations. If None, "
+       "defaults to False.")
+
   def _static_optimizations(self):
     """Produces the list of enabled static optimizations."""
     result = set()
@@ -194,6 +200,7 @@ class OptimizationOptions(options.OptionsBase):
         "noop_elimination",
         "parallel_batch",
         "shuffle_and_repeat_fusion",
+        "unbatch_and_batch_fusion",
     ]
     for optimization in all_optimizations:
       if getattr(self, optimization):


### PR DESCRIPTION
This PR is part of the effort to address the issue in #31548. In certain situations there might be a need to adjust the batch of Dataset, e.g., from `m-batch` to `n-batch`. This could be achieved through `dataset.unbatch().batch(n)` though a fused step could be desirable.

This PR adds ExperimentalUnbatchAndBatchDataset so that it is possible to use it for static optimization.

This PR fixes #31548

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>