### PR TITLE
[tf.data] replace flat_structure with _flat_structure

### DIFF
--- a/tensorflow/python/data/experimental/ops/batching.py
+++ b/tensorflow/python/data/experimental/ops/batching.py
@@ -461,7 +461,7 @@ class _UnbatchDataset(dataset_ops.UnaryDataset):
 
     variant_tensor = ged_ops.experimental_unbatch_dataset(
         self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-        **dataset_ops.flat_structure(self))
+        **self._flat_structure)
     super(_UnbatchDataset, self).__init__(input_dataset, variant_tensor)
 
   @property

--- a/tensorflow/python/data/experimental/ops/get_single_element.py
+++ b/tensorflow/python/data/experimental/ops/get_single_element.py
@@ -65,4 +65,4 @@ def get_single_element(dataset):
   # pylint: disable=protected-access
   return dataset._element_structure._from_compatible_tensor_list(
       gen_dataset_ops.dataset_to_single_element(
-          dataset._variant_tensor, **dataset_ops.flat_structure(dataset)))
+          dataset._variant_tensor, **dataset._flat_structure))

--- a/tensorflow/python/data/experimental/ops/optimization.py
+++ b/tensorflow/python/data/experimental/ops/optimization.py
@@ -304,7 +304,7 @@ class _ChooseFastestBranchDataset(dataset_ops.UnaryDataset):
             num_elements_per_branch=num_elements_per_branch,
             branches=[f.function for f in self._funcs],
             other_arguments_lengths=self._capture_lengths,
-            **dataset_ops.flat_structure(self)))
+            **self._flat_structure))
     super(_ChooseFastestBranchDataset, self).__init__(input_dataset,
                                                       variant_tensor)
 

--- a/tensorflow/python/data/experimental/ops/prefetching_ops.py
+++ b/tensorflow/python/data/experimental/ops/prefetching_ops.py
@@ -112,7 +112,7 @@ class _CopyToDeviceDataset(dataset_ops.UnaryUnchangedStructureDataset):
       """
       ds_variant = gen_dataset_ops.unwrap_dataset_variant(wrap_ds_variant)
       resource = gen_dataset_ops.anonymous_iterator(
-          **dataset_ops.flat_structure(self._input_dataset))
+          **self._input_dataset._flat_structure)
       with ops.control_dependencies(
           [gen_dataset_ops.make_iterator(ds_variant, resource)]):
         return gen_dataset_ops.iterator_to_string_handle(resource)
@@ -174,7 +174,7 @@ class _CopyToDeviceDataset(dataset_ops.UnaryUnchangedStructureDataset):
       """
       iterator_resource = gen_dataset_ops.iterator_from_string_handle_v2(
           string_handle,
-          **dataset_ops.flat_structure(self._input_dataset))
+          **self._input_dataset._flat_structure)
       with ops.control_dependencies([
           resource_variable_ops.destroy_resource_op(
               iterator_resource, ignore_lookup_error=True)]):
@@ -208,7 +208,7 @@ class _CopyToDeviceDataset(dataset_ops.UnaryUnchangedStructureDataset):
           init_func=self._init_func,
           next_func=self._next_func,
           finalize_func=self._finalize_func,
-          **dataset_ops.flat_structure(self._input_dataset))
+          **self._input_dataset._flat_structure)
     super(_CopyToDeviceDataset, self).__init__(input_dataset, variant_tensor)
 
   # The one_shot_iterator implementation needs a 0 arg _make_dataset function
@@ -243,7 +243,7 @@ class _MapOnGpuDataset(dataset_ops.UnaryDataset):
         self._map_func.function.captured_inputs,
         f=self._map_func.function,
         use_inter_op_parallelism=self._use_inter_op_parallelism,
-        **dataset_ops.flat_structure(self))
+        **self._flat_structure)
     super(_MapOnGpuDataset, self).__init__(input_dataset, variant_tensor)
 
   def _functions(self):

