### PR TITLE
r2.0-Cherrypick:Makes `nest` able to flatten dictionary views (produced by dict.items…

### DIFF
--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections as _collections
 import six as _six
 
 from tensorflow.python import pywrap_tensorflow as _pywrap_tensorflow
@@ -133,8 +134,8 @@ def _sequence_like(instance, args):
     # corresponding `OrderedDict` to pack it back).
     result = dict(zip(_sorted(instance), args))
     instance_type = type(instance)
-    if instance_type == _collections.defaultdict:
-      d = _collections.defaultdict(instance.default_factory)
+    if instance_type == _collections_abc.defaultdict:
+      d = _collections_abc.defaultdict(instance.default_factory)
       for key in instance:
         d[key] = result[key]
       return d

--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -134,8 +134,8 @@ def _sequence_like(instance, args):
     # corresponding `OrderedDict` to pack it back).
     result = dict(zip(_sorted(instance), args))
     instance_type = type(instance)
-    if instance_type == _collections_abc.defaultdict:
-      d = _collections_abc.defaultdict(instance.default_factory)
+    if instance_type == _collections.defaultdict:
+      d = _collections.defaultdict(instance.default_factory)
       for key in instance:
         d[key] = result[key]
       return d

--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -107,6 +107,7 @@ def _is_namedtuple(instance, strict=False):
 
 # See the swig file (util.i) for documentation.
 _is_mapping = _pywrap_tensorflow.IsMapping
+_is_mapping_view = _pywrap_tensorflow.IsMappingView
 _is_attrs = _pywrap_tensorflow.IsAttrs
 _is_composite_tensor = _pywrap_tensorflow.IsCompositeTensor
 _is_type_spec = _pywrap_tensorflow.IsTypeSpec
@@ -131,7 +132,17 @@ def _sequence_like(instance, args):
     # ordered and plain dicts (e.g., flattening a dict but using a
     # corresponding `OrderedDict` to pack it back).
     result = dict(zip(_sorted(instance), args))
-    return type(instance)((key, result[key]) for key in instance)
+    instance_type = type(instance)
+    if instance_type == _collections.defaultdict:
+      d = _collections.defaultdict(instance.default_factory)
+      for key in instance:
+        d[key] = result[key]
+      return d
+    else:
+      return instance_type((key, result[key]) for key in instance)
+  elif _is_mapping_view(instance):
+    # We can't directly construct mapping views, so we create a list instead
+    return list(args)
   elif _is_namedtuple(instance) or _is_attrs(instance):
     return type(instance)(*args)
   elif _is_composite_tensor(instance):
@@ -1316,3 +1327,4 @@ def flatten_with_tuple_paths(structure, expand_composites=False):
 
 _pywrap_tensorflow.RegisterType("Mapping", _collections_abc.Mapping)
 _pywrap_tensorflow.RegisterType("Sequence", _collections_abc.Sequence)
+_pywrap_tensorflow.RegisterType("MappingView", _collections_abc.MappingView)

--- a/tensorflow/python/util/nest_test.py
+++ b/tensorflow/python/util/nest_test.py
@@ -172,6 +172,23 @@ class NestTest(parameterized.TestCase, test.TestCase):
         custom_reconstruction)
     self.assertEqual({"d": 3, "b": 1, "a": 0, "c": 2}, plain_reconstruction)
 
+  @test_util.assert_no_new_pyobjects_executing_eagerly
+  def testFlattenAndPackMappingViews(self):
+    """`flatten` orders dicts by key, including OrderedDicts."""
+    ordered = collections.OrderedDict([("d", 3), ("b", 1), ("a", 0), ("c", 2)])
+
+    # test flattening
+    ordered_keys_flat = nest.flatten(ordered.keys())
+    ordered_values_flat = nest.flatten(ordered.values())
+    ordered_items_flat = nest.flatten(ordered.items())
+    self.assertEqual([3, 1, 0, 2], ordered_values_flat)
+    self.assertEqual(["d", "b", "a", "c"], ordered_keys_flat)
+    self.assertEqual(["d", 3, "b", 1, "a", 0, "c", 2], ordered_items_flat)
+
+    # test packing
+    self.assertEqual([("d", 3), ("b", 1), ("a", 0), ("c", 2)],
+                     nest.pack_sequence_as(ordered.items(), ordered_items_flat))
+
   Abc = collections.namedtuple("A", ("b", "c"))  # pylint: disable=invalid-name
 
   @test_util.assert_no_new_pyobjects_executing_eagerly
@@ -259,6 +276,9 @@ class NestTest(parameterized.TestCase, test.TestCase):
     self.assertTrue(nest.is_nested(((7, 8), (5, 6))))
     self.assertTrue(nest.is_nested([]))
     self.assertTrue(nest.is_nested({"a": 1, "b": 2}))
