### PR TITLE
r2.0-CherryPick: Refactor the keras TensorLikeDataAdapter (numpy array, EagerTensor, etc) to use tf.shuffle rather than np.shuffle

### DIFF
--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -26,11 +26,14 @@ import numpy as np
 import six
 
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework.ops import composite_tensor
 from tensorflow.python.keras.engine import training_utils
 from tensorflow.python.keras.utils import data_utils
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import random_ops
 from tensorflow.python.util import nest
 from tensorflow.python.util import tf_inspect
 
@@ -219,7 +222,15 @@ class TensorLikeDataAdapter(DataAdapter):
     else:
       inputs = (x,)
 
-    num_samples = int(nest.flatten(x)[0].shape[0])
+    num_samples = set(int(i.shape[0]) for i in nest.flatten(inputs))
+    if len(num_samples) > 1:
+      msg = "Data cardinality is ambiguous:\n"
+      for label, data in zip(["x", "y", "sample_weight"], inputs):
+        msg += "  {} sizes: {}\n".format(
+            label, ", ".join([str(i.shape[0]) for i in nest.flatten(data)]))
+      msg += "Please provide data which shares the same first dimension."
+      raise ValueError(msg)
+    num_samples = num_samples.pop()
 
     # If batch_size is not passed but steps is, calculate from the input data.
     if steps and not batch_size:
@@ -232,12 +243,9 @@ class TensorLikeDataAdapter(DataAdapter):
 
     self._size = int(math.ceil(num_samples / batch_size))
     self._batch_size = batch_size
-    self._has_partial_batch = (self._size != (num_samples // batch_size))
 
-    self._partial_batch_size = None
-    if self._has_partial_batch:
-      self._partial_batch_size = (
-          num_samples - (self._size - 1) * self._batch_size)
+    num_full_batches = int(num_samples // batch_size)
+    self._partial_batch_size = num_samples % batch_size
 
     # Vectorized version of shuffle.
     # This is a performance improvement over using `from_tensor_slices`.
@@ -246,54 +254,65 @@ class TensorLikeDataAdapter(DataAdapter):
     # at each step. The performance improvements here come from:
     # 1. vectorized batch using gather
     # 2. parallelized map
-    # 3. vectorized shuffle by using reshape and unbatch
-    # 4. disabled static optimizations
-    indices_list = []
-    for _ in range(epochs):
-      indices = np.arange(num_samples)
+    # 3. pipelined permutation generation
+    # 4. optimized permutation batching
+    # 5. disabled static optimizations
+
+    indices_dataset = dataset_ops.DatasetV2.range(1).repeat()
+    def permutation(_):
+      # It turns out to be more performant to make a new set of indices rather
+      # than reusing the same range Tensor. (presumably because of buffer
+      # forwarding.)
+      indices = math_ops.range(num_samples, dtype=dtypes.int64)
       if shuffle:
-        np.random.shuffle(indices)
+        indices = random_ops.random_shuffle(indices)
+      return indices
 
-      full_batch_indices = np.reshape(
-          indices[:(num_samples // batch_size) * batch_size], [-1, batch_size])
-      partial_batch_indices = indices[(num_samples // batch_size) * batch_size:]
+    # We prefetch a single element. Computing large permutations can take quite
+    # a while so we don't want to wait for prefetching over an epoch boundary to
+    # trigger the next permutation. On the other hand, too many simultaneous
+    # shuffles can contend on a hardware level and degrade all performance.
+    indices_dataset = indices_dataset.map(permutation).prefetch(1)
 
-      epoch_indices_ds = dataset_ops.DatasetV2.from_tensors(
-          full_batch_indices).unbatch()
-      if partial_batch_indices.size:
-        epoch_indices_ds = epoch_indices_ds.concatenate(
-            dataset_ops.DatasetV2.from_tensors(partial_batch_indices))
+    def slice_batch_indices(indices):
+      """Convert a Tensor of indices into a dataset of batched indices.
 
-      indices_list.append(epoch_indices_ds)
+      This step can be accomplished in several ways. The most natural is to
+      slice the Tensor in a Dataset map. (With a condition on the upper index to
+      handle the partial batch.) However it turns out that coercing the Tensor
+      into a shape which is divisible by the batch size (and handling the last
+      partial batch separately) allows for a much more favorable memory access
+      pattern and improved performance.
 
-    indices_ds = dataset_ops.DatasetV2.from_tensor_slices(
-        indices_list).flat_map(lambda x: x)
+      Args:
+        indices: Tensor which determines the data order for an entire epoch.
 
-    data_ds = dataset_ops.DatasetV2.from_tensors(inputs).repeat()
-    dataset = dataset_ops.DatasetV2.zip((data_ds, indices_ds))
+      Returns:
+        A Dataset of batched indices.
+      """
+      num_in_full_batch = num_full_batches * batch_size
+      first_k_indices = array_ops.slice(indices, [0], [num_in_full_batch])
+      first_k_indices = array_ops.reshape(
+          first_k_indices, [num_full_batches, batch_size])
 
-    def _nested_grab_batch(data, indices):
-      """Grabs batches of Tensors in `data` based on `indices`."""
+      flat_dataset = dataset_ops.DatasetV2.from_tensor_slices(first_k_indices)
+      if self._partial_batch_size:
+        index_remainder = dataset_ops.DatasetV2.from_tensors(array_ops.slice(
+            indices, [num_in_full_batch], [self._partial_batch_size]))
+        flat_dataset = flat_dataset.concatenate(index_remainder)
+      return flat_dataset
 
-      def _grab_batch(x):
-        """Grabs a batch of `x`."""
-        x_batch = array_ops.gather(x, indices)
-        x_shape = x.shape.as_list()
+    indices_dataset = indices_dataset.flat_map(slice_batch_indices)
+    dataset = dataset_ops.DatasetV2.zip((
+        indices_dataset,
+        dataset_ops.DatasetV2.from_tensors(inputs).repeat()
+    ))
 
-        if not self._has_partial_batch:
-          # Recover the batch shape info.
-          x_shape[0] = self._batch_size
-          x_batch.set_shape(x_shape)
-        elif self._partial_batch_size >= num_samples:
-          # Only one batch per epoch.
-          x_shape[0] = self._partial_batch_size
-          x_batch.set_shape(x_shape)
-        return x_batch
-
-      return nest.map_structure(_grab_batch, data)
+    def grab_batch(i, data):
+      return nest.map_structure(lambda d: array_ops.gather(d, i, axis=0), data)
 
     dataset = dataset.map(
-        _nested_grab_batch, num_parallel_calls=dataset_ops.AUTOTUNE)
+        grab_batch, num_parallel_calls=dataset_ops.AUTOTUNE)
 
     # Default optimizations are disabled to avoid the overhead of (unnecessary)
     # input pipeline graph serialization and deserialization
@@ -312,10 +331,10 @@ class TensorLikeDataAdapter(DataAdapter):
     return self._batch_size
 
   def has_partial_batch(self):
-    return self._has_partial_batch
+    return self._partial_batch_size > 0
 
   def partial_batch_size(self):
-    return self._partial_batch_size
+    return self._partial_batch_size or None
 
   def should_recreate_iterator(self, _):
     # An infinite dataset is always created here.


### PR DESCRIPTION
This cherrypick depends on: https://github.com/tensorflow/tensorflow/pull/31863