### PR TITLE
Remove unused code

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/shape.cc
+++ b/tensorflow/lite/delegates/gpu/common/shape.cc
@@ -111,15 +111,5 @@ std::string ToString(const Shape& s) {
                       absl::StrJoin(s.dimensions, ", "), "}}");
 }
 
-template <>
-int64_t StrongShape<Layout::OHWI>::LinearIndex(
-    const std::array<int32_t, 4>& coordinates) const {
-  int64_t index = coordinates[0];
-  index = index * StrongShape::get(1) + coordinates[1];
-  index = index * StrongShape::get(2) + coordinates[2];
-  index = index * StrongShape::get(3) + coordinates[3];
-  return index;
-}
-
 }  // namespace gpu
 }  // namespace tflite


### PR DESCRIPTION
```
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: common/shape.o:shape.cc:(.text+0x8c6): multiple definition of `tflite::gpu::StrongShape<(tflite::gpu::Layout)7>::LinearIndex(std::array<int, 4ull> const&) const'; cl/kernels/conv_buffer.o:conv_buffer.cc:(.text$_ZNK6tflite3gpu11StrongShapeILNS0_6LayoutE7EE11LinearIndexERKSt5arrayIiLy4EE[_ZNK6tflite3gpu11StrongShapeILNS0_6LayoutE7EE11LinearIndexERKSt5arrayIiLy4EE]+0x0): first defined here

collect2.exe: error: ld returned 1 exit status
```
This code make an error.