--- a/tensorflow/python/data/experimental/ops/shuffle_ops.py
+++ b/tensorflow/python/data/experimental/ops/shuffle_ops.py
@@ -46,7 +46,7 @@ class _ShuffleAndRepeatDataset(dataset_ops.UnaryUnchangedStructureDataset):
         count=self._count,
         seed=self._seed,
         seed2=self._seed2,
-        **dataset_ops.flat_structure(self))
+        **self._flat_structure)
     super(_ShuffleAndRepeatDataset, self).__init__(input_dataset,
                                                    variant_tensor)
 

--- a/tensorflow/python/data/experimental/ops/snapshot.py
+++ b/tensorflow/python/data/experimental/ops/snapshot.py
@@ -33,7 +33,7 @@ class _SnapshotDataset(dataset_ops.UnaryUnchangedStructureDataset):
     variant_tensor = ged_ops.snapshot_dataset(
         self._input_dataset._variant_tensor,  # pylint: disable=protected-access
         path=self._path,
-        **dataset_ops.flat_structure(self))
+        **self._flat_structure)
     super(_SnapshotDataset, self).__init__(input_dataset, variant_tensor)
 
 

--- a/tensorflow/python/data/experimental/ops/stats_ops.py
+++ b/tensorflow/python/data/experimental/ops/stats_ops.py
@@ -117,5 +117,5 @@ class _StatsDataset(dataset_ops.UnaryUnchangedStructureDataset):
     variant_tensor = self._op_function(
         self._input_dataset._variant_tensor,  # pylint: disable=protected-access
         self._tag,
-        **dataset_ops.flat_structure(self))
+        **self._flat_structure)
     super(_StatsDataset, self).__init__(input_dataset, variant_tensor)

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -304,6 +304,41 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     return ("<%s shapes: %s, types: %s>" % (type(self).__name__, output_shapes,
                                             output_types))
 
+  @property
+  def _flat_shapes(self):
+    """Returns a list `tf.TensorShapes`s for the element tensor representation.
+    Returns:
+      A list `tf.TensorShapes`s for the element tensor representation.
+    """
+    return self._element_structure._flat_shapes
+
+  @property
+  def _flat_types(self):
+    """Returns a list `tf.DType`s for the element tensor representation.
+    Returns:
+      A list `tf.DType`s for the element tensor representation.
+    """
+    return self._element_structure._flat_types
+
+  @property
+  def _flat_structure(self):
+    """Helper for setting `output_shapes` and `output_types` attrs of an op.
+
+    Most dataset op constructors expect `output_shapes` and `output_types`
+    arguments that represent the flattened structure of an element. This helper
+    function generates these attrs as a keyword argument dictionary, allowing
+    `Dataset._variant_tensor` implementations to pass `**self._flat_structure`
+    to the op constructor.
+
+    Returns:
+      A dictionary of keyword arguments that can be passed to a dataset op
+      constructor.
+    """
+    return {
+        "output_shapes": self._flat_shapes,
+        "output_types": self._flat_types,
+    }
+
   def _to_components(self):
     return [self._variant_tensor]
 
@@ -1569,7 +1604,7 @@ class DatasetV1(DatasetV2):
     # pylint: disable=protected-access
     return iterator_ops.Iterator(
         gen_dataset_ops.one_shot_iterator(
-            dataset_factory=_make_dataset, **flat_structure(self)),
+            dataset_factory=_make_dataset, **self._flat_structure),
         None, get_legacy_output_types(self), get_legacy_output_shapes(self),
         get_legacy_output_classes(self))
 
