### PR TITLE
Add skip_mismatch argument to load_weights.

### DIFF
--- a/tensorflow/contrib/tpu/python/tpu/keras_support.py
+++ b/tensorflow/contrib/tpu/python/tpu/keras_support.py
@@ -2139,8 +2139,11 @@ class KerasTPUModel(models.Model):
     self._cpu_model.set_weights(weights)
     self._tpu_weights_initialized = False
 
-  def load_weights(self, filepath, by_name=False):
-    self._cpu_model.load_weights(filepath, by_name)
+  def load_weights(self, filepath, by_name=False, skip_mismatch=False):
+    self._cpu_model.load_weights(
+        filepath,
+        by_name=by_name,
+        skip_mismatch=skip_mismatch)
     self._tpu_weights_initialized = False
 
 

--- a/tensorflow/python/keras/engine/network.py
+++ b/tensorflow/python/keras/engine/network.py
@@ -1291,7 +1291,7 @@ class Network(base_layer.Layer):
           save_relative_paths=True,
           all_model_checkpoint_paths=[filepath])
 
-  def load_weights(self, filepath, by_name=False):
+  def load_weights(self, filepath, by_name=False, skip_mismatch=False):
     """Loads all layer weights, either from a TensorFlow or an HDF5 weight file.
 
     If `by_name` is False weights are loaded based on the network's
@@ -1318,6 +1318,9 @@ class Network(base_layer.Layer):
         by_name: Boolean, whether to load weights by name or by topological
             order. Only topological loading is supported for weight files in
             TensorFlow format.
+        skip_mismatch: Boolean, whether to skip loading of layers where there is
+            a mismatch in the number of weights, or a mismatch in the shape of
+            the weight (only valid when `by_name`=True).
 
     Returns:
         When loading a weight file in TensorFlow format, returns the same status
@@ -1368,7 +1371,10 @@ class Network(base_layer.Layer):
       if 'layer_names' not in f.attrs and 'model_weights' in f:
         f = f['model_weights']
       if by_name:
-        saving.load_weights_from_hdf5_group_by_name(f, self.layers)
+        saving.load_weights_from_hdf5_group_by_name(
+            f,
+            self.layers,
+            skip_mismatch=skip_mismatch)
       else:
         saving.load_weights_from_hdf5_group(f, self.layers)
 

--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -172,14 +172,17 @@ class Model(network.Network):
         return super(Model, self).get_weights()
     return super(Model, self).get_weights()
 
-  def load_weights(self, filepath, by_name=False):
+  def load_weights(self, filepath, by_name=False, skip_mismatch=False):
     """Loads all layer weights, either from a TensorFlow or an HDF5 file."""
     if distributed_training_utils.is_tpu_strategy(self._distribution_strategy):
       if (self._distribution_strategy.extended.steps_per_run > 1 and
           (not network._is_hdf5_filepath(filepath))):  # pylint: disable=protected-access
         raise ValueError('Load weights is not yet supported with TPUStrategy '
                          'with steps_per_run greater than 1.')
-    return super(Model, self).load_weights(filepath, by_name)
+    return super(Model, self).load_weights(
+        filepath,
+        by_name=by_name,
+        skip_mismatch=skip_mismatch)
 
   @trackable.no_automatic_dependency_tracking
   def compile(self,

--- a/tensorflow/python/keras/saving/hdf5_format_test.py
+++ b/tensorflow/python/keras/saving/hdf5_format_test.py
@@ -337,7 +337,7 @@ class TestWeightSavingAndLoading(test.TestCase, parameterized.TestCase):
       hdf5_format.load_weights_from_hdf5_group_by_name(f_model, model.layers)
 
   @test_util.run_in_graph_and_eager_modes
-  def test_sequential_weight_loading_group_name_with_incorrect_length_with_skip_mismatch(self):
+  def test_sequential_weight_loading_group_name_with_incorrect_length_with_skip_mismatch(self):  # pylint: disable=line-too-long
     if h5py is None:
       return
 


### PR DESCRIPTION
This PR is analogous to https://github.com/keras-team/keras/pull/8462 in Keras.

With it, you can load weights into models that have a mismatch, but use the same names. A practical application would be for transfer learning, where the number of classes influences the size of the weights. It can still be useful to load the weights that are not changed in shape to provide a better starting point.

Note: I don't have a TPU, I am relying on the unit tests to tell me if it is correctly implemented or not.