### PR TITLE
r2.0-CherryPick:Limit py_func on gpu to only take numeric types

### DIFF
--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -697,6 +697,23 @@ class PyFuncTest(test.TestCase):
       output = sess.run(z, feed_dict={x: 3.0})
       self.assertEqual(output, 18.0)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testEagerPyFuncOnGPUWithStrings(self):
+
+    def fn(a):
+      return str(a.dtype)
+
+    x = constant_op.constant("x", dtype=dtypes.string)
+    output = script_ops.eager_py_func(fn, inp=[x], Tout=dtypes.string)
+    self.assertEqual(self.evaluate(output), "<dtype: 'string'>".encode("utf8"))
+
+  @test_util.run_in_graph_and_eager_modes
+  def testEagerPyFuncNotACallable(self):
+    x = constant_op.constant("x", dtype=dtypes.string)
+
+    with self.assertRaisesRegexp(ValueError, "callable"):
+      _ = script_ops.eager_py_func(x, inp=[x], Tout=dtypes.string)
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -363,6 +363,19 @@ class PyFuncOp : public OpKernel {
 REGISTER_KERNEL_BUILDER(Name("PyFunc").Device(DEVICE_CPU), PyFuncOp);
 REGISTER_KERNEL_BUILDER(Name("PyFuncStateless").Device(DEVICE_CPU), PyFuncOp);
 REGISTER_KERNEL_BUILDER(Name("EagerPyFunc").Device(DEVICE_CPU), PyFuncOp);
-REGISTER_KERNEL_BUILDER(Name("EagerPyFunc").Device(DEVICE_GPU), PyFuncOp);
+
+DataType gpu_types[] = {
+    // No strings and int32s, no ref types and no resource/variant types.
+    DT_FLOAT,  DT_DOUBLE,     DT_UINT8,    DT_INT16,  DT_INT8,
+    DT_STRING, DT_COMPLEX64,  DT_INT64,    DT_BOOL,   DT_QINT8,
+    DT_QUINT8, DT_QINT32,     DT_BFLOAT16, DT_QINT16, DT_QUINT16,
+    DT_UINT16, DT_COMPLEX128, DT_HALF,     DT_UINT32, DT_UINT64,
+};
+
+REGISTER_KERNEL_BUILDER(Name("EagerPyFunc")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint("Tin", *gpu_types)
+                            .TypeConstraint("Tout", *gpu_types),
+                        PyFuncOp);
 
 }  // end namespace tensorflow

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -366,16 +366,16 @@ REGISTER_KERNEL_BUILDER(Name("EagerPyFunc").Device(DEVICE_CPU), PyFuncOp);
 
 DataType gpu_types[] = {
     // No strings and int32s, no ref types and no resource/variant types.
-    DT_FLOAT,  DT_DOUBLE,     DT_UINT8,    DT_INT16,  DT_INT8,
-    DT_STRING, DT_COMPLEX64,  DT_INT64,    DT_BOOL,   DT_QINT8,
-    DT_QUINT8, DT_QINT32,     DT_BFLOAT16, DT_QINT16, DT_QUINT16,
-    DT_UINT16, DT_COMPLEX128, DT_HALF,     DT_UINT32, DT_UINT64,
+    DT_FLOAT,      DT_DOUBLE,   DT_UINT8,  DT_INT16,   DT_INT8,
+    DT_COMPLEX64,  DT_INT64,    DT_BOOL,   DT_QINT8,   DT_QUINT8,
+    DT_QINT32,     DT_BFLOAT16, DT_QINT16, DT_QUINT16, DT_UINT16,
+    DT_COMPLEX128, DT_HALF,     DT_UINT32, DT_UINT64,
 };
 
 REGISTER_KERNEL_BUILDER(Name("EagerPyFunc")
                             .Device(DEVICE_GPU)
-                            .TypeConstraint("Tin", *gpu_types)
-                            .TypeConstraint("Tout", *gpu_types),
+                            .TypeConstraint("Tin", gpu_types)
+                            .TypeConstraint("Tout", gpu_types),
                         PyFuncOp);
 
 }  // end namespace tensorflow

--- a/tensorflow/python/ops/script_ops.py
+++ b/tensorflow/python/ops/script_ops.py
@@ -256,6 +256,9 @@ def _internal_py_func(func,
                       is_grad_func=False,
                       name=None):
   """See documentation for py_func and eager_py_func."""
+  if not callable(func):
+    raise ValueError("Expected func to be callable, got func of type {}".format(
+        type(func)))
 
   is_list_or_tuple = False
   if isinstance(Tout, (list, tuple)):


### PR DESCRIPTION
Allow py_func with string tensors to work correctly when a GPU is attached. 