@@ -1616,10 +1651,10 @@ class DatasetV1(DatasetV2):
       shared_name = ""
     if compat.forward_compatible(2018, 8, 3):
       iterator_resource = gen_dataset_ops.iterator_v2(
-          container="", shared_name=shared_name, **flat_structure(self))
+          container="", shared_name=shared_name, **self._flat_structure)
     else:
       iterator_resource = gen_dataset_ops.iterator(
-          container="", shared_name=shared_name, **flat_structure(self))
+          container="", shared_name=shared_name, **self._flat_structure)
     with ops.colocate_with(iterator_resource):
       initializer = gen_dataset_ops.make_iterator(
           dataset._variant_tensor,  # pylint: disable=protected-access
@@ -2589,30 +2624,6 @@ class StructuredFunctionWrapper(object):
     return self._function
 
 
-def flat_structure(dataset):
-  """Helper for setting `output_shapes` and `output_types` attrs of Dataset ops.
-
-  Most Dataset op constructors expect `output_shapes` and `output_types`
-  arguments that represent the flattened structure of an element. This helper
-  function generates these attrs as a keyword argument dictionary, allowing
-  `Dataset._variant_tensor` implementations to pass
-  `**flat_structure(self)` to the op constructor.
-
-  Args:
-    dataset: A `tf.data.Dataset`.
-
-  Returns:
-    A dictionary of keyword arguments that can be passed to many Dataset op
-    constructors.
-  """
-  # pylint: disable=protected-access
-  structure = dataset._element_structure
-  return {
-      "output_shapes": structure._flat_shapes,
-      "output_types": structure._flat_types,
-  }
-
-
 class _GeneratorDataset(DatasetSource):
   """A `Dataset` that generates elements by invoking a function."""
 
@@ -2657,7 +2668,7 @@ class _GeneratorDataset(DatasetSource):
         init_func=self._init_func.function,
         next_func=self._next_func.function,
         finalize_func=self._finalize_func.function,
-        **flat_structure(self))
+        **self._flat_structure)
     super(_GeneratorDataset, self).__init__(variant_tensor)
 
   @property
@@ -2692,7 +2703,7 @@ class ZipDataset(DatasetV2):
     # pylint: disable=protected-access
     variant_tensor = gen_dataset_ops.zip_dataset(
         [ds._variant_tensor for ds in nest.flatten(self._datasets)],
-        **flat_structure(self))
+        **self._flat_structure)
     # pylint: enable=protected-access
     super(ZipDataset, self).__init__(variant_tensor)
 
@@ -2740,7 +2751,7 @@ class ConcatenateDataset(DatasetV2):
     # pylint: disable=protected-access
     variant_tensor = gen_dataset_ops.concatenate_dataset(
         input_dataset._variant_tensor, dataset_to_concatenate._variant_tensor,
-        **flat_structure(self))
+        **self._flat_structure)
     # pylint: enable=protected-access
     super(ConcatenateDataset, self).__init__(variant_tensor)
 
@@ -2766,7 +2777,7 @@ class RepeatDataset(UnaryUnchangedStructureDataset):
     variant_tensor = gen_dataset_ops.repeat_dataset(
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         count=self._count,
-        **flat_structure(self))
+        **self._flat_structure)
     super(RepeatDataset, self).__init__(input_dataset, variant_tensor)
 
 
@@ -2781,7 +2792,7 @@ class RangeDataset(DatasetSource):
         start=self._start,
         stop=self._stop,
         step=self._step,
-        **flat_structure(self))
+        **self._flat_structure)
     super(RangeDataset, self).__init__(variant_tensor)
 
   def _parse_args(self, *args):
@@ -2820,7 +2831,7 @@ class CacheDataset(UnaryUnchangedStructureDataset):
     variant_tensor = gen_dataset_ops.cache_dataset(
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         filename=self._filename,
-        **flat_structure(self))
+        **self._flat_structure)
     super(CacheDataset, self).__init__(input_dataset, variant_tensor)
 
 
@@ -2866,7 +2877,7 @@ class ShuffleDataset(UnaryUnchangedStructureDataset):
         seed=self._seed,
         seed2=self._seed2,
         reshuffle_each_iteration=self._reshuffle_each_iteration,
-        **flat_structure(self))
+        **self._flat_structure)
     super(ShuffleDataset, self).__init__(input_dataset, variant_tensor)
 
 
