### PR TITLE
Update API docs for ParallelInterleaveDataset

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDataset.pbtxt
@@ -33,9 +33,10 @@ END
     name: "sloppy"
     description: <<END
 If `True`, return elements as they become available, even if that means returning
-these elements in a different order.
-If `False`, the operation of this dataset will be deterministic, but the
-dataset may block.
+these elements in a different order. Sloppy operation may result in better
+performance in the presence of stragglers, but the dataset will still block if
+all of its open streams are blocked.
+If `False`, always return elements in the same order.
 END
   }
   in_arg {
@@ -83,7 +84,8 @@ block, it will skip that input dataset. This dataset is especially useful
 when loading data from a variable-latency datastores (e.g. HDFS, GCS), as it
 allows the training step to proceed so long as some data is available.
 
-!! WARNING !! This dataset is not deterministic!
+!! WARNING !! If the `sloppy` parameter is set to `True`, the operation of this
+dataset will not be deterministic!
 
 This dataset has been superseded by `ParallelInterleaveDatasetV2`.  New code
 should use `ParallelInterleaveDatasetV2`. 

--- a/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDataset.pbtxt
@@ -1,6 +1,60 @@
 op {
   graph_op_name: "ParallelInterleaveDataset"
   visibility: HIDDEN
+  in_arg {
+    name: "input_dataset"
+    description: <<END
+Dataset that produces a stream of arguments for the function `f`.
+END
+  }
+  in_arg {
+    name: "other_arguments"
+    description: <<END
+Additional arguments to pass to `f` beyond those produced by `input_dataset`.
+Evaluated once when the dataset is instantiated. 
+END
+  }
+  in_arg {
+    name: "cycle_length"
+    description: <<END
+Number of datasets (each created by applying `f` to the elements of
+`input_dataset`) among which the `ParallelInterleaveDataset` will cycle in a 
+round-robin fashion.
+END
+  }
+  in_arg {
+    name: "block_length"
+    description: <<END
+Number of elements at a time to produce from each interleaved invocation of a
+dataset returned by `f`.
+END
+  }
+  in_arg {
+    name: "sloppy"
+    description: <<END
+If `True`, return elements as they become available, even if that means returning
+these elements in a different order.
+If `False`, the operation of this dataset will be deterministic, but the
+dataset may block.
+END
+  }
+  in_arg {
+    name: "buffer_output_elements"
+    description: <<END
+The number of elements each iterator being interleaved should buffer (similar
+to the `.prefetch()` transformation for each interleaved iterator).
+END
+  }
+  in_arg {
+    name: "prefetch_input_elements"
+    description: <<END
+Determines the number of iterators to prefetch, allowing buffers to warm up and
+data to be pre-fetched without blocking the main thread.
+END
+  }
+  out_arg {
+    name: "handle"
+  }
   attr {
     name: "f"
     description: <<END
@@ -8,6 +62,18 @@ A function mapping elements of `input_dataset`, concatenated with
 `other_arguments`, to a Dataset variant that contains elements matching
 `output_types` and `output_shapes`.
 END
+  }
+  attr {
+    name: "Targuments"
+    description: <<END
+Types of the elements of `other_arguments`.
+END
+  }
+  attr {
+    name: "output_types"
+  }
+  attr {
+    name: "output_shapes"
   }
   summary: "Creates a dataset that applies `f` to the outputs of `input_dataset`."
   description: <<END
@@ -18,5 +84,11 @@ when loading data from a variable-latency datastores (e.g. HDFS, GCS), as it
 allows the training step to proceed so long as some data is available.
 
 !! WARNING !! This dataset is not deterministic!
+
+This dataset has been superseded by `ParallelInterleaveDatasetV2`.  New code
+should use `ParallelInterleaveDatasetV2`. 
+
+The Python API `tf.data.experimental.parallel_interleave` creates instances of
+this op. `tf.data.experimental.parallel_interleave` is a deprecated API.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDataset.pbtxt
@@ -33,10 +33,10 @@ END
     name: "sloppy"
     description: <<END
 If `True`, return elements as they become available, even if that means returning
-these elements in a different order. Sloppy operation may result in better
+these elements in a non-deterministic order. Sloppy operation may result in better
 performance in the presence of stragglers, but the dataset will still block if
 all of its open streams are blocked.
-If `False`, always return elements in the same order.
+If `False`, always return elements in a deterministic order.
 END
   }
   in_arg {


### PR DESCRIPTION
This pull request updates the API docs for the `ParallelInterleaveDataset` op. I added documentation for the inputs and arguments, added a reference to the Python API call that creates instances of this dataset, and added a note that there is a newer implementation under the name `ParallelInterleaveDatasetV2`.