### PR TITLE
Add documentation about Dataset shard's deterministic nature

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -973,6 +973,23 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
   def shard(self, num_shards, index):
     """Creates a `Dataset` that includes only 1/`num_shards` of this dataset.
 
+    For example:
+    
+    ```python
+    # Create a Dataset with 60 elements.
+    A = tf.data.Dataset.range(60) # ==> [0, 1, 2, 3, ..., 57, 58, 59]
+
+    # Create 3 Datasets, each with 20 elements from Dataset A.
+    B = A.shard(num_shards=3, index=0) # ==> [0, 3, 6, 9, ..., 51, 54, 57]
+    C = A.shard(num_shards=3, index=1) # ==> [1, 4, 7, 10, ..., 52, 55, 58]
+    D = A.shard(num_shards=3, index=2) # ==> [2, 5, 8, 11, ..., 53, 56, 59]
+
+    # There is no overlap between Datasets B, C and D.
+    ```
+    
+    `shard` is a deterministic operator; the returned Dataset depends only
+    on the target Dataset, and the values of `num_shards` and `index`.
+    
     This dataset operator is very useful when running distributed training, as
     it allows each worker to read a unique subset.
 


### PR DESCRIPTION
Hi everyone,
This pull request addresses the issue raised in issue #31698. 
Specifically, I have edited the documentation so that it clearly mentions that the `shard` operation in the Dataset API is deterministic.

[Here](https://github.com/tensorflow/tensorflow/blob/r2.0/tensorflow/core/kernels/data/shard_dataset_op.cc) is the file containing the implementation of `shard` in r2.0.
If I understand correctly, [this line](https://github.com/tensorflow/tensorflow/blob/b8b60ae09afb3b05dde9f183bac587c7dd437c78/tensorflow/core/kernels/data/shard_dataset_op.cc#L132) dictates exactly how the target Dataset is split into its "shards".

Please let me know your feedback.
Thanks for your time.