@@ -2880,7 +2891,7 @@ class TakeDataset(UnaryUnchangedStructureDataset):
     variant_tensor = gen_dataset_ops.take_dataset(
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         count=self._count,
-        **flat_structure(self))
+        **self._flat_structure)
     super(TakeDataset, self).__init__(input_dataset, variant_tensor)
 
 
@@ -2894,7 +2905,7 @@ class SkipDataset(UnaryUnchangedStructureDataset):
     variant_tensor = gen_dataset_ops.skip_dataset(
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         count=self._count,
-        **flat_structure(self))
+        **self._flat_structure)
     super(SkipDataset, self).__init__(input_dataset, variant_tensor)
 
 
@@ -2911,7 +2922,7 @@ class ShardDataset(UnaryUnchangedStructureDataset):
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         num_shards=self._num_shards,
         index=self._index,
-        **flat_structure(self))
+        **self._flat_structure)
     super(ShardDataset, self).__init__(input_dataset, variant_tensor)
 
 
@@ -2939,7 +2950,7 @@ class BatchDataset(UnaryDataset):
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         batch_size=self._batch_size,
         drop_remainder=self._drop_remainder,
-        **flat_structure(self))
+        **self._flat_structure)
     super(BatchDataset, self).__init__(input_dataset, variant_tensor)
 
   @property
@@ -3194,7 +3205,7 @@ class MapDataset(UnaryDataset):
         f=self._map_func.function,
         use_inter_op_parallelism=self._use_inter_op_parallelism,
         preserve_cardinality=self._preserve_cardinality,
-        **flat_structure(self))
+        **self._flat_structure)
     super(MapDataset, self).__init__(input_dataset, variant_tensor)
 
   def _functions(self):
@@ -3236,7 +3247,7 @@ class ParallelMapDataset(UnaryDataset):
         num_parallel_calls=self._num_parallel_calls,
         use_inter_op_parallelism=self._use_inter_op_parallelism,
         preserve_cardinality=self._preserve_cardinality,
-        **flat_structure(self))
+        **self._flat_structure)
     super(ParallelMapDataset, self).__init__(input_dataset, variant_tensor)
 
   def _functions(self):
@@ -3267,7 +3278,7 @@ class FlatMapDataset(UnaryDataset):
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         self._map_func.function.captured_inputs,
         f=self._map_func.function,
-        **flat_structure(self))
+        **self._flat_structure)
     super(FlatMapDataset, self).__init__(input_dataset, variant_tensor)
 
   def _functions(self):
@@ -3306,7 +3317,7 @@ class InterleaveDataset(UnaryDataset):
         self._cycle_length,
         self._block_length,
         f=self._map_func.function,
-        **flat_structure(self))
+        **self._flat_structure)
     super(InterleaveDataset, self).__init__(input_dataset, variant_tensor)
 
   def _functions(self):
@@ -3347,7 +3358,7 @@ class ParallelInterleaveDataset(UnaryDataset):
         self._block_length,
         self._num_parallel_calls,
         f=self._map_func.function,
-        **flat_structure(self))
+        **self._flat_structure)
     super(ParallelInterleaveDataset, self).__init__(input_dataset,
                                                     variant_tensor)
 
@@ -3384,7 +3395,7 @@ class FilterDataset(UnaryUnchangedStructureDataset):
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         other_arguments=self._predicate.function.captured_inputs,
         predicate=self._predicate.function,
-        **flat_structure(self))
+        **self._flat_structure)
     super(FilterDataset, self).__init__(input_dataset, variant_tensor)
 
   def _functions(self):
@@ -3419,7 +3430,7 @@ class PrefetchDataset(UnaryUnchangedStructureDataset):
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         buffer_size=self._buffer_size,
         slack_period=slack_period,
-        **flat_structure(self))
+        **self._flat_structure)
     super(PrefetchDataset, self).__init__(input_dataset, variant_tensor)
 
 
