### PR TITLE
Update lite/micro for latest Ambiq Apollo3 SDK

### DIFF
--- a/tensorflow/lite/experimental/micro/tools/make/download_and_extract.sh
+++ b/tensorflow/lite/experimental/micro/tools/make/download_and_extract.sh
@@ -49,9 +49,6 @@ patch_am_sdk() {
   sed -i -e $'22s/\*(.text\*)/\*(.text\*)\\\n\\\n\\\t\/\* These are the C++ global constructors.  Stick them all here and\\\n\\\t \* then walk through the array in main() calling them all.\\\n\\\t \*\/\\\n\\\t_init_array_start = .;\\\n\\\tKEEP (\*(SORT(.init_array\*)))\\\n\\\t_init_array_end = .;\\\n\\\n\\\t\/\* XXX Currently not doing anything for global destructors. \*\/\\\n/g' "${dest_dir}/apollo3evb.ld"
   sed -i -e $'70s/} > SRAM/} > SRAM\\\n    \/\* Add this to satisfy reference to symbol "end" from libnosys.a(sbrk.o)\\\n     \* to denote the HEAP start.\\\n     \*\/\\\n   end = .;/g' "${dest_dir}/apollo3evb.ld"
 
-  # Workaround for bug in 2.0.0 SDK, remove once that's fixed.
-  sed -i -e $'s/#ifndef AM_HAL_GPIO_H/#ifdef __cplusplus\\\nextern "C" {\\\n#endif\\\n#ifndef AM_HAL_GPIO_H/g' ${am_dir}/mcu/apollo3/hal/am_hal_gpio.h
-
   # Add a delay after establishing serial connection
   sed -ir -E $'s/    with serial\.Serial\(args\.port, args\.baud, timeout=12\) as ser:/    with serial.Serial(args.port, args.baud, timeout=12) as ser:\\\n        # Patched.\\\n        import time\\\n        time.sleep(0.25)\\\n        # End patch./g' "${am_dir}/tools/apollo3_scripts/uart_wired_update.py"
 

--- a/tensorflow/lite/experimental/micro/tools/make/targets/apollo3evb_makefile.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/targets/apollo3evb_makefile.inc
@@ -5,21 +5,21 @@ ifeq ($(TARGET),$(filter $(TARGET),apollo3evb sparkfun_edge))
   TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
   # Download the Ambiq Apollo3 SDK and set this variable to find the header
   # files:
-  APOLLO3_SDK := $(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.0.0
+  APOLLO3_SDK := $(MAKEFILE_DIR)/downloads/$(AM_SDK_DEST)
   # Need a pointer to the GNU ARM toolchain for crtbegin.o for the fp functions
   # with the hard interfaces.
   GCC_ARM := $(MAKEFILE_DIR)/downloads/gcc_embedded/
 
   $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
   $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
-  $(eval $(call add_third_party_download,$(AM_SDK_URL),$(AM_SDK_MD5),AmbiqSuite-Rel2.0.0,patch_am_sdk))
+  $(eval $(call add_third_party_download,$(AM_SDK_URL),$(AM_SDK_MD5),$(AM_SDK_DEST),patch_am_sdk))
   $(eval $(call add_third_party_download,$(AP3_URL),$(AP3_MD5),apollo3_ext,))
   $(eval $(call add_third_party_download,$(CUST_CMSIS_URL),$(CUST_CMSIS_MD5),CMSIS_ext,))
 
   ifeq ($(TARGET), sparkfun_edge)
-    $(eval $(call add_third_party_download,$(SPARKFUN_EDGE_BSP_URL),$(SPARKFUN_EDGE_BSP_MD5),AmbiqSuite-Rel2.0.0/boards/SparkFun_TensorFlow_Apollo3_BSP,))
+    $(eval $(call add_third_party_download,$(SPARKFUN_EDGE_BSP_URL),$(SPARKFUN_EDGE_BSP_MD5),$(AM_SDK_DEST)/boards/SparkFun_TensorFlow_Apollo3_BSP,))
     # Make sure that we download the full Ambiq SDK before the SparkFun one.
-$(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.0.0/boards/SparkFun_TensorFlow_Apollo3_BSP: $(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.0.0
+$(MAKEFILE_DIR)/downloads/$(AM_SDK_DEST)/boards/SparkFun_TensorFlow_Apollo3_BSP: $(MAKEFILE_DIR)/downloads/$(AM_SDK_DEST)
   endif
 
   # Use the faster depthwise conv implementation.

--- a/tensorflow/lite/experimental/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/third_party_downloads.inc
@@ -19,6 +19,7 @@ CMSIS_MD5 := "f451f1dccc844e894939055db278a40e"
 
 AM_SDK_URL := "http://s3.asia.ambiqmicro.com/downloads/AmbiqSuite-Rel2.0.0.zip"
 AM_SDK_MD5 := "70332bc6968602bd85bee600ca81d06f"
+AM_SDK_DEST := AmbiqSuite-Rel2.0.0
 
 AP3_URL := "https://github.com/AmbiqMicro/TFLiteMicro_Apollo3/archive/dfbcef9a57276c087d95aab7cb234f1d4c9eaaba.zip"
 AP3_MD5 := "fc9cbda4562ea97ce21b6df542b66597"

--- a/tensorflow/lite/experimental/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/third_party_downloads.inc
@@ -17,8 +17,8 @@ endif
 CMSIS_URL := "https://github.com/ARM-software/CMSIS_5/archive/5.4.0.zip"
 CMSIS_MD5 := "f451f1dccc844e894939055db278a40e"
 
-AM_SDK_URL := "http://s3.asia.ambiqmicro.com/downloads/AmbiqSuite-Rel2.0.0.zip"
-AM_SDK_MD5 := "70332bc6968602bd85bee600ca81d06f"
+AM_SDK_URL := "http://s3.asia.ambiqmicro.com/downloads/AmbiqSuite-Rel2.2.0.zip"
+AM_SDK_MD5 := "7605fa2d4d97e6bb7a1190c92b66b597"
 AM_SDK_DEST := AmbiqSuite-Rel2.0.0
 
 AP3_URL := "https://github.com/AmbiqMicro/TFLiteMicro_Apollo3/archive/dfbcef9a57276c087d95aab7cb234f1d4c9eaaba.zip"

--- a/tensorflow/lite/experimental/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/experimental/micro/tools/make/third_party_downloads.inc
@@ -19,7 +19,7 @@ CMSIS_MD5 := "f451f1dccc844e894939055db278a40e"
 
 AM_SDK_URL := "http://s3.asia.ambiqmicro.com/downloads/AmbiqSuite-Rel2.2.0.zip"
 AM_SDK_MD5 := "7605fa2d4d97e6bb7a1190c92b66b597"
-AM_SDK_DEST := AmbiqSuite-Rel2.0.0
+AM_SDK_DEST := AmbiqSuite-Rel2.2.0
 
 AP3_URL := "https://github.com/AmbiqMicro/TFLiteMicro_Apollo3/archive/dfbcef9a57276c087d95aab7cb234f1d4c9eaaba.zip"
 AP3_MD5 := "fc9cbda4562ea97ce21b6df542b66597"


### PR DESCRIPTION
Pulling in the latest SDK from Ambiq to support the Apollo3 microcontroller used in the lite/micro examples 'micro_speech' and 'micro_vision'

This is regular maintenance that will keep future development efforts relevant.

