### PR TITLE
Expose tf.keras.preprocessing.text.tokenizer_from_json to match keras API

### DIFF
--- a/tensorflow/python/keras/preprocessing/text.py
+++ b/tensorflow/python/keras/preprocessing/text.py
@@ -27,9 +27,12 @@ text_to_word_sequence = text.text_to_word_sequence
 one_hot = text.one_hot
 hashing_trick = text.hashing_trick
 Tokenizer = text.Tokenizer
+tokenizer_from_json = text.tokenizer_from_json
 
 keras_export(
     'keras.preprocessing.text.text_to_word_sequence')(text_to_word_sequence)
 keras_export('keras.preprocessing.text.one_hot')(one_hot)
 keras_export('keras.preprocessing.text.hashing_trick')(hashing_trick)
 keras_export('keras.preprocessing.text.Tokenizer')(Tokenizer)
+keras_export(
+    'keras.preprocessing.text.tokenizer_from_json')(tokenizer_from_json)


### PR DESCRIPTION
Note: This fix is a a re-apply of #30062 

PR #30062 fixed #30061 issue. However, due to an incompatibility issue it was reverted. Now since 2.0.0RC0 is released, this PR is re-applied to carry #30062 again.

See https://github.com/tensorflow/tensorflow/pull/30062#issuecomment-524014058 for related details.

/cc @mihaimaruseac @mike-edmonds 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>