@@ -3452,7 +3463,7 @@ class WindowDataset(UnaryDataset):
         self._shift,
         self._stride,
         self._drop_remainder,
-        **flat_structure(self))
+        **self._flat_structure)
     super(WindowDataset, self).__init__(input_dataset, variant_tensor)
 
   @property
@@ -3485,7 +3496,7 @@ class _ModelDataset(UnaryUnchangedStructureDataset):
     variant_tensor = gen_dataset_ops.model_dataset(
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         cpu_budget=cpu_budget,
-        **flat_structure(self))
+        **self._flat_structure)
     super(_ModelDataset, self).__init__(input_dataset, variant_tensor)
 
 
@@ -3504,7 +3515,7 @@ class _OptimizeDataset(UnaryUnchangedStructureDataset):
         input_dataset._variant_tensor,  # pylint: disable=protected-access
         self._optimizations,
         optimization_configs=optimization_configs,
-        **flat_structure(self))
+        **self._flat_structure)
     super(_OptimizeDataset, self).__init__(input_dataset, variant_tensor)
 
 

--- a/tensorflow/python/data/ops/multi_device_iterator_ops.py
+++ b/tensorflow/python/data/ops/multi_device_iterator_ops.py
@@ -132,7 +132,7 @@ class _PerDeviceGenerator(dataset_ops.DatasetV2):
         init_func=self._init_func,
         next_func=self._next_func,
         finalize_func=self._finalize_func,
-        **dataset_ops.flat_structure(self))
+        **self._flat_structure)
     super(_PerDeviceGenerator, self).__init__(variant_tensor)
 
   def _inputs(self):
@@ -175,7 +175,7 @@ class _ReincarnatedPerDeviceGenerator(dataset_ops.DatasetV2):
         init_func=self._init_func,
         next_func=self._next_func,
         finalize_func=self._finalize_func,
-        **dataset_ops.flat_structure(self))
+        **self._flat_structure)
     super(_ReincarnatedPerDeviceGenerator, self).__init__(variant_tensor)
 
   def _inputs(self):
@@ -235,7 +235,7 @@ class MultiDeviceIterator(object):
               devices=self._devices,
               shared_name=shared_name,
               container="",
-              **dataset_ops.flat_structure(self._dataset)))
+              **self._dataset._flat_structure))
       if context.executing_eagerly():
         # Delete the resource when this object is deleted
         self._resource_deleter = resource_variable_ops.EagerResourceDeleter(

--- a/tensorflow/python/data/util/traverse_test.py
+++ b/tensorflow/python/data/util/traverse_test.py
@@ -33,9 +33,9 @@ class _TestDataset(dataset_ops.UnaryUnchangedStructureDataset):
     temp_variant_tensor = gen_dataset_ops.prefetch_dataset(
         input_dataset._variant_tensor,
         buffer_size=1,
-        **dataset_ops.flat_structure(self))
+        **self._flat_structure)
     variant_tensor = gen_dataset_ops.model_dataset(
-        temp_variant_tensor, **dataset_ops.flat_structure(self))
+        temp_variant_tensor, **self._flat_structure)
     super(_TestDataset, self).__init__(input_dataset, variant_tensor)
 
 

--- a/tensorflow/python/distribute/input_ops_test.py
+++ b/tensorflow/python/distribute/input_ops_test.py
@@ -264,9 +264,9 @@ class _TestDataset(dataset_ops.UnaryUnchangedStructureDataset):
     temp_variant_tensor = gen_dataset_ops.prefetch_dataset(
         input_dataset._variant_tensor,
         buffer_size=1,
-        **dataset_ops.flat_structure(self))
+        **self._flat_structure)
     variant_tensor = gen_dataset_ops.model_dataset(
-        temp_variant_tensor, **dataset_ops.flat_structure(self))
+        temp_variant_tensor, **self._flat_structure)
     super(_TestDataset, self).__init__(input_dataset, variant_tensor)
 
 


### PR DESCRIPTION
@jsimsa 

This is a bug fix from JIZHI, the AI platform in Tencent.

