### PR TITLE
[r1.15 cherrypick] Add a note to ignore dlerror for CPU-only pip package

### DIFF
--- a/tensorflow/stream_executor/cuda/cudart_stub.cc
+++ b/tensorflow/stream_executor/cuda/cudart_stub.cc
@@ -25,7 +25,11 @@ void* GetDsoHandle() {
   static auto handle = []() -> void* {
     auto handle_or =
         stream_executor::internal::DsoLoader::GetCudaRuntimeDsoHandle();
-    if (!handle_or.ok()) return nullptr;
+    if (!handle_or.ok()) {
+      LOG(INFO) << "Ignore above cudart dlerror if you do not have a GPU set "
+                   "up on your machine.";
+      return nullptr;
+    }
     return handle_or.ValueOrDie();
   }();
   return handle;


### PR DESCRIPTION
…mically opening cudart fails.

PiperOrigin-RevId: 264940821