### PR TITLE
r2.0-CherryPick

### DIFF
--- a/tensorflow/lite/model.h
+++ b/tensorflow/lite/model.h
@@ -139,6 +139,10 @@ class FlatBufferModel {
   // version encodes the minimum required interpreter version to run the
   // flatbuffer model. If the minimum version can't be determined, an empty
   // string will be returned.
+  // Note that the returned minimum version is a lower-bound but not a strict
+  // lower-bound; ops in the graph may not have an associated runtime version,
+  // in which case the actual required runtime might be greater than the
+  // reported minimum.
   string GetMinimumRuntime() const;
 
   /// Returns true if the model identifier is correct (otherwise false and

--- a/tensorflow/lite/toco/tflite/BUILD
+++ b/tensorflow/lite/toco/tflite/BUILD
@@ -146,6 +146,7 @@ cc_library(
         ":operator",
         "//tensorflow/lite/toco:model",
         "//tensorflow/lite/toco:tooling_util",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/tensorflow/lite/toco/tflite/op_version.h
+++ b/tensorflow/lite/toco/tflite/op_version.h
@@ -20,6 +20,11 @@ limitations under the License.
 namespace toco {
 namespace tflite {
 
+// Returns true if the first version string precedes the second.
+// For example, '1.14' should precede '1.9', also '1.14.1' should precede
+// '1.14'. If two version string is equal, then false will be returned.
+bool CompareVersion(const string&, const string&);
+
 // Get the minimum TF Lite runtime required to run a model. Each built-in
 // operator in the model will have its own minimum requirement of a runtime, and
 // the model's minimum requirement of runtime is defined as the maximum of all

--- a/tensorflow/lite/toco/tflite/op_version_test.cc
+++ b/tensorflow/lite/toco/tflite/op_version_test.cc
@@ -134,6 +134,18 @@ TEST(OpVersionTest, MinimumVersionForMixedOpVersions) {
   EXPECT_EQ(GetMinimumRuntimeVersionForModel(model), "1.10.0");
 }
 
+TEST(OpVersionTest, CompareVersionString) {
+  EXPECT_TRUE(CompareVersion("1.9", "1.13"));
+  EXPECT_FALSE(CompareVersion("1.13", "1.13"));
+  EXPECT_TRUE(CompareVersion("1.14", "1.14.1"));
+  EXPECT_FALSE(CompareVersion("1.14.1", "1.14"));
+  EXPECT_FALSE(CompareVersion("1.14.1", "1.9"));
+  EXPECT_FALSE(CompareVersion("1.0.9", "1.0.8"));
+  EXPECT_FALSE(CompareVersion("2.1.0", "1.2.0"));
+  EXPECT_TRUE(CompareVersion("", "1.13"));
+  EXPECT_FALSE(CompareVersion("", ""));
+}
+
 }  // namespace
 }  // namespace tflite
 }  // namespace toco


### PR DESCRIPTION
The fix will correct the generation of 'minimum runtime version' in TF Lite's flatbuffer model.