In TF r1.14, _flat_structure is used in file tensorflow/python/data/ops/readers.py, but its definition has not been updated in file tensorflow/python/data/ops/dataset_ops.py.

replace all flat_structure with _flat_structure to fix the error like below:
  File "transformer_main.py", line 670, in <module>
    absl_app.run(main)
  File "/usr/lib/python2.7/site-packages/absl/app.py", line 300, in run
    _run_main(main, args)
  File "/usr/lib/python2.7/site-packages/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "transformer_main.py", line 664, in main
    run_transformer(flags.FLAGS)
  File "transformer_main.py", line 644, in run_transformer
    vocab_file=flags_obj.vocab_file)
  File "transformer_main.py", line 343, in run_loop
    hooks=train_hooks)
  File "/usr/lib/python2.7/site-packages/tensorflow_estimator/python/estimator/estimator.py", line 367, in train
    loss = self._train_model(input_fn, hooks, saving_listeners)
  File "/usr/lib/python2.7/site-packages/tensorflow_estimator/python/estimator/estimator.py", line 1156, in _train_model
    return self._train_model_distributed(input_fn, hooks, saving_listeners)
  File "/usr/lib/python2.7/site-packages/tensorflow_estimator/python/estimator/estimator.py", line 1219, in _train_model_distributed
    self._config._train_distribute, input_fn, hooks, saving_listeners)
  File "/usr/lib/python2.7/site-packages/tensorflow_estimator/python/estimator/estimator.py", line 1255, in _actual_train_model_distributed
    input_fn, ModeKeys.TRAIN, strategy)
  File "/usr/lib/python2.7/site-packages/tensorflow_estimator/python/estimator/estimator.py", line 1009, in _get_iterator_from_input_fn
    lambda input_context: self._call_input_fn(input_fn, mode,
  File "/usr/lib/python2.7/site-packages/tensorflow/python/distribute/distribute_lib.py", line 774, in make_input_fn_iterator
    input_fn, replication_mode)
  File "/usr/lib/python2.7/site-packages/tensorflow/python/distribute/distribute_lib.py", line 406, in make_input_fn_iterator
    input_fn, replication_mode=replication_mode)
  File "/usr/lib/python2.7/site-packages/tensorflow/python/distribute/one_device_strategy.py", line 100, in _make_input_fn_iterator
    self._container_strategy())
  File "/usr/lib/python2.7/site-packages/tensorflow/python/distribute/input_lib.py", line 550, in __init__
    result = input_fn(ctx)
  File "/usr/lib/python2.7/site-packages/tensorflow_estimator/python/estimator/estimator.py", line 1010, in <lambda>
    input_context))
  File "/usr/lib/python2.7/site-packages/tensorflow_estimator/python/estimator/estimator.py", line 1113, in _call_input_fn
    return input_fn(**kwargs)
  File "/dockerdata/xinan/tensorflow/pub/models/official/transformer/utils/dataset.py", line 272, in train_input_fn
    repeat=params["repeat_dataset"], static_batch=params["static_batch"])
  File "/dockerdata/xinan/tensorflow/pub/models/official/transformer/utils/dataset.py", line 227, in _read_and_batch_from_files
    _load_records, sloppy=shuffle, cycle_length=num_parallel_calls))
  File "/usr/lib/python2.7/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 1853, in apply
    return DatasetV1Adapter(super(DatasetV1, self).apply(transformation_func))
  File "/usr/lib/python2.7/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 1290, in apply
    dataset = transformation_func(self)
  File "/usr/lib/python2.7/site-packages/tensorflow/python/data/experimental/ops/interleave_ops.py", line 94, in _apply_fn
    buffer_output_elements, prefetch_input_elements)
  File "/usr/lib/python2.7/site-packages/tensorflow/python/data/ops/readers.py", line 253, in __init__
    **self._flat_structure)
AttributeError: 'ParallelInterleaveDataset' object has no attribute '_flat_structure'