### PR TITLE
Explicitly disable XLA for AMP test

### DIFF
--- a/tensorflow/python/grappler/auto_mixed_precision_test.py
+++ b/tensorflow/python/grappler/auto_mixed_precision_test.py
@@ -601,6 +601,7 @@ class AutoMixedPrecisionTest(test.TestCase):
     self._run_simple_loop_test('C', 'CgbgWC', 'g')
 
   @test_util.run_deprecated_v1
+  @test_util.disable_xla('This test does not pass with XLA')
   def test_noninlined_funcdef(self):
     """Test graph with non-inlined function subgraph.
 
@@ -623,6 +624,7 @@ class AutoMixedPrecisionTest(test.TestCase):
       self.assertAllClose(output_val_ref, output_val, atol=1e-3, rtol=1e-3)
 
   @test_util.run_deprecated_v1
+  @test_util.disable_xla('This test does not pass with XLA')
   def test_ingraph_train_loop(self):
     """Tests a graph containing a while loop around a training update.
 


### PR DESCRIPTION
This test checks for certain graph nodes to verify AMP correctness,
but XLA changes the graph in ways that make these checks fail.