+    self.assertTrue(nest.is_nested({"a": 1, "b": 2}.keys()))
+    self.assertTrue(nest.is_nested({"a": 1, "b": 2}.values()))
+    self.assertTrue(nest.is_nested({"a": 1, "b": 2}.items()))
     self.assertFalse(nest.is_nested(set([1, 2])))
     ones = array_ops.ones([2, 3])
     self.assertFalse(nest.is_nested(ones))

--- a/tensorflow/python/util/util.cc
+++ b/tensorflow/python/util/util.cc
@@ -221,6 +221,16 @@ int IsMappingHelper(PyObject* o) {
   return check_cache->CachedLookup(o);
 }
 
+// Returns 1 if `o` is considered a mapping view for the purposes of Flatten().
+// Returns 0 otherwise.
+// Returns -1 if an error occurred.
+int IsMappingViewHelper(PyObject* o) {
+  static auto* const check_cache = new CachedTypeCheck([](PyObject* to_check) {
+    return IsInstanceOfRegisteredType(to_check, "MappingView");
+  });
+  return check_cache->CachedLookup(o);
+}
+
 // Returns 1 if `o` is an instance of attrs-decorated class.
 // Returns 0 otherwise.
 int IsAttrsHelper(PyObject* o) {
@@ -283,6 +293,7 @@ int IsVariableHelper(PyObject* o) {
 int IsSequenceHelper(PyObject* o) {
   // We treat dicts and other mappings as special cases of sequences.
   if (IsMappingHelper(o)) return true;
+  if (IsMappingViewHelper(o)) return true;
   if (IsAttrsHelper(o)) return true;
   if (PySet_Check(o) && !WarnedThatSetIsNotSequence) {
     LOG(WARNING) << "Sets are not currently considered sequences, "
@@ -830,6 +841,7 @@ bool AssertSameStructureHelper(
 
 bool IsSequence(PyObject* o) { return IsSequenceHelper(o) == 1; }
 bool IsMapping(PyObject* o) { return IsMappingHelper(o) == 1; }
+bool IsMappingView(PyObject* o) { return IsMappingViewHelper(o) == 1; }
 bool IsAttrs(PyObject* o) { return IsAttrsHelper(o) == 1; }
 bool IsTensor(PyObject* o) { return IsTensorHelper(o) == 1; }
 bool IsResourceVariable(PyObject* o) {

--- a/tensorflow/python/util/util.h
+++ b/tensorflow/python/util/util.h
@@ -86,6 +86,15 @@ PyObject* IsNamedtuple(PyObject* o, bool strict);
 //   True if the sequence subclasses mapping.
 bool IsMapping(PyObject* o);
 
+// Returns a true if its input is a collections.MappingView.
+//
+// Args:
+//   seq: the input to be checked.
+//
+// Returns:
+//   True if the sequence subclasses mapping.
+bool IsMappingView(PyObject* o);
+
 // A version of PyMapping_Keys that works in C++11
 //
 // Args:

--- a/tensorflow/python/util/util.i
+++ b/tensorflow/python/util/util.i
@@ -105,6 +105,18 @@ Returns:
 %unignore tensorflow::swig::IsMapping;
 %noexception tensorflow::swig::IsMapping;
 
+%feature("docstring") tensorflow::swig::IsMappingView
+"""Returns True iff `instance` is a `collections.MappingView`.
+
+Args:
+  instance: An instance of a Python object.
+
+Returns:
+  True if `instance` is a `collections.MappingView`.
+"""
+%unignore tensorflow::swig::IsMappingView;
+%noexception tensorflow::swig::IsMappingView;
+
 %feature("docstring") tensorflow::swig::IsAttrs
 """Returns True iff `instance` is an instance of an `attr.s` decorated class.
 


### PR DESCRIPTION
…(), dict.values(), dict.keys() in Python3.)

This is done for all mapping views rather than just ordereddict views because:
1. In python2 these all returned lists anyway so nest worked on them even if dictionary ordering wasn't guaranteed
2. In python 3.6 dictionaries became insertion-ordered as an implementation detail, and as of python 3.7 this became a language feature: https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6

So, this would only pose a not-already-present randomization risk with nest.flatten for:
- people using python3 with Custom mappings or built-in mappings that don't have order guarantees (I'm not sure if there are still built-in mappings that don't have order guarantees)
- people using dict views with older python3 versions that are < 3.6

Note: This cl makes nest.pack_sequence_as with views as structures return a list rather than a mapping view, because you cannot directly instantiate built-in mapping views.
PiperOrigin-RevId: 264433983